### PR TITLE
Testing stages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,12 @@ stages:
   - build
   - deploy to dev
   - deploy npm
+  # testing that all the moving parts fit together
   - integration testing
+  # testing against what is about to come (next browser version, next firmware release)
+  - canary testing
+  # testing of what we are releasing together with what is already out in the wild
+  - legacy testing
   - build artifacts
   - utils
   - deploy to staging

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -5,6 +5,28 @@
     - schedules
     - /^release\//
 
+.connect_included_methods: &connect_included_methods
+  TESTS_INCLUDED_METHODS:
+    [
+      "applySettings,applyFlags,getFeatures,getFirmwareHash,checkFirmwareAuthenticity",
+      "signTransaction",
+      "getAccountInfo,getAccountDescriptor,getAddress,getPublicKey,signMessage,verifyMessage,composeTransaction,getOwnershipId,getOwnershipProof",
+      "stellarGetAddress,stellarSignTransaction",
+      "cardanoGetAddress,cardanoGetNativeScriptHash,cardanoGetPublicKey,cardanoSignTransaction",
+      "eosGetPublicKey,eosSignTransaction",
+      "ethereumGetAddress,ethereumGetPublicKey,ethereumSignMessage,ethereumSignTransaction,ethereumVerifyMessage,ethereumSignTypedData",
+      "nemGetAddress,nemSignTransaction",
+      "rippleGetAddress,rippleSignTransaction",
+      "tezosGetAddress,tezosGetPublicKey,tezosSignTransaction",
+      "binanceGetAddress,binanceGetPublicKey,binanceSignTransaction",
+    ]
+
+.connect_test_pattern_1: &connect_test_pattern_1
+  TESTS_PATTERN: "init authorizeCoinjoin cancelCoinjoinAuthorization passphrase unlockPath setBusy override"
+
+.connect_test_pattern_2: &connect_test_pattern_2
+  TESTS_PATTERN: "methods"
+
 # @trezor/suite-web
 .e2e web:
   stage: integration testing
@@ -77,6 +99,7 @@
 
 suite web migrations:
   extends: .e2e web
+  stage: legacy testing
   variables:
     # Each test file will be run for all urls in TEST_URLS array. Useful for migration tests
     CYPRESS_TEST_URLS: release/22.5 ${CI_COMMIT_REF_NAME}
@@ -97,16 +120,18 @@ suite web snapshots:
     CYPRESS_updateSnapshots: 1
 
 # Tests against latest trezor-firmware main
-suite web 2-master:
+suite web canary fws:
   extends: .suite web base
+  stage: canary testing
   only:
     refs:
       - schedules
   variables:
     FIRMWARE: 2-master
 
-suite web 2-master manual:
+suite web canary fws manual:
   extends: .suite web base
+  stage: canary testing
   except:
     refs:
       - schedules
@@ -249,8 +274,9 @@ connect-popup manual:
     <<: *run_everything_rules
   when: manual
 
-connect-popup legacy:
+connect-popup legacy npm package:
   extends: .e2e connect-popup
+  stage: legacy testing
   needs:
     - install
     - connect-web build
@@ -321,6 +347,7 @@ connect-popup-webextension manual:
 
 .connect:
   stage: integration testing
+  retry: 1
   dependencies:
     - install
   variables:
@@ -371,40 +398,45 @@ connect-popup-webextension manual:
   parallel:
     matrix:
       - TESTS_ENVIRONMENT: ["node", "web"]
-        TESTS_PATTERN: "init authorizeCoinjoin cancelCoinjoinAuthorization passphrase unlockPath setBusy override"
-        TESTS_FIRMWARE: ["2-master", "2.2.0"]
-        # todo:
-        # TESTS_NODE_VERSION: ["12", "14", "16"]
+        <<: *connect_test_pattern_1
       - TESTS_ENVIRONMENT: ["node", "web"]
-        TESTS_PATTERN: "methods"
-        TESTS_FIRMWARE: ["2-master", "2.2.0"]
-        # todo:
-        # TESTS_NODE_VERSION: ["12", "14", "16"]
-        TESTS_INCLUDED_METHODS:
-          [
-            "applySettings,applyFlags,getFeatures,getFirmwareHash,checkFirmwareAuthenticity",
-            "signTransaction",
-            "getAccountInfo,getAccountDescriptor,getAddress,getPublicKey,signMessage,verifyMessage,composeTransaction,getOwnershipId,getOwnershipProof",
-            "stellarGetAddress,stellarSignTransaction",
-            "cardanoGetAddress,cardanoGetNativeScriptHash,cardanoGetPublicKey,cardanoSignTransaction",
-            "eosGetPublicKey,eosSignTransaction",
-            "ethereumGetAddress,ethereumGetPublicKey,ethereumSignMessage,ethereumSignTransaction,ethereumVerifyMessage,ethereumSignTypedData",
-            "nemGetAddress,nemSignTransaction",
-            "rippleGetAddress,rippleSignTransaction",
-            "tezosGetAddress,tezosGetPublicKey,tezosSignTransaction",
-            "binanceGetAddress,binanceGetPublicKey,binanceSignTransaction",
-          ]
+        <<: *connect_test_pattern_2
+        <<: *connect_included_methods
         TESTS_MOCK_BACKENDS: "false"
 
-connect:
+.connect legacy fws base:
   extends: .connect matrix
-  retry: 1
+  stage: legacy testing
+  variables:
+    TESTS_FIRMWARE: "2.2.0"
+
+connect legacy fws:
+  extends: .connect legacy fws base
   only:
     refs:
-      - schedules # only nightly jobs, this is too heavy for develop branches at the moment
+      - schedules
 
-connect manual:
+connect legacy fws manual:
+  extends: .connect legacy fws base
+  except:
+    refs:
+      - schedules
+  when: manual
+
+.connect canary fws base:
   extends: .connect matrix
+  stage: canary testing
+  variables:
+    TESTS_FIRMWARE: "2-master"
+
+connect canary fws:
+  extends: .connect canary fws base
+  only:
+    refs:
+      - schedules
+
+connect canary fws manual:
+  extends: .connect canary fws base
   except:
     refs:
       - schedules


### PR DESCRIPTION
I understand that we are moving to github actions and thus not actively developing gitlab. But anyway, you can see this as preliminary analysis for the transformation. 

integration tests are big mess now, look:
<img width="581" alt="image" src="https://github.com/trezor/trezor-suite/assets/30367552/7bc794a7-6259-4fa6-a9d5-8c60399e4a80">

As the first step,  I suggest splitting "integration tests" into 3 categories:
- legacy: are tests that test something old (firmware), or something which is already released in the wild (migrations, backwards compatibility with npm packages)
- canary: are early warning system tests. will anything break when we add new firmware? will connect still work in the upcoming chrome release?
- integration: is the rest. I have some ideas how to break this down more in the future.

screenshot how it looks for regularar branch
<img width="1141" alt="image" src="https://github.com/trezor/trezor-suite/assets/30367552/c1d2a9fc-3f06-4553-9acd-fe48d4d78960">


more canary tests are coming in #9933