### PR TITLE
ci(connect): use node 18

### DIFF
--- a/.github/workflows/connect-test-params.yml
+++ b/.github/workflows/connect-test-params.yml
@@ -17,13 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        #? note: version 18 won't build either due to some node-canvas error during yarn install
-        # todo: running multiple versions from 'fast' pipeline for branches is overkill. move it to some nightly job (relates to missing nvm in gitlab)
-        node-version: [
-            16.x,
-            # todo: skipping this version for better speed for now
-            # 18.x
-          ]
+        node-version: [18.x]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -47,11 +41,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - name: Use Node.js 16.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v3
         with:
           # karma tests are run in browser, so node version doesn't matter too much
-          node-version: 16.x
+          node-version: 18.x
           cache: yarn
       # todo: ideally do not install everything. possibly only devDependencies could be enough for testing (if there was not for building libs)?
       - run: sed -i "/\"node\"/d" package.json

--- a/.github/workflows/connect-test.yml
+++ b/.github/workflows/connect-test.yml
@@ -5,12 +5,16 @@ on:
   push:
     paths:
       - "packages/blockchain-link"
-      - "packages/connect*/**"
+      - "packages/connect/**"
+      - "packages/connect-common/**"
+      - "packages/connect-iframe/**"
+      - "packages/connect-web/**"
       - "packages/transport"
       - "packages/utxo-lib"
       - "packages/utils"
       - "docker"
       - "submodules/trezor-common"
+      - "yarn.lock"
 
 jobs:
   # todo: meaning of 'build' job is questionable. only 'web' tests use part of this jobs output

--- a/.github/workflows/connect-test.yml
+++ b/.github/workflows/connect-test.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x]
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
update to yarn4 is causing CI to fail 

![image](https://github.com/trezor/trezor-suite/assets/30367552/da02558f-715d-4a2d-af63-18a60e7b0252)
