### PR TITLE
fix(trezor-user-env-link): auto reconnect websocket

### DIFF
--- a/packages/trezor-user-env-link/src/websocket-client.ts
+++ b/packages/trezor-user-env-link/src/websocket-client.ts
@@ -121,7 +121,10 @@ class TrezorUserEnvLinkClass extends EventEmitter {
     }
 
     // todo: typesafe interface
-    send(params: any) {
+    async send(params: any) {
+        // probably after update to node 18 it started to disconnect after certain
+        // period of inactivity.
+        await this.connect();
         const { ws } = this;
         if (!ws) throw NOT_INITIALIZED;
         const id = this.messageID;


### PR DESCRIPTION
healing failing test again https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/5533977795

not sure where it comes from, could be after node 18 update? I really don't know, but the problem was that thist test started, did some work with trezor-user-env, did some other work that took relatively long and in the meantime websocket disconnected.

this change adds remedy in that way that trezor-user-env-link before sending a message always checks whether websocket is open and reopens it if it is not. 