### PR TITLE
fix(suite-native): correct brightness on iphone when leaving app

### DIFF
--- a/suite-native/qr-code/src/components/QRCode.tsx
+++ b/suite-native/qr-code/src/components/QRCode.tsx
@@ -36,8 +36,8 @@ export const QRCode = ({ data }: QRCodeProps) => {
         const subscription = AppState.addEventListener('change', nextAppState => {
             if (!originalBrightnessValue) return;
 
-            // When app goes to background, restore the original brightness value.
-            if (nextAppState === 'background') {
+            // When app goes to background (or inactive to work on iOS), restore the original brightness value.
+            if (['inactive', 'background'].includes(nextAppState)) {
                 Brightness.setBrightnessAsync(originalBrightnessValue);
             }
             // When app goes to foreground set full brightness.


### PR DESCRIPTION
it still didnt work on iOS if only checked 'background' state and not 'inactive' on ios. Checking both now (android is not tracking 'inactive').

## Related Issue

fixes: #8688
