### PR TITLE
style(connect-explorer): fix thick padding

### DIFF
--- a/packages/connect-explorer/src/components/Devices.tsx
+++ b/packages/connect-explorer/src/components/Devices.tsx
@@ -10,7 +10,7 @@ const LayoutWrapper = styled.div`
     color: #fff;
     background: #2c2c2c;
     padding: 0;
-    padding: 4px 0 8px 20px;
+    padding: 4px 0 6px 20px;
 `;
 
 const DeviceList = styled.ul`
@@ -20,12 +20,10 @@ const DeviceList = styled.ul`
 const DeviceItem = styled.li`
     position: relative;
     cursor: pointer;
-    padding: 10px 15px;
+    padding: 0;
     white-space: nowrap;
     width: 25%;
     display: inline-block;
-    border-top: 1px solid transparent;
-    border-bottom: 4px solid transparent;
 
     &.active {
         background: #060606;


### PR DESCRIPTION
Fixes too thick nav bar and position of the device name when connected device.

Also smaller (-2px from the original) padding below the text in both states (not connected and connected device)

Before:
<img width="705" alt="image" src="https://github.com/trezor/trezor-suite/assets/57008159/0c1f28c9-eaee-4616-9367-8ee5dee596a0">
<img width="862" alt="image" src="https://github.com/trezor/trezor-suite/assets/57008159/16a60f34-bf1f-4883-802a-5b3930647e7f">



After:
<img width="795" alt="image" src="https://github.com/trezor/trezor-suite/assets/57008159/34a55b9c-1136-45a4-9c0f-dfcb69b5ffbb">
<img width="790" alt="image" src="https://github.com/trezor/trezor-suite/assets/57008159/fcab1ec3-db15-4ede-8183-c9dc37ef9d18">

