### PR TITLE
ci(blockchain-link): use node 18

### DIFF
--- a/.github/workflows/blockchain-link-test.yml
+++ b/.github/workflows/blockchain-link-test.yml
@@ -22,11 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [
-            # todo: not sure if we wan't to test other versions of node?
-            # 14.x,
-            16.x,
-          ]
+        node-version: [18.x]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/release-suite-config.yml
+++ b/.github/workflows/release-suite-config.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           lfs: true
       - name: Configure aws credentials
+        # todo: node16?
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: arn:aws:iam::538326561891:role/gh_actions_trezor_suite_prod_deploy


### PR DESCRIPTION
I am just revisiting how are blockchain-link tests run #9921