### PR TITLE
Move as much `@ethereumjs` dependencies as possible to connect

### DIFF
--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -49,6 +49,8 @@
         "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "dependencies": {
+        "@ethereumjs/common": "^3.1.2",
+        "@ethereumjs/tx": "^4.1.2",
         "@fivebinaries/coin-selection": "2.2.0",
         "@trezor/blockchain-link": "workspace:*",
         "@trezor/blockchain-link-types": "workspace:*",
@@ -83,6 +85,7 @@
         "ts-node": "^10.9.1",
         "tsx": "^3.14.0",
         "typescript": "5.3.2",
+        "web3-utils": "^1.10.0",
         "webpack": "^5.89.0",
         "ws": "7.5.9"
     },

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -72,6 +72,7 @@
         "@trezor/trezor-user-env-link": "workspace:*",
         "@types/karma": "^6.3.6",
         "@types/parse-uri": "^1.0.2",
+        "ethereum-cryptography": "^2.0.0",
         "jest": "29.5.0",
         "jest-environment-jsdom": "^29.5.0",
         "karma": "^6.4.2",
@@ -85,7 +86,6 @@
         "ts-node": "^10.9.1",
         "tsx": "^3.14.0",
         "typescript": "5.3.2",
-        "web3-utils": "^1.10.0",
         "webpack": "^5.89.0",
         "ws": "7.5.9"
     },

--- a/packages/connect/src/api/ethereum/__fixtures__/ethereumSignTx.ts
+++ b/packages/connect/src/api/ethereum/__fixtures__/ethereumSignTx.ts
@@ -1,0 +1,55 @@
+export const serializeEthereumTx = [
+    {
+        // https://eth1.trezor.io/tx/0xf6652a681b4474132b8b96512eb0bd5311f5ed8414af59e715c9738a3b3673f3
+        description: 'ETH regular',
+        tx: {
+            // data sent to TrezorConnect.ethereumSignTransaction
+            to: '0x4dC573D5DB497C0bF0674599E81c7dB91151D4e6',
+            value: '0x3905f13a8f0e',
+            chainId: 1,
+            nonce: '0x12',
+            gasLimit: '0x5208',
+            gasPrice: '0x104c533c00',
+            data: '0x',
+            // data received from TrezorConnect.ethereumSignTransaction
+            v: '0x1c',
+            r: '0x4256ec5ddf73f12f781e9f646f56fd8843296cf3eb7e2fb8f0b67ea317be3e7c',
+            s: '0x7be26525b6d6d39ef8745801bbb463c35ede09746708316a011e6eee7a2d83cf',
+        },
+        result: '0xf6652a681b4474132b8b96512eb0bd5311f5ed8414af59e715c9738a3b3673f3',
+    },
+    {
+        // https://eth1.trezor.io/tx/0xdcaf3eba690a3cdbad8c2926a8f5a95cd20003c5ba2aace91d8c5fe8048e395b
+        description: 'Eth with ERC20',
+        tx: {
+            to: '0xa74476443119A942dE498590Fe1f2454d7D4aC0d',
+            value: '0x0',
+            chainId: 1,
+            nonce: '0xb',
+            gasLimit: '0x30d40',
+            gasPrice: '0x12a05f200',
+            data: '0xa9059cbb000000000000000000000000a6abb480640d6d27d2fb314196d94463cedcb31e0000000000000000000000000000000000000000000000000011c37937e08000',
+            v: '0x26',
+            r: '0x47ef1bb1625e4152b0febf6ddc1a57bfcea6438132928dda4c9c092b34f38a78',
+            s: '0x3f70084c300235d588b70103988dd6f367e0f67bf38e2759a4c77aa461b220e2',
+        },
+        result: '0xdcaf3eba690a3cdbad8c2926a8f5a95cd20003c5ba2aace91d8c5fe8048e395b',
+    },
+    {
+        // https://etc1.trezor.io/tx/0xebd7ef20c4358a6fdb09a951d6e77b8e88b37ac0f7a8d4e3b68f1666bf4c1d1a
+        description: 'ETC regular',
+        tx: {
+            to: '0xABE894C18832edbe9B7926D729FA950673faD1EC',
+            value: '0x56c212a8e4628',
+            chainId: 61,
+            nonce: '0x0',
+            gasLimit: '0x5208',
+            gasPrice: '0x5409c6a7b',
+            data: '0x',
+            v: '0x9e',
+            r: '0x9d4599beedc587e0dc3d88578d79573c0138f9389810ffb036c37423ccd86375',
+            s: '0x4a0eb870fbae9a11a02e3e0068830d141ee952bb4ab4d1e1b7542d75f7a24dc1',
+        },
+        result: '0xebd7ef20c4358a6fdb09a951d6e77b8e88b37ac0f7a8d4e3b68f1666bf4c1d1a',
+    },
+];

--- a/packages/connect/src/api/ethereum/__tests__/ethereumSignTx.test.ts
+++ b/packages/connect/src/api/ethereum/__tests__/ethereumSignTx.test.ts
@@ -1,5 +1,6 @@
 import { Transaction } from '@ethereumjs/tx';
-import { sha3 } from 'web3-utils';
+import { keccak256 } from 'ethereum-cryptography/keccak';
+import { bytesToHex } from 'ethereum-cryptography/utils';
 
 import { serializeEthereumTx } from '../ethereumSignTx';
 
@@ -17,8 +18,8 @@ describe('helpers/ethereumSignTx', () => {
                     expect(`0x${hash1}`).toEqual(f.result);
                 }
                 const serialized = serializeEthereumTx({ ...f.tx, type: 0 }, f.tx.chainId);
-                const hash2 = sha3(serialized);
-                expect(hash2).toEqual(f.result);
+                const hash2 = bytesToHex(keccak256(Buffer.from(serialized.slice(2), 'hex')));
+                expect(`0x${hash2}`).toEqual(f.result);
             });
         });
     });

--- a/packages/connect/src/api/ethereum/__tests__/ethereumSignTx.test.ts
+++ b/packages/connect/src/api/ethereum/__tests__/ethereumSignTx.test.ts
@@ -1,0 +1,25 @@
+import { Transaction } from '@ethereumjs/tx';
+import { sha3 } from 'web3-utils';
+
+import { serializeEthereumTx } from '../ethereumSignTx';
+
+import * as fixtures from '../__fixtures__/ethereumSignTx';
+
+describe('helpers/ethereumSignTx', () => {
+    describe('serializeEthereumTx', () => {
+        fixtures.serializeEthereumTx.forEach(f => {
+            it(f.description, () => {
+                // verify hash using 2 different tools
+                if (f.tx.chainId !== 61) {
+                    // ETC is not supported
+                    const tx = Transaction.fromTxData(f.tx);
+                    const hash1 = tx.hash().toString('hex');
+                    expect(`0x${hash1}`).toEqual(f.result);
+                }
+                const serialized = serializeEthereumTx({ ...f.tx, type: 0 }, f.tx.chainId);
+                const hash2 = sha3(serialized);
+                expect(hash2).toEqual(f.result);
+            });
+        });
+    });
+});

--- a/packages/connect/src/api/ethereum/api/ethereumSignTransaction.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumSignTransaction.ts
@@ -166,6 +166,15 @@ export default class EthereumSignTransaction extends AbstractMethod<
                       definitions,
                   );
 
-        return signature;
+        const serializedTx = helper.serializeEthereumTx(
+            {
+                ...tx,
+                ...signature,
+                type: type === 'legacy' ? 0 : 2,
+            },
+            tx.chainId,
+        );
+
+        return { ...signature, serializedTx };
     }
 }

--- a/packages/connect/src/types/api/ethereum/index.ts
+++ b/packages/connect/src/types/api/ethereum/index.ts
@@ -50,6 +50,7 @@ export interface EthereumSignedTx {
     v: string;
     r: string;
     s: string;
+    serializedTx: string;
 }
 
 // ethereumSignTypedData

--- a/packages/connect/src/utils/formatUtils.ts
+++ b/packages/connect/src/utils/formatUtils.ts
@@ -57,3 +57,22 @@ export const messageToHex = (message: string) => {
     }
     return buffer.toString('hex');
 };
+
+export const deepTransform = (transform: (str: string) => string) => {
+    const recursion = <T>(value: T): T => {
+        if (typeof value === 'string') {
+            return transform(value) as T;
+        }
+        if (Array.isArray(value)) {
+            return value.map(recursion) as T;
+        }
+        if (value && typeof value === 'object') {
+            return Object.entries(value).reduce(
+                (obj, [k, v]) => ({ ...obj, [k]: recursion(v) }),
+                {},
+            ) as T;
+        }
+        return value;
+    };
+    return recursion;
+};

--- a/packages/connect/src/utils/formatUtils.ts
+++ b/packages/connect/src/utils/formatUtils.ts
@@ -31,6 +31,8 @@ export const hasHexPrefix = (str: string) => str.slice(0, 2).toLowerCase() === '
 
 export const stripHexPrefix = (str: string) => (hasHexPrefix(str) ? str.slice(2) : str);
 
+export const addHexPrefix = (str: string) => (str && !hasHexPrefix(str) ? `0x${str}` : str);
+
 // from (isHexString) https://github.com/ethjs/ethjs-util/blob/master/src/index.js
 const isHexString = (value: string, length?: number) => {
     if (typeof value !== 'string' || !value.match(/^(0x|0X)?[0-9A-Fa-f]*$/)) {

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -19,7 +19,6 @@
         "test-unit:watch": "jest -o --watch"
     },
     "dependencies": {
-        "@ethereumjs/util": "^9.0.1",
         "@formatjs/intl": "2.9.6",
         "@hookform/resolvers": "3.1.0",
         "@reduxjs/toolkit": "1.9.5",

--- a/packages/suite/src/actions/wallet/send/sendFormEthereumActions.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormEthereumActions.ts
@@ -7,7 +7,6 @@ import {
     calculateTotal,
     calculateMax,
     calculateEthFee,
-    serializeEthereumTx,
     getEthereumEstimateFeeParams,
     prepareEthereumTransaction,
     getExternalComposeOutput,
@@ -294,8 +293,5 @@ export const signTransaction =
             return;
         }
 
-        return serializeEthereumTx({
-            ...transaction,
-            ...signedTx.payload,
-        });
+        return signedTx.payload.serializedTx;
     };

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Address/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Address/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 import styled from 'styled-components';
-import { isValidChecksumAddress, toChecksumAddress } from '@ethereumjs/util';
+import { checkAddressChecksum, toChecksumAddress } from 'web3-utils';
 import { capitalizeFirstLetter } from '@trezor/utils';
 import { Input, useTheme, Icon, Button, Tooltip } from '@trezor/components';
 import { AddressLabeling, Translation, MetadataLabeling } from 'src/components/suite';
@@ -188,7 +188,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
             },
             // eth addresses are valid without checksum but Trezor displays them as checksummed
             checksum: (value: string) => {
-                if (networkType === 'ethereum' && !isValidChecksumAddress(value)) {
+                if (networkType === 'ethereum' && !checkAddressChecksum(value)) {
                     return translationString('RECIPIENT_IS_NOT_VALID');
                 }
             },

--- a/suite-common/wallet-utils/package.json
+++ b/suite-common/wallet-utils/package.json
@@ -14,7 +14,6 @@
     "dependencies": {
         "@ethereumjs/common": "^4.1.0",
         "@ethereumjs/tx": "^5.1.0",
-        "@ethereumjs/util": "^9.0.1",
         "@suite-common/fiat-services": "workspace:*",
         "@suite-common/metadata-types": "workspace:*",
         "@suite-common/suite-config": "workspace:*",

--- a/suite-common/wallet-utils/package.json
+++ b/suite-common/wallet-utils/package.json
@@ -12,8 +12,6 @@
         "test-unit:watch": "jest -c ../../jest.config.base.js -o --watch"
     },
     "dependencies": {
-        "@ethereumjs/common": "^4.1.0",
-        "@ethereumjs/tx": "^5.1.0",
         "@suite-common/fiat-services": "workspace:*",
         "@suite-common/metadata-types": "workspace:*",
         "@suite-common/suite-config": "workspace:*",

--- a/suite-common/wallet-utils/src/__fixtures__/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/__fixtures__/sendFormUtils.ts
@@ -51,62 +51,6 @@ export const prepareEthereumTransaction = [
     },
 ];
 
-export const serializeEthereumTx = [
-    {
-        // https://eth1.trezor.io/tx/0xf6652a681b4474132b8b96512eb0bd5311f5ed8414af59e715c9738a3b3673f3
-        description: 'ETH regular',
-        tx: {
-            // data sent to TrezorConnect.ethereumSignTransaction
-            to: '0x4dC573D5DB497C0bF0674599E81c7dB91151D4e6',
-            value: '0x3905f13a8f0e',
-            chainId: 1,
-            nonce: '0x12',
-            gasLimit: '0x5208',
-            gasPrice: '0x104c533c00',
-            data: '0x',
-            // data received from TrezorConnect.ethereumSignTransaction
-            v: '0x1c',
-            r: '0x4256ec5ddf73f12f781e9f646f56fd8843296cf3eb7e2fb8f0b67ea317be3e7c',
-            s: '0x7be26525b6d6d39ef8745801bbb463c35ede09746708316a011e6eee7a2d83cf',
-        },
-        result: '0xf6652a681b4474132b8b96512eb0bd5311f5ed8414af59e715c9738a3b3673f3',
-    },
-    {
-        // https://eth1.trezor.io/tx/0xdcaf3eba690a3cdbad8c2926a8f5a95cd20003c5ba2aace91d8c5fe8048e395b
-        description: 'Eth with ERC20',
-        tx: {
-            to: '0xa74476443119A942dE498590Fe1f2454d7D4aC0d',
-            value: '0x0',
-            chainId: 1,
-            nonce: '0xb',
-            gasLimit: '0x30d40',
-            gasPrice: '0x12a05f200',
-            data: '0xa9059cbb000000000000000000000000a6abb480640d6d27d2fb314196d94463cedcb31e0000000000000000000000000000000000000000000000000011c37937e08000',
-            v: '0x26',
-            r: '0x47ef1bb1625e4152b0febf6ddc1a57bfcea6438132928dda4c9c092b34f38a78',
-            s: '0x3f70084c300235d588b70103988dd6f367e0f67bf38e2759a4c77aa461b220e2',
-        },
-        result: '0xdcaf3eba690a3cdbad8c2926a8f5a95cd20003c5ba2aace91d8c5fe8048e395b',
-    },
-    {
-        // https://etc1.trezor.io/tx/0xebd7ef20c4358a6fdb09a951d6e77b8e88b37ac0f7a8d4e3b68f1666bf4c1d1a
-        description: 'ETC regular',
-        tx: {
-            to: '0xABE894C18832edbe9B7926D729FA950673faD1EC',
-            value: '0x56c212a8e4628',
-            chainId: 61,
-            nonce: '0x0',
-            gasLimit: '0x5208',
-            gasPrice: '0x5409c6a7b',
-            data: '0x',
-            v: '0x9e',
-            r: '0x9d4599beedc587e0dc3d88578d79573c0138f9389810ffb036c37423ccd86375',
-            s: '0x4a0eb870fbae9a11a02e3e0068830d141ee952bb4ab4d1e1b7542d75f7a24dc1',
-        },
-        result: '0xebd7ef20c4358a6fdb09a951d6e77b8e88b37ac0f7a8d4e3b68f1666bf4c1d1a',
-    },
-];
-
 export const restoreOrigOutputsOrder = [
     {
         description: 'order not changed',

--- a/suite-common/wallet-utils/src/__tests__/ethUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/ethUtils.test.ts
@@ -1,11 +1,4 @@
-import {
-    decimalToHex,
-    hexToDecimal,
-    padLeftEven,
-    sanitizeHex,
-    strip,
-    validateAddress,
-} from '../ethUtils';
+import { decimalToHex, hexToDecimal, padLeftEven, sanitizeHex, strip } from '../ethUtils';
 
 describe('eth utils', () => {
     it('decimalToHex', () => {
@@ -41,19 +34,5 @@ describe('eth utils', () => {
         expect(strip('0x')).toBe('');
         expect(strip('0x2540be3ff')).toBe('02540be3ff');
         expect(strip('2540be3ff')).toBe('02540be3ff');
-    });
-
-    it('validate address', () => {
-        // TODO: add more tests
-        expect(validateAddress('')).toBe('Address is not set');
-        expect(validateAddress('0x73d0385F4d8E00C5e6504C6030F47BF6212736A8')).toBeNull();
-
-        expect(validateAddress('aaa')).toBe('Address is not valid');
-        expect(validateAddress('0x89205A3A3b2A69De6Dbf7f01ED13B2108B2c43e6')).toBe(
-            'Address is not a valid checksum',
-        );
-        expect(validateAddress('BB9bc244D798123fDe783fCc1C72d3Bb8C189413')).toBe(
-            'Address is not valid',
-        );
     });
 });

--- a/suite-common/wallet-utils/src/__tests__/sendFormUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/sendFormUtils.test.ts
@@ -1,6 +1,3 @@
-import { TransactionFactory } from '@ethereumjs/tx';
-import { sha3 } from 'web3-utils';
-
 import { networksCompatibility as NETWORKS } from '@suite-common/wallet-config';
 import { testMocks } from '@suite-common/test-utils';
 
@@ -18,7 +15,6 @@ import {
     getInputState,
     prepareEthereumTransaction,
     restoreOrigOutputsOrder,
-    serializeEthereumTx,
 } from '../sendFormUtils';
 
 const { getUtxo, getWalletAccount } = testMocks;
@@ -27,21 +23,6 @@ describe('sendForm utils', () => {
     fixtures.prepareEthereumTransaction.forEach(f => {
         it(`prepareEthereumTransaction: ${f.description}`, () => {
             expect(prepareEthereumTransaction(f.txInfo)).toEqual(f.result);
-        });
-    });
-
-    fixtures.serializeEthereumTx.forEach(f => {
-        it(`serializeEthereumTx: ${f.description}`, () => {
-            // verify hash using 2 different tools
-            if (f.tx.chainId !== 61) {
-                // ETC is not supported
-                const tx = TransactionFactory.fromTxData(f.tx);
-                const hash1 = Buffer.from(tx.hash()).toString('hex');
-                expect(`0x${hash1}`).toEqual(f.result);
-            }
-            const serialized = serializeEthereumTx(f.tx);
-            const hash2 = sha3(serialized);
-            expect(hash2).toEqual(f.result);
         });
     });
 

--- a/suite-common/wallet-utils/src/ethUtils.ts
+++ b/suite-common/wallet-utils/src/ethUtils.ts
@@ -1,7 +1,4 @@
-import { isValidChecksumAddress, isValidAddress } from '@ethereumjs/util';
 import BigNumber from 'bignumber.js';
-
-import { hasUppercaseLetter } from '@trezor/utils';
 
 export const decimalToHex = (dec: number): string => new BigNumber(dec).toString(16);
 
@@ -23,17 +20,4 @@ export const strip = (str: string): string => {
         return padLeftEven(str.substring(2, str.length));
     }
     return padLeftEven(str);
-};
-
-export const validateAddress = (address: string): string | null => {
-    if (address.length < 1) {
-        return 'Address is not set';
-    }
-    if (!isValidAddress(address)) {
-        return 'Address is not valid';
-    }
-    if (hasUppercaseLetter(address) && !isValidChecksumAddress(address)) {
-        return 'Address is not a valid checksum';
-    }
-    return null;
 };

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -8,8 +8,6 @@ import {
 } from 'react-hook-form';
 
 import BigNumber from 'bignumber.js';
-import { Common, Chain, Hardfork } from '@ethereumjs/common';
-import { LegacyTxData, TransactionFactory } from '@ethereumjs/tx';
 import { fromWei, padLeft, toHex, toWei } from 'web3-utils';
 
 import { fiatCurrencies } from '@suite-common/suite-config';
@@ -146,31 +144,6 @@ export const prepareEthereumTransaction = (txInfo: EthTransactionData) => {
     }
 
     return result;
-};
-
-export const serializeEthereumTx = (tx: LegacyTxData & EthereumTransaction) => {
-    // @ethereumjs/tx doesn't support ETC (chain 61) by default
-    // and it needs to be declared as custom chain
-    // see: https://github.com/ethereumjs/ethereumjs-tx/blob/master/examples/custom-chain-tx.ts
-    const options =
-        tx.chainId === 61
-            ? {
-                  common: Common.custom(
-                      {
-                          name: 'ethereum-classic',
-                          networkId: 1,
-                          chainId: 61,
-                      },
-                      { baseChain: Chain.Mainnet, hardfork: Hardfork.Petersburg },
-                  ),
-              }
-            : {
-                  chain: tx.chainId,
-              };
-
-    const ethTx = TransactionFactory.fromTxData(tx, options);
-    const hexEthTx = Buffer.from(ethTx.serialize()).toString('hex');
-    return `0x${hexEthTx}`;
 };
 
 export const getFeeLevels = (networkType: Network['networkType'], feeInfo: FeeInfo) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2403,23 +2403,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethereumjs/common@npm:^3.2.0":
+"@ethereumjs/common@npm:^3.1.2, @ethereumjs/common@npm:^3.2.0":
   version: 3.2.0
   resolution: "@ethereumjs/common@npm:3.2.0"
   dependencies:
     "@ethereumjs/util": "npm:^8.1.0"
     crc-32: "npm:^1.2.0"
   checksum: b3f612406b6bcefaf9117ceb42eff58d311e2b50205e3d55b4c793d803de517efbc84075e058dc0e2ec27a2bff11dfc279dda1fa2b249ed6ab3973be045898f4
-  languageName: node
-  linkType: hard
-
-"@ethereumjs/common@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@ethereumjs/common@npm:4.1.0"
-  dependencies:
-    "@ethereumjs/util": "npm:^9.0.1"
-    crc: "npm:^4.3.2"
-  checksum: 87079979431a1f79af868d0487d22bd84b4fe40a5e4cefc0da5e2125b11416c5f72bfbaabc8f5805c74de45d71c97fad56af7fd0aae6963dd89d119da98c8f28
   languageName: node
   linkType: hard
 
@@ -2432,16 +2422,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethereumjs/rlp@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "@ethereumjs/rlp@npm:5.0.1"
-  bin:
-    rlp: bin/rlp.cjs
-  checksum: 5d68bfe03cda3d06e9ce9cc3dbe3b4abfd96a99171cc77f3353618340b38746771d866e2f10ace7ae3553a046d37d8c3ac669de5c8025ec353ae463698565a55
-  languageName: node
-  linkType: hard
-
-"@ethereumjs/tx@npm:^4.2.0":
+"@ethereumjs/tx@npm:^4.1.2, @ethereumjs/tx@npm:^4.2.0":
   version: 4.2.0
   resolution: "@ethereumjs/tx@npm:4.2.0"
   dependencies:
@@ -2453,23 +2434,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethereumjs/tx@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "@ethereumjs/tx@npm:5.1.0"
-  dependencies:
-    "@ethereumjs/common": "npm:^4.1.0"
-    "@ethereumjs/rlp": "npm:^5.0.1"
-    "@ethereumjs/util": "npm:^9.0.1"
-    ethereum-cryptography: "npm:^2.1.2"
-  peerDependencies:
-    c-kzg: ^2.1.2
-  peerDependenciesMeta:
-    c-kzg:
-      optional: true
-  checksum: f147f3a7101b1db055562b3eedda20c5a4b0cf8d518fc3416c4d40b1d116c7dbd17b003c348e88db45da0449b61cc503cebcc27f7095e6c5c023164ebb6498af
-  languageName: node
-  linkType: hard
-
 "@ethereumjs/util@npm:^8.1.0":
   version: 8.1.0
   resolution: "@ethereumjs/util@npm:8.1.0"
@@ -2478,21 +2442,6 @@ __metadata:
     ethereum-cryptography: "npm:^2.0.0"
     micro-ftch: "npm:^0.3.1"
   checksum: cc35338932e49b15e54ca6e548b32a1f48eed7d7e1d34ee743e4d3600dd616668bd50f70139e86c5c35f55aac35fba3b6cc4e6f679cf650aeba66bf93016200c
-  languageName: node
-  linkType: hard
-
-"@ethereumjs/util@npm:^9.0.1":
-  version: 9.0.1
-  resolution: "@ethereumjs/util@npm:9.0.1"
-  dependencies:
-    "@ethereumjs/rlp": "npm:^5.0.1"
-    ethereum-cryptography: "npm:^2.1.2"
-  peerDependencies:
-    c-kzg: ^2.1.2
-  peerDependenciesMeta:
-    c-kzg:
-      optional: true
-  checksum: 1e8bb27994ffd1cbd5b5e2b6f35376f43f05e6999b7a703c7bb54a162c2d92e55d63e7aec067d980bec5837930cb2979ef62eb4925d4f3ef73d977809b7ead91
   languageName: node
   linkType: hard
 
@@ -7170,9 +7119,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-common/wallet-utils@workspace:suite-common/wallet-utils"
   dependencies:
-    "@ethereumjs/common": "npm:^4.1.0"
-    "@ethereumjs/tx": "npm:^5.1.0"
-    "@ethereumjs/util": "npm:^9.0.1"
     "@suite-common/fiat-services": "workspace:*"
     "@suite-common/metadata-types": "workspace:*"
     "@suite-common/suite-config": "workspace:*"
@@ -8875,6 +8821,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/connect@workspace:packages/connect"
   dependencies:
+    "@ethereumjs/common": "npm:^3.1.2"
+    "@ethereumjs/tx": "npm:^4.1.2"
     "@fivebinaries/coin-selection": "npm:2.2.0"
     "@trezor/blockchain-link": "workspace:*"
     "@trezor/blockchain-link-types": "workspace:*"
@@ -8893,6 +8841,7 @@ __metadata:
     bs58: "npm:^5.0.0"
     bs58check: "npm:^3.0.1"
     cross-fetch: "npm:^4.0.0"
+    ethereum-cryptography: "npm:^2.0.0"
     events: "npm:^3.3.0"
     jest: "npm:29.5.0"
     jest-environment-jsdom: "npm:^29.5.0"
@@ -9447,7 +9396,6 @@ __metadata:
   resolution: "@trezor/suite@workspace:packages/suite"
   dependencies:
     "@crowdin/cli": "npm:^3.15.0"
-    "@ethereumjs/util": "npm:^9.0.1"
     "@formatjs/cli": "npm:^6.2.1"
     "@formatjs/intl": "npm:2.9.6"
     "@hookform/resolvers": "npm:3.1.0"
@@ -15213,18 +15161,6 @@ __metadata:
   dependencies:
     buffer: "npm:^5.1.0"
   checksum: 3a43061e692113d60fbaf5e438c5f6aa3374fe2368244a75cc083ecee6762513bcee8583f67c2c56feea0b0c72b41b7304fbd3c1e26cfcfaec310b9a18543fa8
-  languageName: node
-  linkType: hard
-
-"crc@npm:^4.3.2":
-  version: 4.3.2
-  resolution: "crc@npm:4.3.2"
-  peerDependencies:
-    buffer: ">=6.0.3"
-  peerDependenciesMeta:
-    buffer:
-      optional: true
-  checksum: daa5c340de4ccb0d248ad579d1ca1317efe89d2b3f68a124850a140e9afc17d595cdfc058bd14ea78325c0a706ac73ad94962c1efede6a2a1abf58a48ebbb9da
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

After Connect chunking was merged in #9552, we should move as much shitcoin dependencies from Suite to Connect as possible. This PR does exactly this for ETH.

- https://github.com/trezor/trezor-suite/pull/9963/commits/85fc7149231fe665f918904ad119680b93dabd93 - remove unused `validateAddress` from `wallet-utils`, which allows us to remove `@ethereumjs/util` dependency from there
- https://github.com/trezor/trezor-suite/pull/9963/commits/1c932df0243780f9af47169c884740a70d438a9f - prerequisite refactoring; stronger type handling of `legacy`/`eip1559` txs in `ethereumSignTransaction`; `strip` util separated into stripping hex prefix itself and recursive `deepTransform`, which will be used later
- https://github.com/trezor/trezor-suite/pull/9963/commits/ec14fbf6232460ab76959abaaca55bafa846c10f - move `serializeEthereumTx` util from `suite-common` to connect (incl. unit tests); extending the util so it can handle both `legacy` and `eip1559` txs (Suite supported only legacy); transforming the input data so the strings always have hex prefix (as opposed to `ethereumSignTransaction` where they're always stripped away; they're optional in connect params)
- https://github.com/trezor/trezor-suite/pull/9963/commits/3d12e4438139c58b0d9ba6e7e4f5c5d0e19d1581 - remove `serializeEthereumTx` from `suite-common`, which allows us to remove `@ethereumjs/common` and `@ethereumjs/tx` as well
- https://github.com/trezor/trezor-suite/pull/9963/commits/89b25a0462ff6c9ee1737ff1471501eae3610001 - serialize signed tx at the end of `ethereumSignTransaction` and return it as newly added field (should be backwards-compatible)
- https://github.com/trezor/trezor-suite/pull/9963/commits/52e434032cec827734fdeafed43eebd498989a43 - use already serialized tx directly in Suite
- https://github.com/trezor/trezor-suite/pull/9963/commits/7c765e78eb5ef8f57b699af4ee9c30a5986dc9b8 - use `web3-utils` instead of `@ethereumjs/util` (so it can be removed) for validating address checksums in Suite's send form
- https://github.com/trezor/trezor-suite/pull/9963/commits/dfe002fd4ab20c2219f5b5ee9572f087b8d43c4e - use `ethereum-cryptography` (already there as nested dependency) instead of `web3-utils` (so it can be removed) in connect's unit tests
- https://github.com/trezor/trezor-suite/pull/9963/commits/8a996431e6049ac50d94c8a84288894292bd1cb7 - `yarn.lock` update
- https://github.com/trezor/trezor-suite/pull/9963/commits/3e2cd81d7cc59c1356d13a4f857bf7ca05932993 - update `trezor-common` submodule