### PR TITLE
fix(suite): RBF use increased feeLevel instead of baseFee

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AdvancedTxDetails/AdvancedTxDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AdvancedTxDetails/AdvancedTxDetails.tsx
@@ -3,7 +3,8 @@ import styled from 'styled-components';
 import { Translation } from 'src/components/suite';
 import { variables } from '@trezor/components';
 import { isTestnet } from '@suite-common/wallet-utils';
-import { Network, WalletAccountTransaction } from 'src/types/wallet';
+import { WalletAccountTransaction, ChainedTransactions } from '@suite-common/wallet-types';
+import { Network } from 'src/types/wallet';
 import { AmountDetails } from './AmountDetails';
 import { IODetails } from './IODetails/IODetails';
 import { ChainedTxs } from '../ChainedTxs';
@@ -50,7 +51,7 @@ interface AdvancedTxDetailsProps {
     defaultTab?: TabID;
     network: Network;
     tx: WalletAccountTransaction;
-    chainedTxs: WalletAccountTransaction[];
+    chainedTxs?: ChainedTransactions;
     explorerUrl: string;
 }
 
@@ -69,7 +70,7 @@ export const AdvancedTxDetails = ({
         content = <AmountDetails tx={tx} isTestnet={isTestnet(network.symbol)} />;
     } else if (selectedTab === 'io' && network.networkType !== 'ripple') {
         content = <IODetails tx={tx} />;
-    } else if (selectedTab === 'chained' && chainedTxs.length > 0) {
+    } else if (selectedTab === 'chained' && chainedTxs) {
         content = <ChainedTxs txs={chainedTxs} explorerUrl={explorerUrl} network={network} />;
     }
 
@@ -89,7 +90,7 @@ export const AdvancedTxDetails = ({
                     </TabButton>
                 )}
 
-                {chainedTxs.length > 0 && (
+                {chainedTxs && (
                     <TabButton
                         selected={selectedTab === 'chained'}
                         onClick={() => setSelectedTab('chained')}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChainedTxs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChainedTxs.tsx
@@ -1,14 +1,28 @@
 import styled from 'styled-components';
 
-import { WalletAccountTransaction } from '@suite-common/wallet-types';
+import { variables } from '@trezor/components';
+import { ChainedTransactions } from '@suite-common/wallet-types';
 
-import { TrezorLink } from 'src/components/suite';
+import { TrezorLink, Translation } from 'src/components/suite';
 import { TransactionItem } from 'src/components/wallet/TransactionItem/TransactionItem';
 import { Network } from 'src/types/wallet';
+import { AffectedTransactionItem } from './ChangeFee/AffectedTransactionItem';
 
 const Wrapper = styled.div`
     text-align: left;
     margin-top: 25px;
+`;
+
+const Header = styled.div`
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
+    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+    font-size: ${variables.FONT_SIZE.SMALL};
+    padding: 0 20px;
+`;
+
+const Label = styled(Header)`
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
+    padding: 12px 20px;
 `;
 
 const StyledTrezorLink = styled(TrezorLink)`
@@ -17,8 +31,19 @@ const StyledTrezorLink = styled(TrezorLink)`
 
 const ChainedTransactionItem = styled(TransactionItem)`
     width: 100%;
-    padding: 0 40px;
     cursor: pointer;
+    border-left: 0;
+
+    &:hover {
+        background: ${({ theme }) => theme.BG_GREY};
+    }
+`;
+
+const StyledAffectedTransactionItem = styled(AffectedTransactionItem)`
+    width: 100%;
+    cursor: pointer;
+    padding: 20px;
+    border-radius: 12px;
 
     &:hover {
         background: ${({ theme }) => theme.BG_GREY};
@@ -26,14 +51,23 @@ const ChainedTransactionItem = styled(TransactionItem)`
 `;
 
 interface ChainedTxsProps {
-    txs: WalletAccountTransaction[];
+    txs: ChainedTransactions;
     network: Network;
     explorerUrl: string;
 }
 
 export const ChainedTxs = ({ txs, network, explorerUrl }: ChainedTxsProps) => (
     <Wrapper>
-        {txs.map((tx, index) => (
+        <Header>
+            <Translation id="TR_AFFECTED_TXS_HEADER" />
+        </Header>
+
+        {txs.own.length > 0 && (
+            <Label>
+                <Translation id="TR_AFFECTED_TXS_OWN" />
+            </Label>
+        )}
+        {txs.own.map((tx, index) => (
             <StyledTrezorLink key={tx.txid} href={`${explorerUrl}${tx.txid}`} variant="nostyle">
                 <ChainedTransactionItem
                     key={tx.txid}
@@ -44,6 +78,17 @@ export const ChainedTxs = ({ txs, network, explorerUrl }: ChainedTxsProps) => (
                     accountKey={`${tx.descriptor}-${tx.symbol}-${tx.deviceState}`}
                     index={index}
                 />
+            </StyledTrezorLink>
+        ))}
+
+        {txs.others.length > 0 && (
+            <Label>
+                <Translation id="TR_AFFECTED_TXS_OTHERS" />
+            </Label>
+        )}
+        {txs.others.map(tx => (
+            <StyledTrezorLink key={tx.txid} href={`${explorerUrl}${tx.txid}`} variant="nostyle">
+                <StyledAffectedTransactionItem tx={tx} />
             </StyledTrezorLink>
         ))}
     </Wrapper>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/AffectedTransactionItem.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/AffectedTransactionItem.tsx
@@ -1,0 +1,80 @@
+import styled from 'styled-components';
+import { Icon, useTheme, variables } from '@trezor/components';
+import { WalletAccountTransaction } from '@suite-common/wallet-types';
+import { FormattedDate } from 'src/components/suite';
+import { useLayoutSize } from 'src/hooks/suite/useLayoutSize';
+import { truncateMiddle } from '@trezor/utils';
+
+const TxRow = styled.div`
+    display: flex;
+    align-items: center;
+    padding: 4px 0;
+`;
+
+const IconWrapper = styled.div`
+    padding-right: 24px;
+`;
+
+const Text = styled.span`
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
+    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+    font-size: ${variables.FONT_SIZE.SMALL};
+    font-variant-numeric: tabular-nums;
+`;
+
+const Txid = styled(Text)`
+    text-overflow: ellipsis;
+    overflow: hidden;
+    flex: 1;
+    font-variant-numeric: slashed-zero tabular-nums;
+`;
+
+const Timestamp = styled(Text)`
+    white-space: nowrap;
+    margin-left: 4px;
+`;
+
+const Bullet = styled.div`
+    margin-left: 8px;
+    margin-right: 8px;
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
+`;
+
+export const AffectedTransactionItem = ({
+    tx,
+    isAccountOwned,
+    className,
+}: {
+    tx: WalletAccountTransaction;
+    isAccountOwned?: boolean;
+    className?: string;
+}) => {
+    const theme = useTheme();
+    const { isMobileLayout } = useLayoutSize();
+    const shownTxidChars = isMobileLayout ? 4 : 8;
+    const iconType = tx.type === 'recv' ? 'RECEIVE' : 'SEND';
+    return (
+        <TxRow className={className}>
+            {!isMobileLayout && (
+                <IconWrapper>
+                    <Icon
+                        size={16}
+                        color={theme.TYPE_LIGHT_GREY}
+                        icon={isAccountOwned ? iconType : 'CLOCK'}
+                    />
+                </IconWrapper>
+            )}
+
+            {tx.blockTime && (
+                <>
+                    <Timestamp>
+                        <FormattedDate value={new Date(tx.blockTime * 1000)} time />
+                    </Timestamp>
+                    <Bullet>&bull;</Bullet>
+                </>
+            )}
+
+            <Txid>{truncateMiddle(tx.txid, shownTxidChars, shownTxidChars + 2)}</Txid>
+        </TxRow>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/AffectedTransactions.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/AffectedTransactions.tsx
@@ -1,13 +1,10 @@
 import styled from 'styled-components';
-import BigNumber from 'bignumber.js';
-import { Icon, Button, useTheme, variables } from '@trezor/components';
-import { formatNetworkAmount } from '@suite-common/wallet-utils';
-import { FormattedCryptoAmount, Sign, Translation, FormattedDate } from 'src/components/suite';
+import { Button } from '@trezor/components';
+import { Translation } from 'src/components/suite';
 import { useRbfContext } from 'src/hooks/wallet/useRbfForm';
-import { useLayoutSize } from 'src/hooks/suite/useLayoutSize';
-import { truncateMiddle } from '@trezor/utils';
 import { GreyCard } from './GreyCard';
 import { WarnHeader } from './WarnHeader';
+import { AffectedTransactionItem } from './AffectedTransactionItem';
 
 const ChainedTxs = styled.div`
     display: flex;
@@ -17,52 +14,9 @@ const ChainedTxs = styled.div`
     border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
 `;
 
-const TxRow = styled.div`
-    display: flex;
-    align-items: center;
-    padding: 4px 0;
-`;
-
-const IconWrapper = styled.div`
-    margin-right: 16px;
-`;
-
-const Text = styled.span`
-    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
-    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-    font-size: ${variables.FONT_SIZE.SMALL};
-    font-variant-numeric: tabular-nums;
-`;
-
-const Txid = styled(Text)`
-    text-overflow: ellipsis;
-    overflow: hidden;
-    flex: 1;
-    font-variant-numeric: slashed-zero tabular-nums;
-`;
-
-const Timestamp = styled(Text)`
-    white-space: nowrap;
-    margin-left: 8px;
-`;
-
-const Amount = styled(Text)`
-    display: flex;
-    margin-left: auto;
-`;
-
-const Bullet = styled.div`
-    margin-left: 8px;
-    margin-right: 8px;
-    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
-`;
-
 export const AffectedTransactions = ({ showChained }: { showChained: () => void }) => {
-    const theme = useTheme();
-    const { isMobileLayout } = useLayoutSize();
-    const { network, chainedTxs } = useRbfContext();
-    if (chainedTxs.length === 0) return null;
-    const shownTxidChars = isMobileLayout ? 4 : 8;
+    const { chainedTxs } = useRbfContext();
+    if (!chainedTxs) return null;
 
     return (
         <GreyCard>
@@ -81,43 +35,12 @@ export const AffectedTransactions = ({ showChained }: { showChained: () => void 
                 <Translation id="TR_AFFECTED_TXS" />
             </WarnHeader>
             <ChainedTxs>
-                {chainedTxs.map(tx => {
-                    const amount = formatNetworkAmount(tx.amount, tx.symbol);
-                    return (
-                        <TxRow key={tx.txid}>
-                            {!isMobileLayout && (
-                                <IconWrapper>
-                                    <Icon
-                                        size={16}
-                                        color={theme.TYPE_LIGHT_GREY}
-                                        icon={tx.type === 'recv' ? 'RECEIVE' : 'SEND'}
-                                    />
-                                </IconWrapper>
-                            )}
-
-                            {tx.blockTime && (
-                                <>
-                                    <Timestamp>
-                                        <FormattedDate value={new Date(tx.blockTime * 1000)} time />
-                                    </Timestamp>
-                                    <Bullet>&bull;</Bullet>
-                                </>
-                            )}
-
-                            <Txid>
-                                {truncateMiddle(tx.txid, shownTxidChars, shownTxidChars + 2)}
-                            </Txid>
-                            <Amount>
-                                <Sign
-                                    value={new BigNumber(amount)}
-                                    grayscale
-                                    grayscaleColor={theme.TYPE_LIGHT_GREY}
-                                />
-                                <FormattedCryptoAmount value={amount} symbol={network.symbol} />
-                            </Amount>
-                        </TxRow>
-                    );
-                })}
+                {chainedTxs.own.map(tx => (
+                    <AffectedTransactionItem key={tx.txid} tx={tx} isAccountOwned />
+                ))}
+                {chainedTxs.others.map(tx => (
+                    <AffectedTransactionItem key={tx.txid} tx={tx} />
+                ))}
             </ChainedTxs>
         </GreyCard>
     );

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ChangeFee.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ChangeFee.tsx
@@ -112,7 +112,7 @@ interface ChangeFeeProps extends UseRbfProps {
 
 const ChangeFeeLoaded = (props: ChangeFeeProps) => {
     const contextValues = useRbf(props);
-    const { tx, chainedTxs, showChained, finalize, children } = props;
+    const { tx, showChained, finalize, children } = props;
     const { networkType } = contextValues.account;
     const feeRate =
         networkType === 'bitcoin' ? `${tx.rbfParams?.feeRate} ${getFeeUnits(networkType)}` : null;
@@ -152,7 +152,7 @@ const ChangeFeeLoaded = (props: ChangeFeeProps) => {
                         <RbfFees />
                     </Inner>
                     <DecreasedOutputs />
-                    {chainedTxs.length > 0 && <AffectedTransactions showChained={showChained} />}
+                    <AffectedTransactions showChained={showChained} />
                 </Box>
                 {finalize && (
                     <FinalizeWarning>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/WarnHeader.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/WarnHeader.tsx
@@ -11,13 +11,10 @@ const Header = styled.div`
     align-items: center;
 `;
 
-const IconWrapper = styled.div`
-    margin-right: 16px;
-`;
-
 const Body = styled.div`
     display: flex;
     flex: 1;
+    padding: 0 16px;
 `;
 
 interface WarnHeaderProps extends HTMLAttributes<HTMLDivElement> {
@@ -30,9 +27,7 @@ export const WarnHeader = ({ action, children, ...rest }: WarnHeaderProps) => {
 
     return (
         <Header {...rest}>
-            <IconWrapper>
-                <Icon size={16} icon="WARNING" color={theme.TYPE_ORANGE} />
-            </IconWrapper>
+            <Icon size={16} icon="WARNING" color={theme.TYPE_ORANGE} />
             <Body>{children}</Body>
             {action}
         </Header>

--- a/packages/suite/src/hooks/wallet/__fixtures__/useRbfForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useRbfForm.ts
@@ -106,8 +106,8 @@ const PREPARE_TX = (params = {}) => ({
             address: '1DyHzbQUoQEsLxJn6M7fMD8Xdt1XvNiwNE',
             transfers: 1,
         },
-        feeRate: 1,
-        baseFee: 1,
+        feeRate: '3.79',
+        baseFee: 175,
         ...params,
     },
 });
@@ -140,6 +140,8 @@ export const composeAndSign = [
         composedLevels: {
             normal: {
                 type: 'final',
+                fee: '1761',
+                feePerByte: '7.79', // 3.79 (old) + 4 (new)
                 outputs: [
                     {
                         address: '1MCgrVZjXRJJJhi2Z6SR11GpRjCyvNjscY',
@@ -161,7 +163,7 @@ export const composeAndSign = [
                 },
                 {
                     address_n: [2147483692, 2147483648, 2147483648, 1, 0],
-                    amount: '10095',
+                    amount: '9239',
                     orig_index: 1,
                     orig_hash: 'ABCD',
                 },
@@ -180,6 +182,7 @@ export const composeAndSign = [
         composedLevels: {
             normal: {
                 type: 'final',
+                feePerByte: '7.79', // 3.79 (old) + 4 (new)
                 outputs: [
                     {
                         address: '1MCgrVZjXRJJJhi2Z6SR11GpRjCyvNjscY',
@@ -197,7 +200,7 @@ export const composeAndSign = [
                 {
                     // change-output is restored
                     address_n: [2147483692, 2147483648, 2147483648, 1, 0],
-                    amount: '10095',
+                    amount: '9239',
                     orig_index: 0,
                     orig_hash: 'ABCD',
                 },
@@ -232,10 +235,12 @@ export const composeAndSign = [
                     formattedAmount: '0.0003',
                 },
             ],
+            feeRate: '1',
         }),
         composedLevels: {
             normal: {
                 fee: '1000',
+                feePerByte: '5.21', // 1 (old) + 4 (new) + 0.21 (dropped as dust)
                 outputs: [
                     // change-output is gone
                     {
@@ -279,6 +284,7 @@ export const composeAndSign = [
                     formattedAmount: '0.000304',
                 },
             ],
+            feeRate: '1',
         }),
         composedLevels: {
             normal: {
@@ -287,7 +293,7 @@ export const composeAndSign = [
             custom: {
                 type: 'final',
                 fee: '600',
-                feePerByte: '3.13',
+                feePerByte: '3.13', // 1 (old) + 2.13 (highest possible)
                 outputs: [
                     // change-output is gone
                     {
@@ -350,11 +356,13 @@ export const composeAndSign = [
                 },
             ],
             changeAddress: undefined,
+            feeRate: '12',
         }),
         composedLevels: {
             normal: {
                 type: 'final',
-                fee: '3741',
+                fee: '8228',
+                feePerByte: '22', // 12 (old) + 10 (new)
                 inputs: [{ prev_hash: DCBA }, { prev_hash: ABCD }],
                 outputs: [
                     {
@@ -364,7 +372,7 @@ export const composeAndSign = [
                     // change-output is added, note that this is first unused address (not first on the list)
                     {
                         address_n: [2147483692, 2147483648, 2147483648, 1, 1],
-                        amount: '6259',
+                        amount: '1772',
                     },
                 ],
             },
@@ -379,7 +387,7 @@ export const composeAndSign = [
                     orig_hash: 'ABCD',
                 },
                 {
-                    amount: '6259',
+                    amount: '1772',
                 },
             ],
         },
@@ -423,13 +431,14 @@ export const composeAndSign = [
                     formattedAmount: '0.00031',
                 },
             ],
+            feeRate: '1',
             changeAddress: undefined,
         }),
         composedLevels: {
             custom: {
                 type: 'final',
                 fee: '1000',
-                feePerByte: '2.94',
+                feePerByte: '2.94', // 1 (old) + 1.94 (highest possible)
                 inputs: [{ prev_hash: DCBA }, { prev_hash: ABCD }],
                 outputs: [
                     {
@@ -497,12 +506,13 @@ export const composeAndSign = [
                     formattedAmount: '0.000302',
                 },
             ],
+            feeRate: '1',
         }),
         composedLevels: {
             custom: {
                 type: 'final',
                 fee: '1800', // new utxo + old change-output + old fee (100)
-                feePerByte: '5.29',
+                feePerByte: '5.29', // 1 (old) + 4.29 (highest possible)
                 inputs: [{ prev_hash: DCBA }, { prev_hash: ABCD }], // new utxo added
                 outputs: [
                     // change output was removed
@@ -566,17 +576,19 @@ export const composeAndSign = [
                     formattedAmount: '0.00031',
                 },
             ],
+            feeRate: '2',
             changeAddress: undefined,
         }),
         composedLevels: {
             normal: {
                 type: 'final',
-                fee: '1921',
+                fee: '2304',
+                feePerByte: '12', // 2 (old) + 10 (new)
                 inputs: [{ prev_hash: DCBA }],
                 outputs: [
                     {
                         address: '1MCgrVZjXRJJJhi2Z6SR11GpRjCyvNjscY',
-                        amount: '29079',
+                        amount: '28696',
                     },
                 ],
             },
@@ -588,7 +600,7 @@ export const composeAndSign = [
             outputs: [
                 {
                     address: '1MCgrVZjXRJJJhi2Z6SR11GpRjCyvNjscY',
-                    amount: '29079',
+                    amount: '28696',
                     orig_index: 0,
                     orig_hash: 'ABCD',
                 },
@@ -625,6 +637,7 @@ export const composeAndSign = [
                     formattedAmount: '0.00031',
                 },
             ],
+            feeRate: '1.37',
             changeAddress: undefined,
         }),
         composeTransactionCalls: 1, // 1. immediate send-max
@@ -632,12 +645,13 @@ export const composeAndSign = [
         composedLevels: {
             normal: {
                 type: 'final',
-                fee: '769',
+                fee: '1032',
+                feePerByte: '5.38', // 1.37 (old) + 4 (new) + 0.01 (fee rounding)
                 inputs: [{ prev_hash: DCBA }],
                 outputs: [
                     {
                         address: '1MCgrVZjXRJJJhi2Z6SR11GpRjCyvNjscY',
-                        amount: '30231',
+                        amount: '29968',
                     },
                 ],
             },
@@ -647,7 +661,7 @@ export const composeAndSign = [
             outputs: [
                 {
                     address: '1MCgrVZjXRJJJhi2Z6SR11GpRjCyvNjscY',
-                    amount: '30231',
+                    amount: '29968',
                     orig_index: 0,
                     orig_hash: 'ABCD',
                 },
@@ -675,11 +689,12 @@ export const composeAndSign = [
         composedLevels: {
             normal: {
                 type: 'final',
-                fee: '769',
+                fee: '1496',
+                feePerByte: '7.79', // 3.79 (old) + 4 (new)
                 outputs: [
                     {
                         address: '1MCgrVZjXRJJJhi2Z6SR11GpRjCyvNjscY',
-                        amount: '30231',
+                        amount: '29504',
                     },
                 ],
             },
@@ -691,7 +706,7 @@ export const composeAndSign = [
             outputs: [
                 {
                     address: '1MCgrVZjXRJJJhi2Z6SR11GpRjCyvNjscY',
-                    amount: '30231',
+                    amount: '29504',
                     orig_index: 0,
                     orig_hash: 'ABCD',
                 },
@@ -710,7 +725,7 @@ export const composeAndSign = [
                 {
                     type: 'change',
                     address: '1DyHzbQUoQEsLxJn6M7fMD8Xdt1XvNiwNE',
-                    amount: '700',
+                    amount: '29043',
                     formattedAmount: '0.000007',
                 },
                 {
@@ -725,11 +740,13 @@ export const composeAndSign = [
                     formattedAmount: '0.00001',
                 },
             ],
+            feeRate: '3',
         }),
         composedLevels: {
             normal: {
                 type: 'final',
-                fee: '957',
+                fee: '1673',
+                feePerByte: '7', // 3 (old) + 4 (new)
                 // outputs indexes are totally mixed up
                 outputs: [
                     {
@@ -739,7 +756,7 @@ export const composeAndSign = [
                         amount: '1000', // external
                     },
                     {
-                        amount: '29043', // change
+                        amount: '28327', // change
                     },
                 ],
             },
@@ -750,7 +767,7 @@ export const composeAndSign = [
             outputs: [
                 {
                     address_n: [2147483692, 2147483648, 2147483648, 1, 0],
-                    amount: '29043',
+                    amount: '28327',
                     orig_index: 0,
                     orig_hash: 'ABCD',
                 },
@@ -797,6 +814,7 @@ export const composeAndSign = [
                     formattedAmount: '0.000005',
                 },
             ],
+            feeRate: '1',
             changeAddress: undefined,
         }),
         composedLevels: {
@@ -860,13 +878,14 @@ export const composeAndSign = [
                     formattedAmount: '0.000078',
                 },
             ],
-            feeRate: 11.33,
-            baseFee: 2175.36, // 192 * 11.33,
+            feeRate: '11.33',
             changeAddress: undefined,
         }),
         composedLevels: {
             normal: {
                 type: 'final',
+                fee: '2944',
+                feePerByte: '15.33', // 11.33 (old) + 4 (new)
             },
         },
         composeTransactionCalls: 1, // 1. immediate send-max
@@ -876,7 +895,7 @@ export const composeAndSign = [
             outputs: [
                 {
                     address: '1MCgrVZjXRJJJhi2Z6SR11GpRjCyvNjscY',
-                    amount: '5057',
+                    amount: '5056',
                     orig_index: 0,
                     orig_hash: 'ABCD',
                 },
@@ -945,13 +964,14 @@ export const composeAndSign = [
                     formattedAmount: '0.000078',
                 },
             ],
-            feeRate: 11.33,
-            baseFee: 2175.36, // 192 * 11.33,
+            feeRate: '11.33',
             changeAddress: undefined,
         }),
         composedLevels: {
             normal: {
                 type: 'final',
+                fee: '2944',
+                feePerByte: '15.33', // 11.33 (old) + 4 (new)
             },
         },
         composeTransactionCalls: 1, // 1. immediate send-max
@@ -961,7 +981,7 @@ export const composeAndSign = [
             outputs: [
                 {
                     address: '1MCgrVZjXRJJJhi2Z6SR11GpRjCyvNjscY',
-                    amount: '5057',
+                    amount: '5056',
                     orig_index: 0,
                     orig_hash: 'ABCD',
                 },

--- a/packages/suite/src/hooks/wallet/__fixtures__/useRbfForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useRbfForm.ts
@@ -171,6 +171,61 @@ export const composeAndSign = [
         },
     },
     {
+        description: 'change-output reduced by fee + baseFee of chainedTransactions',
+        store: {
+            selectedAccount: {
+                ...BTC_ACCOUNT,
+            },
+        },
+        chainedTxs: {
+            own: [{ txid: 'aaaa', fee: '500' }],
+            others: [
+                { txid: 'bbbb', fee: '500' },
+                { txid: 'cccc', fee: '5000' },
+            ],
+        },
+        tx: PREPARE_TX({
+            outputs: [
+                {
+                    type: 'payment',
+                    address: '1MCgrVZjXRJJJhi2Z6SR11GpRjCyvNjscY',
+                    amount: '20000',
+                    formattedAmount: '0.0002',
+                },
+                {
+                    type: 'change',
+                    address: '1DyHzbQUoQEsLxJn6M7fMD8Xdt1XvNiwNE',
+                    amount: '10771',
+                    formattedAmount: '0.00010771',
+                },
+            ],
+        }),
+        composedLevels: {
+            normal: {
+                type: 'final',
+                fee: '7761', // 1761 + 6000 for chainedTxs
+                feePerByte: '34.34', // 3.79 (old) + 4 (new) + 26.55 for chainedTxs
+            },
+        },
+        composeTransactionCalls: 1,
+        signedTx: {
+            outputs: [
+                {
+                    address: '1MCgrVZjXRJJJhi2Z6SR11GpRjCyvNjscY',
+                    amount: '20000',
+                    orig_index: 0,
+                    orig_hash: 'ABCD',
+                },
+                {
+                    address_n: [2147483692, 2147483648, 2147483648, 1, 0],
+                    amount: '3239',
+                    orig_index: 1,
+                    orig_hash: 'ABCD',
+                },
+            ],
+        },
+    },
+    {
         description:
             'change-output reduced by fee. outputs needs reordering. change was moved by compose process.',
         store: {
@@ -998,4 +1053,3 @@ export const composeAndSign = [
 // TODO: finalize (check constants)
 // TODO: with locktime
 // TODO: ethereum cases
-// TODO: with chained txs

--- a/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
@@ -119,7 +119,7 @@ describe('useRbfForm hook', () => {
             const { unmount } = renderWithProviders(
                 store,
                 // @ts-expect-error f.tx is not exact
-                <ChangeFee tx={f.tx} finalize={false} chainedTxs={[]} showChained={() => {}}>
+                <ChangeFee tx={f.tx} chainedTxs={f.chainedTxs} showChained={() => {}}>
                     <Component callback={callback} />
                 </ChangeFee>,
             );

--- a/packages/suite/src/hooks/wallet/form/useFees.ts
+++ b/packages/suite/src/hooks/wallet/form/useFees.ts
@@ -64,6 +64,7 @@ export const useFees = <TFieldValues extends FormState>({
     // watch custom feePerUnit/feeLimit inputs change
     const feePerUnit = watch('feePerUnit');
     const feeLimit = watch('feeLimit');
+    const baseFee = watch('baseFee');
     useEffect(() => {
         if (selectedFeeRef.current !== 'custom') return;
 
@@ -126,9 +127,9 @@ export const useFees = <TFieldValues extends FormState>({
             )!;
             // set custom values from a previously selected composed transaction
             // or from previously selected FeeLevel
-            const transactionInfo = composedLevels && composedLevels[selectedFeeRef.current!];
+            const transactionInfo = composedLevels && composedLevels[currentLevel.label];
             feePerUnit =
-                transactionInfo && transactionInfo.type !== 'error'
+                !baseFee && transactionInfo && transactionInfo.type !== 'error'
                     ? transactionInfo.feePerByte
                     : currentLevel.feePerUnit;
             feeLimit = getValues('estimatedFeeLimit') || currentLevel.feeLimit || '';

--- a/packages/suite/src/hooks/wallet/useRbfForm.ts
+++ b/packages/suite/src/hooks/wallet/useRbfForm.ts
@@ -9,7 +9,7 @@ import {
     SelectedAccountLoaded,
     Account,
     RbfTransactionParams,
-    WalletAccountTransaction,
+    ChainedTransactions,
 } from '@suite-common/wallet-types';
 import { FormState, FeeInfo } from 'src/types/wallet/sendForm';
 import { useFees } from './form/useFees';
@@ -22,7 +22,7 @@ export type UseRbfProps = {
     selectedAccount: SelectedAccountLoaded;
     rbfParams: RbfTransactionParams;
     finalize: boolean;
-    chainedTxs: WalletAccountTransaction[];
+    chainedTxs?: ChainedTransactions;
 };
 
 const getBitcoinFeeInfo = (info: FeeInfo, feeRate: string) => {
@@ -144,10 +144,9 @@ const useRbfState = ({ selectedAccount, rbfParams, finalize, chainedTxs }: UseRb
         // try to overprice them. offer fee higher than sum of both:
         // - current tx with higher feeRate
         // - sum of all fees of all chainedTxs
-        let baseFee = 0;
-        if (chainedTxs.length > 0) {
-            baseFee = chainedTxs.reduce((f, ctx) => f + parseFloat(ctx.fee), baseFee);
-        }
+        const baseFee =
+            chainedTxs &&
+            chainedTxs.own.concat(chainedTxs.others).reduce((f, ctx) => f + parseFloat(ctx.fee), 0);
 
         return {
             account: rbfAccount,

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7476,6 +7476,17 @@ export default defineMessages({
     TR_FEE_ROUNDING_WARNING: {
         id: 'TR_FEE_ROUNDING_WARNING',
         defaultMessage: 'Your Trezor may display a different rate caused by fee rounding.',
+        description:
+            'Removed in favor of TR_FEE_ROUNDING_DEFAULT_WARNING and TR_FEE_ROUNDING_BASEFEE_WARNING',
+    },
+    TR_FEE_ROUNDING_DEFAULT_WARNING: {
+        id: 'TR_FEE_ROUNDING_DEFAULT_WARNING',
+        defaultMessage: 'The fee rate of {feeRate} has been increased due to fee rounding',
+    },
+    TR_FEE_ROUNDING_BASEFEE_WARNING: {
+        id: 'TR_FEE_ROUNDING_BASEFEE_WARNING',
+        defaultMessage:
+            'The fee rate of {feeRate} has been increased to pay for the chained transactions within the mempool',
     },
     TR_FEE_RATE_CHANGED: {
         id: 'TR_FEE_RATE_CHANGED',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -6238,6 +6238,19 @@ export default defineMessages({
         id: 'TR_AFFECTED_TXS',
         defaultMessage: 'This operation will remove the following transactions from the mempool',
     },
+    TR_AFFECTED_TXS_HEADER: {
+        id: 'TR_AFFECTED_TXS_HEADER',
+        defaultMessage:
+            'Chained transactions are created from the output of this initial transaction',
+    },
+    TR_AFFECTED_TXS_OWN: {
+        id: 'TR_AFFECTED_TXS_OWN',
+        defaultMessage: 'Your transactions',
+    },
+    TR_AFFECTED_TXS_OTHERS: {
+        id: 'TR_AFFECTED_TXS_OTHERS',
+        defaultMessage: 'Transactions created from other accounts',
+    },
     TR_OUTPUTS: {
         id: 'TR_OUTPUTS',
         defaultMessage: 'Outputs',

--- a/suite-common/wallet-core/src/transactions/transactionsReducer.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsReducer.ts
@@ -199,6 +199,17 @@ export const selectPendingAccountAddresses = memoizeWithArgs(
     { size: EXPECTED_MAX_NUMBER_OF_ACCOUNTS },
 );
 
+export const selectAllPendingTransactions = (state: TransactionsRootState) => {
+    const { transactions } = state.wallet.transactions;
+    return Object.keys(transactions).reduce(
+        (response, accountKey) => {
+            response[accountKey] = transactions[accountKey].filter(isPending);
+            return response;
+        },
+        {} as typeof transactions,
+    );
+};
+
 // Note: Account key is passed because there can be duplication of TXIDs if self transaction was sent.
 export const selectTransactionByTxidAndAccountKey = (
     state: TransactionsRootState,

--- a/suite-common/wallet-types/src/sendForm.ts
+++ b/suite-common/wallet-types/src/sendForm.ts
@@ -31,6 +31,7 @@ export interface FormState {
     feePerUnit: string; // bitcoin/ethereum/ripple custom fee field (satB/gasPrice/drops)
     feeLimit: string; // ethereum only (gasLimit)
     estimatedFeeLimit?: string; // ethereum only (gasLimit)
+    baseFee?: number; // used by RBF from. pay for related transactions
     // advanced form inputs
     options: FormOptions[];
     bitcoinLockTime?: string; // bitcoin RBF/schedule

--- a/suite-common/wallet-types/src/transaction.ts
+++ b/suite-common/wallet-types/src/transaction.ts
@@ -182,6 +182,11 @@ export interface WalletAccountTransaction extends AccountTransaction {
     deadline?: number;
 }
 
+export interface ChainedTransactions {
+    own: WalletAccountTransaction[];
+    others: WalletAccountTransaction[];
+}
+
 export interface SignTransactionData {
     account: Account;
     address: string;

--- a/suite-common/wallet-utils/src/__fixtures__/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/__fixtures__/transactionUtils.ts
@@ -846,107 +846,133 @@ export const searchTransactions = [
     },
 ];
 
+const CHAINED_TXS = {
+    'account1-key': [
+        {
+            descriptor: 'account1',
+            txid: 'ABCD-child-child-child',
+            type: 'received', // 3rd
+            details: {
+                vin: [{ txid: 'ABCD-child-child' }],
+            },
+        },
+        {
+            descriptor: 'account1',
+            txid: 'ABCD-child-child',
+            type: 'sent', // 2nd tx in chain to account 3
+            details: {
+                vin: [{ txid: 'ABCD-child' }],
+            },
+        },
+        {
+            descriptor: 'account1',
+            txid: 'ABCD-child',
+            type: 'received', // 1st
+            details: {
+                vin: [{ txid: 'ABCD' }],
+            },
+        },
+    ],
+    'account2-key': [
+        {
+            descriptor: 'account2',
+            txid: '4567',
+            details: {
+                vin: [{ txid: '8910' }],
+            },
+        },
+        {
+            descriptor: 'account2',
+            txid: 'ABCD-child', // 1st tx in chain to account 1
+            type: 'sent',
+            details: {
+                vin: [{ txid: 'ABCD' }],
+            },
+        },
+    ],
+    'account3-key': [
+        {
+            descriptor: 'account3',
+            txid: 'external_txid',
+            type: 'sent', // 4th tx in chain spend to somewhere else
+            details: {
+                vin: [{ txid: 'ABCD-child-child-child' }],
+            },
+        },
+        {
+            descriptor: 'account3',
+            txid: 'ABCD-child-child-child',
+            type: 'sent', // 3rd tx in chain back to account 1
+            details: {
+                vin: [{ txid: 'ABCD-child-child' }],
+            },
+        },
+        {
+            descriptor: 'account3',
+            txid: 'ABCD-child-child',
+            type: 'received', // 2nd
+            details: {
+                vin: [{ txid: 'ABCD-child' }],
+            },
+        },
+    ],
+};
+
 export const findChainedTransactions = [
     {
-        description: 'deeply chained transactions',
+        description: 'deeply chained transactions by account 1',
+        descriptor: 'account1',
         txid: 'ABCD',
-        transactions: {
-            'account1-key': [
-                {
-                    txid: 'ABCD-child',
-                    details: {
-                        vin: [{ txid: 'ABCD' }],
-                    },
-                },
-                {
-                    txid: 'ABCD-child-child',
-                    details: {
-                        vin: [{ txid: 'ABCD-child' }],
-                    },
-                },
-                {
-                    txid: 'ABCD-child-child-child',
-                    details: {
-                        vin: [{ txid: 'ABCD-child-child' }],
-                    },
-                },
+        transactions: CHAINED_TXS,
+        result: {
+            own: [
+                { txid: 'ABCD-child' },
+                { txid: 'ABCD-child-child' },
+                { txid: 'ABCD-child-child-child' },
             ],
-            'account2-key': [
-                {
-                    txid: '0123',
-                    details: {
-                        vin: [{ txid: '0012' }],
-                    },
-                },
-                {
-                    txid: 'XYZ0',
-                    details: {
-                        vin: [{ txid: 'ABCD-child-child-child' }],
-                    },
-                },
-                {
-                    txid: '4567',
-                    details: {
-                        vin: [{ txid: '8910' }],
-                    },
-                },
-            ],
-            'account3-key': [
-                {
-                    txid: 'XYZ1',
-                    details: {
-                        vin: [{ txid: 'ABCD-child' }],
-                    },
-                },
+            others: [{ txid: 'external_txid' }],
+        },
+    },
+    {
+        description: 'deeply chained transactions by account 2',
+        descriptor: 'account2',
+        txid: 'ABCD',
+        transactions: CHAINED_TXS,
+        result: {
+            own: [{ txid: 'ABCD-child' }],
+            others: [
+                { txid: 'ABCD-child-child' },
+                { txid: 'ABCD-child-child-child' },
+                { txid: 'external_txid' },
             ],
         },
-        result: [
-            {
-                key: 'account1-key',
-                txs: [
-                    {
-                        txid: 'ABCD-child',
-                        details: {
-                            vin: [{ txid: 'ABCD' }],
-                        },
-                    },
-                    {
-                        txid: 'ABCD-child-child',
-                        details: {
-                            vin: [{ txid: 'ABCD-child' }],
-                        },
-                    },
-                    {
-                        txid: 'ABCD-child-child-child',
-                        details: {
-                            vin: [{ txid: 'ABCD-child-child' }],
-                        },
-                    },
-                ],
-            },
-            {
-                key: 'account2-key',
-                txs: [
-                    {
-                        txid: 'XYZ0',
-                        details: {
-                            vin: [{ txid: 'ABCD-child-child-child' }],
-                        },
-                    },
-                ],
-            },
-            {
-                key: 'account3-key',
-                txs: [
-                    {
-                        txid: 'XYZ1',
-                        details: {
-                            vin: [{ txid: 'ABCD-child' }],
-                        },
-                    },
-                ],
-            },
-        ],
+    },
+    {
+        description: 'last from chained transactions by account 1',
+        descriptor: 'account2',
+        txid: 'ABCD-child-child-child',
+        transactions: CHAINED_TXS,
+        result: {
+            own: [],
+            others: [{ txid: 'external_txid' }],
+        },
+    },
+    {
+        description: 'last from chained transactions by account 3',
+        descriptor: 'account3',
+        txid: 'ABCD-child-child-child',
+        transactions: CHAINED_TXS,
+        result: {
+            own: [{ txid: 'external_txid' }],
+            others: [],
+        },
+    },
+    {
+        description: 'no results',
+        descriptor: 'account3',
+        txid: 'external_txid',
+        transactions: CHAINED_TXS,
+        result: undefined,
     },
 ];
 

--- a/suite-common/wallet-utils/src/__tests__/transactionUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/transactionUtils.test.ts
@@ -157,7 +157,22 @@ describe('transaction utils', () => {
 
     fixtures.findChainedTransactions.forEach(f => {
         it(`findChainedTransactions: ${f.description}`, () => {
-            expect(findChainedTransactions(f.txid, f.transactions as any)).toEqual(f.result);
+            const chained = findChainedTransactions(f.descriptor, f.txid, f.transactions as any);
+            if (!chained || !f.result) {
+                expect(chained).toEqual(f.result);
+                return;
+            }
+
+            expect(
+                chained.own.map(t => ({
+                    txid: t.txid,
+                })),
+            ).toEqual(f.result.own);
+            expect(
+                chained.others.map(t => ({
+                    txid: t.txid,
+                })),
+            ).toEqual(f.result.others);
         });
     });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

### First commit
Should fix https://github.com/trezor/trezor-suite/issues/9424

in new fee calculation using `baseFee` parameter returns invalid results when new utxo and new change output are added (described in the issue)

new feeRate for composeTransactions process can be easily taken from the useRbfForm state (increased levels old + new)
it wasn't done like this until now because there was a time when transactions received from the backend didnt have feeRate field, but they have it some time now (there are multiple fallbacks for missing feeRate accross the suite code)

NOTE: field name is ambiguous and confusing (rbfParams.baseFee !== baseFee param in Trezorconnect.composeTransaction) i will remove it completely from the rbfParams in upcoming PR

### Second commit
Should fix https://github.com/trezor/trezor-suite/issues/8863
Display reason and actual calculated fee rate if entered/requested custom fee rate is different than calculated

#### Dropping dust (fee rounding) in send form
![Screenshot from 2023-12-05 19-17-15](https://github.com/trezor/trezor-suite/assets/3435913/ba25eb30-a7f4-48a6-a7f5-67cbb7389a9f)

#### Paying for chained transactions in rbf form

![Screenshot from 2023-12-05 20-15-25](https://github.com/trezor/trezor-suite/assets/3435913/70d00ede-ead2-4d36-9b7b-abacb4e0713a)

### Third commit

do not switch to calculated fee rate if baseFee is used, this would lead to unnecessary overprice tx

### Fourth commit

Reworking chained transactions logic and UI.
Chained txs are divided in to `own` and `others` transactions 


![Screenshot from 2023-12-05 19-42-05](https://github.com/trezor/trezor-suite/assets/3435913/dc917ceb-2876-4c29-b47f-36b824c05f78)

![Screenshot from 2023-12-05 19-42-52](https://github.com/trezor/trezor-suite/assets/3435913/69b2b2ea-70bf-415b-a85a-457d48450cdc)

![Screenshot from 2023-12-05 19-43-36](https://github.com/trezor/trezor-suite/assets/3435913/ed34047c-d669-4732-8a16-13e753e33286)
