### PR TITLE
chore: wrong version format err

### DIFF
--- a/packages/utils/src/versionUtils.ts
+++ b/packages/utils/src/versionUtils.ts
@@ -32,7 +32,7 @@ const parse = (versionArr: VersionArray) => ({
 const split = (version: string) => {
     const arr = version.split('.').map(v => Number(v));
     if (!isVersionArray(arr)) {
-        throw new Error('version string is in wrong format');
+        throw new Error(`version string is in wrong format: ${version}`);
     }
     return arr;
 };


### PR DESCRIPTION
hmm I am still not sure where exactly this might come from https://satoshilabs.sentry.io/issues/4638693595/?project=5193825&query=is%3Aunresolved+%22version+string+is+in+wrong+format%22&referrer=issue-stream&statsPeriod=90d&stream_index=0

Initially I thought it was with cardano, but it is not on model 1 so the problematic part should not execute
![image](https://github.com/trezor/trezor-suite/assets/30367552/92f315de-13e6-43c4-b600-2f67ec0ee803)

so at least I am adding more info to the error for now