### PR TITLE
Feat/analytics queue update

### DIFF
--- a/packages/analytics/src/analytics.ts
+++ b/packages/analytics/src/analytics.ts
@@ -1,5 +1,11 @@
 import { encodeDataToQueryString, getRandomId, getUrl, reportEvent } from './utils';
-import type { InitOptions, Event as AnalyticsEvent, App, ReportConfig } from './types';
+import type {
+    InitOptions,
+    Event as AnalyticsEvent,
+    App,
+    ReportConfig,
+    AnalyticsOptions,
+} from './types';
 
 export class Analytics<T extends AnalyticsEvent> {
     private enabled = false;
@@ -17,9 +23,10 @@ export class Analytics<T extends AnalyticsEvent> {
 
     private callbacks?: InitOptions['callbacks'];
 
-    constructor(version: string, app: App) {
+    constructor({ version, app, useQueue = false }: AnalyticsOptions) {
         this.version = version;
         this.app = app;
+        this.useQueue = useQueue;
     }
 
     public init = (enabled: boolean, options: InitOptions) => {

--- a/packages/analytics/src/tests/analytics.test.ts
+++ b/packages/analytics/src/tests/analytics.test.ts
@@ -31,7 +31,7 @@ describe('analytics', () => {
         const sessionId = getRandomId();
         const commitId = 'abc';
 
-        const analytics = new Analytics('1.18', app);
+        const analytics = new Analytics({ version: '1.18', app });
 
         analytics.init(false, { environment, isDev, instanceId, sessionId, commitId });
 
@@ -81,7 +81,7 @@ describe('analytics', () => {
         const sessionId = getRandomId();
         const commitId = 'abc';
 
-        const analytics = new Analytics('1.18', app);
+        const analytics = new Analytics({ version: '1.18', app });
 
         analytics.init(true, { isDev, instanceId, sessionId, commitId });
 
@@ -107,7 +107,7 @@ describe('analytics', () => {
         const sessionId = getRandomId();
         const commitId = 'abc';
 
-        const analytics = new Analytics('1.18', app);
+        const analytics = new Analytics({ version: '1.18', app });
         analytics.init(false, {
             environment,
             isDev,
@@ -146,7 +146,7 @@ describe('analytics', () => {
         const sessionId = getRandomId();
         const commitId = 'abc';
 
-        const analytics = new Analytics('1.18', app);
+        const analytics = new Analytics({ version: '1.18', app, useQueue: true });
         analytics.init(false, {
             environment,
             isDev,

--- a/packages/analytics/src/types.ts
+++ b/packages/analytics/src/types.ts
@@ -14,12 +14,11 @@ export type InitOptions = {
         onEnable?: () => void;
         onDisable?: () => void;
     };
-    /* after analytics is enabled, report events happened before enablement */
-    useQueue?: boolean;
 };
 
 export type Event = {
     type: string;
+    timestamp?: string;
     payload?: {
         [key: string]: string | string[] | number | number[] | boolean | null;
     };

--- a/packages/analytics/src/types.ts
+++ b/packages/analytics/src/types.ts
@@ -2,6 +2,8 @@ import { Environment } from '@trezor/env-utils';
 
 export type App = 'suite' | 'connect';
 
+export type AnalyticsOptions = { version: string; app: App; useQueue?: boolean };
+
 export type InitOptions = {
     sessionId?: string;
     instanceId?: string;

--- a/packages/analytics/src/utils.ts
+++ b/packages/analytics/src/utils.ts
@@ -13,7 +13,7 @@ export const encodeDataToQueryString = <T extends AnalyticsEvent>(
     version: string,
     event: T,
 ) => {
-    const { type } = event;
+    const { type, timestamp } = event;
 
     const params = new URLSearchParams({
         c_v: version,
@@ -21,7 +21,7 @@ export const encodeDataToQueryString = <T extends AnalyticsEvent>(
         c_commit: commitId,
         c_instance_id: instanceId,
         c_session_id: sessionId,
-        c_timestamp: Date.now().toString(),
+        c_timestamp: timestamp || Date.now().toString(),
         c_message_id: getRandomId(),
     });
 

--- a/packages/connect-analytics/src/index.ts
+++ b/packages/connect-analytics/src/index.ts
@@ -2,7 +2,11 @@ import { Analytics, getRandomId } from '@trezor/analytics';
 
 import type { ConnectAnalyticsEvent } from './types/events';
 
-const analytics = new Analytics<ConnectAnalyticsEvent>(process.env.VERSION!, 'connect');
+const analytics = new Analytics<ConnectAnalyticsEvent>({
+    version: process.env.VERSION!,
+    app: 'connect',
+    useQueue: true,
+});
 
 export { analytics, getRandomId };
 export * from './types/events';

--- a/packages/connect-iframe/src/index.ts
+++ b/packages/connect-iframe/src/index.ts
@@ -124,13 +124,11 @@ const handleMessage = async (event: PostMessageEvent) => {
             // eslint-disable-next-line camelcase
             const { tracking_enabled, tracking_id } = storage.load();
 
-            // eslint-disable-next-line camelcase
-            analytics.init(tracking_enabled || false, {
+            analytics.init(tracking_enabled, {
                 // eslint-disable-next-line camelcase
                 instanceId: tracking_id,
                 commitId: process.env.COMMIT_HASH || '',
                 isDev: process.env.NODE_ENV === 'development',
-                useQueue: true,
             });
 
             analytics.report({

--- a/packages/connect-ui/src/utils/analytics.ts
+++ b/packages/connect-ui/src/utils/analytics.ts
@@ -48,7 +48,7 @@ export const initAnalytics = () => {
 
     const userAllowedTracking = storage.load().tracking_enabled;
 
-    analytics.init(userAllowedTracking || false, {
+    analytics.init(userAllowedTracking, {
         instanceId: trackingId,
         commitId: process.env.COMMIT_HASH || '',
         isDev: process.env.NODE_ENV === 'development',
@@ -56,7 +56,6 @@ export const initAnalytics = () => {
             onEnable,
             onDisable,
         },
-        useQueue: true,
     });
 
     analytics.report({

--- a/packages/suite-analytics/src/index.ts
+++ b/packages/suite-analytics/src/index.ts
@@ -2,7 +2,11 @@ import { Analytics, getRandomId } from '@trezor/analytics';
 
 import type { SuiteAnalyticsEvent } from './types/events';
 
-const analytics = new Analytics<SuiteAnalyticsEvent>(process.env.VERSION!, 'suite');
+const analytics = new Analytics<SuiteAnalyticsEvent>({
+    version: process.env.VERSION!,
+    app: 'suite',
+    useQueue: true,
+});
 
 export { analytics, getRandomId };
 export * from './types/definitions';

--- a/packages/suite/src/actions/suite/analyticsActions.ts
+++ b/packages/suite/src/actions/suite/analyticsActions.ts
@@ -60,7 +60,7 @@ export const init = () => (dispatch: Dispatch, getState: GetState) => {
         },
     });
 
-    allowSentryReport(userAllowedTracking);
+    allowSentryReport(!!userAllowedTracking);
     setSentryUser(instanceId);
 
     dispatch(

--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -18,7 +18,6 @@ import {
     hasBitcoinOnlyFirmware,
     isDeviceInBootloaderMode,
 } from '@trezor/device-utils';
-import { analyticsActions } from '@suite-common/analytics';
 
 import { SUITE, ROUTER } from 'src/actions/suite/constants';
 import { COINJOIN } from 'src/actions/wallet/constants';
@@ -64,15 +63,6 @@ const analyticsMiddleware =
                     type: EventType.SuiteReady,
                     payload: getSuiteReadyPayload(state),
                 });
-                break;
-            case analyticsActions.enableAnalytics.type:
-                if (state.suite.flags.initialRun) {
-                    // suite-ready event was not reported on analytics initialization because analytics was not yet confirmed
-                    analytics.report({
-                        type: EventType.SuiteReady,
-                        payload: getSuiteReadyPayload(state),
-                    });
-                }
                 break;
             case TRANSPORT.START:
                 analytics.report({

--- a/packages/suite/src/utils/suite/protocol.ts
+++ b/packages/suite/src/utils/suite/protocol.ts
@@ -17,21 +17,21 @@ export const getProtocolInfo = (uri: string): CoinProtocolInfo | null => {
     if (url) {
         const { protocol, pathname, host, search } = url;
         const scheme = protocol.slice(0, -1); // slice ":" from protocol
-
         const params = parseQuery(search);
+
+        analytics.report({
+            type: EventType.AppUriHandler,
+            payload: {
+                scheme,
+                isAmountPresent: params.amount !== undefined,
+            },
+        });
 
         if (isProtocolScheme(scheme)) {
             if (!pathname && !host) return null; // address may be in pathname (regular bitcoin:addr) or host (bitcoin://addr)
+
             const floatAmount = Number.parseFloat(params.amount ?? '');
             const amount = !Number.isNaN(floatAmount) && floatAmount > 0 ? floatAmount : undefined;
-
-            analytics.report({
-                type: EventType.AppUriHandler,
-                payload: {
-                    scheme,
-                    isAmountPresent: amount !== undefined,
-                },
-            });
 
             return {
                 scheme,

--- a/packages/suite/src/views/settings/SettingsGeneral/Analytics.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Analytics.tsx
@@ -32,7 +32,7 @@ export const Analytics = () => {
                 <PositionedSwitch>
                     <Switch
                         dataTest="@analytics/toggle-switch"
-                        isChecked={userAllowedTracking}
+                        isChecked={!!userAllowedTracking}
                         onChange={() => {
                             if (userAllowedTracking) {
                                 analytics.disable();

--- a/suite-common/analytics/src/analyticsReducer.ts
+++ b/suite-common/analytics/src/analyticsReducer.ts
@@ -59,6 +59,11 @@ export const selectIsAnalyticsEnabled = (state: AnalyticsRootState): boolean => 
     return isAnalyticsConfirmed ? !!state.analytics.enabled : false;
 };
 
-// allow tracking only if user already confirmed data collection
-export const selectHasUserAllowedTracking = (state: AnalyticsRootState): boolean =>
-    !!state.analytics.confirmed && !!state.analytics.enabled;
+export const selectHasUserAllowedTracking = (state: AnalyticsRootState): boolean | undefined => {
+    // If the user has not yet confirmed analytics, return undefined.
+    // Otherwise, return true or false based on the 'confirmed' and 'enabled' flags.
+    if (!state.analytics.confirmed) {
+        return undefined;
+    }
+    return !!state.analytics.confirmed && !!state.analytics.enabled;
+};

--- a/suite-native/analytics/src/analytics.ts
+++ b/suite-native/analytics/src/analytics.ts
@@ -4,7 +4,10 @@ import { Analytics } from '@trezor/analytics';
 
 import { SuiteNativeAnalyticsEvent } from './events';
 
-export const analytics = new Analytics<SuiteNativeAnalyticsEvent>(getSuiteVersion(), 'suite');
+export const analytics = new Analytics<SuiteNativeAnalyticsEvent>({
+    version: getSuiteVersion(),
+    app: 'suite',
+});
 
 if (isDebugEnv()) {
     // Do not send analytics in development


### PR DESCRIPTION
## Description

- be able to use queue when analytics object is created so that the queue is used before the analytics is initiated, fixes app uri handler event and events on coinmarket redirect
- queue cannot be enabled / disabled during init now

There are x cases which should work:
1. New User - Suite Launched, Decision on Reporting Analytics Pending:

- Enable Later: Queue is flushed.
- Disable Later: Queue is disabled and emptied.
2. Existing User - Suite Launched, Decision on Reporting Analytics Known:

- Report Analytics (Enabled): Queue is flushed.
- Do Not Report Analytics (Disabled): Queue is disabled and emptied.

The `enabled` property is set as `boolean | undefined`. This is to prevent a situation where the queue is used but never flushed, due to analytics not being enabled, resulting in the queue growing indefinitely in size.

Move analytics uri handler report before validation

## Related Issue

closes https://github.com/trezor/trezor-suite/issues/9533

<img width="452" alt="Screenshot 2023-11-17 at 12 38 48" src="https://github.com/trezor/trezor-suite/assets/33235762/2f104170-e0c1-4ac1-a9fc-30e5dc6d4fc7">

