### PR TITLE
chore(github): fix link to support in github template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
 contact_links:
   - name: General support and product feedback
-    url: https://support.trezor.io
+    url: https://trezor.io/support
     about: Please do not use this Github repository for technical support. Contact Trezor support directly or visit our community forum at forum.trezor.io.


### PR DESCRIPTION
## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/9901

## Screenshots:

![image](https://github.com/trezor/trezor-suite/assets/3729633/5fd68cf2-5c37-4057-9b14-b70bc275bcdb)
