### PR TITLE
refactor(transport): rename files

### DIFF
--- a/packages/transport-native/src/nativeUsb.ts
+++ b/packages/transport-native/src/nativeUsb.ts
@@ -1,13 +1,13 @@
 import { WebUSB } from '@trezor/react-native-usb';
 import {
     Transport as AbstractTransport,
-    AbstractUsbTransport,
+    AbstractApiTransport,
     SessionsClient,
     SessionsBackground,
-    UsbInterface,
+    UsbApi,
 } from '@trezor/transport';
 
-export class NativeUsbTransport extends AbstractUsbTransport {
+export class NativeUsbTransport extends AbstractApiTransport {
     // TODO: Not sure how to solve this type correctly.
     public name = 'NativeUsbTransport' as any;
 
@@ -26,7 +26,7 @@ export class NativeUsbTransport extends AbstractUsbTransport {
 
         super({
             messages,
-            usbInterface: new UsbInterface({
+            api: new UsbApi({
                 usbInterface: new WebUSB(),
                 logger,
             }),

--- a/packages/transport/src/api/abstract.ts
+++ b/packages/transport/src/api/abstract.ts
@@ -4,9 +4,9 @@ import { success, error, unknownError } from '../utils/result';
 
 import * as ERRORS from '../errors';
 
-type ConstructorParams = {
+export interface AbstractApiConstructorParams {
     logger?: Logger;
-};
+}
 
 /**
  * This class defines unifying shape for native communication interfaces such as
@@ -14,13 +14,13 @@ type ConstructorParams = {
  * - navigator.usb
  * This is not public API. Only a building block which is used in src/transports
  */
-export abstract class AbstractInterface extends TypedEmitter<{
+export abstract class AbstractApi extends TypedEmitter<{
     'transport-interface-change': string[];
     'transport-interface-error': typeof ERRORS.DEVICE_NOT_FOUND | typeof ERRORS.DEVICE_UNREADABLE;
 }> {
     logger: Logger;
 
-    constructor({ logger }: ConstructorParams) {
+    constructor({ logger }: AbstractApiConstructorParams) {
         super();
 
         // some abstract inactive logger
@@ -34,7 +34,12 @@ export abstract class AbstractInterface extends TypedEmitter<{
     /**
      * enumerate connected devices
      */
-    abstract enumerate(): AsyncResultWithTypedError<string[], string>;
+    abstract enumerate(): AsyncResultWithTypedError<
+        string[],
+        | typeof ERRORS.ABORTED_BY_TIMEOUT
+        | typeof ERRORS.ABORTED_BY_SIGNAL
+        | typeof ERRORS.UNEXPECTED_ERROR
+    >;
 
     /**
      * read from device on path

--- a/packages/transport/src/api/udp.ts
+++ b/packages/transport/src/api/udp.ts
@@ -1,18 +1,16 @@
 import UDP from 'dgram';
 import { isNotUndefined } from '@trezor/utils';
 
-import { AbstractInterface } from './abstract';
+import { AbstractApi, AbstractApiConstructorParams } from './abstract';
 import { AsyncResultWithTypedError, ResultWithTypedError } from '../types';
 
 import * as ERRORS from '../errors';
 
-type ConstructorParams = ConstructorParameters<typeof AbstractInterface>[0];
-
-export class UdpInterface extends AbstractInterface {
+export class UdpApi extends AbstractApi {
     interface = UDP.createSocket('udp4');
     protected communicating = false;
 
-    constructor({ logger }: ConstructorParams) {
+    constructor({ logger }: AbstractApiConstructorParams) {
         super({ logger });
     }
 

--- a/packages/transport/src/api/usb.ts
+++ b/packages/transport/src/api/usb.ts
@@ -1,4 +1,4 @@
-import { AbstractInterface } from './abstract';
+import { AbstractApi, AbstractApiConstructorParams } from './abstract';
 import { AsyncResultWithTypedError } from '../types';
 import {
     CONFIGURATION_ID,
@@ -11,22 +11,22 @@ import { createTimeoutPromise } from '@trezor/utils';
 
 import * as ERRORS from '../errors';
 
-type ConstructorParams = ConstructorParameters<typeof AbstractInterface>[0] & {
+interface ConstructorParams extends AbstractApiConstructorParams {
     usbInterface: USB;
-};
+}
 
-type TransportInterfaceDevice = {
+interface TransportInterfaceDevice {
     session?: null | string;
     path: string;
     device: USBDevice;
-};
+}
 
 /**
  * Local error. We cast it to "device disconnected during action" from bridge as it means the same
  */
 const INTERFACE_DEVICE_DISCONNECTED = 'The device was disconnected.' as const;
 
-export class UsbInterface extends AbstractInterface {
+export class UsbApi extends AbstractApi {
     devices: TransportInterfaceDevice[] = [];
     usbInterface: ConstructorParams['usbInterface'];
 

--- a/packages/transport/src/index.ts
+++ b/packages/transport/src/index.ts
@@ -15,8 +15,8 @@ export type { Descriptor } from './types';
 export { TREZOR_USB_DESCRIPTORS, TRANSPORT } from './constants';
 
 export { AbstractTransport as Transport } from './transports/abstract';
-export { AbstractUsbTransport } from './transports/abstractUsb';
-export { UsbInterface } from './interfaces/usb';
+export { AbstractApiTransport } from './transports/abstractApi';
+export { UsbApi } from './api/usb';
 
 // messages are exported but there is no real need to use them elsewhere
 // transports have reference to this already

--- a/packages/transport/src/transports/nodeusb.ts
+++ b/packages/transport/src/transports/nodeusb.ts
@@ -1,15 +1,15 @@
 import { WebUSB } from 'usb';
 import { AbstractTransportParams } from './abstract';
-import { AbstractUsbTransport } from './abstractUsb';
+import { AbstractApiTransport } from './abstractApi';
 import { SessionsClient } from '../sessions/client';
 import { SessionsBackground } from '../sessions/background';
-import { UsbInterface } from '../interfaces/usb';
+import { UsbApi } from '../api/usb';
 
 // notes:
 // to make it work on Linux I needed to run `sudo chmod -R 777 /dev/bus/usb/` which is obviously not
 // the way to go.
 
-export class NodeUsbTransport extends AbstractUsbTransport {
+export class NodeUsbTransport extends AbstractApiTransport {
     public name = 'NodeUsbTransport' as const;
 
     constructor(params?: AbstractTransportParams) {
@@ -29,13 +29,12 @@ export class NodeUsbTransport extends AbstractUsbTransport {
 
         super({
             messages,
-            usbInterface: new UsbInterface({
+            api: new UsbApi({
                 usbInterface: new WebUSB({
                     allowAllDevices: true, // return all devices, not only authorized
                 }),
                 logger,
             }),
-
             sessionsClient,
         });
     }

--- a/packages/transport/src/transports/udp.ts
+++ b/packages/transport/src/transports/udp.ts
@@ -1,12 +1,12 @@
 import { AbstractTransportParams } from './abstract';
 
-import { UdpInterface } from '../interfaces/udp';
-import { AbstractUsbTransport } from './abstractUsb';
+import { UdpApi } from '../api/udp';
+import { AbstractApiTransport } from './abstractApi';
 
 import { SessionsClient } from '../sessions/client';
 import { SessionsBackground } from '../sessions/background';
 
-export class UdpTransport extends AbstractUsbTransport {
+export class UdpTransport extends AbstractApiTransport {
     public name = 'UdpTransport' as const;
 
     constructor(params?: AbstractTransportParams) {
@@ -25,10 +25,8 @@ export class UdpTransport extends AbstractUsbTransport {
 
         super({
             messages,
-            // @ts-expect-error
-            usbInterface: new UdpInterface({ logger }),
+            api: new UdpApi({ logger }),
             logger,
-
             sessionsClient,
         });
 

--- a/packages/transport/src/transports/webusb.browser.ts
+++ b/packages/transport/src/transports/webusb.browser.ts
@@ -1,7 +1,7 @@
 import { AbstractTransportParams } from './abstract';
-import { AbstractUsbTransport } from './abstractUsb';
+import { AbstractApiTransport } from './abstractApi';
 import { SessionsClient } from '../sessions/client';
-import { UsbInterface } from '../interfaces/usb';
+import { UsbApi } from '../api/usb';
 
 import { initBackgroundInBrowser } from '../sessions/background-browser';
 
@@ -10,7 +10,7 @@ import { initBackgroundInBrowser } from '../sessions/background-browser';
  * - chrome supported
  * - firefox not supported https://mozilla.github.io/standards-positions/#webusb
  */
-export class WebUsbTransport extends AbstractUsbTransport {
+export class WebUsbTransport extends AbstractApiTransport {
     public name = 'WebUsbTransport' as const;
 
     constructor(params?: AbstractTransportParams) {
@@ -19,7 +19,7 @@ export class WebUsbTransport extends AbstractUsbTransport {
 
         super({
             messages,
-            usbInterface: new UsbInterface({
+            api: new UsbApi({
                 usbInterface: navigator.usb,
                 logger,
             }),


### PR DESCRIPTION
## Description

- `interface` dir > `api` dir
- `interface/absrtact/AbstractInterface` class > `api/absrtact/AbstractApi` class
- `interface/udp/UdpInterface` class > `api/udp/UdpApi` class
- `interface/usb/UsbInterface` class > `api/usb/UsbApi` class
- `transport/abstractUsb` file > `transport/abstractApi` file
- `transport/AbstractUsbTransport` class > `transport/AbstractApiTransport` class
- `transport/AbstractUsbTransport.usbInterface` parameter > `transport/AbstractApiTransport.api` parameter

additionaly resolved multiple `@ts-expect-error`
