### PR TITLE
fix(suite-native): card alert gap

### DIFF
--- a/suite-native/atoms/src/Card/Card.tsx
+++ b/suite-native/atoms/src/Card/Card.tsx
@@ -38,7 +38,7 @@ export const Card = ({ children, style, alertVariant, alertTitle }: CardProps) =
     const isAlertDisplayed = !!alertVariant;
 
     return (
-        <>
+        <View>
             {isAlertDisplayed && (
                 <AlertBox isStandalone={false} variant={alertVariant} title={alertTitle} />
             )}
@@ -46,6 +46,6 @@ export const Card = ({ children, style, alertVariant, alertTitle }: CardProps) =
             <View style={[applyStyle(cardContainerStyle, { isAlertDisplayed }), style]}>
                 {children}
             </View>
-        </>
+        </View>
     );
 };


### PR DESCRIPTION
Card and its Alert were wrapped into a View, to not apply a parent provided gap style to them.

## Screenshot
![Screenshot 2023-11-17 at 10 28 47](https://github.com/trezor/trezor-suite/assets/26143964/76ca912f-9487-4970-94bb-72517562755d)
