### PR TITLE
suite-desktop: make node bridge available under --bridge-node flag

### DIFF
--- a/docs/packages/suite-desktop.md
+++ b/docs/packages/suite-desktop.md
@@ -96,6 +96,7 @@ Available flags:
 | `--open-devtools`     | Open DevTools on app launch.                                                                                                                                                           |
 | `--pre-release`       | Tells the auto-updater to fetch pre-release updates.                                                                                                                                   |
 | `--bridge-dev`        | Instruct Bridge to support emulator (starts Bridge with `-e 21324`).                                                                                                                   |
+| `--bridge-node`       | Instruct Suite to start alternative node-bridge implementation                                                                                                                         |
 | `--log-level=NAME`    | Set the logging level. Available levels are [name (value)]: error (1), warn (2), info(3), debug (4). All logs with a value equal or lower to the selected log level will be displayed. |
 | `--log-write`         | Write log to disk                                                                                                                                                                      |
 | `--log-ui`            | Enables printing of UI console messages in the console.                                                                                                                                |

--- a/packages/node-utils/src/index.ts
+++ b/packages/node-utils/src/index.ts
@@ -1,3 +1,3 @@
 export { ensureDirectoryExists } from './ensureDirectoryExists';
 export { getFreePort } from './getFreePort';
-export { HttpServer, allowOrigins } from './http';
+export { HttpServer, allowOrigins, parseBodyJSON, parseBodyText, type Handler } from './http';

--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -27,6 +27,7 @@
         "@trezor/node-utils": "workspace:*",
         "@trezor/request-manager": "workspace:*",
         "@trezor/suite-desktop-api": "workspace:*",
+        "@trezor/transport-bridge": "workspace:*",
         "@trezor/urls": "workspace:*",
         "@trezor/utils": "workspace:*",
         "chalk": "^4.1.2",

--- a/packages/suite-desktop-core/src/libs/http-receiver.ts
+++ b/packages/suite-desktop-core/src/libs/http-receiver.ts
@@ -41,9 +41,9 @@ export const createHttpReceiver = () => {
     const httpReceiver = new HttpServer<Events>({ logger: global.logger, port: 21335 });
 
     httpReceiver.use([
-        (_request, response, next) => {
+        (request, response, next) => {
             response.setHeader('Content-Type', 'text/html; charset=UTF-8');
-            next();
+            next(request, response);
         },
     ]);
 

--- a/packages/suite-desktop-core/src/modules/bridge.ts
+++ b/packages/suite-desktop-core/src/modules/bridge.ts
@@ -24,6 +24,16 @@ const handleBridgeStatus = async (
     return status;
 };
 
+const start = async (bridge: BridgeProcess) => {
+    if (bridgeDev) {
+        await bridge.startDev();
+    } else if (bridgeTest) {
+        await bridge.startTest();
+    } else {
+        await bridge.start();
+    }
+};
+
 const load = async ({ store, mainWindow }: Dependencies) => {
     const { logger } = global;
     const bridge = new BridgeProcess();
@@ -40,7 +50,7 @@ const load = async ({ store, mainWindow }: Dependencies) => {
                 await bridge.stop();
                 store.setBridgeSettings({ startOnStartup: false });
             } else {
-                await bridge.start();
+                await start(bridge);
                 store.setBridgeSettings({ startOnStartup: true });
             }
             return { success: true };
@@ -66,13 +76,7 @@ const load = async ({ store, mainWindow }: Dependencies) => {
 
     try {
         logger.info(SERVICE_NAME, `Starting (Dev: ${b2t(bridgeDev)})`);
-        if (bridgeDev) {
-            await bridge.startDev();
-        } else if (bridgeTest) {
-            await bridge.startTest();
-        } else {
-            await bridge.start();
-        }
+        await start(bridge);
         handleBridgeStatus(bridge, mainWindow);
     } catch (err) {
         logger.error(SERVICE_NAME, `Start failed: ${err.message}`);

--- a/packages/suite-desktop-core/tsconfig.json
+++ b/packages/suite-desktop-core/tsconfig.json
@@ -24,6 +24,7 @@
         { "path": "../node-utils" },
         { "path": "../request-manager" },
         { "path": "../suite-desktop-api" },
+        { "path": "../transport-bridge" },
         { "path": "../urls" },
         { "path": "../utils" },
         { "path": "../trezor-user-env-link" },

--- a/packages/transport-bridge/package.json
+++ b/packages/transport-bridge/package.json
@@ -15,6 +15,7 @@
         "typescript": "4.9.5"
     },
     "dependencies": {
+        "@trezor/node-utils": "workspace:^",
         "@trezor/protocol": "workspace:*",
         "@trezor/transport": "workspace:*",
         "@trezor/utils": "workspace:*",

--- a/packages/transport-bridge/src/http.ts
+++ b/packages/transport-bridge/src/http.ts
@@ -149,4 +149,24 @@ export class TrezordNode {
     }
 
     public stop() {}
+
+    public async status() {
+        const running = await fetch(`http://127.0.0.1:${this.port}/`)
+            .then(resp => resp.ok)
+            .catch(() => false);
+        return {
+            service: running,
+            process: running,
+        };
+    }
+
+    // compatibility with "BridgeProcess" type
+    public startDev() {
+        return this.start();
+    }
+
+    // compatibility with "BridgeProcess" type
+    public startTest() {
+        return this.start();
+    }
 }

--- a/packages/transport-bridge/src/http.ts
+++ b/packages/transport-bridge/src/http.ts
@@ -1,7 +1,4 @@
-import http from 'http';
-import express from 'express';
-import cors from 'cors';
-
+import { HttpServer, parseBodyJSON, parseBodyText, Handler } from '@trezor/node-utils';
 import { Descriptor } from '@trezor/transport/src/types';
 import { arrayPartition } from '@trezor/utils/lib/arrayPartition';
 
@@ -10,6 +7,8 @@ import { sessionsClient, enumerate, acquire, release, call, send, receive } from
 const defaults = {
     port: 21325,
 };
+
+const str = (value: Record<string, any> | string) => JSON.stringify(value);
 
 export class TrezordNode {
     /** versioning, baked in by webpack */
@@ -20,11 +19,11 @@ export class TrezordNode {
     /** pending /listen subscriptions that are supposed to be resolved whenever descriptors change is detected */
     listenSubscriptions: {
         descriptors: string;
-        req: express.Request;
-        res: express.Response;
+        req: Parameters<Handler>[0];
+        res: Parameters<Handler>[1];
     }[];
     port: number;
-    server?: http.Server<typeof http.IncomingMessage, typeof http.ServerResponse>;
+    server?: HttpServer<never>;
 
     constructor({ port }: { port: number }) {
         this.port = port || defaults.port;
@@ -41,109 +40,145 @@ export class TrezordNode {
 
     private resolveListenSubscriptions(descriptors: Descriptor[]) {
         this.descriptors = JSON.stringify(descriptors);
-
         const [affected, unaffected] = arrayPartition(
             this.listenSubscriptions,
             subscription => subscription.descriptors !== this.descriptors,
         );
         affected.forEach(subscription => {
-            subscription.res.send(this.descriptors);
+            subscription.res.end(this.descriptors);
         });
         this.listenSubscriptions = unaffected;
     }
 
     public start() {
         return new Promise<void>(resolve => {
-            const app = express();
+            const app = new HttpServer({ port: this.port, logger: console });
 
-            // todo: limit to whitelisted domains
-            app.use(cors());
+            app.use([
+                (_req, res, next) => {
+                    // todo: limit to whitelisted domains
+                    res.setHeader('Access-Control-Allow-Origin', '*');
+                    next(_req, res);
+                },
+            ]);
 
-            app.get('/', (_req, res) => {
-                res.send(`hello, I am bridge in node, version: ${this.version}`);
-            });
+            app.post('/enumerate', [
+                (_req, res) => {
+                    res.setHeader('Content-Type', 'text/plain');
+                    enumerate()
+                        .then(result => {
+                            if (!result.success) {
+                                throw new Error(result.error);
+                            }
+                            res.end(str(result.payload.descriptors));
+                        })
+                        .catch(err => {
+                            res.end(str({ error: err.message }));
+                        });
+                },
+            ]);
 
-            app.post('/', (_req, res) => {
-                res.set('Content-Type', 'text/plain');
-
-                res.send({
-                    version: this.version,
-                });
-            });
-
-            app.post('/enumerate', (_req, res) => {
-                res.set('Content-Type', 'text/plain');
-                enumerate()
-                    .then(result => {
-                        if (!result.success) {
-                            throw new Error(result.error);
-                        }
-                        res.send(result.payload.descriptors);
-                    })
-                    .catch(err => {
-                        res.send({ error: err.message });
+            app.post('/listen', [
+                parseBodyJSON,
+                (req, res) => {
+                    res.setHeader('Content-Type', 'text/plain');
+                    this.listenSubscriptions.push({
+                        // todo: type in that if parseBodyText was called as previous handler, req.body is string. is that even possible
+                        // @ts-expect-error
+                        descriptors: req.body,
+                        req,
+                        res,
                     });
-            });
+                },
+            ]);
 
-            app.post('/listen', express.json(), (req, res) => {
-                res.set('Content-Type', 'text/plain');
+            app.post('/acquire/:path/:previous', [
+                (req, res) => {
+                    res.setHeader('Content-Type', 'text/plain');
+                    acquire({ path: req.params.path, previous: req.params.previous }).then(
+                        result => {
+                            if (!result.success) {
+                                return res.end(str({ error: result.error }));
+                            }
+                            res.end(str({ session: result.payload.session }));
+                        },
+                    );
+                },
+            ]);
 
-                this.listenSubscriptions.push({
-                    descriptors: JSON.stringify(req.body),
-                    req,
-                    res,
-                });
-            });
+            app.post('/release/:session', [
+                parseBodyText,
+                (req, res) => {
+                    // todo:
+                    // @ts-expect-error
+                    release({ session: req.params.session, path: req.body }).then(result => {
+                        if (!result.success) {
+                            return res.end(str({ error: result.error }));
+                        }
+                        res.end(str({ session: req.params.session }));
+                    });
+                },
+            ]);
 
-            app.post('/acquire/:path/:previous', express.json(), (req, res) => {
-                res.set('Content-Type', 'text/plain');
+            app.post('/call/:session', [
+                parseBodyText,
+                (req, res) => {
+                    // todo:
+                    // @ts-expect-error
+                    call({ session: req.params.session, data: req.body }).then(result => {
+                        if (!result.success) {
+                            return res.end(str({ error: result.error }));
+                        }
+                        res.end(str(result.payload));
+                    });
+                },
+            ]);
 
-                acquire({ path: req.params.path, previous: req.params.previous }).then(result => {
-                    if (!result.success) {
-                        return res.send({ error: result.error });
-                    }
-                    res.send({ session: result.payload.session });
-                });
-            });
+            app.post('/read/:session', [
+                parseBodyJSON,
+                (req, res) => {
+                    receive({ session: req.params.session }).then(result => {
+                        if (!result.success) {
+                            return res.end(str({ error: result.error }));
+                        }
+                        res.end(str(result.payload));
+                    });
+                },
+            ]);
 
-            app.post('/release/:session', express.json(), (req, res) => {
-                release({ session: req.params.session, path: req.body }).then(result => {
-                    if (!result.success) {
-                        return res.send({ error: result.error });
-                    }
-                    res.send({ session: req.params.session });
-                });
-            });
+            app.post('/post/:session', [
+                parseBodyJSON,
+                (req, res) => {
+                    // todo:
+                    // @ts-expect-error
+                    send({ session: req.params.session, data: req.body }).then(result => {
+                        if (!result.success) {
+                            return res.end(str({ error: result.error }));
+                        }
+                        res.end();
+                    });
+                },
+            ]);
 
-            app.post('/call/:session', express.text(), (req, res) => {
-                res.set('Content-Type', 'text/plain');
-                call({ session: req.params.session, data: req.body }).then(result => {
-                    if (!result.success) {
-                        return res.send({ error: result.error });
-                    }
-                    res.send(result.payload);
-                });
-            });
+            app.get('/', [
+                (_req, res) => {
+                    res.end(`hello, I am bridge in node, version: ${this.version}`);
+                },
+            ]);
 
-            app.post('/read/:session', (req, res) => {
-                receive({ session: req.params.session }).then(result => {
-                    if (!result.success) {
-                        return res.send({ error: result.error });
-                    }
-                    res.send(result.payload);
-                });
-            });
+            app.post('/', [
+                (_req, res) => {
+                    res.writeHead(200, { 'Content-Type': 'text/plain' });
+                    res.end(
+                        str({
+                            version: this.version,
+                        }),
+                    );
+                },
+            ]);
 
-            app.post('/post/:session', express.text(), (req, res) => {
-                send({ session: req.params.session, data: req.body }).then(result => {
-                    if (!result.success) {
-                        return res.send({ error: result.error });
-                    }
-                    res.send();
-                });
-            });
-
-            this.server = app.listen(this.port, () => {
+            app.start().then(() => {
+                this.server = app;
                 resolve();
             });
         });
@@ -152,7 +187,7 @@ export class TrezordNode {
     public stop() {
         // send empty descriptors (imitate that all devices have disconnected)
         this.resolveListenSubscriptions([]);
-        this.server?.close();
+        this.server?.stop();
     }
 
     public async status() {

--- a/packages/transport-bridge/tsconfig.json
+++ b/packages/transport-bridge/tsconfig.json
@@ -2,6 +2,7 @@
     "extends": "../../tsconfig.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
+        { "path": "../node-utils" },
         { "path": "../protocol" },
         { "path": "../transport" },
         { "path": "../utils" }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9676,6 +9676,7 @@ __metadata:
     "@trezor/node-utils": "workspace:*"
     "@trezor/request-manager": "workspace:*"
     "@trezor/suite-desktop-api": "workspace:*"
+    "@trezor/transport-bridge": "workspace:*"
     "@trezor/trezor-user-env-link": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/urls": "workspace:*"
@@ -9964,7 +9965,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/transport-bridge@workspace:packages/transport-bridge":
+"@trezor/transport-bridge@workspace:*, @trezor/transport-bridge@workspace:packages/transport-bridge":
   version: 0.0.0-use.local
   resolution: "@trezor/transport-bridge@workspace:packages/transport-bridge"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -9428,7 +9428,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/node-utils@workspace:*, @trezor/node-utils@workspace:packages/node-utils":
+"@trezor/node-utils@workspace:*, @trezor/node-utils@workspace:^, @trezor/node-utils@workspace:packages/node-utils":
   version: 0.0.0-use.local
   resolution: "@trezor/node-utils@workspace:packages/node-utils"
   dependencies:
@@ -9969,6 +9969,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/transport-bridge@workspace:packages/transport-bridge"
   dependencies:
+    "@trezor/node-utils": "workspace:^"
     "@trezor/protocol": "workspace:*"
     "@trezor/transport": "workspace:*"
     "@trezor/utils": "workspace:*"


### PR DESCRIPTION
### Description
This PR changes behavior of suite-desktop:
- adds a new flag `--bridge-node` to suite-desktop app
- when started with this flag, app would not launch trezord-go process and it would spawn node bridge module instead
- it exposes bridge interface to the outer world, under the hood leveraging nodeusb transport

This is so far meant mainly for internal testing.

### Related issues
- builds on top of  #9991

<img width="1128" alt="image" src="https://github.com/trezor/trezor-suite/assets/30367552/fe5a0722-83fc-4d0c-87a6-e0a203f90369">



web suite utilizing bridge provided by desktop app

![image](https://github.com/trezor/trezor-suite/assets/30367552/f5d91658-c69c-4357-8482-8eb9b13aa6bd)

the good part is that switching bridge process on and off still works as expected even for the new node bridge. 

<img width="831" alt="image" src="https://github.com/trezor/trezor-suite/assets/30367552/9f15fe02-43d2-4fcc-9eee-2c2cbf67beec">
