### PR TITLE
feat(suite-native): native device access mutex

### DIFF
--- a/suite-native/device-mutex/package.json
+++ b/suite-native/device-mutex/package.json
@@ -1,0 +1,19 @@
+{
+    "name": "@suite-native/device-mutex",
+    "version": "1.0.0",
+    "main": "src/index",
+    "license": "See LICENSE.md in repo root",
+    "private": true,
+    "sideEffects": false,
+    "dependencies": {
+        "@mobily/ts-belt": "^3.13.1"
+    },
+    "scripts": {
+        "type-check": "tsc --build",
+        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "test:unit": "jest -c ../../jest.config.base.js --passWithNoTests"
+    },
+    "devDependencies": {
+        "jest": "^26.6.3"
+    }
+}

--- a/suite-native/device-mutex/src/DeviceAccessMutex.ts
+++ b/suite-native/device-mutex/src/DeviceAccessMutex.ts
@@ -1,0 +1,48 @@
+/**
+ * Orchestrates concurrent exclusive access to the connected device.
+ */
+class DeviceAccessMutex {
+    isLocked: boolean;
+    taskQueue: ((value: unknown) => void)[];
+    constructor() {
+        this.isLocked = false;
+        this.taskQueue = [];
+    }
+
+    prioritizedLock() {
+        if (this.isLocked) {
+            return new Promise(resolve => {
+                // Put prioritized task at the beginning of the queue.
+                this.taskQueue.splice(1, 0, resolve);
+            });
+        }
+        this.isLocked = true;
+
+        return Promise.resolve();
+    }
+
+    lock() {
+        if (this.isLocked) {
+            return new Promise(resolve => {
+                // Put the task at the end of the queue.
+                this.taskQueue.push(resolve);
+            });
+        }
+        this.isLocked = true;
+
+        return Promise.resolve();
+    }
+
+    unlock() {
+        const resolve = this.taskQueue.shift();
+        if (resolve) {
+            // If there is a task in queue, execute it.
+            resolve?.(null);
+        } else {
+            // Otherwise unlock the mutex.
+            this.isLocked = false;
+        }
+    }
+}
+
+export const deviceAccessMutex = new DeviceAccessMutex();

--- a/suite-native/device-mutex/src/index.ts
+++ b/suite-native/device-mutex/src/index.ts
@@ -1,0 +1,1 @@
+export * from './requestDeviceAccess';

--- a/suite-native/device-mutex/src/requestDeviceAccess.ts
+++ b/suite-native/device-mutex/src/requestDeviceAccess.ts
@@ -1,0 +1,29 @@
+import { deviceAccessMutex } from './DeviceAccessMutex';
+
+/**
+ * Puts the callback to the end of the queue and waits for its turn to execute.
+ */
+export const requestDeviceAccess = async <TParams extends unknown[], TReturnType>(
+    deviceCallback: (...args: TParams) => TReturnType,
+    ...callbackParams: TParams
+): Promise<TReturnType> => {
+    await deviceAccessMutex.lock();
+    const response = await deviceCallback(...callbackParams);
+    deviceAccessMutex.unlock();
+
+    return response;
+};
+
+/**
+ * Puts the callback to the beginning of the queue to execute the callback with priority.
+ */
+export const requestPrioritizedDeviceAccess = async <TParams extends unknown[], TReturnType>(
+    deviceCallback: (...args: TParams) => TReturnType,
+    ...callbackParams: TParams
+): Promise<TReturnType> => {
+    await deviceAccessMutex.prioritizedLock();
+    const response = await deviceCallback(...callbackParams);
+    deviceAccessMutex.unlock();
+
+    return response;
+};

--- a/suite-native/device-mutex/src/tests/DeviceAccessMutex.test.ts
+++ b/suite-native/device-mutex/src/tests/DeviceAccessMutex.test.ts
@@ -1,0 +1,101 @@
+/* eslint-disable guard-for-in */
+/* eslint-disable no-restricted-syntax */
+/* eslint-disable no-await-in-loop */
+import { A } from '@mobily/ts-belt';
+
+import { deviceAccessMutex } from '../DeviceAccessMutex';
+import { requestDeviceAccess, requestPrioritizedDeviceAccess } from '../requestDeviceAccess';
+
+const deviceAccessCallbackMock = () =>
+    new Promise(resolve => {
+        setTimeout(() => {
+            resolve(true);
+        }, 50);
+    });
+
+describe('DeviceAccessMutex', () => {
+    test('Locking and unlocking the deviceAccessMutex', async () => {
+        expect(deviceAccessMutex.isLocked).toBe(false);
+
+        await deviceAccessMutex.lock();
+        expect(deviceAccessMutex.isLocked).toBe(true);
+
+        deviceAccessMutex.unlock();
+        expect(deviceAccessMutex.isLocked).toBe(false);
+    });
+
+    test('locking deviceAccessMutex with tasks in the queue', async () => {
+        // Lock the mutex with the task 1.
+        await deviceAccessMutex.lock();
+
+        // Ensure the mutex is locked and there is no other task waiting in the queue.
+        expect(deviceAccessMutex.isLocked).toBe(true);
+        expect(deviceAccessMutex.taskQueue.length).toBe(0);
+
+        // Add task 2. to the queue.
+        deviceAccessMutex.lock();
+
+        // Ensure the mutex is still locked with task 2. in the queue.
+        expect(deviceAccessMutex.isLocked).toBe(true);
+        expect(deviceAccessMutex.taskQueue.length).toBe(1);
+
+        // Finish the execution of the task 1.
+        deviceAccessMutex.unlock();
+
+        // The mutex should still be locked and the task 2. should be poped from the queue.
+        expect(deviceAccessMutex.isLocked).toBe(true);
+        expect(deviceAccessMutex.taskQueue.length).toBe(0);
+
+        // Finish the task 2.
+        deviceAccessMutex.unlock();
+
+        // After finishing the 2. task, the mutex should be unlocked.
+        expect(deviceAccessMutex.isLocked).toBe(false);
+        expect(deviceAccessMutex.taskQueue.length).toBe(0);
+    });
+});
+
+describe('RequestDeviceAccess', () => {
+    test('requesting by multiple tasks in parallel', async () => {
+        const numberOfTasks = 5;
+
+        // Put multiple tasks in the queue.
+        const queuedTasks = A.makeWithIndex(numberOfTasks, () =>
+            requestDeviceAccess(deviceAccessCallbackMock),
+        );
+
+        let expectedQueueLength = 4;
+        expect(deviceAccessMutex.isLocked).toBe(true);
+        expect(deviceAccessMutex.taskQueue.length).toBe(expectedQueueLength);
+
+        for (const index in queuedTasks) {
+            expect(deviceAccessMutex.isLocked).toBe(true);
+
+            // Execute each of the tasks.
+            await queuedTasks[index];
+
+            expectedQueueLength = Math.max(0, expectedQueueLength - 1);
+            expect(deviceAccessMutex.taskQueue.length).toBe(expectedQueueLength);
+        }
+
+        // Mutex should be unlocked after execution of all the queued tasks.
+        expect(deviceAccessMutex.isLocked).toBe(false);
+    });
+});
+
+describe('RequestPrioritizedDeviceAccess', () => {
+    test('prioritized task execution', async () => {
+        // Put multiple tasks in the queue.
+        A.makeWithIndex(5, () => requestDeviceAccess(deviceAccessCallbackMock));
+
+        expect(deviceAccessMutex.isLocked).toBe(true);
+
+        // Execute prioritized task.
+        await requestPrioritizedDeviceAccess(deviceAccessCallbackMock);
+
+        // The prioritized task should be put at the beginning of the queue, so after its execution,
+        // so there should be still the rest of the tasks in the queue.
+        expect(deviceAccessMutex.isLocked).toBe(true);
+        expect(deviceAccessMutex.taskQueue.length).toBe(2);
+    });
+});

--- a/suite-native/device-mutex/tsconfig.json
+++ b/suite-native/device-mutex/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": { "outDir": "libDev" },
+    "references": []
+}

--- a/suite-native/discovery/package.json
+++ b/suite-native/discovery/package.json
@@ -22,6 +22,7 @@
         "@suite-native/accounts": "workspace:*",
         "@suite-native/config": "workspace:*",
         "@suite-native/device": "workspace:*",
+        "@suite-native/device-mutex": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/device-utils": "workspace:*"
     }

--- a/suite-native/discovery/src/utils.ts
+++ b/suite-native/discovery/src/utils.ts
@@ -4,38 +4,6 @@ import { DiscoveryItem } from '@suite-common/wallet-types';
 import TrezorConnect from '@trezor/connect';
 
 import { DiscoveryDescriptorItem } from './types';
-
-/**
- * Used to handle concurrent read-access to the connected device.
- */
-export class DeviceAccessMutex {
-    isLocked: boolean;
-    taskQueue: ((value: unknown) => void)[];
-    constructor() {
-        this.isLocked = false;
-        this.taskQueue = [];
-    }
-
-    lock() {
-        if (this.isLocked) {
-            return new Promise(resolve => {
-                this.taskQueue.push(resolve);
-            });
-        }
-        this.isLocked = true;
-        return Promise.resolve();
-    }
-
-    unlock() {
-        const resolve = this.taskQueue.shift();
-        if (resolve) {
-            resolve?.(null);
-        } else {
-            this.isLocked = false;
-        }
-    }
-}
-
 // This function will be removed in one of the following PRs, when `TrezorConnect.getAccountDescriptor` method is ready.
 // see more: https://github.com/trezor/trezor-suite/issues/9658
 export const fetchBundleDescriptors = async (bundle: DiscoveryItem[]) => {

--- a/suite-native/discovery/tsconfig.json
+++ b/suite-native/discovery/tsconfig.json
@@ -26,6 +26,7 @@
         { "path": "../accounts" },
         { "path": "../config" },
         { "path": "../device" },
+        { "path": "../device-mutex" },
         { "path": "../../packages/connect" },
         { "path": "../../packages/device-utils" }
     ]

--- a/suite-native/receive/package.json
+++ b/suite-native/receive/package.json
@@ -25,6 +25,7 @@
         "@suite-native/analytics": "workspace:*",
         "@suite-native/atoms": "workspace:*",
         "@suite-native/device-manager": "workspace:*",
+        "@suite-native/device-mutex": "workspace:*",
         "@suite-native/ethereum-tokens": "workspace:*",
         "@suite-native/formatters": "workspace:*",
         "@suite-native/helpers": "workspace:*",

--- a/suite-native/receive/src/hooks/useAccountReceiveAddress.tsx
+++ b/suite-native/receive/src/hooks/useAccountReceiveAddress.tsx
@@ -14,6 +14,7 @@ import {
 import { AccountKey } from '@suite-common/wallet-types';
 import { getFirstFreshAddress } from '@suite-common/wallet-utils';
 import { analytics, EventType } from '@suite-native/analytics';
+import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 
 export const useAccountReceiveAddress = (accountKey: AccountKey) => {
     const dispatch = useDispatch();
@@ -43,9 +44,14 @@ export const useAccountReceiveAddress = (accountKey: AccountKey) => {
 
     const verifyAddressOnDevice = useCallback(async () => {
         if (accountKey && freshAddress) {
-            const { success } = await dispatch(
-                confirmAddressOnDeviceThunk({ accountKey, addressPath: freshAddress.path }),
-            ).unwrap();
+            const { success } = await requestPrioritizedDeviceAccess(() =>
+                dispatch(
+                    confirmAddressOnDeviceThunk({
+                        accountKey,
+                        addressPath: freshAddress.path,
+                    }),
+                ).unwrap(),
+            );
 
             return success;
         }

--- a/suite-native/receive/tsconfig.json
+++ b/suite-native/receive/tsconfig.json
@@ -19,6 +19,7 @@
         { "path": "../analytics" },
         { "path": "../atoms" },
         { "path": "../device-manager" },
+        { "path": "../device-mutex" },
         { "path": "../ethereum-tokens" },
         { "path": "../formatters" },
         { "path": "../helpers" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7371,6 +7371,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@suite-native/device-mutex@workspace:*, @suite-native/device-mutex@workspace:suite-native/device-mutex":
+  version: 0.0.0-use.local
+  resolution: "@suite-native/device-mutex@workspace:suite-native/device-mutex"
+  dependencies:
+    "@mobily/ts-belt": "npm:^3.13.1"
+    jest: "npm:^26.6.3"
+  languageName: unknown
+  linkType: soft
+
 "@suite-native/device@workspace:*, @suite-native/device@workspace:suite-native/device":
   version: 0.0.0-use.local
   resolution: "@suite-native/device@workspace:suite-native/device"
@@ -7414,6 +7423,7 @@ __metadata:
     "@suite-native/accounts": "workspace:*"
     "@suite-native/config": "workspace:*"
     "@suite-native/device": "workspace:*"
+    "@suite-native/device-mutex": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/device-utils": "workspace:*"
   languageName: unknown
@@ -7999,6 +8009,7 @@ __metadata:
     "@suite-native/analytics": "workspace:*"
     "@suite-native/atoms": "workspace:*"
     "@suite-native/device-manager": "workspace:*"
+    "@suite-native/device-mutex": "workspace:*"
     "@suite-native/ethereum-tokens": "workspace:*"
     "@suite-native/formatters": "workspace:*"
     "@suite-native/helpers": "workspace:*"


### PR DESCRIPTION
- new package @suite-native/device with a suite-native global device mutex creted
- only `requestDeviceAccess` and `requestPrioritizedDeviceMutex` functions exported from this package to ensure that mutex is not manipulated in any other way
- tests created

Closes #9986
