### PR TITLE
feat(transport): add node-bridge module

### DIFF
--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -45,6 +45,8 @@
     "devDependencies": {
         "@trezor/trezor-user-env-link": "workspace:*",
         "@types/bytebuffer": "^5.0.46",
+        "@types/cors": "^2.8.15",
+        "@types/express": "^4",
         "@types/sharedworker": "^0.0.105",
         "@types/w3c-web-usb": "^1.0.9",
         "jest": "29.5.0",
@@ -57,7 +59,9 @@
         "@trezor/protobuf": "workspace:*",
         "@trezor/protocol": "workspace:*",
         "@trezor/utils": "workspace:*",
+        "cors": "^2.8.5",
         "cross-fetch": "^4.0.0",
+        "express": "^4.18.2",
         "json-stable-stringify": "^1.0.2",
         "long": "^4.0.0",
         "protobufjs": "7.2.5",

--- a/packages/transport/src/bridge/core.ts
+++ b/packages/transport/src/bridge/core.ts
@@ -1,0 +1,149 @@
+import { WebUSB } from 'usb';
+
+import { v1 as protocolV1, bridge as protocolBridge } from '@trezor/protocol';
+
+import { receive as receiveUtil } from '../utils/receive';
+import { SessionsBackground } from '../sessions/background';
+import { SessionsClient } from '../sessions/client';
+import { UsbApi } from '../api/usb';
+import { AcquireInput, ReleaseInput } from '../transports/abstract';
+
+export const sessionsBackground = new SessionsBackground();
+
+// todo: here we should have MultiApi
+export const api = new UsbApi({
+    usbInterface: new WebUSB({
+        allowAllDevices: true, // return all devices, not only authorized
+    }),
+});
+
+export const sessionsClient = new SessionsClient({
+    requestFn: args => sessionsBackground.handleMessage(args),
+    registerBackgroundCallbacks: () => {},
+});
+
+sessionsBackground.on('descriptors', descriptors => {
+    sessionsClient.emit('descriptors', descriptors);
+});
+
+// whenever low-level api reports changes to descriptors, report them to sessions module
+api.on('transport-interface-change', paths => {
+    sessionsClient.enumerateDone({ paths });
+});
+
+const writeUtil = async ({ path, data }: { path: string; data: string }) => {
+    const { typeId, buffer: restBuffer } = protocolBridge.decode(
+        new Uint8Array(Buffer.from(data, 'hex')),
+    );
+
+    const buffers = protocolV1.encode(restBuffer, {
+        messageType: typeId,
+    });
+
+    for (let i = 0; i < buffers.length; i++) {
+        const bufferSegment = buffers[i];
+        await api.write(path, bufferSegment);
+    }
+};
+
+const readUtil = async ({ path }: { path: string }) => {
+    try {
+        const message = await receiveUtil(
+            () =>
+                api.read(path).then(result => {
+                    if (result.success) {
+                        return result.payload;
+                    }
+                    throw new Error(result.error);
+                }),
+            protocolV1.decode,
+        );
+        return protocolBridge
+            .encode(message.buffer, { messageType: message.typeId })[0]
+            .toString('hex');
+    } catch (err) {
+        return { success: false as const, error: err.message };
+    }
+};
+
+export const enumerate = async () => {
+    await sessionsClient.enumerateIntent();
+
+    const enumerateResult = await api.enumerate();
+    if (!enumerateResult.success) {
+        return enumerateResult;
+    }
+    return sessionsClient.enumerateDone({ paths: enumerateResult.payload });
+};
+
+export const acquire = async (acquireInput: AcquireInput) => {
+    const acquireIntentResult = await sessionsClient.acquireIntent({
+        path: acquireInput.path,
+        previous: acquireInput.previous === 'null' ? null : acquireInput.previous,
+    });
+    if (!acquireIntentResult.success) {
+        return acquireIntentResult;
+    }
+    await sessionsClient.acquireDone({ path: acquireInput.path });
+
+    return acquireIntentResult;
+};
+
+export const release = async ({ session, path }: ReleaseInput) => {
+    await sessionsClient.releaseIntent({ session });
+    const sessionsResult = await sessionsClient.getPathBySession({
+        session,
+    });
+    if (!sessionsResult.success) {
+        return sessionsResult;
+    }
+
+    await api.closeDevice(path);
+    return sessionsClient.releaseDone({ path: sessionsResult.payload.path });
+};
+
+export const call = async ({ session, data }: { session: string; data: string }) => {
+    const sessionsResult = await sessionsClient.getPathBySession({
+        session,
+    });
+    if (!sessionsResult.success) {
+        return sessionsResult;
+    }
+    const { path } = sessionsResult.payload;
+    await api.openDevice(path, false);
+    await writeUtil({ path, data });
+    const message = await readUtil({ path });
+    return { success: true as const, payload: message };
+};
+
+export const send = async ({ session, data }: { session: string; data: string }) => {
+    const sessionsResult = await sessionsClient.getPathBySession({
+        session,
+    });
+
+    if (!sessionsResult.success) {
+        return sessionsResult;
+    }
+    const { path } = sessionsResult.payload;
+
+    await api.openDevice(path, false);
+    await writeUtil({ path, data });
+    return { success: true as const };
+};
+
+export const receive = async ({ session }: { session: string }) => {
+    const sessionsResult = await sessionsClient.getPathBySession({
+        session,
+    });
+
+    if (!sessionsResult.success) {
+        return sessionsResult;
+    }
+    const { path } = sessionsResult.payload;
+
+    await api.openDevice(path, false);
+
+    const message = await readUtil({ path });
+
+    return { success: true as const, payload: message };
+};

--- a/packages/transport/src/bridge/http.ts
+++ b/packages/transport/src/bridge/http.ts
@@ -1,0 +1,154 @@
+import express, { Express, Request, Response } from 'express';
+import cors from 'cors';
+
+import { arrayPartition } from '@trezor/utils/lib/arrayPartition';
+
+import { Descriptor } from '../types';
+import { sessionsClient, enumerate, acquire, release, call, send, receive } from './core';
+
+const defaults = {
+    port: 21325,
+};
+
+export class TrezordNode {
+    /** versioning, baked in by webpack */
+    version = '3.0.0';
+    serviceName = 'trezord-node';
+    /** last known descriptors state */
+    descriptors: string;
+    /** pending /listen subscriptions that are supposed to be resolved whenever descriptors change is detected */
+    listenSubscriptions: {
+        descriptors: string;
+        req: Request;
+        res: Response;
+    }[];
+    port: number;
+    server: Express = express();
+
+    constructor({ port }: { port: number }) {
+        this.port = port || defaults.port;
+
+        this.descriptors = '{}';
+
+        this.listenSubscriptions = [];
+
+        // whenever sessions module reports changes to descriptors (including sessions), resolve affected /listen subscriptions
+        sessionsClient.on('descriptors', descriptors => {
+            this.resolveListenSubscriptions(descriptors);
+        });
+    }
+
+    private resolveListenSubscriptions(descriptors: Descriptor[]) {
+        this.descriptors = JSON.stringify(descriptors);
+
+        const [affected, unaffected] = arrayPartition(
+            this.listenSubscriptions,
+            subscription => subscription.descriptors !== this.descriptors,
+        );
+        affected.forEach(subscription => {
+            subscription.res.send(this.descriptors);
+        });
+        this.listenSubscriptions = unaffected;
+    }
+
+    public start() {
+        return new Promise<void>(resolve => {
+            console.log(`starting ${this.serviceName}, version: ${this.version}}`);
+
+            const app = express();
+
+            // todo: limit to whitelisted domains
+            app.use(cors());
+
+            app.get('/', (_req, res) => {
+                res.send(`hello, I am bridge in node, version: ${this.version}`);
+            });
+
+            app.post('/', (_req, res) => {
+                res.set('Content-Type', 'text/plain');
+
+                res.send({
+                    version: this.version,
+                });
+            });
+
+            app.post('/enumerate', (_req, res) => {
+                res.set('Content-Type', 'text/plain');
+                enumerate()
+                    .then(result => {
+                        if (!result.success) {
+                            throw new Error(result.error);
+                        }
+                        res.send(result.payload.descriptors);
+                    })
+                    .catch(err => {
+                        res.send({ error: err.message });
+                    });
+            });
+
+            app.post('/listen', express.json(), (req, res) => {
+                res.set('Content-Type', 'text/plain');
+
+                this.listenSubscriptions.push({
+                    descriptors: JSON.stringify(req.body),
+                    req,
+                    res,
+                });
+            });
+
+            app.post('/acquire/:path/:previous', express.json(), (req, res) => {
+                res.set('Content-Type', 'text/plain');
+
+                acquire({ path: req.params.path, previous: req.params.previous }).then(result => {
+                    if (!result.success) {
+                        return res.send({ error: result.error });
+                    }
+                    res.send({ session: result.payload.session });
+                });
+            });
+
+            app.post('/release/:session', express.json(), (req, res) => {
+                release({ session: req.params.session, path: req.body }).then(result => {
+                    if (!result.success) {
+                        return res.send({ error: result.error });
+                    }
+                    res.send({ session: req.params.session });
+                });
+            });
+
+            app.post('/call/:session', express.text(), (req, res) => {
+                res.set('Content-Type', 'text/plain');
+                call({ session: req.params.session, data: req.body }).then(result => {
+                    if (!result.success) {
+                        return res.send({ error: result.error });
+                    }
+                    res.send(result.payload);
+                });
+            });
+
+            app.post('/read/:session', (req, res) => {
+                receive({ session: req.params.session }).then(result => {
+                    if (!result.success) {
+                        return res.send({ error: result.error });
+                    }
+                    res.send(result.payload);
+                });
+            });
+
+            app.post('/post/:session', express.text(), (req, res) => {
+                send({ session: req.params.session, data: req.body }).then(result => {
+                    if (!result.success) {
+                        return res.send({ error: result.error });
+                    }
+                    res.send();
+                });
+            });
+
+            app.listen(this.port, () => {
+                resolve();
+            });
+        });
+    }
+
+    public stop() {}
+}

--- a/packages/transport/src/utils/receive.ts
+++ b/packages/transport/src/utils/receive.ts
@@ -39,14 +39,25 @@ async function receiveBuffer(
     return { received: result, typeId };
 }
 
+export async function receive(
+    receiver: () => Promise<ArrayBuffer>,
+    decoder: TransportProtocolDecode,
+) {
+    const { received, typeId } = await receiveBuffer(receiver, decoder);
+    return {
+        typeId,
+        buffer: received,
+    };
+}
+
 export async function receiveAndParse(
     messages: Root,
     receiver: () => Promise<ArrayBuffer>,
     decoder: TransportProtocolDecode,
 ) {
-    const { received, typeId } = await receiveBuffer(receiver, decoder);
+    const { buffer, typeId } = await receive(receiver, decoder);
     const { Message, messageName } = createMessageFromType(messages, typeId);
-    const message = decodeProtobuf(Message, received);
+    const message = decodeProtobuf(Message, buffer);
     return {
         message,
         type: messageName,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9438,9 +9438,13 @@ __metadata:
     "@trezor/trezor-user-env-link": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@types/bytebuffer": "npm:^5.0.46"
+    "@types/cors": "npm:^2.8.15"
+    "@types/express": "npm:^4"
     "@types/sharedworker": "npm:^0.0.105"
     "@types/w3c-web-usb": "npm:^1.0.9"
+    cors: "npm:^2.8.5"
     cross-fetch: "npm:^4.0.0"
+    express: "npm:^4.18.2"
     jest: "npm:29.5.0"
     json-stable-stringify: "npm:^1.0.2"
     long: "npm:^4.0.0"
@@ -10015,15 +10019,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/express@npm:*, @types/express@npm:^4.17.13, @types/express@npm:^4.7.0":
-  version: 4.17.17
-  resolution: "@types/express@npm:4.17.17"
+"@types/express@npm:*, @types/express@npm:^4, @types/express@npm:^4.17.13, @types/express@npm:^4.7.0":
+  version: 4.17.21
+  resolution: "@types/express@npm:4.17.21"
   dependencies:
     "@types/body-parser": "npm:*"
     "@types/express-serve-static-core": "npm:^4.17.33"
     "@types/qs": "npm:*"
     "@types/serve-static": "npm:*"
-  checksum: e2959a5fecdc53f8a524891a16e66dfc330ee0519e89c2579893179db686e10cfa6079a68e0fb8fd00eedbcaf3eabfd10916461939f3bc02ef671d848532c37e
+  checksum: 7a6d26cf6f43d3151caf4fec66ea11c9d23166e4f3102edfe45a94170654a54ea08cf3103d26b3928d7ebcc24162c90488e33986b7e3a5f8941225edd5eb18c7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description
This PR creates a module which combines building blocks of nodeusb transport into a new module (transport/bridge/core) and wraps it with http interface (transport/bridge/http) effectively building alternative to https://github.dev/trezor/trezord-go that can be used as a javascript module.

### Todos
- [ ] cors module or should we set headers manually?
- [ ] set proper response headers
- [ ] maybe accept logger in params
- [ ] UI on port 21325 GET?

### Related issues
- builds on top of #10008
- prerequisite for #9985
- prerequisite for  #10356
