### PR TITLE
fix(suite-native): portfolio graph selects only device accounts

### DIFF
--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -140,9 +140,9 @@ export const selectDeviceAccounts = (state: AccountsRootState & DeviceRootState)
         A.filter(account => account.deviceState === selectDevice(state)?.state),
     );
 
-export const selectMainnetAccounts = memoize((state: AccountsRootState) =>
+export const selectDeviceMainnetAccounts = memoize((state: AccountsRootState & DeviceRootState) =>
     pipe(
-        selectAccounts(state),
+        selectDeviceAccounts(state),
         A.filter(account => !isTestnet(account.symbol)),
     ),
 );

--- a/suite-native/assets/src/components/Assets.tsx
+++ b/suite-native/assets/src/components/Assets.tsx
@@ -18,7 +18,7 @@ import { selectIsDeviceDiscoveryActive } from '@suite-common/wallet-core';
 import { useTranslate } from '@suite-native/intl';
 
 import { DiscoveryAssetsLoader } from './DiscoveryAssetsLoader';
-import { selectAssetsWithBalances } from '../assetsSelectors';
+import { selectDeviceAssetsWithBalances } from '../assetsSelectors';
 import { calculateAssetsPercentage } from '../utils';
 import { AssetItem } from './AssetItem';
 import { NetworkAssetsBottomSheet } from './NetworkAssetsBottomSheet';
@@ -38,14 +38,14 @@ export const Assets = ({ maximumAssetsVisible }: AssetsProps) => {
 
     const { translate } = useTranslate();
 
-    const assetsData = useSelector(selectAssetsWithBalances);
+    const deviceAssetsData = useSelector(selectDeviceAssetsWithBalances);
     const isDiscoveryActive = useSelector(selectIsDeviceDiscoveryActive);
 
     const [selectedAssetSymbol, setSelectedAssetSymbol] = useState<NetworkSymbol | null>(null);
 
     const assetsDataWithPercentage = useMemo(
-        () => calculateAssetsPercentage(assetsData),
-        [assetsData],
+        () => calculateAssetsPercentage(deviceAssetsData),
+        [deviceAssetsData],
     );
 
     const navigateToAssets = () => {

--- a/suite-native/graph/src/hooks.ts
+++ b/suite-native/graph/src/hooks.ts
@@ -10,7 +10,7 @@ import {
 import {
     AccountsRootState,
     selectAccountByKey,
-    selectMainnetAccounts,
+    selectDeviceMainnetAccounts,
 } from '@suite-common/wallet-core';
 import { AccountKey } from '@suite-common/wallet-types';
 import { analytics, EventType } from '@suite-native/analytics';
@@ -107,9 +107,9 @@ export const useGraphForSingleAccount = ({
     };
 };
 
-export const useGraphForAllAccounts = ({ fiatCurrency }: CommonUseGraphParams) => {
+export const useGraphForAllDeviceAccounts = ({ fiatCurrency }: CommonUseGraphParams) => {
     const dispatch = useDispatch();
-    const accounts = useSelector(selectMainnetAccounts);
+    const accounts = useSelector(selectDeviceMainnetAccounts);
     const portfolioGraphTimeframe = useSelector(selectPortfolioGraphTimeframe);
 
     const { startOfTimeFrameDate, endOfTimeFrameDate } =

--- a/suite-native/module-home/src/components/PortfolioGraph.tsx
+++ b/suite-native/module-home/src/components/PortfolioGraph.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { useSetAtom } from 'jotai';
 
-import { useGraphForAllAccounts, Graph, TimeSwitch } from '@suite-native/graph';
+import { useGraphForAllDeviceAccounts, Graph, TimeSwitch } from '@suite-native/graph';
 import { selectFiatCurrency } from '@suite-native/module-settings';
 import { VStack } from '@suite-native/atoms';
 import { selectIsDeviceDiscoveryActive, selectIsPortfolioEmpty } from '@suite-common/wallet-core';
@@ -19,7 +19,7 @@ export const PortfolioGraph = () => {
     const isDiscoveryActive = useSelector(selectIsDeviceDiscoveryActive);
     const isPortfolioEmpty = useSelector(selectIsPortfolioEmpty);
     const { graphPoints, error, isLoading, refetch, onSelectTimeFrame, timeframe } =
-        useGraphForAllAccounts({
+        useGraphForAllDeviceAccounts({
             fiatCurrency: fiatCurrency.label,
         });
     const setSelectedPoint = useSetAtom(selectedPointAtom);


### PR DESCRIPTION
Portfolio graph now represents only accounts that are related to the selected device and no others.
