### PR TITLE
Fix/analytics e2e timestamp

### DIFF
--- a/packages/analytics/src/analytics.ts
+++ b/packages/analytics/src/analytics.ts
@@ -77,7 +77,9 @@ export class Analytics<T extends AnalyticsEvent> {
 
     public report = (data: T, config?: ReportConfig) => {
         // Add a timestamp to each event to track its actual occurrence time, considering possible queuing delays.
-        data.timestamp = Date.now().toString();
+        if (!data.timestamp) {
+            data.timestamp = Date.now().toString();
+        }
 
         const isMissingFields =
             !this.url || !this.instanceId || !this.sessionId || !this.commitId || !this.version;

--- a/packages/suite-web/e2e/tests/analytics/events.test.ts
+++ b/packages/suite-web/e2e/tests/analytics/events.test.ts
@@ -139,7 +139,8 @@ describe('Analytics Events', () => {
         // settings/analytics and suite-ready should be reported now
         // settings/analytics is logged 1st
         // suite-ready is logged 2nd
-        cy.wrap(requests).should('have.length', 2);
+        // other events are from queue
+        cy.wrap(requests).should('have.length.at.least', 2);
 
         cy.wrap(requests).its(0).should('have.property', 'c_type', EventType.SettingsAnalytics);
         cy.wrap(requests).its(1).should('have.property', 'c_type', EventType.SuiteReady);


### PR DESCRIPTION
## Description

- fix e2e test, as all the events before user confirms are also sent
- timestamp was not tracked correctly for queued events

