### PR TITLE
Feat: tranport unify protocol encode/decode

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -1,7 +1,7 @@
 // original file https://github.com/trezor/connect/blob/develop/src/js/device/Device.js
-
 import { TypedEmitter } from '@trezor/utils/lib/typedEventEmitter';
 import { createDeferred, Deferred, versionUtils } from '@trezor/utils';
+import { TransportProtocol, v1 as v1Protocol, bridge as bridgeProtocol } from '@trezor/protocol';
 import { DeviceCommands } from './DeviceCommands';
 import { PROTO, ERRORS, NETWORK } from '../constants';
 import { DEVICE, DeviceButtonRequestPayload, UI } from '../events';
@@ -79,6 +79,7 @@ export interface DeviceEvents {
  */
 export class Device extends TypedEmitter<DeviceEvents> {
     transport: Transport;
+    protocol: TransportProtocol;
 
     originalDescriptor: Descriptor;
 
@@ -129,6 +130,12 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
     constructor(transport: Transport, descriptor: Descriptor) {
         super();
+
+        if (transport.name === 'BridgeTransport') {
+            this.protocol = bridgeProtocol;
+        } else {
+            this.protocol = v1Protocol;
+        }
 
         // === immutable properties
         this.transport = transport;

--- a/packages/connect/src/device/DeviceCommands.ts
+++ b/packages/connect/src/device/DeviceCommands.ts
@@ -381,6 +381,7 @@ export class DeviceCommands {
             session: this.sessionId,
             name: type,
             data: msg,
+            protocol: this.device.protocol,
         });
         const res = await this.callPromise.promise;
         this.callPromise = undefined;
@@ -423,7 +424,10 @@ export class DeviceCommands {
         } catch (error) {
             // handle possible race condition
             // Bridge may have some unread message in buffer, read it
-            await this.transport.receive({ session: this.sessionId });
+            await this.transport.receive({
+                session: this.sessionId,
+                protocol: this.device.protocol,
+            });
             // throw error anyway, next call should be resolved properly
             throw error;
         }
@@ -751,6 +755,7 @@ export class DeviceCommands {
             }
         } else {
             await this.transport.send({
+                protocol: this.device.protocol,
                 session: this.sessionId,
                 name: 'Cancel',
                 data: {},

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -18,7 +18,7 @@
     ],
     "scripts": {
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
-        "test:unit": "jest -c ../../jest.config.base.js --passWithNoTests",
+        "test:unit": "jest -c ../../jest.config.base.js",
         "type-check": "tsc --build",
         "build:lib": "rimraf ./lib && yarn tsc --build tsconfig.lib.json",
         "prepublishOnly": "yarn tsx ../../scripts/prepublishNPM.js",

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -2,3 +2,4 @@ export * as v1 from './protocol-v1';
 export * as bridge from './protocol-bridge';
 export * as trzd from './protocol-trzd';
 export * from './errors';
+export * from './types';

--- a/packages/protocol/src/protocol-bridge/decode.ts
+++ b/packages/protocol/src/protocol-bridge/decode.ts
@@ -1,5 +1,7 @@
 import ByteBuffer from 'bytebuffer';
 
+import { TransportProtocolDecode } from '../types';
+
 /**
  * Reads meta information from buffer
  */
@@ -10,11 +12,13 @@ const readHeader = (buffer: ByteBuffer) => {
     return { typeId, length };
 };
 
-export const decode = (byteBuffer: ByteBuffer) => {
-    const { typeId } = readHeader(byteBuffer);
+export const decode: TransportProtocolDecode = bytes => {
+    const byteBuffer = ByteBuffer.wrap(bytes, undefined, undefined, true);
+    const { typeId, length } = readHeader(byteBuffer);
 
     return {
         typeId,
+        length,
         buffer: byteBuffer,
     };
 };

--- a/packages/protocol/src/protocol-bridge/encode.ts
+++ b/packages/protocol/src/protocol-bridge/encode.ts
@@ -1,15 +1,12 @@
 import ByteBuffer from 'bytebuffer';
 
 import { HEADER_SIZE } from '../protocol-v1/constants';
-
-type Options = {
-    messageType: number;
-};
+import { TransportProtocolEncode } from '../types';
 
 // this file is basically combination of "trezor v1 protocol" and "bridge protocol"
 // there is actually no officially described bridge protocol, but in fact there is one
 // it is because bridge does some parts of the protocol itself (like chunking)
-export const encode = (data: ByteBuffer, options: Options) => {
+export const encode: TransportProtocolEncode = (data, options) => {
     const { messageType } = options;
     const fullSize = HEADER_SIZE - 2 + data.limit;
 
@@ -28,5 +25,5 @@ export const encode = (data: ByteBuffer, options: Options) => {
 
     // todo: it would be nicer to return Buffer instead of ByteBuffer. The problem is that ByteBuffer.Buffer.toString behaves differently in web and node.
     // anyway, for now we can keep this legacy behavior
-    return encodedByteBuffer;
+    return [encodedByteBuffer];
 };

--- a/packages/protocol/src/protocol-trzd/decode.ts
+++ b/packages/protocol/src/protocol-trzd/decode.ts
@@ -1,11 +1,20 @@
 import ByteBuffer from 'bytebuffer';
 
+// Decode `trzd` protocol used for decoding of dynamically loaded `@trezor/protobuf` messages
+// https://github.com/trezor/trezor-firmware/blob/087becd2caa5618eecab37ac3f2ca51172e52eb9/docs/common/ethereum-definitions.md#definition-format
+
 export const decode = (bytes: ArrayBuffer) => {
     const byteBuffer = ByteBuffer.wrap(bytes);
+    byteBuffer.LE(true); // use little endian byte order
+    // 5 bytes magic `trzd`
     const magic = byteBuffer.readBytes(5).toUTF8();
+    // 1 byte
     const definitionType = byteBuffer.readUint8();
+    // 4 bytes
     const dataVersion = byteBuffer.readUint32();
-    const protobufLength = byteBuffer.readUint8();
+    // 2 bytes
+    const protobufLength = byteBuffer.readUint16();
+    // N bytes
     const protobufPayload = byteBuffer.slice(12, 12 + protobufLength);
 
     return {

--- a/packages/protocol/src/protocol-v1/decode.ts
+++ b/packages/protocol/src/protocol-v1/decode.ts
@@ -2,6 +2,7 @@ import ByteBuffer from 'bytebuffer';
 
 import * as ERRORS from '../errors';
 import { MESSAGE_HEADER_BYTE, MESSAGE_MAGIC_HEADER_BYTE } from './constants';
+import { TransportProtocolDecode } from '../types';
 
 /**
  * Reads meta information from chunked buffer
@@ -18,7 +19,7 @@ const readHeaderChunked = (buffer: ByteBuffer) => {
 
 // Parses first raw input that comes from Trezor and returns some information about the whole message.
 // [compatibility]: accept Buffer just like decode does. But this would require changes in lower levels
-export const decodeChunked = (bytes: ArrayBuffer) => {
+export const decode: TransportProtocolDecode = bytes => {
     // convert to ByteBuffer so it's easier to read
     const byteBuffer = ByteBuffer.wrap(bytes, undefined, undefined, true);
 
@@ -33,5 +34,5 @@ export const decodeChunked = (bytes: ArrayBuffer) => {
         throw new Error(ERRORS.PROTOCOL_MALFORMED);
     }
 
-    return { length, typeId, restBuffer: byteBuffer };
+    return { length, typeId, buffer: byteBuffer };
 };

--- a/packages/protocol/src/protocol-v1/encode.ts
+++ b/packages/protocol/src/protocol-v1/encode.ts
@@ -11,6 +11,7 @@ import { TransportProtocolEncode } from '../types';
 export const encode: TransportProtocolEncode = (data, options) => {
     const { messageType } = options;
     const fullSize = HEADER_SIZE + data.limit;
+    const chunkSize = options.chunkSize || BUFFER_SIZE;
 
     const encodedByteBuffer = new ByteBuffer(fullSize);
 
@@ -29,7 +30,7 @@ export const encode: TransportProtocolEncode = (data, options) => {
 
     encodedByteBuffer.reset();
 
-    const size = BUFFER_SIZE - 1;
+    const size = chunkSize - 1;
 
     const chunkCount = Math.ceil(encodedByteBuffer.limit / size) || 1;
 
@@ -42,7 +43,7 @@ export const encode: TransportProtocolEncode = (data, options) => {
         const start = i * size;
         const end = Math.min((i + 1) * size, encodedByteBuffer.limit);
 
-        const buffer = new ByteBuffer(BUFFER_SIZE);
+        const buffer = new ByteBuffer(chunkSize);
 
         buffer.writeByte(MESSAGE_MAGIC_HEADER_BYTE);
 

--- a/packages/protocol/src/protocol-v1/encode.ts
+++ b/packages/protocol/src/protocol-v1/encode.ts
@@ -6,12 +6,9 @@ import {
     BUFFER_SIZE,
     MESSAGE_MAGIC_HEADER_BYTE,
 } from './constants';
+import { TransportProtocolEncode } from '../types';
 
-type Options = {
-    messageType: number;
-};
-
-export const encode = (data: ByteBuffer, options: Options): Buffer[] => {
+export const encode: TransportProtocolEncode = (data, options) => {
     const { messageType } = options;
     const fullSize = HEADER_SIZE + data.limit;
 
@@ -38,7 +35,7 @@ export const encode = (data: ByteBuffer, options: Options): Buffer[] => {
 
     // size with one reserved byte for header
 
-    const result = [];
+    const result: ByteBuffer[] = [];
     // How many pieces will there actually be
     // slice and dice
     for (let i = 0; i < chunkCount; i++) {
@@ -53,7 +50,7 @@ export const encode = (data: ByteBuffer, options: Options): Buffer[] => {
         slice.compact();
 
         buffer.append(slice);
-        result.push(buffer.buffer);
+        result.push(buffer);
     }
 
     return result;

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -1,0 +1,19 @@
+export type TransportProtocolDecode = (bytes: ArrayBuffer) => {
+    length: number;
+    typeId: number;
+    buffer: ByteBuffer;
+};
+
+export interface TransportProtocolEncodeOptions {
+    messageType: number;
+}
+
+export type TransportProtocolEncode = (
+    data: ByteBuffer,
+    options: TransportProtocolEncodeOptions,
+) => ByteBuffer[];
+
+export interface TransportProtocol {
+    encode: TransportProtocolEncode;
+    decode: TransportProtocolDecode;
+}

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -6,6 +6,7 @@ export type TransportProtocolDecode = (bytes: ArrayBuffer) => {
 
 export interface TransportProtocolEncodeOptions {
     messageType: number;
+    chunkSize?: number;
 }
 
 export type TransportProtocolEncode = (

--- a/packages/protocol/tests/protocol-bridge.test.ts
+++ b/packages/protocol/tests/protocol-bridge.test.ts
@@ -7,13 +7,15 @@ describe('protocol-bridge', () => {
         let chunks;
         // encode small chunk, message without data
         chunks = bridge.encode(new ByteBuffer(0), { messageType: 55 });
-        expect(chunks.limit).toEqual(6);
+        expect(chunks.length).toEqual(1);
+        expect(chunks[0].limit).toEqual(6);
 
         // encode big chunk, message with data
         chunks = bridge.encode(new ByteBuffer(371), { messageType: 55 });
-        expect(chunks.slice(0, 6).toString('hex')).toEqual('003700000173');
-        expect(chunks.readUint32(2)).toEqual(371);
-        expect(chunks.buffer.length).toEqual(371 + 6);
+        expect(chunks.length).toEqual(1);
+        expect(chunks[0].slice(0, 6).toString('hex')).toEqual('003700000173');
+        expect(chunks[0].readUint32(2)).toEqual(371);
+        expect(chunks[0].buffer.length).toEqual(371 + 6);
     });
 
     it('decode', () => {
@@ -22,7 +24,8 @@ describe('protocol-bridge', () => {
         data.fill(getFeatures, 0, 2);
         data.writeUint32BE(379, 2);
 
-        const read = bridge.decode(ByteBuffer.fromHex(data.toString('hex')));
+        const read = bridge.decode(data);
         expect(read.typeId).toEqual(55);
+        expect(read.length).toEqual(379);
     });
 });

--- a/packages/protocol/tests/protocol-bridge.test.ts
+++ b/packages/protocol/tests/protocol-bridge.test.ts
@@ -1,0 +1,28 @@
+import ByteBuffer from 'bytebuffer';
+
+import { bridge } from '../src/index';
+
+describe('protocol-bridge', () => {
+    it('encode', () => {
+        let chunks;
+        // encode small chunk, message without data
+        chunks = bridge.encode(new ByteBuffer(0), { messageType: 55 });
+        expect(chunks.limit).toEqual(6);
+
+        // encode big chunk, message with data
+        chunks = bridge.encode(new ByteBuffer(371), { messageType: 55 });
+        expect(chunks.slice(0, 6).toString('hex')).toEqual('003700000173');
+        expect(chunks.readUint32(2)).toEqual(371);
+        expect(chunks.buffer.length).toEqual(371 + 6);
+    });
+
+    it('decode', () => {
+        const getFeatures = Buffer.from('0037', 'hex');
+        const data = Buffer.allocUnsafe(385).fill(0);
+        data.fill(getFeatures, 0, 2);
+        data.writeUint32BE(379, 2);
+
+        const read = bridge.decode(ByteBuffer.fromHex(data.toString('hex')));
+        expect(read.typeId).toEqual(55);
+    });
+});

--- a/packages/protocol/tests/protocol-trzd.test.ts
+++ b/packages/protocol/tests/protocol-trzd.test.ts
@@ -1,0 +1,46 @@
+import { trzd } from '../src/index';
+
+describe('protocol-v1', () => {
+    it('decode', () => {
+        // Testnet chain
+        let data = Buffer.from(
+            '74727a643100585a6865130008011203455448183c2208457468657265756dDEAD',
+            'hex',
+        );
+        let read;
+
+        read = trzd.decode(data);
+        expect(read.magic).toEqual('trzd1');
+        expect(read.definitionType).toEqual(0);
+        expect(read.protobufLength).toEqual(19);
+        expect(read.protobufPayload.toBuffer().toString('hex')).toEqual(
+            '08011203455448183c2208457468657265756d',
+        );
+
+        // Testnet token
+        data = Buffer.from(
+            '74727a643101585a686532000a147af963cf6d228e564e2a0aa0ddbf06210b38615d10051a0354535420122a11676f65726c69205465737420746f6b656eDEAD',
+            'hex',
+        );
+        read = trzd.decode(data);
+        expect(read.magic).toEqual('trzd1');
+        expect(read.definitionType).toEqual(1);
+        expect(read.protobufLength).toEqual(50);
+        expect(read.protobufPayload.toBuffer().toString('hex')).toEqual(
+            '0a147af963cf6d228e564e2a0aa0ddbf06210b38615d10051a0354535420122a11676f65726c69205465737420746f6b656e',
+        );
+
+        // chain name > 256
+        const longName = Buffer.from('LongName'.repeat(50)); // 400 bytes
+        const len = Buffer.alloc(2);
+        len.writeInt16LE(longName.length);
+        data = Buffer.from(
+            `74727a643100585a6865${len.toString('hex')}${longName.toString('hex')}DEAD`,
+            'hex',
+        );
+        console.warn(len.toString('hex'));
+        read = trzd.decode(data);
+        expect(read.protobufLength).toEqual(400);
+        expect(read.protobufPayload.toBuffer()).toEqual(longName);
+    });
+});

--- a/packages/protocol/tests/protocol-v1.test.ts
+++ b/packages/protocol/tests/protocol-v1.test.ts
@@ -1,0 +1,39 @@
+import ByteBuffer from 'bytebuffer';
+
+import { v1 } from '../src/index';
+
+describe('protocol-v1', () => {
+    it('encode', () => {
+        let chunks;
+        // encode only one chunk, message without data
+        chunks = v1.encode(new ByteBuffer(0), { messageType: 55 });
+        expect(chunks.length).toEqual(1);
+        expect(chunks[0].length).toEqual(64);
+
+        // encode multiple chunks, message with data
+        chunks = v1.encode(new ByteBuffer(371), { messageType: 55 });
+        expect(chunks.length).toEqual(7);
+        chunks.forEach((chunk, index) => {
+            expect(chunk.length).toEqual(64);
+            if (index === 0) {
+                // first chunk with additional data
+                expect(chunk.slice(0, 9).toString('hex')).toEqual('3f2323003700000173');
+                expect(chunk.readUInt32BE(5)).toEqual(371);
+            } else {
+                // following chunk starts with MESSAGE_MAGIC_HEADER_BYTE
+                expect(chunk.slice(0, 5).toString('hex')).toEqual('3f00000000');
+            }
+        });
+    });
+
+    it('decode', () => {
+        const getFeatures = Buffer.from('3f23230037', 'hex');
+        const data = Buffer.allocUnsafe(360).fill(0);
+        data.fill(getFeatures, 0, 5);
+        data.writeUint32BE(379, 5);
+
+        const read = v1.decodeChunked(data);
+        expect(read.typeId).toEqual(55);
+        expect(read.length).toEqual(379);
+    });
+});

--- a/packages/protocol/tests/protocol-v1.test.ts
+++ b/packages/protocol/tests/protocol-v1.test.ts
@@ -8,17 +8,17 @@ describe('protocol-v1', () => {
         // encode only one chunk, message without data
         chunks = v1.encode(new ByteBuffer(0), { messageType: 55 });
         expect(chunks.length).toEqual(1);
-        expect(chunks[0].length).toEqual(64);
+        expect(chunks[0].limit).toEqual(64);
 
         // encode multiple chunks, message with data
         chunks = v1.encode(new ByteBuffer(371), { messageType: 55 });
         expect(chunks.length).toEqual(7);
         chunks.forEach((chunk, index) => {
-            expect(chunk.length).toEqual(64);
+            expect(chunk.limit).toEqual(64);
             if (index === 0) {
                 // first chunk with additional data
                 expect(chunk.slice(0, 9).toString('hex')).toEqual('3f2323003700000173');
-                expect(chunk.readUInt32BE(5)).toEqual(371);
+                expect(chunk.readUint32(5)).toEqual(371);
             } else {
                 // following chunk starts with MESSAGE_MAGIC_HEADER_BYTE
                 expect(chunk.slice(0, 5).toString('hex')).toEqual('3f00000000');
@@ -32,7 +32,7 @@ describe('protocol-v1', () => {
         data.fill(getFeatures, 0, 5);
         data.writeUint32BE(379, 5);
 
-        const read = v1.decodeChunked(data);
+        const read = v1.decode(data);
         expect(read.typeId).toEqual(55);
         expect(read.length).toEqual(379);
     });

--- a/packages/transport/src/utils/receive.ts
+++ b/packages/transport/src/utils/receive.ts
@@ -2,19 +2,7 @@ import ByteBuffer from 'bytebuffer';
 import { Root } from 'protobufjs/light';
 
 import { decode as decodeProtobuf, createMessageFromType } from '@trezor/protobuf';
-import { v1 as protocolV1, bridge as bridgeProtocol } from '@trezor/protocol';
-
-export function receiveOne(messages: Root, data: string) {
-    const bytebuffer = ByteBuffer.wrap(data, 'hex');
-
-    const { typeId, buffer } = bridgeProtocol.decode(bytebuffer);
-    const { Message, messageName } = createMessageFromType(messages, typeId);
-    const message = decodeProtobuf(Message, buffer);
-    return {
-        message,
-        type: messageName,
-    };
-}
+import { TransportProtocolDecode } from '@trezor/protocol';
 
 async function receiveRest(
     parsedInput: ByteBuffer,
@@ -34,20 +22,27 @@ async function receiveRest(
     return receiveRest(parsedInput, receiver, expectedLength);
 }
 
-async function receiveBuffer(receiver: () => Promise<ArrayBuffer>) {
+async function receiveBuffer(
+    receiver: () => Promise<ArrayBuffer>,
+    decoder: TransportProtocolDecode,
+) {
     const data = await receiver();
-    const { length, typeId, restBuffer } = protocolV1.decodeChunked(data);
+    const { length, typeId, buffer } = decoder(data);
     const decoded = new ByteBuffer(length);
 
     if (length) {
-        decoded.append(restBuffer);
+        decoded.append(buffer);
     }
     await receiveRest(decoded, receiver, length);
     return { received: decoded, typeId };
 }
 
-export async function receiveAndParse(messages: Root, receiver: () => Promise<ArrayBuffer>) {
-    const { received, typeId } = await receiveBuffer(receiver);
+export async function receiveAndParse(
+    messages: Root,
+    receiver: () => Promise<ArrayBuffer>,
+    decoder: TransportProtocolDecode,
+) {
+    const { received, typeId } = await receiveBuffer(receiver, decoder);
     const { Message, messageName } = createMessageFromType(messages, typeId);
     received.reset();
     const message = decodeProtobuf(Message, received);

--- a/packages/transport/src/utils/send.ts
+++ b/packages/transport/src/utils/send.ts
@@ -3,42 +3,17 @@
 // Logic of "call" is broken to two parts - sending and receiving
 import { Root } from 'protobufjs/light';
 import { encode as encodeProtobuf, createMessageFromName } from '@trezor/protobuf';
-import { v1 as protocolV1, bridge as bridgeProtocol } from '@trezor/protocol';
+import { TransportProtocolEncode } from '@trezor/protocol';
 
-// Sends more buffers to device.
-async function sendBuffers(sender: (data: Buffer) => Promise<void>, buffers: Array<Buffer>) {
-    for (const buffer of buffers) {
-        await sender(buffer);
-    }
-}
-
-// Sends message to device.
-// Resolves if everything gets sent
-export function buildOne(messages: Root, name: string, data: Record<string, unknown>) {
-    const { Message, messageType } = createMessageFromName(messages, name);
-
-    const buffer = encodeProtobuf(Message, data);
-    return bridgeProtocol.encode(buffer, {
-        messageType,
-    });
-}
-
-export const buildBuffers = (messages: Root, name: string, data: Record<string, unknown>) => {
+export const buildBuffers = (
+    messages: Root,
+    name: string,
+    data: Record<string, unknown>,
+    encoder: TransportProtocolEncode,
+) => {
     const { Message, messageType } = createMessageFromName(messages, name);
     const buffer = encodeProtobuf(Message, data);
-    return protocolV1.encode(buffer, {
+    return encoder(buffer, {
         messageType,
     });
 };
-
-// Sends message to device.
-// Resolves if everything gets sent
-export function buildAndSend(
-    messages: Root,
-    sender: (data: Buffer) => Promise<void>,
-    name: string,
-    data: Record<string, unknown>,
-) {
-    const buffers = buildBuffers(messages, name, data);
-    return sendBuffers(sender, buffers);
-}

--- a/packages/transport/tests/abstractUsb.test.ts
+++ b/packages/transport/tests/abstractUsb.test.ts
@@ -1,3 +1,4 @@
+import { v1 as v1Protocol } from '@trezor/protocol';
 import { AbstractTransport } from '../src/transports/abstract';
 import { AbstractApiTransport } from '../src/transports/abstractApi';
 import { UsbApi } from '../src/api/usb';
@@ -277,8 +278,12 @@ describe('Usb', () => {
         });
 
         it('call error - called without acquire.', async () => {
-            const res = await transport.call({ name: 'GetAddress', data: {}, session: '1' })
-                .promise;
+            const res = await transport.call({
+                name: 'GetAddress',
+                data: {},
+                session: '1',
+                protocol: v1Protocol,
+            }).promise;
             expect(res).toEqual({ success: false, error: 'device disconnected during action' });
         });
 
@@ -298,6 +303,7 @@ describe('Usb', () => {
                 name: 'GetAddress',
                 data: {},
                 session: acquireRes.payload,
+                protocol: v1Protocol,
             }).promise;
             expect(res).toEqual({
                 success: true,
@@ -324,6 +330,7 @@ describe('Usb', () => {
                 name: 'GetAddress',
                 data: {},
                 session: acquireRes.payload,
+                protocol: v1Protocol,
             }).promise;
             expect(sendRes).toEqual({
                 success: true,
@@ -331,6 +338,7 @@ describe('Usb', () => {
             });
             const receiveRes = await transport.receive({
                 session: acquireRes.payload,
+                protocol: v1Protocol,
             }).promise;
             expect(receiveRes).toEqual({
                 success: true,
@@ -374,6 +382,7 @@ describe('Usb', () => {
                 name: 'GetAddress',
                 data: {},
                 session: acquireRes.payload,
+                protocol: v1Protocol,
             });
             abort();
 
@@ -386,6 +395,7 @@ describe('Usb', () => {
                 name: 'GetAddress',
                 data: {},
                 session: acquireRes.payload,
+                protocol: v1Protocol,
             });
             // await promise2;
             expect(promise2).resolves.toEqual({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. unification of `@trezor/protocols` used by `@trezor/transport` package
    - created common interface with same input/output from encoding/decoding functions
    - using `TransportProtocol` in `@trezor/transport` - there is always a chunked output from protocol encode: with one big chunk protocol-bridge, multiple smaller chunks from protocol-v1

2. accept protocol parameter in AbstractTransport send, receive and call methods
    Allow connect to decide which protocol will be used, param is optional it fallbacks to bridge/v1 protocol accordingly 
    
3. add optional `chunkSize` to `TransportProtocolEncodeOptions` 
    Useful for bluetooth which is using protocol-v1 but with different chunk size (244)
