### PR TITLE
fix(suite): swap continue actions in DeviceAuthenticity

### DIFF
--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/DeviceAuthenticity.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/DeviceAuthenticity.tsx
@@ -74,7 +74,7 @@ export const DeviceAuthenticity = () => {
             setIsLoading(false);
             setIsSubmitted(true);
         };
-        const goToNext = () => (isOnboarding ? goToSuite() : goToNextStep());
+        const goToNext = () => (isOnboarding ? goToNextStep() : goToSuite());
         const handleClick = isCheckSuccessful ? goToNext : authenticateDevice;
 
         const buttonText = isCheckSuccessful ? 'TR_CONTINUE' : 'TR_START_CHECK';


### PR DESCRIPTION
I broke this during conflict resolution in https://github.com/trezor/trezor-suite/pull/9892, the actions should be the other way round. 🙇 
