### PR TITLE
fix(suite-native): device manager UI bugs

### DIFF
--- a/suite-common/icons/assets/icons/trezorConnectedDark.svg
+++ b/suite-common/icons/assets/icons/trezorConnectedDark.svg
@@ -1,0 +1,12 @@
+<svg fill="none" viewBox="0 0 26 30">
+  <g clip-path="url(#prefix__a)">
+    <path stroke="#2FBC81" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 1.625V4.25m6.806.194L15.95 6.3m-9.9 9.9-1.855 1.855M4 11.25H1.375M6.05 6.3 4.195 4.445"/>
+  </g>
+  <path stroke="#4E504F" stroke-width="2" d="M11 12.727c0-.866.804-1.727 2-1.727h10c1.196 0 2 .86 2 1.727v8.89c0 1.358-.493 2.69-1.422 3.789l-2.74 3.238a1.078 1.078 0 0 1-.823.356h-3.587c-.328 0-.616-.132-.795-.325l-3.008-3.232C11.567 24.306 11 22.883 11 21.427v-8.7Z"/>
+  <path stroke="#4E504F" stroke-width="2" d="M14.5 20.636v-6h7v6h-7Z"/>
+  <defs>
+    <clipPath id="prefix__a">
+      <path fill="#fff" d="M0 0h19v20H0z"/>
+    </clipPath>
+  </defs>
+</svg>

--- a/suite-common/icons/assets/icons/trezorConnectedLight.svg
+++ b/suite-common/icons/assets/icons/trezorConnectedLight.svg
@@ -1,0 +1,12 @@
+<svg fill="none" viewBox="0 0 26 30">
+  <g clip-path="url(#prefix__a)">
+    <path stroke="#00854D" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 1.625V4.25m6.806.194L15.95 6.3m-9.9 9.9-1.855 1.855M4 11.25H1.375M6.05 6.3 4.195 4.445"/>
+  </g>
+  <path stroke="#333" stroke-width="2" d="M11 12.727c0-.866.804-1.727 2-1.727h10c1.196 0 2 .86 2 1.727v8.89c0 1.358-.493 2.69-1.422 3.789l-2.74 3.238a1.078 1.078 0 0 1-.823.356h-3.587c-.328 0-.616-.132-.795-.325l-3.008-3.232C11.567 24.306 11 22.883 11 21.427v-8.7Z"/>
+  <path stroke="#333" stroke-width="2" d="M14.5 20.636v-6h7v6h-7Z"/>
+  <defs>
+    <clipPath id="prefix__a">
+      <path d="M0 0h19v20H0z"/>
+    </clipPath>
+  </defs>
+</svg>

--- a/suite-common/icons/src/components/Icon.tsx
+++ b/suite-common/icons/src/components/Icon.tsx
@@ -7,7 +7,7 @@ import { Color, CSSColor } from '@trezor/theme';
 
 import { IconName, icons } from '../icons';
 
-export type IconColor = Color | SharedValue<CSSColor>;
+export type IconColor = 'svgSource' | Color | SharedValue<CSSColor>;
 
 type IconProps = {
     name: IconName;
@@ -43,6 +43,9 @@ export const Icon = ({ name, customSize, size = 'large', color = 'iconDefault' }
 
     // Paint has to be Reanimated derived value, to allow color transition animation on the UI thread.
     const paint = useDerivedValue(() => {
+        // If color is  set to 'svgSource', it means that the SVG file contains its own colors and we don't want to override them.
+        if (color === 'svgSource') return undefined;
+
         const colorCode = isReanimatedSharedValue(color) ? color.value : colors[color];
 
         const freshPaint = Skia.Paint();

--- a/suite-common/icons/src/icons.ts
+++ b/suite-common/icons/src/icons.ts
@@ -91,6 +91,8 @@ export const icons = {
     trashAlt: require('../assets/icons/trashAlt.svg'),
     treeStructure: require('../assets/icons/treeStructure.svg'),
     trezor: require('../assets/icons/trezor.svg'),
+    trezorConnectedDark: require('../assets/icons/trezorConnectedDark.svg'),
+    trezorConnectedLight: require('../assets/icons/trezorConnectedLight.svg'),
     trezorT: require('../assets/icons/trezorT.svg'),
     twitter: require('../assets/icons/twitter.svg'),
     userFocus: require('../assets/icons/userFocus.svg'),

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -637,29 +637,37 @@ export const selectIsSelectedDeviceImported = (state: DeviceRootState) => {
     return device?.id === PORTFOLIO_TRACKER_DEVICE_ID;
 };
 
-export const selectDeviceLabel = (state: DeviceRootState, id: TrezorDevice['id']) => {
+export const selectDeviceLabelById = (state: DeviceRootState, id: TrezorDevice['id']) => {
     const device = selectDeviceById(state, id);
     return device?.label ?? null;
 };
 
-export const selectDeviceName = (state: DeviceRootState, id: TrezorDevice['id']): string | null => {
+export const selectDeviceNameById = (
+    state: DeviceRootState,
+    id: TrezorDevice['id'],
+): string | null => {
     const device = selectDeviceById(state, id);
     return device?.name ?? null;
 };
 
 export const selectSelectedDeviceName = (state: DeviceRootState) => {
     const selectedDevice = selectDevice(state);
-    return selectDeviceName(state, selectedDevice?.id);
+    return selectDeviceNameById(state, selectedDevice?.id);
 };
 
-export const selectSelectedDeviceId = (state: DeviceRootState) => {
+export const selectDeviceId = (state: DeviceRootState) => {
     const selectedDevice = selectDevice(state);
     return selectedDevice?.id ?? null;
 };
 
+export const selectDeviceModelById = (state: DeviceRootState, id: TrezorDevice['id']) => {
+    const device = selectDeviceById(state, id);
+    return device?.features?.internal_model ?? null;
+};
+
 export const selectDeviceModel = (state: DeviceRootState) => {
-    const features = selectDeviceFeatures(state);
-    return features?.internal_model ?? null;
+    const selectedDevice = selectDevice(state);
+    return selectDeviceModelById(state, selectedDevice?.id);
 };
 
 export const selectDeviceReleaseInfo = (state: DeviceRootState) => {

--- a/suite-native/device-manager/package.json
+++ b/suite-native/device-manager/package.json
@@ -11,6 +11,7 @@
         "type-check": "tsc --build"
     },
     "dependencies": {
+        "@mobily/ts-belt": "^3.13.1",
         "@react-navigation/native": "^6.1.3",
         "@reduxjs/toolkit": "1.9.5",
         "@suite-common/icons": "workspace:*",
@@ -21,8 +22,10 @@
         "@suite-native/intl": "workspace:*",
         "@suite-native/navigation": "workspace:*",
         "@suite-native/screen-overlay": "workspace:*",
+        "@suite-native/theme": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/styles": "workspace:*",
+        "@trezor/theme": "workspace:*",
         "jotai": "1.9.1",
         "react": "^18.2.0",
         "react-native": "0.71.8",

--- a/suite-native/device-manager/src/components/DeviceControlButtons.tsx
+++ b/suite-native/device-manager/src/components/DeviceControlButtons.tsx
@@ -43,12 +43,12 @@ export const DeviceControlButtons = () => {
     return (
         <HStack>
             <Box flex={1}>
-                <Button colorScheme="dangerElevation0" iconLeft="eject" onPress={handleEject}>
+                <Button colorScheme="dangerElevation1" iconLeft="eject" onPress={handleEject}>
                     {translate('deviceManager.deviceButtons.eject')}
                 </Button>
             </Box>
             <Box flex={2}>
-                <Button colorScheme="tertiaryElevation0" onPress={handleDeviceRedirect}>
+                <Button colorScheme="tertiaryElevation1" onPress={handleDeviceRedirect}>
                     {translate('deviceManager.deviceButtons.deviceInfo')}
                 </Button>
             </Box>

--- a/suite-native/device-manager/src/components/DeviceItem.tsx
+++ b/suite-native/device-manager/src/components/DeviceItem.tsx
@@ -2,19 +2,18 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Pressable } from 'react-native';
 
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
-import { HStack, Text, VStack } from '@suite-native/atoms';
+import { HStack } from '@suite-native/atoms';
 import {
     DeviceRootState,
-    selectDevice,
     selectDeviceById,
-    selectDeviceLabel,
-    selectDeviceName,
+    selectDeviceId,
     selectDeviceThunk,
 } from '@suite-common/wallet-core';
 import { Icon } from '@suite-common/icons';
 import { TrezorDevice } from '@suite-common/suite-types';
 
 import { useDeviceManager } from '../hooks/useDeviceManager';
+import { DeviceItemContent } from './DeviceItemContent';
 
 type DeviceItemProps = {
     id: TrezorDevice['id'];
@@ -24,29 +23,24 @@ const deviceItemWrapperStyle = prepareNativeStyle(utils => ({
     justifyContent: 'space-between',
     alignItems: 'center',
     borderRadius: utils.borders.radii.medium,
-    backgroundColor: utils.colors.backgroundTertiaryDefaultOnElevation0,
+    backgroundColor: utils.colors.backgroundTertiaryDefaultOnElevation1,
     paddingHorizontal: utils.spacings.medium,
     paddingVertical: 12,
 }));
 
-export const DeviceItem = ({ id }: DeviceItemProps) => {
+export const DeviceItem = ({ id: deviceItemId }: DeviceItemProps) => {
     const dispatch = useDispatch();
-
-    const deviceLabel = useSelector((state: DeviceRootState) => selectDeviceLabel(state, id));
-    const deviceName = useSelector((state: DeviceRootState) => selectDeviceName(state, id));
-    const device = useSelector((state: DeviceRootState) => selectDeviceById(state, id));
-    const currentDevice = useSelector(selectDevice);
-
     const { applyStyle } = useNativeStyles();
 
-    const { setIsDeviceManagerVisible } = useDeviceManager();
+    const selectedDeviceId = useSelector(selectDeviceId);
+    const device = useSelector((state: DeviceRootState) => selectDeviceById(state, deviceItemId));
 
-    if (!deviceLabel) return null;
+    const { setIsDeviceManagerVisible } = useDeviceManager();
 
     const handleSelectDevice = () => {
         setIsDeviceManagerVisible(false);
 
-        if (device?.id === currentDevice?.id) return;
+        if (deviceItemId === selectedDeviceId) return;
 
         dispatch(selectDeviceThunk(device));
     };
@@ -54,14 +48,8 @@ export const DeviceItem = ({ id }: DeviceItemProps) => {
     return (
         <Pressable onPress={handleSelectDevice}>
             <HStack style={applyStyle(deviceItemWrapperStyle)}>
-                <HStack spacing="medium" alignItems="center">
-                    <Icon name="stack" />
-                    <VStack spacing="extraSmall">
-                        <Text>{deviceName}</Text>
-                        <Text>{deviceLabel}</Text>
-                    </VStack>
-                </HStack>
-                <Icon name="chevronRight" />
+                <DeviceItemContent deviceId={deviceItemId} />
+                <Icon name="chevronRight" color="iconDefault" />
             </HStack>
         </Pressable>
     );

--- a/suite-native/device-manager/src/components/DeviceItemContent.tsx
+++ b/suite-native/device-manager/src/components/DeviceItemContent.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+
+import { Icon, IconName } from '@suite-common/icons';
+import { HStack, Box, Text } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+import {
+    selectDeviceNameById,
+    DeviceRootState,
+    PORTFOLIO_TRACKER_DEVICE_ID,
+    selectDeviceLabelById,
+} from '@suite-common/wallet-core';
+import { TrezorDevice } from '@suite-common/suite-types';
+import { TypographyStyle } from '@trezor/theme';
+import { useActiveColorScheme } from '@suite-native/theme';
+
+type Props = {
+    deviceId: TrezorDevice['id'];
+    isPortfolioLabelDisplayed?: boolean;
+    deviceNameTextVariant?: TypographyStyle;
+};
+
+export const DeviceItemContent = ({
+    deviceId,
+    isPortfolioLabelDisplayed = true,
+    deviceNameTextVariant = 'body',
+}: Props) => {
+    const activeColorScheme = useActiveColorScheme();
+
+    const deviceName = useSelector((state: DeviceRootState) =>
+        selectDeviceNameById(state, deviceId),
+    );
+    const deviceLabel = useSelector((state: DeviceRootState) =>
+        selectDeviceLabelById(state, deviceId),
+    );
+
+    const isPortfolioTrackerDevice = deviceId === PORTFOLIO_TRACKER_DEVICE_ID;
+
+    // TODO: when we enable remember mode, icon representing disconnected device have to be handled.
+    const trezorDeviceIcon: IconName =
+        activeColorScheme === 'standard' ? 'trezorConnectedLight' : 'trezorConnectedDark';
+
+    return (
+        <HStack alignItems="center" spacing="medium">
+            {isPortfolioTrackerDevice ? (
+                <Icon name="database" color="iconDefault" />
+            ) : (
+                <Icon name={trezorDeviceIcon} color="svgSource" />
+            )}
+            <Box>
+                <Text variant={deviceNameTextVariant}>
+                    {(isPortfolioTrackerDevice ? deviceName : deviceLabel) ?? deviceName}
+                </Text>
+                {isPortfolioTrackerDevice ? (
+                    isPortfolioLabelDisplayed && (
+                        <Text variant="label" color="textSubdued">
+                            <Translation id="deviceManager.status.portfolioTracker" />
+                        </Text>
+                    )
+                ) : (
+                    // TODO: when we enable remember mode, grey 'Disconnected' label has to be displayed.
+                    <Text variant="label" color="textSecondaryHighlight">
+                        <Translation id="deviceManager.status.connected" />
+                    </Text>
+                )}
+            </Box>
+        </HStack>
+    );
+};

--- a/suite-native/device-manager/src/components/DeviceManagerContent.tsx
+++ b/suite-native/device-manager/src/components/DeviceManagerContent.tsx
@@ -1,12 +1,14 @@
 import { useSelector } from 'react-redux';
+import { useMemo } from 'react';
 
+import { A } from '@mobily/ts-belt';
 import { useNavigation } from '@react-navigation/native';
 
 import { Button, Text, VStack } from '@suite-native/atoms';
 import {
     selectDevices,
     selectIsSelectedDeviceImported,
-    selectSelectedDeviceId,
+    selectDeviceId,
 } from '@suite-common/wallet-core';
 import {
     ConnectDeviceStackRoutes,
@@ -33,7 +35,7 @@ export const DeviceManagerContent = () => {
     const { translate } = useTranslate();
 
     const devices = useSelector(selectDevices);
-    const selectedDeviceId = useSelector(selectSelectedDeviceId);
+    const selectedDeviceId = useSelector(selectDeviceId);
     const isPortfolioTrackerDevice = useSelector(selectIsSelectedDeviceImported);
 
     const { setIsDeviceManagerVisible } = useDeviceManager();
@@ -45,26 +47,30 @@ export const DeviceManagerContent = () => {
         });
     };
 
+    const listedDevice = useMemo(
+        () => devices.filter(device => device.id !== selectedDeviceId),
+        [devices, selectedDeviceId],
+    );
+
     return (
         <DeviceManagerModal>
             {!isPortfolioTrackerDevice && <DeviceControlButtons />}
-            <VStack>
-                <Text variant="callout">
-                    <Translation id="deviceManager.deviceList.sectionTitle" />
-                </Text>
-                {devices.map(device => {
-                    if (device.id !== selectedDeviceId) {
-                        return <DeviceItem key={device.path} id={device.id} />;
-                    }
-                    return null;
-                })}
-            </VStack>
+            {A.isNotEmpty(listedDevice) && (
+                <VStack>
+                    <Text variant="callout">
+                        <Translation id="deviceManager.deviceList.sectionTitle" />
+                    </Text>
+                    {listedDevice.map(device => (
+                        <DeviceItem key={device.path} id={device.id} />
+                    ))}
+                </VStack>
+            )}
             {isPortfolioTrackerDevice && (
                 <VStack>
                     <Text variant="callout">
                         <Translation id="deviceManager.connectDevice.sectionTitle" />
                     </Text>
-                    <Button colorScheme="tertiaryElevation0" onPress={handleConnectDevice}>
+                    <Button colorScheme="tertiaryElevation1" onPress={handleConnectDevice}>
                         {translate('deviceManager.connectDevice.connectButton')}
                     </Button>
                 </VStack>

--- a/suite-native/device-manager/src/components/DeviceManagerModal.tsx
+++ b/suite-native/device-manager/src/components/DeviceManagerModal.tsx
@@ -15,11 +15,11 @@ type DeviceManagerModalProps = {
 
 const modalWrapperStyle = prepareNativeStyle<{ insets: EdgeInsets }>((utils, { insets }) => ({
     paddingTop: Math.max(insets.top, utils.spacings.medium),
-    backgroundColor: utils.colors.backgroundSurfaceElevation0,
+    backgroundColor: utils.colors.backgroundSurfaceElevation1,
 }));
 
 const contentWrapperStyle = prepareNativeStyle(utils => ({
-    backgroundColor: utils.colors.backgroundTertiaryDefaultOnElevation1,
+    backgroundColor: utils.colors.backgroundSurfaceElevation1,
     borderBottomRadius: utils.borders.radii.large,
     paddingHorizontal: utils.spacings.medium,
     paddingBottom: utils.spacings.medium,

--- a/suite-native/device-manager/src/components/DeviceSwitch.tsx
+++ b/suite-native/device-manager/src/components/DeviceSwitch.tsx
@@ -1,22 +1,17 @@
-import { Pressable } from 'react-native';
+import { Pressable, TouchableOpacity } from 'react-native';
 import { useSelector } from 'react-redux';
 
-import { Box, HStack, IconButton, Text } from '@suite-native/atoms';
-import { Icon, IconName } from '@suite-common/icons';
+import { Box, HStack } from '@suite-native/atoms';
+import { Icon } from '@suite-common/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
-import {
-    selectDeviceModel,
-    selectIsDeviceConnectedAndAuthorized,
-    selectIsSelectedDeviceImported,
-    selectSelectedDeviceName,
-} from '@suite-common/wallet-core';
-import { Translation } from '@suite-native/intl';
-import { DeviceModelInternal } from '@trezor/connect';
+import { selectDeviceId } from '@suite-common/wallet-core';
 
 import { SCREEN_HEADER_HEIGHT } from '../constants';
 import { useDeviceManager } from '../hooks/useDeviceManager';
+import { DeviceItemContent } from './DeviceItemContent';
 
 const switchStyle = prepareNativeStyle(utils => ({
+    flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
@@ -33,55 +28,39 @@ const switchWrapperStyle = prepareNativeStyle(_ => ({
     flex: 1,
 }));
 
-const deviceIcon = {
-    [DeviceModelInternal.T1B1]: 'trezor',
-    [DeviceModelInternal.T2T1]: 'trezorT',
-    [DeviceModelInternal.T2B1]: 'trezor',
-} as const satisfies Record<DeviceModelInternal, IconName>;
-
 export const DeviceSwitch = () => {
-    const deviceName = useSelector(selectSelectedDeviceName);
-    const isPortfolioTrackerDevice = useSelector(selectIsSelectedDeviceImported);
-    const isDeviceConnectedAndAuthorized = useSelector(selectIsDeviceConnectedAndAuthorized);
-    const deviceModel = useSelector(selectDeviceModel);
-
     const { applyStyle } = useNativeStyles();
 
-    const { setIsDeviceManagerVisible, isDeviceManagerVisible } = useDeviceManager();
+    const deviceId = useSelector(selectDeviceId);
 
-    if (!deviceModel) return null;
+    const { setIsDeviceManagerVisible, isDeviceManagerVisible } = useDeviceManager();
 
     const toggleDeviceManager = () => {
         setIsDeviceManagerVisible(!isDeviceManagerVisible);
     };
+    if (!deviceId) return null;
 
     return (
-        <HStack alignItems="center">
-            <Pressable onPress={toggleDeviceManager} style={applyStyle(switchWrapperStyle)}>
+        <Pressable onPress={toggleDeviceManager} style={applyStyle(switchWrapperStyle)}>
+            <HStack justifyContent="space-between" alignItems="center" spacing="medium">
                 <Box style={applyStyle(switchStyle)}>
-                    <HStack alignItems="center" spacing="medium">
-                        <Icon
-                            name={isPortfolioTrackerDevice ? 'database' : deviceIcon[deviceModel]}
-                        />
-                        <Box>
-                            <Text variant="highlight">{deviceName}</Text>
-                            {!isPortfolioTrackerDevice && isDeviceConnectedAndAuthorized && (
-                                <Text variant="label" color="textSecondaryHighlight">
-                                    <Translation id="deviceManager.status.connected" />
-                                </Text>
-                            )}
-                        </Box>
-                    </HStack>
-                    <Icon name="chevronUpAndDown" />
+                    <DeviceItemContent
+                        deviceId={deviceId}
+                        deviceNameTextVariant="highlight"
+                        isPortfolioLabelDisplayed={false}
+                    />
+                    {!isDeviceManagerVisible && (
+                        <Icon name="chevronUpAndDown" color="iconDefault" />
+                    )}
                 </Box>
-            </Pressable>
-            {isDeviceManagerVisible && (
-                <IconButton
-                    colorScheme="tertiaryElevation0"
-                    iconName="close"
-                    onPress={toggleDeviceManager}
-                />
-            )}
-        </HStack>
+                {isDeviceManagerVisible && (
+                    <TouchableOpacity onPress={toggleDeviceManager}>
+                        <Box paddingHorizontal="medium">
+                            <Icon name="close" size="mediumLarge" />
+                        </Box>
+                    </TouchableOpacity>
+                )}
+            </HStack>
+        </Pressable>
     );
 };

--- a/suite-native/device-manager/src/components/PortfolioTrackerDeviceManagerContent.tsx
+++ b/suite-native/device-manager/src/components/PortfolioTrackerDeviceManagerContent.tsx
@@ -34,17 +34,17 @@ export const PortfolioTrackerDeviceManagerContent = () => {
 
     return (
         <DeviceManagerModal>
-            <Button colorScheme="tertiaryElevation0" onPress={handleSyncCoins}>
+            <Button colorScheme="tertiaryElevation1" onPress={handleSyncCoins}>
                 {translate('deviceManager.syncCoinsButton')}
             </Button>
             <VStack>
                 <Text variant="callout">
                     <Translation id="deviceManager.portfolioTracker.explore" />
                 </Text>
-                <Button colorScheme="tertiaryElevation0">
+                <Button colorScheme="tertiaryElevation1">
                     {translate('deviceManager.portfolioTracker.learnBasics')}
                 </Button>
-                <Button colorScheme="tertiaryElevation0">
+                <Button colorScheme="tertiaryElevation1">
                     {translate('deviceManager.portfolioTracker.readDocs')}
                 </Button>
             </VStack>

--- a/suite-native/device-manager/tsconfig.json
+++ b/suite-native/device-manager/tsconfig.json
@@ -14,7 +14,9 @@
         { "path": "../intl" },
         { "path": "../navigation" },
         { "path": "../screen-overlay" },
+        { "path": "../theme" },
         { "path": "../../packages/connect" },
-        { "path": "../../packages/styles" }
+        { "path": "../../packages/styles" },
+        { "path": "../../packages/theme" }
     ]
 }

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -299,6 +299,7 @@ export const en = {
             readDocs: 'Read the docs',
         },
         status: {
+            portfolioTracker: 'Sync & track coins',
             connected: 'Connected',
         },
         syncCoinsButton: 'Sync coins',

--- a/yarn.lock
+++ b/yarn.lock
@@ -7354,6 +7354,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/device-manager@workspace:suite-native/device-manager"
   dependencies:
+    "@mobily/ts-belt": "npm:^3.13.1"
     "@react-navigation/native": "npm:^6.1.3"
     "@reduxjs/toolkit": "npm:1.9.5"
     "@suite-common/icons": "workspace:*"
@@ -7364,8 +7365,10 @@ __metadata:
     "@suite-native/intl": "workspace:*"
     "@suite-native/navigation": "workspace:*"
     "@suite-native/screen-overlay": "workspace:*"
+    "@suite-native/theme": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/styles": "workspace:*"
+    "@trezor/theme": "workspace:*"
     jotai: "npm:1.9.1"
     react: "npm:^18.2.0"
     react-native: "npm:0.71.8"


### PR DESCRIPTION
## Description 

- [feat(suite-native): icon can use svg source colors](https://github.com/trezor/trezor-suite/pull/10020/commits/ca41d40eac538b8f655d665999b172825ca664cf):  makes svg accept `svgSource` color variant to use the svg source file original colors
- [refactor(suite-native): device selector naming unified](https://github.com/trezor/trezor-suite/pull/10020/commits/682da24e62b0607462e1d6fc57e5043d7702ad6f): unifies naming of the device selectors, now everything that just starts by prefix `selectDevice...` queries for `selectedDevice` (active device) state. On the other hand anything the follows`selectDevice...ById` makes query based on argument provided deviceId 
- [fix(suite-native): minor device manager UI bugs](https://github.com/trezor/trezor-suite/pull/10020/commits/e3ce2037942ed80343253276623227b33e0c71fd): Fixed minor UI bigs described by #9993:


> ![Screenshot 2023-11-22 at 9 28 43](https://github.com/trezor/trezor-suite/assets/26143964/678f7b0b-6cb6-4171-a226-0a393a138806)

## Related issues
Fixes #9997
Fixes #9998
Fixes #9999 
Fixes #10000
Fixes #10001
Fixes #10010

## Screenshot

https://github.com/trezor/trezor-suite/assets/26143964/55136cd1-bee5-4cba-ba47-33f18e4b6b38


