### PR TITLE
feat(suite-native): all assets displayed in dashboard

### DIFF
--- a/suite-native/assets/src/components/Assets.tsx
+++ b/suite-native/assets/src/components/Assets.tsx
@@ -4,9 +4,8 @@ import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 
 import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
-import { Card, VStack, TextButton } from '@suite-native/atoms';
+import { Card, VStack } from '@suite-native/atoms';
 import {
-    AccountsStackRoutes,
     AppTabsParamList,
     AppTabsRoutes,
     RootStackParamList,
@@ -15,7 +14,6 @@ import {
 } from '@suite-native/navigation';
 import { networks, NetworkSymbol } from '@suite-common/wallet-config';
 import { selectIsDeviceDiscoveryActive } from '@suite-common/wallet-core';
-import { useTranslate } from '@suite-native/intl';
 
 import { DiscoveryAssetsLoader } from './DiscoveryAssetsLoader';
 import { selectDeviceAssetsWithBalances } from '../assetsSelectors';
@@ -29,14 +27,8 @@ type NavigationProp = TabToStackCompositeNavigationProp<
     RootStackParamList
 >;
 
-type AssetsProps = {
-    maximumAssetsVisible: number;
-};
-
-export const Assets = ({ maximumAssetsVisible }: AssetsProps) => {
+export const Assets = () => {
     const navigation = useNavigation<NavigationProp>();
-
-    const { translate } = useTranslate();
 
     const deviceAssetsData = useSelector(selectDeviceAssetsWithBalances);
     const isDiscoveryActive = useSelector(selectIsDeviceDiscoveryActive);
@@ -47,10 +39,6 @@ export const Assets = ({ maximumAssetsVisible }: AssetsProps) => {
         () => calculateAssetsPercentage(deviceAssetsData),
         [deviceAssetsData],
     );
-
-    const navigateToAssets = () => {
-        navigation.navigate(AppTabsRoutes.AccountsStack, { screen: AccountsStackRoutes.Accounts });
-    };
 
     const handleSelectAssetsAccount = useCallback(
         (accountKey: AccountKey, tokenContract?: TokenAddress) => {
@@ -67,13 +55,11 @@ export const Assets = ({ maximumAssetsVisible }: AssetsProps) => {
         setSelectedAssetSymbol(null);
     }, [setSelectedAssetSymbol]);
 
-    const isViewMoreButtonVisible = assetsDataWithPercentage.length > maximumAssetsVisible;
-
     return (
         <>
             <Card>
                 <VStack spacing={19}>
-                    {assetsDataWithPercentage.slice(0, maximumAssetsVisible).map(asset => (
+                    {assetsDataWithPercentage.map(asset => (
                         <AssetItem
                             key={asset.symbol}
                             iconName={asset.symbol}
@@ -86,14 +72,7 @@ export const Assets = ({ maximumAssetsVisible }: AssetsProps) => {
                             onPress={setSelectedAssetSymbol}
                         />
                     ))}
-                    {isDiscoveryActive && (
-                        <DiscoveryAssetsLoader emptyListSkeletonCount={maximumAssetsVisible} />
-                    )}
-                    {isViewMoreButtonVisible && (
-                        <TextButton variant="tertiary" isUnderlined onPress={navigateToAssets}>
-                            {translate('assets.dashboard.viewAllAssets')}
-                        </TextButton>
-                    )}
+                    {isDiscoveryActive && <DiscoveryAssetsLoader />}
                 </VStack>
             </Card>
             {selectedAssetSymbol && (

--- a/suite-native/assets/src/components/DiscoveryAssetsLoader.tsx
+++ b/suite-native/assets/src/components/DiscoveryAssetsLoader.tsx
@@ -6,11 +6,10 @@ import { Icon } from '@suite-common/icons';
 import { useTranslate } from '@suite-native/intl';
 import { selectIsAccountsListEmpty } from '@suite-common/wallet-core';
 
-type DiscoveryAssetsLoaderProps = {
-    emptyListSkeletonCount: number;
-};
+const EMPTY_LIST_SKELETON_COUNT = 3;
+const NONEMPTY_LIST_SKELETON_COUNT = 1;
 
-export const DiscoveryAssetsLoader = ({ emptyListSkeletonCount }: DiscoveryAssetsLoaderProps) => {
+export const DiscoveryAssetsLoader = () => {
     const { translate } = useTranslate();
     const isListEmpty = useSelector(selectIsAccountsListEmpty);
 
@@ -20,7 +19,9 @@ export const DiscoveryAssetsLoader = ({ emptyListSkeletonCount }: DiscoveryAsset
             : 'assets.dashboard.discoveryProgress.stillWorking',
     );
 
-    const numberOfSkeletons = isListEmpty ? emptyListSkeletonCount : 1;
+    const numberOfSkeletons = isListEmpty
+        ? EMPTY_LIST_SKELETON_COUNT
+        : NONEMPTY_LIST_SKELETON_COUNT;
 
     return (
         <>

--- a/suite-native/graph/package.json
+++ b/suite-native/graph/package.json
@@ -24,6 +24,7 @@
         "@suite-native/analytics": "workspace:*",
         "@suite-native/atoms": "workspace:*",
         "@suite-native/formatters": "workspace:*",
+        "@suite-native/intl": "workspace:*",
         "@suite-native/react-native-graph": "workspace:*",
         "@suite-native/storage": "workspace:*",
         "@suite-native/theme": "workspace:*",

--- a/suite-native/graph/src/components/Graph.tsx
+++ b/suite-native/graph/src/components/Graph.tsx
@@ -12,6 +12,7 @@ import {
     GroupedBalanceMovementEvent,
     GroupedBalanceMovementEventPayload,
 } from '@suite-common/graph';
+import { useTranslate } from '@suite-native/intl';
 
 import { getExtremaFromGraphPoints } from '../utils';
 import { AxisLabel, MAX_CLAMP_VALUE } from './AxisLabel';
@@ -89,9 +90,9 @@ export const Graph = <TGraphPoint extends FiatGraphPoint>({
         applyStyle,
         utils: { colors },
     } = useNativeStyles();
+    const { translate } = useTranslate();
 
     const isPointsEmpty = points.length <= 1;
-
     const nonEmptyPoints = isPointsEmpty ? emptyPoints : points;
     const extremaFromGraphPoints = useMemo(() => getExtremaFromGraphPoints(points), [points]);
     const axisLabels = useMemo(() => {
@@ -138,7 +139,7 @@ export const Graph = <TGraphPoint extends FiatGraphPoint>({
             />
             {loading && (
                 <Box style={applyStyle(graphMessageStyleContainer)}>
-                    <Loader title="Loading graph data..." />
+                    <Loader title={translate('graph.retrievingData')} />
                 </Box>
             )}
             {error && !loading && (

--- a/suite-native/graph/tsconfig.json
+++ b/suite-native/graph/tsconfig.json
@@ -22,6 +22,7 @@
         { "path": "../analytics" },
         { "path": "../atoms" },
         { "path": "../formatters" },
+        { "path": "../intl" },
         { "path": "../react-native-graph" },
         { "path": "../storage" },
         { "path": "../theme" },

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -75,7 +75,6 @@ export const en = {
     },
     assets: {
         dashboard: {
-            viewAllAssets: 'View all assets',
             discoveryProgress: { loading: 'Loading...', stillWorking: 'Still working...' },
         },
     },
@@ -324,6 +323,9 @@ export const en = {
         addressCopied: 'Address copied',
         copyButton: 'Copy',
         shareButton: 'Share',
+    },
+    graph: {
+        retrievingData: 'Retrieving data...',
     },
 };
 

--- a/suite-native/module-home/src/components/PortfolioContent.tsx
+++ b/suite-native/module-home/src/components/PortfolioContent.tsx
@@ -3,7 +3,6 @@ import { Assets } from '@suite-native/assets';
 import { useIsUsbDeviceConnectFeatureEnabled } from '@suite-native/feature-flags';
 
 import { PortfolioGraph } from './PortfolioGraph';
-import { MAX_ASSETS_ON_DASHBOARD } from '../constants';
 import { DashboardNavigationButtons } from './DashboardNavigationButtons';
 
 export const PortfolioContent = () => {
@@ -12,7 +11,7 @@ export const PortfolioContent = () => {
     return (
         <VStack spacing="large" marginTop="small">
             <PortfolioGraph />
-            <Assets maximumAssetsVisible={MAX_ASSETS_ON_DASHBOARD} />
+            <Assets />
             {!isUsbDeviceConnectFeatureEnabled && <DashboardNavigationButtons />}
         </VStack>
     );

--- a/suite-native/module-home/src/constants.ts
+++ b/suite-native/module-home/src/constants.ts
@@ -1,1 +1,0 @@
-export const MAX_ASSETS_ON_DASHBOARD = 3;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7539,6 +7539,7 @@ __metadata:
     "@suite-native/analytics": "workspace:*"
     "@suite-native/atoms": "workspace:*"
     "@suite-native/formatters": "workspace:*"
+    "@suite-native/intl": "workspace:*"
     "@suite-native/react-native-graph": "workspace:*"
     "@suite-native/storage": "workspace:*"
     "@suite-native/theme": "workspace:*"


### PR DESCRIPTION
All assets are now displayed in the dashboard and if there is running discovery, there is a graph loader message informing about that.

Closes #9760