### PR TITLE
feat(suite-native): wipe disconnected device data

### DIFF
--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -3,7 +3,6 @@ import { memoize } from 'proxy-memoize';
 import * as deviceUtils from '@suite-common/suite-utils';
 import { getStatus } from '@suite-common/suite-utils';
 import { Device, Features } from '@trezor/connect';
-import { DiscoveryStatus } from '@suite-common/wallet-constants';
 import { getFirmwareVersion, getFirmwareVersionArray } from '@trezor/device-utils';
 import { Network, networks } from '@suite-common/wallet-config';
 import { versionUtils } from '@trezor/utils';
@@ -15,8 +14,7 @@ import {
 } from '@suite-common/device-authenticity';
 
 import { deviceActions } from './deviceActions';
-import { DiscoveryRootState, selectDiscoveryByDeviceState } from '../discovery/discoveryReducer';
-import { PORTFOLIO_TRACKER_DEVICE_ID } from './deviceConstants';
+import { PORTFOLIO_TRACKER_DEVICE_ID, PORTFOLIO_TRACKER_DEVICE_STATE } from './deviceConstants';
 
 export type State = {
     devices: TrezorDevice[];
@@ -597,37 +595,6 @@ export const selectDeviceStatus = (state: DeviceRootState) => {
     return device && getStatus(device);
 };
 
-export const selectDiscoveryForDevice = (state: DiscoveryRootState & { device: State }) =>
-    selectDiscoveryByDeviceState(state, state.device.selectedDevice?.state);
-
-export const selectIsDeviceDiscoveryActive = (state: DiscoveryRootState & DeviceRootState) => {
-    const discovery = selectDiscoveryForDevice(state);
-
-    if (!discovery) return false;
-
-    return (
-        discovery.status === DiscoveryStatus.RUNNING ||
-        discovery.status === DiscoveryStatus.STOPPING
-    );
-};
-
-/**
- * Helper selector called from components
- * return `true` if discovery process is running/completed and `authConfirm` is required
- */
-export const selectIsDiscoveryAuthConfirmationRequired = (
-    state: DiscoveryRootState & DeviceRootState,
-) => {
-    const discovery = selectDiscoveryForDevice(state);
-
-    return (
-        discovery &&
-        discovery.authConfirm &&
-        (discovery.status < DiscoveryStatus.STOPPING ||
-            discovery.status === DiscoveryStatus.COMPLETED)
-    );
-};
-
 export const selectSupportedNetworks = (state: DeviceRootState) => {
     const device = selectDevice(state);
     const deviceModelInternal = device?.features?.internal_model;
@@ -704,3 +671,8 @@ export const selectDeviceFirmwareVersion = memoize((state: DeviceRootState) => {
     const device = selectDevice(state);
     return getFirmwareVersionArray(device);
 });
+
+export const selectPersistedDevicesStates = (state: DeviceRootState) => {
+    const devices = selectDevices(state);
+    return [...devices.map(d => d.id), PORTFOLIO_TRACKER_DEVICE_STATE];
+};

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -19,10 +19,14 @@ import {
     stopDiscovery,
     updateDiscovery,
 } from './discoveryActions';
-import { selectDiscoveryByDeviceState, selectDiscovery } from './discoveryReducer';
+import {
+    selectDiscoveryByDeviceState,
+    selectDiscovery,
+    selectDiscoveryForDevice,
+} from './discoveryReducer';
 import { selectAccounts } from '../accounts/accountsReducer';
 import { accountsActions } from '../accounts/accountsActions';
-import { selectDevice, selectDevices, selectDiscoveryForDevice } from '../device/deviceReducer';
+import { selectDevice, selectDevices } from '../device/deviceReducer';
 
 type ProgressEvent = BundleProgress<AccountInfo | null>['payload'];
 

--- a/suite-native/app/src/initActions.ts
+++ b/suite-native/app/src/initActions.ts
@@ -6,6 +6,7 @@ import { periodicFetchFiatRatesThunk } from '@suite-native/fiat-rates';
 import { selectFiatCurrencyCode } from '@suite-native/module-settings';
 import { getJWSPublicKey } from '@suite-native/config';
 import { initMessageSystemThunk } from '@suite-common/message-system';
+import { wipeDisconnectedDevicesDataThunk } from '@suite-native/device';
 
 import { setIsAppReady, setIsConnectInitialized } from '../../state/src/appSlice';
 
@@ -40,6 +41,10 @@ export const applicationInit = createThunk(
             // Since devices are not persisted,
             // we need to create device instance on app start
             dispatch(createImportedDeviceThunk());
+
+            // In case that user closed the app while device was connected,
+            // remove its persistent data on app init if the device is not connected anymore.
+            dispatch(wipeDisconnectedDevicesDataThunk());
         } catch (error) {
             console.error(error);
         } finally {

--- a/suite-native/device/package.json
+++ b/suite-native/device/package.json
@@ -16,6 +16,7 @@
         "@reduxjs/toolkit": "1.9.5",
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
+        "@suite-common/wallet-types": "workspace:*",
         "@suite-native/alerts": "workspace:*",
         "@suite-native/atoms": "workspace:*",
         "@suite-native/feature-flags": "workspace:*",

--- a/suite-native/device/src/deviceThunks.ts
+++ b/suite-native/device/src/deviceThunks.ts
@@ -1,0 +1,22 @@
+import { createThunk } from '@suite-common/redux-utils';
+import {
+    accountsActions,
+    discoveryActions,
+    selectDevicelessAccounts,
+    selectDevicelessDiscoveries,
+} from '@suite-common/wallet-core';
+
+const actionPrefix = '@suite-native/device';
+
+export const wipeDisconnectedDevicesDataThunk = createThunk(
+    `${actionPrefix}/wipeDisconnectedDevicesDataThunk`,
+    (_, { getState, dispatch }) => {
+        const devicelessAccounts = selectDevicelessAccounts(getState());
+        const devicelessDiscoveries = selectDevicelessDiscoveries(getState());
+
+        dispatch(accountsActions.removeAccount(devicelessAccounts));
+        devicelessDiscoveries.forEach(discovery =>
+            dispatch(discoveryActions.removeDiscovery(discovery.deviceState)),
+        );
+    },
+);

--- a/suite-native/device/src/index.ts
+++ b/suite-native/device/src/index.ts
@@ -2,4 +2,5 @@ export * from './middlewares/deviceMiddleware';
 export * from './middlewares/buttonRequestMiddleware';
 export * from './hooks/useDeviceConnect';
 export * from './screens/DeviceInfoModalScreen';
+export * from './deviceThunks';
 export * from './utils';

--- a/suite-native/device/src/middlewares/deviceMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceMiddleware.ts
@@ -12,6 +12,8 @@ import {
 } from '@suite-common/wallet-core';
 import { selectIsDeviceConnectFeatureFlagEnabled } from '@suite-native/feature-flags';
 
+import { wipeDisconnectedDevicesDataThunk } from '../deviceThunks';
+
 const isActionDeviceRelated = (action: AnyAction): boolean => {
     if (
         isAnyOf(
@@ -73,6 +75,7 @@ export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps(
                 break;
             case DEVICE.DISCONNECT:
                 dispatch(handleDeviceDisconnect(action.payload));
+                dispatch(wipeDisconnectedDevicesDataThunk());
                 break;
             default:
                 break;

--- a/suite-native/device/tsconfig.json
+++ b/suite-native/device/tsconfig.json
@@ -8,6 +8,9 @@
         {
             "path": "../../suite-common/wallet-core"
         },
+        {
+            "path": "../../suite-common/wallet-types"
+        },
         { "path": "../alerts" },
         { "path": "../atoms" },
         { "path": "../feature-flags" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7392,6 +7392,7 @@ __metadata:
     "@reduxjs/toolkit": "npm:1.9.5"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
+    "@suite-common/wallet-types": "workspace:*"
     "@suite-native/alerts": "workspace:*"
     "@suite-native/atoms": "workspace:*"
     "@suite-native/feature-flags": "workspace:*"


### PR DESCRIPTION
## Description

- on device.DISCONNECT event are its persisted accounts and discoveries removed
- If the user starts the app and there are some data of disconnected device, its wiped during the app init

Closes #10015