### PR TITLE
Connect webextension followup

### DIFF
--- a/packages/connect-examples/update-webextensions-sw.js
+++ b/packages/connect-examples/update-webextensions-sw.js
@@ -37,9 +37,6 @@ rootPaths.forEach(dir => {
     const buildPath = path.join(rootPath, buildFolder);
     const vendorPath = path.join(buildPath, 'vendor');
 
-    const contentScriptPath = path.join(vendorPath, 'trezor-content-script.js');
-    const backgroundScriptPath = path.join(rootPath, 'background.js');
-
     fs.rmSync(buildPath, { recursive: true, force: true });
     if (!fs.existsSync(buildPath)) {
         fs.mkdirSync(buildPath);
@@ -47,8 +44,6 @@ rootPaths.forEach(dir => {
     if (!fs.existsSync(vendorPath)) {
         fs.mkdirSync(vendorPath);
     }
-
-    const srcPath = path.join(__dirname, '../connect-web');
 
     if (npmSrc) {
         fetch(npmSrc).then(res => {

--- a/packages/connect-examples/webextension-mv3-sw/README.md
+++ b/packages/connect-examples/webextension-mv3-sw/README.md
@@ -12,6 +12,7 @@ Run the commands below in order to get the webextension ready to be loaded in th
 -   `yarn build:libs`
 -   `yarn workspace @trezor/connect-webextension build`
 -   `node packages/connect-examples/update-webextensions-sw.js`
+-   `yarn workspace @trezor/connect-iframe build:core-module`
 -   `yarn workspace @trezor/connect-popup dev`
 
 This extension is super simple and only reacts to "reload" button.

--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -41,7 +41,7 @@ import { isPhishingDomain } from './utils/isPhishingDomain';
 import { initLog, setLogWriter, LogWriter } from '@trezor/connect/lib/utils/debug';
 
 const log = initLog('@trezor/connect-popup');
-let logWriterProxy: LogWriter | undefined;
+const proxyLogger = initLog('@trezor/connect-webextension');
 
 let handshakeTimeout: ReturnType<typeof setTimeout>;
 let renderConnectUIPromise: Promise<void> | undefined;
@@ -205,13 +205,6 @@ const handleInitMessage = (event: MessageEvent<PopupEvent | IFrameLogRequest>) =
         return;
     }
 
-    if (data.type === IFRAME.LOG) {
-        if (logWriterProxy) {
-            logWriterProxy.add(data.payload);
-        }
-        return;
-    }
-
     // This is message from the window.opener
     if (data.type === POPUP.INIT) {
         init(escapeHtml(data.payload));
@@ -288,14 +281,6 @@ const handleMessageInCoreMode = (
 
     if (disposed) return;
 
-    if (data.type === IFRAME.LOG) {
-        if (logWriterProxy) {
-            logWriterProxy.add(data.payload);
-        }
-
-        return;
-    }
-
     if (data.type === POPUP.HANDSHAKE) {
         handshake(data, getState().settings?.origin || '');
         const core = ensureCore();
@@ -329,6 +314,22 @@ const handleMessageInCoreMode = (
     handleUIAffectingMessage(message);
 };
 
+const handleLogMessage = (event: MessageEvent<IFrameLogRequest>) => {
+    const { data } = event;
+    if (!data) return;
+
+    if (data.type === IFRAME.LOG) {
+        proxyLogger.addMessage(
+            {
+                level: data.payload.level,
+                prefix: data.payload.prefix,
+                timestamp: data.payload.timestamp,
+            },
+            ...data.payload.message,
+        );
+    }
+};
+
 // handle POPUP.INIT message from window.opener
 const init = async (payload: PopupInit['payload']) => {
     log.debug('popup init', payload);
@@ -356,7 +357,6 @@ const init = async (payload: PopupInit['payload']) => {
         if (payload.settings.sharedLogger !== false) {
             logWriterFactory = initLogWriterWithSrcPath('./workers/shared-logger-worker.js');
             setLogWriter(logWriterFactory);
-            logWriterProxy = logWriterFactory();
         }
 
         if (payload.useCore) {
@@ -513,6 +513,7 @@ const fail = (error: ErrorViewProps) => {
 
 addWindowEventListener('load', onLoad, false);
 addWindowEventListener('message', handleInitMessage, false);
+addWindowEventListener('message', handleLogMessage, false);
 
 // global method used in html-inline elements
 // @ts-expect-error not defined in window

--- a/packages/connect-webextension/src/contentScript.ts
+++ b/packages/connect-webextension/src/contentScript.ts
@@ -39,7 +39,7 @@ channel.init().then(() => {
             return;
         }
         if (event.source === window && event.data) {
-            channel.postMessage(event.data, false);
+            channel.postMessage(event.data, { usePromise: false });
         }
     });
 });

--- a/packages/connect-webextension/src/index.ts
+++ b/packages/connect-webextension/src/index.ts
@@ -41,7 +41,7 @@ const logWriterFactory = (popupManager: popup.PopupManager): LogWriter => ({
                 type: IFRAME.LOG,
                 payload: message,
             },
-            false,
+            { usePromise: false, useQueue: true },
         );
     },
 });
@@ -75,9 +75,8 @@ const init = (settings: Partial<ConnectSettings> = {}): Promise<void> => {
     _settings = parseConnectSettings({ ..._settings, ...settings });
     if (!_popupManager) {
         _popupManager = new popup.PopupManager(_settings, { logger: popupManagerLogger });
+        setLogWriter(() => logWriterFactory(_popupManager));
     }
-
-    setLogWriter(() => logWriterFactory(_popupManager));
 
     logger.enabled = !!settings.debug;
 

--- a/packages/connect/src/utils/debug.ts
+++ b/packages/connect/src/utils/debug.ts
@@ -10,6 +10,7 @@ const colors: Record<string, string> = {
     // blue, npm package related
     '@trezor/connect': `color: ${blue}; background: #000;`,
     '@trezor/connect-web': `color: ${blue}; background: #000;`,
+    '@trezor/connect-webextension': `color: ${blue}; background: #000;`,
     // orange, api related
     IFrame: `color: ${orange}; background: #000;`,
     Core: `color: ${orange}; background: #000;`,
@@ -53,13 +54,16 @@ export class Log {
         }
     }
 
-    addMessage(level: string, prefix: string, ...args: any[]) {
+    addMessage(
+        { level, prefix, timestamp }: { level: string; prefix: string; timestamp?: number },
+        ...args: any[]
+    ) {
         const message = {
             level,
             prefix,
             css: this.css,
             message: args,
-            timestamp: Date.now(),
+            timestamp: timestamp || Date.now(),
         };
 
         this.messages.push(message);
@@ -83,28 +87,28 @@ export class Log {
     }
 
     log(...args: any[]) {
-        this.addMessage('log', this.prefix, ...args);
+        this.addMessage({ level: 'log', prefix: this.prefix }, ...args);
         if (this.enabled) {
             console.log(`%c${this.prefix}`, this.css, ...args);
         }
     }
 
     error(...args: any[]) {
-        this.addMessage('error', this.prefix, ...args);
+        this.addMessage({ level: 'error', prefix: this.prefix }, ...args);
         if (this.enabled) {
             console.error(`%c${this.prefix}`, this.css, ...args);
         }
     }
 
     warn(...args: any[]) {
-        this.addMessage('warn', this.prefix, ...args);
+        this.addMessage({ level: 'warn', prefix: this.prefix }, ...args);
         if (this.enabled) {
             console.warn(`%c${this.prefix}`, this.css, ...args);
         }
     }
 
     debug(...args: any[]) {
-        this.addMessage('debug', this.prefix, ...args);
+        this.addMessage({ level: 'debug', prefix: this.prefix }, ...args);
         if (this.enabled) {
             if (this.css) {
                 console.log(`%c${this.prefix}`, this.css, ...args);


### PR DESCRIPTION
couple of changes, followup for https://github.com/trezor/trezor-suite/pull/9916

- updated docs
- removed unused code from update webextensions script
- changed logger module to allow better flexibility and extandability. 
- change postMessage to accept `{useQueue: bool,  usePromise}` param
- in connect-popup, log messages are handled by only one event handler now. previously there were 2 which was causing some troubles.