### PR TITLE
Fix/discovery fixes

### DIFF
--- a/suite-native/discovery/src/discoveryMiddleware.ts
+++ b/suite-native/discovery/src/discoveryMiddleware.ts
@@ -28,17 +28,19 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
             deviceModel,
         );
 
-        // On successful authorization, create discovery instance and run.
-        if (deviceActions.authDevice.match(action) && device) {
-            if (isDeviceFirmwareVersionSupported) {
-                dispatch(
-                    startDescriptorPreloadedDiscoveryThunk({
-                        deviceState: action.payload.state,
-                        device,
-                        areTestnetsEnabled,
-                    }),
-                );
-            }
+        // On successful authorization, create discovery instance and run it.
+        if (
+            deviceActions.authDevice.match(action) &&
+            device?.state &&
+            isDeviceFirmwareVersionSupported
+        ) {
+            dispatch(
+                startDescriptorPreloadedDiscoveryThunk({
+                    deviceState: action.payload.state,
+                    device,
+                    areTestnetsEnabled,
+                }),
+            );
         }
 
         // If user enables testnets discovery, run it.

--- a/suite-native/discovery/src/discoveryThunks.ts
+++ b/suite-native/discovery/src/discoveryThunks.ts
@@ -44,7 +44,7 @@ const finishNetworkTypeDiscoveryThunk = createThunk(
             }),
         );
 
-        if (finishedNetworksCount === discovery.networks.length) {
+        if (finishedNetworksCount >= discovery.total) {
             dispatch(removeDiscovery(discovery.deviceState));
         }
     },
@@ -224,13 +224,15 @@ export const createDescriptorPreloadedDiscoveryThunk = createThunk(
             }),
         ).unwrap();
 
+        const discoveryNetworksTotalCount = filterUnavailableNetworks(networks, device).length;
+
         dispatch(
             createDiscovery({
                 deviceState,
                 authConfirm: false,
                 index: 0,
                 status: DiscoveryStatus.IDLE,
-                total: networks.length,
+                total: discoveryNetworksTotalCount,
                 bundleSize: 0,
                 loaded: 0,
                 failed: [],


### PR DESCRIPTION

## Description

12f85e3a2384736814bcb69ac7c834c1d75a0ec3 - Discovery is executed only once after is the device authorization finished and its contain unique device state.

4861b19d85ae325557ac250808b62d8eedbe6471 - Discovery is not removed prematurely anymore. The finish condition was corrected.

