### PR TITLE
chore(suite): token definitions do not bundle connect

### DIFF
--- a/packages/suite/src/actions/wallet/sendFormActions.ts
+++ b/packages/suite/src/actions/wallet/sendFormActions.ts
@@ -1,7 +1,6 @@
 import BigNumber from 'bignumber.js';
 
 import TrezorConnect, { PROTO, SignedTransaction } from '@trezor/connect';
-import { getEthereumDefinitions } from '@trezor/connect/src/api/ethereum/ethereumDefinitions';
 import {
     accountsActions,
     addFakePendingCardanoTxThunk,
@@ -400,11 +399,13 @@ export const signTransaction =
         }
 
         if (account.networkType === 'ethereum' && !isCardanoTx(account, enhancedTxInfo)) {
-            const definitions = await getEthereumDefinitions({
-                chainId: network?.chainId,
-                contractAddress: enhancedTxInfo.token?.contract.substring(2),
-            });
-            enhancedTxInfo.isTokenKnown = !!definitions?.encoded_token;
+            const response = await fetch(
+                `https://data.trezor.io/firmware/eth-definitions/chain-id/${network?.chainId}/token-${enhancedTxInfo.token?.contract
+                    .substring(2)
+                    .toLowerCase()}.dat`,
+            );
+
+            enhancedTxInfo.isTokenKnown = response.ok;
         }
 
         // store formValues and transactionInfo in send reducer to be used by TransactionReviewModal


### PR DESCRIPTION
## Description

- do not use connect method which caused bundling part of connect into suite
- i will make it nicer in #10034, probably i will change it to `HEAD` request, but it does not make sense now as it is fetched for suite and then again for connect so it can use cache
  - I will also try to reuse the url from connect somehow using url package, let's see

## Related Issue

It caused https://github.com/trezor/trezor-suite/pull/9716/files#r1402345320

## Screenshots:
![Screenshot 2023-11-28 at 10 08 33](https://github.com/trezor/trezor-suite/assets/33235762/61fece4a-a6eb-4ca5-bf73-59fb4a9098c1)
