### PR TITLE
chore(ci): fix windows build by installing libudev-dev dependency

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -72,6 +72,7 @@ suite-web build stable codesign:
 .build: &build
   stage: build
   script:
+    - apt-get update && apt-get install -y libudev-dev # required for rebuilding usb native module
     - yarn install --immutable
     - yarn workspace @trezor/suite-desktop build:${platform}
     - ls -la packages/suite-desktop/build-electron


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Fix win CI build (pass on this branch https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/5632214566#L2112, failing in develop https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/5632314750#L4007)


Building win on linux without docker should be possible, but probably need lot of config (adding all needed system dependencies). This fixes the build for now and adding not that many extra seconds to the builds.