### PR TITLE
fix(e2e): outputlabeling test

### DIFF
--- a/packages/suite-web/e2e/tests/metadata/output-labeling.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/output-labeling.test.ts
@@ -15,7 +15,7 @@ describe('Metadata - Output labeling', () => {
     providers.forEach(provider => {
         it(provider, () => {
             const targetEl1 =
-                '@metadata/outputLabel/9f472739fa7034dfb9736fa4d98915f2e8ddf70a86ee5e0a9ac0634f8c1d0007-0/add-label-button';
+                '@metadata/outputLabel/1d7a8556bb5bda4895596c52017b98c9af29eda10770865e845d3848aa222d1c-0/add-label-button';
             // prepare test
             cy.task('startEmu', { wipe: true });
             cy.task('setupEmu', {


### PR DESCRIPTION
seems like there are more txs now and tests are looking for some element which has been moved to the next page. 

this is of course something that needs to be addressed better (swithching to using local regtest will do, cc @trezor/qa).

also please check on tx pagination, I believe it might be broken. what I observed

Page 1:
- ..txs
- tx A
- tx B

Page 2:
- tx A
- tx B
- ...tsx

seems that 2 txs are duplicated at the botton of one page and at the top of the following one. cc @trezor/qa