### PR TITLE
Fix/message system renderer

### DIFF
--- a/suite-native/app/src/App.tsx
+++ b/suite-native/app/src/App.tsx
@@ -13,7 +13,7 @@ import { FormatterProvider } from '@suite-common/formatters';
 import { AlertRenderer } from '@suite-native/alerts';
 import { NavigationContainerWithAnalytics } from '@suite-native/navigation';
 import { AuthenticatorProvider } from '@suite-native/biometrics';
-import { MessageSystemRenderer } from '@suite-native/message-system';
+import { FeatureMessageScreen, MessageSystemBannerRenderer } from '@suite-native/message-system';
 import { IntlProvider } from '@suite-native/intl';
 import { ScreenshotProvider, ScreenshotCapturer } from '@suite-native/screen-overlay';
 
@@ -55,24 +55,28 @@ const AppComponent = () => {
     if (!isAppReady) return null;
 
     return (
-        <FormatterProvider config={formattersConfig}>
-            <ScreenshotProvider>
-                <AuthenticatorProvider>
-                    <AlertRenderer>
-                        {/* Notifications are disabled until the problem with after-import notifications flooding is solved. */}
-                        {/* More here: https://github.com/trezor/trezor-suite/issues/7721  */}
-                        {/* <NotificationRenderer> */}
-                        <ToastRenderer>
-                            <ScreenshotCapturer>
-                                <MessageSystemRenderer />
-                                <RootStackNavigator />
-                            </ScreenshotCapturer>
-                        </ToastRenderer>
-                        {/* </NotificationRenderer> */}
-                    </AlertRenderer>
-                </AuthenticatorProvider>
-            </ScreenshotProvider>
-        </FormatterProvider>
+        <>
+            <FormatterProvider config={formattersConfig}>
+                <ScreenshotProvider>
+                    <AuthenticatorProvider>
+                        <AlertRenderer>
+                            {/* Notifications are disabled until the problem with after-import notifications flooding is solved. */}
+                            {/* More here: https://github.com/trezor/trezor-suite/issues/7721  */}
+                            {/* <NotificationRenderer> */}
+                            <ToastRenderer>
+                                <ScreenshotCapturer>
+                                    <MessageSystemBannerRenderer />
+                                    <RootStackNavigator />
+                                </ScreenshotCapturer>
+                            </ToastRenderer>
+                            {/* </NotificationRenderer> */}
+                        </AlertRenderer>
+                    </AuthenticatorProvider>
+                </ScreenshotProvider>
+            </FormatterProvider>
+            {/* NOTE: Rendered as last item so that it covers the whole app screen */}
+            <FeatureMessageScreen />
+        </>
     );
 };
 

--- a/suite-native/app/src/App.tsx
+++ b/suite-native/app/src/App.tsx
@@ -59,17 +59,16 @@ const AppComponent = () => {
             <ScreenshotProvider>
                 <AuthenticatorProvider>
                     <AlertRenderer>
-                        <MessageSystemRenderer>
-                            {/* Notifications are disabled until the problem with after-import notifications flooding is solved. */}
-                            {/* More here: https://github.com/trezor/trezor-suite/issues/7721  */}
-                            {/* <NotificationRenderer> */}
-                            <ToastRenderer>
-                                <ScreenshotCapturer>
-                                    <RootStackNavigator />
-                                </ScreenshotCapturer>
-                            </ToastRenderer>
-                            {/* </NotificationRenderer> */}
-                        </MessageSystemRenderer>
+                        {/* Notifications are disabled until the problem with after-import notifications flooding is solved. */}
+                        {/* More here: https://github.com/trezor/trezor-suite/issues/7721  */}
+                        {/* <NotificationRenderer> */}
+                        <ToastRenderer>
+                            <ScreenshotCapturer>
+                                <MessageSystemRenderer />
+                                <RootStackNavigator />
+                            </ScreenshotCapturer>
+                        </ToastRenderer>
+                        {/* </NotificationRenderer> */}
                     </AlertRenderer>
                 </AuthenticatorProvider>
             </ScreenshotProvider>

--- a/suite-native/message-system/src/components/FeatureMessageScreen.tsx
+++ b/suite-native/message-system/src/components/FeatureMessageScreen.tsx
@@ -1,27 +1,28 @@
 import { Linking } from 'react-native';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { A, G } from '@mobily/ts-belt';
 
 import { IconName } from '@suite-common/icons/src';
 import { Box, Button, Pictogram, PictogramVariant, VStack } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
-import { Message, Variant } from '@suite-common/suite-types';
-import { messageSystemActions } from '@suite-common/message-system';
+import { Variant } from '@suite-common/suite-types';
+import { messageSystemActions, selectActiveFeatureMessages } from '@suite-common/message-system';
 import { useTranslate } from '@suite-native/intl';
-import { Screen } from '@suite-native/navigation';
-
-type MessageScreenProps = {
-    message: Message;
-};
 
 const screenStyle = prepareNativeStyle(utils => ({
+    flexGrow: 1,
     justifyContent: 'center',
     alignItems: 'center',
     paddingHorizontal: utils.spacings.large,
-    marginBottom: utils.spacings.extraLarge,
-    flexGrow: 1,
     paddingTop: utils.spacings.xxl,
+    paddingBottom: utils.spacings.extraLarge,
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: utils.colors.backgroundSurfaceElevation0,
 }));
 
 const contentStyle = prepareNativeStyle(_ => ({
@@ -45,10 +46,16 @@ const iconVariantMap = {
     critical: 'warningTriangleLight',
 } as const satisfies Record<Variant, IconName>;
 
-export const MessageScreen = ({ message }: MessageScreenProps) => {
-    const { applyStyle } = useNativeStyles();
+export const FeatureMessageScreen = () => {
     const dispatch = useDispatch();
+
+    const activeFeatureMessages = useSelector(selectActiveFeatureMessages);
+    const firstFeatureMessage = A.head(activeFeatureMessages);
+
+    const { applyStyle } = useNativeStyles();
     const { translate } = useTranslate();
+
+    if (!firstFeatureMessage) return null;
 
     const {
         id: messageId,
@@ -59,7 +66,7 @@ export const MessageScreen = ({ message }: MessageScreenProps) => {
         dismissible: isDismissable,
         category,
         feature,
-    } = message;
+    } = firstFeatureMessage;
 
     const isKillswitch = A.isNotEmpty(
         feature?.filter(item => item.domain === 'killswitch' && item.flag) ?? [],
@@ -101,35 +108,29 @@ export const MessageScreen = ({ message }: MessageScreenProps) => {
     const defaultContent = isKillswitch ? translate('messageSystem.killswitch.content') : undefined;
 
     return (
-        <Screen>
-            <Box style={applyStyle(screenStyle)}>
-                <Box style={applyStyle(contentStyle)}>
-                    <Pictogram
-                        title={messageTitle ?? defaultTitle}
-                        variant={variantMap[variant]}
-                        subtitle={messageContent ?? defaultContent}
-                        icon={iconVariantMap[variant]}
-                        titleVariant="titleMedium"
-                    />
-                </Box>
-
-                <VStack spacing="medium" style={applyStyle(buttonsWrapperStyle)}>
-                    {isCtaVisible && (
-                        <Button size="large" colorScheme="primary" onPress={handleCtaPress}>
-                            {ctaLabel}
-                        </Button>
-                    )}
-                    {isDismissable && (
-                        <Button
-                            size="large"
-                            colorScheme="tertiaryElevation0"
-                            onPress={handleDismiss}
-                        >
-                            {translate('generic.buttons.dismiss')}
-                        </Button>
-                    )}
-                </VStack>
+        <Box style={applyStyle(screenStyle)}>
+            <Box style={applyStyle(contentStyle)}>
+                <Pictogram
+                    title={messageTitle ?? defaultTitle}
+                    variant={variantMap[variant]}
+                    subtitle={messageContent ?? defaultContent}
+                    icon={iconVariantMap[variant]}
+                    titleVariant="titleMedium"
+                />
             </Box>
-        </Screen>
+
+            <VStack spacing="medium" style={applyStyle(buttonsWrapperStyle)}>
+                {isCtaVisible && (
+                    <Button size="large" colorScheme="primary" onPress={handleCtaPress}>
+                        {ctaLabel}
+                    </Button>
+                )}
+                {isDismissable && (
+                    <Button size="large" onPress={handleDismiss}>
+                        {translate('generic.buttons.dismiss')}
+                    </Button>
+                )}
+            </VStack>
+        </Box>
     );
 };

--- a/suite-native/message-system/src/components/MessageSystemBannerRenderer.tsx
+++ b/suite-native/message-system/src/components/MessageSystemBannerRenderer.tsx
@@ -1,14 +1,9 @@
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useSelector } from 'react-redux';
 
-import { A } from '@mobily/ts-belt';
-
-import { Box, VStack } from '@suite-native/atoms';
+import { VStack } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
-import {
-    selectActiveBannerMessages,
-    selectActiveFeatureMessages,
-} from '@suite-common/message-system';
+import { selectActiveBannerMessages } from '@suite-common/message-system';
 
 import { MessageBanner } from './MessageBanner';
 
@@ -18,13 +13,11 @@ const messageBannerContainerStyle = prepareNativeStyle<{ topSafeAreaInset: numbe
     }),
 );
 
-export const MessageSystemRenderer = () => {
+export const MessageSystemBannerRenderer = () => {
     const { applyStyle } = useNativeStyles();
     const { top: topSafeAreaInset } = useSafeAreaInsets();
 
     const activeBannerMessages = useSelector(selectActiveBannerMessages);
-    const activeFeatureMessages = useSelector(selectActiveFeatureMessages);
-    const firstFeatureMessage = A.head(activeFeatureMessages);
 
     return (
         <VStack

--- a/suite-native/message-system/src/components/MessageSystemRenderer.tsx
+++ b/suite-native/message-system/src/components/MessageSystemRenderer.tsx
@@ -1,4 +1,3 @@
-import { ReactNode } from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useSelector } from 'react-redux';
 
@@ -12,7 +11,6 @@ import {
 } from '@suite-common/message-system';
 
 import { MessageBanner } from './MessageBanner';
-import { MessageScreen } from './MessageScreen';
 
 const messageBannerContainerStyle = prepareNativeStyle<{ topSafeAreaInset: number }>(
     (_, { topSafeAreaInset }) => ({
@@ -20,19 +18,7 @@ const messageBannerContainerStyle = prepareNativeStyle<{ topSafeAreaInset: numbe
     }),
 );
 
-const messageFeatureContainerStyle = prepareNativeStyle(_ => ({
-    position: 'absolute',
-    left: 0,
-    top: 0,
-    right: 0,
-    bottom: 0,
-}));
-
-type MessageSystemRendererProps = {
-    children: ReactNode;
-};
-
-export const MessageSystemRenderer = ({ children }: MessageSystemRendererProps) => {
+export const MessageSystemRenderer = () => {
     const { applyStyle } = useNativeStyles();
     const { top: topSafeAreaInset } = useSafeAreaInsets();
 
@@ -41,25 +27,15 @@ export const MessageSystemRenderer = ({ children }: MessageSystemRendererProps) 
     const firstFeatureMessage = A.head(activeFeatureMessages);
 
     return (
-        <Box flex={1}>
-            {children}
-            <Box
-                style={applyStyle(messageBannerContainerStyle, {
-                    topSafeAreaInset,
-                })}
-            >
-                <VStack spacing="extraSmall">
-                    {activeBannerMessages.map(message => (
-                        <MessageBanner key={message.id} message={message} />
-                    ))}
-                </VStack>
-            </Box>
-            {/* Put feature screen over everything else */}
-            {firstFeatureMessage && (
-                <Box style={applyStyle(messageFeatureContainerStyle)}>
-                    <MessageScreen message={firstFeatureMessage} />
-                </Box>
-            )}
-        </Box>
+        <VStack
+            spacing={4}
+            style={applyStyle(messageBannerContainerStyle, {
+                topSafeAreaInset,
+            })}
+        >
+            {activeBannerMessages.map(message => (
+                <MessageBanner key={message.id} message={message} />
+            ))}
+        </VStack>
     );
 };

--- a/suite-native/message-system/src/index.ts
+++ b/suite-native/message-system/src/index.ts
@@ -1,2 +1,3 @@
 export * from './messageSystemMiddleware';
-export * from './components/MessageSystemRenderer';
+export * from './components/MessageSystemBannerRenderer';
+export * from './components/FeatureMessageScreen';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- separate `MessageSystemRenderer` and `FeatureMessageScreen`. Makes more sense to have them separate so that we don't have to use weird hacks, using `Screen` component etc
- `MessageSystemRenderer` is now rendered as a sibling to the `RootStackNavigator`
- `FeatureMessageScreen` is rendered as last element inside JSX of `App.tsx` so it's utilizing higher `zIndex` value (rather is layered on top of the app)
- Dismiss button inside `FeatureMessageScreen` now has a correct color scheme to be according to design

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/9970

## Screenshots:
