### PR TITLE
tests: switch to fw main branch

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -127,7 +127,7 @@ suite web canary fws:
     refs:
       - schedules
   variables:
-    FIRMWARE: 2-master
+    FIRMWARE: 2-main
 
 suite web canary fws manual:
   extends: .suite web base
@@ -137,7 +137,7 @@ suite web canary fws manual:
       - schedules
   when: manual
   variables:
-    FIRMWARE: 2-master
+    FIRMWARE: 2-main
 
 # TODO scheduled jobs against beta chrome channel
 # TODO scheduled jobs against suite.trezor.io
@@ -441,7 +441,7 @@ connect legacy fws manual:
   extends: .connect matrix
   stage: canary testing
   variables:
-    TESTS_FIRMWARE: "2-master"
+    TESTS_FIRMWARE: "2-main"
 
 connect canary fws:
   extends: .connect canary fws base

--- a/docker/docker-connect-test.sh
+++ b/docker/docker-connect-test.sh
@@ -34,7 +34,7 @@ show_usage() {
   echo "  -d       Disable docker. Useful when running own instance of trezor-user-env. default: enabled"
   echo "  -D PATH  Set path to docker executable. Can be replaced with \`podman\`. default: docker"
   echo "  -e       All methods except excluded, example: applySettings,signTransaction"
-  echo "  -f       Use specific firmware version, example: 2.1.4, 1.8.0 default: 2-master"
+  echo "  -f       Use specific firmware version, example: 2.1.4, 1.8.0 default: 2-main"
   echo "  -i       Included methods only, example: applySettings,signTransaction"
   echo "  -s       actual test script. default: 'yarn test:integration'"
   echo "  -u       Firmware url"

--- a/packages/connect/e2e/__fixtures__/stellarSignTransaction.ts
+++ b/packages/connect/e2e/__fixtures__/stellarSignTransaction.ts
@@ -149,7 +149,7 @@ const legacyResultsMap: Record<string, LegacyResult[]> = {
             rules: ['<2.4.3'],
             payload: {
                 publicKey: '2f22b9c62f08b774f3ebe6dd6e7db93c3ec2cbde0279561a3d9c5225b8c32292',
-                // signature is different in 2.4.2 from what we get from 2-master
+                // signature is different in 2.4.2 from what we get from 2-main
                 signature:
                     '864eb69e7ecb30b0a27112742716ccfedf38167a78ffdb1890bd4d473f2ab4850f3e6e5523d88dfad7b7b308369406d69abb9ecaf8dfb7a87ed4e8b57bfc2201',
             },

--- a/packages/connect/e2e/common.setup.js
+++ b/packages/connect/e2e/common.setup.js
@@ -132,7 +132,7 @@ const initTrezorConnect = async (TrezorUserEnvLink, options) => {
 const skipTest = rules => {
     if (!rules || !Array.isArray(rules)) return;
     const fwModel = firmware.substring(0, 1);
-    const fwMaster = firmware.includes('-master');
+    const fwMaster = firmware.includes('-main');
     const rule = rules
         .filter(skip => skip.substring(0, 1) === fwModel || skip.substring(1, 2) === fwModel) // filter rules only for current model
         .find(skip => {

--- a/packages/suite-desktop-core/e2e/tests/coinjoin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/coinjoin.test.ts
@@ -115,7 +115,7 @@ testPlaywright.describe('Coinjoin', () => {
         await TrezorUserEnvLink.api.trezorUserEnvConnect();
         await waitForCoinjoinBackend();
         await TrezorUserEnvLink.api.stopBridge();
-        await TrezorUserEnvLink.api.startEmu({ wipe: true, version: '2-master' });
+        await TrezorUserEnvLink.api.startEmu({ wipe: true, version: '2-main' });
         await TrezorUserEnvLink.api.setupEmu({
             needs_backup: false,
             passphrase_protection: true,

--- a/packages/suite-web/e2e/tests/metadata/account-metadata.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/account-metadata.test.ts
@@ -8,14 +8,14 @@ const fixtures = [
     {
         provider: 'dropbox',
         numberOfRequests: {
-            '2-master': [25, 27],
+            '2-main': [25, 27],
             legacy: [25, 26],
         },
     },
     {
         provider: 'google',
         numberOfRequests: {
-            '2-master': [9, 12],
+            '2-main': [9, 12],
             legacy: [9, 12],
         },
     },

--- a/packages/suite-web/e2e/tests/metadata/wallet-metadata.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/wallet-metadata.test.ts
@@ -3,7 +3,7 @@
 
 import { rerouteMetadataToMockProvider, stubOpen } from '../../stubs/metadata';
 
-const firmwares = ['2.2.0', '2-master'] as const;
+const firmwares = ['2.2.0', '2-main'] as const;
 const provider = 'dropbox';
 
 const mnemonic = 'all all all all all all all all all all all all';

--- a/packages/suite-web/e2e/tests/settings/t2b1-device-settings.test.ts
+++ b/packages/suite-web/e2e/tests/settings/t2b1-device-settings.test.ts
@@ -9,7 +9,7 @@
 
 describe('T2B1 - Device settings', () => {
     const startEmuOpts = {
-        version: '2-master',
+        version: '2-main',
         model: 'R', // TODO: T2B1 DeviceModelInternal
         wipe: true,
     };

--- a/packages/suite-web/e2e/tests/settings/t2t1-device-settings.test.ts
+++ b/packages/suite-web/e2e/tests/settings/t2t1-device-settings.test.ts
@@ -90,7 +90,7 @@ describe('T2T1 - Device settings', () => {
     });
 
     it('able to change homescreen in firmware >= 2.5.4', () => {
-        cy.task('startEmu', { wipe: true, version: '2-master' });
+        cy.task('startEmu', { wipe: true, version: '2-main' });
         cy.task('setupEmu');
 
         cy.prefixedVisit('/settings/device');

--- a/packages/transport/e2e/tests/bridge.test.ts
+++ b/packages/transport/e2e/tests/bridge.test.ts
@@ -18,7 +18,7 @@ const emulatorSetupOpts = {
     needs_backup: true,
 };
 
-const emulatorStartOpts = { version: '2-master', wipe: true };
+const emulatorStartOpts = { version: '2-main', wipe: true };
 
 describe('bridge', () => {
     beforeAll(async () => {

--- a/packages/transport/e2e/tests/events.test.ts
+++ b/packages/transport/e2e/tests/events.test.ts
@@ -34,7 +34,7 @@ const getDescriptor = (descriptor: any): Descriptor => ({
     ...descriptor,
 });
 
-const emulatorStartOpts = { version: '2-master', wipe: true };
+const emulatorStartOpts = { version: '2-main', wipe: true };
 
 describe('bridge', () => {
     let bridge1: BridgeTransport;


### PR DESCRIPTION
trezor-firmware has switched from master branch to main branch some time ago. this has already been reflected on trezor-user-env as well. Now its only us being the stain on proper PC culture. Lest change it!

connect tests refuse to work with main https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/5638873047#L2990 so we need to switch asap.

green pipeline with almost all tests running https://gitlab.com/satoshilabs/trezor/trezor-suite/-/pipelines/1089219148