### PR TITLE
Explicitly set `en-US` as a locale for unit tests

### DIFF
--- a/packages/suite/jest.config.js
+++ b/packages/suite/jest.config.js
@@ -1,5 +1,6 @@
 // all tests have same UTC timezone
 process.env.TZ = 'UTC';
+process.env.LANG = 'en-US';
 
 const babelConfig = {
     presets: [


### PR DESCRIPTION
## Description

When running unit tests on a PC with different locale than `en-US`, some of them could fail. This fixed it, at least for me.
