### PR TITLE
fix(cardano): set-max output

### DIFF
--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -51,7 +51,7 @@
     "dependencies": {
         "@ethereumjs/common": "^3.1.2",
         "@ethereumjs/tx": "^4.1.2",
-        "@fivebinaries/coin-selection": "2.2.0",
+        "@fivebinaries/coin-selection": "2.2.1",
         "@trezor/blockchain-link": "workspace:*",
         "@trezor/blockchain-link-types": "workspace:*",
         "@trezor/connect-analytics": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2193,17 +2193,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emurgo/cardano-serialization-lib-browser@npm:^11.0.0":
-  version: 11.1.0
-  resolution: "@emurgo/cardano-serialization-lib-browser@npm:11.1.0"
-  checksum: b2182e35296d8239d7c1bc6d5b3e8b6b5dec4838372df6bceb5f49c140adf9e2c004751a7d2c76acf8f2fd87343cc4be5f411e9d8eaa9342559c178b9d54922d
+"@emurgo/cardano-serialization-lib-browser@npm:^11.5.0":
+  version: 11.5.0
+  resolution: "@emurgo/cardano-serialization-lib-browser@npm:11.5.0"
+  checksum: e4d74d20a59ebc20671363fa357c526c10f2f13c9f36fd34b2d269f1c6f3d637be62fe31ea89641cd90a1410aaf5f9613dfe7f3e616cff606ea8f63a7296ecb3
   languageName: node
   linkType: hard
 
-"@emurgo/cardano-serialization-lib-nodejs@npm:11.0.0":
-  version: 11.0.0
-  resolution: "@emurgo/cardano-serialization-lib-nodejs@npm:11.0.0"
-  checksum: 9809436e6df1c4d3f7a7df87ede2cf84f5ab75e284dc5ef85be082cc3c719ab2382ae3c05126d754fdf2c3a0b4e079d9c22da5a2abc771b87dc8d92505f4afb4
+"@emurgo/cardano-serialization-lib-nodejs@npm:11.5.0":
+  version: 11.5.0
+  resolution: "@emurgo/cardano-serialization-lib-nodejs@npm:11.5.0"
+  checksum: 3fff8448001c6d70807ef8e1a80a663ef60381e55bfd26c0f1b644e096895da7298fb991ac86670d4c5aee2e3e417e44ac80ab59080f7af107d8fa89906f9075
   languageName: node
   linkType: hard
 
@@ -2996,13 +2996,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fivebinaries/coin-selection@npm:2.2.0":
-  version: 2.2.0
-  resolution: "@fivebinaries/coin-selection@npm:2.2.0"
+"@fivebinaries/coin-selection@npm:2.2.1":
+  version: 2.2.1
+  resolution: "@fivebinaries/coin-selection@npm:2.2.1"
   dependencies:
-    "@emurgo/cardano-serialization-lib-browser": "npm:^11.0.0"
-    "@emurgo/cardano-serialization-lib-nodejs": "npm:11.0.0"
-  checksum: 49a1b508f2cf0f9ee0d3dcfc069433063a072eb73fb3bb11651605a6e2999a57095b565989799b029c3eab55c94c398df623f42a0266e701dd353d9b301a2585
+    "@emurgo/cardano-serialization-lib-browser": "npm:^11.5.0"
+    "@emurgo/cardano-serialization-lib-nodejs": "npm:11.5.0"
+  checksum: 3b5a45c9cf978978f96b781a994faf3e09d3cfe88f4f337205385caa1ba11f117d67fc059f09674a2a8064ccdde66bed69a2cb1182686bf83cbb9bdb13365d47
   languageName: node
   linkType: hard
 
@@ -8839,7 +8839,7 @@ __metadata:
   dependencies:
     "@ethereumjs/common": "npm:^3.1.2"
     "@ethereumjs/tx": "npm:^4.1.2"
-    "@fivebinaries/coin-selection": "npm:2.2.0"
+    "@fivebinaries/coin-selection": "npm:2.2.1"
     "@trezor/blockchain-link": "workspace:*"
     "@trezor/blockchain-link-types": "workspace:*"
     "@trezor/connect-analytics": "workspace:*"


### PR DESCRIPTION
## Description
Cardano coin-selection lib had a bug that occasionally while using set-max functionality, caused an incorrect calculation of the amount available for spending, resulting in an error "Not enough funds". The bug has been fixed in `@fivebinaries/coin-selection@2.2.1`. This PR bumps the dependency.

https://github.com/fivebinaries/coin-selection/pull/29

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/9888

