### PR TITLE
fix(suite-native): ADA xpub is not displayed as receive address

### DIFF
--- a/suite-native/discovery/src/discoveryThunks.ts
+++ b/suite-native/discovery/src/discoveryThunks.ts
@@ -75,7 +75,7 @@ const discoverAccountsByDescriptorThunk = createThunk(
                 coin: bundleItem.coin,
                 descriptor: bundleItem.descriptor,
                 useEmptyPassphrase: true,
-                details: 'tokenBalances',
+                details: 'txs',
             });
 
             if (success) {

--- a/suite-native/module-accounts-import/src/screens/AccountImportLoadingScreen.tsx
+++ b/suite-native/module-accounts-import/src/screens/AccountImportLoadingScreen.tsx
@@ -67,7 +67,7 @@ export const AccountImportLoadingScreen = ({
                 TrezorConnect.getAccountInfo({
                     coin: networkSymbol,
                     descriptor: xpubAddress,
-                    details: 'tokenBalances',
+                    details: 'txs',
                     suppressBackupWarning: true,
                 }),
                 dispatch(


### PR DESCRIPTION
## Description

- during the importing/discovering account, we also fetch the receive addresses and transactions from the backend
- as a result, the ADA xpub is not showed anymore in the receive flow
## Related Issue

Resolve #9862
Resolve #10037

