### PR TITLE
fix(connect-popup): only send to parent when in core mode

### DIFF
--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -150,7 +150,10 @@ export const handleUIAffectingMessage = (message: CoreMessage) => {
 
 const handleResponseEvent = (data: any) => {
     if (data.type === RESPONSE_EVENT) {
-        postMessageToParent(data);
+        if (getState().core) {
+            // If we send this event to parent when iframe mode it gets duplicated in connect-web.
+            postMessageToParent(data);
+        }
 
         // When success we can close popup.
         if (data.success) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The issue described in https://github.com/trezor/trezor-suite/issues/10121 was that RESPONSE_EVENTS were duplicated in connect-web and that is why it did not know about the second one that was sent from popup. If I understand well the concept of core and iframe mode I would say that sending response events from popup to parent is only required in core mode, but I might be wrong, it would be nice your opinion @mroz22 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/10121