### PR TITLE
fix(suite): coins section crash when no fw

### DIFF
--- a/packages/suite/src/components/suite/CoinList/CoinList.tsx
+++ b/packages/suite/src/components/suite/CoinList/CoinList.tsx
@@ -58,6 +58,7 @@ export const CoinList = ({
                 const firmwareSupportRestriction =
                     deviceModelInternal && support?.[deviceModelInternal];
                 const isSupportedByApp =
+                    !firmwareVersion ||
                     !firmwareSupportRestriction ||
                     versionUtils.isNewerOrEqual(firmwareVersion, firmwareSupportRestriction);
 

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -616,6 +616,7 @@ export const selectSupportedNetworks = (state: DeviceRootState) => {
             const firmwareSupportRestriction =
                 deviceModelInternal && support?.[deviceModelInternal];
             const isSupportedByApp =
+                !firmwareVersion ||
                 !firmwareSupportRestriction ||
                 versionUtils.isNewerOrEqual(firmwareVersion, firmwareSupportRestriction);
 
@@ -623,7 +624,15 @@ export const selectSupportedNetworks = (state: DeviceRootState) => {
                 ? device?.unavailableCapabilities?.[symbol]
                 : 'update-required';
 
-            if (['no-support', 'no-capability'].includes(unavailableReason || '')) {
+            // if device does not have fw, do not show coins which are not supported by device in any case
+            if (!firmwareVersion && unavailableReason === 'no-support') {
+                return null;
+            }
+            // if device has fw, do not show coins which are not supported by current fw
+            if (
+                firmwareVersion &&
+                ['no-support', 'no-capability'].includes(unavailableReason || '')
+            ) {
                 return null;
             }
 


### PR DESCRIPTION
## Description

- `deviceReducer`
  - when device has no fw, symbol is supported by the app no matter the fw version
  - when device has no fw, we do not show coins which are not supported by this device at all
- `CoinList` 
  - when device has no fw, symbol is supported by the app no matter the fw version

Tested on T1B1, T2T1, T2B1 when no fw, when in bl mode, when in normal mode, when btc-only. All seems to work

## Related Issue

closes #10035

