### PR TITLE
Fix/multiple discovery runs

### DIFF
--- a/suite-native/device-mutex/src/DeviceAccessMutex.ts
+++ b/suite-native/device-mutex/src/DeviceAccessMutex.ts
@@ -3,7 +3,7 @@
  */
 class DeviceAccessMutex {
     isLocked: boolean;
-    taskQueue: ((value: unknown) => void)[];
+    taskQueue: ((value: boolean) => void)[];
     constructor() {
         this.isLocked = false;
         this.taskQueue = [];
@@ -13,31 +13,31 @@ class DeviceAccessMutex {
         if (this.isLocked) {
             return new Promise(resolve => {
                 // Put prioritized task at the beginning of the queue.
-                this.taskQueue.splice(1, 0, resolve);
+                this.taskQueue.splice(1, 0, () => resolve(true));
             });
         }
         this.isLocked = true;
 
-        return Promise.resolve();
+        return Promise.resolve(true);
     }
 
     lock() {
         if (this.isLocked) {
-            return new Promise(resolve => {
+            return new Promise<boolean>(resolve => {
                 // Put the task at the end of the queue.
                 this.taskQueue.push(resolve);
             });
         }
         this.isLocked = true;
 
-        return Promise.resolve();
+        return Promise.resolve(true);
     }
 
     unlock() {
         const resolve = this.taskQueue.shift();
         if (resolve) {
             // If there is a task in queue, execute it.
-            resolve?.(null);
+            resolve?.(true);
         } else {
             // Otherwise unlock the mutex.
             this.isLocked = false;
@@ -45,6 +45,9 @@ class DeviceAccessMutex {
     }
 
     clearQueue() {
+        // Resolve all tasks of the queue with `false` to indicate that task should not be executed.
+        this.taskQueue.forEach(taskResolver => taskResolver(false));
+
         this.taskQueue = [];
         this.isLocked = false;
     }

--- a/suite-native/device-mutex/src/DeviceAccessMutex.ts
+++ b/suite-native/device-mutex/src/DeviceAccessMutex.ts
@@ -43,6 +43,11 @@ class DeviceAccessMutex {
             this.isLocked = false;
         }
     }
+
+    clearQueue() {
+        this.taskQueue = [];
+        this.isLocked = false;
+    }
 }
 
 export const deviceAccessMutex = new DeviceAccessMutex();

--- a/suite-native/device-mutex/src/constants.ts
+++ b/suite-native/device-mutex/src/constants.ts
@@ -1,0 +1,4 @@
+export const DEVICE_ACCESS_ERROR = {
+    success: false,
+    error: 'Device access failed - device was disconnected.',
+} as const;

--- a/suite-native/device-mutex/src/requestDeviceAccess.ts
+++ b/suite-native/device-mutex/src/requestDeviceAccess.ts
@@ -27,3 +27,7 @@ export const requestPrioritizedDeviceAccess = async <TParams extends unknown[], 
 
     return response;
 };
+
+export const clearAndUnlockDeviceAccessQueue = () => {
+    deviceAccessMutex.clearQueue();
+};

--- a/suite-native/device-mutex/src/requestDeviceAccess.ts
+++ b/suite-native/device-mutex/src/requestDeviceAccess.ts
@@ -1,4 +1,6 @@
 import { deviceAccessMutex } from './DeviceAccessMutex';
+import { DEVICE_ACCESS_ERROR } from './constants';
+import { DeviceAccessResponse } from './types';
 
 /**
  * Puts the callback to the end of the queue and waits for its turn to execute.
@@ -6,12 +8,14 @@ import { deviceAccessMutex } from './DeviceAccessMutex';
 export const requestDeviceAccess = async <TParams extends unknown[], TReturnType>(
     deviceCallback: (...args: TParams) => TReturnType,
     ...callbackParams: TParams
-): Promise<TReturnType> => {
-    await deviceAccessMutex.lock();
+): DeviceAccessResponse<TReturnType> => {
+    const wasLockSuccessful = await deviceAccessMutex.lock();
+    if (!wasLockSuccessful) return DEVICE_ACCESS_ERROR;
+
     const response = await deviceCallback(...callbackParams);
     deviceAccessMutex.unlock();
 
-    return response;
+    return { success: true, payload: response };
 };
 
 /**
@@ -20,12 +24,14 @@ export const requestDeviceAccess = async <TParams extends unknown[], TReturnType
 export const requestPrioritizedDeviceAccess = async <TParams extends unknown[], TReturnType>(
     deviceCallback: (...args: TParams) => TReturnType,
     ...callbackParams: TParams
-): Promise<TReturnType> => {
-    await deviceAccessMutex.prioritizedLock();
+): DeviceAccessResponse<TReturnType> => {
+    const wasLockSuccessful = await deviceAccessMutex.prioritizedLock();
+    if (!wasLockSuccessful) return DEVICE_ACCESS_ERROR;
+
     const response = await deviceCallback(...callbackParams);
     deviceAccessMutex.unlock();
 
-    return response;
+    return { success: true, payload: response };
 };
 
 export const clearAndUnlockDeviceAccessQueue = () => {

--- a/suite-native/device-mutex/src/types.ts
+++ b/suite-native/device-mutex/src/types.ts
@@ -1,0 +1,10 @@
+type DeviceAccessResponseBody<TDeviceCallbackResponse> =
+    | { success: false; error: string }
+    | {
+          success: true;
+          payload: TDeviceCallbackResponse;
+      };
+
+export type DeviceAccessResponse<TDeviceCallbackResponse> = Promise<
+    DeviceAccessResponseBody<Awaited<TDeviceCallbackResponse>>
+>;

--- a/suite-native/device/package.json
+++ b/suite-native/device/package.json
@@ -20,6 +20,7 @@
         "@suite-native/alerts": "workspace:*",
         "@suite-native/analytics": "workspace:*",
         "@suite-native/atoms": "workspace:*",
+        "@suite-native/device-mutex": "workspace:*",
         "@suite-native/feature-flags": "workspace:*",
         "@suite-native/helpers": "workspace:*",
         "@suite-native/intl": "workspace:*",

--- a/suite-native/device/src/deviceThunks.ts
+++ b/suite-native/device/src/deviceThunks.ts
@@ -5,6 +5,7 @@ import {
     selectDevicelessAccounts,
     selectDevicelessDiscoveries,
 } from '@suite-common/wallet-core';
+import { clearAndUnlockDeviceAccessQueue } from '@suite-native/device-mutex';
 
 const actionPrefix = '@suite-native/device';
 
@@ -18,5 +19,8 @@ export const wipeDisconnectedDevicesDataThunk = createThunk(
         devicelessDiscoveries.forEach(discovery =>
             dispatch(discoveryActions.removeDiscovery(discovery.deviceState)),
         );
+
+        // TODO: rename
+        clearAndUnlockDeviceAccessQueue();
     },
 );

--- a/suite-native/device/tsconfig.json
+++ b/suite-native/device/tsconfig.json
@@ -14,6 +14,7 @@
         { "path": "../alerts" },
         { "path": "../analytics" },
         { "path": "../atoms" },
+        { "path": "../device-mutex" },
         { "path": "../feature-flags" },
         { "path": "../helpers" },
         { "path": "../intl" },

--- a/suite-native/discovery/src/discoveryMiddleware.ts
+++ b/suite-native/discovery/src/discoveryMiddleware.ts
@@ -28,34 +28,32 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
             deviceModel,
         );
 
-        // On successful authorization, create discovery instance and run it.
-        if (
-            deviceActions.authDevice.match(action) &&
-            device?.state &&
-            isDeviceFirmwareVersionSupported
-        ) {
-            dispatch(
-                startDescriptorPreloadedDiscoveryThunk({
-                    deviceState: action.payload.state,
-                    device,
-                    areTestnetsEnabled,
-                }),
-            );
-        }
-
         // If user enables testnets discovery, run it.
         if (toggleAreTestnetsEnabled.match(action) && !areTestnetsEnabled && device?.state) {
             if (isDeviceFirmwareVersionSupported) {
                 dispatch(
                     startDescriptorPreloadedDiscoveryThunk({
                         deviceState: device.state,
-                        device,
                         areTestnetsEnabled: true,
                     }),
                 );
             }
         }
 
-        return next(action);
+        // We need to wait until is the `authDevice` action applied, because we need
+        // to know the device state when starting discovery of newly authorized device.
+        next(action);
+
+        // On successful authorization, create discovery instance and run it.
+        if (deviceActions.authDevice.match(action) && isDeviceFirmwareVersionSupported) {
+            dispatch(
+                startDescriptorPreloadedDiscoveryThunk({
+                    deviceState: action.payload.state,
+                    areTestnetsEnabled,
+                }),
+            );
+        }
+
+        return action;
     },
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -7344,6 +7344,7 @@ __metadata:
     "@suite-native/alerts": "workspace:*"
     "@suite-native/analytics": "workspace:*"
     "@suite-native/atoms": "workspace:*"
+    "@suite-native/device-mutex": "workspace:*"
     "@suite-native/feature-flags": "workspace:*"
     "@suite-native/helpers": "workspace:*"
     "@suite-native/intl": "workspace:*"


### PR DESCRIPTION

## Description
- c21772678cc9cc2bad70fc76b463e570c13f4a59 
  - on device disconnect the deviceAccessMutex is cleared, so it is ready to use during the next device connection
- 90079fadda8761a2cf7904edac9da7dc472262d8 
  - authDevice is dispatched only once, so the discovery is not executed multiple times
  - discoveryThunks refactored to not take `device` argument that is selectable from the redux state
## Related Issue

Resolve #10142
