### PR TITLE
feat(wallet-utils): eth account outdated if balance changes

### DIFF
--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -582,7 +582,10 @@ export const isAccountOutdated = (account: Account, freshInfo: AccountInfo) => {
                 freshInfo.misc!.reserve !== account.misc.reserve
             );
         case 'ethereum':
-            return freshInfo.misc!.nonce !== account.misc.nonce;
+            return (
+                freshInfo.misc!.nonce !== account.misc.nonce ||
+                freshInfo.balance !== account.balance // balance can change because of beacon chain txs (staking)
+            );
         case 'cardano':
             return (
                 // stake address (de)registration


### PR DESCRIPTION
## Description

- should resolve not updating an account when user gets a reward from staking
- user will not see a transaction, because it is a beacon chain tx, however his account balance updates

## Related Issue

- closes https://github.com/trezor/trezor-suite/issues/9771
