### PR TITLE
fix(suite-native): add top offset to messages only if they exist

### DIFF
--- a/suite-native/message-system/src/components/MessageSystemBannerRenderer.tsx
+++ b/suite-native/message-system/src/components/MessageSystemBannerRenderer.tsx
@@ -1,6 +1,8 @@
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useSelector } from 'react-redux';
 
+import { A } from '@mobily/ts-belt';
+
 import { VStack } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { selectActiveBannerMessages } from '@suite-common/message-system';
@@ -18,12 +20,12 @@ export const MessageSystemBannerRenderer = () => {
     const { top: topSafeAreaInset } = useSafeAreaInsets();
 
     const activeBannerMessages = useSelector(selectActiveBannerMessages);
-
+    const topInset = A.isNotEmpty(activeBannerMessages) ? topSafeAreaInset : 0;
     return (
         <VStack
             spacing={4}
             style={applyStyle(messageBannerContainerStyle, {
-                topSafeAreaInset,
+                topSafeAreaInset: topInset,
             })}
         >
             {activeBannerMessages.map(message => (


### PR DESCRIPTION
There is an extra top inset added in MessageSystemBannerRenderer. Add this only if there is a message to show. Removes the extra space on top

fixes: #10155

before:
<img src="https://github.com/trezor/trezor-suite/assets/2011829/b94a1ffd-6e0f-4c09-aea3-ce3c191ff169" height="400"/>


after:
<img src="https://github.com/trezor/trezor-suite/assets/2011829/27f286e8-96c3-45fe-a33b-0e4c2f888cf7" height="400"/>
