### PR TITLE
fix(connect-popup): when connect-src not same as host popup display u…

### DIFF
--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -452,9 +452,15 @@ const handshake = (handshake: PopupHandshake, origin: string) => {
 
     clearTimeout(handshakeTimeout);
 
+    let thirdPartyOrigin = origin;
+    // `origin` is empty string when using `BroadcastChannel` in iframe popup mode,
+    // so when that happens we use origin from settings and validate it with `parseConnectSettings`.
+    if (origin === '' && payload.settings.origin) {
+        thirdPartyOrigin = payload.settings.origin;
+    }
     // when this message comes from iframe, settings is already validated.
     // when there is no iframe, we must validate it here
-    const trustedSettings = parseConnectSettings(payload.settings, origin);
+    const trustedSettings = parseConnectSettings(payload.settings, thirdPartyOrigin);
     setState({ settings: trustedSettings });
 
     if (isPhishingDomain(trustedSettings.origin || '')) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When running connect with different source as host popup was displaying unknown origin.

I think this might have a better solution in the origin of the event but still not sure.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/10156

