### PR TITLE
feat(metadata): support multiple providers in metadata actions

### DIFF
--- a/packages/suite/src/actions/suite/__fixtures__/metadataActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/metadataActions.ts
@@ -361,7 +361,7 @@ const addMetadata = [
                 },
                 providers: [
                     {
-                        client: 'clientId',
+                        clientId: 'clientId',
                         type: 'dropbox',
                         user: 'User Name',
                         tokens: { refreshToken: 'oauth-token' },

--- a/packages/suite/src/views/settings/SettingsGeneral/DisconnectLabelingProvider.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/DisconnectLabelingProvider.tsx
@@ -55,7 +55,12 @@ export const DisconnectLabelingProvider = () => {
                 <ActionButton
                     variant="secondary"
                     onClick={() =>
-                        dispatch(disconnectProvider({ clientId: metadata.selectedProvider.labels }))
+                        dispatch(
+                            disconnectProvider({
+                                clientId: metadata.selectedProvider.labels,
+                                dataType: 'labels',
+                            }),
+                        )
                     }
                     data-test="@settings/metadata/disconnect-provider-button"
                 >


### PR DESCRIPTION
cherry-picked from #10162 in which there are still some open questions to be answered. This however should just be pure refactoring aiming at making it possible to work with multiple providers at once. 