### PR TITLE
perf(suite-native): discovery batch size decreased

### DIFF
--- a/suite-native/discovery/src/discoveryThunks.ts
+++ b/suite-native/discovery/src/discoveryThunks.ts
@@ -25,7 +25,7 @@ import { analytics, EventType } from '@suite-native/analytics';
 
 import { fetchBundleDescriptors } from './utils';
 
-const DISCOVERY_BATCH_SIZE = 3;
+const DISCOVERY_BATCH_SIZE = 2;
 
 // Note: This is for analytics purposes
 let discoveryStartTime: number | null = null;


### PR DESCRIPTION
Discovery batch size decreased to 2 accounts per round to improve performance of devices with less accounts.
