### PR TITLE
chore(connect): add option for chunkify on Solana

### DIFF
--- a/docs/packages/connect/methods/solanaGetAddress.md
+++ b/docs/packages/connect/methods/solanaGetAddress.md
@@ -19,6 +19,7 @@ const result = await TrezorConnect.solanaGetAddress(params);
 -   `path` — _required_ `string | Array<number>` minimum length is `2`. [read more](../path.md)
 -   `address` — _required_ `string` address for validation (read `Handle button request` section below)
 -   `showOnTrezor` — _optional_ `boolean` determines if address will be displayed on device. Default is set to `true`
+-   `chunkify` — _optional_ `boolean` determines if address will be displayed in chunks of 4 characters. Default is set to `false`
 
 #### Exporting bundle of addresses
 

--- a/packages/connect/src/api/solana/api/solanaGetAddress.ts
+++ b/packages/connect/src/api/solana/api/solanaGetAddress.ts
@@ -39,6 +39,7 @@ export default class SolanaGetAddress extends AbstractMethod<'solanaGetAddress',
                 { name: 'path', required: true },
                 { name: 'address', type: 'string' },
                 { name: 'showOnTrezor', type: 'boolean' },
+                { name: 'chunkify', type: 'boolean' },
             ]);
 
             const path = validatePath(batch.path, 2);
@@ -46,6 +47,7 @@ export default class SolanaGetAddress extends AbstractMethod<'solanaGetAddress',
                 address_n: path,
                 address: batch.address,
                 show_display: typeof batch.showOnTrezor === 'boolean' ? batch.showOnTrezor : true,
+                chunkify: typeof batch.chunkify === 'boolean' ? batch.chunkify : false,
             };
         });
 
@@ -124,11 +126,12 @@ export default class SolanaGetAddress extends AbstractMethod<'solanaGetAddress',
         return uiResp.payload;
     }
 
-    async _call({ address_n, show_display }: Params) {
+    async _call({ address_n, show_display, chunkify }: Params) {
         const cmd = this.device.getCommands();
         const response = await cmd.typedCall('SolanaGetAddress', 'SolanaAddress', {
             address_n,
             show_display,
+            chunkify,
         });
         return response.message;
     }


### PR DESCRIPTION
## Description

Followup for #9671.

Add support of chunkify also for Solana. Right now FW supports it just in `getAddress` (reveal) method for Solana.

## Screenshots:
![F83AD5EF-FE39-4268-9FA2-B21E7E9A08F5](https://github.com/trezor/trezor-suite/assets/66002635/1163cea7-5ea0-4c37-8551-0921e31abcc6)