### PR TITLE
feat(suite): add headingSize props to Modal

### DIFF
--- a/packages/components/src/components/modals/Modal/Modal.tsx
+++ b/packages/components/src/components/modals/Modal/Modal.tsx
@@ -80,12 +80,12 @@ const HeadingContainer = styled.div<HeadingContainerProps>`
         `}
 `;
 
-type HeadingSize = 'default' | 'large';
-
-const HEADING_SIZES: Record<HeadingSize, { css: string; buttonSize: ButtonSize }> = {
+const HEADING_SIZES: Record<string, { css: string; buttonSize: ButtonSize }> = {
     default: { css: typography.titleSmall, buttonSize: 'small' },
     large: { css: typography.titleMedium, buttonSize: 'medium' },
 };
+
+type HeadingSize = keyof typeof HEADING_SIZES;
 
 type HeadingProps = { isWithIcon?: boolean; $headingSize: HeadingSize };
 

--- a/packages/components/src/components/modals/Modal/Modal.tsx
+++ b/packages/components/src/components/modals/Modal/Modal.tsx
@@ -8,6 +8,7 @@ import { Icon, IconType } from '../../assets/Icon/Icon';
 import { Stepper } from '../../loaders/Stepper/Stepper';
 import { IconButton } from '../../buttons/IconButton/IconButton';
 import { H3 } from '../../typography/Heading/Heading';
+import { ButtonSize } from '../../buttons/buttonStyleUtils';
 
 const CLOSE_ICON_SIZE = spacings.xxl;
 const CLOSE_ICON_MARGIN = 16;
@@ -79,7 +80,16 @@ const HeadingContainer = styled.div<HeadingContainerProps>`
         `}
 `;
 
-const Heading = styled(H3)<{ isWithIcon?: boolean }>`
+type HeadingSize = 'default' | 'large';
+
+const HEADING_SIZES: Record<HeadingSize, { css: string; buttonSize: ButtonSize }> = {
+    default: { css: typography.titleSmall, buttonSize: 'small' },
+    large: { css: typography.titleMedium, buttonSize: 'medium' },
+};
+
+type HeadingProps = { isWithIcon?: boolean; $headingSize: HeadingSize };
+
+const Heading = styled(H3)<HeadingProps>`
     ${({ isWithIcon }) =>
         isWithIcon &&
         css`
@@ -89,6 +99,7 @@ const Heading = styled(H3)<{ isWithIcon?: boolean }>`
                 margin-right: ${spacingsPx.xs};
             }
         `}
+    ${({ $headingSize }) => HEADING_SIZES[$headingSize].css};
 `;
 
 const Subheading = styled.span<{ isWithMargin: boolean }>`
@@ -161,6 +172,7 @@ interface ModalProps {
     subheading?: ReactNode;
     modalPrompt?: ReactNode;
     headerIcon?: IconType;
+    headingSize?: HeadingSize;
     isHeadingCentered?: boolean;
     description?: ReactNode;
     bottomBarComponents?: ReactNode;
@@ -181,6 +193,7 @@ const Modal = ({
     subheading,
     modalPrompt,
     headerIcon,
+    headingSize = 'default',
     isHeadingCentered,
     description, // LEGACY PROP
     bottomBarComponents,
@@ -251,7 +264,7 @@ const Modal = ({
                                     </Subheading>
                                 )}
 
-                                <Heading isWithIcon={!!headerIcon}>
+                                <Heading $headingSize={headingSize} isWithIcon={!!headerIcon}>
                                     {headerIcon && (
                                         <Icon
                                             icon={headerIcon}
@@ -280,7 +293,7 @@ const Modal = ({
                                         icon="CROSS"
                                         data-test="@modal/close-button"
                                         onClick={onCancel}
-                                        size="small"
+                                        size={HEADING_SIZES[headingSize].buttonSize}
                                     />
                                 )}
                             </HeaderComponentsContainer>

--- a/packages/connect-popup/src/static/popup.css
+++ b/packages/connect-popup/src/static/popup.css
@@ -53,13 +53,18 @@ body {
     position: relative;
     min-height: 500px;
     min-width: 328px;
-    font-family: 'TT Satoshi', -apple-system, 'Segoe UI', 'Roboto', 'Helvetica Neue', Arial,
+    font-family:
+        'TT Satoshi',
+        -apple-system,
+        'Segoe UI',
+        'Roboto',
+        'Helvetica Neue',
+        Arial,
         sans-serif;
     font-weight: 400;
     font-size: 14px;
     color: #494949;
     background-color: #ffffff;
-    
 }
 main {
     width: 100%;
@@ -125,7 +130,9 @@ a:visited {
     position: relative;
     color: #01b757;
     text-decoration: none;
-    transition: background-color 0.3s ease-in-out, color 0.3s ease-in-out,
+    transition:
+        background-color 0.3s ease-in-out,
+        color 0.3s ease-in-out,
         border-color 0.3s ease-in-out;
 }
 a:not(.button):after,
@@ -164,7 +171,9 @@ button {
     background: #01b757;
     color: #ffffff;
     border: 0px;
-    transition: background-color 0.3s ease-in-out, color 0.3s ease-in-out,
+    transition:
+        background-color 0.3s ease-in-out,
+        color 0.3s ease-in-out,
         border-color 0.3s ease-in-out;
 }
 a.button:hover,
@@ -197,7 +206,9 @@ button.transparent {
     background: transparent;
     border: 0px;
     color: #757575;
-    transition: background-color 0.3s ease-in-out, color 0.3s ease-in-out,
+    transition:
+        background-color 0.3s ease-in-out,
+        color 0.3s ease-in-out,
         border-color 0.3s ease-in-out;
 }
 a.button.transparent:hover,
@@ -398,7 +409,9 @@ input[type='password'] {
     background-color: #ffffff;
     border: 1px solid #e3e3e3;
     border-radius: 2px;
-    transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
+    transition:
+        border-color ease-in-out 0.15s,
+        box-shadow ease-in-out 0.15s;
     padding: 6px 12px;
     width: 260px;
 }
@@ -448,7 +461,9 @@ input[type='password']:focus {
     -moz-osx-font-smoothing: grayscale;
     text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.004);
     content: '\e91c';
-    transition: background-color 0.3s ease-in-out, color 0.3s ease-in-out,
+    transition:
+        background-color 0.3s ease-in-out,
+        color 0.3s ease-in-out,
         border-color 0.3s ease-in-out;
     position: absolute;
     top: 0;
@@ -520,7 +535,9 @@ input[type='password']:focus {
 .loader .circular .path {
     stroke-dasharray: 1, 200;
     stroke-dashoffset: 0;
-    animation: dash 1.5s ease-in-out infinite, color 6s ease-in-out infinite;
+    animation:
+        dash 1.5s ease-in-out infinite,
+        color 6s ease-in-out infinite;
     stroke-linecap: round;
 }
 @media screen and (min-width: 768px) {
@@ -533,24 +550,22 @@ input[type='password']:focus {
         height: 160px;
     }
 }
-
 @font-face {
     font-family: 'TT Satoshi';
     src: url('./fonts/TTSatoshi-Medium.otf') format('opentype');
     font-weight: 500;
     font-style: normal;
 }
-
 @font-face {
     font-family: 'TT Satoshi';
     src: url('./fonts/TTSatoshi-DemiBold.otf') format('opentype');
     font-weight: 600;
     font-style: normal;
 }
-
 @font-face {
     font-family: 'Roboto Zero';
-    src: url(./fonts/RobotoZeroc19ef375e09c0446ee38.eot) format('embedded-opentype'),
+    src:
+        url(./fonts/RobotoZeroc19ef375e09c0446ee38.eot) format('embedded-opentype'),
         url(./fonts/RobotoZeroc19ef375e09c0446ee38.eot?#iefix) format('embedded-opentype'),
         url(./fonts/RobotoZero29cc77529672c0fd144d.woff) format('woff'),
         url(./fonts/RobotoZerof20cf957fc6f55b6b98b.ttf) format('truetype');
@@ -558,7 +573,8 @@ input[type='password']:focus {
 @font-face {
     font-family: 'Roboto Mono';
     font-style: normal;
-    src: url(./fonts/roboto-mono-v4-greek_cyrillic-ext_greek-ext_latin_cyrillic_vietnamese_latin-ext-regularc3820318b20a155142f6.eot)
+    src:
+        url(./fonts/roboto-mono-v4-greek_cyrillic-ext_greek-ext_latin_cyrillic_vietnamese_latin-ext-regularc3820318b20a155142f6.eot)
             format('embedded-opentype'),
         /* IE9 Compat Modes */
             url(./fonts/roboto-mono-v4-greek_cyrillic-ext_greek-ext_latin_cyrillic_vietnamese_latin-ext-regularc3820318b20a155142f6.eot?#iefix)
@@ -579,7 +595,8 @@ input[type='password']:focus {
 }
 @font-face {
     font-family: 'icomoon';
-    src: url(./fonts/icomoon78a0524c3a8df054cd5c.eot) format('embedded-opentype'),
+    src:
+        url(./fonts/icomoon78a0524c3a8df054cd5c.eot) format('embedded-opentype'),
         url(./fonts/icomoon78a0524c3a8df054cd5c.eot?#iefix) format('embedded-opentype'),
         url(./fonts/icomoon70a5709371d24d38b885.woff) format('woff'),
         url(./fonts/icomoone0e510584c12e6d42fe0.ttf) format('truetype'),
@@ -588,7 +605,8 @@ input[type='password']:focus {
 @font-face {
     font-family: 'text-security-disc';
     src: url(./fonts/text-security-discd3995fb5c90f4436a47a.eot);
-    src: url(./fonts/text-security-discd3995fb5c90f4436a47a.eot?#iefix) format('embedded-opentype'),
+    src:
+        url(./fonts/text-security-discd3995fb5c90f4436a47a.eot?#iefix) format('embedded-opentype'),
         url(./fonts/text-security-disc0020690534bc05d23144.woff) format('woff'),
         url(./fonts/text-security-disc5bd8137c2cc18e31a4a6.ttf) format('truetype'),
         url(./fonts/text-security-disc086a4dc87cc229bdfdff.svg#text-security) format('svg');
@@ -1157,7 +1175,9 @@ section > div .divider span:after {
     line-height: 1px;
     left: 0px;
     bottom: -1px;
-    transition: border-color 0.3s, color 0.3s;
+    transition:
+        border-color 0.3s,
+        color 0.3s;
 }
 .select-account .tab-selection:hover,
 .select-account .tab-selection:active,
@@ -1282,7 +1302,9 @@ section > div .divider span:after {
 .select-account .select-account-list p {
     color: #757575;
     fill: #757575;
-    transition: color 0.3s ease-in-out, fill 0.3s ease-in-out;
+    transition:
+        color 0.3s ease-in-out,
+        fill 0.3s ease-in-out;
 }
 .select-account .select-account-list:hover svg,
 .select-account .select-account-list:active svg,
@@ -1311,7 +1333,9 @@ section > div .divider span:after {
 .select-account .enable-labeling p {
     color: #757575;
     fill: #757575;
-    transition: color 0.3s ease-in-out, fill 0.3s ease-in-out;
+    transition:
+        color 0.3s ease-in-out,
+        fill 0.3s ease-in-out;
 }
 .select-account .enable-labeling:hover svg,
 .select-account .enable-labeling:active svg,

--- a/packages/suite/src/components/suite/modals/Modal/Modal.tsx
+++ b/packages/suite/src/components/suite/modals/Modal/Modal.tsx
@@ -9,6 +9,7 @@ export type ModalProps = TrezorModalProps & {
 export const Modal = ({ renderer: View = DefaultRenderer, ...props }: ModalProps) => (
     <View {...props} />
 );
+
 Modal.Header = TrezorModal.Header;
 Modal.Body = TrezorModal.Body;
 Modal.Description = TrezorModal.Description;

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseModal.tsx
@@ -165,6 +165,7 @@ export const PassphraseModal = ({ device }: PassphraseModalProps) => {
     // show 2-column modal for selecting between standard and hidden wallets
     return (
         <SmallModal
+            headingSize="large"
             isCancelable
             onCancel={onCancel}
             heading={<Translation id="TR_SELECT_WALLET_TO_ACCESS" />}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -238,6 +238,7 @@ export const AddAccountModal = ({ device, onCancel, symbol, noRedirect }: AddAcc
         <StyledModal
             isCancelable
             onCancel={onCancel}
+            headingSize="large"
             bottomBarComponents={
                 selectedNetwork &&
                 (isSelectedNetworkEnabled ? (


### PR DESCRIPTION
## Description

Add default and large font-size for the Modals Heading

- The size of heading for Wallet Switch and New Account modals increased to `larger`
- On top, I have also increased the `AddAccountModal` as it seems to me as same type of modal

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/10052

## Screenshots:

![image](https://github.com/trezor/trezor-suite/assets/152899911/c32dc02a-5955-490f-8646-b374f8b0758a)
![image](https://github.com/trezor/trezor-suite/assets/152899911/01e125e6-f7f4-43c5-b69e-4d6b479a2ce6)


![image](https://github.com/trezor/trezor-suite/assets/152899911/c24b7c9f-0a12-4d58-8919-5c10278bbb04)
![image](https://github.com/trezor/trezor-suite/assets/152899911/eb528553-70ce-456c-9455-27ed313378ca)

![image](https://github.com/trezor/trezor-suite/assets/152899911/e4b54b53-1e85-4e01-bd31-6393d9fbfe2e)
![image](https://github.com/trezor/trezor-suite/assets/152899911/7da0ef86-e795-4d9c-80db-ca3c3d9a72de)


