### PR TITLE
chore: dont require default case, be explicit rather then implicit

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -97,6 +97,8 @@ module.exports = {
                 includeTypes: true,
             },
         ],
+        // This promotes using default case, which is not always correct (explicit is better than implicit)
+        'default-case': 'off',
         // Does not work with TypeScript export type.
         'import/prefer-default-export': 'off',
         'import/no-named-as-default': 'off', // default export is forbidden anyway


### PR DESCRIPTION
## Description

Disables the ESLint rule that promotes the defaults/implicits. It is better to be explicit and leverage the type-mapping and type-narrowing features of the Typescript to never have to deal with undefined/unexpected values.

## Related Issue

Follow-up of https://github.com/trezor/trezor-suite/pull/9581

