### PR TITLE
chore(mobile): remove brigtness increase for QR codes

### DIFF
--- a/suite-native/app/ios/Podfile.lock
+++ b/suite-native/app/ios/Podfile.lock
@@ -19,8 +19,6 @@ PODS:
     - React-Core
   - Expo (48.0.1):
     - ExpoModulesCore
-  - ExpoBrightness (11.3.0):
-    - ExpoModulesCore
   - ExpoClipboard (4.1.1):
     - ExpoModulesCore
   - ExpoDevice (5.6.0):
@@ -550,7 +548,6 @@ DEPENDENCIES:
   - EXConstants (from `../../../node_modules/expo-constants/ios`)
   - EXImageLoader (from `../../../node_modules/expo-image-loader/ios`)
   - Expo (from `../../../node_modules/expo`)
-  - ExpoBrightness (from `../../../node_modules/expo-brightness/ios`)
   - ExpoClipboard (from `../../../node_modules/expo-clipboard/ios`)
   - ExpoDevice (from `../../../node_modules/expo-device/ios`)
   - ExpoHaptics (from `../../../node_modules/expo-haptics/ios`)
@@ -675,8 +672,6 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/expo-image-loader/ios"
   Expo:
     :path: "../../../node_modules/expo"
-  ExpoBrightness:
-    :path: "../../../node_modules/expo-brightness/ios"
   ExpoClipboard:
     :path: "../../../node_modules/expo-clipboard/ios"
   ExpoDevice:
@@ -802,7 +797,6 @@ SPEC CHECKSUMS:
   EXConstants: 29269f841ed8786d483b753021953264ac04818f
   EXImageLoader: fd053169a8ee932dd83bf1fe5487a50c26d27c2b
   Expo: 79deb55f33fab1b232232868a74713772943238d
-  ExpoBrightness: 13a6108d77641ad310b7873438a0260f9eedfe5c
   ExpoClipboard: 8a36a8376ab93df9050c14577e9e0fcb805e9114
   ExpoDevice: 4b9825263a3f996fd5a89ec26426e22e6cbc32d6
   ExpoHaptics: 360af6898407ee4e8265d30a1a8fb16491a660eb
@@ -883,4 +877,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: d37876aaf00e7f8309b694188119b139b8452ca1
 
-COCOAPODS: 1.14.2
+COCOAPODS: 1.11.3

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -83,7 +83,6 @@
         "buffer": "^6.0.3",
         "expo": "48.0.1",
         "expo-barcode-scanner": "^12.3.1",
-        "expo-brightness": "^11.2.1",
         "expo-clipboard": "^4.1.1",
         "expo-haptics": "^12.4.0",
         "expo-linear-gradient": "^12.5.0",

--- a/suite-native/qr-code/package.json
+++ b/suite-native/qr-code/package.json
@@ -20,7 +20,6 @@
         "@trezor/styles": "workspace:*",
         "@trezor/theme": "workspace:*",
         "expo-barcode-scanner": "^12.3.1",
-        "expo-brightness": "^11.2.1",
         "react": "18.2.0",
         "react-native": "0.71.8",
         "react-qr-code": "2.0.8"

--- a/suite-native/qr-code/src/components/QRCode.tsx
+++ b/suite-native/qr-code/src/components/QRCode.tsx
@@ -1,11 +1,8 @@
-import { useEffect, useState } from 'react';
-import { AppState, Dimensions, View } from 'react-native';
+import { Dimensions, View } from 'react-native';
 import ReactQRCode from 'react-qr-code';
 
-import * as Brightness from 'expo-brightness';
-
-import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { Box } from '@suite-native/atoms';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { colorVariants } from '@trezor/theme';
 
 type QRCodeProps = {
@@ -30,45 +27,6 @@ const qrCodeContainerStyle = prepareNativeStyle(_ => ({
 
 export const QRCode = ({ data }: QRCodeProps) => {
     const { applyStyle } = useNativeStyles();
-    const [originalBrightnessValue, setOriginalBrightnessValue] = useState<number>();
-
-    useEffect(() => {
-        const subscription = AppState.addEventListener('change', nextAppState => {
-            if (!originalBrightnessValue) return;
-
-            // When app goes to background (or inactive to work on iOS), restore the original brightness value.
-            if (['inactive', 'background'].includes(nextAppState)) {
-                Brightness.setBrightnessAsync(originalBrightnessValue);
-            }
-            // When app goes to foreground set full brightness.
-            if (nextAppState === 'active') {
-                Brightness.setBrightnessAsync(1);
-            }
-        });
-
-        return () => {
-            subscription.remove();
-        };
-    }, [originalBrightnessValue]);
-
-    useEffect(() => {
-        const storeBrightnessValue = async () => {
-            const brightnessValue = await Brightness.getBrightnessAsync();
-            setOriginalBrightnessValue(brightnessValue);
-        };
-
-        // Set brightness to maximum and store the original value.
-        storeBrightnessValue();
-        Brightness.setBrightnessAsync(1);
-    }, []);
-
-    useEffect(
-        // Restore the original brightness value when the QR code is unmounted.
-        () => () => {
-            if (originalBrightnessValue) Brightness.setBrightnessAsync(originalBrightnessValue);
-        },
-        [originalBrightnessValue],
-    );
 
     return (
         <Box alignItems="center">

--- a/yarn.lock
+++ b/yarn.lock
@@ -7950,7 +7950,6 @@ __metadata:
     "@trezor/styles": "workspace:*"
     "@trezor/theme": "workspace:*"
     expo-barcode-scanner: "npm:^12.3.1"
-    expo-brightness: "npm:^11.2.1"
     react: "npm:18.2.0"
     react-native: "npm:0.71.8"
     react-qr-code: "npm:2.0.8"
@@ -9322,7 +9321,6 @@ __metadata:
     buffer: "npm:^6.0.3"
     expo: "npm:48.0.1"
     expo-barcode-scanner: "npm:^12.3.1"
-    expo-brightness: "npm:^11.2.1"
     expo-clipboard: "npm:^4.1.1"
     expo-haptics: "npm:^12.4.0"
     expo-linear-gradient: "npm:^12.5.0"
@@ -18326,15 +18324,6 @@ __metadata:
   peerDependencies:
     expo: "*"
   checksum: 8c33bc7ab96b9da36081227f4b4354daf12eb4100cd7d3c57945256fc251d7b73f61bdfab7331ffdb50bbd2c4895f2142da4f2c0c0fbfaa9e5d8de77628c80b0
-  languageName: node
-  linkType: hard
-
-"expo-brightness@npm:^11.2.1":
-  version: 11.3.0
-  resolution: "expo-brightness@npm:11.3.0"
-  peerDependencies:
-    expo: "*"
-  checksum: b1930e197698c71fddd0baa378b82e142a444a23ac774b132f5f3d820fe1437ff70090845a054d7878ae5c34988ad0ec475308feaccc0117a1ac0e87f97a4cf1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
It doesn't work correctly for most of Android phones and reliable fix is very hard. Simples solution is to let people handle their brightness.

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve #10229 

## Screenshots:
