### PR TITLE
feat(connect-explorer): add Solana

### DIFF
--- a/docs/packages/connect/methods.md
+++ b/docs/packages/connect/methods.md
@@ -63,6 +63,12 @@ Every method require an [`Object`](https://developer.mozilla.org/en-US/docs/Web/
 -   [TrezorConnect.rippleGetAddress](methods/rippleGetAddress.md)
 -   [TrezorConnect.rippleSignTransaction](methods/rippleSignTransaction.md)
 
+## Solana
+
+-   [TrezorConnect.solanaGetPublicKey](methods/solanaGetPublicKey.md)
+-   [TrezorConnect.solanaGetAddress](methods/solanaGetAddress.md)
+-   [TrezorConnect.solanaSignTransaction](methods/solanaSignTransaction.md)
+
 ## Tezos
 
 -   [TrezorConnect.tezosGetAddress](methods/tezosGetAddress.md)

--- a/docs/packages/connect/methods/solanaGetAddress.md
+++ b/docs/packages/connect/methods/solanaGetAddress.md
@@ -1,7 +1,5 @@
 ## Solana: get address
 
-⚠️ **BETA**: This api is unstable and may change!
-
 Display requested address derived by given [BIP44 path](../path.md) on device and return it to the caller. User is presented with a description of the requested address and asked to confirm the export on Trezor.
 
 ```javascript

--- a/docs/packages/connect/methods/solanaGetPublicKey.md
+++ b/docs/packages/connect/methods/solanaGetPublicKey.md
@@ -1,7 +1,5 @@
 ## Solana: get public key
 
-⚠️ **BETA**: This api is unstable and may change!
-
 Display requested public key derived by given [BIP44 path](../path.md) on device and return it to the caller. User is presented with a description of the requested public key and asked to confirm the export on Trezor.
 
 ```javascript

--- a/docs/packages/connect/methods/solanaSignTransaction.md
+++ b/docs/packages/connect/methods/solanaSignTransaction.md
@@ -1,7 +1,5 @@
 ## Solana: Sign transaction
 
-⚠️ **BETA**: This api is unstable and may change!
-
 Asks device to sign given transaction. User is asked to confirm all transaction details on Trezor.
 
 ```javascript
@@ -16,14 +14,42 @@ const result = await TrezorConnect.solanaSignTransaction(params);
 
 -   `path` — _required_ `string | Array<number>` minimum length is `2`. [read more](../path.md)
 -   `serializedTx` — _required_ `string`
+-   `additionalInfo` - _optional_ [SolanaTxAdditionalInfo](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/solana/index.ts#L18)
+    -   `tokenAccountsInfos` - _optional_ `Array` of [SolanaTxTokenAccountInfo](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/solana/index.ts#L11)
 
-### Example
+### SolanaTxAdditionalInfo
+
+The parameter is currently used only for sending `tokenAccountsInfos` to Trezor. `tokenAccountsInfos` are used when transferring tokens to associated token accounts. Using `tokenAccountsInfos` you can provide Trezor information about the recipient's base (system) account of the associated token account and Trezor can then safely display the base account address to the user instead of displaying the token account address which most users don't even know about.
+
+_Displaying base address only works for transactions which transfer tokens or which create a token account and transfer tokens to that account._
+
+### Examples
 
 ```javascript
 TrezorConnect.solanaSignTransaction({
     path: "m/44'/501'/0'/0'",
     serializedTx:
         '0200030500d1699dcb1811b50bb0055f13044463128242e37a463b52f6c97a1f6eef88ad8c72b471e11674bdcd1e5f85421be42097d5d9c8642172ab73ccf6ff003a43f3000000000000000000000000000000000000000000000000000000000000000006a1d8179137542a983437bdfe2a7ab2557f535c8a78722b68a49dc00000000006a7d517192c5c51218cc94c3d4af17f58daee089ba1fd44e3dbd98a000000001aea57c9906a7cad656ff61b3893abda63f4b6b210c939855e7ab6e54049213d02020200013400000000002d310100000000e80300000000000006a1d8179137542a983437bdfe2a7ab2557f535c8a78722b68a49dc00000000003020104740000000000d1699dcb1811b50bb0055f13044463128242e37a463b52f6c97a1f6eef88ad00d1699dcb1811b50bb0055f13044463128242e37a463b52f6c97a1f6eef88ad000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+});
+```
+
+If you try the following request with the `all all ...` mnemonic you should see `BVRFH6vt5bNXub6WnnFRgaHFTcbkjBrf7x1troU1izGg` as the recipient although the tokens are really transferred to `J5rhFGUkeoHVnCvMyqWq1XPjfU1G1hsTh9tTQtST2out` (the associated token account of `BVRFH6vt5bNXub6WnnFRgaHFTcbkjBrf7x1troU1izGg`).
+
+```javascript
+TrezorConnect.solanaSignTransaction({
+    path: "m/44'/501'/0'/0'",
+    serializedTx:
+        '0100040700d1699dcb1811b50bb0055f13044463128242e37a463b52f6c97a1f6eef88ad9bdc8c11af6a471f7373e52c917aac6304c71796b97b47350d46cf4c54bae9d9fdd530a73d5e74613b17aaeb9346f9fc3c5fd6a7ad126b269e3e73454e2a0b1b000000000000000000000000000000000000000000000000000000000000000081432588d91c8e02d613baa94e05994e78467cf5a8821d8f4c2e373e8b9b56ef8c97258f4e2489f1bb3d1029148e0d830b5a1399daff1084048e7bd8dbe9f85906ddf6e1d765a193d9cbe146ceeb79ac1cb485ed5f5b37913a8cf5857eff00a91aea57c9906a7cad656ff61b3893abda63f4b6b210c939855e7ab6e54049213d020506000201040306000604010402000a0c0b0000000000000009',
+    additionalInfo: {
+        tokenAccountsInfos: [
+            {
+                baseAddress: 'BVRFH6vt5bNXub6WnnFRgaHFTcbkjBrf7x1troU1izGg',
+                tokenProgram: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+                tokenMint: '9hayiPmEobVfiTbw5R91StWeQzw9EJGfswLH5o33UDAW',
+                tokenAccount: 'J5rhFGUkeoHVnCvMyqWq1XPjfU1G1hsTh9tTQtST2out',
+            },
+        ],
+    },
 });
 ```
 

--- a/packages/connect-explorer/src/data/menu.ts
+++ b/packages/connect-explorer/src/data/menu.ts
@@ -446,6 +446,50 @@ export default [
         ],
     },
     {
+        name: 'Solana',
+        children: [
+            {
+                name: 'Get public key',
+                children: [
+                    {
+                        name: 'export public key',
+                        url: '/method/solanaGetPublicKey',
+                    },
+                    {
+                        name: 'export multiple public keys',
+                        url: '/method/solanaGetPublicKey-multiple',
+                    },
+                ],
+            },
+            {
+                name: 'Get address',
+                children: [
+                    {
+                        name: 'export address',
+                        url: '/method/solanaGetAddress',
+                    },
+                    {
+                        name: 'export multiple addresses',
+                        url: '/method/solanaGetAddress-multiple',
+                    },
+                ],
+            },
+            {
+                name: 'Sign transaction',
+                url: '/method/solanaSignTransaction',
+            },
+            {
+                name: 'Account info',
+                children: [
+                    {
+                        name: 'using discovery',
+                        url: '/method/getAccountInfo-discovery-solana',
+                    },
+                ],
+            },
+        ],
+    },
+    {
         name: 'Other methods',
         children: [
             {

--- a/packages/connect-explorer/src/data/methods/blockchain/index.ts
+++ b/packages/connect-explorer/src/data/methods/blockchain/index.ts
@@ -19,6 +19,8 @@ const select = [
     { value: 'tsep', label: 'Sepolia' },
     { value: 'tgor', label: 'Goerli' },
     { value: 'thol', label: 'Holesky' },
+    { value: 'sol', label: 'Solana' },
+    { value: 'dsol', label: 'Solana devnet' },
 ];
 
 const json = `[

--- a/packages/connect-explorer/src/data/methods/index.ts
+++ b/packages/connect-explorer/src/data/methods/index.ts
@@ -7,6 +7,7 @@ import cardano from './cardano/index';
 import tezos from './tezos';
 import eos from './eos';
 import binance from './binance';
+import solana from './solana';
 import other from './other';
 
 import management from './management';
@@ -22,6 +23,7 @@ export default [
     ...tezos,
     ...eos,
     ...binance,
+    ...solana,
     ...other,
     ...management,
     ...blockchain,

--- a/packages/connect-explorer/src/data/methods/solana/getAccountInfo.ts
+++ b/packages/connect-explorer/src/data/methods/solana/getAccountInfo.ts
@@ -1,0 +1,23 @@
+const name = 'getAccountInfo';
+const docs = 'methods/getAccountInfo.md';
+
+export default [
+    {
+        url: '/method/getAccountInfo-discovery-solana',
+        name,
+        docs,
+        submitButton: 'Get account info',
+        fields: [
+            {
+                name: 'coin',
+                type: 'select',
+                value: 'dsol',
+                affect: 'path',
+                data: [
+                    { value: 'sol', label: 'Solana', affectedValue: `m/44'/501'/0'/0'` },
+                    { value: 'dsol', label: 'Solana Devnet', affectedValue: `m/44'/501'/0'/0'` },
+                ],
+            },
+        ],
+    },
+];

--- a/packages/connect-explorer/src/data/methods/solana/getAddress.ts
+++ b/packages/connect-explorer/src/data/methods/solana/getAddress.ts
@@ -1,0 +1,34 @@
+const name = 'solanaGetAddress';
+const docs = 'methods/solanaGetAddress.md';
+
+const getAddress = {
+    name: 'path',
+    label: 'Bip44 path',
+    type: 'input',
+    value: `m/44'/501'/0'/0'`,
+};
+const showOnTrezor = {
+    name: 'showOnTrezor',
+    label: 'Show on Trezor',
+    type: 'checkbox',
+    value: true,
+};
+
+const chunkify = {
+    name: 'chunkify',
+    label: 'Display address in chunks of 4 characters',
+    type: 'checkbox',
+    value: false,
+};
+
+const batch = [getAddress, showOnTrezor, chunkify];
+
+export default [
+    {
+        url: '/method/solanaGetAddress',
+        name,
+        docs,
+        submitButton: 'Get address',
+        fields: batch,
+    },
+];

--- a/packages/connect-explorer/src/data/methods/solana/getPublicKey.ts
+++ b/packages/connect-explorer/src/data/methods/solana/getPublicKey.ts
@@ -1,0 +1,48 @@
+const name = 'solanaGetPublicKey';
+const docs = 'methods/solanaGetPublicKey.md';
+
+const getAddress = {
+    name: 'path',
+    label: 'Bip44 path',
+    type: 'input',
+    value: `m/44'/501'/0'/0'`,
+};
+
+const showOnTrezor = {
+    name: 'showOnTrezor',
+    label: 'Show on Trezor',
+    type: 'checkbox',
+    value: true,
+};
+
+const batch = [getAddress, showOnTrezor];
+
+export default [
+    {
+        url: '/method/solanaGetPublicKey',
+        name,
+        docs,
+        submitButton: 'Get public key',
+        fields: batch,
+    },
+    {
+        url: '/method/solanaGetPublicKey-multiple',
+        name,
+        docs,
+        submitButton: 'Get multiple public keys',
+
+        fields: [
+            {
+                name: 'bundle',
+                type: 'array',
+                batch: [
+                    {
+                        type: '',
+                        fields: batch,
+                    },
+                ],
+                items: [batch, batch],
+            },
+        ],
+    },
+];

--- a/packages/connect-explorer/src/data/methods/solana/index.ts
+++ b/packages/connect-explorer/src/data/methods/solana/index.ts
@@ -1,0 +1,6 @@
+import getPublicKey from './getPublicKey';
+import getAddress from './getAddress';
+import signTransaction from './signTransaction';
+import getAccountInfo from './getAccountInfo';
+
+export default [...getPublicKey, ...getAddress, ...signTransaction, ...getAccountInfo];

--- a/packages/connect-explorer/src/data/methods/solana/signTransaction.ts
+++ b/packages/connect-explorer/src/data/methods/solana/signTransaction.ts
@@ -1,0 +1,44 @@
+const name = 'solanaSignTransaction';
+const docs = 'methods/solanaSignTransaction.md';
+
+const serializedTx =
+    '0100040700d1699dcb1811b50bb0055f13044463128242e37a463b52f6c97a1f6eef88ad9bdc8c11af6a471f7373e52c917aac6304c71796b97b47350d46cf4c54bae9d9fdd530a73d5e74613b17aaeb9346f9fc3c5fd6a7ad126b269e3e73454e2a0b1b000000000000000000000000000000000000000000000000000000000000000081432588d91c8e02d613baa94e05994e78467cf5a8821d8f4c2e373e8b9b56ef8c97258f4e2489f1bb3d1029148e0d830b5a1399daff1084048e7bd8dbe9f85906ddf6e1d765a193d9cbe146ceeb79ac1cb485ed5f5b37913a8cf5857eff00a91aea57c9906a7cad656ff61b3893abda63f4b6b210c939855e7ab6e54049213d020506000201040306000604010402000a0c0b0000000000000009';
+
+const additionalInfo = {
+    tokenAccountsInfos: [
+        {
+            baseAddress: 'BVRFH6vt5bNXub6WnnFRgaHFTcbkjBrf7x1troU1izGg',
+            tokenProgram: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+            tokenMint: '9hayiPmEobVfiTbw5R91StWeQzw9EJGfswLH5o33UDAW',
+            tokenAccount: 'J5rhFGUkeoHVnCvMyqWq1XPjfU1G1hsTh9tTQtST2out',
+        },
+    ],
+};
+
+export default [
+    {
+        url: '/method/solanaSignTransaction',
+        name,
+        docs,
+        submitButton: 'Sign transaction',
+        fields: [
+            {
+                name: 'path',
+                label: 'Bip44 path',
+                type: 'input',
+                value: `m/44'/501'/0'/0'`,
+            },
+            {
+                name: 'serializedTx',
+                label: 'Serialized transaction',
+                type: 'input-long',
+                value: serializedTx,
+            },
+            {
+                name: 'additionalInfo',
+                type: 'json',
+                value: additionalInfo,
+            },
+        ],
+    },
+];

--- a/packages/connect/src/api/solana/api/solanaGetAddress.ts
+++ b/packages/connect/src/api/solana/api/solanaGetAddress.ts
@@ -15,8 +15,6 @@ export default class SolanaGetAddress extends AbstractMethod<'solanaGetAddress',
     confirmed?: boolean;
 
     init() {
-        console.warn('⚠️ BETA: This api is unstable and may change!');
-
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(
             this.name,

--- a/packages/connect/src/api/solana/api/solanaGetPublicKey.ts
+++ b/packages/connect/src/api/solana/api/solanaGetPublicKey.ts
@@ -13,8 +13,6 @@ export default class SolanaGetPublicKey extends AbstractMethod<
     confirmed?: boolean;
 
     init() {
-        console.warn('⚠️ BETA: This api is unstable and may change!');
-
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(
             this.name,

--- a/packages/connect/src/api/solana/api/solanaSignTransaction.ts
+++ b/packages/connect/src/api/solana/api/solanaSignTransaction.ts
@@ -10,8 +10,6 @@ export default class SolanaSignTransaction extends AbstractMethod<
     PROTO.SolanaSignTx
 > {
     init() {
-        console.warn('⚠️ BETA: This api is unstable and may change!');
-
         this.requiredPermissions = ['read', 'write'];
         this.firmwareRange = getFirmwareRange(
             this.name,


### PR DESCRIPTION
This PR adds Solana to Connect Explorer. It also updates Solana Connect docs and removes `⚠️ BETA: This api is unstable and may change!` from both docs and the methods themselves.

In 2f2ebe1098dea2469abdd90902358c0318bbe83d I also tried to add `getAccountInfo` but wasn't able to get it working properly - probably because it tries to use a `m/44'/501'/0'/0/0` path which fails for Solana - or there's some other problem. If someone feels like investigating and fixing this then feel free, otherwise IMO we can drop it for now.

_While adding this I also noticed that we (VL) forgot to add `chunkify` to `solanaGetAddress` but saw that @AdamSchinzel added it. Thanks 👍_