### PR TITLE
fix(suite-native): broken layout on android

### DIFF
--- a/suite-native/module-connect-device/src/screens/ConnectingDeviceScreen.tsx
+++ b/suite-native/module-connect-device/src/screens/ConnectingDeviceScreen.tsx
@@ -28,12 +28,14 @@ export const ConnectingDeviceScreen = () => {
         <ConnectDeviceSreenView style={applyStyle(screenStyle)}>
             <VStack spacing="medium" alignItems="center">
                 <ActivityIndicator size="large" />
-                <Text variant="titleMedium">
-                    <Translation id="moduleConnectDevice.connectingDeviceScreen.title" />{' '}
-                    <Box paddingBottom="small">
+                <Box flexDirection="row" alignItems="center">
+                    <Text variant="titleMedium">
+                        <Translation id="moduleConnectDevice.connectingDeviceScreen.title" />
+                    </Text>
+                    <Box paddingBottom="small" paddingLeft="small">
                         <Icon name="trezor" size="extraLarge" />
                     </Box>
-                </Text>
+                </Box>
                 <Text variant="highlight" color="textSubdued">
                     <Translation id="moduleConnectDevice.connectingDeviceScreen.hodlOn" />
                 </Text>


### PR DESCRIPTION
old: 
<span> <img src="https://github.com/trezor/trezor-suite/assets/2011829/5da97924-3e2a-421e-a078-fbfffa02d901" height=300/> 

new:
<img src="https://github.com/trezor/trezor-suite/assets/2011829/294e3ddd-8182-49be-bce2-f287c36ffcb5" height=300/></span>
