### PR TITLE
wip: @trezor/worker-proxy to allow connect-explorer in webextension with connect in service worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,9 @@ packages/suite-data/files/browser-detection
 packages/suite-data/files/guide
 packages/suite-data/files/translations/master.json
 
+# @trezor/connect-explorer
+packages/connect-explorer/build-webextension
+
 # cypress download folder
 
 packages/suite-web/e2e/downloads

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -320,7 +320,10 @@ connect-popup legacy npm package:
     IS_WEBEXTENSION: "true"
   script:
     - yarn install --immutable
-    - yarn workspace @trezor/connect-explorer-webextension build
+    - yarn build:libs
+    - yarn workspace @trezor/connect-webextension build
+    - yarn workspace @trezor/connect-iframe build:core-module
+    - yarn workspace @trezor/connect-explorer build:webextension
     - docker-compose pull
     - docker-compose up -d trezor-user-env-unix
     - docker-compose run test-run
@@ -339,16 +342,16 @@ connect-popup legacy npm package:
     matrix:
       - TEST_FILE: ["methods.test"]
       - TEST_FILE: ["passphrase.test"]
-      - TEST_FILE: ["popup-close.test"]
-      - TEST_FILE: ["popup-error-page.test"]
+      # - TEST_FILE: ["popup-error-page.test"]
+      # - TEST_FILE: ["popup-close.test"]
 
 connect-popup-webextension:
   extends: .e2e connect-popup-webextension
   dependencies:
     - install
     - connect-web build
-  only:
-    <<: *run_everything_rules
+  # only:
+  #   <<: *run_everything_rules
 
 connect-popup-webextension manual:
   extends: .e2e connect-popup-webextension

--- a/docker/docker-compose.connect-popup-test.yml
+++ b/docker/docker-compose.connect-popup-test.yml
@@ -18,7 +18,7 @@ services:
     network_mode: service:trezor-user-env-unix
 
   test-run:
-    image: mcr.microsoft.com/playwright:latest
+    image: mcr.microsoft.com/playwright:v1.39.0-jammy
     container_name: explorer-test-runner
     depends_on:
       - trezor-user-env-unix

--- a/docker/docker-connect-popup-test.sh
+++ b/docker/docker-connect-popup-test.sh
@@ -5,5 +5,6 @@ xhost +
 LOCAL_USER_ID="$(id -u "$USER")"
 export LOCAL_USER_ID
 export TEST_FILE=$1
+export URL=https://suite.corp.sldev.cz/connect/feat/connect-explorer-serviceworker-proxy/
 
 docker-compose -f ./docker/docker-compose.connect-popup-test.yml up --build --abort-on-container-exit

--- a/packages/connect-common/src/messageChannel/abstract.ts
+++ b/packages/connect-common/src/messageChannel/abstract.ts
@@ -185,4 +185,8 @@ export abstract class AbstractMessageChannel<
 
         return this.messagePromises[message.id].promise;
     }
+
+    clear() {
+        this.handshakeFinished = undefined;
+    }
 }

--- a/packages/connect-explorer/package.json
+++ b/packages/connect-explorer/package.json
@@ -5,6 +5,7 @@
     "scripts": {
         "dev": "rimraf build && TS_NODE_PROJECT=\"tsconfig.json\" yarn webpack --config ./webpack/dev.webpack.config.ts",
         "build": "rimraf build && TS_NODE_PROJECT=\"tsconfig.json\" yarn webpack --config ./webpack/prod.webpack.config.ts",
+        "build:webextension": "rimraf build-webextension && TS_NODE_PROJECT=\"tsconfig.json\" yarn webpack --config ./webpack/webextension.webpack.config.ts",
         "lint:js": "yarn g:eslint '**/*{.ts,.tsx}'",
         "lint:styles": "npx stylelint './src/**/*{.ts,.tsx}' --cache --config ../../.stylelintrc",
         "type-check": "tsc --build tsconfig.json"
@@ -12,7 +13,10 @@
     "dependencies": {
         "@trezor/components": "workspace:*",
         "@trezor/connect-web": "workspace:*",
+        "@trezor/connect-webextension": "workspace:^",
         "@trezor/protobuf": "workspace:*",
+        "@trezor/utils": "workspace:^",
+        "@trezor/worker-proxy": "workspace:^",
         "copy-webpack-plugin": "^11.0.0",
         "markdown-it": "^13.0.2",
         "markdown-it-imsize": "^2.0.1",

--- a/packages/connect-explorer/src-webextension/README.md
+++ b/packages/connect-explorer/src-webextension/README.md
@@ -1,0 +1,10 @@
+Run it for dev:
+
+```
+yarn && \
+yarn build:libs && \
+yarn workspace @trezor/connect-webextension build && \
+yarn workspace @trezor/connect-iframe build:core-module && \
+yarn workspace @trezor/connect-explorer build:webextension && \
+yarn workspace @trezor/connect-popup dev
+```

--- a/packages/connect-explorer/src-webextension/background/serviceWorker.ts
+++ b/packages/connect-explorer/src-webextension/background/serviceWorker.ts
@@ -1,0 +1,4 @@
+// Import TrezorConnect.
+importScripts('vendor/trezor-connect-webextension.js');
+// Import TrezorConnect background proxy to listen to foreground proxy counterpart.
+importScripts('vendor/trezor-connect-webextension-background-proxy.js');

--- a/packages/connect-explorer/src-webextension/manifest.json
+++ b/packages/connect-explorer/src-webextension/manifest.json
@@ -1,0 +1,13 @@
+{
+    "name": "@trezor/connect-explorer",
+    "version": "1.0.0",
+    "manifest_version": 3,
+    "action": {
+        "default_popup": "extension-popup.html"
+    },
+    "background": {
+        "service_worker": "serviceWorker.bundle.js"
+    },
+    "permissions": ["tabs", "notifications", "scripting", "activeTab"],
+    "host_permissions": ["http://*/*", "https://*/*"]
+}

--- a/packages/connect-explorer/src-webextension/manifest.json
+++ b/packages/connect-explorer/src-webextension/manifest.json
@@ -8,6 +8,6 @@
     "background": {
         "service_worker": "serviceWorker.bundle.js"
     },
-    "permissions": ["tabs", "notifications", "scripting", "activeTab"],
+    "permissions": ["scripting"],
     "host_permissions": ["http://*/*", "https://*/*"]
 }

--- a/packages/connect-explorer/src-webextension/pages/connect-explorer/index.html
+++ b/packages/connect-explorer/src-webextension/pages/connect-explorer/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Connect Explorer</title>
+    </head>
+
+    <body>
+        <div id="connect-explorer-container"></div>
+    </body>
+</html>

--- a/packages/connect-explorer/src-webextension/pages/connect-explorer/index.tsx
+++ b/packages/connect-explorer/src-webextension/pages/connect-explorer/index.tsx
@@ -1,0 +1,7 @@
+import { createRoot } from 'react-dom/client';
+
+import App from '../../../src/router/';
+
+const container = document.getElementById('connect-explorer-container');
+const root = createRoot(container!);
+root.render(<App />);

--- a/packages/connect-explorer/src-webextension/pages/extension-popup/ExtensionPopup.tsx
+++ b/packages/connect-explorer/src-webextension/pages/extension-popup/ExtensionPopup.tsx
@@ -1,0 +1,15 @@
+export const ExtensionPopup = () => {
+    const openExplorerTab = () => {
+        chrome.tabs.create({ url: 'connect-explorer.html' });
+    };
+
+    return (
+        <div className="App">
+            <p>Welcome to Trezor Connect Explorer extension!</p>
+
+            <button type="button" onClick={openExplorerTab}>
+                Open Connect Explorer
+            </button>
+        </div>
+    );
+};

--- a/packages/connect-explorer/src-webextension/pages/extension-popup/index.html
+++ b/packages/connect-explorer/src-webextension/pages/extension-popup/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Popup</title>
+    </head>
+
+    <body>
+        <div id="extension-popup-container"></div>
+    </body>
+</html>

--- a/packages/connect-explorer/src-webextension/pages/extension-popup/index.tsx
+++ b/packages/connect-explorer/src-webextension/pages/extension-popup/index.tsx
@@ -1,0 +1,7 @@
+import { createRoot } from 'react-dom/client';
+
+import { ExtensionPopup } from './ExtensionPopup';
+
+const container = document.getElementById('extension-popup-container');
+const root = createRoot(container!);
+root.render(<ExtensionPopup />);

--- a/packages/connect-explorer/src/middlewares/trezorConnectMiddleware.ts
+++ b/packages/connect-explorer/src/middlewares/trezorConnectMiddleware.ts
@@ -1,7 +1,6 @@
 import { MiddlewareAPI } from 'redux';
 
 import { Dispatch, AppState, Action } from '../types';
-import { getQueryVariable } from '../utils/windowUtils';
 import { ON_LOCATION_CHANGE } from '../actions';
 import { init } from '../actions/trezorConnectActions';
 
@@ -12,7 +11,11 @@ export const trezorConnectMiddleware =
         next(action);
 
         if (action.type === ON_LOCATION_CHANGE && !prevConnectOptions) {
-            const connectSrc = getQueryVariable('src');
+            // TODO: just for dev! still need to figure out best way to pass proper src to web-extension version of connect-explorer
+            // const connectSrc = getQueryVariable('src');
+            // const connectSrc = 'http://localhost:8088';
+            const connectSrc =
+                'https://suite.corp.sldev.cz/connect/feat/connect-explorer-serviceworker-proxy/';
             const options = {};
             if (connectSrc) {
                 Object.assign(options, { connectSrc });

--- a/packages/connect-explorer/webpack/webextension.webpack.config.ts
+++ b/packages/connect-explorer/webpack/webextension.webpack.config.ts
@@ -1,0 +1,187 @@
+/* eslint-disable import/no-default-export */
+import path from 'path';
+import webpack from 'webpack';
+import HtmlWebpackPlugin from 'html-webpack-plugin';
+import CopyPlugin from 'copy-webpack-plugin';
+import { execSync } from 'child_process';
+
+const commitHash = execSync('git rev-parse HEAD').toString().trim();
+
+const DIST = path.resolve(__dirname, '../build-webextension');
+const CONNECT_WEB_PATH = path.join(__dirname, '..', '..', 'connect-web');
+
+const CONNECT_WEB_EXTENSION_PATH = path.join(CONNECT_WEB_PATH, 'src', 'webextension');
+
+const CONNECT_WEB_EXTENSION_PACKAGE_PATH = path.join(
+    __dirname,
+    '..',
+    '..',
+    'connect-webextension',
+    'build',
+);
+
+const config: webpack.Configuration = {
+    target: 'web',
+    mode: 'production',
+    entry: {
+        extensionPopup: path.join(
+            __dirname,
+            '..',
+            'src-webextension',
+            'pages',
+            'extension-popup',
+            'index.tsx',
+        ),
+        connectExplorer: path.join(
+            __dirname,
+            '..',
+            'src-webextension',
+            'pages',
+            'connect-explorer',
+            'index.tsx',
+        ),
+        serviceWorker: path.join(
+            __dirname,
+            '..',
+            'src-webextension',
+            'background',
+            'serviceWorker.ts',
+        ),
+    },
+    output: {
+        filename: '[name].bundle.js',
+        path: DIST,
+        publicPath: './',
+    },
+    module: {
+        rules: [
+            {
+                test: /\.(j|t)sx?$/,
+                exclude: /node_modules/,
+                use: {
+                    loader: 'babel-loader',
+                    options: {
+                        cacheDirectory: true,
+                        presets: [
+                            [
+                                '@babel/preset-react',
+                                {
+                                    runtime: 'automatic',
+                                },
+                            ],
+                            '@babel/preset-typescript',
+                        ],
+                        plugins: [
+                            '@babel/plugin-proposal-class-properties',
+                            [
+                                'babel-plugin-styled-components',
+                                {
+                                    displayName: true,
+                                    preprocess: true,
+                                },
+                            ],
+                        ],
+                    },
+                },
+            },
+            {
+                test: /\.(gif|jpe?g|png|svg)$/,
+                type: 'asset/resource',
+                generator: {
+                    filename: './images/[name][contenthash][ext]',
+                },
+            },
+        ],
+    },
+    resolve: {
+        extensions: ['.ts', '.tsx', '.js', '.jsx'],
+        modules: ['node_modules'],
+        mainFields: ['browser', 'module', 'main'],
+        fallback: {
+            fs: false, // ignore "fs" import in markdown-it-imsize
+            path: false, // ignore "path" import in markdown-it-imsize
+        },
+    },
+    performance: {
+        hints: false,
+    },
+    plugins: [
+        new HtmlWebpackPlugin({
+            chunks: ['extensionPopup'],
+            filename: 'extension-popup.html',
+            template: path.join(
+                __dirname,
+                '..',
+                'src-webextension',
+                'pages',
+                'extension-popup',
+                'index.html',
+            ),
+            inject: true,
+            minify: false,
+        }),
+        new HtmlWebpackPlugin({
+            chunks: ['connectExplorer'],
+            filename: 'connect-explorer.html',
+            template: path.join(
+                __dirname,
+                '..',
+                'src-webextension',
+                'pages',
+                'connect-explorer',
+                'index.html',
+            ),
+            inject: true,
+            minify: false,
+        }),
+        new CopyPlugin({
+            patterns: [
+                {
+                    from: path.join(__dirname, '..', 'src-webextension', 'manifest.json'),
+                    to: `${DIST}/`,
+                },
+            ],
+        }),
+        new CopyPlugin({
+            patterns: [
+                {
+                    from: path.join(
+                        CONNECT_WEB_EXTENSION_PACKAGE_PATH,
+                        'trezor-connect-webextension.js',
+                    ),
+                    to: `${DIST}/vendor`,
+                    info: { minimized: false },
+                },
+                {
+                    from: path.join(
+                        CONNECT_WEB_EXTENSION_PACKAGE_PATH,
+                        'trezor-connect-webextension-background-proxy.js',
+                    ),
+                    to: `${DIST}/vendor`,
+                    info: { minimized: false },
+                },
+                {
+                    from: path.join(CONNECT_WEB_EXTENSION_PATH, 'trezor-usb-permissions.js'),
+                    to: `${DIST}/vendor`,
+                },
+                {
+                    from: path.join(CONNECT_WEB_EXTENSION_PATH, 'trezor-usb-permissions.html'),
+                    to: `${DIST}`,
+                },
+            ],
+        }),
+        new webpack.DefinePlugin({
+            // eslint-disable-next-line no-underscore-dangle
+            'process.env.__TREZOR_CONNECT_SRC': JSON.stringify(process.env.__TREZOR_CONNECT_SRC),
+            'process.env.COMMIT_HASH': JSON.stringify(commitHash),
+        }),
+        // TODO
+        // imports from @trezor-connect-web in @trezor/connect-explorer package need to be replaced by imports from @trezor/connect-proxy
+        new webpack.NormalModuleReplacementPlugin(
+            /@trezor\/connect-web/,
+            '@trezor/connect-webextension/lib/proxy',
+        ),
+    ],
+};
+
+export default config;

--- a/packages/connect-popup/e2e/support/helpers.ts
+++ b/packages/connect-popup/e2e/support/helpers.ts
@@ -28,8 +28,8 @@ const getExtensionPage = async () => {
         '..',
         '..',
         '..',
-        'connect-explorer-webextension',
-        'build',
+        'connect-explorer',
+        'build-webextension',
     );
 
     const initialBrowserContext = await chromium.launchPersistentContext(

--- a/packages/connect-popup/e2e/tests/passphrase.test.ts
+++ b/packages/connect-popup/e2e/tests/passphrase.test.ts
@@ -20,6 +20,8 @@ test.beforeAll(async () => {
 });
 
 test.beforeEach(async () => {
+    log('beforeEach url', url);
+    log('beforeEach isWebExtension', `${isWebExtension}`);
     log('beforeEach', 'stopBridge');
     await TrezorUserEnvLink.api.stopBridge();
     log('beforeEach', 'stopEmu');
@@ -55,6 +57,7 @@ let popup: Page;
 // Debug mode does not have to be enable since it is default in connect-explorer
 test('input passphrase in popup and device accepts it', async ({ page }) => {
     log('start', test.info().title);
+    log('url', url);
     const { explorerPage, exploreUrl, browserContext } = await getContexts(
         page,
         url,
@@ -102,6 +105,8 @@ test('input passphrase in popup and device accepts it', async ({ page }) => {
 });
 
 test('introduce passphrase in popup and device rejects it', async ({ page }) => {
+    log('start', test.info().title);
+
     const { explorerPage, exploreUrl, browserContext } = await getContexts(
         page,
         url,
@@ -137,6 +142,8 @@ test('introduce passphrase in popup and device rejects it', async ({ page }) => 
 });
 
 test('introduce passphrase successfully next time should not ask for it', async ({ page }) => {
+    log('start', test.info().title);
+
     const { explorerPage, exploreUrl, browserContext } = await getContexts(
         page,
         url,
@@ -188,6 +195,8 @@ test('introduce passphrase successfully next time should not ask for it', async 
 test('introduce passphrase successfully reload 3rd party it should ask again for passphrase', async ({
     page,
 }) => {
+    log('start', test.info().title);
+
     const { explorerPage, exploreUrl, browserContext } = await getContexts(
         page,
         url,
@@ -240,6 +249,8 @@ test('introduce passphrase successfully reload 3rd party it should ask again for
 });
 
 test('passphrase mismatch', async ({ page }) => {
+    log('start', test.info().title);
+
     if (isWebExtension) {
         // This test uses addScriptTag so we cannot run it in web extension.
         test.skip();

--- a/packages/connect-webextension/package.json
+++ b/packages/connect-webextension/package.json
@@ -31,13 +31,15 @@
         "build:lib": "rimraf ./lib && yarn tsc --build tsconfig.lib.json",
         "build:content-script": "TS_NODE_PROJECT=\"tsconfig.lib.json\" webpack --config ./webpack/content-script.webpack.config.ts",
         "build:inline": "TS_NODE_PROJECT=\"tsconfig.lib.json\" webpack --config ./webpack/inline.webpack.config.ts",
+        "build:proxy": "TS_NODE_PROJECT=\"tsconfig.lib.json\" webpack --config ./webpack/proxy.webpack.config.ts",
         "build:webextension": "TS_NODE_PROJECT=\"tsconfig.lib.json\" yarn webpack --config ./webpack/prod.webpack.config.ts",
-        "build": "rimraf build && yarn build:content-script &&  yarn build:webextension && yarn build:inline && node ./webpack/inline-content-script.js"
+        "build": "rimraf build && yarn build:content-script &&  yarn build:webextension && yarn build:inline && node ./webpack/inline-content-script.js && yarn build:proxy"
     },
     "dependencies": {
         "@trezor/connect": "workspace:*",
         "@trezor/connect-common": "workspace:*",
         "@trezor/utils": "workspace:*",
+        "@trezor/worker-proxy": "workspace:^",
         "events": "^3.3.0"
     },
     "devDependencies": {

--- a/packages/connect-webextension/src/channels/serviceworker-window.ts
+++ b/packages/connect-webextension/src/channels/serviceworker-window.ts
@@ -76,5 +76,6 @@ export class ServiceWorkerWindowChannel<
 
     disconnect() {
         this.port?.disconnect();
+        this.clear();
     }
 }

--- a/packages/connect-webextension/src/channels/serviceworker-window.ts
+++ b/packages/connect-webextension/src/channels/serviceworker-window.ts
@@ -74,6 +74,19 @@ export class ServiceWorkerWindowChannel<
         });
     }
 
+    resolveMessagePromises() {
+        // This is useful when we know that the connection has been interrupted but there might be something waiting for it.x
+        Object.keys(this.messagePromises).forEach(id =>
+            this.messagePromises[id as any].resolve({
+                id,
+                payload: {
+                    code: 'Method_Interrupted',
+                    error: 'Popup closed',
+                },
+            }),
+        );
+    }
+
     disconnect() {
         this.port?.disconnect();
         this.clear();

--- a/packages/connect-webextension/src/contentScript.ts
+++ b/packages/connect-webextension/src/contentScript.ts
@@ -47,7 +47,6 @@ channel.init().then(() => {
         window.postMessage(
             {
                 type: 'popup-closed',
-                payload: { ...chrome.runtime.getManifest(), id: chrome.runtime.id },
             },
             window.location.origin,
         );

--- a/packages/connect-webextension/src/contentScript.ts
+++ b/packages/connect-webextension/src/contentScript.ts
@@ -42,4 +42,14 @@ channel.init().then(() => {
             channel.postMessage(event.data, { usePromise: false });
         }
     });
+
+    window.addEventListener('beforeunload', () => {
+        window.postMessage(
+            {
+                type: 'popup-closed',
+                payload: { ...chrome.runtime.getManifest(), id: chrome.runtime.id },
+            },
+            window.location.origin,
+        );
+    });
 });

--- a/packages/connect-webextension/src/index.ts
+++ b/packages/connect-webextension/src/index.ts
@@ -86,6 +86,7 @@ const init = (settings: Partial<ConnectSettings> = {}): Promise<void> => {
     }
 
     _popupManager.channel.on('message', message => {
+        console.log('message in init connect-webextension TrezorConnect', message);
         if (message.type === POPUP.CORE_LOADED) {
             _popupManager.channel.postMessage({
                 type: POPUP.HANDSHAKE,
@@ -98,6 +99,8 @@ const init = (settings: Partial<ConnectSettings> = {}): Promise<void> => {
         // TODO: because when popup closes and TrezorConnect is leaving there it cannot respond, but we know
         // TODO: it was interrupted.
         if (message.type === 'popup-closed') {
+            console.log('calling resolveMessagePromises from service worker');
+            _popupManager.channel.resolveMessagePromises();
             // _popupManager.clear();
             // dispose();
         }
@@ -138,6 +141,8 @@ const call: CallMethod = async params => {
             type: IFRAME.CALL,
             payload: params,
         });
+
+        console.log('response after post message in call in webextension', response);
 
         logger.debug('call: response: ', response);
 

--- a/packages/connect-webextension/src/proxy/background-proxy-api.ts
+++ b/packages/connect-webextension/src/proxy/background-proxy-api.ts
@@ -1,0 +1,37 @@
+let _settings: any;
+const broadcast = new BroadcastChannel('connect-explorer');
+broadcast.onmessage = (event: any) => {
+    const { data } = event;
+    const { method, args, id } = data;
+
+    if (method === 'init') {
+        const { settings } = args[0];
+        // TODO: use the provided settings in init.
+        console.log('settings', settings);
+        // const devSettings = {
+        //     manifest: {
+        //         email: 'test@webextension.com',
+        //         appUrl: 'http://localhost:8088',
+        //     },
+        //     transports: ['BridgeTransport', 'WebUsbTransport'],
+        //     connectSrc: 'http://localhost:8088/',
+        // };
+        // @ts-expect-error
+        TrezorConnect.init(settings).then((response: any) => {
+            broadcast.postMessage({
+                id,
+                payload: response,
+            });
+        });
+        return;
+    }
+
+    // @ts-expect-error
+    TrezorConnect[method](...args).then((response: any) => {
+        console.log('res', response);
+        broadcast.postMessage({
+            id,
+            payload: response,
+        });
+    });
+};

--- a/packages/connect-webextension/src/proxy/index.ts
+++ b/packages/connect-webextension/src/proxy/index.ts
@@ -1,0 +1,122 @@
+import EventEmitter from 'events';
+
+// NOTE: @trezor/connect part is intentionally not imported from the index due to NormalReplacementPlugin
+// in packages/suite-build/configs/web.webpack.config.ts
+import {
+    ERRORS,
+    createErrorMessage,
+    ConnectSettings,
+    Manifest,
+    UiResponseEvent,
+    CallMethod,
+} from '@trezor/connect/lib/exports';
+import { factory } from '@trezor/connect/lib/factory';
+import { createWorkerProxy } from '@trezor/worker-proxy';
+
+import { parseConnectSettings } from '../connectSettings';
+
+const eventEmitter = new EventEmitter();
+let _settings = parseConnectSettings();
+
+// TODO: type it
+let _proxy: any;
+
+const manifest = (data: Manifest) => {
+    _settings = parseConnectSettings({
+        ..._settings,
+        manifest: data,
+    });
+};
+
+const dispose = () => {
+    eventEmitter.removeAllListeners();
+    _settings = parseConnectSettings();
+
+    if (_proxy) {
+        _proxy.dispose();
+    }
+    return Promise.resolve(undefined);
+};
+
+const cancel = (error?: string) => {
+    console.error(error);
+
+    if (_proxy) {
+        _proxy.cancel();
+    }
+};
+
+const init = async (settings: Partial<ConnectSettings> = {}): Promise<void> => {
+    console.log('settings in init in proxy/index', settings);
+    _settings = parseConnectSettings({ ..._settings, ...settings });
+
+    if (!_proxy) {
+        _proxy = await createWorkerProxy<typeof TrezorConnect>('TrezorConnect');
+    }
+
+    if (!_settings.manifest) {
+        throw ERRORS.TypedError('Init_ManifestMissing');
+    }
+
+    if (!_settings.transports?.length) {
+        _settings.transports = ['BridgeTransport', 'WebUsbTransport'];
+    }
+
+    return _proxy.init({ settings: _settings });
+};
+
+const call: CallMethod = async (params: any) => {
+    try {
+        const response = await _proxy[params.method](params);
+        if (response) {
+            return response;
+        }
+        return createErrorMessage(ERRORS.TypedError('Method_NoResponse'));
+    } catch (error) {
+        _proxy.clear();
+
+        return createErrorMessage(error);
+    }
+};
+
+const uiResponse = (response: UiResponseEvent) => {
+    const { type, payload } = response;
+    console.log('type', type);
+    console.log('payload', payload);
+    // TODO: ???
+};
+
+const renderWebUSBButton = () => {};
+
+const requestLogin = () => {
+    // todo: not supported yet
+    throw ERRORS.TypedError('Method_InvalidPackage');
+};
+
+const disableWebUSB = () => {
+    // todo: not supported yet, probably not needed
+    throw ERRORS.TypedError('Method_InvalidPackage');
+};
+
+const requestWebUSBDevice = () => {
+    // not needed - webusb pairing happens in popup
+    throw ERRORS.TypedError('Method_InvalidPackage');
+};
+
+const TrezorConnect = factory({
+    eventEmitter,
+    manifest,
+    init,
+    call,
+    requestLogin,
+    uiResponse,
+    renderWebUSBButton,
+    disableWebUSB,
+    requestWebUSBDevice,
+    cancel,
+    dispose,
+});
+
+// eslint-disable-next-line import/no-default-export
+export default TrezorConnect;
+export * from '@trezor/connect/lib/exports';

--- a/packages/connect-webextension/webpack/proxy.webpack.config.ts
+++ b/packages/connect-webextension/webpack/proxy.webpack.config.ts
@@ -1,0 +1,30 @@
+import webpack from 'webpack';
+import path from 'path';
+
+import prod from './prod.webpack.config';
+
+// Generate inline script hosted on https://connect.trezor.io/X/trezor-connect-webextension.js
+// This is compiled and polyfilled npm package without Core logic
+
+const BACKGROUND_PROXY_API_PATH = path.resolve(__dirname, '../src/proxy/background-proxy-api.ts');
+
+const config: webpack.Configuration = {
+    target: 'web',
+    mode: 'production',
+    entry: {
+        // TODO: add minimize version of it?
+        'trezor-connect-webextension-background-proxy': BACKGROUND_PROXY_API_PATH,
+    },
+    output: {
+        filename: '[name].js',
+        path: path.resolve(__dirname, '../build'),
+    },
+
+    module: prod.module,
+    resolve: prod.resolve,
+    performance: prod.performance,
+    optimization: prod.optimization,
+};
+
+// eslint-disable-next-line import/no-default-export
+export default config;

--- a/packages/worker-proxy/package.json
+++ b/packages/worker-proxy/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "@trezor/worker-proxy",
+    "version": "1.0.0",
+    "private": true,
+    "license": "See LICENSE.md in repo root",
+    "sideEffects": false,
+    "main": "src/index",
+    "scripts": {
+        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "test:unit": "jest -c ../../jest.config.base.js --passWithNoTests",
+        "type-check": "tsc --build"
+    },
+    "dependencies": {
+        "@trezor/utils": "workspace:^"
+    }
+}

--- a/packages/worker-proxy/src/index.ts
+++ b/packages/worker-proxy/src/index.ts
@@ -1,0 +1,121 @@
+import { createDeferred, Deferred } from '@trezor/utils/lib/createDeferred';
+
+const getWorkerProxyApi = (proxyName: string) =>
+    // @ts-expect-error
+    typeof window !== 'undefined' ? window[proxyName] : undefined;
+
+// BroadcastChannelApi
+// type WorkerProxyApi = {
+//     // TODO: should it be async?
+//     init: (constructorParams: any) => Promise<any>;
+//     // BroadCastChannel extends EventTarget
+//     onmessage: ((channel: BroadcastChannel, ev: MessageEvent) => any) | null;
+//     postMessage(message: any): void;
+//     close(): void;
+// };
+
+let broadcastChannel: any;
+
+let proxyCallId = 0;
+let deferred: Deferred<any>[] = [];
+
+const getWorkerProxyMethods = () =>
+    // workerProxyApi: WorkerProxyApi,
+    // channelName: string,
+    // instanceId: string,
+    {
+        let initialized = false;
+
+        const init = (constructorParams?: any) => {
+            console.log('constructorParams in worker-proxy', constructorParams);
+            if (initialized) return true;
+            // Handshake with service worker
+            broadcastChannel = new BroadcastChannel('connect-explorer');
+            broadcastChannel.onmessage = (event: any) => {
+                const { data } = event;
+                const dfd = deferred.find(d => d.id === data.id);
+                if (!dfd) {
+                    return;
+                }
+                // TODO: handle errors.
+                // if (data.type === RESPONSES.ERROR) {
+                //     dfd.reject(new CustomError(data.payload.code, data.payload.message));
+                // } else {
+                //     dfd.resolve(data.payload);
+                // }
+                console.log('data.payload', data.payload);
+                dfd.resolve(data.payload);
+                deferred = deferred.filter(d => d !== dfd);
+            };
+            initialized = true;
+        };
+
+        const request =
+            (method: string) =>
+            (...args: any[]) => {
+                console.log('request in worker proxy');
+                console.log('method', method);
+                console.log('args', args);
+                console.log('broadcastChannel', broadcastChannel);
+                if (!broadcastChannel) {
+                    init();
+                }
+                const dfd = createDeferred(proxyCallId);
+                deferred.push(dfd);
+                broadcastChannel.postMessage({ method, args, id: proxyCallId });
+                proxyCallId++;
+                return dfd.promise;
+            };
+
+        return {
+            init,
+            request,
+        };
+    };
+
+interface WorkerProxyOptions {
+    proxyName?: string;
+    target?: Record<string, any>;
+}
+
+export const createWorkerProxy = async <T extends object>(
+    channelName: string,
+    options: WorkerProxyOptions = {},
+    ...constructorParams: any[] // constructor of <T> params, could be undefined
+) => {
+    const proxyName = options?.proxyName || 'BroadcastChannel';
+
+    const workerProxyApi = getWorkerProxyApi(proxyName);
+    if (!workerProxyApi) {
+        throw new Error(`${proxyName} not found`);
+    }
+
+    // const instanceId = await workerProxyApi.create(channelName, options.target);
+    const instanceId = 'test';
+
+    // workerProxyApi, channelName, instanceId
+    const { init, request } = getWorkerProxyMethods();
+
+    await init(constructorParams);
+
+    const prefix = `${channelName}/${instanceId}:`;
+    const target = { _workerProxy: prefix, ...options.target } as T;
+
+    const proxyHandler: ProxyHandler<T> = {
+        get: (proxyTarget: any, name) => {
+            if (typeof name === 'symbol') return proxyTarget[name];
+
+            // exclude promise-like methods. they presence may be checked since the whole process is async
+            if (['then', 'catch', 'finally'].includes(name)) return undefined;
+
+            if (proxyTarget[name]) {
+                return proxyTarget[name];
+            }
+
+            proxyTarget[name] = request(name);
+            return proxyTarget[name];
+        },
+    };
+
+    return new Proxy(target, proxyHandler);
+};

--- a/packages/worker-proxy/tsconfig.json
+++ b/packages/worker-proxy/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": { "outDir": "libDev" },
+    "references": []
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8536,7 +8536,10 @@ __metadata:
   dependencies:
     "@trezor/components": "workspace:*"
     "@trezor/connect-web": "workspace:*"
+    "@trezor/connect-webextension": "workspace:^"
     "@trezor/protobuf": "workspace:*"
+    "@trezor/utils": "workspace:^"
+    "@trezor/worker-proxy": "workspace:^"
     "@types/markdown-it": "npm:^13.0.5"
     "@types/markdown-it-link-attributes": "npm:^3.0.3"
     "@types/react-router": "npm:^5.1.20"
@@ -8724,7 +8727,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/connect-webextension@workspace:packages/connect-webextension":
+"@trezor/connect-webextension@workspace:^, @trezor/connect-webextension@workspace:packages/connect-webextension":
   version: 0.0.0-use.local
   resolution: "@trezor/connect-webextension@workspace:packages/connect-webextension"
   dependencies:
@@ -8737,6 +8740,7 @@ __metadata:
     "@trezor/node-utils": "workspace:*"
     "@trezor/trezor-user-env-link": "workspace:*"
     "@trezor/utils": "workspace:*"
+    "@trezor/worker-proxy": "workspace:^"
     "@types/chrome": "npm:latest"
     copy-webpack-plugin: "npm:^12.0.1"
     events: "npm:^3.3.0"
@@ -9573,7 +9577,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/utils@workspace:*, @trezor/utils@workspace:packages/utils":
+"@trezor/utils@workspace:*, @trezor/utils@workspace:^, @trezor/utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@trezor/utils@workspace:packages/utils"
   dependencies:
@@ -9632,6 +9636,14 @@ __metadata:
     jest: "npm:29.5.0"
     typescript: "npm:5.3.2"
     yup: "npm:^0.32.11"
+  languageName: unknown
+  linkType: soft
+
+"@trezor/worker-proxy@workspace:^, @trezor/worker-proxy@workspace:packages/worker-proxy":
+  version: 0.0.0-use.local
+  resolution: "@trezor/worker-proxy@workspace:packages/worker-proxy"
+  dependencies:
+    "@trezor/utils": "workspace:^"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Creating a new @trezor/worker-proxy to allow using new @trezor/connect-webextension package with connect explorer and without changes in connect-explorer proxy the connect communication to TrezorConnect running in service worker.

Run the commands below:
```
yarn && \
yarn build:libs && \
yarn workspace @trezor/connect-webextension build && \
yarn workspace @trezor/connect-iframe build:core-module && \
yarn workspace @trezor/connect-explorer build:webextension && \
yarn workspace @trezor/connect-popup dev
```
And then go to Chrome browser:

-   Go to chrome://extensions
-   Enable developer mode and load unpacked
-   Choose `packages/connect-explorer/build-webextension` directory
