### PR TITLE
chore(suite): bump version of the hookform/resolvers + fix the typing…

### DIFF
--- a/packages/components/src/components/form/Textarea/Textarea.tsx
+++ b/packages/components/src/components/form/Textarea/Textarea.tsx
@@ -60,7 +60,7 @@ export interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElemen
     noTopLabel?: boolean;
     noError?: boolean;
     value?: string;
-    characterCount?: boolean | { current: number; max: number };
+    characterCount?: boolean | { current: number | undefined; max: number };
 }
 
 export const Textarea = ({
@@ -93,7 +93,7 @@ export const Textarea = ({
         }
         // uncontrolled component
         if (typeof characterCount === 'object') {
-            return `${characterCount.current} / ${characterCount.max}`;
+            return `${characterCount.current ?? 0} / ${characterCount.max}`;
         }
     };
 

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "@formatjs/intl": "2.9.6",
-        "@hookform/resolvers": "3.1.0",
+        "@hookform/resolvers": "3.3.2",
         "@mobily/ts-belt": "^3.13.1",
         "@reduxjs/toolkit": "1.9.5",
         "@sentry/core": "^7.77.0",

--- a/packages/suite/src/hooks/wallet/sign-verify/useCopySignedMessage.ts
+++ b/packages/suite/src/hooks/wallet/sign-verify/useCopySignedMessage.ts
@@ -5,7 +5,10 @@ import { notificationsActions } from '@suite-common/toast-notifications';
 type SignedMessageData = {
     message: string;
     address: string;
-    signature: string;
+
+    // Due to wrong abstraction in `useSignVerifyForm` this needs to be optional.
+    // If we ever separate Sign and Verify forms this shall be set to required.
+    signature?: string;
 };
 
 const format = (

--- a/packages/suite/src/views/wallet/sign-verify/index.tsx
+++ b/packages/suite/src/views/wallet/sign-verify/index.tsx
@@ -297,7 +297,7 @@ const SignVerify = () => {
                             <Textarea
                                 maxLength={MAX_LENGTH_SIGNATURE}
                                 characterCount={{
-                                    current: formValues.signature?.length ?? 0,
+                                    current: formValues.signature?.length,
                                     max: MAX_LENGTH_SIGNATURE,
                                 }}
                                 rows={4}

--- a/packages/suite/src/views/wallet/sign-verify/index.tsx
+++ b/packages/suite/src/views/wallet/sign-verify/index.tsx
@@ -85,7 +85,7 @@ const Divider = styled.div`
     background: ${({ theme }) => theme.STROKE_GREY};
 `;
 
-const Copybutton = styled(Button)`
+const CopyButton = styled(Button)`
     position: absolute;
     right: 0;
     top: -2px;
@@ -169,14 +169,14 @@ const SignVerify = () => {
     const onSubmit = async (data: SignVerifyFields) => {
         const { address, path, message, signature, hex, isElectrum } = data;
 
-        if (isSignPage) {
+        if (isSignPage && path !== undefined) {
             const result = await dispatch(sign(path, message, hex, isElectrum));
 
             if (result) {
                 formSetSignature(result);
                 setIsCompleted(true);
             }
-        } else {
+        } else if (signature !== undefined) {
             const result = await dispatch(verify(address, message, signature, hex));
 
             if (result) setIsCompleted(true);
@@ -272,14 +272,14 @@ const SignVerify = () => {
                         {isSignPage ? (
                             <>
                                 {canCopy && (
-                                    <Copybutton
+                                    <CopyButton
                                         type="button"
                                         variant="tertiary"
                                         onClick={copy}
                                         icon="COPY"
                                     >
                                         <Translation id="TR_COPY_SIGNED_MESSAGE" />
-                                    </Copybutton>
+                                    </CopyButton>
                                 )}
 
                                 <Input
@@ -297,7 +297,7 @@ const SignVerify = () => {
                             <Textarea
                                 maxLength={MAX_LENGTH_SIGNATURE}
                                 characterCount={{
-                                    current: formValues.signature.length,
+                                    current: formValues.signature?.length ?? 0,
                                     max: MAX_LENGTH_SIGNATURE,
                                 }}
                                 rows={4}

--- a/suite-native/forms/package.json
+++ b/suite-native/forms/package.json
@@ -11,7 +11,7 @@
         "type-check": "tsc --build"
     },
     "dependencies": {
-        "@hookform/resolvers": "3.1.0",
+        "@hookform/resolvers": "3.3.2",
         "@suite-native/atoms": "workspace:*",
         "react": "18.2.0",
         "react-hook-form": "^7.48.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3351,12 +3351,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hookform/resolvers@npm:3.1.0":
-  version: 3.1.0
-  resolution: "@hookform/resolvers@npm:3.1.0"
+"@hookform/resolvers@npm:3.3.2":
+  version: 3.3.2
+  resolution: "@hookform/resolvers@npm:3.3.2"
   peerDependencies:
     react-hook-form: ^7.0.0
-  checksum: 6598cc7f44614bc3a678fa06d361fd75e123d66f4978eb4817dfa3df37e57214da13a5720bd7902a195cbd794954374cf8be3672eadc6b573fb257a2e6295454
+  checksum: 354930674c708c8b1c974fc944ad8f3980f9fed99e97ae57cb288c23f398b49276458755b45a1014de6dd2a587270377c38057cb16fb65b16c72431b96a34f81
   languageName: node
   linkType: hard
 
@@ -7337,7 +7337,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/forms@workspace:suite-native/forms"
   dependencies:
-    "@hookform/resolvers": "npm:3.1.0"
+    "@hookform/resolvers": "npm:3.3.2"
     "@suite-native/atoms": "workspace:*"
     react: "npm:18.2.0"
     react-hook-form: "npm:^7.48.2"
@@ -9281,7 +9281,7 @@ __metadata:
     "@crowdin/cli": "npm:^3.15.0"
     "@formatjs/cli": "npm:^6.2.1"
     "@formatjs/intl": "npm:2.9.6"
-    "@hookform/resolvers": "npm:3.1.0"
+    "@hookform/resolvers": "npm:3.3.2"
     "@mobily/ts-belt": "npm:^3.13.1"
     "@reduxjs/toolkit": "npm:1.9.5"
     "@sentry/core": "npm:^7.77.0"


### PR DESCRIPTION
## Description

This PR bumps version of the hookform/resolvers + fixies the typing error in the SignForm.

(The type of the form shall be always inferred from the validation scheme.)


### Sidenote:
This Sign & Verify forms shall be separate. This is wrong abstraction. This leads to many ifs (checks for `isSignPage`) all over the place effectively implementing both forms separately but in very messy way, smashed together.

This shall be refactored to implement those two forms separately. 



## Related Issue 

Resolve https://github.com/trezor/trezor-suite/issues/9863