### PR TITLE
fix(suite-desktop): disable native dependencies rebuild by setting build from source

### DIFF
--- a/packages/suite-desktop/electron-builder-config.js
+++ b/packages/suite-desktop/electron-builder-config.js
@@ -19,6 +19,8 @@ module.exports = {
     directories: {
         output: 'build-electron',
     },
+    buildDependenciesFromSource: true,
+    nodeGypRebuild: false,
     files: [
         // defaults are https://www.electron.build/configuration/contents.html#files
         'build/**/*',


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Potential release unblocker 🤞 

- both usb and blake-hash have prebuilds so they don't actually need rebuild during electron build

## Screenshots:
<img width="840" alt="image" src="https://github.com/trezor/trezor-suite/assets/3729633/782f94d1-9eb7-41ac-a2f6-6b9ab5e29226">

