### PR TITLE
fix(suite-desktop): disable rebuild of native dependencies completely

### DIFF
--- a/packages/suite-desktop/electron-builder-config.js
+++ b/packages/suite-desktop/electron-builder-config.js
@@ -19,8 +19,7 @@ module.exports = {
     directories: {
         output: 'build-electron',
     },
-    buildDependenciesFromSource: true,
-    nodeGypRebuild: false,
+    npmRebuild: false,
     files: [
         // defaults are https://www.electron.build/configuration/contents.html#files
         'build/**/*',


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

followup for https://github.com/trezor/trezor-suite/pull/10281
- Previous config disabled only cross platform rebuild but broke rebuild for same platform. This disable it completely.


Documentation of the params can be found here:
https://www.electron.build/configuration/configuration

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
<img width="891" alt="image" src="https://github.com/trezor/trezor-suite/assets/3729633/903f0068-0586-4265-81de-6058e861fd4c">
