### PR TITLE
Throttler throttling instead of debouncing in `@trezor/blockchain-link`

### DIFF
--- a/packages/blockchain-link/tests/unit/fixtures/notifications-blockbook.ts
+++ b/packages/blockchain-link/tests/unit/fixtures/notifications-blockbook.ts
@@ -82,7 +82,7 @@ const notifyBlocks = [
                 data: { hash: 'efgh05', height: 5 },
             },
         ],
-        notificationsCount: 1,
+        notificationsCount: 2,
         result: {
             blockHash: 'efgh05',
             blockHeight: 5,

--- a/packages/connect/src/backend/Blockchain.ts
+++ b/packages/connect/src/backend/Blockchain.ts
@@ -83,6 +83,7 @@ export class Blockchain {
             server,
             debug: options.debug,
             proxy: options.proxy,
+            ...(blockchainLink.type === 'ripple' ? { throttleBlockEvent: 60 * 1000 } : {}),
         });
     }
 


### PR DESCRIPTION
## Description

Relates only to block/notification events from blockchain-link. The difference is that from now on, the first throttled event is not delayed.

Also, timers mocked in unit tests.