### PR TITLE
fix(connect-explorer): fs, path, fallbacks in webpack

### DIFF
--- a/packages/connect-explorer-webextension/webpack/prod.webpack.config.ts
+++ b/packages/connect-explorer-webextension/webpack/prod.webpack.config.ts
@@ -72,9 +72,14 @@ const config: webpack.Configuration = {
         ],
     },
     resolve: {
+        // todo: this block is identical in connect-web, connect-explorer, and connect-explorer-webextension
         extensions: ['.ts', '.tsx', '.js', '.jsx'],
         modules: ['node_modules'],
         mainFields: ['browser', 'module', 'main'],
+        fallback: {
+            fs: false, // ignore "fs" import in markdown-it-imsize
+            path: false, // ignore "path" import in markdown-it-imsize
+        },
     },
     performance: {
         hints: false,

--- a/packages/connect-explorer/webpack/prod.webpack.config.ts
+++ b/packages/connect-explorer/webpack/prod.webpack.config.ts
@@ -58,10 +58,15 @@ const config: webpack.Configuration = {
             },
         ],
     },
+    // todo: this block is identical in connect-web, connect-explorer, and connect-explorer-webextension
     resolve: {
         extensions: ['.ts', '.tsx', '.js', '.jsx'],
         modules: ['node_modules'],
         mainFields: ['browser', 'module', 'main'],
+        fallback: {
+            fs: false, // ignore "fs" import in markdown-it-imsize
+            path: false, // ignore "path" import in markdown-it-imsize
+        },
     },
     performance: {
         hints: false,

--- a/packages/connect-web/webpack/prod.webpack.config.ts
+++ b/packages/connect-web/webpack/prod.webpack.config.ts
@@ -43,10 +43,15 @@ const config: webpack.Configuration = {
             },
         ],
     },
+    // todo: this block is identical in connect-web, connect-explorer, and connect-explorer-webextension
     resolve: {
         modules: ['node_modules'],
         mainFields: ['browser', 'module', 'main'],
         extensions: ['.ts', '.js'],
+        fallback: {
+            fs: false, // ignore "fs" import in markdown-it-imsize
+            path: false, // ignore "path" import in markdown-it-imsize
+        },
     },
     performance: {
         hints: false,


### PR DESCRIPTION
hmm somehow we managed to break CI again, for example https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/5726919141

this is fixing it but I totaly don't get how it did happen? it must have been some combination of 2 changes where each of them passed its own pipeline but started to fail when they got merged together? I don't get it :( 