### PR TITLE
chore(connect): use `tslib` as dependency  in all public libs

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -21,5 +21,8 @@
     "devDependencies": {
         "jest": "29.5.0",
         "typescript": "5.3.2"
+    },
+    "peerDependencies": {
+        "tslib": "^2.6.2"
     }
 }

--- a/packages/analytics/tsconfig.lib.json
+++ b/packages/analytics/tsconfig.lib.json
@@ -2,6 +2,7 @@
     "extends": "../../tsconfig.lib.json",
     "compilerOptions": {
         "outDir": "./lib",
+        "importHelpers": true,
         "esModuleInterop": false
     },
     "include": ["./src"]

--- a/packages/blockchain-link-utils/package.json
+++ b/packages/blockchain-link-utils/package.json
@@ -29,5 +29,8 @@
         "rimraf": "^5.0.5",
         "tsx": "^4.6.2",
         "typescript": "5.3.2"
+    },
+    "peerDependencies": {
+        "tslib": "^2.6.2"
     }
 }

--- a/packages/blockchain-link-utils/tsconfig.lib.json
+++ b/packages/blockchain-link-utils/tsconfig.lib.json
@@ -1,7 +1,8 @@
 {
     "extends": "../../tsconfig.lib.json",
     "compilerOptions": {
-        "outDir": "lib"
+        "outDir": "lib",
+        "importHelpers": true
     },
     "include": ["./src"]
 }

--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -79,5 +79,8 @@
         "ripple-lib": "^1.10.1",
         "socks-proxy-agent": "6.1.1",
         "ws": "7.5.9"
+    },
+    "peerDependencies": {
+        "tslib": "^2.6.2"
     }
 }

--- a/packages/blockchain-link/tsconfig.lib.json
+++ b/packages/blockchain-link/tsconfig.lib.json
@@ -3,7 +3,8 @@
     "compilerOptions": {
         "outDir": "./lib",
         "lib": ["webworker"],
-        "types": ["jest", "node", "web"]
+        "types": ["jest", "node", "web"],
+        "importHelpers": true
     },
     "include": ["./src"]
 }

--- a/packages/connect-analytics/package.json
+++ b/packages/connect-analytics/package.json
@@ -18,5 +18,8 @@
     },
     "devDependencies": {
         "typescript": "5.3.2"
+    },
+    "peerDependencies": {
+        "tslib": "^2.6.2"
     }
 }

--- a/packages/connect-analytics/tsconfig.lib.json
+++ b/packages/connect-analytics/tsconfig.lib.json
@@ -2,6 +2,7 @@
     "extends": "../../tsconfig.lib.json",
     "compilerOptions": {
         "outDir": "./lib",
+        "importHelpers": true,
         "esModuleInterop": false
     },
     "include": ["./src"]

--- a/packages/connect-common/package.json
+++ b/packages/connect-common/package.json
@@ -44,5 +44,8 @@
         "rimraf": "^5.0.5",
         "tsx": "^4.6.2",
         "typescript": "5.3.2"
+    },
+    "peerDependencies": {
+        "tslib": "^2.6.2"
     }
 }

--- a/packages/connect-common/tsconfig.lib.json
+++ b/packages/connect-common/tsconfig.lib.json
@@ -3,6 +3,7 @@
     "compilerOptions": {
         "target": "es5",
         "outDir": "./lib",
+        "importHelpers": true,
         "esModuleInterop": false
     },
     "include": ["./src"]

--- a/packages/connect-plugin-ethereum/package.json
+++ b/packages/connect-plugin-ethereum/package.json
@@ -23,7 +23,8 @@
         "lib/"
     ],
     "peerDependencies": {
-        "@metamask/eth-sig-util": "^7.0.0"
+        "@metamask/eth-sig-util": "^7.0.0",
+        "tslib": "^2.6.2"
     },
     "devDependencies": {
         "@metamask/eth-sig-util": "^7.0.0",

--- a/packages/connect-plugin-ethereum/tsconfig.lib.json
+++ b/packages/connect-plugin-ethereum/tsconfig.lib.json
@@ -2,6 +2,7 @@
     "extends": "../../tsconfig.lib.json",
     "compilerOptions": {
         "outDir": "lib",
+        "importHelpers": true,
         "lib": ["ES2019"]
     },
     "include": ["./src"]

--- a/packages/connect-plugin-stellar/package.json
+++ b/packages/connect-plugin-stellar/package.json
@@ -24,7 +24,8 @@
     ],
     "peerDependencies": {
         "@trezor/connect": "9.x.x",
-        "stellar-sdk": "^v11.0.0-beta.3"
+        "stellar-sdk": "^v11.0.0-beta.3",
+        "tslib": "^2.6.2"
     },
     "devDependencies": {
         "jest": "29.5.0",

--- a/packages/connect-plugin-stellar/tsconfig.lib.json
+++ b/packages/connect-plugin-stellar/tsconfig.lib.json
@@ -1,7 +1,8 @@
 {
     "extends": "../../tsconfig.lib.json",
     "compilerOptions": {
-        "outDir": "lib"
+        "outDir": "lib",
+        "importHelpers": true
     },
     "include": ["./src"]
 }

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -62,5 +62,8 @@
         "webpack-merge": "^5.10.0",
         "webpack-plugin-serve": "^1.6.0",
         "xvfb-maybe": "^0.2.1"
+    },
+    "peerDependencies": {
+        "tslib": "^2.6.2"
     }
 }

--- a/packages/connect-webextension/package.json
+++ b/packages/connect-webextension/package.json
@@ -58,5 +58,8 @@
         "webpack-merge": "^5.9.0",
         "webpack-plugin-serve": "^1.6.0",
         "xvfb-maybe": "^0.2.1"
+    },
+    "peerDependencies": {
+        "tslib": "^2.6.2"
     }
 }

--- a/packages/env-utils/package.json
+++ b/packages/env-utils/package.json
@@ -35,7 +35,8 @@
     "peerDependencies": {
         "expo-localization": "^14.1.1",
         "react-native": "0.71.8",
-        "react-native-config": "^1.5.0"
+        "react-native-config": "^1.5.0",
+        "tslib": "^2.6.2"
     },
     "peerDependenciesMeta": {
         "expo-localization": {

--- a/packages/env-utils/tsconfig.lib.json
+++ b/packages/env-utils/tsconfig.lib.json
@@ -1,7 +1,8 @@
 {
     "extends": "../../tsconfig.lib.json",
     "compilerOptions": {
-        "outDir": "lib"
+        "outDir": "lib",
+        "importHelpers": true
     },
     "include": ["./src"]
 }

--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -40,5 +40,8 @@
         "rimraf": "^5.0.5",
         "tsx": "^4.6.2",
         "typescript": "5.3.2"
+    },
+    "peerDependencies": {
+        "tslib": "^2.6.2"
     }
 }

--- a/packages/protobuf/tsconfig.lib.json
+++ b/packages/protobuf/tsconfig.lib.json
@@ -1,7 +1,8 @@
 {
     "extends": "../../tsconfig.lib.json",
     "compilerOptions": {
-        "outDir": "lib"
+        "outDir": "lib",
+        "importHelpers": true
     },
     "include": ["./src"]
 }

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -32,5 +32,8 @@
         "rimraf": "^5.0.5",
         "tsx": "^4.6.2",
         "typescript": "5.3.2"
+    },
+    "peerDependencies": {
+        "tslib": "^2.6.2"
     }
 }

--- a/packages/protocol/tsconfig.lib.json
+++ b/packages/protocol/tsconfig.lib.json
@@ -1,7 +1,8 @@
 {
     "extends": "../../tsconfig.lib.json",
     "compilerOptions": {
-        "outDir": "lib"
+        "outDir": "lib",
+        "importHelpers": true
     },
     "include": ["./src"]
 }

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -63,5 +63,8 @@
         "long": "^4.0.0",
         "protobufjs": "7.2.5",
         "usb": "^2.11.0"
+    },
+    "peerDependencies": {
+        "tslib": "^2.6.2"
     }
 }

--- a/packages/transport/tsconfig.lib.json
+++ b/packages/transport/tsconfig.lib.json
@@ -2,7 +2,8 @@
     "extends": "../../tsconfig.lib.json",
     "compilerOptions": {
         "outDir": "./lib",
-        "types": ["w3c-web-usb"]
+        "types": ["w3c-web-usb"],
+        "importHelpers": true
     },
     "include": ["./src"]
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -32,5 +32,8 @@
         "rimraf": "^5.0.5",
         "tsx": "^4.6.2",
         "typescript": "5.3.2"
+    },
+    "peerDependencies": {
+        "tslib": "^2.6.2"
     }
 }

--- a/packages/utils/tsconfig.lib.json
+++ b/packages/utils/tsconfig.lib.json
@@ -1,7 +1,8 @@
 {
     "extends": "../../tsconfig.lib.json",
     "compilerOptions": {
-        "outDir": "lib"
+        "outDir": "lib",
+        "importHelpers": true
     },
     "include": ["./src"]
 }

--- a/packages/utxo-lib/package.json
+++ b/packages/utxo-lib/package.json
@@ -67,5 +67,8 @@
         "rimraf": "^5.0.5",
         "tsx": "^4.6.2",
         "typescript": "5.3.2"
+    },
+    "peerDependencies": {
+        "tslib": "^2.6.2"
     }
 }

--- a/packages/utxo-lib/tsconfig.lib.json
+++ b/packages/utxo-lib/tsconfig.lib.json
@@ -1,7 +1,8 @@
 {
     "extends": "../../tsconfig.lib.json",
     "compilerOptions": {
-        "outDir": "./lib"
+        "outDir": "./lib",
+        "importHelpers": true
     },
     "include": ["./src"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8268,6 +8268,8 @@ __metadata:
     "@trezor/utils": "workspace:*"
     jest: "npm:29.5.0"
     typescript: "npm:5.3.2"
+  peerDependencies:
+    tslib: ^2.6.2
   languageName: unknown
   linkType: soft
 
@@ -8313,6 +8315,8 @@ __metadata:
     rimraf: "npm:^5.0.5"
     tsx: "npm:^4.6.2"
     typescript: "npm:5.3.2"
+  peerDependencies:
+    tslib: ^2.6.2
   languageName: unknown
   linkType: soft
 
@@ -8345,6 +8349,8 @@ __metadata:
     webpack-dev-server: "npm:^4.15.1"
     worker-loader: "npm:^3.0.8"
     ws: "npm:7.5.9"
+  peerDependencies:
+    tslib: ^2.6.2
   languageName: unknown
   linkType: soft
 
@@ -8422,6 +8428,8 @@ __metadata:
   dependencies:
     "@trezor/analytics": "workspace:*"
     typescript: "npm:5.3.2"
+  peerDependencies:
+    tslib: ^2.6.2
   languageName: unknown
   linkType: soft
 
@@ -8435,6 +8443,8 @@ __metadata:
     rimraf: "npm:^5.0.5"
     tsx: "npm:^4.6.2"
     typescript: "npm:5.3.2"
+  peerDependencies:
+    tslib: ^2.6.2
   languageName: unknown
   linkType: soft
 
@@ -8533,6 +8543,7 @@ __metadata:
     typescript: "npm:5.3.2"
   peerDependencies:
     "@metamask/eth-sig-util": ^7.0.0
+    tslib: ^2.6.2
   languageName: unknown
   linkType: soft
 
@@ -8549,6 +8560,7 @@ __metadata:
   peerDependencies:
     "@trezor/connect": 9.x.x
     stellar-sdk: ^v11.0.0-beta.3
+    tslib: ^2.6.2
   languageName: unknown
   linkType: soft
 
@@ -8644,6 +8656,8 @@ __metadata:
     webpack-merge: "npm:^5.10.0"
     webpack-plugin-serve: "npm:^1.6.0"
     xvfb-maybe: "npm:^0.2.1"
+  peerDependencies:
+    tslib: ^2.6.2
   languageName: unknown
   linkType: soft
 
@@ -8672,6 +8686,8 @@ __metadata:
     webpack-merge: "npm:^5.9.0"
     webpack-plugin-serve: "npm:^1.6.0"
     xvfb-maybe: "npm:^0.2.1"
+  peerDependencies:
+    tslib: ^2.6.2
   languageName: unknown
   linkType: soft
 
@@ -8769,6 +8785,7 @@ __metadata:
     expo-localization: ^14.1.1
     react-native: 0.71.8
     react-native-config: ^1.5.0
+    tslib: ^2.6.2
   peerDependenciesMeta:
     expo-localization:
       optional: true
@@ -8806,6 +8823,8 @@ __metadata:
     rimraf: "npm:^5.0.5"
     tsx: "npm:^4.6.2"
     typescript: "npm:5.3.2"
+  peerDependencies:
+    tslib: ^2.6.2
   languageName: unknown
   linkType: soft
 
@@ -8818,6 +8837,8 @@ __metadata:
     rimraf: "npm:^5.0.5"
     tsx: "npm:^4.6.2"
     typescript: "npm:5.3.2"
+  peerDependencies:
+    tslib: ^2.6.2
   languageName: unknown
   linkType: soft
 
@@ -9423,6 +9444,8 @@ __metadata:
     tsx: "npm:^4.6.2"
     typescript: "npm:5.3.2"
     usb: "npm:^2.11.0"
+  peerDependencies:
+    tslib: ^2.6.2
   languageName: unknown
   linkType: soft
 
@@ -9463,6 +9486,8 @@ __metadata:
     rimraf: "npm:^5.0.5"
     tsx: "npm:^4.6.2"
     typescript: "npm:5.3.2"
+  peerDependencies:
+    tslib: ^2.6.2
   languageName: unknown
   linkType: soft
 
@@ -9499,6 +9524,8 @@ __metadata:
     typescript: "npm:5.3.2"
     varuint-bitcoin: "npm:^1.1.2"
     wif: "npm:^4.0.0"
+  peerDependencies:
+    tslib: ^2.6.2
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use `tslib` in all public libs, [connect is already using it](https://github.com/trezor/trezor-suite/commit/f8280779b4d63e79f63fc8da5872d215e2d3b325) but underlying libs are not.

This reduces final minified build size of connect-iframe  by ~50kb i didnt measure suite-desktop bundles size

```
du -bc ./packages/connect-iframe/build/js

// before:
4716020	total

// after:
4665216	total
```
