### PR TITLE
fix(suite): fix Solana account subscription and then disable it for now

### DIFF
--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -329,8 +329,8 @@ const subscribeAccounts = async (
                     },
                 },
             });
-            state.addAccounts([{ ...a, subscriptionId }]);
         });
+        state.addAccounts([{ ...a, subscriptionId }]);
     });
     return { subscribed: true };
 };
@@ -433,6 +433,20 @@ class SolanaWorker extends BaseWorker<SolanaAPI> {
     }
 
     disconnect(): void {
+        if (!this.api) {
+            return;
+        }
+
+        this.state.accounts.forEach(
+            a => a.subscriptionId && this.api?.removeAccountChangeListener(a.subscriptionId),
+        );
+
+        if (this.state.getSubscription('block')) {
+            const interval = this.state.getSubscription('block') as NodeJS.Timer;
+            clearInterval(interval);
+            this.state.removeSubscription('block');
+        }
+
         this.api = undefined;
     }
 }

--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -282,6 +282,7 @@ const unsubscribeBlock = ({ state }: Context) => {
     state.removeSubscription('block');
 };
 
+// @ts-expect-error
 const subscribeAccounts = async (
     { connect, state, post }: Context,
     accounts: SubscriptionAccountInfo[],
@@ -335,6 +336,7 @@ const subscribeAccounts = async (
     return { subscribed: true };
 };
 
+// @ts-expect-error
 const unsubscribeAccounts = async (
     { state, connect }: Context,
     accounts: SubscriptionAccountInfo[] | undefined = [],
@@ -354,7 +356,8 @@ const subscribe = (request: Request<MessageTypes.Subscribe>) => {
             subscribeBlock(request);
             break;
         case 'accounts':
-            subscribeAccounts(request, request.payload.accounts);
+            // accounts subscription is currently disabled due to it possibly causing crashes
+            // subscribeAccounts(request, request.payload.accounts);
             break;
         default:
             throw new CustomError('worker_unknown_request', `+${request.type}`);
@@ -371,7 +374,8 @@ const unsubscribe = (request: Request<MessageTypes.Unsubscribe>) => {
             unsubscribeBlock(request);
             break;
         case 'accounts': {
-            unsubscribeAccounts(request, request.payload.accounts);
+            // accounts subscription is currently disabled due to it possibly causing crashes
+            // unsubscribeAccounts(request, request.payload.accounts);
             break;
         }
         default:
@@ -408,7 +412,8 @@ class SolanaWorker extends BaseWorker<SolanaAPI> {
     }
 
     tryConnect(url: string): Promise<SolanaAPI> {
-        const api = new Connection(url, { wsEndpoint: url.replace('https', 'wss') });
+        // websocket connection is currently disabled due to it possibly causing crashes
+        const api = new Connection(url /* , { wsEndpoint: url.replace('https', 'wss') } */);
         this.post({ id: -1, type: RESPONSES.CONNECTED });
         return Promise.resolve(api);
     }
@@ -437,9 +442,10 @@ class SolanaWorker extends BaseWorker<SolanaAPI> {
             return;
         }
 
-        this.state.accounts.forEach(
-            a => a.subscriptionId && this.api?.removeAccountChangeListener(a.subscriptionId),
-        );
+        // accounts subscription is currently disabled due to it possibly causing crashes
+        // this.state.accounts.forEach(
+        //     a => a.subscriptionId && this.api?.removeAccountChangeListener(a.subscriptionId),
+        // );
 
         if (this.state.getSubscription('block')) {
             const interval = this.state.getSubscription('block') as NodeJS.Timer;


### PR DESCRIPTION
We're facing some weird issues with Solana (probably only on Suite desktop app) which aren't easy to reproduce and probably are caused by the Solana SDK's websockets connection. So for now we decided to temporarily disable the websockets which ultimately only serve to update the account if a transaction was received. Solana accounts are updated every 10 seconds anyway so we are not losing much in this regard.

We identified some issues with the account subscriptions so we first fix those in bddb465f9455f17a849f63505004a3c6c5e945f4. And then in f4459a5bea79979ab65cf10b80086e1af9fe98b6 we disable the account subscription altogether (along with websockets).

The issue we're trying to avoid is that sometimes when some Solana account action is made - Solana devnet gets enabled or a transaction is sent - the app gets into a weird loop state which eventually freezes the app and the only thing printed in the logs is:
```
accountSubscribe error for argument [
  '2MLmmoKgCrxVEzMeGatnjdABYS5RXsQSNikcWrmnvQna',
  { encoding: 'base64', commitment: 'finalized' }
] The socket was closed while data was being compressed
accountSubscribe error for argument [
  'DNDSiWVRF37n1KgQKRF3yuZNiadoXMCePLWqbuYFfveW',
  { encoding: 'base64', commitment: 'finalized' }
] The socket was closed while data was being compressed
accountSubscribe error for argument [
  '2MLmmoKgCrxVEzMeGatnjdABYS5RXsQSNikcWrmnvQna',
  { encoding: 'base64', commitment: 'finalized' }
] Tried to call a JSON-RPC method `accountSubscribe` but the socket was not `CONNECTING` or `OPEN` (`readyState` was 3)
```
There's no way to recover the app, it needs to be restarted.

As mentioned above - we weren't able to reliably reproduce the issue and thus it's hard to identify and thus fix the real issue.