### PR TITLE
fix(suite): hide fiat value when discovery fails

### DIFF
--- a/packages/suite/src/views/dashboard/components/PortfolioCard/index.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/index.tsx
@@ -141,18 +141,20 @@ const PortfolioCard = memo(() => {
             }
         >
             <StyledCard noPadding>
-                <Header
-                    showGraphControls={showGraphControls}
-                    hideBorder={!body}
-                    portfolioValue={portfolioValue}
-                    localCurrency={localCurrency}
-                    isWalletEmpty={isWalletEmpty}
-                    isWalletLoading={isWalletLoading}
-                    isWalletError={isWalletError}
-                    isDiscoveryRunning={isDiscoveryRunning}
-                    receiveClickHandler={goToReceive}
-                    buyClickHandler={goToBuy}
-                />
+                {discoveryStatus && discoveryStatus.status === 'exception' ? null : (
+                    <Header
+                        showGraphControls={showGraphControls}
+                        hideBorder={!body}
+                        portfolioValue={portfolioValue}
+                        localCurrency={localCurrency}
+                        isWalletEmpty={isWalletEmpty}
+                        isWalletLoading={isWalletLoading}
+                        isWalletError={isWalletError}
+                        isDiscoveryRunning={isDiscoveryRunning}
+                        receiveClickHandler={goToReceive}
+                        buyClickHandler={goToBuy}
+                    />
+                )}
 
                 {body && <Body>{body}</Body>}
             </StyledCard>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Hides the fiat value when discovery fails.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/9483

## Screenshots:
![image](https://github.com/trezor/trezor-suite/assets/152899911/e2d9ebfe-7f75-4931-a723-1d7e127693d2)
