### PR TITLE
fix(suite): fit spanish into QR code description

### DIFF
--- a/packages/suite/src/components/suite/QrCode.tsx
+++ b/packages/suite/src/components/suite/QrCode.tsx
@@ -1,7 +1,7 @@
 import { QRCodeSVG } from 'qrcode.react';
 import styled from 'styled-components';
 
-import { Icon, colors, variables } from '@trezor/components';
+import { Icon, Tooltip, colors, variables } from '@trezor/components';
 import { Translation } from './Translation';
 
 export const QRCODE_SIZE = 384;
@@ -16,24 +16,31 @@ const Wrapper = styled.div`
     background: ${colors.BG_WHITE};
     max-width: ${QRCODE_SIZE}px;
     position: relative;
-`;
 
-const MessageWrapper = styled.div`
     display: flex;
-    gap: 6px;
-    position: absolute;
-    left: 50%;
-    bottom: 9px;
-    transform: translate(-50%, 0);
-    width: 100%;
-    align-items: center;
-    justify-content: center;
+    flex-direction: column;
 `;
 
 const Message = styled.div`
     font-size: ${variables.FONT_SIZE.SMALL};
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
     color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
+    margin-top: 12px;
+    white-space: nowrap;
+`;
+
+const StyledIcon = styled(Icon)`
+    display: inline-block;
+    margin-left: 5px;
+    vertical-align: middle;
+`;
+
+const SpanToResetWhitespace = styled.span`
+    white-space: normal;
+`;
+
+const StyledTooltip = styled(Tooltip)`
+    display: inline-block;
 `;
 
 interface QrCodeProps {
@@ -55,12 +62,16 @@ export const QrCode = ({ value, className, bgColor, fgColor, showMessage }: QrCo
             style={{ width: '100%', height: '100%', objectFit: 'contain' }}
         />
         {showMessage && (
-            <MessageWrapper>
-                <Message>
+            <Message>
+                <SpanToResetWhitespace>
                     <Translation id="TR_QR_RECEIVE_ADDRESS_CONFIRM" />
-                </Message>
-                <Icon icon="INFO" size={12} color={fgColor || colors.TYPE_DARK_GREY} />
-            </MessageWrapper>
+                </SpanToResetWhitespace>
+                <StyledTooltip
+                    content={<Translation id="TR_QR_RECEIVE_ADDRESS_CONFIRM_EXPLANATION" />}
+                >
+                    <StyledIcon icon="INFO" size={12} color={fgColor || colors.TYPE_DARK_GREY} />
+                </StyledTooltip>
+            </Message>
         )}
     </Wrapper>
 );

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5334,6 +5334,11 @@ export default defineMessages({
         id: 'TR_QR_RECEIVE_ADDRESS_CONFIRM',
         defaultMessage: 'Confirm on Trezor before scanning',
     },
+    TR_QR_RECEIVE_ADDRESS_CONFIRM_EXPLANATION: {
+        id: 'TR_QR_RECEIVE_ADDRESS_CONFIRM_EXPLANATION',
+        defaultMessage:
+            "Please confirm the receiving address on device first, as it's trusted display can't be hacked unlike this one.",
+    },
     TR_MY_ASSETS: {
         id: 'TR_MY_ASSETS',
         defaultMessage: 'Assets',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a space for Spanish in the QR code description.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/10313

## Screenshots:
![image](https://github.com/trezor/trezor-suite/assets/152899911/ba61992f-ce44-4be1-a66d-bddc4dcab315)
![image](https://github.com/trezor/trezor-suite/assets/152899911/81d39e19-359e-4a2c-a794-4ca215843050)

-----
![image](https://github.com/trezor/trezor-suite/assets/152899911/e050665d-9881-4c71-b7d7-e93abfd0b1b2)
![image](https://github.com/trezor/trezor-suite/assets/152899911/603cce1f-70fe-44c3-92db-8102ab57a56e)



