### PR TITLE
Feat/utxo-lib coinselect use BN instead of string

### DIFF
--- a/packages/utxo-lib/src/coinselect/coinselectUtils.ts
+++ b/packages/utxo-lib/src/coinselect/coinselectUtils.ts
@@ -259,11 +259,8 @@ export function finalize(
     const remainderAfterExtraOutput = sumInputs.sub(sumOutputs.add(new BN(feeAfterExtraOutput)));
     const dustAmount = getDustAmount(feeRate, options);
 
-    const finalOutputs: CoinSelectOutputFinal[] = outputs.map(o =>
-        Object.assign({}, o, {
-            value: o.value as BN, // it's verified that output have value (sumOutputs) TODO: refactor sumOrNaN to return correct type (outputs with values)
-        }),
-    );
+    // it's verified that output have value (sumOutputs)
+    const finalOutputs = [...(outputs as CoinSelectOutputFinal[])];
 
     // is it worth a change output?
     if (remainderAfterExtraOutput.gte(new BN(dustAmount))) {
@@ -276,7 +273,7 @@ export function finalize(
     return {
         inputs,
         outputs: finalOutputs,
-        fee: sumInputs.sub(sumOrNaN(finalOutputs, true)).toNumber(), // it's verified that output have value (sumOutputs) TODO: refactor sumOrNaN to return correct type (outputs with values)
+        fee: sumInputs.sub(sumOrNaN(finalOutputs, true)).toNumber(),
     };
 }
 

--- a/packages/utxo-lib/src/coinselect/coinselectUtils.ts
+++ b/packages/utxo-lib/src/coinselect/coinselectUtils.ts
@@ -140,12 +140,12 @@ export function bignumberOrNaN(v?: BN | string, forgiving = false) {
     }
 }
 
-export function sumOrNaN(range: { value?: string }[]): BN | undefined;
+export function sumOrNaN(range: { value?: BN }[]): BN | undefined;
 export function sumOrNaN<F extends boolean>(
-    range: { value?: string }[],
+    range: { value?: BN }[],
     forgiving: F,
 ): F extends true ? BN : BN | undefined;
-export function sumOrNaN(range: { value?: string }[], forgiving = false) {
+export function sumOrNaN(range: { value?: BN }[], forgiving = false) {
     return range.reduce((a: BN | undefined, x) => {
         if (!a) return a;
         const value = bignumberOrNaN(x.value);
@@ -187,7 +187,7 @@ function getDogeFee(
 
     // find all outputs below dust limit
     const limit = new BN(dustThreshold);
-    const dustOutputsCount = outputs.filter(({ value }) => value && new BN(value).lt(limit)).length;
+    const dustOutputsCount = outputs.filter(({ value }) => value && value.lt(limit)).length;
 
     // increase for every output below dustThreshold
     return fee + dustOutputsCount * dustThreshold;
@@ -261,7 +261,7 @@ export function finalize(
 
     const finalOutputs: CoinSelectOutputFinal[] = outputs.map(o =>
         Object.assign({}, o, {
-            value: o.value as string, // it's verified that output have value (sumOutputs) TODO: refactor sumOrNaN to return correct type (outputs with values)
+            value: o.value as BN, // it's verified that output have value (sumOutputs) TODO: refactor sumOrNaN to return correct type (outputs with values)
         }),
     );
 
@@ -269,7 +269,7 @@ export function finalize(
     if (remainderAfterExtraOutput.gte(new BN(dustAmount))) {
         finalOutputs.push({
             ...changeOutput,
-            value: remainderAfterExtraOutput.toString(),
+            value: remainderAfterExtraOutput,
         });
     }
 
@@ -297,7 +297,7 @@ export function anyOf(algorithms: CoinSelectAlgorithm[]): CoinSelectAlgorithm {
 }
 
 export function utxoScore(x: CoinSelectInput, feeRate: number) {
-    return new BN(x.value).sub(new BN(getFeeForBytes(feeRate, inputBytes(x))));
+    return x.value.sub(new BN(getFeeForBytes(feeRate, inputBytes(x))));
 }
 
 export function sortByScore(feeRate: number) {

--- a/packages/utxo-lib/src/coinselect/outputs/split.ts
+++ b/packages/utxo-lib/src/coinselect/outputs/split.ts
@@ -48,13 +48,12 @@ export function split(
     if (unspecified && splitValue.lt(new BN(dustAmount))) return { fee };
 
     // assign splitValue to outputs not user defined
-    const outputsSplit = outputs.map(x => {
-        if (x.value) return x;
-
-        // not user defined, but still copy over any non-value fields
-        const y = Object.assign({}, x);
-        y.value = splitValue;
-        return y;
+    const outputsSplit = outputs.map(output => {
+        if (output.value) return output;
+        return {
+            ...output,
+            value: splitValue,
+        };
     });
 
     return finalize(utxos, outputsSplit, feeRate, options);

--- a/packages/utxo-lib/src/coinselect/outputs/split.ts
+++ b/packages/utxo-lib/src/coinselect/outputs/split.ts
@@ -53,7 +53,7 @@ export function split(
 
         // not user defined, but still copy over any non-value fields
         const y = Object.assign({}, x);
-        y.value = splitValue.toString();
+        y.value = splitValue;
         return y;
     });
 

--- a/packages/utxo-lib/src/compose/result.ts
+++ b/packages/utxo-lib/src/compose/result.ts
@@ -59,12 +59,13 @@ export function getResult<
 
     const totalSpent = result.outputs.reduce((total, output, index) => {
         if (request.outputs[index]) {
-            return total.add(new BN(output.value));
+            return total.add(output.value);
         }
         return total;
     }, new BN(result.fee));
 
-    const max = sendMaxOutputIndex >= 0 ? result.outputs[sendMaxOutputIndex].value : undefined;
+    const max =
+        sendMaxOutputIndex >= 0 ? result.outputs[sendMaxOutputIndex].value.toString() : undefined;
     const bytes = transactionBytes(result.inputs, result.outputs);
     const feePerByte = result.fee / bytes;
 

--- a/packages/utxo-lib/src/compose/transaction.ts
+++ b/packages/utxo-lib/src/compose/transaction.ts
@@ -1,4 +1,3 @@
-import BN from 'bn.js';
 import {
     ComposeRequest,
     CoinSelectSuccess,
@@ -16,7 +15,7 @@ function convertOutput(
     if (composeOutput.type === 'change') {
         return {
             ...composeOutput,
-            amount: selectedOutput.value,
+            amount: selectedOutput.value.toString(),
         };
     }
 
@@ -27,7 +26,7 @@ function convertOutput(
     return {
         ...composeOutput,
         type: 'payment' as const,
-        amount: selectedOutput.value,
+        amount: selectedOutput.value.toString(),
     };
 }
 
@@ -37,7 +36,7 @@ function inputComparator(a: ComposeInput, b: ComposeInput) {
 
 function outputComparator(a: CoinSelectOutputFinal, b: CoinSelectOutputFinal) {
     return (
-        new BN(a.value).cmp(new BN(b.value)) ||
+        a.value.cmp(b.value) ||
         (Buffer.isBuffer(a.script) && Buffer.isBuffer(b.script)
             ? a.script.compare(b.script)
             : a.script.length - b.script.length)

--- a/packages/utxo-lib/src/script/ops.ts
+++ b/packages/utxo-lib/src/script/ops.ts
@@ -1,15 +1,13 @@
 import * as ops from 'bitcoin-ops';
 
 // extend with Decred OP codes
-const OPS: { [key: string]: number } = Object.assign(
-    {
-        OP_SSTX: 0xba,
-        OP_SSTXCHANGE: 0xbd,
-        OP_SSGEN: 0xbb,
-        OP_SSRTX: 0xbc,
-    },
-    ops || {},
-);
+const OPS: Record<string, number> = {
+    ...ops,
+    OP_SSTX: 0xba,
+    OP_SSTXCHANGE: 0xbd,
+    OP_SSGEN: 0xbb,
+    OP_SSRTX: 0xbc,
+};
 
 const REVERSE_OPS: string[] = [];
 Object.keys(OPS).forEach(code => {

--- a/packages/utxo-lib/src/transaction/index.ts
+++ b/packages/utxo-lib/src/transaction/index.ts
@@ -42,10 +42,7 @@ class Transaction extends TransactionBase<dash.DashSpecific | zcash.ZcashSpecifi
     }
 
     static fromHex(hex: string, options: TransactionOptions = {}) {
-        return this.fromBuffer(
-            Buffer.from(hex, 'hex'),
-            Object.assign(options, { nostrict: false }),
-        );
+        return this.fromBuffer(Buffer.from(hex, 'hex'), { ...options, nostrict: false });
     }
 }
 

--- a/packages/utxo-lib/src/types/coinselect.ts
+++ b/packages/utxo-lib/src/types/coinselect.ts
@@ -1,3 +1,5 @@
+import BN from 'bn.js';
+
 export type CoinSelectPaymentType = 'p2pkh' | 'p2sh' | 'p2tr' | 'p2wpkh' | 'p2wsh';
 
 export interface CoinSelectOptions {
@@ -18,7 +20,7 @@ export interface CoinSelectInput {
     type: CoinSelectPaymentType;
     i: number;
     script: { length: number };
-    value: string;
+    value: BN;
     confirmations: number;
     coinbase?: boolean;
     required?: boolean;
@@ -28,13 +30,13 @@ export interface CoinSelectInput {
 
 export interface CoinSelectOutput {
     script: { length: number };
-    value?: string;
+    value?: BN;
     weight?: number;
 }
 
 export interface CoinSelectOutputFinal {
     script: { length: number };
-    value: string;
+    value: BN;
 }
 
 export interface CoinSelectRequest extends CoinSelectOptions {

--- a/packages/utxo-lib/tests/__fixtures__/coinselect/accumulative.ts
+++ b/packages/utxo-lib/tests/__fixtures__/coinselect/accumulative.ts
@@ -819,43 +819,6 @@ export default [
         dustThreshold: 546,
     },
     {
-        description: 'input with float values (NaN)',
-        feeRate: 10,
-        inputs: ['20000.5'],
-        outputs: ['10000', '1200'],
-        expected: {
-            fee: 2260,
-        },
-        dustThreshold: 546,
-    },
-    {
-        description: '2 outputs, with float values (NaN)',
-        feeRate: 10,
-        inputs: ['20000'],
-        outputs: ['10000.25', '1200.5'],
-        expected: {
-            fee: 2260,
-        },
-        dustThreshold: 546,
-    },
-    {
-        description: '2 outputs, number values (NaN)',
-        feeRate: 10,
-        inputs: ['20000'],
-        outputs: [
-            {
-                value: 100,
-            },
-            {
-                value: 204,
-            },
-        ],
-        expected: {
-            fee: 2260,
-        },
-        dustThreshold: 546,
-    },
-    {
         description: 'DOGE: 2 inputs, not enough to cover fee',
         feeRate: 100000,
         baseFee: 100000000,

--- a/packages/utxo-lib/tests/__fixtures__/coinselect/bnb.ts
+++ b/packages/utxo-lib/tests/__fixtures__/coinselect/bnb.ts
@@ -484,22 +484,6 @@ export default [
         dustThreshold: 546,
     },
     {
-        description: 'input with float values (NaN)',
-        feeRate: 10,
-        inputs: ['20000.5'],
-        outputs: ['10000', '1200'],
-        expected: { fee: 0 },
-        dustThreshold: 546,
-    },
-    {
-        description: '2 outputs, with float values (NaN)',
-        feeRate: 10,
-        inputs: ['20000'],
-        outputs: ['10000.25', '1200.5'],
-        expected: { fee: 0 },
-        dustThreshold: 546,
-    },
-    {
         description: '2 outputs, string values (NaN)',
         feeRate: 10,
         inputs: ['20000'],

--- a/packages/utxo-lib/tests/__fixtures__/coinselect/coinselect-index.ts
+++ b/packages/utxo-lib/tests/__fixtures__/coinselect/coinselect-index.ts
@@ -1216,64 +1216,6 @@ export default [
         dustThreshold: 546,
     },
     {
-        description: 'input with float values (NaN)',
-        feeRate: 10,
-        inputs: [
-            {
-                value: 20000.5,
-                coinbase: false,
-                own: true,
-                confirmations: 100,
-            },
-        ],
-        outputs: ['10000', '1200'],
-        expected: {
-            fee: 2260,
-        },
-        dustThreshold: 546,
-    },
-    {
-        description: '2 outputs, with float values (NaN)',
-        feeRate: 10,
-        inputs: [
-            {
-                value: '20000',
-                coinbase: false,
-                own: true,
-                confirmations: 100,
-            },
-        ],
-        outputs: [10000.25, 1200.5],
-        expected: {
-            fee: 2260,
-        },
-        dustThreshold: 546,
-    },
-    {
-        description: '2 outputs, number values (NaN)',
-        feeRate: 10,
-        inputs: [
-            {
-                value: '20000',
-                coinbase: false,
-                own: true,
-                confirmations: 100,
-            },
-        ],
-        outputs: [
-            {
-                value: 100,
-            },
-            {
-                value: 204,
-            },
-        ],
-        expected: {
-            fee: 2260,
-        },
-        dustThreshold: 546,
-    },
-    {
         description: 'exhausting BnB',
         feeRate: 10,
         inputs: [

--- a/packages/utxo-lib/tests/__fixtures__/coinselect/split.ts
+++ b/packages/utxo-lib/tests/__fixtures__/coinselect/split.ts
@@ -234,48 +234,6 @@ export default [
         dustThreshold: 546,
     },
     {
-        description: '2 outputs, some with float values (NaN)',
-        feeRate: 10,
-        inputs: ['20000'],
-        outputs: [
-            {
-                value: '4000.5',
-            },
-            {},
-        ],
-        expected: {
-            fee: 2260,
-        },
-        dustThreshold: 546,
-    },
-    {
-        description: '2 outputs, number values (NaN)',
-        feeRate: 11,
-        inputs: ['20000'],
-        outputs: [
-            {
-                value: 100,
-            },
-            {
-                value: 204,
-            },
-        ],
-        expected: {
-            fee: 2486,
-        },
-        dustThreshold: 546,
-    },
-    {
-        description: 'input with float values (NaN)',
-        feeRate: 10,
-        inputs: ['20000.5'],
-        outputs: [{}, {}],
-        expected: {
-            fee: 2260,
-        },
-        dustThreshold: 546,
-    },
-    {
         description: '1 to 1, not enough funds',
         feeRate: 1000,
         inputs: ['5000'],

--- a/packages/utxo-lib/tests/coinselect/accumulative.test.ts
+++ b/packages/utxo-lib/tests/coinselect/accumulative.test.ts
@@ -18,11 +18,11 @@ describe('coinselect: accumulative', () => {
             } as CoinSelectOptions;
 
             const actual = accumulative(inputs, outputs, f.feeRate, options);
-            expect(actual).toEqual(expected);
+            expect(utils.serialize(actual)).toEqual(expected);
 
             if (actual.inputs) {
                 const feedback = accumulative(actual.inputs, actual.outputs, f.feeRate, options);
-                expect(feedback).toEqual(expected);
+                expect(utils.serialize(feedback)).toEqual(expected);
             }
         });
     });

--- a/packages/utxo-lib/tests/coinselect/bnb.test.ts
+++ b/packages/utxo-lib/tests/coinselect/bnb.test.ts
@@ -15,11 +15,11 @@ describe('coinselect: branchAndBound (bnb)', () => {
             } as CoinSelectOptions;
 
             const actual = bnb(inputs, outputs, f.feeRate, options);
-            expect(actual).toEqual(expected);
+            expect(utils.serialize(actual)).toEqual(expected);
 
             if (actual.inputs) {
                 const feedback = bnb(actual.inputs, actual.outputs, f.feeRate, options);
-                expect(feedback).toEqual(expected);
+                expect(utils.serialize(feedback)).toEqual(expected);
             }
         });
     });

--- a/packages/utxo-lib/tests/coinselect/coinselect.test.ts
+++ b/packages/utxo-lib/tests/coinselect/coinselect.test.ts
@@ -39,7 +39,7 @@ describe('coinselect index', () => {
                 sendMaxOutputIndex: -1,
             });
 
-            expect(actual).toEqual(expected);
+            expect(utils.serialize(actual)).toEqual(expected);
             if (actual.inputs) {
                 const feedback = coinselect({
                     txType: 'p2pkh',
@@ -49,7 +49,7 @@ describe('coinselect index', () => {
                     outputs: actual.outputs,
                     sendMaxOutputIndex: -1,
                 });
-                expect(feedback).toEqual(expected);
+                expect(utils.serialize(feedback)).toEqual(expected);
             }
         });
     });

--- a/packages/utxo-lib/tests/coinselect/coinselectUtils.test.ts
+++ b/packages/utxo-lib/tests/coinselect/coinselectUtils.test.ts
@@ -1,3 +1,4 @@
+import BN from 'bn.js';
 import { bignumberOrNaN, getFee, getDustAmount } from '../../src/coinselect/coinselectUtils';
 
 describe('coinselectUtils', () => {
@@ -43,8 +44,8 @@ describe('coinselectUtils', () => {
             getFee(
                 [],
                 [
-                    { value: '8', script: { length: 49 } },
-                    { value: '7', script: { length: 50 } },
+                    { value: new BN('8'), script: { length: 49 } },
+                    { value: new BN('7'), script: { length: 50 } },
                 ],
                 2,
                 { feePolicy: 'doge', baseFee: 1000, dustThreshold: 1000 },
@@ -54,8 +55,8 @@ describe('coinselectUtils', () => {
             getFee(
                 [],
                 [
-                    { value: '8', script: { length: 500 } },
-                    { value: '7', script: { length: 472 } },
+                    { value: new BN('8'), script: { length: 500 } },
+                    { value: new BN('7'), script: { length: 472 } },
                 ],
                 2,
                 { feePolicy: 'doge', baseFee: 1000, dustThreshold: 1000, floorBaseFee: true },
@@ -67,7 +68,7 @@ describe('coinselectUtils', () => {
         const IN = {
             type: 'p2pkh',
             i: 0,
-            value: '0',
+            value: new BN('1000'),
             confirmations: 0,
             script: { length: 108 },
         } as const;

--- a/packages/utxo-lib/tests/coinselect/split.test.ts
+++ b/packages/utxo-lib/tests/coinselect/split.test.ts
@@ -18,11 +18,11 @@ describe('coinselect split', () => {
             } as CoinSelectOptions;
 
             const actual = split(inputs, outputs, f.feeRate, options);
-            expect(actual).toEqual(expected);
+            expect(utils.serialize(actual)).toEqual(expected);
 
             if (actual.inputs) {
                 const feedback = split(actual.inputs, actual.outputs, f.feeRate, options);
-                expect(feedback).toEqual(expected);
+                expect(utils.serialize(feedback)).toEqual(expected);
             }
         });
     });

--- a/packages/utxo-lib/tests/compose.request.test.ts
+++ b/packages/utxo-lib/tests/compose.request.test.ts
@@ -87,7 +87,22 @@ describe('validateAndParseRequest', () => {
         // missing amount field
         expect(getRequest([{ ...UTXO, amount: undefined }])).toEqual({
             ...expectedError,
-            message: 'Missing amount at index 0',
+            message: 'Invalid amount at index 0',
+        });
+        // invalid amount field (NaN)
+        expect(getRequest([{ ...UTXO, amount: 'abcd' }])).toEqual({
+            ...expectedError,
+            message: 'Invalid amount at index 0',
+        });
+        // invalid amount field (float)
+        expect(getRequest([{ ...UTXO, amount: '0.1' }])).toEqual({
+            ...expectedError,
+            message: 'Invalid amount at index 0',
+        });
+        // invalid amount field (number)
+        expect(getRequest([{ ...UTXO, amount: 1 }])).toEqual({
+            ...expectedError,
+            message: 'Invalid amount at index 0',
         });
     });
 
@@ -124,7 +139,22 @@ describe('validateAndParseRequest', () => {
         // missing amount
         expect(getRequest([{ type: 'payment-noaddress' }])).toEqual({
             ...expectedError,
-            message: 'Missing output amount at index 0',
+            message: 'Invalid amount at index 0',
+        });
+        // invalid amount field (NaN)
+        expect(getRequest([{ type: 'payment-noaddress', amount: 'abcd' }])).toEqual({
+            ...expectedError,
+            message: 'Invalid amount at index 0',
+        });
+        // invalid amount field (float)
+        expect(getRequest([{ type: 'payment-noaddress', amount: '1.1' }])).toEqual({
+            ...expectedError,
+            message: 'Invalid amount at index 0',
+        });
+        // invalid amount field (number)
+        expect(getRequest([{ type: 'payment-noaddress', amount: 1 }])).toEqual({
+            ...expectedError,
+            message: 'Invalid amount at index 0',
         });
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

another utxo-lib followup https://github.com/trezor/trezor-suite/issues/4528
continuation of https://github.com/trezor/trezor-suite/pull/10224

use input/output value as `BN` in coinselect module instead converting back and forth `string` to `BN` and `BN` to `string`

additional cleanup: use spread instead of Object.assing
