### PR TITLE
Connect Core Revamp pt. 1

### DIFF
--- a/packages/connect-iframe/src/index.ts
+++ b/packages/connect-iframe/src/index.ts
@@ -3,7 +3,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/iframe/iframe.js
 
 import {
-    CORE_EVENT,
     RESPONSE_EVENT,
     DEVICE_EVENT,
     TRANSPORT_EVENT,
@@ -21,7 +20,7 @@ import {
     CoreRequestMessage,
     CoreEventMessage,
 } from '@trezor/connect';
-import { Core, initCore, initTransport } from '@trezor/connect/src/core';
+import { Core, initCore } from '@trezor/connect/src/core';
 import { DataManager } from '@trezor/connect/src/data/DataManager';
 import { config } from '@trezor/connect/src/data/config';
 import { initLog, LogWriter } from '@trezor/connect/src/utils/debug';
@@ -319,11 +318,7 @@ const init = async (payload: IFrameInit['payload'], origin: string) => {
 
     try {
         // initialize core
-        _core = await initCore(parsedSettings, logWriterFactory);
-        _core.on(CORE_EVENT, postMessage);
-
-        // initialize transport and wait for the first transport event (start or error)
-        await initTransport(parsedSettings);
+        _core = await initCore(parsedSettings, postMessage, logWriterFactory);
         postMessage(
             createIFrameMessage(IFRAME.LOADED, {
                 useBroadcastChannel: !!_popupMessagePort,

--- a/packages/connect-iframe/src/index.ts
+++ b/packages/connect-iframe/src/index.ts
@@ -107,39 +107,38 @@ const handleMessage = async (event: MessageEvent<CoreRequestMessage>) => {
         );
         _log.debug('loading current method');
         const method = await _core.getCurrentMethod();
-        (method.initAsyncPromise ? method.initAsyncPromise : Promise.resolve()).finally(() => {
-            if (method.info) {
-                postMessage(
-                    createPopupMessage(POPUP.METHOD_INFO, {
-                        method: method.name,
-                        info: method.info, // method.info might change based on initAsync
-                    }),
-                );
-            }
 
-            // eslint-disable-next-line camelcase
-            const { tracking_enabled, tracking_id } = storage.load();
-
-            analytics.init(tracking_enabled, {
-                // eslint-disable-next-line camelcase
-                instanceId: tracking_id,
-                commitId: process.env.COMMIT_HASH || '',
-                isDev: process.env.NODE_ENV === 'development',
-            });
-
-            analytics.report({
-                type: EventType.AppReady,
-                payload: {
-                    version: settings?.version,
-                    origin: settings?.origin,
-                    referrerApp: settings?.manifest?.appUrl,
-                    referrerEmail: settings?.manifest?.email,
+        if (method.info) {
+            postMessage(
+                createPopupMessage(POPUP.METHOD_INFO, {
                     method: method.name,
-                    payload: method.payload ? Object.keys(method.payload) : undefined,
-                    transportType: transport?.type,
-                    transportVersion: transport?.version,
-                },
-            });
+                    info: method.info, // method.info might change based on initAsync
+                }),
+            );
+        }
+
+        // eslint-disable-next-line camelcase
+        const { tracking_enabled, tracking_id } = storage.load();
+
+        analytics.init(tracking_enabled, {
+            // eslint-disable-next-line camelcase
+            instanceId: tracking_id,
+            commitId: process.env.COMMIT_HASH || '',
+            isDev: process.env.NODE_ENV === 'development',
+        });
+
+        analytics.report({
+            type: EventType.AppReady,
+            payload: {
+                version: settings?.version,
+                origin: settings?.origin,
+                referrerApp: settings?.manifest?.appUrl,
+                referrerEmail: settings?.manifest?.email,
+                method: method.name,
+                payload: method.payload ? Object.keys(method.payload) : undefined,
+                transportType: transport?.type,
+                transportVersion: transport?.version,
+            },
         });
     }
 

--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -305,13 +305,12 @@ const handleMessageInCoreMode = (
 
         core.getCurrentMethod().then(method => {
             log.debug('handling method in popup', method.name);
-            (method.initAsyncPromise ? method.initAsyncPromise : Promise.resolve()).finally(() => {
-                setState({
-                    method: method.name,
-                    info: method.info,
-                });
-                reactEventBus.dispatch({ type: 'state-update', payload: getState() });
+
+            setState({
+                method: method.name,
+                info: method.info,
             });
+            reactEventBus.dispatch({ type: 'state-update', payload: getState() });
         });
     }
 

--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -13,7 +13,6 @@ import {
     PopupInit,
     PopupHandshake,
     MethodResponseMessage,
-    CORE_EVENT,
     IFrameCallMessage,
     IFrameLogRequest,
     CoreEventMessage,
@@ -404,26 +403,30 @@ const initCoreInPopup = async (
     // init core
     log.debug('initiating core with settings: ', payload.settings);
     reactEventBus.dispatch({ type: 'loading', message: 'initiating core' });
-    const core: Core = await initCore(
-        { ...payload.settings, trustedHost: false },
-        logWriterFactory,
-    );
-    if (disposed) return;
-    core.on(CORE_EVENT, event => {
+    const onCoreEvent = (event: any) => {
         const message = parseMessage<CoreEventMessage>(event);
         handleUIAffectingMessage(message);
         if (message.type === RESPONSE_EVENT) {
             handleResponseEvent(message);
         }
-    });
+    };
+    const core: Core = await initCore(
+        { ...payload.settings, trustedHost: false },
+        onCoreEvent,
+        logWriterFactory,
+    );
+    if (disposed) return;
+
     setState({ core });
     log.debug('initiated core');
 
     // init transport
+    /*
     log.debug('initiating transport with settings: ', payload.settings);
     reactEventBus.dispatch({ type: 'loading', message: 'initiating transport' });
     await initTransport(payload.settings);
     if (disposed) return;
+    */
     log.debug('initiated transport');
 
     // done, in popup, we are ready to handle incoming messages

--- a/packages/connect-popup/src/view/common.tsx
+++ b/packages/connect-popup/src/view/common.tsx
@@ -1,6 +1,13 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/popup/view/common.js
 
-import { POPUP, ERRORS, PopupInit, CoreMessage, createUiResponse } from '@trezor/connect';
+import {
+    POPUP,
+    ERRORS,
+    PopupInit,
+    createUiResponse,
+    CoreRequestMessage,
+    CoreEventMessage,
+} from '@trezor/connect';
 import { createRoot } from 'react-dom/client';
 
 import { ConnectUI, State, getDefaultState } from '@trezor/connect-ui';
@@ -166,7 +173,7 @@ export const initMessageChannelWithIframe = async (
 };
 
 // this method can be used from anywhere
-export const postMessage = (message: CoreMessage) => {
+export const postMessage = (message: CoreRequestMessage) => {
     const { broadcast, iframe, core } = getState();
     if (core) {
         core.handleMessage(message);
@@ -183,7 +190,7 @@ export const postMessage = (message: CoreMessage) => {
     throw ERRORS.TypedError('Popup_ConnectionMissing');
 };
 
-export const postMessageToParent = (message: CoreMessage) => {
+export const postMessageToParent = (message: CoreEventMessage) => {
     if (window.opener) {
         // post message to parent and wait for POPUP.INIT message
         window.opener.postMessage(message, '*');

--- a/packages/connect-popup/src/view/selectDevice.ts
+++ b/packages/connect-popup/src/view/selectDevice.ts
@@ -41,10 +41,7 @@ const initWebUsbButton = (showLoader: boolean) => {
                 const channel = new BroadcastChannel(WEBEXTENSION.USB_PERMISSIONS_BROADCAST);
                 channel.onmessage = event => {
                     if (event.data.type === WEBEXTENSION.USB_PERMISSIONS_FINISHED) {
-                        postMessage({
-                            event: UI_EVENT,
-                            type: TRANSPORT.REQUEST_DEVICE,
-                        });
+                        postMessage({ type: TRANSPORT.REQUEST_DEVICE });
                     }
                 };
                 return;

--- a/packages/connect-ui/src/index.tsx
+++ b/packages/connect-ui/src/index.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState, useMemo, ReactNode } from 'react';
 
 import styled from 'styled-components';
 
-import { PostMessage, UI, UI_REQUEST, POPUP, createPopupMessage } from '@trezor/connect';
+import { UI, UI_REQUEST, POPUP, CoreRequestMessage } from '@trezor/connect';
 import { storage, OriginBoundState } from '@trezor/connect-common';
 
 // views
@@ -39,7 +39,7 @@ const Layout = styled.div`
 `;
 
 type ConnectUIProps = {
-    postMessage: PostMessage;
+    postMessage: (message: CoreRequestMessage) => void;
     clearLegacyView: () => void;
 };
 
@@ -172,9 +172,10 @@ export const ConnectUI = ({ postMessage, clearLegacyView }: ConnectUIProps) => {
 
                         <BottomRightFloatingBar
                             onAnalyticsConfirm={enabled => {
-                                postMessage(
-                                    createPopupMessage(POPUP.ANALYTICS_RESPONSE, { enabled }),
-                                );
+                                postMessage({
+                                    type: POPUP.ANALYTICS_RESPONSE,
+                                    payload: { enabled },
+                                });
                             }}
                         />
                     </Layout>

--- a/packages/connect-ui/src/views/Passphrase.tsx
+++ b/packages/connect-ui/src/views/Passphrase.tsx
@@ -3,7 +3,7 @@ import { FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
 
 import { analytics, EventType } from '@trezor/connect-analytics';
-import { createUiResponse, UI, UiEvent, PostMessage } from '@trezor/connect';
+import { UI, UiEvent, CoreRequestMessage } from '@trezor/connect';
 import { variables, PassphraseTypeCard } from '@trezor/components';
 
 import { View } from '../components/View';
@@ -33,21 +33,24 @@ const Divider = styled.div`
 
 export type PassphraseEventProps = Extract<UiEvent, { type: 'ui-request_passphrase' }>;
 
-type PassphraseProps = PassphraseEventProps & { postMessage: PostMessage };
+type PassphraseProps = PassphraseEventProps & {
+    postMessage: (message: CoreRequestMessage) => void;
+};
 
 export const Passphrase = (props: PassphraseProps) => {
     const { device } = props.payload;
     const { features } = device;
 
     const onPassphraseSubmit = (value: string, passphraseOnDevice?: boolean) => {
-        props.postMessage(
-            createUiResponse(UI.RECEIVE_PASSPHRASE, {
+        props.postMessage({
+            type: UI.RECEIVE_PASSPHRASE,
+            payload: {
                 value,
                 passphraseOnDevice,
                 // todo: what is this param?
                 save: true,
-            }),
-        );
+            },
+        });
 
         analytics.report({
             type: EventType.WalletType,

--- a/packages/connect-web/src/iframe/index.ts
+++ b/packages/connect-web/src/iframe/index.ts
@@ -1,8 +1,8 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/iframe/builder.js
 
-import { createDeferred, Deferred } from '@trezor/utils/lib/createDeferred';
+import { createDeferred } from '@trezor/utils/lib/createDeferred';
 import * as ERRORS from '@trezor/connect/lib/constants/errors';
-import { IFRAME, CoreRequestMessage, IFrameCallMessage } from '@trezor/connect/lib/events';
+import { IFRAME, CoreRequestMessage } from '@trezor/connect/lib/events';
 import type { ConnectSettings } from '@trezor/connect/lib/types';
 import { getOrigin } from '@trezor/connect/lib/utils/urlUtils';
 import { setLogWriter, LogMessage, LogWriter } from '@trezor/connect/lib/utils/debug';
@@ -15,10 +15,6 @@ export let initPromise = createDeferred();
 export let timeout = 0;
 export let error: ERRORS.TrezorError;
 /* eslint-enable import/no-mutable-exports */
-
-let _messageID = 0;
-// every postMessage to iframe has its own promise to resolve
-export const messagePromises: { [key: number]: Deferred<any> } = {};
 
 export const dispose = () => {
     if (instance && instance.parentNode) {
@@ -179,20 +175,6 @@ export const postMessage = (message: CoreRequestMessage) => {
         throw ERRORS.TypedError('Init_IframeBlocked');
     }
     instance.contentWindow?.postMessage(message, origin);
-};
-
-// post messages to iframe
-export const postMessageAsync = (message: Omit<IFrameCallMessage, 'id'>) => {
-    if (!instance) {
-        throw ERRORS.TypedError('Init_IframeBlocked');
-    }
-
-    _messageID++;
-    const id = _messageID;
-    messagePromises[_messageID] = createDeferred();
-    const { promise } = messagePromises[_messageID];
-    instance.contentWindow?.postMessage({ id, ...message }, origin);
-    return promise;
 };
 
 export const clearTimeout = () => {

--- a/packages/connect-web/src/popup/index.ts
+++ b/packages/connect-web/src/popup/index.ts
@@ -2,7 +2,7 @@
 
 import EventEmitter from 'events';
 import { createDeferred, Deferred } from '@trezor/utils/lib/createDeferred';
-import { POPUP, IFRAME, UI, CoreMessage, IFrameLoaded } from '@trezor/connect/lib/events';
+import { POPUP, IFRAME, UI, CoreEventMessage, IFrameLoaded } from '@trezor/connect/lib/events';
 import type { ConnectSettings } from '@trezor/connect/lib/types';
 import { getOrigin } from '@trezor/connect/lib/utils/urlUtils';
 import { showPopupRequest } from './showPopupRequest';
@@ -330,7 +330,7 @@ export class PopupManager extends EventEmitter {
         this.popupWindow = null;
     }
 
-    async postMessage(message: CoreMessage) {
+    async postMessage(message: CoreEventMessage) {
         // device needs interaction but there is no popup/ui
         // maybe popup request wasn't handled
         // ignore "ui_request_window" type

--- a/packages/connect-webextension/src/popup.ts
+++ b/packages/connect-webextension/src/popup.ts
@@ -2,7 +2,7 @@
 import EventEmitter from 'events';
 
 import { Deferred, createDeferred } from '@trezor/utils/lib';
-import { PopupEventMessage, ConnectSettings } from '@trezor/connect/lib/exports';
+import { POPUP, ConnectSettings } from '@trezor/connect/lib/exports';
 import { getOrigin } from '@trezor/connect/lib/utils/urlUtils';
 import { Log } from '@trezor/connect/lib/utils/debug';
 
@@ -31,7 +31,7 @@ export class PopupManager extends EventEmitter {
 
     locked = false;
 
-    channel: ServiceWorkerWindowChannel<PopupEventMessage>;
+    channel;
 
     extensionTabId = 0;
 
@@ -45,7 +45,9 @@ export class PopupManager extends EventEmitter {
         this.origin = getOrigin(settings.popupSrc);
         this.logger = logger;
         this.handshakePromise = createDeferred();
-        this.channel = new ServiceWorkerWindowChannel<PopupEventMessage>({
+        this.channel = new ServiceWorkerWindowChannel<{
+            type: typeof POPUP.CORE_LOADED | typeof POPUP.CLOSED;
+        }>({
             name: 'trezor-connect',
             channel: {
                 here: '@trezor/connect-webextension',

--- a/packages/connect/src/api/firmware/uploadFirmware.ts
+++ b/packages/connect/src/api/firmware/uploadFirmware.ts
@@ -1,6 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/helpers/uploadFirmware.js
 
-import { UI, DEVICE, createUiMessage, PostMessage } from '../../events';
+import { UI, DEVICE, createUiMessage, CoreEventMessage } from '../../events';
 import { PROTO, ERRORS } from '../../constants';
 import type { Device } from '../../device/Device';
 import type { TypedCall } from '../../device/DeviceCommands';
@@ -14,7 +14,11 @@ const postConfirmationMessage = (device: Device) => {
     }
 };
 
-const postProgressMessage = (device: Device, progress: number, postMessage: PostMessage) => {
+const postProgressMessage = (
+    device: Device,
+    progress: number,
+    postMessage: (message: CoreEventMessage) => void,
+) => {
     postMessage(
         createUiMessage(UI.FIRMWARE_PROGRESS, {
             device: device.toMessageObject(),
@@ -25,7 +29,7 @@ const postProgressMessage = (device: Device, progress: number, postMessage: Post
 
 export const uploadFirmware = async (
     typedCall: TypedCall,
-    postMessage: PostMessage,
+    postMessage: (message: CoreEventMessage) => void,
     device: Device,
     { payload }: PROTO.FirmwareUpload,
 ) => {

--- a/packages/connect/src/backend/Blockchain.ts
+++ b/packages/connect/src/backend/Blockchain.ts
@@ -4,7 +4,7 @@ import BlockchainLink, {
     BlockchainLinkParams,
     BlockchainLinkResponse,
 } from '@trezor/blockchain-link';
-import { createBlockchainMessage, BLOCKCHAIN, PostMessage } from '../events';
+import { createBlockchainMessage, BLOCKCHAIN, CoreEventMessage } from '../events';
 import { ERRORS } from '../constants';
 import {
     BlockbookWorker,
@@ -35,7 +35,7 @@ const getWorker = (type: string) => {
 
 export type BlockchainOptions = {
     coinInfo: CoinInfo;
-    postMessage: PostMessage;
+    postMessage: (message: CoreEventMessage) => void;
     proxy?: Proxy;
     debug?: boolean;
     onConnected?: (url: string) => void;

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -12,7 +12,7 @@ import {
     CallMethodResponse,
     UiRequestButtonData,
     UiPromiseCreator,
-    PostMessage,
+    CoreEventMessage,
 } from '../events';
 import { getHost } from '../utils/urlUtils';
 import type { Device } from '../device/Device';
@@ -91,7 +91,7 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
 
     // callbacks
     // @ts-expect-error: strictPropertyInitialization
-    postMessage: PostMessage;
+    postMessage: (message: CoreEventMessage) => void;
     // @ts-expect-error: strictPropertyInitialization
     getPopupPromise: () => Deferred<void>;
     // @ts-expect-error: strictPropertyInitialization

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -100,7 +100,6 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
     removeUiPromise: (promise: Deferred<any>) => void;
 
     initAsync?(): Promise<void>;
-    initAsyncPromise?: Promise<void>;
 
     constructor(message: { id?: number; payload: Payload<Name> }) {
         const { payload } = message;

--- a/packages/connect/src/core/method.native.ts
+++ b/packages/connect/src/core/method.native.ts
@@ -20,7 +20,7 @@ const getMethodModule = (method: IFrameCallMessage['payload']['method']) =>
     MODULES.find(module => method.startsWith(module));
 
 // eslint-disable-next-line require-await
-export const getMethod = async (message: IFrameCallMessage & { id?: number }) => {
+export const getMethod = async (message: IFrameCallMessage) => {
     const { method } = message.payload;
     if (typeof method !== 'string') {
         throw TypedError('Method_InvalidParameter', 'Message method is not set');

--- a/packages/connect/src/core/method.ts
+++ b/packages/connect/src/core/method.ts
@@ -7,9 +7,7 @@ import type { AbstractMethod } from './AbstractMethod';
 const getMethodModule = (method: IFrameCallMessage['payload']['method']) =>
     MODULES.find(module => method.startsWith(module));
 
-export const getMethod = async (
-    message: IFrameCallMessage & { id?: number },
-): Promise<AbstractMethod<any>> => {
+export const getMethod = async (message: IFrameCallMessage): Promise<AbstractMethod<any>> => {
     const { method } = message.payload;
     if (typeof method !== 'string') {
         throw TypedError('Method_InvalidParameter', 'Message method is not set');
@@ -22,7 +20,7 @@ export const getMethod = async (
     const MethodConstructor = methods[method];
 
     if (MethodConstructor) {
-        return new MethodConstructor(message as any);
+        return new MethodConstructor(message);
     }
 
     throw TypedError('Method_InvalidParameter', `Method ${method} not found`);

--- a/packages/connect/src/data/analyticsInfo.ts
+++ b/packages/connect/src/data/analyticsInfo.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-case-declarations */
 // import { EventType } from '@trezor/connect-analytics';
-import { CoreMessage, PostMessage, UI_REQUEST } from '../events';
+import { CoreEventMessage, UI_REQUEST } from '../events';
 import type { Device } from '../types';
 
 // TODO: imho this belongs somewhere to packages/connect-iframe package.
@@ -8,8 +8,8 @@ import type { Device } from '../types';
 // to release new packages. Having it here means that I would need to
 // release 2 new packages to npm which is unjustifiable burden
 export const enhancePostMessageWithAnalytics = (
-    callback: PostMessage,
-    message: CoreMessage,
+    callback: (message: CoreEventMessage) => void,
+    message: CoreEventMessage,
     data: { device?: Device },
 ) => {
     switch (message.type) {

--- a/packages/connect/src/events/call.ts
+++ b/packages/connect/src/events/call.ts
@@ -47,7 +47,7 @@ export type CallMethodAnyResponse = ReturnType<CallMethodUnion>;
 export type CallMethod = (params: CallMethodPayload) => Promise<any>;
 
 export interface IFrameCallMessage {
-    event: typeof IFRAME.CALL;
+    id: number;
     type: typeof IFRAME.CALL;
     payload: CallMethodPayload;
 }

--- a/packages/connect/src/events/core.ts
+++ b/packages/connect/src/events/core.ts
@@ -1,51 +1,60 @@
 import type { BlockchainEventMessage } from './blockchain';
 import type { IFrameCallMessage, MethodResponseMessage } from './call';
 import type { DeviceEventMessage } from './device';
-import type { IFrameEventMessage } from './iframe';
-import type { PopupEventMessage } from './popup';
-import type { TransportEventMessage } from './transport';
+import type { IFrameEventMessage, IFrameInit, IFrameLogRequest } from './iframe';
+import type { PopupAnalyticsResponse, PopupClosedMessage, PopupEventMessage } from './popup';
+import type {
+    TransportEventMessage,
+    TransportDisableWebUSB,
+    TransportRequestWebUSBDevice,
+} from './transport';
 import type { UiEventMessage } from './ui-request';
-import type { UiResponseMessage } from './ui-response';
+import type { UiResponseEvent } from './ui-response';
 import type { Unsuccessful } from '../types/params';
 
 export const CORE_EVENT = 'CORE_EVENT';
 
-export type CoreMessage = {
-    id?: number; // response id in ResponseMessage
+export type CoreRequestMessage =
+    | PopupClosedMessage
+    | PopupAnalyticsResponse
+    | TransportDisableWebUSB
+    | TransportRequestWebUSBDevice
+    | UiResponseEvent
+    | IFrameInit
+    | IFrameCallMessage
+    | IFrameLogRequest;
+
+export type CoreEventMessage = {
     success?: boolean; // response status in ResponseMessage
 } & (
     | BlockchainEventMessage
     | DeviceEventMessage
     | TransportEventMessage
     | UiEventMessage
-    | UiResponseMessage
-    | IFrameCallMessage
     | MethodResponseMessage
     | IFrameEventMessage
     | PopupEventMessage
 );
 
-export type PostMessageEvent = MessageEvent<CoreMessage>;
-
-export type PostMessage = (message: CoreMessage) => void;
-
 // parse MessageEvent .data into CoreMessage
-export const parseMessage = (messageData: any): CoreMessage => {
-    const message: CoreMessage = {
+export const parseMessage = <T extends CoreRequestMessage | CoreEventMessage = never>(
+    messageData: any,
+): T => {
+    const message = {
         event: messageData.event,
         type: messageData.type,
         payload: messageData.payload,
     };
 
     if (typeof messageData.id === 'number') {
-        message.id = messageData.id;
+        (message as any).id = messageData.id;
     }
 
     if (typeof messageData.success === 'boolean') {
-        message.success = messageData.success;
+        (message as any).success = messageData.success;
     }
 
-    return message;
+    return message as T;
 };
 
 // common response used straight from npm index (not from Core)

--- a/packages/connect/src/events/iframe.ts
+++ b/packages/connect/src/events/iframe.ts
@@ -50,8 +50,6 @@ export interface IFrameLogRequest {
 export type IFrameEvent =
     | { type: typeof IFRAME.BOOTSTRAP; payload?: typeof undefined }
     | IFrameLoaded
-    | IFrameInit
-    | IFrameLogRequest
     | IFrameError;
 
 export type IFrameEventMessage = IFrameEvent & { event: typeof UI_EVENT };

--- a/packages/connect/src/events/popup.ts
+++ b/packages/connect/src/events/popup.ts
@@ -90,8 +90,6 @@ export type PopupEvent =
     | PopupInit
     | PopupHandshake
     | PopupError
-    | PopupClosedMessage
-    | PopupAnalyticsResponse
     | PopupContentScriptLoaded
     | PopupMethodInfo;
 

--- a/packages/connect/src/events/ui-request.ts
+++ b/packages/connect/src/events/ui-request.ts
@@ -4,7 +4,6 @@
 import type { EventTypeDeviceSelected } from '@trezor/connect-analytics';
 
 import type { PROTO } from '../constants';
-import type { TransportDisableWebUSB, TransportRequestWebUSBDevice } from './transport';
 import type { Device, CoinInfo, BitcoinNetworkInfo, SelectFeeLevel } from '../types';
 import type { DiscoveryAccountType, DiscoveryAccount } from '../types/account';
 import type { MessageFactoryFn } from '../types/utils';
@@ -271,9 +270,7 @@ export type UiEvent =
     | FirmwareProgress
     | FirmwareException
     | UiRequestAddressValidation
-    | UiRequestSetOperation
-    | TransportDisableWebUSB
-    | TransportRequestWebUSBDevice;
+    | UiRequestSetOperation;
 
 export type UiEventMessage = UiEvent & { event: typeof UI_EVENT };
 

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -1,7 +1,7 @@
 import EventEmitter from 'events';
 
 import { createDeferred, Deferred } from '@trezor/utils/lib/createDeferred';
-import { Core, initCore, initTransport } from './core';
+import { Core, initCore } from './core';
 import { factory } from './factory';
 import { parseConnectSettings } from './data/connectSettings';
 import { initLog } from './utils/debug';
@@ -127,9 +127,7 @@ const init = async (settings: Partial<ConnectSettings> = {}) => {
         return;
     }
 
-    _core = await initCore(_settings);
-    _core.on(CORE_EVENT, handleMessage);
-    await initTransport(_settings);
+    _core = await initCore(_settings, handleMessage);
 };
 
 const call: CallMethod = async params => {


### PR DESCRIPTION
## Description

First part of cleaning of the dusty Connect Core.

- https://github.com/trezor/trezor-suite/pull/10363/commits/ddd6f899afd8845af82d870549bfabb104130a6c - trying to separate general `CoreMessage` union into two parts: `CoreRequestMessage` going into Connect Core, and `CoreEventMessage` going outside of Connect Core. It's probably not 100% precise, but it already helped a bit to remove some useless type checks. In the future, we should document all the communication participants and which types of messages are going from/to them.
- https://github.com/trezor/trezor-suite/pull/10363/commits/ca567915f052d2da0a0198c4a2a7502fa4e96040 - making `initTransport` inseparable part of `initCore`; given that they're always called together anyway, it should simplify the api a bit
- https://github.com/trezor/trezor-suite/pull/10363/commits/870154b6b60aa061b7fcd1c3b491ddc4b07b412a - removing `initAsyncPromise` from connect methods; now `getSynchronize` util is used so `getCurrentMethod` awaits the whole method initialization (both `getMethod` and `initAsync`)
- https://github.com/trezor/trezor-suite/pull/10363/commits/5c993b54a8772a8d2c06e1e8418fabab01cf105f - deferred promises in connect index and connect-web index replaced by `createDeferredManager`

## Followup

#10391