### PR TITLE
deps(connect-plugin-ethereum): @metamask/eth-sig-util@^7.0.0->^7.0.1

### DIFF
--- a/packages/connect-plugin-ethereum/package.json
+++ b/packages/connect-plugin-ethereum/package.json
@@ -23,11 +23,11 @@
         "lib/"
     ],
     "peerDependencies": {
-        "@metamask/eth-sig-util": "^7.0.0",
+        "@metamask/eth-sig-util": "^7.0.1",
         "tslib": "^2.6.2"
     },
     "devDependencies": {
-        "@metamask/eth-sig-util": "^7.0.0",
+        "@metamask/eth-sig-util": "^7.0.1",
         "jest": "29.5.0",
         "rimraf": "^5.0.5",
         "typescript": "5.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3863,18 +3863,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-sig-util@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "@metamask/eth-sig-util@npm:7.0.0"
+"@metamask/eth-sig-util@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "@metamask/eth-sig-util@npm:7.0.1"
   dependencies:
     "@ethereumjs/util": "npm:^8.1.0"
     "@metamask/abi-utils": "npm:^2.0.2"
     "@metamask/utils": "npm:^8.1.0"
     ethereum-cryptography: "npm:^2.1.2"
-    ethjs-util: "npm:^0.1.6"
     tweetnacl: "npm:^1.0.3"
     tweetnacl-util: "npm:^0.15.1"
-  checksum: c399e615749ac78224d5e68883eff9bfb856eb26225d218937ac5ccb84e529157c0b1244dce449eb3dcb408a7830f2b4c0c1b2a6b1653049d93b3d76aae17860
+  checksum: e2aa3f0ad4db75b872705863a502414e17cd72d70c8b2a3f49c700ee237c428919161f345d42c6d00c5267fe87909ec021dee601cc02cb65bab04db2ec771997
   languageName: node
   linkType: hard
 
@@ -8544,12 +8543,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/connect-plugin-ethereum@workspace:packages/connect-plugin-ethereum"
   dependencies:
-    "@metamask/eth-sig-util": "npm:^7.0.0"
+    "@metamask/eth-sig-util": "npm:^7.0.1"
     jest: "npm:29.5.0"
     rimraf: "npm:^5.0.5"
     typescript: "npm:5.3.2"
   peerDependencies:
-    "@metamask/eth-sig-util": ^7.0.0
+    "@metamask/eth-sig-util": ^7.0.1
     tslib: ^2.6.2
   languageName: unknown
   linkType: soft
@@ -17871,16 +17870,6 @@ __metadata:
     bn.js: "npm:4.11.6"
     number-to-bn: "npm:1.7.0"
   checksum: 35086cb671806992ec36d5dd43ab67e68ad7a9237e42c0e963f9081c88e40147cda86c1a258b0a3180bf2b7bc1960e607c5bcaefdb2196e0f3564acf73276189
-  languageName: node
-  linkType: hard
-
-"ethjs-util@npm:^0.1.6":
-  version: 0.1.6
-  resolution: "ethjs-util@npm:0.1.6"
-  dependencies:
-    is-hex-prefixed: "npm:1.0.0"
-    strip-hex-prefix: "npm:1.0.0"
-  checksum: 02e1d37f743a78742651a11be35461dfe8ed653f113d630435aada8036e1e199691c2cfffbbf1e800bfdeb14bb34c7ed69fab5d3c727058c1daf3effc6bf6f69
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

`@metamask/eth-sig-util` `7.0.1` contains a fix for a regression present in versions `6.0.1` and `7.0.0`. Bumping the dependency range ensures that users don't pull in the deprecated `7.0.0`.

[Release notes](https://github.com/MetaMask/eth-sig-util/releases/tag/v7.0.1):

>    #### Changed
>    - Remove dependency `ethjs-util` ([#349](https://github.com/MetaMask/eth-sig-util/pull/349))
>    
>    #### Fixed
>    - **BREAKING**: fix: interpret 0x as hex in bytes encodeField ([#354](https://github.com/MetaMask/eth-sig-util/pull/354))
>      - This fixes a regression introduced in `6.0.1` which caused inconsistent signatures when data was supplied as literal `0x`.
>    - fix: Exclude test files from published release ([#350](https://github.com/MetaMask/eth-sig-util/pull/350))
>    - fix: Bump @babel/traverse from 7.21.5 to 7.23.2 ([#341](https://github.com/MetaMask/eth-sig-util/pull/341))  


[Package diff](https://npm-diff.app/@metamask/eth-sig-util@7.0.0...@metamask/eth-sig-util@7.0.1)
