### PR TITLE
Fix/release blockers

### DIFF
--- a/packages/suite-web/e2e/tests/onboarding/t2t1-recovery-persistence.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/t2t1-recovery-persistence.test.ts
@@ -66,6 +66,12 @@ describe('Onboarding - T2T1 in recovery mode', () => {
         cy.getTestElement('@onboarding/recovery/start-button').click();
         cy.getTestElement('@onboarding/confirm-on-device');
         cy.task('pressYes');
+        cy.wait(1000);
+        cy.task('pressYes');
+        cy.wait(1000);
+        cy.task('selectNumOfWordsEmu', 20);
+        cy.wait(1000);
+        cy.task('pressYes');
         cy.wait(501); // wait for device release
 
         // disconnect device, reload application

--- a/packages/suite/src/views/onboarding/steps/Backup.tsx
+++ b/packages/suite/src/views/onboarding/steps/Backup.tsx
@@ -21,6 +21,7 @@ import { backupDevice } from 'src/actions/backup/backupActions';
 import { goto } from 'src/actions/suite/routerActions';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { selectIsActionAbortable } from 'src/reducers/suite/suiteReducer';
+import * as onboardingActions from 'src/actions/onboarding/onboardingActions';
 
 const StyledImage = styled(Image)`
     flex: 1;
@@ -113,6 +114,7 @@ export const BackupStep = () => {
                     innerActions={
                         <OnboardingButtonCta
                             onClick={() => {
+                                dispatch(onboardingActions.resetOnboarding());
                                 dispatch(
                                     goto('settings-device', { anchor: SettingsAnchor.WipeDevice }),
                                 );

--- a/packages/suite/src/views/start/StartContent.tsx
+++ b/packages/suite/src/views/start/StartContent.tsx
@@ -4,7 +4,6 @@ import { DataAnalytics } from '@trezor/components';
 import { analytics } from '@trezor/suite-analytics';
 import { DOCS_ANALYTICS_URL, DATA_TOS_URL } from '@trezor/urls';
 import { selectIsAnalyticsConfirmed } from '@suite-common/analytics';
-import { selectDevice } from '@suite-common/wallet-core';
 import { rerun } from 'src/actions/recovery/recoveryActions';
 import { PrerequisitesGuide, TrezorLink } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -19,7 +18,6 @@ export const StartContent = () => {
     const confirmed = useSelector(selectIsAnalyticsConfirmed);
     const recovery = useSelector(state => state.recovery);
     const prerequisite = useSelector(selectPrerequisite);
-    const device = useSelector(selectDevice);
 
     const dispatch = useDispatch();
 
@@ -52,12 +50,13 @@ export const StartContent = () => {
             />
         );
     }
-    if (device) {
-        return <SecurityCheck />;
-    }
-    if (prerequisite) {
+
+    if (
+        prerequisite &&
+        !['device-initialize', 'firmware-missing', 'device-recovery-mode'].includes(prerequisite)
+    ) {
         return <PrerequisitesGuide />;
     }
 
-    return null;
+    return <SecurityCheck />;
 };


### PR DESCRIPTION
- fixes `no next step exists` error
  - https://satoshilabs.slack.com/archives/C031LD98L9K/p1702900897319309
  - which occurs when user fails backup, reset device and wants to start onboarding again
  
- fixes getting into onboarding with initialised device in fresh app
  - check device without seed, with fw/without fw on fresh/old app
 