### PR TITLE
Connect Core Revamp pt. 2

### DIFF
--- a/packages/connect-popup/e2e/tests/passphrase.test.ts
+++ b/packages/connect-popup/e2e/tests/passphrase.test.ts
@@ -337,9 +337,6 @@ test('passphrase mismatch', async ({ page }) => {
     log('waiting and click for invalid passphrase try again button');
     await waitAndClick(popup, ['@invalid-passphrase/try-again']);
 
-    log('waiting and click confirm permissions button');
-    await waitAndClick(popup, ['@permissions/confirm-button']);
-
     log('typing passphrase');
     // Input right passphrase.
     (await popup.waitForSelector("input[data-test='@passphrase/input']")).type('abc');

--- a/packages/connect/src/api/applyFlags.ts
+++ b/packages/connect/src/api/applyFlags.ts
@@ -1,7 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/ApplyFlags.js
 
 import { AbstractMethod } from '../core/AbstractMethod';
-import { UI, createUiMessage } from '../events';
 import { PROTO } from '../constants';
 import { Assert } from '@trezor/schema-utils';
 
@@ -19,28 +18,15 @@ export default class ApplyFlags extends AbstractMethod<'applyFlags', PROTO.Apply
         };
     }
 
-    async confirmation() {
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'device-management',
-                customConfirmButton: {
-                    className: 'confirm',
-                    label: 'Proceed',
-                },
-                label: 'Do you really want to apply flags?',
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        return uiResp.payload;
+    get confirmation() {
+        return {
+            view: 'device-management' as const,
+            customConfirmButton: {
+                className: 'confirm',
+                label: 'Proceed',
+            },
+            label: 'Do you really want to apply flags?',
+        };
     }
 
     async run() {

--- a/packages/connect/src/api/applySettings.ts
+++ b/packages/connect/src/api/applySettings.ts
@@ -1,7 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/ApplySettings.js
 
 import { AbstractMethod } from '../core/AbstractMethod';
-import { UI, createUiMessage } from '../events';
 import { PROTO } from '../constants';
 import { Assert } from '@trezor/schema-utils';
 import { ApplySettings as ApplySettingsSchema } from '../types/api/applySettings';
@@ -28,28 +27,15 @@ export default class ApplySettings extends AbstractMethod<'applySettings', PROTO
         };
     }
 
-    async confirmation() {
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'device-management',
-                customConfirmButton: {
-                    className: 'confirm',
-                    label: 'Proceed',
-                },
-                label: 'Do you really want to change device settings?',
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        return uiResp.payload;
+    get confirmation() {
+        return {
+            view: 'device-management' as const,
+            customConfirmButton: {
+                className: 'confirm',
+                label: 'Proceed',
+            },
+            label: 'Do you really want to change device settings?',
+        };
     }
 
     async run() {

--- a/packages/connect/src/api/backupDevice.ts
+++ b/packages/connect/src/api/backupDevice.ts
@@ -1,7 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/BackupDevice.js
 
 import { AbstractMethod } from '../core/AbstractMethod';
-import { UI, createUiMessage } from '../events';
 
 export default class BackupDevice extends AbstractMethod<'backupDevice'> {
     init() {
@@ -9,28 +8,15 @@ export default class BackupDevice extends AbstractMethod<'backupDevice'> {
         this.useDeviceState = false;
     }
 
-    async confirmation() {
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'device-management',
-                customConfirmButton: {
-                    className: 'confirm',
-                    label: 'Proceed',
-                },
-                label: 'Do you want to initiate backup procedure?',
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        return uiResp.payload;
+    get confirmation() {
+        return {
+            view: 'device-management' as const,
+            customConfirmButton: {
+                className: 'confirm',
+                label: 'Proceed',
+            },
+            label: 'Do you want to initiate backup procedure?',
+        };
     }
 
     async run() {

--- a/packages/connect/src/api/binance/api/binanceGetAddress.ts
+++ b/packages/connect/src/api/binance/api/binanceGetAddress.ts
@@ -20,6 +20,7 @@ export default class BinanceGetAddress extends AbstractMethod<'binanceGetAddress
     confirmed?: boolean;
 
     init() {
+        this.noBackupConfirmationMode = 'always';
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('BNB'), this.firmwareRange);
 
@@ -94,25 +95,6 @@ export default class BinanceGetAddress extends AbstractMethod<'binanceGetAddress
         this.confirmed = uiResp.payload;
 
         return this.confirmed;
-    }
-
-    async noBackupConfirmation() {
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'no-backup',
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        return uiResp.payload;
     }
 
     async _call({ address_n, show_display, chunkify }: Params) {

--- a/packages/connect/src/api/binance/api/binanceGetAddress.ts
+++ b/packages/connect/src/api/binance/api/binanceGetAddress.ts
@@ -17,7 +17,6 @@ type Params = PROTO.BinanceGetAddress & {
 export default class BinanceGetAddress extends AbstractMethod<'binanceGetAddress', Params[]> {
     hasBundle?: boolean;
     progress = 0;
-    confirmed?: boolean;
 
     init() {
         this.noBackupConfirmationMode = 'always';
@@ -49,7 +48,6 @@ export default class BinanceGetAddress extends AbstractMethod<'binanceGetAddress
             this.params.length === 1 &&
             typeof this.params[0].address === 'string' &&
             this.params[0].show_display;
-        this.confirmed = useEventListener;
         this.useUi = !useEventListener;
     }
 
@@ -74,27 +72,13 @@ export default class BinanceGetAddress extends AbstractMethod<'binanceGetAddress
         }
     }
 
-    async confirmation() {
-        if (this.confirmed) return true;
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'export-address',
-                label: this.info,
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        this.confirmed = uiResp.payload;
-
-        return this.confirmed;
+    get confirmation() {
+        return !this.useUi
+            ? undefined
+            : {
+                  view: 'export-address' as const,
+                  label: this.info,
+              };
     }
 
     async _call({ address_n, show_display, chunkify }: Params) {

--- a/packages/connect/src/api/binance/api/binanceGetPublicKey.ts
+++ b/packages/connect/src/api/binance/api/binanceGetPublicKey.ts
@@ -14,7 +14,6 @@ export default class BinanceGetPublicKey extends AbstractMethod<
     PROTO.BinanceGetPublicKey[]
 > {
     hasBundle?: boolean;
-    confirmed?: boolean;
 
     init() {
         this.requiredPermissions = ['read'];
@@ -43,36 +42,16 @@ export default class BinanceGetPublicKey extends AbstractMethod<
         return 'Export Binance public key';
     }
 
-    async confirmation() {
-        if (this.confirmed) return true;
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        let label: string;
-        if (this.params.length > 1) {
-            label = 'Export multiple Binance public keys';
-        } else {
-            label = `Export Binance public key for account #${
-                fromHardened(this.params[0].address_n[2]) + 1
-            }`;
-        }
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'export-address',
-                label,
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        this.confirmed = uiResp.payload;
-
-        return this.confirmed;
+    get confirmation() {
+        return {
+            view: 'export-address' as const,
+            label:
+                this.params.length > 1
+                    ? 'Export multiple Binance public keys'
+                    : `Export Binance public key for account #${
+                          fromHardened(this.params[0].address_n[2]) + 1
+                      }`,
+        };
     }
 
     async run() {

--- a/packages/connect/src/api/cardano/api/cardanoGetAddress.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetAddress.ts
@@ -26,6 +26,7 @@ export default class CardanoGetAddress extends AbstractMethod<'cardanoGetAddress
     confirmed?: boolean;
 
     init() {
+        this.noBackupConfirmationMode = 'always';
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(
             this.name,
@@ -111,25 +112,6 @@ export default class CardanoGetAddress extends AbstractMethod<'cardanoGetAddress
         this.confirmed = uiResp.payload;
 
         return this.confirmed;
-    }
-
-    async noBackupConfirmation() {
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'no-backup',
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        return uiResp.payload;
     }
 
     async _call({

--- a/packages/connect/src/api/cardano/api/cardanoGetAddress.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetAddress.ts
@@ -23,7 +23,6 @@ type Params = PROTO.CardanoGetAddress & {
 export default class CardanoGetAddress extends AbstractMethod<'cardanoGetAddress', Params[]> {
     hasBundle?: boolean;
     progress = 0;
-    confirmed?: boolean;
 
     init() {
         this.noBackupConfirmationMode = 'always';
@@ -65,7 +64,6 @@ export default class CardanoGetAddress extends AbstractMethod<'cardanoGetAddress
             this.params.length === 1 &&
             typeof this.params[0].address === 'string' &&
             this.params[0].show_display;
-        this.confirmed = useEventListener;
         this.useUi = !useEventListener;
     }
 
@@ -91,27 +89,13 @@ export default class CardanoGetAddress extends AbstractMethod<'cardanoGetAddress
         }
     }
 
-    async confirmation() {
-        if (this.confirmed) return true;
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'export-address',
-                label: this.info,
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        this.confirmed = uiResp.payload;
-
-        return this.confirmed;
+    get confirmation() {
+        return !this.useUi
+            ? undefined
+            : {
+                  view: 'export-address' as const,
+                  label: this.info,
+              };
     }
 
     async _call({

--- a/packages/connect/src/api/cardano/api/cardanoGetPublicKey.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetPublicKey.ts
@@ -16,7 +16,6 @@ interface Params extends PROTO.CardanoGetPublicKey {
 
 export default class CardanoGetPublicKey extends AbstractMethod<'cardanoGetPublicKey', Params[]> {
     hasBundle?: boolean;
-    confirmed?: boolean;
 
     init() {
         this.requiredPermissions = ['read'];
@@ -60,36 +59,16 @@ export default class CardanoGetPublicKey extends AbstractMethod<'cardanoGetPubli
         return 'Export Cardano public key';
     }
 
-    async confirmation() {
-        if (this.confirmed) return true;
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        let label: string;
-        if (this.params.length > 1) {
-            label = 'Export multiple Cardano public keys';
-        } else {
-            label = `Export Cardano public key for account #${
-                fromHardened(this.params[0].address_n[2]) + 1
-            }`;
-        }
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'export-xpub',
-                label,
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        this.confirmed = uiResp.payload;
-
-        return this.confirmed;
+    get confirmation() {
+        return {
+            view: 'export-xpub' as const,
+            label:
+                this.params.length > 1
+                    ? 'Export multiple Cardano public keys'
+                    : `Export Cardano public key for account #${
+                          fromHardened(this.params[0].address_n[2]) + 1
+                      }`,
+        };
     }
 
     async run() {

--- a/packages/connect/src/api/cardano/api/cardanoGetPublicKey.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetPublicKey.ts
@@ -48,6 +48,12 @@ export default class CardanoGetPublicKey extends AbstractMethod<'cardanoGetPubli
                 suppress_backup_warning: batch.suppressBackupWarning,
             };
         });
+
+        this.noBackupConfirmationMode = this.params.every(
+            batch => batch.suppressBackupWarning || !batch.show_display,
+        )
+            ? 'popup-only'
+            : 'always';
     }
 
     get info() {
@@ -84,31 +90,6 @@ export default class CardanoGetPublicKey extends AbstractMethod<'cardanoGetPubli
         this.confirmed = uiResp.payload;
 
         return this.confirmed;
-    }
-
-    async noBackupConfirmation(allowSuppression?: boolean) {
-        if (
-            allowSuppression &&
-            this.params.every(batch => batch.suppressBackupWarning || !batch.show_display)
-        ) {
-            return true;
-        }
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'no-backup',
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        return uiResp.payload;
     }
 
     async run() {

--- a/packages/connect/src/api/changeLanguage.ts
+++ b/packages/connect/src/api/changeLanguage.ts
@@ -1,7 +1,7 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/ChangeLanguage.js
 
 import { AbstractMethod } from '../core/AbstractMethod';
-import { UI, createUiMessage } from '../events';
+import { UI } from '../events';
 import { Assert } from '@trezor/schema-utils';
 import { ChangeLanguage as ChangeLanguageSchema } from '../types/api/changeLanguage';
 
@@ -19,28 +19,15 @@ export default class ChangeLanguage extends AbstractMethod<'changeLanguage', Cha
         this.params = payload;
     }
 
-    async confirmation() {
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'device-management',
-                customConfirmButton: {
-                    className: 'confirm',
-                    label: 'Proceed',
-                },
-                label: 'Do you want to change language?',
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        return uiResp.payload;
+    get confirmation() {
+        return {
+            view: 'device-management' as const,
+            customConfirmButton: {
+                className: 'confirm',
+                label: 'Proceed',
+            },
+            label: 'Do you want to change language?',
+        };
     }
 
     run() {

--- a/packages/connect/src/api/eos/api/eosGetPublicKey.ts
+++ b/packages/connect/src/api/eos/api/eosGetPublicKey.ts
@@ -14,7 +14,6 @@ export default class EosGetPublicKey extends AbstractMethod<
     PROTO.EosGetPublicKey[]
 > {
     hasBundle?: boolean;
-    confirmed?: boolean;
 
     init() {
         this.requiredPermissions = ['read'];
@@ -44,36 +43,16 @@ export default class EosGetPublicKey extends AbstractMethod<
         return 'Export Eos public key';
     }
 
-    async confirmation() {
-        if (this.confirmed) return true;
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        let label: string;
-        if (this.params.length > 1) {
-            label = 'Export multiple Eos public keys';
-        } else {
-            label = `Export Eos public key for account #${
-                fromHardened(this.params[0].address_n[2]) + 1
-            }`;
-        }
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'export-address',
-                label,
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        this.confirmed = uiResp.payload;
-
-        return this.confirmed;
+    get confirmation() {
+        return {
+            view: 'export-address' as const,
+            label:
+                this.params.length > 1
+                    ? 'Export multiple Eos public keys'
+                    : `Export Eos public key for account #${
+                          fromHardened(this.params[0].address_n[2]) + 1
+                      }`,
+        };
     }
 
     async run() {

--- a/packages/connect/src/api/ethereum/api/ethereumGetAddress.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumGetAddress.ts
@@ -30,6 +30,7 @@ export default class EthereumGetAddress extends AbstractMethod<'ethereumGetAddre
     confirmed?: boolean;
 
     init() {
+        this.noBackupConfirmationMode = 'always';
         this.requiredPermissions = ['read'];
 
         // create a bundle with only one batch if bundle doesn't exists
@@ -129,25 +130,6 @@ export default class EthereumGetAddress extends AbstractMethod<'ethereumGetAddre
         this.confirmed = uiResp.payload;
 
         return this.confirmed;
-    }
-
-    async noBackupConfirmation() {
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'no-backup',
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        return uiResp.payload;
     }
 
     _call({ address_n, show_display, encoded_network, chunkify }: Params) {

--- a/packages/connect/src/api/ethereum/api/ethereumGetAddress.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumGetAddress.ts
@@ -27,7 +27,6 @@ type Params = PROTO.EthereumGetAddress & {
 export default class EthereumGetAddress extends AbstractMethod<'ethereumGetAddress', Params[]> {
     hasBundle?: boolean;
     progress = 0;
-    confirmed?: boolean;
 
     init() {
         this.noBackupConfirmationMode = 'always';
@@ -61,7 +60,6 @@ export default class EthereumGetAddress extends AbstractMethod<'ethereumGetAddre
             this.params.length === 1 &&
             typeof this.params[0].address === 'string' &&
             this.params[0].show_display;
-        this.confirmed = useEventListener;
         this.useUi = !useEventListener;
     }
 
@@ -109,27 +107,11 @@ export default class EthereumGetAddress extends AbstractMethod<'ethereumGetAddre
         }
     }
 
-    async confirmation() {
-        if (this.confirmed) return true;
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'export-address',
-                label: this.info,
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        this.confirmed = uiResp.payload;
-
-        return this.confirmed;
+    get confirmation() {
+        return {
+            view: 'export-address' as const,
+            label: this.info,
+        };
     }
 
     _call({ address_n, show_display, encoded_network, chunkify }: Params) {

--- a/packages/connect/src/api/ethereum/api/ethereumGetPublicKey.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumGetPublicKey.ts
@@ -17,7 +17,6 @@ type Params = PROTO.EthereumGetPublicKey & {
 
 export default class EthereumGetPublicKey extends AbstractMethod<'ethereumGetPublicKey', Params[]> {
     hasBundle?: boolean;
-    confirmed?: boolean;
 
     init() {
         this.requiredPermissions = ['read'];
@@ -58,27 +57,11 @@ export default class EthereumGetPublicKey extends AbstractMethod<'ethereumGetPub
         return 'Export multiple public keys';
     }
 
-    async confirmation() {
-        if (this.confirmed) return true;
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'export-xpub',
-                label: this.info,
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        this.confirmed = uiResp.payload;
-
-        return this.confirmed;
+    get confirmation() {
+        return {
+            view: 'export-xpub' as const,
+            label: this.info,
+        };
     }
 
     async run() {

--- a/packages/connect/src/api/firmwareUpdate.ts
+++ b/packages/connect/src/api/firmwareUpdate.ts
@@ -3,7 +3,7 @@
 import { randomBytes } from 'crypto';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { ERRORS } from '../constants';
-import { UI, createUiMessage } from '../events';
+import { UI } from '../events';
 import {
     getBinary,
     shouldStripFwHeaders,
@@ -53,28 +53,15 @@ export default class FirmwareUpdate extends AbstractMethod<'firmwareUpdate', Par
         }
     }
 
-    async confirmation() {
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'device-management',
-                customConfirmButton: {
-                    className: 'wipe',
-                    label: 'Proceed',
-                },
-                label: 'Do you want to update firmware? Never do this without your recovery card.',
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        return uiResp.payload;
+    get confirmation() {
+        return {
+            view: 'device-management' as const,
+            customConfirmButton: {
+                className: 'wipe',
+                label: 'Proceed',
+            },
+            label: 'Do you want to update firmware? Never do this without your recovery card.',
+        };
     }
 
     async run() {

--- a/packages/connect/src/api/getAccountDescriptor.ts
+++ b/packages/connect/src/api/getAccountDescriptor.ts
@@ -53,6 +53,10 @@ export default class GetAccountDescriptor extends AbstractMethod<
                 coinInfo,
             };
         });
+
+        this.noBackupConfirmationMode = this.params.every(batch => batch.suppressBackupWarning)
+            ? 'popup-only'
+            : 'always';
     }
 
     get info() {
@@ -99,28 +103,6 @@ export default class GetAccountDescriptor extends AbstractMethod<
             createUiMessage(UI.REQUEST_CONFIRMATION, {
                 view: 'export-account-info',
                 label: `Export descriptor for: ${str.join('')}`,
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        return uiResp.payload;
-    }
-
-    async noBackupConfirmation(allowSuppression?: boolean) {
-        if (allowSuppression && this.params.every(batch => batch.suppressBackupWarning)) {
-            return true;
-        }
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'no-backup',
             }),
         );
 

--- a/packages/connect/src/api/getAccountDescriptor.ts
+++ b/packages/connect/src/api/getAccountDescriptor.ts
@@ -63,12 +63,7 @@ export default class GetAccountDescriptor extends AbstractMethod<
         return 'Export account descriptor';
     }
 
-    async confirmation() {
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
+    get confirmation() {
         const keys: {
             [coin: string]: { coinInfo: CoinInfo; values: DerivationPath[] };
         } = {};
@@ -99,17 +94,10 @@ export default class GetAccountDescriptor extends AbstractMethod<
             });
         });
 
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'export-account-info',
-                label: `Export descriptor for: ${str.join('')}`,
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        return uiResp.payload;
+        return {
+            view: 'export-account-info' as const,
+            label: `Export descriptor for: ${str.join('')}`,
+        };
     }
 
     // override AbstractMethod function

--- a/packages/connect/src/api/getAccountDescriptor.ts
+++ b/packages/connect/src/api/getAccountDescriptor.ts
@@ -115,7 +115,7 @@ export default class GetAccountDescriptor extends AbstractMethod<
     // override AbstractMethod function
     // this is a special case where we want to check firmwareRange in bundle
     // and return error with bundle indexes
-    async checkFirmwareRange(_isUsingPopup: boolean) {
+    checkFirmwareRange() {
         // check each batch and return error with invalid bundle indexes
         // find invalid ranges
         const invalid = [];
@@ -126,7 +126,7 @@ export default class GetAccountDescriptor extends AbstractMethod<
                 this.params[i].coinInfo,
                 DEFAULT_FIRMWARE_RANGE,
             );
-            const exception = await super.checkFirmwareRange(false);
+            const exception = super.checkFirmwareRange();
             if (exception) {
                 invalid.push({
                     index: i,

--- a/packages/connect/src/api/getAccountInfo.ts
+++ b/packages/connect/src/api/getAccountInfo.ts
@@ -171,10 +171,9 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
     // override AbstractMethod function
     // this is a special case where we want to check firmwareRange in bundle
     // and return error with bundle indexes
-    async checkFirmwareRange(isUsingPopup: boolean) {
-        // for popup mode use it like it was before
-        if (isUsingPopup || this.params.length === 1) {
-            return super.checkFirmwareRange(isUsingPopup);
+    checkFirmwareRange() {
+        if (this.params.length === 1) {
+            return super.checkFirmwareRange();
         }
         // for trusted mode check each batch and return error with invalid bundle indexes
         // find invalid ranges
@@ -186,7 +185,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
                 this.params[i].coinInfo,
                 DEFAULT_FIRMWARE_RANGE,
             );
-            const exception = await super.checkFirmwareRange(false);
+            const exception = super.checkFirmwareRange();
             if (exception) {
                 invalid.push({
                     index: i,

--- a/packages/connect/src/api/getAccountInfo.ts
+++ b/packages/connect/src/api/getAccountInfo.ts
@@ -103,24 +103,16 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
         return 'Export account info';
     }
 
-    async confirmation() {
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
+    get confirmation() {
         if (this.params.length === 1 && !this.params[0].path && !this.params[0].descriptor) {
-            // request confirmation view
-            this.postMessage(
-                createUiMessage(UI.REQUEST_CONFIRMATION, {
-                    view: 'export-account-info',
-                    label: `Export info for ${this.params[0].coinInfo.label} account of your selection`,
-                    customConfirmButton: {
-                        label: 'Proceed to account selection',
-                        className: 'not-empty-css',
-                    },
-                }),
-            );
+            return {
+                view: 'export-account-info' as const,
+                label: `Export info for ${this.params[0].coinInfo.label} account of your selection`,
+                customConfirmButton: {
+                    label: 'Proceed to account selection',
+                    className: 'not-empty-css',
+                },
+            };
         } else {
             const keys: {
                 [coin: string]: { coinInfo: CoinInfo; values: DerivationPath[] };
@@ -154,18 +146,11 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
                 });
             });
 
-            this.postMessage(
-                createUiMessage(UI.REQUEST_CONFIRMATION, {
-                    view: 'export-account-info',
-                    label: `Export info for: ${str.join('')}`,
-                }),
-            );
+            return {
+                view: 'export-account-info' as const,
+                label: `Export info for: ${str.join('')}`,
+            };
         }
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        return uiResp.payload;
     }
 
     // override AbstractMethod function

--- a/packages/connect/src/api/getAccountInfo.ts
+++ b/packages/connect/src/api/getAccountInfo.ts
@@ -93,6 +93,10 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
 
         this.useDevice = willUseDevice;
         this.useUi = willUseDevice;
+
+        this.noBackupConfirmationMode = this.params.every(batch => batch.suppressBackupWarning)
+            ? 'popup-only'
+            : 'always';
     }
 
     get info() {
@@ -157,28 +161,6 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
                 }),
             );
         }
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        return uiResp.payload;
-    }
-
-    async noBackupConfirmation(allowSuppression?: boolean) {
-        if (allowSuppression && this.params.every(batch => batch.suppressBackupWarning)) {
-            return true;
-        }
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'no-backup',
-            }),
-        );
 
         // wait for user action
         const uiResp = await uiPromise.promise;

--- a/packages/connect/src/api/getAddress.ts
+++ b/packages/connect/src/api/getAddress.ts
@@ -22,6 +22,7 @@ export default class GetAddress extends AbstractMethod<'getAddress', Params[]> {
     confirmed?: boolean;
 
     init() {
+        this.noBackupConfirmationMode = 'always';
         this.requiredPermissions = ['read'];
 
         // create a bundle with only one batch if bundle doesn't exists
@@ -130,25 +131,6 @@ export default class GetAddress extends AbstractMethod<'getAddress', Params[]> {
         this.confirmed = uiResp.payload;
 
         return this.confirmed;
-    }
-
-    async noBackupConfirmation() {
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'no-backup',
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        return uiResp.payload;
     }
 
     async _call({

--- a/packages/connect/src/api/getAddress.ts
+++ b/packages/connect/src/api/getAddress.ts
@@ -19,7 +19,6 @@ type Params = PROTO.GetAddress & {
 export default class GetAddress extends AbstractMethod<'getAddress', Params[]> {
     hasBundle?: boolean;
     progress = 0;
-    confirmed?: boolean;
 
     init() {
         this.noBackupConfirmationMode = 'always';
@@ -82,7 +81,6 @@ export default class GetAddress extends AbstractMethod<'getAddress', Params[]> {
             this.params.length === 1 &&
             typeof this.params[0].address === 'string' &&
             this.params[0].show_display;
-        this.confirmed = useEventListener;
         this.useUi = !useEventListener;
     }
 
@@ -110,27 +108,13 @@ export default class GetAddress extends AbstractMethod<'getAddress', Params[]> {
         }
     }
 
-    async confirmation() {
-        if (this.confirmed) return true;
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'export-address',
-                label: this.info,
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        this.confirmed = uiResp.payload;
-
-        return this.confirmed;
+    get confirmation() {
+        return !this.useUi
+            ? undefined
+            : {
+                  view: 'export-address' as const,
+                  label: this.info,
+              };
     }
 
     async _call({

--- a/packages/connect/src/api/getOwnershipId.ts
+++ b/packages/connect/src/api/getOwnershipId.ts
@@ -13,7 +13,6 @@ export default class GetOwnershipId extends AbstractMethod<
     PROTO.GetOwnershipId[]
 > {
     hasBundle?: boolean;
-    confirmed?: boolean;
 
     init() {
         this.requiredPermissions = ['read'];
@@ -46,31 +45,11 @@ export default class GetOwnershipId extends AbstractMethod<
         return 'Export ownership id';
     }
 
-    async confirmation() {
-        if (this.confirmed) return true;
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION, this.device);
-        let label = this.info;
-        if (this.params.length > 1) {
-            label = 'Export multiple ownership proof ids';
-        }
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'export-address',
-                label,
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        this.confirmed = uiResp.payload;
-
-        return this.confirmed;
+    get confirmation() {
+        return {
+            view: 'export-address' as const,
+            label: this.params.length > 1 ? 'Export multiple ownership proof ids' : this.info,
+        };
     }
 
     async run() {

--- a/packages/connect/src/api/getOwnershipProof.ts
+++ b/packages/connect/src/api/getOwnershipProof.ts
@@ -13,7 +13,6 @@ export default class GetOwnershipProof extends AbstractMethod<
     PROTO.GetOwnershipProof[]
 > {
     hasBundle?: boolean;
-    confirmed?: boolean;
 
     init() {
         this.requiredPermissions = ['read'];
@@ -52,31 +51,11 @@ export default class GetOwnershipProof extends AbstractMethod<
         return 'Export ownership proof';
     }
 
-    async confirmation() {
-        if (this.confirmed) return true;
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION, this.device);
-        let label = this.info;
-        if (this.params.length > 1) {
-            label = 'Export multiple ownership proofs';
-        }
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'export-address',
-                label,
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        this.confirmed = uiResp.payload;
-
-        return this.confirmed;
+    get confirmation() {
+        return {
+            view: 'export-address' as const,
+            label: this.params.length > 1 ? 'Export multiple ownership proofs' : this.info,
+        };
     }
 
     async run() {

--- a/packages/connect/src/api/getPublicKey.ts
+++ b/packages/connect/src/api/getPublicKey.ts
@@ -64,6 +64,12 @@ export default class GetPublicKey extends AbstractMethod<'getPublicKey', Params[
                 suppress_backup_warning: batch.suppressBackupWarning,
             };
         });
+
+        this.noBackupConfirmationMode = this.params.every(
+            batch => batch.suppressBackupWarning || !batch.show_display,
+        )
+            ? 'popup-only'
+            : 'always';
     }
 
     get info() {
@@ -97,31 +103,6 @@ export default class GetPublicKey extends AbstractMethod<'getPublicKey', Params[
         this.confirmed = uiResp.payload;
 
         return this.confirmed;
-    }
-
-    async noBackupConfirmation(allowSuppression?: boolean) {
-        if (
-            allowSuppression &&
-            this.params.every(batch => batch.suppressBackupWarning || !batch.show_display)
-        ) {
-            return true;
-        }
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'no-backup',
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        return uiResp.payload;
     }
 
     async run() {

--- a/packages/connect/src/api/getPublicKey.ts
+++ b/packages/connect/src/api/getPublicKey.ts
@@ -20,7 +20,6 @@ type Params = PROTO.GetPublicKey & {
 
 export default class GetPublicKey extends AbstractMethod<'getPublicKey', Params[]> {
     hasBundle?: boolean;
-    confirmed?: boolean;
 
     init() {
         this.requiredPermissions = ['read'];
@@ -76,33 +75,14 @@ export default class GetPublicKey extends AbstractMethod<'getPublicKey', Params[
         return 'Export public key';
     }
 
-    async confirmation() {
-        if (this.confirmed) return true;
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-        let label: string;
-        if (this.params.length > 1) {
-            label = 'Export multiple public keys';
-        } else {
-            label = getPublicKeyLabel(this.params[0].address_n, this.params[0].coinInfo);
-        }
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'export-xpub',
-                label,
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        this.confirmed = uiResp.payload;
-
-        return this.confirmed;
+    get confirmation() {
+        return {
+            view: 'export-xpub' as const,
+            label:
+                this.params.length > 1
+                    ? 'Export multiple public keys'
+                    : getPublicKeyLabel(this.params[0].address_n, this.params[0].coinInfo),
+        };
     }
 
     async run() {

--- a/packages/connect/src/api/nem/api/nemGetAddress.ts
+++ b/packages/connect/src/api/nem/api/nemGetAddress.ts
@@ -24,6 +24,7 @@ export default class NEMGetAddress extends AbstractMethod<'nemGetAddress', Param
     confirmed?: boolean;
 
     init() {
+        this.noBackupConfirmationMode = 'always';
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('NEM'), this.firmwareRange);
 
@@ -113,25 +114,6 @@ export default class NEMGetAddress extends AbstractMethod<'nemGetAddress', Param
         this.confirmed = uiResp.payload;
 
         return this.confirmed;
-    }
-
-    async noBackupConfirmation() {
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'no-backup',
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        return uiResp.payload;
     }
 
     async _call({ address_n, network, show_display, chunkify }: Params) {

--- a/packages/connect/src/api/nem/api/nemGetAddress.ts
+++ b/packages/connect/src/api/nem/api/nemGetAddress.ts
@@ -21,7 +21,6 @@ const MIJIN = 0x60; // 96
 export default class NEMGetAddress extends AbstractMethod<'nemGetAddress', Params[]> {
     hasBundle?: boolean;
     progress = 0;
-    confirmed?: boolean;
 
     init() {
         this.noBackupConfirmationMode = 'always';
@@ -54,7 +53,6 @@ export default class NEMGetAddress extends AbstractMethod<'nemGetAddress', Param
             this.params.length === 1 &&
             typeof this.params[0].address === 'string' &&
             this.params[0].show_display;
-        this.confirmed = useEventListener;
         this.useUi = !useEventListener;
     }
 
@@ -93,27 +91,11 @@ export default class NEMGetAddress extends AbstractMethod<'nemGetAddress', Param
         }
     }
 
-    async confirmation() {
-        if (this.confirmed) return true;
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'export-address',
-                label: this.info,
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        this.confirmed = uiResp.payload;
-
-        return this.confirmed;
+    get confirmation() {
+        return {
+            view: 'export-address' as const,
+            label: this.info,
+        };
     }
 
     async _call({ address_n, network, show_display, chunkify }: Params) {

--- a/packages/connect/src/api/rebootToBootloader.ts
+++ b/packages/connect/src/api/rebootToBootloader.ts
@@ -2,7 +2,7 @@
 
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getFirmwareRange } from './common/paramsValidator';
-import { UI, createUiMessage } from '../events';
+import { UI } from '../events';
 import { Assert } from '@trezor/schema-utils';
 import { PROTO } from '../constants';
 
@@ -10,8 +10,6 @@ export default class RebootToBootloader extends AbstractMethod<
     'rebootToBootloader',
     PROTO.RebootToBootloader
 > {
-    confirmed?: boolean;
-
     init() {
         this.allowDeviceMode = [UI.INITIALIZE, UI.SEEDLESS];
         this.skipFinalReload = true;
@@ -34,31 +32,15 @@ export default class RebootToBootloader extends AbstractMethod<
         return 'Reboot to bootloader';
     }
 
-    async confirmation() {
-        if (this.confirmed) return true;
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'device-management',
-                customConfirmButton: {
-                    className: 'confirm',
-                    label: `Reboot`,
-                },
-                label: 'Are you sure you want to reboot to bootloader?',
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        this.confirmed = uiResp.payload;
-
-        return this.confirmed;
+    get confirmation() {
+        return {
+            view: 'device-management' as const,
+            customConfirmButton: {
+                className: 'confirm',
+                label: `Reboot`,
+            },
+            label: 'Are you sure you want to reboot to bootloader?',
+        };
     }
 
     async run() {

--- a/packages/connect/src/api/recoveryDevice.ts
+++ b/packages/connect/src/api/recoveryDevice.ts
@@ -1,7 +1,7 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/RecoveryDevice.js
 
 import { AbstractMethod } from '../core/AbstractMethod';
-import { UI, createUiMessage } from '../events';
+import { UI } from '../events';
 import { Assert } from '@trezor/schema-utils';
 import type { PROTO } from '../constants';
 import { RecoveryDevice as RecoveryDeviceSchema } from '../types/api/recoveryDevice';
@@ -29,28 +29,15 @@ export default class RecoveryDevice extends AbstractMethod<'recoveryDevice', PRO
         this.useDeviceState = false;
     }
 
-    async confirmation() {
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'device-management',
-                customConfirmButton: {
-                    className: 'confirm',
-                    label: 'Proceed',
-                },
-                label: 'Do you want to recover device from seed?',
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        return uiResp.payload;
+    get confirmation() {
+        return {
+            view: 'device-management' as const,
+            customConfirmButton: {
+                className: 'confirm',
+                label: 'Proceed',
+            },
+            label: 'Do you want to recover device from seed?',
+        };
     }
 
     async run() {

--- a/packages/connect/src/api/resetDevice.ts
+++ b/packages/connect/src/api/resetDevice.ts
@@ -1,14 +1,12 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/ResetDevice.js
 
 import { AbstractMethod } from '../core/AbstractMethod';
-import { UI, createUiMessage } from '../events';
+import { UI } from '../events';
 import { getFirmwareRange } from './common/paramsValidator';
 import { PROTO } from '../constants';
 import { Assert } from '@trezor/schema-utils';
 
 export default class ResetDevice extends AbstractMethod<'resetDevice', PROTO.ResetDevice> {
-    confirmed?: boolean;
-
     init() {
         this.allowDeviceMode = [UI.INITIALIZE, UI.SEEDLESS];
         this.useDeviceState = false;
@@ -37,27 +35,11 @@ export default class ResetDevice extends AbstractMethod<'resetDevice', PROTO.Res
         return 'Setup device';
     }
 
-    async confirmation() {
-        if (this.confirmed) return true;
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'device-management',
-                label: 'Do you really you want to create a new wallet?',
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        this.confirmed = uiResp.payload;
-
-        return this.confirmed;
+    get confirmation() {
+        return {
+            view: 'device-management' as const,
+            label: 'Do you really you want to create a new wallet?',
+        };
     }
 
     async run() {

--- a/packages/connect/src/api/ripple/api/rippleGetAddress.ts
+++ b/packages/connect/src/api/ripple/api/rippleGetAddress.ts
@@ -20,6 +20,7 @@ export default class RippleGetAddress extends AbstractMethod<'rippleGetAddress',
     confirmed?: boolean;
 
     init() {
+        this.noBackupConfirmationMode = 'always';
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(
             this.name,
@@ -96,25 +97,6 @@ export default class RippleGetAddress extends AbstractMethod<'rippleGetAddress',
         this.confirmed = uiResp.payload;
 
         return this.confirmed;
-    }
-
-    async noBackupConfirmation() {
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'no-backup',
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        return uiResp.payload;
     }
 
     async _call({ address_n, show_display, chunkify }: Params) {

--- a/packages/connect/src/api/ripple/api/rippleGetAddress.ts
+++ b/packages/connect/src/api/ripple/api/rippleGetAddress.ts
@@ -17,7 +17,6 @@ type Params = PROTO.RippleGetAddress & {
 export default class RippleGetAddress extends AbstractMethod<'rippleGetAddress', Params[]> {
     hasBundle?: boolean;
     progress = 0;
-    confirmed?: boolean;
 
     init() {
         this.noBackupConfirmationMode = 'always';
@@ -53,7 +52,6 @@ export default class RippleGetAddress extends AbstractMethod<'rippleGetAddress',
             this.params.length === 1 &&
             typeof this.params[0].address === 'string' &&
             this.params[0].show_display;
-        this.confirmed = useEventListener;
         this.useUi = !useEventListener;
     }
 
@@ -77,26 +75,11 @@ export default class RippleGetAddress extends AbstractMethod<'rippleGetAddress',
         }
     }
 
-    async confirmation() {
-        if (this.confirmed) return true;
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'export-address',
-                label: this.info,
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-        this.confirmed = uiResp.payload;
-
-        return this.confirmed;
+    get confirmation() {
+        return {
+            view: 'export-address' as const,
+            label: this.info,
+        };
     }
 
     async _call({ address_n, show_display, chunkify }: Params) {

--- a/packages/connect/src/api/solana/api/solanaGetAddress.ts
+++ b/packages/connect/src/api/solana/api/solanaGetAddress.ts
@@ -15,7 +15,6 @@ type Params = PROTO.SolanaGetAddress & {
 export default class SolanaGetAddress extends AbstractMethod<'solanaGetAddress', Params[]> {
     hasBundle?: boolean;
     progress = 0;
-    confirmed?: boolean;
 
     init() {
         this.noBackupConfirmationMode = 'always';
@@ -51,7 +50,6 @@ export default class SolanaGetAddress extends AbstractMethod<'solanaGetAddress',
             this.params.length === 1 &&
             typeof this.params[0].address === 'string' &&
             this.params[0].show_display;
-        this.confirmed = useEventListener;
         this.useUi = !useEventListener;
     }
 
@@ -73,36 +71,16 @@ export default class SolanaGetAddress extends AbstractMethod<'solanaGetAddress',
         }
     }
 
-    async confirmation() {
-        if (this.confirmed) return true;
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        let label: string;
-        if (this.params.length > 1) {
-            label = 'Export multiple Solana addresses';
-        } else {
-            label = `Export Solana address for account #${
-                fromHardened(this.params[0].address_n[2]) + 1
-            }`;
-        }
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'export-address',
-                label,
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        this.confirmed = uiResp.payload;
-
-        return this.confirmed;
+    get confirmation() {
+        return {
+            view: 'export-address' as const,
+            label:
+                this.params.length > 1
+                    ? 'Export multiple Solana addresses'
+                    : `Export Solana address for account #${
+                          fromHardened(this.params[0].address_n[2]) + 1
+                      }`,
+        };
     }
 
     async _call({ address_n, show_display, chunkify }: Params) {

--- a/packages/connect/src/api/solana/api/solanaGetAddress.ts
+++ b/packages/connect/src/api/solana/api/solanaGetAddress.ts
@@ -18,6 +18,7 @@ export default class SolanaGetAddress extends AbstractMethod<'solanaGetAddress',
     confirmed?: boolean;
 
     init() {
+        this.noBackupConfirmationMode = 'always';
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(
             this.name,
@@ -102,25 +103,6 @@ export default class SolanaGetAddress extends AbstractMethod<'solanaGetAddress',
         this.confirmed = uiResp.payload;
 
         return this.confirmed;
-    }
-
-    async noBackupConfirmation() {
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'no-backup',
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        return uiResp.payload;
     }
 
     async _call({ address_n, show_display, chunkify }: Params) {

--- a/packages/connect/src/api/solana/api/solanaGetPublicKey.ts
+++ b/packages/connect/src/api/solana/api/solanaGetPublicKey.ts
@@ -15,6 +15,7 @@ export default class SolanaGetPublicKey extends AbstractMethod<
     confirmed?: boolean;
 
     init() {
+        this.noBackupConfirmationMode = 'always';
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(
             this.name,
@@ -75,25 +76,6 @@ export default class SolanaGetPublicKey extends AbstractMethod<
         this.confirmed = uiResp.payload;
 
         return this.confirmed;
-    }
-
-    async noBackupConfirmation() {
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'no-backup',
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        return uiResp.payload;
     }
 
     async run() {

--- a/packages/connect/src/api/solana/api/solanaGetPublicKey.ts
+++ b/packages/connect/src/api/solana/api/solanaGetPublicKey.ts
@@ -12,7 +12,6 @@ export default class SolanaGetPublicKey extends AbstractMethod<
     PROTO.SolanaGetPublicKey[]
 > {
     hasBundle?: boolean;
-    confirmed?: boolean;
 
     init() {
         this.noBackupConfirmationMode = 'always';
@@ -46,36 +45,16 @@ export default class SolanaGetPublicKey extends AbstractMethod<
         return 'Export Solana public key';
     }
 
-    async confirmation() {
-        if (this.confirmed) return true;
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        let label: string;
-        if (this.params.length > 1) {
-            label = 'Export multiple Solana public keys';
-        } else {
-            label = `Export Solana public key for account #${
-                fromHardened(this.params[0].address_n[2]) + 1
-            }`;
-        }
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'export-xpub',
-                label,
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        this.confirmed = uiResp.payload;
-
-        return this.confirmed;
+    get confirmation() {
+        return {
+            view: 'export-xpub' as const,
+            label:
+                this.params.length > 1
+                    ? 'Export multiple Solana public keys'
+                    : `Export Solana public key for account #${
+                          fromHardened(this.params[0].address_n[2]) + 1
+                      }`,
+        };
     }
 
     async run() {

--- a/packages/connect/src/api/stellar/api/stellarGetAddress.ts
+++ b/packages/connect/src/api/stellar/api/stellarGetAddress.ts
@@ -17,7 +17,6 @@ type Params = PROTO.StellarGetAddress & {
 export default class StellarGetAddress extends AbstractMethod<'stellarGetAddress', Params[]> {
     hasBundle?: boolean;
     progress = 0;
-    confirmed?: boolean;
 
     init() {
         this.noBackupConfirmationMode = 'always';
@@ -53,7 +52,6 @@ export default class StellarGetAddress extends AbstractMethod<'stellarGetAddress
             this.params.length === 1 &&
             typeof this.params[0].address === 'string' &&
             this.params[0].show_display;
-        this.confirmed = useEventListener;
         this.useUi = !useEventListener;
     }
 
@@ -77,27 +75,11 @@ export default class StellarGetAddress extends AbstractMethod<'stellarGetAddress
         }
     }
 
-    async confirmation() {
-        if (this.confirmed) return true;
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'export-address',
-                label: this.info,
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        this.confirmed = uiResp.payload;
-
-        return this.confirmed;
+    get confirmation() {
+        return {
+            view: 'export-address' as const,
+            label: this.info,
+        };
     }
 
     async _call({ address_n, show_display, chunkify }: Params) {

--- a/packages/connect/src/api/stellar/api/stellarGetAddress.ts
+++ b/packages/connect/src/api/stellar/api/stellarGetAddress.ts
@@ -20,6 +20,7 @@ export default class StellarGetAddress extends AbstractMethod<'stellarGetAddress
     confirmed?: boolean;
 
     init() {
+        this.noBackupConfirmationMode = 'always';
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(
             this.name,
@@ -97,25 +98,6 @@ export default class StellarGetAddress extends AbstractMethod<'stellarGetAddress
         this.confirmed = uiResp.payload;
 
         return this.confirmed;
-    }
-
-    async noBackupConfirmation() {
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'no-backup',
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        return uiResp.payload;
     }
 
     async _call({ address_n, show_display, chunkify }: Params) {

--- a/packages/connect/src/api/tezos/api/tezosGetAddress.ts
+++ b/packages/connect/src/api/tezos/api/tezosGetAddress.ts
@@ -20,6 +20,7 @@ export default class TezosGetAddress extends AbstractMethod<'tezosGetAddress', P
     confirmed?: boolean;
 
     init() {
+        this.noBackupConfirmationMode = 'always';
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(
             this.name,
@@ -97,25 +98,6 @@ export default class TezosGetAddress extends AbstractMethod<'tezosGetAddress', P
         this.confirmed = uiResp.payload;
 
         return this.confirmed;
-    }
-
-    async noBackupConfirmation() {
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'no-backup',
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        return uiResp.payload;
     }
 
     async _call({ address_n, show_display, chunkify }: Params) {

--- a/packages/connect/src/api/tezos/api/tezosGetAddress.ts
+++ b/packages/connect/src/api/tezos/api/tezosGetAddress.ts
@@ -17,7 +17,6 @@ type Params = PROTO.TezosGetAddress & {
 export default class TezosGetAddress extends AbstractMethod<'tezosGetAddress', Params[]> {
     hasBundle?: boolean;
     progress = 0;
-    confirmed?: boolean;
 
     init() {
         this.noBackupConfirmationMode = 'always';
@@ -53,7 +52,6 @@ export default class TezosGetAddress extends AbstractMethod<'tezosGetAddress', P
             this.params.length === 1 &&
             typeof this.params[0].address === 'string' &&
             this.params[0].show_display;
-        this.confirmed = useEventListener;
         this.useUi = !useEventListener;
     }
 
@@ -77,27 +75,11 @@ export default class TezosGetAddress extends AbstractMethod<'tezosGetAddress', P
         }
     }
 
-    async confirmation() {
-        if (this.confirmed) return true;
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'export-address',
-                label: this.info,
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        this.confirmed = uiResp.payload;
-
-        return this.confirmed;
+    get confirmation() {
+        return {
+            view: 'export-address' as const,
+            label: this.info,
+        };
     }
 
     async _call({ address_n, show_display, chunkify }: Params) {

--- a/packages/connect/src/api/tezos/api/tezosGetPublicKey.ts
+++ b/packages/connect/src/api/tezos/api/tezosGetPublicKey.ts
@@ -14,7 +14,6 @@ export default class TezosGetPublicKey extends AbstractMethod<
     PROTO.TezosGetPublicKey[]
 > {
     hasBundle?: boolean;
-    confirmed?: boolean;
 
     init() {
         this.requiredPermissions = ['read'];
@@ -48,36 +47,16 @@ export default class TezosGetPublicKey extends AbstractMethod<
         return 'Export Tezos public key';
     }
 
-    async confirmation() {
-        if (this.confirmed) return true;
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        let label: string;
-        if (this.params.length > 1) {
-            label = 'Export multiple Tezos public keys';
-        } else {
-            label = `Export Tezos public key for account #${
-                fromHardened(this.params[0].address_n[2]) + 1
-            }`;
-        }
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'export-address',
-                label,
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        this.confirmed = uiResp.payload;
-
-        return this.confirmed;
+    get confirmation() {
+        return {
+            view: 'export-address' as const,
+            label:
+                this.params.length > 1
+                    ? 'Export multiple Tezos public keys'
+                    : `Export Tezos public key for account #${
+                          fromHardened(this.params[0].address_n[2]) + 1
+                      }`,
+        };
     }
 
     async run() {

--- a/packages/connect/src/api/wipeDevice.ts
+++ b/packages/connect/src/api/wipeDevice.ts
@@ -1,12 +1,10 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/WipeDevice.js
 
 import { AbstractMethod } from '../core/AbstractMethod';
-import { UI, createUiMessage, DEVICE } from '../events';
+import { UI, DEVICE } from '../events';
 import { getFirmwareRange } from './common/paramsValidator';
 
 export default class WipeDevice extends AbstractMethod<'wipeDevice'> {
-    confirmed?: boolean;
-
     init() {
         this.allowDeviceMode = [UI.INITIALIZE, UI.SEEDLESS, UI.BOOTLOADER];
         this.useDeviceState = false;
@@ -14,31 +12,15 @@ export default class WipeDevice extends AbstractMethod<'wipeDevice'> {
         this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
     }
 
-    async confirmation() {
-        if (this.confirmed) return true;
-        // wait for popup window
-        await this.getPopupPromise().promise;
-        // initialize user response promise
-        const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-
-        // request confirmation view
-        this.postMessage(
-            createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'device-management',
-                customConfirmButton: {
-                    className: 'wipe',
-                    label: `Wipe ${this.device.toMessageObject().label}`,
-                },
-                label: 'Are you sure you want to wipe your device?',
-            }),
-        );
-
-        // wait for user action
-        const uiResp = await uiPromise.promise;
-
-        this.confirmed = uiResp.payload;
-
-        return this.confirmed;
+    get confirmation() {
+        return {
+            view: 'device-management' as const,
+            customConfirmButton: {
+                className: 'wipe',
+                label: `Wipe ${this.device.toMessageObject().label}`,
+            },
+            label: 'Are you sure you want to wipe your device?',
+        };
     }
 
     get info() {

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -13,6 +13,7 @@ import {
     UiRequestButtonData,
     UiPromiseCreator,
     CoreEventMessage,
+    UiRequestConfirmation,
 } from '../events';
 import { getHost } from '../utils/urlUtils';
 import type { Device } from '../device/Device';
@@ -60,6 +61,10 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
         return '';
     } // method info, displayed in popup info-panel
 
+    get confirmation(): UiRequestConfirmation['payload'] | undefined {
+        return undefined;
+    }
+
     useUi: boolean; // should use popup?
 
     useDevice: boolean; // use device
@@ -83,8 +88,6 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
     network: NETWORK.NetworkType;
 
     useCardanoDerivation: boolean;
-
-    confirmation?(): Promise<boolean | undefined>;
 
     noBackupConfirmationMode: 'never' | 'always' | 'popup-only';
 

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -2,7 +2,7 @@ import { storage } from '@trezor/connect-common';
 import { versionUtils } from '@trezor/utils';
 import { Deferred } from '@trezor/utils';
 import { DataManager } from '../data/DataManager';
-import { ERRORS, NETWORK } from '../constants';
+import { NETWORK } from '../constants';
 import {
     UI,
     DEVICE,
@@ -252,7 +252,7 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
         }
     }
 
-    async checkFirmwareRange(isUsingPopup?: boolean) {
+    checkFirmwareRange() {
         if (this.skipFirmwareCheck) {
             return;
         }
@@ -282,23 +282,7 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
         }
 
         if (range.max !== '0' && versionUtils.isNewer(version, range.max)) {
-            if (isUsingPopup) {
-                // wait for popup handshake
-                await this.getPopupPromise().promise;
-                // initialize user response promise
-                const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION);
-                // show unexpected state information and wait for confirmation
-                this.postMessage(
-                    createUiMessage(UI.FIRMWARE_NOT_COMPATIBLE, device.toMessageObject()),
-                );
-
-                const uiResp = await uiPromise.promise;
-                if (!uiResp.payload) {
-                    throw ERRORS.TypedError('Method_PermissionsNotGranted');
-                }
-            } else {
-                return UI.FIRMWARE_NOT_COMPATIBLE;
-            }
+            return UI.FIRMWARE_NOT_COMPATIBLE;
         }
     }
 

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -86,7 +86,7 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
 
     confirmation?(): Promise<boolean | undefined>;
 
-    noBackupConfirmation?(allowSuppression?: boolean): Promise<boolean>;
+    noBackupConfirmationMode: 'never' | 'always' | 'popup-only';
 
     getButtonRequestData?(code: string): UiRequestButtonData | undefined;
 
@@ -148,6 +148,7 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
             typeof payload.useCardanoDerivation === 'boolean'
                 ? payload.useCardanoDerivation
                 : payload.method.startsWith('cardano');
+        this.noBackupConfirmationMode = 'never';
     }
 
     setDevice(device: Device) {

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -8,7 +8,7 @@ import { storage } from '@trezor/connect-common';
 
 import { DataManager } from '../data/DataManager';
 import { DeviceList } from '../device/DeviceList';
-import { enhancePostMessageWithAnalytics } from '../data/analyticsInfo';
+import { enhanceMessageWithAnalytics } from '../data/analyticsInfo';
 import { ERRORS } from '../constants';
 import {
     CORE_EVENT,
@@ -342,9 +342,12 @@ const inner = async (method: AbstractMethod<any>, device: Device) => {
 
             // request confirmation view
             postMessage(
-                createUiMessage(UI.REQUEST_CONFIRMATION, {
-                    view: 'no-backup',
-                }),
+                enhanceMessageWithAnalytics(
+                    createUiMessage(UI.REQUEST_CONFIRMATION, {
+                        view: 'no-backup',
+                    }),
+                    { device: device.toMessageObject() },
+                ),
             );
 
             // wait for user action
@@ -380,7 +383,12 @@ const inner = async (method: AbstractMethod<any>, device: Device) => {
             const uiPromise = uiPromises.create(UI.RECEIVE_CONFIRMATION, device);
 
             // request confirmation view
-            postMessage(createUiMessage(UI.REQUEST_CONFIRMATION, requestConfirmation));
+            postMessage(
+                enhanceMessageWithAnalytics(
+                    createUiMessage(UI.REQUEST_CONFIRMATION, requestConfirmation),
+                    { device: device.toMessageObject() },
+                ),
+            );
 
             // wait for user action
             const confirmed = await uiPromise.promise.then(({ payload }) => payload);
@@ -574,9 +582,6 @@ const onCall = async (message: IFrameCallMessage) => {
         postMessage(createResponseMessage(responseID, false, { error }));
         throw error;
     }
-
-    method.postMessage = (message: CoreEventMessage) =>
-        enhancePostMessageWithAnalytics(postMessage, message, { device: device.toMessageObject() });
 
     method.setDevice(device);
 

--- a/packages/connect/src/data/analyticsInfo.ts
+++ b/packages/connect/src/data/analyticsInfo.ts
@@ -6,16 +6,15 @@ import type { Device } from '../types';
 // There I can freely import from anyplace within monorepo without needing
 // to release new packages. Having it here means that I would need to
 // release 2 new packages to npm which is unjustifiable burden
-export const enhancePostMessageWithAnalytics = (
-    callback: (message: CoreEventMessage) => void,
+export const enhanceMessageWithAnalytics = (
     message: CoreEventMessage,
     data: { device?: Device },
-) => {
+): CoreEventMessage => {
     switch (message.type) {
         case UI_REQUEST.REQUEST_CONFIRMATION:
             const { device } = data;
 
-            callback({
+            return {
                 ...message,
                 // @ts-expect-error (EventType.DeviceSelected is inlined here)
                 payload: {
@@ -44,10 +43,9 @@ export const enhancePostMessageWithAnalytics = (
                         },
                     },
                 },
-            });
-            break;
+            };
 
         default:
-            callback(message);
+            return message;
     }
 };

--- a/packages/connect/src/utils/popupPromiseManager.ts
+++ b/packages/connect/src/utils/popupPromiseManager.ts
@@ -1,0 +1,24 @@
+import { Deferred, createDeferred } from '@trezor/utils';
+
+export const createPopupPromiseManager = () => {
+    let _popupPromise: Deferred<void> | undefined; // Waiting for popup handshake
+
+    const ensure = () => _popupPromise ?? (_popupPromise = createDeferred());
+
+    const wait = () => ensure().promise;
+
+    const resolve = () => ensure().resolve();
+
+    const isWaiting = () => !!_popupPromise;
+
+    const reject = (error: Error) => {
+        _popupPromise?.reject(error);
+        _popupPromise = undefined;
+    };
+
+    const clear = () => {
+        _popupPromise = undefined;
+    };
+
+    return { wait, isWaiting, clear, resolve, reject };
+};

--- a/packages/connect/src/utils/uiPromiseManager.ts
+++ b/packages/connect/src/utils/uiPromiseManager.ts
@@ -1,0 +1,62 @@
+import { DEVICE, UiPromise, AnyUiPromise, UiPromiseCreator, UiPromiseResponse } from '../events';
+import { createDeferred, arrayPartition } from '@trezor/utils';
+
+export const createUiPromiseManager = (interactionTimeout: () => void) => {
+    let _uiPromises: AnyUiPromise[] = [];
+
+    const exists = (type: UiPromiseResponse['type']) => _uiPromises.some(p => p.id === type);
+
+    // Creates an instance of uiPromise.
+    const create: UiPromiseCreator = (promiseEvent, device) => {
+        const uiPromise: UiPromise<typeof promiseEvent> = {
+            ...createDeferred(promiseEvent),
+            device,
+        };
+        _uiPromises.push(uiPromise as unknown as AnyUiPromise);
+
+        // Interaction timeout
+        interactionTimeout();
+
+        return uiPromise;
+    };
+
+    const resolve = (event: UiPromiseResponse) => {
+        const uiPromise = _uiPromises.find(p => p.id === event.type) as
+            | UiPromise<typeof event.type>
+            | undefined;
+        if (!uiPromise) return false;
+        uiPromise.resolve(event);
+        _uiPromises = _uiPromises.filter(p => p !== uiPromise);
+
+        return true;
+    };
+
+    const rejectAll = (error: Error) => {
+        _uiPromises.forEach(p => p.reject(error));
+        _uiPromises = [];
+    };
+
+    const disconnected = (devicePath: string) => {
+        const [toResolve, toKeep] = arrayPartition(
+            _uiPromises,
+            (p): p is UiPromise<typeof DEVICE.DISCONNECT> =>
+                p.device?.getDevicePath() === devicePath && p.id === DEVICE.DISCONNECT,
+        );
+        toResolve.forEach(p => p.resolve({ type: DEVICE.DISCONNECT }));
+        _uiPromises = toKeep;
+
+        return !!toResolve.length || toKeep.some(p => p.device?.getDevicePath() === devicePath);
+    };
+
+    const get = <T extends UiPromiseResponse['type']>(type: T) => {
+        const uiPromise = _uiPromises.find(p => p.id === type) as UiPromise<T> | undefined;
+
+        return uiPromise?.promise ?? Promise.reject(new Error(`UiPromise ${type} doesn't exist`));
+    };
+
+    const clear = () => {
+        _uiPromises = [];
+    };
+
+    return { exists, create, resolve, rejectAll, disconnected, get, clear };
+};


### PR DESCRIPTION
## Description

Second part of cleaning of the dusty Connect Core (followup of #10363). The main goal is to linearize the logic in Connect core (e.g. flatten the recursion and nested calls), and move there most of the communication logic from Connect methods (which also removes a lot of repeated code as a byproduct).

## Commits

- https://github.com/trezor/trezor-suite/pull/10391/commits/0776e5043307dadd9d58cfbb2d619ba843f01104 - factor out UI promises from core to separate `uiPromisesManager`; everything should stay the same
- https://github.com/trezor/trezor-suite/pull/10391/commits/01cdfd930d6c7112aeccafc1a2294e1b1613a6cf - move `inner` function outside `onCall` function and pass the closured variables as params
- https://github.com/trezor/trezor-suite/pull/10391/commits/7fb374da2a4f7b1496bc41e7d8e702804ab661b4 - remove one case of `inner` function recursion (wrong pin loop) by repeating only `device.validateState()` instead of the whole `inner` fn
- https://github.com/trezor/trezor-suite/pull/10391/commits/4d14af49ce4a6ef08cfd3b369843455001480780 - remove repeated `noBackupConfirmation` fn from Connect methods and replace it by `noBackupConfirmationMode` enum; move the asynchronous logic (based on `noBackupConfirmationMode`) to core
- https://github.com/trezor/trezor-suite/pull/10391/commits/30ebb3012af86535d554f421dad20623c0b4d026 - move asynchronous logic from `checkFirmwareRange` fn to core, therefore make the Connect methods independent on `isUsingPopup`
- https://github.com/trezor/trezor-suite/pull/10391/commits/16dc9fd0eb21f8f355418997e30be5af8e6419c8 - remove second case of `inner` function recursion (incorrect passphrase), so `inner` doesn't have to be recursive anymore
- https://github.com/trezor/trezor-suite/pull/10391/commits/42c27d8340dee0274c29db8a0c6e0fd03d4e400d - Connect method's `confirmation` fn now returns only confirmation data; the rest of the process was moved to core
- https://github.com/trezor/trezor-suite/pull/10391/commits/1e90f69d4513e3933bbdb8e6fb59527087e808b7 - `requestPermissions` fn moved to core, so there's no need for `getPopupPromise` in Connect methods
- https://github.com/trezor/trezor-suite/pull/10391/commits/70b9f3f8a1b31a903c0173c0affc608dd1ac4f8f - improve `enhancePostMessageWithAnalytics` so method's `postMessage` doesn't have to be enhanced and reassigned
- https://github.com/trezor/trezor-suite/pull/10391/commits/9928f8d6aea1c4a72aaf8f04ab813bb38d41787b - factor out popup promise from core to separate `popupPromiseManager`; everything should stay the same
- https://github.com/trezor/trezor-suite/pull/10391/commits/2eb29360ab97a8ca7b3799f63161625ab1f6a62f - e2e test adjustments; Connect now doesn't ask for permissions again when another passphrase is tried
