### PR TITLE
fix(device-utils): fix firmware version array util

### DIFF
--- a/packages/device-utils/src/firmwareUtils.ts
+++ b/packages/device-utils/src/firmwareUtils.ts
@@ -11,7 +11,7 @@ export const getFirmwareVersionArray = (device?: Device): VersionArray | null =>
     const { features } = device;
 
     if (isDeviceInBootloaderMode(device)) {
-        return features.fw_major && features.fw_minor && features.fw_patch
+        return features.fw_major
             ? ([features.fw_major, features.fw_minor, features.fw_patch] as VersionArray)
             : null;
     }


### PR DESCRIPTION
## Description

- on fw versions having minor or patch version equal to 0, it would return null
- major version will never be 0 so we are safe