### PR TITLE
Make TS3 wipeable again!

### DIFF
--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -255,7 +255,9 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
             return;
         }
         const { device } = this;
-        if (!device.features) return;
+
+        // do not do fw range check for devices in BL mode as fw version of T1B1 in BL mode is not defined
+        if (!device.features || device.isBootloader()) return;
         const range = this.firmwareRange[device.features.internal_model];
 
         if (device.firmwareStatus === 'none') {


### PR DESCRIPTION
## Description

- we dont know fw version of `T1B1` in bootloader mode so we cant fix `getVersion()` in `Device.ts` properly
=> disable check firmware range for bootloader mode for all device to have it unified

## Related Issue

closes #10245

## Screenshots:
![image](https://github.com/trezor/trezor-suite/assets/33235762/12c82603-9784-4f3d-b42c-d67f521b1dfc)