### PR TITLE
fix(suite): labels too big

### DIFF
--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
@@ -102,6 +102,7 @@ const RelativeButton = styled(Button)`
     padding-bottom: 4px;
     padding-top: 4px;
     position: relative;
+    overflow: hidden;
 `;
 
 const RelativeLabel = styled(Label)<{ isVisible?: boolean }>`

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/withEditable.tsx
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/withEditable.tsx
@@ -51,6 +51,9 @@ const Editable = styled.div<{ value?: string; isButton?: boolean; touched: boole
         `}
 
     color: ${({ touched, theme }) => (!touched ? theme.TYPE_LIGHT_GREY : 'inherit')};
+
+    overflow: hidden;
+    justify-content: start;
 `;
 
 interface WithEditableProps {

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Address/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Address/index.tsx
@@ -35,6 +35,10 @@ const StyledIcon = styled(Icon)`
     display: flex;
 `;
 
+const MetadataLabelingWrapper = styled.div`
+    max-width: 200px;
+`;
+
 interface AddressProps {
     outputId: number;
     outputsCount: number;
@@ -206,24 +210,26 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
             isMonospace
             innerAddon={
                 metadataEnabled && broadcastEnabled ? (
-                    <MetadataLabeling
-                        defaultVisibleValue=""
-                        payload={{
-                            type: 'outputLabel',
-                            entityKey: account.key,
-                            // txid is not known at this moment. metadata is only saved
-                            // along with other sendForm data and processed in sendFormActions
-                            txid: 'will-be-replaced',
-                            outputIndex: outputId,
-                            defaultValue: `${outputId}`,
-                            value: label,
-                        }}
-                        onSubmit={(value: string | undefined) => {
-                            setValue(`outputs.${outputId}.label`, value || '');
-                            setDraftSaveRequest(true);
-                        }}
-                        visible
-                    />
+                    <MetadataLabelingWrapper>
+                        <MetadataLabeling
+                            defaultVisibleValue=""
+                            payload={{
+                                type: 'outputLabel',
+                                entityKey: account.key,
+                                // txid is not known at this moment. metadata is only saved
+                                // along with other sendForm data and processed in sendFormActions
+                                txid: 'will-be-replaced',
+                                outputIndex: outputId,
+                                defaultValue: `${outputId}`,
+                                value: label,
+                            }}
+                            onSubmit={(value: string | undefined) => {
+                                setValue(`outputs.${outputId}.label`, value || '');
+                                setDraftSaveRequest(true);
+                            }}
+                            visible
+                        />
+                    </MetadataLabelingWrapper>
                 ) : undefined
             }
             label={


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes the overflowing labels. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/4744

## Screenshots:

![image](https://github.com/trezor/trezor-suite/assets/152899911/f03e2a9d-d5f1-48c9-9898-46f0aa3b1a12)
![image](https://github.com/trezor/trezor-suite/assets/152899911/401a001f-c672-4373-85e5-c97cc0f08de2)

![image](https://github.com/trezor/trezor-suite/assets/152899911/22e8819f-d973-4183-b044-b6e6e4dab04c)

![image](https://github.com/trezor/trezor-suite/assets/152899911/bdad00ed-3457-4d29-8e4c-cd44c4f7daac)

