### PR TITLE
Support Electrum backends without json-rpc batching

### DIFF
--- a/packages/blockchain-link/src/workers/electrum/client/batching.ts
+++ b/packages/blockchain-link/src/workers/electrum/client/batching.ts
@@ -16,6 +16,8 @@ export class BatchingJsonRpcClient extends JsonRpcClient {
     private timeoutMs: number;
     private maxQueueLength: number;
 
+    protected batchingDisabled = false;
+
     constructor(options?: Options) {
         super();
         this.timeoutMs = options?.timeoutMs || TIMEOUT_MS;
@@ -23,6 +25,10 @@ export class BatchingJsonRpcClient extends JsonRpcClient {
     }
 
     protected send(message: string) {
+        if (this.batchingDisabled) {
+            super.send(message);
+            return;
+        }
         const { queue } = this;
         queue.push(message);
         if (this.batchTimer) clearTimeout(this.batchTimer);

--- a/packages/blockchain-link/src/workers/electrum/client/electrum.ts
+++ b/packages/blockchain-link/src/workers/electrum/client/electrum.ts
@@ -49,6 +49,14 @@ export class ElectrumClient extends BatchingJsonRpcClient implements ElectrumAPI
                 name,
                 protocolVersion,
             );
+            // Simplified version of BlueWallet's heuristics. Might be improved later.
+            // https://github.com/BlueWallet/BlueWallet/blob/509add5c59a4f84e0f49b4d3891ed5a650e2adb2/blue_modules/BlueElectrum.js#L146
+            if (
+                this.version[0]?.startsWith('ElectrumPersonalServer') ||
+                this.version[0]?.startsWith('electrs-esplora')
+            ) {
+                this.batchingDisabled = true;
+            }
             (this as ElectrumAPI).on('blockchain.headers.subscribe', this.onBlock.bind(this));
             this.lastBlock = await (this as ElectrumAPI).request('blockchain.headers.subscribe');
         } catch (err) {


### PR DESCRIPTION
## Description

Turn off json-rpc batching for non-supportive Electrum implementations (`electrs-esplora` and `ElectrumPersonalServer`). Haven't tested for EPS, but seems to be working well for Esplora and is kinda uncontroversial.

## Related Issue

Should resolve #10387
