### PR TITLE
Fix/solana token issues

### DIFF
--- a/packages/blockchain-link-types/src/solana.ts
+++ b/packages/blockchain-link-types/src/solana.ts
@@ -6,6 +6,12 @@ export type SolanaValidParsedTxWithMeta = ParsedTransactionWithMeta & {
     blockTime: Required<NonNullable<ParsedTransactionWithMeta['blockTime']>>;
 };
 
+export type SolanaTokenAccountInfo = {
+    address: string;
+    mint: string | undefined;
+    decimals: number | undefined;
+};
+
 export type {
     ParsedInstruction,
     ParsedTransactionWithMeta,

--- a/packages/blockchain-link-utils/src/solana.ts
+++ b/packages/blockchain-link-utils/src/solana.ts
@@ -30,12 +30,19 @@ export const WSOL_MINT = 'So11111111111111111111111111111111111111112';
 
 // https://github.com/viaprotocol/tokenlists
 // Aggregated token list with tokens listed on multiple exchanges
-const solanaTokenListUrl =
+const SOLANA_TOKEN_LIST_URL =
     'https://cdn.jsdelivr.net/gh/viaprotocol/tokenlists/all_tokens/solana.json';
+
+const LOCAL_TOKEN_METADATA: TokenDetailByMint = {
+    DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263: {
+        name: 'Bonk',
+        symbol: 'BONK',
+    },
+};
 
 export const getTokenMetadata = async (): Promise<TokenDetailByMint> => {
     const tokenListResult: { address: string; name: string; symbol: string }[] = await (
-        await fetch(solanaTokenListUrl)
+        await fetch(SOLANA_TOKEN_LIST_URL)
     ).json();
 
     const tokenMap = tokenListResult.reduce(
@@ -52,7 +59,7 @@ export const getTokenMetadata = async (): Promise<TokenDetailByMint> => {
     // Explicitly set Wrapped SOL symbol to WSOL instead of the official 'SOL' which leads to confusion in UI
     tokenMap[WSOL_MINT].symbol = 'WSOL';
 
-    return tokenMap;
+    return { ...LOCAL_TOKEN_METADATA, ...tokenMap };
 };
 
 export const getTokenNameAndSymbol = (mint: string, tokenDetailByMint: TokenDetailByMint) => {

--- a/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
+++ b/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
@@ -52,6 +52,19 @@ const instructions = {
         },
         program: 'spl-token',
     },
+    // without mint and tokenAmount
+    tokenTransferToAssociated: {
+        parsed: {
+            info: {
+                amount: '1534951700',
+                authority: '5oPm4YqwfGceRoyAYJUZ3FqLb5KvhkLFTzRv92gXzCtz',
+                destination: 'CoWky2oRf1LEENrV7WsFFzFgrbs14y5PibvtetdfTvXg',
+                source: 'DaL2xPLQQ2rxHyqQxaE9E44Boa5bRpnfAZt9HaRMr9RY',
+            },
+            type: 'transfer',
+        },
+        program: 'spl-token',
+    },
 };
 
 const parsedTransactions = {
@@ -169,6 +182,24 @@ const parsedTransactions = {
                         { pubkey: { toString: () => 'address2' } },
                     ],
                     instructions: [instructions.tokenTransfer, instructions.secondTokenTransfer],
+                },
+            },
+            version: 'legacy',
+            blockTime: 1631753600,
+            slot: 5,
+        },
+    },
+    tokenTransferToAssociated: {
+        transaction: {
+            meta: {},
+            transaction: {
+                signatures: ['txid1'],
+                message: {
+                    accountKeys: [
+                        { pubkey: { toString: () => 'address1' } },
+                        { pubkey: { toString: () => 'address2' } },
+                    ],
+                    instructions: [instructions.tokenTransferToAssociated],
                 },
             },
             version: 'legacy',
@@ -626,15 +657,45 @@ export const fixtures = {
                 transaction: parsedTransactions.basic.transaction,
                 accountAddress: 'someAddress',
                 map: sampleMintToDetailMap,
+                tokenAccountsInfos: [],
             },
             expectedOutput: [],
         },
         {
             description: 'parses a single token transfer',
             input: {
+                transaction: parsedTransactions.tokenTransferToAssociated.transaction,
+                accountAddress: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF',
+                map: sampleMintToDetailMap,
+                tokenAccountsInfos: [
+                    {
+                        address: 'CoWky2oRf1LEENrV7WsFFzFgrbs14y5PibvtetdfTvXg',
+                        mint: 'So11111111111111111111111111111111111115555',
+                        decimals: 1,
+                    },
+                ],
+            },
+            expectedOutput: [
+                {
+                    type: 'recv',
+                    standard: 'SPL',
+                    from: '5oPm4YqwfGceRoyAYJUZ3FqLb5KvhkLFTzRv92gXzCtz',
+                    to: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF',
+                    contract: 'So11111111111111111111111111111111111115555',
+                    decimals: 1,
+                    name: 'So11111111111111111111111111111111111115555',
+                    symbol: 'So1...',
+                    amount: '1534951700',
+                },
+            ],
+        },
+        {
+            description: 'parses a token transfer to associated token account',
+            input: {
                 transaction: parsedTransactions.singleTokenTransfer.transaction,
                 accountAddress: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF',
                 map: sampleMintToDetailMap,
+                tokenAccountsInfos: [],
             },
             expectedOutput: [
                 {
@@ -656,6 +717,7 @@ export const fixtures = {
                 transaction: parsedTransactions.multiTokenTransfer.transaction,
                 accountAddress: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF',
                 map: sampleMintToDetailMap,
+                tokenAccountsInfos: [],
             },
             expectedOutput: [
                 {
@@ -689,6 +751,7 @@ export const fixtures = {
             input: {
                 transaction: parsedTransactions.basic.transaction,
                 accountAddress: effects.negative.address,
+                tokenAccountsInfos: [],
             },
             expectedOutput: {
                 type: 'sent',

--- a/packages/blockchain-link-utils/src/tests/solana.test.ts
+++ b/packages/blockchain-link-utils/src/tests/solana.test.ts
@@ -107,6 +107,7 @@ describe('solana/utils', () => {
                     input.transaction as ParsedTransactionWithMeta,
                     input.accountAddress,
                     input.map,
+                    input.tokenAccountsInfos,
                 );
                 expect(result).toEqual(expectedOutput);
             });
@@ -119,6 +120,7 @@ describe('solana/utils', () => {
                 const result = await transformTransaction(
                     input.transaction as SolanaValidParsedTxWithMeta,
                     input.accountAddress,
+                    input.tokenAccountsInfos,
                 );
                 expect(result).toEqual(expectedOutput);
             });

--- a/packages/connect/src/api/getAccountInfo.ts
+++ b/packages/connect/src/api/getAccountInfo.ts
@@ -243,22 +243,35 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
             let legacyXpub: string | undefined;
 
             if (this.disposed) break;
-
+            console.log(request);
             // get descriptor from device
             if (address_n && typeof descriptor !== 'string') {
                 try {
-                    const accountDescriptor = await this.device
-                        .getCommands()
-                        .getAccountDescriptor(
-                            request.coinInfo,
+                    if (
+                        (request.coin === 'sol' || request.coin === 'dsol') &&
+                        request.path?.endsWith("0'/0'")
+                    ) {
+                        const accountDescriptor = {
+                            descriptor: '3FcwHQtEXRsNj6Mw5A4T242kSNsS7Xw8Jh7zZf83AiXv',
                             address_n,
-                            typeof request.derivationType !== 'undefined'
-                                ? request.derivationType
-                                : PROTO.CardanoDerivationType.ICARUS_TREZOR,
-                        );
-                    if (accountDescriptor) {
+                            legacyXpub: undefined,
+                        };
                         descriptor = accountDescriptor.descriptor;
                         legacyXpub = accountDescriptor.legacyXpub;
+                    } else {
+                        const accountDescriptor = await this.device
+                            .getCommands()
+                            .getAccountDescriptor(
+                                request.coinInfo,
+                                address_n,
+                                typeof request.derivationType !== 'undefined'
+                                    ? request.derivationType
+                                    : PROTO.CardanoDerivationType.ICARUS_TREZOR,
+                            );
+                        if (accountDescriptor) {
+                            descriptor = accountDescriptor.descriptor;
+                            legacyXpub = accountDescriptor.legacyXpub;
+                        }
                     }
                 } catch (error) {
                     if (this.hasBundle) {


### PR DESCRIPTION
Fix the issue some users are facing, supposedly after sending tokens to their wallets.

 - actual fix, I was able to reproduce, you can too, since I left the commit that mocks non-working account. **Dont forget to drop it before merge**
 - issue seems to be related to missing `mint` field indeed, probably in relation to sending to associated token account instead of normal one

Changes: 
 - typeguard token accounts, filter out invalid ones.
 - add metadata for BONK token
 - give tokenAccounts context to tx parsing so we can get mint and decimals also for instructions that do not have it
 
 Feel free to cherry pick what makes sense to you.

