### PR TITLE
fix(suite-native): account type labels

### DIFF
--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -518,15 +518,11 @@ type Networks = typeof networks;
 export type NetworkSymbol = keyof Networks;
 export type NetworkType = Network['networkType'];
 type NetworkValue = Networks[NetworkSymbol];
-export type AccountType =
-    | Keys<NetworkValue['accountTypes']>
-    | 'imported'
-    | 'taproot'
-    | 'legacySegwit';
+export type AccountType = Keys<NetworkValue['accountTypes']> | 'imported' | 'taproot' | 'normal';
 export type NetworkFeature = 'rbf' | 'sign-verify' | 'amount-unit' | 'tokens' | 'staking';
 export type Network = Without<NetworkValue, 'accountTypes'> & {
     symbol: NetworkSymbol;
-    accountType?: 'normal' | AccountType;
+    accountType?: AccountType;
     backendType?: BackendType;
     testnet?: boolean;
     isHidden?: boolean;

--- a/suite-common/wallet-core/src/accounts/constants.ts
+++ b/suite-common/wallet-core/src/accounts/constants.ts
@@ -3,9 +3,8 @@ import { AccountType } from '@suite-common/wallet-types';
 export const actionPrefix = '@common/wallet-core/accounts';
 
 export const formattedAccountTypeMap: Partial<Record<AccountType, string>> = {
-    legacy: 'Legacy',
-    legacySegwit: 'Legacy SegWit',
-    segwit: 'SegWit',
+    normal: 'SegWit', // represents the default Suite account type (`SegWit Native` at the moment).
     taproot: 'Taproot',
-    normal: 'SegWit Native',
+    segwit: 'Legacy SegWit',
+    legacy: 'Legacy',
 };

--- a/suite-native/module-accounts-import/src/constants.ts
+++ b/suite-native/module-accounts-import/src/constants.ts
@@ -1,8 +1,8 @@
 import { AccountType } from '@suite-common/wallet-config';
 
 export const paymentTypeToAccountType: Record<string, AccountType> = {
+    p2wpkh: 'normal', // `p2wpkh` (SegWit Native) is mapped to `normal`, because it is currently the default account type of Suite.
     p2pkh: 'legacy',
-    p2sh: 'legacySegwit',
-    p2wpkh: 'segwit',
+    p2sh: 'segwit',
     p2tr: 'taproot',
 };


### PR DESCRIPTION

## Description
- discovered accounts display the correct account type (segwit, legacy segwit, taproot etc.)
- account type labels unified for portfolio tracker imported accounts and device discovered accounts

## Related Issue

Resolve #10354 
