### PR TITLE
fix(mobile): fix animation related crashes

### DIFF
--- a/suite-common/icons/package.json
+++ b/suite-common/icons/package.json
@@ -18,7 +18,7 @@
         "@trezor/theme": "workspace:*",
         "react": "18.2.0",
         "react-native": "0.71.8",
-        "react-native-reanimated": "3.6.1"
+        "react-native-reanimated": "3.7.0-nightly-20240101-9d365ae7b"
     },
     "devDependencies": {
         "jest": "29.5.0",

--- a/suite-native/accounts/package.json
+++ b/suite-native/accounts/package.json
@@ -34,7 +34,7 @@
         "proxy-memoize": "2.0.2",
         "react": "18.2.0",
         "react-native": "0.71.8",
-        "react-native-reanimated": "3.6.1",
+        "react-native-reanimated": "3.7.0-nightly-20240101-9d365ae7b",
         "react-redux": "8.0.7"
     },
     "devDependencies": {

--- a/suite-native/alerts/package.json
+++ b/suite-native/alerts/package.json
@@ -16,6 +16,6 @@
         "jotai": "1.9.1",
         "react": "18.2.0",
         "react-native": "0.71.8",
-        "react-native-reanimated": "3.6.1"
+        "react-native-reanimated": "3.7.0-nightly-20240101-9d365ae7b"
     }
 }

--- a/suite-native/app/ios/Podfile.lock
+++ b/suite-native/app/ios/Podfile.lock
@@ -517,7 +517,7 @@ PODS:
     - React-Core
   - RNGestureHandler (2.9.0):
     - React-Core
-  - RNReanimated (3.6.1):
+  - RNReanimated (3.7.0-nightly-20240101-9d365ae7b):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
     - ReactCommon/turbomodule/core
@@ -894,7 +894,7 @@ SPEC CHECKSUMS:
   ReactNativeUsb: 9a142098b76ab35afa7bb979d40e7f68ac482193
   RNFlashList: ade81b4e928ebd585dd492014d40fb8d0e848aab
   RNGestureHandler: 071d7a9ad81e8b83fe7663b303d132406a7d8f39
-  RNReanimated: 79f572a7903c60f5aa86cf1698049ab5f75ececd
+  RNReanimated: eabcc13f3292013ec2712b9662f8c0d001a0d8bf
   RNScreens: ea4cd3a853063cda19a4e3c28d2e52180c80f4eb
   RNSentry: 4fb2cd7d2d6cb94423c24884488206ef881da136
   RNSVG: c1e76b81c76cdcd34b4e1188852892dc280eb902
@@ -911,4 +911,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: d37876aaf00e7f8309b694188119b139b8452ca1
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.11.3

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -102,7 +102,7 @@
         "react-native-flipper": "0.164.0",
         "react-native-gesture-handler": "^2.9.0",
         "react-native-mmkv": "2.11.0",
-        "react-native-reanimated": "3.6.1",
+        "react-native-reanimated": "3.7.0-nightly-20240101-9d365ae7b",
         "react-native-restart": "^0.0.27",
         "react-native-safe-area-context": "^4.5.0",
         "react-native-screens": "^3.19.0",

--- a/suite-native/assets/package.json
+++ b/suite-native/assets/package.json
@@ -33,7 +33,7 @@
         "proxy-memoize": "2.0.2",
         "react": "^18.2.0",
         "react-native": "0.71.8",
-        "react-native-reanimated": "3.6.1",
+        "react-native-reanimated": "3.7.0-nightly-20240101-9d365ae7b",
         "react-redux": "8.0.7"
     },
     "devDependencies": {

--- a/suite-native/atoms/package.json
+++ b/suite-native/atoms/package.json
@@ -26,7 +26,7 @@
         "react": "18.2.0",
         "react-native": "0.71.8",
         "react-native-gesture-handler": "^2.9.0",
-        "react-native-reanimated": "3.6.1",
+        "react-native-reanimated": "3.7.0-nightly-20240101-9d365ae7b",
         "react-native-root-toast": "^3.3.1",
         "react-native-safe-area-context": "^4.5.0",
         "react-redux": "8.0.7"

--- a/suite-native/device-manager/package.json
+++ b/suite-native/device-manager/package.json
@@ -30,7 +30,7 @@
         "jotai": "1.9.1",
         "react": "^18.2.0",
         "react-native": "0.71.8",
-        "react-native-reanimated": "3.6.1",
+        "react-native-reanimated": "3.7.0-nightly-20240101-9d365ae7b",
         "react-native-safe-area-context": "^4.5.0",
         "react-redux": "8.0.7"
     }

--- a/suite-native/graph/package.json
+++ b/suite-native/graph/package.json
@@ -37,7 +37,7 @@
         "react": "18.2.0",
         "react-intl": "^6.5.1",
         "react-native": "0.71.8",
-        "react-native-reanimated": "3.6.1",
+        "react-native-reanimated": "3.7.0-nightly-20240101-9d365ae7b",
         "react-redux": "8.0.7"
     },
     "devDependencies": {

--- a/suite-native/link/package.json
+++ b/suite-native/link/package.json
@@ -15,6 +15,6 @@
         "@trezor/theme": "workspace:*",
         "react": "18.2.0",
         "react-native": "0.71.8",
-        "react-native-reanimated": "3.6.1"
+        "react-native-reanimated": "3.7.0-nightly-20240101-9d365ae7b"
     }
 }

--- a/suite-native/message-system/package.json
+++ b/suite-native/message-system/package.json
@@ -27,7 +27,7 @@
         "proxy-memoize": "2.0.2",
         "react": "18.2.0",
         "react-native": "0.71.8",
-        "react-native-reanimated": "3.6.1",
+        "react-native-reanimated": "3.7.0-nightly-20240101-9d365ae7b",
         "react-native-safe-area-context": "^4.5.0",
         "react-redux": "8.0.7"
     }

--- a/suite-native/module-accounts-import/package.json
+++ b/suite-native/module-accounts-import/package.json
@@ -49,7 +49,7 @@
         "lottie-react-native": "^5.1.5",
         "react": "18.2.0",
         "react-native": "0.71.8",
-        "react-native-reanimated": "3.6.1",
+        "react-native-reanimated": "3.7.0-nightly-20240101-9d365ae7b",
         "react-redux": "8.0.7"
     },
     "devDependencies": {

--- a/suite-native/module-accounts-management/package.json
+++ b/suite-native/module-accounts-management/package.json
@@ -46,7 +46,7 @@
         "react": "18.2.0",
         "react-hook-form": "^7.48.2",
         "react-native": "0.71.8",
-        "react-native-reanimated": "3.6.1",
+        "react-native-reanimated": "3.7.0-nightly-20240101-9d365ae7b",
         "react-redux": "8.0.7"
     }
 }

--- a/suite-native/notifications/package.json
+++ b/suite-native/notifications/package.json
@@ -26,7 +26,7 @@
         "react": "18.2.0",
         "react-native": "0.71.8",
         "react-native-gesture-handler": "^2.9.0",
-        "react-native-reanimated": "3.6.1",
+        "react-native-reanimated": "3.7.0-nightly-20240101-9d365ae7b",
         "react-native-safe-area-context": "^4.5.0",
         "react-redux": "8.0.7"
     }

--- a/suite-native/react-native-graph/package.json
+++ b/suite-native/react-native-graph/package.json
@@ -16,6 +16,6 @@
         "react": "18.2.0",
         "react-native": "0.71.8",
         "react-native-gesture-handler": "^2.9.0",
-        "react-native-reanimated": "3.6.1"
+        "react-native-reanimated": "3.7.0-nightly-20240101-9d365ae7b"
     }
 }

--- a/suite-native/receive/package.json
+++ b/suite-native/receive/package.json
@@ -43,7 +43,7 @@
         "react": "18.2.0",
         "react-native": "0.71.8",
         "react-native-gesture-handler": "^2.9.0",
-        "react-native-reanimated": "3.6.1",
+        "react-native-reanimated": "3.7.0-nightly-20240101-9d365ae7b",
         "react-redux": "8.0.7"
     }
 }

--- a/suite-native/test-utils/package.json
+++ b/suite-native/test-utils/package.json
@@ -15,7 +15,7 @@
         "@trezor/theme": "workspace:*",
         "react": "18.2.0",
         "react-native-gesture-handler": "^2.9.0",
-        "react-native-reanimated": "3.6.1",
+        "react-native-reanimated": "3.7.0-nightly-20240101-9d365ae7b",
         "react-native-safe-area-context": "^4.5.0",
         "react-redux": "8.0.7"
     },

--- a/suite-native/toasts/package.json
+++ b/suite-native/toasts/package.json
@@ -19,7 +19,7 @@
         "jotai": "1.9.1",
         "react": "18.2.0",
         "react-native-gesture-handler": "^2.9.0",
-        "react-native-reanimated": "3.6.1",
+        "react-native-reanimated": "3.7.0-nightly-20240101-9d365ae7b",
         "react-native-safe-area-context": "^4.5.0"
     }
 }

--- a/suite-native/transactions/package.json
+++ b/suite-native/transactions/package.json
@@ -44,7 +44,7 @@
         "react": "18.2.0",
         "react-native": "0.71.8",
         "react-native-gesture-handler": "^2.9.0",
-        "react-native-reanimated": "3.6.1",
+        "react-native-reanimated": "3.7.0-nightly-20240101-9d365ae7b",
         "react-redux": "8.0.7",
         "web3-utils": "^1.10.0"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6677,7 +6677,7 @@ __metadata:
     jest: "npm:29.5.0"
     react: "npm:18.2.0"
     react-native: "npm:0.71.8"
-    react-native-reanimated: "npm:3.6.1"
+    react-native-reanimated: "npm:3.7.0-nightly-20240101-9d365ae7b"
     svgo: "npm:3.0.2"
     tsx: "npm:^4.6.2"
     typescript: "npm:5.3.2"
@@ -7026,7 +7026,7 @@ __metadata:
     proxy-memoize: "npm:2.0.2"
     react: "npm:18.2.0"
     react-native: "npm:0.71.8"
-    react-native-reanimated: "npm:3.6.1"
+    react-native-reanimated: "npm:3.7.0-nightly-20240101-9d365ae7b"
     react-redux: "npm:8.0.7"
   languageName: unknown
   linkType: soft
@@ -7041,7 +7041,7 @@ __metadata:
     jotai: "npm:1.9.1"
     react: "npm:18.2.0"
     react-native: "npm:0.71.8"
-    react-native-reanimated: "npm:3.6.1"
+    react-native-reanimated: "npm:3.7.0-nightly-20240101-9d365ae7b"
   languageName: unknown
   linkType: soft
 
@@ -7089,7 +7089,7 @@ __metadata:
     proxy-memoize: "npm:2.0.2"
     react: "npm:^18.2.0"
     react-native: "npm:0.71.8"
-    react-native-reanimated: "npm:3.6.1"
+    react-native-reanimated: "npm:3.7.0-nightly-20240101-9d365ae7b"
     react-redux: "npm:8.0.7"
   languageName: unknown
   linkType: soft
@@ -7114,7 +7114,7 @@ __metadata:
     react: "npm:18.2.0"
     react-native: "npm:0.71.8"
     react-native-gesture-handler: "npm:^2.9.0"
-    react-native-reanimated: "npm:3.6.1"
+    react-native-reanimated: "npm:3.7.0-nightly-20240101-9d365ae7b"
     react-native-root-toast: "npm:^3.3.1"
     react-native-safe-area-context: "npm:^4.5.0"
     react-redux: "npm:8.0.7"
@@ -7187,7 +7187,7 @@ __metadata:
     jotai: "npm:1.9.1"
     react: "npm:^18.2.0"
     react-native: "npm:0.71.8"
-    react-native-reanimated: "npm:3.6.1"
+    react-native-reanimated: "npm:3.7.0-nightly-20240101-9d365ae7b"
     react-native-safe-area-context: "npm:^4.5.0"
     react-redux: "npm:8.0.7"
   languageName: unknown
@@ -7375,7 +7375,7 @@ __metadata:
     react: "npm:18.2.0"
     react-intl: "npm:^6.5.1"
     react-native: "npm:0.71.8"
-    react-native-reanimated: "npm:3.6.1"
+    react-native-reanimated: "npm:3.7.0-nightly-20240101-9d365ae7b"
     react-redux: "npm:8.0.7"
     typescript: "npm:5.3.2"
   languageName: unknown
@@ -7414,7 +7414,7 @@ __metadata:
     "@trezor/theme": "workspace:*"
     react: "npm:18.2.0"
     react-native: "npm:0.71.8"
-    react-native-reanimated: "npm:3.6.1"
+    react-native-reanimated: "npm:3.7.0-nightly-20240101-9d365ae7b"
   languageName: unknown
   linkType: soft
 
@@ -7438,7 +7438,7 @@ __metadata:
     proxy-memoize: "npm:2.0.2"
     react: "npm:18.2.0"
     react-native: "npm:0.71.8"
-    react-native-reanimated: "npm:3.6.1"
+    react-native-reanimated: "npm:3.7.0-nightly-20240101-9d365ae7b"
     react-native-safe-area-context: "npm:^4.5.0"
     react-redux: "npm:8.0.7"
   languageName: unknown
@@ -7486,7 +7486,7 @@ __metadata:
     lottie-react-native: "npm:^5.1.5"
     react: "npm:18.2.0"
     react-native: "npm:0.71.8"
-    react-native-reanimated: "npm:3.6.1"
+    react-native-reanimated: "npm:3.7.0-nightly-20240101-9d365ae7b"
     react-redux: "npm:8.0.7"
     typescript: "npm:5.3.2"
   languageName: unknown
@@ -7531,7 +7531,7 @@ __metadata:
     react: "npm:18.2.0"
     react-hook-form: "npm:^7.48.2"
     react-native: "npm:0.71.8"
-    react-native-reanimated: "npm:3.6.1"
+    react-native-reanimated: "npm:3.7.0-nightly-20240101-9d365ae7b"
     react-redux: "npm:8.0.7"
   languageName: unknown
   linkType: soft
@@ -7776,7 +7776,7 @@ __metadata:
     react: "npm:18.2.0"
     react-native: "npm:0.71.8"
     react-native-gesture-handler: "npm:^2.9.0"
-    react-native-reanimated: "npm:3.6.1"
+    react-native-reanimated: "npm:3.7.0-nightly-20240101-9d365ae7b"
     react-native-safe-area-context: "npm:^4.5.0"
     react-redux: "npm:8.0.7"
   languageName: unknown
@@ -7811,7 +7811,7 @@ __metadata:
     react: "npm:18.2.0"
     react-native: "npm:0.71.8"
     react-native-gesture-handler: "npm:^2.9.0"
-    react-native-reanimated: "npm:3.6.1"
+    react-native-reanimated: "npm:3.7.0-nightly-20240101-9d365ae7b"
   languageName: unknown
   linkType: soft
 
@@ -7851,7 +7851,7 @@ __metadata:
     react: "npm:18.2.0"
     react-native: "npm:0.71.8"
     react-native-gesture-handler: "npm:^2.9.0"
-    react-native-reanimated: "npm:3.6.1"
+    react-native-reanimated: "npm:3.7.0-nightly-20240101-9d365ae7b"
     react-redux: "npm:8.0.7"
   languageName: unknown
   linkType: soft
@@ -7922,7 +7922,7 @@ __metadata:
     jest: "npm:29.5.0"
     react: "npm:18.2.0"
     react-native-gesture-handler: "npm:^2.9.0"
-    react-native-reanimated: "npm:3.6.1"
+    react-native-reanimated: "npm:3.7.0-nightly-20240101-9d365ae7b"
     react-native-safe-area-context: "npm:^4.5.0"
     react-redux: "npm:8.0.7"
     typescript: "npm:5.3.2"
@@ -7956,7 +7956,7 @@ __metadata:
     jotai: "npm:1.9.1"
     react: "npm:18.2.0"
     react-native-gesture-handler: "npm:^2.9.0"
-    react-native-reanimated: "npm:3.6.1"
+    react-native-reanimated: "npm:3.7.0-nightly-20240101-9d365ae7b"
     react-native-safe-area-context: "npm:^4.5.0"
   languageName: unknown
   linkType: soft
@@ -7999,7 +7999,7 @@ __metadata:
     react: "npm:18.2.0"
     react-native: "npm:0.71.8"
     react-native-gesture-handler: "npm:^2.9.0"
-    react-native-reanimated: "npm:3.6.1"
+    react-native-reanimated: "npm:3.7.0-nightly-20240101-9d365ae7b"
     react-redux: "npm:8.0.7"
     web3-utils: "npm:^1.10.0"
   languageName: unknown
@@ -9197,7 +9197,7 @@ __metadata:
     react-native-flipper: "npm:0.164.0"
     react-native-gesture-handler: "npm:^2.9.0"
     react-native-mmkv: "npm:2.11.0"
-    react-native-reanimated: "npm:3.6.1"
+    react-native-reanimated: "npm:3.7.0-nightly-20240101-9d365ae7b"
     react-native-restart: "npm:^0.0.27"
     react-native-safe-area-context: "npm:^4.5.0"
     react-native-screens: "npm:^3.19.0"
@@ -28505,9 +28505,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-reanimated@npm:3.6.1":
-  version: 3.6.1
-  resolution: "react-native-reanimated@npm:3.6.1"
+"react-native-reanimated@npm:3.7.0-nightly-20240101-9d365ae7b":
+  version: 3.7.0-nightly-20240101-9d365ae7b
+  resolution: "react-native-reanimated@npm:3.7.0-nightly-20240101-9d365ae7b"
   dependencies:
     "@babel/plugin-transform-object-assign": "npm:^7.16.7"
     "@babel/preset-typescript": "npm:^7.16.7"
@@ -28522,7 +28522,7 @@ __metadata:
     "@babel/plugin-transform-template-literals": ^7.0.0-0
     react: "*"
     react-native: "*"
-  checksum: 594a4ace054fdafa02ea2f126aeeda474f32306698b1d7c15ec8495b606b80e9e10a69eef2653d4b7f9cb743d0007ada1ab27e5f3064af1bfcc95291d70bb824
+  checksum: 634988cef4c6208137b22c389fbfd420b0ae023a4c6af6c78a16619ff83986811c058c293e862641872525887cfb8abd703cb1e79d83b43314c77b2beed1210b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This version contains fix for [#5421](https://github.com/software-mansion/react-native-reanimated/pull/5505#issuecomment-1868478332) which caused app crash on startup quite often on both platforms. We shoudn't wait with update until stable version 3.7.0 because these crash is very common in latest versions of app.

It safe to use `nigthly` version for now and we will update to stable once it will be out. Should be quite soon.

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve #10132  #10361 

## Screenshots:
