### PR TITLE
chore(suite-data): update tor

### DIFF
--- a/packages/suite-data/files/bin/tor/linux-arm64/tor
+++ b/packages/suite-data/files/bin/tor/linux-arm64/tor
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a17e02f814350ac671e1fd5453950b4067ec903ce057062e09c92479b00a1d50
-size 16058224
+oid sha256:810df26623ce84932fb9d727902dd5d02c3bc4e1ef9d4b9afffc626d1d2ff466
+size 16070400

--- a/packages/suite-data/files/bin/tor/linux-x64/tor
+++ b/packages/suite-data/files/bin/tor/linux-x64/tor
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:94a85323777ef5940d2bac5d6745c771ec5dacff2ba8671ff21ca75891f47d2a
-size 16808896
+oid sha256:a1c7515d7bc28b3426a361beb6452b51042bfdf4ea15d5bcf71a7bf35270cb39
+size 16812920

--- a/packages/suite-data/files/bin/tor/mac-arm64/tor
+++ b/packages/suite-data/files/bin/tor/mac-arm64/tor
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9db5a59066b3d20c650eb99605d864399a980b79d22292f0285a22f28b24bbc3
-size 6200944
+oid sha256:540b9777f64d88a9de8ddafedb6be54f8b22a3d3a5b8896d4d7aefda3f67a32a
+size 4762752

--- a/packages/suite-data/files/bin/tor/mac-x64/tor
+++ b/packages/suite-data/files/bin/tor/mac-x64/tor
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9d6ef0cd31171568d4f0988566e9deba3bf8ea486b2ace8274e9a730e05e3563
-size 6613568
+oid sha256:9ae4bef1d828e729c3269db0d591eaad6f8471fb815a52aeae9db1fcf6c39843
+size 5206944

--- a/packages/suite-data/files/bin/tor/update.sh
+++ b/packages/suite-data/files/bin/tor/update.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
-CRX_VER=1_0_33
-CRX_LINUX_ARM_VER=1_0_2
+CRX_VER=1_0_34
+CRX_LINUX_ARM_VER=1_0_3
 
 # check whether we have all required commands
 for cmd in 7z curl lipo shasum ; do

--- a/packages/suite-data/files/bin/tor/win-x64/tor.exe
+++ b/packages/suite-data/files/bin/tor/win-x64/tor.exe
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dcde46350dfafb4a3f69fe167b5c5e61e0cb461072f2394b34da84998bc638a0
-size 16932360
+oid sha256:d66535d9b9293c45a92a007a86d8d4fb8909539ba98535c951fad0b98a3d954b
+size 16935976


### PR DESCRIPTION
Update to Tor version 0.4.8.9.

Can be verified by running `update.sh` from `packages/suite-data/files/bin/tor` directory.