### PR TITLE
Fix/buttons breaking UI espanol

### DIFF
--- a/packages/components/src/config/variables.ts
+++ b/packages/components/src/config/variables.ts
@@ -55,7 +55,7 @@ export const Z_INDEX = {
     PAGE_HEADER: 11, // above STICKY_BAR to hide it when the page is on top
     STICKY_BAR: 10, // above page content to scroll over it
     SECONDARY_STICKY_BAR: 9, // below STICKY_BAR so that it can hide beneath it when no longer needed
-    ONNBOARDING_FOREGROUND: 2, // for handling multiple layers on the onboarding page
+    ONBOARDING_FOREGROUND: 2, // for handling multiple layers on the onboarding page
     BASE: 1, // above static content to be fully visible
 } as const;
 

--- a/packages/suite/src/components/onboarding/OnboardingStepBox.tsx
+++ b/packages/suite/src/components/onboarding/OnboardingStepBox.tsx
@@ -14,7 +14,7 @@ import { TrezorDevice } from '@suite-common/suite-types';
 const ConfirmWrapper = styled.div`
     margin-bottom: 20px;
     height: 62px;
-    z-index: ${variables.Z_INDEX.ONNBOARDING_FOREGROUND};
+    z-index: ${variables.Z_INDEX.ONBOARDING_FOREGROUND};
 `;
 
 const InnerActions = styled.div`
@@ -29,7 +29,7 @@ const OuterActions = styled.div<{ smallMargin?: boolean }>`
     margin-top: ${({ smallMargin }) => (smallMargin ? '0px' : '20px')};
     width: 100%;
     justify-content: center;
-    z-index: ${variables.Z_INDEX.ONNBOARDING_FOREGROUND};
+    z-index: ${variables.Z_INDEX.ONBOARDING_FOREGROUND};
 `;
 
 export const StyledBackdrop = styled(Backdrop)<{ show: boolean }>`

--- a/packages/suite/src/components/suite/Preloader/SuiteLayout/NavigationBar/NavigationActions/NavSettings.tsx
+++ b/packages/suite/src/components/suite/Preloader/SuiteLayout/NavigationBar/NavigationActions/NavSettings.tsx
@@ -4,10 +4,12 @@ import { Translation } from 'src/components/suite';
 import { ActionItem } from './ActionItem';
 import { useDispatch } from 'src/hooks/suite';
 import { goto } from 'src/actions/suite/routerActions';
+import { variables } from '@trezor/components';
 
 const Wrapper = styled.div`
     margin-left: 8px;
     position: relative;
+    z-index: ${variables.Z_INDEX.ONBOARDING_FOREGROUND};
 `;
 
 interface NavSettingsProps {

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceInitialize.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceInitialize.tsx
@@ -4,6 +4,11 @@ import { Translation, TroubleshootingTips } from 'src/components/suite';
 import { useDispatch } from 'src/hooks/suite';
 import { goto } from 'src/actions/suite/routerActions';
 import { enableOnboardingReducer, resetOnboarding } from 'src/actions/onboarding/onboardingActions';
+import styled from 'styled-components';
+
+const StyledButton = styled(Button)`
+    white-space: normal;
+`;
 
 export const DeviceInitialize = () => {
     const dispatch = useDispatch();
@@ -22,9 +27,9 @@ export const DeviceInitialize = () => {
         <TroubleshootingTips
             label={<Translation id="TR_DEVICE_NOT_INITIALIZED" />}
             cta={
-                <Button data-test="@button/go-to-onboarding" onClick={handleCtaClick}>
+                <StyledButton data-test="@button/go-to-onboarding" onClick={handleCtaClick}>
                     <Translation id="TR_GO_TO_ONBOARDING" />
-                </Button>
+                </StyledButton>
             }
             items={[
                 {

--- a/packages/suite/src/components/suite/troubleshooting/TroubleshootingTips.tsx
+++ b/packages/suite/src/components/suite/troubleshooting/TroubleshootingTips.tsx
@@ -82,6 +82,10 @@ const StyledButton = styled(Button)`
     margin: 0 20px 20px;
 `;
 
+const StyledButtonContactSupport = styled(Button)`
+    white-space: normal;
+`;
+
 interface Item {
     key: string;
     heading?: ReactNode;
@@ -154,9 +158,9 @@ export const TroubleshootingTips = ({
                 </FooterText>
 
                 <TrezorLink variant="nostyle" href={TREZOR_SUPPORT_URL}>
-                    <Button variant="tertiary">
+                    <StyledButtonContactSupport variant="tertiary">
                         <Translation id="TR_CONTACT_SUPPORT" />
-                    </Button>
+                    </StyledButtonContactSupport>
                 </TrezorLink>
             </ContactSupport>
         </WhiteCollapsibleBox>

--- a/packages/suite/src/views/dashboard/components/SecurityCard.tsx
+++ b/packages/suite/src/views/dashboard/components/SecurityCard.tsx
@@ -68,9 +68,9 @@ const Footer = styled.div`
 const Action = styled.div`
     display: flex;
     width: 100%;
-    height: 40px;
     align-items: center;
     justify-content: center;
+    min-height: 40px;
 `;
 
 const CheckIconWrapper = styled.div`
@@ -94,6 +94,10 @@ const Line = styled.div`
     background: ${({ theme }) => theme.STROKE_GREY};
 
     /* border-top: 1px solid ${({ theme }) => theme.STROKE_GREY}; */
+`;
+
+const StyledButton = styled(Button)`
+    white-space: normal;
 `;
 
 export interface SecurityCardProps extends CardProps {
@@ -136,7 +140,7 @@ export const SecurityCard = ({
                 <Footer>
                     {cta && variant === 'primary' && (
                         <Action>
-                            <Button
+                            <StyledButton
                                 fullWidth
                                 variant="secondary"
                                 isDisabled={cta.isDisabled}
@@ -148,14 +152,14 @@ export const SecurityCard = ({
                                     : {})}
                             >
                                 {cta.label}
-                            </Button>
+                            </StyledButton>
                         </Action>
                     )}
                     {cta && variant === 'secondary' && (
                         <>
                             <Line />
                             <Action>
-                                <Button
+                                <StyledButton
                                     variant="tertiary"
                                     isDisabled={cta.isDisabled}
                                     onClick={cta.action}
@@ -168,7 +172,7 @@ export const SecurityCard = ({
                                         : {})}
                                 >
                                     {cta.label}
-                                </Button>
+                                </StyledButton>
                             </Action>
                         </>
                     )}

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheckFail.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheckFail.tsx
@@ -41,6 +41,7 @@ const StyledTrezorLink = styled(TrezorLink)`
 
 const StyledSecurityCheckButton = styled(SecurityCheckButton)`
     flex-grow: 1;
+    white-space: normal;
 `;
 
 const checklistItems = [

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheckLayout.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheckLayout.tsx
@@ -7,7 +7,7 @@ import { useSelector } from 'src/hooks/suite';
 
 const Wrapper = styled.div`
     display: grid;
-    grid-template-columns: 260px 1fr;
+    grid-template-columns: minmax(230px, 260px) 1fr;
     gap: 24px;
     width: 100%;
 


### PR DESCRIPTION
## Description

- fixing some UI issues in onboarding caused by long spanish texts

## Screenshots:
Before:
<img width="514" alt="Screenshot 2024-01-02 at 9 44 13" src="https://github.com/trezor/trezor-suite/assets/33235762/765f130f-e521-43e0-9f38-98aa1b059c5f">
Now:
<img width="531" alt="Screenshot 2024-01-02 at 9 44 05" src="https://github.com/trezor/trezor-suite/assets/33235762/e8e44d3b-7085-4505-8721-b455f8a408a5">
Before:
<img width="610" alt="Screenshot 2024-01-02 at 10 12 43" src="https://github.com/trezor/trezor-suite/assets/33235762/8d842e86-effe-4e9f-b46b-8addfbf1dee5">
Now:
<img width="549" alt="Screenshot 2024-01-02 at 10 12 46" src="https://github.com/trezor/trezor-suite/assets/33235762/e00abd00-1ed6-4077-bfdf-67631cbb8e0f">
Before (missing gear icon):
<img width="999" alt="Screenshot 2024-01-02 at 9 52 21" src="https://github.com/trezor/trezor-suite/assets/33235762/e5e5909a-7848-4f15-bb8a-d2d7cd976684">
Now:
<img width="505" alt="Screenshot 2024-01-02 at 10 03 32" src="https://github.com/trezor/trezor-suite/assets/33235762/6f410edf-79c4-485d-ac0a-6c77f129bc2a">
Before:
<img width="672" alt="Screenshot 2024-01-02 at 9 45 04" src="https://github.com/trezor/trezor-suite/assets/33235762/8efbb05c-4c33-418d-96bd-6a74516ab09e">
Now:
<img width="646" alt="Screenshot 2024-01-02 at 9 47 34" src="https://github.com/trezor/trezor-suite/assets/33235762/cf8ba768-1903-4d0c-a905-6279663c526d">
Before:
<img width="439" alt="Screenshot 2024-01-02 at 9 46 06" src="https://github.com/trezor/trezor-suite/assets/33235762/6cebc4e5-62e0-4b36-81c5-90c23d162588">
Now:
<img width="601" alt="Screenshot 2024-01-02 at 9 45 57" src="https://github.com/trezor/trezor-suite/assets/33235762/e7111002-6532-49f1-bd67-e8ec30d18231">


