### PR TITLE
fix(suite): selectedProvider unhandled error during db migration

### DIFF
--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -706,7 +706,14 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
 
     if (oldVersion < 41) {
         await updateAll(transaction, 'metadata', metadata => {
-            metadata.selectedProvider.passwords = '';
+            // although selectedProvider is added in version 39 I saw a report by QA that
+            // migration was trying to set 'passwords' of undefined here.
+            if (!metadata.selectedProvider) {
+                metadata.selectedProvider = { labels: '', passwords: '' };
+            }
+            if (!metadata.selectedProvider.passwords) {
+                metadata.selectedProvider.passwords = '';
+            }
             return metadata;
         });
     }


### PR DESCRIPTION
Received this report by @bosomt today 

![image](https://github.com/trezor/trezor-suite/assets/30367552/aa53ddb4-c347-447b-aa8d-05c0278d5c5e)

It does not crash app and everything seems to work normally (although maybe newly added hidden passwords feature might be affected). 

Not sure how it could happen, I went through the code and did not find any place where we would delete this field. selectedProvider field was added in migration 39. 