### PR TITLE
fix(graph): allow negative balance in graph to fix rare bitcoin graph issues

### DIFF
--- a/suite-common/graph/src/graphDataFetching.ts
+++ b/suite-common/graph/src/graphDataFetching.ts
@@ -39,9 +39,6 @@ export const addBalanceForAccountMovementHistory = (
 
         balance = new BigNumber(balance).plus(normalizedReceived).minus(normalizedSent);
 
-        // for some coins like ETH, simple sum of received and sent is not enough and could result in nonsense like negative balance
-        balance = balance.isNegative() ? new BigNumber('0') : balance;
-
         return {
             time: dataPoint.time,
             cryptoBalance: formatNetworkAmount(balance.toFixed(), symbol),


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Transactions in graph are ordered by timestamp and not by blockheight and in rare cases it can be in oposite order. If we would like to prevent negative value in graph, we should do that on different level.

Example (see exact timestamps): 
https://btc1.trezor.io/block/360626
https://btc1.trezor.io/block/360627


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/10344

## Screenshots:
<img width="506" alt="image" src="https://github.com/trezor/trezor-suite/assets/3729633/3420dbc5-7c82-4d89-ad18-e65a7e31ae24">

