### PR TITLE
feat(suite-native): account type grouped account list

### DIFF
--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -8,7 +8,7 @@ import { Account, AccountKey } from '@suite-common/wallet-types';
 import { networks, NetworkSymbol } from '@suite-common/wallet-config';
 
 import { accountsActions } from './accountsActions';
-import { formattedAccountTypeMap } from './constants';
+import { formattedBitcoinAccountTypeMap } from './constants';
 import {
     DeviceRootState,
     selectDevice,
@@ -85,14 +85,17 @@ export const prepareAccountsReducer = createReducerWithExtraDeps(
                 state.push(account);
             })
             .addCase(accountsActions.createIndexLabeledAccount, (state, action) => {
-                const { deviceState, symbol } = action.payload;
-                const deviceNetworkAccounts = state.filter(
-                    account => account.deviceState === deviceState && account.symbol === symbol,
+                const { deviceState, symbol, accountType } = action.payload;
+                const matchingNetworkAndTypeAccounts = state.filter(
+                    account =>
+                        account.deviceState === deviceState &&
+                        account.symbol === symbol &&
+                        account.accountType === accountType,
                 );
 
-                const indexOfLastAccount = deviceNetworkAccounts.length;
+                const indexOfPreviousAccount = matchingNetworkAndTypeAccounts.length;
                 const networkName = networks[symbol].name;
-                const accountLabel = `${networkName} #${indexOfLastAccount + 1}`;
+                const accountLabel = `${networkName} #${indexOfPreviousAccount + 1}`;
 
                 const account = {
                     ...action.payload,
@@ -187,7 +190,7 @@ export const selectHasAccountTransactions = (state: AccountsRootState, accountKe
     return !!account?.history.total;
 };
 
-export const selectAccountsByNetworkSymbol = memoizeWithArgs(
+export const selectDeviceAccountsByNetworkSymbol = memoizeWithArgs(
     (state: AccountsRootState & DeviceRootState, networkSymbol: NetworkSymbol | null) => {
         if (G.isNull(networkSymbol)) return [];
 
@@ -243,7 +246,7 @@ export const selectFormattedAccountType = (
 
     if (!account || account?.networkType !== 'bitcoin') return null;
 
-    return formattedAccountTypeMap[account.accountType] ?? null;
+    return formattedBitcoinAccountTypeMap[account.accountType] ?? null;
 };
 
 export const selectIsAccountUtxoBased = (state: AccountsRootState, accountKey: AccountKey) => {

--- a/suite-common/wallet-core/src/accounts/constants.ts
+++ b/suite-common/wallet-core/src/accounts/constants.ts
@@ -2,7 +2,7 @@ import { AccountType } from '@suite-common/wallet-types';
 
 export const accountsActionsPrefix = '@common/wallet-core/accounts';
 
-export const formattedAccountTypeMap: Partial<Record<AccountType, string>> = {
+export const formattedBitcoinAccountTypeMap: Partial<Record<AccountType, string>> = {
     normal: 'SegWit', // represents the default Suite account type (`SegWit Native` at the moment).
     taproot: 'Taproot',
     segwit: 'Legacy SegWit',

--- a/suite-native/accounts/src/components/AccountListItemInteractive.tsx
+++ b/suite-native/accounts/src/components/AccountListItemInteractive.tsx
@@ -1,7 +1,6 @@
 import { TouchableOpacity } from 'react-native';
 import { useSelector } from 'react-redux';
 
-import { Box } from '@suite-native/atoms';
 import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
 import { selectIsEthereumAccountWithTokensWithFiatRates } from '@suite-native/ethereum-tokens';
 import { SettingsSliceRootState } from '@suite-native/module-settings';
@@ -23,7 +22,7 @@ export const AccountListItemInteractive = ({
     );
 
     return (
-        <Box padding="medium">
+        <>
             <TouchableOpacity onPress={() => onSelectAccount(account.key)}>
                 <AccountListItem
                     key={account.key}
@@ -34,6 +33,6 @@ export const AccountListItemInteractive = ({
             {areTokensDisplayed && (
                 <TokenList accountKey={account.key} onSelectAccount={onSelectAccount} />
             )}
-        </Box>
+        </>
     );
 };

--- a/suite-native/accounts/src/components/AccountsList.tsx
+++ b/suite-native/accounts/src/components/AccountsList.tsx
@@ -7,9 +7,9 @@ import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
 import { FiatRatesRootState } from '@suite-native/fiat-rates';
 import { SettingsSliceRootState } from '@suite-native/module-settings';
 
-import { AccountsListGroup } from './AccountsListGroup';
-import { selectFilteredAccountsGroupedByNetwork } from '../selectors';
+import { selectFilteredAccountsGroupedByNetworkAccountType } from '../selectors';
 import { AccountListPlaceholder } from './AccountListPlaceholder';
+import { GroupedAccountsList } from './GroupedAccountsList';
 
 type AccountsListProps = {
     onSelectAccount: (accountKey: AccountKey, tokenContract?: TokenAddress) => void;
@@ -17,26 +17,18 @@ type AccountsListProps = {
 };
 
 export const AccountsList = ({ onSelectAccount, filterValue = '' }: AccountsListProps) => {
-    const accounts = useSelector(
+    const groupedAccounts = useSelector(
         (
             state: AccountsRootState &
                 FiatRatesRootState &
                 SettingsSliceRootState &
                 DeviceRootState,
-        ) => selectFilteredAccountsGroupedByNetwork(state, filterValue),
+        ) => selectFilteredAccountsGroupedByNetworkAccountType(state, filterValue),
     );
 
-    if (D.isEmpty(accounts)) return <AccountListPlaceholder />;
+    if (D.isEmpty(groupedAccounts)) return <AccountListPlaceholder />;
 
     return (
-        <>
-            {Object.entries(accounts).map(([networkSymbol, networkAccounts]) => (
-                <AccountsListGroup
-                    key={networkSymbol}
-                    accounts={networkAccounts}
-                    onSelectAccount={onSelectAccount}
-                />
-            ))}
-        </>
+        <GroupedAccountsList groupedAccounts={groupedAccounts} onSelectAccount={onSelectAccount} />
     );
 };

--- a/suite-native/accounts/src/components/AccountsListGroup.tsx
+++ b/suite-native/accounts/src/components/AccountsListGroup.tsx
@@ -1,29 +1,21 @@
-import { G } from '@mobily/ts-belt';
-
-import { Box } from '@suite-native/atoms';
-import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+import { HeaderedCard, VStack } from '@suite-native/atoms';
 import { Account, AccountKey, TokenAddress } from '@suite-common/wallet-types';
 
 import { AccountListItemInteractive } from './AccountListItemInteractive';
 
 type AccountsListGroupProps = {
-    accounts: readonly Account[] | null;
+    groupHeader: string;
+    accounts: Account[];
     onSelectAccount: (accountKey: AccountKey, tokenContract?: TokenAddress) => void;
 };
 
-const accountListGroupStyle = prepareNativeStyle(utils => ({
-    backgroundColor: utils.colors.backgroundSurfaceElevation1,
-    borderRadius: 12,
-    marginBottom: utils.spacings.small,
-}));
-
-export const AccountsListGroup = ({ accounts, onSelectAccount }: AccountsListGroupProps) => {
-    const { applyStyle } = useNativeStyles();
-
-    if (G.isNull(accounts)) return null;
-
-    return (
-        <Box style={applyStyle(accountListGroupStyle)}>
+export const AccountsListGroup = ({
+    groupHeader,
+    accounts,
+    onSelectAccount,
+}: AccountsListGroupProps) => (
+    <HeaderedCard title={groupHeader}>
+        <VStack spacing="medium">
             {accounts.map(account => (
                 <AccountListItemInteractive
                     key={account.key}
@@ -31,6 +23,6 @@ export const AccountsListGroup = ({ accounts, onSelectAccount }: AccountsListGro
                     onSelectAccount={onSelectAccount}
                 />
             ))}
-        </Box>
-    );
-};
+        </VStack>
+    </HeaderedCard>
+);

--- a/suite-native/accounts/src/components/GroupedAccountsList.tsx
+++ b/suite-native/accounts/src/components/GroupedAccountsList.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import { VStack } from '@suite-native/atoms';
+import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
+
+import { GroupedAccounts } from '../types';
+import { AccountsListGroup } from './AccountsListGroup';
+
+type GroupedAccountsListProps = {
+    groupedAccounts: GroupedAccounts;
+    onSelectAccount: (accountKey: AccountKey, tokenContract?: TokenAddress) => void;
+};
+
+export const GroupedAccountsList = ({
+    groupedAccounts,
+    onSelectAccount,
+}: GroupedAccountsListProps) => (
+    <VStack spacing="large" paddingBottom="medium">
+        {Object.entries(groupedAccounts).map(
+            ([accountTypeHeader, networkAccounts]) =>
+                networkAccounts && (
+                    <AccountsListGroup
+                        key={accountTypeHeader}
+                        groupHeader={accountTypeHeader}
+                        accounts={networkAccounts}
+                        onSelectAccount={onSelectAccount}
+                    />
+                ),
+        )}
+    </VStack>
+);

--- a/suite-native/accounts/src/tests/selectors.test.ts
+++ b/suite-native/accounts/src/tests/selectors.test.ts
@@ -1,11 +1,12 @@
 import { Account } from '@suite-common/wallet-types';
 
-import { isFilterValueMatchingAccount } from '../selectors';
+import { isFilterValueMatchingAccount, groupAccountsByNetworkAccountType } from '../utils';
 
 describe('isFilterValueMatchingAccountLabelOrNetworkName', () => {
     const account = {
         accountLabel: 'Original account name',
         symbol: 'eth',
+        accountType: 'legacy',
         tokens: [{ name: 'Tether USD' }],
     } as Account;
 
@@ -27,6 +28,18 @@ describe('isFilterValueMatchingAccountLabelOrNetworkName', () => {
         expect(isFilterValueMatchingAccount(account, filterValue)).toBe(true);
     });
 
+    test('should return true if filter value matches the account type', () => {
+        const filterValue = 'legacy';
+
+        expect(isFilterValueMatchingAccount(account, filterValue)).toBe(true);
+    });
+
+    test('should return true if filter value matches the account type', () => {
+        const filterValue = 'taproot';
+
+        expect(isFilterValueMatchingAccount(account, filterValue)).toBe(false);
+    });
+
     test('should return true if filter value matches the included token name', () => {
         const filterValue = 'tether';
 
@@ -37,5 +50,33 @@ describe('isFilterValueMatchingAccountLabelOrNetworkName', () => {
         const filterValue = 'Original account';
 
         expect(isFilterValueMatchingAccount(account, filterValue)).toBe(true);
+    });
+});
+
+describe('groupAccountsByNetworkAccountType', () => {
+    it('groups accounts by network and account type', () => {
+        const fixtureAccounts = [
+            { symbol: 'btc', accountType: 'normal' },
+            { symbol: 'btc', accountType: 'normal' },
+            { symbol: 'btc', accountType: 'segwit' },
+            { symbol: 'btc', accountType: 'legacy' },
+            { symbol: 'btc', accountType: 'taproot' },
+            { symbol: 'eth', accountType: 'normal' },
+            { symbol: 'ltc', accountType: 'segwit' },
+        ] as unknown as Account[];
+
+        const result = groupAccountsByNetworkAccountType(fixtureAccounts);
+
+        expect(result).toEqual({
+            'Bitcoin default accounts': [
+                { symbol: 'btc', accountType: 'normal' },
+                { symbol: 'btc', accountType: 'normal' },
+            ],
+            'Bitcoin Legacy Segwit accounts': [{ symbol: 'btc', accountType: 'segwit' }],
+            'Bitcoin Legacy accounts': [{ symbol: 'btc', accountType: 'legacy' }],
+            'Bitcoin Taproot accounts': [{ symbol: 'btc', accountType: 'taproot' }],
+            'Ethereum accounts': [{ symbol: 'eth', accountType: 'normal' }],
+            'Litecoin Legacy Segwit accounts': [{ symbol: 'ltc', accountType: 'segwit' }],
+        });
     });
 });

--- a/suite-native/accounts/src/types.ts
+++ b/suite-native/accounts/src/types.ts
@@ -1,0 +1,3 @@
+import { Account } from '@suite-common/wallet-types';
+
+export type GroupedAccounts = Record<string, [Account, ...Account[]]>;

--- a/suite-native/accounts/src/utils.ts
+++ b/suite-native/accounts/src/utils.ts
@@ -1,0 +1,77 @@
+import { A, D, G } from '@mobily/ts-belt';
+
+import { AccountType, networks } from '@suite-common/wallet-config';
+import { formattedBitcoinAccountTypeMap } from '@suite-common/wallet-core/src/accounts/constants';
+import { Account } from '@suite-common/wallet-types';
+import { getNetwork } from '@suite-common/wallet-utils';
+
+const accountTypeToSectionHeader: Readonly<Partial<Record<AccountType, string>>> = {
+    normal: 'default',
+    taproot: 'Taproot',
+    segwit: 'Legacy Segwit',
+    legacy: 'Legacy',
+    ledger: 'Ledger',
+};
+
+/**
+ * Returns true if account label, network name, account type or account included token contains filter value as a substring.
+ */
+export const isFilterValueMatchingAccount = (account: Account, filterValue: string) => {
+    const lowerCaseFilterValue = filterValue?.trim().toLowerCase();
+
+    const isMatchingLabel = account.accountLabel?.toLowerCase().includes(lowerCaseFilterValue);
+
+    if (isMatchingLabel) return true;
+
+    const accountNetwork = getNetwork(account.symbol);
+    const isMatchingNetworkName = accountNetwork?.name.toLowerCase().includes(lowerCaseFilterValue);
+
+    if (isMatchingNetworkName) return true;
+
+    const isBitcoinNetworkType = networks[account.symbol].networkType === 'bitcoin';
+    const lowercasedSectionHeader = accountTypeToSectionHeader[account.accountType]?.toLowerCase();
+    const lowercasedBitcoinAccountType =
+        formattedBitcoinAccountTypeMap[account.accountType]?.toLowerCase();
+
+    const isMatchingAccountType =
+        (lowercasedSectionHeader?.includes(filterValue) ||
+            (isBitcoinNetworkType && lowercasedBitcoinAccountType?.includes(filterValue))) ??
+        false;
+
+    if (isMatchingAccountType) return true;
+
+    const isMatchingTokenName =
+        account.tokens?.some(token => token.name?.toLowerCase().includes(lowerCaseFilterValue)) ??
+        false;
+
+    if (isMatchingTokenName) return true;
+
+    return false;
+};
+
+/**
+ * Filter accounts by labels, network names and included token names.
+ */
+export const filterAccountsByLabelAndNetworkNames = (
+    accounts: readonly Account[],
+    filterValue: string,
+) => {
+    if (!filterValue) return accounts;
+
+    return A.filter(accounts, account => isFilterValueMatchingAccount(account, filterValue));
+};
+
+/**
+ * Returns object with key equal string composed by network name and account type. Values are arrays of corresponding accounts.
+ */
+export const groupAccountsByNetworkAccountType = A.groupBy((account: Account) => {
+    const { symbol, accountType } = account;
+    const networkConfig = networks[symbol];
+    const networkName = networkConfig.name;
+    const formattedAccountType = accountTypeToSectionHeader[accountType];
+
+    if (D.isEmpty(networkConfig.accountTypes) || G.isNullable(formattedAccountType))
+        return `${networkName} accounts`;
+
+    return `${networkName} ${formattedAccountType} accounts`;
+});

--- a/suite-native/assets/src/components/AssetItem.tsx
+++ b/suite-native/assets/src/components/AssetItem.tsx
@@ -9,7 +9,7 @@ import { NetworkSymbol } from '@suite-common/wallet-config';
 import {
     AccountsRootState,
     DeviceRootState,
-    selectAccountsByNetworkSymbol,
+    selectDeviceAccountsByNetworkSymbol,
 } from '@suite-common/wallet-core';
 import { Box, Text } from '@suite-native/atoms';
 import { CryptoAmountFormatter, FiatAmountFormatter } from '@suite-native/formatters';
@@ -73,7 +73,7 @@ export const AssetItem = memo(
         const navigation = useNavigation<NavigationType>();
 
         const accountsForNetworkSymbol = useSelector((state: AccountsRootState & DeviceRootState) =>
-            selectAccountsByNetworkSymbol(state, cryptoCurrencySymbol),
+            selectDeviceAccountsByNetworkSymbol(state, cryptoCurrencySymbol),
         );
         const accountsPerAsset = accountsForNetworkSymbol.length;
 

--- a/suite-native/assets/src/components/NetworkAssetsBottomSheet.tsx
+++ b/suite-native/assets/src/components/NetworkAssetsBottomSheet.tsx
@@ -1,19 +1,14 @@
 import { useSelector } from 'react-redux';
 
-import { G } from '@mobily/ts-belt';
-
 import { BottomSheet } from '@suite-native/atoms';
-import { AccountsListGroup } from '@suite-native/accounts';
+import { selectNetworkAccountsGroupedByAccountType } from '@suite-native/accounts';
 import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
-import {
-    AccountsRootState,
-    DeviceRootState,
-    selectAccountsByNetworkSymbol,
-} from '@suite-common/wallet-core';
+import { AccountsRootState, DeviceRootState } from '@suite-common/wallet-core';
 import { NetworkSymbol } from '@suite-common/wallet-config';
+import { GroupedAccountsList } from '@suite-native/accounts/src/components/GroupedAccountsList';
 
 type NetworkAssetsBottomSheetProps = {
-    networkSymbol: NetworkSymbol | null;
+    networkSymbol: NetworkSymbol;
     onSelectAccount: (accountKey: AccountKey, tokenContract?: TokenAddress) => void;
     onClose: () => void;
 };
@@ -23,15 +18,16 @@ export const NetworkAssetsBottomSheet = ({
     onSelectAccount,
     onClose,
 }: NetworkAssetsBottomSheetProps) => {
-    const selectedAccounts = useSelector((state: AccountsRootState & DeviceRootState) =>
-        selectAccountsByNetworkSymbol(state, networkSymbol),
+    const groupedNetworkAccounts = useSelector((state: AccountsRootState & DeviceRootState) =>
+        selectNetworkAccountsGroupedByAccountType(state, networkSymbol),
     );
-
-    if (G.isNull(networkSymbol)) return null;
 
     return (
         <BottomSheet title="Select Account" isVisible onClose={onClose}>
-            <AccountsListGroup accounts={selectedAccounts} onSelectAccount={onSelectAccount} />
+            <GroupedAccountsList
+                groupedAccounts={groupedNetworkAccounts}
+                onSelectAccount={onSelectAccount}
+            />
         </BottomSheet>
     );
 };

--- a/suite-native/blockchain/src/blockchainThunks.ts
+++ b/suite-native/blockchain/src/blockchainThunks.ts
@@ -4,7 +4,7 @@ import {
     blockchainActions,
     fetchAndUpdateAccountThunk,
     selectDeviceAccountByDescriptorAndNetworkSymbol,
-    selectAccountsByNetworkSymbol,
+    selectDeviceAccountsByNetworkSymbol,
     selectAccountsSymbols,
     subscribeBlockchainThunk,
 } from '@suite-common/wallet-core';
@@ -32,7 +32,7 @@ const shouldRefetchAccount = ({
 export const syncAccountsWithBlockchainThunk = createThunk(
     `${actionsPrefix}/syncAccountsThunk`,
     async ({ symbol }: { symbol: NetworkSymbol }, { getState, dispatch }) => {
-        const accounts = selectAccountsByNetworkSymbol(getState(), symbol);
+        const accounts = selectDeviceAccountsByNetworkSymbol(getState(), symbol);
         const accountForRefetch = accounts.filter(({ key }) =>
             shouldRefetchAccount({ accountKey: key }),
         );


### PR DESCRIPTION
## Description
- account list grouped by combination of network and account type
- filtering now supports account type
## Related Issue

Resolve #10352 

## Screenshots:

https://github.com/trezor/trezor-suite/assets/26143964/a63182a1-3bab-4cf8-a00d-2a42b3dadc8f

