### PR TITLE
Remove `altMode` from passphrase checking in Connect

### DIFF
--- a/packages/connect/src/data/config.ts
+++ b/packages/connect/src/data/config.ts
@@ -113,6 +113,11 @@ export const config = {
             comment: ['There were protobuf backwards incompatible changes.'],
         },
         {
+            coin: ['ada', 'tada'],
+            min: { T1B1: '0', T2T1: '2.4.3' },
+            comment: ['Since 2.4.3 there is initialize.derive_cardano message'],
+        },
+        {
             methods: ['rippleGetAddress', 'rippleSignTransaction'],
             min: { T1B1: '0', T2T1: '2.1.0' },
             comment: [

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -467,8 +467,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
             // ...and if it's not then unlock device and proceed to regular GetAddress flow
         }
 
-        const altMode = this._altModeChange(networkType);
-        const expectedState = altMode ? undefined : this.getExternalState();
+        const expectedState = this.getExternalState();
         const state = await this.getCommands().getDeviceState(networkType);
         const uniqueState = `${state}@${this.features.device_id || 'device_id'}:${this.instance}`;
         if (!this.useLegacyPassphrase() && this.features.session_id) {
@@ -750,33 +749,6 @@ export class Device extends TypedEmitter<DeviceEvents> {
             features: this.features,
             unavailableCapabilities: this.unavailableCapabilities,
         };
-    }
-
-    _getNetworkTypeState() {
-        return this.networkTypeState[this.instance];
-    }
-
-    _setNetworkTypeState(networkType?: NETWORK.NetworkType) {
-        if (typeof networkType !== 'string') {
-            delete this.networkTypeState[this.instance];
-        } else {
-            this.networkTypeState[this.instance] = networkType;
-        }
-    }
-
-    _altModeChange(networkType?: NETWORK.NetworkType) {
-        const prevAltMode = this._isAltModeNetworkType(this._getNetworkTypeState());
-        const nextAltMode = this._isAltModeNetworkType(networkType);
-
-        // Update network type
-        this._setNetworkTypeState(networkType);
-
-        return prevAltMode !== nextAltMode;
-    }
-
-    // Is it a network type that requires the device to operate in an alternative state (ie: Cardano)
-    _isAltModeNetworkType(networkType?: keyof typeof NETWORK.TYPES) {
-        return networkType ? ['cardano'].includes(networkType) : false;
     }
 
     async legacyForceRelease() {

--- a/packages/suite-web/e2e/tests/suite/passphrase-cardano.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase-cardano.test.ts
@@ -1,0 +1,91 @@
+// @group:passphrase
+// @retry=2
+
+const correctPassprhaseAddr =
+    'addr1qx3ufjpwcx30ee73a7r29surauze6yt0jvr7c3rnahw0hnppg7qp5xvslcfucsqqayrtjhm4u66x';
+
+describe('Passphrase with cardano', () => {
+    beforeEach(() => {
+        cy.task('startEmu', { wipe: true });
+        cy.task('setupEmu', {
+            mnemonic: 'all all all all all all all all all all all all',
+            passphrase_protection: true,
+        });
+        cy.task('startBridge');
+
+        cy.viewport(1080, 1440).resetDb();
+        cy.prefixedVisit('/settings/coins');
+        cy.passThroughInitialRun();
+    });
+
+    it('verify cardano address behind passphrase.', () => {
+        // enable cardano in settings
+        cy.getTestElement('@settings/wallet/network/ada').click();
+
+        // starting discovery triggers passphrase dialogue
+        cy.getTestElement('@suite/menu/wallet-index').click();
+
+        // enter 'secret passphrase A'
+        cy.getTestElement('@passphrase/input').type('secret passphrase A');
+        cy.getTestElement('@passphrase/hidden/submit-button').click();
+        cy.task('pressYes');
+        cy.task('pressYes');
+        cy.getTestElement('@passphrase/confirm-checkbox', { timeout: 10000 }).click();
+        cy.getTestElement('@passphrase/input').type('secret passphrase A');
+        cy.getTestElement('@passphrase/hidden/submit-button').click();
+        cy.task('pressYes');
+        cy.task('pressYes');
+
+        // remember device
+        cy.getTestElement('@menu/switch-device').click();
+        cy.getTestElement('@switch-device/wallet-on-index/0/toggle-remember-switch').click({
+            force: true,
+        });
+        cy.getTestElement('@modal/close-button').click();
+
+        // restart device
+        cy.task('stopEmu');
+        cy.getTestElement('@deviceStatus-disconnected');
+        cy.task('startEmu');
+        cy.getTestElement('@deviceStatus-connected');
+
+        // reveal cardano address
+        cy.getTestElement('@account-menu/ada/normal/0').click();
+        cy.getTestElement('@wallet/menu/wallet-receive').click();
+        cy.getTestElement('@wallet/receive/reveal-address-button').click();
+
+        // device after reset asks for passphrase again, enter correct passphrase associated with this account
+        cy.getTestElement('@passphrase/input').type('secret passphrase A');
+        cy.getTestElement('@passphrase/hidden/submit-button').click();
+        cy.task('pressYes');
+        cy.task('pressYes');
+        cy.getTestElement('@modal/confirm-address/address-field').should(
+            'contain',
+            correctPassprhaseAddr,
+        );
+        cy.task('pressYes');
+        cy.getTestElement('@metadata/copy-address-button');
+        cy.wait(1000);
+        cy.getTestElement('@modal/close-button').click();
+        cy.getTestElement('@wallet/receive/reveal-address-button');
+
+        // restart device again
+        // restart device
+        cy.task('stopEmu');
+        cy.getTestElement('@deviceStatus-disconnected');
+        cy.task('startEmu');
+        cy.getTestElement('@deviceStatus-connected');
+
+        // reveal cardano address, now enter wrong passphrase
+        cy.getTestElement('@wallet/receive/reveal-address-button').click();
+        cy.getTestElement('@passphrase/input').type('wrong passphrase');
+        cy.getTestElement('@passphrase/hidden/submit-button').click();
+        cy.task('pressYes');
+        cy.task('pressYes');
+
+        // error should be displayed. definitely no address modal
+        cy.getTestElement('@toast/verify-address-error');
+    });
+});
+
+export {};


### PR DESCRIPTION
## Description
For some (hopefully) historical reason, passphrase correctness wasn't checked when switched between ADA and nonADA coins. After careful testing, we've decided to remove this exception which should resolve some issues, mainly receive address mismatch when inserting wrong passphrase for ADA acc.

## Related historical issues/PRs

https://github.com/trezor/trezor-firmware/issues/1231
https://github.com/trezor/trezor-firmware/pull/1873
