### PR TITLE
fix(suite-native): account type migration fix

### DIFF
--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -10,7 +10,11 @@ import {
 import { prepareFiatRatesReducer } from '@suite-native/fiat-rates';
 import { appSettingsReducer, appSettingsPersistWhitelist } from '@suite-native/module-settings';
 import { logsSlice } from '@suite-common/logger';
-import { migrateAccountLabel, preparePersistReducer } from '@suite-native/storage';
+import {
+    migrateAccountLabel,
+    deriveAccountTypeFromPaymentType,
+    preparePersistReducer,
+} from '@suite-native/storage';
 import { prepareAnalyticsReducer } from '@suite-common/analytics';
 import { prepareMessageSystemReducer } from '@suite-common/message-system';
 import { notificationsReducer } from '@suite-common/toast-notifications';
@@ -50,11 +54,19 @@ export const prepareRootReducers = async () => {
         reducer: walletReducers,
         persistedKeys: ['accounts', 'transactions'],
         key: 'wallet',
-        version: 2,
+        version: 3,
         migrations: {
             2: (oldState: any) => {
                 const oldAccountsState: { accounts: any } = { accounts: oldState.accounts };
                 const migratedAccounts = migrateAccountLabel(oldAccountsState.accounts);
+                const migratedState = { ...oldState, accounts: migratedAccounts };
+                return migratedState;
+            },
+            3: oldState => {
+                const oldAccountsState: { accounts: any } = { accounts: oldState.accounts };
+                const migratedAccounts = deriveAccountTypeFromPaymentType(
+                    oldAccountsState.accounts,
+                );
                 const migratedState = { ...oldState, accounts: migratedAccounts };
                 return migratedState;
             },

--- a/suite-native/storage/package.json
+++ b/suite-native/storage/package.json
@@ -12,6 +12,10 @@
     },
     "dependencies": {
         "@reduxjs/toolkit": "1.9.5",
+        "@suite-common/wallet-config": "workspace:*",
+        "@suite-common/wallet-types": "workspace:*",
+        "@trezor/utxo-lib": "workspace:*",
+        "bs58": "^5.0.0",
         "expo-random": "^13.1.1",
         "expo-secure-store": "^12.1.1",
         "expo-splash-screen": "0.18.1",

--- a/suite-native/storage/src/index.ts
+++ b/suite-native/storage/src/index.ts
@@ -6,3 +6,4 @@ export * from './storage';
 export * from './atomWithUnecryptedStorage';
 
 export * from './migrations/account/v2';
+export * from './migrations/account/v3';

--- a/suite-native/storage/src/migrations/account/v3.ts
+++ b/suite-native/storage/src/migrations/account/v3.ts
@@ -1,0 +1,81 @@
+import { decode } from 'bs58';
+
+const BIP32_PAYMENT_TYPES = {
+    0x0488b21e: 'p2pkh', // 76067358, xpub
+    0x049d7cb2: 'p2sh', // 77429938, ypub
+    0x04b24746: 'p2wpkh', // 78792518, zpub
+    0x043587cf: 'p2pkh', // 70617039, tpub
+    0x044a5262: 'p2sh', // 71979618, upub
+    0x045f1cf6: 'p2wpkh', // 73342198, vpub
+    0x019da462: 'p2pkh', // 27108450, Ltub
+    0x01b26ef6: 'p2sh', // 28471030, Mtub
+} as const;
+
+type NetworkSymbol =
+    | 'btc'
+    | 'ltc'
+    | 'eth'
+    | 'etc'
+    | 'xrp'
+    | 'bch'
+    | 'btg'
+    | 'dash'
+    | 'dgb'
+    | 'doge'
+    | 'nmc'
+    | 'vtc'
+    | 'zec'
+    | 'test'
+    | 'regtest'
+    | 'tsep'
+    | 'tgor'
+    | 'thol'
+    | 'txrp'
+    | 'ada'
+    | 'tada'
+    | 'sol'
+    | 'dsol';
+
+type NetworkType = 'bitcoin' | 'ethereum' | 'ripple' | 'cardano' | 'solana';
+
+type XpubVersion = keyof typeof BIP32_PAYMENT_TYPES;
+
+const getPaymentTypeFromXpub = (xpub: string) => {
+    if (xpub.startsWith('tr(')) return 'p2tr';
+
+    const xpubVersion = Buffer.from(decode(xpub)).readUInt32BE();
+    return BIP32_PAYMENT_TYPES[xpubVersion as XpubVersion];
+};
+
+type AccountType = 'normal' | 'legacy' | 'segwit' | 'taproot';
+export type Account = {
+    symbol: NetworkSymbol;
+    descriptor: string;
+    accountType: AccountType;
+    networkType: NetworkType;
+};
+
+const paymentTypeToAccountType: Record<string, AccountType> = {
+    p2wpkh: 'normal',
+    p2pkh: 'legacy',
+    p2sh: 'segwit',
+    p2tr: 'taproot',
+};
+
+/**
+ * Fixes account type based on payment type. Necessary for accounts created in suite-native version < 24.1.1 which were configuring wrong account type.
+ */
+export const deriveAccountTypeFromPaymentType = (oldAccounts: Account[]): Account[] =>
+    oldAccounts.map(oldAccount => {
+        const { descriptor, networkType } = oldAccount;
+
+        if (networkType !== 'bitcoin') return oldAccount;
+
+        const paymentType = getPaymentTypeFromXpub(descriptor);
+        const migratedAccountType = paymentTypeToAccountType[paymentType];
+
+        return {
+            ...oldAccount,
+            accountType: migratedAccountType,
+        };
+    });

--- a/suite-native/storage/src/tests/migrations/accountV3.test.ts
+++ b/suite-native/storage/src/tests/migrations/accountV3.test.ts
@@ -1,0 +1,83 @@
+import { deriveAccountTypeFromPaymentType, Account } from '../../migrations/account/v3';
+
+describe('deriveAccountTypeFromPaymentType', () => {
+    it('should derive account type correctly for each account', () => {
+        const oldAccounts = [
+            {
+                descriptor:
+                    'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
+                accountType: 'segwit',
+                symbol: 'btc',
+                networkType: 'bitcoin',
+            },
+            {
+                descriptor:
+                    "tr([5c9e228d/86'/0'/0']xpub6Bw885JisRbcKmowfBvMmCxaFHodKn1VpmRmctmJJoM8D4DzyP4qJv8ZdD9V9r3SSGjmK2KJEDnvLH6f1Q4HrobEvnCeKydNvf1eir3RHZk/<0;1>/*)",
+                accountType: 'taproot',
+                symbol: 'btc',
+                networkType: 'bitcoin',
+            },
+            {
+                descriptor:
+                    'ypub6XKbB5DSkq8Royg8isNtGktj6bmEfGJXDs83Ad5CZ5tpDV8QofwSWQFTWP2Pv24vNdrPhquehL7vRMvSTj2GpKv6UaTQCBKZALm6RJAmxG6',
+                accountType: 'segwitLegacy',
+                symbol: 'btc',
+                networkType: 'bitcoin',
+            },
+            {
+                descriptor:
+                    'xpub6BiVtCpG9fQPxnPmHXG8PhtzQdWC2Su4qWu6XW9tpWFYhxydCLJGrWBJZ5H6qTAHdPQ7pQhtpjiYZVZARo14qHiay2fvrX996oEP42u8wZy',
+                accountType: 'legacy',
+                symbol: 'btc',
+                networkType: 'bitcoin',
+            },
+            {
+                descriptor: 'ethereum-receive-address-mock',
+                accountType: 'normal',
+                symbol: 'eth',
+                networkType: 'ethereum',
+            },
+        ] as unknown as Account[];
+
+        const migratedAccounts = [
+            {
+                descriptor:
+                    'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
+                accountType: 'normal',
+                symbol: 'btc',
+                networkType: 'bitcoin',
+            },
+            {
+                descriptor:
+                    "tr([5c9e228d/86'/0'/0']xpub6Bw885JisRbcKmowfBvMmCxaFHodKn1VpmRmctmJJoM8D4DzyP4qJv8ZdD9V9r3SSGjmK2KJEDnvLH6f1Q4HrobEvnCeKydNvf1eir3RHZk/<0;1>/*)",
+                accountType: 'taproot',
+                symbol: 'btc',
+                networkType: 'bitcoin',
+            },
+            {
+                descriptor:
+                    'ypub6XKbB5DSkq8Royg8isNtGktj6bmEfGJXDs83Ad5CZ5tpDV8QofwSWQFTWP2Pv24vNdrPhquehL7vRMvSTj2GpKv6UaTQCBKZALm6RJAmxG6',
+                accountType: 'segwit',
+                symbol: 'btc',
+                networkType: 'bitcoin',
+            },
+            {
+                descriptor:
+                    'xpub6BiVtCpG9fQPxnPmHXG8PhtzQdWC2Su4qWu6XW9tpWFYhxydCLJGrWBJZ5H6qTAHdPQ7pQhtpjiYZVZARo14qHiay2fvrX996oEP42u8wZy',
+                accountType: 'legacy',
+                symbol: 'btc',
+                networkType: 'bitcoin',
+            },
+            {
+                descriptor: 'ethereum-receive-address-mock',
+                accountType: 'normal',
+                symbol: 'eth',
+                networkType: 'ethereum',
+            },
+        ];
+
+        const result = deriveAccountTypeFromPaymentType(oldAccounts);
+
+        expect(result).toEqual(migratedAccounts);
+    });
+});

--- a/suite-native/storage/tsconfig.json
+++ b/suite-native/storage/tsconfig.json
@@ -1,5 +1,13 @@
 {
     "extends": "../../tsconfig.json",
     "compilerOptions": { "outDir": "libDev" },
-    "references": []
+    "references": [
+        {
+            "path": "../../suite-common/wallet-config"
+        },
+        {
+            "path": "../../suite-common/wallet-types"
+        },
+        { "path": "../../packages/utxo-lib" }
+    ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7941,6 +7941,10 @@ __metadata:
   resolution: "@suite-native/storage@workspace:suite-native/storage"
   dependencies:
     "@reduxjs/toolkit": "npm:1.9.5"
+    "@suite-common/wallet-config": "workspace:*"
+    "@suite-common/wallet-types": "workspace:*"
+    "@trezor/utxo-lib": "workspace:*"
+    bs58: "npm:^5.0.0"
     expo-random: "npm:^13.1.1"
     expo-secure-store: "npm:^12.1.1"
     expo-splash-screen: "npm:0.18.1"


### PR DESCRIPTION
## Description
- add migration that fixes account type mismatch of old portfolio tracker accounts


Resolve #10488 
