### PR TITLE
style(suite): Fix backround color in Select

### DIFF
--- a/packages/components/src/components/form/Select/Select.tsx
+++ b/packages/components/src/components/form/Select/Select.tsx
@@ -18,6 +18,10 @@ const createSelectStyle = (theme: DefaultTheme): StylesConfig<Option, boolean> =
         ...base,
         zIndex: zIndices.modal /* Necessary to be visible inside a Modal */,
     }),
+    menu: base => ({
+        ...base,
+        background: theme.backgroundSurfaceElevation1,
+    }),
     option: (base, { isFocused }) => ({
         ...base,
         background: isFocused ? theme.backgroundSurfaceElevation0 : 'transparent',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

Before
<img width="914" alt="image" src="https://github.com/trezor/trezor-suite/assets/858321/78364cca-14e5-4f9e-bd5e-7ebc8630aea0">

But it worked fine in storybook 🤷‍♂️
<img width="1071" alt="image" src="https://github.com/trezor/trezor-suite/assets/858321/8b815b86-3555-452f-9faa-bca7569ccf84">


After
<img width="794" alt="image" src="https://github.com/trezor/trezor-suite/assets/858321/fc56bc99-40ea-438f-a91d-d4cfd2aab54a">


