### PR TITLE
Fix/10449 receive address mismatch

### DIFF
--- a/suite-native/discovery/src/discoveryThunks.ts
+++ b/suite-native/discovery/src/discoveryThunks.ts
@@ -181,11 +181,9 @@ const discoverNetworkBatchThunk = createThunk(
 
         const chunkBundle: Array<DiscoveryItem> = [];
 
-        A.makeWithIndex(batchSize, index => {
-            const accountPath = network.bip43Path.replace(
-                'i',
-                (lastDiscoveredAccountIndex + index).toString(),
-            );
+        A.makeWithIndex(batchSize, batchIndex => {
+            const index = lastDiscoveredAccountIndex + batchIndex;
+            const accountPath = network.bip43Path.replace('i', index.toString());
 
             const isAccountAlreadyDiscovered = selectIsAccountAlreadyDiscovered(getState(), {
                 deviceState,

--- a/suite-native/discovery/src/utils.ts
+++ b/suite-native/discovery/src/utils.ts
@@ -4,8 +4,7 @@ import { DiscoveryItem } from '@suite-common/wallet-types';
 import TrezorConnect from '@trezor/connect';
 
 import { DiscoveryDescriptorItem } from './types';
-// This function will be removed in one of the following PRs, when `TrezorConnect.getAccountDescriptor` method is ready.
-// see more: https://github.com/trezor/trezor-suite/issues/9658
+
 export const fetchBundleDescriptors = async (bundle: DiscoveryItem[]) => {
     const { success, payload } = await TrezorConnect.getAccountDescriptor({
         bundle,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- During batched discovery, wrong index was associated with an account and  later used in enhanceAddresses util to create account patch. It led to duplicated paths for different addresses.


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/10449

## Screenshots:
<img width="697" alt="image" src="https://github.com/trezor/trezor-suite/assets/3729633/3729a66a-0b91-42c1-8206-63d8b5585832">

