### PR TITLE
feat(suite): separate translation strings for TX_ID in case of RBF/Finalize

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
@@ -30,6 +30,7 @@ export type TransactionReviewOutputProps = {
     state: TransactionReviewStepIndicatorProps['state'];
     symbol: Network['symbol'];
     account: Account;
+    isRbf: boolean;
 } & ReviewOutput;
 
 export const TransactionReviewOutput = forwardRef<HTMLDivElement, TransactionReviewOutputProps>(
@@ -124,7 +125,7 @@ export const TransactionReviewOutput = forwardRef<HTMLDivElement, TransactionRev
             outputLines = [
                 {
                     id: 'txid',
-                    label: <Translation id="TR_TXID" />,
+                    label: <Translation id={props.isRbf ? 'TR_TXID_RBF' : 'TR_TXID'} />,
                     value: outputValue,
                     plainValue: true,
                 },

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
@@ -190,6 +190,7 @@ export const TransactionReviewOutputList = ({
                                     state={state}
                                     symbol={symbol}
                                     account={account}
+                                    isRbf={isRbfAction}
                                 />
                             );
                         })}

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -6640,6 +6640,10 @@ export default defineMessages({
         id: 'TR_TXID',
         defaultMessage: 'TX ID',
     },
+    TR_TXID_RBF: {
+        id: 'TR_TXID_RBF',
+        defaultMessage: 'Original TX ID to be replaced',
+    },
     TR_FINALIZE_TS_RBF_OFF_WARN: {
         id: 'TR_FINALIZE_TS_RBF_OFF_WARN',
         defaultMessage: 'Finalizing transaction will turn RBF <strong>OFF</strong>',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Separates the translation strings for TX_ID in case of RBF/Finalize

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/10260

## Screenshots:

![image](https://github.com/trezor/trezor-suite/assets/152899911/92a38ef6-3844-4efa-88b6-6fa2e4f20aa0)





