### PR TITLE
[WIP] connect - core in popup fallback

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -262,8 +262,8 @@ connect-popup:
   dependencies:
     - install
     - connect-web build
-  only:
-    <<: *run_everything_rules
+  # only:
+  #   <<: *run_everything_rules
 
 connect-popup manual:
   extends: .e2e connect-popup

--- a/packages/connect-common/src/index.ts
+++ b/packages/connect-common/src/index.ts
@@ -1,5 +1,3 @@
-import * as storage from './storage';
+export * from './storage';
 
 export * from './systemInfo';
-
-export { storage };

--- a/packages/connect-common/src/test/storage.test.ts
+++ b/packages/connect-common/src/test/storage.test.ts
@@ -1,15 +1,16 @@
 import { storage } from '..';
 
+const origin = 'foo.bar';
+
 describe('storage', () => {
     beforeEach(() => {
         window.localStorage?.clear();
     });
 
     test('window.localStorage', () => {
-        expect(storage.load().permissions).toBe(undefined);
-        storage.save(state => ({ ...state, permissions: [] }));
-        expect(storage.load().permissions).toStrictEqual([]);
-
+        expect(storage.load().origin[origin].permissions).toBe(undefined);
+        storage.save(state => ({ ...state }));
+        expect(storage.load().origin[origin].permissions).toStrictEqual([]);
         // @ts-expect-error
         expect(storage.load().random).toBe(undefined);
         storage.save(state => ({ ...state, random: {} }));
@@ -18,11 +19,10 @@ describe('storage', () => {
     });
 
     test('memoryStorage', () => {
-        expect(storage.load(true).permissions).toBe(undefined);
-        storage.save(state => ({ ...state, permissions: [] }), true);
-        expect(storage.load(true).permissions).toStrictEqual([]);
-        expect(storage.load().permissions).toBe(undefined);
-
+        expect(storage.load(true).origin[origin].permissions).toBe(undefined);
+        storage.save(state => ({ ...state }), true);
+        expect(storage.load(true).origin[origin].permissions).toStrictEqual([]);
+        expect(storage.load().origin[origin].permissions).toBe(undefined);
         // @ts-expect-error
         expect(storage.load(true).random).toBe(undefined);
         storage.save(state => ({ ...state, random: {} }), true);
@@ -36,9 +36,9 @@ describe('storage', () => {
         // @ts-expect-error
         global.window = undefined;
 
-        expect(storage.load().permissions).toBe(undefined);
+        expect(storage.load().origin[origin].permissions).toBe(undefined);
         storage.save(state => ({ ...state, permissions: [] }));
-        expect(storage.load().permissions).toStrictEqual([]);
+        expect(storage.load().origin[origin].permissions).toStrictEqual([]);
 
         // @ts-expect-error
         expect(storage.load().random).toBe(undefined);

--- a/packages/connect-common/tsconfig.lib.json
+++ b/packages/connect-common/tsconfig.lib.json
@@ -1,7 +1,6 @@
 {
     "extends": "../../tsconfig.lib.json",
     "compilerOptions": {
-        "target": "es5",
         "outDir": "./lib",
         "importHelpers": true,
         "esModuleInterop": false

--- a/packages/connect-iframe/src/index.ts
+++ b/packages/connect-iframe/src/index.ts
@@ -268,13 +268,16 @@ const filterDeviceEvent = (message: DeviceEvent) => {
     const features =
         'device' in message.payload ? message.payload.device.features : message.payload.features;
     if (features) {
-        const savedPermissions = storage.load().permissions || storage.load(true).permissions;
+        const origin = DataManager.getSettings('origin')!;
+
+        const savedPermissions =
+            storage.loadForOrigin(origin)?.permissions ||
+            storage.loadForOrigin(origin, true)?.permissions ||
+            [];
+
         if (savedPermissions) {
             const devicePermissions = savedPermissions.filter(
-                p =>
-                    p.origin === DataManager.getSettings('origin') &&
-                    p.type === 'read' &&
-                    p.device === features.device_id,
+                p => p.type === 'read' && p.device === features.device_id,
             );
             return devicePermissions.length > 0;
         }

--- a/packages/connect-popup/src/view/common.tsx
+++ b/packages/connect-popup/src/view/common.tsx
@@ -3,7 +3,7 @@
 import { POPUP, ERRORS, PopupInit, CoreMessage, createUiResponse } from '@trezor/connect';
 import { createRoot } from 'react-dom/client';
 
-import { ConnectUI, State } from '@trezor/connect-ui';
+import { ConnectUI, State, getDefaultState } from '@trezor/connect-ui';
 import { StyleSheetWrapper } from './react/StylesSheetWrapper';
 import { reactEventBus } from '@trezor/connect-ui/src/utils/eventBus';
 
@@ -11,7 +11,7 @@ export const header: HTMLElement = document.getElementsByTagName('header')[0];
 export const container: HTMLElement = document.getElementById('container')!;
 export const views: HTMLElement = document.getElementById('views')!;
 
-let state: State = {};
+let state: State = getDefaultState();
 
 export const setState = (newState: Partial<State>) => (state = { ...state, ...newState });
 export const getState = () => state;

--- a/packages/connect-popup/src/view/common.tsx
+++ b/packages/connect-popup/src/view/common.tsx
@@ -81,6 +81,8 @@ export const initMessageChannelWithIframe = async (
     payload: PopupInit['payload'],
     handler: (e: MessageEvent) => void,
 ) => {
+    throw ERRORS.TypedError('Popup_ConnectionMissing');
+
     // settings received from window.opener (POPUP.INIT) are not considered as safe (they could be injected/modified)
     // settings will be set later on, after POPUP.HANDSHAKE event from iframe
     const { settings, systemInfo, useBroadcastChannel } = payload;
@@ -186,6 +188,10 @@ export const postMessage = (message: CoreMessage) => {
 export const postMessageToParent = (message: CoreMessage) => {
     if (window.opener) {
         // post message to parent and wait for POPUP.INIT message
+        message.channel = {
+            here: 'popup',
+            peer: 'connect-web',
+        };
         window.opener.postMessage(message, '*');
     } else {
         // webextensions doesn't have "window.opener" reference and expect this message in "content-script" above popup [see: packages/connect-web/src/webextension/trezor-content-script.js]

--- a/packages/connect-ui/src/components/InfoPanel.tsx
+++ b/packages/connect-ui/src/components/InfoPanel.tsx
@@ -2,6 +2,10 @@ import { ReactNode } from 'react';
 
 import styled from 'styled-components';
 
+import { Button } from '@trezor/components';
+
+import { State } from '../types';
+
 const Aside = styled.aside`
     display: flex;
     flex-flow: column;
@@ -70,13 +74,28 @@ interface InfoPanelProps {
     origin?: string;
     hostLabel?: string;
     topSlot?: ReactNode;
+    preferredDevice?: State['preferredDevice'];
+    onEjectDevice?: () => void;
 }
 
-export const InfoPanel = ({ method, origin, hostLabel, topSlot }: InfoPanelProps) => (
+export const InfoPanel = ({
+    method,
+    origin,
+    topSlot,
+    hostLabel,
+    preferredDevice,
+    onEjectDevice,
+}: InfoPanelProps) => (
     <>
         <Aside data-test="@info-panel">
             {/*  notifications appear hear */}
             {topSlot && topSlot}
+            {preferredDevice && onEjectDevice && (
+                <>
+                    <div>zpreferovany device: {JSON.stringify({ preferredDevice })}</div>
+                    <Button onClick={onEjectDevice}>eject</Button>
+                </>
+            )}
 
             <MainSlot>
                 <Header>

--- a/packages/connect-ui/src/index.tsx
+++ b/packages/connect-ui/src/index.tsx
@@ -8,6 +8,7 @@ import {
     UI_REQUEST,
     POPUP,
     createPopupMessage,
+    createUiResponse,
 } from '@trezor/connect';
 import { storage, OriginBoundState } from '@trezor/connect-common';
 
@@ -162,6 +163,12 @@ export const ConnectUI = ({ postMessage, clearLegacyView }: ConnectUIProps) => {
                             origin={state?.settings?.origin}
                             hostLabel={state?.settings?.hostLabel}
                             topSlot={Object.values(Notifications)}
+                            preferredDevice={state?.preferredDevice}
+                            onEjectDevice={() => {
+                                postMessage(createUiResponse(UI.EJECT_DEVICE));
+                                postMessage({ type: POPUP.CLOSE_WINDOW });
+                                window.close();
+                            }}
                         />
                         {Component && (
                             <div

--- a/packages/connect-ui/src/types.ts
+++ b/packages/connect-ui/src/types.ts
@@ -1,5 +1,6 @@
 import { PopupHandshake, PopupMethodInfo, IFrameLoaded } from '@trezor/connect';
 import type { Core } from '@trezor/connect/lib/core';
+import type { OriginBoundState } from '@trezor/connect-common';
 
 export type State = Partial<PopupHandshake['payload']> &
     Partial<PopupMethodInfo['payload']> &
@@ -7,7 +8,8 @@ export type State = Partial<PopupHandshake['payload']> &
         iframe?: Window;
         broadcast?: BroadcastChannel;
         core?: Core;
-        // preferred device will appear here
-    };
+    } & Partial<OriginBoundState>;
 
-export const getDefaultState = (): State => ({});
+export const getDefaultState = (): State => ({
+    permissions: [],
+});

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -40,6 +40,7 @@
     },
     "dependencies": {
         "@trezor/connect": "workspace:*",
+        "@trezor/connect-webextension": "workspace:*",
         "@trezor/utils": "workspace:*",
         "events": "^3.3.0"
     },

--- a/packages/connect-web/src/channels/window-window.ts
+++ b/packages/connect-web/src/channels/window-window.ts
@@ -1,0 +1,38 @@
+import {
+    AbstractMessageChannel,
+    AbstractMessageChannelConstructorParams,
+    // Message,
+} from '@trezor/connect-common/src/messageChannel/abstract';
+
+/**
+ * Communication channel between:
+ * - here: chrome message port (in service worker)
+ * - peer: window.onMessage in trezor-content-script
+ */
+
+export class WindowWindowChannel<
+    IncomingMessages extends { type: string },
+> extends AbstractMessageChannel<IncomingMessages> {
+    constructor({
+        // name,
+        channel,
+    }: Pick<AbstractMessageChannelConstructorParams, 'channel'> & { name: string }) {
+        super({
+            channel,
+            sendFn: (message: any) => {
+                console.log('window window sending', message)
+                window.postMessage(message);
+            },
+        });
+
+        window.addEventListener('message', (message: MessageEvent<IncomingMessages>) => {
+            console.log('window window message received', message);
+            // @ts-ignore
+            this.onMessage(message);
+        });
+    }
+
+    disconnect() {
+        // window.removeEventListener('message', this.onMessage);
+    }
+}

--- a/packages/connect-web/src/popup/index.ts
+++ b/packages/connect-web/src/popup/index.ts
@@ -285,6 +285,8 @@ export class PopupManager extends EventEmitter {
             });
         } else if (data.type === POPUP.CANCEL_POPUP_REQUEST || data.type === UI.CLOSE_UI_WINDOW) {
             this.clear(false);
+        } else if (data.type === POPUP.CORE_LOADED) {
+            // handshakePromise.resolve();
         }
     }
 

--- a/packages/connect-web/tsconfig.json
+++ b/packages/connect-web/tsconfig.json
@@ -20,6 +20,7 @@
     ],
     "references": [
         { "path": "../connect" },
+        { "path": "../connect-webextension" },
         { "path": "../utils" }
     ]
 }

--- a/packages/connect-webextension/src/popup.ts
+++ b/packages/connect-webextension/src/popup.ts
@@ -5,7 +5,7 @@ import { PopupEventMessage, ConnectSettings } from '@trezor/connect/lib/exports'
 import { getOrigin } from '@trezor/connect/lib/utils/urlUtils';
 import { Log } from '@trezor/connect/lib/utils/debug';
 
-import { ServiceWorkerWindowChannel } from './channels/serviceworker-window';
+import { AbstractMessageChannel } from '@trezor/connect-common/src/messageChannel/abstract';
 
 export class PopupManager extends EventEmitter {
     popupWindow: chrome.tabs.Tab | undefined;
@@ -16,25 +16,21 @@ export class PopupManager extends EventEmitter {
 
     locked = false;
 
-    channel: ServiceWorkerWindowChannel<PopupEventMessage>;
+    channel: AbstractMessageChannel<PopupEventMessage>;
 
     extensionTabId = 0;
 
     logger: Log;
 
-    constructor(settings: ConnectSettings, { logger }: { logger: Log }) {
+    constructor(
+        settings: ConnectSettings,
+        { logger, channel }: { logger: Log; channel: AbstractMessageChannel<any> },
+    ) {
         super();
         this.settings = settings;
         this.origin = getOrigin(settings.popupSrc);
         this.logger = logger;
-        this.channel = new ServiceWorkerWindowChannel<PopupEventMessage>({
-            name: 'trezor-connect',
-            channel: {
-                here: '@trezor/connect-webextension',
-                peer: '@trezor/connect-content-script',
-            },
-            logger,
-        });
+        this.channel = channel;
         this.channel.init();
     }
 

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -178,33 +178,34 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
         return false;
     }
 
-    checkPermissions() {
-        const savedPermissions = storage.load().permissions;
+    private getOriginPermissions() {
+        const origin = DataManager.getSettings('origin');
+        if (!origin) {
+            throw new Error('origin is not set');
+        }
 
+        return storage.loadForOrigin(origin)?.permissions || [];
+    }
+
+    checkPermissions() {
+        const originPermissions = this.getOriginPermissions();
         let notPermitted = [...this.requiredPermissions];
-        if (savedPermissions) {
-            // find permissions for this origin
-            const originPermissions = savedPermissions.filter(
-                p => p.origin === DataManager.getSettings('origin'),
-            );
-            if (originPermissions.length > 0) {
-                // check if permission was granted
-                notPermitted = notPermitted.filter(np => {
-                    const granted = originPermissions.find(
-                        p => p.type === np && p.device === this.device.features.device_id,
-                    );
-                    return !granted;
-                });
-            }
+        if (originPermissions.length > 0) {
+            // check if permission was granted
+            notPermitted = notPermitted.filter(np => {
+                const granted = originPermissions.find(
+                    p => p.type === np && p.device === this.device.features.device_id,
+                );
+                return !granted;
+            });
         }
         this.requiredPermissions = notPermitted;
     }
 
     savePermissions(temporary = false) {
-        const savedPermissions = storage.load(temporary).permissions || [];
+        const originPermissions = this.getOriginPermissions();
 
         let permissionsToSave = this.requiredPermissions.map(p => ({
-            origin: DataManager.getSettings('origin'),
             type: p,
             device: this.device.features.device_id || undefined,
         }));
@@ -213,21 +214,14 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
         // if so, emit "device_connect" event because this wasn't send before
         let emitEvent = false;
         if (this.requiredPermissions.indexOf('read') >= 0) {
-            const wasAlreadyGranted = savedPermissions.filter(
-                p =>
-                    p.origin === DataManager.getSettings('origin') &&
-                    p.type === 'read' &&
-                    p.device === this.device.features.device_id,
+            const wasAlreadyGranted = originPermissions.filter(
+                p => p.type === 'read' && p.device === this.device.features.device_id,
             );
             if (wasAlreadyGranted.length < 1) {
                 emitEvent = true;
             }
         }
 
-        // find permissions for this origin
-        const originPermissions = savedPermissions.filter(
-            p => p.origin === DataManager.getSettings('origin'),
-        );
         if (originPermissions.length > 0) {
             permissionsToSave = permissionsToSave.filter(p2s => {
                 const granted = originPermissions.find(
@@ -237,10 +231,19 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
             });
         }
 
+        const origin = DataManager.getSettings('origin')!;
         storage.save(
             state => ({
                 ...state,
-                permissions: savedPermissions.concat(permissionsToSave),
+                origin: {
+                    ...state.origin,
+                    [origin]: {
+                        permissions: [
+                            ...(state.origin[origin]?.permissions || []),
+                            ...permissionsToSave,
+                        ],
+                    },
+                },
             }),
             temporary,
         );

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -179,6 +179,19 @@ export const handleMessage = (message: CoreMessage) => {
             }
             break;
         }
+        // todo: not sure about name UI group
+        case UI.EJECT_DEVICE: {
+            const origin = DataManager.getSettings('origin');
+            if (!origin) {
+                return;
+            }
+            storage.save(data => {
+                delete data.origin[origin]?.preferredDevice;
+                return data;
+            });
+
+            break;
+        }
 
         // message from index
         case IFRAME.CALL:

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -3,6 +3,7 @@ import EventEmitter from 'events';
 
 import { TRANSPORT, TRANSPORT_ERROR } from '@trezor/transport';
 import { createDeferred, Deferred } from '@trezor/utils';
+import { storage } from '@trezor/connect-common';
 
 import { DataManager } from '../data/DataManager';
 import { DeviceList } from '../device/DeviceList';
@@ -34,14 +35,13 @@ import { initLog, enableLog, setLogWriter, LogWriter } from '../utils/debug';
 import { dispose as disposeBackend } from '../backend/BlockchainLink';
 import { InteractionTimeout } from '../utils/interactionTimeout';
 import type { DeviceEvents, Device } from '../device/Device';
-import type { ConnectSettings, CommonParams, Device as DeviceTyped } from '../types';
+import type { ConnectSettings, Device as DeviceTyped } from '../types';
 
 // Public variables
 let _core: Core; // Class with event emitter
 let _deviceList: DeviceList | undefined; // Instance of DeviceList
 let _popupPromise: Deferred<void> | undefined; // Waiting for popup handshake
 const _uiPromises: AnyUiPromise[] = []; // Waiting for ui response
-let _preferredDevice: CommonParams['device'];
 const _callMethods: AbstractMethod<any>[] = []; // generic type is irrelevant. only common functions are called at this level
 let _interactionTimeout: InteractionTimeout;
 let _deviceListInitTimeout: ReturnType<typeof setTimeout> | undefined;
@@ -261,7 +261,15 @@ const initDevice = async (method: AbstractMethod<any>) => {
             if (uiPromise) {
                 const { payload } = await uiPromise.promise;
                 if (payload.remember) {
-                    _preferredDevice = payload.device;
+                    const { path, state } = payload.device;
+                    storage.save(store => {
+                        store.origin[origin] = {
+                            ...store.origin[origin],
+                            preferredDevice: { path, state },
+                        };
+
+                        return store;
+                    });
                 }
                 device = _deviceList.getDevice(payload.device.path);
             }
@@ -292,9 +300,11 @@ export const onCall = async (message: CoreMessage) => {
     const responseID = message.id;
     const trustedHost = DataManager.getSettings('trustedHost');
     const isUsingPopup = DataManager.getSettings('popup');
+    const origin = DataManager.getSettings('origin')!;
 
-    if (_preferredDevice && !message.payload.device) {
-        message.payload.device = _preferredDevice;
+    const { preferredDevice } = storage.loadForOrigin(origin) || {};
+    if (preferredDevice && !message.payload.device) {
+        message.payload.device = preferredDevice;
     }
 
     // find method and parse incoming params

--- a/packages/connect/src/events/ui-response.ts
+++ b/packages/connect/src/events/ui-response.ts
@@ -19,6 +19,7 @@ export const UI_RESPONSE = {
     INVALID_PASSPHRASE_ACTION: 'ui-invalid_passphrase_action',
     CHANGE_SETTINGS: 'ui-change_settings',
     LOGIN_CHALLENGE_RESPONSE: 'ui-login_challenge_response',
+    EJECT_DEVICE: 'ui-eject_device',
 } as const;
 
 export interface UiResponsePopupHandshake {
@@ -100,6 +101,11 @@ export interface UiResponseLoginChallenge {
     };
 }
 
+export interface UiResponseEjectDevice {
+    type: typeof UI_RESPONSE.EJECT_DEVICE;
+    payload: undefined;
+}
+
 export type UiResponseEvent =
     | UiResponsePopupHandshake
     | UiResponsePermission
@@ -111,7 +117,8 @@ export type UiResponseEvent =
     | UiResponsePassphraseAction
     | UiResponseAccount
     | UiResponseFee
-    | UiResponseLoginChallenge;
+    | UiResponseLoginChallenge
+    | UiResponseEjectDevice;
 
 export type UiResponseMessage = UiResponseEvent & { event: typeof UI_EVENT };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8648,6 +8648,7 @@ __metadata:
     "@playwright/browser-webkit": "npm:^1.39.0"
     "@playwright/test": "npm:^1.39.0"
     "@trezor/connect": "workspace:*"
+    "@trezor/connect-webextension": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@types/chrome": "npm:^0.0.250"
     "@types/w3c-web-usb": "npm:^1.0.9"
@@ -8669,7 +8670,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/connect-webextension@workspace:packages/connect-webextension":
+"@trezor/connect-webextension@workspace:*, @trezor/connect-webextension@workspace:packages/connect-webextension":
   version: 0.0.0-use.local
   resolution: "@trezor/connect-webextension@workspace:packages/connect-webextension"
   dependencies:


### PR DESCRIPTION
based on #9790

the goal here is:
- to handle situations where for some reason iframe can't be loaded. loading connect core inside iframe gives superior UX compared  to loading it in popup but in some cases it might not be available (for example browsers tightening their security policies) so it makes sense to have a fallback ready. 
- also running core in popup is the only option how to make connect on 3rd party work with webusb directly without bridge. we maybe want to give implementators an option to opt-in for "core in popup" variant. ?