### PR TITLE
chore(connect): meditating build size

### DIFF
--- a/packages/connect-web/scripts/check-inline-build-size.sh
+++ b/packages/connect-web/scripts/check-inline-build-size.sh
@@ -12,7 +12,10 @@ SIZE_S=$(du -s "$parent_path/../build/trezor-connect.js" | cut -f1)
 # at time of creating this script size was 320
 # if you have considerably more, there is a chance that you accidentally included
 # parts of code that shouldn't be in this build.
-if [[ "$SIZE_S" -gt 400 ]]
+echo "size: $SIZE_S"
+# todo: size should be smaller, it grew after https://github.com/trezor/trezor-suite/pull/10280 was merged
+# plan is to decresase it https://github.com/trezor/trezor-suite/issues/10554
+if [[ "$SIZE_S" -gt 610 ]]
 then
     echo "suspiciously large build detected!"
     exit 1;

--- a/packages/connect-web/src/iframe/index.ts
+++ b/packages/connect-web/src/iframe/index.ts
@@ -1,6 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/iframe/builder.js
 
-import { createDeferred, Deferred } from '@trezor/utils';
+import { createDeferred, Deferred } from '@trezor/utils/lib/createDeferred';
 import { IFRAME, UI_EVENT, ERRORS, ConnectSettings } from '@trezor/connect/lib/exports';
 import { getOrigin } from '@trezor/connect/lib/utils/urlUtils';
 import { setLogWriter, LogMessage, LogWriter } from '@trezor/connect/lib/utils/debug';

--- a/packages/connect-web/src/popup/index.ts
+++ b/packages/connect-web/src/popup/index.ts
@@ -1,7 +1,7 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/popup/PopupManager.js
 
 import EventEmitter from 'events';
-import { createDeferred, Deferred } from '@trezor/utils';
+import { createDeferred, Deferred } from '@trezor/utils/lib/createDeferred';
 import {
     POPUP,
     IFRAME,

--- a/packages/connect/e2e/__fixtures__/ethereumSignMessage.ts
+++ b/packages/connect/e2e/__fixtures__/ethereumSignMessage.ts
@@ -1,4 +1,4 @@
-import { arrayPartition } from '@trezor/utils';
+import { arrayPartition } from '@trezor/utils/lib/arrayPartition';
 /* eslint-disable @typescript-eslint/prefer-ts-expect-error */
 // @ts-ignore
 import commonFixtures from '../../../../submodules/trezor-common/tests/fixtures/ethereum/signmessage.json';

--- a/packages/connect/src/api/bitcoin/refTx.ts
+++ b/packages/connect/src/api/bitcoin/refTx.ts
@@ -6,7 +6,7 @@ import {
     Transaction as BitcoinJsTransaction,
     Network,
 } from '@trezor/utxo-lib';
-import { bufferUtils } from '@trezor/utils';
+import * as bufferUtils from '@trezor/utils/lib/bufferUtils';
 import { getHDPath, getScriptType, getOutputScriptType } from '../../utils/pathUtils';
 import { TypedError } from '../../constants/errors';
 import type {

--- a/packages/connect/src/api/common/paramsValidator.ts
+++ b/packages/connect/src/api/common/paramsValidator.ts
@@ -1,5 +1,5 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/helpers/paramsValidator.js
-import { versionUtils } from '@trezor/utils';
+import * as versionUtils from '@trezor/utils/lib/versionUtils';
 
 import { ERRORS } from '../../constants';
 import { fromHardened } from '../../utils/pathUtils';

--- a/packages/connect/src/api/firmware/getBinary.ts
+++ b/packages/connect/src/api/firmware/getBinary.ts
@@ -1,4 +1,4 @@
-import { versionUtils } from '@trezor/utils';
+import * as versionUtils from '@trezor/utils/lib/versionUtils';
 
 import { httpRequest } from '../../utils/assets';
 import { isStrictFeatures } from '../../utils/firmwareUtils';

--- a/packages/connect/src/api/firmware/modifyFirmware.ts
+++ b/packages/connect/src/api/firmware/modifyFirmware.ts
@@ -1,4 +1,4 @@
-import { versionUtils } from '@trezor/utils';
+import * as versionUtils from '@trezor/utils/lib/versionUtils';
 
 import type { Features } from '../../types';
 

--- a/packages/connect/src/api/firmware/verifyAuthenticityProof.ts
+++ b/packages/connect/src/api/firmware/verifyAuthenticityProof.ts
@@ -1,5 +1,5 @@
 import * as crypto from 'crypto';
-import { bufferUtils } from '@trezor/utils';
+import * as bufferUtils from '@trezor/utils/lib/bufferUtils';
 
 import { PROTO } from '../../constants';
 import { DeviceAuthenticityConfig } from '../../data/deviceAuthenticityConfig';

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -1,5 +1,6 @@
 import { storage } from '@trezor/connect-common';
-import { Deferred, versionUtils } from '@trezor/utils';
+import * as versionUtils from '@trezor/utils/lib/versionUtils';
+import { Deferred } from '@trezor/utils/lib/createDeferred';
 import { DataManager } from '../data/DataManager';
 import { ERRORS, NETWORK } from '../constants';
 import {

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -2,7 +2,7 @@
 import EventEmitter from 'events';
 
 import { TRANSPORT, TRANSPORT_ERROR } from '@trezor/transport';
-import { createDeferred, Deferred } from '@trezor/utils';
+import { createDeferred, Deferred } from '@trezor/utils/lib/createDeferred';
 
 import { DataManager } from '../data/DataManager';
 import { DeviceList } from '../device/DeviceList';

--- a/packages/connect/src/data/coinInfo.ts
+++ b/packages/connect/src/data/coinInfo.ts
@@ -1,5 +1,5 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/data/CoinInfo.js
-import { cloneObject } from '@trezor/utils';
+import { cloneObject } from '@trezor/utils/lib/cloneObject';
 import { getBitcoinFeeLevels, getEthereumFeeLevels, getMiscFeeLevels } from './defaultFeeLevels';
 import { ERRORS } from '../constants';
 import { toHardened, fromHardened } from '../utils/pathUtils';

--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -1,6 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/data/FirmwareInfo.js
 
-import { versionUtils } from '@trezor/utils';
+import * as versionUtils from '@trezor/utils/lib/versionUtils';
 import {
     filterSafeListByFirmware,
     filterSafeListByBootloader,

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -1,6 +1,7 @@
 // original file https://github.com/trezor/connect/blob/develop/src/js/device/Device.js
 import { TypedEmitter } from '@trezor/utils/lib/typedEventEmitter';
-import { createDeferred, Deferred, versionUtils } from '@trezor/utils';
+import { createDeferred, Deferred } from '@trezor/utils/lib/createDeferred';
+import * as versionUtils from '@trezor/utils/lib/versionUtils';
 import { TransportProtocol, v1 as v1Protocol, bridge as bridgeProtocol } from '@trezor/protocol';
 import { DeviceCommands } from './DeviceCommands';
 import { PROTO, ERRORS, NETWORK } from '../constants';

--- a/packages/connect/src/device/DeviceCommands.ts
+++ b/packages/connect/src/device/DeviceCommands.ts
@@ -3,7 +3,7 @@
 import { randomBytes } from 'crypto';
 import { Transport } from '@trezor/transport';
 import * as Messages from '@trezor/protobuf/lib/messages-schema';
-import { versionUtils } from '@trezor/utils';
+import * as versionUtils from '@trezor/utils/lib/versionUtils';
 import { ERRORS, NETWORK } from '../constants';
 import { DEVICE } from '../events';
 import * as hdnodeUtils from '../utils/hdnodeUtils';

--- a/packages/connect/src/events/ui-promise.ts
+++ b/packages/connect/src/events/ui-promise.ts
@@ -1,4 +1,4 @@
-import type { Deferred } from '@trezor/utils';
+import type { Deferred } from '@trezor/utils/lib/createDeferred';
 import type { DEVICE } from './device';
 import type { Device } from '../device/Device';
 import type { UiResponseEvent } from './ui-response';

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -1,6 +1,6 @@
 import EventEmitter from 'events';
 
-import { createDeferred, Deferred } from '@trezor/utils';
+import { createDeferred, Deferred } from '@trezor/utils/lib/createDeferred';
 import { Core, initCore, initTransport } from './core';
 import { factory } from './factory';
 import { parseConnectSettings } from './data/connectSettings';

--- a/packages/connect/src/utils/deviceFeaturesUtils.ts
+++ b/packages/connect/src/utils/deviceFeaturesUtils.ts
@@ -1,4 +1,4 @@
-import { versionUtils } from '@trezor/utils';
+import * as versionUtils from '@trezor/utils/lib/versionUtils';
 import { PROTO } from '../constants';
 import { config } from '../data/config';
 import { Features, CoinInfo, UnavailableCapabilities, DeviceModelInternal } from '../types';

--- a/packages/connect/src/utils/firmwareUtils.ts
+++ b/packages/connect/src/utils/firmwareUtils.ts
@@ -1,4 +1,4 @@
-import { versionUtils } from '@trezor/utils';
+import * as versionUtils from '@trezor/utils/lib/versionUtils';
 import type { Features, StrictFeatures, FirmwareRelease, VersionArray } from '../types';
 
 export const isStrictFeatures = (extFeatures: Features): extFeatures is StrictFeatures =>

--- a/packages/connect/src/utils/urlUtils.ts
+++ b/packages/connect/src/utils/urlUtils.ts
@@ -1,6 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/utils/urlUtils.js
 
-import { urlToOnion } from '@trezor/utils';
+import { urlToOnion } from '@trezor/utils/lib/urlToOnion';
 
 export const getOrigin = (url: unknown) => {
     if (typeof url !== 'string') return 'unknown';


### PR DESCRIPTION
`yarn workspace @trezor/connect-web build:inline`
this produces a build file in `packages/connect-web/build/trezor-connect.js` (using this [webpack](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-web/webpack/inline.webpack.config.ts#L0-L1))

I noted that there is entire content of @trezor/utils package bundled inside this lib although majority of its exports are not used. Before this change size of `trezor-connect.js` is 624KB, after this change 600KB

This can be easily mitigated by what I did in 83fc88adb9575afa7ac3bb80fb1b41c5dd458be2 but this is something we don't want to do manually. We want to delegate it to some clever buildshaking mechanism which I have no idea about. Maybe @Nodonisko could help please? 

Size grew considerably after #10280 was merged (from 167 KB to 624KB) because  build now contains entire API schema description. 

### Follow up 
https://github.com/trezor/trezor-suite/issues/10554

definitions should not be part of trezor-connect.js at all, because they are not used in this package. here we in fact only need types. but since we are inferring types from definition, is it even possible to separate it somehow? 

Likely the solution would be as follows:
- stop merging protobuf types into one file (`messages-schema.ts`), lets have something like "proto-bitcoin", "proto-eth".
- introduce plug-in architecture adding packages for specific coins  (`@trezor/connect-eth`, `@trezor/connect-ada`,`...`). Whoever wants to use coin specific API needs to install a new package first.
- change `exports.ts` so that it does not re-export all types and schemas
https://github.com/trezor/trezor-suite/blob/31ae4e691f9e66954c7d1813a2d91d574e950f1e/packages/connect/src/exports.ts#L1-L3
https://github.com/trezor/trezor-suite/blob/31ae4e691f9e66954c7d1813a2d91d574e950f1e/packages/connect/src/types/index.ts#L1-L18


