### PR TITLE
Fix/connect deps check

### DIFF
--- a/ci/npm-deploy.yml
+++ b/ci/npm-deploy.yml
@@ -18,6 +18,7 @@
             "env-utils",
             "protocol",
             "protobuf",
+            "schema-utils",
           ]
 
 .packages_matrix_connect: &packages_matrix_connect

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.12",
     "license": "See LICENSE.md in repo root",
     "sideEffects": false,
-    "main": "src/index",
+    "main": "lib/index",
     "files": [
         "lib/",
         "!**/*.map"

--- a/packages/blockchain-link-utils/src/solana.ts
+++ b/packages/blockchain-link-utils/src/solana.ts
@@ -1,7 +1,7 @@
 import { A, D, F, pipe } from '@mobily/ts-belt';
 import BigNumber from 'bignumber.js';
-import { Target, TokenTransfer, Transaction } from 'packages/blockchain-link-types/lib';
 
+import { Target, TokenTransfer, Transaction } from '@trezor/blockchain-link-types/lib';
 import { arrayPartition } from '@trezor/utils';
 import type {
     AccountInfo,

--- a/packages/blockchain-link-utils/src/tests/solana.test.ts
+++ b/packages/blockchain-link-utils/src/tests/solana.test.ts
@@ -1,7 +1,6 @@
 import { ParsedTransactionWithMeta } from '@solana/web3.js';
-import { TokenTransfer } from 'packages/blockchain-link-types/lib';
 
-import { Transaction } from '@trezor/blockchain-link-types';
+import { TokenTransfer, Transaction } from '@trezor/blockchain-link-types/lib';
 import { SolanaValidParsedTxWithMeta } from '@trezor/blockchain-link-types/lib/solana';
 
 import {

--- a/packages/connect-web/scripts/check-inline-build-size.sh
+++ b/packages/connect-web/scripts/check-inline-build-size.sh
@@ -12,7 +12,10 @@ SIZE_S=$(du -s "$parent_path/../build/trezor-connect.js" | cut -f1)
 # at time of creating this script size was 320
 # if you have considerably more, there is a chance that you accidentally included
 # parts of code that shouldn't be in this build.
-if [[ "$SIZE_S" -gt 400 ]]
+echo "size: $SIZE_S"
+# todo: size should be smaller, it grew after https://github.com/trezor/trezor-suite/pull/10280 was merged
+# plan is to decresase it https://github.com/trezor/trezor-suite/issues/10554
+if [[ "$SIZE_S" -gt 610 ]]
 then
     echo "suspiciously large build detected!"
     exit 1;

--- a/packages/connect-web/src/iframe/index.ts
+++ b/packages/connect-web/src/iframe/index.ts
@@ -1,6 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/iframe/builder.js
 
-import { createDeferred, Deferred } from '@trezor/utils';
+import { createDeferred, Deferred } from '@trezor/utils/lib/createDeferred';
 import { IFRAME, UI_EVENT, ERRORS, ConnectSettings } from '@trezor/connect/lib/exports';
 import { getOrigin } from '@trezor/connect/lib/utils/urlUtils';
 import { setLogWriter, LogMessage, LogWriter } from '@trezor/connect/lib/utils/debug';

--- a/packages/connect-web/src/popup/index.ts
+++ b/packages/connect-web/src/popup/index.ts
@@ -1,7 +1,7 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/popup/PopupManager.js
 
 import EventEmitter from 'events';
-import { createDeferred, Deferred } from '@trezor/utils';
+import { createDeferred, Deferred } from '@trezor/utils/lib/createDeferred';
 import {
     POPUP,
     IFRAME,

--- a/packages/connect/e2e/__fixtures__/ethereumSignMessage.ts
+++ b/packages/connect/e2e/__fixtures__/ethereumSignMessage.ts
@@ -1,4 +1,4 @@
-import { arrayPartition } from '@trezor/utils';
+import { arrayPartition } from '@trezor/utils/lib/arrayPartition';
 /* eslint-disable @typescript-eslint/prefer-ts-expect-error */
 // @ts-ignore
 import commonFixtures from '../../../../submodules/trezor-common/tests/fixtures/ethereum/signmessage.json';

--- a/packages/connect/e2e/test-yarn-install.sh
+++ b/packages/connect/e2e/test-yarn-install.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-trap "cd .. && rm -rf connect-implementation" EXIT
+# trap "cd .. && rm -rf connect-implementation" EXIT
 
 npm --version
 node --version
@@ -14,5 +14,12 @@ mkdir connect-implementation
 cd connect-implementation
 npm init -y
 touch yarn.lock
+
+# install connect package
 yarn add @trezor/connect
-yarn add @trezor/connect-web
+# prepare minimal typescript implementation
+echo import TrezorConnect from \"@trezor/connect\" > index.ts
+
+# compile with typescript
+yarn add typescript@5.3.2
+yarn tsc ./index.ts --types node

--- a/packages/connect/src/api/bitcoin/refTx.ts
+++ b/packages/connect/src/api/bitcoin/refTx.ts
@@ -6,7 +6,7 @@ import {
     Transaction as BitcoinJsTransaction,
     Network,
 } from '@trezor/utxo-lib';
-import { bufferUtils } from '@trezor/utils';
+import * as bufferUtils from '@trezor/utils/lib/bufferUtils';
 import { getHDPath, getScriptType, getOutputScriptType } from '../../utils/pathUtils';
 import { TypedError } from '../../constants/errors';
 import type {

--- a/packages/connect/src/api/common/paramsValidator.ts
+++ b/packages/connect/src/api/common/paramsValidator.ts
@@ -1,5 +1,5 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/helpers/paramsValidator.js
-import { versionUtils } from '@trezor/utils';
+import * as versionUtils from '@trezor/utils/lib/versionUtils';
 
 import { ERRORS } from '../../constants';
 import { fromHardened } from '../../utils/pathUtils';

--- a/packages/connect/src/api/firmware/getBinary.ts
+++ b/packages/connect/src/api/firmware/getBinary.ts
@@ -1,4 +1,4 @@
-import { versionUtils } from '@trezor/utils';
+import * as versionUtils from '@trezor/utils/lib/versionUtils';
 
 import { httpRequest } from '../../utils/assets';
 import { isStrictFeatures } from '../../utils/firmwareUtils';

--- a/packages/connect/src/api/firmware/modifyFirmware.ts
+++ b/packages/connect/src/api/firmware/modifyFirmware.ts
@@ -1,4 +1,4 @@
-import { versionUtils } from '@trezor/utils';
+import * as versionUtils from '@trezor/utils/lib/versionUtils';
 
 import type { Features } from '../../types';
 

--- a/packages/connect/src/api/firmware/verifyAuthenticityProof.ts
+++ b/packages/connect/src/api/firmware/verifyAuthenticityProof.ts
@@ -1,5 +1,5 @@
 import * as crypto from 'crypto';
-import { bufferUtils } from '@trezor/utils';
+import * as bufferUtils from '@trezor/utils/lib/bufferUtils';
 
 import { PROTO } from '../../constants';
 import { DeviceAuthenticityConfig } from '../../data/deviceAuthenticityConfig';

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -1,5 +1,6 @@
 import { storage } from '@trezor/connect-common';
-import { Deferred, versionUtils } from '@trezor/utils';
+import * as versionUtils from '@trezor/utils/lib/versionUtils';
+import { Deferred } from '@trezor/utils/lib/createDeferred';
 import { DataManager } from '../data/DataManager';
 import { ERRORS, NETWORK } from '../constants';
 import {

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -2,7 +2,7 @@
 import EventEmitter from 'events';
 
 import { TRANSPORT, TRANSPORT_ERROR } from '@trezor/transport';
-import { createDeferred, Deferred } from '@trezor/utils';
+import { createDeferred, Deferred } from '@trezor/utils/lib/createDeferred';
 
 import { DataManager } from '../data/DataManager';
 import { DeviceList } from '../device/DeviceList';

--- a/packages/connect/src/data/coinInfo.ts
+++ b/packages/connect/src/data/coinInfo.ts
@@ -1,5 +1,5 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/data/CoinInfo.js
-import { cloneObject } from '@trezor/utils';
+import { cloneObject } from '@trezor/utils/lib/cloneObject';
 import { getBitcoinFeeLevels, getEthereumFeeLevels, getMiscFeeLevels } from './defaultFeeLevels';
 import { ERRORS } from '../constants';
 import { toHardened, fromHardened } from '../utils/pathUtils';

--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -1,6 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/data/FirmwareInfo.js
 
-import { versionUtils } from '@trezor/utils';
+import * as versionUtils from '@trezor/utils/lib/versionUtils';
 import {
     filterSafeListByFirmware,
     filterSafeListByBootloader,

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -1,6 +1,7 @@
 // original file https://github.com/trezor/connect/blob/develop/src/js/device/Device.js
 import { TypedEmitter } from '@trezor/utils/lib/typedEventEmitter';
-import { createDeferred, Deferred, versionUtils } from '@trezor/utils';
+import { createDeferred, Deferred } from '@trezor/utils/lib/createDeferred';
+import * as versionUtils from '@trezor/utils/lib/versionUtils';
 import { TransportProtocol, v1 as v1Protocol, bridge as bridgeProtocol } from '@trezor/protocol';
 import { DeviceCommands } from './DeviceCommands';
 import { PROTO, ERRORS, NETWORK } from '../constants';

--- a/packages/connect/src/device/DeviceCommands.ts
+++ b/packages/connect/src/device/DeviceCommands.ts
@@ -3,7 +3,7 @@
 import { randomBytes } from 'crypto';
 import { Transport } from '@trezor/transport';
 import * as Messages from '@trezor/protobuf/lib/messages-schema';
-import { versionUtils } from '@trezor/utils';
+import * as versionUtils from '@trezor/utils/lib/versionUtils';
 import { ERRORS, NETWORK } from '../constants';
 import { DEVICE } from '../events';
 import * as hdnodeUtils from '../utils/hdnodeUtils';

--- a/packages/connect/src/events/ui-promise.ts
+++ b/packages/connect/src/events/ui-promise.ts
@@ -1,4 +1,4 @@
-import type { Deferred } from '@trezor/utils';
+import type { Deferred } from '@trezor/utils/lib/createDeferred';
 import type { DEVICE } from './device';
 import type { Device } from '../device/Device';
 import type { UiResponseEvent } from './ui-response';

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -1,6 +1,6 @@
 import EventEmitter from 'events';
 
-import { createDeferred, Deferred } from '@trezor/utils';
+import { createDeferred, Deferred } from '@trezor/utils/lib/createDeferred';
 import { Core, initCore, initTransport } from './core';
 import { factory } from './factory';
 import { parseConnectSettings } from './data/connectSettings';

--- a/packages/connect/src/utils/deviceFeaturesUtils.ts
+++ b/packages/connect/src/utils/deviceFeaturesUtils.ts
@@ -1,4 +1,4 @@
-import { versionUtils } from '@trezor/utils';
+import * as versionUtils from '@trezor/utils/lib/versionUtils';
 import { PROTO } from '../constants';
 import { config } from '../data/config';
 import { Features, CoinInfo, UnavailableCapabilities, DeviceModelInternal } from '../types';

--- a/packages/connect/src/utils/firmwareUtils.ts
+++ b/packages/connect/src/utils/firmwareUtils.ts
@@ -1,4 +1,4 @@
-import { versionUtils } from '@trezor/utils';
+import * as versionUtils from '@trezor/utils/lib/versionUtils';
 import type { Features, StrictFeatures, FirmwareRelease, VersionArray } from '../types';
 
 export const isStrictFeatures = (extFeatures: Features): extFeatures is StrictFeatures =>

--- a/packages/connect/src/utils/urlUtils.ts
+++ b/packages/connect/src/utils/urlUtils.ts
@@ -1,6 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/utils/urlUtils.js
 
-import { urlToOnion } from '@trezor/utils';
+import { urlToOnion } from '@trezor/utils/lib/urlToOnion';
 
 export const getOrigin = (url: unknown) => {
     if (typeof url !== 'string') return 'unknown';

--- a/packages/protobuf/scripts/protobuf-types.js
+++ b/packages/protobuf/scripts/protobuf-types.js
@@ -2,7 +2,14 @@ const fs = require('fs');
 const path = require('path');
 
 const json = require('../messages.json');
-const { RULE_PATCH, TYPE_PATCH, DEFINITION_PATCH, SKIP, UINT_TYPE, SINT_TYPE } = require('./protobuf-patches');
+const {
+    RULE_PATCH,
+    TYPE_PATCH,
+    DEFINITION_PATCH,
+    SKIP,
+    UINT_TYPE,
+    SINT_TYPE,
+} = require('./protobuf-patches');
 
 const INDENT = ' '.repeat(4);
 

--- a/packages/schema-utils/CHANGELOG.md
+++ b/packages/schema-utils/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 1.0.0
+
+-   initial release

--- a/packages/schema-utils/package.json
+++ b/packages/schema-utils/package.json
@@ -3,15 +3,19 @@
     "version": "1.0.0",
     "license": "See LICENSE.md in repo root",
     "sideEffects": false,
-    "main": "src/index",
+    "main": "lib/index",
+    "npmPublishAccess": "public",
     "files": [
-        "src/"
+        "lib/"
     ],
     "scripts": {
         "test:unit": "jest",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
         "type-check": "tsc --build",
-        "codegen": "ts-node --skip-project ./src/codegen.ts"
+        "build:lib": "rimraf ./lib && yarn tsc --build tsconfig.lib.json",
+        "codegen": "ts-node --skip-project ./src/codegen.ts",
+        "prepublishOnly": "yarn tsx ../../scripts/prepublishNPM.js",
+        "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "devDependencies": {
         "@sinclair/typebox-codegen": "^0.8.13",

--- a/packages/schema-utils/tsconfig.lib.json
+++ b/packages/schema-utils/tsconfig.lib.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.lib.json",
+    "compilerOptions": {
+        "outDir": "lib",
+        "importHelpers": true
+    },
+    "include": ["./src"]
+}

--- a/packages/suite-data/package.json
+++ b/packages/suite-data/package.json
@@ -20,6 +20,7 @@
     "dependencies": {
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/suite-utils": "workspace:*",
+        "@trezor/connect": "workspace:*",
         "@trezor/env-utils": "workspace:*",
         "@trezor/urls": "workspace:*",
         "@trezor/utils": "workspace:*"

--- a/packages/suite-data/tsconfig.json
+++ b/packages/suite-data/tsconfig.json
@@ -13,6 +13,7 @@
         {
             "path": "../../suite-common/suite-utils"
         },
+        { "path": "../connect" },
         { "path": "../env-utils" },
         { "path": "../urls" },
         { "path": "../utils" }

--- a/packages/suite-desktop-core/e2e/tests/general/wallet-discovery.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/general/wallet-discovery.test.ts
@@ -4,7 +4,8 @@ import {
     ElectronApplication,
     Page,
 } from '@playwright/test';
-import { TrezorUserEnvLink } from 'packages/trezor-user-env-link/src';
+
+import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link/src';
 
 import { launchSuite, rmDirRecursive } from '../../support/common';
 import { onDashboardPage } from '../../support/pageActions/dashboardActions';

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -1,3 +1,35 @@
+import { execSync } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+console.log('prepublish script running for package: ' + process.env.npm_package_name);
+
+//  test all d.ts files for existence of non-resolvable imports such as:
+//  import("packages/protobuf/lib").MessageType
+//  in the example "packages" segment is not resolvable. "packages" is a folder in the monorepo root and typescript
+//  compiler does not replace it with absolute import starting with "@trezor".
+//  there were issues with this in the past: https://github.com/trezor/trezor-suite/issues/10389
+//  There are two ways to fix this:
+//  1. rename "packages" folder in monorepo to "@trezor"
+//  2. find and replace all the problematic occurrences before actual release.
+//     not very good solution and yarn advices against doing it https://yarnpkg.com/advanced/lifecycle-scripts
+
+execSync(
+    `./replace-imports.sh ${path.join(
+        __dirname,
+        '..',
+        'packages',
+        process.env.npm_package_name.split('/')[1],
+    )}/lib`,
+    {
+        encoding: 'utf-8',
+        cwd: __dirname,
+    },
+);
+
 if (!process.env.CI) {
     console.log('DO NOT TRY TO PUBLISH FROM YOUR LOCAL MACHINE! Publish only from CI.');
     process.exit(1);

--- a/scripts/replace-imports.sh
+++ b/scripts/replace-imports.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+echo replacing imports in "$1"
+
+find "$1" -type f -exec sed -i '' "s/import(\"packages/import(\"@trezor/g" {} +

--- a/yarn.lock
+++ b/yarn.lock
@@ -9017,6 +9017,7 @@ __metadata:
     "@mobily/ts-belt": "npm:^3.13.1"
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/suite-utils": "workspace:*"
+    "@trezor/connect": "workspace:*"
     "@trezor/env-utils": "workspace:*"
     "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"


### PR DESCRIPTION
couple of changes needed to address https://github.com/trezor/trezor-suite/issues/10389

19cb880c2e update unresolvable imports before publish. this is to fix this: ![image](https://github.com/trezor/trezor-suite/assets/30367552/a8ae66fa-165b-4329-b53a-9105b951e92c). "packages" in import can't  be resolved obviously outside of monorepo. I found 2 solutions to this. the other, rather brutalistic, is to rename packages folder to @trezor folder.
27f0295faf chore(suite-data): list connect dependency to fix build:libs errors. I don't understand why this is needed but without this I kept getting errors when running build:libs. 
8e29d07eec chore(schema-utils): prepare for npm release. We added a new package so it is going to be released to npm with next connect release.
eb134deffd test(suite-desktop): fix import using proper @trezor/ prefix
a6eddcd237 fix(blockchain-link): correct import in solana using @trezor/ prefix
4f024fbb74 ci(connect): check tsc connect compilation with lib check. 
f03b6c9504 fix(connect): point analytics to lib

