### PR TITLE
Remove Cardano `<2.4.3` compatibility branches

### DIFF
--- a/packages/connect/e2e/__fixtures__/cardanoGetAddress.ts
+++ b/packages/connect/e2e/__fixtures__/cardanoGetAddress.ts
@@ -3,14 +3,6 @@ import { MessagesSchema } from '@trezor/protobuf';
 
 const { CardanoAddressType } = MessagesSchema;
 
-const legacyResults = [
-    {
-        // cardanoGetAddress not supported below this version
-        rules: ['<2.3.2', '1'],
-        success: false,
-    },
-];
-
 export default {
     method: 'cardanoGetAddress',
     setup: {
@@ -30,7 +22,6 @@ export default {
             result: {
                 address: 'Ae2tdPwUPEZ5YUb8sM3eS8JqKgrRLzhiu71crfuH2MFtqaYr5ACNRdsswsZ',
             },
-            legacyResults,
         },
         {
             description: "Byron Mainnet - m/44'/1815'",
@@ -57,7 +48,6 @@ export default {
             result: {
                 address: 'Ae2tdPwUPEZJb8r1VZxweSwHDTYtqeYqF39rZmVbrNK62JHd4Wd7Ytsc8eG',
             },
-            legacyResults,
         },
         {
             description: "Byron Mainnet- m/44'/1815'/0'/0/2",
@@ -72,7 +62,6 @@ export default {
             result: {
                 address: 'Ae2tdPwUPEZFm6Y7aPZGKMyMAK16yA5pWWKU9g73ncUQNZsAjzjhszenCsq',
             },
-            legacyResults,
         },
         {
             description: "Byron Testnet - m/44'/1815'/0'/0/0",
@@ -87,7 +76,6 @@ export default {
             result: {
                 address: '2657WMsDfac5F3zbgs9BwNWx3dhGAJERkAL93gPa68NJ2i8mbCHm2pLUHWSj8Mfea',
             },
-            legacyResults,
         },
         {
             description: "Byron Testnet - m/44'/1815'/0'/0/1",
@@ -102,7 +90,6 @@ export default {
             result: {
                 address: '2657WMsDfac6ezKWszxLFqJjSUgpg9NgxKc1koqi24sVpRaPhiwMaExk4useKn5HA',
             },
-            legacyResults,
         },
         {
             description: "Byron Testnet - m/44'/1815'/0'/0/2",
@@ -117,7 +104,6 @@ export default {
             result: {
                 address: '2657WMsDfac7hr1ioJGr6g7r6JRx4r1My8Rj91tcPTeVjJDpfBYKURrPG2zVLx2Sq',
             },
-            legacyResults,
         },
         {
             description: "Base Mainnet - m/1852'/1815'/4'/0/0",
@@ -134,7 +120,6 @@ export default {
                 address:
                     'addr1q8v42wjda8r6mpfj40d36znlgfdcqp7jtj03ah8skh6u8wnrqua2vw243tmjfjt0h5wsru6appuz8c0pfd75ur7myyeqsx9990',
             },
-            legacyResults,
         },
         {
             description: "Base Mainnet Paths as Numbers - m/1852'/1815'/4'/0/0",
@@ -151,7 +136,6 @@ export default {
                 address:
                     'addr1q8v42wjda8r6mpfj40d36znlgfdcqp7jtj03ah8skh6u8wnrqua2vw243tmjfjt0h5wsru6appuz8c0pfd75ur7myyeqsx9990',
             },
-            legacyResults,
         },
         {
             description: "Base Testnet - m/1852'/1815'/4'/0/0",
@@ -168,7 +152,6 @@ export default {
                 address:
                     'addr_test1qrv42wjda8r6mpfj40d36znlgfdcqp7jtj03ah8skh6u8wnrqua2vw243tmjfjt0h5wsru6appuz8c0pfd75ur7myyeqnsc9fs',
             },
-            legacyResults,
         },
         {
             description: "Base Staking Key Hash Mainnet - m/1852'/1815'/4'/0/0",
@@ -185,7 +168,6 @@ export default {
                 address:
                     'addr1q8v42wjda8r6mpfj40d36znlgfdcqp7jtj03ah8skh6u8wsmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hlsydc62k',
             },
-            legacyResults,
         },
         {
             description: "Base Staking Key Hash Testnet - m/1852'/1815'/4'/0/0",
@@ -202,7 +184,6 @@ export default {
                 address:
                     'addr_test1qrv42wjda8r6mpfj40d36znlgfdcqp7jtj03ah8skh6u8wsmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hls8m96xf',
             },
-            legacyResults,
         },
         {
             description: 'Base Script Key Mainnet',
@@ -219,12 +200,6 @@ export default {
                 address:
                     'addr1zyx44jlk580mpjrjfesd7v2fsuc4ejlh3wmvp7dk702k3lsj922xhxkn6twlq2wn4q50q352annk3903tj00h45mgfmsf42dkl',
             },
-            legacyResults: [
-                {
-                    rules: ['<2.4.3', '1'],
-                    payload: false,
-                },
-            ],
         },
         {
             description: 'Base Script Key Testnet',
@@ -241,12 +216,6 @@ export default {
                 address:
                     'addr_test1zqx44jlk580mpjrjfesd7v2fsuc4ejlh3wmvp7dk702k3lsj922xhxkn6twlq2wn4q50q352annk3903tj00h45mgfms2rhd6q',
             },
-            legacyResults: [
-                {
-                    rules: ['<2.4.3', '1'],
-                    payload: false,
-                },
-            ],
         },
         {
             description: 'Base Key Script Mainnet',
@@ -263,12 +232,6 @@ export default {
                 address:
                     'addr1yxq0nckg3ekgzuqg7w5p9mvgnd9ym28qh5grlph8xd2z925d004u0fv0r3a4ld7f8yg8rmxnk5dsxf542ghcc42ngw5s8vnrtt',
             },
-            legacyResults: [
-                {
-                    rules: ['<2.4.3', '1'],
-                    payload: false,
-                },
-            ],
         },
         {
             description: 'Base Key Script Testnet',
@@ -285,12 +248,6 @@ export default {
                 address:
                     'addr_test1yzq0nckg3ekgzuqg7w5p9mvgnd9ym28qh5grlph8xd2z925d004u0fv0r3a4ld7f8yg8rmxnk5dsxf542ghcc42ngw5sy6wr85',
             },
-            legacyResults: [
-                {
-                    rules: ['<2.4.3', '1'],
-                    payload: false,
-                },
-            ],
         },
         {
             description: 'Base Script Script Mainnet',
@@ -307,12 +264,6 @@ export default {
                 address:
                     'addr1xyx44jlk580mpjrjfesd7v2fsuc4ejlh3wmvp7dk702k3l5d004u0fv0r3a4ld7f8yg8rmxnk5dsxf542ghcc42ngw5s3gftll',
             },
-            legacyResults: [
-                {
-                    rules: ['<2.4.3', '1'],
-                    payload: false,
-                },
-            ],
         },
         {
             description: 'Base Script Script Testnet',
@@ -329,12 +280,6 @@ export default {
                 address:
                     'addr_test1xqx44jlk580mpjrjfesd7v2fsuc4ejlh3wmvp7dk702k3l5d004u0fv0r3a4ld7f8yg8rmxnk5dsxf542ghcc42ngw5sj75tnq',
             },
-            legacyResults: [
-                {
-                    rules: ['<2.4.3', '1'],
-                    payload: false,
-                },
-            ],
         },
         {
             description: "Enterprise Mainnet - m/1852'/1815'/0'/0/0",
@@ -349,7 +294,6 @@ export default {
             result: {
                 address: 'addr1vxq0nckg3ekgzuqg7w5p9mvgnd9ym28qh5grlph8xd2z92su77c6m',
             },
-            legacyResults,
         },
         {
             description: "Enterprise Testnet - m/1852'/1815'/0'/0/0",
@@ -364,7 +308,6 @@ export default {
             result: {
                 address: 'addr_test1vzq0nckg3ekgzuqg7w5p9mvgnd9ym28qh5grlph8xd2z92s8k2y47',
             },
-            legacyResults,
         },
         {
             description: 'Enterprise Script Mainnet',
@@ -379,12 +322,6 @@ export default {
             result: {
                 address: 'addr1wyx44jlk580mpjrjfesd7v2fsuc4ejlh3wmvp7dk702k3lsqee7sp',
             },
-            legacyResults: [
-                {
-                    rules: ['<2.4.3', '1'],
-                    payload: false,
-                },
-            ],
         },
         {
             description: 'Enterprise Script Testnet',
@@ -399,12 +336,6 @@ export default {
             result: {
                 address: 'addr_test1wqx44jlk580mpjrjfesd7v2fsuc4ejlh3wmvp7dk702k3lsm3dzly',
             },
-            legacyResults: [
-                {
-                    rules: ['<2.4.3', '1'],
-                    payload: false,
-                },
-            ],
         },
         {
             description: "Pointer Mainnet - m/1852'/1815'/0'/0/0",
@@ -424,7 +355,6 @@ export default {
             result: {
                 address: 'addr1gxq0nckg3ekgzuqg7w5p9mvgnd9ym28qh5grlph8xd2z92spqgpsl97q83',
             },
-            legacyResults,
         },
         {
             description: "Pointer Testnet - m/1852'/1815'/0'/0/0",
@@ -444,7 +374,6 @@ export default {
             result: {
                 address: 'addr_test1gzq0nckg3ekgzuqg7w5p9mvgnd9ym28qh5grlph8xd2z925ph3wczvf2ag2x9t',
             },
-            legacyResults,
         },
         {
             description: 'Pointer Script Mainnet',
@@ -464,12 +393,6 @@ export default {
             result: {
                 address: 'addr12yx44jlk580mpjrjfesd7v2fsuc4ejlh3wmvp7dk702k3l5ph3wczvf2zmd4yp',
             },
-            legacyResults: [
-                {
-                    rules: ['<2.4.3', '1'],
-                    payload: false,
-                },
-            ],
         },
         {
             description: 'Pointer Script Testnet',
@@ -489,12 +412,6 @@ export default {
             result: {
                 address: 'addr_test12qx44jlk580mpjrjfesd7v2fsuc4ejlh3wmvp7dk702k3l5ph3wczvf2d4sugn',
             },
-            legacyResults: [
-                {
-                    rules: ['<2.4.3', '1'],
-                    payload: false,
-                },
-            ],
         },
         {
             description: "Reward Mainnet - m/1852'/1815'/0'/2/0",
@@ -509,7 +426,6 @@ export default {
             result: {
                 address: 'stake1uyfz49rtntfa9h0s98f6s28sg69weemgjhc4e8hm66d5yacalmqha',
             },
-            legacyResults,
         },
         {
             description: "Reward Testnet - m/1852'/1815'/0'/2/0",
@@ -524,7 +440,6 @@ export default {
             result: {
                 address: 'stake_test1uqfz49rtntfa9h0s98f6s28sg69weemgjhc4e8hm66d5yac643znq',
             },
-            legacyResults,
         },
         {
             description: 'Reward Script Mainnet',
@@ -539,12 +454,6 @@ export default {
             result: {
                 address: 'stake17xxhh6785k83c76lklynjyr3anfm2xcry624ytuv24f582gt5mad4',
             },
-            legacyResults: [
-                {
-                    rules: ['<2.4.3', '1'],
-                    payload: false,
-                },
-            ],
         },
         {
             description: 'Reward Script Testnet',
@@ -559,12 +468,6 @@ export default {
             result: {
                 address: 'stake_test17zxhh6785k83c76lklynjyr3anfm2xcry624ytuv24f582gv73lfg',
             },
-            legacyResults: [
-                {
-                    rules: ['<2.4.3', '1'],
-                    payload: false,
-                },
-            ],
         },
         {
             description: 'Reward Mainnet - path sent as path instead of stakingPath',
@@ -579,7 +482,6 @@ export default {
             result: {
                 address: 'stake1uyfz49rtntfa9h0s98f6s28sg69weemgjhc4e8hm66d5yacalmqha',
             },
-            legacyResults,
         },
         {
             description: 'Reward Mainnet - both path and stakingPath are set',

--- a/packages/connect/e2e/__fixtures__/cardanoGetAddressDerivations.ts
+++ b/packages/connect/e2e/__fixtures__/cardanoGetAddressDerivations.ts
@@ -28,20 +28,5 @@ export default {
         result: {
             address: result.expected_address,
         },
-        legacyResults: [
-            {
-                // before derivations were implemented
-                rules: ['<2.4.3', '1'],
-                payload: {
-                    address:
-                        'addr1q8g9th06vccxzl96nr905al0vgg2t0fqfxrxmv7ecye3x2e66sl9kvzd905ad5natzd5wghy2w3a9lm0y7u7c5sv0c2snql3c4',
-                },
-            },
-            {
-                // cardanoGetAddress not supported below this version
-                rules: ['<2.3.2', '1'],
-                success: false,
-            },
-        ],
     })),
 };

--- a/packages/connect/e2e/__fixtures__/cardanoGetNativeScriptHash.ts
+++ b/packages/connect/e2e/__fixtures__/cardanoGetNativeScriptHash.ts
@@ -20,12 +20,6 @@ export default {
             result: {
                 scriptHash: '29fb5fd4aa8cadd6705acc8263cee0fc62edca5ac38db593fec2f9fd',
             },
-            legacyResults: [
-                {
-                    rules: ['<2.4.3', '1'],
-                    payload: false,
-                },
-            ],
         },
         {
             description: 'PUB_KEY script containing a path',
@@ -39,12 +33,6 @@ export default {
             result: {
                 scriptHash: '29fb5fd4aa8cadd6705acc8263cee0fc62edca5ac38db593fec2f9fd',
             },
-            legacyResults: [
-                {
-                    rules: ['<2.4.3', '1'],
-                    payload: false,
-                },
-            ],
         },
         {
             description: 'ALL script',
@@ -67,12 +55,6 @@ export default {
             result: {
                 scriptHash: 'af5c2ce476a6ede1c879f7b1909d6a0b96cb2081391712d4a355cef6',
             },
-            legacyResults: [
-                {
-                    rules: ['<2.4.3', '1'],
-                    payload: false,
-                },
-            ],
         },
         {
             description: 'ALL script containing a path',
@@ -95,12 +77,6 @@ export default {
             result: {
                 scriptHash: 'af5c2ce476a6ede1c879f7b1909d6a0b96cb2081391712d4a355cef6',
             },
-            legacyResults: [
-                {
-                    rules: ['<2.4.3', '1'],
-                    payload: false,
-                },
-            ],
         },
         {
             description: 'ALL script containing a 1855 path',
@@ -123,12 +99,6 @@ export default {
             result: {
                 scriptHash: 'fbf6672eb655c29b0f148fa1429be57c2174b067a7b3e3942e967fe8',
             },
-            legacyResults: [
-                {
-                    rules: ['<2.4.3', '1'],
-                    payload: false,
-                },
-            ],
         },
         {
             description: 'ANY script',
@@ -151,12 +121,6 @@ export default {
             result: {
                 scriptHash: 'd6428ec36719146b7b5fb3a2d5322ce702d32762b8c7eeeb797a20db',
             },
-            legacyResults: [
-                {
-                    rules: ['<2.4.3', '1'],
-                    payload: false,
-                },
-            ],
         },
         {
             description: 'ANY script containing a path',
@@ -179,12 +143,6 @@ export default {
             result: {
                 scriptHash: 'd6428ec36719146b7b5fb3a2d5322ce702d32762b8c7eeeb797a20db',
             },
-            legacyResults: [
-                {
-                    rules: ['<2.4.3', '1'],
-                    payload: false,
-                },
-            ],
         },
         {
             description: 'N_OF_K script',
@@ -212,12 +170,6 @@ export default {
             result: {
                 scriptHash: '2b2b17fd18e18acae4601d4818a1dee00a917ff72e772fa8482e36c9',
             },
-            legacyResults: [
-                {
-                    rules: ['<2.4.3', '1'],
-                    payload: false,
-                },
-            ],
         },
         {
             description: 'N_OF_K script containing a path',
@@ -245,12 +197,6 @@ export default {
             result: {
                 scriptHash: '2b2b17fd18e18acae4601d4818a1dee00a917ff72e772fa8482e36c9',
             },
-            legacyResults: [
-                {
-                    rules: ['<2.4.3', '1'],
-                    payload: false,
-                },
-            ],
         },
         {
             description: 'INVALID_BEFORE script',
@@ -273,12 +219,6 @@ export default {
             result: {
                 scriptHash: 'c6262ef9bb2b1291c058d93b46dabf458e2d135f803f60713f84b0b7',
             },
-            legacyResults: [
-                {
-                    rules: ['<2.4.3', '1'],
-                    payload: false,
-                },
-            ],
         },
         {
             description: 'INVALID_HEREAFTER script',
@@ -301,12 +241,6 @@ export default {
             result: {
                 scriptHash: 'b12ac304f89f4cd4d23f59a2b90d2b2697f7540b8f470d6aa05851b5',
             },
-            legacyResults: [
-                {
-                    rules: ['<2.4.3', '1'],
-                    payload: false,
-                },
-            ],
         },
         {
             description: 'Nested script',
@@ -371,12 +305,6 @@ export default {
             result: {
                 scriptHash: '4a6b4288459bf34668c0b281f922691460caf0c7c09caee3a726c27a',
             },
-            legacyResults: [
-                {
-                    rules: ['<2.4.3', '1'],
-                    payload: false,
-                },
-            ],
         },
     ],
 };

--- a/packages/connect/e2e/__fixtures__/cardanoGetPublicKey.ts
+++ b/packages/connect/e2e/__fixtures__/cardanoGetPublicKey.ts
@@ -1,11 +1,3 @@
-const legacyResults = [
-    {
-        // cardanoGetPublicKey not supported below this version
-        rules: ['<2.3.2', '1'],
-        success: false,
-    },
-];
-
 export default {
     method: 'cardanoGetPublicKey',
     setup: {
@@ -21,7 +13,6 @@ export default {
                 publicKey:
                     'a938c8554ae04616cfaae7cd0eb557475082c4e910242ce774967e0bd7492408cbf6ab47c8eb1a0477fc40b25dbb6c4a99454edb97d6fe5acedd3e238ef46fe0',
             },
-            legacyResults,
         },
         {
             description: "m/44'/1815'",
@@ -39,7 +30,6 @@ export default {
                 publicKey:
                     '17cc0bf978756d0d5c76f931629036a810c61801b78beecb44555773d13e3791646ac4a6295326bae6831be05921edfbcb362de48dfd37b12e74c227dfad768d',
             },
-            legacyResults,
         },
         {
             description: "m/44'/1815'/0'/0/0",
@@ -50,7 +40,6 @@ export default {
                 publicKey:
                     'b90fb812a2268e9569ff1172e8daed1da3dc7e72c7bded7c5bcb7282039f90d5fd8e71c1543de2cdc7f7623130c5f2cceb53549055fa1f5bc88199989e08cce7',
             },
-            legacyResults,
         },
         {
             description: "m/1852'/1815'/0'",
@@ -61,7 +50,6 @@ export default {
                 publicKey:
                     'd507c8f866691bd96e131334c355188b1a1d0b2fa0ab11545075aab332d77d9eb19657ad13ee581b56b0f8d744d66ca356b93d42fe176b3de007d53e9c4c4e7a',
             },
-            legacyResults,
         },
         {
             description: "m/1852'/1815'/0'/0/0",
@@ -72,7 +60,6 @@ export default {
                 publicKey:
                     '5d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c1f123474e140a2c360b01f0fa66f2f22e2e965a5b07a80358cf75f77abbd66088',
             },
-            legacyResults,
         },
     ],
 };

--- a/packages/connect/e2e/__fixtures__/cardanoSignTransaction.ts
+++ b/packages/connect/e2e/__fixtures__/cardanoSignTransaction.ts
@@ -396,41 +396,6 @@ const VALIDITY_INTERVAL_START = '47';
 const SCRIPT_DATA_HASH = 'd593fd793c377ac50a3169bb8378ffc257c944da31aa8f355dfa5a4f6ff89e02';
 const TOTAL_COLLATERAL = '1000';
 
-const legacyResults = {
-    beforeTransactionStreaming: {
-        // FW without transaction streaming is no longer supported by Connect
-        rules: ['<2.4.2', '1'],
-        success: false,
-    },
-    beforeMultisig: {
-        // older FW doesn't support multisig
-        rules: ['<2.4.3', '1'],
-        payload: false,
-    },
-    beforePlutus: {
-        // older FW doesn't support plutus-related features (OutputDatumHash, ScriptDataHash,
-        // Plutus, KeyHashStakeCredential)
-        rules: ['<2.4.4', '1'],
-        payload: false,
-    },
-    beforeBabbage: {
-        // older FW doesn't support babbage-related features (inlineDatum, referenceScript, collateralReturn,
-        // totalCollateral, referenceInputs)
-        rules: ['<2.5.2', '1'],
-        payload: false,
-    },
-    beforeCIP36Registration: {
-        // older FW doesn't support CIP36 registration format
-        rules: ['<2.5.3', '1'],
-        payload: false,
-    },
-    beforeCIP36RegistrationExternalPaymentAddress: {
-        // older FW doesn't support payment address given as a string in vote key registrations
-        rules: ['<2.5.4', '1'],
-        payload: false,
-    },
-};
-
 export default {
     method: 'cardanoSignTransaction',
     setup: {
@@ -462,7 +427,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforeTransactionStreaming],
         },
 
         {
@@ -490,7 +454,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforeTransactionStreaming],
         },
 
         {
@@ -520,7 +483,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforeTransactionStreaming],
         },
 
         {
@@ -550,7 +512,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforeTransactionStreaming],
         },
 
         {
@@ -580,7 +541,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforeTransactionStreaming],
         },
 
         {
@@ -610,7 +570,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforeTransactionStreaming],
         },
 
         {
@@ -638,7 +597,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforeTransactionStreaming],
         },
 
         {
@@ -666,7 +624,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforeTransactionStreaming],
         },
 
         {
@@ -704,7 +661,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforeTransactionStreaming],
         },
 
         {
@@ -739,7 +695,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforeTransactionStreaming],
         },
 
         {
@@ -775,7 +730,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforeTransactionStreaming],
         },
 
         {
@@ -839,7 +793,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforeTransactionStreaming],
         },
 
         {
@@ -884,7 +837,6 @@ export default {
                         'ed3335aead65c665ceee21f2549c0ef4c9137b94c13fa642bea4a2c24e44e7f1ee06b47e14151efcf8d5569a404260c01f277b3ba516b5826a15c8ba2c97f70c',
                 },
             },
-            legacyResults: [legacyResults.beforeTransactionStreaming],
         },
 
         {
@@ -929,7 +881,6 @@ export default {
                         'ed3335aead65c665ceee21f2549c0ef4c9137b94c13fa642bea4a2c24e44e7f1ee06b47e14151efcf8d5569a404260c01f277b3ba516b5826a15c8ba2c97f70c',
                 },
             },
-            legacyResults: [legacyResults.beforeTransactionStreaming],
         },
 
         {
@@ -986,7 +937,6 @@ export default {
                         '2671b8e668ffce235647ac89deda6cc222e7b31a3d44606c2723fcf711b29f9af1e30b0c6b4f87ba37ddf9f6adf0226c39c09e655255890644a3dc4e64c3a001',
                 },
             },
-            legacyResults: [legacyResults.beforeCIP36Registration],
         },
 
         {
@@ -1039,7 +989,6 @@ export default {
                         'ebc00c615f988c6fc2e132d4419a719f04bbec56fe2569a00746a9e9b0d6e5bdd0809515cb2522c773c991c5ae39834403654d36b37e70b14897c0e98c8c0a0c',
                 },
             },
-            legacyResults: [legacyResults.beforeCIP36Registration],
         },
 
         {
@@ -1088,7 +1037,6 @@ export default {
                         'ba05ac525e5dcc74e5a6cdbb7fb111d8e21163d79fe76777a5b730fe93512f09415f6f7b4904b12c6f12fe33b6c553d9889beb024299fa1256a0d3e98c8ff203',
                 },
             },
-            legacyResults: [legacyResults.beforeCIP36RegistrationExternalPaymentAddress],
         },
 
         {
@@ -1115,7 +1063,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforePlutus],
         },
 
         {
@@ -1143,7 +1090,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforePlutus],
         },
 
         {
@@ -1175,7 +1121,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforeTransactionStreaming],
         },
 
         {
@@ -1203,7 +1148,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforeTransactionStreaming],
         },
 
         {
@@ -1231,7 +1175,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforeTransactionStreaming],
         },
 
         {
@@ -1258,13 +1201,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [
-                {
-                    // older FW doesn't support validity interval start
-                    rules: ['<2.3.5', '1'],
-                    payload: false,
-                },
-            ],
         },
 
         {
@@ -1290,13 +1226,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [
-                {
-                    // older FW doesn't support multiasset outputs
-                    rules: ['<2.3.5', '1'],
-                    payload: false,
-                },
-            ],
         },
 
         {
@@ -1333,13 +1262,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [
-                {
-                    // older FW doesn't support token minting
-                    rules: ['<2.4.3', '1'],
-                    payload: false,
-                },
-            ],
         },
 
         {
@@ -1376,7 +1298,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforeMultisig],
         },
 
         {
@@ -1405,7 +1326,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforeMultisig],
         },
 
         {
@@ -1444,7 +1364,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforeMultisig],
         },
 
         {
@@ -1480,7 +1399,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforeMultisig],
         },
 
         {
@@ -1517,7 +1435,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforeMultisig],
         },
 
         {
@@ -1579,7 +1496,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforePlutus],
         },
 
         {
@@ -1609,13 +1525,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [
-                {
-                    // older FW doesn't support a zero ttl
-                    rules: ['<2.4.2', '1'],
-                    payload: false,
-                },
-            ],
         },
 
         {
@@ -1646,13 +1555,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [
-                {
-                    // older FW doesn't support a zero validityIntervalStart
-                    rules: ['<2.4.2', '1'],
-                    payload: false,
-                },
-            ],
         },
 
         {
@@ -1839,7 +1741,6 @@ export default {
                         '3064949c9f186138f95e228075d0119dd5cb50e1b7e75d24d569fa547e018a597615da7c79a39ca8e394ee1ba8acb83e70be80f37e69aef3b86e7c4a6bd44903',
                 },
             },
-            legacyResults: [legacyResults.beforeCIP36Registration],
         },
 
         {
@@ -1868,13 +1769,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [
-                {
-                    // older FW doesn't support network id in tx body
-                    rules: ['<2.4.4', '1'],
-                    payload: false,
-                },
-            ],
         },
 
         {
@@ -1906,7 +1800,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforePlutus],
         },
 
         {
@@ -1952,7 +1845,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforePlutus],
         },
 
         {
@@ -1990,7 +1882,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforePlutus],
         },
 
         {
@@ -2038,7 +1929,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforePlutus],
         },
 
         {
@@ -2083,7 +1973,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforePlutus],
         },
 
         {
@@ -2129,7 +2018,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforePlutus],
         },
 
         {
@@ -2182,7 +2070,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforePlutus],
         },
 
         {
@@ -2228,7 +2115,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforePlutus],
         },
 
         {
@@ -2276,7 +2162,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforePlutus],
         },
 
         {
@@ -2355,7 +2240,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforePlutus],
         },
 
         {
@@ -2382,7 +2266,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforeBabbage],
         },
 
         {
@@ -2417,7 +2300,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforeBabbage],
         },
 
         {
@@ -2453,7 +2335,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforeBabbage],
         },
 
         {
@@ -2519,7 +2400,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforeBabbage],
         },
 
         {
@@ -2546,7 +2426,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforeBabbage],
         },
 
         {
@@ -2573,7 +2452,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforeBabbage],
         },
 
         {
@@ -2624,7 +2502,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforeBabbage],
         },
 
         {
@@ -2673,7 +2550,6 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [legacyResults.beforeBabbage],
         },
     ],
 };

--- a/packages/connect/src/api/cardano/api/cardanoGetAddress.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetAddress.ts
@@ -119,33 +119,12 @@ export default class CardanoGetAddress extends AbstractMethod<'cardanoGetAddress
         return response.message;
     }
 
-    _ensureFirmwareSupportsBatch(batch: Params) {
-        const SCRIPT_ADDRESSES_TYPES = [
-            PROTO.CardanoAddressType.BASE_SCRIPT_KEY,
-            PROTO.CardanoAddressType.BASE_KEY_SCRIPT,
-            PROTO.CardanoAddressType.BASE_SCRIPT_SCRIPT,
-            PROTO.CardanoAddressType.POINTER_SCRIPT,
-            PROTO.CardanoAddressType.ENTERPRISE_SCRIPT,
-            PROTO.CardanoAddressType.REWARD_SCRIPT,
-        ];
-
-        if (SCRIPT_ADDRESSES_TYPES.includes(batch.address_parameters.address_type)) {
-            if (!this.device.atLeast(['0', '2.4.3'])) {
-                throw ERRORS.TypedError(
-                    'Method_InvalidParameter',
-                    `Address type not supported by device firmware`,
-                );
-            }
-        }
-    }
-
     async run() {
         const responses: MethodReturnType<typeof this.name> = [];
 
         for (let i = 0; i < this.params.length; i++) {
             const batch = this.params[i];
 
-            this._ensureFirmwareSupportsBatch(batch);
             batch.address_parameters = modifyAddressParametersForBackwardsCompatibility(
                 this.device,
                 batch.address_parameters,

--- a/packages/connect/src/api/cardano/api/cardanoGetAddress.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetAddress.ts
@@ -126,7 +126,6 @@ export default class CardanoGetAddress extends AbstractMethod<'cardanoGetAddress
             const batch = this.params[i];
 
             batch.address_parameters = modifyAddressParametersForBackwardsCompatibility(
-                this.device,
                 batch.address_parameters,
             );
 

--- a/packages/connect/src/api/cardano/api/cardanoSignTransaction.ts
+++ b/packages/connect/src/api/cardano/api/cardanoSignTransaction.ts
@@ -407,7 +407,6 @@ export default class CardanoSignTransaction extends AbstractMethod<
             const { cvote_registration_parameters } = this.params.auxiliaryData;
             if (cvote_registration_parameters) {
                 this.params.auxiliaryData = modifyAuxiliaryDataForBackwardsCompatibility(
-                    this.device,
                     this.params.auxiliaryData,
                 );
             }

--- a/packages/connect/src/api/cardano/cardanoAddressParameters.ts
+++ b/packages/connect/src/api/cardano/cardanoAddressParameters.ts
@@ -2,7 +2,6 @@
 
 import { validatePath } from '../../utils/pathUtils';
 import { PROTO, ERRORS } from '../../constants';
-import type { Device } from '../../device/Device';
 import { CardanoAddressParameters } from '../../types/api/cardano';
 import { Assert } from '@trezor/schema-utils';
 
@@ -18,7 +17,6 @@ export const validateAddressParameters = (addressParameters: CardanoAddressParam
 };
 
 export const modifyAddressParametersForBackwardsCompatibility = (
-    device: Device,
     address_parameters: PROTO.CardanoAddressParametersType,
 ): PROTO.CardanoAddressParametersType => {
     if (address_parameters.address_type === PROTO.CardanoAddressType.REWARD) {
@@ -32,14 +30,9 @@ export const modifyAddressParametersForBackwardsCompatibility = (
             );
         }
 
-        if (device.atLeast(['0', '2.4.3'])) {
-            if (address_n.length > 0) {
-                address_n_staking = address_n;
-                address_n = [];
-            }
-        } else if (address_n_staking.length > 0) {
-            address_n = address_n_staking;
-            address_n_staking = [];
+        if (address_n.length > 0) {
+            address_n_staking = address_n;
+            address_n = [];
         }
 
         return {

--- a/packages/connect/src/api/cardano/cardanoAuxiliaryData.ts
+++ b/packages/connect/src/api/cardano/cardanoAuxiliaryData.ts
@@ -6,7 +6,6 @@ import {
     validateAddressParameters,
 } from './cardanoAddressParameters';
 import { validatePath } from '../../utils/pathUtils';
-import type { Device } from '../../device/Device';
 import { ERRORS, PROTO } from '../../constants';
 import {
     CardanoAuxiliaryData,
@@ -101,14 +100,12 @@ export const transformAuxiliaryData = (
 };
 
 export const modifyAuxiliaryDataForBackwardsCompatibility = (
-    device: Device,
     auxiliary_data: PROTO.CardanoTxAuxiliaryData,
 ): PROTO.CardanoTxAuxiliaryData => {
     const { cvote_registration_parameters } = auxiliary_data;
     if (cvote_registration_parameters?.payment_address_parameters) {
         cvote_registration_parameters.payment_address_parameters =
             modifyAddressParametersForBackwardsCompatibility(
-                device,
                 cvote_registration_parameters.payment_address_parameters,
             );
 

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -213,12 +213,11 @@ const MAX_PIN_TRIES = 3;
 /** Including up to 3 pin tries **/
 const getInvalidDeviceState = async (
     device: Device,
-    network: AbstractMethod<any>['network'],
     preauthorized?: boolean,
 ): Promise<string | undefined> => {
     for (let i = 0; i < MAX_PIN_TRIES - 1; ++i) {
         try {
-            return await device.validateState(network, preauthorized);
+            return await device.validateState(preauthorized);
         } catch (error) {
             if (error.message.includes('PIN invalid')) {
                 postMessage(createUiMessage(UI.INVALID_PIN, { device: device.toMessageObject() }));
@@ -228,7 +227,7 @@ const getInvalidDeviceState = async (
         }
     }
 
-    return device.validateState(network, preauthorized);
+    return device.validateState(preauthorized);
 };
 
 /**
@@ -392,11 +391,7 @@ const inner = async (method: AbstractMethod<any>, device: Device) => {
     const isDeviceUnlocked = device.features.unlocked;
     if (method.useDeviceState) {
         try {
-            let invalidDeviceState = await getInvalidDeviceState(
-                device,
-                method.network,
-                method.preauthorized,
-            );
+            let invalidDeviceState = await getInvalidDeviceState(device, method.preauthorized);
             if (isUsingPopup) {
                 while (invalidDeviceState) {
                     const uiPromise = uiPromises.create(UI.INVALID_PASSPHRASE_ACTION, device);
@@ -418,7 +413,6 @@ const inner = async (method: AbstractMethod<any>, device: Device) => {
 
                         invalidDeviceState = await getInvalidDeviceState(
                             device,
-                            method.network,
                             method.preauthorized,
                         );
                     } else {

--- a/packages/connect/src/data/config.ts
+++ b/packages/connect/src/data/config.ts
@@ -140,18 +140,18 @@ export const config = {
         },
         {
             methods: ['cardanoGetAddress', 'cardanoGetPublicKey'],
-            min: { T1B1: '0', T2T1: '2.3.2' },
-            comment: ['Shelley fork support since firmware 2.3.2'],
+            min: { T1B1: '0', T2T1: '2.4.3' },
+            comment: ['Since 2.4.3 Cardano derivation behavior has changed'],
         },
         {
             methods: ['cardanoSignTransaction'],
-            min: { T1B1: '0', T2T1: '2.4.2' },
-            comment: ['Non-streamed signing no longer supported'],
+            min: { T1B1: '0', T2T1: '2.6.0' },
+            comment: ['Before 2.6.0 not all Cardano transactions were supported'],
         },
         {
             methods: ['cardanoGetNativeScriptHash'],
             min: { T1B1: '0', T2T1: '2.4.3' },
-            comment: ['Cardano GetNativeScriptHash call added in 2.4.3'],
+            comment: ['Since 2.4.3 Cardano derivation behavior has changed'],
         },
         {
             methods: ['tezosSignTransaction'],

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -480,7 +480,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
         return this.externalState[this.instance];
     }
 
-    async validateState(networkType?: NETWORK.NetworkType, preauthorized = false) {
+    async validateState(preauthorized = false) {
         if (!this.features) return;
 
         if (!this.features.unlocked && preauthorized) {
@@ -493,7 +493,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
         }
 
         const expectedState = this.getExternalState();
-        const state = await this.getCommands().getDeviceState(networkType);
+        const state = await this.getCommands().getDeviceState();
         const uniqueState = `${state}@${this.features.device_id || 'device_id'}:${this.instance}`;
         if (!this.useLegacyPassphrase() && this.features.session_id) {
             this.setInternalState(this.features.session_id);

--- a/packages/connect/src/device/DeviceCommands.ts
+++ b/packages/connect/src/device/DeviceCommands.ts
@@ -530,6 +530,7 @@ export class DeviceCommands {
             coin_name: 'Testnet',
             script_type: 'SPENDADDRESS',
         });
+
         return message.address;
     }
 

--- a/packages/connect/src/device/DeviceCommands.ts
+++ b/packages/connect/src/device/DeviceCommands.ts
@@ -4,7 +4,7 @@ import { randomBytes } from 'crypto';
 import { Transport } from '@trezor/transport';
 import { MessagesSchema as Messages } from '@trezor/protobuf';
 import { versionUtils } from '@trezor/utils';
-import { ERRORS, NETWORK } from '../constants';
+import { ERRORS } from '../constants';
 import { DEVICE } from '../events';
 import * as hdnodeUtils from '../utils/hdnodeUtils';
 import { isTaprootPath, getSerializedPath, getScriptType, toHardened } from '../utils/pathUtils';
@@ -308,16 +308,8 @@ export class DeviceCommands {
         }
     }
 
-    getDeviceState(networkType?: string) {
-        // cardano backwards compatibility. we only need this for firmware before initialize.derive_cardano message was introduced
-        if (!this.device.atLeast('2.4.3')) {
-            return this._getAddressForNetworkType(networkType);
-        }
-
-        // skipping network type parameter intentionally
-        return this._getAddressForNetworkType();
-
-        // bitcoin.crypto.hash256(Buffer.from(secret, 'binary')).toString('hex');
+    getDeviceState() {
+        return this._getAddress();
     }
 
     // Sends an async message to the opened device.
@@ -532,34 +524,13 @@ export class DeviceCommands {
         return Promise.resolve(res);
     }
 
-    async _getAddressForNetworkType(networkType?: string) {
-        switch (networkType) {
-            case NETWORK.TYPES.cardano: {
-                const { message } = await this.typedCall('CardanoGetAddress', 'CardanoAddress', {
-                    address_parameters: {
-                        address_type: 8, // Byron
-                        address_n: [toHardened(44), toHardened(1815), toHardened(0), 0, 0],
-                        address_n_staking: [],
-                    },
-                    protocol_magic: 42,
-                    network_id: 0,
-                    // derivation type doesn't really matter as it is not recognized by older firmwares.
-                    // but it is a required field within protobuf definitions so we must provide something here
-                    derivation_type: 2, // icarus_trezor
-                });
-
-                return message.address;
-            }
-            default: {
-                const { message } = await this.typedCall('GetAddress', 'Address', {
-                    address_n: [toHardened(44), toHardened(1), toHardened(0), 0, 0],
-                    coin_name: 'Testnet',
-                    script_type: 'SPENDADDRESS',
-                });
-
-                return message.address;
-            }
-        }
+    private async _getAddress() {
+        const { message } = await this.typedCall('GetAddress', 'Address', {
+            address_n: [toHardened(44), toHardened(1), toHardened(0), 0, 0],
+            coin_name: 'Testnet',
+            script_type: 'SPENDADDRESS',
+        });
+        return message.address;
     }
 
     _promptPin(type?: Messages.PinMatrixRequestType) {


### PR DESCRIPTION
## Description

As `2.4.3` fw is required for Cardano since [previous PR](https://github.com/trezor/trezor-suite/pull/10493), we can remove correspondent backward compatibility code branches.

## Related Issue

Resolve #10504
