### PR TITLE
fix(connect): check custom Transport instance

### DIFF
--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -12,6 +12,7 @@ import {
     TRANSPORT,
     Descriptor,
     TRANSPORT_ERROR,
+    isTransportInstance,
 } from '@trezor/transport';
 import { ERRORS } from '../constants';
 import { DEVICE, TransportInfo } from '../events';
@@ -122,7 +123,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> {
                             `DeviceList.init: transports[] of unexpected type: ${transportType}`,
                         );
                 }
-            } else if (transportType instanceof Transport) {
+            } else if (isTransportInstance(transportType)) {
                 // custom Transport might be initialized without messages, update them if so
                 if (!transportType.getMessage()) {
                     transportType.updateMessages(this.messages);

--- a/packages/transport/src/index.ts
+++ b/packages/transport/src/index.ts
@@ -14,7 +14,7 @@ protobuf.configure();
 export type { Descriptor } from './types';
 export { TREZOR_USB_DESCRIPTORS, TRANSPORT } from './constants';
 
-export { AbstractTransport as Transport } from './transports/abstract';
+export { AbstractTransport as Transport, isTransportInstance } from './transports/abstract';
 export { AbstractApiTransport } from './transports/abstractApi';
 export { UsbApi } from './api/usb';
 

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -50,6 +50,24 @@ export interface AbstractTransportParams {
     logger?: Logger;
 }
 
+export const isTransportInstance = (transport?: AbstractTransport) => {
+    const requiredMethods = [
+        'init',
+        'enumerate',
+        'listen',
+        'acquire',
+        'release',
+        'send',
+        'receive',
+        'call',
+    ] as const;
+
+    if (transport && typeof transport === 'object') {
+        return !requiredMethods.some(m => typeof transport[m] !== 'function');
+    }
+    return false;
+};
+
 export abstract class AbstractTransport extends TypedEmitter<{
     [TRANSPORT.UPDATE]: DeviceDescriptorDiff;
     [TRANSPORT.ERROR]:


### PR DESCRIPTION
## Description

`instanceof Transport` is not always working - especially when transport package and connect package are bundled in separate chunks

