### PR TITLE
fix(suite-native): remove account list section headers

### DIFF
--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -8,7 +8,7 @@ import { Account, AccountKey } from '@suite-common/wallet-types';
 import { networks, NetworkSymbol } from '@suite-common/wallet-config';
 
 import { accountsActions } from './accountsActions';
-import { formattedBitcoinAccountTypeMap } from './constants';
+import { formattedAccountTypeMap } from './constants';
 import {
     DeviceRootState,
     selectDevice,
@@ -243,10 +243,14 @@ export const selectFormattedAccountType = (
     accountKey: AccountKey,
 ): string | null => {
     const account = selectAccountByKey(state, accountKey);
+    if (!account) return null;
 
-    if (!account || account?.networkType !== 'bitcoin') return null;
+    const { networkType, accountType } = account;
+    const formattedType = formattedAccountTypeMap[networkType]?.[accountType];
 
-    return formattedBitcoinAccountTypeMap[account.accountType] ?? null;
+    if (!formattedType) return null;
+
+    return formattedType;
 };
 
 export const selectIsAccountUtxoBased = (state: AccountsRootState, accountKey: AccountKey) => {

--- a/suite-common/wallet-core/src/accounts/constants.ts
+++ b/suite-common/wallet-core/src/accounts/constants.ts
@@ -1,10 +1,19 @@
+import { NetworkType } from '@suite-common/wallet-config';
 import { AccountType } from '@suite-common/wallet-types';
 
 export const accountsActionsPrefix = '@common/wallet-core/accounts';
 
-export const formattedBitcoinAccountTypeMap: Partial<Record<AccountType, string>> = {
-    normal: 'SegWit', // represents the default Suite account type (`SegWit Native` at the moment).
-    taproot: 'Taproot',
-    segwit: 'Legacy SegWit',
-    legacy: 'Legacy',
+export const formattedAccountTypeMap: Partial<
+    Record<NetworkType, Partial<Record<AccountType, string>>>
+> = {
+    bitcoin: {
+        normal: 'SegWit',
+        taproot: 'Taproot',
+        segwit: 'Legacy SegWit',
+        legacy: 'Legacy',
+    },
+    cardano: {
+        legacy: 'Legacy',
+        ledger: 'Ledger',
+    },
 };

--- a/suite-native/accounts/src/components/AccountsListGroup.tsx
+++ b/suite-native/accounts/src/components/AccountsListGroup.tsx
@@ -1,20 +1,15 @@
-import { HeaderedCard, VStack } from '@suite-native/atoms';
+import { Card, VStack } from '@suite-native/atoms';
 import { Account, AccountKey, TokenAddress } from '@suite-common/wallet-types';
 
 import { AccountListItemInteractive } from './AccountListItemInteractive';
 
 type AccountsListGroupProps = {
-    groupHeader: string;
     accounts: Account[];
     onSelectAccount: (accountKey: AccountKey, tokenContract?: TokenAddress) => void;
 };
 
-export const AccountsListGroup = ({
-    groupHeader,
-    accounts,
-    onSelectAccount,
-}: AccountsListGroupProps) => (
-    <HeaderedCard title={groupHeader}>
+export const AccountsListGroup = ({ accounts, onSelectAccount }: AccountsListGroupProps) => (
+    <Card>
         <VStack spacing="medium">
             {accounts.map(account => (
                 <AccountListItemInteractive
@@ -24,5 +19,5 @@ export const AccountsListGroup = ({
                 />
             ))}
         </VStack>
-    </HeaderedCard>
+    </Card>
 );

--- a/suite-native/accounts/src/components/GroupedAccountsList.tsx
+++ b/suite-native/accounts/src/components/GroupedAccountsList.tsx
@@ -15,13 +15,12 @@ export const GroupedAccountsList = ({
     groupedAccounts,
     onSelectAccount,
 }: GroupedAccountsListProps) => (
-    <VStack spacing="large" paddingBottom="medium">
+    <VStack spacing="medium" paddingBottom="medium">
         {Object.entries(groupedAccounts).map(
             ([accountTypeHeader, networkAccounts]) =>
                 networkAccounts && (
                     <AccountsListGroup
                         key={accountTypeHeader}
-                        groupHeader={accountTypeHeader}
                         accounts={networkAccounts}
                         onSelectAccount={onSelectAccount}
                     />

--- a/suite-native/accounts/src/utils.ts
+++ b/suite-native/accounts/src/utils.ts
@@ -1,7 +1,7 @@
 import { A, D, G } from '@mobily/ts-belt';
 
 import { AccountType, networks } from '@suite-common/wallet-config';
-import { formattedBitcoinAccountTypeMap } from '@suite-common/wallet-core/src/accounts/constants';
+import { formattedAccountTypeMap } from '@suite-common/wallet-core/src/accounts/constants';
 import { Account } from '@suite-common/wallet-types';
 import { getNetwork } from '@suite-common/wallet-utils';
 
@@ -30,12 +30,13 @@ export const isFilterValueMatchingAccount = (account: Account, filterValue: stri
 
     const isBitcoinNetworkType = networks[account.symbol].networkType === 'bitcoin';
     const lowercasedSectionHeader = accountTypeToSectionHeader[account.accountType]?.toLowerCase();
-    const lowercasedBitcoinAccountType =
-        formattedBitcoinAccountTypeMap[account.accountType]?.toLowerCase();
+
+    const lowerCasedAccountType =
+        formattedAccountTypeMap[account.networkType]?.[account.accountType]?.toLowerCase();
 
     const isMatchingAccountType =
         (lowercasedSectionHeader?.includes(filterValue) ||
-            (isBitcoinNetworkType && lowercasedBitcoinAccountType?.includes(filterValue))) ??
+            (isBitcoinNetworkType && lowerCasedAccountType?.includes(filterValue))) ??
         false;
 
     if (isMatchingAccountType) return true;


### PR DESCRIPTION
## Description
- account list section headers (account type) removed
- cardano legacy and ledger accounts displays corresponding badge


## Related Issue

Resolve #10352 

## Screenshots:

https://github.com/trezor/trezor-suite/assets/26143964/7e7aa322-cf36-46e3-b84f-44c6607e2f8e

