### PR TITLE
Fix fiat input in send form

### DIFF
--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -64,7 +64,6 @@ const getStateFromProps = (props: UseSendFormProps) => {
     const coinFees = props.fees[symbol];
     const levels = getFeeLevels(networkType, coinFees);
     const feeInfo = { ...coinFees, levels };
-    const fiatRates = props.coins.find(item => item.symbol === symbol);
     const localCurrencyOption = {
         value: props.localCurrency,
         label: props.localCurrency.toUpperCase(),
@@ -75,7 +74,6 @@ const getStateFromProps = (props: UseSendFormProps) => {
         network,
         coinFees,
         feeInfo,
-        fiatRates,
         localCurrencyOption,
         online: props.online,
         metadataEnabled: props.metadataEnabled,
@@ -90,6 +88,10 @@ const getStateFromProps = (props: UseSendFormProps) => {
 export const useSendForm = (props: UseSendFormProps): SendContextValues => {
     // public variables, exported to SendFormContext
     const [isLoading, setLoading] = useState(false);
+    const fiatRates = props.coins.find(
+        item => item.symbol === props.selectedAccount.account.symbol,
+    );
+
     const [state, setState] = useState<UseSendFormState>(getStateFromProps(props));
     // private variables, used inside sendForm hook
     const draft = useRef<FormState | undefined>(undefined);
@@ -155,7 +157,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
     // declare sendFormUtils, sub-hook of useSendForm
     const sendFormUtils = useSendFormFields({
         ...useFormMethods,
-        fiatRates: state.fiatRates,
+        fiatRates,
         network: state.network,
     });
 
@@ -220,7 +222,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
     const { importTransaction } = useSendFormImport({
         network: state.network,
         tokens: state.account.tokens,
-        fiatRates: state.fiatRates,
+        fiatRates,
         localCurrencyOption,
     });
 
@@ -359,6 +361,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
         ...useFormMethods,
         isLoading,
         register,
+        fiatRates,
         outputs: outputsFieldArray.fields,
         composedLevels,
         updateContext,

--- a/packages/suite/src/hooks/wallet/useSendFormFields.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormFields.ts
@@ -9,9 +9,10 @@ import {
 } from 'src/types/wallet/sendForm';
 import { isFeatureFlagEnabled } from '@suite-common/suite-utils';
 import { useBitcoinAmountUnit } from './useBitcoinAmountUnit';
+import { CoinFiatRates } from '@suite-common/wallet-types';
 
 type Props = UseFormReturn<FormState> & {
-    fiatRates: UseSendFormState['fiatRates'];
+    fiatRates?: CoinFiatRates;
     network: UseSendFormState['network'];
 };
 

--- a/packages/suite/src/hooks/wallet/useSendFormImport.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormImport.ts
@@ -4,11 +4,12 @@ import { DEFAULT_PAYMENT } from '@suite-common/wallet-constants';
 import { fiatCurrencies } from '@suite-common/suite-config';
 import { fromFiatCurrency, toFiatCurrency } from '@suite-common/wallet-utils';
 import { UseSendFormState, Output } from 'src/types/wallet/sendForm';
+import { CoinFiatRates } from '@suite-common/wallet-types';
 
 type Props = {
     network: UseSendFormState['network'];
     tokens: UseSendFormState['account']['tokens'];
-    fiatRates: UseSendFormState['fiatRates'];
+    fiatRates?: CoinFiatRates;
     localCurrencyOption: UseSendFormState['localCurrencyOption'];
 };
 

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/Fiat.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/Fiat.tsx
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+import { Timestamp } from '@suite-common/wallet-types';
 import BigNumber from 'bignumber.js';
 import styled from 'styled-components';
 import { Controller } from 'react-hook-form';
@@ -8,7 +9,6 @@ import { useSendFormContext } from 'src/hooks/wallet';
 import {
     fromFiatCurrency,
     getInputState,
-    getFiatRate,
     findToken,
     isLowAnonymityWarning,
     amountToSatoshi,
@@ -21,6 +21,10 @@ import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 import { NumberInput } from 'src/components/suite';
 import { useTranslation } from 'src/hooks/suite';
 import { validateDecimals } from 'src/utils/suite/validation';
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { updateFiatRatesThunk } from '@suite-common/wallet-core';
+import { useDispatch } from 'react-redux';
 
 const Wrapper = styled.div`
     display: flex;
@@ -44,13 +48,14 @@ export const Fiat = ({ output, outputId }: FiatProps) => {
         getDefaultValue,
         control,
         setValue,
-        localCurrencyOption,
         composeTransaction,
+        watch,
     } = useSendFormContext();
 
     const { shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
 
     const { translationString } = useTranslation();
+    const dispatch = useDispatch();
 
     const fiatInputName = `outputs.${outputId}.fiat` as const;
     const currencyInputName = `outputs.${outputId}.currency` as const;
@@ -62,9 +67,31 @@ export const Fiat = ({ output, outputId }: FiatProps) => {
     const error = outputError ? outputError.fiat : undefined;
     const fiatValue = getDefaultValue(fiatInputName, output.fiat || '');
     const tokenValue = getDefaultValue(tokenInputName, output.token);
-    const currencyValue =
-        getDefaultValue(currencyInputName, output.currency) || localCurrencyOption;
+    const amountValue = getDefaultValue(amountInputName, '');
     const token = findToken(account.tokens, tokenValue);
+
+    const currencyValue = watch(currencyInputName);
+
+    const recalculateFiat = (rate: number) => {
+        const formattedAmount = new BigNumber(
+            shouldSendInSats ? formatAmount(amountValue, network.decimals) : amountValue,
+        );
+
+        if (
+            rate &&
+            formattedAmount &&
+            !formattedAmount.isNaN() &&
+            formattedAmount.gt(0) // formatAmount() returns '-1' on error
+        ) {
+            const fiatValueBigNumber = formattedAmount.multipliedBy(rate);
+
+            setValue(fiatInputName, fiatValueBigNumber.toFixed(2), {
+                shouldValidate: true,
+            });
+            // call compose to store draft, precomposedTx should be the same
+            composeTransaction(amountInputName);
+        }
+    };
 
     // relation case:
     // Amount input has an error and Fiat has not (but it should)
@@ -97,7 +124,7 @@ export const Fiat = ({ output, outputId }: FiatProps) => {
 
             // calculate new Amount, Fiat input times currency rate
             // NOTE: get fresh values (currencyValue may be outdated)
-            const { value: fiatCurrency } = getDefaultValue(currencyInputName, localCurrencyOption);
+            const fiatCurrency = currencyValue.value;
 
             const decimals = token ? token.decimals : network.decimals;
 
@@ -120,19 +147,18 @@ export const Fiat = ({ output, outputId }: FiatProps) => {
             composeTransaction(amountInputName);
         },
         [
-            amountInputName,
-            clearErrors,
-            composeTransaction,
-            currencyInputName,
-            error,
-            fiatRates,
-            getDefaultValue,
             isSetMaxActive,
-            localCurrencyOption,
-            network.decimals,
-            setValue,
+            error,
+            currencyValue.value,
             token,
+            network.decimals,
+            fiatRates,
             shouldSendInSats,
+            composeTransaction,
+            amountInputName,
+            setValue,
+            getDefaultValue,
+            clearErrors,
         ],
     );
 
@@ -150,58 +176,37 @@ export const Fiat = ({ output, outputId }: FiatProps) => {
         };
     }
 
-    const renderCurrencySelect = useCallback(
-        ({ field: { onChange, value } }: CallbackParams) => (
-            <Select
-                options={buildCurrencyOptions(value)}
-                value={value}
-                isClearable={false}
-                isSearchable
-                hideTextCursor
-                minWidth="58px"
-                isClean
-                data-test={currencyInputName}
-                onChange={(selected: CurrencyOption) => {
-                    // propagate changes to FormState
-                    onChange(selected);
-                    // calculate Amount value
-                    const rate = getFiatRate(fiatRates, selected.value);
-                    const amountValue = getDefaultValue(amountInputName, '');
+    const renderCurrencySelect = ({ field: { onChange, value } }: CallbackParams) => (
+        <Select
+            options={buildCurrencyOptions(value)}
+            value={value}
+            isClearable={false}
+            isSearchable
+            hideTextCursor
+            minWidth="58px"
+            isClean
+            data-test={currencyInputName}
+            onChange={async (selected: CurrencyOption) => {
+                // propagate changes to FormState
+                onChange(selected);
 
-                    const formattedAmount = new BigNumber(
-                        shouldSendInSats
-                            ? formatAmount(amountValue, network.decimals)
-                            : amountValue,
-                    );
+                // Get (fresh) fiat rates for newly selected currency
+                const updateFiatRatesResult = await dispatch(
+                    updateFiatRatesThunk({
+                        ticker: { symbol: account.symbol as NetworkSymbol },
+                        localCurrency: selected.value as FiatCurrencyCode,
+                        rateType: 'current',
+                        lastSuccessfulFetchTimestamp: Date.now() as Timestamp,
+                    }),
+                );
 
-                    if (
-                        rate &&
-                        formattedAmount &&
-                        !formattedAmount.isNaN() &&
-                        formattedAmount.gt(0) // formatAmount() returns '-1' on error
-                    ) {
-                        const fiatValueBigNumber = formattedAmount.multipliedBy(rate);
+                if (updateFiatRatesResult.meta.requestStatus === 'fulfilled') {
+                    const rate = updateFiatRatesResult.payload as number;
 
-                        setValue(fiatInputName, fiatValueBigNumber.toFixed(2), {
-                            shouldValidate: true,
-                        });
-                        // call compose to store draft, precomposedTx should be the same
-                        composeTransaction(amountInputName);
-                    }
-                }}
-            />
-        ),
-        [
-            currencyInputName,
-            fiatRates,
-            amountInputName,
-            composeTransaction,
-            getDefaultValue,
-            fiatInputName,
-            setValue,
-            shouldSendInSats,
-            network.decimals,
-        ],
+                    recalculateFiat(rate);
+                }
+            }}
+        />
     );
 
     return (

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/Fiat.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/Fiat.tsx
@@ -52,7 +52,7 @@ export const Fiat = ({ output, outputId }: FiatProps) => {
 
     const { translationString } = useTranslation();
 
-    const inputName = `outputs.${outputId}.fiat` as const;
+    const fiatInputName = `outputs.${outputId}.fiat` as const;
     const currencyInputName = `outputs.${outputId}.currency` as const;
     const amountInputName = `outputs.${outputId}.amount` as const;
     const tokenInputName = `outputs.${outputId}.token` as const;
@@ -60,7 +60,7 @@ export const Fiat = ({ output, outputId }: FiatProps) => {
 
     const outputError = errors.outputs ? errors.outputs[outputId] : undefined;
     const error = outputError ? outputError.fiat : undefined;
-    const fiatValue = getDefaultValue(inputName, output.fiat || '');
+    const fiatValue = getDefaultValue(fiatInputName, output.fiat || '');
     const tokenValue = getDefaultValue(tokenInputName, output.token);
     const currencyValue =
         getDefaultValue(currencyInputName, output.currency) || localCurrencyOption;
@@ -182,7 +182,7 @@ export const Fiat = ({ output, outputId }: FiatProps) => {
                     ) {
                         const fiatValueBigNumber = formattedAmount.multipliedBy(rate);
 
-                        setValue(inputName, fiatValueBigNumber.toFixed(2), {
+                        setValue(fiatInputName, fiatValueBigNumber.toFixed(2), {
                             shouldValidate: true,
                         });
                         // call compose to store draft, precomposedTx should be the same
@@ -197,7 +197,7 @@ export const Fiat = ({ output, outputId }: FiatProps) => {
             amountInputName,
             composeTransaction,
             getDefaultValue,
-            inputName,
+            fiatInputName,
             setValue,
             shouldSendInSats,
             network.decimals,
@@ -211,8 +211,8 @@ export const Fiat = ({ output, outputId }: FiatProps) => {
                 inputState={inputState}
                 isMonospace
                 onChange={handleChange}
-                name={inputName}
-                data-test={inputName}
+                name={fiatInputName}
+                data-test={fiatInputName}
                 defaultValue={fiatValue}
                 maxLength={MAX_LENGTH.FIAT}
                 rules={rules}

--- a/suite-common/wallet-types/src/sendForm.ts
+++ b/suite-common/wallet-types/src/sendForm.ts
@@ -54,9 +54,8 @@ export type UseSendFormState = {
     account: Account;
     network: Network;
     coinFees: FeeInfo;
-    feeInfo: FeeInfo;
-    fiatRates: CoinFiatRates | undefined;
     localCurrencyOption: CurrencyOption;
+    feeInfo: FeeInfo;
     composedLevels?: PrecomposedLevels | PrecomposedLevelsCardano;
     online: boolean;
     metadataEnabled: boolean;
@@ -101,6 +100,7 @@ export type SendContextValues<TFormValues extends FormState = FormState> =
     UseFormReturn<TFormValues> &
         UseSendFormState & {
             isLoading: boolean;
+            fiatRates?: CoinFiatRates;
             // additional fields
             outputs: Partial<Output & { id: string }>[]; // useFieldArray fields
             updateContext: (value: Partial<UseSendFormState>) => void;


### PR DESCRIPTION
## Description

The problem is, that before we had `symbol`'s fiat rate for all currencies. Currently, we are getting it just for the currency set it settings.

- [chore(suite): move fiatRates from sendForm state](https://github.com/trezor/trezor-suite/pull/10552/commits/5b14699637d95661458ca5b76d986884416cc0e7)
  - this commit ensures that `fiatRates` are always up-to-date
  - another solution could be to use `updateContext` to update `state` on `fiatRates`. However, it sounds stupid
- [chore(suite): rename fiat input name](https://github.com/trezor/trezor-suite/pull/10552/commits/0f69301f53623263cd92493b5110894c86c4b399)
  - just a name refactor, not nice for hotfix, but it is small 
- [fix(suite): fetch fiat rates for locally selected currency in sendform](https://github.com/trezor/trezor-suite/pull/10552/commits/8e8d6b49d7347ad67626ea1905386a6bcc11ea89)
  - it fetches current `symbol`'s fiat rate for locally selected currency 

## Related Issue

Resolves #10545

## Screenshots

https://github.com/trezor/trezor-suite/assets/33235762/2d0b0f32-f194-4a46-b443-15cf8df36e53

