### PR TITLE
Fix/eth tokens discovery

### DIFF
--- a/suite-native/accounts/src/components/AccountListItemInteractive.tsx
+++ b/suite-native/accounts/src/components/AccountListItemInteractive.tsx
@@ -5,6 +5,7 @@ import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
 import { selectIsEthereumAccountWithTokensWithFiatRates } from '@suite-native/ethereum-tokens';
 import { SettingsSliceRootState } from '@suite-native/module-settings';
 import { FiatRatesRootState } from '@suite-native/fiat-rates';
+import { Box } from '@suite-native/atoms';
 
 import { TokenList } from './TokenList';
 import { AccountListItem, AccountListItemProps } from './AccountListItem';
@@ -22,7 +23,7 @@ export const AccountListItemInteractive = ({
     );
 
     return (
-        <>
+        <Box>
             <TouchableOpacity onPress={() => onSelectAccount(account.key)}>
                 <AccountListItem
                     key={account.key}
@@ -33,6 +34,6 @@ export const AccountListItemInteractive = ({
             {areTokensDisplayed && (
                 <TokenList accountKey={account.key} onSelectAccount={onSelectAccount} />
             )}
-        </>
+        </Box>
     );
 };

--- a/suite-native/discovery/src/discoveryThunks.ts
+++ b/suite-native/discovery/src/discoveryThunks.ts
@@ -15,8 +15,8 @@ import {
 import { selectIsAccountAlreadyDiscovered } from '@suite-native/accounts';
 import TrezorConnect from '@trezor/connect';
 import { DiscoveryItem } from '@suite-common/wallet-types';
-import { getDerivationType, getNetwork } from '@suite-common/wallet-utils';
-import { Network, NetworkSymbol } from '@suite-common/wallet-config';
+import { getDerivationType } from '@suite-common/wallet-utils';
+import { Network, NetworkSymbol, getNetworkType } from '@suite-common/wallet-config';
 import { DiscoveryStatus } from '@suite-common/wallet-constants';
 import { requestDeviceAccess } from '@suite-native/device-mutex';
 import { analytics, EventType } from '@suite-native/analytics';
@@ -88,9 +88,13 @@ const finishNetworkTypeDiscoveryThunk = createThunk(
 );
 
 const getDetailsLevels = (coin: NetworkSymbol) => {
-    const network = getNetwork(coin);
+    const networkType = getNetworkType(coin);
     // For Cardano we need to fetch at least one tx otherwise it will not generate correctly new receive addresses (xpub instead of address)
-    if (network?.networkType === 'cardano') return { details: 'txs', pageSize: 1 } as const;
+    if (networkType === 'cardano') return { details: 'txs', pageSize: 1 } as const;
+
+    // For Ethereum we need to fetch token balances to be able to get their fiat rates and later display them in the UI.
+    if (networkType === 'ethereum') return { details: 'tokenBalances' } as const;
+
     return { details: 'tokens' } as const;
 };
 

--- a/suite-native/discovery/src/discoveryThunks.ts
+++ b/suite-native/discovery/src/discoveryThunks.ts
@@ -87,7 +87,7 @@ const finishNetworkTypeDiscoveryThunk = createThunk(
     },
 );
 
-const getDetailsLevels = (coin: NetworkSymbol) => {
+const getAccountInfoDetailsLevel = (coin: NetworkSymbol) => {
     const networkType = getNetworkType(coin);
     // For Cardano we need to fetch at least one tx otherwise it will not generate correctly new receive addresses (xpub instead of address)
     if (networkType === 'cardano') return { details: 'txs', pageSize: 1 } as const;
@@ -95,7 +95,7 @@ const getDetailsLevels = (coin: NetworkSymbol) => {
     // For Ethereum we need to fetch token balances to be able to get their fiat rates and later display them in the UI.
     if (networkType === 'ethereum') return { details: 'tokenBalances' } as const;
 
-    return { details: 'tokens' } as const;
+    return { details: 'basic' } as const;
 };
 
 const discoverAccountsByDescriptorThunk = createThunk(
@@ -124,7 +124,7 @@ const discoverAccountsByDescriptorThunk = createThunk(
                 descriptor: bundleItem.descriptor,
                 useEmptyPassphrase: true,
                 skipFinalReload: true,
-                ...getDetailsLevels(bundleItem.coin),
+                ...getAccountInfoDetailsLevel(bundleItem.coin),
             });
 
             if (success) {


### PR DESCRIPTION

## Description
- 95cbc47b41b38b666db67e4405fbd12f99c995ca: After discovery of ETH account, the fiat rates middleware downloads fiat rates for all its tokens. This step is crucial, because we are displaying only tokens that have fiat rates. Other are considered as scam tokens and ignored.
- 360d54198a7a315858c66c13d711ec2579b67068: `AccountListItem` is now wrapped into Box component, to avoid malformed layout created by parent `VStack` component.

## Related Issue

Resolve #10525 

## Screenshots:

https://github.com/trezor/trezor-suite/assets/26143964/c85fdeba-ca0b-4cd7-899f-b01d39ede5ae

