### PR TITLE
fix(mobile): fix Cardano receive

### DIFF
--- a/packages/react-native-usb/android/src/main/java/io/trezor/rnusb/ReactNativeUsbModule.kt
+++ b/packages/react-native-usb/android/src/main/java/io/trezor/rnusb/ReactNativeUsbModule.kt
@@ -262,7 +262,9 @@ class ReactNativeUsbModule : Module() {
             Log.e("ReactNativeUsbModule", "Failed to get endpoint $endpointNumber for device ${device.deviceName}")
             throw Exception("Failed to get endpoint $endpointNumber for device ${device.deviceName}")
         }
-        return usbConnection.bulkTransfer(usbEndpoint, dataByteArray, dataByteArray.size, 0)
+        val result = usbConnection.bulkTransfer(usbEndpoint, dataByteArray, dataByteArray.size, 0)
+        Log.d("ReactNativeUsbModule", "Transfered data to device ${device.deviceName}: $result")
+        return result
     }
 
     private fun transferIn(deviceName: String, endpointNumber: Int, length: Int): IntArray {

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -192,7 +192,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                     const { encode, decode } = protocol || v1Protocol;
                     const buffers = buildBuffers(this.messages, name, data, encode);
                     for (const chunk of buffers) {
-                        this.api.write(path, chunk).then(result => {
+                        await this.api.write(path, chunk).then(result => {
                             if (!result.success) {
                                 throw new Error(result.error);
                             }


### PR DESCRIPTION
There was issue on mobile that if there was more than one 64 bytes chunks in `call` to device, it sometimes failed because chunks order get mixed up. This change should enforce sensing chunks in series not parallel which resulted in unexpected behavior on mobile randomly.

I guess this worked OK on desktop because there are some build in queues for write call.

This change should be tested also no desktop with physical device, ideally on same scenario like on mobile (generating address for Cardano #1 from all seed) 

## Related Issue

Resolve #10343 

## Screenshots:
