### PR TITLE
chore(transport): move node-bridge logic to transport-bridge package

### DIFF
--- a/packages/transport-bridge/README.md
+++ b/packages/transport-bridge/README.md
@@ -1,0 +1,3 @@
+# @trezor/transport-bridge
+
+-   javascript clone of https://github.com/trezor/trezord-go

--- a/packages/transport-bridge/package.json
+++ b/packages/transport-bridge/package.json
@@ -1,0 +1,25 @@
+{
+    "name": "@trezor/transport-bridge",
+    "version": "1.0.0",
+    "main": "src/index",
+    "license": "See LICENSE.md in repo root",
+    "private": true,
+    "sideEffects": false,
+    "scripts": {
+        "type-check": "tsc --build",
+        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
+    },
+    "devDependencies": {
+        "@types/cors": "^2.8.15",
+        "@types/express": "^4",
+        "typescript": "4.9.5"
+    },
+    "dependencies": {
+        "@trezor/protocol": "workspace:*",
+        "@trezor/transport": "workspace:*",
+        "@trezor/utils": "workspace:*",
+        "cors": "^2.8.5",
+        "express": "^4.18.2",
+        "usb": "^2.11.0"
+    }
+}

--- a/packages/transport-bridge/src/core.ts
+++ b/packages/transport-bridge/src/core.ts
@@ -1,12 +1,11 @@
 import { WebUSB } from 'usb';
 
 import { v1 as protocolV1, bridge as protocolBridge } from '@trezor/protocol';
-
-import { receive as receiveUtil } from '../utils/receive';
-import { SessionsBackground } from '../sessions/background';
-import { SessionsClient } from '../sessions/client';
-import { UsbApi } from '../api/usb';
-import { AcquireInput, ReleaseInput } from '../transports/abstract';
+import { receive as receiveUtil } from '@trezor/transport/src/utils/receive';
+import { SessionsBackground } from '@trezor/transport/src/sessions/background';
+import { SessionsClient } from '@trezor/transport/src/sessions/client';
+import { UsbApi } from '@trezor/transport/src/api/usb';
+import { AcquireInput, ReleaseInput } from '@trezor/transport/src/transports/abstract';
 
 export const sessionsBackground = new SessionsBackground();
 
@@ -42,6 +41,7 @@ const writeUtil = async ({ path, data }: { path: string; data: string }) => {
 
     for (let i = 0; i < buffers.length; i++) {
         const bufferSegment = buffers[i];
+        // eslint-disable-next-line no-await-in-loop
         await api.write(path, bufferSegment);
     }
 };

--- a/packages/transport-bridge/src/http.ts
+++ b/packages/transport-bridge/src/http.ts
@@ -1,9 +1,9 @@
-import express, { Express, Request, Response } from 'express';
+import express from 'express';
 import cors from 'cors';
 
+import { Descriptor } from '@trezor/transport/src/types';
 import { arrayPartition } from '@trezor/utils/lib/arrayPartition';
 
-import { Descriptor } from '../types';
 import { sessionsClient, enumerate, acquire, release, call, send, receive } from './core';
 
 const defaults = {
@@ -19,11 +19,11 @@ export class TrezordNode {
     /** pending /listen subscriptions that are supposed to be resolved whenever descriptors change is detected */
     listenSubscriptions: {
         descriptors: string;
-        req: Request;
-        res: Response;
+        req: express.Request;
+        res: express.Response;
     }[];
     port: number;
-    server: Express = express();
+    server = express();
 
     constructor({ port }: { port: number }) {
         this.port = port || defaults.port;
@@ -53,8 +53,6 @@ export class TrezordNode {
 
     public start() {
         return new Promise<void>(resolve => {
-            console.log(`starting ${this.serviceName}, version: ${this.version}}`);
-
             const app = express();
 
             // todo: limit to whitelisted domains

--- a/packages/transport-bridge/src/index.ts
+++ b/packages/transport-bridge/src/index.ts
@@ -1,0 +1,1 @@
+export { TrezordNode } from './http';

--- a/packages/transport-bridge/tsconfig.json
+++ b/packages/transport-bridge/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": { "outDir": "libDev" },
+    "references": [
+        { "path": "../protocol" },
+        { "path": "../transport" },
+        { "path": "../utils" }
+    ]
+}

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -45,8 +45,6 @@
     "devDependencies": {
         "@trezor/trezor-user-env-link": "workspace:*",
         "@types/bytebuffer": "^5.0.46",
-        "@types/cors": "^2.8.15",
-        "@types/express": "^4",
         "@types/sharedworker": "^0.0.105",
         "@types/w3c-web-usb": "^1.0.9",
         "jest": "29.5.0",
@@ -59,9 +57,7 @@
         "@trezor/protobuf": "workspace:*",
         "@trezor/protocol": "workspace:*",
         "@trezor/utils": "workspace:*",
-        "cors": "^2.8.5",
         "cross-fetch": "^4.0.0",
-        "express": "^4.18.2",
         "json-stable-stringify": "^1.0.2",
         "long": "^4.0.0",
         "protobufjs": "7.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9482,6 +9482,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@trezor/transport-bridge@workspace:packages/transport-bridge":
+  version: 0.0.0-use.local
+  resolution: "@trezor/transport-bridge@workspace:packages/transport-bridge"
+  dependencies:
+    "@trezor/protocol": "workspace:*"
+    "@trezor/transport": "workspace:*"
+    "@trezor/utils": "workspace:*"
+    "@types/cors": "npm:^2.8.15"
+    "@types/express": "npm:^4"
+    cors: "npm:^2.8.5"
+    express: "npm:^4.18.2"
+    typescript: "npm:4.9.5"
+    usb: "npm:^2.11.0"
+  languageName: unknown
+  linkType: soft
+
 "@trezor/transport-native@workspace:*, @trezor/transport-native@workspace:packages/transport-native":
   version: 0.0.0-use.local
   resolution: "@trezor/transport-native@workspace:packages/transport-native"
@@ -9500,13 +9516,9 @@ __metadata:
     "@trezor/trezor-user-env-link": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@types/bytebuffer": "npm:^5.0.46"
-    "@types/cors": "npm:^2.8.15"
-    "@types/express": "npm:^4"
     "@types/sharedworker": "npm:^0.0.105"
     "@types/w3c-web-usb": "npm:^1.0.9"
-    cors: "npm:^2.8.5"
     cross-fetch: "npm:^4.0.0"
-    express: "npm:^4.18.2"
     jest: "npm:29.5.0"
     json-stable-stringify: "npm:^1.0.2"
     long: "npm:^4.0.0"


### PR DESCRIPTION
moving node bridge logic to `@trezor/transport-bridge` package. 

next steps: 
- multitransport/multiapi, #10563 
- binary build #10356 
- running node-bridge as a module in suite desktop app #9985