### PR TITLE
style(suite): Redesign banners

### DIFF
--- a/packages/components/src/components/buttons/Button/buttons.stories.tsx
+++ b/packages/components/src/components/buttons/Button/buttons.stories.tsx
@@ -4,7 +4,14 @@ import { capitalizeFirstLetter } from '@trezor/utils';
 import { StoryColumn } from '../../../support/Story';
 import { ButtonVariant } from '../buttonStyleUtils';
 
-const variants: Array<ButtonVariant> = ['primary', 'secondary', 'tertiary', 'destructive'];
+const variants: Array<ButtonVariant> = [
+    'primary',
+    'secondary',
+    'tertiary',
+    'info',
+    'warning',
+    'destructive',
+];
 
 export default {
     title: 'Buttons/Button/All',

--- a/packages/components/src/components/buttons/buttonStyleUtils.ts
+++ b/packages/components/src/components/buttons/buttonStyleUtils.ts
@@ -7,7 +7,13 @@ import {
     nextElevation,
 } from '@trezor/theme';
 
-export type ButtonVariant = 'primary' | 'secondary' | 'tertiary' | 'destructive';
+export type ButtonVariant =
+    | 'primary'
+    | 'secondary'
+    | 'tertiary'
+    | 'info'
+    | 'warning'
+    | 'destructive';
 export type ButtonSize = 'large' | 'medium' | 'small' | 'tiny';
 export type IconAlignment = 'left' | 'right';
 
@@ -48,6 +54,10 @@ export const getIconColor = (variant: ButtonVariant, isDisabled: boolean, theme:
             return theme.iconOnSecondary;
         case 'tertiary':
             return theme.iconOnTertiary;
+        case 'info':
+            return theme.iconAlertBlue;
+        case 'warning':
+            return theme.iconAlertYellow;
         case 'destructive':
             return theme.iconAlertRed;
         // no default
@@ -104,6 +114,26 @@ export const getVariantStyle = (variant: ButtonVariant, elevation: Elevation) =>
                 :active {
                     background: ${({ theme }) =>
                         theme[mapElevationToBackgroundTertiary[nextElevation[elevation]]]};
+                }
+            `;
+        case 'info':
+            return css`
+                background: ${({ theme }) => theme.backgroundAlertBlueSubtleOnElevation0};
+                color: ${({ theme }) => theme.textAlertBlue};
+
+                :hover,
+                :active {
+                    background: ${({ theme }) => theme.backgroundAlertBlueSubtleOnElevation1};
+                }
+            `;
+        case 'warning':
+            return css`
+                background: ${({ theme }) => theme.backgroundAlertYellowSubtleOnElevation0};
+                color: ${({ theme }) => theme.textAlertYellow};
+
+                :hover,
+                :active {
+                    background: ${({ theme }) => theme.backgroundAlertYellowSubtleOnElevation1};
                 }
             `;
         case 'destructive':

--- a/packages/suite/src/components/suite/Preloader/SuiteLayout/CoinjoinBars/CoinjoinStatusBar.tsx
+++ b/packages/suite/src/components/suite/Preloader/SuiteLayout/CoinjoinBars/CoinjoinStatusBar.tsx
@@ -34,8 +34,8 @@ const Container = styled.div<{ isClickable: boolean }>`
     align-items: center;
     height: 28px;
     padding: 0 ${SPACING}px;
-    background: ${({ theme }) => theme.BG_WHITE};
-    border-bottom: 1px solid ${({ theme }) => theme.STROKE_LIGHT_GREY};
+    background: ${({ theme }) => theme.backgroundSurfaceElevationNegative};
+    border-bottom: 1px solid ${({ theme }) => theme.borderOnElevation0};
     font-size: ${variables.FONT_SIZE.TINY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     transition: background 0.15s;

--- a/packages/suite/src/components/suite/banners/Banner.tsx
+++ b/packages/suite/src/components/suite/banners/Banner.tsx
@@ -1,41 +1,73 @@
 import { ReactNode } from 'react';
-import styled, { useTheme } from 'styled-components';
-import { Button, Icon, SuiteThemeColors, variables } from '@trezor/components';
+import styled, { DefaultTheme, useTheme } from 'styled-components';
+import { Button, Icon, variables } from '@trezor/components';
+import { borders, spacingsPx, typography } from '@trezor/theme';
+import { ButtonVariant } from '@trezor/components/src/components/buttons/buttonStyleUtils';
 
-const getBgColor = (variant: BannerProps['variant'], theme: SuiteThemeColors) => {
+export type BannerVariant = Extract<ButtonVariant, 'info' | 'warning' | 'destructive'>;
+
+interface BannerProps {
+    body: ReactNode;
+    variant: BannerVariant;
+    action?: {
+        label: ReactNode | string;
+        onClick: () => void;
+        'data-test': string;
+    };
+    dismissal?: {
+        onClick: () => void;
+        'data-test': string;
+    };
+    className?: string;
+}
+
+const getBackgroundColor = (variant: BannerVariant, theme: DefaultTheme) => {
     switch (variant) {
         case 'info':
-            return theme.TYPE_BLUE;
+            return theme.backgroundAlertBlueBold;
         case 'warning':
-            return theme.TYPE_ORANGE;
-        case 'critical':
-            return theme.BG_RED;
+            return theme.backgroundAlertYellowBold;
+        case 'destructive':
+            return theme.backgroundAlertRedBold;
         default:
-            return 'transparent';
+            return theme.backgroundAlertBlueBold;
     }
 };
 
-const getIcon = (variant: BannerProps['variant'], theme: SuiteThemeColors) => {
+const getForegroundColor = (variant: BannerVariant, theme: DefaultTheme) => {
     switch (variant) {
         case 'info':
-            return <Icon icon="INFO" size={18} color={theme.TYPE_WHITE} />;
+            return theme.textDefaultInverse;
         case 'warning':
-        case 'critical':
-            return <Icon icon="WARNING" size={18} color={theme.TYPE_WHITE} />;
+            return theme.textDefaultInverse;
+        case 'destructive':
+            return theme.textDefaultInverse;
+        default:
+            return theme.textDefaultInverse;
+    }
+};
+const getIcon = (variant: BannerVariant, theme: DefaultTheme) => {
+    switch (variant) {
+        case 'info':
+            return <Icon icon="INFO" size={22} color={theme.textDefaultInverse} />; // @TODO iconDefaultInverse
+        case 'warning':
+            return <Icon icon="WARNING" size={22} color={theme.textDefaultInverse} />; // @TODO iconDefaultInverse
+        case 'destructive':
+            return <Icon icon="WARNING" size={22} color={theme.textDefaultInverse} />; // @TODO iconDefaultInverse
         default:
             return null;
     }
 };
 
-const Wrapper = styled.div<{ variant: BannerProps['variant'] }>`
+const Wrapper = styled.div<{ variant: BannerVariant }>`
     display: flex;
-    background: ${({ theme, variant }) => getBgColor(variant, theme)};
-    color: ${({ theme }) => theme.TYPE_WHITE};
-    padding: 7px 9px;
-    font-weight: 600;
-    border-radius: 10px;
-    margin: 6px 6px 4px;
-    line-height: 1.5;
+    gap: ${spacingsPx.xs};
+    background: ${({ theme, variant }) => getBackgroundColor(variant, theme)};
+    color: ${({ theme, variant }) => getForegroundColor(variant, theme)};
+    padding: ${spacingsPx.xs} ${spacingsPx.sm};
+    ${typography.highlight}
+    border-radius: ${borders.radii.sm};
+    margin: ${spacingsPx.xs};
     align-items: center;
 
     @media (max-width: ${variables.SCREEN_SIZE.SM}) {
@@ -44,7 +76,7 @@ const Wrapper = styled.div<{ variant: BannerProps['variant'] }>`
 `;
 
 const IconWrapper = styled.div`
-    margin: auto 8px auto 4px;
+    margin: auto ${spacingsPx.xxs};
 
     @media (max-width: ${variables.SCREEN_SIZE.SM}) {
         display: none;
@@ -59,6 +91,7 @@ const BlankLeft = styled.div`
 
 const Body = styled.div`
     display: flex;
+    gap: ${spacingsPx.xs};
     width: 100%;
     position: relative;
     justify-content: left;
@@ -77,7 +110,7 @@ const ActionsWrapper = styled.div`
     display: flex;
     align-items: center;
     justify-content: flex-end;
-    right: 14px;
+    right: ${spacingsPx.sm};
 
     @media screen and (max-width: ${variables.SCREEN_SIZE.XL}) {
         position: relative;
@@ -85,8 +118,8 @@ const ActionsWrapper = styled.div`
     }
 
     @media (max-width: ${variables.SCREEN_SIZE.SM}) {
-        padding-left: 18px;
-        padding-right: 18px;
+        padding-left: ${spacingsPx.lg};
+        padding-right: ${spacingsPx.lg};
     }
 
     @media (min-width: ${variables.SCREEN_SIZE.XL}) {
@@ -94,39 +127,14 @@ const ActionsWrapper = styled.div`
     }
 `;
 
-const ActionButton = styled(Button)<{ color: BannerProps['variant'] }>`
-    height: 24px;
-    margin-right: 4px;
-    margin-left: 10px;
-
-    @media (max-width: ${variables.SCREEN_SIZE.SM}) {
-        margin-top: 5px;
-    }
-`;
-
 const CancelWrapper = styled.div`
-    margin-left: 5px;
+    margin-left: ${spacingsPx.xs};
 `;
-
-interface BannerProps {
-    body: ReactNode;
-    variant: 'info' | 'warning' | 'critical';
-    action?: {
-        label: ReactNode | string;
-        onClick: () => void;
-        'data-test': string;
-    };
-    dismissal?: {
-        onClick: () => void;
-        'data-test': string;
-    };
-    className?: string;
-}
 
 export const Banner = ({ body, variant, action, dismissal, className }: BannerProps) => {
     const theme = useTheme();
-    const iconElement = getIcon(variant, theme);
 
+    const iconElement = getIcon(variant, theme);
     return (
         <Wrapper variant={variant} className={className}>
             <BlankLeft />
@@ -136,21 +144,21 @@ export const Banner = ({ body, variant, action, dismissal, className }: BannerPr
             </Body>
             <ActionsWrapper>
                 {action && (
-                    <ActionButton
-                        color={variant}
+                    <Button
+                        size="tiny"
                         variant="tertiary"
                         onClick={action.onClick}
                         data-test={action['data-test']}
                     >
                         {action.label}
-                    </ActionButton>
+                    </Button>
                 )}
                 {dismissal && (
                     <CancelWrapper>
                         <Icon
                             size={20}
                             icon="CROSS"
-                            color={theme.TYPE_WHITE}
+                            color={getForegroundColor(variant, theme)}
                             onClick={dismissal.onClick}
                             data-test={dismissal['data-test']}
                         />

--- a/packages/suite/src/components/suite/banners/MessageSystemBanner.tsx
+++ b/packages/suite/src/components/suite/banners/MessageSystemBanner.tsx
@@ -63,7 +63,7 @@ export const MessageSystemBanner = ({ message }: MessageSystemBannerProps) => {
 
     return (
         <BannerOnTop
-            variant={variant}
+            variant={variant === 'critical' ? 'destructive' : variant}
             body={content[language] || content.en}
             action={actionConfig}
             dismissal={dismissalConfig}

--- a/packages/suite/src/components/suite/banners/SuiteBanners/FailedBackupBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/FailedBackupBanner.tsx
@@ -14,6 +14,10 @@ export const FailedBackup = () => {
     };
 
     return (
-        <Banner variant="critical" body={<Translation id="TR_FAILED_BACKUP" />} action={action} />
+        <Banner
+            variant="destructive"
+            body={<Translation id="TR_FAILED_BACKUP" />}
+            action={action}
+        />
     );
 };

--- a/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareHashMismatchBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareHashMismatchBanner.tsx
@@ -2,5 +2,5 @@ import { Banner } from '../Banner';
 import { Translation } from 'src/components/suite';
 
 export const FirmwareHashMismatch = () => (
-    <Banner variant="critical" body={<Translation id="TR_FIRMWARE_HASH_MISMATCH" />} />
+    <Banner variant="destructive" body={<Translation id="TR_FIRMWARE_HASH_MISMATCH" />} />
 );

--- a/packages/suite/src/components/suite/banners/SuiteBanners/NoBackupBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/NoBackupBanner.tsx
@@ -17,5 +17,5 @@ export const NoBackup = () => {
         'TR_YOUR_TREZOR_IS_NOT_BACKED_UP',
     )} ${translationString('TR_IF_YOUR_DEVICE_IS_EVER_LOST')}`;
 
-    return <Banner variant="critical" body={translation} action={action} />;
+    return <Banner variant="destructive" body={translation} action={action} />;
 };

--- a/packages/suite/src/components/suite/banners/SuiteBanners/OnlineStatusBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/OnlineStatusBanner.tsx
@@ -8,5 +8,7 @@ interface OnlineStatusProps {
 export const OnlineStatus = ({ isOnline }: OnlineStatusProps) => {
     if (isOnline) return null;
 
-    return <Banner variant="critical" body={<Translation id="TR_YOU_WERE_DISCONNECTED_DOT" />} />;
+    return (
+        <Banner variant="destructive" body={<Translation id="TR_YOU_WERE_DISCONNECTED_DOT" />} />
+    );
 };

--- a/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
@@ -19,7 +19,8 @@ import { FirmwareHashMismatch } from './FirmwareHashMismatchBanner';
 import styled from 'styled-components';
 
 const Container = styled.div`
-    background: ${({ theme }) => theme.backgroundSurfaceElevation0};
+    background: ${({ theme }) => theme.backgroundSurfaceElevationNegative};
+    border-bottom: solid 1px ${({ theme }) => theme.borderOnElevation0};
 `;
 
 export const SuiteBanners = () => {

--- a/packages/suite/src/components/suite/section/SectionItem.tsx
+++ b/packages/suite/src/components/suite/section/SectionItem.tsx
@@ -12,7 +12,10 @@ const Content = styled.div<{ shouldHighlight?: boolean }>`
     margin: -${spacingsPx.md};
     border-radius: ${({ shouldHighlight }) => shouldHighlight && borders.radii.xs};
 
-    /* so that the borders underneath are hidden  */
+    /*
+        so that the borders underneath are hidden - used for anchor highlighting
+        @TODO it causes following bug: https://github.com/trezor/trezor-suite/issues/10792
+    */
     z-index: 1;
     ${anchorOutlineStyles}
 

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/CoinjoinContextMessage.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/CoinjoinContextMessage.tsx
@@ -28,7 +28,7 @@ export const CoinjoinContextMessage = ({ account }: CoinjoinContextMessageProps)
                       }
                     : undefined
             }
-            variant={message.variant}
+            variant={message.variant === 'critical' ? 'destructive' : message.variant}
         >
             {message.content}
         </NotificationCard>

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/XRPReserve.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/XRPReserve.tsx
@@ -1,7 +1,8 @@
 import Bignumber from 'bignumber.js';
-import { NotificationCard, Translation, ReadMoreLink } from 'src/components/suite';
+import { NotificationCard, Translation } from 'src/components/suite';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import type { Account } from 'src/types/wallet/index';
+import { HELP_CENTER_XRP_URL } from '@trezor/urls';
 
 interface XRPReserveProps {
     account: Account | undefined;
@@ -13,9 +14,10 @@ export const XRPReserve = ({ account }: XRPReserveProps) => {
     const bigReserve = new Bignumber(account.misc.reserve);
     return bigBalance.isLessThan(bigReserve) ? (
         <NotificationCard
-            variant="info"
+            variant="warning"
             button={{
-                children: <ReadMoreLink url="HELP_CENTER_XRP_URL" />,
+                children: <Translation id="TR_LEARN_MORE" />,
+                href: HELP_CENTER_XRP_URL,
             }}
         >
             <Translation

--- a/packages/suite/src/views/dashboard/components/PortfolioCard/components/Header.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/components/Header.tsx
@@ -1,13 +1,14 @@
 import { useCallback } from 'react';
 import styled, { css } from 'styled-components';
 
-import { Button, ButtonGroup, LoadingContent } from '@trezor/components';
+import { Button, LoadingContent } from '@trezor/components';
 
 import { GraphRangeSelector, Translation } from 'src/components/suite';
 import { updateGraphData } from 'src/actions/wallet/graphActions';
 import { useFastAccounts } from 'src/hooks/wallet';
 import { GraphRange } from 'src/types/wallet/graph';
 import { FiatHeader } from '../../FiatHeader';
+import { spacingsPx } from '@trezor/theme';
 
 const Wrapper = styled.div<{ hideBorder: boolean }>`
     display: flex;
@@ -32,7 +33,10 @@ const Right = styled.div`
     align-items: center;
 `;
 
-const StyledButtonGroup = styled(ButtonGroup)`
+const Buttons = styled.div`
+    display: flex;
+    gap: ${spacingsPx.md};
+
     > * {
         min-width: 120px;
     }
@@ -77,14 +81,18 @@ export const Header = ({
         if (isWalletEmpty) {
             actions = (
                 <>
-                    <StyledButtonGroup variant="primary">
+                    <Buttons>
                         <Button onClick={receiveClickHandler} data-test="@dashboard/receive-button">
                             <Translation id="TR_RECEIVE" />
                         </Button>
-                        <Button onClick={buyClickHandler} data-test="@dashboard/buy-button">
+                        <Button
+                            onClick={buyClickHandler}
+                            data-test="@dashboard/buy-button"
+                            variant="tertiary"
+                        >
                             <Translation id="TR_BUY" />
                         </Button>
-                    </StyledButtonGroup>
+                    </Buttons>
                 </>
             );
         } else if (showGraphControls) {

--- a/packages/suite/src/views/wallet/coinmarket/savings/CoinmarketReauthorizationCard.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/savings/CoinmarketReauthorizationCard.tsx
@@ -23,11 +23,9 @@ export const CoinmarketReauthorizationCard = ({
 
     return (
         <StyledNotificationCard
-            variant="critical"
+            variant="destructive"
             button={{
-                type: 'button',
                 children: <Translation id="TR_SAVINGS_AUTHORIZATION_ERROR_BUTTON_LABEL" />,
-                variant: 'destructive',
                 onClick: handleSubmit,
             }}
         >

--- a/packages/theme/src/colors.ts
+++ b/packages/theme/src/colors.ts
@@ -52,6 +52,8 @@ export const mapElevationToBackground: Record<Elevation, BackgroundElevationColo
     3: 'backgroundSurfaceElevation3',
 };
 
+// @TODO create iconDefaultInverse (packages/suite/src/components/suite/banners/Banner.tsx)
+
 export const colorVariants = {
     standard: {
         transparent: '#00000000',
@@ -141,7 +143,7 @@ export const colorVariants = {
         backgroundAlertBlueSubtleOnElevation1: '#092734ff',
         backGroundOnboardingCard: '#000000BD',
         textDefault: '#ffffffff',
-        textDefaultInverse: '#ffffffff',
+        textDefaultInverse: '#000000ff',
         textSubdued: '#a2a4a3ff',
         textSecondaryHighlight: '#2fbc81ff',
         textOnPrimary: '#000000ff',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Related Issue

Resolve #10523

## Screenshots:


### new Button variants

**info**
<img width="428" alt="image" src="https://github.com/trezor/trezor-suite/assets/858321/3baac3c0-61e6-4cb5-8575-9d249c46fd05">

<img width="430" alt="image" src="https://github.com/trezor/trezor-suite/assets/858321/a714e4be-90be-4be6-9101-0a497205a6bf">



**warning**
<img width="432" alt="image" src="https://github.com/trezor/trezor-suite/assets/858321/496c5a0f-53aa-47a4-ae3d-2caeb4a4c051">

<img width="431" alt="image" src="https://github.com/trezor/trezor-suite/assets/858321/6cc2a43b-a59d-4400-bcfd-58b3640353e0">



### NotificationCard

Note: Button backgrounds are not perfect becase we don't have defined all variantions for button backgrounds on different elevations. It will be done in different PR.

**info**

<img width="1122" alt="Screenshot 2024-01-24 at 14 36 40" src="https://github.com/trezor/trezor-suite/assets/858321/01503cff-3f71-45cd-a470-91efad520b0e">

<img width="1122" alt="Screenshot 2024-01-24 at 14 36 46" src="https://github.com/trezor/trezor-suite/assets/858321/6f154271-5499-4889-afe1-c74b0708c2ac">

<img width="1121" alt="image" src="https://github.com/trezor/trezor-suite/assets/858321/24667f29-0f10-4446-95ce-3399e17e33d2">

<img width="1123" alt="image" src="https://github.com/trezor/trezor-suite/assets/858321/e2ed651f-c98a-42cb-9c20-c37b44e5c207">



**warning**
<img width="1125" alt="Screenshot 2024-01-24 at 14 33 56" src="https://github.com/trezor/trezor-suite/assets/858321/4f8f1651-fc93-4a2c-b75b-bf8aea734763">

<img width="1118" alt="Screenshot 2024-01-24 at 14 37 40" src="https://github.com/trezor/trezor-suite/assets/858321/8caf342b-65c4-4887-9622-480809b22f4b">

<img width="1126" alt="Screenshot 2024-01-24 at 15 58 08" src="https://github.com/trezor/trezor-suite/assets/858321/c328fad7-92d1-4910-b76f-3b0085da43c7">

<img width="1123" alt="image" src="https://github.com/trezor/trezor-suite/assets/858321/1e0639ae-8641-4ad0-a670-4f106931d673">



**destructive**
<img width="1125" alt="Screenshot 2024-01-24 at 14 36 19" src="https://github.com/trezor/trezor-suite/assets/858321/e5cd9354-cff9-41f8-9901-9dcd70759541">

<img width="1123" alt="Screenshot 2024-01-24 at 14 37 03" src="https://github.com/trezor/trezor-suite/assets/858321/2b7751f1-ba89-4f80-aed0-a7607dba02c6">

<img width="1126" alt="Screenshot 2024-01-24 at 15 59 17" src="https://github.com/trezor/trezor-suite/assets/858321/401705d8-18e4-4d5a-9ef0-fcb569620b5a">

<img width="1130" alt="Screenshot 2024-01-24 at 15 59 22" src="https://github.com/trezor/trezor-suite/assets/858321/39655d94-db8d-47fc-a967-ab57c8714ec6">





### Banner

**info**
<img width="1374" alt="Screenshot 2024-01-24 at 15 17 07" src="https://github.com/trezor/trezor-suite/assets/858321/bb46432e-38a5-49bb-871f-4c5df44559c7">

<img width="1370" alt="Screenshot 2024-01-24 at 15 14 11" src="https://github.com/trezor/trezor-suite/assets/858321/bfc23951-3fb6-4d77-9335-ce8c4740de47">
<img width="1126" alt="Screenshot 2024-01-24 at 15 59 17" src="https://github.com/trezor/trezor-suite/assets/858321/29470532-212e-4a85-b5c2-0e31b37a47a2">


**warning**

<img width="1372" alt="Screenshot 2024-01-24 at 15 24 57" src="https://github.com/trezor/trezor-suite/assets/858321/1aa4283c-7903-43d8-ac17-62d8f38ea4c2">

<img width="1372" alt="Screenshot 2024-01-24 at 15 24 28" src="https://github.com/trezor/trezor-suite/assets/858321/1cd512a9-d358-42c0-bf53-e202eecda8d1">

<img width="1373" alt="Screenshot 2024-01-24 at 15 31 34" src="https://github.com/trezor/trezor-suite/assets/858321/1c13910e-217f-4585-adc3-15c3ada932ae">


**destructive**
<img width="1374" alt="Screenshot 2024-01-24 at 15 16 23" src="https://github.com/trezor/trezor-suite/assets/858321/fcb03715-4ecb-4f21-b5f7-3c1f8e75219c">

<img width="1371" alt="Screenshot 2024-01-24 at 15 14 56" src="https://github.com/trezor/trezor-suite/assets/858321/95abe2a7-9749-4665-a4c8-99ee69f74be6">




