### PR TITLE
fix(suite-native): correct error for firmwareless device

### DIFF
--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -727,5 +727,5 @@ export const selectDeviceLanguage = (state: DeviceRootState) => {
 export const selectHasDeviceFirmwareInstalled = (state: DeviceRootState) => {
     const device = selectDevice(state);
 
-    return device?.firmware !== 'none';
+    return !!device && device.firmware !== 'none';
 };

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -723,3 +723,9 @@ export const selectDeviceLanguage = (state: DeviceRootState) => {
     const features = selectDeviceFeatures(state);
     return features?.language ?? null;
 };
+
+export const selectHasDeviceFirmwareInstalled = (state: DeviceRootState) => {
+    const device = selectDevice(state);
+
+    return device?.firmware !== 'none';
+};

--- a/suite-native/device/src/hooks/useDetectDeviceError.tsx
+++ b/suite-native/device/src/hooks/useDetectDeviceError.tsx
@@ -11,6 +11,7 @@ import {
     selectIsDeviceInBootloader,
     selectIsUnacquiredDevice,
     selectIsSelectedDeviceImported,
+    selectHasDeviceFirmwareInstalled,
 } from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
 import { useTranslate } from '@suite-native/intl';
@@ -33,6 +34,7 @@ export const useDetectDeviceError = () => {
     const isSelectedDeviceImported = useSelector(selectIsSelectedDeviceImported);
     const isNoPhysicalDeviceConnected = useSelector(selectIsNoPhysicalDeviceConnected);
     const isDeviceInBootloader = useSelector(selectIsDeviceInBootloader);
+    const hasDeviceFirmwareInstalled = useSelector(selectHasDeviceFirmwareInstalled);
 
     const isFirmwareSupported = useSelector(selectIsFirmwareSupported);
 
@@ -127,7 +129,7 @@ export const useDetectDeviceError = () => {
     ]);
 
     useEffect(() => {
-        if (isDeviceInBootloader && !wasDeviceEjectedByUser) {
+        if (isDeviceInBootloader && hasDeviceFirmwareInstalled && !wasDeviceEjectedByUser) {
             showAlert({
                 title: translate('moduleDevice.bootloaderModal.title'),
                 description: translate('moduleDevice.bootloaderModal.description'),
@@ -145,7 +147,14 @@ export const useDetectDeviceError = () => {
                 },
             });
         }
-    }, [isDeviceInBootloader, wasDeviceEjectedByUser, showAlert, translate, handleDisconnect]);
+    }, [
+        isDeviceInBootloader,
+        hasDeviceFirmwareInstalled,
+        wasDeviceEjectedByUser,
+        showAlert,
+        translate,
+        handleDisconnect,
+    ]);
 
     useEffect(() => {
         // Hide the error alert on disconnect of the device


### PR DESCRIPTION
This commit fixes the error message for firmwareless devices. Until now if you have connected firmwareless device, the error message saying that the device is in bootloader mode was displayed. After this change, correct message instructing user to setup the device is displayed.

Closes #10611
