### PR TITLE
Fix/solana replace token list source for metaplex

### DIFF
--- a/packages/blockchain-link-utils/src/solana.ts
+++ b/packages/blockchain-link-utils/src/solana.ts
@@ -29,40 +29,6 @@ export const SYSTEM_PROGRAM_PUBLIC_KEY = '11111111111111111111111111111111';
 // when parsing tx effects.
 export const WSOL_MINT = 'So11111111111111111111111111111111111111112';
 
-// https://github.com/viaprotocol/tokenlists
-// Aggregated token list with tokens listed on multiple exchanges
-const SOLANA_TOKEN_LIST_URL =
-    'https://cdn.jsdelivr.net/gh/viaprotocol/tokenlists/all_tokens/solana.json';
-
-const LOCAL_TOKEN_METADATA: TokenDetailByMint = {
-    DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263: {
-        name: 'Bonk',
-        symbol: 'BONK',
-    },
-};
-
-export const getTokenMetadata = async (): Promise<TokenDetailByMint> => {
-    const tokenListResult: { address: string; name: string; symbol: string }[] = await (
-        await fetch(SOLANA_TOKEN_LIST_URL)
-    ).json();
-
-    const tokenMap = tokenListResult.reduce(
-        (acc, token) => ({
-            [token.address]: {
-                name: token.name,
-                symbol: token.symbol,
-            },
-            ...acc,
-        }),
-        {} as TokenDetailByMint,
-    );
-
-    // Explicitly set Wrapped SOL symbol to WSOL instead of the official 'SOL' which leads to confusion in UI
-    tokenMap[WSOL_MINT].symbol = 'WSOL';
-
-    return { ...LOCAL_TOKEN_METADATA, ...tokenMap };
-};
-
 export const getTokenNameAndSymbol = (mint: string, tokenDetailByMint: TokenDetailByMint) => {
     const tokenDetail = tokenDetailByMint[mint];
 
@@ -533,12 +499,12 @@ export const getTokens = (
     return effects;
 };
 
-export const transformTransaction = async (
+export const transformTransaction = (
     tx: SolanaValidParsedTxWithMeta,
     accountAddress: string,
     tokenAccountsInfos: SolanaTokenAccountInfo[],
-): Promise<Transaction> => {
-    const tokenDetailByMint = await getTokenMetadata();
+    tokenDetailByMint: TokenDetailByMint,
+): Transaction => {
     const nativeEffects = getNativeEffects(tx);
 
     const tokens = getTokens(tx, accountAddress, tokenDetailByMint, tokenAccountsInfos);

--- a/packages/blockchain-link-utils/src/tests/solana.test.ts
+++ b/packages/blockchain-link-utils/src/tests/solana.test.ts
@@ -120,6 +120,7 @@ describe('solana/utils', () => {
                     input.transaction as SolanaValidParsedTxWithMeta,
                     input.accountAddress,
                     input.tokenAccountsInfos,
+                    {},
                 );
                 expect(result).toEqual(expectedOutput);
             });

--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -67,6 +67,7 @@
         "worker-loader": "^3.0.8"
     },
     "dependencies": {
+        "@metaplex-foundation/mpl-token-metadata": "2.5.2",
         "@solana/buffer-layout": "^4.0.1",
         "@solana/web3.js": "^1.87.6",
         "@trezor/blockchain-link-types": "workspace:*",

--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -21,7 +21,7 @@ import {
     transformTokenInfo,
     TOKEN_PROGRAM_PUBLIC_KEY,
 } from '@trezor/blockchain-link-utils/lib/solana';
-import { TOKEN_ACCOUNT_LAYOUT } from './tokenUtils';
+import { TOKEN_ACCOUNT_LAYOUT, fetchMetaplexMetadata } from './tokenUtils';
 
 export type SolanaAPI = Connection;
 
@@ -166,7 +166,10 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
     // Fetch token info only if the account owns tokens
     let tokens: TokenInfo[] = [];
     if (tokenAccounts.value.length > 0) {
-        const tokenMetadata = await solanaUtils.getTokenMetadata();
+        const tokenMetadata = await fetchMetaplexMetadata(
+            api,
+            tokenAccountsInfos.map(a => a.mint).filter((mint): mint is string => !!mint),
+        );
 
         tokens = transformTokenInfo(tokenAccounts.value, tokenMetadata);
     }

--- a/packages/blockchain-link/src/workers/solana/tokenUtils.ts
+++ b/packages/blockchain-link/src/workers/solana/tokenUtils.ts
@@ -1,4 +1,7 @@
 import * as BufferLayout from '@solana/buffer-layout';
+import { Connection, PublicKey } from '@solana/web3.js';
+import type { Metadata } from '@metaplex-foundation/mpl-token-metadata';
+import { TokenDetailByMint } from 'packages/blockchain-link-types/lib/solana';
 
 // This type is required to construct the TOKEN_ACCOUNT_LAYOUT,
 // See: https://stackoverflow.com/questions/72413915/encoding-typescript-lib-solana-buffer-layout
@@ -15,3 +18,53 @@ export const TOKEN_ACCOUNT_LAYOUT = BufferLayout.struct<TokenAccountLayout>([
     BufferLayout.nu64('amount'),
     BufferLayout.blob(93),
 ]);
+
+// https://docs.metaplex.com/programs/token-metadata/changelog/v1.0#token-metadata-program
+const getTokenMetaPDA = async (mint: string): Promise<PublicKey> => {
+    const { PROGRAM_ID } = await import('@metaplex-foundation/mpl-token-metadata');
+    return (
+        await PublicKey.findProgramAddress(
+            [
+                Buffer.from('metadata'),
+                new PublicKey(PROGRAM_ID).toBuffer(),
+                new PublicKey(mint).toBuffer(),
+            ],
+            new PublicKey(PROGRAM_ID),
+        )
+    )[0];
+};
+
+const replaceNullCharacters = (str: string): string => str.replace(/\0/g, '');
+
+export const fetchMetaplexMetadata = async (
+    api: Connection,
+    mintBundle: string[],
+): Promise<TokenDetailByMint> => {
+    try {
+        const tokenMetaPubkeyBundle = await Promise.all(
+            mintBundle.map(mint => getTokenMetaPDA(mint)),
+        );
+
+        const { Metadata } = await import('@metaplex-foundation/mpl-token-metadata');
+        const metadataBundle = (
+            await Promise.all(
+                tokenMetaPubkeyBundle.map(metaPubKey =>
+                    Metadata.fromAccountAddress(api, metaPubKey).catch(() => null),
+                ),
+            )
+        ).filter((meta): meta is Metadata => meta !== null);
+
+        return metadataBundle.reduce((acc, meta) => {
+            const { mint, data } = meta;
+            return {
+                ...acc,
+                [mint.toString()]: {
+                    name: replaceNullCharacters(data.name),
+                    symbol: replaceNullCharacters(data.symbol),
+                },
+            };
+        }, {} as TokenDetailByMint);
+    } catch (e) {
+        return {};
+    }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1724,6 +1724,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.23.4":
+  version: 7.23.8
+  resolution: "@babel/runtime@npm:7.23.8"
+  dependencies:
+    regenerator-runtime: "npm:^0.14.0"
+  checksum: ec8f1967a36164da6cac868533ffdff97badd76d23d7d820cc84f0818864accef972f22f9c6a710185db1e3810e353fc18c3da721e5bb3ee8bc61bdbabce03ff
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.0.0, @babel/template@npm:^7.22.15, @babel/template@npm:^7.22.5, @babel/template@npm:^7.3.3":
   version: 7.22.15
   resolution: "@babel/template@npm:7.22.15"
@@ -3893,6 +3902,52 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metaplex-foundation/beet-solana@npm:^0.4.0":
+  version: 0.4.1
+  resolution: "@metaplex-foundation/beet-solana@npm:0.4.1"
+  dependencies:
+    "@metaplex-foundation/beet": "npm:>=0.1.0"
+    "@solana/web3.js": "npm:^1.56.2"
+    bs58: "npm:^5.0.0"
+    debug: "npm:^4.3.4"
+  checksum: 35a26557943d154174231458d5bbf70a7b221ad3371bbefb3b3114c2853811220db6efae3568ef5d11dab898954e74ff9b567dcf233c517a6b6370eb4dd14fa8
+  languageName: node
+  linkType: hard
+
+"@metaplex-foundation/beet@npm:>=0.1.0, @metaplex-foundation/beet@npm:^0.7.1":
+  version: 0.7.2
+  resolution: "@metaplex-foundation/beet@npm:0.7.2"
+  dependencies:
+    ansicolors: "npm:^0.3.2"
+    assert: "npm:^2.1.0"
+    bn.js: "npm:^5.2.0"
+    debug: "npm:^4.3.3"
+  checksum: 86131fce3d7917eaab5d2fe8a508620e37bd0456ab292f92d2a5b1dfbdb42bf9b4bc4787734bb04937d2cb24ce59a4db74466f6ee1bac29132da0996ba34f4a6
+  languageName: node
+  linkType: hard
+
+"@metaplex-foundation/cusper@npm:^0.0.2":
+  version: 0.0.2
+  resolution: "@metaplex-foundation/cusper@npm:0.0.2"
+  checksum: 0a2fa1fd34321d63933a58584858cf6fd3c6607339c4b3154def3094eb9bfd916b8f094e49ff5c2d0b5bdfdc6261253c4e8e8553833e7b4f2b788761ce63823f
+  languageName: node
+  linkType: hard
+
+"@metaplex-foundation/mpl-token-metadata@npm:2.5.2":
+  version: 2.5.2
+  resolution: "@metaplex-foundation/mpl-token-metadata@npm:2.5.2"
+  dependencies:
+    "@metaplex-foundation/beet": "npm:^0.7.1"
+    "@metaplex-foundation/beet-solana": "npm:^0.4.0"
+    "@metaplex-foundation/cusper": "npm:^0.0.2"
+    "@solana/spl-token": "npm:^0.3.6"
+    "@solana/web3.js": "npm:^1.66.2"
+    bn.js: "npm:^5.2.0"
+    debug: "npm:^4.3.4"
+  checksum: fdd27932a0470b4b6edd188bbddfd462bdd01200670045fc7105214735128d9359fa5997e49ed64bd7a05015c6f084c07ecddeecb67e78f25b61ec63c787d1d2
+  languageName: node
+  linkType: hard
+
 "@mobily/ts-belt@npm:^3.13.1":
   version: 3.13.1
   resolution: "@mobily/ts-belt@npm:3.13.1"
@@ -3947,6 +4002,13 @@ __metadata:
   version: 1.3.2
   resolution: "@noble/hashes@npm:1.3.2"
   checksum: 685f59d2d44d88e738114b71011d343a9f7dce9dfb0a121f1489132f9247baa60bc985e5ec6f3213d114fbd1e1168e7294644e46cbd0ce2eba37994f28eeb51b
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:^1.3.2":
+  version: 1.3.3
+  resolution: "@noble/hashes@npm:1.3.3"
+  checksum: 1025ddde4d24630e95c0818e63d2d54ee131b980fe113312d17ed7468bc18f54486ac86c907685759f8a7e13c2f9b9e83ec7b67d1cc20836f36b5e4a65bb102d
   languageName: node
   linkType: hard
 
@@ -5771,12 +5833,134 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@solana/buffer-layout-utils@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@solana/buffer-layout-utils@npm:0.2.0"
+  dependencies:
+    "@solana/buffer-layout": "npm:^4.0.0"
+    "@solana/web3.js": "npm:^1.32.0"
+    bigint-buffer: "npm:^1.1.5"
+    bignumber.js: "npm:^9.0.1"
+  checksum: 720779f45843ef1947b735a8c3e7f948574f569d5359178d877d08178baa2878de799081c3922892194293f1cf26f205208e5fb20d3e0621f09b9e740f34ef72
+  languageName: node
+  linkType: hard
+
 "@solana/buffer-layout@npm:^4.0.0, @solana/buffer-layout@npm:^4.0.1":
   version: 4.0.1
   resolution: "@solana/buffer-layout@npm:4.0.1"
   dependencies:
     buffer: "npm:~6.0.3"
   checksum: c64b996b832b2b7966a09e97f501fdd1409fece8975f7fb47698d7b8addb97504360cfb2f3d1368949c643d23ed9a4c9f79e19bbd721ebe5bf229353252f649e
+  languageName: node
+  linkType: hard
+
+"@solana/codecs-core@npm:2.0.0-experimental.8618508":
+  version: 2.0.0-experimental.8618508
+  resolution: "@solana/codecs-core@npm:2.0.0-experimental.8618508"
+  checksum: 6c3c8b22834288881f8132130001d4b6dadc20891638b939fc5f427d1e6f58959c6ac0b9936829739009d15b09c6306d8970457353954febe53c21c77c925d72
+  languageName: node
+  linkType: hard
+
+"@solana/codecs-data-structures@npm:2.0.0-experimental.8618508":
+  version: 2.0.0-experimental.8618508
+  resolution: "@solana/codecs-data-structures@npm:2.0.0-experimental.8618508"
+  dependencies:
+    "@solana/codecs-core": "npm:2.0.0-experimental.8618508"
+    "@solana/codecs-numbers": "npm:2.0.0-experimental.8618508"
+  checksum: ff872260d6eca82d72fa1ce0af537b8915ada2b2d442d66879ff3c58ba4802a3330d2bbe78072765cfdeb10f21da8ceb13ac1dbd59e8a943f39b19b33f2cf61b
+  languageName: node
+  linkType: hard
+
+"@solana/codecs-numbers@npm:2.0.0-experimental.8618508":
+  version: 2.0.0-experimental.8618508
+  resolution: "@solana/codecs-numbers@npm:2.0.0-experimental.8618508"
+  dependencies:
+    "@solana/codecs-core": "npm:2.0.0-experimental.8618508"
+  checksum: 49af5b65e88598d9687782e7924d5848a39f03c266eb9c38ffd4eabaa043e6658b0ad8835fc00fc4946f0fb62da5576fcbd18e5f72dfab8a8c212e65e5b53f6d
+  languageName: node
+  linkType: hard
+
+"@solana/codecs-strings@npm:2.0.0-experimental.8618508":
+  version: 2.0.0-experimental.8618508
+  resolution: "@solana/codecs-strings@npm:2.0.0-experimental.8618508"
+  dependencies:
+    "@solana/codecs-core": "npm:2.0.0-experimental.8618508"
+    "@solana/codecs-numbers": "npm:2.0.0-experimental.8618508"
+  peerDependencies:
+    fastestsmallesttextencoderdecoder: ^1.0.22
+  checksum: d4d5f1e055d58e3a9b6dc84fefe738660f81822ca2dadd346c3a895c4d0cb0d91512d2456cdb2d6c3fa66d7183689e617b9ed60e864b6cf7a277265ab16e4c48
+  languageName: node
+  linkType: hard
+
+"@solana/options@npm:2.0.0-experimental.8618508":
+  version: 2.0.0-experimental.8618508
+  resolution: "@solana/options@npm:2.0.0-experimental.8618508"
+  dependencies:
+    "@solana/codecs-core": "npm:2.0.0-experimental.8618508"
+    "@solana/codecs-numbers": "npm:2.0.0-experimental.8618508"
+  checksum: 0e45c93a3940e63cefc080aa4dbba14408efb7b4ab16ce8ffd18b7ef39709b220caf899c4353caf560085c6bde31aeed15d30a611867a8fbd71dc574b8f98362
+  languageName: node
+  linkType: hard
+
+"@solana/spl-token-metadata@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "@solana/spl-token-metadata@npm:0.1.2"
+  dependencies:
+    "@solana/codecs-core": "npm:2.0.0-experimental.8618508"
+    "@solana/codecs-data-structures": "npm:2.0.0-experimental.8618508"
+    "@solana/codecs-numbers": "npm:2.0.0-experimental.8618508"
+    "@solana/codecs-strings": "npm:2.0.0-experimental.8618508"
+    "@solana/options": "npm:2.0.0-experimental.8618508"
+    "@solana/spl-type-length-value": "npm:0.1.0"
+  peerDependencies:
+    "@solana/web3.js": ^1.87.6
+  checksum: 48974cb66e4fb2895a800236752ff22c17d3095235ae5144c4bc56766f046d15e079eea881b7ababe91150ad1c06f0f74cacc8c2bce337d07df8274dbf1f5338
+  languageName: node
+  linkType: hard
+
+"@solana/spl-token@npm:^0.3.6":
+  version: 0.3.11
+  resolution: "@solana/spl-token@npm:0.3.11"
+  dependencies:
+    "@solana/buffer-layout": "npm:^4.0.0"
+    "@solana/buffer-layout-utils": "npm:^0.2.0"
+    "@solana/spl-token-metadata": "npm:^0.1.2"
+    buffer: "npm:^6.0.3"
+  peerDependencies:
+    "@solana/web3.js": ^1.88.0
+  checksum: e2f424f034c5b99de5aaaf15f05e11045aa3e92e2940e2b727790aff3c212b64b8eb8238a5c24f81a2b5c23b9e43ec6a226a98b8bd4619a7266cdf484b89d9b9
+  languageName: node
+  linkType: hard
+
+"@solana/spl-type-length-value@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@solana/spl-type-length-value@npm:0.1.0"
+  dependencies:
+    buffer: "npm:^6.0.3"
+  checksum: 00ca61fb03a7eafb90ba43803b8a1e3c3a8ff8558c452ce2e0d571468f0d205ceeb64640160f5474e15c63e31aa75d664f49324f777ad18b019292d50c8b083b
+  languageName: node
+  linkType: hard
+
+"@solana/web3.js@npm:^1.32.0, @solana/web3.js@npm:^1.56.2, @solana/web3.js@npm:^1.66.2":
+  version: 1.89.0
+  resolution: "@solana/web3.js@npm:1.89.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.23.4"
+    "@noble/curves": "npm:^1.2.0"
+    "@noble/hashes": "npm:^1.3.2"
+    "@solana/buffer-layout": "npm:^4.0.1"
+    agentkeepalive: "npm:^4.5.0"
+    bigint-buffer: "npm:^1.1.5"
+    bn.js: "npm:^5.2.1"
+    borsh: "npm:^0.7.0"
+    bs58: "npm:^4.0.1"
+    buffer: "npm:6.0.3"
+    fast-stable-stringify: "npm:^1.0.0"
+    jayson: "npm:^4.1.0"
+    node-fetch: "npm:^2.7.0"
+    rpc-websockets: "npm:^7.5.1"
+    superstruct: "npm:^0.14.2"
+  checksum: 092fe33d037a15fb315173579fc7fefaec2b1b3baa337611e3733a781b80ddf141e0137ab90269d3dab0748ffe033e9d3676e3c6a0cd0a23dabdd76ab50d4102
   languageName: node
   linkType: hard
 
@@ -8378,6 +8562,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/blockchain-link@workspace:packages/blockchain-link"
   dependencies:
+    "@metaplex-foundation/mpl-token-metadata": "npm:2.5.2"
     "@solana/buffer-layout": "npm:^4.0.1"
     "@solana/web3.js": "npm:^1.87.6"
     "@trezor/blockchain-link-types": "workspace:*"
@@ -11781,7 +11966,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"agentkeepalive@npm:^4.2.1, agentkeepalive@npm:^4.3.0":
+"agentkeepalive@npm:^4.2.1, agentkeepalive@npm:^4.3.0, agentkeepalive@npm:^4.5.0":
   version: 4.5.0
   resolution: "agentkeepalive@npm:4.5.0"
   dependencies:
@@ -11988,6 +12173,13 @@ __metadata:
   version: 6.2.1
   resolution: "ansi-styles@npm:6.2.1"
   checksum: 70fdf883b704d17a5dfc9cde206e698c16bcd74e7f196ab821511651aee4f9f76c9514bdfa6ca3a27b5e49138b89cb222a28caf3afe4567570139577f991df32
+  languageName: node
+  linkType: hard
+
+"ansicolors@npm:^0.3.2":
+  version: 0.3.2
+  resolution: "ansicolors@npm:0.3.2"
+  checksum: 0704d1485d84d65a47aacd3d2d26f501f21aeeb509922c8f2496d0ec5d346dc948efa64f3151aef0571d73e5c44eb10fd02f27f59762e9292fe123bb1ea9ff7d
   languageName: node
   linkType: hard
 
@@ -12378,6 +12570,19 @@ __metadata:
     object-is: "npm:^1.0.1"
     util: "npm:^0.12.0"
   checksum: 5bd5e80a0dc5fce9ac812254ad39bcec8c224878705e5021a1a0ae84e2c30b980f90584ef544a5f6b1cd79edb002e80972367731260dac723c7a6f76e0fcd2ea
+  languageName: node
+  linkType: hard
+
+"assert@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "assert@npm:2.1.0"
+  dependencies:
+    call-bind: "npm:^1.0.2"
+    is-nan: "npm:^1.3.2"
+    object-is: "npm:^1.1.5"
+    object.assign: "npm:^4.1.4"
+    util: "npm:^0.12.5"
+  checksum: 6b9d813c8eef1c0ac13feac5553972e4bd180ae16000d4eb5c0ded2489188737c75a5aacefc97a985008b37502f62fe1bad34da1a7481a54bbfabec3964c8aa7
   languageName: node
   linkType: hard
 
@@ -13102,7 +13307,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bignumber.js@npm:^9.0.0, bignumber.js@npm:^9.1.1, bignumber.js@npm:^9.1.2":
+"bignumber.js@npm:^9.0.0, bignumber.js@npm:^9.0.1, bignumber.js@npm:^9.1.1, bignumber.js@npm:^9.1.2":
   version: 9.1.2
   resolution: "bignumber.js@npm:9.1.2"
   checksum: d89b8800a987225d2c00dcbf8a69dc08e92aa0880157c851c287b307d31ceb2fc2acb0c62c3e3a3d42b6c5fcae9b004035f13eb4386e56d529d7edac18d5c9d8
@@ -21456,7 +21661,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-nan@npm:^1.2.1":
+"is-nan@npm:^1.2.1, is-nan@npm:^1.3.2":
   version: 1.3.2
   resolution: "is-nan@npm:1.3.2"
   dependencies:
@@ -25839,7 +26044,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.0.0, node-fetch@npm:^2.2.0, node-fetch@npm:^2.6.0, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.11, node-fetch@npm:^2.6.12, node-fetch@npm:^2.6.7":
+"node-fetch@npm:^2.0.0, node-fetch@npm:^2.2.0, node-fetch@npm:^2.6.0, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.11, node-fetch@npm:^2.6.12, node-fetch@npm:^2.6.7, node-fetch@npm:^2.7.0":
   version: 2.7.0
   resolution: "node-fetch@npm:2.7.0"
   dependencies:
@@ -26219,7 +26424,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-is@npm:^1.0.1":
+"object-is@npm:^1.0.1, object-is@npm:^1.1.5":
   version: 1.1.5
   resolution: "object-is@npm:1.1.5"
   dependencies:
@@ -33672,7 +33877,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"util@npm:^0.12.0, util@npm:^0.12.4":
+"util@npm:^0.12.0, util@npm:^0.12.4, util@npm:^0.12.5":
   version: 0.12.5
   resolution: "util@npm:0.12.5"
   dependencies:


### PR DESCRIPTION
Also
 - fetch solana token metadata only when needed, previously we fetched when parsing transaction (facepalm), and also for basic account info
 
 Metaplex: https://github.com/metaplex-foundation/mpl-token-metadata - Program to attach additional data to Fungible or Non-Fungible tokens on Solana, standardly used in solana ecosystem
 
More context:
 - in slack, we were talking about replacing the old metadata source with coingecko, for two reasons I haven't used coingecko 
    - metadata that coingecko returns for a token, is very much fiat rates oriented, the JSON is is quite big even tho we care only about name and ticker.
    - later we actually fetch conversion rates from this endpoint, so we would be fetching the same thing twice, first just to get name and ticker, then to get the conversion rates
    
Disadvantages of multiplex
 - fetched onChain metadata, basically a `getAccountInfo` request, which is 50 credits per token
 - new dependency
 
 
 Edit, check coingecko alternative here: https://github.com/trezor/trezor-suite/pull/10672