### PR TITLE
fix(suite-native): flat graph for zero value

### DIFF
--- a/suite-common/graph/src/graphUtils.ts
+++ b/suite-common/graph/src/graphUtils.ts
@@ -83,7 +83,8 @@ export const mapCryptoBalanceMovementToFixedTimeFrame = ({
             return {
                 date: fromUnixTime(fiatRatePoint.time),
                 cryptoBalance: cryptoBalance.toFixed(),
-                value: cryptoBalance.multipliedBy(fiatRate).toNumber(),
+                // We display only two decimal places in the graph. So if there is any value lower than that, we want to round it.
+                value: Number(cryptoBalance.multipliedBy(fiatRate).toFixed(2)),
             };
         }),
     );


### PR DESCRIPTION
In the UI displays only two decimal points in the graph. Sometimes, if there was a value lower than 0.01,  the graph was raising and dropping even though that value was displayed as 0.00. This change fixes that by rounding every value lower than 0.01 to zero.

Closes #10632
