### PR TITLE
Chore/typed emitter

### DIFF
--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -71,6 +71,7 @@
         "@solana/web3.js": "^1.87.6",
         "@trezor/blockchain-link-types": "workspace:*",
         "@trezor/blockchain-link-utils": "workspace:*",
+        "@trezor/node-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
         "@trezor/utxo-lib": "workspace:*",
         "@types/web": "^0.0.119",

--- a/packages/blockchain-link/src/index.ts
+++ b/packages/blockchain-link/src/index.ts
@@ -1,4 +1,4 @@
-import { TypedEmitter } from '@trezor/utils/lib/typedEventEmitter';
+import { TypedEmitter } from '@trezor/node-utils/lib/typedEventEmitter';
 import { createDeferred, Deferred } from '@trezor/utils/lib/createDeferred';
 import { CustomError } from '@trezor/blockchain-link-types/lib/constants/errors';
 import { MESSAGES, RESPONSES } from '@trezor/blockchain-link-types/lib/constants';

--- a/packages/blockchain-link/src/workers/baseWebsocket.ts
+++ b/packages/blockchain-link/src/workers/baseWebsocket.ts
@@ -1,6 +1,6 @@
 import WebSocket from 'ws';
 import { createDeferred, Deferred } from '@trezor/utils/lib/createDeferred';
-import { TypedEmitter } from '@trezor/utils/lib/typedEventEmitter';
+import { TypedEmitter } from '@trezor/node-utils/lib/typedEventEmitter';
 
 import { CustomError } from '@trezor/blockchain-link-types/lib/constants/errors';
 

--- a/packages/blockchain-link/tsconfig.json
+++ b/packages/blockchain-link/tsconfig.json
@@ -9,6 +9,7 @@
     "references": [
         { "path": "../blockchain-link-types" },
         { "path": "../blockchain-link-utils" },
+        { "path": "../node-utils" },
         { "path": "../utils" },
         { "path": "../utxo-lib" },
         { "path": "../e2e-utils" },

--- a/packages/coinjoin/package.json
+++ b/packages/coinjoin/package.json
@@ -27,6 +27,7 @@
         "@trezor/blockchain-link": "workspace:*",
         "@trezor/blockchain-link-types": "workspace:*",
         "@trezor/blockchain-link-utils": "workspace:*",
+        "@trezor/node-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
         "@trezor/utxo-lib": "workspace:*",
         "bignumber.js": "^9.1.1",

--- a/packages/coinjoin/src/backend/CoinjoinBackend.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackend.ts
@@ -1,4 +1,4 @@
-import { TypedEmitter } from '@trezor/utils/lib/typedEventEmitter';
+import { TypedEmitter } from '@trezor/node-utils/lib/typedEventEmitter';
 
 import { CoinjoinBackendClient } from './CoinjoinBackendClient';
 import { CoinjoinFilterController } from './CoinjoinFilterController';

--- a/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
@@ -1,5 +1,5 @@
 import { scheduleAction, arrayShuffle, urlToOnion } from '@trezor/utils';
-import { TypedEmitter } from '@trezor/utils/lib/typedEventEmitter';
+import { TypedEmitter } from '@trezor/node-utils/lib/typedEventEmitter';
 import type { BlockbookAPI } from '@trezor/blockchain-link/lib/workers/blockbook/websocket';
 
 import { RequestOptions, resetIdentityCircuit } from '../utils/http';

--- a/packages/coinjoin/src/client/CoinjoinClient.ts
+++ b/packages/coinjoin/src/client/CoinjoinClient.ts
@@ -1,4 +1,4 @@
-import { TypedEmitter } from '@trezor/utils/lib/typedEventEmitter';
+import { TypedEmitter } from '@trezor/node-utils/lib/typedEventEmitter';
 
 import { Status } from './Status';
 import { Account } from './Account';

--- a/packages/coinjoin/src/client/CoinjoinPrison.ts
+++ b/packages/coinjoin/src/client/CoinjoinPrison.ts
@@ -1,4 +1,4 @@
-import { TypedEmitter } from '@trezor/utils/lib/typedEventEmitter';
+import { TypedEmitter } from '@trezor/node-utils/lib/typedEventEmitter';
 
 import { CoinjoinPrisonInmate, CoinjoinPrisonEvents } from '../types/client';
 import { WabiSabiProtocolErrorCode } from '../enums';

--- a/packages/coinjoin/src/client/CoinjoinRound.ts
+++ b/packages/coinjoin/src/client/CoinjoinRound.ts
@@ -1,4 +1,4 @@
-import { TypedEmitter } from '@trezor/utils/lib/typedEventEmitter';
+import { TypedEmitter } from '@trezor/node-utils/lib/typedEventEmitter';
 import { scheduleAction, arrayDistinct, arrayPartition } from '@trezor/utils';
 import { Network } from '@trezor/utxo-lib';
 

--- a/packages/coinjoin/src/client/Status.ts
+++ b/packages/coinjoin/src/client/Status.ts
@@ -1,4 +1,4 @@
-import { TypedEmitter } from '@trezor/utils/lib/typedEventEmitter';
+import { TypedEmitter } from '@trezor/node-utils/lib/typedEventEmitter';
 
 import * as coordinator from './coordinator';
 import { transformStatus } from '../utils/roundUtils';

--- a/packages/coinjoin/tsconfig.json
+++ b/packages/coinjoin/tsconfig.json
@@ -5,6 +5,7 @@
         { "path": "../blockchain-link" },
         { "path": "../blockchain-link-types" },
         { "path": "../blockchain-link-utils" },
+        { "path": "../node-utils" },
         { "path": "../utils" },
         { "path": "../utxo-lib" }
     ]

--- a/packages/connect-common/package.json
+++ b/packages/connect-common/package.json
@@ -37,6 +37,7 @@
     },
     "dependencies": {
         "@trezor/env-utils": "workspace:*",
+        "@trezor/node-utils": "workspace:*",
         "@trezor/utils": "workspace:*"
     },
     "devDependencies": {

--- a/packages/connect-common/src/messageChannel/abstract.ts
+++ b/packages/connect-common/src/messageChannel/abstract.ts
@@ -4,7 +4,7 @@
  */
 
 import { Deferred, createDeferred } from '@trezor/utils/lib/createDeferred';
-import { TypedEmitter } from '@trezor/utils/lib/typedEventEmitter';
+import { TypedEmitter } from '@trezor/node-utils/lib/typedEventEmitter';
 import { scheduleAction } from '@trezor/utils/lib/scheduleAction';
 
 // todo: I can't import Log from connect to connect-common (connect imports from connect-common).

--- a/packages/connect-common/tsconfig.json
+++ b/packages/connect-common/tsconfig.json
@@ -4,6 +4,7 @@
     "include": ["."],
     "references": [
         { "path": "../env-utils" },
+        { "path": "../node-utils" },
         { "path": "../utils" }
     ]
 }

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -56,6 +56,7 @@
         "@trezor/blockchain-link-types": "workspace:*",
         "@trezor/connect-analytics": "workspace:*",
         "@trezor/connect-common": "workspace:*",
+        "@trezor/node-utils": "workspace:*",
         "@trezor/protobuf": "workspace:*",
         "@trezor/protocol": "workspace:*",
         "@trezor/schema-utils": "workspace:*",

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -1,5 +1,5 @@
 // original file https://github.com/trezor/connect/blob/develop/src/js/device/Device.js
-import { TypedEmitter } from '@trezor/utils/lib/typedEventEmitter';
+import { TypedEmitter } from '@trezor/node-utils/lib/typedEventEmitter';
 import { createDeferred, Deferred } from '@trezor/utils/lib/createDeferred';
 import * as versionUtils from '@trezor/utils/lib/versionUtils';
 import { TransportProtocol, v1 as v1Protocol, bridge as bridgeProtocol } from '@trezor/protocol';

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -2,7 +2,7 @@
 
 /* eslint-disable no-restricted-syntax */
 
-import { TypedEmitter } from '@trezor/utils/lib/typedEventEmitter';
+import { TypedEmitter } from '@trezor/node-utils/lib/typedEventEmitter';
 import {
     BridgeTransport,
     WebUsbTransport,

--- a/packages/connect/tsconfig.json
+++ b/packages/connect/tsconfig.json
@@ -9,6 +9,7 @@
         { "path": "../blockchain-link-types" },
         { "path": "../connect-analytics" },
         { "path": "../connect-common" },
+        { "path": "../node-utils" },
         { "path": "../protobuf" },
         { "path": "../protocol" },
         { "path": "../schema-utils" },

--- a/packages/node-utils/package.json
+++ b/packages/node-utils/package.json
@@ -1,17 +1,39 @@
 {
     "name": "@trezor/node-utils",
     "version": "1.0.0",
-    "private": true,
-    "license": "See LICENSE.md in repo root",
+    "author": "Trezor <info@trezor.io>",
+    "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/utils",
+    "description": "A collection of typescript node-env only utils that are intended to be used across trezor-suite monorepo.",
+    "npmPublishAccess": "public",
+    "license": "SEE LICENSE IN LICENSE.md",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/trezor/trezor-suite.git"
+    },
+    "bugs": {
+        "url": "https://github.com/trezor/trezor-suite/issues"
+    },
     "sideEffects": false,
-    "main": "src/index",
+    "main": "lib/index",
+    "files": [
+        "lib/",
+        "!**/*.map"
+    ],
     "scripts": {
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
-        "test:unit": "jest -c ../../jest.config.base.js --passWithNoTests",
-        "type-check": "tsc --build"
+        "test:unit": "jest --verbose -c ../../jest.config.base.js",
+        "type-check": "tsc --build tsconfig.json",
+        "build:lib": "rimraf ./lib && yarn tsc --build tsconfig.lib.json",
+        "prepublishOnly": "yarn tsx ../../scripts/prepublishNPM.js",
+        "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "devDependencies": {
         "jest": "29.5.0",
+        "rimraf": "^5.0.5",
+        "tsx": "^4.6.2",
         "typescript": "5.3.2"
+    },
+    "peerDependencies": {
+        "tslib": "^2.6.2"
     }
 }

--- a/packages/node-utils/src/index.ts
+++ b/packages/node-utils/src/index.ts
@@ -1,2 +1,3 @@
 export { ensureDirectoryExists } from './ensureDirectoryExists';
 export { getFreePort } from './getFreePort';
+export { TypedEmitter } from './typedEventEmitter';

--- a/packages/node-utils/src/tests/typedEventEmitter.test.ts
+++ b/packages/node-utils/src/tests/typedEventEmitter.test.ts
@@ -1,4 +1,4 @@
-import { TypedEmitter } from '../src/typedEventEmitter';
+import { TypedEmitter } from '../typedEventEmitter';
 
 type PayloadUnion = { foo: number } | { bar: string };
 

--- a/packages/node-utils/src/typedEventEmitter.ts
+++ b/packages/node-utils/src/typedEventEmitter.ts
@@ -1,10 +1,7 @@
 /*
 
-This file should not be exported from index to prevent missing dependency/polyfill error.
-EventEmitter is accessible in nodejs but requires polyfills in web builds.
-
 use:
-import { TypedEmitter } from '@trezor/utils/lib/typedEventEmitter';
+import { TypedEmitter } from '@trezor/node-utils/lib/typedEventEmitter';
 
 example:
 type EventMap = {

--- a/packages/node-utils/tsconfig.lib.json
+++ b/packages/node-utils/tsconfig.lib.json
@@ -1,7 +1,8 @@
 {
     "extends": "../../tsconfig.lib.json",
     "compilerOptions": {
-        "outDir": "lib"
+        "outDir": "lib",
+        "importHelpers": true
     },
     "include": ["./src"]
 }

--- a/packages/suite-desktop-core/src/libs/http-receiver.ts
+++ b/packages/suite-desktop-core/src/libs/http-receiver.ts
@@ -3,7 +3,7 @@ import * as net from 'net';
 import * as url from 'url';
 
 import { xssFilters } from '@trezor/utils';
-import { TypedEmitter } from '@trezor/utils/lib/typedEventEmitter';
+import { TypedEmitter } from '@trezor/node-utils/lib/typedEventEmitter';
 
 import { HTTP_ORIGINS_DEFAULT } from './constants';
 

--- a/packages/suite-desktop-core/src/modules/index.ts
+++ b/packages/suite-desktop-core/src/modules/index.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
 import { isNotUndefined } from '@trezor/utils';
-import { TypedEmitter } from '@trezor/utils/lib/typedEventEmitter';
+import { TypedEmitter } from '@trezor/node-utils/lib/typedEventEmitter';
 import { InterceptedEvent } from '@trezor/request-manager';
 import { isDevEnv } from '@suite-common/suite-utils';
 import type { HandshakeClient, TorStatus } from '@trezor/suite-desktop-api';

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -54,6 +54,7 @@
         "typescript": "5.3.2"
     },
     "dependencies": {
+        "@trezor/node-utils": "workspace:*",
         "@trezor/protobuf": "workspace:*",
         "@trezor/protocol": "workspace:*",
         "@trezor/utils": "workspace:*",

--- a/packages/transport/src/api/abstract.ts
+++ b/packages/transport/src/api/abstract.ts
@@ -1,4 +1,4 @@
-import { TypedEmitter } from '@trezor/utils/lib/typedEventEmitter';
+import { TypedEmitter } from '@trezor/node-utils/lib/typedEventEmitter';
 import type { AnyError, AsyncResultWithTypedError, Success, Logger } from '../types';
 import { success, error, unknownError } from '../utils/result';
 

--- a/packages/transport/src/sessions/background.ts
+++ b/packages/transport/src/sessions/background.ts
@@ -10,7 +10,7 @@
  */
 
 import { createDeferred, Deferred } from '@trezor/utils';
-import { TypedEmitter } from '@trezor/utils/lib/typedEventEmitter';
+import { TypedEmitter } from '@trezor/node-utils/lib/typedEventEmitter';
 
 import type {
     EnumerateDoneRequest,

--- a/packages/transport/src/sessions/client.ts
+++ b/packages/transport/src/sessions/client.ts
@@ -1,5 +1,5 @@
 import { getWeakRandomId } from '@trezor/utils';
-import { TypedEmitter } from '@trezor/utils/lib/typedEventEmitter';
+import { TypedEmitter } from '@trezor/node-utils/lib/typedEventEmitter';
 
 import { Descriptor } from '../types';
 import {

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -1,6 +1,6 @@
 import * as protobuf from 'protobufjs/light';
 import { scheduleAction, ScheduleActionParams, ScheduledAction, Deferred } from '@trezor/utils';
-import { TypedEmitter } from '@trezor/utils/lib/typedEventEmitter';
+import { TypedEmitter } from '@trezor/node-utils/lib/typedEventEmitter';
 import { PROTOCOL_MALFORMED, TransportProtocol } from '@trezor/protocol';
 import { MessageFromTrezor } from '@trezor/protobuf';
 

--- a/packages/transport/tsconfig.json
+++ b/packages/transport/tsconfig.json
@@ -5,6 +5,7 @@
         "types": ["w3c-web-usb", "jest", "node"]
     },
     "references": [
+        { "path": "../node-utils" },
         { "path": "../protobuf" },
         { "path": "../protocol" },
         { "path": "../utils" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8383,6 +8383,7 @@ __metadata:
     "@trezor/blockchain-link-types": "workspace:*"
     "@trezor/blockchain-link-utils": "workspace:*"
     "@trezor/e2e-utils": "workspace:*"
+    "@trezor/node-utils": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@trezor/utxo-lib": "workspace:*"
@@ -8415,6 +8416,7 @@ __metadata:
     "@trezor/blockchain-link": "workspace:*"
     "@trezor/blockchain-link-types": "workspace:*"
     "@trezor/blockchain-link-utils": "workspace:*"
+    "@trezor/node-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@trezor/utxo-lib": "workspace:*"
     bignumber.js: "npm:^9.1.1"
@@ -8492,6 +8494,7 @@ __metadata:
   resolution: "@trezor/connect-common@workspace:packages/connect-common"
   dependencies:
     "@trezor/env-utils": "workspace:*"
+    "@trezor/node-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     jest: "npm:29.5.0"
     rimraf: "npm:^5.0.5"
@@ -8756,6 +8759,7 @@ __metadata:
     "@trezor/blockchain-link-types": "workspace:*"
     "@trezor/connect-analytics": "workspace:*"
     "@trezor/connect-common": "workspace:*"
+    "@trezor/node-utils": "workspace:*"
     "@trezor/protobuf": "workspace:*"
     "@trezor/protocol": "workspace:*"
     "@trezor/schema-utils": "workspace:*"
@@ -8862,7 +8866,11 @@ __metadata:
   resolution: "@trezor/node-utils@workspace:packages/node-utils"
   dependencies:
     jest: "npm:29.5.0"
+    rimraf: "npm:^5.0.5"
+    tsx: "npm:^4.6.2"
     typescript: "npm:5.3.2"
+  peerDependencies:
+    tslib: ^2.6.2
   languageName: unknown
   linkType: soft
 
@@ -9511,6 +9519,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/transport@workspace:packages/transport"
   dependencies:
+    "@trezor/node-utils": "workspace:*"
     "@trezor/protobuf": "workspace:*"
     "@trezor/protocol": "workspace:*"
     "@trezor/trezor-user-env-link": "workspace:*"


### PR DESCRIPTION
similary to #10658 this PR is related to https://github.com/trezor/trezor-suite/pull/9985

I am thining about creating some our-own http server utility and reuse it for http-receiver and node-bridge. It will need to be instance of TypedEmitter since HttpReceiver inherits from it. And it felt twisted to define this new common server logic inside `node-utils` importing from `utils`.
 
what do you think @marekrjpolak ? 