### PR TITLE
fix(suite): reduce amount of Solana requests

### DIFF
--- a/packages/blockchain-link-types/src/common.ts
+++ b/packages/blockchain-link-types/src/common.ts
@@ -215,6 +215,7 @@ export interface SubscriptionAccountInfo {
     descriptor: string;
     addresses?: AccountAddresses; // bitcoin addresses
     subscriptionId?: number;
+    tokens?: TokenInfo[]; // solana tokens
 }
 
 export type ChannelMessage<T> = T & { id: number };

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -299,7 +299,12 @@ export const onBlockMinedThunk = createThunk(
     `${blockchainActionsPrefix}/onBlockMinedThunk`,
     (block: BlockchainBlock, { dispatch }) => {
         const symbol = block.coin.shortcut.toLowerCase();
-        if (isNetworkSymbol(symbol)) {
+        const network = getNetwork(symbol);
+
+        // Don't sync Solana because we emit a new block for Solana every 10 seconds.
+        // Solana accounts are updated via account subscription or also by the timer
+        // in syncAccountsWithBlockchainThunk.
+        if (isNetworkSymbol(symbol) && network?.networkType !== 'solana') {
             return dispatch(syncAccountsWithBlockchainThunk(symbol));
         }
     },


### PR DESCRIPTION
This PR attempts to reduce the amount of requests Suite makes for Solana.

## Previous behaviour

Suite would update Solana accounts every 10 seconds which resulted in a lot of requests being made and thus high costs. The amount of requests depends on the number of accounts and tokens the user has. There could be about 30 requests every 10 seconds for small accounts (2 accounts + 10 tokens) and even more for larger accounts. More exact example is included below.

## New behaviour

The 10 second update has been removed - block and blockhash are still fetched every 10 seconds but account sync has been turned off for these updates. We rather subscribe to changes for the accounts i.e. the blockchain notifies us about changes and only then do we update the accounts.

There is however also an update every minute which is built into Suite and we haven't disabled this update as it can serve as a fallback if for some reason the subscriptions should fail.

**This means we reduce the number of periodic requests by ~80%. The overload load won't be reduced by ~80% since a lot of requests also happen on app load, but it will definitely be significantly reduced. (More exact numbers are included below)**

When someone sends tokens which you do not yet own (i.e. they create a token account for you) we don't receive a notification from the blockchain regarding this, so it might take up to a minute (because of the sync timer) for the changes to be reflected in the app. After that the token account should be properly subscribed to changes.

## Number of requests

_Data from a wallet with 4 accounts and 12 token accounts._

**Before**
On load 45 requests. Every 10 seconds 34 requests.

**After**
On load 46 requests (extra request for [accountSubscribe](https://www.quicknode.com/docs/solana/accountSubscribe)). Every 10 seconds 1 request (block update). Every minute 34 requests. When a transaction is received then 34 requests are made + the event message from the subscription counts as 1 request. But the minute update timer is then reset. 

**Total requests in various session lengths**
|                    | Before | After | % |
|--------------------|--------|-------|-------------|
| 2 minute session   | 419    | 223   | 53%         |
| 5 minutes session  | 1031   | 505   | 48%         |
| 10 minutes session | 2051   | 975   | 47%         |


## How to test
- Solana accounts should be loaded
- Sending SOL and tokens should work as well
- When you receive SOL and tokens the account should be updated as soon as the transaction is finalised.
- When you receive token which you don't yet own it can take up to a minute for the transaction to show up. After that the account should be subscribed and thus further transactions should show up as soon as they're finalised.

Previously we also had reports of Suite Desktop crashing after enabling Solana Devnet. This was most probably caused by Solana's websocket connection which is used for account subscriptions. We therefore previously disabled Solana websockets but this PR enables them again. So we need to make sure that this issue doesn't happen again. We did make minor fixes to the account subscriptions which might have fixed the issue. However since the issue was hard to reproduce we don't know what exactly caused it. It would be great if you could properly try to reproduce the issue to make sure it's either found or so that we know it most probably will not reappear.

## Outstanding issues

- We haven't updated the fetching of blockhash i.e. it's still fetched every 10 seconds rather then when building the transaction.