### PR TITLE
fix(connect-popup): change popup core path

### DIFF
--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -387,11 +387,10 @@ const initCoreInPopup = async (
     // dynamically load core module
     reactEventBus.dispatch({ type: 'loading', message: 'loading core' });
 
+    const { connectSrc } = payload.settings;
     // core is built in a separate build step.
     const { initCore, initTransport } = await import(
-        // @ts-expect-error
-        // eslint-disable-next-line import/extensions
-        /* webpackIgnore: true */ './js/core.js'
+        /* webpackIgnore: true */ `${connectSrc}js/core.js`
     ).catch(_err => {
         fail({
             type: 'error',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Right now it search for `https://connect.trezor.io/9/js/js/core.js` and it does not find it, because the script is at `https://connect.trezor.io/9/js/core.js`
