### PR TITLE
fix(connect-examples): remove unnecesary permissions

### DIFF
--- a/packages/connect-examples/webextension-mv3-sw/src/manifest.json
+++ b/packages/connect-examples/webextension-mv3-sw/src/manifest.json
@@ -5,6 +5,6 @@
     "background": {
         "service_worker": "serviceWorker.js"
     },
-    "permissions": ["tabs", "notifications", "scripting", "activeTab"],
-    "host_permissions": ["http://*/*", "https://*/*"]
+    "permissions": ["scripting"],
+    "host_permissions": ["*://connect.trezor.io/9/*"]
 }

--- a/packages/connect-examples/webextension-mv3-sw/src/serviceWorker.js
+++ b/packages/connect-examples/webextension-mv3-sw/src/serviceWorker.js
@@ -1,15 +1,17 @@
 // import connect
 importScripts('vendor/trezor-connect-webextension.js');
 
+const connectSrc = 'https://connect.trezor.io/9/';
+
 // call connect once extension is started. and thats all
 chrome.runtime.onInstalled.addListener(details => {
     TrezorConnect.init({
         manifest: {
             email: 'meow',
-            appUrl: 'http://localhost:8088',
+            appUrl: 'https://yourAppUrl.com/',
         },
         transports: ['BridgeTransport', 'WebUsbTransport'],
-        connectSrc: 'http://localhost:8088/',
+        connectSrc,
     });
 
     TrezorConnect.on('DEVICE_EVENT', event => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removing  permissions "tabs", "notifications" and "activeTab" from connect-example `webextension-mv3-sw`  because they are not necessary and can create confusion.

Besides I also changed the connectSrc to `https://connect.trezor.io/9/` since it is already providing `core.js` that was necessary and I think it makes the example better with real connectSrc.