### PR TITLE
Unify isCodesignBuild checks

### DIFF
--- a/packages/env-utils/src/envUtils.ts
+++ b/packages/env-utils/src/envUtils.ts
@@ -91,7 +91,7 @@ const isLinux = () => {
     return getPlatform().startsWith('Linux');
 };
 
-const isCodesignBuild = () => !!process.env.CODESIGN_BUILD;
+const isCodesignBuild = () => process.env.IS_CODESIGN_BUILD === 'true';
 
 const getOsName = () => {
     if (isWindows()) return 'windows';

--- a/packages/suite-build/configs/base.webpack.config.ts
+++ b/packages/suite-build/configs/base.webpack.config.ts
@@ -165,7 +165,7 @@ const config: webpack.Configuration = {
             'process.env.COMMITHASH': JSON.stringify(gitRevision),
             'process.env.ASSET_PREFIX': JSON.stringify(assetPrefix),
             'process.env.JWS_PUBLIC_KEY': JSON.stringify(jwsPublicKey),
-            'process.env.CODESIGN_BUILD': isCodesignBuild,
+            'process.env.IS_CODESIGN_BUILD': `"${isCodesignBuild}"`, // to keep it as string "true"/"false" and not boolean
             'process.env.SENTRY_RELEASE': JSON.stringify(sentryRelease),
             __SENTRY_DEBUG__: isDev,
             __SENTRY_TRACING__: false, // needs to be removed when we introduce performance monitoring in trezor-suite

--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -22,6 +22,7 @@
         "@trezor/coinjoin": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/connect-common": "workspace:*",
+        "@trezor/env-utils": "workspace:*",
         "@trezor/ipc-proxy": "workspace:*",
         "@trezor/node-utils": "workspace:*",
         "@trezor/request-manager": "workspace:*",

--- a/packages/suite-desktop-core/src/libs/constants.ts
+++ b/packages/suite-desktop-core/src/libs/constants.ts
@@ -1,12 +1,13 @@
 import url from 'url';
 
+import { isDevEnv } from '@suite-common/suite-utils';
 import { TOR_URLS } from '@trezor/urls';
-import { isDevEnv, isCodesignBuild } from '@suite-common/suite-utils';
+import { isCodesignBuild } from '@trezor/env-utils';
 
 const getAppName = () => {
     const appName = 'Trezor Suite';
 
-    if (!isCodesignBuild) {
+    if (!isCodesignBuild()) {
         return `${appName} ${isDevEnv ? 'Local' : 'Dev'}`;
     }
 

--- a/packages/suite-desktop-core/tsconfig.json
+++ b/packages/suite-desktop-core/tsconfig.json
@@ -19,6 +19,7 @@
         { "path": "../coinjoin" },
         { "path": "../connect" },
         { "path": "../connect-common" },
+        { "path": "../env-utils" },
         { "path": "../ipc-proxy" },
         { "path": "../node-utils" },
         { "path": "../request-manager" },

--- a/packages/suite/src/actions/suite/analyticsActions.ts
+++ b/packages/suite/src/actions/suite/analyticsActions.ts
@@ -4,7 +4,7 @@
  */
 
 import { allowSentryReport, setSentryUser } from 'src/utils/suite/sentry';
-import { getEnvironment, getCommitHash } from '@trezor/env-utils';
+import { getEnvironment, getCommitHash, isCodesignBuild } from '@trezor/env-utils';
 import type { Dispatch, GetState } from 'src/types/suite';
 
 import {
@@ -53,7 +53,7 @@ export const init = () => (dispatch: Dispatch, getState: GetState) => {
         sessionId,
         environment: getEnvironment(),
         commitId: getCommitHash(),
-        isDev: !process.env.CODESIGN_BUILD,
+        isDev: !isCodesignBuild(),
         callbacks: {
             onEnable: () => dispatch(enableAnalyticsThunk()),
             onDisable: () => dispatch(disableAnalyticsThunk()),

--- a/packages/suite/src/actions/suite/guideActions.ts
+++ b/packages/suite/src/actions/suite/guideActions.ts
@@ -1,8 +1,5 @@
 import { analytics, EventType } from '@trezor/suite-analytics';
 
-import { GUIDE } from './constants';
-import { Dispatch } from 'src/types/suite';
-
 import type {
     ActiveView,
     Feedback,
@@ -11,6 +8,10 @@ import type {
     GuideNode,
 } from '@suite-common/suite-types';
 import { notificationsActions } from '@suite-common/toast-notifications';
+import { isCodesignBuild } from '@trezor/env-utils';
+
+import { Dispatch } from 'src/types/suite';
+import { GUIDE } from './constants';
 
 export type GuideAction =
     | { type: typeof GUIDE.OPEN }
@@ -68,7 +69,7 @@ const getUrl = (feedbackType: FeedbackType) => {
     const typeUri = feedbackType === 'BUG' ? 'bugs' : 'feedback';
     const base = `https://data.trezor.io/suite/${typeUri}`;
 
-    if (process.env.CODESIGN_BUILD) {
+    if (isCodesignBuild()) {
         return `${base}/stable.log`;
     }
 

--- a/packages/suite/src/reducers/store.ts
+++ b/packages/suite/src/reducers/store.ts
@@ -6,6 +6,7 @@ import { createLogger } from 'redux-logger';
 
 import { prepareFirmwareReducer } from '@suite-common/wallet-core';
 import { addLog } from '@suite-common/logger';
+import { isCodesignBuild } from '@trezor/env-utils';
 
 import suiteMiddlewares from 'src/middlewares/suite';
 import walletMiddlewares from 'src/middlewares/wallet';
@@ -54,7 +55,7 @@ const middleware = [
 
 const excludedActions = [addLog.type];
 
-if (!process.env.CODESIGN_BUILD) {
+if (!isCodesignBuild()) {
     const excludeLogger = (_getState: any, action: any): boolean =>
         // exclude generated lifecycle actions
         // https://redux-toolkit.js.org/api/createAsyncThunk#promise-lifecycle-actions

--- a/packages/suite/src/utils/suite/logsUtils.ts
+++ b/packages/suite/src/utils/suite/logsUtils.ts
@@ -17,6 +17,7 @@ import {
     getSuiteVersion,
     getWindowHeight,
     getWindowWidth,
+    isCodesignBuild,
 } from '@trezor/env-utils';
 import { LogEntry } from '@suite-common/logger';
 import { DEVICE } from '@trezor/connect';
@@ -179,7 +180,7 @@ export const getApplicationInfo = (state: AppState, hideSensitiveInfo: boolean) 
     suiteVersion: getSuiteVersion(),
     commitHash: getCommitHash(),
     startTime,
-    isDev: !process.env.CODESIGN_BUILD,
+    isDev: !isCodesignBuild(),
     debugMenu: state.suite.settings.debug.showDebugMenu,
     online: state.suite.online,
     browserName: getBrowserName(),

--- a/suite-common/message-system/scripts/sign-config.ts
+++ b/suite-common/message-system/scripts/sign-config.ts
@@ -4,6 +4,8 @@ import * as fs from 'fs-extra';
 import * as jws from 'jws';
 import { join } from 'path';
 
+import { isCodesignBuild } from '@trezor/env-utils';
+
 import { CONFIG_PATH, PACKAGE_ROOT } from './constants';
 import {
     JWS_CONFIG_FILENAME_REMOTE,
@@ -19,9 +21,7 @@ MHQCAQEEINi7lfZE3Y5U9srS58A+AN7Ul7HeBXsHEfzVzijColOkoAcGBSuBBAAKoUQDQgAEbSUHJlr1
 const getPrivateKey = () => {
     /* Only CI jobs flagged with "codesign", sign message system config by production private key.
      * All other branches use development key. */
-    const isCodesignBuild = process.env.IS_CODESIGN_BUILD === 'true';
-
-    if (!isCodesignBuild) {
+    if (!isCodesignBuild()) {
         console.log('Signing config using develop private key!');
 
         return devPrivateKey;

--- a/suite-common/message-system/src/messageSystemThunks.ts
+++ b/suite-common/message-system/src/messageSystemThunks.ts
@@ -1,6 +1,6 @@
 import { decode, verify } from 'jws';
 
-import { isCodesignBuild, getEnvironment } from '@trezor/env-utils';
+import { getEnvironment, isCodesignBuild } from '@trezor/env-utils';
 import { scheduleAction } from '@trezor/utils';
 import { createThunk } from '@suite-common/redux-utils';
 import { MessageSystem } from '@suite-common/suite-types';

--- a/suite-common/suite-utils/src/build.ts
+++ b/suite-common/suite-utils/src/build.ts
@@ -1,3 +1,1 @@
 export const isDevEnv = process.env.NODE_ENV !== 'production';
-
-export const isCodesignBuild = process.env.IS_CODESIGN_BUILD === 'true';

--- a/yarn.lock
+++ b/yarn.lock
@@ -9269,6 +9269,7 @@ __metadata:
     "@trezor/coinjoin": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/connect-common": "workspace:*"
+    "@trezor/env-utils": "workspace:*"
     "@trezor/ipc-proxy": "workspace:*"
     "@trezor/node-utils": "workspace:*"
     "@trezor/request-manager": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Disclaimer: I have little experience with this, please check it thoroughly.

<!--- Describe your changes in detail -->
- use `IS_CODESIGN_BUILD: string` over `CODESIGN_BUILD: boolean`
- use `isCodesignBuild: () => boolean` from `@trezor/env-utils` over `isCodesignBuild: boolean` from `@suite-common/suite-utils`
- use util over accession env variable directly

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/10191

## Screenshots:
