### PR TITLE
fix(blockchain-link-utils): display Solana `self` token txs correctly

### DIFF
--- a/packages/blockchain-link-utils/src/solana.ts
+++ b/packages/blockchain-link-utils/src/solana.ts
@@ -275,6 +275,10 @@ export const getTargets = (
         });
 
 const getTokenTransferTxType = (transfers: TokenTransfer[]) => {
+    if (transfers.some(transfer => transfer.to === transfer.from)) {
+        return 'self';
+    }
+
     if (transfers.some(({ type }) => type === 'recv')) {
         return 'recv';
     }


### PR DESCRIPTION
## Description
Fix token transfers originating and going to the same account, previously they were shown as unknown, now we show them correctly.  

## Screenshot
![image](https://github.com/trezor/trezor-suite/assets/71935095/04dcca47-64e1-45a6-bf1f-232c5347324e)
