### PR TITLE
fix(suite-native): select persisted devices  selector

### DIFF
--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -706,7 +706,7 @@ export const selectDeviceFirmwareVersion = memoize((state: DeviceRootState) => {
 
 export const selectPersistedDevicesStates = (state: DeviceRootState) => {
     const devices = selectDevices(state);
-    return [...devices.map(d => d.id), PORTFOLIO_TRACKER_DEVICE_STATE];
+    return [...devices.map(d => d.state), PORTFOLIO_TRACKER_DEVICE_STATE];
 };
 
 export const selectIsNoPhysicalDeviceConnected = (state: DeviceRootState) => {


### PR DESCRIPTION
## Description

- fixes issue that the `selectPersistedDevicesStates` was returning device ids instead of device states
