### PR TITLE
fix(connect-popup): webusb issue with webextension

### DIFF
--- a/packages/connect-explorer/webpack/dev.webpack.config.ts
+++ b/packages/connect-explorer/webpack/dev.webpack.config.ts
@@ -25,6 +25,7 @@ const dev: webpack.Configuration = {
                 path.join(__dirname, '../build'),
                 path.join(__dirname, '../../connect-popup/build'),
                 path.join(__dirname, '../../connect-iframe/build'),
+                path.join(__dirname, '../../connect-web/build'),
             ],
         }),
     ],

--- a/packages/connect-ui/src/views/Error.tsx
+++ b/packages/connect-ui/src/views/Error.tsx
@@ -164,7 +164,20 @@ const getTroubleshootingTips = (props: ErrorViewProps) => {
             icon: 'QUESTION',
             title: 'Could not communicate with the host website',
             detail: {
-                steps: [<Step>Please make sure Ad-blocker is not active</Step>],
+                steps: [
+                    <Step>Please make sure Ad-blocker is not active</Step>,
+                    <Step>
+                        Try downloading and setting up{' '}
+                        <a
+                            href="https://suite.trezor.io/web/bridge/"
+                            target="_blank"
+                            rel="noreferrer"
+                        >
+                            Trezor Bridge
+                        </a>{' '}
+                        for the best experience
+                    </Step>,
+                ],
             },
         });
     }

--- a/packages/connect-web/src/webextension/extensionPermissions.ts
+++ b/packages/connect-web/src/webextension/extensionPermissions.ts
@@ -1,16 +1,24 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/webusb/extensionPermissions.js
 
 import { config } from '@trezor/connect/lib/data/config';
+import { WEBEXTENSION } from '@trezor/connect/lib/events';
 
 // This file is hosted on https://connect.trezor.io/*/extension-permissions.html
 // It's included WITHIN webextension application in trezor-usb-permissions.html to allow pairing webusb and trezor.io domain properly.
 
 // send message from iframe to parent
-export const sendMessage = (message: string, origin: string) =>
+export const sendMessage = (message: string, origin: string) => {
     window.parent.postMessage(message, origin);
+};
+
+const broadcastPermissionFinished = () => {
+    const channel = new BroadcastChannel(WEBEXTENSION.USB_PERMISSIONS_BROADCAST);
+    channel.postMessage({ type: WEBEXTENSION.USB_PERMISSIONS_FINISHED });
+    channel.close();
+};
 
 const onLoad = () => {
-    sendMessage('usb-permissions-init', '*');
+    sendMessage(WEBEXTENSION.USB_PERMISSIONS_INIT, '*');
 };
 
 const init = (label: string) => {
@@ -25,7 +33,8 @@ const init = (label: string) => {
         if (usb) {
             try {
                 await usb.requestDevice({ filters: config.webusb });
-                sendMessage('usb-permissions-close', '*');
+                sendMessage(WEBEXTENSION.USB_PERMISSIONS_CLOSE, '*');
+                broadcastPermissionFinished();
             } catch (error) {
                 // empty
             }
@@ -33,12 +42,12 @@ const init = (label: string) => {
     };
 
     cancelButton.onclick = () => {
-        sendMessage('usb-permissions-close', '*');
+        sendMessage(WEBEXTENSION.USB_PERMISSIONS_CLOSE, '*');
     };
 };
 
 const handleMessage = ({ data, origin }: any) => {
-    if (data && data.type === 'usb-permissions-init') {
+    if (data && data.type === WEBEXTENSION.USB_PERMISSIONS_INIT) {
         window.removeEventListener('message', handleMessage, false);
         const knownHost = config.knownHosts.find(host => host.origin === data.extension);
         const label = knownHost && knownHost.label ? knownHost.label : origin;

--- a/packages/connect/src/events/index.ts
+++ b/packages/connect/src/events/index.ts
@@ -11,6 +11,7 @@ export * from './transport';
 export * from './ui-promise';
 export * from './ui-request';
 export * from './ui-response';
+export * from './webextension';
 
 // NOTE: for backward compatibility wrap ui const into one
 export const UI = {

--- a/packages/connect/src/events/webextension.ts
+++ b/packages/connect/src/events/webextension.ts
@@ -1,0 +1,6 @@
+export const WEBEXTENSION = {
+    USB_PERMISSIONS_BROADCAST: 'usb-permissions',
+    USB_PERMISSIONS_INIT: 'usb-permissions-init',
+    USB_PERMISSIONS_CLOSE: 'usb-permissions-close',
+    USB_PERMISSIONS_FINISHED: 'usb-permissions-finished',
+};


### PR DESCRIPTION
Users reported a problem when connecting their Trezor to Metamask with the latest Connect release. 
Nothing would happen when clicking "Pair devices" and "Unable to establish connection with iframe would" appear in the console. 

## Description

1. Fixed the root cause of the problem in `selectDevice`, where usb was loaded from the popup's context and not the iframe context (error since d944e50167affdba294a7e1137d14514a110d5e1)
2. Added communication between the popup and the USB permissions page in the extension to automatically refresh the devices in the popup. This is done using `BroadcastChannel`, since there is no path to communicate using `window.postMessage` and using the Chrome Port would require updates in the 3rd party vendors extensions
3. Added error handling in selectDevice, an error message will be shown. We could add more helpful info to the Error screen, the best advice is probably to set up Trezor Bridge in case WebUSB is not working

## Related Issue

#9549, however I'm not 100% sure if it's exactly the same thing