### PR TITLE
ci(connect): tsc using esModuleInterop

### DIFF
--- a/packages/connect/e2e/test-yarn-install.sh
+++ b/packages/connect/e2e/test-yarn-install.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-# trap "cd .. && rm -rf connect-implementation" EXIT
+trap "cd .. && rm -rf connect-implementation" EXIT
 
 npm --version
 node --version
@@ -22,4 +22,4 @@ echo import TrezorConnect from \"@trezor/connect\" > index.ts
 
 # compile with typescript
 yarn add typescript@5.3.2
-yarn tsc ./index.ts --types node
+yarn tsc ./index.ts --types node --esModuleInterop


### PR DESCRIPTION
followup for #10519 where I accidentally commented out line 7
also this check should be run with `--esModuleInterop` param since [we compile connect with this option](https://github.com/trezor/trezor-suite/blob/develop/tsconfig.json#L25) and when using skipLibCheck:false while not having esModuleInterop it fails on I think `varuint-bitcoin` lib in utxo-lib. 

once this is merged and connect 9.1.10 is released, [this nightly check](https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/5954201406) should become green again