### PR TITLE
fix(connect-popup): selectdevice core (mv3) support

### DIFF
--- a/packages/connect-popup/src/view/selectDevice.ts
+++ b/packages/connect-popup/src/view/selectDevice.ts
@@ -19,8 +19,10 @@ const initWebUsbButton = (showLoader: boolean) => {
     const webusbContainer = container.getElementsByClassName('webusb')[0] as HTMLElement;
     webusbContainer.style.display = 'flex';
     const button = webusbContainer.getElementsByTagName('button')[0];
-    const { iframe, settings } = getState();
-    const usb = iframe ? iframe.navigator.usb : null;
+    const { core, iframe, settings } = getState();
+    let usb: USB | null = null;
+    if (core) usb = window.navigator.usb;
+    if (iframe) usb = iframe.navigator.usb;
 
     button.innerHTML = '<span class="plus"></span><span class="text">Pair devices</span>';
 


### PR DESCRIPTION
After testing MV3 extensions with the last fix (#10709), we realised that they're not properly taken into account in `selectDevice`

## Description

- Added a case for `core` in `selectDevice` to support MV3 properly