### PR TITLE
fix(suite-native): device selectors naming

### DIFF
--- a/packages/suite/src/actions/wallet/selectedAccountActions.ts
+++ b/packages/suite/src/actions/wallet/selectedAccountActions.ts
@@ -1,5 +1,5 @@
 import {
-    selectDiscoveryForDevice,
+    selectDeviceDiscovery,
     selectDevice,
     accountsActions,
     blockchainActions,
@@ -35,7 +35,7 @@ const getAccountState = (state: AppState): SelectedAccountStatus => {
     }
 
     // waiting for discovery
-    const discovery = selectDiscoveryForDevice(state);
+    const discovery = selectDeviceDiscovery(state);
     if (!device.state || !discovery) {
         return {
             status: 'loading',

--- a/packages/suite/src/components/suite/CoinList/CoinList.tsx
+++ b/packages/suite/src/components/suite/CoinList/CoinList.tsx
@@ -4,7 +4,7 @@ import { getCoinUnavailabilityMessage } from '@suite-common/suite-utils';
 import { Tooltip } from '@trezor/components';
 import { getFirmwareVersion, isDeviceInBootloaderMode } from '@trezor/device-utils';
 import { versionUtils } from '@trezor/utils';
-import { selectSupportedNetworks } from '@suite-common/wallet-core';
+import { selectDeviceSupportedNetworks } from '@suite-common/wallet-core';
 
 import { Translation } from 'src/components/suite';
 import { useDevice, useSelector } from 'src/hooks/suite';
@@ -36,10 +36,10 @@ export const CoinList = ({
 }: CoinListProps) => {
     const { device, isLocked } = useDevice();
     const blockchain = useSelector(state => state.wallet.blockchain);
-    const supportedNetworkSymbols = useSelector(selectSupportedNetworks);
+    const deviceSupportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
 
     const supportedNetworks = networks.filter(network =>
-        supportedNetworkSymbols.includes(network.symbol),
+        deviceSupportedNetworkSymbols.includes(network.symbol),
     );
 
     const isDeviceLocked = !!device && isLocked();

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import styled from 'styled-components';
 
 import { Button } from '@trezor/components';
-import { accountsActions, selectSupportedNetworks } from '@suite-common/wallet-core';
+import { accountsActions, selectDeviceSupportedNetworks } from '@suite-common/wallet-core';
 import { arrayPartition } from '@trezor/utils';
 import { FirmwareType } from '@trezor/connect';
 import { Translation, Modal } from 'src/components/suite';
@@ -47,7 +47,7 @@ export const AddAccountModal = ({ device, onCancel, symbol, noRedirect }: AddAcc
     const mainnetSymbols = mainnets.map(mainnet => mainnet.symbol);
     const testnetSymbols = testnets.map(testnet => testnet.symbol);
 
-    const supportedNetworks = useSelector(selectSupportedNetworks);
+    const supportedNetworks = useSelector(selectDeviceSupportedNetworks);
     const supportedMainnetNetworks = supportedNetworks.filter(network =>
         mainnetSymbols.includes(network),
     );

--- a/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
@@ -2,7 +2,7 @@ import {
     authorizeDevice,
     deviceActions,
     selectDevice,
-    selectDiscoveryForDevice,
+    selectDeviceDiscovery,
     accountsActions,
     disableAccountsThunk,
     createDiscoveryThunk,
@@ -22,7 +22,7 @@ import { getApp } from 'src/utils/suite/router';
 export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
     async (action, { dispatch, next, getState }) => {
         const prevState = getState();
-        const prevDiscovery = selectDiscoveryForDevice(prevState);
+        const prevDiscovery = selectDeviceDiscovery(prevState);
         const discoveryIsRunning =
             prevDiscovery &&
             prevDiscovery.status > DiscoveryStatus.IDLE &&
@@ -141,7 +141,7 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
             walletSettingsActions.changeNetworks.match(action) ||
             accountsActions.changeAccountVisibility.match(action)
         ) {
-            const discovery = selectDiscoveryForDevice(getState());
+            const discovery = selectDeviceDiscovery(getState());
             if (
                 device &&
                 device.connected &&

--- a/packages/suite/src/middlewares/wallet/graphMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/graphMiddleware.ts
@@ -4,7 +4,7 @@ import {
     discoveryActions,
     accountsActions,
     transactionsActions,
-    selectDiscoveryForDevice,
+    selectDeviceDiscovery,
 } from '@suite-common/wallet-core';
 import { DiscoveryStatus } from '@suite-common/wallet-constants';
 
@@ -34,7 +34,7 @@ const graphMiddleware =
             const { account, transactions } = action.payload;
 
             // don't run during discovery and on unconfirmed txs
-            const discovery = selectDiscoveryForDevice(api.getState());
+            const discovery = selectDeviceDiscovery(api.getState());
             if (
                 discovery?.status === DiscoveryStatus.COMPLETED &&
                 transactions.some(t => (t.blockHeight ?? 0) > 0)

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -62,7 +62,7 @@ export const extraDependencies: ExtraDependencies = {
         selectDesktopBinDir: (state: AppState) => state.desktop?.paths?.binDir,
         selectDevice: (state: AppState) => state.device.selectedDevice,
         selectMetadata: (state: AppState) => state.metadata,
-        selectDiscoveryForDevice: (state: DiscoveryRootState & DeviceRootState) =>
+        selectDeviceDiscovery: (state: DiscoveryRootState & DeviceRootState) =>
             selectDiscoveryByDeviceState(state, state.device.selectedDevice?.state),
         selectRouterApp: (state: AppState) => state.router.app,
         selectCheckFirmwareAuthenticity: (state: AppState) =>

--- a/packages/suite/src/views/dashboard/components/AssetsCard/index.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsCard/index.tsx
@@ -3,7 +3,7 @@ import BigNumber from 'bignumber.js';
 import { AnimatePresence } from 'framer-motion';
 
 import { variables, Icon, Button, colors, LoadingContent } from '@trezor/components';
-import { selectSupportedNetworks } from '@suite-common/wallet-core';
+import { selectDeviceSupportedNetworks } from '@suite-common/wallet-core';
 
 import { NETWORKS } from 'src/config/wallet';
 import { DashboardSection } from 'src/components/dashboard';
@@ -90,10 +90,10 @@ const AssetsCard = () => {
     const { dashboardAssetsGridMode } = useSelector(s => s.suite.flags);
 
     const { mainnets, enabledNetworks } = useEnabledNetworks();
-    const supportedNetworks = useSelector(selectSupportedNetworks);
+    const deviceSupportedNetworks = useSelector(selectDeviceSupportedNetworks);
 
     const mainnetSymbols = mainnets.map(mainnet => mainnet.symbol);
-    const supportedMainnetNetworks = supportedNetworks.filter(network =>
+    const supportedMainnetNetworks = deviceSupportedNetworks.filter(network =>
         mainnetSymbols.includes(network),
     );
     const hasMainnetNetworksToEnable = supportedMainnetNetworks.some(

--- a/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 import { hasBitcoinOnlyFirmware, isBitcoinOnlyDevice } from '@trezor/device-utils';
-import { selectSupportedNetworks } from '@suite-common/wallet-core';
+import { selectDeviceSupportedNetworks } from '@suite-common/wallet-core';
 
 import { DeviceBanner, SettingsLayout, SettingsSection } from 'src/components/settings';
 import { CoinGroup, SectionItem, TooltipSymbol, Translation } from 'src/components/suite';
@@ -22,9 +22,9 @@ export const SettingsCoins = () => {
     const { firmwareTypeBannerClosed } = useSelector(state => state.suite.flags);
 
     const { mainnets, testnets, enabledNetworks, setEnabled } = useEnabledNetworks();
-    const supportedNetworks = useSelector(selectSupportedNetworks);
+    const deviceSupportedNetworks = useSelector(selectDeviceSupportedNetworks);
     const supportedEnabledNetworks = enabledNetworks.filter(enabledNetwork =>
-        supportedNetworks.includes(enabledNetwork),
+        deviceSupportedNetworks.includes(enabledNetwork),
     );
 
     const { anchorRef: anchorRefCrypto, shouldHighlight: shouldHighlightCrypto } = useAnchor(

--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -46,7 +46,7 @@ export type ExtraDependencies = {
         selectDevice: SuiteCompatibleSelector<TrezorDevice | undefined>;
         selectRouterApp: SuiteCompatibleSelector<string>;
         selectMetadata: SuiteCompatibleSelector<any>;
-        selectDiscoveryForDevice: SuiteCompatibleSelector<Discovery | undefined>;
+        selectDeviceDiscovery: SuiteCompatibleSelector<Discovery | undefined>;
         selectCheckFirmwareAuthenticity: SuiteCompatibleSelector<boolean>;
     };
     // You should only use ActionCreatorWithPayload from redux-toolkit!

--- a/suite-common/test-utils/src/extraDependenciesMock.ts
+++ b/suite-common/test-utils/src/extraDependenciesMock.ts
@@ -78,7 +78,7 @@ export const extraDependenciesMock: ExtraDependencies = {
         selectDevice: mockSelector('selectDevice', {
             ...testMocks.getSuiteDevice(),
         }),
-        selectDiscoveryForDevice: mockSelector('selectDiscoveryForDevice', undefined),
+        selectDeviceDiscovery: mockSelector('selectDeviceDiscovery', undefined),
         selectCheckFirmwareAuthenticity: mockSelector('selectCheckFirmwareAuthenticity', false),
     },
     actions: {

--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -13,8 +13,8 @@ import {
     DeviceRootState,
     selectDevice,
     selectIsNoPhysicalDeviceConnected,
-    selectIsSelectedDeviceImported,
-    selectPersistedDevicesStates,
+    selectIsPortfolioTrackerDevice,
+    selectPersistedDeviceStates,
 } from '../device/deviceReducer';
 import { DiscoveryRootState, selectIsDeviceDiscoveryActive } from '../discovery/discoveryReducer';
 
@@ -203,7 +203,7 @@ export const selectDeviceAccountsByNetworkSymbol = memoizeWithArgs(
     },
 );
 
-export const selectAccountsByNetworkAndDevice = memoizeWithArgs(
+export const selectAccountsByNetworkAndDeviceState = memoizeWithArgs(
     (state: AccountsRootState, deviceState: string, networkSymbol: NetworkSymbol) => {
         const accounts = selectAccounts(state);
 
@@ -304,20 +304,20 @@ export const selectAccountsSymbols = memoize(
         ) as NetworkSymbol[],
 );
 
-export const selectIsAccountsListEmpty = (state: AccountsRootState & DeviceRootState) =>
+export const selectIsDeviceAccountless = (state: AccountsRootState & DeviceRootState) =>
     pipe(selectDeviceAccounts(state), A.isEmpty);
 
-export const selectIsPortfolioEmpty = (
+export const selectIsDeviceDiscoveryEmpty = (
     state: AccountsRootState & DeviceRootState & DiscoveryRootState,
 ) => {
-    const isAccountsListEmpty = selectIsAccountsListEmpty(state);
-    const isDiscoveryActive = selectIsDeviceDiscoveryActive(state);
+    const isDeviceAccountless = selectIsDeviceAccountless(state);
+    const isDeviceDiscoveryActive = selectIsDeviceDiscoveryActive(state);
 
-    return isAccountsListEmpty && !isDiscoveryActive;
+    return isDeviceAccountless && !isDeviceDiscoveryActive;
 };
 
 export const selectDevicelessAccounts = (state: AccountsRootState & DeviceRootState) => {
-    const persistedDevicesStates = selectPersistedDevicesStates(state);
+    const persistedDevicesStates = selectPersistedDeviceStates(state);
 
     return pipe(
         selectAccounts(state),
@@ -328,17 +328,17 @@ export const selectDevicelessAccounts = (state: AccountsRootState & DeviceRootSt
 export const selectAreAllDevicesDisconnectedOrAccountless = (
     state: AccountsRootState & DeviceRootState & DiscoveryRootState,
 ) => {
-    const isPortfolioEmpty = selectIsPortfolioEmpty(state);
+    const isDeviceDiscoveryEmpty = selectIsDeviceDiscoveryEmpty(state);
     const isNoPhysicalDeviceConnected = selectIsNoPhysicalDeviceConnected(state);
 
-    return isPortfolioEmpty && isNoPhysicalDeviceConnected;
+    return isDeviceDiscoveryEmpty && isNoPhysicalDeviceConnected;
 };
 
 export const selectIsPortfolioTrackerEmpty = (
     state: AccountsRootState & DeviceRootState & DiscoveryRootState,
 ) => {
-    const isDeviceImported = selectIsSelectedDeviceImported(state);
-    const isPortfolioEmpty = selectIsPortfolioEmpty(state);
+    const isPortfolioTrackerDevice = selectIsPortfolioTrackerDevice(state);
+    const isDeviceDiscoveryEmpty = selectIsDeviceDiscoveryEmpty(state);
 
-    return isDeviceImported && isPortfolioEmpty;
+    return isPortfolioTrackerDevice && isDeviceDiscoveryEmpty;
 };

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -585,13 +585,13 @@ export const selectIsConnectedDeviceUninitialized = (state: DeviceRootState) => 
     return device && !isDeviceInitialized;
 };
 
-export const selectIsSelectedDeviceAuthorized = (state: DeviceRootState) => {
+export const selectIsDeviceAuthorized = (state: DeviceRootState) => {
     const device = selectDevice(state);
     return !!device?.state;
 };
 
 export const selectIsDeviceConnectedAndAuthorized = (state: DeviceRootState) => {
-    const isDeviceAuthorized = selectIsSelectedDeviceAuthorized(state);
+    const isDeviceAuthorized = selectIsDeviceAuthorized(state);
     const deviceFeatures = selectDeviceFeatures(state);
 
     return isDeviceAuthorized && !!deviceFeatures;
@@ -610,7 +610,7 @@ export const selectDeviceStatus = (state: DeviceRootState) => {
     return device && getStatus(device);
 };
 
-export const selectSupportedNetworks = (state: DeviceRootState) => {
+export const selectDeviceSupportedNetworks = (state: DeviceRootState) => {
     const device = selectDevice(state);
     const deviceModelInternal = device?.features?.internal_model;
     const firmwareVersion = getFirmwareVersion(device);
@@ -656,7 +656,7 @@ export const selectDeviceAuthenticity = (state: DeviceRootState) => {
     return device?.id ? state.device.deviceAuthenticity?.[device.id] : undefined;
 };
 
-export const selectIsSelectedDeviceImported = (state: DeviceRootState) => {
+export const selectIsPortfolioTrackerDevice = (state: DeviceRootState) => {
     const device = selectDevice(state);
     return device?.id === PORTFOLIO_TRACKER_DEVICE_ID;
 };
@@ -674,7 +674,7 @@ export const selectDeviceNameById = (
     return device?.name ?? null;
 };
 
-export const selectSelectedDeviceLabel = (state: DeviceRootState) => {
+export const selectDeviceLabel = (state: DeviceRootState) => {
     const selectedDevice = selectDevice(state);
     return selectDeviceLabelById(state, selectedDevice?.id);
 };
@@ -704,7 +704,7 @@ export const selectDeviceFirmwareVersion = memoize((state: DeviceRootState) => {
     return getFirmwareVersionArray(device);
 });
 
-export const selectPersistedDevicesStates = (state: DeviceRootState) => {
+export const selectPersistedDeviceStates = (state: DeviceRootState) => {
     const devices = selectDevices(state);
     return [...devices.map(d => d.id), PORTFOLIO_TRACKER_DEVICE_STATE];
 };

--- a/suite-common/wallet-core/src/discovery/discoveryReducer.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryReducer.ts
@@ -9,7 +9,7 @@ import { discoveryActions } from './discoveryActions';
 import {
     DeviceRootState,
     selectDevice,
-    selectPersistedDevicesStates,
+    selectPersistedDeviceStates,
 } from '../device/deviceReducer';
 
 export type DiscoveryState = Discovery[];
@@ -91,13 +91,13 @@ export const selectDiscoveryByDeviceState = (
     deviceState: string | undefined,
 ) => (deviceState ? state.wallet.discovery.find(d => d.deviceState === deviceState) : undefined);
 
-export const selectDiscoveryForDevice = (state: DiscoveryRootState & DeviceRootState) => {
+export const selectDeviceDiscovery = (state: DiscoveryRootState & DeviceRootState) => {
     const selectedDevice = selectDevice(state);
     return selectDiscoveryByDeviceState(state, selectedDevice?.state);
 };
 
 export const selectIsDeviceDiscoveryActive = (state: DiscoveryRootState & DeviceRootState) => {
-    const discovery = selectDiscoveryForDevice(state);
+    const discovery = selectDeviceDiscovery(state);
 
     if (!discovery) return false;
 
@@ -114,7 +114,7 @@ export const selectIsDeviceDiscoveryActive = (state: DiscoveryRootState & Device
 export const selectIsDiscoveryAuthConfirmationRequired = (
     state: DiscoveryRootState & DeviceRootState,
 ) => {
-    const discovery = selectDiscoveryForDevice(state);
+    const discovery = selectDeviceDiscovery(state);
 
     return (
         discovery &&
@@ -125,10 +125,10 @@ export const selectIsDiscoveryAuthConfirmationRequired = (
 };
 
 export const selectDevicelessDiscoveries = (state: DiscoveryRootState & DeviceRootState) => {
-    const persistedDevicesStates = selectPersistedDevicesStates(state);
+    const persistedDeviceStates = selectPersistedDeviceStates(state);
 
     return pipe(
         selectDiscovery(state),
-        A.filter(discovery => !persistedDevicesStates.includes(discovery.deviceState)),
+        A.filter(discovery => !persistedDeviceStates.includes(discovery.deviceState)),
     ) as Discovery[];
 };

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -22,7 +22,7 @@ import {
 import {
     selectDiscoveryByDeviceState,
     selectDiscovery,
-    selectDiscoveryForDevice,
+    selectDeviceDiscovery,
 } from './discoveryReducer';
 import { selectAccounts } from '../accounts/accountsReducer';
 import { accountsActions } from '../accounts/accountsActions';
@@ -160,7 +160,7 @@ const handleProgressThunk = createThunk(
 export const stopDiscoveryThunk = createThunk(
     `${DISCOVERY_MODULE_PREFIX}/stop`,
     (_, { dispatch, getState }) => {
-        const discovery = selectDiscoveryForDevice(getState());
+        const discovery = selectDeviceDiscovery(getState());
         if (discovery && discovery.running) {
             dispatch(
                 interruptDiscovery({
@@ -329,7 +329,7 @@ export const startDiscoveryThunk = createThunk(
         } = extra;
         const device = selectDevice(getState());
         const metadata = selectMetadata(getState());
-        const discovery = selectDiscoveryForDevice(getState());
+        const discovery = selectDeviceDiscovery(getState());
 
         if (!device) {
             dispatch(
@@ -654,7 +654,7 @@ export const updateNetworkSettingsThunk = createThunk(
 export const restartDiscoveryThunk = createThunk(
     `${DISCOVERY_MODULE_PREFIX}/restart`,
     async (_, { dispatch, getState }) => {
-        const discovery = selectDiscoveryForDevice(getState());
+        const discovery = selectDeviceDiscovery(getState());
         if (!discovery) return;
         const progress = dispatch(
             calculateProgress({

--- a/suite-native/accounts/src/components/AccountsList.tsx
+++ b/suite-native/accounts/src/components/AccountsList.tsx
@@ -7,7 +7,7 @@ import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
 import { FiatRatesRootState } from '@suite-native/fiat-rates';
 import { SettingsSliceRootState } from '@suite-native/module-settings';
 
-import { selectFilteredAccountsGroupedByNetworkAccountType } from '../selectors';
+import { selectFilteredDeviceAccountsGroupedByNetworkAccountType } from '../selectors';
 import { AccountListPlaceholder } from './AccountListPlaceholder';
 import { GroupedAccountsList } from './GroupedAccountsList';
 
@@ -23,7 +23,7 @@ export const AccountsList = ({ onSelectAccount, filterValue = '' }: AccountsList
                 FiatRatesRootState &
                 SettingsSliceRootState &
                 DeviceRootState,
-        ) => selectFilteredAccountsGroupedByNetworkAccountType(state, filterValue),
+        ) => selectFilteredDeviceAccountsGroupedByNetworkAccountType(state, filterValue),
     );
 
     if (D.isEmpty(groupedAccounts))

--- a/suite-native/accounts/src/selectors.ts
+++ b/suite-native/accounts/src/selectors.ts
@@ -17,7 +17,7 @@ import { NetworkSymbol, networks } from '@suite-common/wallet-config';
 import { GroupedAccounts } from './types';
 import { filterAccountsByLabelAndNetworkNames, groupAccountsByNetworkAccountType } from './utils';
 
-export const selectFilteredAccountsGroupedByNetworkAccountType = memoizeWithArgs(
+export const selectFilteredDeviceAccountsGroupedByNetworkAccountType = memoizeWithArgs(
     (
         state: AccountsRootState & FiatRatesRootState & SettingsSliceRootState & DeviceRootState,
         filterValue: string,
@@ -43,7 +43,7 @@ export const selectFilteredAccountsGroupedByNetworkAccountType = memoizeWithArgs
     { size: 1 },
 );
 
-export const selectNetworkAccountsGroupedByAccountType = memoizeWithArgs(
+export const selectDeviceNetworkAccountsGroupedByAccountType = memoizeWithArgs(
     (state: AccountsRootState & DeviceRootState, networkSymbol: NetworkSymbol) =>
         pipe(
             selectDeviceAccountsByNetworkSymbol(state, networkSymbol),

--- a/suite-native/assets/src/components/NetworkAssetsBottomSheet.tsx
+++ b/suite-native/assets/src/components/NetworkAssetsBottomSheet.tsx
@@ -1,7 +1,7 @@
 import { useSelector } from 'react-redux';
 
 import { BottomSheet } from '@suite-native/atoms';
-import { selectNetworkAccountsGroupedByAccountType } from '@suite-native/accounts';
+import { selectDeviceNetworkAccountsGroupedByAccountType } from '@suite-native/accounts';
 import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
 import { AccountsRootState, DeviceRootState } from '@suite-common/wallet-core';
 import { NetworkSymbol } from '@suite-common/wallet-config';
@@ -19,7 +19,7 @@ export const NetworkAssetsBottomSheet = ({
     onClose,
 }: NetworkAssetsBottomSheetProps) => {
     const groupedNetworkAccounts = useSelector((state: AccountsRootState & DeviceRootState) =>
-        selectNetworkAccountsGroupedByAccountType(state, networkSymbol),
+        selectDeviceNetworkAccountsGroupedByAccountType(state, networkSymbol),
     );
 
     return (

--- a/suite-native/device-manager/src/components/DeviceManagerContent.tsx
+++ b/suite-native/device-manager/src/components/DeviceManagerContent.tsx
@@ -8,7 +8,7 @@ import { analytics, EventType } from '@suite-native/analytics';
 import { Button, Text, VStack } from '@suite-native/atoms';
 import {
     selectDevices,
-    selectIsSelectedDeviceImported,
+    selectIsPortfolioTrackerDevice,
     selectDeviceId,
     selectIsNoPhysicalDeviceConnected,
 } from '@suite-common/wallet-core';
@@ -38,7 +38,7 @@ export const DeviceManagerContent = () => {
 
     const devices = useSelector(selectDevices);
     const selectedDeviceId = useSelector(selectDeviceId);
-    const isPortfolioTrackerDevice = useSelector(selectIsSelectedDeviceImported);
+    const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const isNoPhysicalDeviceConnected = useSelector(selectIsNoPhysicalDeviceConnected);
 
     const { setIsDeviceManagerVisible } = useDeviceManager();

--- a/suite-native/device-manager/src/components/PortfolioTrackerDeviceManagerContent.tsx
+++ b/suite-native/device-manager/src/components/PortfolioTrackerDeviceManagerContent.tsx
@@ -11,7 +11,7 @@ import {
     RootStackRoutes,
     StackToStackCompositeNavigationProps,
 } from '@suite-native/navigation';
-import { selectIsPortfolioEmpty } from '@suite-common/wallet-core';
+import { selectIsDeviceDiscoveryEmpty } from '@suite-common/wallet-core';
 import { useOpenLink } from '@suite-native/link';
 
 import { DeviceManagerModal } from './DeviceManagerModal';
@@ -27,7 +27,7 @@ export const PortfolioTrackerDeviceManagerContent = () => {
     const { translate } = useTranslate();
     const openLink = useOpenLink();
 
-    const isPortfolioEmpty = useSelector(selectIsPortfolioEmpty);
+    const isDeviceDiscoveryEmpty = useSelector(selectIsDeviceDiscoveryEmpty);
 
     const navigation = useNavigation<NavigationProp>();
 
@@ -61,7 +61,7 @@ export const PortfolioTrackerDeviceManagerContent = () => {
     };
 
     const syncButtonTitle = translate(
-        isPortfolioEmpty
+        isDeviceDiscoveryEmpty
             ? 'deviceManager.syncCoinsButton.syncMyCoins'
             : 'deviceManager.syncCoinsButton.syncAnother',
     );

--- a/suite-native/device/src/hooks/useDetectDeviceError.tsx
+++ b/suite-native/device/src/hooks/useDetectDeviceError.tsx
@@ -10,13 +10,13 @@ import {
     selectIsNoPhysicalDeviceConnected,
     selectIsDeviceInBootloader,
     selectIsUnacquiredDevice,
-    selectIsSelectedDeviceImported,
+    selectIsPortfolioTrackerDevice,
     selectHasDeviceFirmwareInstalled,
 } from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
 import { useTranslate } from '@suite-native/intl';
 
-import { selectIsFirmwareSupported } from '../selectors';
+import { selectIsDeviceFirmwareSupported } from '../selectors';
 import { IncompatibleDeviceModalAppendix } from '../components/IncompatibleDeviceModalAppendix';
 import { BootloaderModalAppendix } from '../components/BootloaderModalAppendix';
 import { UnacquiredDeviceModalAppendix } from '../components/UnacquiredDeviceModalAppendix';
@@ -31,12 +31,12 @@ export const useDetectDeviceError = () => {
     const selectedDevice = useSelector(selectDevice);
     const isUnacquiredDevice = useSelector(selectIsUnacquiredDevice);
     const isConnectedDeviceUninitialized = useSelector(selectIsConnectedDeviceUninitialized);
-    const isSelectedDeviceImported = useSelector(selectIsSelectedDeviceImported);
+    const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const isNoPhysicalDeviceConnected = useSelector(selectIsNoPhysicalDeviceConnected);
     const isDeviceInBootloader = useSelector(selectIsDeviceInBootloader);
     const hasDeviceFirmwareInstalled = useSelector(selectHasDeviceFirmwareInstalled);
 
-    const isFirmwareSupported = useSelector(selectIsFirmwareSupported);
+    const isDeviceFirmwareSupported = useSelector(selectIsDeviceFirmwareSupported);
 
     const handleDisconnect = useCallback(() => {
         if (selectedDevice) {
@@ -72,7 +72,7 @@ export const useDetectDeviceError = () => {
     }, [isUnacquiredDevice, translate, dispatch, hideAlert, showAlert]);
 
     useEffect(() => {
-        if (!isFirmwareSupported && !isSelectedDeviceImported && !wasDeviceEjectedByUser) {
+        if (!isDeviceFirmwareSupported && !isPortfolioTrackerDevice && !wasDeviceEjectedByUser) {
             showAlert({
                 title: translate('moduleDevice.unsupportedFirmwareModal.title'),
                 description: translate('moduleDevice.unsupportedFirmwareModal.description'),
@@ -91,8 +91,8 @@ export const useDetectDeviceError = () => {
             });
         }
     }, [
-        isFirmwareSupported,
-        isSelectedDeviceImported,
+        isDeviceFirmwareSupported,
+        isPortfolioTrackerDevice,
         wasDeviceEjectedByUser,
         dispatch,
         showAlert,

--- a/suite-native/device/src/hooks/useHandleDeviceConnection.ts
+++ b/suite-native/device/src/hooks/useHandleDeviceConnection.ts
@@ -13,7 +13,7 @@ import {
     StackToStackCompositeNavigationProps,
 } from '@suite-native/navigation';
 import {
-    selectIsSelectedDeviceImported,
+    selectIsPortfolioTrackerDevice,
     selectIsNoPhysicalDeviceConnected,
     selectIsDeviceConnectedAndAuthorized,
 } from '@suite-common/wallet-core';
@@ -27,7 +27,7 @@ type NavigationProp = StackToStackCompositeNavigationProps<
 
 export const useHandleDeviceConnection = () => {
     const isNoPhysicalDeviceConnected = useSelector(selectIsNoPhysicalDeviceConnected);
-    const isSelectedDeviceImported = useSelector(selectIsSelectedDeviceImported);
+    const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const isOnboardingFinished = useSelector(selectIsOnboardingFinished);
     const isDeviceConnectedAndAuthorized = useSelector(selectIsDeviceConnectedAndAuthorized);
 
@@ -36,14 +36,14 @@ export const useHandleDeviceConnection = () => {
     // At the moment when unauthorized physical device is selected,
     // redirect to the Connecting screen where is handled the connection logic.
     useEffect(() => {
-        if (isOnboardingFinished && !isSelectedDeviceImported && !isDeviceConnectedAndAuthorized) {
+        if (isOnboardingFinished && !isPortfolioTrackerDevice && !isDeviceConnectedAndAuthorized) {
             navigation.navigate(RootStackRoutes.ConnectDevice, {
                 screen: ConnectDeviceStackRoutes.ConnectingDevice,
             });
         }
     }, [
         isOnboardingFinished,
-        isSelectedDeviceImported,
+        isPortfolioTrackerDevice,
         isNoPhysicalDeviceConnected,
         isDeviceConnectedAndAuthorized,
         navigation,

--- a/suite-native/device/src/screens/DeviceInfoModalScreen.tsx
+++ b/suite-native/device/src/screens/DeviceInfoModalScreen.tsx
@@ -28,8 +28,8 @@ import {
     selectDevice,
     selectDeviceModel,
     selectDeviceReleaseInfo,
-    selectIsSelectedDeviceImported,
-    selectSelectedDeviceLabel,
+    selectIsPortfolioTrackerDevice,
+    selectDeviceLabel,
 } from '@suite-common/wallet-core';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { useTranslate } from '@suite-native/intl';
@@ -66,9 +66,9 @@ export const DeviceInfoModalScreen = () => {
     const openLink = useOpenLink();
 
     const deviceModel = useSelector(selectDeviceModel);
-    const deviceLabel = useSelector(selectSelectedDeviceLabel);
+    const deviceLabel = useSelector(selectDeviceLabel);
     const device = useSelector(selectDevice);
-    const isPortfolioTrackerDevice = useSelector(selectIsSelectedDeviceImported);
+    const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const deviceReleaseInfo = useSelector(selectDeviceReleaseInfo);
     const { applyStyle } = useNativeStyles();
 

--- a/suite-native/device/src/selectors.ts
+++ b/suite-native/device/src/selectors.ts
@@ -6,13 +6,13 @@ import {
     selectDeviceModel,
     selectIsConnectedDeviceUninitialized,
     selectIsDeviceConnectedAndAuthorized,
-    selectIsPortfolioEmpty,
+    selectIsDeviceDiscoveryEmpty,
     selectIsUnacquiredDevice,
 } from '@suite-common/wallet-core';
 
 import { isFirmwareVersionSupported } from './utils';
 
-export const selectIsFirmwareSupported = (state: DeviceRootState) => {
+export const selectIsDeviceFirmwareSupported = (state: DeviceRootState) => {
     const deviceFwVersion = selectDeviceFirmwareVersion(state);
     const deviceModel = selectDeviceModel(state);
 
@@ -23,10 +23,10 @@ export const selectIsDeviceReadyToUse = (
     state: DeviceRootState & AccountsRootState & DiscoveryRootState,
 ) => {
     const isUnacquiredDevice = selectIsUnacquiredDevice(state);
-    const isFirmwareSupported = selectIsFirmwareSupported(state);
+    const isDeviceFirmwareSupported = selectIsDeviceFirmwareSupported(state);
     const isDeviceUninitialized = selectIsConnectedDeviceUninitialized(state);
 
-    return !isUnacquiredDevice && !isDeviceUninitialized && isFirmwareSupported;
+    return !isUnacquiredDevice && !isDeviceUninitialized && isDeviceFirmwareSupported;
 };
 
 export const selectIsDeviceReadyToUseAndAuthorized = (
@@ -34,7 +34,7 @@ export const selectIsDeviceReadyToUseAndAuthorized = (
 ) => {
     const isDeviceReadyToUse = selectIsDeviceReadyToUse(state);
     const isDeviceConnectedAndAuthorized = selectIsDeviceConnectedAndAuthorized(state);
-    const isPortfolioEmpty = selectIsPortfolioEmpty(state);
+    const isDeviceDiscoveryEmpty = selectIsDeviceDiscoveryEmpty(state);
 
-    return isDeviceReadyToUse && isDeviceConnectedAndAuthorized && !isPortfolioEmpty;
+    return isDeviceReadyToUse && isDeviceConnectedAndAuthorized && !isDeviceDiscoveryEmpty;
 };

--- a/suite-native/discovery/src/discoveryConfigSlice.ts
+++ b/suite-native/discovery/src/discoveryConfigSlice.ts
@@ -4,7 +4,7 @@ import { pipe } from '@mobily/ts-belt';
 import {
     DeviceRootState,
     filterUnavailableNetworks,
-    selectSupportedNetworks,
+    selectDeviceSupportedNetworks,
 } from '@suite-common/wallet-core';
 import {
     filterBlacklistedNetworks,
@@ -53,7 +53,7 @@ export const selectDiscoverySupportedNetworks = (
     areTestnetsEnabled: boolean,
 ) =>
     pipe(
-        selectSupportedNetworks(state),
+        selectDeviceSupportedNetworks(state),
         networkSymbols => filterTestnetNetworks(networkSymbols, areTestnetsEnabled),
         filterUnavailableNetworks,
         filterBlacklistedNetworks,

--- a/suite-native/discovery/src/discoveryThunks.ts
+++ b/suite-native/discovery/src/discoveryThunks.ts
@@ -5,7 +5,7 @@ import {
     accountsActions,
     DISCOVERY_MODULE_PREFIX,
     selectDeviceAccountsLengthPerNetwork,
-    selectDiscoveryForDevice,
+    selectDeviceDiscovery,
     updateDiscovery,
     createDiscovery,
     removeDiscovery,
@@ -53,7 +53,7 @@ type DiscoveryDescriptorItem = DiscoveryItem & { descriptor: string };
 const finishNetworkTypeDiscoveryThunk = createThunk(
     `${DISCOVERY_MODULE_PREFIX}/finishNetworkTypeDiscoveryThunk`,
     (_, { dispatch, getState }) => {
-        const discovery = selectDiscoveryForDevice(getState());
+        const discovery = selectDeviceDiscovery(getState());
 
         if (!discovery) {
             return;
@@ -159,7 +159,7 @@ const discoverNetworkBatchThunk = createThunk(
         },
         { dispatch, getState },
     ) => {
-        const discovery = selectDiscoveryForDevice(getState());
+        const discovery = selectDeviceDiscovery(getState());
         const batchSize = getBatchSizeByCoin(network.symbol);
 
         if (!discovery || !deviceState) {
@@ -302,7 +302,7 @@ export const startDescriptorPreloadedDiscoveryThunk = createThunk(
     ) => {
         const device = selectDeviceByState(getState(), deviceState);
 
-        const discovery1 = selectDiscoveryForDevice(getState());
+        const discovery1 = selectDeviceDiscovery(getState());
         if (discovery1) {
             console.warn(
                 `Warning discovery for device ${deviceState} already exists. Skipping discovery.`,
@@ -327,7 +327,7 @@ export const startDescriptorPreloadedDiscoveryThunk = createThunk(
         );
 
         // We need to check again here because it's possible that things changed in the meantime because async thunks
-        const discovery2 = selectDiscoveryForDevice(getState());
+        const discovery2 = selectDeviceDiscovery(getState());
         if (!discovery2) {
             return;
         }

--- a/suite-native/module-accounts-import/src/accountsImportThunks.ts
+++ b/suite-native/module-accounts-import/src/accountsImportThunks.ts
@@ -2,7 +2,7 @@ import { createThunk } from '@suite-common/redux-utils';
 import {
     accountsActions,
     PORTFOLIO_TRACKER_DEVICE_STATE,
-    selectAccountsByNetworkAndDevice,
+    selectAccountsByNetworkAndDeviceState,
 } from '@suite-common/wallet-core';
 import { AccountInfo } from '@trezor/connect';
 import { networks, NetworkSymbol, AccountType } from '@suite-common/wallet-config';
@@ -34,7 +34,7 @@ export const importAccountThunk = createThunk(
     ({ accountInfo, accountLabel, coin }: ImportAssetThunkPayload, { dispatch, getState }) => {
         const deviceState = PORTFOLIO_TRACKER_DEVICE_STATE;
 
-        const deviceNetworkAccounts = selectAccountsByNetworkAndDevice(
+        const deviceNetworkAccounts = selectAccountsByNetworkAndDeviceState(
             getState(),
             deviceState,
             coin,

--- a/suite-native/module-accounts-import/src/components/AccountImportSubHeader.tsx
+++ b/suite-native/module-accounts-import/src/components/AccountImportSubHeader.tsx
@@ -14,7 +14,7 @@ import {
     StackToTabCompositeProps,
 } from '@suite-native/navigation';
 import { Translation } from '@suite-native/intl';
-import { selectIsAccountsListEmpty } from '@suite-common/wallet-core';
+import { selectIsDeviceAccountless } from '@suite-common/wallet-core';
 
 type NavigationProp = StackToTabCompositeProps<
     AccountsImportStackParamList,
@@ -24,7 +24,7 @@ type NavigationProp = StackToTabCompositeProps<
 
 export const AccountImportSubHeader = () => {
     const navigation = useNavigation<NavigationProp>();
-    const isAccountsListEmpty = useSelector(selectIsAccountsListEmpty);
+    const isDeviceAccountless = useSelector(selectIsDeviceAccountless);
 
     const handleCloseOnboarding = () => {
         navigation.navigate(RootStackRoutes.AppTabs, {
@@ -38,7 +38,7 @@ export const AccountImportSubHeader = () => {
     return (
         <ScreenSubHeader
             leftIcon={
-                !isAccountsListEmpty ? (
+                !isDeviceAccountless ? (
                     <IconButton
                         iconName="close"
                         colorScheme="tertiaryElevation0"

--- a/suite-native/module-accounts-import/src/components/AccountImportSummaryForm.tsx
+++ b/suite-native/module-accounts-import/src/components/AccountImportSummaryForm.tsx
@@ -5,7 +5,7 @@ import { CommonActions, useNavigation } from '@react-navigation/core';
 import { networks, NetworkSymbol } from '@suite-common/wallet-config';
 import {
     AccountsRootState,
-    selectAccountsByNetworkAndDevice,
+    selectAccountsByNetworkAndDeviceState,
     PORTFOLIO_TRACKER_DEVICE_STATE,
 } from '@suite-common/wallet-core';
 import { Box, Button, Divider, VStack } from '@suite-native/atoms';
@@ -57,7 +57,7 @@ export const AccountImportSummaryForm = ({
     const showImportError = useShowImportError(networkSymbol, navigation);
 
     const deviceNetworkAccounts = useSelector((state: AccountsRootState) =>
-        selectAccountsByNetworkAndDevice(state, PORTFOLIO_TRACKER_DEVICE_STATE, networkSymbol),
+        selectAccountsByNetworkAndDeviceState(state, PORTFOLIO_TRACKER_DEVICE_STATE, networkSymbol),
     );
 
     const defaultAccountLabel = `${networks[networkSymbol].name} #${

--- a/suite-native/module-accounts-management/src/screens/AccountSettingsScreen.tsx
+++ b/suite-native/module-accounts-management/src/screens/AccountSettingsScreen.tsx
@@ -15,7 +15,7 @@ import {
     selectAccountByKey,
     selectAccountLabel,
     selectFormattedAccountType,
-    selectIsSelectedDeviceImported,
+    selectIsPortfolioTrackerDevice,
 } from '@suite-common/wallet-core';
 import { CryptoIcon } from '@suite-common/icons';
 
@@ -49,7 +49,7 @@ export const AccountSettingsScreen = ({
 }: StackProps<RootStackParamList, RootStackRoutes.AccountSettings>) => {
     const { accountKey } = route.params;
 
-    const isSelectedDevicePortfolioTracker = useSelector(selectIsSelectedDeviceImported);
+    const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
 
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
@@ -89,7 +89,7 @@ export const AccountSettingsScreen = ({
                 </Card>
                 <VStack marginHorizontal="medium" spacing="medium">
                     <AccountSettingsShowXpubButton accountKey={account.key} />
-                    {isSelectedDevicePortfolioTracker && (
+                    {isPortfolioTrackerDevice && (
                         <AccountSettingsRemoveCoinButton accountKey={account.key} />
                     )}
                 </VStack>

--- a/suite-native/module-accounts-management/src/screens/AccountsScreen.tsx
+++ b/suite-native/module-accounts-management/src/screens/AccountsScreen.tsx
@@ -14,7 +14,7 @@ import { AccountsList, SearchableAccountsListScreenHeader } from '@suite-native/
 import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
 import {
     selectAreAllDevicesDisconnectedOrAccountless,
-    selectIsSelectedDeviceImported,
+    selectIsPortfolioTrackerDevice,
 } from '@suite-common/wallet-core';
 
 import { AddAccountButton } from '../components/AddAccountsButton';
@@ -23,7 +23,7 @@ export const AccountsScreen = () => {
     const navigation =
         useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes.AccountDetail>>();
 
-    const isSelectedDevicePortfolioTracker = useSelector(selectIsSelectedDeviceImported);
+    const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const areAllDevicesDisconnectedOrAccountless = useSelector(
         selectAreAllDevicesDisconnectedOrAccountless,
     );
@@ -49,7 +49,7 @@ export const AccountsScreen = () => {
                     title="My assets"
                     onSearchInputChange={handleFilterChange}
                     rightIcon={
-                        isSelectedDevicePortfolioTracker &&
+                        isPortfolioTrackerDevice &&
                         !areAllDevicesDisconnectedOrAccountless && <AddAccountButton />
                     }
                 />

--- a/suite-native/module-home/src/screens/HomeScreen/HomeScreen.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/HomeScreen.tsx
@@ -1,7 +1,7 @@
 import { useRef } from 'react';
 import { useSelector } from 'react-redux';
 
-import { selectIsPortfolioEmpty } from '@suite-common/wallet-core';
+import { selectIsDeviceDiscoveryEmpty } from '@suite-common/wallet-core';
 import { DeviceManagerScreenHeader } from '@suite-native/device-manager';
 import { Screen } from '@suite-native/navigation';
 import { Box } from '@suite-native/atoms';
@@ -12,9 +12,12 @@ import { PortfolioContent, PortfolioContentRef } from './components/PortfolioCon
 import { useHomeRefreshControl } from './useHomeRefreshControl';
 
 export const HomeScreen = () => {
-    const isPortfolioEmpty = useSelector(selectIsPortfolioEmpty);
+    const isDeviceDiscoveryEmpty = useSelector(selectIsDeviceDiscoveryEmpty);
     const portfolioContentRef = useRef<PortfolioContentRef>(null);
-    const refreshControl = useHomeRefreshControl({ isPortfolioEmpty, portfolioContentRef });
+    const refreshControl = useHomeRefreshControl({
+        isPortfolioEmpty: isDeviceDiscoveryEmpty,
+        portfolioContentRef,
+    });
 
     return (
         <Screen
@@ -22,7 +25,7 @@ export const HomeScreen = () => {
             refreshControl={refreshControl}
             customHorizontalPadding={0}
         >
-            {isPortfolioEmpty ? (
+            {isDeviceDiscoveryEmpty ? (
                 <Box marginHorizontal="small">
                     <EmptyHomeRenderer />
                 </Box>

--- a/suite-native/module-home/src/screens/HomeScreen/components/EmptyHomeRenderer.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/EmptyHomeRenderer.tsx
@@ -3,8 +3,8 @@ import { useSelector } from 'react-redux';
 import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
 import {
     selectAreAllDevicesDisconnectedOrAccountless,
-    selectIsSelectedDeviceAuthorized,
-    selectIsSelectedDeviceImported,
+    selectIsDeviceAuthorized,
+    selectIsPortfolioTrackerDevice,
 } from '@suite-common/wallet-core';
 import { selectIsDeviceReadyToUse } from '@suite-native/device';
 
@@ -15,8 +15,8 @@ import { EmptyPortfolioCrossroads } from './EmptyPortfolioCrossroads';
 export const EmptyHomeRenderer = () => {
     const [isUsbDeviceConnectFeatureEnabled] = useFeatureFlag(FeatureFlag.IsDeviceConnectEnabled);
 
-    const isDeviceAuthorized = useSelector(selectIsSelectedDeviceAuthorized);
-    const isDeviceImported = useSelector(selectIsSelectedDeviceImported);
+    const isDeviceAuthorized = useSelector(selectIsDeviceAuthorized);
+    const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const areAllDevicesDisconnectedOrAccountless = useSelector(
         selectAreAllDevicesDisconnectedOrAccountless,
     );
@@ -24,7 +24,7 @@ export const EmptyHomeRenderer = () => {
 
     // This state is present only for a fraction of second while redirecting to the Connecting screen is already happening.
     // Because the animation takes some time, this makes sure that the screen content of newly selected device does not flash during the redirect.
-    if (!isDeviceImported && !isDeviceReadyToUse) {
+    if (!isPortfolioTrackerDevice && !isDeviceReadyToUse) {
         return null;
     }
 
@@ -34,7 +34,7 @@ export const EmptyHomeRenderer = () => {
             return <EmptyPortfolioCrossroads />;
         }
 
-        if (!isDeviceImported && isDeviceAuthorized) {
+        if (!isPortfolioTrackerDevice && isDeviceAuthorized) {
             return <EmptyConnectedDeviceState />;
         }
     }

--- a/suite-native/module-home/src/screens/HomeScreen/components/PortfolioContent.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/PortfolioContent.tsx
@@ -12,7 +12,7 @@ import {
     RootStackRoutes,
     StackNavigationProps,
 } from '@suite-native/navigation';
-import { selectIsSelectedDeviceImported } from '@suite-common/wallet-core';
+import { selectIsPortfolioTrackerDevice } from '@suite-common/wallet-core';
 import { useTranslate } from '@suite-native/intl';
 
 import { PortfolioGraph, PortfolioGraphRef } from './PortfolioGraph';
@@ -27,7 +27,7 @@ export const PortfolioContent = forwardRef<PortfolioContentRef>((_props, ref) =>
 
     const navigation = useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes>>();
 
-    const isDeviceImported = useSelector(selectIsSelectedDeviceImported);
+    const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
 
     const [isUsbDeviceConnectFeatureEnabled] = useFeatureFlag(FeatureFlag.IsDeviceConnectEnabled);
 
@@ -56,7 +56,7 @@ export const PortfolioContent = forwardRef<PortfolioContentRef>((_props, ref) =>
                 <Box>
                     <Assets />
                 </Box>
-                {isDeviceImported && (
+                {isPortfolioTrackerDevice && (
                     <Box>
                         <Button
                             data-testID="@home/portfolio/sync-coins-button"

--- a/suite-native/module-home/src/screens/HomeScreen/components/PortfolioGraph.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/PortfolioGraph.tsx
@@ -6,7 +6,10 @@ import { useSetAtom } from 'jotai';
 import { useGraphForAllDeviceAccounts, Graph, TimeSwitch } from '@suite-native/graph';
 import { selectFiatCurrency } from '@suite-native/module-settings';
 import { VStack } from '@suite-native/atoms';
-import { selectIsDeviceDiscoveryActive, selectIsPortfolioEmpty } from '@suite-common/wallet-core';
+import {
+    selectIsDeviceDiscoveryActive,
+    selectIsDeviceDiscoveryEmpty,
+} from '@suite-common/wallet-core';
 import { useIsDiscoveryDurationTooLong } from '@suite-native/discovery';
 
 import {
@@ -22,7 +25,7 @@ export type PortfolioGraphRef = {
 export const PortfolioGraph = forwardRef<PortfolioGraphRef>((_props, ref) => {
     const fiatCurrency = useSelector(selectFiatCurrency);
     const isDiscoveryActive = useSelector(selectIsDeviceDiscoveryActive);
-    const isPortfolioEmpty = useSelector(selectIsPortfolioEmpty);
+    const isDeviceDiscoveryEmpty = useSelector(selectIsDeviceDiscoveryEmpty);
 
     const loadingTakesLongerThanExpected = useIsDiscoveryDurationTooLong();
 
@@ -53,7 +56,7 @@ export const PortfolioGraph = forwardRef<PortfolioGraphRef>((_props, ref) => {
         [refetch],
     );
 
-    if (isPortfolioEmpty && isDiscoveryActive) return null;
+    if (isDeviceDiscoveryEmpty && isDiscoveryActive) return null;
 
     return (
         <VStack spacing="large">

--- a/suite-native/receive/src/components/ReceiveAddressCard.tsx
+++ b/suite-native/receive/src/components/ReceiveAddressCard.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import { Box, Card } from '@suite-native/atoms';
 import { AddressQRCode } from '@suite-native/qr-code';
 import { networks, NetworkSymbol } from '@suite-common/wallet-config';
-import { selectIsSelectedDeviceImported } from '@suite-common/wallet-core';
+import { selectIsPortfolioTrackerDevice } from '@suite-common/wallet-core';
 import { useTranslate } from '@suite-native/intl';
 
 import { UnverifiedAddress } from './UnverifiedAddress';
@@ -27,12 +27,12 @@ export const ReceiveAddressCard = ({
     isEthereumTokenAddress = false,
 }: ReceiveAddressCardProps) => {
     const { translate } = useTranslate();
-    const isPortfolioTracker = useSelector(selectIsSelectedDeviceImported);
+    const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
 
     const { networkType } = networks[networkSymbol];
 
     const getCardAlertProps = () => {
-        if (isReceiveApproved && !isPortfolioTracker) {
+        if (isReceiveApproved && !isPortfolioTrackerDevice) {
             return {
                 alertTitle: translate('moduleReceive.receiveAddressCard.alert.success'),
                 alertVariant: 'success',

--- a/suite-native/receive/src/components/ShowAddressButtons.tsx
+++ b/suite-native/receive/src/components/ShowAddressButtons.tsx
@@ -4,14 +4,14 @@ import { useSelector } from 'react-redux';
 import { VStack, TextButton, Button } from '@suite-native/atoms';
 import { useOpenLink } from '@suite-native/link';
 import { useTranslate } from '@suite-native/intl';
-import { selectIsSelectedDeviceImported } from '@suite-common/wallet-core';
+import { selectIsPortfolioTrackerDevice } from '@suite-common/wallet-core';
 
 type ShowAddressButtonsProps = {
     onShowAddress: () => void;
 };
 
 export const ShowAddressButtons = ({ onShowAddress }: ShowAddressButtonsProps) => {
-    const isPortfolioTracker = useSelector(selectIsSelectedDeviceImported);
+    const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
 
     const openLink = useOpenLink();
     const { translate } = useTranslate();
@@ -24,7 +24,7 @@ export const ShowAddressButtons = ({ onShowAddress }: ShowAddressButtonsProps) =
         <VStack spacing="large">
             <Button iconLeft="eye" size="large" onPress={onShowAddress}>
                 {translate(
-                    isPortfolioTracker
+                    isPortfolioTrackerDevice
                         ? 'moduleReceive.receiveAddressCard.showAddress.buttonTracker'
                         : 'moduleReceive.receiveAddressCard.showAddress.button',
                 )}

--- a/suite-native/receive/src/components/UnverifiedAddress.tsx
+++ b/suite-native/receive/src/components/UnverifiedAddress.tsx
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux';
 
-import { selectIsSelectedDeviceImported } from '@suite-common/wallet-core';
+import { selectIsPortfolioTrackerDevice } from '@suite-common/wallet-core';
 import { VStack } from '@suite-native/atoms';
 
 import { ShowAddressButtons } from './ShowAddressButtons';
@@ -20,11 +20,11 @@ export const UnverifiedAddress = ({
     isCardanoAddress,
     onShowAddress,
 }: UnverifiedAddressSectionProps) => {
-    const isPortfolioTracker = useSelector(selectIsSelectedDeviceImported);
+    const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
 
     return (
         <VStack spacing="medium">
-            {isPortfolioTracker ? (
+            {isPortfolioTrackerDevice ? (
                 <UnverifiedAddressWarning />
             ) : (
                 <UnverifiedAddressDevice

--- a/suite-native/receive/src/hooks/useAccountReceiveAddress.tsx
+++ b/suite-native/receive/src/hooks/useAccountReceiveAddress.tsx
@@ -12,7 +12,7 @@ import {
     selectPendingAccountAddresses,
     selectIsAccountUtxoBased,
     selectAccountNetworkSymbol,
-    selectIsSelectedDeviceImported,
+    selectIsPortfolioTrackerDevice,
     confirmAddressOnDeviceThunk,
 } from '@suite-common/wallet-core';
 import { AccountKey } from '@suite-common/wallet-types';
@@ -24,7 +24,7 @@ export const useAccountReceiveAddress = (accountKey: AccountKey) => {
     const dispatch = useDispatch();
     const [isReceiveApproved, setIsReceiveApproved] = useState(false);
     const [isUnverifiedAddressRevealed, setIsUnverifiedAddressRevealed] = useState(false);
-    const isPortfolioTracker = useSelector(selectIsSelectedDeviceImported);
+    const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const navigation = useNavigation();
 
     const { showAlert } = useAlert();
@@ -102,7 +102,7 @@ export const useAccountReceiveAddress = (accountKey: AccountKey) => {
     }, [accountKey, freshAddress, dispatch, showAlert, navigation]);
 
     const handleShowAddress = useCallback(async () => {
-        if (isPortfolioTracker) {
+        if (isPortfolioTrackerDevice) {
             if (networkSymbol) {
                 analytics.report({
                     type: EventType.CreateReceiveAddressShowAddress,
@@ -119,7 +119,7 @@ export const useAccountReceiveAddress = (accountKey: AccountKey) => {
                 setIsReceiveApproved(true);
             }
         }
-    }, [isPortfolioTracker, networkSymbol, verifyAddressOnDevice]);
+    }, [isPortfolioTrackerDevice, networkSymbol, verifyAddressOnDevice]);
 
     return {
         address: freshAddress?.address,


### PR DESCRIPTION
- anything that is related to the `device.selectedDevice` state (accounts, discoveries, device features, etc.) starts with the `selectDevice...` prefix
- selectors that select some device or its features based on a parameter (e.g. `deviceState`) follow the structure `selectDevice...ByState`
- a few other selectors were renamed to reflect better their functionality

Closes #10311