### PR TITLE
chore: remove integration-tests folder remnants

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,7 +8,6 @@ packages/suite-data/files/bin/tor/mac-*/*.dylib filter=lfs diff=lfs merge=lfs -t
 packages/suite-data/files/bin/tor/mac-*/tor filter=lfs diff=lfs merge=lfs -text
 packages/suite-data/files/bin/tor/win-*/*.dll filter=lfs diff=lfs merge=lfs -text
 packages/suite-data/files/bin/tor/win-*/tor.exe filter=lfs diff=lfs merge=lfs -text
-packages/integration-tests/projects/suite-web/snapshots/** filter=lfs diff=lfs merge=lfs -text
 packages/connect-common/files/firmware/t1b1/*.bin filter=lfs diff=lfs merge=lfs -text
 packages/connect-common/files/firmware/t2b1/*.bin filter=lfs diff=lfs merge=lfs -text
 packages/connect-common/files/firmware/t2t1/*.bin filter=lfs diff=lfs merge=lfs -text

--- a/docker/docker-compose.suite-test.yml
+++ b/docker/docker-compose.suite-test.yml
@@ -40,8 +40,6 @@ services:
       - LOCAL_USER_ID=$LOCAL_USER_ID
     working_dir: /e2e
     command: bash -c "docker/wait-for-200.sh http://localhost:8000 && cypress open --project /e2e/packages/suite-web/e2e"
-    # if you want to debug run_tests.js (which runs tests in CI) locally
-    # command: bash -c "node ./packages/integration-tests/projects/suite-web/run_tests.js"
     volumes:
       - ../:/e2e
       - /tmp/.X11-unix:/tmp/.X11-unix:rw

--- a/docs/tests/e2e-connect-popup.md
+++ b/docs/tests/e2e-connect-popup.md
@@ -29,4 +29,4 @@ Fixtures are located in [packages/connect-popup](https://github.com/trezor/trezo
 
 ## Test results
 
-Checkout [latest screenshots](https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/artifacts/develop/file/packages/integration-tests/connect-popup-overview.html?job=connect-popup)
+Checkout [latest screenshots](https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/artifacts/develop/file/packages/connect-popup/connect-popup-overview.html?job=connect-popup%3A%20%5Bmethods.test%5D)

--- a/packages/suite-data/src/translations/list-unused.ts
+++ b/packages/suite-data/src/translations/list-unused.ts
@@ -29,7 +29,6 @@ const ignore = [
     'coverage',
     '.git',
     'suite-data',
-    'integration-tests',
     'connect-common',
     '.yarn',
     'screenshots',


### PR DESCRIPTION
resolve #8275

there is still one place where 'integration-tests' string can be found here https://github.com/trezor/trezor-suite/blob/develop/packages/suite-web/e2e/run_tests.ts#L289 but this is also a part of "currently dead code branch" which is taking care of snapshots updating and (visual) snapshots testing has been turned off for maybe two years now. 


cc @Hannsek this PR also contains a static link to the latest popup screenshots