### PR TITLE
fix(suite-native): fee rate formatter

### DIFF
--- a/suite-native/formatters/src/components/FeeFormatter.tsx
+++ b/suite-native/formatters/src/components/FeeFormatter.tsx
@@ -18,7 +18,7 @@ export const FeeFormatter = ({ transaction }: FeeFormatterProps) => {
         () =>
             networkType === 'ethereum'
                 ? fromWei(transaction.ethereumSpecific?.gasPrice ?? '0', 'gwei')
-                : getFeeRate(transaction),
+                : transaction.feeRate || getFeeRate(transaction),
         [networkType, transaction],
     );
 


### PR DESCRIPTION
## Description
- if the fee rate is already present in the TX object, use it.

## Related Issue

Resolve #10070

## Screenshots:


https://github.com/trezor/trezor-suite/assets/26143964/b6ddccf5-a8e3-4288-9bbf-b605f328f660


