### PR TITLE
Blockchain-link identities

### DIFF
--- a/packages/connect/src/api/blockchainDisconnect.ts
+++ b/packages/connect/src/api/blockchainDisconnect.ts
@@ -9,6 +9,7 @@ import { Assert } from '@trezor/schema-utils';
 
 type Params = {
     coinInfo: CoinInfo;
+    identity?: string;
 };
 
 export default class BlockchainDisconnect extends AbstractMethod<'blockchainDisconnect', Params> {
@@ -31,6 +32,7 @@ export default class BlockchainDisconnect extends AbstractMethod<'blockchainDisc
 
         this.params = {
             coinInfo,
+            identity: payload.identity,
         };
     }
 
@@ -39,10 +41,8 @@ export default class BlockchainDisconnect extends AbstractMethod<'blockchainDisc
     }
 
     run() {
-        const backend = findBackend(this.params.coinInfo.shortcut);
-        if (backend) {
-            backend.disconnect();
-        }
+        const backend = findBackend(this.params.coinInfo.shortcut, this.params.identity);
+        backend?.disconnect();
 
         return Promise.resolve({ disconnected: true });
     }

--- a/packages/connect/src/api/blockchainEstimateFee.ts
+++ b/packages/connect/src/api/blockchainEstimateFee.ts
@@ -10,6 +10,7 @@ import type { CoinInfo } from '../types';
 
 type Params = {
     coinInfo: CoinInfo;
+    identity?: string;
     request: Payload<'blockchainEstimateFee'>['request'];
 };
 
@@ -23,10 +24,11 @@ export default class BlockchainEstimateFee extends AbstractMethod<'blockchainEst
         // validate incoming parameters
         validateParams(payload, [
             { name: 'coin', type: 'string', required: true },
+            { name: 'identity', type: 'string' },
             { name: 'request', type: 'object' },
         ]);
 
-        const { request } = payload;
+        const { request, identity } = payload;
 
         if (request) {
             validateParams(request, [
@@ -55,12 +57,13 @@ export default class BlockchainEstimateFee extends AbstractMethod<'blockchainEst
 
         this.params = {
             coinInfo,
+            identity,
             request,
         };
     }
 
     async run() {
-        const { coinInfo, request } = this.params;
+        const { coinInfo, identity, request } = this.params;
         const feeInfo: MethodReturnType<typeof this.name> = {
             blockTime: coinInfo.blockTime,
             minFee: coinInfo.minFee,
@@ -73,12 +76,12 @@ export default class BlockchainEstimateFee extends AbstractMethod<'blockchainEst
             // TODO: https://github.com/trezor/trezor-suite/issues/5340
             // smart fees for DOGE are not relevant since their fee policy changed, see @trezor/utxo-lib/compose: baseFee
             if (request.feeLevels === 'smart' && coinInfo.shortcut !== 'DOGE') {
-                const backend = await initBlockchain(coinInfo, this.postMessage);
+                const backend = await initBlockchain(coinInfo, this.postMessage, identity);
                 await fees.load(backend);
             }
             feeInfo.levels = fees.levels;
         } else {
-            const backend = await initBlockchain(coinInfo, this.postMessage);
+            const backend = await initBlockchain(coinInfo, this.postMessage, identity);
             feeInfo.levels = await backend.estimateFee(request || {});
         }
 

--- a/packages/connect/src/api/blockchainGetAccountBalanceHistory.ts
+++ b/packages/connect/src/api/blockchainGetAccountBalanceHistory.ts
@@ -9,6 +9,7 @@ import type { CoinInfo } from '../types';
 
 type Params = {
     coinInfo: CoinInfo;
+    identity?: string;
     request: Omit<Payload<'blockchainGetAccountBalanceHistory'>, 'method' | 'coin'>;
 };
 
@@ -25,6 +26,7 @@ export default class BlockchainGetAccountBalanceHistory extends AbstractMethod<
         // validate incoming parameters
         validateParams(payload, [
             { name: 'coin', type: 'string', required: true },
+            { name: 'identity', type: 'string' },
             { name: 'descriptor', type: 'string', required: true },
             { name: 'from', type: 'number' },
             { name: 'to', type: 'number' },
@@ -40,6 +42,7 @@ export default class BlockchainGetAccountBalanceHistory extends AbstractMethod<
 
         this.params = {
             coinInfo,
+            identity: payload.identity,
             request: {
                 descriptor: payload.descriptor,
                 from: payload.from,
@@ -50,7 +53,11 @@ export default class BlockchainGetAccountBalanceHistory extends AbstractMethod<
     }
 
     async run() {
-        const backend = await initBlockchain(this.params.coinInfo, this.postMessage);
+        const backend = await initBlockchain(
+            this.params.coinInfo,
+            this.postMessage,
+            this.params.identity,
+        );
 
         return backend.getAccountBalanceHistory(this.params.request);
     }

--- a/packages/connect/src/api/blockchainGetCurrentFiatRates.ts
+++ b/packages/connect/src/api/blockchainGetCurrentFiatRates.ts
@@ -9,6 +9,7 @@ import type { CoinInfo } from '../types';
 
 type Params = {
     coinInfo: CoinInfo;
+    identity?: string;
     currencies: Payload<'blockchainGetCurrentFiatRates'>['currencies'];
     token: Payload<'blockchainGetCurrentFiatRates'>['token'];
 };
@@ -28,6 +29,7 @@ export default class BlockchainGetCurrentFiatRates extends AbstractMethod<
             { name: 'currencies', type: 'array', required: false },
             { name: 'token', type: 'string' },
             { name: 'coin', type: 'string', required: true },
+            { name: 'identity', type: 'string' },
         ]);
 
         const coinInfo = getCoinInfo(payload.coin);
@@ -41,11 +43,16 @@ export default class BlockchainGetCurrentFiatRates extends AbstractMethod<
             currencies: payload.currencies,
             token: payload.token,
             coinInfo,
+            identity: payload.identity,
         };
     }
 
     async run() {
-        const backend = await initBlockchain(this.params.coinInfo, this.postMessage);
+        const backend = await initBlockchain(
+            this.params.coinInfo,
+            this.postMessage,
+            this.params.identity,
+        );
 
         return backend.getCurrentFiatRates({
             currencies: this.params.currencies,

--- a/packages/connect/src/api/blockchainGetFiatRatesForTimestamps.ts
+++ b/packages/connect/src/api/blockchainGetFiatRatesForTimestamps.ts
@@ -9,6 +9,7 @@ import type { CoinInfo } from '../types';
 
 type Params = {
     coinInfo: CoinInfo;
+    identity?: string;
     currencies: Payload<'blockchainGetFiatRatesForTimestamps'>['currencies'];
     timestamps: Payload<'blockchainGetFiatRatesForTimestamps'>['timestamps'];
     token: Payload<'blockchainGetFiatRatesForTimestamps'>['token'];
@@ -30,6 +31,7 @@ export default class BlockchainGetFiatRatesForTimestamps extends AbstractMethod<
             { name: 'timestamps', type: 'array', required: true },
             { name: 'token', type: 'string' },
             { name: 'coin', type: 'string', required: true },
+            { name: 'identity', type: 'string' },
         ]);
 
         const coinInfo = getCoinInfo(payload.coin);
@@ -44,11 +46,16 @@ export default class BlockchainGetFiatRatesForTimestamps extends AbstractMethod<
             timestamps: payload.timestamps,
             token: payload.token,
             coinInfo,
+            identity: payload.identity,
         };
     }
 
     async run() {
-        const backend = await initBlockchain(this.params.coinInfo, this.postMessage);
+        const backend = await initBlockchain(
+            this.params.coinInfo,
+            this.postMessage,
+            this.params.identity,
+        );
 
         return backend.getFiatRatesForTimestamps({
             currencies: this.params.currencies,

--- a/packages/connect/src/api/blockchainGetTransactions.ts
+++ b/packages/connect/src/api/blockchainGetTransactions.ts
@@ -10,6 +10,7 @@ import type { CoinInfo } from '../types';
 type Params = {
     txs: string[];
     coinInfo: CoinInfo;
+    identity?: string;
 };
 
 export default class BlockchainGetTransactions extends AbstractMethod<
@@ -26,6 +27,7 @@ export default class BlockchainGetTransactions extends AbstractMethod<
         validateParams(payload, [
             { name: 'txs', type: 'array', required: true },
             { name: 'coin', type: 'string', required: true },
+            { name: 'identity', type: 'string' },
         ]);
 
         const coinInfo = getCoinInfo(payload.coin);
@@ -38,11 +40,16 @@ export default class BlockchainGetTransactions extends AbstractMethod<
         this.params = {
             txs: payload.txs,
             coinInfo,
+            identity: payload.identity,
         };
     }
 
     async run() {
-        const backend = await initBlockchain(this.params.coinInfo, this.postMessage);
+        const backend = await initBlockchain(
+            this.params.coinInfo,
+            this.postMessage,
+            this.params.identity,
+        );
 
         return backend.getTransactions(this.params.txs);
     }

--- a/packages/connect/src/api/blockchainSetCustomBackend.ts
+++ b/packages/connect/src/api/blockchainSetCustomBackend.ts
@@ -46,6 +46,7 @@ export default class BlockchainSetCustomBackend extends AbstractMethod<
 
     async run() {
         await reconnectAllBackends(this.params.coinInfo);
+
         return true;
     }
 }

--- a/packages/connect/src/api/blockchainSetCustomBackend.ts
+++ b/packages/connect/src/api/blockchainSetCustomBackend.ts
@@ -3,7 +3,7 @@
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { ERRORS } from '../constants';
-import { findBackend, setCustomBackend, initBlockchain } from '../backend/BlockchainLink';
+import { setCustomBackend, reconnectAllBackends } from '../backend/BlockchainLink';
 import { getCoinInfo } from '../data/coinInfo';
 import type { CoinInfo } from '../types';
 
@@ -45,12 +45,7 @@ export default class BlockchainSetCustomBackend extends AbstractMethod<
     }
 
     async run() {
-        const current = findBackend(this.params.coinInfo.shortcut);
-        if (current) {
-            current.disconnect();
-            await initBlockchain(this.params.coinInfo, this.postMessage);
-        }
-
+        await reconnectAllBackends(this.params.coinInfo);
         return true;
     }
 }

--- a/packages/connect/src/api/blockchainSubscribe.ts
+++ b/packages/connect/src/api/blockchainSubscribe.ts
@@ -9,6 +9,7 @@ import type { CoinInfo } from '../types';
 
 type Params = {
     accounts: Payload<'blockchainSubscribe'>['accounts'];
+    blocks: boolean;
     coinInfo: CoinInfo;
     identity?: string;
 };
@@ -23,6 +24,7 @@ export default class BlockchainSubscribe extends AbstractMethod<'blockchainSubsc
         // validate incoming parameters
         validateParams(payload, [
             { name: 'accounts', type: 'array', allowEmpty: true },
+            { name: 'blocks', type: 'boolean' },
             { name: 'coin', type: 'string', required: true },
             { name: 'identity', type: 'string' },
         ]);
@@ -42,6 +44,7 @@ export default class BlockchainSubscribe extends AbstractMethod<'blockchainSubsc
 
         this.params = {
             accounts: payload.accounts,
+            blocks: payload.blocks ?? true, // default is true because of backwards compatibility
             coinInfo,
             identity: payload.identity,
         };
@@ -54,6 +57,13 @@ export default class BlockchainSubscribe extends AbstractMethod<'blockchainSubsc
             this.params.identity,
         );
 
-        return backend.subscribe(this.params.accounts);
+        const { blocks, accounts } = this.params;
+
+        let result = { subscribed: false };
+
+        if (blocks) result = await backend.subscribeBlocks();
+        if (accounts) result = await backend.subscribeAccounts(accounts);
+
+        return result;
     }
 }

--- a/packages/connect/src/api/blockchainSubscribe.ts
+++ b/packages/connect/src/api/blockchainSubscribe.ts
@@ -10,6 +10,7 @@ import type { CoinInfo } from '../types';
 type Params = {
     accounts: Payload<'blockchainSubscribe'>['accounts'];
     coinInfo: CoinInfo;
+    identity?: string;
 };
 
 export default class BlockchainSubscribe extends AbstractMethod<'blockchainSubscribe', Params> {
@@ -23,6 +24,7 @@ export default class BlockchainSubscribe extends AbstractMethod<'blockchainSubsc
         validateParams(payload, [
             { name: 'accounts', type: 'array', allowEmpty: true },
             { name: 'coin', type: 'string', required: true },
+            { name: 'identity', type: 'string' },
         ]);
 
         if (payload.accounts) {
@@ -41,11 +43,16 @@ export default class BlockchainSubscribe extends AbstractMethod<'blockchainSubsc
         this.params = {
             accounts: payload.accounts,
             coinInfo,
+            identity: payload.identity,
         };
     }
 
     async run() {
-        const backend = await initBlockchain(this.params.coinInfo, this.postMessage);
+        const backend = await initBlockchain(
+            this.params.coinInfo,
+            this.postMessage,
+            this.params.identity,
+        );
 
         return backend.subscribe(this.params.accounts);
     }

--- a/packages/connect/src/api/blockchainSubscribeFiatRates.ts
+++ b/packages/connect/src/api/blockchainSubscribeFiatRates.ts
@@ -10,6 +10,7 @@ import type { CoinInfo } from '../types';
 type Params = {
     currency: Payload<'blockchainSubscribeFiatRates'>['currency'];
     coinInfo: CoinInfo;
+    identity?: string;
 };
 
 export default class BlockchainSubscribeFiatRates extends AbstractMethod<
@@ -26,6 +27,7 @@ export default class BlockchainSubscribeFiatRates extends AbstractMethod<
         validateParams(payload, [
             { name: 'currency', type: 'string', required: false },
             { name: 'coin', type: 'string', required: true },
+            { name: 'identity', type: 'string' },
         ]);
 
         const coinInfo = getCoinInfo(payload.coin);
@@ -38,11 +40,16 @@ export default class BlockchainSubscribeFiatRates extends AbstractMethod<
         this.params = {
             currency: payload.currency,
             coinInfo,
+            identity: payload.identity,
         };
     }
 
     async run() {
-        const backend = await initBlockchain(this.params.coinInfo, this.postMessage);
+        const backend = await initBlockchain(
+            this.params.coinInfo,
+            this.postMessage,
+            this.params.identity,
+        );
 
         return backend.subscribeFiatRates(this.params.currency);
     }

--- a/packages/connect/src/api/blockchainUnsubscribe.ts
+++ b/packages/connect/src/api/blockchainUnsubscribe.ts
@@ -10,6 +10,7 @@ import type { CoinInfo } from '../types';
 type Params = {
     accounts: Payload<'blockchainUnsubscribe'>['accounts'];
     coinInfo: CoinInfo;
+    identity?: string;
 };
 
 export default class BlockchainUnsubscribe extends AbstractMethod<'blockchainUnsubscribe', Params> {
@@ -23,6 +24,7 @@ export default class BlockchainUnsubscribe extends AbstractMethod<'blockchainUns
         validateParams(payload, [
             { name: 'accounts', type: 'array', allowEmpty: true },
             { name: 'coin', type: 'string', required: true },
+            { name: 'identity', type: 'string' },
         ]);
 
         if (payload.accounts) {
@@ -41,11 +43,16 @@ export default class BlockchainUnsubscribe extends AbstractMethod<'blockchainUns
         this.params = {
             accounts: payload.accounts,
             coinInfo,
+            identity: payload.identity,
         };
     }
 
     async run() {
-        const backend = await initBlockchain(this.params.coinInfo, this.postMessage);
+        const backend = await initBlockchain(
+            this.params.coinInfo,
+            this.postMessage,
+            this.params.identity,
+        );
 
         return backend.unsubscribe(this.params.accounts);
     }

--- a/packages/connect/src/api/blockchainUnsubscribe.ts
+++ b/packages/connect/src/api/blockchainUnsubscribe.ts
@@ -54,6 +54,8 @@ export default class BlockchainUnsubscribe extends AbstractMethod<'blockchainUns
             this.params.identity,
         );
 
-        return backend.unsubscribe(this.params.accounts);
+        const { accounts } = this.params;
+
+        return accounts ? backend.unsubscribeAccounts(accounts) : backend.unsubscribeAll();
     }
 }

--- a/packages/connect/src/api/blockchainUnsubscribeFiatRates.ts
+++ b/packages/connect/src/api/blockchainUnsubscribeFiatRates.ts
@@ -9,6 +9,7 @@ import type { CoinInfo } from '../types';
 
 type Params = {
     coinInfo: CoinInfo;
+    identity?: string;
 };
 
 export default class BlockchainUnsubscribeFiatRates extends AbstractMethod<
@@ -22,7 +23,10 @@ export default class BlockchainUnsubscribeFiatRates extends AbstractMethod<
         const { payload } = this;
 
         // validate incoming parameters
-        validateParams(payload, [{ name: 'coin', type: 'string', required: true }]);
+        validateParams(payload, [
+            { name: 'coin', type: 'string', required: true },
+            { name: 'identity', type: 'string' },
+        ]);
 
         const coinInfo = getCoinInfo(payload.coin);
         if (!coinInfo) {
@@ -33,11 +37,16 @@ export default class BlockchainUnsubscribeFiatRates extends AbstractMethod<
 
         this.params = {
             coinInfo,
+            identity: payload.identity,
         };
     }
 
     async run() {
-        const backend = await initBlockchain(this.params.coinInfo, this.postMessage);
+        const backend = await initBlockchain(
+            this.params.coinInfo,
+            this.postMessage,
+            this.params.identity,
+        );
 
         return backend.unsubscribeFiatRates();
     }

--- a/packages/connect/src/api/getAccountInfo.ts
+++ b/packages/connect/src/api/getAccountInfo.ts
@@ -41,6 +41,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
             // validate incoming parameters
             validateParams(batch, [
                 { name: 'coin', type: 'string', required: true },
+                { name: 'identity', type: 'string' },
                 { name: 'descriptor', type: 'string' },
                 { name: 'path', type: 'string' },
 
@@ -284,7 +285,11 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
                 }
 
                 // initialize backend
-                const blockchain = await initBlockchain(request.coinInfo, this.postMessage);
+                const blockchain = await initBlockchain(
+                    request.coinInfo,
+                    this.postMessage,
+                    request.identity,
+                );
 
                 if (this.disposed) break;
 
@@ -344,8 +349,8 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
     }
 
     async discover(request: Request) {
-        const { coinInfo, defaultAccountType } = request;
-        const blockchain = await initBlockchain(coinInfo, this.postMessage);
+        const { coinInfo, identity, defaultAccountType } = request;
+        const blockchain = await initBlockchain(coinInfo, this.postMessage, identity);
         const dfd = this.createUiPromise(UI.RECEIVE_ACCOUNT);
 
         const discovery = new Discovery({

--- a/packages/connect/src/api/pushTransaction.ts
+++ b/packages/connect/src/api/pushTransaction.ts
@@ -11,6 +11,7 @@ import { PushTransaction as PushTransactionSchema } from '../types/api/pushTrans
 type Params = {
     tx: string;
     coinInfo: CoinInfo;
+    identity?: string;
 };
 
 export default class PushTransaction extends AbstractMethod<'pushTransaction', Params> {
@@ -38,11 +39,16 @@ export default class PushTransaction extends AbstractMethod<'pushTransaction', P
         this.params = {
             tx: payload.tx,
             coinInfo,
+            identity: payload.identity,
         };
     }
 
     async run() {
-        const backend = await initBlockchain(this.params.coinInfo, this.postMessage);
+        const backend = await initBlockchain(
+            this.params.coinInfo,
+            this.postMessage,
+            this.params.identity,
+        );
         const txid = await backend.pushTransaction(this.params.tx);
 
         return {

--- a/packages/connect/src/backend/BlockchainLink.ts
+++ b/packages/connect/src/backend/BlockchainLink.ts
@@ -7,7 +7,7 @@ export { Blockchain } from './Blockchain';
 
 const backends = new BackendManager();
 
-export const findBackend = (coin: string) => backends.get(coin);
+export const findBackend = (coin: string, identity?: string) => backends.get(coin, identity);
 
 export const setCustomBackend = (coinInfo: CoinInfo, blockchainLink: CoinInfo['blockchainLink']) =>
     blockchainLink?.url.length
@@ -16,9 +16,12 @@ export const setCustomBackend = (coinInfo: CoinInfo, blockchainLink: CoinInfo['b
 
 export const isBackendSupported = (coinInfo: CoinInfo) => backends.isSupported(coinInfo);
 
-export const initBlockchain = (coinInfo: CoinInfo, postMessage: Options['postMessage']) =>
-    backends.getOrConnect(coinInfo, postMessage);
+export const initBlockchain = (
+    coinInfo: CoinInfo,
+    postMessage: Options['postMessage'],
+    identity?: string,
+) => backends.getOrConnect({ coinInfo, identity, postMessage });
 
-export const reconnectAllBackends = () => backends.reconnectAll();
+export const reconnectAllBackends = (coinInfo?: CoinInfo) => backends.reconnectAll(coinInfo);
 
 export const dispose = () => backends.dispose();

--- a/packages/connect/src/backend/__tests__/BackendManager.test.ts
+++ b/packages/connect/src/backend/__tests__/BackendManager.test.ts
@@ -4,7 +4,7 @@ import { CoinInfo } from '../../types';
 import { BackendManager } from '../BackendManager';
 import type { CoreEventMessage } from '../../events';
 
-const COIN_INFO = {
+const coinInfo = {
     shortcut: 'BTC',
     blockchainLink: { type: 'blockbook', url: ['url_1', 'url_2', 'url_3'] },
 } as CoinInfo;
@@ -37,19 +37,19 @@ describe('backend/BackendManager', () => {
     });
 
     it('reuse backend', async () => {
-        const backend1 = await manager.getOrConnect(COIN_INFO, postMessage);
+        const backend1 = await manager.getOrConnect({ coinInfo, postMessage });
         expectExactMessages('blockchain-connect');
         const networkInfo = await backend1.getNetworkInfo();
         expect(networkInfo).toMatchObject({ shortcut: 'BTC' });
 
         await delay(1000);
 
-        await manager.getOrConnect(COIN_INFO, postMessage);
+        await manager.getOrConnect({ coinInfo, postMessage });
         expectNoMessage();
     });
 
     it('reconnect backend after disconnection', async () => {
-        const backend1 = await manager.getOrConnect(COIN_INFO, postMessage);
+        const backend1 = await manager.getOrConnect({ coinInfo, postMessage });
         expectExactMessages('blockchain-connect');
 
         await delay(1000);
@@ -59,12 +59,12 @@ describe('backend/BackendManager', () => {
         await delay(1000);
         expectNoMessage();
 
-        await manager.getOrConnect(COIN_INFO, postMessage);
+        await manager.getOrConnect({ coinInfo, postMessage });
         expectExactMessages('blockchain-connect');
     });
 
     it('reconnect backend automatically when subscribed', async () => {
-        const backend = await manager.getOrConnect(COIN_INFO, postMessage);
+        const backend = await manager.getOrConnect({ coinInfo, postMessage });
         expectExactMessages('blockchain-connect');
         const { subscribed } = await backend.subscribe();
         expect(subscribed).toBe(true);
@@ -76,12 +76,12 @@ describe('backend/BackendManager', () => {
         await delay(1000);
         expectExactMessages('blockchain-connect');
 
-        await manager.getOrConnect(COIN_INFO, postMessage);
+        await manager.getOrConnect({ coinInfo, postMessage });
         expectNoMessage();
     });
 
     it('reconnect backend infinitely when cannot reconnect', async () => {
-        const backend = await manager.getOrConnect(COIN_INFO, postMessage);
+        const backend = await manager.getOrConnect({ coinInfo, postMessage });
         expectExactMessages('blockchain-connect');
         const { subscribed } = await backend.subscribe();
         expect(subscribed).toBe(true);
@@ -94,9 +94,9 @@ describe('backend/BackendManager', () => {
         expectExactMessages('blockchain-error', 'blockchain-reconnecting');
 
         await delay(1000);
-        expectExactMessages('blockchain-reconnecting');
+        expectExactMessages('blockchain-error', 'blockchain-reconnecting');
 
         await delay(2000);
-        expectExactMessages('blockchain-reconnecting');
+        expectExactMessages('blockchain-error', 'blockchain-reconnecting');
     });
 });

--- a/packages/connect/src/backend/__tests__/BackendManager.test.ts
+++ b/packages/connect/src/backend/__tests__/BackendManager.test.ts
@@ -66,7 +66,7 @@ describe('backend/BackendManager', () => {
     it('reconnect backend automatically when subscribed', async () => {
         const backend = await manager.getOrConnect({ coinInfo, postMessage });
         expectExactMessages('blockchain-connect');
-        const { subscribed } = await backend.subscribe();
+        const { subscribed } = await backend.subscribeBlocks();
         expect(subscribed).toBe(true);
 
         await delay(1000);
@@ -83,7 +83,7 @@ describe('backend/BackendManager', () => {
     it('reconnect backend infinitely when cannot reconnect', async () => {
         const backend = await manager.getOrConnect({ coinInfo, postMessage });
         expectExactMessages('blockchain-connect');
-        const { subscribed } = await backend.subscribe();
+        const { subscribed } = await backend.subscribeBlocks();
         expect(subscribed).toBe(true);
 
         await delay(1000);

--- a/packages/connect/src/events/blockchain.ts
+++ b/packages/connect/src/events/blockchain.ts
@@ -19,6 +19,7 @@ export const BLOCKCHAIN = {
 
 export interface BlockchainInfo extends ServerInfo {
     coin: CoinInfo;
+    identity?: string;
     misc?: {
         reserve?: string;
     };
@@ -26,11 +27,13 @@ export interface BlockchainInfo extends ServerInfo {
 
 export interface BlockchainReconnecting {
     coin: CoinInfo;
+    identity?: string;
     time: number;
 }
 
 export interface BlockchainError {
     coin: CoinInfo;
+    identity?: string;
     error: string;
     code?: string;
 }

--- a/packages/connect/src/types/api/bitcoin/index.ts
+++ b/packages/connect/src/types/api/bitcoin/index.ts
@@ -75,6 +75,7 @@ export interface SignTransaction {
         transactions?: AccountTransaction[]; // refTxs in different format. see refTxs/validateReferencedTransactions
     };
     coin: string;
+    identity?: string;
     locktime?: number;
     timestamp?: number;
     version?: number;

--- a/packages/connect/src/types/api/blockchainSetCustomBackend.ts
+++ b/packages/connect/src/types/api/blockchainSetCustomBackend.ts
@@ -1,7 +1,8 @@
-import type { CommonParamsWithCoin, Response } from '../params';
+import type { CommonParams, Response } from '../params';
 import type { BlockchainLink } from '../coinInfo';
 
-export type BlockchainSetCustomBackend = CommonParamsWithCoin & {
+export type BlockchainSetCustomBackend = CommonParams & {
+    coin: string;
     blockchainLink?: BlockchainLink;
 };
 

--- a/packages/connect/src/types/api/blockchainSubscribe.ts
+++ b/packages/connect/src/types/api/blockchainSubscribe.ts
@@ -2,6 +2,7 @@ import type { SubscriptionAccountInfo, BlockchainLinkResponse } from '@trezor/bl
 import type { CommonParamsWithCoin, Response } from '../params';
 
 export type BlockchainSubscribe = CommonParamsWithCoin & {
+    blocks?: boolean;
     accounts?: SubscriptionAccountInfo[];
 };
 

--- a/packages/connect/src/types/api/composeTransaction.ts
+++ b/packages/connect/src/types/api/composeTransaction.ts
@@ -23,6 +23,7 @@ export type ComposeOutput = Exclude<ComposeOutputBase, { type: 'payment' }> | Co
 export interface ComposeParams {
     outputs: ComposeOutput[];
     coin: string;
+    identity?: string;
     account?: undefined;
     feeLevels?: undefined;
     push?: boolean;
@@ -44,6 +45,7 @@ export type ComposeUtxo = AccountUtxo & Partial<ComposeInputBase>;
 export interface PrecomposeParams {
     outputs: ComposeOutput[];
     coin: string;
+    identity?: string;
     account: {
         path: string;
         addresses: AccountAddresses;

--- a/packages/connect/src/types/api/getAccountInfo.ts
+++ b/packages/connect/src/types/api/getAccountInfo.ts
@@ -5,6 +5,7 @@ import type { AccountInfo, DiscoveryAccountType } from '../account';
 
 export interface GetAccountInfo extends Omit<BlockchainLinkParams<'getAccountInfo'>, 'descriptor'> {
     coin: string;
+    identity?: string;
     path?: string;
     descriptor?: string;
     defaultAccountType?: DiscoveryAccountType;

--- a/packages/connect/src/types/api/getCoinInfo.ts
+++ b/packages/connect/src/types/api/getCoinInfo.ts
@@ -1,4 +1,4 @@
-import type { CommonParamsWithCoin, Response } from '../params';
+import type { CommonParams, Response } from '../params';
 import type { CoinInfo } from '../coinInfo';
 
-export declare function getCoinInfo(params: CommonParamsWithCoin): Response<CoinInfo>;
+export declare function getCoinInfo(params: CommonParams & { coin: string }): Response<CoinInfo>;

--- a/packages/connect/src/types/api/pushTransaction.ts
+++ b/packages/connect/src/types/api/pushTransaction.ts
@@ -9,6 +9,7 @@ export type PushTransaction = Static<typeof PushTransaction>;
 export const PushTransaction = Type.Object({
     tx: Type.String(),
     coin: Type.String(),
+    identity: Type.Optional(Type.String()),
 });
 
 // push transaction response

--- a/packages/connect/src/types/coinInfo.ts
+++ b/packages/connect/src/types/coinInfo.ts
@@ -23,6 +23,7 @@ export const Network = Type.Object({
 export type CoinObj = Static<typeof CoinObj>;
 export const CoinObj = Type.Object({
     coin: Type.String(),
+    identity: Type.Optional(Type.String()),
 });
 
 export type CoinSupport = Static<typeof CoinSupport>;

--- a/packages/connect/src/types/params.ts
+++ b/packages/connect/src/types/params.ts
@@ -30,6 +30,7 @@ export type BundledParams<T> = CommonParams & Bundle<T>;
 
 export interface CommonParamsWithCoin extends CommonParams {
     coin: string;
+    identity?: string; // ensures that different backend connections are opened for different identities
 }
 
 export interface Unsuccessful {

--- a/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
@@ -456,17 +456,32 @@ export const onConnect = [
     {
         description: 'successful, blockchainEstimateFee failed',
         initialState: {
-            accounts: [{ symbol: 'eth', history: {} }],
+            accounts: [{ symbol: 'btc', history: {} }],
         },
         // order: subscribe > estimateFee
         connect: [undefined, { success: false }],
-        symbol: 'eth',
+        symbol: 'btc',
         actions: [
             { type: blockchainActions.synced.type },
             { type: blockchainActions.connected.type },
         ],
         blockchainEstimateFee: 1,
         blockchainSubscribe: 1,
+    },
+    {
+        description: 'successful, ETH blockchainEstimateFee failed',
+        initialState: {
+            accounts: [{ symbol: 'eth', history: {}, deviceState: 'abc' }],
+        },
+        // order: subscribe > subscribe > estimateFee
+        connect: [undefined, undefined, { success: false }],
+        symbol: 'eth',
+        actions: [
+            { type: blockchainActions.synced.type },
+            { type: blockchainActions.connected.type },
+        ],
+        blockchainEstimateFee: 1,
+        blockchainSubscribe: 2,
     },
 ];
 

--- a/packages/suite/src/actions/wallet/graphActions.ts
+++ b/packages/suite/src/actions/wallet/graphActions.ts
@@ -2,7 +2,7 @@ import { isWithinInterval, fromUnixTime } from 'date-fns';
 import { Dispatch, GetState } from 'src/types/suite';
 import { Account } from 'src/types/wallet';
 
-import { isTrezorConnectBackendType } from '@suite-common/wallet-utils';
+import { tryGetAccountIdentity, isTrezorConnectBackendType } from '@suite-common/wallet-utils';
 
 import TrezorConnect from '@trezor/connect';
 
@@ -90,6 +90,7 @@ export const fetchAccountGraphData =
         const localCurrency = selectLocalCurrency(getState());
         const response = await TrezorConnect.blockchainGetAccountBalanceHistory({
             coin: account.symbol,
+            identity: tryGetAccountIdentity(account),
             descriptor: account.descriptor,
             groupBy: 3600 * 24, // day
         });

--- a/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
@@ -10,6 +10,7 @@ import {
     getExternalComposeOutput,
     formatAmount,
     isPending,
+    getAccountIdentity,
 } from '@suite-common/wallet-utils';
 import {
     StakeFormState,
@@ -127,6 +128,7 @@ export const composeTransaction =
             from: account.descriptor,
             amount,
             symbol: account.symbol,
+            identity: getAccountIdentity(account),
         });
 
         if (!stakeTxGasLimit.success) return stakeTxGasLimit.error;
@@ -253,6 +255,8 @@ export const signTransaction =
             nonce = formValues.rbfParams.ethereumNonce.toString();
         }
 
+        const identity = getAccountIdentity(account);
+
         // transform to TrezorConnect.ethereumSignTransaction params
         const { ethereumStakeType } = formValues;
         let txData;
@@ -260,6 +264,7 @@ export const signTransaction =
             txData = await prepareStakeEthTx({
                 symbol: account.symbol,
                 from: account.descriptor,
+                identity,
                 amount: formValues.outputs[0].amount,
                 gasPrice: transactionInfo.feePerByte,
                 nonce,
@@ -270,6 +275,7 @@ export const signTransaction =
             txData = await prepareUnstakeEthTx({
                 symbol: account.symbol,
                 from: account.descriptor,
+                identity,
                 amount: formValues.outputs[0].amount,
                 gasPrice: transactionInfo.feePerByte,
                 nonce,
@@ -281,6 +287,7 @@ export const signTransaction =
             txData = await prepareClaimEthTx({
                 symbol: account.symbol,
                 from: account.descriptor,
+                identity,
                 gasPrice: transactionInfo.feePerByte,
                 nonce,
                 chainId: network.chainId,

--- a/packages/suite/src/actions/wallet/stakeActions.ts
+++ b/packages/suite/src/actions/wallet/stakeActions.ts
@@ -8,7 +8,7 @@ import {
     stakeActions,
 } from '@suite-common/wallet-core';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { formatNetworkAmount } from '@suite-common/wallet-utils';
+import { formatNetworkAmount, tryGetAccountIdentity } from '@suite-common/wallet-utils';
 
 import {
     StakeFormState,
@@ -62,7 +62,10 @@ const pushTransaction =
         const device = selectDevice(getState());
         if (!signedTx || !precomposedTx || !account) return;
 
-        const sentTx = await TrezorConnect.pushTransaction(signedTx);
+        const sentTx = await TrezorConnect.pushTransaction({
+            ...signedTx,
+            identity: tryGetAccountIdentity(account),
+        });
 
         // close modal regardless result
         dispatch(modalActions.onCancel());

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddTokenModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddTokenModal.tsx
@@ -7,7 +7,7 @@ import { addToken } from 'src/actions/wallet/tokenActions';
 import { Modal } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
-import { isAddressValid } from '@suite-common/wallet-utils';
+import { tryGetAccountIdentity, isAddressValid } from '@suite-common/wallet-utils';
 import { Account } from 'src/types/wallet';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
@@ -41,6 +41,7 @@ export const AddTokenModal = ({ onCancel }: AddTokenModalProps) => {
             setIsFetching(true);
             const response = await TrezorConnect.getAccountInfo({
                 coin: acc.symbol,
+                identity: tryGetAccountIdentity(acc),
                 descriptor: acc.descriptor,
                 details: 'tokenBalances',
                 contractFilter: contractAddress,

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/BackendDisconnected.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/BackendDisconnected.tsx
@@ -1,6 +1,6 @@
 import { NotificationCard, Translation } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
-import { isTrezorConnectBackendType } from '@suite-common/wallet-utils';
+import { tryGetAccountIdentity, isTrezorConnectBackendType } from '@suite-common/wallet-utils';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
 import { useBackendReconnection } from 'src/hooks/settings/backends';
 
@@ -50,12 +50,13 @@ export const BackendDisconnected = () => {
 
     const {
         network: { symbol },
-        account: { deviceState: identity },
+        account,
     } = selectedAccount;
 
+    const identity = tryGetAccountIdentity(account);
+
     const chain =
-        (symbol === 'eth' ? blockchain[symbol]?.identityConnections?.[identity] : undefined) ??
-        blockchain[symbol];
+        (identity && blockchain[symbol]?.identityConnections?.[identity]) ?? blockchain[symbol];
 
     if (!chain || chain.connected) return null;
 

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/BackendDisconnected.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/BackendDisconnected.tsx
@@ -1,58 +1,37 @@
-import { useState, useEffect } from 'react';
 import { NotificationCard, Translation } from 'src/components/suite';
-import { useDispatch, useSelector } from 'src/hooks/suite';
-import { reconnectBlockchainThunk } from '@suite-common/wallet-core';
+import { useSelector } from 'src/hooks/suite';
 import { isTrezorConnectBackendType } from '@suite-common/wallet-utils';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
+import { useBackendReconnection } from 'src/hooks/settings/backends';
 
 const DisconnectedNotification = ({
     symbol,
-    resolveTime = 0,
+    identity,
+    resolveTime,
 }: {
     symbol: NetworkSymbol;
+    identity?: string;
     resolveTime: number | undefined;
 }) => {
-    const [progress, setProgress] = useState(false);
-    const [time, setTime] = useState<number>();
-
-    const dispatch = useDispatch();
-
-    useEffect(() => {
-        const interval = setInterval(() => {
-            const secToResolve = Math.round((resolveTime - new Date().getTime()) / 1000);
-            setTime(secToResolve);
-        }, 500);
-
-        return () => {
-            clearInterval(interval);
-        };
-    }, [resolveTime]);
-
-    const click = async () => {
-        setProgress(true);
-        const r: any = await dispatch(reconnectBlockchainThunk(symbol));
-        if (!r.success) {
-            setProgress(false);
-        }
-    };
-
-    const isResolving = typeof time === 'number' && time <= 0;
-    const displayTime =
-        time && !isResolving ? (
-            <Translation id="TR_BACKEND_RECONNECTING" values={{ time }} />
-        ) : null;
+    const { reconnect, isReconnecting, countdownSeconds } = useBackendReconnection(
+        symbol,
+        identity,
+        resolveTime,
+    );
 
     return (
         <NotificationCard
             variant="warning"
             button={{
-                onClick: click,
-                isLoading: progress || isResolving,
+                onClick: reconnect,
+                isLoading: isReconnecting,
                 children: <Translation id="TR_CONNECT" />,
             }}
         >
             <Translation id="TR_BACKEND_DISCONNECTED" />
-            {displayTime}
+            {countdownSeconds ? (
+                <Translation id="TR_BACKEND_RECONNECTING" values={{ time: countdownSeconds }} />
+            ) : null}
         </NotificationCard>
     );
 };
@@ -69,9 +48,22 @@ export const BackendDisconnected = () => {
     // TODO handle non-standard backends differently
     if (!isTrezorConnectBackendType(selectedAccount.account.backendType)) return null;
 
-    const { symbol } = selectedAccount.network;
-    const chain = blockchain[symbol];
+    const {
+        network: { symbol },
+        account: { deviceState: identity },
+    } = selectedAccount;
+
+    const chain =
+        (symbol === 'eth' ? blockchain[symbol]?.identityConnections?.[identity] : undefined) ??
+        blockchain[symbol];
+
     if (!chain || chain.connected) return null;
 
-    return <DisconnectedNotification symbol={symbol} resolveTime={chain.reconnection?.time} />;
+    return (
+        <DisconnectedNotification
+            symbol={symbol}
+            identity={identity}
+            resolveTime={chain.reconnectionTime}
+        />
+    );
 };

--- a/packages/suite/src/hooks/settings/backends/index.ts
+++ b/packages/suite/src/hooks/settings/backends/index.ts
@@ -1,4 +1,5 @@
 export { useDefaultUrls } from './useDefaultUrls';
 export { useBackendsForm } from './useBackendsForm';
 export { useCustomBackends } from './useCustomBackends';
+export { useBackendReconnection } from './useBackendReconnection';
 export type { BackendOption } from './useBackendsForm';

--- a/packages/suite/src/hooks/settings/backends/useBackendReconnection.ts
+++ b/packages/suite/src/hooks/settings/backends/useBackendReconnection.ts
@@ -1,0 +1,43 @@
+import { useState, useEffect } from 'react';
+
+import { reconnectBlockchainThunk } from '@suite-common/wallet-core';
+
+import { useDispatch } from 'src/hooks/suite';
+import { NetworkSymbol } from 'src/types/wallet';
+
+export const useBackendReconnection = (
+    coin: NetworkSymbol,
+    identity?: string,
+    resolveTime?: number,
+) => {
+    const [progress, setProgress] = useState(false);
+    const [time, setTime] = useState<number>();
+
+    const dispatch = useDispatch();
+
+    useEffect(() => {
+        if (!resolveTime) return;
+        const interval = setInterval(() => {
+            const secToResolve = Math.round((resolveTime - new Date().getTime()) / 1000);
+            setTime(secToResolve);
+        }, 500);
+
+        return () => {
+            clearInterval(interval);
+        };
+    }, [resolveTime]);
+
+    const reconnect = async () => {
+        setProgress(true);
+        const r: any = await dispatch(reconnectBlockchainThunk({ coin, identity }));
+        if (!r.success) {
+            setProgress(false);
+        }
+    };
+
+    const isResolving = typeof time === 'number' && time <= 0;
+    const countdownSeconds = !isResolving ? time : undefined;
+    const isReconnecting = progress || isResolving;
+
+    return { reconnect, isReconnecting, countdownSeconds };
+};

--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -1308,7 +1308,10 @@ export const signAndPush = [
                 payload: {
                     serializedTx: 'serializedABCD',
                 },
-            },
+            }, // ethereumSignTransaction
+            undefined, // pushTransaction
+            undefined, // getAccountInfo
+            undefined, // blockchainEstimateFee
         ],
         result: {
             formValues: {
@@ -1799,6 +1802,10 @@ export const feeChange = [
                 payload: {
                     levels: [{ feeLimit: '21009' }],
                 },
+            },
+            {
+                success: true,
+                payload: { levels: [{}] },
             },
         ],
         actionSequence: [

--- a/packages/suite/src/middlewares/wallet/__tests__/walletMiddleware.test.ts
+++ b/packages/suite/src/middlewares/wallet/__tests__/walletMiddleware.test.ts
@@ -121,10 +121,12 @@ describe('walletMiddleware', () => {
                 if (subscribe.called) {
                     // @ts-expect-error
                     const accounts = subscribe.accounts?.map(a => getWalletAccount(a));
-                    expect(TrezorConnect.blockchainSubscribe).toHaveBeenLastCalledWith({
-                        accounts,
-                        coin: subscribe.coin,
-                    });
+                    expect(TrezorConnect.blockchainSubscribe).toHaveBeenLastCalledWith(
+                        expect.objectContaining({
+                            accounts,
+                            coin: subscribe.coin,
+                        }),
+                    );
                 }
             }
 

--- a/packages/suite/src/utils/suite/stake.ts
+++ b/packages/suite/src/utils/suite/stake.ts
@@ -43,12 +43,14 @@ export const getEthNetworkForWalletSdk = (symbol: NetworkSymbol) => {
 type StakeTxBaseArgs = {
     from: string;
     symbol: NetworkSymbol;
+    identity?: string;
 };
 
 const stake = async ({
     from,
     amount,
     symbol,
+    identity,
 }: StakeTxBaseArgs & {
     amount: string;
 }) => {
@@ -67,6 +69,7 @@ const stake = async ({
         // amount is essential for a proper calculation of gasLimit (via blockbook/geth)
         const estimatedFee = await TrezorConnect.blockchainEstimateFee({
             coin: symbol,
+            identity,
             request: {
                 blocks: [2],
                 specific: {
@@ -98,6 +101,7 @@ const stake = async ({
 const unstake = async ({
     from,
     amount,
+    identity,
     interchanges,
     symbol,
 }: StakeTxBaseArgs & {
@@ -107,6 +111,7 @@ const unstake = async ({
     try {
         const accountInfo = await TrezorConnect.getAccountInfo({
             coin: symbol,
+            identity,
             details: 'tokenBalances',
             descriptor: from,
         });
@@ -142,6 +147,7 @@ const unstake = async ({
         // amount is essential for a proper calculation of gasLimit (via blockbook/geth)
         const estimatedFee = await TrezorConnect.blockchainEstimateFee({
             coin: symbol,
+            identity,
             request: {
                 blocks: [2],
                 specific: {
@@ -169,10 +175,11 @@ const unstake = async ({
     }
 };
 
-const claimWithdrawRequest = async ({ from, symbol }: StakeTxBaseArgs) => {
+const claimWithdrawRequest = async ({ from, symbol, identity }: StakeTxBaseArgs) => {
     try {
         const accountInfo = await TrezorConnect.getAccountInfo({
             coin: symbol,
+            identity,
             details: 'tokenBalances',
             descriptor: from,
         });
@@ -202,6 +209,7 @@ const claimWithdrawRequest = async ({ from, symbol }: StakeTxBaseArgs) => {
         // amount is essential for a proper calculation of gasLimit (via blockbook/geth)
         const estimatedFee = await TrezorConnect.blockchainEstimateFee({
             coin: symbol,
+            identity,
             request: {
                 blocks: [2],
                 specific: {
@@ -292,6 +300,7 @@ const transformTx = (
 
 interface PrepareStakeEthTxParams {
     symbol: NetworkSymbol;
+    identity?: string;
     from: string;
     amount: string;
     gasPrice: string;
@@ -315,12 +324,14 @@ export const prepareStakeEthTx = async ({
     gasPrice,
     nonce,
     chainId,
+    identity,
 }: PrepareStakeEthTxParams): Promise<PrepareStakeEthTxResponse> => {
     try {
         const tx = await stake({
             from,
             amount,
             symbol,
+            identity,
         });
         const transformedTx = transformTx(tx, gasPrice, nonce, chainId);
 
@@ -349,12 +360,14 @@ export const prepareUnstakeEthTx = async ({
     gasPrice,
     nonce,
     chainId,
+    identity,
     interchanges = 0,
 }: PrepareUnstakeEthTxParams): Promise<PrepareStakeEthTxResponse> => {
     try {
         const tx = await unstake({
             from,
             amount,
+            identity,
             interchanges,
             symbol,
         });
@@ -378,13 +391,14 @@ interface PrepareClaimEthTxParams extends Omit<PrepareStakeEthTxParams, 'amount'
 
 export const prepareClaimEthTx = async ({
     symbol,
+    identity,
     from,
     gasPrice,
     nonce,
     chainId,
 }: PrepareClaimEthTxParams): Promise<PrepareStakeEthTxResponse> => {
     try {
-        const tx = await claimWithdrawRequest({ from, symbol });
+        const tx = await claimWithdrawRequest({ from, symbol, identity });
         const transformedTx = transformTx(tx, gasPrice, nonce, chainId);
 
         return {
@@ -406,6 +420,7 @@ interface GetStakeTxGasLimitParams {
     from: string;
     amount: string;
     symbol: NetworkSymbol;
+    identity?: string;
 }
 
 export type GetStakeTxGasLimitResponse =
@@ -423,6 +438,7 @@ export const getStakeTxGasLimit = async ({
     from,
     amount,
     symbol,
+    identity,
 }: GetStakeTxGasLimitParams): Promise<GetStakeTxGasLimitResponse> => {
     const genericError: PrecomposedLevels = {
         normal: {
@@ -444,7 +460,7 @@ export const getStakeTxGasLimit = async ({
 
         let txData;
         if (ethereumStakeType === 'stake') {
-            txData = await stake({ from, amount, symbol });
+            txData = await stake({ from, amount, symbol, identity });
         }
         if (ethereumStakeType === 'unstake') {
             // Increase allowedInterchangeNum to enable instant unstaking.
@@ -453,10 +469,11 @@ export const getStakeTxGasLimit = async ({
                 amount,
                 interchanges: 0,
                 symbol,
+                identity,
             });
         }
         if (ethereumStakeType === 'claim') {
-            txData = await claimWithdrawRequest({ from, symbol });
+            txData = await claimWithdrawRequest({ from, symbol, identity });
         }
 
         if (!txData) {

--- a/packages/suite/src/views/settings/SettingsDebug/Backends.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/Backends.tsx
@@ -1,0 +1,167 @@
+import styled from 'styled-components';
+
+import { typography } from '@trezor/theme';
+import { Button, CoinLogo } from '@trezor/components';
+import { networks } from '@suite-common/wallet-config';
+import { ConnectionStatus } from '@suite-common/wallet-types';
+
+import { SectionItem, StatusLight, Translation } from 'src/components/suite';
+import { useEnabledNetworks } from 'src/hooks/settings/useEnabledNetworks';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { NetworkSymbol } from 'src/types/wallet';
+import { selectNetworkBlockchainInfo } from '@suite-common/wallet-core';
+import { useBackendReconnection } from 'src/hooks/settings/backends';
+import { openModal } from 'src/actions/suite/modalActions';
+
+const CoinSection = styled.div`
+    display: flex;
+    flex: 1;
+    gap: 16px;
+    align-items: center;
+    justify-content: space-between;
+
+    > div {
+        display: flex;
+        gap: 8px;
+        flex-direction: column;
+    }
+`;
+
+const CoinCell = styled.div`
+    display: flex;
+    gap: 8px;
+    align-items: center;
+`;
+
+const BackendRow = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 16px;
+
+    > :nth-child(2) {
+        width: 200px;
+
+        > * {
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+    }
+
+    > :last-child {
+        width: 100px;
+        display: flex;
+        justify-content: end;
+    }
+`;
+
+const Title = styled.div`
+    ${typography.body}
+`;
+
+const Subtitle = styled.div<{ $error?: boolean }>`
+    ${typography.hint}
+    color: ${({ $error, theme }) => ($error ? theme.textAlertRed : theme.TYPE_LIGHT_GREY)};
+`;
+
+const BackendItem = ({
+    symbol,
+    identity,
+    url,
+    connected,
+    error,
+    reconnectionTime,
+}: { identity?: string; symbol: NetworkSymbol; url?: string } & ConnectionStatus) => {
+    const { reconnect, isReconnecting, countdownSeconds } = useBackendReconnection(
+        symbol,
+        identity,
+        reconnectionTime,
+    );
+
+    const subtitle =
+        (countdownSeconds && (
+            <Translation id="TR_BACKEND_RECONNECTING" values={{ time: countdownSeconds }} />
+        )) ||
+        (error ?? url);
+
+    return (
+        <BackendRow>
+            <div>
+                <StatusLight variant={connected ? 'primary' : 'destructive'} />
+            </div>
+            <div>
+                <Title>{identity ?? 'Default'}</Title>
+                <Subtitle $error={!!error}>{subtitle}</Subtitle>
+            </div>
+            <div>
+                {!connected && (
+                    <Button
+                        size="tiny"
+                        variant="tertiary"
+                        isLoading={isReconnecting}
+                        onClick={reconnect}
+                    >
+                        <Translation id="TR_CONNECT" />
+                    </Button>
+                )}
+            </div>
+        </BackendRow>
+    );
+};
+
+const CoinItem = ({ symbol }: { symbol: NetworkSymbol }) => {
+    const { url, error, connected, reconnectionTime, identityConnections } = useSelector(
+        selectNetworkBlockchainInfo(symbol),
+    );
+
+    const dispatch = useDispatch();
+
+    const onSettings = () => {
+        dispatch(
+            openModal({
+                type: 'advanced-coin-settings',
+                coin: symbol,
+            }),
+        );
+    };
+
+    return (
+        <SectionItem>
+            <CoinSection>
+                <div>
+                    <CoinCell>
+                        <CoinLogo symbol={symbol} />
+                        <Title>{networks[symbol].name}</Title>
+                    </CoinCell>
+                    <Button size="tiny" variant="tertiary" onClick={onSettings}>
+                        <Translation id="TR_SETTINGS" />
+                    </Button>
+                </div>
+                <div>
+                    <BackendItem
+                        symbol={symbol}
+                        url={url}
+                        connected={connected}
+                        error={error}
+                        reconnectionTime={reconnectionTime}
+                    />
+                    {Object.entries(identityConnections ?? {}).map(([identity, connection]) => (
+                        <BackendItem
+                            key={identity}
+                            identity={identity}
+                            symbol={symbol}
+                            url={url}
+                            {...connection}
+                        />
+                    ))}
+                </div>
+            </CoinSection>
+        </SectionItem>
+    );
+};
+
+export const Backends = () => {
+    const { enabledNetworks } = useEnabledNetworks();
+
+    return enabledNetworks.map(symbol => <CoinItem key={symbol} symbol={symbol} />);
+};

--- a/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
@@ -17,6 +17,7 @@ import { Processes } from './Processes';
 import { PasswordManager } from './PasswordManager/PasswordManager';
 import { ViewOnlySettings } from './ViewOnlySettings';
 import { TriggerHighlight } from './TriggerHighlight';
+import { Backends } from './Backends';
 
 export const SettingsDebug = () => (
     <SettingsLayout>
@@ -54,6 +55,9 @@ export const SettingsDebug = () => (
         )}
         <SettingsSection title="Transports">
             <Transport />
+        </SettingsSection>
+        <SettingsSection title="Backends">
+            <Backends />
         </SettingsSection>
         <SettingsSection title="Password manager">
             <PasswordManager />

--- a/packages/suite/src/views/wallet/send/components/Raw.tsx
+++ b/packages/suite/src/views/wallet/send/components/Raw.tsx
@@ -6,8 +6,8 @@ import { sendFormActions, pushSendFormRawTransactionThunk } from '@suite-common/
 
 import { Translation } from 'src/components/suite';
 import { useDispatch, useTranslation } from 'src/hooks/suite';
-import { getInputState, isHexValid } from '@suite-common/wallet-utils';
-import { Network } from 'src/types/wallet';
+import { tryGetAccountIdentity, getInputState, isHexValid } from '@suite-common/wallet-utils';
+import { Account } from 'src/types/wallet';
 import { OpenGuideFromTooltip } from 'src/components/guide';
 import { spacingsPx } from '@trezor/theme';
 
@@ -36,12 +36,12 @@ const SendButton = styled(Button)`
 `;
 
 interface RawProps {
-    network: Network;
+    account: Account;
 }
 
 const INPUT_NAME = 'rawTx';
 
-export const Raw = ({ network }: RawProps) => {
+export const Raw = ({ account }: RawProps) => {
     const {
         register,
         setValue,
@@ -59,7 +59,7 @@ export const Raw = ({ network }: RawProps) => {
     const inputValue = watch(INPUT_NAME);
     const error = errors[INPUT_NAME];
     const inputState = getInputState(error);
-    const prefix = network.networkType === 'ethereum' ? '0x' : undefined;
+    const prefix = account.networkType === 'ethereum' ? '0x' : undefined;
 
     const { ref: inputRef, ...inputField } = register(INPUT_NAME, {
         required: translationString('RAW_TX_NOT_SET'),
@@ -72,7 +72,11 @@ export const Raw = ({ network }: RawProps) => {
 
     const send = async () => {
         const result = await dispatch(
-            pushSendFormRawTransactionThunk({ tx: inputValue, coin: network.symbol }),
+            pushSendFormRawTransactionThunk({
+                tx: inputValue,
+                coin: account.symbol,
+                identity: tryGetAccountIdentity(account),
+            }),
         ).unwrap();
 
         if (result) {
@@ -80,7 +84,7 @@ export const Raw = ({ network }: RawProps) => {
             analytics.report({
                 type: EventType.SendRawTransaction,
                 payload: {
-                    networkSymbol: network.symbol,
+                    networkSymbol: account.symbol,
                 },
             });
         }

--- a/packages/suite/src/views/wallet/send/index.tsx
+++ b/packages/suite/src/views/wallet/send/index.tsx
@@ -78,7 +78,7 @@ const SendLoaded = ({ children, selectedAccount }: SendLoadedProps) => {
     if (props.sendRaw) {
         return (
             <WalletLayout title="TR_NAV_SEND" isSubpage account={selectedAccount}>
-                <Raw network={selectedAccount.network} />
+                <Raw account={selectedAccount.account} />
             </WalletLayout>
         );
     }

--- a/suite-common/graph/src/graphBalanceEvents.ts
+++ b/suite-common/graph/src/graphBalanceEvents.ts
@@ -112,7 +112,7 @@ export const getAccountMovementEvents = async ({
     startOfTimeFrameDate: Date | null;
     endOfTimeFrameDate: Date;
 }) => {
-    const { coin, descriptor } = account;
+    const { coin, identity, descriptor } = account;
 
     const getBalanceHistory = async () => {
         if (getNetworkType(coin) === 'ripple') {
@@ -123,6 +123,7 @@ export const getAccountMovementEvents = async ({
         }
         const connectBalanceHistory = await TrezorConnect.blockchainGetAccountBalanceHistory({
             coin,
+            identity,
             descriptor,
             from: startOfTimeFrameDate ? getUnixTime(startOfTimeFrameDate) : undefined,
             to: getUnixTime(endOfTimeFrameDate),

--- a/suite-common/graph/src/types.ts
+++ b/suite-common/graph/src/types.ts
@@ -11,6 +11,7 @@ export type FiatGraphPointWithCryptoBalance = {
 
 export type AccountItem = {
     coin: NetworkSymbol;
+    identity?: string;
     descriptor: string;
 };
 

--- a/suite-common/transaction-cache-engine/src/TransactionCacheEngine.ts
+++ b/suite-common/transaction-cache-engine/src/TransactionCacheEngine.ts
@@ -119,6 +119,7 @@ export class TransactionCacheEngine {
             const result = await TrezorConnect.getAccountInfo({
                 coin,
                 descriptor,
+                // TODO add identity when used for eth-like coins
                 details: 'txs',
                 page,
                 pageSize,
@@ -276,6 +277,7 @@ export class TransactionCacheEngine {
                 TrezorConnect.blockchainSubscribe({
                     accounts: accountDescriptors,
                     coin,
+                    // TODO add identity when used for eth-like coins
                 });
             }),
         );
@@ -287,6 +289,7 @@ export class TransactionCacheEngine {
         TrezorConnect.blockchainUnsubscribe({
             accounts: [{ descriptor }],
             coin,
+            // TODO add identity when used for eth-like coins
         });
     }
 }

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -6,6 +6,7 @@ import {
     findAccountDevice,
     formatNetworkAmount,
     formatTokenAmount,
+    tryGetAccountIdentity,
     getAccountTransactions,
     getAreSatoshisUsed,
     isAccountOutdated,
@@ -53,6 +54,7 @@ const fetchAccountTokens = async (account: Account, payloadTokens: AccountInfo['
     const promises = customTokens.map(t =>
         TrezorConnect.getAccountInfo({
             coin: account.symbol,
+            identity: tryGetAccountIdentity(account),
             descriptor: account.descriptor,
             details: 'tokenBalances',
             contractFilter: t.contract,
@@ -87,6 +89,7 @@ export const fetchAndUpdateAccountThunk = createThunk(
         // basic check returns only small amount of data without full transaction history
         const basic = await TrezorConnect.getAccountInfo({
             coin: account.symbol,
+            identity: tryGetAccountIdentity(account),
             descriptor: account.descriptor,
             details: 'basic',
             suppressBackupWarning: true,
@@ -107,6 +110,7 @@ export const fetchAndUpdateAccountThunk = createThunk(
 
         const response = await TrezorConnect.getAccountInfo({
             coin: account.symbol,
+            identity: tryGetAccountIdentity(account),
             descriptor: account.descriptor,
             details: 'txs',
             page: 1, // useful for every network except ripple

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -148,7 +148,8 @@ export const updateFeeInfoThunk = createThunk(
 // call TrezorConnect.unsubscribe, it doesn't cost anything and should emit BLOCKCHAIN.CONNECT or BLOCKCHAIN.ERROR event
 export const reconnectBlockchainThunk = createThunk(
     `${BLOCKCHAIN_MODULE_PREFIX}/reconnectBlockchainThunk`,
-    (coin: NetworkSymbol) => TrezorConnect.blockchainUnsubscribeFiatRates({ coin }),
+    (payload: { coin: NetworkSymbol; identity?: string }) =>
+        TrezorConnect.blockchainUnsubscribeFiatRates(payload),
 );
 
 const setBackendsToConnect = (backends: CustomBackend[]) =>
@@ -197,7 +198,7 @@ export const initBlockchainThunk = createThunk(
             }
         });
 
-        const promises = coins.map(coin => dispatch(reconnectBlockchainThunk(coin)));
+        const promises = coins.map(coin => dispatch(reconnectBlockchainThunk({ coin })));
         await Promise.all(promises);
 
         // continue suite initialization

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -3,7 +3,11 @@ import { DiscoveryStatus } from '@suite-common/wallet-constants';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import TrezorConnect, { AccountInfo, BundleProgress, UI } from '@trezor/connect';
 import { TrezorDevice } from '@suite-common/suite-types';
-import { getDerivationType, isTrezorConnectBackendType } from '@suite-common/wallet-utils';
+import {
+    tryGetAccountIdentity,
+    getDerivationType,
+    isTrezorConnectBackendType,
+} from '@suite-common/wallet-utils';
 import { Discovery, DiscoveryItem, PartialDiscovery } from '@suite-common/wallet-types';
 import { getTxsPerPage } from '@suite-common/suite-utils';
 import { networksCompatibility, NetworkSymbol } from '@suite-common/wallet-config';
@@ -243,6 +247,10 @@ export const getBundleThunk = createThunk(
                 bundle.push({
                     path: configNetwork.bip43Path.replace('i', index.toString()),
                     coin: configNetwork.symbol,
+                    identity: tryGetAccountIdentity({
+                        networkType: configNetwork.networkType,
+                        deviceState: discovery.deviceState,
+                    }),
                     details: 'txs',
                     index,
                     pageSize: getTxsPerPage(configNetwork.networkType),

--- a/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
@@ -15,6 +15,7 @@ import {
     formatAmount,
     isPending,
     getNetwork,
+    getAccountIdentity,
 } from '@suite-common/wallet-utils';
 import { createThunk } from '@suite-common/redux-utils';
 import { ETH_DEFAULT_GAS_LIMIT } from '@suite-common/wallet-constants';
@@ -124,6 +125,7 @@ export const composeEthereumSendFormTransactionThunk = createThunk(
         // amount in essential for a proper calculation of gasLimit (via blockbook/geth)
         const estimatedFee = await TrezorConnect.blockchainEstimateFee({
             coin: account.symbol,
+            identity: getAccountIdentity(account),
             request: {
                 blocks: [2],
                 specific: {

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -18,6 +18,7 @@ import {
     getRbfParams,
     replaceEthereumSpecific,
     advancedSearchTransactions,
+    tryGetAccountIdentity,
 } from '@suite-common/wallet-utils';
 import { AccountLabels } from '@suite-common/metadata-types';
 import TrezorConnect from '@trezor/connect';
@@ -354,6 +355,7 @@ export const fetchTransactionsThunk = createThunk(
         const { marker } = account;
         const result = await TrezorConnect.getAccountInfo({
             coin: account.symbol,
+            identity: tryGetAccountIdentity(account),
             descriptor: account.descriptor,
             details: 'txs',
             page, // useful for every network except ripple

--- a/suite-common/wallet-types/src/backend.ts
+++ b/suite-common/wallet-types/src/backend.ts
@@ -25,26 +25,27 @@ export type BackendSettings = Partial<{
     }>;
 }>;
 
-interface BlockchainReconnection {
-    time: number; // timestamp when it will be resolved
+export interface ConnectionStatus {
+    connected: boolean;
+    error?: string;
+    reconnectionTime?: number; // timestamp when it will be resolved
 }
 
-export interface Blockchain {
+export interface Blockchain extends ConnectionStatus {
     url?: string;
     explorer: {
         tx: string;
         account: string;
         queryString: string;
     };
-    connected: boolean;
-    subscribed?: boolean;
-    error?: string;
     blockHash: string;
     blockHeight: number;
     version: string;
-    reconnection?: BlockchainReconnection;
     syncTimeout?: Timeout;
     backends: BackendSettings;
+    identityConnections?: {
+        [identity: string]: ConnectionStatus;
+    };
 }
 
 export type BlockchainNetworks = {

--- a/suite-common/wallet-types/src/discovery.ts
+++ b/suite-common/wallet-types/src/discovery.ts
@@ -37,6 +37,7 @@ export type DiscoveryItem = {
     path: string;
     unlockPath?: Account['unlockPath'];
     coin: Account['symbol'];
+    identity?: string;
     details?: 'basic' | 'tokens' | 'tokenBalances' | 'txids' | 'txs';
     pageSize?: number;
     suppressBackupWarning?: boolean;

--- a/suite-common/wallet-utils/src/backendUtils.ts
+++ b/suite-common/wallet-utils/src/backendUtils.ts
@@ -3,8 +3,14 @@ import type {
     CustomBackend,
     BlockchainNetworks,
     BackendSettings,
+    Account,
 } from '@suite-common/wallet-types';
-import { TREZOR_CONNECT_BACKENDS, BackendType, NetworkSymbol } from '@suite-common/wallet-config';
+import {
+    TREZOR_CONNECT_BACKENDS,
+    BackendType,
+    NetworkSymbol,
+    getNetworkType,
+} from '@suite-common/wallet-config';
 
 export const getDefaultBackendType = (coin: NetworkSymbol) => {
     if (coin === 'ada' || coin === 'tada') {
@@ -52,3 +58,10 @@ export const isTrezorConnectBackendType = (type?: BackendType) => {
 
     return !!TREZOR_CONNECT_BACKENDS.find(b => b === type);
 };
+
+export const shouldUseIdentities = (symbol: NetworkSymbol) => getNetworkType(symbol) === 'ethereum';
+
+export const getAccountIdentity = (account: Pick<Account, 'deviceState'>) => account.deviceState;
+
+export const tryGetAccountIdentity = (account: Pick<Account, 'networkType' | 'deviceState'>) =>
+    account.networkType === 'ethereum' ? getAccountIdentity(account) : undefined;

--- a/suite-native/blockchain/src/blockchainThunks.ts
+++ b/suite-native/blockchain/src/blockchainThunks.ts
@@ -70,7 +70,9 @@ export const onBlockchainConnectThunk = createThunk(
         const network = getNetwork(symbol.toLowerCase());
         if (!network) return;
 
-        await dispatch(subscribeBlockchainThunk({ symbol: network.symbol, fiatRates: true }));
+        await dispatch(
+            subscribeBlockchainThunk({ symbol: network.symbol, fiatRates: true, onConnect: true }),
+        );
 
         // update accounts for connected network
         await dispatch(syncAccountsWithBlockchainThunk({ symbol: network.symbol }));

--- a/suite-native/graph/package.json
+++ b/suite-native/graph/package.json
@@ -22,6 +22,7 @@
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
+        "@suite-common/wallet-utils": "workspace:*",
         "@suite-native/analytics": "workspace:*",
         "@suite-native/atoms": "workspace:*",
         "@suite-native/formatters": "workspace:*",

--- a/suite-native/graph/src/hooks.ts
+++ b/suite-native/graph/src/hooks.ts
@@ -17,6 +17,7 @@ import {
 import { AccountKey } from '@suite-common/wallet-types';
 import { analytics, EventType } from '@suite-native/analytics';
 import { NetworkSymbol } from '@suite-common/wallet-config';
+import { tryGetAccountIdentity } from '@suite-common/wallet-utils';
 
 import { timeSwitchItems } from './components/TimeSwitch';
 import { TimeframeHoursValue } from './types';
@@ -92,6 +93,7 @@ export const useGraphForSingleAccount = ({
             {
                 coin: account.symbol,
                 descriptor: account.descriptor,
+                identity: tryGetAccountIdentity(account),
             },
         ] as AccountItem[];
     }, [account]);
@@ -132,6 +134,7 @@ export const useGraphForAllDeviceAccounts = ({ fiatCurrency }: CommonUseGraphPar
             accounts.map(account => ({
                 coin: account.symbol,
                 descriptor: account.descriptor,
+                identity: tryGetAccountIdentity(account),
             })),
         [accounts],
     );

--- a/suite-native/graph/tsconfig.json
+++ b/suite-native/graph/tsconfig.json
@@ -19,6 +19,9 @@
         {
             "path": "../../suite-common/wallet-types"
         },
+        {
+            "path": "../../suite-common/wallet-utils"
+        },
         { "path": "../analytics" },
         { "path": "../atoms" },
         { "path": "../formatters" },

--- a/suite-native/module-accounts-import/src/screens/AccountImportLoadingScreen.tsx
+++ b/suite-native/module-accounts-import/src/screens/AccountImportLoadingScreen.tsx
@@ -10,8 +10,9 @@ import {
     StackToStackCompositeScreenProps,
 } from '@suite-native/navigation';
 import TrezorConnect, { AccountInfo } from '@trezor/connect';
-import { updateFiatRatesThunk } from '@suite-common/wallet-core';
+import { PORTFOLIO_TRACKER_DEVICE_STATE, updateFiatRatesThunk } from '@suite-common/wallet-core';
 import { Timestamp, TokenAddress } from '@suite-common/wallet-types';
+import { getAccountIdentity, shouldUseIdentities } from '@suite-common/wallet-utils';
 
 import { AccountImportLoader } from '../components/AccountImportLoader';
 import { useShowImportError } from '../useShowImportError';
@@ -67,6 +68,9 @@ export const AccountImportLoadingScreen = ({
             const [fetchedAccountInfo] = await Promise.all([
                 TrezorConnect.getAccountInfo({
                     coin: networkSymbol,
+                    identity: shouldUseIdentities(networkSymbol)
+                        ? getAccountIdentity({ deviceState: PORTFOLIO_TRACKER_DEVICE_STATE })
+                        : undefined,
                     descriptor: xpubAddress,
                     details: 'txs',
                     suppressBackupWarning: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9059,6 +9059,7 @@ __metadata:
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
+    "@suite-common/wallet-utils": "workspace:*"
     "@suite-native/analytics": "workspace:*"
     "@suite-native/atoms": "workspace:*"
     "@suite-native/formatters": "workspace:*"


### PR DESCRIPTION
## Description

Add special `identity` param to all Connect methods which communicate with backends. This params enforces that method calls with different `identity` should always use separate backend connections, regardless the backend type.

While in future it can be used for any coins and contexts (e.g. for proxying through different Tor identities), currently it is used solely for separating ETH-like account subscriptions based on their `deviceState` (= hidden wallets) as Blockbook only allows 10 ETH addresses per websocket.

## PR structure

- Connect identities implementation
  - https://github.com/trezor/trezor-suite/pull/10723/commits/c80df14dfe863397cf4e233dd52d9daa2d12e55f - mostly reworking of `BackendManager` so backend connection is identified by coin+identity instead of coin alone; backends are connecting and automatically reconnecting independently based on identities; `BLOCKCHAIN` events are now emitted including `identity` param
  - https://github.com/trezor/trezor-suite/pull/10723/commits/56a1942d8e481a5e0e492a4d67ecca5d859197c3 - `BackendManager` unit tests adjustment
  - https://github.com/trezor/trezor-suite/pull/10723/commits/a8adc6cc04219c99b4c2060ccbbe410575121fa7 - optionally receiving `identity` param in every relevant Connect method and passing it to backend init requests
- Suite identities implementation
  - https://github.com/trezor/trezor-suite/pull/10723/commits/f955a729ff3e7880a119fbb7dc4d1b703e180a87 - `blockchainReducer` adjusted so backend info for identity connections is stored together with the primary, identity-less backend connection for the same coin
  - https://github.com/trezor/trezor-suite/pull/10723/commits/777642b7abadcb654f805ff8ea9f01e63bb6734b - backend reconnection logic is separated into `useBackendReconnection` hook, with support for identitites
  - https://github.com/trezor/trezor-suite/pull/10723/commits/c1abb9575825b90cc5e31a2aab98e275f17a8e56 - auxiliary `Backends` section is added into debug menu, so we have better overview what is connected to where
  - https://github.com/trezor/trezor-suite/pull/10723/commits/2aa405c93e0fc8b91b9918ec9a0c7791772784e0 - `identity` param (based on account's `deviceState`) added to every Connect method call for ETH where it seemed desirable; other coins should remain unchanged; `subscribeBlockchainThunk` and `unsubscribeBlockchainThunk` changed the most
  - https://github.com/trezor/trezor-suite/pull/10723/commits/c2537c4de21905aa2271b6f323aef1cc925a847b - same thing, but for ETH staking; separated in order to simplify the review
  - https://github.com/trezor/trezor-suite/pull/10723/commits/679476c04a2e16309de2878e0a45e050a79aa832 - same thing, but for suite-native, separated in order to simplify the review
- Separation of block and account subscriptions
  - https://github.com/trezor/trezor-suite/pull/10723/commits/0d90df2d2d7355441e49141cbbc21b48377d2a0e - added optional `blocks` param to Connect's `blockchainSubscribe` method; allows to subscribe only to accounts and not blocks (so BLOCK event isn't duplicated for every connected identity backend)
  - https://github.com/trezor/trezor-suite/pull/10723/commits/9507fc4c263109da6c0ec9bc8f2e01e6f1ab26eb - when backend with identity is connected, subscribe to `blocks` on identity-less backend (meant as a primary backend unrelated to specific accounts)
  - https://github.com/trezor/trezor-suite/pull/10723/commits/e1b6f8c75a26a3023822dcc779f09a5a50f7c1ea - unit tests adjustment

## QA

This can potentially break a lot of things. I'll try to somehow sort it by priorities.
- All the backend operations with non-ETH coins should work exactly as before (discovery, sync, send, reconnect in case of lost connection, etc...)
- All the backend operations with ETH coins should seem to work exactly as before, but additional backend should be used for every (standard/hidden) wallet, plus one default backend for block events, fiat rates etc. (can be checked in new debug menu section) 
![image](https://github.com/trezor/trezor-suite/assets/26326960/6a5e7b4f-ecd7-4b53-a159-f07de3fe2978)
- All the extra ETH backends should connect, disconnect and reconnect exactly as before, ETH tx notifications should work for all the accounts, as well as block notifications
- ETH staking should work (presuming that it worked up to now)
- Suite Native should implement the same logic as well

## Related issue

Should resolve #10696
