### PR TITLE
feat(node-utils): add http util

### DIFF
--- a/packages/node-utils/package.json
+++ b/packages/node-utils/package.json
@@ -10,6 +10,10 @@
         "test:unit": "jest -c ../../jest.config.base.js --passWithNoTests",
         "type-check": "tsc --build"
     },
+    "dependencies": {
+        "@trezor/type-utils": "workspace:*",
+        "@trezor/utils": "workspace:*"
+    },
     "devDependencies": {
         "jest": "29.5.0",
         "typescript": "5.3.2"

--- a/packages/node-utils/src/http.ts
+++ b/packages/node-utils/src/http.ts
@@ -1,0 +1,311 @@
+import * as http from 'http';
+import * as net from 'net';
+import * as url from 'url';
+
+import type { RequiredKey } from '@trezor/type-utils';
+import { TypedEmitter } from '@trezor/utils/lib/typedEventEmitter';
+
+import { getFreePort } from './getFreePort';
+
+type Request = RequiredKey<http.IncomingMessage, 'url'>;
+type EventMap = { [event: string]: any };
+
+type LogFn = (message: string | string[]) => void;
+type Logger = {
+    info: LogFn;
+    warn: LogFn;
+    error: LogFn;
+};
+
+type OriginalLogFn = (topic: string, message: string | string[]) => void;
+type OriginalLogger = {
+    info: OriginalLogFn;
+    warn: OriginalLogFn;
+    error: OriginalLogFn;
+};
+
+export type Handler = (
+    request: Request,
+    response: http.ServerResponse,
+    next: () => void,
+    { logger }: { logger: Logger },
+) => void;
+
+/**
+ * Events that may be emitted or listened to by HttpServer
+ */
+type BaseEvents = {
+    'server/listening': (address: NonNullable<net.AddressInfo>) => void;
+    'server/closing': () => void;
+    'server/closed': () => void;
+    'server/error': (error: string) => void;
+};
+
+/**
+ * Http server listening on localhost.
+ */
+export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents> {
+    server: http.Server;
+    private routes: {
+        method: 'GET' | 'POST' | 'PUT' | 'DELETE' | '*';
+        pathname: string;
+        handler: Handler[];
+    }[] = [];
+    private logger: Logger;
+    private readonly emitter: TypedEmitter<BaseEvents> = this;
+    private port?: number;
+    private sockets: Record<number, net.Socket> = {};
+
+    constructor({ logger, port }: { logger: OriginalLogger; port?: number }) {
+        super();
+
+        this.port = port;
+
+        // this class accepts subset of suite-desktop-core "ILogger" interface.
+        // - in order to omit need for passing the first argument "topic" in each call, we wrap the logger and prepend "http: ${this.port}" to each call
+        // - here it implements also only a subset of ILogger functionality
+        // - todo: unify loggers across the codebase
+        this.logger = {
+            info: (message: string | string[]) => logger.info(`${this.logName}`, message),
+            warn: (message: string | string[]) => logger.warn(`${this.logName}`, message),
+            error: (message: string | string[]) => logger.error(`${this.logName}`, message),
+        };
+        // this.logger = logger;
+        this.server = http.createServer(this.onRequest);
+    }
+
+    get logName() {
+        return `http: ${this.port || 'unknown port'}`;
+    }
+
+    public getServerAddress() {
+        const address = this.server.address();
+        if (!address || typeof address === 'string') {
+            // this is only for typescript
+            // net.AddressInfo may also be string for a server listening on a pipe or Unix domain socket, the name is returned as a string.
+            throw new Error(`Unexpected server address: ${address}`);
+        }
+
+        return address;
+    }
+
+    getRouteAddress(pathname: string) {
+        const address = this.getServerAddress();
+        const route = this.routes.find(r => r.pathname === pathname);
+        if (!route) return;
+        return `http://${address.address}:${address.port}${route.pathname}`;
+    }
+
+    public getInfo() {
+        const address = this.getServerAddress();
+        return {
+            url: `http://${address.address}:${address.port}`,
+        };
+    }
+
+    public async start() {
+        const port = this.port || (this.port = await getFreePort());
+        return new Promise((resolve, reject) => {
+            let nextSocketId = 0;
+            this.server.on('connection', socket => {
+                // Add a newly connected socket
+                const socketId = nextSocketId++;
+                this.sockets[socketId] = socket;
+                // Remove the socket when it closes
+                socket.on('close', () => {
+                    delete this.sockets[socketId];
+                });
+            });
+
+            this.server.on('error', e => {
+                this.server.close();
+                // @ts-expect-error - type is missing
+                const errorCode: string = e.code;
+
+                const errorMessage =
+                    errorCode === 'EADDRINUSE'
+                        ? `Port ${port} already in use!` // TODO: Try different port?
+                        : `Start error code: ${errorCode}`;
+
+                this.logger.error(errorMessage);
+                return reject(new Error(`http-receiver: ${errorMessage}`));
+            });
+
+            this.server.listen(port, '127.0.0.1', undefined, () => {
+                this.logger.info('Server started');
+                const address = this.getServerAddress();
+                if (address) {
+                    this.emitter.emit('server/listening', address);
+                }
+                return resolve(address);
+            });
+        });
+    }
+
+    public stop() {
+        // note that this method only stops listening but keeps existing connections open and thus port blocked
+        this.emitter.removeAllListeners();
+
+        return new Promise<void>(resolve => {
+            this.emitter.emit('server/closing');
+            this.server.closeAllConnections();
+            this.server.close(err => {
+                if (err) {
+                    this.logger.info('trying to close server which was not running');
+                }
+                this.logger.info('Server stopped');
+                this.emitter.emit('server/closed');
+                resolve();
+            });
+            Object.values(this.sockets).forEach(socket => {
+                socket.destroy();
+            });
+        });
+    }
+
+    public post(pathname: string, handler: Handler[]) {
+        this.routes.push({
+            method: 'POST',
+            pathname,
+            handler,
+        });
+    }
+
+    public get(pathname: string, handler: Handler[]) {
+        this.routes.push({
+            method: 'GET',
+            pathname,
+            handler,
+        });
+    }
+
+    /**
+     * Register common handlers that are run for all requests before route handlers
+     */
+    public use(handler: Handler[]) {
+        this.routes.push({
+            method: '*',
+            pathname: '*',
+            handler,
+        });
+    }
+
+    // PUT, DELETE etc are not used anywhere in our codebase, so no need to implement them now
+
+    /**
+     * Entry point for handling requests
+     */
+    private onRequest = (request: http.IncomingMessage, response: http.ServerResponse) => {
+        // mostly ts stuff. request should always have url defined.
+        if (!request.url) {
+            this.logger.warn('Unexpected incoming message (no url)');
+            this.emitter.emit('server/error', 'Unexpected incoming message');
+            return;
+        }
+
+        request.on('aborted', () => {
+            this.logger.info(`Request ${request.url} aborted`);
+        });
+
+        const { pathname } = url.parse(request.url, true);
+
+        this.logger.info(`Handling request for ${pathname}`);
+
+        const route = this.routes.find(r => r.pathname === pathname && r.method === request.method);
+        if (!route) {
+            this.emitter.emit('server/error', `Route not found for ${pathname}`);
+            this.logger.warn(`Route not found for ${pathname}`);
+            return;
+        }
+
+        if (!route.handler.length) {
+            this.emitter.emit('server/error', `No handlers registered for route ${pathname}`);
+            this.logger.warn(`No handlers registered for route ${pathname}`);
+            return;
+        }
+
+        const handlers = [
+            ...this.routes
+                .filter(r => r.method === '*' && r.pathname === '*')
+                .flatMap(r => r.handler),
+            ...route.handler,
+        ];
+
+        const run = ([handler, ...rest]: Handler[]) => {
+            handler?.(request as Request, response, () => run(rest), { logger: this.logger });
+        };
+
+        run(handlers);
+    };
+}
+
+const checkOrigin = ({
+    request,
+    allowedOrigin,
+    pathname,
+    logger,
+}: {
+    request: Parameters<Handler>[0];
+    allowedOrigin?: string[];
+    pathname: string;
+    logger: Logger;
+}) => {
+    const { referer } = request.headers;
+    const origins = allowedOrigin ?? [];
+    let isOriginAllowed = false;
+    // Allow all origins
+    if (origins.includes('*')) {
+        isOriginAllowed = true;
+    }
+
+    // If referer is not defined, check if empty referers are allowed
+    else if (referer === undefined) {
+        isOriginAllowed = origins.includes('');
+    } else {
+        // Domain of referer has to be in the allowed origins for that endpoint
+        let domain: string;
+        try {
+            domain = new URL(referer).hostname;
+        } catch (err) {
+            logger.warn(`Invalid referer ${referer}`);
+            return false;
+        }
+
+        return (
+            origins.findIndex(origin => {
+                // Wildcard for subdomains
+                if (origin.startsWith('*')) {
+                    return domain.endsWith(origin.substring(1));
+                }
+
+                return origin.includes(domain);
+            }) > -1
+        );
+    }
+
+    if (!isOriginAllowed) {
+        logger.warn(`Origin rejected for ${pathname}`);
+        logger.warn(`- Received: '${referer}'`);
+        logger.warn(`- Allowed origins: ${origins.map(o => `'${o}'`).join(', ')}`);
+        return false;
+    }
+    return true;
+};
+
+/**
+ * Built-middleware "allow origin"
+ */
+export const allowOrigins =
+    (allowedOrigin?: string[]): Handler =>
+    (request, _response, next, { logger }) => {
+        if (
+            checkOrigin({
+                request,
+                allowedOrigin,
+                pathname: request.url,
+                logger,
+            })
+        ) {
+            next();
+        }
+    };

--- a/packages/node-utils/src/index.ts
+++ b/packages/node-utils/src/index.ts
@@ -1,2 +1,3 @@
 export { ensureDirectoryExists } from './ensureDirectoryExists';
 export { getFreePort } from './getFreePort';
+export { HttpServer, allowOrigins } from './http';

--- a/packages/node-utils/src/tests/http.test.ts
+++ b/packages/node-utils/src/tests/http.test.ts
@@ -1,0 +1,175 @@
+import { HttpServer, allowOrigins } from '../http';
+
+type Events = {
+    foo: (arg: string) => void;
+};
+
+const muteLogger = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+};
+
+describe('HttpServer', () => {
+    let server: HttpServer<Events>;
+    beforeEach(() => {
+        server = new HttpServer<Events>({
+            logger: muteLogger,
+        });
+    });
+
+    afterEach(done => {
+        server.stop().finally(() => {
+            done();
+        });
+    });
+
+    test('getServerAddress before server start', () => {
+        expect(() => server.getServerAddress()).toThrowError();
+    });
+
+    test('getServerAddress after server start', async () => {
+        await server.start();
+        expect(server.getServerAddress()).toMatchObject({
+            address: '127.0.0.1',
+            family: 'IPv4',
+            port: expect.any(Number),
+        });
+    });
+
+    test('getInfo', async () => {
+        await server.start();
+        expect(server.getInfo()).toMatchObject({
+            url: expect.any(String),
+        });
+    });
+
+    test('a port can be passed to the constructor', async () => {
+        server = new HttpServer<Events>({ logger: muteLogger, port: 65526 });
+        await server.start();
+        expect(server.getServerAddress()).toMatchObject({
+            port: 65526,
+        });
+    });
+
+    test('register a route and getRouterAddress', async () => {
+        const handler = jest.fn((_request, response, _next) => {
+            response.end('ok');
+        });
+        server.get('/foo', [handler]);
+        await server.start();
+        const address = server.getServerAddress();
+        expect(address).toBeDefined();
+        const res = await fetch(`http://${address.address}:${address.port}/foo`);
+        expect(res.status).toEqual(200);
+        expect(handler).toHaveBeenCalled();
+
+        expect(server.getRouteAddress('/foo')).toEqual(
+            `http://${address.address}:${address.port}/foo`,
+        );
+    });
+
+    test('set response headers in a custom middleware handler', async () => {
+        const middlewareHandler = jest.fn((_request, response, next) => {
+            response.setHeader('foo', 'bar');
+            next();
+        });
+        const handler = jest.fn((_request, response) => {
+            response.end('ok');
+        });
+        server.get('/foo', [middlewareHandler, handler]);
+        await server.start();
+        const address = server.getServerAddress();
+        expect(address).toBeDefined();
+        const res = await fetch(`http://${address.address}:${address.port}/foo`);
+        expect(res.headers.get('foo')).toEqual('bar');
+    });
+
+    test('calling endpoint which as no defined handler', async () => {
+        await server.start();
+        const address = server.getServerAddress();
+        expect(address).toBeDefined();
+
+        fetch(`http://${address.address}:${address.port}/foo`).catch(_err => {});
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        server.stop();
+
+        await new Promise<void>(resolve => {
+            server.on('server/closed', () => {
+                resolve();
+            });
+        });
+    });
+
+    test('aborting request', async () => {
+        const controller = new AbortController();
+        const { signal } = controller;
+        server.get('/foo', [
+            (_request, response) => {
+                setTimeout(() => response.end('ok'), 1000);
+            },
+        ]);
+        await server.start();
+
+        const address = server.getServerAddress();
+        expect(address).toBeDefined();
+        fetch(`http://${address.address}:${address.port}/foo`, { signal }).catch(_err => {});
+        await new Promise(resolve => setTimeout(resolve, 500));
+        controller.abort();
+        await new Promise(resolve => setTimeout(resolve, 500));
+        expect(muteLogger.info).toHaveBeenLastCalledWith(
+            expect.any(String),
+            'Request /foo aborted',
+        );
+    });
+
+    test('allowOrigin middleware lets request with allowed origin through', async () => {
+        const handler = jest.fn((_request, response) => {
+            response.end('ok');
+        });
+
+        server.get('/foo', [allowOrigins(['*']), allowOrigins(['*.meow.com']), handler]);
+
+        server.get('/foo-bar', [
+            // empty string is allowed origin when referer is not defined
+            allowOrigins(['']),
+            handler,
+        ]);
+        await server.start();
+
+        const address = server.getServerAddress();
+        expect(address).toBeDefined();
+        const res1 = await fetch(`http://${address.address}:${address.port}/foo`, {
+            headers: {
+                referer: 'http://sub.meow.com',
+            },
+        });
+
+        const res2 = await fetch(`http://${address.address}:${address.port}/foo-bar`);
+
+        expect(res1.status).toEqual(200);
+        expect(res2.status).toEqual(200);
+    });
+
+    test('handler order', async () => {
+        const calledHandlers: string[] = [];
+        const handler = (name: string, end?: boolean) => (_: any, res: any, next: () => void) => {
+            calledHandlers.push(name);
+            if (end) res.end('ok');
+            else next();
+        };
+
+        server.use([handler('use1'), handler('use2')]);
+        server.post('/foo', [handler('post1', true)]);
+        server.get('/foo', [handler('get1', true)]);
+
+        await server.start();
+        const { address, port } = server.getServerAddress();
+
+        await fetch(`http://${address}:${port}/foo`);
+
+        expect(calledHandlers).toStrictEqual(['use1', 'use2', 'get1']);
+    });
+});

--- a/packages/node-utils/tsconfig.json
+++ b/packages/node-utils/tsconfig.json
@@ -5,5 +5,8 @@
         "outDir": "libDev"
     },
     "include": ["."],
-    "references": []
+    "references": [
+        { "path": "../type-utils" },
+        { "path": "../utils" }
+    ]
 }

--- a/packages/suite-desktop-core/src/__tests__/http.test.ts
+++ b/packages/suite-desktop-core/src/__tests__/http.test.ts
@@ -1,6 +1,6 @@
 import fetch from 'cross-fetch';
 
-import { HttpReceiver } from '../libs/http-receiver';
+import { createHttpReceiver } from '../libs/http-receiver';
 import { fixtures } from '../__fixtures__/http';
 import { Logger } from '../libs/logger';
 
@@ -8,7 +8,7 @@ global.logger = new Logger('mute');
 
 describe('http receiver', () => {
     it('start should emit started event', async () => {
-        const receiver = new HttpReceiver();
+        const receiver = createHttpReceiver();
 
         const spy = jest.spyOn(receiver, 'emit');
         await receiver.start();
@@ -22,7 +22,7 @@ describe('http receiver', () => {
 
     fixtures.forEach(f => {
         it(`${f.method}: ${f.path}`, async () => {
-            const receiver = new HttpReceiver();
+            const receiver = createHttpReceiver();
             const spy = jest.spyOn(receiver, 'emit');
 
             await receiver.start();

--- a/packages/suite-desktop-core/src/libs/http-receiver.ts
+++ b/packages/suite-desktop-core/src/libs/http-receiver.ts
@@ -1,14 +1,9 @@
-import * as http from 'http';
-import * as net from 'net';
 import * as url from 'url';
 
-import type { RequiredKey } from '@trezor/type-utils';
 import { xssFilters } from '@trezor/utils';
-import { TypedEmitter } from '@trezor/utils/lib/typedEventEmitter';
+import { HttpServer, allowOrigins } from '@trezor/node-utils';
 
 import { HTTP_ORIGINS_DEFAULT } from './constants';
-
-type Request = RequiredKey<http.IncomingMessage, 'url'>;
 
 type TemplateOptions = {
     title?: string;
@@ -18,8 +13,6 @@ type TemplateOptions = {
  * Events that may be emitted or listened to by HttpReceiver
  */
 interface Events {
-    'server/listening': (address: NonNullable<net.AddressInfo>) => void;
-    'server/error': (error: string) => void;
     'oauth/response': (response: { [key: string]: string }) => void;
     'oauth/error': (message: string) => void;
     'buy/redirect': (url: string) => void;
@@ -27,334 +20,75 @@ interface Events {
     'spend/message': (event: Partial<MessageEvent>) => void;
 }
 
-/**
- * Http server listening on localhost.
- */
-export class HttpReceiver extends TypedEmitter<Events> {
-    server: http.Server;
-    routes: {
-        pathname: string;
-        handler: (request: Request, response: http.ServerResponse) => void;
-        origins?: string[];
-    }[];
-    private logger: ILogger;
+const applyTemplate = (content: string, options?: TemplateOptions) => {
+    const template = `
+        <!DOCTYPE html>
+        <html>
+            <head>
+                <title>${options?.title ?? 'Trezor Suite'}</title>
+                ${options?.script || ''}
+            </head>
+            <body>
+                ${content}
+            </body>
+        </html>
+    `;
 
-    // Possible ports
-    // We need to be specific here (cant let OS automatically assign a port) because there are exact redirect uris registered within oauth providers
-    // todo: add more to prevent case when port is blocked
-    static PORTS = [21335];
+    return template;
+};
 
-    constructor() {
-        super();
+export const createHttpReceiver = () => {
+    const httpReceiver = new HttpServer<Events>({ logger: global.logger, port: 21335 });
 
-        this.routes = [
-            {
-                pathname: '/oauth',
-                handler: this.oauthHandler,
-                origins: ['', '127.0.0.1', 'www.dropbox.com'], // No referer is sent by Google, Dropbox sends referer when using Safari
-            },
-            {
-                pathname: '/buy-redirect',
-                handler: this.buyHandler,
-                origins: ['', 'localhost:3000', '*.invity.io', 'invity.io'],
-            },
-            {
-                pathname: '/buy-post',
-                handler: this.buyPostSubmitHandler,
-                origins: [''], // No referer
-            },
-            {
-                pathname: '/sell-redirect',
-                handler: this.sellHandler,
-                origins: [''], // No referer
-            },
-            {
-                pathname: '/spend-iframe',
-                handler: this.spendIframeHandler,
-                origins: [''], // Opened in a new tab, no referer
-            },
-            {
-                pathname: '/spend-handle-message',
-                handler: this.spendHandleMessage,
-                // Default referers
-            },
-            /**
-             * Register more routes here. Each route must have pathname and handler function.
-             */
-        ];
-        this.server = http.createServer(this.onRequest);
-        this.logger = global.logger;
-    }
+    httpReceiver.use([
+        (_request, response, next) => {
+            response.setHeader('Content-Type', 'text/html; charset=UTF-8');
+            next();
+        },
+    ]);
 
-    getServerAddress() {
-        const address = this.server.address();
-        if (!address || typeof address === 'string') {
-            // this is only for typescript
-            // net.AddressInfo may also be string for a server listening on a pipe or Unix domain socket, the name is returned as a string.
-            throw new Error(`Unexpected server address: ${address}`);
-        }
+    httpReceiver.get('/oauth', [
+        allowOrigins(['', '127.0.0.1', 'www.dropbox.com']), // No referer is sent by Google, Dropbox sends referer when using Safari
+        (request, response) => {
+            const { search } = url.parse(request.url, true);
+            if (search) {
+                // send data back to main window
+                httpReceiver.emit('oauth/response', { search });
+            }
 
-        return address;
-    }
+            // replace # with ? so that query parameters can be read by renderer
+            const script = `
+                <script>
+                    if (window.location.href.includes('#')) {
+                        fetch(window.location.href.replace('#', '?'))
+                    }
+                </script>
+            `;
+            const template = applyTemplate('You may now close this window.', { script });
+            response.end(template);
+        },
+    ]);
 
-    getRouteAddress(pathname: string) {
-        const address = this.getServerAddress();
-        const route = this.routes.find(r => r.pathname === pathname);
-        if (!route) return;
-        return `http://${address.address}:${address.port}${route.pathname}`;
-    }
+    httpReceiver.get('/buy-redirect', [
+        allowOrigins(['', 'localhost:3000', '*.invity.io', 'invity.io']),
+        (request, response) => {
+            const { query } = url.parse(request.url, true);
+            if (query && query.p) {
+                httpReceiver.emit('buy/redirect', query.p.toString());
+            }
 
-    getInfo() {
-        const address = this.getServerAddress();
-        return {
-            url: `http://${address.address}:${address.port}`,
-        };
-    }
+            const template = applyTemplate('You may now close this window.');
+            response.end(template);
+        },
+    ]);
 
-    start() {
-        return new Promise((resolve, reject) => {
-            const port = HttpReceiver.PORTS[0];
-            this.server.on('error', e => {
-                this.server.close();
-                // @ts-expect-error - type is missing
-                const errorCode: string = e.code;
-
-                const errorMessage =
-                    errorCode === 'EADDRINUSE'
-                        ? `Port ${port} already in use!` // TODO: Try different port?
-                        : `Start error code: ${errorCode}`;
-
-                this.logger.error('http-receiver', errorMessage);
-                return reject(new Error(`http-receiver: ${errorMessage}`));
-            });
-            this.server.listen(port, '127.0.0.1', undefined, () => {
-                this.logger.info('http-receiver', 'Server started');
-                const address = this.getServerAddress();
-                if (address) {
-                    this.emit('server/listening', address);
-                }
-                return resolve(address);
-            });
-        });
-    }
-
-    stop() {
-        // note that this method only stops listening but keeps existing connections open and thus port blocked
-        this.server.close(() => {
-            this.logger.info('http-receiver', 'Server stopped');
-        });
-        this.removeAllListeners();
-    }
-
-    /**
-     * Entry point for handling requests
-     */
-    private onRequest = (request: http.IncomingMessage, response: http.ServerResponse) => {
-        // mostly ts stuff. request should always have url defined.
-        if (!request.url) {
-            this.logger.warn('http-receiver', 'Unexpected incoming message (no url)');
-            this.emit('server/error', 'Unexpected incoming message');
-            return;
-        }
-
-        // only method GET is supported
-        if (request.method !== 'GET') {
-            this.logger.warn('http-receiver', `Incorrect method used (${request.method})`);
-            return;
-        }
-
-        const { pathname } = url.parse(request.url, true);
-        const route = this.routes.find(r => r.pathname === pathname);
-        if (!route) {
-            this.logger.warn('http-receiver', `Route not found for ${pathname}`);
-            return;
-        }
-
-        const { referer } = request.headers;
-        const origins = route.origins ?? HTTP_ORIGINS_DEFAULT;
-        if (!this.isOriginAllowed(origins, referer)) {
-            this.logger.warn('http-receiver', `Origin rejected for ${pathname}`);
-            this.logger.warn('http-receiver', `- Received: '${referer}'`);
-            this.logger.warn(
-                'http-receiver',
-                `- Allowed origins: ${origins.map(o => `'${o}'`).join(', ')}`,
-            );
-            return;
-        }
-
-        this.logger.info('http-receiver', `Handling request for ${pathname}`);
-
-        response.setHeader('Content-Type', 'text/html; charset=UTF-8');
-        // original type has url as optional, Request alias makes it required.
-        return route.handler(request as Request, response);
-    };
-
-    private isOriginAllowed = (origins: string[], referer?: string) => {
-        // Allow all origins
-        if (origins.includes('*')) {
-            return true;
-        }
-
-        // If referer is not defined, check if empty referers are allowed
-        if (referer === undefined) {
-            return origins.includes('');
-        }
-
-        // Domain of referer has to be in the allowed origins for that endpoint
-        const domain = new URL(referer).hostname;
-        return (
-            origins.findIndex(origin => {
-                // Wildcard for subdomains
-                if (origin.startsWith('*')) {
-                    return domain.endsWith(origin.substring(1));
-                }
-
-                return origin.includes(domain);
-            }) > -1
-        );
-    };
-
-    // TODO: add option to auto-close after X seconds. Possible?
-    private applyTemplate = (content: string, options?: TemplateOptions) => {
-        const template = `
-            <!DOCTYPE html>
-            <html>
-                <head>
-                    <title>${options?.title ?? 'Trezor Suite'}</title>
-                    ${options?.script || ''}
-                </head>
-                <body>
-                    ${content}
-                </body>
-            </html>
-        `;
-
-        return template;
-    };
-
-    /**
-     * Handlers sections starts here
-     */
-
-    private oauthHandler = (request: Request, response: http.ServerResponse) => {
-        const { search } = url.parse(request.url, true);
-        if (search) {
-            // send data back to main window
-            this.emit('oauth/response', { search });
-        }
-
-        // replace # with ? so that query parameters can be read by renderer
-        const script = `
-            <script>
-                if (window.location.href.includes('#')) {
-                    fetch(window.location.href.replace('#', '?'))
-                }
-            </script>
-        `;
-        const template = this.applyTemplate('You may now close this window.', { script });
-        response.end(template);
-    };
-
-    private buyHandler = (request: Request, response: http.ServerResponse) => {
-        const { query } = url.parse(request.url, true);
-        if (query && query.p) {
-            this.emit('buy/redirect', query.p.toString());
-        }
-
-        const template = this.applyTemplate('You may now close this window.');
-        response.end(template);
-    };
-
-    private sellHandler = (request: Request, response: http.ServerResponse) => {
-        const { query } = url.parse(request.url, true);
-        if (query && query.p) {
-            this.emit('sell/redirect', query.p.toString());
-        }
-
-        const template = this.applyTemplate('You may now close this window.');
-        response.end(template);
-    };
-
-    private spendIframeHandler = (_request: Request, response: http.ServerResponse) => {
-        const regex = /^https:\/\/(.+\.|)bitrefill\.com$/;
-        const template = `<!DOCTYPE html>
-                <head>
-                    <style>
-                        body, html {
-                            width: 100%;
-                            height: 100%;
-                            margin: 0;
-                            padding: 0;
-                            display: flex;
-                            justify-content: center;
-                            font-family: sans-serif;
-                            display: flex;
-                            flex-direction: column;
-                            justify-content: center;
-                            align-items: center;
-                        }
-                        .title {
-                            font-size: 12pt;
-                            color: #888;
-                            margin: 20px;
-                        }
-                        iframe {
-                            border: 1px #888 solid;
-                            width: 95%;
-                            height: 100%;
-                            display: block;
-                        }
-                    </style>
-                </head>
-                <body>
-                    <div class="title">Content of this page is provided by our partner</div>
-                    <iframe
-                        id="iframe"
-                        title="."
-                        sandbox="allow-scripts allow-forms allow-same-origin"
-                        src=""
-                    ></iframe>
-                    <script>
-                        function eventHandler(event, handleMessageEndpoint) {
-                            var req = new XMLHttpRequest();
-                            req.open("GET", handleMessageEndpoint + '?data=' + encodeURIComponent(event.data) + '&origin=' + event.origin);
-                            req.send();
-                        }
-                        const urlParams = new URLSearchParams(window.location.search);
-                        const iframe = document.getElementById('iframe');
-                        const iframeSrc = urlParams.get('voucherSiteUrl');
-                        const iframeUrl = new URL(urlParams.get('voucherSiteUrl'));
-                        const origin = iframeUrl.origin;
-                        const regex = ${regex};
-                        if(regex.test(origin)) {
-                            const handleMessageEndpoint = urlParams.get('handleMessageEndpoint');
-                            iframe.src = decodeURIComponent(iframeSrc);
-                            window.addEventListener('message', function(event) {
-                                eventHandler(event, handleMessageEndpoint);
-                            });
-                        }
-                    </script>
-                </body>
-            </html>`;
-        response.end(template);
-    };
-
-    private spendHandleMessage = (request: Request, response: http.ServerResponse) => {
-        const { query } = url.parse(request.url, true);
-        this.emit('spend/message', {
-            origin: Array.isArray(query.origin) ? query.origin.join(',') : query.origin,
-            data: Array.isArray(query.data) ? query.data.join(',') : query.data,
-        });
-
-        const template = this.applyTemplate('You may now close this window.');
-        response.end(template);
-    };
-
-    private buyPostSubmitHandler = (request: Request, response: http.ServerResponse) => {
-        try {
-            const { searchParams } = new URL(request.url, 'http://127.0.0.1:21335'); // hostname is not important here, just to be able to validate relative URL
-            const action = new URL(searchParams.get('a') || '').href; // action has to be a valid URL, otherwise throw an error
-            const content = `
+    httpReceiver.get('/buy-post', [
+        allowOrigins(['']), // No referer
+        (request, response) => {
+            try {
+                const { searchParams } = new URL(request.url, 'http://127.0.0.1:21335'); // hostname is not important here, just to be able to validate relative URL
+                const action = new URL(searchParams.get('a') || '').href; // action has to be a valid URL, otherwise throw an error
+                const content = `
             Forwarding to ${xssFilters.inHTML(action)}...
             <form id="buy-form" method="POST" action="${xssFilters.inDoubleQuotes(action)}">
             ${Array.from(searchParams)
@@ -370,16 +104,109 @@ export class HttpReceiver extends TypedEmitter<Events> {
             <script type="text/javascript">document.getElementById("buy-form").submit();</script>
         `;
 
-            const template = this.applyTemplate(content);
-            response.end(template);
-        } catch (error) {
-            const template = this.applyTemplate('Error');
-            response.end(template);
-            throw new Error(`Could not handle buy post request: ${error}`);
-        }
-    };
+                const template = applyTemplate(content);
+                response.end(template);
+            } catch (error) {
+                const template = applyTemplate('Error');
+                response.end(template);
+                throw new Error(`Could not handle buy post request: ${error}`);
+            }
+        },
+    ]);
 
-    /**
-     * Add your own handlers here
-     */
-}
+    httpReceiver.get('/sell-redirect', [
+        allowOrigins(['']), // No referer
+        (request, response) => {
+            const { query } = url.parse(request.url, true);
+            if (query && query.p) {
+                httpReceiver.emit('sell/redirect', query.p.toString());
+            }
+
+            const template = applyTemplate('You may now close this window.');
+            response.end(template);
+        },
+    ]);
+
+    httpReceiver.get('/spend-iframe', [
+        allowOrigins(['']), // Opened in a new tab, no referer
+        (_request, response) => {
+            const regex = /^https:\/\/(.+\.|)bitrefill\.com$/;
+            const template = `<!DOCTYPE html>
+                    <head>
+                        <style>
+                            body, html {
+                                width: 100%;
+                                height: 100%;
+                                margin: 0;
+                                padding: 0;
+                                display: flex;
+                                justify-content: center;
+                                font-family: sans-serif;
+                                display: flex;
+                                flex-direction: column;
+                                justify-content: center;
+                                align-items: center;
+                            }
+                            .title {
+                                font-size: 12pt;
+                                color: #888;
+                                margin: 20px;
+                            }
+                            iframe {
+                                border: 1px #888 solid;
+                                width: 95%;
+                                height: 100%;
+                                display: block;
+                            }
+                        </style>
+                    </head>
+                    <body>
+                        <div class="title">Content of this page is provided by our partner</div>
+                        <iframe
+                            id="iframe"
+                            title="."
+                            sandbox="allow-scripts allow-forms allow-same-origin"
+                            src=""
+                        ></iframe>
+                        <script>
+                            function eventHandler(event, handleMessageEndpoint) {
+                                var req = new XMLHttpRequest();
+                                req.open("GET", handleMessageEndpoint + '?data=' + encodeURIComponent(event.data) + '&origin=' + event.origin);
+                                req.send();
+                            }
+                            const urlParams = new URLSearchParams(window.location.search);
+                            const iframe = document.getElementById('iframe');
+                            const iframeSrc = urlParams.get('voucherSiteUrl');
+                            const iframeUrl = new URL(urlParams.get('voucherSiteUrl'));
+                            const origin = iframeUrl.origin;
+                            const regex = ${regex};
+                            if(regex.test(origin)) {
+                                const handleMessageEndpoint = urlParams.get('handleMessageEndpoint');
+                                iframe.src = decodeURIComponent(iframeSrc);
+                                window.addEventListener('message', function(event) {
+                                    eventHandler(event, handleMessageEndpoint);
+                                });
+                            }
+                        </script>
+                    </body>
+                </html>`;
+            response.end(template);
+        },
+    ]);
+
+    httpReceiver.get('/spend-handle-message', [
+        allowOrigins(HTTP_ORIGINS_DEFAULT),
+        (request, response) => {
+            const { query } = url.parse(request.url, true);
+            httpReceiver.emit('spend/message', {
+                origin: Array.isArray(query.origin) ? query.origin.join(',') : query.origin,
+                data: Array.isArray(query.data) ? query.data.join(',') : query.data,
+            });
+
+            const template = applyTemplate('You may now close this window.');
+            response.end(template);
+        },
+    ]);
+
+    return httpReceiver;
+};

--- a/packages/suite-desktop-core/src/modules/http-receiver.ts
+++ b/packages/suite-desktop-core/src/modules/http-receiver.ts
@@ -2,7 +2,7 @@
  * Local web server for handling requests to app
  */
 import { app, ipcMain } from '../typed-electron';
-import { HttpReceiver } from '../libs/http-receiver';
+import { createHttpReceiver } from '../libs/http-receiver';
 
 import type { Module } from './index';
 
@@ -10,13 +10,13 @@ export const SERVICE_NAME = 'http-receiver';
 
 export const init: Module = ({ mainWindow }) => {
     const { logger } = global;
-    let httpReceiver: HttpReceiver | null = null;
+    let httpReceiver: ReturnType<typeof createHttpReceiver> | null = null;
     return async () => {
         if (httpReceiver) {
             return httpReceiver.getInfo();
         }
         // External request handler
-        const receiver = new HttpReceiver();
+        const receiver = createHttpReceiver();
         httpReceiver = receiver;
 
         // wait for httpReceiver to start accepting connections then register event handlers

--- a/yarn.lock
+++ b/yarn.lock
@@ -8891,6 +8891,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/node-utils@workspace:packages/node-utils"
   dependencies:
+    "@trezor/type-utils": "workspace:*"
+    "@trezor/utils": "workspace:*"
     jest: "npm:29.5.0"
     typescript: "npm:5.3.2"
   languageName: unknown


### PR DESCRIPTION
having discussed this topic with @marekrjpolak we have arrived at conclusion that we probably don't want to include `express` server into suite-desktop-core bundle (added in #9985)

so here I drafted a http server module in `@trezor/node-utils` that could be used for both node-bridge and http-receiver. 

## QA 
- please test invity features, ideally make sure that all endpoints work: `/buy-redirect`, `/buy-post`, `/sell-redirect`, `/spend-iframe`and `/spend-handle-message`.

resolves #10859