### PR TITLE
fix(suite): fetch fiat rates only for erc-20 tokens with definitions

### DIFF
--- a/suite-common/fiat-services/package.json
+++ b/suite-common/fiat-services/package.json
@@ -12,6 +12,7 @@
     },
     "dependencies": {
         "@suite-common/suite-config": "workspace:*",
+        "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/utils": "workspace:*",

--- a/suite-common/fiat-services/tsconfig.json
+++ b/suite-common/fiat-services/tsconfig.json
@@ -3,6 +3,7 @@
     "compilerOptions": { "outDir": "libDev" },
     "references": [
         { "path": "../suite-config" },
+        { "path": "../wallet-config" },
         { "path": "../wallet-types" },
         { "path": "../../packages/connect" },
         { "path": "../../packages/utils" }

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -563,3 +563,7 @@ export const getEthereumTypeNetworkSymbols = () =>
 export const getTestnetSymbols = () => getTestnets().map(n => n.symbol);
 
 export const getNetworkType = (symbol: NetworkSymbol) => networks[symbol]?.networkType;
+
+export const getEthereumChainId = (symbol: NetworkSymbol) =>
+    networksCompatibility.filter(n => n.networkType === 'ethereum').find(n => n.symbol === symbol)
+        ?.chainId;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6659,6 +6659,7 @@ __metadata:
   resolution: "@suite-common/fiat-services@workspace:suite-common/fiat-services"
   dependencies:
     "@suite-common/suite-config": "workspace:*"
+    "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/utils": "workspace:*"


### PR DESCRIPTION
## Description

Try to fetch fiat rate only for erc-20 tokens with definitions. From my testing on `allall` it works 99% of time because for example [this token](https://eth1.trezor.io/address/0xa74476443119A942dE498590Fe1f2454d7D4aC0d) has definitions but doesn't have rates on Coingecko.
