### PR TITLE
fix(connect): rebootToBootloader misbehaviour

### DIFF
--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -648,17 +648,16 @@ export const onCall = async (message: CoreMessage) => {
         const response = messageResponse;
 
         if (response) {
-            if (method.name === 'rebootToBootloader' && response.success) {
-                // Wait for device to switch to bootloader
-                // This delay is crucial see https://github.com/trezor/trezor-firmware/issues/1983
+            // Wait for device to switch to bootloader
+            // This delay is crucial see https://github.com/trezor/trezor-firmware/issues/1983
+            if (method.device.isT1() && method.name === 'rebootToBootloader' && response.success) {
                 await resolveAfter(1000).promise;
                 // call Device.run with empty function to fetch new Features
                 // (acquire > Initialize > nothing > release)
                 try {
                     await device.run(() => Promise.resolve(), { skipFinalReload: true });
                 } catch (err) {
-                    // ignore. on model T, this block of code is probably not needed at all. but I am keeping it here for
-                    // backwards compatibility
+                    // empty
                 }
             }
 

--- a/packages/suite/src/hooks/firmware/useRebootRequest.ts
+++ b/packages/suite/src/hooks/firmware/useRebootRequest.ts
@@ -8,7 +8,6 @@ import { getFirmwareVersion } from '@trezor/device-utils';
 import type { TrezorDevice } from 'src/types/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { SUITE } from 'src/actions/suite/constants';
-import { isWebUsb } from 'src/utils/suite/transport';
 
 export type RebootRequestedMode = 'bootloader' | 'normal';
 export type RebootPhase = 'initial' | 'wait-for-confirm' | 'disconnected' | 'done';
@@ -24,16 +23,11 @@ export const useRebootRequest = (
 ): RebootRequest => {
     const [phase, setPhase] = useState<RebootPhase>('initial');
 
-    const transport = useSelector(state => state.suite.transport);
-
-    const isWebUsbTransport = isWebUsb(transport);
-
     // Default reboot method is 'manual'. If the device is connected when
     // the hook is first called and fw version is sufficient,
     // then the 'automatic' method is enabled.
-    // Automatic reboot to bootloader not working properly with WebUSB so it's disabled for now.
     const [method, setMethod] = useState<RebootMethod>(() => {
-        if (!device?.connected || !device?.features || isWebUsbTransport) return 'manual';
+        if (!device?.connected || !device?.features) return 'manual';
 
         const deviceFwVersion = getFirmwareVersion(device);
 


### PR DESCRIPTION
This should re-enable automatic reboot to bootloader feature when using webusb.

Couple of testing tips:
- only webusb got enabled by this PR, no other changes, bridge should the same.
- test both firmares (1, 2)
- test both transports (bridge, webusb) just to be sure
- try to test reboot to bootloader feature couple of times to rule out possible race conditions.

Other notes:
- please lets test this before merging this PR
- not sure, is there an issue to be linked here?

@MiroslavProchazka @Hannsek 