### PR TITLE
Feat: connect-webextension proxy for connect explorer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,9 @@ packages/suite-data/files/browser-detection
 packages/suite-data/files/guide
 packages/suite-data/files/translations/master.json
 
+# @trezor/connect-explorer
+packages/connect-explorer/build-webextension
+
 # cypress download folder
 
 packages/suite-web/e2e/downloads

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -254,6 +254,8 @@ suite-desktop build windows codesign:
     # build webextension example using @trezor/connect-webextension package
     - yarn workspace @trezor/connect-webextension build
     - node ./packages/connect-examples/update-webextensions-sw.js
+    # build webextension inside package @trezor/connect-explorer package
+    - yarn workspace @trezor/connect-explorer build:webextension
 
   artifacts:
     expire_in: 14 days
@@ -267,6 +269,7 @@ suite-desktop build windows codesign:
       - packages/connect-examples/webextension-mv3/build-legacy
       - packages/connect-examples/webextension-mv3-sw/build
       - packages/connect-explorer-webextension/build
+      - packages/connect-explorer/build-webextension
 
 connect-explorer build:
   extends: .connect-explorer build base

--- a/packages/connect-explorer/package.json
+++ b/packages/connect-explorer/package.json
@@ -5,6 +5,7 @@
     "scripts": {
         "dev": "rimraf build && TS_NODE_PROJECT=\"tsconfig.json\" NODE_ENV=development yarn webpack --config ./webpack/dev.webpack.config.ts",
         "build": "rimraf build && TS_NODE_PROJECT=\"tsconfig.json\" yarn webpack --config ./webpack/prod.webpack.config.ts",
+        "build:webextension": "rimraf build-webextension && TS_NODE_PROJECT=\"tsconfig.json\" yarn webpack --config ./webpack/webextension.webpack.config.ts",
         "lint:js": "yarn g:eslint '**/*{.ts,.tsx}'",
         "lint:styles": "npx stylelint './src/**/*{.ts,.tsx}' --cache --config ../../.stylelintrc",
         "type-check": "tsc --build tsconfig.json"
@@ -12,7 +13,9 @@
     "dependencies": {
         "@trezor/components": "workspace:*",
         "@trezor/connect-web": "workspace:*",
+        "@trezor/connect-webextension": "workspace:^",
         "@trezor/protobuf": "workspace:*",
+        "@trezor/utils": "workspace:^",
         "copy-webpack-plugin": "^11.0.0",
         "markdown-it": "^13.0.2",
         "markdown-it-imsize": "^2.0.1",

--- a/packages/connect-explorer/src-webextension/README.md
+++ b/packages/connect-explorer/src-webextension/README.md
@@ -1,3 +1,9 @@
+# Connect explorer in a webextension
+
+This packages aims to use connect-explorer in the context of a webextension in order to reuse the tests we have to test all the connect features in different contexts. It also serves as example for third party implementers of TrezorConnect in webextension.
+
+## Development
+
 Run it for dev:
 
 ```

--- a/packages/connect-explorer/src-webextension/README.md
+++ b/packages/connect-explorer/src-webextension/README.md
@@ -1,0 +1,10 @@
+Run it for dev:
+
+```
+yarn && \
+yarn build:libs && \
+yarn workspace @trezor/connect-webextension build && \
+yarn workspace @trezor/connect-iframe build:core-module && \
+yarn workspace @trezor/connect-explorer build:webextension && \
+yarn workspace @trezor/connect-popup dev
+```

--- a/packages/connect-explorer/src-webextension/background/serviceWorker.ts
+++ b/packages/connect-explorer/src-webextension/background/serviceWorker.ts
@@ -1,0 +1,2 @@
+// Import TrezorConnect.
+importScripts('vendor/trezor-connect-webextension.js');

--- a/packages/connect-explorer/src-webextension/manifest.json
+++ b/packages/connect-explorer/src-webextension/manifest.json
@@ -1,0 +1,13 @@
+{
+    "name": "@trezor/connect-explorer",
+    "version": "1.0.0",
+    "manifest_version": 3,
+    "action": {
+        "default_popup": "extension-popup.html"
+    },
+    "background": {
+        "service_worker": "serviceWorker.bundle.js"
+    },
+    "permissions": ["scripting"],
+    "host_permissions": ["http://*/*", "https://*/*"]
+}

--- a/packages/connect-explorer/src-webextension/pages/connect-explorer/index.html
+++ b/packages/connect-explorer/src-webextension/pages/connect-explorer/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Connect Explorer</title>
+    </head>
+
+    <body>
+        <div id="connect-explorer-container"></div>
+    </body>
+</html>

--- a/packages/connect-explorer/src-webextension/pages/connect-explorer/index.tsx
+++ b/packages/connect-explorer/src-webextension/pages/connect-explorer/index.tsx
@@ -1,0 +1,7 @@
+import { createRoot } from 'react-dom/client';
+
+import App from '../../../src/router';
+
+const container = document.getElementById('connect-explorer-container');
+const root = createRoot(container!);
+root.render(<App />);

--- a/packages/connect-explorer/src-webextension/pages/extension-popup/ExtensionPopup.tsx
+++ b/packages/connect-explorer/src-webextension/pages/extension-popup/ExtensionPopup.tsx
@@ -1,0 +1,15 @@
+export const ExtensionPopup = () => {
+    const openExplorerTab = () => {
+        chrome.tabs.create({ url: 'connect-explorer.html#/settings' });
+    };
+
+    return (
+        <div className="App">
+            <p>Welcome to Trezor Connect Explorer extension!</p>
+
+            <button type="button" onClick={openExplorerTab}>
+                Open Connect Explorer
+            </button>
+        </div>
+    );
+};

--- a/packages/connect-explorer/src-webextension/pages/extension-popup/index.html
+++ b/packages/connect-explorer/src-webextension/pages/extension-popup/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Popup</title>
+    </head>
+
+    <body>
+        <div id="extension-popup-container"></div>
+    </body>
+</html>

--- a/packages/connect-explorer/src-webextension/pages/extension-popup/index.tsx
+++ b/packages/connect-explorer/src-webextension/pages/extension-popup/index.tsx
@@ -1,0 +1,7 @@
+import { createRoot } from 'react-dom/client';
+
+import { ExtensionPopup } from './ExtensionPopup';
+
+const container = document.getElementById('extension-popup-container');
+const root = createRoot(container!);
+root.render(<ExtensionPopup />);

--- a/packages/connect-explorer/tsconfig.json
+++ b/packages/connect-explorer/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "../../tsconfig.json",
     "compilerOptions": {
+        "types": ["chrome"],
         "noImplicitAny": false,
         "outDir": "./libDev"
     },
@@ -12,7 +13,9 @@
     "references": [
         { "path": "../components" },
         { "path": "../connect-web" },
-        { "path": "../protobuf" }
+        { "path": "../connect-webextension" },
+        { "path": "../protobuf" },
+        { "path": "../utils" }
     ],
     "ts-node": {
         "compilerOptions": {

--- a/packages/connect-explorer/webpack/webextension.webpack.config.ts
+++ b/packages/connect-explorer/webpack/webextension.webpack.config.ts
@@ -1,0 +1,178 @@
+import path from 'path';
+import webpack from 'webpack';
+import HtmlWebpackPlugin from 'html-webpack-plugin';
+import CopyPlugin from 'copy-webpack-plugin';
+import { execSync } from 'child_process';
+
+const commitHash = execSync('git rev-parse HEAD').toString().trim();
+
+const DIST = path.resolve(__dirname, '../build-webextension');
+const CONNECT_WEB_PATH = path.join(__dirname, '..', '..', 'connect-web');
+
+const CONNECT_WEB_EXTENSION_PATH = path.join(CONNECT_WEB_PATH, 'src', 'webextension');
+
+const CONNECT_WEB_EXTENSION_PACKAGE_PATH = path.join(
+    __dirname,
+    '..',
+    '..',
+    'connect-webextension',
+    'build',
+);
+
+const config: webpack.Configuration = {
+    target: 'web',
+    mode: 'production',
+    entry: {
+        extensionPopup: path.join(
+            __dirname,
+            '..',
+            'src-webextension',
+            'pages',
+            'extension-popup',
+            'index.tsx',
+        ),
+        connectExplorer: path.join(
+            __dirname,
+            '..',
+            'src-webextension',
+            'pages',
+            'connect-explorer',
+            'index.tsx',
+        ),
+        serviceWorker: path.join(
+            __dirname,
+            '..',
+            'src-webextension',
+            'background',
+            'serviceWorker.ts',
+        ),
+    },
+    output: {
+        filename: '[name].bundle.js',
+        path: DIST,
+        publicPath: './',
+    },
+    module: {
+        rules: [
+            {
+                test: /\.(j|t)sx?$/,
+                exclude: /node_modules/,
+                use: {
+                    loader: 'babel-loader',
+                    options: {
+                        cacheDirectory: true,
+                        presets: [
+                            [
+                                '@babel/preset-react',
+                                {
+                                    runtime: 'automatic',
+                                },
+                            ],
+                            '@babel/preset-typescript',
+                        ],
+                        plugins: [
+                            '@babel/plugin-proposal-class-properties',
+                            [
+                                'babel-plugin-styled-components',
+                                {
+                                    displayName: true,
+                                    preprocess: true,
+                                },
+                            ],
+                        ],
+                    },
+                },
+            },
+            {
+                test: /\.(gif|jpe?g|png|svg)$/,
+                type: 'asset/resource',
+                generator: {
+                    filename: './images/[name][contenthash][ext]',
+                },
+            },
+        ],
+    },
+    resolve: {
+        extensions: ['.ts', '.tsx', '.js', '.jsx'],
+        modules: ['node_modules'],
+        mainFields: ['browser', 'module', 'main'],
+        fallback: {
+            fs: false, // ignore "fs" import in markdown-it-imsize
+            path: false, // ignore "path" import in markdown-it-imsize
+        },
+    },
+    performance: {
+        hints: false,
+    },
+    plugins: [
+        new HtmlWebpackPlugin({
+            chunks: ['extensionPopup'],
+            filename: 'extension-popup.html',
+            template: path.join(
+                __dirname,
+                '..',
+                'src-webextension',
+                'pages',
+                'extension-popup',
+                'index.html',
+            ),
+            inject: true,
+            minify: false,
+        }),
+        new HtmlWebpackPlugin({
+            chunks: ['connectExplorer'],
+            filename: 'connect-explorer.html',
+            template: path.join(
+                __dirname,
+                '..',
+                'src-webextension',
+                'pages',
+                'connect-explorer',
+                'index.html',
+            ),
+            inject: true,
+            minify: false,
+        }),
+        new CopyPlugin({
+            patterns: [
+                {
+                    from: path.join(__dirname, '..', 'src-webextension', 'manifest.json'),
+                    to: `${DIST}/`,
+                },
+            ],
+        }),
+        new CopyPlugin({
+            patterns: [
+                {
+                    from: path.join(
+                        CONNECT_WEB_EXTENSION_PACKAGE_PATH,
+                        'trezor-connect-webextension.js',
+                    ),
+                    to: `${DIST}/vendor`,
+                    info: { minimized: false },
+                },
+                {
+                    from: path.join(CONNECT_WEB_EXTENSION_PATH, 'trezor-usb-permissions.js'),
+                    to: `${DIST}/vendor`,
+                },
+                {
+                    from: path.join(CONNECT_WEB_EXTENSION_PATH, 'trezor-usb-permissions.html'),
+                    to: `${DIST}`,
+                },
+            ],
+        }),
+        new webpack.DefinePlugin({
+            // eslint-disable-next-line no-underscore-dangle
+            'process.env.__TREZOR_CONNECT_SRC': JSON.stringify(process.env.__TREZOR_CONNECT_SRC),
+            'process.env.COMMIT_HASH': JSON.stringify(commitHash),
+        }),
+        // Imports from @trezor-connect-web in @trezor/connect-explorer package need to be replaced by imports from @trezor/connect-webextension/lib/prox
+        // in order to work properly with @trezor/connect-webextension service worker.
+        new webpack.NormalModuleReplacementPlugin(
+            /@trezor\/connect-web/,
+            '@trezor/connect-webextension/lib/proxy',
+        ),
+    ],
+};
+
+export default config;

--- a/packages/connect-webextension/src/popup.ts
+++ b/packages/connect-webextension/src/popup.ts
@@ -1,10 +1,10 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/popup/PopupManager.js
 import EventEmitter from 'events';
 
+import { Deferred, createDeferred } from '@trezor/utils/lib';
 import { PopupEventMessage, ConnectSettings } from '@trezor/connect/lib/exports';
 import { getOrigin } from '@trezor/connect/lib/utils/urlUtils';
 import { Log } from '@trezor/connect/lib/utils/debug';
-import { createDeferred, Deferred } from '@trezor/utils/lib';
 
 import { ServiceWorkerWindowChannel } from './channels/serviceworker-window';
 
@@ -23,7 +23,7 @@ const checkIfTabExists = (tabId: number | undefined) =>
     });
 
 export class PopupManager extends EventEmitter {
-    popupWindow: chrome.tabs.Tab | undefined;
+    popupWindow: chrome.tabs.Tab | null = null;
 
     settings: ConnectSettings;
 
@@ -93,6 +93,7 @@ export class PopupManager extends EventEmitter {
     // create a special content script to be injected into log.html and stop sending logs over popup
     open() {
         const url = `${this.settings.popupSrc}`;
+
         chrome.windows.getCurrent(currentWindow => {
             this.logger.debug('opening popup. currentWindow: ', currentWindow);
 
@@ -158,7 +159,7 @@ export class PopupManager extends EventEmitter {
     };
 
     clear(focus = true) {
-        this.locked = false;
+        this.unlock();
 
         this.handshakePromise = createDeferred();
 
@@ -188,5 +189,6 @@ export class PopupManager extends EventEmitter {
                 this.logger.error('closed with error', e);
             }
         });
+        this.popupWindow = null;
     }
 }

--- a/packages/connect-webextension/src/proxy/index.ts
+++ b/packages/connect-webextension/src/proxy/index.ts
@@ -1,0 +1,124 @@
+import EventEmitter from 'events';
+
+// NOTE: @trezor/connect part is intentionally not imported from the index
+import {
+    ERRORS,
+    IFRAME,
+    POPUP,
+    createErrorMessage,
+    ConnectSettings,
+    Manifest,
+    CallMethod,
+} from '@trezor/connect/lib/exports';
+import { factory } from '@trezor/connect/lib/factory';
+
+import { WindowServiceWorkerChannel } from '../channels/window-serviceworker';
+
+const eventEmitter = new EventEmitter();
+let _channel: any;
+
+const manifest = (data: Manifest) => {
+    if (_channel) {
+        _channel.postMessage({
+            type: POPUP.INIT,
+            payload: {
+                settings: { manifest: data },
+            },
+        });
+    }
+    return Promise.resolve(undefined);
+};
+
+const dispose = () => {
+    eventEmitter.removeAllListeners();
+    return Promise.resolve(undefined);
+};
+
+const cancel = () => {
+    if (_channel) {
+        _channel.clear();
+    }
+};
+
+const init = (settings: Partial<ConnectSettings> = {}): Promise<void> => {
+    if (!_channel) {
+        _channel = new WindowServiceWorkerChannel({
+            name: 'trezor-connect-proxy',
+            channel: {
+                here: '@trezor/connect-foreground-proxy',
+                peer: '@trezor/connect-service-worker-proxy',
+            },
+        });
+    }
+
+    return _channel.init().then(() =>
+        _channel.postMessage(
+            {
+                type: POPUP.INIT,
+                payload: { settings },
+            },
+            { usePromise: false },
+        ),
+    );
+};
+
+const call: CallMethod = async (params: any) => {
+    try {
+        const response = await _channel.postMessage({
+            type: IFRAME.CALL,
+            payload: params,
+        });
+        if (response) {
+            return response;
+        }
+
+        return createErrorMessage(ERRORS.TypedError('Method_NoResponse'));
+    } catch (error) {
+        _channel.clear();
+
+        return createErrorMessage(error);
+    }
+};
+
+const uiResponse = () => {
+    // Not needed here.
+    throw ERRORS.TypedError('Method_InvalidPackage');
+};
+
+const renderWebUSBButton = () => {
+    // Not needed here - webUSB pairing happens in popup.
+    throw ERRORS.TypedError('Method_InvalidPackage');
+};
+
+const requestLogin = () => {
+    // Not needed here - Not used here.
+    throw ERRORS.TypedError('Method_InvalidPackage');
+};
+
+const disableWebUSB = () => {
+    // Not needed here - webUSB pairing happens in popup.
+    throw ERRORS.TypedError('Method_InvalidPackage');
+};
+
+const requestWebUSBDevice = () => {
+    // Not needed here - webUSB pairing happens in popup.
+    throw ERRORS.TypedError('Method_InvalidPackage');
+};
+
+const TrezorConnect = factory({
+    eventEmitter,
+    manifest,
+    init,
+    call,
+    requestLogin,
+    uiResponse,
+    renderWebUSBButton,
+    disableWebUSB,
+    requestWebUSBDevice,
+    cancel,
+    dispose,
+});
+
+// eslint-disable-next-line import/no-default-export
+export default TrezorConnect;
+export * from '@trezor/connect/lib/exports';

--- a/packages/connect-webextension/tsconfig.json
+++ b/packages/connect-webextension/tsconfig.json
@@ -2,7 +2,7 @@
     "extends": "../../tsconfig.json",
     "compilerOptions": {
         "isolatedModules": false,
-        "noEmit": true,
+        "outDir": "./lib",
         "types": ["chrome", "w3c-web-usb"]
     },
     "include": ["**/*.ts", "**/*.js"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -8780,7 +8780,9 @@ __metadata:
   dependencies:
     "@trezor/components": "workspace:*"
     "@trezor/connect-web": "workspace:*"
+    "@trezor/connect-webextension": "workspace:^"
     "@trezor/protobuf": "workspace:*"
+    "@trezor/utils": "workspace:^"
     "@types/markdown-it": "npm:^13.0.5"
     "@types/markdown-it-link-attributes": "npm:^3.0.3"
     "@types/react-router": "npm:^5.1.20"
@@ -8968,7 +8970,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/connect-webextension@workspace:packages/connect-webextension":
+"@trezor/connect-webextension@workspace:^, @trezor/connect-webextension@workspace:packages/connect-webextension":
   version: 0.0.0-use.local
   resolution: "@trezor/connect-webextension@workspace:packages/connect-webextension"
   dependencies:
@@ -9721,7 +9723,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/utils@workspace:*, @trezor/utils@workspace:packages/utils":
+"@trezor/utils@workspace:*, @trezor/utils@workspace:^, @trezor/utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@trezor/utils@workspace:packages/utils"
   dependencies:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Proxy for `@trezor/connect-web` to use service worker from `@trezor/connect-webextension` that is using Trezor Connect core running in Trezor Popup.

This version uses channels from `@trezor/connect-webextension` as `serviceworker-window` and `window-serviceworker` to allow communication between connect-explorer running in frontend of webextension and use service worker as a proxy to communicate with TrezorConnect running in popup.

- 0bfd88d6bb04008507d1c6ebf6218fb217809872 - foreground proxy is intended to be run in frontend of webextension for example connect-explorer running in webextension, it connects TrezorConnect with the one in Service Worker by using `WindowServiceWorkerChannel`.
- 595de1e645243568ed35b270719d77838346b725 - is the foreground proxy  counterpart that connect the 2 parts running in the Service Worker
- c7b417a0e9452f49a657279c7770143ae1b7c975 - adds `lazyHandshake` flag to `AbstractMessageChannel` so it is possible to have an element that does not start sending handshake request until it receives one from the other part. At the end the handshake is confirmed in both sides as well.
- ac704e4f7a73da49ddf5bbd657d87a35dbfbabf9 - create `src-webextension` in `connect-explorer` package. This is connect-explorer running in webextension with Manifest V3, core running in popup and using all the previous commits to allow communication between TrezorConnect in connect-explorer and the actual real one running in popup.
- 6d8f7c75ecd859ffb2430fbdb62c3fbce150ce4f - some ts configs
- 56d461198cca322b343c5bacec464ff1590dec78 - adding some documentation, it can be improved a lot but for following PRs.

Popup tests using this webextension are coming in following PR. 
I will also add artifacts to CI.


## Testing
Use the artifact from GitLab https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/6070973801/artifacts/browse/packages/connect-explorer/  or Build it your own by running the commands below:
```
yarn && \
yarn build:libs && \
yarn workspace @trezor/connect-webextension build && \
yarn workspace @trezor/connect-iframe build:core-module && \
yarn workspace @trezor/connect-explorer build:webextension && \
yarn workspace @trezor/connect-popup dev
```
And then go to Chrome browser:

-   Go to chrome://extensions
-   Enable developer mode and load unpacked
-   Choose `packages/connect-explorer/build-webextension` directory

## Related Issue

https://github.com/trezor/trezor-suite/pull/9525

## Screenshots:
Open the webextension and set  in setting the connectSrc you want to use for example `https://connect.trezor.io/9/` :


![image](https://github.com/trezor/trezor-suite/assets/5362163/df7138be-b5e1-4663-961c-25531f79f9d6)

Then you can go to GetAddress and run it:

![image](https://github.com/trezor/trezor-suite/assets/5362163/60f443a6-c65c-41c5-8273-c1d8787dfc8b)
