### PR TITLE
feat(suite): Add custom backend to sidebar

### DIFF
--- a/packages/suite-desktop-ui/src/support/DesktopUpdater/EarlyAccessDisable.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater/EarlyAccessDisable.tsx
@@ -8,6 +8,7 @@ import { desktopApi } from '@trezor/suite-desktop-api';
 import { Button, Image } from '@trezor/components';
 
 import { Translation, Modal, TrezorLink } from 'src/components/suite';
+import { DialogModal } from 'src/components/suite/modals/Modal/DialogRenderer';
 
 import { ImageWrapper, Description, Title } from './styles';
 
@@ -49,11 +50,11 @@ export const EarlyAccessDisable = ({ hideWindow }: EarlyAccessDisableProps) => {
         <StyledModal
             bottomBarComponents={
                 <>
-                    <Button onClick={hideWindow} variant="secondary">
-                        <Translation id="TR_EARLY_ACCESS_STAY_IN" />
-                    </Button>
                     <Button onClick={allowPrerelease}>
                         <Translation id="TR_EARLY_ACCESS_DISABLE" />
+                    </Button>
+                    <Button onClick={hideWindow} variant="tertiary">
+                        <Translation id="TR_EARLY_ACCESS_STAY_IN" />
                     </Button>
                 </>
             }
@@ -69,29 +70,22 @@ export const EarlyAccessDisable = ({ hideWindow }: EarlyAccessDisableProps) => {
             </Description>
         </StyledModal>
     ) : (
-        <StyledModal
+        <DialogModal
+            icon="check"
+            bodyHeading={<Translation id="TR_EARLY_ACCESS_LEFT_TITLE" />}
+            text={<Translation id="TR_EARLY_ACCESS_LEFT_DESCRIPTION" />}
             bottomBarComponents={
                 <>
-                    <Button onClick={hideWindow} variant="secondary">
-                        <Translation id="TR_EARLY_ACCESS_SKIP_REINSTALL" />
-                    </Button>
                     <Link variant="nostyle" href={SUITE_URL}>
                         <LinkButton icon="EXTERNAL_LINK" iconAlignment="right">
                             <Translation id="TR_EARLY_ACCESS_REINSTALL" />
                         </LinkButton>
                     </Link>
+                    <Button onClick={hideWindow} variant="tertiary">
+                        <Translation id="TR_EARLY_ACCESS_SKIP_REINSTALL" />
+                    </Button>
                 </>
             }
-        >
-            <ImageWrapper>
-                <Image image="UNI_SUCCESS" />
-            </ImageWrapper>
-            <Title>
-                <Translation id="TR_EARLY_ACCESS_LEFT_TITLE" />
-            </Title>
-            <Description>
-                <Translation id="TR_EARLY_ACCESS_LEFT_DESCRIPTION" />
-            </Description>
-        </StyledModal>
+        />
     );
 };

--- a/packages/suite-desktop-ui/src/support/DesktopUpdater/EarlyAccessEnable.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater/EarlyAccessEnable.tsx
@@ -7,8 +7,9 @@ import { desktopApi } from '@trezor/suite-desktop-api';
 import { Button, Paragraph, Tooltip, Image } from '@trezor/components';
 
 import { CheckItem, Translation, Modal } from 'src/components/suite';
+import { DialogModal } from 'src/components/suite/modals/Modal/DialogRenderer';
 
-import { ImageWrapper, Description, Divider, Title } from './styles';
+import { Description, Divider } from './styles';
 
 const DescriptionWrapper = styled.div`
     display: flex;
@@ -26,14 +27,6 @@ const DescriptionTextWrapper = styled.div`
 // Checkbox has 80% max-width by default but it's nicer full width here.
 const Checkbox = styled(CheckItem)`
     max-width: 100%;
-`;
-
-const StyledModal = styled(Modal)`
-    ${Modal.BottomBar} {
-        > * {
-            flex: 1;
-        }
-    }
 `;
 
 interface EarlyAccessEnableProps {
@@ -58,28 +51,21 @@ export const EarlyAccessEnable = ({ hideWindow }: EarlyAccessEnableProps) => {
     const checkForUpdates = useCallback(() => desktopApi.checkForUpdates(true), []);
 
     return enabled ? (
-        <StyledModal
+        <DialogModal
+            icon="check"
+            bodyHeading={<Translation id="TR_EARLY_ACCESS_JOINED_TITLE" />}
+            text={<Translation id="TR_EARLY_ACCESS_JOINED_DESCRIPTION" />}
             bottomBarComponents={
                 <>
-                    <Button onClick={hideWindow} variant="secondary">
-                        <Translation id="TR_EARLY_ACCESS_SKIP_CHECK" />
-                    </Button>
                     <Button onClick={checkForUpdates}>
                         <Translation id="TR_EARLY_ACCESS_CHECK_UPDATE" />
                     </Button>
+                    <Button onClick={hideWindow} variant="tertiary">
+                        <Translation id="TR_EARLY_ACCESS_SKIP_CHECK" />
+                    </Button>
                 </>
             }
-        >
-            <ImageWrapper>
-                <Image image="UNI_SUCCESS" />
-            </ImageWrapper>
-            <Title>
-                <Translation id="TR_EARLY_ACCESS_JOINED_TITLE" />
-            </Title>
-            <Description>
-                <Translation id="TR_EARLY_ACCESS_JOINED_DESCRIPTION" />
-            </Description>
-        </StyledModal>
+        />
     ) : (
         <Modal
             heading={<Translation id="TR_EARLY_ACCESS" />}

--- a/packages/suite-desktop-ui/src/support/DesktopUpdater/styles.ts
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater/styles.ts
@@ -28,8 +28,6 @@ export const Divider = styled.div`
 `;
 
 export const ImageWrapper = styled.div`
-    margin-left: auto;
-    margin-right: auto;
     top: 50px;
     left: 0;
     right: 0;

--- a/packages/suite/src/components/suite/Preloader/SuiteLayout/MobileMenu/MobileMenuActions.tsx
+++ b/packages/suite/src/components/suite/Preloader/SuiteLayout/MobileMenu/MobileMenuActions.tsx
@@ -9,11 +9,11 @@ import { goto } from 'src/actions/suite/routerActions';
 import { Translation } from 'src/components/suite';
 import { findRouteByName } from 'src/utils/suite/router';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { useCustomBackends } from 'src/hooks/settings/backends';
 import { useGuide } from 'src/hooks/guide/useGuide';
 import { selectIsDiscreteModeActive } from 'src/reducers/wallet/settingsReducer';
 
 import { MobileActionItem } from './MobileActionItem';
+import { useEnabledBackends } from '../utils';
 
 const MobileWrapper = styled.div`
     display: flex;
@@ -30,7 +30,7 @@ export const MobileMenuActions = ({ closeMobileNavigation }: MobileMenuActionsPr
     const notifications = useSelector(state => state.notifications);
     const discreetMode = useSelector(selectIsDiscreteModeActive);
     const allowPrerelease = useSelector(state => state.desktopUpdate.allowPrerelease);
-    const enabledNetworks = useSelector(state => state.wallet.settings.enabledNetworks);
+    const enabledBackends = useEnabledBackends();
     const dispatch = useDispatch();
 
     const { openGuide } = useGuide();
@@ -52,10 +52,6 @@ export const MobileMenuActions = ({ closeMobileNavigation }: MobileMenuActionsPr
 
     const unseenNotifications = useMemo(() => notifications.some(n => !n.seen), [notifications]);
 
-    const customBackends = useCustomBackends().filter(backend =>
-        enabledNetworks.includes(backend.coin),
-    );
-
     return (
         <MobileWrapper>
             <MobileActionItem
@@ -65,7 +61,7 @@ export const MobileMenuActions = ({ closeMobileNavigation }: MobileMenuActionsPr
                 icon={discreetMode ? 'HIDE' : 'SHOW'}
             />
 
-            {!!customBackends.length && (
+            {!!enabledBackends.length && (
                 <MobileActionItem
                     onClick={() => action('settings-coins')}
                     label={<Translation id="TR_BACKENDS" />}

--- a/packages/suite/src/components/suite/Preloader/SuiteLayout/Sidebar/ActionButton.tsx
+++ b/packages/suite/src/components/suite/Preloader/SuiteLayout/Sidebar/ActionButton.tsx
@@ -1,0 +1,8 @@
+import { IconButton } from '@trezor/components';
+import { borders } from '@trezor/theme';
+import styled from 'styled-components';
+
+export const ActionButton = styled(IconButton)`
+    width: 100%;
+    border-radius: ${borders.radii.sm};
+`;

--- a/packages/suite/src/components/suite/Preloader/SuiteLayout/Sidebar/ActionButton.tsx
+++ b/packages/suite/src/components/suite/Preloader/SuiteLayout/Sidebar/ActionButton.tsx
@@ -1,8 +1,20 @@
-import { IconButton } from '@trezor/components';
+import React from 'react';
+import { IconButton, IconButtonProps, Tooltip } from '@trezor/components';
 import { borders } from '@trezor/theme';
 import styled from 'styled-components';
 
-export const ActionButton = styled(IconButton)`
+interface ActionButtonProps extends IconButtonProps {
+    title: string;
+    className?: string;
+}
+
+export const Button = styled(IconButton)`
     width: 100%;
     border-radius: ${borders.radii.sm};
 `;
+
+export const ActionButton = ({ className, title, ...props }: ActionButtonProps) => (
+    <Tooltip content={title} cursor="pointer">
+        <Button className={className} {...props} />
+    </Tooltip>
+);

--- a/packages/suite/src/components/suite/Preloader/SuiteLayout/Sidebar/HelperIcons.tsx
+++ b/packages/suite/src/components/suite/Preloader/SuiteLayout/Sidebar/HelperIcons.tsx
@@ -1,0 +1,73 @@
+import styled, { useTheme } from 'styled-components';
+import { Icon, Tooltip } from '@trezor/components';
+import { borders, spacingsPx } from '@trezor/theme';
+import { useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
+import { goto } from 'src/actions/suite/routerActions';
+import { SettingsAnchor } from 'src/constants/suite/anchors';
+
+const Container = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: ${spacingsPx.xxxs};
+    justify-content: space-between;
+    align-items: stretch;
+    border-right: 1px solid ${({ theme }) => theme.borderOnElevation0};
+    padding: ${spacingsPx.xxxs};
+`;
+
+const HelperIcon = styled.div`
+    border-radius: ${borders.radii.xxxs};
+    width: ${spacingsPx.lg};
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+`;
+
+const EapIcon = styled(HelperIcon)<{ isEapEnabled: boolean }>`
+    background-color: ${({ theme, isEapEnabled }) =>
+        isEapEnabled ? '#8247E5' : theme.backgroundAlertYellowBold};
+
+    :hover {
+        background-color: ${({ theme, isEapEnabled }) =>
+            isEapEnabled ? '#551ab8' : theme.iconAlertYellow};
+    }
+`;
+
+const DebugModeIcon = styled(HelperIcon)`
+    background-color: ${({ theme }) => theme.backgroundAlertRedBold};
+`;
+
+export const HelperIcons = () => {
+    const isEapEnabled = useSelector(state => state.desktopUpdate.allowPrerelease);
+    const allowPrerelease = useSelector(state => state.desktopUpdate.allowPrerelease);
+    const showDebugMode = useSelector(state => state.suite.settings.debug.showDebugMenu);
+    const { translationString } = useTranslation();
+    const dispatch = useDispatch();
+    const theme = useTheme();
+
+    const handleEapClick = () => {
+        dispatch(goto('settings-index', { anchor: SettingsAnchor.EarlyAccess }));
+    };
+
+    if (!allowPrerelease && !showDebugMode) return null;
+
+    return (
+        <Container>
+            {allowPrerelease && (
+                <EapIcon onClick={handleEapClick} isEapEnabled={isEapEnabled}>
+                    <Tooltip cursor="pointer" content={translationString('TR_EARLY_ACCESS')}>
+                        <Icon icon="EXPERIMENTAL" size={16} color={theme.iconOnSecondary} />
+                    </Tooltip>
+                </EapIcon>
+            )}
+            {showDebugMode && (
+                <DebugModeIcon>
+                    <Tooltip content="Debug mode active">
+                        <Icon icon="FLAG" size={16} color={theme.iconOnSecondary} />
+                    </Tooltip>
+                </DebugModeIcon>
+            )}
+        </Container>
+    );
+};

--- a/packages/suite/src/components/suite/Preloader/SuiteLayout/Sidebar/NavBackends.tsx
+++ b/packages/suite/src/components/suite/Preloader/SuiteLayout/Sidebar/NavBackends.tsx
@@ -1,0 +1,142 @@
+import React, { useRef, useState } from 'react';
+import styled from 'styled-components';
+
+import { Dropdown, DropdownRef, CoinLogo } from '@trezor/components';
+import { Translation, StatusLight } from 'src/components/suite';
+import { useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
+import { goto } from 'src/actions/suite/routerActions';
+import { BlockchainState } from '@suite-common/wallet-core';
+import type { CustomBackend } from 'src/types/wallet';
+import { ActionButton } from './ActionButton';
+import { openModal } from 'src/actions/suite/modalActions';
+import { spacingsPx, typography } from '@trezor/theme';
+
+const StyledDropdown = styled(Dropdown)`
+    display: block;
+    width: 100%;
+`;
+
+const RowWrapper = styled.div`
+    display: flex;
+    width: 260px;
+    align-items: center;
+
+    > * + * {
+        margin-left: ${spacingsPx.xs};
+    }
+
+    > div:nth-child(2) {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        margin-left: ${spacingsPx.xs};
+        overflow: hidden;
+
+        > span:first-child {
+            ${typography.body}
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        > span:last-child {
+            ${typography.hint}
+            color: ${({ theme }) => theme.textSubdued};
+            text-transform: capitalize;
+        }
+    }
+`;
+
+const BackendRow = ({
+    backend: { coin, type },
+    blockchain,
+}: {
+    backend: CustomBackend;
+    blockchain: BlockchainState;
+}) => {
+    const chain = blockchain[coin];
+    return (
+        <RowWrapper>
+            <CoinLogo symbol={coin} />
+            <div>
+                {chain?.url ? (
+                    <span>{chain.url}</span>
+                ) : (
+                    <Translation id="TR_BACKEND_DISCONNECTED" />
+                )}
+                <span>{type}</span>
+            </div>
+            <StatusLight status={chain?.connected ? 'ok' : 'error'} />
+        </RowWrapper>
+    );
+};
+
+const DefaultBackendsLabel = styled.div`
+    white-space: normal;
+`;
+
+type NavBackendsProps = {
+    customBackends: CustomBackend[];
+};
+
+export const NavBackends = ({ customBackends }: NavBackendsProps) => {
+    const [open, setOpen] = useState(false);
+    const dropdownRef = useRef<DropdownRef>();
+    const blockchain = useSelector(state => state.wallet.blockchain);
+    const dispatch = useDispatch();
+    const { translationString } = useTranslation();
+
+    const goToCoinsSettings = () => dispatch(goto('settings-coins'));
+    const items = [
+        {
+            key: 'backends',
+            label: <Translation id="TR_BACKENDS" />,
+            options: customBackends.map(backend => ({
+                key: backend.coin,
+                label: <BackendRow backend={backend} blockchain={blockchain} />,
+                onClick: () =>
+                    dispatch(
+                        openModal({
+                            type: 'advanced-coin-settings',
+                            coin: backend.coin,
+                        }),
+                    ),
+            })),
+        },
+        {
+            key: 'note',
+            options: [
+                {
+                    key: '1',
+                    label: (
+                        <DefaultBackendsLabel>
+                            <Translation id="TR_OTHER_COINS_USE_DEFAULT_BACKEND" />
+                        </DefaultBackendsLabel>
+                    ),
+                    isDisabled: true,
+                    separatorBefore: true,
+                },
+            ],
+        },
+    ];
+
+    return (
+        <StyledDropdown
+            onToggle={() => setOpen(!open)}
+            ref={dropdownRef}
+            alignMenu="top-right"
+            addon={{
+                onClick: goToCoinsSettings,
+                label: <Translation id="TR_MANAGE" />,
+                icon: 'ARROW_RIGHT_LONG',
+            }}
+            items={items}
+        >
+            <ActionButton
+                title={translationString('TR_CUSTOM_BACKEND')}
+                icon="BACKEND"
+                size="small"
+                variant="tertiary"
+            />
+        </StyledDropdown>
+    );
+};

--- a/packages/suite/src/components/suite/Preloader/SuiteLayout/Sidebar/QuickActions.tsx
+++ b/packages/suite/src/components/suite/Preloader/SuiteLayout/Sidebar/QuickActions.tsx
@@ -9,9 +9,15 @@ import { selectTorState } from 'src/reducers/suite/suiteReducer';
 import { setDiscreetMode } from 'src/actions/settings/walletSettingsActions';
 import { selectIsDiscreteModeActive } from 'src/reducers/wallet/settingsReducer';
 import { NavigationItemBase } from './NavigationItem';
-import { useCustomBackends } from 'src/hooks/settings/backends';
 import { ActionButton } from './ActionButton';
 import { NavBackends } from './NavBackends';
+import { HelperIcons } from './HelperIcons';
+import { useEnabledBackends } from '../utils';
+
+const Container = styled.div`
+    display: flex;
+    border-top: 1px solid ${({ theme }) => theme.borderOnElevation0};
+`;
 
 const DescreetContainer = styled(NavigationItemBase)`
     width: 100%;
@@ -21,33 +27,16 @@ const DescreetContainer = styled(NavigationItemBase)`
     }
 `;
 
-const ActionsContainer = styled.div<{ numberOfColumns: number }>`
-    position: relative;
-    display: grid;
-    grid-template-columns: ${({ numberOfColumns }) => '1fr '.repeat(numberOfColumns)};
-    gap: ${spacingsPx.md};
-    padding: ${spacingsPx.xs};
-    border-top: 1px solid ${({ theme }) => theme.borderOnElevation0};
-    align-items: stretch;
-`;
-
-const Column = styled.div`
+const ActionsContainer = styled.div`
+    flex: 1;
     position: relative;
     display: flex;
-    flex-direction: column;
-    justify-content: center;
+    gap: ${spacingsPx.xxs};
+    padding: ${spacingsPx.xxs};
+    align-items: stretch;
 
-    &:not(:last-child)::after {
-        background: ${({ theme }) => theme.borderOnElevation0};
-        width: 1px;
-        content: '';
-        display: block;
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        right: 0;
-        height: 100%;
-        margin-right: -9px;
+    > * {
+        flex: 1;
     }
 `;
 
@@ -79,76 +68,70 @@ const TorToggleContainer = styled.div`
 export const QuickActions = () => {
     const isDiscreetModeActive = useSelector(selectIsDiscreteModeActive);
     const { isTorEnabled, isTorLoading } = useSelector(selectTorState);
-    const enabledNetworks = useSelector(state => state.wallet.settings.enabledNetworks);
-
     const dispatch = useDispatch();
     const { translationString } = useTranslation();
     const theme = useTheme();
-
-    const handleDicreetModeClick = () => dispatch(setDiscreetMode(!isDiscreetModeActive));
-    const customBackends = useCustomBackends().filter(backend =>
-        enabledNetworks.includes(backend.coin),
-    );
+    const handleDiscreetModeClick = () => dispatch(setDiscreetMode(!isDiscreetModeActive));
+    const enabledBackends = useEnabledBackends();
     const translationLabel = isDiscreetModeActive ? 'TR_SHOW_BALANCES' : 'TR_HIDE_BALANCES';
-    const isCustomBackendIconVisible = customBackends.length > 0;
+    const isCustomBackendIconVisible = enabledBackends.length > 0;
     const isTorIconVisible = isDesktop();
-    const numberOfColumns = [isCustomBackendIconVisible, isTorIconVisible, true].filter(
-        Boolean,
-    ).length;
 
     const CheckIcon = () => (
         <StyledCheckIcon icon="CHECK_ACTIVE" size={12} color={theme.iconPrimaryDefault} />
     );
 
     return (
-        <ActionsContainer numberOfColumns={numberOfColumns}>
-            {isCustomBackendIconVisible && (
-                <Column>
-                    <Tooltip content={translationString('TR_CUSTOM_BACKEND')} cursor="pointer">
-                        <>
-                            <NavBackends customBackends={customBackends} />
-
-                            <CheckIcon />
-                        </>
-                    </Tooltip>
-                </Column>
-            )}
-            {isTorIconVisible && (
-                <Column>
-                    <Tooltip content={translationString('TR_TOR')} cursor="pointer">
-                        <TorToggleContainer>
-                            <ActionButton
-                                icon="TOR"
-                                isLoading={isTorLoading}
-                                onClick={() =>
-                                    dispatch(goto('settings-index', { anchor: SettingsAnchor.Tor }))
-                                }
-                                size="small"
-                                variant="tertiary"
-                            />
-
-                            {isTorEnabled && <CheckIcon />}
-                        </TorToggleContainer>
-                    </Tooltip>
-                </Column>
-            )}
-            <Column>
-                {numberOfColumns === 1 ? (
-                    <DescreetContainer onClick={handleDicreetModeClick}>
+        <Container>
+            <HelperIcons />
+            <ActionsContainer>
+                {!isCustomBackendIconVisible && !isTorIconVisible ? (
+                    <DescreetContainer onClick={handleDiscreetModeClick}>
                         <Icon size={16} icon={isDiscreetModeActive ? 'HIDE' : 'SHOW'} />
                         <Label>{translationString(translationLabel)} </Label>
                     </DescreetContainer>
                 ) : (
-                    <Tooltip content={translationString(translationLabel)} cursor="pointer">
+                    <>
+                        {isCustomBackendIconVisible && (
+                            <Tooltip
+                                content={translationString('TR_CUSTOM_BACKEND')}
+                                cursor="pointer"
+                            >
+                                <>
+                                    <NavBackends customBackends={enabledBackends} />
+                                    <CheckIcon />
+                                </>
+                            </Tooltip>
+                        )}
+                        {isTorIconVisible && (
+                            <TorToggleContainer>
+                                <ActionButton
+                                    icon="TOR"
+                                    title={translationString('TR_TOR')}
+                                    isLoading={isTorLoading}
+                                    onClick={() =>
+                                        dispatch(
+                                            goto('settings-index', { anchor: SettingsAnchor.Tor }),
+                                        )
+                                    }
+                                    size="small"
+                                    variant="tertiary"
+                                />
+
+                                {isTorEnabled && <CheckIcon />}
+                            </TorToggleContainer>
+                        )}
+
                         <ActionButton
+                            title={translationString(translationLabel)}
                             icon={isDiscreetModeActive ? 'HIDE' : 'SHOW'}
-                            onClick={handleDicreetModeClick}
+                            onClick={handleDiscreetModeClick}
                             variant="tertiary"
                             size="small"
                         />
-                    </Tooltip>
+                    </>
                 )}
-            </Column>
-        </ActionsContainer>
+            </ActionsContainer>
+        </Container>
     );
 };

--- a/packages/suite/src/components/suite/Preloader/SuiteLayout/utils.ts
+++ b/packages/suite/src/components/suite/Preloader/SuiteLayout/utils.ts
@@ -1,0 +1,8 @@
+import { useCustomBackends } from 'src/hooks/settings/backends';
+import { useSelector } from 'src/hooks/suite';
+
+export const useEnabledBackends = () => {
+    const enabledNetworks = useSelector(state => state.wallet.settings.enabledNetworks);
+    const customBackends = useCustomBackends();
+    return customBackends.filter(backend => enabledNetworks.includes(backend.coin));
+};

--- a/packages/theme/src/borders.ts
+++ b/packages/theme/src/borders.ts
@@ -5,6 +5,7 @@ export const borders = {
         large: '2px',
     },
     radii: {
+        xxxs: '2px',
         xxs: '4px',
         xs: '8px',
         sm: '12px',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

#10118

## Screenshots:

feat(suite): Add custom backends to sidebar

### EDIT: Helpers (EAP, Dev mode) added:

EAP inactive:
![image](https://github.com/trezor/trezor-suite/assets/858321/fc77280d-4b68-4e74-82d7-58e50dec2117)

EAP active:
![image](https://github.com/trezor/trezor-suite/assets/858321/d6a9dad4-3fd9-44d9-ac41-0b0912cde510)

EAP icon hover:
![image](https://github.com/trezor/trezor-suite/assets/858321/79f80963-26b9-452c-a4da-5a081718fd3d)


dev mode inactive:

![image](https://github.com/trezor/trezor-suite/assets/858321/15846df4-709f-4468-b3c4-464ea1543e3e)



_Quick actions without helpers (just older screenshots):_
 
### Desktop:

No custom backend:
![image](https://github.com/trezor/trezor-suite/assets/858321/cefba307-bbf9-47c2-80e8-58d81558bf4b)

Custom backend:
![image](https://github.com/trezor/trezor-suite/assets/858321/afb96ac9-b194-4153-abea-8e2d5281cd7a)

Custom backend dropdown (+ focus state on icon):
![image](https://github.com/trezor/trezor-suite/assets/858321/86102d5f-ab72-447f-860c-6062e6ccd2f1)

### Web

No custom backend:
![image](https://github.com/trezor/trezor-suite/assets/858321/746d4a2f-450a-40d8-a93d-38067f3e9b2f)

Hovered custom backend icon (works also for other icons):
![image](https://github.com/trezor/trezor-suite/assets/858321/706f0651-b1d9-4d88-94bb-7a1f7261dc1e)

Custom backend:
![image](https://github.com/trezor/trezor-suite/assets/858321/d67184cc-094a-4457-83fc-245f4481b8c7)


