### PR TITLE
chore(suite): split metadataActions

### DIFF
--- a/packages/suite/src/actions/suite/__fixtures__/metadataActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/metadataActions.ts
@@ -3,7 +3,7 @@ import { deviceActions } from '@suite-common/wallet-core';
 
 import { METADATA } from 'src/actions/suite/constants';
 
-import * as metadataActions from '../metadataActions';
+import * as metadataLabelingActions from '../metadataLabelingActions';
 
 const { getSuiteDevice } = testMocks;
 
@@ -14,7 +14,7 @@ type Fixture<T extends (...a: any) => any> = {
     result?: any;
 };
 
-const setDeviceMetadataKey: Fixture<(typeof metadataActions)['setDeviceMetadataKey']>[] = [
+const setDeviceMetadataKey: Fixture<(typeof metadataLabelingActions)['setDeviceMetadataKey']>[] = [
     {
         description: `Metadata not enabled`,
         params: [getSuiteDevice({ state: 'a' }), METADATA.ENCRYPTION_VERSION],
@@ -560,7 +560,7 @@ const disposeMetadata = [
                 selectedProvider: { labels: 'clientId' },
             },
         },
-        params: [],
+        params: [] as const,
         result: {
             metadata: {
                 providers: [
@@ -576,30 +576,15 @@ const disposeMetadata = [
             },
         },
     },
+];
+
+const disposeMetadataKeys = [
     {
         description: 'keys',
         initialState: {
             device: {
                 state: 'device-state',
                 metadata: { 1: { fileName: 'foo', aesKey: 'bar' } },
-            },
-            metadata: {
-                providers: [
-                    {
-                        type: 'dropbox',
-                        data: {
-                            'filename-123': {
-                                outputLabels: {
-                                    TXID: {
-                                        0: 'Foo',
-                                    },
-                                },
-                            },
-                        },
-                        clientId: 'clientId',
-                    },
-                ],
-                selectedProvider: { labels: 'clientId' },
             },
             accounts: [
                 {
@@ -614,7 +599,7 @@ const disposeMetadata = [
                 },
             ],
         },
-        params: [true],
+        params: [] as const,
         result: {
             device: { selectedDevice: { state: 'device-state', metadata: {} } },
             wallet: {
@@ -633,4 +618,5 @@ export {
     addMetadata,
     init,
     disposeMetadata,
+    disposeMetadataKeys,
 };

--- a/packages/suite/src/actions/suite/__tests__/metadataActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/metadataActions.test.ts
@@ -14,6 +14,8 @@ import { extraDependencies } from 'src/support/extraDependencies';
 
 import { STORAGE, MODAL } from '../constants';
 import * as metadataActions from '../metadataActions';
+import * as metadataProviderActions from '../metadataProviderActions';
+import * as metadataLabelingActions from '../metadataLabelingActions';
 import * as fixtures from '../__fixtures__/metadataActions';
 
 const deviceReducer = prepareDeviceReducer(extraDependencies);
@@ -91,7 +93,9 @@ const initStore = (state: State) => {
             // automatically resolve modal decision
             switch (action.payload.type) {
                 case 'metadata-provider':
-                    await store.dispatch(metadataActions.connectProvider({ type: 'dropbox' }));
+                    await store.dispatch(
+                        metadataProviderActions.connectProvider({ type: 'dropbox' }),
+                    );
                     action.payload.decision.resolve(true);
                     break;
                 default:
@@ -150,7 +154,7 @@ describe('Metadata Actions', () => {
     fixtures.setDeviceMetadataKey.forEach(f => {
         it(`setDeviceMetadataKey - ${f.description}`, async () => {
             const store = initStore(getInitialState(f.initialState));
-            await store.dispatch(metadataActions.setDeviceMetadataKey(...f.params));
+            await store.dispatch(metadataLabelingActions.setDeviceMetadataKey(...f.params));
             if (!f.result) {
                 expect(store.getActions().length).toEqual(0);
             } else {
@@ -165,7 +169,7 @@ describe('Metadata Actions', () => {
             const store = initStore(getInitialState(f.initialState));
             const account = await store.dispatch(
                 // @ts-expect-error Account is not complete
-                metadataActions.setAccountMetadataKey(...f.params),
+                metadataLabelingActions.setAccountMetadataKey(...f.params),
             );
             expect(account).toMatchObject(f.result);
         });
@@ -176,7 +180,7 @@ describe('Metadata Actions', () => {
             // @ts-expect-error
             const store = initStore(getInitialState(f.initialState));
             // @ts-expect-error, params
-            await store.dispatch(metadataActions.addDeviceMetadata(f.params));
+            await store.dispatch(metadataLabelingActions.addDeviceMetadata(f.params));
             if (!f.result) {
                 expect(store.getActions().length).toEqual(0);
             }
@@ -188,7 +192,7 @@ describe('Metadata Actions', () => {
             // @ts-expect-error
             const store = initStore(getInitialState(f.initialState));
             // @ts-expect-error, params
-            await store.dispatch(metadataActions.addAccountMetadata(f.params));
+            await store.dispatch(metadataLabelingActions.addAccountMetadata(f.params));
 
             const result = store.getActions();
             if (!f.result) {
@@ -204,7 +208,7 @@ describe('Metadata Actions', () => {
             // @ts-expect-error
             const store = initStore(getInitialState(f.initialState));
             // @ts-expect-error, params
-            const result = await store.dispatch(metadataActions.connectProvider(f.params));
+            const result = await store.dispatch(metadataProviderActions.connectProvider(f.params));
 
             if (!f.result) {
                 expect(store.getActions().length).toEqual(0);
@@ -220,7 +224,7 @@ describe('Metadata Actions', () => {
             const store = initStore(getInitialState(f.initialState));
 
             // @ts-expect-error, params
-            const result = await store.dispatch(metadataActions.addMetadata(f.params));
+            const result = await store.dispatch(metadataLabelingActions.addMetadata(f.params));
 
             if (!f.result) {
                 expect(store.getActions().length).toEqual(0);
@@ -262,7 +266,7 @@ describe('Metadata Actions', () => {
         it(`initMetadata - ${f.description}`, async () => {
             // @ts-expect-error
             const store = initStore(getInitialState(f.initialState));
-            await store.dispatch(metadataActions.init(false));
+            await store.dispatch(metadataLabelingActions.init(false));
             if (!f.result) {
                 expect(store.getActions().length).toEqual(0);
             } else {
@@ -276,6 +280,17 @@ describe('Metadata Actions', () => {
             // @ts-expect-error
             const store = initStore(getInitialState(f.initialState));
             await store.dispatch(metadataActions.disposeMetadata(...f.params));
+            if (f.result) {
+                expect(store.getState()).toMatchObject(f.result);
+            }
+        });
+    });
+
+    fixtures.disposeMetadataKeys.forEach(f => {
+        it(`disposeMetadataKeys - ${f.description}`, async () => {
+            // @ts-expect-error
+            const store = initStore(getInitialState(f.initialState));
+            await store.dispatch(metadataActions.disposeMetadataKeys(...f.params));
             if (f.result) {
                 expect(store.getState()).toMatchObject(f.result);
             }

--- a/packages/suite/src/actions/suite/initAction.ts
+++ b/packages/suite/src/actions/suite/initAction.ts
@@ -8,7 +8,7 @@ import {
 
 import * as routerActions from 'src/actions/suite/routerActions';
 import * as analyticsActions from 'src/actions/suite/analyticsActions';
-import * as metadataActions from 'src/actions/suite/metadataActions';
+import * as metadataLabelingActions from 'src/actions/suite/metadataLabelingActions';
 import * as languageActions from 'src/actions/settings/languageActions';
 import type { Dispatch, GetState } from 'src/types/suite';
 import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
@@ -80,7 +80,7 @@ export const init = () => async (dispatch: Dispatch, getState: GetState) => {
     // 9. fetch metadata. metadata is not saved together with other data in storage.
     // historically it was saved in indexedDB together with devices and accounts and we did not need to load them
     // immediately after suite start.
-    dispatch(metadataActions.fetchAndSaveMetadataForAllDevices());
+    dispatch(metadataLabelingActions.fetchAndSaveMetadataForAllDevices());
 
     // 9. backend connected, suite is ready to use
     dispatch(onSuiteReady());

--- a/packages/suite/src/actions/suite/metadataActions.ts
+++ b/packages/suite/src/actions/suite/metadataActions.ts
@@ -1,45 +1,21 @@
-/* eslint @typescript-eslint/no-use-before-define: 1 */
 import { createAction } from '@reduxjs/toolkit';
 
-import TrezorConnect from '@trezor/connect';
-import { analytics, EventType } from '@trezor/suite-analytics';
-import { createDeferred, cloneObject } from '@trezor/utils';
-import { notificationsActions } from '@suite-common/toast-notifications';
-import { selectDevices, selectDevice, selectDeviceByState } from '@suite-common/wallet-core';
+import { selectDevices } from '@suite-common/wallet-core';
 
 import { METADATA } from 'src/actions/suite/constants';
-import { Dispatch, GetState, TrezorDevice } from 'src/types/suite';
+import { Dispatch, GetState } from 'src/types/suite';
 import {
-    MetadataProviderType,
     MetadataProvider,
-    MetadataAddPayload,
-    Tokens,
     DeviceMetadata,
-    Error as MetadataProviderError,
-    OAuthServerEnvironment,
-    ProviderErrorAction,
     Labels,
     DataType,
-    MetadataEncryptionVersion,
     WalletLabels,
     AccountLabels,
 } from 'src/types/suite/metadata';
-import { Account } from 'src/types/wallet';
 import * as metadataUtils from 'src/utils/suite/metadata';
-import * as modalActions from 'src/actions/suite/modalActions';
-import DropboxProvider from 'src/services/suite/metadata/DropboxProvider';
-import GoogleProvider from 'src/services/suite/metadata/GoogleProvider';
-import FileSystemProvider from 'src/services/suite/metadata/FileSystemProvider';
-import {
-    selectLabelableEntities,
-    selectMetadata,
-    selectSelectedProviderForLabels,
-} from 'src/reducers/suite/metadataReducer';
-import { InMemoryTestProvider } from '../../services/suite/metadata/InMemoryTestProvider';
-
-export const setAccountAdd = createAction(METADATA.ACCOUNT_ADD, (payload: Account) => ({
-    payload,
-}));
+import { selectSelectedProviderForLabels } from 'src/reducers/suite/metadataReducer';
+import { Account } from '@suite-common/wallet-types';
+import type { AbstractMetadataProvider } from 'src/types/suite/metadata';
 
 export type MetadataAction =
     | { type: typeof METADATA.ENABLE }
@@ -76,50 +52,20 @@ export type MetadataAction =
           type: typeof METADATA.SET_ERROR_FOR_DEVICE;
           payload: { deviceState: string; failed: boolean };
       }
-    | ReturnType<typeof setAccountAdd>;
+    | {
+          type: typeof METADATA.ACCOUNT_ADD;
+          payload: Account;
+      };
 
-// needs to be declared here in top level context because it's not recommended to keep classes instances in redux state (serialization)
-const providerInstance: Record<
-    DataType,
-    DropboxProvider | GoogleProvider | FileSystemProvider | InMemoryTestProvider | undefined
-> = {
-    labels: undefined,
-    passwords: undefined,
-};
-
-const fetchIntervals: { [deviceState: string]: any } = {}; // any because of native at the moment, otherwise number | undefined
-
-const createProviderInstance = (
-    type: MetadataProvider['type'],
-    tokens: Tokens = {},
-    environment: OAuthServerEnvironment = 'production',
-    clientId?: string,
-) => {
-    // eslint-disable-next-line default-case
-    switch (type) {
-        case 'dropbox':
-            return new DropboxProvider({
-                token: tokens?.refreshToken,
-                clientId: clientId || METADATA.DROPBOX_CLIENT_ID,
-            });
-        case 'google':
-            return new GoogleProvider(tokens, environment);
-        case 'fileSystem':
-            return new FileSystemProvider();
-        case 'inMemoryTest':
-            return new InMemoryTestProvider();
-    }
-};
+export const setAccountAdd = createAction(METADATA.ACCOUNT_ADD, (payload: Account) => ({
+    payload,
+}));
 
 /**
  * dispose metadata from all labelable objects.
- * Has keys parameter,
- * if true - dispose also metadata keys
- * if false - dispose only metadata values
  */
-export const disposeMetadata = (keys?: boolean) => (dispatch: Dispatch, getState: GetState) => {
+export const disposeMetadata = () => (dispatch: Dispatch, getState: GetState) => {
     const provider = selectSelectedProviderForLabels(getState());
-    const devices = selectDevices(getState());
 
     if (!provider) {
         return;
@@ -132,169 +78,31 @@ export const disposeMetadata = (keys?: boolean) => (dispatch: Dispatch, getState
             data: undefined,
         },
     });
-
-    if (keys) {
-        getState().wallet.accounts.forEach(account => {
-            const updatedAccount = JSON.parse(JSON.stringify(account));
-
-            delete updatedAccount.metadata[METADATA.ENCRYPTION_VERSION];
-            dispatch(setAccountAdd(updatedAccount));
-        });
-
-        devices.forEach(device => {
-            if (device.state) {
-                // set metadata as disabled for this device, remove all metadata related information
-                dispatch({
-                    type: METADATA.SET_DEVICE_METADATA,
-                    payload: {
-                        deviceState: device.state,
-                        metadata: {},
-                    },
-                });
-            }
-        });
-    }
 };
 
-export const disconnectProvider =
-    ({
-        clientId,
-        dataType,
-        removeMetadata = true,
-    }: {
-        clientId: string;
-        dataType: DataType;
-        removeMetadata?: boolean;
-    }) =>
-    async (dispatch: Dispatch) => {
-        Object.values(fetchIntervals).forEach((deviceState, num) => {
-            clearInterval(num);
-            delete fetchIntervals[deviceState];
-        });
+export const disposeMetadataKeys = () => (dispatch: Dispatch, getState: GetState) => {
+    const devices = selectDevices(getState());
 
-        // dispose metadata values (not keys)
-        if (removeMetadata) {
-            dispatch(disposeMetadata());
+    getState().wallet.accounts.forEach(account => {
+        const updatedAccount = JSON.parse(JSON.stringify(account));
+
+        delete updatedAccount.metadata[METADATA.ENCRYPTION_VERSION];
+        dispatch(setAccountAdd(updatedAccount));
+    });
+
+    devices.forEach(device => {
+        if (device.state) {
+            // set metadata as disabled for this device, remove all metadata related information
+            dispatch({
+                type: METADATA.SET_DEVICE_METADATA,
+                payload: {
+                    deviceState: device.state,
+                    metadata: {},
+                },
+            });
         }
-
-        /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
-        const provider = dispatch(getProviderInstance({ clientId, dataType }));
-
-        if (provider) {
-            await provider.disconnect();
-            providerInstance[dataType] = undefined;
-        }
-        // flush reducer
-        dispatch({
-            type: METADATA.REMOVE_PROVIDER,
-            payload: provider,
-        });
-        dispatch({
-            type: METADATA.SET_SELECTED_PROVIDER,
-            payload: { dataType, clientId: undefined },
-        });
-
-        analytics.report({
-            type: EventType.SettingsGeneralLabelingProvider,
-            payload: {
-                provider: '',
-            },
-        });
-    };
-
-/**
- * handleProviderError method controls how application reacts to various errors from metadata providers
- * Toasts go in this format:
- * Error: <Action>: <Reason>
- * Error: Upload failed: Access token is invalid
- */
-const handleProviderError =
-    ({
-        error,
-        action,
-        clientId,
-    }: {
-        error: MetadataProviderError;
-        action: string;
-        clientId?: string;
-    }) =>
-    (dispatch: Dispatch) => {
-        // error should be of specified type, but in case it is not (catch is not typed) show generic error
-        // if this happens, it means that there is a hole in error handling and it should be fixed
-        const toastError = error.code
-            ? `${action}: ${error?.error}`
-            : `Labeling action failed. ${error}`;
-
-        dispatch(
-            notificationsActions.addToast({
-                type: 'error',
-                error: toastError,
-            }),
-        );
-
-        if (clientId) {
-            // handle nicely wrapped errors here
-            switch (error.code) {
-                // possibly programmer errors
-                // something is screwed up, we don't really know what.
-                // react by disabling all metadata and toasting error;
-                case 'ACCESS_ERROR':
-                case 'BAD_INPUT_ERROR':
-                case 'OTHER_ERROR':
-                    dispatch(disposeMetadata());
-                    dispatch(
-                        disconnectProvider({
-                            clientId,
-                            dataType: 'labels',
-                        }),
-                    );
-                    break;
-                case 'PROVIDER_ERROR':
-                case 'RATE_LIMIT_ERROR':
-                case 'AUTH_ERROR':
-                    dispatch(
-                        disconnectProvider({
-                            clientId,
-                            dataType: 'labels',
-                        }),
-                    );
-                    break;
-                case 'CONNECTIVITY_ERROR':
-                default:
-                    break;
-            }
-        }
-    };
-
-/**
- * Return already existing instance of AbstractProvider or recreate it from token;
- */
-const getProviderInstance =
-    ({ clientId, dataType = 'labels' }: { clientId: string; dataType: DataType }) =>
-    (_dispatch: Dispatch, getState: GetState) => {
-        const state = getState();
-        const { providers } = state.metadata;
-
-        const provider = providers.find(p => p.clientId === clientId);
-
-        if (!provider) return;
-
-        // instance already exists but user did not finish log in and decided to use another provider;
-        if (providerInstance[dataType] && providerInstance[dataType]?.type !== provider.type) {
-            providerInstance[dataType] = undefined;
-        }
-
-        if (providerInstance[dataType]) return providerInstance[dataType];
-
-        providerInstance[dataType] = createProviderInstance(
-            provider.type,
-            provider.tokens,
-            state.suite.settings.debug.oauthServerEnvironment,
-            clientId,
-        );
-
-        return providerInstance[dataType];
-    };
+    });
+};
 
 export const enableMetadata = (): MetadataAction => ({
     type: METADATA.ENABLE,
@@ -305,16 +113,11 @@ export const disableMetadata = () => (dispatch: Dispatch) => {
         type: METADATA.DISABLE,
     });
     // dispose metadata values and keys
-    dispatch(disposeMetadata(true));
+    dispatch(disposeMetadata());
+    dispatch(disposeMetadataKeys());
 };
 
-export const initProvider = () => (dispatch: Dispatch) => {
-    const decision = createDeferred<boolean>();
-    dispatch(modalActions.openModal({ type: 'metadata-provider', decision }));
-    return decision.promise;
-};
-
-const setMetadata =
+export const setMetadata =
     ({
         provider,
         fileName,
@@ -336,738 +139,24 @@ const setMetadata =
         });
     };
 
-export const getLabelableEntities =
-    (deviceState: string) => (_dispatch: Dispatch, getState: GetState) =>
-        selectLabelableEntities(getState(), deviceState);
-
-type LabelableEntity = ReturnType<ReturnType<typeof getLabelableEntities>>[number];
-
-const fetchMetadata =
-    ({
-        provider,
-        entity,
-        encryptionVersion = METADATA.ENCRYPTION_VERSION,
-    }: {
-        provider: MetadataProvider;
-        entity: LabelableEntity;
-        encryptionVersion?: MetadataEncryptionVersion;
-    }) =>
-    async (dispatch: Dispatch) => {
-        const dataType = 'labels';
-
-        const providerInstance = dispatch(
-            getProviderInstance({
-                clientId: provider.clientId,
-                dataType,
-            }),
-        );
-
-        if (!providerInstance) {
-            throw new Error('no provider instance');
-        }
-
-        const entityMetadata = entity[encryptionVersion];
-        if (!entityMetadata) {
-            throw new Error('trying to fetch entity without metadata');
-        }
-
-        const { fileName, aesKey } = entityMetadata;
-
-        const response = await providerInstance.getFileContent(fileName);
-
-        if (!response.success) {
-            throw response;
-        }
-
-        if (!response.payload) {
-            return undefined;
-        }
-
-        // we found associated metadata file for given account, decrypt it and return it
-        const decryptedData = metadataUtils.decrypt(
-            metadataUtils.arrayBufferToBuffer(response.payload),
-            aesKey,
-        );
-
-        // validation of fetched data structure. in theory, user may save any data in metadata file (although it is very unlikely)
-        // so we should make sure that it at least matches AccountLabels types
-        if (entity.type === 'account') {
-            if (!decryptedData.addressLabels) {
-                console.error('fetchMetadata: addressLabels missing in metadata file');
-                decryptedData.addressLabels = {};
-            }
-            if (!decryptedData.outputLabels) {
-                console.error('fetchMetadata: outputLabels missing in metadata file');
-                decryptedData.outputLabels = {};
-            }
-        }
-
-        return {
-            fileName,
-            data: decryptedData,
-        };
-    };
-
-export const fetchPasswords =
-    (fileName: string, key: Buffer) => async (dispatch: Dispatch, _getState: GetState) => {
-        const provider = dispatch(
-            getProviderInstance({
-                clientId: METADATA.DROPBOX_PASSWORDS_CLIENT_ID,
-                dataType: 'passwords',
-            }),
-        );
-        if (!provider) {
-            return;
-        }
-
-        // this triggers renewal of access token if needed. Otherwise multiple requests
-        // to renew access token are issued by every provider.getFileContent
-        const response = await provider.getProviderDetails();
-        if (!response.success) {
-            return dispatch(
-                handleProviderError({
-                    error: response,
-                    action: ProviderErrorAction.LOAD,
-                    clientId: provider.clientId,
-                }),
-            );
-        }
-
-        return new Promise<void>((resolve, reject) =>
-            provider.getFileContent(fileName).then(result => {
-                if (!result.success) {
-                    return reject(result);
-                }
-
-                if (result.payload) {
-                    try {
-                        const decrypted = metadataUtils.decrypt(
-                            metadataUtils.arrayBufferToBuffer(result.payload),
-                            key,
-                        );
-
-                        dispatch({
-                            type: METADATA.SET_DATA,
-                            payload: {
-                                provider,
-                                data: {
-                                    [fileName]: decrypted,
-                                },
-                            },
-                        });
-                    } catch (err) {
-                        const error = provider.error('OTHER_ERROR', err.message);
-                        return reject(error);
-                    }
-                }
-
-                resolve();
-            }),
-        );
-    };
-
-export const setAccountMetadataKey =
-    (account: Account, encryptionVersion = METADATA.ENCRYPTION_VERSION) =>
-    (dispatch: Dispatch, getState: GetState) => {
-        const device = selectDeviceByState(getState(), account.deviceState);
-        const deviceMetaKey = device?.metadata[encryptionVersion]?.key;
-
-        if (!deviceMetaKey) {
-            // account keys can't be set without device keys
-            return account;
-        }
-        try {
-            const metaKey = metadataUtils.deriveMetadataKey(deviceMetaKey, account.metadata.key);
-            const fileName = metadataUtils.deriveFilenameForLabeling(metaKey, encryptionVersion);
-
-            const aesKey = metadataUtils.deriveAesKey(metaKey);
-            return {
-                ...account,
-                metadata: {
-                    ...account.metadata,
-                    [encryptionVersion]: { fileName, aesKey },
-                },
-            };
-        } catch (error) {
-            dispatch(handleProviderError({ error, action: ProviderErrorAction.SAVE }));
-        }
-        return account;
-    };
-
-/**
- * Fill any record in reducer that may have metadata with metadata keys (not values).
- */
-const syncMetadataKeys =
-    (device: TrezorDevice, encryptionVersion = METADATA.ENCRYPTION_VERSION) =>
-    (dispatch: Dispatch, getState: GetState) => {
-        if (!device.metadata[METADATA.ENCRYPTION_VERSION]) {
-            return;
-        }
-        const targetAccounts = getState().wallet.accounts.filter(
-            acc => !acc.metadata[encryptionVersion]?.fileName && acc.deviceState === device.state,
-        );
-
-        targetAccounts.forEach(account => {
-            const accountWithMetadata = dispatch(setAccountMetadataKey(account, encryptionVersion));
-            dispatch(setAccountAdd(accountWithMetadata));
-        });
-        // note that devices are intentionally omitted here - device receives metadata
-        // keys sooner when enabling labeling on device;
-    };
-
-export const fetchAndSaveMetadata =
-    (deviceStateArg?: string) => async (dispatch: Dispatch, getState: GetState) => {
-        const provider = selectSelectedProviderForLabels(getState());
-        if (!provider) return;
-
-        let device = deviceStateArg
-            ? selectDeviceByState(getState(), deviceStateArg)
-            : selectDevice(getState());
-
-        if (!device?.state || !device?.metadata?.[METADATA.ENCRYPTION_VERSION]) return;
-
-        const providerInstance = dispatch(
-            getProviderInstance({
-                clientId: provider.clientId,
-                dataType: 'labels',
-            }),
-        );
-        if (!providerInstance) {
-            return;
-        }
-
-        try {
-            // this triggers renewal of access token if needed. Otherwise multiple requests
-            // to renew access token are issued by every provider.getFileContent
-            const response = await providerInstance.getProviderDetails();
-
-            device = deviceStateArg
-                ? selectDeviceByState(getState(), deviceStateArg)
-                : selectDevice(getState());
-            if (!device?.state || !device?.metadata?.[METADATA.ENCRYPTION_VERSION]) return;
-
-            dispatch(syncMetadataKeys(device));
-
-            if (!response.success) {
-                dispatch(
-                    handleProviderError({
-                        error: response,
-                        action: ProviderErrorAction.LOAD,
-                        clientId: provider.clientId,
-                    }),
-                );
-
-                return;
-            }
-
-            // device is disconnected or something is wrong with it
-            if (!device?.metadata?.[METADATA.ENCRYPTION_VERSION]) {
-                if (fetchIntervals[device.state]) {
-                    clearInterval(fetchIntervals[device.state]);
-                    delete fetchIntervals[device.state];
-                }
-
-                return;
-            }
-
-            const labelableEntities = dispatch(getLabelableEntities(device.state));
-            const promises = labelableEntities.map(entity =>
-                dispatch(fetchMetadata({ provider, entity })).then(result => {
-                    if (result) {
-                        dispatch(setMetadata({ ...result, provider }));
-                    }
-                }),
-            );
-            await Promise.all(promises);
-        } catch (error) {
-            // This handles cases of providers that do not support token renewal.
-            // We want those to work normally as long as their short-lived token allows. And only if
-            // it expires, we want them to silently disconnect provider, keep metadata in place.
-            // So that users will not notice that token expired until they will try to add or edit
-            // already existing label
-            if (device?.state && fetchIntervals[device.state]) {
-                return dispatch(
-                    disconnectProvider({
-                        removeMetadata: false,
-                        dataType: 'labels',
-                        clientId: provider.clientId,
-                    }),
-                );
-            }
-            // If there is no interval set, it means that error occurred in the first fetch
-            // in such case, display error notification
-            dispatch(
-                handleProviderError({
-                    error,
-                    action: ProviderErrorAction.LOAD,
-                    clientId: provider.clientId,
-                }),
-            );
-        }
-    };
-
-export const fetchAndSaveMetadataForAllDevices = () => (dispatch: Dispatch, getState: GetState) => {
-    const metadata = selectMetadata(getState());
-    if (!metadata.enabled) {
-        return;
-    }
-    const devices = selectDevices(getState());
-    devices.forEach(device => {
-        if (!device.state || !device.metadata[METADATA.ENCRYPTION_VERSION]) return;
-        dispatch(fetchAndSaveMetadata(device.state));
-    });
-};
-
-export const selectProvider =
-    ({ dataType, clientId }: { dataType: DataType; clientId: string }) =>
-    (dispatch: Dispatch) => {
-        dispatch({
-            type: METADATA.SET_SELECTED_PROVIDER,
-            payload: {
-                dataType,
-                clientId,
-            },
-        });
-    };
-
-export const connectProvider =
-    ({
-        type,
-        dataType = 'labels',
-        clientId,
-    }: {
-        type: MetadataProviderType;
-        dataType?: DataType;
-        clientId?: string;
-    }) =>
-    async (dispatch: Dispatch, getState: GetState) => {
-        const providerInstance = createProviderInstance(
-            type,
-            {},
-            getState().suite.settings.debug.oauthServerEnvironment,
-            clientId,
-        );
-
-        const isConnected = await providerInstance.isConnected();
-        if (!isConnected) {
-            const connectionResult = await providerInstance.connect();
-            if ('error' in connectionResult) {
-                return connectionResult.error;
-            }
-        }
-
-        const providerDetails = await providerInstance.getProviderDetails();
-        if (!providerDetails.success) {
-            dispatch(
-                handleProviderError({
-                    error: providerDetails,
-                    action: ProviderErrorAction.CONNECT,
-                    clientId: providerInstance.clientId,
-                }),
-            );
-            return;
-        }
-
-        dispatch({
-            type: METADATA.ADD_PROVIDER,
-            payload: {
-                ...providerDetails.payload,
-                data: {},
-            },
-        });
-
-        analytics.report({
-            type: EventType.SettingsGeneralLabelingProvider,
-            payload: {
-                provider: providerDetails.payload.type,
-            },
-        });
-
-        dispatch(selectProvider({ dataType, clientId: providerInstance.clientId }));
-
-        return true;
-    };
-
-const encryptAndSaveMetadata =
-    ({
-        data,
+export const encryptAndSaveMetadata = async ({
+    data,
+    aesKey,
+    fileName,
+    providerInstance,
+}: {
+    data: AccountLabels | WalletLabels;
+    aesKey: string;
+    fileName: string;
+    providerInstance: AbstractMetadataProvider;
+}) => {
+    const encrypted = await metadataUtils.encrypt(
+        {
+            version: METADATA.FORMAT_VERSION,
+            ...data,
+        },
         aesKey,
-        fileName,
-        provider,
-    }: {
-        data: AccountLabels | WalletLabels;
-        aesKey: string;
-        fileName: string;
-        provider: MetadataProvider;
-    }) =>
-    async (dispatch: Dispatch) => {
-        const providerInstance = dispatch(
-            getProviderInstance({ clientId: provider.clientId, dataType: 'labels' }),
-        );
+    );
 
-        if (!providerInstance) {
-            // provider should always be set here
-            return Promise.resolve({ success: false, error: 'no provider instance' });
-        }
-
-        const encrypted = await metadataUtils.encrypt(
-            {
-                version: METADATA.FORMAT_VERSION,
-                ...data,
-            },
-            aesKey,
-        );
-
-        return providerInstance.setFileContent(fileName, encrypted);
-    };
-
-export const addDeviceMetadata =
-    (payload: Extract<MetadataAddPayload, { type: 'walletLabel' }>) =>
-    (dispatch: Dispatch, getState: GetState) => {
-        const devices = selectDevices(getState());
-        const device = devices.find(d => d.state === payload.entityKey);
-        const provider = selectSelectedProviderForLabels(getState());
-
-        if (!provider)
-            return Promise.resolve({
-                success: false,
-                error: 'provider missing',
-            });
-
-        const { fileName, aesKey } = device?.metadata[METADATA.ENCRYPTION_VERSION] || {};
-        if (!fileName || !aesKey) {
-            return Promise.resolve({
-                success: false,
-                error: `fileName or aesKey is missing for device ${device?.state}`,
-            });
-        }
-
-        // todo: not danger overwrite empty?
-        const metadata = fileName ? provider.data[fileName] : undefined;
-
-        const nextMetadata = cloneObject(
-            metadata ?? METADATA.DEFAULT_WALLET_METADATA,
-        ) as WalletLabels;
-
-        const walletLabel =
-            typeof payload.value === 'string' && payload.value.length > 0
-                ? payload.value
-                : undefined;
-
-        nextMetadata.walletLabel = walletLabel;
-
-        dispatch(
-            setMetadata({
-                provider,
-                fileName,
-                data: nextMetadata,
-            }),
-        );
-
-        return dispatch(
-            encryptAndSaveMetadata({
-                data: { walletLabel },
-                aesKey,
-                fileName,
-
-                provider,
-            }),
-        );
-    };
-
-/**
- * @param payload - metadata payload
- * @param save - should metadata be saved into persistent storage? this is useful when you are updating multiple records
- *               in a single account you may want to set "save" param to true only for the last call
- */
-export const addAccountMetadata =
-    (payload: Exclude<MetadataAddPayload, { type: 'walletLabel' }>, save = true) =>
-    (dispatch: Dispatch, getState: GetState) => {
-        const account = getState().wallet.accounts.find(a => a.key === payload.entityKey);
-        const provider = selectSelectedProviderForLabels(getState());
-
-        if (!account || !provider)
-            return Promise.resolve({ success: false, error: 'account or provider missing' });
-
-        // todo: not danger overwrite empty?
-        const { fileName, aesKey } = account.metadata?.[METADATA.ENCRYPTION_VERSION] || {};
-
-        if (!fileName || !aesKey) {
-            return Promise.resolve({
-                success: false,
-                error: `filename of version ${METADATA.ENCRYPTION_VERSION} does not exist for account ${account.path}`,
-            });
-        }
-        const data = provider.data[fileName];
-
-        const nextMetadata = cloneObject(
-            data ?? METADATA.DEFAULT_ACCOUNT_METADATA,
-        ) as AccountLabels;
-
-        if (payload.type === 'outputLabel') {
-            if (typeof payload.value !== 'string' || payload.value.length === 0) {
-                if (!nextMetadata.outputLabels[payload.txid]) {
-                    // If we try to delete already deleted label it's ok.
-                    // No problem happened. ¯\_ (ツ)_/¯
-
-                    return Promise.resolve({ success: true });
-                }
-
-                delete nextMetadata.outputLabels[payload.txid][payload.outputIndex];
-                if (Object.keys(nextMetadata.outputLabels[payload.txid]).length === 0) {
-                    delete nextMetadata.outputLabels[payload.txid];
-                }
-            } else {
-                if (!nextMetadata.outputLabels[payload.txid]) {
-                    nextMetadata.outputLabels[payload.txid] = {};
-                }
-
-                nextMetadata.outputLabels[payload.txid][payload.outputIndex] = payload.value;
-
-                // 2.0.0
-                // metadata.outputLabels[payload.txid][payload.outputIndex] = {
-                //     ts,
-                //     value: payload.value,
-                // };
-            }
-        }
-
-        if (payload.type === 'addressLabel') {
-            if (typeof payload.value !== 'string' || payload.value.length === 0) {
-                delete nextMetadata.addressLabels[payload.defaultValue];
-            } else {
-                nextMetadata.addressLabels[payload.defaultValue] = payload.value;
-            }
-        }
-
-        if (payload.type === 'accountLabel') {
-            if (typeof payload.value !== 'string' || payload.value.length === 0) {
-                delete nextMetadata.accountLabel;
-            } else {
-                nextMetadata.accountLabel = payload.value;
-            }
-        }
-
-        dispatch(
-            setMetadata({
-                fileName,
-                provider,
-                data: nextMetadata,
-            }),
-        );
-
-        // we might intentionally skip saving metadata content to persistent storage.
-        if (!save) return Promise.resolve({ success: true });
-
-        return dispatch(
-            encryptAndSaveMetadata({
-                data: {
-                    accountLabel: nextMetadata.accountLabel,
-                    outputLabels: nextMetadata.outputLabels,
-                    addressLabels: nextMetadata.addressLabels,
-                },
-                aesKey,
-                fileName,
-                provider,
-            }),
-        );
-    };
-
-/**
- * Generate device master-key
- * */
-export const setDeviceMetadataKey =
-    (device: TrezorDevice, encryptionVersion = METADATA.ENCRYPTION_VERSION) =>
-    async (dispatch: Dispatch, getState: GetState) => {
-        if (!device.state || !device.connected) return;
-
-        const result = await TrezorConnect.cipherKeyValue({
-            device: {
-                path: device.path,
-                state: device.state,
-                instance: device.instance,
-            },
-            useEmptyPassphrase: device.useEmptyPassphrase,
-            ...METADATA.ENCRYPTION_VERSION_CONFIGS[encryptionVersion],
-        });
-
-        if (result.success) {
-            if (!getState().metadata.enabled) {
-                dispatch({
-                    type: METADATA.ENABLE,
-                });
-            }
-
-            const [stateAddress] = device.state.split('@'); // address@device_id:instance
-            const metaKey = metadataUtils.deriveMetadataKey(result.payload.value, stateAddress);
-            const fileName = metadataUtils.deriveFilenameForLabeling(metaKey, encryptionVersion);
-            const aesKey = metadataUtils.deriveAesKey(metaKey);
-
-            dispatch({
-                type: METADATA.SET_DEVICE_METADATA,
-                payload: {
-                    deviceState: device.state,
-                    metadata: {
-                        ...device.metadata,
-                        [encryptionVersion]: {
-                            fileName,
-                            aesKey,
-                            key: result.payload.value,
-                        },
-                    },
-                },
-            });
-
-            return { success: true };
-        }
-
-        return { success: false };
-    };
-
-export const addMetadata =
-    (payload: MetadataAddPayload) => (dispatch: Dispatch, getState: GetState) =>
-        (payload.type === 'walletLabel'
-            ? dispatch(addDeviceMetadata(payload))
-            : dispatch(addAccountMetadata(payload))
-        ).then(result => {
-            if (!result.success) {
-                if ('code' in result) {
-                    dispatch(
-                        handleProviderError({
-                            error: result,
-                            action: ProviderErrorAction.SAVE,
-                            clientId: selectSelectedProviderForLabels(getState())!.clientId,
-                        }),
-                    );
-                } else {
-                    const providerInstance = dispatch(
-                        getProviderInstance({
-                            clientId: selectSelectedProviderForLabels(getState())!.clientId,
-                            dataType: 'labels',
-                        }),
-                    );
-                    if (providerInstance) {
-                        dispatch(
-                            handleProviderError({
-                                error: providerInstance.error(
-                                    'OTHER_ERROR',
-                                    'error' in result ? result.error : '',
-                                ),
-                                action: ProviderErrorAction.SAVE,
-                                clientId: selectSelectedProviderForLabels(getState())!.clientId,
-                            }),
-                        );
-                    }
-                }
-            }
-
-            return result.success;
-        });
-
-/**
- * init - prepare everything needed to load + decrypt and upload + decrypt metadata. Note that this method
- * consists of number of steps of which not all have to necessarily happen. For example
- * user may directly navigate to /settings, enable metadata (by invoking init), but his device
- * does not have state yet.
- * In this case, setDeviceMetadataKey method and those that follow
- * are skipped and user will be asked again either after authorization process or when user
- * tries to add new label.
- */
-export const init =
-    (force: boolean, deviceState?: string) => async (dispatch: Dispatch, getState: GetState) => {
-        let device = deviceState
-            ? selectDeviceByState(getState(), deviceState)
-            : selectDevice(getState());
-
-        if (!device?.state) {
-            return false;
-        }
-
-        if (!force && getState().metadata.error?.[device.state]) {
-            return false;
-        }
-
-        dispatch({ type: METADATA.SET_INITIATING, payload: true });
-        if (getState().metadata.error?.[device.state]) {
-            // remove error note about failed migration potentially set in a previous run
-            dispatch({
-                type: METADATA.SET_ERROR_FOR_DEVICE,
-                payload: {
-                    deviceState: device.state,
-                    failed: false,
-                },
-            });
-        }
-
-        // 1. set metadata enabled globally
-        if (!getState().metadata.enabled) {
-            dispatch(enableMetadata());
-        }
-
-        if (!device.metadata?.[METADATA.ENCRYPTION_VERSION]) {
-            const result = await dispatch(
-                setDeviceMetadataKey(device, METADATA.ENCRYPTION_VERSION),
-            );
-            if (!result?.success) {
-                dispatch({ type: METADATA.SET_INITIATING, payload: false });
-                dispatch({ type: METADATA.SET_EDITING, payload: undefined });
-                dispatch({
-                    type: METADATA.SET_ERROR_FOR_DEVICE,
-                    payload: {
-                        deviceState: device.state!,
-                        failed: true,
-                    },
-                });
-                return false;
-            }
-        }
-
-        // 3. we have master key. use it to derive account keys
-        dispatch(syncMetadataKeys(device, METADATA.ENCRYPTION_VERSION));
-
-        device = deviceState
-            ? selectDeviceByState(getState(), deviceState)
-            : selectDevice(getState());
-
-        if (!device) return false;
-
-        // 4. connect to provider
-        if (!selectSelectedProviderForLabels(getState())) {
-            const providerResult = await dispatch(initProvider());
-            if (!providerResult) {
-                dispatch({ type: METADATA.SET_INITIATING, payload: false });
-                dispatch({ type: METADATA.SET_EDITING, payload: undefined });
-                return false;
-            }
-        }
-
-        // todo: 5. migration
-
-        // 6. fetch metadata
-        await dispatch(fetchAndSaveMetadata(device.state));
-
-        // now we may allow user to edit labels. everything is ready, local data is synced with provider
-        if (getState().metadata.initiating) {
-            dispatch({ type: METADATA.SET_INITIATING, payload: false });
-        }
-
-        // 7. if interval for watching provider is not set, create it
-        if (device.state && !fetchIntervals[device.state]) {
-            // todo: possible race condition that has been around since always
-            // user is editing label and at that very moment update arrives. updates to specific entities should be probably discarded in such case?
-            fetchIntervals[device.state] = setInterval(() => {
-                const device = selectDevice(getState());
-                if (!getState().suite.online || !device?.state) {
-                    return;
-                }
-                dispatch(fetchAndSaveMetadata(device.state));
-            }, METADATA.FETCH_INTERVAL);
-        }
-
-        return true;
-    };
-
-export const setEditing = (payload: string | undefined): MetadataAction => ({
-    type: METADATA.SET_EDITING,
-    payload,
-});
+    return providerInstance.setFileContent(fileName, encrypted);
+};

--- a/packages/suite/src/actions/suite/metadataLabelingActions.ts
+++ b/packages/suite/src/actions/suite/metadataLabelingActions.ts
@@ -1,0 +1,630 @@
+import TrezorConnect from '@trezor/connect';
+import { cloneObject } from '@trezor/utils';
+
+import { selectDevices, selectDevice, selectDeviceByState } from '@suite-common/wallet-core';
+
+import { METADATA } from 'src/actions/suite/constants';
+import { Dispatch, GetState, TrezorDevice } from 'src/types/suite';
+import {
+    MetadataProvider,
+    MetadataAddPayload,
+    ProviderErrorAction,
+    MetadataEncryptionVersion,
+    WalletLabels,
+    AccountLabels,
+} from 'src/types/suite/metadata';
+import { Account } from 'src/types/wallet';
+import * as metadataUtils from 'src/utils/suite/metadata';
+import {
+    selectLabelableEntities,
+    selectMetadata,
+    selectSelectedProviderForLabels,
+} from 'src/reducers/suite/metadataReducer';
+
+import type { MetadataAction } from './metadataActions';
+import * as metadataActions from './metadataActions';
+import * as metadataProviderActions from './metadataProviderActions';
+
+export const getLabelableEntities =
+    (deviceState: string) => (_dispatch: Dispatch, getState: GetState) =>
+        selectLabelableEntities(getState(), deviceState);
+
+type LabelableEntity = ReturnType<ReturnType<typeof getLabelableEntities>>[number];
+
+const fetchMetadata =
+    ({
+        provider,
+        entity,
+        encryptionVersion = METADATA.ENCRYPTION_VERSION,
+    }: {
+        provider: MetadataProvider;
+        entity: LabelableEntity;
+        encryptionVersion?: MetadataEncryptionVersion;
+    }) =>
+    async (dispatch: Dispatch) => {
+        const dataType = 'labels';
+
+        const providerInstance = dispatch(
+            metadataProviderActions.getProviderInstance({
+                clientId: provider.clientId,
+                dataType,
+            }),
+        );
+
+        if (!providerInstance) {
+            throw new Error('no provider instance');
+        }
+
+        const entityMetadata = entity[encryptionVersion];
+        if (!entityMetadata) {
+            throw new Error('trying to fetch entity without metadata');
+        }
+
+        const { fileName, aesKey } = entityMetadata;
+
+        const response = await providerInstance.getFileContent(fileName);
+
+        if (!response.success) {
+            throw response;
+        }
+
+        if (!response.payload) {
+            return undefined;
+        }
+
+        // we found associated metadata file for given account, decrypt it and return it
+        const decryptedData = metadataUtils.decrypt(
+            metadataUtils.arrayBufferToBuffer(response.payload),
+            aesKey,
+        );
+
+        // validation of fetched data structure. in theory, user may save any data in metadata file (although it is very unlikely)
+        // so we should make sure that it at least matches AccountLabels types
+        if (entity.type === 'account') {
+            if (!decryptedData.addressLabels) {
+                console.error('fetchMetadata: addressLabels missing in metadata file');
+                decryptedData.addressLabels = {};
+            }
+            if (!decryptedData.outputLabels) {
+                console.error('fetchMetadata: outputLabels missing in metadata file');
+                decryptedData.outputLabels = {};
+            }
+        }
+
+        return {
+            fileName,
+            data: decryptedData,
+        };
+    };
+
+export const setAccountMetadataKey =
+    (account: Account, encryptionVersion = METADATA.ENCRYPTION_VERSION) =>
+    (dispatch: Dispatch, getState: GetState) => {
+        const device = selectDeviceByState(getState(), account.deviceState);
+        const deviceMetaKey = device?.metadata[encryptionVersion]?.key;
+
+        if (!deviceMetaKey) {
+            // account keys can't be set without device keys
+            return account;
+        }
+        try {
+            const metaKey = metadataUtils.deriveMetadataKey(deviceMetaKey, account.metadata.key);
+            const fileName = metadataUtils.deriveFilenameForLabeling(metaKey, encryptionVersion);
+
+            const aesKey = metadataUtils.deriveAesKey(metaKey);
+            return {
+                ...account,
+                metadata: {
+                    ...account.metadata,
+                    [encryptionVersion]: { fileName, aesKey },
+                },
+            };
+        } catch (error) {
+            dispatch(
+                metadataProviderActions.handleProviderError({
+                    error,
+                    action: ProviderErrorAction.SAVE,
+                }),
+            );
+        }
+        return account;
+    };
+
+/**
+ * Fill any record in reducer that may have metadata with metadata keys (not values).
+ */
+const syncMetadataKeys =
+    (device: TrezorDevice, encryptionVersion = METADATA.ENCRYPTION_VERSION) =>
+    (dispatch: Dispatch, getState: GetState) => {
+        if (!device.metadata[METADATA.ENCRYPTION_VERSION]) {
+            return;
+        }
+        const targetAccounts = getState().wallet.accounts.filter(
+            acc => !acc.metadata[encryptionVersion]?.fileName && acc.deviceState === device.state,
+        );
+
+        targetAccounts.forEach(account => {
+            const accountWithMetadata = dispatch(setAccountMetadataKey(account, encryptionVersion));
+            dispatch(metadataActions.setAccountAdd(accountWithMetadata));
+        });
+        // note that devices are intentionally omitted here - device receives metadata
+        // keys sooner when enabling labeling on device;
+    };
+
+export const fetchAndSaveMetadata =
+    (deviceStateArg?: string) => async (dispatch: Dispatch, getState: GetState) => {
+        const provider = selectSelectedProviderForLabels(getState());
+        if (!provider) return;
+
+        let device = deviceStateArg
+            ? selectDeviceByState(getState(), deviceStateArg)
+            : selectDevice(getState());
+
+        if (!device?.state || !device?.metadata?.[METADATA.ENCRYPTION_VERSION]) return;
+
+        const providerInstance = dispatch(
+            metadataProviderActions.getProviderInstance({
+                clientId: provider.clientId,
+                dataType: 'labels',
+            }),
+        );
+        if (!providerInstance) {
+            return;
+        }
+
+        try {
+            // this triggers renewal of access token if needed. Otherwise multiple requests
+            // to renew access token are issued by every provider.getFileContent
+            const response = await providerInstance.getProviderDetails();
+
+            device = deviceStateArg
+                ? selectDeviceByState(getState(), deviceStateArg)
+                : selectDevice(getState());
+            if (!device?.state || !device?.metadata?.[METADATA.ENCRYPTION_VERSION]) return;
+
+            dispatch(syncMetadataKeys(device));
+
+            if (!response.success) {
+                dispatch(
+                    metadataProviderActions.handleProviderError({
+                        error: response,
+                        action: ProviderErrorAction.LOAD,
+                        clientId: provider.clientId,
+                    }),
+                );
+
+                return;
+            }
+
+            // device is disconnected or something is wrong with it
+            if (!device?.metadata?.[METADATA.ENCRYPTION_VERSION]) {
+                if (metadataProviderActions.fetchIntervals[device.state]) {
+                    clearInterval(metadataProviderActions.fetchIntervals[device.state]);
+                    delete metadataProviderActions.fetchIntervals[device.state];
+                }
+
+                return;
+            }
+
+            const labelableEntities = dispatch(getLabelableEntities(device.state));
+            const promises = labelableEntities.map(entity =>
+                dispatch(fetchMetadata({ provider, entity })).then(result => {
+                    if (result) {
+                        dispatch(metadataActions.setMetadata({ ...result, provider }));
+                    }
+                }),
+            );
+            await Promise.all(promises);
+        } catch (error) {
+            // This handles cases of providers that do not support token renewal.
+            // We want those to work normally as long as their short-lived token allows. And only if
+            // it expires, we want them to silently disconnect provider, keep metadata in place.
+            // So that users will not notice that token expired until they will try to add or edit
+            // already existing label
+            if (device?.state && metadataProviderActions.fetchIntervals[device.state]) {
+                return dispatch(
+                    metadataProviderActions.disconnectProvider({
+                        removeMetadata: false,
+                        dataType: 'labels',
+                        clientId: provider.clientId,
+                    }),
+                );
+            }
+            // If there is no interval set, it means that error occurred in the first fetch
+            // in such case, display error notification
+            dispatch(
+                metadataProviderActions.handleProviderError({
+                    error,
+                    action: ProviderErrorAction.LOAD,
+                    clientId: provider.clientId,
+                }),
+            );
+        }
+    };
+
+export const fetchAndSaveMetadataForAllDevices = () => (dispatch: Dispatch, getState: GetState) => {
+    const metadata = selectMetadata(getState());
+    if (!metadata.enabled) {
+        return;
+    }
+    const devices = selectDevices(getState());
+    devices.forEach(device => {
+        if (!device.state || !device.metadata[METADATA.ENCRYPTION_VERSION]) return;
+        dispatch(fetchAndSaveMetadata(device.state));
+    });
+};
+
+export const addDeviceMetadata =
+    (payload: Extract<MetadataAddPayload, { type: 'walletLabel' }>) =>
+    (dispatch: Dispatch, getState: GetState) => {
+        const devices = selectDevices(getState());
+        const device = devices.find(d => d.state === payload.entityKey);
+        const provider = selectSelectedProviderForLabels(getState());
+
+        if (!provider)
+            return Promise.resolve({
+                success: false as const,
+                error: 'provider missing',
+            });
+
+        const { fileName, aesKey } = device?.metadata[METADATA.ENCRYPTION_VERSION] || {};
+        if (!fileName || !aesKey) {
+            return Promise.resolve({
+                success: false as const,
+                error: `fileName or aesKey is missing for device ${device?.state}`,
+            });
+        }
+
+        // todo: not danger overwrite empty?
+        const metadata = fileName ? provider.data[fileName] : undefined;
+
+        const nextMetadata = cloneObject(
+            metadata ?? METADATA.DEFAULT_WALLET_METADATA,
+        ) as WalletLabels;
+
+        const walletLabel =
+            typeof payload.value === 'string' && payload.value.length > 0
+                ? payload.value
+                : undefined;
+
+        nextMetadata.walletLabel = walletLabel;
+
+        dispatch(
+            metadataActions.setMetadata({
+                provider,
+                fileName,
+                data: nextMetadata,
+            }),
+        );
+
+        const providerInstance = dispatch(
+            metadataProviderActions.getProviderInstance({
+                clientId: selectSelectedProviderForLabels(getState())!.clientId,
+                dataType: 'labels',
+            }),
+        );
+        if (!providerInstance) {
+            // provider should always be set here
+            return Promise.resolve({ success: false as const, error: 'no provider instance' });
+        }
+
+        return metadataActions.encryptAndSaveMetadata({
+            data: { walletLabel },
+            aesKey,
+            fileName,
+            providerInstance,
+        });
+    };
+
+/**
+ * @param payload - metadata payload
+ * @param save - should metadata be saved into persistent storage? this is useful when you are updating multiple records
+ *               in a single account you may want to set "save" param to true only for the last call
+ */
+export const addAccountMetadata =
+    (payload: Exclude<MetadataAddPayload, { type: 'walletLabel' }>, save = true) =>
+    (dispatch: Dispatch, getState: GetState) => {
+        const account = getState().wallet.accounts.find(a => a.key === payload.entityKey);
+        const provider = selectSelectedProviderForLabels(getState());
+
+        if (!account || !provider) {
+            return Promise.resolve({
+                success: false as const,
+                error: 'account or provider missing',
+            });
+        }
+
+        // todo: not danger overwrite empty?
+        const { fileName, aesKey } = account.metadata?.[METADATA.ENCRYPTION_VERSION] || {};
+
+        if (!fileName || !aesKey) {
+            return Promise.resolve({
+                success: false as const,
+                error: `filename of version ${METADATA.ENCRYPTION_VERSION} does not exist for account ${account.path}`,
+            });
+        }
+        const data = provider.data[fileName];
+
+        const nextMetadata = cloneObject(
+            data ?? METADATA.DEFAULT_ACCOUNT_METADATA,
+        ) as AccountLabels;
+
+        if (payload.type === 'outputLabel') {
+            if (typeof payload.value !== 'string' || payload.value.length === 0) {
+                if (!nextMetadata.outputLabels[payload.txid]) {
+                    // If we try to delete already deleted label it's ok.
+                    // No problem happened. ¯\_ (ツ)_/¯
+
+                    return Promise.resolve({ success: true as const });
+                }
+
+                delete nextMetadata.outputLabels[payload.txid][payload.outputIndex];
+                if (Object.keys(nextMetadata.outputLabels[payload.txid]).length === 0) {
+                    delete nextMetadata.outputLabels[payload.txid];
+                }
+            } else {
+                if (!nextMetadata.outputLabels[payload.txid]) {
+                    nextMetadata.outputLabels[payload.txid] = {};
+                }
+
+                nextMetadata.outputLabels[payload.txid][payload.outputIndex] = payload.value;
+
+                // 2.0.0
+                // metadata.outputLabels[payload.txid][payload.outputIndex] = {
+                //     ts,
+                //     value: payload.value,
+                // };
+            }
+        }
+
+        if (payload.type === 'addressLabel') {
+            if (typeof payload.value !== 'string' || payload.value.length === 0) {
+                delete nextMetadata.addressLabels[payload.defaultValue];
+            } else {
+                nextMetadata.addressLabels[payload.defaultValue] = payload.value;
+            }
+        }
+
+        if (payload.type === 'accountLabel') {
+            if (typeof payload.value !== 'string' || payload.value.length === 0) {
+                delete nextMetadata.accountLabel;
+            } else {
+                nextMetadata.accountLabel = payload.value;
+            }
+        }
+
+        dispatch(
+            metadataActions.setMetadata({
+                fileName,
+                provider,
+                data: nextMetadata,
+            }),
+        );
+
+        // we might intentionally skip saving metadata content to persistent storage.
+        if (!save) {
+            return Promise.resolve({ success: true as const });
+        }
+
+        const providerInstance = dispatch(
+            metadataProviderActions.getProviderInstance({
+                clientId: selectSelectedProviderForLabels(getState())!.clientId,
+                dataType: 'labels',
+            }),
+        );
+        if (!providerInstance) {
+            // provider should always be set here
+            return Promise.resolve({ success: false as const, error: 'no provider instance' });
+        }
+
+        return metadataActions.encryptAndSaveMetadata({
+            data: {
+                accountLabel: nextMetadata.accountLabel,
+                outputLabels: nextMetadata.outputLabels,
+                addressLabels: nextMetadata.addressLabels,
+            },
+            aesKey,
+            fileName,
+            providerInstance,
+        });
+    };
+
+/**
+ * Generate device master-key
+ * */
+export const setDeviceMetadataKey =
+    (device: TrezorDevice, encryptionVersion = METADATA.ENCRYPTION_VERSION) =>
+    async (dispatch: Dispatch, getState: GetState) => {
+        if (!device.state || !device.connected) return;
+
+        const result = await TrezorConnect.cipherKeyValue({
+            device: {
+                path: device.path,
+                state: device.state,
+                instance: device.instance,
+            },
+            useEmptyPassphrase: device.useEmptyPassphrase,
+            ...METADATA.ENCRYPTION_VERSION_CONFIGS[encryptionVersion],
+        });
+
+        if (result.success) {
+            if (!getState().metadata.enabled) {
+                dispatch({
+                    type: METADATA.ENABLE,
+                });
+            }
+
+            const [stateAddress] = device.state.split('@'); // address@device_id:instance
+            const metaKey = metadataUtils.deriveMetadataKey(result.payload.value, stateAddress);
+            const fileName = metadataUtils.deriveFilenameForLabeling(metaKey, encryptionVersion);
+            const aesKey = metadataUtils.deriveAesKey(metaKey);
+
+            dispatch({
+                type: METADATA.SET_DEVICE_METADATA,
+                payload: {
+                    deviceState: device.state,
+                    metadata: {
+                        ...device.metadata,
+                        [encryptionVersion]: {
+                            fileName,
+                            aesKey,
+                            key: result.payload.value,
+                        },
+                    },
+                },
+            });
+
+            return { success: true };
+        }
+
+        return { success: false };
+    };
+
+export const addMetadata =
+    (payload: MetadataAddPayload) => (dispatch: Dispatch, getState: GetState) =>
+        (payload.type === 'walletLabel'
+            ? dispatch(addDeviceMetadata(payload))
+            : dispatch(addAccountMetadata(payload))
+        ).then(result => {
+            if (!result.success) {
+                if ('code' in result) {
+                    console.log(result.code);
+                    dispatch(
+                        metadataProviderActions.handleProviderError({
+                            error: result,
+                            action: ProviderErrorAction.SAVE,
+                            clientId: selectSelectedProviderForLabels(getState())!.clientId,
+                        }),
+                    );
+                } else {
+                    const providerInstance = dispatch(
+                        metadataProviderActions.getProviderInstance({
+                            clientId: selectSelectedProviderForLabels(getState())!.clientId,
+                            dataType: 'labels',
+                        }),
+                    );
+                    if (providerInstance) {
+                        dispatch(
+                            metadataProviderActions.handleProviderError({
+                                error: providerInstance.error(
+                                    'OTHER_ERROR',
+                                    'error' in result ? result.error : '',
+                                ),
+                                action: ProviderErrorAction.SAVE,
+                                clientId: selectSelectedProviderForLabels(getState())!.clientId,
+                            }),
+                        );
+                    }
+                }
+            }
+
+            return result.success;
+        });
+
+/**
+ * init - prepare everything needed to load + decrypt and upload + decrypt metadata. Note that this method
+ * consists of number of steps of which not all have to necessarily happen. For example
+ * user may directly navigate to /settings, enable metadata (by invoking init), but his device
+ * does not have state yet.
+ * In this case, setDeviceMetadataKey method and those that follow
+ * are skipped and user will be asked again either after authorization process or when user
+ * tries to add new label.
+ */
+export const init =
+    (force: boolean, deviceState?: string) => async (dispatch: Dispatch, getState: GetState) => {
+        let device = deviceState
+            ? selectDeviceByState(getState(), deviceState)
+            : selectDevice(getState());
+
+        if (!device?.state) {
+            return false;
+        }
+
+        if (!force && getState().metadata.error?.[device.state]) {
+            return false;
+        }
+
+        dispatch({ type: METADATA.SET_INITIATING, payload: true });
+        if (getState().metadata.error?.[device.state]) {
+            // remove error note about failed migration potentially set in a previous run
+            dispatch({
+                type: METADATA.SET_ERROR_FOR_DEVICE,
+                payload: {
+                    deviceState: device.state,
+                    failed: false,
+                },
+            });
+        }
+
+        // 1. set metadata enabled globally
+        if (!getState().metadata.enabled) {
+            dispatch(metadataActions.enableMetadata());
+        }
+
+        if (!device.metadata?.[METADATA.ENCRYPTION_VERSION]) {
+            const result = await dispatch(
+                setDeviceMetadataKey(device, METADATA.ENCRYPTION_VERSION),
+            );
+            if (!result?.success) {
+                dispatch({ type: METADATA.SET_INITIATING, payload: false });
+                dispatch({ type: METADATA.SET_EDITING, payload: undefined });
+                dispatch({
+                    type: METADATA.SET_ERROR_FOR_DEVICE,
+                    payload: {
+                        deviceState: device.state!,
+                        failed: true,
+                    },
+                });
+                return false;
+            }
+        }
+
+        // 3. we have master key. use it to derive account keys
+        dispatch(syncMetadataKeys(device, METADATA.ENCRYPTION_VERSION));
+
+        device = deviceState
+            ? selectDeviceByState(getState(), deviceState)
+            : selectDevice(getState());
+
+        if (!device) return false;
+
+        // 4. connect to provider
+        if (!selectSelectedProviderForLabels(getState())) {
+            const providerResult = await dispatch(metadataProviderActions.initProvider());
+            if (!providerResult) {
+                dispatch({ type: METADATA.SET_INITIATING, payload: false });
+                dispatch({ type: METADATA.SET_EDITING, payload: undefined });
+                return false;
+            }
+        }
+
+        // todo: 5. migration
+
+        // 6. fetch metadata
+        await dispatch(fetchAndSaveMetadata(device.state));
+
+        // now we may allow user to edit labels. everything is ready, local data is synced with provider
+        if (getState().metadata.initiating) {
+            dispatch({ type: METADATA.SET_INITIATING, payload: false });
+        }
+
+        // 7. if interval for watching provider is not set, create it
+        if (device.state && !metadataProviderActions.fetchIntervals[device.state]) {
+            // todo: possible race condition that has been around since always
+            // user is editing label and at that very moment update arrives. updates to specific entities should be probably discarded in such case?
+            metadataProviderActions.fetchIntervals[device.state] = setInterval(() => {
+                const device = selectDevice(getState());
+                if (!getState().suite.online || !device?.state) {
+                    return;
+                }
+                dispatch(fetchAndSaveMetadata(device.state));
+            }, METADATA.FETCH_INTERVAL);
+        }
+
+        return true;
+    };
+
+export const setEditing = (payload: string | undefined): MetadataAction => ({
+    type: METADATA.SET_EDITING,
+    payload,
+});

--- a/packages/suite/src/actions/suite/metadataPasswordsActions.ts
+++ b/packages/suite/src/actions/suite/metadataPasswordsActions.ts
@@ -1,0 +1,64 @@
+import { METADATA } from 'src/actions/suite/constants';
+import { Dispatch, GetState } from 'src/types/suite';
+import { ProviderErrorAction } from 'src/types/suite/metadata';
+import * as metadataUtils from 'src/utils/suite/metadata';
+
+import * as metadataProviderActions from './metadataProviderActions';
+
+export const fetchPasswords =
+    (fileName: string, key: Buffer) => async (dispatch: Dispatch, _getState: GetState) => {
+        const provider = dispatch(
+            metadataProviderActions.getProviderInstance({
+                clientId: METADATA.DROPBOX_PASSWORDS_CLIENT_ID,
+                dataType: 'passwords',
+            }),
+        );
+        if (!provider) {
+            return;
+        }
+
+        // this triggers renewal of access token if needed. Otherwise multiple requests
+        // to renew access token are issued by every provider.getFileContent
+        const response = await provider.getProviderDetails();
+        if (!response.success) {
+            return dispatch(
+                metadataProviderActions.handleProviderError({
+                    error: response,
+                    action: ProviderErrorAction.LOAD,
+                    clientId: provider.clientId,
+                }),
+            );
+        }
+
+        return new Promise<void>((resolve, reject) =>
+            provider.getFileContent(fileName).then(result => {
+                if (!result.success) {
+                    return reject(result);
+                }
+
+                if (result.payload) {
+                    try {
+                        const decrypted = metadataUtils.decrypt(
+                            metadataUtils.arrayBufferToBuffer(result.payload),
+                            key,
+                        );
+
+                        dispatch({
+                            type: METADATA.SET_DATA,
+                            payload: {
+                                provider,
+                                data: {
+                                    [fileName]: decrypted,
+                                },
+                            },
+                        });
+                    } catch (err) {
+                        const error = provider.error('OTHER_ERROR', err.message);
+                        return reject(error);
+                    }
+                }
+
+                resolve();
+            }),
+        );
+    };

--- a/packages/suite/src/actions/suite/metadataProviderActions.ts
+++ b/packages/suite/src/actions/suite/metadataProviderActions.ts
@@ -1,0 +1,281 @@
+import { analytics, EventType } from '@trezor/suite-analytics';
+import { createDeferred } from '@trezor/utils';
+import { notificationsActions } from '@suite-common/toast-notifications';
+
+import { METADATA } from 'src/actions/suite/constants';
+import { Dispatch, GetState } from 'src/types/suite';
+import {
+    MetadataProviderType,
+    MetadataProvider,
+    Tokens,
+    Error as MetadataProviderError,
+    OAuthServerEnvironment,
+    ProviderErrorAction,
+    DataType,
+} from 'src/types/suite/metadata';
+import * as modalActions from 'src/actions/suite/modalActions';
+import DropboxProvider from 'src/services/suite/metadata/DropboxProvider';
+import GoogleProvider from 'src/services/suite/metadata/GoogleProvider';
+import FileSystemProvider from 'src/services/suite/metadata/FileSystemProvider';
+import { InMemoryTestProvider } from '../../services/suite/metadata/InMemoryTestProvider';
+
+import * as metadataActions from './metadataActions';
+
+export type MetadataAction = {
+    type: typeof METADATA.SET_SELECTED_PROVIDER;
+    payload: {
+        dataType: DataType;
+        clientId: string;
+    };
+};
+
+export type ProviderInstance =
+    | DropboxProvider
+    | GoogleProvider
+    | FileSystemProvider
+    | InMemoryTestProvider;
+
+// needs to be declared here in top level context because it's not recommended to keep classes instances in redux state (serialization)
+export const providerInstance: Record<DataType, ProviderInstance | undefined> = {
+    labels: undefined,
+    passwords: undefined,
+};
+
+export const fetchIntervals: { [deviceState: string]: any } = {}; // any because of native at the moment, otherwise number | undefined
+
+const createProviderInstance = (
+    type: MetadataProvider['type'],
+    tokens: Tokens = {},
+    environment: OAuthServerEnvironment = 'production',
+    clientId?: string,
+) => {
+    // eslint-disable-next-line default-case
+    switch (type) {
+        case 'dropbox':
+            return new DropboxProvider({
+                token: tokens?.refreshToken,
+                clientId: clientId || METADATA.DROPBOX_CLIENT_ID,
+            });
+        case 'google':
+            return new GoogleProvider(tokens, environment);
+        case 'fileSystem':
+            return new FileSystemProvider();
+        case 'inMemoryTest':
+            return new InMemoryTestProvider();
+    }
+};
+
+/**
+ * Return already existing instance of AbstractProvider or recreate it from token;
+ */
+export const getProviderInstance =
+    ({ clientId, dataType = 'labels' }: { clientId: string; dataType: DataType }) =>
+    (_dispatch: Dispatch, getState: GetState) => {
+        const state = getState();
+        const { providers } = state.metadata;
+
+        const provider = providers.find(p => p.clientId === clientId);
+
+        if (!provider) return;
+
+        // instance already exists but user did not finish log in and decided to use another provider;
+        if (providerInstance[dataType] && providerInstance[dataType]?.type !== provider.type) {
+            providerInstance[dataType] = undefined;
+        }
+
+        if (providerInstance[dataType]) return providerInstance[dataType];
+
+        providerInstance[dataType] = createProviderInstance(
+            provider.type,
+            provider.tokens,
+            state.suite.settings.debug.oauthServerEnvironment,
+            clientId,
+        );
+
+        return providerInstance[dataType];
+    };
+
+export const disconnectProvider =
+    ({
+        clientId,
+        dataType,
+        removeMetadata = true,
+    }: {
+        clientId: string;
+        dataType: DataType;
+        removeMetadata?: boolean;
+    }) =>
+    async (dispatch: Dispatch) => {
+        Object.values(fetchIntervals).forEach((deviceState, num) => {
+            clearInterval(num);
+            delete fetchIntervals[deviceState];
+        });
+
+        // dispose metadata values (not keys)
+        if (removeMetadata) {
+            dispatch(metadataActions.disposeMetadata());
+        }
+
+        const provider = dispatch(getProviderInstance({ clientId, dataType }));
+
+        if (provider) {
+            await provider.disconnect();
+            providerInstance[dataType] = undefined;
+        }
+        // flush reducer
+        dispatch({
+            type: METADATA.REMOVE_PROVIDER,
+            payload: provider,
+        });
+        dispatch({
+            type: METADATA.SET_SELECTED_PROVIDER,
+            payload: { dataType, clientId: undefined },
+        });
+
+        analytics.report({
+            type: EventType.SettingsGeneralLabelingProvider,
+            payload: {
+                provider: '',
+            },
+        });
+    };
+
+/**
+ * handleProviderError method controls how application reacts to various errors from metadata providers
+ * Toasts go in this format:
+ * Error: <Action>: <Reason>
+ * Error: Upload failed: Access token is invalid
+ */
+export const handleProviderError =
+    ({
+        error,
+        action,
+        clientId,
+    }: {
+        error: MetadataProviderError;
+        action: string;
+        clientId?: string;
+    }) =>
+    (dispatch: Dispatch) => {
+        // error should be of specified type, but in case it is not (catch is not typed) show generic error
+        // if this happens, it means that there is a hole in error handling and it should be fixed
+        const toastError = error.code
+            ? `${action}: ${error?.error}`
+            : `Labeling action failed. ${error}`;
+
+        dispatch(
+            notificationsActions.addToast({
+                type: 'error',
+                error: toastError,
+            }),
+        );
+
+        if (clientId) {
+            // handle nicely wrapped errors here
+            switch (error.code) {
+                // possibly programmer errors
+                // something is screwed up, we don't really know what.
+                // react by disabling all metadata and toasting error;
+                case 'ACCESS_ERROR':
+                case 'BAD_INPUT_ERROR':
+                case 'OTHER_ERROR':
+                    dispatch(metadataActions.disposeMetadata());
+                    dispatch(
+                        disconnectProvider({
+                            clientId,
+                            dataType: 'labels',
+                        }),
+                    );
+                    break;
+                case 'PROVIDER_ERROR':
+                case 'RATE_LIMIT_ERROR':
+                case 'AUTH_ERROR':
+                    dispatch(
+                        disconnectProvider({
+                            clientId,
+                            dataType: 'labels',
+                        }),
+                    );
+                    break;
+                case 'CONNECTIVITY_ERROR':
+                default:
+                    break;
+            }
+        }
+    };
+
+export const initProvider = () => (dispatch: Dispatch) => {
+    const decision = createDeferred<boolean>();
+    dispatch(modalActions.openModal({ type: 'metadata-provider', decision }));
+    return decision.promise;
+};
+
+export const selectProvider =
+    ({ dataType, clientId }: { dataType: DataType; clientId: string }) =>
+    (dispatch: Dispatch) => {
+        dispatch({
+            type: METADATA.SET_SELECTED_PROVIDER,
+            payload: {
+                dataType,
+                clientId,
+            },
+        });
+    };
+
+export const connectProvider =
+    ({
+        type,
+        dataType = 'labels',
+        clientId,
+    }: {
+        type: MetadataProviderType;
+        dataType?: DataType;
+        clientId?: string;
+    }) =>
+    async (dispatch: Dispatch, getState: GetState) => {
+        const providerInstance = createProviderInstance(
+            type,
+            {},
+            getState().suite.settings.debug.oauthServerEnvironment,
+            clientId,
+        );
+
+        const isConnected = await providerInstance.isConnected();
+        if (!isConnected) {
+            const connectionResult = await providerInstance.connect();
+            if ('error' in connectionResult) {
+                return connectionResult.error;
+            }
+        }
+
+        const providerDetails = await providerInstance.getProviderDetails();
+        if (!providerDetails.success) {
+            dispatch(
+                handleProviderError({
+                    error: providerDetails,
+                    action: ProviderErrorAction.CONNECT,
+                    clientId: providerInstance.clientId,
+                }),
+            );
+            return;
+        }
+
+        dispatch({
+            type: METADATA.ADD_PROVIDER,
+            payload: {
+                ...providerDetails.payload,
+                data: {},
+            },
+        });
+
+        analytics.report({
+            type: EventType.SettingsGeneralLabelingProvider,
+            payload: {
+                provider: providerDetails.payload.type,
+            },
+        });
+
+        dispatch(selectProvider({ dataType, clientId: providerInstance.clientId }));
+
+        return true;
+    };

--- a/packages/suite/src/actions/wallet/moveLabelsForRbfActions.ts
+++ b/packages/suite/src/actions/wallet/moveLabelsForRbfActions.ts
@@ -1,7 +1,7 @@
 import { selectLabelingDataForAccount } from '../../reducers/suite/metadataReducer';
 import { findChainedTransactions, findTransactions } from '@suite-common/wallet-utils';
 import { Dispatch, GetState } from 'src/types/suite';
-import * as metadataActions from 'src/actions/suite/metadataActions';
+import * as metadataLabelingActions from 'src/actions/suite/metadataLabelingActions';
 import { AccountLabels, AccountOutputLabels } from '@suite-common/metadata-types';
 import { AccountKey, WalletAccountTransaction } from '@suite-common/wallet-types';
 
@@ -22,7 +22,7 @@ const deleteDanglingLabels = async ({
     for (const outputIndex of Object.keys(labels)) {
         // eslint-disable-next-line no-await-in-loop
         await dispatch(
-            metadataActions.addMetadata({
+            metadataLabelingActions.addMetadata({
                 type: 'outputLabel',
                 entityKey: accountKey,
                 txid,
@@ -52,7 +52,7 @@ export const copyLabelToNewTransaction = async ({
         const value = accountOutputLabels[outputIndex];
         // eslint-disable-next-line no-await-in-loop
         await dispatch(
-            metadataActions.addMetadata({
+            metadataLabelingActions.addMetadata({
                 type: 'outputLabel',
                 entityKey: accountKey,
                 txid: newTxid,

--- a/packages/suite/src/actions/wallet/sendFormActions.ts
+++ b/packages/suite/src/actions/wallet/sendFormActions.ts
@@ -29,7 +29,7 @@ import {
 import { cloneObject, getSynchronize } from '@trezor/utils';
 
 import * as modalActions from 'src/actions/suite/modalActions';
-import * as metadataActions from 'src/actions/suite/metadataActions';
+import * as metadataLabelingActions from 'src/actions/suite/metadataLabelingActions';
 import { SEND } from 'src/actions/wallet/constants';
 import { Dispatch, GetState } from 'src/types/suite';
 import { Account } from 'src/types/wallet';
@@ -360,7 +360,7 @@ const pushTransaction =
                         const isLast = index === arr.length - 1;
 
                         synchronize(() =>
-                            dispatch(metadataActions.addAccountMetadata(output, isLast)),
+                            dispatch(metadataLabelingActions.addAccountMetadata(output, isLast)),
                         );
                     });
             }

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import { Button, Icon, useTheme } from '@trezor/components';
 import { useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
-import { addMetadata, init, setEditing } from 'src/actions/suite/metadataActions';
+import { addMetadata, init, setEditing } from 'src/actions/suite/metadataLabelingActions';
 import { MetadataAddPayload } from 'src/types/suite/metadata';
 import { Translation } from 'src/components/suite';
 import { Props, ExtendedProps, DropdownMenuItem } from './definitions';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MetadataProviderModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MetadataProviderModal.tsx
@@ -4,7 +4,7 @@ import { P, Button, variables } from '@trezor/components';
 
 import { Translation, Modal } from 'src/components/suite';
 import { useDispatch } from 'src/hooks/suite';
-import { connectProvider } from 'src/actions/suite/metadataActions';
+import { connectProvider } from 'src/actions/suite/metadataProviderActions';
 import type { Deferred } from '@trezor/utils';
 import { MetadataProviderType } from 'src/types/suite/metadata';
 import { isFeatureFlagEnabled } from '@suite-common/suite-utils';

--- a/packages/suite/src/hooks/suite/usePasswords.ts
+++ b/packages/suite/src/hooks/suite/usePasswords.ts
@@ -5,7 +5,8 @@ import TrezorConnect from '@trezor/connect';
 import { selectDevice } from '@suite-common/wallet-core';
 
 import { useSelector, useDispatch } from 'src/hooks/suite';
-import * as metadataActions from 'src/actions/suite/metadataActions';
+import * as metadataProviderActions from 'src/actions/suite/metadataProviderActions';
+import * as metadataPasswordsActions from 'src/actions/suite/metadataPasswordsActions';
 import type { PasswordManagerState } from 'src/types/suite/metadata';
 import { METADATA } from 'src/actions/suite/constants';
 import {
@@ -80,7 +81,7 @@ export const usePasswords = () => {
 
                 if (!selectedProvider) {
                     await dispatch(
-                        metadataActions.connectProvider({
+                        metadataProviderActions.connectProvider({
                             type: 'dropbox',
                             dataType: 'passwords',
                             clientId: METADATA.DROPBOX_PASSWORDS_CLIENT_ID,
@@ -89,7 +90,7 @@ export const usePasswords = () => {
                 }
 
                 setFetchingPasswords(true);
-                await dispatch(metadataActions.fetchPasswords(fname, encryptionKey));
+                await dispatch(metadataPasswordsActions.fetchPasswords(fname, encryptionKey));
                 setFetchingPasswords(false);
             })
             .finally(() => {
@@ -100,7 +101,7 @@ export const usePasswords = () => {
     const disconnect = () => {
         if (!selectedProvider) return;
         dispatch(
-            metadataActions.disconnectProvider({
+            metadataProviderActions.disconnectProvider({
                 clientId: selectedProvider.clientId,
                 dataType: 'passwords',
                 removeMetadata: false,

--- a/packages/suite/src/middlewares/suite/metadataMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/metadataMiddleware.ts
@@ -2,7 +2,7 @@ import { MiddlewareAPI } from 'redux';
 
 import { accountsActions, deviceActions } from '@suite-common/wallet-core';
 
-import * as metadataActions from 'src/actions/suite/metadataActions';
+import * as metadataLabelingActions from 'src/actions/suite/metadataLabelingActions';
 import { AppState, Action, Dispatch } from 'src/types/suite';
 import { METADATA, ROUTER } from 'src/actions/suite/constants';
 
@@ -11,7 +11,9 @@ const metadata =
     (next: Dispatch) =>
     (action: Action): Action => {
         if (accountsActions.createAccount.match(action)) {
-            action.payload = api.dispatch(metadataActions.setAccountMetadataKey(action.payload));
+            action.payload = api.dispatch(
+                metadataLabelingActions.setAccountMetadataKey(action.payload),
+            );
         }
 
         // pass action
@@ -23,7 +25,7 @@ const metadata =
                 api.getState().metadata.enabled &&
                 !action.payload.device.metadata[METADATA.ENCRYPTION_VERSION]
             ) {
-                api.dispatch(metadataActions.init(false));
+                api.dispatch(metadataLabelingActions.init(false));
             }
         }
 
@@ -31,7 +33,7 @@ const metadata =
             case ROUTER.LOCATION_CHANGE:
                 // if there is editing field active, changing route turns it inactive
                 if (api.getState().metadata.editing) {
-                    api.dispatch(metadataActions.setEditing(undefined));
+                    api.dispatch(metadataLabelingActions.setEditing(undefined));
                 }
                 break;
             default:

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -16,6 +16,7 @@ import { NetworkSymbol } from '@suite-common/wallet-config';
 import { ExtraDependencies } from '@suite-common/redux-utils';
 
 import { StorageLoadAction } from 'src/actions/suite/storageActions';
+import * as metadataLabelingActions from 'src/actions/suite/metadataLabelingActions';
 import * as metadataActions from 'src/actions/suite/metadataActions';
 import * as cardanoStakingActions from 'src/actions/wallet/cardanoStakingActions';
 import * as walletSettingsActions from 'src/actions/settings/walletSettingsActions';
@@ -46,8 +47,8 @@ export const extraDependencies: ExtraDependencies = {
     thunks: {
         cardanoValidatePendingTxOnBlock: cardanoStakingActions.validatePendingTxOnBlock,
         cardanoFetchTrezorPools: cardanoStakingActions.fetchTrezorPools,
-        initMetadata: metadataActions.init,
-        fetchAndSaveMetadata: metadataActions.fetchAndSaveMetadata,
+        initMetadata: metadataLabelingActions.init,
+        fetchAndSaveMetadata: metadataLabelingActions.fetchAndSaveMetadata,
     },
     selectors: {
         selectFeeInfo: (networkSymbol: NetworkSymbol) => (state: AppState) =>

--- a/packages/suite/src/views/settings/SettingsGeneral/ConnectLabelingProvider.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/ConnectLabelingProvider.tsx
@@ -6,7 +6,7 @@ import {
     Translation,
 } from 'src/components/suite';
 import { useDispatch } from 'src/hooks/suite';
-import * as metadataActions from 'src/actions/suite/metadataActions';
+import * as metadataLabelingActions from 'src/actions/suite/metadataLabelingActions';
 import { useAnchor } from 'src/hooks/suite/useAnchor';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 
@@ -27,7 +27,7 @@ export const ConnectLabelingProvider = () => {
             <ActionColumn>
                 <ActionButton
                     variant="secondary"
-                    onClick={() => dispatch(metadataActions.init(true))}
+                    onClick={() => dispatch(metadataLabelingActions.init(true))}
                     data-test="@settings/metadata/connect-provider-button"
                 >
                     <Translation id="TR_CONNECT" />

--- a/packages/suite/src/views/settings/SettingsGeneral/DisconnectLabelingProvider.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/DisconnectLabelingProvider.tsx
@@ -8,7 +8,7 @@ import {
     Translation,
 } from 'src/components/suite';
 import { useSelector, useDispatch } from 'src/hooks/suite';
-import { disconnectProvider } from 'src/actions/suite/metadataActions';
+import { disconnectProvider } from 'src/actions/suite/metadataProviderActions';
 import { useAnchor } from 'src/hooks/suite/useAnchor';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { selectSelectedProviderForLabels } from 'src/reducers/suite/metadataReducer';

--- a/packages/suite/src/views/settings/SettingsGeneral/Labeling.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Labeling.tsx
@@ -5,6 +5,7 @@ import { HELP_CENTER_LABELING } from '@trezor/urls';
 import { ActionColumn, SectionItem, TextColumn, Translation } from 'src/components/suite';
 import { useSelector, useDispatch, useDevice } from 'src/hooks/suite';
 import * as metadataActions from 'src/actions/suite/metadataActions';
+import * as metadataLabelingActions from 'src/actions/suite/metadataLabelingActions';
 import { useAnchor } from 'src/hooks/suite/useAnchor';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 
@@ -19,7 +20,7 @@ export const Labeling = () => {
         if (metadata.enabled) {
             dispatch(metadataActions.disableMetadata());
         } else {
-            dispatch(metadataActions.init(true));
+            dispatch(metadataLabelingActions.init(true));
         }
 
         analytics.report({


### PR DESCRIPTION
this is a prerequisite for #10661 where more and more logic pretty similar to metadata/labeling feature is being implemented. so now it is time to make a stop and do some general refactoring to build on top of.

here I am splitting content of `metadataActions` into:

`metadataProviderActions` - working with metadata providers, connecting, disconnecting, fetching data. may import only from `metadataActions` but this import could be removed later too.
`metadataActions` - working with data, storing data, encrypting data. common stuff, must not import from others
`metadataLabelingActions` - strictly for the "labeling" feature and nothing else
`metadataPasswordsActions` - strictly for the newly developed passwords feature and nothing else. 

The first commit (5be20685a13703e4f3b488768a0abf3b1f64c63f) is almost pure refactoring. Only moving stuff around, changing imports etc. I didn't really touch anything although it was tempting, one can see many many refactoring opportunities there. 

cc @komret, maybe @peter-sanderson wants to review this? 