### PR TITLE
fix(suite-native): network symbol formatter units optional

### DIFF
--- a/suite-common/formatters/src/FormatterProvider.tsx
+++ b/suite-common/formatters/src/FormatterProvider.tsx
@@ -21,7 +21,10 @@ import { SignValueFormatter } from './formatters/SignValueFormatter';
 import { prepareDateFormatter } from './formatters/prepareDateFormatter';
 import { prepareTimeFormatter } from './formatters/prepareTimeFormatter';
 import { prepareDateTimeFormatter } from './formatters/prepareDateTimeFormatter';
-import { prepareNetworkSymbolFormatter } from './formatters/prepareNetworkSymbolFormatter';
+import {
+    NetworkSymbolFormatterDataContext,
+    prepareNetworkSymbolFormatter,
+} from './formatters/prepareNetworkSymbolFormatter';
 import { MonthNameFormatter } from './formatters/prepareMonthNameFormatter';
 
 type FormatterProviderProps = {
@@ -35,7 +38,7 @@ export type Formatters = {
         string,
         CryptoAmountFormatterDataContext
     >;
-    NetworkSymbolFormatter: Formatter<NetworkSymbol, string>;
+    NetworkSymbolFormatter: Formatter<NetworkSymbol, string, NetworkSymbolFormatterDataContext>;
     SignValueFormatter: Formatter<SignValue | undefined, string>;
     FiatAmountFormatter: Formatter<
         string | number,

--- a/suite-common/formatters/src/formatters/prepareNetworkSymbolFormatter.ts
+++ b/suite-common/formatters/src/formatters/prepareNetworkSymbolFormatter.ts
@@ -4,23 +4,28 @@ import { networksCompatibility as NETWORKS, NetworkSymbol } from '@suite-common/
 import { FormatterConfig } from '../types';
 import { makeFormatter } from '../makeFormatter';
 
+export type NetworkSymbolFormatterDataContext = { areAmountUnitsEnabled?: boolean };
+
 export const prepareNetworkSymbolFormatter = (config: FormatterConfig) =>
-    makeFormatter<NetworkSymbol, string>(symbol => {
-        const { bitcoinAmountUnit } = config;
+    makeFormatter<NetworkSymbol, string, NetworkSymbolFormatterDataContext>(
+        (symbol, dataContext) => {
+            const { bitcoinAmountUnit } = config;
+            const { areAmountUnitsEnabled = true } = dataContext;
 
-        const { features: networkFeatures, testnet: isTestnet } =
-            NETWORKS.find(network => network.symbol === symbol) ?? {};
-        const areAmountUnitsSupported = !!networkFeatures?.includes('amount-unit');
+            const { features: networkFeatures, testnet: isTestnet } =
+                NETWORKS.find(network => network.symbol === symbol) ?? {};
+            const areAmountUnitsSupported = !!networkFeatures?.includes('amount-unit');
+            let formattedSymbol = symbol.toUpperCase();
 
-        let formattedSymbol = symbol.toUpperCase();
+            // convert to different units if needed
+            if (areAmountUnitsEnabled && areAmountUnitsSupported) {
+                const unitAbbreviation = UNIT_ABBREVIATIONS[bitcoinAmountUnit];
+                formattedSymbol = isTestnet
+                    ? `${unitAbbreviation} ${symbol.toUpperCase()}`
+                    : unitAbbreviation;
+            }
 
-        // convert to different units if needed
-        if (areAmountUnitsSupported) {
-            const unitAbbreviation = UNIT_ABBREVIATIONS[bitcoinAmountUnit];
-            formattedSymbol = isTestnet
-                ? `${unitAbbreviation} ${symbol.toUpperCase()}`
-                : unitAbbreviation;
-        }
-
-        return formattedSymbol;
-    }, 'NetworkSymbolFormatter');
+            return formattedSymbol;
+        },
+        'NetworkSymbolFormatter',
+    );

--- a/suite-native/module-accounts-import/src/components/SelectableNetworkItem.tsx
+++ b/suite-native/module-accounts-import/src/components/SelectableNetworkItem.tsx
@@ -48,7 +48,10 @@ export const SelectableNetworkItem = ({ symbol, onPress }: SelectableAssetItemPr
                         <Text variant="body">{networkName}</Text>
                         <HStack alignItems="center" justifyContent="center">
                             <Text variant="hint" color="textSubdued">
-                                <NetworkSymbolFormatter value={symbol} />
+                                <NetworkSymbolFormatter
+                                    value={symbol}
+                                    areAmountUnitsEnabled={false}
+                                />
                             </Text>
                             {isEthereumNetwork && (
                                 <Box style={applyStyle(erc20BadgeStyle)}>


### PR DESCRIPTION
## Description
- NetworkSymbolFormatter extended by optional parameter `areAmountUnitsEnabled`
- Import asset screen uses this parameter co correctly format the bitcoin symbol to `BTC` instead of `sats`

## Related Issue

Resolve #9057 
## Screenshots:


https://github.com/trezor/trezor-suite/assets/26143964/3e94e778-149f-428e-b158-37c72f00f068

