### PR TITLE
fix: webextensions examples - update usb permissions url

### DIFF
--- a/packages/connect-examples/update-webextensions.js
+++ b/packages/connect-examples/update-webextensions.js
@@ -61,11 +61,19 @@ rootPaths.forEach(dir => {
 
     const srcPath = path.join(__dirname, '../connect-web');
 
-    ['trezor-content-script.js', 'trezor-usb-permissions.js'].forEach(p => {
+    ['trezor-content-script.js'].forEach(p => {
         fs.copyFileSync(
             path.join(srcPath, 'src', 'webextension', p),
             path.join(rootPath, buildFolder, 'vendor', p),
         );
+    });
+
+    ['trezor-usb-permissions.js'].forEach(p => {
+        let content = fs.readFileSync(path.join(srcPath, 'src', 'webextension', p), 'utf-8');
+        if (trezorConnectSrc !== DEFAULT_SRC) {
+            content = content.replace(/^const url = .*$/gm, `const url = '${trezorConnectSrc}';`);
+        }
+        fs.writeFileSync(path.join(rootPath, buildFolder, 'vendor', p), content, 'utf-8');
     });
 
     ['trezor-usb-permissions.html'].forEach(p => {


### PR DESCRIPTION
In the webextensions examples we have a build script (update-webextensions.js) that let's us replace the Connect src URL to another address, for example the staging server.
However this doesn't update the URL for the permissions prompt iframe, so there are corss origin issues

## Description

Added a logic to the buildscript to replace the URL in `trezor-usb-permissions.js`