### PR TITLE
refactor(connect): optional token symbol

### DIFF
--- a/packages/blockchain-link-types/src/blockbook-api.ts
+++ b/packages/blockchain-link-types/src/blockbook-api.ts
@@ -47,7 +47,7 @@ export interface TokenTransfer {
     to: string;
     contract: string;
     name: string;
-    symbol: string;
+    symbol?: string;
     decimals: number;
     value?: string;
     multiTokenValues?: MultiTokenValue[];

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AdvancedTxDetails/IODetails/IODetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AdvancedTxDetails/IODetails/IODetails.tsx
@@ -221,7 +221,7 @@ const IOGridGroupWrapper = ({
 interface GridRowGroupComponentProps {
     from?: string;
     to?: string;
-    symbol: string;
+    symbol?: string;
     amount?: string | ReactNode;
     isPhishingTransaction?: boolean;
 }

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
@@ -38,7 +38,7 @@ export const TransactionHeader = ({ transaction, isPending }: TransactionHeaderP
     }
 
     const isMultiTokenTransaction = transaction.tokens.length > 1;
-    const symbol = getTxHeaderSymbol(transaction).toUpperCase();
+    const symbol = getTxHeaderSymbol(transaction)?.toUpperCase();
 
     switch (transaction.type) {
         case 'sent':

--- a/packages/suite/src/hooks/suite/useFiatFromCryptoValue.ts
+++ b/packages/suite/src/hooks/suite/useFiatFromCryptoValue.ts
@@ -7,10 +7,11 @@ import { selectFiatRatesByFiatRateKey } from '@suite-common/wallet-core';
 import { TimestampedRates } from 'src/types/wallet/fiatRates';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { TokenAddress } from '@suite-common/wallet-types';
+import { TokenTransfer } from '@trezor/blockchain-link-types';
 
 interface CommonOwnProps {
     amount: string;
-    symbol: Network['symbol'] | string;
+    symbol: Network['symbol'] | TokenTransfer['symbol'];
     tokenAddress?: string;
     fiatCurrency?: string;
 }

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -4,8 +4,8 @@ import { networksCompatibility as NETWORKS } from '@suite-common/wallet-config';
 import {
     analyzeTransactions,
     findAccountDevice,
-    formatAmount,
     formatNetworkAmount,
+    formatTokenAmount,
     getAccountTransactions,
     getAreSatoshisUsed,
     isAccountOutdated,
@@ -143,8 +143,9 @@ export const fetchAndUpdateAccountThunk = createThunk(
                 const areSatoshisUsed = getAreSatoshisUsed(bitcoinAmountUnit, account);
 
                 const formattedAmount = token
-                    ? `${formatAmount(token.amount, token.decimals)} ${token.symbol.toUpperCase()}`
+                    ? formatTokenAmount(token)
                     : formatNetworkAmount(tx.amount, account.symbol, true, areSatoshisUsed);
+
                 dispatch(
                     notificationsActions.addEvent({
                         type: 'tx-confirmed',

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -4,8 +4,8 @@ import {
     findAccountDevice,
     findAccountsByDescriptor,
     findAccountsByNetwork,
-    formatAmount,
     formatNetworkAmount,
+    formatTokenAmount,
     getAreSatoshisUsed,
     getBackendFromSettings,
     getCustomBackends,
@@ -349,7 +349,7 @@ export const onBlockchainNotificationThunk = createThunk(
             );
 
             const formattedAmount = token
-                ? `${formatAmount(token.amount, token.decimals)} ${token.symbol.toUpperCase()}`
+                ? formatTokenAmount(token)
                 : formatNetworkAmount(tx.amount, account.symbol, true, areSatoshisUsed);
 
             dispatch(

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -7,6 +7,7 @@ import {
     AccountTransaction,
     AccountUtxo,
     PrecomposedTransactionFinalCardano,
+    TokenTransfer,
 } from '@trezor/connect';
 import { arrayDistinct, bufferUtils } from '@trezor/utils';
 import {
@@ -351,6 +352,13 @@ export const formatNetworkAmount = (
     }
 
     return formattedAmount;
+};
+
+export const formatTokenAmount = (tokenTransfer: TokenTransfer) => {
+    const formattedAmount = formatAmount(tokenTransfer.amount, tokenTransfer.decimals);
+    const formattedTokenSymbol = tokenTransfer.symbol?.toUpperCase();
+
+    return formattedTokenSymbol ? `${formattedAmount} ${formattedTokenSymbol}` : formattedAmount;
 };
 
 export const sortByCoin = (accounts: Account[]) =>

--- a/suite-common/wallet-utils/src/exportTransactionsUtils.ts
+++ b/suite-common/wallet-utils/src/exportTransactionsUtils.ts
@@ -210,7 +210,7 @@ const prepareContent = (data: Data, tokenDefinitions: TokenDefinitions): Fields[
                         address: token.to || '', // SENT - it is destination address, RECV - it is MY address
                         label: '', // token transactions do not have labels
                         amount: token.amount, // TODO: what to show if token.decimals missing so amount is not formatted correctly?
-                        symbol: token.symbol.toUpperCase() || token.contract, // if symbol not available, use contract address
+                        symbol: token.symbol?.toUpperCase() || token.contract, // if symbol not available, use contract address
                         fiat: '', // missing rates for tokens
                         other: '',
                     };


### PR DESCRIPTION
## Description
`TokenTransfer.symbol` type changed to optional because, ETH token symbol might not be specified. Only unique identifier of a ETH token is a `contract`.

## Related Issue

Resolve #8478 

