### PR TITLE
Correct `getSynchronize` return type

### DIFF
--- a/packages/utils/src/getSynchronize.ts
+++ b/packages/utils/src/getSynchronize.ts
@@ -11,9 +11,9 @@
  * ```
  */
 export const getSynchronize = () => {
-    let lock: Promise<any> | undefined;
+    let lock: Promise<unknown> | undefined;
 
-    return <T>(action: () => T | Promise<T>): Promise<T> => {
+    return <T>(action: () => T): T extends Promise<unknown> ? T : Promise<T> => {
         const newLock = (lock ?? Promise.resolve())
             .catch(() => {})
             .then(action)
@@ -23,7 +23,7 @@ export const getSynchronize = () => {
                 }
             });
         lock = newLock;
-        return lock;
+        return lock as any;
     };
 };
 


### PR DESCRIPTION
## Description

In case where return type of function called inside `getSynchronize` was a union of promises, the resulting type was incorrect.

```javascript
const synchronize = getSynchronize();
const action = (): Promise<number> | Promise<string> => null as any;
const result = synchronize(action);

// expected result type
//     Promise<number> | Promise<string>
// instead got error
//     Argument of type '() => Promise<number> | Promise<string>' is not assignable
//     to parameter of type '() => number | Promise<number>'.
```

## Related issues

Should help in #10755
