### PR TITLE
ci(connect): split dev and prod builds

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -233,22 +233,8 @@ suite-desktop build windows codesign:
     paths:
       - packages/connect-explorer/build
 
-connect-explorer build:
-  extends: .connect-explorer build base
-  # only:
-  #   <<: *run_connect_rules
-
-# connect-explorer build manual:
-#   extends: .connect-explorer build base
-#   except:
-#     <<: *run_everything_rules
-#   # when: manual
-
-# connect-web build
-connect-web build:
+.connect-web build base:
   stage: build
-  # only:
-  #   <<: *run_connect_rules
   interruptible: true
   variables:
     GIT_STRATEGY: clone
@@ -281,6 +267,38 @@ connect-web build:
       - packages/connect-examples/webextension-mv3/build-legacy
       - packages/connect-examples/webextension-mv3-sw/build
       - packages/connect-explorer-webextension/build
+
+connect-explorer build:
+  extends: .connect-explorer build base
+  except:
+    refs:
+      - /^release\/connect\//
+  variables:
+    NODE_ENV: "development"
+
+connect-web build:
+  extends: .connect-web build base
+  except:
+    refs:
+      - /^release\/connect\//
+  variables:
+    NODE_ENV: "development"
+
+connect-explorer build production:
+  extends: .connect-explorer build base
+  only:
+    refs:
+      - /^release\/connect/\//
+  variables:
+    NODE_ENV: "production"
+
+connect-web build production:
+  extends: .connect-web build base
+  only:
+    refs:
+      - /^release\/connect/\//
+  variables:
+    NODE_ENV: "production"
 
 # Build components
 

--- a/ci/releases.yml
+++ b/ci/releases.yml
@@ -126,12 +126,12 @@ connect v9 rollback production:
 .connect v9 deploy:
   stage: deploy to production
   dependencies:
-    - connect-web build
-    - connect-explorer build
+    - connect-web build production
+    - connect-explorer build production
   needs:
     - release commit messages
-    - connect-web build
-    - connect-explorer build
+    - connect-web build production
+    - connect-explorer build production
   before_script:
     - source ${CONNECT_DEPLOY_KEYFILE}
   tags:

--- a/packages/connect-explorer/package.json
+++ b/packages/connect-explorer/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "private": true,
     "scripts": {
-        "dev": "rimraf build && TS_NODE_PROJECT=\"tsconfig.json\" yarn webpack --config ./webpack/dev.webpack.config.ts",
+        "dev": "rimraf build && TS_NODE_PROJECT=\"tsconfig.json\" NODE_ENV=development yarn webpack --config ./webpack/dev.webpack.config.ts",
         "build": "rimraf build && TS_NODE_PROJECT=\"tsconfig.json\" yarn webpack --config ./webpack/prod.webpack.config.ts",
         "lint:js": "yarn g:eslint '**/*{.ts,.tsx}'",
         "lint:styles": "npx stylelint './src/**/*{.ts,.tsx}' --cache --config ../../.stylelintrc",

--- a/packages/connect-explorer/webpack/prod.webpack.config.ts
+++ b/packages/connect-explorer/webpack/prod.webpack.config.ts
@@ -83,6 +83,7 @@ const config: webpack.Configuration = {
             // eslint-disable-next-line no-underscore-dangle
             'process.env.__TREZOR_CONNECT_SRC': JSON.stringify(process.env.__TREZOR_CONNECT_SRC),
             'process.env.COMMIT_HASH': JSON.stringify(commitHash),
+            'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
         }),
         new CopyPlugin({
             patterns: [

--- a/packages/connect-iframe/webpack/base.webpack.config.ts
+++ b/packages/connect-iframe/webpack/base.webpack.config.ts
@@ -132,6 +132,7 @@ export const config: webpack.Configuration = {
                 env: {
                     VERSION: JSON.stringify(version),
                     COMMIT_HASH: JSON.stringify(commitHash),
+                    NODE_ENV: JSON.stringify(process.env.NODE_ENV),
                 },
             },
         }),

--- a/packages/connect-popup/webpack/prod.webpack.config.ts
+++ b/packages/connect-popup/webpack/prod.webpack.config.ts
@@ -71,12 +71,9 @@ const config: webpack.Configuration = {
     },
     plugins: [
         new DefinePlugin({
-            process: {
-                env: {
-                    VERSION: JSON.stringify(version),
-                    COMMIT_HASH: JSON.stringify(commitHash),
-                },
-            },
+            'process.env.VERSION': JSON.stringify(version),
+            'process.env.COMMIT_HASH': JSON.stringify(commitHash),
+            'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
         }),
         new HtmlWebpackPlugin({
             chunks: ['popup'],


### PR DESCRIPTION
till now, we treat all our connect builds as "production" ones. this had its reason, we did not have staging environment before and we wanted to test as close to production as possible. we now have staging environmnet, so sldev builds can now be treated as development builds.

resolve #7482

## QA
- please check that analytics events on sldev go to /develop endpoint and analytics events on staging go to /production endpoint