### PR TITLE
chore(suite): split metadata constants

### DIFF
--- a/packages/suite-web/e2e/tests/metadata/interval-fetching.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/interval-fetching.test.ts
@@ -1,7 +1,7 @@
 // @group:metadata
 // @retry=2
 
-import * as METADATA from '@trezor/suite/src/actions/suite/constants/metadataConstants';
+import * as METADATA_LABELING from '@trezor/suite/src/actions/suite/constants/metadataLabelingConstants';
 
 import { rerouteMetadataToMockProvider, stubOpen } from '../../stubs/metadata';
 
@@ -85,7 +85,7 @@ describe('Metadata - suite is watching cloud provider and syncs periodically', (
             });
 
             // and this does the time travel to trigger fetch
-            cy.tick(METADATA.FETCH_INTERVAL);
+            cy.tick(METADATA_LABELING.FETCH_INTERVAL);
             cy.getTestElement('@account-menu/btc/normal/0/label').should('contain', f.content);
         });
     });

--- a/packages/suite/src/actions/suite/__fixtures__/metadataActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/metadataActions.ts
@@ -1,7 +1,7 @@
 import { testMocks } from '@suite-common/test-utils';
 import { deviceActions } from '@suite-common/wallet-core';
 
-import { METADATA } from 'src/actions/suite/constants';
+import { METADATA, METADATA_LABELING } from 'src/actions/suite/constants/';
 
 import * as metadataLabelingActions from '../metadataLabelingActions';
 
@@ -17,14 +17,14 @@ type Fixture<T extends (...a: any) => any> = {
 const setDeviceMetadataKey: Fixture<(typeof metadataLabelingActions)['setDeviceMetadataKey']>[] = [
     {
         description: `Metadata not enabled`,
-        params: [getSuiteDevice({ state: 'a' }), METADATA.ENCRYPTION_VERSION],
+        params: [getSuiteDevice({ state: 'a' }), METADATA_LABELING.ENCRYPTION_VERSION],
         initialState: {
             metadata: { enabled: false, providers: [] },
         },
     },
     {
         description: `Device without state`,
-        params: [getSuiteDevice({ state: undefined }), METADATA.ENCRYPTION_VERSION],
+        params: [getSuiteDevice({ state: undefined }), METADATA_LABELING.ENCRYPTION_VERSION],
         initialState: {
             metadata: { enabled: true, providers: [] },
         },
@@ -33,7 +33,7 @@ const setDeviceMetadataKey: Fixture<(typeof metadataLabelingActions)['setDeviceM
         description: `Device not connected (remembered)`,
         params: [
             getSuiteDevice({ state: 'device-state', connected: false, metadata: {} }),
-            METADATA.ENCRYPTION_VERSION,
+            METADATA_LABELING.ENCRYPTION_VERSION,
         ],
         initialState: {
             metadata: { enabled: true, providers: [] },
@@ -43,7 +43,7 @@ const setDeviceMetadataKey: Fixture<(typeof metadataLabelingActions)['setDeviceM
         description: `Master key successfully generated`,
         params: [
             getSuiteDevice({ state: 'device-state', connected: true, metadata: {} }),
-            METADATA.ENCRYPTION_VERSION,
+            METADATA_LABELING.ENCRYPTION_VERSION,
         ],
         initialState: {
             metadata: {
@@ -195,7 +195,7 @@ const addAccountMetadata = [
             accounts: [
                 {
                     metadata: {
-                        [METADATA.ENCRYPTION_VERSION]: {
+                        [METADATA_LABELING.ENCRYPTION_VERSION]: {
                             aesKey: '9bc3736f0b45cd681854a724b5bba67b9da1e50bc9983fd2dd56e53e74b75480',
                             fileName: 'a',
                         },

--- a/packages/suite/src/actions/suite/constants/index.ts
+++ b/packages/suite/src/actions/suite/constants/index.ts
@@ -4,8 +4,24 @@ import * as MODAL from './modalConstants';
 import * as ROUTER from './routerConstants';
 import * as RESIZE from './resizeConstants';
 import * as METADATA from './metadataConstants';
+import * as METADATA_LABELING from './metadataLabelingConstants';
+import * as METADATA_PROVIDER from './metadataProviderConstants';
+import * as METADATA_PASSWORDS from './metadataPasswordsConstants';
 import * as DESKTOP_UPDATE from './desktopUpdateConstants';
 import * as GUIDE from './guideConstants';
 import * as PROTOCOL from './protocolConstants';
 
-export { STORAGE, SUITE, MODAL, ROUTER, RESIZE, METADATA, DESKTOP_UPDATE, GUIDE, PROTOCOL };
+export {
+    STORAGE,
+    SUITE,
+    MODAL,
+    ROUTER,
+    RESIZE,
+    METADATA,
+    METADATA_LABELING,
+    METADATA_PROVIDER,
+    METADATA_PASSWORDS,
+    DESKTOP_UPDATE,
+    GUIDE,
+    PROTOCOL,
+};

--- a/packages/suite/src/actions/suite/constants/metadataConstants.ts
+++ b/packages/suite/src/actions/suite/constants/metadataConstants.ts
@@ -1,10 +1,3 @@
-import {
-    MetadataEncryptionVersion,
-    AccountLabels,
-    WalletLabels,
-} from '@suite-common/metadata-types';
-import { TrezorConnect } from '@trezor/connect';
-
 export const ENABLE = '@metadata/enable';
 export const DISABLE = '@metadata/disable';
 export const SET_DEVICE_METADATA = '@metadata/set-device-metadata';
@@ -16,64 +9,3 @@ export const SET_INITIATING = '@metadata/set-initiating';
 export const SET_DATA = '@metadata/set-data';
 export const SET_SELECTED_PROVIDER = '@metadata/set-selected-provider';
 export const SET_ERROR_FOR_DEVICE = '@metadata/set-error-for-device';
-
-export const FORMAT_VERSION = '1.0.0';
-
-// @trezor/connect params
-export const ENABLE_LABELING_PATH = "m/10015'/0'";
-export const ENABLE_LABELING_KEY = 'Enable labeling?';
-export const ENABLE_LABELING_VALUE =
-    'fedcba98765432100123456789abcdeffedcba98765432100123456789abcdef';
-export const FETCH_INTERVAL = 1000 * 60 * 3; // 3 minutes?
-
-export const AUTH_WINDOW_TITLE = 'AuthPopup';
-export const AUTH_WINDOW_WIDTH = 600;
-export const AUTH_WINDOW_HEIGHT = 720;
-export const AUTH_WINDOW_PROPS = `width=${AUTH_WINDOW_WIDTH},height=${AUTH_WINDOW_HEIGHT},dialog=yes,dependent=yes,scrollbars=yes,location=yes`;
-
-// used for desktop app when auth-server is running - generate testing credentials for development
-export const GOOGLE_CODE_FLOW_CLIENT_ID =
-    '705190185912-m4mrh55knjbg6gqhi72fr906a6n0b0u1.apps.googleusercontent.com';
-
-// used in web app or as a fallback from authorization code flow
-export const GOOGLE_IMPLICIT_FLOW_CLIENT_ID =
-    '705190185912-nejegm4dbdecdaiumncbaa4ulrfnpk82.apps.googleusercontent.com';
-
-// dropbox allows authorization code flow for both web and desktop without client secret
-export const DROPBOX_CLIENT_ID = 'wg0yz2pbgjyhoda';
-
-export const ENCRYPTION_VERSION: MetadataEncryptionVersion = 1;
-
-export const ENCRYPTION_VERSION_CONFIGS: Record<
-    MetadataEncryptionVersion,
-    Parameters<TrezorConnect['cipherKeyValue']>[0]['bundle'][0]
-> = {
-    1: {
-        path: ENABLE_LABELING_PATH,
-        key: ENABLE_LABELING_KEY,
-        value: ENABLE_LABELING_VALUE,
-        encrypt: true,
-        askOnEncrypt: true,
-        askOnDecrypt: true,
-    },
-    2: {
-        path: ENABLE_LABELING_PATH,
-        key: ENABLE_LABELING_KEY,
-        value: ENABLE_LABELING_VALUE,
-        encrypt: true,
-        askOnEncrypt: false,
-        askOnDecrypt: false,
-    },
-};
-
-export const DEFAULT_ACCOUNT_METADATA: AccountLabels = {
-    accountLabel: '',
-    outputLabels: {},
-    addressLabels: {},
-};
-
-export const DEFAULT_WALLET_METADATA: WalletLabels = {
-    walletLabel: '',
-};
-
-export const DROPBOX_PASSWORDS_CLIENT_ID = 's340kh3l0vla1nv';

--- a/packages/suite/src/actions/suite/constants/metadataLabelingConstants.ts
+++ b/packages/suite/src/actions/suite/constants/metadataLabelingConstants.ts
@@ -1,0 +1,49 @@
+import {
+    MetadataEncryptionVersion,
+    AccountLabels,
+    WalletLabels,
+} from '@suite-common/metadata-types';
+import { TrezorConnect } from '@trezor/connect';
+
+export const FORMAT_VERSION = '1.0.0';
+
+// @trezor/connect params
+export const ENABLE_LABELING_PATH = "m/10015'/0'";
+export const ENABLE_LABELING_KEY = 'Enable labeling?';
+export const ENABLE_LABELING_VALUE =
+    'fedcba98765432100123456789abcdeffedcba98765432100123456789abcdef';
+export const FETCH_INTERVAL = 1000 * 60 * 3; // 3 minutes?
+
+export const ENCRYPTION_VERSION: MetadataEncryptionVersion = 1;
+
+export const ENCRYPTION_VERSION_CONFIGS: Record<
+    MetadataEncryptionVersion,
+    Parameters<TrezorConnect['cipherKeyValue']>[0]['bundle'][0]
+> = {
+    1: {
+        path: ENABLE_LABELING_PATH,
+        key: ENABLE_LABELING_KEY,
+        value: ENABLE_LABELING_VALUE,
+        encrypt: true,
+        askOnEncrypt: true,
+        askOnDecrypt: true,
+    },
+    2: {
+        path: ENABLE_LABELING_PATH,
+        key: ENABLE_LABELING_KEY,
+        value: ENABLE_LABELING_VALUE,
+        encrypt: true,
+        askOnEncrypt: false,
+        askOnDecrypt: false,
+    },
+};
+
+export const DEFAULT_ACCOUNT_METADATA: AccountLabels = {
+    accountLabel: '',
+    outputLabels: {},
+    addressLabels: {},
+};
+
+export const DEFAULT_WALLET_METADATA: WalletLabels = {
+    walletLabel: '',
+};

--- a/packages/suite/src/actions/suite/constants/metadataPasswordsConstants.ts
+++ b/packages/suite/src/actions/suite/constants/metadataPasswordsConstants.ts
@@ -1,0 +1,16 @@
+import type { PasswordManagerState } from 'src/types/suite/metadata';
+
+export const FILENAME_MESS = '5f91add3fa1c3c76e90c90a3bd0999e2bd7833d06a483fe884ee60397aca277a';
+export const HD_HARDENED = 0x80000000;
+export const PATH = [10016 + HD_HARDENED, 0];
+export const DEFAULT_KEYPHRASE = 'Activate TREZOR Password Manager?';
+export const DEFAULT_NONCE =
+    '2d650551248d792eabf628f451200d7f51cb63e46aadcbb1038aacb05e8c8aee2d650551248d792eabf628f451200d7f51cb63e46aadcbb1038aacb05e8c8aee';
+export const DEFAULT_PASSWORD_MANAGER_STATE: PasswordManagerState = {
+    config: {
+        orderType: 'date',
+    },
+    entries: {},
+    extVersion: '',
+    tags: {},
+};

--- a/packages/suite/src/actions/suite/constants/metadataProviderConstants.ts
+++ b/packages/suite/src/actions/suite/constants/metadataProviderConstants.ts
@@ -1,0 +1,17 @@
+export const AUTH_WINDOW_TITLE = 'AuthPopup';
+export const AUTH_WINDOW_WIDTH = 600;
+export const AUTH_WINDOW_HEIGHT = 720;
+export const AUTH_WINDOW_PROPS = `width=${AUTH_WINDOW_WIDTH},height=${AUTH_WINDOW_HEIGHT},dialog=yes,dependent=yes,scrollbars=yes,location=yes`;
+
+// used for desktop app when auth-server is running - generate testing credentials for development
+export const GOOGLE_CODE_FLOW_CLIENT_ID =
+    '705190185912-m4mrh55knjbg6gqhi72fr906a6n0b0u1.apps.googleusercontent.com';
+
+// used in web app or as a fallback from authorization code flow
+export const GOOGLE_IMPLICIT_FLOW_CLIENT_ID =
+    '705190185912-nejegm4dbdecdaiumncbaa4ulrfnpk82.apps.googleusercontent.com';
+
+// dropbox allows authorization code flow for both web and desktop without client secret
+export const DROPBOX_CLIENT_ID = 'wg0yz2pbgjyhoda';
+
+export const DROPBOX_PASSWORDS_CLIENT_ID = 's340kh3l0vla1nv';

--- a/packages/suite/src/actions/suite/metadataActions.ts
+++ b/packages/suite/src/actions/suite/metadataActions.ts
@@ -2,7 +2,7 @@ import { createAction } from '@reduxjs/toolkit';
 
 import { selectDevices } from '@suite-common/wallet-core';
 
-import { METADATA } from 'src/actions/suite/constants';
+import { METADATA, METADATA_LABELING } from 'src/actions/suite/constants';
 import { Dispatch, GetState } from 'src/types/suite';
 import {
     MetadataProvider,
@@ -86,7 +86,7 @@ export const disposeMetadataKeys = () => (dispatch: Dispatch, getState: GetState
     getState().wallet.accounts.forEach(account => {
         const updatedAccount = JSON.parse(JSON.stringify(account));
 
-        delete updatedAccount.metadata[METADATA.ENCRYPTION_VERSION];
+        delete updatedAccount.metadata[METADATA_LABELING.ENCRYPTION_VERSION];
         dispatch(setAccountAdd(updatedAccount));
     });
 
@@ -152,7 +152,7 @@ export const encryptAndSaveMetadata = async ({
 }) => {
     const encrypted = await metadataUtils.encrypt(
         {
-            version: METADATA.FORMAT_VERSION,
+            version: METADATA_LABELING.FORMAT_VERSION,
             ...data,
         },
         aesKey,

--- a/packages/suite/src/actions/suite/metadataPasswordsActions.ts
+++ b/packages/suite/src/actions/suite/metadataPasswordsActions.ts
@@ -1,4 +1,4 @@
-import { METADATA } from 'src/actions/suite/constants';
+import { METADATA, METADATA_PROVIDER } from 'src/actions/suite/constants';
 import { Dispatch, GetState } from 'src/types/suite';
 import { ProviderErrorAction } from 'src/types/suite/metadata';
 import * as metadataUtils from 'src/utils/suite/metadata';
@@ -9,7 +9,7 @@ export const fetchPasswords =
     (fileName: string, key: Buffer) => async (dispatch: Dispatch, _getState: GetState) => {
         const provider = dispatch(
             metadataProviderActions.getProviderInstance({
-                clientId: METADATA.DROPBOX_PASSWORDS_CLIENT_ID,
+                clientId: METADATA_PROVIDER.DROPBOX_PASSWORDS_CLIENT_ID,
                 dataType: 'passwords',
             }),
         );

--- a/packages/suite/src/actions/suite/metadataProviderActions.ts
+++ b/packages/suite/src/actions/suite/metadataProviderActions.ts
@@ -2,7 +2,7 @@ import { analytics, EventType } from '@trezor/suite-analytics';
 import { createDeferred } from '@trezor/utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 
-import { METADATA } from 'src/actions/suite/constants';
+import { METADATA, METADATA_PROVIDER } from 'src/actions/suite/constants';
 import { Dispatch, GetState } from 'src/types/suite';
 import {
     MetadataProviderType,
@@ -54,7 +54,7 @@ const createProviderInstance = (
         case 'dropbox':
             return new DropboxProvider({
                 token: tokens?.refreshToken,
-                clientId: clientId || METADATA.DROPBOX_CLIENT_ID,
+                clientId: clientId || METADATA_PROVIDER.DROPBOX_CLIENT_ID,
             });
         case 'google':
             return new GoogleProvider(tokens, environment);

--- a/packages/suite/src/hooks/suite/usePasswords.ts
+++ b/packages/suite/src/hooks/suite/usePasswords.ts
@@ -7,27 +7,11 @@ import { selectDevice } from '@suite-common/wallet-core';
 import { useSelector, useDispatch } from 'src/hooks/suite';
 import * as metadataProviderActions from 'src/actions/suite/metadataProviderActions';
 import * as metadataPasswordsActions from 'src/actions/suite/metadataPasswordsActions';
-import type { PasswordManagerState } from 'src/types/suite/metadata';
-import { METADATA } from 'src/actions/suite/constants';
+import { METADATA_PROVIDER, METADATA_PASSWORDS } from 'src/actions/suite/constants';
 import {
     selectPasswordManagerState,
     selectSelectedProviderForPasswords,
 } from 'src/reducers/suite/metadataReducer';
-
-const FILENAME_MESS = '5f91add3fa1c3c76e90c90a3bd0999e2bd7833d06a483fe884ee60397aca277a';
-const HD_HARDENED = 0x80000000;
-const PATH = [10016 + HD_HARDENED, 0];
-const DEFAULT_KEYPHRASE = 'Activate TREZOR Password Manager?';
-const DEFAULT_NONCE =
-    '2d650551248d792eabf628f451200d7f51cb63e46aadcbb1038aacb05e8c8aee2d650551248d792eabf628f451200d7f51cb63e46aadcbb1038aacb05e8c8aee';
-const DEFAULT_PASSWORD_MANAGER_STATE: PasswordManagerState = {
-    config: {
-        orderType: 'date',
-    },
-    entries: {},
-    extVersion: '',
-    tags: {},
-};
 
 export const usePasswords = () => {
     // todo: filename is saved only locally. for production grade state of this feature we will of course need to save it into app state.
@@ -43,7 +27,7 @@ export const usePasswords = () => {
 
     const { entries, tags, extVersion } =
         useSelector(state => selectPasswordManagerState(state, fileName)) ||
-        DEFAULT_PASSWORD_MANAGER_STATE;
+        METADATA_PASSWORDS.DEFAULT_PASSWORD_MANAGER_STATE;
 
     const connect = () => {
         setFileName('');
@@ -52,9 +36,9 @@ export const usePasswords = () => {
             device: { path: device?.path },
             override: true,
             useEmptyPassphrase: true,
-            path: PATH,
-            key: DEFAULT_KEYPHRASE,
-            value: DEFAULT_NONCE,
+            path: METADATA_PASSWORDS.PATH,
+            key: METADATA_PASSWORDS.DEFAULT_KEYPHRASE,
+            value: METADATA_PASSWORDS.DEFAULT_NONCE,
             encrypt: true,
             askOnEncrypt: true,
             askOnDecrypt: true,
@@ -74,7 +58,7 @@ export const usePasswords = () => {
                 const fileKey = res.payload.value.substring(0, res.payload.value.length / 2);
                 const fname = `${crypto
                     .createHmac('sha256', fileKey)
-                    .update(FILENAME_MESS)
+                    .update(METADATA_PASSWORDS.FILENAME_MESS)
                     .digest('hex')}.pswd`;
 
                 setFileName(fname);
@@ -84,7 +68,7 @@ export const usePasswords = () => {
                         metadataProviderActions.connectProvider({
                             type: 'dropbox',
                             dataType: 'passwords',
-                            clientId: METADATA.DROPBOX_PASSWORDS_CLIENT_ID,
+                            clientId: METADATA_PROVIDER.DROPBOX_PASSWORDS_CLIENT_ID,
                         }),
                     );
                 }

--- a/packages/suite/src/middlewares/suite/metadataMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/metadataMiddleware.ts
@@ -4,7 +4,7 @@ import { accountsActions, deviceActions } from '@suite-common/wallet-core';
 
 import * as metadataLabelingActions from 'src/actions/suite/metadataLabelingActions';
 import { AppState, Action, Dispatch } from 'src/types/suite';
-import { METADATA, ROUTER } from 'src/actions/suite/constants';
+import { METADATA_LABELING, ROUTER } from 'src/actions/suite/constants';
 
 const metadata =
     (api: MiddlewareAPI<Dispatch, AppState>) =>
@@ -23,7 +23,7 @@ const metadata =
             if (
                 action.payload.success &&
                 api.getState().metadata.enabled &&
-                !action.payload.device.metadata[METADATA.ENCRYPTION_VERSION]
+                !action.payload.device.metadata[METADATA_LABELING.ENCRYPTION_VERSION]
             ) {
                 api.dispatch(metadataLabelingActions.init(false));
             }

--- a/packages/suite/src/reducers/suite/metadataReducer.ts
+++ b/packages/suite/src/reducers/suite/metadataReducer.ts
@@ -11,7 +11,7 @@ import {
     deviceActions,
 } from '@suite-common/wallet-core';
 
-import { STORAGE, METADATA } from 'src/actions/suite/constants';
+import { STORAGE, METADATA, METADATA_LABELING } from 'src/actions/suite/constants';
 import { Action, TrezorDevice } from 'src/types/suite';
 import {
     MetadataState,
@@ -23,7 +23,7 @@ import { Account } from 'src/types/wallet';
 import {
     DEFAULT_ACCOUNT_METADATA,
     DEFAULT_WALLET_METADATA,
-} from 'src/actions/suite/constants/metadataConstants';
+} from 'src/actions/suite/constants/metadataLabelingConstants';
 
 import { SuiteRootState } from './suiteReducer';
 import { AccountKey } from '@suite-common/wallet-types';
@@ -134,7 +134,7 @@ export const selectLabelingDataForSelectedAccount = (state: {
     const provider = selectSelectedProviderForLabels(state);
     const { selectedAccount } = state.wallet;
 
-    const metadataKeys = selectedAccount?.account?.metadata[METADATA.ENCRYPTION_VERSION];
+    const metadataKeys = selectedAccount?.account?.metadata[METADATA_LABELING.ENCRYPTION_VERSION];
     if (!metadataKeys || !metadataKeys.fileName || !provider?.data[metadataKeys.fileName]) {
         return DEFAULT_ACCOUNT_METADATA;
     }
@@ -151,7 +151,7 @@ export const selectLabelingDataForAccount = (
 ) => {
     const provider = selectSelectedProviderForLabels(state);
     const account = selectAccountByKey(state, accountKey);
-    const metadataKeys = account?.metadata?.[METADATA.ENCRYPTION_VERSION];
+    const metadataKeys = account?.metadata?.[METADATA_LABELING.ENCRYPTION_VERSION];
 
     if (!metadataKeys || !metadataKeys?.fileName || !provider?.data[metadataKeys.fileName]) {
         return DEFAULT_ACCOUNT_METADATA;
@@ -171,7 +171,7 @@ export const selectAccountLabels = (state: {
 
     return state.wallet.accounts.reduce(
         (dict, account) => {
-            const metadataKeys = account?.metadata?.[METADATA.ENCRYPTION_VERSION];
+            const metadataKeys = account?.metadata?.[METADATA_LABELING.ENCRYPTION_VERSION];
             if (
                 !metadataKeys ||
                 !metadataKeys?.fileName ||
@@ -199,10 +199,10 @@ export const selectLabelingDataForWallet = (
     const provider = selectSelectedProviderForLabels(state);
     const devices = selectDevices(state);
     const device = devices.find(d => d.state === deviceState);
-    if (!device?.metadata[METADATA.ENCRYPTION_VERSION]) {
+    if (!device?.metadata[METADATA_LABELING.ENCRYPTION_VERSION]) {
         return DEFAULT_WALLET_METADATA;
     }
-    const metadataKeys = device?.metadata[METADATA.ENCRYPTION_VERSION];
+    const metadataKeys = device?.metadata[METADATA_LABELING.ENCRYPTION_VERSION];
 
     if (metadataKeys && metadataKeys.fileName && provider?.data[metadataKeys.fileName]) {
         return provider.data[metadataKeys.fileName] as WalletLabels;
@@ -257,7 +257,7 @@ export const selectIsLabelingAvailable = (state: MetadataRootState) => {
 
     return (
         enabled &&
-        device?.metadata?.[METADATA.ENCRYPTION_VERSION] &&
+        device?.metadata?.[METADATA_LABELING.ENCRYPTION_VERSION] &&
         !!provider &&
         device.state &&
         !error?.[device.state]
@@ -272,7 +272,8 @@ export const selectIsLabelingInitPossible = (state: MetadataRootState) => {
 
     return (
         // device already has keys or it is at least connected and authorized
-        (device?.metadata?.[METADATA.ENCRYPTION_VERSION] || (device?.connected && device.state)) &&
+        (device?.metadata?.[METADATA_LABELING.ENCRYPTION_VERSION] ||
+            (device?.connected && device.state)) &&
         // storage provider is connected or we are at least able to connect to it
         (selectSelectedProviderForLabels(state) || state.suite.online)
     );
@@ -289,7 +290,7 @@ export const selectIsLabelingAvailableForEntity = (
     return (
         selectIsLabelingAvailable(state) &&
         entity &&
-        entity?.[METADATA.ENCRYPTION_VERSION]?.fileName
+        entity?.[METADATA_LABELING.ENCRYPTION_VERSION]?.fileName
     );
 };
 

--- a/packages/suite/src/services/google.ts
+++ b/packages/suite/src/services/google.ts
@@ -6,7 +6,7 @@
  * in case our authorization server (which holds a client secret necessary for the authorization code flow) is not available.
  */
 
-import { METADATA } from 'src/actions/suite/constants';
+import { METADATA_PROVIDER } from 'src/actions/suite/constants';
 import { isDesktop } from '@trezor/env-utils';
 import { OAuthServerEnvironment, Tokens } from 'src/types/suite/metadata';
 import {
@@ -128,14 +128,14 @@ class Client {
                     // the app has two sets of credentials to enable both OAuth flows
                     Client.clientId =
                         Client.flow === 'code'
-                            ? METADATA.GOOGLE_CODE_FLOW_CLIENT_ID
-                            : METADATA.GOOGLE_IMPLICIT_FLOW_CLIENT_ID;
+                            ? METADATA_PROVIDER.GOOGLE_CODE_FLOW_CLIENT_ID
+                            : METADATA_PROVIDER.GOOGLE_IMPLICIT_FLOW_CLIENT_ID;
                     resolve(Client);
                 });
             } else {
                 // code flow with loopback IP address does not work unless redirect_uri is localhost (Google returns redirect_uri_mismatch)
                 Client.flow = 'implicit';
-                Client.clientId = METADATA.GOOGLE_IMPLICIT_FLOW_CLIENT_ID;
+                Client.clientId = METADATA_PROVIDER.GOOGLE_IMPLICIT_FLOW_CLIENT_ID;
                 resolve(Client);
             }
         });
@@ -246,7 +246,7 @@ class Client {
     static async forceImplicitFlow() {
         if (Client.flow === 'code') {
             Client.flow = 'implicit';
-            Client.clientId = METADATA.GOOGLE_IMPLICIT_FLOW_CLIENT_ID;
+            Client.clientId = METADATA_PROVIDER.GOOGLE_IMPLICIT_FLOW_CLIENT_ID;
             await Client.authorize();
         }
     }

--- a/packages/suite/src/utils/suite/logsUtils.ts
+++ b/packages/suite/src/utils/suite/logsUtils.ts
@@ -34,7 +34,7 @@ import { getPhysicalDeviceUniqueIds } from '@suite-common/suite-utils';
 
 import { getIsTorEnabled } from 'src/utils/suite/tor';
 import { AppState, TrezorDevice } from 'src/types/suite';
-import { METADATA } from 'src/actions/suite/constants';
+import { METADATA_LABELING } from 'src/actions/suite/constants';
 import { Account } from 'src/types/wallet';
 import { selectLabelingDataForWallet } from 'src/reducers/suite/metadataReducer';
 
@@ -244,7 +244,7 @@ export const getApplicationInfo = (state: AppState, hideSensitiveInfo: boolean) 
         deviceLabel: hideSensitiveInfo ? REDACTED_REPLACEMENT : device.label,
         label:
             // eslint-disable-next-line no-nested-ternary
-            device.metadata[METADATA.ENCRYPTION_VERSION]
+            device.metadata[METADATA_LABELING.ENCRYPTION_VERSION]
                 ? hideSensitiveInfo
                     ? REDACTED_REPLACEMENT
                     : selectLabelingDataForWallet(state).walletLabel

--- a/packages/suite/src/utils/suite/oauth.ts
+++ b/packages/suite/src/utils/suite/oauth.ts
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 import { desktopApi } from '@trezor/suite-desktop-api';
 import { getPrefixedURL } from 'src/utils/suite/router';
-import { METADATA } from 'src/actions/suite/constants';
+import { METADATA_PROVIDER } from 'src/actions/suite/constants';
 import { Deferred, createDeferred } from '@trezor/utils';
 import { urlHashParams, urlSearchParams } from 'src/utils/suite/metadata';
 
@@ -149,13 +149,13 @@ export const extractCredentialsFromAuthorizationFlow = (url: string) => {
         desktopApi.removeAllListeners('oauth/response');
         // this listener may never be called in some cases
         desktopApi.once('oauth/response', getDesktopHandlerInstance(dfd, originalParams));
-        window.open(url, METADATA.AUTH_WINDOW_TITLE, METADATA.AUTH_WINDOW_PROPS);
+        window.open(url, METADATA_PROVIDER.AUTH_WINDOW_TITLE, METADATA_PROVIDER.AUTH_WINDOW_PROPS);
     } else {
         window.addEventListener('message', getWebHandlerInstance(dfd, originalParams));
         openWindowOnAnotherDomain(
             url,
-            METADATA.AUTH_WINDOW_TITLE,
-            METADATA.AUTH_WINDOW_PROPS,
+            METADATA_PROVIDER.AUTH_WINDOW_TITLE,
+            METADATA_PROVIDER.AUTH_WINDOW_PROPS,
             () => {
                 // note that this rejection happens even on successful authorization.
                 // 'window closed' error message may be used to differentiate between errors

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
@@ -21,8 +21,8 @@ import {
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { TrezorDevice, AcquiredDevice } from 'src/types/suite';
 import { selectLabelingDataForWallet } from 'src/reducers/suite/metadataReducer';
-import { METADATA } from 'src/actions/suite/constants';
 import { useWalletLabeling } from '../../../../components/suite/labeling/WalletLabeling';
+import { METADATA_LABELING } from 'src/actions/suite/constants';
 
 const InstanceType = styled.div`
     display: flex;
@@ -166,7 +166,7 @@ export const WalletInstance = ({
                                     type: 'walletLabel',
                                     entityKey: instance.state,
                                     defaultValue: instance.state,
-                                    value: instance?.metadata[METADATA.ENCRYPTION_VERSION]
+                                    value: instance?.metadata[METADATA_LABELING.ENCRYPTION_VERSION]
                                         ? walletLabel
                                         : '',
                                 }}


### PR DESCRIPTION
this does basically the same as #10755 but this time for file 'metadataConstants'

zero logic changes, just imports and renaming. 

prerequisite for #10661