### PR TITLE
feat(suite-native): close sheets by click outside

### DIFF
--- a/suite-native/atoms/src/Sheet/BottomSheet.tsx
+++ b/suite-native/atoms/src/Sheet/BottomSheet.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState, ReactNode } from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Animated from 'react-native-reanimated';
 import { ScrollView, PanGestureHandler } from 'react-native-gesture-handler';
+import { GestureResponderEvent, Pressable } from 'react-native';
 
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
@@ -78,6 +79,10 @@ export const BottomSheet = ({
         closeSheetAnimated();
     };
 
+    const handlePressOutside = (event: GestureResponderEvent) => {
+        if (event.target === event.currentTarget) closeSheetAnimated();
+    };
+
     const insetBottom = Math.max(insets.bottom, DEFAULT_INSET_BOTTOM);
 
     return (
@@ -85,43 +90,47 @@ export const BottomSheet = ({
             <Animated.View
                 style={[animatedSheetWithOverlayStyle, applyStyle(sheetWithOverlayStyle)]}
             >
-                <PanGestureHandler
-                    enabled={isCloseScrollEnabled}
-                    ref={panGestureRef.current}
-                    activeOffsetY={5}
-                    failOffsetY={-5}
-                    onGestureEvent={panGestureEvent}
-                >
-                    <Animated.View
-                        style={[
-                            animatedSheetWrapperStyle,
-                            applyStyle(sheetWrapperStyle, {
-                                insetBottom,
-                            }),
-                        ]}
+                <Pressable style={applyStyle(sheetWithOverlayStyle)} onPress={handlePressOutside}>
+                    <PanGestureHandler
+                        enabled={isCloseScrollEnabled}
+                        ref={panGestureRef.current}
+                        activeOffsetY={5}
+                        failOffsetY={-5}
+                        onGestureEvent={panGestureEvent}
                     >
-                        <BottomSheetHeader
-                            title={title}
-                            subtitle={subtitle}
-                            isCloseDisplayed={isCloseDisplayed}
-                            onCloseSheet={closeSheetAnimated}
-                        />
-                        <ScrollView
-                            ref={scrollViewRef.current}
-                            waitFor={
-                                isCloseScrollEnabled ? panGestureRef.current : scrollViewRef.current
-                            }
-                            onScroll={scrollEvent}
-                            keyboardShouldPersistTaps="handled"
+                        <Animated.View
+                            style={[
+                                animatedSheetWrapperStyle,
+                                applyStyle(sheetWrapperStyle, {
+                                    insetBottom,
+                                }),
+                            ]}
                         >
-                            <Animated.View>
-                                <Box paddingHorizontal="medium" {...boxProps}>
-                                    {children}
-                                </Box>
-                            </Animated.View>
-                        </ScrollView>
-                    </Animated.View>
-                </PanGestureHandler>
+                            <BottomSheetHeader
+                                title={title}
+                                subtitle={subtitle}
+                                isCloseDisplayed={isCloseDisplayed}
+                                onCloseSheet={closeSheetAnimated}
+                            />
+                            <ScrollView
+                                ref={scrollViewRef.current}
+                                waitFor={
+                                    isCloseScrollEnabled
+                                        ? panGestureRef.current
+                                        : scrollViewRef.current
+                                }
+                                onScroll={scrollEvent}
+                                keyboardShouldPersistTaps="handled"
+                            >
+                                <Animated.View>
+                                    <Box paddingHorizontal="medium" {...boxProps}>
+                                        {children}
+                                    </Box>
+                                </Animated.View>
+                            </ScrollView>
+                        </Animated.View>
+                    </PanGestureHandler>
+                </Pressable>
             </Animated.View>
         </BottomSheetContainer>
     );

--- a/suite-native/device-manager/src/components/DeviceManagerModal.tsx
+++ b/suite-native/device-manager/src/components/DeviceManagerModal.tsx
@@ -1,9 +1,9 @@
-import { Modal } from 'react-native';
+import { GestureResponderEvent, Modal, Pressable } from 'react-native';
 import { ReactNode } from 'react';
 import { useSafeAreaInsets, EdgeInsets } from 'react-native-safe-area-context';
 import Animated, { SlideInUp } from 'react-native-reanimated';
 
-import { Box, ScreenHeaderWrapper, VStack } from '@suite-native/atoms';
+import { ScreenHeaderWrapper, VStack } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { DeviceSwitch } from './DeviceSwitch';
@@ -45,6 +45,10 @@ export const DeviceManagerModal = ({ children }: DeviceManagerModalProps) => {
         setIsDeviceManagerVisible(false);
     };
 
+    const handlePressOutside = (event: GestureResponderEvent) => {
+        if (event.target === event.currentTarget) handleClose();
+    };
+
     return (
         <Modal
             transparent
@@ -53,7 +57,7 @@ export const DeviceManagerModal = ({ children }: DeviceManagerModalProps) => {
             presentationStyle="overFullScreen"
             animationType="fade"
         >
-            <Box style={applyStyle(modalBackgroundOverlayStyle)}>
+            <Pressable style={applyStyle(modalBackgroundOverlayStyle)} onPress={handlePressOutside}>
                 <Animated.View
                     entering={SlideInUp.damping(30)}
                     style={applyStyle(deviceManagerModalWrapperStyle, { insets })}
@@ -65,7 +69,7 @@ export const DeviceManagerModal = ({ children }: DeviceManagerModalProps) => {
                         {children}
                     </VStack>
                 </Animated.View>
-            </Box>
+            </Pressable>
         </Modal>
     );
 };


### PR DESCRIPTION
## Description
- bottom sheet and device manager can be closed by clicking outside of it

## Related Issue

Resolve #10775 

## Screenshots:

https://github.com/trezor/trezor-suite/assets/26143964/f54f37d5-5c0c-454b-91b8-c59f0937dc59

