### PR TITLE
fix(suite-native): bottom sheet pan gesture sticky

### DIFF
--- a/suite-native/atoms/src/Sheet/useBottomSheetAnimation.ts
+++ b/suite-native/atoms/src/Sheet/useBottomSheetAnimation.ts
@@ -117,6 +117,7 @@ export const useBottomSheetAnimation = ({
         },
         onActive: (event, context) => {
             const { translationY } = event;
+            if (translationY < 0) return;
             translatePanY.value = translationY + context.translatePanY;
         },
         onEnd: event => {


### PR DESCRIPTION
## Description
- bottom sheet cant be grabbed higher then default position

## Related Issue

Resolve #10777
## Screenshots:

https://github.com/trezor/trezor-suite/assets/26143964/16b4e64e-79a3-4465-9efc-824111cd2c29


