### PR TITLE
Proper timeouts in blockchain-link websockets

### DIFF
--- a/packages/utils/src/createDeferredManager.ts
+++ b/packages/utils/src/createDeferredManager.ts
@@ -1,0 +1,110 @@
+import { createDeferred, Deferred } from './createDeferred';
+
+type ManagedDeferred<T> = Deferred<T, number> & { deadline: number };
+
+type DeferredManagerOptions = {
+    /** default timeout for promises without explicitly specified timeout */
+    timeout?: number;
+    /** callback which is called whenever a promise time out, with its id */
+    onTimeout?: (promiseId: number) => void;
+    /** from which id should the promises start (for specific use case, should be removed in the future) */
+    initialId?: number;
+};
+
+type DeferredManager<T> = {
+    /** How many pending promises are there */
+    length: () => number;
+    /** ID of the next created promise (for specific use case, should be removed in the future) */
+    nextId: () => number;
+    /** Creates new pending promise (with optional timeout) and returns it and its unique id */
+    create: (timeout?: number) => { promiseId: number; promise: Promise<T> };
+    /** Resolves (and removes) promise with given id by given value and returns whether it was present or not */
+    resolve: (promiseId: number, value: T) => boolean;
+    /** Rejects (and removes) promise with given id by given error and returns whether it was present or not */
+    reject: (promiseId: number, error: Error) => boolean;
+    /** Rejects (and removes) all pending promises by given error */
+    rejectAll: (error: Error) => void;
+};
+
+/**
+ * Handles the frequently repeated pattern of many deferred promises with unique ids
+ * (usually requests), which can be resolved or rejected in a random order, or they can
+ * time out
+ *
+ * @param options optional default timeout and onTimeout callback
+ *
+ * @returns Deferred promise manager instance
+ */
+export const createDeferredManager = <T = any>(
+    options?: DeferredManagerOptions,
+): DeferredManager<T> => {
+    const { initialId = 0, timeout: defaultTimeout = 0, onTimeout } = options ?? {};
+    const promises: ManagedDeferred<T>[] = [];
+
+    let ID = initialId;
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+
+    const length = () => promises.length;
+
+    const nextId = () => ID;
+
+    const replanTimeout = () => {
+        const now = Date.now();
+        const nearestDeadline = promises.reduce(
+            (prev, { deadline }) => (prev && deadline ? Math.min : Math.max)(prev, deadline),
+            0,
+        );
+        if (timeoutHandle) clearTimeout(timeoutHandle);
+        timeoutHandle = nearestDeadline
+            ? // eslint-disable-next-line @typescript-eslint/no-use-before-define
+              setTimeout(timeoutCallback, Math.max(nearestDeadline - now, 0)) // TODO min safe interval instead of zero?
+            : undefined;
+    };
+
+    const timeoutCallback = () => {
+        const now = Date.now();
+        promises
+            .filter(promise => promise.deadline && promise.deadline <= now)
+            .forEach(promise => {
+                onTimeout?.(promise.id);
+                promise.deadline = 0;
+            });
+        replanTimeout();
+    };
+
+    const create = (timeout = defaultTimeout) => {
+        const promiseId = ID++;
+        const deferred = createDeferred<T, number>(promiseId);
+        const deadline = timeout && Date.now() + timeout;
+        promises.push({ ...deferred, deadline });
+        if (timeout) replanTimeout();
+        return { promiseId, promise: deferred.promise };
+    };
+
+    const extract = (promiseId: number) => {
+        const index = promises.findIndex(({ id }) => id === promiseId);
+        const [promise] = index >= 0 ? promises.splice(index, 1) : [undefined];
+        if (promise?.deadline) replanTimeout();
+        return promise;
+    };
+
+    const resolve = (promiseId: number, value: T) => {
+        const promise = extract(promiseId);
+        promise?.resolve(value);
+        return !!promise;
+    };
+
+    const reject = (promiseId: number, error: Error) => {
+        const promise = extract(promiseId);
+        promise?.reject(error);
+        return !!promise;
+    };
+
+    const rejectAll = (error: Error) => {
+        promises.forEach(promise => promise.reject(error));
+        const deleted = promises.splice(0, promises.length);
+        if (deleted.length) replanTimeout();
+    };
+
+    return { length, nextId, create, resolve, reject, rejectAll };
+};

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -9,6 +9,7 @@ export * from './cloneObject';
 export * from './countBytesInString';
 export * from './createCooldown';
 export * from './createDeferred';
+export * from './createDeferredManager';
 export * from './createTimeoutPromise';
 export * as enumUtils from './enumUtils';
 export * from './getNumberFromPixelString';

--- a/packages/utils/tests/createDeferredManager.test.ts
+++ b/packages/utils/tests/createDeferredManager.test.ts
@@ -1,0 +1,83 @@
+import { createDeferredManager } from '../src/createDeferredManager';
+
+describe('createDeferredManager', () => {
+    jest.useFakeTimers();
+
+    it('basic', async () => {
+        const manager = createDeferredManager();
+
+        const first = manager.create();
+        const second = manager.create();
+
+        setTimeout(() => manager.resolve(first.promiseId, 'foo'), 200);
+        setTimeout(() => manager.reject(second.promiseId, new Error('bar')), 100);
+
+        expect(manager.length()).toBe(2);
+
+        jest.advanceTimersByTime(100);
+
+        await expect(second.promise).rejects.toThrow('bar');
+        expect(manager.length()).toBe(1);
+
+        jest.advanceTimersByTime(100);
+
+        await expect(first.promise).resolves.toBe('foo');
+        expect(manager.length()).toBe(0);
+    });
+
+    it('timeout', () => {
+        const onTimeout = jest.fn();
+        const manager = createDeferredManager({ timeout: 200, onTimeout });
+
+        const first = manager.create();
+        const second = manager.create(300);
+        const third = manager.create(100);
+
+        jest.advanceTimersByTime(150);
+
+        expect(onTimeout).toHaveBeenCalledTimes(1);
+
+        jest.advanceTimersByTime(100);
+
+        expect(onTimeout).toHaveBeenCalledTimes(2);
+
+        jest.advanceTimersByTime(150);
+
+        expect(manager.length()).toBe(3);
+        expect(onTimeout).toHaveBeenCalledTimes(3);
+        expect(onTimeout).toHaveBeenNthCalledWith(1, third.promiseId);
+        expect(onTimeout).toHaveBeenNthCalledWith(2, first.promiseId);
+        expect(onTimeout).toHaveBeenNthCalledWith(3, second.promiseId);
+    });
+
+    it('reject all but first', async () => {
+        const onTimeout = jest.fn();
+        const manager = createDeferredManager({
+            timeout: 200,
+            onTimeout: id => {
+                onTimeout(id);
+                manager.resolve(id, 'foo');
+                manager.rejectAll(new Error('err'));
+            },
+        });
+
+        const first = manager.create();
+        const second = manager.create(300);
+        const third = manager.create(100);
+
+        expect(manager.length()).toBe(3);
+
+        jest.advanceTimersByTime(300);
+
+        expect(manager.length()).toBe(0);
+
+        await Promise.all([
+            expect(first.promise).rejects.toThrow('err'),
+            expect(second.promise).rejects.toThrow('err'),
+            expect(third.promise).resolves.toBe('foo'),
+        ]);
+
+        expect(onTimeout).toHaveBeenCalledTimes(1);
+        expect(onTimeout).toHaveBeenCalledWith(third.promiseId);
+    });
+});


### PR DESCRIPTION
## Description

In `blockchain-link`'s `baseWebsocket` class (Blockbook & Blockfrost APIs), response timeouts were always (re)calculated from the last message sent, meaning that no timeout was ever thrown until new requests were being sent.

- https://github.com/trezor/trezor-suite/pull/10787/commits/cf300f0e40a1d43758430368cb4a599deae986ae - implemented  `createPromiseManager` util, which handles uniquely identified deferred promises and their potential timeouts; will be reused in  #10363
- https://github.com/trezor/trezor-suite/pull/10787/commits/a69f8e9b1d3fe67e828381f0b9443c4707b9ed40 - `createPromiseManager` used in baseWebsocket
  - initial connection timeout separated from ordinary message timeout, meaning that `onTimeout` method is now used only for messages and its part regarding initial connection moved to `connect` method
  - `connectionTimeout` is now set and cleared only locally; there was no reason to store it as a class field

## Related Issue

Could resolve #10460

## QA

Apart from resolving the linked issue, please make sure that the backend connection works well in general; the changes could be more significant than they look like.