### PR TITLE
Style/10533 button group device orientation

### DIFF
--- a/packages/suite/src/views/settings/SettingsDevice/DisplayRotation.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/DisplayRotation.tsx
@@ -1,15 +1,8 @@
-import styled from 'styled-components';
 import { analytics, EventType } from '@trezor/suite-analytics';
 
-import {
-    ActionButton,
-    ActionColumn,
-    SectionItem,
-    TextColumn,
-    Translation,
-} from 'src/components/suite';
-import { variables } from '@trezor/components';
-import { useDispatch } from 'src/hooks/suite';
+import { ActionColumn, SectionItem, TextColumn, Translation } from 'src/components/suite';
+import { Button, ButtonGroup } from '@trezor/components';
+import { useDevice, useDispatch } from 'src/hooks/suite';
 import { applySettings } from 'src/actions/settings/deviceSettingsActions';
 import { useAnchor } from 'src/hooks/suite/useAnchor';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
@@ -21,17 +14,6 @@ const DISPLAY_ROTATIONS = [
     { label: <Translation id="TR_WEST" />, value: 270 },
 ] as const;
 
-const RotationButton = styled(ActionButton)`
-    min-width: 81px;
-    flex-basis: auto;
-
-    &:not(:first-of-type) {
-        @media (max-width: ${variables.SCREEN_SIZE.SM}) {
-            margin-top: 10px;
-        }
-    }
-`;
-
 interface DisplayRotationProps {
     isDeviceLocked: boolean;
 }
@@ -39,6 +21,8 @@ interface DisplayRotationProps {
 export const DisplayRotation = ({ isDeviceLocked }: DisplayRotationProps) => {
     const dispatch = useDispatch();
     const { anchorRef, shouldHighlight } = useAnchor(SettingsAnchor.DisplayRotation);
+    const { device } = useDevice();
+    const currentRotation = device?.features?.display_rotation;
 
     return (
         <SectionItem
@@ -48,25 +32,26 @@ export const DisplayRotation = ({ isDeviceLocked }: DisplayRotationProps) => {
         >
             <TextColumn title={<Translation id="TR_DEVICE_SETTINGS_DISPLAY_ROTATION" />} />
             <ActionColumn>
-                {DISPLAY_ROTATIONS.map(variant => (
-                    <RotationButton
-                        key={variant.value}
-                        variant="secondary"
-                        onClick={() => {
-                            dispatch(applySettings({ display_rotation: variant.value }));
-                            analytics.report({
-                                type: EventType.SettingsDeviceChangeOrientation,
-                                payload: {
-                                    value: variant.value,
-                                },
-                            });
-                        }}
-                        data-test={`@settings/device/rotation-button/${variant.value}`}
-                        isDisabled={isDeviceLocked}
-                    >
-                        {variant.label}
-                    </RotationButton>
-                ))}
+                <ButtonGroup size="small" isDisabled={isDeviceLocked}>
+                    {DISPLAY_ROTATIONS.map(variant => (
+                        <Button
+                            key={variant.value}
+                            variant={currentRotation === variant.value ? 'primary' : 'secondary'}
+                            onClick={() => {
+                                dispatch(applySettings({ display_rotation: variant.value }));
+                                analytics.report({
+                                    type: EventType.SettingsDeviceChangeOrientation,
+                                    payload: {
+                                        value: variant.value,
+                                    },
+                                });
+                            }}
+                            data-test={`@settings/device/rotation-button/${variant.value}`}
+                        >
+                            {variant.label}
+                        </Button>
+                    ))}
+                </ButtonGroup>
             </ActionColumn>
         </SectionItem>
     );

--- a/packages/suite/src/views/settings/SettingsDevice/Homescreen.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/Homescreen.tsx
@@ -12,7 +12,7 @@ import {
     TextColumn,
     Translation,
 } from 'src/components/suite';
-import { Tooltip, variables } from '@trezor/components';
+import { Button, ButtonGroup, Tooltip, variables } from '@trezor/components';
 import { useDevice, useDispatch } from 'src/hooks/suite';
 import { openModal } from 'src/actions/suite/modalActions';
 import { applySettings } from 'src/actions/settings/deviceSettingsActions';
@@ -27,14 +27,6 @@ import {
 } from 'src/utils/suite/homescreen';
 import { useAnchor } from 'src/hooks/suite/useAnchor';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
-
-const StyledActionButton = styled(ActionButton)`
-    &:not(:first-of-type) {
-        @media (max-width: ${variables.SCREEN_SIZE.SM}) {
-            margin-top: 10px;
-        }
-    }
-`;
 
 const HiddenInput = styled.input`
     display: none;
@@ -163,31 +155,24 @@ export const Homescreen = ({ isDeviceLocked }: HomescreenProps) => {
                             )
                         }
                     >
-                        <StyledActionButton
-                            onClick={() => fileInputElement?.current?.click()}
-                            isDisabled={isDeviceLocked || !isSupportedHomescreen}
-                            variant="secondary"
-                            data-test="@settings/device/homescreen-upload"
-                        >
-                            <Translation id="TR_DEVICE_SETTINGS_HOMESCREEN_UPLOAD_IMAGE" />
-                        </StyledActionButton>
-                    </Tooltip>
-                    <Tooltip
-                        maxWidth={285}
-                        content={
-                            !isSupportedHomescreen && (
-                                <Translation id="TR_UPDATE_FIRMWARE_HOMESCREEN_TOOLTIP" />
-                            )
-                        }
-                    >
-                        <StyledActionButton
-                            onClick={openGallery}
-                            isDisabled={isDeviceLocked || !isSupportedHomescreen}
-                            data-test="@settings/device/homescreen-gallery"
-                            variant="secondary"
-                        >
-                            <Translation id="TR_DEVICE_SETTINGS_HOMESCREEN_SELECT_FROM_GALLERY" />
-                        </StyledActionButton>
+                        <ButtonGroup size="small">
+                            <Button
+                                onClick={() => fileInputElement?.current?.click()}
+                                isDisabled={isDeviceLocked || !isSupportedHomescreen}
+                                variant="secondary"
+                                data-test="@settings/device/homescreen-upload"
+                            >
+                                <Translation id="TR_DEVICE_SETTINGS_HOMESCREEN_UPLOAD_IMAGE" />
+                            </Button>
+                            <Button
+                                onClick={openGallery}
+                                isDisabled={isDeviceLocked || !isSupportedHomescreen}
+                                data-test="@settings/device/homescreen-gallery"
+                                variant="secondary"
+                            >
+                                <Translation id="TR_DEVICE_SETTINGS_HOMESCREEN_SELECT_FROM_GALLERY" />
+                            </Button>
+                        </ButtonGroup>
                     </Tooltip>
                 </ActionColumn>
             </SectionItem>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- use button group for display rotation
- indicate current rotation
- use button group for image inputs

## Related Issue

Resolve #10533

## Screenshots:

**before:**
<img width="1319" alt="image" src="https://github.com/trezor/trezor-suite/assets/858321/94a9c9b0-be9f-4ad8-b47c-4fde84f653f4">


**after:**
<img width="1327" alt="Screenshot 2024-01-25 at 8 34 58" src="https://github.com/trezor/trezor-suite/assets/858321/d4213d5b-7650-4f71-a668-d9a21dad34ea">


