### PR TITLE
fix: nem and eth signTx validation issues

### DIFF
--- a/packages/connect/src/api/nem/api/nemSignTransaction.ts
+++ b/packages/connect/src/api/nem/api/nemSignTransaction.ts
@@ -19,6 +19,11 @@ export default class NEMSignTransaction extends AbstractMethod<
 
         const { payload } = this;
         // validate incoming parameters
+
+        // Workaround for NEM timestamp case-sensitivity issue (issue #10793)
+        if ((payload?.transaction as any)?.timestamp) {
+            payload.transaction.timeStamp = (payload.transaction as any).timestamp;
+        }
         Assert(NEMSignTransactionSchema, payload);
 
         const path = validatePath(payload.path, 3);

--- a/packages/connect/src/types/api/ethereum/index.ts
+++ b/packages/connect/src/types/api/ethereum/index.ts
@@ -88,7 +88,7 @@ export interface EthereumSignTypedDataMessage<T extends EthereumSignTypedDataTyp
     domain: {
         name?: string;
         version?: string;
-        chainId?: number | bigint;
+        chainId?: number | bigint | string;
         verifyingContract?: string;
         salt?: ArrayBuffer | string;
     };
@@ -100,7 +100,8 @@ export const EthereumSignTypedDataMessage = Type.Object({
     domain: Type.Object({
         name: Type.Optional(Type.String()),
         version: Type.Optional(Type.String()),
-        chainId: Type.Optional(Type.Union([Type.Number(), Type.BigInt()])),
+        // loosened to support string due to issue #10793
+        chainId: Type.Optional(Type.Union([Type.Number(), Type.BigInt(), Type.String()])),
         verifyingContract: Type.Optional(Type.String()),
         salt: Type.Optional(Type.Union([Type.ArrayBuffer(), Type.String()])),
     }),

--- a/packages/connect/src/types/api/nem/index.ts
+++ b/packages/connect/src/types/api/nem/index.ts
@@ -59,7 +59,7 @@ export const Message = Type.Object({
 
 export type TransactionCommon = Static<typeof TransactionCommon>;
 export const TransactionCommon = Type.Object({
-    version: NEM.EnumTxVersion,
+    version: Type.Union([NEM.EnumTxVersion, Type.Number()]), // users may potentially want to use any arbitrary chain
     timeStamp: Type.Number(),
     fee: Type.Number(),
     deadline: Type.Number(),


### PR DESCRIPTION
Fixes for ETH and NEM validation being too strict and causing incompatibility

## Description

1. Eth: domain chainId can be a string
2. Nem: version can be any number
3. Nem: workaround for `timeStamp` case sensitivity

## Related Issue

#10793
