### PR TITLE
Schema validation loosening and improvements

### DIFF
--- a/packages/connect/src/api/binance/api/binanceSignTransaction.ts
+++ b/packages/connect/src/api/binance/api/binanceSignTransaction.ts
@@ -6,7 +6,7 @@ import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath } from '../../../utils/pathUtils';
 import * as helper from '../binanceSignTx';
 import { BinanceSignTransaction as BinanceSignTransactionSchema } from '../../../types/api/binance';
-import { Assert } from '@trezor/schema-utils';
+import { AssertWeak } from '@trezor/schema-utils';
 
 import type { BinancePreparedTransaction } from '../../../types/api/binance';
 
@@ -26,7 +26,8 @@ export default class BinanceSignTransaction extends AbstractMethod<
 
         const { payload } = this;
         // validate incoming parameters
-        Assert(BinanceSignTransactionSchema, payload);
+        // TODO: weak assert for compatibility purposes (issue #10841)
+        AssertWeak(BinanceSignTransactionSchema, payload);
 
         const path = validatePath(payload.path, 3);
         const transaction = helper.validate(payload.transaction);

--- a/packages/connect/src/api/cardano/api/cardanoSignTransaction.ts
+++ b/packages/connect/src/api/cardano/api/cardanoSignTransaction.ts
@@ -36,7 +36,7 @@ import {
 import { gatherWitnessPaths } from '../cardanoWitnesses';
 import type { AssetGroupWithTokens } from '../cardanoTokenBundle';
 import { tokenBundleToProto } from '../cardanoTokenBundle';
-import { Assert, Type } from '@trezor/schema-utils';
+import { AssertWeak, Type } from '@trezor/schema-utils';
 
 // todo: remove when listed firmwares become mandatory for cardanoSignTransaction
 const CardanoSignTransactionFeatures = Object.freeze({
@@ -134,7 +134,11 @@ export default class CardanoSignTransaction extends AbstractMethod<
         }
 
         // validate incoming parameters
-        Assert(Type.Union([CardanoSignTransactionSchema, CardanoSignTransactionExtended]), payload);
+        // TODO: weak assert for compatibility purposes (issue #10841)
+        AssertWeak(
+            Type.Union([CardanoSignTransactionSchema, CardanoSignTransactionExtended]),
+            payload,
+        );
 
         const inputsWithPath = payload.inputs.map(transformInput);
 

--- a/packages/connect/src/api/eos/api/eosSignTransaction.ts
+++ b/packages/connect/src/api/eos/api/eosSignTransaction.ts
@@ -6,7 +6,7 @@ import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath } from '../../../utils/pathUtils';
 import * as helper from '../eosSignTx';
 import type { PROTO } from '../../../constants';
-import { Assert } from '@trezor/schema-utils';
+import { AssertWeak } from '@trezor/schema-utils';
 import { EosSignTransaction as EosSignTransactionSchema } from '../../../types/api/eos';
 
 type Params = {
@@ -24,7 +24,8 @@ export default class EosSignTransaction extends AbstractMethod<'eosSignTransacti
 
         const { payload } = this;
         // validate incoming parameters
-        Assert(EosSignTransactionSchema, payload);
+        // TODO: weak assert for compatibility purposes (issue #10841)
+        AssertWeak(EosSignTransactionSchema, payload);
 
         const path = validatePath(payload.path, 3);
         const { chain_id, header, ack } = helper.validate(payload.transaction);

--- a/packages/connect/src/api/nem/api/nemSignTransaction.ts
+++ b/packages/connect/src/api/nem/api/nemSignTransaction.ts
@@ -6,7 +6,7 @@ import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath } from '../../../utils/pathUtils';
 import * as helper from '../nemSignTx';
 import type { PROTO } from '../../../constants';
-import { Assert } from '@trezor/schema-utils';
+import { AssertWeak } from '@trezor/schema-utils';
 import { NEMSignTransaction as NEMSignTransactionSchema } from '../../../types/api/nem';
 
 export default class NEMSignTransaction extends AbstractMethod<
@@ -24,7 +24,8 @@ export default class NEMSignTransaction extends AbstractMethod<
         if ((payload?.transaction as any)?.timestamp) {
             payload.transaction.timeStamp = (payload.transaction as any).timestamp;
         }
-        Assert(NEMSignTransactionSchema, payload);
+        // TODO: weak assert for compatibility purposes (issue #10841)
+        AssertWeak(NEMSignTransactionSchema, payload);
 
         const path = validatePath(payload.path, 3);
         // incoming data should be in nem-sdk format

--- a/packages/connect/src/api/ripple/api/rippleSignTransaction.ts
+++ b/packages/connect/src/api/ripple/api/rippleSignTransaction.ts
@@ -5,7 +5,7 @@ import { getFirmwareRange } from '../../common/paramsValidator';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath } from '../../../utils/pathUtils';
 import type { PROTO } from '../../../constants';
-import { Assert } from '@trezor/schema-utils';
+import { AssertWeak } from '@trezor/schema-utils';
 import { RippleSignTransaction as RippleSignTransactionSchema } from '../../../types/api/ripple';
 
 export default class RippleSignTransaction extends AbstractMethod<
@@ -22,7 +22,8 @@ export default class RippleSignTransaction extends AbstractMethod<
 
         const { payload } = this;
         // validate incoming parameters
-        Assert(RippleSignTransactionSchema, payload);
+        // TODO: weak assert for compatibility purposes (issue #10841)
+        AssertWeak(RippleSignTransactionSchema, payload);
 
         const path = validatePath(payload.path, 5);
         // incoming data should be in ripple-sdk format

--- a/packages/connect/src/api/solana/api/solanaSignTransaction.ts
+++ b/packages/connect/src/api/solana/api/solanaSignTransaction.ts
@@ -4,7 +4,7 @@ import { getFirmwareRange } from '../../common/paramsValidator';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath } from '../../../utils/pathUtils';
 import { transformAdditionalInfo } from '../additionalInfo';
-import { Assert } from '@trezor/schema-utils';
+import { AssertWeak } from '@trezor/schema-utils';
 import { SolanaSignTransaction as SolanaSignTransactionSchema } from '../../../types/api/solana';
 
 export default class SolanaSignTransaction extends AbstractMethod<
@@ -22,7 +22,8 @@ export default class SolanaSignTransaction extends AbstractMethod<
         const { payload } = this;
 
         // validate bundle type
-        Assert(SolanaSignTransactionSchema, payload);
+        // TODO: weak assert for compatibility purposes (issue #10841)
+        AssertWeak(SolanaSignTransactionSchema, payload);
 
         const path = validatePath(payload.path, 2);
 

--- a/packages/connect/src/api/stellar/api/stellarSignTransaction.ts
+++ b/packages/connect/src/api/stellar/api/stellarSignTransaction.ts
@@ -10,7 +10,7 @@ import {
     StellarTransaction,
     StellarSignTransaction as StellarSignTransactionSchema,
 } from '../../../types/api/stellar';
-import { Assert } from '@trezor/schema-utils';
+import { AssertWeak } from '@trezor/schema-utils';
 
 type Params = {
     path: number[];
@@ -37,7 +37,8 @@ export default class StellarSignTransaction extends AbstractMethod<
 
         const { payload } = this;
         // validate incoming parameters
-        Assert(StellarSignTransactionSchema, payload);
+        // TODO: weak assert for compatibility purposes (issue #10841)
+        AssertWeak(StellarSignTransactionSchema, payload);
 
         const path = validatePath(payload.path, 3);
         // incoming data should be in stellar-sdk format

--- a/packages/connect/src/api/tezos/api/tezosSignTransaction.ts
+++ b/packages/connect/src/api/tezos/api/tezosSignTransaction.ts
@@ -6,7 +6,7 @@ import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath } from '../../../utils/pathUtils';
 import * as helper from '../tezosSignTx';
 import type { PROTO } from '../../../constants';
-import { Assert } from '@trezor/schema-utils';
+import { AssertWeak } from '@trezor/schema-utils';
 import { TezosSignTransaction as TezosSignTransactionSchema } from '../../../types/api/tezos';
 
 export default class TezosSignTransaction extends AbstractMethod<
@@ -24,7 +24,8 @@ export default class TezosSignTransaction extends AbstractMethod<
         const { payload } = this;
 
         // validate incoming parameters
-        Assert(TezosSignTransactionSchema, payload);
+        // TODO: weak assert for compatibility purposes (issue #10841)
+        AssertWeak(TezosSignTransactionSchema, payload);
 
         const path = validatePath(payload.path, 3);
         this.params = helper.createTx(path, payload.branch, payload.operation);

--- a/packages/schema-utils/src/errors.ts
+++ b/packages/schema-utils/src/errors.ts
@@ -1,7 +1,10 @@
-export class InvalidParameter extends Error {
-    field?: string;
+import { ValueErrorType } from '@sinclair/typebox/errors';
 
-    constructor(reason: string, field: string, value?: any) {
+export class InvalidParameter extends Error {
+    field: string;
+    type: ValueErrorType;
+
+    constructor(reason: string, field: string, type: ValueErrorType, value?: any) {
         let message = `Invalid parameter`;
         message += ` "${field.substring(1)}"`;
         message += ` (= ${JSON.stringify(value)})`;
@@ -9,5 +12,6 @@ export class InvalidParameter extends Error {
         super(message);
         this.name = 'InvalidParameter';
         this.field = field;
+        this.type = type;
     }
 }

--- a/packages/schema-utils/src/index.ts
+++ b/packages/schema-utils/src/index.ts
@@ -1,5 +1,6 @@
-import { JavaScriptTypeBuilder, Static, TSchema, TObject, Optional } from '@sinclair/typebox';
-import { ValueErrorType, Errors } from '@sinclair/typebox/errors';
+/* eslint-disable @typescript-eslint/no-use-before-define */
+import { JavaScriptTypeBuilder, Static, TSchema, TObject, Optional, Kind } from '@sinclair/typebox';
+import { ValueErrorType, Errors, ValueError } from '@sinclair/typebox/errors';
 import { Mixin } from 'ts-mixer';
 
 import { ArrayBufferBuilder, BufferBuilder, KeyofEnumBuilder, UintBuilder } from './custom-types';
@@ -15,11 +16,45 @@ class CustomTypeBuilder extends Mixin(
 
 export function Validate<T extends TSchema>(schema: T, value: unknown): value is Static<T> {
     try {
-        // eslint-disable-next-line @typescript-eslint/no-use-before-define
         Assert(schema, value);
         return true;
     } catch (e) {
         return false;
+    }
+}
+
+function FindErrorInUnion(error: ValueError) {
+    const currentValue: any = error.value;
+    const unionMembers: TSchema[] = error.schema.anyOf;
+    const hasValidMember = unionMembers.find(unionSchema => Validate(unionSchema, currentValue));
+    if (!hasValidMember) {
+        // Find possible matches by literals
+        const possibleMatchesByLiterals = unionMembers.filter(unionSchema => {
+            if (unionSchema[Kind] !== 'Object') return false;
+            return !Object.entries(unionSchema.properties as TObject['properties']).find(
+                ([property, propertySchema]) =>
+                    propertySchema.const && propertySchema.const !== currentValue[property],
+            );
+        });
+        if (possibleMatchesByLiterals.length === 1) {
+            // There is only one possible match
+            Assert(possibleMatchesByLiterals[0], currentValue);
+        } else if (possibleMatchesByLiterals.length > 1) {
+            // Find match with least amount of errors
+            const errorsOfPossibleMatches = possibleMatchesByLiterals.map(
+                (matchSchema: TSchema) => ({
+                    schema: matchSchema,
+                    errors: [...Errors(matchSchema, currentValue)],
+                }),
+            );
+            const sortedErrors = errorsOfPossibleMatches.sort(
+                (a, b) => a.errors.length - b.errors.length,
+            );
+            const [bestMatch] = sortedErrors;
+            Assert(bestMatch.schema, currentValue);
+        }
+
+        throw new InvalidParameter(error.message, error.path, error.type, error.value);
     }
 }
 
@@ -33,16 +68,31 @@ export function Assert<T extends TSchema>(schema: T, value: unknown): asserts va
             // Optional can also accept null values
         } else if (error.type === ValueErrorType.Union) {
             // Drill down into the union
-            const currentValue = error.value;
-            const hasValidMember = error.schema.anyOf.find((unionSchema: TSchema) =>
-                Validate(unionSchema, currentValue),
-            );
-            if (!hasValidMember) throw new InvalidParameter(error.message, error.path, error.value);
+            FindErrorInUnion(error);
         } else {
-            throw new InvalidParameter(error.message, error.path, error.value);
+            throw new InvalidParameter(error.message, error.path, error.type, error.value);
         }
         errors.shift();
         [error] = errors;
+    }
+}
+
+export function AssertWeak<T extends TSchema>(
+    schema: T,
+    value: unknown,
+): asserts value is Static<T> {
+    try {
+        Assert(schema, value);
+    } catch (e) {
+        if (e instanceof InvalidParameter) {
+            if (e.type === ValueErrorType.ObjectRequiredProperty) {
+                // We consider this error to be serious
+                throw e;
+            }
+            console.warn('Method params validation failed', e);
+        } else {
+            throw e;
+        }
     }
 }
 

--- a/packages/schema-utils/src/utils.ts
+++ b/packages/schema-utils/src/utils.ts
@@ -1,0 +1,15 @@
+/**
+ * Sets a value in an object by a path
+ * From https://stackoverflow.com/a/53762921
+ * @param obj object to set value in
+ * @param param path to the value
+ * @param value value to set
+ */
+export function setDeepValue(obj: any, [prop, ...path]: string[], value: any) {
+    if (!path.length) {
+        obj[prop] = value;
+    } else {
+        if (!(prop in obj)) obj[prop] = {};
+        setDeepValue(obj[prop], path, value);
+    }
+}

--- a/packages/schema-utils/tests/complex-example.test.ts
+++ b/packages/schema-utils/tests/complex-example.test.ts
@@ -1,4 +1,4 @@
-import { Type, Validate } from '../src';
+import { Assert, Type, Validate } from '../src';
 
 describe('complex-example', () => {
     it('should work with a schema like StellarSignTx', () => {
@@ -75,5 +75,57 @@ describe('complex-example', () => {
             encoded_network: 'invalid',
         };
         expect(Validate(schema, invalidValue)).toBe(false);
+    });
+
+    it('should work with union types', () => {
+        const schemaA = Type.Object({
+            type: Type.Literal('A'),
+            a: Type.String(),
+        });
+
+        const schemaA2 = Type.Object({
+            type: Type.Literal('A'),
+            b: Type.Number(),
+            c: Type.Number(),
+        });
+
+        const schemaB = Type.Object({
+            type: Type.Literal('B'),
+            b: Type.String(),
+        });
+
+        const schema = Type.Union([schemaA, schemaA2, schemaB]);
+
+        const invalidSchema = {
+            type: 'C',
+        };
+        expect(() => Assert(schema, invalidSchema)).toThrow(
+            'Invalid parameter "" (= {"type":"C"}): Expected union value',
+        );
+
+        const invalidSchema2 = {
+            type: 'A',
+            a: 123,
+        };
+        expect(() => Assert(schema, invalidSchema2)).toThrow(
+            'Invalid parameter "a" (= 123): Expected string',
+        );
+
+        const invalidSchema3 = {
+            type: 'A',
+            b: 123,
+            c: 'str',
+        };
+        expect(() => Assert(schema, invalidSchema3)).toThrow(
+            'Invalid parameter "c" (= "str"): Expected number',
+        );
+
+        const invalidSchema4 = {
+            type: 'B',
+            a: 123,
+        };
+        expect(() => Assert(schema, invalidSchema4)).toThrow(
+            'Invalid parameter "b" (= undefined): Required property',
+        );
     });
 });

--- a/packages/schema-utils/tests/number-autocast.test.ts
+++ b/packages/schema-utils/tests/number-autocast.test.ts
@@ -1,0 +1,23 @@
+import { Type, Assert } from '../src';
+
+describe('number-autocast', () => {
+    it('should string to number if needed', () => {
+        const schema = Type.Object({
+            number: Type.Number(),
+            nested: Type.Object({
+                number: Type.Number(),
+            }),
+        });
+
+        const input = {
+            number: '1',
+            nested: {
+                number: '1',
+            },
+        };
+
+        Assert(schema, input);
+        expect(input.number).toEqual(1);
+        expect(input.nested.number).toEqual(1);
+    });
+});

--- a/packages/schema-utils/tests/utils.test.ts
+++ b/packages/schema-utils/tests/utils.test.ts
@@ -1,0 +1,21 @@
+import { setDeepValue } from '../src/utils';
+
+describe('setDeepValue', () => {
+    it('sets a deep value in an object', () => {
+        const obj = {};
+        setDeepValue(obj, ['a', 'b', 'c'], 123);
+        expect(obj).toEqual({ a: { b: { c: 123 } } });
+    });
+
+    it('overwrites existing values', () => {
+        const obj = { a: { b: { c: 123 } } };
+        setDeepValue(obj, ['a', 'b', 'c'], 456);
+        expect(obj).toEqual({ a: { b: { c: 456 } } });
+    });
+
+    it('creates intermediate objects if necessary', () => {
+        const obj = {};
+        setDeepValue(obj, ['a', 'b', 'c'], 123);
+        expect(obj).toEqual({ a: { b: { c: 123 } } });
+    });
+});

--- a/packages/schema-utils/tests/weak-assert.test.ts
+++ b/packages/schema-utils/tests/weak-assert.test.ts
@@ -1,0 +1,43 @@
+import { AssertWeak, Type } from '../src';
+
+describe('weak-assert', () => {
+    it('should not throw if type is mismatched', () => {
+        const schema = Type.Object({
+            foo: Type.String(),
+        });
+        const value = {
+            foo: 123,
+        };
+
+        console.warn = jest.fn();
+        expect(() => AssertWeak(schema, value)).not.toThrow();
+        expect(console.warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not throw if a property is mismatched in a union', () => {
+        const schema = Type.Union([
+            Type.Object({
+                foo: Type.String(),
+            }),
+            Type.Object({
+                bar: Type.Number(),
+            }),
+        ]);
+        const value = {
+            foo: 123,
+        };
+
+        console.warn = jest.fn();
+        expect(() => AssertWeak(schema, value)).not.toThrow();
+        expect(console.warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw if a required field is missing', () => {
+        const schema = Type.Object({
+            foo: Type.String(),
+        });
+        const value = {};
+
+        expect(() => AssertWeak(schema, value)).toThrow();
+    });
+});


### PR DESCRIPTION
With the stricter new validation system, we could encounter problems with incompatibility with 3rd parties which are not using the exact types. 
The goal is to loosen the types for complicated methods such as signTransaction in altcoins.

## Description

1. Improved error messages for unions, previously it would only give a very generic error. 
After the change it will find the closest matching type in the union and validate the input against it to give a more accurate error message.

2. Added `AssertWeak` - throws only if required property is missing, otherwise it only logs a warning to console

3. Added automatic cast from string -> number if possible. This is a common mistake that we see and we can mitigate it automatically