### PR TITLE
Revert "feat(blockchain-link); get sol token metadata from coingecko"

### DIFF
--- a/packages/blockchain-link-utils/src/solana.ts
+++ b/packages/blockchain-link-utils/src/solana.ts
@@ -29,6 +29,40 @@ export const SYSTEM_PROGRAM_PUBLIC_KEY = '11111111111111111111111111111111';
 // when parsing tx effects.
 export const WSOL_MINT = 'So11111111111111111111111111111111111111112';
 
+// https://github.com/viaprotocol/tokenlists
+// Aggregated token list with tokens listed on multiple exchanges
+const SOLANA_TOKEN_LIST_URL =
+    'https://cdn.jsdelivr.net/gh/viaprotocol/tokenlists/all_tokens/solana.json';
+
+const LOCAL_TOKEN_METADATA: TokenDetailByMint = {
+    DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263: {
+        name: 'Bonk',
+        symbol: 'BONK',
+    },
+};
+
+export const getTokenMetadata = async (): Promise<TokenDetailByMint> => {
+    const tokenListResult: { address: string; name: string; symbol: string }[] = await (
+        await fetch(SOLANA_TOKEN_LIST_URL)
+    ).json();
+
+    const tokenMap = tokenListResult.reduce(
+        (acc, token) => ({
+            [token.address]: {
+                name: token.name,
+                symbol: token.symbol,
+            },
+            ...acc,
+        }),
+        {} as TokenDetailByMint,
+    );
+
+    // Explicitly set Wrapped SOL symbol to WSOL instead of the official 'SOL' which leads to confusion in UI
+    tokenMap[WSOL_MINT].symbol = 'WSOL';
+
+    return { ...LOCAL_TOKEN_METADATA, ...tokenMap };
+};
+
 export const getTokenNameAndSymbol = (mint: string, tokenDetailByMint: TokenDetailByMint) => {
     const tokenDetail = tokenDetailByMint[mint];
 
@@ -503,12 +537,12 @@ export const getTokens = (
     return effects;
 };
 
-export const transformTransaction = (
+export const transformTransaction = async (
     tx: SolanaValidParsedTxWithMeta,
     accountAddress: string,
     tokenAccountsInfos: SolanaTokenAccountInfo[],
-    tokenDetailByMint: TokenDetailByMint,
-): Transaction => {
+): Promise<Transaction> => {
+    const tokenDetailByMint = await getTokenMetadata();
     const nativeEffects = getNativeEffects(tx);
 
     const tokens = getTokens(tx, accountAddress, tokenDetailByMint, tokenAccountsInfos);

--- a/packages/blockchain-link-utils/src/tests/solana.test.ts
+++ b/packages/blockchain-link-utils/src/tests/solana.test.ts
@@ -120,7 +120,6 @@ describe('solana/utils', () => {
                     input.transaction as SolanaValidParsedTxWithMeta,
                     input.accountAddress,
                     input.tokenAccountsInfos,
-                    {},
                 );
                 expect(result).toEqual(expectedOutput);
             });

--- a/packages/blockchain-link/src/workers/solana/tokenUtils.ts
+++ b/packages/blockchain-link/src/workers/solana/tokenUtils.ts
@@ -1,5 +1,4 @@
 import * as BufferLayout from '@solana/buffer-layout';
-import { TokenDetailByMint } from 'packages/blockchain-link-types/lib/solana';
 
 // This type is required to construct the TOKEN_ACCOUNT_LAYOUT,
 // See: https://stackoverflow.com/questions/72413915/encoding-typescript-lib-solana-buffer-layout
@@ -16,64 +15,3 @@ export const TOKEN_ACCOUNT_LAYOUT = BufferLayout.struct<TokenAccountLayout>([
     BufferLayout.nu64('amount'),
     BufferLayout.blob(93),
 ]);
-
-// a proxy for https://api.coingecko.com/api/v3
-const getCoingeckoTokenDetailUrl = (mint: string) =>
-    `https://cdn.trezor.io/dynamic/coingecko/api/v3/coins/solana/contract/${mint}?localization=false&tickers=false&market_data=false&community_data=false&developer_data=false&sparkline=false`;
-
-type TokenDetail = {
-    name: string;
-    symbol: string;
-};
-
-const isTokenDetail = (data: any): data is TokenDetail =>
-    data &&
-    'name' in data &&
-    typeof data.name === 'string' &&
-    'symbol' in data &&
-    typeof data.symbol === 'string';
-
-const fetchTokenDetail = async (mint: string): Promise<TokenDetail | null> =>
-    (await fetch(getCoingeckoTokenDetailUrl(mint))).json().then((data: any) => {
-        if (isTokenDetail(data)) {
-            return data;
-        }
-        return null;
-    });
-
-export const fetchCoingeckoTokenDetailByMint = async (
-    mintBundle: string[],
-): Promise<TokenDetailByMint> => {
-    try {
-        const metadataBundle = (
-            await Promise.all(
-                mintBundle.map(async mint => {
-                    const detail = await fetchTokenDetail(mint).catch(() => null);
-                    return detail
-                        ? {
-                              mint,
-                              detail,
-                          }
-                        : null;
-                }),
-            )
-        ).filter(
-            (detailWithMint): detailWithMint is { mint: string; detail: TokenDetail } =>
-                detailWithMint !== null,
-        );
-
-        const result = metadataBundle.reduce((acc, meta) => {
-            const { mint, detail } = meta;
-            return {
-                ...acc,
-                [mint]: {
-                    name: detail.name,
-                    symbol: detail.symbol,
-                },
-            };
-        }, {} as TokenDetailByMint);
-        return result;
-    } catch (e) {
-        return {};
-    }
-};


### PR DESCRIPTION
This reverts commit 312a0b9be3b706e685fe4b3bb461c900907c6fd9.

We want to use #10646 instead because if request to CoinGecko fails, the tokens do not have name. 

cc @MiroslavProchazka 