### PR TITLE
Add new coin account

### DIFF
--- a/suite-native/accounts/src/components/SelectableNetworkItem.tsx
+++ b/suite-native/accounts/src/components/SelectableNetworkItem.tsx
@@ -1,12 +1,14 @@
 import { TouchableOpacity } from 'react-native';
 
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
-import { Badge, Box, HStack, RoundedIcon, Text } from '@suite-native/atoms';
 import { networks, NetworkSymbol } from '@suite-common/wallet-config';
 import { useFormatters } from '@suite-common/formatters';
+import { Icon, IconName } from '@suite-common/icons';
+import { Badge, Box, HStack, RoundedIcon, Text } from '@suite-native/atoms';
 
 export type SelectableAssetItemProps = {
     symbol: NetworkSymbol;
+    rightIcon?: IconName;
     onPress?: (networkSymbol: NetworkSymbol) => void;
 };
 
@@ -22,7 +24,7 @@ const erc20BadgeStyle = prepareNativeStyle(utils => ({
     paddingBottom: utils.spacings.extraSmall / 2,
 }));
 
-export const SelectableNetworkItem = ({ symbol, onPress }: SelectableAssetItemProps) => {
+export const SelectableNetworkItem = ({ symbol, onPress, rightIcon }: SelectableAssetItemProps) => {
     const { applyStyle } = useNativeStyles();
     const { NetworkSymbolFormatter } = useFormatters();
 
@@ -61,6 +63,7 @@ export const SelectableNetworkItem = ({ symbol, onPress }: SelectableAssetItemPr
                         </HStack>
                     </Box>
                 </Box>
+                {rightIcon && <Icon name={rightIcon} color="iconDisabled" size="large" />}
             </Box>
         </TouchableOpacity>
     );

--- a/suite-native/accounts/src/index.ts
+++ b/suite-native/accounts/src/index.ts
@@ -2,6 +2,7 @@ export * from './components/AccountsList';
 export * from './components/AccountsListGroup';
 export * from './components/AccountListItem';
 export * from './components/SearchableAccountsListScreenHeader';
+export * from './components/SelectableNetworkItem';
 export * from './useAccountLabelForm';
 export * from './selectors';
 export * from './transactionCacheMiddleware';

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -44,6 +44,7 @@
         "@suite-native/message-system": "workspace:*",
         "@suite-native/module-accounts-import": "workspace:*",
         "@suite-native/module-accounts-management": "workspace:*",
+        "@suite-native/module-add-accounts": "workspace:*",
         "@suite-native/module-connect-device": "workspace:*",
         "@suite-native/module-dev-utils": "workspace:*",
         "@suite-native/module-home": "workspace:*",

--- a/suite-native/app/src/navigation/RootStackNavigator.tsx
+++ b/suite-native/app/src/navigation/RootStackNavigator.tsx
@@ -18,6 +18,7 @@ import { TransactionDetailScreen } from '@suite-native/transactions';
 import { OnboardingStackNavigator } from '@suite-native/module-onboarding';
 import { ReceiveModalScreen } from '@suite-native/receive';
 import { ConnectDeviceStackNavigator } from '@suite-native/module-connect-device';
+import { AddCoinAccountStackNavigator } from '@suite-native/module-add-accounts';
 import { DeviceInfoModalScreen, useHandleDeviceConnection } from '@suite-native/device';
 
 import { AppTabNavigator } from './AppTabNavigator';
@@ -73,6 +74,10 @@ export const RootStackNavigator = () => {
             <RootStack.Screen
                 name={RootStackRoutes.DevUtilsStack}
                 component={DevUtilsStackNavigator}
+            />
+            <RootStack.Screen
+                name={RootStackRoutes.AddCoinAccountStack}
+                component={AddCoinAccountStackNavigator}
             />
             <RootStack.Screen name={RootStackRoutes.ReceiveModal} component={ReceiveModalScreen} />
             <RootStack.Screen name={RootStackRoutes.DeviceInfo} component={DeviceInfoModalScreen} />

--- a/suite-native/app/tsconfig.json
+++ b/suite-native/app/tsconfig.json
@@ -39,6 +39,7 @@
         {
             "path": "../module-accounts-management"
         },
+        { "path": "../module-add-accounts" },
         { "path": "../module-connect-device" },
         { "path": "../module-dev-utils" },
         { "path": "../module-home" },

--- a/suite-native/discovery/src/discoveryConfigSlice.ts
+++ b/suite-native/discovery/src/discoveryConfigSlice.ts
@@ -1,5 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { pipe } from '@mobily/ts-belt';
+import { memoizeWithArgs } from 'proxy-memoize';
 
 import {
     DeviceRootState,
@@ -71,17 +72,18 @@ export const selectDisabledDiscoveryNetworkSymbolsForDevelopment = (
     state: DiscoveryConfigSliceRootState,
 ) => state.discoveryConfig.disabledDiscoveryNetworkSymbolsForDevelopment;
 
-export const selectDiscoverySupportedNetworks = (
-    state: DeviceRootState,
-    areTestnetsEnabled: boolean,
-) =>
-    pipe(
-        selectDeviceSupportedNetworks(state),
-        networkSymbols => filterTestnetNetworks(networkSymbols, areTestnetsEnabled),
-        filterUnavailableNetworks,
-        filterBlacklistedNetworks,
-        sortNetworks,
-    );
+export const selectDiscoverySupportedNetworks = memoizeWithArgs(
+    (state: DeviceRootState, areTestnetsEnabled: boolean) =>
+        pipe(
+            selectDeviceSupportedNetworks(state),
+            networkSymbols => filterTestnetNetworks(networkSymbols, areTestnetsEnabled),
+            filterUnavailableNetworks,
+            filterBlacklistedNetworks,
+            sortNetworks,
+        ),
+    // for all areTestnetsEnabled states
+    { size: 2 },
+);
 
 export const {
     toggleAreTestnetsEnabled,

--- a/suite-native/discovery/src/index.ts
+++ b/suite-native/discovery/src/index.ts
@@ -1,3 +1,4 @@
 export { prepareDiscoveryMiddleware } from './discoveryMiddleware';
 export * from './discoveryConfigSlice';
 export * from './useIsDiscoveryDurationTooLong';
+export * from './discoveryThunks';

--- a/suite-native/ethereum-tokens/src/ethereumTokensSelectors.ts
+++ b/suite-native/ethereum-tokens/src/ethereumTokensSelectors.ts
@@ -124,7 +124,7 @@ const selectAccountTransactionsWithTokensWithFiatRates = memoizeWithArgs(
             A.map(transaction => ({
                 ...transaction,
                 tokens: pipe(
-                    transaction.tokens,
+                    transaction?.tokens ?? [],
                     A.filter(isNotZeroAmountTranfer),
                     A.filter(token =>
                         selectEthereumTokenHasFiatRates(

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -153,6 +153,25 @@ export const en = {
             confirmButton: 'Got it',
         },
     },
+    moduleAddAccounts: {
+        addCoinAccountScreen: {
+            title: 'Add new',
+        },
+        alerts: {
+            tooManyAccounts: {
+                title: 'You have reached maximum number of accounts',
+                description: 'You can create up to 10 accounts of a type for each coin.',
+                actionPrimary: 'Close',
+            },
+            anotherEmptyAccount: {
+                title: 'Can’t create another fresh account',
+                description: 'The last account you created for this coin has no transactions yet.',
+                actionPrimary: 'Close',
+                actionSecondary: 'Learn more',
+                actionSecondaryUrl: 'https://trezor.io/learn/a/multiple-accounts-in-trezor-suite',
+            },
+        },
+    },
     moduleConnectDevice: {
         connectAndUnlockScreen: {
             title: 'Connect & unlock\nyour Trezor',

--- a/suite-native/module-accounts-import/src/components/SelectableNetworkList.tsx
+++ b/suite-native/module-accounts-import/src/components/SelectableNetworkList.tsx
@@ -1,8 +1,7 @@
+import { SelectableNetworkItem } from '@suite-native/accounts';
 import { HeaderedCard, VStack } from '@suite-native/atoms';
 import { Network, NetworkSymbol } from '@suite-common/wallet-config';
 import { portfolioTrackerMainnets, portfolioTrackerTestnets } from '@suite-native/config';
-
-import { SelectableNetworkItem } from './SelectableNetworkItem';
 
 type SelectableAssetListProps = {
     onSelectItem: (networkSymbol: NetworkSymbol) => void;

--- a/suite-native/module-accounts-import/src/screens/XpubScanScreen.tsx
+++ b/suite-native/module-accounts-import/src/screens/XpubScanScreen.tsx
@@ -25,11 +25,11 @@ import {
     // TODO: This direct import is needed to avoid importing the `@suite-common/wallet-utils`
     // to the `connect` packages. Should be revisited soon when fixing the monorepo tree shaking problems.
 } from '@suite-common/validators/src/schemas/xpubSchema';
+import { SelectableNetworkItem } from '@suite-native/accounts';
 
 import { XpubImportSection } from '../components/XpubImportSection';
 import { AccountImportSubHeader } from '../components/AccountImportSubHeader';
 import { DevXpub } from '../components/DevXpub';
-import { SelectableNetworkItem } from '../components/SelectableNetworkItem';
 import { XpubHint } from '../components/XpubHint';
 import { XpubHintBottomSheet } from '../components/XpubHintBottomSheet';
 

--- a/suite-native/module-accounts-management/src/components/AddAccountsButton.tsx
+++ b/suite-native/module-accounts-management/src/components/AddAccountsButton.tsx
@@ -1,3 +1,5 @@
+import { useSelector } from 'react-redux';
+
 import { useNavigation } from '@react-navigation/native';
 
 import {
@@ -7,8 +9,10 @@ import {
     StackNavigationProps,
 } from '@suite-native/navigation';
 import { IconButton } from '@suite-native/atoms';
+import { selectIsPortfolioTrackerDevice } from '@suite-common/wallet-core';
 
 export const AddAccountButton = () => {
+    const isSelectedDevicePortfolioTracker = useSelector(selectIsPortfolioTrackerDevice);
     const navigation =
         useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes.AccountsImport>>();
 
@@ -18,10 +22,14 @@ export const AddAccountButton = () => {
         });
     };
 
+    const navigateToAddCoinAccount = () => navigation.navigate(RootStackRoutes.AddCoinAccountStack);
+
     return (
         <IconButton
             iconName="plus"
-            onPress={navigateToImportScreen}
+            onPress={
+                isSelectedDevicePortfolioTracker ? navigateToImportScreen : navigateToAddCoinAccount
+            }
             colorScheme="tertiaryElevation0"
             size="medium"
         />

--- a/suite-native/module-accounts-management/src/screens/AccountsScreen.tsx
+++ b/suite-native/module-accounts-management/src/screens/AccountsScreen.tsx
@@ -14,7 +14,7 @@ import { AccountsList, SearchableAccountsListScreenHeader } from '@suite-native/
 import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
 import {
     selectAreAllDevicesDisconnectedOrAccountless,
-    selectIsPortfolioTrackerDevice,
+    selectDeviceDiscovery,
 } from '@suite-common/wallet-core';
 
 import { AddAccountButton } from '../components/AddAccountsButton';
@@ -23,10 +23,11 @@ export const AccountsScreen = () => {
     const navigation =
         useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes.AccountDetail>>();
 
-    const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const areAllDevicesDisconnectedOrAccountless = useSelector(
         selectAreAllDevicesDisconnectedOrAccountless,
     );
+
+    const discovery = useSelector(selectDeviceDiscovery);
 
     const [accountsFilterValue, setAccountsFilterValue] = useState<string>('');
 
@@ -49,8 +50,8 @@ export const AccountsScreen = () => {
                     title="My assets"
                     onSearchInputChange={handleFilterChange}
                     rightIcon={
-                        isPortfolioTrackerDevice &&
-                        !areAllDevicesDisconnectedOrAccountless && <AddAccountButton />
+                        !areAllDevicesDisconnectedOrAccountless &&
+                        !discovery && <AddAccountButton />
                     }
                 />
             }

--- a/suite-native/module-add-accounts/package.json
+++ b/suite-native/module-add-accounts/package.json
@@ -1,9 +1,10 @@
 {
-    "name": "@suite-native/discovery",
+    "name": "@suite-native/module-add-accounts",
     "version": "1.0.0",
     "private": true,
     "license": "See LICENSE.md in repo root",
     "sideEffects": false,
+    "type": "module",
     "main": "src/index",
     "scripts": {
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
@@ -11,23 +12,24 @@
     },
     "dependencies": {
         "@mobily/ts-belt": "^3.13.1",
+        "@react-navigation/native": "6.1.9",
+        "@react-navigation/native-stack": "6.9.17",
         "@reduxjs/toolkit": "1.9.5",
-        "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
-        "@suite-common/wallet-constants": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
-        "@suite-common/wallet-utils": "workspace:*",
         "@suite-native/accounts": "workspace:*",
-        "@suite-native/analytics": "workspace:*",
-        "@suite-native/config": "workspace:*",
-        "@suite-native/device": "workspace:*",
-        "@suite-native/device-mutex": "workspace:*",
-        "@trezor/connect": "workspace:*",
-        "@trezor/device-utils": "workspace:*",
-        "proxy-memoize": "2.0.2",
+        "@suite-native/alerts": "workspace:*",
+        "@suite-native/atoms": "workspace:*",
+        "@suite-native/discovery": "workspace:*",
+        "@suite-native/intl": "workspace:*",
+        "@suite-native/link": "workspace:*",
+        "@suite-native/navigation": "workspace:*",
         "react": "18.2.0",
         "react-redux": "8.0.7"
+    },
+    "devDependencies": {
+        "typescript": "5.3.2"
     }
 }

--- a/suite-native/module-add-accounts/redux.d.ts
+++ b/suite-native/module-add-accounts/redux.d.ts
@@ -1,0 +1,7 @@
+import { AsyncThunkAction } from '@reduxjs/toolkit';
+
+declare module 'redux' {
+    export interface Dispatch {
+        <TThunk extends AsyncThunkAction<any, any, any>>(thunk: TThunk): ReturnType<TThunk>;
+    }
+}

--- a/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
+++ b/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
@@ -1,0 +1,191 @@
+import { useMemo, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { useNavigation } from '@react-navigation/native';
+import { A, pipe } from '@mobily/ts-belt';
+
+import { AccountType, NetworkSymbol, Network, networks } from '@suite-common/wallet-config';
+import {
+    AccountsRootState,
+    DeviceRootState,
+    LIMIT,
+    selectDevice,
+    selectDeviceAccounts,
+} from '@suite-common/wallet-core';
+import { useAlert } from '@suite-native/alerts';
+import {
+    addAndDiscoverNetworkAccountThunk,
+    selectAreTestnetsEnabled,
+    selectDiscoverySupportedNetworks,
+    NORMAL_ACCOUNT_TYPE,
+} from '@suite-native/discovery';
+import { useTranslate } from '@suite-native/intl';
+import { useOpenLink } from '@suite-native/link';
+import {
+    RootStackParamList,
+    RootStackRoutes,
+    StackNavigationProps,
+} from '@suite-native/navigation';
+
+export const useAddCoinAccount = () => {
+    const dispatch = useDispatch();
+    const { translate } = useTranslate();
+    const openLink = useOpenLink();
+    const areTestnetsEnabled = useSelector(selectAreTestnetsEnabled);
+    const supportedNetworks = useSelector((state: DeviceRootState) =>
+        selectDiscoverySupportedNetworks(state, areTestnetsEnabled),
+    );
+    const accounts = useSelector((state: AccountsRootState & DeviceRootState) =>
+        selectDeviceAccounts(state),
+    );
+    const device = useSelector(selectDevice);
+    const { showAlert, hideAlert } = useAlert();
+    const navigation =
+        useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes.AccountDetail>>();
+    const [isAddingCoinAccount, setIsAddingCoinAccount] = useState<boolean>(false);
+
+    const supportedNetworkSymbols = pipe(
+        supportedNetworks,
+        A.map(n => n.symbol),
+        A.uniq,
+    );
+
+    const availableNetworkAccountTypes = useMemo(() => {
+        // first account type for every network is set to normal and represents default type
+        const availableTypes: Map<NetworkSymbol | undefined, AccountType[]> = new Map();
+        Object.keys(networks).forEach(symbol =>
+            availableTypes.set(symbol as NetworkSymbol, [
+                NORMAL_ACCOUNT_TYPE,
+                ...(Object.keys(networks[symbol].accountTypes) as AccountType[]).filter(
+                    accountType => accountType !== 'coinjoin', // coinjoin is not supported
+                ),
+            ]),
+        );
+        return availableTypes;
+    }, []);
+
+    const getAvailableAccountTypesForNetwork = ({ network }: { network: Network }) =>
+        availableNetworkAccountTypes.get(network.symbol) ?? [NORMAL_ACCOUNT_TYPE];
+
+    const getDefaultAccountType = ({ network }: { network: Network }) =>
+        getAvailableAccountTypesForNetwork({ network })[0];
+
+    const getNetworkToAdd = ({
+        networkSymbol,
+        accountType,
+    }: {
+        networkSymbol: NetworkSymbol;
+        accountType?: AccountType;
+    }) => {
+        const type =
+            accountType ??
+            getDefaultAccountType({
+                network: supportedNetworks.filter(network => network.symbol === networkSymbol)[0],
+            });
+
+        return supportedNetworks.filter(
+            network =>
+                network.symbol === networkSymbol &&
+                (type === NORMAL_ACCOUNT_TYPE
+                    ? network.accountType === undefined
+                    : network.accountType === type),
+        )[0];
+    };
+
+    const showTooManyAccountsAlert = () =>
+        showAlert({
+            title: translate('moduleAddAccounts.alerts.tooManyAccounts.title'),
+            description: translate('moduleAddAccounts.alerts.tooManyAccounts.description'),
+            icon: 'warningCircle',
+            pictogramVariant: 'red',
+            primaryButtonTitle: translate('moduleAddAccounts.alerts.tooManyAccounts.actionPrimary'),
+            onPressPrimaryButton: () => {
+                hideAlert();
+            },
+        });
+
+    const showAnotherEmptyAccountAlert = () =>
+        showAlert({
+            title: translate('moduleAddAccounts.alerts.anotherEmptyAccount.title'),
+            description: translate('moduleAddAccounts.alerts.anotherEmptyAccount.description'),
+            icon: 'warningCircle',
+            pictogramVariant: 'red',
+            primaryButtonTitle: translate(
+                'moduleAddAccounts.alerts.anotherEmptyAccount.actionPrimary',
+            ),
+            onPressPrimaryButton: () => {
+                hideAlert();
+            },
+            secondaryButtonTitle: translate(
+                'moduleAddAccounts.alerts.anotherEmptyAccount.actionSecondary',
+            ),
+            onPressSecondaryButton: () => {
+                openLink(
+                    translate('moduleAddAccounts.alerts.anotherEmptyAccount.actionSecondaryUrl'),
+                );
+                hideAlert();
+            },
+        });
+
+    const addCoinAccount = async ({ network, type }: { network: Network; type?: AccountType }) => {
+        if (!device?.state) {
+            return false;
+        }
+
+        const accountType = type ?? getDefaultAccountType({ network });
+
+        const currentAccountTypeAccounts = accounts.filter(
+            account => account.symbol === network.symbol && account.accountType === accountType,
+        );
+
+        // Do not allow adding more than 10 accounts of the same type
+        if (currentAccountTypeAccounts.length > LIMIT) {
+            showTooManyAccountsAlert();
+            return false;
+        }
+
+        // Do not allow adding another empty account if there is already one
+        const emptyAccounts = currentAccountTypeAccounts.filter(account => account.empty);
+
+        if (emptyAccounts.length > 0) {
+            showAnotherEmptyAccountAlert();
+            return false;
+        }
+
+        setIsAddingCoinAccount(true);
+        const account = await dispatch(
+            addAndDiscoverNetworkAccountThunk({
+                network,
+                accountType,
+                deviceState: device.state,
+            }),
+        ).unwrap();
+
+        setIsAddingCoinAccount(false);
+
+        if (account) {
+            navigation.navigate(RootStackRoutes.AccountDetail, {
+                accountKey: account.key,
+                tokenContract: undefined,
+            });
+        }
+    };
+
+    const onSelectedNetworkItem = (networkSymbol: NetworkSymbol) => {
+        if (isAddingCoinAccount) {
+            return;
+        }
+        const network = getNetworkToAdd({ networkSymbol });
+        if (network) {
+            addCoinAccount({ network });
+        }
+    };
+
+    return {
+        supportedNetworkSymbols,
+        isAddingCoinAccount,
+        onSelectedNetworkItem,
+        getAvailableAccountTypesForNetwork,
+        addCoinAccount,
+    };
+};

--- a/suite-native/module-add-accounts/src/index.ts
+++ b/suite-native/module-add-accounts/src/index.ts
@@ -1,0 +1,1 @@
+export * from './navigation/AddCoinAccountStackNavigator';

--- a/suite-native/module-add-accounts/src/navigation/AddCoinAccountStackNavigator.tsx
+++ b/suite-native/module-add-accounts/src/navigation/AddCoinAccountStackNavigator.tsx
@@ -1,0 +1,24 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+
+import {
+    AddCoinAccountStackParamList,
+    AddCoinAccountStackRoutes,
+    stackNavigationOptionsConfig,
+} from '@suite-native/navigation';
+
+import { AddCoinAccountScreen } from '../screens/AddCoinAccountScreen';
+
+const AddCoinAccountStack = createNativeStackNavigator<AddCoinAccountStackParamList>();
+
+export const AddCoinAccountStackNavigator = () => (
+    <AddCoinAccountStack.Navigator
+        initialRouteName={AddCoinAccountStackRoutes.AddCoinAccount}
+        screenOptions={stackNavigationOptionsConfig}
+    >
+        <AddCoinAccountStack.Screen
+            options={{ title: AddCoinAccountStackRoutes.AddCoinAccount }}
+            name={AddCoinAccountStackRoutes.AddCoinAccount}
+            component={AddCoinAccountScreen}
+        />
+    </AddCoinAccountStack.Navigator>
+);

--- a/suite-native/module-add-accounts/src/screens/AddCoinAccountScreen.tsx
+++ b/suite-native/module-add-accounts/src/screens/AddCoinAccountScreen.tsx
@@ -1,0 +1,36 @@
+import { Screen, ScreenSubHeader } from '@suite-native/navigation';
+import { Card, VStack } from '@suite-native/atoms';
+import { useTranslate } from '@suite-native/intl';
+import { SelectableNetworkItem } from '@suite-native/accounts';
+
+import { useAddCoinAccount } from '../hooks/useAddCoinAccount';
+
+export const AddCoinAccountScreen = () => {
+    const { translate } = useTranslate();
+
+    const { supportedNetworkSymbols, onSelectedNetworkItem } = useAddCoinAccount();
+
+    return (
+        <Screen
+            screenHeader={
+                <ScreenSubHeader
+                    content={translate('moduleAddAccounts.addCoinAccountScreen.title')}
+                />
+            }
+        >
+            <Card>
+                <VStack spacing="large">
+                    {supportedNetworkSymbols.map(symbol => (
+                        <SelectableNetworkItem
+                            key={symbol}
+                            symbol={symbol}
+                            data-testID={`@add-account/select-coin/${symbol}`}
+                            onPress={onSelectedNetworkItem}
+                            rightIcon="plus"
+                        />
+                    ))}
+                </VStack>
+            </Card>
+        </Screen>
+    );
+};

--- a/suite-native/module-add-accounts/tsconfig.json
+++ b/suite-native/module-add-accounts/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "noImplicitAny": false,
+        "outDir": "libDev"
+    },
+    "references": [
+        {
+            "path": "../../suite-common/suite-types"
+        },
+        {
+            "path": "../../suite-common/wallet-config"
+        },
+        {
+            "path": "../../suite-common/wallet-core"
+        },
+        {
+            "path": "../../suite-common/wallet-types"
+        },
+        { "path": "../accounts" },
+        { "path": "../alerts" },
+        { "path": "../atoms" },
+        { "path": "../discovery" },
+        { "path": "../intl" },
+        { "path": "../link" },
+        { "path": "../navigation" }
+    ]
+}

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -15,6 +15,7 @@ import {
     DevUtilsStackRoutes,
     OnboardingStackRoutes,
     ConnectDeviceStackRoutes,
+    AddCoinAccountStackRoutes,
 } from './routes';
 
 type ReceiveAccountsParams = {
@@ -82,6 +83,10 @@ export type AccountsImportStackParamList = {
     };
 };
 
+export type AddCoinAccountStackParamList = {
+    [AddCoinAccountStackRoutes.AddCoinAccount]: undefined;
+};
+
 export type ConnectDeviceStackParamList = {
     [ConnectDeviceStackRoutes.ConnectAndUnlockDevice]: undefined;
     [ConnectDeviceStackRoutes.PinMatrix]: undefined;
@@ -106,4 +111,5 @@ export type RootStackParamList = {
         tokenContract?: TokenAddress;
     };
     [RootStackRoutes.DeviceInfo]: undefined;
+    [RootStackRoutes.AddCoinAccountStack]: undefined;
 };

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -9,6 +9,7 @@ export enum RootStackRoutes {
     TransactionDetail = 'TransactionDetail',
     ReceiveModal = 'ReceiveModal',
     DeviceInfo = 'DeviceInfo',
+    AddCoinAccountStack = 'AddCoinAccountStack',
 }
 
 export enum AppTabsRoutes {
@@ -55,6 +56,10 @@ export enum AccountsStackRoutes {
 
 export enum ReceiveStackRoutes {
     ReceiveAccounts = 'ReceiveAccounts',
+}
+
+export enum AddCoinAccountStackRoutes {
+    AddCoinAccount = 'AddCoinAccount',
 }
 
 export enum SettingsStackRoutes {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7305,6 +7305,7 @@ __metadata:
     "@suite-native/message-system": "workspace:*"
     "@suite-native/module-accounts-import": "workspace:*"
     "@suite-native/module-accounts-management": "workspace:*"
+    "@suite-native/module-add-accounts": "workspace:*"
     "@suite-native/module-connect-device": "workspace:*"
     "@suite-native/module-dev-utils": "workspace:*"
     "@suite-native/module-home": "workspace:*"
@@ -7556,6 +7557,7 @@ __metadata:
     "@suite-native/device-mutex": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/device-utils": "workspace:*"
+    proxy-memoize: "npm:2.0.2"
     react: "npm:18.2.0"
     react-redux: "npm:8.0.7"
   languageName: unknown
@@ -7837,6 +7839,31 @@ __metadata:
     react-native: "npm:0.73.2"
     react-native-reanimated: "npm:3.7.0-nightly-20240101-9d365ae7b"
     react-redux: "npm:8.0.7"
+  languageName: unknown
+  linkType: soft
+
+"@suite-native/module-add-accounts@workspace:*, @suite-native/module-add-accounts@workspace:suite-native/module-add-accounts":
+  version: 0.0.0-use.local
+  resolution: "@suite-native/module-add-accounts@workspace:suite-native/module-add-accounts"
+  dependencies:
+    "@mobily/ts-belt": "npm:^3.13.1"
+    "@react-navigation/native": "npm:6.1.9"
+    "@react-navigation/native-stack": "npm:6.9.17"
+    "@reduxjs/toolkit": "npm:1.9.5"
+    "@suite-common/suite-types": "workspace:*"
+    "@suite-common/wallet-config": "workspace:*"
+    "@suite-common/wallet-core": "workspace:*"
+    "@suite-common/wallet-types": "workspace:*"
+    "@suite-native/accounts": "workspace:*"
+    "@suite-native/alerts": "workspace:*"
+    "@suite-native/atoms": "workspace:*"
+    "@suite-native/discovery": "workspace:*"
+    "@suite-native/intl": "workspace:*"
+    "@suite-native/link": "workspace:*"
+    "@suite-native/navigation": "workspace:*"
+    react: "npm:18.2.0"
+    react-redux: "npm:8.0.7"
+    typescript: "npm:5.3.2"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
User can add new coin account from the assets screen.

When user wants to add new coin to be in the app, he can create it via "+" button on My asset page
When user clicks on the "+" he can choose from available coins for the connected device
When user chooses coin, new coin with default account type is added

## Related Issue

Resolve [#10675](https://github.com/trezor/trezor-suite/issues/10675)

## Screenshots:

https://github.com/trezor/trezor-suite/assets/2011829/e5a991b6-f68e-4a80-8f24-719bfb5f5106

