### PR TITLE
chore(fiat-services): remove unused fetch /simple/token_price/

### DIFF
--- a/suite-common/fiat-services/src/coingecko.ts
+++ b/suite-common/fiat-services/src/coingecko.ts
@@ -48,36 +48,6 @@ const buildCoinUrl = (ticker: TickerId) => {
 };
 
 /**
- * Returns the current rate for a given token fetched from CoinGecko API.
- * Returns null if main network for the token is not ethereum.
- * Supports only tokens on ethereum.
- *
- * @param {TickerId} ticker
- * @returns
- */
-export const fetchCurrentTokenFiatRates = async (ticker: TickerId) => {
-    if (!ticker.tokenAddress) return null;
-
-    const networkTickerConfig = getTickerConfig(ticker);
-    if (!networkTickerConfig || networkTickerConfig?.coingeckoId !== 'ethereum') {
-        console.warn('fetchCurrentTokenFiatRates: This API supports only ethereum', ticker);
-        return null;
-    }
-
-    const url = `${COINGECKO_API_BASE_URL}/simple/token_price/${
-        networkTickerConfig.coingeckoId
-    }?contract_addresses=${ticker.tokenAddress}&vs_currencies=${FIAT_CONFIG.currencies.join(',')}`;
-
-    const rates = await fetchCoinGecko(url);
-    if (!rates) return null;
-
-    return {
-        ts: new Date().getTime() / 1000,
-        rates: rates[ticker.tokenAddress.toLowerCase()],
-    };
-};
-
-/**
  * Returns the current rate for a given symbol fetched from CoinGecko API.
  * Returns null if coin for a given symbol was not found.
  *

--- a/suite-common/fiat-services/src/index.ts
+++ b/suite-common/fiat-services/src/index.ts
@@ -1,2 +1,3 @@
 export * from './rates';
+export { getTickerConfig } from './coingecko';
 export { isTickerSupported as isTickerSupportedByBlockbook } from './blockbook';

--- a/suite-common/fiat-services/src/rates.ts
+++ b/suite-common/fiat-services/src/rates.ts
@@ -8,8 +8,6 @@ import { scheduleAction } from '@trezor/utils';
 import * as coingeckoService from './coingecko';
 import * as blockbookService from './blockbook';
 
-export const { getTickerConfig, fetchCurrentTokenFiatRates } = coingeckoService;
-
 const CONNECT_FETCH_TIMEOUT = 10_000;
 
 const getConnectFiatRatesForTimestamp = (


### PR DESCRIPTION
## Description

- remove unused method for fetching fiat rates
- we use `api/v3/coins/${id}/contract/${contract-id}` instead
