### PR TITLE
Use open API correctly

### DIFF
--- a/packages/connect-web/src/popup/index.ts
+++ b/packages/connect-web/src/popup/index.ts
@@ -169,10 +169,7 @@ export class PopupManager extends EventEmitter {
         } else if (this.settings.env === 'electron') {
             this.popupWindow = window.open(url, 'modal');
         } else {
-            this.popupWindow = window.open('', '_blank');
-            if (this.popupWindow) {
-                this.popupWindow.location.href = url; // otherwise android/chrome loose window.opener reference
-            }
+            this.popupWindow = window.open(url, '_blank');
         }
     }
 


### PR DESCRIPTION
## Description

Attempt to use `window.open` according to its formal API rather than the current implementation to avoid unexpected behaviour.

> out of the assumption that attached explanatory comment ("`otherwise android/chrome loose window.opener reference`") is no longer relevant after X years that passed from when this line was introduced
