### PR TITLE
fix(suite): passwords undefined migration

### DIFF
--- a/packages/suite/src/storage/CHANGELOG.md
+++ b/packages/suite/src/storage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Storage changelog
 
+## 43
+
+-   fixes bug cannot set properties of undefined (setting 'passwords') introduced by migration 41
+
 ## 42
 
 -   remove fiatRates table

--- a/packages/suite/src/storage/index.ts
+++ b/packages/suite/src/storage/index.ts
@@ -4,7 +4,7 @@ import { migrate } from './migrations';
 
 import type { SuiteDBSchema } from './definitions';
 
-const VERSION = 42; // don't forget to add migration and CHANGELOG when changing versions!
+const VERSION = 43; // don't forget to add migration and CHANGELOG when changing versions!
 
 /**
  *  If the object stores don't already exist then creates them.

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -706,14 +706,7 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
 
     if (oldVersion < 41) {
         await updateAll(transaction, 'metadata', metadata => {
-            // although selectedProvider is added in version 39 I saw a report by QA that
-            // migration was trying to set 'passwords' of undefined here.
-            if (!metadata.selectedProvider) {
-                metadata.selectedProvider = { labels: '', passwords: '' };
-            }
-            if (!metadata.selectedProvider.passwords) {
-                metadata.selectedProvider.passwords = '';
-            }
+            metadata.selectedProvider.passwords = '';
             return metadata;
         });
     }
@@ -724,5 +717,19 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
             // @ts-expect-error fiatRates doesn't exists anymore
             db.deleteObjectStore('fiatRates');
         }
+    }
+
+    if (oldVersion < 43) {
+        await updateAll(transaction, 'metadata', metadata => {
+            // although selectedProvider is added in version 39 I saw a report by QA that
+            // migration was trying to set 'passwords' of undefined in migration 41.
+            if (!metadata.selectedProvider) {
+                metadata.selectedProvider = { labels: '', passwords: '' };
+            }
+            if (!metadata.selectedProvider.passwords) {
+                metadata.selectedProvider.passwords = '';
+            }
+            return metadata;
+        });
     }
 };


### PR DESCRIPTION
## Description

Migration 41 was before trying to set passwords that can be undefined that starting to cause mentioned issue. It was fixed in the same migration but since some users probably applied the wrong migration, we still were getting the issue.

Therefore I created a new migration that basically is copy of the new 41 and reverted the changes in 41 in the same time.

It's a reminder that migrations should never be overwritten if even a few users already migrated by them.

## Related Issue

Resolve #10705
