### PR TITLE
chore(blockchain-link-types): move deps from dev to dependencies

### DIFF
--- a/packages/blockchain-link-types/.eslintrc.js
+++ b/packages/blockchain-link-types/.eslintrc.js
@@ -1,5 +1,0 @@
-module.exports = {
-    rules: {
-        'import/no-extraneous-dependencies': ['error', { includeTypes: true }],
-    },
-};

--- a/packages/blockchain-link-types/package.json
+++ b/packages/blockchain-link-types/package.json
@@ -15,13 +15,15 @@
         "prepublishOnly": "yarn tsx ../../scripts/prepublishNPM.js",
         "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
-    "devDependencies": {
-        "@solana/web3.js": "^1.87.6",
+    "dependencies": {
         "@trezor/type-utils": "workspace:*",
         "@trezor/utxo-lib": "workspace:*",
+        "@solana/web3.js": "^1.87.6",
+        "socks-proxy-agent": "6.1.1"
+    },
+    "devDependencies": {
         "rimraf": "^5.0.5",
         "ripple-lib": "^1.10.1",
-        "socks-proxy-agent": "6.1.1",
         "tsx": "^4.6.2",
         "typescript": "5.3.2"
     }


### PR DESCRIPTION
part of https://satoshilabs.slack.com/archives/C03929Z0U1W/p1706524215284199?thread_ts=1694181355.146599&cid=C03929Z0U1W

tldr to make tsc compilation work with skipLibCheck: false, we must include all dependencies that declare some types in dependencies, not devDependencies, because devDependencies of libs are not installed by default. 

@martykan please check errors related to typebox. 