### PR TITLE
docs(connect): fix broken links

### DIFF
--- a/docs/packages/connect/methods/authorizeCoinjoin.md
+++ b/docs/packages/connect/methods/authorizeCoinjoin.md
@@ -54,7 +54,7 @@ TrezorConnect.authorizeCoinjoin({
 
 ### Result
 
-[Success type](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts)
+Success type
 
 ```javascript
 {

--- a/docs/packages/connect/methods/binanceSignTransaction.md
+++ b/docs/packages/connect/methods/binanceSignTransaction.md
@@ -91,7 +91,7 @@ TrezorConnect.binanceSignTransaction({
 
 ### Result
 
-[BinanceSignedTx type](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts)
+[BinanceSignedTx type](https://github.com/trezor/trezor-suite/blob/develop/packages/protobuf/src/messages.ts)
 
 ```javascript
 {

--- a/docs/packages/connect/methods/cancelCoinjoinAuthorization.md
+++ b/docs/packages/connect/methods/cancelCoinjoinAuthorization.md
@@ -25,7 +25,7 @@ TrezorConnect.cancelCoinjoinAuthorization({
 
 ### Result
 
-[Success type](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts)
+Success type
 
 ```javascript
 {

--- a/docs/packages/connect/methods/eosSignTransaction.md
+++ b/docs/packages/connect/methods/eosSignTransaction.md
@@ -56,7 +56,7 @@ TrezorConnect.eosSignTransaction({
 
 ### Result
 
-[EosSignedTx type](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts)
+[EosSignedTx type](https://github.com/trezor/trezor-suite/blob/develop/packages/protobuf/src/messages.ts)
 
 ```javascript
 {

--- a/docs/packages/connect/methods/ethereumSignMessage.md
+++ b/docs/packages/connect/methods/ethereumSignMessage.md
@@ -26,7 +26,7 @@ TrezorConnect.ethereumSignMessage({
 
 ### Result
 
-[MessageSignature type](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts)
+[MessageSignature type](https://github.com/trezor/trezor-suite/blob/develop/packages/protobuf/src/messages.ts)
 
 ```javascript
 {

--- a/docs/packages/connect/methods/ethereumSignTypedData.md
+++ b/docs/packages/connect/methods/ethereumSignTypedData.md
@@ -93,7 +93,7 @@ TrezorConnect.ethereumSignTypedData({
 
 ### Result
 
-[EthereumMessageSignature type](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts)
+[EthereumMessageSignature type](https://github.com/trezor/trezor-suite/blob/develop/packages/protobuf/src/messages.ts)
 
 ```javascript
 {

--- a/docs/packages/connect/methods/ethereumVerifyMessage.md
+++ b/docs/packages/connect/methods/ethereumVerifyMessage.md
@@ -31,7 +31,7 @@ TrezorConnect.ethereumVerifyMessage({
 
 ### Result
 
-[Success type](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts)
+Success type
 
 ```javascript
 {

--- a/docs/packages/connect/methods/getAddress.md
+++ b/docs/packages/connect/methods/getAddress.md
@@ -17,9 +17,9 @@ const result = await TrezorConnect.getAddress(params);
 -   `showOnTrezor` — _optional_ `boolean` determines if address will be displayed on device. Default is set to `true`
 -   `coin` - _optional_ `string` determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/files/coins.json) file. Coin `shortcut`, `name` or `label` can be used. If `coin` is not set API will try to get network definition from `path`.
 -   `crossChain` — _optional_ `boolean` Advanced feature. Use it only if you are know what you are doing. Allows to generate address between chains. For example Bitcoin path on Litecoin network will display cross chain address in Litecoin format.
--   `multisig` - _optional_ [MultisigRedeemScriptType](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts), redeem script information (multisig addresses only)
--   `scriptType` - _optional_ [InputScriptType](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts), address script type
--   `unlockPath` - _optional_ [PROTO.UnlockPath](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts), the result of [TrezorConnect.unlockPath](./unlockPath.md) method.
+-   `multisig` - _optional_ [MultisigRedeemScriptType](https://github.com/trezor/trezor-suite/blob/develop/packages/protobuf/src/messages.ts), redeem script information (multisig addresses only)
+-   `scriptType` - _optional_ [InputScriptType](https://github.com/trezor/trezor-suite/blob/develop/packages/protobuf/src/messages.ts), address script type
+-   `unlockPath` - _optional_ [PROTO.UnlockPath](https://github.com/trezor/trezor-suite/blob/develop/packages/protobuf/src/messages.ts), the result of [TrezorConnect.unlockPath](./unlockPath.md) method.
 -   `chunkify` — _optional_ `boolean` determines if address will be displayed in chunks of 4 characters. Default is set to `false`
 
 #### Exporting bundle of addresses

--- a/docs/packages/connect/methods/getFirmwareHash.md
+++ b/docs/packages/connect/methods/getFirmwareHash.md
@@ -20,7 +20,7 @@ TrezorConnect.getFirmwareHash({
 
 ### Result
 
-[FirmwareHash type](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts)
+[FirmwareHash type](https://github.com/trezor/trezor-suite/blob/develop/packages/protobuf/src/messages.ts)
 
 ```javascript
 {

--- a/docs/packages/connect/methods/getPublicKey.md
+++ b/docs/packages/connect/methods/getPublicKey.md
@@ -19,7 +19,7 @@ const result = await TrezorConnect.getPublicKey(params);
 -   `ignoreXpubMagic` — _optional_ `boolean` ignore SLIP-0132 XPUB magic, use xpub/tpub prefix for all account types.
 -   `ecdsaCurveName` — _optional_ `string` ECDSA curve name to use
 -   `crossChain` — _optional_ `boolean` Advanced feature. Use it only if you are know what you are doing. Allows to generate address between chains. For example Bitcoin path on Litecoin network will display cross chain address in Litecoin format.
--   `unlockPath` - _optional_ [PROTO.UnlockPath](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts), the result of [TrezorConnect.unlockPath](./unlockPath.md) method.
+-   `unlockPath` - _optional_ [PROTO.UnlockPath](https://github.com/trezor/trezor-suite/blob/develop/packages/protobuf/src/messages.ts), the result of [TrezorConnect.unlockPath](./unlockPath.md) method.
 -   `suppressBackupWarning` - _optional_ `boolean` By default, this method will emit an event to show a warning if the wallet does not have a backup. This option suppresses the message.
 
 #### Exporting bundle of public keys

--- a/docs/packages/connect/methods/nemSignTransaction.md
+++ b/docs/packages/connect/methods/nemSignTransaction.md
@@ -81,7 +81,7 @@ TrezorConnect.nemSignTransaction(
 
 ### Result
 
-[NEMSignedTx type](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts)
+[NEMSignedTx type](https://github.com/trezor/trezor-suite/blob/develop/packages/protobuf/src/messages.ts)
 
 ```javascript
 {

--- a/docs/packages/connect/methods/resetDevice.md
+++ b/docs/packages/connect/methods/resetDevice.md
@@ -28,7 +28,7 @@ TrezorConnect.resetDevice({
 
 ### Result
 
-[Success type](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts)
+Success type
 
 ```javascript
 {

--- a/docs/packages/connect/methods/showDeviceTutorial.md
+++ b/docs/packages/connect/methods/showDeviceTutorial.md
@@ -22,7 +22,7 @@ TrezorConnect.showDeviceTutorial({
 
 ### Result
 
-[Success type](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts)
+Success type
 
 ```javascript
 {

--- a/docs/packages/connect/methods/signMessage.md
+++ b/docs/packages/connect/methods/signMessage.md
@@ -28,7 +28,7 @@ TrezorConnect.signMessage({
 
 ### Result
 
-[MessageSignature type](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts)
+[MessageSignature type](https://github.com/trezor/trezor-suite/blob/develop/packages/protobuf/src/messages.ts)
 
 ```javascript
 {

--- a/docs/packages/connect/methods/signTransaction.md
+++ b/docs/packages/connect/methods/signTransaction.md
@@ -18,9 +18,9 @@ const result = await TrezorConnect.signTransaction(params);
     > Determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/files/coins.json) file.
     > Coin `shortcut`, `name` or `label` can be used.
     > See [supported coins](../supported-coins.md)
--   `inputs` - _required_ `Array` of [PROTO.TxInputType](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts),
--   `outputs` - _required_ `Array` of [PROTO.TxOutputType](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts),
--   `paymentRequests` - _optional_ `Array` of [PROTO.TxAckPaymentRequest](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts). See [SLIP-24](https://github.com/satoshilabs/slips/blob/slip24/slip-0024.md)
+-   `inputs` - _required_ `Array` of [PROTO.TxInputType](https://github.com/trezor/trezor-suite/blob/develop/packages/protobuf/src/messages.ts),
+-   `outputs` - _required_ `Array` of [PROTO.TxOutputType](https://github.com/trezor/trezor-suite/blob/develop/packages/protobuf/src/messages.ts),
+-   `paymentRequests` - _optional_ `Array` of [PROTO.TxAckPaymentRequest](https://github.com/trezor/trezor-suite/blob/develop/packages/protobuf/src/messages.ts). See [SLIP-24](https://github.com/satoshilabs/slips/blob/slip24/slip-0024.md)
 -   `refTxs` - _optional_ `Array` of [RefTransaction](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/bitcoin/index.ts).
     > If you don't want to use build-in `blockbook` backend you can optionally provide those data from your own backend transformed to `Trezor` format.
     > Since Firmware 2.3.0/1.9.0 referenced transactions are required.
@@ -35,7 +35,7 @@ const result = await TrezorConnect.signTransaction(params);
 -   `push` - _optional_ `boolean` Broadcast signed transaction to blockchain. Default is set to false
 -   `amountUnit` — _optional_ `PROTO.AmountUnit`
     > show amounts in BTC, mBTC, uBTC, sat
--   `unlockPath` - _optional_ [PROTO.UnlockPath](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts), the result of [TrezorConnect.unlockPath](./unlockPath.md) method.
+-   `unlockPath` - _optional_ [PROTO.UnlockPath](https://github.com/trezor/trezor-suite/blob/develop/packages/protobuf/src/messages.ts), the result of [TrezorConnect.unlockPath](./unlockPath.md) method.
 -   `serialize` - _optional_ `boolean`, default `true` serialize the full transaction, as opposed to only outputting the signatures
 -   `chunkify` — _optional_ `boolean` determines if recipient address will be displayed in chunks of 4 characters. Default is set to `false`
 

--- a/docs/packages/connect/methods/tezosSignTransaction.md
+++ b/docs/packages/connect/methods/tezosSignTransaction.md
@@ -209,7 +209,7 @@ TrezorConnect.tezosSignTransaction({
 
 ### Result
 
-[TezosSignedTx type](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts)
+[TezosSignedTx type](https://github.com/trezor/trezor-suite/blob/develop/packages/protobuf/src/messages.ts)
 
 ```javascript
 {

--- a/docs/packages/connect/methods/verifyMessage.md
+++ b/docs/packages/connect/methods/verifyMessage.md
@@ -33,7 +33,7 @@ TrezorConnect.verifyMessage({
 
 ### Result
 
-[Success type](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts)
+Success type
 
 ```javascript
 {

--- a/docs/packages/connect/methods/wipeDevice.md
+++ b/docs/packages/connect/methods/wipeDevice.md
@@ -21,7 +21,7 @@ TrezorConnect.wipeDevice();
 
 ### Result
 
-[Success type](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts)
+Success type
 
 ```javascript
 {


### PR DESCRIPTION
We have some issues with the current Connect docs

## Description

1. Fixed broken links that lead to an old file in transport which is now in the protobuf package

## TODO

- [ ] multisig is badly documented