### PR TITLE
feat(connect-example): add serviceworker proxy to mv3 example

### DIFF
--- a/packages/connect-examples/update-webextensions-sw.js
+++ b/packages/connect-examples/update-webextensions-sw.js
@@ -53,7 +53,7 @@ rootPaths.forEach(dir => {
             res.body.pipe(dest);
         });
     } else {
-        ['trezor-connect-webextension.js'].forEach(p => {
+        ['trezor-connect-webextension.js', 'trezor-connect-webextension-proxy.js'].forEach(p => {
             fs.copyFileSync(
                 path.join(__dirname, '../connect-webextension', 'build', p),
                 path.join(rootPath, buildFolder, 'vendor', p),

--- a/packages/connect-examples/webextension-mv3-sw/src/connect-manager.html
+++ b/packages/connect-examples/webextension-mv3-sw/src/connect-manager.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    </head>
+    <body>
+        <button id="tab">New tab</button>
+        <button id="get-features" data-test="get-features">Get features</button>
+        <button id="get-address" data-test="get-address">Get address</button>
+        <div id="result"></div>
+        <!-- TODO: try to load changing content security policy -->
+        <!-- https://developer.chrome.com/docs/extensions/mv3/manifest/content_security_policy/ -->
+        <!-- https://stackoverflow.com/questions/67439012/chrome-extension-manifest-v3-content-security-policy -->
+        <!-- <script type="text/javascript" src="https://staging-connect.trezor.io/9/trezor-connect.js"></script> -->
+        <script src="./vendor/trezor-connect-webextension-proxy.js" type="text/javascript"></script>
+        <script src="./connect-manager.js" type="module"></script>
+    </body>
+</html>

--- a/packages/connect-examples/webextension-mv3-sw/src/connect-manager.js
+++ b/packages/connect-examples/webextension-mv3-sw/src/connect-manager.js
@@ -1,0 +1,35 @@
+const DEFAULT_SRC = 'https://connect.trezor.io/9/';
+
+window.TrezorConnect.init({
+    lazyLoad: true,
+    manifest: {
+        email: 'developer@xyz.com',
+        appUrl: 'http://your.application.com',
+    },
+    connectSrc: DEFAULT_SRC,
+});
+
+const getAddressButton = document.getElementById('get-address');
+getAddressButton.addEventListener('click', () => {
+    window.TrezorConnect.getAddress({
+        showOnTrezor: true,
+        path: "m/49'/0'/0'/0/0",
+        coin: 'btc',
+    }).then(res => {
+        console.info(res);
+        document.getElementById('result').innerText = JSON.stringify(res);
+    });
+});
+
+const getFeaturesButton = document.getElementById('get-features');
+getFeaturesButton.addEventListener('click', () => {
+    window.TrezorConnect.getFeatures().then(res => {
+        console.info(res);
+        document.getElementById('result').innerText = JSON.stringify(res);
+    });
+});
+
+const newTabButton = document.getElementById('tab');
+newTabButton.addEventListener('click', () => {
+    chrome.tabs.create({ url: 'connect-manager.html' });
+});

--- a/packages/connect-examples/webextension-mv3-sw/src/manifest.json
+++ b/packages/connect-examples/webextension-mv3-sw/src/manifest.json
@@ -2,9 +2,16 @@
     "name": "@trezor/connect web extension mv3 example",
     "version": "1.0.0",
     "manifest_version": 3,
+    "action": {
+        "default_popup": "popup.html"
+    },
     "background": {
         "service_worker": "serviceWorker.js"
     },
     "permissions": ["scripting"],
-    "host_permissions": ["*://connect.trezor.io/9/*"]
+    "host_permissions": [
+        "*://connect.trezor.io/9/*",
+        "*://suite.corp.sldev.cz/*",
+        "*://localhost/*"
+    ]
 }

--- a/packages/connect-examples/webextension-mv3-sw/src/popup.html
+++ b/packages/connect-examples/webextension-mv3-sw/src/popup.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    </head>
+    <body>
+        <button id="tab">Connect manager</button>
+        <script src="./popup.js" type="module"></script>
+    </body>
+</html>

--- a/packages/connect-examples/webextension-mv3-sw/src/popup.js
+++ b/packages/connect-examples/webextension-mv3-sw/src/popup.js
@@ -1,0 +1,4 @@
+const newTabButton = document.getElementById('tab');
+newTabButton.addEventListener('click', () => {
+    chrome.tabs.create({ url: 'connect-manager.html' });
+});

--- a/packages/connect-webextension/webpack/inline.webpack.config.ts
+++ b/packages/connect-webextension/webpack/inline.webpack.config.ts
@@ -13,6 +13,8 @@ const config: webpack.Configuration = {
     entry: {
         'trezor-connect-webextension': path.resolve(__dirname, '../src/index.ts'),
         'trezor-connect-webextension.min': path.resolve(__dirname, '../src/index.ts'),
+        'trezor-connect-webextension-proxy': path.resolve(__dirname, '../src/proxy/index.ts'),
+        'trezor-connect-webextension-proxy.min': path.resolve(__dirname, '../src/proxy/index.ts'),
     },
     output: {
         filename: '[name].js',


### PR DESCRIPTION
## Description

Added webextension-proxy as an inline output. 
Updated the `webextension-mv3-sw` example to showcase the use of the proxy. 