### PR TITLE
Expo build fixes

### DIFF
--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -64,7 +64,7 @@
         "@trezor/styles": "workspace:*",
         "@trezor/theme": "workspace:*",
         "buffer": "^6.0.3",
-        "expo": "50.0.3",
+        "expo": "50.0.4",
         "expo-av": "13.10.3",
         "expo-barcode-scanner": "12.9.2",
         "expo-build-properties": "^0.11.0",

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -20,7 +20,7 @@
         "@react-navigation/native": "6.1.9",
         "@react-navigation/native-stack": "6.9.17",
         "@reduxjs/toolkit": "1.9.5",
-        "@sentry/react-native": "5.17.0",
+        "@sentry/react-native": "5.16.0",
         "@shopify/flash-list": "1.6.3",
         "@shopify/react-native-skia": "0.1.234",
         "@suite-common/analytics": "workspace:*",

--- a/suite-native/module-dev-utils/package.json
+++ b/suite-native/module-dev-utils/package.json
@@ -13,7 +13,7 @@
     "dependencies": {
         "@react-navigation/core": "^6.4.10",
         "@react-navigation/native-stack": "6.9.17",
-        "@sentry/react-native": "5.17.0",
+        "@sentry/react-native": "5.16.0",
         "@suite-common/icons": "workspace:*",
         "@suite-common/logger": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",

--- a/suite-native/navigation/package.json
+++ b/suite-native/navigation/package.json
@@ -14,7 +14,7 @@
         "@react-navigation/bottom-tabs": "6.5.11",
         "@react-navigation/native": "6.1.9",
         "@react-navigation/native-stack": "6.9.17",
-        "@sentry/react-native": "5.17.0",
+        "@sentry/react-native": "5.16.0",
         "@suite-common/icons": "workspace:*",
         "@suite-common/message-system": "workspace:*",
         "@suite-common/suite-constants": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2524,9 +2524,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@expo/cli@npm:0.17.2":
-  version: 0.17.2
-  resolution: "@expo/cli@npm:0.17.2"
+"@expo/cli@npm:0.17.3":
+  version: 0.17.3
+  resolution: "@expo/cli@npm:0.17.3"
   dependencies:
     "@babel/runtime": "npm:^7.20.0"
     "@expo/code-signing-certificates": "npm:0.0.5"
@@ -2605,7 +2605,7 @@ __metadata:
     ws: "npm:^8.12.1"
   bin:
     expo-internal: build/bin/cli
-  checksum: 7eb743dba3ffa1bcff9a00e3295d7047e7b7fad2d38f92b57598de7e8523ec3028114d4565a661bcb01997f7769c42b224f4a34920acd2dc7b0c723bc41798b2
+  checksum: b64fc1da100ef90052c0b77c2e439fe7e38d26b8fc5cebdab2edea54247791849f86b77edb3624834c8cf4fa6b7d4e16b382b4e23cffbd45fe78b67110dcbc6a
   languageName: node
   linkType: hard
 
@@ -7321,7 +7321,7 @@ __metadata:
     "@trezor/theme": "workspace:*"
     babel-plugin-transform-remove-console: "npm:^6.9.4"
     buffer: "npm:^6.0.3"
-    expo: "npm:50.0.3"
+    expo: "npm:50.0.4"
     expo-av: "npm:13.10.3"
     expo-barcode-scanner: "npm:12.9.2"
     expo-build-properties: "npm:^0.11.0"
@@ -18193,12 +18193,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo@npm:50.0.3":
-  version: 50.0.3
-  resolution: "expo@npm:50.0.3"
+"expo@npm:50.0.4":
+  version: 50.0.4
+  resolution: "expo@npm:50.0.4"
   dependencies:
     "@babel/runtime": "npm:^7.20.0"
-    "@expo/cli": "npm:0.17.2"
+    "@expo/cli": "npm:0.17.3"
     "@expo/config": "npm:8.5.4"
     "@expo/config-plugins": "npm:7.8.4"
     "@expo/metro-config": "npm:0.17.3"
@@ -18214,7 +18214,7 @@ __metadata:
     whatwg-url-without-unicode: "npm:8.0.0-3"
   bin:
     expo: bin/cli
-  checksum: ebd7a5ca142655769904a8195d28d432f437139af9c9336fa72548f50c7e7c0c8f56178fd898e24134695535e67dd2aa1e6ecb85c03d9cbc466cb3cbb7be880e
+  checksum: 59b8a917290d35b2c614df2f2bc4942093731c30c787e3272b9b943349790cb2f29ce300668e2060d8c3e3697998babf623ac3db709fe0ca00e94e255881fdfa
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5429,10 +5429,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry/cli-darwin@npm:2.23.0":
+  version: 2.23.0
+  resolution: "@sentry/cli-darwin@npm:2.23.0"
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
 "@sentry/cli-darwin@npm:2.25.2":
   version: 2.25.2
   resolution: "@sentry/cli-darwin@npm:2.25.2"
   conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"@sentry/cli-linux-arm64@npm:2.23.0":
+  version: 2.23.0
+  resolution: "@sentry/cli-linux-arm64@npm:2.23.0"
+  conditions: (os=linux | os=freebsd) & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -5443,10 +5457,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry/cli-linux-arm@npm:2.23.0":
+  version: 2.23.0
+  resolution: "@sentry/cli-linux-arm@npm:2.23.0"
+  conditions: (os=linux | os=freebsd) & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@sentry/cli-linux-arm@npm:2.25.2":
   version: 2.25.2
   resolution: "@sentry/cli-linux-arm@npm:2.25.2"
   conditions: (os=linux | os=freebsd) & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@sentry/cli-linux-i686@npm:2.23.0":
+  version: 2.23.0
+  resolution: "@sentry/cli-linux-i686@npm:2.23.0"
+  conditions: (os=linux | os=freebsd) & (cpu=x86 | cpu=ia32)
   languageName: node
   linkType: hard
 
@@ -5457,10 +5485,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry/cli-linux-x64@npm:2.23.0":
+  version: 2.23.0
+  resolution: "@sentry/cli-linux-x64@npm:2.23.0"
+  conditions: (os=linux | os=freebsd) & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@sentry/cli-linux-x64@npm:2.25.2":
   version: 2.25.2
   resolution: "@sentry/cli-linux-x64@npm:2.25.2"
   conditions: (os=linux | os=freebsd) & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@sentry/cli-win32-i686@npm:2.23.0":
+  version: 2.23.0
+  resolution: "@sentry/cli-win32-i686@npm:2.23.0"
+  conditions: os=win32 & (cpu=x86 | cpu=ia32)
   languageName: node
   linkType: hard
 
@@ -5471,6 +5513,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry/cli-win32-x64@npm:2.23.0":
+  version: 2.23.0
+  resolution: "@sentry/cli-win32-x64@npm:2.23.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@sentry/cli-win32-x64@npm:2.25.2":
   version: 2.25.2
   resolution: "@sentry/cli-win32-x64@npm:2.25.2"
@@ -5478,7 +5527,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/cli@npm:2.25.2, @sentry/cli@npm:^2.21.2":
+"@sentry/cli@npm:2.23.0":
+  version: 2.23.0
+  resolution: "@sentry/cli@npm:2.23.0"
+  dependencies:
+    "@sentry/cli-darwin": "npm:2.23.0"
+    "@sentry/cli-linux-arm": "npm:2.23.0"
+    "@sentry/cli-linux-arm64": "npm:2.23.0"
+    "@sentry/cli-linux-i686": "npm:2.23.0"
+    "@sentry/cli-linux-x64": "npm:2.23.0"
+    "@sentry/cli-win32-i686": "npm:2.23.0"
+    "@sentry/cli-win32-x64": "npm:2.23.0"
+    https-proxy-agent: "npm:^5.0.0"
+    node-fetch: "npm:^2.6.7"
+    progress: "npm:^2.0.3"
+    proxy-from-env: "npm:^1.1.0"
+    which: "npm:^2.0.2"
+  dependenciesMeta:
+    "@sentry/cli-darwin":
+      optional: true
+    "@sentry/cli-linux-arm":
+      optional: true
+    "@sentry/cli-linux-arm64":
+      optional: true
+    "@sentry/cli-linux-i686":
+      optional: true
+    "@sentry/cli-linux-x64":
+      optional: true
+    "@sentry/cli-win32-i686":
+      optional: true
+    "@sentry/cli-win32-x64":
+      optional: true
+  bin:
+    sentry-cli: bin/sentry-cli
+  checksum: f4c2c8e743410e6da03bd50d8ca4cac7049496390a2eb63072017ec544d28581bd334e867ade2ea62070a6c860abb679e04740586aedeeeeee28b5afd4dbe45b
+  languageName: node
+  linkType: hard
+
+"@sentry/cli@npm:^2.21.2":
   version: 2.25.2
   resolution: "@sentry/cli@npm:2.25.2"
   dependencies:
@@ -5614,12 +5700,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/react-native@npm:5.17.0":
-  version: 5.17.0
-  resolution: "@sentry/react-native@npm:5.17.0"
+"@sentry/react-native@npm:5.16.0":
+  version: 5.16.0
+  resolution: "@sentry/react-native@npm:5.16.0"
   dependencies:
     "@sentry/browser": "npm:7.81.1"
-    "@sentry/cli": "npm:2.25.2"
+    "@sentry/cli": "npm:2.23.0"
     "@sentry/core": "npm:7.81.1"
     "@sentry/hub": "npm:7.81.1"
     "@sentry/integrations": "npm:7.81.1"
@@ -5635,7 +5721,7 @@ __metadata:
       optional: true
   bin:
     sentry-expo-upload-sourcemaps: scripts/expo-upload-sourcemaps.js
-  checksum: c2e7bb151409e73718490b87bf97bdbcde78ee6d13199bca96c15f07233f3bbf00b158362b740a726bdea2c09d3bed09a5507fadf5e5f88c6370142d8d0ee319
+  checksum: 3f82dd09a61be4b4608003d80f3c041eca6d80b8fd7fcda306e315993d41e6f4bd460546744e3c28372f8e543ebc4dcaa011c086c34d366af9c9086ad9e7f235
   languageName: node
   linkType: hard
 
@@ -7190,7 +7276,7 @@ __metadata:
     "@react-navigation/native": "npm:6.1.9"
     "@react-navigation/native-stack": "npm:6.9.17"
     "@reduxjs/toolkit": "npm:1.9.5"
-    "@sentry/react-native": "npm:5.17.0"
+    "@sentry/react-native": "npm:5.16.0"
     "@shopify/flash-list": "npm:1.6.3"
     "@shopify/react-native-skia": "npm:0.1.234"
     "@suite-common/analytics": "workspace:*"
@@ -7778,7 +7864,7 @@ __metadata:
   dependencies:
     "@react-navigation/core": "npm:^6.4.10"
     "@react-navigation/native-stack": "npm:6.9.17"
-    "@sentry/react-native": "npm:5.17.0"
+    "@sentry/react-native": "npm:5.16.0"
     "@suite-common/icons": "workspace:*"
     "@suite-common/logger": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
@@ -7947,7 +8033,7 @@ __metadata:
     "@react-navigation/bottom-tabs": "npm:6.5.11"
     "@react-navigation/native": "npm:6.1.9"
     "@react-navigation/native-stack": "npm:6.9.17"
-    "@sentry/react-native": "npm:5.17.0"
+    "@sentry/react-native": "npm:5.16.0"
     "@suite-common/icons": "workspace:*"
     "@suite-common/message-system": "workspace:*"
     "@suite-common/suite-constants": "workspace:*"


### PR DESCRIPTION
## Description
- downgrades Sentry to 5.16.0
- upgrade expo to 50.0.4

⚠️CAUTION! the build dont work with cocoapods version>15.0.0. Tested and working on 14.0.3