### PR TITLE
test(suite): improve flaky passphrase test

### DIFF
--- a/packages/suite-web/e2e/tests/suite/passphrase.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase.test.ts
@@ -76,7 +76,9 @@ describe('Passphrase', () => {
             })
             .should('contain', abcAddr);
         cy.task('pressYes');
-        cy.getTestElement('@metadata/copy-address-button').should('exist');
+        cy.getTestElement('@metadata/copy-address-button')
+            .should('exist')
+            .should('not.be.disabled');
         // close modal
         cy.getTestElement('@modal/close-button').click();
 
@@ -127,7 +129,9 @@ describe('Passphrase', () => {
             })
             .should('contain', defAddr);
         cy.task('pressYes');
-        cy.getTestElement('@metadata/copy-address-button').should('exist');
+        cy.getTestElement('@metadata/copy-address-button')
+            .should('exist')
+            .should('not.be.disabled');
         // close modal
         cy.getTestElement('@modal/close-button').click();
 


### PR DESCRIPTION
fixing https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/6074222972/artifacts/file/packages/suite-web/e2e/videos/passphrase.test.ts.mp4
track-suite https://track-suite-ff9ad9f5b4f6.herokuapp.com/#/flaky-test-passphrase

after empower, copy button is visible all the time so waiting for it to appear and then closing modal actually triggers cancel call to connect. we need to wait for call to finish which manifests itself as button becoming actionable. I hope it helps.