### PR TITLE
Backend reconnection in Connect

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -38,4 +38,8 @@ module.exports = {
 
     // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
     watchPathIgnorePatterns: ['libDev', 'lib'],
+
+    // An array of regexp pattern strings that are matched against all module paths before those paths are
+    // to be considered 'visible' to the module loader
+    modulePathIgnorePatterns: ['libDev'],
 };

--- a/packages/blockchain-link-types/src/events.ts
+++ b/packages/blockchain-link-types/src/events.ts
@@ -7,5 +7,4 @@ export interface Events {
     block: BlockEvent['payload'];
     mempool: MempoolEvent['payload'];
     fiatRates: FiatRatesEvent['payload'];
-    error: Error;
 }

--- a/packages/blockchain-link/src/ui/index.ui.ts
+++ b/packages/blockchain-link/src/ui/index.ui.ts
@@ -327,11 +327,6 @@ const handleConnectionEvent = (blockchain: BlockchainLink, status: boolean) => {
     );
 };
 
-const handleErrorEvent = (_blockchain: BlockchainLink, message: any) => {
-    const parent = document.getElementById('notification-status') as HTMLElement;
-    prepareResponse(parent, message, true);
-};
-
 // utils
 
 const onAccountInfoModeChange = (event: any) => {
@@ -392,7 +387,6 @@ CONFIG.forEach(i => {
 
     b.on('connected', handleConnectionEvent.bind(null, b, true));
     b.on('disconnected', handleConnectionEvent.bind(null, b, false));
-    b.on('error', handleErrorEvent.bind(null, b, false));
     b.on('block', handleBlockEvent.bind(null, b));
     b.on('mempool', handleMempoolEvent.bind(null, b));
     b.on('fiatRates', handleFiatRatesEvent.bind(null, b));

--- a/packages/connect/src/__mocks__/@trezor/blockchain-link.ts
+++ b/packages/connect/src/__mocks__/@trezor/blockchain-link.ts
@@ -24,7 +24,6 @@ class BlockchainLink {
     }
 
     connect() {
-        this.emit('connected');
         return Promise.resolve(true);
     }
     disconnect() {
@@ -33,15 +32,18 @@ class BlockchainLink {
     }
     dispose() {}
     getInfo() {
-        return {
+        return Promise.resolve({
             url: this.name,
             name: this.name,
             shortcut: this.name,
             consensusBranchId: 1001,
-        };
+        });
     }
     estimateFee(params: { blocks: number[] }) {
-        return params.blocks.map(() => ({ feePerUnit: '-1' }));
+        return Promise.resolve(params.blocks.map(() => ({ feePerUnit: '-1' })));
+    }
+    subscribe() {
+        return Promise.resolve({ subscribed: true });
     }
 }
 

--- a/packages/connect/src/__mocks__/@trezor/blockchain-link.ts
+++ b/packages/connect/src/__mocks__/@trezor/blockchain-link.ts
@@ -1,0 +1,51 @@
+type Listener = (...args: any[]) => void;
+
+class BlockchainLink {
+    name = 'jest-mocked-module';
+
+    /* EventEmitter functionality mock */
+    private readonly listeners: [string, Listener][] = [];
+    private emit(event: string, ...args: any[]) {
+        this.listeners.filter(([e]) => e === event).forEach(([_, listener]) => listener(...args));
+    }
+    on(event: string, listener: Listener) {
+        this.listeners.push([event, listener]);
+    }
+    removeAllListeners() {
+        this.listeners.splice(0, this.listeners.length);
+    }
+    listenerCount(event: string) {
+        return this.listeners.filter(([e]) => e === event).length;
+    }
+    /* */
+
+    constructor(args: any) {
+        this.name = args.name;
+    }
+
+    connect() {
+        this.emit('connected');
+        return Promise.resolve(true);
+    }
+    disconnect() {
+        this.emit('disconnected');
+        return Promise.resolve(true);
+    }
+    dispose() {}
+    getInfo() {
+        return {
+            url: this.name,
+            name: this.name,
+            shortcut: this.name,
+            consensusBranchId: 1001,
+        };
+    }
+    estimateFee(params: { blocks: number[] }) {
+        return params.blocks.map(() => ({ feePerUnit: '-1' }));
+    }
+}
+
+module.exports = {
+    __esModule: true,
+    default: BlockchainLink,
+};

--- a/packages/connect/src/api/bitcoin/__tests__/Fees.test.ts
+++ b/packages/connect/src/api/bitcoin/__tests__/Fees.test.ts
@@ -5,38 +5,6 @@ import { parseCoinsJson, getBitcoinNetwork } from '../../../data/coinInfo';
 import { initBlockchain } from '../../../backend/BlockchainLink';
 import { FeeLevels } from '../Fees';
 
-// mock blockchain-link module to spy/mock `estimateFee` method
-jest.mock('@trezor/blockchain-link', () => ({
-    __esModule: true,
-    default: class BlockchainLink {
-        name = 'jest-mocked-module';
-        listeners: Record<string, () => void> = {};
-        constructor(args: any) {
-            this.name = args.name;
-        }
-        on(...args: any[]) {
-            const [type, fn] = args;
-            this.listeners[type] = fn;
-        }
-        connect() {
-            this.listeners.connected();
-        }
-        disconnect() {}
-        removeAllListeners() {}
-        dispose() {}
-        getInfo() {
-            return {
-                url: this,
-                name: this.name,
-                shortcut: this.name,
-            };
-        }
-        estimateFee(params: { blocks: number[] }) {
-            return params.blocks.map(() => ({ feePerUnit: '-1' }));
-        }
-    },
-}));
-
 describe('api/bitcoin/Fees', () => {
     // load coin definitions
     parseCoinsJson({ ...coinsJSON, eth: ethereumCoinsJSON });

--- a/packages/connect/src/api/bitcoin/__tests__/enhanceSignTx.test.ts
+++ b/packages/connect/src/api/bitcoin/__tests__/enhanceSignTx.test.ts
@@ -1,33 +1,6 @@
 import { enhanceSignTx } from '../enhanceSignTx';
 import { initBlockchain } from '../../../backend/BlockchainLink';
 
-// mock blockchain-link module to get consensusBranchId from ServerInfo
-jest.mock('@trezor/blockchain-link', () => ({
-    __esModule: true,
-    default: class BlockchainLink {
-        name = 'jest-mocked-module';
-        listeners: Record<string, any> = {};
-        constructor(args: any) {
-            this.name = args.name;
-        }
-        on(...args: any[]) {
-            const [type, fn] = args;
-            this.listeners[type] = fn;
-        }
-        connect() {
-            this.listeners.connected();
-        }
-        getInfo() {
-            return {
-                url: this,
-                name: this.name,
-                shortcut: this.name,
-                consensusBranchId: 1001,
-            };
-        }
-    },
-}));
-
 describe('api/bitcoin/enhanceSignTx', () => {
     it('zcash/zcash testnet', () => {
         ['ZEC', 'TAZ'].forEach(shortcut => {

--- a/packages/connect/src/backend/BackendManager.ts
+++ b/packages/connect/src/backend/BackendManager.ts
@@ -1,56 +1,62 @@
 import { DataManager } from '../data/DataManager';
 import { ERRORS } from '../constants';
 import { Blockchain, BlockchainOptions } from './Blockchain';
+import { createBlockchainMessage, BLOCKCHAIN } from '../events';
 
 import type { CoinInfo, BlockchainLink } from '../types';
 
 type CoinShortcut = CoinInfo['shortcut'];
+type Reconnect = { attempts: number; handle: ReturnType<typeof setTimeout> };
 
 export class BackendManager {
     private readonly instances: { [shortcut: CoinShortcut]: Blockchain } = {};
     private readonly custom: { [shortcut: CoinShortcut]: BlockchainLink } = {};
     private readonly preferred: { [shortcut: CoinShortcut]: string } = {};
+    private readonly reconnect: { [shortcut: CoinShortcut]: Reconnect } = {};
 
     get(shortcut: CoinShortcut): Blockchain | null {
         return this.instances[shortcut] ?? null;
-    }
-
-    remove(shortcut: CoinShortcut) {
-        delete this.instances[shortcut];
     }
 
     async getOrConnect(
         coinInfo: CoinInfo,
         postMessage: BlockchainOptions['postMessage'],
     ): Promise<Blockchain> {
-        let backend = this.get(coinInfo.shortcut);
+        let backend = this.instances[coinInfo.shortcut];
         if (!backend) {
             backend = new Blockchain({
                 coinInfo: this.patchCoinInfo(coinInfo),
                 postMessage,
                 debug: DataManager.getSettings('debug'),
                 proxy: DataManager.getSettings('proxy'),
-                onConnected: url => this.setPreferred(coinInfo.shortcut, url),
-                onDisconnected: () => this.remove(coinInfo.shortcut),
+                onDisconnected: this.onDisconnected.bind(this),
             });
-            this.instances[coinInfo.shortcut] = backend;
-
-            try {
-                await backend.init();
-            } catch (error) {
-                this.remove(coinInfo.shortcut);
-                this.removePreferred(coinInfo.shortcut);
-                throw error;
-            }
+            this.setInstance(coinInfo.shortcut, backend);
         }
-        return backend;
+
+        const reconnect = this.clearReconnect(coinInfo.shortcut);
+
+        try {
+            const info = await backend.init();
+            this.setPreferred(coinInfo.shortcut, info.url);
+            return backend;
+        } catch (error) {
+            this.setInstance(coinInfo.shortcut, undefined);
+            this.setPreferred(coinInfo.shortcut, undefined);
+            if (reconnect) {
+                this.planReconnect(backend.coinInfo, backend.postMessage, reconnect.attempts);
+            }
+            throw error;
+        }
     }
 
     dispose() {
+        Object.keys(this.reconnect).forEach(this.clearReconnect, this);
         Object.values(this.instances).forEach(i => i.disconnect());
     }
 
     reconnectAll() {
+        Object.keys(this.reconnect).forEach(this.clearReconnect, this);
         // collect all running backends as parameters tuple
         const params = Object.values(this.instances).map(i => [i.coinInfo, i.postMessage] as const);
         // remove all backends
@@ -67,23 +73,54 @@ export class BackendManager {
     }
 
     setCustom(shortcut: CoinShortcut, blockchainLink: BlockchainLink) {
-        this.removePreferred(shortcut);
+        this.setPreferred(shortcut, undefined);
         this.custom[shortcut] = blockchainLink;
     }
 
     removeCustom(shortcut: CoinShortcut) {
-        this.removePreferred(shortcut);
+        this.setPreferred(shortcut, undefined);
         delete this.custom[shortcut];
+    }
+
+    private setInstance(shortcut: CoinShortcut, instance: Blockchain | undefined) {
+        if (!instance) delete this.instances[shortcut];
+        else this.instances[shortcut] = instance;
     }
 
     // keep backend as a preferred once connection is successfully made
     // switching between urls could lead to side effects (mempool differences, non existing/missing pending transactions)
-    private setPreferred(shortcut: CoinShortcut, url: string) {
-        this.preferred[shortcut] = url;
+    private setPreferred(shortcut: CoinShortcut, url: string | undefined) {
+        if (!url) delete this.preferred[shortcut];
+        else this.preferred[shortcut] = url;
     }
 
-    private removePreferred(shortcut: CoinShortcut) {
-        delete this.preferred[shortcut];
+    private planReconnect(
+        coinInfo: CoinInfo,
+        postMessage: BlockchainOptions['postMessage'],
+        attempts: number,
+    ) {
+        const timeout = Math.min(2500 * attempts, 20000);
+        const time = Date.now() + timeout;
+        const handle = setTimeout(() => {
+            this.getOrConnect(coinInfo, postMessage).catch(() => {});
+        }, timeout);
+        clearTimeout(this.reconnect[coinInfo.shortcut]?.handle);
+        this.reconnect[coinInfo.shortcut] = { attempts: attempts + 1, handle };
+        postMessage(createBlockchainMessage(BLOCKCHAIN.RECONNECTING, { coin: coinInfo, time }));
+    }
+
+    private clearReconnect(shortcut: CoinShortcut) {
+        const reconnect = this.reconnect[shortcut];
+        clearTimeout(reconnect?.handle);
+        delete this.reconnect[shortcut];
+        return reconnect;
+    }
+
+    private onDisconnected(backend: Blockchain, pendingSubscriptions?: boolean) {
+        this.setInstance(backend.coinInfo.shortcut, undefined);
+        if (pendingSubscriptions) {
+            this.planReconnect(backend.coinInfo, backend.postMessage, 0);
+        }
     }
 
     private patchCoinInfo(coinInfo: CoinInfo): CoinInfo {

--- a/packages/connect/src/backend/Blockchain.ts
+++ b/packages/connect/src/backend/Blockchain.ts
@@ -125,10 +125,6 @@ export class Blockchain {
             this.onError(ERRORS.TypedError('Backend_Disconnected'));
         });
 
-        this.link.on('error', error => {
-            this.onError(ERRORS.TypedError('Backend_Error', error.message));
-        });
-
         try {
             await this.link.connect();
         } catch (error) {

--- a/packages/connect/src/backend/Blockchain.ts
+++ b/packages/connect/src/backend/Blockchain.ts
@@ -38,8 +38,7 @@ export type BlockchainOptions = {
     postMessage: (message: CoreEventMessage) => void;
     proxy?: Proxy;
     debug?: boolean;
-    onConnected?: (url: string) => void;
-    onDisconnected?: () => void;
+    onDisconnected?: (backend: Blockchain, pendingSubscriptions?: boolean) => void;
 };
 
 export class Blockchain {
@@ -53,13 +52,12 @@ export class Blockchain {
 
     feeTimestamp = 0;
 
-    private onConnected: BlockchainOptions['onConnected'];
     private onDisconnected: BlockchainOptions['onDisconnected'];
+    private initPromise?: Promise<ServerInfo>;
 
     constructor(options: BlockchainOptions) {
         this.coinInfo = options.coinInfo;
         this.postMessage = options.postMessage;
-        this.onConnected = options.onConnected;
         this.onDisconnected = options.onDisconnected;
 
         const { blockchainLink } = options.coinInfo;
@@ -88,6 +86,11 @@ export class Blockchain {
     }
 
     onError(error: ERRORS.TrezorError) {
+        const pendingSubscriptions =
+            this.link.listenerCount('block') ||
+            this.link.listenerCount('notification') ||
+            this.link.listenerCount('fiatRates');
+
         this.link.dispose();
         this.postMessage(
             createBlockchainMessage(BLOCKCHAIN.ERROR, {
@@ -96,41 +99,58 @@ export class Blockchain {
                 code: error.code,
             }),
         );
-        this.onDisconnected?.();
+        this.onDisconnected?.(this, !!pendingSubscriptions);
     }
 
-    async init() {
-        this.link.on('connected', async () => {
-            const info = await this.link.getInfo();
-            this.serverInfo = info;
-            // There is no `rippled` setting that defines which network it uses neither mainnet or testnet
-            // see: https://xrpl.org/parallel-networks.html
-            const shortcut = this.coinInfo.shortcut === 'tXRP' ? 'XRP' : this.coinInfo.shortcut;
-            if (info.shortcut.toLowerCase() !== shortcut.toLowerCase()) {
-                this.onError(ERRORS.TypedError('Backend_Invalid'));
-                return;
-            }
+    /** should be called only once, from Blockchain.init() method */
+    private async initLink() {
+        let info;
+        try {
+            await this.link.connect();
+            info = await this.link.getInfo();
+        } catch (error) {
+            throw ERRORS.TypedError('Backend_Error', error.message);
+        }
 
-            this.onConnected?.(info.url);
+        this.serverInfo = info;
 
-            this.postMessage(
-                createBlockchainMessage(BLOCKCHAIN.CONNECT, {
-                    coin: this.coinInfo,
-                    ...info,
-                }),
-            );
-        });
+        // There is no `rippled` setting that defines which network it uses neither mainnet or testnet
+        // see: https://xrpl.org/parallel-networks.html
+        const shortcut = this.coinInfo.shortcut === 'tXRP' ? 'XRP' : this.coinInfo.shortcut;
+        if (info.shortcut.toLowerCase() !== shortcut.toLowerCase()) {
+            throw ERRORS.TypedError('Backend_Invalid');
+        }
+
+        this.postMessage(
+            createBlockchainMessage(BLOCKCHAIN.CONNECT, {
+                coin: this.coinInfo,
+                ...info,
+            }),
+        );
 
         this.link.on('disconnected', () => {
             this.onError(ERRORS.TypedError('Backend_Disconnected'));
         });
 
-        try {
-            await this.link.connect();
-        } catch (error) {
-            this.onError(ERRORS.TypedError('Backend_Error', error.message));
-            throw error;
+        return info;
+    }
+
+    /** Method is idempotent (only the first call really starts the init process, subsequent calls just return the promise) */
+    init() {
+        if (!this.initPromise) {
+            this.initPromise = this.initLink()
+                .then(info => {
+                    this.initPromise = Promise.resolve(info);
+                    return info;
+                })
+                .catch(error => {
+                    this.initPromise = Promise.reject(error);
+                    this.link.dispose();
+                    return this.initPromise;
+                });
         }
+
+        return this.initPromise;
     }
 
     getTransactions(txs: string[]) {

--- a/packages/connect/src/backend/__tests__/BackendManager.test.ts
+++ b/packages/connect/src/backend/__tests__/BackendManager.test.ts
@@ -1,0 +1,102 @@
+import BlockchainLink from '@trezor/blockchain-link';
+
+import { CoinInfo } from '../../types';
+import { BackendManager } from '../BackendManager';
+import type { CoreEventMessage } from '../../events';
+
+const COIN_INFO = {
+    shortcut: 'BTC',
+    blockchainLink: { type: 'blockbook', url: ['url_1', 'url_2', 'url_3'] },
+} as CoinInfo;
+
+describe('backend/BackendManager', () => {
+    let manager: BackendManager;
+    let postMessage: jest.Mock;
+
+    jest.useFakeTimers();
+
+    const delay = (ms: number) => jest.advanceTimersByTimeAsync(ms);
+
+    const expectExactMessages = (...types: CoreEventMessage['type'][]) => {
+        expect(postMessage).toHaveBeenCalledTimes(types.length);
+        types.forEach((type, i) =>
+            expect(postMessage).toHaveBeenNthCalledWith(i + 1, expect.objectContaining({ type })),
+        );
+        postMessage.mockClear();
+    };
+
+    const expectNoMessage = () => expect(postMessage).toHaveBeenCalledTimes(0);
+
+    beforeEach(() => {
+        manager = new BackendManager();
+        postMessage = jest.fn();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('reuse backend', async () => {
+        const backend1 = await manager.getOrConnect(COIN_INFO, postMessage);
+        expectExactMessages('blockchain-connect');
+        const networkInfo = await backend1.getNetworkInfo();
+        expect(networkInfo).toMatchObject({ shortcut: 'BTC' });
+
+        await delay(1000);
+
+        await manager.getOrConnect(COIN_INFO, postMessage);
+        expectNoMessage();
+    });
+
+    it('reconnect backend after disconnection', async () => {
+        const backend1 = await manager.getOrConnect(COIN_INFO, postMessage);
+        expectExactMessages('blockchain-connect');
+
+        await delay(1000);
+        backend1.disconnect();
+        expectExactMessages('blockchain-error');
+
+        await delay(1000);
+        expectNoMessage();
+
+        await manager.getOrConnect(COIN_INFO, postMessage);
+        expectExactMessages('blockchain-connect');
+    });
+
+    it('reconnect backend automatically when subscribed', async () => {
+        const backend = await manager.getOrConnect(COIN_INFO, postMessage);
+        expectExactMessages('blockchain-connect');
+        const { subscribed } = await backend.subscribe();
+        expect(subscribed).toBe(true);
+
+        await delay(1000);
+        backend.link.emit('disconnected');
+        expectExactMessages('blockchain-error', 'blockchain-reconnecting');
+
+        await delay(1000);
+        expectExactMessages('blockchain-connect');
+
+        await manager.getOrConnect(COIN_INFO, postMessage);
+        expectNoMessage();
+    });
+
+    it('reconnect backend infinitely when cannot reconnect', async () => {
+        const backend = await manager.getOrConnect(COIN_INFO, postMessage);
+        expectExactMessages('blockchain-connect');
+        const { subscribed } = await backend.subscribe();
+        expect(subscribed).toBe(true);
+
+        await delay(1000);
+        jest.spyOn(BlockchainLink.prototype, 'connect').mockImplementation(() =>
+            Promise.reject(new Error('foo')),
+        );
+        backend.link.emit('disconnected');
+        expectExactMessages('blockchain-error', 'blockchain-reconnecting');
+
+        await delay(1000);
+        expectExactMessages('blockchain-reconnecting');
+
+        await delay(2000);
+        expectExactMessages('blockchain-reconnecting');
+    });
+});

--- a/packages/connect/src/backend/__tests__/Blockchain.test.ts
+++ b/packages/connect/src/backend/__tests__/Blockchain.test.ts
@@ -4,35 +4,6 @@ import BlockchainLink from '@trezor/blockchain-link';
 import { parseCoinsJson, getBitcoinNetwork, getEthereumNetwork } from '../../data/coinInfo';
 import { initBlockchain } from '../BlockchainLink';
 
-// mock blockchain-link module to spy/mock `estimateFee` method
-jest.mock('@trezor/blockchain-link', () => ({
-    __esModule: true,
-    default: class BlockchainLink {
-        name = 'jest-mocked-module';
-        listeners: Record<string, () => void> = {};
-        constructor(args: any) {
-            this.name = args.name;
-        }
-        on(...args: any[]) {
-            const [type, fn] = args;
-            this.listeners[type] = fn;
-        }
-        connect() {
-            this.listeners.connected();
-        }
-        getInfo() {
-            return {
-                url: this,
-                name: this.name,
-                shortcut: this.name,
-            };
-        }
-        estimateFee(params: { blocks: number[] }) {
-            return params.blocks.map(() => ({ feePerUnit: '-1' }));
-        }
-    },
-}));
-
 describe('backend/Blockchain', () => {
     // load coin definitions
     parseCoinsJson({ ...coinsJSON, eth: ethereumCoinsJSON });

--- a/packages/connect/src/events/blockchain.ts
+++ b/packages/connect/src/events/blockchain.ts
@@ -5,6 +5,7 @@ import type { MessageFactoryFn } from '../types/utils';
 export const BLOCKCHAIN_EVENT = 'BLOCKCHAIN_EVENT';
 export const BLOCKCHAIN = {
     CONNECT: 'blockchain-connect',
+    RECONNECTING: 'blockchain-reconnecting',
     ERROR: 'blockchain-error',
     BLOCK: 'blockchain-block',
     NOTIFICATION: 'blockchain-notification',
@@ -16,6 +17,11 @@ export interface BlockchainInfo extends ServerInfo {
     misc?: {
         reserve?: string;
     };
+}
+
+export interface BlockchainReconnecting {
+    coin: CoinInfo;
+    time: number;
 }
 
 export interface BlockchainError {
@@ -42,6 +48,10 @@ export type BlockchainEvent =
     | {
           type: typeof BLOCKCHAIN.CONNECT;
           payload: BlockchainInfo;
+      }
+    | {
+          type: typeof BLOCKCHAIN.RECONNECTING;
+          payload: BlockchainReconnecting;
       }
     | {
           type: typeof BLOCKCHAIN.ERROR;

--- a/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
@@ -487,7 +487,7 @@ export const onDisconnect = [
             accounts: [{ symbol: 'btc' }],
         },
         symbol: 'btc',
-        actions: [{ type: blockchainActions.reconnectTimeoutStart.type }],
+        actions: [],
     },
     {
         description: 'with accounts, with reconnection, reconnection restarted',
@@ -503,7 +503,7 @@ export const onDisconnect = [
             },
         },
         symbol: 'btc',
-        actions: [{ type: blockchainActions.reconnectTimeoutStart.type }],
+        actions: [],
     },
 ];
 

--- a/packages/suite/src/actions/wallet/selectedAccountActions.ts
+++ b/packages/suite/src/actions/wallet/selectedAccountActions.ts
@@ -172,7 +172,6 @@ const actions = [
     blockchainActions.setBackend.type,
     blockchainActions.synced.type,
     blockchainActions.connected.type,
-    blockchainActions.reconnectTimeoutStart.type,
     blockchainActions.updateFee.type,
     discoveryActions.stopDiscovery.type,
     discoveryActions.interruptDiscovery.type,

--- a/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
@@ -41,8 +41,11 @@ jest.mock('@trezor/blockchain-link', () => ({
             const [type, fn] = args;
             this.listeners[type] = fn;
         }
+        listenerCount() {
+            return 0;
+        }
         connect() {
-            this.listeners.connected();
+            return true;
         }
         disconnect() {}
         removeAllListeners() {}

--- a/suite-common/wallet-core/src/blockchain/blockchainActions.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainActions.ts
@@ -13,19 +13,6 @@ const connected = createAction(
     }),
 );
 
-type ReconnectTimeoutStartPayload = {
-    symbol: NetworkSymbol;
-    id: Timeout;
-    time: number;
-    count: number;
-};
-const reconnectTimeoutStart = createAction(
-    `${blockchainActionsPrefix}/reconnectTimeoutStart`,
-    (payload: ReconnectTimeoutStartPayload) => ({
-        payload,
-    }),
-);
-
 const updateFee = createAction(
     `${blockchainActionsPrefix}/updateFee`,
     (payload: Partial<NetworksFees>) => ({
@@ -53,7 +40,6 @@ const setBackend = createAction(
 export const blockchainActions = {
     setBackend,
     connected,
-    reconnectTimeoutStart,
     updateFee,
     synced,
 };

--- a/suite-common/wallet-types/src/backend.ts
+++ b/suite-common/wallet-types/src/backend.ts
@@ -26,9 +26,7 @@ export type BackendSettings = Partial<{
 }>;
 
 interface BlockchainReconnection {
-    id: Timeout; // setTimeout id
     time: number; // timestamp when it will be resolved
-    count: number; // number of tries
 }
 
 export interface Blockchain {


### PR DESCRIPTION
## Description

Move backend reconnection logic from Suite to Connect. The reason is that a) then it's shared with 3rd parties which makes integration easier and b) it serves as a prerequisite for #10463 and potentially other backend-related stuff.

## Commits

- https://github.com/trezor/trezor-suite/pull/11011/commits/3fa49f5c40dbbd06dfd5fa11c597bca4e7925777 - another place where `createDeferredManager` can be used :tada: 
- https://github.com/trezor/trezor-suite/pull/11011/commits/8451cd53a2640db9546d7202b007c0e76eff9ab8 - `error` event seemed never emitted from `BlockchainLink` so I removed it
- https://github.com/trezor/trezor-suite/pull/11011/commits/a17d5923306712cdaa058fcb74c432e00c05b09d - unified multiple `BlockchainLink` mocks from connect tests into single global one
- https://github.com/trezor/trezor-suite/pull/11011/commits/aae279fb65562dbb4eeea19bf92f313a3a6f350b - main thing; defines new `BlockchainReconnecting` event; makes `Blockchain.init()` method idempotent; init process is now linear (not separated into init method itself and `connected` event); `onDisconnected` handler now receives whether there were pending subscriptions; `BackendManager` is now responsible for backend reconnection whenever there were.
- https://github.com/trezor/trezor-suite/pull/11011/commits/8751e1fdbfadccb4de8059bd31f587a1aa225f4d - add unit tests for `BackendManager`
- https://github.com/trezor/trezor-suite/pull/11011/commits/acd4830eb386c40e67d96c170fee25f886cd21de - remove reconnection logic from Suite as now it should be handled by Connect's `BackendManager`
- https://github.com/trezor/trezor-suite/pull/11011/commits/231b850612815295c2cf2f46862f82fd41a18250 - fixed random unit test in Suite

## QA

There should be no changes in Suite's behavior (yet). We have to make sure that Suite is still able to handle cases where backend is unexpectedly disconnected and then reconnects/cannot reconnect/is manually reconnected/etc. etc. etc.