### PR TITLE
fix: wait for Solana transaction confirmation

### DIFF
--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -15,7 +15,7 @@ import type * as MessageTypes from '@trezor/blockchain-link-types/lib/messages';
 import { CustomError } from '@trezor/blockchain-link-types/lib/constants/errors';
 import { BaseWorker, ContextType, CONTEXT } from '../baseWorker';
 import { MESSAGES, RESPONSES } from '@trezor/blockchain-link-types/lib/constants';
-import { Connection, Message, PublicKey } from '@solana/web3.js';
+import { Connection, Message, PublicKey, sendAndConfirmRawTransaction } from '@solana/web3.js';
 import { solanaUtils } from '@trezor/blockchain-link-utils';
 
 import {
@@ -94,7 +94,7 @@ const isValidTransaction = (tx: ParsedTransactionWithMeta): tx is SolanaValidPar
 const pushTransaction = async (request: Request<MessageTypes.PushTransaction>) => {
     const rawTx = request.payload.startsWith('0x') ? request.payload.slice(2) : request.payload;
     const api = await request.connect();
-    const payload = await api.sendRawTransaction(Buffer.from(rawTx, 'hex'));
+    const payload = await sendAndConfirmRawTransaction(api, Buffer.from(rawTx, 'hex'));
     return {
         type: RESPONSES.PUSH_TRANSACTION,
         payload,

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 import { analytics, EventType } from '@trezor/suite-analytics';
@@ -102,6 +102,8 @@ export const TransactionReviewOutputList = ({
         precomposedForm;
     const broadcastEnabled = options.includes('broadcast');
 
+    const [isSending, setIsSending] = useState<boolean>(false);
+
     const reportTransactionCreatedEvent = (action: 'sent' | 'copied' | 'downloaded' | 'replaced') =>
         analytics.report({
             type: EventType.TransactionCreated,
@@ -125,6 +127,7 @@ export const TransactionReviewOutputList = ({
             },
         });
     const handleSend = () => {
+        setIsSending(true);
         if (decision) {
             decision.resolve(true);
 
@@ -211,7 +214,7 @@ export const TransactionReviewOutputList = ({
                     {broadcastEnabled ? (
                         <StyledButton
                             data-test="@modal/send"
-                            isDisabled={!signedTx}
+                            isDisabled={!signedTx || isSending}
                             onClick={handleSend}
                         >
                             <Translation id={isRbfAction ? 'TR_REPLACE_TX' : 'SEND_TRANSACTION'} />


### PR DESCRIPTION
## Description

We currently do not wait for Solana tx confirmation. This means that when the user clicks the "Send" button we don't actually check if it's been successfully confirmed. It can happen that the tx won't be finalized e.g. if network is congested and the default fee is too low. In that case we display a notification that the tx has been submitted but the user doesn't see any notification about the transaction failing because of low fee. Since the transaction hasn't been confirmed it also doesn't show up in tx history.

This PR attempts to fix the issue, although it's more of a patch than a fix. During tx submission we would now also wait for it to be confirmed. If confirmation would fail then an error notification should be shown to the user. There's two issues with this fix though:
1. `sendAndConfirmRawTransaction` as it is used is currently deprecated. The same function with a different signature ([here](https://github.com/solana-labs/solana-web3.js/blob/1e328b9ea938473950c7337f7486b048bc1a72a4/packages/library-legacy/src/utils/send-and-confirm-raw-transaction.ts#L23)) should be used instead but we currently don't have the proper data in `pushTransaction` to set the `confirmationStrategy` - we would need `lastValidBlockHeight` which is not a part of the transaction and thus can't be determined in `pushTransaction`. `lastValidBlockHeight` is a part of the Suite store though, I'm just not sure how to properly pass it to `pushTransaction`.
2. Since tx confirmation actually takes a couple of seconds, the `TransactionReviewModal` stays open until the tx is confirmed. And so after the user clicks the "Send" button, there is currently no indication in the UI that something is happening. That's why I added the `isSending` state to `TransactionReviewOutputList` and disabled the Send button if `isSending` is true. I'm not sure if this is at all acceptable. A better solution would be to use a loading spinner but I'm not sure what spinner to use and if this would be acceptable even then.

A proper solution might be to implement pending transaction for Solana as e.g. similarly to Cardano. I have no idea how this works in Suite though. For this, issue 1 mentioned above would probably need to be resolved i.e. `lastValidBlockHeight` would need to be stored somewhere along with the transaction and then we would probably need to subscribe to [signatureSubscribe](https://solana.com/docs/rpc/websocket/signaturesubscribe) somewhere in the pending transactions logic.

