### PR TITLE
fix(suite-native): add qrcode padding

### DIFF
--- a/suite-native/qr-code/src/components/QRCode.tsx
+++ b/suite-native/qr-code/src/components/QRCode.tsx
@@ -12,7 +12,7 @@ type QRCodeProps = {
 const SCREEN_WIDTH = Dimensions.get('screen').width;
 
 const MAX_QRCODE_SIZE = 250;
-const QRCODE_PADDING = 12;
+const QRCODE_PADDING = 24;
 
 const QRCODE_SIZE =
     SCREEN_WIDTH < MAX_QRCODE_SIZE + QRCODE_PADDING ? SCREEN_WIDTH : MAX_QRCODE_SIZE;


### PR DESCRIPTION
## Description
- qrcode white border padding made larger to avoid scanning problems with dark mode enabled
## Related Issue

Resolve #10674 

