### PR TITLE
fix(connect): use devicepath without preferred device in list

### DIFF
--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -223,9 +223,9 @@ const initDevice = async (method: AbstractMethod<any>) => {
         });
     }
 
-    if (method.devicePath && preferredDevice && preferredDeviceInList) {
+    if (method.devicePath) {
         device = _deviceList.getDevice(method.devicePath);
-        showDeviceSelection = !!device?.unreadableError;
+        showDeviceSelection = !device || !!device?.unreadableError;
     } else {
         const devices = _deviceList.asArray();
         if (devices.length === 1 && !isWebUsb) {


### PR DESCRIPTION
## Description

Due to a change in https://github.com/trezor/trezor-suite/pull/9790 there was an error where Suite would not be able to connect to the saved device, since they use their own storage for remembering it. 
This change removes the additional check for the `preferredDevice` saved in storage