### PR TITLE
fix(coinmarket): fix alignment of an exchange quote cta button

### DIFF
--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/List/ExchangeQuote.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/List/ExchangeQuote.tsx
@@ -42,6 +42,9 @@ const Column = styled.div<ColumnProps>`
     justify-content: flex-start;
     max-width: ${({ maxWidth }) => maxWidth ?? '100%'};
 `;
+const ColumnButton = styled(Column)`
+    align-items: flex-end;
+`;
 
 const Heading = styled.div`
     display: flex;
@@ -227,7 +230,7 @@ export const ExchangeQuote = ({ className, quote }: QuoteProps) => {
                     </Heading>
                     <Value>{provider?.kycPolicy}</Value>
                 </Column>
-                <Column>
+                <ColumnButton>
                     <StyledButton
                         isLoading={callInProgress}
                         isDisabled={errorQuote || callInProgress}
@@ -236,7 +239,7 @@ export const ExchangeQuote = ({ className, quote }: QuoteProps) => {
                     >
                         <Translation id="TR_EXCHANGE_GET_THIS_OFFER" />
                     </StyledButton>
-                </Column>
+                </ColumnButton>
             </Details>
             {approvalFee && swapFee && localCurrency && (
                 <DexFooter>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

 task was to align button to the end of the column

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
