### PR TITLE
fix(connect-ui): tipcontainer bottom margin

### DIFF
--- a/packages/connect-ui/src/views/Error.tsx
+++ b/packages/connect-ui/src/views/Error.tsx
@@ -216,6 +216,7 @@ const Text = styled.div`
 
 const TipsContainer = styled.div`
     margin-top: 40px;
+    margin-bottom: 20px;
 `;
 
 const StyledIcon = styled(Icon)`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixing separation between tip box and button in popup error page.
Hopefully that is enough to be visually appealing, but I am open to ideas.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/11052

## Screenshots:


![image](https://github.com/trezor/trezor-suite/assets/5362163/f578f5a7-3b3f-4e28-86e0-9a5fc71438a8)


