### PR TITLE
fix(suite-native): input top padding

### DIFF
--- a/suite-native/atoms/src/Input/Input.tsx
+++ b/suite-native/atoms/src/Input/Input.tsx
@@ -55,7 +55,6 @@ type InputLabelStyleProps = {
 
 type InputStyleProps = {
     isIconDisplayed: boolean;
-    isFocused: boolean;
 };
 
 const inputWrapperStyle = prepareNativeStyle<InputWrapperStyleProps>(
@@ -100,7 +99,7 @@ const inputWrapperStyle = prepareNativeStyle<InputWrapperStyleProps>(
     }),
 );
 
-const inputStyle = prepareNativeStyle<InputStyleProps>((utils, { isIconDisplayed, isFocused }) => ({
+const inputStyle = prepareNativeStyle<InputStyleProps>((utils, { isIconDisplayed }) => ({
     ...utils.typography.body,
     // letterSpacing from `typography.body` is making strange layout jumps on Android while filling the input.
     // This resets it to the default TextInput value.
@@ -113,7 +112,7 @@ const inputStyle = prepareNativeStyle<InputStyleProps>((utils, { isIconDisplayed
     borderWidth: 0,
     flex: 1,
     // Make the text input uniform on both platforms (https://stackoverflow.com/a/68458803/1281305)
-    paddingTop: isFocused ? utils.spacings.large : 0,
+    paddingTop: utils.spacings.large,
     paddingBottom: utils.spacings.extraSmall,
 }));
 
@@ -251,7 +250,7 @@ export const Input = forwardRef<TextInput, InputProps>(
                     <Box flexDirection="row" alignItems="center">
                         <TextInput
                             ref={ref}
-                            style={applyStyle(inputStyle, { isIconDisplayed, isFocused })}
+                            style={applyStyle(inputStyle, { isIconDisplayed })}
                             onFocus={handleOnFocus}
                             onBlur={handleOnBlur}
                             hitSlop={inputHitSlop}


### PR DESCRIPTION
## Description

- fixes conditonal top padding, the padding should be always the same independent of `isFocused` state

## Related issue

Closes #9472

## Screenshots:

https://github.com/trezor/trezor-suite/assets/26143964/66525716-4dfa-45ce-9824-11a92c8fa450

