### PR TITLE
fix(connect-popup): display errors with no code

### DIFF
--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -164,13 +164,12 @@ const handleResponseEvent = (data: MethodResponseMessage) => {
         window.close();
     }
 
-    if (
-        !data.success &&
-        typeof data.payload === 'object' &&
-        'code' in data.payload &&
-        typeof data.payload.code === 'string'
-    ) {
-        switch (data.payload.code) {
+    if (!data.success && typeof data.payload === 'object') {
+        const code =
+            'code' in data.payload && typeof data.payload.code === 'string'
+                ? data.payload.code
+                : undefined;
+        switch (code) {
             case 'Device_CallInProgress':
                 // Ignoring when device call is in progress.
                 // User triggers new call but device call is in progress PopupManager will focus popup.
@@ -191,7 +190,7 @@ const handleResponseEvent = (data: MethodResponseMessage) => {
                 });
                 analytics.report({
                     type: EventType.ViewChangeError,
-                    payload: { code: data.payload.code || 'Code missing' },
+                    payload: { code: code || 'Code missing' },
                 });
         }
     }


### PR DESCRIPTION
## Description

Fix for an error that appeared in https://github.com/trezor/trezor-suite/pull/10363 and caused tests to fail.

There was a new condition which required errors to include code before displaying them, but some errors did not have it set. 