### PR TITLE
fix(connect-popup): don't show error when no device selected

### DIFF
--- a/packages/connect-popup/src/view/selectDevice.ts
+++ b/packages/connect-popup/src/view/selectDevice.ts
@@ -67,6 +67,9 @@ const initWebUsbButton = (showLoader: boolean) => {
             }
         } catch (error) {
             console.error(error);
+            if (error instanceof DOMException && error.name === 'NotFoundError') {
+                return;
+            }
             reactEventBus.dispatch({
                 type: 'error',
                 detail: 'iframe-failure',


### PR DESCRIPTION
## Description

When the user declined USB device selection, an unrelated error message would show up. The error message should be ignored for this case.