### PR TITLE
Feat/improve scams

### DIFF
--- a/packages/suite/src/components/suite/FormattedNftAmount.tsx
+++ b/packages/suite/src/components/suite/FormattedNftAmount.tsx
@@ -8,6 +8,7 @@ import { HiddenPlaceholder, Sign } from 'src/components/suite';
 // importing directly, otherwise unit tests fail, seems to be a styled-components issue
 import { TrezorLink } from 'src/components/suite/TrezorLink';
 import { useSelector } from 'src/hooks/suite/useSelector';
+import { variables } from '@trezor/components';
 
 const Container = styled.div`
     max-width: 100%;
@@ -25,6 +26,9 @@ const StyledTrezorLink = styled(TrezorLink)`
     color: ${({ theme }) => theme.TYPE_GREEN};
     text-decoration: underline;
     display: flex;
+    font-size: ${variables.FONT_SIZE.TINY};
+    line-height: initial;
+    align-items: center;
 `;
 
 const NoLink = styled.div`

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionHeading.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionHeading.tsx
@@ -18,6 +18,7 @@ import {
 import { TransactionHeader } from './TransactionHeader';
 import { WalletAccountTransaction } from 'src/types/wallet';
 import BigNumber from 'bignumber.js';
+import { BlurWrapper } from './TransactionItemBlurWrapper';
 
 const Wrapper = styled.span`
     display: flex;
@@ -166,7 +167,9 @@ export const TransactionHeading = ({
                             icon="WARNING"
                         />
                     )}
-                    <TransactionHeader transaction={transaction} isPending={isPending} />
+                    <BlurWrapper isBlurred={isPhishingTransaction}>
+                        <TransactionHeader transaction={transaction} isPending={isPending} />
+                    </BlurWrapper>
                 </HeadingWrapper>
 
                 <ChevronIconWrapper

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-array-index-key */
-import { memo, Fragment, useState } from 'react';
+import { memo, useState } from 'react';
 import styled, { css } from 'styled-components';
 import { AnimatePresence } from 'framer-motion';
 import { variables, Button, Card } from '@trezor/components';
@@ -31,6 +31,7 @@ import { SECONDARY_PANEL_HEIGHT } from 'src/components/suite/AppNavigation/AppNa
 import { anchorOutlineStyles } from 'src/utils/suite/anchor';
 import { TransactionTimestamp } from 'src/components/wallet/TransactionTimestamp';
 import { selectIsPhishingTransaction } from '@suite-common/wallet-core';
+import { BlurWrapper } from './TransactionItemBlurWrapper';
 
 const Wrapper = styled(Card)<{
     isPending: boolean;
@@ -201,7 +202,7 @@ export const TransactionItem = memo(
                                 {!isUnknown && type !== 'failed' && previewTargets.length ? (
                                     <>
                                         {previewTargets.map((t, i) => (
-                                            <Fragment key={i}>
+                                            <BlurWrapper isBlurred={isPhishingTransaction} key={i}>
                                                 {t.type === 'target' && (
                                                     <TransactionTarget
                                                         // render first n targets, n = DEFAULT_LIMIT
@@ -251,14 +252,17 @@ export const TransactionItem = memo(
                                                         }
                                                     />
                                                 )}
-                                            </Fragment>
+                                            </BlurWrapper>
                                         ))}
                                         <AnimatePresence initial={false}>
                                             {limit > 0 &&
                                                 allOutputs
                                                     .slice(DEFAULT_LIMIT, DEFAULT_LIMIT + limit)
                                                     .map((t, i) => (
-                                                        <Fragment key={i}>
+                                                        <BlurWrapper
+                                                            isBlurred={isPhishingTransaction}
+                                                            key={i}
+                                                        >
                                                             {t.type === 'target' && (
                                                                 <TransactionTarget
                                                                     target={t.payload}
@@ -313,7 +317,7 @@ export const TransactionItem = memo(
                                                                     }
                                                                 />
                                                             )}
-                                                        </Fragment>
+                                                        </BlurWrapper>
                                                     ))}
                                         </AnimatePresence>
                                     </>
@@ -345,14 +349,16 @@ export const TransactionItem = memo(
                                 )}
 
                                 {showFeeRow && (
-                                    <StyledFeeRow
-                                        fee={fee}
-                                        transaction={transaction}
-                                        useFiatValues={useFiatValues}
-                                        $noInputsOutputs={noInputsOutputs}
-                                        isFirst
-                                        isLast
-                                    />
+                                    <BlurWrapper isBlurred={isPhishingTransaction}>
+                                        <StyledFeeRow
+                                            fee={fee}
+                                            transaction={transaction}
+                                            useFiatValues={useFiatValues}
+                                            $noInputsOutputs={noInputsOutputs}
+                                            isFirst
+                                            isLast
+                                        />
+                                    </BlurWrapper>
                                 )}
 
                                 {isExpandable && (

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionItemBlurWrapper.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionItemBlurWrapper.tsx
@@ -1,0 +1,11 @@
+import styled, { css } from 'styled-components';
+
+export const BlurWrapper = styled.span<{ isBlurred: boolean }>`
+    ${({ isBlurred }) =>
+        isBlurred &&
+        css`
+            filter: blur(2px);
+            pointer-events: none;
+            user-select: none;
+        `};
+`;

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TokenTransferAddressLabel.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TokenTransferAddressLabel.tsx
@@ -1,17 +1,7 @@
-import styled, { css } from 'styled-components';
 import { ArrayElement } from '@trezor/type-utils';
 import { Translation, AddressLabeling } from 'src/components/suite';
 import { WalletAccountTransaction } from 'src/types/wallet';
-
-const BlurWrapper = styled.span<{ isBlurred: boolean }>`
-    ${({ isBlurred }) =>
-        isBlurred &&
-        css`
-            filter: blur(2px);
-            pointer-events: none;
-            user-select: none;
-        `};
-`;
+import { BlurWrapper } from '../TransactionItemBlurWrapper';
 
 interface TokenTransferAddressLabelProps {
     transfer: ArrayElement<WalletAccountTransaction['tokens']>;

--- a/suite-common/wallet-utils/src/antiFraud.ts
+++ b/suite-common/wallet-utils/src/antiFraud.ts
@@ -19,10 +19,16 @@ export const getIsFakeTokenPhishing = (
     transaction.tokens.every(tokenTx => !isNftTokenTransfer(tokenTx)) && // non-nfts
     !transaction.tokens.some(tokenTx => tokenDefinitions[tokenTx.contract]?.isTokenKnown); // all tokens are unknown
 
+// TEMP: solution to tag all NFT txs on Polygon PoS as scam before we introduce NFT definitions
+export const getIsPolygonNftTransaction = (transaction: WalletAccountTransaction) =>
+    transaction.symbol === 'matic' &&
+    transaction.tokens.some(tokenTx => isNftTokenTransfer(tokenTx));
+
 export const getIsPhishingTransaction = (
     transaction: WalletAccountTransaction,
     tokenDefinitions: TokenDefinitions,
 ) =>
     getIsZeroValuePhishing(transaction) ||
+    getIsPolygonNftTransaction(transaction) ||
     (D.isNotEmpty(tokenDefinitions) && // at least one token definition is available
         getIsFakeTokenPhishing(transaction, tokenDefinitions));


### PR DESCRIPTION
## Description

- tag all nft txs on polygon as potential scams (will be removed in march release when we introduce nft definitions)
- blur also heading and symbol and amount of scam txs
- fix nft link in tx modal

## Related Issue

resolves #11071

## Screenshots:

![Screenshot 2024-02-07 at 10 03 14](https://github.com/trezor/trezor-suite/assets/33235762/dddb16dd-2449-4f45-a486-911bfe172cfd)

![Screenshot 2024-02-07 at 10 03 25](https://github.com/trezor/trezor-suite/assets/33235762/f4b49dca-a99e-4d26-8137-90d60652975f)
