### PR TITLE
defeat(suite): hide polygon under debug mode

### DIFF
--- a/packages/suite/src/components/suite/modals/ConfirmEvmExplanationModal.tsx
+++ b/packages/suite/src/components/suite/modals/ConfirmEvmExplanationModal.tsx
@@ -116,6 +116,7 @@ export const ConfirmEvmExplanationModal = ({
     const isVisible =
         account.empty &&
         network.networkType === 'ethereum' &&
+        account.symbol === 'matic' && // TODO: POLYGON DEBUG
         !confirmExplanationModalClosed[account.symbol]?.[route];
 
     if (!isVisible) {

--- a/packages/suite/src/hooks/settings/useEnabledNetworks.ts
+++ b/packages/suite/src/hooks/settings/useEnabledNetworks.ts
@@ -15,7 +15,7 @@ export const useEnabledNetworks = (): EnabledNetworks => {
     const enabledNetworks = useSelector(state => state.wallet.settings.enabledNetworks);
     const isDebug = useSelector(state => state.suite.settings.debug.showDebugMenu);
 
-    const mainnets = getMainnets();
+    const mainnets = getMainnets(isDebug);
 
     const testnets = getTestnets(isDebug);
 

--- a/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
+++ b/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
@@ -180,7 +180,8 @@ export const FreshAddress = ({
                     <Translation id="RECEIVE_ADDRESS_REVEAL" />
                 </StyledButton>
             </Tooltip>
-            {account.networkType === 'ethereum' && (
+            {/* TODO: POLYGON DEBUG */}
+            {account.networkType === 'ethereum' && account.symbol === 'matic' && (
                 <StyledEvmExplanationBox
                     caret
                     symbol={account.symbol}

--- a/packages/suite/src/views/wallet/send/components/Outputs/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/index.tsx
@@ -83,26 +83,27 @@ export const Outputs = ({ disableAnim }: OutputsProps) => {
                                 <OpReturn outputId={index} />
                             ) : (
                                 <>
-                                    {account.networkType === 'ethereum' && (
-                                        <StyledEvmExplanationBox
-                                            symbol={account.symbol}
-                                            title={
+                                    {account.networkType === 'ethereum' &&
+                                        account.symbol === 'matic' && ( // TODO: POLYGON DEBUG
+                                            <StyledEvmExplanationBox
+                                                symbol={account.symbol}
+                                                title={
+                                                    <Translation
+                                                        id="TR_EVM_EXPLANATION_SEND_TITLE"
+                                                        values={{
+                                                            network: networks[account.symbol].name,
+                                                        }}
+                                                    />
+                                                }
+                                            >
                                                 <Translation
-                                                    id="TR_EVM_EXPLANATION_SEND_TITLE"
+                                                    id="TR_EVM_EXPLANATION_SEND_DESCRIPTION"
                                                     values={{
                                                         network: networks[account.symbol].name,
                                                     }}
                                                 />
-                                            }
-                                        >
-                                            <Translation
-                                                id="TR_EVM_EXPLANATION_SEND_DESCRIPTION"
-                                                values={{
-                                                    network: networks[account.symbol].name,
-                                                }}
-                                            />
-                                        </StyledEvmExplanationBox>
-                                    )}
+                                            </StyledEvmExplanationBox>
+                                        )}
                                     <Address
                                         output={outputs[index]}
                                         outputId={index}

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -517,6 +517,7 @@ export const networks = {
         features: ['rbf', 'sign-verify', 'tokens', 'token-definitions'],
         customBackends: ['blockbook'],
         accountTypes: {},
+        isDebugOnly: true, // TODO: POLYGON DEBUG
     },
 } as const;
 
@@ -558,6 +559,7 @@ export type Network = Without<NetworkValue, 'accountTypes'> & {
     support?: {
         [key in DeviceModelInternal]: string;
     };
+    isDebugOnly?: boolean;
 };
 
 // Transforms the network object into the previously used format so we don't have to change
@@ -575,7 +577,8 @@ export const networksCompatibility: Network[] = Object.entries(networks).flatMap
     ],
 );
 
-export const getMainnets = () => networksCompatibility.filter(n => !n.accountType && !n.testnet);
+export const getMainnets = (debug = false) =>
+    networksCompatibility.filter(n => !n.accountType && !n.testnet && (!n.isDebugOnly || debug));
 
 export const getTestnets = (debug = false) =>
     networksCompatibility.filter(


### PR DESCRIPTION
## Description

- hide polygon 
- it's hidden unless you enable it under debug mode
- if you enable it, then the polygon will be there even though the debug is disabled afterewards

## Related Issue


## Screenshots:
![Screenshot 2024-02-07 at 11 58 52](https://github.com/trezor/trezor-suite/assets/33235762/9a6de847-278e-4a9e-a0e7-c3b034ae6ba5)
![Screenshot 2024-02-07 at 11 59 30](https://github.com/trezor/trezor-suite/assets/33235762/913921d0-b3a0-40ef-a297-0f3eda8b8aa5)
![Screenshot 2024-02-07 at 11 59 45](https://github.com/trezor/trezor-suite/assets/33235762/4f0ca949-445a-477a-a97f-e0dd3fc0aa14)
![Screenshot 2024-02-07 at 11 59 56](https://github.com/trezor/trezor-suite/assets/33235762/a94486f1-b05c-4361-bb5e-c54902001fb6)
