### PR TITLE
chore(suite-native): fix ios build with flipper

### DIFF
--- a/suite-native/app/app.config.ts
+++ b/suite-native/app/app.config.ts
@@ -115,6 +115,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
                 },
                 ios: {
                     deploymentTarget: '14.0',
+                    flipper: 'true',
                 },
             },
         ],


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

- Flipper not allowed by default on ios but breaking the native build

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
before:
<img width="980" alt="image" src="https://github.com/trezor/trezor-suite/assets/3729633/39d20899-f758-4c1e-a875-b9b6ff29b08d">

after:
<img width="609" alt="image" src="https://github.com/trezor/trezor-suite/assets/3729633/439e6e96-8d82-4de3-873a-ccb4d8e13e3d">

