### PR TITLE
chore(suite): hide polygon trade in trade section

### DIFF
--- a/packages/suite/src/hooks/settings/useEnabledNetworks.ts
+++ b/packages/suite/src/hooks/settings/useEnabledNetworks.ts
@@ -3,6 +3,7 @@ import { changeCoinVisibility } from 'src/actions/settings/walletSettingsActions
 import type { Network } from 'src/types/wallet';
 
 import { getMainnets, getTestnets } from '@suite-common/wallet-config';
+import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
 
 type EnabledNetworks = {
     mainnets: Network[];
@@ -13,7 +14,7 @@ type EnabledNetworks = {
 
 export const useEnabledNetworks = (): EnabledNetworks => {
     const enabledNetworks = useSelector(state => state.wallet.settings.enabledNetworks);
-    const isDebug = useSelector(state => state.suite.settings.debug.showDebugMenu);
+    const isDebug = useSelector(selectIsDebugModeActive);
 
     const mainnets = getMainnets(isDebug);
 

--- a/packages/suite/src/hooks/wallet/useCoinmarketExchangeOffers.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketExchangeOffers.ts
@@ -25,6 +25,7 @@ import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 
 import { useCoinmarketRecomposeAndSign } from './useCoinmarketRecomposeAndSign';
 import { cryptoToNetworkSymbol } from 'src/utils/wallet/coinmarket/cryptoSymbolUtils';
+import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
 
 export const useOffers = ({ selectedAccount }: UseCoinmarketExchangeFormProps) => {
     const timer = useTimer();
@@ -61,6 +62,7 @@ export const useOffers = ({ selectedAccount }: UseCoinmarketExchangeFormProps) =
     const device = useSelector(selectDevice);
     const { addressVerified, dexQuotes, exchangeInfo, fixedQuotes, floatQuotes, quotesRequest } =
         useSelector(state => state.wallet.coinmarket.exchange);
+    const isDebug = useSelector(selectIsDebugModeActive);
 
     const [innerFixedQuotes, setInnerFixedQuotes] = useState<ExchangeTrade[] | undefined>(
         fixedQuotes,
@@ -144,7 +146,10 @@ export const useOffers = ({ selectedAccount }: UseCoinmarketExchangeFormProps) =
             const unavailableCapabilities = device?.unavailableCapabilities ?? {};
             // is the symbol supported by the suite and the device natively
             const receiveNetworks = networks.filter(
-                n => n.symbol === receiveNetwork && !unavailableCapabilities[n.symbol],
+                n =>
+                    n.symbol === receiveNetwork &&
+                    !unavailableCapabilities[n.symbol] &&
+                    ((n.isDebugOnly && isDebug) || !n.isDebugOnly),
             );
             if (receiveNetworks.length > 0) {
                 // get accounts of the current symbol belonging to the current device
@@ -162,7 +167,7 @@ export const useOffers = ({ selectedAccount }: UseCoinmarketExchangeFormProps) =
             }
         }
         setSuiteReceiveAccounts(undefined);
-    }, [accounts, device, exchangeStep, receiveNetwork, selectedQuote]);
+    }, [accounts, device, exchangeStep, receiveNetwork, selectedQuote, isDebug]);
 
     const confirmTrade = async (address: string, extraField?: string, trade?: ExchangeTrade) => {
         let ok = false;

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/index.tsx
@@ -21,6 +21,7 @@ import {
 } from 'src/utils/wallet/coinmarket/cryptoSymbolUtils';
 import { useSelector } from 'src/hooks/suite';
 import { selectDeviceAccounts } from '@suite-common/wallet-core';
+import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
 
 const Row = styled.div<{ spaceBefore?: boolean }>`
     display: flex;
@@ -63,6 +64,7 @@ const Inputs = () => {
     const { shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
     const deviceAccounts = useSelector(selectDeviceAccounts);
     const { elevation } = useElevation();
+    const isDebug = useSelector(selectIsDebugModeActive);
 
     const { outputs, receiveCryptoSelect } = getValues();
     const tokenAddress = outputs?.[0]?.token;
@@ -158,25 +160,27 @@ const Inputs = () => {
             <Row spaceBefore>
                 <ReceiveCryptoSelect />
             </Row>
-            {isReceiveTokenBalanceZero && (
-                <Row spaceBefore>
-                    <StyledEvmExplanationBox
-                        caret
-                        elevation={elevation}
-                        symbol={receiveCryptoNetworkSymbol}
-                        title={<Translation id="TR_EVM_EXPLANATION_EXCHANGE_TITLE" />}
-                    >
-                        <Translation
-                            id="TR_EVM_EXPLANATION_EXCHANGE_DESCRIPTION"
-                            values={{
-                                coin: receiveCryptoSelect.label,
-                                network: networks[receiveCryptoNetworkSymbol].name,
-                                networkSymbol: receiveCryptoNetworkSymbol.toUpperCase(),
-                            }}
-                        />
-                    </StyledEvmExplanationBox>
-                </Row>
-            )}
+            {isReceiveTokenBalanceZero &&
+                (receiveCryptoNetworkSymbol !== 'matic' || // TODO: POLYGON DEBUG
+                    (receiveCryptoNetworkSymbol === 'matic' && isDebug)) && (
+                    <Row spaceBefore>
+                        <StyledEvmExplanationBox
+                            caret
+                            elevation={elevation}
+                            symbol={receiveCryptoNetworkSymbol}
+                            title={<Translation id="TR_EVM_EXPLANATION_EXCHANGE_TITLE" />}
+                        >
+                            <Translation
+                                id="TR_EVM_EXPLANATION_EXCHANGE_DESCRIPTION"
+                                values={{
+                                    coin: receiveCryptoSelect.label,
+                                    network: networks[receiveCryptoNetworkSymbol].name,
+                                    networkSymbol: receiveCryptoNetworkSymbol.toUpperCase(),
+                                }}
+                            />
+                        </StyledEvmExplanationBox>
+                    </Row>
+                )}
         </Wrapper>
     );
 };


### PR DESCRIPTION
## Description

- hide polygon missing MATIC banner when not in debug mode
- hide add polygon account when not in debug mode

## Screenshots:

**debug mode**
![Screenshot 2024-02-07 at 14 49 13](https://github.com/trezor/trezor-suite/assets/33235762/79f71b9b-077b-4c56-8e44-93829503d462)
![Screenshot 2024-02-07 at 14 48 58](https://github.com/trezor/trezor-suite/assets/33235762/92d1b232-d862-4a33-9bb6-94c8a1fdeb74)

**no debug mode** 
![Screenshot 2024-02-07 at 14 49 38](https://github.com/trezor/trezor-suite/assets/33235762/93b1358f-35c9-42ba-8c72-1d996c15f720)
![Screenshot 2024-02-07 at 14 49 26](https://github.com/trezor/trezor-suite/assets/33235762/1eee0244-c376-4486-897a-c1734f57c44d)

