### PR TITLE
fix(connect-popup): remove initTransport from core import

### DIFF
--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -393,9 +393,7 @@ const initCoreInPopup = async (
         });
     });
 
-    if (!initCore || !initTransport) {
-        return;
-    }
+    if (!initCore) return;
     if (disposed) return;
 
     // init core
@@ -418,13 +416,13 @@ const initCoreInPopup = async (
     setState({ core });
     log.debug('initiated core');
 
-    // init transport
-    /*
-    log.debug('initiating transport with settings: ', payload.settings);
-    reactEventBus.dispatch({ type: 'loading', message: 'initiating transport' });
-    await initTransport(payload.settings);
-    if (disposed) return;
-    */
+    // init transport - deprecated, here for backward compatibility
+    if (initTransport) {
+        log.debug('initiating transport with settings: ', payload.settings);
+        reactEventBus.dispatch({ type: 'loading', message: 'initiating transport' });
+        await initTransport(payload.settings);
+        if (disposed) return;
+    }
     log.debug('initiated transport');
 
     // done, in popup, we are ready to handle incoming messages


### PR DESCRIPTION
## Description

In https://github.com/trezor/trezor-suite/commit/00deffaa63db5cf0143b7760d5bc23b45d30e0f3 `initTransport` was removed. 
However in connect-popup remained a condition to check if it's defined, so initiating core would fail. 

I moved the condition around the old commented-out block for initTransport, so it won't be called for the new version but can be called if it's present for backwards compatibility.