### PR TITLE
fix(suite): dropdown to be clickable without collapsing the custom children

### DIFF
--- a/packages/components/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/components/src/components/Dropdown/Dropdown.stories.tsx
@@ -5,9 +5,27 @@ import { Dropdown as DropdownComponent, DropdownProps } from './Dropdown';
 
 const Center = styled.div`
     display: flex;
+    flex-direction: column;
     justify-content: center;
     width: 100%;
     padding: 100px 0;
+    gap: 20px;
+`;
+
+const ClickableAreaTestWrapper = styled.div`
+    background: ${({ theme }) => theme.backgroundAlertRedSubtleOnElevation1};
+    width: fit-content;
+    display: flex;
+`;
+
+const ColoredBox = styled.div`
+    background-color: ${({ theme }) => theme.backgroundAlertBlueSubtleOnElevation1};
+`;
+
+// This will cause inner content to be "cut" by the container
+// This is the way how it may be used, if you want to swap custom component into dropdown.
+const StyledDropdown = styled(DropdownComponent)`
+    overflow: hidden;
 `;
 
 export default {
@@ -18,7 +36,19 @@ export default {
 export const Dropdown: StoryObj<DropdownProps> = {
     render: args => (
         <Center>
-            <DropdownComponent {...args} />
+            <h3>Default dots as content</h3>
+            <ClickableAreaTestWrapper>
+                <DropdownComponent {...args} />
+            </ClickableAreaTestWrapper>
+            <hr />
+            <h3>Custom children with overflow: hidden; on the Dropdown itself</h3>
+            <ClickableAreaTestWrapper>
+                <StyledDropdown {...args}>
+                    <ColoredBox>
+                        Everything the State says is a lie, and everything it has it has stolen.
+                    </ColoredBox>
+                </StyledDropdown>
+            </ClickableAreaTestWrapper>
         </Center>
     ),
     args: {
@@ -29,6 +59,7 @@ export const Dropdown: StoryObj<DropdownProps> = {
             label: 'some link',
             icon: 'ARROW_RIGHT_LONG',
         },
+        alignMenu: 'right-top',
         items: [
             {
                 key: '1',

--- a/packages/components/src/components/Dropdown/Dropdown.tsx
+++ b/packages/components/src/components/Dropdown/Dropdown.tsx
@@ -27,7 +27,7 @@ const MoreIcon = styled(IconButton)<{ $isToggled: boolean }>`
     }
 `;
 
-const Container = styled.div<{ disabled?: boolean }>`
+const Container = styled.div<{ disabled?: boolean; $hasCustomChildren: boolean }>`
     all: unset;
     width: fit-content;
     height: fit-content;
@@ -35,6 +35,12 @@ const Container = styled.div<{ disabled?: boolean }>`
     border: 1px solid transparent;
     ${getFocusShadowStyle()};
     cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
+
+    /** 
+        This must be here to reduce clickable area to the "circle" of the (...) children.
+        However, if you use custom children its your own responsibility to handle it.
+    */
+    ${({ $hasCustomChildren }) => ($hasCustomChildren ? undefined : '50%;')}
 `;
 
 const getPlacementData = (
@@ -100,7 +106,7 @@ export const Dropdown = forwardRef(
     ) => {
         const [isToggled, setIsToggledState] = useState(false);
         const [coords, setCoords] = useState<Coords>();
-        const [clickPos, setСlickPos] = useState<Coords>();
+        const [clickPos, setClickPos] = useState<Coords>();
 
         const menuRef = useRef<HTMLUListElement>(null);
         const toggleRef = useRef<HTMLDivElement>(null);
@@ -176,10 +182,11 @@ export const Dropdown = forwardRef(
 
             setToggled(!isToggled);
             if (renderOnClickPosition) {
-                setСlickPos({ x: e.pageX, y: e.pageY });
+                setClickPos({ x: e.pageX, y: e.pageY });
             }
         };
 
+        const hasCustomChildren = children !== undefined && children !== null;
         const childComponent = typeof children === 'function' ? children(isToggled) : children;
 
         const ToggleComponent = childComponent ? (
@@ -226,6 +233,7 @@ export const Dropdown = forwardRef(
                 onClick={onToggleClick}
                 onFocus={() => !isDisabled && !renderOnClickPosition && setToggled(true)}
                 onBlur={e => !menuRef.current?.contains(e.relatedTarget) && setToggled(false)}
+                $hasCustomChildren={hasCustomChildren}
             >
                 {ToggleComponent}
                 {isToggled && PortalMenu}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Solves this [comment](https://github.com/trezor/trezor-suite/pull/11081#discussion_r1481416885) from @dahaca 

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

Before:
![image](https://github.com/trezor/trezor-suite/assets/152899911/a446e895-2772-47de-9666-65020d787dae)


After:
![image](https://github.com/trezor/trezor-suite/assets/152899911/b11cbd03-148e-4122-8398-b37a2ae41595)

Storybook:
![image](https://github.com/trezor/trezor-suite/assets/152899911/6a5e1fef-4dbe-4b7d-97f5-75ca509093ad)

