### PR TITLE
connect-web core in popup mode

### DIFF
--- a/.github/workflows/template-connect-popup-test-params.yml
+++ b/.github/workflows/template-connect-popup-test-params.yml
@@ -21,6 +21,11 @@ on:
         type: "boolean"
         required: false
         default: true
+      run-core-in-popup:
+        description: "Flag to indicate whether to run the core-in-popup job"
+        type: "boolean"
+        required: false
+        default: false
       build-overview:
         description: "Flag to indicate whether to build connect-popup-overview.html"
         type: "boolean"
@@ -68,7 +73,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ inputs.build-overview }}
         with:
-          name: static-overview-${{ inputs.test-name }}-${{ github.run_attempt }}
+          name: core-in-popup-static-overview-${{ inputs.test-name }}-${{ github.run_attempt }}
           path: |
             tmp_overview_directory/
 
@@ -136,6 +141,67 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: webextension-test-artifacts-${{ inputs.test-name }}-${{ github.run_attempt }}-${{ github.run_id }}
+          path: |
+            packages/connect-popup/test-results
+
+      - name: Check Test Success
+        run: |
+          # If there is `test-results` it means it has failed.
+          if [ -f "packages/connect-popup/test-results" ]; then
+            echo "Tests failed"
+            exit 1
+          fi
+
+  core_in_popup:
+    name: core_in_popup
+    runs-on: ubuntu-latest
+    if: ${{ inputs.run-core-in-popup }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Extract branch name
+        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        id: extract_branch
+
+      - name: Install dependencies
+        run: |
+          echo -e "\nenableScripts: false" >> .yarnrc.yml
+          yarn workspaces focus @trezor/connect-popup
+
+      - name: Run connect popup test
+        env:
+          URL: https://${{ inputs.DEV_SERVER_HOSTNAME }}/connect/${{ steps.extract_branch.outputs.branch }}/?core-in-popup=true
+          CORE_IN_POPUP: true
+          # skip settings page, this url is set at build time anyway
+          #TREZOR_CONNECT_SRC: https://${{ inputs.DEV_SERVER_HOSTNAME }}/connect/${{ steps.extract_branch.outputs.branch }}/
+          CI_COMMIT_BRANCH: ${{ steps.extract_branch.outputs.branch }}
+          CI_JOB_NAME: ${{ inputs.test-name }}-${{ github.run_attempt }}
+        run: |
+          ./docker/docker-connect-popup-ci.sh ${{ inputs.test-name }}
+
+      - name: Prepare static overview
+        if: ${{ inputs.build-overview }}
+        run: |
+          echo "Preparing static overview"
+          mkdir -p tmp_overview_directory
+          cp -R ./packages/connect-popup/e2e/screenshots/* tmp_overview_directory/
+          cp packages/connect-popup/connect-popup-overview.html  tmp_overview_directory/connect-popup-overview.html
+
+      - name: Upload static overview artifact
+        uses: actions/upload-artifact@v4
+        if: ${{ inputs.build-overview }}
+        with:
+          name: static-overview-${{ inputs.test-name }}-${{ github.run_attempt }}
+          path: |
+            tmp_overview_directory/
+
+      - name: Upload artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: core-in-popup-test-artifacts-${{ inputs.test-name }}-${{ github.run_attempt }}-${{ github.run_id }}
           path: |
             packages/connect-popup/test-results
 

--- a/.github/workflows/test-connect-popup.yml
+++ b/.github/workflows/test-connect-popup.yml
@@ -72,6 +72,7 @@ jobs:
       test-name: methods.test
       DEV_SERVER_HOSTNAME: dev.suite.sldev.cz
       run-webextension: ${{ github.event_name == 'schedule' }}
+      run-core-in-popup: true
       build-overview: true
 
   popup-close:
@@ -81,6 +82,7 @@ jobs:
       test-name: popup-close.test
       DEV_SERVER_HOSTNAME: dev.suite.sldev.cz
       run-webextension: true
+      run-core-in-popup: true
 
   passphrase:
     needs: [build-deploy]
@@ -89,6 +91,7 @@ jobs:
       test-name: passphrase.test
       DEV_SERVER_HOSTNAME: dev.suite.sldev.cz
       run-webextension: true
+      run-core-in-popup: true
 
   popup-pages:
     needs: [build-deploy]

--- a/docker/docker-compose.connect-popup-ci.yml
+++ b/docker/docker-compose.connect-popup-ci.yml
@@ -22,6 +22,7 @@ services:
       - CI_JOB_NAME=$CI_JOB_NAME
       - TEST_FILE=$TEST_FILE
       - IS_WEBEXTENSION=$IS_WEBEXTENSION
+      - CORE_IN_POPUP=$CORE_IN_POPUP
       - TREZOR_CONNECT_SRC=$TREZOR_CONNECT_SRC
     working_dir: /e2e
     command: bash -c "npx playwright install && yarn workspace @trezor/connect-popup test:e2e $TEST_FILE"

--- a/docker/docker-compose.connect-popup-test.yml
+++ b/docker/docker-compose.connect-popup-test.yml
@@ -33,6 +33,7 @@ services:
       - PWDEBUG=console
       - TEST_FILE=$TEST_FILE
       - IS_WEBEXTENSION=$IS_WEBEXTENSION
+      - CORE_IN_POPUP=$CORE_IN_POPUP
       - TREZOR_CONNECT_SRC=$TREZOR_CONNECT_SRC
     working_dir: /trezor-suite
     command: bash -c "docker/wait-for-200.sh http://localhost:8088/index.html && yarn workspace @trezor/connect-popup test:e2e $TEST_FILE"

--- a/docker/docker-connect-popup-ci.sh
+++ b/docker/docker-connect-popup-ci.sh
@@ -6,6 +6,7 @@ export LOCAL_USER_ID
 export TEST_FILE=$1
 export URL=$URL
 export TREZOR_CONNECT_SRC=$TREZOR_CONNECT_SRC
+export CORE_IN_POPUP=$CORE_IN_POPUP
 export IS_WEBEXTENSION=$IS_WEBEXTENSION
 
 docker compose -f ./docker/docker-compose.connect-popup-ci.yml up --build --abort-on-container-exit

--- a/docker/docker-connect-popup-test.sh
+++ b/docker/docker-connect-popup-test.sh
@@ -6,5 +6,7 @@ LOCAL_USER_ID="$(id -u "$USER")"
 export LOCAL_USER_ID
 export TEST_FILE=$1
 export TREZOR_CONNECT_SRC=http://localhost:8088/
+export CORE_IN_POPUP=$CORE_IN_POPUP
+export IS_WEBEXTENSION=$IS_WEBEXTENSION
 
 docker compose -f ./docker/docker-compose.connect-popup-test.yml up --build --abort-on-container-exit

--- a/packages/connect-explorer/src/actions/trezorConnectActions.ts
+++ b/packages/connect-explorer/src/actions/trezorConnectActions.ts
@@ -100,7 +100,12 @@ export const init =
             console.log('using @trezor/connect hosted on: ', window.__TREZOR_CONNECT_SRC);
         }
 
+        // Get default useCoreInPopup from URL params (?core-in-popup=true)
+        const urlParams = new URLSearchParams(window.location.search);
+        const useCoreInPopup = urlParams.get('core-in-popup') === 'true';
+
         const connectOptions = {
+            useCoreInPopup,
             transportReconnect: true,
             popup: true,
             debug: true,

--- a/packages/connect-explorer/src/pages/settings.mdx
+++ b/packages/connect-explorer/src/pages/settings.mdx
@@ -23,6 +23,7 @@ export const Settings = () => {
     const connectOptions = useSelector(state => ({
         trustedHost: state.connect?.options?.trustedHost,
         connectSrc: state.connect?.options?.connectSrc,
+        useCoreInPopup: state?.connect?.options?.useCoreInPopup,
     }));
 
     const isHandshakeConfirmed = useSelector(state => state.connect?.isHandshakeConfirmed || false);
@@ -38,6 +39,12 @@ export const Settings = () => {
             type: 'checkbox',
             key: 'trustedHost',
             value: connectOptions?.trustedHost || false,
+        },
+        {
+            name: 'useCoreInPopup',
+            type: 'checkbox',
+            key: 'useCoreInPopup',
+            value: connectOptions?.useCoreInPopup || false,
         },
         {
             name: 'connectSrc',

--- a/packages/connect-popup/e2e/support/helpers.ts
+++ b/packages/connect-popup/e2e/support/helpers.ts
@@ -161,6 +161,9 @@ export const setConnectSettings = async (
             connectSrc,
         );
     }
+    if (process.env.CORE_IN_POPUP) {
+        await waitAndClick(explorerPage, ['@checkbox/useCoreInPopup']);
+    }
     await waitAndClick(explorerPage, ['@submit-button']);
 };
 

--- a/packages/connect-popup/e2e/tests/methods.test.ts
+++ b/packages/connect-popup/e2e/tests/methods.test.ts
@@ -15,6 +15,7 @@ let device = {};
 let context: any = null;
 
 const isWebExtension = process.env.IS_WEBEXTENSION === 'true';
+const isCoreInPopup = process.env.CORE_IN_POPUP === 'true';
 
 const screenshotEmu = async (path: string) => {
     const { response } = await TrezorUserEnvLink.send({
@@ -133,7 +134,7 @@ filteredFixtures.forEach(f => {
         });
         await popup.click("button[data-test='@analytics/continue-button']");
 
-        if (isWebExtension) {
+        if (isWebExtension || isCoreInPopup) {
             log(f.url, 'waiting for select device');
             await popup.waitForSelector('.select-device-list button.list', { state: 'visible' });
             await popup.click('.select-device-list button.list');

--- a/packages/connect-popup/e2e/tests/popup-pages.test.ts
+++ b/packages/connect-popup/e2e/tests/popup-pages.test.ts
@@ -145,10 +145,11 @@ test('log page should contain logs from shared worker', async ({ page, context }
     // Open new tab to go to log.html
     const logsPage = await persistentContext.newPage();
 
-    log(`go to: ${url}log.html`);
-    await logsPage.goto(`${url}log.html`);
+    const logsUrl = `${url.split('?')[0]}log.html`;
+    log(`go to: ${logsUrl}`);
+    await logsPage.goto(logsUrl);
     await logsPage.waitForLoadState('load');
-    log(`loaded: ${url}log.html`);
+    log(`loaded: ${logsUrl}`);
 
     log('waiting for download-button to be visible');
     await logsPage.waitForSelector("button[data-test='@log-container/download-button']", {

--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -40,6 +40,9 @@ import {
 import { isPhishingDomain } from './utils/isPhishingDomain';
 import { initLog, setLogWriter, LogWriter } from '@trezor/connect/src/utils/debug';
 
+const INTERVAL_CHECK_PARENT_ALIVE_MS = 1000;
+const INTERVAL_HANDSHAKE_TIMEOUT_MS = 90 * 1000;
+
 const log = initLog('@trezor/connect-popup');
 const proxyLogger = initLog('@trezor/connect-webextension');
 
@@ -324,6 +327,20 @@ const handleMessageInCoreMode = (
     handleUIAffectingMessage(message);
 };
 
+const handleWindowBeforeUnload = (_e: BeforeUnloadEvent) => {
+    if (getState().core) {
+        const core = ensureCore();
+        core.handleMessage({
+            type: POPUP.CLOSED,
+            payload: null,
+        });
+    }
+};
+
+const handleParentClosed = () => {
+    window.close();
+};
+
 const handleLogMessage = (event: MessageEvent<IFrameLogRequest>) => {
     const { data } = event;
     if (!data) return;
@@ -382,6 +399,15 @@ const init = async (payload: PopupInit['payload']) => {
 
         if (payload.useCore) {
             addWindowEventListener('message', handleMessageInCoreMode, false);
+            addWindowEventListener('beforeunload', handleWindowBeforeUnload, false);
+            if (window.opener) {
+                // Most reliable way to detect parent close seems to be to check it periodically
+                setInterval(() => {
+                    if (!window.opener || window.opener.closed) {
+                        handleParentClosed();
+                    }
+                }, INTERVAL_CHECK_PARENT_ALIVE_MS);
+            }
             await initCoreInPopup(payload, logWriterFactory);
         } else {
             addWindowEventListener('message', handleMessageInIframeMode, false);
@@ -523,7 +549,7 @@ const onLoad = () => {
             type: 'error',
             detail: 'handshake-timeout',
         });
-    }, 90 * 1000);
+    }, INTERVAL_HANDSHAKE_TIMEOUT_MS);
 };
 
 /**

--- a/packages/connect-popup/src/static/popup.html
+++ b/packages/connect-popup/src/static/popup.html
@@ -3232,12 +3232,9 @@
         </div>
 
         <script type="text/javascript" async="false">
-            const message = {
-                type: 'popup-bootstrap',
-                channel: {
-                    here: '@trezor/connect-popup',
-                    peer: '@trezor/connect-web',
-                },
+            const channel = {
+                here: '@trezor/connect-popup',
+                peer: '@trezor/connect-web',
             };
 
             // Workaround for popup-content-script-loaded earlier than popup-loaded
@@ -3254,9 +3251,24 @@
             };
             window.addEventListener('message', handlePopupContentScriptLoaded);
 
+            // The handshake is sent after the bootstrap message, so we process it here to avoid delays loading popup.js
+            // In the future, channel handling should be done in popup.js directly.
+            // todo: connect10
+
+            window.addEventListener('message', event => {
+                if (event.data.type === 'channel-handshake-request') {
+                    const handshakeMessage = { type: 'channel-handshake-confirm', channel };
+                    if (window.opener) {
+                        window.opener.postMessage(handshakeMessage, '*');
+                    } else {
+                        window.postMessage(handshakeMessage, '*');
+                    }
+                }
+            });
+
             setTimeout(() => {
-                console.log('popup-bootstrap');
                 // Slight delay to ensure content script (if present) is initialized first
+                const message = { type: 'popup-bootstrap', channel };
                 if (window.opener) {
                     window.opener.postMessage(message, '*');
                 } else {

--- a/packages/connect-web/src/impl/core-in-iframe.ts
+++ b/packages/connect-web/src/impl/core-in-iframe.ts
@@ -1,0 +1,336 @@
+import EventEmitter from 'events';
+
+// NOTE: @trezor/connect part is intentionally not imported from the index due to NormalReplacementPlugin
+// in packages/suite-build/configs/web.webpack.config.ts
+import * as ERRORS from '@trezor/connect/src/constants/errors';
+import {
+    POPUP,
+    IFRAME,
+    UI,
+    UI_EVENT,
+    DEVICE_EVENT,
+    RESPONSE_EVENT,
+    TRANSPORT_EVENT,
+    BLOCKCHAIN_EVENT,
+    TRANSPORT,
+    parseMessage,
+    createUiMessage,
+    createErrorMessage,
+    UiResponseEvent,
+    CallMethod,
+    CoreEventMessage,
+} from '@trezor/connect/src/events';
+import type { ConnectSettings, Manifest } from '@trezor/connect/src/types';
+import { factory } from '@trezor/connect/src/factory';
+import { initLog } from '@trezor/connect/src/utils/debug';
+import { config } from '@trezor/connect/src/data/config';
+import { createDeferredManager } from '@trezor/utils/src/createDeferredManager';
+
+import * as iframe from '../iframe';
+import * as popup from '../popup';
+import webUSBButton from '../webusb/button';
+import { parseConnectSettings } from '../connectSettings';
+
+const eventEmitter = new EventEmitter();
+const _log = initLog('@trezor/connect-web');
+
+let _settings = parseConnectSettings();
+let _popupManager: popup.PopupManager | undefined;
+
+const messagePromises = createDeferredManager({ initialId: 1 });
+
+const initPopupManager = () => {
+    const pm = new popup.PopupManager(_settings, { logger: _log });
+    pm.on(POPUP.CLOSED, (error?: string) => {
+        iframe.postMessage({
+            type: POPUP.CLOSED,
+            payload: error ? { error } : null,
+        });
+    });
+
+    return pm;
+};
+
+const manifest = (data: Manifest) => {
+    _settings = parseConnectSettings({
+        ..._settings,
+        manifest: data,
+    });
+};
+
+const dispose = () => {
+    eventEmitter.removeAllListeners();
+    iframe.dispose();
+    _settings = parseConnectSettings();
+    if (_popupManager) {
+        _popupManager.close();
+    }
+
+    return Promise.resolve(undefined);
+};
+
+const cancel = (error?: string) => {
+    if (_popupManager) {
+        _popupManager.emit(POPUP.CLOSED, error);
+    }
+};
+
+// handle message received from iframe
+const handleMessage = (messageEvent: MessageEvent<CoreEventMessage>) => {
+    // ignore messages from domain other then iframe origin
+    if (messageEvent.origin !== iframe.origin) return;
+
+    const message = parseMessage<CoreEventMessage>(messageEvent.data);
+
+    _log.log('handleMessage', message);
+
+    switch (message.event) {
+        case RESPONSE_EVENT: {
+            const { id = 0, success, payload } = message;
+            const resolved = messagePromises.resolve(id, { id, success, payload });
+            if (!resolved) _log.warn(`Unknown message id ${id}`);
+            break;
+        }
+        case DEVICE_EVENT:
+            // pass DEVICE event up to html
+            eventEmitter.emit(message.event, message);
+            eventEmitter.emit(message.type, message.payload); // DEVICE_EVENT also emit single events (connect/disconnect...)
+            break;
+
+        case TRANSPORT_EVENT:
+            eventEmitter.emit(message.event, message);
+            eventEmitter.emit(message.type, message.payload);
+            break;
+
+        case BLOCKCHAIN_EVENT:
+            eventEmitter.emit(message.event, message);
+            eventEmitter.emit(message.type, message.payload);
+            break;
+
+        case UI_EVENT:
+            if (message.type === IFRAME.BOOTSTRAP) {
+                iframe.clearTimeout();
+                break;
+            }
+            if (message.type === IFRAME.LOADED) {
+                iframe.initPromise.resolve();
+            }
+            if (message.type === IFRAME.ERROR) {
+                iframe.initPromise.reject(message.payload.error as any);
+            }
+
+            // pass UI event up
+            eventEmitter.emit(message.event, message);
+            eventEmitter.emit(message.type, message.payload);
+            break;
+
+        default:
+            _log.log('Undefined message', messageEvent.data);
+    }
+};
+
+const init = async (settings: Partial<ConnectSettings> = {}): Promise<void> => {
+    if (iframe.instance) {
+        throw ERRORS.TypedError('Init_AlreadyInitialized');
+    }
+
+    _settings = parseConnectSettings({ ..._settings, ...settings });
+
+    if (!_settings.manifest) {
+        throw ERRORS.TypedError('Init_ManifestMissing');
+    }
+
+    // defaults for connect-web
+    if (!_settings.transports?.length) {
+        _settings.transports = ['BridgeTransport', 'WebUsbTransport'];
+    }
+
+    if (_settings.lazyLoad) {
+        // reset "lazyLoad" after first use
+        _settings.lazyLoad = false;
+
+        return;
+    }
+
+    if (!_popupManager) {
+        _popupManager = initPopupManager();
+    }
+
+    _log.enabled = !!_settings.debug;
+
+    window.addEventListener('message', handleMessage);
+    window.addEventListener('unload', dispose);
+
+    await iframe.init(_settings);
+
+    // sharedLogger can be disable but it is enable by default.
+    if (_settings.sharedLogger !== false) {
+        // connect-web is running in third-party domain so we use iframe to pass logs to shared worker.
+        iframe.initIframeLogger();
+    }
+};
+
+const call: CallMethod = async params => {
+    if (!iframe.instance && !iframe.timeout) {
+        // init popup with lazy loading before iframe initialization
+        _settings = parseConnectSettings(_settings);
+
+        if (!_settings.manifest) {
+            return createErrorMessage(ERRORS.TypedError('Init_ManifestMissing'));
+        }
+
+        if (!_popupManager) {
+            _popupManager = initPopupManager();
+        }
+        _popupManager.request();
+
+        // auto init with default settings
+        try {
+            await init(_settings);
+        } catch (error) {
+            if (_popupManager) {
+                // Catch fatal iframe errors (not loading)
+                if (['Init_IframeBlocked', 'Init_IframeTimeout'].includes(error.code)) {
+                    _popupManager.postMessage(createUiMessage(UI.IFRAME_FAILURE));
+                } else {
+                    _popupManager.clear();
+                }
+            }
+
+            return createErrorMessage(error);
+        }
+    }
+
+    if (iframe.timeout) {
+        // this.init was called, but iframe doesn't return handshake yet
+        await iframe.initPromise.promise;
+    }
+
+    if (iframe.error) {
+        // iframe was initialized with error
+        return createErrorMessage(iframe.error);
+    }
+
+    // request popup window it might be used in the future
+    if (_settings.popup && _popupManager) {
+        _popupManager.request();
+    }
+
+    // post message to iframe
+    try {
+        const { promiseId, promise } = messagePromises.create();
+        iframe.postMessage({ id: promiseId, type: IFRAME.CALL, payload: params });
+        const response = await promise;
+        if (response) {
+            if (
+                !response.success &&
+                response.payload.code !== 'Device_CallInProgress' &&
+                _popupManager
+            ) {
+                _popupManager.unlock();
+            }
+
+            return response;
+        }
+        if (_popupManager) {
+            _popupManager.unlock();
+        }
+
+        return createErrorMessage(ERRORS.TypedError('Method_NoResponse'));
+    } catch (error) {
+        _log.error('__call error', error);
+        if (_popupManager) {
+            _popupManager.clear(false);
+        }
+
+        return createErrorMessage(error);
+    }
+};
+
+const uiResponse = (response: UiResponseEvent) => {
+    if (!iframe.instance) {
+        throw ERRORS.TypedError('Init_NotInitialized');
+    }
+    iframe.postMessage(response);
+};
+
+const renderWebUSBButton = (className?: string) => {
+    webUSBButton(className, _settings.webusbSrc);
+};
+
+const requestLogin = async (params: any) => {
+    if (typeof params.callback === 'function') {
+        const { callback } = params;
+
+        // TODO: set message listener only if iframe is loaded correctly
+        const loginChallengeListener = async (event: MessageEvent<CoreEventMessage>) => {
+            const { data } = event;
+            if (data && data.type === UI.LOGIN_CHALLENGE_REQUEST) {
+                try {
+                    const payload = await callback();
+                    iframe.postMessage({
+                        type: UI.LOGIN_CHALLENGE_RESPONSE,
+                        payload,
+                    });
+                } catch (error) {
+                    iframe.postMessage({
+                        type: UI.LOGIN_CHALLENGE_RESPONSE,
+                        payload: error.message,
+                    });
+                }
+            }
+        };
+
+        window.addEventListener('message', loginChallengeListener, false);
+
+        const response = await call({
+            method: 'requestLogin',
+            ...params,
+            asyncChallenge: true,
+            callback: null,
+        });
+        window.removeEventListener('message', loginChallengeListener);
+
+        return response;
+    }
+
+    return call({ method: 'requestLogin', ...params });
+};
+
+const disableWebUSB = () => {
+    if (!iframe.instance) {
+        throw ERRORS.TypedError('Init_NotInitialized');
+    }
+    iframe.postMessage({ type: TRANSPORT.DISABLE_WEBUSB });
+};
+
+/**
+ * Initiate device pairing procedure.
+ */
+const requestWebUSBDevice = async () => {
+    try {
+        await window.navigator.usb.requestDevice({ filters: config.webusb });
+        iframe.postMessage({ type: TRANSPORT.REQUEST_DEVICE });
+    } catch (_err) {
+        // user hits cancel gets "DOMException: No device selected."
+        // no need to log this
+    }
+};
+
+export const methods = {
+    eventEmitter,
+    manifest,
+    init,
+    call,
+    requestLogin,
+    uiResponse,
+    renderWebUSBButton,
+    disableWebUSB,
+    requestWebUSBDevice,
+    cancel,
+    dispose,
+};
+
+const TrezorConnect = factory(methods);
+
+export default TrezorConnect;

--- a/packages/connect-web/src/impl/core-in-iframe.ts
+++ b/packages/connect-web/src/impl/core-in-iframe.ts
@@ -17,320 +17,332 @@ import {
     createUiMessage,
     createErrorMessage,
     UiResponseEvent,
-    CallMethod,
     CoreEventMessage,
+    CallMethodPayload,
 } from '@trezor/connect/src/events';
 import type { ConnectSettings, Manifest } from '@trezor/connect/src/types';
-import { factory } from '@trezor/connect/src/factory';
-import { initLog } from '@trezor/connect/src/utils/debug';
+import { ConnectFactoryDependencies, factory } from '@trezor/connect/src/factory';
+import { Log, initLog } from '@trezor/connect/src/utils/debug';
 import { config } from '@trezor/connect/src/data/config';
-import { createDeferredManager } from '@trezor/utils/src/createDeferredManager';
+import { DeferredManager, createDeferredManager } from '@trezor/utils/src/createDeferredManager';
 
 import * as iframe from '../iframe';
 import * as popup from '../popup';
 import webUSBButton from '../webusb/button';
 import { parseConnectSettings } from '../connectSettings';
 
-const eventEmitter = new EventEmitter();
-const _log = initLog('@trezor/connect-web');
+export class CoreInIframe implements ConnectFactoryDependencies {
+    public eventEmitter = new EventEmitter();
+    protected _settings: ConnectSettings;
 
-let _settings = parseConnectSettings();
-let _popupManager: popup.PopupManager | undefined;
+    private _log: Log;
+    private _popupManager?: popup.PopupManager;
+    private _messagePromises: DeferredManager<{ id: number; success: boolean; payload: any }>;
 
-const messagePromises = createDeferredManager({ initialId: 1 });
+    private readonly boundHandleMessage = this.handleMessage.bind(this);
+    private readonly boundDispose = this.dispose.bind(this);
 
-const initPopupManager = () => {
-    const pm = new popup.PopupManager(_settings, { logger: _log });
-    pm.on(POPUP.CLOSED, (error?: string) => {
-        iframe.postMessage({
-            type: POPUP.CLOSED,
-            payload: error ? { error } : null,
+    public constructor() {
+        this._settings = parseConnectSettings();
+        this._log = initLog('@trezor/connect-web');
+        this._messagePromises = createDeferredManager({ initialId: 1 });
+    }
+
+    private initPopupManager() {
+        const pm = new popup.PopupManager(this._settings, { logger: this._log });
+        pm.on(POPUP.CLOSED, (error?: string) => {
+            iframe.postMessage({
+                type: POPUP.CLOSED,
+                payload: error ? { error } : null,
+            });
         });
-    });
 
-    return pm;
-};
-
-const manifest = (data: Manifest) => {
-    _settings = parseConnectSettings({
-        ..._settings,
-        manifest: data,
-    });
-};
-
-const dispose = () => {
-    eventEmitter.removeAllListeners();
-    iframe.dispose();
-    _settings = parseConnectSettings();
-    if (_popupManager) {
-        _popupManager.close();
+        return pm;
     }
 
-    return Promise.resolve(undefined);
-};
-
-const cancel = (error?: string) => {
-    if (_popupManager) {
-        _popupManager.emit(POPUP.CLOSED, error);
+    public manifest(data: Manifest) {
+        this._settings = parseConnectSettings({
+            ...this._settings,
+            manifest: data,
+        });
     }
-};
 
-// handle message received from iframe
-const handleMessage = (messageEvent: MessageEvent<CoreEventMessage>) => {
-    // ignore messages from domain other then iframe origin
-    if (messageEvent.origin !== iframe.origin) return;
-
-    const message = parseMessage<CoreEventMessage>(messageEvent.data);
-
-    _log.log('handleMessage', message);
-
-    switch (message.event) {
-        case RESPONSE_EVENT: {
-            const { id = 0, success, payload } = message;
-            const resolved = messagePromises.resolve(id, { id, success, payload });
-            if (!resolved) _log.warn(`Unknown message id ${id}`);
-            break;
+    public dispose() {
+        this.eventEmitter.removeAllListeners();
+        iframe.dispose();
+        this._settings = parseConnectSettings();
+        if (this._popupManager) {
+            this._popupManager.close();
         }
-        case DEVICE_EVENT:
-            // pass DEVICE event up to html
-            eventEmitter.emit(message.event, message);
-            eventEmitter.emit(message.type, message.payload); // DEVICE_EVENT also emit single events (connect/disconnect...)
-            break;
+        window.removeEventListener('message', this.boundHandleMessage);
+        window.removeEventListener('unload', this.boundDispose);
 
-        case TRANSPORT_EVENT:
-            eventEmitter.emit(message.event, message);
-            eventEmitter.emit(message.type, message.payload);
-            break;
+        return Promise.resolve(undefined);
+    }
 
-        case BLOCKCHAIN_EVENT:
-            eventEmitter.emit(message.event, message);
-            eventEmitter.emit(message.type, message.payload);
-            break;
+    public cancel(error?: string) {
+        if (this._popupManager) {
+            this._popupManager.emit(POPUP.CLOSED, error);
+        }
+    }
 
-        case UI_EVENT:
-            if (message.type === IFRAME.BOOTSTRAP) {
-                iframe.clearTimeout();
+    // handle message received from iframe
+    private handleMessage(messageEvent: MessageEvent<CoreEventMessage>) {
+        // ignore messages from domain other then iframe origin
+        if (messageEvent.origin !== iframe.origin) return;
+
+        const message = parseMessage<CoreEventMessage>(messageEvent.data);
+
+        this._log.log('handleMessage', message);
+
+        switch (message.event) {
+            case RESPONSE_EVENT: {
+                const { id = 0, success, payload } = message;
+                const resolved = this._messagePromises.resolve(id, { id, success, payload });
+                if (!resolved) this._log.warn(`Unknown message id ${id}`);
                 break;
             }
-            if (message.type === IFRAME.LOADED) {
-                iframe.initPromise.resolve();
-            }
-            if (message.type === IFRAME.ERROR) {
-                iframe.initPromise.reject(message.payload.error as any);
-            }
+            case DEVICE_EVENT:
+                // pass DEVICE event up to html
+                this.eventEmitter.emit(message.event, message);
+                this.eventEmitter.emit(message.type, message.payload); // DEVICE_EVENT also emit single events (connect/disconnect...)
+                break;
 
-            // pass UI event up
-            eventEmitter.emit(message.event, message);
-            eventEmitter.emit(message.type, message.payload);
-            break;
+            case TRANSPORT_EVENT:
+                this.eventEmitter.emit(message.event, message);
+                this.eventEmitter.emit(message.type, message.payload);
+                break;
 
-        default:
-            _log.log('Undefined message', messageEvent.data);
-    }
-};
+            case BLOCKCHAIN_EVENT:
+                this.eventEmitter.emit(message.event, message);
+                this.eventEmitter.emit(message.type, message.payload);
+                break;
 
-const init = async (settings: Partial<ConnectSettings> = {}): Promise<void> => {
-    if (iframe.instance) {
-        throw ERRORS.TypedError('Init_AlreadyInitialized');
-    }
-
-    _settings = parseConnectSettings({ ..._settings, ...settings });
-
-    if (!_settings.manifest) {
-        throw ERRORS.TypedError('Init_ManifestMissing');
-    }
-
-    // defaults for connect-web
-    if (!_settings.transports?.length) {
-        _settings.transports = ['BridgeTransport', 'WebUsbTransport'];
-    }
-
-    if (_settings.lazyLoad) {
-        // reset "lazyLoad" after first use
-        _settings.lazyLoad = false;
-
-        return;
-    }
-
-    if (!_popupManager) {
-        _popupManager = initPopupManager();
-    }
-
-    _log.enabled = !!_settings.debug;
-
-    window.addEventListener('message', handleMessage);
-    window.addEventListener('unload', dispose);
-
-    await iframe.init(_settings);
-
-    // sharedLogger can be disable but it is enable by default.
-    if (_settings.sharedLogger !== false) {
-        // connect-web is running in third-party domain so we use iframe to pass logs to shared worker.
-        iframe.initIframeLogger();
-    }
-};
-
-const call: CallMethod = async params => {
-    if (!iframe.instance && !iframe.timeout) {
-        // init popup with lazy loading before iframe initialization
-        _settings = parseConnectSettings(_settings);
-
-        if (!_settings.manifest) {
-            return createErrorMessage(ERRORS.TypedError('Init_ManifestMissing'));
-        }
-
-        if (!_popupManager) {
-            _popupManager = initPopupManager();
-        }
-        _popupManager.request();
-
-        // auto init with default settings
-        try {
-            await init(_settings);
-        } catch (error) {
-            if (_popupManager) {
-                // Catch fatal iframe errors (not loading)
-                if (['Init_IframeBlocked', 'Init_IframeTimeout'].includes(error.code)) {
-                    _popupManager.postMessage(createUiMessage(UI.IFRAME_FAILURE));
-                } else {
-                    _popupManager.clear();
+            case UI_EVENT:
+                if (message.type === IFRAME.BOOTSTRAP) {
+                    iframe.clearTimeout();
+                    break;
                 }
+                if (message.type === IFRAME.LOADED) {
+                    iframe.initPromise.resolve();
+                }
+                if (message.type === IFRAME.ERROR) {
+                    iframe.initPromise.reject(message.payload.error as any);
+                }
+
+                // pass UI event up
+                this.eventEmitter.emit(message.event, message);
+                this.eventEmitter.emit(message.type, message.payload);
+                break;
+
+            default:
+                this._log.log('Undefined message', messageEvent.data);
+        }
+    }
+
+    public async init(settings: Partial<ConnectSettings> = {}) {
+        if (iframe.instance) {
+            throw ERRORS.TypedError('Init_AlreadyInitialized');
+        }
+
+        this._settings = parseConnectSettings({ ...this._settings, ...settings });
+
+        if (!this._settings.manifest) {
+            throw ERRORS.TypedError('Init_ManifestMissing');
+        }
+
+        // defaults for connect-web
+        if (!this._settings.transports?.length) {
+            this._settings.transports = ['BridgeTransport', 'WebUsbTransport'];
+        }
+
+        if (this._settings.lazyLoad) {
+            // reset "lazyLoad" after first use
+            this._settings.lazyLoad = false;
+
+            return;
+        }
+
+        if (!this._popupManager) {
+            this._popupManager = this.initPopupManager();
+        }
+
+        this._log.enabled = !!this._settings.debug;
+
+        window.addEventListener('message', this.boundHandleMessage);
+        window.addEventListener('unload', this.boundDispose);
+
+        await iframe.init(this._settings);
+
+        // sharedLogger can be disable but it is enable by default.
+        if (this._settings.sharedLogger !== false) {
+            // connect-web is running in third-party domain so we use iframe to pass logs to shared worker.
+            iframe.initIframeLogger();
+        }
+    }
+
+    public async call(params: CallMethodPayload) {
+        if (!iframe.instance && !iframe.timeout) {
+            // init popup with lazy loading before iframe initialization
+            this._settings = parseConnectSettings(this._settings);
+
+            if (!this._settings.manifest) {
+                return createErrorMessage(ERRORS.TypedError('Init_ManifestMissing'));
+            }
+
+            if (!this._popupManager) {
+                this._popupManager = this.initPopupManager();
+            }
+            this._popupManager.request();
+
+            // auto init with default settings
+            try {
+                await this.init(this._settings);
+            } catch (error) {
+                if (this._popupManager) {
+                    // Catch fatal iframe errors (not loading)
+                    if (['Init_IframeBlocked', 'Init_IframeTimeout'].includes(error.code)) {
+                        this._popupManager.postMessage(createUiMessage(UI.IFRAME_FAILURE));
+                    } else {
+                        this._popupManager.clear();
+                    }
+                }
+
+                return createErrorMessage(error);
+            }
+        }
+
+        if (iframe.timeout) {
+            // this.init was called, but iframe doesn't return handshake yet
+            await iframe.initPromise.promise;
+        }
+
+        if (iframe.error) {
+            // iframe was initialized with error
+            return createErrorMessage(iframe.error);
+        }
+
+        // request popup window it might be used in the future
+        if (this._settings.popup && this._popupManager) {
+            this._popupManager.request();
+        }
+
+        // post message to iframe
+        try {
+            const { promiseId, promise } = this._messagePromises.create();
+            iframe.postMessage({ id: promiseId, type: IFRAME.CALL, payload: params });
+            const response = await promise;
+            if (response) {
+                if (
+                    !response.success &&
+                    response.payload.code !== 'Device_CallInProgress' &&
+                    this._popupManager
+                ) {
+                    this._popupManager.unlock();
+                }
+
+                return response;
+            }
+            if (this._popupManager) {
+                this._popupManager.unlock();
+            }
+
+            return createErrorMessage(ERRORS.TypedError('Method_NoResponse'));
+        } catch (error) {
+            this._log.error('__call error', error);
+            if (this._popupManager) {
+                this._popupManager.clear(false);
             }
 
             return createErrorMessage(error);
         }
     }
 
-    if (iframe.timeout) {
-        // this.init was called, but iframe doesn't return handshake yet
-        await iframe.initPromise.promise;
+    public uiResponse(response: UiResponseEvent) {
+        if (!iframe.instance) {
+            throw ERRORS.TypedError('Init_NotInitialized');
+        }
+        iframe.postMessage(response);
     }
 
-    if (iframe.error) {
-        // iframe was initialized with error
-        return createErrorMessage(iframe.error);
+    public renderWebUSBButton(className?: string) {
+        webUSBButton(className, this._settings.webusbSrc);
     }
 
-    // request popup window it might be used in the future
-    if (_settings.popup && _popupManager) {
-        _popupManager.request();
-    }
+    public async requestLogin(params: any) {
+        if (typeof params.callback === 'function') {
+            const { callback } = params;
 
-    // post message to iframe
-    try {
-        const { promiseId, promise } = messagePromises.create();
-        iframe.postMessage({ id: promiseId, type: IFRAME.CALL, payload: params });
-        const response = await promise;
-        if (response) {
-            if (
-                !response.success &&
-                response.payload.code !== 'Device_CallInProgress' &&
-                _popupManager
-            ) {
-                _popupManager.unlock();
-            }
+            // TODO: set message listener only if iframe is loaded correctly
+            const loginChallengeListener = async (event: MessageEvent<CoreEventMessage>) => {
+                const { data } = event;
+                if (data && data.type === UI.LOGIN_CHALLENGE_REQUEST) {
+                    try {
+                        const payload = await callback();
+                        iframe.postMessage({
+                            type: UI.LOGIN_CHALLENGE_RESPONSE,
+                            payload,
+                        });
+                    } catch (error) {
+                        iframe.postMessage({
+                            type: UI.LOGIN_CHALLENGE_RESPONSE,
+                            payload: error.message,
+                        });
+                    }
+                }
+            };
+
+            window.addEventListener('message', loginChallengeListener, false);
+
+            const response = await this.call({
+                method: 'requestLogin',
+                ...params,
+                asyncChallenge: true,
+                callback: null,
+            });
+            window.removeEventListener('message', loginChallengeListener);
 
             return response;
         }
-        if (_popupManager) {
-            _popupManager.unlock();
+
+        return this.call({ method: 'requestLogin', ...params });
+    }
+
+    public disableWebUSB() {
+        if (!iframe.instance) {
+            throw ERRORS.TypedError('Init_NotInitialized');
         }
+        iframe.postMessage({ type: TRANSPORT.DISABLE_WEBUSB });
+    }
 
-        return createErrorMessage(ERRORS.TypedError('Method_NoResponse'));
-    } catch (error) {
-        _log.error('__call error', error);
-        if (_popupManager) {
-            _popupManager.clear(false);
+    /**
+     * Initiate device pairing procedure.
+     */
+    public async requestWebUSBDevice() {
+        try {
+            await window.navigator.usb.requestDevice({ filters: config.webusb });
+            iframe.postMessage({ type: TRANSPORT.REQUEST_DEVICE });
+        } catch (_err) {
+            // user hits cancel gets "DOMException: No device selected."
+            // no need to log this
         }
-
-        return createErrorMessage(error);
     }
-};
+}
 
-const uiResponse = (response: UiResponseEvent) => {
-    if (!iframe.instance) {
-        throw ERRORS.TypedError('Init_NotInitialized');
-    }
-    iframe.postMessage(response);
-};
+const methods = new CoreInIframe();
 
-const renderWebUSBButton = (className?: string) => {
-    webUSBButton(className, _settings.webusbSrc);
-};
-
-const requestLogin = async (params: any) => {
-    if (typeof params.callback === 'function') {
-        const { callback } = params;
-
-        // TODO: set message listener only if iframe is loaded correctly
-        const loginChallengeListener = async (event: MessageEvent<CoreEventMessage>) => {
-            const { data } = event;
-            if (data && data.type === UI.LOGIN_CHALLENGE_REQUEST) {
-                try {
-                    const payload = await callback();
-                    iframe.postMessage({
-                        type: UI.LOGIN_CHALLENGE_RESPONSE,
-                        payload,
-                    });
-                } catch (error) {
-                    iframe.postMessage({
-                        type: UI.LOGIN_CHALLENGE_RESPONSE,
-                        payload: error.message,
-                    });
-                }
-            }
-        };
-
-        window.addEventListener('message', loginChallengeListener, false);
-
-        const response = await call({
-            method: 'requestLogin',
-            ...params,
-            asyncChallenge: true,
-            callback: null,
-        });
-        window.removeEventListener('message', loginChallengeListener);
-
-        return response;
-    }
-
-    return call({ method: 'requestLogin', ...params });
-};
-
-const disableWebUSB = () => {
-    if (!iframe.instance) {
-        throw ERRORS.TypedError('Init_NotInitialized');
-    }
-    iframe.postMessage({ type: TRANSPORT.DISABLE_WEBUSB });
-};
-
-/**
- * Initiate device pairing procedure.
- */
-const requestWebUSBDevice = async () => {
-    try {
-        await window.navigator.usb.requestDevice({ filters: config.webusb });
-        iframe.postMessage({ type: TRANSPORT.REQUEST_DEVICE });
-    } catch (_err) {
-        // user hits cancel gets "DOMException: No device selected."
-        // no need to log this
-    }
-};
-
-export const methods = {
-    eventEmitter,
-    manifest,
-    init,
-    call,
-    requestLogin,
-    uiResponse,
-    renderWebUSBButton,
-    disableWebUSB,
-    requestWebUSBDevice,
-    cancel,
-    dispose,
-};
-
-const TrezorConnect = factory(methods);
-
-export default TrezorConnect;
+// Exported to enable using directly
+export const TrezorConnect = factory({
+    // Bind all methods due to shadowing `this`
+    eventEmitter: methods.eventEmitter,
+    init: methods.init.bind(methods),
+    call: methods.call.bind(methods),
+    manifest: methods.manifest.bind(methods),
+    requestLogin: methods.requestLogin.bind(methods),
+    uiResponse: methods.uiResponse.bind(methods),
+    renderWebUSBButton: methods.renderWebUSBButton.bind(methods),
+    disableWebUSB: methods.disableWebUSB.bind(methods),
+    requestWebUSBDevice: methods.requestWebUSBDevice.bind(methods),
+    cancel: methods.cancel.bind(methods),
+    dispose: methods.dispose.bind(methods),
+});

--- a/packages/connect-web/src/impl/core-in-popup.ts
+++ b/packages/connect-web/src/impl/core-in-popup.ts
@@ -198,8 +198,10 @@ export class CoreInPopup implements ConnectFactoryDependencies {
 }
 
 const methods = new CoreInPopup();
-// Bind all methods due to shadowing `this`
-const TrezorConnect = factory({
+
+// Exported to enable using directly
+export const TrezorConnect = factory({
+    // Bind all methods due to shadowing `this`
     eventEmitter: methods.eventEmitter,
     init: methods.init.bind(methods),
     call: methods.call.bind(methods),
@@ -212,5 +214,3 @@ const TrezorConnect = factory({
     cancel: methods.cancel.bind(methods),
     dispose: methods.dispose.bind(methods),
 });
-
-export default TrezorConnect;

--- a/packages/connect-web/src/impl/core-in-popup.ts
+++ b/packages/connect-web/src/impl/core-in-popup.ts
@@ -1,0 +1,216 @@
+import EventEmitter from 'events';
+
+// NOTE: @trezor/connect part is intentionally not imported from the index so we do include the whole library.
+import {
+    POPUP,
+    IFRAME,
+    UI_EVENT,
+    createErrorMessage,
+    UiResponseEvent,
+    CallMethodPayload,
+} from '@trezor/connect/src/events';
+import * as ERRORS from '@trezor/connect/src/constants/errors';
+import type { ConnectSettings, Manifest, Response } from '@trezor/connect/src/types';
+import { ConnectFactoryDependencies, factory } from '@trezor/connect/src/factory';
+import { initLog, setLogWriter, LogMessage, LogWriter, Log } from '@trezor/connect/src/utils/debug';
+import * as popup from '../popup';
+
+import { parseConnectSettings } from '../connectSettings';
+import { Login } from '@trezor/connect/src/types/api/requestLogin';
+
+/**
+ * Base class for CoreInPopup methods for TrezorConnect factory.
+ * This implementation is directly used here in connect-web, but it is also extended in connect-webextension.
+ */
+export class CoreInPopup implements ConnectFactoryDependencies {
+    public eventEmitter = new EventEmitter();
+    protected _settings: ConnectSettings;
+
+    protected logger: Log;
+    protected popupManagerLogger: Log;
+    private _popupManager?: popup.PopupManager;
+
+    public constructor() {
+        this._settings = parseConnectSettings();
+        this.logger = initLog('@trezor/connect-web');
+        this.popupManagerLogger = initLog('@trezor/connect-web/popupManager');
+    }
+
+    private logWriterFactory(popupManager: popup.PopupManager): LogWriter {
+        return {
+            add: (message: LogMessage) => {
+                popupManager.channel.postMessage(
+                    {
+                        event: UI_EVENT,
+                        type: IFRAME.LOG,
+                        payload: message,
+                    },
+                    { usePromise: false, useQueue: true },
+                );
+            },
+        };
+    }
+
+    public manifest(data: Manifest) {
+        this._settings = parseConnectSettings({
+            ...this._settings,
+            manifest: data,
+        });
+    }
+
+    public dispose() {
+        this.eventEmitter.removeAllListeners();
+        this._settings = parseConnectSettings();
+        if (this._popupManager) {
+            this._popupManager.close();
+        }
+
+        return Promise.resolve(undefined);
+    }
+
+    public cancel(error?: string) {
+        if (this._popupManager) {
+            this._popupManager.emit(POPUP.CLOSED, error);
+        }
+    }
+
+    public init(settings: Partial<ConnectSettings> = {}): Promise<void> {
+        const oldSettings = parseConnectSettings({
+            ...this._settings,
+        });
+        const newSettings = parseConnectSettings({
+            ...this._settings,
+            ...settings,
+        });
+
+        // defaults
+        if (!newSettings.transports?.length) {
+            newSettings.transports = ['BridgeTransport', 'WebUsbTransport'];
+        }
+        newSettings.useCoreInPopup = true;
+        if (typeof window !== 'undefined' && window?.location?.origin) {
+            newSettings.origin = window.location.origin;
+        }
+        const equalSettings = JSON.stringify(oldSettings) === JSON.stringify(newSettings);
+        this._settings = newSettings;
+
+        if (!this._popupManager || !equalSettings) {
+            if (this._popupManager) this._popupManager.close();
+            this._popupManager = new popup.PopupManager(this._settings, {
+                logger: this.popupManagerLogger,
+            });
+            setLogWriter(() => this.logWriterFactory(this._popupManager!));
+        }
+
+        this.logger.enabled = !!settings.debug;
+
+        if (!this._settings.manifest) {
+            throw ERRORS.TypedError('Init_ManifestMissing');
+        }
+
+        this.logger.debug('initiated');
+
+        return Promise.resolve();
+    }
+
+    /**
+     * 1. opens popup
+     * 2. sends request to popup where the request is handled by core
+     * 3. returns response
+     */
+    public async call(params: CallMethodPayload): Promise<any> {
+        this.logger.debug('call', params);
+
+        if (!this._popupManager) {
+            return createErrorMessage(ERRORS.TypedError('Init_NotInitialized'));
+        }
+
+        // request popup window it might be used in the future
+        if (this._settings.popup) {
+            await this._popupManager.request();
+        }
+
+        await this._popupManager.channel.init();
+
+        if (this._settings.env === 'webextension') {
+            // In webextension we init based on the popup promise
+            // In core this is handled in the popup manager
+            await this._popupManager.popupPromise?.promise;
+
+            this._popupManager.channel.postMessage({
+                type: POPUP.INIT,
+                payload: {
+                    settings: this._settings,
+                    useCore: true,
+                },
+            });
+        }
+
+        await this._popupManager.handshakePromise?.promise;
+
+        // post message to core in popup
+        try {
+            const response = await this._popupManager.channel.postMessage({
+                type: IFRAME.CALL,
+                payload: params,
+            });
+
+            this.logger.debug('call: response: ', response);
+
+            if (response) {
+                if (this._popupManager && response.success) {
+                    this._popupManager.clear();
+                }
+
+                return response;
+            }
+
+            return createErrorMessage(ERRORS.TypedError('Method_NoResponse'));
+        } catch (error) {
+            this.logger.error('call: error', error);
+            this._popupManager.clear(false);
+
+            return createErrorMessage(error);
+        }
+    }
+
+    uiResponse(response: UiResponseEvent) {
+        const { type, payload } = response;
+        this._popupManager?.channel?.postMessage({ event: UI_EVENT, type, payload });
+    }
+
+    renderWebUSBButton() {}
+
+    requestLogin(): Response<Login> {
+        // todo: not supported yet
+        throw ERRORS.TypedError('Method_InvalidPackage');
+    }
+
+    disableWebUSB() {
+        // todo: not supported yet, probably not needed
+        throw ERRORS.TypedError('Method_InvalidPackage');
+    }
+
+    requestWebUSBDevice() {
+        // not needed - webusb pairing happens in popup
+        throw ERRORS.TypedError('Method_InvalidPackage');
+    }
+}
+
+const methods = new CoreInPopup();
+// Bind all methods due to shadowing `this`
+const TrezorConnect = factory({
+    eventEmitter: methods.eventEmitter,
+    init: methods.init.bind(methods),
+    call: methods.call.bind(methods),
+    manifest: methods.manifest.bind(methods),
+    requestLogin: methods.requestLogin.bind(methods),
+    uiResponse: methods.uiResponse.bind(methods),
+    renderWebUSBButton: methods.renderWebUSBButton.bind(methods),
+    disableWebUSB: methods.disableWebUSB.bind(methods),
+    requestWebUSBDevice: methods.requestWebUSBDevice.bind(methods),
+    cancel: methods.cancel.bind(methods),
+    dispose: methods.dispose.bind(methods),
+});
+
+export default TrezorConnect;

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -1,335 +1,50 @@
-import EventEmitter from 'events';
+import TrezorConnectIframe from './impl/core-in-iframe';
+import TrezorConnectCoreInPopup from './impl/core-in-popup';
+import type {
+    ConnectSettings,
+    Manifest,
+    TrezorConnect as TrezorConnectInterface,
+} from '@trezor/connect/src/types';
 
-// NOTE: @trezor/connect part is intentionally not imported from the index due to NormalReplacementPlugin
-// in packages/suite-build/configs/web.webpack.config.ts
-import * as ERRORS from '@trezor/connect/src/constants/errors';
-import {
-    POPUP,
-    IFRAME,
-    UI,
-    UI_EVENT,
-    DEVICE_EVENT,
-    RESPONSE_EVENT,
-    TRANSPORT_EVENT,
-    BLOCKCHAIN_EVENT,
-    TRANSPORT,
-    parseMessage,
-    createUiMessage,
-    createErrorMessage,
-    UiResponseEvent,
-    CallMethod,
-    CoreEventMessage,
-} from '@trezor/connect/src/events';
-import type { ConnectSettings, Manifest } from '@trezor/connect/src/types';
-import { factory } from '@trezor/connect/src/factory';
-import { initLog } from '@trezor/connect/src/utils/debug';
-import { config } from '@trezor/connect/src/data/config';
-import { createDeferredManager } from '@trezor/utils';
+type TrezorConnectType = 'core-in-popup' | 'iframe';
 
-import * as iframe from './iframe';
-import * as popup from './popup';
-import webUSBButton from './webusb/button';
-import { parseConnectSettings } from './connectSettings';
+class TrezorConnectProxyHandler implements ProxyHandler<TrezorConnectInterface> {
+    private currentTarget: TrezorConnectType = 'iframe';
 
-const eventEmitter = new EventEmitter();
-const _log = initLog('@trezor/connect-web');
-
-let _settings = parseConnectSettings();
-let _popupManager: popup.PopupManager | undefined;
-
-const messagePromises = createDeferredManager({ initialId: 1 });
-
-const initPopupManager = () => {
-    const pm = new popup.PopupManager(_settings, { logger: _log });
-    pm.on(POPUP.CLOSED, (error?: string) => {
-        iframe.postMessage({
-            type: POPUP.CLOSED,
-            payload: error ? { error } : null,
-        });
-    });
-
-    return pm;
-};
-
-const manifest = (data: Manifest) => {
-    _settings = parseConnectSettings({
-        ..._settings,
-        manifest: data,
-    });
-};
-
-const dispose = () => {
-    eventEmitter.removeAllListeners();
-    iframe.dispose();
-    _settings = parseConnectSettings();
-    if (_popupManager) {
-        _popupManager.close();
-    }
-
-    return Promise.resolve(undefined);
-};
-
-const cancel = (error?: string) => {
-    if (_popupManager) {
-        _popupManager.emit(POPUP.CLOSED, error);
-    }
-};
-
-// handle message received from iframe
-const handleMessage = (messageEvent: MessageEvent<CoreEventMessage>) => {
-    // ignore messages from domain other then iframe origin
-    if (messageEvent.origin !== iframe.origin) return;
-
-    const message = parseMessage<CoreEventMessage>(messageEvent.data);
-
-    _log.log('handleMessage', message);
-
-    switch (message.event) {
-        case RESPONSE_EVENT: {
-            const { id = 0, success, payload } = message;
-            const resolved = messagePromises.resolve(id, { id, success, payload });
-            if (!resolved) _log.warn(`Unknown message id ${id}`);
-            break;
+    private getTarget(defaultTarget: TrezorConnectInterface) {
+        switch (this.currentTarget) {
+            case 'core-in-popup':
+                return TrezorConnectCoreInPopup;
+            case 'iframe':
+            default:
+                // Use default target
+                return defaultTarget;
         }
-        case DEVICE_EVENT:
-            // pass DEVICE event up to html
-            eventEmitter.emit(message.event, message);
-            eventEmitter.emit(message.type, message.payload); // DEVICE_EVENT also emit single events (connect/disconnect...)
-            break;
-
-        case TRANSPORT_EVENT:
-            eventEmitter.emit(message.event, message);
-            eventEmitter.emit(message.type, message.payload);
-            break;
-
-        case BLOCKCHAIN_EVENT:
-            eventEmitter.emit(message.event, message);
-            eventEmitter.emit(message.type, message.payload);
-            break;
-
-        case UI_EVENT:
-            if (message.type === IFRAME.BOOTSTRAP) {
-                iframe.clearTimeout();
-                break;
-            }
-            if (message.type === IFRAME.LOADED) {
-                iframe.initPromise.resolve();
-            }
-            if (message.type === IFRAME.ERROR) {
-                iframe.initPromise.reject(message.payload.error as any);
-            }
-
-            // pass UI event up
-            eventEmitter.emit(message.event, message);
-            eventEmitter.emit(message.type, message.payload);
-            break;
-
-        default:
-            _log.log('Undefined message', messageEvent.data);
-    }
-};
-
-const init = async (settings: Partial<ConnectSettings> = {}): Promise<void> => {
-    if (iframe.instance) {
-        throw ERRORS.TypedError('Init_AlreadyInitialized');
     }
 
-    _settings = parseConnectSettings({ ..._settings, ...settings });
-
-    if (!_settings.manifest) {
-        throw ERRORS.TypedError('Init_ManifestMissing');
-    }
-
-    // defaults for connect-web
-    if (!_settings.transports?.length) {
-        _settings.transports = ['BridgeTransport', 'WebUsbTransport'];
-    }
-
-    if (_settings.lazyLoad) {
-        // reset "lazyLoad" after first use
-        _settings.lazyLoad = false;
-
-        return;
-    }
-
-    if (!_popupManager) {
-        _popupManager = initPopupManager();
-    }
-
-    _log.enabled = !!_settings.debug;
-
-    window.addEventListener('message', handleMessage);
-    window.addEventListener('unload', dispose);
-
-    await iframe.init(_settings);
-
-    // sharedLogger can be disable but it is enable by default.
-    if (_settings.sharedLogger !== false) {
-        // connect-web is running in third-party domain so we use iframe to pass logs to shared worker.
-        iframe.initIframeLogger();
-    }
-};
-
-const call: CallMethod = async params => {
-    if (!iframe.instance && !iframe.timeout) {
-        // init popup with lazy loading before iframe initialization
-        _settings = parseConnectSettings(_settings);
-
-        if (!_settings.manifest) {
-            return createErrorMessage(ERRORS.TypedError('Init_ManifestMissing'));
-        }
-
-        if (!_popupManager) {
-            _popupManager = initPopupManager();
-        }
-        _popupManager.request();
-
-        // auto init with default settings
-        try {
-            await init(_settings);
-        } catch (error) {
-            if (_popupManager) {
-                // Catch fatal iframe errors (not loading)
-                if (['Init_IframeBlocked', 'Init_IframeTimeout'].includes(error.code)) {
-                    _popupManager.postMessage(createUiMessage(UI.IFRAME_FAILURE));
+    get(defaultTarget: TrezorConnectInterface, prop: string, receiver: any) {
+        if (prop === 'init') {
+            return async (settings: { manifest: Manifest } & Partial<ConnectSettings>) => {
+                if (settings?.useCoreInPopup === true) {
+                    this.currentTarget = 'core-in-popup';
                 } else {
-                    _popupManager.clear();
+                    this.currentTarget = 'iframe';
                 }
-            }
 
-            return createErrorMessage(error);
-        }
-    }
+                const target = this.getTarget(defaultTarget);
 
-    if (iframe.timeout) {
-        // this.init was called, but iframe doesn't return handshake yet
-        await iframe.initPromise.promise;
-    }
-
-    if (iframe.error) {
-        // iframe was initialized with error
-        return createErrorMessage(iframe.error);
-    }
-
-    // request popup window it might be used in the future
-    if (_settings.popup && _popupManager) {
-        _popupManager.request();
-    }
-
-    // post message to iframe
-    try {
-        const { promiseId, promise } = messagePromises.create();
-        iframe.postMessage({ id: promiseId, type: IFRAME.CALL, payload: params });
-        const response = await promise;
-        if (response) {
-            if (
-                !response.success &&
-                response.payload.code !== 'Device_CallInProgress' &&
-                _popupManager
-            ) {
-                _popupManager.unlock();
-            }
-
-            return response;
-        }
-        if (_popupManager) {
-            _popupManager.unlock();
+                return await target.init.apply(target, [settings]);
+            };
         }
 
-        return createErrorMessage(ERRORS.TypedError('Method_NoResponse'));
-    } catch (error) {
-        _log.error('__call error', error);
-        if (_popupManager) {
-            _popupManager.clear(false);
-        }
-
-        return createErrorMessage(error);
+        return Reflect.get(this.getTarget(defaultTarget), prop, receiver);
     }
-};
+}
 
-const uiResponse = (response: UiResponseEvent) => {
-    if (!iframe.instance) {
-        throw ERRORS.TypedError('Init_NotInitialized');
-    }
-    iframe.postMessage(response);
-};
-
-const renderWebUSBButton = (className?: string) => {
-    webUSBButton(className, _settings.webusbSrc);
-};
-
-const requestLogin = async (params: any) => {
-    if (typeof params.callback === 'function') {
-        const { callback } = params;
-
-        // TODO: set message listener only if iframe is loaded correctly
-        const loginChallengeListener = async (event: MessageEvent<CoreEventMessage>) => {
-            const { data } = event;
-            if (data && data.type === UI.LOGIN_CHALLENGE_REQUEST) {
-                try {
-                    const payload = await callback();
-                    iframe.postMessage({
-                        type: UI.LOGIN_CHALLENGE_RESPONSE,
-                        payload,
-                    });
-                } catch (error) {
-                    iframe.postMessage({
-                        type: UI.LOGIN_CHALLENGE_RESPONSE,
-                        payload: error.message,
-                    });
-                }
-            }
-        };
-
-        window.addEventListener('message', loginChallengeListener, false);
-
-        const response = await call({
-            method: 'requestLogin',
-            ...params,
-            asyncChallenge: true,
-            callback: null,
-        });
-        window.removeEventListener('message', loginChallengeListener);
-
-        return response;
-    }
-
-    return call({ method: 'requestLogin', ...params });
-};
-
-const disableWebUSB = () => {
-    if (!iframe.instance) {
-        throw ERRORS.TypedError('Init_NotInitialized');
-    }
-    iframe.postMessage({ type: TRANSPORT.DISABLE_WEBUSB });
-};
-
-/**
- * Initiate device pairing procedure.
- */
-const requestWebUSBDevice = async () => {
-    try {
-        await window.navigator.usb.requestDevice({ filters: config.webusb });
-        iframe.postMessage({ type: TRANSPORT.REQUEST_DEVICE });
-    } catch (_err) {
-        // user hits cancel gets "DOMException: No device selected."
-        // no need to log this
-    }
-};
-
-const TrezorConnect = factory({
-    eventEmitter,
-    manifest,
-    init,
-    call,
-    requestLogin,
-    uiResponse,
-    renderWebUSBButton,
-    disableWebUSB,
-    requestWebUSBDevice,
-    cancel,
-    dispose,
-});
+const TrezorConnect = new Proxy<TrezorConnectInterface>(
+    TrezorConnectIframe, // default target
+    new TrezorConnectProxyHandler(),
+);
 
 export default TrezorConnect;
 export * from '@trezor/connect/src/exports';

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -1,50 +1,187 @@
-import TrezorConnectIframe from './impl/core-in-iframe';
-import TrezorConnectCoreInPopup from './impl/core-in-popup';
-import type {
-    ConnectSettings,
-    Manifest,
-    TrezorConnect as TrezorConnectInterface,
-} from '@trezor/connect/src/types';
+import { ConnectFactoryDependencies, factory } from '@trezor/connect/src/factory';
+import { CoreInIframe } from './impl/core-in-iframe';
+import { CoreInPopup } from './impl/core-in-popup';
+import type { ConnectSettings, Manifest } from '@trezor/connect/src/types';
+import EventEmitter from 'events';
+import { CallMethodPayload } from '@trezor/connect';
 
 type TrezorConnectType = 'core-in-popup' | 'iframe';
 
-class TrezorConnectProxyHandler implements ProxyHandler<TrezorConnectInterface> {
-    private currentTarget: TrezorConnectType = 'iframe';
+class ProxyEventEmitter implements EventEmitter {
+    private eventEmitters: EventEmitter[];
 
-    private getTarget(defaultTarget: TrezorConnectInterface) {
-        switch (this.currentTarget) {
-            case 'core-in-popup':
-                return TrezorConnectCoreInPopup;
-            case 'iframe':
-            default:
-                // Use default target
-                return defaultTarget;
-        }
+    constructor(eventEmitters: EventEmitter[]) {
+        this.eventEmitters = eventEmitters;
     }
 
-    get(defaultTarget: TrezorConnectInterface, prop: string, receiver: any) {
-        if (prop === 'init') {
-            return async (settings: { manifest: Manifest } & Partial<ConnectSettings>) => {
-                if (settings?.useCoreInPopup === true) {
-                    this.currentTarget = 'core-in-popup';
-                } else {
-                    this.currentTarget = 'iframe';
-                }
+    emit(eventName: string | symbol, ...args: any[]): boolean {
+        this.eventEmitters.forEach(emitter => emitter.emit(eventName, ...args));
 
-                const target = this.getTarget(defaultTarget);
+        return true;
+    }
 
-                return await target.init.apply(target, [settings]);
-            };
-        }
+    on(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        this.eventEmitters.forEach(emitter => emitter.on(eventName, listener));
 
-        return Reflect.get(this.getTarget(defaultTarget), prop, receiver);
+        return this;
+    }
+
+    off(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        this.eventEmitters.forEach(emitter => emitter.off(eventName, listener));
+
+        return this;
+    }
+
+    once(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        this.eventEmitters.forEach(emitter => emitter.once(eventName, listener));
+
+        return this;
+    }
+
+    addListener(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        this.eventEmitters.forEach(emitter => emitter.addListener(eventName, listener));
+
+        return this;
+    }
+
+    prependListener(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        this.eventEmitters.forEach(emitter => emitter.prependListener(eventName, listener));
+
+        return this;
+    }
+
+    prependOnceListener(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        this.eventEmitters.forEach(emitter => emitter.prependOnceListener(eventName, listener));
+
+        return this;
+    }
+
+    removeAllListeners(event?: string | symbol | undefined): this {
+        this.eventEmitters.forEach(emitter => emitter.removeAllListeners(event));
+
+        return this;
+    }
+
+    removeListener(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        this.eventEmitters.forEach(emitter => emitter.removeListener(eventName, listener));
+
+        return this;
+    }
+
+    setMaxListeners(n: number): this {
+        this.eventEmitters.forEach(emitter => emitter.setMaxListeners(n));
+
+        return this;
+    }
+
+    eventNames(): (string | symbol)[] {
+        return this.eventEmitters[0].eventNames();
+    }
+
+    getMaxListeners(): number {
+        return this.eventEmitters[0].getMaxListeners();
+    }
+
+    listenerCount(eventName: string | symbol, listener?: FunctionConstructor | undefined) {
+        return this.eventEmitters[0].listenerCount(eventName, listener);
+    }
+
+    rawListeners(eventName: string | symbol) {
+        return this.eventEmitters[0].rawListeners(eventName);
+    }
+
+    listeners(eventName: string | symbol) {
+        return this.eventEmitters[0].listeners(eventName);
     }
 }
 
-const TrezorConnect = new Proxy<TrezorConnectInterface>(
-    TrezorConnectIframe, // default target
-    new TrezorConnectProxyHandler(),
-);
+/**
+ * Implementation of TrezorConnect that can dynamically switch between iframe and core-in-popup implementations
+ */
+export class TrezorConnectDynamicImpl implements ConnectFactoryDependencies {
+    public eventEmitter: EventEmitter;
+
+    private currentTarget: TrezorConnectType = 'iframe';
+    private coreInIframeImpl: CoreInIframe;
+    private coreInPopupImpl: CoreInPopup;
+
+    public constructor() {
+        this.coreInIframeImpl = new CoreInIframe();
+        this.coreInPopupImpl = new CoreInPopup();
+        this.eventEmitter = new ProxyEventEmitter([
+            this.coreInIframeImpl.eventEmitter,
+            this.coreInPopupImpl.eventEmitter,
+        ]);
+    }
+
+    private getTarget() {
+        return this.currentTarget === 'iframe' ? this.coreInIframeImpl : this.coreInPopupImpl;
+    }
+
+    public manifest(data: Manifest) {
+        this.getTarget().manifest(data);
+    }
+
+    public init(settings: Partial<ConnectSettings> = {}) {
+        if (settings.useCoreInPopup) {
+            this.currentTarget = 'core-in-popup';
+        } else {
+            this.currentTarget = 'iframe';
+        }
+
+        return this.getTarget().init(settings);
+    }
+
+    public call(params: CallMethodPayload) {
+        return this.getTarget().call(params);
+    }
+
+    public requestLogin(params: any) {
+        return this.getTarget().requestLogin(params);
+    }
+
+    public uiResponse(params: any) {
+        return this.getTarget().uiResponse(params);
+    }
+
+    public renderWebUSBButton() {
+        return this.getTarget().renderWebUSBButton();
+    }
+
+    public disableWebUSB() {
+        return this.getTarget().disableWebUSB();
+    }
+
+    public requestWebUSBDevice() {
+        return this.getTarget().requestWebUSBDevice();
+    }
+
+    public cancel() {
+        return this.getTarget().cancel();
+    }
+
+    public dispose() {
+        this.eventEmitter.removeAllListeners();
+
+        return this.getTarget().dispose();
+    }
+}
+
+const methods = new TrezorConnectDynamicImpl();
+
+const TrezorConnect = factory({
+    eventEmitter: methods.eventEmitter,
+    init: methods.init.bind(methods),
+    call: methods.call.bind(methods),
+    manifest: methods.manifest.bind(methods),
+    requestLogin: methods.requestLogin.bind(methods),
+    uiResponse: methods.uiResponse.bind(methods),
+    renderWebUSBButton: methods.renderWebUSBButton.bind(methods),
+    disableWebUSB: methods.disableWebUSB.bind(methods),
+    requestWebUSBDevice: methods.requestWebUSBDevice.bind(methods),
+    cancel: methods.cancel.bind(methods),
+    dispose: methods.dispose.bind(methods),
+});
 
 export default TrezorConnect;
 export * from '@trezor/connect/src/exports';

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -722,6 +722,11 @@ const onCall = async (message: IFrameCallMessage) => {
 
             await device.cleanup();
 
+            if (useCoreInPopup) {
+                // We need to send response before closing popup
+                postMessage(response);
+            }
+
             closePopup();
             cleanup();
 
@@ -734,7 +739,10 @@ const onCall = async (message: IFrameCallMessage) => {
                     _deviceList.removeAuthPenalty(device);
                 }
             }
-            postMessage(response);
+
+            if (!useCoreInPopup) {
+                postMessage(response);
+            }
         }
     }
 };

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -108,6 +108,11 @@ const initDevice = async (devicePath?: string) => {
     // in TrezorConnect.init, this method may emit UI.SELECT_DEVICE with wrong parameters (for example it thinks that it does not use weubsb although it should)
     await _deviceList.transportFirstEventPromise;
 
+    if (!_deviceList) {
+        // Need to check again if _deviceList is still available
+        throw ERRORS.TypedError('Transport_Missing');
+    }
+
     const isWebUsb = _deviceList.transportType() === 'WebUsbTransport';
     let device: Device | typeof undefined;
     let showDeviceSelection = isWebUsb;

--- a/packages/connect/src/factory.ts
+++ b/packages/connect/src/factory.ts
@@ -3,7 +3,7 @@ import type { EventEmitter } from 'events';
 import type { TrezorConnect } from './types';
 import type { CallMethod } from './events/call';
 
-interface Dependencies {
+export interface ConnectFactoryDependencies {
     call: CallMethod;
     eventEmitter: EventEmitter;
     manifest: TrezorConnect['manifest'];
@@ -29,7 +29,7 @@ export const factory = ({
     requestWebUSBDevice,
     cancel,
     dispose,
-}: Dependencies): TrezorConnect => {
+}: ConnectFactoryDependencies): TrezorConnect => {
     const api: TrezorConnect = {
         manifest,
         init,

--- a/packages/utils/src/createDeferredManager.ts
+++ b/packages/utils/src/createDeferredManager.ts
@@ -11,7 +11,7 @@ type DeferredManagerOptions = {
     initialId?: number;
 };
 
-type DeferredManager<T> = {
+export type DeferredManager<T> = {
     /** How many pending promises are there */
     length: () => number;
     /** ID of the next created promise (for specific use case, should be removed in the future) */


### PR DESCRIPTION
## Description

We want to be able to run core inside popup, without iframe. This way we can have working WebUSB on 3rd party sites and handle issues with loading iframe. 

Changes: 
1. Moved existing iframe implementation in`connect-web` to `connect-web/impl/iframe`
2. Added new core-in-popup implementation `connect-web/impl/core-in-popup` based on existing work in webextension
3. Added a facade as default export of `connect-web` which forwards calls to the correct impl based on `settings.useCoreInPopup`