### PR TITLE
feat(suite-native): Add Account with type selection

### DIFF
--- a/packages/theme/src/boxShadows.ts
+++ b/packages/theme/src/boxShadows.ts
@@ -38,6 +38,16 @@ export const nativeBoxShadows: Record<string, NativeBoxShadowDefinition> = {
         shadowOpacity: 0.1,
         shadowRadius: 4,
     },
+    medium: {
+        elevation: 3,
+        shadowColor: 'rgba(0, 0, 0, 0.4)',
+        shadowOffset: {
+            height: 16,
+            width: 0,
+        },
+        shadowOpacity: 0.16,
+        shadowRadius: 16,
+    },
 };
 
 export type NativeBoxShadow = keyof typeof nativeBoxShadows;

--- a/suite-native/atoms/src/SelectableItem.tsx
+++ b/suite-native/atoms/src/SelectableItem.tsx
@@ -1,0 +1,98 @@
+import { TouchableOpacity, View } from 'react-native';
+import { ReactNode } from 'react';
+
+import { useTranslate } from '@suite-native/intl';
+import { useNativeStyles, prepareNativeStyle } from '@trezor/styles';
+
+import { Card } from './Card/Card';
+import { VStack } from './Stack';
+import { Box } from './Box';
+import { Badge } from './Badge';
+import { Text } from './Text';
+import { Radio } from './Radio';
+
+const cardStyle = prepareNativeStyle((utils, { isSelected }: { isSelected: boolean }) => ({
+    padding: utils.spacings.medium,
+    extend: [
+        {
+            condition: isSelected,
+            style: {
+                borderColor: utils.colors.iconPrimaryDefault,
+                borderWidth: utils.borders.widths.large,
+                padding: utils.spacings.medium - utils.borders.widths.large,
+                ...utils.boxShadows.medium,
+            },
+        },
+    ],
+}));
+
+const titleWrapper = prepareNativeStyle(_ => ({
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+}));
+
+const radioWrapper = prepareNativeStyle(_ => ({
+    width: '100%',
+    alignItems: 'flex-end',
+    paddingTop: 12,
+}));
+
+const subtitleWrapper = prepareNativeStyle(utils => ({
+    paddingBottom: utils.spacings.extraSmall,
+}));
+
+const badgeWrapper = prepareNativeStyle(utils => ({
+    paddingTop: utils.spacings.extraSmall,
+}));
+
+type SelectableItemProps = {
+    title: string;
+    subtitle?: string;
+    description?: ReactNode;
+    isSelected: boolean;
+    isDefault: boolean;
+    onSelected: () => void;
+};
+
+export const SelectableItem = ({
+    title,
+    subtitle,
+    description,
+    isSelected,
+    isDefault,
+    onSelected,
+}: SelectableItemProps) => {
+    const { applyStyle, utils } = useNativeStyles();
+    const { translate } = useTranslate();
+
+    return (
+        <TouchableOpacity onPress={onSelected} activeOpacity={0.6}>
+            <Card style={applyStyle(cardStyle, { isSelected })}>
+                <VStack spacing={utils.spacings.extraSmall}>
+                    <Box style={applyStyle(titleWrapper)}>
+                        <Text variant="titleSmall" color="textDefault">
+                            {title}
+                        </Text>
+                        {isDefault && (
+                            <View style={applyStyle(badgeWrapper)}>
+                                <Badge
+                                    key="defaultType"
+                                    variant="green"
+                                    label={translate('generic.default')}
+                                    icon="checkCircle"
+                                />
+                            </View>
+                        )}
+                    </Box>
+                    <Text variant="hint" color="textDefault" style={applyStyle(subtitleWrapper)}>
+                        {subtitle}
+                    </Text>
+                    <Text>{description}</Text>
+                </VStack>
+                <View style={applyStyle(radioWrapper)}>
+                    <Radio value="toggle" onPress={onSelected} isChecked={isSelected} />
+                </View>
+            </Card>
+        </TouchableOpacity>
+    );
+};

--- a/suite-native/atoms/src/index.ts
+++ b/suite-native/atoms/src/index.ts
@@ -39,5 +39,6 @@ export * from './TrezorSuiteLiteHeader';
 export * from './Skeleton/BoxSkeleton';
 export * from './Skeleton/ListItemSkeleton';
 export * from './BulletListItem';
+export * from './SelectableItem';
 
 export { useDebugView } from './DebugView';

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -16,6 +16,7 @@ export const en = {
             eject: 'Eject',
         },
         unknownError: 'Something went wrong',
+        default: 'Default',
     },
     messageSystem: {
         killswitch: {
@@ -169,6 +170,45 @@ export const en = {
                 actionPrimary: 'Close',
                 actionSecondary: 'Learn more',
                 actionSecondaryUrl: 'https://trezor.io/learn/a/multiple-accounts-in-trezor-suite',
+            },
+        },
+        accountTypeDecisionBootomSheet: {
+            title: 'Add <coin></coin> account',
+            description:
+                '<type></type> is the default address type. <moreLink>Learn more</moreLink>',
+            buttons: {
+                select: 'Change account type',
+                confirm: 'Continue with <type></type>',
+            },
+        },
+        selectAccountTypeScreen: {
+            title: 'Select <symbol></symbol> account type',
+            accountTypes: {
+                normal: {
+                    title: 'SegWit',
+                    subtitle: 'BIP84, P2WPKH, Bech32',
+                    desc: '<li>Reduces transaction size, boosts capacity, and enhances scalability</li><li>Enables lower transaction fees</li><li>May not work with some older services.</li>',
+                },
+                taproot: {
+                    title: 'Taproot',
+                    subtitle: 'BIP86, P2TR, Bech32m',
+                    desc: '<li>Enhances privacy and network efficiency</li><li>Allows more complex spending conditions privately on the blockchain</li><li>May not be supported by all services</li>',
+                },
+                segwit: {
+                    title: 'Legacy SegWit ',
+                    subtitle: 'BIP49, P2SH-P2WPKH, Base58',
+                    desc: '<li>Enhances privacy and network efficiency</li><li>Allows more complex spending conditions privately on the blockchain</li><li>May not be supported by all services</li>',
+                },
+                legacy: {
+                    title: 'Legacy',
+                    subtitle: 'BIP44, P2PKH, Base58',
+                    desc: '<li>Uses simpler transaction formats</li><li>May result in higher transaction fees</li><li>Lacks the efficiency and features found in newer address types</li>',
+                },
+            },
+            aboutTypesLabel: 'Curious about different address types?',
+            buttons: {
+                more: 'Learn more',
+                confirm: 'Continue with <type></type>',
             },
         },
     },

--- a/suite-native/module-add-accounts/package.json
+++ b/suite-native/module-add-accounts/package.json
@@ -26,7 +26,12 @@
         "@suite-native/intl": "workspace:*",
         "@suite-native/link": "workspace:*",
         "@suite-native/navigation": "workspace:*",
+        "@trezor/styles": "workspace:*",
+        "@trezor/theme": "workspace:*",
+        "expo-linear-gradient": "12.7.1",
         "react": "18.2.0",
+        "react-native": "0.73.2",
+        "react-native-safe-area-context": "4.8.2",
         "react-redux": "8.0.7"
     },
     "devDependencies": {

--- a/suite-native/module-add-accounts/src/components/AccountTypeDecisionBootomSheet.tsx
+++ b/suite-native/module-add-accounts/src/components/AccountTypeDecisionBootomSheet.tsx
@@ -1,0 +1,71 @@
+import { BottomSheet, Button, VStack, Text } from '@suite-native/atoms';
+import { useTranslate } from '@suite-native/intl';
+import { Link } from '@suite-native/link';
+import { useNativeStyles, prepareNativeStyle } from '@trezor/styles';
+
+const ACCOUNT_TYPES_URL = 'https://trezor.io/learn/a/multiple-accounts-in-trezor-suite';
+
+const descStyle = prepareNativeStyle(utils => ({
+    alignSelf: 'center',
+    paddingBottom: utils.spacings.small,
+}));
+
+type AccountTypeDecisionBootomSheetProps = {
+    coinName: string;
+    typeName: string;
+    isVisible: boolean;
+    onTypeSelectionTap: () => void;
+    onConfirmTap: () => void;
+    onClose: () => void;
+};
+
+export const AccountTypeDecisionBootomSheet = ({
+    coinName,
+    typeName,
+    isVisible,
+    onTypeSelectionTap,
+    onConfirmTap,
+    onClose,
+}: AccountTypeDecisionBootomSheetProps) => {
+    const { translate } = useTranslate();
+    const { applyStyle } = useNativeStyles();
+    return (
+        <BottomSheet
+            title={translate('moduleAddAccounts.accountTypeDecisionBootomSheet.title', {
+                coin: _ => coinName.toUpperCase(),
+            })}
+            isVisible={isVisible}
+            onClose={onClose}
+            isCloseDisplayed={false}
+        >
+            <VStack spacing="medium">
+                <Text color="textSubdued" style={applyStyle(descStyle)}>
+                    {translate('moduleAddAccounts.accountTypeDecisionBootomSheet.description', {
+                        type: _ => (
+                            <Text color="textDefault" variant="highlight">
+                                {typeName}
+                            </Text>
+                        ),
+                        moreLink: chunks => (
+                            <Link
+                                href={ACCOUNT_TYPES_URL}
+                                label={chunks}
+                                isUnderlined
+                                textColor="textDefault"
+                                textPressedColor="textDefault"
+                            />
+                        ),
+                    })}
+                </Text>
+                <Button size="medium" onPress={onConfirmTap}>
+                    {translate('moduleAddAccounts.accountTypeDecisionBootomSheet.buttons.confirm', {
+                        type: _ => typeName,
+                    })}
+                </Button>
+                <Button size="medium" colorScheme="tertiaryElevation0" onPress={onTypeSelectionTap}>
+                    {translate('moduleAddAccounts.accountTypeDecisionBootomSheet.buttons.select')}
+                </Button>
+            </VStack>
+        </BottomSheet>
+    );
+};

--- a/suite-native/module-add-accounts/src/navigation/AddCoinAccountStackNavigator.tsx
+++ b/suite-native/module-add-accounts/src/navigation/AddCoinAccountStackNavigator.tsx
@@ -7,6 +7,7 @@ import {
 } from '@suite-native/navigation';
 
 import { AddCoinAccountScreen } from '../screens/AddCoinAccountScreen';
+import { SelectAccountTypeScreen } from '../screens/SelectAccountTypeScreen';
 
 const AddCoinAccountStack = createNativeStackNavigator<AddCoinAccountStackParamList>();
 
@@ -19,6 +20,11 @@ export const AddCoinAccountStackNavigator = () => (
             options={{ title: AddCoinAccountStackRoutes.AddCoinAccount }}
             name={AddCoinAccountStackRoutes.AddCoinAccount}
             component={AddCoinAccountScreen}
+        />
+        <AddCoinAccountStack.Screen
+            options={{ title: AddCoinAccountStackRoutes.SelectAccountType }}
+            name={AddCoinAccountStackRoutes.SelectAccountType}
+            component={SelectAccountTypeScreen}
         />
     </AddCoinAccountStack.Navigator>
 );

--- a/suite-native/module-add-accounts/src/screens/AddCoinAccountScreen.tsx
+++ b/suite-native/module-add-accounts/src/screens/AddCoinAccountScreen.tsx
@@ -1,14 +1,43 @@
+import { G } from '@mobily/ts-belt';
+
 import { Screen, ScreenSubHeader } from '@suite-native/navigation';
 import { Card, VStack } from '@suite-native/atoms';
 import { useTranslate } from '@suite-native/intl';
 import { SelectableNetworkItem } from '@suite-native/accounts';
 
-import { useAddCoinAccount } from '../hooks/useAddCoinAccount';
+import { accountTypeTranslationKeys, useAddCoinAccount } from '../hooks/useAddCoinAccount';
+import { AccountTypeDecisionBootomSheet } from '../components/AccountTypeDecisionBootomSheet';
 
 export const AddCoinAccountScreen = () => {
     const { translate } = useTranslate();
 
-    const { supportedNetworkSymbols, onSelectedNetworkItem } = useAddCoinAccount();
+    const {
+        supportedNetworkSymbols,
+        onSelectedNetworkItem,
+        networkWithTypeToBeAdded,
+        clearNetworkWithTypeToBeAdded,
+        navigateToAccountTypeSelectionScreen,
+        addCoinAccount,
+    } = useAddCoinAccount();
+
+    const accountTypeName = networkWithTypeToBeAdded
+        ? translate(accountTypeTranslationKeys[networkWithTypeToBeAdded[1]].titleKey)
+        : '';
+
+    const handleTypeSelectionTap = () => {
+        if (networkWithTypeToBeAdded) {
+            navigateToAccountTypeSelectionScreen(networkWithTypeToBeAdded[0]);
+        }
+    };
+
+    const handleConfirmTap = () => {
+        if (networkWithTypeToBeAdded) {
+            addCoinAccount({
+                network: networkWithTypeToBeAdded[0],
+                accountType: networkWithTypeToBeAdded[1],
+            });
+        }
+    };
 
     return (
         <Screen
@@ -26,11 +55,22 @@ export const AddCoinAccountScreen = () => {
                             symbol={symbol}
                             data-testID={`@add-account/select-coin/${symbol}`}
                             onPress={onSelectedNetworkItem}
-                            rightIcon="plus"
                         />
                     ))}
                 </VStack>
             </Card>
+            <AccountTypeDecisionBootomSheet
+                coinName={
+                    G.isNotNullable(networkWithTypeToBeAdded)
+                        ? networkWithTypeToBeAdded[0].symbol
+                        : ''
+                }
+                typeName={accountTypeName}
+                isVisible={G.isNotNullable(networkWithTypeToBeAdded)}
+                onClose={clearNetworkWithTypeToBeAdded}
+                onTypeSelectionTap={handleTypeSelectionTap}
+                onConfirmTap={handleConfirmTap}
+            />
         </Screen>
     );
 };

--- a/suite-native/module-add-accounts/src/screens/SelectAccountTypeScreen.tsx
+++ b/suite-native/module-add-accounts/src/screens/SelectAccountTypeScreen.tsx
@@ -1,0 +1,174 @@
+import { useState } from 'react';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { View } from 'react-native';
+
+import { useNavigation } from '@react-navigation/native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+import { useNativeStyles, prepareNativeStyle } from '@trezor/styles';
+import { AccountType } from '@suite-common/wallet-config';
+import {
+    StackNavigationProps,
+    AddCoinAccountStackParamList,
+    AddCoinAccountStackRoutes,
+    Screen,
+    ScreenSubHeader,
+    StackProps,
+} from '@suite-native/navigation';
+import { Button, VStack, Text, IconButton, Box, SelectableItem } from '@suite-native/atoms';
+import { useTranslate, Translation, TxKeyPath } from '@suite-native/intl';
+import { useOpenLink } from '@suite-native/link';
+
+import { useAddCoinAccount, accountTypeTranslationKeys } from '../hooks/useAddCoinAccount';
+
+const GRADIENT_HEIGHT = 48;
+
+// for extra space on the bottom due to android showing odd SafeAreaInsets.bottom
+const EXTRA_BOTTOM_PADDING = 48;
+
+const ACCOUNT_TYPES_URL = 'https://trezor.io/learn/a/multiple-accounts-in-trezor-suite';
+
+const bulletsForKeyPath = (keyPath: TxKeyPath) => (
+    <Translation
+        id={keyPath}
+        values={{
+            li: chunks =>
+                chunks.map(row => (
+                    <Box flexDirection="row">
+                        <Text variant="hint" color="textSubdued">
+                            {'  '}•{'  '}
+                        </Text>
+                        <Text variant="hint" color="textSubdued">
+                            {row}
+                        </Text>
+                    </Box>
+                )),
+        }}
+    />
+);
+
+const itemsStyle = prepareNativeStyle(utils => ({
+    paddingHorizontal: utils.spacings.extraSmall,
+}));
+
+const bottomWrapperStyle = prepareNativeStyle((_, { bottomInset }: { bottomInset: number }) => ({
+    position: 'absolute',
+    paddingBottom: bottomInset,
+    left: 0,
+    right: 0,
+    bottom: 0,
+}));
+
+const gradientStyle = prepareNativeStyle(_ => ({
+    height: GRADIENT_HEIGHT,
+}));
+
+const buttonWrapperStyle = prepareNativeStyle(utils => ({
+    paddingHorizontal: utils.spacings.medium,
+    backgroundColor: utils.colors.backgroundSurfaceElevation0,
+}));
+
+const aboutStyle = prepareNativeStyle((utils, { bottomInset }: { bottomInset: number }) => ({
+    paddingTop: utils.spacings.extraLarge,
+    paddingBottom: EXTRA_BOTTOM_PADDING + GRADIENT_HEIGHT + bottomInset,
+    width: '100%',
+    paddingHorizontal: utils.spacings.small,
+    gap: 12,
+}));
+
+export const SelectAccountTypeScreen = ({
+    route,
+}: StackProps<AddCoinAccountStackParamList, AddCoinAccountStackRoutes.SelectAccountType>) => {
+    const { accountType: defaultType, network } = route.params;
+    const { translate } = useTranslate();
+    const openLink = useOpenLink();
+    const insets = useSafeAreaInsets();
+    const { applyStyle, utils } = useNativeStyles();
+    const navigation =
+        useNavigation<
+            StackNavigationProps<
+                AddCoinAccountStackParamList,
+                AddCoinAccountStackRoutes.SelectAccountType
+            >
+        >();
+
+    const { getAvailableAccountTypesForNetwork, addCoinAccount } = useAddCoinAccount();
+
+    const [selectedAccountType, setSelectedAccountType] = useState<AccountType>(defaultType);
+
+    const types: AccountType[] = getAvailableAccountTypesForNetwork({ network });
+    const { titleKey: accountTypeKey } = accountTypeTranslationKeys[selectedAccountType];
+
+    const handleClose = () => navigation.goBack();
+
+    const handleMoreTap = () => openLink(ACCOUNT_TYPES_URL);
+
+    const handleConfirmTap = () => {
+        addCoinAccount({ network, accountType: selectedAccountType });
+    };
+
+    return (
+        <>
+            <Screen
+                screenHeader={
+                    <ScreenSubHeader
+                        content={translate('moduleAddAccounts.selectAccountTypeScreen.title', {
+                            symbol: _ => network.symbol.toUpperCase(),
+                        })}
+                        leftIcon={
+                            <IconButton
+                                iconName="close"
+                                onPress={handleClose}
+                                colorScheme="tertiaryElevation0"
+                                size="medium"
+                            />
+                        }
+                    />
+                }
+            >
+                <VStack spacing="large" style={applyStyle(itemsStyle)}>
+                    {types.map(item => {
+                        const { titleKey, subtitleKey, descKey } = accountTypeTranslationKeys[item];
+
+                        return (
+                            <SelectableItem
+                                key={`select-type-${item}`}
+                                title={translate(titleKey)}
+                                subtitle={translate(subtitleKey)}
+                                description={bulletsForKeyPath(descKey)}
+                                isSelected={selectedAccountType === item}
+                                isDefault={defaultType === item}
+                                data-testID={`@add-account/select-type/${item}`}
+                                onSelected={() => setSelectedAccountType(item)}
+                            />
+                        );
+                    })}
+                </VStack>
+                <View style={applyStyle(aboutStyle, { bottomInset: insets.bottom })}>
+                    <Text variant="hint" color="textSubdued" textAlign="center">
+                        <Translation id="moduleAddAccounts.selectAccountTypeScreen.aboutTypesLabel" />
+                    </Text>
+                    <Button size="medium" colorScheme="tertiaryElevation0" onPress={handleMoreTap}>
+                        {translate('moduleAddAccounts.selectAccountTypeScreen.buttons.more')}
+                    </Button>
+                </View>
+            </Screen>
+            <View style={applyStyle(bottomWrapperStyle, { bottomInset: insets.bottom })}>
+                <LinearGradient
+                    style={applyStyle(gradientStyle)}
+                    colors={[
+                        utils.transparentize(1, utils.colors.backgroundSurfaceElevation0),
+                        utils.colors.backgroundSurfaceElevation0,
+                    ]}
+                />
+                <View style={applyStyle(buttonWrapperStyle)}>
+                    <Button size="medium" onPress={handleConfirmTap}>
+                        {translate('moduleAddAccounts.selectAccountTypeScreen.buttons.confirm', {
+                            type: _ => translate(accountTypeKey),
+                        })}
+                    </Button>
+                </View>
+            </View>
+        </>
+    );
+};

--- a/suite-native/module-add-accounts/tsconfig.json
+++ b/suite-native/module-add-accounts/tsconfig.json
@@ -23,6 +23,8 @@
         { "path": "../discovery" },
         { "path": "../intl" },
         { "path": "../link" },
-        { "path": "../navigation" }
+        { "path": "../navigation" },
+        { "path": "../../packages/styles" },
+        { "path": "../../packages/theme" }
     ]
 }

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -1,7 +1,7 @@
 import { NavigatorScreenParams } from '@react-navigation/native';
 
 import { AccountKey, TokenAddress, XpubAddress } from '@suite-common/wallet-types';
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import { AccountType, Network, NetworkSymbol } from '@suite-common/wallet-config';
 import { AccountInfo, TokenTransfer } from '@trezor/connect';
 
 import {
@@ -85,6 +85,10 @@ export type AccountsImportStackParamList = {
 
 export type AddCoinAccountStackParamList = {
     [AddCoinAccountStackRoutes.AddCoinAccount]: undefined;
+    [AddCoinAccountStackRoutes.SelectAccountType]: {
+        accountType: AccountType;
+        network: Network;
+    };
 };
 
 export type ConnectDeviceStackParamList = {

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -60,6 +60,7 @@ export enum ReceiveStackRoutes {
 
 export enum AddCoinAccountStackRoutes {
     AddCoinAccount = 'AddCoinAccount',
+    SelectAccountType = 'SelectAccountType',
 }
 
 export enum SettingsStackRoutes {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8183,7 +8183,12 @@ __metadata:
     "@suite-native/intl": "workspace:*"
     "@suite-native/link": "workspace:*"
     "@suite-native/navigation": "workspace:*"
+    "@trezor/styles": "workspace:*"
+    "@trezor/theme": "workspace:*"
+    expo-linear-gradient: "npm:12.7.1"
     react: "npm:18.2.0"
+    react-native: "npm:0.73.2"
+    react-native-safe-area-context: "npm:4.8.2"
     react-redux: "npm:8.0.7"
     typescript: "npm:5.3.2"
   languageName: unknown
@@ -27909,6 +27914,16 @@ __metadata:
   peerDependencies:
     react-native: ">=0.47.0"
   checksum: 248746df31a5ede2a042e6a04104599e259bfdefff48cc505492f201f591315f6f0aecfc637788d085b0e97090971e2b7f8a11590da200384135ac72ca3147ab
+  languageName: node
+  linkType: hard
+
+"react-native-safe-area-context@npm:4.8.2":
+  version: 4.8.2
+  resolution: "react-native-safe-area-context@npm:4.8.2"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: ea01a7e3bceec23273a7b2807816b917fae48030431c1d966ee912c5ef12b131620c10b909f2604a2f296fc84ab1a3bdd9e536701401bdca6452441e2a825b60
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
When user wants to add new coin to be in the app, he can create it via "+" button on My asset page
User can choose from available coins for the connected device
BTC like coins - user must choose account type
ETH like coins - user does not need to choose the account type
User can’t create new account if the previous one has no transactions
Maximum number of accounts under one coin is 10

## Related Issue

Resolve #10676

## Screenshots:

https://github.com/trezor/trezor-suite/assets/2011829/0ea02c65-e6ad-4bb6-b2ec-a9741a06cbec



