### PR TITLE
fix(suite): fetching fiat rates using eth token definitions

### DIFF
--- a/suite-common/wallet-config/src/types.ts
+++ b/suite-common/wallet-config/src/types.ts
@@ -2,3 +2,8 @@ import { networks, NetworkSymbol } from './networksConfig';
 
 export const isNetworkSymbol = (symbol: NetworkSymbol | string): symbol is NetworkSymbol =>
     symbol in networks;
+
+export const isEthereumBasedNetwork = (
+    network: (typeof networks)[NetworkSymbol],
+): network is (typeof networks)[NetworkSymbol] & { chainId: number } =>
+    network.networkType === 'ethereum';

--- a/suite-common/wallet-core/src/token-definitions/tokenDefinitionsReducer.ts
+++ b/suite-common/wallet-core/src/token-definitions/tokenDefinitionsReducer.ts
@@ -10,13 +10,13 @@ export const prepareTokenDefinitionsReducer = createReducerWithExtraDeps(
     builder => {
         builder
             .addCase(getTokenDefinitionThunk.pending, (state, action) => {
-                const { network, contractAddress } = action.meta.arg;
+                const { networkSymbol, contractAddress } = action.meta.arg;
 
-                if (!state[network.symbol]) {
-                    state[network.symbol] = {};
+                if (!state[networkSymbol]) {
+                    state[networkSymbol] = {};
                 }
 
-                const networkDefinitions = state[network.symbol];
+                const networkDefinitions = state[networkSymbol];
 
                 if (networkDefinitions) {
                     networkDefinitions[contractAddress] = {
@@ -26,9 +26,9 @@ export const prepareTokenDefinitionsReducer = createReducerWithExtraDeps(
                 }
             })
             .addCase(getTokenDefinitionThunk.fulfilled, (state, action) => {
-                const { network, contractAddress } = action.meta.arg;
+                const { networkSymbol, contractAddress } = action.meta.arg;
 
-                const networkDefinitions = state[network.symbol];
+                const networkDefinitions = state[networkSymbol];
 
                 if (networkDefinitions) {
                     networkDefinitions[contractAddress] = {
@@ -38,9 +38,9 @@ export const prepareTokenDefinitionsReducer = createReducerWithExtraDeps(
                 }
             })
             .addCase(getTokenDefinitionThunk.rejected, (state, action) => {
-                const { network, contractAddress } = action.meta.arg;
+                const { networkSymbol, contractAddress } = action.meta.arg;
 
-                const networkDefinitions = state[network.symbol];
+                const networkDefinitions = state[networkSymbol];
 
                 if (networkDefinitions) {
                     networkDefinitions[contractAddress] = {

--- a/suite-common/wallet-core/src/token-definitions/tokenDefinitionsThunks.ts
+++ b/suite-common/wallet-core/src/token-definitions/tokenDefinitionsThunks.ts
@@ -1,5 +1,5 @@
 import { createThunk } from '@suite-common/redux-utils';
-import { Network } from '@suite-common/wallet-config';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 
 import { selectSpecificTokenDefinition } from './tokenDefinitionsSelectors';
 
@@ -8,19 +8,19 @@ const actionsPrefix = '@common/wallet-core/token-definitions';
 export const getTokenDefinitionThunk = createThunk(
     `${actionsPrefix}/getTokenDefinition`,
     async (
-        params: { network: Network; contractAddress: string },
+        params: { networkSymbol: NetworkSymbol; chainId: number; contractAddress: string },
         { getState, fulfillWithValue, rejectWithValue },
     ) => {
-        const { network, contractAddress } = params;
+        const { networkSymbol, chainId, contractAddress } = params;
         const { isTokenKnown } =
-            selectSpecificTokenDefinition(getState(), network.symbol, contractAddress) || {};
+            selectSpecificTokenDefinition(getState(), networkSymbol, contractAddress) || {};
 
         if (isTokenKnown === undefined) {
             try {
                 const fetchedTokenDefinition = await fetch(
-                    `https://data.trezor.io/firmware/eth-definitions/chain-id/${
-                        network.chainId
-                    }/token-${contractAddress.substring(2).toLowerCase()}.dat`,
+                    `https://data.trezor.io/firmware/eth-definitions/chain-id/${chainId}/token-${contractAddress
+                        .substring(2)
+                        .toLowerCase()}.dat`,
                     { method: 'HEAD' },
                 );
 


### PR DESCRIPTION
## Description

- fetch token definitions on create/update of account instead of selecting account
- `getTokenDefinitionThunk` is `evm` specific, will need to be redone for solana, thats why `isEthereumBasedNetwork` can be used. Solana does not have `chainId`
- one can thing that fetching fiats can be earlier than fetch of token definitions. It never happened for me but I would like to investigate that in the next sprint

## Related Issue

Resolves #11086

## Screenshots:

https://github.com/trezor/trezor-suite/assets/33235762/3f0c9f41-6fb9-4aa8-afd5-0e48ab88d08a

