### PR TITLE
Npm release/connect 9.1.12

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/analytics",
-    "version": "1.0.13",
+    "version": "1.0.14",
     "license": "See LICENSE.md in repo root",
     "sideEffects": false,
     "main": "lib/index",

--- a/packages/blockchain-link-types/package.json
+++ b/packages/blockchain-link-types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/blockchain-link-types",
-    "version": "1.0.12",
+    "version": "1.0.13",
     "license": "See LICENSE.md in repo root",
     "sideEffects": false,
     "main": "lib/index",

--- a/packages/blockchain-link-utils/CHANGELOG.md
+++ b/packages/blockchain-link-utils/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.14
+
+-   Revert feat(blockchain-link); get sol token metadata from coingecko (61cf93cd62)
+
 # 1.0.13
 
 -   feat(blockchain-link); get sol token metadata from coingecko (5c901ea8f)

--- a/packages/blockchain-link-utils/package.json
+++ b/packages/blockchain-link-utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/blockchain-link-utils",
-    "version": "1.0.13",
+    "version": "1.0.14",
     "license": "See LICENSE.md in repo root",
     "sideEffects": false,
     "main": "lib/index",

--- a/packages/blockchain-link/CHANGELOG.md
+++ b/packages/blockchain-link/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.1.25
+
+-   feat(suite): Rename Polygon to Polygon PoS (15a7fd38dc)
+-   feat(suite): add Polygon (8c569ca580)
+-   Revert feat(blockchain-link); get sol token metadata from coingecko (61cf93cd62)
+
 # 2.1.23
 
 -   feat(blockchain-link); get sol token metadata from coingecko (5c901ea8f)

--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/blockchain-link",
-    "version": "2.1.24",
+    "version": "2.1.25",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/blockchain-link",
     "description": "High-level javascript interface for blockchain communication",

--- a/packages/connect-analytics/package.json
+++ b/packages/connect-analytics/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/connect-analytics",
-    "version": "1.0.11",
+    "version": "1.0.12",
     "license": "See LICENSE.md in repo root",
     "sideEffects": false,
     "main": "lib/index",

--- a/packages/connect-common/CHANGELOG.md
+++ b/packages/connect-common/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.0.28
+
+-   feat(suite): Rename Polygon to Polygon PoS (15a7fd38dc)
+-   feat(suite): add Polygon (8c569ca580)
+-   chore(connect-common): remove es5 target (fails with TypedEmitter) (0a19580f63)
+-   feat(connect-common): store is event emitter, saves permissions and preferred device (db0e9631da)
+
 # 0.0.27
 
 -   feat(connect-common): message channel to allow lazy handshake (79be923e67)

--- a/packages/connect-common/package.json
+++ b/packages/connect-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/connect-common",
-    "version": "0.0.27",
+    "version": "0.0.28",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect-common",
     "keywords": [

--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -1,5 +1,20 @@
 # 9.1.12
 
+-   chore(connect): add new CA pubkeys and update timestamp (a4ca9b1)
+-   chore(connect): improve types, replace any with PassphrasePromptResponse (9a95962)
+-   feat: add Polygon (8c569ca)
+-   fix(connect-popup): display errors with no code (8b7cbfa)
+-   fix(connect-popup): don't show error when no device selected (f246369)
+-   fix(connect-ui): tipcontainer bottom margin (bb0379d)
+-   refactor(connect): unify message promises (b0d4b11)
+-   refactor(connect): remove initAsyncPromise (da48a71)
+-   refactor(connect): unify initCore and initTransport (00deffa, 027be4f)
+-   refactor(connect): CoreRequestMessage/CoreEventMessage separation (ea3afa2)
+-   chore(connect-ui): mirror store to local react state (b587a65)
+-   feat(connect): deal with disconnected && preferredDevice (40e9db8, 6e4ddb4)
+-   chore(connect): use preferred device from store (d1899e8)
+-   chore(connect-common): remove es5 target (fails with TypedEmitter) (0a19580)
+-   feat(connect-common): store is event emitter, saves permissions and preferred device (db0e963)
 -   feat(connect-common): message channel to allow lazy handshake (79be923)
 -   chore(connect-ui): ui changes (dcb8e02, 03c6cc6, 936f6b5, 6b7ed69, 8f9f3e2, 4cc0cd6)
 -   fix(libs): changes in libs that should allow compiling connect with typescript option skipLibCheck: false

--- a/packages/env-utils/package.json
+++ b/packages/env-utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/env-utils",
-    "version": "1.0.12",
+    "version": "1.0.13",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/env-utils",
     "npmPublishAccess": "public",
     "license": "See LICENSE.md in repo root",

--- a/packages/protobuf/CHANGELOG.md
+++ b/packages/protobuf/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.8
+
+-   fix(suite): navbar positioning (icons) (123882a387)
+
 # 1.0.6
 
 -   chore(protobuf): lint fix (cebcf0256)

--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/protobuf",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "license": "See LICENSE.md in repo root",
     "repository": {
         "type": "git",

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/transport",
-    "version": "1.1.23",
+    "version": "1.1.24",
     "description": "Low level library facilitating protocol buffers based communication with Trezor devices",
     "npmPublishAccess": "public",
     "license": "SEE LICENSE IN LICENSE.md",

--- a/packages/type-utils/package.json
+++ b/packages/type-utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/type-utils",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "license": "See LICENSE.md in repo root",
     "sideEffects": false,
     "main": "src/index",

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.0.21
+
+-   chore(suite): make better mapping for colors (481c82f56e)
+
 # 9.0.20
 
 -   fix(mobile): fix broken formatting on iOS (#10893) (4e5d028907)

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/utils",
-    "version": "9.0.20",
+    "version": "9.0.21",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/utils",
     "description": "A collection of typescript utils that are intended to be used across trezor-suite monorepo.",

--- a/packages/utxo-lib/package.json
+++ b/packages/utxo-lib/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/utxo-lib",
-    "version": "2.0.5",
+    "version": "2.0.6",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/utxo-lib",
     "description": "Client-side Bitcoin-like JavaScript library",


### PR DESCRIPTION
this is code changes from https://github.com/trezor/trezor-suite/pull/11128 
without bump of connect to 9.1.13 
with updated connect changelog.

doing it like this because we skipped 9.1.12 release but already pushed npm packages. and I don't want to skip connect version. people don't like it.