### PR TITLE
fix(connect-explorer): docs connect-explorer-webextension

### DIFF
--- a/packages/connect-explorer/webpack/webextension.webpack.config.ts
+++ b/packages/connect-explorer/webpack/webextension.webpack.config.ts
@@ -139,18 +139,10 @@ const config: webpack.Configuration = {
                     from: path.join(__dirname, '..', 'src-webextension', 'manifest.json'),
                     to: `${DIST}/`,
                 },
-            ],
-        }),
-        new CopyPlugin({
-            patterns: [
                 {
                     from: path.join(__dirname, '..', 'src', 'fonts'),
                     to: `${DIST}/fonts/`,
                 },
-            ],
-        }),
-        new CopyPlugin({
-            patterns: [
                 {
                     from: path.join(
                         CONNECT_WEB_EXTENSION_PACKAGE_PATH,
@@ -166,6 +158,10 @@ const config: webpack.Configuration = {
                 {
                     from: path.join(CONNECT_WEB_EXTENSION_PATH, 'trezor-usb-permissions.html'),
                     to: `${DIST}`,
+                },
+                {
+                    from: path.resolve(__dirname, '../../../docs/packages/connect'),
+                    to: path.resolve(DIST, 'docs'),
                 },
             ],
         }),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding `docs` markdown so it is included in the connect-explorer-webextension bundle.

## Related Issue

https://github.com/trezor/trezor-suite/issues/11113

## Screenshots:
![image](https://github.com/trezor/trezor-suite/assets/5362163/29415a42-6508-40f9-91c0-708768cbd570)
