### PR TITLE
fix: fiat input for tokens

### DIFF
--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -88,9 +88,6 @@ const getStateFromProps = (props: UseSendFormProps) => {
 export const useSendForm = (props: UseSendFormProps): SendContextValues => {
     // public variables, exported to SendFormContext
     const [isLoading, setLoading] = useState(false);
-    const fiatRates = props.coins.find(
-        item => item.symbol === props.selectedAccount.account.symbol,
-    );
 
     const [state, setState] = useState<UseSendFormState>(getStateFromProps(props));
     // private variables, used inside sendForm hook
@@ -106,6 +103,17 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
     });
 
     const { control, reset, register, getValues, formState, setValue, trigger } = useFormMethods;
+
+    const values = getValues();
+    const token = values?.outputs?.[0]?.token;
+
+    const fiatRates = props.coins.find(item => {
+        const hasToken = !!token;
+        return (
+            item.symbol === props.selectedAccount.account.symbol &&
+            (!hasToken || item.tokenAddress === token)
+        );
+    });
 
     // register array fields (outputs array in react-hook-form)
     const outputsFieldArray = useFieldArray({

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/Fiat.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/Fiat.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { Timestamp } from '@suite-common/wallet-types';
+import { Timestamp, TokenAddress } from '@suite-common/wallet-types';
 import BigNumber from 'bignumber.js';
 import styled from 'styled-components';
 import { Controller } from 'react-hook-form';
@@ -192,7 +192,10 @@ export const Fiat = ({ output, outputId }: FiatProps) => {
                 // Get (fresh) fiat rates for newly selected currency
                 const updateFiatRatesResult = await dispatch(
                     updateFiatRatesThunk({
-                        ticker: { symbol: account.symbol as NetworkSymbol },
+                        ticker: {
+                            symbol: account.symbol as NetworkSymbol,
+                            tokenAddress: token?.contract as TokenAddress,
+                        },
                         localCurrency: selected.value as FiatCurrencyCode,
                         rateType: 'current',
                         lastSuccessfulFetchTimestamp: Date.now() as Timestamp,


### PR DESCRIPTION
## Description

Display fiat input in send form also for tokens with fiat rates. Also removed the message displaying total token balance (we are not doing for ETH and other stuff so why here).

## Related Issue

Resolve #1847

## Screenshots:

<img width="525" alt="Screenshot 2024-02-09 at 5 07 43 PM" src="https://github.com/trezor/trezor-suite/assets/66002635/963cb7c6-ff8b-4b03-992a-2cd2922473c0">