### PR TITLE
fix(wallet-utils): token name is optional so do not filter those tokens

### DIFF
--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -419,9 +419,10 @@ export const countUniqueCoins = (accounts: Account[]) => {
 export const enhanceTokens = (tokens: Account['tokens']) => {
     if (!tokens) return [];
     return tokens
-        .filter(t => t.symbol && t.balance && t.name)
+        .filter(t => t.symbol && t.balance)
         .map(t => ({
             ...t,
+            name: t.name || t.symbol,
             symbol: t.symbol!.toLowerCase(),
             balance: formatAmount(t.balance!, t.decimals),
         }));


### PR DESCRIPTION
## Description

- token name is optional but we filtered out those tokens
- it was not possible to add `0x0d88eD6E74bbFD96B831231638b66C05571e824F` because it has no name

![Screenshot 2024-02-12 at 14 58 18](https://github.com/trezor/trezor-suite/assets/33235762/311c68a2-c880-4f8a-af5c-89a6d1747645)

## Related Issue

https://satoshilabs.slack.com/archives/CKN5C51CJ/p1707738135002779

## Screenshots:

![Screenshot 2024-02-12 at 14 56 31](https://github.com/trezor/trezor-suite/assets/33235762/25e0af54-c231-405e-9384-47faea6f03ab)
