### PR TITLE
fix(docker): update playwright image

### DIFF
--- a/docker/docker-compose.connect-popup-test.yml
+++ b/docker/docker-compose.connect-popup-test.yml
@@ -18,7 +18,7 @@ services:
     network_mode: service:trezor-user-env-unix
 
   test-run:
-    image: mcr.microsoft.com/playwright:latest
+    image: mcr.microsoft.com/playwright:v1.41.2-jammy
     container_name: explorer-test-runner
     depends_on:
       - trezor-user-env-unix


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

It apparently does not work with `latest` so I am updating it to latest version to avoid message below:

![image](https://github.com/trezor/trezor-suite/assets/5362163/829f64ec-3151-424a-9826-980cb14b2f4d)

It looks like it has to be updated manually every time the playwright team update it.