### PR TITLE
fix(connect-webextension): equalSettings in init, don't focus extension on error

### DIFF
--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -233,7 +233,7 @@ const call: CallMethod = async params => {
     } catch (error) {
         _log.error('__call error', error);
         if (_popupManager) {
-            _popupManager.clear();
+            _popupManager.clear(false);
         }
         return createErrorMessage(error);
     }


### PR DESCRIPTION
## Description

1. Improved comparison of equalSettings in init, previously it would be true almost always
2. Close popupManager before creating new one, if it exists already
3. Don't focus extension page when returning errors

## Related

@karliatto

Fixes test connect-explorer-webextension: popup-close.test in https://github.com/trezor/trezor-suite/pull/10988

Cherry picked from PopupManager refactor https://github.com/trezor/trezor-suite/pull/10975