### PR TITLE
fix(ci): always run connect deploy to dev

### DIFF
--- a/ci/deploy.yml
+++ b/ci/deploy.yml
@@ -72,14 +72,9 @@ msg-system deploy sldev:
 # connect deploy to dev
 connect deploy to dev:
   stage: deploy to dev
-  # only:
-  #   <<: *run_connect_rules
   needs:
     - connect-web build
     - connect-explorer build
-  except:
-    refs:
-      - /^release\/connect\//
   variables:
     GIT_STRATEGY: none
     DEPLOY_DIRECTORY: ${DEPLOY_BASE_DIR}/connect/${CI_COMMIT_REF_NAME}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We always want to deploy to connect to dev because we use those sldev urls for testing.

Until last week it was set to run always with exception of connect v8 https://github.com/trezor/trezor-suite/commit/0c5972d83cf08010c162ca8d20b4adde5bd3c093#diff-4d6ba8bc09f2a51a8eaa882571b37a4dd044c2d8013e22918883ddda3a28f78fL81



