### PR TITLE
test(suite-desktop) test using --bridge-node-test

### DIFF
--- a/packages/suite-desktop-core/e2e/support/common.ts
+++ b/packages/suite-desktop-core/e2e/support/common.ts
@@ -12,7 +12,7 @@ export const launchSuite = async () => {
         args: [
             path.join(appDir, './dist/app.js'),
             `--log-level=${desiredLogLevel}`,
-            '--bridge-test',
+            '--bridge-node-test',
         ],
         // when testing electron, video needs to be setup like this. it works locally but not in docker
         // recordVideo: { dir: 'test-results' },

--- a/packages/suite-desktop-core/e2e/tests/settings/electrum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/electrum.test.ts
@@ -16,7 +16,6 @@ testPlaywright.describe.serial('Suite works with Electrum server', () => {
         await TrezorUserEnvLink.api.stopBridge();
         await TrezorUserEnvLink.api.trezorUserEnvConnect();
         await TrezorUserEnvLink.api.startEmu({ wipe: true });
-        await TrezorUserEnvLink.api.startBridge();
         await TrezorUserEnvLink.api.setupEmu({
             needs_backup: true,
             mnemonic: 'all all all all all all all all all all all all',

--- a/packages/suite-desktop-core/e2e/tests/spawn-bridge.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/spawn-bridge.test.ts
@@ -7,14 +7,9 @@ import { launchSuite, waitForDataTestSelector } from '../support/common';
 testPlaywright.describe.serial('Bridge', () => {
     testPlaywright.beforeAll(async () => {
         // We make sure that bridge from trezor-user-env is stopped.
-        // So we properly test the electron app spawning bridge binary.
+        // So we properly test the electron app starting node-bridge module.
         await TrezorUserEnvLink.api.trezorUserEnvConnect();
         await TrezorUserEnvLink.api.stopBridge();
-    });
-
-    testPlaywright.afterAll(async () => {
-        // When finish we make bridge from trezor-user-env to run so it is ready for the rest of the tests.
-        await TrezorUserEnvLink.api.startBridge();
     });
 
     testPlaywright('App spawns bundled bridge and stops it after app quit', async ({ request }) => {

--- a/packages/suite-desktop-core/src/modules/bridge.ts
+++ b/packages/suite-desktop-core/src/modules/bridge.ts
@@ -13,6 +13,7 @@ const bridgeDev = app.commandLine.hasSwitch('bridge-dev');
 const bridgeTest = app.commandLine.hasSwitch('bridge-test');
 // bridge node is intended for internal testing
 const bridgeNode = app.commandLine.hasSwitch('bridge-node');
+const bridgeNodeTest = app.commandLine.hasSwitch('bridge-node-test');
 
 export const SERVICE_NAME = 'bridge';
 
@@ -41,8 +42,8 @@ const start = async (bridge: BridgeProcess | TrezordNode) => {
 };
 
 const getBridgeInstance = () => {
-    if (bridgeNode) {
-        return new TrezordNode({ port: 21325 });
+    if (bridgeNode || bridgeNodeTest) {
+        return new TrezordNode({ port: 21325, api: bridgeNodeTest ? 'udp' : 'usb' });
     }
     return new BridgeProcess();
 };

--- a/packages/suite-web/e2e/cypress.config.ts
+++ b/packages/suite-web/e2e/cypress.config.ts
@@ -225,6 +225,10 @@ export default defineConfig({
                     return store[key];
                 },
                 ...TrezorUserEnvLink.api,
+                async setupEmu(opts: Parameters<typeof TrezorUserEnvLink.api.setupEmu>[0]) {
+                    await TrezorUserEnvLink.api.setupEmu(opts);
+                    return TrezorUserEnvLink.api.startBridge();
+                },
             });
         },
     },

--- a/packages/transport-bridge/src/bin.ts
+++ b/packages/transport-bridge/src/bin.ts
@@ -1,5 +1,5 @@
 import { TrezordNode } from './http';
 
-const trezordNode = new TrezordNode({ port: 21325 });
+const trezordNode = new TrezordNode({ port: 21325, api: 'usb' });
 
 trezordNode.start();

--- a/packages/transport-bridge/src/core.ts
+++ b/packages/transport-bridge/src/core.ts
@@ -5,16 +5,10 @@ import { receive as receiveUtil } from '@trezor/transport/src/utils/receive';
 import { SessionsBackground } from '@trezor/transport/src/sessions/background';
 import { SessionsClient } from '@trezor/transport/src/sessions/client';
 import { UsbApi } from '@trezor/transport/src/api/usb';
+import { UdpApi } from '@trezor/transport/src/api/udp';
 import { AcquireInput, ReleaseInput } from '@trezor/transport/src/transports/abstract';
 
 export const sessionsBackground = new SessionsBackground();
-
-// todo: here we should have MultiApi
-export const api = new UsbApi({
-    usbInterface: new WebUSB({
-        allowAllDevices: true, // return all devices, not only authorized
-    }),
-});
 
 export const sessionsClient = new SessionsClient({
     requestFn: args => sessionsBackground.handleMessage(args),
@@ -25,125 +19,145 @@ sessionsBackground.on('descriptors', descriptors => {
     sessionsClient.emit('descriptors', descriptors);
 });
 
-// whenever low-level api reports changes to descriptors, report them to sessions module
-api.on('transport-interface-change', paths => {
-    sessionsClient.enumerateDone({ paths });
-});
+export const createApi = (apiStr: 'usb' | 'udp') => {
+    const api =
+        apiStr === 'udp'
+            ? new UdpApi({})
+            : new UsbApi({
+                  usbInterface: new WebUSB({
+                      allowAllDevices: true, // return all devices, not only authorized
+                  }),
+              });
 
-const writeUtil = async ({ path, data }: { path: string; data: string }) => {
-    const { typeId, buffer: restBuffer } = protocolBridge.decode(
-        new Uint8Array(Buffer.from(data, 'hex')),
-    );
-
-    const buffers = protocolV1.encode(restBuffer, {
-        messageType: typeId,
+    // whenever low-level api reports changes to descriptors, report them to sessions module
+    api.on('transport-interface-change', paths => {
+        sessionsClient.enumerateDone({ paths });
     });
 
-    for (let i = 0; i < buffers.length; i++) {
-        const bufferSegment = buffers[i];
-
-        await api.write(path, bufferSegment);
-    }
-};
-
-const readUtil = async ({ path }: { path: string }) => {
-    try {
-        const message = await receiveUtil(
-            () =>
-                api.read(path).then(result => {
-                    if (result.success) {
-                        return result.payload;
-                    }
-                    throw new Error(result.error);
-                }),
-            protocolV1.decode,
+    const writeUtil = async ({ path, data }: { path: string; data: string }) => {
+        const { typeId, buffer: restBuffer } = protocolBridge.decode(
+            new Uint8Array(Buffer.from(data, 'hex')),
         );
-        return protocolBridge
-            .encode(message.buffer, { messageType: message.typeId })[0]
-            .toString('hex');
-    } catch (err) {
-        return { success: false as const, error: err.message };
-    }
-};
 
-export const enumerate = async () => {
-    await sessionsClient.enumerateIntent();
+        const buffers = protocolV1.encode(restBuffer, {
+            messageType: typeId,
+        });
 
-    const enumerateResult = await api.enumerate();
-    if (!enumerateResult.success) {
-        return enumerateResult;
-    }
-    return sessionsClient.enumerateDone({ paths: enumerateResult.payload });
-};
+        for (let i = 0; i < buffers.length; i++) {
+            const bufferSegment = buffers[i];
 
-export const acquire = async (acquireInput: AcquireInput) => {
-    const acquireIntentResult = await sessionsClient.acquireIntent({
-        path: acquireInput.path,
-        previous: acquireInput.previous === 'null' ? null : acquireInput.previous,
-    });
-    if (!acquireIntentResult.success) {
+            await api.write(path, bufferSegment);
+        }
+    };
+
+    const readUtil = async ({ path }: { path: string }) => {
+        try {
+            const message = await receiveUtil(
+                () =>
+                    api.read(path).then(result => {
+                        if (result.success) {
+                            return result.payload;
+                        }
+                        throw new Error(result.error);
+                    }),
+                protocolV1.decode,
+            );
+            return protocolBridge
+                .encode(message.buffer, { messageType: message.typeId })[0]
+                .toString('hex');
+        } catch (err) {
+            return { success: false as const, error: err.message };
+        }
+    };
+
+    const enumerate = async () => {
+        await sessionsClient.enumerateIntent();
+
+        const enumerateResult = await api.enumerate();
+        if (!enumerateResult.success) {
+            return enumerateResult;
+        }
+        return sessionsClient.enumerateDone({ paths: enumerateResult.payload });
+    };
+
+    const acquire = async (acquireInput: AcquireInput) => {
+        const acquireIntentResult = await sessionsClient.acquireIntent({
+            path: acquireInput.path,
+            previous: acquireInput.previous === 'null' ? null : acquireInput.previous,
+        });
+        if (!acquireIntentResult.success) {
+            return acquireIntentResult;
+        }
+        await sessionsClient.acquireDone({ path: acquireInput.path });
+
         return acquireIntentResult;
-    }
-    await sessionsClient.acquireDone({ path: acquireInput.path });
+    };
 
-    return acquireIntentResult;
-};
+    const release = async ({ session, path }: ReleaseInput) => {
+        await sessionsClient.releaseIntent({ session });
+        const sessionsResult = await sessionsClient.getPathBySession({
+            session,
+        });
+        if (!sessionsResult.success) {
+            return sessionsResult;
+        }
 
-export const release = async ({ session, path }: ReleaseInput) => {
-    await sessionsClient.releaseIntent({ session });
-    const sessionsResult = await sessionsClient.getPathBySession({
-        session,
-    });
-    if (!sessionsResult.success) {
-        return sessionsResult;
-    }
+        await api.closeDevice(path);
+        return sessionsClient.releaseDone({ path: sessionsResult.payload.path });
+    };
 
-    await api.closeDevice(path);
-    return sessionsClient.releaseDone({ path: sessionsResult.payload.path });
-};
+    const call = async ({ session, data }: { session: string; data: string }) => {
+        const sessionsResult = await sessionsClient.getPathBySession({
+            session,
+        });
+        if (!sessionsResult.success) {
+            return sessionsResult;
+        }
+        const { path } = sessionsResult.payload;
+        await api.openDevice(path, false);
+        await writeUtil({ path, data });
+        const message = await readUtil({ path });
+        return { success: true as const, payload: message };
+    };
 
-export const call = async ({ session, data }: { session: string; data: string }) => {
-    const sessionsResult = await sessionsClient.getPathBySession({
-        session,
-    });
-    if (!sessionsResult.success) {
-        return sessionsResult;
-    }
-    const { path } = sessionsResult.payload;
-    await api.openDevice(path, false);
-    await writeUtil({ path, data });
-    const message = await readUtil({ path });
-    return { success: true as const, payload: message };
-};
+    const send = async ({ session, data }: { session: string; data: string }) => {
+        const sessionsResult = await sessionsClient.getPathBySession({
+            session,
+        });
 
-export const send = async ({ session, data }: { session: string; data: string }) => {
-    const sessionsResult = await sessionsClient.getPathBySession({
-        session,
-    });
+        if (!sessionsResult.success) {
+            return sessionsResult;
+        }
+        const { path } = sessionsResult.payload;
 
-    if (!sessionsResult.success) {
-        return sessionsResult;
-    }
-    const { path } = sessionsResult.payload;
+        await api.openDevice(path, false);
+        await writeUtil({ path, data });
+        return { success: true as const };
+    };
 
-    await api.openDevice(path, false);
-    await writeUtil({ path, data });
-    return { success: true as const };
-};
+    const receive = async ({ session }: { session: string }) => {
+        const sessionsResult = await sessionsClient.getPathBySession({
+            session,
+        });
 
-export const receive = async ({ session }: { session: string }) => {
-    const sessionsResult = await sessionsClient.getPathBySession({
-        session,
-    });
+        if (!sessionsResult.success) {
+            return sessionsResult;
+        }
+        const { path } = sessionsResult.payload;
 
-    if (!sessionsResult.success) {
-        return sessionsResult;
-    }
-    const { path } = sessionsResult.payload;
+        await api.openDevice(path, false);
 
-    await api.openDevice(path, false);
+        const message = await readUtil({ path });
 
-    const message = await readUtil({ path });
+        return { success: true as const, payload: message };
+    };
 
-    return { success: true as const, payload: message };
+    return {
+        enumerate,
+        acquire,
+        release,
+        call,
+        send,
+        receive,
+    };
 };

--- a/packages/transport-bridge/src/http.ts
+++ b/packages/transport-bridge/src/http.ts
@@ -177,6 +177,14 @@ export class TrezordNode {
 
             app.get('/', [
                 (_req, res) => {
+                    res.writeHead(301, {
+                        Location: `http://127.0.0.1:${this.port}/status`,
+                    });
+                },
+            ]);
+
+            app.get('/status', [
+                (_req, res) => {
                     res.end(`hello, I am bridge in node, version: ${this.version}`);
                 },
             ]);

--- a/packages/transport-bridge/src/http.ts
+++ b/packages/transport-bridge/src/http.ts
@@ -2,7 +2,7 @@ import { HttpServer, parseBodyJSON, parseBodyText, Handler } from '@trezor/node-
 import { Descriptor } from '@trezor/transport/src/types';
 import { arrayPartition } from '@trezor/utils/lib/arrayPartition';
 
-import { sessionsClient, enumerate, acquire, release, call, send, receive } from './core';
+import { sessionsClient, createApi } from './core';
 
 const defaults = {
     port: 21325,
@@ -24,8 +24,9 @@ export class TrezordNode {
     }[];
     port: number;
     server?: HttpServer<never>;
+    api: ReturnType<typeof createApi>;
 
-    constructor({ port }: { port: number }) {
+    constructor({ port, api }: { port: number; api: 'usb' | 'udp' }) {
         this.port = port || defaults.port;
 
         this.descriptors = '{}';
@@ -36,6 +37,7 @@ export class TrezordNode {
         sessionsClient.on('descriptors', descriptors => {
             this.resolveListenSubscriptions(descriptors);
         });
+        this.api = createApi(api);
     }
 
     private resolveListenSubscriptions(descriptors: Descriptor[]) {
@@ -65,7 +67,8 @@ export class TrezordNode {
             app.post('/enumerate', [
                 (_req, res) => {
                     res.setHeader('Content-Type', 'text/plain');
-                    enumerate()
+                    this.api
+                        .enumerate()
                         .then(result => {
                             if (!result.success) {
                                 throw new Error(result.error);
@@ -95,49 +98,57 @@ export class TrezordNode {
             app.post('/acquire/:path/:previous', [
                 (req, res) => {
                     res.setHeader('Content-Type', 'text/plain');
-                    acquire({ path: req.params.path, previous: req.params.previous }).then(
-                        result => {
+                    this.api
+                        .acquire({ path: req.params.path, previous: req.params.previous })
+                        .then(result => {
                             if (!result.success) {
                                 return res.end(str({ error: result.error }));
                             }
                             res.end(str({ session: result.payload.session }));
-                        },
-                    );
+                        });
                 },
             ]);
 
             app.post('/release/:session', [
                 parseBodyText,
                 (req, res) => {
-                    // todo:
-                    // @ts-expect-error
-                    release({ session: req.params.session, path: req.body }).then(result => {
-                        if (!result.success) {
-                            return res.end(str({ error: result.error }));
-                        }
-                        res.end(str({ session: req.params.session }));
-                    });
+                    this.api
+                        .release({
+                            session: req.params.session,
+                            // @ts-expect-error
+                            path: req.body,
+                        })
+                        .then(result => {
+                            if (!result.success) {
+                                return res.end(str({ error: result.error }));
+                            }
+                            res.end(str({ session: req.params.session }));
+                        });
                 },
             ]);
 
             app.post('/call/:session', [
                 parseBodyText,
                 (req, res) => {
-                    // todo:
-                    // @ts-expect-error
-                    call({ session: req.params.session, data: req.body }).then(result => {
-                        if (!result.success) {
-                            return res.end(str({ error: result.error }));
-                        }
-                        res.end(str(result.payload));
-                    });
+                    this.api
+                        .call({
+                            session: req.params.session,
+                            // @ts-expect-error
+                            data: req.body,
+                        })
+                        .then(result => {
+                            if (!result.success) {
+                                return res.end(str({ error: result.error }));
+                            }
+                            res.end(str(result.payload));
+                        });
                 },
             ]);
 
             app.post('/read/:session', [
                 parseBodyJSON,
                 (req, res) => {
-                    receive({ session: req.params.session }).then(result => {
+                    this.api.receive({ session: req.params.session }).then(result => {
                         if (!result.success) {
                             return res.end(str({ error: result.error }));
                         }
@@ -149,14 +160,18 @@ export class TrezordNode {
             app.post('/post/:session', [
                 parseBodyJSON,
                 (req, res) => {
-                    // todo:
-                    // @ts-expect-error
-                    send({ session: req.params.session, data: req.body }).then(result => {
-                        if (!result.success) {
-                            return res.end(str({ error: result.error }));
-                        }
-                        res.end();
-                    });
+                    this.api
+                        .send({
+                            session: req.params.session,
+                            // @ts-expect-error
+                            data: req.body,
+                        })
+                        .then(result => {
+                            if (!result.success) {
+                                return res.end(str({ error: result.error }));
+                            }
+                            res.end();
+                        });
                 },
             ]);
 

--- a/packages/trezor-user-env-link/src/api.ts
+++ b/packages/trezor-user-env-link/src/api.ts
@@ -40,10 +40,6 @@ interface ReadAndConfirmShamirMnemonicEmu {
     threshold: number;
 }
 
-// remember which version was bridge last started with and reuse it on other places where
-// bridge is started and stopped implicitly (setupEmu)
-let bridgeVersion: string | undefined;
-
 export const api = (controller: any) => ({
     setupEmu: async (options: SetupEmu) => {
         const defaults = {
@@ -65,7 +61,7 @@ export const api = (controller: any) => ({
             ...defaults,
             ...options,
         });
-        await controller.send({ type: 'bridge-start', version: bridgeVersion });
+
         return null;
     },
     sendToAddressAndMineBlock: async (options: SendToAddressAndMineBlock) => {
@@ -90,7 +86,6 @@ export const api = (controller: any) => ({
         return null;
     },
     startBridge: async (version?: string) => {
-        bridgeVersion = version;
         await controller.send({ type: 'bridge-start', version });
         return null;
     },


### PR DESCRIPTION
lets start using --bridge-node in e2e tests in desktop. this is part of broader effort aiming to get more confidence with the new node bridge.

b22d429322 chore(trezor-user-env-link): no implicit bridge start. this was some utility tight coupling from old times when this code was part of cypress for suite test. 
f868f6c397 feat(transport-bridge): add /status endpoint
ec0120f1e9 test(suite-desktop): use --brige-node-test that would run node-bridge in suite-desktop core using Udp
6807fe6020 feat(transport-bridge): support emulator. option to start node bridge using Udp

Followups:
 - The ultimate solution should be achieved in  #10563 (support for multiple transports at once)

passed in https://gitlab.com/satoshilabs/trezor/trezor-suite/-/pipelines/1178996758