### PR TITLE
style(suite): Fix onboarding styles

### DIFF
--- a/packages/suite/src/components/backup/BackupSeedCard.tsx
+++ b/packages/suite/src/components/backup/BackupSeedCard.tsx
@@ -10,18 +10,19 @@ const StyledCheckbox = styled(Checkbox)`
     left: 0;
     height: 100%;
     width: 100%;
-
     > div {
         position: absolute;
 
         /* Card padding */
-        bottom: ${spacingsPx.sm};
+        top: ${spacingsPx.lg};
         left: ${spacingsPx.sm};
     }
 
-    ${variables.SCREEN_QUERY.MOBILE} {
+    ${variables.SCREEN_QUERY.ABOVE_MOBILE} {
         > div {
-            bottom: auto;
+            top: auto;
+            bottom: ${spacingsPx.md};
+            left: ${spacingsPx.lg};
         }
     }
 `;

--- a/packages/suite/src/components/backup/BackupSeedCard.tsx
+++ b/packages/suite/src/components/backup/BackupSeedCard.tsx
@@ -10,6 +10,7 @@ const StyledCheckbox = styled(Checkbox)`
     left: 0;
     height: 100%;
     width: 100%;
+
     > div {
         position: absolute;
 

--- a/packages/suite/src/views/onboarding/steps/Final.tsx
+++ b/packages/suite/src/views/onboarding/steps/Final.tsx
@@ -5,7 +5,6 @@ import { analytics, EventType } from '@trezor/suite-analytics';
 
 import {
     Button,
-    Icon,
     variables,
     Dropdown,
     DropdownRef,
@@ -19,36 +18,7 @@ import { DEFAULT_LABEL } from 'src/constants/suite/device';
 import { isHomescreenSupportedOnDevice } from 'src/utils/suite/homescreen';
 import { selectIsActionAbortable } from 'src/reducers/suite/suiteReducer';
 import { ChangeDeviceLabel } from 'src/components/suite/ChangeDeviceLabel';
-import { borders, spacingsPx, typography } from '@trezor/theme';
-
-const StyledButton = styled(Button)`
-    display: flex;
-    padding: ${spacingsPx.sm} ${spacingsPx.md};
-    height: 42px;
-    border: 1px solid ${({ theme }) => theme.borderOnElevation1};
-    border-radius: ${borders.radii.xxs};
-    align-items: center;
-    cursor: pointer;
-    background-color: transparent;
-    ${typography.hint}
-
-    :not(:disabled) {
-        color: ${({ theme }) => theme.TYPE_DARK_GREY};
-    }
-
-    :hover,
-    :focus {
-        background-color: transparent;
-        color: initial;
-    }
-`;
-
-const StyledIcon = styled(Icon)`
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    margin: auto ${spacingsPx.md} auto 0;
-`;
+import { spacingsPx, typography } from '@trezor/theme';
 
 const Content = styled.div`
     flex-direction: column;
@@ -187,13 +157,15 @@ export const FinalStep = () => {
                     </Heading>
                     {!state && (
                         <SetupActions>
-                            <StyledButton
+                            <Button
+                                variant="tertiary"
+                                size="small"
+                                icon="PENCIL"
                                 onClick={() => setState('rename')}
                                 isDisabled={isWaitingForConfirm}
                             >
-                                <StyledIcon size={16} icon="PENCIL" />
                                 <Translation id="TR_DEVICE_SETTINGS_DEVICE_EDIT_LABEL" />
-                            </StyledButton>
+                            </Button>
 
                             <Tooltip
                                 maxWidth={285}
@@ -217,10 +189,14 @@ export const FinalStep = () => {
                                         </GalleryWrapper>
                                     }
                                 >
-                                    <StyledButton onClick={() => setState(null)}>
-                                        <StyledIcon size={16} icon="DASHBOARD" />
+                                    <Button
+                                        variant="tertiary"
+                                        size="small"
+                                        onClick={() => setState(null)}
+                                        icon="DASHBOARD"
+                                    >
                                         <Translation id="TR_ONBOARDING_FINAL_CHANGE_HOMESCREEN" />
-                                    </StyledButton>
+                                    </Button>
                                 </Dropdown>
                             </Tooltip>
                         </SetupActions>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve #11111 

## Screenshots:
<img width="434" alt="image" src="https://github.com/trezor/trezor-suite/assets/858321/9bc5cd3e-936d-4a4e-98ef-f444c01a6004">

<img width="629" alt="image" src="https://github.com/trezor/trezor-suite/assets/858321/0b735cb2-8cdf-4967-a9b8-9cf98f7693c8">

<img width="882" alt="image" src="https://github.com/trezor/trezor-suite/assets/858321/040e5c84-c51b-429d-b6ff-d9f796d081fd">



**Also fixing this:**

Before:
<img width="1009" alt="Screenshot 2024-02-12 at 16 36 50" src="https://github.com/trezor/trezor-suite/assets/858321/a73ba42d-65b0-414d-8d6e-67e22f54a0ea">

After:
<img width="1008" alt="Screenshot 2024-02-13 at 13 42 07" src="https://github.com/trezor/trezor-suite/assets/858321/89af2fac-3d6b-4bcc-b8f1-d95476383519">
