### PR TITLE
fix(protobuf): codegen devdependencies

### DIFF
--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -25,8 +25,8 @@
         "test:unit": "yarn g:jest -c ../../jest.config.base.js",
         "type-check": "yarn g:tsc --build",
         "build:lib": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json",
-        "update:schema": "yarn workspace @trezor/schema-utils codegen $(pwd)/src/messages.ts > src/messages-schema.ts && npx prettier --write src/messages-schema.ts && eslint --fix src/messages-schema.ts",
-        "update:protobuf": "./scripts/protobuf-build.sh && npx prettier --write \"{messages.json,src/messages.ts}\"",
+        "update:schema": "yarn workspace @trezor/schema-utils codegen $(pwd)/src/messages.ts > src/messages-schema.ts && yarn g:prettier --write src/messages-schema.ts && yarn g:eslint --fix src/messages-schema.ts",
+        "update:protobuf": "./scripts/protobuf-build.sh && yarn g:prettier --write \"{messages.json,src/messages.ts}\"",
         "prepublishOnly": "yarn g:tsx ../../scripts/prepublishNPM.js",
         "prepublish": "yarn g:tsx ../../scripts/prepublish.js"
     },

--- a/packages/schema-utils/package.json
+++ b/packages/schema-utils/package.json
@@ -18,7 +18,8 @@
         "prepublish": "yarn g:tsx ../../scripts/prepublish.js"
     },
     "devDependencies": {
-        "@sinclair/typebox-codegen": "^0.8.13"
+        "@sinclair/typebox-codegen": "^0.8.13",
+        "ts-node": "^10.9.2"
     },
     "dependencies": {
         "@sinclair/typebox": "^0.31.28",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9457,6 +9457,7 @@ __metadata:
     "@sinclair/typebox": "npm:^0.31.28"
     "@sinclair/typebox-codegen": "npm:^0.8.13"
     ts-mixer: "npm:^6.0.3"
+    ts-node: "npm:^10.9.2"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description

- fix missing devDependency on ts-node in schema-utils
- use global instances of other tools in protobuf