### PR TITLE
Don't call `toMessageObject` on `undefined` device

### DIFF
--- a/packages/connect/e2e/jest.config.ts
+++ b/packages/connect/e2e/jest.config.ts
@@ -1,7 +1,7 @@
 export default {
     rootDir: './',
     moduleFileExtensions: ['ts', 'js'],
-    modulePathIgnorePatterns: ['node_modules'],
+    modulePathIgnorePatterns: ['node_modules', '__mocks__'],
     setupFilesAfterEnv: ['<rootDir>/e2e/jest.setup.js', '<rootDir>/e2e/common.setup.js'],
     globalSetup: '<rootDir>/e2e/jest.globalSetup.js',
     globalTeardown: '<rootDir>/e2e/jest.globalTeardown.js',

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -247,8 +247,8 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> {
                     d.forEach(descriptor => {
                         const path = descriptor.path.toString();
                         const device = this.devices[path];
-                        _log.debug('Event', e, device.toMessageObject());
                         if (device) {
+                            _log.debug('Event', e, device.toMessageObject());
                             this.emit(e, device.toMessageObject());
                         }
                     });


### PR DESCRIPTION
## Description

Moved a line with logging so `device.toMessageObject` is called only when device is defined. This could resolve #9904, at least according to the simulated stack trace:
```
    at eval (webpack://@trezor/suite-desktop-core/../connect/src/device/DeviceList.ts?:204:30)
    at Array.forEach (<anonymous>)
    at eval (webpack://@trezor/suite-desktop-core/../connect/src/device/DeviceList.ts?:201:13)
    at Array.forEach (<anonymous>)
    at NodeUsbTransport.eval (webpack://@trezor/suite-desktop-core/../connect/src/device/DeviceList.ts?:197:16)
    at NodeUsbTransport.emit (node:events:514:28)
    at NodeUsbTransport.emit (node:domain:489:12)
    at NodeUsbTransport.handleDescriptorsChange (webpack://@trezor/suite-desktop-core/../transport/lib/transports/abstract.js?:160:10)
    at NodeUsbTransport.eval (webpack://@trezor/suite-desktop-core/../transport/lib/transports/abstractApi.js?:51:12)
    at Generator.next (<anonymous>)
```
## Related Issue

Could resolve #9904
