### PR TITLE
Refine language names

### DIFF
--- a/packages/suite/src/config/suite/languages.ts
+++ b/packages/suite/src/config/suite/languages.ts
@@ -23,7 +23,7 @@ const LANGUAGES = {
     nl: { name: 'Nederlands', en: 'Dutch' },
     no: { name: 'Norsk', en: 'Norwegian' },
     pl: { name: 'Polski', en: 'Polish' },
-    pt: { name: 'Português', en: 'Portuguese', type: 'community' },
+    pt: { name: 'Português (BR)', en: 'Portuguese (BR)', type: 'community' },
     ro: { name: 'Română', en: 'Romanian' },
     ru: { name: 'Русский', en: 'Russian', type: 'community' },
     sk: { name: 'Slovenčina', en: 'Slovak' },

--- a/packages/suite/src/config/suite/languages.ts
+++ b/packages/suite/src/config/suite/languages.ts
@@ -17,7 +17,7 @@ const LANGUAGES = {
     hu: { name: 'Magyar', en: 'Hungarian', type: 'community' },
     id: { name: 'Bahasa Indonesia', en: 'Indonesian' },
     it: { name: 'Italiano', en: 'Italian', type: 'community' },
-    ja: { name: '日本語（ベータ版）', en: 'Japanese', type: 'community' },
+    ja: { name: '日本語', en: 'Japanese', type: 'community' },
     jv: { name: 'Basa Jawa', en: 'Javanese' },
     ko: { name: '한국어', en: 'Korean' },
     nl: { name: 'Nederlands', en: 'Dutch' },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- Specify Portuguese as Brazilian (This is inconsistent with other languages which do not specify region, but requested by @Hermez-cz.)
-  Remove the beta attribute from Japanese, it is not needed as it is clearly marked as a community language.

## Screenshots:
![Screenshot 2024-02-14 at 15 22 20](https://github.com/trezor/trezor-suite/assets/42465546/39d0782d-0989-408e-a324-e13fa1e9574c)

