### PR TITLE
fix(suite): #11146 inconsistent border radius in firmware install

### DIFF
--- a/packages/suite/src/components/firmware/FirmwareProgressBar.tsx
+++ b/packages/suite/src/components/firmware/FirmwareProgressBar.tsx
@@ -12,6 +12,12 @@ const Wrapper = styled.div`
     font-size: ${variables.FONT_SIZE.SMALL};
     color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     align-items: center;
+
+    ${variables.SCREEN_QUERY.ABOVE_LAPTOP} {
+        &:last-child {
+            border-radius: 0 0 ${borders.radii.md} ${borders.radii.md};
+        }
+    }
 `;
 
 const Label = styled.div`


### PR DESCRIPTION
## Description

When the FirmwareProgressBar component is the last child and it's above laptop viewport (there is no padding), the border radius was inconsistent with the parent component. 
This change makes it the same for this case.  

## Related Issue

Resolve #11146

## Screenshots:
<img width="638" alt="Screenshot 2024-02-14 at 15 27 31" src="https://github.com/trezor/trezor-suite/assets/8833813/40af6c40-a560-448f-bfa6-ab9a167d17b9">
