### PR TITLE
fix(suite): #10877 timerange dropdown border

### DIFF
--- a/packages/components/src/components/Timerange/Timerange.tsx
+++ b/packages/components/src/components/Timerange/Timerange.tsx
@@ -420,6 +420,7 @@ const StyledTimerange = styled.div`
     flex-direction: column;
     background: ${({ theme }) => theme.backgroundSurfaceElevation1};
     border-radius: ${borders.radii.sm};
+    margin: -${spacingsPx.sm};
 
     ${mediaQueries.dark_theme} {
         border: 1px solid ${({ theme }) => theme.borderOnElevation0};
@@ -466,7 +467,6 @@ const Calendar = styled.div`
     .rdrDateDisplayItem {
         border-radius: ${borders.radii.xxs};
         background-color: transparent;
-        border: 1px solid ${({ theme }) => theme.borderOnElevation1};
     }
 
     .rdrDateDisplayItem input {
@@ -572,6 +572,7 @@ const Calendar = styled.div`
         padding-bottom: ${spacingsPx.sm};
         background: ${({ theme }) => theme.backgroundSurfaceElevation3};
         border-bottom: 1px solid ${({ theme }) => theme.borderOnElevation1};
+        border-radius: ${borders.radii.xs};
     }
 
     .rdrMonthAndYearWrapper {


### PR DESCRIPTION
## Description

Fix borders and margin in Timerange component

## Related Issue

Resolve #10877

## Screenshots:

<img width="638" alt="Screenshot 2024-02-14 at 16 28 51" src="https://github.com/trezor/trezor-suite/assets/8833813/47448b70-3397-4eb2-8ccc-0bc4e674306f">

<img width="638" alt="Screenshot 2024-02-14 at 16 28 44" src="https://github.com/trezor/trezor-suite/assets/8833813/ab8d3ddb-2eb5-4f37-9e9a-77de4373d7cb">