### PR TITLE
Ignore `__mocks__` in connect e2e tests

### DIFF
--- a/packages/connect/e2e/jest.config.ts
+++ b/packages/connect/e2e/jest.config.ts
@@ -1,7 +1,7 @@
 export default {
     rootDir: './',
     moduleFileExtensions: ['ts', 'js'],
-    modulePathIgnorePatterns: ['node_modules'],
+    modulePathIgnorePatterns: ['node_modules', '__mocks__'],
     setupFilesAfterEnv: ['<rootDir>/e2e/jest.setup.js', '<rootDir>/e2e/common.setup.js'],
     globalSetup: '<rootDir>/e2e/jest.globalSetup.js',
     globalTeardown: '<rootDir>/e2e/jest.globalTeardown.js',


### PR DESCRIPTION
## Description

In #11011 I mocked `BlockchainLink` globally in Connect tests, which unfortunately broke e2e tests. Now `__mocks__` folders are by default ignored in e2e tests.