### PR TITLE
feat(suite-native): production workflow

### DIFF
--- a/.github/workflows/suite-native_production_ci.yml
+++ b/.github/workflows/suite-native_production_ci.yml
@@ -1,23 +1,45 @@
-#name: "[Build] release"
-#
-#on: [pull_request]
-#jobs:
-#  build:
-#    name: Install and build
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - uses: actions/setup-node@v3
-#        with:
-#          node-version-file: ".nvmrc"
-#          cache: yarn
-#      - name: Setup EAS
-#        uses: expo/expo-github-action@v8
-#        with:
-#          eas-version: latest
-#          token: ${{ secrets.EXPO_TOKEN }}
-#      - name: Install libs
-#        run: yarn install
-#      - name: Build on EAS
-#        run: eas build --platform all --profile production --auto-submit --non-interactive
-#        working-directory: suite-native/app
+name: "[Release] suite-native production"
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Install and build
+    environment: production
+    runs-on: ubuntu-latest
+    env:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+          cache: yarn
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+      - name: Install libs
+        run: yarn install
+      - name: Build on EAS iOS
+        run: eas build
+          --platform ios
+          --profile production
+          --non-interactive
+          --auto-submit
+          --message ${{ github.sha }}
+        working-directory: suite-native/app
+      - name: Build on EAS Android
+        run: eas build
+          --platform android
+          --profile production
+          --non-interactive
+          --auto-submit
+          --message ${{ github.sha }}
+        working-directory: suite-native/app

--- a/suite-native/app/app.config.ts
+++ b/suite-native/app/app.config.ts
@@ -59,6 +59,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
         ...config,
         name,
         slug,
+        owner: 'trezorcompany',
         version: suiteNativeVersion,
         splash: {
             image: './assets/splash_icon.png',
@@ -76,6 +77,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
         ios: {
             bundleIdentifier,
             icon: appIconIos,
+            supportsTablet: true,
             infoPlist: {
                 NSCameraUsageDescription:
                     '$(PRODUCT_NAME) needs access to your Camera to scan your XPUB.',
@@ -99,6 +101,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
                         },
                     },
                 },
+                UIRequiredDeviceCapabilities: ['armv7'],
             },
         },
         plugins: [
@@ -145,6 +148,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
             // These should come last
             './plugins/withRemoveXcodeLocalEnv.js',
             ['./plugins/withEnvFile.js', { buildType }],
+            './plugins/withRemoveiOSNotificationEntitlement.js',
         ],
         extra: {
             commitHash: process.env.EAS_BUILD_GIT_COMMIT_HASH || '',
@@ -152,6 +156,5 @@ export default ({ config }: ConfigContext): ExpoConfig => {
                 projectId,
             },
         },
-        owner: 'trezorcompany',
     };
 };

--- a/suite-native/app/eas.json
+++ b/suite-native/app/eas.json
@@ -1,8 +1,8 @@
 {
     "cli": {
         "version": ">= 7.1.1",
-        "promptToConfigurePushNotifications": false,
-        "appVersionSource": "remote"
+        "appVersionSource": "remote",
+        "promptToConfigurePushNotifications": false
     },
     "build": {
         "develop": {
@@ -32,10 +32,6 @@
     },
     "submit": {
         "develop": {
-            "android": {
-                "track": "internal",
-                "changesNotSentForReview": true
-            },
             "ios": {
                 "bundleIdentifier": "io.trezor.suite.develop",
                 "ascAppId": "1631884497",

--- a/suite-native/app/plugins/withRemoveiOSNotificationEntitlement.js
+++ b/suite-native/app/plugins/withRemoveiOSNotificationEntitlement.js
@@ -1,0 +1,13 @@
+const { withEntitlementsPlist } = require('expo/config-plugins');
+
+// This disables push notifications. Even though we have them turned off by default
+// eas fails in Fastlane step because there is some legacy bug.
+// More here: https://github.com/expo/eas-cli/issues/987
+const withRemoveiOSNotificationEntitlement = config => {
+    return withEntitlementsPlist(config, mod => {
+        delete mod.modResults['aps-environment'];
+        return mod;
+    });
+};
+
+module.exports = withRemoveiOSNotificationEntitlement;

--- a/suite-native/app/upload-to-firebase.sh
+++ b/suite-native/app/upload-to-firebase.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then
-  curl -sL https://firebase.tools | bash
+  if [[ "$EAS_BUILD_PROFILE" == "develop" ]]; then
+    curl -sL https://firebase.tools | bash
 
   release_notes="Last commit hash: $EAS_BUILD_GIT_COMMIT_HASH"
   echo "$EAS_BUILD_GIT_COMMIT_HASH"
@@ -11,6 +12,7 @@ if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then
     --groups "develop-testers" \
     --release-notes "$release_notes" \
     --token "$FIREBASE_TOKEN"
+  fi
 elif [[ "$EAS_BUILD_PLATFORM" == "ios" ]]; then
   exit 0
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Enable EAS to build and submit production build on iOS and Android. 

Had to create a plugin to remove push notification ios settings, tweak some stuff in `app.config.ts`.

## Related Issue
https://github.com/trezor/trezor-suite/issues/10789

## Screenshots:
