### PR TITLE
small scripts/ci fixes

### DIFF
--- a/ci/utils.yml
+++ b/ci/utils.yml
@@ -96,3 +96,13 @@ test unit manual:
   when: manual
   except:
     <<: *run_everything_rules
+
+test protobuf nightly:
+  stage: utils
+  only:
+    <<: *run_everything_rules
+  needs: []
+  script:
+    - yarn install --immutable
+    - yarn workspace @trezor/protobuf update:protobuf
+    - yarn workspace @trezor/protobuf update:schema

--- a/packages/transport-bridge/package.json
+++ b/packages/transport-bridge/package.json
@@ -8,8 +8,8 @@
     "scripts": {
         "type-check": "yarn g:tsc --build",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
-        "build:js": "rimraf ./dist && yarn esbuild ./src/bin.ts --bundle --outfile=dist/bin.js --platform=node --target=node18 --external:usb",
-        "build:bin": "rimraf -rf build && yarn pkg ./dist/bin.js --config package.json",
+        "build:js": "yarn g:rimraf ./dist && yarn esbuild ./src/bin.ts --bundle --outfile=dist/bin.js --platform=node --target=node18 --external:usb",
+        "build:bin": "yarn g:rimraf -rf build && yarn pkg ./dist/bin.js --config package.json",
         "build": "yarn build:js && yarn build:bin"
     },
     "devDependencies": {


### PR DESCRIPTION
- global rimraf to fix failing build job
- add nighly test for codegen scripts in protobuf. they may break during monorepo refactoring without noticing