### PR TITLE
fix(suite-native): shorten commit hash

### DIFF
--- a/.github/workflows/suite-native_develop_ci.yml
+++ b/.github/workflows/suite-native_develop_ci.yml
@@ -38,6 +38,7 @@ jobs:
           --profile develop
           --non-interactive
           --no-wait
+          --message ${{ github.event.head_commit.message }} ${{ github.sha }}
         working-directory: suite-native/app
       - name: Build on EAS iOS
         run: eas build
@@ -46,4 +47,5 @@ jobs:
           --non-interactive
           --auto-submit
           --no-wait
+          --message ${{ github.event.head_commit.message }} ${{ github.sha }}
         working-directory: suite-native/app

--- a/suite-native/app/app.config.ts
+++ b/suite-native/app/app.config.ts
@@ -147,7 +147,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
             ['./plugins/withEnvFile.js', { buildType }],
         ],
         extra: {
-            commitHash: process.env.EAS_BUILD_GIT_COMMIT_HASH?.substring(-6) || '',
+            commitHash: process.env.EAS_BUILD_GIT_COMMIT_HASH || '',
             eas: {
                 projectId,
             },

--- a/suite-native/app/upload-to-firebase.sh
+++ b/suite-native/app/upload-to-firebase.sh
@@ -3,9 +3,8 @@
 if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then
   curl -sL https://firebase.tools | bash
 
-  commit_hash=$(git log -1 --pretty=format:"%H")
-  release_notes="Bug fixes and improvements. Last commit hash: $commit_hash"
-
+  release_notes="Last commit hash: $EAS_BUILD_GIT_COMMIT_HASH"
+  echo "$EAS_BUILD_GIT_COMMIT_HASH"
   firebase appdistribution:distribute "$EAS_BUILD_WORKINGDIR"/suite-native/app/android/app/build/outputs/apk/release/app-release.apk \
     --project pc-api-4710771878548015996-769 \
     --app 1:191883890128:android:625bcdab76b3b3a644bdd5 \

--- a/suite-native/module-settings/src/components/AppVersion.tsx
+++ b/suite-native/module-settings/src/components/AppVersion.tsx
@@ -17,7 +17,7 @@ export const AppVersion = () => (
         <ProductionDebug>
             {S.isNotEmpty(getCommitHash()) && (
                 <Text variant="hint" color="textDisabled">
-                    Last commit hash: {getCommitHash()}
+                    Last commit hash: {getCommitHash().slice(-7)}
                 </Text>
             )}
         </ProductionDebug>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- shorten commit hash in FAQ screen
- add commit hash to build run in expo for matching
- add commit hash to firebase release notes


## Related Issue
https://github.com/trezor/trezor-suite/issues/10789

## Screenshots:
