### PR TITLE
fix(connect): set min version for rebootToBootloader to correct value

### DIFF
--- a/packages/connect/src/data/config.ts
+++ b/packages/connect/src/data/config.ts
@@ -211,7 +211,7 @@ export const config = {
         },
         {
             methods: ['rebootToBootloader'],
-            min: { T1B1: '1.11.0', T2T1: '2.6.0' },
+            min: { T1B1: '1.10.0', T2T1: '2.6.0' },
         },
         {
             methods: ['getFirmwareHash'],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
I knew this was a Connect bug :)

This fix re-enables rebooting to bootloader for FW 1.10

The bug originated from a copy-paste error in [this commit](https://github.com/trezor/trezor-suite/commit/34aefbd62152d171ca866613b4e930f23ad821d0). 👀 @szymonlesisz
## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/10776
