### PR TITLE
feat(suite-native): Add coin account via receive

### DIFF
--- a/suite-native/accounts/src/components/AddAccountsButton.tsx
+++ b/suite-native/accounts/src/components/AddAccountsButton.tsx
@@ -4,6 +4,7 @@ import { useNavigation } from '@react-navigation/native';
 
 import {
     AccountsImportStackRoutes,
+    AddCoinAccountStackRoutes,
     RootStackParamList,
     RootStackRoutes,
     StackNavigationProps,
@@ -22,7 +23,13 @@ export const AddAccountButton = () => {
         });
     };
 
-    const navigateToAddCoinAccount = () => navigation.navigate(RootStackRoutes.AddCoinAccountStack);
+    const navigateToAddCoinAccount = () =>
+        navigation.navigate(RootStackRoutes.AddCoinAccountStack, {
+            screen: AddCoinAccountStackRoutes.AddCoinAccount,
+            params: {
+                flowType: 'accounts',
+            },
+        });
 
     return (
         <IconButton

--- a/suite-native/accounts/src/components/SearchableAccountsListScreenHeader.tsx
+++ b/suite-native/accounts/src/components/SearchableAccountsListScreenHeader.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useState } from 'react';
+import { useState } from 'react';
 import Animated, {
     EntryExitAnimationFunction,
     FadeOut,
@@ -6,17 +6,22 @@ import Animated, {
     withDelay,
     withTiming,
 } from 'react-native-reanimated';
+import { useSelector } from 'react-redux';
 
 import { ScreenSubHeader } from '@suite-native/navigation';
 import { Box, IconButton } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+import {
+    selectAreAllDevicesDisconnectedOrAccountless,
+    selectDeviceDiscovery,
+} from '@suite-common/wallet-core';
 
 import { AccountsSearchForm, SEARCH_INPUT_ANIMATION_DURATION } from './AccountsSearchForm';
+import { AddAccountButton } from './AddAccountsButton';
 
 type SearchableAccountsListScreenHeaderProps = {
     title: string;
     onSearchInputChange: (value: string) => void;
-    rightIcon?: ReactNode;
 };
 
 const HEADER_ANIMATION_DURATION = 100;
@@ -30,11 +35,14 @@ const searchFormContainerStyle = prepareNativeStyle(utils => ({
 export const SearchableAccountsListScreenHeader = ({
     title,
     onSearchInputChange,
-    rightIcon,
 }: SearchableAccountsListScreenHeaderProps) => {
     const isFirstRender = useSharedValue(true);
     const { applyStyle } = useNativeStyles();
 
+    const discovery = useSelector(selectDeviceDiscovery);
+    const areAllDevicesDisconnectedOrAccountless = useSelector(
+        selectAreAllDevicesDisconnectedOrAccountless,
+    );
     const [isSearchActive, setIsSearchActive] = useState(false);
 
     const handleHideFilter = () => {
@@ -78,7 +86,10 @@ export const SearchableAccountsListScreenHeader = ({
                 >
                     <ScreenSubHeader
                         content={title}
-                        rightIcon={rightIcon}
+                        rightIcon={
+                            !areAllDevicesDisconnectedOrAccountless &&
+                            !discovery && <AddAccountButton />
+                        }
                         leftIcon={
                             <IconButton
                                 iconName="search"

--- a/suite-native/accounts/src/index.ts
+++ b/suite-native/accounts/src/index.ts
@@ -1,3 +1,4 @@
+export * from './components/AddAccountsButton';
 export * from './components/AccountsList';
 export * from './components/AccountsListGroup';
 export * from './components/AccountListItem';

--- a/suite-native/atoms/src/BulletListItem.tsx
+++ b/suite-native/atoms/src/BulletListItem.tsx
@@ -1,3 +1,5 @@
+import { ReactNode } from 'react';
+
 import { Color, TypographyStyle } from '@trezor/theme';
 
 import { Box } from './Box';
@@ -6,7 +8,7 @@ import { Text } from './Text';
 const INDENTED_BULLET_POINT_SYMBOL = ' \u2022 ';
 
 type BulletListItemProps = {
-    children: string;
+    children: ReactNode;
     variant?: TypographyStyle;
     color?: Color;
 };

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -171,6 +171,11 @@ export const en = {
                 actionSecondary: 'Learn more',
                 actionSecondaryUrl: 'https://trezor.io/learn/a/multiple-accounts-in-trezor-suite',
             },
+            generalError: {
+                title: 'We couldn’t add your account.',
+                description: 'There’s been an unknown technical issue on our end.',
+                actionPrimary: 'Close',
+            },
         },
         accountTypeDecisionBootomSheet: {
             title: 'Add <coin></coin> account',

--- a/suite-native/module-accounts-management/src/screens/AccountsScreen.tsx
+++ b/suite-native/module-accounts-management/src/screens/AccountsScreen.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
@@ -12,22 +11,10 @@ import {
 } from '@suite-native/navigation';
 import { AccountsList, SearchableAccountsListScreenHeader } from '@suite-native/accounts';
 import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
-import {
-    selectAreAllDevicesDisconnectedOrAccountless,
-    selectDeviceDiscovery,
-} from '@suite-common/wallet-core';
-
-import { AddAccountButton } from '../components/AddAccountsButton';
 
 export const AccountsScreen = () => {
     const navigation =
         useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes.AccountDetail>>();
-
-    const areAllDevicesDisconnectedOrAccountless = useSelector(
-        selectAreAllDevicesDisconnectedOrAccountless,
-    );
-
-    const discovery = useSelector(selectDeviceDiscovery);
 
     const [accountsFilterValue, setAccountsFilterValue] = useState<string>('');
 
@@ -49,10 +36,6 @@ export const AccountsScreen = () => {
                 <SearchableAccountsListScreenHeader
                     title="My assets"
                     onSearchInputChange={handleFilterChange}
-                    rightIcon={
-                        !areAllDevicesDisconnectedOrAccountless &&
-                        !discovery && <AddAccountButton />
-                    }
                 />
             }
         >

--- a/suite-native/module-add-accounts/src/screens/AddCoinAccountScreen.tsx
+++ b/suite-native/module-add-accounts/src/screens/AddCoinAccountScreen.tsx
@@ -1,6 +1,12 @@
 import { G } from '@mobily/ts-belt';
 
-import { Screen, ScreenSubHeader } from '@suite-native/navigation';
+import {
+    AddCoinAccountStackParamList,
+    AddCoinAccountStackRoutes,
+    Screen,
+    ScreenSubHeader,
+    StackProps,
+} from '@suite-native/navigation';
 import { Card, VStack } from '@suite-native/atoms';
 import { useTranslate } from '@suite-native/intl';
 import { SelectableNetworkItem } from '@suite-native/accounts';
@@ -8,7 +14,9 @@ import { SelectableNetworkItem } from '@suite-native/accounts';
 import { accountTypeTranslationKeys, useAddCoinAccount } from '../hooks/useAddCoinAccount';
 import { AccountTypeDecisionBootomSheet } from '../components/AccountTypeDecisionBootomSheet';
 
-export const AddCoinAccountScreen = () => {
+export const AddCoinAccountScreen = ({
+    route,
+}: StackProps<AddCoinAccountStackParamList, AddCoinAccountStackRoutes.AddCoinAccount>) => {
     const { translate } = useTranslate();
 
     const {
@@ -20,13 +28,15 @@ export const AddCoinAccountScreen = () => {
         addCoinAccount,
     } = useAddCoinAccount();
 
+    const { flowType } = route.params;
+
     const accountTypeName = networkWithTypeToBeAdded
         ? translate(accountTypeTranslationKeys[networkWithTypeToBeAdded[1]].titleKey)
         : '';
 
     const handleTypeSelectionTap = () => {
         if (networkWithTypeToBeAdded) {
-            navigateToAccountTypeSelectionScreen(networkWithTypeToBeAdded[0]);
+            navigateToAccountTypeSelectionScreen(networkWithTypeToBeAdded[0], flowType);
         }
     };
 
@@ -35,6 +45,7 @@ export const AddCoinAccountScreen = () => {
             addCoinAccount({
                 network: networkWithTypeToBeAdded[0],
                 accountType: networkWithTypeToBeAdded[1],
+                flowType,
             });
         }
     };
@@ -49,12 +60,17 @@ export const AddCoinAccountScreen = () => {
         >
             <Card>
                 <VStack spacing="large">
-                    {supportedNetworkSymbols.map(symbol => (
+                    {supportedNetworkSymbols.map(networkSymbol => (
                         <SelectableNetworkItem
-                            key={symbol}
-                            symbol={symbol}
-                            data-testID={`@add-account/select-coin/${symbol}`}
-                            onPress={onSelectedNetworkItem}
+                            key={networkSymbol}
+                            symbol={networkSymbol}
+                            data-testID={`@add-account/select-coin/${networkSymbol}`}
+                            onPress={() =>
+                                onSelectedNetworkItem({
+                                    networkSymbol,
+                                    flowType,
+                                })
+                            }
                         />
                     ))}
                 </VStack>

--- a/suite-native/module-add-accounts/src/screens/SelectAccountTypeScreen.tsx
+++ b/suite-native/module-add-accounts/src/screens/SelectAccountTypeScreen.tsx
@@ -2,20 +2,26 @@ import { useState } from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { View } from 'react-native';
 
-import { useNavigation } from '@react-navigation/native';
 import { LinearGradient } from 'expo-linear-gradient';
 
 import { useNativeStyles, prepareNativeStyle } from '@trezor/styles';
 import { AccountType } from '@suite-common/wallet-config';
 import {
-    StackNavigationProps,
     AddCoinAccountStackParamList,
     AddCoinAccountStackRoutes,
     Screen,
     ScreenSubHeader,
     StackProps,
 } from '@suite-native/navigation';
-import { Button, VStack, Text, IconButton, Box, SelectableItem } from '@suite-native/atoms';
+import {
+    Button,
+    VStack,
+    Text,
+    IconButton,
+    SelectableItem,
+    BulletListItem,
+    Box,
+} from '@suite-native/atoms';
 import { useTranslate, Translation, TxKeyPath } from '@suite-native/intl';
 import { useOpenLink } from '@suite-native/link';
 
@@ -29,22 +35,22 @@ const EXTRA_BOTTOM_PADDING = 48;
 const ACCOUNT_TYPES_URL = 'https://trezor.io/learn/a/multiple-accounts-in-trezor-suite';
 
 const bulletsForKeyPath = (keyPath: TxKeyPath) => (
-    <Translation
-        id={keyPath}
-        values={{
-            li: chunks =>
-                chunks.map(row => (
-                    <Box flexDirection="row">
-                        <Text variant="hint" color="textSubdued">
-                            {'  '}•{'  '}
-                        </Text>
-                        <Text variant="hint" color="textSubdued">
-                            {row}
-                        </Text>
-                    </Box>
-                )),
-        }}
-    />
+    <Box paddingLeft="small">
+        <Translation
+            id={keyPath}
+            values={{
+                li: chunks =>
+                    chunks.map(
+                        row =>
+                            row && (
+                                <BulletListItem key={`${row}`} variant="hint" color="textSubdued">
+                                    {row}
+                                </BulletListItem>
+                            ),
+                    ),
+            }}
+        />
+    </Box>
 );
 
 const itemsStyle = prepareNativeStyle(utils => ({
@@ -78,19 +84,13 @@ const aboutStyle = prepareNativeStyle((utils, { bottomInset }: { bottomInset: nu
 
 export const SelectAccountTypeScreen = ({
     route,
+    navigation,
 }: StackProps<AddCoinAccountStackParamList, AddCoinAccountStackRoutes.SelectAccountType>) => {
-    const { accountType: defaultType, network } = route.params;
+    const { accountType: defaultType, network, flowType } = route.params;
     const { translate } = useTranslate();
     const openLink = useOpenLink();
     const insets = useSafeAreaInsets();
     const { applyStyle, utils } = useNativeStyles();
-    const navigation =
-        useNavigation<
-            StackNavigationProps<
-                AddCoinAccountStackParamList,
-                AddCoinAccountStackRoutes.SelectAccountType
-            >
-        >();
 
     const { getAvailableAccountTypesForNetwork, addCoinAccount } = useAddCoinAccount();
 
@@ -103,9 +103,8 @@ export const SelectAccountTypeScreen = ({
 
     const handleMoreTap = () => openLink(ACCOUNT_TYPES_URL);
 
-    const handleConfirmTap = () => {
-        addCoinAccount({ network, accountType: selectedAccountType });
-    };
+    const handleConfirmTap = () =>
+        addCoinAccount({ network, accountType: selectedAccountType, flowType });
 
     return (
         <>

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -83,11 +83,16 @@ export type AccountsImportStackParamList = {
     };
 };
 
+export type AddCoinFlowType = 'receive' | 'accounts';
+
 export type AddCoinAccountStackParamList = {
-    [AddCoinAccountStackRoutes.AddCoinAccount]: undefined;
+    [AddCoinAccountStackRoutes.AddCoinAccount]: {
+        flowType: AddCoinFlowType;
+    };
     [AddCoinAccountStackRoutes.SelectAccountType]: {
         accountType: AccountType;
         network: Network;
+        flowType: AddCoinFlowType;
     };
 };
 
@@ -115,5 +120,5 @@ export type RootStackParamList = {
         tokenContract?: TokenAddress;
     };
     [RootStackRoutes.DeviceInfo]: undefined;
-    [RootStackRoutes.AddCoinAccountStack]: undefined;
+    [RootStackRoutes.AddCoinAccountStack]: NavigatorScreenParams<AddCoinAccountStackParamList>;
 };


### PR DESCRIPTION
When user clicks on Receive, he sees available coins with active accounts
User can click on (+)  and sees all available coins
If user chooses coin and type we activate the coin (add coin) on his behalf
User continues to receive address verification
When user leaves the Receive address flow and comes back to My assets, he sees new account activated


## Related Issue

Resolve #10677


https://github.com/trezor/trezor-suite/assets/2011829/fd22f69a-d5b1-4b26-91f7-3b725dc8a5e2


