### PR TITLE
fix(suite-native): fix missing animation by defining width

### DIFF
--- a/suite-native/module-connect-device/src/screens/ConnectAndUnlockDeviceScreen.tsx
+++ b/suite-native/module-connect-device/src/screens/ConnectAndUnlockDeviceScreen.tsx
@@ -18,7 +18,9 @@ const screenContentStyle = prepareNativeStyle(() => ({
 }));
 
 const animationStyle = prepareNativeStyle(() => ({
+    // Both height and width has to be set https://github.com/lottie-react-native/lottie-react-native/blob/master/MIGRATION-5-TO-6.md#updating-the-style-props
     height: ANIMATION_HEIGHT,
+    width: '100%',
 }));
 
 export const ConnectAndUnlockDeviceScreen = () => {

--- a/suite-native/module-onboarding/src/screens/ConnectTrezorScreen.tsx
+++ b/suite-native/module-onboarding/src/screens/ConnectTrezorScreen.tsx
@@ -17,9 +17,9 @@ import { OnboardingScreen } from '../components/OnboardingScreen';
 const ANIMATION_HEIGHT = Dimensions.get('screen').height * 0.35;
 
 const animationStyle = prepareNativeStyle(() => ({
+    // Both height and width has to be set https://github.com/lottie-react-native/lottie-react-native/blob/master/MIGRATION-5-TO-6.md#updating-the-style-props
     height: ANIMATION_HEIGHT,
-    // This is very strange bug, if you remove this border, the animation will not be displayed
-    borderWidth: 1,
+    width: '100%',
     borderColor: 'transparent',
 }));
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Lottie animation not rendered properly if both height and width are not defined since lottie-react-native@v6 https://github.com/lottie-react-native/lottie-react-native/pull/992

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/11202

## Screenshots:
<img width="1137" alt="image" src="https://github.com/trezor/trezor-suite/assets/3729633/caa57f9d-1e11-49f5-aab2-e5ae4affa008">
