### PR TITLE
chore(github): use nvmrc for node version

### DIFF
--- a/.github/workflows/blockchain-link-test.yml
+++ b/.github/workflows/blockchain-link-test.yml
@@ -20,17 +20,14 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [18.x]
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - name: node ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+      - name: Setup node
+        uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version-file: ".nvmrc"
           cache: yarn
           cache-dependency-path: "**/yarn.lock"
       - run: node --version

--- a/.github/workflows/connect-test-params.yml
+++ b/.github/workflows/connect-test-params.yml
@@ -13,19 +13,16 @@ on:
 
 jobs:
   node:
-    name: node (${{ matrix.node-version }})
+    name: node
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [18.x]
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+      - name: Setup node
+        uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version-file: ".nvmrc"
           cache: yarn
       # todo: ideally do not install everything. possibly only devDependencies could be enough for testing (if there was not for building libs)?
       - run: sed -i "/\"node\"/d" package.json
@@ -41,11 +38,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
+      - name: Setup node
+        uses: actions/setup-node@v4
         with:
-          # karma tests are run in browser, so node version doesn't matter too much
-          node-version: 18.x
+          node-version-file: ".nvmrc"
           cache: yarn
       # todo: ideally do not install everything. possibly only devDependencies could be enough for testing (if there was not for building libs)?
       - run: sed -i "/\"node\"/d" package.json

--- a/.github/workflows/connect-test.yml
+++ b/.github/workflows/connect-test.yml
@@ -20,17 +20,14 @@ jobs:
   # todo: meaning of 'build' job is questionable. only 'web' tests use part of this jobs output
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [18.x]
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - name: node ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+      - name: Setup node
+        uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version-file: ".nvmrc"
           cache: yarn
           cache-dependency-path: "**/yarn.lock"
       - run: sed -i "/\"node\"/d" package.json


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changing to use `node-version-file: ".nvmrc"` instead of hardcoded 18.x version in the actions.

If we have only one in the actions I guess it makes sense to use the one from nvmrc as a source of truth.
