### PR TITLE
chore: remove cross-fetch from tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
         "babel-jest": "29.7.0",
-        "cross-fetch": "^4.0.0",
         "eslint": "^8.56.0",
         "eslint-plugin-chai-friendly": "^0.7.4",
         "eslint-plugin-cypress": "^2.15.1",

--- a/packages/request-manager/e2e/interceptor.test.ts
+++ b/packages/request-manager/e2e/interceptor.test.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import http from 'http';
 import WebSocket from 'ws';
-import fetch from 'cross-fetch';
 
 import { TorController, createInterceptor } from '../src';
 import { torRunner } from './torRunner';
@@ -267,7 +266,7 @@ describe('Interceptor', () => {
         it('POST request headers', async () => {
             const { serverUrl, host } = serverInit;
 
-            // default headers added by cross-fetch and underlying libs
+            // default headers
             await expect(
                 fetchHeaders(serverUrl, {
                     method: 'POST',
@@ -305,7 +304,7 @@ describe('Interceptor', () => {
         it('GET request headers', async () => {
             const { serverUrl, host } = serverInit;
 
-            // default headers added by cross-fetch and underlying libs
+            // default headers
             await expect(
                 fetchHeaders(serverUrl, {
                     method: 'GET',

--- a/packages/request-manager/package.json
+++ b/packages/request-manager/package.json
@@ -16,7 +16,6 @@
         "socks-proxy-agent": "6.1.1"
     },
     "devDependencies": {
-        "cross-fetch": "^4.0.0",
         "ts-node": "^10.9.1",
         "ws": "^8.16.0"
     }

--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -46,7 +46,6 @@
         "@trezor/trezor-user-env-link": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@types/electron-localshortcut": "^3.1.3",
-        "cross-fetch": "^4.0.0",
         "electron": "27.0.4",
         "glob": "^10.3.10",
         "terser-webpack-plugin": "^5.3.9",

--- a/packages/suite-desktop-core/src/__tests__/http.test.ts
+++ b/packages/suite-desktop-core/src/__tests__/http.test.ts
@@ -1,5 +1,3 @@
-import fetch from 'cross-fetch';
-
 import { createHttpReceiver } from '../libs/http-receiver';
 import { fixtures } from '../__fixtures__/http';
 import { Logger } from '../libs/logger';

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -54,7 +54,6 @@
         "@trezor/protobuf": "workspace:*",
         "@trezor/protocol": "workspace:*",
         "@trezor/utils": "workspace:*",
-        "cross-fetch": "^4.0.0",
         "json-stable-stringify": "^1.1.1",
         "long": "^4.0.0",
         "protobufjs": "7.2.6",

--- a/packages/transport/src/utils/bridgeApiCall.ts
+++ b/packages/transport/src/utils/bridgeApiCall.ts
@@ -1,5 +1,3 @@
-import fetch from 'cross-fetch';
-
 import { success, error, unknownError } from './result';
 
 import * as ERRORS from '../errors';

--- a/packages/trezor-user-env-link/package.json
+++ b/packages/trezor-user-env-link/package.json
@@ -10,7 +10,6 @@
     },
     "dependencies": {
         "@trezor/utils": "workspace:*",
-        "cross-fetch": "^4.0.0",
         "ws": "^8.16.0"
     }
 }

--- a/packages/trezor-user-env-link/src/websocket-client.ts
+++ b/packages/trezor-user-env-link/src/websocket-client.ts
@@ -2,7 +2,6 @@
 
 import WebSocket from 'ws';
 import { EventEmitter } from 'events';
-import fetch from 'cross-fetch';
 
 import { createDeferred, Deferred } from '@trezor/utils';
 

--- a/packages/urls/package.json
+++ b/packages/urls/package.json
@@ -9,8 +9,5 @@
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
         "type-check": "yarn g:tsc --build",
         "test:e2e": "yarn g:jest -c ../../jest.config.base.js"
-    },
-    "devDependencies": {
-        "cross-fetch": "^4.0.0"
     }
 }

--- a/packages/urls/tests/urls.test.ts
+++ b/packages/urls/tests/urls.test.ts
@@ -1,5 +1,3 @@
-import fetch from 'cross-fetch';
-
 import * as URLS from '../src/urls';
 
 // Excluded urls

--- a/yarn.lock
+++ b/yarn.lock
@@ -9645,7 +9645,6 @@ __metadata:
   resolution: "@trezor/request-manager@workspace:packages/request-manager"
   dependencies:
     "@trezor/utils": "workspace:*"
-    cross-fetch: "npm:^4.0.0"
     socks-proxy-agent: "npm:6.1.1"
     ts-node: "npm:^10.9.1"
     ws: "npm:^8.16.0"
@@ -9811,7 +9810,6 @@ __metadata:
     "@trezor/utils": "workspace:*"
     "@types/electron-localshortcut": "npm:^3.1.3"
     chalk: "npm:^4.1.2"
-    cross-fetch: "npm:^4.0.0"
     electron: "npm:27.0.4"
     electron-localshortcut: "npm:^3.2.1"
     electron-store: "npm:^8.1.0"
@@ -10136,8 +10134,6 @@ __metadata:
 "@trezor/urls@workspace:*, @trezor/urls@workspace:packages/urls":
   version: 0.0.0-use.local
   resolution: "@trezor/urls@workspace:packages/urls"
-  dependencies:
-    cross-fetch: "npm:^4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -32135,7 +32131,6 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^6.21.0"
     "@typescript-eslint/parser": "npm:^6.21.0"
     babel-jest: "npm:29.7.0"
-    cross-fetch: "npm:^4.0.0"
     eslint: "npm:^8.56.0"
     eslint-plugin-chai-friendly: "npm:^0.7.4"
     eslint-plugin-cypress: "npm:^2.15.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10103,7 +10103,6 @@ __metadata:
     "@types/bytebuffer": "npm:^5.0.48"
     "@types/sharedworker": "npm:^0.0.111"
     "@types/w3c-web-usb": "npm:^1.0.10"
-    cross-fetch: "npm:^4.0.0"
     jest: "npm:29.7.0"
     json-stable-stringify: "npm:^1.1.1"
     long: "npm:^4.0.0"
@@ -10120,7 +10119,6 @@ __metadata:
   resolution: "@trezor/trezor-user-env-link@workspace:packages/trezor-user-env-link"
   dependencies:
     "@trezor/utils": "workspace:*"
-    cross-fetch: "npm:^4.0.0"
     ws: "npm:^8.16.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Remove `cross-fetch` from tests.

It is no longer needed since Jest 28: https://jestjs.io/blog/2022/04/25/jest-28#all-nodejs-globals
