### PR TITLE
Fix failing XRP or ¬XRP when both is enabled.

### DIFF
--- a/packages/suite-desktop-core/webpack/core.webpack.config.ts
+++ b/packages/suite-desktop-core/webpack/core.webpack.config.ts
@@ -144,6 +144,7 @@ const config: webpack.Configuration = {
             'process.env.SUITE_TYPE': JSON.stringify(PROJECT),
             'process.env.IS_CODESIGN_BUILD': `"${isCodesignBuild}"`, // to keep it as string "true"/"false" and not boolean
             'process.env.NODE_BACKEND': JSON.stringify('js'),
+            'process.env.WS_NO_BUFFER_UTIL': true, // ignore bufferutils import in ws lib (https://github.com/trezor/trezor-suite/pull/11225)
         }),
     ],
 


### PR DESCRIPTION
## Description

When built Suite app (= not web/not dev) started with XRP and anything else active, XRP discovery failed. When Suite started with only XRP active, it worked; but then the other coins didn't after they were turned on.

It happened since bumping `ws` dependency to 8.16.0 (https://github.com/trezor/trezor-suite/commit/bd1e5ec81b1ef2a53dc49271794edfbd75232aa1), because `ripple-lib` uses it in ^7.2.0. There is optional dependency of `ws` called `bufferutils`, explicitly omitted in Suite. Really don't know why, but when two different `ws` versions tried to require this dependency, the first one failed (as expected), but the second one didn't, so `ws` tried to use it, unsuccessfully.

Adding `WS_NO_BUFFER_UTIL` env variable completely turned off the require in `ws` >= 8.x.x, so the older one fails as expected. Not the cleanest fix, but at least it's small. If anyone knows what is really happening there, please let me know.

_buffer-utils.js in ws >= 8.x.x_
```javascript
if (!process.env.WS_NO_BUFFER_UTIL) {
  try {
    const bufferUtil = require('bufferutil');
```

_buffer-utils.js in ws < 8.x.x_
```javascript
try {
  const bufferUtil = require('bufferutil');
```

## Related Issue

Should resolve #11148
