### PR TITLE
chore(github): actions to use latest version

### DIFF
--- a/.github/workflows/blockchain-link-test.yml
+++ b/.github/workflows/blockchain-link-test.yml
@@ -21,7 +21,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup node

--- a/.github/workflows/bot-rebase.yml
+++ b/.github/workflows/bot-rebase.yml
@@ -21,7 +21,7 @@ jobs:
               body: "Start rebasing: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             })
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.TREZOR_BOT_TOKEN }}

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/commit-messages-check.yml
+++ b/.github/workflows/commit-messages-check.yml
@@ -6,7 +6,7 @@ jobs:
   commit-message-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Check commit messages
         run: ./scripts/check-commit-messages.sh

--- a/.github/workflows/connect-explorer_deploy.yml
+++ b/.github/workflows/connect-explorer_deploy.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
 

--- a/.github/workflows/connect-pre-release-init.yml
+++ b/.github/workflows/connect-pre-release-init.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Number of commits to fetch. 0 indicates all history for all branches and tags.
           fetch-depth: 0
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
       - name: Run @trezor/connect create npm release branch

--- a/.github/workflows/connect-release-init.yml
+++ b/.github/workflows/connect-release-init.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Number of commits to fetch. 0 indicates all history for all branches and tags.
           fetch-depth: 0
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
       - name: Run @trezor/connect create v9 release branch

--- a/.github/workflows/connect-test-params.yml
+++ b/.github/workflows/connect-test-params.yml
@@ -16,7 +16,7 @@ jobs:
     name: node
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup node
@@ -35,7 +35,7 @@ jobs:
     name: web
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup node
@@ -49,7 +49,7 @@ jobs:
       # todo: ideally reuse libs from build step
       - run: yarn build:libs
       - name: Retrieve build artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: packages/connect-web/build

--- a/.github/workflows/connect-test.yml
+++ b/.github/workflows/connect-test.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup node
@@ -36,7 +36,7 @@ jobs:
       - run: yarn workspace @trezor/connect-iframe build
       - run: yarn workspace @trezor/connect-web build
       # upload + download takes longer than doing yarn build:libs
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: build-artifact
           path: packages/connect-web/build

--- a/.github/workflows/crowdin_sync.yml
+++ b/.github/workflows/crowdin_sync.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
       - name: Set current timestamp as env variable

--- a/.github/workflows/release-suite-config.yml
+++ b/.github/workflows/release-suite-config.yml
@@ -21,7 +21,7 @@ jobs:
       AWS_CLOUDFRONT_ID: E1ERY5K2OTKKI1
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: true
       - name: Configure aws credentials

--- a/.github/workflows/shell_validation.yml
+++ b/.github/workflows/shell_validation.yml
@@ -8,7 +8,7 @@ jobs:
   shellcheck:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: shellcheck
         run: ./scripts/shellcheck.sh

--- a/.github/workflows/suite-native_develop_ci.yml
+++ b/.github/workflows/suite-native_develop_ci.yml
@@ -20,8 +20,8 @@ jobs:
     env:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
           cache: yarn

--- a/.github/workflows/suite-native_production_ci.yml
+++ b/.github/workflows/suite-native_production_ci.yml
@@ -15,8 +15,8 @@ jobs:
     env:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
           cache: yarn

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: "true"
           fetch-depth: 0
       - name: Install node and yarn
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
       - name: Get yarn cache directory path


### PR DESCRIPTION
We are getting many deprecation warnings in actions since GitHub is going to use node 20 as
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

<!--- Provide a general summary of your changes in the Title above -->

## Description

We are getting deprecation warnings from GitHub actions, since they are going to deprecate many of those since spring 2024 https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/



## Screenshots:
![image](https://github.com/trezor/trezor-suite/assets/5362163/19bd6fd9-b5ad-4131-bf1a-c0dceafdf12a)

![image](https://github.com/trezor/trezor-suite/assets/5362163/524a1768-6523-4f8b-b1b4-5b2e16d6b339)
