### PR TITLE
chore(e2e): uniting testid attributes

### DIFF
--- a/packages/components/src/components/CollapsibleBox/CollapsibleBox.tsx
+++ b/packages/components/src/components/CollapsibleBox/CollapsibleBox.tsx
@@ -175,7 +175,7 @@ const CollapsibleBox: FC<CollapsibleBoxProps> & CollapsibleBoxSubcomponents = ({
                         ease: isCollapsed ? motionEasing.enter : motionEasing.exit,
                     },
                 }}
-                data-test="@collapsible-box/body"
+                data-test-id="@collapsible-box/body"
             >
                 <Content variant={variant}>{children}</Content>
             </Collapser>

--- a/packages/components/src/components/ConfirmOnDevice/ConfirmOnDevice.tsx
+++ b/packages/components/src/components/ConfirmOnDevice/ConfirmOnDevice.tsx
@@ -170,7 +170,7 @@ export const ConfirmOnDevice = ({
     return (
         <Wrapper
             animation={isConfirmed ? AnimationDirection.Down : AnimationDirection.Up}
-            data-test="@prompts/confirm-on-device"
+            data-test-id="@prompts/confirm-on-device"
         >
             <Left>
                 {deviceModelInternal === DeviceModelInternal.T2B1 && (
@@ -191,7 +191,9 @@ export const ConfirmOnDevice = ({
                 <Title>{title}</Title>
 
                 {successText && hasSteps && activeStep > steps && (
-                    <Success data-test="@prompts/confirm-on-device/success">{successText}</Success>
+                    <Success data-test-id="@prompts/confirm-on-device/success">
+                        {successText}
+                    </Success>
                 )}
 
                 {hasSteps && activeStep <= steps && (
@@ -200,7 +202,7 @@ export const ConfirmOnDevice = ({
                             <Step
                                 key={step}
                                 isActive={isStepActive(index, activeStep)}
-                                data-test={`@prompts/confirm-on-device/step/${index}${
+                                data-test-id={`@prompts/confirm-on-device/step/${index}${
                                     isStepActive(index, activeStep) ? '/active' : ''
                                 }`}
                             />
@@ -212,7 +214,7 @@ export const ConfirmOnDevice = ({
             <Right>
                 <CloseWrapper>
                     {onCancel && (
-                        <Close onClick={onCancel} data-test="@confirm-on-device/close-button">
+                        <Close onClick={onCancel} data-test-id="@confirm-on-device/close-button">
                             <Icon icon="CROSS" size={16} color={theme.textOnTertiary} />
                         </Close>
                     )}

--- a/packages/components/src/components/DataAnalytics.tsx
+++ b/packages/components/src/components/DataAnalytics.tsx
@@ -123,7 +123,7 @@ export const DataAnalytics = ({
     const [trackingEnabled, setTrackingEnabled] = useState<boolean>(true);
 
     return (
-        <StyledCard data-test="@analytics/consent" className={className}>
+        <StyledCard data-test-id="@analytics/consent" className={className}>
             <Wrapper>
                 <Heading>
                     <FormattedMessage
@@ -179,7 +179,7 @@ export const DataAnalytics = ({
 
                 <ButtonWrapper>
                     <StyledButton
-                        data-test="@analytics/continue-button"
+                        data-test-id="@analytics/continue-button"
                         onClick={() => onConfirm(trackingEnabled)}
                     >
                         <FormattedMessage id="TR_CONFIRM" defaultMessage="Confirm" />

--- a/packages/components/src/components/Dropdown/Dropdown.tsx
+++ b/packages/components/src/components/Dropdown/Dropdown.tsx
@@ -36,7 +36,7 @@ const Container = styled.div<{ disabled?: boolean; $hasCustomChildren: boolean }
     ${getFocusShadowStyle()};
     cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
 
-    /** 
+    /**
         This must be here to reduce clickable area to the "circle" of the (...) children.
         However, if you use custom children its your own responsibility to handle it.
     */
@@ -75,7 +75,7 @@ export type DropdownProps = Omit<MenuProps, 'setToggled'> & {
     renderOnClickPosition?: boolean;
     onToggle?: (isToggled: boolean) => void;
     className?: string;
-    'data-test'?: string;
+    'data-test-id'?: string;
     children?: ((isToggled: boolean) => ReactElement<any>) | ReactElement<any>;
 };
 
@@ -100,7 +100,7 @@ export const Dropdown = forwardRef(
             onToggle,
             className,
             children,
-            'data-test': dataTest,
+            'data-test-id': dataTest,
         }: DropdownProps,
         ref,
     ) => {
@@ -208,7 +208,7 @@ export const Dropdown = forwardRef(
                 onClick={e => e.stopPropagation()}
                 $isToggled={isToggled}
                 isDisabled={isDisabled}
-                data-test={dataTest}
+                data-test-id={dataTest}
             />
         );
 

--- a/packages/components/src/components/Dropdown/Menu.tsx
+++ b/packages/components/src/components/Dropdown/Menu.tsx
@@ -149,7 +149,7 @@ export interface DropdownMenuItemProps {
     isDisabled?: boolean;
     isHidden?: boolean;
     separatorBefore?: boolean;
-    'data-test'?: string;
+    'data-test-id'?: string;
 }
 
 interface MenuItemComponentProps extends DropdownMenuItemProps {

--- a/packages/components/src/components/Passphrase/PassphraseTypeCard.tsx
+++ b/packages/components/src/components/Passphrase/PassphraseTypeCard.tsx
@@ -268,7 +268,7 @@ export const PassphraseTypeCard = (props: PassphraseTypeCardProps) => {
                     setHiddenWalletTouched(true);
                 }
             }}
-            data-test={`@passphrase-type/${props.type}`}
+            data-test-id={`@passphrase-type/${props.type}`}
         >
             {!props.singleColModal && (
                 // only used to show options in modal where user selects wallet type
@@ -285,7 +285,9 @@ export const PassphraseTypeCard = (props: PassphraseTypeCardProps) => {
                         <Col>
                             <WalletTitle
                                 withMargin={props.type === 'hidden'}
-                                data-test={props.type === 'hidden' && '@tooltip/passphrase-tooltip'}
+                                data-test-id={
+                                    props.type === 'hidden' && '@tooltip/passphrase-tooltip'
+                                }
                             >
                                 {props.type === 'hidden' ? (
                                     <Tooltip
@@ -328,7 +330,7 @@ export const PassphraseTypeCard = (props: PassphraseTypeCardProps) => {
                         {/* Show passphrase input */}
                         <InputWrapper authConfirmation={props.authConfirmation}>
                             <PassphraseInput
-                                data-test="@passphrase/input"
+                                data-test-id="@passphrase/input"
                                 placeholder={intl.formatMessage({
                                     defaultMessage: 'Enter passphrase',
                                     id: 'TR_ENTER_PASSPHRASE',
@@ -359,7 +361,7 @@ export const PassphraseTypeCard = (props: PassphraseTypeCardProps) => {
                                             }
                                             setShowPassword(!showPassword);
                                         }}
-                                        data-test="@passphrase/show-toggle"
+                                        data-test-id="@passphrase/show-toggle"
                                     />
                                 }
                             />
@@ -372,7 +374,7 @@ export const PassphraseTypeCard = (props: PassphraseTypeCardProps) => {
                 // Checkbox if user fully understands what's happening when confirming empty passphrase
                 <Content>
                     <Checkbox
-                        data-test="@passphrase/confirm-checkbox"
+                        data-test-id="@passphrase/confirm-checkbox"
                         onClick={() => setEnabled(!enabled)}
                         isChecked={enabled}
                     >
@@ -391,7 +393,7 @@ export const PassphraseTypeCard = (props: PassphraseTypeCardProps) => {
                         {(props.singleColModal || hiddenWalletTouched) && (
                             <motion.div {...motionConfig.motionAnimation.expand}>
                                 <ActionButton
-                                    data-test={`@passphrase/${
+                                    data-test-id={`@passphrase/${
                                         props.type === 'hidden' ? 'hidden' : 'standard'
                                     }/submit-button`}
                                     isDisabled={!enabled || isTooLong}
@@ -410,7 +412,7 @@ export const PassphraseTypeCard = (props: PassphraseTypeCardProps) => {
                                 variant="tertiary"
                                 onClick={() => submit(value, true)}
                                 isFullWidth
-                                data-test="@passphrase/enter-on-device-button"
+                                data-test-id="@passphrase/enter-on-device-button"
                             >
                                 <FormattedMessage
                                     id="TR_ENTER_PASSPHRASE_ON_DEVICE"

--- a/packages/components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.tsx
@@ -147,7 +147,7 @@ export const Tooltip = ({
     // set data-test attribute to Tippy https://github.com/atomiks/tippyjs-react/issues/89
     const onCreate = (instance: Instance) => {
         const content = instance.popper;
-        content.setAttribute('data-test', '@tooltip');
+        content.setAttribute('data-test-id', '@tooltip');
     };
 
     const animationVariants = {

--- a/packages/components/src/components/assets/CoinLogo/coinLogos.stories.tsx
+++ b/packages/components/src/components/assets/CoinLogo/coinLogos.stories.tsx
@@ -34,7 +34,7 @@ export const All: StoryObj = {
                 {variables.COINS.map((coin: CoinType) => (
                     <Icon key={coin}>
                         <CoinName>{coin}</CoinName>
-                        <CoinLogo symbol={coin} data-test={`coin-${coin}`} size={64} />
+                        <CoinLogo symbol={coin} data-test-id={`coin-${coin}`} size={64} />
                     </Icon>
                 ))}
             </WrapperIcons>

--- a/packages/components/src/components/assets/Flag/flags.stories.tsx
+++ b/packages/components/src/components/assets/Flag/flags.stories.tsx
@@ -46,7 +46,7 @@ export const All: StoryFn = () => {
                     <Text>{country}</Text>
                     <Flag
                         country={country}
-                        data-test={`icon-${country.toLowerCase().replace('_', '-')}`}
+                        data-test-id={`icon-${country.toLowerCase().replace('_', '-')}`}
                     />
                 </FlagWrapper>
             ))}

--- a/packages/components/src/components/assets/Icon/Icon.tsx
+++ b/packages/components/src/components/assets/Icon/Icon.tsx
@@ -58,7 +58,7 @@ export interface IconProps extends SVGAttributes<HTMLDivElement> {
     color?: string;
     hoverColor?: string;
     useCursorPointer?: boolean;
-    'data-test'?: string;
+    'data-test-id'?: string;
 }
 
 export const Icon = forwardRef(
@@ -73,7 +73,7 @@ export const Icon = forwardRef(
             onClick,
             onMouseEnter,
             onMouseLeave,
-            'data-test': dataTest,
+            'data-test-id': dataTest,
         }: IconProps,
         ref?: Ref<HTMLDivElement>,
     ) => {
@@ -91,7 +91,7 @@ export const Icon = forwardRef(
                 ref={ref}
                 $useCursorPointer={onClick !== undefined || useCursorPointer}
                 $color={defaultColor}
-                data-test={dataTest}
+                data-test-id={dataTest}
             >
                 <ReactSVG
                     src={ICONS[icon]}

--- a/packages/components/src/components/assets/Icon/icons.stories.tsx
+++ b/packages/components/src/components/assets/Icon/icons.stories.tsx
@@ -35,7 +35,7 @@ export const All = () => (
         {variables.ICONS.map((icon: IconType) => (
             <IconWrapper key={icon}>
                 <IconText>{icon}</IconText>
-                <Icon icon={icon} data-test={`icon-${icon.toLowerCase().replace('_', '-')}`} />
+                <Icon icon={icon} data-test-id={`icon-${icon.toLowerCase().replace('_', '-')}`} />
             </IconWrapper>
         ))}
     </Wrapper>

--- a/packages/components/src/components/assets/TrezorLogo/trezorLogos.stories.tsx
+++ b/packages/components/src/components/assets/TrezorLogo/trezorLogos.stories.tsx
@@ -26,20 +26,24 @@ export const All: StoryObj = {
                 <TrezorLogo
                     type="horizontal"
                     width="200px"
-                    data-test="trezor-logo-horizontal-black"
+                    data-test-id="trezor-logo-horizontal-black"
                 />
-                <TrezorLogo type="vertical" width="120px" data-test="trezor-logo-vertical-black" />
-                <TrezorLogo type="symbol" width="50px" data-test="trezor-logo-symbol-black" />
-                <TrezorLogo type="suite" width="200px" data-test="trezor-suite-logo-black" />
+                <TrezorLogo
+                    type="vertical"
+                    width="120px"
+                    data-test-id="trezor-logo-vertical-black"
+                />
+                <TrezorLogo type="symbol" width="50px" data-test-id="trezor-logo-symbol-black" />
+                <TrezorLogo type="suite" width="200px" data-test-id="trezor-suite-logo-black" />
                 <TrezorLogo
                     type="suite_square"
                     width="50px"
-                    data-test="trezor-suite-square-logo-white"
+                    data-test-id="trezor-suite-square-logo-white"
                 />
                 <TrezorLogo
                     type="suite_compact"
                     width="200px"
-                    data-test="trezor-suite-compact-logo-white"
+                    data-test-id="trezor-suite-compact-logo-white"
                 />
             </LogoWrapper>
         </StoryColumn>

--- a/packages/components/src/components/buttons/Button/Button.tsx
+++ b/packages/components/src/components/buttons/Button/Button.tsx
@@ -91,7 +91,7 @@ export interface ButtonProps extends SelectedHTMLButtonProps {
     children: React.ReactNode;
     title?: string;
     className?: string;
-    'data-test'?: string;
+    'data-test-id'?: string;
 }
 
 export const Button = ({

--- a/packages/components/src/components/buttons/Button/buttons.stories.tsx
+++ b/packages/components/src/components/buttons/Button/buttons.stories.tsx
@@ -23,7 +23,7 @@ export const All: StoryFn = () => (
             <StoryColumn key={variant} minWidth={350} maxWidth={420}>
                 <Button
                     variant={variant}
-                    data-test={`button-${variant}`}
+                    data-test-id={`button-${variant}`}
                     onClick={() => {
                         console.log('click');
                     }}
@@ -33,7 +33,7 @@ export const All: StoryFn = () => (
                 <Button
                     variant={variant}
                     size="medium"
-                    data-test={`button-${variant}`}
+                    data-test-id={`button-${variant}`}
                     onClick={() => {
                         console.log('click');
                     }}
@@ -43,7 +43,7 @@ export const All: StoryFn = () => (
                 <Button
                     variant={variant}
                     size="small"
-                    data-test={`button-${variant}`}
+                    data-test-id={`button-${variant}`}
                     onClick={() => {
                         console.log('click');
                     }}
@@ -53,7 +53,7 @@ export const All: StoryFn = () => (
 
                 <Button
                     variant={variant}
-                    data-test={`button-${variant}-icon`}
+                    data-test-id={`button-${variant}-icon`}
                     icon="PALETTE"
                     onClick={() => {
                         console.log('click');
@@ -63,22 +63,22 @@ export const All: StoryFn = () => (
                 </Button>
                 <Button
                     variant={variant}
-                    data-test={`button-${variant}-icon-right`}
+                    data-test-id={`button-${variant}-icon-right`}
                     iconAlignment="right"
                     icon="PLUS"
                 >
                     {capitalizeFirstLetter(variant)} icon right
                 </Button>
-                <Button variant={variant} data-test={`button-${variant}-loading`} isLoading>
+                <Button variant={variant} data-test-id={`button-${variant}-loading`} isLoading>
                     {capitalizeFirstLetter(variant)} loading
                 </Button>
-                <Button variant={variant} data-test={`button-${variant}-full-width`} isFullWidth>
+                <Button variant={variant} data-test-id={`button-${variant}-full-width`} isFullWidth>
                     {capitalizeFirstLetter(variant)} full width
                 </Button>
                 <Button
                     variant={variant}
                     isDisabled
-                    data-test={`button-${variant}-disabled`}
+                    data-test-id={`button-${variant}-disabled`}
                     onClick={() => {
                         console.log('click');
                     }}

--- a/packages/components/src/components/buttons/IconButton/IconButtons.stories.tsx
+++ b/packages/components/src/components/buttons/IconButton/IconButtons.stories.tsx
@@ -18,7 +18,7 @@ export const IconButtons: StoryObj = {
                     <IconButton
                         icon="PALETTE"
                         variant={variant}
-                        data-test={`button-${variant}`}
+                        data-test-id={`button-${variant}`}
                         onClick={() => {
                             console.log('click');
                         }}
@@ -27,7 +27,7 @@ export const IconButtons: StoryObj = {
                         icon="PALETTE"
                         variant={variant}
                         size="medium"
-                        data-test={`button-${variant}`}
+                        data-test-id={`button-${variant}`}
                         onClick={() => {
                             console.log('click');
                         }}
@@ -37,7 +37,7 @@ export const IconButtons: StoryObj = {
                         icon="PALETTE"
                         variant={variant}
                         size="small"
-                        data-test={`button-${variant}`}
+                        data-test-id={`button-${variant}`}
                         onClick={() => {
                             console.log('click');
                         }}
@@ -45,7 +45,7 @@ export const IconButtons: StoryObj = {
 
                     <IconButton
                         variant={variant}
-                        data-test={`button-${variant}-icon`}
+                        data-test-id={`button-${variant}-icon`}
                         icon="PALETTE"
                         label={<span>Label</span>}
                         onClick={() => {
@@ -56,7 +56,7 @@ export const IconButtons: StoryObj = {
                     <IconButton
                         icon="PALETTE"
                         variant={variant}
-                        data-test={`button-${variant}-loading`}
+                        data-test-id={`button-${variant}-loading`}
                         isLoading
                     />
 
@@ -64,7 +64,7 @@ export const IconButtons: StoryObj = {
                         icon="PALETTE"
                         variant={variant}
                         isDisabled
-                        data-test={`button-${variant}-disabled`}
+                        data-test-id={`button-${variant}-disabled`}
                         onClick={() => {
                             console.log('click');
                         }}
@@ -74,7 +74,7 @@ export const IconButtons: StoryObj = {
                         bottomLabel={<span>Bottom Label</span>}
                         variant={variant}
                         isDisabled
-                        data-test={`button-${variant}-disabled`}
+                        data-test-id={`button-${variant}-disabled`}
                         onClick={() => {
                             console.log('click');
                         }}

--- a/packages/components/src/components/buttons/TextButton/TextButtons.stories.tsx
+++ b/packages/components/src/components/buttons/TextButton/TextButtons.stories.tsx
@@ -11,7 +11,7 @@ export const All: StoryFn = () => (
     <>
         <StoryColumn minWidth={350} maxWidth={420}>
             <TextButton
-                data-test="text-button"
+                data-test-id="text-button"
                 onClick={() => {
                     console.log('click');
                 }}
@@ -20,7 +20,7 @@ export const All: StoryFn = () => (
             </TextButton>
             <TextButton
                 size="medium"
-                data-test="text-button"
+                data-test-id="text-button"
                 onClick={() => {
                     console.log('click');
                 }}
@@ -30,7 +30,7 @@ export const All: StoryFn = () => (
 
             <TextButton
                 size="small"
-                data-test="text-button"
+                data-test-id="text-button"
                 onClick={() => {
                     console.log('click');
                 }}
@@ -39,7 +39,7 @@ export const All: StoryFn = () => (
             </TextButton>
 
             <TextButton
-                data-test="text-button-icon"
+                data-test-id="text-button-icon"
                 icon="GHOST"
                 onClick={() => {
                     console.log('click');
@@ -48,14 +48,14 @@ export const All: StoryFn = () => (
                 Text Button Icon
             </TextButton>
 
-            <TextButton icon="GHOST" data-test="text-button-loading" isLoading>
+            <TextButton icon="GHOST" data-test-id="text-button-loading" isLoading>
                 Text Button loading
             </TextButton>
 
             <TextButton
                 icon="GHOST"
                 isDisabled
-                data-test="text-button-disabled"
+                data-test-id="text-button-disabled"
                 onClick={() => {
                     console.log('click');
                 }}

--- a/packages/components/src/components/form/Checkbox/Checkbox.tsx
+++ b/packages/components/src/components/form/Checkbox/Checkbox.tsx
@@ -143,7 +143,7 @@ export interface CheckboxProps {
     isDisabled?: boolean;
     labelAlignment?: LabelAlignment;
     onClick: EventHandler<SyntheticEvent>;
-    'data-test'?: string;
+    'data-test-id'?: string;
     className?: string;
     children?: ReactNode;
 }
@@ -154,7 +154,7 @@ export const Checkbox = ({
     isDisabled,
     labelAlignment = 'right',
     onClick,
-    'data-test': dataTest,
+    'data-test-id': dataTest,
     className,
     children,
 }: CheckboxProps) => {
@@ -172,7 +172,7 @@ export const Checkbox = ({
             labelAlignment={labelAlignment}
             onClick={onClick}
             onKeyUp={handleKeyUp}
-            data-test={dataTest}
+            data-test-id={dataTest}
             className={className}
         >
             <HiddenInput

--- a/packages/components/src/components/form/Input/Input.tsx
+++ b/packages/components/src/components/form/Input/Input.tsx
@@ -135,7 +135,7 @@ const Input = ({
             onMouseEnter={() => setIsHovered(true)}
             onMouseLeave={() => setIsHovered(false)}
             hasBottomPadding={hasBottomPadding === true && bottomText === null}
-            data-test={dataTest}
+            data-test-id={dataTest}
             className={className}
         >
             <TopAddons isHovered={isHovered} hoverAddon={labelHoverAddon} addonRight={labelRight} />

--- a/packages/components/src/components/form/Radio/Radio.tsx
+++ b/packages/components/src/components/form/Radio/Radio.tsx
@@ -100,7 +100,7 @@ export interface RadioProps {
     isDisabled?: boolean;
     labelAlignment?: LabelAlignment;
     onClick: EventHandler<SyntheticEvent>;
-    'data-test'?: string;
+    'data-test-id'?: string;
     children?: ReactNode;
 }
 
@@ -110,7 +110,7 @@ export const Radio = ({
     labelAlignment,
     isDisabled,
     onClick,
-    'data-test': dataTest,
+    'data-test-id': dataTest,
     children,
 }: RadioProps) => {
     const handleKeyUp = (event: KeyboardEvent<HTMLElement>) => {
@@ -126,7 +126,7 @@ export const Radio = ({
             isDisabled={isDisabled}
             labelAlignment={labelAlignment}
             data-checked={isChecked}
-            data-test={dataTest}
+            data-test-id={dataTest}
         >
             <HiddenInput
                 type="radio"

--- a/packages/components/src/components/form/Select/Select.tsx
+++ b/packages/components/src/components/form/Select/Select.tsx
@@ -235,7 +235,7 @@ interface CommonProps extends Omit<ReactSelectProps<Option>, 'onChange'> {
     minValueWidth?: string; // TODO: should be probably removed
     inputState?: InputState;
     onChange?: (value: Option, ref?: SelectInstance<Option, boolean> | null) => void;
-    'data-test'?: string;
+    'data-test-id'?: string;
 }
 
 // Make sure isSearchable can't be defined if useKeyPressScroll===true
@@ -262,7 +262,7 @@ export const Select = ({
     onChange,
     placeholder,
     isDisabled,
-    'data-test': dataTest,
+    'data-test-id': dataTest,
     ...props
 }: SelectProps) => {
     const selectRef = useRef<SelectInstance<Option, boolean>>(null);

--- a/packages/components/src/components/form/Select/customComponents.tsx
+++ b/packages/components/src/components/form/Select/customComponents.tsx
@@ -12,7 +12,7 @@ export const Control = ({ dataTest, ...controlProps }: ControlComponentProps) =>
             dataTest
                 ? ({
                       ...controlProps.innerProps,
-                      'data-test': `${dataTest}/input`,
+                      'data-test-id': `${dataTest}/input`,
                   } as ControlProps<OptionType>['innerProps'])
                 : controlProps.innerProps
         }
@@ -29,7 +29,7 @@ export const Option = ({ dataTest, ...optionProps }: OptionComponentProps) => (
         innerProps={
             {
                 ...optionProps.innerProps,
-                'data-test': `${dataTest}/option/${
+                'data-test-id': `${dataTest}/option/${
                     typeof optionProps.data.value === 'string'
                         ? optionProps.data.value
                         : optionProps.label

--- a/packages/components/src/components/form/SelectBar/SelectBar.tsx
+++ b/packages/components/src/components/form/SelectBar/SelectBar.tsx
@@ -222,7 +222,7 @@ export const SelectBar: <V extends ValueTypes>(props: SelectBarProps<V>) => JSX.
                                 ? selectedOptionIn === option.value
                                 : false
                         }
-                        data-test={`select-bar/${String(option.value)}`}
+                        data-test-id={`select-bar/${String(option.value)}`}
                     >
                         <span>{option.label}</span>
                         <WidthMock>{option.label}</WidthMock>

--- a/packages/components/src/components/form/Switch/Switch.tsx
+++ b/packages/components/src/components/form/Switch/Switch.tsx
@@ -131,7 +131,7 @@ export const Switch = ({
                     e.preventDefault();
                     handleChange();
                 }}
-                data-test={dataTest}
+                data-test-id={dataTest}
                 isSmall={isSmall}
             >
                 <Handle

--- a/packages/components/src/components/form/Textarea/Textarea.tsx
+++ b/packages/components/src/components/form/Textarea/Textarea.tsx
@@ -81,7 +81,7 @@ export interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElemen
     hasBottomPadding?: boolean;
     value?: string;
     characterCount?: CharacterCountProps['characterCount'];
-    'data-test'?: string;
+    'data-test-id'?: string;
 }
 
 export const Textarea = ({
@@ -99,7 +99,7 @@ export const Textarea = ({
     labelRight,
     characterCount,
     hasBottomPadding = true,
-    'data-test': dataTest,
+    'data-test-id': dataTest,
     ...rest
 }: TextareaProps) => {
     const [isHovered, setIsHovered] = useState(false);
@@ -124,7 +124,7 @@ export const Textarea = ({
                     disabled={isDisabled}
                     inputState={inputState}
                     rows={rows}
-                    data-test={dataTest}
+                    data-test-id={dataTest}
                     placeholder={placeholder || ''} // needed for uncontrolled inputs
                     ref={innerRef}
                     {...rest}

--- a/packages/components/src/components/form/form.stories.tsx
+++ b/packages/components/src/components/form/form.stories.tsx
@@ -241,22 +241,22 @@ export const All: StoryObj = {
             <StoryColumn maxWidth={200}>
                 <Heading>Checkbox</Heading>
                 <SubHeading>Unchecked</SubHeading>
-                <Checkbox onClick={() => {}} data-test="checkbox">
+                <Checkbox onClick={() => {}} data-test-id="checkbox">
                     Label
                 </Checkbox>
                 <SubHeading>Checked</SubHeading>
-                <Checkbox onClick={() => {}} isChecked data-test="checkbox-checked">
+                <Checkbox onClick={() => {}} isChecked data-test-id="checkbox-checked">
                     Label
                 </Checkbox>
             </StoryColumn>
             <StoryColumn maxWidth={200}>
                 <Heading>Radio Buttons</Heading>
                 <SubHeading>Unchecked</SubHeading>
-                <Radio onClick={() => {}} data-test="radio-button">
+                <Radio onClick={() => {}} data-test-id="radio-button">
                     Label
                 </Radio>
                 <SubHeading>Checked</SubHeading>
-                <Radio onClick={() => {}} isChecked data-test="radio-button-checked">
+                <Radio onClick={() => {}} isChecked data-test-id="radio-button-checked">
                     Label
                 </Radio>
             </StoryColumn>

--- a/packages/components/src/components/loaders/Spinner/Spinner.tsx
+++ b/packages/components/src/components/loaders/Spinner/Spinner.tsx
@@ -80,7 +80,7 @@ export const Spinner = ({
             $isGrey={isGrey}
             className={className}
             {...getProps()}
-            data-test={dataTest}
+            data-test-id={dataTest}
         />
     );
 };

--- a/packages/components/src/components/modals/DialogModal/DialogModal.stories.tsx
+++ b/packages/components/src/components/modals/DialogModal/DialogModal.stories.tsx
@@ -42,7 +42,7 @@ export const DialogModal: StoryObj<DialogModalProps> = {
         className: {
             control: 'none',
         },
-        'data-test': {
+        'data-test-id': {
             control: 'none',
         },
     },

--- a/packages/components/src/components/modals/DialogModal/DialogModal.tsx
+++ b/packages/components/src/components/modals/DialogModal/DialogModal.tsx
@@ -31,7 +31,7 @@ type PickedModalProps = Pick<
     | 'currentProgressBarStep'
     | 'totalProgressBarSteps'
     | 'className'
-    | 'data-test'
+    | 'data-test-id'
 >;
 
 export interface DialogModalProps extends PickedModalProps {

--- a/packages/components/src/components/modals/Modal/Modal.stories.tsx
+++ b/packages/components/src/components/modals/Modal/Modal.stories.tsx
@@ -78,7 +78,7 @@ export const Modal: StoryObj<ModalProps> = {
         className: {
             control: 'none',
         },
-        'data-test': {
+        'data-test-id': {
             control: 'none',
         },
     },

--- a/packages/components/src/components/modals/Modal/Modal.tsx
+++ b/packages/components/src/components/modals/Modal/Modal.tsx
@@ -188,7 +188,7 @@ interface ModalProps {
     currentProgressBarStep?: number;
     headerComponent?: ReactNode;
     className?: string;
-    'data-test'?: string;
+    'data-test-id'?: string;
 }
 
 const Modal = ({
@@ -209,7 +209,7 @@ const Modal = ({
     currentProgressBarStep,
     headerComponent,
     className,
-    'data-test': dataTest = '@modal',
+    'data-test-id': dataTest = '@modal',
 }: ModalProps) => {
     const [componentsWidth, setComponentsWidth] = useState<number>();
     const theme = useTheme();
@@ -243,7 +243,7 @@ const Modal = ({
 
             <Container
                 onClick={e => e.stopPropagation()} // needed because of the Backdrop implementation
-                data-test={dataTest}
+                data-test-id={dataTest}
                 className={className}
             >
                 {(!!onBackClick || !!heading || showHeaderActions) && (
@@ -297,7 +297,7 @@ const Modal = ({
                                     <IconButton
                                         variant="tertiary"
                                         icon="CROSS"
-                                        data-test="@modal/close-button"
+                                        data-test-id="@modal/close-button"
                                         onClick={onCancel}
                                         size={HEADING_SIZES[headingSize].buttonSize}
                                     />

--- a/packages/components/src/components/typography/Link/Link.tsx
+++ b/packages/components/src/components/typography/Link/Link.tsx
@@ -52,7 +52,7 @@ interface LinkProps {
     variant?: 'default' | 'nostyle' | 'underline';
     icon?: IconProps['icon'];
     iconProps?: IconProps;
-    'data-test'?: string;
+    'data-test-id'?: string;
 }
 
 const Link = ({
@@ -62,7 +62,7 @@ const Link = ({
     iconProps,
     type,
     onClick,
-    'data-test': dataTest,
+    'data-test-id': dataTest,
     ...props
 }: LinkProps) => {
     const theme = useTheme();
@@ -74,7 +74,7 @@ const Link = ({
             href={href}
             target={target || '_blank'}
             rel="noreferrer noopener"
-            data-test={dataTest}
+            data-test-id={dataTest}
             onClick={(e: MouseEvent<any>) => {
                 e.stopPropagation();
                 onClick?.(e);

--- a/packages/components/src/components/typography/Paragraph/Paragraph.tsx
+++ b/packages/components/src/components/typography/Paragraph/Paragraph.tsx
@@ -5,7 +5,7 @@ import { typography, TypographyStyle } from '@trezor/theme';
 export type ParagraphProps = {
     type?: TypographyStyle;
     className?: string; // Used for color, margins etc. while typography properties should be set via type prop.
-    'data-test'?: string;
+    'data-test-id'?: string;
     children: React.ReactNode;
 };
 
@@ -16,10 +16,10 @@ const P = styled.div<{ type: TypographyStyle }>`
 export const Paragraph = ({
     className,
     type = 'body',
-    'data-test': dataTest,
+    'data-test-id': dataTest,
     children,
 }: ParagraphProps) => (
-    <P className={className} type={type} data-test={dataTest}>
+    <P className={className} type={type} data-test-id={dataTest}>
         {children}
     </P>
 );

--- a/packages/components/src/components/typography/typography.stories.tsx
+++ b/packages/components/src/components/typography/typography.stories.tsx
@@ -9,11 +9,11 @@ export default {
 export const All: StoryFn = () => (
     <>
         <StoryColumn>
-            <H1 data-test="heading-1">Heading 1</H1>
-            <H2 data-test="heading-2">Heading 2</H2>
+            <H1 data-test-id="heading-1">Heading 1</H1>
+            <H2 data-test-id="heading-2">Heading 2</H2>
         </StoryColumn>
         <StoryColumn>
-            <Paragraph data-test="paragraph-default">
+            <Paragraph data-test-id="paragraph-default">
                 default
                 <br />
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a ante quis lectus
@@ -21,49 +21,49 @@ export const All: StoryFn = () => (
                 interdum eros, eget placerat lorem pulvinar in. Ut elit orci, rhoncus eu porta vel,
                 feugiat vel mi.
             </Paragraph>
-            <Paragraph type="titleLarge" data-test="paragraph-titleLarge">
+            <Paragraph type="titleLarge" data-test-id="paragraph-titleLarge">
                 type="titleLarge" <br />
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a ante quis lectus
                 eleifend rutrum. Aenean tincidunt odio vel fermentum ultricies. Sed suscipit
                 interdum eros, eget placerat lorem pulvinar in. Ut elit orci, rhoncus eu porta vel,
                 feugiat vel mi.
             </Paragraph>
-            <Paragraph type="titleMedium" data-test="paragraph-titleMedium">
+            <Paragraph type="titleMedium" data-test-id="paragraph-titleMedium">
                 type="titleMedium" <br />
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a ante quis lectus
                 eleifend rutrum. Aenean tincidunt odio vel fermentum ultricies. Sed suscipit
                 interdum eros, eget placerat lorem pulvinar in. Ut elit orci, rhoncus eu porta vel,
                 feugiat vel mi.
             </Paragraph>
-            <Paragraph type="titleSmall" data-test="paragraph-titleSmall">
+            <Paragraph type="titleSmall" data-test-id="paragraph-titleSmall">
                 type ="titleSmall" <br />
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a ante quis lectus
                 eleifend rutrum. Aenean tincidunt odio vel fermentum ultricies. Sed suscipit
                 interdum eros, eget placerat lorem pulvinar in. Ut elit orci, rhoncus eu porta vel,
                 feugiat vel mi.
             </Paragraph>
-            <Paragraph type="highlight" data-test="paragraph-highlight">
+            <Paragraph type="highlight" data-test-id="paragraph-highlight">
                 type="highlight" <br />
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a ante quis lectus
                 eleifend rutrum. Aenean tincidunt odio vel fermentum ultricies. Sed suscipit
                 interdum eros, eget placerat lorem pulvinar in. Ut elit orci, rhoncus eu porta vel,
                 feugiat vel mi.
             </Paragraph>
-            <Paragraph type="callout" data-test="paragraph-callout">
+            <Paragraph type="callout" data-test-id="paragraph-callout">
                 type="callout" <br />
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a ante quis lectus
                 eleifend rutrum. Aenean tincidunt odio vel fermentum ultricies. Sed suscipit
                 interdum eros, eget placerat lorem pulvinar in. Ut elit orci, rhoncus eu porta vel,
                 feugiat vel mi.
             </Paragraph>
-            <Paragraph type="hint" data-test="paragraph-hint">
+            <Paragraph type="hint" data-test-id="paragraph-hint">
                 type="hint" <br />
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a ante quis lectus
                 eleifend rutrum. Aenean tincidunt odio vel fermentum ultricies. Sed suscipit
                 interdum eros, eget placerat lorem pulvinar in. Ut elit orci, rhoncus eu porta vel,
                 feugiat vel mi.
             </Paragraph>
-            <Paragraph type="label" data-test="paragraph-label">
+            <Paragraph type="label" data-test-id="paragraph-label">
                 type="label" <br />
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a ante quis lectus
                 eleifend rutrum. Aenean tincidunt odio vel fermentum ultricies. Sed suscipit
@@ -71,13 +71,13 @@ export const All: StoryFn = () => (
                 feugiat vel mi.
             </Paragraph>
 
-            <Paragraph data-test="paragraph-link">
+            <Paragraph data-test-id="paragraph-link">
                 Default text with <Link href="/">link</Link>.
             </Paragraph>
-            <Paragraph type="hint" data-test="paragraph-link-hint">
+            <Paragraph type="hint" data-test-id="paragraph-link-hint">
                 Hint text with <Link href="/">link</Link>.
             </Paragraph>
-            <Paragraph type="label" data-test="paragraph-link-label">
+            <Paragraph type="label" data-test-id="paragraph-link-label">
                 Label text with <Link href="/">link</Link>.
             </Paragraph>
         </StoryColumn>

--- a/packages/connect-examples/webextension-mv2/src/connect-manager.html
+++ b/packages/connect-examples/webextension-mv2/src/connect-manager.html
@@ -5,8 +5,9 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     </head>
+
     <body>
-        <button id="get-address" data-test="get-address">Get Address</button>
+        <button id="get-address" data-test-id="get-address">Get Address</button>
         <div id="result"></div>
         <script src="./connect-manager.js" type="module"></script>
     </body>

--- a/packages/connect-examples/webextension-mv2/src/connect-manager.js
+++ b/packages/connect-examples/webextension-mv2/src/connect-manager.js
@@ -19,7 +19,7 @@ chrome.runtime.onMessage.addListener((message, sender) => {
         document.getElementById('result').innerText = JSON.stringify(data);
     } else if (type === 'connectLoaded') {
         const connectLoaded = document.createElement('div');
-        connectLoaded.setAttribute('data-test', 'connect-loaded');
+        connectLoaded.setAttribute('data-test-id', 'connect-loaded');
         connectLoaded.innerText = 'TrezorConnect is loaded';
         connectLoaded.style.display = 'block';
         document.body.appendChild(connectLoaded);

--- a/packages/connect-examples/webextension-mv3-sw/src/connect-manager.html
+++ b/packages/connect-examples/webextension-mv3-sw/src/connect-manager.html
@@ -5,10 +5,11 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     </head>
+
     <body>
         <button id="tab">New tab</button>
-        <button id="get-features" data-test="get-features">Get features</button>
-        <button id="get-address" data-test="get-address">Get address</button>
+        <button id="get-features" data-test-id="get-features">Get features</button>
+        <button id="get-address" data-test-id="get-address">Get address</button>
         <div id="result"></div>
         <!-- TODO: try to load changing content security policy -->
         <!-- https://developer.chrome.com/docs/extensions/mv3/manifest/content_security_policy/ -->

--- a/packages/connect-examples/webextension-mv3/src/connect-manager.html
+++ b/packages/connect-examples/webextension-mv3/src/connect-manager.html
@@ -5,10 +5,11 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     </head>
+
     <body>
         <button id="tab">New tab</button>
-        <button id="get-features" data-test="get-features">Get features</button>
-        <button id="get-address" data-test="get-address">Get address</button>
+        <button id="get-features" data-test-id="get-features">Get features</button>
+        <button id="get-address" data-test-id="get-address">Get address</button>
         <div id="result"></div>
         <!-- TODO: try to load changing content security policy -->
         <!-- https://developer.chrome.com/docs/extensions/mv3/manifest/content_security_policy/ -->

--- a/packages/connect-explorer/src/components/Method.tsx
+++ b/packages/connect-explorer/src/components/Method.tsx
@@ -49,7 +49,7 @@ export const getField = (field: Field<any> | FieldWithBundle<any>, props: Props)
         case 'checkbox':
             return (
                 <Checkbox
-                    data-test={`@checkbox/${field.name}`}
+                    data-test-id={`@checkbox/${field.name}`}
                     key={field.name}
                     field={field}
                     onChange={props.actions.onFieldChange}
@@ -119,7 +119,7 @@ const Method = () => {
         <MethodContent>
             {fields.map(field => getField(field, { actions }))}
             <Row>
-                <Button onClick={onSubmit} data-test="@submit-button">
+                <Button onClick={onSubmit} data-test-id="@submit-button">
                     {submitButton}
                 </Button>
                 {response && response.success && <VerifyButton name={name} onClick={onVerify} />}

--- a/packages/connect-explorer/src/components/Response.tsx
+++ b/packages/connect-explorer/src/components/Response.tsx
@@ -123,7 +123,7 @@ const Response = ({ code, docs, hasDocumentation, response, tab }: ResponseProps
                         ) : null;
 
                         return (
-                            <Container data-test="@response">
+                            <Container data-test-id="@response">
                                 <CopyToClipboard data={JSON.stringify(response, null, 2)} />
                                 {json}
                             </Container>
@@ -132,7 +132,7 @@ const Response = ({ code, docs, hasDocumentation, response, tab }: ResponseProps
 
                     case 'code':
                         return (
-                            <CodeContainer data-test="@code">
+                            <CodeContainer data-test-id="@code">
                                 <CopyToClipboard data={code} />
                                 {code}
                             </CodeContainer>
@@ -140,7 +140,7 @@ const Response = ({ code, docs, hasDocumentation, response, tab }: ResponseProps
 
                     case 'docs':
                         return (
-                            <div data-test="@docs">
+                            <div data-test-id="@docs">
                                 <Container
                                     className="docs-container"
                                     dangerouslySetInnerHTML={{ __html: docs! }}

--- a/packages/connect-explorer/src/components/Settings.tsx
+++ b/packages/connect-explorer/src/components/Settings.tsx
@@ -46,7 +46,7 @@ export const Settings = () => {
         <SettingsContent>
             {fields.map(field => getField(field, { actions }))}
             <Row>
-                <Button onClick={actions.onSubmitInit} data-test="@submit-button">
+                <Button onClick={actions.onSubmitInit} data-test-id="@submit-button">
                     {submitButton}
                 </Button>
             </Row>

--- a/packages/connect-popup/e2e/playwright.config.ts
+++ b/packages/connect-popup/e2e/playwright.config.ts
@@ -10,6 +10,7 @@ const config: PlaywrightTestConfig = {
         ignoreHTTPSErrors: true,
         trace: 'retain-on-failure',
         ...devices['Desktop Chrome'],
+        testIdAttribute: 'data-test-id',
     },
 };
 export default config;

--- a/packages/connect-popup/e2e/support/helpers.ts
+++ b/packages/connect-popup/e2e/support/helpers.ts
@@ -4,16 +4,16 @@ import { BrowserContext, chromium, Page } from '@playwright/test';
 // Waits and clicks for an array on buttons in serial order.
 export const waitAndClick = async (page: Page, buttons: string[]) => {
     for (const button of buttons) {
-        await page.waitForSelector(`[data-test='${button}']`, { state: 'visible' });
-        await page.click(`[data-test='${button}']`);
+        await page.waitForSelector(`[data-test-id='${button}']`, { state: 'visible' });
+        await page.click(`[data-test-id='${button}']`);
     }
 };
 
 // Helper to use data-test attributes to find elements.
 export const findElementByDataTest = async (page: Page, dataTest: string, timeout?: number) => {
-    await page.waitForSelector(`[data-test='${dataTest}']`, { state: 'visible', timeout });
+    await page.waitForSelector(`[data-test-id='${dataTest}']`, { state: 'visible', timeout });
 
-    return page.$(`[data-test='${dataTest}']`);
+    return page.$(`[data-test-id='${dataTest}']`);
 };
 
 export const log = (...val: string[]) => {
@@ -109,13 +109,13 @@ export const openPopup = (
     } else {
         triggerPopup.push(explorerPage.waitForEvent('popup'));
     }
-    triggerPopup.push(explorerPage.click("button[data-test='@submit-button']"));
+    triggerPopup.push(explorerPage.click("button[data-test-id='@submit-button']"));
 
     return Promise.all(triggerPopup) as Promise<Page[]>;
 };
 
 export const checkHasLogs = async (logPage: Page) => {
-    const locator = await logPage.locator("button[data-test='@log-container/download-button']");
+    const locator = await logPage.locator("button[data-test-id='@log-container/download-button']");
     if (await locator.isVisible()) {
         return true;
     }
@@ -126,7 +126,7 @@ export const checkHasLogs = async (logPage: Page) => {
 export const downloadLogs = async (logPage: Page, downloadLogPath: string) => {
     const [download] = await Promise.all([
         logPage.waitForEvent('download'), // wait for download to start
-        logPage.click("button[data-test='@log-container/download-button']"),
+        logPage.click("button[data-test-id='@log-container/download-button']"),
     ]);
 
     await download.saveAs(downloadLogPath);

--- a/packages/connect-popup/e2e/tests/__fixtures__/methods.ts
+++ b/packages/connect-popup/e2e/tests/__fixtures__/methods.ts
@@ -81,11 +81,11 @@ const getAddress = [
         views: [
             confirmExportAddressScreen,
             {
-                selector: '[data-test="@passphrase/enter-on-device-button"]',
+                selector: '[data-test-id="@passphrase/enter-on-device-button"]',
                 screenshot: {
                     name: 'passhprase-screen',
                 },
-                next: '[data-test="@passphrase/enter-on-device-button"]',
+                next: '[data-test-id="@passphrase/enter-on-device-button"]',
             },
             {
                 selector: '.passphrase-on-device >> visible=true',
@@ -227,7 +227,7 @@ const signMessage = [
         device: initializedDevice,
         views: [
             {
-                selector: '[data-test="@info-panel"]', // does not have a special screen
+                selector: '[data-test-id="@info-panel"]', // does not have a special screen
                 screenshot: {
                     name: 'sign-message',
                 },
@@ -236,7 +236,7 @@ const signMessage = [
                 },
             },
             {
-                selector: '[data-test="@info-panel"]',
+                selector: '[data-test-id="@info-panel"]',
                 nextEmu: {
                     type: 'emulator-press-yes',
                 },

--- a/packages/connect-popup/e2e/tests/analytics.test.ts
+++ b/packages/connect-popup/e2e/tests/analytics.test.ts
@@ -29,12 +29,12 @@ test('reporting', async ({ page }) => {
 
     await page.goto(`${url}#/method/getAddress`);
 
-    await page.waitForSelector("button[data-test='@submit-button']", { state: 'visible' });
+    await page.waitForSelector("button[data-test-id='@submit-button']", { state: 'visible' });
     const [popup] = await Promise.all([
         // It is important to call waitForEvent before click to set up waiting.
         page.waitForEvent('popup'),
         // Opens popup.
-        page.click("button[data-test='@submit-button']"),
+        page.click("button[data-test-id='@submit-button']"),
     ]);
     await popup.waitForLoadState('load');
 
@@ -51,11 +51,11 @@ test('reporting', async ({ page }) => {
     // analytics events sent yet
     expect(requests.length).toEqual(0);
 
-    await popup.waitForSelector("div[data-test='@analytics/consent']", {
+    await popup.waitForSelector("div[data-test-id='@analytics/consent']", {
         state: 'visible',
         timeout: 40000,
     });
-    await popup.click("button[data-test='@analytics/continue-button']");
+    await popup.click("button[data-test-id='@analytics/continue-button']");
 
     // analytics is now enabled, events should be sent now
     expect(requests.length).toBeGreaterThan(0);
@@ -64,14 +64,14 @@ test('reporting', async ({ page }) => {
     // should be saved in local storage
     expect(localStorage.search('"tracking_enabled\\":true')).toBeTruthy();
 
-    await popup.click("div[data-test='@analytics/settings']");
+    await popup.click("div[data-test-id='@analytics/settings']");
 
     // disable analytics
-    await popup.click("div[data-test='@analytics/toggle-switch']");
+    await popup.click("div[data-test-id='@analytics/toggle-switch']");
 
     requests = [];
 
-    await popup.click("button[data-test='@analytics/continue-button']");
+    await popup.click("button[data-test-id='@analytics/continue-button']");
 
     // disable analytics event is sent
     expect(requests.length).toBe(1);

--- a/packages/connect-popup/e2e/tests/browser-support.test.ts
+++ b/packages/connect-popup/e2e/tests/browser-support.test.ts
@@ -20,7 +20,7 @@ const openPopup = async (page: Page) =>
             // It is important to call waitForEvent before click to set up waiting.
             page.waitForEvent('popup'),
             // Opens popup.
-            page.click("button[data-test='@submit-button']"),
+            page.click("button[data-test-id='@submit-button']"),
         ])
     )[0];
 
@@ -36,7 +36,7 @@ test('unsupported browser', async ({ browser }) => {
     });
     const page = await context.newPage();
     await page.goto(`${url}#/method/getPublicKey`);
-    await page.waitForSelector("button[data-test='@submit-button']", { state: 'visible' });
+    await page.waitForSelector("button[data-test-id='@submit-button']", { state: 'visible' });
     popup = await openPopup(page);
     await popup.waitForSelector('text=Unsupported browser');
     await popup.screenshot({ path: `${dir}/browser-not-supported.png` });
@@ -52,7 +52,7 @@ test('outdated-browser', async ({ browser }) => {
     });
     const page = await context.newPage();
     await page.goto(`${url}#/method/getPublicKey`);
-    await page.waitForSelector("button[data-test='@submit-button']", { state: 'visible' });
+    await page.waitForSelector("button[data-test-id='@submit-button']", { state: 'visible' });
     popup = await openPopup(page);
     await popup.waitForLoadState('load');
     await popup.waitForSelector('text=Outdated browser');

--- a/packages/connect-popup/e2e/tests/log-page.test.ts
+++ b/packages/connect-popup/e2e/tests/log-page.test.ts
@@ -39,7 +39,7 @@ test('log page should contain logs from shared worker', async ({ page, context }
     await page.goto(`${url}#/method/verifyMessage`);
     [popup] = await Promise.all([
         page.waitForEvent('popup'),
-        page.click("button[data-test='@submit-button']"),
+        page.click("button[data-test-id='@submit-button']"),
     ]);
     await popup.waitForLoadState('load');
     log(`loaded: ${url}#/method/verifyMessage`);
@@ -52,7 +52,7 @@ test('log page should contain logs from shared worker', async ({ page, context }
     log(`loaded: ${url}log.html`);
 
     log('waiting for download-button to be visible');
-    await logsPage.waitForSelector("button[data-test='@log-container/download-button']", {
+    await logsPage.waitForSelector("button[data-test-id='@log-container/download-button']", {
         state: 'visible',
         timeout: 40 * 1000,
     });
@@ -60,7 +60,7 @@ test('log page should contain logs from shared worker', async ({ page, context }
     log('clicking download button and waiting for download to start');
     const [download] = await Promise.all([
         logsPage.waitForEvent('download'), // wait for download to start
-        logsPage.click("button[data-test='@log-container/download-button']"),
+        logsPage.click("button[data-test-id='@log-container/download-button']"),
     ]);
 
     log('download started');

--- a/packages/connect-popup/e2e/tests/methods.test.ts
+++ b/packages/connect-popup/e2e/tests/methods.test.ts
@@ -89,11 +89,11 @@ filteredFixtures.forEach(f => {
         // screenshot request
         log(f.url, 'screenshot @trezor/connect call params');
 
-        const code = explorerPage.locator('[data-test="@code"]');
+        const code = explorerPage.locator('[data-test-id="@code"]');
         await code.screenshot({ path: `${screenshotsPath}/1-request.png` });
 
         log(f.url, 'submitting in connect explorer');
-        await explorerPage.waitForSelector("button[data-test='@submit-button']", {
+        await explorerPage.waitForSelector("button[data-test-id='@submit-button']", {
             state: 'visible',
         });
         log(f.url, 'waiting for popup promise');
@@ -102,11 +102,11 @@ filteredFixtures.forEach(f => {
         log(f.url, 'popup promise resolved');
 
         log(f.url, 'waiting for confirm analytics');
-        await popup.waitForSelector("button[data-test='@analytics/continue-button']", {
+        await popup.waitForSelector("button[data-test-id='@analytics/continue-button']", {
             state: 'visible',
             timeout: 40000,
         });
-        await popup.click("button[data-test='@analytics/continue-button']");
+        await popup.click("button[data-test-id='@analytics/continue-button']");
 
         log(f.url, 'waiting for confirm permissions button');
         await popup.waitForSelector('button.confirm', { state: 'visible' });
@@ -121,7 +121,7 @@ filteredFixtures.forEach(f => {
         const methodName = await popup.evaluate(() => {
             return (document as Document)
                 ?.querySelector('#react')
-                ?.shadowRoot?.querySelector("aside[data-test='@info-panel'] h2")?.textContent;
+                ?.shadowRoot?.querySelector("aside[data-test-id='@info-panel'] h2")?.textContent;
         });
         expect(methodName).not.toBe(undefined);
         expect(methodName).not.toBe('');
@@ -172,7 +172,7 @@ filteredFixtures.forEach(f => {
 
         // screenshot response
         log(f.url, 'screenshot response');
-        const response = explorerPage.locator('[data-test="@response"]');
+        const response = explorerPage.locator('[data-test-id="@response"]');
         await response.screenshot({ path: `${screenshotsPath}/4-response.png` });
         log(f.url, 'method finished');
     });

--- a/packages/connect-popup/e2e/tests/passphrase.test.ts
+++ b/packages/connect-popup/e2e/tests/passphrase.test.ts
@@ -81,9 +81,9 @@ test('input passphrase in popup and device accepts it', async ({ page }) => {
     await waitAndClick(popup, ['@permissions/confirm-button', '@export-address/confirm-button']);
 
     log('typing passphrase');
-    (await popup.waitForSelector("input[data-test='@passphrase/input']", { timeout: 40000 })).type(
-        'abc',
-    );
+    (
+        await popup.waitForSelector("input[data-test-id='@passphrase/input']", { timeout: 40000 })
+    ).type('abc');
 
     log('submitting passphrase');
     await waitAndClick(popup, ['@passphrase/hidden/submit-button']);
@@ -121,7 +121,7 @@ test('introduce passphrase in popup and device rejects it', async ({ page }) => 
     log('waiting for confirm permissions button');
     await waitAndClick(popup, ['@permissions/confirm-button', '@export-address/confirm-button']);
 
-    (await popup.waitForSelector("input[data-test='@passphrase/input']")).type('abc');
+    (await popup.waitForSelector("input[data-test-id='@passphrase/input']")).type('abc');
 
     await waitAndClick(popup, ['@passphrase/hidden/submit-button']);
 
@@ -156,7 +156,7 @@ test('introduce passphrase successfully next time should not ask for it', async 
     log('waiting for confirm permissions button');
     await waitAndClick(popup, ['@permissions/confirm-button', '@export-address/confirm-button']);
 
-    (await popup.waitForSelector("input[data-test='@passphrase/input']")).type('abc');
+    (await popup.waitForSelector("input[data-test-id='@passphrase/input']")).type('abc');
 
     await waitAndClick(popup, ['@passphrase/hidden/submit-button']);
 
@@ -207,7 +207,7 @@ test('introduce passphrase successfully reload 3rd party it should ask again for
     log('waiting and click confirm permissions button');
     await waitAndClick(popup, ['@permissions/confirm-button', '@export-address/confirm-button']);
 
-    (await popup.waitForSelector("input[data-test='@passphrase/input']")).type('abc');
+    (await popup.waitForSelector("input[data-test-id='@passphrase/input']")).type('abc');
 
     await waitAndClick(popup, ['@passphrase/hidden/submit-button']);
 
@@ -236,7 +236,7 @@ test('introduce passphrase successfully reload 3rd party it should ask again for
     await waitAndClick(popup, ['@permissions/confirm-button', '@export-address/confirm-button']);
 
     // Popup should go to passphrase screen
-    await popup.waitForSelector("input[data-test='@passphrase/input']");
+    await popup.waitForSelector("input[data-test-id='@passphrase/input']");
 });
 
 test('passphrase mismatch', async ({ page }) => {
@@ -276,7 +276,7 @@ test('passphrase mismatch', async ({ page }) => {
 
     log('typing passphrase');
     // use different passphrase (not corresponding to device.state)
-    (await popup.waitForSelector("input[data-test='@passphrase/input']")).type('cba');
+    (await popup.waitForSelector("input[data-test-id='@passphrase/input']")).type('cba');
     log('submitting passphrase');
     await waitAndClick(popup, ['@passphrase/hidden/submit-button']);
     // Accept to see Passphrase.
@@ -292,7 +292,7 @@ test('passphrase mismatch', async ({ page }) => {
 
     log('typing passphrase');
     // Input right passphrase.
-    (await popup.waitForSelector("input[data-test='@passphrase/input']")).type('abc');
+    (await popup.waitForSelector("input[data-test-id='@passphrase/input']")).type('abc');
 
     log('submitting passphrase');
     await waitAndClick(popup, ['@passphrase/hidden/submit-button']);
@@ -335,7 +335,7 @@ test('passphrase mismatch', async ({ page }) => {
     await waitAndClick(popup, ['@permissions/confirm-button', '@export-address/confirm-button']);
 
     // Use different passphrase (not corresponding to device.state)
-    (await popup.waitForSelector("input[data-test='@passphrase/input']")).type('cba');
+    (await popup.waitForSelector("input[data-test-id='@passphrase/input']")).type('cba');
 
     await waitAndClick(popup, ['@passphrase/hidden/submit-button']);
 

--- a/packages/connect-popup/e2e/tests/permissions.test.ts
+++ b/packages/connect-popup/e2e/tests/permissions.test.ts
@@ -32,7 +32,7 @@ const fixtures = [
             'iframe and host same origins but with settings to NOT trustedHost -> show permissions',
         queryString: '',
         setTrustedHost: false,
-        expect: () => popup.waitForSelector("[data-test='@permissions/confirm-button']"),
+        expect: () => popup.waitForSelector("[data-test-id='@permissions/confirm-button']"),
     },
 ];
 
@@ -47,7 +47,7 @@ fixtures.forEach(f => {
 
         [popup] = await Promise.all([
             page.waitForEvent('popup'),
-            page.click("button[data-test='@submit-button']"),
+            page.click("button[data-test-id='@submit-button']"),
         ]);
 
         await f.expect();

--- a/packages/connect-popup/e2e/tests/popup-close-legacy.test.ts
+++ b/packages/connect-popup/e2e/tests/popup-close-legacy.test.ts
@@ -58,8 +58,8 @@ test.beforeEach(async ({ page }) => {
     await TrezorUserEnvLink.api.startBridge(BRIDGE_VERSION);
     log('beforeEach', 'go to: ', `${url}#/method/verifyMessage`);
     await page.goto(`${url}#/method/verifyMessage`);
-    log('beforeEach', 'waitForSelector: ', "button[data-test='@submit-button']");
-    await page.waitForSelector("button[data-test='@submit-button']", { state: 'visible' });
+    log('beforeEach', 'waitForSelector: ', "button[data-test-id='@submit-button']");
+    await page.waitForSelector("button[data-test-id='@submit-button']", { state: 'visible' });
 
     // Subscribe to 'request' and 'response' events.
     page.on('request', request => {
@@ -91,16 +91,16 @@ test.beforeEach(async ({ page }) => {
     log('beforeEach', 'waitForEvent: ', 'popup');
     [popup] = await Promise.all([
         page.waitForEvent('popup'),
-        page.click("button[data-test='@submit-button']"),
+        page.click("button[data-test-id='@submit-button']"),
     ]);
 
     log('beforeEach', 'waitForLoadState: ', 'load');
-    await popup.waitForSelector("button[data-test='@analytics/continue-button']", {
+    await popup.waitForSelector("button[data-test-id='@analytics/continue-button']", {
         state: 'visible',
         timeout: 40000,
     });
-    log('beforeEach', 'click: ', "button[data-test='@analytics/continue-button']");
-    await popup.click("button[data-test='@analytics/continue-button']");
+    log('beforeEach', 'click: ', "button[data-test-id='@analytics/continue-button']");
+    await popup.click("button[data-test-id='@analytics/continue-button']");
 
     popupClosedPromise = new Promise(resolve => {
         popup.on('close', () => resolve(undefined));
@@ -124,12 +124,12 @@ test.beforeEach(async ({ page }) => {
 test.afterEach(async ({ page }) => {
     log('afterEach', `goto: ${url}#/method/verifyMessage`);
     await page.goto(`${url}#/method/verifyMessage`);
-    log('afterEach', 'waitForSelector: ', "button[data-test='@submit-button']");
-    await page.waitForSelector("button[data-test='@submit-button']", { state: 'visible' });
+    log('afterEach', 'waitForSelector: ', "button[data-test-id='@submit-button']");
+    await page.waitForSelector("button[data-test-id='@submit-button']", { state: 'visible' });
     log('afterEach', 'waitForEvent: ', 'popup');
     [popup] = await Promise.all([
         page.waitForEvent('popup'),
-        page.click("button[data-test='@submit-button']"),
+        page.click("button[data-test-id='@submit-button']"),
     ]);
 
     log('afterEach', 'waitForLoadState: ', 'load');
@@ -219,7 +219,7 @@ test.skip(`popup is reloaded by user. bridge version ${BRIDGE_VERSION}`, async (
     await popup.reload();
     // after popup is reload, communication is lost, there is only infinite loader
     log('waiting for infinite loader');
-    await popup.waitForSelector('div[data-test="@connect-ui/loader"]');
+    await popup.waitForSelector('div[data-test-id="@connect-ui/loader"]');
     // todo: there is no message into client about the fact that popup was unloaded
 });
 
@@ -237,11 +237,11 @@ test.skip('when user cancels permissions in popup it closes automatically', asyn
     await popupClosedPromise;
 
     await page.goto(`${url}#/method/getAddress`);
-    await page.waitForSelector("button[data-test='@submit-button']", { state: 'visible' });
+    await page.waitForSelector("button[data-test-id='@submit-button']", { state: 'visible' });
 
     [popup] = await Promise.all([
         page.waitForEvent('popup'),
-        page.click("button[data-test='@submit-button']"),
+        page.click("button[data-test-id='@submit-button']"),
     ]);
 
     popupClosedPromise = new Promise(resolve => {
@@ -250,9 +250,9 @@ test.skip('when user cancels permissions in popup it closes automatically', asyn
 
     await popup.waitForLoadState('load');
     await popup.waitForSelector('button.confirm', { state: 'visible', timeout: 40000 });
-    await popup.waitForSelector("button[data-test='@permissions/confirm-button']");
+    await popup.waitForSelector("button[data-test-id='@permissions/confirm-button']");
     // We are testing that when cancel permissions, popup is closed automatically.
-    await popup.click("button[data-test='@permissions/cancel-button']");
+    await popup.click("button[data-test-id='@permissions/cancel-button']");
     // Wait for popup to close.
     await popupClosedPromise;
 });
@@ -273,10 +273,10 @@ test.skip('when user cancels Export Bitcoin address dialog in popup it closes au
     await popupClosedPromise;
 
     await page.goto(`${url}#/method/getAddress`);
-    await page.waitForSelector("button[data-test='@submit-button']", { state: 'visible' });
+    await page.waitForSelector("button[data-test-id='@submit-button']", { state: 'visible' });
     [popup] = await Promise.all([
         page.waitForEvent('popup'),
-        page.click("button[data-test='@submit-button']"),
+        page.click("button[data-test-id='@submit-button']"),
     ]);
     popupClosedPromise = new Promise(resolve => {
         popup.on('close', () => resolve(undefined));
@@ -284,11 +284,11 @@ test.skip('when user cancels Export Bitcoin address dialog in popup it closes au
 
     await popup.waitForLoadState('load');
     await popup.waitForSelector('button.confirm', { state: 'visible', timeout: 40000 });
-    await popup.waitForSelector("button[data-test='@permissions/confirm-button']");
-    await popup.click("button[data-test='@permissions/confirm-button']");
-    await popup.waitForSelector("button[data-test='@export-address/cancel-button']");
+    await popup.waitForSelector("button[data-test-id='@permissions/confirm-button']");
+    await popup.click("button[data-test-id='@permissions/confirm-button']");
+    await popup.waitForSelector("button[data-test-id='@export-address/cancel-button']");
     // We are testing that when cancel Export Bitcoin address, popup is closed automatically.
-    await popup.click("button[data-test='@export-address/cancel-button']");
+    await popup.click("button[data-test-id='@export-address/cancel-button']");
     // Wait for popup to close.
     await popupClosedPromise;
 });

--- a/packages/connect-popup/e2e/tests/popup-close.test.ts
+++ b/packages/connect-popup/e2e/tests/popup-close.test.ts
@@ -75,7 +75,7 @@ test.beforeAll(async () => {
         explorerUrl = contexts.exploreUrl;
 
         await explorerPage.goto(`${explorerUrl}#/method/verifyMessage`);
-        await explorerPage.waitForSelector("button[data-test='@submit-button']", {
+        await explorerPage.waitForSelector("button[data-test-id='@submit-button']", {
             state: 'visible',
         });
 
@@ -110,12 +110,12 @@ test.beforeAll(async () => {
         [popup] = await openPopup(browserContext, explorerPage, isWebExtension);
 
         log('beforeEach', 'waiting for analytics confirm button');
-        await popup.waitForSelector("button[data-test='@analytics/continue-button']", {
+        await popup.waitForSelector("button[data-test-id='@analytics/continue-button']", {
             state: 'visible',
             timeout: 40000,
         });
         log('beforeEach', 'clicking on analytics confirm button');
-        await popup.click("button[data-test='@analytics/continue-button']");
+        await popup.click("button[data-test-id='@analytics/continue-button']");
 
         popupClosedPromise = new Promise(resolve => {
             popup.on('close', () => resolve(undefined));
@@ -162,7 +162,7 @@ test.beforeAll(async () => {
         log('afterEach', 'go to verifyMessage');
         await explorerPage.goto(`${explorerUrl}#/method/verifyMessage`);
         log('afterEach', 'waiting for submit button');
-        await explorerPage.waitForSelector("button[data-test='@submit-button']", {
+        await explorerPage.waitForSelector("button[data-test-id='@submit-button']", {
             state: 'visible',
         });
         log('afterEach', 'waiting for popup open');
@@ -217,7 +217,7 @@ test.beforeAll(async () => {
             expect(response.url).not.toContain('post');
         });
 
-        await popup.click("button[data-test='@connect-ui/error-close-button']");
+        await popup.click("button[data-test-id='@connect-ui/error-close-button']");
         await releasePromise!.promise;
         await popupClosedPromise;
 
@@ -240,7 +240,7 @@ test.beforeAll(async () => {
             status: 400,
         });
 
-        await popup.click("button[data-test='@connect-ui/error-close-button']");
+        await popup.click("button[data-test-id='@connect-ui/error-close-button']");
         await releasePromise!.promise;
         await popupClosedPromise;
 
@@ -284,7 +284,7 @@ test.beforeAll(async () => {
         log(`test: ${test.info().title}`);
         await popup.reload();
         // after popup is reload, communication is lost, there is only infinite loader
-        await popup.waitForSelector('div[data-test="@connect-ui/loader"]');
+        await popup.waitForSelector('div[data-test-id="@connect-ui/loader"]');
         // todo: there is no message into client about the fact that popup was unloaded
     });
 
@@ -302,7 +302,7 @@ test.beforeAll(async () => {
         await popupClosedPromise;
 
         await explorerPage.goto(`${explorerUrl}#/method/getAddress`);
-        await explorerPage.waitForSelector("button[data-test='@submit-button']", {
+        await explorerPage.waitForSelector("button[data-test-id='@submit-button']", {
             state: 'visible',
         });
 
@@ -315,9 +315,9 @@ test.beforeAll(async () => {
 
         await popup.waitForLoadState('load');
         await popup.waitForSelector('button.confirm', { state: 'visible', timeout: 40000 });
-        await popup.waitForSelector("button[data-test='@permissions/confirm-button']");
+        await popup.waitForSelector("button[data-test-id='@permissions/confirm-button']");
         // We are testing that when cancel permissions, popup is closed automatically.
-        await popup.click("button[data-test='@permissions/cancel-button']");
+        await popup.click("button[data-test-id='@permissions/cancel-button']");
         // Wait for popup to close.
         await popupClosedPromise;
     });
@@ -336,7 +336,7 @@ test.beforeAll(async () => {
         await popupClosedPromise;
 
         await explorerPage.goto(`${explorerUrl}#/method/getAddress`);
-        await explorerPage.waitForSelector("button[data-test='@submit-button']", {
+        await explorerPage.waitForSelector("button[data-test-id='@submit-button']", {
             state: 'visible',
         });
 
@@ -348,11 +348,11 @@ test.beforeAll(async () => {
 
         await popup.waitForLoadState('load');
         await popup.waitForSelector('button.confirm', { state: 'visible', timeout: 40000 });
-        await popup.waitForSelector("button[data-test='@permissions/confirm-button']");
-        await popup.click("button[data-test='@permissions/confirm-button']");
-        await popup.waitForSelector("button[data-test='@export-address/cancel-button']");
+        await popup.waitForSelector("button[data-test-id='@permissions/confirm-button']");
+        await popup.click("button[data-test-id='@permissions/confirm-button']");
+        await popup.waitForSelector("button[data-test-id='@export-address/cancel-button']");
         // We are testing that when cancel Export Bitcoin address, popup is closed automatically.
-        await popup.click("button[data-test='@export-address/cancel-button']");
+        await popup.click("button[data-test-id='@export-address/cancel-button']");
         // Wait for popup to close.
         await popupClosedPromise;
     });
@@ -397,7 +397,7 @@ test.beforeAll(async () => {
         await popupClosedPromise;
 
         await explorerPage.goto(`${explorerUrl}#/method/getAddress`);
-        await explorerPage.waitForSelector("button[data-test='@submit-button']", {
+        await explorerPage.waitForSelector("button[data-test-id='@submit-button']", {
             state: 'visible',
         });
 
@@ -408,7 +408,7 @@ test.beforeAll(async () => {
             popup.on('close', () => resolve(undefined));
         });
 
-        await popup.waitForSelector("button[data-test='@permissions/confirm-button']");
+        await popup.waitForSelector("button[data-test-id='@permissions/confirm-button']");
 
         await waitAndClick(popup, ['@permissions/confirm-button']);
 
@@ -441,7 +441,7 @@ test.beforeAll(async () => {
         await popupClosedPromise;
 
         await explorerPage.goto(`${explorerUrl}#/method/getAddress`);
-        await explorerPage.waitForSelector("button[data-test='@submit-button']", {
+        await explorerPage.waitForSelector("button[data-test-id='@submit-button']", {
             state: 'visible',
         });
         log('waiting for popup open');

--- a/packages/connect-popup/e2e/tests/popup-error-page.test.ts
+++ b/packages/connect-popup/e2e/tests/popup-error-page.test.ts
@@ -53,24 +53,26 @@ test('popup should display error page when device disconnected and debug mode', 
     log('opening explorer page');
     await explorerPage.goto(`${exploreUrl}#/method/verifyMessage`);
     log('waiting for explorer to load');
-    await explorerPage.waitForSelector("button[data-test='@submit-button']", { state: 'visible' });
+    await explorerPage.waitForSelector("button[data-test-id='@submit-button']", {
+        state: 'visible',
+    });
 
     log('opening popup');
     [popup] = await openPopup(context, explorerPage, isWebExtension);
 
     log('waiting for popup analytics to load');
-    await popup.waitForSelector("button[data-test='@analytics/continue-button']", {
+    await popup.waitForSelector("button[data-test-id='@analytics/continue-button']", {
         state: 'visible',
         timeout: 40000,
     });
     log('clicking on analytics continue button');
-    await popup.click("button[data-test='@analytics/continue-button']");
+    await popup.click("button[data-test-id='@analytics/continue-button']");
 
     log('waiting for permissions');
-    await popup.waitForSelector("div[data-test='@permissions']");
+    await popup.waitForSelector("div[data-test-id='@permissions']");
 
     log('stopEmu');
     await TrezorUserEnvLink.api.stopEmu();
     log('waiting for popup error page');
-    await popup.waitForSelector("div[data-test='@connect-ui/error']");
+    await popup.waitForSelector("div[data-test-id='@connect-ui/error']");
 });

--- a/packages/connect-popup/e2e/tests/transport.test.ts
+++ b/packages/connect-popup/e2e/tests/transport.test.ts
@@ -40,7 +40,7 @@ fixtures.forEach(f => {
 
         [popup] = await Promise.all([
             page.waitForEvent('popup'),
-            page.click("button[data-test='@submit-button']"),
+            page.click("button[data-test-id='@submit-button']"),
         ]);
 
         await f.expect();

--- a/packages/connect-popup/e2e/tests/unchained.test.ts
+++ b/packages/connect-popup/e2e/tests/unchained.test.ts
@@ -14,11 +14,11 @@ test.beforeAll(async () => {
 });
 
 const handleAnalyticsConfirm = async (popup: Page) => {
-    await popup.waitForSelector("button[data-test='@analytics/continue-button']", {
+    await popup.waitForSelector("button[data-test-id='@analytics/continue-button']", {
         state: 'visible',
         timeout: 40000,
     });
-    await popup.click("button[data-test='@analytics/continue-button']");
+    await popup.click("button[data-test-id='@analytics/continue-button']");
 };
 
 /**

--- a/packages/connect-popup/src/log.tsx
+++ b/packages/connect-popup/src/log.tsx
@@ -70,7 +70,7 @@ const DownloadButton = ({ array, filename }: { array: any[]; filename: string })
     };
 
     return (
-        <Button data-test="@log-container/download-button" onClick={downloadArrayAsFile}>
+        <Button data-test-id="@log-container/download-button" onClick={downloadArrayAsFile}>
             Download Logs
         </Button>
     );
@@ -149,7 +149,7 @@ const DebugCenter = () => {
             {logs.length > 0 ? (
                 <View
                     title="Logs"
-                    data-test="@connect-logs/logs"
+                    data-test-id="@connect-logs/logs"
                     buttons={
                         <DownloadButton
                             array={orderByTimestamp(logs)}
@@ -165,7 +165,7 @@ const DebugCenter = () => {
                 </View>
             ) : (
                 <Wrapper>
-                    <StyledP data-test="@connect-logs/no-logs">
+                    <StyledP data-test-id="@connect-logs/no-logs">
                         Waiting for an app to connect
                     </StyledP>
                 </Wrapper>

--- a/packages/connect-popup/src/static/popup.html
+++ b/packages/connect-popup/src/static/popup.html
@@ -22,6 +22,7 @@
         <!-- suite-like fonts -->
         <link media="all" rel="stylesheet" href="./fonts/fonts.css" />
     </head>
+
     <body>
         <main>
             <!--
@@ -275,7 +276,7 @@
             <!-- Passphrase: END -->
 
             <!-- invalid passphrase -->
-            <div data-test="@invalid-passphrase" class="invalid-passphrase">
+            <div data-test-id="@invalid-passphrase" class="invalid-passphrase">
                 <div>
                     <h3>Passphrase doesn't match</h3>
                     <p>Looks like You have set a different passphrase</p>
@@ -475,11 +476,11 @@
                 </div>
 
                 <div class="buttons">
-                    <button data-test="@invalid-passphrase/try-again" class="confirm retry">
+                    <button data-test-id="@invalid-passphrase/try-again" class="confirm retry">
                         No, Try again
                     </button>
                     <button
-                        data-test="@invalid-passphrase/use-this-passphrase"
+                        data-test-id="@invalid-passphrase/use-this-passphrase"
                         class="cancel useCurrent"
                         tabindex="4"
                     >
@@ -490,7 +491,7 @@
             <!-- invalid passphrase: END -->
 
             <!-- Permissions -->
-            <div data-test="@permissions" class="permissions">
+            <div data-test-id="@permissions" class="permissions">
                 <h3>Allow<span class="host-name"></span>permissions to:</h3>
 
                 <div class="list-wrapper">
@@ -511,10 +512,10 @@
                     >
                 </div>
                 <div class="buttons">
-                    <button data-test="@permissions/confirm-button" class="confirm">
+                    <button data-test-id="@permissions/confirm-button" class="confirm">
                         Allow once for this session
                     </button>
-                    <button data-test="@permissions/cancel-button" class="cancel">Cancel</button>
+                    <button data-test-id="@permissions/cancel-button" class="cancel">Cancel</button>
                 </div>
             </div>
             <!-- Permissions: END -->
@@ -2849,7 +2850,7 @@
             <!-- No backup confirmation: END -->
 
             <!-- Export address -->
-            <div data-test="@export-address" class="export-address">
+            <div data-test-id="@export-address" class="export-address">
                 <div>
                     <h3></h3>
                 </div>
@@ -3144,16 +3145,18 @@
                     </svg>
                 </div>
                 <div class="buttons">
-                    <button data-test="@export-address/confirm-button" class="confirm">
+                    <button data-test-id="@export-address/confirm-button" class="confirm">
                         Export
                     </button>
-                    <button data-test="@export-address/cancel-button" class="cancel">Cancel</button>
+                    <button data-test-id="@export-address/cancel-button" class="cancel">
+                        Cancel
+                    </button>
                 </div>
             </div>
             <!-- Export address: END -->
 
             <!-- Check address on device -->
-            <div data-test="@check-address-on-device" class="check-address">
+            <div data-test-id="@check-address-on-device" class="check-address">
                 <svg width="12px" height="35px" viewBox="0 0 20 57">
                     <g stroke="none" stroke-width="1" fill="none" transform="translate(1, 1)">
                         <path

--- a/packages/connect-ui/src/components/FloatingMenu.tsx
+++ b/packages/connect-ui/src/components/FloatingMenu.tsx
@@ -23,7 +23,7 @@ const IconWrapper = styled.div`
 type FloatingMenuProps = { onShowAnalyticsConsent: () => void };
 
 export const FloatingMenu = ({ onShowAnalyticsConsent }: FloatingMenuProps) => (
-    <IconWrapper onClick={onShowAnalyticsConsent} data-test="@analytics/settings">
+    <IconWrapper onClick={onShowAnalyticsConsent} data-test-id="@analytics/settings">
         <Icon icon="SETTINGS" size={22} color={colors.TYPE_DARK_GREY} />
     </IconWrapper>
 );

--- a/packages/connect-ui/src/components/InfoPanel.tsx
+++ b/packages/connect-ui/src/components/InfoPanel.tsx
@@ -74,7 +74,7 @@ interface InfoPanelProps {
 
 export const InfoPanel = ({ method, origin, hostLabel, topSlot }: InfoPanelProps) => (
     <>
-        <Aside data-test="@info-panel">
+        <Aside data-test-id="@info-panel">
             {/*  notifications appear hear */}
             {topSlot && topSlot}
 

--- a/packages/connect-ui/src/components/Loader.tsx
+++ b/packages/connect-ui/src/components/Loader.tsx
@@ -99,7 +99,7 @@ interface LoaderProps {
     message?: string;
 }
 export const Loader = ({ message }: LoaderProps) => (
-    <StyledLoaderWrapper data-test="@connect-ui/loader">
+    <StyledLoaderWrapper data-test-id="@connect-ui/loader">
         <StyledLoader>
             <Circular>
                 <svg

--- a/packages/connect-ui/src/views/Error.tsx
+++ b/packages/connect-ui/src/views/Error.tsx
@@ -246,7 +246,7 @@ export const ErrorView = (props: ErrorViewProps) => {
     const tips = getTroubleshootingTips(props);
 
     return (
-        <View data-test="@connect-ui/error">
+        <View data-test-id="@connect-ui/error">
             <InnerWrapper>
                 <H>Error</H>
 
@@ -280,7 +280,7 @@ export const ErrorView = (props: ErrorViewProps) => {
                 </TipsContainer>
 
                 <Button
-                    data-test="@connect-ui/error-close-button"
+                    data-test-id="@connect-ui/error-close-button"
                     variant="primary"
                     onClick={() => window.close()}
                 >

--- a/packages/connect-web/e2e/playwright.config.ts
+++ b/packages/connect-web/e2e/playwright.config.ts
@@ -9,6 +9,7 @@ const config: PlaywrightTestConfig = {
         headless: process.env.HEADLESS === 'true',
         ignoreHTTPSErrors: true,
         trace: 'retain-on-failure',
+        testIdAttribute: 'data-test-id',
     },
 };
 export default config;

--- a/packages/connect-webextension/e2e/playwright.config.ts
+++ b/packages/connect-webextension/e2e/playwright.config.ts
@@ -9,5 +9,6 @@ export const config: PlaywrightTestConfig = {
         headless: process.env.HEADLESS === 'true',
         ignoreHTTPSErrors: true,
         trace: 'retain-on-failure',
+        testIdAttribute: 'data-test-id',
     },
 };

--- a/packages/connect-webextension/e2e/webextension.test.ts
+++ b/packages/connect-webextension/e2e/webextension.test.ts
@@ -75,18 +75,18 @@ test('Basic web extension MV2', async () => {
     await page.goto(`chrome-extension://${extensionId}/connect-manager.html`);
 
     // Wait for connect to be ready.
-    await page.waitForSelector("div[data-test='connect-loaded']");
+    await page.waitForSelector("div[data-test-id='connect-loaded']");
 
-    await page.waitForSelector("button[data-test='get-address']");
-    await page.click("button[data-test='get-address']");
+    await page.waitForSelector("button[data-test-id='get-address']");
+    await page.click("button[data-test-id='get-address']");
 
     const popup = await browserContext.waitForEvent('page');
     await popup.waitForLoadState('load');
-    await popup.waitForSelector("button[data-test='@analytics/continue-button']", {
+    await popup.waitForSelector("button[data-test-id='@analytics/continue-button']", {
         state: 'visible',
         timeout: 40000,
     });
-    await popup.click("button[data-test='@analytics/continue-button']");
+    await popup.click("button[data-test-id='@analytics/continue-button']");
 
     await popup.waitForSelector('button.confirm', { state: 'visible', timeout: 40000 });
     await popup.click('button.confirm');
@@ -165,17 +165,17 @@ test('Basic web extension MV3', async () => {
     await page.goto(`chrome-extension://${extensionId}/connect-manager.html`);
     await page.screenshot({ path: `${dir}/web-extension-mv3-1.png` });
 
-    await (await page.waitForSelector("button[data-test='get-address']")).click();
+    await (await page.waitForSelector("button[data-test-id='get-address']")).click();
 
     const popup = await browserContext.waitForEvent('page');
     await popup.waitForLoadState('load');
 
     // There is not analytics button since this test is after the MV2 that already clicked it and the container is not pruned after.
-    // await popup.waitForSelector("button[data-test='@analytics/continue-button']", {
+    // await popup.waitForSelector("button[data-test-id='@analytics/continue-button']", {
     //     state: 'visible',
     //     timeout: 40000,
     // });
-    // await popup.click("button[data-test='@analytics/continue-button']");
+    // await popup.click("button[data-test-id='@analytics/continue-button']");
 
     await popup.waitForSelector('button.confirm', { state: 'visible', timeout: 40000 });
     await popup.click('button.confirm');

--- a/packages/suite-data/src/browser-detection/index.ts
+++ b/packages/suite-data/src/browser-detection/index.ts
@@ -69,11 +69,11 @@ window.addEventListener('load', () => {
                 <br>
                 To keep your funds safe, we recommend using the latest version of a supported browser.
                 </p>
-                <p class=${style.continueButton} id="continue-to-suite" data-test="@continue-to-suite">Continue at my own risk</p>`
+                <p class=${style.continueButton} id="continue-to-suite" data-test-id="@continue-to-suite">Continue at my own risk</p>`
             : '';
 
     const getMainHtml = (props: MainHtmlProps) => `
-    <div id="unsupported-browser" class="${style.container}" data-test="@browser-detect">
+    <div id="unsupported-browser" class="${style.container}" data-test-id="@browser-detect">
         <h1 class="${style.title}">${props.title}</h1>
         <p class="${style.subtitle}">${props.subtitle}</p>
         ${getSupportedDevicesList(props)}

--- a/packages/suite-desktop-core/e2e/playwright.config.ts
+++ b/packages/suite-desktop-core/e2e/playwright.config.ts
@@ -9,7 +9,7 @@ const config: PlaywrightTestConfig = {
         trace: 'on',
         video: 'on',
         screenshot: 'on',
-        testIdAttribute: 'data-test',
+        testIdAttribute: 'data-test-id',
     },
     reportSlowTests: null,
     reporter: [['list']],

--- a/packages/suite-desktop-core/e2e/support/common.ts
+++ b/packages/suite-desktop-core/e2e/support/common.ts
@@ -39,11 +39,11 @@ export const launchSuite = async () => {
 };
 
 export const waitForDataTestSelector = (window: Page, selector: string, options = {}) =>
-    window.waitForSelector(`[data-test="${selector}"]`, options);
+    window.waitForSelector(`[data-test-id="${selector}"]`, options);
 
 // TODO: usage of .click is discouraged by playwright devs. Refactor all usage to locator.click()
 export const clickDataTest = (window: Page, selector: string) => {
-    window.click(`[data-test="${selector}"]`);
+    window.click(`[data-test-id="${selector}"]`);
 };
 
 export const rmDirRecursive = (folder: string) => {

--- a/packages/suite-desktop-core/e2e/support/pageActions/suiteGuideActions.ts
+++ b/packages/suite-desktop-core/e2e/support/pageActions/suiteGuideActions.ts
@@ -59,9 +59,9 @@ class SuiteGuide {
 
     async closeGuide(window: Page) {
         // since there's a possibility of a notification, we first check for it
-        const suiteNotification = await window.locator('[data-test*="@toast"]').first();
+        const suiteNotification = await window.locator('[data-test-id*="@toast"]').first();
         if (await suiteNotification.isVisible()) {
-            await suiteNotification.locator('[data-test$="close"]').click();
+            await suiteNotification.locator('[data-test-id$="close"]').click();
             await suiteNotification.waitFor({ state: 'detached' });
         }
         await window.getByTestId('@guide/button-close').click();

--- a/packages/suite-desktop-core/e2e/tests/coinjoin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/coinjoin.test.ts
@@ -22,62 +22,62 @@ import { sendToAddress, generateBlock, waitForCoinjoinBackend } from '../support
 const timeout = 1000 * 60 * 5;
 
 const enableCoinjoinInSettings = async (window: Page) => {
-    await window.click('[data-test="@suite/menu/settings"]');
+    await window.click('[data-test-id="@suite/menu/settings"]');
 
     // enable debug
     for (let i = 0; i < 5; i++) {
-        await window.click('[data-test="@settings/menu/title"]');
+        await window.click('[data-test-id="@settings/menu/title"]');
     }
 
     // go to debug menu
-    await window.click('[data-test="@settings/menu/debug"]');
+    await window.click('[data-test-id="@settings/menu/debug"]');
 
     // change regtest server source to localhost (actually not changing anything because it is default)
-    await window.click('[data-test="@settings/debug/coinjoin/regtest/server-select/input"]', {
+    await window.click('[data-test-id="@settings/debug/coinjoin/regtest/server-select/input"]', {
         trial: true,
     });
-    await window.click('[data-test="@settings/debug/coinjoin/regtest/server-select/input"]');
+    await window.click('[data-test-id="@settings/debug/coinjoin/regtest/server-select/input"]');
     await window.click(
-        '[data-test="@settings/debug/coinjoin/regtest/server-select/option/localhost"]',
+        '[data-test-id="@settings/debug/coinjoin/regtest/server-select/option/localhost"]',
     );
-    await window.click('[data-test="@settings/debug/coinjoin/allow-no-tor"] >> role=button');
+    await window.click('[data-test-id="@settings/debug/coinjoin/allow-no-tor"] >> role=button');
 
     // go to coins menu
-    await window.click('[data-test="@settings/menu/wallet"]');
-    await window.click('[data-test="@settings/wallet/network/btc"]'); // disable btc
-    await window.click('[data-test="@settings/wallet/network/regtest"]'); // enable regtest
+    await window.click('[data-test-id="@settings/menu/wallet"]');
+    await window.click('[data-test-id="@settings/wallet/network/btc"]'); // disable btc
+    await window.click('[data-test-id="@settings/wallet/network/regtest"]'); // enable regtest
 
     // open advance settings for regtest
-    await window.click('[data-test="@settings/wallet/network/regtest/advance"]');
-    await window.click('[data-test="@settings/advance/button/save"]');
+    await window.click('[data-test-id="@settings/wallet/network/regtest/advance"]');
+    await window.click('[data-test-id="@settings/advance/button/save"]');
 };
 
 const startCoinjoin = async (window: Page) => {
     await window.click('role=button[name="Anonymize"]');
 
-    await window.click('[data-test="@coinjoin/checkbox"] div >> nth=0');
+    await window.click('[data-test-id="@coinjoin/checkbox"] div >> nth=0');
     await window.click('role=button[name="Anonymize"]');
-    await window.waitForSelector('[data-test="@prompts/confirm-on-device"]');
+    await window.waitForSelector('[data-test-id="@prompts/confirm-on-device"]');
     await TrezorUserEnvLink.api.pressYes();
-    await window.waitForSelector('[data-test="@prompts/confirm-on-device"]');
+    await window.waitForSelector('[data-test-id="@prompts/confirm-on-device"]');
     await TrezorUserEnvLink.api.pressYes();
 
     await window.waitForSelector('text=Collecting inputs');
 };
 
 const addCoinjoinAccount = async (window: Page) => {
-    await window.click('[data-test="@suite/menu/wallet-index"]');
-    await window.click('[data-test="@account-menu/add-account"]');
-    await window.click('[data-test="@settings/wallet/network/regtest"]');
-    await window.click('[data-test="@add-account-type/select/input"]', { trial: true });
-    await window.click('[data-test="@add-account-type/select/input"]');
-    await window.click('[data-test="@add-account-type/select/option/Bitcoin Regtest"]');
-    await window.click('[data-test="@add-account"]');
+    await window.click('[data-test-id="@suite/menu/wallet-index"]');
+    await window.click('[data-test-id="@account-menu/add-account"]');
+    await window.click('[data-test-id="@settings/wallet/network/regtest"]');
+    await window.click('[data-test-id="@add-account-type/select/input"]', { trial: true });
+    await window.click('[data-test-id="@add-account-type/select/input"]');
+    await window.click('[data-test-id="@add-account-type/select/option/Bitcoin Regtest"]');
+    await window.click('[data-test-id="@add-account"]');
 
     await window.screenshot({ path: './test-results/1.png', fullPage: true, type: 'png' });
-    await window.click('[data-test="@request-enable-tor-modal/skip-button"]');
+    await window.click('[data-test-id="@request-enable-tor-modal/skip-button"]');
     await window.screenshot({ path: './test-results/2.png', fullPage: true, type: 'png' });
-    await window.waitForSelector('[data-test="@prompts/confirm-on-device"]', {
+    await window.waitForSelector('[data-test-id="@prompts/confirm-on-device"]', {
         timeout: 60 * 1000,
     });
     // todo: this is weird it looks like device sometimes is not ready to accept pressYes, although modal
@@ -100,10 +100,10 @@ const receiveCoins = async () => {
 };
 
 const passThroughInitialRun = async (window: Page) => {
-    await window.click('[data-test="@analytics/continue-button"]');
-    await window.click('[data-test="@onboarding/exit-app-button"]');
-    await window.click('[data-test="@passphrase-type/standard"]');
-    await window.waitForSelector('[data-test="@dashboard/graph"]');
+    await window.click('[data-test-id="@analytics/continue-button"]');
+    await window.click('[data-test-id="@onboarding/exit-app-button"]');
+    await window.click('[data-test-id="@passphrase-type/standard"]');
+    await window.waitForSelector('[data-test-id="@dashboard/graph"]');
 };
 
 testPlaywright.describe('Coinjoin', () => {
@@ -145,24 +145,24 @@ testPlaywright.describe('Coinjoin', () => {
         // i know renders only when discovery is finished
         // https://github.com/trezor/trezor-suite/issues/6748
         // todo: anonymize should be added to wrapped methods in TrezorConnectActions
-        await suite.window.waitForSelector('[data-test="@wallet/menu/wallet-receive"]');
+        await suite.window.waitForSelector('[data-test-id="@wallet/menu/wallet-receive"]');
         await suite.window.waitForTimeout(5000);
 
         // enable passphrase 'a'
-        await suite.window.click('[data-test="@menu/switch-device"]');
-        await suite.window.click('[data-test="@switch-device/add-hidden-wallet-button"]');
-        await suite.window.locator('[data-test="@passphrase/input"]').type('a');
-        await suite.window.click('[data-test="@passphrase/hidden/submit-button"]');
-        await suite.window.waitForSelector('[data-test="@prompts/confirm-on-device"]');
+        await suite.window.click('[data-test-id="@menu/switch-device"]');
+        await suite.window.click('[data-test-id="@switch-device/add-hidden-wallet-button"]');
+        await suite.window.locator('[data-test-id="@passphrase/input"]').type('a');
+        await suite.window.click('[data-test-id="@passphrase/hidden/submit-button"]');
+        await suite.window.waitForSelector('[data-test-id="@prompts/confirm-on-device"]');
         await TrezorUserEnvLink.api.pressYes();
-        await suite.window.waitForSelector('[data-test="@prompts/confirm-on-device"]');
+        await suite.window.waitForSelector('[data-test-id="@prompts/confirm-on-device"]');
         await TrezorUserEnvLink.api.pressYes();
-        await suite.window.locator('[data-test="@passphrase/input"]').type('a');
-        await suite.window.click('[data-test="@passphrase/confirm-checkbox"] div >> nth=0');
-        await suite.window.click('[data-test="@passphrase/hidden/submit-button"]');
-        await suite.window.waitForSelector('[data-test="@prompts/confirm-on-device"]');
+        await suite.window.locator('[data-test-id="@passphrase/input"]').type('a');
+        await suite.window.click('[data-test-id="@passphrase/confirm-checkbox"] div >> nth=0');
+        await suite.window.click('[data-test-id="@passphrase/hidden/submit-button"]');
+        await suite.window.waitForSelector('[data-test-id="@prompts/confirm-on-device"]');
         await TrezorUserEnvLink.api.pressYes();
-        await suite.window.waitForSelector('[data-test="@prompts/confirm-on-device"]');
+        await suite.window.waitForSelector('[data-test-id="@prompts/confirm-on-device"]');
         await TrezorUserEnvLink.api.pressYes();
 
         // add coinjoin account fro passphrase 'a'
@@ -172,9 +172,9 @@ testPlaywright.describe('Coinjoin', () => {
         await startCoinjoin(suite.window);
 
         // switch to standard wallet
-        await suite.window.click('[data-test="@menu/switch-device"]');
-        await suite.window.click('[data-test="@switch-device/wallet-on-index/0"]');
-        await suite.window.click('[data-test="@account-menu/regtest/coinjoin/0"]');
+        await suite.window.click('[data-test-id="@menu/switch-device"]');
+        await suite.window.click('[data-test-id="@switch-device/wallet-on-index/0"]');
+        await suite.window.click('[data-test-id="@account-menu/regtest/coinjoin/0"]');
 
         // start coinjoin in standard wallet
         await startCoinjoin(suite.window);
@@ -185,18 +185,21 @@ testPlaywright.describe('Coinjoin', () => {
         for (let i = 0; i < rounds; i++) {
             await suite.window.waitForSelector(
                 // todo: add proper data test selector
-                '[data-test="@modal"] >> text=Establishing connection...',
+                '[data-test-id="@modal"] >> text=Establishing connection...',
                 { timeout },
             );
 
             // todo: add proper data test selector
-            await suite.window.waitForSelector('[data-test="@modal"] >> text=Registering outputs', {
-                timeout,
-            });
+            await suite.window.waitForSelector(
+                '[data-test-id="@modal"] >> text=Registering outputs',
+                {
+                    timeout,
+                },
+            );
 
             // todo: add proper data test selector
             await suite.window.waitForSelector(
-                '[data-test="@modal"] >> text=Signing transactions',
+                '[data-test-id="@modal"] >> text=Signing transactions',
                 {
                     timeout,
                 },

--- a/packages/suite-desktop-core/e2e/tests/spawn-tor.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/spawn-tor.test.ts
@@ -6,26 +6,26 @@ import { NetworkAnalyzer } from '../support/networkAnalyzer';
 const timeout = 1000 * 60 * 5; // 5 minutes because it takes a while to start tor.
 
 const turnOnTorInSettings = async (window: Page, shouldEnableTor = true) => {
-    await window.click('[data-test="@suite/menu/settings"]');
-    await window.waitForSelector('[data-test="@settings/general/tor-switch"]');
+    await window.click('[data-test-id="@suite/menu/settings"]');
+    await window.waitForSelector('[data-test-id="@settings/general/tor-switch"]');
     const torIAlreadyEnabled = await window.isChecked(
-        '[data-test="@settings/general/tor-switch"] > input',
+        '[data-test-id="@settings/general/tor-switch"] > input',
     );
     if ((shouldEnableTor && torIAlreadyEnabled) || (!shouldEnableTor && !torIAlreadyEnabled)) {
         // If tor is already enabled, we return early.
         return;
     }
 
-    await window.click('[data-test="@settings/general/tor-switch"]');
-    await window.waitForSelector('[data-test="@loading-content/loader"]', {
+    await window.click('[data-test-id="@settings/general/tor-switch"]');
+    await window.waitForSelector('[data-test-id="@loading-content/loader"]', {
         state: 'visible',
     });
-    await window.waitForSelector('[data-test="@loading-content/loader"]', {
+    await window.waitForSelector('[data-test-id="@loading-content/loader"]', {
         state: 'detached',
         timeout,
     });
     await expectPlaywright(
-        window.locator('[data-test="@settings/general/tor-switch"] > input'),
+        window.locator('[data-test-id="@settings/general/tor-switch"] > input'),
     ).toBeChecked();
 
     await window.waitForTimeout(1000);
@@ -43,11 +43,11 @@ testPlaywright.describe('Tor loading screen', () => {
 
         suite = await launchSuite();
 
-        await suite.window.waitForSelector('[data-test="@tor-loading-screen"]', {
+        await suite.window.waitForSelector('[data-test-id="@tor-loading-screen"]', {
             state: 'visible',
         });
 
-        await suite.window.waitForSelector('[data-test="@welcome/title"]', { timeout });
+        await suite.window.waitForSelector('[data-test-id="@welcome/title"]', { timeout });
 
         suite.electronApp.close();
     });
@@ -69,11 +69,11 @@ testPlaywright.describe('Tor loading screen', () => {
             // Start network analyzer after making sure tor is going to be running.
             networkAnalyzer.start();
 
-            await suite.window.waitForSelector('[data-test="@tor-loading-screen"]', {
+            await suite.window.waitForSelector('[data-test-id="@tor-loading-screen"]', {
                 state: 'visible',
             });
 
-            await suite.window.waitForSelector('[data-test="@welcome/title"]', { timeout });
+            await suite.window.waitForSelector('[data-test-id="@welcome/title"]', { timeout });
             networkAnalyzer.stop();
             const requests = networkAnalyzer.getRequests();
             requests.forEach(request => {
@@ -95,17 +95,17 @@ testPlaywright.describe('Tor loading screen', () => {
 
         suite = await launchSuite();
 
-        await suite.window.waitForSelector('[data-test="@tor-loading-screen"]', {
+        await suite.window.waitForSelector('[data-test-id="@tor-loading-screen"]', {
             state: 'visible',
         });
-        await suite.window.click('[data-test="@tor-loading-screen/disable-button"]');
+        await suite.window.click('[data-test-id="@tor-loading-screen/disable-button"]');
 
         // disabling loader appears and disappears
         suite.window.locator('text=Disabling Tor');
-        await suite.window.click('[data-test="@suite/menu/settings"]');
+        await suite.window.click('[data-test-id="@suite/menu/settings"]');
 
         await expectPlaywright(
-            suite.window.locator('[data-test="@settings/general/tor-switch"] > input'),
+            suite.window.locator('[data-test-id="@settings/general/tor-switch"] > input'),
         ).not.toBeChecked();
 
         suite.electronApp.close();

--- a/packages/suite-desktop-ui/src/support/DesktopUpdater/EarlyAccessEnable.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater/EarlyAccessEnable.tsx
@@ -97,7 +97,7 @@ export const EarlyAccessEnable = ({ hideWindow }: EarlyAccessEnableProps) => {
             </DescriptionWrapper>
             <Divider />
             <Checkbox
-                data-test="@settings/early-access-confirm-check"
+                data-test-id="@settings/early-access-confirm-check"
                 title={
                     <Paragraph type="highlight">
                         <Translation id="TR_EARLY_ACCESS_ENABLE_CONFIRM_CHECK" />

--- a/packages/suite-desktop-ui/src/support/screens/TorLoadingScreen.tsx
+++ b/packages/suite-desktop-ui/src/support/screens/TorLoadingScreen.tsx
@@ -28,7 +28,7 @@ export const TorLoadingScreen = ({ callback }: TorLoadingScreenProps) => {
 
     return (
         <ThemeProvider>
-            <Wrapper data-test="@tor-loading-screen">
+            <Wrapper data-test-id="@tor-loading-screen">
                 <TorLoader ModalWrapper={StyledModal} callback={callback} />
             </Wrapper>
         </ThemeProvider>

--- a/packages/suite-web/e2e/support/utils/selectors.ts
+++ b/packages/suite-web/e2e/support/utils/selectors.ts
@@ -1,11 +1,11 @@
 /**
- * Just like cy.get() but will return element specified with 'data-test=' attribute.
+ * Just like cy.get() but will return element specified with 'data-test-id=' attribute.
  *
  * @example any element <div data=test="my-fancy-attr-name" />
  * cy.getTestElement('my-fancy-attr-name')
  *
  * @example example Select element
- * <Select data-test="send/fee-select" options=[{label: 'foo', value: 'bla'}] />
+ * <Select data-test-id="send/fee-select" options=[{label: 'foo', value: 'bla'}] />
  *
  *  - will get input
  *  getTestElement('send/fee-select/input')
@@ -15,7 +15,7 @@
  */
 
 export const getTestElement = (selector: string, options?: Parameters<typeof cy.get>[1]) =>
-    cy.get(`[data-test="${selector}"]`, options);
+    cy.get(`[data-test-id="${selector}"]`, options);
 
 export const getConfirmActionOnDeviceModal = () =>
     cy.getTestElement('@suite/modal/confirm-action-on-device');

--- a/packages/suite-web/e2e/support/utils/shortcuts.ts
+++ b/packages/suite-web/e2e/support/utils/shortcuts.ts
@@ -115,9 +115,9 @@ export const createAccountFromMyAccounts = (coin: string, label: string) => {
     //     cy.getTestElement('@account-menu/add-account').should('be.visible').click();
     // }
     cy.getTestElement('@modal').should('be.visible');
-    cy.get(`[data-test="@settings/wallet/network/${coin}"]`).should('be.visible').click();
+    cy.get(`[data-test-id="@settings/wallet/network/${coin}"]`).should('be.visible').click();
     cy.getTestElement('@add-account-type/select/input').click();
-    cy.get(`[data-test="@add-account-type/select/option/${label}"]`).click();
+    cy.get(`[data-test-id="@add-account-type/select/option/${label}"]`).click();
     cy.getTestElement('@add-account').click();
 };
 

--- a/packages/suite-web/e2e/tests/settings/application-log.test.ts
+++ b/packages/suite-web/e2e/tests/settings/application-log.test.ts
@@ -21,7 +21,7 @@ describe('ApplicationLog', () => {
         cy.getTestElement('@log/export-button');
         // cypress open todo: implement match-image snapshot. blackout stopped working properly
         cy.getTestElement('@modal/application-log').screenshot('log-modal', {
-            blackout: ['[data-test="@log/content"]'],
+            blackout: ['[data-test-id="@log/content"]'],
         });
 
         // todo: check it really exports something;

--- a/packages/suite-web/e2e/tests/settings/safety-checks.test.ts
+++ b/packages/suite-web/e2e/tests/settings/safety-checks.test.ts
@@ -25,14 +25,14 @@ describe('Safety Checks Settings', () => {
         });
 
         // There should be two radio buttons, one checked and one not.
-        cy.get('[data-test*="@radio-button"]').should('have.length', 2);
-        cy.get('[data-test*="@radio-button"][data-checked="true"]').should('have.length', 1);
-        cy.get('[data-test*="@radio-button"][data-checked="false"]').should('have.length', 1);
+        cy.get('[data-test-id*="@radio-button"]').should('have.length', 2);
+        cy.get('[data-test-id*="@radio-button"][data-checked="true"]').should('have.length', 1);
+        cy.get('[data-test-id*="@radio-button"][data-checked="false"]').should('have.length', 1);
 
-        cy.get('[data-test*="@radio-button"][data-checked="false"]').click();
+        cy.get('[data-test-id*="@radio-button"][data-checked="false"]').click();
         // After switching the value, there should still be one checked and one unchecked.
-        cy.get('[data-test*="@radio-button"][data-checked="true"]').should('have.length', 1);
-        cy.get('[data-test*="@radio-button"][data-checked="false"]').should('have.length', 1);
+        cy.get('[data-test-id*="@radio-button"][data-checked="true"]').should('have.length', 1);
+        cy.get('[data-test-id*="@radio-button"][data-checked="false"]').should('have.length', 1);
     });
 
     it('Apply button is enabled only when value is changed', () => {
@@ -42,7 +42,7 @@ describe('Safety Checks Settings', () => {
         });
 
         cy.getTestElement('@safety-checks-apply').should('have.attr', 'disabled');
-        cy.get('[data-test*="@radio-button"][data-checked="false"]').click();
+        cy.get('[data-test-id*="@radio-button"][data-checked="false"]').click();
         cy.getTestElement('@safety-checks-apply').should('not.have.attr', 'disabled');
     });
 
@@ -52,10 +52,10 @@ describe('Safety Checks Settings', () => {
         });
         // Don't assume the device is set to any particular value.
         // Just switch to the one that is not currently checked.
-        cy.get('[data-test*="@radio-button"][data-checked="false"]')
+        cy.get('[data-test-id*="@radio-button"][data-checked="false"]')
             .click()
             .then(b => {
-                const targetValue = b.attr('data-test');
+                const targetValue = b.attr('data-test-id');
                 console.log(`Changing safety_checks to ${targetValue})`);
                 cy.getTestElement('@safety-checks-apply').click();
                 cy.getTestElement('@suite/modal/confirm-action-on-device');
@@ -64,7 +64,7 @@ describe('Safety Checks Settings', () => {
                 cy.getTestElement('@settings/device/safety-checks-button').click({
                     scrollBehavior: 'bottom',
                 });
-                cy.get(`[data-test="${targetValue}"]`)
+                cy.get(`[data-test-id="${targetValue}"]`)
                     .invoke('attr', 'data-checked')
                     .should('eq', 'true');
             });

--- a/packages/suite-web/e2e/tests/suite/bridge.test.ts
+++ b/packages/suite-web/e2e/tests/suite/bridge.test.ts
@@ -29,7 +29,7 @@ describe('Bridge page', () => {
         cy.getTestElement('@bridge/installers/input').should('contain', 'Windows');
 
         cy.getTestElement('@modal/bridge').matchImageSnapshot('bridge-modal', {
-            blackout: ['[data-test="@bridge/download-button"]'],
+            blackout: ['[data-test-id="@bridge/download-button"]'],
         });
 
         // user may exit bridge page and use webusb

--- a/packages/suite-web/e2e/tests/suite/database-migration.test.ts
+++ b/packages/suite-web/e2e/tests/suite/database-migration.test.ts
@@ -98,7 +98,7 @@ describe('Database migration', () => {
         // remember the wallet
         cy.getTestElement('@menu/switch-device').click();
         cy.contains(hiddenWalletSelector, 'Hidden wallet #1')
-            .find('[data-test*="toggle-remember-switch"]')
+            .find('[data-test-id*="toggle-remember-switch"]')
             .click()
             .find('input')
             .should('be.checked');
@@ -142,7 +142,7 @@ describe('Database migration', () => {
 
         // checking the Send form
         cy.getTestElement('@wallet/menu/wallet-send').click();
-        // TODO: remove this workaround after the "old" version also uses the new data-testid attribute
+        // TODO: remove this workaround after the "old" version also uses the new data-test-id attribute
         cy.getTestElement(workaroundBtcAddressInputSelector)
             .should('be.visible')
             .invoke('attr', 'value')

--- a/packages/suite-web/e2e/tests/suite/guide.test.ts
+++ b/packages/suite-web/e2e/tests/suite/guide.test.ts
@@ -61,7 +61,7 @@ describe('Test Guide', () => {
         cy.getTestElement('@guide/button-feedback').click();
         // cypress open todo: panel is probably animated, we need to wait until it is fully expanded
         cy.getTestElement('@guide/panel').screenshot('guide-side-panel', {
-            blackout: ['[data-test="@guide/support/version"]'],
+            blackout: ['[data-test-id="@guide/support/version"]'],
         });
     });
 });

--- a/packages/suite-web/e2e/tests/suite/passphrase.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase.test.ts
@@ -65,7 +65,7 @@ describe('Passphrase', () => {
         // click reveal address
         cy.getTestElement('@wallet/receive/reveal-address-button').click();
         cy.getTestElement('@modal/confirm-address/address-field')
-            .find('[data-test*="chunk"]')
+            .find('[data-test-id*="chunk"]')
             .then(chunks => {
                 let fullAddress = '';
                 // @ts-expect-error
@@ -119,7 +119,7 @@ describe('Passphrase', () => {
         cy.getTestElement('@wallet/receive/reveal-address-button').should('not.be.disabled');
         cy.getTestElement('@wallet/receive/reveal-address-button').click();
         cy.getTestElement('@modal/confirm-address/address-field')
-            .find('[data-test*="chunk"]')
+            .find('[data-test-id*="chunk"]')
             .then(chunks => {
                 let fullAddress = '';
                 // @ts-expect-error
@@ -152,7 +152,7 @@ describe('Passphrase', () => {
 
         // should display confirm passphrase modal
         cy.getTestElement('@modal/confirm-address/address-field')
-            .find('[data-test*="chunk"]')
+            .find('[data-test-id*="chunk"]')
             .then(chunks => {
                 let fullAddress = '';
                 // @ts-expect-error

--- a/packages/suite-web/e2e/tests/suite/safety-checks-warning.test.ts
+++ b/packages/suite-web/e2e/tests/suite/safety-checks-warning.test.ts
@@ -39,7 +39,7 @@ describe('safety_checks Warning For PromptTemporarily', () => {
         cy.getTestElement('@settings/device/safety-checks-button').click({
             scrollBehavior: 'bottom',
         });
-        cy.get(`[data-test="@radio-button-prompt"]`).click();
+        cy.get(`[data-test-id="@radio-button-prompt"]`).click();
         cy.getTestElement('@safety-checks-apply').click();
         cy.getTestElement('@prompts/confirm-on-device');
         cy.task('pressYes');
@@ -66,7 +66,7 @@ describe('safety_checks Warning For PromptTemporarily', () => {
         cy.getTestElement('@settings/device/safety-checks-button').click({
             scrollBehavior: 'bottom',
         });
-        cy.get('[data-test="@radio-button-strict"]').click();
+        cy.get('[data-test-id="@radio-button-strict"]').click();
         cy.getTestElement('@safety-checks-apply').click();
         cy.getTestElement('@prompts/confirm-on-device');
         cy.task('pressYes');
@@ -81,7 +81,7 @@ describe('safety_checks Warning For PromptTemporarily', () => {
         cy.getTestElement('@settings/device/safety-checks-button').click({
             scrollBehavior: 'bottom',
         });
-        cy.get('[data-test="@radio-button-strict"]').click();
+        cy.get('[data-test-id="@radio-button-strict"]').click();
         cy.getTestElement('@safety-checks-apply').click();
         cy.getTestElement('@prompts/confirm-on-device');
         cy.task('pressYes');
@@ -91,7 +91,7 @@ describe('safety_checks Warning For PromptTemporarily', () => {
         cy.getTestElement('@settings/device/safety-checks-button').click({
             scrollBehavior: 'bottom',
         });
-        cy.get(`[data-test="@radio-button-prompt"]`).click();
+        cy.get(`[data-test-id="@radio-button-prompt"]`).click();
         cy.getTestElement('@safety-checks-apply').click();
         cy.getTestElement('@prompts/confirm-on-device');
         cy.task('pressYes');

--- a/packages/suite-web/e2e/tests/wallet/add-account-types.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/add-account-types.test.ts
@@ -74,7 +74,7 @@ describe('Account types suite', () => {
                 // for a specific type of BTC acc, get the current number of accounts
                 cy.getTestElement(`@account-menu/${type}/group`)
                     .children()
-                    .not(`[data-test="@account-menu/account-item-skeleton"]`)
+                    .not(`[data-test-id="@account-menu/account-item-skeleton"]`)
                     .then(specificAccounts => {
                         const numberOfAccounts1 = specificAccounts.length;
 
@@ -84,7 +84,7 @@ describe('Account types suite', () => {
                         // for a specific type of BTC acc, get the current number of accounts again for comparison
                         cy.getTestElement(`@account-menu/${type}/group`)
                             .children()
-                            .not(`[data-test="@account-menu/account-item-skeleton"]`)
+                            .not(`[data-test-id="@account-menu/account-item-skeleton"]`)
                             .then(specificAccounts => {
                                 const numberOfAccounts2 = specificAccounts.length;
                                 expect(numberOfAccounts2).to.be.equal(numberOfAccounts1 + 1);
@@ -128,19 +128,19 @@ describe('Account types suite', () => {
         coins.forEach((coin: NetworkSymbol) => {
             onAccountsPage.applyCoinFilter(coin);
             // get the element containing all accounts
-            cy.get(`[type="normal"] [data-test*="@account-menu/${coin}/normal"]`).then(
+            cy.get(`[type="normal"] [data-test-id*="@account-menu/${coin}/normal"]`).then(
                 currentAccounts => {
                     const numberOfAccounts1 = currentAccounts.length;
 
                     cy.getTestElement('@account-menu/add-account').should('be.visible').click();
                     cy.getTestElement('@modal').should('be.visible');
-                    cy.get(`[data-test="@settings/wallet/network/${coin}"]`)
+                    cy.get(`[data-test-id="@settings/wallet/network/${coin}"]`)
                         .should('be.visible')
                         .click();
                     cy.getTestElement('@add-account').click();
                     cy.discoveryShouldFinish();
 
-                    cy.get(`[type="normal"] [data-test*="@account-menu/${coin}/normal"]`).then(
+                    cy.get(`[type="normal"] [data-test-id*="@account-menu/${coin}/normal"]`).then(
                         newAccounts => {
                             const numberOfAccounts2 = newAccounts.length;
                             expect(numberOfAccounts2).to.be.equal(numberOfAccounts1 + 1);

--- a/packages/suite/src/components/backup/AfterBackupCheckboxes.tsx
+++ b/packages/suite/src/components/backup/AfterBackupCheckboxes.tsx
@@ -19,21 +19,21 @@ export const AfterBackupCheckboxes = () => {
     return (
         <CheckboxWrapper>
             <CheckItem
-                data-test="@backup/check-item/wrote-seed-properly"
+                data-test-id="@backup/check-item/wrote-seed-properly"
                 onClick={() => dispatch(toggleCheckboxByKey('wrote-seed-properly'))}
                 title={<Translation id="TR_BACKUP_CHECKBOX_1_TITLE" />}
                 description={<Translation id="TR_BACKUP_CHECKBOX_1_DESCRIPTION" />}
                 isChecked={isChecked('wrote-seed-properly')}
             />
             <CheckItem
-                data-test="@backup/check-item/made-no-digital-copy"
+                data-test-id="@backup/check-item/made-no-digital-copy"
                 onClick={() => dispatch(toggleCheckboxByKey('made-no-digital-copy'))}
                 title={<Translation id="TR_BACKUP_CHECKBOX_2_TITLE" />}
                 description={<Translation id="TR_BACKUP_CHECKBOX_2_DESCRIPTION" />}
                 isChecked={isChecked('made-no-digital-copy')}
             />
             <CheckItem
-                data-test="@backup/check-item/will-hide-seed"
+                data-test-id="@backup/check-item/will-hide-seed"
                 onClick={() => dispatch(toggleCheckboxByKey('will-hide-seed'))}
                 title={<Translation id="TR_BACKUP_CHECKBOX_3_TITLE" />}
                 description={<Translation id="TR_BACKUP_CHECKBOX_3_DESCRIPTION" />}

--- a/packages/suite/src/components/backup/BackupSeedCard.tsx
+++ b/packages/suite/src/components/backup/BackupSeedCard.tsx
@@ -85,7 +85,7 @@ interface BackupSeedCardProps {
     icon: IconProps['icon'];
     isChecked: boolean;
     onClick: () => void;
-    ['data-test']: string;
+    ['data-test-id']: string;
 }
 
 export const BackupSeedCard = ({
@@ -93,7 +93,7 @@ export const BackupSeedCard = ({
     icon,
     isChecked,
     onClick,
-    'data-test': dataTest,
+    'data-test-id': dataTest,
 }: BackupSeedCardProps) => {
     const theme = useTheme();
 
@@ -103,7 +103,7 @@ export const BackupSeedCard = ({
     };
 
     return (
-        <Container forceElevation={2} checked={isChecked} data-test={dataTest}>
+        <Container forceElevation={2} checked={isChecked} data-test-id={dataTest}>
             <Content>
                 <IconWrapper>
                     <Icon icon={icon} color={theme.iconDefault} />

--- a/packages/suite/src/components/backup/BackupSeedCards.tsx
+++ b/packages/suite/src/components/backup/BackupSeedCards.tsx
@@ -77,7 +77,7 @@ export const BackupSeedCards = () => {
                 {items.map(item => (
                     <StyledBackupSeedCard
                         // TODO: change data-test, checkbox keys to something more generic, independent of actual content
-                        data-test={`@backup/check-item/${item.key}`}
+                        data-test-id={`@backup/check-item/${item.key}`}
                         key={item.key}
                         onClick={() => dispatch(toggleCheckboxByKey(item.key))}
                         label={item.label}

--- a/packages/suite/src/components/backup/PreBackupCheckboxes.tsx
+++ b/packages/suite/src/components/backup/PreBackupCheckboxes.tsx
@@ -24,21 +24,21 @@ export const PreBackupCheckboxes = () => {
     return (
         <CheckboxWrapper>
             <CheckItem
-                data-test="@backup/check-item/has-enough-time"
+                data-test-id="@backup/check-item/has-enough-time"
                 onClick={() => dispatch(toggleCheckboxByKey('has-enough-time'))}
                 title={<Translation id="TR_I_HAVE_ENOUGH_TIME_TO_DO" />}
                 description={<Translation id="TR_ONCE_YOU_BEGIN_THIS_PROCESS" />}
                 isChecked={isChecked('has-enough-time')}
             />
             <CheckItem
-                data-test="@backup/check-item/is-in-private"
+                data-test-id="@backup/check-item/is-in-private"
                 onClick={() => dispatch(toggleCheckboxByKey('is-in-private'))}
                 title={<Translation id="TR_I_AM_IN_SAFE_PRIVATE_OR" />}
                 description={<Translation id="TR_MAKE_SURE_NO_ONE_CAN_PEEK" />}
                 isChecked={isChecked('is-in-private')}
             />
             <CheckItem
-                data-test="@backup/check-item/understands-what-seed-is"
+                data-test-id="@backup/check-item/understands-what-seed-is"
                 onClick={() => dispatch(toggleCheckboxByKey('understands-what-seed-is'))}
                 title={<Translation id="TR_I_UNDERSTAND_SEED_IS_IMPORTANT" />}
                 description={<Translation id="TR_BACKUP_SEED_IS_ULTIMATE" />}

--- a/packages/suite/src/components/firmware/Buttons/FirmwareContinueButton.tsx
+++ b/packages/suite/src/components/firmware/Buttons/FirmwareContinueButton.tsx
@@ -8,7 +8,7 @@ const StyledButton = styled(Button)`
 `;
 
 export const FirmwareContinueButton = (props: Omit<ButtonProps, 'children'>) => (
-    <StyledButton {...props} data-test="@firmware/continue-button">
+    <StyledButton {...props} data-test-id="@firmware/continue-button">
         <Translation id="TR_CONTINUE" />
     </StyledButton>
 );

--- a/packages/suite/src/components/firmware/Buttons/FirmwareInstallButton.tsx
+++ b/packages/suite/src/components/firmware/Buttons/FirmwareInstallButton.tsx
@@ -11,7 +11,7 @@ const StyledButton = styled(Button)`
 const InstallButtonCommon = (
     props: Omit<ButtonProps, 'children'> & { children?: React.ReactNode },
 ) => (
-    <StyledButton {...props} data-test="@firmware/install-button">
+    <StyledButton {...props} data-test-id="@firmware/install-button">
         {props.children || <Translation id="TR_INSTALL" />}
     </StyledButton>
 );

--- a/packages/suite/src/components/firmware/Buttons/FirmwareRetryButton.tsx
+++ b/packages/suite/src/components/firmware/Buttons/FirmwareRetryButton.tsx
@@ -4,7 +4,7 @@ import { Button, ButtonProps } from '@trezor/components';
 import { Translation } from 'src/components/suite';
 
 export const FirmwareRetryButton = (props: Omit<ButtonProps, 'children'>) => (
-    <Button {...props} data-test="@firmware/retry-button">
+    <Button {...props} data-test-id="@firmware/retry-button">
         <Translation id="TR_RETRY" />
     </Button>
 );

--- a/packages/suite/src/components/firmware/CheckSeedStep.tsx
+++ b/packages/suite/src/components/firmware/CheckSeedStep.tsx
@@ -128,7 +128,7 @@ export const CheckSeedStep = ({ onClose, onSuccess, willBeWiped }: CheckSeedStep
                 <FirmwareButtonsRow withCancelButton={willBeWiped} onClose={onClose}>
                     <Button
                         onClick={onSuccess}
-                        data-test="@firmware/confirm-seed-button"
+                        data-test-id="@firmware/confirm-seed-button"
                         isDisabled={!device?.connected || !hasSeed}
                     >
                         <Translation id={willBeWiped ? 'TR_WIPE_AND_REINSTALL' : 'TR_CONTINUE'} />
@@ -146,7 +146,7 @@ export const CheckSeedStep = ({ onClose, onSuccess, willBeWiped }: CheckSeedStep
             <StyledCheckbox
                 isChecked={hasSeed}
                 onClick={toggleHasSeed}
-                data-test="@firmware/confirm-seed-checkbox"
+                data-test-id="@firmware/confirm-seed-checkbox"
             >
                 {checkbox}
             </StyledCheckbox>

--- a/packages/suite/src/components/firmware/FirmwareInitial.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInitial.tsx
@@ -395,7 +395,7 @@ export const FirmwareInitial = ({
                             goToNextStep();
                             updateAnalytics({ firmware: 'skip' });
                         }}
-                        data-test="@firmware/skip-button"
+                        data-test-id="@firmware/skip-button"
                     >
                         <Translation id="TR_SKIP_UPDATE" />
                     </OnboardingButtonSkip>

--- a/packages/suite/src/components/firmware/FirmwareInstallation.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInstallation.tsx
@@ -70,7 +70,7 @@ export const FirmwareInstallation = ({
                     <Button
                         variant="primary"
                         onClick={getContinueAction}
-                        data-test="@firmware/continue-button"
+                        data-test-id="@firmware/continue-button"
                     >
                         <Translation id={standaloneFwUpdate ? 'TR_CLOSE' : 'TR_CONTINUE'} />
                     </Button>

--- a/packages/suite/src/components/firmware/FirmwareOffer.tsx
+++ b/packages/suite/src/components/firmware/FirmwareOffer.tsx
@@ -81,7 +81,7 @@ export const FirmwareOffer = ({
     const futureFirmwareType = getSuiteFirmwareTypeString(targetFirmwareType || targetType);
 
     const nextVersionElement = (
-        <Version isNew data-test="@firmware/offer-version/new">
+        <Version isNew data-test-id="@firmware/offer-version/new">
             {futureFirmwareType ? translationString(futureFirmwareType) : ''}
             {nextVersion ? ` ${nextVersion}` : ''}
             {useDevkit ? ' DEVKIT' : ''}

--- a/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
+++ b/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
@@ -193,7 +193,7 @@ const ReconnectStep = ({ order, active, dataTest, children }: ReconnectStepProps
     <BulletPointWrapper>
         {order && <BulletPointNumber active={active}>{order}</BulletPointNumber>}
 
-        <BulletPointText active={active} data-test={active ? dataTest : undefined}>
+        <BulletPointText active={active} data-test-id={active ? dataTest : undefined}>
             {children}
         </BulletPointText>
     </BulletPointWrapper>
@@ -274,7 +274,7 @@ export const ReconnectDevicePrompt = ({
         >
             {onClose && rebootPhase === 'initial' && <StyledAbortButton onAbort={onClose} />}
 
-            <Wrapper data-test={`@firmware/reconnect-device/${requestedMode}`}>
+            <Wrapper data-test-id={`@firmware/reconnect-device/${requestedMode}`}>
                 {isAnimationVisible && (
                     <RebootDeviceGraphics
                         device={expectedDevice}
@@ -330,7 +330,7 @@ export const ReconnectDevicePrompt = ({
                     ) : (
                         <>
                             {requestedMode === 'bootloader' && (
-                                <Button onClick={onSuccess} data-test="@firmware/install-button">
+                                <Button onClick={onSuccess} data-test-id="@firmware/install-button">
                                     <Translation id="TR_INSTALL" />
                                 </Button>
                             )}

--- a/packages/suite/src/components/guide/Feedback.tsx
+++ b/packages/suite/src/components/guide/Feedback.tsx
@@ -237,9 +237,9 @@ export const Feedback = ({ type }: FeedbackProps) => {
                         <Headline>
                             <Translation id="TR_GUIDE_FEEDBACK_CATEGORY_HEADLINE" />
                         </Headline>
-                        <SelectWrapper data-test="@guide/feedback/suggestion-dropdown">
+                        <SelectWrapper data-test-id="@guide/feedback/suggestion-dropdown">
                             <Select
-                                data-test="@guide/feedback/suggestion-dropdown/select"
+                                data-test-id="@guide/feedback/suggestion-dropdown/select"
                                 isSearchable={false}
                                 defaultValue={category && categoryToOption(category)}
                                 options={Object.keys(feedbackCategories).map(category =>
@@ -266,7 +266,7 @@ export const Feedback = ({ type }: FeedbackProps) => {
                                     key={item.id}
                                     selected={rating?.id === item.id}
                                     onClick={() => setRating(item)}
-                                    data-test={`@guide/feedback/suggestion/${item.id}`}
+                                    data-test-id={`@guide/feedback/suggestion/${item.id}`}
                                 >
                                     {item.value}
                                 </RatingItem>
@@ -292,7 +292,7 @@ export const Feedback = ({ type }: FeedbackProps) => {
                         setDescription(e.target.value)
                     }
                     characterCount
-                    data-test="@guide/feedback/suggestion-form"
+                    data-test-id="@guide/feedback/suggestion-form"
                     maxLength={MESSAGE_CHARACTER_LIMIT}
                 />
 
@@ -303,7 +303,7 @@ export const Feedback = ({ type }: FeedbackProps) => {
                         (type === 'SUGGESTION' && rating === undefined) ||
                         (type === 'BUG' && category === undefined)
                     }
-                    data-test="@guide/feedback/submit-button"
+                    data-test-id="@guide/feedback/submit-button"
                 >
                     <Translation id="TR_GUIDE_FEEDBACK_SEND_REPORT" />
                 </Submit>

--- a/packages/suite/src/components/guide/Guide.tsx
+++ b/packages/suite/src/components/guide/Guide.tsx
@@ -85,7 +85,7 @@ export const Guide = () => {
             <FeedbackBorder />
             <FeedbackLinkWrapper>
                 <FeedbackButton
-                    data-test="@guide/button-feedback"
+                    data-test-id="@guide/button-feedback"
                     onClick={handleFeedbackButtonClick}
                 >
                     <Icon icon="USERS" size={24} color={theme.iconOnTertiary} />

--- a/packages/suite/src/components/guide/GuideButton.tsx
+++ b/packages/suite/src/components/guide/GuideButton.tsx
@@ -37,7 +37,11 @@ export const GuideButton = () => {
 
     return (
         <FreeFocusInside>
-            <Wrapper data-test="@guide/button-open" onClick={openGuide} $isGuideOpen={isGuideOpen}>
+            <Wrapper
+                data-test-id="@guide/button-open"
+                onClick={openGuide}
+                $isGuideOpen={isGuideOpen}
+            >
                 <Icon size={18} icon="LIGHTBULB" />
             </Wrapper>
         </FreeFocusInside>

--- a/packages/suite/src/components/guide/GuideCategories.tsx
+++ b/packages/suite/src/components/guide/GuideCategories.tsx
@@ -35,7 +35,7 @@ export const GuideCategories = ({ node, label }: GuideCategoriesProps) => {
     return (
         <Section>
             {label && <SectionHeading>{label}</SectionHeading>}
-            <Nodes data-test="@guide/nodes">
+            <Nodes data-test-id="@guide/nodes">
                 {node.children.map(child => (
                     <GuideNode key={child.id} node={child} />
                 ))}

--- a/packages/suite/src/components/guide/GuideCategory.tsx
+++ b/packages/suite/src/components/guide/GuideCategory.tsx
@@ -63,7 +63,7 @@ export const GuideCategory = () => {
                         <SectionHeading>
                             <Translation id="TR_GUIDE_ARTICLES" />
                         </SectionHeading>
-                        <Nodes data-test="@guide/nodes">
+                        <Nodes data-test-id="@guide/nodes">
                             {pages.map(page => (
                                 <GuideNode key={page.id} node={page} />
                             ))}

--- a/packages/suite/src/components/guide/GuideHeader.tsx
+++ b/packages/suite/src/components/guide/GuideHeader.tsx
@@ -87,10 +87,10 @@ export const GuideHeader = ({ back, label, useBreadcrumb }: GuideHeaderProps) =>
                         icon="ARROW_LEFT_LONG"
                         onClick={goBack}
                         variant="tertiary"
-                        data-test="@guide/button-back"
+                        data-test-id="@guide/button-back"
                     />
 
-                    {label && <Label data-test="@guide/label">{label}</Label>}
+                    {label && <Label data-test-id="@guide/label">{label}</Label>}
                 </>
             )}
             {!useBreadcrumb && !back && label && <MainLabel>{label}</MainLabel>}
@@ -101,7 +101,7 @@ export const GuideHeader = ({ back, label, useBreadcrumb }: GuideHeaderProps) =>
                 icon="ARROW_RIGHT_LINE"
                 variant="tertiary"
                 onClick={handleClose}
-                data-test="@guide/button-close"
+                data-test-id="@guide/button-close"
                 size="medium"
             />
         </HeaderWrapper>

--- a/packages/suite/src/components/guide/GuideNode.tsx
+++ b/packages/suite/src/components/guide/GuideNode.tsx
@@ -96,7 +96,7 @@ export const GuideNode = ({ node, description }: GuideNodeProps) => {
 
     if (node.type === 'page') {
         return (
-            <PageNodeButton data-test={`@guide/node${node.id}`} onClick={navigateToNode}>
+            <PageNodeButton data-test-id={`@guide/node${node.id}`} onClick={navigateToNode}>
                 <PageNodeButtonIcon icon="ARTICLE" size={20} color={theme.TYPE_LIGHT_GREY} />
                 {label}
             </PageNodeButton>
@@ -105,7 +105,7 @@ export const GuideNode = ({ node, description }: GuideNodeProps) => {
 
     if (node.type === 'category') {
         return (
-            <CategoryNodeButton data-test={`@guide/category${node.id}`} onClick={navigateToNode}>
+            <CategoryNodeButton data-test-id={`@guide/category${node.id}`} onClick={navigateToNode}>
                 {node.image && <Image src={resolveStaticPath(node.image)} />}
                 {label}
             </CategoryNodeButton>

--- a/packages/suite/src/components/guide/GuideRouter.tsx
+++ b/packages/suite/src/components/guide/GuideRouter.tsx
@@ -75,7 +75,7 @@ export const GuideRouter = () => {
                 <AnimatePresence>
                     {isGuideOpen && (
                         <MotionGuide
-                            data-test="@guide/panel"
+                            data-test-id="@guide/panel"
                             initial={{
                                 width: isFirstRender ? variables.LAYOUT_SIZE.GUIDE_PANEL_WIDTH : 0,
                             }}

--- a/packages/suite/src/components/guide/GuideSearch.tsx
+++ b/packages/suite/src/components/guide/GuideSearch.tsx
@@ -81,11 +81,11 @@ export const GuideSearch = ({ pageRoot, setSearchActive }: GuideSearchProps) => 
                 showClearButton="always"
                 onClear={() => setQuery('')}
                 innerAddon={loading ? <Spinner size={24} /> : <Icon icon="SEARCH" size={24} />}
-                data-test="@guide/search"
+                data-test-id="@guide/search"
             />
 
             {searchResult.length ? (
-                <PageFoundList data-test="@guide/search/results">
+                <PageFoundList data-test-id="@guide/search/results">
                     {searchResult.map(({ page, preview }) => (
                         <GuideNode
                             key={page.id}
@@ -97,7 +97,7 @@ export const GuideSearch = ({ pageRoot, setSearchActive }: GuideSearchProps) => 
             ) : (
                 query &&
                 !loading && (
-                    <NoResults data-test="@guide/search/no-results">
+                    <NoResults data-test-id="@guide/search/no-results">
                         <Translation id="TR_ACCOUNT_SEARCH_NO_RESULTS" />
                     </NoResults>
                 )

--- a/packages/suite/src/components/guide/HeaderBreadcrumb.tsx
+++ b/packages/suite/src/components/guide/HeaderBreadcrumb.tsx
@@ -106,7 +106,7 @@ export const HeaderBreadcrumb = () => {
                         navigateToGuideDashboard();
                     }
                 }}
-                data-test="@guide/header-breadcrumb/previous-category-link"
+                data-test-id="@guide/header-breadcrumb/previous-category-link"
             >
                 {grandParentNode ? (
                     getNodeTitle(grandParentNode, language)
@@ -123,7 +123,7 @@ export const HeaderBreadcrumb = () => {
                         navigateToCategory(parentNode);
                     }
                 }}
-                data-test="@guide/header-breadcrumb/category-link"
+                data-test-id="@guide/header-breadcrumb/category-link"
             >
                 {parentNode && getNodeTitle(parentNode, language)}
             </CategoryLink>

--- a/packages/suite/src/components/guide/OpenGuideFromTooltip.tsx
+++ b/packages/suite/src/components/guide/OpenGuideFromTooltip.tsx
@@ -36,7 +36,7 @@ export const OpenGuideFromTooltip = ({ id, instance, dataTest }: OpenGuideFromTo
 
     return (
         <OpenGuideLink
-            data-test={dataTest}
+            data-test-id={dataTest}
             onClick={(e: MouseEvent<any>) => {
                 e.stopPropagation();
                 instance.hide();

--- a/packages/suite/src/components/guide/SupportFeedbackSelection.tsx
+++ b/packages/suite/src/components/guide/SupportFeedbackSelection.tsx
@@ -147,7 +147,7 @@ export const SupportFeedbackSelection = () => {
                     <SectionButton
                         onClick={handleBugButtonClick}
                         hasBackground
-                        data-test="@guide/feedback/bug"
+                        data-test-id="@guide/feedback/bug"
                     >
                         <ButtonImage
                             src={resolveStaticPath('images/png/recovery@2x.png')}
@@ -167,7 +167,7 @@ export const SupportFeedbackSelection = () => {
                     <SectionButton
                         onClick={handleFeedbackButtonClick}
                         hasBackground
-                        data-test="@guide/feedback/suggestion"
+                        data-test-id="@guide/feedback/suggestion"
                     >
                         <ButtonImage
                             src={resolveStaticPath('images/png/understand@2x.png')}
@@ -192,7 +192,7 @@ export const SupportFeedbackSelection = () => {
                     </SectionHeader>
 
                     <StyledLink href={TREZOR_FORUM_URL} variant="nostyle">
-                        <SectionButton data-test="@guide/forum">
+                        <SectionButton data-test-id="@guide/forum">
                             <Label>
                                 <LabelHeadline>
                                     <Translation id="TR_GUIDE_FORUM" />
@@ -206,7 +206,7 @@ export const SupportFeedbackSelection = () => {
                     </StyledLink>
 
                     <StyledLink href={TREZOR_SUPPORT_URL} variant="nostyle">
-                        <SectionButton data-test="@guide/support">
+                        <SectionButton data-test-id="@guide/support">
                             <Label>
                                 <LabelHeadline>
                                     <Translation id="TR_GUIDE_SUPPORT" />
@@ -218,7 +218,7 @@ export const SupportFeedbackSelection = () => {
                 </Section>
 
                 <Details>
-                    <DetailItem data-test="@guide/support/version">
+                    <DetailItem data-test-id="@guide/support/version">
                         <Translation id="TR_APP" />
                         :&nbsp;
                         {!isDevEnv && appUpToDate ? (

--- a/packages/suite/src/components/onboarding/Buttons/OnboardingButtonBack.tsx
+++ b/packages/suite/src/components/onboarding/Buttons/OnboardingButtonBack.tsx
@@ -3,7 +3,7 @@ import { Translation } from 'src/components/suite';
 
 export const OnboardingButtonBack = (props: Omit<ButtonProps, 'children'>) => (
     <Button
-        data-test="@onboarding/back-button"
+        data-test-id="@onboarding/back-button"
         variant="tertiary"
         size="small"
         icon="ARROW_LEFT"

--- a/packages/suite/src/components/onboarding/Buttons/OnboardingButtonSkip.tsx
+++ b/packages/suite/src/components/onboarding/Buttons/OnboardingButtonSkip.tsx
@@ -11,7 +11,7 @@ const StyledSpan = styled.span`
 `;
 
 export const OnboardingButtonSkip = (props: HtmlHTMLAttributes<HTMLSpanElement>) => (
-    <StyledSpan data-test="@onboarding/skip-button" {...props}>
+    <StyledSpan data-test-id="@onboarding/skip-button" {...props}>
         {props.children}
     </StyledSpan>
 );

--- a/packages/suite/src/components/onboarding/CollapsibleOnboardingCard.tsx
+++ b/packages/suite/src/components/onboarding/CollapsibleOnboardingCard.tsx
@@ -209,7 +209,7 @@ export const CollapsibleOnboardingCard = ({
         animate={expanded ? 'expanded' : 'closed'}
         transition={{ duration: 0.4, ease: motionEasing.transition }}
         onClick={expandable && !expanded ? onToggle : undefined}
-        data-test="@components/collapsible-box"
+        data-test-id="@components/collapsible-box"
         {...rest}
     >
         <CardWrapperInner expandable={expandable}>

--- a/packages/suite/src/components/onboarding/OnboardingLayout.tsx
+++ b/packages/suite/src/components/onboarding/OnboardingLayout.tsx
@@ -143,7 +143,7 @@ export const OnboardingLayout = ({ children }: OnboardingLayoutProps) => {
         <Wrapper>
             {bannerMessage && <MessageSystemBanner message={bannerMessage} />}
 
-            <Body data-test="@onboarding-layout/body">
+            <Body data-test-id="@onboarding-layout/body">
                 <ScrollingWrapper>
                     <ModalContextProvider>
                         <ContentWrapper id="layout-scroll">

--- a/packages/suite/src/components/onboarding/OnboardingStepBox.tsx
+++ b/packages/suite/src/components/onboarding/OnboardingStepBox.tsx
@@ -80,7 +80,7 @@ export const OnboardingStepBox = ({
         <>
             <StyledBackdrop show={isBackDropVisible} />
             {!disableConfirmWrapper && (
-                <ConfirmWrapper data-test="@onboarding/confirm-on-device">
+                <ConfirmWrapper data-test-id="@onboarding/confirm-on-device">
                     {deviceModelInternal && (
                         <ConfirmOnDevice
                             title={devicePromptTitle || <Translation id="TR_CONFIRM_ON_TREZOR" />}

--- a/packages/suite/src/components/onboarding/SkipStepConfirmation.tsx
+++ b/packages/suite/src/components/onboarding/SkipStepConfirmation.tsx
@@ -58,7 +58,7 @@ export const SkipStepConfirmation = ({ onCancel }: SkipStepConfirmationProps) =>
                     </Button>
                     <Button
                         variant="destructive"
-                        data-test="@onboarding/skip-button-confirm"
+                        data-test-id="@onboarding/skip-button-confirm"
                         onClick={() => goToNextStep(nextStep)}
                     >
                         {text}

--- a/packages/suite/src/components/recovery/SelectRecoveryType.tsx
+++ b/packages/suite/src/components/recovery/SelectRecoveryType.tsx
@@ -12,7 +12,7 @@ export const SelectRecoveryType = ({ onSelect }: SelectRecoveryTypeProps) => (
             icon="SEED_SINGLE"
             heading={<Translation id="TR_BASIC_RECOVERY" />}
             description={<Translation id="TR_BASIC_RECOVERY_OPTION" />}
-            data-test="@recover/select-type/basic"
+            data-test-id="@recover/select-type/basic"
         />
         <OptionsDivider />
         <OnboardingOption
@@ -20,7 +20,7 @@ export const SelectRecoveryType = ({ onSelect }: SelectRecoveryTypeProps) => (
             icon="SEED_SHAMIR"
             heading={<Translation id="TR_ADVANCED_RECOVERY" />}
             description={<Translation id="TR_ADVANCED_RECOVERY_OPTION" />}
-            data-test="@recover/select-type/advanced"
+            data-test-id="@recover/select-type/advanced"
         />
     </OptionsWrapper>
 );

--- a/packages/suite/src/components/recovery/SelectWordCount.tsx
+++ b/packages/suite/src/components/recovery/SelectWordCount.tsx
@@ -19,7 +19,7 @@ export const SelectWordCount = ({ onSelect }: SelectWordCountProps) => (
                 onSelect(12);
             }}
             heading={<Translation id="TR_WORDS" values={{ count: '12' }} />}
-            data-test="@recover/select-count/12"
+            data-test-id="@recover/select-count/12"
         />
         <OptionsDivider />
         <StyledOption
@@ -27,7 +27,7 @@ export const SelectWordCount = ({ onSelect }: SelectWordCountProps) => (
                 onSelect(18);
             }}
             heading={<Translation id="TR_WORDS" values={{ count: '18' }} />}
-            data-test="@recover/select-count/18"
+            data-test-id="@recover/select-count/18"
         />
         <OptionsDivider />
         <StyledOption
@@ -35,7 +35,7 @@ export const SelectWordCount = ({ onSelect }: SelectWordCountProps) => (
                 onSelect(24);
             }}
             heading={<Translation id="TR_WORDS" values={{ count: '24' }} />}
-            data-test="@recover/select-count/24"
+            data-test-id="@recover/select-count/24"
         />
     </OptionsWrapper>
 );

--- a/packages/suite/src/components/settings/DeviceBanner.tsx
+++ b/packages/suite/src/components/settings/DeviceBanner.tsx
@@ -56,7 +56,7 @@ export const DeviceBanner = ({ title, description }: DeviceBannerProps) => {
     const isWebUsbTransport = isWebUsb(transport);
 
     return (
-        <Wrapper data-test="@settings/device/disconnected-device-banner">
+        <Wrapper data-test-id="@settings/device/disconnected-device-banner">
             <StyledLottieAnimation
                 type="CONNECT"
                 shape="CIRCLE"

--- a/packages/suite/src/components/settings/SettingsLayout/SettingsLayout.tsx
+++ b/packages/suite/src/components/settings/SettingsLayout/SettingsLayout.tsx
@@ -14,7 +14,7 @@ const Wrapper = styled.div`
 type SettingsLayoutProps = {
     title?: string;
     children?: ReactNode;
-    ['data-test']?: string;
+    ['data-test-id']?: string;
     className?: string;
 };
 
@@ -22,13 +22,13 @@ export const SettingsLayout = ({
     title,
     children,
     className,
-    'data-test': dataTest,
+    'data-test-id': dataTest,
 }: SettingsLayoutProps) => {
     useLayout(title || 'Settings', SettingsMenu);
     const { isDiscoveryRunning } = useDiscovery();
 
     return (
-        <Wrapper className={className} data-test={dataTest}>
+        <Wrapper className={className} data-test-id={dataTest}>
             <SettingsLoading isPresent={isDiscoveryRunning} />
             <>{children}</>
         </Wrapper>

--- a/packages/suite/src/components/settings/SettingsLayout/SettingsMenu.tsx
+++ b/packages/suite/src/components/settings/SettingsLayout/SettingsMenu.tsx
@@ -70,21 +70,21 @@ export const SettingsMenu = () => {
                 id: 'settings-index',
                 title: <Translation id="TR_GENERAL" />,
                 position: 'primary',
-                'data-test': '@settings/menu/general',
+                'data-test-id': '@settings/menu/general',
                 callback: () => dispatch(goto('settings-index', { preserveParams: true })),
             },
             {
                 id: 'settings-device',
                 title: <Translation id="TR_DEVICE" />,
                 position: 'primary',
-                'data-test': '@settings/menu/device',
+                'data-test-id': '@settings/menu/device',
                 callback: () => dispatch(goto('settings-device', { preserveParams: true })),
             },
             {
                 id: 'settings-coins',
                 title: <Translation id="TR_COINS" />,
                 position: 'primary',
-                'data-test': '@settings/menu/wallet',
+                'data-test-id': '@settings/menu/wallet',
                 callback: () => dispatch(goto('settings-coins', { preserveParams: true })),
             },
             {
@@ -92,7 +92,7 @@ export const SettingsMenu = () => {
                 title: <Translation id="TR_DEBUG_SETTINGS" />,
                 position: 'primary',
                 isHidden: !showDebugMenu,
-                'data-test': '@settings/menu/debug',
+                'data-test-id': '@settings/menu/debug',
                 callback: () => dispatch(goto('settings-debug', { preserveParams: true })),
             },
         ],
@@ -104,7 +104,7 @@ export const SettingsMenu = () => {
             title={
                 <span
                     aria-hidden="true"
-                    data-test="@settings/menu/title"
+                    data-test-id="@settings/menu/title"
                     onClick={handleTitleClick}
                 >
                     <Translation id="TR_SETTINGS" />
@@ -117,7 +117,7 @@ export const SettingsMenu = () => {
                         <CloseButtonSticky
                             isAppNavigationPanelInView={isAppNavigationPanelInView}
                             onClick={handleClose}
-                            data-test="@settings/menu/close"
+                            data-test-id="@settings/menu/close"
                         />
                     </CloseButtonWrapper>
                 )

--- a/packages/suite/src/components/suite/AccountFormCloseButton.tsx
+++ b/packages/suite/src/components/suite/AccountFormCloseButton.tsx
@@ -7,5 +7,5 @@ export const AccountFormCloseButton = () => {
 
     const handleClick = () => dispatch(goto('wallet-index', { preserveParams: true }));
 
-    return <CloseButton onClick={handleClick} data-test="@wallet/menu/close-button" />;
+    return <CloseButton onClick={handleClick} data-test-id="@wallet/menu/close-button" />;
 };

--- a/packages/suite/src/components/suite/AmountUnitSwitchWrapper.tsx
+++ b/packages/suite/src/components/suite/AmountUnitSwitchWrapper.tsx
@@ -54,7 +54,7 @@ export const AmountUnitSwitchWrapper = ({ symbol, children }: AmountUnitSwitchWr
         >
             <Container
                 onClick={handleToggleBitcoinAmountUnits}
-                data-test={`amount-unit-switch/${symbol}`}
+                data-test-id={`amount-unit-switch/${symbol}`}
             >
                 {children}
             </Container>

--- a/packages/suite/src/components/suite/AppNavigation/AppNavigation.tsx
+++ b/packages/suite/src/components/suite/AppNavigation/AppNavigation.tsx
@@ -149,7 +149,7 @@ export type NavigationItem = {
     id: string;
     callback: () => void;
     title: JSX.Element;
-    'data-test'?: string;
+    'data-test-id'?: string;
     isHidden?: boolean;
 };
 export type ActionItem = NavigationItem & {
@@ -251,7 +251,7 @@ export const AppNavigation = ({ items, actions, primaryContent, inView }: AppNav
                                                         isActive={isActive}
                                                         isNavigationDisabled={isAccountLoading}
                                                         onClick={onClick}
-                                                        data-test={item['data-test']}
+                                                        data-test-id={item['data-test-id']}
                                                     >
                                                         <Text>{title}</Text>
                                                     </StyledNavLink>
@@ -291,7 +291,7 @@ export const AppNavigation = ({ items, actions, primaryContent, inView }: AppNav
                                             icon={buyAction?.icon}
                                             key={buyAction?.id}
                                             onClick={buyAction?.callback}
-                                            data-test={`@wallet/menu/${buyAction?.id}`}
+                                            data-test-id={`@wallet/menu/${buyAction?.id}`}
                                             variant="tertiary"
                                             size="small"
                                             isDisabled={disabledButtonsDueDiscovery}
@@ -315,7 +315,7 @@ export const AppNavigation = ({ items, actions, primaryContent, inView }: AppNav
                                                         icon={icon}
                                                         key={id}
                                                         onClick={item.callback}
-                                                        data-test={`@wallet/menu/${item.id}`}
+                                                        data-test-id={`@wallet/menu/${item.id}`}
                                                         variant={
                                                             id === 'wallet-coinmarket-buy'
                                                                 ? 'tertiary'
@@ -334,7 +334,7 @@ export const AppNavigation = ({ items, actions, primaryContent, inView }: AppNav
                                         <Dropdown
                                             alignMenu="bottom-right"
                                             isDisabled={disabledButtonsDueDiscovery}
-                                            data-test="@wallet/menu/extra-dropdown"
+                                            data-test-id="@wallet/menu/extra-dropdown"
                                             items={[
                                                 {
                                                     key: 'extra',
@@ -350,7 +350,7 @@ export const AppNavigation = ({ items, actions, primaryContent, inView }: AppNav
                                                                             ? undefined
                                                                             : item.callback,
                                                                     label: title,
-                                                                    'data-test': `@wallet/menu/${item.id}`,
+                                                                    'data-test-id': `@wallet/menu/${item.id}`,
                                                                 };
                                                             },
                                                         ),

--- a/packages/suite/src/components/suite/AppNavigationPanel.tsx
+++ b/packages/suite/src/components/suite/AppNavigationPanel.tsx
@@ -113,7 +113,7 @@ export const AppNavigationPanel = ({
                     <BasicInfo>
                         <TitleRow>
                             <Title>{title}</Title>
-                            <Aside data-test="@app/navigation/aside">
+                            <Aside data-test-id="@app/navigation/aside">
                                 {titleContent?.(inView)}
                             </Aside>
                         </TitleRow>

--- a/packages/suite/src/components/suite/BundleLoader.tsx
+++ b/packages/suite/src/components/suite/BundleLoader.tsx
@@ -14,7 +14,7 @@ const LoaderWrapper = styled.div`
 `;
 
 export const BundleLoader = () => (
-    <LoaderWrapper data-test="@suite/bundle-loader">
+    <LoaderWrapper data-test-id="@suite/bundle-loader">
         <Spinner size={64} isGrey={false} />
     </LoaderWrapper>
 );

--- a/packages/suite/src/components/suite/ChangeDeviceLabel.tsx
+++ b/packages/suite/src/components/suite/ChangeDeviceLabel.tsx
@@ -78,14 +78,14 @@ export const ChangeDeviceLabel = ({
                 placeholder={placeholder}
                 inputState={error ? 'error' : undefined}
                 onChange={handleChange}
-                data-test="@settings/device/label-input"
+                data-test-id="@settings/device/label-input"
                 hasBottomPadding={false}
                 size={isVertical ? 'small' : 'large'}
             />
             <Button
                 onClick={handleClick}
                 isDisabled={isDisabled}
-                data-test="@settings/device/label-submit"
+                data-test-id="@settings/device/label-submit"
                 size={isVertical ? 'small' : 'large'}
                 isFullWidth
             >

--- a/packages/suite/src/components/suite/CoinBalance.tsx
+++ b/packages/suite/src/components/suite/CoinBalance.tsx
@@ -11,6 +11,6 @@ export const CoinBalance = ({ value, symbol }: CoinBalanceProps) => (
         value={value}
         symbol={symbol}
         isBalance
-        data-test={`@wallet/coin-balance/value-${symbol}`}
+        data-test-id={`@wallet/coin-balance/value-${symbol}`}
     />
 );

--- a/packages/suite/src/components/suite/CoinList/Coin.tsx
+++ b/packages/suite/src/components/suite/CoinList/Coin.tsx
@@ -188,7 +188,7 @@ export const Coin = ({
             forceHover={forceHover}
             hasSettings={!!onSettings}
             onClick={onToggle}
-            data-test={`@settings/wallet/network/${symbol}`}
+            data-test-id={`@settings/wallet/network/${symbol}`}
             data-active={toggled}
         >
             <ImageWrapper>
@@ -210,7 +210,7 @@ export const Coin = ({
             <SettingsWrapper
                 onClick={onSettingsClick}
                 toggled={toggled}
-                data-test={`@settings/wallet/network/${symbol}/advance`}
+                data-test-id={`@settings/wallet/network/${symbol}/advance`}
             >
                 <Icon icon="SETTINGS" />
             </SettingsWrapper>

--- a/packages/suite/src/components/suite/ConnectDevicePrompt.tsx
+++ b/packages/suite/src/components/suite/ConnectDevicePrompt.tsx
@@ -99,7 +99,7 @@ export const ConnectDevicePrompt = ({
             initial={{ opacity: 0, y: -50 }}
             animate={{ opacity: 1, y: -0 }}
             transition={{ delay: 0.2, duration: 0.6, ease: motionEasing.enter }}
-            data-test="@connect-device-prompt"
+            data-test-id="@connect-device-prompt"
         >
             <ImageWrapper>
                 <StyledLottieAnimation

--- a/packages/suite/src/components/suite/DeviceDisplay.tsx
+++ b/packages/suite/src/components/suite/DeviceDisplay.tsx
@@ -130,7 +130,7 @@ export const DeviceDisplay = ({ address, network, valueDataTest }: DeviceDisplay
         chunks?.map((row, rowIndex) => (
             <Row key={rowIndex} isAlignedRight={rowIndex === 0 && isNextAddress}>
                 {row.map((chunk, chunkIndex) => (
-                    <Text isPixelType={isPixelType} key={chunkIndex} data-test="chunk">
+                    <Text isPixelType={isPixelType} key={chunkIndex} data-test-id="chunk">
                         {chunk}
                     </Text>
                 ))}
@@ -163,7 +163,7 @@ export const DeviceDisplay = ({ address, network, valueDataTest }: DeviceDisplay
         };
 
         return (
-            <Chunks onCopy={handleOnCopy} data-test={valueDataTest}>
+            <Chunks onCopy={handleOnCopy} data-test-id={valueDataTest}>
                 {showChunksInRows(groupedChunks)}
             </Chunks>
         );
@@ -175,7 +175,7 @@ export const DeviceDisplay = ({ address, network, valueDataTest }: DeviceDisplay
 
             return (
                 <>
-                    <Text isPixelType={isPixelType} data-test={valueDataTest}>
+                    <Text isPixelType={isPixelType} data-test-id={valueDataTest}>
                         {address.slice(0, breakpoint)}
                     </Text>
                     <StyledNextIcon {...iconConfig} isPixelType={isPixelType} icon={iconNextName} />

--- a/packages/suite/src/components/suite/DeviceInvalidModeLayout.tsx
+++ b/packages/suite/src/components/suite/DeviceInvalidModeLayout.tsx
@@ -44,7 +44,7 @@ type DeviceInvalidModeLayoutProps = {
     image?: ImageType;
     allowSwitchDevice?: boolean;
     resolveButton?: ReactNode;
-    ['data-test']?: string;
+    ['data-test-id']?: string;
 };
 
 export const DeviceInvalidModeLayout = ({
@@ -53,7 +53,7 @@ export const DeviceInvalidModeLayout = ({
     image = 'UNI_WARNING',
     allowSwitchDevice,
     resolveButton,
-    'data-test': dataTest,
+    'data-test-id': dataTest,
 }: DeviceInvalidModeLayoutProps) => {
     const devicesCount = useSelector(selectDevicesCount);
     const dispatch = useDispatch();
@@ -65,7 +65,7 @@ export const DeviceInvalidModeLayout = ({
         <StyledModal
             heading={title}
             description={text}
-            data-test={dataTest}
+            data-test-id={dataTest}
             bottomBarComponents={
                 <>
                     {resolveButton && resolveButton}

--- a/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
+++ b/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
@@ -32,7 +32,7 @@ export interface FormattedCryptoAmountProps {
     signValue?: SignValue;
     disableHiddenPlaceholder?: boolean;
     isRawString?: boolean;
-    'data-test'?: string;
+    'data-test-id'?: string;
     className?: string;
 }
 
@@ -43,7 +43,7 @@ export const FormattedCryptoAmount = ({
     signValue,
     disableHiddenPlaceholder,
     isRawString,
-    'data-test': dataTest,
+    'data-test-id': dataTest,
     className,
 }: FormattedCryptoAmountProps) => {
     const locale = useSelector(state => state.suite.settings.language);
@@ -90,7 +90,7 @@ export const FormattedCryptoAmount = ({
         <Container className={className}>
             {!!signValue && <Sign value={signValue} />}
 
-            <Value data-test={dataTest}>{formattedValue}</Value>
+            <Value data-test-id={dataTest}>{formattedValue}</Value>
 
             {symbol && <Symbol>&nbsp;{formattedSymbol}</Symbol>}
         </Container>

--- a/packages/suite/src/components/suite/HiddenPlaceholder.tsx
+++ b/packages/suite/src/components/suite/HiddenPlaceholder.tsx
@@ -25,7 +25,7 @@ interface HiddenPlaceholderProps {
     enforceIntensity?: number;
     children: ReactNode;
     className?: string;
-    ['data-test']?: string;
+    ['data-test-id']?: string;
 }
 
 export const HiddenPlaceholder = ({
@@ -58,7 +58,7 @@ export const HiddenPlaceholder = ({
             intensity={enforceIntensity !== undefined ? enforceIntensity : automaticIntensity}
             className={className}
             ref={ref}
-            data-test={rest['data-test']}
+            data-test-id={rest['data-test-id']}
         >
             {children}
         </Wrapper>

--- a/packages/suite/src/components/suite/HomescreenGallery.tsx
+++ b/packages/suite/src/components/suite/HomescreenGallery.tsx
@@ -66,7 +66,7 @@ export const HomescreenGallery = ({ onConfirm }: HomescreenGalleryProps) => {
                 <BackgroundGalleryWrapper>
                     {homescreens[deviceModelInternal].map(image => (
                         <BackgroundImageBW64x128
-                            data-test={`@modal/gallery/bw_64x128/${image}`}
+                            data-test-id={`@modal/gallery/bw_64x128/${image}`}
                             key={image}
                             id={image}
                             onClick={e =>
@@ -81,7 +81,7 @@ export const HomescreenGallery = ({ onConfirm }: HomescreenGalleryProps) => {
                 <BackgroundGalleryWrapper>
                     {homescreens[deviceModelInternal].map(image => (
                         <BackgroundImageColor240x240
-                            data-test={`@modal/gallery/color_240x240/${image}`}
+                            data-test-id={`@modal/gallery/color_240x240/${image}`}
                             key={image}
                             id={image}
                             onClick={e =>

--- a/packages/suite/src/components/suite/Loading.tsx
+++ b/packages/suite/src/components/suite/Loading.tsx
@@ -15,7 +15,7 @@ type LoadingProps = {
 };
 
 export const Loading = ({ className }: LoadingProps) => (
-    <LoaderWrapper data-test="@suite/loading" className={className}>
+    <LoaderWrapper data-test-id="@suite/loading" className={className}>
         <Spinner size={80} isGrey={false} />
     </LoaderWrapper>
 );

--- a/packages/suite/src/components/suite/NotificationCard.tsx
+++ b/packages/suite/src/components/suite/NotificationCard.tsx
@@ -27,7 +27,7 @@ interface NotificationCardProps {
     isLoading?: boolean;
     button?: ButtonType;
     className?: string;
-    ['data-test']?: string;
+    ['data-test-id']?: string;
     icon?: IconType;
 }
 
@@ -148,7 +148,7 @@ export const NotificationCard = ({
             variant={variant}
             className={className}
             elevation={elevation}
-            data-test={props['data-test']}
+            data-test-id={props['data-test-id']}
         >
             <ElevationContext baseElevation={elevation}>
                 <IconWrapper>

--- a/packages/suite/src/components/suite/PinMatrix/PinInput/PinInput.tsx
+++ b/packages/suite/src/components/suite/PinMatrix/PinInput/PinInput.tsx
@@ -131,7 +131,7 @@ export const PinInput = ({ isSubmitting, onPinSubmit }: PinInputProps) => {
     }, [onPinAdd, onPinBackspace, submit]);
 
     return (
-        <Wrapper data-test="@pin">
+        <Wrapper data-test-id="@pin">
             <InputWrapper>
                 <InputPin value={pin} onDeleteClick={() => onPinBackspace()} />
             </InputWrapper>
@@ -140,19 +140,19 @@ export const PinInput = ({ isSubmitting, onPinSubmit }: PinInputProps) => {
                     blur={isSubmitting}
                     data-value="7"
                     onClick={() => onPinAdd('7')}
-                    data-test="@pin/input/7"
+                    data-test-id="@pin/input/7"
                 />
                 <StyledPinButton
                     blur={isSubmitting}
                     data-value="8"
                     onClick={() => onPinAdd('8')}
-                    data-test="@pin/input/8"
+                    data-test-id="@pin/input/8"
                 />
                 <StyledPinButton
                     blur={isSubmitting}
                     data-value="9"
                     onClick={() => onPinAdd('9')}
-                    data-test="@pin/input/9"
+                    data-test-id="@pin/input/9"
                 />
             </PinRow>
             <PinRow>
@@ -160,19 +160,19 @@ export const PinInput = ({ isSubmitting, onPinSubmit }: PinInputProps) => {
                     blur={isSubmitting}
                     data-value="4"
                     onClick={() => onPinAdd('4')}
-                    data-test="@pin/input/4"
+                    data-test-id="@pin/input/4"
                 />
                 <StyledPinButton
                     blur={isSubmitting}
                     data-value="5"
                     onClick={() => onPinAdd('5')}
-                    data-test="@pin/input/5"
+                    data-test-id="@pin/input/5"
                 />
                 <StyledPinButton
                     blur={isSubmitting}
                     data-value="6"
                     onClick={() => onPinAdd('6')}
-                    data-test="@pin/input/6"
+                    data-test-id="@pin/input/6"
                 />
             </PinRow>
             <PinRow>
@@ -180,20 +180,20 @@ export const PinInput = ({ isSubmitting, onPinSubmit }: PinInputProps) => {
                     blur={isSubmitting}
                     data-value="1"
                     onClick={() => onPinAdd('1')}
-                    data-test="@pin/input/1"
+                    data-test-id="@pin/input/1"
                 />
 
                 <StyledPinButton
                     blur={isSubmitting}
                     data-value="2"
                     onClick={() => onPinAdd('2')}
-                    data-test="@pin/input/2"
+                    data-test-id="@pin/input/2"
                 />
                 <StyledPinButton
                     blur={isSubmitting}
                     data-value="3"
                     onClick={() => onPinAdd('3')}
-                    data-test="@pin/input/3"
+                    data-test-id="@pin/input/3"
                 />
             </PinRow>
 
@@ -204,7 +204,7 @@ export const PinInput = ({ isSubmitting, onPinSubmit }: PinInputProps) => {
                     isDisabled={isSubmitting}
                     isFullWidth
                     onClick={submit}
-                    data-test="@pin/submit-button"
+                    data-test-id="@pin/submit-button"
                 >
                     {isSubmitting ? (
                         <Translation id="TR_VERIFYING_PIN" />

--- a/packages/suite/src/components/suite/Preloader/LoggedOutLayout.tsx
+++ b/packages/suite/src/components/suite/Preloader/LoggedOutLayout.tsx
@@ -37,9 +37,9 @@ export const LoggedOutLayout = ({ children }: LoggedOutLayout) => {
                     <ModalSwitcher />
 
                     <LayoutContext.Provider value={setLayoutPayload}>
-                        <Body data-test="@suite-layout/body">
+                        <Body data-test-id="@suite-layout/body">
                             <Columns>
-                                <AppWrapper data-test="@app" ref={scrollRef} id="layout-scroll">
+                                <AppWrapper data-test-id="@app" ref={scrollRef} id="layout-scroll">
                                     {TopMenu && <TopMenu />}
 
                                     <ContentWrapper>{children}</ContentWrapper>

--- a/packages/suite/src/components/suite/Preloader/SuiteLayout/DeviceSelector/DeviceSelector.tsx
+++ b/packages/suite/src/components/suite/Preloader/SuiteLayout/DeviceSelector/DeviceSelector.tsx
@@ -165,7 +165,7 @@ export const DeviceSelector = () => {
 
     return (
         <Wrapper
-            data-test="@menu/switch-device"
+            data-test-id="@menu/switch-device"
             onClick={handleSwitchDeviceClick}
             isAnimationTriggered={isAnimationTriggered}
             tabIndex={0}

--- a/packages/suite/src/components/suite/Preloader/SuiteLayout/MobileMenu/MobileActionItem.tsx
+++ b/packages/suite/src/components/suite/Preloader/SuiteLayout/MobileMenu/MobileActionItem.tsx
@@ -82,7 +82,7 @@ interface CommonProps extends Pick<HTMLAttributes<HTMLDivElement>, 'onClick'> {
     label: ReactNode;
     isActive?: boolean;
     indicator?: IndicatorStatus;
-    'data-test'?: string;
+    'data-test-id'?: string;
 }
 
 interface CustomIconComponentProps extends CommonProps {
@@ -105,7 +105,7 @@ export const MobileActionItem = ({
     isActive,
     label,
     onClick,
-    'data-test': dataTest,
+    'data-test-id': dataTest,
 }: MobileActionItemProps) => {
     const theme = useTheme();
 
@@ -143,7 +143,7 @@ export const MobileActionItem = ({
     );
 
     return (
-        <MobileWrapper data-test={dataTest} onClick={onClick}>
+        <MobileWrapper data-test-id={dataTest} onClick={onClick}>
             <MobileIconWrapper>{Content}</MobileIconWrapper>
             <Label isActive={isActive}>{label}</Label>
         </MobileWrapper>

--- a/packages/suite/src/components/suite/Preloader/SuiteLayout/MobileMenu/MobileMenuActions.tsx
+++ b/packages/suite/src/components/suite/Preloader/SuiteLayout/MobileMenu/MobileMenuActions.tsx
@@ -78,7 +78,7 @@ export const MobileMenuActions = ({ closeMobileNavigation }: MobileMenuActionsPr
 
             <MobileActionItem
                 label={<Translation id="TR_NOTIFICATIONS" />}
-                data-test="@suite/menu/notifications-index"
+                data-test-id="@suite/menu/notifications-index"
                 onClick={() => action('notifications-index')}
                 isActive={getIfTabIsActive(['notifications-index'])}
                 icon="NOTIFICATION"
@@ -87,14 +87,14 @@ export const MobileMenuActions = ({ closeMobileNavigation }: MobileMenuActionsPr
 
             <MobileActionItem
                 label={<Translation id="TR_GUIDE_VIEW_HEADLINE_LEARN_AND_DISCOVER" />}
-                data-test="@suite/menu/guide-index"
+                data-test-id="@suite/menu/guide-index"
                 onClick={handleOpenGuide}
                 icon="LIGHTBULB"
             />
 
             <MobileActionItem
                 label={<Translation id="TR_SETTINGS" />}
-                data-test="@suite/menu/settings-index"
+                data-test-id="@suite/menu/settings-index"
                 onClick={() => action('settings-index')}
                 isActive={getIfTabIsActive([
                     'settings-index',

--- a/packages/suite/src/components/suite/Preloader/SuiteLayout/MobileMenu/MobileNavigation.tsx
+++ b/packages/suite/src/components/suite/Preloader/SuiteLayout/MobileMenu/MobileNavigation.tsx
@@ -94,7 +94,7 @@ export const MobileNavigation = ({ closeMobileNavigation }: MobileNavigationProp
                 return (
                     <HoverAnimation isHoverable={!isActive} key={route}>
                         <MenuItem
-                            data-test={`@suite/menu/${route}`}
+                            data-test-id={`@suite/menu/${route}`}
                             onClick={() => {
                                 if (!isDisabled) {
                                     if (route === 'wallet-index') {

--- a/packages/suite/src/components/suite/Preloader/SuiteLayout/Sidebar/NavigationItem.tsx
+++ b/packages/suite/src/components/suite/Preloader/SuiteLayout/Sidebar/NavigationItem.tsx
@@ -96,7 +96,7 @@ export const NavigationItem = ({
         <Container
             isActive={isActive || isActiveRoute}
             onClick={handleClick}
-            data-test={dataTest! !== undefined ? dataTest : `@suite/menu/${goToRoute}`}
+            data-test-id={dataTest! !== undefined ? dataTest : `@suite/menu/${goToRoute}`}
             className={className}
             tabIndex={0}
             elevation={elevation}

--- a/packages/suite/src/components/suite/Preloader/SuiteLayout/SuiteLayout.tsx
+++ b/packages/suite/src/components/suite/Preloader/SuiteLayout/SuiteLayout.tsx
@@ -109,11 +109,11 @@ export const SuiteLayout = ({ children }: SuiteLayoutProps) => {
                     <DiscoveryProgress />
 
                     <LayoutContext.Provider value={setLayoutPayload}>
-                        <Body data-test="@suite-layout/body">
+                        <Body data-test-id="@suite-layout/body">
                             <Columns>
                                 {!isMobileLayout && <Sidebar />}
 
-                                <AppWrapper data-test="@app" ref={scrollRef} id="layout-scroll">
+                                <AppWrapper data-test-id="@app" ref={scrollRef} id="layout-scroll">
                                     {isMobileLayout && <MobileAccountsMenu />}
                                     {TopMenu && <TopMenu />}
 

--- a/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
+++ b/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
@@ -7,7 +7,7 @@ import { Preloader } from '../Preloader';
 
 // render only Translation.id in data-test attribute
 jest.mock('src/components/suite/Translation', () => ({
-    Translation: ({ id }: any) => <div data-test={id}>{id}</div>,
+    Translation: ({ id }: any) => <div data-test-id={id}>{id}</div>,
 }));
 
 // @trezor/connect fetching ethereum definitions
@@ -20,17 +20,17 @@ jest.mock('cross-fetch', () => ({
 
 // jest.mock('@firmware-components/ReconnectDevicePrompt', () => ({
 //     __esModule: true, // export as module
-//     default: ({ children }: any) => <div data-test="box">{children}</div>,
+//     default: ({ children }: any) => <div data-test-id="box">{children}</div>,
 // }));
 // jest.mock('src/components/onboarding/DeviceAnimation', () => ({
 //     __esModule: true, // export as module
-//     default: ({ children }: any) => <div data-test="box">{children}</div>,
+//     default: ({ children }: any) => <div data-test-id="box">{children}</div>,
 // }));
 // do not render animations
 // jest.mock('lottie-react', () => ({
 //     // Lottie: ({ trezorVersion }: any) => <div>{trezorVersion}</div>,
 //     __esModule: true, // export as module
-//     default: ({ trezorVersion }: any) => <div data-test="lottie-image">{trezorVersion}</div>,
+//     default: ({ trezorVersion }: any) => <div data-test-id="lottie-image">{trezorVersion}</div>,
 // }));
 // jest.mock('react-use/lib/useMeasure', () => ({
 //     // Lottie: ({ trezorVersion }: any) => <div>{trezorVersion}</div>,

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceAcquire.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceAcquire.tsx
@@ -19,7 +19,7 @@ export const DeviceAcquire = () => {
     };
 
     const ctaButton = (
-        <Button data-test="@device-acquire" isLoading={isDeviceLocked} onClick={handleClick}>
+        <Button data-test-id="@device-acquire" isLoading={isDeviceLocked} onClick={handleClick}>
             <Translation id="TR_ACQUIRE_DEVICE" />
         </Button>
     );

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceConnect.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceConnect.tsx
@@ -33,8 +33,8 @@ export const DeviceConnect = ({ isWebUsbTransport }: DeviceConnectProps) => {
             label={<Translation id="TR_STILL_DONT_SEE_YOUR_TREZOR" />}
             items={items}
             offerWebUsb={isWebUsbTransport}
-            cta={isWebUsbTransport ? <WebUsbButton data-test="@webusb-button" /> : undefined}
-            data-test="@connect-device-prompt/no-device-detected"
+            cta={isWebUsbTransport ? <WebUsbButton data-test-id="@webusb-button" /> : undefined}
+            data-test-id="@connect-device-prompt/no-device-detected"
         />
     );
 };

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceInitialize.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceInitialize.tsx
@@ -22,7 +22,7 @@ export const DeviceInitialize = () => {
         <TroubleshootingTips
             label={<Translation id="TR_DEVICE_NOT_INITIALIZED" />}
             cta={
-                <Button data-test="@button/go-to-onboarding" onClick={handleCtaClick}>
+                <Button data-test-id="@button/go-to-onboarding" onClick={handleCtaClick}>
                     <Translation id="TR_GO_TO_ONBOARDING" />
                 </Button>
             }

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUnreadable.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUnreadable.tsx
@@ -30,7 +30,7 @@ const UdevWeb = () => (
                 description: <UdevDownload />,
             },
         ]}
-        data-test="@connect-device-prompt/unreadable-udev"
+        data-test-id="@connect-device-prompt/unreadable-udev"
     />
 );
 
@@ -66,7 +66,7 @@ const UdevDesktop = () => {
                 opened={false}
                 label={<Translation id="TR_RECONNECT_IN_NORMAL" />}
                 items={[]}
-                data-test="@connect-device-prompt/unreadable-udev"
+                data-test-id="@connect-device-prompt/unreadable-udev"
             />
         );
     }
@@ -92,7 +92,7 @@ const UdevDesktop = () => {
                     noBullet: true,
                 },
             ]}
-            data-test="@connect-device-prompt/unreadable-udev"
+            data-test-id="@connect-device-prompt/unreadable-udev"
         />
     );
 };
@@ -111,7 +111,7 @@ export const DeviceUnreadable = ({ device, isWebUsbTransport }: DeviceUnreadable
                 label={<Translation id="TR_TROUBLESHOOTING_UNREADABLE_WEBUSB" />}
                 items={[TROUBLESHOOTING_TIP_BRIDGE_STATUS, TROUBLESHOOTING_TIP_BRIDGE_INSTALL]}
                 offerWebUsb
-                data-test="@connect-device-prompt/unreadable-hid"
+                data-test-id="@connect-device-prompt/unreadable-hid"
             />
         );
     }
@@ -135,7 +135,7 @@ export const DeviceUnreadable = ({ device, isWebUsbTransport }: DeviceUnreadable
                 TROUBLESHOOTING_TIP_DIFFERENT_COMPUTER,
             ]}
             offerWebUsb={isWebUsbTransport}
-            data-test="@connect-device-prompt/unreadable-unknown"
+            data-test-id="@connect-device-prompt/unreadable-unknown"
         />
     );
 };

--- a/packages/suite/src/components/suite/PrerequisitesGuide/Transport.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/Transport.tsx
@@ -16,6 +16,6 @@ export const Transport = () => (
             TROUBLESHOOTING_TIP_BRIDGE_INSTALL,
             TROUBLESHOOTING_TIP_RESTART_COMPUTER,
         ]}
-        data-test="@connect-device-prompt/bridge-not-running"
+        data-test-id="@connect-device-prompt/bridge-not-running"
     />
 );

--- a/packages/suite/src/components/suite/TorLoader/TorLoader.tsx
+++ b/packages/suite/src/components/suite/TorLoader/TorLoader.tsx
@@ -88,7 +88,7 @@ export const TorLoader = ({ callback, ModalWrapper }: TorLoadingScreenProps) => 
             bottomBarComponents={
                 isTorError && (
                     <StyledButton
-                        data-test="@tor-loading-screen/try-again-button"
+                        data-test-id="@tor-loading-screen/try-again-button"
                         icon="REFRESH"
                         onClick={tryAgain}
                     >

--- a/packages/suite/src/components/suite/TorLoader/TorProgressBar.tsx
+++ b/packages/suite/src/components/suite/TorLoader/TorProgressBar.tsx
@@ -134,7 +134,7 @@ export const TorProgressBar = ({
 
                 {!isTorDisabling && (
                     <DisableButton
-                        data-test="@tor-loading-screen/disable-button"
+                        data-test-id="@tor-loading-screen/disable-button"
                         variant="secondary"
                         onClick={disableTor}
                     >

--- a/packages/suite/src/components/suite/WebUsbButton.tsx
+++ b/packages/suite/src/components/suite/WebUsbButton.tsx
@@ -3,7 +3,7 @@ import { ButtonProps, Button } from '@trezor/components';
 import { Translation } from './Translation';
 
 export const WebUsbButton = (props: Omit<ButtonProps, 'children'>) => (
-    <div data-test="web-usb-button">
+    <div data-test-id="web-usb-button">
         <Button
             {...props}
             icon="SEARCH"

--- a/packages/suite/src/components/suite/WelcomeLayout/NavSettings.tsx
+++ b/packages/suite/src/components/suite/WelcomeLayout/NavSettings.tsx
@@ -41,7 +41,7 @@ export const NavSettings = ({ isActive }: NavSettingsProps) => {
             content={<Translation id="TR_SETTINGS" />}
         >
             <HoverAnimation>
-                <Wrapper data-test="@suite/menu/settings" onClick={handleClick}>
+                <Wrapper data-test-id="@suite/menu/settings" onClick={handleClick}>
                     <Icon
                         color={isActive ? theme.TYPE_DARK_GREY : theme.TYPE_LIGHT_GREY}
                         size={24}

--- a/packages/suite/src/components/suite/WelcomeLayout/WelcomeLayout.tsx
+++ b/packages/suite/src/components/suite/WelcomeLayout/WelcomeLayout.tsx
@@ -128,7 +128,7 @@ export const WelcomeLayout = ({ children }: WelcomeLayoutProps) => {
         <Wrapper>
             {bannerMessage && <MessageSystemBanner message={bannerMessage} />}
 
-            <Body data-test="@welcome-layout/body">
+            <Body data-test-id="@welcome-layout/body">
                 <WelcomeWrapper>
                     <AnimatePresence>
                         {(!isGuideOpen || isGuideOnTop) && (
@@ -151,7 +151,7 @@ export const WelcomeLayout = ({ children }: WelcomeLayoutProps) => {
                                 <Expander>
                                     <TrezorLogo type="suite" width="128px" />
 
-                                    <WelcomeTitle data-test="@welcome/title">
+                                    <WelcomeTitle data-test-id="@welcome/title">
                                         <Translation id="TR_ONBOARDING_WELCOME_HEADING" />
                                     </WelcomeTitle>
                                 </Expander>

--- a/packages/suite/src/components/suite/WordInput.tsx
+++ b/packages/suite/src/components/suite/WordInput.tsx
@@ -88,7 +88,7 @@ export const WordInput = memo(() => {
                     trim: true,
                     matchFrom: 'start',
                 })}
-                data-test="@word-input-select"
+                data-test-id="@word-input-select"
             />
         </SelectWrapper>
     );

--- a/packages/suite/src/components/suite/WordInputAdvanced.tsx
+++ b/packages/suite/src/components/suite/WordInputAdvanced.tsx
@@ -141,7 +141,7 @@ export const WordInputAdvanced = ({ count }: WordInputAdvancedProps) => {
                             <PinButton
                                 data-value="1"
                                 onClick={() => onSubmit('1')}
-                                data-test="@recovery/word-input-advanced/1"
+                                data-test-id="@recovery/word-input-advanced/1"
                             />
                             <PinButton data-value="2" onClick={() => onSubmit('2')} />
                             <PinButton data-value="3" onClick={() => onSubmit('3')} />
@@ -163,7 +163,7 @@ export const WordInputAdvanced = ({ count }: WordInputAdvancedProps) => {
                             <PinButton
                                 data-value="2"
                                 onClick={() => onSubmit('1')}
-                                data-test="@recovery/word-input-advanced/1"
+                                data-test-id="@recovery/word-input-advanced/1"
                             />
                             <PinButton data-value="3" onClick={() => onSubmit('3')} />
                         </Row>

--- a/packages/suite/src/components/suite/banners/Banner.tsx
+++ b/packages/suite/src/components/suite/banners/Banner.tsx
@@ -12,11 +12,11 @@ interface BannerProps {
     action?: {
         label: ReactNode | string;
         onClick: () => void;
-        'data-test': string;
+        'data-test-id': string;
     };
     dismissal?: {
         onClick: () => void;
-        'data-test': string;
+        'data-test-id': string;
     };
     className?: string;
 }
@@ -149,7 +149,7 @@ export const Banner = ({ body, variant, action, dismissal, className }: BannerPr
                         size="tiny"
                         variant="tertiary"
                         onClick={action.onClick}
-                        data-test={action['data-test']}
+                        data-test-id={action['data-test-id']}
                     >
                         {action.label}
                     </Button>
@@ -161,7 +161,7 @@ export const Banner = ({ body, variant, action, dismissal, className }: BannerPr
                             icon="CROSS"
                             color={getForegroundColor(variant, theme)}
                             onClick={dismissal.onClick}
-                            data-test={dismissal['data-test']}
+                            data-test-id={dismissal['data-test-id']}
                         />
                     </CancelWrapper>
                 )}

--- a/packages/suite/src/components/suite/banners/MessageSystemBanner.tsx
+++ b/packages/suite/src/components/suite/banners/MessageSystemBanner.tsx
@@ -47,7 +47,7 @@ export const MessageSystemBanner = ({ message }: MessageSystemBannerProps) => {
         return {
             label: label[language] || label.en,
             onClick: onClick!,
-            'data-test': `@message-system/${id}/cta`,
+            'data-test-id': `@message-system/${id}/cta`,
         };
     }, [id, cta, dispatch, language, isTorEnabled, torOnionLinks]);
 
@@ -57,7 +57,7 @@ export const MessageSystemBanner = ({ message }: MessageSystemBannerProps) => {
         return {
             onClick: () =>
                 dispatch(messageSystemActions.dismissMessage({ id, category: 'banner' })),
-            'data-test': `@message-system/${id}/dismiss`,
+            'data-test-id': `@message-system/${id}/dismiss`,
         };
     }, [id, dismissible, dispatch]);
 

--- a/packages/suite/src/components/suite/banners/SuiteBanners/FailedBackupBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/FailedBackupBanner.tsx
@@ -10,7 +10,7 @@ export const FailedBackup = () => {
     const action = {
         label: <Translation id="TR_CONTINUE" />,
         onClick: () => dispatch(goto('settings-device', { anchor: SettingsAnchor.BackupFailed })),
-        'data-test': '@notification/failed-backup/cta',
+        'data-test-id': '@notification/failed-backup/cta',
     };
 
     return (

--- a/packages/suite/src/components/suite/banners/SuiteBanners/NoBackupBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/NoBackupBanner.tsx
@@ -10,7 +10,7 @@ export const NoBackup = () => {
     const action = {
         label: <Translation id="TR_CREATE_BACKUP" />,
         onClick: () => dispatch(goto('backup-index')),
-        'data-test': '@notification/no-backup/button',
+        'data-test-id': '@notification/no-backup/button',
     };
 
     const translation = `${translationString(

--- a/packages/suite/src/components/suite/banners/SuiteBanners/SafetyChecksBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/SafetyChecksBanner.tsx
@@ -20,7 +20,7 @@ export const SafetyChecksBanner = ({ onDismiss }: SafetyChecksBannerProps) => {
                     anchor: SettingsAnchor.SafetyChecks,
                 }),
             ),
-        'data-test': '@banner/safety-checks/button',
+        'data-test-id': '@banner/safety-checks/button',
     };
 
     return (
@@ -32,7 +32,7 @@ export const SafetyChecksBanner = ({ onDismiss }: SafetyChecksBannerProps) => {
                 onDismiss
                     ? {
                           onClick: onDismiss,
-                          'data-test': '@banner/safety-checks/dismiss',
+                          'data-test-id': '@banner/safety-checks/dismiss',
                       }
                     : undefined
             }

--- a/packages/suite/src/components/suite/banners/SuiteBanners/TranslationModeBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/TranslationModeBanner.tsx
@@ -8,7 +8,7 @@ export const TranslationMode = () => (
         action={{
             label: 'Turn off',
             onClick: () => setTranslationMode(false),
-            'data-test': '@notification/translation-mode/button',
+            'data-test-id': '@notification/translation-mode/button',
         }}
     />
 );

--- a/packages/suite/src/components/suite/banners/SuiteBanners/UpdateBridgeBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/UpdateBridgeBanner.tsx
@@ -9,7 +9,7 @@ export const UpdateBridge = () => {
     const action = {
         label: <Translation id="TR_SHOW_DETAILS" />,
         onClick: () => dispatch(goto('suite-bridge')),
-        'data-test': '@notification/update-bridge/button',
+        'data-test-id': '@notification/update-bridge/button',
     };
 
     return (

--- a/packages/suite/src/components/suite/banners/SuiteBanners/UpdateFirmwareBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/UpdateFirmwareBanner.tsx
@@ -9,7 +9,7 @@ export const UpdateFirmware = () => {
     const action = {
         label: <Translation id="TR_SHOW_DETAILS" />,
         onClick: () => dispatch(goto('firmware-index')),
-        'data-test': '@notification/update-firmware/button',
+        'data-test-id': '@notification/update-firmware/button',
     };
 
     return (

--- a/packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipBase.tsx
+++ b/packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipBase.tsx
@@ -164,7 +164,7 @@ export const GraphTooltipBase = (props: GraphTooltipBaseProps) => {
         <CustomTooltipWrapper
             positionX={props.coordinate!.x!}
             boxWidth={props.viewBox!.width!}
-            data-test="@dashboard/customtooltip"
+            data-test-id="@dashboard/customtooltip"
         >
             <Row>
                 <Title>{date && formatDate(date, dateFormat)}</Title>

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
@@ -122,7 +122,7 @@ const ButtonLikeLabel = ({
     defaultVisibleValue,
     onSubmit,
     onBlur,
-    'data-test': dataTest,
+    'data-test-id': dataTest,
 }: ExtendedProps) => {
     const EditableButton = useMemo(() => withEditable(RelativeButton), []);
 
@@ -132,7 +132,7 @@ const ButtonLikeLabel = ({
                 // @ts-expect-error todo: hm this needs some clever generic
                 variant="tertiary"
                 icon="TAG"
-                data-test={dataTest}
+                data-test-id={dataTest}
                 originalValue={payload.value ?? defaultEditableValue}
                 onSubmit={onSubmit}
                 onBlur={onBlur}
@@ -143,7 +143,7 @@ const ButtonLikeLabel = ({
 
     if (payload.value) {
         return (
-            <LabelButton variant="tertiary" icon="TAG" data-test={dataTest} size="tiny">
+            <LabelButton variant="tertiary" icon="TAG" data-test-id={dataTest} size="tiny">
                 <Inline>
                     <LabelValue>{payload.value} </LabelValue>
                     {/* This is the defaultVisibleValue which shows up after you hover over the label name: */}
@@ -163,7 +163,7 @@ const TextLikeLabel = ({
     defaultVisibleValue,
     defaultEditableValue,
     payload,
-    'data-test': dataTest,
+    'data-test-id': dataTest,
     onSubmit,
     onBlur,
 }: ExtendedProps) => {
@@ -172,7 +172,7 @@ const TextLikeLabel = ({
     if (editActive) {
         return (
             <EditableLabel
-                data-test={dataTest}
+                data-test-id={dataTest}
                 originalValue={payload.value ?? defaultEditableValue}
                 onSubmit={onSubmit}
                 onBlur={onBlur}
@@ -182,7 +182,7 @@ const TextLikeLabel = ({
 
     if (payload.value) {
         return (
-            <Label data-test={dataTest}>
+            <Label data-test-id={dataTest}>
                 <LabelValue>{payload.value}</LabelValue>
             </Label>
         );
@@ -300,7 +300,7 @@ export const MetadataLabeling = ({
         {
             onClick: () => activateEdit(),
             label: l10nLabelling.edit,
-            'data-test': '@metadata/edit-button',
+            'data-test-id': '@metadata/edit-button',
             key: 'edit-label',
         },
     ];
@@ -358,7 +358,7 @@ export const MetadataLabeling = ({
     // metadata is still initiating, on hover, show only disabled button with spinner
     if (metadata.initiating)
         return (
-            <LabelContainer data-test={labelContainerDataTest}>
+            <LabelContainer data-test-id={labelContainerDataTest}>
                 {defaultVisibleValue}
                 <ActionButton variant="tertiary" isDisabled isLoading size="tiny">
                     <Translation id="TR_LOADING" />
@@ -375,7 +375,7 @@ export const MetadataLabeling = ({
 
     return (
         <LabelContainer
-            data-test={labelContainerDataTest}
+            data-test-id={labelContainerDataTest}
             onClick={e => editActive && e.stopPropagation()}
         >
             {payload.type === 'outputLabel' ? (
@@ -384,7 +384,7 @@ export const MetadataLabeling = ({
                         editActive={editActive}
                         onSubmit={onSubmit || defaultOnSubmit}
                         onBlur={handleBlur}
-                        data-test={dataTestBase}
+                        data-test-id={dataTestBase}
                         payload={payload}
                         defaultEditableValue={defaultEditableValue}
                         defaultVisibleValue={defaultVisibleValue}
@@ -392,7 +392,7 @@ export const MetadataLabeling = ({
                     />
                     {showOutputLabelActionButton && (
                         <ActionButton
-                            data-test={`${dataTestBase}/add-label-button`}
+                            data-test-id={`${dataTestBase}/add-label-button`}
                             variant="tertiary"
                             icon={!actionButtonsDisabled ? 'TAG' : undefined}
                             isLoading={actionButtonsDisabled}
@@ -418,14 +418,14 @@ export const MetadataLabeling = ({
                         editActive={editActive}
                         onSubmit={onSubmit || defaultOnSubmit}
                         onBlur={handleBlur}
-                        data-test={dataTestBase}
+                        data-test-id={dataTestBase}
                         payload={payload}
                         defaultEditableValue={defaultEditableValue}
                         defaultVisibleValue={defaultVisibleValue}
                     />
                     {showActionButton && (
                         <ActionButton
-                            data-test={
+                            data-test-id={
                                 payload.value
                                     ? `${dataTestBase}/edit-label-button`
                                     : `${dataTestBase}/add-label-button`
@@ -450,7 +450,7 @@ export const MetadataLabeling = ({
             {showSuccess && !editActive && (
                 <SuccessButton
                     variant="tertiary"
-                    data-test={`${dataTestBase}/success`}
+                    data-test-id={`${dataTestBase}/success`}
                     icon="CHECK"
                     size="tiny"
                 >

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/definitions.ts
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/definitions.ts
@@ -19,5 +19,5 @@ export interface ExtendedProps extends Props {
     editActive: boolean;
     onSubmit: (value: string | undefined) => void;
     onBlur: () => void;
-    'data-test': string;
+    'data-test-id': string;
 }

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/withDropdown.tsx
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/withDropdown.tsx
@@ -30,7 +30,7 @@ export const withDropdown = (WrappedComponent: FC<ExtendedProps>) => (props: Pro
                 key: 'key',
                 options: props.dropdownOptions.map(it => ({
                     ...it,
-                    'data-test': `${props['data-test']}/dropdown/${it.key}`,
+                    'data-test-id': `${props['data-test-id']}/dropdown/${it.key}`,
                 })),
             },
         ]}

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/withEditable.tsx
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/withEditable.tsx
@@ -92,7 +92,7 @@ export const withEditable =
                     <Editable
                         minWidth={20}
                         ref={divRef}
-                        data-test="@metadata/input"
+                        data-test-id="@metadata/input"
                         value={value}
                         // onBlur={onBlur}
                         onChange={event => {
@@ -115,7 +115,7 @@ export const withEditable =
                         <Icon
                             useCursorPointer
                             size={14}
-                            data-test="@metadata/submit"
+                            data-test-id="@metadata/submit"
                             icon="CHECK"
                             onClick={e => {
                                 e.stopPropagation();
@@ -129,7 +129,7 @@ export const withEditable =
                         <Icon
                             useCursorPointer
                             size={14}
-                            data-test="@metadata/cancel"
+                            data-test-id="@metadata/cancel"
                             icon="CROSS"
                             onClick={e => {
                                 e.stopPropagation();

--- a/packages/suite/src/components/suite/modals/AbortButton.tsx
+++ b/packages/suite/src/components/suite/modals/AbortButton.tsx
@@ -85,7 +85,7 @@ export const AbortButton = ({ onAbort, className }: AbortButtonProps) => {
     return (
         <AbortContainer
             key="@modal/close-button" // passed in array
-            data-test="@modal/close-button"
+            data-test-id="@modal/close-button"
             onClick={onAbort}
             className={className}
         >

--- a/packages/suite/src/components/suite/modals/ModalSwitcher/DiscoveryLoader.tsx
+++ b/packages/suite/src/components/suite/modals/ModalSwitcher/DiscoveryLoader.tsx
@@ -17,7 +17,7 @@ export const DiscoveryLoader = () => (
     <StyledModal
         heading={<Translation id="TR_COIN_DISCOVERY_IN_PROGRESS" />}
         description={<Translation id="TR_TO_FIND_YOUR_ACCOUNTS_AND" />}
-        data-test="@discovery/loader"
+        data-test-id="@discovery/loader"
     >
         <Expand>
             <Spinner size={80} isGrey={false} />

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
@@ -170,7 +170,7 @@ export const ConfirmValueModal = ({
                             <StyledButton
                                 isDisabled={!addressConfirmed}
                                 onClick={copy}
-                                data-test={copyButtonDataTest}
+                                data-test-id={copyButtonDataTest}
                             >
                                 {copyButtonText}
                             </StyledButton>

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/NoBackupModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/NoBackupModal.tsx
@@ -34,7 +34,7 @@ export const NoBackupModal = () => {
                     <Button
                         variant="destructive"
                         onClick={confirm}
-                        data-test="@no-backup/take-risk-button"
+                        data-test-id="@no-backup/take-risk-button"
                     >
                         <Translation id="TR_CONTINUE_ANYWAY" />
                     </Button>

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmActionModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmActionModal.tsx
@@ -25,7 +25,7 @@ interface ConfirmActionProps extends DevicePromptModalProps {
 }
 
 export const ConfirmActionModal = ({ device, ...rest }: ConfirmActionProps) => (
-    <StyledDevicePromptModal data-test="@suite/modal/confirm-action-on-device" {...rest}>
+    <StyledDevicePromptModal data-test-id="@suite/modal/confirm-action-on-device" {...rest}>
         <StyledDeviceConfirmImage device={device} />
 
         <StyledH1>

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmFingerprintModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmFingerprintModal.tsx
@@ -22,7 +22,7 @@ export const ConfirmFingerprintModal = ({ device, ...rest }: ConfirmFingerprintP
             />
         }
         heading={<Translation id="TR_CHECK_FINGERPRINT" />}
-        data-test="@suite/modal/confirm-fingerprint-on-device"
+        data-test-id="@suite/modal/confirm-fingerprint-on-device"
         {...rest}
     >
         <Fingerprint device={device} />

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/DevicePromptModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/DevicePromptModal.tsx
@@ -38,7 +38,7 @@ export interface DevicePromptModalProps {
     onAbort?: () => void;
     className?: string;
     children?: ReactNode;
-    'data-test'?: string;
+    'data-test-id'?: string;
 }
 
 const DevicePromptModalRenderer = ({

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseOnDeviceModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseOnDeviceModal.tsx
@@ -41,7 +41,10 @@ export const PassphraseOnDeviceModal = ({ device }: PassphraseOnDeviceModalProps
         useSelector(selectIsDiscoveryAuthConfirmationRequired) || device.authConfirm;
 
     return (
-        <StyledDevicePromptModal isAbortable={false} data-test="@modal/enter-passphrase-on-device">
+        <StyledDevicePromptModal
+            isAbortable={false}
+            data-test-id="@modal/enter-passphrase-on-device"
+        >
             <StyledDeviceConfirmImage device={device} />
 
             <StyledH2>

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseSourceModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseSourceModal.tsx
@@ -33,7 +33,7 @@ export const PassphraseSourceModal = ({ device }: PassphraseSourceModalProps) =>
     return (
         <StyledDevicePromptModal
             isPillShown={!authConfirmation}
-            data-test={
+            data-test-id={
                 authConfirmation ? '@modal/confirm-empty-hidden-wallet' : '@modal/passphrase-source'
             }
         >

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PinModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PinModal.tsx
@@ -55,7 +55,7 @@ export const PinModal = ({ device, ...rest }: PinModalProps) => {
             }
             onCancel={onCancel}
             isCancelable
-            data-test="@modal/pin"
+            data-test-id="@modal/pin"
             $isExtended={isExtended}
             {...rest}
         >

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/WordModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/WordModal.tsx
@@ -13,7 +13,7 @@ export const WordModal = (props: ModalProps) => {
 
     return (
         <StyledModal
-            data-test="@recovery/word"
+            data-test-id="@recovery/word"
             heading={<Translation id="TR_FOLLOW_INSTRUCTIONS_ON_DEVICE" />}
             description={
                 <>

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
@@ -215,7 +215,7 @@ export const TransactionReviewOutputList = ({
                 <RightBottom>
                     {broadcastEnabled ? (
                         <StyledButton
-                            data-test="@modal/send"
+                            data-test-id="@modal/send"
                             isDisabled={!signedTx}
                             onClick={handleSend}
                         >
@@ -226,7 +226,7 @@ export const TransactionReviewOutputList = ({
                             <StyledButton
                                 isDisabled={!signedTx}
                                 onClick={handleCopy}
-                                data-test="@send/copy-raw-transaction"
+                                data-test-id="@send/copy-raw-transaction"
                             >
                                 <Translation id="COPY_TRANSACTION_TO_CLIPBOARD" />
                             </StyledButton>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeSelect.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeSelect.tsx
@@ -53,7 +53,7 @@ export const AccountTypeSelect = ({
     return (
         <>
             <Select
-                data-test="@add-account-type/select"
+                data-test-id="@add-account-type/select"
                 label={<Translation id="TR_ACCOUNT_TYPE" />}
                 isSearchable={false}
                 isClearable={false}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddButton.tsx
@@ -20,7 +20,7 @@ export const AddButton = ({
         isDisabled={!!disabledMessage}
         size="small"
         onClick={handleClick}
-        data-test="@add-account"
+        data-test-id="@add-account"
         {...buttonProps}
     >
         <Translation id="TR_ADD_NETWORK_ACCOUNT" values={{ network: networkName }} />

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -226,7 +226,7 @@ export const AddAccountModal = ({ device, onCancel, symbol, noRedirect }: AddAcc
                               <StyledCollapsibleBox
                                   variant="small"
                                   heading={<Translation id="TR_TESTNET_COINS" />}
-                                  data-test="@modal/account/activate_more_coins"
+                                  data-test-id="@modal/account/activate_more_coins"
                               >
                                   <CoinList
                                       onToggle={selectNetwork}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/BackendTypeSelect.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/BackendTypeSelect.tsx
@@ -35,7 +35,7 @@ const useBackendOptions = (network: Network) =>
                                 id="TR_BACKEND_CUSTOM_SERVERS"
                                 values={{
                                     type: (
-                                        <Capitalize data-test={`@settings/advance/${backend}`}>
+                                        <Capitalize data-test-id={`@settings/advance/${backend}`}>
                                             {backend}
                                         </Capitalize>
                                     ),
@@ -63,7 +63,7 @@ export const BackendTypeSelect = ({ network, value, onChange }: BackendTypeSelec
             value={backendOptions.find(option => option.value === value)}
             onChange={changeType}
             options={backendOptions}
-            data-test="@settings/advance/select-type"
+            data-test-id="@settings/advance/select-type"
         />
     ) : null;
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/CustomBackends.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/CustomBackends.tsx
@@ -150,7 +150,7 @@ export const CustomBackends = ({ network, onCancel }: CustomBackendsProps) => {
 
                 {editable && (
                     <Input
-                        data-test={`@settings/advance/${name}`}
+                        data-test-id={`@settings/advance/${name}`}
                         placeholder={placeholder}
                         inputState={error ? 'error' : undefined}
                         bottomText={error?.message || null}
@@ -163,7 +163,7 @@ export const CustomBackends = ({ network, onCancel }: CustomBackendsProps) => {
                     <AddUrlButton
                         variant="tertiary"
                         icon="PLUS"
-                        data-test="@settings/advance/button/add"
+                        data-test-id="@settings/advance/button/add"
                         onClick={() => {
                             addUrl(value);
                             reset();
@@ -185,7 +185,7 @@ export const CustomBackends = ({ network, onCancel }: CustomBackendsProps) => {
                     variant="primary"
                     onClick={onSaveClick}
                     isDisabled={!!error}
-                    data-test="@settings/advance/button/save"
+                    data-test-id="@settings/advance/button/save"
                 >
                     <Translation id="TR_CONFIRM" />
                 </SaveButton>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApplicationLogModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApplicationLogModal.tsx
@@ -75,14 +75,14 @@ export const ApplicationLogModal = ({ onCancel }: ApplicationLogModalProps) => {
             onCancel={onCancel}
             heading={<Translation id="TR_LOG" />}
             description={<Translation id="LOG_DESCRIPTION" />}
-            data-test="@modal/application-log"
+            data-test-id="@modal/application-log"
             bottomBarComponents={
-                <Button variant="secondary" onClick={download} data-test="@log/export-button">
+                <Button variant="secondary" onClick={download} data-test-id="@log/export-button">
                     <Translation id="TR_EXPORT_TO_FILE" />
                 </Button>
             }
         >
-            <LogWrapper ref={htmlElement} data-test="@log/content">
+            <LogWrapper ref={htmlElement} data-test-id="@log/content">
                 {log}
             </LogWrapper>
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CoinmarketTermsModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CoinmarketTermsModal.tsx
@@ -109,7 +109,7 @@ export const CoinmarketTermsModal = ({
             bottomBarComponents={
                 <FooterContent>
                     <Button
-                        data-test={`@coinmarket/${lowercaseType}/offers/buy-terms-confirm-button`}
+                        data-test-id={`@coinmarket/${lowercaseType}/offers/buy-terms-confirm-button`}
                         onClick={() => {
                             decision.resolve(true);
                             onCancel();

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DeviceAuthenticityOptOutModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DeviceAuthenticityOptOutModal.tsx
@@ -53,7 +53,7 @@ export const DeviceAuthenticityOptOutModal = ({ onCancel }: DeviceAuthenticityOp
                     variant="destructive"
                     onClick={handleDeviceAuthenticityOptOut}
                     isDisabled={!isConfirmed}
-                    data-test="@device-authenticity/opt-out/button"
+                    data-test-id="@device-authenticity/opt-out/button"
                 >
                     <Translation id="TR_DEVICE_AUTHENTICITY_OPT_OUT_MODAL_BUTTON" />
                 </Button>
@@ -76,7 +76,7 @@ export const DeviceAuthenticityOptOutModal = ({ onCancel }: DeviceAuthenticityOp
                     title={<Translation id="TR_DEVICE_AUTHENTICITY_OPT_OUT_MODAL_CHECKBOX_TITLE" />}
                     isChecked={isConfirmed}
                     onClick={() => setIsConfirmed(!isConfirmed)}
-                    data-test="@device-authenticity/checkbox"
+                    data-test-id="@device-authenticity/checkbox"
                 />
             </CheckboxWrapper>
         </StyledModal>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MetadataProviderModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MetadataProviderModal.tsx
@@ -86,7 +86,7 @@ export const MetadataProviderModal = ({ onCancel, decision }: MetadataProviderMo
             isCancelable
             onCancel={onModalCancel}
             heading={<Translation id="METADATA_MODAL_HEADING" />}
-            data-test="@modal/metadata-provider"
+            data-test-id="@modal/metadata-provider"
             bottomBarComponents={
                 <Wrapper>
                     <StyledButton
@@ -94,7 +94,7 @@ export const MetadataProviderModal = ({ onCancel, decision }: MetadataProviderMo
                         onClick={() => connect('dropbox')}
                         isLoading={isLoading === 'dropbox'}
                         isDisabled={!!isLoading}
-                        data-test="@modal/metadata-provider/dropbox-button"
+                        data-test-id="@modal/metadata-provider/dropbox-button"
                         icon="DROPBOX"
                     >
                         <Translation id="TR_DROPBOX" />
@@ -106,7 +106,7 @@ export const MetadataProviderModal = ({ onCancel, decision }: MetadataProviderMo
                             onClick={() => connect('google')}
                             isLoading={isLoading === 'google'}
                             isDisabled={!!isLoading}
-                            data-test="@modal/metadata-provider/google-button"
+                            data-test-id="@modal/metadata-provider/google-button"
                             icon="GOOGLE_DRIVE"
                         >
                             <Translation id="TR_GOOGLE_DRIVE" />
@@ -120,7 +120,7 @@ export const MetadataProviderModal = ({ onCancel, decision }: MetadataProviderMo
                             onClick={() => connect('fileSystem')}
                             isLoading={isLoading === 'fileSystem'}
                             isDisabled={!!isLoading}
-                            data-test="@modal/metadata-provider/file-system-button"
+                            data-test-id="@modal/metadata-provider/file-system-button"
                         >
                             <Translation id="TR_LOCAL_FILE_SYSTEM" />
                         </StyledButton>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PassphraseDuplicateModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PassphraseDuplicateModal.tsx
@@ -29,7 +29,7 @@ export const PassphraseDuplicateModal = ({ device, duplicate }: PassphraseDuplic
         <Modal
             heading={<Translation id="TR_WALLET_DUPLICATE_TITLE" />}
             description={<Translation id="TR_WALLET_DUPLICATE_DESC" />}
-            data-test="@passphrase-duplicate"
+            data-test-id="@passphrase-duplicate"
             bottomBarComponents={
                 <>
                     <Button

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PinMismatchModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PinMismatchModal.tsx
@@ -24,10 +24,10 @@ export const PinMismatchModal = (props: ModalProps) => {
             // need to pass props when cloning this inside nested modal
             {...props}
             heading={<Translation id="TR_PIN_MISMATCH_HEADING" />}
-            data-test="@pin-mismatch"
+            data-test-id="@pin-mismatch"
         >
             <StyledImage image="UNI_ERROR" />
-            <Button onClick={onTryAgain} data-test="@pin-mismatch/try-again-button">
+            <Button onClick={onTryAgain} data-test-id="@pin-mismatch/try-again-button">
                 <Translation id="TR_TRY_AGAIN" />
             </Button>
         </StyledModal>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/RequestEnableTorModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/RequestEnableTorModal.tsx
@@ -70,7 +70,7 @@ export const RequestEnableTorModal = ({ onCancel, decision }: RequestEnableTorMo
                         <Button
                             variant="tertiary"
                             onClick={onSkip}
-                            data-test="@request-enable-tor-modal/skip-button"
+                            data-test-id="@request-enable-tor-modal/skip-button"
                         >
                             <Translation id="TR_TOR_SKIP" />
                         </Button>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/SafetyChecksModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/SafetyChecksModal.tsx
@@ -51,7 +51,7 @@ export const SafetyChecksModal = ({ onCancel }: ModalProps) => {
                     onClick={confirm}
                     // Only allow confirming when the value will be changed.
                     isDisabled={isLocked() || level === device?.features?.safety_checks}
-                    data-test="@safety-checks-apply"
+                    data-test-id="@safety-checks-apply"
                 >
                     <Translation id="TR_CONFIRM" />
                 </StyledButton>
@@ -61,7 +61,7 @@ export const SafetyChecksModal = ({ onCancel }: ModalProps) => {
                 <Radio
                     isChecked={level === 'Strict'}
                     onClick={() => setLevel('Strict')}
-                    data-test="@radio-button-strict"
+                    data-test-id="@radio-button-strict"
                 >
                     <RadioInner>
                         <H3>
@@ -76,7 +76,7 @@ export const SafetyChecksModal = ({ onCancel }: ModalProps) => {
                     // For the purpose of this modal consider `PromptAlways` as identical to `PromptTemporarily`.
                     isChecked={level === 'PromptTemporarily' || level === 'PromptAlways'}
                     onClick={() => setLevel('PromptTemporarily')}
-                    data-test="@radio-button-prompt"
+                    data-test-id="@radio-button-prompt"
                 >
                     <RadioInner>
                         <H3>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/DecreasedOutputs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/DecreasedOutputs.tsx
@@ -115,7 +115,7 @@ export const DecreasedOutputs = () => {
         <AnimatePresence initial>
             <motion.div {...motionAnimation.expand}>
                 <GreyCard>
-                    <WarnHeader data-test="@send/decreased-outputs">
+                    <WarnHeader data-test-id="@send/decreased-outputs">
                         <Translation id={decreaseWarning} />
                     </WarnHeader>
                     <OutputsWrapper>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ReplaceTxButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ReplaceTxButton.tsx
@@ -26,7 +26,7 @@ export const ReplaceTxButton = ({ finalize }: { finalize: boolean }) => {
     return (
         <Wrapper>
             <StyledButton
-                data-test="@send/replace-tx-button"
+                data-test-id="@send/replace-tx-button"
                 isDisabled={isDisabled || isLoading}
                 onClick={signTransaction}
             >

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/IOAddress.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/IOAddress.tsx
@@ -97,7 +97,7 @@ export const IOAddress = ({
         <HiddenPlaceholder>
             <TextOverflowContainer
                 onMouseLeave={() => setIsClicked(false)}
-                data-test="@tx-detail/txid-value"
+                data-test-id="@tx-detail/txid-value"
                 id={txAddress}
                 shouldAllowCopy={shouldAllowCopy}
             >

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WipeDeviceModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WipeDeviceModal.tsx
@@ -61,7 +61,7 @@ export const WipeDeviceModal = ({ onCancel }: WipeDeviceModalProps) => {
                     variant="destructive"
                     onClick={handleWipeDevice}
                     isDisabled={isLocked() || !checkbox1 || !checkbox2}
-                    data-test="@wipe/wipe-button"
+                    data-test-id="@wipe/wipe-button"
                 >
                     <Translation id="TR_DEVICE_SETTINGS_BUTTON_WIPE_DEVICE" />
                 </Button>
@@ -76,14 +76,14 @@ export const WipeDeviceModal = ({ onCancel }: WipeDeviceModalProps) => {
                         description={<Translation id="TR_WIPE_DEVICE_CHECKBOX_1_DESCRIPTION" />}
                         isChecked={checkbox1}
                         onClick={() => setCheckbox1(!checkbox1)}
-                        data-test="@wipe/checkbox-1"
+                        data-test-id="@wipe/checkbox-1"
                     />
                     <CheckItem
                         title={<Translation id="TR_WIPE_DEVICE_CHECKBOX_2_TITLE" />}
                         description={<Translation id="TR_WIPE_DEVICE_CHECKBOX_2_DESCRIPTION" />}
                         isChecked={checkbox2}
                         onClick={() => setCheckbox2(!checkbox2)}
-                        data-test="@wipe/checkbox-2"
+                        data-test-id="@wipe/checkbox-2"
                     />
                 </Col>
             </CheckItems>

--- a/packages/suite/src/components/suite/notifications/ToastNotification.tsx
+++ b/packages/suite/src/components/suite/notifications/ToastNotification.tsx
@@ -97,7 +97,7 @@ const ToastNotification = ({
     );
 
     return (
-        <Wrapper data-test={dataTestBase} variant={variant} isTall={isTall} ref={wrapperRef}>
+        <Wrapper data-test-id={dataTestBase} variant={variant} isTall={isTall} ref={wrapperRef}>
             {defaultIcon && typeof defaultIcon === 'string' ? (
                 <Icon icon={defaultIcon} size={24} color={getVariantColor(variant)} />
             ) : (
@@ -119,7 +119,7 @@ const ToastNotification = ({
                     icon="CROSS"
                     hoverColor={theme.TYPE_LIGHTER_GREY}
                     onClick={handleCancelClick}
-                    data-test={`${dataTestBase}/close`}
+                    data-test-id={`${dataTestBase}/close`}
                 />
             )}
         </Wrapper>

--- a/packages/suite/src/components/suite/troubleshooting/TroubleshootingTips.tsx
+++ b/packages/suite/src/components/suite/troubleshooting/TroubleshootingTips.tsx
@@ -90,7 +90,7 @@ interface TroubleshootingTipsProps {
     items: Item[];
     offerWebUsb?: boolean;
     opened?: boolean;
-    'data-test'?: string;
+    'data-test-id'?: string;
 }
 
 export const TroubleshootingTips = ({
@@ -99,7 +99,7 @@ export const TroubleshootingTips = ({
     cta,
     offerWebUsb,
     opened,
-    'data-test': dataTest,
+    'data-test-id': dataTest,
 }: TroubleshootingTipsProps) => {
     const memoizedItems = useMemo(
         () =>
@@ -126,14 +126,14 @@ export const TroubleshootingTips = ({
             heading={cta}
             iconLabel={label}
             isOpen={opened}
-            data-test={dataTest || '@onboarding/expand-troubleshooting-tips'}
+            data-test-id={dataTest || '@onboarding/expand-troubleshooting-tips'}
         >
             {items.length > 0 && <Items>{memoizedItems}</Items>}
 
             {offerWebUsb && !isAndroid() && (
                 <StyledButton
                     variant="secondary"
-                    data-test="@onboarding/try-bridge-button"
+                    data-test-id="@onboarding/try-bridge-button"
                     onClick={() => TrezorConnect.disableWebUSB()}
                 >
                     <Translation id="TR_DISABLE_WEBUSB_TRY_BRIDGE" />

--- a/packages/suite/src/components/suite/troubleshooting/tips.tsx
+++ b/packages/suite/src/components/suite/troubleshooting/tips.tsx
@@ -29,7 +29,7 @@ const UdevDescription = () => {
                         <TrezorLink
                             variant="underline"
                             onClick={handleClick}
-                            data-test="@goto/udev"
+                            data-test-id="@goto/udev"
                         >
                             {chunks}
                         </TrezorLink>

--- a/packages/suite/src/components/wallet/DiscoveryProgress.tsx
+++ b/packages/suite/src/components/wallet/DiscoveryProgress.tsx
@@ -15,6 +15,9 @@ export const DiscoveryProgress = () => {
     if (!discovery || !isDiscoveryRunning) return null;
 
     return (
-        <StyledProgressBar value={calculateProgress()} data-test="@wallet/discovery-progress-bar" />
+        <StyledProgressBar
+            value={calculateProgress()}
+            data-test-id="@wallet/discovery-progress-bar"
+        />
     );
 };

--- a/packages/suite/src/components/wallet/Fees/CustomFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/CustomFee.tsx
@@ -171,7 +171,7 @@ export const CustomFee = <TFieldValues extends FormState>({
                         label={<Translation id="TR_GAS_LIMIT" />}
                         inputState={getInputState(feeLimitError)}
                         name={FEE_LIMIT}
-                        data-test={FEE_LIMIT}
+                        data-test-id={FEE_LIMIT}
                         onChange={changeFeeLimit}
                         rules={feeLimitRules}
                         bottomText={
@@ -192,7 +192,7 @@ export const CustomFee = <TFieldValues extends FormState>({
                     inputState={getInputState(feePerUnitError)}
                     innerAddon={<Units>{feeUnits}</Units>}
                     name={FEE_PER_UNIT}
-                    data-test={FEE_PER_UNIT}
+                    data-test-id={FEE_PER_UNIT}
                     rules={feeRules}
                     bottomText={feePerUnitError?.message || null}
                 />

--- a/packages/suite/src/components/wallet/Pagination.tsx
+++ b/packages/suite/src/components/wallet/Pagination.tsx
@@ -98,7 +98,7 @@ export const Pagination = ({
                 calculatedPages.map(i => (
                     <PageItem
                         key={i}
-                        data-test={`@wallet/accounts/pagination/${i}`}
+                        data-test-id={`@wallet/accounts/pagination/${i}`}
                         data-test-activated={i === currentPage ?? 'true'}
                         onClick={() => onPageSelected(i)}
                         isActive={i === currentPage}
@@ -114,7 +114,7 @@ export const Pagination = ({
                         // https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318
                         <PageItem
                             key={i}
-                            data-test={`@wallet/accounts/pagination/${i + 1}`}
+                            data-test-id={`@wallet/accounts/pagination/${i + 1}`}
                             onClick={() => onPageSelected(i + 1)}
                         >
                             {i + 1}

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionHeading.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionHeading.tsx
@@ -145,7 +145,7 @@ export const TransactionHeading = ({
                 onMouseLeave={() => setHeadingIsHovered(false)}
                 onClick={onClick}
             >
-                <HeadingWrapper data-test={`${dataTestBase}/heading`}>
+                <HeadingWrapper data-test-id={`${dataTestBase}/heading`}>
                     {isPhishingTransaction && (
                         <TooltipSymbol
                             content={

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/AuthConfirmFailed.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/AuthConfirmFailed.tsx
@@ -18,7 +18,7 @@ export const AuthConfirmFailed = () => {
                 onClick: handleClick,
                 isLoading: isLocked(),
                 icon: 'REFRESH',
-                'data-test': '@passphrase-mismatch/retry-button',
+                'data-test-id': '@passphrase-mismatch/retry-button',
                 children: <Translation id="TR_AUTH_CONFIRM_FAILED_RETRY" />,
             }}
         >

--- a/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountNavigation.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountNavigation.tsx
@@ -136,7 +136,7 @@ export const AccountNavigation = ({
     // collect all items suitable for current networkType
     const items = ITEMS.filter(item => !item.isHidden).map(item => ({
         ...item,
-        'data-test': `@wallet/menu/${item.id}${dataTestSuffix ? `-${dataTestSuffix}` : ''}`,
+        'data-test-id': `@wallet/menu/${item.id}${dataTestSuffix ? `-${dataTestSuffix}` : ''}`,
     }));
 
     return (

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountGroup.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountGroup.tsx
@@ -115,12 +115,12 @@ export const AccountGroup = forwardRef(
                         <Header
                             isOpen={isOpen}
                             onClick={!keepOpen ? onClick : undefined}
-                            data-test={`@account-menu/${type}`}
+                            data-test-id={`@account-menu/${type}`}
                         >
                             <ChevronContainer>
                                 {!keepOpen && (
                                     <ChevronIcon
-                                        data-test="@account-menu/arrow"
+                                        data-test-id="@account-menu/arrow"
                                         isActive={isOpen}
                                         size={18}
                                         color={theme.iconSubdued}

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem.tsx
@@ -142,7 +142,7 @@ export const AccountItem = forwardRef(
                 isSelected={isSelected}
                 ref={ref}
                 onClick={handleHeaderClick}
-                data-test={dataTestKey}
+                data-test-id={dataTestKey}
                 tabIndex={0}
             >
                 <Left>
@@ -151,7 +151,7 @@ export const AccountItem = forwardRef(
                 </Left>
                 <Right>
                     <Row>
-                        <AccountName isSelected={isSelected} data-test={`${dataTestKey}/label`}>
+                        <AccountName isSelected={isSelected} data-test-id={`${dataTestKey}/label`}>
                             <AccountLabelContainer>
                                 <AccountLabel
                                     accountLabel={accountLabel}

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemSkeleton.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemSkeleton.tsx
@@ -14,7 +14,7 @@ export const AccountItemSkeleton = () => {
     const { shouldAnimate } = useLoadingSkeleton();
 
     return (
-        <NavigationItemBase data-test="@account-menu/account-item-skeleton">
+        <NavigationItemBase data-test-id="@account-menu/account-item-skeleton">
             <Left>
                 <SkeletonCircle size="24px" />
             </Left>

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSearchBox.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSearchBox.tsx
@@ -51,7 +51,7 @@ export const AccountSearchBox = () => {
                 placeholder={translationString('TR_SEARCH')}
                 showClearButton="always"
                 onClear={onClear}
-                data-test="@account-menu/search-input"
+                data-test-id="@account-menu/search-input"
             />
         </InputWrapper>
     );

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenu.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenu.tsx
@@ -119,7 +119,7 @@ export const AccountsMenu = () => {
                     {!isEmpty && <AccountSearchBox />}
                     <AddAccountButton
                         isFullWidth={isEmpty}
-                        data-test="@account-menu/add-account"
+                        data-test-id="@account-menu/add-account"
                         device={device}
                     />
                 </Row>

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AnimationWrapper.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AnimationWrapper.tsx
@@ -38,7 +38,7 @@ export const AnimationWrapper = ({
                     onUpdate={onUpdate}
                     onAnimationComplete={onAnimationComplete}
                     transition={transition}
-                    data-test={dataTest}
+                    data-test-id={dataTest}
                 >
                     {children}
                 </motion.div>

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/CoinsFilter.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/CoinsFilter.tsx
@@ -89,7 +89,7 @@ export const CoinsFilter = () => {
                         >
                             <motion.div key={network} {...coinAnimcationConfig} layout>
                                 <StyledCoinLogo
-                                    data-test={`@account-menu/filter/${network}`}
+                                    data-test-id={`@account-menu/filter/${network}`}
                                     symbol={network}
                                     size={16}
                                     data-test-activated={coinFilter === network}

--- a/packages/suite/src/components/wallet/WalletLayout/WalletLayoutNavLink.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/WalletLayoutNavLink.tsx
@@ -58,14 +58,14 @@ export interface WalletLayoutNavLinkProps {
     values?: ExtendedMessageDescriptor['values'];
     badge?: ExtendedMessageDescriptor['id'];
     onClick: () => void;
-    'data-test'?: string;
+    'data-test-id'?: string;
 }
 
 export const WalletLayoutNavLink = (props: WalletLayoutNavLinkProps) => {
     const { active, title, onClick, values, badge } = props;
 
     return (
-        <NavLink active={active} onClick={onClick} data-test={props['data-test']}>
+        <NavLink active={active} onClick={onClick} data-test-id={props['data-test-id']}>
             <NavLinkText>
                 <Translation id={title} values={values} />
                 {badge && (

--- a/packages/suite/src/support/tests/hooksHelper.tsx
+++ b/packages/suite/src/support/tests/hooksHelper.tsx
@@ -40,14 +40,14 @@ export function findByTestId(id: RegExp): HTMLElement[];
 export function findByTestId(id: any) {
     if (typeof id === 'string') {
         return screen.getByText((_, element) => {
-            const attrValue = element?.getAttribute('data-test');
+            const attrValue = element?.getAttribute('data-test-id');
 
             return attrValue ? attrValue === id : false;
         });
     }
 
     return screen.getAllByText((_, element) => {
-        const attrValue = element?.getAttribute('data-test');
+        const attrValue = element?.getAttribute('data-test-id');
 
         return attrValue ? id.test(attrValue) : false;
     });

--- a/packages/suite/src/views/backup/index.tsx
+++ b/packages/suite/src/views/backup/index.tsx
@@ -49,7 +49,7 @@ type CloseButtonProps = {
 const CloseButton = ({ onClick, variant }: CloseButtonProps) => (
     <StyledButton
         onClick={onClick}
-        data-test="@backup/close-button"
+        data-test-id="@backup/close-button"
         variant="tertiary"
         icon="CROSS"
     >
@@ -98,7 +98,7 @@ export const Backup = ({ cancelable, onCancel }: ForegroundAppProps) => {
                 heading={<Translation id="TR_RECONNECT_HEADER" />}
                 isCancelable
                 onCancel={onCancel}
-                data-test="@backup/no-device"
+                data-test-id="@backup/no-device"
             >
                 <StyledImage image="CONNECT_DEVICE" width="360" />
             </Modal>
@@ -125,7 +125,7 @@ export const Backup = ({ cancelable, onCancel }: ForegroundAppProps) => {
                 {device.features.unfinished_backup ? (
                     <VerticalCenter>
                         <StyledImage image="UNI_ERROR" />
-                        <StyledP data-test="@backup/already-failed-message">
+                        <StyledP data-test-id="@backup/already-failed-message">
                             <Translation id="BACKUP_BACKUP_ALREADY_FAILED_DESCRIPTION" />
                             <TrezorLink icon="EXTERNAL_LINK" href={HELP_CENTER_FAILED_BACKUP_URL}>
                                 <Translation id="TR_LEARN_MORE" />
@@ -135,7 +135,7 @@ export const Backup = ({ cancelable, onCancel }: ForegroundAppProps) => {
                 ) : (
                     <VerticalCenter>
                         <StyledImage image="UNI_SUCCESS" />
-                        <StyledP data-test="@backup/already-finished-message">
+                        <StyledP data-test-id="@backup/already-finished-message">
                             <Translation id="BACKUP_BACKUP_ALREADY_FINISHED_DESCRIPTION" />
                         </StyledP>
                     </VerticalCenter>
@@ -148,7 +148,7 @@ export const Backup = ({ cancelable, onCancel }: ForegroundAppProps) => {
         <StyledModal
             isCancelable={cancelable}
             onCancel={onCancel}
-            data-test="@backup"
+            data-test-id="@backup"
             heading={getModalHeading(backup.status)}
             totalProgressBarSteps={nonErrorBackupStatuses.length}
             currentProgressBarStep={currentProgressBarStep}
@@ -157,7 +157,7 @@ export const Backup = ({ cancelable, onCancel }: ForegroundAppProps) => {
                     {backup.status === 'initial' && (
                         <>
                             <StyledButton
-                                data-test="@backup/start-button"
+                                data-test-id="@backup/start-button"
                                 onClick={() => dispatch(backupDevice())}
                                 isDisabled={!canStart(backup.userConfirmed, locks)}
                             >
@@ -180,7 +180,7 @@ export const Backup = ({ cancelable, onCancel }: ForegroundAppProps) => {
                                 <>
                                     <CloseButton onClick={onCancel} variant="TR_SKIP_PIN" />
                                     <StyledButton
-                                        data-test="@backup/continue-to-pin-button"
+                                        data-test-id="@backup/continue-to-pin-button"
                                         isDisabled={!canContinue(backup.userConfirmed)}
                                         onClick={() => {
                                             onCancel();
@@ -213,7 +213,7 @@ export const Backup = ({ cancelable, onCancel }: ForegroundAppProps) => {
 
             {backup.status === 'finished' && (
                 <>
-                    <StyledP type="hint" data-test="@backup/success-message">
+                    <StyledP type="hint" data-test-id="@backup/success-message">
                         <Translation id="TR_BACKUP_FINISHED_TEXT" />
                     </StyledP>
                     <AfterBackupCheckboxes />
@@ -223,7 +223,7 @@ export const Backup = ({ cancelable, onCancel }: ForegroundAppProps) => {
             {backup.status === 'error' && (
                 <VerticalCenter>
                     <StyledImage image="UNI_ERROR" />
-                    <StyledP data-test="@backup/error-message">{backup.error}</StyledP>
+                    <StyledP data-test-id="@backup/error-message">{backup.error}</StyledP>
                 </VerticalCenter>
             )}
         </StyledModal>

--- a/packages/suite/src/views/dashboard/components/AssetsView/components/AssetRow.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsView/components/AssetRow.tsx
@@ -172,7 +172,7 @@ export const AssetRow = memo(
                 {!failed ? (
                     <CryptoBalanceWrapper
                         isLastRow={isLastRow}
-                        data-test={`@asset-card/${symbol}/balance`}
+                        data-test-id={`@asset-card/${symbol}/balance`}
                     >
                         <FiatBalanceWrapper>
                             <FiatValue amount={cryptoValue} symbol={symbol} />

--- a/packages/suite/src/views/dashboard/components/AssetsView/index.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsView/index.tsx
@@ -164,7 +164,7 @@ export const AssetsView = () => {
                         )}
                         <Icon
                             icon="TABLE"
-                            data-test="@dashboard/assets/table-icon"
+                            data-test-id="@dashboard/assets/table-icon"
                             onClick={setTable}
                             color={
                                 !dashboardAssetsGridMode
@@ -174,7 +174,7 @@ export const AssetsView = () => {
                         />
                         <Icon
                             icon="GRID"
-                            data-test="@dashboard/assets/grid-icon"
+                            data-test-id="@dashboard/assets/grid-icon"
                             onClick={setGrid}
                             color={
                                 dashboardAssetsGridMode

--- a/packages/suite/src/views/dashboard/components/CoinmarketBuyButton.tsx
+++ b/packages/suite/src/views/dashboard/components/CoinmarketBuyButton.tsx
@@ -41,7 +41,7 @@ export const CoinmarketBuyButton = ({ symbol, dataTest }: BuyButtonProps) => {
     };
 
     return (
-        <Button onClick={onClick} variant="tertiary" data-test={dataTest} size="small">
+        <Button onClick={onClick} variant="tertiary" data-test-id={dataTest} size="small">
             <Translation id="TR_BUY_BUY" />
         </Button>
     );

--- a/packages/suite/src/views/dashboard/components/PortfolioCard/components/DashboardGraph.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/components/DashboardGraph.tsx
@@ -124,7 +124,7 @@ export const DashboardGraph = memo(({ accounts }: DashboardGraphProps) => {
     }, [dispatch, isLoading, selectedDeviceState, selectedRange]);
 
     return (
-        <Wrapper data-test="@dashboard/graph">
+        <Wrapper data-test-id="@dashboard/graph">
             <GraphWrapper>
                 {allFailed ? (
                     <ErrorMessage>

--- a/packages/suite/src/views/dashboard/components/PortfolioCard/components/EmptyWallet.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/components/EmptyWallet.tsx
@@ -47,7 +47,7 @@ const SecurityItem = styled.div`
 type EmptyWalletProps = HTMLAttributes<HTMLDivElement>;
 
 export const EmptyWallet = (props: EmptyWalletProps) => (
-    <Wrapper {...props} data-test="@dashboard/wallet-ready">
+    <Wrapper {...props} data-test-id="@dashboard/wallet-ready">
         <StyledImage image="UNI_SUCCESS" />
         <Content>
             <Title>

--- a/packages/suite/src/views/dashboard/components/PortfolioCard/components/Exception.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/components/Exception.tsx
@@ -68,7 +68,7 @@ const Container = ({ title, description, cta, dataTestBase }: ContainerProps) =>
     const actions = Array.isArray(cta) ? cta : [cta];
 
     return (
-        <Wrapper data-test={`@exception/${dataTestBase}`}>
+        <Wrapper data-test-id={`@exception/${dataTestBase}`}>
             <StyledImage image="UNI_ERROR" />
             <Title>
                 <Translation id={title} />
@@ -90,7 +90,7 @@ const Container = ({ title, description, cta, dataTestBase }: ContainerProps) =>
                         icon={a.icon || 'PLUS'}
                         isLoading={isLocked()}
                         onClick={a.action}
-                        data-test={`@exception/${dataTestBase}/${a.variant || 'primary'}-button`}
+                        data-test-id={`@exception/${dataTestBase}/${a.variant || 'primary'}-button`}
                     >
                         <Translation id={a.label || 'TR_RETRY'} />
                     </Button>

--- a/packages/suite/src/views/dashboard/components/PortfolioCard/components/Header.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/components/Header.tsx
@@ -84,12 +84,15 @@ export const Header = ({
             actions = (
                 <>
                     <Buttons>
-                        <Button onClick={receiveClickHandler} data-test="@dashboard/receive-button">
+                        <Button
+                            onClick={receiveClickHandler}
+                            data-test-id="@dashboard/receive-button"
+                        >
                             <Translation id="TR_RECEIVE" />
                         </Button>
                         <Button
                             onClick={buyClickHandler}
-                            data-test="@dashboard/buy-button"
+                            data-test-id="@dashboard/buy-button"
                             variant="tertiary"
                         >
                             <Translation id="TR_BUY" />

--- a/packages/suite/src/views/dashboard/components/PortfolioCard/index.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/index.tsx
@@ -67,7 +67,7 @@ const PortfolioCard = memo(() => {
         body = dashboardGraphHidden ? null : (
             <SkeletonTransactionsGraphWrapper>
                 <Wrapper>
-                    <GraphSkeleton data-test="@dashboard/loading" />
+                    <GraphSkeleton data-test-id="@dashboard/loading" />
                 </Wrapper>
             </SkeletonTransactionsGraphWrapper>
         );

--- a/packages/suite/src/views/dashboard/components/SecurityCard.tsx
+++ b/packages/suite/src/views/dashboard/components/SecurityCard.tsx
@@ -127,7 +127,7 @@ export const SecurityCard = ({
                                     size="small"
                                     {...(cta.dataTest
                                         ? {
-                                              'data-test': `@dashboard/security-card/${cta.dataTest}/button`,
+                                              'data-test-id': `@dashboard/security-card/${cta.dataTest}/button`,
                                           }
                                         : {})}
                                 >
@@ -150,7 +150,7 @@ export const SecurityCard = ({
                                     size="small"
                                     {...(cta.dataTest
                                         ? {
-                                              'data-test': `@dashboard/security-card/${cta.dataTest}/button`,
+                                              'data-test-id': `@dashboard/security-card/${cta.dataTest}/button`,
                                           }
                                         : {})}
                                 >

--- a/packages/suite/src/views/dashboard/index.tsx
+++ b/packages/suite/src/views/dashboard/index.tsx
@@ -26,7 +26,7 @@ export const Dashboard = () => {
     useLayout('Home', Nav);
 
     return (
-        <Wrapper data-test="@dashboard/index">
+        <Wrapper data-test-id="@dashboard/index">
             <PortfolioCard />
             <T2B1PromoBanner />
             <AssetsView />

--- a/packages/suite/src/views/firmware/FirmwareCustom.tsx
+++ b/packages/suite/src/views/firmware/FirmwareCustom.tsx
@@ -178,7 +178,7 @@ export const FirmwareCustom = () => {
                     />
                 )
             }
-            data-test="@firmware-custom"
+            data-test-id="@firmware-custom"
         >
             <ModalContent isNarrow={status === 'initial'}>
                 <Step />

--- a/packages/suite/src/views/firmware/index.tsx
+++ b/packages/suite/src/views/firmware/index.tsx
@@ -176,7 +176,7 @@ export const Firmware = ({ shouldSwitchFirmwareType }: FirmwareProps) => {
                 )
             }
             onCancel={onClose}
-            data-test="@firmware"
+            data-test-id="@firmware"
             heading={<Translation id={heading} />}
         >
             <Wrapper isWithTopPadding={!isCancelable}>{Component}</Wrapper>

--- a/packages/suite/src/views/onboarding/UnexpectedState/components/IsSameDevice.tsx
+++ b/packages/suite/src/views/onboarding/UnexpectedState/components/IsSameDevice.tsx
@@ -24,7 +24,7 @@ const IsSameDevice = () => {
                         enableOnboardingReducer(true);
                     }}
                     variant="secondary"
-                    data-test="@onboarding/unexpected-state/is-same/start-over-button"
+                    data-test-id="@onboarding/unexpected-state/is-same/start-over-button"
                 >
                     <Translation id="TR_START_AGAIN" />
                 </Button>

--- a/packages/suite/src/views/onboarding/steps/Backup.tsx
+++ b/packages/suite/src/views/onboarding/steps/Backup.tsx
@@ -48,7 +48,7 @@ export const BackupStep = () => {
                     description={<Translation id="TR_BACKUP_SUBHEADING_1" />}
                     innerActions={
                         <OnboardingButtonCta
-                            data-test="@backup/start-button"
+                            data-test-id="@backup/start-button"
                             onClick={() => {
                                 dispatch(updateAnalytics({ backup: 'create' }));
                                 dispatch(backupDevice({}, true));
@@ -60,7 +60,7 @@ export const BackupStep = () => {
                     }
                     outerActions={
                         <OnboardingButtonSkip
-                            data-test="@onboarding/exit-app-button"
+                            data-test-id="@onboarding/exit-app-button"
                             onClick={() => {
                                 dispatch(updateAnalytics({ backup: 'skip' }));
                                 setShowSkipConfirmation(true);
@@ -94,7 +94,7 @@ export const BackupStep = () => {
                     description={<Translation id="TR_BACKUP_FINISHED_TEXT" />}
                     innerActions={
                         <OnboardingButtonCta
-                            data-test="@backup/close-button"
+                            data-test-id="@backup/close-button"
                             onClick={() => dispatch(goToNextStep())}
                             isDisabled={!canContinue(backup.userConfirmed)}
                         >

--- a/packages/suite/src/views/onboarding/steps/BasicSettings/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/BasicSettings/index.tsx
@@ -33,7 +33,7 @@ const BasicSettings = () => {
             outerActions={
                 <AdvancedSetup>
                     <OnboardingButtonCta
-                        data-test="@onboarding/coins/continue-button"
+                        data-test-id="@onboarding/coins/continue-button"
                         onClick={() => {
                             goToNextStep();
                         }}

--- a/packages/suite/src/views/onboarding/steps/CreateOrRecover.tsx
+++ b/packages/suite/src/views/onboarding/steps/CreateOrRecover.tsx
@@ -19,7 +19,7 @@ const CreateOrRecoverStep = () => {
             <OptionsWrapper>
                 <OnboardingOption
                     icon="NEW"
-                    data-test="@onboarding/path-create-button"
+                    data-test-id="@onboarding/path-create-button"
                     onClick={() => {
                         addPath(STEP.PATH_CREATE);
                         goToNextStep();
@@ -30,7 +30,7 @@ const CreateOrRecoverStep = () => {
                 <OptionsDivider />
                 <OnboardingOption
                     icon="RECOVER"
-                    data-test="@onboarding/path-recovery-button"
+                    data-test-id="@onboarding/path-recovery-button"
                     onClick={() => {
                         addPath(STEP.PATH_RECOVERY);
                         goToNextStep();

--- a/packages/suite/src/views/onboarding/steps/Final.tsx
+++ b/packages/suite/src/views/onboarding/steps/Final.tsx
@@ -138,7 +138,7 @@ export const FinalStep = () => {
 
     return (
         <OnboardingStepBox
-            data-test="@onboarding/final"
+            data-test-id="@onboarding/final"
             device={isWaitingForConfirm ? device : undefined}
             isActionAbortable={isActionAbortable}
         >
@@ -213,7 +213,7 @@ export const FinalStep = () => {
 
                     <EnterSuiteButton
                         variant="secondary"
-                        data-test="@onboarding/exit-app-button"
+                        data-test-id="@onboarding/exit-app-button"
                         onClick={() => {
                             goToSuite(true);
 

--- a/packages/suite/src/views/onboarding/steps/Pin.tsx
+++ b/packages/suite/src/views/onboarding/steps/Pin.tsx
@@ -82,11 +82,11 @@ const SetPinStep = () => {
                 image="PIN"
                 key="pin-mismatch" // to properly rerender in translation mode
                 heading={<Translation id="TR_PIN_MISMATCH_HEADING" />}
-                data-test="@pin-mismatch"
+                data-test-id="@pin-mismatch"
                 innerActions={
                     <OnboardingButtonCta
                         onClick={onTryAgain}
-                        data-test="@pin-mismatch/try-again-button"
+                        data-test-id="@pin-mismatch/try-again-button"
                     >
                         <Translation id="TR_TRY_AGAIN" />
                     </OnboardingButtonCta>
@@ -105,7 +105,7 @@ const SetPinStep = () => {
                 description={<Translation id="TR_PIN_SET_SUCCESS" />}
                 outerActions={
                     <OnboardingButtonCta
-                        data-test="@onboarding/pin/continue-button"
+                        data-test-id="@onboarding/pin/continue-button"
                         onClick={() => goToNextStep()}
                     >
                         <Translation id="TR_CONTINUE" />
@@ -136,7 +136,7 @@ const SetPinStep = () => {
                     // "Create a pin" button to start the process, continue button after the pin is set (as outerAction), no primary CTA during the setup procedure on T2T1
                     !showConfirmationPrompt ? (
                         <OnboardingButtonCta
-                            data-test="@onboarding/set-pin-button"
+                            data-test-id="@onboarding/set-pin-button"
                             onClick={setPin}
                         >
                             <Translation id="TR_SET_PIN" />
@@ -147,7 +147,10 @@ const SetPinStep = () => {
                     // show skip button only if we are not done yet with setting up the pin (state is other than success state)
                     // and if confirmation prompt is not active (I guess there is no point showing back btn which can't be clicked because it is under the modal)
                     !showConfirmationPrompt ? (
-                        <OnboardingButtonSkip data-test="@onboarding/skip-button" onClick={skipPin}>
+                        <OnboardingButtonSkip
+                            data-test-id="@onboarding/skip-button"
+                            onClick={skipPin}
+                        >
                             <Translation id="TR_SKIP" />
                         </OnboardingButtonSkip>
                     ) : undefined

--- a/packages/suite/src/views/onboarding/steps/Recovery/RecoveryStepBox.tsx
+++ b/packages/suite/src/views/onboarding/steps/Recovery/RecoveryStepBox.tsx
@@ -54,7 +54,7 @@ const RecoveryStepBox = (props: OnboardingStepBoxProps) => {
                 isBackButtonVisible() ? (
                     <OnboardingButtonBack
                         onClick={() => handleBack()}
-                        data-test="@onboarding/recovery/back-button"
+                        data-test-id="@onboarding/recovery/back-button"
                     />
                 ) : undefined
             }

--- a/packages/suite/src/views/onboarding/steps/Recovery/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Recovery/index.tsx
@@ -79,7 +79,7 @@ export const RecoveryStep = () => {
                 }
                 innerActions={
                     <OnboardingButtonCta
-                        data-test="@onboarding/recovery/start-button"
+                        data-test-id="@onboarding/recovery/start-button"
                         onClick={recoverDevice}
                     >
                         <Translation id="TR_START_RECOVERY" />
@@ -170,7 +170,7 @@ export const RecoveryStep = () => {
                 heading={<Translation id="TR_WALLET_RECOVERED_FROM_SEED" />}
                 innerActions={
                     <OnboardingButtonCta
-                        data-test="@onboarding/recovery/continue-button"
+                        data-test-id="@onboarding/recovery/continue-button"
                         onClick={handleClick}
                     >
                         <Translation id="TR_CONTINUE" />
@@ -188,7 +188,7 @@ export const RecoveryStep = () => {
                 description={<Translation id="TR_RECOVERY_ERROR" values={{ error }} />}
                 innerActions={
                     <OnboardingButtonCta
-                        data-test="@onboarding/recovery/retry-button"
+                        data-test-id="@onboarding/recovery/retry-button"
                         onClick={
                             deviceModelInternal === DeviceModelInternal.T1B1
                                 ? resetReducer

--- a/packages/suite/src/views/onboarding/steps/ResetDevice.tsx
+++ b/packages/suite/src/views/onboarding/steps/ResetDevice.tsx
@@ -84,7 +84,7 @@ export const ResetDeviceStep = () => {
                 <OptionsWrapper fullWidth={false}>
                     <OnboardingOption
                         icon="SEED_SINGLE"
-                        data-test={
+                        data-test-id={
                             isShamirBackupAvailable
                                 ? '@onboarding/button-standard-backup'
                                 : '@onboarding/only-backup-option-button'
@@ -99,7 +99,7 @@ export const ResetDeviceStep = () => {
                             <OptionsDivider />
                             <OnboardingOption
                                 icon="SEED_SHAMIR"
-                                data-test="@onboarding/shamir-backup-option-button"
+                                data-test-id="@onboarding/shamir-backup-option-button"
                                 onClick={isDisabled ? undefined : handleShamirReset}
                                 heading={<Translation id="SHAMIR_SEED" />}
                                 description={<Translation id="SHAMIR_SEED_DESCRIPTION" />}

--- a/packages/suite/src/views/onboarding/steps/Security.tsx
+++ b/packages/suite/src/views/onboarding/steps/Security.tsx
@@ -23,7 +23,7 @@ const SecurityStep = () => {
                 description={<Translation id="TR_SECURITY_SUBHEADING" />}
                 innerActions={
                     <OnboardingButtonCta
-                        data-test="@onboarding/create-backup-button"
+                        data-test-id="@onboarding/create-backup-button"
                         onClick={() => {
                             goToNextStep();
                         }}
@@ -33,7 +33,7 @@ const SecurityStep = () => {
                 }
                 outerActions={
                     <OnboardingButtonSkip
-                        data-test="@onboarding/skip-backup"
+                        data-test-id="@onboarding/skip-backup"
                         onClick={() => {
                             setShowSkipConfirmation(true);
                             updateAnalytics({ backup: 'skip' });

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/DeviceAuthenticity.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/DeviceAuthenticity.tsx
@@ -85,7 +85,7 @@ export const DeviceAuthenticity = () => {
                 onClick={handleClick}
                 isDisabled={isLoading}
                 isLoading={isLoading}
-                data-test={
+                data-test-id={
                     isCheckSuccessful
                         ? '@authenticity-check/continue-button'
                         : `@authenticity-check/start-button`

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheck.tsx
@@ -242,7 +242,7 @@ export const SecurityCheck = () => {
                         </StyledSecurityCheckButton>
                         {initialized ? (
                             <StyledSecurityCheckButton
-                                data-test="@onboarding/exit-app-button"
+                                data-test-id="@onboarding/exit-app-button"
                                 onClick={handleContinueButtonClick}
                             >
                                 <Translation id="TR_YES_CONTINUE" />
@@ -250,7 +250,7 @@ export const SecurityCheck = () => {
                         ) : (
                             <SecurityCheckButtonWithSecondLine
                                 onClick={handleSetupButtonClick}
-                                data-test="@analytics/continue-button"
+                                data-test-id="@analytics/continue-button"
                             >
                                 <Translation id={primaryButtonTopText} />
                                 <TimeEstimateWrapper>

--- a/packages/suite/src/views/recovery/index.tsx
+++ b/packages/suite/src/views/recovery/index.tsx
@@ -104,7 +104,7 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
                 heading={<Translation id="TR_RECONNECT_HEADER" />}
                 isCancelable
                 onCancel={onCancel}
-                data-test="@recovery/no-device"
+                data-test-id="@recovery/no-device"
             >
                 <StyledImage image="CONNECT_DEVICE" width="360" />
             </Modal>
@@ -121,7 +121,7 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
                             : dispatch(checkSeed())
                     }
                     isDisabled={!understood || isLocked()}
-                    data-test="@recovery/start-button"
+                    data-test-id="@recovery/start-button"
                 >
                     <Translation id="TR_START" />
                 </StyledButton>
@@ -185,7 +185,7 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
                         </StepsContainer>
 
                         <CheckItem
-                            data-test="@recovery/user-understands-checkbox"
+                            data-test-id="@recovery/user-understands-checkbox"
                             title={<Translation id="TR_DRY_RUN_CHECK_ITEM_TITLE" />}
                             description={<Translation id="TR_DRY_RUN_CHECK_ITEM_DESCRIPTION" />}
                             isChecked={understood}
@@ -230,7 +230,7 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
                 return !recovery.error ? (
                     <VerticalCenter>
                         <StatusImage image="UNI_SUCCESS" />
-                        <H2 data-test="@recovery/success-title">
+                        <H2 data-test-id="@recovery/success-title">
                             <Translation id="TR_SEED_CHECK_SUCCESS_TITLE" />
                         </H2>
                         <StyledP type="hint">

--- a/packages/suite/src/views/settings/SettingsDebug/CheckFirmwareAuthenticity.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/CheckFirmwareAuthenticity.tsx
@@ -25,7 +25,7 @@ export const CheckFirmwareAuthenticity = () => {
 
     return (
         <>
-            <SectionItem data-test="@settings/debug/check-firmware-authenticity">
+            <SectionItem data-test-id="@settings/debug/check-firmware-authenticity">
                 <TextColumn
                     title="Check firmware authenticity"
                     description="Download firmware binary from data.trezor.io and compare its hash with firmware hash provided by Trezor device."
@@ -40,7 +40,7 @@ export const CheckFirmwareAuthenticity = () => {
                     </Button>
                 </ActionColumn>
             </SectionItem>
-            <SectionItem data-test="@settings/debug/check-firmware-authenticity-on-connect/switch">
+            <SectionItem data-test-id="@settings/debug/check-firmware-authenticity-on-connect/switch">
                 <TextColumn
                     title="Check firmware authenticity regularly"
                     description="Carry out firmware authenticity check every time you authorize Trezor device"

--- a/packages/suite/src/views/settings/SettingsDebug/CoinjoinApi.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/CoinjoinApi.tsx
@@ -63,7 +63,7 @@ const CoordinatorServer = ({
     const networkName = networks[symbol].name;
 
     return (
-        <SectionItem data-test={`@settings/debug/coinjoin/${symbol}`}>
+        <SectionItem data-test-id={`@settings/debug/coinjoin/${symbol}`}>
             <TextColumn
                 title={`${networkName}`}
                 description={
@@ -79,7 +79,7 @@ const CoordinatorServer = ({
                     onChange={({ value }) => onChange(symbol, value)}
                     value={selectedOption}
                     options={options}
-                    data-test={`@settings/debug/coinjoin/${symbol}/server-select`}
+                    data-test-id={`@settings/debug/coinjoin/${symbol}/server-select`}
                 />
             </ActionColumn>
         </SectionItem>
@@ -127,7 +127,7 @@ export const CoinjoinApi = () => {
                     />
                 );
             })}
-            <SectionItem data-test="@settings/debug/coinjoin-allow-no-tor">
+            <SectionItem data-test-id="@settings/debug/coinjoin-allow-no-tor">
                 <TextColumn
                     title="Allow no Tor"
                     description="Normally, coinjoin is allowed only when Tor is running. You may allow coinjoin without running Tor"
@@ -136,7 +136,7 @@ export const CoinjoinApi = () => {
                     <Switch
                         onChange={handleTorChange}
                         isChecked={debug?.coinjoinAllowNoTor ?? false}
-                        data-test="@settings/debug/coinjoin/allow-no-tor-checkbox"
+                        data-test-id="@settings/debug/coinjoin/allow-no-tor-checkbox"
                     />
                 </ActionColumn>
             </SectionItem>

--- a/packages/suite/src/views/settings/SettingsDebug/DeviceAuthenticity.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/DeviceAuthenticity.tsx
@@ -12,7 +12,7 @@ export const DeviceAuthenticity = () => {
         dispatch(setDebugMode({ isUnlockedBootloaderAllowed: state }));
 
     return (
-        <SectionItem data-test="@settings/debug/device-authenticity/switch">
+        <SectionItem data-test-id="@settings/debug/device-authenticity/switch">
             <TextColumn
                 title="Allow unlocked bootloader"
                 description="Skip device authenticity check when bootloader is unlocked."

--- a/packages/suite/src/views/settings/SettingsDebug/Devkit.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/Devkit.tsx
@@ -13,7 +13,7 @@ export const Devkit = () => {
     };
 
     return (
-        <SectionItem data-test="@settings/debug/firmware-devkit/switch">
+        <SectionItem data-test-id="@settings/debug/firmware-devkit/switch">
             <TextColumn
                 title="Devkit"
                 description="Offer devkit versions of firmware binaries. Never install regular firmware on devkit and vice versa! Use this only if you know what you are doing."

--- a/packages/suite/src/views/settings/SettingsDebug/GithubIssue.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/GithubIssue.tsx
@@ -11,7 +11,7 @@ export const GithubIssue = () => {
 
     return (
         <SectionItem
-            data-test="@settings/debug/github"
+            data-test-id="@settings/debug/github"
             ref={anchorRef}
             shouldHighlight={shouldHighlight}
         >

--- a/packages/suite/src/views/settings/SettingsDebug/InvityApi.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/InvityApi.tsx
@@ -37,7 +37,7 @@ export const InvityApi = () => {
 
     return (
         <SectionItem
-            data-test="@settings/debug/invity-api"
+            data-test-id="@settings/debug/invity-api"
             ref={anchorRef}
             shouldHighlight={shouldHighlight}
         >

--- a/packages/suite/src/views/settings/SettingsDebug/OAuthApi.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/OAuthApi.tsx
@@ -31,7 +31,7 @@ export const OAuthApi = () => {
 
     return (
         <SectionItem
-            data-test="@settings/debug/oauth-api"
+            data-test-id="@settings/debug/oauth-api"
             ref={anchorRef}
             shouldHighlight={shouldHighlight}
         >

--- a/packages/suite/src/views/settings/SettingsDebug/Processes.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/Processes.tsx
@@ -53,14 +53,17 @@ export const Processes = () => {
 
     return (
         <>
-            <SectionItem data-test="@settings/debug/processes">
+            <SectionItem data-test-id="@settings/debug/processes">
                 <TextColumn
                     title="Processes"
                     description="You may control subprocesses launched by Trezor Suite in this panel"
                 />
             </SectionItem>
             {items.map(item => (
-                <SectionItem data-test={`@settings/debug/processes/${item.name}`} key={item.name}>
+                <SectionItem
+                    data-test-id={`@settings/debug/processes/${item.name}`}
+                    key={item.name}
+                >
                     <TextColumn title={item.name} />
                     <ActionColumn>
                         <Checkbox

--- a/packages/suite/src/views/settings/SettingsDebug/ThrowTestingError.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/ThrowTestingError.tsx
@@ -3,7 +3,7 @@ import { ActionButton, ActionColumn, SectionItem, TextColumn } from 'src/compone
 // TODO add possibility to throw testing error from Electron main process
 
 export const ThrowTestingError = () => (
-    <SectionItem data-test="@settings/debug/throw-testing-error">
+    <SectionItem data-test-id="@settings/debug/throw-testing-error">
         <TextColumn
             title="Throw testing error"
             description="Throw testing error to debug issues reporting to Sentry"

--- a/packages/suite/src/views/settings/SettingsDebug/TranslationMode.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/TranslationMode.tsx
@@ -10,7 +10,7 @@ export const TranslationMode = () => {
 
     return (
         <SectionItem
-            data-test="@settings/debug/translation-mode"
+            data-test-id="@settings/debug/translation-mode"
             ref={anchorRef}
             shouldHighlight={shouldHighlight}
         >

--- a/packages/suite/src/views/settings/SettingsDebug/Transport.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/Transport.tsx
@@ -42,7 +42,7 @@ export const Transport = () => {
 
     return (
         <>
-            <SectionItem data-test="@settings/debug/transport">
+            <SectionItem data-test-id="@settings/debug/transport">
                 <TextColumn
                     title="Transports"
                     description="You may override TrezorConnect default settings here. Select preferred transports that are to be used. You will need to reload after changes"
@@ -51,7 +51,7 @@ export const Transport = () => {
             {/* todo: make it drag and drop sortable */}
             {transports.map(transport => (
                 <SectionItem
-                    data-test={`@settings/debug/transport/${transport.name}`}
+                    data-test-id={`@settings/debug/transport/${transport.name}`}
                     key={transport.name}
                 >
                     <TextColumn title={`${transport.name} ${transport.active ? '(Active)' : ''}`} />

--- a/packages/suite/src/views/settings/SettingsDebug/WipeData.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/WipeData.tsx
@@ -22,7 +22,7 @@ export const WipeData = () => {
 
     return (
         <SectionItem
-            data-test="@settings/debug/wipe-data"
+            data-test-id="@settings/debug/wipe-data"
             ref={anchorRef}
             shouldHighlight={shouldHighlight}
         >

--- a/packages/suite/src/views/settings/SettingsDevice/AutoLock.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/AutoLock.tsx
@@ -62,7 +62,7 @@ export const AutoLock = ({ isDeviceLocked }: AutoLockProps) => {
 
     return (
         <SectionItem
-            data-test="@settings/device/autolock"
+            data-test-id="@settings/device/autolock"
             ref={anchorRef}
             shouldHighlight={shouldHighlight}
         >
@@ -80,7 +80,7 @@ export const AutoLock = ({ isDeviceLocked }: AutoLockProps) => {
                         option => autoLockDelay && autoLockDelay / 1000 === option.value,
                     )}
                     isDisabled={isDeviceLocked}
-                    data-test="@settings/auto-lock-select"
+                    data-test-id="@settings/auto-lock-select"
                 />
             </ActionColumn>
         </SectionItem>

--- a/packages/suite/src/views/settings/SettingsDevice/BackupFailed.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/BackupFailed.tsx
@@ -15,7 +15,7 @@ export const BackupFailed = () => {
 
     return (
         <SectionItem
-            data-test="@settings/device/failed-backup-row"
+            data-test-id="@settings/device/failed-backup-row"
             ref={anchorRef}
             shouldHighlight={shouldHighlight}
         >

--- a/packages/suite/src/views/settings/SettingsDevice/BackupRecoverySeed.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/BackupRecoverySeed.tsx
@@ -27,7 +27,7 @@ export const BackupRecoverySeed = ({ isDeviceLocked }: BackupRecoverySeedProps) 
 
     return (
         <SectionItem
-            data-test="@settings/device/backup-recovery-seed"
+            data-test-id="@settings/device/backup-recovery-seed"
             ref={anchorRef}
             shouldHighlight={shouldHighlight}
         >
@@ -38,7 +38,7 @@ export const BackupRecoverySeed = ({ isDeviceLocked }: BackupRecoverySeedProps) 
             />
             <ActionColumn>
                 <ActionButton
-                    data-test="@settings/device/create-backup-button"
+                    data-test-id="@settings/device/create-backup-button"
                     onClick={handleClick}
                     isDisabled={isDeviceLocked || !needsBackup}
                 >

--- a/packages/suite/src/views/settings/SettingsDevice/ChangePin.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/ChangePin.tsx
@@ -29,7 +29,7 @@ export const ChangePin = ({ isDeviceLocked }: ChangePinProps) => {
 
     return (
         <SectionItem
-            data-test="@settings/device/change-pin"
+            data-test-id="@settings/device/change-pin"
             ref={anchorRef}
             shouldHighlight={shouldHighlight}
         >

--- a/packages/suite/src/views/settings/SettingsDevice/CheckRecoverySeed.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/CheckRecoverySeed.tsx
@@ -28,7 +28,7 @@ export const CheckRecoverySeed = ({ isDeviceLocked }: CheckRecoverySeedProps) =>
 
     return (
         <SectionItem
-            data-test="@settings/device/check-recovery-seed"
+            data-test-id="@settings/device/check-recovery-seed"
             ref={anchorRef}
             shouldHighlight={shouldHighlight}
         >
@@ -39,7 +39,7 @@ export const CheckRecoverySeed = ({ isDeviceLocked }: CheckRecoverySeedProps) =>
             />
             <ActionColumn>
                 <ActionButton
-                    data-test="@settings/device/check-seed-button"
+                    data-test-id="@settings/device/check-seed-button"
                     onClick={handleClick}
                     isDisabled={isDeviceLocked || needsBackup}
                     variant="secondary"

--- a/packages/suite/src/views/settings/SettingsDevice/CustomFirmware.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/CustomFirmware.tsx
@@ -24,7 +24,7 @@ export const CustomFirmware = () => {
 
     return (
         <SectionItem
-            data-test="@settings/device/custom-firmware"
+            data-test-id="@settings/device/custom-firmware"
             ref={anchorRef}
             shouldHighlight={shouldHighlight}
         >
@@ -38,7 +38,7 @@ export const CustomFirmware = () => {
                     onClick={openModal}
                     variant="destructive"
                     isDisabled={isDeviceLocked}
-                    data-test="@settings/device/custom-firmware-modal-button"
+                    data-test-id="@settings/device/custom-firmware-modal-button"
                 >
                     <Translation id="TR_DEVICE_SETTINGS_CUSTOM_FIRMWARE_BUTTON" />
                 </ActionButton>

--- a/packages/suite/src/views/settings/SettingsDevice/DeviceAuthenticityOptOut.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/DeviceAuthenticityOptOut.tsx
@@ -25,7 +25,7 @@ export const DeviceAuthenticityOptOut = () => {
         );
 
     return (
-        <SectionItem data-test="@settings/device/device-authenticity-opt-out">
+        <SectionItem data-test-id="@settings/device/device-authenticity-opt-out">
             <TextColumn
                 title={
                     <Translation
@@ -51,7 +51,7 @@ export const DeviceAuthenticityOptOut = () => {
                 <ActionButton
                     onClick={handleClick}
                     variant={isDeviceAuthenticityCheckDisabled ? 'primary' : 'destructive'}
-                    data-test="@settings/device/open-device-authenticity-opt-out-modal-button"
+                    data-test-id="@settings/device/open-device-authenticity-opt-out-modal-button"
                 >
                     <Translation
                         id={

--- a/packages/suite/src/views/settings/SettingsDevice/DeviceLabel.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/DeviceLabel.tsx
@@ -13,7 +13,7 @@ export const DeviceLabel = ({ isDeviceLocked }: DeviceLabelProps) => {
 
     return (
         <SectionItem
-            data-test="@settings/device/device-label"
+            data-test-id="@settings/device/device-label"
             ref={anchorRef}
             shouldHighlight={shouldHighlight}
         >

--- a/packages/suite/src/views/settings/SettingsDevice/DisplayRotation.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/DisplayRotation.tsx
@@ -26,7 +26,7 @@ export const DisplayRotation = ({ isDeviceLocked }: DisplayRotationProps) => {
 
     return (
         <SectionItem
-            data-test="@settings/device/display-rotation"
+            data-test-id="@settings/device/display-rotation"
             ref={anchorRef}
             shouldHighlight={shouldHighlight}
         >
@@ -46,7 +46,7 @@ export const DisplayRotation = ({ isDeviceLocked }: DisplayRotationProps) => {
                                     },
                                 });
                             }}
-                            data-test={`@settings/device/rotation-button/${variant.value}`}
+                            data-test-id={`@settings/device/rotation-button/${variant.value}`}
                         >
                             {variant.label}
                         </Button>

--- a/packages/suite/src/views/settings/SettingsDevice/FirmwareTypeChange.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/FirmwareTypeChange.tsx
@@ -56,7 +56,7 @@ export const FirmwareTypeChange = ({ isDeviceLocked }: FirmwareTypeProps) => {
 
     return (
         <SectionItem
-            data-test="@settings/device/firmware-type"
+            data-test-id="@settings/device/firmware-type"
             ref={anchorRef}
             shouldHighlight={shouldHighlight}
         >
@@ -93,7 +93,7 @@ export const FirmwareTypeChange = ({ isDeviceLocked }: FirmwareTypeProps) => {
                     <ActionButton
                         variant="secondary"
                         onClick={handleAction}
-                        data-test="@settings/device/switch-fw-type-button"
+                        data-test-id="@settings/device/switch-fw-type-button"
                         isDisabled={isDeviceLocked}
                     >
                         <Translation

--- a/packages/suite/src/views/settings/SettingsDevice/FirmwareVersion.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/FirmwareVersion.tsx
@@ -92,7 +92,7 @@ export const FirmwareVersion = ({ isDeviceLocked }: FirmwareVersionProps) => {
 
     return (
         <SectionItem
-            data-test="@settings/device/firmware-version"
+            data-test-id="@settings/device/firmware-version"
             ref={anchorRef}
             shouldHighlight={shouldHighlight}
         >
@@ -128,7 +128,7 @@ export const FirmwareVersion = ({ isDeviceLocked }: FirmwareVersionProps) => {
                 <ActionButton
                     variant="secondary"
                     onClick={handleUpdate}
-                    data-test="@settings/device/update-button"
+                    data-test-id="@settings/device/update-button"
                     isDisabled={isDeviceLocked}
                 >
                     <Translation

--- a/packages/suite/src/views/settings/SettingsDevice/Homescreen.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/Homescreen.tsx
@@ -95,7 +95,7 @@ export const Homescreen = ({ isDeviceLocked }: HomescreenProps) => {
     return (
         <>
             <SectionItem
-                data-test="@settings/device/homescreen"
+                data-test-id="@settings/device/homescreen"
                 ref={anchorRef}
                 shouldHighlight={shouldHighlight}
             >
@@ -142,7 +142,7 @@ export const Homescreen = ({ isDeviceLocked }: HomescreenProps) => {
                                 onClick={() => fileInputElement?.current?.click()}
                                 isDisabled={isDeviceLocked || !isSupportedHomescreen}
                                 variant="secondary"
-                                data-test="@settings/device/homescreen-upload"
+                                data-test-id="@settings/device/homescreen-upload"
                                 key="@settings/device/homescreen-upload"
                             >
                                 <Translation id="TR_DEVICE_SETTINGS_HOMESCREEN_UPLOAD_IMAGE" />
@@ -150,7 +150,7 @@ export const Homescreen = ({ isDeviceLocked }: HomescreenProps) => {
                             <Button
                                 onClick={openGallery}
                                 isDisabled={isDeviceLocked || !isSupportedHomescreen}
-                                data-test="@settings/device/homescreen-gallery"
+                                data-test-id="@settings/device/homescreen-gallery"
                                 key="@settings/device/homescreen-gallery"
                                 variant="secondary"
                             >

--- a/packages/suite/src/views/settings/SettingsDevice/Passphrase.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/Passphrase.tsx
@@ -31,7 +31,7 @@ export const Passphrase = ({ isDeviceLocked }: PassphraseProps) => {
 
     return (
         <SectionItem
-            data-test="@settings/device/passphrase"
+            data-test-id="@settings/device/passphrase"
             ref={anchorRef}
             shouldHighlight={shouldHighlight}
         >

--- a/packages/suite/src/views/settings/SettingsDevice/PinProtection.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/PinProtection.tsx
@@ -30,7 +30,7 @@ export const PinProtection = ({ isDeviceLocked }: PinProtectionProps) => {
 
     return (
         <SectionItem
-            data-test="@settings/device/pin-protection"
+            data-test-id="@settings/device/pin-protection"
             ref={anchorRef}
             shouldHighlight={shouldHighlight}
         >

--- a/packages/suite/src/views/settings/SettingsDevice/SafetyChecks.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/SafetyChecks.tsx
@@ -23,7 +23,7 @@ export const SafetyChecks = ({ isDeviceLocked }: SafetyChecksProps) => {
 
     return (
         <SectionItem
-            data-test="@settings/device/safety-checks"
+            data-test-id="@settings/device/safety-checks"
             ref={anchorRef}
             shouldHighlight={shouldHighlight}
         >
@@ -35,7 +35,7 @@ export const SafetyChecks = ({ isDeviceLocked }: SafetyChecksProps) => {
                 <ActionButton
                     variant="secondary"
                     onClick={handleClick}
-                    data-test="@settings/device/safety-checks-button"
+                    data-test-id="@settings/device/safety-checks-button"
                     isDisabled={isDeviceLocked}
                 >
                     <Translation id="TR_DEVICE_SETTINGS_SAFETY_CHECKS_BUTTON" />

--- a/packages/suite/src/views/settings/SettingsDevice/WipeCode.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/WipeCode.tsx
@@ -42,7 +42,7 @@ export const WipeCode = ({ isDeviceLocked }: Props) => {
 
     return (
         <SectionItem
-            data-test="@settings/device/change-wipe-code"
+            data-test-id="@settings/device/change-wipe-code"
             ref={anchorRef}
             shouldHighlight={shouldHighlight}
         >

--- a/packages/suite/src/views/settings/SettingsDevice/WipeDevice.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/WipeDevice.tsx
@@ -23,7 +23,7 @@ export const WipeDevice = ({ isDeviceLocked }: WipeDeviceProps) => {
 
     return (
         <SectionItem
-            data-test="@settings/device/wipe-device"
+            data-test-id="@settings/device/wipe-device"
             ref={anchorRef}
             shouldHighlight={shouldHighlight}
         >
@@ -36,7 +36,7 @@ export const WipeDevice = ({ isDeviceLocked }: WipeDeviceProps) => {
                     onClick={handleClick}
                     variant="destructive"
                     isDisabled={isDeviceLocked}
-                    data-test="@settings/device/open-wipe-modal-button"
+                    data-test-id="@settings/device/open-wipe-modal-button"
                 >
                     <Translation id="TR_DEVICE_SETTINGS_BUTTON_WIPE_DEVICE" />
                 </ActionButton>

--- a/packages/suite/src/views/settings/SettingsGeneral/AddressDisplay.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/AddressDisplay.tsx
@@ -37,7 +37,7 @@ export const AddressDisplay = () => {
 
     return (
         <SectionItem
-            data-test="@settings/address-display"
+            data-test-id="@settings/address-display"
             ref={anchorRef}
             shouldHighlight={shouldHighlight}
         >

--- a/packages/suite/src/views/settings/SettingsGeneral/Analytics.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Analytics.tsx
@@ -20,7 +20,7 @@ export const Analytics = () => {
 
     return (
         <SectionItem
-            data-test="@settings/analytics"
+            data-test-id="@settings/analytics"
             ref={anchorRef}
             shouldHighlight={shouldHighlight}
         >

--- a/packages/suite/src/views/settings/SettingsGeneral/BitcoinAmountUnit.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/BitcoinAmountUnit.tsx
@@ -21,7 +21,7 @@ export const BitcoinAmountUnit = () => {
 
     return (
         <SectionItem
-            data-test="@settings/btc-units"
+            data-test-id="@settings/btc-units"
             ref={anchorRef}
             shouldHighlight={shouldHighlight}
         >
@@ -37,7 +37,7 @@ export const BitcoinAmountUnit = () => {
                     }}
                     options={UNIT_OPTIONS}
                     onChange={handleUnitsChange}
-                    data-test="@settings/btc-units-select"
+                    data-test-id="@settings/btc-units-select"
                 />
             </ActionColumn>
         </SectionItem>

--- a/packages/suite/src/views/settings/SettingsGeneral/ClearStorage.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/ClearStorage.tsx
@@ -33,7 +33,7 @@ export const ClearStorage = () => {
 
     return (
         <SectionItem
-            data-test="@settings/storage"
+            data-test-id="@settings/storage"
             ref={anchorRef}
             shouldHighlight={shouldHighlight}
         >
@@ -45,7 +45,7 @@ export const ClearStorage = () => {
                 <ActionButton
                     onClick={hanldeClick}
                     variant="secondary"
-                    data-test="@settings/reset-app-button"
+                    data-test-id="@settings/reset-app-button"
                 >
                     <Translation id="TR_CLEAR_STORAGE" />
                 </ActionButton>

--- a/packages/suite/src/views/settings/SettingsGeneral/ConnectLabelingProvider.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/ConnectLabelingProvider.tsx
@@ -16,7 +16,7 @@ export const ConnectLabelingProvider = () => {
 
     return (
         <SectionItem
-            data-test="@settings/labeling-connect"
+            data-test-id="@settings/labeling-connect"
             ref={anchorRef}
             shouldHighlight={shouldHighlight}
         >
@@ -28,7 +28,7 @@ export const ConnectLabelingProvider = () => {
                 <ActionButton
                     variant="secondary"
                     onClick={() => dispatch(metadataLabelingActions.init(true))}
-                    data-test="@settings/metadata/connect-provider-button"
+                    data-test-id="@settings/metadata/connect-provider-button"
                 >
                     <Translation id="TR_CONNECT" />
                 </ActionButton>

--- a/packages/suite/src/views/settings/SettingsGeneral/DesktopSuiteBanner.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/DesktopSuiteBanner.tsx
@@ -135,7 +135,7 @@ export const DesktopSuiteBanner = () => {
                         size={18}
                         icon="CROSS"
                         onClick={handleClose}
-                        data-test="@banner/install-desktop-suite/close-button"
+                        data-test-id="@banner/install-desktop-suite/close-button"
                     />
 
                     <StyledImage image="TREZOR_PATTERN" width={140} />

--- a/packages/suite/src/views/settings/SettingsGeneral/DisconnectLabelingProvider.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/DisconnectLabelingProvider.tsx
@@ -25,7 +25,7 @@ export const DisconnectLabelingProvider = () => {
 
     return (
         <SectionItem
-            data-test="@settings/metadata-provider"
+            data-test-id="@settings/metadata-provider"
             ref={anchorRef}
             shouldHighlight={shouldHighlight}
         >
@@ -62,7 +62,7 @@ export const DisconnectLabelingProvider = () => {
                             }),
                         )
                     }
-                    data-test="@settings/metadata/disconnect-provider-button"
+                    data-test-id="@settings/metadata/disconnect-provider-button"
                 >
                     <Translation id="TR_DISCONNECT" />
                 </ActionButton>

--- a/packages/suite/src/views/settings/SettingsGeneral/EarlyAccess.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/EarlyAccess.tsx
@@ -32,7 +32,7 @@ export const EarlyAccess = () => {
 
     return (
         <SectionItem
-            data-test="@settings/early-access"
+            data-test-id="@settings/early-access"
             ref={anchorRef}
             shouldHighlight={shouldHighlight}
         >

--- a/packages/suite/src/views/settings/SettingsGeneral/Fiat.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Fiat.tsx
@@ -37,7 +37,11 @@ export const Fiat = () => {
     };
 
     return (
-        <SectionItem data-test="@settings/fiat" ref={anchorRef} shouldHighlight={shouldHighlight}>
+        <SectionItem
+            data-test-id="@settings/fiat"
+            ref={anchorRef}
+            shouldHighlight={shouldHighlight}
+        >
             <TextColumn title={<Translation id="TR_PRIMARY_FIAT" />} />
             <ActionColumn>
                 <ActionSelect
@@ -45,7 +49,7 @@ export const Fiat = () => {
                     onChange={handleChange}
                     value={value}
                     options={options}
-                    data-test="@settings/fiat-select"
+                    data-test-id="@settings/fiat-select"
                 />
             </ActionColumn>
         </SectionItem>

--- a/packages/suite/src/views/settings/SettingsGeneral/Labeling.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Labeling.tsx
@@ -45,7 +45,7 @@ export const Labeling = () => {
 
     return (
         <SectionItem
-            data-test="@settings/metadata"
+            data-test-id="@settings/metadata"
             ref={anchorRef}
             shouldHighlight={shouldHighlight}
         >

--- a/packages/suite/src/views/settings/SettingsGeneral/Language.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Language.tsx
@@ -99,7 +99,7 @@ export const Language = () => {
 
     return (
         <SectionItem
-            data-test="@settings/language"
+            data-test-id="@settings/language"
             ref={anchorRef}
             shouldHighlight={shouldHighlight}
         >
@@ -116,7 +116,7 @@ export const Language = () => {
                     options={options}
                     onChange={onChange}
                     isDisabled={isTranslationMode()}
-                    data-test="@settings/language-select"
+                    data-test-id="@settings/language-select"
                 />
             </ActionColumn>
         </SectionItem>

--- a/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
@@ -48,7 +48,7 @@ export const SettingsGeneral = () => {
     const isProviderConnected = useSelector(selectSelectedProviderForLabels);
 
     return (
-        <SettingsLayout data-test="@settings/index">
+        <SettingsLayout data-test-id="@settings/index">
             {isWeb() && !isMobileLayout && shouldShowSettingsDesktopAppPromoBanner && (
                 <DesktopSuiteBanner />
             )}

--- a/packages/suite/src/views/settings/SettingsGeneral/ShowApplicationLog.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/ShowApplicationLog.tsx
@@ -18,7 +18,7 @@ export const ShowApplicationLog = () => {
 
     return (
         <SectionItem
-            data-test="@settings/application-log"
+            data-test-id="@settings/application-log"
             ref={anchorRef}
             shouldHighlight={shouldHighlight}
         >
@@ -30,7 +30,7 @@ export const ShowApplicationLog = () => {
                 <ActionButton
                     onClick={handleClick}
                     variant="secondary"
-                    data-test="@settings/show-log-button"
+                    data-test-id="@settings/show-log-button"
                 >
                     <Translation id="TR_SHOW_LOG" />
                 </ActionButton>

--- a/packages/suite/src/views/settings/SettingsGeneral/Theme.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Theme.tsx
@@ -84,7 +84,11 @@ export const Theme = () => {
     };
 
     return (
-        <SectionItem data-test="@settings/theme" ref={anchorRef} shouldHighlight={shouldHighlight}>
+        <SectionItem
+            data-test-id="@settings/theme"
+            ref={anchorRef}
+            shouldHighlight={shouldHighlight}
+        >
             <TextColumn
                 title={<Translation id="TR_COLOR_SCHEME" />}
                 description={<Translation id="TR_COLOR_SCHEME_DESCRIPTION" />}
@@ -95,7 +99,7 @@ export const Theme = () => {
                     value={selectedValue}
                     options={options}
                     onChange={onChange}
-                    data-test="@theme/color-scheme-select"
+                    data-test-id="@theme/color-scheme-select"
                 />
             </ActionColumn>
         </SectionItem>

--- a/packages/suite/src/views/settings/SettingsGeneral/Tor.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Tor.tsx
@@ -52,7 +52,7 @@ export const Tor = () => {
     };
 
     return (
-        <SectionItem data-test="@settings/tor" ref={anchorRef} shouldHighlight={shouldHighlight}>
+        <SectionItem data-test-id="@settings/tor" ref={anchorRef} shouldHighlight={shouldHighlight}>
             <TextColumn
                 title={
                     <LoadingContent isLoading={isTorLoading} isSuccessful={!hasTorError}>

--- a/packages/suite/src/views/settings/SettingsGeneral/TorOnionLinks.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/TorOnionLinks.tsx
@@ -26,7 +26,7 @@ export const TorOnionLinks = () => {
 
     return (
         <SectionItem
-            data-test="@settings/tor-onion-links"
+            data-test-id="@settings/tor-onion-links"
             ref={anchorRef}
             shouldHighlight={shouldHighlight}
         >

--- a/packages/suite/src/views/settings/SettingsGeneral/VersionWithUpdate.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/VersionWithUpdate.tsx
@@ -43,7 +43,7 @@ export const VersionWithUpdate = () => {
 
     return (
         <SectionItem
-            data-test="@settings/version"
+            data-test-id="@settings/version"
             ref={anchorRef}
             shouldHighlight={shouldHighlight}
         >

--- a/packages/suite/src/views/start/SuiteStart.tsx
+++ b/packages/suite/src/views/start/SuiteStart.tsx
@@ -11,7 +11,7 @@ const Content = styled.div`
 
 export const SuiteStart = () => (
     <WelcomeLayout>
-        <Content data-test="@onboarding/welcome">
+        <Content data-test-id="@onboarding/welcome">
             <StartContent />
         </Content>
     </WelcomeLayout>

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/AddWalletButton.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/AddWalletButton.tsx
@@ -74,7 +74,7 @@ export const AddWalletButton = ({
                 cursor="pointer"
             >
                 <StyledButton
-                    data-test={
+                    data-test-id={
                         emptyPassphraseWalletExists
                             ? '@switch-device/add-hidden-wallet-button'
                             : '@switch-device/add-wallet-button'

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceHeaderButton.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceHeaderButton.tsx
@@ -35,7 +35,7 @@ export const DeviceHeaderButton = ({
                     button={{
                         children: <Translation id="TR_SOLVE_ISSUE" />,
                         onClick: onSolveIssueClick,
-                        'data-test': `@switch-device/${device.path}/solve-issue-button`,
+                        'data-test-id': `@switch-device/${device.path}/solve-issue-button`,
                     }}
                 >
                     {deviceStatusMessage && <Translation id={deviceStatusMessage} />}

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceStatusText.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceStatusText.tsx
@@ -54,7 +54,7 @@ export const DeviceStatusText = ({
     return (
         <Container
             color={connected ? theme.textPrimaryDefault : theme.textSubdued}
-            data-test={connected ? '@deviceStatus-connected' : '@deviceStatus-disconnected'}
+            data-test-id={connected ? '@deviceStatus-connected' : '@deviceStatus-disconnected'}
         >
             <TextRow>
                 <Icon

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
@@ -144,7 +144,7 @@ export const WalletInstance = ({
 
     return (
         <Wrapper
-            data-test={dataTestBase}
+            data-test-id={dataTestBase}
             key={`${instance.label}${instance.instance}${instance.state}`}
             state={isSelected ? 'success' : undefined}
             {...rest}
@@ -214,7 +214,7 @@ export const WalletInstance = ({
 
                     <ColEject centerItems>
                         <Icon
-                            data-test={`${dataTestBase}/eject-button`}
+                            data-test-id={`${dataTestBase}/eject-button`}
                             icon="EJECT"
                             size={22}
                             color={theme.TYPE_LIGHT_GREY}

--- a/packages/suite/src/views/suite/bridge/index.tsx
+++ b/packages/suite/src/views/suite/bridge/index.tsx
@@ -137,7 +137,7 @@ export const InstallBridge = () => {
         <Modal
             heading={<Translation id="TR_TREZOR_BRIDGE_DOWNLOAD" />}
             description={<Translation id="TR_NEW_COMMUNICATION_TOOL" />}
-            data-test="@modal/bridge"
+            data-test-id="@modal/bridge"
         >
             <Metadata title="Download Bridge | Trezor Suite" />
             <Content>
@@ -154,7 +154,7 @@ export const InstallBridge = () => {
                 </Version>
                 <StyledImage image={`BRIDGE_CHECK_TREZOR_${DeviceModelInternal.T2T1}`} />
                 {isLoading ? (
-                    <LoaderWrapper data-test="@bridge/loading">
+                    <LoaderWrapper data-test-id="@bridge/loading">
                         <CenteredLoader size={50} />
                         <Paragraph>
                             <Translation id="TR_GATHERING_INFO" />
@@ -169,11 +169,11 @@ export const InstallBridge = () => {
                             onChange={setSelectedTarget}
                             options={installers}
                             maxMenuHeight={160}
-                            data-test="@bridge/installers"
+                            data-test-id="@bridge/installers"
                         />
 
                         <TrezorLink variant="nostyle" href={`${data.uri}${target.value}`}>
-                            <DownloadBridgeButton data-test="@bridge/download-button">
+                            <DownloadBridgeButton data-test-id="@bridge/download-button">
                                 <Translation
                                     id="TR_DOWNLOAD_LATEST_BRIDGE"
                                     values={{ version: data.latestVersion }}
@@ -198,7 +198,7 @@ export const InstallBridge = () => {
                             icon="ARROW_LEFT"
                             variant="tertiary"
                             onClick={goToWallet}
-                            data-test="@bridge/goto/wallet-index"
+                            data-test-id="@bridge/goto/wallet-index"
                         >
                             <Translation id="TR_TAKE_ME_BACK_TO_WALLET" />
                         </StyledButton>

--- a/packages/suite/src/views/suite/device-unreadable/index.tsx
+++ b/packages/suite/src/views/suite/device-unreadable/index.tsx
@@ -12,7 +12,7 @@ export const DeviceUnreadable = () => {
 
     return (
         <DeviceInvalidModeLayout
-            data-test="@device-invalid-mode/unreadable"
+            data-test-id="@device-invalid-mode/unreadable"
             title={<Translation id="TR_UNREADABLE" />}
             text={<Translation id="TR_UNREADABLE_EXPLAINED" />}
             resolveButton={

--- a/packages/suite/src/views/suite/udev/index.tsx
+++ b/packages/suite/src/views/suite/udev/index.tsx
@@ -12,7 +12,7 @@ const Wrapper = styled.div`
 
 export const UdevRules = ({ onCancel }: ForegroundAppProps) => (
     <Modal
-        data-test="@modal/udev"
+        data-test-id="@modal/udev"
         isCancelable
         onCancel={onCancel}
         heading={<Translation id="TR_UDEV_DOWNLOAD_TITLE" />}

--- a/packages/suite/src/views/suite/version/index.tsx
+++ b/packages/suite/src/views/suite/version/index.tsx
@@ -14,15 +14,15 @@ const Line = styled.div`
 `;
 
 export const Version = () => (
-    <Modal data-test="@modal/version">
+    <Modal data-test-id="@modal/version">
         <Wrapper>
             <Paragraph type="callout">APPLICATION VERSION</Paragraph>
-            <H2 data-test="@version/number">{getSuiteVersion()}</H2>
+            <H2 data-test-id="@version/number">{getSuiteVersion()}</H2>
             <Line />
             <Paragraph type="callout">LAST COMMIT HASH</Paragraph>
             <Link
                 href={`https://github.com/trezor/trezor-suite/commits/${getCommitHash()}`}
-                data-test="@version/commit-hash-link"
+                data-test-id="@version/commit-hash-link"
             >
                 <H2>{getCommitHash()}</H2>
             </Link>

--- a/packages/suite/src/views/wallet/anonymize/components/CoinjoinConfirmation.tsx
+++ b/packages/suite/src/views/wallet/anonymize/components/CoinjoinConfirmation.tsx
@@ -173,7 +173,7 @@ export const CoinjoinConfirmation = ({ account }: CoinjoinConfirmationProps) => 
                 <StyledCheckbox
                     isChecked={termsConfirmed}
                     onClick={toggleTermsConfirmation}
-                    data-test="@coinjoin/checkbox"
+                    data-test-id="@coinjoin/checkbox"
                 >
                     <Translation
                         id="TR_TERMS_AND_PRIVACY_CONFIRMATION"

--- a/packages/suite/src/views/wallet/coinmarket/buy/components/BuyForm/Footer/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/components/BuyForm/Footer/index.tsx
@@ -74,7 +74,7 @@ const Footer = () => {
                     name={countrySelect}
                     render={({ field: { onChange, value } }) => (
                         <StyledSelect
-                            data-test="@coinmarket/buy/country-select"
+                            data-test-id="@coinmarket/buy/country-select"
                             options={regional.countriesOptions}
                             isSearchable
                             value={value}
@@ -107,7 +107,7 @@ const Footer = () => {
                     isDisabled={!(formIsValid && hasValues) || formState.isSubmitting}
                     isLoading={formState.isSubmitting}
                     type="submit"
-                    data-test="@coinmarket/buy/compare-button"
+                    data-test-id="@coinmarket/buy/compare-button"
                 >
                     <Translation id="TR_BUY_SHOW_OFFERS" />
                 </StyledButton>

--- a/packages/suite/src/views/wallet/coinmarket/buy/components/BuyForm/Inputs/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/components/BuyForm/Inputs/index.tsx
@@ -128,7 +128,7 @@ const Inputs = () => {
                                         .filter(c => buyInfo?.supportedFiatCurrencies.has(c))
                                         .map((currency: string) => buildFiatOption(currency))}
                                     isSearchable
-                                    data-test="@coinmarket/buy/fiat-currency-select"
+                                    data-test-id="@coinmarket/buy/fiat-currency-select"
                                     value={value}
                                     isClearable={false}
                                     minValueWidth="58px"
@@ -141,7 +141,7 @@ const Inputs = () => {
                             )}
                         />
                     }
-                    data-test="@coinmarket/buy/fiat-input"
+                    data-test-id="@coinmarket/buy/fiat-input"
                 />
             </Left>
             <Middle responsiveSize="LG">
@@ -176,7 +176,7 @@ const Inputs = () => {
                                     value={value}
                                     isSearchable
                                     isClearable={false}
-                                    data-test="@coinmarket/buy/crypto-currency-select"
+                                    data-test-id="@coinmarket/buy/crypto-currency-select"
                                     options={getCryptoOptions(
                                         account.symbol,
                                         buyInfo?.supportedCryptoCurrencies || new Set(),
@@ -202,7 +202,7 @@ const Inputs = () => {
                             )}
                         />
                     }
-                    data-test="@coinmarket/buy/crypto-input"
+                    data-test-id="@coinmarket/buy/crypto-input"
                 />
             </Right>
         </Wrapper>

--- a/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/List/BuyQuote.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/List/BuyQuote.tsx
@@ -271,7 +271,7 @@ export const BuyQuote = ({ className, quote, wantCrypto }: QuoteProps) => {
                             <StyledButton
                                 isDisabled={!!quote.error}
                                 onClick={() => selectQuote(quote)}
-                                data-test="@coinmarket/buy/offers/get-this-deal-button"
+                                data-test-id="@coinmarket/buy/offers/get-this-deal-button"
                             >
                                 <Translation id="TR_BUY_GET_THIS_OFFER" />
                             </StyledButton>

--- a/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/List/BuyQuoteList.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/List/BuyQuoteList.tsx
@@ -95,7 +95,7 @@ export const BuyQuoteList = ({ isAlternative, quotes }: ListProps) => {
     const { fiatStringAmount, fiatCurrency, wantCrypto } = quotesRequest;
 
     return (
-        <Wrapper data-test="@coinmarket/buy/offers-list">
+        <Wrapper data-test-id="@coinmarket/buy/offers-list">
             <Header>
                 <Left>
                     <SummaryRow>

--- a/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/SelectedOffer/components/VerifyAddress/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/SelectedOffer/components/VerifyAddress/index.tsx
@@ -197,7 +197,7 @@ const VerifyAddressComponent = () => {
                     <Button
                         isLoading={callInProgress}
                         isDisabled={callInProgress}
-                        data-test="@coinmarket/buy/offers/confirm-on-trezor-button"
+                        data-test-id="@coinmarket/buy/offers/confirm-on-trezor-button"
                         onClick={() => {
                             if (accountAddress && address) {
                                 verifyAddress(account, address, accountAddress.path);
@@ -211,7 +211,7 @@ const VerifyAddressComponent = () => {
                     <Button
                         isLoading={callInProgress}
                         isDisabled={callInProgress}
-                        data-test="@coinmarket/buy/offers/finish-transaction-button"
+                        data-test-id="@coinmarket/buy/offers/finish-transaction-button"
                         onClick={() => goToPayment(address)}
                     >
                         <Translation id="TR_BUY_GO_TO_PAYMENT" />

--- a/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/SelectedOffer/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/SelectedOffer/index.tsx
@@ -32,7 +32,7 @@ const SelectedOffer = () => {
                 selectedQuote={selectedQuote}
                 account={account}
                 providers={providersInfo}
-                data-test="@CoinmarketBuyOfferInfo"
+                data-test-id="@CoinmarketBuyOfferInfo"
             />
         </Wrapper>
     );

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketLayoutNavigation.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketLayoutNavigation.tsx
@@ -88,7 +88,7 @@ export const CoinmarketLayoutNavigation = () => {
         icon: IconName;
     }) => (
         <NavListItem
-            data-test={`@coinmarket/menu/${route}`}
+            data-test-id={`@coinmarket/menu/${route}`}
             nameId={title}
             isActive={routeName === route}
             icon={icon}

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketTopPanel.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketTopPanel.tsx
@@ -69,7 +69,7 @@ const CoinmarketTopPanel = ({ backRoute }: CoinmarketTopPanelProps) => {
         <Wrapper>
             <Content>
                 <Left>
-                    <Back onClick={goBack} data-test="@coinmarket/back">
+                    <Back onClick={goBack} data-test-id="@coinmarket/back">
                         <StyledIcon icon="ARROW_LEFT" />
                         <AccountLabeling account={account} />
                     </Back>

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/CoinmarketExchangeOfferInfo.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/CoinmarketExchangeOfferInfo.tsx
@@ -232,7 +232,7 @@ export const CoinmarketExchangeOfferInfo = ({
                         <CoinmarketProviderInfo
                             exchange={exchange}
                             providers={exchangeInfo?.providerInfos}
-                            data-test="@CoinmarketExchangeProviderInfo"
+                            data-test-id="@CoinmarketExchangeProviderInfo"
                         />
                     </RightColumn>
                 </Row>

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Footer/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Footer/index.tsx
@@ -34,7 +34,7 @@ const Footer = () => {
                     }
                     isLoading={formState.isSubmitting || isComposing}
                     type="submit"
-                    data-test="@coinmarket/exchange/compare-button"
+                    data-test-id="@coinmarket/exchange/compare-button"
                 >
                     <Translation id="TR_EXCHANGE_SHOW_OFFERS" />
                 </StyledButton>

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/FiatInput/FiatSelect/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/FiatInput/FiatSelect/index.tsx
@@ -20,7 +20,7 @@ const FiatSelect = () => {
                         updateFiatCurrency(selected);
                         setAmountLimits(undefined);
                     }}
-                    data-test="@coinmarket/exchange/fiat-select"
+                    data-test-id="@coinmarket/exchange/fiat-select"
                     value={value}
                     isClearable={false}
                     options={buildCurrencyOptions(value)}

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/FiatInput/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/FiatInput/index.tsx
@@ -56,7 +56,7 @@ const FiatInput = () => {
             rules={fiatInputRules}
             bottomText={fiatError?.message || null}
             innerAddon={<FiatSelect />}
-            data-test="@coinmarket/exchange/fiat-input"
+            data-test-id="@coinmarket/exchange/fiat-input"
         />
     );
 };

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/ReceiveCryptoSelect/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/ReceiveCryptoSelect/index.tsx
@@ -157,7 +157,7 @@ const ReceiveCryptoSelect = () => {
                             exchangeInfo,
                             tokenData?.symbol,
                         )}
-                        data-test="@coinmarket/exchange/receive-crypto-select"
+                        data-test-id="@coinmarket/exchange/receive-crypto-select"
                         minValueWidth="70px"
                         formatOptionLabel={(
                             option: ReturnType<typeof buildOptions>[number]['options'][number],

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/SendCryptoInput/SendCryptoSelect/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/SendCryptoInput/SendCryptoSelect/index.tsx
@@ -91,7 +91,7 @@ const SendCryptoSelect = () => {
                     isDisabled={account.networkType !== 'ethereum'}
                     minValueWidth="58px"
                     isClean
-                    data-test="@coinmarket/exchange/crypto-currency-select"
+                    data-test-id="@coinmarket/exchange/crypto-currency-select"
                 />
             )}
         />

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/SendCryptoInput/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/SendCryptoInput/index.tsx
@@ -86,7 +86,7 @@ const SendCryptoInput = () => {
     return (
         <StyledInput
             control={control}
-            data-test="@coinmarket/exchange/crypto-input"
+            data-test-id="@coinmarket/exchange/crypto-input"
             onChange={value => {
                 updateFiatValue(value);
                 clearErrors(FIAT_INPUT);

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/index.tsx
@@ -158,7 +158,7 @@ const Inputs = () => {
                         disabled={isBalanceZero}
                         onFractionClick={setRatioAmount}
                         onAllClick={setAllAmount}
-                        data-test="@coinmarket/exchange/fiat-input"
+                        data-test-id="@coinmarket/exchange/fiat-input"
                     />
                 </Right>
             </Row>

--- a/packages/suite/src/views/wallet/coinmarket/exchange/detail/components/PaymentSuccessful/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/detail/components/PaymentSuccessful/index.tsx
@@ -56,7 +56,10 @@ const PaymentSuccessful = ({ account }: PaymentSuccessfulProps) => {
             <Description>
                 <Translation id="TR_EXCHANGE_DETAIL_SUCCESS_TEXT" />
             </Description>
-            <Button data-test="@coinmarket/exchange/payment/back-to-account" onClick={handleClick}>
+            <Button
+                data-test-id="@coinmarket/exchange/payment/back-to-account"
+                onClick={handleClick}
+            >
                 <Translation id="TR_EXCHANGE_DETAIL_SUCCESS_BUTTON" />
             </Button>
         </Wrapper>

--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/List/ExchangeQuote.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/List/ExchangeQuote.tsx
@@ -260,7 +260,7 @@ export const ExchangeQuote = ({ className, quote }: QuoteProps) => {
                         isLoading={callInProgress}
                         isDisabled={errorQuote || callInProgress}
                         onClick={() => selectQuote(quote)}
-                        data-test="@coinmarket/exchange/offers/get-this-deal-button"
+                        data-test-id="@coinmarket/exchange/offers/get-this-deal-button"
                     >
                         <Translation id="TR_EXCHANGE_GET_THIS_OFFER" />
                     </StyledButton>

--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/SendSwapTransaction/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/SendSwapTransaction/index.tsx
@@ -298,7 +298,7 @@ const SendSwapTransactionComponent = () => {
                                     size="small"
                                     inputState={customSlippageError && 'error'}
                                     name="CustomSlippage"
-                                    data-test="CustomSlippage"
+                                    data-test-id="CustomSlippage"
                                     onChange={changeCustomSlippage}
                                     bottomText={customSlippageError?.message || null}
                                 />

--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/SendTransaction/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/SendTransaction/index.tsx
@@ -66,7 +66,7 @@ const SendTransactionComponent = () => {
 
             <ButtonWrapper>
                 <Button
-                    data-test="@coinmarket/exchange/offers/confirm-on-trezor-and-send"
+                    data-test-id="@coinmarket/exchange/offers/confirm-on-trezor-and-send"
                     isLoading={callInProgress}
                     onClick={sendTransaction}
                 >

--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/VerifyAddress/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/VerifyAddress/index.tsx
@@ -247,7 +247,7 @@ const VerifyAddressComponent = () => {
                     {(!addressVerified || addressVerified !== address) &&
                         selectedAccountOption.account && (
                             <Button
-                                data-test="@coinmarket/exchange/offers/confirm-on-trezor-button"
+                                data-test-id="@coinmarket/exchange/offers/confirm-on-trezor-button"
                                 isLoading={callInProgress}
                                 isDisabled={callInProgress}
                                 onClick={() => {
@@ -266,7 +266,7 @@ const VerifyAddressComponent = () => {
                     {((addressVerified && addressVerified === address) ||
                         selectedAccountOption?.type === 'NON_SUITE') && (
                         <Button
-                            data-test="@coinmarket/exchange/offers/continue-transaction-button"
+                            data-test-id="@coinmarket/exchange/offers/continue-transaction-button"
                             isLoading={callInProgress}
                             onClick={() => {
                                 if (address) {

--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/index.tsx
@@ -125,7 +125,7 @@ const SelectedOffer = () => {
                 account={account}
                 exchangeInfo={exchangeInfo}
                 receiveAccount={receiveAccount}
-                data-test="@coinmarket/exchange/offers/coinmarket-exchange-offer-info"
+                data-test-id="@coinmarket/exchange/offers/coinmarket-exchange-offer-info"
             />
         </Wrapper>
     );

--- a/packages/suite/src/views/wallet/coinmarket/p2p/form/Footer.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/p2p/form/Footer.tsx
@@ -113,7 +113,7 @@ export const Footer = () => {
                     isDisabled={!(formIsValid && hasValues) || isSubmitting}
                     isLoading={isSubmitting}
                     type="submit"
-                    data-test="@coinmarket/p2p/compare-button"
+                    data-test-id="@coinmarket/p2p/compare-button"
                 >
                     <Translation id="TR_P2P_SHOW_OFFERS" />
                 </StyledButton>

--- a/packages/suite/src/views/wallet/coinmarket/p2p/form/Inputs.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/p2p/form/Inputs.tsx
@@ -84,7 +84,7 @@ export const Inputs = () => {
                             )}
                         />
                     }
-                    data-test="@coinmarket/p2p/fiat-input"
+                    data-test-id="@coinmarket/p2p/fiat-input"
                 />
             </Left>
             <Right>

--- a/packages/suite/src/views/wallet/coinmarket/p2p/offers/List/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/p2p/offers/List/index.tsx
@@ -113,7 +113,7 @@ export const List = ({ quotes }: ListProps) => {
     const alternativeQuotes = quotes.filter(quote => !currencyMatches(quote));
 
     return (
-        <Wrapper data-test="@coinmarket/p2p/offers-list">
+        <Wrapper data-test-id="@coinmarket/p2p/offers-list">
             <Header>
                 <Left>
                     <SummaryRow>

--- a/packages/suite/src/views/wallet/coinmarket/sell/offers/Offers/SelectedOffer/components/SelectBankAccount.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/offers/Offers/SelectedOffer/components/SelectBankAccount.tsx
@@ -134,7 +134,7 @@ export const SelectBankAccount = () => {
                         <RegisterAnother
                             variant="tertiary"
                             icon="PLUS"
-                            data-test="add-output"
+                            data-test-id="add-output"
                             onClick={addBankAccount}
                         >
                             <Translation id="TR_SELL_ADD_BANK_ACCOUNT" />

--- a/packages/suite/src/views/wallet/details/index.tsx
+++ b/packages/suite/src/views/wallet/details/index.tsx
@@ -150,7 +150,7 @@ const Details = () => {
                             <ActionColumn>
                                 <StyledActionButton
                                     variant="secondary"
-                                    data-test="@wallets/details/show-xpub-button"
+                                    data-test-id="@wallets/details/show-xpub-button"
                                     onClick={handleXpubClick}
                                     isDisabled={disabled}
                                     isLoading={locked}

--- a/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
+++ b/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
@@ -173,7 +173,7 @@ export const FreshAddress = ({
             </AddressContainer>
             <Tooltip content={buttonTooltipContent()}>
                 <StyledButton
-                    data-test="@wallet/receive/reveal-address-button"
+                    data-test-id="@wallet/receive/reveal-address-button"
                     icon="TREZOR_LOGO"
                     onClick={handleAddressReveal}
                     isDisabled={disabled || locked || coinjoinDisallowReveal || !firstFreshAddress}

--- a/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
+++ b/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
@@ -117,7 +117,7 @@ const Item = ({ addr, locked, symbol, onClick, metadataPayload, index }: ItemPro
     return (
         <>
             <GridItemAddress
-                data-test={`@wallet/receive/used-address/${index}`}
+                data-test-id={`@wallet/receive/used-address/${index}`}
                 onMouseEnter={() => setIsHovered(true)}
                 onMouseLeave={() => setIsHovered(false)}
             >
@@ -141,7 +141,7 @@ const Item = ({ addr, locked, symbol, onClick, metadataPayload, index }: ItemPro
             >
                 <AddressActions isVisible={isHovered}>
                     <Button
-                        data-test={`@wallet/receive/reveal-address-button/${index}`}
+                        data-test-id={`@wallet/receive/reveal-address-button/${index}`}
                         variant="tertiary"
                         isDisabled={locked}
                         isLoading={locked}

--- a/packages/suite/src/views/wallet/send/components/Header/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Header/index.tsx
@@ -27,7 +27,7 @@ export const Header = () => {
     const options: Array<DropdownMenuItemProps> = [
         {
             key: 'opreturn',
-            'data-test': '@send/header-dropdown/opreturn',
+            'data-test-id': '@send/header-dropdown/opreturn',
             onClick: addOpReturn,
             label: <Translation id="OP_RETURN_ADD" />,
             isDisabled: !!opreturnOutput,
@@ -35,7 +35,7 @@ export const Header = () => {
         },
         {
             key: 'import',
-            'data-test': '@send/header-dropdown/import',
+            'data-test-id': '@send/header-dropdown/import',
             onClick: () => {
                 loadTransaction();
             },
@@ -44,7 +44,7 @@ export const Header = () => {
         },
         {
             key: 'raw',
-            'data-test': '@send/header-dropdown/raw',
+            'data-test-id': '@send/header-dropdown/raw',
             onClick: () => {
                 dispatch(sendRaw(true));
             },
@@ -59,7 +59,7 @@ export const Header = () => {
                     size="small"
                     variant="tertiary"
                     onClick={resetContext}
-                    data-test="clear-form"
+                    data-test-id="clear-form"
                 >
                     <Translation id="TR_CLEAR_ALL" />
                 </ClearButton>
@@ -67,7 +67,7 @@ export const Header = () => {
 
             <Dropdown
                 alignMenu="bottom-right"
-                data-test="@send/header-dropdown"
+                data-test-id="@send/header-dropdown"
                 items={[
                     {
                         key: 'header',

--- a/packages/suite/src/views/wallet/send/components/Options/BitcoinOptions/BitcoinOptions.tsx
+++ b/packages/suite/src/views/wallet/send/components/Options/BitcoinOptions/BitcoinOptions.tsx
@@ -106,7 +106,7 @@ export const BitcoinOptions = () => {
                                     toggleOption('bitcoinLockTime');
                                     composeTransaction();
                                 }}
-                                data-test="add-locktime-button"
+                                data-test-id="add-locktime-button"
                             >
                                 <Translation id="LOCKTIME_ADD" />
                             </StyledButton>
@@ -151,7 +151,7 @@ export const BitcoinOptions = () => {
                                 toggleOption('broadcast');
                                 composeTransaction();
                             }}
-                            data-test="broadcast-button"
+                            data-test-id="broadcast-button"
                         >
                             <Inline>
                                 <Translation id="BROADCAST" />
@@ -176,7 +176,7 @@ export const BitcoinOptions = () => {
                                 size="small"
                                 icon="COIN_CONTROL"
                                 onClick={toggleUtxoSelection}
-                                data-test="coin-control-button"
+                                data-test-id="coin-control-button"
                             >
                                 <Inline>
                                     <Translation id="TR_COIN_CONTROL" />
@@ -192,7 +192,7 @@ export const BitcoinOptions = () => {
                         variant="tertiary"
                         size="small"
                         icon="PLUS"
-                        data-test="add-output"
+                        data-test-id="add-output"
                         onClick={addOutput}
                         isFullWidth
                     >

--- a/packages/suite/src/views/wallet/send/components/Options/BitcoinOptions/Locktime.tsx
+++ b/packages/suite/src/views/wallet/send/components/Options/BitcoinOptions/Locktime.tsx
@@ -113,7 +113,7 @@ export const Locktime = ({ close }: LocktimeProps) => {
                     <IconButton icon="CROSS" size="tiny" variant="tertiary" onClick={close} />
                 }
                 bottomText={error?.message || null}
-                data-test="locktime-input"
+                data-test-id="locktime-input"
             />
 
             {isFeatureFlagEnabled('RBF') && network.features?.includes('rbf') && (

--- a/packages/suite/src/views/wallet/send/components/Options/CardanoOptions/CardanoOptions.tsx
+++ b/packages/suite/src/views/wallet/send/components/Options/CardanoOptions/CardanoOptions.tsx
@@ -29,7 +29,7 @@ export const CardanoOptions = () => {
                 variant="tertiary"
                 size="small"
                 icon="PLUS"
-                data-test="add-output"
+                data-test-id="add-output"
                 onClick={addOutput}
             >
                 <Translation id="RECIPIENT_ADD" />

--- a/packages/suite/src/views/wallet/send/components/Options/EthereumOptions/Data.tsx
+++ b/packages/suite/src/views/wallet/send/components/Options/EthereumOptions/Data.tsx
@@ -103,7 +103,7 @@ export const Data = ({ close }: DataProps) => {
         <Wrapper>
             <Textarea
                 inputState={getInputState(asciiError)}
-                data-test={inputAsciiName}
+                data-test-id={inputAsciiName}
                 defaultValue={asciiValue}
                 maxLength={formInputsMaxLength.ethData}
                 bottomText={asciiError?.message || null}
@@ -114,7 +114,7 @@ export const Data = ({ close }: DataProps) => {
             <Space> = </Space>
             <Textarea
                 inputState={getInputState(hexError)}
-                data-test={inputHexName}
+                data-test-id={inputHexName}
                 defaultValue={hexValue}
                 maxLength={formInputsMaxLength.ethData}
                 bottomText={hexError?.message || null}
@@ -122,7 +122,7 @@ export const Data = ({ close }: DataProps) => {
                     <Icon
                         size={20}
                         icon="CROSS"
-                        data-test="send/close-ethereum-data"
+                        data-test-id="send/close-ethereum-data"
                         onClick={handleClose}
                     />
                 }

--- a/packages/suite/src/views/wallet/send/components/Options/EthereumOptions/EthereumOptions.tsx
+++ b/packages/suite/src/views/wallet/send/components/Options/EthereumOptions/EthereumOptions.tsx
@@ -47,7 +47,7 @@ export const EthereumOptions = () => {
                             variant="tertiary"
                             size="small"
                             icon="DATA"
-                            data-test="send/open-ethereum-data"
+                            data-test-id="send/open-ethereum-data"
                             onClick={toggleData}
                         >
                             <Translation id="DATA_ETH_ADD" />
@@ -60,7 +60,7 @@ export const EthereumOptions = () => {
                         variant="tertiary"
                         size="small"
                         icon="BROADCAST"
-                        data-test="send/broadcast"
+                        data-test-id="send/broadcast"
                         onClick={toggleBroadcast}
                     >
                         <Translation id="BROADCAST" />

--- a/packages/suite/src/views/wallet/send/components/Options/RippleOptions/DestinationTag.tsx
+++ b/packages/suite/src/views/wallet/send/components/Options/RippleOptions/DestinationTag.tsx
@@ -41,7 +41,7 @@ export const DestinationTag = ({ close }: DestinationTagProps) => {
     return (
         <Input
             inputState={getInputState(error)}
-            data-test={inputName}
+            data-test-id={inputName}
             defaultValue={inputValue}
             maxLength={formInputsMaxLength.xrpDestinationTag}
             label={<Translation id="DESTINATION_TAG" />}

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Address/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Address/index.tsx
@@ -274,7 +274,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                             icon="CROSS"
                             size="tiny"
                             variant="tertiary"
-                            data-test={`outputs.${outputId}.remove`}
+                            data-test-id={`outputs.${outputId}.remove`}
                             onClick={() => {
                                 removeOutput(outputId);
                                 // compose by first Output
@@ -293,7 +293,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                         addressBottomText
                     )
                 }
-                data-test={inputName}
+                data-test-id={inputName}
                 defaultValue={addressValue}
                 maxLength={formInputsMaxLength.address}
                 innerRef={inputRef}

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/Fiat.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/Fiat.tsx
@@ -184,7 +184,7 @@ export const Fiat = ({ output, outputId }: FiatProps) => {
             isSearchable
             minValueWidth="58px"
             isClean
-            data-test={currencyInputName}
+            data-test-id={currencyInputName}
             onChange={async (selected: CurrencyOption) => {
                 // propagate changes to FormState
                 onChange(selected);
@@ -218,7 +218,7 @@ export const Fiat = ({ output, outputId }: FiatProps) => {
                 inputState={inputState}
                 onChange={handleChange}
                 name={fiatInputName}
-                data-test={fiatInputName}
+                data-test-id={fiatInputName}
                 defaultValue={fiatValue}
                 maxLength={formInputsMaxLength.fiat}
                 rules={rules}

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/TokenSelect.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/TokenSelect.tsx
@@ -123,7 +123,7 @@ const CardanoOption = ({ tokenInputName, ...optionProps }: any) => (
         {...optionProps}
         innerProps={{
             ...optionProps.innerProps,
-            'data-test': `${tokenInputName}/option/${optionProps.value}`,
+            'data-test-id': `${tokenInputName}/option/${optionProps.value}`,
         }}
     >
         <OptionWrapper>
@@ -206,7 +206,7 @@ export const TokenSelect = ({ output, outputId }: TokenSelectProps) => {
         <Controller
             control={control}
             name={tokenInputName}
-            data-test={tokenInputName}
+            data-test-id={tokenInputName}
             defaultValue={tokenValue}
             render={({ field: { onChange } }) => (
                 <Select
@@ -232,7 +232,7 @@ export const TokenSelect = ({ output, outputId }: TokenSelectProps) => {
                         // compose (could be prevented because of Amount error from re-validation above)
                         composeTransaction(amountInputName);
                     }}
-                    data-test="@amount-select"
+                    data-test-id="@amount-select"
                 />
             )}
         />

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/index.tsx
@@ -250,7 +250,7 @@ export const Amount = ({ output, outputId }: AmountProps) => {
                         bottomText={bottomText || null}
                         onChange={handleInputChange}
                         name={inputName}
-                        data-test={inputName}
+                        data-test-id={inputName}
                         defaultValue={amountValue}
                         maxLength={formInputsMaxLength.amount}
                         rules={cryptoAmountRules}

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/OpReturn/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/OpReturn/index.tsx
@@ -110,7 +110,7 @@ export const OpReturn = ({ outputId }: { outputId: number }) => {
             <Inputs>
                 <StyledTextarea
                     inputState={getInputState(asciiError)}
-                    data-test={inputAsciiName}
+                    data-test-id={inputAsciiName}
                     defaultValue={asciiValue}
                     maxLength={formInputsMaxLength.opReturn}
                     bottomText={asciiError?.message || null}
@@ -121,7 +121,7 @@ export const OpReturn = ({ outputId }: { outputId: number }) => {
                 <Space> = </Space>
                 <StyledTextarea
                     inputState={getInputState(hexError)}
-                    data-test={inputHexName}
+                    data-test-id={inputHexName}
                     defaultValue={hexValue}
                     maxLength={formInputsMaxLength.opReturn}
                     bottomText={hexError?.message || null}

--- a/packages/suite/src/views/wallet/send/components/Raw.tsx
+++ b/packages/suite/src/views/wallet/send/components/Raw.tsx
@@ -107,7 +107,7 @@ export const Raw = ({ network }: RawProps) => {
 
             <StyledTextarea
                 inputState={inputState}
-                data-test={INPUT_NAME}
+                data-test-id={INPUT_NAME}
                 defaultValue={inputValue}
                 bottomText={error?.message || null}
                 label={<Translation id="RAW_TRANSACTION" />}

--- a/packages/suite/src/views/wallet/send/components/ReviewButton.tsx
+++ b/packages/suite/src/views/wallet/send/components/ReviewButton.tsx
@@ -166,7 +166,7 @@ export const ReviewButton = () => {
                 interactiveTooltip={!coinControlOpen}
                 isRed={anonymityWarningChecked}
                 tooltipContent={tooltipContent}
-                data-test="@send/review-button"
+                data-test-id="@send/review-button"
                 isDisabled={isDisabled || isLoading}
                 onClick={signTransaction}
             >

--- a/packages/suite/src/views/wallet/send/index.tsx
+++ b/packages/suite/src/views/wallet/send/index.tsx
@@ -88,7 +88,7 @@ const SendLoaded = ({ children, selectedAccount }: SendLoadedProps) => {
             <SendContext.Provider value={sendContextValues}>
                 <Header />
 
-                <FormGrid data-test="@wallet/send/outputs-and-options">
+                <FormGrid data-test-id="@wallet/send/outputs-and-options">
                     <Outputs disableAnim={!!children} />
                     <Options />
                     <SendFees />

--- a/packages/suite/src/views/wallet/sign-verify/components/ButtonRow.tsx
+++ b/packages/suite/src/views/wallet/sign-verify/components/ButtonRow.tsx
@@ -116,7 +116,7 @@ export const ButtonRow = ({
                     iconSize={20}
                     isDisabled={isTrezorLocked}
                     isLoading={isSubmitting}
-                    data-test="@sign-verify/submit"
+                    data-test-id="@sign-verify/submit"
                 >
                     <Translation id={isSignPage ? 'TR_SIGN' : 'TR_VERIFY'} />
                 </StyledButton>

--- a/packages/suite/src/views/wallet/sign-verify/components/Navigation.tsx
+++ b/packages/suite/src/views/wallet/sign-verify/components/Navigation.tsx
@@ -13,13 +13,13 @@ export const Navigation = ({ page, setPage }: NavigationProps) => (
             title="TR_SIGN_MESSAGE"
             active={page === 'sign'}
             onClick={() => setPage('sign')}
-            data-test="@sign-verify/navigation/sign"
+            data-test-id="@sign-verify/navigation/sign"
         />
         <WalletLayoutNavLink
             title="TR_VERIFY_MESSAGE"
             active={page === 'verify'}
             onClick={() => setPage('verify')}
-            data-test="@sign-verify/navigation/verify"
+            data-test-id="@sign-verify/navigation/verify"
         />
     </WalletLayoutNavigation>
 );

--- a/packages/suite/src/views/wallet/sign-verify/components/SignAddressInput.tsx
+++ b/packages/suite/src/views/wallet/sign-verify/components/SignAddressInput.tsx
@@ -25,7 +25,7 @@ const Option = ({ data, value, isFocused, innerProps, ...rest }: any) => (
         isFocused={isFocused}
         innerProps={{
             ...innerProps,
-            'data-test': `@sign-verify/sign-address/option/${value}`,
+            'data-test-id': `@sign-verify/sign-address/option/${value}`,
         }}
         {...rest}
     >

--- a/packages/suite/src/views/wallet/sign-verify/index.tsx
+++ b/packages/suite/src/views/wallet/sign-verify/index.tsx
@@ -158,7 +158,7 @@ const SignVerify = () => {
         label: translationString('TR_SIGNATURE'),
         inputState: getInputState(formErrors.signature) as ReturnType<typeof getInputState>,
         bottomText: signatureError,
-        'data-test': '@sign-verify/signature',
+        'data-test-id': '@sign-verify/signature',
         innerRef: signatureRef,
         ...signatureField,
     };
@@ -223,7 +223,7 @@ const SignVerify = () => {
                             }}
                             bottomText={messageError || null}
                             rows={4}
-                            data-test="@sign-verify/message"
+                            data-test-id="@sign-verify/message"
                             innerRef={messageRef}
                             {...messageField}
                         />
@@ -238,7 +238,7 @@ const SignVerify = () => {
                                 revealedAddresses={revealedAddresses}
                                 inputState={getInputState(formErrors.path)}
                                 bottomText={pathError || null}
-                                data-test="@sign-verify/sign-address"
+                                data-test-id="@sign-verify/sign-address"
                                 {...pathField}
                             />
                         ) : (
@@ -248,7 +248,7 @@ const SignVerify = () => {
                                 type="text"
                                 inputState={getInputState(formErrors.address)}
                                 bottomText={addressError || null}
-                                data-test="@sign-verify/select-address"
+                                data-test-id="@sign-verify/select-address"
                                 {...addressField}
                             />
                         )}
@@ -261,7 +261,7 @@ const SignVerify = () => {
                                     </Tooltip>
                                 }
                                 options={formatOptions}
-                                data-test="@sign-verify/format"
+                                data-test-id="@sign-verify/format"
                                 {...isElectrumField}
                             />
                         )}

--- a/packages/suite/src/views/wallet/transactions/TradeBox/TradeBoxMenu.tsx
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/TradeBoxMenu.tsx
@@ -83,7 +83,7 @@ export const TradeBoxMenu = ({ account }: TradeBoxMenuProps) => {
                             });
                             dispatch(goto(item.route, { preserveParams: true }));
                         }}
-                        data-test={`@coinmarket/menu/${item.route}`}
+                        data-test-id={`@coinmarket/menu/${item.route}`}
                     >
                         {item.title}
                     </StyledButton>

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
@@ -183,7 +183,7 @@ export const TransactionList = ({
                     accountMetadata={accountMetadata}
                 />
             }
-            data-test="@wallet/accounts/transaction-list"
+            data-test-id="@wallet/accounts/transaction-list"
         >
             {account.accountType === 'coinjoin' && !isSearching && (
                 <TransactionCandidates accountKey={account.key} />

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/ExportAction.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/ExportAction.tsx
@@ -118,24 +118,24 @@ export const ExportAction = ({ account, searchQuery, accountMetadata }: ExportAc
                             key: 'export-csv',
                             label: <Translation id="TR_EXPORT_AS" values={{ as: 'CSV' }} />,
                             onClick: () => runExport('csv'),
-                            'data-test': `${dataTest}/csv`,
+                            'data-test-id': `${dataTest}/csv`,
                         },
                         {
                             key: 'export-pdf',
                             label: <Translation id="TR_EXPORT_AS" values={{ as: 'PDF' }} />,
                             onClick: () => runExport('pdf'),
-                            'data-test': `${dataTest}/pdf`,
+                            'data-test-id': `${dataTest}/pdf`,
                         },
                         {
                             key: 'export-json',
                             label: <Translation id="TR_EXPORT_AS" values={{ as: 'JSON' }} />,
                             onClick: () => runExport('json'),
-                            'data-test': `${dataTest}/json`,
+                            'data-test-id': `${dataTest}/json`,
                         },
                     ],
                 },
             ]}
-            data-test={`${dataTest}/dropdown`}
+            data-test-id={`${dataTest}/dropdown`}
         />
     );
 };

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/SearchAction.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/SearchAction.tsx
@@ -174,7 +174,7 @@ export const SearchAction = ({ account, searchQuery, setSearch, setSelectedPage 
 
             <StyledInput
                 isExpanded={isExpanded}
-                data-test="@wallet/accounts/search-icon"
+                data-test-id="@wallet/accounts/search-icon"
                 size="small"
                 innerRef={inputRef}
                 innerAddon={<SearchIcon icon="SEARCH" size={16} color={theme.iconSubdued} />}

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/DayHeader.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/DayHeader.tsx
@@ -83,7 +83,7 @@ export const DayHeader = ({
     return (
         <Wrapper>
             {dateKey === 'pending' ? (
-                <ColPending data-test="@transaction-group/pending/count">
+                <ColPending data-test-id="@transaction-group/pending/count">
                     <Translation id="TR_PENDING_TX_HEADING" values={{ count: txsCount }} /> •{' '}
                     {txsCount}
                 </ColPending>

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/TransactionsGroup.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/TransactionsGroup.tsx
@@ -44,7 +44,7 @@ export const TransactionsGroup = ({
         <TransactionsGroupWrapper
             key={dateKey}
             onMouseEnter={() => setIsHovered(true)}
-            data-test={`@wallet/accounts/transaction-list/group/${index}`}
+            data-test-id={`@wallet/accounts/transaction-list/group/${index}`}
             onMouseLeave={() => setIsHovered(false)}
             {...rest}
         >

--- a/packages/suite/src/views/wallet/transactions/components/AccountEmpty.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/AccountEmpty.tsx
@@ -117,7 +117,7 @@ export const AccountEmpty = ({ account }: AccountEmptyProps) => {
 
                 <Actions>
                     <ActionButton
-                        data-test="@accounts/empty-account/receive"
+                        data-test-id="@accounts/empty-account/receive"
                         variant="primary"
                         onClick={handleNavigateToReceivePage}
                     >
@@ -125,7 +125,7 @@ export const AccountEmpty = ({ account }: AccountEmptyProps) => {
                     </ActionButton>
 
                     <ActionButton
-                        data-test="@accounts/empty-account/buy"
+                        data-test-id="@accounts/empty-account/buy"
                         variant="primary"
                         onClick={handleNavigateToBuyPage}
                     >

--- a/packages/suite/src/views/wallet/transactions/components/TaprootBanner.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TaprootBanner.tsx
@@ -56,13 +56,13 @@ export const TaprootBanner = ({ onClose }: TaprootBannerProps) => {
     const theme = useTheme();
 
     return (
-        <StyledCard data-test="@accounts/empty-account/taproot-account">
+        <StyledCard data-test-id="@accounts/empty-account/taproot-account">
             <Heading>
                 <Title>
                     <Translation id="TR_TAPROOT_BANNER_TITLE" />
                 </Title>
                 <Button
-                    data-test="@accounts/empty-account/taproot-account/close"
+                    data-test-id="@accounts/empty-account/taproot-account/close"
                     variant="tertiary"
                     onClick={onClose}
                 >

--- a/suite-native/atoms/src/types.ts
+++ b/suite-native/atoms/src/types.ts
@@ -1,9 +1,9 @@
 export type TestProps = {
     ['data-testid']?: never;
     ['data-test']?: never;
-    ['data-test-id']?: never;
     ['data-testId']?: never;
-    ['data-testID']?: string;
+    ['data-testID']?: never;
+    ['data-test-id']?: string;
 };
 
 export type SurfaceElevation = '0' | '1';

--- a/suite-native/module-accounts-import/src/components/AccountImportOverview.tsx
+++ b/suite-native/module-accounts-import/src/components/AccountImportOverview.tsx
@@ -39,7 +39,7 @@ export const AccountImportOverview = ({ balance, networkSymbol }: AssetsOverview
             <VStack spacing="large">
                 {!isTestnet(networkSymbol) && <FiatBalanceFormatter value={fiatBalanceValue} />}
                 <TextInputField
-                    data-testID="@account-import/coin-synced/label-input"
+                    data-test-id="@account-import/coin-synced/label-input"
                     name="accountLabel"
                     label="Coin label"
                     elevation="1"

--- a/suite-native/module-accounts-import/src/components/AccountImportOverviewCard.tsx
+++ b/suite-native/module-accounts-import/src/components/AccountImportOverviewCard.tsx
@@ -64,7 +64,7 @@ export const AccountImportOverviewCard = ({
                 </Box>
                 {shouldDisplayDeleteIcon && (
                     <IconButton
-                        data-testID="@account-import/coin-synced/delete-icon"
+                        data-test-id="@account-import/coin-synced/delete-icon"
                         iconName="trashAlt"
                         colorScheme="tertiaryElevation1"
                         onPress={handleNavigateToQRScan}

--- a/suite-native/module-accounts-import/src/components/AccountImportSummary.tsx
+++ b/suite-native/module-accounts-import/src/components/AccountImportSummary.tsx
@@ -55,7 +55,7 @@ export const AccountImportSummary = ({ networkSymbol, accountInfo }: AccountImpo
                     title={
                         <Text
                             variant="titleSmall"
-                            data-testID="@account-import/coin-synced/success-text"
+                            data-test-id="@account-import/coin-synced/success-text"
                         >
                             {title}
                         </Text>

--- a/suite-native/module-accounts-import/src/components/AccountImportSummaryForm.tsx
+++ b/suite-native/module-accounts-import/src/components/AccountImportSummaryForm.tsx
@@ -126,7 +126,7 @@ export const AccountImportSummaryForm = ({
                 <Divider marginHorizontal="extraLarge" />
                 <Box marginHorizontal="medium">
                     <Button
-                        data-testID="@account-import/coin-synced/confirm-button"
+                        data-test-id="@account-import/coin-synced/confirm-button"
                         onPress={handleImportAccount}
                         size="large"
                         style={applyStyle(confirmButtonStyle)}

--- a/suite-native/module-accounts-import/src/components/DevXpub.tsx
+++ b/suite-native/module-accounts-import/src/components/DevXpub.tsx
@@ -28,7 +28,7 @@ export const DevXpub = ({ symbol, onSelect }: DevXpubProps) => {
     return (
         <Box marginTop="medium">
             <Button
-                data-testID={`@accounts-import/sync-coins/dev-xpub/${symbol}`}
+                data-test-id={`@accounts-import/sync-coins/dev-xpub/${symbol}`}
                 onPress={() => onSelect({ xpubAddress: xpub })}
                 colorScheme="tertiaryElevation0"
             >

--- a/suite-native/module-accounts-import/src/components/SelectableNetworkList.tsx
+++ b/suite-native/module-accounts-import/src/components/SelectableNetworkList.tsx
@@ -22,7 +22,7 @@ const NetworkItemSection = ({
                 <SelectableNetworkItem
                     key={symbol}
                     symbol={symbol}
-                    data-testID={`@onboarding/select-coin/${symbol}`}
+                    data-test-id={`@onboarding/select-coin/${symbol}`}
                     onPress={onSelectItem}
                 />
             ))}

--- a/suite-native/module-accounts-import/src/components/XpubHint.tsx
+++ b/suite-native/module-accounts-import/src/components/XpubHint.tsx
@@ -36,7 +36,7 @@ export const XpubHint = ({ networkType, handleOpen }: XpubScanHintSheet) => {
                 <TextButton
                     iconLeft="question"
                     onPress={handleOpen}
-                    data-testID="@accounts-import/sync-coins/xpub-help-link"
+                    data-test-id="@accounts-import/sync-coins/xpub-help-link"
                 >
                     {buttonTitle}
                 </TextButton>

--- a/suite-native/module-accounts-import/src/components/XpubHintBottomSheet.tsx
+++ b/suite-native/module-accounts-import/src/components/XpubHintBottomSheet.tsx
@@ -46,7 +46,7 @@ export const XpubHintBottomSheet = ({
                 </VStack>
                 <Box marginTop="extraLarge">
                     <Button
-                        data-testID="@accounts-import/xpub-help-modal/confirm-btn"
+                        data-test-id="@accounts-import/xpub-help-modal/confirm-btn"
                         onPress={handleClose}
                     >
                         {translate('moduleAccountImport.xpubScanScreen.confirmButton')}

--- a/suite-native/module-add-accounts/src/screens/AddCoinAccountScreen.tsx
+++ b/suite-native/module-add-accounts/src/screens/AddCoinAccountScreen.tsx
@@ -53,7 +53,7 @@ export const AddCoinAccountScreen = () => {
                         <SelectableNetworkItem
                             key={symbol}
                             symbol={symbol}
-                            data-testID={`@add-account/select-coin/${symbol}`}
+                            data-test-id={`@add-account/select-coin/${symbol}`}
                             onPress={onSelectedNetworkItem}
                         />
                     ))}

--- a/suite-native/module-add-accounts/src/screens/SelectAccountTypeScreen.tsx
+++ b/suite-native/module-add-accounts/src/screens/SelectAccountTypeScreen.tsx
@@ -138,7 +138,7 @@ export const SelectAccountTypeScreen = ({
                                 description={bulletsForKeyPath(descKey)}
                                 isSelected={selectedAccountType === item}
                                 isDefault={defaultType === item}
-                                data-testID={`@add-account/select-type/${item}`}
+                                data-test-id={`@add-account/select-type/${item}`}
                                 onSelected={() => setSelectedAccountType(item)}
                             />
                         );

--- a/suite-native/module-home/src/screens/HomeScreen/components/BiometricsBottomSheet.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/BiometricsBottomSheet.tsx
@@ -154,12 +154,12 @@ export const BiometricsBottomSheet = () => {
             <Box style={applyStyle(buttonWrapperStyle)}>
                 <Button
                     colorScheme="tertiaryElevation0"
-                    data-testID="reject-biometrics"
+                    data-test-id="reject-biometrics"
                     onPress={handleClose}
                 >
                     {translate('moduleHome.biometricsModal.button.later')}
                 </Button>
-                <Button data-testID="enable-biometrics" onPress={handleEnable}>
+                <Button data-test-id="enable-biometrics" onPress={handleEnable}>
                     {translate('moduleHome.biometricsModal.button.enable')}
                 </Button>
             </Box>

--- a/suite-native/module-home/src/screens/HomeScreen/components/PortfolioContent.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/PortfolioContent.tsx
@@ -59,7 +59,7 @@ export const PortfolioContent = forwardRef<PortfolioContentRef>((_props, ref) =>
                 {isPortfolioTrackerDevice && (
                     <Box>
                         <Button
-                            data-testID="@home/portfolio/sync-coins-button"
+                            data-test-id="@home/portfolio/sync-coins-button"
                             colorScheme="tertiaryElevation0"
                             size="large"
                             onPress={handleImportAssets}
@@ -73,7 +73,7 @@ export const PortfolioContent = forwardRef<PortfolioContentRef>((_props, ref) =>
                         <Divider />
                         <Box>
                             <Button
-                                data-testID="@home/portolio/recieve-button"
+                                data-test-id="@home/portolio/recieve-button"
                                 size="large"
                                 onPress={handleReceive}
                                 iconLeft="receive"


### PR DESCRIPTION
I've united the usage of testid attributes for Suite web and Suite desktop tests under one version -> `data-testid`.

I've also added the setting into all other playwright configs (the connect ones) in case somebody starts to use those. 
