### PR TITLE
Suite - Implement device translations (only settings for Beta)

### DIFF
--- a/packages/connect/src/data/config.ts
+++ b/packages/connect/src/data/config.ts
@@ -228,5 +228,9 @@ export const config = {
                 "Since firmware 2.6.3 there is a new protobuf field 'chunkify' in almost all getAddress and signTx methods",
             ],
         },
+        {
+            methods: ['changeLanguage'],
+            min: { T1B1: '0', T2T1: '2.7.0', T2B1: '2.7.0' },
+        },
     ],
 };

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
@@ -59,7 +59,10 @@ export type NotificationRendererProps<
     notification: Extract<NotificationEntry, { type: T }>;
 };
 
-export const NotificationRenderer = ({ notification, render }: NotificationRendererProps) => {
+export const NotificationRenderer = ({
+    notification,
+    render,
+}: NotificationRendererProps): JSX.Element => {
     switch (notification.type) {
         case 'acquire-error':
             return error(render, notification, 'TOAST_ACQUIRE_ERROR');
@@ -283,7 +286,11 @@ export const NotificationRenderer = ({ notification, render }: NotificationRende
             return success(render, notification, 'TOAST_SUCCESSFUL_CLAIM', 'CHECK', {
                 symbol: notification.symbol,
             });
-        default:
-            return info(render, notification, 'TR_404_DESCRIPTION');
+        case 'firmware-language-changed':
+            return success(render, notification, 'TR_FIRMWARE_LANGUAGE_CHANGED');
+        case 'firmware-language-fetch-error':
+            return error(render, notification, 'TR_FIRMWARE_LANGUAGE_FETCH_ERROR');
+
+        // intentionally no default, all cases must be handled.
     }
 };

--- a/packages/suite/src/constants/suite/anchors.ts
+++ b/packages/suite/src/constants/suite/anchors.ts
@@ -20,6 +20,7 @@ export const enum SettingsAnchor {
     CheckRecoverySeed = '@device-settings/check-recovery-seed',
     FirmwareVersion = '@device-settings/firmware-version',
     FirmwareType = '@device-settings/firmware-type',
+    FirmwareLanguage = '@device-settings/firmware-language',
     PinProtection = '@device-settings/pin-protection',
     ChangePin = '@device-settings/change-pin',
     WipeCode = '@device-settings/wipe-code',

--- a/packages/suite/src/hooks/suite/useDevice.ts
+++ b/packages/suite/src/hooks/suite/useDevice.ts
@@ -5,8 +5,14 @@ import { selectDevice } from '@suite-common/wallet-core';
 import { SUITE } from 'src/actions/suite/constants';
 
 import { useSelector } from './useSelector';
+import { TrezorDevice } from '@suite-common/suite-types';
 
-export const useDevice = () => {
+type Result = {
+    device?: TrezorDevice;
+    isLocked: (ignoreDisconnectedDevice?: boolean) => boolean;
+};
+
+export const useDevice = (): Result => {
     const device = useSelector(selectDevice);
     const locks = useSelector(state => state.suite.locks);
 

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5965,6 +5965,14 @@ export default defineMessages({
         id: 'TR_UPDATE_FIRMWARE_HOMESCREEN_TOOLTIP',
         defaultMessage: 'Update your firmware to change your homescreen',
     },
+    TR_FIRMWARE_LANGUAGE_CHANGED: {
+        id: 'TR_FIRMWARE_LANGUAGE_CHANGED',
+        defaultMessage: 'Device language sucessfully changed',
+    },
+    TR_FIRMWARE_LANGUAGE_FETCH_ERROR: {
+        id: 'TR_FIRMWARE_LANGUAGE_FETCH_ERROR',
+        defaultMessage: 'Translations download failed',
+    },
     TR_UPDATE_FIRMWARE_HOMESCREEN_LATER_TOOLTIP: {
         id: 'TR_UPDATE_FIRMWARE_HOMESCREEN_LATER_TOOLTIP',
         defaultMessage:

--- a/packages/suite/src/views/settings/SettingsDevice/ChangeLanguage.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/ChangeLanguage.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import {
+    ActionColumn,
+    ActionSelect,
+    SectionItem,
+    TextColumn,
+    Translation,
+} from 'src/components/suite';
+import { useAnchor } from '../../../hooks/suite/useAnchor';
+import { SettingsAnchor } from '../../../constants/suite/anchors';
+import { useDevice, useDispatch } from '../../../hooks/suite';
+import { changeLanguage } from '../../../actions/settings/deviceSettingsActions';
+import { LANGUAGES } from '../../../config/suite';
+import { Locale } from '../../../config/suite/languages';
+
+const BASE_TRANSLATIONS = [{ value: 'en-US', label: LANGUAGES['en'].name }];
+
+interface Props {
+    isDeviceLocked: boolean;
+}
+
+export const ChangeLanguage = ({ isDeviceLocked }: Props) => {
+    const { anchorRef, shouldHighlight } = useAnchor(SettingsAnchor.FirmwareLanguage);
+    const { device } = useDevice();
+    const dispatch = useDispatch();
+
+    const onChange = ({ value }: { value: Locale }) => {
+        dispatch(changeLanguage({ device, language: `${value}` }));
+    };
+
+    const isSupportedDevice = device?.features?.capabilities?.includes('Capability_Translations');
+
+    const deviceSupportedTranslations = (device?.availableTranslations ?? []).map(it => ({
+        value: it,
+        label: `${LANGUAGES[it.split('-')[0] as Locale].name} (beta)`,
+    }));
+
+    if (isSupportedDevice !== true || deviceSupportedTranslations.length === 0) {
+        return null;
+    }
+
+    const languageOptions = BASE_TRANSLATIONS.concat(deviceSupportedTranslations);
+
+    const selectedValue = languageOptions.find(
+        option => option.value === device?.features?.language,
+    );
+
+    return (
+        <SectionItem
+            data-test="@settings/device/language"
+            ref={anchorRef}
+            shouldHighlight={shouldHighlight}
+        >
+            <TextColumn title={<Translation id="TR_LANGUAGE" />} />
+            <ActionColumn>
+                <ActionSelect
+                    useKeyPressScroll
+                    value={selectedValue}
+                    options={languageOptions}
+                    onChange={onChange}
+                    isDisabled={isDeviceLocked}
+                    data-test="@settings/device/firmware-language-select"
+                />
+            </ActionColumn>
+        </SectionItem>
+    );
+};

--- a/packages/suite/src/views/settings/SettingsDevice/SettingsDevice.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/SettingsDevice.tsx
@@ -25,6 +25,7 @@ import { PinProtection } from './PinProtection';
 import { SafetyChecks } from './SafetyChecks';
 import { WipeCode } from './WipeCode';
 import { WipeDevice } from './WipeDevice';
+import { ChangeLanguage } from './ChangeLanguage';
 
 const deviceSettingsUnavailable = (device?: TrezorDevice, transport?: Partial<TransportInfo>) => {
     const noTransportAvailable = transport && !transport.type;
@@ -121,6 +122,7 @@ export const SettingsDevice = () => {
                 {(!bootloaderMode || bitcoinOnlyDevice) && (
                     <FirmwareTypeChange isDeviceLocked={isDeviceLocked} />
                 )}
+                <ChangeLanguage isDeviceLocked={isDeviceLocked} />
             </SettingsSection>
 
             {!bootloaderMode && !initializeMode && (

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -106,6 +106,7 @@ export const connectInitThunk = createThunk(
                 ...connectInitSettings,
                 pendingTransportEvent: selectIsPendingTransportEvent(getState()),
                 transports: selectDebugSettings(getState()).transports,
+                // debug: true, // Enable debug logs in TrezorConnect
             });
         } catch (error) {
             let formattedError: string;

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -152,6 +152,12 @@ export type ToastPayload = (
           type: 'successful-claim';
           symbol: string;
       }
+    | {
+          type: 'firmware-language-changed';
+      }
+    | {
+          type: 'firmware-language-fetch-error';
+      }
     | StakedTransactionNotification
     | UnstakedTransactionNotification
     | ClaimedTransactionNotification


### PR DESCRIPTION
Resolves https://github.com/trezor/trezor-suite/issues/11336

![signal-2024-02-28-103418](https://github.com/trezor/trezor-suite/assets/152899911/1f87a13f-8bbd-4404-be3a-8f15294a5c16)


For Model One, the switch is not there:
![image](https://github.com/trezor/trezor-suite/assets/152899911/386cf112-5323-4248-b96b-dd5e9fa5af6c)


For old firmware it is disabled: 
![image](https://github.com/trezor/trezor-suite/assets/152899911/aae6c96a-bfac-476d-b04e-9bd2a39d5d10)



---

based on #11183

a87a312ce75647ac13f6f8632446624aec0af35b - temporary commit. `device.availableTranslations` is now available and when running local connect, it should be possible to call TrezorConnect.changeLanguage({"baseUrl": "."}).  