### PR TITLE
feat(connect): rebootToBootloader, add params (boot_command, firmware…

### DIFF
--- a/packages/connect-explorer/src/data/methods/management/rebootToBootloader.ts
+++ b/packages/connect-explorer/src/data/methods/management/rebootToBootloader.ts
@@ -5,6 +5,19 @@ export default [
         url: `/method/rebootToBootloader`,
         name,
         submitButton: 'Reboot to bootloader',
-        fields: [],
+        fields: [
+            {
+                name: 'boot_command',
+                label: 'boot_command',
+                type: 'select',
+                optional: false,
+                value: 0,
+                placeholder: 'Select',
+                data: [
+                    { value: 0, label: 'STOP_AND_WAIT' },
+                    { value: 1, label: 'INSTALL_UPGRADE' },
+                ],
+            },
+        ],
     },
 ];

--- a/packages/connect/src/api/rebootToBootloader.ts
+++ b/packages/connect/src/api/rebootToBootloader.ts
@@ -3,8 +3,13 @@
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getFirmwareRange } from './common/paramsValidator';
 import { UI, createUiMessage } from '../events';
+import { Assert } from '@trezor/schema-utils';
+import { PROTO } from '../constants';
 
-export default class RebootToBootloader extends AbstractMethod<'rebootToBootloader'> {
+export default class RebootToBootloader extends AbstractMethod<
+    'rebootToBootloader',
+    PROTO.RebootToBootloader
+> {
     confirmed?: boolean;
 
     init() {
@@ -14,6 +19,15 @@ export default class RebootToBootloader extends AbstractMethod<'rebootToBootload
         this.requiredPermissions = ['management'];
         this.useDeviceState = false;
         this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
+
+        const { payload } = this;
+        Assert(PROTO.RebootToBootloader, payload);
+
+        this.params = {
+            boot_command: payload.boot_command,
+            firmware_header: payload.firmware_header,
+            language_data_length: payload.language_data_length,
+        };
     }
 
     get info() {
@@ -49,7 +63,7 @@ export default class RebootToBootloader extends AbstractMethod<'rebootToBootload
 
     async run() {
         const cmd = this.device.getCommands();
-        const response = await cmd.typedCall('RebootToBootloader', 'Success');
+        const response = await cmd.typedCall('RebootToBootloader', 'Success', this.params);
 
         return response.message;
     }

--- a/packages/connect/src/types/api/rebootToBootloader.ts
+++ b/packages/connect/src/types/api/rebootToBootloader.ts
@@ -3,6 +3,8 @@
  */
 
 import type { PROTO } from '../../constants';
-import type { CommonParams, Response } from '../params';
+import type { Params, Response } from '../params';
 
-export declare function rebootToBootloader(params?: CommonParams): Response<PROTO.Success>;
+export declare function rebootToBootloader(
+    params?: Params<PROTO.RebootToBootloader>,
+): Response<PROTO.Success>;


### PR DESCRIPTION
steps towards:
- more seamless firmware update
- silent language update, in cases of:
  - outadated language blob
  - wiped device
  - fw upgrade flow

related to #11183 #11243

this is not so easy task. it would be great if we could have just one connect method that would handle all the fw update complexity. but this can't be done since:
- part of fw update process is device reconnecting. and connect methods have not been design to withstand this (bigger problem)
- we would need to retest all the complexity from past, such as all different intermediary versions etc. (still a problem)

In this PR, I am so far only adding new params to `rebootToBootloader` method. Next steps should be discussed (cc @komret), I am even considering some more "crazy" solutions  https://satoshilabs.slack.com/archives/CKZHV2G13/p1708429851037539 