### PR TITLE
Fix commit message check script for CI

### DIFF
--- a/.github/workflows/commit-messages-check.yml
+++ b/.github/workflows/commit-messages-check.yml
@@ -8,5 +8,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Fetch base and current branch
+        run: |
+          git fetch --no-tags origin ${{ github.base_ref }}
+          git fetch --no-tags origin ${{ github.head_ref }}:${{ github.head_ref }}
+          git switch ${{ github.head_ref }}
+
       - name: Check commit messages
         run: ./scripts/check-commit-messages.sh
+        env:
+          BASE_BRANCH_NAME: ${{ github.base_ref }}

--- a/scripts/check-commit-messages.sh
+++ b/scripts/check-commit-messages.sh
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
-for commit in $(git rev-list origin/HEAD..HEAD); do
+
+# This script is run by commit-messages-check github action
+
+if ! git rev-list origin/"$BASE_BRANCH_NAME"..HEAD > /dev/null 2>&1; then
+  tput -T linux setaf 1
+  echo "git rev-list command failed"
+  tput -T linux sgr0
+  exit 1
+fi
+
+for commit in $(git rev-list origin/"$BASE_BRANCH_NAME"..HEAD); do
 
     commit_msg=$(git log --format=%B -n 1 "$commit")
 
@@ -10,18 +20,18 @@ for commit in $(git rev-list origin/HEAD..HEAD); do
 
     # Check for fixup commits
     if echo "$commit_msg" | grep -qE "^fixup! "; then
-    tput setaf 1
-    echo -e "Fixup commit validation failed for commit $commit:\n$commit_msg"
-    tput sgr0
+    tput -T linux setaf 1
+    echo "Fixup commit validation failed for commit $commit: $commit_msg"
+    tput -T linux sgr0
     echo -e "To squash fixup commits, run:\ngit rebase -i --autosquash origin/HEAD"
     exit 1
     fi
 
     # Check commit message syntax
     if ! echo "$commit_msg" | grep -qE "^(build|ci|docs|feat|fix|perf|refactor|style|test|chore|revert)(\([a-z, -]+\))?: "; then
-    tput setaf 1
-    echo -e "Conventional Commits validation failed for commit $commit:\n$commit_msg"
-    tput sgr0
+    tput -T linux setaf 1
+    echo "Conventional Commits validation failed for commit $commit: $commit_msg"
+    tput -T linux sgr0
     echo "Learn more about Conventional Commits at https://www.conventionalcommits.org"
     exit 1
     fi


### PR DESCRIPTION
This should fix the commit message/fixup check. The original script was failing silently in CI because `origin/HEAD` is not available with the checkout action - see [this run](https://github.com/trezor/trezor-suite/actions/runs/7970823748/job/21759232793?pr=11183).

I also added some error handling and fixed the console output colors.