### PR TITLE
chore(suite): refactor local currency selectors

### DIFF
--- a/packages/suite/src/components/suite/Ticker/Ticker.tsx
+++ b/packages/suite/src/components/suite/Ticker/Ticker.tsx
@@ -9,6 +9,7 @@ import { NoRatesTooltip } from './NoRatesTooltip';
 import { selectFiatRatesByFiatRateKey } from '@suite-common/wallet-core';
 import { getFiatRateKey } from '@suite-common/wallet-utils';
 import { NetworkSymbol } from '@suite-common/wallet-config';
+import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
 
 const FiatRateWrapper = styled.span`
     display: flex;
@@ -28,7 +29,7 @@ interface TickerProps {
 }
 
 export const Ticker = ({ symbol, tooltipPos = 'top' }: TickerProps) => {
-    const localCurrency = useSelector(state => state.wallet.settings.localCurrency);
+    const localCurrency = useSelector(selectLocalCurrency);
     const theme = useTheme();
 
     const fiatRateKey = getFiatRateKey(symbol, localCurrency);

--- a/packages/suite/src/components/suite/Ticker/TrendTicker.tsx
+++ b/packages/suite/src/components/suite/Ticker/TrendTicker.tsx
@@ -7,6 +7,7 @@ import { FiatValue } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
 import { NoRatesTooltip } from './NoRatesTooltip';
 import { NetworkSymbol } from '@suite-common/wallet-config';
+import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
 
 const PercentageWrapper = styled.div<{ isRateGoingUp: boolean }>`
     ${typography.hint}
@@ -24,7 +25,7 @@ interface TickerProps {
 }
 export const TrendTicker = ({ symbol }: TickerProps) => {
     const locale = useSelector(state => state.suite.settings.language);
-    const localCurrency = useSelector(state => state.wallet.settings.localCurrency);
+    const localCurrency = useSelector(selectLocalCurrency);
     const fiatRateKey = getFiatRateKey(symbol, localCurrency);
     const lastWeekRate = useSelector(state =>
         selectFiatRatesByFiatRateKey(state, fiatRateKey, 'lastWeek'),

--- a/packages/suite/src/hooks/wallet/useCoinmarketExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketExchangeForm.ts
@@ -53,6 +53,7 @@ import { useFees } from './form/useFees';
 import { AddressDisplayOptions, selectAddressDisplayType } from 'src/reducers/suite/suiteReducer';
 import { networkToCryptoSymbol } from 'src/utils/wallet/coinmarket/cryptoSymbolUtils';
 import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
 
 export const ExchangeFormContext = createContext<ExchangeFormContextValues | null>(null);
 ExchangeFormContext.displayName = 'CoinmarketExchangeContext';
@@ -90,7 +91,7 @@ export const useCoinmarketExchangeForm = ({
     const { exchangeInfo, quotesRequest } = useSelector(state => state.wallet.coinmarket.exchange);
     const { symbolsInfo } = useSelector(state => state.wallet.coinmarket.info);
     const device = useSelector(selectDevice);
-    const localCurrency = useSelector(state => state.wallet.settings.localCurrency);
+    const localCurrency = useSelector(selectLocalCurrency);
     const fees = useSelector(state => state.wallet.fees);
     const dispatch = useDispatch();
     const addressDisplayType = useSelector(selectAddressDisplayType);

--- a/packages/suite/src/hooks/wallet/useCoinmarketP2pFormDefaultValues.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketP2pFormDefaultValues.ts
@@ -2,9 +2,10 @@ import { useMemo } from 'react';
 import { useSelector } from 'src/hooks/suite';
 import { buildFiatOption, getDefaultCountry } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import { P2pInfo } from 'src/actions/wallet/coinmarketP2pActions';
+import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
 
 export const useCoinmarketP2pFormDefaultValues = (p2pInfo?: P2pInfo) => {
-    const localCurrency = useSelector(state => state.wallet.settings.localCurrency);
+    const localCurrency = useSelector(selectLocalCurrency);
 
     const country = p2pInfo?.country;
     const suggestedFiatCurrency = p2pInfo?.suggestedFiatCurrency || localCurrency;

--- a/packages/suite/src/hooks/wallet/useCoinmarketSellForm.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketSellForm.ts
@@ -53,6 +53,7 @@ import { useFees } from './form/useFees';
 import { AddressDisplayOptions, selectAddressDisplayType } from 'src/reducers/suite/suiteReducer';
 import { networkToCryptoSymbol } from 'src/utils/wallet/coinmarket/cryptoSymbolUtils';
 import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
 
 export const SellFormContext = createContext<SellFormContextValues | null>(null);
 SellFormContext.displayName = 'CoinmarketSellContext';
@@ -92,7 +93,7 @@ export const useCoinmarketSellForm = ({
 
     const accounts = useSelector(state => state.wallet.accounts);
     const device = useSelector(selectDevice);
-    const localCurrency = useSelector(state => state.wallet.settings.localCurrency);
+    const localCurrency = useSelector(selectLocalCurrency);
     const fees = useSelector(state => state.wallet.fees);
     const sellInfo = useSelector(state => state.wallet.coinmarket.sell.sellInfo);
     const quotesRequest = useSelector(state => state.wallet.coinmarket.sell.quotesRequest);

--- a/packages/suite/src/views/dashboard/components/PortfolioCard/components/DashboardGraph.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/components/DashboardGraph.tsx
@@ -14,6 +14,7 @@ import { Account } from 'src/types/wallet';
 import { TransactionsGraph, Translation, HiddenPlaceholder } from 'src/components/suite';
 import { AggregatedDashboardHistory } from 'src/types/wallet/graph';
 import { getMinMaxValueFromData } from 'src/utils/wallet/graph';
+import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
 
 const Wrapper = styled.div`
     display: flex;
@@ -48,7 +49,7 @@ interface DashboardGraphProps {
 export const DashboardGraph = memo(({ accounts }: DashboardGraphProps) => {
     const { error, isLoading, selectedRange } = useSelector(state => state.wallet.graph);
     const selectedDevice = useSelector(selectDevice);
-    const localCurrency = useSelector(state => state.wallet.settings.localCurrency);
+    const localCurrency = useSelector(selectLocalCurrency);
     const dispatch = useDispatch();
 
     const [data, setData] = useState<AggregatedDashboardHistory[]>([]);

--- a/packages/suite/src/views/dashboard/components/PortfolioCard/index.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/index.tsx
@@ -19,6 +19,7 @@ import { Exception } from './components/Exception';
 import { EmptyWallet } from './components/EmptyWallet';
 import { DashboardGraph } from './components/DashboardGraph';
 import { selectFiatRates } from '@suite-common/wallet-core';
+import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
 
 const Body = styled.div`
     align-items: center;
@@ -46,7 +47,7 @@ const Wrapper = styled.div`
 
 const PortfolioCard = memo(() => {
     const rates = useSelector(selectFiatRates);
-    const localCurrency = useSelector(state => state.wallet.settings.localCurrency);
+    const localCurrency = useSelector(selectLocalCurrency);
     const { discovery, getDiscoveryStatus, isDiscoveryRunning } = useDiscovery();
     const accounts = useFastAccounts();
     const { dashboardGraphHidden } = useSelector(s => s.suite.flags);

--- a/packages/suite/src/views/settings/SettingsGeneral/Fiat.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Fiat.tsx
@@ -12,6 +12,7 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 import { setLocalCurrency } from 'src/actions/settings/walletSettingsActions';
 import { useAnchor } from 'src/hooks/suite/useAnchor';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
+import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
 
 const buildCurrencyOption = (currency: string) => ({
     value: currency,
@@ -19,7 +20,7 @@ const buildCurrencyOption = (currency: string) => ({
 });
 
 export const Fiat = () => {
-    const localCurrency = useSelector(state => state.wallet.settings.localCurrency);
+    const localCurrency = useSelector(selectLocalCurrency);
     const dispatch = useDispatch();
     const { anchorRef, shouldHighlight } = useAnchor(SettingsAnchor.Fiat);
 

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
@@ -23,6 +23,7 @@ import { TrezorDevice, AcquiredDevice } from 'src/types/suite';
 import { selectLabelingDataForWallet } from 'src/reducers/suite/metadataReducer';
 import { useWalletLabeling } from '../../../../components/suite/labeling/WalletLabeling';
 import { METADATA_LABELING } from 'src/actions/suite/constants';
+import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
 
 const InstanceType = styled.div`
     display: flex;
@@ -111,7 +112,7 @@ export const WalletInstance = ({
 }: WalletInstanceProps) => {
     const accounts = useSelector(state => state.wallet.accounts);
     const rates = useSelector(selectFiatRates);
-    const localCurrency = useSelector(state => state.wallet.settings.localCurrency);
+    const localCurrency = useSelector(selectLocalCurrency);
     const editing = useSelector(state => state.metadata.editing);
     const dispatch = useDispatch();
 

--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/List/ExchangeQuote.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/List/ExchangeQuote.tsx
@@ -18,6 +18,7 @@ import {
     CoinmarketTag,
 } from 'src/views/wallet/coinmarket/common';
 import { cryptoToCoinSymbol } from 'src/utils/wallet/coinmarket/cryptoSymbolUtils';
+import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
 
 const Details = styled.div`
     display: flex;
@@ -183,7 +184,7 @@ export const ExchangeQuote = ({ className, quote }: QuoteProps) => {
     const feePerByte = useSelector(
         state => state.wallet.coinmarket.composedTransactionInfo.composed?.feePerByte,
     );
-    const localCurrency = useSelector(state => state.wallet.settings.localCurrency);
+    const localCurrency = useSelector(selectLocalCurrency);
     const fiatRateKey = getFiatRateKey(account.symbol, localCurrency);
     const fiatRate = useSelector(state => selectFiatRatesByFiatRateKey(state, fiatRateKey));
 

--- a/packages/suite/src/views/wallet/receive/components/CoinjoinReceiveWarning.tsx
+++ b/packages/suite/src/views/wallet/receive/components/CoinjoinReceiveWarning.tsx
@@ -8,6 +8,7 @@ import { formatAmount, getAccountDecimals } from '@suite-common/wallet-utils';
 import { UNECONOMICAL_COINJOIN_THRESHOLD } from 'src/services/coinjoin';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 import { selectIsAccountWithRatesByKey } from '@suite-common/wallet-core';
+import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
 
 const StyledWarning = styled(Warning)`
     justify-content: space-between;
@@ -66,7 +67,7 @@ const StyledButton = styled(Button)`
 
 export const CoinjoinReceiveWarning = () => {
     const account = useSelector(selectSelectedAccount);
-    const localCurrency = useSelector(state => state.wallet.settings.localCurrency);
+    const localCurrency = useSelector(selectLocalCurrency);
     const isAccountWithRate = useSelector(state =>
         selectIsAccountWithRatesByKey(state, account?.key || '', localCurrency),
     );

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/TokenSelect.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/TokenSelect.tsx
@@ -14,6 +14,7 @@ import { TooltipSymbol, Translation } from 'src/components/suite';
 import { getNetworkFeatures } from '@suite-common/wallet-config';
 import { enhanceTokensWithRates, sortTokensWithRates } from 'src/utils/wallet/tokenUtils';
 import { getShortFingerprint } from '@suite-common/wallet-utils';
+import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
 
 const UnrecognizedTokensHeading = styled.div`
     display: flex;
@@ -164,7 +165,7 @@ export const TokenSelect = ({ output, outputId }: TokenSelectProps) => {
         watch,
     } = useSendFormContext();
     const tokenDefinitions = useSelector(state => selectTokenDefinitions(state, account.symbol));
-    const localCurrency = useSelector(state => state.wallet.settings.localCurrency);
+    const localCurrency = useSelector(selectLocalCurrency);
     const tokensWithRates = enhanceTokensWithRates(account.tokens, localCurrency, account.symbol);
 
     const sortedTokens = useMemo(() => {

--- a/packages/suite/src/views/wallet/tokens/components/TokenList.tsx
+++ b/packages/suite/src/views/wallet/tokens/components/TokenList.tsx
@@ -16,6 +16,7 @@ import { spacingsPx } from '@trezor/theme';
 import { NetworkSymbol, getNetworkFeatures } from '@suite-common/wallet-config';
 import { enhanceTokensWithRates, sortTokensWithRates } from 'src/utils/wallet/tokenUtils';
 import { Rate } from '@suite-common/wallet-types';
+import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
 
 const Wrapper = styled(Card)<{ isTestnet?: boolean }>`
     display: grid;
@@ -107,7 +108,7 @@ export const TokenList = ({
 }: TokenListProps) => {
     const theme = useTheme();
     const tokenDefinitions = useSelector(state => selectTokenDefinitions(state, networkSymbol));
-    const localCurrency = useSelector(state => state.wallet.settings.localCurrency);
+    const localCurrency = useSelector(selectLocalCurrency);
     const { account } = useSelector(state => state.wallet.selectedAccount);
 
     if (!account) return null;

--- a/packages/suite/src/views/wallet/transactions/TradeBox/TradeBox.tsx
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/TradeBox.tsx
@@ -12,6 +12,7 @@ import { Card, CoinLogo, variables } from '@trezor/components';
 import { TradeBoxMenu } from './TradeBoxMenu';
 import { TradeBoxPrices } from './TradeBoxPrices';
 import { getFiatRateKey } from '@suite-common/wallet-utils';
+import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
 
 const StyledCard = styled(Card)`
     flex-flow: row wrap;
@@ -77,7 +78,7 @@ interface TradeBoxProps {
 
 export const TradeBox = ({ account }: TradeBoxProps) => {
     const network = getMainnets().find(n => n.symbol === account.symbol);
-    const localCurrency = useSelector(state => state.wallet.settings.localCurrency);
+    const localCurrency = useSelector(selectLocalCurrency);
     const fiatRateKey = getFiatRateKey(account.symbol, localCurrency);
     const fiatRates = useSelector(state => selectFiatRatesByFiatRateKey(state, fiatRateKey));
 

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
@@ -25,6 +25,7 @@ import { TransactionCandidates } from './TransactionCandidates';
 import { selectLabelingDataForAccount } from 'src/reducers/suite/metadataReducer';
 import { getTxsPerPage } from '@suite-common/suite-utils';
 import { SkeletonStack } from '@trezor/components';
+import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
 
 const StyledSection = styled(DashboardSection)`
     margin-bottom: 20px;
@@ -47,7 +48,7 @@ export const TransactionList = ({
     account,
     symbol,
 }: TransactionListProps) => {
-    const localCurrency = useSelector(state => state.wallet.settings.localCurrency);
+    const localCurrency = useSelector(selectLocalCurrency);
     const anchor = useSelector(state => state.router.anchor);
     const dispatch = useDispatch();
     const accountMetadata = useSelector(state => selectLabelingDataForAccount(state, account.key));

--- a/packages/suite/src/views/wallet/transactions/components/TransactionSummary.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionSummary.tsx
@@ -17,6 +17,7 @@ import { variables, Button, Card } from '@trezor/components';
 import { TransactionSummaryDropdown } from './TransactionSummaryDropdown';
 import { SummaryCards } from './SummaryCards';
 import { aggregateBalanceHistory, getMinMaxValueFromData } from 'src/utils/wallet/graph';
+import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
 
 const Wrapper = styled.div`
     display: flex;
@@ -61,7 +62,7 @@ interface TransactionSummaryProps {
 
 export const TransactionSummary = ({ account }: TransactionSummaryProps) => {
     const selectedRange = useSelector(state => state.wallet.graph.selectedRange);
-    const localCurrency = useSelector(state => state.wallet.settings.localCurrency);
+    const localCurrency = useSelector(selectLocalCurrency);
     const dispatch = useDispatch();
 
     const intervalGraphData = dispatch(getGraphDataForInterval({ account }));


### PR DESCRIPTION
## Description

Use `selectLocalCurrency` selector instead of accessing the state directly.
