### PR TITLE
fix(suite): `fromWei` and `toWei`check errors

### DIFF
--- a/packages/blockchain-link-types/src/blockbook-api.ts
+++ b/packages/blockchain-link-types/src/blockbook-api.ts
@@ -32,7 +32,7 @@ export interface EthereumSpecific {
     nonce: number;
     gasLimit: number;
     gasUsed?: number;
-    gasPrice: string;
+    gasPrice?: string;
     data?: string;
     parsedData?: EthereumParsedInputData;
     internalTransfers?: EthereumInternalTransfer[];

--- a/packages/blockchain-link-utils/src/blockbook.ts
+++ b/packages/blockchain-link-utils/src/blockbook.ts
@@ -239,7 +239,7 @@ export const transformTransaction = (
 
     const fee =
         tx.ethereumSpecific && !tx.ethereumSpecific.gasUsed
-            ? new BigNumber(tx.ethereumSpecific.gasPrice)
+            ? new BigNumber(tx.ethereumSpecific?.gasPrice ?? '0')
                   .times(tx.ethereumSpecific.gasLimit)
                   .toString()
             : tx.fees;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
@@ -326,7 +326,7 @@ export const BasicTxDetails = ({
                             <StyledIcon icon="GAS" size={10} />
                             <Translation id="TR_GAS_PRICE" />
                         </Title>
-                        <Value>{`${fromWei(tx.ethereumSpecific.gasPrice, 'gwei')} ${getFeeUnits(
+                        <Value>{`${fromWei(tx.ethereumSpecific?.gasPrice ?? '0', 'gwei')} ${getFeeUnits(
                             'ethereum',
                         )}`}</Value>
 

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -442,7 +442,7 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
                     ethereumSpecific: origTx.ethereumSpecific
                         ? {
                               ...origTx.ethereumSpecific,
-                              gasPrice: toWei(origTx.ethereumSpecific.gasPrice, 'gwei'),
+                              gasPrice: toWei(origTx.ethereumSpecific?.gasPrice ?? '0', 'gwei'),
                           }
                         : undefined,
                     cardanoSpecific: origTx.cardanoSpecific

--- a/suite-common/wallet-utils/src/exportTransactionsUtils.ts
+++ b/suite-common/wallet-utils/src/exportTransactionsUtils.ts
@@ -102,7 +102,7 @@ const formatAmounts =
         ethereumSpecific: tx.ethereumSpecific
             ? {
                   ...tx.ethereumSpecific,
-                  gasPrice: fromWei(tx.ethereumSpecific.gasPrice, 'gwei'),
+                  gasPrice: fromWei(tx.ethereumSpecific?.gasPrice ?? '0', 'gwei'),
               }
             : undefined,
         cardanoSpecific: tx.cardanoSpecific

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -552,7 +552,7 @@ const getEthereumRbfParams = (
         ],
         ethereumNonce: tx.ethereumSpecific.nonce,
         ethereumData,
-        feeRate: fromWei(tx.ethereumSpecific.gasPrice, 'gwei'),
+        feeRate: fromWei(tx.ethereumSpecific?.gasPrice ?? '0', 'gwei'),
         baseFee: 0, // irrelevant
     };
 };


### PR DESCRIPTION
## Description

Turns out that `gasPrice` can be somehow undefined and we should handle it if we pass these values to `toWei` and `fromWei` functions from `web3-utils`.

`gasPrice` type was changed manually but it will be [updated in blockbook](https://github.com/trezor/blockbook/pull/1037). So the next time someone generates blockbook typings it will remain unchanged.

## Related Issue

Resolve #9698
Resolve #8931