### PR TITLE
fix(blockchain-link-utils): fee display in Solana self token txs

### DIFF
--- a/packages/blockchain-link-utils/src/solana.ts
+++ b/packages/blockchain-link-utils/src/solana.ts
@@ -565,15 +565,13 @@ export const transformTransaction = (
         type,
     );
 
-    const isSelfTransferWithZeroSolValue = type === 'self' && amount === tx.meta.fee.toString();
-
     const details = getDetails(tx, nativeEffects, accountAddress, type);
 
     return {
         type,
         txid: tx.transaction.signatures[0].toString(),
         blockTime: tx.blockTime,
-        amount: isSelfTransferWithZeroSolValue ? '0' : amount,
+        amount,
         fee: tx.meta.fee.toString(),
         targets,
         tokens,

--- a/packages/blockchain-link-utils/src/solana.ts
+++ b/packages/blockchain-link-utils/src/solana.ts
@@ -565,13 +565,15 @@ export const transformTransaction = (
         type,
     );
 
+    const isSelfTransferWithZeroSolValue = type === 'self' && amount === tx.meta.fee.toString();
+
     const details = getDetails(tx, nativeEffects, accountAddress, type);
 
     return {
         type,
         txid: tx.transaction.signatures[0].toString(),
         blockTime: tx.blockTime,
-        amount,
+        amount: isSelfTransferWithZeroSolValue ? '0' : amount,
         fee: tx.meta.fee.toString(),
         targets,
         tokens,


### PR DESCRIPTION
The native effects and transaction ammount is calculated to account for multi asset transfers. If the transfer amount to self is equal to the fee (i.e. only the fee was paid, no SOL was transfered) we set it to 0.

I suggest further investigation into why the modal displays a different value than the tx history item, since the tx history item correctly displayed -fee whereas the modal displays +fee. 
Since I perceive that the fee display as a sent value is a bug anyway I didn't address this.

## Related Issue

Resolves #10920

## Screenshots:
![image](https://github.com/trezor/trezor-suite/assets/71935095/9efdd7c8-47b7-4828-8ccd-a99d9076ad89)
![image](https://github.com/trezor/trezor-suite/assets/71935095/b56ac168-2734-4e9c-bd0b-89c19f2dbab2)

