### PR TITLE
npm-release: connect-webextension 9.1.12

### DIFF
--- a/packages/connect-webextension/CHANGELOG.md
+++ b/packages/connect-webextension/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 9.1.12
+
+-   initial non-beta release
+-   added serviceworker proxy and example how to use it.
+
 # 0.0.0-beta.3
 
 -   Include directory `lib/` into release in order to publish TypeScript types.

--- a/packages/connect-webextension/README.md
+++ b/packages/connect-webextension/README.md
@@ -1,4 +1,4 @@
-# @trezor/connect-webextension BETA
+# @trezor/connect-webextension
 
 [![Build Status](https://github.com/trezor/trezor-suite/actions/workflows/connect-test.yml/badge.svg)](https://github.com/trezor/trezor-suite/actions/workflows/connect-test.yml)
 [![NPM](https://img.shields.io/npm/v/@trezor/connect-webextension.svg)](https://www.npmjs.org/package/@trezor/connect-webextension)

--- a/packages/connect-webextension/package.json
+++ b/packages/connect-webextension/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/connect-webextension",
-    "version": "0.0.0-beta.3",
+    "version": "9.1.12",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect-webextension",
     "description": "High-level javascript interface for Trezor hardware wallet in webextension serviceworker environment.",


### PR DESCRIPTION
are we ready? cc @karliatto @Hannsek 

- from now on, this package will be released together with other connect npm packages. 
- all relevant trezor.io changes for this package should already be deployed on trezor.io, right? cc @martykan 

prerequisite for #11048
