### PR TITLE
Fix: analytics button storage

### DIFF
--- a/packages/components/src/components/DataAnalytics.tsx
+++ b/packages/components/src/components/DataAnalytics.tsx
@@ -110,6 +110,7 @@ interface DataAnalyticsProps {
     analyticsLink?: (chunks: ReactNode[]) => JSX.Element;
     tosLink?: (chunks: ReactNode[]) => JSX.Element;
     className?: string;
+    isInitialTrackingEnabled?: boolean;
 }
 
 // This component is used in connect-ui, therefore it's located in this library,
@@ -119,8 +120,9 @@ export const DataAnalytics = ({
     analyticsLink,
     tosLink,
     className,
+    isInitialTrackingEnabled = true,
 }: DataAnalyticsProps) => {
-    const [trackingEnabled, setTrackingEnabled] = useState<boolean>(true);
+    const [trackingEnabled, setTrackingEnabled] = useState<boolean>(isInitialTrackingEnabled);
 
     return (
         <StyledCard data-test="@analytics/consent" className={className}>

--- a/packages/connect-ui/src/components/AnalyticsConsentWrapper.tsx
+++ b/packages/connect-ui/src/components/AnalyticsConsentWrapper.tsx
@@ -12,10 +12,14 @@ const StyledDataAnalytics = styled(DataAnalytics)`
 `;
 
 type AnalyticsConsentWrapperProps = {
+    isInitialTrackingEnabled: boolean;
     onAnalyticsConfirm: (enabled: boolean) => void;
 };
 
-export const AnalyticsConsentWrapper = ({ onAnalyticsConfirm }: AnalyticsConsentWrapperProps) => {
+export const AnalyticsConsentWrapper = ({
+    isInitialTrackingEnabled,
+    onAnalyticsConfirm,
+}: AnalyticsConsentWrapperProps) => {
     const onConfirm = (trackingEnabled: boolean) => {
         if (trackingEnabled) {
             analytics.enable();
@@ -28,7 +32,10 @@ export const AnalyticsConsentWrapper = ({ onAnalyticsConfirm }: AnalyticsConsent
 
     return (
         <Wrapper>
-            <StyledDataAnalytics onConfirm={onConfirm} />
+            <StyledDataAnalytics
+                isInitialTrackingEnabled={isInitialTrackingEnabled}
+                onConfirm={onConfirm}
+            />
         </Wrapper>
     );
 };

--- a/packages/connect-ui/src/components/BottomRightFloatingBar.tsx
+++ b/packages/connect-ui/src/components/BottomRightFloatingBar.tsx
@@ -14,14 +14,12 @@ const Wrapper = styled.div`
     z-index: 1;
 `;
 
-enum View {
-    AnalyticsConsent,
-    Default,
-}
+const View = {
+    AnalyticsConsent: 'AnalyticsConsent',
+    Default: 'Default',
+} as const;
 
-const getView = () => {
-    const showAnalyticsConsent = storage.load().tracking_enabled === undefined;
-
+const getView = (showAnalyticsConsent: boolean) => {
     if (showAnalyticsConsent) {
         return View.AnalyticsConsent;
     }
@@ -34,13 +32,16 @@ type BottomRightFloatingBarProps = {
 };
 
 export const BottomRightFloatingBar = ({ onAnalyticsConfirm }: BottomRightFloatingBarProps) => {
-    const [view, setView] = useState(getView());
+    const initialStorage = storage.load();
+    const [view, setView] = useState(getView(initialStorage.tracking_enabled === undefined));
+    const isInitialTrackingEnabled = initialStorage.tracking_enabled !== false;
 
     let content;
     switch (view) {
         case View.AnalyticsConsent:
             content = (
                 <AnalyticsConsentWrapper
+                    isInitialTrackingEnabled={isInitialTrackingEnabled}
                     onAnalyticsConfirm={(enabled: boolean) => {
                         setView(View.Default);
                         onAnalyticsConfirm(enabled);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix analytics button in Trezor Popup show it as non-checked when it is not enabled.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/11216

## Screenshots:

![image](https://github.com/trezor/trezor-suite/assets/5362163/d35785e1-11bb-4912-bc46-32aa31415ebf)

