### PR TITLE
Connect Popup tests are comming to GitHub Actions :tada: 

### DIFF
--- a/.github/workflows/connect-dev-release-test.yml
+++ b/.github/workflows/connect-dev-release-test.yml
@@ -1,5 +1,4 @@
-# TODO: add tests and call it [Build/Test]
-name: "[Build] connect"
+name: "[Build/Test] Connect Explorer"
 
 permissions:
   id-token: write # for fetching the OIDC token
@@ -21,6 +20,7 @@ on:
       - "submodules/trezor-common/**"
       - "yarn.lock"
       - ".github/workflows/connect-dev-release.yml"
+      - ".github/workflows/template-connect-popup-test-params.yml"
 
 concurrency:
   group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
@@ -30,7 +30,7 @@ env:
   DEV_SERVER_HOSTNAME: "dev.suite.sldev.cz"
 
 jobs:
-  build-connect-explorer:
+  build-deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -81,7 +81,6 @@ jobs:
       - name: Build connect-explorer
         env:
           ASSET_PREFIX: /connect/${{ steps.extract_branch.outputs.branch }}
-          # TODO: maybe we don't want to build it for production for every branch
           NODE_ENV: "production"
           url: https://${{ env.DEV_SERVER_HOSTNAME }}/connect/${{ steps.extract_branch.outputs.branch }}
           __TREZOR_CONNECT_SRC: https://${{ env.DEV_SERVER_HOSTNAME }}/connect/${{ steps.extract_branch.outputs.branch }}/
@@ -125,3 +124,62 @@ jobs:
             packages/connect-examples/webextension-mv3/build-legacy
             packages/connect-examples/webextension-mv3-sw/build
             packages/connect-explorer/build-webextension
+
+  methods:
+    needs: [build-deploy]
+    uses: ./.github/workflows/template-connect-popup-test-params.yml
+    with:
+      test-name: methods.test
+      DEV_SERVER_HOSTNAME: dev.suite.sldev.cz
+      run-webextension: true
+
+  popup-close:
+    needs: [build-deploy]
+    uses: ./.github/workflows/template-connect-popup-test-params.yml
+    with:
+      test-name: popup-close.test
+      DEV_SERVER_HOSTNAME: dev.suite.sldev.cz
+      run-webextension: true
+
+  passphrase:
+    needs: [build-deploy]
+    uses: ./.github/workflows/template-connect-popup-test-params.yml
+    with:
+      test-name: passphrase.test
+      DEV_SERVER_HOSTNAME: dev.suite.sldev.cz
+      run-webextension: true
+
+  popup-pages:
+    needs: [build-deploy]
+    uses: ./.github/workflows/template-connect-popup-test-params.yml
+    with:
+      test-name: popup-pages.test
+      DEV_SERVER_HOSTNAME: dev.suite.sldev.cz
+
+  browser-support:
+    needs: [build-deploy]
+    uses: ./.github/workflows/template-connect-popup-test-params.yml
+    with:
+      test-name: browser-support.test
+      DEV_SERVER_HOSTNAME: dev.suite.sldev.cz
+
+  permissions:
+    needs: [build-deploy]
+    uses: ./.github/workflows/template-connect-popup-test-params.yml
+    with:
+      test-name: permissions.test
+      DEV_SERVER_HOSTNAME: dev.suite.sldev.cz
+
+  transport:
+    needs: [build-deploy]
+    uses: ./.github/workflows/template-connect-popup-test-params.yml
+    with:
+      test-name: transport.test
+      DEV_SERVER_HOSTNAME: dev.suite.sldev.cz
+
+  unchained:
+    needs: [build-deploy]
+    uses: ./.github/workflows/template-connect-popup-test-params.yml
+    with:
+      test-name: unchained.test
+      DEV_SERVER_HOSTNAME: dev.suite.sldev.cz

--- a/.github/workflows/template-connect-popup-test-params.yml
+++ b/.github/workflows/template-connect-popup-test-params.yml
@@ -1,0 +1,118 @@
+name: "[Template] Connect e2e"
+
+on:
+  workflow_call:
+    inputs:
+      test-name:
+        description: "Test name to be run (e.g. `analytics` or `popup-close`)"
+        type: "string"
+        required: true
+      DEV_SERVER_HOSTNAME:
+        description: "URL used by popup connect tests (e.g. dev.suite.sldev.cz)"
+        type: "string"
+        required: true
+      run-webextension:
+        description: "Flag to indicate whether to run the webextension job"
+        type: "boolean"
+        required: false
+
+jobs:
+  web:
+    name: web
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Extract branch name
+        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        id: extract_branch
+
+      - run: yarn install
+
+      - run: yarn build:libs
+
+      - name: Make Docker Script Executable
+        run: chmod +x ./docker/docker-connect-popup-ci.sh
+
+      - name: Check Script Permissions
+        run: ls -l ./docker/docker-connect-popup-ci.sh
+
+      - name: Docker Version
+        run: docker --version
+
+      - name: Run connect popup test
+        env:
+          URL: https://${{ inputs.DEV_SERVER_HOSTNAME }}/connect/${{ steps.extract_branch.outputs.branch }}/
+          TREZOR_CONNECT_SRC: https://${{ inputs.DEV_SERVER_HOSTNAME }}/connect/${{ steps.extract_branch.outputs.branch }}/
+        run: |
+          ./docker/docker-connect-popup-ci.sh ${{ inputs.test-name }}
+
+      - name: Upload artifacts
+        # We upload test artifacts only if it fails and we use it to `Check Test Success` in next step.
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-artifacts-${{ inputs.test-name }}-${{ github.run_attempt }}
+          path: |
+            packages/connect-popup/e2e/screenshots
+            packages/connect-popup/test-results
+
+      - name: Check Test Success
+        run: |
+          # If there is `test-results` it means it has failed.
+          if [ -f "packages/connect-popup/test-results" ]; then
+            echo "Tests failed"
+            exit 1
+          fi
+
+  webextension:
+    name: webextension
+    runs-on: ubuntu-latest
+    if: ${{ inputs.run-webextension }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Extract branch name
+        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        id: extract_branch
+
+      - name: Build webextension
+        run: |
+          yarn install --immutable
+          yarn build:libs
+          yarn workspace @trezor/connect-webextension build
+          yarn workspace @trezor/connect-iframe build:core-module
+          yarn workspace @trezor/connect-explorer build:webextension
+
+      - name: Make Docker Script Executable
+        run: chmod +x ./docker/docker-connect-popup-ci.sh
+
+      - name: Run connect popup test
+        env:
+          URL: https://${{ inputs.DEV_SERVER_HOSTNAME }}/connect/${{ steps.extract_branch.outputs.branch }}/
+          TREZOR_CONNECT_SRC: https://${{ inputs.DEV_SERVER_HOSTNAME }}/connect/${{ steps.extract_branch.outputs.branch }}/
+          IS_WEBEXTENSION: true
+        run: |
+          ./docker/docker-connect-popup-ci.sh ${{ inputs.test-name }}
+
+      - name: Upload artifacts
+        # We upload test artifacts only if it fails and we use it to `Check Test Success` in next step.
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-artifacts-${{ inputs.test-name }}-${{ github.run_attempt }}
+          path: |
+            packages/connect-popup/e2e/screenshots
+            packages/connect-popup/test-results
+
+      - name: Check Test Success
+        run: |
+          # If there is `test-results` it means it has failed.
+          if [ -f "packages/connect-popup/test-results" ]; then
+            echo "Tests failed"
+            exit 1
+          fi

--- a/docker/docker-compose.connect-popup-ci.yml
+++ b/docker/docker-compose.connect-popup-ci.yml
@@ -8,7 +8,7 @@ services:
     # network_mode: bridge # this makes docker reuse existing networks
 
   test-run:
-    image: mcr.microsoft.com/playwright:focal
+    image: mcr.microsoft.com/playwright:v1.41.2-jammy
     container_name: explorer-test-runner
     ipc: host
     depends_on:

--- a/docker/docker-connect-popup-ci.sh
+++ b/docker/docker-connect-popup-ci.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+LOCAL_USER_ID="$(id -u "$USER")"
+export LOCAL_USER_ID
+export TEST_FILE=$1
+export URL=$URL
+export TREZOR_CONNECT_SRC=$TREZOR_CONNECT_SRC
+
+docker-compose -f ./docker/docker-compose.connect-popup-ci.yml up --build --abort-on-container-exit

--- a/packages/connect-popup/e2e/tests/browser-support.test.ts
+++ b/packages/connect-popup/e2e/tests/browser-support.test.ts
@@ -1,6 +1,7 @@
 import { test, expect, Page, devices } from '@playwright/test';
 import { ensureDirectoryExists } from '@trezor/node-utils';
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
+import { log, waitAndClick } from '../support/helpers';
 
 const url = process.env.URL || 'http://localhost:8088/';
 
@@ -62,7 +63,10 @@ test('outdated-browser', async ({ browser }) => {
     await popup.click('text=I acknowledge and wish to continue');
     // only after this check react renders
     await popup.waitForSelector('#reactRenderIn');
-    await popup.waitForSelector('text=Pair devices');
+    log('clicking on analytics continue button');
+    await waitAndClick(popup, ['@analytics/continue-button']);
+    // In Firefox it should display Install Bridge page.
+    await popup.getByRole('heading', { name: 'Install Bridge' });
     await popup.close({ runBeforeUnload: true });
     await page.close();
     await context.close();

--- a/packages/connect-popup/e2e/tests/popup-close.test.ts
+++ b/packages/connect-popup/e2e/tests/popup-close.test.ts
@@ -79,12 +79,10 @@ test.beforeAll(async () => {
         explorerPage = contexts.explorerPage;
         explorerUrl = contexts.explorerUrl;
 
-        if (connectSrc) {
-            await setConnectSettings(explorerPage, explorerUrl, {
-                trustedHost: false,
-                connectSrc,
-            });
-        }
+        await setConnectSettings(explorerPage, explorerUrl, {
+            trustedHost: false,
+            ...(connectSrc && { connectSrc }),
+        });
 
         await explorerPage.goto(`${explorerUrl}#/method/verifyMessage`);
         await explorerPage.waitForSelector("button[data-test='@submit-button']", {

--- a/packages/connect-web/src/channels/serviceworker-window.ts
+++ b/packages/connect-web/src/channels/serviceworker-window.ts
@@ -68,6 +68,7 @@ export class ServiceWorkerWindowChannel<
                     'https://connect.trezor.io',
                     'https://staging-connect.trezor.io',
                     'https://suite.corp.sldev.cz',
+                    'https://dev.suite.sldev.cz',
                     'http://localhost:8088',
                 ];
 


### PR DESCRIPTION
This PR implements Connect e2e tests using connect-explorer and popup for `web` and `webextension` from GitLab to GitHub Actions.


I would like to get this merged, and continue with the rest of the test that we want to migrate to GitHub in a followup like:

- `connect-popup legacy npm package`
- `connect legacy fws`
- `connect canary fws`


I would be cautious with tests since they are providing us very useful information and would like to see them behaving in production before getting rid of them from GitLab ci/test.yml.

Once we get rid of those tests in GitLab we will need to get the habit of looking at those tests in release branch in GitHub as well.

Some of the tests are flaky and GitHub makes it even more obvious, so it will force us to make them more robust. 


Related to https://github.com/trezor/trezor-suite/issues/11228  https://github.com/trezor/trezor-suite/issues/7916
