### PR TITLE
fix(connect): device acquired handling

### DIFF
--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -444,6 +444,7 @@ const initCoreInIframe = async (payload: PopupInit['payload']) => {
     reactEventBus.dispatch({ type: 'loading', message: 'waiting for iframe init' });
     await initMessageChannelWithIframe(payload, handleMessageInIframeMode);
     // done, popup is ready to handle incoming messages, waiting for handshake from iframe
+    reactEventBus.dispatch({ type: 'loading', message: 'waiting for handshake' });
 };
 
 // handle POPUP.HANDSHAKE message from iframe or npm-client

--- a/packages/connect-ui/src/index.tsx
+++ b/packages/connect-ui/src/index.tsx
@@ -53,6 +53,10 @@ export const ConnectUI = ({ postMessage, clearLegacyView }: ConnectUIProps) => {
         // set state
         if (message?.type === 'state-update') {
             setState(message.payload);
+
+            // do not add state-update messages to the list of messages
+            // it would mean Component gets set to null
+            return;
         }
 
         // set current view


### PR DESCRIPTION
1. Display prompt to select device when it's in an unacquired state

<img width="673" alt="Screenshot 2024-02-22 at 20 16 10" src="https://github.com/trezor/trezor-suite/assets/8833813/7bd6bb27-1fb9-4afb-b132-afacbc4f6123">

This probably worked before but somehow stopped, or maybe it was intentionally changed? @mroz22 

2. Display loading after opening the popup, before device is acquired. Previously there was just a blank screen, which is bad UX in case the init takes longer. Now we keep the loading spinner before we can display something else