### PR TITLE
feat(suite-native): token definitions redux logic

### DIFF
--- a/packages/suite-desktop/tsconfig.json
+++ b/packages/suite-desktop/tsconfig.json
@@ -1,8 +1,6 @@
 {
     "extends": "../../tsconfig.base.json",
-    "compilerOptions": {
-        "outDir": "./libDev"
-    },
+    "compilerOptions": { "outDir": "./libDev" },
     "include": ["./src", "./e2e", "**/*.json"],
     "references": []
 }

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx
@@ -103,7 +103,9 @@ export const TxDetailModal = ({ tx, rbfForm, onCancel }: TxDetailModalProps) => 
     );
     const account = useSelector(state => selectAccountByKey(state, accountKey));
     const network = account && getAccountNetwork(account);
-    const isPhishingTransaction = useSelector(state => selectIsPhishingTransaction(state, tx));
+    const isPhishingTransaction = useSelector(state =>
+        selectIsPhishingTransaction(state, tx.txid, accountKey),
+    );
 
     return (
         <StyledModal

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
@@ -146,7 +146,7 @@ export const TransactionItem = memo(
             );
         };
         const isPhishingTransaction = useSelector(state =>
-            selectIsPhishingTransaction(state, transaction),
+            selectIsPhishingTransaction(state, transaction.txid, accountKey),
         );
 
         const dataTestBase = `@transaction-item/${index}${

--- a/suite-common/wallet-core/src/index.ts
+++ b/suite-common/wallet-core/src/index.ts
@@ -27,3 +27,4 @@ export * from './token-definitions/tokenDefinitionsSelectors';
 export * from './token-definitions/tokenDefinitionsReducer';
 export * from './token-definitions/tokenDefinitionsThunks';
 export * from './token-definitions/tokenDefinitionsMiddleware';
+export * from './token-definitions/tokenDefinitionsTypes';

--- a/suite-common/wallet-core/src/token-definitions/tokenDefinitionsSelectors.ts
+++ b/suite-common/wallet-core/src/token-definitions/tokenDefinitionsSelectors.ts
@@ -1,4 +1,6 @@
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import { D, pipe } from '@mobily/ts-belt';
+
+import { NetworkSymbol, isEthereumBasedNetwork, networks } from '@suite-common/wallet-config';
 
 import { TokenDefinitionsRootState } from './tokenDefinitionsTypes';
 
@@ -12,3 +14,27 @@ export const selectSpecificTokenDefinition = (
     networkSymbol: NetworkSymbol,
     contractAddress: string,
 ) => state.wallet.tokenDefinitions?.[networkSymbol]?.[contractAddress];
+
+export const selectShouldFetchTokenDefinition = (
+    state: TokenDefinitionsRootState,
+    networkSymbol: NetworkSymbol,
+    contractAddress: string,
+) => {
+    const tokenDefinition = selectSpecificTokenDefinition(state, networkSymbol, contractAddress);
+    const network = networks[networkSymbol];
+
+    return isEthereumBasedNetwork(network) && (!tokenDefinition || tokenDefinition.error);
+};
+
+export const selectKnownNetworkTokens = (
+    state: TokenDefinitionsRootState,
+    networkSymbol: NetworkSymbol,
+) => {
+    const networkTokenDefinitions = selectTokenDefinitions(state, networkSymbol);
+
+    return pipe(
+        networkTokenDefinitions,
+        D.filter(tokenDefinition => !!tokenDefinition.isTokenKnown),
+        D.keys,
+    );
+};

--- a/suite-common/wallet-core/src/transactions/transactionsReducer.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsReducer.ts
@@ -5,7 +5,6 @@ import {
     findTransaction,
     getConfirmations,
     isPending,
-    getIsZeroValuePhishing,
     getIsPhishingTransaction,
 } from '@suite-common/wallet-utils';
 import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
@@ -288,8 +287,8 @@ export const selectTransactionConfirmations = (
     return getConfirmations(transaction, blockchainHeight);
 };
 
-export const selectIsTransactionZeroValuePhishing = (
-    state: TransactionsRootState,
+export const selectIsPhishingTransaction = (
+    state: TokenDefinitionsRootState & TransactionsRootState,
     txid: string,
     accountKey: AccountKey,
 ) => {
@@ -297,13 +296,6 @@ export const selectIsTransactionZeroValuePhishing = (
 
     if (!transaction) return false;
 
-    return getIsZeroValuePhishing(transaction);
-};
-
-export const selectIsPhishingTransaction = (
-    state: TokenDefinitionsRootState,
-    transaction: WalletAccountTransaction,
-) => {
     const tokenDefinitions = selectTokenDefinitions(state, transaction.symbol);
 
     if (!tokenDefinitions) return false;

--- a/suite-native/module-accounts-import/src/screens/AccountImportLoadingScreen.tsx
+++ b/suite-native/module-accounts-import/src/screens/AccountImportLoadingScreen.tsx
@@ -11,7 +11,8 @@ import {
     StackToStackCompositeScreenProps,
 } from '@suite-native/navigation';
 import TrezorConnect, { AccountInfo } from '@trezor/connect';
-import { TokenAddress } from '@suite-common/wallet-types';
+import { getTokenDefinitionThunk } from '@suite-common/wallet-core';
+import { networks } from '@suite-common/wallet-config';
 
 import { AccountImportLoader } from '../components/AccountImportLoader';
 import { useShowImportError } from '../useShowImportError';
@@ -85,18 +86,15 @@ export const AccountImportLoadingScreen = ({
             if (!ignore) {
                 if (fetchedAccountInfo?.success) {
                     if (networkSymbol === 'eth') {
-                        fetchedAccountInfo.payload.tokens?.forEach(token => {
+                        fetchedAccountInfo.payload.tokens?.forEach(token =>
                             dispatch(
-                                updateFiatRatesThunk({
-                                    ticker: {
-                                        symbol: 'eth',
-                                        tokenAddress: token.contract as TokenAddress,
-                                    },
-                                    rateType: 'current',
-                                    localCurrency: fiatCurrency,
+                                getTokenDefinitionThunk({
+                                    networkSymbol: 'eth',
+                                    chainId: networks.eth.chainId,
+                                    contractAddress: token.contract,
                                 }),
-                            );
-                        });
+                            ),
+                        );
                     }
                     setAccountInfo(fetchedAccountInfo.payload);
                 } else {

--- a/suite-native/state/package.json
+++ b/suite-native/state/package.json
@@ -30,6 +30,7 @@
         "@suite-native/module-settings": "workspace:*",
         "@suite-native/storage": "workspace:*",
         "@suite-native/toasts": "workspace:*",
+        "@suite-native/token-definitions": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/transport-native": "workspace:*",
         "@trezor/utils": "workspace:*",

--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -5,6 +5,7 @@ import {
     prepareBlockchainReducer,
     prepareDeviceReducer,
     prepareDiscoveryReducer,
+    prepareTokenDefinitionsReducer,
     prepareTransactionsReducer,
 } from '@suite-common/wallet-core';
 import { prepareFiatRatesReducer } from '@suite-native/fiat-rates';
@@ -36,6 +37,7 @@ const analyticsReducer = prepareAnalyticsReducer(extraDependencies);
 const messageSystemReducer = prepareMessageSystemReducer(extraDependencies);
 const deviceReducer = prepareDeviceReducer(extraDependencies);
 const discoveryReducer = prepareDiscoveryReducer(extraDependencies);
+const tokenDefinitionsReducer = prepareTokenDefinitionsReducer(extraDependencies);
 
 export const prepareRootReducers = async () => {
     const appSettingsPersistedReducer = await preparePersistReducer({
@@ -51,6 +53,7 @@ export const prepareRootReducers = async () => {
         fiat: fiatRatesReducer,
         transactions: transactionsReducer,
         discovery: discoveryReducer,
+        tokenDefinitions: tokenDefinitionsReducer,
     });
 
     const walletPersistedReducer = await preparePersistReducer({

--- a/suite-native/state/src/store.ts
+++ b/suite-native/state/src/store.ts
@@ -6,6 +6,7 @@ import { prepareButtonRequestMiddleware, prepareDeviceMiddleware } from '@suite-
 import { prepareDiscoveryMiddleware } from '@suite-native/discovery';
 import { prepareTransactionCacheMiddleware } from '@suite-native/accounts';
 import { blockchainMiddleware } from '@suite-native/blockchain';
+import { tokenDefinitionsMiddleware } from '@suite-native/token-definitions';
 
 import { extraDependencies } from './extraDependencies';
 import { prepareRootReducers } from './reducers';
@@ -18,6 +19,7 @@ const middlewares: Middleware[] = [
     prepareButtonRequestMiddleware(extraDependencies),
     prepareDiscoveryMiddleware(extraDependencies),
     prepareTransactionCacheMiddleware(extraDependencies),
+    tokenDefinitionsMiddleware,
 ];
 
 if (__DEV__) {

--- a/suite-native/state/tsconfig.json
+++ b/suite-native/state/tsconfig.json
@@ -33,6 +33,7 @@
         { "path": "../module-settings" },
         { "path": "../storage" },
         { "path": "../toasts" },
+        { "path": "../token-definitions" },
         { "path": "../../packages/connect" },
         {
             "path": "../../packages/transport-native"

--- a/suite-native/token-definitions/package.json
+++ b/suite-native/token-definitions/package.json
@@ -1,0 +1,18 @@
+{
+    "name": "@suite-native/token-definitions",
+    "version": "1.0.0",
+    "private": true,
+    "license": "See LICENSE.md in repo root",
+    "sideEffects": false,
+    "main": "src/index",
+    "scripts": {
+        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "type-check": "yarn g:tsc --build"
+    },
+    "dependencies": {
+        "@reduxjs/toolkit": "1.9.5",
+        "@suite-common/redux-utils": "workspace:*",
+        "@suite-common/wallet-config": "workspace:*",
+        "@suite-common/wallet-core": "workspace:*"
+    }
+}

--- a/suite-native/token-definitions/src/index.ts
+++ b/suite-native/token-definitions/src/index.ts
@@ -1,0 +1,1 @@
+export * from './tokenDefinitionsMiddleware';

--- a/suite-native/token-definitions/src/tokenDefinitionsMiddleware.ts
+++ b/suite-native/token-definitions/src/tokenDefinitionsMiddleware.ts
@@ -1,0 +1,79 @@
+import { isAnyOf } from '@reduxjs/toolkit';
+
+import { createMiddleware } from '@suite-common/redux-utils';
+import { getNetworkFeatures, isEthereumBasedNetwork, networks } from '@suite-common/wallet-config';
+import {
+    accountsActions,
+    getTokenDefinitionThunk,
+    selectShouldFetchTokenDefinition,
+} from '@suite-common/wallet-core';
+
+const isAccountChangingAction = isAnyOf(
+    accountsActions.createAccount,
+    accountsActions.updateAccount,
+);
+
+export const tokenDefinitionsMiddleware = createMiddleware(
+    (action, { dispatch, next, getState }) => {
+        // The action changes has to be stored before evaluated in this middleware,
+        // because it needs to check the latest state to decide if we should fetch token definitions.
+        next(action);
+
+        if (isAccountChangingAction(action)) {
+            const { symbol } = action.payload;
+
+            const networkFeatures = getNetworkFeatures(symbol);
+
+            if (networkFeatures.includes('token-definitions')) {
+                action.payload.tokens?.forEach(token => {
+                    const contractAddress = token.contract;
+
+                    const shouldFetchTokenDefinition = selectShouldFetchTokenDefinition(
+                        getState(),
+                        symbol,
+                        contractAddress,
+                    );
+
+                    const network = networks[symbol];
+                    if (shouldFetchTokenDefinition && isEthereumBasedNetwork(network)) {
+                        dispatch(
+                            getTokenDefinitionThunk({
+                                networkSymbol: symbol,
+                                chainId: network.chainId,
+                                contractAddress,
+                            }),
+                        );
+                    }
+                });
+            }
+        }
+
+        // Fetch token definitions for each token of the suite-native discovery created account.
+        if (accountsActions.createIndexLabeledAccount.match(action)) {
+            const { tokens, symbol } = action.payload;
+
+            const network = networks[symbol];
+            if (isEthereumBasedNetwork(network)) {
+                const { chainId } = network;
+                tokens?.forEach(token => {
+                    const shouldFetchTokenDefinition = selectShouldFetchTokenDefinition(
+                        getState(),
+                        symbol,
+                        token.contract,
+                    );
+
+                    if (shouldFetchTokenDefinition)
+                        dispatch(
+                            getTokenDefinitionThunk({
+                                networkSymbol: symbol,
+                                contractAddress: token.contract,
+                                chainId,
+                            }),
+                        );
+                });
+            }
+        }
+
+        return action;
+    },
+);

--- a/suite-native/token-definitions/tsconfig.json
+++ b/suite-native/token-definitions/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": { "outDir": "libDev" },
+    "references": [
+        {
+            "path": "../../suite-common/redux-utils"
+        },
+        {
+            "path": "../../suite-common/wallet-config"
+        },
+        {
+            "path": "../../suite-common/wallet-core"
+        }
+    ]
+}

--- a/suite-native/transactions/src/components/TransactionDetail/TransactionDetailData.tsx
+++ b/suite-native/transactions/src/components/TransactionDetail/TransactionDetailData.tsx
@@ -7,12 +7,13 @@ import { useFormatters } from '@suite-common/formatters';
 import { CryptoAmountFormatter, CryptoToFiatAmountFormatter } from '@suite-native/formatters';
 import {
     selectTransactionBlockTimeById,
-    selectIsTransactionZeroValuePhishing,
     TransactionsRootState,
+    selectIsPhishingTransaction,
 } from '@suite-common/wallet-core';
 import { EthereumTokenTransfer, WalletAccountTransaction } from '@suite-native/ethereum-tokens';
 import { Translation } from '@suite-native/intl';
 import { Link } from '@suite-native/link';
+import { TokenDefinitionsRootState } from '@suite-common/wallet-core';
 
 import { TransactionDetailSummary } from './TransactionDetailSummary';
 import { TransactionDetailRow } from './TransactionDetailRow';
@@ -35,8 +36,9 @@ export const TransactionDetailData = ({
         selectTransactionBlockTimeById(state, transaction.txid, accountKey),
     );
 
-    const isZeroValuePhishing = useSelector((state: TransactionsRootState) =>
-        selectIsTransactionZeroValuePhishing(state, transaction.txid, accountKey),
+    const isPhishingTransaction = useSelector(
+        (state: TokenDefinitionsRootState & TransactionsRootState) =>
+            selectIsPhishingTransaction(state, transaction.txid, accountKey),
     );
 
     const transactionTokensCount = transaction.tokens.length;
@@ -50,7 +52,7 @@ export const TransactionDetailData = ({
     return (
         <>
             <VStack>
-                {isZeroValuePhishing && (
+                {isPhishingTransaction && (
                     <AlertBox
                         variant="error"
                         isStandalone

--- a/suite-native/transactions/src/components/TransactionsList/TransactionListItemContainer.tsx
+++ b/suite-native/transactions/src/components/TransactionsList/TransactionListItemContainer.tsx
@@ -15,9 +15,10 @@ import {
 import { Badge, Box, HStack, Text } from '@suite-native/atoms';
 import { useFormatters } from '@suite-common/formatters';
 import {
+    selectIsPhishingTransaction,
     selectIsTransactionPending,
-    selectIsTransactionZeroValuePhishing,
     selectTransactionBlockTimeById,
+    TokenDefinitionsRootState,
     TransactionsRootState,
 } from '@suite-common/wallet-core';
 import { NetworkSymbol } from '@suite-common/wallet-config';
@@ -161,8 +162,9 @@ export const TransactionListItemContainer = ({
         selectIsTransactionPending(state, txid, accountKey),
     );
 
-    const isZeroValuePhishing = useSelector((state: TransactionsRootState) =>
-        selectIsTransactionZeroValuePhishing(state, txid, accountKey),
+    const isPhishingTransaction = useSelector(
+        (state: TokenDefinitionsRootState & TransactionsRootState) =>
+            selectIsPhishingTransaction(state, txid, accountKey),
     );
 
     const iconColor: Color = isTransactionPending ? 'backgroundAlertYellowBold' : 'iconSubdued';
@@ -187,7 +189,7 @@ export const TransactionListItemContainer = ({
                     <HStack flexDirection="row" alignItems="center" spacing="extraSmall">
                         <Box style={applyStyle(titleStyle)}>
                             <Text variant="body">{transactionTitle}</Text>
-                            {isZeroValuePhishing && (
+                            {isPhishingTransaction && (
                                 <Badge
                                     label={translate('transactions.phishing.badge')}
                                     size="small"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -101,6 +101,9 @@
         { "path": "suite-native/test-utils" },
         { "path": "suite-native/theme" },
         { "path": "suite-native/toasts" },
+        {
+            "path": "suite-native/token-definitions"
+        },
         { "path": "suite-native/transactions" },
         { "path": "suite-native/video-assets" },
         { "path": "packages/analytics" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8761,6 +8761,7 @@ __metadata:
     "@suite-native/module-settings": "workspace:*"
     "@suite-native/storage": "workspace:*"
     "@suite-native/toasts": "workspace:*"
+    "@suite-native/token-definitions": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/transport-native": "workspace:*"
     "@trezor/utils": "workspace:*"
@@ -8838,6 +8839,17 @@ __metadata:
     react-native-gesture-handler: "npm:2.15.0"
     react-native-reanimated: "npm:3.7.0-nightly-20240101-9d365ae7b"
     react-native-safe-area-context: "npm:4.9.0"
+  languageName: unknown
+  linkType: soft
+
+"@suite-native/token-definitions@workspace:*, @suite-native/token-definitions@workspace:suite-native/token-definitions":
+  version: 0.0.0-use.local
+  resolution: "@suite-native/token-definitions@workspace:suite-native/token-definitions"
+  dependencies:
+    "@reduxjs/toolkit": "npm:1.9.5"
+    "@suite-common/redux-utils": "workspace:*"
+    "@suite-common/wallet-config": "workspace:*"
+    "@suite-common/wallet-core": "workspace:*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION

## Description
- token definitions reducer + middleware used in suite-native
- on creating new account the token definitions are downloaded first before trying to fetch fiat rates
- if is account with tokens discovered, the definitions are fetched from the middleware

## Related Issue

Closes #8434
Closes #11308 

## Screenshots:
Token definitions are correctly handled in the redux state, app works as expected:
![Screenshot 2024-02-22 at 14 52 09](https://github.com/trezor/trezor-suite/assets/26143964/ccad96d2-2935-447f-a552-d72bbf26f516)
