### PR TITLE
chore(suite-native): analytics for add new account

### DIFF
--- a/suite-native/analytics/src/constants.ts
+++ b/suite-native/analytics/src/constants.ts
@@ -26,4 +26,5 @@ export enum EventType {
     ConnectDevice = 'device_connect',
     UnsupportedDevice = 'unsupported_device',
     CoinDiscovery = 'coin_discovery',
+    CoinDiscoveryNewAccount = 'coin_discovery/new_account',
 }

--- a/suite-native/analytics/src/events.ts
+++ b/suite-native/analytics/src/events.ts
@@ -1,6 +1,6 @@
 import { FiatCurrencyCode } from '@suite-common/suite-config';
 import { UNIT_ABBREVIATION } from '@suite-common/suite-constants';
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import { AccountType, NetworkSymbol } from '@suite-common/wallet-config';
 import { TokenAddress, TokenSymbol } from '@suite-common/wallet-types';
 import { DeviceModelInternal, VersionArray } from '@trezor/connect';
 
@@ -177,5 +177,13 @@ export type SuiteNativeAnalyticsEvent =
               loadDuration: number;
           } & {
               [key in NetworkSymbol]: number;
+          };
+      }
+    | {
+          type: EventType.CoinDiscoveryNewAccount;
+          payload: {
+              symbol: NetworkSymbol;
+              path: string;
+              type: AccountType;
           };
       };

--- a/suite-native/discovery/src/discoveryThunks.ts
+++ b/suite-native/discovery/src/discoveryThunks.ts
@@ -157,6 +157,15 @@ const addAccountsByDescriptorThunk = createThunk(
                     accountInfo,
                 }),
             );
+
+            analytics.report({
+                type: EventType.CoinDiscoveryNewAccount,
+                payload: {
+                    symbol: bundleItem.coin,
+                    path: bundleItem.path,
+                    type: bundleItem.accountType,
+                },
+            });
         }
     },
 );


### PR DESCRIPTION
sending event with: 

```
  _c_type: 'coin_discovery/new_account'
  type: 'normal',
  path: "m/84'/0'/1",
  symbol: 'btc'
```

## Related Issue

Resolve #11104

