### PR TITLE
Fix database migration test

### DIFF
--- a/packages/suite-web/e2e/tests/suite/database-migration.test.ts
+++ b/packages/suite-web/e2e/tests/suite/database-migration.test.ts
@@ -87,7 +87,7 @@ describe('Database migration', () => {
         cy.getTestElement('@wallet/menu/wallet-send').click();
         cy.getTestElement(btcAddressInputSelector).should('be.visible').type(testData.btcAddress);
         cy.wait(500); // wait has to be for a state save to happen
-        cy.getTestElement('@account-subpage/back').last().click();
+        cy.getTestElement('@wallet/menu/close-button').last().click();
 
         // check and store address of first btc tx
         cy.get('[data-test^="@metadata/outputLabel"] > span').should('be.visible');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix database migration test by using the correct test id. The test runs on two versions of Suite, the older one has a different layout and thus some test ids differ. `@wallet/menu/close-button` exists in v22.7, current `develop` uses `@account-subpage/back`.
