### PR TITLE
chore(suite-native): testnet cannot be imported as bitcoin account

### DIFF
--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -130,6 +130,10 @@ export const en = {
                     description: 'To check the balance of your coin, scan your public key (XPUB).',
                     hintButton: 'Where to find it?',
                 },
+                xpub: {
+                    title: 'Incompatible XPUB detected',
+                    description: "Provided XPUB doesn't correspond with selected network.",
+                },
             },
             input: {
                 label: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Works only for bitcoin and its testnets now.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/11029

## Screenshots:
https://github.com/trezor/trezor-suite/assets/36101761/2473899f-cab5-4570-a625-8905ba2b1903

