### PR TITLE
Fix/evm rates

### DIFF
--- a/packages/suite/src/hooks/suite/useFiatFromCryptoValue.ts
+++ b/packages/suite/src/hooks/suite/useFiatFromCryptoValue.ts
@@ -39,8 +39,8 @@ export const useFiatFromCryptoValue = ({
     const targetCurrency = fiatCurrency ?? localCurrency;
     const currentFiatRates = coins.find(f =>
         tokenAddress
-            ? f.tokenAddress?.toLowerCase() === tokenAddress?.toLowerCase()
-            : f.symbol.toLowerCase() === symbol.toLowerCase(),
+            ? f.tokenAddress?.toLowerCase() === tokenAddress.toLowerCase()
+            : f.symbol.toLowerCase() === symbol.toLowerCase() && !f.tokenAddress,
     )?.current;
 
     const ratesSource = useCustomSource ? source : currentFiatRates?.rates;


### PR DESCRIPTION
## Description

Fixes:
- `ETH` showing fiat rate of the first fetched token

The bug is there from January release. However, thanks to the possibility, that token fiat rate can now be fetched before it is fetched by "periodic" fiat rate method. It simply takes price of first token and uses it for `ETH` / `MATIC` native coins because the previous condition just checked that `symbol` is correct but not that it is native token.
Previously there was `ETH` in the array on first position, now it can be on random position.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
![Screenshot 2024-02-26 at 21 50 41](https://github.com/trezor/trezor-suite/assets/33235762/00e9dce9-f572-4b5f-820e-631bed508ab7)
