### PR TITLE
chore(suite-native): fix name of selector to be less confusing

### DIFF
--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -350,7 +350,10 @@ export const selectDevicelessAccounts = (state: AccountsRootState & DeviceRootSt
     ) as Account[];
 };
 
-export const selectAreAllDevicesDisconnectedOrAccountless = (
+/**
+ * Return true only if there is just a portfolio tracker device and that has empty accounts.
+ */
+export const selectIsDeviceDiscoveryEmptyAndNoPhysicalDeviceConnected = (
     state: AccountsRootState & DeviceRootState & DiscoveryRootState,
 ) => {
     const isDeviceDiscoveryEmpty = selectIsDeviceDiscoveryEmpty(state);

--- a/suite-native/device-manager/src/components/DeviceSwitch.tsx
+++ b/suite-native/device-manager/src/components/DeviceSwitch.tsx
@@ -6,7 +6,7 @@ import { Icon } from '@suite-common/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import {
     selectDeviceId,
-    selectAreAllDevicesDisconnectedOrAccountless,
+    selectIsDeviceDiscoveryEmptyAndNoPhysicalDeviceConnected,
 } from '@suite-common/wallet-core';
 
 import { SCREEN_HEADER_HEIGHT } from '../constants';
@@ -43,8 +43,8 @@ const switchWrapperStyle = prepareNativeStyle(_ => ({
 export const DeviceSwitch = () => {
     const { applyStyle } = useNativeStyles();
 
-    const areAllDevicesDisconnectedOrAccountless = useSelector(
-        selectAreAllDevicesDisconnectedOrAccountless,
+    const isDeviceDiscoveryEmptyAndNoPhysicalDeviceConnected = useSelector(
+        selectIsDeviceDiscoveryEmptyAndNoPhysicalDeviceConnected,
     );
     const deviceId = useSelector(selectDeviceId);
 
@@ -59,7 +59,11 @@ export const DeviceSwitch = () => {
             <HStack justifyContent="space-between" alignItems="center" spacing="medium">
                 <Box style={applyStyle(switchStyle, { isDeviceManagerVisible })}>
                     <DeviceItemContent
-                        deviceId={areAllDevicesDisconnectedOrAccountless ? undefined : deviceId}
+                        deviceId={
+                            isDeviceDiscoveryEmptyAndNoPhysicalDeviceConnected
+                                ? undefined
+                                : deviceId
+                        }
                         headerTextVariant="highlight"
                         isPortfolioLabelDisplayed={false}
                     />

--- a/suite-native/module-home/src/screens/HomeScreen/components/EmptyHomeRenderer.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/EmptyHomeRenderer.tsx
@@ -2,7 +2,7 @@ import { useSelector } from 'react-redux';
 
 import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
 import {
-    selectAreAllDevicesDisconnectedOrAccountless,
+    selectIsDeviceDiscoveryEmptyAndNoPhysicalDeviceConnected,
     selectIsDeviceAuthorized,
     selectIsPortfolioTrackerDevice,
 } from '@suite-common/wallet-core';
@@ -17,8 +17,8 @@ export const EmptyHomeRenderer = () => {
 
     const isDeviceAuthorized = useSelector(selectIsDeviceAuthorized);
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
-    const areAllDevicesDisconnectedOrAccountless = useSelector(
-        selectAreAllDevicesDisconnectedOrAccountless,
+    const isDeviceDiscoveryEmptyAndNoPhysicalDeviceConnected = useSelector(
+        selectIsDeviceDiscoveryEmptyAndNoPhysicalDeviceConnected,
     );
     const isDeviceReadyToUse = useSelector(selectIsDeviceReadyToUse);
 
@@ -30,7 +30,7 @@ export const EmptyHomeRenderer = () => {
 
     if (isUsbDeviceConnectFeatureEnabled) {
         // Crossroads should be displayed only if there is no real device connected and portfolio tracker has no accounts.
-        if (areAllDevicesDisconnectedOrAccountless) {
+        if (isDeviceDiscoveryEmptyAndNoPhysicalDeviceConnected) {
             return <EmptyPortfolioCrossroads />;
         }
 


### PR DESCRIPTION
- All devices disconnected OR account-less wasn't correct, there is AND operator.