### PR TITLE
Make commit message check work with other remotes

### DIFF
--- a/.github/workflows/commit-messages-check.yml
+++ b/.github/workflows/commit-messages-check.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Fetch base and current branch
         run: |
           git fetch --no-tags origin ${{ github.base_ref }}
-          git fetch --no-tags origin ${{ github.head_ref }}:${{ github.head_ref }}
+          git fetch --no-tags ${{github.event.pull_request.head.repo.clone_url}} ${{ github.head_ref }}:${{ github.head_ref }}
           git switch ${{ github.head_ref }}
 
       - name: Check commit messages


### PR DESCRIPTION
Should fix [this](https://github.com/trezor/trezor-suite/actions/runs/8064705698/job/22033672899?pr=11187). The commit check did not work properly when a pull request was coming from a fork as it was expecting the origin to always be the Trezor repo. Now it is dynamic.

Successful run in a test branch: https://github.com/trezor/trezor-suite/actions/runs/8082139119/job/22082263279
![Screenshot 2024-02-28 at 15 49 36](https://github.com/trezor/trezor-suite/assets/42465546/d57aaa7e-9e13-4281-83ed-8f08b19b1282)

