### PR TITLE
chore(suite-native): delete always falsy condition

### DIFF
--- a/suite-native/module-home/src/screens/HomeScreen/components/PortfolioGraph.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/PortfolioGraph.tsx
@@ -6,10 +6,6 @@ import { useSetAtom } from 'jotai';
 import { useGraphForAllDeviceAccounts, Graph, TimeSwitch } from '@suite-native/graph';
 import { selectFiatCurrency } from '@suite-native/module-settings';
 import { VStack } from '@suite-native/atoms';
-import {
-    selectIsDeviceDiscoveryActive,
-    selectIsDeviceDiscoveryEmpty,
-} from '@suite-common/wallet-core';
 import { useIsDiscoveryDurationTooLong } from '@suite-native/discovery';
 
 import {
@@ -24,8 +20,6 @@ export type PortfolioGraphRef = {
 
 export const PortfolioGraph = forwardRef<PortfolioGraphRef>((_props, ref) => {
     const fiatCurrency = useSelector(selectFiatCurrency);
-    const isDiscoveryActive = useSelector(selectIsDeviceDiscoveryActive);
-    const isDeviceDiscoveryEmpty = useSelector(selectIsDeviceDiscoveryEmpty);
 
     const loadingTakesLongerThanExpected = useIsDiscoveryDurationTooLong();
 
@@ -55,8 +49,6 @@ export const PortfolioGraph = forwardRef<PortfolioGraphRef>((_props, ref) => {
         }),
         [refetch],
     );
-
-    if (isDeviceDiscoveryEmpty && isDiscoveryActive) return null;
 
     return (
         <VStack spacing="large">


### PR DESCRIPTION
- isDeviceDiscoveryEmpty && isDiscoveryActive cant't be true, because isDeviceDiscoveryEmpty includes negation of isDiscoveryActive

```
isDeviceDiscoveryEmpty = isDeviceAccountless && !isDiscoveryActive

isDeviceAccountless && !isDiscoveryActive && isDiscoveryActive = !isDiscoveryActive && isDiscoveryActive
!isDiscoveryActive && isDiscoveryActive = false
```

Other thing is that PortfolioGraph is never rendered with  `isDeviceDiscoveryEmpty === false` https://github.com/trezor/trezor-suite/blob/chore/remove-dead-code/suite-native/module-home/src/screens/HomeScreen/HomeScreen.tsx/#L28