### PR TITLE
fix: from g:tsx to local tsx in prepublish script

### DIFF
--- a/packages/blockchain-link-types/package.json
+++ b/packages/blockchain-link-types/package.json
@@ -12,8 +12,8 @@
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
         "type-check": "yarn g:tsc --build",
         "build:lib": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json",
-        "prepublishOnly": "yarn g:tsx ../../scripts/prepublishNPM.js",
-        "prepublish": "yarn g:tsx ../../scripts/prepublish.js"
+        "prepublishOnly": "yarn tsx ../../scripts/prepublishNPM.js",
+        "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "dependencies": {
         "@solana/web3.js": "^1.90.0",
@@ -22,6 +22,7 @@
         "socks-proxy-agent": "6.1.1"
     },
     "devDependencies": {
-        "ripple-lib": "^1.10.1"
+        "ripple-lib": "^1.10.1",
+        "tsx": "^4.7.0"
     }
 }

--- a/packages/blockchain-link-utils/package.json
+++ b/packages/blockchain-link-utils/package.json
@@ -13,8 +13,8 @@
         "test:unit": "yarn g:jest -c ../../jest.config.base.js",
         "type-check": "yarn g:tsc --build",
         "build:lib": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json",
-        "prepublishOnly": "yarn g:tsx ../../scripts/prepublishNPM.js",
-        "prepublish": "yarn g:tsx ../../scripts/prepublish.js"
+        "prepublishOnly": "yarn tsx ../../scripts/prepublishNPM.js",
+        "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "dependencies": {
         "@mobily/ts-belt": "^3.13.1",
@@ -24,7 +24,8 @@
     },
     "devDependencies": {
         "@trezor/blockchain-link-types": "workspace:*",
-        "@trezor/type-utils": "workspace:*"
+        "@trezor/type-utils": "workspace:*",
+        "tsx": "^4.7.0"
     },
     "peerDependencies": {
         "tslib": "^2.6.2"

--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -48,8 +48,8 @@
         "test:unit": "yarn g:jest --verbose -c jest.config.unit.js",
         "test:integration": "yarn g:jest -c jest.config.integration.js",
         "type-check": "yarn g:tsc --build tsconfig.json",
-        "prepublishOnly": "yarn g:tsx ../../scripts/prepublishNPM.js",
-        "prepublish": "yarn g:tsx ../../scripts/prepublish.js"
+        "prepublishOnly": "yarn tsx ../../scripts/prepublishNPM.js",
+        "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "devDependencies": {
         "@trezor/e2e-utils": "workspace:*",
@@ -57,6 +57,7 @@
         "fs-extra": "^11.2.0",
         "html-webpack-plugin": "^5.6.0",
         "tiny-worker": "^2.3.0",
+        "tsx": "^4.7.0",
         "webpack": "^5.90.1",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^4.15.1",

--- a/packages/connect-common/package.json
+++ b/packages/connect-common/package.json
@@ -35,8 +35,8 @@
         "test:unit": "yarn g:jest",
         "build:lib": "yarn g:rimraf lib && yarn g:tsc --build ./tsconfig.lib.json",
         "type-check": "yarn g:tsc --build tsconfig.json",
-        "prepublishOnly": "yarn g:tsx ../../scripts/prepublishNPM.js",
-        "prepublish": "yarn g:tsx ../../scripts/prepublish.js"
+        "prepublishOnly": "yarn tsx ../../scripts/prepublishNPM.js",
+        "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "dependencies": {
         "@trezor/env-utils": "workspace:*",
@@ -44,5 +44,8 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
+    },
+    "devDependencies": {
+        "tsx": "^4.7.0"
     }
 }

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -35,8 +35,8 @@
         "build:webextension": "TS_NODE_PROJECT=\"tsconfig.lib.json\" yarn webpack --config ./webpack/prod.webpack.config.ts",
         "build": "yarn g:rimraf build && yarn build:inline && yarn build:webextension",
         "test:e2e": "yarn playwright install && yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts",
-        "prepublishOnly": "yarn g:tsx ../../scripts/prepublishNPM.js",
-        "prepublish": "yarn g:tsx ../../scripts/prepublish.js"
+        "prepublishOnly": "yarn tsx ../../scripts/prepublishNPM.js",
+        "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "dependencies": {
         "@trezor/connect": "workspace:*",
@@ -54,6 +54,7 @@
         "html-webpack-plugin": "^5.6.0",
         "selfsigned": "^2.4.1",
         "terser-webpack-plugin": "^5.3.9",
+        "tsx": "^4.7.0",
         "webpack": "^5.90.1",
         "webpack-cli": "^5.1.4",
         "webpack-merge": "^5.10.0",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -45,8 +45,8 @@
         "version:major": "yarn g:tsx scripts/bump-version.ts major",
         "test:e2e:web": "ts-node -O '{\"module\": \"commonjs\", \"moduleResolution\": \"node\"}' ./e2e/run.ts web",
         "test:e2e:node": "ts-node -O '{\"module\": \"commonjs\", \"moduleResolution\": \"node\"}' ./e2e/run.ts node",
-        "prepublishOnly": "yarn g:tsx ../../scripts/prepublishNPM.js",
-        "prepublish": "yarn g:tsx ../../scripts/prepublish.js"
+        "prepublishOnly": "yarn tsx ../../scripts/prepublishNPM.js",
+        "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "dependencies": {
         "@ethereumjs/common": "^4.2.0",
@@ -83,6 +83,7 @@
         "karma-sourcemap-loader": "^0.4.0",
         "karma-webpack": "^5.0.1",
         "ts-node": "^10.9.1",
+        "tsx": "^4.7.0",
         "webpack": "^5.90.1",
         "ws": "^8.16.0"
     },

--- a/packages/env-utils/package.json
+++ b/packages/env-utils/package.json
@@ -24,8 +24,8 @@
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
         "type-check": "yarn g:tsc --build",
         "build:lib": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json",
-        "prepublishOnly": "yarn g:tsx ../../scripts/prepublishNPM.js",
-        "prepublish": "yarn g:tsx ../../scripts/prepublish.js"
+        "prepublishOnly": "yarn tsx ../../scripts/prepublishNPM.js",
+        "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "dependencies": {
         "expo-constants": "15.4.5",
@@ -43,5 +43,8 @@
         "react-native": {
             "optional": true
         }
+    },
+    "devDependencies": {
+        "tsx": "^4.7.0"
     }
 }

--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -30,8 +30,8 @@
         "build:lib": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json",
         "update:schema": "yarn workspace @trezor/schema-utils codegen $(pwd)/src/messages.ts > src/messages-schema.ts && yarn g:prettier --write src/messages-schema.ts && yarn g:eslint --fix src/messages-schema.ts",
         "update:protobuf": "./scripts/protobuf-build.sh && yarn g:prettier --write \"{messages.json,src/messages.ts}\" && yarn g:eslint --fix src/messages.ts",
-        "prepublishOnly": "yarn g:tsx ../../scripts/prepublishNPM.js",
-        "prepublish": "yarn g:tsx ../../scripts/prepublish.js"
+        "prepublishOnly": "yarn tsx ../../scripts/prepublishNPM.js",
+        "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "dependencies": {
         "@trezor/schema-utils": "workspace:*",
@@ -39,7 +39,8 @@
         "protobufjs": "7.2.6"
     },
     "devDependencies": {
-        "protobufjs-cli": "^1.1.2"
+        "protobufjs-cli": "^1.1.2",
+        "tsx": "^4.7.0"
     },
     "peerDependencies": {
         "tslib": "^2.6.2"

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -24,10 +24,13 @@
         "test:unit": "yarn g:jest -c ../../jest.config.base.js",
         "type-check": "yarn g:tsc --build",
         "build:lib": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json",
-        "prepublishOnly": "yarn g:tsx ../../scripts/prepublishNPM.js",
-        "prepublish": "yarn g:tsx ../../scripts/prepublish.js"
+        "prepublishOnly": "yarn tsx ../../scripts/prepublishNPM.js",
+        "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
+    },
+    "devDependencies": {
+        "tsx": "^4.7.0"
     }
 }

--- a/packages/schema-utils/package.json
+++ b/packages/schema-utils/package.json
@@ -17,12 +17,13 @@
         "type-check": "yarn g:tsc --build",
         "build:lib": "rimraf ./lib && yarn g:tsc --build tsconfig.lib.json",
         "codegen": "ts-node --skip-project ./src/codegen.ts",
-        "prepublishOnly": "yarn g:tsx ../../scripts/prepublishNPM.js",
-        "prepublish": "yarn g:tsx ../../scripts/prepublish.js"
+        "prepublishOnly": "yarn tsx ../../scripts/prepublishNPM.js",
+        "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "devDependencies": {
         "@sinclair/typebox-codegen": "^0.8.13",
-        "ts-node": "^10.9.2"
+        "ts-node": "^10.9.2",
+        "tsx": "^4.7.0"
     },
     "dependencies": {
         "@sinclair/typebox": "^0.31.28",

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -39,8 +39,8 @@
         "publish:lib": "./scripts/publish-lib.sh",
         "test:unit": "jest",
         "test:e2e": "ts-node -O '{\"module\": \"commonjs\", \"esModuleInterop\": true}' ./e2e/run.ts",
-        "prepublishOnly": "yarn g:tsx ../../scripts/prepublishNPM.js",
-        "prepublish": "yarn g:tsx ../../scripts/prepublish.js"
+        "prepublishOnly": "yarn tsx ../../scripts/prepublishNPM.js",
+        "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "devDependencies": {
         "@trezor/trezor-user-env-link": "workspace:*",
@@ -48,7 +48,8 @@
         "@types/sharedworker": "^0.0.111",
         "@types/w3c-web-usb": "^1.0.10",
         "jest": "29.7.0",
-        "ts-node": "^10.9.1"
+        "ts-node": "^10.9.1",
+        "tsx": "^4.7.0"
     },
     "dependencies": {
         "@trezor/protobuf": "workspace:*",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -27,10 +27,13 @@
         "test:unit": "yarn g:jest --verbose -c ../../jest.config.base.js",
         "type-check": "yarn g:tsc --build tsconfig.json",
         "build:lib": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json",
-        "prepublishOnly": "yarn g:tsx ../../scripts/prepublishNPM.js",
-        "prepublish": "yarn g:tsx ../../scripts/prepublish.js"
+        "prepublishOnly": "yarn tsx ../../scripts/prepublishNPM.js",
+        "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
+    },
+    "devDependencies": {
+        "tsx": "^4.7.0"
     }
 }

--- a/packages/utxo-lib/package.json
+++ b/packages/utxo-lib/package.json
@@ -32,8 +32,8 @@
         "test:unit": "yarn g:jest --verbose -c jest.config.js",
         "type-check": "yarn g:tsc --build tsconfig.json",
         "build:lib": "yarn g:rimraf lib && yarn g:tsc --build ./tsconfig.lib.json",
-        "prepublishOnly": "yarn g:tsx ../../scripts/prepublishNPM.js",
-        "prepublish": "yarn g:tsx ../../scripts/prepublish.js"
+        "prepublishOnly": "yarn tsx ../../scripts/prepublishNPM.js",
+        "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "dependencies": {
         "@trezor/utils": "workspace:*",
@@ -62,7 +62,8 @@
         "@types/create-hash": "^1.2.6",
         "@types/create-hmac": "^1.1.2",
         "@types/wif": "^2.0.5",
-        "minimaldata": "^1.0.2"
+        "minimaldata": "^1.0.2",
+        "tsx": "^4.7.0"
     },
     "peerDependencies": {
         "tslib": "^2.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9640,6 +9640,7 @@ __metadata:
     "@trezor/utxo-lib": "workspace:*"
     ripple-lib: "npm:^1.10.1"
     socks-proxy-agent: "npm:6.1.1"
+    tsx: "npm:^4.7.0"
   languageName: unknown
   linkType: soft
 
@@ -9653,6 +9654,7 @@ __metadata:
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     bignumber.js: "npm:^9.1.2"
+    tsx: "npm:^4.7.0"
   peerDependencies:
     tslib: ^2.6.2
   languageName: unknown
@@ -9678,6 +9680,7 @@ __metadata:
     ripple-lib: "npm:^1.10.1"
     socks-proxy-agent: "npm:6.1.1"
     tiny-worker: "npm:^2.3.0"
+    tsx: "npm:^4.7.0"
     webpack: "npm:^5.90.1"
     webpack-cli: "npm:^5.1.4"
     webpack-dev-server: "npm:^4.15.1"
@@ -9770,6 +9773,7 @@ __metadata:
   dependencies:
     "@trezor/env-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
+    tsx: "npm:^4.7.0"
   peerDependencies:
     tslib: ^2.6.2
   languageName: unknown
@@ -9957,6 +9961,7 @@ __metadata:
     html-webpack-plugin: "npm:^5.6.0"
     selfsigned: "npm:^2.4.1"
     terser-webpack-plugin: "npm:^5.3.9"
+    tsx: "npm:^4.7.0"
     webpack: "npm:^5.90.1"
     webpack-cli: "npm:^5.1.4"
     webpack-merge: "npm:^5.10.0"
@@ -10031,6 +10036,7 @@ __metadata:
     karma-sourcemap-loader: "npm:^0.4.0"
     karma-webpack: "npm:^5.0.1"
     ts-node: "npm:^10.9.1"
+    tsx: "npm:^4.7.0"
     webpack: "npm:^5.90.1"
     ws: "npm:^8.16.0"
   peerDependencies:
@@ -10074,6 +10080,7 @@ __metadata:
   resolution: "@trezor/env-utils@workspace:packages/env-utils"
   dependencies:
     expo-constants: "npm:15.4.5"
+    tsx: "npm:^4.7.0"
     ua-parser-js: "npm:^1.0.37"
   peerDependencies:
     expo-localization: "*"
@@ -10110,6 +10117,7 @@ __metadata:
     long: "npm:^4.0.0"
     protobufjs: "npm:7.2.6"
     protobufjs-cli: "npm:^1.1.2"
+    tsx: "npm:^4.7.0"
   peerDependencies:
     tslib: ^2.6.2
   languageName: unknown
@@ -10118,6 +10126,8 @@ __metadata:
 "@trezor/protocol@workspace:*, @trezor/protocol@workspace:packages/protocol":
   version: 0.0.0-use.local
   resolution: "@trezor/protocol@workspace:packages/protocol"
+  dependencies:
+    tsx: "npm:^4.7.0"
   peerDependencies:
     tslib: ^2.6.2
   languageName: unknown
@@ -10164,6 +10174,7 @@ __metadata:
     "@sinclair/typebox-codegen": "npm:^0.8.13"
     ts-mixer: "npm:^6.0.3"
     ts-node: "npm:^10.9.2"
+    tsx: "npm:^4.7.0"
   languageName: unknown
   linkType: soft
 
@@ -10616,6 +10627,7 @@ __metadata:
     long: "npm:^4.0.0"
     protobufjs: "npm:7.2.6"
     ts-node: "npm:^10.9.1"
+    tsx: "npm:^4.7.0"
     usb: "npm:^2.11.0"
   peerDependencies:
     tslib: ^2.6.2
@@ -10649,6 +10661,8 @@ __metadata:
 "@trezor/utils@workspace:*, @trezor/utils@workspace:^, @trezor/utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@trezor/utils@workspace:packages/utils"
+  dependencies:
+    tsx: "npm:^4.7.0"
   peerDependencies:
     tslib: ^2.6.2
   languageName: unknown
@@ -10680,6 +10694,7 @@ __metadata:
     minimaldata: "npm:^1.0.2"
     pushdata-bitcoin: "npm:^1.0.1"
     tiny-secp256k1: "npm:^1.1.6"
+    tsx: "npm:^4.7.0"
     typeforce: "npm:^1.18.0"
     varuint-bitcoin: "npm:^1.1.2"
     wif: "npm:^4.0.0"
@@ -33476,8 +33491,8 @@ __metadata:
   linkType: hard
 
 "tsx@npm:^4.7.0":
-  version: 4.7.0
-  resolution: "tsx@npm:4.7.0"
+  version: 4.7.1
+  resolution: "tsx@npm:4.7.1"
   dependencies:
     esbuild: "npm:~0.19.10"
     fsevents: "npm:~2.3.3"
@@ -33487,7 +33502,7 @@ __metadata:
       optional: true
   bin:
     tsx: dist/cli.mjs
-  checksum: 3e6ee0a0a8adb7b1cb58875f50b143b41df0132ade3a7cdda16a166ac473eee446197762ba6afb235ace4c6adae7e55f61a420ee55b17438717eea1e55e611c0
+  checksum: 3a462b595f31ae58b31f9c6e8c450577dc87660b1225012bd972b6b58d7d2f6c4034728763ebc53bb731acff68de8b0fa50586e4c1ec4c086226f1788ccf9b7d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
From g:tsx to local tsx in prepublish script
<!--- Provide a general summary of your changes in the Title above -->

## Description

The usage of g:tsx was causing issues in the npm relase process since the required env variable "process.env.npm_package_name" was set to trezor-suite instead of @trezor/<package-name> that is expected by prepublish.js script.

