### PR TITLE
fix(scripts): filename script checkNpmAndLocal.js to kebap case check-npm-and-local.js

### DIFF
--- a/ci/scripts/check-npm-and-local.js
+++ b/ci/scripts/check-npm-and-local.js
@@ -73,7 +73,7 @@ const packModule = (moduleName, modulePath, outputDirectory) => {
 
         // Run npm pack
         const fileName = `${moduleName}.tgz`;
-        const result = execSync(`yarn pack -o ${outputDirectory}/${fileName}`, {
+        execSync(`yarn pack -o ${outputDirectory}/${fileName}`, {
             encoding: 'utf8',
         });
 

--- a/ci/scripts/helpers.js
+++ b/ci/scripts/helpers.js
@@ -7,7 +7,7 @@ const child_process = require('child_process');
 
 const readFile = util.promisify(fs.readFile);
 
-const { getLocalAndRemoteChecksums } = require('./checkNpmAndLocal');
+const { getLocalAndRemoteChecksums } = require('./check-npm-and-local');
 
 const rootPath = path.join(__dirname, '..', '..');
 const packagesPath = path.join(rootPath, 'packages');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Change filename from `checkNpmAndLocal.js` to `check-npm-and-local.js` to follow the kebab case that we use for scripts .js files.

Delete `result` const  from function `packModule` because is not used.