### PR TITLE
fix(connect-popup): e2e methods test always reset emulator

### DIFF
--- a/packages/connect-popup/e2e/tests/methods.test.ts
+++ b/packages/connect-popup/e2e/tests/methods.test.ts
@@ -60,7 +60,8 @@ filteredFixtures.forEach(f => {
         // do complete setup if:
         // - fixture require different device than prev fixture, or
         // - fixture is retried
-        if (JSON.stringify(device) !== JSON.stringify(f.device) || retry) {
+        // FIXME: always reset for now, due to flaky tests with bridge bug
+        if (true || JSON.stringify(device) !== JSON.stringify(f.device) || retry) {
             device = f.device;
             await TrezorUserEnvLink.api.stopBridge();
             await TrezorUserEnvLink.api.stopEmu();


### PR DESCRIPTION
## Description

I have a theory that a lot of flakiness in methods.test is due to a bug in bridge and emulator. 
If we reset the bridge+emulator before each test we should mitgate that.