### PR TITLE
chore(connect-iframe): fix conflicting variable webpack warning on bu…

### DIFF
--- a/packages/connect-iframe/webpack/base.webpack.config.ts
+++ b/packages/connect-iframe/webpack/base.webpack.config.ts
@@ -17,7 +17,7 @@ const commitHash =
 
 export const config: webpack.Configuration = {
     target: 'web',
-    mode: 'production',
+    mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
     module: {
         rules: [
             {
@@ -30,7 +30,6 @@ export const config: webpack.Configuration = {
                     },
                 },
             },
-
             {
                 test: (input: string) => input.includes('background-sharedworker'),
                 loader: 'worker-loader',
@@ -131,13 +130,8 @@ export const config: webpack.Configuration = {
             ],
         }),
         new webpack.DefinePlugin({
-            process: {
-                env: {
-                    VERSION: JSON.stringify(version),
-                    COMMIT_HASH: JSON.stringify(commitHash),
-                    NODE_ENV: JSON.stringify(process.env.NODE_ENV),
-                },
-            },
+            'process.env.VERSION': JSON.stringify(version),
+            'process.env.COMMIT_HASH': JSON.stringify(commitHash),
         }),
     ],
 

--- a/packages/connect-iframe/webpack/core.webpack.config.ts
+++ b/packages/connect-iframe/webpack/core.webpack.config.ts
@@ -8,7 +8,7 @@ const DIST = path.resolve(__dirname, '../build');
 
 export const config: webpack.Configuration = {
     target: 'web',
-    mode: 'production',
+    mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
     entry: {
         core: path.resolve(__dirname, '../../connect/src/core/index.ts'),
     },

--- a/packages/connect-popup/webpack/prod.webpack.config.ts
+++ b/packages/connect-popup/webpack/prod.webpack.config.ts
@@ -14,7 +14,7 @@ const commitHash = execSync('git rev-parse HEAD').toString().trim();
 
 const config: webpack.Configuration = {
     target: 'web',
-    mode: 'production',
+    mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
     entry: {
         popup: path.resolve(__dirname, '../src/index.tsx'),
         log: path.resolve(__dirname, '../src/log.tsx'),
@@ -73,7 +73,6 @@ const config: webpack.Configuration = {
         new DefinePlugin({
             'process.env.VERSION': JSON.stringify(version),
             'process.env.COMMIT_HASH': JSON.stringify(commitHash),
-            'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
         }),
         new HtmlWebpackPlugin({
             chunks: ['popup'],


### PR DESCRIPTION
<img width="730" alt="image" src="https://github.com/trezor/trezor-suite/assets/30367552/01890b1e-321e-42a1-840e-e9e3c972d1c6">

- webpack.mode sets process.env.NODE_ENV under the hood which is conflicting when the same variable is set by provide plugin to a different value. 
- now it behaves like this - if not set locally, mode is 'developement'. this is mainly needed for analytics logs to be sent to development.log bucket. 
- on CI we already set this env so from this perspective, nothing should change https://github.com/trezor/trezor-suite/blob/develop/ci/build.yml#L302