### PR TITLE
feat(suite-native): allow platform input on releasse workflow

### DIFF
--- a/.github/workflows/suite-native_production_ci.yml
+++ b/.github/workflows/suite-native_production_ci.yml
@@ -2,16 +2,26 @@ name: "[Release] suite-native production"
 
 on:
   workflow_dispatch:
+    inputs:
+      PLATFORM:
+        choice:
+        type: choice
+        options:
+          - iOS
+          - Android
+          - Both
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: Install and build
+  ios:
+    name: Build and release iOS
     environment: production
     runs-on: ubuntu-latest
+    if: ${{ github.event.inputs.PLATFORM == 'iOS' || github.event.inputs.PLATFORM == 'Both' }}
     env:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
@@ -35,6 +45,26 @@ jobs:
           --auto-submit
           --message ${{ github.sha }}
         working-directory: suite-native/app
+  android:
+    name: Build and release Android
+    environment: production
+    runs-on: ubuntu-latest
+    if: ${{ github.event.inputs.PLATFORM == 'Android' || github.event.inputs.PLATFORM == 'Both' }}
+    env:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: yarn
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+      - name: Install libs
+        run: yarn install
       - name: Build on EAS Android
         run: eas build
           --platform android

--- a/.github/workflows/suite-native_production_ci.yml
+++ b/.github/workflows/suite-native_production_ci.yml
@@ -22,8 +22,6 @@ jobs:
     environment: production
     runs-on: ubuntu-latest
     if: ${{ github.event.inputs.PLATFORM == 'iOS' || github.event.inputs.PLATFORM == 'Both' }}
-    env:
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -50,8 +48,6 @@ jobs:
     environment: production
     runs-on: ubuntu-latest
     if: ${{ github.event.inputs.PLATFORM == 'Android' || github.event.inputs.PLATFORM == 'Both' }}
-    env:
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allow selection of Platform which will run. Also separating jobs so they run concurrently on expo eas.

## Related Issue
https://github.com/trezor/trezor-suite/issues/10789

