### PR TITLE
chore(eth-staking): use blockbook for staking actions

### DIFF
--- a/packages/suite-desktop-core/src/config.ts
+++ b/packages/suite-desktop-core/src/config.ts
@@ -25,9 +25,6 @@ export const allowedDomains = [
     'trezor-cardano-mainnet.blockfrost.io',
     'trezor-cardano-preview.blockfrost.io',
     'blockfrost.dev',
-    'eth-goerli.public.blastapi.io',
-    'ethereum-holesky.publicnode.com',
-    'mainnet.infura.io',
     'eth-api-b2c-stage.everstake.one',
     'eth-api-b2c.everstake.one',
 ];

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -19,7 +19,7 @@
         "test-unit:watch": "yarn g:jest -o --watch"
     },
     "dependencies": {
-        "@everstake/wallet-sdk": "^0.3.39",
+        "@everstake/wallet-sdk": "^0.3.40",
         "@formatjs/intl": "2.10.0",
         "@hookform/resolvers": "3.3.4",
         "@mobily/ts-belt": "^3.13.1",

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimEthForm.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimEthForm.tsx
@@ -27,7 +27,7 @@ const GreenTxt = styled.span`
 `;
 
 const StyledWarning = styled(Warning)`
-    margin-top: ${spacingsPx.sm};
+    margin: ${spacingsPx.sm} 0 ${spacingsPx.sm} 0;
     justify-content: flex-start;
 `;
 
@@ -83,15 +83,15 @@ export const ClaimEthForm = () => {
                 </TxtRight>
             </AmountInfo>
 
+            {errors[CRYPTO_INPUT] && (
+                <StyledWarning variant="destructive">{errors[CRYPTO_INPUT]?.message}</StyledWarning>
+            )}
+
             <FeesInfo
                 transactionInfo={transactionInfo}
                 symbol={symbol}
                 helperText={<Translation id="TR_STAKE_PAID_FROM_BALANCE" />}
             />
-
-            {errors[CRYPTO_INPUT] && (
-                <StyledWarning variant="destructive">{errors[CRYPTO_INPUT]?.message}</StyledWarning>
-            )}
 
             <ClaimingPeriodWrapper>
                 <GreyP>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/UnstakeEthForm.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/UnstakeEthForm.tsx
@@ -70,7 +70,28 @@ export const UnstakeEthForm = () => {
 
     return (
         <form onSubmit={handleSubmit(signTx)}>
+            {canClaim && (
+                <StyledWarning variant="info">
+                    <Translation
+                        id="TR_STAKE_CAN_CLAIM_WARNING"
+                        values={{
+                            amount: claimableAmount,
+                            symbol: symbol.toUpperCase(),
+                            br: <br />,
+                        }}
+                    />
+                </StyledWarning>
+            )}
+
             <Options symbol={symbol} />
+
+            <WarningsWrapper>
+                {errors[CRYPTO_INPUT] && (
+                    <StyledWarning variant="destructive">
+                        {errors[CRYPTO_INPUT]?.message}
+                    </StyledWarning>
+                )}
+            </WarningsWrapper>
 
             <DividerWrapper>
                 <Divider />
@@ -81,27 +102,6 @@ export const UnstakeEthForm = () => {
                 symbol={symbol}
                 helperText={<Translation id="TR_STAKE_PAID_FROM_BALANCE" />}
             />
-
-            <WarningsWrapper>
-                {errors[CRYPTO_INPUT] && (
-                    <StyledWarning variant="destructive">
-                        {errors[CRYPTO_INPUT]?.message}
-                    </StyledWarning>
-                )}
-
-                {canClaim && (
-                    <StyledWarning variant="info">
-                        <Translation
-                            id="TR_STAKE_CAN_CLAIM_WARNING"
-                            values={{
-                                amount: claimableAmount,
-                                symbol: symbol.toUpperCase(),
-                                br: <br />,
-                            }}
-                        />
-                    </StyledWarning>
-                )}
-            </WarningsWrapper>
 
             <UpToDaysWrapper>
                 {!Number.isNaN(unstakingPeriod) && (

--- a/packages/suite/src/constants/suite/ethStaking.ts
+++ b/packages/suite/src/constants/suite/ethStaking.ts
@@ -10,12 +10,6 @@ export const MIN_ETH_AMOUNT_FOR_STAKING = new BigNumber(0.1);
 export const MIN_ETH_FOR_WITHDRAWALS = new BigNumber(0.03);
 export const MIN_ETH_BALANCE_FOR_STAKING = MIN_ETH_AMOUNT_FOR_STAKING.plus(MIN_ETH_FOR_WITHDRAWALS);
 
-// source is a required parameter for some functions in the Everstake Wallet SDK.
-// This parameter is used for some contract calls.
-// It is a constant which allows the SDK to define which app calls its functions.
-// Each app which integrates the SDK has its own source, e.g. source for Trezor Suite is '1'.
-export const WALLET_SDK_SOURCE = '1';
-
 // Used when Everstake pool stats are not available from the API.
 export const BACKUP_ETH_APY = '4.13';
 

--- a/packages/suite/src/hooks/wallet/__tests__/useSendForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useSendForm.test.tsx
@@ -57,7 +57,7 @@ const initStore = ({ send, fees, selectedAccount, coinjoin, bitcoinAmountUnit }:
             wallet: {
                 send,
                 coinjoin,
-                settings: { bitcoinAmountUnit },
+                settings: { bitcoinAmountUnit, enabledNetworks: ['thol'] },
             },
         },
     });

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -8782,4 +8782,8 @@ export default defineMessages({
         id: 'TR_STAKE_CLAIM_IN_NEXT_BLOCK',
         defaultMessage: 'in the next block',
     },
+    TR_STAKE_NOT_ENOUGH_FUNDS: {
+        id: 'TR_STAKE_NOT_ENOUGH_FUNDS',
+        defaultMessage: 'Not enough {symbol} to pay network fees',
+    },
 });

--- a/suite-common/wallet-types/src/transaction.ts
+++ b/suite-common/wallet-types/src/transaction.ts
@@ -29,7 +29,8 @@ type PrecomposedTransactionErrorExtended =
               | 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE'
               | 'AMOUNT_IS_NOT_ENOUGH'
               | 'AMOUNT_IS_TOO_LOW'
-              | 'AMOUNT_IS_LESS_THAN_RESERVE';
+              | 'AMOUNT_IS_LESS_THAN_RESERVE'
+              | 'TR_STAKE_NOT_ENOUGH_FUNDS';
       };
 
 export type TxNonFinalCardano = PrecomposedTransactionNonFinalCardano & {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3268,9 +3268,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@everstake/wallet-sdk@npm:^0.3.39":
-  version: 0.3.39
-  resolution: "@everstake/wallet-sdk@npm:0.3.39"
+"@everstake/wallet-sdk@npm:^0.3.40":
+  version: 0.3.40
+  resolution: "@everstake/wallet-sdk@npm:0.3.40"
   dependencies:
     "@cosmjs/stargate": "npm:^0.30.1"
     "@mysten/sui.js": "npm:^0.46.1"
@@ -3282,7 +3282,7 @@ __metadata:
     bip39: "npm:^3.1.0"
     bs58: "npm:^5.0.0"
     web3: "npm:^1.9.0"
-  checksum: be8548bffc072fe2af62340d5037141a9a476ea4b2b83293b1d670cdeade48146b41cbb24ac0f5b341d357e7c3df7443b6030a6ba0af050db95f7e19cbd7c0fa
+  checksum: bc673d0e8de4e630ac6a721a1c5b8184ce6ad2e01d1c95c6b61e5b95b39cc1b9e10839080b735ac84cd49409cd97260241115a6ef574d7a0c0bebfad78812be7
   languageName: node
   linkType: hard
 
@@ -10385,7 +10385,7 @@ __metadata:
   resolution: "@trezor/suite@workspace:packages/suite"
   dependencies:
     "@crowdin/cli": "npm:^3.18.0"
-    "@everstake/wallet-sdk": "npm:^0.3.39"
+    "@everstake/wallet-sdk": "npm:^0.3.40"
     "@formatjs/cli": "npm:^6.2.7"
     "@formatjs/intl": "npm:2.10.0"
     "@hookform/resolvers": "npm:3.3.4"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

1. Blockbook is used for fee estimations for the stake, unstake and claim actions
2. The pool stats are no longer requested when no eth network is enabled in Suite
3. Warning messages places and texts for the unstake and claim modals are updated


## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
<img width="525" alt="Знімок екрана 2024-03-04 о 13 13 20" src="https://github.com/trezor/trezor-suite/assets/42133844/58e210e6-55b2-4135-b432-24aad3486f4f">
<img width="525" alt="Знімок екрана 2024-03-04 о 13 13 37" src="https://github.com/trezor/trezor-suite/assets/42133844/5387c879-4491-4ffb-b215-9c3728f3bcbb">
