### PR TITLE
chore(repo): remove peer deps warning during install

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -9,3 +9,5 @@ plugins:
     spec: "https://mskelton.dev/yarn-outdated/v3"
 
 yarnPath: .yarn/releases/yarn-4.0.2.cjs
+
+logFilters: [{ code: "YN0002", level: "discard" }]


### PR DESCRIPTION
We ignore these peer deps warnings anyway and they are no useful for us. Now it's much cleaner:

![Screenshot 2024-03-04 at 14 21 16](https://github.com/trezor/trezor-suite/assets/5837757/7d22b97a-f362-4fd1-bc7a-a983cefbf529)


## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
