### PR TITLE
feat(coinmarket): Use partner's brandName for non-legal purposes and partner's companyName for the legal ones

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -121,7 +121,7 @@
         "@testing-library/react": "14.2.1",
         "@testing-library/user-event": "14.5.2",
         "@types/file-saver": "^2.0.6",
-        "@types/invity-api": "^1.0.20",
+        "@types/invity-api": "^1.0.21",
         "@types/jws": "^3.2.9",
         "@types/pako": "^2.0.3",
         "@types/pdfmake": "^0.2.9",

--- a/packages/suite/src/views/wallet/coinmarket/buy/detail/Detail/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/detail/Detail/index.tsx
@@ -67,7 +67,7 @@ const CoinmarketDetail = () => {
                     <WaitingForUser
                         trade={trade.data}
                         account={account}
-                        providerName={provider?.companyName}
+                        providerName={provider?.brandName || provider?.companyName}
                     />
                 )}
                 {showSuccess && <PaymentSuccessful account={account} />}

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketProviderInfo.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketProviderInfo.tsx
@@ -39,6 +39,7 @@ interface CoinmarketProviderInfoProps {
         [name: string]: {
             logo: string;
             companyName: string;
+            brandName?: string;
         };
     };
 }
@@ -64,7 +65,7 @@ export const CoinmarketProviderInfo = ({ exchange, providers }: CoinmarketProvid
                             </Bg>
                         </IconWrapper>
                     )}
-                    <Text>{provider.companyName}</Text>
+                    <Text>{provider.brandName || provider.companyName}</Text>
                 </>
             )}
         </Wrapper>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10445,7 +10445,7 @@ __metadata:
     "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@types/file-saver": "npm:^2.0.6"
-    "@types/invity-api": "npm:^1.0.20"
+    "@types/invity-api": "npm:^1.0.21"
     "@types/jws": "npm:^3.2.9"
     "@types/pako": "npm:^2.0.3"
     "@types/pdfmake": "npm:^0.2.9"
@@ -11267,10 +11267,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/invity-api@npm:^1.0.20":
-  version: 1.0.20
-  resolution: "@types/invity-api@npm:1.0.20"
-  checksum: 1ff08d92d17d1d70d8100cca245f5fb66d4474d651b32b36b5c0129750bb1bc2bd1753389cf836648f401733d0e995421ec6bb389c367d13369331ba761764f6
+"@types/invity-api@npm:^1.0.21":
+  version: 1.0.21
+  resolution: "@types/invity-api@npm:1.0.21"
+  checksum: fd3e7413898f93ac635800e316dada5f4f051372c3a11214f6a151398f2f9516701badb10a939270b74388e8e415a2dce9e7c33d8917470ed1a97414e7cc7886
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Current state: We use company name for legal and non-legal purposes in Trezor Suite.

New State: We need to distinguish between brand and company name. Brand name will be used for non-legal purposes, whereas company name will be used for the legal ones.

![image](https://github.com/trezor/trezor-suite/assets/7394177/25ae853c-c812-429d-a6df-9efca72d1d7a)
![image](https://github.com/trezor/trezor-suite/assets/7394177/2b2ae2f9-198a-4405-b1bf-58efdad7d84d)

Resolves: https://github.com/trezor/trezor-suite/issues/11433