### PR TITLE
test(ci): make legacy test run when all runs

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -304,8 +304,7 @@ connect-popup legacy npm package manual:
 connect-popup legacy npm package:
   extends: .connect-popup legacy npm package base
   only:
-    refs:
-      - schedules
+    <<: *run_everything_rules
 
 .e2e connect-explorer-webextension:
   stage: integration testing
@@ -428,8 +427,7 @@ connect-explorer-webextension manual:
 connect legacy fws:
   extends: .connect legacy fws base
   only:
-    refs:
-      - schedules
+    <<: *run_everything_rules
 
 connect legacy fws manual:
   extends: .connect legacy fws base


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Make Connect legacy tests we have for firmware and connect-popup to run when `run_everything_rules` so it run also in the `release/*` branch.
