### PR TITLE
fix(protobuf): undefined in messageToJSON

### DIFF
--- a/packages/protobuf/src/decode.ts
+++ b/packages/protobuf/src/decode.ts
@@ -46,6 +46,10 @@ export function messageToJSON(
     MessageParam: Message<Record<string, unknown>>,
     fields: Type['fields'],
 ) {
+    // MessageParams was being called with undefined
+    if (!MessageParam) {
+        return {};
+    }
     // get rid of Message.prototype references
     const { ...message } = MessageParam;
     const res: { [key: string]: any } = {};


### PR DESCRIPTION
## Description

A problem appeared with protobuf decoding in the latest release when signing with legacy FW. 
The `messageToJSON` function is called with `MessageParam` as `undefined`, which causes an unhandled exception

## Related Issue

Resolve #11437