### PR TITLE
fix(ci): legacy test require dependencies

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -303,6 +303,9 @@ connect-popup legacy npm package manual:
 
 connect-popup legacy npm package:
   extends: .connect-popup legacy npm package base
+  dependencies:
+    - install
+    - connect-web build
   only:
     <<: *run_everything_rules
 
@@ -426,6 +429,9 @@ connect-explorer-webextension manual:
 
 connect legacy fws:
   extends: .connect legacy fws base
+  dependencies:
+    - install
+    - connect-web build
   only:
     <<: *run_everything_rules
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If we look at the other tests using:

```
  only:
    <<: *run_everything_rules
```

They have `dependencies` in set up in the test that is extending https://github.com/trezor/trezor-suite/blob/develop/ci/test.yml#L264
