### PR TITLE
ci(connect): delete files in rollback bucket

### DIFF
--- a/ci/scripts/connect-release-production.sh
+++ b/ci/scripts/connect-release-production.sh
@@ -24,7 +24,7 @@ Used only for version 9"
 echo "Backing up current production version $latest_version to rollback bucket"
 
 # sync the files to rollback bucket
-aws s3 sync "s3://connect.trezor.io/$latest_version/" "s3://rollback-connect.trezor.io/$latest_version/"
+aws s3 sync --delete "s3://connect.trezor.io/$latest_version/" "s3://rollback-connect.trezor.io/$latest_version/"
 
 echo "Uploading to s3://connect.trezor.io/$latest_version/ and s3://connect.trezor.io/$current_version/"
 


### PR DESCRIPTION
but should they really be deleted? lets say:

1. I do a release containing `index.html` pointing to `javascript.abc`
2. now I am doing next release,  so I first copy content of release folder so rollback bucket now contains `index.html` and `javascript.abc` and apply `index.html(2)` pointing to `javascript.cba`;
3. now I apply rollback, release folder now contains `index.html` pointing to `javascript.abc`. all looks good, but what if all different caching layers still serve the old `index.html` pointing to a file which no longer exist?

Maybe applying rollback bucket should:
1. overwrite files with the same names
2. merge all other files

?