### PR TITLE
chore(suite-data): update tor to 0.4.8.10

### DIFF
--- a/packages/suite-data/files/bin/tor/linux-arm64/tor
+++ b/packages/suite-data/files/bin/tor/linux-arm64/tor
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:810df26623ce84932fb9d727902dd5d02c3bc4e1ef9d4b9afffc626d1d2ff466
-size 16070400
+oid sha256:c2fadf09c6483b8824e22fa777a088083031d875faa5611f93c5f4cc1ca6cd09
+size 17621624

--- a/packages/suite-data/files/bin/tor/linux-x64/tor
+++ b/packages/suite-data/files/bin/tor/linux-x64/tor
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a1c7515d7bc28b3426a361beb6452b51042bfdf4ea15d5bcf71a7bf35270cb39
-size 16812920
+oid sha256:2e4c944a9952cdabb2a66a385d3e8303959cc00bf7902c48adfcd71128a5ac2b
+size 18389352

--- a/packages/suite-data/files/bin/tor/mac-arm64/tor
+++ b/packages/suite-data/files/bin/tor/mac-arm64/tor
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:540b9777f64d88a9de8ddafedb6be54f8b22a3d3a5b8896d4d7aefda3f67a32a
-size 4762752
+oid sha256:35576ca5ec0374c79897ea130114d5d005f23c5b2ba7031a22250ef4da60c4a7
+size 5908496

--- a/packages/suite-data/files/bin/tor/mac-x64/tor
+++ b/packages/suite-data/files/bin/tor/mac-x64/tor
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9ae4bef1d828e729c3269db0d591eaad6f8471fb815a52aeae9db1fcf6c39843
-size 5206944
+oid sha256:4ce8317418d77e04290522276fa602e26a1936294e29278ad09349c0ca7ef9f2
+size 6390608

--- a/packages/suite-data/files/bin/tor/update.sh
+++ b/packages/suite-data/files/bin/tor/update.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
-CRX_VER=1_0_34
-CRX_LINUX_ARM_VER=1_0_3
+CRX_VER=1_0_35
+CRX_LINUX_ARM_VER=1_0_4
 
 # check whether we have all required commands
 for cmd in 7z curl lipo shasum ; do

--- a/packages/suite-data/files/bin/tor/win-x64/tor.exe
+++ b/packages/suite-data/files/bin/tor/win-x64/tor.exe
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d66535d9b9293c45a92a007a86d8d4fb8909539ba98535c951fad0b98a3d954b
-size 16935976
+oid sha256:eaacd918cb2ab07c60ee7ec3e65c0377daddf8c69e7e428b5a9ef059eefcc09c
+size 18673088


### PR DESCRIPTION
Regular Tor update as described in [Notion](https://www.notion.so/satoshilabs/Update-Tor-binaries-d41bd5fd4f4243628c7627bec38c6712).