### PR TITLE
chore(fix): fix wrong paths in build outputs

### DIFF
--- a/packages/components/src/components/AutoScalingInput/AutoScalingInput.stories.tsx
+++ b/packages/components/src/components/AutoScalingInput/AutoScalingInput.stories.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { AutoScalingInput as Input } from './AutoScalingInput';
+import { Meta } from '@storybook/react';
 
 const Wrapper = styled.div`
     display: flex;
@@ -21,9 +22,10 @@ const BorderlessAutoScalingInput = styled(Input)`
     background-color: #ccc;
 `;
 
-export default {
+const meta: Meta = {
     title: 'Form/AutoScalingInput',
 };
+export default meta;
 
 export const AutoScalingInput = {
     render: () => (

--- a/packages/components/src/components/Badge/Badge.stories.tsx
+++ b/packages/components/src/components/Badge/Badge.stories.tsx
@@ -1,10 +1,11 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { Badge as BadgeComponent, BadgeProps } from './Badge';
 
-export default {
+const meta: Meta = {
     title: 'Misc/Badge',
     component: BadgeComponent,
 } as Meta;
+export default meta;
 
 export const Badge: StoryObj<BadgeProps> = {
     args: {

--- a/packages/components/src/components/Box/Box.stories.tsx
+++ b/packages/components/src/components/Box/Box.stories.tsx
@@ -14,9 +14,10 @@ const Wrapper = styled.div`
     gap: 20px;
 `;
 
-export default {
+const meta: Meta = {
     title: 'Misc/Box',
 } as Meta;
+export default meta;
 
 export const Box: StoryObj = {
     render: () => (

--- a/packages/components/src/components/Card/Card.stories.tsx
+++ b/packages/components/src/components/Card/Card.stories.tsx
@@ -1,10 +1,11 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { Card as CardComponent } from './Card';
 
-export default {
+const meta: Meta = {
     title: 'Misc/Card',
     component: CardComponent,
 } as Meta;
+export default meta;
 
 export const Card: StoryObj = {
     args: {

--- a/packages/components/src/components/CollapsibleBox/CollapsibleBox.stories.tsx
+++ b/packages/components/src/components/CollapsibleBox/CollapsibleBox.stories.tsx
@@ -7,10 +7,11 @@ const Content = styled.div`
     width: 400px;
 `;
 
-export default {
+const meta: Meta = {
     title: 'Misc/CollapsibleBox',
     component: CollapsibleBoxComponent,
 } as Meta;
+export default meta;
 
 export const CollapsibleBox: StoryObj = {
     args: {

--- a/packages/components/src/components/ConfirmOnDevice/ConfirmOnDevice.stories.tsx
+++ b/packages/components/src/components/ConfirmOnDevice/ConfirmOnDevice.stories.tsx
@@ -3,7 +3,7 @@ import { DeviceModelInternal } from '@trezor/connect';
 import { ConfirmOnDevice as ConfirmOnDeviceComponent } from './ConfirmOnDevice';
 import { StoryColumn } from '../../support/Story';
 
-export default {
+const meta: Meta = {
     title: 'Misc/ConfirmOnDevice',
     parameters: {
         options: {
@@ -11,6 +11,7 @@ export default {
         },
     },
 } as Meta;
+export default meta;
 
 export const ConfirmOnDevice: StoryFn = () => (
     <>

--- a/packages/components/src/components/Divider/Divider.stories.tsx
+++ b/packages/components/src/components/Divider/Divider.stories.tsx
@@ -1,9 +1,10 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { Divider as DividerComponent } from '../../index';
 
-export default {
+const meta: Meta = {
     title: 'Misc/Divider',
     component: DividerComponent,
 } as Meta;
+export default meta;
 
 export const Divider: StoryObj = {};

--- a/packages/components/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/components/src/components/Dropdown/Dropdown.stories.tsx
@@ -28,10 +28,11 @@ const StyledDropdown = styled(DropdownComponent)`
     overflow: hidden;
 `;
 
-export default {
+const meta: Meta = {
     title: 'Misc/Dropdown',
     component: DropdownComponent,
 } as Meta;
+export default meta;
 
 export const Dropdown: StoryObj<DropdownProps> = {
     render: args => (

--- a/packages/components/src/components/ElevationContext/ElevationContext.stories.tsx
+++ b/packages/components/src/components/ElevationContext/ElevationContext.stories.tsx
@@ -7,9 +7,10 @@ import { useElevation } from './ElevationContext';
 import { Elevation, mapElevationToBackground } from '@trezor/theme';
 import { ReactNode } from 'react';
 
-export default {
+const meta: Meta = {
     title: 'Misc/ElevationContext',
 } as Meta;
+export default meta;
 
 const Wrapper = styled.div`
     padding-bottom: 20px;

--- a/packages/components/src/components/GradientOverlay/GradientOverlay.stories.tsx
+++ b/packages/components/src/components/GradientOverlay/GradientOverlay.stories.tsx
@@ -13,7 +13,7 @@ const TestContainer = styled.div`
     margin: 10px 0;
 `;
 
-export default {
+const meta: Meta = {
     title: 'Misc/GradientOverlay',
     component: GradientOverlayComponent,
     decorators: [
@@ -41,6 +41,7 @@ export default {
         ),
     ],
 } as Meta;
+export default meta;
 
 export const GradientOverlay: StoryObj<GradientOverlayProps> = {
     args: {

--- a/packages/components/src/components/Note/Note.stories.tsx
+++ b/packages/components/src/components/Note/Note.stories.tsx
@@ -1,10 +1,11 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { Note as NoteComponent, NoteProps } from './Note';
 
-export default {
+const meta: Meta = {
     title: 'Misc/Note',
     component: NoteComponent,
 } as Meta;
+export default meta;
 
 export const Note: StoryObj<NoteProps> = {
     args: {

--- a/packages/components/src/components/Passphrase/PassphraseTypeCard.stories.tsx
+++ b/packages/components/src/components/Passphrase/PassphraseTypeCard.stories.tsx
@@ -5,7 +5,7 @@ import {
 } from './PassphraseTypeCard';
 import { Meta, StoryObj } from '@storybook/react';
 
-export default {
+const meta: Meta = {
     title: 'Loaders/PassphraseTypeCard',
     decorators: [
         (Story: React.FC) => (
@@ -16,6 +16,7 @@ export default {
     ],
     component: PassphraseTypeCardComponent,
 } as Meta;
+export default meta;
 
 export const PassphraseTypeCard: StoryObj<PassphraseTypeCardProps> = {
     args: {

--- a/packages/components/src/components/Timerange/Timerange.stories.tsx
+++ b/packages/components/src/components/Timerange/Timerange.stories.tsx
@@ -9,10 +9,11 @@ const Center = styled.div`
     padding: 100px 0;
 `;
 
-export default {
+const meta: Meta = {
     title: 'Misc/Timerange',
     component: TimerangeComponent,
 } as Meta;
+export default meta;
 
 export const Timerange: StoryObj<TimerangeProps> = {
     render: args => (

--- a/packages/components/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.stories.tsx
@@ -16,10 +16,11 @@ const Addon = styled.span`
     color: white;
 `;
 
-export default {
+const meta: Meta = {
     title: 'Misc/Tooltip',
     component: TooltipComponent,
 } as Meta;
+export default meta;
 
 export const Tooltip: StoryObj<TooltipProps> = {
     render: args => (

--- a/packages/components/src/components/Truncate/Truncate.stories.tsx
+++ b/packages/components/src/components/Truncate/Truncate.stories.tsx
@@ -10,9 +10,10 @@ const Holder = styled.div`
     padding: 100px 0;
 `;
 
-export default {
+const meta: Meta = {
     title: 'Misc/Truncate',
 } as Meta;
+export default meta;
 
 export const Truncate: StoryObj<TruncateProps> = {
     render: ({ ...args }) => (

--- a/packages/components/src/components/Warning/Warning.stories.tsx
+++ b/packages/components/src/components/Warning/Warning.stories.tsx
@@ -9,7 +9,7 @@ const Wrapper = styled.div`
     gap: 20px;
 `;
 
-export default {
+const meta: Meta = {
     title: 'Misc/Warning',
     component: WarningComponent,
     render: ({ children, ...rest }) => (
@@ -29,6 +29,7 @@ export default {
         </Wrapper>
     ),
 } as Meta;
+export default meta;
 
 export const Warning: StoryObj<WarningProps> = {
     args: {

--- a/packages/components/src/components/assets/CoinLogo/CoinLogo.stories.tsx
+++ b/packages/components/src/components/assets/CoinLogo/CoinLogo.stories.tsx
@@ -9,10 +9,11 @@ const Center = styled.div`
     padding: 100px 0;
 `;
 
-export default {
+const meta: Meta = {
     title: 'Assets/CoinLogos',
     component: CoinLogoComponent,
 } as Meta;
+export default meta;
 
 export const CoinLogo: StoryObj<CoinLogoProps> = {
     render: ({ symbol, size }) => (

--- a/packages/components/src/components/assets/CoinLogo/coinLogos.stories.tsx
+++ b/packages/components/src/components/assets/CoinLogo/coinLogos.stories.tsx
@@ -23,9 +23,10 @@ const Icon = styled.div`
     align-items: center;
 `;
 
-export default {
+const meta: Meta = {
     title: 'Assets/CoinLogos',
 } as Meta;
+export default meta;
 
 export const All: StoryObj = {
     render: () => (

--- a/packages/components/src/components/assets/Flag/Flag.stories.tsx
+++ b/packages/components/src/components/assets/Flag/Flag.stories.tsx
@@ -1,10 +1,11 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { Flag as FlagComponent } from './Flag';
 
-export default {
+const meta: Meta = {
     title: 'Assets/Flags',
     component: FlagComponent,
 } as Meta;
+export default meta;
 
 export const Flag: StoryObj<typeof FlagComponent> = {
     args: { country: 'CZ' },

--- a/packages/components/src/components/assets/Flag/flags.stories.tsx
+++ b/packages/components/src/components/assets/Flag/flags.stories.tsx
@@ -27,7 +27,7 @@ const Text = styled.div`
     padding-bottom: 10px;
 `;
 
-export default {
+const meta: Meta = {
     title: 'Assets/Flags',
     parameters: {
         options: {
@@ -35,6 +35,7 @@ export default {
         },
     },
 } as Meta;
+export default meta;
 
 export const All: StoryFn = () => {
     const flags = Object.keys(FLAGS) as FlagType[];

--- a/packages/components/src/components/assets/Icon/Icon.stories.tsx
+++ b/packages/components/src/components/assets/Icon/Icon.stories.tsx
@@ -1,10 +1,11 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { Icon as IconComponent, IconProps, variables } from '../../../index';
 
-export default {
+const meta: Meta = {
     title: 'Assets/Icons',
     component: IconComponent,
 } as Meta;
+export default meta;
 
 export const Icon: StoryObj<IconProps> = {
     args: {

--- a/packages/components/src/components/assets/Icon/icons.stories.tsx
+++ b/packages/components/src/components/assets/Icon/icons.stories.tsx
@@ -26,9 +26,10 @@ const IconText = styled.div`
     color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
-export default {
+const meta: Meta = {
     title: 'Assets/Icons/All',
 } as Meta;
+export default meta;
 
 export const All = () => (
     <Wrapper>

--- a/packages/components/src/components/assets/TrezorLogo/TrezorLogo.stories.tsx
+++ b/packages/components/src/components/assets/TrezorLogo/TrezorLogo.stories.tsx
@@ -1,10 +1,11 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { TrezorLogo as TrezorLogoComponent, TrezorLogoProps } from '../../../index';
 
-export default {
+const meta: Meta = {
     title: 'Assets/TrezorLogo',
     component: TrezorLogoComponent,
 } as Meta;
+export default meta;
 
 export const TrezorLogo: StoryObj<TrezorLogoProps> = {
     args: {

--- a/packages/components/src/components/assets/TrezorLogo/trezorLogos.stories.tsx
+++ b/packages/components/src/components/assets/TrezorLogo/trezorLogos.stories.tsx
@@ -15,9 +15,10 @@ const LogoWrapper = styled.div<WrapperProps>`
     align-items: center;
 `;
 
-export default {
+const meta: Meta = {
     title: 'Assets/TrezorLogos',
 } as Meta;
+export default meta;
 
 export const All: StoryObj = {
     render: () => (

--- a/packages/components/src/components/buttons/Button/Button.stories.tsx
+++ b/packages/components/src/components/buttons/Button/Button.stories.tsx
@@ -1,10 +1,11 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { Button as ButtonComponent, ButtonProps } from './Button';
 
-export default {
+const meta: Meta = {
     title: 'Buttons/Button',
     component: ButtonComponent,
 } as Meta;
+export default meta;
 
 export const Button: StoryObj<ButtonProps> = {
     args: {

--- a/packages/components/src/components/buttons/Button/buttons.stories.tsx
+++ b/packages/components/src/components/buttons/Button/buttons.stories.tsx
@@ -1,4 +1,4 @@
-import { Button, ButtonProps } from '../../../index';
+import { Button } from '../../../index';
 import { Meta, StoryFn } from '@storybook/react';
 import { capitalizeFirstLetter } from '@trezor/utils';
 import { StoryColumn } from '../../../support/Story';
@@ -13,9 +13,10 @@ const variants: Array<ButtonVariant> = [
     'destructive',
 ];
 
-export default {
+const meta: Meta<typeof Button> = {
     title: 'Buttons/Button/All',
-} as Meta<ButtonProps>;
+};
+export default meta;
 
 export const All: StoryFn = () => (
     <>

--- a/packages/components/src/components/buttons/ButtonGroup/ButtonGroups.stories.tsx
+++ b/packages/components/src/components/buttons/ButtonGroup/ButtonGroups.stories.tsx
@@ -5,10 +5,11 @@ import { Button } from '../Button/Button';
 import { ButtonGroup } from './ButtonGroup';
 import { IconButton } from '../IconButton/IconButton';
 
-export default {
+const meta: Meta = {
     title: 'Buttons/ButtonGroup',
     component: ButtonGroup,
 } as Meta;
+export default meta;
 
 export const ButtonGroups: StoryFn = () => (
     <StoryColumn minWidth={350} maxWidth={420}>

--- a/packages/components/src/components/buttons/IconButton/IconButton.stories.tsx
+++ b/packages/components/src/components/buttons/IconButton/IconButton.stories.tsx
@@ -1,10 +1,11 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { IconButton as IconButtonComponent, IconButtonProps } from './IconButton';
 
-export default {
+const meta: Meta = {
     title: 'Buttons/IconButton',
     component: IconButtonComponent,
 } as Meta;
+export default meta;
 
 export const IconButton: StoryObj<IconButtonProps> = {
     args: {

--- a/packages/components/src/components/buttons/IconButton/IconButtons.stories.tsx
+++ b/packages/components/src/components/buttons/IconButton/IconButtons.stories.tsx
@@ -6,9 +6,10 @@ import { Meta, StoryObj } from '@storybook/react';
 
 const variants: Array<Exclude<ButtonVariant, 'danger'>> = ['primary', 'secondary', 'tertiary'];
 
-export default {
+const meta: Meta = {
     title: 'Buttons/IconButton',
 } as Meta;
+export default meta;
 
 export const IconButtons: StoryObj = {
     render: () => (

--- a/packages/components/src/components/buttons/PinButton/PinButton.stories.tsx
+++ b/packages/components/src/components/buttons/PinButton/PinButton.stories.tsx
@@ -1,9 +1,10 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { PinButton as PinButtonComponent } from './PinButton';
 
-export default {
+const meta: Meta = {
     title: 'Buttons/PinButton',
     component: PinButtonComponent,
 } as Meta;
+export default meta;
 
 export const PinButton: StoryObj<typeof PinButtonComponent> = {};

--- a/packages/components/src/components/buttons/TextButton/TextButton.stories.tsx
+++ b/packages/components/src/components/buttons/TextButton/TextButton.stories.tsx
@@ -1,10 +1,11 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { TextButton as TextButtonComponent, TextButtonProps } from './TextButton';
 
-export default {
+const meta: Meta = {
     title: 'Buttons/TextButton',
     component: TextButtonComponent,
 } as Meta;
+export default meta;
 
 export const TextButton: StoryObj<TextButtonProps> = {
     args: {

--- a/packages/components/src/components/buttons/TextButton/TextButtons.stories.tsx
+++ b/packages/components/src/components/buttons/TextButton/TextButtons.stories.tsx
@@ -3,9 +3,10 @@ import { Meta, StoryFn } from '@storybook/react';
 import { TextButton } from '../../../index';
 import { StoryColumn } from '../../../support/Story';
 
-export default {
+const meta: Meta = {
     title: 'Buttons/TextButton/All',
 } as Meta;
+export default meta;
 
 export const All: StoryFn = () => (
     <>

--- a/packages/components/src/components/buttons/TooltipButton/TooltipButton.stories.tsx
+++ b/packages/components/src/components/buttons/TooltipButton/TooltipButton.stories.tsx
@@ -1,10 +1,11 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { TooltipButton as TooltipButtonComponent } from './TooltipButton';
 
-export default {
+const meta: Meta = {
     title: 'Buttons/TooltipButton',
     component: TooltipButtonComponent,
 } as Meta;
+export default meta;
 
 export const TooltipButton: StoryObj<typeof TooltipButtonComponent> = {
     args: {

--- a/packages/components/src/components/form/Checkbox/Checkbox.stories.tsx
+++ b/packages/components/src/components/form/Checkbox/Checkbox.stories.tsx
@@ -3,10 +3,11 @@ import { Meta, StoryObj } from '@storybook/react';
 
 import { Checkbox as CheckboxComponent, CheckboxProps } from './Checkbox';
 
-export default {
+const meta: Meta = {
     title: 'Form/Checkbox',
     component: CheckboxComponent,
 } as Meta;
+export default meta;
 
 export const Checkbox: StoryObj<CheckboxProps> = {
     render: ({ ...args }) => {

--- a/packages/components/src/components/form/Checkbox/Checkbox.tsx
+++ b/packages/components/src/components/form/Checkbox/Checkbox.tsx
@@ -5,7 +5,7 @@ import { borders, Color, spacingsPx, typography } from '@trezor/theme';
 import { KEYBOARD_CODE } from '../../../constants/keyboardEvents';
 import { Icon } from '../../assets/Icon/Icon';
 import { getFocusShadowStyle } from '../../../utils/utils';
-import { UIHorizontalAlignment, UIVariant } from 'packages/components/src/config/types';
+import { UIHorizontalAlignment, UIVariant } from '../../../config/types';
 import { FrameProps, ComponentFrame } from '../../common/ComponentFrame';
 
 interface VariantStyles {

--- a/packages/components/src/components/form/Input/Input.stories.tsx
+++ b/packages/components/src/components/form/Input/Input.stories.tsx
@@ -4,7 +4,7 @@ import { Meta, StoryObj } from '@storybook/react';
 
 import { Input as InputComponent, InputProps } from './Input';
 
-export default {
+const meta: Meta = {
     title: 'Form/Input',
     args: {
         value: 'Input',
@@ -40,6 +40,7 @@ export default {
         },
     },
 } as Meta;
+export default meta;
 
 export const Input: StoryObj<InputProps> = {
     render: ({ ...args }) => {

--- a/packages/components/src/components/form/Input/Input.tsx
+++ b/packages/components/src/components/form/Input/Input.tsx
@@ -15,7 +15,7 @@ import { BOTTOM_TEXT_MIN_HEIGHT, BottomText } from '../BottomText';
 import { InputState, InputSize } from '../inputTypes';
 import { TopAddons } from '../TopAddons';
 import { useElevation } from '../../ElevationContext/ElevationContext';
-import { UIHorizontalAlignment } from 'packages/components/src/config/types';
+import { UIHorizontalAlignment } from '../../../config/types';
 
 const Wrapper = styled.div<Pick<InputProps, 'width'> & { hasBottomPadding: boolean }>`
     display: inline-flex;

--- a/packages/components/src/components/form/Radio/Radio.stories.tsx
+++ b/packages/components/src/components/form/Radio/Radio.stories.tsx
@@ -14,10 +14,11 @@ const Wrapper = styled.div`
     }
 `;
 
-export default {
+const meta: Meta = {
     title: 'Form/RadioButton',
     component: RadioComponent,
 } as Meta;
+export default meta;
 
 export const RadioButton: StoryObj<RadioProps> = {
     render: ({ ...args }) => {

--- a/packages/components/src/components/form/Range/Range.stories.tsx
+++ b/packages/components/src/components/form/Range/Range.stories.tsx
@@ -3,9 +3,10 @@ import { Meta, StoryObj } from '@storybook/react';
 
 import { Range as RangeComponent, RangeProps } from './Range';
 
-export default {
+const meta: Meta = {
     title: 'Form/Range',
 } as Meta;
+export default meta;
 
 export const Range: StoryObj<RangeProps> = {
     render: args => {

--- a/packages/components/src/components/form/Select/Select.stories.tsx
+++ b/packages/components/src/components/form/Select/Select.stories.tsx
@@ -15,10 +15,11 @@ const options = Object.keys(values)
     .filter((k: string) => values[k])
     .map((k: string) => values[k]);
 
-export default {
+const meta: Meta = {
     title: 'Form/Select',
     component: SelectComponent,
 } as Meta;
+export default meta;
 
 export const Select: StoryObj<SelectProps> = {
     render: ({ ...args }) => {

--- a/packages/components/src/components/form/SelectBar/SelectBar.stories.tsx
+++ b/packages/components/src/components/form/SelectBar/SelectBar.stories.tsx
@@ -10,11 +10,12 @@ const options = [
     { label: 'custom', value: 'custom' },
 ];
 
-export default {
+const meta: Meta = {
     title: 'Form/SelectBar',
     args: { selectedOption: 'low', label: 'fee' },
     component: SelectBarComponent,
 } as Meta;
+export default meta;
 
 export const SelectBar: StoryObj<SelectBarProps<string>> = {
     render: ({ ...args }) => {

--- a/packages/components/src/components/form/Switch/Switch.stories.tsx
+++ b/packages/components/src/components/form/Switch/Switch.stories.tsx
@@ -3,9 +3,10 @@ import { Meta, StoryObj } from '@storybook/react';
 
 import { Switch as SwitchComponent, SwitchProps } from './Switch';
 
-export default {
+const meta: Meta = {
     title: 'Form/Switch',
 } as Meta;
+export default meta;
 
 export const Switch: StoryObj<SwitchProps> = {
     render: ({ ...args }) => {

--- a/packages/components/src/components/form/Switch/Switch.tsx
+++ b/packages/components/src/components/form/Switch/Switch.tsx
@@ -8,7 +8,7 @@ import {
     getFocusShadowStyle,
     focusStyleTransition,
 } from '../../../utils/utils';
-import { UIHorizontalAlignment } from 'packages/components/src/config/types';
+import { UIHorizontalAlignment } from '../../../config/types';
 
 const Wrapper = styled.div<Pick<SwitchProps, 'labelPosition' | 'isSmall'>>`
     display: flex;

--- a/packages/components/src/components/form/Textarea/Textarea.stories.tsx
+++ b/packages/components/src/components/form/Textarea/Textarea.stories.tsx
@@ -3,10 +3,11 @@ import { Meta, StoryObj } from '@storybook/react';
 import { ChangeEventHandler } from 'react';
 import { Textarea as TextareaComponent, TextareaProps } from './Textarea';
 
-export default {
+const meta: Meta = {
     title: 'Form/Textarea',
     component: TextareaComponent,
 } as Meta;
+export default meta;
 
 const Component = ({ ...args }) => {
     const [{ value }, updateArgs] = useArgs();

--- a/packages/components/src/components/form/form.stories.tsx
+++ b/packages/components/src/components/form/form.stories.tsx
@@ -27,9 +27,10 @@ const SELECT_OPTIONS = [
     },
 ];
 
-export default {
+const meta: Meta = {
     title: 'Form/All',
 } as Meta;
+export default meta;
 
 export const All: StoryObj = {
     render: () => (

--- a/packages/components/src/components/loaders/LoadingContent/LoadingContent.stories.tsx
+++ b/packages/components/src/components/loaders/LoadingContent/LoadingContent.stories.tsx
@@ -1,9 +1,10 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { H1, LoadingContent as LoadingContentComponent, LoadingContentProps } from '../../../index';
 
-export default {
+const meta: Meta = {
     title: 'Loaders/LoadingContent',
 } as Meta;
+export default meta;
 
 export const LoadingContent: StoryObj<LoadingContentProps> = {
     render: ({ ...args }) => (

--- a/packages/components/src/components/loaders/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/components/src/components/loaders/ProgressBar/ProgressBar.stories.tsx
@@ -1,10 +1,11 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { ProgressBar as ProgressBarComponent, ProgressBarProps } from './ProgressBar';
 
-export default {
+const meta: Meta = {
     title: 'Loaders/ProgressBar',
     component: ProgressBarComponent,
 } as Meta;
+export default meta;
 
 export const ProgressBar: StoryObj<ProgressBarProps> = {
     args: {

--- a/packages/components/src/components/loaders/ProgressPie/ProgressPie.stories.tsx
+++ b/packages/components/src/components/loaders/ProgressPie/ProgressPie.stories.tsx
@@ -1,10 +1,11 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { ProgressPie as ProgressPieComponent, ProgressPieProps } from './ProgressPie';
 
-export default {
+const meta: Meta = {
     title: 'Loaders/ProgressPie',
     component: ProgressPieComponent,
 } as Meta;
+export default meta;
 
 export const ProgressPie: StoryObj<ProgressPieProps> = {
     args: {

--- a/packages/components/src/components/loaders/Spinner/Spinner.stories.tsx
+++ b/packages/components/src/components/loaders/Spinner/Spinner.stories.tsx
@@ -1,10 +1,11 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { Spinner as SpinnerComponent, SpinnerProps } from './Spinner';
 
-export default {
+const meta: Meta = {
     title: 'Loaders/Spinner',
     component: SpinnerComponent,
 } as Meta;
+export default meta;
 
 export const Spinner: StoryObj<SpinnerProps> = {
     args: {

--- a/packages/components/src/components/loaders/Stepper/Stepper.stories.tsx
+++ b/packages/components/src/components/loaders/Stepper/Stepper.stories.tsx
@@ -1,10 +1,11 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { Stepper as StepperComponent, StepperProps } from './Stepper';
 
-export default {
+const meta: Meta = {
     title: 'Loaders/Stepper',
     component: StepperComponent,
 } as Meta;
+export default meta;
 
 export const Stepper: StoryObj<StepperProps> = {
     args: {

--- a/packages/components/src/components/modals/DialogModal/DialogModal.stories.tsx
+++ b/packages/components/src/components/modals/DialogModal/DialogModal.stories.tsx
@@ -13,10 +13,11 @@ const Buttons = () => (
     </>
 );
 
-export default {
+const meta: Meta = {
     title: 'Modals/DialogModal',
     component: ModalComponent,
 } as Meta;
+export default meta;
 
 export const DialogModal: StoryObj<DialogModalProps> = {
     args: {

--- a/packages/components/src/components/modals/Modal/Modal.stories.tsx
+++ b/packages/components/src/components/modals/Modal/Modal.stories.tsx
@@ -13,10 +13,11 @@ const Buttons = () => (
     </>
 );
 
-export default {
+const meta: Meta = {
     title: 'Modals/Modal',
     component: ModalComponent,
 } as Meta;
+export default meta;
 
 export const Modal: StoryObj<ModalProps> = {
     args: {

--- a/packages/components/src/components/skeletons/SkeletonCircle.stories.tsx
+++ b/packages/components/src/components/skeletons/SkeletonCircle.stories.tsx
@@ -1,10 +1,11 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { SkeletonCircle as SkeletonCircleComponent, SkeletonCircleProps } from './SkeletonCircle';
 
-export default {
+const meta: Meta = {
     title: 'Skeletons/SkeletonCircle',
     component: SkeletonCircleComponent,
 } as Meta;
+export default meta;
 
 export const SkeletonCircle: StoryObj<SkeletonCircleProps> = {
     args: {

--- a/packages/components/src/components/skeletons/SkeletonRectangle.stories.tsx
+++ b/packages/components/src/components/skeletons/SkeletonRectangle.stories.tsx
@@ -4,10 +4,11 @@ import {
     SkeletonRectangleProps,
 } from './SkeletonRectangle';
 
-export default {
+const meta: Meta = {
     title: 'Skeletons/SkeletonRectangle',
     component: SkeletonRectangleComponent,
 } as Meta;
+export default meta;
 
 export const SkeletonRectangle: StoryObj<SkeletonRectangleProps> = {
     args: {

--- a/packages/components/src/components/skeletons/SkeletonSpread.stories.tsx
+++ b/packages/components/src/components/skeletons/SkeletonSpread.stories.tsx
@@ -8,10 +8,11 @@ const Container = styled.div`
     width: 600px;
 `;
 
-export default {
+const meta: Meta = {
     title: 'Skeletons/SkeletonSpread',
     component: SkeletonSpreadComponent,
 } as Meta;
+export default meta;
 
 export const SkeletonSpread: StoryObj<SkeletonSpreadProps> = {
     render: args => (

--- a/packages/components/src/components/skeletons/SkeletonStack.stories.tsx
+++ b/packages/components/src/components/skeletons/SkeletonStack.stories.tsx
@@ -3,10 +3,11 @@ import { SkeletonStack as SkeletonStackComponent, SkeletonStackProps } from './S
 import { SkeletonCircle } from './SkeletonCircle';
 import { ElevationContext } from '../ElevationContext/ElevationContext';
 
-export default {
+const meta: Meta = {
     title: 'Skeletons/SkeletonStack',
     component: SkeletonStackComponent,
 } as Meta;
+export default meta;
 
 export const SkeletonStack: StoryObj<SkeletonStackProps> = {
     render: args => (

--- a/packages/components/src/components/typography/Heading/Heading.stories.tsx
+++ b/packages/components/src/components/typography/Heading/Heading.stories.tsx
@@ -7,9 +7,10 @@ const Wrapper = styled.div`
     flex-direction: column;
 `;
 
-export default {
+const meta: Meta = {
     title: 'Typography/Heading',
 } as Meta;
+export default meta;
 
 export const Heading: StoryObj = {
     render: () => (

--- a/packages/components/src/components/typography/Link/Link.stories.tsx
+++ b/packages/components/src/components/typography/Link/Link.stories.tsx
@@ -1,10 +1,11 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { Link as LinkComponent, LinkProps } from '../../../index';
 
-export default {
+const meta: Meta = {
     title: 'Typography/Link',
     component: LinkComponent,
 } as Meta;
+export default meta;
 
 export const Link: StoryObj<LinkProps> = {
     args: {

--- a/packages/components/src/components/typography/Paragraph/Paragraph.stories.tsx
+++ b/packages/components/src/components/typography/Paragraph/Paragraph.stories.tsx
@@ -1,10 +1,11 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { Paragraph as P, ParagraphProps } from '../../../index';
 
-export default {
+const meta: Meta = {
     title: 'Typography/Paragraph',
     component: P,
 } as Meta;
+export default meta;
 
 export const Paragraph: StoryObj<ParagraphProps> = {
     args: {

--- a/packages/components/src/components/typography/typography.stories.tsx
+++ b/packages/components/src/components/typography/typography.stories.tsx
@@ -2,9 +2,10 @@ import { StoryColumn } from '../../support/Story';
 import { H1, H2, Paragraph, Link } from '../../index';
 import { Meta, StoryFn } from '@storybook/react';
 
-export default {
+const meta: Meta = {
     title: 'Typography/All',
 } as Meta;
+export default meta;
 
 export const All: StoryFn = () => (
     <>

--- a/packages/suite-desktop-core/e2e/support/pageActions/dashboardActions.ts
+++ b/packages/suite-desktop-core/e2e/support/pageActions/dashboardActions.ts
@@ -1,5 +1,6 @@
 import { Page, Locator, expect as playwrightExpect } from '@playwright/test';
-import { NetworkSymbol } from 'suite-common/wallet-config/src';
+
+import { NetworkSymbol } from '@suite-common/wallet-config';
 
 import { waitForDataTestSelector } from '../common';
 

--- a/packages/suite-desktop-core/e2e/support/pageActions/settingsActions.ts
+++ b/packages/suite-desktop-core/e2e/support/pageActions/settingsActions.ts
@@ -1,5 +1,6 @@
 import { Page } from '@playwright/test';
-import { BackendType, NetworkSymbol } from 'suite-common/wallet-config/src';
+
+import { BackendType, NetworkSymbol } from '@suite-common/wallet-config';
 
 import { waitForDataTestSelector } from '../common';
 

--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -19,6 +19,7 @@
         "@suite-common/sentry": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/suite-utils": "workspace:*",
+        "@suite-common/wallet-config": "workspace:*",
         "@trezor/coinjoin": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/connect-common": "workspace:*",

--- a/packages/suite-desktop-core/tsconfig.json
+++ b/packages/suite-desktop-core/tsconfig.json
@@ -17,6 +17,9 @@
         {
             "path": "../../suite-common/suite-utils"
         },
+        {
+            "path": "../../suite-common/wallet-config"
+        },
         { "path": "../coinjoin" },
         { "path": "../connect" },
         { "path": "../connect-common" },

--- a/scripts/replace-imports.sh
+++ b/scripts/replace-imports.sh
@@ -4,4 +4,14 @@ set -euxo pipefail
 
 echo "replacing imports in $1"
 
-find "$1" -type f -exec sed -i "s/import(\"packages/import(\"@trezor/g" {} +
+# Determine the operating system
+OS="$(uname)"
+
+# Execute the appropriate command based on the OS
+if [[ "$OS" == "Darwin" ]]; then
+    # macOS command with -i '' for in-place editing without backup and -E for extended regex
+    find "$1" -type f -exec sed -i '' -E "s/import\(\"@trezor\/([^/]+)\/src/import(\"@trezor\/\1\/lib/g" {} +
+else
+    # Linux command with -i for in-place editing without backup (GNU sed syntax)
+    find "$1" -type f -exec sed -i "s/import\(\"@trezor\/([^/]+)\/src/import(\"@trezor\/\1\/lib/g" {} +
+fi

--- a/suite-common/icons/src/config.ts
+++ b/suite-common/icons/src/config.ts
@@ -1,5 +1,4 @@
-import { TokenAddress } from 'suite-common/wallet-types/src';
-
+import { TokenAddress } from '@suite-common/wallet-types';
 import { Color } from '@trezor/theme';
 
 import { IconName, FlagIconName, CryptoIconName } from './icons';

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesConstants.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesConstants.ts
@@ -1,4 +1,4 @@
-import { RateType } from 'suite-common/wallet-types';
+import { RateType } from '@suite-common/wallet-types';
 
 export const fiatRatesActionsPrefix = '@common/wallet-core/fiat-rates';
 

--- a/suite-common/wallet-core/src/token-definitions/tokenDefinitionsMiddleware.ts
+++ b/suite-common/wallet-core/src/token-definitions/tokenDefinitionsMiddleware.ts
@@ -1,6 +1,6 @@
-import { Account, Timestamp, TokenAddress } from 'suite-common/wallet-types/src';
 import { isAnyOf } from '@reduxjs/toolkit';
 
+import { Account, Timestamp, TokenAddress } from '@suite-common/wallet-types';
 import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
 import {
     NetworkSymbol,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,7 +3,6 @@
         "allowJs": true,
         "allowSyntheticDefaultImports": true,
         "allowUnreachableCode": false,
-        "baseUrl": ".",
         "jsx": "preserve",
         "module": "ESNext",
         "moduleResolution": "Bundler",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10245,6 +10245,7 @@ __metadata:
     "@suite-common/sentry": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/suite-utils": "workspace:*"
+    "@suite-common/wallet-config": "workspace:*"
     "@trezor/coinjoin": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/connect-common": "workspace:*"


### PR DESCRIPTION
Whole problem with relative paths being published was caused by using `baseUrl` in root tsconfig, sadly this will default to `baseUrl: <monorepoRoot>` when it's extended in package tsconfig. But we want `baseUrl: <packageRoot>` which is default value if not set.

When `baseUrl` was removed so it defaulted to package root it reveleaded some bad imports/exports that was necessary to fix (that's reason why so big diff, otherwise it would be one liner).

Now when it's correct it should never happen there will relative path leading out of package. I hoped that I will be able to remove replace imports scripts but I found out that now I need to replace `@trezor/*/src` with `@trezor/*/lib`. I will try to address this issue later, but for now it works as expected.

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
