### PR TITLE
fix(suite): align custom firmware modal correctly

### DIFF
--- a/packages/suite/src/views/firmware/FirmwareCustom.tsx
+++ b/packages/suite/src/views/firmware/FirmwareCustom.tsx
@@ -26,12 +26,11 @@ const StyledModal = styled(Modal)<{ isNarrow: boolean }>`
     width: ${({ isNarrow }) => (isNarrow ? '450px' : '620px')};
 `;
 
-const ModalContent = styled.div<{ isNarrow: boolean }>`
+const ModalContent = styled.div`
     text-align: left;
     display: flex;
     flex-direction: column;
     align-items: center;
-    width: ${({ isNarrow }) => (isNarrow ? '380px' : '550px')};
 `;
 
 export const FirmwareCustom = () => {
@@ -180,7 +179,7 @@ export const FirmwareCustom = () => {
             }
             data-test="@firmware-custom"
         >
-            <ModalContent isNarrow={status === 'initial'}>
+            <ModalContent>
                 <Step />
             </ModalContent>
         </StyledModal>


### PR DESCRIPTION
## Screenshots:
Before:
![image](https://github.com/trezor/trezor-suite/assets/42465546/2ca114ce-26b8-4dbd-a2f1-c5fd9f834b1b)
![image](https://github.com/trezor/trezor-suite/assets/42465546/659663a2-e4eb-4ac3-bb99-b078bc324b73)

After:
![Screenshot 2024-03-06 at 13 31 43](https://github.com/trezor/trezor-suite/assets/42465546/94501cc0-f3fb-4bba-81ce-cf8c061a9a20)
![Screenshot 2024-03-06 at 13 38 42](https://github.com/trezor/trezor-suite/assets/42465546/cbd068b4-96c8-41c4-abfa-052887595cb5)
![Screenshot 2024-03-06 at 13 27 27](https://github.com/trezor/trezor-suite/assets/42465546/3302a692-a4d5-49d2-b375-bbf483f7d9ed)

