### PR TITLE
fix(ci): nightly connect canary fws

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -445,6 +445,9 @@ connect legacy fws manual:
 .connect canary fws base:
   extends: .connect matrix
   stage: canary testing
+  needs:
+    - install
+    - connect-web build
   variables:
     TESTS_FIRMWARE: "2-main"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Because the "needs" dependency was moved from the based job  it needs to be added to all the ones extending it.

It was not included in the scheadule job and they were failing nightly because of that.

![image](https://github.com/trezor/trezor-suite/assets/5362163/cf0aca0a-64ef-402f-b60b-0602ed13b7a2)

