### PR TITLE
fix(suite): Remove unnecessary z-index from AccountItem hover effect

### DIFF
--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem.tsx
@@ -29,7 +29,6 @@ const Wrapper = styled(NavigationItemBase)<{ isSelected: boolean }>`
 
     :hover {
         position: relative;
-        z-index: 2;
         background: ${({ theme, isSelected }) =>
             !isSelected && theme.backgroundTertiaryPressedOnElevation0};
     }


### PR DESCRIPTION
Didn't find a reason for z-index on hover effect so I removed it

## Related Issue

Resolve #11480

## Screenshots:
![image](https://github.com/trezor/trezor-suite/assets/12121074/7f97f2f9-a953-4cd1-8df2-d8b372689fc4)
