### PR TITLE
fix(suite): fix webpack build

### DIFF
--- a/packages/suite-build/configs/base.webpack.config.ts
+++ b/packages/suite-build/configs/base.webpack.config.ts
@@ -91,6 +91,8 @@ const config: webpack.Configuration = {
         maxEntrypointSize: 1000 * 1000,
     },
     module: {
+        // Throw error on missing exports instead of warning
+        strictExportPresence: true,
         rules: [
             // TypeScript/JavaScript
             {
@@ -133,7 +135,7 @@ const config: webpack.Configuration = {
             },
             // Workers
             {
-                test: /\/workers\/(.*).ts$/,
+                test: /\/workers\/[^\/]+\/index\.ts$/,
                 use: [
                     {
                         loader: 'worker-loader',


### PR DESCRIPTION
All files in blockchain-link/src/workers were picked by worker-loader which transformed them into basically empty files without exports so warnings were right about missing exports. I also turned on that it will fail build now if export is missing which I think is better behavior than silent fail.

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
