### PR TITLE
fix(connect): no request device in suite

### DIFF
--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -236,7 +236,7 @@ const initDevice = async (method: AbstractMethod<any>) => {
             !device || !!device?.unreadableError || (device.isUnacquired() && !!isUsingPopup);
     } else {
         const devices = _deviceList.asArray();
-        if (devices.length === 1 && !isWebUsb) {
+        if (devices.length === 1 && (!isWebUsb || !isUsingPopup)) {
             // there is only one device available. use it
             device = _deviceList.getDevice(devices[0].path);
             showDeviceSelection = !!device?.unreadableError || device.isUnacquired();


### PR DESCRIPTION
Bug (observable in suite):

1. call connect method without device param
2. use webusb
3. don't use popup
4. method hangs on request device promise

Proposed fix in this PR, please check @martykan if it doenst have any unexpected sideffects. 

Also I am not sure how broken current relase of suite is, could be that if some method in suite doesn't send device, it will not work over webusb right now. cc @trezor/qa 


reported by @peter-sanderson 