### PR TITLE
fix: wait on solana confirmed tx

### DIFF
--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -14,7 +14,12 @@ import type * as MessageTypes from '@trezor/blockchain-link-types/src/messages';
 import { CustomError } from '@trezor/blockchain-link-types/src/constants/errors';
 import { BaseWorker, ContextType, CONTEXT } from '../baseWorker';
 import { MESSAGES, RESPONSES } from '@trezor/blockchain-link-types/src/constants';
-import { Connection, Message, PublicKey } from '@solana/web3.js';
+import {
+    BlockheightBasedTransactionConfirmationStrategy,
+    Connection,
+    Message,
+    PublicKey,
+} from '@solana/web3.js';
 import { solanaUtils } from '@trezor/blockchain-link-utils';
 
 import {
@@ -95,6 +100,14 @@ const pushTransaction = async (request: Request<MessageTypes.PushTransaction>) =
     const rawTx = request.payload.startsWith('0x') ? request.payload.slice(2) : request.payload;
     const api = await request.connect();
     const payload = await api.sendRawTransaction(Buffer.from(rawTx, 'hex'));
+    const { blockhash, lastValidBlockHeight } = await api.getLatestBlockhash('finalized');
+    const confirmStrategy: BlockheightBasedTransactionConfirmationStrategy = {
+        blockhash,
+        lastValidBlockHeight,
+        signature: payload,
+    };
+
+    await api.confirmTransaction(confirmStrategy);
 
     return {
         type: RESPONSES.PUSH_TRANSACTION,

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
@@ -45,6 +45,7 @@ export const TransactionReviewModalContent = ({
     const isActionAbortable = useSelector(selectIsActionAbortable);
     const dispatch = useDispatch();
     const [detailsOpen, setDetailsOpen] = useState(false);
+    const [isSending, setIsSending] = useState(false);
 
     const deviceModelInternal = device?.features?.internal_model;
 
@@ -73,10 +74,6 @@ export const TransactionReviewModalContent = ({
 
     const ethereumStakeType =
         'ethereumStakeType' in precomposedForm ? precomposedForm.ethereumStakeType : null;
-    const actionText = getTransactionReviewModalActionText({
-        ethereumStakeType,
-        isRbfAction,
-    });
 
     // omit other button requests (like passphrase)
     const buttonRequests = device.buttonRequests.filter(
@@ -140,7 +137,10 @@ export const TransactionReviewModalContent = ({
                 broadcast={precomposedForm.options.includes('broadcast')}
                 detailsOpen={detailsOpen}
                 onDetailsClick={() => setDetailsOpen(!detailsOpen)}
-                actionText={actionText}
+                actionText={getTransactionReviewModalActionText({
+                    ethereumStakeType,
+                    isRbfAction,
+                })}
             />
             <TransactionReviewOutputList
                 account={selectedAccount.account}
@@ -152,7 +152,13 @@ export const TransactionReviewModalContent = ({
                 outputs={outputs}
                 buttonRequestsCount={buttonRequestsCount}
                 isRbfAction={isRbfAction}
-                actionText={actionText}
+                actionText={getTransactionReviewModalActionText({
+                    ethereumStakeType,
+                    isRbfAction,
+                    isSending,
+                })}
+                isSending={isSending}
+                setIsSending={() => setIsSending(true)}
             />
             <TransactionReviewEvmExplanation account={selectedAccount.account} />
         </StyledModal>

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
@@ -89,6 +89,8 @@ export interface TransactionReviewOutputListProps {
     buttonRequestsCount: number;
     isRbfAction: boolean;
     actionText: TranslationKey;
+    isSending?: boolean;
+    setIsSending?: () => void;
 }
 
 export const TransactionReviewOutputList = ({
@@ -102,6 +104,8 @@ export const TransactionReviewOutputList = ({
     buttonRequestsCount,
     isRbfAction,
     actionText,
+    isSending,
+    setIsSending,
 }: TransactionReviewOutputListProps) => {
     const dispatch = useDispatch();
     const { networkType } = account;
@@ -141,6 +145,9 @@ export const TransactionReviewOutputList = ({
             },
         });
     const handleSend = () => {
+        if (networkType === 'solana') {
+            setIsSending?.();
+        }
         if (decision) {
             decision.resolve(true);
 
@@ -228,6 +235,7 @@ export const TransactionReviewOutputList = ({
                         <StyledButton
                             data-test="@modal/send"
                             isDisabled={!signedTx}
+                            isLoading={isSending}
                             onClick={handleSend}
                         >
                             <Translation id={actionText} />

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -6487,6 +6487,10 @@ export default defineMessages({
         id: 'TR_REPLACE_TX',
         defaultMessage: 'Replace transaction',
     },
+    TR_CONFIRMING_TX: {
+        id: 'TR_CONFIRMING_TX',
+        defaultMessage: 'Confirming transaction',
+    },
     TR_FINALIZE_TX: {
         id: 'TR_FINALIZE_TX',
         defaultMessage: 'Finalize transaction',

--- a/packages/suite/src/utils/suite/transactionReview.ts
+++ b/packages/suite/src/utils/suite/transactionReview.ts
@@ -4,11 +4,13 @@ import { StakeFormState } from '@suite-common/wallet-types';
 interface getTransactionReviewModalActionTextParams {
     ethereumStakeType: StakeFormState['ethereumStakeType'] | null;
     isRbfAction: boolean;
+    isSending?: boolean;
 }
 
 export const getTransactionReviewModalActionText = ({
     ethereumStakeType,
     isRbfAction,
+    isSending,
 }: getTransactionReviewModalActionTextParams): TranslationKey => {
     switch (ethereumStakeType) {
         case 'stake':
@@ -22,6 +24,10 @@ export const getTransactionReviewModalActionText = ({
 
     if (isRbfAction) {
         return 'TR_REPLACE_TX';
+    }
+
+    if (isSending) {
+        return 'TR_CONFIRMING_TX';
     }
 
     return 'SEND_TRANSACTION';


### PR DESCRIPTION
## Description

Followup on #11033 because I don't have permissions to push to Vaccumlabs fork.

This PR improves both parts of the old PR but still it's not a final solution for handling transaction status on Solana. It would be better to handle it with pending state in transaction list and more or less make it the same UX as on other chains but let's do it later

1. 1e1a11680e845ed731b404115c46cfb84a0b654e - Waiting on transaction status inside the modal is made using the "correct" approach so not using deprecated method. More on how I find the "correct" approach can be found [here](https://github.com/solana-labs/solana/issues/23949).
2. 766c42499c579c9e52c48ea96fc17faa3a51d9a3 - Just UI/UX improvements for the waiting time using loader and different button text.

## Screenshots:
![Screenshot 2024-03-08 at 2 19 43 PM](https://github.com/trezor/trezor-suite/assets/66002635/403b1702-737c-45c0-ba5d-4f3a42795707)
