### PR TITLE
fix(blockchain-link): fix hanging websocket

### DIFF
--- a/packages/blockchain-link/src/workers/baseWebsocket.ts
+++ b/packages/blockchain-link/src/workers/baseWebsocket.ts
@@ -225,9 +225,8 @@ export abstract class BaseWebsocket<T extends EventMap> extends TypedEmitter<T &
             clearTimeout(this.pingTimeout);
         }
 
-        if (this.isConnected()) {
-            this.disconnect();
-        }
+        this.disconnect();
+
         this.ws?.removeAllListeners();
         this.messages.rejectAll(
             new CustomError('websocket_runtime_error', 'Websocket closed unexpectedly'),


### PR DESCRIPTION
Occasionally on mobile it can happen, that worker gets into a state, when its WebSocket is closed due to no connection (e.g. app is in background) and it does not clear connectPromise. 

The worker and its backend is not properly cleaned due to disconnect called when ws state is closed and keeps returning error in promise, blocking backend disposal and initiation of a new one even if the connection is restored.

Resolves [#11153](https://github.com/trezor/trezor-suite/issues/11153)