### PR TITLE
chore: TS project references for build:libs + buildless utxo-lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
         "refs": "yarn update-project-references",
         "types": "yarn type-check",
         "messages": "yarn message-system-sign-config",
-        "validate": "yarn verify-project-references && yarn nx:lint:js && yarn nx:lint:styles && yarn nx:build:libs && yarn nx:type-check && yarn nx:test-unit && yarn check-workspace-resolutions",
+        "validate": "yarn verify-project-references && yarn lint:js && yarn nx:lint:styles && yarn nx:build:libs && yarn nx:type-check && yarn nx:test-unit && yarn check-workspace-resolutions",
         "a": "yarn native:android",
         "ios": "yarn native:ios",
         "p": "yarn native:prebuild",
@@ -143,6 +143,7 @@
         "tar": "^6.2.0",
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^4.2.0",
+        "tslib": "^2.6.2",
         "tsx": "^4.7.0",
         "typescript": "5.3.3",
         "version-bump-prompt": "^6.1.0"

--- a/packages/analytics/tsconfig.lib.json
+++ b/packages/analytics/tsconfig.lib.json
@@ -2,8 +2,11 @@
     "extends": "../../tsconfig.lib.json",
     "compilerOptions": {
         "outDir": "./lib",
-        "importHelpers": true,
         "esModuleInterop": false
     },
-    "include": ["./src"]
+    "include": ["./src"],
+    "references": [
+        { "path": "../env-utils" },
+        { "path": "../utils" }
+    ]
 }

--- a/packages/analytics/tsconfig.lib.json
+++ b/packages/analytics/tsconfig.lib.json
@@ -6,7 +6,11 @@
     },
     "include": ["./src"],
     "references": [
-        { "path": "../env-utils" },
-        { "path": "../utils" }
+        {
+            "path": "../env-utils"
+        },
+        {
+            "path": "../utils"
+        }
     ]
 }

--- a/packages/auth-server/package.json
+++ b/packages/auth-server/package.json
@@ -9,7 +9,7 @@
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
         "type-check": "yarn g:tsc --build",
         "dev": "yarn g:tsx watch ./src/index.ts",
-        "build": "rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/replace-imports.sh ./lib",
+        "build": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/replace-imports.sh ./lib",
         "start": "node ./lib/index.js"
     },
     "dependencies": {
@@ -18,5 +18,8 @@
     },
     "devDependencies": {
         "@types/cors": "^2.8.17"
+    },
+    "peerDependencies": {
+        "tslib": "^2.6.2"
     }
 }

--- a/packages/auth-server/tsconfig.lib.json
+++ b/packages/auth-server/tsconfig.lib.json
@@ -1,6 +1,8 @@
 {
     "extends": "../../tsconfig.lib.json",
-    "compilerOptions": { "outDir": "lib" },
+    "compilerOptions": {
+        "outDir": "lib"
+    },
     "include": ["./src"],
     "references": []
 }

--- a/packages/auth-server/tsconfig.lib.json
+++ b/packages/auth-server/tsconfig.lib.json
@@ -1,7 +1,6 @@
 {
     "extends": "../../tsconfig.lib.json",
-    "compilerOptions": {
-        "outDir": "lib"
-    },
-    "include": ["./src"]
+    "compilerOptions": { "outDir": "lib" },
+    "include": ["./src"],
+    "references": []
 }

--- a/packages/blockchain-link-types/package.json
+++ b/packages/blockchain-link-types/package.json
@@ -27,5 +27,8 @@
     "devDependencies": {
         "ripple-lib": "^1.10.1",
         "tsx": "^4.7.0"
+    },
+    "peerDependencies": {
+        "tslib": "^2.6.2"
     }
 }

--- a/packages/blockchain-link-types/tsconfig.lib.json
+++ b/packages/blockchain-link-types/tsconfig.lib.json
@@ -1,9 +1,15 @@
 {
     "extends": "../../tsconfig.lib.json",
-    "compilerOptions": { "outDir": "lib" },
+    "compilerOptions": {
+        "outDir": "lib"
+    },
     "include": ["./src"],
     "references": [
-        { "path": "../type-utils" },
-        { "path": "../utxo-lib" }
+        {
+            "path": "../type-utils"
+        },
+        {
+            "path": "../utxo-lib"
+        }
     ]
 }

--- a/packages/blockchain-link-types/tsconfig.lib.json
+++ b/packages/blockchain-link-types/tsconfig.lib.json
@@ -1,7 +1,9 @@
 {
     "extends": "../../tsconfig.lib.json",
-    "compilerOptions": {
-        "outDir": "lib"
-    },
-    "include": ["./src"]
+    "compilerOptions": { "outDir": "lib" },
+    "include": ["./src"],
+    "references": [
+        { "path": "../type-utils" },
+        { "path": "../utxo-lib" }
+    ]
 }

--- a/packages/blockchain-link-utils/tsconfig.lib.json
+++ b/packages/blockchain-link-utils/tsconfig.lib.json
@@ -1,10 +1,18 @@
 {
     "extends": "../../tsconfig.lib.json",
-    "compilerOptions": { "outDir": "lib" },
+    "compilerOptions": {
+        "outDir": "lib"
+    },
     "include": ["./src"],
     "references": [
-        { "path": "../utils" },
-        { "path": "../blockchain-link-types" },
-        { "path": "../type-utils" }
+        {
+            "path": "../utils"
+        },
+        {
+            "path": "../blockchain-link-types"
+        },
+        {
+            "path": "../type-utils"
+        }
     ]
 }

--- a/packages/blockchain-link-utils/tsconfig.lib.json
+++ b/packages/blockchain-link-utils/tsconfig.lib.json
@@ -1,8 +1,10 @@
 {
     "extends": "../../tsconfig.lib.json",
-    "compilerOptions": {
-        "outDir": "lib",
-        "importHelpers": true
-    },
-    "include": ["./src"]
+    "compilerOptions": { "outDir": "lib" },
+    "include": ["./src"],
+    "references": [
+        { "path": "../utils" },
+        { "path": "../blockchain-link-types" },
+        { "path": "../type-utils" }
+    ]
 }

--- a/packages/blockchain-link/tsconfig.lib.json
+++ b/packages/blockchain-link/tsconfig.lib.json
@@ -7,11 +7,23 @@
     },
     "include": ["./src"],
     "references": [
-        { "path": "../blockchain-link-types" },
-        { "path": "../blockchain-link-utils" },
-        { "path": "../utils" },
-        { "path": "../utxo-lib" },
-        { "path": "../e2e-utils" },
-        { "path": "../type-utils" }
+        {
+            "path": "../blockchain-link-types"
+        },
+        {
+            "path": "../blockchain-link-utils"
+        },
+        {
+            "path": "../utils"
+        },
+        {
+            "path": "../utxo-lib"
+        },
+        {
+            "path": "../e2e-utils"
+        },
+        {
+            "path": "../type-utils"
+        }
     ]
 }

--- a/packages/blockchain-link/tsconfig.lib.json
+++ b/packages/blockchain-link/tsconfig.lib.json
@@ -3,8 +3,15 @@
     "compilerOptions": {
         "outDir": "./lib",
         "lib": ["webworker"],
-        "types": ["jest", "node", "web"],
-        "importHelpers": true
+        "types": ["jest", "node", "web"]
     },
-    "include": ["./src"]
+    "include": ["./src"],
+    "references": [
+        { "path": "../blockchain-link-types" },
+        { "path": "../blockchain-link-utils" },
+        { "path": "../utils" },
+        { "path": "../utxo-lib" },
+        { "path": "../e2e-utils" },
+        { "path": "../type-utils" }
+    ]
 }

--- a/packages/connect-analytics/tsconfig.lib.json
+++ b/packages/connect-analytics/tsconfig.lib.json
@@ -5,5 +5,9 @@
         "esModuleInterop": false
     },
     "include": ["./src"],
-    "references": [{ "path": "../analytics" }]
+    "references": [
+        {
+            "path": "../analytics"
+        }
+    ]
 }

--- a/packages/connect-analytics/tsconfig.lib.json
+++ b/packages/connect-analytics/tsconfig.lib.json
@@ -2,8 +2,8 @@
     "extends": "../../tsconfig.lib.json",
     "compilerOptions": {
         "outDir": "./lib",
-        "importHelpers": true,
         "esModuleInterop": false
     },
-    "include": ["./src"]
+    "include": ["./src"],
+    "references": [{ "path": "../analytics" }]
 }

--- a/packages/connect-common/tsconfig.lib.json
+++ b/packages/connect-common/tsconfig.lib.json
@@ -2,8 +2,11 @@
     "extends": "../../tsconfig.lib.json",
     "compilerOptions": {
         "outDir": "./lib",
-        "importHelpers": true,
         "esModuleInterop": false
     },
-    "include": ["./src"]
+    "include": ["./src"],
+    "references": [
+        { "path": "../env-utils" },
+        { "path": "../utils" }
+    ]
 }

--- a/packages/connect-common/tsconfig.lib.json
+++ b/packages/connect-common/tsconfig.lib.json
@@ -6,7 +6,11 @@
     },
     "include": ["./src"],
     "references": [
-        { "path": "../env-utils" },
-        { "path": "../utils" }
+        {
+            "path": "../env-utils"
+        },
+        {
+            "path": "../utils"
+        }
     ]
 }

--- a/packages/connect-plugin-ethereum/tsconfig.lib.json
+++ b/packages/connect-plugin-ethereum/tsconfig.lib.json
@@ -2,8 +2,8 @@
     "extends": "../../tsconfig.lib.json",
     "compilerOptions": {
         "outDir": "lib",
-        "importHelpers": true,
         "lib": ["ES2019"]
     },
-    "include": ["./src"]
+    "include": ["./src"],
+    "references": []
 }

--- a/packages/connect-plugin-stellar/tsconfig.lib.json
+++ b/packages/connect-plugin-stellar/tsconfig.lib.json
@@ -1,6 +1,8 @@
 {
     "extends": "../../tsconfig.lib.json",
-    "compilerOptions": { "outDir": "lib" },
+    "compilerOptions": {
+        "outDir": "lib"
+    },
     "include": ["./src"],
     "references": []
 }

--- a/packages/connect-plugin-stellar/tsconfig.lib.json
+++ b/packages/connect-plugin-stellar/tsconfig.lib.json
@@ -1,8 +1,6 @@
 {
     "extends": "../../tsconfig.lib.json",
-    "compilerOptions": {
-        "outDir": "lib",
-        "importHelpers": true
-    },
-    "include": ["./src"]
+    "compilerOptions": { "outDir": "lib" },
+    "include": ["./src"],
+    "references": []
 }

--- a/packages/connect-web/tsconfig.lib.json
+++ b/packages/connect-web/tsconfig.lib.json
@@ -3,8 +3,12 @@
     "compilerOptions": {
         "outDir": "lib",
         "target": "es2017",
-        "types": ["chrome", "w3c-web-usb"],
-        "importHelpers": true
+        "types": ["chrome", "w3c-web-usb"]
     },
-    "include": ["./src"]
+    "include": ["./src"],
+    "references": [
+        { "path": "../connect" },
+        { "path": "../connect-common" },
+        { "path": "../utils" }
+    ]
 }

--- a/packages/connect-web/tsconfig.lib.json
+++ b/packages/connect-web/tsconfig.lib.json
@@ -7,8 +7,14 @@
     },
     "include": ["./src"],
     "references": [
-        { "path": "../connect" },
-        { "path": "../connect-common" },
-        { "path": "../utils" }
+        {
+            "path": "../connect"
+        },
+        {
+            "path": "../connect-common"
+        },
+        {
+            "path": "../utils"
+        }
     ]
 }

--- a/packages/connect-webextension/tsconfig.lib.json
+++ b/packages/connect-webextension/tsconfig.lib.json
@@ -3,8 +3,15 @@
     "compilerOptions": {
         "outDir": "lib",
         "target": "es2017",
-        "types": ["chrome", "w3c-web-usb"],
-        "importHelpers": true
+        "types": ["chrome", "w3c-web-usb"]
     },
-    "include": ["./src"]
+    "include": ["./src"],
+    "references": [
+        { "path": "../connect" },
+        { "path": "../connect-common" },
+        { "path": "../connect-web" },
+        { "path": "../utils" },
+        { "path": "../node-utils" },
+        { "path": "../trezor-user-env-link" }
+    ]
 }

--- a/packages/connect-webextension/tsconfig.lib.json
+++ b/packages/connect-webextension/tsconfig.lib.json
@@ -7,11 +7,23 @@
     },
     "include": ["./src"],
     "references": [
-        { "path": "../connect" },
-        { "path": "../connect-common" },
-        { "path": "../connect-web" },
-        { "path": "../utils" },
-        { "path": "../node-utils" },
-        { "path": "../trezor-user-env-link" }
+        {
+            "path": "../connect"
+        },
+        {
+            "path": "../connect-common"
+        },
+        {
+            "path": "../connect-web"
+        },
+        {
+            "path": "../utils"
+        },
+        {
+            "path": "../node-utils"
+        },
+        {
+            "path": "../trezor-user-env-link"
+        }
     ]
 }

--- a/packages/connect/tsconfig.lib.json
+++ b/packages/connect/tsconfig.lib.json
@@ -3,10 +3,20 @@
     "compilerOptions": {
         "outDir": "lib",
         "target": "es2019",
-        "lib": ["es2019", "webworker"],
-        // note: do not remove tslib from package.json. It might seem that it is not used
-        // but it is required due to importHelpers: true
-        "importHelpers": true
+        "lib": ["es2019", "webworker"]
     },
-    "include": ["./src"]
+    "include": ["./src"],
+    "references": [
+        { "path": "../blockchain-link" },
+        { "path": "../blockchain-link-types" },
+        { "path": "../connect-analytics" },
+        { "path": "../connect-common" },
+        { "path": "../protobuf" },
+        { "path": "../protocol" },
+        { "path": "../schema-utils" },
+        { "path": "../transport" },
+        { "path": "../utils" },
+        { "path": "../utxo-lib" },
+        { "path": "../trezor-user-env-link" }
+    ]
 }

--- a/packages/connect/tsconfig.lib.json
+++ b/packages/connect/tsconfig.lib.json
@@ -7,16 +7,38 @@
     },
     "include": ["./src"],
     "references": [
-        { "path": "../blockchain-link" },
-        { "path": "../blockchain-link-types" },
-        { "path": "../connect-analytics" },
-        { "path": "../connect-common" },
-        { "path": "../protobuf" },
-        { "path": "../protocol" },
-        { "path": "../schema-utils" },
-        { "path": "../transport" },
-        { "path": "../utils" },
-        { "path": "../utxo-lib" },
-        { "path": "../trezor-user-env-link" }
+        {
+            "path": "../blockchain-link"
+        },
+        {
+            "path": "../blockchain-link-types"
+        },
+        {
+            "path": "../connect-analytics"
+        },
+        {
+            "path": "../connect-common"
+        },
+        {
+            "path": "../protobuf"
+        },
+        {
+            "path": "../protocol"
+        },
+        {
+            "path": "../schema-utils"
+        },
+        {
+            "path": "../transport"
+        },
+        {
+            "path": "../utils"
+        },
+        {
+            "path": "../utxo-lib"
+        },
+        {
+            "path": "../trezor-user-env-link"
+        }
     ]
 }

--- a/packages/env-utils/tsconfig.lib.json
+++ b/packages/env-utils/tsconfig.lib.json
@@ -1,6 +1,8 @@
 {
     "extends": "../../tsconfig.lib.json",
-    "compilerOptions": { "outDir": "lib" },
+    "compilerOptions": {
+        "outDir": "lib"
+    },
     "include": ["./src"],
     "references": []
 }

--- a/packages/env-utils/tsconfig.lib.json
+++ b/packages/env-utils/tsconfig.lib.json
@@ -1,8 +1,6 @@
 {
     "extends": "../../tsconfig.lib.json",
-    "compilerOptions": {
-        "outDir": "lib",
-        "importHelpers": true
-    },
-    "include": ["./src"]
+    "compilerOptions": { "outDir": "lib" },
+    "include": ["./src"],
+    "references": []
 }

--- a/packages/protobuf/tsconfig.lib.json
+++ b/packages/protobuf/tsconfig.lib.json
@@ -1,8 +1,6 @@
 {
     "extends": "../../tsconfig.lib.json",
-    "compilerOptions": {
-        "outDir": "lib",
-        "importHelpers": true
-    },
-    "include": ["./src"]
+    "compilerOptions": { "outDir": "lib" },
+    "include": ["./src"],
+    "references": [{ "path": "../schema-utils" }]
 }

--- a/packages/protobuf/tsconfig.lib.json
+++ b/packages/protobuf/tsconfig.lib.json
@@ -1,6 +1,12 @@
 {
     "extends": "../../tsconfig.lib.json",
-    "compilerOptions": { "outDir": "lib" },
+    "compilerOptions": {
+        "outDir": "lib"
+    },
     "include": ["./src"],
-    "references": [{ "path": "../schema-utils" }]
+    "references": [
+        {
+            "path": "../schema-utils"
+        }
+    ]
 }

--- a/packages/protocol/tsconfig.lib.json
+++ b/packages/protocol/tsconfig.lib.json
@@ -1,6 +1,8 @@
 {
     "extends": "../../tsconfig.lib.json",
-    "compilerOptions": { "outDir": "lib" },
+    "compilerOptions": {
+        "outDir": "lib"
+    },
     "include": ["./src"],
     "references": []
 }

--- a/packages/protocol/tsconfig.lib.json
+++ b/packages/protocol/tsconfig.lib.json
@@ -1,8 +1,6 @@
 {
     "extends": "../../tsconfig.lib.json",
-    "compilerOptions": {
-        "outDir": "lib",
-        "importHelpers": true
-    },
-    "include": ["./src"]
+    "compilerOptions": { "outDir": "lib" },
+    "include": ["./src"],
+    "references": []
 }

--- a/packages/schema-utils/package.json
+++ b/packages/schema-utils/package.json
@@ -15,7 +15,7 @@
         "test:unit": "yarn g:jest",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
         "type-check": "yarn g:tsc --build",
-        "build:lib": "rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/replace-imports.sh ./lib",
+        "build:lib": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/replace-imports.sh ./lib",
         "codegen": "ts-node --skip-project ./src/codegen.ts",
         "prepublishOnly": "yarn tsx ../../scripts/prepublishNPM.js",
         "prepublish": "yarn tsx ../../scripts/prepublish.js"
@@ -28,5 +28,8 @@
     "dependencies": {
         "@sinclair/typebox": "^0.31.28",
         "ts-mixer": "^6.0.3"
+    },
+    "peerDependencies": {
+        "tslib": "^2.6.2"
     }
 }

--- a/packages/schema-utils/tsconfig.lib.json
+++ b/packages/schema-utils/tsconfig.lib.json
@@ -1,6 +1,8 @@
 {
     "extends": "../../tsconfig.lib.json",
-    "compilerOptions": { "outDir": "lib" },
+    "compilerOptions": {
+        "outDir": "lib"
+    },
     "include": ["./src"],
     "references": []
 }

--- a/packages/schema-utils/tsconfig.lib.json
+++ b/packages/schema-utils/tsconfig.lib.json
@@ -1,8 +1,6 @@
 {
     "extends": "../../tsconfig.lib.json",
-    "compilerOptions": {
-        "outDir": "lib",
-        "importHelpers": true
-    },
-    "include": ["./src"]
+    "compilerOptions": { "outDir": "lib" },
+    "include": ["./src"],
+    "references": []
 }

--- a/packages/transport/tsconfig.lib.json
+++ b/packages/transport/tsconfig.lib.json
@@ -6,9 +6,17 @@
     },
     "include": ["./src"],
     "references": [
-        { "path": "../protobuf" },
-        { "path": "../protocol" },
-        { "path": "../utils" },
-        { "path": "../trezor-user-env-link" }
+        {
+            "path": "../protobuf"
+        },
+        {
+            "path": "../protocol"
+        },
+        {
+            "path": "../utils"
+        },
+        {
+            "path": "../trezor-user-env-link"
+        }
     ]
 }

--- a/packages/transport/tsconfig.lib.json
+++ b/packages/transport/tsconfig.lib.json
@@ -2,8 +2,13 @@
     "extends": "../../tsconfig.lib.json",
     "compilerOptions": {
         "outDir": "./lib",
-        "types": ["w3c-web-usb"],
-        "importHelpers": true
+        "types": ["w3c-web-usb"]
     },
-    "include": ["./src"]
+    "include": ["./src"],
+    "references": [
+        { "path": "../protobuf" },
+        { "path": "../protocol" },
+        { "path": "../utils" },
+        { "path": "../trezor-user-env-link" }
+    ]
 }

--- a/packages/utils/tsconfig.lib.json
+++ b/packages/utils/tsconfig.lib.json
@@ -1,6 +1,8 @@
 {
     "extends": "../../tsconfig.lib.json",
-    "compilerOptions": { "outDir": "lib" },
+    "compilerOptions": {
+        "outDir": "lib"
+    },
     "include": ["./src"],
     "references": []
 }

--- a/packages/utils/tsconfig.lib.json
+++ b/packages/utils/tsconfig.lib.json
@@ -1,8 +1,6 @@
 {
     "extends": "../../tsconfig.lib.json",
-    "compilerOptions": {
-        "outDir": "lib",
-        "importHelpers": true
-    },
-    "include": ["./src"]
+    "compilerOptions": { "outDir": "lib" },
+    "include": ["./src"],
+    "references": []
 }

--- a/packages/utxo-lib/package.json
+++ b/packages/utxo-lib/package.json
@@ -20,13 +20,16 @@
         "utxo",
         "javascript"
     ],
-    "main": "./lib/index.js",
+    "main": "./src/index.ts",
     "files": [
         "lib/",
         "!**/*.map"
     ],
-    "types": "lib/index.d.ts",
-    "typings": "lib/index.d.ts",
+    "publishConfig": {
+        "main": "./lib/index.js",
+        "types": "lib/index.d.ts",
+        "typings": "lib/index.d.ts"
+    },
     "scripts": {
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
         "test:unit": "yarn g:jest --verbose -c jest.config.js",

--- a/packages/utxo-lib/tsconfig.lib.json
+++ b/packages/utxo-lib/tsconfig.lib.json
@@ -1,6 +1,12 @@
 {
     "extends": "../../tsconfig.lib.json",
-    "compilerOptions": { "outDir": "./lib" },
+    "compilerOptions": {
+        "outDir": "./lib"
+    },
     "include": ["./src"],
-    "references": [{ "path": "../utils" }]
+    "references": [
+        {
+            "path": "../utils"
+        }
+    ]
 }

--- a/packages/utxo-lib/tsconfig.lib.json
+++ b/packages/utxo-lib/tsconfig.lib.json
@@ -1,8 +1,6 @@
 {
     "extends": "../../tsconfig.lib.json",
-    "compilerOptions": {
-        "outDir": "./lib",
-        "importHelpers": true
-    },
-    "include": ["./src"]
+    "compilerOptions": { "outDir": "./lib" },
+    "include": ["./src"],
+    "references": [{ "path": "../utils" }]
 }

--- a/scripts/updateProjectReferences.ts
+++ b/scripts/updateProjectReferences.ts
@@ -28,9 +28,12 @@ const rootTsConfigLocation = path.join(__dirname, '..', 'tsconfig.json');
 
     const prettierConfig = await getPrettierConfig();
 
-    const serializeConfig = (config: any) => {
+    const serializeConfig = (config: any, stringifySpaces?: number) => {
         try {
-            return prettier.format(JSON.stringify(config).replace(/\\\\/g, '/'), prettierConfig);
+            return prettier.format(
+                JSON.stringify(config, null, stringifySpaces).replace(/\\\\/g, '/'),
+                prettierConfig,
+            );
         } catch (error) {
             console.error(error);
             process.exit(1);
@@ -135,7 +138,7 @@ const rootTsConfigLocation = path.join(__dirname, '..', 'tsconfig.json');
                     ) {
                         fs.writeFileSync(
                             workspaceLibConfigPath,
-                            await serializeConfig(workspaceLibConfig),
+                            await serializeConfig(workspaceLibConfig, 2),
                         );
                     }
                 } catch {

--- a/scripts/updateProjectReferences.ts
+++ b/scripts/updateProjectReferences.ts
@@ -119,6 +119,33 @@ const rootTsConfigLocation = path.join(__dirname, '..', 'tsconfig.json');
             if (!readOnlyGlobs.some((path: string) => minimatch(workspace.location, path))) {
                 fs.writeFileSync(workspaceConfigPath, await serializeConfig(workspaceConfig));
             }
+
+            // Copy references also to tsconfig.lib.json if exists
+            const workspaceLibConfigPath = path.resolve(workspacePath, 'tsconfig.lib.json');
+            if (fs.existsSync(workspaceLibConfigPath)) {
+                try {
+                    const workspaceLibConfig = JSON.parse(
+                        fs.readFileSync(workspaceLibConfigPath).toString(),
+                    );
+
+                    workspaceLibConfig.references = nextWorkspaceReferences;
+
+                    if (
+                        !readOnlyGlobs.some((path: string) => minimatch(workspace.location, path))
+                    ) {
+                        fs.writeFileSync(
+                            workspaceLibConfigPath,
+                            await serializeConfig(workspaceLibConfig),
+                        );
+                    }
+                } catch {
+                    console.error(
+                        chalk.bold.red('Error while parsing file: '),
+                        workspaceLibConfigPath,
+                    );
+                    process.exit(1);
+                }
+            }
         });
 
     if (isTesting) {

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -4,6 +4,7 @@
         "module": "commonjs",
         "moduleResolution": "node",
         "target": "es6",
+        "importHelpers": true,
 
         "composite": false,
         "incremental": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9568,6 +9568,8 @@ __metadata:
     "@types/cors": "npm:^2.8.17"
     cors: "npm:^2.8.5"
     express: "npm:^4.18.2"
+  peerDependencies:
+    tslib: ^2.6.2
   languageName: unknown
   linkType: soft
 
@@ -9581,6 +9583,8 @@ __metadata:
     ripple-lib: "npm:^1.10.1"
     socks-proxy-agent: "npm:6.1.1"
     tsx: "npm:^4.7.0"
+  peerDependencies:
+    tslib: ^2.6.2
   languageName: unknown
   linkType: soft
 
@@ -10114,6 +10118,8 @@ __metadata:
     ts-mixer: "npm:^6.0.3"
     ts-node: "npm:^10.9.2"
     tsx: "npm:^4.7.0"
+  peerDependencies:
+    tslib: ^2.6.2
   languageName: unknown
   linkType: soft
 
@@ -33249,6 +33255,7 @@ __metadata:
     tar: "npm:^6.2.0"
     ts-node: "npm:^10.9.2"
     tsconfig-paths: "npm:^4.2.0"
+    tslib: "npm:^2.6.2"
     tsx: "npm:^4.7.0"
     typescript: "npm:5.3.3"
     version-bump-prompt: "npm:^6.1.0"


### PR DESCRIPTION
I used TS project references also for build:libs it should not affect output just keeping things more consistent and it will also solve some errors that happened because of buildless utxo-lib (there was some defined global types was not available in other packages).

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
