### PR TITLE
feat(suite-desktop): use node-bridge as primary transport

### DIFF
--- a/docs/packages/suite-desktop.md
+++ b/docs/packages/suite-desktop.md
@@ -95,8 +95,9 @@ Available flags:
 | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--open-devtools`     | Open DevTools on app launch.                                                                                                                                                           |
 | `--pre-release`       | Tells the auto-updater to fetch pre-release updates.                                                                                                                                   |
-| `--bridge-dev`        | Instruct Bridge to support emulator (starts Bridge with `-e 21324`).                                                                                                                   |
-| `--bridge-node`       | Instruct Suite to start alternative node-bridge implementation                                                                                                                         |
+| `--bridge-legacy`     | Use Legacy (trezord-go) Bridge implementation                                                                                                                                          |
+| `--bridge-legacy-dev` | Instruct legacy (trezord-go) Bridge to support emulator (starts Bridge with `-e 21324`).                                                                                               |
+| `--bridge-dev`        | Instruct Bridge to support emulator on port 21324                                                                                                                                      |
 | `--log-level=NAME`    | Set the logging level. Available levels are [name (value)]: error (1), warn (2), info(3), debug (4). All logs with a value equal or lower to the selected log level will be displayed. |
 | `--log-write`         | Write log to disk                                                                                                                                                                      |
 | `--log-ui`            | Enables printing of UI console messages in the console.                                                                                                                                |


### PR DESCRIPTION
Another step in old bridge deprecation:
- ensure feature parity between old and new bridge
- make new bridge run by default in desktop app

As of now, suite-desktop e2e tests already use the new node bridge and it is also possible already to force the new bridge using `--bridge-node` flag. However suite-desktop app in production would still start trezord-go binary on startup. 


  - trezord-go is no longer started, trezor-suite starts node-bridge module which exposes the same interface as the old bridge instead
  - old bridge is stil runable using flags `--bridge-legacy` and `--bridge-legacy-dev` (for emulator support) 

issues: 
- #12163