### PR TITLE
fix(suite): distinguish account symbol for labelling addresses

### DIFF
--- a/packages/suite/src/components/suite/labeling/AddressLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/AddressLabeling.tsx
@@ -1,20 +1,22 @@
 import { findAccountsByAddress } from '@suite-common/wallet-utils';
 import { useSelector } from 'src/hooks/suite';
 import { AccountLabeling } from './AccountLabeling';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 
 interface AddressLabelingProps {
+    networkSymbol: NetworkSymbol;
     address?: string | null;
     knownOnly?: boolean;
 }
 
-export const AddressLabeling = ({ address, knownOnly }: AddressLabelingProps) => {
+export const AddressLabeling = ({ networkSymbol, address, knownOnly }: AddressLabelingProps) => {
     const accounts = useSelector(state => state.wallet.accounts);
 
-    if (!address) {
+    if (!address || !networkSymbol) {
         return null;
     }
 
-    const relevantAccounts = findAccountsByAddress(address, accounts);
+    const relevantAccounts = findAccountsByAddress(networkSymbol, address, accounts);
 
     if (relevantAccounts.length < 1) {
         return !knownOnly ? <span>{address}</span> : null;

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TargetAddressLabel.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TargetAddressLabel.tsx
@@ -3,6 +3,7 @@ import { WalletAccountTransaction } from 'src/types/wallet';
 import { ArrayElement } from '@trezor/type-utils';
 import { Translation, AddressLabeling } from 'src/components/suite';
 import { AccountLabels } from 'src/types/suite/metadata';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 
 const TruncatedSpan = styled.span<{ isBlurred?: boolean }>`
     overflow: hidden;
@@ -10,12 +11,18 @@ const TruncatedSpan = styled.span<{ isBlurred?: boolean }>`
 `;
 
 interface TargetAddressLabelProps {
+    networkSymbol: NetworkSymbol;
     target: ArrayElement<WalletAccountTransaction['targets']>;
     type: WalletAccountTransaction['type'];
     accountMetadata?: AccountLabels;
 }
 
-export const TargetAddressLabel = ({ target, type, accountMetadata }: TargetAddressLabelProps) => {
+export const TargetAddressLabel = ({
+    networkSymbol,
+    target,
+    type,
+    accountMetadata,
+}: TargetAddressLabelProps) => {
     const isLocalTarget = (type === 'sent' || type === 'self') && target.isAccountTarget;
 
     if (isLocalTarget) {
@@ -34,7 +41,7 @@ export const TargetAddressLabel = ({ target, type, accountMetadata }: TargetAddr
                 type === 'sent' ? (
                     // Using index as a key is safe as the array doesn't change (no filter/reordering, pushing new items)
 
-                    <AddressLabeling key={i} address={a} />
+                    <AddressLabeling key={i} address={a} networkSymbol={networkSymbol} />
                 ) : (
                     <span key={i}>{accountMetadata?.addressLabels[a] || a}</span>
                 ),

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TokenTransferAddressLabel.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TokenTransferAddressLabel.tsx
@@ -2,14 +2,17 @@ import { ArrayElement } from '@trezor/type-utils';
 import { Translation, AddressLabeling } from 'src/components/suite';
 import { WalletAccountTransaction } from 'src/types/wallet';
 import { BlurWrapper } from '../TransactionItemBlurWrapper';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 
 interface TokenTransferAddressLabelProps {
+    networkSymbol: NetworkSymbol;
     transfer: ArrayElement<WalletAccountTransaction['tokens']>;
     type: WalletAccountTransaction['type'];
     isPhishingTransaction: boolean;
 }
 
 export const TokenTransferAddressLabel = ({
+    networkSymbol,
     transfer,
     type,
     isPhishingTransaction,
@@ -20,7 +23,7 @@ export const TokenTransferAddressLabel = ({
     if (type === 'sent') {
         return (
             <BlurWrapper isBlurred={isPhishingTransaction}>
-                <AddressLabeling address={transfer.to} />
+                <AddressLabeling address={transfer.to} networkSymbol={networkSymbol} />
             </BlurWrapper>
         );
     }

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
@@ -45,6 +45,7 @@ export const TokenTransfer = ({
             {...baseLayoutProps}
             addressLabel={
                 <TokenTransferAddressLabel
+                    networkSymbol={transaction.symbol}
                     isPhishingTransaction={isPhishingTransaction}
                     transfer={transfer}
                     type={transaction.type}
@@ -81,7 +82,9 @@ export const InternalTransfer = ({
     return (
         <TransactionTargetLayout
             {...baseLayoutProps}
-            addressLabel={<AddressLabeling address={transfer.to} />}
+            addressLabel={
+                <AddressLabeling address={transfer.to} networkSymbol={transaction.symbol} />
+            }
             amount={
                 !baseLayoutProps.singleRowLayout && (
                     <StyledFormattedCryptoAmount
@@ -157,6 +160,7 @@ export const TransactionTarget = ({
                     isDisabled={isActionDisabled}
                     defaultVisibleValue={
                         <TargetAddressLabel
+                            networkSymbol={transaction.symbol}
                             accountMetadata={accountMetadata}
                             target={target}
                             type={transaction.type}

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Address/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Address/index.tsx
@@ -216,8 +216,11 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
     });
 
     // required for the correct functionality of bottom text in the input
-    const addressLabelComponent = <AddressLabeling address={addressValue} knownOnly />;
+    const addressLabelComponent = (
+        <AddressLabeling address={addressValue} knownOnly networkSymbol={symbol} />
+    );
     const isAddressWithLabel = !!addressLabelComponent.type({
+        networkSymbol: symbol,
         address: addressValue,
         knownOnly: true,
     });

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -122,7 +122,7 @@ export const addFakePendingTxThunk = createThunk<AddFakePendingTransactionParams
         }>(
             (result, output) => {
                 if (output.addresses) {
-                    findAccountsByAddress(output.addresses[0], accounts).forEach(
+                    findAccountsByAddress(account.symbol, output.addresses[0], accounts).forEach(
                         affectedAccount => {
                             if (affectedAccount.key === account.key) return accounts;
                             if (!result[affectedAccount.key]) {

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -378,19 +378,25 @@ export const findAccountsByNetwork = (symbol: NetworkSymbol, accounts: Account[]
 export const findAccountsByDescriptor = (descriptor: string, accounts: Account[]) =>
     accounts.filter(a => a.descriptor === descriptor);
 
-export const findAccountsByAddress = (address: string, accounts: Account[]) =>
-    accounts.filter(a => {
-        if (a.addresses) {
-            return (
-                a.addresses.used.find(u => u.address === address) ||
-                a.addresses.unused.find(u => u.address === address) ||
-                a.addresses.change.find(u => u.address === address) ||
-                a.descriptor === address
-            );
-        }
+export const findAccountsByAddress = (
+    networkSymbol: NetworkSymbol,
+    address: string,
+    accounts: Account[],
+) =>
+    accounts
+        .filter(account => account.symbol === networkSymbol)
+        .filter(a => {
+            if (a.addresses) {
+                return (
+                    a.addresses.used.find(u => u.address === address) ||
+                    a.addresses.unused.find(u => u.address === address) ||
+                    a.addresses.change.find(u => u.address === address) ||
+                    a.descriptor === address
+                );
+            }
 
-        return a.descriptor === address;
-    });
+            return a.descriptor === address;
+        });
 
 export const findAccountDevice = (account: Account, devices: TrezorDevice[]) =>
     devices.find(d => d.state === account.deviceState);


### PR DESCRIPTION
## Description

Fixed in tx history and in send form

I found some bugs which can be addressed in later releases #11537, #11536, #11535




## Related Issue

https://satoshilabs.slack.com/archives/G019WLX2P7B/p1710048435342539

## Screenshots:
In production, there would be ETH because eth accounts are first in accounts redux state object
![Screenshot 2024-03-11 at 12 14 37](https://github.com/trezor/trezor-suite/assets/33235762/8082b613-8b0e-4096-a3c4-26d07a201ca8)
