### PR TITLE
fix(github): add explorer and webextension to connect action

### DIFF
--- a/.github/workflows/connect-dev-release.yml
+++ b/.github/workflows/connect-dev-release.yml
@@ -8,15 +8,17 @@ permissions:
 on:
   pull_request:
     paths:
-      - "packages/blockchain-link"
+      - "packages/blockchain-link/**"
       - "packages/connect/**"
       - "packages/connect-common/**"
       - "packages/connect-iframe/**"
+      - "packages/connect-explorer/**"
+      - "packages/connect-webextension/**"
       - "packages/connect-web/**"
-      - "packages/transport"
-      - "packages/utxo-lib"
-      - "packages/utils"
-      - "submodules/trezor-common"
+      - "packages/transport/**"
+      - "packages/utxo-lib/**"
+      - "packages/utils/**"
+      - "submodules/trezor-common/**"
       - "yarn.lock"
       - ".github/workflows/connect-dev-release.yml"
 

--- a/.github/workflows/connect-test.yml
+++ b/.github/workflows/connect-test.yml
@@ -4,18 +4,18 @@ name: "[Test] connect"
 on:
   push:
     paths:
-      - "packages/blockchain-link"
+      - "packages/blockchain-link/**"
       - "packages/connect-common/**"
       - "packages/connect-iframe/**"
       - "packages/connect-web/**"
       - "packages/connect/**"
-      - "packages/protobuf"
-      - "packages/schema-utils"
-      - "packages/transport"
-      - "packages/utils"
-      - "packages/utxo-lib"
-      - "docker"
-      - "submodules/trezor-common"
+      - "packages/protobuf/**"
+      - "packages/schema-utils/**"
+      - "packages/transport/**"
+      - "packages/utils/**"
+      - "packages/utxo-lib/**"
+      - "docker/**"
+      - "submodules/trezor-common/**"
       - "yarn.lock"
 
 concurrency:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The main reason for this PR is to add the packages below to the path to run the action `.github/workflows/connect-dev-release.yml`:

      - "packages/connect-explorer/**"
      - "packages/connect-webextension/**"

But I also realized that in the path sometimes we are using `/**` at the end of the path and sometimes no. I think we should add it there for consistency and I think we want to run it even if sub-directories are changed.