### PR TITLE
chore(suite): reorganize media queries and selectors

### DIFF
--- a/packages/suite/src/views/wallet/send/index.tsx
+++ b/packages/suite/src/views/wallet/send/index.tsx
@@ -27,17 +27,20 @@ const SendLayout = styled(WalletLayout)`
 `;
 
 const FormGrid = styled.div`
-    display: grid;
-    grid-template-columns: minmax(500px, auto) minmax(340px, 420px);
     gap: ${spacingsPx.md};
 
-    > :not(:last-child) {
-        grid-column: 1;
-    }
+    ${breakpointMediaQueries.xl} {
+        display: grid;
+        grid-template-columns: minmax(500px, auto) minmax(340px, 420px);
 
-    > :last-child {
-        grid-column: 2;
-        grid-row: 1;
+        > :not(:last-child) {
+            grid-column: 1;
+        }
+
+        > :last-child {
+            grid-column: 2;
+            grid-row: 1;
+        }
     }
 
     ${breakpointMediaQueries.below_xl} {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Only apply styles for the screen sizes where they can be used.

![giphy](https://github.com/trezor/trezor-suite/assets/42465546/70ff52e1-8b84-45e1-aa98-c08670293aba)

## Screenshots:
Otherwise, you see this in devtools:
<img width="390" alt="Screenshot 2024-03-12 at 11 54 04" src="https://github.com/trezor/trezor-suite/assets/42465546/420d7570-3cc1-44bd-af9a-8521177f1634">
<img width="402" alt="Screenshot 2024-03-12 at 11 54 22" src="https://github.com/trezor/trezor-suite/assets/42465546/1a5eb13f-1358-4e73-bc4a-d9012847f7b9">

