### PR TITLE
fix(suite): prevent graph tooltip from rendering during discovery.

### DIFF
--- a/packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipDashboard.tsx
+++ b/packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipDashboard.tsx
@@ -20,7 +20,8 @@ interface GraphTooltipDashboardProps extends TooltipProps<number, any> {
 export const GraphTooltipDashboard = (props: GraphTooltipDashboardProps) => {
     const { FiatAmountFormatter } = useFormatters();
 
-    if (!props.active || !props.payload) {
+    // Note: payload is [] when discovery is paused.
+    if (!props.active || !props.payload?.length) {
         return null;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Prevent app from crashing when user hovers over graph during paused discovery.

Reproduction steps:
1. Start discovery of any wallet.
1. Click the wallet switcher in top left corner while discovery is still running.
1. Before it opens, hover over the loading graph.

Slack thread: https://satoshilabs.slack.com/archives/G019WLX2P7B/p1709741128743889

## Screenshots:
![image](https://github.com/trezor/trezor-suite/assets/42465546/227e5005-3784-4d74-a481-10eaabf2a93e)
See `active: true` and `payload: []`
![Screenshot 2024-03-12 at 17 03 53](https://github.com/trezor/trezor-suite/assets/42465546/ee07c009-1e0e-4d18-99bf-b5dc883dc2ef)


https://github.com/trezor/trezor-suite/assets/42465546/f290c59d-1094-463e-86e4-3d12df32ff92


