### PR TITLE
chore(ci): faster commit linting

### DIFF
--- a/.github/workflows/commit-messages-check.yml
+++ b/.github/workflows/commit-messages-check.yml
@@ -14,8 +14,8 @@ jobs:
 
       - name: Fetch base and current branch
         run: |
-          git fetch --no-tags origin ${{ github.base_ref }}
-          git fetch --no-tags ${{github.event.pull_request.head.repo.clone_url}} ${{ github.head_ref }}:${{ github.head_ref }}
+          git fetch --no-tags origin ${{ github.base_ref }} --depth=150
+          git fetch --no-tags ${{github.event.pull_request.head.repo.clone_url}} ${{ github.head_ref }}:${{ github.head_ref }} --depth=150
           git switch ${{ github.head_ref }}
 
       - name: Check commit messages


### PR DESCRIPTION
This should make this job much faster by fetching only last 150 commits instead of all, it currently runs for more than minute which is quite a lot for such simple thing like commit lint.

I tested this with fixup and other wrong formats of commits and it seems to work correctly.

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
