### PR TITLE
fix(suite): icon-only for no-fiat-rates situation

### DIFF
--- a/packages/suite/src/views/wallet/tokens/components/TokenList.tsx
+++ b/packages/suite/src/views/wallet/tokens/components/TokenList.tsx
@@ -192,7 +192,7 @@ export const TokenList = ({
                                                         />
                                                     </FiatWrapper>
                                                 ) : (
-                                                    <StyledNoRatesTooltip />
+                                                    <StyledNoRatesTooltip iconOnly={true} />
                                                 )}
                                             </Col>
                                         )}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Icon only for error in fiat rates for tokens

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/11483

## Screenshots:

![image](https://github.com/trezor/trezor-suite/assets/152899911/1047caba-4824-448e-8c4f-9c4ef65e0f60)
