### PR TITLE
fix(suite): phishing color banner

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx
@@ -35,12 +35,12 @@ const PhishingBanner = styled.div`
     padding: ${spacingsPx.xs} ${spacingsPx.sm};
     border-radius: ${borders.radii.xs};
     background: ${({ theme }) => theme.backgroundAlertRedBold};
-    color: ${({ theme }) => theme.textDefault};
+    color: ${({ theme }) => theme.textDefaultInverted};
     ${typography.hint};
 `;
 
 const HelpLink = styled(TrezorLink)`
-    color: ${({ theme }) => theme.textDefault};
+    color: ${({ theme }) => theme.textDefaultInverted};
     ${typography.hint}
 `;
 


### PR DESCRIPTION
## Description

- I used same color as is used for destructive message system banners

## Related Issue

fix #11561

## Screenshots:
![Screenshot 2024-03-13 at 18 49 02](https://github.com/trezor/trezor-suite/assets/33235762/af8fa602-0bc4-4583-9ae6-c9192371bf0f)
![Screenshot 2024-03-13 at 18 48 09](https://github.com/trezor/trezor-suite/assets/33235762/1ccf5ced-1431-4654-b39b-fb97d6935a0a)

