### PR TITLE
ci(github): schedule to connect tests

### DIFF
--- a/.github/workflows/connect-test.yml
+++ b/.github/workflows/connect-test.yml
@@ -2,6 +2,9 @@ name: "[Test] connect"
 
 # run only if there are changes in connect or related libs paths
 on:
+  schedule:
+    # Runs at midnight UTC every day at 01:00 AM CET
+    - cron: "0 0 * * *"
   pull_request:
     paths:
       - "packages/blockchain-link/**"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Following our strategy https://github.com/trezor/trezor-suite/issues/11228 and in the process of making GitHub Actions the house of our tests we should run them everyday on schedule to find out if some unexpected change broke them.

Related to https://github.com/trezor/trezor-suite/issues/7916