### PR TITLE
fix(suite-web-test): updating test group tags in gitlab job

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -104,7 +104,7 @@ suite web migrations:
     CYPRESS_USE_TREZOR_USER_ENV_BRIDGE: 1
   parallel:
     matrix:
-      - TEST_GROUP: "@group:migrations"
+      - TEST_GROUP: "@group_migrations"
         CONTAINERS: "trezor-user-env-unix"
 
 suite web:

--- a/docs/tests/e2e-suite-web.md
+++ b/docs/tests/e2e-suite-web.md
@@ -130,17 +130,17 @@ in run_tests.js.
 
 At the moment, there are the following tags:
 
--   @group:[string]
+-   @group\_[string]
 -   @retry=[number]
 
 #### @group
 
 Assigning a @group allows run_tests.js script to sort the test files into groups and run them in parallel on CI. At the moment these groups exist:
 
--   `@group:metadata`
--   `@group:device-management`
--   `@group:suite`
--   `@group:settings`
+-   `@group_metadata`
+-   `@group_device-management`
+-   `@group_suite`
+-   `@group_settings`
 
 #### @retry
 


### PR DESCRIPTION
Updating test group names in the `test.yaml` so canary tests also run on gitlab again


