### PR TITLE
chore: loosen Nx config

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -2,11 +2,9 @@
     "extends": "nx/presets/npm.json",
     "namedInputs": {
         "sharedGlobals": [
-            "{workspaceRoot}/nx.json",
             "{workspaceRoot}/.yarnrc.yml",
             "{workspaceRoot}/patches/*.patch",
-            "{workspaceRoot}/package.json",
-            "{workspaceRoot}/.github/workflows/*.yml"
+            "{workspaceRoot}/package.json"
         ],
         "default": ["{projectRoot}/**/*", "sharedGlobals"],
         "prod": ["default", "!{projectRoot}/**/*.test.{ts,tsx}"]


### PR DESCRIPTION
There is some issue with Nx affected command that runs everything all the time on CI, but it's impossible to debug it because when I do any changes in CI or Nx config it will run everything because of this config anyway so I need to (at least temporarily) remove it.

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
