### PR TITLE
chore(suite): refactoring: split components for DeviceItem

### DIFF
--- a/packages/components/src/components/assets/Icon/Icon.stories.tsx
+++ b/packages/components/src/components/assets/Icon/Icon.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { Icon as IconComponent, IconProps, variables } from '../../../index';
+import { Icon as IconComponent, IconProps, variables, IconVariant } from '../../../index';
 
 const meta: Meta = {
     title: 'Assets/Icons',
@@ -9,11 +9,24 @@ export default meta;
 
 export const Icon: StoryObj<IconProps> = {
     args: {
-        icon: 'ARROW_DOWN',
+        icon: 'TAG',
+        variant: 'primary',
     },
     argTypes: {
         icon: {
             options: variables.ICONS,
+            control: {
+                type: 'select',
+            },
+        },
+        variant: {
+            options: ['primary', 'tertiary', 'info', 'destructive', 'warning'] as IconVariant[],
+            control: {
+                type: 'select',
+            },
+        },
+        color: {
+            options: [undefined, '#9be887'],
             control: {
                 type: 'select',
             },

--- a/packages/components/src/components/assets/Icon/Icon.tsx
+++ b/packages/components/src/components/assets/Icon/Icon.tsx
@@ -5,11 +5,20 @@ import { ReactSVG } from 'react-svg';
 import { ICONS } from './icons';
 import { UIVariant } from '../../../config/types';
 import { CSSColor, Color, Colors } from '@trezor/theme';
+import { TransientProps } from '../../../utils/transientProps';
 
 export type IconVariant = Extract<
     UIVariant,
     'primary' | 'tertiary' | 'info' | 'warning' | 'destructive'
 >;
+
+type ExclusiveColorOrVariant =
+    | { variant?: IconVariant; color?: undefined }
+    | {
+          variant?: undefined;
+          /** @deprecated Use only is case of absolute desperation. Prefer using `variant`. */
+          color?: string;
+      };
 
 const variantColorMap: Record<IconVariant, Color> = {
     primary: 'iconPrimaryDefault',
@@ -20,10 +29,8 @@ const variantColorMap: Record<IconVariant, Color> = {
 };
 
 type ColorProps = {
-    $variant?: IconVariant;
     theme: Colors;
-    $color?: string;
-};
+} & TransientProps<ExclusiveColorOrVariant>;
 
 const getColorForIconVariant = ({
     $variant,
@@ -40,12 +47,10 @@ const getColorForIconVariant = ({
 export type IconType = keyof typeof ICONS;
 
 type SvgWrapperProps = {
-    $color: WrapperProps['color'] | undefined;
-    $variant: IconVariant | undefined;
     $hoverColor: WrapperProps['hoverColor'];
     $size: WrapperProps['size'];
     $useCursorPointer: WrapperProps['useCursorPointer'];
-};
+} & TransientProps<ExclusiveColorOrVariant>;
 
 const SvgWrapper = styled.div<SvgWrapperProps>`
     display: flex;
@@ -95,14 +100,7 @@ export type IconProps = SVGAttributes<HTMLDivElement> & {
     hoverColor?: string;
     useCursorPointer?: boolean;
     'data-test'?: string;
-} & (
-        | { variant?: IconVariant; color?: undefined }
-        | {
-              variant?: undefined;
-              /** @deprecated Use only is case of absolute desperation. Prefer using `variant`. */
-              color?: string;
-          }
-    );
+} & ExclusiveColorOrVariant;
 
 export const Icon = forwardRef(
     (
@@ -130,8 +128,7 @@ export const Icon = forwardRef(
             $size={size}
             ref={ref}
             $useCursorPointer={onClick !== undefined || useCursorPointer}
-            $color={color}
-            $variant={variant}
+            {...(variant !== undefined ? { $variant: variant } : { $color: color })}
             data-test={dataTest}
         >
             <ReactSVG

--- a/packages/components/src/components/typography/Link/Link.tsx
+++ b/packages/components/src/components/typography/Link/Link.tsx
@@ -73,6 +73,12 @@ const Link = ({
 
     const iconSize = typographyStylesBase[type || 'body'].fontSize;
 
+    const {
+        variant: iconVariant,
+        color: iconColor,
+        ...restIconVariant
+    } = iconProps ?? { variant: undefined };
+
     return (
         <A
             href={href}
@@ -89,7 +95,14 @@ const Link = ({
             {children}
             {icon && (
                 <IconWrapper>
-                    <Icon size={iconSize} icon={icon} color={theme.iconSubdued} {...iconProps} />
+                    <Icon
+                        size={iconSize}
+                        icon={icon}
+                        {...(variant !== undefined
+                            ? { variant: iconVariant }
+                            : { color: iconColor ?? theme.iconSubdued })}
+                        {...restIconVariant}
+                    />
                 </IconWrapper>
             )}
         </A>

--- a/packages/components/src/components/typography/Text/Text.tsx
+++ b/packages/components/src/components/typography/Text/Text.tsx
@@ -2,11 +2,20 @@ import styled from 'styled-components';
 import { UIVariant } from '../../../config/types';
 import { CSSColor, Color, Colors, TypographyStyle, typography } from '@trezor/theme';
 import { ReactNode } from 'react';
+import { TransientProps } from '../../../utils/transientProps';
 
 export type TextVariant = Extract<
     UIVariant,
     'primary' | 'tertiary' | 'info' | 'warning' | 'destructive'
 >;
+
+type ExclusiveColorOrVariant =
+    | { variant?: TextVariant; color?: undefined }
+    | {
+          variant?: undefined;
+          /** @deprecated Use only is case of absolute desperation. Prefer using `variant`. */
+          color?: string;
+      };
 
 const variantColorMap: Record<TextVariant, Color> = {
     primary: 'textPrimaryDefault',
@@ -17,10 +26,8 @@ const variantColorMap: Record<TextVariant, Color> = {
 };
 
 type ColorProps = {
-    $variant?: TextVariant;
     theme: Colors;
-    $color?: string;
-};
+} & TransientProps<ExclusiveColorOrVariant>;
 
 const getColorForTextVariant = ({
     $variant,
@@ -35,10 +42,8 @@ const getColorForTextVariant = ({
 };
 
 type StyledTextProps = {
-    $variant?: TextVariant;
-    $color?: string;
     $typographyStyle?: TypographyStyle;
-};
+} & ExclusiveColorOrVariant;
 
 const StyledText = styled.span<StyledTextProps>`
     color: ${getColorForTextVariant};
@@ -49,20 +54,12 @@ type TextProps = {
     children: ReactNode;
     className?: string;
     typographyStyle?: TypographyStyle;
-} & (
-    | { variant?: TextVariant; color?: undefined }
-    | {
-          variant?: undefined;
-          /** @deprecated Use only is case of absolute desperation. Prefer using `variant`. */
-          color?: string;
-      }
-);
+} & ExclusiveColorOrVariant;
 
 export const Text = ({ variant, color, children, className, typographyStyle }: TextProps) => {
     return (
         <StyledText
-            $variant={variant}
-            $color={color}
+            {...(variant !== undefined ? { $variant: variant } : { $color: color })}
             className={className}
             $typographyStyle={typographyStyle}
         >

--- a/packages/components/src/components/typography/Text/Text.tsx
+++ b/packages/components/src/components/typography/Text/Text.tsx
@@ -3,10 +3,14 @@ import { UIVariant } from '../../../config/types';
 import { CSSColor, Color, Colors, TypographyStyle, typography } from '@trezor/theme';
 import { ReactNode } from 'react';
 
-export type TextVariant = Extract<UIVariant, 'primary' | 'info' | 'warning' | 'destructive'>;
+export type TextVariant = Extract<
+    UIVariant,
+    'primary' | 'tertiary' | 'info' | 'warning' | 'destructive'
+>;
 
 const variantColorMap: Record<TextVariant, Color> = {
     primary: 'textPrimaryDefault',
+    tertiary: 'textSubdued',
     info: 'textAlertBlue',
     warning: 'textAlertYellow',
     destructive: 'textAlertRed',
@@ -18,7 +22,11 @@ type ColorProps = {
     $color?: string;
 };
 
-const getColor = ({ $variant, theme, $color }: ColorProps): CSSColor | 'inherit' | string => {
+const getColorForTextVariant = ({
+    $variant,
+    theme,
+    $color,
+}: ColorProps): CSSColor | 'inherit' | string => {
     if ($color !== undefined) {
         return $color;
     }
@@ -26,12 +34,14 @@ const getColor = ({ $variant, theme, $color }: ColorProps): CSSColor | 'inherit'
     return $variant === undefined ? 'inherit' : theme[variantColorMap[$variant]];
 };
 
-const StyledText = styled.span<{
+type StyledTextProps = {
     $variant?: TextVariant;
     $color?: string;
     $typographyStyle?: TypographyStyle;
-}>`
-    color: ${getColor};
+};
+
+const StyledText = styled.span<StyledTextProps>`
+    color: ${getColorForTextVariant};
     ${({ $typographyStyle }) => ($typographyStyle ? typography[$typographyStyle] : '')}
 `;
 

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceStatusWithLabel.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceStatusWithLabel.tsx
@@ -7,18 +7,9 @@ import { TrezorDevice } from 'src/types/suite';
 import { useWalletLabeling } from '../../../labeling/WalletLabeling';
 import { DeviceModelInternal } from '@trezor/connect';
 import { DeviceStatusText } from 'src/views/suite/SwitchDevice/DeviceItem/DeviceStatusText';
-import { spacingsPx, typography } from '@trezor/theme';
 import { selectLabelingDataForWallet } from '../../../../../reducers/suite/metadataReducer';
 import { useDispatch, useSelector } from '../../../../../hooks/suite';
-
-const DeviceLabel = styled.div`
-    ${typography.body};
-    margin-bottom: -${spacingsPx.xxs};
-    min-width: 0;
-    color: ${({ theme }) => theme.textDefault};
-    overflow: hidden;
-    text-overflow: ellipsis;
-`;
+import { DeviceDetail } from '../../../../../views/suite/SwitchDevice/DeviceItem/DeviceDetail';
 
 const DeviceWrapper = styled.div<{ $isLowerOpacity: boolean }>`
     display: flex;
@@ -30,14 +21,6 @@ const StyledImage = styled(Image)`
 
     /* do not apply the darkening filter in dark mode on device images */
     filter: none;
-`;
-
-const DeviceDetail = styled.div`
-    display: flex;
-    flex: 1;
-    flex-direction: column;
-    overflow: hidden;
-    align-self: center;
 `;
 
 const needsRefresh = (device?: TrezorDevice) => {
@@ -99,9 +82,7 @@ export const DeviceStatusWithLabel = () => {
                 )}
             </DeviceWrapper>
 
-            <DeviceDetail>
-                <DeviceLabel>{selectedDevice.label}</DeviceLabel>
-
+            <DeviceDetail label={selectedDevice.label}>
                 <DeviceStatusText
                     onRefreshClick={handleRefreshClick}
                     device={selectedDevice}

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTypeIcon.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTypeIcon.tsx
@@ -17,7 +17,7 @@ const ClockIcon = styled(Icon)`
     border-radius: 50%;
 `;
 
-interface TransactionTypeIconProps extends Omit<IconProps, 'icon'> {
+interface TransactionTypeIconProps extends Omit<IconProps, 'icon' | 'variant'> {
     type: WalletAccountTransaction['type'];
     isPending: boolean;
 }

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceConnectionText.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceConnectionText.tsx
@@ -1,0 +1,46 @@
+import { Icon, IconType, Text, TextVariant } from '@trezor/components';
+import { spacingsPx, typography } from '@trezor/theme';
+import styled, { css } from 'styled-components';
+import { ReactNode } from 'react';
+
+const Container = styled.span<{ $isAction?: boolean }>`
+    ${typography.label}
+
+    ${({ $isAction }) =>
+        $isAction &&
+        css`
+            &:hover {
+                opacity: 0.8;
+            }
+        `}
+`;
+const TextRow = styled.div`
+    display: flex;
+    align-items: center;
+    gap: ${spacingsPx.xxs};
+`;
+
+type DeviceConnectionTextProps = {
+    onClick?: () => void;
+    variant: TextVariant;
+    'data-test'?: string;
+    icon: IconType;
+    children: ReactNode;
+    isAction?: boolean;
+};
+
+export const DeviceConnectionText = ({
+    onClick,
+    variant,
+    'data-test': dataTest,
+    children,
+    icon,
+    isAction,
+}: DeviceConnectionTextProps) => (
+    <Container $isAction={isAction} onClick={onClick} data-test={dataTest}>
+        <TextRow>
+            <Icon icon={icon} size={12} variant={variant} />
+            <Text variant={variant}>{children} </Text>
+        </TextRow>
+    </Container>
+);

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceDetail.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceDetail.tsx
@@ -1,0 +1,26 @@
+import { TruncateWithTooltip } from '@trezor/components';
+import { spacingsPx, typography } from '@trezor/theme';
+import { ReactNode } from 'react';
+import styled from 'styled-components';
+
+const Container = styled.div`
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    overflow: hidden;
+    align-self: center;
+`;
+
+const DeviceLabel = styled(TruncateWithTooltip)`
+    ${typography.body};
+    margin-bottom: -${spacingsPx.xxs};
+    min-width: 0;
+    color: ${({ theme }) => theme.textDefault};
+`;
+
+export const DeviceDetail = ({ label, children }: { label: string; children: ReactNode }) => (
+    <Container>
+        <DeviceLabel>{label}</DeviceLabel>
+        {children}
+    </Container>
+);


### PR DESCRIPTION
Just another refactoring to split some spaghetti code.

\+ Better usage of variants for Text and Icon component

![image](https://github.com/trezor/trezor-suite/assets/152899911/ec5b945a-6f39-4363-9f2c-24fcf42a96e8)
