### PR TITLE
ci(github): connect e2e to run in schedule

### DIFF
--- a/.github/workflows/connect-dev-release-test.yml
+++ b/.github/workflows/connect-dev-release-test.yml
@@ -5,6 +5,9 @@ permissions:
   contents: read # for actions/checkout
 
 on:
+  schedule:
+    # Runs at midnight UTC every day at 01:00 AM CET
+    - cron: "0 0 * * *"
   pull_request:
     paths:
       - "packages/blockchain-link/**"
@@ -19,7 +22,7 @@ on:
       - "packages/utils/**"
       - "submodules/trezor-common/**"
       - "yarn.lock"
-      - ".github/workflows/connect-dev-release.yml"
+      - ".github/workflows/connect-dev-release-test.yml"
       - ".github/workflows/template-connect-popup-test-params.yml"
 
 concurrency:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Make connect e2e tests run on schedule as well.

And fixing wrong path " ".github/workflows/connect-dev-release-test.yml""