### PR TITLE
feat(suite-desktop): Remove unused permission descriptions from Info.plist

### DIFF
--- a/packages/suite-desktop/electron-builder-config.js
+++ b/packages/suite-desktop/electron-builder-config.js
@@ -99,6 +99,15 @@ module.exports = {
         darkModeSupport: true,
         entitlements: 'entitlements.mac.inherit.plist',
         entitlementsInherit: 'entitlements.mac.inherit.plist',
+        extendInfo: {
+            // Delete those keys from Info.plist, Electron adds them by default but Trezor Suite does not need these permissions
+            NSBluetoothAlwaysUsageDescription: undefined,
+            NSBluetoothPeripheralUsageDescription: undefined,
+            NSMicrophoneUsageDescription: undefined,
+            // Replace default "This app needs access to the camera" message with our own
+            NSCameraUsageDescription:
+                'Allow Trezor Suite to access the camera to scan QR codes? Or enter the address manually.',
+        },
         target: ['dmg', 'zip'],
     },
     win: {


### PR DESCRIPTION
## Description

Electron add those by default https://github.com/electron/electron/blob/3759e59bbda0ea9fe0660288b2f3e6ff8d139c56/shell/browser/resources/mac/Info.plist#L49 It doesn't mean that app requests for those permissions. But it can confuse some people if they check the source code.

Notes for @trezor/qa:
Please test Mac version, scanning QR code

How to reset camera permission on Mac? You can't just disallow it in settings, then app never asked again. You need to call from terminal:
`tccutil reset Camera io.trezor.TrezorSuite` (or `tccutil reset Camera io.trezor.TrezorSuite.dev` for dev builds)

## Screenshot
<img width="275" alt="image" src="https://github.com/trezor/trezor-suite/assets/3729633/70f081e8-3e87-4d12-b0dc-9be2491a2bd6">
<img width="1734" alt="image" src="https://github.com/trezor/trezor-suite/assets/3729633/7000e725-938e-4f14-b097-c10cc3056672">
