### PR TITLE
ci(github): transport e2e test to github

### DIFF
--- a/.github/workflows/connect-transport-e2e-test.yml
+++ b/.github/workflows/connect-transport-e2e-test.yml
@@ -1,0 +1,40 @@
+name: "[Test] Transport e2e"
+
+on:
+  schedule:
+    # Runs at midnight UTC every day at 01:00 AM CET
+    - cron: "0 0 * * *"
+  pull_request:
+    paths:
+      - "packages/transport/**"
+      - "packages/protobuf/**"
+      - "packages/protocol/**"
+      - "packages/trezor-user-env-link/**"
+      - "packages/utils/**"
+      - "docker/docker-compose.transport-test.yml"
+      - ".github/workflows/connect-transport-e2e-test.yml"
+      - "yarn.lock"
+
+jobs:
+  transport-e2e:
+    runs-on: ubuntu-latest
+    env:
+      COMPOSE_FILE: ./docker/docker-compose.transport-test.yml
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Install dependencies
+        run: |
+          yarn install --immutable
+          yarn build:libs
+
+      - name: Run E2E tests
+        run: ./docker/docker-transport-test.sh


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Migration of Transport e2e tests to GitHub Actions.

Related to https://github.com/trezor/trezor-suite/issues/7916


It works!

![image](https://github.com/trezor/trezor-suite/assets/5362163/ac8eea5e-c5a4-4b14-8221-eed9c13632e9)
