### PR TITLE
chore(ci): disable LFS for suite-web build + tests

### DIFF
--- a/.github/workflows/build-test-suite-web-e2e.yaml
+++ b/.github/workflows/build-test-suite-web-e2e.yaml
@@ -27,8 +27,7 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v4
-              with:
-                  lfs: true
+
             - name: Configure aws credentials
               uses: aws-actions/configure-aws-credentials@v4
               with:
@@ -95,8 +94,7 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v4
-              with:
-                  lfs: true
+
             - name: Setup node
               uses: actions/setup-node@v4
               with:

--- a/.github/workflows/connect-dev-release-test.yml
+++ b/.github/workflows/connect-dev-release-test.yml
@@ -39,8 +39,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          lfs: true
           submodules: recursive
+
+      # Pull only files needed for connect to save LFS bandwidth
+      - name: "Pull LFS files for connect"
+        run: git lfs pull --include "packages/connect-common/files/**/*"
 
       - name: Configure aws credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/connect-nextra-dev-release.yml
+++ b/.github/workflows/connect-nextra-dev-release.yml
@@ -24,8 +24,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          lfs: true
           submodules: recursive
+
+      # Pull only files needed for connect to save LFS bandwidth
+      - name: "Pull LFS files for connect"
+        run: git lfs pull --include "packages/connect-common/files/**/*"
 
       - name: Configure aws credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/release-suite-config.yml
+++ b/.github/workflows/release-suite-config.yml
@@ -25,8 +25,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          lfs: true
+
       - name: Configure aws credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:


### PR DESCRIPTION
Removed `lfs` from CI flows where it's not needed. Specifically suite-web e2e did lfs pull in every job in matrix which is a lot. Also added some filter to specific job to fetch only very needed files for connect.

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
