### PR TITLE
fix(connect): More robust conversion of e.g. `44h` to `44'`

### DIFF
--- a/packages/connect/src/device/__tests__/resolveDescriptorForTaproot.test.ts
+++ b/packages/connect/src/device/__tests__/resolveDescriptorForTaproot.test.ts
@@ -51,4 +51,23 @@ describe(resolveDescriptorForTaproot.name, () => {
             xpub: "tr([71d98c03/86'/0'/0']xpub6CXYpDGLuWpjqFXRTbo8LMYVsiiRjwWiDY7iwDkq1mk4GDYE7TWmSBCnNmbcVYQK4T56RZRRwhCAG7ucTBHAG2rhWHpXdMQtkZVDeVuv33p/<0;1>/*)",
         });
     });
+
+    it('wont break when taproot xpub ends with "h" before the end', () => {
+        const response = resolveDescriptorForTaproot({
+            response: originalResponse,
+            publicKey: {
+                ...publicKey,
+
+                // This breaks the `publicKey` data-object integrity, but for this test its fine
+                descriptor:
+                    // ............................................... There is this "h" at the end before "/" which may break the "h" to "'" replacement ⬎
+                    'tr([71d98c03/86h/0h/0h]xpub6CXYpDGLuWpjqFXRTbo8LMYVsiiRjwWiDY7iwDkq1mk4GDYE7TWmSBCnNmbcVYQK4T56RZRRwhCAG7ucTBHAG2rhWHpXdMQtkZVDeVuv33h/<0;1>/*)#gvfjd7ak',
+            },
+        });
+
+        expect(response).toEqual({
+            checksum: 'gvfjd7ak',
+            xpub: "tr([71d98c03/86'/0'/0']xpub6CXYpDGLuWpjqFXRTbo8LMYVsiiRjwWiDY7iwDkq1mk4GDYE7TWmSBCnNmbcVYQK4T56RZRRwhCAG7ucTBHAG2rhWHpXdMQtkZVDeVuv33h/<0;1>/*)",
+        });
+    });
 });

--- a/packages/connect/src/device/__tests__/resolveDescriptorForTaproot.test.ts
+++ b/packages/connect/src/device/__tests__/resolveDescriptorForTaproot.test.ts
@@ -70,4 +70,22 @@ describe(resolveDescriptorForTaproot.name, () => {
             xpub: "tr([71d98c03/86'/0'/0']xpub6CXYpDGLuWpjqFXRTbo8LMYVsiiRjwWiDY7iwDkq1mk4GDYE7TWmSBCnNmbcVYQK4T56RZRRwhCAG7ucTBHAG2rhWHpXdMQtkZVDeVuv33h/<0;1>/*)",
         });
     });
+
+    it("work for descriptor in non-extended version. The checksum won't be shown tho.", () => {
+        const response = resolveDescriptorForTaproot({
+            response: originalResponse,
+            publicKey: {
+                ...publicKey,
+
+                // descriptor is xpub in non-extended form
+                descriptor:
+                    'xpub6CXYpDGLuWpjqFXRTbo8LMYVsiiRjwWiDY7iwDkq1mk4GDYE7TWmSBCnNmbcVYQK4T56RZRRwhCAG7ucTBHAG2rhWHpXdMQtkZVDeVuv33p',
+            },
+        });
+
+        expect(response).toEqual({
+            checksum: undefined, // code is defensive, it will work but it wont provide checksum
+            xpub: "tr([71d98c03/86'/0'/0']xpub6CXYpDGLuWpjqFXRTbo8LMYVsiiRjwWiDY7iwDkq1mk4GDYE7TWmSBCnNmbcVYQK4T56RZRRwhCAG7ucTBHAG2rhWHpXdMQtkZVDeVuv33p/<0;1>/*)",
+        });
+    });
 });

--- a/packages/connect/src/device/resolveDescriptorForTaproot.ts
+++ b/packages/connect/src/device/resolveDescriptorForTaproot.ts
@@ -11,25 +11,32 @@ export const resolveDescriptorForTaproot = ({ response, publicKey }: Params) => 
         const [xpub, checksum] = publicKey.descriptor.split('#');
 
         // This is here to keep backwards compatibility, suite and blockbooks are still using `'` over `h`
-        const [beforeOpeningSquareBracket, afterOpeningSquareBracket] = xpub.split('[');
-        const [path, afterClosingSquareBracket] = afterOpeningSquareBracket.split(']');
+        const openingSquareBracketSplit = xpub.split('[');
+        if (openingSquareBracketSplit.length === 2) {
+            const [beforeOpeningBracket, afterOpeningBracket] = openingSquareBracketSplit;
 
-        const correctedPath = path.replace(/h/g, "'"); // .replaceAll()
+            const closingSquareBracketSplit = afterOpeningBracket.split(']');
+            if (closingSquareBracketSplit.length === 2) {
+                const [path, afterClosingBracket] = closingSquareBracketSplit;
 
-        return {
-            xpub: `${beforeOpeningSquareBracket}[${correctedPath}]${afterClosingSquareBracket}`,
-            checksum,
-        };
-    } else {
-        // wrap regular xpub into bitcoind native descriptor
-        const fingerprint = Number(publicKey.root_fingerprint || 0)
-            .toString(16)
-            .padStart(8, '0');
-        const descriptorPath = `${fingerprint}${response.serializedPath.substring(1)}`;
+                const correctedPath = path.replace(/h/g, "'"); // .replaceAll()
 
-        return {
-            xpub: `tr([${descriptorPath}]${response.xpub}/<0;1>/*)`,
-            checksum: undefined,
-        };
+                return {
+                    xpub: `${beforeOpeningBracket}[${correctedPath}]${afterClosingBracket}`,
+                    checksum,
+                };
+            }
+        }
     }
+
+    // wrap regular xpub into bitcoind native descriptor
+    const fingerprint = Number(publicKey.root_fingerprint || 0)
+        .toString(16)
+        .padStart(8, '0');
+    const descriptorPath = `${fingerprint}${response.serializedPath.substring(1)}`;
+
+    return {
+        xpub: `tr([${descriptorPath}]${response.xpub}/<0;1>/*)`,
+        checksum: undefined,
+    };
 };

--- a/packages/connect/src/device/resolveDescriptorForTaproot.ts
+++ b/packages/connect/src/device/resolveDescriptorForTaproot.ts
@@ -10,11 +10,14 @@ export const resolveDescriptorForTaproot = ({ response, publicKey }: Params) => 
     if (publicKey.descriptor !== null && publicKey.descriptor !== undefined) {
         const [xpub, checksum] = publicKey.descriptor.split('#');
 
+        // This is here to keep backwards compatibility, suite and blockbooks are still using `'` over `h`
+        const [beforeOpeningSquareBracket, afterOpeningSquareBracket] = xpub.split('[');
+        const [path, afterClosingSquareBracket] = afterOpeningSquareBracket.split(']');
+
+        const correctedPath = path.replace(/h/g, "'"); // .replaceAll()
+
         return {
-            xpub: xpub
-                // This is here to keep backwards compatibility, suite and blockbooks are still using `'` over `h`
-                .replace(/h\//g, "'/")
-                .replace(/h]/g, "']"),
+            xpub: `${beforeOpeningSquareBracket}[${correctedPath}]${afterClosingSquareBracket}`,
             checksum,
         };
     } else {


### PR DESCRIPTION
Fixes the bug, where `h` at the end of the xpub can break the conversion of `h` to `'`