### PR TITLE
ci(github): Connect legacy and canary tests migrated to GitHub Actions

### DIFF
--- a/.github/workflows/connect-test-params.yml
+++ b/.github/workflows/connect-test-params.yml
@@ -10,6 +10,11 @@ on:
         description: "Test pattern to use (e.g. `init` or `methods`)"
         type: "string"
         required: true
+      tests-firmware:
+        description: "Firmware version for the tests (example 2-latest, 2.2.0, 2-main)"
+        type: "string"
+        required: false
+        default: "2-latest"
 
 jobs:
   node:
@@ -27,7 +32,7 @@ jobs:
       # todo: ideally do not install everything. possibly only devDependencies could be enough for testing (if there was not for building libs)?
       - run: sed -i "/\"node\"/d" package.json
       - run: yarn install
-      - run: './docker/docker-connect-test.sh node -p "${{ inputs.test-pattern }}" -f 2-latest -i ${{ inputs.methods }}'
+      - run: './docker/docker-connect-test.sh node -p "${{ inputs.test-pattern }}" -f ${{ inputs.tests-firmware }} -i ${{ inputs.methods }}'
 
   web:
     name: web
@@ -58,4 +63,4 @@ jobs:
       - run: cd packages/connect-iframe && tree .
       - name: "Echo download path"
         run: echo ${{steps.download.outputs.download-path}}
-      - run: './docker/docker-connect-test.sh web -p "${{ inputs.test-pattern }}" -f 2-latest -i ${{ inputs.methods }}'
+      - run: './docker/docker-connect-test.sh web -p "${{ inputs.test-pattern }}" -f ${{ inputs.tests-firmware }} -i ${{ inputs.methods }}'

--- a/.github/workflows/connect-test.yml
+++ b/.github/workflows/connect-test.yml
@@ -66,12 +66,37 @@ jobs:
     with:
       test-pattern: "init authorizeCoinjoin cancelCoinjoinAuthorization passphrase unlockPath setBusy override checkFirmwareAuthenticity"
 
+  legacy-canary-firmware-api:
+    needs: [build]
+    if: github.event_name == 'schedule'
+    uses: ./.github/workflows/connect-test-params.yml
+    with:
+      test-pattern: "init authorizeCoinjoin cancelCoinjoinAuthorization passphrase unlockPath setBusy override checkFirmwareAuthenticity"
+      tests-firmware: ${{ matrix.firmware }}
+    strategy:
+      matrix:
+        firmware: ["2.2.0", "2-main"]
+      fail-fast: false
+
   management:
     needs: [build]
     uses: ./.github/workflows/connect-test-params.yml
     with:
       test-pattern: methods
       methods: "applySettings,applyFlags,getFeatures,getFirmwareHash"
+
+  legacy-canary-firmware-management:
+    needs: [build]
+    if: github.event_name == 'schedule'
+    uses: ./.github/workflows/connect-test-params.yml
+    with:
+      test-pattern: methods
+      methods: "applySettings,applyFlags,getFeatures,getFirmwareHash"
+      tests-firmware: ${{ matrix.firmware }}
+    strategy:
+      matrix:
+        firmware: ["2.2.0", "2-main"]
+      fail-fast: false
 
   btc-sign:
     needs: [build]
@@ -80,12 +105,38 @@ jobs:
       test-pattern: methods
       methods: "signTransaction"
 
+  legacy-canary-firmware-btc-sign:
+    needs: [build]
+    if: github.event_name == 'schedule'
+    uses: ./.github/workflows/connect-test-params.yml
+    with:
+      test-pattern: methods
+      methods: "signTransaction"
+      tests-firmware: ${{ matrix.firmware }}
+    strategy:
+      matrix:
+        firmware: ["2.2.0", "2-main"]
+      fail-fast: false
+
   btc-others:
     needs: [build]
     uses: ./.github/workflows/connect-test-params.yml
     with:
       test-pattern: methods
       methods: "getAccountInfo,getAccountDescriptor,getAddress,getPublicKey,signMessage,verifyMessage,composeTransaction,getOwnershipId,getOwnershipProof"
+
+  legacy-canary-firmware-btc-others:
+    needs: [build]
+    if: github.event_name == 'schedule'
+    uses: ./.github/workflows/connect-test-params.yml
+    with:
+      test-pattern: methods
+      methods: "getAccountInfo,getAccountDescriptor,getAddress,getPublicKey,signMessage,verifyMessage,composeTransaction,getOwnershipId,getOwnershipProof"
+      tests-firmware: ${{ matrix.firmware }}
+    strategy:
+      matrix:
+        firmware: ["2.2.0", "2-main"]
+      fail-fast: false
 
   stellar:
     needs: [build]
@@ -94,12 +145,38 @@ jobs:
       test-pattern: methods
       methods: "stellarGetAddress,stellarSignTransaction"
 
+  legacy-canary-firmware-stellar:
+    needs: [build]
+    if: github.event_name == 'schedule'
+    uses: ./.github/workflows/connect-test-params.yml
+    with:
+      test-pattern: methods
+      methods: "stellarGetAddress,stellarSignTransaction"
+      tests-firmware: ${{ matrix.firmware }}
+    strategy:
+      matrix:
+        firmware: ["2.2.0", "2-main"]
+      fail-fast: false
+
   cardano:
     needs: [build]
     uses: ./.github/workflows/connect-test-params.yml
     with:
       test-pattern: methods
       methods: "cardanoGetAddress,cardanoGetNativeScriptHash,cardanoGetPublicKey,cardanoSignTransaction"
+
+  legacy-canary-firmware-cardano:
+    needs: [build]
+    if: github.event_name == 'schedule'
+    uses: ./.github/workflows/connect-test-params.yml
+    with:
+      test-pattern: methods
+      methods: "cardanoGetAddress,cardanoGetNativeScriptHash,cardanoGetPublicKey,cardanoSignTransaction"
+      tests-firmware: ${{ matrix.firmware }}
+    strategy:
+      matrix:
+        firmware: ["2.2.0", "2-main"]
+      fail-fast: false
 
   eos:
     needs: [build]
@@ -108,12 +185,38 @@ jobs:
       test-pattern: methods
       methods: "eosGetPublicKey,eosSignTransaction"
 
+  legacy-canary-firmware-eos:
+    needs: [build]
+    if: github.event_name == 'schedule'
+    uses: ./.github/workflows/connect-test-params.yml
+    with:
+      test-pattern: methods
+      methods: "eosGetPublicKey,eosSignTransaction"
+      tests-firmware: ${{ matrix.firmware }}
+    strategy:
+      matrix:
+        firmware: ["2.2.0", "2-main"]
+      fail-fast: false
+
   ethereum:
     needs: [build]
     uses: ./.github/workflows/connect-test-params.yml
     with:
       test-pattern: methods
       methods: "ethereumGetAddress,ethereumGetPublicKey,ethereumSignMessage,ethereumSignTransaction,ethereumVerifyMessage,ethereumSignTypedData"
+
+  legacy-canary-firmware-ethereum:
+    needs: [build]
+    if: github.event_name == 'schedule'
+    uses: ./.github/workflows/connect-test-params.yml
+    with:
+      test-pattern: methods
+      methods: "ethereumGetAddress,ethereumGetPublicKey,ethereumSignMessage,ethereumSignTransaction,ethereumVerifyMessage,ethereumSignTypedData"
+      tests-firmware: ${{ matrix.firmware }}
+    strategy:
+      matrix:
+        firmware: ["2.2.0", "2-main"]
+      fail-fast: false
 
   nem:
     needs: [build]
@@ -122,12 +225,38 @@ jobs:
       test-pattern: methods
       methods: "nemGetAddress,nemSignTransaction"
 
+  legacy-canary-firmware-nem:
+    needs: [build]
+    if: github.event_name == 'schedule'
+    uses: ./.github/workflows/connect-test-params.yml
+    with:
+      test-pattern: methods
+      methods: "nemGetAddress,nemSignTransaction"
+      tests-firmware: ${{ matrix.firmware }}
+    strategy:
+      matrix:
+        firmware: ["2.2.0", "2-main"]
+      fail-fast: false
+
   ripple:
     needs: [build]
     uses: ./.github/workflows/connect-test-params.yml
     with:
       test-pattern: methods
       methods: "rippleGetAddress,rippleSignTransaction"
+
+  legacy-canary-firmware-ripple:
+    needs: [build]
+    if: github.event_name == 'schedule'
+    uses: ./.github/workflows/connect-test-params.yml
+    with:
+      test-pattern: methods
+      methods: "rippleGetAddress,rippleSignTransaction"
+      tests-firmware: ${{ matrix.firmware }}
+    strategy:
+      matrix:
+        firmware: ["2.2.0", "2-main"]
+      fail-fast: false
 
   tezos:
     needs: [build]
@@ -136,9 +265,35 @@ jobs:
       test-pattern: methods
       methods: "tezosGetAddress,tezosGetPublicKey,tezosSignTransaction"
 
+  legacy-canary-firmware-tezos:
+    needs: [build]
+    if: github.event_name == 'schedule'
+    uses: ./.github/workflows/connect-test-params.yml
+    with:
+      test-pattern: methods
+      methods: "tezosGetAddress,tezosGetPublicKey,tezosSignTransaction"
+      tests-firmware: ${{ matrix.firmware }}
+    strategy:
+      matrix:
+        firmware: ["2.2.0", "2-main"]
+      fail-fast: false
+
   binance:
     needs: [build]
     uses: ./.github/workflows/connect-test-params.yml
     with:
       test-pattern: methods
       methods: "binanceGetAddress,binanceGetPublicKey,binanceSignTransaction"
+
+  legacy-canary-firmware-binance:
+    needs: [build]
+    if: github.event_name == 'schedule'
+    uses: ./.github/workflows/connect-test-params.yml
+    with:
+      test-pattern: methods
+      methods: "binanceGetAddress,binanceGetPublicKey,binanceSignTransaction"
+      tests-firmware: ${{ matrix.firmware }}
+    strategy:
+      matrix:
+        firmware: ["2.2.0", "2-main"]
+      fail-fast: false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Migrating connect legacy and canary firmware tests to GitHub actions so they run only on schedule.

## Related Issue

Related https://github.com/trezor/trezor-suite/issues/7916


To make sure they work I run all the tests here: https://github.com/trezor/trezor-suite/actions/runs/8328480111?pr=11620

But the legacy and canary should be running only on schedule
