### PR TITLE
Add Rainbow Browser Extension to knownHosts

### DIFF
--- a/packages/connect/src/data/config.ts
+++ b/packages/connect/src/data/config.ts
@@ -36,6 +36,16 @@ export const config = {
             label: 'MetaMask',
             icon: '',
         },
+        {
+            origin: 'bpcdaglidgnlggelgbjfagekoapjmccp',
+            label: 'Rainbow',
+            icon: '',
+        },
+        {
+            origin: 'opfgelmcmbiajamepnmloijbpoleiama',
+            label: 'Rainbow',
+            icon: '',
+        },
         { origin: 'file://', label: ' ', icon: '' },
     ],
     onionDomains: {

--- a/packages/connect/src/data/config.ts
+++ b/packages/connect/src/data/config.ts
@@ -38,7 +38,7 @@ export const config = {
         },
         {
             origin: 'bpcdaglidgnlggelgbjfagekoapjmccp',
-            label: 'Rainbow',
+            label: 'Rainbow DEV',
             icon: '',
         },
         {


### PR DESCRIPTION
## Description
I'd like to add Rainbow's extension ids to the knownHosts array so that the permissions copy looks a little nicer in the Trezor popup.
