### PR TITLE
fix(suite-native): better back handling after add coin error

### DIFF
--- a/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
+++ b/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { useNavigation } from '@react-navigation/native';
+import { CommonActions, useNavigation } from '@react-navigation/native';
 import { A, pipe } from '@mobily/ts-belt';
 
 import { AccountType, NetworkSymbol, Network, networks } from '@suite-common/wallet-config';
@@ -28,6 +28,7 @@ import {
     StackToStackCompositeNavigationProps,
     RootStackRoutes,
     AddCoinFlowType,
+    AppTabsRoutes,
 } from '@suite-native/navigation';
 
 type NavigationProps = StackToStackCompositeNavigationProps<
@@ -312,8 +313,23 @@ export const useAddCoinAccount = () => {
         ).unwrap();
 
         if (!account) {
-            navigation.goBack();
             showGeneralErrorAlert();
+            navigation.dispatch(
+                CommonActions.reset({
+                    index: 0,
+                    routes: [
+                        {
+                            name: RootStackRoutes.AppTabs,
+                            params: {
+                                screen:
+                                    flowType === 'accounts'
+                                        ? AppTabsRoutes.AccountsStack
+                                        : AppTabsRoutes.ReceiveStack,
+                            },
+                        },
+                    ],
+                }),
+            );
         }
     };
 


### PR DESCRIPTION
When user adds account via type selection and it ends with error the app stayed on loading screen and didnt go back. 

Now it resets route to assets or receive screen.

Resolve #11317