### PR TITLE
PIN 5 -  do not allow to cancel PIN entry during discovery

### DIFF
--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -263,6 +263,11 @@ export const en = {
                     'Follow the keypad layout on your Trezor device to enter your PIN on your mobile display. Your PIN will be hidden on your mobile display for your security. <link>Learn more here</link>.',
             },
         },
+        pinCanceledDuringDiscovery: {
+            title: 'Some of your balances have not been loaded.',
+            subtitle: 'You need to unlock your device in order to finish loading your balances',
+            button: 'Enter PIN again',
+        },
     },
     moduleDevice: {
         IncompatibleDeviceModalAppendix: {


### PR DESCRIPTION
## Description

 It's an edge case, when device get locked during discovery, canceling PIN entry would lead to inconsistent state.
 
 How to reproduce:
 - Use allall wallet or any other with lot of accounts so discovery takes more than 1 minute. 
 - set auto-lock time to 1 minute (via desktop Suite or trezor-ctl)
 - connect & unlock device
 - discovery started, but before finished, device get locked
 
With this fix, discovery should continue after the user enters the PIN.
 
 This solution is only applicable for the T2 model.
 The T1 model does not report the device as locked during discovery. Instead, the discovery process becomes stuck, which is the same behavior observed on the Suite Desktop.

<!--- Describe your changes in detail -->

## Related Issue

Followup for https://github.com/trezor/trezor-suite/pull/10740 
Related to #10596

## Screenshots:

<img width="230" alt="image" src="https://github.com/trezor/trezor-suite/assets/3729633/36e2b95d-d62f-46be-962c-335950c981a5">


https://github.com/trezor/trezor-suite/assets/3729633/83361d5d-d497-46d7-855c-b8c0c14d24c0




