### PR TITLE
feat(coinmarket): Hide low fee option in sell

### DIFF
--- a/packages/suite/src/hooks/wallet/useCoinmarketSellForm.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketSellForm.ts
@@ -102,7 +102,7 @@ export const useCoinmarketSellForm = ({
     const { shouldSendInSats } = useBitcoinAmountUnit(symbol);
 
     const coinFees = fees[symbol];
-    const levels = getFeeLevels(networkType, coinFees);
+    const levels = getFeeLevels(networkType, coinFees).filter(level => level.label !== 'low');
     const feeInfo = { ...coinFees, levels };
     const symbolForFiat = mapTestnetSymbol(symbol);
     const localCurrencyOption = { value: localCurrency, label: localCurrency.toUpperCase() };


### PR DESCRIPTION
 Hide low fee option in Sell in Trade section

## Related Issue

Resolve #11577

## Screenshots:
![image](https://github.com/trezor/trezor-suite/assets/12121074/ffc64d70-e6ea-47c6-8950-a3893090d31d)
