### PR TITLE
feat(suite): show staking text in tx review modal

### DIFF
--- a/packages/suite-web/e2e/tests/suite/passphrase-cardano.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase-cardano.test.ts
@@ -61,7 +61,7 @@ describe('Passphrase with cardano', () => {
         cy.task('pressYes');
         cy.wait(501);
         cy.task('pressYes');
-        cy.getTestElement('@modal/confirm-address/address-field').should(
+        cy.getTestElement('@device-display/paginated-text').should(
             'contain',
             correctPassphraseAddr,
         );

--- a/packages/suite-web/e2e/tests/suite/passphrase-legacy.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase-legacy.test.ts
@@ -53,7 +53,7 @@ describe.skip('Passphrase - legacy flow', () => {
         cy.getTestElement('@switch-device/wallet-on-index/2').click();
         cy.getTestElement('@dashboard/receive-button').click();
         cy.getTestElement('@wallet/receive/reveal-address-button').click();
-        cy.getTestElement('@modal/confirm-address/address-field');
+        cy.getTestElement('@device-display/chunked-text');
     });
 });
 

--- a/packages/suite-web/e2e/tests/suite/passphrase.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase.test.ts
@@ -64,7 +64,7 @@ describe('Passphrase', () => {
         cy.getTestElement('@wallet/menu/wallet-receive').click({ timeout: 10000 });
         // click reveal address
         cy.getTestElement('@wallet/receive/reveal-address-button').click();
-        cy.getTestElement('@modal/confirm-address/address-field')
+        cy.getTestElement('@device-display/chunked-text')
             .find('[data-test*="chunk"]')
             .then(chunks => {
                 let fullAddress = '';
@@ -118,7 +118,7 @@ describe('Passphrase', () => {
         cy.getTestElement('@wallet/receive/used-address/0').should('not.exist');
         cy.getTestElement('@wallet/receive/reveal-address-button').should('not.be.disabled');
         cy.getTestElement('@wallet/receive/reveal-address-button').click();
-        cy.getTestElement('@modal/confirm-address/address-field')
+        cy.getTestElement('@device-display/chunked-text')
             .find('[data-test*="chunk"]')
             .then(chunks => {
                 let fullAddress = '';
@@ -151,7 +151,7 @@ describe('Passphrase', () => {
         cy.getTestElement('@wallet/receive/reveal-address-button').click();
 
         // should display confirm passphrase modal
-        cy.getTestElement('@modal/confirm-address/address-field')
+        cy.getTestElement('@device-display/chunked-text')
             .find('[data-test*="chunk"]')
             .then(chunks => {
                 let fullAddress = '';

--- a/packages/suite-web/e2e/tests/wallet/check-coins-xpub.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/check-coins-xpub.test.ts
@@ -43,9 +43,9 @@ describe('Check coins XPUB', () => {
 
             cy.getTestElement('@wallet/menu/wallet-details').click();
             cy.getTestElement('@wallets/details/show-xpub-button').click();
-            cy.getTestElement('@xpub-modal/xpub-field').should('exist');
+            cy.getTestElement('@device-display/paginated-text').should('exist');
             if (coin !== 'ada') {
-                cy.getTestElement('@xpub-modal/xpub-field')
+                cy.getTestElement('@device-display/paginated-text')
                     .should('be.visible')
                     .invoke('text')
                     .should('contain', 'zpub');

--- a/packages/suite/src/components/suite/DeviceDisplay/DisplayChunks.tsx
+++ b/packages/suite/src/components/suite/DeviceDisplay/DisplayChunks.tsx
@@ -18,7 +18,6 @@ const ChunksContainer = styled.div`
 
 type DisplayChunksProps = {
     isPixelType: boolean;
-    'data-test'?: string;
     address: string;
 };
 
@@ -35,11 +34,7 @@ const groupByN = <T,>(arr: T[], n: number): T[][] =>
         return result;
     }, [] as T[][]);
 
-export const DisplayChunks = ({
-    isPixelType,
-    'data-test': dataTest,
-    address,
-}: DisplayChunksProps) => {
+export const DisplayChunks = ({ isPixelType, address }: DisplayChunksProps) => {
     const showChunksInRows = (chunks: string[][] | undefined, isNextAddress?: boolean) =>
         chunks?.map((row, rowIndex) => (
             <Row key={rowIndex} $isAlignedRight={rowIndex === 0 && isNextAddress}>
@@ -69,7 +64,7 @@ export const DisplayChunks = ({
     };
 
     return (
-        <ChunksContainer onCopy={handleOnCopy} data-test={dataTest}>
+        <ChunksContainer onCopy={handleOnCopy} data-test="@device-display/chunked-text">
             {showChunksInRows(groupedChunks)}
         </ChunksContainer>
     );

--- a/packages/suite/src/components/suite/DeviceDisplay/DisplayPaginatedText.tsx
+++ b/packages/suite/src/components/suite/DeviceDisplay/DisplayPaginatedText.tsx
@@ -21,7 +21,6 @@ const Container = styled.div`
 
 type DisplayPaginatedTextProps = {
     isPixelType: boolean;
-    'data-test'?: string;
     text: string;
     deviceModel: DeviceModelInternal;
 };
@@ -77,7 +76,6 @@ const Row = ({
 
 export const DisplayPaginatedText = ({
     isPixelType,
-    'data-test': dataTest,
     text,
     deviceModel,
 }: DisplayPaginatedTextProps) => {
@@ -93,7 +91,10 @@ export const DisplayPaginatedText = ({
                 const isLastPage = pageIndex === pages.length - 1;
 
                 return (
-                    <Page key={`page-${pageIndex}`} data-test={isFirstPage ? dataTest : undefined}>
+                    <Page
+                        key={`page-${pageIndex}`}
+                        data-test={isFirstPage ? '@device-display/paginated-text' : undefined}
+                    >
                         {page.rows.map((row, index) => (
                             <Row
                                 isPrevPageIconOnDevice={isPrevPageIconOnDevice}

--- a/packages/suite/src/components/suite/DeviceDisplay/DisplaySinglePageWrapText.tsx
+++ b/packages/suite/src/components/suite/DeviceDisplay/DisplaySinglePageWrapText.tsx
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+import { DeviceDisplayText } from './DeviceDisplayText';
+
+const TextWrapper = styled.div<{ $isPixelType: boolean }>`
+    width: ${({ $isPixelType }) => ($isPixelType ? '10ch' : '20ch')};
+    font-family: inherit;
+`;
+
+type DisplaySinglePageWrapTextProps = {
+    isPixelType: boolean;
+    text: string;
+};
+
+export const DisplaySinglePageWrapText = ({
+    isPixelType,
+    text,
+}: DisplaySinglePageWrapTextProps) => (
+    <DeviceDisplayText $isPixelType={isPixelType} data-test="@device-display/single-page-wrap-text">
+        <TextWrapper $isPixelType={isPixelType}>{text}</TextWrapper>
+    </DeviceDisplayText>
+);

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 
 import { showAddress } from 'src/actions/wallet/receiveActions';
 import { Translation } from 'src/components/suite';
-import { useSelector } from 'src/hooks/suite';
+import { useDisplayMode, useSelector } from 'src/hooks/suite';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 import { ConfirmValueModal, ConfirmValueModalProps } from './ConfirmValueModal/ConfirmValueModal';
 
@@ -13,6 +13,7 @@ interface ConfirmAddressModalProps
 
 export const ConfirmAddressModal = ({ addressPath, value, ...props }: ConfirmAddressModalProps) => {
     const account = useSelector(selectSelectedAccount);
+    const displayMode = useDisplayMode();
 
     const validateAddress = useCallback(
         () => showAddress(addressPath, value),
@@ -36,7 +37,7 @@ export const ConfirmAddressModal = ({ addressPath, value, ...props }: ConfirmAdd
             validateOnDevice={validateAddress}
             value={value}
             copyButtonDataTest="@metadata/copy-address-button"
-            valueDataTest="@modal/confirm-address/address-field"
+            displayMode={displayMode}
             {...props}
         />
     );

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
@@ -10,7 +10,7 @@ import { QrCode } from 'src/components/suite/QrCode';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { Translation, Modal } from 'src/components/suite';
 import { MODAL } from 'src/actions/suite/constants';
-import { ThunkAction } from 'src/types/suite';
+import { DisplayMode, ThunkAction } from 'src/types/suite';
 import { DeviceDisconnected } from './DeviceDisconnected';
 import { TransactionReviewStepIndicator } from '../TransactionReviewModal/TransactionReviewOutputList/TransactionReviewStepIndicator';
 import { TransactionReviewOutputElement } from '../TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement';
@@ -75,7 +75,7 @@ export interface ConfirmValueModalProps extends Pick<ModalProps, 'onCancel' | 'h
     isConfirmed?: boolean;
     validateOnDevice: () => ThunkAction;
     value: string;
-    valueDataTest?: string;
+    displayMode: DisplayMode;
 }
 
 export const ConfirmValueModal = ({
@@ -89,7 +89,7 @@ export const ConfirmValueModal = ({
     onCancel,
     validateOnDevice,
     value,
-    valueDataTest,
+    displayMode,
 }: ConfirmValueModalProps) => {
     const device = useSelector(selectDevice);
     const modalContext = useSelector(state => state.modal.context);
@@ -164,7 +164,7 @@ export const ConfirmValueModal = ({
                             lines={outputLines}
                             state={state}
                             account={account}
-                            valueDataTest={valueDataTest}
+                            displayMode={displayMode}
                         />
                         <Tooltip content={buttonTooltipContent()}>
                             <StyledButton

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmXpubModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmXpubModal.tsx
@@ -4,6 +4,7 @@ import { showXpub } from 'src/actions/wallet/publicKeyActions';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 import { selectLabelingDataForSelectedAccount } from 'src/reducers/suite/metadataReducer';
 import { useSelector } from 'src/hooks/suite';
+import { DisplayMode } from 'src/types/suite';
 
 export const ConfirmXpubModal = (
     props: Pick<ConfirmValueModalProps, 'isConfirmed' | 'onCancel'>,
@@ -39,7 +40,7 @@ export const ConfirmXpubModal = (
             validateOnDevice={showXpub}
             copyButtonText={<Translation id="TR_XPUB_MODAL_CLIPBOARD" />}
             value={xpub}
-            valueDataTest="@xpub-modal/xpub-field"
+            displayMode={DisplayMode.PAGINATED_TEXT}
             {...props}
         />
     );

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
@@ -157,6 +157,7 @@ export const TransactionReviewModalContent = ({
                 })}
                 isSending={isSending}
                 setIsSending={() => setIsSending(true)}
+                ethereumStakeType={ethereumStakeType || undefined}
             />
             <TransactionReviewEvmExplanation account={selectedAccount.account} />
         </StyledModal>

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
@@ -9,6 +9,7 @@ import { amountToSatoshi } from '@suite-common/wallet-utils';
 import { TransactionReviewStepIndicatorProps } from './TransactionReviewStepIndicator';
 import { zIndices } from '@trezor/theme';
 import { DeviceDisplay } from '../../../../DeviceDisplay/DeviceDisplay';
+import { DisplayMode } from 'src/types/suite';
 
 const OutputWrapper = styled.div`
     display: flex;
@@ -147,7 +148,7 @@ export type TransactionReviewOutputElementProps = {
     token?: TokenInfo;
     account?: Account;
     state?: TransactionReviewStepIndicatorProps['state'];
-    valueDataTest?: string;
+    displayMode?: DisplayMode;
 };
 
 export const TransactionReviewOutputElement = forwardRef<
@@ -165,7 +166,7 @@ export const TransactionReviewOutputElement = forwardRef<
             fiatVisible = false,
             account,
             state,
-            valueDataTest,
+            displayMode,
         },
         ref,
     ) => {
@@ -199,11 +200,11 @@ export const TransactionReviewOutputElement = forwardRef<
                             <OutputValue>
                                 <TruncateWrapper condition={hasExpansion}>
                                     {isActive &&
+                                    displayMode &&
                                     (line.id === 'address' || line.id === 'regular_legacy') ? (
                                         <DeviceDisplay
-                                            valueDataTest={valueDataTest}
+                                            displayMode={displayMode}
                                             address={line.value}
-                                            network={network}
                                         />
                                     ) : (
                                         <OutputValueWrapper>

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
@@ -20,7 +20,7 @@ import { getOutputState } from 'src/utils/wallet/reviewTransactionUtils';
 import { TransactionReviewTotalOutput } from './TransactionReviewTotalOutput';
 import { ReviewOutput } from 'src/types/wallet/transaction';
 import { spacingsPx } from '@trezor/theme';
-import { StakeFormState } from '@suite-common/wallet-types';
+import { StakeFormState, StakeType } from '@suite-common/wallet-types';
 
 const Content = styled.div`
     display: flex;
@@ -91,6 +91,7 @@ export interface TransactionReviewOutputListProps {
     actionText: TranslationKey;
     isSending?: boolean;
     setIsSending?: () => void;
+    ethereumStakeType?: StakeType;
 }
 
 export const TransactionReviewOutputList = ({
@@ -106,6 +107,7 @@ export const TransactionReviewOutputList = ({
     actionText,
     isSending,
     setIsSending,
+    ethereumStakeType,
 }: TransactionReviewOutputListProps) => {
     const dispatch = useDispatch();
     const { networkType } = account;
@@ -214,6 +216,7 @@ export const TransactionReviewOutputList = ({
                                     symbol={symbol}
                                     account={account}
                                     isRbf={isRbfAction}
+                                    ethereumStakeType={ethereumStakeType}
                                 />
                             );
                         })}

--- a/packages/suite/src/hooks/suite/index.ts
+++ b/packages/suite/src/hooks/suite/index.ts
@@ -23,6 +23,7 @@ export { usePasswords } from './usePasswords';
 export { useDebugLanguageShortcut } from './useDebugLanguageShortcut';
 export { useValidatorsQueue } from './useValidatorsQueue';
 export { useEverstakePoolStats } from './useEverstakePoolStats';
+export { useDisplayMode } from './useDisplayMode';
 
 // replaced in suite-native
 export { useLocales } from 'src/hooks/suite/useLocales';

--- a/packages/suite/src/hooks/suite/useDisplayMode.ts
+++ b/packages/suite/src/hooks/suite/useDisplayMode.ts
@@ -1,0 +1,25 @@
+import { selectDeviceUnavailableCapabilities } from '@suite-common/wallet-core';
+import { selectAddressDisplayType, AddressDisplayOptions } from 'src/reducers/suite/suiteReducer';
+import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
+import { useSelector } from './useSelector';
+import { StakeType } from '@suite-common/wallet-types';
+import { DisplayMode } from 'src/types/suite';
+
+export const useDisplayMode = (ethereumStakeType?: StakeType) => {
+    const account = useSelector(selectSelectedAccount);
+    const unavailableCapabilities = useSelector(selectDeviceUnavailableCapabilities);
+    const addressDisplayType = useSelector(selectAddressDisplayType);
+
+    if (ethereumStakeType) {
+        return DisplayMode.SINGLE_WRAPPED_TEXT;
+    }
+    if (
+        addressDisplayType === AddressDisplayOptions.CHUNKED &&
+        !unavailableCapabilities?.chunkify &&
+        account?.networkType !== 'cardano'
+    ) {
+        return DisplayMode.CHUNKS;
+    }
+
+    return DisplayMode.PAGINATED_TEXT;
+};

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7330,6 +7330,18 @@ export default defineMessages({
         id: 'TR_STAKING_WITHDRAW',
         defaultMessage: 'Withdraw',
     },
+    TR_STAKE_ON_EVERSTAKE: {
+        id: 'TR_STAKE_ON_EVERSTAKE',
+        defaultMessage: 'Stake {symbol} on Everstake?',
+    },
+    TR_CLAIM_FROM_EVERSTAKE: {
+        id: 'TR_CLAIM_FROM_EVERSTAKE',
+        defaultMessage: 'Claim {symbol} from Everstake?',
+    },
+    TR_UNSTAKE_FROM_EVERSTAKE: {
+        id: 'TR_UNSTAKE_FROM_EVERSTAKE',
+        defaultMessage: 'Unstake {symbol} from Everstake?',
+    },
     TR_TX_WITHDRAWAL: {
         id: 'TR_TX_WITHDRAWAL',
         defaultMessage: 'Withdrawal',

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -125,3 +125,9 @@ export interface TorBootstrap {
     total: number;
     isSlow?: boolean;
 }
+
+export enum DisplayMode {
+    CHUNKS = 1,
+    PAGINATED_TEXT,
+    SINGLE_WRAPPED_TEXT,
+}


### PR DESCRIPTION
## Description

- added another display mode of "address" to Suite. Single page with wrapped text
- got rid of data test value
- all places with this black rectangle should be tested (xpub, receive address, send tx modal, staking, maybe something more?)

## Related Issue

closes #11298
closes #11587
closes  #11583
closes  #11586

## Screenshots:

![Screenshot 2024-03-19 at 14 08 10](https://github.com/trezor/trezor-suite/assets/33235762/f1bd1771-6beb-4f07-a921-ab77ef83907d)
![Screenshot 2024-03-19 at 14 07 54](https://github.com/trezor/trezor-suite/assets/33235762/7dc0d883-c4ab-4506-8d37-3c6062bbcb8c)
