### PR TITLE
fix(blockchain-link): emit disconnect on every socket disconnect

### DIFF
--- a/packages/blockchain-link/src/workers/baseWebsocket.ts
+++ b/packages/blockchain-link/src/workers/baseWebsocket.ts
@@ -208,11 +208,11 @@ export abstract class BaseWebsocket<T extends EventMap> extends TypedEmitter<T &
         ws.on('message', this.onMessage.bind(this));
         ws.on('close', () => {
             this.onClose();
-            this.emitter.emit('disconnected');
         });
     }
 
     disconnect() {
+        this.emitter.emit('disconnected');
         this.ws?.close();
     }
 
@@ -234,7 +234,7 @@ export abstract class BaseWebsocket<T extends EventMap> extends TypedEmitter<T &
     }
 
     dispose() {
-        this.onClose();
         this.removeAllListeners();
+        this.onClose();
     }
 }


### PR DESCRIPTION
When initialising backend in offline state, connectPromise is created, api never connects and All backends are down error is kept in connectPromise indefinitely causing backend not being disposed. Emitting disconnect every time it disconnects should destroy the blockchain object and let it start a new one again.

emitting 'disconnected' in `disconnect()` triggers it no matter from which side the termination comes and is called in onClose()

Resolve [#11153](https://github.com/trezor/trezor-suite/issues/11153)