### PR TITLE
ci(github): connect upload test overview html

### DIFF
--- a/.github/workflows/connect-dev-release-test.yml
+++ b/.github/workflows/connect-dev-release-test.yml
@@ -138,6 +138,7 @@ jobs:
       test-name: methods.test
       DEV_SERVER_HOSTNAME: dev.suite.sldev.cz
       run-webextension: true
+      build-overview: true
 
   popup-close:
     needs: [build-deploy]

--- a/.github/workflows/template-connect-popup-test-params.yml
+++ b/.github/workflows/template-connect-popup-test-params.yml
@@ -15,6 +15,10 @@ on:
         description: "Flag to indicate whether to run the webextension job"
         type: "boolean"
         required: false
+      build-overview:
+        description: "Flag to indicate whether to build connect-popup-overview.html"
+        type: "boolean"
+        required: false
 
 jobs:
   web:
@@ -46,17 +50,33 @@ jobs:
         env:
           URL: https://${{ inputs.DEV_SERVER_HOSTNAME }}/connect/${{ steps.extract_branch.outputs.branch }}/
           TREZOR_CONNECT_SRC: https://${{ inputs.DEV_SERVER_HOSTNAME }}/connect/${{ steps.extract_branch.outputs.branch }}/
+          CI_COMMIT_BRANCH: ${{ steps.extract_branch.outputs.branch }}
+          CI_JOB_NAME: ${{ inputs.test-name }}-${{ github.run_attempt }}
         run: |
           ./docker/docker-connect-popup-ci.sh ${{ inputs.test-name }}
 
+      - name: Prepare static overview
+        if: ${{ inputs.build-overview }}
+        run: |
+          echo "Preparing static overview"
+          mkdir -p tmp_overview_directory
+          cp -R ./packages/connect-popup/e2e/screenshots/* tmp_overview_directory/
+          cp packages/connect-popup/connect-popup-overview.html  tmp_overview_directory/connect-popup-overview.html
+
+      - name: Upload static overview artifact
+        uses: actions/upload-artifact@v4
+        if: ${{ inputs.build-overview }}
+        with:
+          name: static-overview-${{ inputs.test-name }}-${{ github.run_attempt }}
+          path: |
+            tmp_overview_directory/
+
       - name: Upload artifacts
-        # We upload test artifacts only if it fails and we use it to `Check Test Success` in next step.
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: test-artifacts-${{ inputs.test-name }}-${{ github.run_attempt }}
           path: |
-            packages/connect-popup/e2e/screenshots
             packages/connect-popup/test-results
 
       - name: Check Test Success
@@ -106,7 +126,6 @@ jobs:
         with:
           name: test-artifacts-${{ inputs.test-name }}-${{ github.run_attempt }}
           path: |
-            packages/connect-popup/e2e/screenshots
             packages/connect-popup/test-results
 
       - name: Check Test Success

--- a/packages/connect-popup/e2e/support/buildOverview.ts
+++ b/packages/connect-popup/e2e/support/buildOverview.ts
@@ -3,8 +3,6 @@ import path from 'path';
 
 const SCREENSHOTS_DIR = './e2e/screenshots';
 
-const CI_JOB_URL = process.env.CI_JOB_URL || '.';
-
 export const buildOverview = ({ emuScreenshots }: { emuScreenshots: Record<string, string> }) => {
     if (fs.existsSync('connect-popup-overview.html')) {
         fs.rmSync('connect-popup-overview.html');
@@ -40,14 +38,11 @@ export const buildOverview = ({ emuScreenshots }: { emuScreenshots: Record<strin
             </div>
         `;
         screenshots.forEach(screenshot => {
-            const screenshotPath = `${CI_JOB_URL}/${urlPath}/${screenshot}`;
+            const screenshotPath = `./${urlPath}/${screenshot}`;
             html += `
                 <div>
                     <div>${methodName}/${screenshot}</div>
-                    <img src="${screenshotPath.replace(
-                        '/e2e/screenshots',
-                        '/artifacts/raw/packages/connect-popup/e2e/screenshots',
-                    )}" />
+                    <img src="${screenshotPath.replace('./e2e/screenshots/', './')}" />
                     ${renderEmuScreenshot(`./${urlPath}/${screenshot}`)}
                 </div>
             `;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR makes changes to allow to build connect-popup-overview.html with the screenshots coming from the popup test `methods`. This is now uploaded as an artifact, if we find out that there will be added value in deploying it we could easily implement it.

Artifact generated by link below:

 https://github.com/trezor/trezor-suite/actions/runs/8387142696/artifacts/1349291532

## Related Issue

Related https://github.com/trezor/trezor-suite/issues/7916

## Screenshots:
![image](https://github.com/trezor/trezor-suite/assets/5362163/7537dc92-8cd9-474c-aeab-4836fef02751)
