### PR TITLE
Customize link to firmware binaries according to connected device

### DIFF
--- a/packages/suite/src/components/firmware/SelectCustomFirmware.tsx
+++ b/packages/suite/src/components/firmware/SelectCustomFirmware.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 
 import { selectDeviceModel } from '@suite-common/wallet-core';
 import { Button } from '@trezor/components';
+import { spacingsPx } from '@trezor/theme';
 import { GITHUB_FW_BINARIES_URL } from '@trezor/urls';
 
 import { Translation, TrezorLink } from 'src/components/suite';
@@ -17,7 +18,7 @@ const Container = styled.div`
 `;
 
 const StyledLink = styled(TrezorLink)`
-    margin-left: 6px;
+    margin-left: ${spacingsPx.xxs};
 `;
 
 const StyledDropZone = styled(DropZone)`
@@ -25,7 +26,7 @@ const StyledDropZone = styled(DropZone)`
 `;
 
 const InstallButton = styled(Button)`
-    margin: 36px auto 0;
+    margin: ${spacingsPx.xxl} auto 0;
 `;
 
 type SelectCustomFirmwareProps = {
@@ -54,6 +55,12 @@ export const SelectCustomFirmware = ({ device, onSuccess }: SelectCustomFirmware
         }
     };
 
+    const install = () => {
+        if (firmwareBinary) {
+            onSuccess(firmwareBinary);
+        }
+    };
+
     return (
         <Container>
             <InstructionStep
@@ -63,7 +70,7 @@ export const SelectCustomFirmware = ({ device, onSuccess }: SelectCustomFirmware
                 <Translation id="TR_CUSTOM_FIRMWARE_GITHUB" />
                 <StyledLink variant="nostyle" href={githubUrl}>
                     <Button
-                        size="small"
+                        size="tiny"
                         variant="tertiary"
                         icon="EXTERNAL_LINK"
                         iconAlignment="right"
@@ -80,11 +87,7 @@ export const SelectCustomFirmware = ({ device, onSuccess }: SelectCustomFirmware
                 <StyledDropZone accept=".bin" icon="BINARY" onSelect={onFirmwareUpload} />
             </InstructionStep>
 
-            <InstallButton
-                variant="primary"
-                isDisabled={!firmwareBinary}
-                onClick={() => firmwareBinary && onSuccess(firmwareBinary)}
-            >
+            <InstallButton variant="primary" isDisabled={!firmwareBinary} onClick={install}>
                 <Translation id="TR_CUSTOM_FIRMWARE_BUTTON_INSTALL" />
             </InstallButton>
         </Container>

--- a/packages/suite/src/components/firmware/SelectCustomFirmware.tsx
+++ b/packages/suite/src/components/firmware/SelectCustomFirmware.tsx
@@ -1,12 +1,16 @@
 import { useState } from 'react';
 import styled from 'styled-components';
+
+import { selectDeviceModel } from '@suite-common/wallet-core';
 import { Button } from '@trezor/components';
 import { GITHUB_FW_BINARIES_URL } from '@trezor/urls';
+
 import { Translation, TrezorLink } from 'src/components/suite';
 import { DropZone } from 'src/components/suite/DropZone';
 import type { TrezorDevice, ExtendedMessageDescriptor } from 'src/types/suite';
 import { validateFirmware } from 'src/utils/firmware';
 import { InstructionStep } from 'src/components/suite/InstructionStep';
+import { useSelector } from 'src/hooks/suite';
 
 const Container = styled.div`
     width: 100%;
@@ -31,6 +35,11 @@ type SelectCustomFirmwareProps = {
 
 export const SelectCustomFirmware = ({ device, onSuccess }: SelectCustomFirmwareProps) => {
     const [firmwareBinary, setFirmwareBinary] = useState<ArrayBuffer>();
+    const deviceModel = useSelector(selectDeviceModel);
+
+    const githubUrl = deviceModel
+        ? `${GITHUB_FW_BINARIES_URL}/${deviceModel.toLowerCase()}`
+        : GITHUB_FW_BINARIES_URL;
 
     const onFirmwareUpload = async (
         firmware: File,
@@ -52,7 +61,7 @@ export const SelectCustomFirmware = ({ device, onSuccess }: SelectCustomFirmware
                 title={<Translation id="TR_CUSTOM_FIRMWARE_TITLE_DOWNLOAD" />}
             >
                 <Translation id="TR_CUSTOM_FIRMWARE_GITHUB" />
-                <StyledLink variant="nostyle" href={GITHUB_FW_BINARIES_URL}>
+                <StyledLink variant="nostyle" href={githubUrl}>
                     <Button
                         size="small"
                         variant="tertiary"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Before:
The Github link in `SelectCustomFirmware` modal leads to https://github.com/trezor/data/tree/master/firmware

After:
Go to the directory corresponding to the connected device modal to save some clicks, e.g. https://github.com/trezor/data/tree/master/firmware/t2b1

## Screenshots:
before visual changes:
![Screenshot 2024-03-20 at 12 15 52](https://github.com/trezor/trezor-suite/assets/42465546/000c6fd0-562a-4da5-875a-0b0abe71ee86)
after:
![Screenshot 2024-03-20 at 12 48 26](https://github.com/trezor/trezor-suite/assets/42465546/f642fb08-8c13-48f6-95a7-a29348b9c773)

