### PR TITLE
chore(suite): unify prefixes variables for redux actions

### DIFF
--- a/packages/suite/src/actions/settings/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/deviceSettingsActions.ts
@@ -2,7 +2,7 @@ import {
     selectDevices,
     selectDevice,
     deviceActions,
-    firmwareActionsPrefix,
+    FIRMWARE_MODULE_PREFIX,
 } from '@suite-common/wallet-core';
 import * as deviceUtils from '@suite-common/suite-utils';
 import TrezorConnect from '@trezor/connect';
@@ -183,7 +183,7 @@ export const resetDevice =
     };
 
 export const changeLanguage = createThunk(
-    `${firmwareActionsPrefix}/update-firmware-language`,
+    `${FIRMWARE_MODULE_PREFIX}/update-firmware-language`,
     async (params: Parameters<typeof TrezorConnect.changeLanguage>[0], { dispatch, getState }) => {
         const device = selectDevice(getState());
 

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -9,13 +9,13 @@ import { getSynchronize } from '@trezor/utils';
 
 import { cardanoConnectPatch } from './cardanoConnectPatch';
 
-const actionsPrefix = '@common/connect-init';
+const CONNECT_INIT_MODULE = '@common/connect-init';
 
 // If you are looking where connectInitSettings is defined, it is defined in packages/suite/src/support/extraDependencies.ts
 // or in suite-native/state/src/extraDependencies.ts depends on which platform this connectInitThunk runs.
 
 export const connectInitThunk = createThunk(
-    `${actionsPrefix}/initThunk`,
+    `${CONNECT_INIT_MODULE}/initThunk`,
     async (_, { dispatch, getState, extra }) => {
         const {
             selectors: {

--- a/suite-common/wallet-core/src/accounts/accountsActions.ts
+++ b/suite-common/wallet-core/src/accounts/accountsActions.ts
@@ -11,19 +11,19 @@ import {
     getAccountSpecific,
 } from '@suite-common/wallet-utils';
 
-import { accountsActionsPrefix } from './constants';
+import { ACCOUNTS_MODULE_PREFIX } from './accountsConstants';
 
-const disposeAccount = createAction(`${accountsActionsPrefix}/disposeAccount`);
+const disposeAccount = createAction(`${ACCOUNTS_MODULE_PREFIX}/disposeAccount`);
 
 const updateSelectedAccount = createAction(
-    `${accountsActionsPrefix}/updateSelectedAccount`,
+    `${ACCOUNTS_MODULE_PREFIX}/updateSelectedAccount`,
     (payload: SelectedAccountStatus): { payload: SelectedAccountStatus } => ({
         payload,
     }),
 );
 
 const removeAccount = createAction(
-    `${accountsActionsPrefix}/removeAccount`,
+    `${ACCOUNTS_MODULE_PREFIX}/removeAccount`,
     (payload: Account[]): { payload: Account[] } => ({
         payload,
     }),
@@ -91,7 +91,7 @@ const composeCreateAccountActionPayload = ({
 });
 
 const createIndexLabeledAccount = createAction(
-    `${accountsActionsPrefix}/createIndexLabeledAccount`,
+    `${ACCOUNTS_MODULE_PREFIX}/createIndexLabeledAccount`,
     ({
         deviceState,
         discoveryItem,
@@ -102,7 +102,7 @@ const createIndexLabeledAccount = createAction(
 );
 
 const createAccount = createAction(
-    `${accountsActionsPrefix}/createAccount`,
+    `${ACCOUNTS_MODULE_PREFIX}/createAccount`,
     ({
         deviceState,
         discoveryItem,
@@ -121,7 +121,7 @@ const createAccount = createAction(
 );
 
 const updateAccount = createAction(
-    `${accountsActionsPrefix}/updateAccount`,
+    `${ACCOUNTS_MODULE_PREFIX}/updateAccount`,
     (account: Account, accountInfo: AccountInfo | null = null): { payload: Account } => {
         if (accountInfo) {
             return {
@@ -153,7 +153,7 @@ const updateAccount = createAction(
 );
 
 const renameAccount = createAction(
-    `${accountsActionsPrefix}/renameAccount`,
+    `${ACCOUNTS_MODULE_PREFIX}/renameAccount`,
     (accountKey: string, accountLabel: string) => ({
         payload: {
             accountKey,
@@ -163,7 +163,7 @@ const renameAccount = createAction(
 );
 
 const startCoinjoinAccountSync = createAction(
-    `${accountsActionsPrefix}/startCoinjoinAccountSync`,
+    `${ACCOUNTS_MODULE_PREFIX}/startCoinjoinAccountSync`,
     (account: Extract<Account, { backendType: 'coinjoin' }>) => ({
         payload: {
             accountKey: account.key,
@@ -172,7 +172,7 @@ const startCoinjoinAccountSync = createAction(
 );
 
 const endCoinjoinAccountSync = createAction(
-    `${accountsActionsPrefix}/endCoinjoinAccountSync`,
+    `${ACCOUNTS_MODULE_PREFIX}/endCoinjoinAccountSync`,
     (
         account: Extract<Account, { backendType: 'coinjoin' }>,
         status: Extract<Account, { backendType: 'coinjoin' }>['status'],
@@ -185,7 +185,7 @@ const endCoinjoinAccountSync = createAction(
 );
 
 const changeAccountVisibility = createAction(
-    `${accountsActionsPrefix}/changeAccountVisibility`,
+    `${ACCOUNTS_MODULE_PREFIX}/changeAccountVisibility`,
     (account: Account, visible = true): { payload: Account } => ({
         payload: {
             ...account,

--- a/suite-common/wallet-core/src/accounts/accountsConstants.ts
+++ b/suite-common/wallet-core/src/accounts/accountsConstants.ts
@@ -1,7 +1,7 @@
 import { NetworkType } from '@suite-common/wallet-config';
 import { AccountType } from '@suite-common/wallet-types';
 
-export const accountsActionsPrefix = '@common/wallet-core/accounts';
+export const ACCOUNTS_MODULE_PREFIX = '@common/wallet-core/accounts';
 
 export const formattedAccountTypeMap: Partial<
     Record<NetworkType, Partial<Record<AccountType, string>>>

--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -8,7 +8,7 @@ import { Account, AccountKey } from '@suite-common/wallet-types';
 import { AccountType, networks, NetworkSymbol } from '@suite-common/wallet-config';
 
 import { accountsActions } from './accountsActions';
-import { formattedAccountTypeMap } from './constants';
+import { formattedAccountTypeMap } from './accountsConstants';
 import {
     DeviceRootState,
     selectDevice,

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -20,11 +20,11 @@ import { transactionsActions } from '../transactions/transactionsActions';
 import { selectTransactions } from '../transactions/transactionsReducer';
 import { accountsActions } from './accountsActions';
 import { selectAccountByKey, selectAccounts } from './accountsReducer';
-import { accountsActionsPrefix } from './constants';
+import { ACCOUNTS_MODULE_PREFIX } from './accountsConstants';
 import { selectBlockchainHeightBySymbol } from '../blockchain/blockchainReducer';
 
 export const disableAccountsThunk = createThunk(
-    `${accountsActionsPrefix}/disableAccountsThunk`,
+    `${ACCOUNTS_MODULE_PREFIX}/disableAccountsThunk`,
     (_, { dispatch, extra, getState }) => {
         const {
             selectors: { selectEnabledNetworks },
@@ -74,7 +74,7 @@ const fetchAccountTokens = async (account: Account, payloadTokens: AccountInfo['
 // Left here for clarity, but shouldn't be called anywhere but in blockchainActions.syncAccounts
 // as we usually want to update all accounts for a single coin at once
 export const fetchAndUpdateAccountThunk = createThunk(
-    `${accountsActionsPrefix}/fetchAndUpdateAccountThunk`,
+    `${ACCOUNTS_MODULE_PREFIX}/fetchAndUpdateAccountThunk`,
     async ({ accountKey }: { accountKey: AccountKey }, { dispatch, extra, getState }) => {
         const {
             selectors: { selectDevices, selectBitcoinAmountUnit },

--- a/suite-common/wallet-core/src/blockchain/blockchainActions.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainActions.ts
@@ -4,24 +4,24 @@ import { NetworkSymbol } from '@suite-common/wallet-config';
 import type { CustomBackend, NetworksFees } from '@suite-common/wallet-types';
 import type { Timeout } from '@trezor/type-utils';
 
-export const blockchainActionsPrefix = '@common/wallet-core/blockchain';
+export const BLOCKCHAIN_MODULE_PREFIX = '@common/wallet-core/blockchain';
 
 const connected = createAction(
-    `${blockchainActionsPrefix}/connected`,
+    `${BLOCKCHAIN_MODULE_PREFIX}/connected`,
     (payload: NetworkSymbol) => ({
         payload,
     }),
 );
 
 const updateFee = createAction(
-    `${blockchainActionsPrefix}/updateFee`,
+    `${BLOCKCHAIN_MODULE_PREFIX}/updateFee`,
     (payload: Partial<NetworksFees>) => ({
         payload,
     }),
 );
 
 const synced = createAction(
-    `${blockchainActionsPrefix}/synced`,
+    `${BLOCKCHAIN_MODULE_PREFIX}/synced`,
     (payload: { symbol: NetworkSymbol; timeout?: Timeout }) => ({
         payload,
     }),
@@ -31,7 +31,7 @@ export type SetBackendPayload =
     | CustomBackend
     | { coin: NetworkSymbol; type: 'default'; urls?: unknown };
 const setBackend = createAction(
-    `${blockchainActionsPrefix}/setBackend`,
+    `${BLOCKCHAIN_MODULE_PREFIX}/setBackend`,
     (payload: SetBackendPayload) => ({
         payload,
     }),

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -25,7 +25,7 @@ import { notificationsActions } from '@suite-common/toast-notifications';
 
 import { selectAccounts } from '../accounts/accountsReducer';
 import { fetchAndUpdateAccountThunk } from '../accounts/accountsThunks';
-import { blockchainActionsPrefix, blockchainActions } from './blockchainActions';
+import { BLOCKCHAIN_MODULE_PREFIX, blockchainActions } from './blockchainActions';
 import { selectBlockchainState, selectNetworkBlockchainInfo } from './blockchainReducer';
 
 const ACCOUNTS_SYNC_INTERVAL = 60 * 1000;
@@ -43,7 +43,7 @@ const sortLevels = (levels: FeeLevel[]) =>
 
 // shouldn't this be in fee thunks instead?
 export const preloadFeeInfoThunk = createThunk(
-    `${blockchainActionsPrefix}/preloadFeeInfoThunk`,
+    `${BLOCKCHAIN_MODULE_PREFIX}/preloadFeeInfoThunk`,
     async (_, { dispatch }) => {
         // Fetch default fee levels
         const networks = networksCompatibility.filter(n => !n.isHidden && !n.accountType);
@@ -79,7 +79,7 @@ export const preloadFeeInfoThunk = createThunk(
 
 // shouldn't this be in fee thunks instead?
 export const updateFeeInfoThunk = createThunk(
-    `${blockchainActionsPrefix}/updateFeeInfoThunk`,
+    `${BLOCKCHAIN_MODULE_PREFIX}/updateFeeInfoThunk`,
     async (symbol: string, { dispatch, getState, extra }) => {
         const {
             selectors: { selectFeeInfo },
@@ -147,7 +147,7 @@ export const updateFeeInfoThunk = createThunk(
 
 // call TrezorConnect.unsubscribe, it doesn't cost anything and should emit BLOCKCHAIN.CONNECT or BLOCKCHAIN.ERROR event
 export const reconnectBlockchainThunk = createThunk(
-    `${blockchainActionsPrefix}/reconnectBlockchainThunk`,
+    `${BLOCKCHAIN_MODULE_PREFIX}/reconnectBlockchainThunk`,
     (coin: NetworkSymbol) => TrezorConnect.blockchainUnsubscribeFiatRates({ coin }),
 );
 
@@ -165,7 +165,7 @@ const setBackendsToConnect = (backends: CustomBackend[]) =>
     );
 
 export const setCustomBackendThunk = createThunk(
-    `${blockchainActionsPrefix}/setCustomBackendThunk`,
+    `${BLOCKCHAIN_MODULE_PREFIX}/setCustomBackendThunk`,
     (coin: NetworkSymbol, { getState }) => {
         const blockchain = selectBlockchainState(getState());
         const backends = [getBackendFromSettings(coin, blockchain[coin].backends)];
@@ -175,7 +175,7 @@ export const setCustomBackendThunk = createThunk(
 );
 
 export const initBlockchainThunk = createThunk(
-    `${blockchainActionsPrefix}/initBlockchainThunk`,
+    `${BLOCKCHAIN_MODULE_PREFIX}/initBlockchainThunk`,
     async (_, { dispatch, getState }) => {
         await dispatch(preloadFeeInfoThunk());
 
@@ -207,7 +207,7 @@ export const initBlockchainThunk = createThunk(
 // called from WalletMiddleware after ACCOUNT.ADD/UPDATE action
 // or after BLOCKCHAIN.CONNECT event (blockchainActions.onConnect)
 export const subscribeBlockchainThunk = createThunk(
-    `${blockchainActionsPrefix}/subscribeBlockchainThunk`,
+    `${BLOCKCHAIN_MODULE_PREFIX}/subscribeBlockchainThunk`,
     ({ symbol }: { symbol: NetworkSymbol; fiatRates?: boolean }, { getState }) => {
         // do NOT subscribe if there are no accounts
         // it leads to websocket disconnection
@@ -226,7 +226,7 @@ export const subscribeBlockchainThunk = createThunk(
 
 // called from WalletMiddleware after ACCOUNT.REMOVE action
 export const unsubscribeBlockchainThunk = createThunk(
-    `${blockchainActionsPrefix}/unsubscribeBlockchainThunk`,
+    `${BLOCKCHAIN_MODULE_PREFIX}/unsubscribeBlockchainThunk`,
     (removedAccounts: Account[], { getState }) => {
         // collect unique symbols
         const symbols = removedAccounts.map(({ symbol }) => symbol).filter(arrayDistinct);
@@ -257,7 +257,7 @@ const tryClearTimeout = (timeout?: Timeout) => {
 };
 
 export const syncAccountsWithBlockchainThunk = createThunk(
-    `${blockchainActionsPrefix}/syncAccountsThunk`,
+    `${BLOCKCHAIN_MODULE_PREFIX}/syncAccountsThunk`,
     async (symbol: NetworkSymbol, { getState, dispatch }) => {
         const accounts = selectAccounts(getState());
         const blockchain = selectBlockchainState(getState());
@@ -283,7 +283,7 @@ export const syncAccountsWithBlockchainThunk = createThunk(
 );
 
 export const onBlockchainConnectThunk = createThunk(
-    `${blockchainActionsPrefix}/onBlockchainConnectThunk`,
+    `${BLOCKCHAIN_MODULE_PREFIX}/onBlockchainConnectThunk`,
     async (symbol: string, { dispatch }) => {
         const network = getNetwork(symbol.toLowerCase());
         if (!network) return;
@@ -296,7 +296,7 @@ export const onBlockchainConnectThunk = createThunk(
 );
 
 export const onBlockMinedThunk = createThunk(
-    `${blockchainActionsPrefix}/onBlockMinedThunk`,
+    `${BLOCKCHAIN_MODULE_PREFIX}/onBlockMinedThunk`,
     (block: BlockchainBlock, { dispatch }) => {
         const symbol = block.coin.shortcut.toLowerCase();
         const network = getNetwork(symbol);
@@ -318,7 +318,7 @@ export const onBlockMinedThunk = createThunk(
 );
 
 export const onBlockchainNotificationThunk = createThunk(
-    `${blockchainActionsPrefix}/onNotificationThunk`,
+    `${BLOCKCHAIN_MODULE_PREFIX}/onNotificationThunk`,
     (payload: BlockchainNotification, { dispatch, getState, extra }) => {
         const {
             selectors: { selectBitcoinAmountUnit, selectDevices },
@@ -374,7 +374,7 @@ export const onBlockchainNotificationThunk = createThunk(
 );
 
 export const onBlockchainDisconnectThunk = createThunk(
-    `${blockchainActionsPrefix}/onBlockchainDisconnectThunk`,
+    `${BLOCKCHAIN_MODULE_PREFIX}/onBlockchainDisconnectThunk`,
     (error: BlockchainError, { getState }) => {
         const network = getNetwork(error.coin.shortcut.toLowerCase());
         if (!network) return;

--- a/suite-common/wallet-core/src/device/deviceActions.ts
+++ b/suite-common/wallet-core/src/device/deviceActions.ts
@@ -3,7 +3,7 @@ import { createAction } from '@reduxjs/toolkit';
 import { Device, DEVICE } from '@trezor/connect';
 import { ButtonRequest, TrezorDevice } from '@suite-common/suite-types';
 
-export const MODULE_PREFIX = '@suite/device';
+export const DEVICE_MODULE_PREFIX = '@suite/device';
 
 const connectDevice = createAction(DEVICE.CONNECT, (payload: Device) => ({ payload }));
 
@@ -18,66 +18,72 @@ const deviceChanged = createAction(DEVICE.CHANGED, (payload: Device | TrezorDevi
 const deviceDisconnect = createAction(DEVICE.DISCONNECT, (payload: Device) => ({ payload }));
 
 const updatePassphraseMode = createAction(
-    `${MODULE_PREFIX}/updatePassphraseMode`,
+    `${DEVICE_MODULE_PREFIX}/updatePassphraseMode`,
     (payload: { device: TrezorDevice; hidden: boolean; alwaysOnDevice?: boolean }) => ({ payload }),
 );
 
-const authFailed = createAction(`${MODULE_PREFIX}/authFailed`, (payload: TrezorDevice) => ({
+const authFailed = createAction(`${DEVICE_MODULE_PREFIX}/authFailed`, (payload: TrezorDevice) => ({
     payload,
 }));
 
 const receiveAuthConfirm = createAction(
-    `${MODULE_PREFIX}/receiveAuthConfirm`,
+    `${DEVICE_MODULE_PREFIX}/receiveAuthConfirm`,
     (payload: { device: TrezorDevice; success: boolean }) => ({ payload }),
 );
 
 const createDeviceInstance = createAction(
-    `${MODULE_PREFIX}/createDeviceInstance`,
+    `${DEVICE_MODULE_PREFIX}/createDeviceInstance`,
     (payload: TrezorDevice) => ({ payload }),
 );
 
 const rememberDevice = createAction(
-    `${MODULE_PREFIX}/rememberDevice`,
+    `${DEVICE_MODULE_PREFIX}/rememberDevice`,
     (payload: { device: TrezorDevice; remember: boolean; forceRemember: undefined | true }) => ({
         payload,
     }),
 );
 
-const forgetDevice = createAction(`${MODULE_PREFIX}/forgetDevice`, (payload: TrezorDevice) => ({
-    payload,
-}));
+const forgetDevice = createAction(
+    `${DEVICE_MODULE_PREFIX}/forgetDevice`,
+    (payload: TrezorDevice) => ({
+        payload,
+    }),
+);
 
 const authDevice = createAction(
-    `${MODULE_PREFIX}/authDevice`,
+    `${DEVICE_MODULE_PREFIX}/authDevice`,
     (payload: { device: TrezorDevice; state: string }) => ({ payload }),
 );
 
 const addButtonRequest = createAction(
-    `${MODULE_PREFIX}/addButtonRequest`,
+    `${DEVICE_MODULE_PREFIX}/addButtonRequest`,
     (payload: { device?: TrezorDevice; buttonRequest: ButtonRequest }) => ({ payload }),
 );
 
-const requestDeviceReconnect = createAction(`${MODULE_PREFIX}/requestDeviceReconnect`);
+const requestDeviceReconnect = createAction(`${DEVICE_MODULE_PREFIX}/requestDeviceReconnect`);
 
-const selectDevice = createAction(`${MODULE_PREFIX}/selectDevice`, (payload?: TrezorDevice) => ({
-    payload,
-}));
+const selectDevice = createAction(
+    `${DEVICE_MODULE_PREFIX}/selectDevice`,
+    (payload?: TrezorDevice) => ({
+        payload,
+    }),
+);
 
 const updateSelectedDevice = createAction(
-    `${MODULE_PREFIX}/updateSelectedDevice`,
+    `${DEVICE_MODULE_PREFIX}/updateSelectedDevice`,
     (payload?: TrezorDevice) => ({ payload }),
 );
 
 // Remove button requests for specific device by button request code or all button requests if no code is provided.
 export const removeButtonRequests = createAction(
-    `${MODULE_PREFIX}/removeButtonRequests`,
+    `${DEVICE_MODULE_PREFIX}/removeButtonRequests`,
     (payload: { device?: TrezorDevice; buttonRequestCode?: ButtonRequest['code'] }) => ({
         payload,
     }),
 );
 
 export const forgetAndDisconnectDevice = createAction(
-    `${MODULE_PREFIX}/forgetAndDisconnectDevice`,
+    `${DEVICE_MODULE_PREFIX}/forgetAndDisconnectDevice`,
     (payload: TrezorDevice) => ({
         payload,
     }),

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -33,7 +33,7 @@ import {
     selectDeviceById,
     selectDevices,
 } from './deviceReducer';
-import { deviceActions, MODULE_PREFIX } from './deviceActions';
+import { deviceActions, DEVICE_MODULE_PREFIX } from './deviceActions';
 import { selectFirmware } from '../firmware/firmwareReducer';
 import { checkFirmwareAuthenticity } from '../firmware/firmwareThunks';
 import { PORTFOLIO_TRACKER_DEVICE_ID, portfolioTrackerDevice } from './deviceConstants';
@@ -46,7 +46,7 @@ import { selectAccountByKey } from '../accounts/accountsReducer';
  * @param {(Device | TrezorDevice | undefined)} device
  */
 export const selectDeviceThunk = createThunk(
-    `${MODULE_PREFIX}/selectDevice`,
+    `${DEVICE_MODULE_PREFIX}/selectDevice`,
     (device: Device | TrezorDevice | undefined, { dispatch, getState }) => {
         let payload: TrezorDevice | typeof undefined;
         const devices = selectDevices(getState());
@@ -79,7 +79,7 @@ export const selectDeviceThunk = createThunk(
  * Use `forgetDevice` to forget a device regardless if its current state.
  */
 export const toggleRememberDevice = createThunk(
-    `${MODULE_PREFIX}/toggleRememberDevice`,
+    `${DEVICE_MODULE_PREFIX}/toggleRememberDevice`,
     ({ device, forceRemember }: { device: TrezorDevice; forceRemember?: true }, { dispatch }) => {
         analytics.report({
             type: device.remember ? EventType.SwitchDeviceForget : EventType.SwitchDeviceRemember,
@@ -102,7 +102,7 @@ export const toggleRememberDevice = createThunk(
  * @param {boolean} [useEmptyPassphrase=false]
  */
 export const createDeviceInstance = createThunk(
-    `${MODULE_PREFIX}/createDeviceInstance`,
+    `${DEVICE_MODULE_PREFIX}/createDeviceInstance`,
     async (
         {
             device,
@@ -144,7 +144,7 @@ export const createDeviceInstance = createThunk(
  * @param {Device} device
  */
 export const handleDeviceConnect = createThunk(
-    `${MODULE_PREFIX}/handleDeviceConnect`,
+    `${DEVICE_MODULE_PREFIX}/handleDeviceConnect`,
     (device: Device, { dispatch, getState }) => {
         const selectedDevice = selectDeviceSelector(getState());
         const firmware = selectFirmware(getState());
@@ -170,7 +170,7 @@ export const handleDeviceConnect = createThunk(
  * @param {Device} device
  */
 export const handleDeviceDisconnect = createThunk(
-    `${MODULE_PREFIX}/handleDeviceDisconnect`,
+    `${DEVICE_MODULE_PREFIX}/handleDeviceDisconnect`,
     (device: Device, { dispatch, getState, extra }) => {
         const {
             selectors: { selectRouterApp },
@@ -216,7 +216,7 @@ export const handleDeviceDisconnect = createThunk(
  * @param {Device} device
  */
 export const forgetDisconnectedDevices = createThunk(
-    `${MODULE_PREFIX}/forgetDisconnectedDevices`,
+    `${DEVICE_MODULE_PREFIX}/forgetDisconnectedDevices`,
     (device: Device, { dispatch, getState }) => {
         const devices = selectDevices(getState());
         const deviceInstances = devices.filter(d => d.id === device.id);
@@ -256,7 +256,7 @@ export const observeSelectedDevice = () => (dispatch: any, getState: any) => {
  * this is the only place where useEmptyPassphrase should be always set to "true"
  */
 export const acquireDevice = createThunk(
-    `${MODULE_PREFIX}/acquireDevice`,
+    `${DEVICE_MODULE_PREFIX}/acquireDevice`,
     async (requestedDevice: TrezorDevice | undefined, { dispatch, getState }) => {
         const selectedDevice = selectDeviceSelector(getState());
         if (!selectedDevice && !requestedDevice) return;
@@ -284,7 +284,7 @@ export const acquireDevice = createThunk(
  * Fetch device state, update `devices` reducer as result of SUITE.AUTH_DEVICE
  */
 export const authorizeDevice = createThunk(
-    `${MODULE_PREFIX}/authorizeDevice`,
+    `${DEVICE_MODULE_PREFIX}/authorizeDevice`,
     async (_, { dispatch, getState, extra }): Promise<boolean> => {
         const {
             selectors: { selectCheckFirmwareAuthenticity },
@@ -358,7 +358,7 @@ export const authorizeDevice = createThunk(
  * Called from `suiteMiddleware`
  */
 export const authConfirm = createThunk(
-    `${MODULE_PREFIX}/authConfirm`,
+    `${DEVICE_MODULE_PREFIX}/authConfirm`,
     async (_, { dispatch, getState }) => {
         const device = selectDeviceSelector(getState());
         if (!device) return false;
@@ -405,7 +405,7 @@ export const authConfirm = createThunk(
 );
 
 export const switchDuplicatedDevice = createThunk(
-    `${MODULE_PREFIX}/switchDuplicatedDevice`,
+    `${DEVICE_MODULE_PREFIX}/switchDuplicatedDevice`,
     async (
         { device, duplicate }: { device: TrezorDevice; duplicate: TrezorDevice },
         { dispatch, extra },
@@ -431,7 +431,7 @@ export const switchDuplicatedDevice = createThunk(
 );
 
 export const initDevices = createThunk(
-    `${MODULE_PREFIX}/initDevices`,
+    `${DEVICE_MODULE_PREFIX}/initDevices`,
     (_, { dispatch, getState }) => {
         const devices = selectDevices(getState());
         const device = selectDeviceSelector(getState());
@@ -452,7 +452,7 @@ export const initDevices = createThunk(
 );
 
 export const createImportedDeviceThunk = createThunk(
-    `${MODULE_PREFIX}/createImportedDevice`,
+    `${DEVICE_MODULE_PREFIX}/createImportedDevice`,
     (_, { getState, dispatch }) => {
         const device = selectDeviceById(getState(), PORTFOLIO_TRACKER_DEVICE_ID);
 
@@ -463,7 +463,7 @@ export const createImportedDeviceThunk = createThunk(
 );
 
 export const confirmAddressOnDeviceThunk = createThunk(
-    `${MODULE_PREFIX}/confirmAddressOnDeviceThunk`,
+    `${DEVICE_MODULE_PREFIX}/confirmAddressOnDeviceThunk`,
     async (
         {
             accountKey,
@@ -534,7 +534,7 @@ export const confirmAddressOnDeviceThunk = createThunk(
 );
 
 export const onPassphraseSubmit = createThunk(
-    `${MODULE_PREFIX}/onPassphraseSubmit`,
+    `${DEVICE_MODULE_PREFIX}/onPassphraseSubmit`,
     (
         { value, passphraseOnDevice }: { value: string; passphraseOnDevice: boolean },
         { dispatch, getState },

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesConstants.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesConstants.ts
@@ -1,6 +1,6 @@
 import { RateType } from '@suite-common/wallet-types';
 
-export const fiatRatesActionsPrefix = '@common/wallet-core/fiat-rates';
+export const FIAT_RATES_MODULE_PREFIX = '@common/wallet-core/fiat-rates';
 
 const ONE_MINUTE_IN_MS = 60 * 1000;
 const ONE_HOUR_IN_MS = 60 * ONE_MINUTE_IN_MS;

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
@@ -10,7 +10,7 @@ import { isTestnet } from '@suite-common/wallet-utils';
 import { AccountTransaction } from '@trezor/connect';
 import { getNetworkFeatures } from '@suite-common/wallet-config';
 
-import { fiatRatesActionsPrefix, REFETCH_INTERVAL } from './fiatRatesConstants';
+import { FIAT_RATES_MODULE_PREFIX, REFETCH_INTERVAL } from './fiatRatesConstants';
 import { selectTickersToBeUpdated, selectTransactionsWithMissingRates } from './fiatRatesSelectors';
 import { transactionsActions } from '../transactions/transactionsActions';
 import { selectIsSpecificCoinDefinitionKnown } from '../token-definitions/tokenDefinitionsSelectors';
@@ -24,7 +24,7 @@ type UpdateTxsFiatRatesThunkPayload = {
 
 // TODO: Refactor this to batch requests as much as possible
 export const updateTxsFiatRatesThunk = createThunk(
-    `${fiatRatesActionsPrefix}/updateTxsRates`,
+    `${FIAT_RATES_MODULE_PREFIX}/updateTxsRates`,
     async (
         { account, txs, localCurrency }: UpdateTxsFiatRatesThunkPayload,
         { dispatch, getState },
@@ -75,7 +75,7 @@ type UpdateCurrentFiatRatesThunkPayload = {
 };
 
 export const updateFiatRatesThunk = createThunk(
-    `${fiatRatesActionsPrefix}/updateFiatRates`,
+    `${FIAT_RATES_MODULE_PREFIX}/updateFiatRates`,
     async (
         { ticker, localCurrency, rateType, forceFetchToken }: UpdateCurrentFiatRatesThunkPayload,
         { getState },
@@ -112,7 +112,7 @@ export const updateFiatRatesThunk = createThunk(
 );
 
 export const updateMissingTxFiatRatesThunk = createThunk(
-    `${fiatRatesActionsPrefix}/updateMissingTxRates`,
+    `${FIAT_RATES_MODULE_PREFIX}/updateMissingTxRates`,
     ({ localCurrency }: { localCurrency: FiatCurrencyCode }, { dispatch, getState }) => {
         const transactionsWithMissingRates = selectTransactionsWithMissingRates(
             getState(),
@@ -131,7 +131,7 @@ type FetchFiatRatesThunkPayload = {
 };
 
 export const fetchFiatRatesThunk = createThunk(
-    `${fiatRatesActionsPrefix}/fetchFiatRates`,
+    `${FIAT_RATES_MODULE_PREFIX}/fetchFiatRates`,
     ({ rateType, localCurrency }: FetchFiatRatesThunkPayload, { dispatch, getState }) => {
         const currentTimestamp = Date.now();
         const tickers = selectTickersToBeUpdated(
@@ -167,7 +167,7 @@ type PeriodicFetchFiatRatesThunkPayload = {
 };
 
 export const periodicFetchFiatRatesThunk = createThunk(
-    `${fiatRatesActionsPrefix}/periodicFetchFiatRates`,
+    `${FIAT_RATES_MODULE_PREFIX}/periodicFetchFiatRates`,
     async ({ rateType, localCurrency }: PeriodicFetchFiatRatesThunkPayload, { dispatch }) => {
         if (ratesTimeouts[rateType]) {
             clearTimeout(ratesTimeouts[rateType]!);

--- a/suite-common/wallet-core/src/firmware/firmwareActions.ts
+++ b/suite-common/wallet-core/src/firmware/firmwareActions.ts
@@ -3,64 +3,64 @@ import { createAction } from '@reduxjs/toolkit';
 import { AcquiredDevice, FirmwareStatus } from '@suite-common/suite-types';
 import { Device, FirmwareType } from '@trezor/connect';
 
-export const firmwareActionsPrefix = '@common/wallet-core/firmware';
+export const FIRMWARE_MODULE_PREFIX = '@common/wallet-core/firmware';
 
 const setStatus = createAction(
-    `${firmwareActionsPrefix}/set-update-status`,
+    `${FIRMWARE_MODULE_PREFIX}/set-update-status`,
     (payload: FirmwareStatus | 'error') => ({ payload }),
 );
 
 const setHash = createAction(
-    `${firmwareActionsPrefix}/set-hash`,
+    `${FIRMWARE_MODULE_PREFIX}/set-hash`,
     (payload: { hash: string; challenge: string }) => ({ payload }),
 );
 
 const setHashInvalid = createAction(
-    `${firmwareActionsPrefix}/set-hash-invalid`,
+    `${FIRMWARE_MODULE_PREFIX}/set-hash-invalid`,
     (payload: string) => ({
         payload,
     }),
 );
 
-const setError = createAction(`${firmwareActionsPrefix}/set-error`, (payload?: string) => ({
+const setError = createAction(`${FIRMWARE_MODULE_PREFIX}/set-error`, (payload?: string) => ({
     payload,
 }));
 
 const setTargetRelease = createAction(
-    `${firmwareActionsPrefix}/set-target-release`,
+    `${FIRMWARE_MODULE_PREFIX}/set-target-release`,
     (payload: AcquiredDevice['firmwareRelease']) => ({ payload }),
 );
 
-const toggleHasSeed = createAction(`${firmwareActionsPrefix}/toggle-has-seed`);
+const toggleHasSeed = createAction(`${FIRMWARE_MODULE_PREFIX}/toggle-has-seed`);
 
 const setIntermediaryInstalled = createAction(
-    `${firmwareActionsPrefix}/set-intermediary-installed`,
+    `${FIRMWARE_MODULE_PREFIX}/set-intermediary-installed`,
     (payload: boolean) => ({ payload }),
 );
 
 const setTargetType = createAction(
-    `${firmwareActionsPrefix}/set-target-type`,
+    `${FIRMWARE_MODULE_PREFIX}/set-target-type`,
     (payload: FirmwareType) => ({
         payload,
     }),
 );
 
 const rememberPreviousDevice = createAction(
-    `${firmwareActionsPrefix}/remember-previous-device`,
+    `${FIRMWARE_MODULE_PREFIX}/remember-previous-device`,
     (payload: Device) => ({ payload }),
 );
 
 const setIsCustomFirmware = createAction(
-    `${firmwareActionsPrefix}/set-is-custom`,
+    `${FIRMWARE_MODULE_PREFIX}/set-is-custom`,
     (payload: boolean) => ({
         payload,
     }),
 );
 
-const resetReducer = createAction(`${firmwareActionsPrefix}/reset-reducer`);
+const resetReducer = createAction(`${FIRMWARE_MODULE_PREFIX}/reset-reducer`);
 
 const toggleUseDevkit = createAction(
-    `${firmwareActionsPrefix}/toggle-use-devkit`,
+    `${FIRMWARE_MODULE_PREFIX}/toggle-use-devkit`,
     (payload: boolean) => ({
         payload,
     }),

--- a/suite-common/wallet-core/src/firmware/firmwareThunks.ts
+++ b/suite-common/wallet-core/src/firmware/firmwareThunks.ts
@@ -26,10 +26,10 @@ import {
     selectTargetRelease,
     selectUseDevkit,
 } from './firmwareReducer';
-import { firmwareActionsPrefix, firmwareActions } from './firmwareActions';
+import { FIRMWARE_MODULE_PREFIX, firmwareActions } from './firmwareActions';
 
 export const resolveFileBaseUrl = createThunk(
-    `${firmwareActionsPrefix}/resolve-file-url`,
+    `${FIRMWARE_MODULE_PREFIX}/resolve-file-url`,
     (_, { getState, extra }): string | undefined => {
         const {
             selectors: { selectDesktopBinDir, selectDevice },
@@ -54,7 +54,7 @@ export const resolveFileBaseUrl = createThunk(
  * directly exported due to type safety.
  */
 const firmwareInstallThunk = createThunk(
-    `${firmwareActionsPrefix}/firmwareInstall`,
+    `${FIRMWARE_MODULE_PREFIX}/firmwareInstall`,
     async (
         { fwBinary, firmwareType }: { fwBinary?: ArrayBuffer; firmwareType?: FirmwareType },
         { dispatch, getState, extra },
@@ -216,7 +216,7 @@ export const firmwareUpdate = (firmwareType?: FirmwareType) =>
 export const firmwareCustom = (fwBinary: ArrayBuffer) => firmwareInstallThunk({ fwBinary });
 
 const handleFwHashError = createThunk(
-    `${firmwareActionsPrefix}/handleFwHashError`,
+    `${FIRMWARE_MODULE_PREFIX}/handleFwHashError`,
     (getFirmwareHashResponse: Unsuccessful, { dispatch }) => {
         dispatch(
             firmwareActions.setError(
@@ -233,7 +233,7 @@ const handleFwHashError = createThunk(
 );
 
 const handleFwHashMismatch = createThunk(
-    `${firmwareActionsPrefix}/handleFwHashMismatch`,
+    `${FIRMWARE_MODULE_PREFIX}/handleFwHashMismatch`,
     (device: Device, { dispatch }) => {
         // device.id should always be present here (device is initialized and in normal mode) during successful TrezorConnect.getFirmwareHash call
         dispatch(firmwareActions.setHashInvalid(device.id!));
@@ -249,7 +249,7 @@ const handleFwHashMismatch = createThunk(
  * TrezorConnect.getFirmwareHash call
  */
 export const validateFirmwareHash = createThunk(
-    `${firmwareActionsPrefix}/validateFirmwareHash`,
+    `${FIRMWARE_MODULE_PREFIX}/validateFirmwareHash`,
     async (device: Device, { getState, dispatch, extra }) => {
         const {
             selectors: { selectRouterApp },
@@ -327,7 +327,7 @@ export const validateFirmwareHash = createThunk(
 );
 
 export const checkFirmwareAuthenticity = createThunk(
-    `${firmwareActionsPrefix}/checkFirmwareAuthenticity`,
+    `${FIRMWARE_MODULE_PREFIX}/checkFirmwareAuthenticity`,
     async (_, { dispatch, getState, extra }) => {
         const {
             selectors: { selectDevice },
@@ -366,7 +366,7 @@ export const checkFirmwareAuthenticity = createThunk(
 );
 
 export const rebootToBootloader = createThunk(
-    `${firmwareActionsPrefix}/rebootToBootloader`,
+    `${FIRMWARE_MODULE_PREFIX}/rebootToBootloader`,
     async (_, { dispatch, getState, extra }) => {
         const {
             selectors: { selectDevice },

--- a/suite-common/wallet-core/src/index.ts
+++ b/suite-common/wallet-core/src/index.ts
@@ -1,4 +1,5 @@
 export * from './accounts/accountsActions';
+export * from './accounts/accountsConstants';
 export * from './accounts/accountsReducer';
 export * from './accounts/accountsThunks';
 export * from './transactions/transactionsActions';

--- a/suite-common/wallet-core/src/token-definitions/tokenDefinitionsThunks.ts
+++ b/suite-common/wallet-core/src/token-definitions/tokenDefinitionsThunks.ts
@@ -17,10 +17,10 @@ import { Timeout } from '@trezor/type-utils';
 
 import { selectNetworkTokenDefinitions } from './tokenDefinitionsSelectors';
 
-const actionsPrefix = '@common/wallet-core/token-definitions';
+const TOKEN_DEFINITIONS_MODULE = '@common/wallet-core/token-definitions';
 
 export const getTokenDefinitionThunk = createThunk(
-    `${actionsPrefix}/getNftTokenDefinition`,
+    `${TOKEN_DEFINITIONS_MODULE}/getNftTokenDefinition`,
     async (
         params: {
             networkSymbol: NetworkSymbol;
@@ -81,7 +81,7 @@ export const getTokenDefinitionThunk = createThunk(
 );
 
 export const initTokenDefinitionsThunk = createThunk(
-    `${actionsPrefix}/initTokenDefinitionsThunk`,
+    `${TOKEN_DEFINITIONS_MODULE}/initTokenDefinitionsThunk`,
     (_, { getState, dispatch, extra }) => {
         const enabledNetworks = extra.selectors.selectEnabledNetworks(getState());
 
@@ -120,7 +120,7 @@ export const initTokenDefinitionsThunk = createThunk(
 let tokenDefinitionsTimeout: Timeout | null = null;
 
 export const periodicCheckTokenDefinitionsThunk = createThunk(
-    `${actionsPrefix}/periodicCheckTokenDefinitionsThunk`,
+    `${TOKEN_DEFINITIONS_MODULE}/periodicCheckTokenDefinitionsThunk`,
     (_, { dispatch }) => {
         if (tokenDefinitionsTimeout) {
             clearTimeout(tokenDefinitionsTimeout);

--- a/suite-common/wallet-core/src/transactions/transactionsActions.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsActions.ts
@@ -4,14 +4,14 @@ import { Account, WalletAccountTransaction } from '@suite-common/wallet-types';
 import { AccountTransaction } from '@trezor/connect';
 import { enhanceTransaction } from '@suite-common/wallet-utils';
 
-export const transactionsActionsPrefix = '@common/wallet-core/transactions';
+export const TRANSACTIONS_MODULE_PREFIX = '@common/wallet-core/transactions';
 
 const fetchError = createAction(
-    `${transactionsActionsPrefix}/fetchError`,
+    `${TRANSACTIONS_MODULE_PREFIX}/fetchError`,
     (payload: { error: string | null }) => ({ payload }),
 );
-const fetchSuccess = createAction(`${transactionsActionsPrefix}/fetchSuccess`);
-const fetchInit = createAction(`${transactionsActionsPrefix}/fetchInit`);
+const fetchSuccess = createAction(`${TRANSACTIONS_MODULE_PREFIX}/fetchSuccess`);
+const fetchInit = createAction(`${TRANSACTIONS_MODULE_PREFIX}/fetchInit`);
 
 type UpdateTransactionFiatRatePayload = Array<{
     txid: string;
@@ -21,29 +21,29 @@ type UpdateTransactionFiatRatePayload = Array<{
 }>;
 
 const updateTransactionFiatRate = createAction(
-    `${transactionsActionsPrefix}/updateTransactionFiatRate`,
+    `${TRANSACTIONS_MODULE_PREFIX}/updateTransactionFiatRate`,
     (payload: UpdateTransactionFiatRatePayload) => ({
         payload,
     }),
 );
 
 const resetTransaction = createAction(
-    `${transactionsActionsPrefix}/resetTransaction`,
+    `${TRANSACTIONS_MODULE_PREFIX}/resetTransaction`,
     (payload: { account: Account }) => ({ payload }),
 );
 
 const replaceTransaction = createAction(
-    `${transactionsActionsPrefix}/replaceTransaction`,
+    `${TRANSACTIONS_MODULE_PREFIX}/replaceTransaction`,
     (payload: { key: string; txid: string; tx: WalletAccountTransaction }) => ({ payload }),
 );
 
 const removeTransaction = createAction(
-    `${transactionsActionsPrefix}/removeTransaction`,
+    `${TRANSACTIONS_MODULE_PREFIX}/removeTransaction`,
     (payload: { account: Account; txs: { txid: string }[] }) => ({ payload }),
 );
 
 const addTransaction = createAction(
-    `${transactionsActionsPrefix}/addTransaction`,
+    `${TRANSACTIONS_MODULE_PREFIX}/addTransaction`,
     ({
         transactions,
         account,

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -27,7 +27,7 @@ import { createThunk } from '@suite-common/redux-utils';
 
 import { accountsActions } from '../accounts/accountsActions';
 import { selectTransactions } from './transactionsReducer';
-import { transactionsActionsPrefix, transactionsActions } from './transactionsActions';
+import { TRANSACTIONS_MODULE_PREFIX, transactionsActions } from './transactionsActions';
 import { selectAccountByKey, selectAccounts } from '../accounts/accountsReducer';
 import { selectBlockchainHeightBySymbol } from '../blockchain/blockchainReducer';
 import { selectNetworkTokenDefinitions } from '../token-definitions/tokenDefinitionsSelectors';
@@ -44,7 +44,7 @@ interface ReplaceTransactionThunkParams {
 }
 
 export const replaceTransactionThunk = createThunk<ReplaceTransactionThunkParams>(
-    `${transactionsActionsPrefix}/replaceTransactionThunk`,
+    `${TRANSACTIONS_MODULE_PREFIX}/replaceTransactionThunk`,
     ({ precomposedTx, newTxid, signedTransaction }, { getState, dispatch }) => {
         if (!precomposedTx.prevTxid) return; // ignore if it's not a replacement tx
 
@@ -110,7 +110,7 @@ interface AddFakePendingTransactionParams {
 }
 
 export const addFakePendingTxThunk = createThunk<AddFakePendingTransactionParams>(
-    `${transactionsActionsPrefix}/addFakePendingTransaction`,
+    `${TRANSACTIONS_MODULE_PREFIX}/addFakePendingTransaction`,
     ({ transaction, precomposedTx, account }, { dispatch, getState }) => {
         const blockHeight = selectBlockchainHeightBySymbol(getState(), account.symbol);
         const accounts = selectAccounts(getState());
@@ -175,7 +175,7 @@ export const addFakePendingTxThunk = createThunk<AddFakePendingTransactionParams
 );
 
 export const addFakePendingCardanoTxThunk = createThunk(
-    `${transactionsActionsPrefix}/addFakePendingTransaction`,
+    `${TRANSACTIONS_MODULE_PREFIX}/addFakePendingTransaction`,
     (
         {
             precomposedTx,
@@ -220,7 +220,7 @@ export const addFakePendingCardanoTxThunk = createThunk(
 );
 
 export const exportTransactionsThunk = createThunk(
-    `${transactionsActionsPrefix}/exportTransactions`,
+    `${TRANSACTIONS_MODULE_PREFIX}/exportTransactions`,
     async (
         {
             account,
@@ -296,7 +296,7 @@ export const exportTransactionsThunk = createThunk(
 );
 
 export const fetchTransactionsThunk = createThunk(
-    `${transactionsActionsPrefix}/fetchTransactionsThunk`,
+    `${TRANSACTIONS_MODULE_PREFIX}/fetchTransactionsThunk`,
     async (
         {
             accountKey,

--- a/suite-native/accounts/src/utils.ts
+++ b/suite-native/accounts/src/utils.ts
@@ -1,7 +1,7 @@
 import { A, D, G } from '@mobily/ts-belt';
 
 import { AccountType, networks } from '@suite-common/wallet-config';
-import { formattedAccountTypeMap } from '@suite-common/wallet-core/src/accounts/constants';
+import { formattedAccountTypeMap } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 import { getNetwork } from '@suite-common/wallet-utils';
 

--- a/suite-native/blockchain/src/blockchainThunks.ts
+++ b/suite-native/blockchain/src/blockchainThunks.ts
@@ -12,7 +12,7 @@ import { AccountKey } from '@suite-common/wallet-types';
 import { getNetwork } from '@suite-common/wallet-utils';
 import { BlockchainNotification } from '@trezor/connect';
 
-const actionsPrefix = '@native/blockchain';
+const BLOCKCHAIN_MODULE_PREFIX = '@suite-native/blockchain';
 
 const accountLastFetchTime: Record<AccountKey, number> = {};
 const ACCOUNT_LAST_FETCH_TIME_LIMIT_MS = 1000 * 10;
@@ -31,7 +31,7 @@ const shouldRefetchAccount = ({
 };
 
 export const syncAccountsWithBlockchainThunk = createThunk(
-    `${actionsPrefix}/syncAccountsThunk`,
+    `${BLOCKCHAIN_MODULE_PREFIX}/syncAccountsThunk`,
     async ({ symbol }: { symbol: NetworkSymbol }, { getState, dispatch }) => {
         const accounts = selectDeviceAccountsByNetworkSymbol(getState(), symbol);
         const accountForRefetch = accounts.filter(({ key }) =>
@@ -52,7 +52,7 @@ export const syncAccountsWithBlockchainThunk = createThunk(
 );
 
 export const syncAllAccountsWithBlockchainThunk = createThunk(
-    `${actionsPrefix}/syncAllAccountsThunk`,
+    `${BLOCKCHAIN_MODULE_PREFIX}/syncAllAccountsThunk`,
     async (_, { getState, dispatch }) => {
         const accountsSymbols = selectAccountsSymbols(getState());
 
@@ -65,7 +65,7 @@ export const syncAllAccountsWithBlockchainThunk = createThunk(
 );
 
 export const onBlockchainConnectThunk = createThunk(
-    `${actionsPrefix}/onBlockchainConnectThunk`,
+    `${BLOCKCHAIN_MODULE_PREFIX}/onBlockchainConnectThunk`,
     async ({ symbol }: { symbol: string }, { dispatch }) => {
         const network = getNetwork(symbol.toLowerCase());
         if (!network) return;
@@ -79,7 +79,7 @@ export const onBlockchainConnectThunk = createThunk(
 );
 
 export const onBlockchainNotificationThunk = createThunk(
-    `${actionsPrefix}/onNotificationThunk`,
+    `${BLOCKCHAIN_MODULE_PREFIX}/onNotificationThunk`,
     (payload: BlockchainNotification, { dispatch, getState }) => {
         const { descriptor } = payload.notification;
         const symbol = payload.coin.shortcut.toLowerCase();

--- a/suite-native/device/src/deviceThunks.ts
+++ b/suite-native/device/src/deviceThunks.ts
@@ -7,10 +7,10 @@ import {
 } from '@suite-common/wallet-core';
 import { clearAndUnlockDeviceAccessQueue } from '@suite-native/device-mutex';
 
-const actionPrefix = '@suite-native/device';
+const DEVICE_MODULE_PREFIX = '@suite-native/device';
 
 export const wipeDisconnectedDevicesDataThunk = createThunk(
-    `${actionPrefix}/wipeDisconnectedDevicesDataThunk`,
+    `${DEVICE_MODULE_PREFIX}/wipeDisconnectedDevicesDataThunk`,
     (_, { getState, dispatch }) => {
         const devicelessAccounts = selectDevicelessAccounts(getState());
         const devicelessDiscoveries = selectDevicelessDiscoveries(getState());

--- a/suite-native/module-accounts-import/src/accountsImportThunks.ts
+++ b/suite-native/module-accounts-import/src/accountsImportThunks.ts
@@ -10,7 +10,7 @@ import { getXpubOrDescriptorInfo } from '@trezor/utxo-lib';
 
 import { paymentTypeToAccountType } from './constants';
 
-const actionPrefix = '@accountsImport';
+const ACCOUNTS_IMPORT_MODULE_PREFIX = '@suite-native/accountsImport';
 
 type ImportAssetThunkPayload = {
     accountInfo: AccountInfo;
@@ -31,7 +31,7 @@ const getAccountTypeFromDescriptor = (
 };
 
 export const importAccountThunk = createThunk(
-    `${actionPrefix}/importAccountThunk`,
+    `${ACCOUNTS_IMPORT_MODULE_PREFIX}/importAccountThunk`,
     ({ accountInfo, accountLabel, coin }: ImportAssetThunkPayload, { dispatch, getState }) => {
         const deviceState = PORTFOLIO_TRACKER_DEVICE_STATE;
 


### PR DESCRIPTION
## Description

Prefixes for actions inside redux had different variable names. This aims to unify it with the more common way of naming prefixes up till now in our repo.