### PR TITLE
fix: handle estimated fee error

### DIFF
--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
@@ -134,6 +134,8 @@ export const NotificationRenderer = ({
             return error(render, notification, 'METADATA_PROVIDER_AUTH_ERROR');
         case 'metadata-unexpected-error':
             return error(render, notification, 'METADATA_PROVIDER_UNEXPECTED_ERROR');
+        case 'estimated-fee-error':
+            return info(render, notification, 'TOAST_ESTIMATED_FEE_ERROR');
         case 'auto-updater-error':
             return error(render, notification, 'TOAST_AUTO_UPDATER_ERROR', {
                 state: notification.state,

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -8789,6 +8789,10 @@ export default defineMessages({
         id: 'TOAST_SUCCESSFUL_CLAIM',
         defaultMessage: '{symbol} claimed successfully',
     },
+    TOAST_ESTIMATED_FEE_ERROR: {
+        id: 'TOAST_ESTIMATED_FEE_ERROR',
+        defaultMessage: 'Fee estimation from network failed. Using backup value.',
+    },
     TR_STAKE_TOTAL_PENDING: {
         id: 'TR_STAKE_TOTAL_PENDING',
         defaultMessage: 'Total stake pending:',

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -61,7 +61,19 @@ export type ToastPayload = (
               | 'sign-message-success'
               | 'verify-message-success'
               | 'firmware-check-authenticity-success'
-              | 'device-authenticity-success';
+              | 'device-authenticity-success'
+              | 'clear-storage'
+              | 'add-token-success'
+              | 'auto-updater-no-new'
+              | 'qr-incorrect-address'
+              | 'copy-to-clipboard'
+              | 'savings-kyc-failed'
+              | 'savings-kyc-success'
+              | 'tor-is-slow'
+              | 'coinjoin-interrupted'
+              | 'firmware-language-changed'
+              | 'firmware-language-fetch-error'
+              | 'estimated-fee-error';
       }
     | SentTransactionNotification
     | {
@@ -69,17 +81,8 @@ export type ToastPayload = (
           txid: string;
       }
     | {
-          type: 'copy-to-clipboard';
-      }
-    | {
-          type: 'clear-storage';
-      }
-    | {
           type: 'bridge-dev-restart';
           devMode: boolean;
-      }
-    | {
-          type: 'add-token-success';
       }
     | {
           type:
@@ -94,15 +97,14 @@ export type ToastPayload = (
               | 'metadata-auth-error'
               | 'metadata-not-found-error'
               | 'metadata-unexpected-error'
-              | 'device-authenticity-error';
+              | 'device-authenticity-error'
+              | 'cardano-delegate-error'
+              | 'cardano-withdrawal-error';
           error: string;
       }
     | {
           type: 'auto-updater-error';
           state: DesktopAppUpdateState;
-      }
-    | {
-          type: 'auto-updater-no-new';
       }
     | {
           type: 'auto-updater-new-version-first-run';
@@ -116,47 +118,18 @@ export type ToastPayload = (
           coin: string;
       }
     | {
-          type: 'qr-incorrect-address';
-      }
-    | {
           type: 'coin-scheme-protocol';
           scheme: PROTOCOL_SCHEME;
           address: string;
           amount?: number;
       }
     | {
-          type: 'cardano-delegate-error';
-          error: string;
-      }
-    | {
-          type: 'cardano-withdrawal-error';
-          error: string;
-      }
-    | {
-          type: 'savings-kyc-failed';
-      }
-    | {
-          type: 'savings-kyc-success';
-      }
-    | {
           type: 'tor-toggle-error';
           error: TranslationKey;
       }
     | {
-          type: 'tor-is-slow';
-      }
-    | {
-          type: 'coinjoin-interrupted';
-      }
-    | {
           type: 'successful-claim';
           symbol: string;
-      }
-    | {
-          type: 'firmware-language-changed';
-      }
-    | {
-          type: 'firmware-language-fetch-error';
       }
     | StakedTransactionNotification
     | UnstakedTransactionNotification

--- a/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
@@ -110,7 +110,7 @@ const calculate = (
 
 export const composeEthereumSendFormTransactionThunk = createThunk(
     `${SEND_MODULE_PREFIX}/composeEthereumSendFormTransactionThunk`,
-    async ({ formValues, formState }: ComposeTransactionThunkArguments) => {
+    async ({ formValues, formState }: ComposeTransactionThunkArguments, { dispatch }) => {
         const { account, network, feeInfo } = formState;
         const composeOutputs = getExternalComposeOutput(formValues, account, network);
         if (!composeOutputs) return; // no valid Output
@@ -151,7 +151,11 @@ export const composeEthereumSendFormTransactionThunk = createThunk(
         } else {
             customFeeLimit = tokenInfo ? ERC20_BACKUP_GAS_LIMIT : ETH_BACKUP_GAS_LIMIT;
 
-            // TODO: catch error from blockbook/geth (invalid contract, not enough balance...)
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'estimated-fee-error',
+                }),
+            );
         }
 
         // FeeLevels are read-only


### PR DESCRIPTION
The error coming from geth and returned the value of the error with a notification. 

I have a couple of questions as I'm not sure what the expected outcome is, I'd be happy to discuss it and get some help. 

- Should I handle every incoming error differently and provide a differently interpreted message or returning the initial error value is sufficient? 
- I'm not sure how to test in this case, I couldn't seem to find any examples on how/where the function is used.

Closes #3283