### PR TITLE
Skip CheckSeedStep when device is not initialized

### DIFF
--- a/packages/suite/src/components/firmware/FirmwareInitial.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInitial.tsx
@@ -155,6 +155,7 @@ export const FirmwareInitial = ({
     // todo: move to utils device.ts
     const devicesConnected = devices.filter(device => device?.connected);
     const multipleDevicesConnected = [...new Set(devicesConnected.map(d => d.path))].length > 1;
+    const shouldCheckSeed = liveDevice?.mode !== 'initialize';
 
     useEffect(() => {
         // When the user choses to install a new firmware update we will ask him/her to reconnect a device in bootloader mode.
@@ -379,7 +380,7 @@ export const FirmwareInitial = ({
                 <FirmwareButtonsRow withCancelButton={willBeWiped} onClose={onClose}>
                     <FirmwareInstallButton
                         onClick={() => {
-                            setStatus(standaloneFwUpdate ? 'check-seed' : 'waiting-for-bootloader');
+                            setStatus(shouldCheckSeed ? 'check-seed' : 'waiting-for-bootloader');
                             updateAnalytics({ firmware: 'update' });
                         }}
                         multipleDevicesConnected={multipleDevicesConnected}

--- a/packages/suite/src/views/firmware/FirmwareCustom.tsx
+++ b/packages/suite/src/views/firmware/FirmwareCustom.tsx
@@ -46,14 +46,17 @@ export const FirmwareCustom = () => {
     const onFirmwareSelected = useCallback(
         (fw: ArrayBuffer) => {
             setFirmwareBinary(fw);
-            // if there is no firmware installed, check-seed and waiting-for-bootloader steps could be skipped
+            // If there is no firmware installed, check-seed and waiting-for-bootloader steps could be skipped.
             if (liveDevice?.firmware === 'none') {
                 firmwareCustom(fw);
+                // No need to check seed on a device which is not initialized.
+            } else if (liveDevice?.mode === 'initialize') {
+                setStatus('waiting-for-bootloader');
             } else {
                 setStatus('check-seed');
             }
         },
-        [liveDevice?.firmware, setStatus, firmwareCustom],
+        [liveDevice?.firmware, liveDevice?.mode, setStatus, firmwareCustom],
     );
 
     const onSeedChecked = useCallback(() => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
User cannot check their seed if they don't have one. Relevant when installing firmware from settings on a device which hasn't been initialized - both update and custom.

## Screenshots:
Before:

https://github.com/trezor/trezor-suite/assets/42465546/91c07fdf-fc24-4ae9-99f7-d2d2c987657a

After:

https://github.com/trezor/trezor-suite/assets/42465546/2c8a2573-6c70-45eb-8ab3-5960a21e54ae

