### PR TITLE
chore(suite): unify background colors in firmware installation

### DIFF
--- a/packages/suite/src/components/firmware/FirmwareProgressBar.tsx
+++ b/packages/suite/src/components/firmware/FirmwareProgressBar.tsx
@@ -5,7 +5,6 @@ import { borders } from '@trezor/theme';
 
 const Wrapper = styled.div`
     display: flex;
-    background: ${({ theme }) => theme.BG_GREY};
     border-radius: ${borders.radii.xs};
     padding: 20px 24px;
     width: 100%;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The progress bar had a slightly different background color than the container, it is more prominent in dark mode.

<!--- Describe your changes in detail -->

## Screenshots:
Before:
![Screenshot 2024-03-21 at 19 26 26](https://github.com/trezor/trezor-suite/assets/42465546/b0bfa787-a9f0-4591-9302-4b9a2b44d7a6)

After:
![Screenshot 2024-03-21 at 19 26 34](https://github.com/trezor/trezor-suite/assets/42465546/d3f2903d-d64f-4428-9aa2-4e52f8145d4b)

