### PR TITLE
fix(suite-native): fetch fiat rates of newly added account tokens

### DIFF
--- a/packages/suite/src/actions/wallet/tokenActions.ts
+++ b/packages/suite/src/actions/wallet/tokenActions.ts
@@ -25,7 +25,7 @@ export const addToken =
                 },
                 localCurrency,
                 rateType: 'current',
-                lastSuccessfulFetchTimestamp: Date.now() as Timestamp,
+                fetchAttemptTimestamp: Date.now() as Timestamp,
                 forceFetchToken: true,
             }),
         );

--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -229,7 +229,7 @@ export const getRootReducer = (selectedAccount = BTC_ACCOUNT, fees = DEFAULT_FEE
                             error: null,
                             isLoading: false,
                             lastTickerTimestamp: 1693235607743000,
-                            lastSuccessfulFetchTimestamp: 1693235607743,
+                            fetchFetchAttemptTimestamp: 1693235607743,
                             rate: 1,
                             ticker: {
                                 symbol: 'btc',
@@ -239,7 +239,7 @@ export const getRootReducer = (selectedAccount = BTC_ACCOUNT, fees = DEFAULT_FEE
                             error: null,
                             isLoading: false,
                             lastTickerTimestamp: 169323560946000,
-                            lastSuccessfulFetchTimestamp: 1693235609465,
+                            fetchFetchAttemptTimestamp: 1693235609465,
                             rate: 1,
                             ticker: {
                                 symbol: 'eth',
@@ -249,7 +249,7 @@ export const getRootReducer = (selectedAccount = BTC_ACCOUNT, fees = DEFAULT_FEE
                             error: null,
                             isLoading: false,
                             lastTickerTimestamp: 1693235609467000,
-                            lastSuccessfulFetchTimestamp: 1693235609467,
+                            fetchFetchAttemptTimestamp: 1693235609467,
                             rate: 1,
                             ticker: {
                                 symbol: 'xrp',
@@ -261,7 +261,7 @@ export const getRootReducer = (selectedAccount = BTC_ACCOUNT, fees = DEFAULT_FEE
                             error: null,
                             isLoading: false,
                             lastTickerTimestamp: 1693235707743000,
-                            lastSuccessfulFetchTimestamp: 1693235707743,
+                            fetchFetchAttemptTimestamp: 1693235707743,
                             rate: 1,
                             ticker: {
                                 symbol: 'btc',
@@ -271,7 +271,7 @@ export const getRootReducer = (selectedAccount = BTC_ACCOUNT, fees = DEFAULT_FEE
                             error: null,
                             isLoading: false,
                             lastTickerTimestamp: 1693235709465000,
-                            lastSuccessfulFetchTimestamp: 1693235709465,
+                            fetchFetchAttemptTimestamp: 1693235709465,
                             rate: 1,
                             ticker: {
                                 symbol: 'eth',
@@ -281,7 +281,7 @@ export const getRootReducer = (selectedAccount = BTC_ACCOUNT, fees = DEFAULT_FEE
                             error: null,
                             isLoading: false,
                             lastTickerTimestamp: 1693235709467000,
-                            lastSuccessfulFetchTimestamp: 1693235709467,
+                            fetchFetchAttemptTimestamp: 1693235709467,
                             rate: 1,
                             ticker: {
                                 symbol: 'xrp',

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/FiatInput/FiatSelect/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/FiatInput/FiatSelect/index.tsx
@@ -36,7 +36,7 @@ const FiatSelect = () => {
                                 },
                                 localCurrency: selected.value as FiatCurrencyCode,
                                 rateType: 'current',
-                                lastSuccessfulFetchTimestamp: Date.now() as Timestamp,
+                                fetchAttemptTimestamp: Date.now() as Timestamp,
                             }),
                         );
                         if (updateFiatRatesResult.meta.requestStatus === 'fulfilled') {

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/SendCryptoInput/SendCryptoSelect/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/SendCryptoInput/SendCryptoSelect/index.tsx
@@ -85,7 +85,7 @@ const SendCryptoSelect = () => {
                                 },
                                 localCurrency: currency?.value as FiatCurrencyCode,
                                 rateType: 'current',
-                                lastSuccessfulFetchTimestamp: Date.now() as Timestamp,
+                                fetchAttemptTimestamp: Date.now() as Timestamp,
                             }),
                         );
                         composeRequest();

--- a/packages/suite/src/views/wallet/coinmarket/savings/setup/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/savings/setup/index.tsx
@@ -131,7 +131,7 @@ const CoinmarketSavingsSetup = (props: WithSelectedAccountLoadedProps) => {
                     },
                     localCurrency: fiatCurrency?.toLowerCase() as FiatCurrencyCode,
                     rateType: 'current',
-                    lastSuccessfulFetchTimestamp: Date.now() as Timestamp,
+                    fetchAttemptTimestamp: Date.now() as Timestamp,
                 }),
             );
         };

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/Fiat.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/Fiat.tsx
@@ -197,7 +197,7 @@ export const Fiat = ({ output, outputId }: FiatProps) => {
                         },
                         localCurrency: selected.value as FiatCurrencyCode,
                         rateType: 'current',
-                        lastSuccessfulFetchTimestamp: Date.now() as Timestamp,
+                        fetchAttemptTimestamp: Date.now() as Timestamp,
                     }),
                 );
 

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/TokenSelect.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/TokenSelect.tsx
@@ -247,7 +247,7 @@ export const TokenSelect = ({ output, outputId }: TokenSelectProps) => {
                                 },
                                 localCurrency: fiatCurrency?.value as FiatCurrencyCode,
                                 rateType: 'current',
-                                lastSuccessfulFetchTimestamp: Date.now() as Timestamp,
+                                fetchAttemptTimestamp: Date.now() as Timestamp,
                             }),
                         );
                         // clear errors in Amount input

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesMiddleware.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesMiddleware.ts
@@ -96,7 +96,7 @@ export const prepareFiatRatesMiddleware = createMiddlewareWithExtraDeps(
                         },
                         rateType: 'current',
                         localCurrency,
-                        lastSuccessfulFetchTimestamp: Date.now() as Timestamp,
+                        fetchAttemptTimestamp: Date.now() as Timestamp,
                     }),
                 );
             });

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesMiddleware.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesMiddleware.ts
@@ -2,9 +2,11 @@ import { isAnyOf } from '@reduxjs/toolkit';
 
 import { isNative } from '@trezor/env-utils';
 import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
+import { Timestamp, TokenAddress } from '@suite-common/wallet-types';
 
 import {
     fetchFiatRatesThunk,
+    updateFiatRatesThunk,
     updateMissingTxFiatRatesThunk,
     updateTxsFiatRatesThunk,
 } from './fiatRatesThunks';
@@ -78,6 +80,26 @@ export const prepareFiatRatesMiddleware = createMiddlewareWithExtraDeps(
                     }),
                 );
             }
+        }
+
+        // Fetch fiat rates for all tokens of newly suite-native discovered account.
+        if (accountsActions.createIndexLabeledAccount.match(action)) {
+            const localCurrency = selectLocalCurrency(getState());
+
+            const { tokens, symbol } = action.payload;
+            tokens?.forEach(token => {
+                dispatch(
+                    updateFiatRatesThunk({
+                        ticker: {
+                            symbol,
+                            tokenAddress: token.contract as TokenAddress,
+                        },
+                        rateType: 'current',
+                        localCurrency,
+                        lastSuccessfulFetchTimestamp: Date.now() as Timestamp,
+                    }),
+                );
+            });
         }
 
         return next(action);

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesReducer.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesReducer.ts
@@ -39,8 +39,7 @@ export const prepareFiatRatesReducer = createReducerWithExtraDeps(
             .addCase(updateFiatRatesThunk.fulfilled, (state, action) => {
                 if (!action.payload) return;
 
-                const { ticker, localCurrency, rateType, lastSuccessfulFetchTimestamp } =
-                    action.meta.arg;
+                const { ticker, localCurrency, rateType, fetchAttemptTimestamp } = action.meta.arg;
                 const fiatRateKey = getFiatRateKeyFromTicker(ticker, localCurrency);
 
                 const currentRate = state[rateType]?.[fiatRateKey];
@@ -54,7 +53,7 @@ export const prepareFiatRatesReducer = createReducerWithExtraDeps(
                     ...currentRate,
                     rate: action.payload.rate,
                     lastTickerTimestamp: (action.payload.lastTickerTimestamp * 1000) as Timestamp,
-                    lastSuccessfulFetchTimestamp,
+                    lastSuccessfulFetchTimestamp: fetchAttemptTimestamp,
                     isLoading: false,
                     error: null,
                 };

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
@@ -69,7 +69,7 @@ const fetchFn: Record<RateType, typeof fetchCurrentFiatRates> = {
 type UpdateCurrentFiatRatesThunkPayload = {
     ticker: TickerId;
     localCurrency: FiatCurrencyCode;
-    lastSuccessfulFetchTimestamp: Timestamp;
+    fetchAttemptTimestamp: Timestamp;
     rateType: RateType;
     forceFetchToken?: boolean;
 };
@@ -148,7 +148,7 @@ export const fetchFiatRatesThunk = createThunk(
                         ticker,
                         localCurrency,
                         rateType,
-                        lastSuccessfulFetchTimestamp: Date.now() as Timestamp,
+                        fetchAttemptTimestamp: Date.now() as Timestamp,
                     }),
                 ),
             ),

--- a/suite-native/module-accounts-import/src/screens/AccountImportLoadingScreen.tsx
+++ b/suite-native/module-accounts-import/src/screens/AccountImportLoadingScreen.tsx
@@ -11,7 +11,7 @@ import {
 } from '@suite-native/navigation';
 import TrezorConnect, { AccountInfo } from '@trezor/connect';
 import { updateFiatRatesThunk } from '@suite-common/wallet-core';
-import { Timestamp } from '@suite-common/wallet-types';
+import { Timestamp, TokenAddress } from '@suite-common/wallet-types';
 
 import { AccountImportLoader } from '../components/AccountImportLoader';
 import { useShowImportError } from '../useShowImportError';
@@ -86,6 +86,21 @@ export const AccountImportLoadingScreen = ({
             if (!ignore) {
                 if (fetchedAccountInfo?.success) {
                     setAccountInfo(fetchedAccountInfo.payload);
+
+                    //fetch fiat rates for all tokens of newly discovered account
+                    fetchedAccountInfo.payload.tokens?.forEach(token =>
+                        dispatch(
+                            updateFiatRatesThunk({
+                                ticker: {
+                                    symbol: networkSymbol,
+                                    tokenAddress: token.contract as TokenAddress,
+                                },
+                                rateType: 'current',
+                                localCurrency: fiatCurrency,
+                                lastSuccessfulFetchTimestamp: Date.now() as Timestamp,
+                            }),
+                        ),
+                    );
                 } else {
                     safelyShowImportError(fetchedAccountInfo.payload.error, getAccountInfo);
                 }

--- a/suite-native/module-accounts-import/src/screens/AccountImportLoadingScreen.tsx
+++ b/suite-native/module-accounts-import/src/screens/AccountImportLoadingScreen.tsx
@@ -78,7 +78,7 @@ export const AccountImportLoadingScreen = ({
                         },
                         rateType: 'current',
                         localCurrency: fiatCurrency,
-                        lastSuccessfulFetchTimestamp: Date.now() as Timestamp,
+                        fetchAttemptTimestamp: Date.now() as Timestamp,
                     }),
                 ),
             ]);
@@ -97,7 +97,7 @@ export const AccountImportLoadingScreen = ({
                                 },
                                 rateType: 'current',
                                 localCurrency: fiatCurrency,
-                                lastSuccessfulFetchTimestamp: Date.now() as Timestamp,
+                                fetchAttemptTimestamp: Date.now() as Timestamp,
                             }),
                         ),
                     );


### PR DESCRIPTION
## Description
Changes of https://github.com/trezor/trezor-suite/pull/11524 disable fetching of token fiat rates on adding a new account. This PR just puts this logic back in the place.

## Screenshots:

### discovery token fiat rates
https://github.com/trezor/trezor-suite/assets/26143964/ca10716a-8ed6-41f2-b881-a07a510dbdd1

### import ETH account token fiat rates
https://github.com/trezor/trezor-suite/assets/26143964/42936a3a-9e91-4686-beec-65bb851d2770


