### PR TITLE
Add prompt to reconnect device to check seed step

### DIFF
--- a/packages/suite/src/components/firmware/CheckSeedStep.tsx
+++ b/packages/suite/src/components/firmware/CheckSeedStep.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Button, Checkbox, variables } from '@trezor/components';
 import { useDevice, useDispatch, useFirmware } from 'src/hooks/suite';
 import { Translation } from 'src/components/suite';
-import { OnboardingStepBox } from 'src/components/onboarding';
+import { ConnectDevicePromptManager, OnboardingStepBox } from 'src/components/onboarding';
 import { FirmwareButtonsRow } from './Buttons/FirmwareButtonsRow';
 import { FirmwareSwitchWarning } from './FirmwareSwitchWarning';
 import { goto } from 'src/actions/suite/routerActions';
@@ -11,13 +11,13 @@ import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { spacingsPx } from '@trezor/theme';
 
 const StyledCheckbox = styled(Checkbox)`
-    margin: 16px 0;
+    margin: ${spacingsPx.md} 0;
 `;
 
 const DescriptionWrapper = styled.div`
     display: flex;
     flex-direction: column;
-    gap: 16px;
+    gap: ${spacingsPx.md};
 `;
 
 const TextButton = styled.span`
@@ -31,7 +31,7 @@ const StyledSwitchWarning = styled(FirmwareSwitchWarning)`
     color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
     margin: ${spacingsPx.xs} ${spacingsPx.md};
-    padding-bottom: 16px;
+    padding-bottom: ${spacingsPx.md};
     text-transform: uppercase;
 `;
 
@@ -46,13 +46,13 @@ export const CheckSeedStep = ({ onClose, onSuccess, willBeWiped }: CheckSeedStep
     const { device } = useDevice();
     const { hasSeed, toggleHasSeed } = useFirmware();
 
-    // unacquired device handled on higher level
-
-    if (!device?.features) return null;
-
-    const isBackedUp = !device.features.needs_backup && !device.features.unfinished_backup;
+    if (!device?.connected || !device?.features) {
+        return <ConnectDevicePromptManager device={device} />;
+    }
 
     const getContent = () => {
+        const isBackedUp = !device.features.needs_backup && !device.features.unfinished_backup;
+
         const noBackupHeading = (
             <Translation
                 id="TR_DEVICE_LABEL_IS_NOT_BACKED_UP"

--- a/packages/suite/src/components/firmware/FirmwareInitial.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInitial.tsx
@@ -45,10 +45,6 @@ const TextButton = styled.button`
     text-decoration: underline;
 `;
 
-const StyledConnectDevicePrompt = styled(ConnectDevicePromptManager)`
-    margin-top: 120px;
-`;
-
 const WarningListWrapper = styled.div`
     display: flex;
     align-items: flex-start;
@@ -177,7 +173,7 @@ export const FirmwareInitial = ({
         // Most users won't see this as they should come here with a connected device.
         // This is just for people who want to shoot themselves in the foot and disconnect the device before proceeding with fw update flow
         // Be aware that disconnection after fw installation () is completed is fine and won't be caught by this, because device variable will point to cached device
-        return <StyledConnectDevicePrompt device={device} />;
+        return <ConnectDevicePromptManager device={device} />;
     }
 
     // Bitcoin-only firmware is only available on T2T1 from v2.0.8 - older devices must first upgrade to 2.1.1 which does not have a Bitcoin-only variant


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

> // unacquired device handled on higher level

Not true :)



I also removed the top margin as I don't think it is necessary, especially with the expandable part below.

<!--- Describe your changes in detail -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/5470

## Screenshots:
![Screenshot 2024-03-21 at 16 01 49](https://github.com/trezor/trezor-suite/assets/42465546/c57b44fa-70cf-47d9-994e-ecda3ee45317)

