### PR TITLE
feat(suite-native): order accounts by networks

### DIFF
--- a/suite-native/accounts/package.json
+++ b/suite-native/accounts/package.json
@@ -23,6 +23,7 @@
         "@suite-common/wallet-types": "workspace:*",
         "@suite-common/wallet-utils": "workspace:*",
         "@suite-native/atoms": "workspace:*",
+        "@suite-native/config": "workspace:*",
         "@suite-native/ethereum-tokens": "workspace:*",
         "@suite-native/feature-flags": "workspace:*",
         "@suite-native/formatters": "workspace:*",

--- a/suite-native/accounts/src/selectors.ts
+++ b/suite-native/accounts/src/selectors.ts
@@ -15,7 +15,11 @@ import { SettingsSliceRootState } from '@suite-native/module-settings';
 import { NetworkSymbol, networks } from '@suite-common/wallet-config';
 
 import { GroupedAccounts } from './types';
-import { filterAccountsByLabelAndNetworkNames, groupAccountsByNetworkAccountType } from './utils';
+import {
+    filterAccountsByLabelAndNetworkNames,
+    groupAccountsByNetworkAccountType,
+    sortAccountsByNetworksAndAccountTypes,
+} from './utils';
 
 export const selectFilteredDeviceAccountsGroupedByNetworkAccountType = memoizeWithArgs(
     (
@@ -26,6 +30,7 @@ export const selectFilteredDeviceAccountsGroupedByNetworkAccountType = memoizeWi
 
         return pipe(
             accounts,
+            sortAccountsByNetworksAndAccountTypes,
             A.map(account => ({
                 ...account,
                 // Select only tokens with fiat rates To apply filter only one those tokens later.
@@ -47,6 +52,7 @@ export const selectDeviceNetworkAccountsGroupedByAccountType = memoizeWithArgs(
     (state: AccountsRootState & DeviceRootState, networkSymbol: NetworkSymbol) =>
         pipe(
             selectDeviceAccountsByNetworkSymbol(state, networkSymbol),
+            sortAccountsByNetworksAndAccountTypes,
             groupAccountsByNetworkAccountType,
         ) as GroupedAccounts,
     { size: D.keys(networks).length },

--- a/suite-native/accounts/src/tests/selectors.test.ts
+++ b/suite-native/accounts/src/tests/selectors.test.ts
@@ -1,6 +1,10 @@
 import { Account } from '@suite-common/wallet-types';
 
-import { isFilterValueMatchingAccount, groupAccountsByNetworkAccountType } from '../utils';
+import {
+    isFilterValueMatchingAccount,
+    groupAccountsByNetworkAccountType,
+    sortAccountsByNetworksAndAccountTypes,
+} from '../utils';
 
 describe('isFilterValueMatchingAccountLabelOrNetworkName', () => {
     const account = {
@@ -78,5 +82,33 @@ describe('groupAccountsByNetworkAccountType', () => {
             'Ethereum accounts': [{ symbol: 'eth', accountType: 'normal' }],
             'Litecoin Legacy Segwit accounts': [{ symbol: 'ltc', accountType: 'segwit' }],
         });
+    });
+});
+
+describe('sortAccountsByNetworksAndAccountTypes', () => {
+    it('accounts sorted by network and account type', () => {
+        const fixtureAccounts = [
+            { symbol: 'btc', accountType: 'normal' },
+            { symbol: 'btc', accountType: 'taproot' },
+            { symbol: 'eth', accountType: 'normal' },
+            { symbol: 'ltc', accountType: 'segwit' },
+            { symbol: 'btc', accountType: 'legacy' },
+            { symbol: 'btc', accountType: 'segwit' },
+            { symbol: 'btc', accountType: 'normal' },
+            { symbol: 'ltc', accountType: 'normal' },
+        ] as unknown as Account[];
+
+        const result = sortAccountsByNetworksAndAccountTypes(fixtureAccounts);
+
+        expect(result).toEqual([
+            { symbol: 'btc', accountType: 'normal' },
+            { symbol: 'btc', accountType: 'normal' },
+            { symbol: 'btc', accountType: 'taproot' },
+            { symbol: 'btc', accountType: 'segwit' },
+            { symbol: 'btc', accountType: 'legacy' },
+            { symbol: 'eth', accountType: 'normal' },
+            { symbol: 'ltc', accountType: 'normal' },
+            { symbol: 'ltc', accountType: 'segwit' },
+        ]);
     });
 });

--- a/suite-native/accounts/src/utils.ts
+++ b/suite-native/accounts/src/utils.ts
@@ -4,6 +4,7 @@ import { AccountType, networks } from '@suite-common/wallet-config';
 import { formattedAccountTypeMap } from '@suite-common/wallet-core/src/accounts/constants';
 import { Account } from '@suite-common/wallet-types';
 import { getNetwork } from '@suite-common/wallet-utils';
+import { discoverySupportedNetworks, orderedAccountTypes } from '@suite-native/config';
 
 const accountTypeToSectionHeader: Readonly<Partial<Record<AccountType, string>>> = {
     normal: 'default',
@@ -76,3 +77,21 @@ export const groupAccountsByNetworkAccountType = A.groupBy((account: Account) =>
 
     return `${networkName} ${formattedAccountType} accounts`;
 });
+
+export const sortAccountsByNetworksAndAccountTypes = (accounts: readonly Account[]) => {
+    return A.sort(accounts, (a, b) => {
+        const aOrder = discoverySupportedNetworks.indexOf(a.symbol) ?? Number.MAX_SAFE_INTEGER;
+        const bOrder = discoverySupportedNetworks.indexOf(b.symbol) ?? Number.MAX_SAFE_INTEGER;
+
+        if (aOrder === bOrder) {
+            const aAccountTypeOrder =
+                orderedAccountTypes.indexOf(a.accountType) ?? Number.MAX_SAFE_INTEGER;
+            const bAccountTypeOrder =
+                orderedAccountTypes.indexOf(b.accountType) ?? Number.MAX_SAFE_INTEGER;
+
+            return aAccountTypeOrder - bAccountTypeOrder;
+        }
+
+        return aOrder - bOrder;
+    });
+};

--- a/suite-native/accounts/tsconfig.json
+++ b/suite-native/accounts/tsconfig.json
@@ -28,6 +28,7 @@
             "path": "../../suite-common/wallet-utils"
         },
         { "path": "../atoms" },
+        { "path": "../config" },
         { "path": "../ethereum-tokens" },
         { "path": "../feature-flags" },
         { "path": "../formatters" },

--- a/suite-native/config/package.json
+++ b/suite-native/config/package.json
@@ -12,6 +12,7 @@
     "dependencies": {
         "@mobily/ts-belt": "^3.13.1",
         "@suite-common/wallet-config": "workspace:*",
+        "@suite-common/wallet-types": "workspace:*",
         "@suite-common/wallet-utils": "workspace:*"
     }
 }

--- a/suite-native/config/src/supportedNetworks.ts
+++ b/suite-native/config/src/supportedNetworks.ts
@@ -2,6 +2,15 @@ import { A } from '@mobily/ts-belt';
 
 import { isTestnet } from '@suite-common/wallet-utils';
 import { Network, NetworkSymbol, getMainnets, getTestnets } from '@suite-common/wallet-config';
+import { AccountType } from '@suite-common/wallet-types';
+
+export const orderedAccountTypes: AccountType[] = [
+    'normal',
+    'taproot',
+    'segwit',
+    'legacy',
+    'ledger',
+];
 
 const discoveryBlacklist: NetworkSymbol[] = ['sol', 'dsol', 'matic'];
 

--- a/suite-native/config/tsconfig.json
+++ b/suite-native/config/tsconfig.json
@@ -6,6 +6,9 @@
             "path": "../../suite-common/wallet-config"
         },
         {
+            "path": "../../suite-common/wallet-types"
+        },
+        {
             "path": "../../suite-common/wallet-utils"
         }
     ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -8672,6 +8672,7 @@ __metadata:
     "@suite-common/wallet-types": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"
     "@suite-native/atoms": "workspace:*"
+    "@suite-native/config": "workspace:*"
     "@suite-native/ethereum-tokens": "workspace:*"
     "@suite-native/feature-flags": "workspace:*"
     "@suite-native/formatters": "workspace:*"
@@ -8908,6 +8909,7 @@ __metadata:
   dependencies:
     "@mobily/ts-belt": "npm:^3.13.1"
     "@suite-common/wallet-config": "workspace:*"
+    "@suite-common/wallet-types": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
make Accounts in assets/receive screen grouped (and ordered) by network and account type correctly