### PR TITLE
fix(transport): accept logger also for usb transports

### DIFF
--- a/packages/transport-bridge/src/core.ts
+++ b/packages/transport-bridge/src/core.ts
@@ -7,6 +7,7 @@ import { SessionsClient } from '@trezor/transport/src/sessions/client';
 import { UsbApi } from '@trezor/transport/src/api/usb';
 import { UdpApi } from '@trezor/transport/src/api/udp';
 import { AcquireInput, ReleaseInput } from '@trezor/transport/src/transports/abstract';
+import { Log } from '@trezor/utils';
 
 export const sessionsBackground = new SessionsBackground();
 
@@ -19,11 +20,12 @@ sessionsBackground.on('descriptors', descriptors => {
     sessionsClient.emit('descriptors', descriptors);
 });
 
-export const createApi = (apiStr: 'usb' | 'udp') => {
+export const createApi = (apiStr: 'usb' | 'udp', logger?: Log) => {
     const api =
         apiStr === 'udp'
-            ? new UdpApi({})
+            ? new UdpApi({ logger })
             : new UsbApi({
+                  logger,
                   usbInterface: new WebUSB({
                       allowAllDevices: true, // return all devices, not only authorized
                   }),

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -27,8 +27,8 @@ export abstract class AbstractApiTransport extends AbstractTransport {
     private api: AbstractApi;
     protected acquirePromise?: Deferred<void>;
 
-    constructor({ messages, api, sessionsClient, signal }: ConstructorParams) {
-        super({ messages, signal });
+    constructor({ messages, api, sessionsClient, signal, logger }: ConstructorParams) {
+        super({ messages, signal, logger });
         this.sessionsClient = sessionsClient;
         this.api = api;
     }

--- a/packages/transport/src/transports/webusb.browser.ts
+++ b/packages/transport/src/transports/webusb.browser.ts
@@ -23,7 +23,7 @@ export class WebUsbTransport extends AbstractApiTransport {
                 usbInterface: navigator.usb,
                 logger,
             }),
-
+            logger,
             // sessions client with a request fn facilitating communication with a session backend (shared worker in case of webusb)
             sessionsClient: new SessionsClient({
                 // @ts-expect-error


### PR DESCRIPTION
part of #11532, followup of #11674

pass logger to all transports where it was missing (usb transports, transport-bridge)