### PR TITLE
chore(node-utils): split referer and origin check middlewares

### DIFF
--- a/packages/node-utils/package.json
+++ b/packages/node-utils/package.json
@@ -7,7 +7,7 @@
     "main": "src/index",
     "scripts": {
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
-        "test:unit": "jest -c ../../jest.config.base.js",
+        "test:unit": "yarn g:jest --verbose -c ../../jest.config.base.js",
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {

--- a/packages/node-utils/src/index.ts
+++ b/packages/node-utils/src/index.ts
@@ -1,3 +1,10 @@
 export { ensureDirectoryExists } from './ensureDirectoryExists';
 export { getFreePort } from './getFreePort';
-export { HttpServer, allowOrigins, parseBodyJSON, parseBodyText, type Handler } from './http';
+export {
+    HttpServer,
+    allowOrigins,
+    allowReferers,
+    parseBodyJSON,
+    parseBodyText,
+    type Handler,
+} from './http';

--- a/packages/node-utils/src/tests/http.test.ts
+++ b/packages/node-utils/src/tests/http.test.ts
@@ -1,4 +1,4 @@
-import { HttpServer, parseBodyJSON, parseBodyText, allowOrigins } from '../http';
+import { HttpServer, parseBodyJSON, parseBodyText, allowReferers } from '../http';
 
 type Events = {
     foo: (arg: string) => void;
@@ -121,20 +121,20 @@ describe('HttpServer', () => {
         await new Promise(resolve => setTimeout(resolve, 500));
         expect(muteLogger.info).toHaveBeenLastCalledWith(
             expect.any(String),
-            'Request /foo aborted',
+            'Request GET /foo aborted',
         );
     });
 
-    test('allowOrigin middleware lets request with allowed origin through', async () => {
+    test('allowReferer middleware lets request with allowed referer through', async () => {
         const handler = jest.fn((_request, response) => {
             response.end('ok');
         });
 
-        server.get('/foo', [allowOrigins(['*']), allowOrigins(['*.meow.com']), handler]);
+        server.get('/foo', [allowReferers(['*']), allowReferers(['*.meow.com']), handler]);
 
         server.get('/foo-bar', [
             // empty string is allowed origin when referer is not defined
-            allowOrigins(['']),
+            allowReferers(['']),
             handler,
         ]);
         await server.start();

--- a/packages/suite-desktop-core/src/libs/http-receiver.ts
+++ b/packages/suite-desktop-core/src/libs/http-receiver.ts
@@ -1,7 +1,7 @@
 import * as url from 'url';
 
 import { xssFilters } from '@trezor/utils';
-import { HttpServer, allowOrigins } from '@trezor/node-utils';
+import { HttpServer, allowReferers } from '@trezor/node-utils';
 
 import { HTTP_ORIGINS_DEFAULT } from './constants';
 
@@ -48,7 +48,7 @@ export const createHttpReceiver = () => {
     ]);
 
     httpReceiver.get('/oauth', [
-        allowOrigins(['', '127.0.0.1', 'www.dropbox.com']), // No referer is sent by Google, Dropbox sends referer when using Safari
+        allowReferers(['', '127.0.0.1', 'www.dropbox.com']), // No referer is sent by Google, Dropbox sends referer when using Safari
         (request, response) => {
             const { search } = url.parse(request.url, true);
             if (search) {
@@ -70,7 +70,7 @@ export const createHttpReceiver = () => {
     ]);
 
     httpReceiver.get('/buy-redirect', [
-        allowOrigins(['', 'localhost:3000', '*.invity.io', 'invity.io']),
+        allowReferers(['', 'localhost:3000', '*.invity.io', 'invity.io']),
         (request, response) => {
             const { query } = url.parse(request.url, true);
             if (query && query.p) {
@@ -83,7 +83,7 @@ export const createHttpReceiver = () => {
     ]);
 
     httpReceiver.get('/buy-post', [
-        allowOrigins(['']), // No referer
+        allowReferers(['']), // No referer
         (request, response) => {
             try {
                 const { searchParams } = new URL(request.url, 'http://127.0.0.1:21335'); // hostname is not important here, just to be able to validate relative URL
@@ -115,7 +115,7 @@ export const createHttpReceiver = () => {
     ]);
 
     httpReceiver.get('/sell-redirect', [
-        allowOrigins(['']), // No referer
+        allowReferers(['']), // No referer
         (request, response) => {
             const { query } = url.parse(request.url, true);
             if (query && query.p) {
@@ -128,7 +128,7 @@ export const createHttpReceiver = () => {
     ]);
 
     httpReceiver.get('/spend-iframe', [
-        allowOrigins(['']), // Opened in a new tab, no referer
+        allowReferers(['']), // Opened in a new tab, no referer
         (_request, response) => {
             const regex = /^https:\/\/(.+\.|)bitrefill\.com$/;
             const template = `<!DOCTYPE html>
@@ -195,7 +195,7 @@ export const createHttpReceiver = () => {
     ]);
 
     httpReceiver.get('/spend-handle-message', [
-        allowOrigins(HTTP_ORIGINS_DEFAULT),
+        allowReferers(HTTP_ORIGINS_DEFAULT),
         (request, response) => {
             const { query } = url.parse(request.url, true);
             httpReceiver.emit('spend/message', {


### PR DESCRIPTION
part of #11532

- `allowOrigin` -> `allowReferer` - should only be refactoring without any changes.
- added new util `allowOrigin` which is than used in  #11532, specifically in https://github.com/trezor/trezor-suite/pull/11532/commits/dbaeef0417ca72f7301a22da62b41ef57e23acef. 

checkOrigin and checkReferer utils are very similar. I can say I feel some urge to merge them somehow and I can imagine that @marekrjpolak could be nicely triggered by having two similar utils in place. But so far I just wanted to make as little changes to existing parts of code.