### PR TITLE
feat(transport): add field type to descriptor

### DIFF
--- a/packages/transport-bridge/src/http.ts
+++ b/packages/transport-bridge/src/http.ts
@@ -15,7 +15,7 @@ export class TrezordNode {
     version = '3.0.0';
     serviceName = 'trezord-node';
     /** last known descriptors state */
-    descriptors: string;
+    descriptors: Descriptor[];
     /** pending /listen subscriptions that are supposed to be resolved whenever descriptors change is detected */
     listenSubscriptions: {
         descriptors: string;
@@ -30,7 +30,7 @@ export class TrezordNode {
     constructor({ port, api }: { port: number; api: 'usb' | 'udp' }) {
         this.port = port || defaults.port;
 
-        this.descriptors = '{}';
+        this.descriptors = [];
 
         this.listenSubscriptions = [];
 
@@ -42,13 +42,13 @@ export class TrezordNode {
     }
 
     private resolveListenSubscriptions(descriptors: Descriptor[]) {
-        this.descriptors = JSON.stringify(descriptors);
+        this.descriptors = descriptors;
         const [affected, unaffected] = arrayPartition(
             this.listenSubscriptions,
-            subscription => subscription.descriptors !== this.descriptors,
+            subscription => subscription.descriptors !== JSON.stringify(this.descriptors),
         );
         affected.forEach(subscription => {
-            subscription.res.end(this.descriptors);
+            subscription.res.end(str(this.descriptors));
         });
         this.listenSubscriptions = unaffected;
     }

--- a/packages/transport/src/api/abstract.ts
+++ b/packages/transport/src/api/abstract.ts
@@ -8,6 +8,16 @@ export interface AbstractApiConstructorParams {
     logger?: Logger;
 }
 
+// https://github.dev/trezor/trezord-go/blob/db03d99230f5b609a354e3586f1dfc0ad6da16f7/core/core.go#L46-L47
+export enum DEVICE_TYPE {
+    TypeT1Hid = 0,
+    TypeT1Webusb = 1,
+    TypeT1WebusbBoot = 2,
+    TypeT2 = 3,
+    TypeT2Boot = 4,
+    TypeEmulator = 5,
+}
+
 /**
  * This class defines unifying shape for native communication interfaces such as
  * - navigator.bluetooth
@@ -35,7 +45,7 @@ export abstract class AbstractApi extends TypedEmitter<{
      * enumerate connected devices
      */
     abstract enumerate(): AsyncResultWithTypedError<
-        string[],
+        { path: string; type: DEVICE_TYPE }[],
         | typeof ERRORS.ABORTED_BY_TIMEOUT
         | typeof ERRORS.ABORTED_BY_SIGNAL
         | typeof ERRORS.UNEXPECTED_ERROR

--- a/packages/transport/src/api/abstract.ts
+++ b/packages/transport/src/api/abstract.ts
@@ -1,5 +1,5 @@
 import { TypedEmitter } from '@trezor/utils';
-import type { AnyError, AsyncResultWithTypedError, Success, Logger } from '../types';
+import type { AnyError, AsyncResultWithTypedError, Success, Logger, Descriptor } from '../types';
 import { success, error, unknownError } from '../utils/result';
 
 import * as ERRORS from '../errors';
@@ -25,7 +25,7 @@ export enum DEVICE_TYPE {
  * This is not public API. Only a building block which is used in src/transports
  */
 export abstract class AbstractApi extends TypedEmitter<{
-    'transport-interface-change': string[];
+    'transport-interface-change': Descriptor[];
     'transport-interface-error': typeof ERRORS.DEVICE_NOT_FOUND | typeof ERRORS.DEVICE_UNREADABLE;
 }> {
     logger: Logger;

--- a/packages/transport/src/api/udp.ts
+++ b/packages/transport/src/api/udp.ts
@@ -1,7 +1,7 @@
 import UDP from 'dgram';
 import { isNotUndefined } from '@trezor/utils';
 
-import { AbstractApi, AbstractApiConstructorParams } from './abstract';
+import { AbstractApi, AbstractApiConstructorParams, DEVICE_TYPE } from './abstract';
 import { AsyncResultWithTypedError, ResultWithTypedError } from '../types';
 
 import * as ERRORS from '../errors';
@@ -118,7 +118,11 @@ export class UdpApi extends AbstractApi {
         const paths = ['127.0.0.1:21324'];
 
         const enumerateResult = await Promise.all(
-            paths.map(path => this.ping(path).then(pinged => (pinged ? path : undefined))),
+            paths.map(path =>
+                this.ping(path).then(pinged =>
+                    pinged ? { path, type: DEVICE_TYPE.TypeEmulator } : undefined,
+                ),
+            ),
         ).then(res => res.filter(isNotUndefined));
 
         return this.success(enumerateResult);

--- a/packages/transport/src/constants.ts
+++ b/packages/transport/src/constants.ts
@@ -3,14 +3,19 @@ export const CONFIGURATION_ID = 1;
 export const INTERFACE_ID = 0;
 export const ENDPOINT_ID = 1;
 export const T1_HID_VENDOR = 0x534c;
+
+const T1_HID_PRODUCT = 0x0001;
+const WEBUSB_FIRMWARE_PRODUCT = 0x53c1;
+export const WEBUSB_BOOTLOADER_PRODUCT = 0x53c0;
+
 export const TREZOR_USB_DESCRIPTORS = [
     // TREZOR v1
     // won't get opened, but we can show error at least
-    { vendorId: 0x534c, productId: 0x0001 },
+    { vendorId: 0x534c, productId: T1_HID_PRODUCT },
     // TREZOR webusb Bootloader
-    { vendorId: 0x1209, productId: 0x53c0 },
+    { vendorId: 0x1209, productId: WEBUSB_BOOTLOADER_PRODUCT },
     // TREZOR webusb Firmware
-    { vendorId: 0x1209, productId: 0x53c1 },
+    { vendorId: 0x1209, productId: WEBUSB_FIRMWARE_PRODUCT },
 ];
 
 /**

--- a/packages/transport/src/errors.ts
+++ b/packages/transport/src/errors.ts
@@ -41,6 +41,10 @@ export const SESSION_WRONG_PREVIOUS = 'wrong previous session' as const;
  */
 export const SESSION_NOT_FOUND = 'session not found' as const;
 /**
+ * from sessions background. it needs to know about descriptor before it can perform certain actions (acquire)
+ */
+export const DESCRIPTOR_NOT_FOUND = 'descriptor not found' as const;
+/**
  * sessions background did not respond in time
  *
  * transports: webusb

--- a/packages/transport/src/sessions/types.ts
+++ b/packages/transport/src/sessions/types.ts
@@ -1,26 +1,25 @@
 import type { AcquireInput } from '../transports/abstract';
-import type { Session, Descriptor, ResultWithTypedError, Success } from '../types';
+import type { Descriptor, ResultWithTypedError, Success } from '../types';
 import * as ERRORS from '../errors';
 
 type BackgroundResponseWithError<T, E> = ResultWithTypedError<T, E> & { id: number };
 type BackgroundResponse<T> = Success<T> & { id: number };
 
-export type Sessions = Record<string, Session | undefined>;
+export type Sessions = Record<string, Descriptor>;
 
 export type HandshakeRequest = Record<string, never>;
 export type HandshakeResponse = BackgroundResponse<undefined>;
 
 export type EnumerateIntentRequest = Record<string, never>;
 export type EnumerateIntentResponse = BackgroundResponse<{
-    sessions: Sessions;
+    descriptors: Descriptor[];
 }>;
 
 export type EnumerateDoneRequest = {
-    paths: string[];
+    descriptors: Descriptor[];
 };
 
 export type EnumerateDoneResponse = BackgroundResponse<{
-    sessions: Sessions;
     descriptors: Descriptor[];
 }>;
 
@@ -28,17 +27,20 @@ export type AcquireIntentRequest = AcquireInput;
 
 export type AcquireIntentResponse = BackgroundResponseWithError<
     { session: string },
-    typeof ERRORS.SESSION_WRONG_PREVIOUS
+    typeof ERRORS.SESSION_WRONG_PREVIOUS | typeof ERRORS.DESCRIPTOR_NOT_FOUND
 >;
 
 export type AcquireDoneRequest = {
     path: string;
 };
 
-export type AcquireDoneResponse = BackgroundResponse<{
-    session: string;
-    descriptors: Descriptor[];
-}>;
+export type AcquireDoneResponse = BackgroundResponseWithError<
+    {
+        session: string;
+        descriptors: Descriptor[];
+    },
+    typeof ERRORS.DESCRIPTOR_NOT_FOUND
+>;
 export interface ReleaseIntentRequest {
     session: string;
 }
@@ -58,7 +60,7 @@ export type ReleaseDoneResponse = BackgroundResponse<{
 
 export type GetSessionsRequest = Record<string, never>;
 export type GetSessionsResponse = BackgroundResponse<{
-    sessions: Sessions;
+    descriptors: Descriptor[];
 }>;
 export interface GetPathBySessionRequest {
     session: string;

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -220,6 +220,7 @@ export abstract class AbstractTransport extends TypedEmitter<{
         string,
         // webusb
         | typeof ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE
+        | typeof ERRORS.DESCRIPTOR_NOT_FOUND
         // bridge
         | typeof ERRORS.WRONG_RESULT_TYPE
         | typeof ERRORS.HTTP_ERROR

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -79,14 +79,21 @@ export abstract class AbstractApiTransport extends AbstractTransport {
             if (!enumerateResult.success) {
                 return enumerateResult;
             }
-            const occupiedPaths = enumerateResult.payload;
+            // partial descriptors with path
+            const descriptors = enumerateResult.payload;
 
             // inform sessions background about occupied paths and get descriptors back
             const enumerateDoneResponse = await this.sessionsClient.enumerateDone({
-                paths: occupiedPaths,
+                paths: descriptors.map(d => d.path),
             });
 
-            return this.success(enumerateDoneResponse.payload.descriptors);
+            return this.success(
+                descriptors.map(d => ({
+                    path: d.path,
+                    type: d.type,
+                    session: enumerateDoneResponse.payload.sessions[d.path],
+                })),
+            );
         });
     }
 

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -51,10 +51,10 @@ export abstract class AbstractApiTransport extends AbstractTransport {
         this.listening = true;
 
         // 1. transport api reports descriptors change
-        this.api.on('transport-interface-change', devices => {
+        this.api.on('transport-interface-change', descriptors => {
             // 2. we signal this to sessions background
             this.sessionsClient.enumerateDone({
-                paths: devices,
+                descriptors,
             });
         });
         // 3. based on 2.sessions background distributes information about descriptors change to all clients
@@ -84,16 +84,10 @@ export abstract class AbstractApiTransport extends AbstractTransport {
 
             // inform sessions background about occupied paths and get descriptors back
             const enumerateDoneResponse = await this.sessionsClient.enumerateDone({
-                paths: descriptors.map(d => d.path),
+                descriptors,
             });
 
-            return this.success(
-                descriptors.map(d => ({
-                    path: d.path,
-                    type: d.type,
-                    session: enumerateDoneResponse.payload.sessions[d.path],
-                })),
-            );
+            return this.success(enumerateDoneResponse.payload.descriptors);
         });
     }
 

--- a/packages/transport/src/types/index.ts
+++ b/packages/transport/src/types/index.ts
@@ -1,7 +1,14 @@
+import { DEVICE_TYPE } from '../api/abstract';
+
 export * from './apiCall';
 
 export type Session = null | string;
-export type Descriptor = { path: string; session?: Session };
+export type Descriptor = {
+    path: string;
+    session?: Session;
+    /** only used in status page */
+    type?: DEVICE_TYPE;
+};
 
 export interface Logger {
     debug(...args: any): void;

--- a/packages/transport/tests/abstractUsb.test.ts
+++ b/packages/transport/tests/abstractUsb.test.ts
@@ -207,10 +207,12 @@ describe('Usb', () => {
                     {
                         path: '123',
                         session: null,
+                        type: 1,
                     },
                     {
                         path: 'bootloader1',
                         session: null,
+                        type: 1,
                     },
                 ],
             });

--- a/packages/transport/tests/abstractUsb.test.ts
+++ b/packages/transport/tests/abstractUsb.test.ts
@@ -6,26 +6,6 @@ import { SessionsClient } from '../src/sessions/client';
 import { SessionsBackground } from '../src/sessions/background';
 import * as messages from '@trezor/protobuf/messages.json';
 
-// we cant directly use abstract class (UsbTransport)
-
-class TestUsbTransport extends AbstractApiTransport {
-    public name = 'WebUsbTransport' as const;
-
-    constructor({
-        messages,
-        api,
-        sessionsClient,
-        signal,
-    }: ConstructorParameters<typeof AbstractApiTransport>[0]) {
-        super({
-            messages,
-            api,
-            sessionsClient,
-            signal,
-        });
-    }
-}
-
 // create devices otherwise returned from navigator.usb.getDevices
 const createMockedDevice = (optional = {}) => ({
     vendorId: 0x1209,
@@ -59,6 +39,68 @@ const createUsbMock = (optional = {}) =>
             Promise.resolve([createMockedDevice(), createMockedDevice({ serialNumber: null })]),
         ...optional,
     }) as unknown as UsbApi['usbInterface'];
+
+class TestUsbTransport extends AbstractApiTransport {
+    public name = 'WebUsbTransport' as const;
+
+    constructor({
+        messages,
+        api,
+        sessionsClient,
+        signal,
+    }: ConstructorParameters<typeof AbstractApiTransport>[0]) {
+        super({
+            messages,
+            api,
+            sessionsClient,
+            signal,
+        });
+    }
+}
+// we cant directly use abstract class (UsbTransport)
+const initTest = async () => {
+    let sessionsBackground: SessionsBackground;
+    let sessionsClient: SessionsClient;
+    let transport: AbstractTransport;
+    let testUsbApi: UsbApi;
+    let abortController: AbortController;
+    sessionsBackground = new SessionsBackground();
+
+    sessionsClient = new SessionsClient({
+        requestFn: params => sessionsBackground.handleMessage(params),
+        registerBackgroundCallbacks: onDescriptorsCallback => {
+            sessionsBackground.on('descriptors', descriptors => {
+                onDescriptorsCallback(descriptors);
+            });
+        },
+    });
+
+    sessionsBackground.on('descriptors', descriptors => {
+        sessionsClient.emit('descriptors', descriptors);
+    });
+
+    // create usb api with navigator.usb mock
+    testUsbApi = new UsbApi({
+        usbInterface: createUsbMock(),
+    });
+
+    abortController = new AbortController();
+
+    transport = new TestUsbTransport({
+        api: testUsbApi,
+        sessionsClient,
+        messages,
+        signal: abortController.signal,
+    });
+    await transport.init().promise;
+
+    return {
+        sessionsBackground,
+        sessionsClient,
+        transport,
+        testUsbApi,
+    };
+};
 
 describe('Usb', () => {
     beforeEach(() => {
@@ -130,53 +172,16 @@ describe('Usb', () => {
     });
 
     describe('with initiated transport', () => {
-        let sessionsBackground: SessionsBackground;
-        let sessionsClient: SessionsClient;
-        let transport: AbstractTransport;
-        let testUsbApi: UsbApi;
-        let abortController: AbortController;
-
-        beforeEach(async () => {
-            sessionsBackground = new SessionsBackground();
-
-            sessionsClient = new SessionsClient({
-                requestFn: params => sessionsBackground.handleMessage(params),
-                registerBackgroundCallbacks: onDescriptorsCallback => {
-                    sessionsBackground.on('descriptors', descriptors => {
-                        onDescriptorsCallback(descriptors);
-                    });
-                },
-            });
-
-            sessionsBackground.on('descriptors', descriptors => {
-                sessionsClient.emit('descriptors', descriptors);
-            });
-
-            // create usb api with navigator.usb mock
-            testUsbApi = new UsbApi({
-                usbInterface: createUsbMock(),
-            });
-
-            abortController = new AbortController();
-
-            transport = new TestUsbTransport({
-                api: testUsbApi,
-                sessionsClient,
-                messages,
-                signal: abortController.signal,
-            });
-
-            await transport.init().promise;
-        });
-
-        it('listen twice -> error', () => {
+        it('listen twice -> error', async () => {
+            const { transport } = await initTest();
             const res1 = transport.listen();
             expect(res1.success).toEqual(true);
             const res2 = transport.listen();
             expect(res2.success).toEqual(false);
         });
 
-        it('handleDescriptorsChange', () => {
+        it('handleDescriptorsChange', async () => {
+            const { transport } = await initTest();
             const spy = jest.fn();
             transport.on('transport-update', spy);
 
@@ -200,6 +205,7 @@ describe('Usb', () => {
         });
 
         it('enumerate', async () => {
+            const { transport } = await initTest();
             const res = await transport.enumerate().promise;
             expect(res).toEqual({
                 success: true,
@@ -219,6 +225,7 @@ describe('Usb', () => {
         });
 
         it('acquire. transport is not listening', async () => {
+            const { transport } = await initTest();
             jest.useFakeTimers();
             const spy = jest.fn();
             transport.on('transport-update', spy);
@@ -238,8 +245,12 @@ describe('Usb', () => {
         });
 
         it('acquire. transport listening. missing descriptor', async () => {
+            const { transport, sessionsClient, sessionsBackground } = await initTest();
+
             sessionsBackground.removeAllListeners();
+
             const enumerateResult = await transport.enumerate().promise;
+
             expect(enumerateResult.success).toEqual(true);
             // @ts-expect-error
             transport.handleDescriptorsChange(enumerateResult.payload);
@@ -262,6 +273,7 @@ describe('Usb', () => {
         });
 
         it('acquire. transport listening. unexpected session', async () => {
+            const { transport, sessionsClient, sessionsBackground } = await initTest();
             sessionsBackground.removeAllListeners();
             const enumerateResult = await transport.enumerate().promise;
             expect(enumerateResult.success).toEqual(true);
@@ -281,6 +293,7 @@ describe('Usb', () => {
         });
 
         it('call error - called without acquire.', async () => {
+            const { transport } = await initTest();
             const res = await transport.call({
                 name: 'GetAddress',
                 data: {},
@@ -291,6 +304,7 @@ describe('Usb', () => {
         });
 
         it('call - with valid message.', async () => {
+            const { transport } = await initTest();
             await transport.enumerate().promise;
             const acquireRes = await transport.acquire({ input: { path: '123', previous: null } })
                 .promise;
@@ -320,6 +334,7 @@ describe('Usb', () => {
         });
 
         it('send and receive.', async () => {
+            const { transport } = await initTest();
             await transport.enumerate().promise;
             const acquireRes = await transport.acquire({ input: { path: '123', previous: null } })
                 .promise;
@@ -355,6 +370,7 @@ describe('Usb', () => {
         });
 
         it('send protocol-v1 with custom chunkSize', async () => {
+            const { transport, testUsbApi } = await initTest();
             await transport.enumerate().promise;
             const acquireRes = await transport.acquire({ input: { path: '123', previous: null } })
                 .promise;
@@ -398,6 +414,7 @@ describe('Usb', () => {
         });
 
         it('release', async () => {
+            const { transport } = await initTest();
             await transport.enumerate().promise;
             const acquireRes = await transport.acquire({ input: { path: '123', previous: null } })
                 .promise;
@@ -419,6 +436,7 @@ describe('Usb', () => {
         });
 
         it('call - with use abort', async () => {
+            const { transport } = await initTest();
             await transport.enumerate().promise;
             const acquireRes = await transport.acquire({ input: { path: '123', previous: null } })
                 .promise;


### PR DESCRIPTION
part of #11532

We can already provide basic information about the device model on the transport layer. Here I would like to propagate this information to higher layers. So far the only use case is displaying this information on the bridge status page (which is being recreated for node bridge in #11532)

<img width="762" alt="image" src="https://github.com/trezor/trezor-suite/assets/30367552/6450cea5-3184-4c6d-9b0f-2190597643de">

I decided to rework the session's background slightly. Previously, it held information about sessions in a dictionary `Record<path: session>`, where both key and value were strings. This wasn't very comfortable to work with, as you can see in [f8c5917](https://github.com/trezor/trezor-suite/pull/11692/commits/f8c591722f81683c1f5a5b4662a93215e0a3957b) where I needed to transform data from one shape to another. So I decided to introduce another change in [7d18cfc](https://github.com/trezor/trezor-suite/pull/11692/commits/7d18cfc91e7bc8db62bd40fcc6f17dc8320200ca) where this info is kept as `Record<path, Descriptor> ` in sessions background.

<img width="1335" alt="image" src="https://github.com/trezor/trezor-suite/assets/30367552/a28c9714-69f9-494a-8d0a-e8e0ebc4022a">


