### PR TITLE
feat(suite): disable token definitions for cardano

### DIFF
--- a/suite-common/token-definitions/src/__fixtures__/utils.ts
+++ b/suite-common/token-definitions/src/__fixtures__/utils.ts
@@ -80,12 +80,13 @@ export const getSupportedDefinitionTypesFixtures = [
         features: ['coin-definitions', 'nft-definitions'],
         result: [DefinitionType.COIN, DefinitionType.NFT],
     },
-    {
-        testName: 'Supports only token definitions',
-        networkSymbol: 'ada' as NetworkSymbol,
-        features: ['coin-definitions'],
-        result: [DefinitionType.COIN],
-    },
+    // Temporarily skipped while token definitions are disabled for Cardano.
+    // {
+    //     testName: 'Supports only token definitions',
+    //     networkSymbol: 'ada' as NetworkSymbol,
+    //     features: ['coin-definitions'],
+    //     result: [DefinitionType.COIN],
+    // },
     {
         testName: 'Supports neither token nor NFT definitions',
         networkSymbol: 'ltc' as NetworkSymbol,

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -282,7 +282,7 @@ export const networks = {
         bip43Path: "m/1852'/1815'/i'",
         decimals: 6,
         testnet: false,
-        features: ['tokens', 'staking', 'coin-definitions'],
+        features: ['tokens', 'staking' /* coin-definitions */],
         explorer: {
             tx: 'https://explorer.blockfrost.dev/transaction/',
             account: 'https://explorer.blockfrost.dev/account/',
@@ -313,7 +313,7 @@ export const networks = {
         bip43Path: "m/44'/501'/i'/0'",
         decimals: 9,
         testnet: false,
-        features: ['tokens', 'coin-definitions' /* , 'staking' */],
+        features: ['tokens', 'coin-definitions' /*, 'staking' */],
         explorer: {
             tx: 'https://explorer.solana.com/tx/',
             account: 'https://explorer.solana.com/address/',


### PR DESCRIPTION
## Description

- disabled token definitions for Cardano as the token definitions list is mix of
  - `policyId`
  - `policyId` + `symbol`
  - `fingerprint`
  
  
![Screenshot 2024-03-22 at 15 48 08](https://github.com/trezor/trezor-suite/assets/33235762/8262eee7-6904-49aa-849f-258b5ef77228)

  