### PR TITLE
Rename `tokenFiatRate` back to `fiatRate`

### DIFF
--- a/packages/suite/src/utils/wallet/tokenUtils.ts
+++ b/packages/suite/src/utils/wallet/tokenUtils.ts
@@ -40,13 +40,13 @@ export const enhanceTokensWithRates = (
             fiatCurrency,
             token.contract as TokenAddress,
         );
-        const tokenFiatRate = rates?.[tokenFiatRateKey];
+        const fiatRate = rates?.[tokenFiatRateKey];
 
-        const fiatValue = new BigNumber(token.balance || 0).multipliedBy(tokenFiatRate?.rate || 0);
+        const fiatValue = new BigNumber(token.balance || 0).multipliedBy(fiatRate?.rate || 0);
 
         return {
             ...token,
-            tokenFiatRate,
+            fiatRate,
             fiatValue,
         };
     });


### PR DESCRIPTION
## Description

Fix of #11702
