### PR TITLE
Fix/tiny font

### DIFF
--- a/suite-native/module-accounts-management/src/components/AccountDetailCryptoValue.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountDetailCryptoValue.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
 
-import { DiscreetTextTrigger, HStack } from '@suite-native/atoms';
+import { HStack } from '@suite-native/atoms';
 import { CryptoAmountFormatter } from '@suite-native/formatters';
 import { CryptoIcon } from '@suite-common/icons';
 import { NetworkSymbol } from '@suite-common/wallet-config';
@@ -15,14 +15,12 @@ export const AccountDetailCryptoValue = memo(
     ({ value, networkSymbol, isBalance = true }: AccountDetailBalanceProps) => (
         <HStack spacing="small" flexDirection="row" alignItems="center" justifyContent="center">
             <CryptoIcon symbol={networkSymbol} size="extraSmall" />
-            <DiscreetTextTrigger>
-                <CryptoAmountFormatter
-                    value={value}
-                    network={networkSymbol}
-                    isBalance={isBalance}
-                    adjustsFontSizeToFit
-                />
-            </DiscreetTextTrigger>
+            <CryptoAmountFormatter
+                value={value}
+                network={networkSymbol}
+                isBalance={isBalance}
+                adjustsFontSizeToFit
+            />
         </HStack>
     ),
 );


### PR DESCRIPTION
## Description
`DiscreetText` was not working correctly in combination with react-native `adjustFontsizeToFit`. There was always predefined typography `lineHeight` used even if the font height was made smaller by `adjustFontsizeToFit` which lead to the glitchy appearance. This PR fixes that.

## Related Issue

Resolve #11668 

## Screenshots:


![Screenshot 2024-03-25 at 13 10 01](https://github.com/trezor/trezor-suite/assets/26143964/f3051011-f8e7-4fd1-adf1-ba37f97bff08)
