### PR TITLE
docs(connect-webextension): knownHost process

### DIFF
--- a/packages/connect-webextension/README.md
+++ b/packages/connect-webextension/README.md
@@ -54,6 +54,10 @@ Amend your manifest.json to include the script as a content script. Replace <pat
   ],
 ```
 
+## Adding your webextension to `knownHosts`
+
+To ensure your extension is displayed with its name rather than its ID, you need to open a Pull Request to include it in the `knownHosts` section of the file located at https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/data/config.ts#L17.
+
 ## Examples
 
 -   [Simple example](https://github.com/trezor/trezor-suite/tree/develop/packages/connect-examples/webextension-mv3-sw)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

It is required to add webextension ID to the file mentioned in this PR for a webextension 3rd party that wants to integrate Trezor Connect and wants the name of the webextension to be displayed in Popup instead of the webextension ID.