### PR TITLE
chore(suite-native): validate environment variables

### DIFF
--- a/suite-native/app/envValidation.ts
+++ b/suite-native/app/envValidation.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const envSchema = z.object({
+    EXPO_PUBLIC_ENVIRONMENT: z.string(),
+    EXPO_PUBLIC_CODESIGN_BUILD: z.string(),
+    EXPO_PUBLIC_JWS_PUBLIC_KEY: z.string(),
+});
+
+declare global {
+    // eslint-disable-next-line @typescript-eslint/no-namespace
+    namespace NodeJS {
+        interface ProcessEnv extends z.infer<typeof envSchema> {}
+    }
+}

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -97,7 +97,8 @@
         "react-native-screens": "3.29.0",
         "react-native-svg": "14.1.0",
         "react-redux": "8.0.7",
-        "redux-persist": "6.0.0"
+        "redux-persist": "6.0.0",
+        "zod": "^3.22.3"
     },
     "devDependencies": {
         "@babel/core": "^7.20.0",

--- a/suite-native/app/src/App.tsx
+++ b/suite-native/app/src/App.tsx
@@ -22,10 +22,15 @@ import { applicationInit } from './initActions';
 import { useReportAppInitToAnalytics } from './hooks/useReportAppInitToAnalytics';
 import { SentryProvider } from './SentryProvider';
 import { ModalsRenderer } from './ModalsRenderer';
+import { envSchema } from '../envValidation';
 
 if (__DEV__) {
     require('./LogBox');
 }
+
+// process.env validation. This will fail if environment variables defined in schema
+// are not passed to the application from the runner.
+envSchema.parse(process.env);
 
 // Base time to measure app loading time.
 // The constant has to be placed at the beginning of this file to be initialized as soon as possible.

--- a/yarn.lock
+++ b/yarn.lock
@@ -8744,6 +8744,7 @@ __metadata:
     react-native-svg: "npm:14.1.0"
     react-redux: "npm:8.0.7"
     redux-persist: "npm:6.0.0"
+    zod: "npm:^3.22.3"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Validation of runtime access to ENV variables. Since it can happen that environment variables are accessible within build time in CI, but don't get passed to JS afterwards, this check will give us security of knowing that if the app is running, we have access to the env variables defined in the `envSchema`.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/11749

## Screenshots:
This is result of removing env variable, rebuilding and running the app. Runtime error which says that ENV variable which is required is not present in the app. After re-adding, rebuilding, and running the app again, the issue is gone and app works as expected.
<img width="1712" alt="image" src="https://github.com/trezor/trezor-suite/assets/36101761/cc0c2e28-c5cd-4155-ad1f-4dec7c4be228">
