### PR TITLE
feat: build desktop apps using github workflows

### DIFF
--- a/.github/workflows/build-desktop-apps.yml
+++ b/.github/workflows/build-desktop-apps.yml
@@ -1,0 +1,113 @@
+name: "[Build] suite-desktop apps"
+
+on:
+  pull_request:
+    types: [opened, labeled]
+  workflow_dispatch:
+
+env:
+  DESKTOP_APP_NAME: "Trezor-Suite"
+  ASSET_PREFIX: /web
+
+concurrency:
+  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  suite-desktop:
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'build-desktop')
+    name: Build suite-desktop-${{ matrix.platform }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            platform: linux
+          - os: macos-latest
+            platform: mac
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+          submodules: recursive
+      - name: Install node and yarn
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Install missing Python deps (to build bcrypto lib in Node)
+        if: matrix.os == 'macos-latest'
+        run: pip install setuptools
+
+      - name: Install deps and build libs
+        run: |
+          yarn install --immutable
+          yarn message-system-sign-config
+
+      - name: Build libs
+        run: |
+          yarn workspace @trezor/suite-data build:lib
+          yarn workspace @trezor/connect-iframe build:lib
+
+      - name: Build ${{ matrix.platform }} suite-desktop
+        run: |
+          yarn workspace @trezor/suite-desktop build:${{ matrix.platform }}
+          bash packages/suite-desktop-core/scripts/gnupg-sign.sh
+          mv packages/suite-desktop/build-electron/* .
+
+      - name: Upload suite-desktop production artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: suite-desktop-${{ matrix.platform }}
+          path: |
+            Trezor-Suite*
+            latest*.yml
+          retention-days: 3
+
+  suite-desktop-win:
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'build-desktop')
+    name: Build suite-desktop-win
+    runs-on: ubuntu-latest
+    env:
+      platform: win
+    container:
+      image: electronuserland/builder:18-wine
+      options: --user 1001
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+          submodules: recursive
+      - name: Install node and yarn
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Install deps and build libs
+        run: |
+          yarn install --immutable
+          yarn message-system-sign-config
+
+      - name: Build libs
+        run: |
+          yarn workspace @trezor/suite-data build:lib
+          yarn workspace @trezor/connect-iframe build:lib
+
+      - name: Build ${{env.platform}} suite-desktop
+        run: |
+          yarn workspace @trezor/suite-desktop build:${{env.platform}}
+          bash packages/suite-desktop-core/scripts/gnupg-sign.sh
+          mv packages/suite-desktop/build-electron/* .
+
+      - name: Upload suite-desktop production artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: suite-desktop-${{env.platform}}
+          path: |
+            Trezor-Suite*
+            latest*.yml
+          retention-days: 3

--- a/packages/connect-iframe/webpack/base.webpack.config.ts
+++ b/packages/connect-iframe/webpack/base.webpack.config.ts
@@ -13,7 +13,9 @@ const DIST = path.resolve(__dirname, '../build');
 // Because of Expo EAS, we need to use the commit hash from expo to avoid failing git command inside EAS
 // because we need to call `yarn build:libs during native build`
 const commitHash =
-    process.env.EAS_BUILD_GIT_COMMIT_HASH || execSync('git rev-parse HEAD').toString().trim();
+    process.env.EAS_BUILD_GIT_COMMIT_HASH ||
+    process.env.GITHUB_SHA ||
+    execSync('git rev-parse HEAD').toString().trim();
 
 export const config: webpack.Configuration = {
     target: 'web',


### PR DESCRIPTION
This adds a workflow to allow building the desktop apps using GitHub actions. This builds desktop apps on demand. 

Meaning:
1. if you're creating PR and you assign the label `build-desktop`, it will build the desktop apps and upload the builds as artifacts
2. if you're trying to build the apps again, you either need to run the workflow manually and select the base branch from which you want to run it or REMOVE the label and add the label again. This will trigger the action again and will build the apps. 

All apps are built in development mode (meaning it is not signed with certificates) 