### PR TITLE
fix(suite-native): handle error on SecureStore.getItemAsync

### DIFF
--- a/suite-native/storage/package.json
+++ b/suite-native/storage/package.json
@@ -12,6 +12,7 @@
     },
     "dependencies": {
         "@reduxjs/toolkit": "1.9.5",
+        "@sentry/react-native": "5.19.1",
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
         "@trezor/utxo-lib": "workspace:*",

--- a/suite-native/storage/src/storage.ts
+++ b/suite-native/storage/src/storage.ts
@@ -2,6 +2,7 @@ import { Alert } from 'react-native';
 import { MMKV } from 'react-native-mmkv';
 import RNRestart from 'react-native-restart';
 
+import { captureException } from '@sentry/react-native';
 import * as Random from 'expo-random';
 import * as SecureStore from 'expo-secure-store';
 import * as SplashScreen from 'expo-splash-screen';
@@ -12,18 +13,25 @@ import { unecryptedJotaiStorage } from './atomWithUnecryptedStorage';
 export const ENCRYPTION_KEY = 'STORAGE_ENCRYPTION_KEY';
 export const ENCRYPTED_STORAGE_ID = 'trezorSuite-app-storage';
 
-export const retrieveStorageEncryptionKey = async () => {
-    let secureKey = await SecureStore.getItemAsync(ENCRYPTION_KEY);
+export let encryptedStorage: MMKV;
 
-    if (secureKey == null) {
-        secureKey = Buffer.from(Random.getRandomBytes(16)).toString('hex');
-        await SecureStore.setItemAsync(ENCRYPTION_KEY, secureKey);
+const retrieveStorageEncryptionKey = async () => {
+    try {
+        const secureKey = await SecureStore.getItemAsync(ENCRYPTION_KEY);
+
+        if (secureKey) return secureKey;
+    } catch (error) {
+        // Some users are facing an error when they uninstall the app and then reinstall it,
+        // see https://github.com/expo/expo/issues/23426
+        await SecureStore.deleteItemAsync(ENCRYPTION_KEY);
+        captureException(error);
     }
+
+    const secureKey = Buffer.from(Random.getRandomBytes(16)).toString('hex');
+    await SecureStore.setItemAsync(ENCRYPTION_KEY, secureKey);
 
     return secureKey;
 };
-
-export let encryptedStorage: MMKV;
 
 export const clearStorage = () => {
     unecryptedJotaiStorage.clearAll();
@@ -35,9 +43,6 @@ export const clearStorage = () => {
 // If someone will mess with encryptionKey it can corrupt storage and app will crash on startup.
 // Then app will hang on splashscreen indefinitely so we at least want to show some error message.
 const tryInitStorage = (encryptionKey: string) => {
-    // storage may be already initialized (for example in dev useEffect fire twice)
-    if (encryptedStorage) return encryptedStorage;
-
     try {
         return new MMKV({
             id: ENCRYPTED_STORAGE_ID,
@@ -67,9 +72,11 @@ const tryInitStorage = (encryptionKey: string) => {
 };
 
 export const initMmkvStorage = async (): Promise<Storage> => {
-    const encryptionKey = await retrieveStorageEncryptionKey();
-
-    encryptedStorage = tryInitStorage(encryptionKey);
+    // storage may be already initialized (for example in dev useEffect fire twice)
+    if (!encryptedStorage) {
+        const encryptionKey = await retrieveStorageEncryptionKey();
+        encryptedStorage = tryInitStorage(encryptionKey);
+    }
 
     return {
         setItem: (key, value) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9652,6 +9652,7 @@ __metadata:
   resolution: "@suite-native/storage@workspace:suite-native/storage"
   dependencies:
     "@reduxjs/toolkit": "npm:1.9.5"
+    "@sentry/react-native": "npm:5.19.1"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@trezor/utxo-lib": "workspace:*"


### PR DESCRIPTION
## Description

- For some users on some phones, sometimes... SecureStore is not wiped correctly on app uninstall so it failed to loaded when app is installed again. See https://github.com/expo/expo/issues/23426

- This is a workaround - deleting the key in that case and genereting new one.

Final solution could be stop using expo-secure-store and that might be doable. Will investigate as followup. 
Another followup will be replacing deprecated expo-random with expo-crypto

## Related Issue

Resolve #11761
