### PR TITLE
fix(connect): webextension save sessions

### DIFF
--- a/packages/connect-common/src/storage.ts
+++ b/packages/connect-common/src/storage.ts
@@ -16,8 +16,11 @@ export interface Permission {
  *  - passphrase to be used
  */
 export interface PreferredDevice {
+    label?: string;
     path: string;
     state?: string;
+    internalState?: string;
+    internalStateExpiration?: number;
     instance?: number;
 }
 

--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -402,6 +402,16 @@ const initCoreInPopup = async (
     if (!initCore) return;
     if (disposed) return;
 
+    const state = getState();
+    if (!payload.settings.origin) {
+        // Assign origin for core in popup modes
+        if (state.settings?.origin) {
+            payload.settings.origin = state.settings.origin;
+        } else if (window.opener) {
+            payload.settings.origin = window.opener.origin;
+        }
+    }
+
     // init core
     log.debug('initiating core with settings: ', payload.settings);
     reactEventBus.dispatch({ type: 'loading', message: 'initiating core' });

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -75,6 +75,7 @@ export interface DeviceEvents {
     [DEVICE.PASSPHRASE_ON_DEVICE]: () => void;
     [DEVICE.BUTTON]: (device: Device, payload: DeviceButtonRequestPayload) => void;
     [DEVICE.ACQUIRED]: () => void;
+    [DEVICE.SAVE_STATE]: (state: string) => void;
 }
 
 /**
@@ -445,8 +446,9 @@ export class Device extends TypedEmitter<DeviceEvents> {
     setInternalState(state?: string) {
         if (typeof state !== 'string') {
             delete this.internalState[this.instance];
-        } else {
+        } else if (state !== this.internalState[this.instance]) {
             this.internalState[this.instance] = state;
+            this.emit(DEVICE.SAVE_STATE, state);
         }
     }
 

--- a/packages/connect/src/events/device.ts
+++ b/packages/connect/src/events/device.ts
@@ -14,6 +14,7 @@ export const DEVICE = {
     ACQUIRED: 'device-acquired',
     RELEASED: 'device-released',
     USED_ELSEWHERE: 'device-used_elsewhere',
+    SAVE_STATE: 'device-save_state',
 
     LOADING: 'device-loading',
 


### PR DESCRIPTION
## Description

Rabby recently switched to the new webextension architecture, but it's an issue that we don't currently remember passwords in the core in popup modes. 

This change adds the ability to save the device's internal state to storage along with rememberedDevice. 
The state's validity is limited to 15 minutes. 

## Related Issue

Resolve #11784