### PR TITLE
chore(ci): dont run suite-web e2e tests for github workflow files change

### DIFF
--- a/.github/workflows/build-desktop-apps.yml
+++ b/.github/workflows/build-desktop-apps.yml
@@ -20,11 +20,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-14]
         include:
           - os: ubuntu-latest
             platform: linux
-          - os: macos-latest
+          - os: macos-14
             platform: mac
     steps:
       - name: Checkout code
@@ -38,16 +38,13 @@ jobs:
           node-version-file: ".nvmrc"
 
       - name: Install missing Python deps (to build bcrypto lib in Node)
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-14'
         run: pip install setuptools
 
       - name: Install deps and build libs
         run: |
           yarn install --immutable
           yarn message-system-sign-config
-
-      - name: Build libs
-        run: |
           yarn workspace @trezor/suite-data build:lib
           yarn workspace @trezor/connect-iframe build:lib
 

--- a/.github/workflows/build-test-suite-web-e2e.yaml
+++ b/.github/workflows/build-test-suite-web-e2e.yaml
@@ -13,6 +13,12 @@ on:
             - 'suite-native/**'
             - 'packages/connect*/**'
             - 'packages/react-native-usb/**'
+            # ignore unrelated github workflows config files
+            - '.github/workflows/coonnect*'
+            - '.github/workflows/suite-native*'
+            - '.github/workflows/build-desktop*'
+            - '.github/workflows/release*'
+            - '.github/workflows/template*'
     # TODO: after a more sophisticated system of test running is implemented, move the cron job into a separate flow that will run all tests
     schedule:
         - cron: '0 0 * * *' # runn all tests every day at midnight


### PR DESCRIPTION
- **chore(ci): dont run suite-web e2e tests for github workflow files change**
- **chore(ci): use macos-14 for building the desktop apps**
