### PR TITLE
ci(github): run connect tests on release branches

### DIFF
--- a/.github/workflows/connect-dev-release-test.yml
+++ b/.github/workflows/connect-dev-release-test.yml
@@ -8,6 +8,8 @@ on:
   schedule:
     # Runs at midnight UTC every day at 01:00 AM CET
     - cron: "0 0 * * *"
+  push:
+    branches: [npm-release/*, release/*]
   pull_request:
     paths:
       - "packages/blockchain-link/**"

--- a/.github/workflows/connect-test.yml
+++ b/.github/workflows/connect-test.yml
@@ -5,6 +5,8 @@ on:
   schedule:
     # Runs at midnight UTC every day at 01:00 AM CET
     - cron: "0 0 * * *"
+  push:
+    branches: [npm-release/*, release/*]
   pull_request:
     paths:
       - "packages/blockchain-link/**"

--- a/.github/workflows/connect-transport-e2e-test.yml
+++ b/.github/workflows/connect-transport-e2e-test.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     # Runs at midnight UTC every day at 01:00 AM CET
     - cron: "0 0 * * *"
+  push:
+    branches: [npm-release/*, release/*]
   pull_request:
     paths:
       - "packages/transport/**"

--- a/.github/workflows/connect-web-e2e-test.yml
+++ b/.github/workflows/connect-web-e2e-test.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     # Runs at midnight UTC every day at 01:00 AM CET
     - cron: "0 0 * * *"
+  push:
+    branches: [npm-release/*, release/*]
   pull_request:
     paths:
       - "packages/connect/**"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Making connect tests run on releases branches.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/7917
Related https://github.com/trezor/trezor-suite/issues/7916
