### PR TITLE
Revert "chore(transport, trezor-user-env-link): remove cross-fetch"

### DIFF
--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -66,6 +66,7 @@
         "@trezor/protobuf": "workspace:*",
         "@trezor/protocol": "workspace:*",
         "@trezor/utils": "workspace:*",
+        "cross-fetch": "^4.0.0",
         "json-stable-stringify": "^1.1.1",
         "long": "^4.0.0",
         "protobufjs": "7.2.6",

--- a/packages/transport/src/utils/bridgeApiCall.ts
+++ b/packages/transport/src/utils/bridgeApiCall.ts
@@ -1,3 +1,5 @@
+import fetch from 'cross-fetch';
+
 import { success, error, unknownError } from './result';
 
 import * as ERRORS from '../errors';

--- a/packages/trezor-user-env-link/package.json
+++ b/packages/trezor-user-env-link/package.json
@@ -10,6 +10,7 @@
     },
     "dependencies": {
         "@trezor/utils": "workspace:*",
+        "cross-fetch": "^4.0.0",
         "ws": "^8.16.0"
     },
     "devDependencies": {

--- a/packages/trezor-user-env-link/src/websocket-client.ts
+++ b/packages/trezor-user-env-link/src/websocket-client.ts
@@ -2,6 +2,7 @@
 
 import WebSocket from 'ws';
 import { EventEmitter } from 'events';
+import fetch from 'cross-fetch';
 
 import { createDeferred, Deferred } from '@trezor/utils';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11176,6 +11176,7 @@ __metadata:
     "@types/bytebuffer": "npm:^5.0.48"
     "@types/sharedworker": "npm:^0.0.111"
     "@types/w3c-web-usb": "npm:^1.0.10"
+    cross-fetch: "npm:^4.0.0"
     jest: "npm:29.7.0"
     json-stable-stringify: "npm:^1.1.1"
     long: "npm:^4.0.0"
@@ -11194,6 +11195,7 @@ __metadata:
   dependencies:
     "@trezor/utils": "workspace:*"
     "@types/ws": "npm:^8.5.5"
+    cross-fetch: "npm:^4.0.0"
     ws: "npm:^8.16.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Apparently there are differences in the native `fetch` and `cross-fetch` as we came over a problem with timeouts.

Details: https://satoshilabs.slack.com/archives/C02V2PSDNA2/p1711539811017599

Reverting the removal of `cross-fetch`.
