### PR TITLE
chore(suite-native): use expo-crypto instead of deprecated expo-random

### DIFF
--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -78,7 +78,6 @@
         "expo-linear-gradient": "12.7.1",
         "expo-localization": "14.8.3",
         "expo-navigation-bar": "2.8.1",
-        "expo-random": "13.6.0",
         "expo-secure-store": "12.8.1",
         "expo-splash-screen": "0.26.4",
         "expo-status-bar": "~1.11.1",

--- a/suite-native/storage/package.json
+++ b/suite-native/storage/package.json
@@ -17,7 +17,7 @@
         "@suite-common/wallet-types": "workspace:*",
         "@trezor/utxo-lib": "workspace:*",
         "bs58": "^5.0.0",
-        "expo-random": "13.6.0",
+        "expo-crypto": "^12.8.1",
         "expo-secure-store": "12.8.1",
         "expo-splash-screen": "0.26.4",
         "jotai": "1.9.1",

--- a/suite-native/storage/src/storage.ts
+++ b/suite-native/storage/src/storage.ts
@@ -3,7 +3,7 @@ import { MMKV } from 'react-native-mmkv';
 import RNRestart from 'react-native-restart';
 
 import { captureException } from '@sentry/react-native';
-import * as Random from 'expo-random';
+import { getRandomBytes } from 'expo-crypto';
 import * as SecureStore from 'expo-secure-store';
 import * as SplashScreen from 'expo-splash-screen';
 import { Storage } from 'redux-persist';
@@ -27,7 +27,7 @@ const retrieveStorageEncryptionKey = async () => {
         captureException(error);
     }
 
-    const secureKey = Buffer.from(Random.getRandomBytes(16)).toString('hex');
+    const secureKey = Buffer.from(getRandomBytes(16)).toString('hex');
     await SecureStore.setItemAsync(ENCRYPTION_KEY, secureKey);
 
     return secureKey;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8776,7 +8776,6 @@ __metadata:
     expo-linear-gradient: "npm:12.7.1"
     expo-localization: "npm:14.8.3"
     expo-navigation-bar: "npm:2.8.1"
-    expo-random: "npm:13.6.0"
     expo-secure-store: "npm:12.8.1"
     expo-splash-screen: "npm:0.26.4"
     expo-status-bar: "npm:~1.11.1"
@@ -9658,7 +9657,7 @@ __metadata:
     "@suite-common/wallet-types": "workspace:*"
     "@trezor/utxo-lib": "workspace:*"
     bs58: "npm:^5.0.0"
-    expo-random: "npm:13.6.0"
+    expo-crypto: "npm:^12.8.1"
     expo-secure-store: "npm:12.8.1"
     expo-splash-screen: "npm:0.26.4"
     jotai: "npm:1.9.1"
@@ -20505,6 +20504,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expo-crypto@npm:^12.8.1":
+  version: 12.8.1
+  resolution: "expo-crypto@npm:12.8.1"
+  dependencies:
+    base64-js: "npm:^1.3.0"
+  peerDependencies:
+    expo: "*"
+  checksum: a98b854aef4dce2a3432fcf6cd1a2be2a79715690019a25ac114f7333eacda1cfbe3295e9dabe200bfe7adc119ef43665b5d6b38ed4c4c1692c34d2c498b3425
+  languageName: node
+  linkType: hard
+
 "expo-dev-client@npm:^3.3.7":
   version: 3.3.8
   resolution: "expo-dev-client@npm:3.3.8"
@@ -20709,17 +20719,6 @@ __metadata:
   peerDependencies:
     expo: "*"
   checksum: 47dbe44f976959f5b0b1cbce030c685d5c86701edd4e308f85802b4f9adaeeabe77d60b2d4a89a09a39d85e182483b8c9fd0f6883e15cc7342a78e45f43e76ad
-  languageName: node
-  linkType: hard
-
-"expo-random@npm:13.6.0":
-  version: 13.6.0
-  resolution: "expo-random@npm:13.6.0"
-  dependencies:
-    base64-js: "npm:^1.3.0"
-  peerDependencies:
-    expo: "*"
-  checksum: d6251a8cf4c53dd3579af510aec625a8fc92aa9d8844680ecbc01a80a3c034ea93837585561b2b46b013ba9fc0d83adc6c16d51bb6cc52fe977f2c2642086ae7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

To get rid off deprecation warning.
