### PR TITLE
fix(suite): zIndex of anchors causes select to overlap

### DIFF
--- a/packages/components/src/components/form/Select/Select.tsx
+++ b/packages/components/src/components/form/Select/Select.tsx
@@ -312,6 +312,7 @@ export const Select = ({
                 classNamePrefix={reactSelectClassNamePrefix}
                 openMenuOnFocus
                 closeMenuOnScroll={closeMenuOnScroll}
+                menuPosition="fixed" // Required for closeMenuOnScroll to work properly when near page bottom
                 menuPortalTarget={menuPortalTarget}
                 styles={createSelectStyle(theme, elevation)}
                 onChange={handleOnChange}

--- a/packages/suite/src/utils/suite/anchor.ts
+++ b/packages/suite/src/utils/suite/anchor.ts
@@ -3,7 +3,7 @@ import { css } from 'styled-components';
 import { AccountTransactionBaseAnchor, AnchorType } from 'src/constants/suite/anchors';
 
 import type { WalletAccountTransaction } from 'src/types/wallet';
-import { borders, zIndices } from '@trezor/theme';
+import { borders } from '@trezor/theme';
 
 export const getTxIdFromAnchor = (anchor?: string): string => anchor?.split('/').pop() || '';
 
@@ -30,7 +30,6 @@ export const anchorOutlineStyles = css<{ $shouldHighlight?: boolean }>`
     transition: all 0.3s;
     transition-delay: 0.3s;
     outline: solid ${borders.widths.large} transparent;
-    z-index: ${zIndices.base};
 
     ${({ $shouldHighlight }) =>
         $shouldHighlight &&

--- a/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
@@ -16,6 +16,7 @@ import { Transport } from './Transport';
 import { Processes } from './Processes';
 import { PasswordManager } from './PasswordManager/PasswordManager';
 import { ViewOnly } from './ViewOnly';
+import { TriggerHighlight } from './TriggerHighlight';
 
 export const SettingsDebug = () => (
     <SettingsLayout>
@@ -27,6 +28,7 @@ export const SettingsDebug = () => (
         <SettingsSection title="Debug">
             <GithubIssue />
             {!isWeb() && <WipeData />}
+            <TriggerHighlight />
         </SettingsSection>
         <SettingsSection title="Invity">
             <InvityApi />

--- a/packages/suite/src/views/settings/SettingsDebug/TriggerHighlight.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/TriggerHighlight.tsx
@@ -1,0 +1,29 @@
+import { ActionButton, ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
+import { goto } from '../../../actions/suite/routerActions';
+import { SettingsAnchor } from '../../../constants/suite/anchors';
+import { useDispatch } from '../../../hooks/suite';
+
+export const TriggerHighlight = () => {
+    const dispatch = useDispatch();
+
+    return (
+        <SectionItem data-test="@settings/debug/github">
+            <TextColumn
+                title="Trigger highlight"
+                description="Goes to the anchor in the application and highlights it. This allows testing of this functionality with custom anchor."
+            />
+            <ActionColumn>
+                <ActionButton
+                    variant="secondary"
+                    onClick={() =>
+                        dispatch(
+                            goto('settings-index', { anchor: SettingsAnchor.BitcoinAmountUnit }),
+                        )
+                    }
+                >
+                    Go to Bitcoin Unit Settings
+                </ActionButton>
+            </ActionColumn>
+        </SectionItem>
+    );
+};


### PR DESCRIPTION
This shall fix this overlap issue. 

![image](https://github.com/trezor/trezor-suite/assets/152899911/4b78d359-a918-4a77-abf3-f856a6c98c95)
