### PR TITLE
feat(suite): add deb build target

### DIFF
--- a/packages/suite-desktop/electron-builder-config.js
+++ b/packages/suite-desktop/electron-builder-config.js
@@ -149,11 +149,11 @@ module.exports = {
                 to: 'bin/coinjoin',
             },
         ],
-        icon: 'build/static/images/desktop/512x512.png',
+        target: ['AppImage', 'deb'],
+        icon: 'build/static/images/desktop/512x512.icns',
         artifactName: 'Trezor-Suite-${version}-linux-${arch}.${ext}',
         executableName: 'trezor-suite',
         category: 'Utility',
-        target: ['AppImage'],
     },
     afterSign: '../suite-desktop-core/scripts/notarize.ts',
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds `deb` build target for the Linux platform. Adding other targets is not as straightforward as this. RPM had some issues when building and I wasn't able to fix it. Flatpak is buildable and is working as expected but that doesn't bring any benefit to the users unless we add it to Flathub a do releases through there.

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

First and really small step towards getting this done #4518 

## Screenshots:
