### PR TITLE
chore(ci): add timeout to suite-desktop build jobs

### DIFF
--- a/.github/workflows/build-desktop-apps.yml
+++ b/.github/workflows/build-desktop-apps.yml
@@ -17,6 +17,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'build-desktop')
     name: Build suite-desktop-${{ matrix.platform }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -39,7 +40,7 @@ jobs:
 
       - name: Install missing Python deps (to build bcrypto lib in Node)
         if: matrix.os == 'macos-14'
-        run: pip install setuptools
+        run: brew install python-setuptools
 
       - name: Install deps and build libs
         run: |
@@ -67,6 +68,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'build-desktop')
     name: Build suite-desktop-win
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       platform: win
     container:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This fixes a flaky build on mac os. It worked before because it wasn't rebuilding some libraries. Pip installed setuptools wasn't recognized by the build process for some reason. This should be more reliable.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
