### PR TITLE
feat(connect): automatically update outdated device language

### DIFF
--- a/packages/connect/src/api/changeLanguage.ts
+++ b/packages/connect/src/api/changeLanguage.ts
@@ -1,12 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/ChangeLanguage.js
 
 import { AbstractMethod } from '../core/AbstractMethod';
-import { ERRORS } from '../constants';
 import { UI, createUiMessage } from '../events';
 import { Assert } from '@trezor/schema-utils';
 import { ChangeLanguage as ChangeLanguageSchema } from '../types/api/changeLanguage';
-import { getLanguage } from './firmware/getLanguage';
-
 export default class ChangeLanguage extends AbstractMethod<'changeLanguage', ChangeLanguageSchema> {
     init() {
         this.allowDeviceMode = [UI.INITIALIZE, UI.SEEDLESS];
@@ -18,15 +15,7 @@ export default class ChangeLanguage extends AbstractMethod<'changeLanguage', Cha
 
         Assert(ChangeLanguageSchema, payload);
 
-        if (payload.binary) {
-            this.params = {
-                binary: payload.binary,
-            };
-        } else {
-            this.params = {
-                language: payload.language,
-            };
-        }
+        this.params = payload;
     }
 
     async confirmation() {
@@ -53,63 +42,12 @@ export default class ChangeLanguage extends AbstractMethod<'changeLanguage', Cha
         return uiResp.payload;
     }
 
-    private async uploadTranslationData(payload: ArrayBuffer | null) {
-        if (!this.device.commands) {
-            throw ERRORS.TypedError('Runtime', 'uploadTranslationData: device.commands is not set');
-        }
-
-        if (payload === null) {
-            const response = await this.device.commands.typedCall(
-                'ChangeLanguage',
-                ['Success'],
-                { data_length: 0 }, // For en-US where we just send `ChangeLanguage(size=0)`
-            );
-
-            return response.message;
-        }
-
-        const length = payload.byteLength;
-
-        let response = await this.device.commands.typedCall(
-            'ChangeLanguage',
-            ['TranslationDataRequest', 'Success'],
-            { data_length: length },
-        );
-
-        while (response.type !== 'Success') {
-            const start = response.message.data_offset!;
-            const end = response.message.data_offset! + response.message.data_length!;
-            const chunk = payload.slice(start, end);
-
-            response = await this.device.commands.typedCall(
-                'TranslationDataAck',
-                ['TranslationDataRequest', 'Success'],
-                {
-                    data_chunk: Buffer.from(chunk).toString('hex'),
-                },
-            );
-        }
-
-        return response.message;
-    }
-
     async run() {
         const { language, binary } = this.params;
-
-        if (language === 'en-US') {
-            return this.uploadTranslationData(null);
-        }
-
         if (binary) {
-            return this.uploadTranslationData(binary);
+            return this.device.changeLanguage({ binary });
+        } else {
+            return this.device.changeLanguage({ language });
         }
-
-        const downloadedBinary = await getLanguage({
-            language,
-            version: this.device.getVersion(),
-            internal_model: this.device.features.internal_model,
-        });
-
-        return this.uploadTranslationData(downloadedBinary);
     }
 }

--- a/packages/connect/src/api/firmware/index.ts
+++ b/packages/connect/src/api/firmware/index.ts
@@ -1,5 +1,5 @@
 export { getBinary } from './getBinary';
-export { getLanguage } from './getLanguage';
+export { getLanguage } from '../../data/getLanguage';
 export { shouldStripFwHeaders, stripFwHeaders } from './modifyFirmware';
 export { uploadFirmware } from './uploadFirmware';
 export { calculateFirmwareHash } from './calculateFirmwareHash';

--- a/packages/connect/src/data/getLanguage.ts
+++ b/packages/connect/src/data/getLanguage.ts
@@ -1,4 +1,4 @@
-import { httpRequest } from '../../utils/assets';
+import { httpRequest } from '../utils/assets';
 
 export const getLanguage = ({
     language,

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -106,7 +106,7 @@ export const connectInitThunk = createThunk(
                 ...connectInitSettings,
                 pendingTransportEvent: selectIsPendingTransportEvent(getState()),
                 transports: selectDebugSettings(getState()).transports,
-                // debug: true, // Enable debug logs in TrezorConnect
+                debug: true, // Enable debug logs in TrezorConnect
             });
         } catch (error) {
             let formattedError: string;


### PR DESCRIPTION
based on #11300

- moves logic from `packages/connect/src/api/changeLanguage.ts` to `packages/connect/src/device/Device.ts` without any changes
- adds automatic language update if `!this.features.language_version_matches` whenever `device.getFeatures` got called. This should get triggered only once per firmware version. [Related discussion here](https://satoshilabs.slack.com/archives/C02V2PSDNA2/p1709672892741739)

There is still one open question:
- user updates from `2.6.4` to `2.7.0`
- this means automatic language upadte during fw update can't take place here (not supported by 2.6.4 yet)
- this means user is on `2.7.0` and his device still speaks english. Now user can change language manually. Next fw update should also update his language using this new feature added in this PR.
- is that enough? Or do we already want to push language update when upgrading to 2.7.0? I guess we do want because without this, language would set only after second firmware update after device purchase. 🤔 

cc @komret @Hannsek 