### PR TITLE
fix(github): unnecessary install yarn in actions

### DIFF
--- a/.github/workflows/connect-pre-release-init.yml
+++ b/.github/workflows/connect-pre-release-init.yml
@@ -30,9 +30,15 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build dependencies
+        # Running `build:libs` requires action to checkout with `submodules: recursive`.
+        run: yarn build:libs
+
       - name: Run @trezor/connect create npm release branch
         run: |
-          npm install -g yarn && yarn install && yarn build:libs
           git config --global user.name "trezor-ci"
           git config --global user.email "${{ secrets.TREZOR_BOT_EMAIL }}"
           gh config set prompt disabled

--- a/.github/workflows/connect-release-init.yml
+++ b/.github/workflows/connect-release-init.yml
@@ -20,9 +20,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
+      - name: Install dependencies
+        run: |
+          yarn install
       - name: Run @trezor/connect create v9 release branch
         run: |
-          npm install -g yarn && yarn install
           git config --global user.name "trezor-ci"
           git config --global user.email "${{ secrets.TREZOR_BOT_EMAIL }}"
           gh config set prompt disabled

--- a/.github/workflows/crowdin_sync.yml
+++ b/.github/workflows/crowdin_sync.yml
@@ -12,16 +12,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Setup node
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
+
       - name: Set current timestamp as env variable
         run: echo "NOW=$(date +'%s')" >> $GITHUB_ENV
 
+      - name: Install dependencies
+        run: yarn install
+
       - name: Run crowdin sync
         run: |
-          npm install -g yarn && yarn install
           git config --global user.name "trezor-ci"
           git config --global user.email "${{ secrets.TREZOR_BOT_EMAIL }}"
           git checkout -B ${{ env.BRANCH_NAME }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Running `npm install -g yarn` is unnecessary since the step `        uses: actions/checkout@v4` is already installing yarn when it recognizes a `yarn.lock` file in the repository.
## Related Issue
Related https://github.com/trezor/trezor-suite/issues/7916
