### PR TITLE
WIP: Fix: connect on release branch test

### DIFF
--- a/.github/workflows/connect-dev-release-test.yml
+++ b/.github/workflows/connect-dev-release-test.yml
@@ -8,8 +8,6 @@ on:
   schedule:
     # Runs at midnight UTC every day at 01:00 AM CET
     - cron: "0 0 * * *"
-  push:
-    branches: [npm-release/*, release/*]
   pull_request:
     paths:
       - "packages/blockchain-link/**"
@@ -26,6 +24,7 @@ on:
       - "yarn.lock"
       - ".github/workflows/connect-dev-release-test.yml"
       - ".github/workflows/template-connect-popup-test-params.yml"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}

--- a/.github/workflows/connect-test.yml
+++ b/.github/workflows/connect-test.yml
@@ -5,8 +5,6 @@ on:
   schedule:
     # Runs at midnight UTC every day at 01:00 AM CET
     - cron: "0 0 * * *"
-  push:
-    branches: [npm-release/*, release/*]
   pull_request:
     paths:
       - "packages/blockchain-link/**"
@@ -26,6 +24,7 @@ on:
       - ".github/workflows/template-connect-test-params.yml"
       - "docker/docker-connect-test.sh"
       - "docker/docker-compose.connect-test.yml"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}

--- a/.github/workflows/connect-transport-e2e-test.yml
+++ b/.github/workflows/connect-transport-e2e-test.yml
@@ -4,8 +4,6 @@ on:
   schedule:
     # Runs at midnight UTC every day at 01:00 AM CET
     - cron: "0 0 * * *"
-  push:
-    branches: [npm-release/*, release/*]
   pull_request:
     paths:
       - "packages/transport/**"
@@ -16,6 +14,7 @@ on:
       - "docker/docker-compose.transport-test.yml"
       - ".github/workflows/connect-transport-e2e-test.yml"
       - "yarn.lock"
+  workflow_dispatch:
 
 jobs:
   transport-e2e:

--- a/.github/workflows/connect-web-e2e-test.yml
+++ b/.github/workflows/connect-web-e2e-test.yml
@@ -4,8 +4,6 @@ on:
   schedule:
     # Runs at midnight UTC every day at 01:00 AM CET
     - cron: "0 0 * * *"
-  push:
-    branches: [npm-release/*, release/*]
   pull_request:
     paths:
       - "packages/connect/**"
@@ -13,6 +11,7 @@ on:
       - "packages/utils/**"
       - ".github/workflows/connect-web-e2e-test.yml"
       - "yarn.lock"
+  workflow_dispatch:
 
 jobs:
   connect-web-e2e:

--- a/ci/scripts/connect-release-init-v9.js
+++ b/ci/scripts/connect-release-init-v9.js
@@ -4,9 +4,16 @@ const child_process = require('child_process');
 const path = require('path');
 const fs = require('fs');
 
-const { exec } = require('./helpers');
+const { exec, triggerWorkflowSync } = require('./helpers');
 
 const ROOT = path.join(__dirname, '..', '..');
+
+const workflowsOnReleaseBranch = [
+    '.github/workflows/connect-dev-release-test.yml',
+    '.github/workflows/connect-test.yml',
+    '.github/workflows/connect-transport-e2e-test.yml',
+    '.github/workflows/connect-web-e2e-test.yml',
+];
 
 const init = () => {
     const PACKAGE_PATH = path.join(ROOT, 'packages', 'connect');
@@ -21,6 +28,11 @@ const init = () => {
     exec('git', ['checkout', '-b', branchName]);
 
     exec('git', ['push', 'origin', branchName]);
+
+    // When branch is created, we trigger workflow to run tests on new created branch.
+    for (const workflowFileName of workflowsOnReleaseBranch) {
+        triggerWorkflowSync(branchName, workflowFileName);
+    }
 };
 
 init();

--- a/ci/scripts/helpers.js
+++ b/ci/scripts/helpers.js
@@ -100,4 +100,9 @@ const comment = ({ prNumber, body }) => {
     exec('gh', ['pr', 'comment', `${prNumber}`, '--body', body]);
 };
 
-module.exports = { checkPackageDependencies, exec, commit, comment };
+const triggerWorkflowSync = async (branchName, workflows) => {
+    // https://cli.github.com/manual/gh_workflow_run
+    exec('gh', ['workflow', 'run', `${workflowFileName}`, '--ref', `${branchName}`]);
+};
+
+module.exports = { checkPackageDependencies, exec, commit, comment, triggerWorkflowSync };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Making connect test run after release branch is crated, otherwise it does not fit our connect release process since we create branch `release/connect<version>` but we o not push on it so we cannot use `push` trigger. 
And we could use `create` trigger but it will run on all new created branches since GitHub does not allow filtering branch on `create` trigger.


## Related Issue
Related https://github.com/trezor/trezor-suite/issues/7916
Related https://github.com/trezor/trezor-suite/issues/7917
