### PR TITLE
feat(suite): left nav account menu groups

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimEthForm.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimEthForm.tsx
@@ -5,10 +5,11 @@ import { Translation, FiatValue, FormattedCryptoAmount } from 'src/components/su
 import { mapTestnetSymbol } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import { useDevice, useSelector } from 'src/hooks/suite';
 import { useClaimEthFormContext } from 'src/hooks/wallet/useClaimEthForm';
-import { selectSelectedAccountEverstakeStakingPool } from 'src/reducers/wallet/selectedAccountReducer';
 import { CRYPTO_INPUT } from 'src/types/wallet/stakeForms';
 import { spacingsPx } from '@trezor/theme';
 import ClaimFees from './Fees';
+import { getAccountEverstakeStakingPool } from 'src/utils/wallet/stakingUtils';
+import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 
 const AmountInfo = styled.div`
     display: flex;
@@ -45,6 +46,7 @@ const GreyP = styled(Paragraph)`
 
 export const ClaimEthForm = () => {
     const { device, isLocked } = useDevice();
+    const account = useSelector(selectSelectedAccount);
     const {
         account: { symbol },
         formState: { errors, isSubmitting },
@@ -58,7 +60,8 @@ export const ClaimEthForm = () => {
     const hasValues = Boolean(watch(CRYPTO_INPUT));
     // used instead of formState.isValid, which is sometimes returning false even if there are no errors
     const formIsValid = Object.keys(errors).length === 0;
-    const { claimableAmount = '0' } = useSelector(selectSelectedAccountEverstakeStakingPool) ?? {};
+
+    const { claimableAmount = '0' } = getAccountEverstakeStakingPool(account) ?? {};
     const isDisabled =
         !(formIsValid && hasValues) || isSubmitting || isLocked() || !device?.available;
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/Options.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/Options.tsx
@@ -8,7 +8,8 @@ import { NetworkSymbol } from '@suite-common/wallet-config';
 import { mapTestnetSymbol } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import { useSelector } from 'src/hooks/suite';
 import { useUnstakeEthFormContext } from 'src/hooks/wallet/useUnstakeEthForm';
-import { selectSelectedAccountEverstakeStakingPool } from 'src/reducers/wallet/selectedAccountReducer';
+import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
+import { getAccountEverstakeStakingPool } from 'src/utils/wallet/stakingUtils';
 
 const GreyP = styled(Paragraph)`
     color: ${({ theme }) => theme.textSubdued};
@@ -67,6 +68,8 @@ interface OptionsProps {
 }
 
 export const Options = ({ symbol }: OptionsProps) => {
+    const selectedAccount = useSelector(selectSelectedAccount);
+
     const [unstakeOption, setUnstakeOption] = useState<UnstakeOptions>('other');
     const isRewardsSelected = unstakeOption === 'rewards';
     const isAllSelected = unstakeOption === 'all';
@@ -78,7 +81,7 @@ export const Options = ({ symbol }: OptionsProps) => {
         autocompoundBalance = '0',
         depositedBalance = '0',
         restakedReward = '0',
-    } = useSelector(selectSelectedAccountEverstakeStakingPool) ?? {};
+    } = getAccountEverstakeStakingPool(selectedAccount) ?? {};
 
     return (
         <div>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/UnstakeEthForm.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/UnstakeEthForm.tsx
@@ -4,10 +4,11 @@ import { spacingsPx } from '@trezor/theme';
 import { Translation } from 'src/components/suite';
 import { useDevice, useSelector, useValidatorsQueue } from 'src/hooks/suite';
 import { useUnstakeEthFormContext } from 'src/hooks/wallet/useUnstakeEthForm';
-import { selectSelectedAccountEverstakeStakingPool } from 'src/reducers/wallet/selectedAccountReducer';
+import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 import { CRYPTO_INPUT, FIAT_INPUT } from 'src/types/wallet/stakeForms';
 import { Options } from './Options';
 import UnstakeFees from './Fees';
+import { getAccountEverstakeStakingPool } from 'src/utils/wallet/stakingUtils';
 
 const GreyP = styled(Paragraph)`
     color: ${({ theme }) => theme.textSubdued};
@@ -43,6 +44,7 @@ const UpToDaysWrapper = styled.div`
 
 export const UnstakeEthForm = () => {
     const { device, isLocked } = useDevice();
+    const selectedAccount = useSelector(selectSelectedAccount);
 
     const {
         account,
@@ -63,7 +65,7 @@ export const UnstakeEthForm = () => {
     const formIsValid = Object.keys(errors).length === 0;
 
     const { canClaim = false, claimableAmount = '0' } =
-        useSelector(selectSelectedAccountEverstakeStakingPool) ?? {};
+        getAccountEverstakeStakingPool(selectedAccount) ?? {};
     const isDisabled =
         !(formIsValid && hasValues) || isSubmitting || isLocked() || !device?.available;
 

--- a/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountNavigation.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountNavigation.tsx
@@ -61,20 +61,20 @@ export const AccountNavigation = () => {
             'data-test': `@wallet/menu/wallet-details`,
         },
         {
-            id: 'wallet-tokens',
-            callback: () => {
-                goToWithAnalytics('wallet-tokens', { preserveParams: true });
-            },
-            title: <Translation id="TR_NAV_TOKENS" />,
-            isHidden: !['cardano', 'ethereum', 'solana'].includes(networkType),
-        },
-        {
             id: 'wallet-staking',
             callback: () => {
                 goToWithAnalytics('wallet-staking', { preserveParams: true });
             },
             title: <Translation id="TR_NAV_STAKING" />,
             isHidden: !hasNetworkFeatures(account, 'staking'),
+        },
+        {
+            id: 'wallet-tokens',
+            callback: () => {
+                goToWithAnalytics('wallet-tokens', { preserveParams: true });
+            },
+            title: <Translation id="TR_NAV_TOKENS" />,
+            isHidden: !['cardano', 'ethereum', 'solana'].includes(networkType),
         },
     ];
 

--- a/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountTopPanel.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountTopPanel.tsx
@@ -1,23 +1,15 @@
-import styled, { useTheme } from 'styled-components';
+import styled from 'styled-components';
 import { forwardRef } from 'react';
 
 import { spacingsPx } from '@trezor/theme';
 import { NetworkSymbol } from '@suite-common/wallet-config';
-import { CoinLogo, Icon, SkeletonCircle, SkeletonRectangle } from '@trezor/components';
+import { CoinLogo, SkeletonCircle, SkeletonRectangle } from '@trezor/components';
 
-import {
-    FormattedCryptoAmount,
-    AmountUnitSwitchWrapper,
-    StakeAmountWrapper,
-} from 'src/components/suite';
+import { FormattedCryptoAmount, AmountUnitSwitchWrapper } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
 import { FiatHeader } from 'src/views/dashboard/components/FiatHeader';
 import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
 import { useFiatFromCryptoValue } from 'src/hooks/suite/useFiatFromCryptoValue';
-import { STAKE_SYMBOLS } from 'src/constants/suite/ethStaking';
-import { selectSelectedAccountAutocompoundBalance } from 'src/reducers/wallet/selectedAccountReducer';
-import { mapTestnetSymbol } from 'src/utils/wallet/coinmarket/coinmarketUtils';
-import { selectAccountStakeTransactions } from '@suite-common/wallet-core';
 
 export const ACCOUNT_INFO_HEIGHT = 80;
 
@@ -62,26 +54,13 @@ const AccountTopPanelSkeleton = ({ animate, symbol }: AccountTopPanelSkeletonPro
 );
 
 export const AccountTopPanel = forwardRef<HTMLDivElement>((_, ref) => {
-    const theme = useTheme();
     const { account, loader, status } = useSelector(state => state.wallet.selectedAccount);
     const localCurrency = useSelector(selectLocalCurrency);
-    const autocompoundBalance = useSelector(selectSelectedAccountAutocompoundBalance);
-    const stakeTxs = useSelector(state =>
-        selectAccountStakeTransactions(state, account?.key || ''),
-    );
-
-    const hasStaked = stakeTxs.length > 0;
 
     // TODO: move this to FiatHeader
     const { fiatAmount } = useFiatFromCryptoValue({
         amount: account?.formattedBalance || '',
         symbol: account?.symbol || '',
-    });
-
-    const mappedSymbol = account?.symbol ? mapTestnetSymbol(account?.symbol) : '';
-    const { fiatAmount: fiatStakeAmount } = useFiatFromCryptoValue({
-        amount: autocompoundBalance,
-        symbol: mappedSymbol,
     });
 
     if (status !== 'loaded' || !account) {
@@ -94,8 +73,6 @@ export const AccountTopPanel = forwardRef<HTMLDivElement>((_, ref) => {
     }
 
     const { symbol, formattedBalance } = account;
-
-    const isStakeShown = STAKE_SYMBOLS.includes(symbol) && hasStaked;
 
     return (
         <Container ref={ref}>
@@ -115,27 +92,6 @@ export const AccountTopPanel = forwardRef<HTMLDivElement>((_, ref) => {
                         fiatAmount={fiatAmount ?? '0'}
                     />
                 </div>
-
-                {isStakeShown && (
-                    <div>
-                        <StakeAmountWrapper>
-                            <AccountCryptoBalance>
-                                <Icon icon="PIGGY_BANK" color={theme.TYPE_DARK_GREY} size={16} />
-
-                                <FormattedCryptoAmount
-                                    value={autocompoundBalance}
-                                    symbol={symbol}
-                                />
-                            </AccountCryptoBalance>
-                        </StakeAmountWrapper>
-
-                        <FiatHeader
-                            size="large"
-                            localCurrency={localCurrency}
-                            fiatAmount={fiatStakeAmount ?? '0'}
-                        />
-                    </div>
-                )}
             </AmountsWrapper>
         </Container>
     );

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AcccountSection.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AcccountSection.tsx
@@ -1,0 +1,70 @@
+import { Account } from '@suite-common/wallet-types';
+import { AccountItemsGroup } from './AccountItemsGroup';
+import { AccountItem } from './AccountItem';
+import { useSelector } from 'src/hooks/suite';
+import { selectAccountStakeTransactions, selectCoinDefinitions } from '@suite-common/wallet-core';
+import { STAKE_SYMBOLS } from 'src/constants/suite/ethStaking';
+import { getNetworkFeatures } from '@suite-common/wallet-config';
+import { isTokenDefinitionKnown } from '@suite-common/token-definitions';
+
+interface AccountSectionProps {
+    account: Account;
+    selected: boolean;
+    accountLabel?: string;
+    onItemClick?: () => void;
+}
+
+export const AccountSection = ({
+    account,
+    selected,
+    accountLabel,
+    onItemClick,
+}: AccountSectionProps) => {
+    const stakeTxs = useSelector(state =>
+        selectAccountStakeTransactions(state, account?.key || ''),
+    );
+    const coinDefinitions = useSelector(state => selectCoinDefinitions(state, account.symbol));
+    const hasStaked = stakeTxs.length > 0;
+    const isStakeShown = STAKE_SYMBOLS.includes(account.symbol) && hasStaked;
+
+    const showGroup = ['ethereum', 'solana', 'cardano'].includes(account.networkType);
+
+    const hasCoinDefinitions = getNetworkFeatures(account.symbol).includes('coin-definitions');
+    const tokens = account.tokens?.reduce<{
+        knownTokens: Account['tokens'];
+    }>(
+        (acc, token) => {
+            if (
+                !hasCoinDefinitions ||
+                isTokenDefinitionKnown(coinDefinitions?.data, account.symbol, token.contract)
+            ) {
+                acc.knownTokens?.push(token);
+            }
+
+            return acc;
+        },
+        { knownTokens: [] },
+    );
+
+    return showGroup && (isStakeShown || !!tokens?.knownTokens?.length) ? (
+        <AccountItemsGroup
+            key={`${account.descriptor}-${account.symbol}`}
+            account={account}
+            accountLabel={accountLabel}
+            selected={selected}
+            showStaking={isStakeShown}
+            tokens={tokens?.knownTokens}
+        />
+    ) : (
+        <AccountItem
+            type="coin"
+            key={`${account.descriptor}-${account.symbol}`}
+            account={account}
+            isSelected={selected}
+            onClick={onItemClick}
+            accountLabel={accountLabel}
+            formattedBalance={account.formattedBalance}
+            tokens={tokens?.knownTokens}
+        />
+    );
+};

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountGroup.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountGroup.tsx
@@ -7,7 +7,7 @@ import { AnimationWrapper } from './AnimationWrapper';
 import { spacingsPx, typography } from '@trezor/theme';
 
 const Container = styled.div`
-    padding: ${spacingsPx.xs};
+    padding: ${spacingsPx.xs} 0;
 `;
 
 const HeaderWrapper = styled.div`
@@ -16,7 +16,7 @@ const HeaderWrapper = styled.div`
 
     /* to not overlap with the Account's focus shadow */
     margin-bottom: ${spacingsPx.xxs};
-    z-index: 1;
+    z-index: 30;
 `;
 
 const ChevronContainer = styled.div`

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemSkeleton.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemSkeleton.tsx
@@ -1,8 +1,14 @@
 import styled from 'styled-components';
 import { useLoadingSkeleton } from 'src/hooks/suite';
 import { Left, Right } from './AccountItem';
-import { NavigationItemBase } from 'src/components/suite/layouts/SuiteLayout/Sidebar/NavigationItem';
 import { SkeletonCircle, SkeletonStack, SkeletonRectangle } from '@trezor/components';
+
+const Wrapper = styled.div`
+    margin-left: 18px;
+    display: flex;
+    align-items: center;
+    flex: 1;
+`;
 
 const StyledSkeletonStack = styled(SkeletonStack)`
     > :last-child {
@@ -14,7 +20,7 @@ export const AccountItemSkeleton = () => {
     const { shouldAnimate } = useLoadingSkeleton();
 
     return (
-        <NavigationItemBase data-test="@account-menu/account-item-skeleton">
+        <Wrapper data-test="@account-menu/account-item-skeleton">
             <Left>
                 <SkeletonCircle size="24px" />
             </Left>
@@ -25,6 +31,6 @@ export const AccountItemSkeleton = () => {
                     <SkeletonRectangle animate={shouldAnimate} />
                 </StyledSkeletonStack>
             </Right>
-        </NavigationItemBase>
+        </Wrapper>
     );
 };

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemsGroup.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemsGroup.tsx
@@ -1,0 +1,111 @@
+import styled from 'styled-components';
+import { AccountItem } from './AccountItem';
+import { Account } from 'src/types/wallet';
+import { borders, spacingsPx } from '@trezor/theme';
+import { useSelector } from 'src/hooks/suite';
+import { selectFiatRates } from '@suite-common/wallet-core';
+import { getTokensFiatBalance } from '@suite-common/wallet-utils';
+import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
+import { getAccountAutocompoundBalance } from 'src/utils/wallet/stakingUtils';
+import { selectRouteName } from 'src/reducers/suite/routerReducer';
+
+const Section = styled.div<{ $selected?: boolean }>`
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    border-radius: ${borders.radii.md};
+    margin: 5px 0;
+    gap: ${spacingsPx.xxs};
+
+    ${({ $selected, theme }) =>
+        $selected &&
+        `border: 1px solid ${theme.borderElevation0};
+         padding: ${spacingsPx.xxs} 0;
+         margin: 5px ${spacingsPx.xxs};
+    `}
+`;
+
+const Wrapper = styled.div`
+    position: relative;
+`;
+
+const Divider = styled.div<{ $selected?: boolean; $isBigger?: boolean }>`
+    position: absolute;
+    left: ${({ $selected }) => ($selected ? '24px' : '29px')};
+    margin-top: 25px;
+    bottom: 20px;
+    border-left: 2px dashed ${({ theme }) => theme.borderDashed};
+    height: ${({ $isBigger }) => ($isBigger ? '80px' : '50px')};
+    width: 1px;
+    z-index: 10;
+`;
+
+interface AccountItemsGroupProps {
+    account: Account;
+    accountLabel?: string;
+    selected: boolean;
+    showStaking: boolean;
+    tokens?: Account['tokens'];
+}
+
+export const AccountItemsGroup = ({
+    account,
+    accountLabel,
+    selected,
+    showStaking,
+    tokens,
+}: AccountItemsGroupProps) => {
+    const autocompoundBalance = getAccountAutocompoundBalance(account);
+
+    const routeName = useSelector(selectRouteName);
+    const localCurrency = useSelector(selectLocalCurrency);
+    const rates = useSelector(selectFiatRates);
+
+    const tokensFiatBalance = getTokensFiatBalance(account, localCurrency, rates, tokens);
+
+    return (
+        <Section $selected={selected}>
+            <AccountItem
+                type="coin"
+                account={account}
+                isSelected={
+                    selected &&
+                    (routeName === 'wallet-index' ||
+                        (routeName === 'wallet-staking' && !showStaking))
+                }
+                accountLabel={accountLabel}
+                formattedBalance={account.formattedBalance}
+                isGroup
+                isGroupSelected={selected}
+            />
+            {showStaking && (
+                <Wrapper>
+                    <Divider $selected={selected} $isBigger />
+                    <AccountItem
+                        account={account}
+                        type="staking"
+                        isSelected={selected && routeName === 'wallet-staking'}
+                        formattedBalance={autocompoundBalance}
+                        isGroup
+                        isGroupSelected={selected}
+                    />
+                </Wrapper>
+            )}
+            {!!tokens?.length && (
+                <Wrapper>
+                    <Divider $selected={selected} />
+                    <AccountItem
+                        account={account}
+                        type="tokens"
+                        isSelected={selected && routeName === 'wallet-tokens'}
+                        formattedBalance={account.formattedBalance}
+                        isGroup
+                        isGroupSelected={selected}
+                        customFiatValue={tokensFiatBalance}
+                        tokens={tokens}
+                    />
+                </Wrapper>
+            )}
+        </Section>
+    );
+};

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
@@ -6,10 +6,10 @@ import { selectAccountLabels } from 'src/reducers/suite/metadataReducer';
 import { Translation } from 'src/components/suite';
 import { AccountItemSkeleton } from './AccountItemSkeleton';
 import { AccountGroup } from './AccountGroup';
-import { AccountItem } from './AccountItem';
 import { AccountsMenuNotice } from './AccountsMenuNotice';
 import styled from 'styled-components';
 import { spacingsPx } from '@trezor/theme';
+import { AccountSection } from './AcccountSection';
 
 const SkeletonContainer = styled.div`
     margin: ${spacingsPx.xs};
@@ -98,12 +98,12 @@ export const AccountsList = ({ onItemClick }: AccountListProps) => {
                     const selected = !!isSelected(account);
 
                     return (
-                        <AccountItem
-                            key={`${account.descriptor}-${account.symbol}`}
+                        <AccountSection
+                            key={account.key}
                             account={account}
-                            isSelected={selected}
-                            closeMenu={onItemClick}
+                            selected={selected}
                             accountLabel={accountLabels[account.key]}
+                            onItemClick={onItemClick}
                         />
                     );
                 })}

--- a/packages/suite/src/hooks/wallet/useUnstakeEthForm.ts
+++ b/packages/suite/src/hooks/wallet/useUnstakeEthForm.ts
@@ -35,8 +35,8 @@ import { isChanged } from '@suite-common/suite-utils';
 import { selectFiatRatesByFiatRateKey } from '@suite-common/wallet-core';
 // @ts-expect-error
 import { Ethereum } from '@everstake/wallet-sdk';
-import { selectSelectedAccountAutocompoundBalance } from '../../reducers/wallet/selectedAccountReducer';
 import { useFees } from './form/useFees';
+import { getAccountAutocompoundBalance } from 'src/utils/wallet/stakingUtils';
 
 type UnstakeContextValues = UnstakeContextValuesBase & {
     amountLimits: AmountLimitsString;
@@ -65,7 +65,7 @@ export const useUnstakeEthForm = ({
         ),
     );
 
-    const autocompoundBalance = useSelector(selectSelectedAccountAutocompoundBalance);
+    const autocompoundBalance = getAccountAutocompoundBalance(account);
     const amountLimits: AmountLimitsString = {
         currency: symbol,
         minCrypto: MIN_ETH_AMOUNT_FOR_STAKING.toString(),

--- a/packages/suite/src/reducers/wallet/selectedAccountReducer.ts
+++ b/packages/suite/src/reducers/wallet/selectedAccountReducer.ts
@@ -1,9 +1,7 @@
 import { accountsActions } from '@suite-common/wallet-core';
 import type { Action } from 'src/types/suite';
-import type { SelectedAccountStatus, StakingPoolExtended } from '@suite-common/wallet-types';
+import type { SelectedAccountStatus } from '@suite-common/wallet-types';
 import { MIN_ETH_BALANCE_FOR_STAKING } from 'src/constants/suite/ethStaking';
-import { fromWei } from 'web3-utils';
-import BigNumber from 'bignumber.js';
 
 export type State = SelectedAccountStatus;
 
@@ -49,37 +47,6 @@ export const selectSelectedAccountHasSufficientEthForStaking = (
     return MIN_ETH_BALANCE_FOR_STAKING.isLessThanOrEqualTo(formattedBalance);
 };
 
-export const selectSelectedAccountEverstakeStakingPool = (
-    state: SelectedAccountRootState,
-): StakingPoolExtended | undefined => {
-    const selectedAccount = selectSelectedAccount(state);
-    const pool = selectedAccount?.stakingPools?.find(pool => pool.name === 'Everstake');
-
-    if (!pool) return;
-
-    return {
-        ...pool,
-        autocompoundBalance: fromWei(pool.autocompoundBalance),
-        claimableAmount: fromWei(pool.claimableAmount),
-        depositedBalance: fromWei(pool.depositedBalance),
-        pendingBalance: fromWei(pool.pendingBalance),
-        pendingDepositedBalance: fromWei(pool.pendingDepositedBalance),
-        restakedReward: fromWei(pool.restakedReward),
-        withdrawTotalAmount: fromWei(pool.withdrawTotalAmount),
-        totalPendingStakeBalance: fromWei(
-            new BigNumber(pool.pendingBalance).plus(pool.pendingDepositedBalance).toString(),
-        ),
-        canClaim:
-            new BigNumber(pool.claimableAmount).gt(0) &&
-            new BigNumber(pool.withdrawTotalAmount).eq(pool.claimableAmount),
-    };
-};
-
-export const selectSelectedAccountAutocompoundBalance = (state: SelectedAccountRootState) => {
-    const pool = selectSelectedAccountEverstakeStakingPool(state);
-
-    return pool?.autocompoundBalance ?? '0';
-};
 export const selectIsSelectedAccountLoaded = (state: SelectedAccountRootState) =>
     state.wallet.selectedAccount.status === 'loaded';
 

--- a/packages/suite/src/types/wallet/index.ts
+++ b/packages/suite/src/types/wallet/index.ts
@@ -54,6 +54,7 @@ export type {
     ReceiveInfo,
 } from '@suite-common/wallet-types';
 export type { WalletParams } from 'src/utils/suite/router';
+export type AccountItemType = 'coin' | 'tokens' | 'staking';
 
 /*
 this action union types are bad, we need it only for legacy reason.

--- a/packages/suite/src/utils/wallet/stakingUtils.ts
+++ b/packages/suite/src/utils/wallet/stakingUtils.ts
@@ -1,0 +1,34 @@
+import { Account, StakingPoolExtended } from '@suite-common/wallet-types';
+import BigNumber from 'bignumber.js';
+import { fromWei } from 'web3-utils';
+
+export const getAccountEverstakeStakingPool = (
+    account?: Account,
+): StakingPoolExtended | undefined => {
+    const pool = account?.stakingPools?.find(pool => pool.name === 'Everstake');
+
+    if (!pool) return;
+
+    return {
+        ...pool,
+        autocompoundBalance: fromWei(pool.autocompoundBalance),
+        claimableAmount: fromWei(pool.claimableAmount),
+        depositedBalance: fromWei(pool.depositedBalance),
+        pendingBalance: fromWei(pool.pendingBalance),
+        pendingDepositedBalance: fromWei(pool.pendingDepositedBalance),
+        restakedReward: fromWei(pool.restakedReward),
+        withdrawTotalAmount: fromWei(pool.withdrawTotalAmount),
+        totalPendingStakeBalance: fromWei(
+            new BigNumber(pool.pendingBalance).plus(pool.pendingDepositedBalance).toString(),
+        ),
+        canClaim:
+            new BigNumber(pool.claimableAmount).gt(0) &&
+            new BigNumber(pool.withdrawTotalAmount).eq(pool.claimableAmount),
+    };
+};
+
+export const getAccountAutocompoundBalance = (account?: Account) => {
+    const pool = getAccountEverstakeStakingPool(account);
+
+    return pool?.autocompoundBalance ?? '0';
+};

--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/PayoutCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/PayoutCard.tsx
@@ -3,9 +3,10 @@ import BigNumber from 'bignumber.js';
 import { useTheme } from 'styled-components';
 import { Icon } from '@trezor/components';
 import { Translation } from 'src/components/suite';
-import { useSelector } from 'src/hooks/suite';
-import { selectSelectedAccountAutocompoundBalance } from 'src/reducers/wallet/selectedAccountReducer';
 import { AccentP, CardBottomContent, GreyP, StyledCard } from './styled';
+import { getAccountAutocompoundBalance } from 'src/utils/wallet/stakingUtils';
+import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
+import { useSelector } from 'src/hooks/suite';
 
 interface PayoutCardProps {
     nextRewardPayout: number | null;
@@ -19,8 +20,9 @@ export const PayoutCard = ({
     validatorWithdrawTime,
 }: PayoutCardProps) => {
     const theme = useTheme();
+    const selectedAccount = useSelector(selectSelectedAccount);
 
-    const autocompoundBalance = useSelector(selectSelectedAccountAutocompoundBalance);
+    const autocompoundBalance = getAccountAutocompoundBalance(selectedAccount);
     const payout = useMemo(() => {
         if (!nextRewardPayout || !daysToAddToPool) return '--';
 

--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/StakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/StakingCard.tsx
@@ -7,16 +7,14 @@ import { isPending } from '@suite-common/wallet-utils';
 import { FiatValue, FormattedCryptoAmount, Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { openModal } from 'src/actions/suite/modalActions';
-import {
-    selectSelectedAccount,
-    selectSelectedAccountEverstakeStakingPool,
-} from 'src/reducers/wallet/selectedAccountReducer';
+import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 import { mapTestnetSymbol } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import { MIN_ETH_AMOUNT_FOR_STAKING } from 'src/constants/suite/ethStaking';
 import { InfoBox, ProgressBar } from './styled';
 import { ProgressLabels } from './ProgressLabels/ProgressLabels';
 import { useProgressLabelsData } from '../hooks/useProgressLabelsData';
 import { useIsTxStatusShown } from '../hooks/useIsTxStatusShown';
+import { getAccountEverstakeStakingPool } from 'src/utils/wallet/stakingUtils';
 
 const StyledCard = styled(Card)`
     padding: ${spacingsPx.md};
@@ -122,8 +120,8 @@ export const StakingCard = ({
     daysToUnstake,
 }: StakingCardProps) => {
     const theme = useTheme();
-    const { symbol, key: selectedAccountKey } = useSelector(selectSelectedAccount) ?? {};
-    const mappedSymbol = symbol ? mapTestnetSymbol(symbol) : '';
+    const selectedAccount = useSelector(selectSelectedAccount);
+    const mappedSymbol = selectedAccount?.symbol ? mapTestnetSymbol(selectedAccount?.symbol) : '';
 
     const {
         autocompoundBalance = '0',
@@ -132,7 +130,7 @@ export const StakingCard = ({
         totalPendingStakeBalance = '0',
         withdrawTotalAmount = '0',
         claimableAmount = '0',
-    } = useSelector(selectSelectedAccountEverstakeStakingPool) ?? {};
+    } = getAccountEverstakeStakingPool(selectedAccount) ?? {};
 
     const canUnstake = MIN_ETH_AMOUNT_FOR_STAKING.lt(autocompoundBalance);
     const isStakePending = new BigNumber(totalPendingStakeBalance).gt(0);
@@ -145,7 +143,7 @@ export const StakingCard = ({
     const isDaysToUnstakeShown = !Number.isNaN(daysToUnstake) && !isValidatorsQueueLoading;
 
     const stakeTxs = useSelector(state =>
-        selectAccountStakeTransactions(state, selectedAccountKey || ''),
+        selectAccountStakeTransactions(state, selectedAccount?.key || ''),
     );
     const isStakeConfirming = stakeTxs.some(tx => isPending(tx));
 
@@ -171,7 +169,7 @@ export const StakingCard = ({
                     <EnteringAmountInfo>
                         <Translation
                             id="TR_STAKE_WAITING_TO_BE_ADDED"
-                            values={{ symbol: symbol?.toUpperCase(), br: <br /> }}
+                            values={{ symbol: selectedAccount?.symbol?.toUpperCase(), br: <br /> }}
                         />
 
                         <EnteringAmountsWrapper>
@@ -183,7 +181,7 @@ export const StakingCard = ({
                             <div>
                                 <FormattedCryptoAmount
                                     value={totalPendingStakeBalance}
-                                    symbol={symbol}
+                                    symbol={selectedAccount?.symbol}
                                 />{' '}
                                 <EnteringFiatValueWrapper>
                                     <FiatValue
@@ -213,7 +211,10 @@ export const StakingCard = ({
                         <Translation id="TR_STAKE_STAKE" />
                     </AmountHeading>
 
-                    <StyledFormattedCryptoAmount value={depositedBalance} symbol={symbol} />
+                    <StyledFormattedCryptoAmount
+                        value={depositedBalance}
+                        symbol={selectedAccount?.symbol}
+                    />
 
                     <StyledFiatValue
                         amount={depositedBalance}
@@ -233,7 +234,7 @@ export const StakingCard = ({
                     <StyledFormattedCryptoAmount
                         $isRewards
                         value={restakedReward}
-                        symbol={symbol}
+                        symbol={selectedAccount?.symbol}
                     />
 
                     <StyledFiatValue
@@ -266,7 +267,10 @@ export const StakingCard = ({
                             </span>
                         </AmountHeading>
 
-                        <StyledFormattedCryptoAmount value={withdrawTotalAmount} symbol={symbol} />
+                        <StyledFormattedCryptoAmount
+                            value={withdrawTotalAmount}
+                            symbol={selectedAccount?.symbol}
+                        />
 
                         <StyledFiatValue
                             amount={withdrawTotalAmount}
@@ -296,7 +300,7 @@ export const StakingCard = ({
                 <Icon icon="INFO" size={12} />
                 <Translation
                     id="TR_STAKE_ETH_REWARDS_EARN_APY"
-                    values={{ symbol: symbol?.toUpperCase() }}
+                    values={{ symbol: selectedAccount?.symbol?.toUpperCase() }}
                 />
             </Info>
 

--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/claim/ClaimCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/claim/ClaimCard.tsx
@@ -2,13 +2,11 @@ import { useEffect, useMemo, useRef } from 'react';
 import { isPending } from '@suite-common/wallet-utils';
 import { selectAccountClaimTransactions } from '@suite-common/wallet-core';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import {
-    selectSelectedAccount,
-    selectSelectedAccountEverstakeStakingPool,
-} from 'src/reducers/wallet/selectedAccountReducer';
+import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { ClaimReadyCard } from './ClaimReadyCard';
 import { ClaimPendingCard } from './ClaimPendingCard';
+import { getAccountEverstakeStakingPool } from 'src/utils/wallet/stakingUtils';
 
 export const ClaimCard = () => {
     const selectedAccount = useSelector(selectSelectedAccount);
@@ -19,7 +17,7 @@ export const ClaimCard = () => {
     const isClaimPending = useMemo(() => claimTxs.some(tx => isPending(tx)), [claimTxs]);
 
     const { canClaim = false, claimableAmount = '0' } =
-        useSelector(selectSelectedAccountEverstakeStakingPool) ?? {};
+        getAccountEverstakeStakingPool(selectedAccount) ?? {};
 
     // Show success message when claim tx confirmation is complete.
     const prevIsClaimPending = useRef(false);


### PR DESCRIPTION
## Description

Show accounts group with staking and tokens information for Ethereum, Polygon and Cardano type of accounts plus remove staking stats from header of account detail.

## Related Issue

Resolve #11398

## Screenshots:
![Screenshot 2024-04-02 at 3 10 20 PM](https://github.com/trezor/trezor-suite/assets/66002635/831e8d5d-50e0-47b4-91c1-15674fd45591)
![Screenshot 2024-04-02 at 3 10 29 PM](https://github.com/trezor/trezor-suite/assets/66002635/04815bff-e3f9-454d-9a81-9de92b6f5154)
