### PR TITLE
Support checksums in descriptor parsing

### DIFF
--- a/packages/utxo-lib/src/derivation.ts
+++ b/packages/utxo-lib/src/derivation.ts
@@ -96,9 +96,9 @@ const getXpubInfo = (xpub: string, network: Network) => {
 };
 
 const getDescriptorInfo = (paymentType: PaymentType, descriptor: string, network: Network) => {
-    const [_match, _script, path, xpub] =
+    const [_match, _script, path, xpub, _checksum] =
         descriptor.match(
-            /^([a-z]+\()+\[([a-z0-9]{8}(?:\/[0-9]+'?){3,})\]([xyztuv]pub[a-zA-Z0-9]*)\/<0;1>\/\*\)+$/,
+            /^([a-z]+\()+\[([a-z0-9]{8}(?:\/[0-9]+'?){3,})\]([xyztuv]pub[a-zA-Z0-9]*)\/<0;1>\/\*\)+(#[a-z0-9]{8})?$/,
         ) || throwError(`Descriptor cannot be parsed: ${descriptor}`);
     const [_fingerprint, ...levels] = path.split('/');
     const version = getVersion(xpub);

--- a/packages/utxo-lib/tests/__fixtures__/derivation.ts
+++ b/packages/utxo-lib/tests/__fixtures__/derivation.ts
@@ -90,7 +90,7 @@ export default {
         {
             description: 'First taproot of all seed',
             xpubs: [
-                "tr([5c9e228d/86'/0'/0']xpub6Bw885JisRbcKmowfBvMmCxaFHodKn1VpmRmctmJJoM8D4DzyP4qJv8ZdD9V9r3SSGjmK2KJEDnvLH6f1Q4HrobEvnCeKydNvf1eir3RHZk/<0;1>/*)",
+                "tr([5c9e228d/86'/0'/0']xpub6Bw885JisRbcKmowfBvMmCxaFHodKn1VpmRmctmJJoM8D4DzyP4qJv8ZdD9V9r3SSGjmK2KJEDnvLH6f1Q4HrobEvnCeKydNvf1eir3RHZk/<0;1>/*)#9thz2a5h",
             ],
             pathPrefix: "m/86'/0'/0'",
             receive: [


### PR DESCRIPTION
## Description

From newer firmwares, account descriptors are returned including checksum at the end. Therefore, descriptor regex in utxo-lib must've been extended to be able to accept and ignore the checksum.

## Related Issue

Resolve #11857