### PR TITLE
fix(docker): docker compose deprecated command

### DIFF
--- a/.github/workflows/connect-transport-e2e-test.yml
+++ b/.github/workflows/connect-transport-e2e-test.yml
@@ -13,6 +13,7 @@ on:
       - "packages/protocol/**"
       - "packages/trezor-user-env-link/**"
       - "packages/utils/**"
+      - "docker/docker-transport-test.sh"
       - "docker/docker-compose.transport-test.yml"
       - ".github/workflows/connect-transport-e2e-test.yml"
       - "yarn.lock"

--- a/docker/docker-transport-test.sh
+++ b/docker/docker-transport-test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -e
 
-docker compose -f ./docker/docker compose.transport-test.yml pull
+docker compose -f ./docker/docker-compose.transport-test.yml pull
 docker compose -f ./docker/docker-compose.transport-test.yml up --build --abort-on-container-exit --force-recreate


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
GitHub deprecated docker compose V1, now it requires the command to be: `docker compose`
https://docs.docker.com/compose/migrate/

But in this case `docker-compose` was the name of the file so it created an issue with `./docker/docker-compose.transport-test.yml pull....`

