### PR TITLE
fix(github): connect test fix release branch name and allow manually

### DIFF
--- a/.github/workflows/connect-dev-release-test.yml
+++ b/.github/workflows/connect-dev-release-test.yml
@@ -9,7 +9,7 @@ on:
     # Runs at midnight UTC every day at 01:00 AM CET
     - cron: "0 0 * * *"
   push:
-    branches: [npm-release/*, release/*]
+    branches: [release/connect/**]
   pull_request:
     paths:
       - "packages/blockchain-link/**"
@@ -26,6 +26,7 @@ on:
       - "yarn.lock"
       - ".github/workflows/connect-dev-release-test.yml"
       - ".github/workflows/template-connect-popup-test-params.yml"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}

--- a/.github/workflows/connect-test.yml
+++ b/.github/workflows/connect-test.yml
@@ -6,7 +6,7 @@ on:
     # Runs at midnight UTC every day at 01:00 AM CET
     - cron: "0 0 * * *"
   push:
-    branches: [npm-release/*, release/*]
+    branches: [release/connect/**]
   pull_request:
     paths:
       - "packages/blockchain-link/**"
@@ -26,6 +26,7 @@ on:
       - ".github/workflows/template-connect-test-params.yml"
       - "docker/docker-connect-test.sh"
       - "docker/docker-compose.connect-test.yml"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}

--- a/.github/workflows/connect-transport-e2e-test.yml
+++ b/.github/workflows/connect-transport-e2e-test.yml
@@ -5,7 +5,7 @@ on:
     # Runs at midnight UTC every day at 01:00 AM CET
     - cron: "0 0 * * *"
   push:
-    branches: [npm-release/*, release/*]
+    branches: [release/connect/**]
   pull_request:
     paths:
       - "packages/transport/**"
@@ -17,6 +17,7 @@ on:
       - "docker/docker-compose.transport-test.yml"
       - ".github/workflows/connect-transport-e2e-test.yml"
       - "yarn.lock"
+  workflow_dispatch:
 
 jobs:
   transport-e2e:

--- a/.github/workflows/connect-web-e2e-test.yml
+++ b/.github/workflows/connect-web-e2e-test.yml
@@ -5,7 +5,7 @@ on:
     # Runs at midnight UTC every day at 01:00 AM CET
     - cron: "0 0 * * *"
   push:
-    branches: [npm-release/*, release/*]
+    branches: [release/connect/**]
   pull_request:
     paths:
       - "packages/connect/**"
@@ -13,6 +13,7 @@ on:
       - "packages/utils/**"
       - ".github/workflows/connect-web-e2e-test.yml"
       - "yarn.lock"
+  workflow_dispatch:
 
 jobs:
   connect-web-e2e:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I think I found the issue why it was not running on previous release, we need to have `release/**` instead of `release/*` because our release branches look  like `release/connect/v9.2.2`

I am also adding the option to run them manually since I think that might be useful in some situations.

## Related Issue

Related https://github.com/trezor/trezor-suite/issues/7916
Related https://github.com/trezor/trezor-suite/issues/7917

