### PR TITLE
chore(suite-build): change fw binaries source

### DIFF
--- a/.github/workflows/build-desktop-apps.yml
+++ b/.github/workflows/build-desktop-apps.yml
@@ -57,7 +57,6 @@ jobs:
           yarn install --immutable
           yarn message-system-sign-config
           yarn workspace @trezor/suite-data build:lib
-          yarn workspace @trezor/connect-iframe build:lib
           yarn workspace @trezor/transport-bridge build:lib
 
       - name: Build ${{ matrix.platform }} suite-desktop
@@ -113,7 +112,6 @@ jobs:
       - name: Build libs
         run: |
           yarn workspace @trezor/suite-data build:lib
-          yarn workspace @trezor/connect-iframe build:lib
           yarn workspace @trezor/transport-bridge build:lib
 
       - name: Build ${{env.platform}} suite-desktop

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -78,7 +78,6 @@ suite-web build stable codesign:
     - apt-get update && apt-get install -y libudev-dev # required for rebuilding usb native module
     - yarn install --immutable
     - yarn workspace @trezor/transport-bridge build:lib
-    - yarn workspace @trezor/connect-iframe build:lib
     - yarn workspace @trezor/suite-desktop build:${platform}
     - ls -la packages/suite-desktop/build-electron
     - mv packages/suite-desktop/build-electron/* .
@@ -96,7 +95,6 @@ suite-web build stable codesign:
     - nix-shell --option system x86_64-darwin --run "yarn install --immutable"
     - nix-shell --option system x86_64-darwin --run "yarn message-system-sign-config"
     - nix-shell --option system x86_64-darwin --run "yarn workspace @trezor/suite-data build:lib"
-    - nix-shell --option system x86_64-darwin --run "yarn workspace @trezor/connect-iframe build:lib"
     - nix-shell --option system x86_64-darwin --run "yarn workspace @trezor/transport-bridge build:lib"
     - nix-shell --option system x86_64-darwin --run "yarn workspace @trezor/suite-desktop build:${platform}"
     - nix-shell --option system x86_64-darwin --run "bash packages/suite-desktop-core/scripts/gnupg-sign.sh"

--- a/packages/suite-build/configs/desktop.webpack.config.ts
+++ b/packages/suite-build/configs/desktop.webpack.config.ts
@@ -42,10 +42,10 @@ const config: webpack.Configuration = {
                         to: path.join(baseDir, 'build', 'static', 'message-system'),
                     },
                 ])
-                // include FW binaries from @trezor/connect-iframe
+                // include FW binaries from @trezor/connect-common
                 .concat([
                     {
-                        from: path.join(__dirname, '../../', 'connect-iframe/build/data/firmware'),
+                        from: path.join(__dirname, '../../', 'connect-common/files/firmware'),
                         to: path.join(baseDir, 'build/static/bin/firmware'),
                     },
                 ])
@@ -56,7 +56,7 @@ const config: webpack.Configuration = {
                               from: path.join(
                                   __dirname,
                                   '../../',
-                                  'connect-iframe/build/data/devkit/firmware',
+                                  'connect-common/files/devkit/firmware',
                               ),
                               to: path.join(baseDir, 'build/static/bin/devkit/firmware'),
                           },


### PR DESCRIPTION
`suite-desktop` should use firmware binaries from `connect-common` instead of the files copies to `connect-iframe` so that `connect-iframe` build is not required to build `suite-desktop`.