### PR TITLE
fix(components): textarea handle value prop

### DIFF
--- a/packages/components/src/components/form/Textarea/Textarea.tsx
+++ b/packages/components/src/components/form/Textarea/Textarea.tsx
@@ -129,6 +129,7 @@ export const Textarea = ({
                     data-test={dataTest}
                     placeholder={placeholder || ''} // needed for uncontrolled inputs
                     ref={innerRef}
+                    value={value}
                     {...rest}
                 />
 


### PR DESCRIPTION
## Description

While working on the new explorer I found out the Textarea component doesn't properly pass the `value` prop to the actual textarea element. 

I wanted to raise this as a separate PR to make sure this is intentional and discuss any possible side effects