### PR TITLE
fix(suite): use estimated gas limit for EVM token transfers

### DIFF
--- a/packages/suite/src/actions/wallet/send/sendFormEthereumThunks.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormEthereumThunks.ts
@@ -17,7 +17,7 @@ import {
     getNetwork,
 } from '@suite-common/wallet-utils';
 import { createThunk } from '@suite-common/redux-utils';
-import { ETH_DEFAULT_GAS_LIMIT, ERC20_GAS_LIMIT } from '@suite-common/wallet-constants';
+import { ETH_DEFAULT_GAS_LIMIT } from '@suite-common/wallet-constants';
 import {
     PrecomposedLevels,
     PrecomposedTransaction,
@@ -123,10 +123,6 @@ export const composeEthereumSendFormTransactionThunk = createThunk(
         const { address, amount } = formValues.outputs[0];
 
         let customFeeLimit: string | undefined;
-        // set gasLimit based on ERC20 transfer
-        if (tokenInfo) {
-            customFeeLimit = ERC20_GAS_LIMIT;
-        }
 
         // gasLimit calculation based on address, amount and data size
         // amount in essential for a proper calculation of gasLimit (via blockbook/geth)

--- a/suite-common/wallet-constants/src/sendForm.ts
+++ b/suite-common/wallet-constants/src/sendForm.ts
@@ -9,7 +9,6 @@ export const ETH_DEFAULT_GAS_PRICE = '1';
 export const ETH_DEFAULT_GAS_LIMIT = '21000';
 
 export const ERC20_TRANSFER = 'a9059cbb'; // 4 bytes function signature of solidity erc20 `transfer(address,uint256)`
-export const ERC20_GAS_LIMIT = '200000';
 
 export const DEFAULT_PAYMENT = {
     type: 'payment',


### PR DESCRIPTION
## Description

No idea why we had hardcoded value `200_000`

I am also suprised that there was no token which required more than `200_000`