### PR TITLE
chore(ci): get rid of transport and connect tests from GitLab

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -5,28 +5,6 @@
     - schedules
     - /^release\//
 
-.connect_included_methods: &connect_included_methods
-  TESTS_INCLUDED_METHODS:
-    [
-      "applySettings,applyFlags,getFeatures,getFirmwareHash,checkFirmwareAuthenticity",
-      "signTransaction",
-      "getAccountInfo,getAccountDescriptor,getAddress,getPublicKey,signMessage,verifyMessage,composeTransaction,getOwnershipId,getOwnershipProof",
-      "stellarGetAddress,stellarSignTransaction",
-      "cardanoGetAddress,cardanoGetNativeScriptHash,cardanoGetPublicKey,cardanoSignTransaction",
-      "eosGetPublicKey,eosSignTransaction",
-      "ethereumGetAddress,ethereumGetPublicKey,ethereumSignMessage,ethereumSignTransaction,ethereumVerifyMessage,ethereumSignTypedData",
-      "nemGetAddress,nemSignTransaction",
-      "rippleGetAddress,rippleSignTransaction",
-      "tezosGetAddress,tezosGetPublicKey,tezosSignTransaction",
-      "binanceGetAddress,binanceGetPublicKey,binanceSignTransaction",
-    ]
-
-.connect_test_pattern_1: &connect_test_pattern_1
-  TESTS_PATTERN: "init authorizeCoinjoin cancelCoinjoinAuthorization passphrase unlockPath setBusy override"
-
-.connect_test_pattern_2: &connect_test_pattern_2
-  TESTS_PATTERN: "methods"
-
 # @trezor/suite-desktop
 .e2e desktop:
   stage: integration testing
@@ -78,42 +56,15 @@ suite desktop manual:
     <<: *run_everything_rules
   when: manual
 
-# @trezor/transport
-.e2e transport:
-  stage: integration testing
-  variables:
-    COMPOSE_FILE: ./docker/docker-compose.transport-test.yml
-  script:
-    - yarn install --immutable
-    - yarn workspace @trezor/utils build:lib
-    - yarn workspace @trezor/transport build:lib
-    # run e2e tests
-    - ./docker/docker-transport-test.sh
-  after_script:
-    - docker-compose down
-    - docker network prune -f
-  interruptible: true
-
-transport:
-  extends: .e2e transport
-  only:
-    <<: *run_everything_rules
-
-transport manual:
-  extends: .e2e transport
-  except:
-    <<: *run_everything_rules
-  when: manual
-
-# @trezor/connect-popup (via @trezor/connect-explorer)
-.e2e connect-popup:
+.connect-popup legacy npm package base:
   stage: integration testing
   retry: 0
   variables:
     COMPOSE_PROJECT_NAME: $CI_JOB_ID
     COMPOSE_FILE: ./docker/docker-compose.connect-popup-ci.yml
-    URL: ${DEV_SERVER_URL}/connect/${CI_COMMIT_REF_NAME}/
+    URL: ${DEV_SERVER_URL}/connect/npm-release/connect-${CONNECT_VERSION}/?trezor-connect-src=${DEV_SERVER_URL}/connect/${CI_COMMIT_REF_NAME}/
     TEST_FILE: $TEST_FILE
+
   script:
     - yarn install --immutable
     - docker-compose pull
@@ -130,47 +81,9 @@ transport manual:
       - ./packages/connect-popup/connect-popup-overview.html
       - ./packages/connect-popup/test-results
   interruptible: true
-  parallel:
-    matrix:
-      - TEST_FILE: ["methods.test"]
-      - TEST_FILE: ["popup-close.test"]
-      - TEST_FILE: ["passphrase.test"]
-      - TEST_FILE: ["popup-pages.test"]
-      - TEST_FILE: ["unchained.test"]
-      - TEST_FILE: ["browser-support.test"]
-      - TEST_FILE: ["transport.test"]
-      - TEST_FILE: ["permissions.test"]
-
-connect-popup:
-  extends: .e2e connect-popup
-  dependencies:
-    - install
-    - connect-web build
-  only:
-    <<: *run_everything_rules
-
-connect-popup manual:
-  extends: .e2e connect-popup
   needs:
     - install
     - connect-web build
-  except:
-    <<: *run_everything_rules
-  when: manual
-
-.connect-popup legacy npm package base:
-  extends: .e2e connect-popup
-  stage: legacy testing
-  needs:
-    - install
-    - connect-web build
-  retry: 0
-  variables:
-    COMPOSE_PROJECT_NAME: $CI_JOB_ID
-    COMPOSE_FILE: ./docker/docker-compose.connect-popup-ci.yml
-    # It will use connect version from npm legacy version with current popup.
-    URL: ${DEV_SERVER_URL}/connect/npm-release/connect-${CONNECT_VERSION}/?trezor-connect-src=${DEV_SERVER_URL}/connect/${CI_COMMIT_REF_NAME}/
-    TEST_FILE: $TEST_FILE
   parallel:
     matrix:
       - CONNECT_VERSION: "9.0.10"
@@ -206,158 +119,6 @@ connect-popup legacy npm package production:
   only:
     refs:
       - /^release\/connect\//
-
-.e2e connect-explorer-webextension:
-  stage: integration testing
-  retry: 0
-  variables:
-    COMPOSE_PROJECT_NAME: $CI_JOB_ID
-    COMPOSE_FILE: ./docker/docker-compose.connect-popup-ci.yml
-    TREZOR_CONNECT_SRC: ${DEV_SERVER_URL}/connect/${CI_COMMIT_REF_NAME}/
-    URL: ${DEV_SERVER_URL}/connect/${CI_COMMIT_REF_NAME}/
-    IS_WEBEXTENSION: "true"
-  script:
-    - yarn install --immutable
-    - yarn build:libs
-    - yarn workspace @trezor/connect-webextension build
-    - yarn workspace @trezor/connect-iframe build:core-module
-    - yarn workspace @trezor/connect-explorer build:webextension
-    - docker-compose pull
-    - docker-compose up -d trezor-user-env-unix
-    - docker-compose run test-run
-  after_script:
-    - docker-compose down
-    - docker network prune -f
-  artifacts:
-    expire_in: 7 days
-    when: always
-    paths:
-      - ./packages/connect-popup/e2e/screenshots
-      - ./packages/connect-popup/connect-popup-overview.html
-      - ./packages/connect-popup/test-results
-  interruptible: true
-  parallel:
-    matrix:
-      - TEST_FILE: ["methods.test"]
-      - TEST_FILE: ["passphrase.test"]
-      - TEST_FILE: ["popup-close.test"]
-      - TEST_FILE: ["popup-pages.test"]
-
-connect-explorer-webextension:
-  extends: .e2e connect-explorer-webextension
-  dependencies:
-    - install
-    - connect-web build
-  only:
-    <<: *run_everything_rules
-
-connect-explorer-webextension manual:
-  extends: .e2e connect-explorer-webextension
-  needs:
-    - install
-    - connect-web build
-  except:
-    <<: *run_everything_rules
-  when: manual
-
-.connect:
-  stage: integration testing
-  retry: 0
-  dependencies:
-    - install
-  variables:
-    COMPOSE_PROJECT_NAME: $CI_JOB_ID
-    COMPOSE_FILE: ./docker/docker-compose.connect-test.yml
-    TESTS_INCLUDED_METHODS: $TESTS_INCLUDED_METHODS
-    TESTS_EXCLUDED_METHODS: $TESTS_EXCLUDED_METHODS
-    TESTS_PATTERN: $TESTS_PATTERN
-    TESTS_SCRIPT: yarn workspace @trezor/connect test:e2e:${TESTS_ENVIRONMENT}
-    TESTS_FIRMWARE: $TESTS_FIRMWARE
-    TESTS_USE_TX_CACHE: $TESTS_MOCK_BACKENDS
-    TESTS_USE_WS_CACHE: $TESTS_MOCK_BACKENDS
-  before_script:
-    - docker-compose down
-    - docker network prune -f
-  script:
-    - git submodule update --init --recursive
-    - yarn install --immutable
-    # should not be needed, rather hand over artifacts?
-    - if [ "$TESTS_ENVIRONMENT" == "web" ]; then yarn workspace @trezor/connect-iframe build; else echo "else"; fi
-    # should not be needed, rather hand over artifacts?
-    - if [ "$TESTS_ENVIRONMENT" == "web" ]; then yarn workspace @trezor/connect-web build; else echo "else"; fi
-
-    # switch node version for testing.
-    # todo: nvm is present in base image but not available here
-    # - sed -i "/\"node\"/d" package.json
-    # - nvm install ${TESTS_NODE_VERSION}
-    - docker-compose pull
-    - docker-compose up -d trezor-user-env-unix
-    - docker-compose run test-run
-  after_script:
-    - docker cp ${CI_JOB_ID}_trezor-user-env-unix_1:/trezor-user-env/logs/debugging.log trezor-user-env-debugging.log
-    - docker cp ${CI_JOB_ID}_trezor-user-env-unix_1:/trezor-user-env/logs/emulator_bridge.log tenv-emulator-bridge-debugging.log
-    - docker cp ${CI_JOB_ID}_trezor-user-env-unix_1:/trezor-user-env/docker/version.txt trezor-user-env-version.txt
-    - docker-compose down
-    - docker network prune -f
-  interruptible: true
-  artifacts:
-    expire_in: 7 days
-    when: always
-    paths:
-      - trezor-user-env-debugging.log
-      - tenv-emulator-bridge-debugging.log
-      - trezor-user-env-version.txt
-
-.connect matrix:
-  extends: .connect
-  parallel:
-    matrix:
-      - TESTS_ENVIRONMENT: ["node", "web"]
-        <<: *connect_test_pattern_1
-      - TESTS_ENVIRONMENT: ["node", "web"]
-        <<: *connect_test_pattern_2
-        <<: *connect_included_methods
-        TESTS_MOCK_BACKENDS: "false"
-
-.connect legacy fws base:
-  extends: .connect matrix
-  stage: legacy testing
-  variables:
-    TESTS_FIRMWARE: "2.2.0"
-
-connect legacy fws:
-  extends: .connect legacy fws base
-  dependencies:
-    - install
-    - connect-web build
-  only:
-    <<: *run_everything_rules
-
-connect legacy fws manual:
-  extends: .connect legacy fws base
-  except:
-    refs:
-      - schedules
-  when: manual
-
-.connect canary fws base:
-  extends: .connect matrix
-  stage: canary testing
-  variables:
-    TESTS_FIRMWARE: "2-main"
-
-connect canary fws:
-  extends: .connect canary fws base
-  only:
-    refs:
-      - schedules
-
-connect canary fws manual:
-  extends: .connect canary fws base
-  except:
-    refs:
-      - schedules
-  when: manual
 
 .e2e connect-web:
   stage: integration testing


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Getting rid of all the connect tests from GitLab because they have proved to work ok in GitHub Actions with the exception of Legacy and Manifest V2 webextension.

## Related Issue

Related to https://github.com/trezor/trezor-suite/issues/7916
