### PR TITLE
ci(github): deploy beta npm connect and connect dependencies

### DIFF
--- a/.github/workflows/release-connect-npm-dependencies.yml
+++ b/.github/workflows/release-connect-npm-dependencies.yml
@@ -1,0 +1,34 @@
+name: "[Release] connect dependencies npm"
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: Name of the package to deploy.
+        required: true
+        type: choice
+        options:
+          - blockchain-link-types
+          - blockchain-link-utils
+          - blockchain-link
+          - connect-common
+          - transport
+          - utils
+          - utxo-lib
+          - connect-plugin-stellar
+          - connect-plugin-ethereum
+          - analytics
+          - connect-analytics
+          - type-utils
+          - env-utils
+          - protocol
+          - protobuf
+          - schema-utils
+
+jobs:
+  deploy-npm-beta:
+    needs: [extract-branch]
+    environment: npm-packages
+    uses: ./.github/workflows/template-release-connect-npm.yml
+    with:
+      deploymentType: beta
+      packageName: ${{ inputs.package }}

--- a/.github/workflows/release-connect-npm.yml
+++ b/.github/workflows/release-connect-npm.yml
@@ -1,0 +1,21 @@
+name: "[Release] connect npm"
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: Name of the package to deploy.
+        required: true
+        type: choice
+        options:
+          - connect
+          - connect-web
+          - connect-webextension
+
+jobs:
+  deploy-npm-beta:
+    needs: [extract-branch]
+    environment: npm-packages
+    uses: ./.github/workflows/template-release-connect-npm.yml
+    with:
+      deploymentType: beta
+      packageName: ${{ inputs.package }}

--- a/.github/workflows/template-release-connect-npm.yml
+++ b/.github/workflows/template-release-connect-npm.yml
@@ -1,0 +1,74 @@
+name: "[Template] NPM Connect deploy"
+
+on:
+  workflow_call:
+    inputs:
+      deploymentType:
+        description: Specifies the deployment type for the npm package. Choose 'beta' for pre-release versions that are not ready for production use, and 'production' for stable versions intended for end-users.
+        required: true
+        type: choice
+        options:
+          - beta
+          - production
+      packageName:
+        description: The name of the package to be deployed. Select from the predefined list of packages.
+        required: true
+        type: choice
+        options:
+          - blockchain-link-types
+          - blockchain-link-utils
+          - blockchain-link
+          - connect-common
+          - transport
+          - utils
+          - utxo-lib
+          - connect-plugin-stellar
+          - connect-plugin-ethereum
+          - analytics
+          - connect-analytics
+          - type-utils
+          - env-utils
+          - protocol
+          - protobuf
+          - schema-utils
+          - connect
+          - connect-web
+          - connect-webextension
+
+jobs:
+  build-deploy-connect:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Extract branch name
+        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        id: extract_branch
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Check version
+        run: node ./ci/scripts/check-version ${{ inputs.package }} ${{ steps.extract_branch.outputs.branch }} ${{ inputs.deploymentType }}
+
+      - name: Set NPM token
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: yarn config set npmAuthToken ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to NPM
+        run: |
+          cd ./packages/${{ inputs.package }}
+          yarn npm publish --tag ${{ inputs.deploymentType }} --access public
+
+      - name: Cleanup
+        if: always()
+        run: yarn config unset npmAuthToken


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR creates a new Template to allow deploying NPM packages. 

I have created 2 different actions, one for connect dependencies and other one for connect packages `@trezor/connect`, `@trezor/connect-web` and `@trezor/connect-webextension` because they are release at different moment during the release process so I think it makes sense to keep those separated but at the same time use the same template because the code to deploy is the same.

Related https://github.com/trezor/trezor-suite/issues/11918


