### PR TITLE
Fix stack overflow when fetching txs on empty account

### DIFF
--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -328,7 +328,7 @@ export const fetchTransactionsThunk = createThunk(
             (page > 1 && txsForPage.length === perPage) ||
             txsForPage.length === account.history.total
         ) {
-            if (recursive && !signal.aborted) {
+            if (recursive && !signal.aborted && account.history.total) {
                 const promise = dispatch(
                     fetchTransactionsThunk({
                         accountKey,


### PR DESCRIPTION
## Description

When recursive fetching of all txs is performed on empty account (search action, export action or coin control), app throws `Maximum call stack size exceeded` due to wrong condition.

While this bug is relatively old, it wasn't accessible until #11232 where send form (and therefore coin control) became accessible even for empty accounts.

This should be the smallest possible fix, but I plan to refactor `fetchTransactionsThunk` a bit in #11355.

## Related Issue

Resolve #11901