### PR TITLE
fix(connect): always show device selection when bridge and using core in popup

### DIFF
--- a/packages/connect-popup/e2e/tests/methods.test.ts
+++ b/packages/connect-popup/e2e/tests/methods.test.ts
@@ -120,6 +120,12 @@ filteredFixtures.forEach(f => {
         });
         await popup.click("button[data-test='@analytics/continue-button']");
 
+        if (isWebExtension) {
+            log(f.url, 'waiting for select device');
+            await popup.waitForSelector('.select-device-list button.list', { state: 'visible' });
+            await popup.click('.select-device-list button.list');
+        }
+
         log(f.url, 'waiting for confirm permissions button');
         await popup.waitForSelector('button.confirm', { state: 'visible' });
         await popup.screenshot({

--- a/packages/connect-popup/e2e/tests/passphrase.test.ts
+++ b/packages/connect-popup/e2e/tests/passphrase.test.ts
@@ -89,12 +89,23 @@ test('input passphrase in popup and device accepts it', async () => {
 
     log('opening popup');
     [popup] = await openPopup(context, explorerPage, isWebExtension);
+    await popup.waitForLoadState('load');
 
     log('waiting for analytics continue button');
     await findElementByDataTest(popup, '@analytics/continue-button', 40 * 1000);
 
+    if (isWebExtension) {
+        // There is an issue in web extension, core takes time to load and accepting analytics too quickly can cause error
+        await popup.waitForTimeout(1000);
+    }
     log('clicking on analytics continue button');
     await waitAndClick(popup, ['@analytics/continue-button']);
+
+    if (isWebExtension) {
+        log('waiting for device list');
+        await popup.waitForSelector('.select-device-list button.list');
+        await popup.click('.select-device-list button.list');
+    }
 
     log('waiting for confirm permissions button');
     await waitAndClick(popup, ['@permissions/confirm-button', '@export-address/confirm-button']);
@@ -127,10 +138,21 @@ test('introduce passphrase in popup and device rejects it', async () => {
     await findElementByDataTest(explorerPage, '@submit-button');
 
     [popup] = await openPopup(context, explorerPage, isWebExtension);
+    await popup.waitForLoadState('load');
 
     await findElementByDataTest(popup, '@analytics/continue-button', 40 * 1000);
 
+    if (isWebExtension) {
+        // There is an issue in web extension, core takes time to load and accepting analytics too quickly can cause error
+        await popup.waitForTimeout(1000);
+    }
     await waitAndClick(popup, ['@analytics/continue-button']);
+
+    if (isWebExtension) {
+        log('waiting for device list');
+        await popup.waitForSelector('.select-device-list button.list');
+        await popup.click('.select-device-list button.list');
+    }
 
     log('waiting for confirm permissions button');
     await waitAndClick(popup, ['@permissions/confirm-button', '@export-address/confirm-button']);

--- a/packages/connect-popup/e2e/tests/popup-close.test.ts
+++ b/packages/connect-popup/e2e/tests/popup-close.test.ts
@@ -134,6 +134,12 @@ test.beforeAll(async () => {
         log('beforeEach', 'waiting for popup load state');
         await popup.waitForLoadState('load');
 
+        if (isWebExtension) {
+            log('beforeEach', 'waiting for select device');
+            await popup.waitForSelector('.select-device-list button.list', { state: 'visible' });
+            await popup.click('.select-device-list button.list');
+        }
+
         log('beforeEach', 'waiting for permissions confirm button');
         await popup.waitForSelector('button.confirm', { state: 'visible', timeout: 40000 });
         log('beforeEach', 'clicking on permissions confirm button');
@@ -183,6 +189,20 @@ test.beforeAll(async () => {
         [popup] = await openPopup(context, explorerPage, isWebExtension);
         log('afterEach', 'waiting for popup load state');
         await popup.waitForLoadState('load');
+
+        if (isWebExtension) {
+            log('afterEach', 'waiting for select device');
+            try {
+                await popup.waitForSelector('.select-device-list button.list', {
+                    state: 'visible',
+                    timeout: 5000,
+                });
+                await popup.click('.select-device-list button.list');
+            } catch (_) {
+                // Device is probably remembered
+                // TODO: do this in a better way
+            }
+        }
 
         await popup.waitForSelector('button.confirm', { state: 'visible', timeout: 40000 });
         await popup.click('button.confirm');
@@ -347,6 +367,10 @@ test.beforeAll(async () => {
         });
 
         await popup.waitForLoadState('load');
+        if (isWebExtension) {
+            await popup.waitForSelector('.select-device-list button.list', { state: 'visible' });
+            await popup.click('.select-device-list button.list');
+        }
         await popup.waitForSelector('button.confirm', { state: 'visible', timeout: 40000 });
         await popup.waitForSelector("button[data-test='@permissions/confirm-button']");
         // We are testing that when cancel permissions, popup is closed automatically.

--- a/packages/connect-popup/src/view/selectDevice.ts
+++ b/packages/connect-popup/src/view/selectDevice.ts
@@ -118,6 +118,11 @@ export const selectDevice = (payload: UiRequestSelectDevice['payload']) => {
         'remember-device',
     )[0] as HTMLInputElement;
 
+    const { settings } = getState();
+    if (settings?.useCoreInPopup && settings.env === 'webextension') {
+        rememberCheckbox.checked = true;
+    }
+
     // Show readable devices first
     payload.devices.sort((d1, d2) => {
         if (d1.type === 'unreadable' && d2.type !== 'unreadable') {

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -273,7 +273,8 @@ const initDevice = async (method: AbstractMethod<any>) => {
             devices.length === 1 &&
             devices[0].type !== 'unreadable' &&
             devices[0].features &&
-            !isWebUsb
+            !isWebUsb &&
+            !useCoreInPopup
         ) {
             // there is one device available. use it
             device = _deviceList.getDevice(devices[0].path);


### PR DESCRIPTION
## Description

Always show device selection when bridge and using core in popup. 
Previously, when only 1 device was connected and available, it would automatically choose it, skipping the device selection screen. 
This means the user wouldn't have the option to select "Remeber device", which means the password wouldn't save either. 

Also change the default state of "Remember device" to checked for webextension MV3 environments. 