### PR TITLE
feat(suite-native): add possibility to enable view-only for connected device

### DIFF
--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -781,6 +781,12 @@ export const selectPersistedDeviceStates = (state: DeviceRootState) => {
     return [...devices.map(d => d.state), PORTFOLIO_TRACKER_DEVICE_STATE];
 };
 
+export const selectPhysicalDevices = (state: DeviceRootState) => {
+    const devices = selectDevices(state);
+
+    return devices.filter(device => device.id !== PORTFOLIO_TRACKER_DEVICE_ID);
+};
+
 export const selectIsNoPhysicalDeviceConnected = (state: DeviceRootState) => {
     const devices = selectDevices(state);
 

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -428,6 +428,8 @@ export const en = {
         viewOnly: {
             title: 'View-only',
             subtitle: 'Check balances without connecting your Trezor.',
+            emptySubitle: 'Connect your device to enable view-only',
+            enableButton: 'Enable',
         },
     },
     moduleOnboarding: {

--- a/suite-native/module-settings/package.json
+++ b/suite-native/module-settings/package.json
@@ -20,6 +20,8 @@
         "@suite-common/icons": "workspace:*",
         "@suite-common/suite-config": "workspace:*",
         "@suite-common/suite-constants": "workspace:*",
+        "@suite-common/suite-types": "workspace:*",
+        "@suite-common/wallet-core": "workspace:*",
         "@suite-native/analytics": "workspace:*",
         "@suite-native/atoms": "workspace:*",
         "@suite-native/biometrics": "workspace:*",

--- a/suite-native/module-settings/src/screens/SettingsViewOnly.tsx
+++ b/suite-native/module-settings/src/screens/SettingsViewOnly.tsx
@@ -1,17 +1,52 @@
+import { useDispatch, useSelector } from 'react-redux';
+
 import { Screen, ScreenSubHeader } from '@suite-native/navigation';
-import { Text } from '@suite-native/atoms';
+import { Box, Button, Card, HStack, IconButton, Text } from '@suite-native/atoms';
 import { Translation, useTranslate } from '@suite-native/intl';
+import { selectPhysicalDevices, toggleRememberDevice } from '@suite-common/wallet-core';
+import { TrezorDevice } from '@suite-common/suite-types';
 
 export const SettingsViewOnly = () => {
+    const dispatch = useDispatch();
     const { translate } = useTranslate();
+
+    const devices = useSelector(selectPhysicalDevices);
+
+    const handleViewOnlyChange = (device: TrezorDevice) => {
+        dispatch(toggleRememberDevice({ device }));
+    };
 
     return (
         <Screen
             screenHeader={<ScreenSubHeader content={translate('moduleSettings.viewOnly.title')} />}
         >
-            <Text>
-                <Translation id="moduleSettings.viewOnly.subtitle" />
-            </Text>
+            <Box marginVertical="medium" marginHorizontal="extraLarge" alignItems="center">
+                <Text variant="hint" textAlign="center">
+                    {devices.length ? (
+                        <Translation id="moduleSettings.viewOnly.subtitle" />
+                    ) : (
+                        <Translation id="moduleSettings.viewOnly.emptySubitle" />
+                    )}
+                </Text>
+            </Box>
+            {devices.map(device => (
+                <Card key={device.id}>
+                    <HStack justifyContent="space-between" alignItems="center">
+                        <Text>{device?.label}</Text>
+                        {device.remember ? (
+                            <IconButton
+                                colorScheme="dangerElevation0"
+                                iconName="close"
+                                onPress={() => handleViewOnlyChange(device)}
+                            />
+                        ) : (
+                            <Button onPress={() => handleViewOnlyChange(device)}>
+                                <Translation id="moduleSettings.viewOnly.enableButton" />
+                            </Button>
+                        )}
+                    </HStack>
+                </Card>
+            ))}
         </Screen>
     );
 };

--- a/suite-native/module-settings/tsconfig.json
+++ b/suite-native/module-settings/tsconfig.json
@@ -12,6 +12,12 @@
         {
             "path": "../../suite-common/suite-constants"
         },
+        {
+            "path": "../../suite-common/suite-types"
+        },
+        {
+            "path": "../../suite-common/wallet-core"
+        },
         { "path": "../analytics" },
         { "path": "../atoms" },
         { "path": "../biometrics" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9466,6 +9466,8 @@ __metadata:
     "@suite-common/icons": "workspace:*"
     "@suite-common/suite-config": "workspace:*"
     "@suite-common/suite-constants": "workspace:*"
+    "@suite-common/suite-types": "workspace:*"
+    "@suite-common/wallet-core": "workspace:*"
     "@suite-native/analytics": "workspace:*"
     "@suite-native/atoms": "workspace:*"
     "@suite-native/biometrics": "workspace:*"


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Add possibility to toggle `remember` flag for connected device. No final UI, just a prototype. It effectively prevents the device from being forgotten upon disconnection, but the functionality for ejecting/forgetting/deleting is not yet operational.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/11851
EPIC https://github.com/trezor/trezor-suite/issues/9187

## Screenshots:
<img width="350" alt="image" src="https://github.com/trezor/trezor-suite/assets/3729633/4c980262-36ad-4140-b69f-30175eb20494">
<img width="350" alt="image" src="https://github.com/trezor/trezor-suite/assets/3729633/39c653ea-1dd4-4372-b41e-b5f744ab69b5">
