### PR TITLE
fix(suite): fix exchange currency

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
@@ -13,16 +13,13 @@ import {
 interface ConfirmAddressModalProps
     extends Pick<ConfirmValueModalProps, 'isConfirmed' | 'onCancel' | 'value'> {
     addressPath: string;
-    receiveSymbol?: CryptoSymbol;
 }
 
-export const ConfirmAddressModal = ({
-    addressPath,
-    value,
-    receiveSymbol,
-    ...props
-}: ConfirmAddressModalProps) => {
+export const ConfirmAddressModal = ({ addressPath, value, ...props }: ConfirmAddressModalProps) => {
     const account = useSelector(selectSelectedAccount);
+    const receiveSymbol = useSelector(
+        state => state.wallet.coinmarket.exchange.quotesRequest?.receive,
+    );
     const displayMode = useDisplayMode();
 
     const validateAddress = useCallback(
@@ -56,7 +53,23 @@ export const ConfirmAddressModal = ({
                         networkName: coinSymbol,
                     }}
                 />
-            }
+            );
+        }
+
+        return (
+            <Translation
+                id="TR_ADDRESS_MODAL_TITLE"
+                values={{
+                    networkName: account.symbol.toUpperCase(),
+                }}
+            />
+        );
+    };
+
+    return (
+        <ConfirmValueModal
+            account={account}
+            heading={getHeading()}
             stepLabel={<Translation id="TR_RECEIVE_ADDRESS" />}
             confirmStepLabel={<Translation id="TR_RECEIVE_ADDRESS_MATCH" />}
             copyButtonText={<Translation id="TR_ADDRESS_MODAL_CLIPBOARD" />}

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
@@ -5,13 +5,23 @@ import { Translation } from 'src/components/suite';
 import { useDisplayMode, useSelector } from 'src/hooks/suite';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 import { ConfirmValueModal, ConfirmValueModalProps } from './ConfirmValueModal/ConfirmValueModal';
+import {
+    cryptoToCoinSymbol,
+    cryptoToNetworkSymbol,
+} from 'src/utils/wallet/coinmarket/cryptoSymbolUtils';
 
 interface ConfirmAddressModalProps
     extends Pick<ConfirmValueModalProps, 'isConfirmed' | 'onCancel' | 'value'> {
     addressPath: string;
+    receiveSymbol?: CryptoSymbol;
 }
 
-export const ConfirmAddressModal = ({ addressPath, value, ...props }: ConfirmAddressModalProps) => {
+export const ConfirmAddressModal = ({
+    addressPath,
+    value,
+    receiveSymbol,
+    ...props
+}: ConfirmAddressModalProps) => {
     const account = useSelector(selectSelectedAccount);
     const displayMode = useDisplayMode();
 
@@ -22,13 +32,29 @@ export const ConfirmAddressModal = ({ addressPath, value, ...props }: ConfirmAdd
 
     if (!account) return null;
 
-    return (
-        <ConfirmValueModal
-            account={account}
-            heading={
+    const getHeading = () => {
+        if (receiveSymbol) {
+            const coinSymbol = cryptoToCoinSymbol(receiveSymbol).toUpperCase();
+            const networkSymbol = cryptoToNetworkSymbol(receiveSymbol)?.toUpperCase();
+
+            if (networkSymbol && coinSymbol !== networkSymbol) {
+                return (
+                    <Translation
+                        id="TR_ADDRESS_MODAL_TITLE_EXCHANGE"
+                        values={{
+                            networkName: networkSymbol,
+                            networkCurrencyName: coinSymbol,
+                        }}
+                    />
+                );
+            }
+
+            return (
                 <Translation
                     id="TR_ADDRESS_MODAL_TITLE"
-                    values={{ networkName: account.symbol.toUpperCase() }}
+                    values={{
+                        networkName: coinSymbol,
+                    }}
                 />
             }
             stepLabel={<Translation id="TR_RECEIVE_ADDRESS" />}

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/DeviceContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/DeviceContextModal.tsx
@@ -29,9 +29,6 @@ export const DeviceContextModal = ({
 }: ReduxModalProps<typeof MODAL.CONTEXT_DEVICE>) => {
     const device = useSelector(selectDevice);
     const intl = useIntl();
-    const receiveSymbol = useSelector(
-        state => state.wallet.coinmarket.exchange.quotesRequest?.receive,
-    );
 
     if (!device) return null;
 
@@ -91,7 +88,6 @@ export const DeviceContextModal = ({
                 <ConfirmAddressModal
                     value={data.address}
                     addressPath={data.serializedPath}
-                    receiveSymbol={receiveSymbol}
                     onCancel={abort}
                 />
             ) : null;

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/DeviceContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/DeviceContextModal.tsx
@@ -29,6 +29,9 @@ export const DeviceContextModal = ({
 }: ReduxModalProps<typeof MODAL.CONTEXT_DEVICE>) => {
     const device = useSelector(selectDevice);
     const intl = useIntl();
+    const receiveSymbol = useSelector(
+        state => state.wallet.coinmarket.exchange.quotesRequest?.receive,
+    );
 
     if (!device) return null;
 
@@ -88,6 +91,7 @@ export const DeviceContextModal = ({
                 <ConfirmAddressModal
                     value={data.address}
                     addressPath={data.serializedPath}
+                    receiveSymbol={receiveSymbol}
                     onCancel={abort}
                 />
             ) : null;

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -1932,6 +1932,10 @@ export default defineMessages({
         defaultMessage: '{networkName} receive address',
         id: 'TR_ADDRESS_MODAL_TITLE',
     },
+    TR_ADDRESS_MODAL_TITLE_EXCHANGE: {
+        defaultMessage: '{networkCurrencyName} receive address on {networkName} network',
+        id: 'TR_ADDRESS_MODAL_TITLE_EXCHANGE',
+    },
     TR_XPUB_MODAL_CLIPBOARD: {
         defaultMessage: 'Copy public key',
         id: 'TR_XPUB_MODAL_CLIPBOARD',


### PR DESCRIPTION
#  Wrong cryptocurrency symbol

## Behaviour
**Current result**: in modal window there is `BTC receive address`
**Expected result**: in modal window there should be `LTC receive address`
![image-20231208-124244](https://github.com/trezor/trezor-suite/assets/15160619/3a622e2f-2026-4c3d-8d8e-8cbf2f437819)
![image-20231208-113942](https://github.com/trezor/trezor-suite/assets/15160619/d3373c29-c893-4718-8635-00df48ccf901)

## Info:
Steps to reproduce (macOS, Trezor Suite - desktop version 23.12.1):

## Steps to reproduce the behavior:
1. Open trade section in Trezor suite 
2. Go to exchange section
3. Choose BTC x LTC pair and fill out desired BTC amount to exchange and choose offer
4. Here after clicking on “Confirm on Trezor” button in modal window there is mentioned, that its BTC, not LTC address
**Expected behavior**
A clear and concise description of what you expected to happen.

resolves #11927