### PR TITLE
Node bridge status page data

### DIFF
--- a/packages/node-utils/src/http.ts
+++ b/packages/node-utils/src/http.ts
@@ -3,7 +3,7 @@ import * as net from 'net';
 import * as url from 'url';
 
 import type { RequiredKey } from '@trezor/type-utils';
-import { TypedEmitter } from '@trezor/utils';
+import { LogMessage, TypedEmitter } from '@trezor/utils';
 import { arrayPartition } from '@trezor/utils';
 
 import { getFreePort } from './getFreePort';
@@ -16,6 +16,7 @@ type Logger = {
     info: LogFn;
     warn: LogFn;
     error: LogFn;
+    getLog: () => LogMessage[];
 };
 
 type OriginalLogFn = (topic: string, message: string | string[]) => void;
@@ -23,6 +24,7 @@ type OriginalLogger = {
     info: OriginalLogFn;
     warn: OriginalLogFn;
     error: OriginalLogFn;
+    getLog?: () => LogMessage[];
 };
 
 type RequestWithParams = Request & {
@@ -63,9 +65,9 @@ type BaseEvents = {
  * Http server listening on localhost.
  */
 export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents> {
-    server: http.Server;
+    public server: http.Server;
+    public logger: Logger;
     private routes: Route[] = [];
-    private logger: Logger;
     private readonly emitter: TypedEmitter<BaseEvents> = this;
     private port?: number;
     private sockets: Record<number, net.Socket> = {};
@@ -83,6 +85,7 @@ export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents>
             info: (message: string | string[]) => logger.info(`${this.logName}`, message),
             warn: (message: string | string[]) => logger.warn(`${this.logName}`, message),
             error: (message: string | string[]) => logger.error(`${this.logName}`, message),
+            getLog: () => (logger.getLog ? logger.getLog() : []),
         };
         // this.logger = logger;
         this.server = http.createServer(this.onRequest);

--- a/packages/transport-bridge/src/http.ts
+++ b/packages/transport-bridge/src/http.ts
@@ -196,8 +196,31 @@ export class TrezordNode {
             ]);
 
             app.get('/status', [
+                async (_req, res) => {
+                    const enumerateResult = await this.api.enumerate();
+                    const props = {
+                        intro: `To download full logs go to http://127.0.0.1:${this.port}/logs`,
+                        version: this.version,
+                        devices: enumerateResult.success ? enumerateResult.payload.descriptors : [],
+                        logs: app.logger.getLog().slice(-20),
+                    };
+
+                    res.end(JSON.stringify(props, null, 2));
+                },
+            ]);
+
+            app.get('/logs', [
                 (_req, res) => {
-                    res.end(`hello, I am bridge in node, version: ${this.version}`);
+                    res.writeHead(200, {
+                        'Content-Type': 'text/plain',
+                        'Content-Disposition': 'attachment; filename=trezor-bridge.txt',
+                    });
+                    res.end(
+                        app.logger
+                            .getLog()
+                            .map(l => l.message.join('. '))
+                            .join('.\n'),
+                    );
                 },
             ]);
 


### PR DESCRIPTION
cherry-picked from #11532

So far only make the data needed for the bridge status page available as JSON. 

There is also `http://127.0.0.1:21325/logs/` which prompts browser to download extended logs from the bridge process.

![image](https://github.com/trezor/trezor-suite/assets/30367552/a05f6088-5266-4379-b6c9-fefe998801d2)

We would like to have some nice UI in the end but it is somewhat controversial so I decided to push it to a new branch https://github.com/trezor/trezor-suite/compare/transport-bridge-ui?expand=1