### PR TITLE
fix(suite): hide devkit flag during installation of custom firmware

### DIFF
--- a/packages/suite/src/components/firmware/FirmwareOffer.tsx
+++ b/packages/suite/src/components/firmware/FirmwareOffer.tsx
@@ -84,7 +84,7 @@ export const FirmwareOffer = ({
         <Version $isNew data-test="@firmware/offer-version/new">
             {futureFirmwareType ? translationString(futureFirmwareType) : ''}
             {nextVersion ? ` ${nextVersion}` : ''}
-            {useDevkit ? ' DEVKIT' : ''}
+            {!customFirmware && useDevkit ? ' DEVKIT' : ''}
         </Version>
     );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Devkit binaries are only used in standard firmware installation, not when installing custom firmware - where the user picks the binary. Removing the text "DEVKIT" from custom firmware modal.

## Screenshots:

![Screenshot 2024-04-10 at 14 10 38](https://github.com/trezor/trezor-suite/assets/42465546/896ffd71-703f-43b8-a530-5aacb4550dfd)

