### PR TITLE
feat(connect): automatically update outdated device language

### DIFF
--- a/packages/connect/src/api/changeLanguage.ts
+++ b/packages/connect/src/api/changeLanguage.ts
@@ -1,12 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/ChangeLanguage.js
 
 import { AbstractMethod } from '../core/AbstractMethod';
-import { ERRORS } from '../constants';
 import { UI, createUiMessage } from '../events';
 import { Assert } from '@trezor/schema-utils';
 import { ChangeLanguage as ChangeLanguageSchema } from '../types/api/changeLanguage';
-import { httpRequest } from '../utils/assets';
-
 export default class ChangeLanguage extends AbstractMethod<'changeLanguage', ChangeLanguageSchema> {
     init() {
         this.allowDeviceMode = [UI.INITIALIZE, UI.SEEDLESS];
@@ -18,16 +15,7 @@ export default class ChangeLanguage extends AbstractMethod<'changeLanguage', Cha
 
         Assert(ChangeLanguageSchema, payload);
 
-        if (payload.binary) {
-            this.params = {
-                binary: payload.binary,
-            };
-        } else {
-            this.params = {
-                language: payload.language,
-                baseUrl: payload.baseUrl || 'https://data.trezor.io',
-            };
-        }
+        this.params = payload;
     }
 
     async confirmation() {
@@ -54,64 +42,12 @@ export default class ChangeLanguage extends AbstractMethod<'changeLanguage', Cha
         return uiResp.payload;
     }
 
-    private async uploadTranslationData(payload: ArrayBuffer | null) {
-        if (!this.device.commands) {
-            throw ERRORS.TypedError('Runtime', 'uploadTranslationData: device.commands is not set');
-        }
-
-        if (payload === null) {
-            const response = await this.device.commands.typedCall(
-                'ChangeLanguage',
-                ['Success'],
-                { data_length: 0 }, // For en-US where we just send `ChangeLanguage(size=0)`
-            );
-
-            return response.message;
-        }
-
-        const length = payload.byteLength;
-
-        let response = await this.device.commands.typedCall(
-            'ChangeLanguage',
-            ['TranslationDataRequest', 'Success'],
-            { data_length: length },
-        );
-
-        while (response.type !== 'Success') {
-            const start = response.message.data_offset!;
-            const end = response.message.data_offset! + response.message.data_length!;
-            const chunk = payload.slice(start, end);
-
-            response = await this.device.commands.typedCall(
-                'TranslationDataAck',
-                ['TranslationDataRequest', 'Success'],
-                {
-                    data_chunk: Buffer.from(chunk).toString('hex'),
-                },
-            );
-        }
-
-        return response.message;
-    }
-
-    async run() {
-        const { language, binary, baseUrl } = this.params;
-
-        if (language === 'en-US') {
-            return this.uploadTranslationData(null);
-        }
-
+    run() {
+        const { language, binary } = this.params;
         if (binary) {
-            return this.uploadTranslationData(binary);
+            return this.device.changeLanguage({ binary });
+        } else {
+            return this.device.changeLanguage({ language });
         }
-
-        const version = this.device.getVersion().join('.');
-        const model = this.device.features.internal_model;
-
-        const url = `${baseUrl}/firmware/translations/${model.toLowerCase()}/translation-${model.toUpperCase()}-${language}-${version}.bin`;
-
-        const downloadedBinary = await httpRequest(url, 'binary');
-
-        return this.uploadTranslationData(downloadedBinary);
     }
 }

--- a/packages/connect/src/data/getLanguage.ts
+++ b/packages/connect/src/data/getLanguage.ts
@@ -1,0 +1,15 @@
+import { httpRequest } from '../utils/assets';
+
+export const getLanguage = ({
+    language,
+    version,
+    internal_model,
+}: {
+    language: string;
+    version: number[];
+    internal_model: string;
+}) => {
+    const url = `https://data.trezor.io/firmware/translations/${internal_model.toLowerCase()}/translation-${internal_model.toUpperCase()}-${language}-${version.join('.')}.bin`;
+
+    return httpRequest(url, 'binary');
+};

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -27,6 +27,7 @@ import {
     VersionArray,
 } from '../types';
 import { models } from '../data/models';
+import { getLanguage } from '../data/getLanguage';
 
 // custom log
 const _log = initLog('Device');
@@ -527,6 +528,66 @@ export class Device extends TypedEmitter<DeviceEvents> {
     async getFeatures() {
         const { message } = await this.getCommands().typedCall('GetFeatures', 'Features', {});
         this._updateFeatures(message);
+
+    async changeLanguage({
+        language,
+        binary,
+    }: { language?: undefined; binary: ArrayBuffer } | { language: string; binary?: undefined }) {
+        if (language === 'en-US') {
+            return this._uploadTranslationData(null);
+        }
+
+        if (binary) {
+            return this._uploadTranslationData(binary);
+        }
+
+        const downloadedBinary = await getLanguage({
+            language,
+            version: this.getVersion(),
+            internal_model: this.features.internal_model,
+        });
+
+        return this._uploadTranslationData(downloadedBinary);
+    }
+
+    private async _uploadTranslationData(payload: ArrayBuffer | null) {
+        if (!this.commands) {
+            throw ERRORS.TypedError('Runtime', 'uploadTranslationData: device.commands is not set');
+        }
+
+        if (payload === null) {
+            const response = await this.commands.typedCall(
+                'ChangeLanguage',
+                ['Success'],
+                { data_length: 0 }, // For en-US where we just send `ChangeLanguage(size=0)`
+            );
+
+            return response.message;
+        }
+
+        const length = payload.byteLength;
+
+        let response = await this.commands.typedCall(
+            'ChangeLanguage',
+            ['TranslationDataRequest', 'Success'],
+            { data_length: length },
+        );
+
+        while (response.type !== 'Success') {
+            const start = response.message.data_offset!;
+            const end = response.message.data_offset! + response.message.data_length!;
+            const chunk = payload.slice(start, end);
+
+            response = await this.commands.typedCall(
+                'TranslationDataAck',
+                ['TranslationDataRequest', 'Success'],
+                {
+                    data_chunk: Buffer.from(chunk).toString('hex'),
+                },
+            );
+        }
+
+        return response.message;
     }
 
     _updateFeatures(feat: Features) {

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -529,6 +529,21 @@ export class Device extends TypedEmitter<DeviceEvents> {
         const { message } = await this.getCommands().typedCall('GetFeatures', 'Features', {});
         this._updateFeatures(message);
 
+        if (
+            !this.features.language_version_matches &&
+            this.features.language &&
+            this.atLeast('2.7.0')
+        ) {
+            _log.info('language version mismatch. silently updating...');
+
+            try {
+                await this.changeLanguage({ language: this.features.language });
+            } catch (err) {
+                _log.error('change language failed silently', err);
+            }
+        }
+    }
+
     async changeLanguage({
         language,
         binary,


### PR DESCRIPTION
cherry-picked from #11300

changes:
- [1d9e319](https://github.com/trezor/trezor-suite/pull/11955/commits/1d9e319ae0a4018037c71cd6e05d67ba3479d3df)
  - this moves logic from `packages/connect/src/api/changeLanguage.ts` into `packages/connect/src/device/Device.ts` since this logic needs to be used internally from inside "seamless firmware update" which is being worked on in #11300 
  - it also separates `packages/connect/src/data/getLanguage.ts` to make it usable separately in #11300
- [6f9517c](https://github.com/trezor/trezor-suite/pull/11955/commits/6f9517c77adaf80b33bb82fb531b96a155f7fc2d) adds automatic language update whenever connect (during device.getFeatures call) detects that `features.language_version_matches` was set to false which means that language blob loaded in the device is not up to date.
