### PR TITLE
nitpick: silence eslint warn for console logs in logs util

### DIFF
--- a/packages/utils/src/logs.ts
+++ b/packages/utils/src/logs.ts
@@ -65,6 +65,7 @@ export class Log {
     log(...args: any[]) {
         this.addMessage({ level: 'log', prefix: this.prefix }, ...args);
         if (this.enabled) {
+            // eslint-disable-next-line no-console
             console.log(`%c${this.prefix}`, this.css, ...args);
         }
     }
@@ -79,6 +80,7 @@ export class Log {
     info(...args: any[]) {
         this.addMessage({ level: 'info', prefix: this.prefix }, ...args);
         if (this.enabled) {
+            // eslint-disable-next-line no-console
             console.info(`%c${this.prefix}`, this.css, ...args);
         }
     }
@@ -94,8 +96,10 @@ export class Log {
         this.addMessage({ level: 'debug', prefix: this.prefix }, ...args);
         if (this.enabled) {
             if (this.css) {
+                // eslint-disable-next-line no-console
                 console.log(`%c${this.prefix}`, this.css, ...args);
             } else {
+                // eslint-disable-next-line no-console
                 console.log(this.prefix, ...args);
             }
         }


### PR DESCRIPTION
silence eslint complaining about console.log in logs util. This is the least controversial eslint silence ever.

![image](https://github.com/trezor/trezor-suite/assets/30367552/7b35d2fd-7f35-41e3-b3e7-db60c0ea5255)
