### PR TITLE
fix(suite): no RBF in transaction review modal for evm

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
@@ -325,21 +325,23 @@ export const TransactionReviewSummary = ({
                         <Translation id={broadcast ? 'TR_ON' : 'TR_OFF'} />
                     </ReviewRbfLeftDetailsLineRight>
                 </LeftDetailsRow>
-                {isFeatureFlagEnabled('RBF') && network.features?.includes('rbf') && (
-                    <LeftDetailsRow>
-                        <ReviewRbfLeftDetailsLineLeft>
-                            <Icon size={12} color={theme.textSubdued} icon="RBF" />
-                            <Translation id="RBF" />
-                        </ReviewRbfLeftDetailsLineLeft>
+                {isFeatureFlagEnabled('RBF') &&
+                    network.features?.includes('rbf') &&
+                    network.networkType !== 'ethereum' && (
+                        <LeftDetailsRow>
+                            <ReviewRbfLeftDetailsLineLeft>
+                                <Icon size={12} color={theme.textSubdued} icon="RBF" />
+                                <Translation id="RBF" />
+                            </ReviewRbfLeftDetailsLineLeft>
 
-                        <ReviewRbfLeftDetailsLineRight
-                            $color={tx.rbf ? theme.textPrimaryDefault : theme.textAlertYellow}
-                            $uppercase
-                        >
-                            <Translation id={tx.rbf ? 'TR_ON' : 'TR_OFF'} />
-                        </ReviewRbfLeftDetailsLineRight>
-                    </LeftDetailsRow>
-                )}
+                            <ReviewRbfLeftDetailsLineRight
+                                $color={tx.rbf ? theme.textPrimaryDefault : theme.textAlertYellow}
+                                $uppercase
+                            >
+                                <Translation id={tx.rbf ? 'TR_ON' : 'TR_OFF'} />
+                            </ReviewRbfLeftDetailsLineRight>
+                        </LeftDetailsRow>
+                    )}
                 {tx.inputs.length !== 0 && (
                     <LeftDetailsBottom>
                         <Separator />


### PR DESCRIPTION
## Description

Resolves https://satoshilabs.slack.com/archives/C0543DJBK0C/p1712573879611759

User can always "bump fee" on EVM.
The best solution is just to hide it in review modal as `rbf` in networks config mean that we can bump fee on specific network and it is on many places and it does not make sense to add if network === ethereum conditions everywhere.