### PR TITLE
Memoize CJ prison selector

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -89,6 +89,7 @@
         "pako": "^2.1.0",
         "pdfmake": "^0.2.9",
         "polished": "^4.3.1",
+        "proxy-memoize": "2.0.2",
         "qrcode.react": "^3.1.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11125,6 +11125,7 @@ __metadata:
     pako: "npm:^2.1.0"
     pdfmake: "npm:^0.2.9"
     polished: "npm:^4.3.1"
+    proxy-memoize: "npm:2.0.2"
     qrcode.react: "npm:^3.1.0"
     react: "npm:18.2.0"
     react-dom: "npm:18.2.0"


### PR DESCRIPTION
## Description

After changes in https://github.com/trezor/trezor-suite/commit/02b15b43db9d2ffa063cba80199c00b949a34dd6, accessing send form from CJ account sometimes results in endless loop of `getSendFormDraftThunk`. By memoizing `selectRegisteredUtxosByAccountKey` output instead of returning new object every time, this should be fixed.

## Related Issue

Should resolve #11950
