### PR TITLE
fix(suite-native): correct onboarding animation height

### DIFF
--- a/suite-native/module-onboarding/src/screens/ConnectTrezorScreen.tsx
+++ b/suite-native/module-onboarding/src/screens/ConnectTrezorScreen.tsx
@@ -14,12 +14,14 @@ import { ConnectDeviceAnimation } from '@suite-native/device';
 import { OnboardingFooter } from '../components/OnboardingFooter';
 import { OnboardingScreen } from '../components/OnboardingScreen';
 
-const ANIMATION_HEIGHT = Dimensions.get('screen').height * 0.35;
+const ANIMATION_SCALE = 0.35;
+const ANIMATION_HEIGHT = Dimensions.get('screen').height * ANIMATION_SCALE;
+const ANIMATION_WIDTH = Dimensions.get('screen').width * ANIMATION_SCALE;
 
 const animationStyle = prepareNativeStyle(() => ({
     // Both height and width has to be set https://github.com/lottie-react-native/lottie-react-native/blob/master/MIGRATION-5-TO-6.md#updating-the-style-props
     height: ANIMATION_HEIGHT,
-    width: '100%',
+    width: ANIMATION_WIDTH,
     borderColor: 'transparent',
 }));
 


### PR DESCRIPTION
Resolve [#11694](https://github.com/trezor/trezor-suite/issues/11694)

<img width="319" alt="Screenshot 2024-04-10 at 21 58 32" src="https://github.com/trezor/trezor-suite/assets/2011829/b5240357-26a3-4952-8379-97e1902585a7">
