### PR TITLE
chore(connect): remove dead code

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -223,9 +223,6 @@ export class Device extends TypedEmitter<DeviceEvents> {
                 }
             }
 
-            if (this.releasePromise) {
-                await this.releasePromise;
-            }
             this.releasePromise = this.transport.release({
                 session: this.activitySessionID,
                 path: this.originalDescriptor.path,


### PR DESCRIPTION
while working on #11532  I noticed this little chunk of dead code.

`releasePromise` is not awaitable. It would need to be `await releasePromise.promise`. So I presume it is pretty safe to delete.