### PR TITLE
Feat/send module init

### DIFF
--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -54,6 +54,7 @@
         "@suite-native/module-onboarding": "workspace:*",
         "@suite-native/module-passphrase": "workspace:*",
         "@suite-native/module-receive": "workspace:*",
+        "@suite-native/module-send": "workspace:*",
         "@suite-native/module-settings": "workspace:*",
         "@suite-native/navigation": "workspace:*",
         "@suite-native/notifications": "workspace:*",

--- a/suite-native/app/src/navigation/RootStackNavigator.tsx
+++ b/suite-native/app/src/navigation/RootStackNavigator.tsx
@@ -21,6 +21,7 @@ import { ConnectDeviceStackNavigator } from '@suite-native/module-connect-device
 import { AddCoinAccountStackNavigator } from '@suite-native/module-add-accounts';
 import { DeviceInfoModalScreen, useHandleDeviceConnection } from '@suite-native/device';
 import { PassphraseStackNavigator } from '@suite-native/module-passphrase';
+import { SendStackNavigator } from '@suite-native/module-send';
 
 import { AppTabNavigator } from './AppTabNavigator';
 
@@ -94,6 +95,7 @@ export const RootStackNavigator = () => {
                     animation: 'slide_from_bottom',
                 }}
             />
+            <RootStack.Screen name={RootStackRoutes.SendStack} component={SendStackNavigator} />
         </RootStack.Navigator>
     );
 };

--- a/suite-native/app/tsconfig.json
+++ b/suite-native/app/tsconfig.json
@@ -45,6 +45,7 @@
         { "path": "../module-onboarding" },
         { "path": "../module-passphrase" },
         { "path": "../module-receive" },
+        { "path": "../module-send" },
         { "path": "../module-settings" },
         { "path": "../navigation" },
         { "path": "../notifications" },

--- a/suite-native/feature-flags/src/featureFlagsSlice.ts
+++ b/suite-native/feature-flags/src/featureFlagsSlice.ts
@@ -1,12 +1,13 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 import { isAndroid } from '@trezor/env-utils';
-import { isDebugEnv } from '@suite-native/config';
+import { isDebugEnv, isDevelopOrDebugEnv } from '@suite-native/config';
 
 export const FeatureFlag = {
     IsDeviceConnectEnabled: 'isDeviceConnectEnabled',
     IsPassphraseEnabled: 'isPassphraseEnabled',
-    IsViewOnlyEnabled: 'IsViewOnlyEnabled',
+    IsViewOnlyEnabled: 'isViewOnlyEnabled',
+    IsSendEnabled: 'isSendEnabled',
 } as const;
 export type FeatureFlag = (typeof FeatureFlag)[keyof typeof FeatureFlag];
 
@@ -20,12 +21,14 @@ export const featureFlagsInitialState: FeatureFlagsState = {
     [FeatureFlag.IsDeviceConnectEnabled]: isAndroid(),
     [FeatureFlag.IsPassphraseEnabled]: isDebugEnv(),
     [FeatureFlag.IsViewOnlyEnabled]: isDebugEnv(),
+    [FeatureFlag.IsSendEnabled]: isAndroid() && isDevelopOrDebugEnv(),
 };
 
 export const featureFlagsPersistedKeys: Array<keyof FeatureFlagsState> = [
     FeatureFlag.IsDeviceConnectEnabled,
     FeatureFlag.IsPassphraseEnabled,
     FeatureFlag.IsViewOnlyEnabled,
+    FeatureFlag.IsSendEnabled,
 ];
 
 export const featureFlagsSlice = createSlice({

--- a/suite-native/module-dev-utils/src/components/FeatureFlags.tsx
+++ b/suite-native/module-dev-utils/src/components/FeatureFlags.tsx
@@ -5,6 +5,7 @@ const featureFlagsTitleMap = {
     [FeatureFlagEnum.IsDeviceConnectEnabled]: 'Connect device',
     [FeatureFlagEnum.IsPassphraseEnabled]: 'Passphrase',
     [FeatureFlagEnum.IsViewOnlyEnabled]: 'View-only',
+    [FeatureFlagEnum.IsSendEnabled]: 'Send',
 } as const satisfies Record<FeatureFlagEnum, string>;
 
 const FeatureFlag = ({ featureFlag }: { featureFlag: FeatureFlagEnum }) => {

--- a/suite-native/module-home/src/screens/HomeScreen/components/PortfolioContent.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/PortfolioContent.tsx
@@ -29,6 +29,7 @@ export const PortfolioContent = forwardRef<PortfolioContentRef>((_props, ref) =>
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
 
     const [isUsbDeviceConnectFeatureEnabled] = useFeatureFlag(FeatureFlag.IsDeviceConnectEnabled);
+    const [isSendEnabled] = useFeatureFlag(FeatureFlag.IsSendEnabled);
 
     const handleImportAssets = () => {
         navigation.navigate(RootStackRoutes.AccountsImport, {

--- a/suite-native/module-home/src/screens/HomeScreen/components/PortfolioContent.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/PortfolioContent.tsx
@@ -10,9 +10,15 @@ import {
     AccountsImportStackRoutes,
     RootStackParamList,
     RootStackRoutes,
+    SendStackRoutes,
     StackNavigationProps,
 } from '@suite-native/navigation';
-import { selectIsPortfolioTrackerDevice } from '@suite-common/wallet-core';
+import {
+    AccountsRootState,
+    DeviceRootState,
+    selectDeviceAccountsByNetworkSymbol,
+    selectIsPortfolioTrackerDevice,
+} from '@suite-common/wallet-core';
 import { Translation } from '@suite-native/intl';
 
 import { PortfolioGraph, PortfolioGraphRef } from './PortfolioGraph';
@@ -28,6 +34,10 @@ export const PortfolioContent = forwardRef<PortfolioContentRef>((_props, ref) =>
 
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
 
+    const testnetAccounts = useSelector((state: AccountsRootState & DeviceRootState) =>
+        selectDeviceAccountsByNetworkSymbol(state, 'test'),
+    );
+
     const [isUsbDeviceConnectFeatureEnabled] = useFeatureFlag(FeatureFlag.IsDeviceConnectEnabled);
     const [isSendEnabled] = useFeatureFlag(FeatureFlag.IsSendEnabled);
 
@@ -39,6 +49,10 @@ export const PortfolioContent = forwardRef<PortfolioContentRef>((_props, ref) =>
 
     const handleReceive = () => {
         navigation.navigate(RootStackRoutes.ReceiveModal, { closeActionType: 'back' });
+    };
+
+    const handleSend = () => {
+        navigation.navigate(RootStackRoutes.SendStack, { screen: SendStackRoutes.SendAccounts });
     };
 
     useImperativeHandle(
@@ -82,6 +96,18 @@ export const PortfolioContent = forwardRef<PortfolioContentRef>((_props, ref) =>
                             </Button>
                         </Box>
                     </>
+                )}
+                {/* TODO: remove this button when there is a proper design of the send flow ready */}
+                {isSendEnabled && (
+                    <Box>
+                        <Button
+                            size="large"
+                            onPress={handleSend}
+                            disabled={testnetAccounts.length === 0}
+                        >
+                            Send crypto
+                        </Button>
+                    </Box>
                 )}
             </VStack>
         </VStack>

--- a/suite-native/module-send/package.json
+++ b/suite-native/module-send/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "@suite-native/module-send",
+    "version": "1.0.0",
+    "private": true,
+    "license": "See LICENSE.md in repo root",
+    "sideEffects": false,
+    "main": "src/index",
+    "scripts": {
+        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "type-check": "yarn g:tsc --build"
+    },
+    "dependencies": {
+        "@react-navigation/native": "6.1.10",
+        "@react-navigation/native-stack": "6.9.18",
+        "@suite-common/wallet-core": "workspace:*",
+        "@suite-common/wallet-types": "workspace:*",
+        "@suite-native/accounts": "workspace:*",
+        "@suite-native/atoms": "workspace:*",
+        "@suite-native/device-manager": "workspace:*",
+        "@suite-native/navigation": "workspace:*",
+        "react": "18.2.0",
+        "react-redux": "8.0.7"
+    }
+}

--- a/suite-native/module-send/src/index.ts
+++ b/suite-native/module-send/src/index.ts
@@ -1,0 +1,1 @@
+export * from './navigation/SendStackNavigator';

--- a/suite-native/module-send/src/navigation/SendStackNavigator.tsx
+++ b/suite-native/module-send/src/navigation/SendStackNavigator.tsx
@@ -1,0 +1,22 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+
+import {
+    SendStackParamList,
+    SendStackRoutes,
+    stackNavigationOptionsConfig,
+} from '@suite-native/navigation';
+
+import { SendAccountsScreen } from '../screens/SendAccountsScreen';
+import { SendFormScreen } from '../screens/SendFormScreen';
+
+const SendStack = createNativeStackNavigator<SendStackParamList>();
+
+export const SendStackNavigator = () => (
+    <SendStack.Navigator
+        initialRouteName={SendStackRoutes.SendAccounts}
+        screenOptions={stackNavigationOptionsConfig}
+    >
+        <SendStack.Screen name={SendStackRoutes.SendAccounts} component={SendAccountsScreen} />
+        <SendStack.Screen name={SendStackRoutes.SendForm} component={SendFormScreen} />
+    </SendStack.Navigator>
+);

--- a/suite-native/module-send/src/screens/SendAccountsScreen.tsx
+++ b/suite-native/module-send/src/screens/SendAccountsScreen.tsx
@@ -1,0 +1,35 @@
+import { DeviceManagerScreenHeader } from '@suite-native/device-manager';
+import { AccountsList } from '@suite-native/accounts';
+import {
+    GoBackIcon,
+    Screen,
+    ScreenSubHeader,
+    SendStackParamList,
+    SendStackRoutes,
+    StackProps,
+} from '@suite-native/navigation';
+import { AccountKey } from '@suite-common/wallet-types';
+
+// TODO: So far we do not want enable send form for any other network than Bitcoin Testnet.
+// This filter will be removed in a follow up PR.
+const TESTNET_FILTER = 'Bitcoin Testnet';
+
+export const SendAccountsScreen = ({
+    navigation,
+}: StackProps<SendStackParamList, SendStackRoutes.SendAccounts>) => {
+    const navigateToSendFormScreen = (accountKey: AccountKey) =>
+        navigation.navigate(SendStackRoutes.SendForm, {
+            accountKey,
+        });
+
+    // TODO: move text content to @suite-native/intl package when is copy ready
+    return (
+        <Screen
+            screenHeader={<DeviceManagerScreenHeader />}
+            subheader={<ScreenSubHeader content={'Send from'} leftIcon={<GoBackIcon />} />}
+        >
+            {/* TODO: Enable filtering same as receive screen has. */}
+            <AccountsList onSelectAccount={navigateToSendFormScreen} filterValue={TESTNET_FILTER} />
+        </Screen>
+    );
+};

--- a/suite-native/module-send/src/screens/SendFormScreen.tsx
+++ b/suite-native/module-send/src/screens/SendFormScreen.tsx
@@ -1,0 +1,42 @@
+import { useSelector } from 'react-redux';
+
+import {
+    GoBackIcon,
+    Screen,
+    ScreenSubHeader,
+    SendStackParamList,
+    SendStackRoutes,
+    StackProps,
+} from '@suite-native/navigation';
+import { Box, Text, VStack } from '@suite-native/atoms';
+import { AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
+
+export const SendFormScreen = ({
+    route: { params },
+}: StackProps<SendStackParamList, SendStackRoutes.SendForm>) => {
+    const { accountKey } = params;
+
+    const account = useSelector((state: AccountsRootState) =>
+        selectAccountByKey(state, accountKey),
+    );
+
+    if (!account) return;
+
+    // TODO: move text content to @suite-native/intl package when is copy ready
+    return (
+        <Screen
+            subheader={<ScreenSubHeader content={'Send form screen'} leftIcon={<GoBackIcon />} />}
+        >
+            <VStack flex={1} justifyContent="center" alignItems="center">
+                <Box>
+                    <Text textAlign="center">Send Form Screen mockup of account:</Text>
+                    <Text textAlign="center">{account.accountLabel}</Text>
+                </Box>
+                <Text textAlign="center">
+                    This screen will soon contain a form that allows users to send crypto from
+                    Trezor Suite Lite. Fingers crossed.
+                </Text>
+            </VStack>
+        </Screen>
+    );
+};

--- a/suite-native/module-send/tsconfig.json
+++ b/suite-native/module-send/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": { "outDir": "libDev" },
+    "references": [
+        {
+            "path": "../../suite-common/wallet-core"
+        },
+        {
+            "path": "../../suite-common/wallet-types"
+        },
+        { "path": "../accounts" },
+        { "path": "../atoms" },
+        { "path": "../device-manager" },
+        { "path": "../navigation" }
+    ]
+}

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -18,6 +18,7 @@ import {
     ConnectDeviceStackRoutes,
     AddCoinAccountStackRoutes,
     PassphraseStackRoutes,
+    SendStackRoutes,
 } from './routes';
 
 type AddCoinFlowParams = RequireAllOrNone<
@@ -58,6 +59,13 @@ export type SettingsStackParamList = {
 
 export type ReceiveStackParamList = {
     [ReceiveStackRoutes.ReceiveAccounts]: undefined;
+};
+
+export type SendStackParamList = {
+    [SendStackRoutes.SendAccounts]: undefined;
+    [SendStackRoutes.SendForm]: {
+        accountKey: AccountKey;
+    };
 };
 
 export type AppTabsParamList = {
@@ -134,4 +142,5 @@ export type RootStackParamList = {
     [RootStackRoutes.DeviceInfo]: undefined;
     [RootStackRoutes.AddCoinAccountStack]: NavigatorScreenParams<AddCoinAccountStackParamList>;
     [RootStackRoutes.PassphraseStack]: NavigatorScreenParams<PassphraseStackParamList>;
+    [RootStackRoutes.SendStack]: NavigatorScreenParams<SendStackParamList>;
 };

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -8,6 +8,7 @@ export enum RootStackRoutes {
     AccountSettings = 'AccountSettings',
     TransactionDetail = 'TransactionDetail',
     ReceiveModal = 'ReceiveModal',
+    SendStack = 'SendStack',
     DeviceInfo = 'DeviceInfo',
     AddCoinAccountStack = 'AddCoinAccountStack',
     PassphraseStack = 'PassphraseStack',
@@ -61,6 +62,11 @@ export enum AccountsStackRoutes {
 
 export enum ReceiveStackRoutes {
     ReceiveAccounts = 'ReceiveAccounts',
+}
+
+export enum SendStackRoutes {
+    SendAccounts = 'SendAccounts',
+    SendForm = 'SendForm',
 }
 
 export enum AddCoinAccountStackRoutes {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -90,6 +90,7 @@
             "path": "suite-native/module-passphrase"
         },
         { "path": "suite-native/module-receive" },
+        { "path": "suite-native/module-send" },
         {
             "path": "suite-native/module-settings"
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8768,6 +8768,7 @@ __metadata:
     "@suite-native/module-onboarding": "workspace:*"
     "@suite-native/module-passphrase": "workspace:*"
     "@suite-native/module-receive": "workspace:*"
+    "@suite-native/module-send": "workspace:*"
     "@suite-native/module-settings": "workspace:*"
     "@suite-native/navigation": "workspace:*"
     "@suite-native/notifications": "workspace:*"
@@ -9473,6 +9474,23 @@ __metadata:
     "@trezor/styles": "workspace:*"
     react: "npm:18.2.0"
     react-native: "npm:0.73.2"
+    react-redux: "npm:8.0.7"
+  languageName: unknown
+  linkType: soft
+
+"@suite-native/module-send@workspace:*, @suite-native/module-send@workspace:suite-native/module-send":
+  version: 0.0.0-use.local
+  resolution: "@suite-native/module-send@workspace:suite-native/module-send"
+  dependencies:
+    "@react-navigation/native": "npm:6.1.10"
+    "@react-navigation/native-stack": "npm:6.9.18"
+    "@suite-common/wallet-core": "workspace:*"
+    "@suite-common/wallet-types": "workspace:*"
+    "@suite-native/accounts": "workspace:*"
+    "@suite-native/atoms": "workspace:*"
+    "@suite-native/device-manager": "workspace:*"
+    "@suite-native/navigation": "workspace:*"
+    react: "npm:18.2.0"
     react-redux: "npm:8.0.7"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Description
- [x] new feature flag `isSendEnabled` added
  -  this flag is set to `true` only in `debug` and `develop` enviroments
- [x] package `suite-native/send-module` is initialized
- [x] SendStackNavigator created with following two screens:
  - [x] `SendAccountsScreen` 
    - lists all the BTC testnet accounts of current device
    - on selecting account it redirects to the form screen with the selected account key inside of `route.params` object
  - [x] `SendFormScreen` 
    - So far empty screen, will be revisited in the followup issue
  
## Related Issue

Resolve #10822 

## Screenshots:

https://github.com/trezor/trezor-suite/assets/26143964/5d762c1f-4b8b-4538-9347-52468ec73144


