### PR TITLE
Continue reconnecting when Tor status changed

### DIFF
--- a/packages/connect/src/backend/BackendManager.ts
+++ b/packages/connect/src/backend/BackendManager.ts
@@ -56,7 +56,6 @@ export class BackendManager {
     }
 
     reconnectAll() {
-        Object.keys(this.reconnect).forEach(this.clearReconnect, this);
         // collect all running backends as parameters tuple
         const params = Object.values(this.instances).map(i => [i.coinInfo, i.postMessage] as const);
         // remove all backends


### PR DESCRIPTION
## Description

When manually reconnecting all backends (only case was Tor status change afaik), timers responsible for automatic reconnection were cleared, so backends which were at that time waiting for reconnection had never recovered.