### PR TITLE
fix(suite-native): fix reading system color scheme

### DIFF
--- a/suite-native/app/app.config.ts
+++ b/suite-native/app/app.config.ts
@@ -145,6 +145,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
             backgroundColor: '#25292E',
             resizeMode: 'contain',
         },
+        userInterfaceStyle: 'automatic',
         android: {
             package: bundleIdentifier,
             adaptiveIcon: {


### PR DESCRIPTION
App mode didnt follow system scheme even when selected. This fixes it.

Resolve #10643
