### PR TITLE
fix(suite-native): coin discovery analytics objectless structure

### DIFF
--- a/packages/analytics/src/types.ts
+++ b/packages/analytics/src/types.ts
@@ -20,7 +20,7 @@ export type Event = {
     type: string;
     timestamp?: string;
     payload?: {
-        [key: string]: string | string[] | number | number[] | boolean | object | null;
+        [key: string]: string | string[] | number | number[] | boolean | null;
     };
 };
 

--- a/suite-native/analytics/src/constants.ts
+++ b/suite-native/analytics/src/constants.ts
@@ -25,6 +25,7 @@ export enum EventType {
     EjectDeviceClick = 'eject_device/click',
     ConnectDevice = 'device_connect',
     UnsupportedDevice = 'unsupported_device',
+    DiscoveryDuration = 'discovery_duration',
     CoinDiscovery = 'coin_discovery',
     CoinDiscoveryNewAccount = 'coin_discovery/new_account',
 }

--- a/suite-native/analytics/src/events.ts
+++ b/suite-native/analytics/src/events.ts
@@ -172,15 +172,20 @@ export type SuiteNativeAnalyticsEvent =
           };
       }
     | {
+          type: EventType.DiscoveryDuration;
+          payload: {
+              discoveryId: string; // Used for grouping multiple events of a single discovery run together.
+              loadDuration: number;
+          };
+      }
+    | {
           type: EventType.CoinDiscovery;
           payload: {
-              loadDuration: number;
-          } & {
-              [key in NetworkSymbol]: {
-                  numberOfAccounts: number;
-                  tokenSymbols?: TokenSymbol[];
-                  tokenAddresses?: TokenAddress[];
-              };
+              discoveryId: string;
+              symbol: NetworkSymbol;
+              numberOfAccounts: number;
+              tokenSymbols?: TokenSymbol[];
+              tokenAddresses?: TokenAddress[];
           };
       }
     | {

--- a/suite-native/discovery/package.json
+++ b/suite-native/discovery/package.json
@@ -26,6 +26,7 @@
         "@suite-native/device-mutex": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/device-utils": "workspace:*",
+        "@trezor/utils": "workspace:*",
         "proxy-memoize": "2.0.2",
         "react": "18.2.0",
         "react-redux": "8.0.7"

--- a/suite-native/discovery/src/discoverySelectors.ts
+++ b/suite-native/discovery/src/discoverySelectors.ts
@@ -20,16 +20,23 @@ export const selectDiscoveryAccountsAnalytics = (
         selectDeviceAccounts(state),
         A.groupBy(account => account.symbol),
         D.mapWithKey((networkSymbol, accounts) => {
+            const numberOfAccounts = accounts?.length ?? 0;
+
             const validTokens = selectValidTokensByNetworkSymbolAndDeviceState(
                 state,
                 deviceState,
                 networkSymbol as NetworkSymbol,
             );
+            if (A.isNotEmpty(validTokens)) {
+                return {
+                    numberOfAccounts,
+                    tokenSymbols: validTokens.map(token => token.symbol as TokenSymbol),
+                    tokenAddresses: validTokens.map(token => token.contract as TokenAddress),
+                };
+            }
 
             return {
-                numberOfAccounts: accounts?.length ?? 0,
-                tokenSymbols: validTokens.map(token => token.symbol as TokenSymbol),
-                tokenAddresses: validTokens.map(token => token.contract as TokenAddress),
+                numberOfAccounts,
             };
         }),
     );

--- a/suite-native/discovery/tsconfig.json
+++ b/suite-native/discovery/tsconfig.json
@@ -29,6 +29,7 @@
         { "path": "../device" },
         { "path": "../device-mutex" },
         { "path": "../../packages/connect" },
-        { "path": "../../packages/device-utils" }
+        { "path": "../../packages/device-utils" },
+        { "path": "../../packages/utils" }
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9016,6 +9016,7 @@ __metadata:
     "@suite-native/device-mutex": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/device-utils": "workspace:*"
+    "@trezor/utils": "workspace:*"
     proxy-memoize: "npm:2.0.2"
     react: "npm:18.2.0"
     react-redux: "npm:8.0.7"


### PR DESCRIPTION
Analytics data backend (Keboola) is unable to parser nested objects. So instead of sending one large object for the whole discovery run, there is a event dispatched for every discovered network.

### New shape of `coin_discovery` event (dispatched once for each network):
```
{
"discoveryId": "Q4jOLZlikH", 
"numberOfAccounts": 5, 
"symbol": "eth", 
"tokenAddresses": ["0x44709a920fCcF795fbC57BAA433cc3dd53C44DbE", "0x0F5D2fB29fb7d3CFeE444a200298f468908cC942", "0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d", "0xdAC17F958D2ee523a2206206994597C13D831ec7"], 
"tokenSymbols": ["radar", "mana", "fox", "usdt"]
}
```

### New `dicovery_duration` event (dispatched only once for whole discovery):
```
{
"discoveryId": "Q4jOLZlikH",
"loadDuration": 8115.408920001239
}
```
Resolve #11487
