### PR TITLE
feat(transport): handle cases when bridge returns descriptor with sam…

### DIFF
--- a/packages/transport/e2e/jest.config.ts
+++ b/packages/transport/e2e/jest.config.ts
@@ -3,7 +3,7 @@ export default {
     moduleFileExtensions: ['ts', 'js'],
     modulePathIgnorePatterns: ['node_modules'],
     watchPathIgnorePatterns: ['<rootDir>/libDev', '<rootDir>/lib'],
-    testPathIgnorePatterns: ['<rootDir>/libDev/', '<rootDir>/lib/'],
+    testPathIgnorePatterns: ['<rootDir>/libDev/', '<rootDir>/lib/', '<rootDir>/tests/'],
     transform: {
         '\\.(js|ts)$': [
             'babel-jest',

--- a/packages/transport/src/api/usb.ts
+++ b/packages/transport/src/api/usb.ts
@@ -85,7 +85,11 @@ export class UsbApi extends AbstractApi {
     }
 
     private devicesToDescriptors() {
-        return this.devices.map(d => ({ path: d.path, type: this.matchDeviceType(d.device) }));
+        return this.devices.map(d => ({
+            path: d.path,
+            type: this.matchDeviceType(d.device),
+            product: d.device.productId,
+        }));
     }
 
     public async enumerate() {

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -345,10 +345,16 @@ export abstract class AbstractTransport extends TypedEmitter<{
     private getDiff(nextDescriptors: Descriptor[]): DeviceDescriptorDiff {
         const connected = nextDescriptors.filter(
             nextDescriptor =>
-                !this.descriptors.find(descriptor => descriptor.path === nextDescriptor.path),
+                !this.descriptors.find(
+                    descriptor =>
+                        `${descriptor.path}${descriptor.product}` ===
+                        `${nextDescriptor.path}${nextDescriptor.product}`,
+                ),
         );
         const disconnected = this.descriptors.filter(
-            d => nextDescriptors.find(x => x.path === d.path) === undefined,
+            d =>
+                nextDescriptors.find(x => `${x.path}${x.product}` === `${d.path}${d.product}`) ===
+                undefined,
         );
         const changedSessions = nextDescriptors.filter(d => {
             const currentDescriptor = this.descriptors.find(x => x.path === d.path);

--- a/packages/transport/src/types/index.ts
+++ b/packages/transport/src/types/index.ts
@@ -8,6 +8,8 @@ export type Descriptor = {
     session?: Session;
     /** only used in status page */
     type?: DEVICE_TYPE;
+    /** only important for T1 over old bridge (trezord-go), defacto part of 'path'. More explanation in https://github.com/trezor/trezor-suite/compare/transport-descriptor-product */
+    product?: number;
 };
 
 export interface Logger {

--- a/packages/transport/src/utils/bridgeApiResult.ts
+++ b/packages/transport/src/utils/bridgeApiResult.ts
@@ -56,8 +56,8 @@ export function devices(res: UnknownPayload) {
             (o: any): Descriptor => ({
                 path: o.path,
                 session: o.session,
-                // @ts-expect-error - this is part of response too, might add it to type later
                 product: o.product,
+                // @ts-expect-error - this is part of response too, might add it to type later
                 vendor: o.vendor,
                 debug: o.debug,
                 debugSession: o.debugSession,

--- a/packages/transport/tests/abstractUsb.test.ts
+++ b/packages/transport/tests/abstractUsb.test.ts
@@ -214,11 +214,13 @@ describe('Usb', () => {
                         path: '123',
                         session: null,
                         type: 1,
+                        product: 21441,
                     },
                     {
                         path: 'bootloader1',
                         session: null,
                         type: 1,
+                        product: 21441,
                     },
                 ],
             });


### PR DESCRIPTION
When the `Reboot to bootloader` message is issued to T1 over the bridge, things stop to be consistent. 

Compare with the sequence of actions for model T:
1. Reboot to bootloader
2. Device disappears from usb
3. Device reappears again
4. `device-connect` event is emitted.

For model T1 and bridge
1. Reboot to bootloader
2. Device is still there, we were only able to detect a change in 'product' field in the descriptor, but since this field is not observed anywhere, transport layer does not signal anything.

before reboot to bootloader 
<img width="262" alt="image" src="https://github.com/trezor/trezor-suite/assets/30367552/36145af7-834c-4bbe-818b-06e8aff667e8">

after reboot to bootloader
<img width="253" alt="image" src="https://github.com/trezor/trezor-suite/assets/30367552/88e2ec48-1945-4633-b87b-2113feff7f37">

This PR adds the "product" to be used along with the `path` field for the purpose of tracking connecting/disconnecting devices and it is needed to make changes in #11300 possible.


