### PR TITLE
Fix/jumping evm fee

### DIFF
--- a/packages/suite/src/components/wallet/Fees/CustomFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/CustomFee.tsx
@@ -13,7 +13,6 @@ import { Note, motionEasing, variables } from '@trezor/components';
 import { Translation } from 'src/components/suite';
 import { NumberInput } from 'src/components/suite/NumberInput';
 import { getInputState, getFeeUnits, isInteger } from '@suite-common/wallet-utils';
-import { ETH_DEFAULT_GAS_LIMIT } from '@suite-common/wallet-constants';
 import { FeeInfo } from '@suite-common/wallet-types';
 import { FormState } from '@suite-common/wallet-types';
 import { NetworkType } from '@suite-common/wallet-config';
@@ -76,7 +75,7 @@ export const CustomFee = <TFieldValues extends FormState>({
 
     const feePerUnitValue = getValues(FEE_PER_UNIT);
     const feeUnits = getFeeUnits(networkType);
-    const estimatedFeeLimit = getValues('estimatedFeeLimit') || ETH_DEFAULT_GAS_LIMIT;
+    const estimatedFeeLimit = getValues('estimatedFeeLimit');
 
     const feePerUnitError = errors.feePerUnit;
     const feeLimitError = errors.feeLimit;
@@ -116,7 +115,7 @@ export const CustomFee = <TFieldValues extends FormState>({
             ...sharedRules.validate,
             feeLimit: (value: string) => {
                 const feeBig = new BigNumber(value);
-                if (feeBig.lt(estimatedFeeLimit)) {
+                if (estimatedFeeLimit && feeBig.lt(estimatedFeeLimit)) {
                     return translationString('CUSTOM_FEE_LIMIT_BELOW_RECOMMENDED');
                 }
             },
@@ -146,6 +145,7 @@ export const CustomFee = <TFieldValues extends FormState>({
 
     const feeLimitValidationProps = {
         onClick: () =>
+            estimatedFeeLimit &&
             setValue(FEE_LIMIT, estimatedFeeLimit, {
                 shouldValidate: true,
             }),

--- a/packages/suite/src/components/wallet/Fees/FeeDetails.tsx
+++ b/packages/suite/src/components/wallet/Fees/FeeDetails.tsx
@@ -5,10 +5,12 @@ import { Translation } from 'src/components/suite';
 import { getFeeUnits } from '@suite-common/wallet-utils';
 import { formatDuration } from '@suite-common/suite-utils';
 import { Network } from 'src/types/wallet';
+
+import { useState, useEffect } from 'react';
 import {
-    FeeInfo,
     PrecomposedTransaction,
     PrecomposedTransactionCardano,
+    FeeInfo,
 } from '@suite-common/wallet-types';
 
 const Wrapper = styled.div`
@@ -83,9 +85,25 @@ const EthereumDetails = ({
     transactionInfo,
     showFee,
 }: DetailsProps) => {
+    // States to remember the last known values of feeLimit and feePerByte when isComposedTx was true.
+    const [lastKnownFeeLimit, setLastKnownFeeLimit] = useState('');
+    const [lastKnownFeePerByte, setLastKnownFeePerByte] = useState('');
+
     const isComposedTx = transactionInfo && transactionInfo.type !== 'error';
-    const gasLimit = isComposedTx ? transactionInfo.feeLimit : selectedLevel.feeLimit;
-    const gasPrice = isComposedTx ? transactionInfo.feePerByte : selectedLevel.feePerUnit;
+
+    useEffect(() => {
+        if (isComposedTx && transactionInfo.feeLimit) {
+            setLastKnownFeeLimit(transactionInfo.feeLimit);
+            setLastKnownFeePerByte(transactionInfo.feePerByte);
+        }
+    }, [isComposedTx, transactionInfo]);
+
+    const gasLimit = isComposedTx
+        ? transactionInfo.feeLimit
+        : lastKnownFeeLimit || selectedLevel.feeLimit;
+    const gasPrice = isComposedTx
+        ? transactionInfo.feePerByte
+        : lastKnownFeePerByte || selectedLevel.feePerUnit;
 
     return (
         <Wrapper>

--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -1818,7 +1818,7 @@ export const feeChange = [
                         selectedFee: 'custom' as const,
                         feePerUnit: '3',
                         feeLimit: '21000', // default
-                        estimatedFeeLimit: undefined,
+                        estimatedFeeLimit: '21000',
                     },
                 },
             },

--- a/suite-common/wallet-constants/src/sendForm.ts
+++ b/suite-common/wallet-constants/src/sendForm.ts
@@ -5,9 +5,8 @@ export const BTC_LOCKTIME_VALUE = 500000000; // if locktime is equal/greater tha
 export const BTC_RBF_SEQUENCE = 0xffffffff - 2;
 export const XRP_FLAG = 0x80000000;
 export const U_INT_32 = 0xffffffff;
-export const ETH_DEFAULT_GAS_PRICE = '1';
-export const ETH_DEFAULT_GAS_LIMIT = '21000';
-
+export const ETH_BACKUP_GAS_LIMIT = '21000';
+export const ERC20_BACKUP_GAS_LIMIT = '200000';
 export const ERC20_TRANSFER = 'a9059cbb'; // 4 bytes function signature of solidity erc20 `transfer(address,uint256)`
 
 export const DEFAULT_PAYMENT = {

--- a/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
@@ -18,7 +18,7 @@ import {
     getAccountIdentity,
 } from '@suite-common/wallet-utils';
 import { createThunk } from '@suite-common/redux-utils';
-import { ETH_DEFAULT_GAS_LIMIT } from '@suite-common/wallet-constants';
+import { ERC20_BACKUP_GAS_LIMIT, ETH_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';
 import {
     PrecomposedLevels,
     PrecomposedTransaction,
@@ -119,8 +119,6 @@ export const composeEthereumSendFormTransactionThunk = createThunk(
         const { availableBalance } = account;
         const { address, amount } = formValues.outputs[0];
 
-        let customFeeLimit: string | undefined;
-
         // gasLimit calculation based on address, amount and data size
         // amount in essential for a proper calculation of gasLimit (via blockbook/geth)
         const estimatedFee = await TrezorConnect.blockchainEstimateFee({
@@ -141,6 +139,8 @@ export const composeEthereumSendFormTransactionThunk = createThunk(
             },
         });
 
+        let customFeeLimit: string | undefined;
+
         if (estimatedFee.success) {
             customFeeLimit = estimatedFee.payload.levels[0].feeLimit;
             if (formValues.ethereumAdjustGasLimit && customFeeLimit) {
@@ -149,6 +149,8 @@ export const composeEthereumSendFormTransactionThunk = createThunk(
                     .toFixed(0);
             }
         } else {
+            customFeeLimit = tokenInfo ? ERC20_BACKUP_GAS_LIMIT : ETH_BACKUP_GAS_LIMIT;
+
             // TODO: catch error from blockbook/geth (invalid contract, not enough balance...)
         }
 
@@ -291,7 +293,7 @@ export const signEthereumSendFormTransactionThunk = createThunk(
             to: formValues.outputs[0].address,
             amount: formValues.outputs[0].amount,
             data: formValues.ethereumDataHex,
-            gasLimit: transactionInfo.feeLimit || ETH_DEFAULT_GAS_LIMIT,
+            gasLimit: transactionInfo.feeLimit || '',
             gasPrice: transactionInfo.feePerByte,
             nonce,
         });

--- a/suite-common/wallet-types/src/transaction.ts
+++ b/suite-common/wallet-types/src/transaction.ts
@@ -99,7 +99,7 @@ export type PrecomposedTransactionNonFinal = PrecomposeResultNonFinal & {
 
 // base of PrecomposedTransactionFinal
 type TxFinal = PrecomposeResultFinal & {
-    max: string | undefined;
+    max?: string;
     feeLimit?: string;
     estimatedFeeLimit?: string;
     token?: TokenInfo;


### PR DESCRIPTION
## Description

- for some tokens simulation does not return fee, let's put there backup gas limit
- when changing amount of tokens, gas limit is jumping to 21000 and back, let's not do this, let's return logic from before

## Related Issue

Fixing two bugs introduced by #11759 and #11897

## Screenshots:

![Screenshot 2024-04-12 at 14 31 42](https://github.com/trezor/trezor-suite/assets/33235762/0f3aebdc-2b6b-4072-96ca-2c1de71093a1)

https://github.com/trezor/trezor-suite/assets/33235762/10e183f3-b42a-4801-9a41-80907b591ba6

