### PR TITLE
Connect/fix multiapp app coop over webusb

### DIFF
--- a/packages/connect/src/device/DeviceCommands.ts
+++ b/packages/connect/src/device/DeviceCommands.ts
@@ -19,7 +19,7 @@ import { getAccountAddressN } from '../utils/accountUtils';
 import { getSegwitNetwork, getBech32Network } from '../data/coinInfo';
 import { initLog } from '../utils/debug';
 
-import type { Device } from './Device';
+import { Device, GET_FEATURES_TIMEOUT } from './Device';
 import type { CoinInfo, BitcoinNetworkInfo, Network } from '../types';
 import type { HDNodeResponse } from '../types/api/getPublicKey';
 import { Assert } from '@trezor/schema-utils';
@@ -391,8 +391,19 @@ export class DeviceCommands {
             name: type,
             data: msg,
             protocol: this.device.protocol,
+            /**
+             * These calls have no right to take longer than certain time. If it takes longer we can be sure that they will never resolve.
+             * With other calls however we can't deploy this timeout rule since some of the calls won't resolve before user interaction on device.
+             * This is no a big problem, because it is always either GetFeatures or Initialize messages which are sent at the beginning of each "session",
+             * and if these messages pass, all subsequent calls will pass as well.
+             */
+            scheduleActionParams: ['Initialize', 'GetFeatures'].includes(type)
+                ? { timeout: GET_FEATURES_TIMEOUT + 100 }
+                : undefined,
         });
+
         const res = await this.callPromise.promise;
+
         this.callPromise = undefined;
         if (!res.success) {
             logger.warn('Received error', res.error);

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -318,6 +318,7 @@ export abstract class AbstractTransport extends TypedEmitter<{
         name: string;
         data: Record<string, unknown>;
         protocol?: TransportProtocol;
+        scheduleActionParams?: ScheduleActionParams;
     }): AbortableCall<
         MessageFromTrezor,
         // bridge

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -181,74 +181,73 @@ export abstract class AbstractApiTransport extends AbstractTransport {
         name,
         data,
         protocol: customProtocol,
+        scheduleActionParams,
     }: AbstractTransportMethodParams<'call'>) {
-        return this.scheduleAction(
-            async () => {
-                const getPathBySessionResponse = await this.sessionsClient.getPathBySession({
-                    session,
+        return this.scheduleAction(async () => {
+            const getPathBySessionResponse = await this.sessionsClient.getPathBySession({
+                session,
+            });
+            if (!getPathBySessionResponse.success) {
+                // session not found means that device was disconnected
+                if (getPathBySessionResponse.error === 'session not found') {
+                    return this.error({ error: ERRORS.DEVICE_DISCONNECTED_DURING_ACTION });
+                }
+
+                return this.error({ error: ERRORS.UNEXPECTED_ERROR });
+            }
+            const { path } = getPathBySessionResponse.payload;
+
+            try {
+                const protocol = customProtocol || v1Protocol;
+                const bytes = buildMessage({
+                    messages: this.messages,
+                    name,
+                    data,
+                    encode: protocol.encode,
                 });
-                if (!getPathBySessionResponse.success) {
-                    // session not found means that device was disconnected
-                    if (getPathBySessionResponse.error === 'session not found') {
-                        return this.error({ error: ERRORS.DEVICE_DISCONNECTED_DURING_ACTION });
-                    }
+                const buffers = createChunks(
+                    bytes,
+                    protocol.getChunkHeader(bytes),
+                    this.api.chunkSize,
+                );
 
-                    return this.error({ error: ERRORS.UNEXPECTED_ERROR });
-                }
-                const { path } = getPathBySessionResponse.payload;
+                for (let i = 0; i < buffers.length; i++) {
+                    const chunk = buffers[i];
 
-                try {
-                    const protocol = customProtocol || v1Protocol;
-                    const bytes = buildMessage({
-                        messages: this.messages,
-                        name,
-                        data,
-                        encode: protocol.encode,
+                    await this.api.write(path, chunk).then(result => {
+                        if (!result.success) {
+                            throw new Error(result.error);
+                        }
                     });
-                    const buffers = createChunks(
-                        bytes,
-                        protocol.getChunkHeader(bytes),
-                        this.api.chunkSize,
-                    );
-                    for (let i = 0; i < buffers.length; i++) {
-                        const chunk = buffers[i];
-
-                        await this.api.write(path, chunk).then(result => {
-                            if (!result.success) {
-                                throw new Error(result.error);
-                            }
-                        });
-                    }
-
-                    const message = await receiveAndParse(
-                        this.messages,
-                        () =>
-                            this.api.read(path).then(result => {
-                                if (result.success) {
-                                    return result.payload;
-                                }
-                                throw new Error(result.error);
-                            }),
-                        protocol,
-                    );
-
-                    return this.success(message);
-                } catch (err) {
-                    // if user revokes usb permissions in browser we need a way how propagate that the device was technically disconnected,
-                    if (err.message === ERRORS.DEVICE_DISCONNECTED_DURING_ACTION) {
-                        this.enumerate();
-                    }
-
-                    return this.unknownError(err, [
-                        ERRORS.DEVICE_DISCONNECTED_DURING_ACTION,
-                        ERRORS.DEVICE_NOT_FOUND,
-                        ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE,
-                        ERRORS.INTERFACE_DATA_TRANSFER,
-                    ]);
                 }
-            },
-            { timeout: undefined },
-        );
+
+                const message = await receiveAndParse(
+                    this.messages,
+                    () =>
+                        this.api.read(path).then(result => {
+                            if (result.success) {
+                                return result.payload;
+                            }
+                            throw new Error(result.error);
+                        }),
+                    protocol,
+                );
+
+                return this.success(message);
+            } catch (err) {
+                // if user revokes usb permissions in browser we need a way how propagate that the device was technically disconnected,
+                if (err.message === ERRORS.DEVICE_DISCONNECTED_DURING_ACTION) {
+                    this.enumerate();
+                }
+
+                return this.unknownError(err, [
+                    ERRORS.DEVICE_DISCONNECTED_DURING_ACTION,
+                    ERRORS.DEVICE_NOT_FOUND,
+                    ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE,
+                    ERRORS.INTERFACE_DATA_TRANSFER,
+                ]);
+            }
+        }, scheduleActionParams);
     }
 
     public send({ data, session, name, protocol }: AbstractTransportMethodParams<'send'>) {

--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -230,34 +230,32 @@ export class BridgeTransport extends AbstractTransport {
         name,
         data,
         protocol: customProtocol,
+        scheduleActionParams,
     }: AbstractTransportMethodParams<'call'>) {
-        return this.scheduleAction(
-            async signal => {
-                const protocol = customProtocol || bridgeProtocol;
-                const bytes = buildMessage({
-                    messages: this.messages,
-                    name,
-                    data,
-                    encode: protocol.encode,
-                });
-                const response = await this.post(`/call`, {
-                    params: session,
-                    body: bytes.toString('hex'),
-                    signal,
-                });
-                if (!response.success) {
-                    return response;
-                }
-                const message = await receiveAndParse(
-                    this.messages,
-                    () => Promise.resolve(Buffer.from(response.payload, 'hex')),
-                    protocol,
-                );
+        return this.scheduleAction(async signal => {
+            const protocol = customProtocol || bridgeProtocol;
+            const bytes = buildMessage({
+                messages: this.messages,
+                name,
+                data,
+                encode: protocol.encode,
+            });
+            const response = await this.post(`/call`, {
+                params: session,
+                body: bytes.toString('hex'),
+                signal,
+            });
+            if (!response.success) {
+                return response;
+            }
+            const message = await receiveAndParse(
+                this.messages,
+                () => Promise.resolve(Buffer.from(response.payload, 'hex')),
+                protocol,
+            );
 
-                return this.success(message);
-            },
-            { timeout: undefined },
-        );
+            return this.success(message);
+        }, scheduleActionParams);
     }
 
     public send({ session, name, data, protocol }: AbstractTransportMethodParams<'send'>) {


### PR DESCRIPTION
mitigation for #12002, part of #11532 

The connected device can't be worked with in any way. This time, the most probable case is that another application called `device.claimInterface` but never called `device.releaseInterface`. This can happen for couple of reasons, one of them is described in #12002 but even if we implement apps synchronization correctly, it is not guaranteed that there is no rogue app in the wild occupying the connected trezor device. 

This PR's goal is to show a meaningful error screen in case this happens. As of textual content, it should say something like:
- make sure there are no other applications or web apps communication with your trezor
- if nothing helped, you may want to try trezor-bridge (old bridge would work but also the new one should help, even if it is run from suite-destkop app).

Commits: 
- 91e178cc4d4170dba28d728173ccd20dcd528076
  - transport layer already implements the `scheduleAction` util, but it is used there only internally. 
  - it is desirable to make some of the calls to the device timeoutable. Not all calls can be timeoutable however since some of them resolve only after the user confirms button requests.
  - this commit adds `scheduleAction` params to `transport.call` to give implementation the ability to make it timeoutable from outside if he decides to do so.
- 66f3b3474599cbda2249ce394880aad3503837ba
  - implements this timeout on the Connect level only for `GetFeatures` and `Initialize` calls.
  
Alternative approach
- maybe it would be better to:
  - use timeout on transports lowest layer? 
  - if call times out, reject, return error and emit new descriptors event with an unreadable device in payload?


Screenshots: 

Before: pair device not reacting. 

<img width="641" alt="image" src="https://github.com/trezor/trezor-suite/assets/30367552/502d849e-a677-40a1-8236-8fa921602b18">

After:
<img width="989" alt="image" src="https://github.com/trezor/trezor-suite/assets/30367552/3dc7bc58-26e5-49fc-9170-0f0250356dec">

Before: 
<img width="869" alt="image" src="https://github.com/trezor/trezor-suite/assets/30367552/9d3aab71-e0a8-4c5e-9cd0-d7a75b7399d9">

After: 
<img width="869" alt="image" src="https://github.com/trezor/trezor-suite/assets/30367552/e485cd8a-d138-4201-baa8-5857e3c25c95">
 
