### PR TITLE
ci(github): connect tests with T3T1

### DIFF
--- a/.github/workflows/connect-test.yml
+++ b/.github/workflows/connect-test.yml
@@ -94,6 +94,7 @@ jobs:
       test-pattern: ${{ matrix.pattern }}
       methods: ${{ matrix.methods }}
       tests-firmware: ${{ matrix.firmware }}
+      test-description: ${{ matrix.name }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.set-matrix.outputs.dailyMatrix) }}
@@ -107,6 +108,7 @@ jobs:
       test-pattern: ${{ matrix.pattern }}
       methods: ${{ matrix.methods }}
       tests-firmware: ${{ matrix.firmware }}
+      test-description: ${{ matrix.name }}-${{ matrix.firmware }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.set-matrix.outputs.legacyCanaryFirmwareMatrix) }}
@@ -114,15 +116,16 @@ jobs:
   connect-other-devices:
     needs: [build, set-matrix]
     if: github.event_name == 'schedule' &&  github.repository == 'trezor/trezor-suite'
-    name: other-devices-${{ matrix.name }}
+    name: other-devices-${{ matrix.name }}-${{ matrix.model }}
     uses: ./.github/workflows/template-connect-test-params.yml
     with:
       test-pattern: ${{ matrix.pattern }}
       methods: ${{ matrix.methods }}
       tests-firmware: ${{ matrix.firmware }}
-      test-firmware-model: "R"
+      test-firmware-model: ${{ matrix.model }}
       node-environment: ${{ matrix.node-environment }}
       web-environment: ${{ matrix.web-environment }}
+      test-description: ${{ matrix.name }}-${{ matrix.firmware }}-${{ matrix.model }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.set-matrix.outputs.otherDevicesMatrix) }}

--- a/.github/workflows/template-connect-test-params.yml
+++ b/.github/workflows/template-connect-test-params.yml
@@ -30,10 +30,15 @@ on:
         type: "boolean"
         required: false
         default: true
+      test-description:
+        description: "A description to make test title more descriptive (example: 2-latest-R)"
+        type: "string"
+        required: false
+        default: ""
 
 jobs:
   node:
-    name: node
+    name: "node-${{ inputs.test-description }}"
     runs-on: ubuntu-latest
     if: ${{ inputs.node-environment }}
     steps:
@@ -51,7 +56,7 @@ jobs:
       - run: './docker/docker-connect-test.sh node -p "${{ inputs.test-pattern }}" -f "${{ inputs.tests-firmware }}" -i ${{ inputs.methods }} -m ${{ inputs.test-firmware-model}}'
 
   web:
-    name: web
+    name: "web-${{ inputs.test-description }}"
     runs-on: ubuntu-latest
     if: ${{ inputs.web-environment }}
     steps:

--- a/ci/scripts/connect-test-matrix-generator.js
+++ b/ci/scripts/connect-test-matrix-generator.js
@@ -77,6 +77,7 @@ const legacyCanaryFirmware = {
 
 const otherDevices = {
     firmwares: ['2-latest'],
+    models: ['R', 'T3T1'],
     tests: [
         {
             name: 'api',
@@ -147,8 +148,14 @@ const otherDevices = {
     ],
 };
 
-const prepareTest = ({ firmwares, tests }) => {
-    return tests.flatMap(test => firmwares.map(firmware => ({ firmware, ...test })));
+const prepareTest = ({ firmwares, tests, models }) => {
+    const withFirmwares = tests.flatMap(test => firmwares.map(firmware => ({ firmware, ...test })));
+
+    if (models && models.length > 0) {
+        return withFirmwares.flatMap(test => models.map(model => ({ model, ...test })));
+    } else {
+        return withFirmwares;
+    }
 };
 
 const testData = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This depends of https://github.com/trezor/trezor-suite/pull/11968 

## Description

Adding new device to nightly  other devices tests `T3T1` to connect unit tests in CI GitHub Action.

The other devices tests is running only on schedule but I run it on this job in order to prove it works https://github.com/trezor/trezor-suite/actions/runs/8684091754/job/23811119867?pr=12010


I also added descriptions to make tests more clear:

![image](https://github.com/trezor/trezor-suite/assets/5362163/88b2fe2c-0592-4ea5-a9ed-eb558a26a5e0)
