### PR TITLE
Fix/protocol repeated enum

### DIFF
--- a/packages/protobuf/src/encode.ts
+++ b/packages/protobuf/src/encode.ts
@@ -1,4 +1,4 @@
-import { Type } from 'protobufjs/light';
+import { Type, Enum } from 'protobufjs/light';
 
 import { isPrimitiveField } from './utils';
 
@@ -47,8 +47,13 @@ export function patch(Message: Type, payload: any) {
         }
         // repeated
         if (field.repeated) {
-            const RefMessage = Message.lookupTypeOrEnum(field.type);
-            patched[key] = value.map((v: any) => patch(RefMessage, v));
+            const fieldType = Message.lookupTypeOrEnum(field.type);
+            if (fieldType instanceof Enum) {
+                // NOTE: Enum doesn't require patching both string (keys) and number values are accepted
+                patched[key] = value;
+            } else {
+                patched[key] = value.map((v: any) => patch(fieldType, v));
+            }
         }
         // message type
         else if (typeof value === 'object' && value !== null) {

--- a/packages/protobuf/src/utils.ts
+++ b/packages/protobuf/src/utils.ts
@@ -40,22 +40,31 @@ export function parseConfigure(data: protobuf.INamespace) {
 export const createMessageFromName = (messages: protobuf.Root, name: string) => {
     const Message = messages.lookupType(name);
     const MessageType = messages.lookupEnum('MessageType');
-    let messageType = MessageType.values[`MessageType_${name}`];
+    let messageTypeId = MessageType.values[`MessageType_${name}`];
 
-    if (!messageType && Message.options) {
-        messageType = Message.options['(wire_type)'];
+    if (typeof messageTypeId !== 'number' && Message.options) {
+        messageTypeId = Message.options['(wire_type)'];
     }
 
     return {
         Message,
-        messageType,
+        messageType: messageTypeId ?? name,
     };
 };
 
-export const createMessageFromType = (messages: protobuf.Root, typeId: number) => {
-    const MessageType = messages.lookupEnum('MessageType');
+export const createMessageFromType = (messages: protobuf.Root, messageType: number | string) => {
+    if (typeof messageType === 'string') {
+        const Message = messages.lookupType(messageType);
 
-    const messageName = MessageType.valuesById[typeId].replace(
+        return {
+            Message,
+            messageName: messageType as MessageFromTrezor['type'],
+        };
+    }
+
+    const messageTypes = messages.lookupEnum('MessageType');
+
+    const messageName = messageTypes.valuesById[messageType].replace(
         'MessageType_',
         '',
     ) as MessageFromTrezor['type'];

--- a/packages/protobuf/tests/encode-decode-basic.test.ts
+++ b/packages/protobuf/tests/encode-decode-basic.test.ts
@@ -269,5 +269,37 @@ describe('basic concepts', () => {
                 decode(ReceiverMessages.lookupType('messages.ButtonRequest'), senderEncoded);
             }).toThrow();
         });
+
+        test('message with repeated enum field', () => {
+            const protobufRoot = ProtoBuf.Root.fromJSON({
+                nested: {
+                    RepeatedEnum: {
+                        values: {
+                            RepeatedEnum_1: 1,
+                            RepeatedEnum_2: 2,
+                            RepeatedEnum_3: 3,
+                        },
+                    },
+                    MessageWithRepeatedEnum: {
+                        fields: {
+                            repeated_enum: {
+                                rule: 'repeated',
+                                type: 'RepeatedEnum',
+                                id: 1,
+                                options: {
+                                    packed: false,
+                                },
+                            },
+                        },
+                    },
+                },
+            });
+
+            const m = protobufRoot.lookupType('MessageWithRepeatedEnum');
+            const encoded = encode(m, { repeated_enum: [3, 'RepeatedEnum_2'] });
+            const decoded = decode(m, encoded);
+
+            expect(decoded.repeated_enum).toEqual(['RepeatedEnum_3', 'RepeatedEnum_2']);
+        });
     });
 });

--- a/packages/protobuf/tests/messages.test.ts
+++ b/packages/protobuf/tests/messages.test.ts
@@ -1,6 +1,6 @@
 import * as protobuf from 'protobufjs/light';
 
-import { createMessageFromName } from '../src/utils';
+import { createMessageFromName, createMessageFromType } from '../src/utils';
 
 const json = {
     nested: {
@@ -34,6 +34,17 @@ const json = {
                                         },
                                     },
                                 },
+                                Initialize: {
+                                    fields: {
+                                        session_id: {
+                                            type: 'bytes',
+                                            id: 1,
+                                        },
+                                    },
+                                },
+                                MessageWithoutId: {
+                                    fields: {},
+                                },
                                 MessageType: {
                                     values: {
                                         MessageType_Initialize: 0,
@@ -54,5 +65,21 @@ describe('messages', () => {
         const name = 'TxAckPrevExtraData';
 
         expect(() => createMessageFromName(messages, name)).not.toThrow();
+    });
+
+    test('createMessageFromName (message without id)', () => {
+        const messages = protobuf.Root.fromJSON(json);
+        const name = 'MessageWithoutId'; // this message has no id defined in MessageType.MessageType_xxx
+        const result = createMessageFromName(messages, name);
+
+        expect(result.messageType).toEqual(name);
+    });
+
+    test('createMessageFromType (messageType as number and string)', () => {
+        const messages = protobuf.Root.fromJSON(json);
+        const asNumber = createMessageFromType(messages, 0);
+        const asString = createMessageFromType(messages, 'Initialize');
+
+        expect(asNumber.messageName).toEqual(asString.messageName);
     });
 });

--- a/packages/protocol/src/protocol-bridge/decode.ts
+++ b/packages/protocol/src/protocol-bridge/decode.ts
@@ -6,20 +6,20 @@ import { TransportProtocolDecode } from '../types';
  */
 const readHeader = (buffer: Buffer) => {
     // 2 bytes
-    const typeId = buffer.readUInt16BE();
+    const messageType = buffer.readUInt16BE();
     // 4 bytes
     const length = buffer.readUInt32BE(2);
 
-    return { typeId, length };
+    return { messageType, length };
 };
 
 export const decode: TransportProtocolDecode = bytes => {
     const buffer = Buffer.from(bytes);
-    const { typeId, length } = readHeader(buffer);
+    const { messageType, length } = readHeader(buffer);
 
     return {
-        typeId,
+        messageType,
         length,
-        buffer: buffer.subarray(HEADER_SIZE),
+        payload: buffer.subarray(HEADER_SIZE),
     };
 };

--- a/packages/protocol/src/protocol-bridge/encode.ts
+++ b/packages/protocol/src/protocol-bridge/encode.ts
@@ -6,6 +6,9 @@ import { TransportProtocolEncode } from '../types';
 // it is because bridge does some parts of the protocol itself (like chunking)
 export const encode: TransportProtocolEncode = (data, options) => {
     const { messageType } = options;
+    if (typeof messageType === 'string') {
+        throw new Error(`Unsupported message type ${messageType}`);
+    }
 
     const encodedBuffer = Buffer.alloc(HEADER_SIZE + data.length);
 

--- a/packages/protocol/src/protocol-v1/decode.ts
+++ b/packages/protocol/src/protocol-v1/decode.ts
@@ -13,18 +13,18 @@ const readHeaderChunked = (buffer: Buffer) => {
     // 1 byte
     const sharp2 = buffer.readUInt8(2);
     // 2 bytes
-    const typeId = buffer.readUInt16BE(3);
+    const messageType = buffer.readUInt16BE(3);
     // 4 bytes
     const length = buffer.readUInt32BE(5);
 
-    return { magic, sharp1, sharp2, typeId, length };
+    return { magic, sharp1, sharp2, messageType, length };
 };
 
 // Parses first raw input that comes from Trezor and returns some information about the whole message.
 // [compatibility]: accept Buffer just like decode does. But this would require changes in lower levels
 export const decode: TransportProtocolDecode = bytes => {
     const buffer = Buffer.from(bytes);
-    const { magic, sharp1, sharp2, typeId, length } = readHeaderChunked(buffer);
+    const { magic, sharp1, sharp2, messageType, length } = readHeaderChunked(buffer);
 
     if (
         magic !== MESSAGE_MAGIC_HEADER_BYTE ||
@@ -37,7 +37,7 @@ export const decode: TransportProtocolDecode = bytes => {
 
     return {
         length,
-        typeId,
-        buffer: buffer.subarray(HEADER_SIZE + 1), // each chunk is prefixed by magic byte
+        messageType,
+        payload: buffer.subarray(HEADER_SIZE + 1), // each chunk is prefixed by magic byte
     };
 };

--- a/packages/protocol/src/protocol-v1/encode.ts
+++ b/packages/protocol/src/protocol-v1/encode.ts
@@ -8,6 +8,10 @@ import { TransportProtocolEncode } from '../types';
 
 export const encode: TransportProtocolEncode = (data, options) => {
     const { messageType } = options;
+    if (typeof messageType === 'string') {
+        throw new Error(`Unsupported message type ${messageType}`);
+    }
+
     const fullSize = HEADER_SIZE + data.length;
     const chunkSize = options.chunkSize || BUFFER_SIZE;
 

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -1,7 +1,7 @@
 export type TransportProtocolDecode = (bytes: ArrayBuffer) => {
     length: number;
-    typeId: number;
-    buffer: Buffer;
+    messageType: number;
+    payload: Buffer;
 };
 
 export interface TransportProtocolEncodeOptions {

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -1,11 +1,11 @@
 export type TransportProtocolDecode = (bytes: ArrayBuffer) => {
     length: number;
-    messageType: number;
+    messageType: number | string;
     payload: Buffer;
 };
 
 export interface TransportProtocolEncodeOptions {
-    messageType: number;
+    messageType: number | string;
     chunkSize?: number;
 }
 

--- a/packages/protocol/tests/protocol-bridge.test.ts
+++ b/packages/protocol/tests/protocol-bridge.test.ts
@@ -23,7 +23,7 @@ describe('protocol-bridge', () => {
         data.writeUint32BE(379, 2);
 
         const read = bridge.decode(data);
-        expect(read.typeId).toEqual(55);
+        expect(read.messageType).toEqual(55);
         expect(read.length).toEqual(379);
     });
 });

--- a/packages/protocol/tests/protocol-bridge.test.ts
+++ b/packages/protocol/tests/protocol-bridge.test.ts
@@ -14,6 +14,11 @@ describe('protocol-bridge', () => {
         expect(chunks[0].subarray(0, 6).toString('hex')).toEqual('003700000173');
         expect(chunks[0].readUint32BE(2)).toEqual(371);
         expect(chunks[0].length).toEqual(371 + 6);
+
+        // fail to encode unsupported messageType (string)
+        expect(() => bridge.encode(Buffer.alloc(64), { messageType: 'Initialize' })).toThrow(
+            'Unsupported message type Initialize',
+        );
     });
 
     it('decode', () => {

--- a/packages/protocol/tests/protocol-v1.test.ts
+++ b/packages/protocol/tests/protocol-v1.test.ts
@@ -31,7 +31,7 @@ describe('protocol-v1', () => {
         data.writeUint32BE(379, 5);
 
         const read = v1.decode(data);
-        expect(read.typeId).toEqual(55);
+        expect(read.messageType).toEqual(55);
         expect(read.length).toEqual(379);
     });
 });

--- a/packages/protocol/tests/protocol-v1.test.ts
+++ b/packages/protocol/tests/protocol-v1.test.ts
@@ -22,6 +22,11 @@ describe('protocol-v1', () => {
                 expect(chunk.subarray(0, 5).toString('hex')).toEqual('3f00000000');
             }
         });
+
+        // fail to encode unsupported messageType (string)
+        expect(() => v1.encode(Buffer.alloc(64), { messageType: 'Initialize' })).toThrow(
+            'Unsupported message type Initialize',
+        );
     });
 
     it('decode', () => {

--- a/packages/transport/src/utils/receive.ts
+++ b/packages/transport/src/utils/receive.ts
@@ -23,7 +23,7 @@ async function receiveRest(
     return receiveRest(result, receiver, length, expectedLength);
 }
 
-async function receiveBuffer(
+export async function receive(
     receiver: () => Promise<ArrayBuffer>,
     decoder: TransportProtocolDecode,
 ) {
@@ -38,18 +38,6 @@ async function receiveBuffer(
     await receiveRest(result, receiver, payload.length, length);
 
     return { messageType, payload: result };
-}
-
-export async function receive(
-    receiver: () => Promise<ArrayBuffer>,
-    decoder: TransportProtocolDecode,
-) {
-    const { payload, messageType } = await receiveBuffer(receiver, decoder);
-
-    return {
-        messageType,
-        payload,
-    };
 }
 
 export async function receiveAndParse(

--- a/packages/transport/src/utils/receive.ts
+++ b/packages/transport/src/utils/receive.ts
@@ -28,27 +28,27 @@ async function receiveBuffer(
     decoder: TransportProtocolDecode,
 ) {
     const data = await receiver();
-    const { length, typeId, buffer } = decoder(data);
+    const { length, messageType, payload } = decoder(data);
     const result = Buffer.alloc(length);
 
     if (length) {
-        buffer.copy(result);
+        payload.copy(result);
     }
 
-    await receiveRest(result, receiver, buffer.length, length);
+    await receiveRest(result, receiver, payload.length, length);
 
-    return { received: result, typeId };
+    return { messageType, payload: result };
 }
 
 export async function receive(
     receiver: () => Promise<ArrayBuffer>,
     decoder: TransportProtocolDecode,
 ) {
-    const { received, typeId } = await receiveBuffer(receiver, decoder);
+    const { payload, messageType } = await receiveBuffer(receiver, decoder);
 
     return {
-        typeId,
-        buffer: received,
+        messageType,
+        payload,
     };
 }
 
@@ -57,9 +57,9 @@ export async function receiveAndParse(
     receiver: () => Promise<ArrayBuffer>,
     decoder: TransportProtocolDecode,
 ) {
-    const { buffer, typeId } = await receive(receiver, decoder);
-    const { Message, messageName } = createMessageFromType(messages, typeId);
-    const message = decodeProtobuf(Message, buffer);
+    const { messageType, payload } = await receive(receiver, decoder);
+    const { Message, messageName } = createMessageFromType(messages, messageType);
+    const message = decodeProtobuf(Message, payload);
 
     return {
         message,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

some early cherry picked commits from `Trezor Host Protocol` implementation:

- unify naming in protocol `encode\decode` functions
- allow to encode/decode protobuf message which is not defined in `MessageType.MessageType_xxx` collection
- fix encoding of array of enums, prod. bug but looks like it was never used as a MessageToTrezor (encoded)