### PR TITLE
fix(suite): tokens nav discreet mode

### DIFF
--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem.tsx
@@ -12,7 +12,13 @@ import {
     TruncateWithTooltip,
 } from '@trezor/components';
 
-import { AccountLabel, CoinBalance, FiatValue, Translation } from 'src/components/suite';
+import {
+    AccountLabel,
+    CoinBalance,
+    FiatValue,
+    HiddenPlaceholder,
+    Translation,
+} from 'src/components/suite';
 import { useDispatch, useLoadingSkeleton, useSelector } from 'src/hooks/suite';
 import { Account, AccountItemType } from 'src/types/wallet';
 import { goto } from 'src/actions/suite/routerActions';
@@ -241,12 +247,14 @@ export const AccountItem = forwardRef(
                             </AccountLabelContainer>
                             <FiatAmount>
                                 {customFiatValue && !isTestnet(symbol) ? (
-                                    <FiatAmountFormatter
-                                        value={customFiatValue}
-                                        currency={localCurrency}
-                                        minimumFractionDigits={0}
-                                        maximumFractionDigits={0}
-                                    />
+                                    <HiddenPlaceholder>
+                                        <FiatAmountFormatter
+                                            value={customFiatValue}
+                                            currency={localCurrency}
+                                            minimumFractionDigits={0}
+                                            maximumFractionDigits={0}
+                                        />
+                                    </HiddenPlaceholder>
                                 ) : (
                                     <FiatValue
                                         amount={formattedBalance}


### PR DESCRIPTION
## Description

Value for tokens in left nav was not blurred when discreet mode was toggled.

## Related Issue

Resolve #11912

## Screenshots:
![Screenshot 2024-04-15 at 12 23 45 PM](https://github.com/trezor/trezor-suite/assets/66002635/b6e24f88-7da5-4398-9c90-359965608b4e)