### PR TITLE
feat(connect-webextension): option to keepalive service worker

### DIFF
--- a/packages/connect-examples/webextension-mv3-sw/src/serviceWorker.js
+++ b/packages/connect-examples/webextension-mv3-sw/src/serviceWorker.js
@@ -12,6 +12,8 @@ chrome.runtime.onInstalled.addListener(details => {
         },
         transports: ['BridgeTransport', 'WebUsbTransport'],
         connectSrc,
+        // This instructs connect to keep the serviceworker in the webextension alive.
+        _extendWebextensionLifetime: true,
     });
 
     TrezorConnect.on('DEVICE_EVENT', event => {

--- a/packages/connect/src/data/connectSettings.ts
+++ b/packages/connect/src/data/connectSettings.ts
@@ -137,5 +137,9 @@ export const parseConnectSettings = (input: Partial<ConnectSettings> = {}) => {
         settings.useCoreInPopup = input.useCoreInPopup;
     }
 
+    if (typeof input._extendWebextensionLifetime === 'boolean') {
+        settings._extendWebextensionLifetime = input._extendWebextensionLifetime;
+    }
+
     return settings;
 };

--- a/packages/connect/src/types/settings.ts
+++ b/packages/connect/src/types/settings.ts
@@ -37,4 +37,6 @@ export interface ConnectSettings {
     proxy?: Proxy;
     sharedLogger?: boolean;
     useCoreInPopup?: boolean;
+    /* _extendWebextensionLifetime features makes the service worker in @trezor/connect-webextension stay alive longer */
+    _extendWebextensionLifetime?: boolean;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allow feature of keepalive from TrezorConnect using Browser API by subscribing to runtime.

## Documentation
* https://developer.chrome.com/docs/extensions/develop/migrate/to-service-workers#keep-sw-alive
* https://developer.chrome.com/blog/longer-esw-lifetimes
* https://stackoverflow.com/questions/66618136/persistent-service-worker-in-chrome-extension
* https://stackoverflow.com/questions/66114681/mv3-chrome-extensions-how-to-forcefully-keep-a-service-worker-alive

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/10471

## How to test it

* Artifact  `connect-example-webextension/webextension-mv3-sw/build` from this link in the one with changes from this PR https://github.com/trezor/trezor-suite/actions/runs/8690218876/artifacts/1414526142

* Artifact `connect-example-webextension/webextension-mv3-sw/build` from current develop https://github.com/trezor/trezor-suite/actions/runs/8682279318/artifacts/1412823173


The issue can be reproduced in the artifact from `develop` following steps:
1. Open the "Connect manager" tab by clicking in the webextension popup
2. On the "Connect manager" from the webextension click on "Get address" and complete the method
3. Wait 30 seconds or a bit more
4. Click again in "Get address" in the "connect manager" tab.
5. Nothing happens, it does not work.

The issue described above should not be possible to replicate in the artifact from this PR. The issue should happen again after 5 minutes of waiting. Is this enough time?