### PR TITLE
chore: removing nightly from standard PR and renaming nightly flow

### DIFF
--- a/.github/workflows/build-test-suite-web-e2e.yaml
+++ b/.github/workflows/build-test-suite-web-e2e.yaml
@@ -19,9 +19,6 @@ on:
             - '.github/workflows/build-desktop*'
             - '.github/workflows/release*'
             - '.github/workflows/template*'
-    # TODO: after a more sophisticated system of test running is implemented, move the cron job into a separate flow that will run all tests
-    schedule:
-        - cron: '0 0 * * *' # run all tests every day at midnight
 
 env:
     DEV_SERVER_URL: 'https://dev.suite.sldev.cz'

--- a/.github/workflows/test-suite-web-nightly.yaml
+++ b/.github/workflows/test-suite-web-nightly.yaml
@@ -1,4 +1,4 @@
-name: '[Build/Test] suite-web migrations and canary'
+name: '[Test] nightly suite-web, migrations and canary'
 
 # run all suite-web related tests every day at midnight
 on:


### PR DESCRIPTION
## Description

- since the standalone `nightly` gha flow is finished, there is no need for a nightly trigger from standard `build/test` flow
- renamed the said nightly flow to better reflect what it is

