### PR TITLE
Refactor/common fee reducer

### DIFF
--- a/packages/connect-explorer-theme/src/components/locale-switch.tsx
+++ b/packages/connect-explorer-theme/src/components/locale-switch.tsx
@@ -4,8 +4,9 @@ import { addBasePath } from 'next/dist/client/add-base-path';
 import { useRouter } from 'next/router';
 import { GlobeIcon } from 'nextra/icons';
 
-import { useConfig } from '../contexts';
 import { Select } from '@trezor/components';
+
+import { useConfig } from '../contexts';
 
 interface LocaleSwitchProps {
     lite?: boolean;

--- a/packages/suite/src/actions/wallet/__tests__/blockchainActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/blockchainActions.test.ts
@@ -14,7 +14,7 @@ import {
 
 import { configureStore, filterThunkActionTypes } from 'src/support/tests/configureStore';
 import { accountsReducer, transactionsReducer, blockchainReducer } from 'src/reducers/wallet';
-import feesReducer from 'src/reducers/wallet/feesReducer';
+import { feesReducer } from 'src/reducers/wallet/feesReducer';
 
 import * as fixtures from '../__fixtures__/blockchainActions';
 

--- a/packages/suite/src/actions/wallet/__tests__/blockchainActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/blockchainActions.test.ts
@@ -14,7 +14,7 @@ import {
 
 import { configureStore, filterThunkActionTypes } from 'src/support/tests/configureStore';
 import { accountsReducer, transactionsReducer, blockchainReducer } from 'src/reducers/wallet';
-import { feesReducer } from 'src/reducers/wallet/feesReducer';
+import { feesReducer } from '@suite-common/wallet-core';
 
 import * as fixtures from '../__fixtures__/blockchainActions';
 

--- a/packages/suite/src/reducers/wallet/feesReducer.ts
+++ b/packages/suite/src/reducers/wallet/feesReducer.ts
@@ -1,26 +1,20 @@
-import produce from 'immer';
 import { FeeInfo } from '@suite-common/wallet-types';
-import { NETWORKS } from 'src/config/wallet';
-import { Network, WalletAction } from 'src/types/wallet';
 import { blockchainActions } from '@suite-common/wallet-core';
+import { Network, networksCompatibility } from '@suite-common/wallet-config';
+import { createReducer } from '@reduxjs/toolkit';
 
-// type Symbol = Network['symbol'] | 'erc20';
-export type State = {
+export type FeesState = {
     [key in Network['symbol']]: FeeInfo;
 };
 
-const initialStatePredefined: Partial<State> = {
-    // erc20: {
-    //     blockHeight: 0,
-    //     blockTime: 10,
-    //     minFee: 1,
-    //     maxFee: 100,
-    //     levels: [{ label: 'normal', feePerUnit: '1', blocks: 0 }],
-    // },
+export type FeesRootState = {
+    wallet: {
+        fees: FeesState;
+    };
 };
 
 // fill initial state, those values will be changed by BLOCKCHAIN.UPDATE_FEE action
-export const initialState = NETWORKS.reduce((state, network) => {
+export const initialState = networksCompatibility.reduce((state, network) => {
     if (network.accountType) return state;
     state[network.symbol] = {
         blockHeight: 0,
@@ -31,16 +25,13 @@ export const initialState = NETWORKS.reduce((state, network) => {
     };
 
     return state;
-}, initialStatePredefined as State);
+}, {} as FeesState);
 
-const feesReducer = (state: State = initialState, action: WalletAction) =>
-    produce(state, draft => {
-        if (blockchainActions.updateFee.match(action)) {
-            return {
-                ...draft,
-                ...action.payload,
-            };
-        }
+export const feesReducer = createReducer(initialState, builder => {
+    builder.addCase(blockchainActions.updateFee, (state, { payload }) => {
+        return {
+            ...state,
+            ...payload,
+        };
     });
-
-export default feesReducer;
+});

--- a/packages/suite/src/reducers/wallet/index.ts
+++ b/packages/suite/src/reducers/wallet/index.ts
@@ -16,7 +16,7 @@ import settingsReducer from './settingsReducer';
 import graphReducer from './graphReducer';
 import selectedAccountReducer from './selectedAccountReducer';
 import receiveReducer from './receiveReducer';
-import feesReducer from './feesReducer';
+import { feesReducer } from './feesReducer';
 import coinmarketReducer from './coinmarketReducer';
 import { prepareSendFormReducer } from '@suite-common/wallet-core';
 import accountSearchReducer from './accountSearchReducer';

--- a/packages/suite/src/reducers/wallet/index.ts
+++ b/packages/suite/src/reducers/wallet/index.ts
@@ -8,6 +8,8 @@ import {
     prepareDiscoveryReducer,
     prepareTokenDefinitionsReducer,
     prepareStakeReducer,
+    prepareSendFormReducer,
+    feesReducer,
 } from '@suite-common/wallet-core';
 
 import { extraDependencies } from 'src/support/extraDependencies';
@@ -16,9 +18,7 @@ import settingsReducer from './settingsReducer';
 import graphReducer from './graphReducer';
 import selectedAccountReducer from './selectedAccountReducer';
 import receiveReducer from './receiveReducer';
-import { feesReducer } from './feesReducer';
 import coinmarketReducer from './coinmarketReducer';
-import { prepareSendFormReducer } from '@suite-common/wallet-core';
 import accountSearchReducer from './accountSearchReducer';
 import formDraftReducer from './formDraftReducer';
 import cardanoStakingReducer from './cardanoStakingReducer';

--- a/suite-common/wallet-core/src/fees/feesReducer.ts
+++ b/suite-common/wallet-core/src/fees/feesReducer.ts
@@ -1,7 +1,9 @@
-import { FeeInfo } from '@suite-common/wallet-types';
-import { blockchainActions } from '@suite-common/wallet-core';
-import { Network, networksCompatibility } from '@suite-common/wallet-config';
 import { createReducer } from '@reduxjs/toolkit';
+
+import { FeeInfo } from '@suite-common/wallet-types';
+import { Network, networksCompatibility } from '@suite-common/wallet-config';
+
+import { blockchainActions } from '../blockchain/blockchainActions';
 
 export type FeesState = {
     [key in Network['symbol']]: FeeInfo;
@@ -14,7 +16,7 @@ export type FeesRootState = {
 };
 
 // fill initial state, those values will be changed by BLOCKCHAIN.UPDATE_FEE action
-export const initialState = networksCompatibility.reduce((state, network) => {
+const initialState = networksCompatibility.reduce((state, network) => {
     if (network.accountType) return state;
     state[network.symbol] = {
         blockHeight: 0,

--- a/suite-common/wallet-core/src/index.ts
+++ b/suite-common/wallet-core/src/index.ts
@@ -18,6 +18,7 @@ export * from './fiat-rates/fiatRatesTypes';
 export * from './discovery/discoveryActions';
 export * from './discovery/discoveryReducer';
 export * from './discovery/discoveryThunks';
+export * from './fees/feesReducer';
 export * from './firmware/firmwareActions';
 export * from './firmware/firmwareThunks';
 export * from './firmware/firmwareReducer';


### PR DESCRIPTION
## Description

FeesReducer migrated to redux-toolkit and moved to suite-common. These changes are needed because of soon comming suite-native sendForm.

Closes #12027 