### PR TITLE
Feat/view only persistance

### DIFF
--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -18,11 +18,13 @@ import {
 } from '../device/deviceReducer';
 import { DiscoveryRootState, selectIsDeviceDiscoveryActive } from '../discovery/discoveryReducer';
 
-export const accountsInitialState: Account[] = [];
+export type AccountsState = Account[];
+
+export const accountsInitialState: AccountsState = [];
 
 export type AccountsRootState = {
     wallet: {
-        accounts: Account[];
+        accounts: AccountsState;
     };
 };
 

--- a/suite-common/wallet-core/src/device/deviceConstants.ts
+++ b/suite-common/wallet-core/src/device/deviceConstants.ts
@@ -66,4 +66,5 @@ export const portfolioTrackerDevice: TrezorDevice = {
     metadata: {},
     unavailableCapabilities: {},
     availableTranslations: [],
+    remember: true,
 };

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -387,7 +387,7 @@ const createInstance = (draft: State, device: TrezorDevice) => {
     const newDevice: TrezorDevice = {
         ...device,
         passphraseOnDevice: false,
-        remember: false,
+        remember: isPortfolioTrackerDevice,
         // In mobile app, we need to keep device state defined by the constant
         // to be able to filter device accounts for portfolio tracker
         state: isPortfolioTrackerDevice ? device.state : undefined,
@@ -835,7 +835,7 @@ export const selectIsDeviceRemembered = (state: DeviceRootState) => {
     return !!device?.remember;
 };
 
-const selectIsDeviceConnected = (state: DeviceRootState) => {
+export const selectIsDeviceConnected = (state: DeviceRootState) => {
     const device = selectDevice(state);
 
     return !!device?.connected;

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -421,6 +421,20 @@ export const switchDuplicatedDevice = createThunk(
     },
 );
 
+// Sort devices by timestamp and put Portfolio Tracker device at the end.
+const sortDevices = (devices: TrezorDevice[]) => {
+    return sortByTimestamp([...devices]).sort((a, b) => {
+        if (a.id === b.id) {
+            return 0;
+        }
+        if (a.id === PORTFOLIO_TRACKER_DEVICE_ID) {
+            return 1;
+        }
+
+        return -1;
+    });
+};
+
 export const initDevices = createThunk(
     `${DEVICE_MODULE_PREFIX}/initDevices`,
     (_, { dispatch, getState }) => {
@@ -433,9 +447,10 @@ export const initDevices = createThunk(
             forcedDevices.forEach(d => {
                 dispatch(toggleRememberDevice({ device: d }));
             });
+
             dispatch(
                 selectDeviceThunk(
-                    forcedDevices.length ? forcedDevices[0] : sortByTimestamp([...devices])[0],
+                    forcedDevices.length ? forcedDevices[0] : sortDevices(devices)[0],
                 ),
             );
         }

--- a/suite-native/app/src/initActions.ts
+++ b/suite-native/app/src/initActions.ts
@@ -3,6 +3,7 @@ import { connectInitThunk } from '@suite-common/connect-init';
 import {
     createImportedDeviceThunk,
     initBlockchainThunk,
+    initDevices,
     periodicFetchFiatRatesThunk,
 } from '@suite-common/wallet-core';
 import { initAnalyticsThunk } from '@suite-native/analytics';
@@ -26,6 +27,9 @@ export const applicationInit = createThunk(
 
             dispatch(initMessageSystemThunk());
 
+            // Select latest remembered device or Portfolio Tracker device.
+            dispatch(initDevices());
+
             await dispatch(connectInitThunk());
 
             dispatch(setIsConnectInitialized(true));
@@ -41,9 +45,7 @@ export const applicationInit = createThunk(
                 }),
             );
 
-            // We need to make sure to have imported device in state
-            // Since devices are not persisted,
-            // we need to create device instance on app start
+            // Create Portfolio Tracker device if it doesn't exist
             dispatch(createImportedDeviceThunk());
 
             // In case that user closed the app while device was connected,

--- a/suite-native/device/src/hooks/useHandleDeviceConnection.ts
+++ b/suite-native/device/src/hooks/useHandleDeviceConnection.ts
@@ -16,6 +16,7 @@ import {
     authorizeDevice,
     selectIsPortfolioTrackerDevice,
     selectDeviceRequestedPin,
+    selectIsDeviceConnected,
     selectIsDeviceConnectedAndAuthorized,
     selectIsNoPhysicalDeviceConnected,
     selectIsDeviceUsingPassphrase,
@@ -36,6 +37,7 @@ export const useHandleDeviceConnection = () => {
     const isOnboardingFinished = useSelector(selectIsOnboardingFinished);
     const isDeviceConnectedAndAuthorized = useSelector(selectIsDeviceConnectedAndAuthorized);
     const hasDeviceRequestedPin = useSelector(selectDeviceRequestedPin);
+    const isDeviceConnected = useSelector(selectIsDeviceConnected);
     const { isBiometricsOverlayVisible } = useIsBiometricsOverlayVisible();
     const isDeviceUsingPassphrase = useSelector(selectIsDeviceUsingPassphrase);
     const navigation = useNavigation<NavigationProp>();
@@ -45,6 +47,7 @@ export const useHandleDeviceConnection = () => {
     // redirect to the Connecting screen where is handled the connection logic.
     useEffect(() => {
         if (
+            isDeviceConnected &&
             isOnboardingFinished &&
             !isPortfolioTrackerDevice &&
             !isDeviceConnectedAndAuthorized &&
@@ -62,6 +65,7 @@ export const useHandleDeviceConnection = () => {
         }
     }, [
         dispatch,
+        isDeviceConnected,
         isOnboardingFinished,
         isPortfolioTrackerDevice,
         isNoPhysicalDeviceConnected,

--- a/suite-native/graph/package.json
+++ b/suite-native/graph/package.json
@@ -41,6 +41,7 @@
         "react-intl": "^6.6.2",
         "react-native": "0.73.6",
         "react-native-reanimated": "3.8.1",
-        "react-redux": "8.0.7"
+        "react-redux": "8.0.7",
+        "redux-persist": "6.0.0"
     }
 }

--- a/suite-native/graph/src/slice.ts
+++ b/suite-native/graph/src/slice.ts
@@ -1,7 +1,9 @@
 import { G } from '@mobily/ts-belt';
+import { createTransform } from 'redux-persist';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 import { AccountKey } from '@suite-common/wallet-types';
+import { selectDeviceStatesNotRemembered, filterObjectKeys } from '@suite-native/storage';
 
 import { TimeframeHoursValue } from './types';
 
@@ -22,10 +24,17 @@ export const graphInitialState: GraphState = {
     accountToGraphTimeframeMap: {},
 };
 
-export const graphPersistWhitelist: Array<keyof GraphState> = [
-    'portfolioGraphTimeframe',
-    'accountToGraphTimeframeMap',
-];
+export const graphPersistTransform = createTransform<GraphState, GraphState>(
+    (inboundState, _, state) => ({
+        ...inboundState,
+        accountToGraphTimeframeMap: filterObjectKeys(
+            inboundState.accountToGraphTimeframeMap,
+            selectDeviceStatesNotRemembered(state),
+        ),
+    }),
+    undefined,
+    { whitelist: ['graph'] },
+);
 
 export const graphSlice = createSlice({
     name: 'graph',

--- a/suite-native/storage/package.json
+++ b/suite-native/storage/package.json
@@ -11,9 +11,12 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
+        "@mobily/ts-belt": "^3.13.1",
         "@reduxjs/toolkit": "1.9.5",
         "@sentry/react-native": "5.19.1",
+        "@suite-common/suite-types": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
+        "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
         "@trezor/utxo-lib": "workspace:*",
         "bs58": "^5.0.0",

--- a/suite-native/storage/src/index.ts
+++ b/suite-native/storage/src/index.ts
@@ -7,3 +7,7 @@ export * from './atomWithUnecryptedStorage';
 
 export * from './migrations/account/v2';
 export * from './migrations/account/v3';
+
+export * from './transforms/deviceTransforms';
+export * from './transforms/walletTransforms';
+export * from './transforms/utils';

--- a/suite-native/storage/src/tests/utils.test.ts
+++ b/suite-native/storage/src/tests/utils.test.ts
@@ -1,0 +1,54 @@
+import { filterObjectKeys } from '../transforms/utils';
+
+describe('filterObjectKeys', () => {
+    it('should filter out keys that are specified in the filterKeys array', () => {
+        const obj = { apple: 1, banana: 2, apricot: 3, berry: 4, ananas: 5 };
+        const filterKeys = ['ap', 'ana'];
+        const expectedResult = { berry: 4 };
+        const result = filterObjectKeys(obj, filterKeys);
+        expect(result).toEqual(expectedResult);
+    });
+
+    it('should return the same object if no keys are filtered', () => {
+        const obj = { apple: 1, banana: 2 };
+        const filterKeys = ['orange'];
+        const expectedResult = { apple: 1, banana: 2 };
+        const result = filterObjectKeys(obj, filterKeys);
+        expect(result).toEqual(expectedResult);
+    });
+
+    it('should return an empty object if all keys are filtered', () => {
+        const obj = { apple: 1, apricot: 2 };
+        const filterKeys = ['a'];
+        const expectedResult = {};
+        const result = filterObjectKeys(obj, filterKeys);
+        expect(result).toEqual(expectedResult);
+    });
+
+    it('should return an empty object when filtering an empty object', () => {
+        const obj = {};
+        const filterKeys = ['a'];
+        const expectedResult = {};
+        const result = filterObjectKeys(obj, filterKeys);
+        expect(result).toEqual(expectedResult);
+    });
+
+    it('should filter out account keys by device states', () => {
+        const accountKeysMap = {
+            'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT-btc-mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@1632F3457D42E393B821ACC9:0':
+                [1, 2, 3],
+            'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT-btc-mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@1632F3457D42E393B821ACC9:1':
+                [4, 5, 6],
+        };
+        const deviceStates = [
+            'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@1632F3457D42E393B821ACC9:0',
+            'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@1632F3457D42E393B821ACC9:3',
+        ];
+        const expectedResult = {
+            'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT-btc-mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@1632F3457D42E393B821ACC9:1':
+                [4, 5, 6],
+        };
+        const result = filterObjectKeys(accountKeysMap, deviceStates);
+        expect(result).toEqual(expectedResult);
+    });
+});

--- a/suite-native/storage/src/transforms/deviceTransforms.ts
+++ b/suite-native/storage/src/transforms/deviceTransforms.ts
@@ -1,0 +1,24 @@
+import { pipe, A } from '@mobily/ts-belt';
+import { createTransform } from 'redux-persist';
+
+import { TrezorDevice } from '@suite-common/suite-types';
+
+const serializeDevice = (device: TrezorDevice) => ({
+    ...device,
+    path: '',
+    remember: true,
+    connected: false,
+    buttonRequests: [],
+});
+
+export const devicePersistTransform = createTransform<TrezorDevice[], Readonly<TrezorDevice[]>>(
+    inboundState => {
+        return pipe(
+            inboundState,
+            A.filter(device => !!device.remember),
+            A.map(serializeDevice),
+        );
+    },
+    undefined,
+    { whitelist: ['devices'] },
+);

--- a/suite-native/storage/src/transforms/utils.ts
+++ b/suite-native/storage/src/transforms/utils.ts
@@ -1,0 +1,22 @@
+import { A, D, O } from '@mobily/ts-belt';
+
+import { DeviceRootState } from '@suite-common/wallet-core';
+
+export const selectDeviceStatesNotRemembered = (state: DeviceRootState) => {
+    return A.filterMap(state.device.devices, device =>
+        device.remember || !device.state ? O.None : O.Some(device.state),
+    );
+};
+
+export const filterObjectKeys = <O extends Record<string, any>>(
+    obj: O,
+    filterKeys: readonly string[],
+): O =>
+    D.keys(obj).reduce((result, key) => {
+        const isKeyFiltered = filterKeys.some(filterKey => key.toString().includes(filterKey));
+        if (isKeyFiltered) {
+            return result;
+        } else {
+            return { ...result, [key]: obj[key] };
+        }
+    }, {} as O);

--- a/suite-native/storage/src/transforms/walletTransforms.ts
+++ b/suite-native/storage/src/transforms/walletTransforms.ts
@@ -1,0 +1,56 @@
+import { A } from '@mobily/ts-belt';
+import { createTransform } from 'redux-persist';
+
+import { AccountsState, TransactionsState } from '@suite-common/wallet-core';
+
+import { selectDeviceStatesNotRemembered, filterObjectKeys } from './utils';
+
+export const walletPersistWhitelist = ['accounts', 'transactions'] satisfies Array<
+    'accounts' | 'transactions'
+>;
+
+export const walletStopPersistTransform = createTransform<any, undefined>(
+    () => undefined,
+    undefined,
+    {
+        whitelist: walletPersistWhitelist,
+    },
+);
+
+type OutboundState = {
+    accounts: Readonly<AccountsState>;
+    transactions: TransactionsState;
+};
+
+type InboundState = OutboundState & {
+    [key: string]: any;
+};
+
+export const walletPersistTransform = createTransform<InboundState, OutboundState>(
+    (inboundState, _, state) => {
+        const devicesStatesNotRemembered = selectDeviceStatesNotRemembered(state);
+
+        const accounts = A.filter(
+            inboundState.accounts,
+            account => !devicesStatesNotRemembered.includes(account?.deviceState),
+        );
+
+        const transactions = filterObjectKeys(
+            inboundState.transactions.transactions,
+            devicesStatesNotRemembered,
+        );
+
+        return {
+            accounts,
+            transactions: {
+                isLoading: false,
+                error: null,
+                transactions,
+            },
+        };
+    },
+    undefined,
+    {
+        whitelist: ['wallet'],
+    },
+);

--- a/suite-native/storage/src/typedPersistReducer.ts
+++ b/suite-native/storage/src/typedPersistReducer.ts
@@ -1,4 +1,6 @@
-import { createMigrate, persistReducer } from 'redux-persist';
+import { createMigrate, persistReducer, Transform } from 'redux-persist';
+import autoMergeLevel1 from 'redux-persist/lib/stateReconciler/autoMergeLevel1';
+import autoMergeLevel2 from 'redux-persist/lib/stateReconciler/autoMergeLevel2';
 import { Reducer } from '@reduxjs/toolkit';
 
 import { initMmkvStorage } from './storage';
@@ -9,12 +11,16 @@ export const preparePersistReducer = async <TReducerInitialState>({
     key,
     version,
     migrations,
+    transforms,
+    mergeLevel = 1,
 }: {
     reducer: Reducer<TReducerInitialState>;
     persistedKeys: Array<keyof TReducerInitialState>;
     key: string;
     version: number;
     migrations?: { [key: string]: (state: any) => any };
+    transforms?: Array<Transform<any, any>>;
+    mergeLevel?: 1 | 2;
 }) => {
     const migrate = createMigrate(migrations ?? {}, { debug: false });
 
@@ -24,6 +30,8 @@ export const preparePersistReducer = async <TReducerInitialState>({
         whitelist: persistedKeys as string[],
         version,
         migrate,
+        transforms,
+        stateReconciler: <any>(mergeLevel === 2 ? autoMergeLevel2 : autoMergeLevel1),
     };
 
     return persistReducer(persistConfig, reducer);

--- a/suite-native/storage/tsconfig.json
+++ b/suite-native/storage/tsconfig.json
@@ -3,7 +3,13 @@
     "compilerOptions": { "outDir": "libDev" },
     "references": [
         {
+            "path": "../../suite-common/suite-types"
+        },
+        {
             "path": "../../suite-common/wallet-config"
+        },
+        {
+            "path": "../../suite-common/wallet-core"
         },
         {
             "path": "../../suite-common/wallet-types"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9246,6 +9246,7 @@ __metadata:
     react-native: "npm:0.73.6"
     react-native-reanimated: "npm:3.8.1"
     react-redux: "npm:8.0.7"
+    redux-persist: "npm:6.0.0"
   languageName: unknown
   linkType: soft
 
@@ -9857,9 +9858,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/storage@workspace:suite-native/storage"
   dependencies:
+    "@mobily/ts-belt": "npm:^3.13.1"
     "@reduxjs/toolkit": "npm:1.9.5"
     "@sentry/react-native": "npm:5.19.1"
+    "@suite-common/suite-types": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
+    "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@trezor/utxo-lib": "workspace:*"
     bs58: "npm:^5.0.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Persist remembered device data in redux-persist.
- Persist also Portfolio Tracker device because it also acts as remembered device.
- Preselect most recently connected remembered device on app start or Portfolio tracker device.

Persisted data:
- list of devices with `remembered === true` (selectedDevice is not remembered, devices are sorted by timestamp instead) 
- graph setting (timeframe) for accounts from remembered devices
- `accounts` and `transactions` related to remembered devices

We may also consider persisting the discovery state.


## Related Issue

Resolve [#11852](https://github.com/trezor/trezor-suite/issues/11852)

