### PR TITLE
fix(suite-native): correct AlertSheet layout

### DIFF
--- a/suite-native/alerts/src/components/AlertSheet.tsx
+++ b/suite-native/alerts/src/components/AlertSheet.tsx
@@ -10,6 +10,7 @@ import {
     useBottomSheetAnimation,
     CenteredTitleHeader,
     Pictogram,
+    Box,
 } from '@suite-native/atoms';
 
 import { useShakeAnimation } from '../useShakeAnimation';
@@ -32,8 +33,9 @@ const alertSheetContainerStyle = prepareNativeStyle(utils => ({
     ...utils.boxShadows.small,
 }));
 
-const alertSheetContentStyle = prepareNativeStyle(_ => ({
+const alertSheetContentStyle = prepareNativeStyle(utils => ({
     width: '100%',
+    gap: utils.spacings.large,
 }));
 
 const shakeTriggerStyle = prepareNativeStyle(_ => ({
@@ -93,9 +95,11 @@ export const AlertSheet = ({ alert }: AlertSheetProps) => {
                         onStartShouldSetResponder={_ => true} // Stop the shake event trigger propagation.
                     >
                         <Card style={applyStyle(alertSheetContainerStyle)}>
-                            <VStack style={applyStyle(alertSheetContentStyle)} spacing="large">
+                            <VStack style={applyStyle(alertSheetContentStyle)}>
                                 {icon && pictogramVariant && (
-                                    <Pictogram variant={pictogramVariant} icon={icon} />
+                                    <Box alignItems="center">
+                                        <Pictogram variant={pictogramVariant} icon={icon} />
+                                    </Box>
                                 )}
                                 <CenteredTitleHeader title={title} subtitle={description} />
                                 {appendix}


### PR DESCRIPTION
Pictogram in AlertSheet had wrong layout after latest changes

Resolve #12035

## Screenshots:
<img src="https://github.com/trezor/trezor-suite/assets/2011829/b39b53d8-d27a-4ac1-adb2-b7ffa3114644" width=250 />
<img src="https://github.com/trezor/trezor-suite/assets/2011829/77fe35df-ad29-4ac6-ad9b-b0c156a03074" width=250 />
