### PR TITLE
feat(protocol): separate chunking from encoding

### DIFF
--- a/packages/protocol/src/protocol-bridge/encode.ts
+++ b/packages/protocol/src/protocol-bridge/encode.ts
@@ -1,6 +1,9 @@
 import { HEADER_SIZE } from './constants';
 import { TransportProtocolEncode } from '../types';
 
+// for type compatibility, bridge doesn't send chunks
+export const getChunkHeader = (_data: Buffer) => Buffer.alloc(0);
+
 // this file is basically combination of "trezor v1 protocol" and "bridge protocol"
 // there is actually no officially described bridge protocol, but in fact there is one
 // it is because bridge does some parts of the protocol itself (like chunking)
@@ -21,5 +24,5 @@ export const encode: TransportProtocolEncode = (data, options) => {
     // then put in the actual message
     data.copy(encodedBuffer, HEADER_SIZE);
 
-    return [encodedBuffer];
+    return encodedBuffer;
 };

--- a/packages/protocol/src/protocol-v1/constants.ts
+++ b/packages/protocol/src/protocol-v1/constants.ts
@@ -1,4 +1,3 @@
 export const MESSAGE_MAGIC_HEADER_BYTE = 63;
 export const MESSAGE_HEADER_BYTE = 0x23;
-export const HEADER_SIZE = 1 + 1 + 2 + 4; // MESSAGE_HEADER_BYTE + MESSAGE_HEADER_BYTE + messageType + dataLength
-export const BUFFER_SIZE = 64;
+export const HEADER_SIZE = 1 + 1 + 1 + 2 + 4; // MESSAGE_MAGIC_HEADER_BYTE + MESSAGE_HEADER_BYTE + MESSAGE_HEADER_BYTE + messageType + dataLength

--- a/packages/protocol/src/protocol-v1/decode.ts
+++ b/packages/protocol/src/protocol-v1/decode.ts
@@ -38,6 +38,6 @@ export const decode: TransportProtocolDecode = bytes => {
     return {
         length,
         messageType,
-        payload: buffer.subarray(HEADER_SIZE + 1), // each chunk is prefixed by magic byte
+        payload: buffer.subarray(HEADER_SIZE),
     };
 };

--- a/packages/protocol/src/protocol-v1/encode.ts
+++ b/packages/protocol/src/protocol-v1/encode.ts
@@ -1,10 +1,12 @@
-import {
-    HEADER_SIZE,
-    MESSAGE_HEADER_BYTE,
-    BUFFER_SIZE,
-    MESSAGE_MAGIC_HEADER_BYTE,
-} from './constants';
+import { HEADER_SIZE, MESSAGE_HEADER_BYTE, MESSAGE_MAGIC_HEADER_BYTE } from './constants';
 import { TransportProtocolEncode } from '../types';
+
+export const getChunkHeader = (_data: Buffer) => {
+    const header = Buffer.alloc(1);
+    header.writeUInt8(MESSAGE_MAGIC_HEADER_BYTE);
+
+    return header;
+};
 
 export const encode: TransportProtocolEncode = (data, options) => {
     const { messageType } = options;
@@ -13,42 +15,23 @@ export const encode: TransportProtocolEncode = (data, options) => {
     }
 
     const fullSize = HEADER_SIZE + data.length;
-    const chunkSize = options.chunkSize || BUFFER_SIZE;
 
     const encodedBuffer = Buffer.alloc(fullSize);
+    // 1 byte
+    encodedBuffer.writeUInt8(MESSAGE_MAGIC_HEADER_BYTE, 0);
 
     // 2*1 byte
-    encodedBuffer.writeUInt8(MESSAGE_HEADER_BYTE, 0);
     encodedBuffer.writeUInt8(MESSAGE_HEADER_BYTE, 1);
+    encodedBuffer.writeUInt8(MESSAGE_HEADER_BYTE, 2);
 
     // 2 bytes
-    encodedBuffer.writeUInt16BE(messageType, 2);
+    encodedBuffer.writeUInt16BE(messageType, 3);
 
-    // 4 bytes (so 8 in total)
-    encodedBuffer.writeUInt32BE(data.length, 4);
+    // 4 bytes (so 9 in total)
+    encodedBuffer.writeUInt32BE(data.length, 5);
 
     // then put in the actual message
     data.copy(encodedBuffer, HEADER_SIZE);
 
-    const size = chunkSize - 1; // chunkSize - 1 byte of MESSAGE_MAGIC_HEADER_BYTE
-
-    const chunkCount = Math.ceil(encodedBuffer.length / size) || 1;
-
-    // size with one reserved byte for header
-
-    const result: Buffer[] = [];
-    // How many pieces will there actually be
-    // slice and dice
-    for (let i = 0; i < chunkCount; i++) {
-        const start = i * size;
-        const end = Math.min((i + 1) * size, encodedBuffer.length);
-
-        const buffer = Buffer.alloc(chunkSize);
-        buffer.writeUInt8(MESSAGE_MAGIC_HEADER_BYTE);
-        encodedBuffer.copy(buffer, 1, start, end);
-
-        result.push(buffer);
-    }
-
-    return result;
+    return encodedBuffer;
 };

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -6,15 +6,15 @@ export type TransportProtocolDecode = (bytes: ArrayBuffer) => {
 
 export interface TransportProtocolEncodeOptions {
     messageType: number | string;
-    chunkSize?: number;
 }
 
 export type TransportProtocolEncode = (
     data: Buffer,
     options: TransportProtocolEncodeOptions,
-) => Buffer[];
+) => Buffer;
 
 export interface TransportProtocol {
     encode: TransportProtocolEncode;
     decode: TransportProtocolDecode;
+    getChunkHeader: (data: Buffer) => Buffer;
 }

--- a/packages/protocol/tests/protocol-bridge.test.ts
+++ b/packages/protocol/tests/protocol-bridge.test.ts
@@ -2,18 +2,16 @@ import { bridge } from '../src/index';
 
 describe('protocol-bridge', () => {
     it('encode', () => {
-        let chunks;
+        let result;
         // encode small chunk, message without data
-        chunks = bridge.encode(Buffer.alloc(0), { messageType: 55 });
-        expect(chunks.length).toEqual(1);
-        expect(chunks[0].length).toEqual(6);
+        result = bridge.encode(Buffer.alloc(0), { messageType: 55 });
+        expect(result.length).toEqual(6);
 
         // encode big chunk, message with data
-        chunks = bridge.encode(Buffer.alloc(371), { messageType: 55 });
-        expect(chunks.length).toEqual(1);
-        expect(chunks[0].subarray(0, 6).toString('hex')).toEqual('003700000173');
-        expect(chunks[0].readUint32BE(2)).toEqual(371);
-        expect(chunks[0].length).toEqual(371 + 6);
+        result = bridge.encode(Buffer.alloc(371), { messageType: 55 });
+        expect(result.subarray(0, 6).toString('hex')).toEqual('003700000173');
+        expect(result.readUint32BE(2)).toEqual(371);
+        expect(result.length).toEqual(371 + 6);
 
         // fail to encode unsupported messageType (string)
         expect(() => bridge.encode(Buffer.alloc(64), { messageType: 'Initialize' })).toThrow(

--- a/packages/transport/src/api/abstract.ts
+++ b/packages/transport/src/api/abstract.ts
@@ -108,6 +108,11 @@ export abstract class AbstractApi extends TypedEmitter<{
         | typeof ERRORS.UNEXPECTED_ERROR
     >;
 
+    /**
+     * packet size for api
+     */
+    abstract chunkSize: number;
+
     protected success<T>(payload: T): Success<T> {
         return success(payload);
     }

--- a/packages/transport/src/api/udp.ts
+++ b/packages/transport/src/api/udp.ts
@@ -7,6 +7,7 @@ import { AsyncResultWithTypedError, ResultWithTypedError } from '../types';
 import * as ERRORS from '../errors';
 
 export class UdpApi extends AbstractApi {
+    chunkSize = 64;
     interface = UDP.createSocket('udp4');
     protected communicating = false;
 

--- a/packages/transport/src/api/usb.ts
+++ b/packages/transport/src/api/usb.ts
@@ -28,6 +28,7 @@ interface TransportInterfaceDevice {
 const INTERFACE_DEVICE_DISCONNECTED = 'The device was disconnected.' as const;
 
 export class UsbApi extends AbstractApi {
+    chunkSize = 64;
     devices: TransportInterfaceDevice[] = [];
     usbInterface: ConstructorParams['usbInterface'];
 

--- a/packages/transport/src/utils/send.ts
+++ b/packages/transport/src/utils/send.ts
@@ -5,16 +5,41 @@ import { Root } from 'protobufjs/light';
 import { encode as encodeProtobuf, createMessageFromName } from '@trezor/protobuf';
 import { TransportProtocolEncode } from '@trezor/protocol';
 
-export const buildBuffers = (
-    messages: Root,
-    name: string,
-    data: Record<string, unknown>,
-    encoder: TransportProtocolEncode,
-) => {
+export const createChunks = (data: Buffer, chunkHeader: Buffer, chunkSize: number) => {
+    if (!chunkSize || data.byteLength <= chunkSize) {
+        const buffer = Buffer.alloc(Math.max(chunkSize, data.byteLength));
+        data.copy(buffer);
+
+        return [buffer];
+    }
+
+    // create first chunk without chunkHeader
+    const chunks = [data.subarray(0, chunkSize)];
+    // create following chunks prefixed with chunkHeader
+    let position = chunkSize;
+    while (position < data.byteLength) {
+        const sliceEnd = Math.min(position + chunkSize - chunkHeader.byteLength, data.byteLength);
+        const slice = data.subarray(position, sliceEnd);
+        const chunk = Buffer.concat([chunkHeader, slice]);
+        chunks.push(Buffer.alloc(chunkSize).fill(chunk, 0, chunk.byteLength));
+        position = sliceEnd;
+    }
+
+    return chunks;
+};
+
+interface BuildMessageProps {
+    messages: Root;
+    name: string;
+    data: Record<string, unknown>;
+    encode: TransportProtocolEncode;
+}
+
+export const buildMessage = ({ messages, name, data, encode }: BuildMessageProps) => {
     const { Message, messageType } = createMessageFromName(messages, name);
     const buffer = encodeProtobuf(Message, data);
 
-    return encoder(buffer, {
+    return encode(buffer, {
         messageType,
     });
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

-  `protocol.encode` returns whole message
- added `getChunkHeader` method to protocol interface, currently it's a static value for both protocol-v1 and protocol-bridge, but will be dynamically generated from encoded data by protocol-v2 (THP)
- chunks creation moved to transport package
- chunks size is defined by `TransportApi.chunkSize`
