### PR TITLE
feat(coinmarket): Add payment method filter

### DIFF
--- a/packages/suite-web/e2e/tests/coinmarket/buy.test.ts
+++ b/packages/suite-web/e2e/tests/coinmarket/buy.test.ts
@@ -178,9 +178,8 @@ describe('Coinmarket buy', () => {
                     .invoke('text')
                     .should('be.equal', 'banxa');
                 cy.wrap(wrapper)
-                    .find('[class*="CoinmarketPaymentType__Text"]')
-                    .invoke('text')
-                    .should('be.equal', 'Bank Transfer');
+                    .find('[class*="CoinmarketPaymentPlainType__Text"]')
+                    .should('contain.text', 'Bank Transfer');
                 cy.wrap(wrapper)
                     .find('[class*="Status__Text"]')
                     .invoke('text')

--- a/packages/suite/src/reducers/wallet/useCoinmarketFilterReducer.ts
+++ b/packages/suite/src/reducers/wallet/useCoinmarketFilterReducer.ts
@@ -1,0 +1,112 @@
+import { BuyCryptoPaymentMethod, BuyTrade } from 'invity-api';
+import { Dispatch, useCallback, useEffect, useReducer } from 'react';
+
+type PaymentMethodValueProps = BuyCryptoPaymentMethod | '';
+
+export interface PaymentMethodListProps {
+    value: PaymentMethodValueProps;
+    label: string;
+}
+
+interface InitialStateProps {
+    paymentMethod: PaymentMethodValueProps;
+    paymentMethods: PaymentMethodListProps[];
+}
+
+type ActionType =
+    | {
+          type: 'FILTER_PAYMENT_METHOD';
+          payload: PaymentMethodValueProps;
+      }
+    | {
+          type: 'FILTER_SET_PAYMENT_METHODS';
+          payload: BuyTrade[];
+      };
+
+export interface UseCoinmarketFilterReducerOutputProps {
+    state: InitialStateProps;
+    dispatch: Dispatch<ActionType>;
+    actions: {
+        handleFilterQuotes: (quotes: BuyTrade[] | undefined) => BuyTrade[] | undefined;
+    };
+}
+
+const getPaymentMethods = (quotes: BuyTrade[]): PaymentMethodListProps[] => {
+    const newPaymentMethods: PaymentMethodListProps[] = [];
+
+    quotes.forEach(quote => {
+        const { paymentMethod } = quote;
+        const isNotInArray = !newPaymentMethods.some(item => item.value === paymentMethod);
+
+        if (typeof paymentMethod !== 'undefined' && isNotInArray) {
+            const label = quote.paymentMethodName ?? paymentMethod;
+
+            newPaymentMethods.push({ value: paymentMethod, label });
+        }
+    });
+
+    return newPaymentMethods;
+};
+
+const reducer = (state: InitialStateProps, action: ActionType) => {
+    switch (action.type) {
+        case 'FILTER_PAYMENT_METHOD':
+            return {
+                ...state,
+                paymentMethod: action.payload,
+            };
+        case 'FILTER_SET_PAYMENT_METHODS': {
+            const newPaymentMethods: PaymentMethodListProps[] = getPaymentMethods(action.payload);
+
+            return {
+                ...state,
+                paymentMethods: newPaymentMethods,
+            };
+        }
+        default:
+            return state;
+    }
+};
+
+export const useCoinmarketFilterReducer = (
+    quotes: BuyTrade[] | undefined,
+): UseCoinmarketFilterReducerOutputProps => {
+    const initialState: InitialStateProps = {
+        paymentMethod: '',
+        paymentMethods: quotes ? getPaymentMethods(quotes) : [],
+    };
+
+    const [state, dispatch] = useReducer(reducer, initialState);
+
+    // if payment method is not in payment methods then reset
+    useEffect(() => {
+        const isMethodInPaymentMethods = state.paymentMethods.find(
+            item => item.value === state.paymentMethod,
+        );
+
+        if (!isMethodInPaymentMethods) {
+            dispatch({ type: 'FILTER_PAYMENT_METHOD', payload: '' });
+        }
+    }, [state.paymentMethod, state.paymentMethods]);
+
+    const handleFilterQuotes = useCallback(
+        (quotes: BuyTrade[] | undefined) => {
+            if (!quotes) return;
+
+            return quotes.filter(quote => {
+                if (state.paymentMethod === '') return true; // all
+
+                return quote.paymentMethod === state.paymentMethod;
+            });
+        },
+        [state.paymentMethod],
+    );
+
+    return {
+        state,
+        dispatch,
+        actions: {
+            handleFilterQuotes,
+        },
+    };
+};

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -4718,6 +4718,10 @@ export default defineMessages({
         id: 'TR_PAYMENT_METHOD_UNKNOWN',
         defaultMessage: 'Unknown',
     },
+    TR_PAYMENT_METHOD_ALL: {
+        id: 'TR_PAYMENT_METHOD_ALL',
+        defaultMessage: 'All payment methods',
+    },
     TR_OFFER_FEE_INFO: {
         id: 'TR_OFFER_FEE_INFO',
         defaultMessage:

--- a/packages/suite/src/types/wallet/coinmarketBuyOffers.ts
+++ b/packages/suite/src/types/wallet/coinmarketBuyOffers.ts
@@ -6,6 +6,7 @@ import type { AppState } from 'src/types/suite';
 import type { Account } from 'src/types/wallet';
 import type { BuyInfo } from 'src/actions/wallet/coinmarketBuyActions';
 import type { WithSelectedAccountLoadedProps } from 'src/components/wallet';
+import { UseCoinmarketFilterReducerOutputProps } from 'src/reducers/wallet/useCoinmarketFilterReducer';
 
 export type UseOffersProps = WithSelectedAccountLoadedProps;
 
@@ -24,6 +25,8 @@ export type ContextValues = {
     goToPayment: (address: string) => void;
     timer: Timer;
     getQuotes: () => Promise<void>;
+    innerQuotesFilterReducer: UseCoinmarketFilterReducerOutputProps;
+    innerAlternativeQuotesFilterReducer: UseCoinmarketFilterReducerOutputProps;
 };
 
 export type AddressOptionsFormState = {

--- a/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/List/BuyQuoteFilter.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/List/BuyQuoteFilter.tsx
@@ -1,0 +1,80 @@
+import { Select } from '@trezor/components';
+import { BuyCryptoPaymentMethod, BuyTrade } from 'invity-api';
+import styled from 'styled-components';
+import { CoinmarketPaymentType } from 'src/views/wallet/coinmarket/common';
+//import { useCoinmarketExchangeFormContext } from 'src/hooks/wallet/useCoinmarketExchangeForm';
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'src/hooks/suite';
+
+const Wrapper = styled.div`
+    margin-top: 20px;
+`;
+
+const Option = styled.div`
+    display: flex;
+    align-items: center;
+`;
+
+interface BuyQuoteFilter {
+    quotes: BuyTrade[];
+}
+
+interface PaymentMethodListProps {
+    value: BuyCryptoPaymentMethod | '';
+    label: string;
+}
+
+export const BuyQuoteFilter = ({ quotes }: BuyQuoteFilter) => {
+    const { translationString } = useTranslation();
+    const defaultMethod: PaymentMethodListProps = {
+        value: '',
+        label: translationString('TR_PAYMENT_METHOD_ALL'),
+    };
+    const [paymentMethod, setPaymentMethod] = useState<PaymentMethodListProps>(defaultMethod);
+
+    const paymentMethods = useMemo(() => {
+        const array: PaymentMethodListProps[] = [];
+
+        quotes.forEach(quote => {
+            const { paymentMethod } = quote;
+            const isNotInArray = !array.some(item => item.value === paymentMethod);
+
+            if (typeof paymentMethod !== 'undefined' && isNotInArray) {
+                const label = quote.paymentMethodName ?? paymentMethod;
+
+                array.push({ value: paymentMethod, label });
+            }
+        });
+
+        return array;
+    }, [quotes]);
+
+    return (
+        <Wrapper data-test="@coinmarket/buy/filter">
+            <Select
+                onChange={(selected: PaymentMethodListProps) => {
+                    setPaymentMethod(selected);
+                }}
+                value={paymentMethod}
+                options={[defaultMethod, ...paymentMethods]}
+                formatOptionLabel={(option: PaymentMethodListProps) => (
+                    <Option>
+                        {option.value !== '' ? (
+                            <CoinmarketPaymentType
+                                method={option.value}
+                                methodName={option.label}
+                            />
+                        ) : (
+                            <div>{option.label}</div>
+                        )}
+                    </Option>
+                )}
+                data-test="@coinmarket/buy/filter-payment-method"
+                minValueWidth="100px"
+                isSearchable
+                isClearable={false}
+                isDisabled={false}
+            />
+        </Wrapper>
+    );
+};

--- a/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/List/BuyQuoteList.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/List/BuyQuoteList.tsx
@@ -90,7 +90,8 @@ interface ListProps {
 }
 
 export const BuyQuoteList = ({ isAlternative, quotes }: ListProps) => {
-    const { quotesRequest, timer } = useCoinmarketBuyOffersContext();
+    const { quotesRequest, timer, innerQuotesFilterReducer, innerAlternativeQuotesFilterReducer } =
+        useCoinmarketBuyOffersContext();
 
     if (!quotesRequest) return null;
     const { fiatStringAmount, fiatCurrency, wantCrypto } = quotesRequest;
@@ -128,7 +129,13 @@ export const BuyQuoteList = ({ isAlternative, quotes }: ListProps) => {
                             />
                         </OrigAmount>
                     )}
-                    <BuyQuoteFilter quotes={quotes} />
+                    <BuyQuoteFilter
+                        quotesFilterReducer={
+                            !isAlternative
+                                ? innerQuotesFilterReducer
+                                : innerAlternativeQuotesFilterReducer
+                        }
+                    />
                 </Left>
                 {!isAlternative && !timer.isStopped && (
                     <Right>

--- a/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/List/BuyQuoteList.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/List/BuyQuoteList.tsx
@@ -12,6 +12,7 @@ import { InvityAPIReloadQuotesAfterSeconds } from 'src/constants/wallet/coinmark
 import { BuyQuote } from './BuyQuote';
 import invityAPI from 'src/services/suite/invityAPI';
 import { cryptoToCoinSymbol } from 'src/utils/wallet/coinmarket/cryptoSymbolUtils';
+import { BuyQuoteFilter } from './BuyQuoteFilter';
 
 const Wrapper = styled.div``;
 const Quotes = styled.div``;
@@ -127,6 +128,7 @@ export const BuyQuoteList = ({ isAlternative, quotes }: ListProps) => {
                             />
                         </OrigAmount>
                     )}
+                    <BuyQuoteFilter quotes={quotes} />
                 </Left>
                 {!isAlternative && !timer.isStopped && (
                     <Right>

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketPaymentPlainType.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketPaymentPlainType.tsx
@@ -1,0 +1,49 @@
+import { ReactNode } from 'react';
+import styled from 'styled-components';
+import { typography } from '@trezor/theme';
+import { BuyCryptoPaymentMethod, SavingsPaymentMethod, SellCryptoPaymentMethod } from 'invity-api';
+import { Translation } from 'src/components/suite';
+
+const Text = styled.div`
+    display: flex;
+    align-items: center;
+    ${typography.body};
+    color: ${({ theme }) => theme.textDefault};
+`;
+
+interface CoinmarketPaymentTypeProps {
+    children?: ReactNode;
+    method?: BuyCryptoPaymentMethod | SellCryptoPaymentMethod | SavingsPaymentMethod;
+    methodName?: string;
+}
+type TranslatedPaymentMethod = 'bankTransfer' | 'creditCard';
+
+type PaymentMethodId = `TR_PAYMENT_METHOD_${Uppercase<TranslatedPaymentMethod>}`;
+
+const getPaymentMethod = (method: TranslatedPaymentMethod): PaymentMethodId =>
+    `TR_PAYMENT_METHOD_${method.toUpperCase() as Uppercase<TranslatedPaymentMethod>}`;
+
+export const CoinmarketPaymentPlainType = ({
+    children,
+    method,
+    methodName,
+}: CoinmarketPaymentTypeProps) => (
+    <div>
+        <Text>
+            {method ? (
+                <>
+                    {method === 'bankTransfer' || method === 'creditCard' ? (
+                        <Translation id={getPaymentMethod(method)} />
+                    ) : (
+                        <Text>{methodName || method}</Text>
+                    )}
+                </>
+            ) : (
+                <Text>
+                    <Translation id="TR_PAYMENT_METHOD_UNKNOWN" />
+                </Text>
+            )}
+        </Text>
+        {children}
+    </div>
+);

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketPaymentType.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketPaymentType.tsx
@@ -1,9 +1,8 @@
 import { ReactNode } from 'react';
 import styled from 'styled-components';
-import { variables } from '@trezor/components';
 import invityApi from 'src/services/suite/invityAPI';
 import { BuyCryptoPaymentMethod, SavingsPaymentMethod, SellCryptoPaymentMethod } from 'invity-api';
-import { Translation } from 'src/components/suite';
+import { CoinmarketPaymentPlainType } from './CoinmarketPaymentPlainType';
 
 const Wrapper = styled.div`
     display: flex;
@@ -25,25 +24,11 @@ const IconWrapper = styled.div`
 
 const Icon = styled.img``;
 
-const Text = styled.div`
-    display: flex;
-    align-items: center;
-    font-size: ${variables.FONT_SIZE.NORMAL};
-    color: ${({ theme }) => theme.TYPE_DARK_GREY};
-    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-`;
-
 interface CoinmarketPaymentTypeProps {
     children?: ReactNode;
     method?: BuyCryptoPaymentMethod | SellCryptoPaymentMethod | SavingsPaymentMethod;
     methodName?: string;
 }
-type TranslatedPaymentMethod = 'bankTransfer' | 'creditCard';
-
-type PaymentMethodId = `TR_PAYMENT_METHOD_${Uppercase<TranslatedPaymentMethod>}`;
-
-const getPaymentMethod = (method: TranslatedPaymentMethod): PaymentMethodId =>
-    `TR_PAYMENT_METHOD_${method.toUpperCase() as Uppercase<TranslatedPaymentMethod>}`;
 
 export const CoinmarketPaymentType = ({
     children,
@@ -60,24 +45,9 @@ export const CoinmarketPaymentType = ({
                     />
                 </Bg>
             </IconWrapper>
-            <div>
-                <Text>
-                    {method ? (
-                        <>
-                            {method === 'bankTransfer' || method === 'creditCard' ? (
-                                <Translation id={getPaymentMethod(method)} />
-                            ) : (
-                                <Text>{methodName || method}</Text>
-                            )}
-                        </>
-                    ) : (
-                        <Text>
-                            <Translation id="TR_PAYMENT_METHOD_UNKNOWN" />
-                        </Text>
-                    )}
-                </Text>
+            <CoinmarketPaymentPlainType method={method} methodName={methodName}>
                 {children}
-            </div>
+            </CoinmarketPaymentPlainType>
         </>
     </Wrapper>
 );


### PR DESCRIPTION
# Info
Add payment method filter above list of offers in Buy flow in Trezor Suite.
- Default payment method will be “All payment methods”
- Filter will show payment methods available for current list of offers (only offers without error)
- Persist selected payment method - if there is no offer, fallback to default

# Design
![image](https://github.com/trezor/trezor-suite/assets/15160619/81bb497f-e5db-4767-ad62-15bb6fcd98ec)
