### PR TITLE
chore(components): refactor checkbox and radio variants

### DIFF
--- a/packages/components/src/components/form/Checkbox/Checkbox.stories.tsx
+++ b/packages/components/src/components/form/Checkbox/Checkbox.stories.tsx
@@ -16,15 +16,24 @@ export const Checkbox: StoryObj<CheckboxProps> = {
         const handleIsChecked = () => updateArgs({ isChecked: !isChecked });
 
         return (
-            <CheckboxComponent
-                variant="primary"
-                isChecked={isChecked}
-                {...args}
-                onClick={handleIsChecked}
-            >
+            <CheckboxComponent isChecked={isChecked} {...args} onClick={handleIsChecked}>
                 {args.children}
             </CheckboxComponent>
         );
     },
-    args: { children: 'Checkbox' },
+    args: { children: 'Checkbox', isDisabled: false, isAlert: false, labelAlignment: 'right' },
+    argTypes: {
+        labelAlignment: {
+            options: ['left', 'right'],
+            control: {
+                type: 'radio',
+            },
+        },
+        variant: {
+            options: ['default', 'indeterminate'],
+            control: {
+                type: 'radio',
+            },
+        },
+    },
 };

--- a/packages/components/src/components/form/Checkbox/Checkbox.tsx
+++ b/packages/components/src/components/form/Checkbox/Checkbox.tsx
@@ -5,7 +5,7 @@ import { borders, Color, spacingsPx, typography } from '@trezor/theme';
 import { KEYBOARD_CODE } from '../../../constants/keyboardEvents';
 import { Icon } from '../../assets/Icon/Icon';
 import { getFocusShadowStyle } from '../../../utils/utils';
-import { UIHorizontalAlignment, UIVariant } from '../../../config/types';
+import { UIHorizontalAlignment } from '../../../config/types';
 import { FrameProps, TransientFrameProps, withFrameProps } from '../../common/frameProps';
 import { makePropsTransient } from '../../../utils/transientProps';
 
@@ -23,7 +23,7 @@ interface VariantStyles {
 }
 
 export const variantStyles: Record<CheckboxVariant, VariantStyles> = {
-    primary: {
+    default: {
         background: 'backgroundSurfaceElevation1',
         border: 'iconSubdued',
         backgroundHover: 'backgroundSurfaceElevation0',
@@ -35,7 +35,7 @@ export const variantStyles: Record<CheckboxVariant, VariantStyles> = {
         backgroundDisabledChecked: 'backgroundPrimarySubtleOnElevation0',
         borderDisabledChecked: 'backgroundPrimarySubtleOnElevation0',
     },
-    destructive: {
+    alert: {
         background: 'backgroundAlertRedSubtleOnElevation0',
         border: 'borderAlertRed',
         backgroundHover: 'backgroundSurfaceElevation0',
@@ -47,7 +47,7 @@ export const variantStyles: Record<CheckboxVariant, VariantStyles> = {
         backgroundDisabledChecked: 'backgroundAlertRedSubtleOnElevation1',
         borderDisabledChecked: 'backgroundAlertRedSubtleOnElevation1',
     },
-    warning: {
+    indeterminate: {
         background: 'backgroundAlertYellowSubtleOnElevation0',
         border: 'backgroundAlertYellowBold',
         backgroundHover: 'backgroundSurfaceElevation0',
@@ -122,7 +122,7 @@ const CheckIcon = styled(Icon)<{ $isVisible: boolean }>`
     transition: opacity 0.1s;
 `;
 
-export const Label = styled.div<{ $isRed: boolean }>`
+export const Label = styled.div<{ $isRed?: boolean }>`
     display: flex;
     justify-content: center;
     text-align: left;
@@ -143,11 +143,12 @@ export const HiddenInput = styled.input`
     height: 0;
 `;
 
-export type CheckboxVariant = Extract<UIVariant, 'primary' | 'destructive' | 'warning'>;
+export type CheckboxVariant = 'default' | 'alert' | 'indeterminate';
 export type LabelAlignment = Extract<UIHorizontalAlignment, 'left' | 'right'>;
 
 export type CheckboxProps = {
-    variant?: CheckboxVariant;
+    variant?: Exclude<CheckboxVariant, 'alert'>;
+    isAlert?: boolean;
     isChecked?: boolean;
     isDisabled?: boolean;
     labelAlignment?: LabelAlignment;
@@ -158,7 +159,8 @@ export type CheckboxProps = {
 } & Pick<FrameProps, 'margin'>;
 
 export const Checkbox = ({
-    variant = 'primary',
+    variant = 'default',
+    isAlert,
     isChecked,
     isDisabled,
     labelAlignment = 'right',
@@ -198,7 +200,7 @@ export const Checkbox = ({
                 tabIndex={-1}
             />
 
-            <CheckContainer tabIndex={0} $variant={variant}>
+            <CheckContainer tabIndex={0} $variant={isAlert ? 'alert' : variant}>
                 <CheckIcon
                     $isVisible={!!isChecked}
                     size={24}
@@ -207,7 +209,7 @@ export const Checkbox = ({
                 />
             </CheckContainer>
 
-            {children && <Label $isRed={variant === 'destructive'}>{children}</Label>}
+            {children && <Label $isRed={isAlert}>{children}</Label>}
         </Container>
     );
 };

--- a/packages/components/src/components/form/Radio/Radio.stories.tsx
+++ b/packages/components/src/components/form/Radio/Radio.stories.tsx
@@ -15,12 +15,12 @@ const Wrapper = styled.div`
 `;
 
 const meta: Meta = {
-    title: 'Form/RadioButton',
+    title: 'Form/Radio',
     component: RadioComponent,
 } as Meta;
 export default meta;
 
-export const RadioButton: StoryObj<RadioProps> = {
+export const Radio: StoryObj<RadioProps> = {
     render: ({ ...args }) => {
         // eslint-disable-next-line
         const [{ isChecked }, updateArgs] = useArgs();
@@ -32,10 +32,24 @@ export const RadioButton: StoryObj<RadioProps> = {
             </RadioComponent>
         );
     },
-    args: { children: 'RadioButton' },
+    args: { children: 'Radio', isDisabled: false, isAlert: false, labelAlignment: 'right' },
+    argTypes: {
+        labelAlignment: {
+            options: ['left', 'right'],
+            control: {
+                type: 'radio',
+            },
+        },
+        variant: {
+            options: ['default', 'indeterminate'],
+            control: {
+                type: 'radio',
+            },
+        },
+    },
 };
 
-export const RadioButtonGroup: StoryObj = {
+export const RadioGroup: StoryObj = {
     render: () => {
         // eslint-disable-next-line
         const [{ option }, updateArgs] = useArgs();
@@ -68,5 +82,4 @@ export const RadioButtonGroup: StoryObj = {
             </Wrapper>
         );
     },
-    args: { option: 'option1' },
 };

--- a/packages/components/src/components/form/Radio/Radio.tsx
+++ b/packages/components/src/components/form/Radio/Radio.tsx
@@ -1,4 +1,4 @@
-import { EventHandler, KeyboardEvent, ReactNode, SyntheticEvent } from 'react';
+import { KeyboardEvent } from 'react';
 import styled from 'styled-components';
 import { Color, borders } from '@trezor/theme';
 
@@ -7,11 +7,11 @@ import { getFocusShadowStyle } from '../../../utils/utils';
 import {
     CheckboxVariant,
     Label,
-    LabelAlignment,
     variantStyles,
     Container,
     HiddenInput,
     CheckContainer,
+    CheckboxProps,
 } from '../Checkbox/Checkbox';
 
 interface VariantStyles {
@@ -21,17 +21,17 @@ interface VariantStyles {
 }
 
 const radioVariantStyles: Record<CheckboxVariant, VariantStyles> = {
-    primary: {
+    default: {
         borderChecked: 'backgroundSecondaryDefault',
         dotDisabledChecked: 'backgroundPrimarySubtleOnElevation0',
         borderDisabledChecked: 'backgroundPrimarySubtleOnElevation1',
     },
-    destructive: {
+    alert: {
         borderChecked: 'backgroundAlertRedSubtleOnElevation0',
         dotDisabledChecked: 'backgroundAlertRedSubtleOnElevation0',
         borderDisabledChecked: 'backgroundAlertRedSubtleOnElevation1',
     },
-    warning: {
+    indeterminate: {
         borderChecked: 'backgroundAlertYellowSubtleOnElevation0',
         dotDisabledChecked: 'backgroundAlertYellowSubtleOnElevation0',
         borderDisabledChecked: 'backgroundAlertYellowSubtleOnElevation1',
@@ -95,18 +95,10 @@ const RadioIcon = styled(CheckContainer)`
     }
 `;
 
-export interface RadioProps {
-    variant?: CheckboxVariant;
-    isChecked?: boolean;
-    isDisabled?: boolean;
-    labelAlignment?: LabelAlignment;
-    onClick: EventHandler<SyntheticEvent>;
-    'data-test'?: string;
-    children?: ReactNode;
-}
-
+export interface RadioProps extends Omit<CheckboxProps, 'className'> {}
 export const Radio = ({
-    variant = 'primary',
+    variant = 'default',
+    isAlert,
     isChecked,
     labelAlignment,
     isDisabled,
@@ -137,9 +129,9 @@ export const Radio = ({
                 tabIndex={-1}
             />
 
-            <RadioIcon $variant={variant} tabIndex={0} />
+            <RadioIcon $variant={isAlert ? 'alert' : variant} tabIndex={0} />
 
-            {children && <Label $isRed={variant === 'destructive'}>{children}</Label>}
+            {children && <Label $isRed={isAlert}>{children}</Label>}
         </Container>
     );
 };

--- a/packages/suite/src/components/backup/BackupSeedCard.tsx
+++ b/packages/suite/src/components/backup/BackupSeedCard.tsx
@@ -112,7 +112,7 @@ export const BackupSeedCard = ({
                 <Label>{label}</Label>
             </Content>
 
-            <StyledCheckbox variant="primary" isChecked={isChecked} onClick={handleCheckboxClick} />
+            <StyledCheckbox isChecked={isChecked} onClick={handleCheckboxClick} />
         </Container>
     );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
API change to make the Checkbox/Radio variants correspond to the naming in [Figma](https://www.figma.com/file/Y2E8dcdNYrSMGIVRjYFXKp/%5BSuite%5D-Components?type=design&mode=design&t=WDeL5yt0x1B64Yt9-0). The previous naming was confusing  because what we called `variant="destructive"` should actually be used for failed validation. Unlike `destructive` Button which denotes dangerous action. I added the `isAlert` prop to make the API simpler.

Also some stories improvements.

