### PR TITLE
fix(github): input for dispatch workflow in NPM beta release

### DIFF
--- a/.github/workflows/release-connect-npm-dependencies.yml
+++ b/.github/workflows/release-connect-npm-dependencies.yml
@@ -25,10 +25,9 @@ on:
           - schema-utils
 
 jobs:
-  deploy-npm-beta:
-    needs: [extract-branch]
+  deploy-npm-dependency-beta:
     environment: npm-packages
     uses: ./.github/workflows/template-release-connect-npm.yml
     with:
       deploymentType: beta
-      packageName: ${{ inputs.package }}
+      packageName: ${{ github.event.inputs.package }}

--- a/.github/workflows/release-connect-npm.yml
+++ b/.github/workflows/release-connect-npm.yml
@@ -13,9 +13,8 @@ on:
 
 jobs:
   deploy-npm-beta:
-    needs: [extract-branch]
     environment: npm-packages
     uses: ./.github/workflows/template-release-connect-npm.yml
     with:
       deploymentType: beta
-      packageName: ${{ inputs.package }}
+      packageName: ${{ github.event.inputs.package }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Couple of issues to fix:
* For dispatch actions inputs should be with `github.event.` before.
* Remove unnecessary  ` needs: [extract-branch]`
* Rename job to `deploy-npm-dependency-beta` for more clarity.

## Related Issue

https://github.com/trezor/trezor-suite/actions/runs/8707504614

## Screenshots:
