### PR TITLE
Fix reading `ethereumSpecific` from `undefined`

### DIFF
--- a/suite-common/wallet-core/src/transactions/transactionsReducer.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsReducer.ts
@@ -310,7 +310,7 @@ export const selectAccountStakeTypeTransactions = (
 ) => {
     const transactions = selectAccountTransactions(state, accountKey);
 
-    return transactions.filter(tx => isStakeTypeTx(tx.ethereumSpecific?.parsedData?.methodId));
+    return transactions.filter(tx => isStakeTypeTx(tx?.ethereumSpecific?.parsedData?.methodId));
 };
 
 export const selectAccountStakeTransactions = (
@@ -319,7 +319,7 @@ export const selectAccountStakeTransactions = (
 ) => {
     const transactions = selectAccountTransactions(state, accountKey);
 
-    return transactions.filter(tx => isStakeTx(tx.ethereumSpecific?.parsedData?.methodId));
+    return transactions.filter(tx => isStakeTx(tx?.ethereumSpecific?.parsedData?.methodId));
 };
 
 export const selectAccountUnstakeTransactions = (
@@ -328,7 +328,7 @@ export const selectAccountUnstakeTransactions = (
 ) => {
     const transactions = selectAccountTransactions(state, accountKey);
 
-    return transactions.filter(tx => isUnstakeTx(tx.ethereumSpecific?.parsedData?.methodId));
+    return transactions.filter(tx => isUnstakeTx(tx?.ethereumSpecific?.parsedData?.methodId));
 };
 
 export const selectAccountClaimTransactions = (
@@ -337,5 +337,5 @@ export const selectAccountClaimTransactions = (
 ) => {
     const transactions = selectAccountTransactions(state, accountKey);
 
-    return transactions.filter(tx => isClaimTx(tx.ethereumSpecific?.parsedData?.methodId));
+    return transactions.filter(tx => isClaimTx(tx?.ethereumSpecific?.parsedData?.methodId));
 };


### PR DESCRIPTION
## Description

Expect undefined txs in Ehtereum-staking-related selectors.

Also, condition for showing staking account item changed (@tomasklim's idea), and polished a bit.

## Related Issue

Resolve #12019