### PR TITLE
[WIP] feat(connect): add instanceId to settings, use in transport

### DIFF
--- a/packages/connect-web/src/connectSettings.ts
+++ b/packages/connect-web/src/connectSettings.ts
@@ -1,5 +1,6 @@
 import { parseConnectSettings as parseSettings } from '@trezor/connect/src/data/connectSettings';
 import type { ConnectSettings } from '@trezor/connect/src/types';
+import { getWeakRandomId } from '@trezor/utils';
 
 export const getEnv = () => {
     if (typeof chrome !== 'undefined' && typeof chrome.runtime?.onConnect !== 'undefined') {
@@ -68,6 +69,11 @@ export const parseConnectSettings = (input: Partial<ConnectSettings> = {}): Conn
     if (typeof input.env !== 'string') {
         settings.env = getEnv();
     }
+
+    // todo: is there something which identifies specific tab better than title?
+    const instanceId = `${getWeakRandomId(4)} ${document.title.substring(0, 20)}`;
+
+    settings.instanceId = instanceId;
 
     return parseSettings(settings);
 };

--- a/packages/connect/src/data/connectSettings.ts
+++ b/packages/connect/src/data/connectSettings.ts
@@ -141,5 +141,9 @@ export const parseConnectSettings = (input: Partial<ConnectSettings> = {}) => {
         settings._extendWebextensionLifetime = input._extendWebextensionLifetime;
     }
 
+    if (typeof input.instanceId === 'string') {
+        settings.instanceId = input.instanceId;
+    }
+
     return settings;
 };

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -66,7 +66,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> {
         super();
 
         let { transports } = DataManager.getSettings();
-        const { debug } = DataManager.getSettings();
+        const { debug, instanceId } = DataManager.getSettings();
         this.messages = DataManager.getProtobufMessages();
 
         // we fill in `transports` with a reasonable fallback in src/index.
@@ -104,6 +104,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> {
                                 latestVersion: getBridgeInfo().version.join('.'),
                                 messages: this.messages,
                                 logger: transportLogger,
+                                instanceId,
                             }),
                         );
                         break;

--- a/packages/connect/src/types/settings.ts
+++ b/packages/connect/src/types/settings.ts
@@ -39,4 +39,5 @@ export interface ConnectSettings {
     useCoreInPopup?: boolean;
     /* _extendWebextensionLifetime features makes the service worker in @trezor/connect-webextension stay alive longer */
     _extendWebextensionLifetime?: boolean;
+    instanceId?: string;
 }

--- a/packages/transport-bridge/src/core.ts
+++ b/packages/transport-bridge/src/core.ts
@@ -92,10 +92,13 @@ export const createApi = (apiStr: 'usb' | 'udp', logger?: Log) => {
         return enumerateDoneResponse;
     };
 
-    const acquire = async (acquireInput: AcquireInput) => {
+    const acquire = async (acquireInput: AcquireInput, { instanceId }: { instanceId?: string }) => {
+        console.log('acquire, instanceId:', instanceId, 'acquireInput:', acquireInput);
+
         const acquireIntentResult = await sessionsClient.acquireIntent({
             path: acquireInput.path,
             previous: acquireInput.previous === 'null' ? null : acquireInput.previous,
+            instanceId,
         });
         if (!acquireIntentResult.success) {
             return acquireIntentResult;
@@ -106,7 +109,7 @@ export const createApi = (apiStr: 'usb' | 'udp', logger?: Log) => {
         if (!openDeviceResult.success) {
             return openDeviceResult;
         }
-        await sessionsClient.acquireDone({ path: acquireInput.path });
+        await sessionsClient.acquireDone({ path: acquireInput.path, instanceId });
 
         return acquireIntentResult;
     };

--- a/packages/transport-bridge/src/http.ts
+++ b/packages/transport-bridge/src/http.ts
@@ -112,10 +112,15 @@ export class TrezordNode {
             ]);
 
             app.post('/acquire/:path/:previous', [
+                parseBodyJSON,
                 (req, res) => {
                     res.setHeader('Content-Type', 'text/plain');
                     this.api
-                        .acquire({ path: req.params.path, previous: req.params.previous })
+                        .acquire(
+                            { path: req.params.path, previous: req.params.previous },
+                            // @ts-expect-error
+                            { instanceId: req.body.instanceId },
+                        )
                         .then(result => {
                             if (!result.success) {
                                 res.statusCode = 400;
@@ -240,6 +245,8 @@ export class TrezordNode {
                         devices: enumerateResult.success ? enumerateResult.payload.descriptors : [],
                         logs: app.logger.getLog().slice(-20),
                     };
+
+                    console.log(props);
 
                     res.end(str(props));
                 },

--- a/packages/transport-bridge/src/ui/components/Device.tsx
+++ b/packages/transport-bridge/src/ui/components/Device.tsx
@@ -28,6 +28,7 @@ export const Device = ({ device }: DeviceProps) => {
             <div>model: {modelName}</div>
             <div>path: {device.path}</div>
             <div>session: {device.session ? device.session : 'none'}</div>
+            <div>app: {device.instanceId} </div>
         </div>
     );
 };

--- a/packages/transport/src/sessions/background.ts
+++ b/packages/transport/src/sessions/background.ts
@@ -195,6 +195,7 @@ export class SessionsBackground extends TypedEmitter<{
             return this.error(ERRORS.DESCRIPTOR_NOT_FOUND);
         }
         this.descriptors[payload.path].session = `${this.lastSession}`;
+        this.descriptors[payload.path].instanceId = payload.instanceId!;
 
         return Promise.resolve(
             this.success({

--- a/packages/transport/src/sessions/types.ts
+++ b/packages/transport/src/sessions/types.ts
@@ -23,7 +23,7 @@ export type EnumerateDoneResponse = BackgroundResponse<{
     descriptors: Descriptor[];
 }>;
 
-export type AcquireIntentRequest = AcquireInput;
+export type AcquireIntentRequest = AcquireInput & { instanceId?: string };
 
 export type AcquireIntentResponse = BackgroundResponseWithError<
     { session: string },
@@ -32,7 +32,7 @@ export type AcquireIntentResponse = BackgroundResponseWithError<
 
 export type AcquireDoneRequest = {
     path: string;
-};
+} & { instanceId?: string };
 
 export type AcquireDoneResponse = BackgroundResponseWithError<
     {

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -48,6 +48,7 @@ export interface AbstractTransportParams {
     messages?: Record<string, any>;
     signal?: AbortSignal;
     logger?: Logger;
+    instanceId: string;
 }
 
 export const isTransportInstance = (transport?: AbstractTransport) => {
@@ -146,8 +147,14 @@ export abstract class AbstractTransport extends TypedEmitter<{
      */
     protected logger: Logger;
 
-    constructor(params?: AbstractTransportParams) {
-        const { messages, signal, logger } = params || {};
+    /**
+     * instanceId is used to identify transport instance in sessions background (there mostly for debugging). It is
+     * also shown on bridge status page
+     */
+    protected instanceId: string;
+
+    constructor(params: AbstractTransportParams) {
+        const { messages, signal, logger, instanceId } = params;
 
         super();
         this.descriptors = [];
@@ -170,6 +177,8 @@ export abstract class AbstractTransport extends TypedEmitter<{
             warn: (..._args: string[]) => {},
             error: (..._args: string[]) => {},
         };
+
+        this.instanceId = instanceId;
     }
 
     /**

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -27,8 +27,8 @@ export abstract class AbstractApiTransport extends AbstractTransport {
     private api: AbstractApi;
     protected acquirePromise?: Deferred<void>;
 
-    constructor({ messages, api, sessionsClient, signal, logger }: ConstructorParams) {
-        super({ messages, signal, logger });
+    constructor({ messages, api, sessionsClient, signal, logger, instanceId }: ConstructorParams) {
+        super({ messages, signal, logger, instanceId });
         this.sessionsClient = sessionsClient;
         this.api = api;
     }
@@ -84,7 +84,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
 
             // inform sessions background about occupied paths and get descriptors back
             const enumerateDoneResponse = await this.sessionsClient.enumerateDone({
-                descriptors,
+                descriptors: descriptors.map(d => ({ ...d, instanceId: this.instanceId })),
             });
 
             return this.success(enumerateDoneResponse.payload.descriptors);

--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -166,6 +166,9 @@ export class BridgeTransport extends AbstractTransport {
 
                 const response = await this.post('/acquire', {
                     params: `${input.path}/${previous}`,
+                    body: {
+                        instanceId: this.instanceId,
+                    },
                     timeout: true,
                     signal,
                 });

--- a/packages/transport/src/types/index.ts
+++ b/packages/transport/src/types/index.ts
@@ -10,6 +10,8 @@ export type Descriptor = {
     type?: DEVICE_TYPE;
     /** only important for T1 over old bridge (trezord-go), defacto part of 'path'. More explanation in https://github.com/trezor/trezor-suite/compare/transport-descriptor-product */
     product?: number;
+    /** connectSettings.instanceId */
+    instanceId: string;
 };
 
 export interface Logger {


### PR DESCRIPTION
this is a very optional part of  #11532 

could be useful to have some indication of which app is using the device. 

This would typically  be used on bridge status page or on "device used elsewhere page". 

<img width="966" alt="image" src="https://github.com/trezor/trezor-suite/assets/30367552/1f6c9b9b-c3ee-4f5e-a872-6abcb17286f7">
