### PR TITLE
fix: reconnect from foreground proxy to keep service worker active when there is a connection

### DIFF
--- a/packages/connect-webextension/src/proxy/index.ts
+++ b/packages/connect-webextension/src/proxy/index.ts
@@ -59,6 +59,16 @@ const init = (settings: Partial<ConnectSettings> = {}): Promise<void> => {
         }
     });
 
+    const reconnect = () => {
+        // By connecting again we keep the service worker active.
+        cancel();
+        _channel = null;
+        init(settings);
+    };
+
+    _channel.port.onDisconnect.removeListener(reconnect);
+    _channel.port.onDisconnect.addListener(reconnect);
+
     return _channel.init().then(() =>
         _channel.postMessage(
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding reconnection to keep service woker up when using foreground proxy in webextension.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/10471
