### PR TITLE
fix(github): npm release Action with environment should have runner

### DIFF
--- a/.github/workflows/release-connect-npm-dependencies.yml
+++ b/.github/workflows/release-connect-npm-dependencies.yml
@@ -27,7 +27,10 @@ on:
 jobs:
   deploy-npm-dependency-beta:
     environment: npm-packages
-    uses: ./.github/workflows/template-release-connect-npm.yml
-    with:
-      deploymentType: beta
-      packageName: ${{ github.event.inputs.package }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to NPM ${{ github.event.inputs.package }}
+        uses: ./.github/workflows/template-release-connect-npm.yml
+        with:
+          deploymentType: beta
+          packageName: ${{ github.event.inputs.package }}

--- a/.github/workflows/release-connect-npm.yml
+++ b/.github/workflows/release-connect-npm.yml
@@ -14,7 +14,10 @@ on:
 jobs:
   deploy-npm-beta:
     environment: npm-packages
-    uses: ./.github/workflows/template-release-connect-npm.yml
-    with:
-      deploymentType: beta
-      packageName: ${{ github.event.inputs.package }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to NPM ${{ github.event.inputs.package }}
+        uses: ./.github/workflows/template-release-connect-npm.yml
+        with:
+          deploymentType: beta
+          packageName: ${{ github.event.inputs.package }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I am not totally sure because I cannot find it in documentation but I have the feeling that when using a environment you need to do it with a runner. That's why I would try to run the template in a step so the job has a runner that can use the environment. But not totally sure. @vdovhanych if you have any other idea let me know.

I am trying to solve the issue that gives error below:

>  Invalid workflow file: .github/workflows/release-connect-npm-dependencies.yml#L30
The workflow is not valid. .github/workflows/release-connect-npm-dependencies.yml (Line: 30, Col: 5): Unexpected value 'uses' .github/workflows/release-connect-npm-dependencies.yml (Line: 31, Col: 5): Unexpected value 'with'

From https://github.com/trezor/trezor-suite/actions/runs/8739810748
