### PR TITLE
fix(mobile): fix Connect firmware assets import

### DIFF
--- a/packages/connect/src/utils/assetUtils.ts
+++ b/packages/connect/src/utils/assetUtils.ts
@@ -1,5 +1,16 @@
 import { DeviceModelInternal } from '../types';
 
+const isDeviceModel = (model: string): model is DeviceModelInternal => {
+    return Object.values(DeviceModelInternal).includes(model as DeviceModelInternal);
+};
+
+const firmwareAssets: Record<DeviceModelInternal, NodeRequire> = {
+    [DeviceModelInternal.T1B1]: require('@trezor/connect-common/files/firmware/t1b1/releases.json'),
+    [DeviceModelInternal.T2T1]: require('@trezor/connect-common/files/firmware/t2t1/releases.json'),
+    [DeviceModelInternal.T2B1]: require('@trezor/connect-common/files/firmware/t2b1/releases.json'),
+    [DeviceModelInternal.T3T1]: require('@trezor/connect-common/files/firmware/t3t1/releases.json'),
+};
+
 export const getAssetByUrl = (url: string) => {
     const fileUrl = url.split('?')[0];
 
@@ -14,14 +25,11 @@ export const getAssetByUrl = (url: string) => {
             return require('@trezor/protobuf/messages.json');
     }
 
-    // Handle dynamic firmware URLs using the DeviceModelInternal enum
     const firmwareMatch = fileUrl.match(/\/firmware\/(\w+)\/releases\.json$/);
     if (firmwareMatch) {
         const modelKey = firmwareMatch[1].toUpperCase();
-        if (Object.values(DeviceModelInternal).includes(modelKey as DeviceModelInternal)) {
-            return require(
-                `@trezor/connect-common/files/firmware/${modelKey.toLowerCase()}/releases.json`,
-            );
+        if (isDeviceModel(modelKey)) {
+            return firmwareAssets[modelKey];
         }
     }
 


### PR DESCRIPTION
This PR fixes issue that was introduced in #11968 and broke mobile app that doesn't support dynamic imports

It uses static imports now but it's still future proof because it will throw error if new device is added into `DeviceModelInternal` enum.

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
