### PR TITLE
Handle bridge target undefined

### DIFF
--- a/packages/suite/src/views/suite/bridge/index.tsx
+++ b/packages/suite/src/views/suite/bridge/index.tsx
@@ -172,7 +172,7 @@ export const InstallBridge = () => {
                             data-test="@bridge/installers"
                         />
 
-                        <TrezorLink variant="nostyle" href={`${data.uri}${target.value}`}>
+                        <TrezorLink variant="nostyle" href={`${data.uri}${target?.value}`}>
                             <DownloadBridgeButton data-test="@bridge/download-button">
                                 <Translation
                                     id="TR_DOWNLOAD_LATEST_BRIDGE"


### PR DESCRIPTION
## Description

In desktop Suite, bridge install target can be `undefined`, so we have to be able to handle it in UI. The strange thing is that the Bridge Install modal shouldn't be accessible in desktop Suite at all, so I really don't know how this bug had been encountered in the first place.

## Related Issue

Resolve #12082
