### PR TITLE
fix(github): checkout repo before using template

### DIFF
--- a/.github/workflows/release-connect-npm-dependencies.yml
+++ b/.github/workflows/release-connect-npm-dependencies.yml
@@ -29,6 +29,10 @@ jobs:
     environment: npm-packages
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
       - name: Deploy to NPM ${{ github.event.inputs.package }}
         uses: ./.github/workflows/template-release-connect-npm.yml
         with:

--- a/.github/workflows/release-connect-npm.yml
+++ b/.github/workflows/release-connect-npm.yml
@@ -16,6 +16,10 @@ jobs:
     environment: npm-packages
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
       - name: Deploy to NPM ${{ github.event.inputs.package }}
         uses: ./.github/workflows/template-release-connect-npm.yml
         with:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
It looks like when calling a template in a step it requires to checkout the repository based on error:

```
Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/trezor-suite/trezor-suite/.github/workflows/template-release-connect-npm.yml'. Did you forget to run actions/checkout before running your local action?
```