### PR TITLE
fix(github): add shell to steps in release npm action

### DIFF
--- a/.github/actions/release-connect-npm/action.yml
+++ b/.github/actions/release-connect-npm/action.yml
@@ -41,6 +41,7 @@ runs:
         submodules: recursive
 
     - name: Extract branch name
+      shell: bash
       run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
       id: extract_branch
 
@@ -51,21 +52,26 @@ runs:
         cache: yarn
 
     - name: Install dependencies
+      shell: bash
       run: yarn install --immutable
 
     - name: Check version
-      run: node ./ci/scripts/check-version ${{ inputs.packageName }} ${{ steps.extract_branch.outputs.branch }} ${{ inputs.deploymentType }}
+      shell: bash
+      run: node ./ci/scripts/check-version.js ${{ inputs.packageName }} ${{ steps.extract_branch.outputs.branch }} ${{ inputs.deploymentType }}
 
     - name: Set NPM token
+      shell: bash
       env:
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        NPM_TOKEN: ${{ env.NPM_TOKEN }}
       run: yarn config set npmAuthToken ${{ secrets.NPM_TOKEN }}
 
     - name: Publish to NPM
+      shell: bash
       run: |
         cd ./packages/${{ inputs.packageName }}
         yarn npm publish --tag ${{ inputs.deploymentType }} --access public
 
     - name: Cleanup
+      shell: bash
       if: always()
       run: yarn config unset npmAuthToken

--- a/.github/workflows/release-connect-npm-dependencies.yml
+++ b/.github/workflows/release-connect-npm-dependencies.yml
@@ -34,6 +34,8 @@ jobs:
           ref: develop
 
       - name: Deploy to NPM ${{ github.event.inputs.package }}
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         uses: ./.github/actions/release-connect-npm
         with:
           deploymentType: beta

--- a/.github/workflows/release-connect-npm.yml
+++ b/.github/workflows/release-connect-npm.yml
@@ -21,6 +21,8 @@ jobs:
           ref: develop
 
       - name: Deploy to NPM ${{ github.event.inputs.package }}
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         uses: ./.github/actions/release-connect-npm
         with:
           deploymentType: beta


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* shell needs to be defined in steps in github actions https://docs.github.com/en/actions/creating-actions/creating-a-composite-action#creating-an-action-metadata-file
* `secrets.NPM_TOKEN` has to be defined in the jobs calling the action and then in the action used as `env`.