### PR TITLE
fix(transport): remove accidental descriptors object mutation

### DIFF
--- a/packages/transport/src/sessions/background.ts
+++ b/packages/transport/src/sessions/background.ts
@@ -91,7 +91,9 @@ export class SessionsBackground extends TypedEmitter<{
                     throw new Error(ERRORS.UNEXPECTED_ERROR);
             }
 
-            return { ...result, id: message.id } as HandleMessageResponse<M>;
+            result = JSON.parse(JSON.stringify({ ...result, id: message.id }));
+
+            return result;
         } catch (err) {
             // catch unexpected errors and notify client.
             // background should never stay in "hanged" state


### PR DESCRIPTION
fix accidental descriptors object mutation introduced here https://github.com/trezor/trezor-suite/pull/11692
It does not affect webusb (most common usecase), because with background in the sharedworker there implicit serialization takes place but we need to be careful when used locally with nodeusb or udp transport 
