### PR TITLE
fix(github): use env for NPM_TOKEN instead of secrets in action

### DIFF
--- a/.github/actions/release-connect-npm/action.yml
+++ b/.github/actions/release-connect-npm/action.yml
@@ -61,9 +61,7 @@ runs:
 
     - name: Set NPM token
       shell: bash
-      env:
-        NPM_TOKEN: ${{ env.NPM_TOKEN }}
-      run: yarn config set npmAuthToken ${{ secrets.NPM_TOKEN }}
+      run: yarn config set npmAuthToken ${{ env.NPM_TOKEN }}
 
     - name: Publish to NPM
       shell: bash


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Use env for NPM_TOKEN instead of secrets in action