### PR TITLE
chore(blockhain-link): beta release 2.1.29-beta.0

### DIFF
--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/blockchain-link",
-    "version": "2.1.28",
+    "version": "2.1.29-beta.0",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/blockchain-link",
     "description": "High-level javascript interface for blockchain communication",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I need to bump the version to a beta one in order to be able to fully test releasing beta npm from GitHub Action. It needs to satisfy the `check-version.js` script.