### PR TITLE
feat(suite-native): obtain usb permission inside app instead of general intent

### DIFF
--- a/packages/react-native-usb/plugins/withUSBDevice.js
+++ b/packages/react-native-usb/plugins/withUSBDevice.js
@@ -39,25 +39,6 @@ async function setCustomConfigAsync(config, androidManifest) {
         });
     }
 
-    // check if the meta-data with the android.hardware.usb.action.USB_DEVICE_ATTACHED resource already exists
-    const existingMetaData = mainActivity['meta-data']?.find(
-        ({ $: { 'android:name': name } }) =>
-            name === 'android.hardware.usb.action.USB_DEVICE_ATTACHED',
-    );
-
-    if (!existingMetaData) {
-        if (!mainActivity['meta-data']) {
-            mainActivity['meta-data'] = [];
-        }
-
-        mainActivity['meta-data']?.push({
-            $: {
-                'android:name': 'android.hardware.usb.action.USB_DEVICE_ATTACHED',
-                'android:resource': '@xml/device_filter',
-            },
-        });
-    }
-
     return androidManifest;
 }
 


### PR DESCRIPTION
…

<!--- Provide a general summary of your changes in the Title above -->

## Description

TODO:
- [ ] test using suite web with app installed and running on background
- [ ] test connecting device before app start
- [ ] add possibility to retry manually from the app 
- [ ] study more why PendingIntent.FLAG_IMMUTABLE is necessary and if there is a secure way ho to pass the result within ACTION_USB_PERMISSION Intent

<!--- Describe your changes in detail -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/11896

## Screenshots:

<img width="250" alt="image" src="https://github.com/trezor/trezor-suite/assets/3729633/8334b540-afe3-42f1-8b8e-a65de5fe3ca5">

