### PR TITLE
transport-bridge fix bin size

### DIFF
--- a/packages/transport-bridge/package.json
+++ b/packages/transport-bridge/package.json
@@ -13,7 +13,7 @@
         "build:node": "yarn build:node:bin && yarn build:node:module",
         "build:ui": "TS_NODE_PROJECT=\"tsconfig.json\" webpack --config ./webpack/ui.webpack.config.ts",
         "build:js": "yarn g:rimraf -rf dist && yarn build:node && yarn build:ui",
-        "build:bin": "yarn g:rimraf -rf build && yarn pkg ./dist/bin.js --config package.json",
+        "build:bin": "yarn g:rimraf -rf build && yarn pkg ./dist/bin.js --config pkg.config.json --compress GZip",
         "build": "yarn build:js && yarn build:bin",
         "build:lib": "yarn build:js"
     },
@@ -36,18 +36,5 @@
         "react-use": "^17.5.0",
         "styled-components": "^6.1.8",
         "usb": "^2.11.0"
-    },
-    "pkg": {
-        "outputPath": "build",
-        "targets": [
-            "node18-macos-x64",
-            "node18-macos-arm64",
-            "node18-linux-x64",
-            "node18-linux-arm64",
-            "node18-win-x64"
-        ],
-        "assets": [
-            "../../node_modules/usb/**/*"
-        ]
     }
 }

--- a/packages/transport-bridge/package.json
+++ b/packages/transport-bridge/package.json
@@ -33,7 +33,6 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-intl": "^6.6.2",
-        "react-use": "^17.5.0",
         "styled-components": "^6.1.8",
         "usb": "^2.11.0"
     }

--- a/packages/transport-bridge/pkg.config.json
+++ b/packages/transport-bridge/pkg.config.json
@@ -1,0 +1,21 @@
+{
+    "__reason_for_this_file__": "pkg packs all the 'dependencies' but we wan't only some of them to be packed.",
+    "name": "@trezor/transport-bridge",
+    "version": "3.0.0",
+    "license": "See LICENSE.md in repo root",
+    "dependencies": {
+        "@trezor/transport": "workspace:*",
+        "@trezor/utils": "workspace:*",
+        "usb": "^2.11.0"
+    },
+    "pkg": {
+        "outputPath": "build",
+        "targets": [
+            "node18-macos-x64",
+            "node18-macos-arm64",
+            "node18-linux-x64",
+            "node18-linux-arm64"
+        ],
+        "assets": ["../../node_modules/usb/**/*", "./dist/ui/**/*"]
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11198,7 +11198,6 @@ __metadata:
     react: "npm:18.2.0"
     react-dom: "npm:18.2.0"
     react-intl: "npm:^6.6.2"
-    react-use: "npm:^17.5.0"
     styled-components: "npm:^6.1.8"
     usb: "npm:^2.11.0"
     webpack: "npm:^5.91.0"


### PR DESCRIPTION
in https://github.com/trezor/trezor-suite/pull/12050 transport-bridge bin started to incorrectly bundle stuff it wasn't supposed to and grew to some 500mb. 

- 2752d208a6d9c02803c341431152f26524bc894f
  - move pkg config from `package.json` to a newly created file `pkg.config.js`
  - remove windows build
  - add some compression
 
- 460c870f087b6fdd77feac78e74880496301e84d
  - remove nowhere used package

This should allow @vdovhanych to take the bundle from nightly build and test it out in the new "trezor-user-env-lite"