### PR TITLE
feat(unstaking):  Instant unstake forecasting

### DIFF
--- a/packages/blockchain-link-types/src/blockbook.ts
+++ b/packages/blockchain-link-types/src/blockbook.ts
@@ -6,6 +6,7 @@ import type {
     GetFiatRatesForTimestampsParams,
     GetFiatRatesTickersListParams,
     EstimateFeeParams,
+    RpcCallParams,
     AccountInfoParams,
 } from './params';
 import type { AccountBalanceHistory, FiatRatesBySymbol, TokenStandard } from './common';
@@ -210,6 +211,7 @@ declare function FSend(
     params: GetFiatRatesForTimestampsParams,
 ): Promise<FiatRatesForTimestamp>;
 declare function FSend(method: 'estimateFee', params: EstimateFeeParams): Promise<Fee>;
+declare function FSend(method: 'rpcCall', params: RpcCallParams): Promise<{ data: string }>;
 declare function FSend(
     method: 'subscribeAddresses',
     params: { addresses: string[] },

--- a/packages/blockchain-link-types/src/constants/messages.ts
+++ b/packages/blockchain-link-types/src/constants/messages.ts
@@ -14,6 +14,7 @@ export const GET_ACCOUNT_UTXO = 'm_get_account_utxo';
 export const GET_TRANSACTION = 'm_get_transaction';
 export const GET_TRANSACTION_HEX = 'm_get_transaction_hex';
 export const ESTIMATE_FEE = 'm_estimate_fee';
+export const RPC_CALL = 'm_rpc_call';
 export const SUBSCRIBE = 'm_subscribe';
 export const UNSUBSCRIBE = 'm_unsubscribe';
 export const PUSH_TRANSACTION = 'm_push_tx';

--- a/packages/blockchain-link-types/src/constants/responses.ts
+++ b/packages/blockchain-link-types/src/constants/responses.ts
@@ -13,6 +13,7 @@ export const GET_ACCOUNT_BALANCE_HISTORY = 'r_get_account_balance_history';
 export const GET_TRANSACTION = 'r_get_transaction';
 export const GET_TRANSACTION_HEX = 'r_get_transaction_hex';
 export const ESTIMATE_FEE = 'r_estimate_fee';
+export const RPC_CALL = 'r_rpc_call';
 export const SUBSCRIBE = 'r_subscribe';
 export const UNSUBSCRIBE = 'r_unsubscribe';
 export const PUSH_TRANSACTION = 'r_push_tx';

--- a/packages/blockchain-link-types/src/messages.ts
+++ b/packages/blockchain-link-types/src/messages.ts
@@ -6,6 +6,7 @@ import type {
     GetFiatRatesForTimestampsParams,
     GetFiatRatesTickersListParams,
     EstimateFeeParams,
+    RpcCallParams,
     AccountInfoParams,
 } from './params';
 
@@ -77,6 +78,11 @@ export interface EstimateFee {
     payload: EstimateFeeParams;
 }
 
+export interface RpcCall {
+    type: typeof MESSAGES.RPC_CALL;
+    payload: RpcCallParams;
+}
+
 export interface Subscribe {
     type: typeof MESSAGES.SUBSCRIBE;
     payload:
@@ -144,6 +150,7 @@ export type Message =
     | ChannelMessage<GetAccountBalanceHistory>
     | ChannelMessage<GetFiatRatesTickersList>
     | ChannelMessage<EstimateFee>
+    | ChannelMessage<RpcCall>
     | ChannelMessage<Subscribe>
     | ChannelMessage<Unsubscribe>
     | ChannelMessage<PushTransaction>;

--- a/packages/blockchain-link-types/src/params.ts
+++ b/packages/blockchain-link-types/src/params.ts
@@ -35,6 +35,12 @@ export interface EstimateFeeParams {
     };
 }
 
+export interface RpcCallParams {
+    from: string;
+    to: string;
+    data: string;
+}
+
 export interface AccountInfoParams {
     descriptor: string; // address or xpub
     details?: 'basic' | 'tokens' | 'tokenBalances' | 'txids' | 'txs'; // depth, default: 'basic'

--- a/packages/blockchain-link-types/src/responses.ts
+++ b/packages/blockchain-link-types/src/responses.ts
@@ -101,6 +101,13 @@ export interface EstimateFee {
     }[];
 }
 
+export interface RpcCall {
+    type: typeof RESPONSES.RPC_CALL;
+    payload: {
+        data: string;
+    };
+}
+
 export interface Subscribe {
     type: typeof RESPONSES.SUBSCRIBE;
     payload: { subscribed: boolean };
@@ -173,6 +180,7 @@ export type Response =
     | ChannelMessage<GetFiatRatesForTimestamps>
     | ChannelMessage<GetFiatRatesTickersList>
     | ChannelMessage<EstimateFee>
+    | ChannelMessage<RpcCall>
     | ChannelMessage<Subscribe>
     | ChannelMessage<Unsubscribe>
     | ChannelMessage<Notification>

--- a/packages/blockchain-link/src/index.ts
+++ b/packages/blockchain-link/src/index.ts
@@ -229,6 +229,13 @@ class BlockchainLink extends TypedEmitter<Events> {
         });
     }
 
+    rpcCall(payload: MessageTypes.RpcCall['payload']): Promise<ResponseTypes.RpcCall['payload']> {
+        return this.sendMessage({
+            type: MESSAGES.RPC_CALL,
+            payload,
+        });
+    }
+
     /**
      * Subscribe for live changes in
      * - blockchain i.e new blocks mined.

--- a/packages/blockchain-link/src/workers/blockbook/index.ts
+++ b/packages/blockchain-link/src/workers/blockbook/index.ts
@@ -163,6 +163,16 @@ const estimateFee = async (request: Request<MessageTypes.EstimateFee>) => {
     } as const;
 };
 
+const rpcCall = async (request: Request<MessageTypes.RpcCall>) => {
+    const api = await request.connect();
+    const resp = await api.rpcCall(request.payload);
+
+    return {
+        type: RESPONSES.RPC_CALL,
+        payload: resp,
+    } as const;
+};
+
 const onNewBlock = ({ post }: Context, event: BlockNotification) => {
     post({
         id: -1,
@@ -417,6 +427,8 @@ const onRequest = (request: Request<MessageTypes.Message>) => {
             return getFiatRatesTickersList(request);
         case MESSAGES.ESTIMATE_FEE:
             return estimateFee(request);
+        case MESSAGES.RPC_CALL:
+            return rpcCall(request);
         case MESSAGES.PUSH_TRANSACTION:
             return pushTransaction(request);
         case MESSAGES.SUBSCRIBE:

--- a/packages/blockchain-link/src/workers/blockbook/websocket.ts
+++ b/packages/blockchain-link/src/workers/blockbook/websocket.ts
@@ -18,6 +18,7 @@ import type {
     AccountInfoParams,
     EstimateFeeParams,
     AccountBalanceHistoryParams,
+    RpcCallParams,
 } from '@trezor/blockchain-link-types/src/params';
 
 import { BaseWebsocket } from '../baseWebsocket';
@@ -124,6 +125,10 @@ export class BlockbookAPI extends BaseWebsocket<BlockbookEvents> {
 
     estimateFee(payload: EstimateFeeParams) {
         return this.send('estimateFee', payload);
+    }
+
+    rpcCall(payload: RpcCallParams) {
+        return this.send('rpcCall', payload);
     }
 
     getCurrentFiatRates(payload: GetCurrentFiatRates['payload']) {

--- a/packages/connect/src/api/blockchainEvmRpcCall.ts
+++ b/packages/connect/src/api/blockchainEvmRpcCall.ts
@@ -1,0 +1,63 @@
+import { AbstractMethod, Payload } from '../core/AbstractMethod';
+import { validateParams } from './common/paramsValidator';
+import { ERRORS } from '../constants';
+import { CoinInfo } from '../types';
+import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
+import { getCoinInfo } from '../data/coinInfo';
+
+type Params = {
+    coinInfo: CoinInfo;
+    identity?: string;
+    request: Omit<Payload<'blockchainEvmRpcCall'>, 'method' | 'coin'>;
+};
+
+export default class BlockchainEvmRpcCall extends AbstractMethod<'blockchainEvmRpcCall', Params> {
+    init() {
+        this.useDevice = false;
+        this.useUi = false;
+
+        const { payload } = this;
+
+        // validate incoming parameters
+        validateParams(payload, [
+            { name: 'coin', type: 'string', required: true },
+            { name: 'identity', type: 'string' },
+            { name: 'from', type: 'string' },
+            { name: 'to', type: 'string', required: true },
+            { name: 'data', type: 'string', required: true },
+        ]);
+
+        const coinInfo = getCoinInfo(payload.coin);
+
+        if (!coinInfo) {
+            throw ERRORS.TypedError('Method_UnknownCoin');
+        }
+        // validate backend
+        isBackendSupported(coinInfo);
+
+        this.params = {
+            coinInfo,
+            identity: payload.identity,
+            request: {
+                from: payload.from,
+                to: payload.to,
+                data: payload.data,
+            },
+        };
+    }
+
+    get info() {
+        return 'Blockchain Evm Rpc Call';
+    }
+
+    async run() {
+        const backend = await initBlockchain(
+            this.params.coinInfo,
+            postMessage,
+            this.params.identity,
+        );
+        const response = await backend.rpcCall(this.params.request);
+
+        return response;
+    }
+}

--- a/packages/connect/src/api/index.ts
+++ b/packages/connect/src/api/index.ts
@@ -9,6 +9,7 @@ export { default as blockchainDisconnect } from './blockchainDisconnect';
 export { default as blockchainEstimateFee } from './blockchainEstimateFee';
 export { default as blockchainGetAccountBalanceHistory } from './blockchainGetAccountBalanceHistory';
 export { default as blockchainGetCurrentFiatRates } from './blockchainGetCurrentFiatRates';
+export { default as blockchainEvmRpcCall } from './blockchainEvmRpcCall';
 export { default as blockchainGetFiatRatesForTimestamps } from './blockchainGetFiatRatesForTimestamps';
 export { default as blockchainGetTransactions } from './blockchainGetTransactions';
 export { default as blockchainSetCustomBackend } from './blockchainSetCustomBackend';

--- a/packages/connect/src/backend/Blockchain.ts
+++ b/packages/connect/src/backend/Blockchain.ts
@@ -217,6 +217,10 @@ export class Blockchain {
         return this.link.getAccountUtxo(descriptor);
     }
 
+    rpcCall(params: BlockchainLinkParams<'rpcCall'>) {
+        return this.link.rpcCall(params);
+    }
+
     async estimateFee(request: Parameters<typeof this.link.estimateFee>[0]) {
         const { blocks } = request;
         // cache should be used if there is no specific data (ethereum case) and requested blocks are already cached/downloaded

--- a/packages/connect/src/factory.ts
+++ b/packages/connect/src/factory.ts
@@ -63,6 +63,8 @@ export const factory = <
     blockchainGetFiatRatesForTimestamps: params =>
         call({ ...params, method: 'blockchainGetFiatRatesForTimestamps' }),
 
+    blockchainEvmRpcCall: params => call({ ...params, method: 'blockchainEvmRpcCall' }),
+
     blockchainDisconnect: params => call({ ...params, method: 'blockchainDisconnect' }),
 
     blockchainEstimateFee: params => call({ ...params, method: 'blockchainEstimateFee' }),

--- a/packages/connect/src/types/api/blockchainEvmRpcCall.ts
+++ b/packages/connect/src/types/api/blockchainEvmRpcCall.ts
@@ -1,0 +1,6 @@
+import { BlockchainLinkParams, BlockchainLinkResponse } from '@trezor/blockchain-link';
+import type { CommonParamsWithCoin, Response } from '../params';
+
+export declare function blockchainEvmRpcCall(
+    params: CommonParamsWithCoin & BlockchainLinkParams<'rpcCall'>,
+): Response<BlockchainLinkResponse<'rpcCall'>>;

--- a/packages/connect/src/types/api/index.ts
+++ b/packages/connect/src/types/api/index.ts
@@ -10,6 +10,7 @@ import { blockchainDisconnect } from './blockchainDisconnect';
 import { blockchainEstimateFee } from './blockchainEstimateFee';
 import { blockchainGetAccountBalanceHistory } from './blockchainGetAccountBalanceHistory';
 import { blockchainGetCurrentFiatRates } from './blockchainGetCurrentFiatRates';
+import { blockchainEvmRpcCall } from './blockchainEvmRpcCall';
 import { blockchainGetFiatRatesForTimestamps } from './blockchainGetFiatRatesForTimestamps';
 import { blockchainGetTransactions } from './blockchainGetTransactions';
 import { blockchainSetCustomBackend } from './blockchainSetCustomBackend';
@@ -126,6 +127,8 @@ export interface TrezorConnect {
 
     // todo: link docs
     blockchainGetCurrentFiatRates: typeof blockchainGetCurrentFiatRates;
+
+    blockchainEvmRpcCall: typeof blockchainEvmRpcCall;
 
     // todo: link docs
     blockchainGetFiatRatesForTimestamps: typeof blockchainGetFiatRatesForTimestamps;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/Options.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/Options.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import styled from 'styled-components';
 import { FiatValue, FormattedCryptoAmount, Translation } from 'src/components/suite';
 import { Paragraph, Radio } from '@trezor/components';
@@ -61,16 +60,14 @@ const InputsWrapper = styled.div<{ $isShown: boolean }>`
     display: ${({ $isShown }) => ($isShown ? 'block' : 'none')};
 `;
 
-type UnstakeOptions = 'all' | 'rewards' | 'other';
-
 interface OptionsProps {
     symbol: NetworkSymbol;
 }
 
 export const Options = ({ symbol }: OptionsProps) => {
     const selectedAccount = useSelector(selectSelectedAccount);
+    const { unstakeOption, setUnstakeOption } = useUnstakeEthFormContext();
 
-    const [unstakeOption, setUnstakeOption] = useState<UnstakeOptions>('all');
     const isRewardsSelected = unstakeOption === 'rewards';
     const isAllSelected = unstakeOption === 'all';
     const isOtherAmountSelected = unstakeOption === 'other';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/UnstakeEthForm.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/UnstakeEthForm.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
-import { Divider, Paragraph, Banner } from '@trezor/components';
-import { spacingsPx } from '@trezor/theme';
+import { Divider, Icon, Paragraph, Tooltip, Banner, Row, Column } from '@trezor/components';
+import { spacings, spacingsPx } from '@trezor/theme';
 import { Translation } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
 import { useUnstakeEthFormContext } from 'src/hooks/wallet/useUnstakeEthForm';
@@ -11,11 +11,8 @@ import { getUnstakingPeriodInDays } from 'src/utils/suite/stake';
 import UnstakeFees from './Fees';
 import { selectValidatorsQueueData } from '@suite-common/wallet-core';
 import { getAccountEverstakeStakingPool } from '@suite-common/wallet-utils';
-
-// eslint-disable-next-line local-rules/no-override-ds-component
-const GreyP = styled(Paragraph)`
-    color: ${({ theme }) => theme.textSubdued};
-`;
+import { ApproximateInstantEthAmount } from 'src/views/wallet/staking/components/EthStakingDashboard/components/ApproximateInstantEthAmount';
+import { BigNumber } from '@trezor/utils';
 
 const DividerWrapper = styled.div`
     & > div {
@@ -37,15 +34,6 @@ const WarningsWrapper = styled.div`
     gap: ${spacingsPx.md};
 `;
 
-const UpToDaysWrapper = styled.div`
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-top: 16px;
-    padding: ${spacingsPx.lg} 0 ${spacingsPx.md};
-    border-top: 1px solid ${({ theme }) => theme.borderElevation2};
-`;
-
 export const UnstakeEthForm = () => {
     const selectedAccount = useSelector(selectSelectedAccount);
 
@@ -54,6 +42,7 @@ export const UnstakeEthForm = () => {
         formState: { errors },
         handleSubmit,
         signTx,
+        approximatedInstantEthAmount,
     } = useUnstakeEthFormContext();
 
     const { symbol } = account;
@@ -62,12 +51,13 @@ export const UnstakeEthForm = () => {
         selectValidatorsQueueData(state, account?.symbol),
     );
     const unstakingPeriod = getUnstakingPeriodInDays(validatorWithdrawTime);
-
     const { canClaim = false, claimableAmount = '0' } =
         getAccountEverstakeStakingPool(selectedAccount) ?? {};
 
     const inputError = errors[CRYPTO_INPUT] || errors[FIAT_INPUT];
     const showError = inputError && inputError.type === 'compose';
+    const shouldShowInstantUnstakeEthAmount =
+        approximatedInstantEthAmount && BigNumber(approximatedInstantEthAmount).gt(0);
 
     return (
         <form onSubmit={handleSubmit(signTx)}>
@@ -96,19 +86,52 @@ export const UnstakeEthForm = () => {
                 <Divider />
             </DividerWrapper>
 
-            <UnstakeFees />
+            <Column gap={spacings.lg} alignItems="normal" hasDivider>
+                <UnstakeFees />
 
-            <UpToDaysWrapper>
-                <GreyP>
-                    <Translation id="TR_STAKE_UNSTAKING_PERIOD" />
-                </GreyP>
-                <Translation
-                    id="TR_UP_TO_DAYS"
-                    values={{
-                        count: unstakingPeriod,
-                    }}
-                />
-            </UpToDaysWrapper>
+                <Column gap={spacings.md} alignItems="normal" margin={{ bottom: spacings.lg }}>
+                    <Row justifyContent="space-between">
+                        <Paragraph typographyStyle="body" variant="tertiary">
+                            <Translation id="TR_STAKE_UNSTAKING_PERIOD" />
+                        </Paragraph>
+                        <Translation
+                            id="TR_UP_TO_DAYS"
+                            values={{
+                                count: unstakingPeriod,
+                            }}
+                        />
+                    </Row>
+
+                    {shouldShowInstantUnstakeEthAmount && (
+                        <Row justifyContent="space-between">
+                            <Row gap={spacings.xxs}>
+                                <Paragraph typographyStyle="body" variant="tertiary">
+                                    <Translation
+                                        id="TR_STAKE_UNSTAKING_APPROXIMATE"
+                                        values={{
+                                            symbol: symbol.toUpperCase(),
+                                        }}
+                                    />
+                                </Paragraph>
+
+                                <Tooltip
+                                    maxWidth={328}
+                                    content={
+                                        <Translation id="TR_STAKE_UNSTAKING_APPROXIMATE_DESCRIPTION" />
+                                    }
+                                >
+                                    <Icon name="info" size={14} />
+                                </Tooltip>
+                            </Row>
+
+                            <ApproximateInstantEthAmount
+                                value={approximatedInstantEthAmount}
+                                symbol={symbol.toUpperCase()}
+                            />
+                        </Row>
+                    )}
+                </Column>
+            </Column>
         </form>
     );
 };

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -8827,6 +8827,16 @@ export default defineMessages({
         id: 'TR_STAKE_UNSTAKING_PERIOD',
         defaultMessage: 'Unstaking period',
     },
+    TR_STAKE_UNSTAKING_APPROXIMATE: {
+        id: 'TR_STAKE_UNSTAKING_APPROXIMATE',
+        defaultMessage: 'Approximate {symbol} available instantly',
+    },
+
+    TR_STAKE_UNSTAKING_APPROXIMATE_DESCRIPTION: {
+        id: 'TR_STAKE_UNSTAKING_APPROXIMATE_DESCRIPTION',
+        defaultMessage:
+            'Liquidity of the staking pool can allow for instant unstake of some funds. Remaining funds will follow the unstaking period',
+    },
     TR_UP_TO_DAYS: {
         id: 'TR_UP_TO_DAYS',
         defaultMessage: 'up to {count, plural, one {# day} other {# days}}',

--- a/packages/suite/src/utils/suite/__fixtures__/stake.ts
+++ b/packages/suite/src/utils/suite/__fixtures__/stake.ts
@@ -863,3 +863,30 @@ export const getChangedInternalTxFixture = [
         },
     },
 ];
+
+export const simulateUnstakeFixture = [
+    {
+        description: 'should return null for no coin, from, or data',
+        args: {
+            amount: undefined,
+            from: undefined,
+            symbol: undefined,
+        },
+        blockchainEvmRpcCallResult: {},
+        result: null,
+    },
+    {
+        description: 'should return approximated amount for valid inputs',
+        args: {
+            amount: '0.1',
+            from: '0xfB0bc552ab5Fa1971E8530852753c957e29eEEFC',
+            to: '0xAFA848357154a6a624686b348303EF9a13F63264',
+            symbol: 'eth',
+        },
+        blockchainEvmRpcCallResult: {
+            success: true,
+            payload: { data: '0x000000000000000000000000000000000000000000000000016345785d8a0000' },
+        },
+        result: '0.1', // 0.1 eth
+    },
+];

--- a/packages/suite/src/utils/suite/__tests__/stake.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/stake.test.ts
@@ -2,6 +2,7 @@ import TrezorConnect, {
     AccountInfo,
     InternalTransfer,
     Success,
+    SuccessWithDevice,
     Unsuccessful,
 } from '@trezor/connect';
 import {
@@ -23,6 +24,7 @@ import {
     getInstantStakeTypeFixture,
     getChangedInternalTxFixture,
     getUnstakingAmountFixtures,
+    simulateUnstakeFixture,
 } from '../__fixtures__/stake';
 import {
     getUnstakingAmount,
@@ -43,6 +45,7 @@ import {
     getEthNetworkForWalletSdk,
     getInstantStakeType,
     getChangedInternalTx,
+    simulateUnstake,
 } from '../stake';
 import {
     BlockchainEstimatedFee,
@@ -261,6 +264,21 @@ describe('getChangedInternalTx', () => {
                 test.args.selectedAccountAddress,
                 test.args.symbol as NetworkSymbol,
             );
+            expect(result).toEqual(test.result);
+        });
+    });
+});
+
+type BlockchainEvmRpcCallResult = Unsuccessful | SuccessWithDevice<{ data: string }>;
+type SimulateUnstakeArgs = StakeTxBaseArgs & { amount: string };
+
+describe('simulateUnstake', () => {
+    simulateUnstakeFixture.forEach(test => {
+        it(test.description, async () => {
+            jest.spyOn(TrezorConnect, 'blockchainEvmRpcCall').mockImplementation(() =>
+                Promise.resolve(test.blockchainEvmRpcCallResult as BlockchainEvmRpcCallResult),
+            );
+            const result = await simulateUnstake(test.args as SimulateUnstakeArgs);
             expect(result).toEqual(test.result);
         });
     });

--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/ApproximateInstantEthAmount.tsx
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/ApproximateInstantEthAmount.tsx
@@ -1,0 +1,29 @@
+import { FormattedCryptoAmount } from 'src/components/suite';
+import { Tooltip } from '@trezor/components';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
+
+interface ApproximateInstantEthAmountProps {
+    value: string | number;
+    symbol: string;
+}
+
+const DEFAULT_MAX_DECIMAL_PLACES = 2;
+
+export const ApproximateInstantEthAmount = ({
+    value,
+    symbol,
+}: ApproximateInstantEthAmountProps) => {
+    const hasDecimals = value.toString().includes('.');
+
+    if (!hasDecimals) {
+        return <FormattedCryptoAmount value={value} symbol={symbol} />;
+    }
+
+    const trimmedAmount = new BigNumber(value).toFixed(DEFAULT_MAX_DECIMAL_PLACES, 1);
+
+    return (
+        <Tooltip content={<FormattedCryptoAmount value={value} symbol={symbol} />}>
+            <FormattedCryptoAmount value={trimmedAmount} symbol={symbol} />
+        </Tooltip>
+    );
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Instant unstake forecasting is added to the eth unstaking modal

<!--- Describe your changes in detail -->

## Related Issue

Resolve [trezor#11402](https://github.com/trezor/trezor-suite/issues/11402)

## Screenshots:
<img width="379" alt="image" src="https://github.com/trezor/trezor-suite/assets/68502706/962e8e60-0f90-4fc1-a42d-8da4684cb3eb">
<img width="388" alt="image" src="https://github.com/trezor/trezor-suite/assets/68502706/ead40693-65f5-44cf-b1ed-aa53469040b9">
