### PR TITLE
fix(wallet-core): discovery do not getFeatures after failure

### DIFF
--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -595,7 +595,14 @@ export const startDiscoveryThunk = createThunk(
                 }
             }
 
-            if (result.payload.error && device.connected) {
+            if (
+                result.payload.error &&
+                device.connected &&
+                // but not when another application stole this device. no need to release session in this case
+                result.payload.code !== 'Device_UsedElsewhere' &&
+                // also not when user disconnected device during discovery
+                result.payload.code !== 'Device_Disconnected'
+            ) {
                 // call getFeatures to release device session
                 await TrezorConnect.getFeatures({
                     device,


### PR DESCRIPTION
when testing #11532 I was able to find an issue which was not a regression brought about by  #11532

1. open 2 suites next to each other
2. let  Suite A start discovery
3. before discovery ends in the Suite A, steal session from Suite B
4. Suite A will likely try to issue getFeatures call, stealing session from the Suite B again.

