### PR TITLE
fix(suite): nearest fee on recompose does not work with the skip-low-fee hack

### DIFF
--- a/packages/connect-common/files/coins.json
+++ b/packages/connect-common/files/coins.json
@@ -25,7 +25,6 @@
             "default_fee_b": {
                 "Economy": 70,
                 "High": 200,
-                "Low": 10,
                 "Normal": 140
             },
             "dust_limit": 546,
@@ -433,7 +432,6 @@
             "default_fee_b": {
                 "Economy": 70,
                 "High": 200,
-                "Low": 10,
                 "Normal": 140
             },
             "dust_limit": 546,
@@ -530,7 +528,7 @@
             "decimals": 8,
             "decred": false,
             "default_fee_b": {
-                "Low": 10
+                "Economy": 10
             },
             "dust_limit": 546,
             "extra_data": false,
@@ -937,7 +935,6 @@
             "default_fee_b": {
                 "Economy": 10,
                 "High": 200,
-                "Low": 1,
                 "Normal": 100
             },
             "dust_limit": 546,
@@ -988,7 +985,6 @@
             "default_fee_b": {
                 "Economy": 10,
                 "High": 200,
-                "Low": 1,
                 "Normal": 100
             },
             "dust_limit": 546,
@@ -1090,7 +1086,6 @@
             "default_fee_b": {
                 "Economy": 20000,
                 "High": 100000,
-                "Low": 10000,
                 "Normal": 50000
             },
             "dust_limit": 546,
@@ -1595,7 +1590,7 @@
             "decimals": 8,
             "decred": false,
             "default_fee_b": {
-                "Low": 10
+                "Economy": 10
             },
             "dust_limit": 546,
             "extra_data": false,
@@ -1646,7 +1641,7 @@
             "decimals": 8,
             "decred": false,
             "default_fee_b": {
-                "Low": 10
+                "Economy": 10
             },
             "dust_limit": 546,
             "extra_data": false,
@@ -1696,7 +1691,6 @@
             "default_fee_b": {
                 "Economy": 70,
                 "High": 200,
-                "Low": 10,
                 "Normal": 140
             },
             "dust_limit": 1000,
@@ -1750,7 +1744,6 @@
             "default_fee_b": {
                 "Economy": 700,
                 "High": 2000,
-                "Low": 100,
                 "Normal": 1400
             },
             "dust_limit": 1820,
@@ -1801,7 +1794,6 @@
             "default_fee_b": {
                 "Economy": 50,
                 "High": 160,
-                "Low": 10,
                 "Normal": 100
             },
             "dust_limit": 546,
@@ -1957,7 +1949,6 @@
             "default_fee_b": {
                 "Economy": 7000,
                 "High": 20000,
-                "Low": 1000,
                 "Normal": 14000
             },
             "dust_limit": 54600,
@@ -2161,7 +2152,6 @@
             "default_fee_b": {
                 "Economy": 70,
                 "High": 200,
-                "Low": 10,
                 "Normal": 140
             },
             "dust_limit": 546,

--- a/packages/connect/src/data/defaultFeeLevels.ts
+++ b/packages/connect/src/data/defaultFeeLevels.ts
@@ -23,7 +23,7 @@ interface CoinsJsonData {
     shortcut: string; // uppercase shortcut
     // data below are defined and relevant only for bitcoin-like coins
     blocktime_seconds: number;
-    default_fee_b: Record<'High' | 'Normal' | 'Economy' | 'Low', number>;
+    default_fee_b: Record<'High' | 'Normal' | 'Economy', number>;
     maxfee_kb: number;
     minfee_kb: number;
     dust_limit: number;

--- a/packages/connect/src/types/api/__tests__/blockchain.ts
+++ b/packages/connect/src/types/api/__tests__/blockchain.ts
@@ -39,7 +39,7 @@ export const blockchainEstimateFee = async (api: TrezorConnect) => {
             if (level.label === 'normal') {
                 level.feePerUnit.toLowerCase();
             }
-            if (level.label === 'high' || level.label === 'low' || level.label === 'economy') {
+            if (level.label === 'high' || level.label === 'economy') {
                 level.feeLimit?.toLocaleLowerCase();
                 level.feePerTx?.toLocaleLowerCase();
             }

--- a/packages/connect/src/types/fees.ts
+++ b/packages/connect/src/types/fees.ts
@@ -14,7 +14,6 @@ export const FeeLevel = Type.Object({
         Type.Literal('high'),
         Type.Literal('normal'),
         Type.Literal('economy'),
-        Type.Literal('low'),
         Type.Literal('custom'),
     ]),
     feePerUnit: Type.String(),

--- a/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
@@ -442,7 +442,7 @@ export const onConnect = [
         },
         // order: estimateFee
         connect: [
-            { payload: { levels: [{ label: 'normal' }, { label: 'high' }, { label: 'low' }] } },
+            { payload: { levels: [{ label: 'normal' }, { label: 'high' }, { label: 'economy' }] } },
         ],
         symbol: 'btc',
         actions: [

--- a/packages/suite/src/components/wallet/Fees/Fees.tsx
+++ b/packages/suite/src/components/wallet/Fees/Fees.tsx
@@ -24,6 +24,7 @@ import {
 import { CustomFee } from './CustomFee';
 import { FeeDetails } from './FeeDetails';
 import { AnimatePresence, motion } from 'framer-motion';
+import { TranslationKey } from '@suite-common/intl-types';
 
 const Container = styled.div`
     width: 100%;
@@ -82,21 +83,18 @@ const HelperTextWrapper = styled(Paragraph)`
     font-size: ${variables.FONT_SIZE.SMALL};
 `;
 
-const FEE_LEVELS_TRANSLATIONS = {
+const FEE_LEVELS_TRANSLATIONS: Record<FeeLevel['label'], TranslationKey> = {
     custom: 'FEE_LEVEL_CUSTOM',
     high: 'FEE_LEVEL_HIGH',
     normal: 'FEE_LEVEL_NORMAL',
     economy: 'FEE_LEVEL_LOW',
-    low: 'FEE_LEVEL_LOW',
 } as const;
 
 const buildFeeOptions = (levels: FeeLevel[]) =>
-    levels
-        .filter(level => level.label !== 'low') // hack to hide "low" fee option
-        .map(({ label }) => ({
-            label: <Translation id={FEE_LEVELS_TRANSLATIONS[label]} />,
-            value: label,
-        }));
+    levels.map(({ label }) => ({
+        label: <Translation id={FEE_LEVELS_TRANSLATIONS[label]} />,
+        value: label,
+    }));
 
 export interface FeesProps<TFieldValues extends FormState> {
     account: Account;

--- a/packages/suite/src/hooks/wallet/useCoinmarketSellForm.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketSellForm.ts
@@ -104,7 +104,7 @@ export const useCoinmarketSellForm = ({
     const { shouldSendInSats } = useBitcoinAmountUnit(symbol);
 
     const coinFees = fees[symbol];
-    const levels = getFeeLevels(networkType, coinFees).filter(level => level.label !== 'low');
+    const levels = getFeeLevels(networkType, coinFees);
     const feeInfo = { ...coinFees, levels };
     const symbolForFiat = mapTestnetSymbol(symbol);
     const localCurrencyOption = { value: localCurrency, label: localCurrency.toUpperCase() };

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5786,10 +5786,6 @@ export default defineMessages({
         defaultMessage: 'Normal',
         id: 'FEE_LEVEL_NORMAL',
     },
-    FEE_LEVEL_ECONOMY: {
-        defaultMessage: 'Economy',
-        id: 'FEE_LEVEL_ECONOMY',
-    },
     FEE_LEVEL_LOW: {
         defaultMessage: 'Low',
         id: 'FEE_LEVEL_LOW',

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -39,7 +39,7 @@ const ACCOUNTS_SYNC_INTERVAL = 60 * 1000;
 
 // sort FeeLevels in reversed order (Low > High)
 // TODO: consider to use same order in @trezor/connect to avoid double sorting
-const order: FeeLevel['label'][] = ['low', 'economy', 'normal', 'high'];
+const order: FeeLevel['label'][] = ['economy', 'normal', 'high'];
 const sortLevels = (levels: FeeLevel[]) =>
     levels.sort((levelA, levelB) => order.indexOf(levelA.label) - order.indexOf(levelB.label));
 


### PR DESCRIPTION
When switching to max (send all) handle correctly the selection of the composed TX based on fee level. It was not working with the low-fee skip hack.

Resolves https://github.com/trezor/trezor-suite/issues/12106