### PR TITLE
ci: submodules, smaller checkout

### DIFF
--- a/.github/workflows/blockchain-link-test.yml
+++ b/.github/workflows/blockchain-link-test.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: true
       - name: Setup node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/build-desktop-apps.yml
+++ b/.github/workflows/build-desktop-apps.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: true
-          submodules: recursive
+          submodules: true
       - name: Install node and yarn
         uses: actions/setup-node@v4
         with:
@@ -99,7 +99,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: true
-          submodules: recursive
+          submodules: true
       - name: Install node and yarn
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/connect-nextra-dev-release.yml
+++ b/.github/workflows/connect-nextra-dev-release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: true
 
       # Pull only files needed for connect to save LFS bandwidth
       - name: "Pull LFS files for connect"

--- a/.github/workflows/connect-pre-release-init.yml
+++ b/.github/workflows/connect-pre-release-init.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           # Number of commits to fetch. 0 indicates all history for all branches and tags.
           fetch-depth: 0
-          submodules: recursive
+          submodules: true
 
       - name: Setup node
         uses: actions/setup-node@v4
@@ -35,7 +35,7 @@ jobs:
         run: yarn install
 
       - name: Build dependencies
-        # Running `build:libs` requires action to checkout with `submodules: recursive`.
+        # Running `build:libs` requires action to checkout with `submodules: true`.
         run: yarn build:libs
 
       - name: Run @trezor/connect create npm release branch

--- a/.github/workflows/connect-test.yml
+++ b/.github/workflows/connect-test.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: true
       - name: Setup node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/connect-transport-e2e-test.yml
+++ b/.github/workflows/connect-transport-e2e-test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: true
 
       - name: Setup node
         uses: actions/setup-node@v4

--- a/.github/workflows/connect-web-e2e-test.yml
+++ b/.github/workflows/connect-web-e2e-test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: true
 
       - name: Setup node
         uses: actions/setup-node@v4

--- a/.github/workflows/template-connect-build-deploy.yml
+++ b/.github/workflows/template-connect-build-deploy.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: true
 
       # Pull only files needed for connect to save LFS bandwidth
       - name: "Pull LFS files for connect"

--- a/.github/workflows/template-connect-popup-test-params.yml
+++ b/.github/workflows/template-connect-popup-test-params.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: true
 
       - name: Extract branch name
         run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
@@ -86,7 +86,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: true
 
       - name: Extract branch name
         run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT

--- a/.github/workflows/template-connect-test-params.yml
+++ b/.github/workflows/template-connect-test-params.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: true
       - name: Setup node
         uses: actions/setup-node@v4
         with:
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: true
       - name: Setup node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: true
       - name: "Checkout branches for Nx"
         uses: ./.github/actions/nx-checkout
       - name: "Minimal yarn install"
@@ -82,7 +82,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: true
       - name: "Checkout branches for Nx"
         uses: ./.github/actions/nx-checkout
       - name: "Minimal yarn install"
@@ -98,7 +98,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: true
       - name: "Checkout branches for Nx"
         uses: ./.github/actions/nx-checkout
       - name: "Minimal yarn install"


### PR DESCRIPTION
recursive shouldn't be needed. 

unfortunately, submodules are needed indeed. but only for some of the tests because of fixtures. for build they shouldn't be needed at all, but are the moment because of some bug in our configuration.