### PR TITLE
chore: pin bn.js version in resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
         "html-webpack-plugin": "^5.6.0",
         "@types/node": "18.17.15",
         "@types/react": "18.2.55",
-        "@sentry/types": "7.92.0"
+        "@sentry/types": "7.92.0",
+        "bn.js": "5.2.1"
     },
     "devDependencies": {
         "@babel/cli": "^7.23.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15018,21 +15018,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bn.js@npm:4.11.6":
-  version: 4.11.6
-  resolution: "bn.js@npm:4.11.6"
-  checksum: 10/22741b015c9fff60fce32fc9988331b298eb9b6db5bfb801babb23b846eaaf894e440e0d067b2b3ae4e46aab754e90972f8f333b31bf94a686bbcb054bfa7b14
-  languageName: node
-  linkType: hard
-
-"bn.js@npm:^4.0.0, bn.js@npm:^4.1.0, bn.js@npm:^4.11.6, bn.js@npm:^4.11.8, bn.js@npm:^4.11.9":
-  version: 4.12.0
-  resolution: "bn.js@npm:4.12.0"
-  checksum: 10/10f8db196d3da5adfc3207d35d0a42aa29033eb33685f20ba2c36cadfe2de63dad05df0a20ab5aae01b418d1c4b3d4d205273085262fa020d17e93ff32b67527
-  languageName: node
-  linkType: hard
-
-"bn.js@npm:^5.0.0, bn.js@npm:^5.1.1, bn.js@npm:^5.1.2, bn.js@npm:^5.2.0, bn.js@npm:^5.2.1":
+"bn.js@npm:5.2.1":
   version: 5.2.1
   resolution: "bn.js@npm:5.2.1"
   checksum: 10/7a7e8764d7a6e9708b8b9841b2b3d6019cc154d2fc23716d0efecfe1e16921b7533c6f7361fb05471eab47986c4aa310c270f88e3507172104632ac8df2cfd84


### PR DESCRIPTION
## Description

A lot of dependencies use the `bn.js` library, but in different version, resulting in duplicates. 
I would pin it to the latest version globally. 

## Screenshots:

For example in Connect core:

Before
<img width="771" alt="Screenshot 2024-04-24 at 13 36 57" src="https://github.com/trezor/trezor-suite/assets/8833813/3e9f3a63-b191-4da9-b9a1-92040494c34f">

After
<img width="983" alt="Screenshot 2024-04-24 at 13 38 22" src="https://github.com/trezor/trezor-suite/assets/8833813/0a2ecb53-dacf-4e6d-8dff-3032b47340df">

Final output size is reduced from about 1.5MB to 1.2MB