### PR TITLE
fix(coinmarket): filter error offers

### DIFF
--- a/packages/suite/src/reducers/wallet/useCoinmarketFilterReducer.ts
+++ b/packages/suite/src/reducers/wallet/useCoinmarketFilterReducer.ts
@@ -96,7 +96,10 @@ export const useCoinmarketFilterReducer = (
             return quotes.filter(quote => {
                 if (state.paymentMethod === '') return true; // all
 
-                return quote.paymentMethod === state.paymentMethod;
+                return (
+                    quote.paymentMethod === state.paymentMethod &&
+                    typeof quote.error === 'undefined'
+                );
             });
         },
         [state.paymentMethod],


### PR DESCRIPTION
## Info
After selecting payment method in coinmarker filter should not be displayed offer with errors