### PR TITLE
fix(github): npm release action to build package

### DIFF
--- a/.github/actions/release-connect-npm/action.yml
+++ b/.github/actions/release-connect-npm/action.yml
@@ -69,6 +69,7 @@ runs:
       shell: bash
       run: |
         cd ./packages/${{ inputs.packageName }}
+        yarn build:lib
         yarn npm publish --tag ${{ inputs.deploymentType }} --access public
 
     - name: Cleanup


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Build libs in the package to release in order fix this issue https://github.com/trezor/trezor-suite/actions/runs/8828868247/job/24238689594#step:3:1102

It issue can be reproduce locally by deleting the lib directories of the package and running ` yarn prepublish` it gives you same error as in CI. Then build libs and run it again, it completes successfully. 