### PR TITLE
fix(connect): make workers-browser imports async

### DIFF
--- a/packages/connect-iframe/webpack/base.webpack.config.ts
+++ b/packages/connect-iframe/webpack/base.webpack.config.ts
@@ -73,6 +73,13 @@ export const config: webpack.Configuration = {
                 },
             },
             {
+                test: /\workers\/solana\/index/i,
+                loader: 'worker-loader',
+                options: {
+                    filename: './workers/solana-worker.[contenthash].js',
+                },
+            },
+            {
                 test: /\.(js|ts)$/,
                 exclude: /node_modules/,
                 use: {


### PR DESCRIPTION
## Description
`workers-browser.ts`, which is used in core.js would bundle all workers directly, unlike the standard version of `workers.ts`. 
This change makes the imports async, the same as in `workers.ts`, reducing the size of core.js under 1MB.