### PR TITLE
fix(suite): do not remove leading zereos on the incomplate number

### DIFF
--- a/packages/suite/src/components/suite/NumberInput.tsx
+++ b/packages/suite/src/components/suite/NumberInput.tsx
@@ -20,8 +20,6 @@ import { getLocaleSeparators } from '@trezor/utils';
 const isValidDecimalString = (value: string) => /^([^.]*)\.[^.]+$/.test(value);
 const hasLeadingZeroes = (value: string) => /^0+(\d+\.\d*|\d+)$/.test(value);
 
-const removeLeadingZeroes = (value: string) => value.replace(/^0+(?!\.|$)/, '');
-
 const cleanValueString = (value: string, locale: Locale) => {
     if (value === undefined) {
         return '';
@@ -34,7 +32,7 @@ const cleanValueString = (value: string, locale: Locale) => {
 
     const { decimalSeparator, thousandsSeparator } = getLocaleSeparators(locale);
 
-    // clean the entered number string if it's not convertable to Number or if it has a non-conventional format
+    // clean the entered number string if it's not convertible to Number or if it has a non-conventional format
     if (
         !Number.isNaN(Number(value)) &&
         thousandsSeparator !== '.' &&
@@ -137,7 +135,7 @@ export const NumberInput = <TFieldValues extends FieldValues>({
             const lastSymbol = rawValue.at(-1);
 
             if (
-                lastSymbol &&
+                lastSymbol !== undefined &&
                 (DECIMAL_SEPARATORS.includes(lastSymbol) ||
                     (lastSymbol === '0' && rawValue.includes(decimalSeparator)))
             ) {
@@ -155,12 +153,11 @@ export const NumberInput = <TFieldValues extends FieldValues>({
                         rawValue = rawValue.slice(0, -1);
                     } else if (lastSymbol !== decimalSeparator) {
                         rawValue = rawValue.slice(0, -1) + decimalSeparator;
-                        // }
                     }
                 }
 
                 // the number is incomplete and not ready do be localized (e.g. 1,234. or 1,0000)
-                return handleSetDisplayValue(removeLeadingZeroes(rawValue));
+                return handleSetDisplayValue(rawValue);
             }
 
             // clean so that it's compatible with Number() and localize
@@ -252,7 +249,7 @@ export const NumberInput = <TFieldValues extends FieldValues>({
                 // the value of `invalid` here is the one before this change has been handled
                 const hasErrorStateChanged = hasError !== invalid;
                 if (hasErrorStateChanged) {
-                    // delaying it becase the form needs some time to update the error state
+                    // delaying it because the form needs some time to update the error state
                     // TODO: get rid of `onChangeCallback()` entirely and use the `watch` method from react-hook form
                     setTimeout(() => {
                         onChangeCallback?.(cleanInput);

--- a/packages/suite/src/components/suite/__tests__/NumberInput.test.tsx
+++ b/packages/suite/src/components/suite/__tests__/NumberInput.test.tsx
@@ -70,6 +70,11 @@ describe('NumberInput component', () => {
         await testCase(input, '12345.67', '12,345.67', '12345.67');
         await testCase(input, '1234,67', '1,234.67', '1234.67');
 
+        await testCase(input, '.', '.', '0');
+        await testCase(input, '0', '0', '0');
+        await testCase(input, '00', '0', '0');
+        await testCase(input, '0.', '0.', '0');
+
         await testCase(input, ',67', '0.67', '0.67');
         await testCase(input, '.67', '0.67', '0.67');
         await testCase(input, '.,67', '0.67', '0.67');
@@ -88,6 +93,11 @@ describe('NumberInput component', () => {
 
         await testCase(input, '22345.67', '22\u00A0345,67', '22345.67');
         await testCase(input, '2234,67', '2\u00A0234,67', '2234.67');
+
+        await testCase(input, ',', ',', '0');
+        await testCase(input, '0', '0', '0');
+        await testCase(input, '00', '0', '0');
+        await testCase(input, '0,', '0,', '0');
 
         await testCase(input, ',67', '0,67', '0.67');
         await testCase(input, '.67', '0,67', '0.67');


### PR DESCRIPTION
When typing `0,` or just `,000` the number is not complete and cannot be normalized. 

## Related Issue

Resolve  https://github.com/trezor/trezor-suite/issues/12106

![image](https://github.com/trezor/trezor-suite/assets/152899911/dc29b7f5-de6f-48d5-a00c-2f60e8fce07f)
![image](https://github.com/trezor/trezor-suite/assets/152899911/e9514cba-bcb3-4024-bb58-0eea1fa0d40c)
![image](https://github.com/trezor/trezor-suite/assets/152899911/3c7728bb-570a-4bfc-96b6-749db1ee3f3b)
![image](https://github.com/trezor/trezor-suite/assets/152899911/0ef9956c-51ac-4312-a24c-cfc20d680b20)


