### PR TITLE
ci(connect): skip passphrase test for webextension

### DIFF
--- a/.github/workflows/connect-dev-release-test.yml
+++ b/.github/workflows/connect-dev-release-test.yml
@@ -80,7 +80,8 @@ jobs:
     with:
       test-name: passphrase.test
       DEV_SERVER_HOSTNAME: dev.suite.sldev.cz
-      run-webextension: true
+      # currently flaky, run only in nightly
+      run-webextension: ${{ github.event_name == 'schedule' }}
 
   popup-pages:
     needs: [build-deploy]


### PR DESCRIPTION
## Description

As mentioned in the Code improvements session, we want to improve the reliability of tests, so I'm disabling one of the very flaky E2E tests in Connect - passphrase in webextension.