### PR TITLE
fix(env-utils,suite-native): bump expo-constants

### DIFF
--- a/packages/env-utils/package.json
+++ b/packages/env-utils/package.json
@@ -29,7 +29,7 @@
     },
     "dependencies": {
         "@suite-common/wallet-constants": "workspace:*",
-        "expo-constants": "15.4.5",
+        "expo-constants": "15.4.6",
         "ua-parser-js": "^1.0.37"
     },
     "peerDependencies": {

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -74,7 +74,7 @@
         "expo-barcode-scanner": "12.9.2",
         "expo-build-properties": "^0.11.1",
         "expo-clipboard": "5.0.1",
-        "expo-constants": "15.4.5",
+        "expo-constants": "15.4.6",
         "expo-dev-client": "^3.3.7",
         "expo-haptics": "12.8.1",
         "expo-image": "1.10.6",

--- a/suite-native/config/package.json
+++ b/suite-native/config/package.json
@@ -14,6 +14,6 @@
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
         "@suite-common/wallet-utils": "workspace:*",
-        "expo-constants": "15.4.5"
+        "expo-constants": "15.4.6"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8758,7 +8758,7 @@ __metadata:
     expo-barcode-scanner: "npm:12.9.2"
     expo-build-properties: "npm:^0.11.1"
     expo-clipboard: "npm:5.0.1"
-    expo-constants: "npm:15.4.5"
+    expo-constants: "npm:15.4.6"
     expo-dev-client: "npm:^3.3.7"
     expo-haptics: "npm:12.8.1"
     expo-image: "npm:1.10.6"
@@ -8889,7 +8889,7 @@ __metadata:
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"
-    expo-constants: "npm:15.4.5"
+    expo-constants: "npm:15.4.6"
   languageName: unknown
   linkType: soft
 
@@ -10683,7 +10683,7 @@ __metadata:
   resolution: "@trezor/env-utils@workspace:packages/env-utils"
   dependencies:
     "@suite-common/wallet-constants": "workspace:*"
-    expo-constants: "npm:15.4.5"
+    expo-constants: "npm:15.4.6"
     tsx: "npm:^4.7.0"
     ua-parser-js: "npm:^1.0.37"
   peerDependencies:
@@ -20892,7 +20892,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-constants@npm:15.4.5, expo-constants@npm:~15.4.0":
+"expo-constants@npm:15.4.6":
+  version: 15.4.6
+  resolution: "expo-constants@npm:15.4.6"
+  dependencies:
+    "@expo/config": "npm:~8.5.0"
+  peerDependencies:
+    expo: "*"
+  checksum: 10/223b945cc3585e8445b20f3dfb9d95bac123c36a5dadf5774236d935f3fc3ca12d948e6761d415f07fd490c285c3bf1f780f40d78b85ad3cf6526e7e28c850b5
+  languageName: node
+  linkType: hard
+
+"expo-constants@npm:~15.4.0":
   version: 15.4.5
   resolution: "expo-constants@npm:15.4.5"
   dependencies:


### PR DESCRIPTION
## Description

Bump `expo-constants` from `15.4.5` to `15.4.6`.

Aside: Perhaps this could be unpinned to `^15.4.6` or `~15.4.6` in order to reduce future need of update churn?

## Related Issue


## Screenshots:
