### PR TITLE
Fix: connect releae script yarn bump

### DIFF
--- a/.github/workflows/connect-pre-release-init.yml
+++ b/.github/workflows/connect-pre-release-init.yml
@@ -9,7 +9,7 @@ on:
         options:
           - patch
           - minor
-          - beta
+          - prerelease
 
 concurrency:
   group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}

--- a/ci/scripts/connect-release-init-npm.js
+++ b/ci/scripts/connect-release-init-npm.js
@@ -8,7 +8,7 @@ const args = process.argv.slice(2);
 if (args.length < 1) throw new Error('Check npm dependencies requires 1 parameter: semver');
 const [semver] = args;
 
-const allowedSemvers = ['patch', 'minor', 'beta'];
+const allowedSemvers = ['patch', 'minor', 'prerelease'];
 if (!allowedSemvers.includes(semver)) {
     throw new Error(`provided semver: ${semver} must be one of ${allowedSemvers.join(', ')}`);
 }
@@ -31,36 +31,6 @@ const splitByNewlines = input => input.split('\n');
 const findIndexByCommit = (commitArr, searchString) =>
     commitArr.findIndex(commit => commit.includes(searchString));
 
-const versionBump = (packageJsonPath, versionType) => {
-    const rawPackageJSON = fs.readFileSync(packageJsonPath);
-    const packageJSON = JSON.parse(rawPackageJSON);
-    let { version } = packageJSON;
-
-    if (versionType === 'beta') {
-        const initialVersion = version.split('-');
-        let baseVersion = initialVersion[0];
-        let betaVersion = 1;
-
-        if (initialVersion[1] && initialVersion[1].startsWith('beta')) {
-            betaVersion = parseInt(initialVersion[1].split('.')[1] || '0') + 1;
-        }
-
-        version = `${baseVersion}-beta.${betaVersion}`;
-    } else {
-        // Handle patch or minor with yarn bump
-        exec('yarn', ['bump', versionType, packageJsonPath]);
-        const updatedPackageJSON = JSON.parse(fs.readFileSync(packageJsonPath));
-        version = updatedPackageJSON.version;
-    }
-
-    fs.writeFileSync(
-        packageJsonPath,
-        JSON.stringify({ ...packageJSON, version }, null, 2),
-        'utf-8',
-    );
-    return version;
-};
-
 const initConnectRelease = async () => {
     const checkResult = await checkPackageDependencies('connect');
 
@@ -72,7 +42,11 @@ const initConnectRelease = async () => {
             const PACKAGE_PATH = path.join(ROOT, 'packages', packageName);
             const PACKAGE_JSON_PATH = path.join(PACKAGE_PATH, 'package.json');
 
-            const version = versionBump(PACKAGE_JSON_PATH, semver);
+            exec('yarn', ['bump', semver, `./packages/${packageName}/package.json`]);
+
+            const rawPackageJSON = fs.readFileSync(PACKAGE_JSON_PATH);
+            const packageJSON = JSON.parse(rawPackageJSON);
+            const { version } = packageJSON;
 
             const packageGitLog = getGitCommitByPackageName(packageName, 1000);
 

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -56,7 +56,7 @@
         "test:unit": "jest --version && jest",
         "type-check": "yarn g:tsc --build",
         "build:lib": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/replace-imports.sh ./lib",
-        "version:beta": "yarn g:tsx scripts/bump-version.ts prerelease",
+        "version:prerelease": "yarn g:tsx scripts/bump-version.ts prerelease",
         "version:patch": "yarn g:tsx scripts/bump-version.ts patch",
         "version:minor": "yarn g:tsx scripts/bump-version.ts minor",
         "version:major": "yarn g:tsx scripts/bump-version.ts major",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Change from `beta ` to `prerelease` for consistency with all the scripts. And use the command `yarn bump ${semver}...` to produce same type of update in all the packages without styling changes.

Anyway the output version it produces is like: `9.2.3-beta.1` and so on.

Like in the connect script https://github.com/trezor/trezor-suite/blob/5b1050ebb59ccafe1ac13abd9e5ede9985928814/packages/connect/scripts/bump-version.ts