### PR TITLE
fix(connect): deviceList, break device handle loop when bridge dies

### DIFF
--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -470,7 +470,9 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> {
                 error.code === 'Device_NotFound' ||
                 error.message === TRANSPORT_ERROR.DEVICE_NOT_FOUND ||
                 error.message === TRANSPORT_ERROR.DEVICE_DISCONNECTED_DURING_ACTION ||
-                error.message === TRANSPORT_ERROR.UNEXPECTED_ERROR
+                error.message === TRANSPORT_ERROR.UNEXPECTED_ERROR ||
+                // bridge died during device initialization
+                error.message === TRANSPORT_ERROR.HTTP_ERROR
             ) {
                 // do nothing
                 // For example:


### PR DESCRIPTION
part of #11532

an edge-case that can happen when you kill bridge during acquire call or it dies. in my case, it is related to #12163

should be possible to simulate with old bridge as well.

<img width="505" alt="image" src="https://github.com/trezor/trezor-suite/assets/30367552/b2c09a2d-8c1f-4f1e-aa67-5504b130c2e3">
