### PR TITLE
Ethereum bump fee

### DIFF
--- a/docs/packages/connect/methods/getAccountInfo.md
+++ b/docs/packages/connect/methods/getAccountInfo.md
@@ -112,7 +112,7 @@ TrezorConnect.getAccountInfo({
         misc?: {
             // Ethereum-like accounts only
             nonce: string,
-            erc20Contract?: TokenInfo, // subject of contractFilter param
+            contractInfo?: TokenInfo, // subject of contractFilter param
             // XRP accounts only
             sequence?: number,
             reserve?: string,

--- a/packages/blockchain-link-types/src/blockbook-api.ts
+++ b/packages/blockchain-link-types/src/blockbook-api.ts
@@ -109,6 +109,17 @@ export interface FeeStats {
     averageFeePerKb: number;
     decilesFeePerKb: number[];
 }
+export interface StakingPool {
+    contract: string;
+    pendingBalance: string;
+    pendingDepositedBalance: string;
+    depositedBalance: string;
+    withdrawTotalAmount: string;
+    claimableAmount: string;
+    restakedReward: string;
+    autocompoundBalance: string;
+    name: string;
+}
 export interface ContractInfo {
     type: string;
     contract: string;

--- a/packages/blockchain-link-types/src/blockbook.ts
+++ b/packages/blockchain-link-types/src/blockbook.ts
@@ -21,6 +21,8 @@ import type {
     MempoolTxidFilterEntries,
     Token as BlockbookToken,
     TokenTransfer as BlockbookTokenTransfer,
+    AddressAlias,
+    ContractInfo,
     StakingPool,
 } from './blockbook-api';
 
@@ -103,7 +105,8 @@ export interface AccountInfo {
     transactions?: Transaction[];
     nonce?: string;
     tokens?: (XPUBAddress | ERC20 | ERC721 | ERC1155)[];
-    erc20Contract?: ERC20;
+    contractInfo?: ContractInfo;
+    addressAliases?: { [key: string]: AddressAlias };
     stakingPools?: StakingPool[];
 }
 

--- a/packages/blockchain-link-types/src/blockbook.ts
+++ b/packages/blockchain-link-types/src/blockbook.ts
@@ -8,7 +8,7 @@ import type {
     EstimateFeeParams,
     AccountInfoParams,
 } from './params';
-import type { AccountBalanceHistory, FiatRatesLegacy, TokenStandard, StakingPool } from './common';
+import type { AccountBalanceHistory, FiatRatesLegacy, TokenStandard } from './common';
 import type {
     Tx as BlockbookTx,
     Vin,
@@ -21,6 +21,7 @@ import type {
     MempoolTxidFilterEntries,
     Token as BlockbookToken,
     TokenTransfer as BlockbookTokenTransfer,
+    StakingPool,
 } from './blockbook-api';
 
 type OptionalKey<M, K extends keyof M> = Omit<M, K> & Partial<Pick<M, K>>;

--- a/packages/blockchain-link-types/src/common.ts
+++ b/packages/blockchain-link-types/src/common.ts
@@ -1,7 +1,12 @@
 import type { SocksProxyAgentOptions } from 'socks-proxy-agent';
 
 import type { Transaction as BlockbookTransaction, VinVout } from './blockbook';
-import type { TokenTransfer as BlockbookTokenTransfer } from './blockbook-api';
+import type {
+    AddressAlias,
+    TokenTransfer as BlockbookTokenTransfer,
+    ContractInfo,
+    StakingPool,
+} from './blockbook-api';
 
 /* Common types used in both params and responses */
 
@@ -182,8 +187,9 @@ export interface AccountInfo {
     misc?: {
         // EVM
         nonce?: string;
-        erc20Contract?: TokenInfo;
+        contractInfo?: ContractInfo;
         stakingPools?: StakingPool[];
+        addressAliases?: { [key: string]: AddressAlias };
         // XRP
         sequence?: number;
         reserve?: string;

--- a/packages/blockchain-link-types/src/common.ts
+++ b/packages/blockchain-link-types/src/common.ts
@@ -164,18 +164,6 @@ export interface TokenInfo {
     // transfers: number, // total transactions?
 }
 
-export interface StakingPool {
-    autocompoundBalance: string;
-    claimableAmount: string;
-    contract: string;
-    depositedBalance: string;
-    name: string;
-    pendingBalance: string;
-    pendingDepositedBalance: string;
-    restakedReward: string;
-    withdrawTotalAmount: string;
-}
-
 export interface AccountInfo {
     descriptor: string;
     balance: string;
@@ -192,9 +180,10 @@ export interface AccountInfo {
         addrTxCount?: number; // number of confirmed address/transaction pairs, only for bitcoin-like
     };
     misc?: {
-        // ETH
+        // EVM
         nonce?: string;
         erc20Contract?: TokenInfo;
+        stakingPools?: StakingPool[];
         // XRP
         sequence?: number;
         reserve?: string;
@@ -221,7 +210,6 @@ export interface AccountInfo {
         ledger: number;
         seq: number;
     };
-    stakingPools?: StakingPool[];
 }
 
 export interface SubscriptionAccountInfo {

--- a/packages/blockchain-link-utils/src/blockbook.ts
+++ b/packages/blockchain-link-utils/src/blockbook.ts
@@ -344,6 +344,7 @@ export const transformAccountInfo = (payload: BlockbookAccountInfo): AccountInfo
     let misc: AccountInfo['misc'] = {};
     if (typeof payload.nonce === 'string') {
         misc.nonce = payload.nonce;
+        misc.stakingPools = payload.stakingPools;
     }
     if (payload.erc20Contract) {
         const token = transformTokenInfo([
@@ -392,7 +393,6 @@ export const transformAccountInfo = (payload: BlockbookAccountInfo): AccountInfo
         },
         misc,
         page,
-        stakingPools: payload?.stakingPools,
     };
 };
 

--- a/packages/blockchain-link/tests/unit/fixtures/getAccountInfo-blockbook.ts
+++ b/packages/blockchain-link/tests/unit/fixtures/getAccountInfo-blockbook.ts
@@ -496,7 +496,7 @@ const fixtures: {
                 response: {
                     data: {
                         address: '0xFc6B5d6af8A13258f7CbD0D39E11b35e01a32F93',
-                        erc20Contract: {
+                        contractInfo: {
                             contract: '0xFc6B5d6af8A13258f7CbD0D39E11b35e01a32F93',
                             name: 'Grzegorz Brzęczyszczykiewicz',
                             symbol: 'GRZBRZ',
@@ -511,7 +511,7 @@ const fixtures: {
             empty: false,
             history: {},
             misc: {
-                erc20Contract: {
+                contractInfo: {
                     type: 'ERC20',
                     contract: '0xFc6B5d6af8A13258f7CbD0D39E11b35e01a32F93',
                     name: 'Grzegorz Brzęczyszczykiewicz',

--- a/packages/blockchain-link/tests/unit/fixtures/getAccountInfo-blockbook.ts
+++ b/packages/blockchain-link/tests/unit/fixtures/getAccountInfo-blockbook.ts
@@ -486,7 +486,7 @@ const fixtures: {
         },
     },
     {
-        description: 'ETH (Ropsten) smart contract',
+        description: 'ETH staking pools',
         params: {
             descriptor: '0xFc6B5d6af8A13258f7CbD0D39E11b35e01a32F93',
         },
@@ -495,13 +495,13 @@ const fixtures: {
                 method: 'getAccountInfo',
                 response: {
                     data: {
+                        nonce: '100',
                         address: '0xFc6B5d6af8A13258f7CbD0D39E11b35e01a32F93',
-                        contractInfo: {
-                            contract: '0xFc6B5d6af8A13258f7CbD0D39E11b35e01a32F93',
-                            name: 'Grzegorz Brzęczyszczykiewicz',
-                            symbol: 'GRZBRZ',
-                            decimals: 3,
-                        },
+                        stakingPools: [
+                            {
+                                name: 'Klimactivist Pool',
+                            },
+                        ],
                     },
                 },
             },
@@ -511,12 +511,118 @@ const fixtures: {
             empty: false,
             history: {},
             misc: {
+                nonce: '100',
+                stakingPools: [
+                    {
+                        name: 'Klimactivist Pool',
+                    },
+                ],
+                addressAliases: undefined,
+                contractInfo: undefined,
+            },
+        },
+    },
+    {
+        description: 'ETH send receive tx',
+        params: {
+            descriptor: '0xFc6B5d6af8A13258f7CbD0D39E11b35e01a32F93',
+        },
+        serverFixtures: [
+            {
+                method: 'getAccountInfo',
+                response: {
+                    data: {
+                        nonce: '100',
+                        address: '0xFc6B5d6af8A13258f7CbD0D39E11b35e01a32F93',
+                        balance: '100',
+                        unconfirmedBalance: '-1',
+                    },
+                },
+            },
+        ],
+        response: {
+            descriptor: '0xFc6B5d6af8A13258f7CbD0D39E11b35e01a32F93',
+            empty: false,
+            balance: '100',
+            availableBalance: '99',
+            history: {},
+            misc: {
+                nonce: '100',
+                stakingPools: undefined,
+                addressAliases: undefined,
+                contractInfo: undefined,
+            },
+        },
+    },
+    {
+        description: 'ETH pending receive tx',
+        params: {
+            descriptor: '0xFc6B5d6af8A13258f7CbD0D39E11b35e01a32F93',
+        },
+        serverFixtures: [
+            {
+                method: 'getAccountInfo',
+                response: {
+                    data: {
+                        nonce: '100',
+                        address: '0xFc6B5d6af8A13258f7CbD0D39E11b35e01a32F93',
+                        balance: '100',
+                        unconfirmedBalance: '1',
+                    },
+                },
+            },
+        ],
+        response: {
+            descriptor: '0xFc6B5d6af8A13258f7CbD0D39E11b35e01a32F93',
+            empty: false,
+            balance: '100',
+            availableBalance: '100',
+            history: {},
+            misc: {
+                nonce: '100',
+                stakingPools: undefined,
+                addressAliases: undefined,
+                contractInfo: undefined,
+            },
+        },
+    },
+    {
+        description: 'ETH smart contract',
+        params: {
+            descriptor: '0x3c205C8B3e02421Da82064646788c82f7bd753B9',
+        },
+        serverFixtures: [
+            {
+                method: 'getAccountInfo',
+                response: {
+                    data: {
+                        nonce: '100',
+                        address: '0x3c205C8B3e02421Da82064646788c82f7bd753B9',
+                        contractInfo: {
+                            type: 'ERC20',
+                            contract: '0x3c205C8B3e02421Da82064646788c82f7bd753B9',
+                            name: 'PureFi Token',
+                            symbol: 'UFI',
+                            decimals: 18,
+                        },
+                    },
+                },
+            },
+        ],
+        response: {
+            descriptor: '0x3c205C8B3e02421Da82064646788c82f7bd753B9',
+            empty: false,
+            history: {},
+            misc: {
+                nonce: '100',
+                stakingPools: undefined,
+                addressAliases: undefined,
                 contractInfo: {
                     type: 'ERC20',
-                    contract: '0xFc6B5d6af8A13258f7CbD0D39E11b35e01a32F93',
-                    name: 'Grzegorz Brzęczyszczykiewicz',
-                    symbol: 'GRZBRZ',
-                    decimals: 3,
+                    contract: '0x3c205C8B3e02421Da82064646788c82f7bd753B9',
+                    name: 'PureFi Token',
+                    symbol: 'UFI',
+                    decimals: 18,
                 },
             },
         },

--- a/packages/connect-explorer-nextra/src/pages/methods/bitcoin/getAccountInfo.mdx
+++ b/packages/connect-explorer-nextra/src/pages/methods/bitcoin/getAccountInfo.mdx
@@ -188,7 +188,7 @@ TrezorConnect.getAccountInfo({
         misc?: {
             // Ethereum-like accounts only
             nonce: string,
-            erc20Contract?: TokenInfo, // subject of contractFilter param
+            contractInfo?: TokenInfo, // subject of contractFilter param
             // XRP accounts only
             sequence?: number,
             reserve?: string,

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AcccountSection.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AcccountSection.tsx
@@ -28,11 +28,11 @@ export const AccountSection = ({
         descriptor,
         formattedBalance,
         tokens: accountTokens = [],
-        stakingPools,
+        misc,
     } = account;
 
     const coinDefinitions = useSelector(state => selectCoinDefinitions(state, symbol));
-    const hasStaked = !!stakingPools?.length;
+    const hasStaked = networkType === 'ethereum' && !!misc?.stakingPools?.length;
     const isStakeShown = isSupportedNetworkSymbol(symbol) && hasStaked;
 
     const showGroup = ['ethereum', 'solana', 'cardano'].includes(networkType);

--- a/packages/suite/src/hooks/wallet/useRbfForm.ts
+++ b/packages/suite/src/hooks/wallet/useRbfForm.ts
@@ -104,6 +104,9 @@ const useRbfState = ({ selectedAccount, rbfParams, chainedTxs }: UseRbfProps) =>
         // override Account data
         const rbfAccount = {
             ...account,
+            // on EVM, when send tx is pending, balance has not been changed yet
+            availableBalance:
+                account.networkType === 'ethereum' ? account.balance : account.availableBalance,
             utxo: rbfParams.utxo.concat(availableUtxo),
             // make sure that the exact same change output will be picked by @trezor/connect > hd-wallet during the tx compose process
             // fallback to default if change address is not present

--- a/packages/suite/src/utils/suite/stake.ts
+++ b/packages/suite/src/utils/suite/stake.ts
@@ -119,7 +119,7 @@ const unstake = async ({
             throw new Error(accountInfo.payload.error);
         }
 
-        const { autocompoundBalance } = accountInfo.payload.stakingPools?.[0] ?? {};
+        const { autocompoundBalance } = accountInfo.payload?.misc?.stakingPools?.[0] ?? {};
         if (!autocompoundBalance) {
             throw new Error('Failed to get the autocompound balance');
         }
@@ -188,7 +188,7 @@ const claimWithdrawRequest = async ({ from, symbol, identity }: StakeTxBaseArgs)
         }
 
         const { withdrawTotalAmount, claimableAmount } =
-            accountInfo.payload.stakingPools?.[0] ?? {};
+            accountInfo.payload?.misc?.stakingPools?.[0] ?? {};
         if (!withdrawTotalAmount || !claimableAmount) {
             throw new Error('Failed to get the claimable or withdraw total amount');
         }

--- a/packages/suite/src/utils/wallet/stakingUtils.ts
+++ b/packages/suite/src/utils/wallet/stakingUtils.ts
@@ -5,7 +5,11 @@ import { fromWei } from 'web3-utils';
 export const getAccountEverstakeStakingPool = (
     account?: Account,
 ): StakingPoolExtended | undefined => {
-    const pool = account?.stakingPools?.find(pool => pool.name === 'Everstake');
+    if (account?.networkType !== 'ethereum') {
+        return;
+    }
+
+    const pool = account?.misc?.stakingPools?.find(pool => pool.name === 'Everstake');
 
     if (!pool) return;
 

--- a/suite-common/wallet-types/src/account.ts
+++ b/suite-common/wallet-types/src/account.ts
@@ -1,7 +1,9 @@
 import { Network, BackendType, NetworkSymbol } from '@suite-common/wallet-config';
 import { AccountEntityKeys } from '@suite-common/metadata-types';
 import { AccountInfo, PROTO, TokenInfo } from '@trezor/connect';
-import { StakingPool } from '@trezor/blockchain-link-types';
+import {
+    StakingPool,
+} from '@trezor/blockchain-link-types/src/blockbook-api';
 
 export type MetadataItem = string;
 export type XpubAddress = string;
@@ -42,7 +44,10 @@ type AccountNetworkSpecific =
       }
     | {
           networkType: 'ethereum';
-          misc: { nonce: string };
+          misc: {
+              nonce: string;
+              stakingPools?: StakingPool[];
+          };
           marker: undefined;
           page: AccountInfo['page'];
       }
@@ -93,7 +98,6 @@ export type Account = {
      * metadata/labeling feature which requires device for encryption. local accountLabel field was introduced.
      */
     accountLabel?: string;
-    stakingPools?: StakingPool[];
 } & AccountBackendSpecific &
     AccountNetworkSpecific;
 

--- a/suite-common/wallet-types/src/account.ts
+++ b/suite-common/wallet-types/src/account.ts
@@ -2,6 +2,8 @@ import { Network, BackendType, NetworkSymbol } from '@suite-common/wallet-config
 import { AccountEntityKeys } from '@suite-common/metadata-types';
 import { AccountInfo, PROTO, TokenInfo } from '@trezor/connect';
 import {
+    AddressAlias,
+    ContractInfo,
     StakingPool,
 } from '@trezor/blockchain-link-types/src/blockbook-api';
 
@@ -46,7 +48,9 @@ type AccountNetworkSpecific =
           networkType: 'ethereum';
           misc: {
               nonce: string;
+              contractInfo?: ContractInfo;
               stakingPools?: StakingPool[];
+              addressAliases?: { [key: string]: AddressAlias };
           };
           marker: undefined;
           page: AccountInfo['page'];

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -668,7 +668,8 @@ export const isAccountOutdated = (account: Account, freshInfo: AccountInfo) => {
             return (
                 freshInfo.misc!.nonce !== account.misc.nonce ||
                 freshInfo.balance !== account.balance || // balance can change because of beacon chain txs (staking) |
-                JSON.stringify(freshInfo?.stakingPools) !== JSON.stringify(account?.stakingPools)
+                JSON.stringify(freshInfo?.misc?.stakingPools) !==
+                    JSON.stringify(account?.misc?.stakingPools)
             );
         case 'cardano':
             return (
@@ -706,11 +707,11 @@ export const getAccountSpecific = (
         return {
             networkType,
             misc: {
+                ...misc,
                 nonce: misc && misc.nonce ? misc.nonce : '0',
             },
             marker: undefined,
             page: accountInfo.page,
-            stakingPools: accountInfo?.stakingPools,
         };
     }
 


### PR DESCRIPTION
## Description

- added logic to identify EVM in blockbook, only EVMs have `nonce`, Bitcoin-like coin does not. Temporarily approved by @marekrjpolak even though noone likes it there is no other solution for now.
- staking pool info moved to `misc` so that it is not there for all Blockbook coins
- staking pool type moved to file "generated" by Blockbook
- replaced deprecated `erc20Contract` by `contractInfo`, it is not used now but who knows, maybe one they it will find place in #7244
- added `addressAliases`, it will be useful for #8618. Good to see it in account to detect bugs. I already reported one to Martin

And now finally:
- fixes bumping EVM txs 
  - there can be issue when address is receiving and sending tx at one time https://github.com/trezor/blockbook/issues/1075 we need change in blockbook

## Related Issue

Fixes #8671

## Screenshots:
![Screenshot 2024-04-29 at 17 24 29](https://github.com/trezor/trezor-suite/assets/33235762/d79b327b-bf70-419b-bf40-7dfcac824445)
