### PR TITLE
fix(connect): fix device release and cancel on beforeunload

### DIFF
--- a/packages/connect-iframe/src/index.ts
+++ b/packages/connect-iframe/src/index.ts
@@ -338,7 +338,7 @@ const init = async (payload: IFrameInit['payload'], origin: string) => {
 };
 
 window.addEventListener('message', handleMessage, false);
-window.addEventListener('unload', () => {
+window.addEventListener('beforeunload', () => {
     if (_core) {
         _core.dispose();
     }

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -1077,14 +1077,14 @@ export class Core extends EventEmitter {
         handleMessage(message);
     }
 
-    async dispose() {
+    dispose() {
         disposeBackend();
         if (_deviceListInitTimeout) {
             clearTimeout(_deviceListInitTimeout);
         }
         this.removeAllListeners();
         if (_deviceList) {
-            await _deviceList.dispose();
+            _deviceList.dispose();
         }
     }
 
@@ -1179,7 +1179,7 @@ const disableWebUSBTransport = async () => {
 
     try {
         // disconnect previous device list
-        await _deviceList.dispose();
+        _deviceList.dispose();
         // and init with new settings, without webusb
         await initDeviceList(settings.transportReconnect);
     } catch (error) {

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -789,12 +789,12 @@ export class Device extends TypedEmitter<DeviceEvents> {
         return null;
     }
 
-    dispose() {
+    async dispose() {
         this.removeAllListeners();
         if (this.isUsedHere() && this.activitySessionID) {
             try {
                 if (this.commands) {
-                    this.commands.cancel();
+                    await this.commands.cancel();
                 }
 
                 return this.transport.release({

--- a/packages/connect/src/device/DeviceCommands.ts
+++ b/packages/connect/src/device/DeviceCommands.ts
@@ -804,7 +804,7 @@ export class DeviceCommands {
                 await this.callPromise.promise;
             }
             // if my observations are correct, it is not necessary to transport.receive after send
-            // transport.call -> transport.send -> tranpsport call returns Failure meaning it won't be
+            // transport.call -> transport.send -> transport call returns Failure meaning it won't be
             // returned in subsequent calls
             // await this.transport.receive({ session: this.sessionId }).promise;
         }

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -390,17 +390,18 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> {
         };
     }
 
-    async dispose() {
+    dispose() {
         this.removeAllListeners();
 
         if (autoResolveTransportEventTimeout) {
             clearTimeout(autoResolveTransportEventTimeout);
         }
         // release all devices
-        await Promise.all(this.allDevices().map(device => device.dispose()));
-        // now we can be relatively sure that release calls have been dispatched
-        // and we can safely kill all async subscriptions in transport layer
-        this.transport.stop();
+        Promise.all(this.allDevices().map(device => device.dispose())).then(() => {
+            // now we can be relatively sure that release calls have been dispatched
+            // and we can safely kill all async subscriptions in transport layer
+            this.transport.stop();
+        });
     }
 
     disconnectDevices() {

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -39,11 +39,11 @@ const manifest = (data: Manifest) => {
     });
 };
 
-const dispose = async () => {
+const dispose = () => {
     eventEmitter.removeAllListeners();
     _settings = parseConnectSettings();
     if (_core) {
-        await _core.dispose();
+        _core.dispose();
         _core = null;
     }
 };

--- a/packages/connect/src/types/api/dispose.ts
+++ b/packages/connect/src/types/api/dispose.ts
@@ -1,1 +1,1 @@
-export declare function dispose(): Promise<void>;
+export declare function dispose(): void;


### PR DESCRIPTION
while testing #11532 I finally fixed a long-lasting issue (see screenshots).

- replace deprecated event https://developer.mozilla.org/en-US/docs/Web/API/Window/unload_event
- fix cancel and release before the page unloads.

when you reload while on this screen:

<img width="674" alt="image" src="https://github.com/trezor/trezor-suite/assets/30367552/4e40378a-7441-4891-82c5-1f5cdbc74c62">

you should not end up on this screen

<img width="683" alt="image" src="https://github.com/trezor/trezor-suite/assets/30367552/bb9ae4a1-9c4a-491f-820c-5092c9eae889">


### breaking change

TrezorConnect.dispose is no longer then-able. Is that a big deal?