### PR TITLE
fix(connect-iframe): revert solana worker-loader, use as async import

### DIFF
--- a/packages/connect-iframe/webpack/base.webpack.config.ts
+++ b/packages/connect-iframe/webpack/base.webpack.config.ts
@@ -73,13 +73,6 @@ export const config: webpack.Configuration = {
                 },
             },
             {
-                test: /\workers\/solana\/index/i,
-                loader: 'worker-loader',
-                options: {
-                    filename: './workers/solana-worker.[contenthash].js',
-                },
-            },
-            {
                 test: /\.(js|ts)$/,
                 exclude: /node_modules/,
                 use: {

--- a/packages/connect/src/workers/workers-browser.ts
+++ b/packages/connect/src/workers/workers-browser.ts
@@ -1,8 +1,15 @@
 import BlockbookWorker from '@trezor/blockchain-link/src/workers/blockbook';
 import RippleWorker from '@trezor/blockchain-link/src/workers/ripple';
 import BlockfrostWorker from '@trezor/blockchain-link/src/workers/blockfrost';
-import SolanaWorker from '@trezor/blockchain-link/src/workers/solana';
+import type { BaseWorker } from '@trezor/blockchain-link/src/workers/baseWorker';
 
+type WorkerAsyncImporter = () => Promise<BaseWorker<unknown>>;
+
+// Solana has some issues with worker-loader, so it's not used in the browser
+const SolanaWorker: WorkerAsyncImporter = () =>
+    import(
+        /* webpackChunkName: "solana-worker" */ '@trezor/blockchain-link/src/workers/solana'
+    ).then(w => w.default());
 const ElectrumWorker = undefined;
 
 export { BlockbookWorker, RippleWorker, BlockfrostWorker, ElectrumWorker, SolanaWorker };


### PR DESCRIPTION
## Description

@bosomt reported problems on Slack after the change in #12147. 
Seems that the Solana libraries have some issues in the Worker context, previously they ran in the Window context. 
I removed `worker-loader` again, but at least added it as an async import, which shouldn't bring these negative side effects.