### PR TITLE
feat(mobile): e2e import invalid accounts

### DIFF
--- a/suite-native/alerts/src/alertsAtoms.ts
+++ b/suite-native/alerts/src/alertsAtoms.ts
@@ -17,6 +17,7 @@ export type Alert = {
     secondaryButtonVariant?: ButtonColorScheme;
     onPressSecondaryButton?: () => void;
     appendix?: ReactNode;
+    testID?: string;
 };
 
 export const alertAtom = atom<Alert | null>(null);

--- a/suite-native/alerts/src/components/AlertSheet.tsx
+++ b/suite-native/alerts/src/components/AlertSheet.tsx
@@ -75,6 +75,7 @@ export const AlertSheet = ({ alert }: AlertSheetProps) => {
         primaryButtonVariant = 'primary',
         secondaryButtonVariant = 'tertiaryElevation1',
         appendix,
+        testID,
     } = alert;
 
     const handlePressPrimaryButton = async () => {
@@ -88,7 +89,7 @@ export const AlertSheet = ({ alert }: AlertSheetProps) => {
     };
 
     return (
-        <Modal transparent visible={!!alert}>
+        <Modal transparent visible={!!alert} testID={testID}>
             <Animated.View style={[animatedSheetWithOverlayStyle, applyStyle(sheetOverlayStyle)]}>
                 <Pressable onPress={runShakeAnimation} style={applyStyle(shakeTriggerStyle)}>
                     <Animated.View

--- a/suite-native/app/e2e/pageObjects/accountImportActions.ts
+++ b/suite-native/app/e2e/pageObjects/accountImportActions.ts
@@ -1,4 +1,7 @@
+import { expect as detoxExpect } from 'detox';
+
 import { scrollUntilVisible } from '../utils';
+import { onTabBar } from './tabBarActions';
 
 class AccountImportActions {
     async importAccount({
@@ -10,29 +13,47 @@ class AccountImportActions {
         xpub: string;
         accountName: string;
     }) {
+        await this.selectCoin({ networkSymbol });
+        await this.submitXpub({ xpub, isValid: true });
+        await this.setAccountName({ accountName });
+        await this.confirmAddAccount();
+        await onTabBar.navigateToMyAssets();
+
+        // after importing some accounts, not all are visible, scrolling might be needed
+        await scrollUntilVisible(by.text(accountName));
+    }
+
+    async selectCoin({ networkSymbol }: { networkSymbol: string }) {
         // not all coin types are visible, so first check if visible, if not, scroll
         await scrollUntilVisible(by.id(`@onboarding/select-coin/${networkSymbol.toLowerCase()}`));
-
         await element(by.id(`@onboarding/select-coin/${networkSymbol.toLowerCase()}`)).tap();
+        await detoxExpect(element(by.id('`@screen/XpubScan`')));
+    }
+
+    async submitXpub({ xpub, isValid }: { xpub: string; isValid: boolean }) {
         await element(by.id('@accounts-import/sync-coins/xpub-input')).replaceText(xpub);
 
         // Submit button is not visible without scrolling
         await element(by.id('@screen/mainScrollView')).scrollTo('bottom');
         await element(by.id('@accounts-import/sync-coins/xpub-submit')).tap();
 
-        await waitFor(element(by.id('@account-import/coin-synced/success-pictogram')))
-            .toBeVisible()
-            .withTimeout(20000); // it may take a while to load data from blockchain
+        if (isValid) {
+            await waitFor(element(by.id('@screen/AccountImportSummary')))
+                .toBeVisible()
+                .withTimeout(20000); // it may take a while to load data from blockchain
+        }
+    }
 
+    async setAccountName({ accountName }: { accountName: string }) {
         await element(by.id('@account-import/coin-synced/label-input')).replaceText(accountName);
+    }
+
+    async confirmAddAccount() {
         // confirm button is not visible for some coins e.g. eth
         await element(by.id('@screen/mainScrollView')).scrollTo('bottom');
         await element(by.id('@account-import/coin-synced/confirm-button')).tap();
 
-        await element(by.id('@tabBar/AccountsStack')).tap();
-
-        // after importing some accounts, not all are visible, scrolling might be needed
-        await scrollUntilVisible(by.text(accountName));
+        await detoxExpect(element(by.id('@screen/Home')));
     }
 }
 

--- a/suite-native/app/e2e/tests/invalidAccountsImport.test.ts
+++ b/suite-native/app/e2e/tests/invalidAccountsImport.test.ts
@@ -1,0 +1,49 @@
+import { expect as detoxExpect } from 'detox';
+
+import { onOnboarding } from '../pageObjects/onboardingActions';
+import { xpubs } from '../fixtures/xpubs';
+import { appIsFullyLoaded, openApp, restartApp } from '../utils';
+import { onAccountImport } from '../pageObjects/accountImportActions';
+import { onMyAssets } from '../pageObjects/myAssetsActions';
+import { onTabBar } from '../pageObjects/tabBarActions';
+
+describe('Import invalid accounts', () => {
+    beforeAll(async () => {
+        await openApp({ newInstance: true });
+        await onOnboarding.finishOnboarding();
+    });
+
+    beforeEach(async () => {
+        await restartApp();
+        await appIsFullyLoaded();
+    });
+    it('Import an already imported XPUB', async () => {
+        // add first account
+        await onTabBar.navigateToMyAssets();
+        await onMyAssets.addAccount();
+        await onAccountImport.importAccount({
+            networkSymbol: 'btc',
+            xpub: xpubs.btc.legacySegwit,
+            accountName: 'BTC Legacy SegWit',
+        });
+
+        // try to add account with same xpub
+        await onTabBar.navigateToMyAssets();
+        await onMyAssets.addAccount();
+        await onAccountImport.selectCoin({ networkSymbol: 'btc' });
+        await onAccountImport.submitXpub({ xpub: xpubs.btc.legacySegwit, isValid: true });
+
+        await detoxExpect(element(by.id('@account-import/summary/account-already-imported')));
+    });
+
+    it('Import BTC receive address', async () => {
+        const btcReceiveAddress = 'bc1qunyzxr3gfcg7ggxp5vpxwm3q7t3xc52rcaupu4';
+
+        await onTabBar.navigateToMyAssets();
+        await onMyAssets.addAccount();
+        await onAccountImport.selectCoin({ networkSymbol: 'btc' });
+        await onAccountImport.submitXpub({ xpub: btcReceiveAddress, isValid: false });
+
+        await detoxExpect(element(by.id('@alert-sheet/error/invalidXpub')));
+    });
+});

--- a/suite-native/module-accounts-import/src/components/AccountAlreadyImported.tsx
+++ b/suite-native/module-accounts-import/src/components/AccountAlreadyImported.tsx
@@ -51,7 +51,11 @@ export const AccountAlreadyImported = ({ account }: AccountImportImportedAccount
         });
 
     return (
-        <Box flex={1} justifyContent="flex-end">
+        <Box
+            flex={1}
+            justifyContent="flex-end"
+            testID="@account-import/summary/account-already-imported"
+        >
             <Card style={applyStyle(contentWrapperStyle)}>
                 {account && <AccountListItem account={account} />}
             </Card>

--- a/suite-native/module-accounts-import/src/components/AccountImportSummary.tsx
+++ b/suite-native/module-accounts-import/src/components/AccountImportSummary.tsx
@@ -57,12 +57,7 @@ export const AccountImportSummary = ({ networkSymbol, accountInfo }: AccountImpo
 
     return (
         <VStack spacing="extraLarge" flex={1}>
-            <Box
-                flex={1}
-                alignItems="center"
-                justifyContent="center"
-                testID="@account-import/coin-synced/success-pictogram"
-            >
+            <Box flex={1} alignItems="center" justifyContent="center">
                 <PictogramTitleHeader
                     title={<Text variant="titleSmall">{title}</Text>}
                     subtitle={subtitle}

--- a/suite-native/module-accounts-import/src/useShowImportError.ts
+++ b/suite-native/module-accounts-import/src/useShowImportError.ts
@@ -102,6 +102,7 @@ export const useShowImportError = (networkSymbol: NetworkSymbol, navigation: Nav
                     pictogramVariant,
                     primaryButtonTitle: 'Go back',
                     onPressPrimaryButton: handleGoBack,
+                    testID: `@alert-sheet/error/${alertError}`,
                 });
             }
         },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I wrote two new tests for these test cases:
- https://www.notion.so/satoshilabs/Import-an-already-imported-XPUB-c15497dd8e3340618c17029745f11aab
- https://www.notion.so/satoshilabs/Import-Bitcoin-address-38cebef2993c479e955ae2dbf3cede12

I also wanted to do this one, but I don't know if the alert is shown at the correct time. After scanning the DASH xpub, the app redirects to the "Confirm to add coin" page. The alert appears after the "Confirm" button is pressed. 
- https://www.notion.so/satoshilabs/Import-a-unsupported-XPUB-1cb0680b7a884834a8d2c5ee95499c82

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
