### PR TITLE
GitBook revision update

### DIFF
--- a/packages/suite-data/src/guide/constants.ts
+++ b/packages/suite-data/src/guide/constants.ts
@@ -1,7 +1,7 @@
 import { resolve, join } from 'path';
 
 export const GITBOOK_SOURCE = 'https://github.com/trezor/trezor-suite-guide.git';
-export const GITBOOK_REVISION = '0ea50a38efb7eeb04b205462fabcd9df468d0438';
+export const GITBOOK_REVISION = 'fd6f1d72dc6f955cb88363715d8b7bfb9bd46783';
 export const TMP = join(resolve(__dirname, '../..'), 'tmp', 'guide');
 // Path to the GitBook assets. Relative to TMP.
 export const GITBOOK_ASSETS_DIR_PREFIX = '.gitbook';


### PR DESCRIPTION
Automatically generated PR to update GitBook revision, i.e. to sync the latest [trezor-suite-guide](https://github.com/trezor/trezor-suite-guide) content to Suite. Before merging, check its [commit history](https://github.com/trezor/trezor-suite-guide/commits/master). Once the pipeline finishes, you can check the result [here](https://suite.corp.sldev.cz/suite-web/chore/update-suite-guide/web/).