### PR TITLE
Connect/dispose core in popup

### DIFF
--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -564,3 +564,10 @@ window.closeWindow = () => {
         window.close();
     }, 100);
 };
+
+window.addEventListener('beforeunload', () => {
+    if (getState().core) {
+        const core = ensureCore();
+        core.dispose();
+    }
+});


### PR DESCRIPTION
- while doing #12170 I realize that we don't dispose core when loaded into popup. Without it, users could bump into some wrong previous session problems. Also dialogues on device wouldn't be correctly canceled. This could be contributing to webextension tests flakiness. 
- I am not sure if it is worth merging now because of https://github.com/trezor/trezor-suite/issues/12210 

