### PR TITLE
chore(lint): improve commit-linting

### DIFF
--- a/COMMITS.md
+++ b/COMMITS.md
@@ -17,17 +17,7 @@ Use this git hook to auto-check your commit messages. Save the following snippet
 ```bash
 #!/bin/sh
 
-commit_msg=$(cat "$1")
-if echo "$commit_msg" | grep -qE "^(Revert|fixup! )"; then
-  # Skip validation in case of fixup and revert commits
-  exit 0
-fi
-
-if ! grep -qE "^(build|ci|docs|feat|fix|perf|refactor|style|test|chore|revert)(\([a-z, -]+\))?: " "$1" ; then
-  echo "Conventional Commits validation failed"
-  exit 1
-fi
-
+LINT_COMMIT_MSG="$1" ./scripts/check-commit-messages.sh
 ```
 
 If you want to bypass commit-msg hook check, you may always use

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -10,6 +10,9 @@ feat: allow provided config object to extend other configs
 feat(lang): added polish language
 ```
 
+### Commit linting
+Use `yarn lint:commits` to validate your commit messages compared to `$BASE_BRANCH_NAME` (default: `develop`)
+
 ### Git hook
 
 Use this git hook to auto-check your commit messages. Save the following snippet into `.git/hooks/commit-msg`. This way, the check will run locally and can avoid some unnecessary CI runs.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "type-check": "yarn nx run-many --target=type-check",
         "type-check:force": "rimraf -rf -- **/libDev && yarn type-check",
         "test:unit": "yarn nx run-many --target=test:unit",
+        "lint:commits": "./scripts/check-commit-messages.sh",
         "lint:js": "eslint . --cache --cache-strategy content --ignore-path .gitignore",
         "lint:styles": "yarn nx run-many --target=lint:styles",
         "lint": "yarn lint:styles && yarn lint:js",

--- a/scripts/check-commit-messages.sh
+++ b/scripts/check-commit-messages.sh
@@ -2,6 +2,8 @@
 
 # This script is run by commit-messages-check github action
 
+BASE_BRANCH_NAME="${BASE_BRANCH_NAME:-develop}"
+
 if ! git rev-list origin/"$BASE_BRANCH_NAME"..HEAD > /dev/null 2>&1; then
   tput -T linux setaf 1
   echo "git rev-list command failed"

--- a/scripts/check-commit-messages.sh
+++ b/scripts/check-commit-messages.sh
@@ -4,37 +4,46 @@
 
 BASE_BRANCH_NAME="${BASE_BRANCH_NAME:-develop}"
 
-if ! git rev-list origin/"$BASE_BRANCH_NAME"..HEAD > /dev/null 2>&1; then
-  tput -T linux setaf 1
-  echo "git rev-list command failed"
-  tput -T linux sgr0
-  exit 1
-fi
+lint_commit() {
+  commit=$1
+  commit_msg=$(git log --format=%B -n 1 "$commit")
 
-for commit in $(git rev-list origin/"$BASE_BRANCH_NAME"..HEAD); do
+  # Skip validation in case of revert commits
+  if echo "$commit_msg" | grep -qE "^Revert"; then
+    return
+  fi
 
-    commit_msg=$(git log --format=%B -n 1 "$commit")
-
-    # Skip validation in case of revert commits
-    if echo "$commit_msg" | grep -qE "^Revert"; then
-    continue
-    fi
-
-    # Check for fixup commits
-    if echo "$commit_msg" | grep -qE "^fixup! "; then
+  # Check for fixup commits
+  if echo "$commit_msg" | grep -qE "^fixup! "; then
     tput -T linux setaf 1
     echo "Fixup commit validation failed for commit $commit: $commit_msg"
     tput -T linux sgr0
     echo -e "To squash fixup commits, run:\ngit rebase -i --autosquash origin/HEAD"
     exit 1
-    fi
+  fi
 
-    # Check commit message syntax
-    if ! echo "$commit_msg" | grep -qE "^(build|ci|docs|feat|fix|perf|refactor|style|test|chore|revert|npm-release|release)(\([a-z, -]+\))?: "; then
+  # Check commit message syntax
+  if ! echo "$commit_msg" | grep -qE "^(build|ci|docs|feat|fix|perf|refactor|style|test|chore|revert|npm-release|release)(\([a-z, -]+\))?: "; then
     tput -T linux setaf 1
     echo "Conventional Commits validation failed for commit $commit: $commit_msg"
     tput -T linux sgr0
     echo "Learn more about Conventional Commits at https://www.conventionalcommits.org"
     exit 1
-    fi
+  fi
+}
+
+if [ -z "$LINT_COMMITS" ]; then
+  # if commit hashes are not passed explicitly, lint history compared to base branch
+  if ! git rev-list origin/"$BASE_BRANCH_NAME"..HEAD > /dev/null 2>&1; then
+    tput -T linux setaf 1
+    echo "git rev-list command failed"
+    tput -T linux sgr0
+    exit 1
+  fi
+  LINT_COMMITS=$(git rev-list origin/"$BASE_BRANCH_NAME"..HEAD)
+fi
+
+
+for commit in $LINT_COMMITS; do
+  lint_commit $commit
 done

--- a/scripts/check-commit-messages.sh
+++ b/scripts/check-commit-messages.sh
@@ -4,10 +4,7 @@
 
 BASE_BRANCH_NAME="${BASE_BRANCH_NAME:-develop}"
 
-lint_commit() {
-  commit=$1
-  commit_msg=$(git log --format=%B -n 1 "$commit")
-
+lint_commit_msg() {
   # Skip validation in case of revert commits
   if echo "$commit_msg" | grep -qE "^Revert"; then
     return
@@ -31,6 +28,18 @@ lint_commit() {
     exit 1
   fi
 }
+
+lint_commit() {
+  commit=$1
+  commit_msg=$(git log --format=%B -n 1 "$commit")
+  lint_commit_msg $commit_msg
+}
+
+if [ ! -z "$LINT_COMMIT_MSG" ]; then
+  # passing an explicit messages skips git interactions; for use in commit hook
+  lint_commit_msg "$LINT_COMMIT_MSG"
+  exit 0
+fi
 
 if [ -z "$LINT_COMMITS" ]; then
   # if commit hashes are not passed explicitly, lint history compared to base branch


### PR DESCRIPTION
## Description

- Add `lint:commits` package script for independent commit linting
- Make `check-commit-message.sh` more dynamic
  - Allow passing explicit commit message via env var `LINT_COMMIT_MSG`
  - Allow passing commit(s) to lint via env var `LINT_COMMITS`
  - Defaults to current behavior 
- docs: Suggest commit-lint hook to use `check-commit-message.sh` to simplify and avoid future drift

## Related Issue


## Screenshots:
n/a