### PR TITLE
ci(gitlab): fix desktop build

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -77,6 +77,8 @@ suite-web build stable codesign:
   script:
     - apt-get update && apt-get install -y libudev-dev # required for rebuilding usb native module
     - yarn install --immutable
+    - yarn workspace @trezor/transport-bridge build:lib
+    - yarn workspace @trezor/connect-iframe build:lib
     - yarn workspace @trezor/suite-desktop build:${platform}
     - ls -la packages/suite-desktop/build-electron
     - mv packages/suite-desktop/build-electron/* .


### PR DESCRIPTION
Although we are going away, it makes sense to have CI green.

![image](https://github.com/trezor/trezor-suite/assets/30367552/f55dbbf5-ba56-486f-9c7d-c9af7eb22437)

https://gitlab.com/satoshilabs/trezor/trezor-suite/-/pipelines/1272992160