### PR TITLE
fix(suite): graph tooltip overflow

### DIFF
--- a/packages/suite/src/views/wallet/transactions/components/TransactionSummary.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionSummary.tsx
@@ -34,6 +34,7 @@ const GraphWrapper = styled(Card)`
     flex-direction: row;
     display: flex;
     height: 320px;
+    overflow: visible;
 `;
 
 const Actions = styled.div`


### PR DESCRIPTION
## Description

Fixes graph tooltip visibility.

## Related Issue

Related #12084

## Screenshots:
Before:
<img width="710" alt="Screenshot 2024-04-30 at 12 28 21 PM" src="https://github.com/trezor/trezor-suite/assets/66002635/8cd34262-6a55-4294-8f89-4f71e081267d">

After:
<img width="758" alt="Screenshot 2024-04-30 at 12 27 25 PM" src="https://github.com/trezor/trezor-suite/assets/66002635/b106a6aa-20de-4a3a-a147-5596128047ce">