### PR TITLE
Show correct step for disconnect event

### DIFF
--- a/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
+++ b/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
@@ -4,7 +4,7 @@ import * as semver from 'semver';
 
 import { pickByDeviceModel, getFirmwareVersion } from '@trezor/device-utils';
 import { H2, Button, ConfirmOnDevice, variables, DeviceAnimation } from '@trezor/components';
-import { DEVICE, Device, DeviceModelInternal } from '@trezor/connect';
+import { DEVICE, Device, DeviceModelInternal, UI } from '@trezor/connect';
 import { Modal, Translation, WebUsbButton } from 'src/components/suite';
 import { DeviceConfirmImage } from 'src/components/suite/DeviceConfirmImage';
 import { useDevice, useFirmware } from 'src/hooks/suite';
@@ -183,8 +183,10 @@ export const ReconnectDevicePrompt = ({ onClose, onSuccess }: ReconnectDevicePro
         ) {
             return 'done';
         }
+        const rebootToBootloaderNotSupported = uiEvent?.type === UI.FIRMWARE_DISCONNECT;
+        const rebootToBootloaderCancelled = device?.connected && device?.mode !== 'bootloader';
 
-        return device?.connected && device?.mode !== 'bootloader'
+        return rebootToBootloaderNotSupported || rebootToBootloaderCancelled
             ? 'waiting-for-reboot'
             : 'disconnected';
     };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

During intermediary FW installation, step 1 (disconnect) should be highlighted until the device is disconnected.

## Screenshots:
Before:
![Screenshot 2024-04-30 at 14 10 22](https://github.com/trezor/trezor-suite/assets/42465546/50651a3e-767d-4d12-85d5-8471d215688a)
After:
![Screenshot 2024-04-30 at 14 10 13](https://github.com/trezor/trezor-suite/assets/42465546/75d1cc63-5add-4c15-9787-8a5139414f51)
