### PR TITLE
fix(scripts): check-version to allow distTags first time

### DIFF
--- a/ci/scripts/check-version.js
+++ b/ci/scripts/check-version.js
@@ -60,6 +60,7 @@ if (PRODUCTION.find(b => branch.startsWith(b))) {
     }
 }
 
-if (!semver.gt(version, npmVersion)) {
+// When npmVersion is undefined it means that there was no previous release on that distTag so every version is valid.
+if (npmVersion && !semver.gt(version, npmVersion)) {
     throw new Error(`${version} is the same or lower than the npm registry version ${npmVersion}`);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Update check-version script to allow a version that is first time in that channel/distTag ('latest', 'beta')
To avoid issues like this https://github.com/trezor/trezor-suite/actions/runs/8893468633

## Related Issue
Related https://github.com/trezor/trezor-suite/issues/11918