### PR TITLE
Connect/t3 releases.json

### DIFF
--- a/packages/connect-common/files/firmware/t3t1/releases.json
+++ b/packages/connect-common/files/firmware/t3t1/releases.json
@@ -4,7 +4,6 @@
         "version": [2, 7, 1],
         "min_firmware_version": [2, 7, 1],
         "min_bootloader_version": [2, 1, 1],
-        "bootloader_version": [2, 1, 4],
         "url": "",
         "url_bitcoinonly": "",
         "fingerprint": "",

--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -238,7 +238,7 @@ export const getInfo = ({ features, releases }: GetInfoProps): ReleaseInfo | nul
         isNewer: isNewerResult,
         intermediaryVersion,
         // translations available to be installed
-        translations: isNewerResult ? prevRelease.translations : release.translations,
+        translations: isNewerResult ? prevRelease?.translations : release?.translations,
     };
 };
 


### PR DESCRIPTION
- t3t1 on my table has higher bootloader version than listed in releases.json. this results in device.firmwareRelease = null because it gets evaluated as unsuitable firmware release for the device on my table
- if there is only one firmware release, we cant obviously work with "latest" and "prev" release.

cc @Hannsek 