### PR TITLE
fix(suite): move notification to not hide buttons

### DIFF
--- a/packages/suite/src/components/suite/notifications/ToastContainer.tsx
+++ b/packages/suite/src/components/suite/notifications/ToastContainer.tsx
@@ -15,7 +15,7 @@ const StyledContainer = styled(BaseToastContainer)`
         padding: 4px;
         box-sizing: border-box;
         border-radius: ${borders.radii.xs};
-        top: 11px;
+        top: 51px;
         right: 11px;
 
         @media only screen and (width <= 480px) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

move notifications down a bit to not cover important buttons

## Related Issue

Resolve  https://github.com/trezor/trezor-suite/issues/11610

## Screenshots:

![image](https://github.com/trezor/trezor-suite/assets/152899911/f2d832fc-a084-44a5-8a59-befc15be0fb2)
