### PR TITLE
ci(connect): use cached txs except for nightly

### DIFF
--- a/.github/workflows/template-connect-test-params.yml
+++ b/.github/workflows/template-connect-test-params.yml
@@ -53,7 +53,10 @@ jobs:
       # todo: ideally do not install everything. possibly only devDependencies could be enough for testing (if there was not for building libs)?
       - run: sed -i "/\"node\"/d" package.json
       - run: yarn install
-      - run: './docker/docker-connect-test.sh node -p "${{ inputs.test-pattern }}" -f "${{ inputs.tests-firmware }}" -i ${{ inputs.methods }} -m ${{ inputs.test-firmware-model}}'
+      # nightly test - run without cached txs
+      - run: 'export ADDITIONAL_ARGS="-c"'
+        if: ${{ github.event_name == 'schedule' }}
+      - run: './docker/docker-connect-test.sh node -p "${{ inputs.test-pattern }}" -f "${{ inputs.tests-firmware }}" -i ${{ inputs.methods }} -m ${{ inputs.test-firmware-model}} $ADDITIONAL_ARGS'
 
   web:
     name: "web-${{ inputs.test-description }}"
@@ -85,4 +88,7 @@ jobs:
       - run: cd packages/connect-iframe && tree .
       - name: "Echo download path"
         run: echo ${{steps.download.outputs.download-path}}
-      - run: './docker/docker-connect-test.sh web -p "${{ inputs.test-pattern }}" -f "${{ inputs.tests-firmware }}" -i ${{ inputs.methods }} -m ${{ inputs.test-firmware-model}}'
+      # nightly test - run without cached txs
+      - run: 'export ADDITIONAL_ARGS="-c"'
+        if: ${{ github.event_name == 'schedule' }}
+      - run: './docker/docker-connect-test.sh web -p "${{ inputs.test-pattern }}" -f "${{ inputs.tests-firmware }}" -i ${{ inputs.methods }} -m ${{ inputs.test-firmware-model}} $ADDITIONAL_ARGS'

--- a/docker/docker-compose.connect-test.yml
+++ b/docker/docker-compose.connect-test.yml
@@ -16,8 +16,8 @@ services:
       - TESTS_INCLUDED_METHODS=$TESTS_INCLUDED_METHODS
       - TESTS_EXCLUDED_METHODS=$TESTS_EXCLUDED_METHODS
       - TESTS_PATTERN=$TESTS_PATTERN
-      - TESTS_USE_TX_CACHE=false
-      - TESTS_USE_WS_CACHE=false
+      - TESTS_USE_TX_CACHE=$TESTS_USE_TX_CACHE
+      - TESTS_USE_WS_CACHE=$TESTS_USE_WS_CACHE
     depends_on:
       - trezor-user-env-unix
     network_mode: service:trezor-user-env-unix

--- a/packages/connect/e2e/__txcache__/testnet/334cd7ad982b3b15d07dd1c84e939e95efb0803071648048a7f289492e7b4c8a.json
+++ b/packages/connect/e2e/__txcache__/testnet/334cd7ad982b3b15d07dd1c84e939e95efb0803071648048a7f289492e7b4c8a.json
@@ -1,36 +1,38 @@
 {
+    "version": 1,
     "inputs": [
         {
+            "address_n": [2147483697, 2147483649, 2147483648, 0, 4],
             "prev_hash": "5e7667690076ae4737e2f872005de6f6b57592f32108ed9b301eeece6de24ad6",
             "prev_index": 1,
-            "address_n": [2147483697, 2147483649, 2147483648, 0, 4],
-            "amount": 100000,
-            "script_type": "SPENDP2SHWITNESS",
             "script_sig": "160014039ba06270e6c6c1ad4e6940515aa5cdbad33f9e",
-            "witness": "0247304402205cfe0d0ca30b23c462f535f0c3670761592ba42517bd65fca959887e131b61c9022017d692c3a24ee7aba1205c9a1ee0df5a3d1fcc6a2906c9a77cf1145edb903f8e012103bb0e339d7495b1f355c49d385b79343e52e68d99de2fe1f7f476c465c9ccd167",
-            "sequence": 4294967295
+            "sequence": 4294967295,
+            "script_type": "SPENDP2SHWITNESS",
+            "amount": 100000,
+            "witness": "0247304402205cfe0d0ca30b23c462f535f0c3670761592ba42517bd65fca959887e131b61c9022017d692c3a24ee7aba1205c9a1ee0df5a3d1fcc6a2906c9a77cf1145edb903f8e012103bb0e339d7495b1f355c49d385b79343e52e68d99de2fe1f7f476c465c9ccd167"
         },
         {
+            "address_n": [2147483697, 2147483649, 2147483648, 0, 3],
             "prev_hash": "efaa41ff3e67edf508846c1a1ed56894cfd32725c590300108f40c9edc1aac35",
             "prev_index": 0,
-            "address_n": [2147483697, 2147483649, 2147483648, 0, 3],
-            "amount": 998060,
-            "script_type": "SPENDP2SHWITNESS",
             "script_sig": "160014209297fb46272a0b7e05139440dbd39daea3e25a",
-            "sequence": 4294967295
+            "sequence": 4294967295,
+            "script_type": "SPENDP2SHWITNESS",
+            "amount": 998060,
+            "witness": "0247304402206f5b2032601278685921b397416cecd5f70cde48b7203bf2a953283c0cd05f4002205fd21a2c318330f11e8433f8fae6b1c4c257a79da55be9712961214ba2752a1f012103c2c2e65556ca4b7371549324b99390725493c8a6792e093a0bdcbb3e2d7df4ab"
         }
     ],
-    "lock_time": 0,
     "outputs": [
         {
             "address": "2MvUUSiQZDSqyeSdofKX9KrSCio1nANPDTe",
-            "amount": 1000000
+            "amount": 1000000,
+            "script_type": "PAYTOADDRESS"
         },
         {
             "address_n": [2147483697, 2147483649, 2147483648, 1, 3],
             "amount": 94280,
-            "script_type": 5
+            "script_type": "PAYTOP2SHWITNESS"
         }
     ],
-    "version": 1
+    "lock_time": 0
 }

--- a/packages/connect/e2e/__txcache__/testnet/ed89acb52cfa438e3653007478e7c7feae89fdde12867943eec91293139730d1.json
+++ b/packages/connect/e2e/__txcache__/testnet/ed89acb52cfa438e3653007478e7c7feae89fdde12867943eec91293139730d1.json
@@ -1,14 +1,5 @@
 {
-    "bin_outputs": [
-        {
-            "amount": 744201489,
-            "script_pubkey": "a9145a699f6166aa26037e367d5edd44e07d676f921d87"
-        },
-        {
-            "amount": 100000000,
-            "script_pubkey": "76a914548cb80e45b1d36312fe0cb075e5e337e3c54cef88ac"
-        }
-    ],
+    "version": 1,
     "inputs": [
         {
             "prev_hash": "6673b7248e324882b2f9d02fdd1ff1d0f9ed216a234e836b8d3ac65661cbb457",
@@ -27,20 +18,21 @@
             "amount": 839318869,
             "script_type": "SPENDP2SHWITNESS",
             "script_sig": "160014681ea49259abb892460bf3373e8a0b43d877fa18",
+            "witness": "02473044022039bb1710e041e9a936bd3adf39f61906ac4363a67d1c29b1a264ff8cf5a0c95102202829307d82141792125480abe6491f0f0c7d675c3d1a06daa383d617afcb53380121028cbc37e1816a23086fa738c8415def477e813e20f484dbbd6f5a33a37c322251",
             "sequence": 4294967295
         }
     ],
-    "lock_time": 0,
     "outputs": [
         {
             "address_n": [2147483697, 2147483649, 2147483648, 1, 6],
             "amount": 744201489,
-            "script_type": 5
+            "script_type": "PAYTOP2SHWITNESS"
         },
         {
             "address": "moE1dVYvebvtaMuNdXQKvu4UxUftLmS1Gt",
-            "amount": 100000000
+            "amount": 100000000,
+            "script_type": "PAYTOADDRESS"
         }
     ],
-    "version": 1
+    "lock_time": 0
 }


### PR DESCRIPTION
## Description

We want to use cached txs in regular Connect tests instead of calling backend directly. 
We will keep the cache disabled in nightly.