### PR TITLE
E2E cancel after every call

### DIFF
--- a/packages/connect/e2e/tests/device/methods.test.ts
+++ b/packages/connect/e2e/tests/device/methods.test.ts
@@ -36,6 +36,10 @@ describe(`TrezorConnect methods`, () => {
                 }
             }, 40000);
 
+            afterEach(() => {
+                TrezorConnect.cancel();
+            });
+
             testCase.tests.forEach(t => {
                 // check if test should be skipped on current configuration
                 conditionalTest(


### PR DESCRIPTION
## Description

When a single test from `methods.test.ts` timeouts (e.g. because of backend requests), the following tests fail as well because of `Device_CallInProgress`. Cancelling after every test could improve this behavior (provided that it doesn't make it even worse).