### PR TITLE
fix(suite): height of the card in SecurityCheck

### DIFF
--- a/packages/components/src/components/Card/Card.tsx
+++ b/packages/components/src/components/Card/Card.tsx
@@ -61,7 +61,6 @@ const CardContainer = styled.div<
     padding: ${mapPaddingTypeToPadding};
     background: ${mapElevationToBackground};
     border-radius: ${borders.radii.md};
-    position: relative;
     overflow: auto;
     ${({ $isClickable, theme }) =>
         $isClickable &&

--- a/packages/suite/src/views/dashboard/components/SecurityCard.tsx
+++ b/packages/suite/src/views/dashboard/components/SecurityCard.tsx
@@ -1,11 +1,10 @@
-import { Button, Card, CardProps, Icon, IconProps, variables } from '@trezor/components';
+import { Button, Card, Icon, IconProps, variables } from '@trezor/components';
 import { spacingsPx, typography } from '@trezor/theme';
 import { ReactNode } from 'react';
 import styled, { useTheme } from 'styled-components';
 
 const Wrapper = styled.div`
     display: flex;
-    flex-direction: column;
     position: relative;
 `;
 
@@ -69,7 +68,7 @@ const Line = styled.div`
     background: ${({ theme }) => theme.borderElevation2};
 `;
 
-export interface SecurityCardProps extends CardProps {
+export type SecurityCardProps = {
     variant: 'primary' | 'secondary';
     icon: IconProps['icon'];
     heading: ReactNode;
@@ -80,22 +79,15 @@ export interface SecurityCardProps extends CardProps {
         dataTest?: string;
         isDisabled?: boolean;
     };
-}
+};
 
-export const SecurityCard = ({
-    variant,
-    icon,
-    heading,
-    description,
-    cta,
-    ...rest
-}: SecurityCardProps) => {
+export const SecurityCard = ({ variant, icon, heading, description, cta }: SecurityCardProps) => {
     const theme = useTheme();
 
     const isDone = variant === 'secondary';
 
     return (
-        <Wrapper {...rest}>
+        <Wrapper>
             <Card>
                 <Header>
                     <Icon icon={icon} size={32} color={theme.iconDefault} />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

By adding a wrapper to the card, the inner element is not stretched vertically. This PR fixes this. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/12007

## Screenshots:
