### PR TITLE
chore(ci): skip aws upload for non-trezor repo owners; minimize credentials exposure to untrusted code

### DIFF
--- a/.github/workflows/connect-nextra-dev-release.yml
+++ b/.github/workflows/connect-nextra-dev-release.yml
@@ -36,13 +36,6 @@ jobs:
       - name: "Pull LFS files for connect"
         run: git lfs pull --include "packages/connect-common/files/**/*"
 
-      - name: Configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::538326561891:role/gh_actions_trezor_suite_dev_deploy
-          aws-region: eu-central-1
-        if: github.repository_owner == 'trezor'
-
       - name: Extract branch name
         run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
         id: extract_branch
@@ -87,6 +80,13 @@ jobs:
           CONNECT_EXPLORER_BASE_PATH: /connect-nextra/${{ steps.extract_branch.outputs.branch }}
         run: |
           yarn workspace @trezor/connect-explorer-nextra build
+
+      - name: Configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::538326561891:role/gh_actions_trezor_suite_dev_deploy
+          aws-region: eu-central-1
+        if: github.repository_owner == 'trezor'
 
       - name: Upload connect-explorer-nextra to dev.suite.sldev.cz
         env:

--- a/.github/workflows/connect-nextra-dev-release.yml
+++ b/.github/workflows/connect-nextra-dev-release.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::538326561891:role/gh_actions_trezor_suite_dev_deploy
           aws-region: eu-central-1
+        if: github.repository_owner == 'trezor'
 
       - name: Extract branch name
         run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
@@ -98,6 +99,7 @@ jobs:
           cp -R ./packages/connect-web/build/* tmp_build_directory/
           cp -R ./packages/connect-explorer-nextra/build/* tmp_build_directory/
           aws s3 sync --delete tmp_build_directory/ "${DEPLOY_PATH}"
+        if: github.repository_owner == 'trezor'
 
       - name: Build connect-explorer-webextension
         run: |

--- a/.github/workflows/template-connect-build-deploy.yml
+++ b/.github/workflows/template-connect-build-deploy.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           role-to-assume: ${{ inputs.awsRoleToAssume }}
           aws-region: ${{ inputs.awsRegion }}
+        if: github.repository_owner == 'trezor'
 
       - name: Setup node
         uses: actions/setup-node@v4
@@ -101,6 +102,7 @@ jobs:
           cp -R ./packages/connect-web/build/* tmp_build_directory/
           cp -R ./packages/connect-explorer/build/* tmp_build_directory/
           aws s3 sync --delete tmp_build_directory/ "${DEPLOY_PATH}"
+        if: github.repository_owner == 'trezor'
 
       - name: Upload  connect-example webextension artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/template-connect-build-deploy.yml
+++ b/.github/workflows/template-connect-build-deploy.yml
@@ -33,13 +33,6 @@ jobs:
       - name: "Pull LFS files for connect"
         run: git lfs pull --include "packages/connect-common/files/**/*"
 
-      - name: Configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ inputs.awsRoleToAssume }}
-          aws-region: ${{ inputs.awsRegion }}
-        if: github.repository_owner == 'trezor'
-
       - name: Setup node
         uses: actions/setup-node@v4
         with:
@@ -89,6 +82,13 @@ jobs:
       - name: Build connect-explorer-webextension
         run: |
           yarn workspace @trezor/connect-explorer build:webextension
+
+      - name: Configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ inputs.awsRoleToAssume }}
+          aws-region: ${{ inputs.awsRegion }}
+        if: github.repository_owner == 'trezor'
 
       # this step should upload build result to s3 bucket DEV_SERVER_HOSTNAME using awscli
       - name: Upload connect-explorer to dev.suite.sldev.cz

--- a/.github/workflows/test-suite-web-e2e.yml
+++ b/.github/workflows/test-suite-web-e2e.yml
@@ -33,13 +33,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::538326561891:role/gh_actions_trezor_suite_dev_deploy
-          aws-region: eu-central-1
-        if: github.repository_owner == 'trezor'
-
       - name: Extract branch name
         id: extract_branch
         run: |
@@ -67,6 +60,14 @@ jobs:
           yarn workspace @trezor/connect-iframe build:lib
           yarn workspace @trezor/connect-web build
           yarn workspace @trezor/suite-web build
+
+      - name: Configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::538326561891:role/gh_actions_trezor_suite_dev_deploy
+          aws-region: eu-central-1
+        if: github.repository_owner == 'trezor'
+
       # this step should upload build result to s3 bucket dev.suite.sldev.cz using awscli
       - name: Upload suite-web to dev.suite.sldev.cz
         env:

--- a/.github/workflows/test-suite-web-e2e.yml
+++ b/.github/workflows/test-suite-web-e2e.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::538326561891:role/gh_actions_trezor_suite_dev_deploy
           aws-region: eu-central-1
+        if: github.repository_owner == 'trezor'
 
       - name: Extract branch name
         id: extract_branch
@@ -72,6 +73,7 @@ jobs:
           DEPLOY_PATH: s3://dev.suite.sldev.cz/suite-web/${{ steps.extract_branch.outputs.branch }}
         run: |
           aws s3 sync --delete ./packages/suite-web/build ${DEPLOY_PATH}/web
+        if: github.repository_owner == 'trezor'
 
   e2e-test-suite-web:
     if: github.repository == 'trezor/trezor-suite'


### PR DESCRIPTION
## Description

The aws OIDC credentials are configured unconditionally for some GitHub Actions workflows. This results in [failures](https://github.com/trezor/trezor-suite/actions/runs/8921834518/job/24503884348?pr=12179) with tests being skipped as result for PRs from any other repo.

Additionally, setting up aws credentials before running tests seems redundant, needlessly exposing aws credentials to test code. The step could be postponed until the credentials are about to be used.

This does two things:
- Only run the aws-specific steps when `github.repository_owner == trezor`
- Move the `aws-actions/configure-aws-credentials` steps to be right before their first actual use

## Related Issue


## Screenshots:
