### PR TITLE
suite-desktop: make node bridge accept ilogger

### DIFF
--- a/packages/suite-desktop-core/src/modules/bridge.ts
+++ b/packages/suite-desktop-core/src/modules/bridge.ts
@@ -48,6 +48,16 @@ const getBridgeInstance = () => {
             port: 21325,
             api: bridgeNodeTest ? 'udp' : 'usb',
             assetPrefix: '../build/node-bridge',
+            // passing down ILogger where Log is expected.
+            // @ts-expect-error
+            logger: {
+                ...global.logger,
+                log: (...args) => logger.info('trezord-node', args.join(' ')),
+                info: (...args) => logger.info('trezord-node', args.join(' ')),
+                warn: (...args) => logger.warn('trezord-node', args.join(' ')),
+                debug: (...args) => logger.debug('trezord-node', args.join(' ')),
+                error: (...args) => logger.error('trezord-node', args.join(' ')),
+            },
         });
     }
 

--- a/packages/transport-bridge/src/http.ts
+++ b/packages/transport-bridge/src/http.ts
@@ -29,19 +29,22 @@ export class TrezordNode {
     port: number;
     server?: HttpServer<never>;
     api: ReturnType<typeof createApi>;
-    logger = new Log('@trezor/transport-bridge', true);
+    logger: Log;
     assetPrefix: string;
 
     constructor({
         port,
         api,
         assetPrefix = '',
+        logger,
     }: {
         port: number;
         api: 'usb' | 'udp';
         assetPrefix?: string;
+        logger?: Log;
     }) {
         this.port = port || defaults.port;
+        this.logger = logger || new Log('@trezor/transport-bridge', true);
 
         this.descriptors = [];
 


### PR DESCRIPTION
part of #11532

At the moment we use two major logging mechanisms [`Log` ](https://github.com/trezor/trezor-suite/blob/develop/packages/utils/src/logs.ts#L12 )(connect, transport) and [`ILogger`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite-desktop-core/src/libs/logger.ts#L43) used by suite-desktop. Maybe there are more of them. 

Since node-bridge is being added to suite-desktop, these 2 mechanisms start to mix. The main motivation of this PR is to unify log output of suite-desktop (see screenshots below). 

before: 
![image](https://github.com/trezor/trezor-suite/assets/30367552/7783d36b-ca36-4549-925f-72cf2ee1d038)

after:
![image](https://github.com/trezor/trezor-suite/assets/30367552/05b1b353-a545-44c5-8884-62dafa3f8331)


How far should we go now? 
 
- [x] - easy: overwrite `ILogger` properties which are needed in runtime to match `Log`
- [ ]  - advanced: create some converter fn in suite-desktop which takes `ILogger` and returns `Log` without any ts-ignores
- [ ] - pro: unify `ILogger` and `Log` under single interface
