### PR TITLE
fix(suite-native): transaction missing data ui error

### DIFF
--- a/suite-native/transactions/src/components/TransactionDetail/NetworkTransactionDetailSummary.tsx
+++ b/suite-native/transactions/src/components/TransactionDetail/NetworkTransactionDetailSummary.tsx
@@ -32,28 +32,28 @@ export const NetworkTransactionDetailSummary = ({
         selectTransactionAddresses(state, txid, accountKey, 'outputs'),
     );
 
-    if (
-        !transaction ||
-        A.isEmpty(transactionInputAddresses) ||
-        A.isEmpty(transactionOutputAddresses)
-    ) {
+    if (!transaction) {
         return <ErrorMessage errorMessage="Target or Origin of transaction is unknown." />;
     }
 
     return (
         <VStack>
-            <TransactionDetailAddressesSection
-                addressesType="inputs"
-                addresses={transactionInputAddresses}
-                onShowMore={onShowMore}
-                icon={transaction.symbol}
-            />
+            {A.isNotEmpty(transactionInputAddresses) && (
+                <TransactionDetailAddressesSection
+                    addressesType="inputs"
+                    addresses={transactionInputAddresses}
+                    onShowMore={onShowMore}
+                    icon={transaction.symbol}
+                />
+            )}
             <TransactionDetailStatusSection txid={txid} accountKey={accountKey} />
-            <TransactionDetailAddressesSection
-                addressesType="outputs"
-                addresses={transactionOutputAddresses}
-                onShowMore={onShowMore}
-            />
+            {A.isNotEmpty(transactionOutputAddresses) && (
+                <TransactionDetailAddressesSection
+                    addressesType="outputs"
+                    addresses={transactionOutputAddresses}
+                    onShowMore={onShowMore}
+                />
+            )}
         </VStack>
     );
 };


### PR DESCRIPTION
Do not hide more data then needed if there are missign tx inputs or outputs.

## Related Issue

Resolve #12241
