### PR TITLE
ci(scripts): update packages when moving to stable from canary

### DIFF
--- a/ci/scripts/connect-release-init-npm.js
+++ b/ci/scripts/connect-release-init-npm.js
@@ -47,7 +47,7 @@ const findIndexByCommit = (commitArr, searchString) =>
     commitArr.findIndex(commit => commit.includes(searchString));
 
 const initConnectRelease = async () => {
-    const checkResult = await checkPackageDependencies('connect');
+    const checkResult = await checkPackageDependencies('connect', deploymentType);
 
     const update = checkResult.update.map(package => package.replace('@trezor/', ''));
     const errors = checkResult.errors.map(package => package.replace('@trezor/', ''));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updating the scripts that identify which packages need to be updated now when we have `stable` and `canary` releases there are 2 things we need to check extra:
1. When doing a `canary` release when last one was also `canary` we need to check if changes where happening in that tag because that contained the last version of the code.
2. When doing an `stable` release when last one was `canary` we need to release the package also to make sure the package is released with the `latest` tag which is the NPM tag that we use for `stable` releases in NPM.

You can easily test it by running the script `ci/scripts/check-npm-dependencies.js` with the required arguments.
## Related Issue

Related https://github.com/trezor/trezor-suite/issues/11918
Related https://github.com/trezor/trezor-suite/issues/12157
