### PR TITLE
fix(suite): eth staking banner on btc only fw when eth enabled

### DIFF
--- a/packages/suite/src/views/dashboard/components/StakeEthCard/StakeEthCard.tsx
+++ b/packages/suite/src/views/dashboard/components/StakeEthCard/StakeEthCard.tsx
@@ -4,7 +4,7 @@ import { variables, H3, Icon, Card } from '@trezor/components';
 import { DashboardSection } from 'src/components/dashboard';
 import { Translation, StakingFeature, Divider } from 'src/components/suite';
 import { Footer } from './components/Footer';
-import { useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
+import { useDevice, useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
 import { useAccounts } from 'src/hooks/wallet';
 import { MIN_ETH_BALANCE_FOR_STAKING } from 'src/constants/suite/ethStaking';
 import { spacingsPx, borders } from '@trezor/theme';
@@ -12,6 +12,7 @@ import { selectEnabledNetworks } from 'src/reducers/wallet/settingsReducer';
 import { selectSuiteFlags } from 'src/reducers/suite/suiteReducer';
 import { setFlag } from 'src/actions/suite/suiteActions';
 import { selectPoolStatsApyData } from '@suite-common/wallet-core';
+import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 
 const Flex = styled.div`
     display: flex;
@@ -68,13 +69,17 @@ export const StakeEthCard = () => {
     const dispatch = useDispatch();
     const enabledNetworks = useSelector(selectEnabledNetworks);
     const { showDashboardStakingPromoBanner } = useSelector(selectSuiteFlags);
+    const { device } = useDevice();
+    const isBitcoinOnlyDevice = hasBitcoinOnlyFirmware(device);
 
     const closeBanner = () => {
         dispatch(setFlag('showDashboardStakingPromoBanner', false));
     };
 
     const isBannerSymbolEnabled =
-        enabledNetworks.includes(bannerSymbol) && showDashboardStakingPromoBanner;
+        enabledNetworks.includes(bannerSymbol) &&
+        showDashboardStakingPromoBanner &&
+        !isBitcoinOnlyDevice;
 
     const ethApy = useSelector(state => selectPoolStatsApyData(state, bannerSymbol));
 


### PR DESCRIPTION

## Description

<!--- Describe your changes in detail -->

## Related Issue

close #12253

## Screenshots:

<img width="1021" alt="Screenshot 2024-05-04 at 20 01 03" src="https://github.com/trezor/trezor-suite/assets/33235762/fe81e30e-117c-4c15-b953-cf018b1c0e22">
<img width="1177" alt="Screenshot 2024-05-04 at 20 00 55" src="https://github.com/trezor/trezor-suite/assets/33235762/5ca091d5-dfb4-47c0-b153-deacedff62b4">
<img width="1463" alt="Screenshot 2024-05-04 at 20 00 49" src="https://github.com/trezor/trezor-suite/assets/33235762/7f61df90-fcd8-47ed-81e0-b9ac4854ec9a">

