### PR TITLE
chore(connect): smaller build of content-script.js

### DIFF
--- a/packages/connect-web/src/channels/window-serviceworker.ts
+++ b/packages/connect-web/src/channels/window-serviceworker.ts
@@ -2,7 +2,8 @@ import {
     AbstractMessageChannel,
     AbstractMessageChannelConstructorParams,
     Message,
-} from '@trezor/connect-common';
+    // import from src explained - this is part of contentScript.ts and importing through index makes it bundle unwanted code too
+} from '@trezor/connect-common/src/messageChannel/abstract';
 
 /**
  * Communication channel between:


### PR DESCRIPTION
this change by @Nodonisko https://github.com/trezor/trezor-suite/pull/11443

made content-script.js bloat a bit by bundling some unwanted code into it. this little change here removes about 80 lines from the resulting bundle, not a big deal but let's keep it clean. 