### PR TITLE
fix(connect-popup): wait for POPUP.LOADED in webextension

### DIFF
--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -541,6 +541,9 @@ const fail = (error: ErrorViewProps) => {
 };
 
 addWindowEventListener('load', onLoad, false);
+if (document.readyState === 'complete') {
+    onLoad();
+}
 addWindowEventListener('message', handleInitMessage, false);
 addWindowEventListener('message', handleLogMessage, false);
 

--- a/packages/connect-popup/src/static/popup.html
+++ b/packages/connect-popup/src/static/popup.html
@@ -3250,8 +3250,11 @@
             const popupScript = document.createElement('script');
             popupScript.setAttribute('type', 'text/javascript');
             popupScript.setAttribute('src', '<%= htmlWebpackPlugin.files.js[0] %>');
-            popupScript.setAttribute('async', 'false');
-            document.body.appendChild(popupScript);
+            popupScript.setAttribute('async', 'true');
+            setTimeout(() => {
+                // Slight delay to ensure content script (if present) is initialized first
+                document.body.appendChild(popupScript);
+            }, 100);
         </script>
     </body>
 </html>

--- a/packages/connect-web/src/popup/index.ts
+++ b/packages/connect-web/src/popup/index.ts
@@ -176,16 +176,13 @@ export class PopupManager extends EventEmitter {
 
     open() {
         const src = this.settings.popupSrc;
+        this.popupPromise = createDeferred(POPUP.LOADED);
+        this.openWrapper(src);
 
         if (this.settings.useCoreInPopup) {
             // Timeout not used in Core mode, we can't run showPopupRequest with no DOM
-            this.openWrapper(src);
-
             return;
         }
-
-        this.popupPromise = createDeferred(POPUP.LOADED);
-        this.openWrapper(src);
 
         this.closeInterval = setInterval(() => {
             if (!this.popupWindow) return;
@@ -285,7 +282,9 @@ export class PopupManager extends EventEmitter {
     };
 
     handleCoreMessage(message: Message<CoreEventMessage>) {
-        if (message.type === POPUP.CORE_LOADED) {
+        if (message.type === POPUP.LOADED) {
+            this.handleMessage(message);
+        } else if (message.type === POPUP.CORE_LOADED) {
             this.channel.postMessage({
                 type: POPUP.HANDSHAKE,
                 // in this case, settings will be validated in popup

--- a/packages/connect-webextension/src/contentScript.ts
+++ b/packages/connect-webextension/src/contentScript.ts
@@ -1,4 +1,5 @@
 import { WindowServiceWorkerChannel } from '@trezor/connect-web/src/channels/window-serviceworker';
+import { POPUP } from '@trezor/connect/src/events/popup';
 
 /**
  * communication between service worker and both webextension and popup manager
@@ -15,7 +16,7 @@ channel.init().then(() => {
     // once script is loaded. send information about the webextension that injected it into the popup
     window.postMessage(
         {
-            type: 'popup-content-script-loaded',
+            type: POPUP.CONTENT_SCRIPT_LOADED,
             payload: { ...chrome.runtime.getManifest(), id: chrome.runtime.id },
         },
         window.location.origin,
@@ -34,7 +35,7 @@ channel.init().then(() => {
     window.addEventListener('message', event => {
         if (
             event.data?.channel?.here === '@trezor/connect-webextension' ||
-            event.data?.type === 'popup-content-script-loaded'
+            event.data?.type === POPUP.CONTENT_SCRIPT_LOADED
         ) {
             return;
         }
@@ -46,7 +47,7 @@ channel.init().then(() => {
     window.addEventListener('beforeunload', () => {
         window.postMessage(
             {
-                type: 'popup-closed',
+                type: POPUP.CLOSED,
             },
             window.location.origin,
         );

--- a/packages/connect-webextension/src/index.ts
+++ b/packages/connect-webextension/src/index.ts
@@ -131,6 +131,8 @@ const call: CallMethod = async params => {
     }
 
     await _popupManager.channel.init();
+    await _popupManager.popupPromise?.promise;
+
     _popupManager.channel.postMessage({
         type: POPUP.INIT,
         payload: {


### PR DESCRIPTION
## Description

1. Always use `popupPromise` in PopupManager
2. Wait for `popupPromise` before sending `POPUP.INIT`
3. Fire `onLoad` in popup even in case the document is already loaded