### PR TITLE
ci(connect-explorer-nextra): allow manual ci run

### DIFF
--- a/.github/workflows/connect-nextra-dev-release.yml
+++ b/.github/workflows/connect-nextra-dev-release.yml
@@ -14,6 +14,7 @@ on:
   schedule:
     # Runs at midnight UTC every day at 01:00 AM CET
     - cron: "0 0 * * *"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
## Description

Add `on: workflow_dispatch` to allow manually running CI. 
Useful for example when we want to deploy from the develop branch during the day. 