### PR TITLE
fix(github): typo in group name in GitHub Actions

### DIFF
--- a/.github/workflows/blockchain-link-test.yml
+++ b/.github/workflows/blockchain-link-test.yml
@@ -15,7 +15,7 @@ on:
       - "yarn.lock"
 
 concurrency:
-  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/bot-rebase.yml
+++ b/.github/workflows/bot-rebase.yml
@@ -5,7 +5,7 @@ on:
     types: [created]
 
 concurrency:
-  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-desktop-apps.yml
+++ b/.github/workflows/build-desktop-apps.yml
@@ -19,7 +19,7 @@ env:
   DESKTOP_APP_NAME: "Trezor-Suite"
 
 concurrency:
-  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -9,7 +9,7 @@ on:
     - cron: "34 02 * * 2"
 
 concurrency:
-  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/commit-messages-check.yml
+++ b/.github/workflows/commit-messages-check.yml
@@ -3,7 +3,7 @@ name: "[Check]: Commit messages"
 on: [pull_request]
 
 concurrency:
-  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/connect-dev-release-test.yml
+++ b/.github/workflows/connect-dev-release-test.yml
@@ -33,7 +33,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/connect-nextra-dev-release.yml
+++ b/.github/workflows/connect-nextra-dev-release.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/connect-pre-release-init.yml
+++ b/.github/workflows/connect-pre-release-init.yml
@@ -12,7 +12,7 @@ on:
           - prerelease
 
 concurrency:
-  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/connect-release-init.yml
+++ b/.github/workflows/connect-release-init.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/connect-release.yml
+++ b/.github/workflows/connect-release.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/connect-test.yml
+++ b/.github/workflows/connect-test.yml
@@ -29,7 +29,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/crowdin_sync.yml
+++ b/.github/workflows/crowdin_sync.yml
@@ -3,7 +3,7 @@ name: "[Bot] Crowdin translations update"
 on: [workflow_dispatch]
 
 concurrency:
-  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release-suite-config.yml
+++ b/.github/workflows/release-suite-config.yml
@@ -12,7 +12,7 @@ on:
         type: environment
         required: true
 concurrency:
-  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release-suite-definitions.yml
+++ b/.github/workflows/release-suite-definitions.yml
@@ -13,7 +13,7 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/shell_validation.yml
+++ b/.github/workflows/shell_validation.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - "**.sh"
 concurrency:
-  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/suite-native_develop_ci.yml
+++ b/.github/workflows/suite-native_develop_ci.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/suite-native_production_ci.yml
+++ b/.github/workflows/suite-native_production_ci.yml
@@ -14,7 +14,7 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Typo in group name in GitHub Actions.

I might be wrong but I think the `$$` double dollar sign is not required, but it could be some GitHub Action feat I am not aware of.