### PR TITLE
chore(suite-native): allow network filtering on develop during discovery

### DIFF
--- a/suite-native/discovery/src/discoveryThunks.ts
+++ b/suite-native/discovery/src/discoveryThunks.ts
@@ -24,7 +24,7 @@ import { AccountType, Network, NetworkSymbol, getNetworkType } from '@suite-comm
 import { DiscoveryStatus } from '@suite-common/wallet-constants';
 import { requestDeviceAccess } from '@suite-native/device-mutex';
 import { analytics, EventType } from '@suite-native/analytics';
-import { isDebugEnv } from '@suite-native/config';
+import { isDevelopOrDebugEnv } from '@suite-native/config';
 
 import {
     selectDisabledDiscoveryNetworkSymbolsForDevelopment,
@@ -527,7 +527,7 @@ export const startDescriptorPreloadedDiscoveryThunk = createThunk(
         let supportedNetworks = selectDiscoverySupportedNetworks(getState(), areTestnetsEnabled);
 
         // For development purposes, you can disable some networks to have quicker discovery in dev utils
-        if (isDebugEnv()) {
+        if (isDevelopOrDebugEnv()) {
             const disabledNetworkSymbols =
                 selectDisabledDiscoveryNetworkSymbolsForDevelopment(getState());
             supportedNetworks = supportedNetworks.filter(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allow coin filtering during discovery on mobile in develop

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
