### PR TITLE
chore(github): update ::set-output in GH Actions

### DIFF
--- a/.github/actions/minimal-yarn-install/action.yml
+++ b/.github/actions/minimal-yarn-install/action.yml
@@ -13,7 +13,7 @@ runs:
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
       shell: bash
-      run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+      run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
     - name: Yarn Cache
       uses: actions/cache@v4

--- a/.github/workflows/connect-dev-release-test.yml
+++ b/.github/workflows/connect-dev-release-test.yml
@@ -42,7 +42,9 @@ jobs:
     steps:
       - name: Extract branch name
         id: extract_branch
-        run: echo "::set-output name=branch::${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+        run: |
+          BRANCH_NAME="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+          echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
   build-deploy:
     needs: [extract-branch]

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -21,7 +21,7 @@ jobs:
           node-version-file: ".nvmrc"
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - name: Yarn Cache
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Github is deprecating `set-output` https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

So this PR updates to using `GITHUB_OUTPUT`  instead.