### PR TITLE
fix(connect-popup): webextension mv2 loading issue

### DIFF
--- a/.github/workflows/connect-dev-release-test.yml
+++ b/.github/workflows/connect-dev-release-test.yml
@@ -131,5 +131,5 @@ jobs:
     with:
       test-name: webextension-example.test
       DEV_SERVER_HOSTNAME: dev.suite.sldev.cz
-      run-webextension: ${{ github.event_name == 'schedule' }}
+      run-webextension: true
       run-web: false

--- a/packages/connect-popup/src/static/popup.html
+++ b/packages/connect-popup/src/static/popup.html
@@ -3241,18 +3241,18 @@
                     peer: '@trezor/connect-web',
                 },
             };
-            if (window.opener) {
-                window.opener.postMessage(message, '*');
-            } else {
-                window.postMessage(message, '*');
-            }
-
-            const popupScript = document.createElement('script');
-            popupScript.setAttribute('type', 'text/javascript');
-            popupScript.setAttribute('src', '<%= htmlWebpackPlugin.files.js[0] %>');
-            popupScript.setAttribute('async', 'true');
             setTimeout(() => {
                 // Slight delay to ensure content script (if present) is initialized first
+                if (window.opener) {
+                    window.opener.postMessage(message, '*');
+                } else {
+                    window.postMessage(message, '*');
+                }
+
+                const popupScript = document.createElement('script');
+                popupScript.setAttribute('type', 'text/javascript');
+                popupScript.setAttribute('src', '<%= htmlWebpackPlugin.files.js[0] %>');
+                popupScript.setAttribute('async', 'true');
                 document.body.appendChild(popupScript);
             }, 100);
         </script>

--- a/packages/connect-web/src/popup/index.ts
+++ b/packages/connect-web/src/popup/index.ts
@@ -33,7 +33,7 @@ const checkIfTabExists = (tabId: number | undefined) =>
 // Event `POPUP_REQUEST_TIMEOUT` is used to close Popup window when there was no handshake from iframe.
 const POPUP_REQUEST_TIMEOUT = 850;
 const POPUP_CLOSE_INTERVAL = 500;
-const POPUP_OPEN_TIMEOUT = 3000;
+const POPUP_OPEN_TIMEOUT = 5000;
 
 export class PopupManager extends EventEmitter {
     popupWindow:


### PR DESCRIPTION
## Description

Content script may not be ready to pass the `POPUP.BOOTSTRAP` message when it's sent from `popup.html`, which would cause the entire loading process to fail.

Mitigation:
- Add 100ms delay to `popup.html` before sending `POPUP.BOOTSTRAP` and loading `popup.js` to ensure content script executes first
- Increase popup open timeout from 3s to 5s to give it more time to load on slower networks

E2E change: 
- Run both tests in an independent context - before a failure of MV2 would affect MV3.