### PR TITLE
fix(suite): anchor auto-scrolling to hightligted element was broken by this in Chromium

### DIFF
--- a/packages/components/src/components/Card/Card.tsx
+++ b/packages/components/src/components/Card/Card.tsx
@@ -61,7 +61,7 @@ const CardContainer = styled.div<
     padding: ${mapPaddingTypeToPadding};
     background: ${mapElevationToBackground};
     border-radius: ${borders.radii.md};
-    overflow: auto;
+
     ${({ $isClickable, theme }) =>
         $isClickable &&
         `

--- a/packages/suite/src/views/settings/SettingsDebug/TriggerHighlight.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/TriggerHighlight.tsx
@@ -16,12 +16,10 @@ export const TriggerHighlight = () => {
                 <ActionButton
                     variant="secondary"
                     onClick={() =>
-                        dispatch(
-                            goto('settings-index', { anchor: SettingsAnchor.BitcoinAmountUnit }),
-                        )
+                        dispatch(goto('settings-index', { anchor: SettingsAnchor.Labeling }))
                     }
                 >
-                    Go to Bitcoin Unit Settings
+                    Go to Labeling
                 </ActionButton>
             </ActionColumn>
         </SectionItem>


### PR DESCRIPTION
## Description

Interestingly this was breaking it only in Chrome

The problem is that Card is the wrapper around the Section in the Settings like:
![image](https://github.com/trezor/trezor-suite/assets/152899911/d64abe2c-8322-4f3e-a011-308f8fc7aca7)

The anchor is the inside it, and by overflow: auto we create scrollable parent for it. 

Not sure why, but it breaks the behavior of the `scrollIntoView` in Chromium based envs.


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/12265

## Screenshots:
