### PR TITLE
refactor(suite-native): extend suite-common sendform reducer by suite…

### DIFF
--- a/suite-common/redux-utils/src/createReducerWithExtraDeps.ts
+++ b/suite-common/redux-utils/src/createReducerWithExtraDeps.ts
@@ -1,11 +1,9 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import { ActionReducerMapBuilder, createReducer } from '@reduxjs/toolkit';
 
-import { ExtraDependencies } from './extraDependenciesType';
+import { ExtraDependenciesForReducer } from './extraDependenciesType';
 
 type NotFunction<T> = T extends Function ? never : T;
-
-type ExtraDependenciesForReducer = Pick<ExtraDependencies, 'actionTypes' | 'actions' | 'reducers'>;
 
 export const createReducerWithExtraDeps =
     <S extends NotFunction<any>>(
@@ -15,7 +13,7 @@ export const createReducerWithExtraDeps =
             extra: ExtraDependenciesForReducer,
         ) => void,
     ) =>
-    (extraDeps: ExtraDependencies) =>
+    (extraDeps: ExtraDependenciesForReducer) =>
         createReducer(initialState, builder =>
             builderCallback(builder, {
                 actionTypes: extraDeps.actionTypes,

--- a/suite-common/redux-utils/src/createSliceWithExtraDeps.ts
+++ b/suite-common/redux-utils/src/createSliceWithExtraDeps.ts
@@ -6,7 +6,8 @@ import {
     SliceCaseReducers,
 } from '@reduxjs/toolkit';
 
-import { ExtraDependencies } from './extraDependenciesType';
+import { ExtraDependenciesForReducer } from './extraDependenciesType';
+
 /*
 This is nearly same function as createSlice from redux-toolkit, but instead of generating reducer it will generate
 prepareReducer function that will be used to generate reducer. This functions accepts one argument - extra dependencies.
@@ -19,7 +20,7 @@ export const createSliceWithExtraDeps = <
     options: Omit<CreateSliceOptions<State, CaseReducers, Name>, 'extraReducers'> & {
         extraReducers: (
             builder: ActionReducerMapBuilder<State>,
-            extra: Pick<ExtraDependencies, 'actionTypes' | 'actions' | 'reducers'>,
+            extra: ExtraDependenciesForReducer,
         ) => void;
     },
 ) => {
@@ -58,7 +59,7 @@ export const createSliceWithExtraDeps = <
         },
     });
 
-    const prepareReducer = (extraDeps: ExtraDependencies) =>
+    const prepareReducer = (extraDeps: ExtraDependenciesForReducer) =>
         createSlice({
             ...options,
             extraReducers: builder => {

--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -126,6 +126,11 @@ export type ExtraDependencies = {
     };
 };
 
+export type ExtraDependenciesForReducer = Pick<
+    ExtraDependencies,
+    'actionTypes' | 'actions' | 'reducers'
+>;
+
 export type ExtraDependenciesPartial = {
     [K in keyof ExtraDependencies]?: Partial<ExtraDependencies[K]>;
 };

--- a/suite-native/module-send/src/index.ts
+++ b/suite-native/module-send/src/index.ts
@@ -1,1 +1,2 @@
 export * from './navigation/SendStackNavigator';
+export * from './sendFormSlice';

--- a/suite-native/module-send/src/screens/SendReviewScreen.tsx
+++ b/suite-native/module-send/src/screens/SendReviewScreen.tsx
@@ -1,8 +1,7 @@
 import { useDispatch, useSelector } from 'react-redux';
-import { useEffect, useState } from 'react';
 
 import { CommonActions } from '@react-navigation/native';
-import { isFulfilled, isRejected } from '@reduxjs/toolkit';
+import { isRejected } from '@reduxjs/toolkit';
 
 import {
     AppTabsRoutes,
@@ -16,14 +15,11 @@ import {
 } from '@suite-native/navigation';
 import { Button, Text, VStack } from '@suite-native/atoms';
 import { AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
-import { SignedTransaction } from '@trezor/connect';
 import { useToast } from '@suite-native/toasts';
 
-import {
-    onDeviceTransactionReviewThunk,
-    sendTransactionAndCleanupSendFormThunk,
-} from '../sendFormThunks';
+import { sendTransactionAndCleanupSendFormThunk } from '../sendFormThunks';
 import { ReviewOutputItemList } from '../components/ReviewOutputItemList';
+import { selectSignedTxMetadata, selectSigningError } from '../sendFormSlice';
 
 export const SendReviewScreen = ({
     route,
@@ -34,28 +30,12 @@ export const SendReviewScreen = ({
 
     const { accountKey } = route.params;
 
-    const [signedTransaction, setSignedTransaction] =
-        useState<SignedTransaction['signedTransaction']>();
+    const signedTransaction = useSelector(selectSignedTxMetadata);
+    const signingError = useSelector(selectSigningError);
 
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
-
-    // Instruct device to sign transaction and start on-device review.
-    useEffect(() => {
-        const signTransactionOnDevice = async () => {
-            const signedTransactionResponse = await dispatch(
-                onDeviceTransactionReviewThunk({ accountKey }),
-            );
-
-            if (isFulfilled(signedTransactionResponse)) {
-                setSignedTransaction(signedTransactionResponse.payload);
-            } else {
-                // TODO: error handling.
-            }
-        };
-        signTransactionOnDevice();
-    }, [accountKey, dispatch]);
 
     if (!account) return;
 
@@ -93,6 +73,10 @@ export const SendReviewScreen = ({
             }),
         );
     };
+
+    if (signingError) {
+        //TODO: handle error of the signing process
+    }
 
     // TODO: move text content to @suite-native/intl package when is copy ready
     return (

--- a/suite-native/module-send/src/sendFormSlice.ts
+++ b/suite-native/module-send/src/sendFormSlice.ts
@@ -1,0 +1,65 @@
+import { PayloadAction } from '@reduxjs/toolkit';
+
+import { createSliceWithExtraDeps } from '@suite-common/redux-utils';
+import {
+    SendState as CommonSendState,
+    prepareSendFormReducer as prepareCommonSendFormReducer,
+    initialState as commonInitialState,
+} from '@suite-common/wallet-core';
+import { SignedTransaction } from '@trezor/connect';
+
+import { onDeviceTransactionReviewThunk } from './sendFormThunks';
+
+export type NativeSignedTransaction = SignedTransaction['signedTransaction'];
+
+type NativeSendState = CommonSendState & {
+    signingError?: string;
+    signedTxMetadata?: NativeSignedTransaction;
+};
+
+export type NativeSendRootState = {
+    wallet: {
+        send: NativeSendState;
+    };
+};
+
+export const initialNativeState: NativeSendState = {
+    ...commonInitialState,
+    signingError: undefined,
+    signedTxMetadata: undefined,
+};
+
+export const sendFormSlice = createSliceWithExtraDeps({
+    name: 'send',
+    initialState: initialNativeState,
+    reducers: {
+        setX: (state, { payload }: PayloadAction<string>) => {
+            state.signingError = payload;
+        },
+    },
+    extraReducers: (builder, extra) => {
+        const commonSendFormReducer = prepareCommonSendFormReducer(extra);
+        builder
+            .addCase(onDeviceTransactionReviewThunk.pending, state => {
+                delete state.signingError;
+            })
+            .addCase(
+                onDeviceTransactionReviewThunk.fulfilled,
+                (state, { payload }: PayloadAction<NativeSignedTransaction>) => {
+                    state.signedTxMetadata = payload;
+                },
+            )
+            .addCase(onDeviceTransactionReviewThunk.rejected, (state, { payload }) => {
+                state.signingError = payload as string;
+            })
+            // In case that this reducer does not match the action, try to handle it by suite-common sendFormReducer.
+            .addDefaultCase((state, action) => {
+                commonSendFormReducer(state, action);
+            });
+    },
+});
+
+export const selectSignedTxMetadata = (state: NativeSendRootState) =>
+    state.wallet.send.signedTxMetadata;
+
+export const selectSigningError = (state: NativeSendRootState) => state.wallet.send.signingError;

--- a/suite-native/state/package.json
+++ b/suite-native/state/package.json
@@ -26,6 +26,7 @@
         "@suite-native/feature-flags": "workspace:*",
         "@suite-native/graph": "workspace:*",
         "@suite-native/message-system": "workspace:*",
+        "@suite-native/module-send": "workspace:*",
         "@suite-native/module-settings": "workspace:*",
         "@suite-native/storage": "workspace:*",
         "@suite-native/toasts": "workspace:*",

--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -7,7 +7,6 @@ import {
     prepareDeviceReducer,
     prepareDiscoveryReducer,
     prepareFiatRatesReducer,
-    prepareSendFormReducer,
     prepareTokenDefinitionsReducer,
     prepareTransactionsReducer,
 } from '@suite-common/wallet-core';
@@ -27,6 +26,7 @@ import { notificationsReducer } from '@suite-common/toast-notifications';
 import { graphReducer, graphPersistWhitelist } from '@suite-native/graph';
 import { discoveryConfigPersistWhitelist, discoveryConfigReducer } from '@suite-native/discovery';
 import { featureFlagsPersistedKeys, featureFlagsReducer } from '@suite-native/feature-flags';
+import { sendFormSlice } from '@suite-native/module-send';
 
 import { extraDependencies } from './extraDependencies';
 import { appReducer } from './appSlice';
@@ -40,7 +40,7 @@ const messageSystemReducer = prepareMessageSystemReducer(extraDependencies);
 const deviceReducer = prepareDeviceReducer(extraDependencies);
 const discoveryReducer = prepareDiscoveryReducer(extraDependencies);
 const tokenDefinitionsReducer = prepareTokenDefinitionsReducer(extraDependencies);
-const sendFormReducer = prepareSendFormReducer(extraDependencies);
+const sendFormReducer = sendFormSlice.prepareReducer(extraDependencies);
 
 export const prepareRootReducers = async () => {
     const appSettingsPersistedReducer = await preparePersistReducer({

--- a/suite-native/state/tsconfig.json
+++ b/suite-native/state/tsconfig.json
@@ -29,6 +29,7 @@
         { "path": "../feature-flags" },
         { "path": "../graph" },
         { "path": "../message-system" },
+        { "path": "../module-send" },
         { "path": "../module-settings" },
         { "path": "../storage" },
         { "path": "../toasts" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9683,6 +9683,7 @@ __metadata:
     "@suite-native/feature-flags": "workspace:*"
     "@suite-native/graph": "workspace:*"
     "@suite-native/message-system": "workspace:*"
+    "@suite-native/module-send": "workspace:*"
     "@suite-native/module-settings": "workspace:*"
     "@suite-native/storage": "workspace:*"
     "@suite-native/toasts": "workspace:*"


### PR DESCRIPTION
This is just a proof of concept, not a final solution!

These changes demonstrates implementation of custom suite-native sendForm reducer that inherits and extends the data shape and logic of suite-common sendform reducer.