### PR TITLE
Fix/cj unavailable status

### DIFF
--- a/packages/suite/src/actions/wallet/__fixtures__/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/coinjoinAccountActions.ts
@@ -29,7 +29,7 @@ export const createCoinjoinAccount = [
         result: {
             actions: [
                 COINJOIN.CLIENT_ENABLE,
-                COINJOIN.CLIENT_ENABLE_FAILED,
+                COINJOIN.CLIENT_DISABLE,
                 notificationsActions.addToast.type,
             ],
         },
@@ -143,7 +143,7 @@ export const startCoinjoinSession = [
         result: {
             actions: [
                 COINJOIN.CLIENT_ENABLE,
-                COINJOIN.CLIENT_ENABLE_FAILED,
+                COINJOIN.CLIENT_DISABLE,
                 notificationsActions.addToast.type,
             ],
         },
@@ -254,7 +254,7 @@ export const restoreCoinjoinAccounts = [
         result: {
             actions: [
                 COINJOIN.CLIENT_ENABLE,
-                COINJOIN.CLIENT_ENABLE_FAILED,
+                COINJOIN.CLIENT_DISABLE,
                 notificationsActions.addToast.type, // failed account 1 + 2 client init
                 COINJOIN.CLIENT_ENABLE,
                 COINJOIN.CLIENT_ENABLE_SUCCESS, // success account A + B client init

--- a/packages/suite/src/actions/wallet/__tests__/coinjoinAccountActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/coinjoinAccountActions.test.ts
@@ -1,7 +1,9 @@
 import { combineReducers, createReducer } from '@reduxjs/toolkit';
 
 import { configureMockStore, initPreloadedState, testMocks } from '@suite-common/test-utils';
+import { prepareMessageSystemReducer } from '@suite-common/message-system';
 
+import { extraDependencies } from 'src/support/extraDependencies';
 import { accountsReducer } from 'src/reducers/wallet';
 import { coinjoinReducer } from 'src/reducers/wallet/coinjoinReducer';
 import selectedAccountReducer from 'src/reducers/wallet/selectedAccountReducer';
@@ -29,6 +31,7 @@ const rootReducer = combineReducers({
         },
         () => ({}),
     ),
+    messageSystem: prepareMessageSystemReducer(extraDependencies),
     device: createReducer({ devices: [DEVICE], selectedDevice: DEVICE }, () => ({})),
     modal: () => ({}),
     wallet: combineReducers({

--- a/packages/suite/src/hooks/coinjoin/useCoinjoinSessionBlockers.ts
+++ b/packages/suite/src/hooks/coinjoin/useCoinjoinSessionBlockers.ts
@@ -25,6 +25,8 @@ export const useCoinjoinSessionBlockers = (
         switch (blocker) {
             case 'FEATURE_DISABLED':
                 return featureMessageContent;
+            case 'COORDINATOR_UNAVAILABLE':
+                return translationString('TR_UNAVAILABLE_COINJOIN_COORDINATOR');
             case 'OFFLINE':
                 return translationString('TR_UNAVAILABLE_COINJOIN_NO_INTERNET');
             case 'NOTHING_TO_ANONYMIZE':

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -547,8 +547,13 @@ export const coinjoinReducer = (
             case COINJOIN.CLIENT_ENABLE_SUCCESS:
                 createClient(draft, action.payload);
                 break;
-            case COINJOIN.CLIENT_DISABLE:
             case COINJOIN.CLIENT_ENABLE_FAILED:
+                draft.clients[action.payload.symbol] = {
+                    ...CLIENT_STATUS_FALLBACK,
+                    status: 'unavailable',
+                };
+                break;
+            case COINJOIN.CLIENT_DISABLE:
                 delete draft.clients[action.payload.symbol];
                 break;
             case COINJOIN.CLIENT_STATUS:
@@ -925,6 +930,9 @@ export const selectCoinjoinSessionBlockerByAccountKey = (
     }
     if (selectIsFeatureDisabled(state, Feature.coinjoin)) {
         return 'FEATURE_DISABLED';
+    }
+    if (selectCoinjoinClient(state, accountKey)?.status === 'unavailable') {
+        return 'COORDINATOR_UNAVAILABLE';
     }
     if (!state.suite.online) {
         return 'OFFLINE';

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -4129,6 +4129,10 @@ export default defineMessages({
         id: 'TR_UNAVAILABLE_COINJOIN_NO_INTERNET',
         defaultMessage: 'Unavailable. No internet connection.',
     },
+    TR_UNAVAILABLE_COINJOIN_COORDINATOR: {
+        id: 'TR_UNAVAILABLE_COINJOIN_COORDINATOR',
+        defaultMessage: 'Coordinator is unavailable.',
+    },
     TR_UNAVAILABLE_COINJOIN_AMOUNTS_TOO_SMALL: {
         id: 'TR_UNAVAILABLE_COINJOIN_AMOUNTS_TOO_SMALL',
         defaultMessage: 'Amounts are too small for coinjoin.',

--- a/packages/suite/src/types/wallet/coinjoin.ts
+++ b/packages/suite/src/types/wallet/coinjoin.ts
@@ -40,7 +40,7 @@ export interface CoinjoinClientInstance
     > {
     rounds: { id: string; phase: RoundPhase }[]; // store only slice of Round in reducer. may be extended in the future
     version?: CoinjoinClientVersion;
-    status: 'loading' | 'loaded';
+    status: 'loading' | 'loaded' | 'unavailable';
 }
 
 export interface CoinjoinSession extends CoinjoinSessionParameters {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. fix CoinjoinClient.enable error
   - set `client.status = "unavailable"` If status fail to load when accessing coinjoin account
   - retry fetching status if its currently unavailable (on each account update)
   - block coinjoin button and display new message if client.status is unavailable

![Screenshot from 2024-05-07 17-44-52](https://github.com/trezor/trezor-suite/assets/3435913/dca3b6d2-72fe-44b8-843e-dabcc66b34a6)

   
2. never fetch `/status` if feature flag is disabled

<!--- Describe your changes in detail -->

## Related Issue

Reported [on slack](https://satoshilabs.slack.com/archives/C048XFAKL10/p1715017915840309) 
