### PR TITLE
fix(suite-native): remove flickering on device screen during discovery

### DIFF
--- a/suite-native/discovery/src/discoveryThunks.ts
+++ b/suite-native/discovery/src/discoveryThunks.ts
@@ -160,7 +160,7 @@ const getCardanoSupportedAccountTypesThunk = createThunk(
         },
         { dispatch, getState },
     ) => {
-        const device = selectDevice(getState());
+        const device = selectDeviceByState(getState(), deviceState);
         if (!device) {
             return undefined;
         }

--- a/suite-native/module-passphrase/src/components/PassphraseForm.tsx
+++ b/suite-native/module-passphrase/src/components/PassphraseForm.tsx
@@ -19,6 +19,7 @@ import {
     selectDevice,
     selectDeviceButtonRequestsCodes,
     selectDeviceState,
+    selectIsDeviceDiscoveryActive,
 } from '@suite-common/wallet-core';
 import {
     PassphraseStackParamList,
@@ -51,6 +52,7 @@ export const PassphraseForm = ({ inputLabel, onFocus }: PassphraseFormProps) => 
     const device = useSelector(selectDevice);
     const buttonRequestCodes = useSelector(selectDeviceButtonRequestsCodes);
     const deviceState = useSelector(selectDeviceState);
+    const isDiscoveryActive = useSelector(selectIsDeviceDiscoveryActive);
 
     const navigation = useNavigation<NavigationProp>();
 
@@ -68,7 +70,7 @@ export const PassphraseForm = ({ inputLabel, onFocus }: PassphraseFormProps) => 
             navigation.navigate(PassphraseStackRoutes.PassphraseConfirmOnTrezor);
             dispatch(deviceActions.removeButtonRequests({ device }));
         }
-    }, [buttonRequestCodes, device, deviceState, dispatch, navigation]);
+    }, [buttonRequestCodes, device, deviceState, dispatch, isDiscoveryActive, navigation]);
 
     const handleCreateHiddenWallet = handleSubmit(({ passphrase }) => {
         dispatch(deviceActions.removeButtonRequests({ device }));

--- a/suite-native/module-passphrase/src/screens/PassphraseConfirmOnTrezorScreen.tsx
+++ b/suite-native/module-passphrase/src/screens/PassphraseConfirmOnTrezorScreen.tsx
@@ -12,7 +12,10 @@ import {
 } from '@suite-native/navigation';
 import { CenteredTitleHeader, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
-import { selectIsDeviceConnectedAndAuthorized } from '@suite-common/wallet-core';
+import {
+    selectIsDeviceConnectedAndAuthorized,
+    selectIsDeviceDiscoveryActive,
+} from '@suite-common/wallet-core';
 
 import { PassphraseScreenHeader } from '../components/PassphraseScreenHeader';
 import { DeviceTS3Svg } from '../assets/DeviceTS3Svg';
@@ -25,14 +28,15 @@ type NavigationProp = StackToStackCompositeNavigationProps<
 
 export const PassphraseConfirmOnTrezorScreen = () => {
     const isDeviceConnectedAndAuthorized = useSelector(selectIsDeviceConnectedAndAuthorized);
+    const isDiscoveryActive = useSelector(selectIsDeviceDiscoveryActive);
 
     const navigation = useNavigation<NavigationProp>();
 
     useEffect(() => {
-        if (isDeviceConnectedAndAuthorized) {
+        if (isDeviceConnectedAndAuthorized && isDiscoveryActive) {
             navigation.navigate(PassphraseStackRoutes.PassphraseLoading);
         }
-    }, [isDeviceConnectedAndAuthorized, navigation]);
+    }, [isDeviceConnectedAndAuthorized, isDiscoveryActive, navigation]);
 
     return (
         <Screen screenHeader={<PassphraseScreenHeader />}>

--- a/suite-native/module-passphrase/src/screens/PassphraseLoadingScreen.tsx
+++ b/suite-native/module-passphrase/src/screens/PassphraseLoadingScreen.tsx
@@ -33,20 +33,17 @@ export const PassphraseLoadingScreen = () => {
     const isDiscoveryActive = useSelector(selectIsDeviceDiscoveryActive);
 
     useEffect(() => {
-        // NOTE: This is just for demo purposes. Proper loading screen will be implemented in a follow-up.
-        if (!isDiscoveryActive) {
-            if (isDeviceAccountless) {
-                navigation.navigate(RootStackRoutes.PassphraseStack, {
-                    screen: PassphraseStackRoutes.PassphraseEmptyWallet,
-                });
-            } else {
-                navigation.navigate(RootStackRoutes.AppTabs, {
-                    screen: AppTabsRoutes.HomeStack,
-                    params: {
-                        screen: HomeStackRoutes.Home,
-                    },
-                });
-            }
+        if (!isDeviceAccountless) {
+            navigation.navigate(RootStackRoutes.AppTabs, {
+                screen: AppTabsRoutes.HomeStack,
+                params: {
+                    screen: HomeStackRoutes.Home,
+                },
+            });
+        } else if (isDeviceAccountless && !isDiscoveryActive) {
+            navigation.navigate(RootStackRoutes.PassphraseStack, {
+                screen: PassphraseStackRoutes.PassphraseEmptyWallet,
+            });
         }
     }, [isDeviceAccountless, isDiscoveryActive, navigation]);
 


### PR DESCRIPTION
This should fix multiple loaders appearing on Trezor device screen during discovery. The problem was that `TrezorConnect.cardanoGetPublicKey` calls were always issued with `device.state = undefined` which triggered fresh keys derivation on Trezor. 

I would expect that the `selectDevice` selector should return `device` with an already updated state but it does not. There is something smelly under the hood going on. 

cc @juriczech 

Resolves https://github.com/trezor/trezor-suite/issues/11752