### PR TITLE
chore(suite-native): button has ReactElement not only icon

### DIFF
--- a/suite-native/atoms/src/Button/IconButton.tsx
+++ b/suite-native/atoms/src/Button/IconButton.tsx
@@ -93,7 +93,7 @@ export const IconButton = ({
                             style,
                         ]}
                     >
-                        <ButtonIcon iconName={iconName} color={iconColor} buttonSize={size} />
+                        <ButtonIcon iconName={iconName} color={iconColor} size={size} />
                     </Animated.View>
                     {title && (
                         <Text variant="label" color="textSubdued">

--- a/suite-native/atoms/src/Button/TextButton.tsx
+++ b/suite-native/atoms/src/Button/TextButton.tsx
@@ -9,7 +9,7 @@ import Animated, {
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { Color } from '@trezor/theme';
 
-import { ButtonIcon, ButtonProps, ButtonSize, buttonToTextSizeMap } from './Button';
+import { ButtonAccessoryView, ButtonProps, ButtonSize, buttonToTextSizeMap } from './Button';
 import { BUTTON_PRESS_ANIMATION_DURATION } from './useButtonPressAnimatedStyle';
 import { HStack } from '../Stack';
 
@@ -48,8 +48,8 @@ const textStyle = prepareNativeStyle(
 );
 
 export const TextButton = ({
-    iconLeft,
-    iconRight,
+    viewLeft,
+    viewRight,
     style,
     children,
     variant = 'primary',
@@ -89,14 +89,7 @@ export const TextButton = ({
         interpolatePressColor();
     };
 
-    const iconName = iconLeft || iconRight;
-    const icon = iconName ? (
-        <ButtonIcon
-            iconName={iconName}
-            color={isDisabled ? 'iconDisabled' : animatedColor}
-            buttonSize={size}
-        />
-    ) : null;
+    const iconColor = isDisabled ? 'iconDisabled' : animatedColor;
 
     return (
         <Pressable
@@ -107,7 +100,9 @@ export const TextButton = ({
             {...pressableProps}
         >
             <HStack alignItems="center">
-                {iconLeft && icon}
+                {viewLeft && (
+                    <ButtonAccessoryView element={viewLeft} iconColor={iconColor} iconSize={size} />
+                )}
                 <Animated.Text
                     style={[
                         applyStyle(textStyle, { buttonSize: size, isUnderlined }),
@@ -116,7 +111,13 @@ export const TextButton = ({
                 >
                     {children}
                 </Animated.Text>
-                {iconRight && icon}
+                {viewRight && (
+                    <ButtonAccessoryView
+                        element={viewRight}
+                        iconColor={iconColor}
+                        iconSize={size}
+                    />
+                )}
             </HStack>
         </Pressable>
     );

--- a/suite-native/atoms/src/Card/HeaderedCard.tsx
+++ b/suite-native/atoms/src/Card/HeaderedCard.tsx
@@ -28,7 +28,7 @@ const CardHeader = ({ title, onButtonPress, buttonTitle, buttonIcon }: CardHeade
             {title}
         </Text>
         {buttonTitle && (
-            <TextButton size="small" onPress={onButtonPress} iconRight={buttonIcon}>
+            <TextButton size="small" onPress={onButtonPress} viewRight={buttonIcon}>
                 {buttonTitle}
             </TextButton>
         )}

--- a/suite-native/device-manager/src/components/DeviceControlButtons.tsx
+++ b/suite-native/device-manager/src/components/DeviceControlButtons.tsx
@@ -48,7 +48,7 @@ export const DeviceControlButtons = () => {
     return (
         <HStack>
             <Box flex={1}>
-                <Button colorScheme="redElevation1" iconLeft="eject" onPress={handleEject}>
+                <Button colorScheme="redElevation1" viewLeft="eject" onPress={handleEject}>
                     <Translation id="deviceManager.deviceButtons.eject" />
                 </Button>
             </Box>

--- a/suite-native/device-manager/src/components/PortfolioTrackerDeviceManagerContent.tsx
+++ b/suite-native/device-manager/src/components/PortfolioTrackerDeviceManagerContent.tsx
@@ -80,14 +80,14 @@ export const PortfolioTrackerDeviceManagerContent = () => {
                 </Text>
                 <Button
                     colorScheme="tertiaryElevation1"
-                    iconRight="link"
+                    viewRight="link"
                     onPress={handleOpenEduLink}
                 >
                     <Translation id="deviceManager.portfolioTracker.learnBasics" />
                 </Button>
                 <Button
                     colorScheme="tertiaryElevation1"
-                    iconRight="link"
+                    viewRight="link"
                     onPress={handleOpenEshopLink}
                 >
                     <Translation id="deviceManager.portfolioTracker.exploreShop" />

--- a/suite-native/device/src/components/HowToUpdateBottomSheet.tsx
+++ b/suite-native/device/src/components/HowToUpdateBottomSheet.tsx
@@ -44,7 +44,7 @@ export const HowToUpdateBottomSheet = ({
                 <Button
                     colorScheme="tertiaryElevation0"
                     onPress={handleHelpClick}
-                    iconRight="arrowUpRight"
+                    viewRight="arrowUpRight"
                 >
                     <Translation id="deviceInfo.updateHowTo.button" />
                 </Button>

--- a/suite-native/device/src/screens/DeviceInfoModalScreen.tsx
+++ b/suite-native/device/src/screens/DeviceInfoModalScreen.tsx
@@ -152,7 +152,7 @@ export const DeviceInfoModalScreen = () => {
                 <Button
                     colorScheme="tertiaryElevation0"
                     onPress={handleAccessoriesClick}
-                    iconRight="arrowUpRight"
+                    viewRight="arrowUpRight"
                 >
                     <Translation id="deviceInfo.goToAccessories" />
                 </Button>

--- a/suite-native/module-accounts-import/src/components/XpubHint.tsx
+++ b/suite-native/module-accounts-import/src/components/XpubHint.tsx
@@ -39,7 +39,7 @@ export const XpubHint = ({ networkType, handleOpen }: XpubScanHintSheet) => {
         <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
             <Box style={applyStyle(sheetTriggerStyle)}>
                 <TextButton
-                    iconLeft="question"
+                    viewLeft="question"
                     onPress={handleOpen}
                     data-testID="@accounts-import/sync-coins/xpub-help-link"
                 >

--- a/suite-native/module-accounts-management/src/components/TransactionListHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/TransactionListHeader.tsx
@@ -128,7 +128,7 @@ export const TransactionListHeader = memo(
                     />
                     {accountHasTransactions && (
                         <Box marginVertical="medium" paddingHorizontal="medium">
-                            <Button iconLeft="receive" size="large" onPress={handleReceive}>
+                            <Button viewLeft="receive" size="large" onPress={handleReceive}>
                                 <Translation id="transactions.receive" />
                             </Button>
                         </Box>

--- a/suite-native/module-dev-utils/src/screens/DemoScreen.tsx
+++ b/suite-native/module-dev-utils/src/screens/DemoScreen.tsx
@@ -134,7 +134,7 @@ export const DemoScreen = () => {
                                     <Button
                                         key={buttonSize}
                                         colorScheme={buttonScheme}
-                                        iconLeft="calendar"
+                                        viewLeft="calendar"
                                         size={buttonSize}
                                     >
                                         {buttonSize}
@@ -155,7 +155,7 @@ export const DemoScreen = () => {
                                 <Button
                                     key={buttonSize}
                                     colorScheme="primary"
-                                    iconLeft="calendar"
+                                    viewLeft="calendar"
                                     size={buttonSize}
                                     isDisabled
                                 >
@@ -215,7 +215,7 @@ export const DemoScreen = () => {
                                 <TextButton
                                     variant={variant}
                                     key={buttonSize}
-                                    iconLeft="trezorT"
+                                    viewLeft="trezorT"
                                     size={buttonSize}
                                 >
                                     {buttonSize}

--- a/suite-native/module-home/src/screens/HomeScreen/components/PortfolioContent.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/PortfolioContent.tsx
@@ -90,7 +90,7 @@ export const PortfolioContent = forwardRef<PortfolioContentRef>((_props, ref) =>
                                 data-testID="@home/portolio/recieve-button"
                                 size="large"
                                 onPress={handleReceive}
-                                iconLeft="receive"
+                                viewLeft="receive"
                             >
                                 <Translation id="moduleHome.buttons.receive" />
                             </Button>

--- a/suite-native/module-passphrase/src/screens/PassphraseFormScreen.tsx
+++ b/suite-native/module-passphrase/src/screens/PassphraseFormScreen.tsx
@@ -108,7 +108,7 @@ export const PassphraseFormScreen = () => {
                                     <Button
                                         size="small"
                                         colorScheme="blueBold"
-                                        iconLeft="arrowLineUpRight"
+                                        viewLeft="arrowLineUpRight"
                                         onPress={handleOpenLink}
                                     >
                                         <Translation id="modulePassphrase.alertCard.button" />

--- a/suite-native/qr-code/src/components/AddressQRCode.tsx
+++ b/suite-native/qr-code/src/components/AddressQRCode.tsx
@@ -46,7 +46,7 @@ export const AddressQRCode = ({ address }: AddressQRCodeProps) => {
             <HStack spacing="small" justifyContent="center">
                 <Button
                     size="small"
-                    iconLeft="copy"
+                    viewLeft="copy"
                     onPress={handleCopyAddress}
                     colorScheme="tertiaryElevation1"
                 >
@@ -54,7 +54,7 @@ export const AddressQRCode = ({ address }: AddressQRCodeProps) => {
                 </Button>
                 <Button
                     size="small"
-                    iconLeft="shareAlt"
+                    viewLeft="shareAlt"
                     colorScheme="tertiaryElevation1"
                     onPress={handleShareData}
                 >

--- a/suite-native/qr-code/src/components/XpubQRCodeBottomSheet.tsx
+++ b/suite-native/qr-code/src/components/XpubQRCodeBottomSheet.tsx
@@ -79,7 +79,7 @@ export const XpubQRCodeBottomSheet = ({
                             <Translation id="moduleAccountManagement.accountSettingsScreen.xpubBottomSheet.copyButton" />
                         </Button>
                     ) : (
-                        <Button size="large" iconLeft="eye" onPress={handleShowXpub}>
+                        <Button size="large" viewLeft="eye" onPress={handleShowXpub}>
                             {showButtonTitle}
                         </Button>
                     )}

--- a/suite-native/receive/src/components/AddressMismatchBottomSheet.tsx
+++ b/suite-native/receive/src/components/AddressMismatchBottomSheet.tsx
@@ -47,7 +47,7 @@ export const AddressMismatchBottomSheet = ({
                 <Box flex={1}>
                     <VStack spacing="medium">
                         <Button
-                            iconLeft="warningTriangle"
+                            viewLeft="warningTriangle"
                             colorScheme="tertiaryElevation0"
                             onPress={handleOpenSupportLink}
                         >

--- a/suite-native/receive/src/components/ShowAddressButtons.tsx
+++ b/suite-native/receive/src/components/ShowAddressButtons.tsx
@@ -40,7 +40,7 @@ export const ShowAddressButtons = ({ onShowAddress }: ShowAddressButtonsProps) =
 
     return (
         <VStack spacing="large">
-            <Button iconLeft="eye" size="large" onPress={handleShowAddress}>
+            <Button viewLeft="eye" size="large" onPress={handleShowAddress}>
                 <Translation
                     id={
                         isPortfolioTrackerDevice
@@ -49,7 +49,7 @@ export const ShowAddressButtons = ({ onShowAddress }: ShowAddressButtonsProps) =
                     }
                 />
             </Button>
-            <TextButton size="small" onPress={handleOpenEduLink} iconRight="arrowUpRight">
+            <TextButton size="small" onPress={handleOpenEduLink} viewRight="arrowUpRight">
                 <Translation id="moduleReceive.receiveAddressCard.showAddress.learnMore" />
             </TextButton>
             <ShowAddressViewOnlyBottomSheet

--- a/suite-native/transactions/src/components/TransactionsEmptyState.tsx
+++ b/suite-native/transactions/src/components/TransactionsEmptyState.tsx
@@ -47,7 +47,7 @@ export const TransactionsEmptyState = ({ accountKey }: { accountKey: string }) =
                     />
                 </Box>
                 <Box style={applyStyle(receiveButtonStyle)}>
-                    <Button iconLeft="receive" onPress={handleReceive} size="large">
+                    <Button viewLeft="receive" onPress={handleReceive} size="large">
                         <Translation id="transactions.emptyState.button" />
                     </Button>
                 </Box>

--- a/suite-native/transactions/src/screens/TransactionDetailScreen.tsx
+++ b/suite-native/transactions/src/screens/TransactionDetailScreen.tsx
@@ -85,7 +85,7 @@ export const TransactionDetailScreen = ({
                 accountKey={accountKey}
             />
             <Button
-                iconLeft="arrowUpRight"
+                viewLeft="arrowUpRight"
                 onPress={handleOpenBlockchain}
                 colorScheme="tertiaryElevation0"
                 style={applyStyle(buttonStyle)}


### PR DESCRIPTION
Make Button to accept not only IconName but also a ReactElement for both sides.

This will let us insert animated elements and I will be able to use that in Device switcher [Change button animation](https://www.figma.com/proto/mmDnYtctfjnreWhTjLfeQH/Passphrase?page-id=0%3A1&type=design&node-id=2146-55968&viewport=5976%2C4395%2C1.31&t=8i3EiJVzLmaibGWX-1&scaling=min-zoom&starting-point-node-id=2146%3A55968&show-proto-sidebar=1&mode=design&fuid=1293095861312443248).


Example of custom and also animated element:


https://github.com/trezor/trezor-suite/assets/2011829/1253af02-a3d9-4e48-920a-e9cb96cac62e




