### PR TITLE
Fix intermediary fw reconnection

### DIFF
--- a/packages/connect/src/events/ui-request.ts
+++ b/packages/connect/src/events/ui-request.ts
@@ -24,8 +24,6 @@ export const UI_REQUEST = {
     FIRMWARE_NOT_INSTALLED: 'ui-device_firmware_not_installed',
     FIRMWARE_PROGRESS: 'ui-firmware-progress',
 
-    /** connect is waiting for device to automatically disconnect */
-    FIRMWARE_DISCONNECT: 'ui-firmware_disconnect',
     /** connect is waiting for device to be automatically reconnected */
     FIRMWARE_RECONNECT: 'ui-firmware_reconnect',
 
@@ -263,30 +261,15 @@ export interface FirmwareProgress {
 }
 
 /**
- * Prompt user to disconnect device during firmware installation.
- */
-export interface FirmwareDisconnect {
-    type: typeof UI_REQUEST.FIRMWARE_DISCONNECT;
-    payload: {
-        device: Device;
-        /** older devices need manual action (connect or disconnect cable). default is false */
-        manual: boolean;
-        intermediary?: boolean;
-    };
-}
-
-/**
  * Prompt user to reconnect device during firmware installation.
  */
 export interface FirmwareReconnect {
     type: typeof UI_REQUEST.FIRMWARE_RECONNECT;
     payload: {
         device: Device;
-        /** older devices need manual action (connect or disconnect cable). default is false */
-        manual: boolean;
-        intermediary?: boolean;
-        /** should device be connected in bootloader mode? */
-        bootloader: boolean;
+        disconnected: boolean;
+        method: 'manual' | 'auto' | 'wait';
+        target: 'normal' | 'bootloader';
         /** how many times this event was fired. resets when request is satisfied */
         i: number;
     };
@@ -306,7 +289,6 @@ export type UiEvent =
     | BundleProgress<any>
     | FirmwareProgress
     | FirmwareException
-    | FirmwareDisconnect
     | FirmwareReconnect
     | UiRequestAddressValidation
     | UiRequestSetOperation;

--- a/packages/connect/src/events/ui-request.ts
+++ b/packages/connect/src/events/ui-request.ts
@@ -271,6 +271,7 @@ export interface FirmwareDisconnect {
         device: Device;
         /** older devices need manual action (connect or disconnect cable). default is false */
         manual: boolean;
+        intermediary?: boolean;
     };
 }
 
@@ -283,6 +284,7 @@ export interface FirmwareReconnect {
         device: Device;
         /** older devices need manual action (connect or disconnect cable). default is false */
         manual: boolean;
+        intermediary?: boolean;
         /** should device be connected in bootloader mode? */
         bootloader: boolean;
         /** how many times this event was fired. resets when request is satisfied */

--- a/packages/suite/src/components/firmware/FirmwareInstallation.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInstallation.tsx
@@ -31,6 +31,7 @@ export const FirmwareInstallation = ({
         if (
             isWebUSB &&
             uiEvent?.type === UI.FIRMWARE_RECONNECT &&
+            uiEvent.payload.disconnected &&
             uiEvent.payload.i > 2 && // Add some latency for cases when the device is already paired or is restarting.
             status !== 'done'
         ) {

--- a/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
+++ b/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
@@ -183,7 +183,8 @@ export const ReconnectDevicePrompt = ({ onClose, onSuccess }: ReconnectDevicePro
         ) {
             return 'done';
         }
-        const rebootToBootloaderNotSupported = uiEvent?.type === UI.FIRMWARE_DISCONNECT;
+        const rebootToBootloaderNotSupported =
+            uiEvent?.type === UI.FIRMWARE_RECONNECT && !uiEvent.payload.disconnected;
         const rebootToBootloaderCancelled = device?.connected && device?.mode !== 'bootloader';
 
         return rebootToBootloaderNotSupported || rebootToBootloaderCancelled
@@ -197,15 +198,17 @@ export const ReconnectDevicePrompt = ({ onClose, onSuccess }: ReconnectDevicePro
     const isAbortable = isManualRebootRequired && rebootPhase == 'waiting-for-reboot';
     const showWebUsbButton = rebootPhase === 'disconnected' && isWebUSB;
 
-    const isIntermediary =
-        uiEvent?.payload && 'intermediary' in uiEvent.payload && uiEvent.payload.intermediary;
+    const toNormal =
+        uiEvent?.type === UI.FIRMWARE_RECONNECT &&
+        uiEvent.payload.target === 'normal' &&
+        uiEvent.payload.method === 'manual';
 
     const getHeading = () => {
         if (isRebootDone) {
             return 'TR_RECONNECT_IN_BOOTLOADER_SUCCESS';
         }
 
-        if (isIntermediary) {
+        if (toNormal) {
             return 'TR_RECONNECT_IN_NORMAL';
         }
 
@@ -216,7 +219,7 @@ export const ReconnectDevicePrompt = ({ onClose, onSuccess }: ReconnectDevicePro
         const deviceFwVersion = getFirmwareVersion(uiEvent?.payload.device);
         const deviceModelInternal = uiEvent?.payload.device.features?.internal_model;
 
-        if (isIntermediary) {
+        if (toNormal) {
             return 'FIRMWARE_CONNECT_IN_NORMAL_MODEL_NO_BUTTON';
         }
 

--- a/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
+++ b/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
@@ -197,9 +197,16 @@ export const ReconnectDevicePrompt = ({ onClose, onSuccess }: ReconnectDevicePro
     const isAbortable = isManualRebootRequired && rebootPhase == 'waiting-for-reboot';
     const showWebUsbButton = rebootPhase === 'disconnected' && isWebUSB;
 
+    const isIntermediary =
+        uiEvent?.payload && 'intermediary' in uiEvent.payload && uiEvent.payload.intermediary;
+
     const getHeading = () => {
         if (isRebootDone) {
             return 'TR_RECONNECT_IN_BOOTLOADER_SUCCESS';
+        }
+
+        if (isIntermediary) {
+            return 'TR_RECONNECT_IN_NORMAL';
         }
 
         return isManualRebootRequired ? 'TR_RECONNECT_IN_BOOTLOADER' : 'TR_REBOOT_INTO_BOOTLOADER';
@@ -208,6 +215,10 @@ export const ReconnectDevicePrompt = ({ onClose, onSuccess }: ReconnectDevicePro
     const getSecondStep = () => {
         const deviceFwVersion = getFirmwareVersion(uiEvent?.payload.device);
         const deviceModelInternal = uiEvent?.payload.device.features?.internal_model;
+
+        if (isIntermediary) {
+            return 'FIRMWARE_CONNECT_IN_NORMAL_MODEL_NO_BUTTON';
+        }
 
         return pickByDeviceModel(deviceModelInternal, {
             default: 'TR_SWITCH_TO_BOOTLOADER_HOLD_LEFT_BUTTON',

--- a/packages/suite/src/hooks/suite/useFirmware.ts
+++ b/packages/suite/src/hooks/suite/useFirmware.ts
@@ -33,9 +33,8 @@ export const useFirmware = () => {
     const originalDevice = firmware.cachedDevice || device;
     // To instruct user to reboot to bootloader manually, UI.FIRMWARE_DISCONNECT event is emitted first, and UI.FIRMWARE_RECONNECT is emitted after the device disconnects.
     const showManualReconnectPrompt =
-        (firmware.uiEvent?.type === UI.FIRMWARE_DISCONNECT ||
-            firmware.uiEvent?.type === UI.FIRMWARE_RECONNECT) &&
-        firmware.uiEvent.payload.manual;
+        firmware.uiEvent?.type === UI.FIRMWARE_RECONNECT &&
+        firmware.uiEvent.payload.method === 'manual';
     const showReconnectPrompt =
         // T1 emits ButtonRequest_ProtectCall in reboot_and_wait flow, T2 devices emit ButtonRequest_Other in reboot_and_wait and reboot_and_upgrade flows:
         (firmware.uiEvent?.type === DEVICE.BUTTON &&
@@ -49,7 +48,8 @@ export const useFirmware = () => {
         modal.windowType === 'ButtonRequest_FirmwareCheck';
     const isCurrentlyBitcoinOnly = hasBitcoinOnlyFirmware(originalDevice);
     const confirmOnDevice =
-        (firmware.uiEvent?.type === UI.FIRMWARE_RECONNECT && firmware.uiEvent.payload.bootloader) ||
+        (firmware.uiEvent?.type === UI.FIRMWARE_RECONNECT &&
+            firmware.uiEvent.payload.method !== 'wait') ||
         (firmware.uiEvent?.type === DEVICE.BUTTON &&
             firmware.uiEvent.payload.code === 'ButtonRequest_FirmwareUpdate');
     const showConfirmationPill =
@@ -83,10 +83,8 @@ export const useFirmware = () => {
         }
         // Automatically restarting from bootloader to normal mode at the end of non-intermediary installation:
         if (
-            (firmware.uiEvent?.type === UI.FIRMWARE_DISCONNECT ||
-                (firmware.uiEvent?.type === UI.FIRMWARE_RECONNECT &&
-                    !firmware.uiEvent.payload.bootloader)) &&
-            !firmware.uiEvent.payload.manual
+            firmware.uiEvent?.type === UI.FIRMWARE_RECONNECT &&
+            firmware.uiEvent.payload.method === 'wait'
         ) {
             return { operation: translationString('TR_WAIT_FOR_REBOOT'), progress: 100 };
         }

--- a/suite-common/wallet-core/src/firmware/firmwareReducer.ts
+++ b/suite-common/wallet-core/src/firmware/firmwareReducer.ts
@@ -4,7 +4,6 @@ import {
     UI,
     DEVICE,
     FirmwareProgress,
-    FirmwareDisconnect,
     FirmwareReconnect,
     DeviceButtonRequest,
 } from '@trezor/connect';
@@ -24,7 +23,7 @@ type FirmwareUpdateCommon = {
     //  todo: !
     firmwareHashInvalid: string[];
     useDevkit: boolean;
-    uiEvent?: DeviceButtonRequest | FirmwareProgress | FirmwareDisconnect | FirmwareReconnect;
+    uiEvent?: DeviceButtonRequest | FirmwareProgress | FirmwareReconnect;
 };
 
 export type FirmwareUpdateState =
@@ -85,12 +84,9 @@ export const prepareFirmwareReducer = createReducerWithExtraDeps(initialState, (
             action => action.type === extra.actionTypes.storageLoad,
             extra.reducers.storageLoadFirmware,
         )
-        .addMatcher<
-            FirmwareProgress | FirmwareDisconnect | FirmwareReconnect | DeviceButtonRequest
-        >(
+        .addMatcher<FirmwareProgress | FirmwareReconnect | DeviceButtonRequest>(
             action =>
                 action.type === UI.FIRMWARE_RECONNECT ||
-                action.type === UI.FIRMWARE_DISCONNECT ||
                 action.type === UI.FIRMWARE_PROGRESS ||
                 action.type === DEVICE.BUTTON,
             (state, action) => {


### PR DESCRIPTION
## Description

Should fix reconnection during intermediary fw installation:
- Connect requires that reconnected device must have newer bootloader than before (otherwise intermediary wasn't yet installed)
- Suite explicitly says that no button should be pressed in order to install intermediary fw