### PR TITLE
fix(connect-explorer-theme): issue with tailwind in prod build

### DIFF
--- a/packages/connect-explorer-theme/tailwind.config.js
+++ b/packages/connect-explorer-theme/tailwind.config.js
@@ -14,9 +14,8 @@ module.exports = {
     prefix: 'nx-',
     content: [
         './src/**/*.tsx',
-        '../nextra/src/icons/*.tsx',
-        '../nextra/src/components/*.tsx',
         './node_modules/nextra/**/*.js',
+        '../../node_modules/nextra/**/*.js',
     ],
     theme: {
         screens: {

--- a/packages/connect-explorer/tsconfig.json
+++ b/packages/connect-explorer/tsconfig.json
@@ -12,8 +12,7 @@
     "include": [
         "next-env.d.ts",
         "**/*.ts",
-        "**/*.tsx",
-        "../connect-explorer-theme/src/components/CopyToClipboard.tsx"
+        "**/*.tsx"
     ],
     "references": [
         { "path": "../components" },


### PR DESCRIPTION
## Description

Missed some graphical glitches due to an issue with Tailwind not picking up some classes due to different `node_modules` placement in CI build.

Plus removed one component that accidentally got into `connect-explorer` tsconfig.