### PR TITLE
fix(connect-popup): update text in selectAccount

### DIFF
--- a/packages/connect-popup/src/static/popup.html
+++ b/packages/connect-popup/src/static/popup.html
@@ -670,16 +670,14 @@
             <div class="select-account p2wpkh">
                 <div>
                     <div class="tabs">
-                        <div data-tab="p2wpkh" class="tab-selection p2wpkh">Accounts</div>
+                        <div data-tab="p2wpkh" class="tab-selection p2wpkh">
+                            Default accounts (SegWit)
+                        </div>
                         <div data-tab="p2tr" class="tab-selection p2tr">Taproot accounts</div>
-                        <div data-tab="p2sh" class="tab-selection p2sh">Segwit accounts</div>
+                        <div data-tab="p2sh" class="tab-selection p2sh">Legacy SegWit accounts</div>
                         <div data-tab="p2pkh" class="tab-selection p2pkh">Legacy accounts</div>
                     </div>
                     <h3>Select <span>#COIN</span> account</h3>
-                    <div class="bech32-warning" style="display: none">
-                        This Account type is supported only in Trezor Suite.<br />
-                        Pick "Segwit account" if you need to use it in Trezor Wallet.
-                    </div>
                 </div>
                 <div class="wrapper">
                     <div class="select-account-list p2wpkh">

--- a/packages/connect-popup/src/view/selectAccount.ts
+++ b/packages/connect-popup/src/view/selectAccount.ts
@@ -41,10 +41,6 @@ export const selectAccount = (payload: UiRequestSelectAccount['payload']) => {
             const selectedType =
                 defaultAccountType || (accountTypes.includes('p2sh') ? 'p2sh' : 'p2wpkh');
             selectAccountContainer.className = `select-account ${selectedType}`;
-            if (accountTypes.includes('p2sh')) {
-                const bech32warn = container.getElementsByClassName('bech32-warning')[0];
-                bech32warn.removeAttribute('style'); // remove default 'display: none' from element
-            }
             for (let i = 0; i < buttons.length; i++) {
                 const button = buttons[i];
                 const type = button.getAttribute('data-tab');


### PR DESCRIPTION
## Description

Rename account types to be the same as in Suite:

- Accounts -> Default accounts (SegWit)
- SegWit accounts -> Legacy SegWit accounts

Removed warning about support in Trezor Wallet

## Screenshots

<img width="922" alt="Screenshot 2024-05-10 at 17 17 03" src="https://github.com/trezor/trezor-suite/assets/8833813/d917438d-a96d-450e-a4c8-ff845f651354">