### PR TITLE
fix(suite): unify decimal/integer errors

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/Inputs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/Inputs.tsx
@@ -8,7 +8,6 @@ import { useTranslation } from 'src/hooks/suite';
 import { useStakeEthFormContext } from 'src/hooks/wallet/useStakeEthForm';
 import {
     validateDecimals,
-    validateInteger,
     validateLimitsBigNum,
     validateMin,
     validateReserveOrBalance,
@@ -69,7 +68,6 @@ export const Inputs = () => {
         required: translationString('AMOUNT_IS_NOT_SET'),
         validate: {
             min: validateMin(translationString),
-            integer: validateInteger(translationString, { except: true }),
             decimals: validateDecimals(translationString, { decimals: network.decimals }),
             reserveOrBalance: validateReserveOrBalance(translationString, {
                 account,

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/Inputs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/Inputs.tsx
@@ -6,12 +6,7 @@ import { formInputsMaxLength } from '@suite-common/validators';
 import { useSelector, useTranslation } from 'src/hooks/suite';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 import { variables } from '@trezor/components/src/config';
-import {
-    validateDecimals,
-    validateInteger,
-    validateLimitsBigNum,
-    validateMin,
-} from 'src/utils/suite/validation';
+import { validateDecimals, validateLimitsBigNum, validateMin } from 'src/utils/suite/validation';
 import { useUnstakeEthFormContext } from 'src/hooks/wallet/useUnstakeEthForm';
 import { useFormatters } from '@suite-common/formatters';
 import { getInputState } from '@suite-common/wallet-utils';
@@ -63,7 +58,6 @@ export const Inputs = () => {
         required: translationString('AMOUNT_IS_NOT_SET'),
         validate: {
             min: validateMin(translationString),
-            integer: validateInteger(translationString, { except: true }),
             decimals: validateDecimals(translationString, { decimals: network.decimals }),
             limits: validateLimitsBigNum(translationString, {
                 amountLimits,

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/SendCryptoInput/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/SendCryptoInput/index.tsx
@@ -71,7 +71,7 @@ const SendCryptoInput = ({ isWithRate }: SendCryptoInputProps) => {
         validate: {
             min: validateMin(translationString),
             integer: validateInteger(translationString, {
-                except: !shouldSendInSats || !!decimals,
+                except: !shouldSendInSats,
             }),
             limits: validateLimits(translationString, {
                 amountLimits,

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/index.tsx
@@ -187,8 +187,7 @@ export const Amount = ({ output, outputId }: AmountProps) => {
         validate: {
             // allow 0 amount ONLY for ethereum transaction with data
             min: validateMin(translationString, { except: !!getDefaultValue('ethereumDataHex') }),
-            // ERC20 without decimal places
-            integer: validateInteger(translationString, { except: !!decimals }),
+            integer: validateInteger(translationString, { except: !shouldSendInSats }),
             decimals: validateDecimals(translationString, { decimals }),
             dust: (value: string) => {
                 const amountBig = new BigNumber(value);


### PR DESCRIPTION
## Description

- integer validation in staking/unstaking should not be there, it is ignored anyway
- i think it is better to say that token does not allow decimals `Maximum {decimals} decimals allowed` instead of `Amount is not an integer`
- I am not sure what error should be there in case of satoshies but I unified it with exchange section


## Screenshots:

![Screenshot 2024-05-10 at 21 45 31](https://github.com/trezor/trezor-suite/assets/33235762/e24f8ad0-1a95-42a6-9dfb-b895a1b2f0de)
