### PR TITLE
fix(suite): staking, unstaking, claiming values send to Trezor device

### DIFF
--- a/packages/suite/src/utils/suite/__fixtures__/stake.ts
+++ b/packages/suite/src/utils/suite/__fixtures__/stake.ts
@@ -1,0 +1,48 @@
+export const transformTxFixtures = [
+    {
+        description:
+            'should transform transaction data, omit "from", and convert units correctly 1',
+        tx: {
+            data: '0x3a29dbae0000000000000000000000000000000000000000000000000000000000000001',
+            from: '0xCe66A9577F4e2589c1D1547B75B7A2b0807cE0ed',
+            gasLimit: 416102,
+            to: '0xAFA848357154a6a624686b348303EF9a13F63264',
+            value: '122222000000000000',
+        },
+        gasPrice: '50',
+        nonce: '26',
+        chainId: 1,
+        result: {
+            data: '0x3a29dbae0000000000000000000000000000000000000000000000000000000000000001',
+            gasLimit: '0x65966',
+            gasPrice: '0xba43b7400',
+            nonce: '0x1a',
+            chainId: 1,
+            to: '0xAFA848357154a6a624686b348303EF9a13F63264',
+            value: '0x1b23842edbce000',
+        },
+    },
+    {
+        description:
+            'should transform transaction data, omit "from", and convert units correctly 2',
+        tx: {
+            data: '0x3a29dbae0000000000000000000000000000000000000000000000000000000000000001',
+            from: '0xCe66A9577F4e2589c1D1547B75B7A2b0807cE0ed',
+            gasLimit: 300000,
+            to: '0xAFA848357154a6a624686b348303EF9a13F63264',
+            value: '10000',
+        },
+        gasPrice: '1',
+        nonce: '1',
+        chainId: 1,
+        result: {
+            data: '0x3a29dbae0000000000000000000000000000000000000000000000000000000000000001',
+            gasLimit: '0x493e0',
+            gasPrice: '0x3b9aca00',
+            nonce: '0x1',
+            chainId: 1,
+            to: '0xAFA848357154a6a624686b348303EF9a13F63264',
+            value: '0x2710',
+        },
+    },
+];

--- a/packages/suite/src/utils/suite/__tests__/stake.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/stake.test.ts
@@ -1,0 +1,12 @@
+import { transformTxFixtures } from '../__fixtures__/stake';
+import { transformTx } from '../stake';
+
+describe('transformTx', () => {
+    transformTxFixtures.forEach(test => {
+        it(test.description, () => {
+            const result = transformTx(test.tx, test.gasPrice, test.nonce, test.chainId);
+            expect(result).toEqual(test.result);
+            expect(result).not.toHaveProperty('from');
+        });
+    });
+});

--- a/packages/suite/src/utils/suite/stake.ts
+++ b/packages/suite/src/utils/suite/stake.ts
@@ -8,7 +8,7 @@ import { DEFAULT_PAYMENT } from '@suite-common/wallet-constants';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 // @ts-expect-error
 import { Ethereum } from '@everstake/wallet-sdk';
-import { fromWei, toHex, toWei } from 'web3-utils';
+import { fromWei, numberToHex, toWei } from 'web3-utils';
 import { getEthereumEstimateFeeParams, sanitizeHex } from '@suite-common/wallet-utils';
 import TrezorConnect, { EthereumTransaction } from '@trezor/connect';
 import BigNumber from 'bignumber.js';
@@ -278,7 +278,7 @@ export const getStakeFormsDefaultValues = ({
     selectedUtxos: [],
 });
 
-const transformTx = (
+export const transformTx = (
     tx: any,
     gasPrice: string,
     nonce: string,
@@ -286,12 +286,13 @@ const transformTx = (
 ): EthereumTransaction => {
     const transformedTx = {
         ...tx,
-        gasLimit: toHex(tx.gasLimit),
-        gasPrice: toHex(toWei(gasPrice, 'gwei')),
-        nonce: toHex(nonce),
+        gasLimit: numberToHex(tx.gasLimit),
+        gasPrice: numberToHex(toWei(gasPrice, 'gwei')),
+        nonce: numberToHex(nonce),
         chainId,
         data: sanitizeHex(tx.data),
-        value: toHex(tx.value),
+        // in send form, the amount is in ether, here in wei because it is converted earlier in stake, unstake, claimToWithdraw methods
+        value: numberToHex(tx.value),
     };
     delete transformedTx.from;
 


### PR DESCRIPTION
## Description

- fixes staking, unstaking, claiming values send to trezor device which got broken by update of `web3-utils` https://github.com/trezor/trezor-suite/pull/12184
- both mainnet and testnet is broken
- please check that all values send to Trezor are correct

## Related Issue

Fixes #12332


## TODO


I created new issue to cover staking by tests #12345
