### PR TITLE
fix(connect-explorer): use connect-web for dev server

### DIFF
--- a/packages/connect-explorer/package.json
+++ b/packages/connect-explorer/package.json
@@ -4,7 +4,7 @@
     "version": "1.0.0",
     "private": true,
     "scripts": {
-        "dev": "concurrently \"next -p 8088\" \"PORT=8089 yarn workspace @trezor/connect-popup dev\"",
+        "dev": "concurrently \"next -p 8088\" \"PORT=8089 NO_HTTPS=true yarn workspace @trezor/connect-web dev\"",
         "dev:explorer": "next -p 8088",
         "build": "next build && rm -rf build && mv out build",
         "build:webextension": "BUILD_TARGET=webextension yarn build && yarn g:rimraf build-webextension && TS_NODE_PROJECT=\"tsconfig.json\" yarn webpack --config ./webpack/webextension.webpack.config.ts && bash ./webpack/replace-next-filenames.sh",

--- a/packages/connect-web/webpack/dev.webpack.config.ts
+++ b/packages/connect-web/webpack/dev.webpack.config.ts
@@ -27,13 +27,17 @@ const dev = {
     plugins: [
         // connect-web dev needs to be served from https
         // to allow injection in 3rd party builds using trezor-connect-src param
+        // for that, you need to generate your own key and cert
         new WebpackPluginServe({
-            port: 8088,
+            port: process.env.PORT ? parseInt(process.env.PORT) : 8088,
             hmr: true,
-            https: {
-                key: fs.readFileSync(path.join(__dirname, '../webpack/connect_dev.key')),
-                cert: fs.readFileSync(path.join(__dirname, '../webpack/connect_dev.crt')),
-            },
+            https:
+                process.env.NO_HTTPS === 'true'
+                    ? undefined
+                    : {
+                          key: fs.readFileSync(path.join(__dirname, '../webpack/connect_dev.key')),
+                          cert: fs.readFileSync(path.join(__dirname, '../webpack/connect_dev.crt')),
+                      },
             static: [
                 path.join(__dirname, '../build'),
                 path.join(__dirname, '../../connect-popup/build'),


### PR DESCRIPTION
## Description

Use `connect-web` along with `connect-explorer` dev server. 
Previously `connect-popup` was used, but it's dev server doesn't include iframe. 

This also adds support for `PORT` and `NO_HTTPS` env variables for configuring the `connect-web` dev server