### PR TITLE
fix(suite-native): view only enabling for no biometrics allowed

### DIFF
--- a/.github/workflows/native-test-e2e-android.yml
+++ b/.github/workflows/native-test-e2e-android.yml
@@ -132,7 +132,7 @@ jobs:
           force-avd-creation: true
           avd-name: ${{ steps.device.outputs.AVD_NAME }}
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -grpc 8554
-          script: yarn test:e2e android.emu.release --headless --take-screenshots failing --record-videos failing --retries 5
+          script: yarn test:e2e android.emu.release --headless --take-screenshots failing --record-videos failing --retries 2
 
       - name: "Store failed test screenshot artifacts"
         if: ${{failure()}}

--- a/suite-native/app/e2e/tests/onboardAndConnect.test.ts
+++ b/suite-native/app/e2e/tests/onboardAndConnect.test.ts
@@ -38,6 +38,12 @@ describe('Go through onboarding and connect Trezor.', () => {
             device.disableSynchronization();
             await TrezorUserEnvLink.api.startEmu();
 
+            await waitFor(element(by.id('skip-view-only-mode')))
+                .toBeVisible()
+                .withTimeout(10000); // communication between connected Trezor and app takes some time.
+
+            await element(by.id('skip-view-only-mode')).tap();
+
             await waitFor(element(by.text(TREZOR_DEVICE_LABEL)))
                 .toBeVisible()
                 .withTimeout(10000); // communication between connected Trezor and app takes some time.

--- a/suite-native/module-home/src/screens/HomeScreen/components/EnableViewOnlyBottomSheet.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/EnableViewOnlyBottomSheet.tsx
@@ -10,7 +10,10 @@ import {
 } from '@suite-common/wallet-core';
 import { BottomSheet, Box, Button, CenteredTitleHeader, VStack } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
-import { useIsBiometricsInitialSetupFinished } from '@suite-native/biometrics';
+import {
+    getIsBiometricsFeatureAvailable,
+    useIsBiometricsInitialSetupFinished,
+} from '@suite-native/biometrics';
 import { Translation } from '@suite-native/intl';
 import {
     selectViewOnlyCancelationTimestamp,
@@ -45,6 +48,16 @@ export const EnableViewOnlyBottomSheet = () => {
     const isDeviceRemembered = useSelector(selectIsDeviceRemembered);
     const { showToast } = useToast();
     const [isVisible, setIsVisible] = useState(false);
+    const [isAvailableBiometrics, setIsAvailableBiometrics] = useState(false);
+
+    useEffect(() => {
+        const fetchBiometricsAvailability = async () => {
+            const isAvailable = await getIsBiometricsFeatureAvailable();
+            setIsAvailableBiometrics(isAvailable);
+        };
+
+        fetchBiometricsAvailability();
+    }, []);
 
     // show the bottom sheet if:
     //     View Only feature is enabled
@@ -52,7 +65,7 @@ export const EnableViewOnlyBottomSheet = () => {
     //     the device is authorized
     //     not a portfolio tracker
     //     the user hasn't made a choice yet
-    //     and biometrics initial setup was decided
+    //     and biometrics initial setup was decided or biometrics is not available
 
     const canBeShowed =
         isViewOnlyModeFeatureEnabled &&
@@ -60,7 +73,7 @@ export const EnableViewOnlyBottomSheet = () => {
         isDeviceAuthorized &&
         !isPortfolioTrackerDevice &&
         !viewOnlyCancelationTimestamp &&
-        isBiometricsInitialSetupFinished;
+        (isBiometricsInitialSetupFinished || !isAvailableBiometrics);
 
     useEffect(() => {
         let isMounted = true;

--- a/suite-native/module-home/src/screens/HomeScreen/components/EnableViewOnlyBottomSheet.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/EnableViewOnlyBottomSheet.tsx
@@ -3,12 +3,12 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import {
     selectDevice,
-    selectIsDeviceAuthorized,
     selectIsPortfolioTrackerDevice,
     toggleRememberDevice,
     selectIsDeviceRemembered,
 } from '@suite-common/wallet-core';
 import { BottomSheet, Box, Button, CenteredTitleHeader, VStack } from '@suite-native/atoms';
+import { selectIsDeviceReadyToUseAndAuthorized } from '@suite-native/device';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import {
     getIsBiometricsFeatureAvailable,
@@ -41,7 +41,7 @@ export const EnableViewOnlyBottomSheet = () => {
     const { applyStyle } = useNativeStyles();
     const [isViewOnlyModeFeatureEnabled] = useFeatureFlag(FeatureFlag.IsViewOnlyEnabled);
     const { isBiometricsInitialSetupFinished } = useIsBiometricsInitialSetupFinished();
-    const isDeviceAuthorized = useSelector(selectIsDeviceAuthorized);
+    const isDeviceReadyToUseAndAuthorized = useSelector(selectIsDeviceReadyToUseAndAuthorized);
     const device = useSelector(selectDevice);
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const viewOnlyCancelationTimestamp = useSelector(selectViewOnlyCancelationTimestamp);
@@ -70,7 +70,7 @@ export const EnableViewOnlyBottomSheet = () => {
     const canBeShowed =
         isViewOnlyModeFeatureEnabled &&
         !isDeviceRemembered &&
-        isDeviceAuthorized &&
+        isDeviceReadyToUseAndAuthorized &&
         !isPortfolioTrackerDevice &&
         !viewOnlyCancelationTimestamp &&
         (isBiometricsInitialSetupFinished || !isAvailableBiometrics);


### PR DESCRIPTION
If device does not have available biometrics, do not wait for it to be resolved before showing EnableViewOnlyBottomSheet for the device