### PR TITLE
ci(github): exec helper script to throw when error

### DIFF
--- a/ci/scripts/helpers.js
+++ b/ci/scripts/helpers.js
@@ -101,8 +101,12 @@ const exec = (cmd, params) => {
         cwd: ROOT,
     });
     if (res.status !== 0) {
-        console.log(cmd, ...params);
-        console.log(res);
+        console.error('Error executing command:', cmd, ...params);
+        console.error('Command output:', res.stdout);
+        console.error('Command error output:', res.stderr);
+        throw new Error(
+            `Command "${cmd} ${params.join(' ')}" failed with exit code ${res.status}: ${res.stderr}`,
+        );
     }
     return res;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`exec` helper script to throw when error when it fails so the workflow is not continuing and it does appears like failed workflow.