### PR TITLE
ci(github): fix input syntax in NPM release workflow

### DIFF
--- a/.github/workflows/release-connect-npm.yml
+++ b/.github/workflows/release-connect-npm.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       packages:
-        description: "Comma-separated names of the packages to deploy. (example: 'connect,blockchain-link-types,blockchain-link-utils')"
+        description: 'Array string with names of the packages to deploy. (example: ["blockchain-link-utils","blockchain-link-types","analytics"])'
         required: true
         type: string
       deploymentType:
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        package: ${{ fromJson('[' + github.event.inputs.packages + ']') }}
+        package: ${{ fromJson(github.event.inputs.packages) }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/ci/scripts/connect-release-init-npm.js
+++ b/ci/scripts/connect-release-init-npm.js
@@ -36,7 +36,7 @@ const ghWorkflowRunReleaseAction = (branch, packages, deployment) =>
         '--ref',
         branch,
         '--field',
-        `packages="${packages}"`,
+        `packages=${packages}`,
         '--field',
         `deploymentType=${deployment}`,
     ]);
@@ -212,7 +212,7 @@ const initConnectRelease = async () => {
     // and a pull request including all the changes.
     // Now we want to trigger the action that will trigger the actual release,
     // after approval form authorized member.
-    const dependenciesToRelease = update.join(',');
+    const dependenciesToRelease = JSON.stringify(update);
     console.log('dependenciesToRelease:', dependenciesToRelease);
     console.log('deploymentType:', deploymentType);
     console.log('branchName:', branchName);
@@ -230,7 +230,7 @@ const initConnectRelease = async () => {
     console.log('Triggering action to release connect.');
     const releaseConnectActionOutput = ghWorkflowRunReleaseAction(
         branchName,
-        ['connect', 'connect-web', 'connect-webextension'].join(','),
+        JSON.stringify(['connect', 'connect-web', 'connect-webextension']),
         deploymentType,
     );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
According to documentation https://docs.github.com/en/actions/learn-github-actions/expressions#example-matching-an-array-of-strings this approach should work, so it creates a matrix from input like:


```
'["blockchain-link-utils","blockchain-link-types","analytics"]'
```
