### PR TITLE
Refactor/send form redux cleanup

### DIFF
--- a/packages/blockchain-link-types/src/index.ts
+++ b/packages/blockchain-link-types/src/index.ts
@@ -2,3 +2,5 @@ export * from './common';
 export * from './params';
 
 export type { Response } from './responses';
+
+export type { Transaction as BlockbookTransaction } from './blockbook';

--- a/packages/suite/src/actions/wallet/moveLabelsForRbfActions.ts
+++ b/packages/suite/src/actions/wallet/moveLabelsForRbfActions.ts
@@ -3,7 +3,11 @@ import { findChainedTransactions, findTransactions } from '@suite-common/wallet-
 import { Dispatch, GetState } from 'src/types/suite';
 import * as metadataLabelingActions from 'src/actions/suite/metadataLabelingActions';
 import { AccountLabels, AccountOutputLabels } from '@suite-common/metadata-types';
-import { AccountKey, WalletAccountTransaction } from '@suite-common/wallet-types';
+import {
+    AccountKey,
+    RbfLabelsToBeUpdated,
+    WalletAccountTransaction,
+} from '@suite-common/wallet-types';
 
 type DeleteAllOutputLabelsParams = {
     labels: AccountLabels['outputLabels']['labels'];
@@ -65,17 +69,9 @@ type FindLabelsToBeMovedOrDeletedParams = {
     prevTxid: string;
 };
 
-export type LabelsToBeMovedOrDeleted = Record<
-    AccountKey,
-    {
-        toBeMoved: WalletAccountTransaction;
-        toBeDeleted: WalletAccountTransaction[];
-    }
->;
-
 export const findLabelsToBeMovedOrDeleted =
     ({ prevTxid }: FindLabelsToBeMovedOrDeletedParams) =>
-    (_dispatch: Dispatch, getState: GetState): LabelsToBeMovedOrDeleted => {
+    (_dispatch: Dispatch, getState: GetState): RbfLabelsToBeUpdated => {
         const accountTransactions = findTransactions(
             prevTxid,
             getState().wallet.transactions.transactions,
@@ -100,12 +96,12 @@ export const findLabelsToBeMovedOrDeleted =
             };
 
             return result;
-        }, {} as LabelsToBeMovedOrDeleted);
+        }, {} as RbfLabelsToBeUpdated);
     };
 
 type MoveLabelsForRbfParams = {
     newTxid: string;
-    toBeMovedOrDeletedList: LabelsToBeMovedOrDeleted;
+    toBeMovedOrDeletedList: RbfLabelsToBeUpdated;
 };
 
 export const moveLabelsForRbfAction =

--- a/packages/suite/src/actions/wallet/send/sendFormThunks.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormThunks.ts
@@ -114,7 +114,7 @@ export const signAndPushSendFormTransactionThunk = createThunk(
         // this action is blocked by modalActions.preserve()
         dispatch(modalActions.preserve());
 
-        const { serializedTx, signedTransaction } = await dispatch(
+        const { serializedTx } = await dispatch(
             signTransactionThunk({
                 formValues,
                 transactionInfo: enhancedTxInfo,
@@ -137,7 +137,6 @@ export const signAndPushSendFormTransactionThunk = createThunk(
             // push tx to the network
             return dispatch(
                 pushSendFormTransactionThunk({
-                    signedTransaction,
                     selectedAccount,
                 }),
             ).unwrap();

--- a/packages/suite/src/actions/wallet/send/sendFormThunks.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormThunks.ts
@@ -1,29 +1,37 @@
 import { G } from '@mobily/ts-belt';
+import { isRejected } from '@reduxjs/toolkit';
 
 import { createThunk } from '@suite-common/redux-utils';
 import {
     Account,
     FormState,
+    GeneralPrecomposedTransactionFinal,
     PrecomposedTransactionFinal,
-    PrecomposedTransactionFinalCardano,
+    RbfLabelsToBeUpdated,
 } from '@suite-common/wallet-types';
+import {
+    enhancePrecomposedTransactionThunk,
+    pushSendFormTransactionThunk,
+    replaceTransactionThunk,
+    selectDevice,
+    selectPrecomposedSendForm,
+    selectSendFormDrafts,
+    signTransactionThunk,
+    sendFormActions,
+} from '@suite-common/wallet-core';
+import { isCardanoTx } from '@suite-common/wallet-utils';
+import { MetadataAddPayload } from '@suite-common/metadata-types';
+import { Unsuccessful } from '@trezor/connect';
+import { getSynchronize } from '@trezor/utils';
 
-import * as modalActions from 'src/actions/suite/modalActions';
 import {
     selectSelectedAccountKey,
     selectIsSelectedAccountLoaded,
 } from 'src/reducers/wallet/selectedAccountReducer';
-
-import {
-    enhancePrecomposedTransactionThunk,
-    pushSendFormTransactionThunk,
-    selectDevice,
-    selectSendFormDrafts,
-    signTransactionThunk,
-} from '@suite-common/wallet-core';
-import { sendFormActions } from '@suite-common/wallet-core';
-import { isRejected } from '@reduxjs/toolkit';
-import { Unsuccessful } from '@trezor/connect';
+import { findLabelsToBeMovedOrDeleted } from '../moveLabelsForRbfActions';
+import { selectMetadata } from 'src/reducers/suite/metadataReducer';
+import * as metadataLabelingActions from 'src/actions/suite/metadataLabelingActions';
+import * as modalActions from 'src/actions/suite/modalActions';
 
 export const MODULE_PREFIX = '@send';
 
@@ -82,6 +90,108 @@ export const importSendFormRequestThunk = createThunk(
     (_, { dispatch }) => dispatch(modalActions.openDeferredModal({ type: 'import-transaction' })),
 );
 
+const updateRbfLabelsThunk = createThunk(
+    `${MODULE_PREFIX}/updateReplacedTransactionThunk`,
+    (
+        {
+            labelsToBeEdited,
+            precomposedTx,
+            txid,
+        }: {
+            labelsToBeEdited: RbfLabelsToBeUpdated;
+            precomposedTx: PrecomposedTransactionFinal;
+            txid: string;
+        },
+        { dispatch, extra },
+    ) => {
+        const {
+            thunks: { moveLabelsForRbfAction },
+        } = extra;
+
+        dispatch(
+            moveLabelsForRbfAction({
+                toBeMovedOrDeletedList: labelsToBeEdited,
+                newTxid: txid,
+            }),
+        );
+
+        // notification from the backend may be delayed.
+        // modify affected transaction(s) in the reducer until the real account update occurs.
+        // this will update transaction details (like time, fee etc.)
+        dispatch(
+            replaceTransactionThunk({
+                precomposedTx,
+                newTxid: txid,
+            }),
+        );
+    },
+);
+
+const applySendFormMetadataLabelsThunk = createThunk(
+    `${MODULE_PREFIX}/applyMetadataLabelsThunk`,
+    (
+        {
+            selectedAccount,
+            precomposedTx,
+            txid,
+        }: {
+            selectedAccount: Account;
+            precomposedTx: GeneralPrecomposedTransactionFinal;
+            txid: string;
+        },
+        { dispatch, getState },
+    ) => {
+        const metadata = selectMetadata(getState());
+        if (metadata.enabled) {
+            const precomposedForm = selectPrecomposedSendForm(getState());
+            let outputsPermutation: number[];
+            if (isCardanoTx(selectedAccount, precomposedTx)) {
+                // cardano preserves order of outputs
+                outputsPermutation = precomposedTx?.outputs.map((_o, i) => i);
+            } else {
+                outputsPermutation = precomposedTx?.outputsPermutation;
+            }
+
+            const synchronize = getSynchronize();
+
+            precomposedForm?.outputs
+                // create array of metadata objects
+                .map((formOutput, index) => {
+                    const { label } = formOutput;
+                    // final ordering of outputs differs from order in send form
+                    // outputsPermutation contains mapping from @trezor/utxo-lib outputs to send form outputs
+                    // mapping goes like this: Array<@trezor/utxo-lib index : send form index>
+                    const outputIndex = outputsPermutation.findIndex(p => p === index);
+                    const outputMetadata: Extract<MetadataAddPayload, { type: 'outputLabel' }> = {
+                        type: 'outputLabel',
+                        entityKey: selectedAccount.key,
+                        txid,
+                        outputIndex,
+                        value: label,
+                        defaultValue: '',
+                    };
+
+                    return outputMetadata;
+                })
+                // filter out empty values AFTER creating metadata objects (see outputs mapping above)
+                .filter(output => output.value)
+                // propagate metadata to reducers and persistent storage
+                .forEach((output, index, arr) => {
+                    const isLast = index === arr.length - 1;
+
+                    synchronize(() =>
+                        dispatch(
+                            metadataLabelingActions.addAccountMetadata({
+                                ...output,
+                                skipSave: !isLast,
+                            }),
+                        ),
+                    );
+                });
+        }
+    },
+);
+
 export const signAndPushSendFormTransactionThunk = createThunk(
     `${MODULE_PREFIX}/signSendFormTransactionThunk`,
     async (
@@ -91,9 +201,7 @@ export const signAndPushSendFormTransactionThunk = createThunk(
             selectedAccount,
         }: {
             formValues: FormState;
-            precomposedTransaction:
-                | PrecomposedTransactionFinal
-                | PrecomposedTransactionFinalCardano;
+            precomposedTransaction: GeneralPrecomposedTransactionFinal;
             selectedAccount?: Account;
         },
         { dispatch, getState },
@@ -130,10 +238,19 @@ export const signAndPushSendFormTransactionThunk = createThunk(
         }
 
         // Open a deferred modal and get the decision
-        const decision = await dispatch(
+        const isPushConfirmed = await dispatch(
             modalActions.openDeferredModal({ type: 'review-transaction' }),
         );
-        if (decision) {
+        if (isPushConfirmed) {
+            const isRbf = precomposedTransaction.prevTxid !== undefined;
+
+            // This has to be executed prior to pushing the transaction!
+            const rbfLabelsToBeEdited = isRbf
+                ? dispatch(
+                      findLabelsToBeMovedOrDeleted({ prevTxid: precomposedTransaction.prevTxid }),
+                  )
+                : null;
+
             // push tx to the network
             const pushResponse = await dispatch(
                 pushSendFormTransactionThunk({
@@ -145,7 +262,28 @@ export const signAndPushSendFormTransactionThunk = createThunk(
                 return pushResponse.payload as Unsuccessful;
             }
 
-            return pushResponse.payload;
+            const result = pushResponse.payload;
+            const { txid } = result.payload;
+
+            if (isRbf && rbfLabelsToBeEdited) {
+                await dispatch(
+                    updateRbfLabelsThunk({
+                        labelsToBeEdited: rbfLabelsToBeEdited,
+                        precomposedTx: precomposedTransaction,
+                        txid,
+                    }),
+                );
+            }
+
+            dispatch(
+                applySendFormMetadataLabelsThunk({
+                    selectedAccount,
+                    precomposedTx: precomposedTransaction,
+                    txid,
+                }),
+            );
+
+            return result;
         }
     },
 );

--- a/packages/suite/src/actions/wallet/send/sendFormThunks.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormThunks.ts
@@ -15,7 +15,7 @@ import {
 } from 'src/reducers/wallet/selectedAccountReducer';
 
 import {
-    prepareTransactionForSigningThunk,
+    enhancePrecomposedTransactionThunk,
     pushSendFormTransactionThunk,
     selectDevice,
     selectSendFormDrafts,
@@ -87,11 +87,13 @@ export const signAndPushSendFormTransactionThunk = createThunk(
     async (
         {
             formValues,
-            transactionInfo,
+            precomposedTransaction,
             selectedAccount,
         }: {
             formValues: FormState;
-            transactionInfo: PrecomposedTransactionFinal | PrecomposedTransactionFinalCardano;
+            precomposedTransaction:
+                | PrecomposedTransactionFinal
+                | PrecomposedTransactionFinalCardano;
             selectedAccount?: Account;
         },
         { dispatch, getState },
@@ -99,17 +101,13 @@ export const signAndPushSendFormTransactionThunk = createThunk(
         const device = selectDevice(getState());
         if (!device || !selectedAccount) return;
 
-        const enhancedTxInfo = await dispatch(
-            prepareTransactionForSigningThunk({
+        const enhancedPrecomposedTransaction = await dispatch(
+            enhancePrecomposedTransactionThunk({
                 transactionFormValues: formValues,
-                transactionInfo,
+                precomposedTransaction,
                 selectedAccount,
             }),
         ).unwrap();
-
-        if (!enhancedTxInfo) {
-            return;
-        }
 
         // TransactionReviewModal has 2 steps: signing and pushing
         // TrezorConnect emits UI.CLOSE_UI.WINDOW after the signing process
@@ -119,7 +117,7 @@ export const signAndPushSendFormTransactionThunk = createThunk(
         const { serializedTx } = await dispatch(
             signTransactionThunk({
                 formValues,
-                transactionInfo: enhancedTxInfo,
+                precomposedTransaction: enhancedPrecomposedTransaction,
                 selectedAccount,
             }),
         ).unwrap();

--- a/packages/suite/src/actions/wallet/send/sendFormThunks.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormThunks.ts
@@ -22,6 +22,8 @@ import {
     signTransactionThunk,
 } from '@suite-common/wallet-core';
 import { sendFormActions } from '@suite-common/wallet-core';
+import { isRejected } from '@reduxjs/toolkit';
+import { Unsuccessful } from '@trezor/connect';
 
 export const MODULE_PREFIX = '@send';
 
@@ -135,11 +137,17 @@ export const signAndPushSendFormTransactionThunk = createThunk(
         );
         if (decision) {
             // push tx to the network
-            return dispatch(
+            const pushResponse = await dispatch(
                 pushSendFormTransactionThunk({
                     selectedAccount,
                 }),
-            ).unwrap();
+            );
+
+            if (isRejected(pushResponse)) {
+                return pushResponse.payload as Unsuccessful;
+            }
+
+            return pushResponse.payload;
         }
     },
 );

--- a/packages/suite/src/actions/wallet/stakeActions.ts
+++ b/packages/suite/src/actions/wallet/stakeActions.ts
@@ -117,7 +117,7 @@ const pushTransaction =
                 // this will update transaction details (like time, fee etc.)
                 dispatch(
                     replaceTransactionThunk({
-                        precomposedTx,
+                        precomposedTransaction: precomposedTx,
                         newTxid: txid,
                     }),
                 );

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
@@ -48,7 +48,7 @@ export const TransactionReviewModalContent = ({
 
     const deviceModelInternal = device?.features?.internal_model;
 
-    const { precomposedTx, precomposedForm, signedTx } = txInfoState;
+    const { precomposedTx, precomposedForm, serializedTx } = txInfoState;
 
     if (selectedAccount.status !== 'loaded' || !device || !precomposedTx || !precomposedForm) {
         return null;
@@ -107,7 +107,7 @@ export const TransactionReviewModalContent = ({
     const buttonRequestsCount = isCardano ? buttonRequests.length - 1 : buttonRequests.length;
 
     const onCancel =
-        isActionAbortable || signedTx
+        isActionAbortable || serializedTx
             ? () => {
                   cancelSignTx();
                   decision?.resolve(false);
@@ -120,7 +120,7 @@ export const TransactionReviewModalContent = ({
                 <ConfirmOnDevice
                     title={<Translation id="TR_CONFIRM_ON_TREZOR" />}
                     steps={outputs.length + 1}
-                    activeStep={signedTx ? outputs.length + 2 : buttonRequestsCount}
+                    activeStep={serializedTx ? outputs.length + 2 : buttonRequestsCount}
                     deviceModelInternal={deviceModelInternal}
                     deviceUnitColor={device?.features?.unit_color}
                     successText={<Translation id="TR_CONFIRMED_TX" />}
@@ -145,7 +145,7 @@ export const TransactionReviewModalContent = ({
                 account={selectedAccount.account}
                 precomposedForm={precomposedForm}
                 precomposedTx={precomposedTx}
-                signedTx={signedTx}
+                signedTx={serializedTx}
                 decision={decision}
                 detailsOpen={detailsOpen}
                 outputs={outputs}

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewDetails.tsx
@@ -2,7 +2,7 @@ import styled, { useTheme } from 'styled-components';
 
 import { Translation } from 'src/components/suite';
 import { Icon, Box, variables } from '@trezor/components';
-import { PrecomposedTransactionFinal, TxFinalCardano } from '@suite-common/wallet-types';
+import { GeneralPrecomposedTransactionFinal } from '@suite-common/wallet-types';
 import { borders, zIndices } from '@trezor/theme';
 
 const TransactionDetailsWrapper = styled.div`
@@ -109,7 +109,7 @@ const Pre = styled.pre`
 `;
 
 export interface TransactionReviewDetailsProps {
-    tx: PrecomposedTransactionFinal | TxFinalCardano;
+    tx: GeneralPrecomposedTransactionFinal;
     txHash?: string;
 }
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
@@ -11,11 +11,7 @@ import { useDispatch } from 'src/hooks/suite';
 import { TransactionReviewDetails } from './TransactionReviewDetails';
 import { TransactionReviewOutput } from './TransactionReviewOutput';
 import type { Account } from 'src/types/wallet';
-import type {
-    FormState,
-    PrecomposedTransactionFinal,
-    TxFinalCardano,
-} from '@suite-common/wallet-types';
+import type { FormState, GeneralPrecomposedTransactionFinal } from '@suite-common/wallet-types';
 import { getOutputState } from 'src/utils/wallet/reviewTransactionUtils';
 import { TransactionReviewTotalOutput } from './TransactionReviewTotalOutput';
 import { ReviewOutput } from 'src/types/wallet/transaction';
@@ -90,7 +86,7 @@ const Nowrap = styled.span`
 export interface TransactionReviewOutputListProps {
     account: Account;
     precomposedForm: FormState | StakeFormState;
-    precomposedTx: PrecomposedTransactionFinal | TxFinalCardano;
+    precomposedTx: GeneralPrecomposedTransactionFinal;
     signedTx?: { tx: string }; // send reducer
     decision?: { resolve: (success: boolean) => void }; // dfd
     detailsOpen: boolean;

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
@@ -7,7 +7,7 @@ import { borders, spacingsPx, typography } from '@trezor/theme';
 import { TranslationKey } from '@suite-common/intl-types';
 import { Translation, FormattedCryptoAmount, AccountLabel } from 'src/components/suite';
 import { Account, Network } from 'src/types/wallet';
-import { PrecomposedTransactionFinal, TxFinalCardano } from '@suite-common/wallet-types';
+import { GeneralPrecomposedTransactionFinal } from '@suite-common/wallet-types';
 import { useSelector } from 'src/hooks/suite/useSelector';
 import { selectLabelingDataForSelectedAccount } from 'src/reducers/suite/metadataReducer';
 
@@ -192,7 +192,7 @@ const ReviewRbfLeftDetailsLineRight = styled.div<{ $color: string; $uppercase?: 
 
 interface TransactionReviewSummaryProps {
     estimateTime?: number;
-    tx: PrecomposedTransactionFinal | TxFinalCardano;
+    tx: GeneralPrecomposedTransactionFinal;
     account: Account;
     network: Network;
     broadcast?: boolean;

--- a/packages/suite/src/hooks/wallet/form/useCompose.ts
+++ b/packages/suite/src/hooks/wallet/form/useCompose.ts
@@ -240,7 +240,7 @@ export const useCompose = <TFieldValues extends FormState>({
             const result = await dispatch(
                 signAndPushSendFormTransactionThunk({
                     formValues: values,
-                    transactionInfo: composedTx,
+                    precomposedTransaction: composedTx,
                     selectedAccount,
                 }),
             ).unwrap();

--- a/packages/suite/src/hooks/wallet/form/useCompose.ts
+++ b/packages/suite/src/hooks/wallet/form/useCompose.ts
@@ -231,16 +231,16 @@ export const useCompose = <TFieldValues extends FormState>({
     // called from the UI, triggers signing process
     const sign = async () => {
         const values = getValues();
-        const composedTx = composedLevels
+        const precomposedTransaction = composedLevels
             ? composedLevels[values.selectedFee || 'normal']
             : undefined;
-        if (composedTx && composedTx.type === 'final') {
+        if (precomposedTransaction && precomposedTransaction.type === 'final') {
             // sign workflow in Actions:
             // signSendFormTransactionThunk > sign[COIN]TransactionThunk > sendFormActions.storeSignedTransaction (modal with promise decision)
             const result = await dispatch(
                 signAndPushSendFormTransactionThunk({
                     formValues: values,
-                    precomposedTransaction: composedTx,
+                    precomposedTransaction,
                     selectedAccount,
                 }),
             ).unwrap();

--- a/packages/suite/src/hooks/wallet/useCardanoStaking.ts
+++ b/packages/suite/src/hooks/wallet/useCardanoStaking.ts
@@ -235,7 +235,11 @@ export const useCardanoStaking = (): CardanoStaking => {
                         }),
                     );
                     dispatch(
-                        addFakePendingCardanoTxThunk({ precomposedTx: txPlan, txid, account }),
+                        addFakePendingCardanoTxThunk({
+                            precomposedTransaction: txPlan,
+                            txid,
+                            account,
+                        }),
                     );
                     dispatch(setPendingStakeTx(account, txid));
                 } else {

--- a/packages/suite/src/hooks/wallet/useCoinmarketRecomposeAndSign.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketRecomposeAndSign.ts
@@ -123,14 +123,14 @@ export const useCoinmarketRecomposeAndSign = () => {
 
                 return;
             }
-            const composedToSign = composedLevels[selectedFee];
+            const precomposedToSign = composedLevels[selectedFee];
 
-            if (!composedToSign || composedToSign.type !== 'final') {
+            if (!precomposedToSign || precomposedToSign.type !== 'final') {
                 let errorMessage: string | undefined;
-                if (composedToSign?.type === 'error' && composedToSign.errorMessage) {
+                if (precomposedToSign?.type === 'error' && precomposedToSign.errorMessage) {
                     errorMessage = translationString(
-                        composedToSign.errorMessage.id,
-                        composedToSign.errorMessage.values as { [key: string]: any },
+                        precomposedToSign.errorMessage.id,
+                        precomposedToSign.errorMessage.values as { [key: string]: any },
                     );
                 }
                 if (!errorMessage) {
@@ -149,7 +149,7 @@ export const useCoinmarketRecomposeAndSign = () => {
             return dispatch(
                 signAndPushSendFormTransactionThunk({
                     formValues,
-                    precomposedTransaction: composedToSign,
+                    precomposedTransaction: precomposedToSign,
                     selectedAccount: account,
                 }),
             ).unwrap();

--- a/packages/suite/src/hooks/wallet/useCoinmarketRecomposeAndSign.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketRecomposeAndSign.ts
@@ -149,7 +149,7 @@ export const useCoinmarketRecomposeAndSign = () => {
             return dispatch(
                 signAndPushSendFormTransactionThunk({
                     formValues,
-                    transactionInfo: composedToSign,
+                    precomposedTransaction: composedToSign,
                     selectedAccount: account,
                 }),
             ).unwrap();

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -268,7 +268,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
             const result = await dispatch(
                 signAndPushSendFormTransactionThunk({
                     formValues: values,
-                    transactionInfo: composedTx,
+                    precomposedTransaction: composedTx,
                     selectedAccount: props.selectedAccount.account,
                 }),
             ).unwrap();

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -258,17 +258,17 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
     // get response from TransactionReviewModal
     const sign = useCallback(async () => {
         const values = getValues();
-        const composedTx = composedLevels
+        const precomposedTransaction = composedLevels
             ? composedLevels[values.selectedFee || 'normal']
             : undefined;
-        if (composedTx && composedTx.type === 'final') {
+        if (precomposedTransaction && precomposedTransaction.type === 'final') {
             // sign workflow in Actions:
             // signSendFormTransactionThunk > sign[COIN]SendFormTransactionThunk > sendFormActions.storeSignedTransaction (modal with promise decision)
             setLoading(true);
             const result = await dispatch(
                 signAndPushSendFormTransactionThunk({
                     formValues: values,
-                    precomposedTransaction: composedTx,
+                    precomposedTransaction,
                     selectedAccount: props.selectedAccount.account,
                 }),
             ).unwrap();

--- a/packages/suite/src/middlewares/wallet/__fixtures__/walletMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/__fixtures__/walletMiddleware.ts
@@ -5,7 +5,7 @@ import { WALLET_SETTINGS } from 'src/actions/settings/constants';
 import { RouterState } from 'src/reducers/suite/routerReducer';
 import { State as SelectedAccountState } from 'src/reducers/wallet/selectedAccountReducer';
 import { accountsActions, sendFormActions } from '@suite-common/wallet-core';
-import { convertSendFormDraftsThunk } from '@suite-common/wallet-core';
+import { convertSendFormDraftsBtcAmountUnitsThunk } from '@suite-common/wallet-core';
 
 export const blockchainSubscription = [
     {
@@ -163,7 +163,7 @@ export const draftsFixtures = [
                 payload: PROTO.AmountUnit.SATOSHI,
             },
             {
-                type: convertSendFormDraftsThunk.pending.type,
+                type: convertSendFormDraftsBtcAmountUnitsThunk.pending.type,
             },
             {
                 type: sendFormActions.storeDraft.type,

--- a/packages/suite/src/middlewares/wallet/walletMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/walletMiddleware.ts
@@ -17,7 +17,7 @@ import { ROUTER } from 'src/actions/suite/constants';
 import { WALLET_SETTINGS } from 'src/actions/settings/constants';
 import * as selectedAccountActions from 'src/actions/wallet/selectedAccountActions';
 import { sendFormActions } from '@suite-common/wallet-core';
-import { convertSendFormDraftsThunk } from '@suite-common/wallet-core';
+import { convertSendFormDraftsBtcAmountUnitsThunk } from '@suite-common/wallet-core';
 import * as modalActions from 'src/actions/suite/modalActions';
 import * as receiveActions from 'src/actions/wallet/receiveActions';
 import * as cardanoStakingActions from 'src/actions/wallet/cardanoStakingActions';
@@ -119,7 +119,9 @@ const walletMiddleware =
         if (action.type === WALLET_SETTINGS.SET_BITCOIN_AMOUNT_UNITS) {
             const nextSelectedAccountKey = selectSelectedAccountKey(api.getState());
             api.dispatch(
-                convertSendFormDraftsThunk({ selectedAccountKey: nextSelectedAccountKey }),
+                convertSendFormDraftsBtcAmountUnitsThunk({
+                    selectedAccountKey: nextSelectedAccountKey,
+                }),
             );
             api.dispatch(coinmarketCommonActions.convertDrafts());
         }

--- a/packages/suite/src/reducers/wallet/__tests__/sendFormReducer.test.ts
+++ b/packages/suite/src/reducers/wallet/__tests__/sendFormReducer.test.ts
@@ -66,7 +66,7 @@ describe('sendFormReducer', () => {
     it('SEND.REQUEST_SIGN_TRANSACTION - save', () => {
         const action: Action = sendFormActions.storePrecomposedTransaction({
             formState: formStateMock,
-            transactionInfo: precomposedTxMock,
+            precomposedTransaction: precomposedTxMock,
         });
 
         const state = prepareSendFormReducer(extraDependencies)(initialState, action);

--- a/packages/suite/src/reducers/wallet/__tests__/sendFormReducer.test.ts
+++ b/packages/suite/src/reducers/wallet/__tests__/sendFormReducer.test.ts
@@ -4,7 +4,7 @@ import { FormState, PrecomposedTransactionFinal } from '@suite-common/wallet-typ
 import { accountsActions } from '@suite-common/wallet-core';
 import { prepareSendFormReducer, initialState, sendFormActions } from '@suite-common/wallet-core';
 
-import { Account, FormSignedTx } from '@suite-common/wallet-types';
+import { Account, SerializedTx } from '@suite-common/wallet-types';
 
 import { PreloadStoreAction } from 'src/support/suite/preloadStore';
 import { extraDependencies } from 'src/support/extraDependencies';
@@ -14,7 +14,7 @@ import { extraDependencies } from 'src/support/extraDependencies';
 // shorter and more readable, it is mocked as a plain string.
 const formStateMock = 'FormStateMock' as unknown as FormState;
 const precomposedTxMock = 'precomposedTx' as unknown as PrecomposedTransactionFinal;
-const formSignedTxMock = 'formSignedTx' as unknown as FormSignedTx;
+const formSignedTxMock = 'formSignedTx' as unknown as SerializedTx;
 
 describe('sendFormReducer', () => {
     it('STORAGE.LOAD', () => {
@@ -76,12 +76,14 @@ describe('sendFormReducer', () => {
 
     it('SEND.REQUEST_PUSH_TRANSACTION - save', () => {
         const action: Action = sendFormActions.storeSignedTransaction({
-            coin: 'btc',
-            tx: 'test',
+            serializedTx: {
+                coin: 'btc',
+                tx: 'test',
+            },
         });
 
         const state = prepareSendFormReducer(extraDependencies)(initialState, action);
-        expect(state.signedTx).toEqual({ coin: 'btc', tx: 'test' });
+        expect(state.serializedTx).toEqual({ coin: 'btc', tx: 'test' });
     });
 
     it('SEND.REQUEST_PUSH_TRANSACTION - delete', () => {
@@ -90,13 +92,13 @@ describe('sendFormReducer', () => {
         const state = prepareSendFormReducer(extraDependencies)(
             {
                 ...initialState,
-                signedTx: formSignedTxMock,
+                serializedTx: formSignedTxMock,
                 precomposedForm: formStateMock,
                 precomposedTx: precomposedTxMock,
             },
             action,
         );
-        expect(state.signedTx).toBeUndefined();
+        expect(state.serializedTx).toBeUndefined();
         expect(state.precomposedTx).toBeUndefined();
         expect(state.precomposedForm).toBeUndefined();
     });
@@ -120,13 +122,13 @@ describe('sendFormReducer', () => {
                 sendRaw: true,
                 precomposedTx: precomposedTxMock,
                 precomposedForm: formStateMock,
-                signedTx: formSignedTxMock,
+                serializedTx: formSignedTxMock,
             },
             action,
         );
         expect(state.sendRaw).toBeUndefined();
         expect(state.precomposedTx).toBeUndefined();
         expect(state.precomposedForm).toBeUndefined();
-        expect(state.signedTx).toBeUndefined();
+        expect(state.serializedTx).toBeUndefined();
     });
 });

--- a/packages/suite/src/reducers/wallet/__tests__/sendFormReducer.test.ts
+++ b/packages/suite/src/reducers/wallet/__tests__/sendFormReducer.test.ts
@@ -65,13 +65,14 @@ describe('sendFormReducer', () => {
 
     it('SEND.REQUEST_SIGN_TRANSACTION - save', () => {
         const action: Action = sendFormActions.storePrecomposedTransaction({
-            formState: formStateMock,
+            accountKey: 'key1',
+            enhancedFormDraft: formStateMock,
             precomposedTransaction: precomposedTxMock,
         });
 
         const state = prepareSendFormReducer(extraDependencies)(initialState, action);
         expect(state.precomposedTx).toEqual(precomposedTxMock);
-        expect(state.precomposedForm).toEqual(formStateMock);
+        expect(state.drafts['key1']).toEqual(formStateMock);
     });
 
     it('SEND.REQUEST_PUSH_TRANSACTION - save', () => {
@@ -93,14 +94,12 @@ describe('sendFormReducer', () => {
             {
                 ...initialState,
                 serializedTx: formSignedTxMock,
-                precomposedForm: formStateMock,
                 precomposedTx: precomposedTxMock,
             },
             action,
         );
         expect(state.serializedTx).toBeUndefined();
         expect(state.precomposedTx).toBeUndefined();
-        expect(state.precomposedForm).toBeUndefined();
     });
 
     it('SEND.SEND_RAW', () => {
@@ -121,14 +120,12 @@ describe('sendFormReducer', () => {
                 ...initialState,
                 sendRaw: true,
                 precomposedTx: precomposedTxMock,
-                precomposedForm: formStateMock,
                 serializedTx: formSignedTxMock,
             },
             action,
         );
         expect(state.sendRaw).toBeUndefined();
         expect(state.precomposedTx).toBeUndefined();
-        expect(state.precomposedForm).toBeUndefined();
         expect(state.serializedTx).toBeUndefined();
     });
 });

--- a/packages/suite/src/utils/wallet/reviewTransactionUtils.ts
+++ b/packages/suite/src/utils/wallet/reviewTransactionUtils.ts
@@ -4,7 +4,7 @@ import { CardanoOutput } from '@trezor/connect';
 import { getFirmwareVersion } from '@trezor/device-utils';
 import { versionUtils } from '@trezor/utils';
 import { TrezorDevice } from 'src/types/suite/index';
-import { FormState, PrecomposedTransactionFinal, TxFinalCardano } from '@suite-common/wallet-types';
+import { FormState, GeneralPrecomposedTransactionFinal } from '@suite-common/wallet-types';
 import { Account } from 'src/types/wallet/index';
 import { getShortFingerprint, isCardanoTx } from '@suite-common/wallet-utils';
 import { ReviewOutput } from 'src/types/wallet/transaction';
@@ -72,7 +72,7 @@ const getCardanoTokenBundle = (account: Account, output: CardanoOutput) => {
 };
 
 type ConstructOutputsParams = {
-    precomposedTx: TxFinalCardano | PrecomposedTransactionFinal;
+    precomposedTx: GeneralPrecomposedTransactionFinal;
     decreaseOutputId: number | undefined;
     account: Account;
     precomposedForm: FormState | StakeFormState;

--- a/suite-common/wallet-core/src/send/sendFormActions.ts
+++ b/suite-common/wallet-core/src/send/sendFormActions.ts
@@ -2,10 +2,9 @@ import { createAction } from '@reduxjs/toolkit';
 
 import {
     FormState,
-    PrecomposedTransactionFinal,
     SerializedTx,
     AccountKey,
-    TxFinalCardano,
+    GeneralPrecomposedTransactionFinal,
 } from '@suite-common/wallet-types';
 import { BlockbookTransaction } from '@trezor/blockchain-link-types';
 
@@ -29,7 +28,7 @@ const storePrecomposedTransaction = createAction(
     `${SEND_MODULE_PREFIX}/store-precomposed-transaction`,
     (payload: {
         formState: FormState;
-        precomposedTransaction: PrecomposedTransactionFinal | TxFinalCardano;
+        precomposedTransaction: GeneralPrecomposedTransactionFinal;
     }) => ({
         payload,
     }),

--- a/suite-common/wallet-core/src/send/sendFormActions.ts
+++ b/suite-common/wallet-core/src/send/sendFormActions.ts
@@ -3,10 +3,11 @@ import { createAction } from '@reduxjs/toolkit';
 import {
     FormState,
     PrecomposedTransactionFinal,
-    FormSignedTx,
+    SerializedTx,
     AccountKey,
     TxFinalCardano,
 } from '@suite-common/wallet-types';
+import { BlockbookTransaction } from '@trezor/blockchain-link-types';
 
 import { SEND_MODULE_PREFIX } from './sendFormConstants';
 
@@ -36,7 +37,7 @@ const storePrecomposedTransaction = createAction(
 
 const storeSignedTransaction = createAction(
     `${SEND_MODULE_PREFIX}/store-signed-transaction`,
-    (payload: FormSignedTx) => ({
+    (payload: { serializedTx: SerializedTx; signedTx?: BlockbookTransaction }) => ({
         payload,
     }),
 );

--- a/suite-common/wallet-core/src/send/sendFormActions.ts
+++ b/suite-common/wallet-core/src/send/sendFormActions.ts
@@ -27,7 +27,8 @@ const removeDraft = createAction(
 const storePrecomposedTransaction = createAction(
     `${SEND_MODULE_PREFIX}/store-precomposed-transaction`,
     (payload: {
-        formState: FormState;
+        accountKey: AccountKey;
+        enhancedFormDraft: FormState;
         precomposedTransaction: GeneralPrecomposedTransactionFinal;
     }) => ({
         payload,

--- a/suite-common/wallet-core/src/send/sendFormActions.ts
+++ b/suite-common/wallet-core/src/send/sendFormActions.ts
@@ -29,7 +29,7 @@ const storePrecomposedTransaction = createAction(
     `${SEND_MODULE_PREFIX}/store-precomposed-transaction`,
     (payload: {
         formState: FormState;
-        transactionInfo: PrecomposedTransactionFinal | TxFinalCardano;
+        precomposedTransaction: PrecomposedTransactionFinal | TxFinalCardano;
     }) => ({
         payload,
     }),

--- a/suite-common/wallet-core/src/send/sendFormCardanoThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormCardanoThunks.ts
@@ -125,9 +125,12 @@ export const signCardanoSendFormTransactionThunk = createThunk(
     `${SEND_MODULE_PREFIX}/signCardanoSendFormTransactionThunk`,
     async (
         {
-            transactionInfo,
+            precomposedTransaction,
             selectedAccount,
-        }: { transactionInfo: PrecomposedTransactionFinalCardano; selectedAccount?: Account },
+        }: {
+            precomposedTransaction: PrecomposedTransactionFinalCardano;
+            selectedAccount?: Account;
+        },
         { dispatch, getState, extra },
     ) => {
         const {
@@ -141,8 +144,8 @@ export const signCardanoSendFormTransactionThunk = createThunk(
             G.isNullable(selectedAccount) ||
             selectedAccountStatus !== 'loaded' ||
             !device ||
-            !transactionInfo ||
-            transactionInfo.type !== 'final'
+            !precomposedTransaction ||
+            precomposedTransaction.type !== 'final'
         )
             return;
 
@@ -159,14 +162,14 @@ export const signCardanoSendFormTransactionThunk = createThunk(
                 state: device.state,
             },
             useEmptyPassphrase: device.useEmptyPassphrase,
-            inputs: transactionInfo.inputs,
-            outputs: transactionInfo.outputs,
-            unsignedTx: transactionInfo.unsignedTx,
+            inputs: precomposedTransaction.inputs,
+            outputs: precomposedTransaction.outputs,
+            unsignedTx: precomposedTransaction.unsignedTx,
             testnet: isTestnet(symbol),
             protocolMagic: getProtocolMagic(symbol),
             networkId: getNetworkId(symbol),
-            fee: transactionInfo.fee,
-            ttl: transactionInfo.ttl?.toString(),
+            fee: precomposedTransaction.fee,
+            ttl: precomposedTransaction.ttl?.toString(),
             derivationType: getDerivationType(accountType),
         });
 

--- a/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
@@ -237,7 +237,7 @@ export const composeEthereumSendFormTransactionThunk = createThunk(
 export const signEthereumSendFormTransactionThunk = createThunk(
     `${SEND_MODULE_PREFIX}/signEthereumSendFormTransactionThunk`,
     async (
-        { formValues, transactionInfo, selectedAccount }: SignTransactionThunkArguments,
+        { formValues, precomposedTransaction, selectedAccount }: SignTransactionThunkArguments,
         { dispatch, getState, extra },
     ) => {
         const {
@@ -251,8 +251,8 @@ export const signEthereumSendFormTransactionThunk = createThunk(
             G.isNullable(selectedAccount) ||
             selectedAccountStatus !== 'loaded' ||
             !device ||
-            !transactionInfo ||
-            transactionInfo.type !== 'final'
+            !precomposedTransaction ||
+            precomposedTransaction.type !== 'final'
         )
             return;
 
@@ -292,13 +292,13 @@ export const signEthereumSendFormTransactionThunk = createThunk(
 
         // transform to TrezorConnect.ethereumSignTransaction params
         const transaction = prepareEthereumTransaction({
-            token: transactionInfo.token,
+            token: precomposedTransaction.token,
             chainId: network.chainId,
             to: formValues.outputs[0].address,
             amount: formValues.outputs[0].amount,
             data: formValues.ethereumDataHex,
-            gasLimit: transactionInfo.feeLimit || '',
-            gasPrice: transactionInfo.feePerByte,
+            gasLimit: precomposedTransaction.feeLimit || '',
+            gasPrice: precomposedTransaction.feePerByte,
             nonce,
         });
 

--- a/suite-common/wallet-core/src/send/sendFormReducer.ts
+++ b/suite-common/wallet-core/src/send/sendFormReducer.ts
@@ -45,8 +45,8 @@ export const prepareSendFormReducer = createReducerWithExtraDeps(initialState, (
         })
         .addCase(
             sendFormActions.storePrecomposedTransaction,
-            (state, { payload: { transactionInfo, formState } }) => {
-                state.precomposedTx = transactionInfo;
+            (state, { payload: { precomposedTransaction, formState } }) => {
+                state.precomposedTx = precomposedTransaction;
                 // Deep-cloning to prevent buggy interaction between react-hook-form and immer, see https://github.com/orgs/react-hook-form/discussions/3715#discussioncomment-2151458
                 // Otherwise, whenever the outputs fieldArray is updated after the form draft or precomposedForm is saved, there is na error:
                 // TypeError: Cannot assign to read only property of object '#<Object>'

--- a/suite-common/wallet-core/src/send/sendFormReducer.ts
+++ b/suite-common/wallet-core/src/send/sendFormReducer.ts
@@ -1,4 +1,4 @@
-import { FormState, PrecomposedTransactionFinal, TxFinalCardano } from '@suite-common/wallet-types';
+import { FormState, GeneralPrecomposedTransactionFinal } from '@suite-common/wallet-types';
 import { cloneObject } from '@trezor/utils';
 import { SerializedTx } from '@suite-common/wallet-types';
 import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
@@ -12,7 +12,7 @@ export type SendState = {
         [key: string]: FormState; // Key: account key
     };
     sendRaw?: boolean;
-    precomposedTx?: PrecomposedTransactionFinal | TxFinalCardano;
+    precomposedTx?: GeneralPrecomposedTransactionFinal;
     precomposedForm?: FormState;
     signedTx?: BlockbookTransaction;
     serializedTx?: SerializedTx; // hex representation of signed transaction (payload for TrezorConnect.pushTransaction)

--- a/suite-common/wallet-core/src/send/sendFormRippleThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormRippleThunks.ts
@@ -183,7 +183,7 @@ export const composeRippleSendFormTransactionThunk = createThunk(
 export const signRippleSendFormTransactionThunk = createThunk(
     `${SEND_MODULE_PREFIX}/signRippleSendFormTransactionThunk`,
     async (
-        { formValues, transactionInfo, selectedAccount }: SignTransactionThunkArguments,
+        { formValues, precomposedTransaction, selectedAccount }: SignTransactionThunkArguments,
         { dispatch, getState, extra },
     ) => {
         const {
@@ -198,8 +198,8 @@ export const signRippleSendFormTransactionThunk = createThunk(
             G.isNullable(selectedAccount) ||
             selectedAccountStatus !== 'loaded' ||
             !device ||
-            !transactionInfo ||
-            transactionInfo.type !== 'final'
+            !precomposedTransaction ||
+            precomposedTransaction.type !== 'final'
         )
             return;
 
@@ -223,7 +223,7 @@ export const signRippleSendFormTransactionThunk = createThunk(
             useEmptyPassphrase: device.useEmptyPassphrase,
             path: selectedAccount.path,
             transaction: {
-                fee: transactionInfo.feePerByte,
+                fee: precomposedTransaction.feePerByte,
                 flags: XRP_FLAG,
                 sequence: selectedAccount.misc.sequence,
                 payment,

--- a/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
@@ -253,7 +253,7 @@ export const composeSolanaSendFormTransactionThunk = createThunk(
 export const signSolanaSendFormTransactionThunk = createThunk(
     `${SEND_MODULE_PREFIX}/signSolanaSendFormTransactionThunk`,
     async (
-        { formValues, transactionInfo, selectedAccount }: SignTransactionThunkArguments,
+        { formValues, precomposedTransaction, selectedAccount }: SignTransactionThunkArguments,
         { dispatch, getState, extra },
     ) => {
         const {
@@ -267,14 +267,14 @@ export const signSolanaSendFormTransactionThunk = createThunk(
             G.isNullable(selectedAccount) ||
             selectedAccountStatus !== 'loaded' ||
             !device ||
-            !transactionInfo ||
-            transactionInfo.type !== 'final' ||
-            transactionInfo.feeLimit == null
+            !precomposedTransaction ||
+            precomposedTransaction.type !== 'final' ||
+            precomposedTransaction.feeLimit == null
         )
             return;
 
         if (selectedAccount.networkType !== 'solana') return;
-        const { token } = transactionInfo;
+        const { token } = precomposedTransaction;
 
         const { blockhash, blockHeight: lastValidBlockHeight } = selectBlockchainBlockInfoBySymbol(
             getState(),
@@ -305,8 +305,8 @@ export const signSolanaSendFormTransactionThunk = createThunk(
                       blockhash,
                       lastValidBlockHeight,
                       {
-                          computeUnitPrice: transactionInfo.feePerByte,
-                          computeUnitLimit: transactionInfo.feeLimit,
+                          computeUnitPrice: precomposedTransaction.feePerByte,
+                          computeUnitLimit: precomposedTransaction.feeLimit,
                       },
                   )
                 : undefined;
@@ -322,8 +322,8 @@ export const signSolanaSendFormTransactionThunk = createThunk(
                   blockhash,
                   lastValidBlockHeight,
                   {
-                      computeUnitPrice: transactionInfo.feePerByte,
-                      computeUnitLimit: transactionInfo.feeLimit,
+                      computeUnitPrice: precomposedTransaction.feePerByte,
+                      computeUnitLimit: precomposedTransaction.feeLimit,
                   },
               );
 

--- a/suite-common/wallet-core/src/send/sendFormTypes.ts
+++ b/suite-common/wallet-core/src/send/sendFormTypes.ts
@@ -12,6 +12,6 @@ export type ComposeTransactionThunkArguments = {
 
 export type SignTransactionThunkArguments = {
     formValues: FormState;
-    transactionInfo: PrecomposedTransactionFinal;
+    precomposedTransaction: PrecomposedTransactionFinal;
     selectedAccount?: Account;
 };

--- a/suite-common/wallet-core/src/stake/stakeReducer.ts
+++ b/suite-common/wallet-core/src/stake/stakeReducer.ts
@@ -1,5 +1,10 @@
 import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
-import { StakeFormState, PrecomposedTransactionFinal, Timestamp } from '@suite-common/wallet-types';
+import {
+    StakeFormState,
+    PrecomposedTransactionFinal,
+    Timestamp,
+    SerializedTx,
+} from '@suite-common/wallet-types';
 import { cloneObject } from '@trezor/utils';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 
@@ -10,7 +15,7 @@ import { fetchEverstakeData } from './stakeThunks';
 export interface StakeState {
     precomposedTx?: PrecomposedTransactionFinal;
     precomposedForm?: StakeFormState;
-    signedTx?: { tx: string; coin: string }; // payload for TrezorConnect.pushTransaction
+    serializedTx?: SerializedTx; // payload for TrezorConnect.pushTransaction
     data: {
         [key in NetworkSymbol]?: {
             poolStats: {
@@ -35,7 +40,7 @@ export interface StakeState {
 
 export const stakeInitialState: StakeState = {
     precomposedTx: undefined,
-    signedTx: undefined,
+    serializedTx: undefined,
     data: {},
 };
 
@@ -56,15 +61,15 @@ export const prepareStakeReducer = createReducerWithExtraDeps(stakeInitialState,
         })
         .addCase(stakeActions.requestPushTransaction, (state, action) => {
             if (action.payload) {
-                state.signedTx = action.payload;
+                state.serializedTx = action.payload;
             } else {
-                delete state.signedTx;
+                delete state.serializedTx;
             }
         })
         .addCase(stakeActions.dispose, state => {
             delete state.precomposedTx;
             delete state.precomposedForm;
-            delete state.signedTx;
+            delete state.serializedTx;
         })
         .addCase(fetchEverstakeData.pending, (state, action) => {
             const { networkSymbol } = action.meta.arg;

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -2,7 +2,7 @@ import {
     Account,
     ExportFileType,
     PrecomposedTransactionFinal,
-    TxFinalCardano,
+    PrecomposedTransactionCardanoFinal,
     WalletAccountTransaction,
     AccountKey,
 } from '@suite-common/wallet-types';
@@ -191,7 +191,7 @@ export const addFakePendingCardanoTxThunk = createThunk(
             txid,
             account,
         }: {
-            precomposedTx: Pick<TxFinalCardano, 'totalSpent' | 'fee'>;
+            precomposedTx: Pick<PrecomposedTransactionCardanoFinal, 'totalSpent' | 'fee'>;
             txid: string;
             account: Account;
         },

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -32,7 +32,6 @@ import { TRANSACTIONS_MODULE_PREFIX, transactionsActions } from './transactionsA
 import { selectAccountByKey, selectAccounts } from '../accounts/accountsReducer';
 import { selectBlockchainHeightBySymbol } from '../blockchain/blockchainReducer';
 import { selectHistoricFiatRates } from '../fiat-rates/fiatRatesSelectors';
-import { selectNetworkTokenDefinitions } from '../token-definitions/tokenDefinitionsSelectors';
 import { selectSendSignedTx } from '../send/sendFormReducer';
 
 /**

--- a/suite-common/wallet-types/src/sendForm.ts
+++ b/suite-common/wallet-types/src/sendForm.ts
@@ -47,7 +47,7 @@ export interface FormState {
     selectedUtxos: AccountUtxo[];
 }
 
-export type FormSignedTx = { tx: string; coin: NetworkSymbol };
+export type SerializedTx = { tx: string; coin: NetworkSymbol };
 
 export type ExcludedUtxos = Record<string, 'low-anonymity' | 'dust' | undefined>;
 

--- a/suite-common/wallet-types/src/sendForm.ts
+++ b/suite-common/wallet-types/src/sendForm.ts
@@ -4,7 +4,7 @@ import { FieldPath, UseFormReturn } from 'react-hook-form';
 import { Network, NetworkSymbol } from '@suite-common/wallet-config';
 import { AccountUtxo, FeeLevel, PROTO } from '@trezor/connect';
 
-import { Account } from './account';
+import { Account, AccountKey } from './account';
 import {
     CurrencyOption,
     FeeInfo,
@@ -12,6 +12,7 @@ import {
     PrecomposedLevels,
     PrecomposedLevelsCardano,
     RbfTransactionParams,
+    WalletAccountTransaction,
 } from './transaction';
 import { Rate } from './fiatRates';
 
@@ -128,3 +129,11 @@ export type SendContextValues<TFormValues extends FormState = FormState> =
             // UTXO selection
             utxoSelection: UtxoSelectionContext;
         };
+
+export type RbfLabelsToBeUpdated = Record<
+    AccountKey,
+    {
+        toBeMoved: WalletAccountTransaction;
+        toBeDeleted: WalletAccountTransaction[];
+    }
+>;

--- a/suite-common/wallet-types/src/transaction.ts
+++ b/suite-common/wallet-types/src/transaction.ts
@@ -5,12 +5,12 @@ import {
     FeeLevel,
     TokenInfo,
     ComposeOutput,
-    PrecomposeResultError,
-    PrecomposeResultNonFinal,
-    PrecomposeResultFinal,
-    PrecomposedTransactionErrorCardano,
-    PrecomposedTransactionNonFinalCardano,
-    PrecomposedTransactionFinalCardano,
+    PrecomposeResultError as PrecomposedTransactionConnectResponseError,
+    PrecomposeResultNonFinal as PrecomposedTransactionConnectResponseNonFinal,
+    PrecomposeResultFinal as PrecomposedTransactionConnectResponseFinal,
+    PrecomposedTransactionErrorCardano as PrecomposedTransactionCardanoConnectResponseError,
+    PrecomposedTransactionNonFinalCardano as PrecomposedTransactionCardanoConnectResponseNonFinal,
+    PrecomposedTransactionFinalCardano as PrecomposedTransactionCardanoConnectResponseFinal,
 } from '@trezor/connect';
 import { Network, NetworkSymbol } from '@suite-common/wallet-config';
 import { TranslationKey } from '@suite-common/intl-types';
@@ -21,7 +21,7 @@ export type { PrecomposedTransactionFinalCardano } from '@trezor/connect';
 
 // extend errors from @trezor/connect + @trezor/utxo-lib with errors from sendForm actions
 type PrecomposedTransactionErrorExtended =
-    | PrecomposeResultError
+    | PrecomposedTransactionConnectResponseError
     | {
           type: 'error';
           error:
@@ -32,12 +32,13 @@ type PrecomposedTransactionErrorExtended =
               | 'TR_STAKE_NOT_ENOUGH_FUNDS';
       };
 
-export type TxNonFinalCardano = PrecomposedTransactionNonFinalCardano & {
-    max?: string;
-    feeLimit?: string;
-    estimatedFeeLimit?: string;
-    token?: TokenInfo;
-};
+export type PrecomposedTransactionCardanoNonFinal =
+    PrecomposedTransactionCardanoConnectResponseNonFinal & {
+        max?: string;
+        feeLimit?: string;
+        estimatedFeeLimit?: string;
+        token?: TokenInfo;
+    };
 
 export type CurrencyOption = { value: string; label: string };
 
@@ -87,9 +88,10 @@ type ComposeError = {
 
 export type PrecomposedTransactionError = PrecomposedTransactionErrorExtended & ComposeError;
 
-export type TxErrorCardano = PrecomposedTransactionErrorCardano & ComposeError;
+export type PrecomposedTransactionCardanoError = PrecomposedTransactionCardanoConnectResponseError &
+    ComposeError;
 
-export type PrecomposedTransactionNonFinal = PrecomposeResultNonFinal & {
+export type PrecomposedTransactionNonFinal = PrecomposedTransactionConnectResponseNonFinal & {
     max: string | undefined;
     feeLimit?: string;
     estimatedFeeLimit?: string;
@@ -97,7 +99,7 @@ export type PrecomposedTransactionNonFinal = PrecomposeResultNonFinal & {
 };
 
 // base of PrecomposedTransactionFinal
-type TxFinal = PrecomposeResultFinal & {
+type TxFinal = PrecomposedTransactionConnectResponseFinal & {
     max?: string;
     feeLimit?: string;
     estimatedFeeLimit?: string;
@@ -106,18 +108,19 @@ type TxFinal = PrecomposeResultFinal & {
 };
 
 // base of PrecomposedTransactionFinal
-export type TxFinalCardano = PrecomposedTransactionFinalCardano & {
-    max?: string;
-    feeLimit?: string;
-    estimatedFeeLimit?: string;
-    token?: TokenInfo;
-    // fake all rbf props just to make it easier to work with since the codebase doesn't use type guards
-    rbf?: false;
-    prevTxid?: undefined;
-    feeDifference?: undefined;
-    useNativeRbf?: undefined;
-    useDecreaseOutput?: undefined;
-};
+export type PrecomposedTransactionCardanoFinal =
+    PrecomposedTransactionCardanoConnectResponseFinal & {
+        max?: string;
+        feeLimit?: string;
+        estimatedFeeLimit?: string;
+        token?: TokenInfo;
+        // fake all rbf props just to make it easier to work with since the codebase doesn't use type guards
+        rbf?: false;
+        prevTxid?: undefined;
+        feeDifference?: undefined;
+        useNativeRbf?: undefined;
+        useDecreaseOutput?: undefined;
+    };
 
 // strict distinction between normal and RBF type
 export type PrecomposedTransactionFinal =
@@ -141,7 +144,14 @@ export type PrecomposedTransaction =
     | PrecomposedTransactionNonFinal
     | PrecomposedTransactionFinal;
 
-export type PrecomposedTransactionCardano = TxErrorCardano | TxNonFinalCardano | TxFinalCardano;
+export type PrecomposedTransactionCardano =
+    | PrecomposedTransactionCardanoError
+    | PrecomposedTransactionCardanoNonFinal
+    | PrecomposedTransactionCardanoFinal;
+
+export type GeneralPrecomposedTransactionFinal =
+    | PrecomposedTransactionFinal
+    | PrecomposedTransactionCardanoFinal;
 
 export type PrecomposedLevels = { [key: string]: PrecomposedTransaction };
 export type PrecomposedLevelsCardano = { [key: string]: PrecomposedTransactionCardano };

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -22,7 +22,7 @@ import {
     PrecomposedTransactionFinal,
     ReceiveInfo,
     TokenAddress,
-    TxFinalCardano,
+    GeneralPrecomposedTransactionFinal,
     RatesByKey,
 } from '@suite-common/wallet-types';
 import { FiatCurrencyCode } from '@suite-common/suite-config';
@@ -836,7 +836,7 @@ export const getUtxoFromSignedTransaction = ({
 }: {
     account: Account;
     receivingAccount?: boolean;
-    tx: PrecomposedTransactionFinal | TxFinalCardano;
+    tx: GeneralPrecomposedTransactionFinal;
     txid: string;
     prevTxid?: string;
 }) => {
@@ -920,7 +920,7 @@ export const getPendingAccount = ({
 }: {
     account: Account;
     receivingAccount?: boolean;
-    tx: PrecomposedTransactionFinal | TxFinalCardano;
+    tx: GeneralPrecomposedTransactionFinal;
     txid: string;
 }) => {
     // calculate availableBalance

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -31,8 +31,7 @@ import type {
     Account,
     CurrencyOption,
     ExcludedUtxos,
-    PrecomposedTransactionFinal,
-    TxFinalCardano,
+    GeneralPrecomposedTransactionFinal,
 } from '@suite-common/wallet-types';
 
 import { amountToSatoshi, getUtxoOutpoint, networkAmountToSatoshi } from './accountUtils';
@@ -204,10 +203,7 @@ export const getFeeUnits = (networkType: NetworkType) => {
     return 'sat/B';
 };
 
-export const getFee = (
-    networkType: NetworkType,
-    tx: PrecomposedTransactionFinal | TxFinalCardano,
-) => {
+export const getFee = (networkType: NetworkType, tx: GeneralPrecomposedTransactionFinal) => {
     if (networkType === 'solana') return tx.fee;
 
     return tx.feePerByte;


### PR DESCRIPTION
Batch of send form redux logic refactoring. I recommend to review this PR commit by commit.

## Description
- [refactor(suite): signed transaction data stored in redux send form state](https://github.com/trezor/trezor-suite/pull/12378/commits/b8fe6faa83f61c7260a2410229ab2d7b270fbf3d): signed transaction unserialized data stored in redux state so it does not have to be passed between thunks as an argument

- [refactor(suite): send form common thunks are rejected on fail](https://github.com/trezor/trezor-suite/pull/12378/commits/b3047003876ab1f5901378065c8c9805bb01f558): suite-common sendFormThunks utilize redux-toolkit `rejectWithValue` for better error handling
- [refactor(suite): send form precomposed transaction arguments naming unified](https://github.com/trezor/trezor-suite/pull/12378/commits/2492c1dc2aec14f0e4913ec2b8ed5b3e07e85c6c): naming of `precomposedForm` arguments unified for better readability
- [refactor(suite): unify send form precomposed-transaction types naming](https://github.com/trezor/trezor-suite/pull/12378/commits/ccb9c1574f02a7d0c7ae036db3d6a4fd4c7b7347): There are two types of a successful precomposedTransaction. One for Cardano and other for rest of the networks. This commit makes the naming of these types clearer.
- [refactor(suite): split pushSendFormTransactionThunk into sub-thunks](https://github.com/trezor/trezor-suite/pull/12378/commits/b84f20bf29c9af3adfde81221c30a402a25b64d2): Bulky pushSendFormTransactionThunk was split into smaller sub-thunks. Some of theme were needed only by desktop, these were moved to `packages/suite` package.
- [refactor(suite): convert send form drafts amount units refactored](https://github.com/trezor/trezor-suite/pull/12378/commits/d381866d6d9799b9aa4dddee4a17da33e671e29a)
- [refactor(suite): redundant precomposedForm state removed from sendFormReducer](https://github.com/trezor/trezor-suite/pull/12378/commits/aea18e1c1128afaacd945b9c9150054987ca931f)
