### PR TITLE
ci(scripts): check version to allow prereleases

### DIFF
--- a/ci/scripts/check-version.js
+++ b/ci/scripts/check-version.js
@@ -12,7 +12,7 @@ if (args.length < 3)
         'Version check script requires 3 parameters: package name, branch name and dist tag (beta | latest)',
     );
 
-const [packageName, branch, distTag] = args;
+const [packageName, distTag] = args;
 
 if (!['latest', 'beta'].includes(distTag)) {
     throw new Error('distTag (3rd parameter) must be either "beta" or "latest"');
@@ -42,23 +42,7 @@ if (npmInfo && npmInfo.error && npmInfo.error.code === 'E404') {
 
 const npmVersion = npmInfo[packageJSON.name]['dist-tags'][distTag];
 
-const PRODUCTION = ['npm-release'];
-
 if (!semver.valid(version)) throw new Error(`${version} is not a valid version`);
-
-if (PRODUCTION.find(b => branch.startsWith(b))) {
-    if (semver.prerelease(version)) {
-        throw new Error(`${version} is a prerelease version`);
-    }
-} else {
-    const pre = semver.prerelease(version);
-    if (!pre) {
-        throw new Error(`${version} is not a prerelease version`);
-    }
-    if (pre[0] !== 'beta') {
-        throw new Error(`${version} prerelease version should contain "-beta" suffix`);
-    }
-}
 
 // When npmVersion is undefined it means that there was no previous release on that distTag so every version is valid.
 if (npmVersion && !semver.gt(version, npmVersion)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Now we are using `npm-release` branch for `prereleases` with `beta` tag so this checks are breaking our current release process. 
We are going to change the process and probably get rid of `npm-release` branches anyway.