### PR TITLE
ci(scripts): fix args in check-version

### DIFF
--- a/.github/actions/release-connect-npm/action.yml
+++ b/.github/actions/release-connect-npm/action.yml
@@ -7,7 +7,7 @@ inputs:
     type: choice
     options:
       - beta
-      - production
+      - latest
   packageName:
     description: "The name of the package to be deployed. Select from the predefined list of packages."
     required: true
@@ -57,7 +57,7 @@ runs:
 
     - name: Check version
       shell: bash
-      run: node ./ci/scripts/check-version.js ${{ inputs.packageName }} ${{ steps.extract_branch.outputs.branch }} ${{ inputs.deploymentType }}
+      run: node ./ci/scripts/check-version.js ${{ inputs.packageName }} ${{ inputs.deploymentType }}
 
     - name: Set NPM token
       shell: bash

--- a/ci/scripts/check-version.js
+++ b/ci/scripts/check-version.js
@@ -7,9 +7,9 @@ const path = require('path');
 
 const args = process.argv.slice(2);
 
-if (args.length < 3)
+if (args.length < 2)
     throw new Error(
-        'Version check script requires 3 parameters: package name, branch name and dist tag (beta | latest)',
+        'Version check script requires 2 parameters: package name and dist tag (beta | latest)',
     );
 
 const [packageName, distTag] = args;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`branchName` was removed from array destruction creating an issue, now we get rid of it from the arguments.

Testing the script locally now works:

```
node ./ci/scripts/check-version.js blockchain-link-utils beta
```
