### PR TITLE
feat(transport): make signal required param

### DIFF
--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -78,42 +78,30 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> {
 
         const transportLogger = initLog('@trezor/transport', debug);
 
+        const transportCommonArgs = {
+            messages: this.messages,
+            logger: transportLogger,
+        };
         // mapping of provided transports[] to @trezor/transport classes
         transports.forEach(transportType => {
             if (typeof transportType === 'string') {
                 switch (transportType) {
                     case 'WebUsbTransport':
-                        this.transports.push(
-                            new WebUsbTransport({
-                                messages: this.messages,
-                                logger: transportLogger,
-                            }),
-                        );
+                        this.transports.push(new WebUsbTransport(transportCommonArgs));
                         break;
                     case 'NodeUsbTransport':
-                        this.transports.push(
-                            new NodeUsbTransport({
-                                messages: this.messages,
-                                logger: transportLogger,
-                            }),
-                        );
+                        this.transports.push(new NodeUsbTransport(transportCommonArgs));
                         break;
                     case 'BridgeTransport':
                         this.transports.push(
                             new BridgeTransport({
                                 latestVersion: getBridgeInfo().version.join('.'),
-                                messages: this.messages,
-                                logger: transportLogger,
+                                ...transportCommonArgs,
                             }),
                         );
                         break;
                     case 'UdpTransport':
-                        this.transports.push(
-                            new UdpTransport({
-                                logger: transportLogger,
-                                messages: this.messages,
-                            }),
-                        );
+                        this.transports.push(new UdpTransport(transportCommonArgs));
                         break;
                     default:
                         throw ERRORS.TypedError(

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -109,6 +109,11 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> {
                             `DeviceList.init: transports[] of unexpected type: ${transportType}`,
                         );
                 }
+            } else if (typeof transportType === 'function' && 'prototype' in transportType) {
+                const transportInstance = new transportType(transportCommonArgs);
+                if (isTransportInstance(transportInstance)) {
+                    this.transports.push(transportInstance);
+                }
             } else if (isTransportInstance(transportType)) {
                 // custom Transport might be initialized without messages, update them if so
                 if (!transportType.getMessage()) {

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -78,9 +78,13 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> {
 
         const transportLogger = initLog('@trezor/transport', debug);
 
+        // todo: this should be passed from above
+        const abortController = new AbortController();
+
         const transportCommonArgs = {
             messages: this.messages,
             logger: transportLogger,
+            signal: abortController.signal,
         };
         // mapping of provided transports[] to @trezor/transport classes
         transports.forEach(transportType => {

--- a/packages/connect/src/device/__tests__/DeviceList.test.ts
+++ b/packages/connect/src/device/__tests__/DeviceList.test.ts
@@ -41,7 +41,7 @@ const createTransportApi = (override = {}) =>
     }) as unknown as UsbApi;
 
 const createTestTransport = (apiMethods = {}) => {
-    const sessionsBackground = new SessionsBackground();
+    const sessionsBackground = new SessionsBackground({ signal: new AbortController().signal });
     const sessionsClient = new SessionsClient({
         requestFn: params => sessionsBackground.handleMessage(params),
         registerBackgroundCallbacks: onDescriptorsCallback => {

--- a/packages/connect/src/types/settings.ts
+++ b/packages/connect/src/types/settings.ts
@@ -18,7 +18,7 @@ export interface ConnectSettings {
     popup?: boolean;
     transportReconnect?: boolean;
     webusb?: boolean; // deprecated
-    transports?: (Transport['name'] | Transport)[];
+    transports?: (Transport['name'] | Transport | (new (...args: any[]) => Transport))[];
     pendingTransportEvent?: boolean;
     lazyLoad?: boolean;
     interactionTimeout?: number;

--- a/packages/suite-web/e2e/cypress.config.ts
+++ b/packages/suite-web/e2e/cypress.config.ts
@@ -159,7 +159,11 @@ export default defineConfig({
                     return null;
                 },
                 stealBridgeSession: async () => {
-                    const bridge = new BridgeTransport({ messages });
+                    const abortController = new AbortController();
+                    const bridge = new BridgeTransport({
+                        messages,
+                        signal: abortController.signal,
+                    });
                     await bridge.init().promise;
                     const enumerateRes = await bridge.enumerate().promise;
                     if (!enumerateRes.success) return null;

--- a/packages/transport-bridge/src/core.ts
+++ b/packages/transport-bridge/src/core.ts
@@ -10,7 +10,8 @@ import { UdpApi } from '@trezor/transport/src/api/udp';
 import { AcquireInput, ReleaseInput } from '@trezor/transport/src/transports/abstract';
 import { Log } from '@trezor/utils';
 
-export const sessionsBackground = new SessionsBackground();
+const abortController = new AbortController();
+export const sessionsBackground = new SessionsBackground({ signal: abortController.signal });
 
 export const sessionsClient = new SessionsClient({
     requestFn: args => sessionsBackground.handleMessage(args),

--- a/packages/transport-native/src/nativeUsb.ts
+++ b/packages/transport-native/src/nativeUsb.ts
@@ -11,9 +11,9 @@ export class NativeUsbTransport extends AbstractApiTransport {
     // TODO: Not sure how to solve this type correctly.
     public name = 'NativeUsbTransport' as any;
 
-    constructor(params?: ConstructorParameters<typeof AbstractTransport>[0]) {
-        const { messages, logger } = params || {};
-        const sessionsBackground = new SessionsBackground();
+    constructor(params: ConstructorParameters<typeof AbstractTransport>[0]) {
+        const { messages, logger, signal } = params;
+        const sessionsBackground = new SessionsBackground({ signal });
 
         const sessionsClient = new SessionsClient({
             requestFn: args => sessionsBackground.handleMessage(args),
@@ -30,8 +30,8 @@ export class NativeUsbTransport extends AbstractApiTransport {
                 usbInterface: new WebUSB(),
                 logger,
             }),
-
             sessionsClient,
+            signal,
         });
     }
 }

--- a/packages/transport/e2e/tests/bridge.test.ts
+++ b/packages/transport/e2e/tests/bridge.test.ts
@@ -45,8 +45,8 @@ describe('bridge', () => {
                 await TrezorUserEnvLink.send({ type: 'emulator-start', ...emulatorStartOpts });
                 await TrezorUserEnvLink.send({ type: 'emulator-setup', ...emulatorSetupOpts });
                 await TrezorUserEnvLink.send({ type: 'bridge-start', version: bridgeVersion });
-
-                bridge = new BridgeTransport({ messages });
+                const abortController = new AbortController();
+                bridge = new BridgeTransport({ messages, signal: abortController.signal });
                 await bridge.init().promise;
 
                 const enumerateResult = await bridge.enumerate().promise;

--- a/packages/transport/e2e/tests/events.test.ts
+++ b/packages/transport/e2e/tests/events.test.ts
@@ -59,8 +59,9 @@ describe('bridge', () => {
         await TrezorUserEnvLink.send({ type: 'emulator-setup', ...emulatorSetupOpts });
         await TrezorUserEnvLink.send({ type: 'bridge-start' });
 
-        bridge1 = new BridgeTransport({ messages });
-        bridge2 = new BridgeTransport({ messages });
+        const abortController = new AbortController();
+        bridge1 = new BridgeTransport({ messages, signal: abortController.signal });
+        bridge2 = new BridgeTransport({ messages, signal: abortController.signal });
 
         await bridge1.init().promise;
         await bridge2.init().promise;

--- a/packages/transport/src/sessions/background-browser.ts
+++ b/packages/transport/src/sessions/background-browser.ts
@@ -64,7 +64,9 @@ export const initBackgroundInBrowser = () => {
         console.warn(
             'Unable to load background-sharedworker. Falling back to use local module. Say bye bye to tabs synchronization',
         );
-        const background = new SessionsBackground();
+
+        const abortController = new AbortController();
+        const background = new SessionsBackground({ signal: abortController.signal });
         const registerBackgroundCallbacks: RegisterBackgroundCallbacks = onDescriptorsCallback => {
             background.on('descriptors', descriptors => {
                 onDescriptorsCallback(descriptors);

--- a/packages/transport/src/sessions/background-sharedworker.ts
+++ b/packages/transport/src/sessions/background-sharedworker.ts
@@ -5,7 +5,9 @@ import { HandleMessageParams } from './types';
 
 declare let self: SharedWorkerGlobalScope;
 
-const background = new SessionsBackground();
+const abortController = new AbortController();
+const background = new SessionsBackground({ signal: abortController.signal });
+
 const ports: MessagePort[] = [];
 
 const handleMessage = async (message: HandleMessageParams, port: MessagePort) => {

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -46,7 +46,7 @@ type DeviceDescriptorDiff = {
 
 export interface AbstractTransportParams {
     messages?: Record<string, any>;
-    signal?: AbortSignal;
+    signal: AbortSignal;
     logger?: Logger;
 }
 
@@ -146,7 +146,7 @@ export abstract class AbstractTransport extends TypedEmitter<{
      */
     protected logger: Logger;
 
-    constructor(params?: AbstractTransportParams) {
+    constructor(params: AbstractTransportParams) {
         const { messages, signal, logger } = params || {};
 
         super();
@@ -155,13 +155,11 @@ export abstract class AbstractTransport extends TypedEmitter<{
 
         this.abortController = new AbortController();
 
-        if (signal) {
-            const abort = () => this.abortController.abort();
-            this.abortController.signal.addEventListener('abort', () =>
-                signal.removeEventListener('abort', abort),
-            );
-            signal.addEventListener('abort', abort);
-        }
+        const abort = () => this.abortController.abort();
+        this.abortController.signal.addEventListener('abort', () =>
+            signal.removeEventListener('abort', abort),
+        );
+        signal.addEventListener('abort', abort);
 
         // some abstract inactive logger
         this.logger = logger || {

--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -72,7 +72,7 @@ export class BridgeTransport extends AbstractTransport {
 
     public name = 'BridgeTransport' as const;
 
-    constructor(params?: BridgeConstructorParameters) {
+    constructor(params: BridgeConstructorParameters) {
         const { url = DEFAULT_URL, latestVersion, ...args } = params || {};
         super(args);
         this.url = url;

--- a/packages/transport/src/transports/nodeusb.browser.ts
+++ b/packages/transport/src/transports/nodeusb.browser.ts
@@ -8,7 +8,7 @@ import { empty, emptyAbortable, emptySync } from '../utils/resultEmpty';
 export class NodeUsbTransport extends AbstractTransport {
     public name = 'NodeUsbTransport' as const;
 
-    constructor(params?: AbstractTransportParams) {
+    constructor(params: AbstractTransportParams) {
         super(params);
         console.error(WRONG_ENVIRONMENT);
     }

--- a/packages/transport/src/transports/nodeusb.ts
+++ b/packages/transport/src/transports/nodeusb.ts
@@ -12,9 +12,9 @@ import { UsbApi } from '../api/usb';
 export class NodeUsbTransport extends AbstractApiTransport {
     public name = 'NodeUsbTransport' as const;
 
-    constructor(params?: AbstractTransportParams) {
-        const { messages, logger } = params || {};
-        const sessionsBackground = new SessionsBackground();
+    constructor(params: AbstractTransportParams) {
+        const { messages, logger, signal } = params;
+        const sessionsBackground = new SessionsBackground({ signal });
 
         // in nodeusb there is no synchronization yet. this is a followup and needs to be decided
         // so far, sessionsClient has direct access to sessionBackground
@@ -36,6 +36,7 @@ export class NodeUsbTransport extends AbstractApiTransport {
                 logger,
             }),
             sessionsClient,
+            signal,
         });
     }
 }

--- a/packages/transport/src/transports/udp.ts
+++ b/packages/transport/src/transports/udp.ts
@@ -9,9 +9,9 @@ import { SessionsBackground } from '../sessions/background';
 export class UdpTransport extends AbstractApiTransport {
     public name = 'UdpTransport' as const;
 
-    constructor(params?: AbstractTransportParams) {
-        const { messages, logger } = params || {};
-        const sessionsBackground = new SessionsBackground();
+    constructor(params: AbstractTransportParams) {
+        const { messages, logger, signal } = params;
+        const sessionsBackground = new SessionsBackground({ signal });
 
         // in udp there is no synchronization yet. it depends where this transport runs (node or browser)
         const sessionsClient = new SessionsClient({
@@ -28,6 +28,7 @@ export class UdpTransport extends AbstractApiTransport {
             api: new UdpApi({ logger }),
             logger,
             sessionsClient,
+            signal,
         });
 
         const enumerateRecursive = () => {

--- a/packages/transport/src/transports/webusb.browser.ts
+++ b/packages/transport/src/transports/webusb.browser.ts
@@ -13,8 +13,8 @@ import { initBackgroundInBrowser } from '../sessions/background-browser';
 export class WebUsbTransport extends AbstractApiTransport {
     public name = 'WebUsbTransport' as const;
 
-    constructor(params?: AbstractTransportParams) {
-        const { messages, logger } = params || {};
+    constructor(params: AbstractTransportParams) {
+        const { messages, logger, signal } = params;
         const { requestFn, registerBackgroundCallbacks } = initBackgroundInBrowser();
 
         super({
@@ -30,6 +30,7 @@ export class WebUsbTransport extends AbstractApiTransport {
                 requestFn,
                 registerBackgroundCallbacks,
             }),
+            signal,
         });
     }
 }

--- a/packages/transport/src/transports/webusb.ts
+++ b/packages/transport/src/transports/webusb.ts
@@ -7,7 +7,7 @@ import { empty, emptyAbortable, emptySync } from '../utils/resultEmpty';
 export class WebUsbTransport extends AbstractTransport {
     public name = 'WebUsbTransport' as const;
 
-    constructor(params?: AbstractTransportParams) {
+    constructor(params: AbstractTransportParams) {
         super(params);
         console.error(WRONG_ENVIRONMENT);
     }

--- a/packages/transport/tests/sessions.test.ts
+++ b/packages/transport/tests/sessions.test.ts
@@ -5,7 +5,8 @@ describe('sessions', () => {
     let requestFn: SessionsClient['request'];
 
     beforeEach(() => {
-        const background = new SessionsBackground();
+        const abortController = new AbortController();
+        const background = new SessionsBackground({ signal: abortController.signal });
         requestFn = params => background.handleMessage(params);
     });
 

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -16,7 +16,7 @@ const deviceType = Device.isDevice ? 'device' : 'emulator';
 const transportsPerDeviceType = {
     device: Platform.select({
         ios: ['BridgeTransport', 'UdpTransport'],
-        android: [new NativeUsbTransport()],
+        android: [NativeUsbTransport],
     }),
     emulator: ['BridgeTransport', 'UdpTransport'],
 } as const;


### PR DESCRIPTION
- [cf97b8d](https://github.com/trezor/trezor-suite/pull/12411/commits/cf97b8df95c5787eb7cecb3ecf7124ce70e9d80c) might be interesting for @Nodonisko or maybe @matejkriz. We don't really want to force implementors of connect, who need to pass a custom transport to call its constructor. so here I made changes that connect accepts transport class constructor instead of its instance. should be ok, tested it.
- other than that this is fixing `Jest did not exit one second after the test run has completed.` in `yarn workspace @trezor/transport test:unit` reported today by @szymonlesisz 

Followups: 

- pass abortController.signal from connect core to device list. This required slightly [more changes in core ](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/core/index.ts#L1035) so  I suggest doing it in a followup.
