### PR TITLE
Fix/transport stopped flag

### DIFF
--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -93,7 +93,7 @@ export abstract class AbstractTransport extends TypedEmitter<{
     /**
      * once transport has been stopped, it does not emit any events
      */
-    protected stopped = false;
+    protected stopped = true;
     /**
      * once transport is listening, it will be emitting TRANSPORT.UPDATE events
      */

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -119,7 +119,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                 const openDeviceResult = await this.api.openDevice(path, reset);
 
                 if (!openDeviceResult.success) {
-                    if (this.listenPromise) {
+                    if (this.listenPromise[path]) {
                         this.listenPromise[path].resolve(openDeviceResult);
                     }
 

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -36,6 +36,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
     public init() {
         return this.scheduleAction(async () => {
             const handshakeRes = await this.sessionsClient.handshake();
+            this.stopped = !handshakeRes.success;
 
             return handshakeRes.success
                 ? this.success(undefined)

--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -95,6 +95,8 @@ export class BridgeTransport extends AbstractTransport {
                 this.isOutdated = versionUtils.isNewer(this.latestVersion, this.version);
             }
 
+            this.stopped = false;
+
             return this.success(undefined);
         });
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Based on https://github.com/trezor/trezor-suite/pull/12422

- Transport should be stopped before calling Transport.init or in case when Transport.init throws error
- AbstractApiTransport.acquire listenPromise condition check
