### PR TITLE
ci(gihtub): fix typo in bash script to check versions

### DIFF
--- a/.github/workflows/release-connect-v9-staging.yml
+++ b/.github/workflows/release-connect-v9-staging.yml
@@ -45,6 +45,7 @@ jobs:
             exit 1 # Fail the job if versions don't match
           else
             echo "Version check passed: $BRANCH_VERSION matches $EXTRACTED_VERSION"
+          fi
 
   # This job deploys to staging-connect.trezor.io/9.x.x
   deploy-staging-semantic-version:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Missing `fi` at then end of `if ... else ... fi` statement in bash script to check that version in the branch is same as version in package.json.