### PR TITLE
feat(suite-native): delete view only feature flag completely

### DIFF
--- a/suite-native/device/tsconfig.json
+++ b/suite-native/device/tsconfig.json
@@ -2,9 +2,7 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
-        {
-            "path": "../../suite-common/icons"
-        },
+        { "path": "../../suite-common/icons" },
         {
             "path": "../../suite-common/redux-utils"
         },

--- a/suite-native/feature-flags/src/featureFlagsSlice.ts
+++ b/suite-native/feature-flags/src/featureFlagsSlice.ts
@@ -6,7 +6,6 @@ import { isDebugEnv, isDetoxTestBuild, isDevelopOrDebugEnv } from '@suite-native
 export const FeatureFlag = {
     IsDeviceConnectEnabled: 'isDeviceConnectEnabled',
     IsPassphraseEnabled: 'isPassphraseEnabled',
-    IsViewOnlyEnabled: 'isViewOnlyEnabled',
     IsSendEnabled: 'isSendEnabled',
     IsRegtestEnabled: 'isRegtestEnabled',
 } as const;
@@ -21,7 +20,6 @@ export type FeatureFlagsRootState = {
 export const featureFlagsInitialState: FeatureFlagsState = {
     [FeatureFlag.IsDeviceConnectEnabled]: isAndroid() || isDebugEnv(),
     [FeatureFlag.IsPassphraseEnabled]: isDebugEnv(),
-    [FeatureFlag.IsViewOnlyEnabled]: isDebugEnv(),
     [FeatureFlag.IsSendEnabled]: isAndroid() && isDevelopOrDebugEnv(),
     [FeatureFlag.IsRegtestEnabled]: isDebugEnv() || isDetoxTestBuild(),
 };
@@ -29,7 +27,6 @@ export const featureFlagsInitialState: FeatureFlagsState = {
 export const featureFlagsPersistedKeys: Array<keyof FeatureFlagsState> = [
     FeatureFlag.IsDeviceConnectEnabled,
     FeatureFlag.IsPassphraseEnabled,
-    FeatureFlag.IsViewOnlyEnabled,
     FeatureFlag.IsSendEnabled,
     FeatureFlag.IsRegtestEnabled,
 ];

--- a/suite-native/module-dev-utils/src/components/FeatureFlags.tsx
+++ b/suite-native/module-dev-utils/src/components/FeatureFlags.tsx
@@ -4,7 +4,6 @@ import { FeatureFlag as FeatureFlagEnum, useFeatureFlag } from '@suite-native/fe
 const featureFlagsTitleMap = {
     [FeatureFlagEnum.IsDeviceConnectEnabled]: 'Connect device',
     [FeatureFlagEnum.IsPassphraseEnabled]: 'Passphrase',
-    [FeatureFlagEnum.IsViewOnlyEnabled]: 'View-only',
     [FeatureFlagEnum.IsSendEnabled]: 'Send',
     [FeatureFlagEnum.IsRegtestEnabled]: 'Regtest',
 } as const satisfies Record<FeatureFlagEnum, string>;

--- a/suite-native/module-home/src/screens/HomeScreen/components/EnableViewOnlyBottomSheet.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/EnableViewOnlyBottomSheet.tsx
@@ -20,7 +20,6 @@ import {
     selectViewOnlyCancelationTimestamp,
     setViewOnlyCancelationTimestamp,
 } from '@suite-native/settings';
-import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
 import { useToast } from '@suite-native/toasts';
 
 import { DisconnectedTrezorSvg } from '../../../assets/DisconnectedTrezorSvg';
@@ -40,7 +39,6 @@ const buttonWrapperStyle = prepareNativeStyle(utils => ({
 export const EnableViewOnlyBottomSheet = () => {
     const dispatch = useDispatch();
     const { applyStyle } = useNativeStyles();
-    const [isViewOnlyModeFeatureEnabled] = useFeatureFlag(FeatureFlag.IsViewOnlyEnabled);
     const { isBiometricsInitialSetupFinished } = useIsBiometricsInitialSetupFinished();
     const isDeviceReadyToUseAndAuthorized = useSelector(selectIsDeviceReadyToUseAndAuthorized);
     const device = useSelector(selectDevice);
@@ -69,7 +67,6 @@ export const EnableViewOnlyBottomSheet = () => {
     //     and biometrics initial setup was decided or biometrics is not available
 
     const canBeShowed =
-        isViewOnlyModeFeatureEnabled &&
         !isDeviceRemembered &&
         isDeviceReadyToUseAndAuthorized &&
         !isPortfolioTrackerDevice &&

--- a/suite-native/module-settings/src/components/ApplicationSettings.tsx
+++ b/suite-native/module-settings/src/components/ApplicationSettings.tsx
@@ -1,7 +1,6 @@
 import { useNavigation } from '@react-navigation/core';
 import { useAtomValue } from 'jotai';
 
-import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
 import {
     SettingsStackRoutes,
     SettingsStackParamList,
@@ -16,7 +15,6 @@ import { isDevButtonVisibleAtom } from './ProductionDebug';
 
 export const ApplicationSettings = () => {
     const isDevButtonVisible = useAtomValue(isDevButtonVisibleAtom);
-    const [isViewOnlyFeatureEnabled] = useFeatureFlag(FeatureFlag.IsViewOnlyEnabled);
 
     const navigation =
         useNavigation<
@@ -59,14 +57,12 @@ export const ApplicationSettings = () => {
                 subtitle="Analytics, Discreet mode, Biometrics"
                 onPress={() => handleNavigation(SettingsStackRoutes.SettingsPrivacyAndSecurity)}
             />
-            {isViewOnlyFeatureEnabled && (
-                <SettingsSectionItem
-                    title="View-only"
-                    iconName="bookmark"
-                    subtitle="Check balances without your Trezor"
-                    onPress={() => handleNavigation(SettingsStackRoutes.SettingsViewOnly)}
-                />
-            )}
+            <SettingsSectionItem
+                title="View-only"
+                iconName="bookmark"
+                subtitle="Check balances without your Trezor"
+                onPress={() => handleNavigation(SettingsStackRoutes.SettingsViewOnly)}
+            />
         </SettingsSection>
     );
 };

--- a/suite-native/receive/package.json
+++ b/suite-native/receive/package.json
@@ -27,7 +27,6 @@
         "@suite-native/device-manager": "workspace:*",
         "@suite-native/device-mutex": "workspace:*",
         "@suite-native/ethereum-tokens": "workspace:*",
-        "@suite-native/feature-flags": "workspace:*",
         "@suite-native/formatters": "workspace:*",
         "@suite-native/helpers": "workspace:*",
         "@suite-native/intl": "workspace:*",

--- a/suite-native/receive/src/components/ReceiveAddressCard.tsx
+++ b/suite-native/receive/src/components/ReceiveAddressCard.tsx
@@ -9,7 +9,6 @@ import {
     selectIsPortfolioTrackerDevice,
 } from '@suite-common/wallet-core';
 import { Translation } from '@suite-native/intl';
-import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
 
 import { UnverifiedAddress } from './UnverifiedAddress';
 
@@ -33,17 +32,10 @@ export const ReceiveAddressCard = ({
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const isDeviceInViewOnlyMode = useSelector(selectIsDeviceInViewOnlyMode);
 
-    const [isViewOnlyFeatureEnabled] = useFeatureFlag(FeatureFlag.IsViewOnlyEnabled);
-
     const { networkType } = networks[networkSymbol];
 
     const getCardAlertProps = () => {
-        if (
-            isReceiveApproved &&
-            !isPortfolioTrackerDevice &&
-            !isDeviceInViewOnlyMode &&
-            !isViewOnlyFeatureEnabled
-        ) {
+        if (isReceiveApproved && !isPortfolioTrackerDevice && !isDeviceInViewOnlyMode) {
             return {
                 alertTitle: <Translation id="moduleReceive.receiveAddressCard.alert.success" />,
                 alertVariant: 'success',

--- a/suite-native/receive/src/components/ShowAddressButtons.tsx
+++ b/suite-native/receive/src/components/ShowAddressButtons.tsx
@@ -8,7 +8,6 @@ import {
     selectIsDeviceInViewOnlyMode,
     selectIsPortfolioTrackerDevice,
 } from '@suite-common/wallet-core';
-import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
 
 import { ShowAddressViewOnlyBottomSheet } from './ShowAddressViewOnlyBottomSheet';
 
@@ -22,8 +21,6 @@ export const ShowAddressButtons = ({ onShowAddress }: ShowAddressButtonsProps) =
 
     const openLink = useOpenLink();
 
-    const [isViewOnlyFeatureEnabled] = useFeatureFlag(FeatureFlag.IsViewOnlyEnabled);
-
     const [isViewOnlyBottomSheetVisible, setIsViewOnlyBottomSheetVisible] = useState(false);
 
     const handleOpenEduLink = () => {
@@ -31,7 +28,7 @@ export const ShowAddressButtons = ({ onShowAddress }: ShowAddressButtonsProps) =
     };
 
     const handleShowAddress = () => {
-        if (isViewOnlyFeatureEnabled && isDeviceInViewOnlyMode) {
+        if (isDeviceInViewOnlyMode) {
             setIsViewOnlyBottomSheetVisible(true);
         } else {
             onShowAddress();

--- a/suite-native/receive/src/hooks/useAccountReceiveAddress.tsx
+++ b/suite-native/receive/src/hooks/useAccountReceiveAddress.tsx
@@ -22,7 +22,6 @@ import { analytics, EventType } from '@suite-native/analytics';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import { useToast } from '@suite-native/toasts';
 import { Translation } from '@suite-native/intl';
-import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
 
 export const useAccountReceiveAddress = (accountKey: AccountKey) => {
     const dispatch = useDispatch();
@@ -31,7 +30,6 @@ export const useAccountReceiveAddress = (accountKey: AccountKey) => {
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const isDeviceInViewOnlyMode = useSelector(selectIsDeviceInViewOnlyMode);
     const navigation = useNavigation();
-    const [isViewOnlyFeatureEnabled] = useFeatureFlag(FeatureFlag.IsViewOnlyEnabled);
 
     const { showToast } = useToast();
 
@@ -134,7 +132,7 @@ export const useAccountReceiveAddress = (accountKey: AccountKey) => {
                 });
                 setIsReceiveApproved(true);
             }
-        } else if (isDeviceInViewOnlyMode && isViewOnlyFeatureEnabled) {
+        } else if (isDeviceInViewOnlyMode) {
             // If device is remembered,
             // no verification should happen and we display the receive address straight away.
             setIsUnverifiedAddressRevealed(true);
@@ -150,13 +148,7 @@ export const useAccountReceiveAddress = (accountKey: AccountKey) => {
                 setIsUnverifiedAddressRevealed(false);
             }
         }
-    }, [
-        isDeviceInViewOnlyMode,
-        isPortfolioTrackerDevice,
-        isViewOnlyFeatureEnabled,
-        networkSymbol,
-        verifyAddressOnDevice,
-    ]);
+    }, [isDeviceInViewOnlyMode, isPortfolioTrackerDevice, networkSymbol, verifyAddressOnDevice]);
 
     return {
         address: freshAddress?.address,

--- a/suite-native/receive/tsconfig.json
+++ b/suite-native/receive/tsconfig.json
@@ -22,7 +22,6 @@
         { "path": "../device-manager" },
         { "path": "../device-mutex" },
         { "path": "../ethereum-tokens" },
-        { "path": "../feature-flags" },
         { "path": "../formatters" },
         { "path": "../helpers" },
         { "path": "../intl" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9803,7 +9803,6 @@ __metadata:
     "@suite-native/device-manager": "workspace:*"
     "@suite-native/device-mutex": "workspace:*"
     "@suite-native/ethereum-tokens": "workspace:*"
-    "@suite-native/feature-flags": "workspace:*"
     "@suite-native/formatters": "workspace:*"
     "@suite-native/helpers": "workspace:*"
     "@suite-native/intl": "workspace:*"


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

It is no more needed, and by this change it is also removed from persist store.

Acceptance criteria for **QA**:
- View only feature is now turned on for everyone, even for those updating from 24.4 version

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/12013

