### PR TITLE
feat(fiat-services): prevent duplicate parallel requests -> speed up Suite loading

### DIFF
--- a/suite-common/fiat-services/src/cache.ts
+++ b/suite-common/fiat-services/src/cache.ts
@@ -1,0 +1,29 @@
+import { Deferred, createDeferred } from '@trezor/utils';
+
+// Cache for parallel requests
+// It's used to prevent multiple requests for the same data
+export class ParallelRequestsCache {
+    private promises: Record<string, Deferred<any>> = {};
+
+    async cache<T>(keys: (string | number | undefined)[], fn: () => Promise<T>): Promise<T> {
+        const key = keys.join('-');
+        if (this.promises[key]) {
+            // Cache hit
+            return this.promises[key].promise;
+        }
+
+        this.promises[key] = createDeferred();
+        try {
+            const res = await fn();
+            this.promises[key].resolve(res);
+            delete this.promises[key];
+
+            return res;
+        } catch (error) {
+            this.promises[key].reject(error);
+            delete this.promises[key];
+
+            throw error;
+        }
+    }
+}


### PR DESCRIPTION
## Description

I noticed that the QA wallet with all accounts enabled is loading very slowly when opening Suite, about 1m20s.
This is mostly due to loading fiat rates during account discovery.
However, it seems that a lot of the requests are duplicated, which is unnecessary and slows down the loading process.

To resolve this, the PR adds `ParallelRequestsCache`, a class which uses Deferreds to prevent duplicate requests.
To use it, the function is wrapped in `ParallelRequestsCache.cache` with the first argument being the key for the request.
This is applied to all fiat rate functions - `fetchCurrentFiatRates`, `fetchLastWeekFiatRates`, and `getFiatRatesForTimestamps`.

From my tests this cuts down the loading time to about 30-40 seconds, so approximately in half. 