### PR TITLE
Handle conversion of non-checksummed eth address

### DIFF
--- a/packages/components/src/components/form/BottomText.tsx
+++ b/packages/components/src/components/form/BottomText.tsx
@@ -10,14 +10,14 @@ import { InputState } from './inputTypes';
 export const BOTTOM_TEXT_MIN_HEIGHT = 26; // 1 line of text + top padding
 
 const slideDown = keyframes`
-    from {
-        opacity: 0;
-        transform: translateY(-2px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
+from {
+    opacity: 0;
+    transform: translateY(-2px);
+}
+to {
+    opacity: 1;
+    transform: translateY(0);
+}
 `;
 
 export const Container = styled.div<{ $inputState?: InputState; $isDisabled?: boolean }>`
@@ -36,25 +36,31 @@ interface BottomTextProps {
     inputState?: InputState;
     isDisabled?: boolean;
     icon?: IconName;
+    withIcon?: boolean;
     children: ReactNode;
 }
-
 export const BottomText = ({
     inputState,
     isDisabled,
-    icon = 'warningCircle',
     children,
+    icon,
+    withIcon,
 }: BottomTextProps) => {
     const theme = useTheme();
+    const iconMap = {
+        error: 'warningCircle',
+        warning: 'warningCircle',
+    } as const satisfies Record<InputState, IconName>;
 
     const iconColor: Color | CSSColor = isDisabled
         ? 'iconDisabled'
         : getInputStateTextColor(inputState, theme);
 
+    const iconName = icon || (inputState && iconMap[inputState]);
+
     return (
         <Container $inputState={inputState} $isDisabled={isDisabled}>
-            {icon && <Icon name={icon} size="medium" color={iconColor} />}
-
+            {withIcon && iconName && <Icon name={iconName} size="medium" color={iconColor} />}
             {children}
         </Container>
     );

--- a/packages/components/src/components/form/Input/Input.tsx
+++ b/packages/components/src/components/form/Input/Input.tsx
@@ -203,7 +203,11 @@ const Input = ({
             </InputWrapper>
 
             {bottomText && (
-                <BottomText inputState={inputState} isDisabled={isDisabled}>
+                <BottomText
+                    withIcon={inputState && ['error', 'warning'].includes(inputState)}
+                    inputState={inputState}
+                    isDisabled={isDisabled}
+                >
                     {bottomText}
                 </BottomText>
             )}

--- a/packages/suite/src/components/wallet/InputChecksumInfo.tsx
+++ b/packages/suite/src/components/wallet/InputChecksumInfo.tsx
@@ -1,0 +1,75 @@
+import styled, { css } from 'styled-components';
+import { useTheme } from 'styled-components';
+import { TooltipSymbol } from '../suite';
+import { spacingsPx, borders } from '@trezor/theme';
+import { TranslationKey, Translation } from '../suite/Translation';
+import { useTranslation } from 'src/hooks/suite';
+import { Icon } from '@suite-common/icons/src/webComponents';
+
+const Wrapper = styled.div`
+    display: flex;
+    align-items: center;
+    gap: ${spacingsPx.xs};
+    width: 100%;
+    justify-content: space-between;
+    background-color: ${({ theme }) => theme.backgroundAlertBlueSubtleOnElevation1};
+    border-radius: ${borders.radii.xxs};
+    position: relative;
+    margin: ${spacingsPx.xxs} 0 ${spacingsPx.sm} 0;
+    padding: ${spacingsPx.xs} ${spacingsPx.sm};
+    ${({ theme }) => css`
+        ::before {
+            content: '';
+            position: absolute;
+            top: -${spacingsPx.xs};
+            left: 20px;
+            transform: translateX(-50%);
+            width: 0;
+            height: 0;
+            border-left: 8px solid transparent;
+            border-right: 8px solid transparent;
+            border-bottom: 8px solid ${theme.backgroundAlertBlueSubtleOnElevation1};
+        }
+    `};
+`;
+
+const Container = styled.div`
+    display: flex;
+    flex-direction: row;
+    margin: 0;
+    padding: 0;
+`;
+
+export const Divider = styled.div`
+    height: inherit;
+    align-self: stretch;
+    width: 2px;
+    background-color: ${({ theme }) => theme.backgroundSurfaceElevation1};
+    margin: -${spacingsPx.xs} ${spacingsPx.xs};
+`;
+
+interface InputChecksumInfoProps {
+    message?: TranslationKey;
+    tooltipContent?: TranslationKey;
+}
+export const InputChecksumInfo = ({ message, tooltipContent }: InputChecksumInfoProps) => {
+    const { translationString } = useTranslation();
+    const theme = useTheme();
+
+    return (
+        <Wrapper>
+            <Container>
+                <Icon name="doubleCheck" size="medium" color={theme.textAlertBlue} />
+                <Divider />
+                {message && <Translation id={message} />}
+            </Container>
+            {tooltipContent && (
+                <TooltipSymbol
+                    content={translationString(tooltipContent)}
+                    iconColor={theme.textAlertBlue}
+                    icon="QUESTION_FILLED"
+                />
+            )}
+        </Wrapper>
+    );
+};

--- a/packages/suite/src/components/wallet/index.tsx
+++ b/packages/suite/src/components/wallet/index.tsx
@@ -1,6 +1,7 @@
 import { WalletLayout } from './WalletLayout/WalletLayout';
 import { WalletSubpageHeading } from './WalletLayout/WalletSubpageHeading';
 import { InputError } from './InputError';
+import { InputChecksumInfo } from './InputChecksumInfo';
 import { AccountExceptionLayout } from './AccountExceptionLayout';
 import { DiscoveryProgress } from './DiscoveryProgress';
 import { UtxoAnonymity } from './UtxoAnonymity';
@@ -16,6 +17,7 @@ export {
     DiscoveryProgress,
     withSelectedAccountLoaded,
     InputError,
+    InputChecksumInfo,
     AccountExceptionLayout,
     UtxoAnonymity,
     Pagination,

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2016,6 +2016,10 @@ export default defineMessages({
         description: 'Placeholder in seed input asking user to pay attention to his device',
         id: 'TR_CHECK_YOUR_DEVICE',
     },
+    TR_CHECKSUM_CONVERSION_INFO: {
+        defaultMessage: 'Converted to checksum',
+        id: 'TR_CHECKSUM_CONVERSION_INFO',
+    },
     TR_CLEAR_ALL: {
         defaultMessage: 'Clear all',
         description: 'Clear form button',
@@ -2186,6 +2190,18 @@ export default defineMessages({
     TR_EDIT: {
         defaultMessage: 'Edit',
         id: 'TR_EDIT',
+    },
+    TR_ETH_ADDRESS_CHECKSUMMED_INFO: {
+        defaultMessage: 'Your address was automatically checksummed. Learn more...',
+        id: 'TR_ETH_ADDRESS_CHECKSUMMED_INFO',
+    },
+    TR_ETH_ADDRESS_CONVERTED_CHECKSUM: {
+        defaultMessage: 'Address converted to checksum format.',
+        id: 'TR_ETH_ADDRESS_CONVERTED_CHECKSUM',
+    },
+    TR_ETH_ADDRESS_NOT_USED_NOT_CHECKSUMMED: {
+        defaultMessage: 'Your address was not used and is not checksummed, please double-check.',
+        id: 'TR_ETH_ADDRESS_NOT_USED_NOT_CHECKSUMMED',
     },
     TR_NEEDS_ATTENTION_BOOTLOADER: {
         defaultMessage: 'Trezor is in Bootloader mode.',

--- a/suite-common/icons/assets/icons/doubleCheck.svg
+++ b/suite-common/icons/assets/icons/doubleCheck.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16">
+  <path stroke="#171717" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m9.25 5.25-5.5 5.5L1 8m14-2.75-5.5 5.5-1.463-1.463"/>
+</svg>

--- a/suite-common/icons/assets/icons/info.svg
+++ b/suite-common/icons/assets/icons/info.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" fill="none" viewBox="0 0 16 16">
-  <path stroke="#0078AC" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M8 14A6 6 0 1 0 8 2a6 6 0 0 0 0 12"/>
-  <path stroke="#0078AC" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M7.5 7.5H8V11h.5"/>
-  <path fill="#1F83AD" d="M7.95 5.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5"/>
+  <path stroke="#171717" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M8 14A6 6 0 1 0 8 2a6 6 0 0 0 0 12"/>
+  <path stroke="#171717" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M7.5 7.5H8V11h.5"/>
+  <path fill="#171717" d="M7.95 5.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5"/>
 </svg>

--- a/suite-common/icons/src/icons.ts
+++ b/suite-common/icons/src/icons.ts
@@ -37,6 +37,7 @@ export const icons = {
     database: require('../assets/icons/database.svg'),
     detective: require('../assets/icons/detective.svg'),
     discover: require('../assets/icons/discover.svg'),
+    doubleCheck: require('../assets/icons/doubleCheck.svg'),
     eject: require('../assets/icons/eject.svg'),
     externalLink: require('../assets/icons/externalLink.svg'),
     eye: require('../assets/icons/eye.svg'),


### PR DESCRIPTION
## Description

Based on the conversation in the issue, I've decided to do the following:

1. Check whether the address is a valid ethereum address (already implemented)
2. Check whether the address is used via blockbook
    a. If the address is used but unchecksummed or incorrectly checksummed, then Suite will automatically convert the address to the correct checksummed form and inform the user:
![image](https://github.com/trezor/trezor-suite/assets/101045932/5002cde6-56b0-4054-8f0c-2e584798a6e1)
    b. if the address haven't been used yet and is not checksummed at all, offer to checksum with a button:
![image](https://github.com/trezor/trezor-suite/assets/101045932/4cf4eda2-f1d1-4992-a468-a8e9d2060a81)


...WOP

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/7407

