### PR TITLE
fix(mobile): fix graph old value on timeframe switch

### DIFF
--- a/suite-native/react-native-graph/src/AnimatedLineGraph.tsx
+++ b/suite-native/react-native-graph/src/AnimatedLineGraph.tsx
@@ -420,7 +420,7 @@ export function AnimatedLineGraph<TEventPayload extends object>({
     useAnimatedReaction(
         () => x.value,
         fingerX => {
-            if (!loading && (isActive.value || fingerX)) {
+            if (!loading && isActive.value && fingerX) {
                 setFingerX(fingerX);
                 runOnJS(setFingerPoint)(fingerX);
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`onPointSelected` callback was called everytime when `loading` was switched to `false` (ended) which is incorrect behavior.

## Related Issue

Resolve #11231 

## Screenshots:
