### PR TITLE
chore(suite-native): longer timeout for test

### DIFF
--- a/suite-native/app/e2e/tests/onboardAndConnect.test.ts
+++ b/suite-native/app/e2e/tests/onboardAndConnect.test.ts
@@ -40,7 +40,7 @@ describe('Go through onboarding and connect Trezor.', () => {
 
             await waitFor(element(by.id('skip-view-only-mode')))
                 .toBeVisible()
-                .withTimeout(10000); // communication between connected Trezor and app takes some time.
+                .withTimeout(20000); // communication between connected Trezor and app takes some time.
 
             await element(by.id('skip-view-only-mode')).tap();
 


### PR DESCRIPTION
Prolong timeout for skiping view only banner in test

Resolve #12464