### PR TITLE
chore(connect): fw-update: add error message when binary is too small

### DIFF
--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -202,17 +202,27 @@ const getBinaryHelper = (
         version: device.firmwareRelease.release.version,
         btcOnly,
         intermediaryVersion,
-    }).then(res => {
-        postMessage(
-            createUiMessage(UI.FIRMWARE_PROGRESS, {
-                device: device.toMessageObject(),
-                operation: 'downloading',
-                progress: 100,
-            }),
-        );
+    })
+        .then(res => {
+            // suspiciously small binary. this typically happens when build does not have git lfs enabled and all
+            // you download here are some pointers to lfs objects which are around ~132 byteLength
+            if (res.byteLength < 200) {
+                throw ERRORS.TypedError('Runtime', 'Firmware binary is too small');
+            }
 
-        return res;
-    });
+            return res;
+        })
+        .then(res => {
+            postMessage(
+                createUiMessage(UI.FIRMWARE_PROGRESS, {
+                    device: device.toMessageObject(),
+                    operation: 'downloading',
+                    progress: 100,
+                }),
+            );
+
+            return res;
+        });
 };
 
 const firmwareCheck = async (


### PR DESCRIPTION
opening this instead of https://github.com/trezor/trezor-suite/pull/12440
the goal is to give a more descriptive error in case connect downloads something which is apparently not a valid firmware. In that case it doesn't make sense to send this invalid binary into the device. Also since we decided not to make fw update possible in feature branches, I believe it will be useful to find out whats going on when QA reports this "bug" in the future. 

![image](https://github.com/trezor/trezor-suite/assets/30367552/a246dfc8-0cf3-4924-a61b-fd18cd98f0de)
