### PR TITLE
chore(suite-desktop): bridge log for node-bridge in suite-desktop

### DIFF
--- a/packages/node-utils/src/tests/http.test.ts
+++ b/packages/node-utils/src/tests/http.test.ts
@@ -14,6 +14,7 @@ describe('HttpServer', () => {
     let server: HttpServer<Events>;
     beforeEach(() => {
         server = new HttpServer<Events>({
+            // @ts-expect-error
             logger: muteLogger,
         });
     });
@@ -45,6 +46,7 @@ describe('HttpServer', () => {
     });
 
     test('a port can be passed to the constructor', async () => {
+        // @ts-expect-error
         server = new HttpServer<Events>({ logger: muteLogger, port: 65526 });
         await server.start();
         expect(server.getServerAddress()).toMatchObject({
@@ -119,10 +121,7 @@ describe('HttpServer', () => {
         await new Promise(resolve => setTimeout(resolve, 500));
         controller.abort();
         await new Promise(resolve => setTimeout(resolve, 500));
-        expect(muteLogger.info).toHaveBeenLastCalledWith(
-            expect.any(String),
-            'Request GET /foo aborted',
-        );
+        expect(muteLogger.info).toHaveBeenLastCalledWith('Request GET /foo aborted');
     });
 
     test('allowReferer middleware lets request with allowed referer through', async () => {

--- a/packages/suite-desktop-core/src/index.d.ts
+++ b/packages/suite-desktop-core/src/index.d.ts
@@ -1,6 +1,13 @@
 // Include suite globals (as some dependencies from @suite can rely on them)
 /// <reference path="../../suite/global.d.ts" />
 
+type LogMessage = {
+    date: Date;
+    level: LogLevel;
+    topic: string;
+    text: string;
+};
+
 declare interface ILogger {
     /**
      * Exit the Logger (will correctly end the log file)
@@ -48,6 +55,10 @@ declare interface ILogger {
      * @param options(Partial<Options>) - Log options
      */
     config;
+    /**
+     * If logs are stored in memory, return array of logs
+     */
+    getLog: () => LogMessage[];
 }
 
 // Globals

--- a/packages/suite-desktop-core/src/libs/http-receiver.ts
+++ b/packages/suite-desktop-core/src/libs/http-receiver.ts
@@ -4,6 +4,7 @@ import { xssFilters } from '@trezor/utils';
 import { HttpServer, allowReferers } from '@trezor/node-utils';
 
 import { HTTP_ORIGINS_DEFAULT } from './constants';
+import { convertILoggerToLog } from '../utils/IloggerToLog';
 
 type TemplateOptions = {
     title?: string;
@@ -38,7 +39,10 @@ const applyTemplate = (content: string, options?: TemplateOptions) => {
 };
 
 export const createHttpReceiver = () => {
-    const httpReceiver = new HttpServer<Events>({ logger: global.logger, port: 21335 });
+    const httpReceiver = new HttpServer<Events>({
+        logger: convertILoggerToLog(global.logger, { serviceName: 'http-receiver' }),
+        port: 21335,
+    });
 
     httpReceiver.use([
         (request, response, next) => {

--- a/packages/suite-desktop-core/src/modules/bridge.ts
+++ b/packages/suite-desktop-core/src/modules/bridge.ts
@@ -6,6 +6,8 @@ import { TrezordNode } from '@trezor/transport-bridge';
 import { app, ipcMain } from '../typed-electron';
 import { BridgeProcess } from '../libs/processes/BridgeProcess';
 import { b2t } from '../libs/utils';
+import { Logger } from '../libs/logger';
+import { convertILoggerToLog } from '../utils/IloggerToLog';
 
 import type { Module, Dependencies } from './index';
 
@@ -53,20 +55,17 @@ const getBridgeInstance = (store: Dependencies['store']) => {
         return new BridgeProcess();
     }
 
+    const bridgeLogger = new Logger('info', {
+        writeToDisk: false,
+        writeToMemory: true,
+    });
+
     return new TrezordNode({
         port: 21325,
         api: bridgeDev || bridgeTest ? 'udp' : 'usb',
         assetPrefix: '../build/node-bridge',
         // passing down ILogger where Log is expected.
-        // @ts-expect-error
-        logger: {
-            ...global.logger,
-            log: (...args) => logger.info('trezord-node', args.join(' ')),
-            info: (...args) => logger.info('trezord-node', args.join(' ')),
-            warn: (...args) => logger.warn('trezord-node', args.join(' ')),
-            debug: (...args) => logger.debug('trezord-node', args.join(' ')),
-            error: (...args) => logger.error('trezord-node', args.join(' ')),
-        },
+        logger: convertILoggerToLog(bridgeLogger, { serviceName: 'trezord-node' }),
     });
 };
 

--- a/packages/suite-desktop-core/src/modules/bridge.ts
+++ b/packages/suite-desktop-core/src/modules/bridge.ts
@@ -138,7 +138,7 @@ const load = async ({ store, mainWindow }: Dependencies) => {
     try {
         logger.info(
             SERVICE_NAME,
-            `Starting (Legacy dev: ${b2t(bridgeLegacyDev)}), Legacy test: ${b2t(bridgeLegacyTest)}), Legacy: ${b2t(bridgeLegacy)}, Test: ${b2t(bridgeTest)}`,
+            `Starting (Legacy dev: ${b2t(bridgeLegacyDev)}, Legacy test: ${b2t(bridgeLegacyTest)}, Legacy: ${b2t(bridgeLegacy)}, Test: ${b2t(bridgeTest)})`,
         );
         await start(bridge);
         handleBridgeStatus(bridge, mainWindow);

--- a/packages/suite-desktop-core/src/utils/IloggerToLog.ts
+++ b/packages/suite-desktop-core/src/utils/IloggerToLog.ts
@@ -1,0 +1,32 @@
+import { Log, LogMessage as UtilsLogMessage } from '@trezor/utils';
+
+/** take an instance of ILogger and return mimicked instance of Log while keeping more or less the same behavior  */
+export const convertILoggerToLog = (
+    iLogger: ILogger,
+    { serviceName }: { serviceName: string },
+): Log => {
+    return {
+        log: (msg: string) => iLogger.info(serviceName, msg),
+        info: (msg: string) => iLogger.info(serviceName, msg),
+        debug: (msg: string) => iLogger.debug(serviceName, msg),
+        warn: (msg: string) => iLogger.warn(serviceName, msg),
+        error: (msg: string) => iLogger.error(serviceName, msg),
+        prefix: '',
+        messages: [],
+        enabled: true,
+        css: '',
+        MAX_ENTRIES: 1000,
+        setColors: (_colors: any) => {},
+        setWriter: (_logWriter: any) => {},
+        addMessage: (_msg: UtilsLogMessage) => {},
+        logWriter: undefined,
+        getLog: (): UtilsLogMessage[] => {
+            return iLogger.getLog().map(log => ({
+                message: [log.text],
+                prefix: '',
+                level: log.level,
+                timestamp: log.date.getTime(),
+            }));
+        },
+    };
+};

--- a/packages/transport-bridge/src/bin.ts
+++ b/packages/transport-bridge/src/bin.ts
@@ -1,5 +1,11 @@
+import { Log } from '@trezor/utils';
+
 import { TrezordNode } from './http';
 
-const trezordNode = new TrezordNode({ port: 21325, api: 'usb' });
+const trezordNode = new TrezordNode({
+    port: 21325,
+    api: 'usb',
+    logger: new Log('@trezor/transport-bridge', true),
+});
 
 trezordNode.start();

--- a/packages/transport-bridge/src/http.ts
+++ b/packages/transport-bridge/src/http.ts
@@ -47,11 +47,10 @@ export class TrezordNode {
         port: number;
         api: 'usb' | 'udp';
         assetPrefix?: string;
-        logger?: Log;
+        logger: Log;
     }) {
         this.port = port || defaults.port;
-        this.logger = logger || new Log('@trezor/transport-bridge', true);
-
+        this.logger = logger;
         this.descriptors = [];
 
         this.listenSubscriptions = [];
@@ -271,7 +270,7 @@ export class TrezordNode {
                         intro: `To download full logs go to http://127.0.0.1:${this.port}/logs`,
                         version: this.version,
                         devices: enumerateResult.success ? enumerateResult.payload.descriptors : [],
-                        logs: app.logger.getLog().slice(-20),
+                        logs: this.logger.getLog().slice(-20),
                     };
 
                     res.end(str(props));


### PR DESCRIPTION
bridge when run by the suite-desktop app in production doesn't really log anything in the current implementation, as pointed out in https://github.com/trezor/trezor-suite/issues/12395

- [71dcd09](https://github.com/trezor/trezor-suite/pull/12476/commits/71dcd09f0a249decbbfe29bb6fca18d51e5ab7a4) gives desktop logger an option to save logs in memory only. 
- [0fe541f](https://github.com/trezor/trezor-suite/pull/12476/commits/0fe541f71ac5c037308d4aa40b57d6ed3c329f3a) 
  -  implements the previous commit for the bridge logger which always saves logs to its memory while keeping all other configuration as it was. 
  - this commit also adds a utility function to create a facade over `ILogger` instance and return shape matching with `Log`. This allows removing some code doing the same thing on multiple places (http-receiver, node-bride server).


fixes https://github.com/trezor/trezor-suite/issues/12395
