### PR TITLE
fix(suite-native): useEmptyPassphrase on undefined device instance

### DIFF
--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -70,7 +70,7 @@ const merge = (device: AcquiredDevice, upcoming: Partial<AcquiredDevice>): Trezo
 
 const getShouldUseEmptyPassphrase = (device: Device, deviceInstance?: number): boolean => {
     if (!device.features) return false;
-    if (isNative() && typeof deviceInstance === 'number' && deviceInstance === 1) {
+    if (isNative() && (!deviceInstance || deviceInstance === 1)) {
         // On mobile, if device has instance === 1, we always want to use empty passphrase since we
         // connect & authorize standard wallet by default. Other instances will have `usePassphraseProtection` set same way as web/desktop app.
         return true;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
After locking,  `features.passphrase_protection` returns `null`, which sets the `deviceInstance` to undefined, which results in settings `useEmptyPassphrase` to false, resulting in triggering the passphrase flow.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/12471

## Screenshots:
