### PR TITLE
fix(mobile): fix infinite loading of XRP

### DIFF
--- a/suite-common/transaction-cache-engine/package.json
+++ b/suite-common/transaction-cache-engine/package.json
@@ -14,6 +14,7 @@
         "@mobily/ts-belt": "^3.13.1",
         "@suite-common/wallet-config": "workspace:*",
         "@trezor/connect": "workspace:*",
+        "@trezor/utils": "workspace:*",
         "bignumber.js": "^9.1.2"
     }
 }

--- a/suite-common/transaction-cache-engine/src/tests/TransactionCacheEngine.test.ts
+++ b/suite-common/transaction-cache-engine/src/tests/TransactionCacheEngine.test.ts
@@ -36,6 +36,7 @@ describe('TransactionCacheEngine', () => {
         const engine = new TransactionCacheEngine({
             storage: new MemoryStorage(),
         });
+        await engine.init();
         const account: AccountUniqueParams = {
             coin: 'btc',
             descriptor: 'xpub',
@@ -51,6 +52,7 @@ describe('TransactionCacheEngine', () => {
         const engine = new TransactionCacheEngine({
             storage: new MemoryStorage(),
         });
+        await engine.init();
         const account: AccountUniqueParams = {
             coin: 'btc',
             descriptor: 'xpub',
@@ -67,6 +69,7 @@ describe('TransactionCacheEngine', () => {
         const engine = new TransactionCacheEngine({
             storage: new MemoryStorage(),
         });
+        await engine.init();
         const account: AccountUniqueParams = {
             coin: 'btc',
             descriptor: 'xpub',
@@ -87,6 +90,7 @@ describe('TransactionCacheEngine', () => {
         const engine = new TransactionCacheEngine({
             storage: new MemoryStorage(),
         });
+        await engine.init();
         const account: AccountUniqueParams = {
             coin: 'btc',
             descriptor: 'xpub',
@@ -108,6 +112,7 @@ describe('TransactionCacheEngine', () => {
         const engine = new TransactionCacheEngine({
             storage: new MemoryStorage(),
         });
+        await engine.init();
         const account: AccountUniqueParams = {
             coin: 'btc',
             descriptor: 'xpub',
@@ -124,6 +129,7 @@ describe('TransactionCacheEngine', () => {
         const engine = new TransactionCacheEngine({
             storage: new MemoryStorage(),
         });
+        await engine.init();
         const account: AccountUniqueParams = {
             coin: 'xrp',
             descriptor: 'xpub',

--- a/suite-common/transaction-cache-engine/tsconfig.json
+++ b/suite-common/transaction-cache-engine/tsconfig.json
@@ -7,6 +7,7 @@
     },
     "references": [
         { "path": "../wallet-config" },
-        { "path": "../../packages/connect" }
+        { "path": "../../packages/connect" },
+        { "path": "../../packages/utils" }
     ]
 }

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -36,6 +36,7 @@
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-constants": "workspace:*",
         "@suite-common/token-definitions": "workspace:*",
+        "@suite-common/transaction-cache-engine": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-native/accounts": "workspace:*",
         "@suite-native/alerts": "workspace:*",

--- a/suite-native/app/src/initActions.ts
+++ b/suite-native/app/src/initActions.ts
@@ -12,6 +12,7 @@ import { initMessageSystemThunk } from '@suite-common/message-system';
 import { wipeDisconnectedDevicesDataThunk } from '@suite-native/device';
 import { setIsAppReady, setIsConnectInitialized } from '@suite-native/state/src/appSlice';
 import { periodicCheckTokenDefinitionsThunk } from '@suite-common/token-definitions';
+import { TransactionCacheEngine } from '@suite-common/transaction-cache-engine';
 
 let isAlreadyInitialized = false;
 
@@ -31,6 +32,8 @@ export const applicationInit = createThunk(
             dispatch(initDevices());
 
             await dispatch(connectInitThunk());
+
+            TransactionCacheEngine.init();
 
             dispatch(setIsConnectInitialized(true));
 

--- a/suite-native/app/tsconfig.json
+++ b/suite-native/app/tsconfig.json
@@ -25,6 +25,9 @@
             "path": "../../suite-common/token-definitions"
         },
         {
+            "path": "../../suite-common/transaction-cache-engine"
+        },
+        {
             "path": "../../suite-common/wallet-core"
         },
         { "path": "../accounts" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8658,6 +8658,7 @@ __metadata:
     "@mobily/ts-belt": "npm:^3.13.1"
     "@suite-common/wallet-config": "workspace:*"
     "@trezor/connect": "workspace:*"
+    "@trezor/utils": "workspace:*"
     bignumber.js: "npm:^9.1.2"
   languageName: unknown
   linkType: soft
@@ -8868,6 +8869,7 @@ __metadata:
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-constants": "workspace:*"
     "@suite-common/token-definitions": "workspace:*"
+    "@suite-common/transaction-cache-engine": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-native/accounts": "workspace:*"
     "@suite-native/alerts": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This fixes one bug and one error:

1. After adding XRP account `TransactionCacheEngine.getAccountBalanceHistory` is called before `TransactionCacheEngine.addAccount` which will throw error but then it recovers so it did not affected users
2. After app is restarted TransactionCache will try to fetch transaction before connect init which will cause `TrezorConnect.getAccountInfo` to run forever (maybe bug in connect?)

## Related Issue

Resolve #12490

## Screenshots:
