### PR TITLE
ci(suite-native): upgrade setup-java e2e workflow

### DIFF
--- a/.github/workflows/test-suite-native-e2e-android.yml
+++ b/.github/workflows/test-suite-native-e2e-android.yml
@@ -38,7 +38,7 @@ jobs:
         run: yarn install
 
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 17


### PR DESCRIPTION
Fixes this: 
![image](https://github.com/trezor/trezor-suite/assets/26143964/4d869537-e805-4ab8-a9dc-3546d418e16b)

warning-less run: https://github.com/trezor/trezor-suite/actions/runs/9169728067