### PR TITLE
fix(connect): waiting for handshake

### DIFF
--- a/packages/connect-iframe/src/index.ts
+++ b/packages/connect-iframe/src/index.ts
@@ -93,6 +93,7 @@ const handleMessage = async (event: MessageEvent<CoreRequestMessage>) => {
             }
             // reassign to current MessagePort
             [_popupMessagePort] = event.ports;
+            _popupMessagePort.onmessage = message => handleMessage(message);
         }
 
         if (!_core) {
@@ -100,6 +101,9 @@ const handleMessage = async (event: MessageEvent<CoreRequestMessage>) => {
 
             return;
         }
+
+        // Handle immediately, before other logic
+        _core?.handleMessage({ type: POPUP.HANDSHAKE });
 
         const transport = _core.getTransportInfo();
         const settings = DataManager.getSettings();
@@ -143,6 +147,8 @@ const handleMessage = async (event: MessageEvent<CoreRequestMessage>) => {
                 transportVersion: transport?.version,
             },
         });
+
+        return;
     }
 
     // clear reference to popup MessagePort
@@ -308,7 +314,7 @@ const init = async (payload: IFrameInit['payload'], origin: string) => {
             _popupMessagePort = new BroadcastChannel(broadcastID);
             _popupMessagePort.onmessage = message => handleMessage(message);
         } catch (error) {
-            // tell the popup to use MessageChannel fallback communication (thru IFRAME.LOADED > POPUP.INIT)
+            // popup will use MessageChannel fallback communication
         }
     }
 

--- a/packages/connect-web/src/channels/window-window.ts
+++ b/packages/connect-web/src/channels/window-window.ts
@@ -26,7 +26,8 @@ export class WindowWindowChannel<
         channel,
         logger,
         origin,
-    }: Pick<AbstractMessageChannelConstructorParams, 'channel' | 'logger'> & {
+        legacyMode,
+    }: Pick<AbstractMessageChannelConstructorParams, 'channel' | 'logger' | 'legacyMode'> & {
         windowHere: Window;
         // specific peer can change over time, for example when different popup is opened
         // therefore it's a function that returns the current peer
@@ -39,6 +40,7 @@ export class WindowWindowChannel<
                 windowPeer()?.postMessage(message, origin);
             },
             logger,
+            legacyMode,
         });
 
         this._listener = this.listener.bind(this);

--- a/packages/connect-web/src/popup/index.ts
+++ b/packages/connect-web/src/popup/index.ts
@@ -98,6 +98,7 @@ export class PopupManager extends EventEmitter {
                 },
                 logger,
                 origin: this.origin,
+                legacyMode: !this.settings.useCoreInPopup,
             });
         }
 
@@ -349,6 +350,7 @@ export class PopupManager extends EventEmitter {
             if (this.openTimeout) clearTimeout(this.openTimeout);
             if (this.popupPromise) {
                 this.popupPromise.resolve();
+                this.popupPromise = undefined;
             }
             // popup is successfully loaded
             this.iframeHandshakePromise?.promise.then(payload => {
@@ -363,7 +365,11 @@ export class PopupManager extends EventEmitter {
                     },
                 });
             });
-        } else if (data.type === POPUP.CANCEL_POPUP_REQUEST || data.type === UI.CLOSE_UI_WINDOW) {
+        } else if (data.type === POPUP.CANCEL_POPUP_REQUEST) {
+            if (this.popupPromise) {
+                this.close();
+            }
+        } else if (data.type === UI.CLOSE_UI_WINDOW) {
             this.clear(false);
         }
     }


### PR DESCRIPTION
## Description

This PR fixes issues with handshakes that users encountered on Adalite. 
The main cause of the issue was incorrect handling of `CANCEL_POPUP_REQUEST`, which didn't actually close the popup. This resulted in a problem where the popup is open but the call (not requiring a popup) would be already finished. 
This should also fix issues relating to fallback in Firefox. 

Testing with: https://adalite.io/?trezor-connect-src=https://dev.suite.sldev.cz/connect/fix/connect-waiting-for-handshake-debug/
(but it needs upgrading `@trezor/connect-web` to properly test the fix)