### PR TITLE
fix(suite-native): orientation warning

### DIFF
--- a/suite-native/app/app.config.ts
+++ b/suite-native/app/app.config.ts
@@ -172,10 +172,6 @@ export default ({ config }: ConfigContext): ExpoConfig => {
                     '$(PRODUCT_NAME) needs Face ID and Touch ID to keep sensitive data about your portfolio private.',
                 NSMicrophoneUsageDescription: 'This app does not require access to the microphone.',
                 ITSAppUsesNonExemptEncryption: false,
-                UISupportedInterfaceOrientations: [
-                    'UIInterfaceOrientationPortrait',
-                    'UIInterfaceOrientationPortraitUpsideDown',
-                ],
                 NSAppTransportSecurity: {
                     NSAllowsArbitraryLoads: true,
                     NSExceptionDomains: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
https://github.com/trezor/trezor-suite/pull/12509 fixed orientation for Android, but since it's been defined in ios Info.plist, it now gives duplication warnings. This PR will fix that while the orientation is working as expected.
![Snímek obrazovky 2024-05-22 v 15 02 15](https://github.com/trezor/trezor-suite/assets/36101761/00130dfc-4bb0-4b8c-b925-7ca85bbfd066)

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
<img width="843" alt="image" src="https://github.com/trezor/trezor-suite/assets/36101761/181d10b5-0131-40c0-b629-a3ab1b7d5647">
