### PR TITLE
Store also first empty accounts after discovery

### DIFF
--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -616,6 +616,7 @@ export const createCoinjoinAccount =
                     descriptor: publicKey.payload.xpubSegwit || publicKey.payload.xpub,
                     legacyXpub: publicKey.payload.xpub,
                 },
+                visible: true,
             }),
         );
 

--- a/suite-common/wallet-core/src/accounts/accountsActions.ts
+++ b/suite-common/wallet-core/src/accounts/accountsActions.ts
@@ -35,6 +35,7 @@ type CreateAccountActionProps = {
     accountInfo: AccountInfo;
     imported?: boolean;
     accountLabel?: string;
+    visible: boolean;
 };
 
 type CreateIndexLabeledAccountActionProps = Omit<
@@ -48,6 +49,7 @@ const composeCreateAccountActionPayload = ({
     accountInfo,
     imported,
     accountLabel,
+    visible,
 }: CreateAccountActionProps): Account => ({
     deviceState,
     accountLabel,
@@ -69,10 +71,7 @@ const composeCreateAccountActionPayload = ({
         : {
               backendType: discoveryItem.backendType,
           }),
-    visible:
-        !accountInfo.empty ||
-        discoveryItem.accountType === 'coinjoin' ||
-        (discoveryItem.accountType === 'normal' && discoveryItem.index === 0),
+    visible,
     balance: accountInfo.balance,
     availableBalance: accountInfo.availableBalance,
     formattedBalance: formatNetworkAmount(
@@ -96,8 +95,14 @@ const createIndexLabeledAccount = createAction(
         deviceState,
         discoveryItem,
         accountInfo,
+        visible,
     }: CreateIndexLabeledAccountActionProps): { payload: Account } => ({
-        payload: composeCreateAccountActionPayload({ deviceState, discoveryItem, accountInfo }),
+        payload: composeCreateAccountActionPayload({
+            deviceState,
+            discoveryItem,
+            accountInfo,
+            visible,
+        }),
     }),
 );
 
@@ -109,6 +114,7 @@ const createAccount = createAction(
         accountInfo,
         imported,
         accountLabel,
+        visible,
     }: CreateAccountActionProps): { payload: Account } => ({
         payload: composeCreateAccountActionPayload({
             deviceState,
@@ -116,6 +122,7 @@ const createAccount = createAction(
             accountInfo,
             imported,
             accountLabel,
+            visible,
         }),
     }),
 );

--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -167,6 +167,10 @@ export const selectDeviceAccounts = (state: AccountsRootState & DeviceRootState)
     return selectAccountsByDeviceState(state, device.state);
 };
 
+export const selectVisibleDeviceAccounts = memoize((state: AccountsRootState & DeviceRootState) =>
+    selectDeviceAccounts(state).filter(account => account.visible),
+);
+
 export const selectDeviceAccountsForNetworkSymbolAndAccountType = memoizeWithArgs(
     (
         state: AccountsRootState & DeviceRootState,
@@ -363,7 +367,7 @@ export const selectAccountsSymbols = memoize(
 );
 
 export const selectIsDeviceAccountless = (state: AccountsRootState & DeviceRootState) =>
-    pipe(selectDeviceAccounts(state), A.isEmpty);
+    pipe(selectVisibleDeviceAccounts(state), A.isEmpty);
 
 // Selected device has no accounts and no active discovery. It can be empty portfolio device.
 export const selectIsEmptyDevice = (

--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -243,6 +243,16 @@ export const selectDeviceAccountsByNetworkSymbol = memoizeWithArgs(
     },
 );
 
+export const selectVisibleDeviceAccountsByNetworkSymbol = memoizeWithArgs(
+    (state: AccountsRootState & DeviceRootState, networkSymbol: NetworkSymbol | null) =>
+        selectDeviceAccountsByNetworkSymbol(state, networkSymbol).filter(
+            account => account.visible,
+        ),
+    {
+        size: Object.keys(networks).length,
+    },
+);
+
 export const selectVisibleNonEmptyDeviceAccountsByNetworkSymbol = (
     state: AccountsRootState & DeviceRootState,
     networkSymbol: NetworkSymbol | null,

--- a/suite-common/wallet-core/src/accounts/tests/accountsReducer.test.ts
+++ b/suite-common/wallet-core/src/accounts/tests/accountsReducer.test.ts
@@ -58,6 +58,7 @@ describe('Account Reducer', () => {
                         unconfirmed: 0,
                     },
                 },
+                visible: true,
             }),
         );
         expect(store.getState().wallet.accounts.length).toEqual(1);

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -148,6 +148,8 @@ const handleProgressThunk = createThunk(
                     deviceState,
                     discoveryItem: item,
                     accountInfo: response,
+                    // first normal account is always visible on web & desktop (but not in suite-native)
+                    visible: (item.accountType === 'normal' && item.index === 0) || !response.empty,
                 }),
             );
         }

--- a/suite-native/accounts/src/selectors.ts
+++ b/suite-native/accounts/src/selectors.ts
@@ -5,7 +5,7 @@ import {
     AccountsRootState,
     DeviceRootState,
     selectAccounts,
-    selectDeviceAccountsByNetworkSymbol,
+    selectVisibleDeviceAccountsByNetworkSymbol,
     selectDeviceAccounts,
     FiatRatesRootState,
 } from '@suite-common/wallet-core';
@@ -51,7 +51,7 @@ export const selectFilteredDeviceAccountsGroupedByNetworkAccountType = memoizeWi
 export const selectDeviceNetworkAccountsGroupedByAccountType = memoizeWithArgs(
     (state: AccountsRootState & DeviceRootState, networkSymbol: NetworkSymbol) =>
         pipe(
-            selectDeviceAccountsByNetworkSymbol(state, networkSymbol),
+            selectVisibleDeviceAccountsByNetworkSymbol(state, networkSymbol),
             sortAccountsByNetworksAndAccountTypes,
             groupAccountsByNetworkAccountType,
         ) as GroupedAccounts,

--- a/suite-native/assets/src/assetsSelectors.ts
+++ b/suite-native/assets/src/assetsSelectors.ts
@@ -6,7 +6,7 @@ import {
     AccountsRootState,
     DeviceRootState,
     FiatRatesRootState,
-    selectDeviceAccounts,
+    selectVisibleDeviceAccounts,
     selectFiatRatesByFiatRateKey,
 } from '@suite-common/wallet-core';
 import { getFiatRateKey, toFiatCurrency } from '@suite-common/wallet-utils';
@@ -29,7 +29,7 @@ const sumBalance = (balances: string[]): BigNumber =>
 
 export const selectDeviceBalancesPerNetwork = memoize(
     (state: AssetsRootState & DeviceRootState): FormattedAssets => {
-        const accounts = selectDeviceAccounts(state);
+        const accounts = selectVisibleDeviceAccounts(state);
 
         const assets: Assets = {};
         accounts.forEach(account => {

--- a/suite-native/assets/src/components/AssetItem.tsx
+++ b/suite-native/assets/src/components/AssetItem.tsx
@@ -9,7 +9,7 @@ import { NetworkSymbol } from '@suite-common/wallet-config';
 import {
     AccountsRootState,
     DeviceRootState,
-    selectDeviceAccountsByNetworkSymbol,
+    selectVisibleDeviceAccountsByNetworkSymbol,
 } from '@suite-common/wallet-core';
 import { Box, Text } from '@suite-native/atoms';
 import { CryptoAmountFormatter, FiatAmountFormatter } from '@suite-native/formatters';
@@ -73,7 +73,7 @@ export const AssetItem = memo(
         const navigation = useNavigation<NavigationType>();
 
         const accountsForNetworkSymbol = useSelector((state: AccountsRootState & DeviceRootState) =>
-            selectDeviceAccountsByNetworkSymbol(state, cryptoCurrencySymbol),
+            selectVisibleDeviceAccountsByNetworkSymbol(state, cryptoCurrencySymbol),
         );
         const accountsPerAsset = accountsForNetworkSymbol.length;
 

--- a/suite-native/discovery/src/discoveryThunks.ts
+++ b/suite-native/discovery/src/discoveryThunks.ts
@@ -255,7 +255,6 @@ const discoverAccountsByDescriptorThunk = createThunk(
             if (success) {
                 if (accountInfo.empty) {
                     isFinalRound = true;
-                    break;
                 }
 
                 dispatch(

--- a/suite-native/discovery/src/discoveryThunks.ts
+++ b/suite-native/discovery/src/discoveryThunks.ts
@@ -205,6 +205,7 @@ const addAccountByDescriptorThunk = createThunk(
                     discoveryItem: bundleItem,
                     deviceState,
                     accountInfo,
+                    visible: true,
                 }),
             );
 
@@ -262,6 +263,7 @@ const discoverAccountsByDescriptorThunk = createThunk(
                         discoveryItem: bundleItem,
                         deviceState,
                         accountInfo,
+                        visible: !accountInfo.empty,
                     }),
                 );
             }

--- a/suite-native/module-accounts-import/src/accountsImportThunks.ts
+++ b/suite-native/module-accounts-import/src/accountsImportThunks.ts
@@ -66,6 +66,7 @@ export const importAccountThunk = createThunk(
                     accountInfo,
                     imported,
                     accountLabel,
+                    visible: true,
                 }),
             );
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

By creating invisible empty discovered accounts, user can see it once he sent some TX there.

We don't repeat discovery on every Trezor connect yet and with view-only feature it can happen more often, that user will send some TX on new account and will never see it in Suite Lite until disable view-only and reconnect.

As opposed to Suite Desktop, in mobile there is a batched discovery so it can happen that there are 2 invisible empty accounts for some coins.

This is not a final solution at all, just a small improvement as a first step – discovery resume/continue needs to be implemented https://github.com/trezor/trezor-suite/issues/11562

## Acceptance criteria (notes for QA)
- If user receive some funds on first empty account, it should appear in Suite Lite automatically.
- If user receive some funds on the very first account of some coin, that wasn't visible in Suite Lite, it should appear automatically.
- User should be able to add new account/coin until reaching 10 accounts per type limit and only 1 empty account limit (it's not possible to add new account if the previous one is empty and already visible)
- It could also affect visibility of empty accounts on desktop, would be nice to double check adding new coin and account there too.

