### PR TITLE
transport-bridge tuning: dispose, tests, etc

### DIFF
--- a/packages/transport-bridge/jest.config.js
+++ b/packages/transport-bridge/jest.config.js
@@ -1,0 +1,6 @@
+const baseConfig = require('../../jest.config.base');
+
+module.exports = {
+    ...baseConfig,
+    testEnvironment: 'node',
+};

--- a/packages/transport-bridge/package.json
+++ b/packages/transport-bridge/package.json
@@ -6,6 +6,7 @@
     "private": true,
     "sideEffects": false,
     "scripts": {
+        "test:unit": "yarn g:jest",
         "type-check": "yarn g:tsc --build",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
         "build:node:bin": "yarn esbuild ./src/bin.ts --bundle --outfile=dist/bin.js --platform=node --target=node18 --external:usb",

--- a/packages/transport-bridge/src/core.ts
+++ b/packages/transport-bridge/src/core.ts
@@ -190,6 +190,10 @@ export const createApi = (apiStr: 'usb' | 'udp', logger?: Log) => {
         return readUtil({ path });
     };
 
+    const dispose = () => {
+        api.dispose();
+    };
+
     return {
         enumerate,
         acquire,
@@ -197,5 +201,6 @@ export const createApi = (apiStr: 'usb' | 'udp', logger?: Log) => {
         call,
         send,
         receive,
+        dispose,
     };
 };

--- a/packages/transport-bridge/src/http.ts
+++ b/packages/transport-bridge/src/http.ts
@@ -11,6 +11,7 @@ import {
 } from '@trezor/node-utils';
 import { Descriptor } from '@trezor/transport/src/types';
 import { Log, arrayPartition } from '@trezor/utils';
+import { AbstractApi } from '@trezor/transport/src/api/abstract';
 
 import { sessionsClient, createApi } from './core';
 
@@ -45,7 +46,7 @@ export class TrezordNode {
         logger,
     }: {
         port: number;
-        api: 'usb' | 'udp';
+        api: 'usb' | 'udp' | AbstractApi;
         assetPrefix?: string;
         logger?: Log;
     }) {

--- a/packages/transport-bridge/tests/http.test.ts
+++ b/packages/transport-bridge/tests/http.test.ts
@@ -1,4 +1,5 @@
 import { getFreePort } from '@trezor/node-utils';
+import { AbstractApi } from '@trezor/transport/src/api/abstract';
 
 import { TrezordNode } from '../src/http';
 
@@ -9,6 +10,35 @@ const muteLogger = {
     warn: (..._args: string[]) => {},
     error: (..._args: string[]) => {},
 };
+
+// todo: szymon is about to re-use this from a single file
+const createTransportApi = (override = {}) =>
+    ({
+        chunkSize: 0,
+        enumerate: () => {
+            return Promise.resolve({ success: true, payload: [{ path: '1' }] });
+        },
+        on: () => {},
+        off: () => {},
+        openDevice: (path: string) => {
+            return Promise.resolve({ success: true, payload: [{ path }] });
+        },
+        closeDevice: () => {
+            return Promise.resolve({ success: true });
+        },
+        write: () => {
+            return Promise.resolve({ success: true });
+        },
+        read: () => {
+            return Promise.resolve({
+                success: true,
+                payload: Buffer.from('3f232300110000000c1002180020006000aa010154', 'hex'), // partial proto.Features
+                // payload: Buffer.from('3f23230002000000060a046d656f77', 'hex'), // proto.Success
+            });
+        },
+        dispose: () => {},
+        ...override,
+    }) as unknown as AbstractApi;
 
 describe('http', () => {
     let port: number;
@@ -26,6 +56,15 @@ describe('http', () => {
             });
             await trezordNode.start();
             await trezordNode.stop();
+        });
+    });
+
+    it('constructor accepts custom AbstractApi', () => {
+        new TrezordNode({
+            port,
+            api: createTransportApi(),
+            // @ts-expect-error
+            logger: muteLogger,
         });
     });
 });

--- a/packages/transport-bridge/tests/http.test.ts
+++ b/packages/transport-bridge/tests/http.test.ts
@@ -1,0 +1,31 @@
+import { getFreePort } from '@trezor/node-utils';
+
+import { TrezordNode } from '../src/http';
+
+const muteLogger = {
+    info: (..._args: string[]) => {},
+    debug: (..._args: string[]) => {},
+    log: (..._args: string[]) => {},
+    warn: (..._args: string[]) => {},
+    error: (..._args: string[]) => {},
+};
+
+describe('http', () => {
+    let port: number;
+    beforeAll(async () => {
+        port = await getFreePort();
+    });
+
+    (['usb', 'udp'] as const).forEach(api => {
+        it(`node bridge using ${api} api should start and stop without stopping jest from exiting`, async () => {
+            const trezordNode = new TrezordNode({
+                port,
+                api,
+                // @ts-expect-error
+                logger: muteLogger,
+            });
+            await trezordNode.start();
+            await trezordNode.stop();
+        });
+    });
+});

--- a/packages/transport/src/api/abstract.ts
+++ b/packages/transport/src/api/abstract.ts
@@ -108,6 +108,8 @@ export abstract class AbstractApi extends TypedEmitter<{
         | typeof ERRORS.UNEXPECTED_ERROR
     >;
 
+    abstract dispose(): void;
+
     /**
      * packet size for api
      */

--- a/packages/transport/src/api/udp.ts
+++ b/packages/transport/src/api/udp.ts
@@ -137,4 +137,9 @@ export class UdpApi extends AbstractApi {
     public closeDevice(_path: string) {
         return Promise.resolve(this.success(undefined));
     }
+
+    public dispose() {
+        this.interface.removeAllListeners();
+        this.interface.close();
+    }
 }

--- a/packages/transport/src/api/usb.ts
+++ b/packages/transport/src/api/usb.ts
@@ -301,4 +301,11 @@ export class UsbApi extends AbstractApi {
 
         return [hidDevices, nonHidDevices];
     }
+
+    public dispose() {
+        if (this.usbInterface) {
+            this.usbInterface.onconnect = null;
+            this.usbInterface.ondisconnect = null;
+        }
+    }
 }


### PR DESCRIPTION
Adding unit tests coverage for node-bridge. This PR doesn't contain anything controversial - only support for efficient testing. This also applies to the newly added `dispose` method to the transport API layer, which is needed to cancel all async jobs after tests finish and which should be used in production.

This is just a kick-off. I will continue adding more tests in other branches.