### PR TITLE
feat(suite-native): enable passphrase on device

### DIFF
--- a/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
@@ -1,5 +1,10 @@
 import { testMocks } from '@suite-common/test-utils';
-import { discoveryActions, deviceActions, authorizeDeviceThunk } from '@suite-common/wallet-core';
+import {
+    discoveryActions,
+    deviceActions,
+    authorizeDeviceThunk,
+    createDeviceInstanceThunk,
+} from '@suite-common/wallet-core';
 import { DEVICE, TRANSPORT } from '@trezor/connect';
 import { notificationsActions } from '@suite-common/toast-notifications';
 
@@ -1000,7 +1005,7 @@ const createDeviceInstance = [
                 }),
             },
         },
-        result: undefined,
+        result: createDeviceInstanceThunk.rejected.type,
     },
     {
         description: `without passphrase_protection`,
@@ -1011,7 +1016,7 @@ const createDeviceInstance = [
                 }),
             },
         },
-        result: deviceActions.createDeviceInstance.type,
+        result: createDeviceInstanceThunk.fulfilled.type,
     },
     {
         description: `without passphrase_protection and @trezor/connect error`,
@@ -1028,7 +1033,7 @@ const createDeviceInstance = [
                 error: 'applySettings error',
             },
         },
-        result: notificationsActions.addToast.type,
+        result: createDeviceInstanceThunk.rejected.type,
     },
     {
         description: `with passphrase_protection enabled`,
@@ -1050,7 +1055,7 @@ const createDeviceInstance = [
                 error: 'applySettings error',
             },
         },
-        result: deviceActions.createDeviceInstance.type,
+        result: createDeviceInstanceThunk.fulfilled.type,
     },
 ];
 

--- a/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
@@ -11,13 +11,13 @@ import {
     acquireDevice,
     authConfirm,
     authorizeDeviceThunk,
-    createDeviceInstanceThunk,
     forgetDisconnectedDevices,
     handleDeviceConnect,
     observeSelectedDevice,
     switchDuplicatedDevice,
     selectDeviceThunk,
     handleDeviceDisconnect,
+    createDeviceInstanceThunk,
 } from '@suite-common/wallet-core';
 import { connectInitThunk } from '@suite-common/connect-init';
 import { DEVICE } from '@trezor/connect';
@@ -287,12 +287,8 @@ describe('Suite Actions', () => {
             await store.dispatch(
                 createDeviceInstanceThunk({ device: f.state.device.selectedDevice }),
             );
-            if (!f.result) {
-                expect(filterThunkActionTypes(store.getActions()).length).toEqual(0);
-            } else {
-                const action = filterThunkActionTypes(store.getActions()).pop();
-                expect(action?.type).toEqual(f.result);
-            }
+            const action = store.getActions().pop();
+            expect(action?.type).toEqual(f.result);
         });
     });
 

--- a/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
@@ -11,7 +11,7 @@ import {
     acquireDevice,
     authConfirm,
     authorizeDeviceThunk,
-    createDeviceInstance,
+    createDeviceInstanceThunk,
     forgetDisconnectedDevices,
     handleDeviceConnect,
     observeSelectedDevice,
@@ -284,7 +284,9 @@ describe('Suite Actions', () => {
             setTrezorConnectFixtures(f.applySettings);
             const state = getInitialState(undefined, f.state.device);
             const store = initStore(state);
-            await store.dispatch(createDeviceInstance({ device: f.state.device.selectedDevice }));
+            await store.dispatch(
+                createDeviceInstanceThunk({ device: f.state.device.selectedDevice }),
+            );
             if (!f.result) {
                 expect(filterThunkActionTypes(store.getActions()).length).toEqual(0);
             } else {

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/useAppShortcuts.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/useAppShortcuts.tsx
@@ -1,4 +1,4 @@
-import { createDeviceInstance, selectDevice } from '@suite-common/wallet-core';
+import { createDeviceInstanceThunk, selectDevice } from '@suite-common/wallet-core';
 import { useEvent } from 'react-use';
 import { goto } from 'src/actions/suite/routerActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -12,7 +12,7 @@ export const useAppShortcuts = () => {
 
         // press CMD + P to show PassphraseModal
         if (modKey && e.key === 'p' && device) {
-            dispatch(createDeviceInstance({ device }));
+            dispatch(createDeviceInstanceThunk({ device }));
             e.preventDefault(); // prevent default behaviour
         }
 

--- a/packages/suite/src/middlewares/suite/suiteMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/suiteMiddleware.ts
@@ -4,6 +4,7 @@ import { AnyAction, isAnyOf } from '@reduxjs/toolkit';
 import {
     authConfirm,
     authorizeDeviceThunk,
+    createDeviceInstanceThunk,
     deviceActions,
     forgetDisconnectedDevices,
     handleDeviceConnect,
@@ -60,8 +61,8 @@ const suite =
         // pass action to reducers
         next(action);
 
-        if (deviceActions.createDeviceInstance.match(action)) {
-            api.dispatch(selectDeviceThunk(action.payload));
+        if (createDeviceInstanceThunk.fulfilled.match(action)) {
+            api.dispatch(selectDeviceThunk(action.payload.device));
         }
 
         if (deviceActions.forgetDevice.match(action)) {

--- a/packages/suite/src/reducers/suite/__fixtures__/deviceReducer.ts
+++ b/packages/suite/src/reducers/suite/__fixtures__/deviceReducer.ts
@@ -964,118 +964,6 @@ const authDevice = [
     },
 ];
 
-const createInstance = [
-    {
-        description: `Create instance, 1 connected`,
-        initialState: { devices: [SUITE_DEVICE] },
-        actions: [
-            {
-                type: deviceActions.createDeviceInstance.type,
-                payload: getSuiteDevice({ useEmptyPassphrase: false, instance: 1 }),
-            },
-        ],
-        result: [
-            {
-                instance: undefined,
-                features: {
-                    device_id: 'device-id',
-                },
-            },
-            {
-                instance: 1,
-                features: {
-                    device_id: 'device-id',
-                },
-            },
-        ],
-    },
-    {
-        description: `Create instance, 2 connected, 1 affected`,
-        initialState: {
-            devices: [
-                getSuiteDevice(undefined, {
-                    device_id: 'ignored-device-id',
-                }),
-                SUITE_DEVICE,
-            ],
-        },
-        actions: [
-            {
-                type: deviceActions.createDeviceInstance.type,
-                payload: getSuiteDevice({ useEmptyPassphrase: false, instance: 1 }),
-            },
-        ],
-        result: [
-            {
-                features: {
-                    device_id: 'ignored-device-id',
-                },
-            },
-            {
-                instance: undefined,
-                features: {
-                    device_id: 'device-id',
-                },
-            },
-            {
-                instance: 1,
-                features: {
-                    device_id: 'device-id',
-                },
-            },
-        ],
-    },
-    {
-        description: `Create instance from instance`,
-        initialState: {
-            devices: [SUITE_DEVICE, getSuiteDevice({ instance: 1 })],
-        },
-        actions: [
-            {
-                type: deviceActions.createDeviceInstance.type,
-                payload: getSuiteDevice({ useEmptyPassphrase: false, instance: 2 }),
-            },
-        ],
-        result: [
-            {
-                instance: undefined,
-                features: {
-                    device_id: 'device-id',
-                },
-            },
-            {
-                instance: 1,
-                features: {
-                    device_id: 'device-id',
-                },
-            },
-            {
-                instance: 2,
-                features: {
-                    device_id: 'device-id',
-                },
-            },
-        ],
-    },
-    {
-        description: `device is unacquired`,
-        initialState: { devices: [SUITE_DEVICE] },
-        actions: [
-            {
-                type: deviceActions.createDeviceInstance.type,
-                payload: getSuiteDevice({
-                    type: 'unacquired',
-                }),
-            },
-        ],
-        result: [
-            {
-                state: undefined,
-            },
-        ],
-    },
-];
-
 const forget = [
     {
         description: `Forget multiple instances (2 connected, 5 instances, 3 affected, last instance remains with undefined state)`,
@@ -1377,7 +1265,6 @@ export default {
     updateTimestamp,
     changePassphraseMode,
     authDevice,
-    createInstance,
     forget,
     remember,
 };

--- a/packages/suite/src/reducers/suite/__tests__/deviceReducer.test.ts
+++ b/packages/suite/src/reducers/suite/__tests__/deviceReducer.test.ts
@@ -125,21 +125,6 @@ describe('SUITE.AUTH_DEVICE', () => {
     });
 });
 
-describe('SUITE.CREATE_DEVICE_INSTANCE', () => {
-    fixtures.createInstance.forEach(f => {
-        it(f.description, () => {
-            let state: State = f.initialState;
-            f.actions.forEach(a => {
-                state = deviceReducer(state, a as Action);
-            });
-            expect(state.devices.length).toEqual(f.result.length);
-            state.devices.forEach((device, i) => {
-                expect(device).toMatchObject(f.result[i]);
-            });
-        });
-    });
-});
-
 describe('SUITE.FORGET_DEVICE', () => {
     fixtures.forget.forEach(f => {
         it(f.description, () => {

--- a/packages/suite/src/views/dashboard/components/SecurityFeatures/index.tsx
+++ b/packages/suite/src/views/dashboard/components/SecurityFeatures/index.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { selectDevice, createDeviceInstance } from '@suite-common/wallet-core';
+import { selectDevice, createDeviceInstanceThunk } from '@suite-common/wallet-core';
 import { Button, variables } from '@trezor/components';
 
 import { Translation } from 'src/components/suite';
@@ -140,7 +140,7 @@ const SecurityFeatures = () => {
               cta: {
                   label: <Translation id="TR_CREATE_HIDDEN_WALLET" />,
                   action: () =>
-                      dispatch(createDeviceInstance({ device: device as AcquiredDevice })),
+                      dispatch(createDeviceInstanceThunk({ device: device as AcquiredDevice })),
                   dataTest: 'create-hidden-wallet',
                   isDisabled: isDeviceLocked,
               },

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx
@@ -2,7 +2,11 @@ import styled from 'styled-components';
 import { variables } from '@trezor/components';
 import * as deviceUtils from '@suite-common/suite-utils';
 
-import { selectDevice, createDeviceInstance, selectDeviceThunk } from '@suite-common/wallet-core';
+import {
+    selectDevice,
+    createDeviceInstanceThunk,
+    selectDeviceThunk,
+} from '@suite-common/wallet-core';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { goto } from 'src/actions/suite/routerActions';
 
@@ -81,7 +85,7 @@ export const DeviceItem = ({
         instance: DeviceItemProps['device'],
         useEmptyPassphrase?: boolean,
     ) => {
-        await dispatch(createDeviceInstance({ device: instance, useEmptyPassphrase }));
+        await dispatch(createDeviceInstanceThunk({ device: instance, useEmptyPassphrase }));
         handleRedirection();
     };
 

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItemLegacy/DeviceItem.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItemLegacy/DeviceItem.tsx
@@ -8,7 +8,7 @@ import * as deviceUtils from '@suite-common/suite-utils';
 import {
     selectDevice,
     acquireDevice,
-    createDeviceInstance,
+    createDeviceInstanceThunk,
     selectDeviceThunk,
 } from '@suite-common/wallet-core';
 import { Translation } from 'src/components/suite';
@@ -169,7 +169,7 @@ export const DeviceItemLegacy = ({
     };
 
     const addDeviceInstance = async (instance: DeviceItemProps['device']) => {
-        await dispatch(createDeviceInstance({ device: instance }));
+        await dispatch(createDeviceInstanceThunk({ device: instance }));
         handleRedirection();
     };
 

--- a/suite-common/wallet-core/src/device/deviceActions.ts
+++ b/suite-common/wallet-core/src/device/deviceActions.ts
@@ -27,11 +27,6 @@ const receiveAuthConfirm = createAction(
     (payload: { device: TrezorDevice; success: boolean }) => ({ payload }),
 );
 
-const createDeviceInstance = createAction(
-    `${DEVICE_MODULE_PREFIX}/createDeviceInstance`,
-    (payload: TrezorDevice) => ({ payload }),
-);
-
 const rememberDevice = createAction(
     `${DEVICE_MODULE_PREFIX}/rememberDevice`,
     (payload: { device: TrezorDevice; remember: boolean; forceRemember: undefined | true }) => ({
@@ -80,7 +75,6 @@ export const deviceActions = {
     deviceDisconnect,
     updatePassphraseMode,
     receiveAuthConfirm,
-    createDeviceInstance,
     rememberDevice,
     forgetDevice,
     addButtonRequest,

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -860,7 +860,14 @@ export const selectIsDeviceUsingPassphrase = (state: DeviceRootState) => {
     const isDeviceProtectedByPassphrase = selectIsDeviceProtectedByPassphrase(state);
     const device = selectDevice(state);
 
-    return isDeviceProtectedByPassphrase && device?.useEmptyPassphrase === false;
+    // If device instance is higher than 1 (newly created device instance), connect returns
+    // `passphrase_protection: false` in features. But we still want to treat it as passphrase protected.
+    const shouldIgnorePassphraseProtection = device?.instance ?? 1 > 1;
+
+    return (
+        (isDeviceProtectedByPassphrase && device?.useEmptyPassphrase === false) ||
+        shouldIgnorePassphraseProtection
+    );
 };
 
 export const selectPhysicalDevicesGrouppedById = memoize((state: DeviceRootState) => {

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -1,4 +1,5 @@
 import { memoize } from 'proxy-memoize';
+import { isAnyOf } from '@reduxjs/toolkit';
 
 import * as deviceUtils from '@suite-common/suite-utils';
 import { getDeviceInstances, getStatus } from '@suite-common/suite-utils';
@@ -15,7 +16,11 @@ import {
 import { isNative } from '@trezor/env-utils';
 
 import { deviceActions } from './deviceActions';
-import { authorizeDeviceThunk } from './deviceThunks';
+import {
+    authorizeDeviceThunk,
+    createDeviceInstanceThunk,
+    createImportedDeviceThunk,
+} from './deviceThunks';
 import { PORTFOLIO_TRACKER_DEVICE_ID } from './deviceConstants';
 
 export type State = {
@@ -536,9 +541,6 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(initialState, (bu
         .addCase(deviceActions.receiveAuthConfirm, (state, { payload }) => {
             authConfirm(state, payload.device, payload.success);
         })
-        .addCase(deviceActions.createDeviceInstance, (state, { payload }) => {
-            createInstance(state, payload);
-        })
         .addCase(deviceActions.rememberDevice, (state, { payload }) => {
             remember(state, payload.device, payload.remember, payload.forceRemember);
         })
@@ -567,7 +569,13 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(initialState, (bu
             setDeviceAuthenticity(state, payload.device, payload.result);
         })
         .addCase(extra.actionTypes.setDeviceMetadata, extra.reducers.setDeviceMetadataReducer)
-        .addCase(extra.actionTypes.storageLoad, extra.reducers.storageLoadDevices);
+        .addCase(extra.actionTypes.storageLoad, extra.reducers.storageLoadDevices)
+        .addMatcher(
+            isAnyOf(createDeviceInstanceThunk.fulfilled, createImportedDeviceThunk.fulfilled),
+            (state, { payload }) => {
+                createInstance(state, payload.device);
+            },
+        );
 });
 
 export const selectDevices = (state: DeviceRootState) => state.device?.devices;
@@ -862,11 +870,11 @@ export const selectIsDeviceUsingPassphrase = (state: DeviceRootState) => {
 
     // If device instance is higher than 1 (newly created device instance), connect returns
     // `passphrase_protection: false` in features. But we still want to treat it as passphrase protected.
-    const shouldIgnorePassphraseProtection = device?.instance ?? 1 > 1;
+    const shouldTreatAsPassphraseProtected = device?.instance ?? 1 > 1;
 
     return (
         (isDeviceProtectedByPassphrase && device?.useEmptyPassphrase === false) ||
-        shouldIgnorePassphraseProtection
+        shouldTreatAsPassphraseProtected
     );
 };
 

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -101,7 +101,7 @@ export const toggleRememberDevice = createThunk(
  * @param {boolean} [useEmptyPassphrase=false]
  */
 export type CreateDeviceInstanceError = { error: 'passphrase-enabling-cancelled' };
-export const createDeviceInstance = createThunk<
+export const createDeviceInstanceThunk = createThunk<
     void,
     { device: TrezorDevice; useEmptyPassphrase?: boolean },
     { rejectValue: CreateDeviceInstanceError }
@@ -396,7 +396,7 @@ export const authConfirm = createThunk(
             // handle error passed from Passphrase modal
             if (response.payload.error === 'auth-confirm-cancel') {
                 // needs await to propagate all actions
-                await dispatch(createDeviceInstance({ device }));
+                await dispatch(createDeviceInstanceThunk({ device }));
                 // forget previous empty wallet
                 dispatch(deviceActions.forgetDevice(device));
 

--- a/suite-native/device-manager/src/components/AddHiddenWalletButton.tsx
+++ b/suite-native/device-manager/src/components/AddHiddenWalletButton.tsx
@@ -1,10 +1,23 @@
 import { useDispatch, useSelector } from 'react-redux';
 
+import { useNavigation } from '@react-navigation/native';
+
 import { Translation } from '@suite-native/intl';
-import { createDeviceInstance, selectDevice } from '@suite-common/wallet-core';
 import { HStack, Text } from '@suite-native/atoms';
+import {
+    createDeviceInstance,
+    selectDevice,
+    selectIsDeviceProtectedByPassphrase,
+} from '@suite-common/wallet-core';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { Icon } from '@suite-common/icons';
+import {
+    PassphraseStackParamList,
+    PassphraseStackRoutes,
+    RootStackParamList,
+    RootStackRoutes,
+    StackToStackCompositeNavigationProps,
+} from '@suite-native/navigation';
 
 import { useDeviceManager } from '../hooks/useDeviceManager';
 import { DeviceAction } from './DeviceAction';
@@ -13,19 +26,36 @@ const textStyle = prepareNativeStyle(_ => ({
     flex: 1,
 }));
 
+type NavigationProp = StackToStackCompositeNavigationProps<
+    PassphraseStackParamList,
+    PassphraseStackRoutes.PassphraseForm,
+    RootStackParamList
+>;
+
 export const AddHiddenWalletButton = () => {
-    const { applyStyle } = useNativeStyles();
     const dispatch = useDispatch();
 
+    const navigation = useNavigation<NavigationProp>();
+
+    const { applyStyle } = useNativeStyles();
+
     const device = useSelector(selectDevice);
+    const isPassphraseEnabledOnDevice = useSelector(selectIsDeviceProtectedByPassphrase);
 
     const { setIsDeviceManagerVisible } = useDeviceManager();
 
     const handleAddHiddenWallet = () => {
         if (!device) return;
-
         setIsDeviceManagerVisible(false);
+
         dispatch(createDeviceInstance({ device }));
+
+        // Create device instance thunk already handles passphrase enabling, so we just redirect to this screen and wait for success / error
+        if (!isPassphraseEnabledOnDevice) {
+            navigation.navigate(RootStackRoutes.PassphraseStack, {
+                screen: PassphraseStackRoutes.PassphraseEnableOnDevice,
+            });
+        }
     };
 
     return (

--- a/suite-native/device-manager/src/components/AddHiddenWalletButton.tsx
+++ b/suite-native/device-manager/src/components/AddHiddenWalletButton.tsx
@@ -5,7 +5,7 @@ import { useNavigation } from '@react-navigation/native';
 import { Translation } from '@suite-native/intl';
 import { HStack, Text } from '@suite-native/atoms';
 import {
-    createDeviceInstance,
+    createDeviceInstanceThunk,
     selectDevice,
     selectIsDeviceProtectedByPassphrase,
 } from '@suite-common/wallet-core';
@@ -48,7 +48,7 @@ export const AddHiddenWalletButton = () => {
         if (!device) return;
         setIsDeviceManagerVisible(false);
 
-        dispatch(createDeviceInstance({ device }));
+        dispatch(createDeviceInstanceThunk({ device }));
 
         // Create device instance thunk already handles passphrase enabling, so we just redirect to this screen and wait for success / error
         if (!isPassphraseEnabledOnDevice) {

--- a/suite-native/device/src/middlewares/deviceMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceMiddleware.ts
@@ -11,6 +11,7 @@ import {
     observeSelectedDevice,
     selectDeviceThunk,
     selectAccountsByDeviceState,
+    createDeviceInstanceThunk,
 } from '@suite-common/wallet-core';
 import { FeatureFlag, selectIsFeatureFlagEnabled } from '@suite-native/feature-flags';
 import { clearAndUnlockDeviceAccessQueue } from '@suite-native/device-mutex';
@@ -45,8 +46,8 @@ export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps(
          expect that the state was already changed by the action stored in the `action` variable. */
         next(action);
 
-        if (deviceActions.createDeviceInstance.match(action)) {
-            dispatch(selectDeviceThunk(action.payload));
+        if (createDeviceInstanceThunk.fulfilled.match(action)) {
+            dispatch(selectDeviceThunk(action.payload.device));
         }
 
         if (deviceActions.forgetDevice.match(action)) {

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -713,6 +713,11 @@ export const en = {
             subtitle: 'You’re trying to enter a passphrase wallet that’s already been opened.',
             button: 'Proceed to passphrase wallet ',
         },
+        enablePassphrase: {
+            title: 'Enable passphrase on your Trezor.',
+            subtitle: 'Go to your device and confirm you’d like to enable passphase.',
+            cancelledError: 'Passphrase enabling cancelled.',
+        },
     },
 };
 

--- a/suite-native/module-passphrase/package.json
+++ b/suite-native/module-passphrase/package.json
@@ -27,6 +27,7 @@
         "@suite-native/navigation": "workspace:*",
         "@suite-native/passphrase": "workspace:*",
         "@suite-native/theme": "workspace:*",
+        "@suite-native/toasts": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/styles": "workspace:*",
         "react": "18.2.0",

--- a/suite-native/module-passphrase/src/navigation/PassphraseStackNavigator.tsx
+++ b/suite-native/module-passphrase/src/navigation/PassphraseStackNavigator.tsx
@@ -13,6 +13,7 @@ import { PassphraseConfirmOnTrezorScreen } from '../screens/PassphraseConfirmOnT
 import { PassphraseEmptyWalletScreen } from '../screens/PassphraseEmptyWalletScreen';
 import { PassphraseVerifyEmptyWalletScreen } from '../screens/PassphraseVerifyEmptyWalletScreen';
 import { PassphraseEnterOnTrezorScreen } from '../screens/PassphraseEnterOnTrezorScreen';
+import { PassphraseEnableOnDeviceScreen } from '../screens/PassphraseEnableOnDeviceScreen';
 
 export const PassphraseStack = createNativeStackNavigator<PassphraseStackParamList>();
 
@@ -44,6 +45,10 @@ export const PassphraseStackNavigator = () => {
             <PassphraseStack.Screen
                 name={PassphraseStackRoutes.PassphraseEnterOnTrezor}
                 component={PassphraseEnterOnTrezorScreen}
+            />
+            <PassphraseStack.Screen
+                name={PassphraseStackRoutes.PassphraseEnableOnDevice}
+                component={PassphraseEnableOnDeviceScreen}
             />
         </PassphraseStack.Navigator>
     );

--- a/suite-native/module-passphrase/src/screens/PassphraseEnableOnDeviceScreen.tsx
+++ b/suite-native/module-passphrase/src/screens/PassphraseEnableOnDeviceScreen.tsx
@@ -1,0 +1,85 @@
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+
+import { useNavigation } from '@react-navigation/native';
+
+import {
+    AppTabsRoutes,
+    HomeStackRoutes,
+    PassphraseStackParamList,
+    PassphraseStackRoutes,
+    RootStackParamList,
+    RootStackRoutes,
+    Screen,
+    StackToStackCompositeNavigationProps,
+} from '@suite-native/navigation';
+import { CenteredTitleHeader, IconButton, ScreenHeaderWrapper, VStack } from '@suite-native/atoms';
+import { Translation, useTranslate } from '@suite-native/intl';
+import { selectPassphraseError } from '@suite-native/passphrase';
+import { useToast } from '@suite-native/toasts';
+import TrezorConnect from '@trezor/connect';
+
+import { DeviceT2B1Svg } from '../assets/DeviceT2B1Svg';
+
+type NavigationProp = StackToStackCompositeNavigationProps<
+    PassphraseStackParamList,
+    PassphraseStackRoutes.PassphraseForm,
+    RootStackParamList
+>;
+
+export const PassphraseEnableOnDeviceScreen = () => {
+    const passphraseError = useSelector(selectPassphraseError);
+
+    const navigation = useNavigation<NavigationProp>();
+
+    const { showToast } = useToast();
+    const { translate } = useTranslate();
+
+    useEffect(() => {
+        if (passphraseError?.error === 'passphrase-enabling-cancelled') {
+            navigation.navigate(RootStackRoutes.AppTabs, {
+                screen: AppTabsRoutes.HomeStack,
+                params: {
+                    screen: HomeStackRoutes.Home,
+                },
+            });
+            showToast({
+                variant: 'error',
+                icon: 'warningTriangleLight',
+                message: translate('modulePassphrase.enablePassphrase.cancelledError'),
+            });
+        }
+    }, [navigation, passphraseError, showToast, translate]);
+
+    const handleClose = () => {
+        if (navigation.canGoBack()) {
+            navigation.goBack();
+        }
+        TrezorConnect.cancel();
+    };
+
+    return (
+        <Screen
+            screenHeader={
+                <ScreenHeaderWrapper>
+                    <IconButton
+                        size="medium"
+                        colorScheme="tertiaryElevation1"
+                        accessibilityRole="button"
+                        accessibilityLabel="close"
+                        iconName="close"
+                        onPress={handleClose}
+                    />
+                </ScreenHeaderWrapper>
+            }
+        >
+            <VStack flex={1} justifyContent="center" alignItems="center" spacing="medium">
+                <DeviceT2B1Svg />
+                <CenteredTitleHeader
+                    title={<Translation id="modulePassphrase.enablePassphrase.title" />}
+                    subtitle={<Translation id="modulePassphrase.enablePassphrase.subtitle" />}
+                />
+            </VStack>
+        </Screen>
+    );
+};

--- a/suite-native/module-passphrase/tsconfig.json
+++ b/suite-native/module-passphrase/tsconfig.json
@@ -24,6 +24,7 @@
         { "path": "../navigation" },
         { "path": "../passphrase" },
         { "path": "../theme" },
+        { "path": "../toasts" },
         { "path": "../../packages/connect" },
         { "path": "../../packages/styles" }
     ]

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -128,6 +128,7 @@ export type PassphraseStackParamList = {
     [PassphraseStackRoutes.PassphraseEmptyWallet]: undefined;
     [PassphraseStackRoutes.PassphraseVerifyEmptyWallet]: undefined;
     [PassphraseStackRoutes.PassphraseEnterOnTrezor]: undefined;
+    [PassphraseStackRoutes.PassphraseEnableOnDevice]: undefined;
 };
 
 export type RootStackParamList = {

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -50,6 +50,7 @@ export enum PassphraseStackRoutes {
     PassphraseEmptyWallet = 'PassphraseEmptyWallet',
     PassphraseVerifyEmptyWallet = 'PassphraseVerifyEmptyWallet',
     PassphraseEnterOnTrezor = 'PassphraseEnterOnTrezor',
+    PassphraseEnableOnDevice = 'PassphraseEnableOnDevice',
 }
 
 export enum DevUtilsStackRoutes {

--- a/suite-native/passphrase/src/passphraseSlice.ts
+++ b/suite-native/passphrase/src/passphraseSlice.ts
@@ -1,4 +1,4 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createSlice, isAnyOf } from '@reduxjs/toolkit';
 
 import {
     AuthorizeDeviceError,
@@ -25,26 +25,30 @@ export const passphraseSlice = createSlice({
     reducers: {},
     extraReducers: builder => {
         builder
-            .addCase(authorizeDeviceThunk.pending, state => {
-                state.error = null;
-            })
-            .addCase(authorizeDeviceThunk.rejected, (state, { payload }) => {
-                if (payload?.error === 'passphrase-duplicate') {
-                    state.error = payload;
-                }
-            });
-        builder
-            .addCase(createDeviceInstanceThunk.pending, state => {
-                state.error = null;
-            })
-            .addCase(createDeviceInstanceThunk.rejected, (state, { payload }) => {
-                if (payload?.error === 'passphrase-enabling-cancelled') {
-                    state.error = payload;
-                }
-            });
+            .addMatcher(
+                isAnyOf(authorizeDeviceThunk.pending, createDeviceInstanceThunk.pending),
+                state => {
+                    state.error = null;
+                },
+            )
+            .addMatcher(
+                isAnyOf(authorizeDeviceThunk.rejected, createDeviceInstanceThunk.rejected),
+                (state, { payload }) => {
+                    if (
+                        payload?.error === 'passphrase-duplicate' ||
+                        payload?.error === 'passphrase-enabling-cancelled'
+                    ) {
+                        state.error = payload;
+                    }
+                },
+            );
     },
 });
 
 export const selectPassphraseError = (state: PassphraseRootState) => state.passphrase.error;
+
+export const selectPassphraseDuplicateError = (state: PassphraseRootState) => {
+    return state.passphrase.error?.error === 'passphrase-duplicate' ? state.passphrase.error : null;
+};
 
 export const passphraseReducer = passphraseSlice.reducer;

--- a/suite-native/passphrase/src/passphraseSlice.ts
+++ b/suite-native/passphrase/src/passphraseSlice.ts
@@ -1,9 +1,14 @@
 import { createSlice } from '@reduxjs/toolkit';
 
-import { AuthorizeDeviceError, authorizeDeviceThunk } from '@suite-common/wallet-core';
+import {
+    AuthorizeDeviceError,
+    CreateDeviceInstanceError,
+    authorizeDeviceThunk,
+    createDeviceInstance,
+} from '@suite-common/wallet-core';
 
 type PassphraseState = {
-    error: AuthorizeDeviceError | null;
+    error: AuthorizeDeviceError | CreateDeviceInstanceError | null;
 };
 
 type PassphraseRootState = {
@@ -25,6 +30,15 @@ export const passphraseSlice = createSlice({
             })
             .addCase(authorizeDeviceThunk.rejected, (state, { payload }) => {
                 if (payload?.error === 'passphrase-duplicate') {
+                    state.error = payload;
+                }
+            });
+        builder
+            .addCase(createDeviceInstance.pending, state => {
+                state.error = null;
+            })
+            .addCase(createDeviceInstance.rejected, (state, { payload }) => {
+                if (payload?.error === 'passphrase-enabling-cancelled') {
                     state.error = payload;
                 }
             });

--- a/suite-native/passphrase/src/passphraseSlice.ts
+++ b/suite-native/passphrase/src/passphraseSlice.ts
@@ -4,7 +4,7 @@ import {
     AuthorizeDeviceError,
     CreateDeviceInstanceError,
     authorizeDeviceThunk,
-    createDeviceInstance,
+    createDeviceInstanceThunk,
 } from '@suite-common/wallet-core';
 
 type PassphraseState = {
@@ -34,10 +34,10 @@ export const passphraseSlice = createSlice({
                 }
             });
         builder
-            .addCase(createDeviceInstance.pending, state => {
+            .addCase(createDeviceInstanceThunk.pending, state => {
                 state.error = null;
             })
-            .addCase(createDeviceInstance.rejected, (state, { payload }) => {
+            .addCase(createDeviceInstanceThunk.rejected, (state, { payload }) => {
                 if (payload?.error === 'passphrase-enabling-cancelled') {
                     state.error = payload;
                 }

--- a/suite-native/passphrase/src/useHandleDuplicatePassphrase.ts
+++ b/suite-native/passphrase/src/useHandleDuplicatePassphrase.ts
@@ -54,7 +54,7 @@ export const useHandleDuplicatePassphrase = () => {
     );
 
     useEffect(() => {
-        if (passphraseError) {
+        if (passphraseError && passphraseError.error === 'passphrase-duplicate') {
             showAlert({
                 title: translate('modulePassphrase.passphraseMismatch.title'),
                 description: translate('modulePassphrase.passphraseMismatch.subtitle'),

--- a/suite-native/passphrase/src/useHandleDuplicatePassphrase.ts
+++ b/suite-native/passphrase/src/useHandleDuplicatePassphrase.ts
@@ -17,7 +17,7 @@ import {
 import { TrezorDevice } from '@suite-common/suite-types';
 import { useTranslate } from '@suite-native/intl';
 
-import { selectPassphraseError } from './passphraseSlice';
+import { selectPassphraseDuplicateError } from './passphraseSlice';
 
 type NavigationProp = StackToStackCompositeNavigationProps<
     PassphraseStackParamList,
@@ -28,7 +28,7 @@ type NavigationProp = StackToStackCompositeNavigationProps<
 export const useHandleDuplicatePassphrase = () => {
     const dispatch = useDispatch();
 
-    const passphraseError = useSelector(selectPassphraseError);
+    const passphraseDuplicateError = useSelector(selectPassphraseDuplicateError);
 
     const { translate } = useTranslate();
 
@@ -54,17 +54,17 @@ export const useHandleDuplicatePassphrase = () => {
     );
 
     useEffect(() => {
-        if (passphraseError && passphraseError.error === 'passphrase-duplicate') {
+        if (passphraseDuplicateError) {
             showAlert({
                 title: translate('modulePassphrase.passphraseMismatch.title'),
                 description: translate('modulePassphrase.passphraseMismatch.subtitle'),
                 primaryButtonTitle: translate('modulePassphrase.passphraseMismatch.button'),
                 onPressPrimaryButton: () =>
                     handleDuplicateDevicePassphrase({
-                        device: passphraseError.device,
-                        duplicate: passphraseError.duplicate,
+                        device: passphraseDuplicateError.device,
+                        duplicate: passphraseDuplicateError.duplicate,
                     }),
             });
         }
-    }, [handleDuplicateDevicePassphrase, passphraseError, showAlert, translate]);
+    }, [handleDuplicateDevicePassphrase, passphraseDuplicateError, showAlert, translate]);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9587,6 +9587,7 @@ __metadata:
     "@suite-native/navigation": "workspace:*"
     "@suite-native/passphrase": "workspace:*"
     "@suite-native/theme": "workspace:*"
+    "@suite-native/toasts": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/styles": "workspace:*"
     react: "npm:18.2.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- first commit solves the issue with enabling passphrase on Trezor device
- then there is some refactoring to bring better type safety with createDeviceInstanceThunk
- deviceActions.createDeviceInstance removed (tests also removed, seem redundant to test the function at current state)

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/12354

## Screenshots:

https://github.com/trezor/trezor-suite/assets/36101761/0b13bb7a-0660-41a7-86af-a8b77336e6a8

