### PR TITLE
fix(suite): card component bug

### DIFF
--- a/packages/components/src/components/Card/Card.tsx
+++ b/packages/components/src/components/Card/Card.tsx
@@ -140,7 +140,7 @@ export const Card = forwardRef<HTMLDivElement, CardProps>(
                 <CardComponent {...props} ref={ref} />
             </Container>
         ) : (
-            <CardComponent {...props} {...frameProps} ref={ref} />
+            <CardComponent {...props} {...makePropsTransient(frameProps)} ref={ref} />
         );
     },
 );


### PR DESCRIPTION
### Info
The `margin` and `maxWidth` properties don't work correctly in the _Card_ component. It works only if the `label` parameter is provided.