### PR TITLE
feat(connect): use full version in URL when beta

### DIFF
--- a/packages/connect/src/data/version.ts
+++ b/packages/connect/src/data/version.ts
@@ -2,4 +2,8 @@ export const VERSION = '9.2.4-beta.1';
 
 const versionN = VERSION.split('.').map(s => parseInt(s, 10));
 
-export const DEFAULT_DOMAIN = `https://connect.trezor.io/${versionN[0]}/`;
+const isBeta = VERSION.includes('beta');
+
+export const DEFAULT_DOMAIN = isBeta
+    ? `https://connect.trezor.io/${VERSION}/`
+    : `https://connect.trezor.io/${versionN[0]}/`;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Enhances the logic for setting the DEFAULT_DOMAIN based on whether the version is a beta release or not. The DEFAULT_DOMAIN will now appropriately use the major version number for non-beta versions and the full version string for beta versions.

## For VERSION = '9.2.4':

DEFAULT_DOMAIN should be https://connect.trezor.io/9/.

## For VERSION = '9.2.4-beta.1':

DEFAULT_DOMAIN should be https://connect.trezor.io/9.2.4-beta.1/.
