### PR TITLE
Fix: connect Core initialization

### DIFF
--- a/packages/connect-iframe/src/index.ts
+++ b/packages/connect-iframe/src/index.ts
@@ -20,7 +20,7 @@ import {
     CoreRequestMessage,
     CoreEventMessage,
 } from '@trezor/connect';
-import { Core, initCore } from '@trezor/connect/src/core';
+import { initCoreState } from '@trezor/connect/src/core';
 import { DataManager } from '@trezor/connect/src/data/DataManager';
 import { config } from '@trezor/connect/src/data/config';
 import { initLog, LogWriter } from '@trezor/connect/src/utils/debug';
@@ -34,7 +34,7 @@ import { analytics, EventType } from '@trezor/connect-analytics';
 import LogWorker from './sharedLoggerWorker';
 import { initLogWriterWithWorker } from './sharedLoggerUtils';
 
-let _core: Core | undefined;
+const coreManager = initCoreState();
 
 // custom log
 const _log = initLog('IFrame');
@@ -50,6 +50,7 @@ const handleMessage = async (event: MessageEvent<CoreRequestMessage>) => {
     // ignore messages from myself (chrome bug?)
     if (event.source === window || !event.data) return;
     const { data } = event;
+    const core = coreManager.getCore();
     const id = 'id' in data && typeof data.id === 'number' ? data.id : 0;
 
     const fail = (error: string) => {
@@ -67,7 +68,7 @@ const handleMessage = async (event: MessageEvent<CoreRequestMessage>) => {
 
     // respond to call
     // TODO: instead of error _core should be initialized automatically
-    if (!_core && data.type === IFRAME.CALL) {
+    if (!core && data.type === IFRAME.CALL) {
         fail('Core not initialized yet!');
 
         return;
@@ -96,16 +97,16 @@ const handleMessage = async (event: MessageEvent<CoreRequestMessage>) => {
             _popupMessagePort.onmessage = message => handleMessage(message);
         }
 
-        if (!_core) {
+        if (!core) {
             fail('POPUP.HANDSHAKE: Core not initialized');
 
             return;
         }
 
         // Handle immediately, before other logic
-        _core?.handleMessage({ type: POPUP.HANDSHAKE });
+        core.handleMessage({ type: POPUP.HANDSHAKE });
 
-        const transport = _core.getTransportInfo();
+        const transport = core.getTransportInfo();
         const settings = DataManager.getSettings();
 
         postMessage(
@@ -115,7 +116,7 @@ const handleMessage = async (event: MessageEvent<CoreRequestMessage>) => {
             }),
         );
         _log.debug('loading current method');
-        const method = await _core.getCurrentMethod();
+        const method = await core.getCurrentMethod();
 
         if (method?.info) {
             postMessage(
@@ -198,9 +199,7 @@ const handleMessage = async (event: MessageEvent<CoreRequestMessage>) => {
     }
 
     // pass data to Core
-    if (_core) {
-        _core.handleMessage(message);
-    }
+    coreManager.getCore()?.handleMessage(message);
 };
 
 // Communication with 3rd party window and Trezor Popup.
@@ -213,8 +212,9 @@ const postMessage = (message: CoreEventMessage) => {
 
     // popup handshake is resolved automatically
     if (!usingPopup) {
-        if (_core && message.type === UI.REQUEST_UI_WINDOW) {
-            _core.handleMessage({ type: POPUP.HANDSHAKE });
+        const core = coreManager.getCore();
+        if (core && message.type === UI.REQUEST_UI_WINDOW) {
+            core.handleMessage({ type: POPUP.HANDSHAKE });
 
             return;
         }
@@ -331,7 +331,7 @@ const init = async (payload: IFrameInit['payload'], origin: string) => {
 
     try {
         // initialize core
-        _core = await initCore(parsedSettings, postMessage, logWriterFactory);
+        await coreManager.getOrInitCore(parsedSettings, postMessage, logWriterFactory);
         postMessage(
             createIFrameMessage(IFRAME.LOADED, {
                 useBroadcastChannel: !!_popupMessagePort,
@@ -345,7 +345,5 @@ const init = async (payload: IFrameInit['payload'], origin: string) => {
 
 window.addEventListener('message', handleMessage, false);
 window.addEventListener('beforeunload', () => {
-    if (_core) {
-        _core.dispose();
-    }
+    coreManager.getCore()?.dispose();
 });

--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -401,7 +401,7 @@ const initCoreInPopup = async (
 
     const { connectSrc } = payload.settings;
     // core is built in a separate build step.
-    const { initCore, initTransport } = await import(
+    const { initCoreState, initTransport } = await import(
         /* webpackIgnore: true */ `${connectSrc}js/core.js`
     ).catch(_err => {
         fail({
@@ -410,7 +410,7 @@ const initCoreInPopup = async (
         });
     });
 
-    if (!initCore) return;
+    if (!initCoreState) return;
     if (disposed) return;
 
     const state = getState();
@@ -433,7 +433,8 @@ const initCoreInPopup = async (
             handleResponseEvent(message);
         }
     };
-    const core: Core = await initCore(
+    const coreManager = initCoreState();
+    const core: Core = await coreManager.getOrInitCore(
         { ...payload.settings, trustedHost: false },
         onCoreEvent,
         logWriterFactory,

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -203,8 +203,9 @@ const call: CallMethod = async params => {
 
     if (iframe.timeout) {
         // this.init was called, but iframe doesn't return handshake yet
-        return createErrorMessage(ERRORS.TypedError('Init_ManifestMissing'));
+        await iframe.initPromise.promise;
     }
+
     if (iframe.error) {
         // iframe was initialized with error
         return createErrorMessage(iframe.error);

--- a/packages/connect/e2e/tests/api/init.test.ts
+++ b/packages/connect/e2e/tests/api/init.test.ts
@@ -4,8 +4,8 @@ import TrezorConnect from '../../../src';
 const INIT_ERROR = { code: 'Init_ManifestMissing' };
 
 describe('TrezorConnect.init', () => {
-    afterEach(async () => {
-        await TrezorConnect.dispose();
+    afterEach(() => {
+        TrezorConnect.dispose();
     });
 
     beforeAll(() => {
@@ -50,6 +50,21 @@ describe('TrezorConnect.init', () => {
         } catch (error) {
             expect(error).toMatchObject({ code: 'Init_AlreadyInitialized' });
         }
+    });
+
+    it('calling multiple methods synchronously', async () => {
+        TrezorConnect.manifest({
+            appUrl: 'a',
+            email: 'b',
+        });
+
+        const result = await Promise.all([
+            TrezorConnect.getCoinInfo({ coin: 'btc' }),
+            TrezorConnect.blockchainEstimateFee({ request: { blocks: [1] }, coin: 'test' }),
+        ]);
+
+        // success, success
+        expect(result.map(r => r.success)).toEqual([true, true]);
     });
 
     it('init success', async () => {

--- a/packages/connect/src/core/__tests__/Core.test.ts
+++ b/packages/connect/src/core/__tests__/Core.test.ts
@@ -1,0 +1,64 @@
+import { parseConnectSettings } from '../../data/connectSettings';
+import { DataManager } from '../../data/DataManager';
+import { initCoreState } from '../index';
+
+// import { createTestTransport } from '../../device/__tests__/DeviceList.test';
+const { createTestTransport } = global.JestMocks;
+
+describe('Core', () => {
+    beforeAll(async () => {});
+
+    it('getOrInitCore throws error on DataManager load', async () => {
+        jest.spyOn(DataManager, 'load').mockImplementation(() => {
+            throw new Error('DataManager init error');
+        });
+
+        const coreManager = initCoreState();
+        await expect(() =>
+            coreManager.getOrInitCore(parseConnectSettings(), jest.fn()),
+        ).rejects.toThrow('DataManager init error');
+
+        jest.restoreAllMocks();
+    });
+
+    // TODO: this test breaks other tests. DeviceList loading is not disposed while disposing core.
+    it.skip('getOrInitCore throws error when disposed before initialization', done => {
+        const coreManager = initCoreState();
+        coreManager.getOrInitCore(parseConnectSettings(), jest.fn()).catch(error => {
+            expect(error.message).toMatch('Core disposed');
+            done();
+        });
+        coreManager.dispose();
+    });
+
+    it('calling getOrInitCore multiple times synchronously', async () => {
+        const coreManager = initCoreState();
+        const transport = createTestTransport();
+        const settings = parseConnectSettings({ transports: [transport], lazyLoad: true });
+        const [c1, c2] = await Promise.all([
+            coreManager.getOrInitCore(settings, jest.fn()),
+            coreManager.getOrInitCore(settings, jest.fn()),
+        ]);
+
+        // the same instance
+        expect(c1).toEqual(c2);
+        coreManager.dispose();
+    });
+
+    it('successful getOrInitCore', async () => {
+        const coreManager = initCoreState();
+        const transport = createTestTransport();
+        const eventsSpy = jest.fn();
+        const core = await coreManager.getOrInitCore(
+            parseConnectSettings({ transports: [transport] }),
+            eventsSpy,
+        );
+        // no events emitted before initialization
+        expect(eventsSpy).toHaveBeenCalledTimes(0);
+        await new Promise(resolve => setTimeout(resolve, 1));
+        // device + transport events emitted in next tick
+        expect(eventsSpy).toHaveBeenCalledTimes(4);
+
+        core.dispose();
+    });
+});

--- a/packages/connect/src/core/coreManager.ts
+++ b/packages/connect/src/core/coreManager.ts
@@ -1,0 +1,92 @@
+import { EventEmitter } from 'events';
+import { createDeferred, Deferred } from '@trezor/utils';
+import { CORE_EVENT, CoreEventMessage } from '../events';
+import { ConnectSettings } from '../types';
+
+// TODO NOTE: types are temporary, once Core will be moved from index to separate file it could by imported directly
+type CoreInstance = EventEmitter & {
+    init: (
+        settings: ConnectSettings,
+        onCoreEvent: (message: CoreEventMessage) => void,
+        ...rest: any[]
+    ) => Promise<void>;
+    dispose: () => any;
+};
+
+// TODO NOTE: argument `core` is temporary, reason same as above
+export const initCoreManager = <Core extends CoreInstance>(core: Core) => {
+    type CoreState = {
+        initPromise?: Promise<Core>;
+        core?: Core;
+    };
+
+    const state: CoreState = {};
+
+    // resolved by getOrInitCore or rejected by dispose
+    let initDfd: Deferred<Core> | undefined;
+
+    // get or init `Core` instance
+    const getOrInitCore = (
+        ...[settings, onCoreEvent, ...rest]: Parameters<Core['init']>
+    ): Promise<Core> => {
+        // return already initialized Core
+        if (state.core) return Promise.resolve(state.core);
+        // return loading Promise<Core>
+        if (state.initPromise) return state.initPromise;
+
+        // do not send any event until Core is fully loaded
+        // DeviceList emits TRANSPORT and DEVICE events if pendingTransportEvent is set
+        const eventThrottle = async (...args: Parameters<typeof onCoreEvent>) => {
+            if (state.initPromise) {
+                // wait for init success or failure before event propagation
+                const core = await state.initPromise.catch(() => {});
+                // do not propagate events in case of failure
+                if (!core) return;
+            }
+            onCoreEvent(...args);
+        };
+
+        // create initDfd
+        const dfd = createDeferred<Core>();
+        initDfd = dfd;
+        state.initPromise = dfd.promise;
+        // try to init new Core instance
+        core.init(settings, eventThrottle, ...rest)
+            .then(() => {
+                // Core initialized successfully, disable throttle
+                core.on(CORE_EVENT, onCoreEvent);
+                core.off(CORE_EVENT, eventThrottle);
+
+                // update state and resolve initPromise
+                state.core = core;
+                dfd.resolve(core);
+            })
+            .catch(dfd.reject)
+            .finally(() => {
+                initDfd = undefined;
+                delete state.initPromise;
+            });
+
+        return dfd.promise;
+    };
+
+    const dispose = () => {
+        // reject running initPromise
+        initDfd?.reject(new Error('Core disposed'));
+        initDfd = undefined;
+
+        // dispose initialized Core
+        state.core?.dispose();
+
+        // clear state
+        delete state.initPromise;
+        delete state.core;
+    };
+
+    return {
+        getOrInitCore,
+        getCore: () => state.core,
+        getInitPromise: () => state.initPromise,
+        dispose,
+    };
+};

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -38,6 +38,7 @@ import { InteractionTimeout } from '../utils/interactionTimeout';
 import type { DeviceEvents, Device } from '../device/Device';
 import type { ConnectSettings, Device as DeviceTyped } from '../types';
 import { onCallFirmwareUpdate } from './onCallFirmwareUpdate';
+import { initCoreManager } from './coreManager';
 
 // Public variables
 let _core: Core; // Class with event emitter
@@ -1133,56 +1134,49 @@ export class Core extends EventEmitter {
         }
         _deviceList.enumerate();
     }
-}
 
-/**
- * Module initialization.
- * This will download the config.json, init Core emitter instance.
- * Returns Core, an event emitter instance.
- * @param {Object} settings - optional // TODO
- * @returns {Promise<Core>}
- * @memberof Core
- */
-export const initCore = async (
-    settings: ConnectSettings,
-    onCoreEvent: (message: CoreEventMessage) => void,
-    logWriterFactory?: () => LogWriter | undefined,
-) => {
-    if (logWriterFactory) {
-        setLogWriter(logWriterFactory);
-    }
-    try {
-        await DataManager.load(settings);
-        enableLog(DataManager.getSettings('debug'));
-        _core = new Core();
-
-        // If we're not in popup mode, set the interaction timeout to 0 (= disabled)
-        _interactionTimeout = new InteractionTimeout(
-            settings.popup ? settings.interactionTimeout : 0,
-        );
-
-        _core.on(CORE_EVENT, onCoreEvent);
-    } catch (error) {
-        // TODO: kill app
-        _log.error('init', error);
-        throw error;
-    }
-
-    try {
-        if (!DataManager.getSettings('transportReconnect')) {
-            // try only once, if it fails kill and throw initialization error
-            await initDeviceList(false);
-        } else {
-            // don't wait for DeviceList result, further communication will be thru TRANSPORT events
-            initDeviceList(true);
+    async init(
+        settings: ConnectSettings,
+        onCoreEvent: (message: CoreEventMessage) => void,
+        logWriterFactory?: () => LogWriter | undefined,
+    ) {
+        if (logWriterFactory) {
+            setLogWriter(logWriterFactory);
         }
-    } catch (error) {
-        _log.error('initTransport', error);
-        throw error;
-    }
+        try {
+            await DataManager.load(settings);
+            enableLog(DataManager.getSettings('debug'));
 
-    return _core;
-};
+            // TODO NOTE: i'm leaving reference to avoid complex changes, top-level reference is used by methods above Core context
+            // eslint-disable-next-line @typescript-eslint/no-this-alias
+            _core = this;
+
+            // If we're not in popup mode, set the interaction timeout to 0 (= disabled)
+            _interactionTimeout = new InteractionTimeout(
+                settings.popup ? settings.interactionTimeout : 0,
+            );
+
+            this.on(CORE_EVENT, onCoreEvent);
+        } catch (error) {
+            // TODO: kill app
+            _log.error('init', error);
+            throw error;
+        }
+
+        try {
+            if (!DataManager.getSettings('transportReconnect')) {
+                // try only once, if it fails kill and throw initialization error
+                await initDeviceList(false);
+            } else {
+                // don't wait for DeviceList result, further communication will be thru TRANSPORT events
+                initDeviceList(true);
+            }
+        } catch (error) {
+            _log.error('initTransport', error);
+            throw error;
+        }
+    }
+}
 
 const disableWebUSBTransport = async () => {
     if (!_deviceList) return;
@@ -1210,4 +1204,11 @@ const disableWebUSBTransport = async () => {
     } catch (error) {
         // do nothing
     }
+};
+
+/**
+ * State initialization
+ */
+export const initCoreState = () => {
+    return initCoreManager(new Core());
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Something to discuss with @marekrjpolak and @mroz22 

Solving problems:
- multiple synchronous initializations at once
- throttle `DeviceList` events to be dispatched **after** Core successful initialization
- first step to `Core` grooming
- invalid condition when iframe is loaded (throws Manifest is missing)

Whats changed:
- created `coreManager` - manager for `Core` state (loaded/loading/init)
- moved `initCore` function to `Core` class
- added some unit tests for Core/coreManager
- moved `createTestTransport` mock to shared definitions
  