### PR TITLE
feat(suite): Add search to coin control

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -6248,6 +6248,11 @@ export default defineMessages({
         defaultMessage: 'These outputs are likely smaller than the fee required to spend them.',
         description: 'Sub-heading in Coin control section',
     },
+    TR_SEARCH_UTXOS: {
+        id: 'TR_SEARCH_UTXOS',
+        defaultMessage: 'Address, transaction ID, or label',
+        description: 'Placeholder text in Coin control search input',
+    },
     TR_CONNECTED_TO_PROVIDER: {
         defaultMessage: 'Connected to {provider} as {user}',
         id: 'TR_CONNECTED_TO_PROVIDER',

--- a/packages/suite/src/utils/wallet/__fixtures__/filterAndCategorizeUtxosFixture.ts
+++ b/packages/suite/src/utils/wallet/__fixtures__/filterAndCategorizeUtxosFixture.ts
@@ -1,0 +1,184 @@
+import { Utxo } from '@trezor/blockchain-link';
+
+const baseUtxo: Omit<Utxo, 'address'> = {
+    txid: '1',
+    vout: 1,
+    amount: '100',
+    blockHeight: 100,
+    path: 'string',
+    confirmations: 100,
+};
+
+type FilterUtxosParams = {
+    searchQuery: string;
+    utxos: Utxo[];
+    spendableUtxos: Utxo[];
+    lowAnonymityUtxos: Utxo[];
+    dustUtxos: Utxo[];
+    outputLabels: { [txid: string]: any };
+};
+
+type FilterUtxosResult = {
+    filteredUtxos: Utxo[];
+    filteredSpendableUtxos: Utxo[];
+    filteredLowAnonymityUtxos: Utxo[];
+    filteredDustUtxos: Utxo[];
+};
+
+type FilterAndCategorize = {
+    params: FilterUtxosParams;
+    checkResult: (result: FilterUtxosResult) => boolean;
+};
+
+export const filterByAddress: FilterAndCategorize[] = [
+    {
+        params: {
+            searchQuery: 'one',
+            utxos: [
+                {
+                    address: 'one',
+                    ...baseUtxo,
+                },
+                {
+                    address: 'two',
+                    ...baseUtxo,
+                },
+                {
+                    address: 'three',
+                    ...baseUtxo,
+                },
+            ],
+            spendableUtxos: [
+                {
+                    address: 'one',
+                    ...baseUtxo,
+                },
+            ],
+            lowAnonymityUtxos: [
+                {
+                    address: 'two',
+                    ...baseUtxo,
+                },
+            ],
+            dustUtxos: [
+                {
+                    address: 'three',
+                    ...baseUtxo,
+                },
+            ],
+            outputLabels: {},
+        },
+        checkResult: result => {
+            return (
+                result.filteredUtxos.length == 1 &&
+                result.filteredSpendableUtxos.length == 1 &&
+                result.filteredLowAnonymityUtxos.length == 0 &&
+                result.filteredDustUtxos.length == 0
+            );
+        },
+    },
+];
+
+export const filterByTxid: FilterAndCategorize[] = [
+    {
+        params: {
+            searchQuery: '1',
+            utxos: [
+                {
+                    address: 'one',
+                    ...baseUtxo,
+                },
+                {
+                    address: 'two',
+                    ...baseUtxo,
+                },
+                {
+                    address: 'three',
+                    ...baseUtxo,
+                },
+            ],
+            spendableUtxos: [
+                {
+                    address: 'one',
+                    ...baseUtxo,
+                },
+            ],
+            lowAnonymityUtxos: [
+                {
+                    address: 'two',
+                    ...baseUtxo,
+                },
+            ],
+            dustUtxos: [
+                {
+                    address: 'three',
+                    ...baseUtxo,
+                },
+            ],
+            outputLabels: {},
+        },
+        checkResult: result => {
+            return (
+                result.filteredUtxos.length == 3 &&
+                result.filteredSpendableUtxos.length == 1 &&
+                result.filteredLowAnonymityUtxos.length == 1 &&
+                result.filteredDustUtxos.length == 1
+            );
+        },
+    },
+];
+
+export const filterByLabel: FilterAndCategorize[] = [
+    {
+        params: {
+            searchQuery: 'label',
+            utxos: [
+                {
+                    address: 'one',
+                    ...baseUtxo,
+                },
+                {
+                    address: 'two',
+                    ...baseUtxo,
+                    txid: '2',
+                },
+                {
+                    address: 'three',
+                    ...baseUtxo,
+                },
+            ],
+            spendableUtxos: [
+                {
+                    address: 'one',
+                    ...baseUtxo,
+                },
+            ],
+            lowAnonymityUtxos: [
+                {
+                    address: 'two',
+                    ...baseUtxo,
+                    txid: '2',
+                },
+            ],
+            dustUtxos: [
+                {
+                    address: 'three',
+                    ...baseUtxo,
+                },
+            ],
+            outputLabels: {
+                '2': {
+                    1: 'label',
+                },
+            },
+        },
+        checkResult: result => {
+            return (
+                result.filteredUtxos.length == 1 &&
+                result.filteredSpendableUtxos.length == 0 &&
+                result.filteredLowAnonymityUtxos.length == 1 &&
+                result.filteredDustUtxos.length == 0
+            );
+        },
+    },
+];

--- a/packages/suite/src/utils/wallet/__tests__/filterAndCategorizeUtxosUtils.test.ts
+++ b/packages/suite/src/utils/wallet/__tests__/filterAndCategorizeUtxosUtils.test.ts
@@ -1,0 +1,28 @@
+import * as filterAndCategorizeUtxos from '../filterAndCategorizeUtxosUtils';
+import * as fixtures from '../__fixtures__/filterAndCategorizeUtxosFixture';
+
+describe('filterAndCategorizeUtxos', () => {
+    it('filter and categorizes correctly while searching by address', () => {
+        fixtures.filterByAddress.forEach(({ params, checkResult }) => {
+            const categorized = filterAndCategorizeUtxos.filterAndCategorizeUtxos(params);
+
+            expect(checkResult(categorized)).toBe(true);
+        });
+    });
+
+    it('filter and categorizes correctly while searching by txid', () => {
+        fixtures.filterByTxid.forEach(({ params, checkResult }) => {
+            const categorized = filterAndCategorizeUtxos.filterAndCategorizeUtxos(params);
+
+            expect(checkResult(categorized)).toBe(true);
+        });
+    });
+
+    it('filter and categorizes correctly while searching by label', () => {
+        fixtures.filterByLabel.forEach(({ params, checkResult }) => {
+            const categorized = filterAndCategorizeUtxos.filterAndCategorizeUtxos(params);
+
+            expect(checkResult(categorized)).toBe(true);
+        });
+    });
+});

--- a/packages/suite/src/utils/wallet/filterAndCategorizeUtxosUtils.ts
+++ b/packages/suite/src/utils/wallet/filterAndCategorizeUtxosUtils.ts
@@ -1,0 +1,30 @@
+import { AccountOutputLabels } from '@suite-common/metadata-types';
+import { Utxo } from '@trezor/blockchain-link';
+
+type FilterAndCategorizeUtxosParams = {
+    searchQuery: string;
+    utxos: Utxo[];
+    spendableUtxos: Utxo[];
+    lowAnonymityUtxos: Utxo[];
+    dustUtxos: Utxo[];
+    outputLabels: { [txid: string]: AccountOutputLabels };
+};
+
+/**
+ * Filter UTXOs based on search query and categorize them into spendable, low anonymity and dust UTXOs.
+ */
+export const filterAndCategorizeUtxos = (params: FilterAndCategorizeUtxosParams) => {
+    const { searchQuery, utxos, spendableUtxos, lowAnonymityUtxos, dustUtxos, outputLabels } =
+        params;
+    const filterUtxos = (utxo: Utxo) =>
+        utxo.address.includes(searchQuery) ||
+        utxo.txid.includes(searchQuery) ||
+        outputLabels?.[utxo.txid]?.[utxo.vout].includes(searchQuery);
+
+    return {
+        filteredUtxos: utxos.filter(filterUtxos),
+        filteredSpendableUtxos: spendableUtxos.filter(filterUtxos),
+        filteredLowAnonymityUtxos: lowAnonymityUtxos.filter(filterUtxos),
+        filteredDustUtxos: dustUtxos.filter(filterUtxos),
+    };
+};

--- a/packages/suite/src/views/wallet/send/components/Options/BitcoinOptions/CoinControl/UtxoSearch.tsx
+++ b/packages/suite/src/views/wallet/send/components/Options/BitcoinOptions/CoinControl/UtxoSearch.tsx
@@ -1,0 +1,60 @@
+import { useCallback, useRef, Dispatch, SetStateAction, ChangeEvent, KeyboardEvent } from 'react';
+import styled, { useTheme } from 'styled-components';
+import { Input, Icon, KEYBOARD_CODE } from '@trezor/components';
+import { useTranslation } from 'src/hooks/suite/useTranslation';
+
+const Container = styled.div`
+    display: flex;
+    align-items: center;
+    width: 100%;
+`;
+
+export type UtxoSearchProps = {
+    searchQuery: string;
+    setSearch: Dispatch<SetStateAction<string>>;
+    setSelectedPage: Dispatch<SetStateAction<number>>;
+};
+
+export const UtxoSearch = ({ searchQuery, setSearch, setSelectedPage }: UtxoSearchProps) => {
+    const theme = useTheme();
+    const inputRef = useRef<HTMLInputElement | null>(null);
+    const { translationString } = useTranslation();
+
+    const onKeyDown = useCallback(
+        (event: KeyboardEvent) => {
+            // Handle ESC (un-focus)
+            if (event.code === KEYBOARD_CODE.ESCAPE && inputRef.current) {
+                setSearch('');
+                inputRef.current.blur();
+            }
+        },
+        [setSearch],
+    );
+
+    const onSearch = useCallback(
+        ({ target }: ChangeEvent<HTMLInputElement>) => {
+            setSearch(target.value);
+            setSelectedPage(1);
+        },
+        [setSearch, setSelectedPage],
+    );
+
+    return (
+        <Container>
+            <Input
+                data-test="@wallet/send/search-icon"
+                innerRef={inputRef}
+                innerAddon={<Icon icon="SEARCH" size={16} color={theme.iconSubdued} />}
+                placeholder={translationString('TR_SEARCH_UTXOS')}
+                onChange={onSearch}
+                onKeyDown={onKeyDown}
+                value={searchQuery}
+                innerAddonAlign="left"
+                maxLength={512}
+                showClearButton="always"
+                size="small"
+                onClear={() => setSearch('')}
+            />
+        </Container>
+    );
+};


### PR DESCRIPTION
## Description
This feature aims to improve the experience when sending transactions using `Coin Control`. 
When using `Coin Control`, users are presented with a paginated list of 25 transactions per page. For accounts with multiple pages, finding the correct transaction could be time-consuming, as users have to navigate through multiple pages. This pull request adds a search bar to that list, allowing users to filter by `address`, `txid` and `label`.
This could be especially useful when dealing with consolidation transactions.


## Screenshots:
<img width="884" alt="screen" src="https://github.com/trezor/trezor-suite/assets/614795/be288a7d-a5f9-48ff-8b0c-abfb398bb3c4">

