### PR TITLE
fix(ci): connect explorer webextension env

### DIFF
--- a/.github/actions/release-connect/action.yml
+++ b/.github/actions/release-connect/action.yml
@@ -122,6 +122,9 @@ runs:
     - name: Build connect-explorer-webextension
       if: inputs.buildArtifacts == 'true'
       shell: bash
+      env:
+        NODE_ENV: "production"
+        __TREZOR_CONNECT_SRC: https://${{ inputs.serverHostname }}/${{ inputs.serverPath }}/
       run: |
         yarn workspace @trezor/connect-explorer build:webextension
 


### PR DESCRIPTION
## Description

Since #12535 webextension E2E have been failing. 
The reason is that `__TREZOR_CONNECT_SRC` is not properly set during the Connect Explorer webextension build in CI, so the beta URL was used instead, but it doesn't exist. 