### PR TITLE
chore(ci): exclude cardano from legacy connect tests

### DIFF
--- a/ci/scripts/connect-test-matrix-generator.js
+++ b/ci/scripts/connect-test-matrix-generator.js
@@ -86,7 +86,9 @@ const daily = {
 
 const legacyCanaryFirmware = {
     firmwares: ['2.2.0', '2-main'],
-    tests: daily.tests,
+    tests: daily.tests
+        // Cardano supports >=2.6.0
+        .filter(test => test.name !== 'cardano'),
 };
 
 const otherDevices = {


### PR DESCRIPTION
## Description

- Exclude Cardano from legacy Connect tests, since we only support >=2.6.0
- Re-add structure for handling feature detection for legacy firmwares in cardanoSignTransactions