### PR TITLE
ci: add 15 minutes timeout to unit tests jobs

### DIFF
--- a/.github/workflows/check-code-validation.yml
+++ b/.github/workflows/check-code-validation.yml
@@ -78,6 +78,7 @@ jobs:
     name: Unit Tests
     needs: setup-and-cache
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
If [something goes wrong in unit tests](https://github.com/trezor/trezor-suite/actions/runs/9227186099/job/25388646704) and it decides to run indefinitely, let's not wait for global github timeout which is 6 hours. 
