### PR TITLE
transport typing refactorings 

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -1,7 +1,6 @@
 // original file https://github.com/trezor/connect/blob/develop/src/js/device/Device.js
-import { TypedEmitter } from '@trezor/utils';
-import { createDeferred, Deferred } from '@trezor/utils';
-import { versionUtils } from '@trezor/utils';
+import { versionUtils, createDeferred, Deferred, TypedEmitter } from '@trezor/utils';
+import { Session } from '@trezor/transport';
 import { TransportProtocol, v1 as v1Protocol, bridge as bridgeProtocol } from '@trezor/protocol';
 import { DeviceCommands, PassphrasePromptResponse } from './DeviceCommands';
 import { PROTO, ERRORS, NETWORK } from '../constants';
@@ -120,7 +119,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
     firstRunPromise: Deferred<boolean>;
 
-    activitySessionID?: string | null;
+    activitySessionID?: Session | null;
 
     commands?: DeviceCommands;
 

--- a/packages/connect/src/device/DeviceCommands.ts
+++ b/packages/connect/src/device/DeviceCommands.ts
@@ -1,7 +1,7 @@
 // original file https://github.com/trezor/connect/blob/develop/src/js/device/DeviceCommands.js
 
 import { randomBytes } from 'crypto';
-import { Transport } from '@trezor/transport';
+import { Transport, Session } from '@trezor/transport';
 import { MessagesSchema as Messages } from '@trezor/protobuf';
 import { versionUtils } from '@trezor/utils';
 import { ERRORS } from '../constants';
@@ -91,7 +91,7 @@ export class DeviceCommands {
 
     transport: Transport;
 
-    sessionId: string;
+    sessionId: Session;
 
     disposed: boolean;
 
@@ -101,7 +101,7 @@ export class DeviceCommands {
     _cancelableRequest?: (error?: any) => void;
     _cancelableRequestBySend?: boolean;
 
-    constructor(device: Device, transport: Transport, sessionId: string) {
+    constructor(device: Device, transport: Transport, sessionId: Session) {
         this.device = device;
         this.transport = transport;
         this.sessionId = sessionId;

--- a/packages/suite-web/e2e/cypress.config.ts
+++ b/packages/suite-web/e2e/cypress.config.ts
@@ -167,7 +167,9 @@ export default defineConfig({
                     await bridge.init().promise;
                     const enumerateRes = await bridge.enumerate().promise;
                     if (!enumerateRes.success) return null;
-                    await bridge.acquire({ input: { path: enumerateRes.payload[0].path } }).promise;
+                    await bridge.acquire({
+                        input: { path: enumerateRes.payload[0].path, previous: null },
+                    }).promise;
 
                     return null;
                 },

--- a/packages/transport-bridge/src/core.ts
+++ b/packages/transport-bridge/src/core.ts
@@ -8,6 +8,7 @@ import { SessionsClient } from '@trezor/transport/src/sessions/client';
 import { UsbApi } from '@trezor/transport/src/api/usb';
 import { UdpApi } from '@trezor/transport/src/api/udp';
 import { AcquireInput, ReleaseInput } from '@trezor/transport/src/transports/abstract';
+import { Session } from '@trezor/transport/src/types';
 import { Log } from '@trezor/utils';
 import { AbstractApi } from '@trezor/transport/src/api/abstract';
 
@@ -106,7 +107,9 @@ export const createApi = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) => 
         return enumerateDoneResponse;
     };
 
-    const acquire = async (acquireInput: AcquireInput) => {
+    const acquire = async (
+        acquireInput: Omit<AcquireInput, 'previous'> & { previous: Session | 'null' },
+    ) => {
         const acquireIntentResult = await sessionsClient.acquireIntent({
             path: acquireInput.path,
             previous: acquireInput.previous === 'null' ? null : acquireInput.previous,
@@ -139,7 +142,7 @@ export const createApi = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) => 
         return sessionsClient.releaseDone({ path: sessionsResult.payload.path });
     };
 
-    const call = async ({ session, data }: { session: string; data: string }) => {
+    const call = async ({ session, data }: { session: Session; data: string }) => {
         const sessionsResult = await sessionsClient.getPathBySession({
             session,
         });
@@ -161,7 +164,7 @@ export const createApi = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) => 
         return readUtil({ path });
     };
 
-    const send = async ({ session, data }: { session: string; data: string }) => {
+    const send = async ({ session, data }: { session: Session; data: string }) => {
         const sessionsResult = await sessionsClient.getPathBySession({
             session,
         });
@@ -179,7 +182,7 @@ export const createApi = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) => 
         return writeUtil({ path, data });
     };
 
-    const receive = async ({ session }: { session: string }) => {
+    const receive = async ({ session }: { session: Session }) => {
         const sessionsResult = await sessionsClient.getPathBySession({
             session,
         });

--- a/packages/transport-bridge/src/http.ts
+++ b/packages/transport-bridge/src/http.ts
@@ -9,7 +9,7 @@ import {
     parseBodyText,
     Handler,
 } from '@trezor/node-utils';
-import { Descriptor } from '@trezor/transport/src/types';
+import { Descriptor, Session } from '@trezor/transport/src/types';
 import { Log, arrayPartition } from '@trezor/utils';
 import { AbstractApi } from '@trezor/transport/src/api/abstract';
 
@@ -149,7 +149,10 @@ export class TrezordNode {
                 (req, res) => {
                     res.setHeader('Content-Type', 'text/plain');
                     this.api
-                        .acquire({ path: req.params.path, previous: req.params.previous })
+                        .acquire({
+                            path: req.params.path,
+                            previous: req.params.previous as Session | 'null',
+                        })
                         .then(result => {
                             if (!result.success) {
                                 res.statusCode = 400;
@@ -166,7 +169,7 @@ export class TrezordNode {
                 (req, res) => {
                     this.api
                         .release({
-                            session: req.params.session,
+                            session: req.params.session as Session,
                             // @ts-expect-error
                             path: req.body,
                         })
@@ -186,7 +189,7 @@ export class TrezordNode {
                 (req, res) => {
                     this.api
                         .call({
-                            session: req.params.session,
+                            session: req.params.session as Session,
                             // @ts-expect-error
                             data: req.body,
                         })
@@ -204,7 +207,7 @@ export class TrezordNode {
             app.post('/read/:session', [
                 parseBodyJSON,
                 (req, res) => {
-                    this.api.receive({ session: req.params.session }).then(result => {
+                    this.api.receive({ session: req.params.session as Session }).then(result => {
                         if (!result.success) {
                             res.statusCode = 400;
 
@@ -220,7 +223,7 @@ export class TrezordNode {
                 (req, res) => {
                     this.api
                         .send({
-                            session: req.params.session,
+                            session: req.params.session as Session,
                             // @ts-expect-error
                             data: req.body,
                         })

--- a/packages/transport/src/api/abstract.ts
+++ b/packages/transport/src/api/abstract.ts
@@ -28,7 +28,7 @@ export abstract class AbstractApi extends TypedEmitter<{
     'transport-interface-change': Descriptor[];
     'transport-interface-error': typeof ERRORS.DEVICE_NOT_FOUND | typeof ERRORS.DEVICE_UNREADABLE;
 }> {
-    logger: Logger;
+    protected logger: Logger;
 
     constructor({ logger }: AbstractApiConstructorParams) {
         super();
@@ -113,7 +113,7 @@ export abstract class AbstractApi extends TypedEmitter<{
     /**
      * packet size for api
      */
-    abstract chunkSize: number;
+    public abstract chunkSize: number;
 
     protected success<T>(payload: T): Success<T> {
         return success(payload);

--- a/packages/transport/src/api/abstract.ts
+++ b/packages/transport/src/api/abstract.ts
@@ -1,5 +1,11 @@
 import { TypedEmitter } from '@trezor/utils';
-import type { AnyError, AsyncResultWithTypedError, Success, Logger, Descriptor } from '../types';
+import type {
+    AnyError,
+    AsyncResultWithTypedError,
+    Success,
+    Logger,
+    DescriptorApiLevel,
+} from '../types';
 import { success, error, unknownError } from '../utils/result';
 
 import * as ERRORS from '../errors';
@@ -25,7 +31,7 @@ export enum DEVICE_TYPE {
  * This is not public API. Only a building block which is used in src/transports
  */
 export abstract class AbstractApi extends TypedEmitter<{
-    'transport-interface-change': Descriptor[];
+    'transport-interface-change': DescriptorApiLevel[];
     'transport-interface-error': typeof ERRORS.DEVICE_NOT_FOUND | typeof ERRORS.DEVICE_UNREADABLE;
 }> {
     protected logger: Logger;
@@ -45,7 +51,7 @@ export abstract class AbstractApi extends TypedEmitter<{
      * enumerate connected devices
      */
     abstract enumerate(): AsyncResultWithTypedError<
-        { path: string; type: DEVICE_TYPE }[],
+        DescriptorApiLevel[],
         | typeof ERRORS.ABORTED_BY_TIMEOUT
         | typeof ERRORS.ABORTED_BY_SIGNAL
         | typeof ERRORS.UNEXPECTED_ERROR

--- a/packages/transport/src/api/udp.ts
+++ b/packages/transport/src/api/udp.ts
@@ -8,7 +8,8 @@ import * as ERRORS from '../errors';
 
 export class UdpApi extends AbstractApi {
     chunkSize = 64;
-    interface = UDP.createSocket('udp4');
+
+    protected interface = UDP.createSocket('udp4');
     protected communicating = false;
 
     constructor({ logger }: AbstractApiConstructorParams) {

--- a/packages/transport/src/api/usb.ts
+++ b/packages/transport/src/api/usb.ts
@@ -1,5 +1,5 @@
 import { AbstractApi, AbstractApiConstructorParams, DEVICE_TYPE } from './abstract';
-import { AsyncResultWithTypedError } from '../types';
+import { AsyncResultWithTypedError, DescriptorApiLevel } from '../types';
 import {
     CONFIGURATION_ID,
     ENDPOINT_ID,
@@ -83,7 +83,7 @@ export class UsbApi extends AbstractApi {
         }
     }
 
-    private devicesToDescriptors() {
+    private devicesToDescriptors(): DescriptorApiLevel[] {
         return this.devices.map(d => ({
             path: d.path,
             type: this.matchDeviceType(d.device),

--- a/packages/transport/src/api/usb.ts
+++ b/packages/transport/src/api/usb.ts
@@ -29,8 +29,9 @@ const INTERFACE_DEVICE_DISCONNECTED = 'The device was disconnected.' as const;
 
 export class UsbApi extends AbstractApi {
     chunkSize = 64;
-    devices: TransportInterfaceDevice[] = [];
-    usbInterface: ConstructorParams['usbInterface'];
+
+    protected devices: TransportInterfaceDevice[] = [];
+    protected usbInterface: ConstructorParams['usbInterface'];
 
     constructor({ usbInterface, logger }: ConstructorParams) {
         super({ logger });

--- a/packages/transport/src/index.ts
+++ b/packages/transport/src/index.ts
@@ -11,7 +11,7 @@ export * as TRANSPORT_ERROR from './errors';
 protobuf.util.Long = Long;
 protobuf.configure();
 
-export type { Descriptor } from './types';
+export type { Descriptor, Session } from './types';
 export { TREZOR_USB_DESCRIPTORS, TRANSPORT } from './constants';
 
 export { AbstractTransport as Transport, isTransportInstance } from './transports/abstract';

--- a/packages/transport/src/sessions/background.ts
+++ b/packages/transport/src/sessions/background.ts
@@ -186,11 +186,10 @@ export class SessionsBackground extends TypedEmitter<{
         const unconfirmedSessions: Sessions = JSON.parse(JSON.stringify(this.descriptors));
 
         this.lastSessionId++;
-        const id = `${this.lastSessionId}`;
-        unconfirmedSessions[payload.path].session = id;
+        unconfirmedSessions[payload.path].session = `${this.lastSessionId}`;
 
         return this.success({
-            session: id,
+            session: unconfirmedSessions[payload.path].session,
             descriptors: Object.values(unconfirmedSessions),
         });
     }
@@ -204,7 +203,7 @@ export class SessionsBackground extends TypedEmitter<{
         if (!this.descriptors[payload.path]) {
             return this.error(ERRORS.DESCRIPTOR_NOT_FOUND);
         }
-        this.descriptors[payload.path].session = this.lastSessionId.toString();
+        this.descriptors[payload.path].session = `${this.lastSessionId}`;
 
         return Promise.resolve(
             this.success({

--- a/packages/transport/src/sessions/types.ts
+++ b/packages/transport/src/sessions/types.ts
@@ -1,5 +1,11 @@
 import type { AcquireInput } from '../transports/abstract';
-import type { Descriptor, ResultWithTypedError, Success } from '../types';
+import type {
+    Descriptor,
+    DescriptorApiLevel,
+    ResultWithTypedError,
+    Session,
+    Success,
+} from '../types';
 import * as ERRORS from '../errors';
 
 type BackgroundResponseWithError<T, E> = ResultWithTypedError<T, E> & { id: number };
@@ -16,7 +22,7 @@ export type EnumerateIntentResponse = BackgroundResponse<{
 }>;
 
 export type EnumerateDoneRequest = {
-    descriptors: Descriptor[];
+    descriptors: DescriptorApiLevel[];
 };
 
 export type EnumerateDoneResponse = BackgroundResponse<{
@@ -26,7 +32,7 @@ export type EnumerateDoneResponse = BackgroundResponse<{
 export type AcquireIntentRequest = AcquireInput;
 
 export type AcquireIntentResponse = BackgroundResponseWithError<
-    { session: string },
+    { session: Session },
     typeof ERRORS.SESSION_WRONG_PREVIOUS | typeof ERRORS.DESCRIPTOR_NOT_FOUND
 >;
 
@@ -36,13 +42,13 @@ export type AcquireDoneRequest = {
 
 export type AcquireDoneResponse = BackgroundResponseWithError<
     {
-        session: string;
+        session: Session;
         descriptors: Descriptor[];
     },
     typeof ERRORS.DESCRIPTOR_NOT_FOUND
 >;
 export interface ReleaseIntentRequest {
-    session: string;
+    session: Session;
 }
 
 export type ReleaseIntentResponse = BackgroundResponseWithError<
@@ -63,7 +69,7 @@ export type GetSessionsResponse = BackgroundResponse<{
     descriptors: Descriptor[];
 }>;
 export interface GetPathBySessionRequest {
-    session: string;
+    session: Session;
 }
 
 export type GetPathBySessionResponse = BackgroundResponseWithError<

--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -11,7 +11,7 @@ import {
 } from './abstract';
 
 import * as ERRORS from '../errors';
-import { AnyError, AsyncResultWithTypedError, Descriptor } from '../types';
+import { AnyError, AsyncResultWithTypedError, Descriptor, Session } from '../types';
 
 const DEFAULT_URL = 'http://127.0.0.1:21325';
 
@@ -326,7 +326,7 @@ export class BridgeTransport extends AbstractTransport {
         endpoint: '/acquire',
         options: IncompleteRequestOptions,
     ): AsyncResultWithTypedError<
-        string,
+        Session,
         | BridgeCommonErrors
         | typeof ERRORS.DEVICE_NOT_FOUND
         | typeof ERRORS.SESSION_WRONG_PREVIOUS

--- a/packages/transport/src/types/index.ts
+++ b/packages/transport/src/types/index.ts
@@ -2,14 +2,18 @@ import { DEVICE_TYPE } from '../api/abstract';
 
 export * from './apiCall';
 
-export type Session = null | string;
-export type Descriptor = {
+export type Session = `${number}`;
+
+export type DescriptorApiLevel = {
     path: string;
-    session?: Session;
     /** only used in status page */
     type?: DEVICE_TYPE;
     /** only important for T1 over old bridge (trezord-go), defacto part of 'path'. More explanation in https://github.com/trezor/trezor-suite/compare/transport-descriptor-product */
     product?: number;
+};
+
+export type Descriptor = DescriptorApiLevel & {
+    session: null | Session;
 };
 
 export interface Logger {

--- a/packages/transport/src/utils/bridgeApiResult.ts
+++ b/packages/transport/src/utils/bridgeApiResult.ts
@@ -1,6 +1,6 @@
 // input checks for high-level transports
 
-import type { Descriptor } from '../types';
+import type { Descriptor, Session } from '../types';
 
 import { success, error } from './result';
 import * as ERRORS from '../errors';
@@ -75,7 +75,7 @@ export function acquire(res: UnknownPayload) {
         return error({ error: ERRORS.WRONG_RESULT_TYPE });
     }
 
-    return success(session);
+    return success(session as Session);
 }
 
 export function call(res: UnknownPayload) {

--- a/packages/transport/tests/abstractUsb.test.ts
+++ b/packages/transport/tests/abstractUsb.test.ts
@@ -299,7 +299,7 @@ describe('Usb', () => {
             transport.listen();
 
             // set some initial descriptors
-            const acquireCall = transport.acquire({ input: { path: '123' } });
+            const acquireCall = transport.acquire({ input: { path: '123', previous: null } });
             setTimeout(() => {
                 sessionsClient.emit('descriptors', [{ path: '123', session: '2' }]);
             }, 1);


### PR DESCRIPTION
- 9b1307dbd9858a82e71220adb0603cfa55d0e93e - just marking transport apis properties with public/private/protected. 
- 5547145e016c97292d972691d7bae57f0abf204b - turns `type Session: string` to template literal type `type Session: "${number}"`.
