### PR TITLE
fix(staking): add base converting bignumber to string

### DIFF
--- a/packages/suite/src/utils/wallet/stakingUtils.ts
+++ b/packages/suite/src/utils/wallet/stakingUtils.ts
@@ -23,7 +23,7 @@ export const getAccountEverstakeStakingPool = (
         restakedReward: fromWei(pool.restakedReward, 'ether'),
         withdrawTotalAmount: fromWei(pool.withdrawTotalAmount, 'ether'),
         totalPendingStakeBalance: fromWei(
-            new BigNumber(pool.pendingBalance).plus(pool.pendingDepositedBalance).toString(),
+            new BigNumber(pool.pendingBalance).plus(pool.pendingDepositedBalance).toString(10),
             'ether',
         ),
         canClaim:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Fixed an issue where BigNumber.js automatically formats the string as exponential. According to the documentation calling toString with a base argument, e.g. toString(10), will always return normal notation.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
