### PR TITLE
chore: BigNumber.toString(10) to prevent output as exponential

### DIFF
--- a/packages/blockchain-link-utils/package.json
+++ b/packages/blockchain-link-utils/package.json
@@ -23,8 +23,7 @@
         "@mobily/ts-belt": "^3.13.1",
         "@solana/web3.js": "^1.91.6",
         "@trezor/env-utils": "workspace:*",
-        "@trezor/utils": "workspace:*",
-        "bignumber.js": "^9.1.2"
+        "@trezor/utils": "workspace:*"
     },
     "devDependencies": {
         "@trezor/blockchain-link-types": "workspace:*",

--- a/packages/blockchain-link-utils/src/blockbook.ts
+++ b/packages/blockchain-link-utils/src/blockbook.ts
@@ -1,5 +1,4 @@
-import BigNumber from 'bignumber.js';
-
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import type {
     Utxo,
     Transaction,

--- a/packages/blockchain-link-utils/src/blockfrost.ts
+++ b/packages/blockchain-link-utils/src/blockfrost.ts
@@ -1,5 +1,4 @@
-import BigNumber from 'bignumber.js';
-
+import { BigNumber, BigNumberValue } from '@trezor/utils/src/bigNumber';
 import type {
     BlockfrostUtxos,
     BlockfrostTransaction,
@@ -203,7 +202,7 @@ export const transformTransaction = (
 
     let type: Transaction['type'];
     let targets: VinVout[] = [];
-    let amount: BigNumber.Value =
+    let amount: BigNumberValue =
         blockfrostTxData.txData.output_amount.find(b => b.unit === 'lovelace')?.quantity || '0';
     const fee = blockfrostTxData.txData.fees;
 

--- a/packages/blockchain-link-utils/src/solana.ts
+++ b/packages/blockchain-link-utils/src/solana.ts
@@ -1,6 +1,6 @@
 import { A, D, F, pipe } from '@mobily/ts-belt';
-import BigNumber from 'bignumber.js';
 
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { Target, TokenTransfer, Transaction } from '@trezor/blockchain-link-types/src';
 import { arrayPartition } from '@trezor/utils';
 import type {

--- a/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
+++ b/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 const getPublicKey = (address: string) => ({
     toString: () => address,

--- a/packages/blockchain-link-utils/src/utils.ts
+++ b/packages/blockchain-link-utils/src/utils.ts
@@ -1,5 +1,4 @@
-import BigNumber from 'bignumber.js';
-
+import { BigNumber, BigNumberValue } from '@trezor/utils/src/bigNumber';
 import { isNotUndefined, topologicalSort } from '@trezor/utils';
 import type { Transaction, EnhancedVinVout } from '@trezor/blockchain-link-types/src/common';
 import type { VinVout } from '@trezor/blockchain-link-types/src/blockbook';
@@ -35,7 +34,7 @@ export const enhanceVinVout =
         isAccountOwned: isAccountOwned(addresses)(vinVout) || undefined,
     });
 
-export const sumVinVout = (sum: BigNumber.Value, { value }: VinVout): BigNumber.Value =>
+export const sumVinVout = (sum: BigNumberValue, { value }: VinVout): BigNumberValue =>
     typeof value === 'string' ? new BigNumber(value || '0').plus(sum) : sum;
 
 export const transformTarget = (target: VinVout, incoming: VinVout[]) => ({

--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -83,7 +83,6 @@
         "@trezor/utils": "workspace:*",
         "@trezor/utxo-lib": "workspace:*",
         "@types/web": "^0.0.138",
-        "bignumber.js": "^9.1.2",
         "events": "^3.3.0",
         "ripple-lib": "^1.10.1",
         "socks-proxy-agent": "6.1.1",

--- a/packages/blockchain-link/src/workers/electrum/methods/getAccountBalanceHistory.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/getAccountBalanceHistory.ts
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { discovery } from '@trezor/utxo-lib';
 import { sumVinVout } from '@trezor/blockchain-link-utils';
 import { Api, tryGetScripthash, getTransactions, discoverAddress, AddressHistory } from '../utils';

--- a/packages/blockchain-link/src/workers/ripple/index.ts
+++ b/packages/blockchain-link/src/workers/ripple/index.ts
@@ -1,6 +1,6 @@
 import { RippleAPI, APIOptions } from 'ripple-lib';
 import { RippleError } from 'ripple-lib/dist/npm/common/errors';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { CustomError } from '@trezor/blockchain-link-types/src/constants/errors';
 import { MESSAGES, RESPONSES } from '@trezor/blockchain-link-types/src/constants';
 import { BaseWorker, CONTEXT, ContextType } from '../baseWorker';

--- a/packages/blockchain-link/src/workers/solana/fee.ts
+++ b/packages/blockchain-link/src/workers/solana/fee.ts
@@ -1,5 +1,5 @@
 import { Connection, Message, PublicKey } from '@solana/web3.js';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 const COMPUTE_BUDGET_PROGRAM_ID = 'ComputeBudget111111111111111111111111111111';
 const DEFAULT_COMPUTE_UNIT_PRICE_MICROLAMPORTS = 100_000; // micro-lamports, value taken from other wallets

--- a/packages/coinjoin/package.json
+++ b/packages/coinjoin/package.json
@@ -29,7 +29,6 @@
         "@trezor/blockchain-link-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
         "@trezor/utxo-lib": "workspace:*",
-        "bignumber.js": "^9.1.2",
         "cross-fetch": "^4.0.0",
         "events": "^3.3.0",
         "golomb": "1.2.0",

--- a/packages/connect-plugin-stellar/package.json
+++ b/packages/connect-plugin-stellar/package.json
@@ -34,7 +34,7 @@
         "@stellar/stellar-sdk": "^11.2.2"
     },
     "dependencies": {
-        "bignumber.js": "^9.1.2"
+        "@trezor/utils": "workspace:*"
     },
     "scripts": {
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",

--- a/packages/connect-plugin-stellar/src/index.ts
+++ b/packages/connect-plugin-stellar/src/index.ts
@@ -9,7 +9,7 @@ import {
     MemoHash,
     MemoReturn,
 } from '@stellar/stellar-sdk';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 /**
  * Transforms Signer to TrezorConnect.StellarTransaction.Signer

--- a/packages/connect-plugin-stellar/tsconfig.json
+++ b/packages/connect-plugin-stellar/tsconfig.json
@@ -2,5 +2,5 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "./libDev" },
     "include": ["."],
-    "references": []
+    "references": [{ "path": "../utils" }]
 }

--- a/packages/connect-plugin-stellar/tsconfig.lib.json
+++ b/packages/connect-plugin-stellar/tsconfig.lib.json
@@ -4,5 +4,9 @@
         "outDir": "lib"
     },
     "include": ["./src"],
-    "references": []
+    "references": [
+        {
+            "path": "../utils"
+        }
+    ]
 }

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -80,7 +80,6 @@
         "@trezor/transport": "workspace:*",
         "@trezor/utils": "workspace:*",
         "@trezor/utxo-lib": "workspace:*",
-        "bignumber.js": "^9.1.2",
         "blakejs": "^1.2.1",
         "bs58": "^5.0.0",
         "bs58check": "^3.0.1",

--- a/packages/connect/src/api/bitcoin/Fees.ts
+++ b/packages/connect/src/api/bitcoin/Fees.ts
@@ -1,6 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/tx/Fees.js
 
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { Blockchain } from '../../backend/BlockchainLink';
 import type { CoinInfo, FeeLevel } from '../../types';
 

--- a/packages/connect/src/api/bitcoin/TransactionComposer.ts
+++ b/packages/connect/src/api/bitcoin/TransactionComposer.ts
@@ -1,6 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/tx/TransactionComposer.js
 
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { composeTx, ComposeOutput } from '@trezor/utxo-lib';
 import { FeeLevels } from './Fees';
 import { Blockchain } from '../../backend/BlockchainLink';

--- a/packages/connect/src/api/bitcoin/createPendingTx.ts
+++ b/packages/connect/src/api/bitcoin/createPendingTx.ts
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { Transaction as BitcoinJsTransaction } from '@trezor/utxo-lib';
 import { getSerializedPath } from '../../utils/pathUtils';

--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -1,6 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/ComposeTransaction.js
 
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { ERRORS } from '../constants';
 import { UI, createUiMessage } from '../events';

--- a/packages/connect/src/api/ethereum/__fixtures__/ethereumSignTypedData.ts
+++ b/packages/connect/src/api/ethereum/__fixtures__/ethereumSignTypedData.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/prefer-ts-expect-error */
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { TrezorError } from '../../../constants/errors';
 import { PROTO } from '../../../constants';
 

--- a/packages/connect/src/api/ethereum/ethereumSignTypedData.ts
+++ b/packages/connect/src/api/ethereum/ethereumSignTypedData.ts
@@ -1,6 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/helpers/ethereumSignTypedData.js
 
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { PROTO, ERRORS } from '../../constants';
 import { messageToHex } from '../../utils/formatUtils';
 import type { EthereumSignTypedDataTypes } from '../../types/api/ethereum';

--- a/packages/connect/src/api/signTransaction.ts
+++ b/packages/connect/src/api/signTransaction.ts
@@ -1,6 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/SignTransaction.js
 
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams, getFirmwareRange } from './common/paramsValidator';

--- a/packages/connect/src/utils/formatUtils.ts
+++ b/packages/connect/src/utils/formatUtils.ts
@@ -1,6 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/utils/formatUtils.js
 
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import type { CoinInfo } from '../types';
 
 export const formatAmount = (n: string, coinInfo: CoinInfo) =>

--- a/packages/suite-web/e2e/fixtures/eth-account.ts
+++ b/packages/suite-web/e2e/fixtures/eth-account.ts
@@ -1,0 +1,136 @@
+const ETH_ACC = {
+    page: 1,
+    totalPages: 1,
+    itemsOnPage: 25,
+    address: '0xcb6139253d4fa49712C08BF0Cb4F6ea6c2007bF5',
+    balance: '1234000000000000000000',
+    unconfirmedBalance: '0',
+    unconfirmedTxs: 0,
+    txs: 1,
+    nonTokenTxs: 1,
+    internalTxs: 0,
+    transactions: [
+        {
+            txid: '0xec38a68a61d7aebe95c0fdf122cef651a7084301e65ebc94d8ae40498bc84958',
+            vin: [
+                {
+                    n: 0,
+                    addresses: ['0x7de62F23453E9230cC038390901A9A0130105A3c'],
+                    isAddress: true,
+                    isOwn: true,
+                },
+            ],
+            vout: [
+                {
+                    value: '100000000000000000',
+                    n: 0,
+                    addresses: ['0xAFA848357154a6a624686b348303EF9a13F63264'],
+                    isAddress: true,
+                },
+            ],
+            blockHash: '0x10d4e0b9db8cf40055154760238f7470ae3f3ccc6b8c6139b454464a2c768e54',
+            blockHeight: 1469357,
+            confirmations: 152124,
+            blockTime: 1714736076,
+            value: '100000000000000000',
+            fees: '347242000000000',
+            ethereumSpecific: {
+                status: 1,
+                nonce: 9,
+                gasLimit: 416102,
+                gasUsed: 173621,
+                gasPrice: '2000000000',
+                data: '0x3a29dbae0000000000000000000000000000000000000000000000000000000000000001',
+                parsedData: {
+                    methodId: '0x3a29dbae',
+                    name: 'Stake',
+                    function: 'stake(uint64)',
+                    params: [
+                        {
+                            type: 'uint64',
+                            values: ['1'],
+                        },
+                    ],
+                },
+                internalTransfers: [
+                    {
+                        type: 0,
+                        from: '0x02a9d3637126923De9369557CD9673aae46666Fd',
+                        to: '0x66cb3AeD024740164EBcF04e292dB09b5B63A2e1',
+                        value: '55324575000000000',
+                    },
+                    {
+                        type: 0,
+                        from: '0xAFA848357154a6a624686b348303EF9a13F63264',
+                        to: '0x66cb3AeD024740164EBcF04e292dB09b5B63A2e1',
+                        value: '100000000000000000',
+                    },
+                ],
+            },
+        },
+    ],
+    stakingPools: [
+        {
+            contract: '0x624087DD1904ab122A32878Ce9e933C7071F53B9',
+            name: 'Everstake',
+            pendingBalance: '1000000000000000000000',
+            pendingDepositedBalance: '2000000000000000000000',
+            depositedBalance: '3000000000000000000000',
+            withdrawTotalAmount: '4000000000000000000000',
+            claimableAmount: '5000000000000000000000',
+            restakedReward: '1234000000000000000000',
+            autocompoundBalance: '7000000000000000000000',
+        },
+    ],
+    nonce: '1',
+    tokens: [],
+    addressAliases: {},
+};
+
+const isFirstAccount = (descriptor: string) => descriptor === ETH_ACC.address;
+
+export const fixtures = [
+    {
+        method: 'getInfo',
+        default: true,
+        response: {
+            id: '0',
+            data: {
+                name: 'Ethereum Archive',
+                shortcut: 'ETH',
+                decimals: 18,
+                version: '0.4.0',
+                bestHeight: 19960825,
+                bestHash: '0x8339e411cd2f62b9493e36c444f7bd11ec716ceaa94f491e9726233d22abc024',
+                block0Hash: '0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3',
+                testnet: false,
+                backend: {
+                    version: 'erigon/2.59.3/linux-amd64/go1.21.6',
+                    consensus_version: 'Prysm/v5.0.2 (linux amd64)',
+                },
+            },
+        },
+    },
+    {
+        method: 'getAccountInfo',
+        default: true,
+        response: ({ params }: any) => {
+            if (isFirstAccount(params.descriptor)) {
+                return { data: ETH_ACC };
+            }
+        },
+    },
+    {
+        method: 'estimateFee',
+        default: true,
+        response: {
+            data: [
+                {
+                    feePerTx: '25293986739000',
+                    feePerUnit: '1204475559',
+                    feeLimit: '21000',
+                },
+            ],
+        },
+    },
+];

--- a/packages/suite-web/e2e/tests/wallet/staking.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/staking.test.ts
@@ -1,0 +1,68 @@
+// @group_wallet
+// @retry=2
+
+describe('ETH staking', () => {
+    beforeEach(() => {
+        cy.task('startEmu', { wipe: true });
+        cy.task('setupEmu', {
+            needs_backup: false,
+            mnemonic: 'access juice claim special truth ugly swarm rabbit hair man error bar',
+        });
+        cy.task('startBridge');
+
+        cy.viewport(1536, 864).resetDb();
+        cy.prefixedVisit('/settings/coins');
+        cy.passThroughInitialRun();
+    });
+
+    afterEach(() => {
+        cy.task('stopEmu');
+        cy.task('stopBlockbookMock');
+    });
+
+    it('checks that staking dashboard works', () => {
+        cy.task('startBlockbookMock', { endpointsFile: 'eth-account' }).then(port => {
+            const customBlockbook = `ws://localhost:${port}`;
+            cy.log(customBlockbook);
+
+            cy.getTestElement('@settings/wallet/network/btc').click();
+            cy.getTestElement('@settings/wallet/network/eth', { timeout: 30000 })
+                .should('exist')
+                .click()
+                .trigger('mouseover');
+            cy.getTestElement('@settings/wallet/network/eth/advance').click();
+            cy.getTestElement('@modal').should('exist');
+            cy.getTestElement('@settings/advance/select-type/input').click();
+            cy.getTestElement('@settings/advance/select-type/option/blockbook').click();
+            cy.getTestElement('@settings/advance/url').type(customBlockbook);
+            cy.getTestElement('@settings/advance/button/save').click();
+
+            cy.wait(1000);
+            cy.prefixedVisit('/accounts/staking#/eth/0');
+            cy.discoveryShouldFinish();
+
+            cy.getTestElement('@account/staking/pending')
+                .invoke('text')
+                .then(text => {
+                    expect(text).to.equal('3,000');
+                });
+            cy.getTestElement('@account/staking/staked')
+                .invoke('text')
+                .then(text => {
+                    expect(text).to.equal('3,000');
+                });
+            cy.getTestElement('@account/staking/rewards')
+                .invoke('text')
+                .then(text => {
+                    expect(text).to.equal('1,234');
+                });
+            cy.getTestElement('@account/staking/unstaking')
+                .invoke('text')
+                .then(text => {
+                    expect(text).to.equal('4,000');
+                });
+        });
+    });
+});
+
+export {};

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -77,7 +77,6 @@
         "@trezor/type-utils": "workspace:*",
         "@trezor/urls": "workspace:*",
         "@trezor/utils": "workspace:*",
-        "bignumber.js": "^9.1.2",
         "bs58check": "^3.0.1",
         "date-fns": "^2.30.0",
         "dropbox": "^10.34.0",

--- a/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { toWei } from 'web3-utils';
 
 import TrezorConnect, { FeeLevel } from '@trezor/connect';

--- a/packages/suite/src/actions/wallet/stakeActions.ts
+++ b/packages/suite/src/actions/wallet/stakeActions.ts
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import TrezorConnect, { SignedTransaction } from '@trezor/connect';
 import {

--- a/packages/suite/src/components/suite/FormFractionButtons.tsx
+++ b/packages/suite/src/components/suite/FormFractionButtons.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { Translation } from 'src/components/suite';
 import { Button, Tooltip } from '@trezor/components';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import {
     MIN_ETH_AMOUNT_FOR_STAKING,
     MIN_ETH_BALANCE_FOR_STAKING,

--- a/packages/suite/src/components/suite/NumberInput.tsx
+++ b/packages/suite/src/components/suite/NumberInput.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react';
 
 import { Control, FieldValues, useController, UseControllerProps } from 'react-hook-form';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { Input, InputProps } from '@trezor/components';
 import { localizeNumber } from '@suite-common/wallet-utils';

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, forwardRef } from 'react';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { Translation } from 'src/components/suite';
 import { formatNetworkAmount, formatAmount, isTestnet } from '@suite-common/wallet-utils';
 import { BTC_LOCKTIME_VALUE } from '@suite-common/wallet-constants';

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from 'react';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { formatAmount, formatNetworkAmount, isTestnet } from '@suite-common/wallet-utils';
 import { selectDevice } from '@suite-common/wallet-core';

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
@@ -1,5 +1,5 @@
 import styled, { useTheme } from 'styled-components';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { getFeeUnits, formatNetworkAmount, formatAmount, getFee } from '@suite-common/wallet-utils';
 import { Icon, CoinLogo, variables } from '@trezor/components';
 import { formatDuration, isFeatureFlagEnabled } from '@suite-common/suite-utils';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AdvancedTxDetails/AmountDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AdvancedTxDetails/AmountDetails.tsx
@@ -14,7 +14,7 @@ import {
     isTxFeePaid,
     roundTimestampToNearestPastHour,
 } from '@suite-common/wallet-utils';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { FormattedNftAmount } from 'src/components/suite/FormattedNftAmount';
 import { useSelector } from 'src/hooks/suite';
 import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/Options.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/Options.tsx
@@ -8,7 +8,7 @@ import { NetworkSymbol } from '@suite-common/wallet-config';
 import { useSelector } from 'src/hooks/suite';
 import { useUnstakeEthFormContext } from 'src/hooks/wallet/useUnstakeEthForm';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { getAccountEverstakeStakingPool } from 'src/utils/wallet/stakingUtils';
 
 const GreyP = styled(Paragraph)`

--- a/packages/suite/src/components/wallet/Fees/CustomFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/CustomFee.tsx
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import styled from 'styled-components';
 import {
     Control,

--- a/packages/suite/src/components/wallet/TransactionItem/CoinjoinBatchItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/CoinjoinBatchItem.tsx
@@ -1,5 +1,5 @@
 import styled, { css } from 'styled-components';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import {
     formatNetworkAmount,

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionHeading.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionHeading.tsx
@@ -17,7 +17,7 @@ import {
 } from '@suite-common/wallet-utils';
 import { TransactionHeader } from './TransactionHeader';
 import { WalletAccountTransaction } from 'src/types/wallet';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { BlurWrapper } from './TransactionItemBlurWrapper';
 
 const Wrapper = styled.span`

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionRow.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionRow.tsx
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { FiatValue, Translation } from 'src/components/suite';
 import {
     formatCardanoWithdrawal,

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/XRPReserve.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/XRPReserve.tsx
@@ -1,4 +1,4 @@
-import Bignumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { NotificationCard, Translation } from 'src/components/suite';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import type { Account } from 'src/types/wallet/index';
@@ -10,8 +10,8 @@ interface XRPReserveProps {
 
 export const XRPReserve = ({ account }: XRPReserveProps) => {
     if (account?.networkType !== 'ripple') return null;
-    const bigBalance = new Bignumber(account.balance);
-    const bigReserve = new Bignumber(account.misc.reserve);
+    const bigBalance = new BigNumber(account.balance);
+    const bigReserve = new BigNumber(account.misc.reserve);
 
     return bigBalance.isLessThan(bigReserve) ? (
         <NotificationCard

--- a/packages/suite/src/constants/suite/ethStaking.ts
+++ b/packages/suite/src/constants/suite/ethStaking.ts
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 export const MIN_ETH_AMOUNT_FOR_STAKING = new BigNumber(0.1);
 export const MIN_ETH_FOR_WITHDRAWALS = new BigNumber(0.03);

--- a/packages/suite/src/hooks/wallet/form/useCoinjoinUnavailableUtxos.ts
+++ b/packages/suite/src/hooks/wallet/form/useCoinjoinUnavailableUtxos.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { AccountUtxo } from '@trezor/connect';
 
 import { getUtxoOutpoint } from '@suite-common/wallet-utils';

--- a/packages/suite/src/hooks/wallet/useCoinmarketExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketExchangeForm.ts
@@ -54,7 +54,7 @@ import { networkToCryptoSymbol } from 'src/utils/wallet/coinmarket/cryptoSymbolU
 import { FiatCurrencyCode } from '@suite-common/suite-config';
 import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
 import { TokenAddress } from '@suite-common/wallet-types';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 export const ExchangeFormContext = createContext<ExchangeFormContextValues | null>(null);
 ExchangeFormContext.displayName = 'CoinmarketExchangeContext';

--- a/packages/suite/src/hooks/wallet/useCoinmarketSavingsOverview.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketSavingsOverview.ts
@@ -6,7 +6,7 @@ import type {
 import { useCoinmarketNavigation } from 'src/hooks/wallet/useCoinmarketNavigation';
 import { useSelector } from 'src/hooks/suite';
 import { Trade } from 'src/types/wallet/coinmarketCommonTypes';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { selectFiatRatesByFiatRateKey } from '@suite-common/wallet-core';
 import { getFiatRateKey } from '@suite-common/wallet-utils';
 import { FiatCurrencyCode } from '@suite-common/suite-config';

--- a/packages/suite/src/hooks/wallet/useRbfForm.ts
+++ b/packages/suite/src/hooks/wallet/useRbfForm.ts
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { createContext, useContext, useState, useEffect, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 import { fromWei } from 'web3-utils';

--- a/packages/suite/src/hooks/wallet/useStakeEthForm.ts
+++ b/packages/suite/src/hooks/wallet/useStakeEthForm.ts
@@ -1,7 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import useDebounce from 'react-use/lib/useDebounce';
 
 import {

--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -1,5 +1,5 @@
 import { MiddlewareAPI } from 'redux';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { getPhysicalDeviceCount } from '@suite-common/suite-utils';
 import {

--- a/packages/suite/src/reducers/wallet/cardanoStakingReducer.ts
+++ b/packages/suite/src/reducers/wallet/cardanoStakingReducer.ts
@@ -2,7 +2,7 @@ import produce from 'immer';
 import { CARDANO_STAKING } from 'src/actions/wallet/constants';
 import { WalletAction } from 'src/types/wallet';
 import { CardanoNetwork, PendingStakeTx, PoolsResponse } from 'src/types/wallet/cardanoStaking';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 export interface State {
     pendingTx: PendingStakeTx[];

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -1,5 +1,5 @@
 import produce from 'immer';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { memoizeWithArgs } from 'proxy-memoize';
 
 import { getInputSize, getOutputSize, RoundPhase } from '@trezor/coinjoin';

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { toWei } from 'web3-utils';
 import { isDesktop } from '@trezor/env-utils';
 import type { State } from 'src/reducers/wallet/settingsReducer';

--- a/packages/suite/src/utils/suite/stake.ts
+++ b/packages/suite/src/utils/suite/stake.ts
@@ -11,7 +11,7 @@ import { Ethereum } from '@everstake/wallet-sdk';
 import { fromWei, numberToHex, toWei } from 'web3-utils';
 import { getEthereumEstimateFeeParams, sanitizeHex } from '@suite-common/wallet-utils';
 import TrezorConnect, { EthereumTransaction } from '@trezor/connect';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { ValidatorsQueue } from '@suite-common/wallet-core';
 
 // Gas reserve ensuring txs are processed

--- a/packages/suite/src/utils/suite/validation.ts
+++ b/packages/suite/src/utils/suite/validation.ts
@@ -8,7 +8,7 @@ import {
     isInteger,
     networkAmountToSatoshi,
 } from '@suite-common/wallet-utils';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { TranslationFunction } from 'src/hooks/suite/useTranslation';
 import { AmountLimits } from 'src/types/wallet/coinmarketCommonTypes';
 

--- a/packages/suite/src/utils/wallet/__fixtures__/stakingUtils.ts
+++ b/packages/suite/src/utils/wallet/__fixtures__/stakingUtils.ts
@@ -1,0 +1,145 @@
+export const getAccountEverstakeStakingPoolFixtures = [
+    {
+        description: 'Ethereum network with Everstake pool and small balances',
+        account: {
+            networkType: 'ethereum',
+            misc: {
+                stakingPools: [
+                    {
+                        name: 'Everstake',
+                        autocompoundBalance: '1000000000000000000', // 1 Ether in wei
+                        claimableAmount: '500000000000000000', // 0.5 Ether in wei
+                        depositedBalance: '3000000000000000000', // 3 Ether in wei
+                        pendingBalance: '100000000000000000', // 0.1 Ether in wei
+                        pendingDepositedBalance: '200000000000000000', // 0.2 Ether in wei
+                        restakedReward: '150000000000000000', // 0.15 Ether in wei
+                        withdrawTotalAmount: '500000000000000000', // 0.5 Ether in wei
+                    },
+                ],
+            },
+        },
+        expected: {
+            name: 'Everstake',
+            autocompoundBalance: '1', // Ether
+            claimableAmount: '0.5', // Ether
+            depositedBalance: '3', // Ether
+            pendingBalance: '0.1', // Ether
+            pendingDepositedBalance: '0.2', // Ether
+            restakedReward: '0.15', // Ether
+            withdrawTotalAmount: '0.5', // Ether
+            totalPendingStakeBalance: '0.3', // 0.1 + 0.2 Ether
+            canClaim: true,
+        },
+    },
+    {
+        description: 'Ethereum network with Everstake pool and extremely large balances',
+        account: {
+            networkType: 'ethereum',
+            misc: {
+                stakingPools: [
+                    {
+                        name: 'Everstake',
+                        autocompoundBalance: '1000000000000000000000', // 1000 Ether in wei
+                        claimableAmount: '50000000000000000000000', // 50,000 Ether in wei
+                        depositedBalance: '30000000000000000000000', // 30,000 Ether in wei
+                        pendingBalance: '1000000000000000000000', // 1000 Ether in wei
+                        pendingDepositedBalance: '2000000000000000000000', // 2000 Ether in wei
+                        restakedReward: '150000000000000000000', // 150 Ether in wei
+                        withdrawTotalAmount: '50000000000000000000000', // 50,000 Ether in wei
+                    },
+                ],
+            },
+        },
+        expected: {
+            name: 'Everstake',
+            autocompoundBalance: '1000', // Ether
+            claimableAmount: '50000', // Ether
+            depositedBalance: '30000', // Ether
+            pendingBalance: '1000', // Ether
+            pendingDepositedBalance: '2000', // Ether
+            restakedReward: '150', // Ether
+            withdrawTotalAmount: '50000', // Ether
+            totalPendingStakeBalance: '3000', // 1000 + 2000 Ether
+            canClaim: true,
+        },
+    },
+    {
+        description: 'Ethereum network without Everstake pool',
+        account: {
+            networkType: 'ethereum',
+            misc: {
+                stakingPools: [
+                    {
+                        name: 'TrezorPool',
+                        autocompoundBalance: '1000000000000000000',
+                    },
+                ],
+            },
+        },
+        expected: undefined,
+    },
+    {
+        description: 'Non-Ethereum network with Everstake pool',
+        account: {
+            networkType: 'bitcoin',
+            misc: {
+                stakingPools: [
+                    {
+                        name: 'Everstake',
+                        autocompoundBalance: '1000000000000000000',
+                    },
+                ],
+            },
+        },
+        expected: undefined,
+    },
+];
+
+export const getAccountAutocompoundBalanceFixtures = [
+    {
+        description: 'Ethereum account with valid Everstake pool',
+        account: {
+            networkType: 'ethereum',
+            misc: {
+                stakingPools: [
+                    {
+                        name: 'Everstake',
+                        autocompoundBalance: '1000000000000000000', // 1 Ether in wei
+                        claimableAmount: '500000000000000000', // 0.5 Ether in wei
+                        depositedBalance: '3000000000000000000', // 3 Ether in wei
+                        pendingBalance: '100000000000000000', // 0.1 Ether in wei
+                        pendingDepositedBalance: '200000000000000000', // 0.2 Ether in wei
+                        restakedReward: '150000000000000000', // 0.15 Ether in wei
+                        withdrawTotalAmount: '500000000000000000', // 0.5 Ether in wei
+                    },
+                ],
+            },
+        },
+        expectedBalance: '1', // Ether
+    },
+    {
+        description: 'Ethereum account without Everstake pool',
+        account: {
+            networkType: 'ethereum',
+            misc: {
+                stakingPools: [],
+            },
+        },
+        expectedBalance: '0',
+    },
+    {
+        description: 'Non-Ethereum network with Everstake pool',
+        account: {
+            networkType: 'bitcoin',
+            misc: {
+                stakingPools: [
+                    {
+                        name: 'Everstake',
+                        autocompoundBalance: '1000000000000000000',
+                    },
+                ],
+            },
+        },
+        expectedBalance: '0',
+    },
+];

--- a/packages/suite/src/utils/wallet/__tests__/stakingUtils.test.ts
+++ b/packages/suite/src/utils/wallet/__tests__/stakingUtils.test.ts
@@ -1,0 +1,24 @@
+import { Account } from '@suite-common/wallet-types';
+import { getAccountAutocompoundBalance, getAccountEverstakeStakingPool } from '../stakingUtils';
+import {
+    getAccountAutocompoundBalanceFixtures,
+    getAccountEverstakeStakingPoolFixtures,
+} from '../__fixtures__/stakingUtils';
+
+describe('getAccountEverstakeStakingPool', () => {
+    getAccountEverstakeStakingPoolFixtures.forEach(({ description, account, expected }) => {
+        it(description, () => {
+            const result = getAccountEverstakeStakingPool(account as unknown as Account);
+            expect(result).toEqual(expected);
+        });
+    });
+});
+
+describe('getAccountAutocompoundBalance', () => {
+    getAccountAutocompoundBalanceFixtures.forEach(({ description, account, expectedBalance }) => {
+        it(description, () => {
+            const result = getAccountAutocompoundBalance(account as unknown as Account);
+            expect(result).toEqual(expectedBalance);
+        });
+    });
+});

--- a/packages/suite/src/utils/wallet/coinjoinUtils.ts
+++ b/packages/suite/src/utils/wallet/coinjoinUtils.ts
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { createHash } from 'crypto';
 import hoursToMilliseconds from 'date-fns/hoursToMilliseconds';
 

--- a/packages/suite/src/utils/wallet/coinmarket/savingsUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/savingsUtils.ts
@@ -3,7 +3,7 @@ import {
     CustomPaymentAmountKey,
     PaymentFrequencyAnnualCoefficient,
 } from 'src/constants/wallet/coinmarket/savings';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import type { PaymentFrequencyOption } from 'src/types/wallet/coinmarketCommonTypes';
 import { isDesktop } from '@trezor/env-utils';
 import { desktopApi } from '@trezor/suite-desktop-api';

--- a/packages/suite/src/utils/wallet/graph/utils.ts
+++ b/packages/suite/src/utils/wallet/graph/utils.ts
@@ -3,7 +3,7 @@ import { resetTime } from '@suite-common/suite-utils';
 import { networks, type NetworkSymbol } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { differenceInMonths } from 'date-fns';
 
 import { CommonAggregatedHistory, GraphData, GraphRange, GraphScale } from 'src/types/wallet/graph';

--- a/packages/suite/src/utils/wallet/graph/utilsShared.ts
+++ b/packages/suite/src/utils/wallet/graph/utilsShared.ts
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { AggregatedAccountHistory, AggregatedDashboardHistory } from 'src/types/wallet/graph';
 
 export type ObjectType<T> = T extends 'account'

--- a/packages/suite/src/utils/wallet/graph/utilsWorker.ts
+++ b/packages/suite/src/utils/wallet/graph/utilsWorker.ts
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { fromUnixTime, getUnixTime, startOfMonth } from 'date-fns';
 
 import {

--- a/packages/suite/src/utils/wallet/stakingUtils.ts
+++ b/packages/suite/src/utils/wallet/stakingUtils.ts
@@ -1,5 +1,5 @@
 import { Account, StakingPoolExtended } from '@suite-common/wallet-types';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { fromWei } from 'web3-utils';
 
 export const getAccountEverstakeStakingPool = (

--- a/packages/suite/src/utils/wallet/tokenUtils.ts
+++ b/packages/suite/src/utils/wallet/tokenUtils.ts
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { Account, Rate, TokenAddress, RatesByKey } from '@suite-common/wallet-types';
 import { TokenInfo } from '@trezor/connect';

--- a/packages/suite/src/views/dashboard/components/AssetsView/components/AssetTable.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsView/components/AssetTable.tsx
@@ -2,7 +2,7 @@ import { AssetFiatBalance } from '@suite-common/assets';
 import { AssetRow, AssetRowSkeleton } from './AssetRow';
 import { AssetTableHeader } from './AssetTableHeader';
 import { Network } from '@suite-common/wallet-config';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import styled from 'styled-components';
 import { spacingsPx } from '@trezor/theme';
 

--- a/packages/suite/src/views/dashboard/components/AssetsView/index.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsView/index.tsx
@@ -1,5 +1,5 @@
 import styled, { useTheme } from 'styled-components';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { Icon, Button, LoadingContent, Card } from '@trezor/components';
 import { selectCurrentFiatRates, selectDeviceSupportedNetworks } from '@suite-common/wallet-core';

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect } from 'react';
 import styled, { css } from 'styled-components';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { isZero, amountToSatoshi, getFiatRateKey } from '@suite-common/wallet-utils';
 import { useCoinmarketExchangeFormContext } from 'src/hooks/wallet/useCoinmarketExchangeForm';

--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/List/ExchangeQuote.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/List/ExchangeQuote.tsx
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import styled, { useTheme } from 'styled-components';
 
 import { Button, variables, Icon, H3, Card } from '@trezor/components';

--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/SendSwapTransaction/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/SendSwapTransaction/index.tsx
@@ -4,7 +4,7 @@ import { Translation, AccountLabeling, FormattedCryptoAmount } from 'src/compone
 import { Button, Icon, Input, Paragraph, SelectBar, Tooltip, variables } from '@trezor/components';
 import { useCoinmarketExchangeOffersContext } from 'src/hooks/wallet/useCoinmarketExchangeOffers';
 import useDebounce from 'react-use/lib/useDebounce';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { FieldError } from 'react-hook-form';
 import { BottomText } from '@trezor/components/src/components/form/BottomText';
 import { TranslationKey } from '@suite-common/intl-types';

--- a/packages/suite/src/views/wallet/coinmarket/p2p/offers/List/Quote.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/p2p/offers/List/Quote.tsx
@@ -1,6 +1,6 @@
 import { FormattedNumber } from 'react-intl';
 import styled, { useTheme } from 'styled-components';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { useFormatters } from '@suite-common/formatters';
 import { Translation } from 'src/components/suite';

--- a/packages/suite/src/views/wallet/coinmarket/sell/components/SellForm/Inputs/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/components/SellForm/Inputs/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect } from 'react';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import styled from 'styled-components';
 
 import { useCoinmarketSellFormContext } from 'src/hooks/wallet/useCoinmarketSellForm';

--- a/packages/suite/src/views/wallet/send/components/Options/BitcoinOptions/Locktime.tsx
+++ b/packages/suite/src/views/wallet/send/components/Options/BitcoinOptions/Locktime.tsx
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import styled from 'styled-components';
 import { NumberInput, Translation } from 'src/components/suite';
 import { useSendFormContext } from 'src/hooks/wallet';

--- a/packages/suite/src/views/wallet/send/components/Options/RippleOptions/DestinationTag.tsx
+++ b/packages/suite/src/views/wallet/send/components/Options/RippleOptions/DestinationTag.tsx
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { Input, Icon } from '@trezor/components';
 import { Translation } from 'src/components/suite';
 import { useSendFormContext } from 'src/hooks/wallet';

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/Fiat.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/Fiat.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { Timestamp, TokenAddress, FiatRatesResult } from '@suite-common/wallet-types';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import styled from 'styled-components';
 import { Controller } from 'react-hook-form';
 

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/TokenSelect.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/TokenSelect.tsx
@@ -7,7 +7,7 @@ import { Account } from 'src/types/wallet';
 import { Output } from '@suite-common/wallet-types';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { updateFiatRatesThunk, selectCurrentFiatRates } from '@suite-common/wallet-core';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { Timestamp, TokenAddress } from '@suite-common/wallet-types';
 import { TooltipSymbol, Translation } from 'src/components/suite';
 import { NetworkSymbol, getNetworkFeatures } from '@suite-common/wallet-config';

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import styled, { useTheme } from 'styled-components';
 
 import { Icon, Warning, variables } from '@trezor/components';

--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/PayoutCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/PayoutCard.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { useTheme } from 'styled-components';
 import { Icon } from '@trezor/components';
 import { Translation } from 'src/components/suite';

--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/StakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/StakingCard.tsx
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import styled, { useTheme } from 'styled-components';
 import { Button, Card, Icon, variables } from '@trezor/components';
 import { spacingsPx } from '@trezor/theme';

--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/StakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/StakingCard.tsx
@@ -152,6 +152,7 @@ export const StakingCard = ({
                         </AmountHeading>
 
                         <TrimmedCryptoAmount
+                            data-test="@account/staking/pending"
                             value={totalPendingStakeBalance}
                             symbol={selectedAccount?.symbol}
                         />
@@ -173,6 +174,7 @@ export const StakingCard = ({
                     </AmountHeading>
 
                     <TrimmedCryptoAmount
+                        data-test="@account/staking/staked"
                         value={depositedBalance}
                         symbol={selectedAccount?.symbol}
                     />
@@ -193,6 +195,7 @@ export const StakingCard = ({
                     </AmountHeading>
 
                     <TrimmedCryptoAmount
+                        data-test="@account/staking/rewards"
                         value={restakedReward}
                         symbol={selectedAccount?.symbol}
                         isRewards
@@ -229,6 +232,7 @@ export const StakingCard = ({
                         </AmountHeading>
 
                         <TrimmedCryptoAmount
+                            data-test="@account/staking/unstaking"
                             value={withdrawTotalAmount}
                             symbol={selectedAccount?.symbol}
                         />

--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/TrimmedCryptoAmount.tsx
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/TrimmedCryptoAmount.tsx
@@ -21,6 +21,7 @@ interface TrimmedCryptoAmountProps {
     symbol: string;
     maxDecimalPlaces?: number;
     isRewards?: boolean;
+    'data-test'?: string;
 }
 
 export const TrimmedCryptoAmount = ({
@@ -28,11 +29,19 @@ export const TrimmedCryptoAmount = ({
     symbol,
     maxDecimalPlaces = DEFAULT_MAX_DECIMAL_PLACES,
     isRewards,
+    'data-test': dataTest,
 }: TrimmedCryptoAmountProps) => {
     const hasDecimals = value.toString().includes('.');
 
     if (!hasDecimals) {
-        return <StyledFormattedCryptoAmount value={value} symbol={symbol} $isRewards={isRewards} />;
+        return (
+            <StyledFormattedCryptoAmount
+                value={value}
+                symbol={symbol}
+                $isRewards={isRewards}
+                data-test={dataTest}
+            />
+        );
     }
 
     const valueBig = new BigNumber(value);
@@ -41,6 +50,7 @@ export const TrimmedCryptoAmount = ({
     return (
         <Tooltip content={<StyledFormattedCryptoAmount value={value} symbol={symbol} $isSmall />}>
             <StyledFormattedCryptoAmount
+                data-test={dataTest}
                 value={trimmedAmount}
                 symbol={symbol}
                 $isRewards={isRewards}

--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/TrimmedCryptoAmount.tsx
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/TrimmedCryptoAmount.tsx
@@ -2,7 +2,7 @@ import { FormattedCryptoAmount } from 'src/components/suite';
 import styled from 'styled-components';
 import { spacingsPx } from '@trezor/theme';
 import { Tooltip, variables } from '@trezor/components';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 const StyledFormattedCryptoAmount = styled(FormattedCryptoAmount)<{
     $isRewards?: boolean;

--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/hooks/useIsTxStatusShown.ts
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/hooks/useIsTxStatusShown.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 export const useIsTxStatusShown = (totalPendingStake: BigNumber, accountDescriptor?: string) => {
     // Handling the edge case, when a user can witness sudden change of pending stake deposit to 0.

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/DayHeader.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/DayHeader.tsx
@@ -1,6 +1,6 @@
 import { FormattedDate } from 'react-intl';
 import styled from 'styled-components';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { variables } from '@trezor/components';
 import { zIndices } from '@trezor/theme';

--- a/packages/suite/src/views/wallet/transactions/components/InfoCard.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/InfoCard.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { variables, Card, SkeletonRectangle } from '@trezor/components';
 import { HiddenPlaceholder, FormattedCryptoAmount, Sign } from 'src/components/suite';
 import { Account } from 'src/types/wallet';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 const Wrapper = styled(Card)`
     display: flex;

--- a/packages/suite/src/views/wallet/transactions/components/SummaryCards.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/SummaryCards.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { Translation, HiddenPlaceholder, FormattedDate } from 'src/components/suite';
 import { Account } from 'src/types/wallet';
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -35,5 +35,8 @@
     },
     "devDependencies": {
         "tsx": "^4.7.0"
+    },
+    "dependencies": {
+        "bignumber.js": "^9.1.2"
     }
 }

--- a/packages/utils/src/bigNumber.ts
+++ b/packages/utils/src/bigNumber.ts
@@ -1,0 +1,9 @@
+import BN from 'bignumber.js';
+
+export const BigNumber = BN.clone({
+    // Set to the maximum value to avoid scientific notation
+    EXPONENTIAL_AT: 1e9,
+});
+
+export type BigNumber = BN;
+export type BigNumberValue = BN.Value;

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -40,3 +40,4 @@ export * from './typedEventEmitter';
 export * from './urlToOnion';
 export * from './logs';
 export * from './logsManager';
+export * from './bigNumber';

--- a/scripts/check-commit-messages.sh
+++ b/scripts/check-commit-messages.sh
@@ -28,7 +28,7 @@ for commit in $(git rev-list origin/"$BASE_BRANCH_NAME"..HEAD); do
     fi
 
     # Check commit message syntax
-    if ! echo "$commit_msg" | grep -qE "^(build|ci|docs|feat|fix|perf|refactor|style|test|chore|revert|npm-release|release)(\([a-z, -]+\))?: "; then
+    if ! echo "$commit_msg" | grep -qE "^(build|ci|docs|feat|fix|perf|refactor|style|test|chore|revert|npm-release|release)(\([a-z0-9, -]+\))?: "; then
     tput -T linux setaf 1
     echo "Conventional Commits validation failed for commit $commit: $commit_msg"
     tput -T linux sgr0

--- a/suite-common/assets/package.json
+++ b/suite-common/assets/package.json
@@ -12,6 +12,6 @@
     },
     "dependencies": {
         "@suite-common/wallet-config": "workspace:*",
-        "bignumber.js": "^9.1.2"
+        "@trezor/utils": "workspace:*"
     }
 }

--- a/suite-common/assets/tsconfig.json
+++ b/suite-common/assets/tsconfig.json
@@ -1,5 +1,8 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
-    "references": [{ "path": "../wallet-config" }]
+    "references": [
+        { "path": "../wallet-config" },
+        { "path": "../../packages/utils" }
+    ]
 }

--- a/suite-common/formatters/package.json
+++ b/suite-common/formatters/package.json
@@ -21,7 +21,7 @@
         "@suite-common/wallet-types": "workspace:*",
         "@suite-common/wallet-utils": "workspace:*",
         "@trezor/connect": "workspace:*",
-        "bignumber.js": "^9.1.2",
+        "@trezor/utils": "workspace:*",
         "date-fns": "^2.30.0",
         "react": "18.2.0",
         "react-intl": "^6.6.2",

--- a/suite-common/formatters/src/formatters/prepareFiatAmountFormatter.ts
+++ b/suite-common/formatters/src/formatters/prepareFiatAmountFormatter.ts
@@ -1,5 +1,6 @@
-import BigNumber from 'bignumber.js';
 import { FormatNumberOptions } from '@formatjs/intl';
+
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { makeFormatter } from '../makeFormatter';
 import { FormatterConfig } from '../types';

--- a/suite-common/formatters/tsconfig.json
+++ b/suite-common/formatters/tsconfig.json
@@ -9,6 +9,7 @@
         { "path": "../wallet-core" },
         { "path": "../wallet-types" },
         { "path": "../wallet-utils" },
-        { "path": "../../packages/connect" }
+        { "path": "../../packages/connect" },
+        { "path": "../../packages/utils" }
     ]
 }

--- a/suite-common/graph/package.json
+++ b/suite-common/graph/package.json
@@ -23,7 +23,7 @@
         "@suite-common/wallet-utils": "workspace:*",
         "@trezor/blockchain-link": "workspace:*",
         "@trezor/connect": "workspace:*",
-        "bignumber.js": "^9.1.2",
+        "@trezor/utils": "workspace:*",
         "date-fns": "^2.30.0",
         "react": "18.2.0",
         "react-redux": "8.0.7"

--- a/suite-common/graph/src/graphDataFetching.ts
+++ b/suite-common/graph/src/graphDataFetching.ts
@@ -1,7 +1,7 @@
 import { A, D, G, pipe } from '@mobily/ts-belt';
-import BigNumber from 'bignumber.js';
 import { fromUnixTime, getUnixTime } from 'date-fns';
 
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { FiatCurrencyCode } from '@suite-common/suite-config';
 import { NetworkSymbol, getNetworkType } from '@suite-common/wallet-config';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';

--- a/suite-common/graph/src/graphUtils.ts
+++ b/suite-common/graph/src/graphUtils.ts
@@ -1,7 +1,7 @@
 import { A, D, pipe } from '@mobily/ts-belt';
-import BigNumber from 'bignumber.js';
 import { differenceInMinutes, eachMinuteOfInterval, fromUnixTime, getUnixTime } from 'date-fns';
 
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { FiatCurrencyCode } from '@suite-common/suite-config';
 import { getBlockbookSafeTime } from '@suite-common/suite-utils';
 import { NetworkSymbol } from '@suite-common/wallet-config';

--- a/suite-common/graph/tsconfig.json
+++ b/suite-common/graph/tsconfig.json
@@ -14,6 +14,7 @@
         {
             "path": "../../packages/blockchain-link"
         },
-        { "path": "../../packages/connect" }
+        { "path": "../../packages/connect" },
+        { "path": "../../packages/utils" }
     ]
 }

--- a/suite-common/suite-types/package.json
+++ b/suite-common/suite-types/package.json
@@ -18,7 +18,6 @@
         "@trezor/connect": "workspace:*",
         "@trezor/env-utils": "workspace:*",
         "@trezor/type-utils": "workspace:*",
-        "@trezor/utils": "workspace:*",
-        "bignumber.js": "^9.1.2"
+        "@trezor/utils": "workspace:*"
     }
 }

--- a/suite-common/suite-types/src/sign.ts
+++ b/suite-common/suite-types/src/sign.ts
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 export type SignOperator = 'positive' | 'negative';
 

--- a/suite-common/suite-utils/package.json
+++ b/suite-common/suite-utils/package.json
@@ -20,7 +20,6 @@
         "@trezor/connect": "workspace:*",
         "@trezor/urls": "workspace:*",
         "@trezor/utils": "workspace:*",
-        "bignumber.js": "^9.1.2",
         "date-fns": "^2.30.0"
     }
 }

--- a/suite-common/transaction-cache-engine/package.json
+++ b/suite-common/transaction-cache-engine/package.json
@@ -14,7 +14,6 @@
         "@mobily/ts-belt": "^3.13.1",
         "@suite-common/wallet-config": "workspace:*",
         "@trezor/connect": "workspace:*",
-        "@trezor/utils": "workspace:*",
-        "bignumber.js": "^9.1.2"
+        "@trezor/utils": "workspace:*"
     }
 }

--- a/suite-common/transaction-cache-engine/src/tests/__fixtures__/xrp.ts
+++ b/suite-common/transaction-cache-engine/src/tests/__fixtures__/xrp.ts
@@ -1,5 +1,4 @@
-import BigNumber from 'bignumber.js';
-
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { AccountInfo, Response as ConnectResponse } from '@trezor/connect';
 
 import { AccountBalanceHistory } from '../../types';

--- a/suite-common/transaction-cache-engine/src/types.ts
+++ b/suite-common/transaction-cache-engine/src/types.ts
@@ -1,5 +1,4 @@
-import BigNumber from 'bignumber.js';
-
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { AccountTransaction, AccountInfo } from '@trezor/connect';
 

--- a/suite-common/transaction-cache-engine/src/utils/balanceHistory.ts
+++ b/suite-common/transaction-cache-engine/src/utils/balanceHistory.ts
@@ -1,5 +1,4 @@
-import BigNumber from 'bignumber.js';
-
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { AccountTransaction } from '@trezor/connect';
 import { NetworkSymbol, getNetworkType } from '@suite-common/wallet-config';
 

--- a/suite-common/wallet-core/package.json
+++ b/suite-common/wallet-core/package.json
@@ -35,7 +35,6 @@
         "@trezor/suite-analytics": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
-        "bignumber.js": "^9.1.2",
         "date-fns": "^2.30.0",
         "proxy-memoize": "2.0.2",
         "web3-utils": "^4.2.3"

--- a/suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts
@@ -1,6 +1,6 @@
-import BigNumber from 'bignumber.js';
 import { G } from '@mobily/ts-belt';
 
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import TrezorConnect, { FeeLevel, Params, SignTransaction } from '@trezor/connect';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {

--- a/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
@@ -1,7 +1,7 @@
-import BigNumber from 'bignumber.js';
 import { toWei } from 'web3-utils';
 import { G } from '@mobily/ts-belt';
 
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import TrezorConnect, { FeeLevel, TokenInfo } from '@trezor/connect';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {

--- a/suite-common/wallet-core/src/send/sendFormRippleThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormRippleThunks.ts
@@ -1,6 +1,6 @@
-import BigNumber from 'bignumber.js';
 import { G } from '@mobily/ts-belt';
 
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import TrezorConnect, { FeeLevel, RipplePayment } from '@trezor/connect';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {

--- a/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
@@ -1,6 +1,6 @@
-import BigNumber from 'bignumber.js';
 import { G } from '@mobily/ts-belt';
 
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import TrezorConnect, { FeeLevel } from '@trezor/connect';
 import type { TokenInfo, TokenAccount } from '@trezor/blockchain-link-types';
 import { SYSTEM_PROGRAM_PUBLIC_KEY } from '@trezor/blockchain-link-utils/src/solana';

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -1,6 +1,6 @@
-import BigNumber from 'bignumber.js';
 import { G, A } from '@mobily/ts-belt';
 
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { createThunk } from '@suite-common/redux-utils';
 import {
     Account,

--- a/suite-common/wallet-core/src/stake/stakeThunks.ts
+++ b/suite-common/wallet-core/src/stake/stakeThunks.ts
@@ -1,5 +1,4 @@
-import BigNumber from 'bignumber.js';
-
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { createThunk } from '@suite-common/redux-utils';
 import { Timeout } from '@trezor/type-utils';
 

--- a/suite-common/wallet-utils/package.json
+++ b/suite-common/wallet-utils/package.json
@@ -32,7 +32,6 @@
         "@trezor/connect": "workspace:*",
         "@trezor/urls": "workspace:*",
         "@trezor/utils": "workspace:*",
-        "bignumber.js": "^9.1.2",
         "date-fns": "^2.30.0",
         "pdfmake": "^0.2.9",
         "react": "18.2.0",

--- a/suite-common/wallet-utils/src/__fixtures__/solanaUtils.ts
+++ b/suite-common/wallet-utils/src/__fixtures__/solanaUtils.ts
@@ -1,5 +1,4 @@
-import BigNumber from 'bignumber.js';
-
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import {
     TOKEN_PROGRAM_PUBLIC_KEY,
     SYSTEM_PROGRAM_PUBLIC_KEY,

--- a/suite-common/wallet-utils/src/__tests__/localizeNumber.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/localizeNumber.test.ts
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { localizeNumber } from '../localizeNumberUtils';
 

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -1,5 +1,4 @@
-import BigNumber from 'bignumber.js';
-
+import { BigNumber, BigNumberValue } from '@trezor/utils/src/bigNumber';
 import {
     AccountInfo,
     AccountAddresses,
@@ -277,7 +276,7 @@ export const getAccountDecimals = (symbol: NetworkSymbol) => {
 export const stripNetworkAmount = (amount: string, decimals: number) =>
     new BigNumber(amount).toFixed(decimals, 1);
 
-export const formatAmount = (amount: BigNumber.Value, decimals: number) => {
+export const formatAmount = (amount: BigNumberValue, decimals: number) => {
     try {
         const bAmount = new BigNumber(amount);
         if (bAmount.isNaN()) {
@@ -290,7 +289,7 @@ export const formatAmount = (amount: BigNumber.Value, decimals: number) => {
     }
 };
 
-export const amountToSatoshi = (amount: BigNumber.Value, decimals: number) => {
+export const amountToSatoshi = (amount: BigNumberValue, decimals: number) => {
     try {
         const bAmount = new BigNumber(amount);
         if (bAmount.isNaN()) {
@@ -304,7 +303,7 @@ export const amountToSatoshi = (amount: BigNumber.Value, decimals: number) => {
     }
 };
 
-export const satoshiAmountToBtc = (amount: BigNumber.Value) => {
+export const satoshiAmountToBtc = (amount: BigNumberValue) => {
     try {
         const satsAmount = new BigNumber(amount);
         if (satsAmount.isNaN()) {

--- a/suite-common/wallet-utils/src/antiFraud.ts
+++ b/suite-common/wallet-utils/src/antiFraud.ts
@@ -1,6 +1,6 @@
-import BigNumber from 'bignumber.js';
 import { D } from '@mobily/ts-belt';
 
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import type { WalletAccountTransaction } from '@suite-common/wallet-types';
 import { TokenDefinitions, isTokenDefinitionKnown } from '@suite-common/token-definitions';
 import { getNetworkType } from '@suite-common/wallet-config';

--- a/suite-common/wallet-utils/src/balanceUtils.ts
+++ b/suite-common/wallet-utils/src/balanceUtils.ts
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { localizeNumber } from './localizeNumberUtils';
 

--- a/suite-common/wallet-utils/src/cardanoUtils.ts
+++ b/suite-common/wallet-utils/src/cardanoUtils.ts
@@ -1,5 +1,4 @@
-import BigNumber from 'bignumber.js';
-
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import {
     Account,
     Output,

--- a/suite-common/wallet-utils/src/ethUtils.ts
+++ b/suite-common/wallet-utils/src/ethUtils.ts
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 export const decimalToHex = (dec: number): string => new BigNumber(dec).toString(16);
 

--- a/suite-common/wallet-utils/src/exportTransactionsUtils.ts
+++ b/suite-common/wallet-utils/src/exportTransactionsUtils.ts
@@ -1,8 +1,8 @@
 import type { TDocumentDefinitions } from 'pdfmake/interfaces';
 import { fromWei } from 'web3-utils';
 import { format } from 'date-fns';
-import BigNumber from 'bignumber.js';
 
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { trezorLogo } from '@suite-common/suite-constants';
 import { TransactionTarget } from '@trezor/connect';
 import { FiatCurrencyCode } from '@suite-common/suite-config';

--- a/suite-common/wallet-utils/src/fiatConverterUtils.ts
+++ b/suite-common/wallet-utils/src/fiatConverterUtils.ts
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 export const toFiatCurrency = (amount: string, rate?: number, decimals = 2) => {
     if (!rate) {

--- a/suite-common/wallet-utils/src/localizeNumberUtils.ts
+++ b/suite-common/wallet-utils/src/localizeNumberUtils.ts
@@ -1,5 +1,4 @@
-import BigNumber from 'bignumber.js';
-
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { getLocaleSeparators } from '@trezor/utils';
 
 export const localizeNumber = (

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -7,9 +7,9 @@ import {
     Merge,
 } from 'react-hook-form';
 
-import BigNumber from 'bignumber.js';
 import { fromWei, numberToHex, padLeft, toWei } from 'web3-utils';
 
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { fiatCurrencies } from '@suite-common/suite-config';
 import { isFeatureFlagEnabled } from '@suite-common/suite-utils';
 import { Network, NetworkType } from '@suite-common/wallet-config';

--- a/suite-common/wallet-utils/src/solanaUtils.ts
+++ b/suite-common/wallet-utils/src/solanaUtils.ts
@@ -1,8 +1,8 @@
 import * as BufferLayout from '@solana/buffer-layout';
 import { A, F, pipe } from '@mobily/ts-belt';
-import BigNumber from 'bignumber.js';
 import type { Transaction } from '@solana/web3.js';
 
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import type { TokenAccount } from '@trezor/blockchain-link-types';
 import { solanaUtils as SolanaBlockchainLinkUtils } from '@trezor/blockchain-link-utils';
 

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -1,7 +1,7 @@
-import BigNumber from 'bignumber.js';
 import { fromWei, toWei } from 'web3-utils';
 import { addDays, startOfMonth } from 'date-fns';
 
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import {
     Account,
     RbfTransactionParams,

--- a/suite-native/assets/package.json
+++ b/suite-native/assets/package.json
@@ -27,7 +27,7 @@
         "@suite-native/navigation": "workspace:*",
         "@suite-native/settings": "workspace:*",
         "@trezor/styles": "workspace:*",
-        "bignumber.js": "^9.1.2",
+        "@trezor/utils": "workspace:*",
         "jotai": "1.9.1",
         "proxy-memoize": "2.0.2",
         "react": "^18.2.0",

--- a/suite-native/assets/src/assetsSelectors.ts
+++ b/suite-native/assets/src/assetsSelectors.ts
@@ -1,6 +1,6 @@
-import BigNumber from 'bignumber.js';
 import { memoize } from 'proxy-memoize';
 
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { networks, NetworkSymbol } from '@suite-common/wallet-config';
 import {
     AccountsRootState,

--- a/suite-native/assets/tsconfig.json
+++ b/suite-native/assets/tsconfig.json
@@ -26,6 +26,7 @@
         { "path": "../intl" },
         { "path": "../navigation" },
         { "path": "../settings" },
-        { "path": "../../packages/styles" }
+        { "path": "../../packages/styles" },
+        { "path": "../../packages/utils" }
     ]
 }

--- a/suite-native/formatters/package.json
+++ b/suite-native/formatters/package.json
@@ -23,7 +23,7 @@
         "@suite-native/settings": "workspace:*",
         "@trezor/blockchain-link": "workspace:*",
         "@trezor/styles": "workspace:*",
-        "bignumber.js": "^9.1.2",
+        "@trezor/utils": "workspace:*",
         "react": "18.2.0",
         "react-native": "0.73.6",
         "react-redux": "8.0.7",

--- a/suite-native/formatters/src/utils.ts
+++ b/suite-native/formatters/src/utils.ts
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 /** Matches three groups: 1. currency symbol,  2. whole number part and 3. decimal part. */
 const BALANCE_PARSING_REGEX = /^(\D+)([\d,]+)(?:\.(\d+))?$/u;

--- a/suite-native/formatters/tsconfig.json
+++ b/suite-native/formatters/tsconfig.json
@@ -26,6 +26,7 @@
         {
             "path": "../../packages/blockchain-link"
         },
-        { "path": "../../packages/styles" }
+        { "path": "../../packages/styles" },
+        { "path": "../../packages/utils" }
     ]
 }

--- a/suite-native/module-send/package.json
+++ b/suite-native/module-send/package.json
@@ -26,7 +26,7 @@
         "@suite-native/forms": "workspace:*",
         "@suite-native/navigation": "workspace:*",
         "@trezor/styles": "workspace:*",
-        "bignumber.js": "^9.1.2",
+        "@trezor/utils": "workspace:*",
         "react": "18.2.0",
         "react-redux": "8.0.7"
     }

--- a/suite-native/module-send/src/sendFormSchema.ts
+++ b/suite-native/module-send/src/sendFormSchema.ts
@@ -1,6 +1,6 @@
 import { G } from '@mobily/ts-belt';
-import BigNumber from 'bignumber.js';
 
+import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { formatNetworkAmount, isAddressValid } from '@suite-common/wallet-utils';
 import { FeeInfo } from '@suite-common/wallet-types';

--- a/suite-native/module-send/tsconfig.json
+++ b/suite-native/module-send/tsconfig.json
@@ -23,6 +23,7 @@
         { "path": "../formatters" },
         { "path": "../forms" },
         { "path": "../navigation" },
-        { "path": "../../packages/styles" }
+        { "path": "../../packages/styles" },
+        { "path": "../../packages/utils" }
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8351,7 +8351,7 @@ __metadata:
   resolution: "@suite-common/assets@workspace:suite-common/assets"
   dependencies:
     "@suite-common/wallet-config": "workspace:*"
-    bignumber.js: "npm:^9.1.2"
+    "@trezor/utils": "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -8411,7 +8411,7 @@ __metadata:
     "@suite-common/wallet-types": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"
     "@trezor/connect": "workspace:*"
-    bignumber.js: "npm:^9.1.2"
+    "@trezor/utils": "workspace:*"
     date-fns: "npm:^2.30.0"
     react: "npm:18.2.0"
     react-intl: "npm:^6.6.2"
@@ -8435,7 +8435,7 @@ __metadata:
     "@suite-common/wallet-utils": "workspace:*"
     "@trezor/blockchain-link": "workspace:*"
     "@trezor/connect": "workspace:*"
-    bignumber.js: "npm:^9.1.2"
+    "@trezor/utils": "workspace:*"
     date-fns: "npm:^2.30.0"
     react: "npm:18.2.0"
     react-redux: "npm:8.0.7"
@@ -8575,7 +8575,6 @@ __metadata:
     "@trezor/env-utils": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
-    bignumber.js: "npm:^9.1.2"
   languageName: unknown
   linkType: soft
 
@@ -8591,7 +8590,6 @@ __metadata:
     "@trezor/connect": "workspace:*"
     "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"
-    bignumber.js: "npm:^9.1.2"
     date-fns: "npm:^2.30.0"
   languageName: unknown
   linkType: soft
@@ -8659,7 +8657,6 @@ __metadata:
     "@suite-common/wallet-config": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/utils": "workspace:*"
-    bignumber.js: "npm:^9.1.2"
   languageName: unknown
   linkType: soft
 
@@ -8719,7 +8716,6 @@ __metadata:
     "@trezor/suite-analytics": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
-    bignumber.js: "npm:^9.1.2"
     date-fns: "npm:^2.30.0"
     proxy-memoize: "npm:2.0.2"
     web3-utils: "npm:^4.2.3"
@@ -8769,7 +8765,6 @@ __metadata:
     "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@types/pdfmake": "npm:^0.2.9"
-    bignumber.js: "npm:^9.1.2"
     date-fns: "npm:^2.30.0"
     pdfmake: "npm:^0.2.9"
     react: "npm:18.2.0"
@@ -8970,7 +8965,7 @@ __metadata:
     "@suite-native/navigation": "workspace:*"
     "@suite-native/settings": "workspace:*"
     "@trezor/styles": "workspace:*"
-    bignumber.js: "npm:^9.1.2"
+    "@trezor/utils": "workspace:*"
     jotai: "npm:1.9.1"
     proxy-memoize: "npm:2.0.2"
     react: "npm:^18.2.0"
@@ -9198,7 +9193,7 @@ __metadata:
     "@suite-native/settings": "workspace:*"
     "@trezor/blockchain-link": "workspace:*"
     "@trezor/styles": "workspace:*"
-    bignumber.js: "npm:^9.1.2"
+    "@trezor/utils": "workspace:*"
     react: "npm:18.2.0"
     react-native: "npm:0.73.6"
     react-redux: "npm:8.0.7"
@@ -9649,7 +9644,7 @@ __metadata:
     "@suite-native/forms": "workspace:*"
     "@suite-native/navigation": "workspace:*"
     "@trezor/styles": "workspace:*"
-    bignumber.js: "npm:^9.1.2"
+    "@trezor/utils": "workspace:*"
     react: "npm:18.2.0"
     react-redux: "npm:8.0.7"
   languageName: unknown
@@ -10351,7 +10346,6 @@ __metadata:
     "@trezor/env-utils": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
-    bignumber.js: "npm:^9.1.2"
     tsx: "npm:^4.7.0"
   peerDependencies:
     tslib: ^2.6.2
@@ -10371,7 +10365,6 @@ __metadata:
     "@trezor/utils": "workspace:*"
     "@trezor/utxo-lib": "workspace:*"
     "@types/web": "npm:^0.0.138"
-    bignumber.js: "npm:^9.1.2"
     events: "npm:^3.3.0"
     fs-extra: "npm:^11.2.0"
     html-webpack-plugin: "npm:^5.6.0"
@@ -10398,7 +10391,6 @@ __metadata:
     "@trezor/blockchain-link-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@trezor/utxo-lib": "workspace:*"
-    bignumber.js: "npm:^9.1.2"
     cross-fetch: "npm:^4.0.0"
     events: "npm:^3.3.0"
     golomb: "npm:1.2.0"
@@ -10607,7 +10599,7 @@ __metadata:
   resolution: "@trezor/connect-plugin-stellar@workspace:packages/connect-plugin-stellar"
   dependencies:
     "@stellar/stellar-sdk": "npm:^11.2.2"
-    bignumber.js: "npm:^9.1.2"
+    "@trezor/utils": "workspace:*"
   peerDependencies:
     "@stellar/stellar-sdk": ^11.2.2
     "@trezor/connect": 9.x.x
@@ -10764,7 +10756,6 @@ __metadata:
     "@types/karma": "npm:^6.3.8"
     "@types/parse-uri": "npm:^1.0.2"
     babel-loader: "npm:^9.1.3"
-    bignumber.js: "npm:^9.1.2"
     blakejs: "npm:^1.2.1"
     bs58: "npm:^5.0.0"
     bs58check: "npm:^3.0.1"
@@ -11277,7 +11268,6 @@ __metadata:
     "@types/ua-parser-js": "npm:^0.7.39"
     "@types/uuid": "npm:^9.0.6"
     "@types/zxcvbn": "npm:^4.4.4"
-    bignumber.js: "npm:^9.1.2"
     bs58check: "npm:^3.0.1"
     date-fns: "npm:^2.30.0"
     dropbox: "npm:^10.34.0"
@@ -11421,6 +11411,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/utils@workspace:packages/utils"
   dependencies:
+    bignumber.js: "npm:^9.1.2"
     tsx: "npm:^4.7.0"
   peerDependencies:
     tslib: ^2.6.2


### PR DESCRIPTION
## Description

This change ensures that all `toString` calls on `BigNumber` objects include base 10 as a parameter. By doing this, we prevent numbers from being displayed in exponential form.

- added unit and e2e test for ETH staking with balances >= 1000 ETH

![Screenshot 2024-05-27 at 15 37 45 (1)](https://github.com/trezor/trezor-suite/assets/33235762/d09d577c-7010-498c-b423-b472ab5b18a3)
