### PR TITLE
ci(github): indentation error in check-connect-version-match

### DIFF
--- a/.github/actions/check-connect-version-match/action.yml
+++ b/.github/actions/check-connect-version-match/action.yml
@@ -1,7 +1,7 @@
 name: "Check Connect Version Match with Branch"
 description: "Check if the version in package.json matches the version in the branch name"
 inputs:
- branch_ref:
+  branch_ref:
     description: "The full ref of the branch"
     required: true
     type: string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix indentation typo in `.github/actions/check-connect-version-match/action.yml`
