### PR TITLE
ci(github): missing shell in action

### DIFF
--- a/.github/actions/check-connect-version-match/action.yml
+++ b/.github/actions/check-connect-version-match/action.yml
@@ -14,6 +14,7 @@ runs:
   using: "composite"
   steps:
     - name: Extract branch version
+      shell: bash
       id: extract-branch-version
       run: |
         BRANCH_REF="${{ inputs.branch_ref }}"
@@ -21,6 +22,7 @@ runs:
         echo "branch_version=$BRANCH_VERSION" >> $GITHUB_OUTPUT
 
     - name: Check if version in package.json matches the one in branch name
+      shell: bash
       run: |
         BRANCH_VERSION="${{ steps.extract-branch-version.outputs.branch_version }}"
         EXTRACTED_VERSION="${{ inputs.extracted_version }}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Actions do not use a shell by default, it requires to be explicitly assigned.
