### PR TITLE
fix(connect-examples): allow multiple lines replicing of url mv2 and mv3

### DIFF
--- a/packages/connect-examples/update-webextensions.js
+++ b/packages/connect-examples/update-webextensions.js
@@ -71,7 +71,8 @@ rootPaths.forEach(dir => {
     ['trezor-usb-permissions.js'].forEach(p => {
         let content = fs.readFileSync(path.join(srcPath, 'src', 'webextension', p), 'utf-8');
         if (trezorConnectSrc !== DEFAULT_SRC) {
-            content = content.replace(/^const url = .*$/gm, `const url = '${trezorConnectSrc}';`);
+            const urlRegex = /const url = .*?;/s;
+            content = content.replace(urlRegex, `const url = '${trezorConnectSrc}';`);
         }
         fs.writeFileSync(path.join(rootPath, buildFolder, 'vendor', p), content, 'utf-8');
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Allow multiple lines replicing of url mv2 and mv3.

Because the new code in `packages/connect-web/src/webextension/trezor-usb-permissions.js` is multi-line like: 

```ts
const url = isBeta
    ? `https://connect.trezor.io/${VERSION}/`
    : `https://connect.trezor.io/${versionN[0]}/`;
```

The build script was producing output like:

```ts
const url = 'https://staging-connect.trezor.io/9.2.4-beta.2/';
    ? `https://connect.trezor.io/${VERSION}/`
    : `https://connect.trezor.io/${versionN[0]}/`;
```

And that was throwing error. The new regex takes everything until `;`.  And the result is:

```ts
const url = 'https://staging-connect.trezor.io/9.2.4-beta.2/';
```

This is not the best building process but it works as a simple example.

## How to test it?

Run 

-   yarn
-   yarn build:libs
-   yarn workspace @trezor/connect-web build:webextension
-   yarn workspace @trezor/connect-web build:inline
-   node ./packages/connect-examples/update-webextensions.js --trezor-connect-src https://staging-connect.trezor.io/9.2.4-beta.2/

