### PR TITLE
fix(connect-explorer): show amountUnit in signTransaction (#12592)

### DIFF
--- a/packages/connect-explorer/src/data/methods/bitcoin/signTransaction.custom.ts
+++ b/packages/connect-explorer/src/data/methods/bitcoin/signTransaction.custom.ts
@@ -50,6 +50,7 @@ export default [
                 name: 'versionGroupId',
                 label: 'Version group id',
                 type: 'number',
+                defaultValue: '',
                 value: '',
             },
             {
@@ -62,6 +63,7 @@ export default [
                 name: 'branchId',
                 label: 'Branch id',
                 type: 'number',
+                defaultValue: '',
                 value: '',
             },
             {
@@ -81,6 +83,18 @@ export default [
                 label: 'Display recipient address in chunks of 4 characters',
                 type: 'checkbox',
                 value: false,
+            },
+            {
+                name: 'amountUnit',
+                label: 'Display amount in units',
+                type: 'select',
+                value: 'BITCOIN',
+                data: [
+                    { value: 0, label: 'BITCOIN (0)' },
+                    { value: 1, label: 'MILLIBITCOIN (1)' },
+                    { value: 2, label: 'MICROBITCOIN (2)' },
+                    { value: 3, label: 'SATOSHI (3)' },
+                ],
             },
         ],
     },

--- a/packages/connect-explorer/src/pages/methods/bitcoin/signTransaction.mdx
+++ b/packages/connect-explorer/src/pages/methods/bitcoin/signTransaction.mdx
@@ -1,5 +1,4 @@
-import { Type } from '@sinclair/typebox';
-
+import { Type } from '@trezor/schema-utils';
 import { PROTO } from '@trezor/connect/src/constants';
 
 import { CommonParamsLink } from '../../../components/CommonParamsLink';
@@ -37,8 +36,8 @@ export const SignTransactionSchema = Type.Object({
     timestamp: Type.Optional(Type.Number()),
     branchId: Type.Optional(Type.Number()),
     push: Type.Optional(Type.Boolean()),
-    amountUnit: Type.Optional(Type.Object({})),
-    unlockPath: Type.Optional(Type.Object({})),
+    amountUnit: Type.Optional(PROTO.EnumAmountUnit),
+    unlockPath: Type.Optional(PROTO.UnlockPath),
     serialize: Type.Optional(Type.Boolean()),
     chunkify: Type.Optional(Type.Boolean()),
 });


### PR DESCRIPTION
## Description

Fix displaying `amountUnit` in Sign transaction params docs. 
Add `amountUnit` to method tester for Sign transaction - Custom, fix default values.

## Related

Resolves #12592