### PR TITLE
feat(suite-desktop): rollout node bridge to 0% of users

### DIFF
--- a/packages/suite-desktop-api/src/messages.ts
+++ b/packages/suite-desktop-api/src/messages.ts
@@ -110,6 +110,7 @@ export type Status = {
 export type BridgeSettings = {
     doNotStartOnStartup: boolean;
     legacy?: boolean;
+    newBridgeRollout?: number;
 };
 
 export type InvokeResult<Payload = undefined> =

--- a/packages/suite-desktop-core/src/index.d.ts
+++ b/packages/suite-desktop-core/src/index.d.ts
@@ -115,4 +115,8 @@ declare type BridgeSettings = {
      * Should run trezord-go
      */
     legacy?: boolean;
+    /**
+     * Should run the new bridge?
+     */
+    newBridgeRollout?: number;
 };

--- a/packages/suite/src/views/settings/SettingsDebug/TransportBackends.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/TransportBackends.tsx
@@ -5,11 +5,14 @@ import { desktopApi } from '@trezor/suite-desktop-api';
 
 import { ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
 import { BridgeSettings } from '@trezor/suite-desktop-api/src/messages';
-
+import { isDevEnv } from '@suite-common/suite-utils';
 interface Process {
     service: boolean;
     process: boolean;
 }
+
+// note that this variable is duplicated with suite-desktop-core
+const NEW_BRIDGE_ROLLOUT_THRESHOLD = 0;
 
 export const TransportBackends = () => {
     const [bridgeProcess, setBridgeProcess] = useState<Process>({ service: false, process: false });
@@ -28,8 +31,6 @@ export const TransportBackends = () => {
         });
 
         desktopApi.getBridgeSettings().then(result => {
-            console.log('bridge settings', result);
-
             if (result.success) {
                 setBridgeSettings(result.payload);
             } else {
@@ -38,7 +39,6 @@ export const TransportBackends = () => {
         });
 
         desktopApi.on('bridge/settings', (settings: BridgeSettings) => {
-            console.log('bridge settings', settings);
             setBridgeSettings(settings);
         });
 
@@ -106,6 +106,14 @@ export const TransportBackends = () => {
                     />
                 </ActionColumn>
             </SectionItem>
+            {!isDevEnv && (
+                <SectionItem data-test="@settings/debug/processes/newBridgeRollout">
+                    <TextColumn
+                        title="New bridge rollout"
+                        description={`New bridge is being rolled out to only ${NEW_BRIDGE_ROLLOUT_THRESHOLD * 100}% of Trezor Suite instances. Your rollout score is ${((bridgeSettings.newBridgeRollout ?? 0) * 100).toFixed()}%`}
+                    />
+                </SectionItem>
+            )}
         </>
     );
 };


### PR DESCRIPTION
- implement rollout mechanism for starting node bridge for a subset of users
- subset size is now 0%
- we may later increase the number by bumping NEW_BRIDGE_ROLLOUT_THRESHOLD
- rollout mechanism can be disabled by starting app with `--skip-new-bridge-rollout`
- added info about rollout to debug settings
- rollout does not apply for dev build
- removed implicit changing of `bridge.doNotStartOnStartup` setting when toggling bridge from debug settings. This side effect maybe made sense while there wasn't a component to change this option in debug settings. 

<img width="938" alt="image" src="https://github.com/trezor/trezor-suite/assets/30367552/a5fbaac8-61f0-4f65-a7b2-173aa8a4c3cb">

