### PR TITLE
fix(suite-desktop): change bridge startOnStartup to doNotStartOnStart…

### DIFF
--- a/packages/suite-desktop-api/src/factory.ts
+++ b/packages/suite-desktop-api/src/factory.ts
@@ -138,7 +138,7 @@ export const factory = <R extends StrictIpcRenderer<any, IpcRendererEvent>>(
         toggleBridge: () => ipcRenderer.invoke('bridge/toggle'),
 
         changeBridgeSettings: payload => {
-            if (validation.isObject({ startOnStartup: 'boolean' }, payload)) {
+            if (validation.isObject({ doNotStartOnStartup: 'boolean' }, payload)) {
                 return ipcRenderer.invoke('bridge/change-settings', payload);
             }
 

--- a/packages/suite-desktop-api/src/messages.ts
+++ b/packages/suite-desktop-api/src/messages.ts
@@ -104,7 +104,7 @@ export type Status = {
 
 // todo: duplicate, see prev comment
 export type BridgeSettings = {
-    startOnStartup: boolean;
+    doNotStartOnStartup: boolean;
     legacy?: boolean;
 };
 

--- a/packages/suite-desktop-core/src/index.d.ts
+++ b/packages/suite-desktop-core/src/index.d.ts
@@ -108,9 +108,9 @@ declare type TorSettings =
 
 declare type BridgeSettings = {
     /**
-     * Should bridge process be spawned on application startup
+     * Force suite not to start bridge on application startup
      */
-    startOnStartup: boolean;
+    doNotStartOnStartup: boolean;
     /**
      * Should run trezord-go
      */

--- a/packages/suite-desktop-core/src/libs/store.ts
+++ b/packages/suite-desktop-core/src/libs/store.ts
@@ -69,7 +69,7 @@ export class Store {
 
     public getBridgeSettings() {
         return this.store.get('bridgeSettings', {
-            startOnStartup: true,
+            doNotStartOnStartup: true,
             legacy: false,
         });
     }

--- a/packages/suite-desktop-core/src/modules/bridge.ts
+++ b/packages/suite-desktop-core/src/modules/bridge.ts
@@ -83,10 +83,16 @@ const load = async ({ store, mainWindow }: Dependencies) => {
         try {
             if (status.service) {
                 await bridge.stop();
-                store.setBridgeSettings({ ...store.getBridgeSettings(), startOnStartup: false });
+                store.setBridgeSettings({
+                    ...store.getBridgeSettings(),
+                    doNotStartOnStartup: false,
+                });
             } else {
                 await start(bridge);
-                store.setBridgeSettings({ ...store.getBridgeSettings(), startOnStartup: true });
+                store.setBridgeSettings({
+                    ...store.getBridgeSettings(),
+                    doNotStartOnStartup: true,
+                });
             }
 
             return { success: true };
@@ -109,7 +115,7 @@ const load = async ({ store, mainWindow }: Dependencies) => {
 
     ipcMain.handle(
         'bridge/change-settings',
-        (_: unknown, payload: { startOnStartup: boolean; legacy?: boolean }) => {
+        (_: unknown, payload: { doNotStartOnStartup: boolean; legacy?: boolean }) => {
             try {
                 store.setBridgeSettings(payload);
 
@@ -130,7 +136,7 @@ const load = async ({ store, mainWindow }: Dependencies) => {
         }
     });
 
-    if (!store.getBridgeSettings().startOnStartup) {
+    if (store.getBridgeSettings().doNotStartOnStartup) {
         return;
     }
 

--- a/packages/suite/src/views/settings/SettingsDebug/TransportBackends.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/TransportBackends.tsx
@@ -96,11 +96,11 @@ export const TransportBackends = () => {
                 <TextColumn title="Run on startup" />
                 <ActionColumn>
                     <Checkbox
-                        isChecked={bridgeSettings.startOnStartup}
+                        isChecked={!bridgeSettings.doNotStartOnStartup}
                         onClick={() => {
                             changeBridgeSettings({
                                 ...bridgeSettings,
-                                startOnStartup: !bridgeSettings.startOnStartup,
+                                doNotStartOnStartup: !bridgeSettings.doNotStartOnStartup,
                             });
                         }}
                     />


### PR DESCRIPTION
ups, fixing a bug reported by @szymonlesisz 

1. use suite from a previous release
2. update to a new release
3. start suite - bridge does not start (missing migration)

There are no store migrations in desktop. at least I am not aware of any. So to keep legacy behavior ( bridge is started automatically) for users that already have store initialized we need to change the recently added field `bridgeSettings.startOnStartup` to `bridgeSettings.doNotStartOnStartup`. 

So if this field does not exist, bridge would start on startup as we are used to.