### PR TITLE
Fix/transport bridge udp

### DIFF
--- a/packages/transport-bridge/src/bin.ts
+++ b/packages/transport-bridge/src/bin.ts
@@ -4,7 +4,7 @@ import { TrezordNode } from './http';
 
 const trezordNode = new TrezordNode({
     port: 21325,
-    api: 'usb',
+    api: process.argv.includes('udp') ? 'udp' : 'usb',
     logger: new Log('@trezor/transport-bridge', true),
 });
 

--- a/packages/transport-bridge/src/core.ts
+++ b/packages/transport-bridge/src/core.ts
@@ -107,6 +107,22 @@ export const createApi = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) => 
         return enumerateDoneResponse;
     };
 
+    let listening = true;
+    let enumerateTimeout: ReturnType<typeof setTimeout> | undefined;
+
+    if (api instanceof UdpApi) {
+        // same as UdpTransport listen, set timeout to ping udp devices
+        const enumerateRecursive = () => {
+            if (!listening) return;
+
+            enumerateTimeout = setTimeout(() => {
+                enumerate().finally(enumerateRecursive);
+            }, 500);
+        };
+
+        enumerateRecursive();
+    }
+
     const acquire = async (
         acquireInput: Omit<AcquireInput, 'previous'> & { previous: Session | 'null' },
     ) => {
@@ -201,6 +217,11 @@ export const createApi = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) => 
     };
 
     const dispose = () => {
+        listening = false;
+        if (enumerateTimeout) {
+            clearTimeout(enumerateTimeout);
+            enumerateTimeout = undefined;
+        }
         api.dispose();
     };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- trezor-bridge use enumerate timeout if UdpApi is used (same as in UdpTransport)
- UdpTransport move enumeration timeout initialization from contructor
- trezor-bridge: handle argument of `node ./packages/transport-bridge/dist/bin.js udp`
