### PR TITLE
POC Ledger derivation path for Solana and EVM

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeDescription.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeDescription.tsx
@@ -11,17 +11,18 @@ const Info = styled(Paragraph)`
 `;
 
 interface AccountTypeDescriptionProps {
-    bip43Path: Network['bip43Path'];
+    network: Network;
     hasMultipleAccountTypes: boolean;
 }
 
 export const AccountTypeDescription = ({
-    bip43Path,
+    network,
     hasMultipleAccountTypes,
 }: AccountTypeDescriptionProps) => {
     if (!hasMultipleAccountTypes) return null;
-    const accountTypeUrl = getAccountTypeUrl(bip43Path);
-    const accountTypeDesc = getAccountTypeDesc(bip43Path);
+
+    const accountTypeUrl = getAccountTypeUrl(network);
+    const accountTypeDesc = getAccountTypeDesc(network);
 
     return (
         <>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeSelect.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeSelect.tsx
@@ -29,10 +29,11 @@ type Option = ReturnType<typeof buildAccountTypeOption>;
 
 const formatLabel = (option: Option) => (
     <LabelWrapper>
-        <Translation id={getAccountTypeName(option.value.bip43Path)} />
+        <Translation id={getAccountTypeName(option.value)} />
 
         <TypeInfo>
-            <Translation id={getAccountTypeTech(option.value.bip43Path)} />
+            <Translation id={getAccountTypeTech(option.value)} />
+            &nbsp;({option.value.bip43Path})
         </TypeInfo>
     </LabelWrapper>
 );
@@ -63,7 +64,7 @@ export const AccountTypeSelect = ({
                 onChange={(option: Option) => onSelectAccountType(option.value)}
             />
             <AccountTypeDescription
-                bip43Path={network.bip43Path}
+                network={network}
                 hasMultipleAccountTypes={accountTypes && accountTypes?.length > 1}
             />
         </>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -8,7 +8,7 @@ import {
 } from '@suite-common/wallet-core';
 import { arrayPartition } from '@trezor/utils';
 import { NetworkSymbol } from '@suite-common/wallet-config';
-import { Button, CoinLogo, CollapsibleBox } from '@trezor/components';
+import { Button, CollapsibleBox } from '@trezor/components';
 import { FirmwareType } from '@trezor/connect';
 import { spacings, spacingsPx } from '@trezor/theme';
 import { Translation, Modal, CoinList, TooltipSymbol } from 'src/components/suite';
@@ -24,6 +24,7 @@ import { AccountTypeSelect } from './AccountTypeSelect/AccountTypeSelect';
 import { SelectNetwork } from './SelectNetwork';
 import { AddAccountButton } from './AddAccountButton/AddAccountButton';
 import { DeviceModelInternal } from '@trezor/connect';
+import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
 
 const StyledModal = styled(Modal)`
     width: 480px;
@@ -34,6 +35,10 @@ const NetworksWrapper = styled.div`
     display: flex;
     flex-direction: column;
     gap: ${spacingsPx.md};
+`;
+
+const StyledCollapsibleBox = styled(CollapsibleBox)`
+    margin-top: ${spacingsPx.md};
 `;
 
 const CoinLogoWrapper = styled.span`
@@ -53,7 +58,7 @@ export const AddAccountModal = ({ device, onCancel, symbol, noRedirect }: AddAcc
     const accounts = useSelector(state => state.wallet.accounts);
     const supportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
     const app = useSelector(state => state.router.app);
-    const debug = useSelector(state => state.suite.settings.debug);
+    const isDebug = useSelector(selectIsDebugModeActive);
     const isCoinjoinPublic = useSelector(selectIsPublic);
     const deviceModel = useSelector(selectDeviceModel);
     const dispatch = useDispatch();
@@ -72,8 +77,6 @@ export const AddAccountModal = ({ device, onCancel, symbol, noRedirect }: AddAcc
     const allTestnetNetworksDisabled = supportedTestnets.some(network =>
         enabledNetworkSymbols.includes(network.symbol),
     );
-
-    const isCoinjoinVisible = isCoinjoinPublic || debug.showDebugMenu;
 
     // applied when changing account in coinmarket exchange receive options context
     const networkPinned = !!symbol;
@@ -114,16 +117,19 @@ export const AddAccountModal = ({ device, onCancel, symbol, noRedirect }: AddAcc
         : [];
 
     // Collect possible accountTypes
-    const accountTypes =
-        isSelectedNetworkEnabled && selectedNetwork?.networkType === 'bitcoin'
-            ? NETWORKS.filter(n => n.symbol === selectedNetwork.symbol)
-                  /**
-                   * Filter out coinjoin account type if it is not visible.
-                   * Visibility of coinjoin account type depends on coinjoin feature config in message system.
-                   * By default it is visible publicly, but it can be remotely hidden under debug menu.
-                   */
-                  .filter(({ backendType }) => backendType !== 'coinjoin' || isCoinjoinVisible)
-            : undefined;
+    const accountTypes = isSelectedNetworkEnabled
+        ? NETWORKS.filter(n => n.symbol === selectedNetwork.symbol)
+              /**
+               * Filter out coinjoin account type if it is not visible.
+               * Visibility of coinjoin account type depends on coinjoin feature config in message system.
+               * By default it is visible publicly, but it can be remotely hidden under debug menu.
+               */
+              .filter(({ backendType }) => backendType !== 'coinjoin' || isCoinjoinPublic)
+              .filter(
+                  ({ isDebugOnlyAccountType }) =>
+                      isDebugOnlyAccountType === undefined || (isDebugOnlyAccountType && isDebug),
+              )
+        : undefined;
 
     const selectedNetworks = selectedNetwork ? [selectedNetwork.symbol] : [];
 
@@ -187,14 +193,7 @@ export const AddAccountModal = ({ device, onCancel, symbol, noRedirect }: AddAcc
                       <Translation
                           id="TR_ADD_NETWORK_ACCOUNT"
                           values={{
-                              network: (
-                                  <>
-                                      <CoinLogoWrapper>
-                                          <CoinLogo size={24} symbol={selectedNetwork.symbol} />
-                                      </CoinLogoWrapper>
-                                      {selectedNetwork.name}
-                                  </>
-                              ),
+                              network: selectedNetwork.name,
                           }}
                       />
                   ),

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountGroup.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountGroup.tsx
@@ -40,6 +40,7 @@ const Header = styled.header<{ $isOpen: boolean; onClick?: () => void }>`
     align-items: center;
     ${typography.label}
     color: ${({ theme }) => theme.textSubdued};
+    height: 40px;
 
     &:hover {
         ${ChevronIcon} {

--- a/packages/suite/src/hooks/wallet/useCoinmarketExchangeOffers.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketExchangeOffers.ts
@@ -154,7 +154,7 @@ export const useOffers = ({ selectedAccount }: UseCoinmarketExchangeFormProps) =
                 n =>
                     n.symbol === receiveNetwork &&
                     !unavailableCapabilities[n.symbol] &&
-                    ((n.isDebugOnly && isDebug) || !n.isDebugOnly),
+                    ((n.isDebugOnlyNetwork && isDebug) || !n.isDebugOnlyNetwork),
             );
             if (receiveNetworks.length > 0) {
                 // get accounts of the current symbol belonging to the current device

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3786,6 +3786,66 @@ export default defineMessages({
         defaultMessage: 'Bip44Change account',
         dynamic: true,
     },
+    TR_ACCOUNT_TYPE_SOLANA_BIP44_CHANGE_LEDGER_NAME: {
+        id: 'TR_ACCOUNT_TYPE_SOLANA_BIP44_CHANGE_LEDGER_NAME',
+        defaultMessage: 'Bip44Change Ledger',
+        dynamic: true,
+    },
+    TR_ACCOUNT_TYPE_SOLANA_BIP44_CHANGE_LEDGER_TECH: {
+        id: 'TR_ACCOUNT_TYPE_SOLANA_BIP44_CHANGE_LEDGER_TECH',
+        defaultMessage: 'BIP44, Base58',
+        dynamic: true,
+    },
+    TR_ACCOUNT_TYPE_SOLANA_BIP44_CHANGE_LEDGER_DESC: {
+        id: 'TR_ACCOUNT_TYPE_SOLANA_BIP44_CHANGE_LEDGER_DESC',
+        defaultMessage: 'Account used in Ledger Live',
+        dynamic: true,
+    },
+    TR_ACCOUNT_TYPE_EVM_BIP44_NAME: {
+        id: 'TR_ACCOUNT_TYPE_EVM_BIP44_NAME',
+        defaultMessage: 'Bip44',
+        dynamic: true,
+    },
+    TR_ACCOUNT_TYPE_EVM_BIP44_LEDGER_NAME: {
+        id: 'TR_ACCOUNT_TYPE_EVM_BIP44_LEDGER_NAME',
+        defaultMessage: 'Ledger Live',
+        dynamic: true,
+    },
+    TR_ACCOUNT_TYPE_EVM_BIP44_LEGACY_NAME: {
+        id: 'TR_ACCOUNT_TYPE_EVM_BIP44_LEGACY_NAME',
+        defaultMessage: 'Ledger Legacy',
+        dynamic: true,
+    },
+    TR_ACCOUNT_TYPE_EVM_BIP44_TECH: {
+        id: 'TR_ACCOUNT_TYPE_EVM_BIP44_TECH',
+        defaultMessage: 'BIP44',
+        dynamic: true,
+    },
+    TR_ACCOUNT_TYPE_EVM_BIP44_LEDGER_TECH: {
+        id: 'TR_ACCOUNT_TYPE_EVM_BIP44_LEDGER_TECH',
+        defaultMessage: 'BIP44',
+        dynamic: true,
+    },
+    TR_ACCOUNT_TYPE_EVM_BIP44_LEGACY_TECH: {
+        id: 'TR_ACCOUNT_TYPE_EVM_BIP44_LEGACY_TECH',
+        defaultMessage: 'BIP44',
+        dynamic: true,
+    },
+    TR_ACCOUNT_TYPE_EVM_BIP44_DESC: {
+        id: 'TR_ACCOUNT_TYPE_EVM_BIP44_DESC',
+        defaultMessage: 'HD path defined by the BIP44 protocol.',
+        dynamic: true,
+    },
+    TR_ACCOUNT_TYPE_EVM_BIP44_LEDGER_DESC: {
+        id: 'TR_ACCOUNT_TYPE_EVM_BIP44_LEDGER_DESC',
+        defaultMessage: 'Ledger official HD path.',
+        dynamic: true,
+    },
+    TR_ACCOUNT_TYPE_EVM_BIP44_LEGACY_DESC: {
+        id: 'TR_ACCOUNT_TYPE_EVM_BIP44_LEGACY_DESC',
+        defaultMessage: 'HD path used by MEW / Mycrypto.',
+        dynamic: true,
+    },
     TR_ACCOUNT_TYPE_SLIP25_NAME: {
         id: 'TR_ACCOUNT_TYPE_SLIP25_NAME',
         defaultMessage: 'Coinjoin',

--- a/packages/suite/src/views/wallet/details/index.tsx
+++ b/packages/suite/src/views/wallet/details/index.tsx
@@ -75,7 +75,7 @@ const Details = () => {
         return <WalletLayout title="TR_ACCOUNT_DETAILS_HEADER" account={selectedAccount} />;
     }
 
-    const { account } = selectedAccount;
+    const { account, network } = selectedAccount;
     const locked = isLocked(true);
     const disabled = !!device.authConfirm || locked;
 
@@ -86,10 +86,10 @@ const Details = () => {
             : undefined;
     // display type name only if there is more than 1 network type
     const accountTypeName =
-        accountTypes && accountTypes.length > 1 ? getAccountTypeName(account.path) : undefined;
-    const accountTypeTech = getAccountTypeTech(account.path);
-    const accountTypeUrl = getAccountTypeUrl(account.path);
-    const accountTypeDesc = getAccountTypeDesc(account.path);
+        accountTypes && accountTypes.length > 1 ? getAccountTypeName(network) : undefined;
+    const accountTypeTech = getAccountTypeTech(network);
+    const accountTypeUrl = getAccountTypeUrl(network);
+    const accountTypeDesc = getAccountTypeDesc(network);
     const isCoinjoinAccount = account.backendType === 'coinjoin';
 
     const handleXpubClick = () => dispatch(showXpub());

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -86,10 +86,12 @@ export const networks = {
             ledger: {
                 // ledger (live)
                 bip43Path: "m/44'/60'/i'/0/0",
+                isDebugOnlyAccountType: true,
             },
             legacy: {
                 // ledger (legacy)
                 bip43Path: "m/44'/60'/0'/i",
+                isDebugOnlyAccountType: true,
             },
         },
         coingeckoId: 'ethereum',
@@ -306,10 +308,12 @@ export const networks = {
             legacy: {
                 // icarus-trezor derivation
                 bip43Path: "m/1852'/1815'/i'",
+                isDebugOnlyAccountType: true,
             },
             ledger: {
                 // ledger derivation
                 bip43Path: "m/1852'/1815'/i'",
+                isDebugOnlyAccountType: true,
             },
         },
         coingeckoId: 'cardano',
@@ -337,6 +341,7 @@ export const networks = {
             ledger: {
                 // bip44Change - Ledger Live
                 bip43Path: "m/44'/501'/i'",
+                isDebugOnlyAccountType: true,
             },
         },
         coingeckoId: 'solana',
@@ -361,10 +366,12 @@ export const networks = {
             ledger: {
                 // ledger (live)
                 bip43Path: "m/44'/60'/i'/0/0",
+                isDebugOnlyAccountType: true,
             },
             legacy: {
                 // ledger (legacy)
                 bip43Path: "m/44'/60'/0'/i",
+                isDebugOnlyAccountType: true,
             },
         },
         coingeckoId: 'polygon-pos',
@@ -454,7 +461,7 @@ export const networks = {
                 bip43Path: "m/44'/1'/i'",
             },
         },
-        isDebugOnly: true,
+        isDebugOnlyNetwork: true,
         coingeckoId: undefined,
     },
     tsep: {
@@ -537,10 +544,12 @@ export const networks = {
             legacy: {
                 // icarus-trezor derivation
                 bip43Path: "m/1852'/1815'/i'",
+                isDebugOnlyAccountType: true,
             },
             ledger: {
                 // ledger derivation
                 bip43Path: "m/1852'/1815'/i'",
+                isDebugOnlyAccountType: true,
             },
         },
         coingeckoId: undefined,
@@ -606,7 +615,8 @@ export type Network = Without<NetworkValue, 'accountTypes'> & {
     support?: {
         [key in DeviceModelInternal]: string;
     };
-    isDebugOnly?: boolean;
+    isDebugOnlyNetwork?: boolean;
+    isDebugOnlyAccountType?: boolean;
     coingeckoId?: string;
 };
 
@@ -626,11 +636,13 @@ export const networksCompatibility: Network[] = Object.entries(networks).flatMap
 );
 
 export const getMainnets = (debug = false) =>
-    networksCompatibility.filter(n => !n.accountType && !n.testnet && (!n.isDebugOnly || debug));
+    networksCompatibility.filter(
+        n => !n.accountType && !n.testnet && (!n.isDebugOnlyNetwork || debug),
+    );
 
 export const getTestnets = (debug = false) =>
     networksCompatibility.filter(
-        n => !n.accountType && n.testnet === true && (!n.isDebugOnly || debug),
+        n => !n.accountType && n.testnet === true && (!n.isDebugOnlyNetwork || debug),
     );
 
 export const getAllNetworkSymbols = () => networksCompatibility.map(n => n.symbol);

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -82,7 +82,16 @@ export const networks = {
             'staking',
         ],
         customBackends: ['blockbook'],
-        accountTypes: {},
+        accountTypes: {
+            ledger: {
+                // ledger (live)
+                bip43Path: "m/44'/60'/i'/0/0",
+            },
+            legacy: {
+                // ledger (legacy)
+                bip43Path: "m/44'/60'/0'/i",
+            },
+        },
         coingeckoId: 'ethereum',
     },
     etc: {
@@ -274,10 +283,9 @@ export const networks = {
         coingeckoId: 'zcash',
     },
     ada: {
-        // icarus derivation
         name: 'Cardano',
         networkType: 'cardano',
-        bip43Path: "m/1852'/1815'/i'",
+        bip43Path: "m/1852'/1815'/i'", // icarus derivation
         decimals: 6,
         testnet: false,
         features: ['tokens', 'staking', 'coin-definitions'],
@@ -309,7 +317,7 @@ export const networks = {
     sol: {
         name: 'Solana',
         networkType: 'solana',
-        bip43Path: "m/44'/501'/i'/0'",
+        bip43Path: "m/44'/501'/i'/0'", // phantom - bip44Change
         decimals: 9,
         testnet: false,
         features: ['tokens', 'coin-definitions' /*, 'staking' */],
@@ -325,7 +333,12 @@ export const networks = {
             [DeviceModelInternal.T3T1]: '2.7.1',
         },
         customBackends: ['solana'],
-        accountTypes: {},
+        accountTypes: {
+            ledger: {
+                // bip44Change - Ledger Live
+                bip43Path: "m/44'/501'/i'",
+            },
+        },
         coingeckoId: 'solana',
     },
     matic: {
@@ -344,7 +357,16 @@ export const networks = {
         },
         features: ['rbf', 'sign-verify', 'tokens', 'coin-definitions', 'nft-definitions'],
         customBackends: ['blockbook'],
-        accountTypes: {},
+        accountTypes: {
+            ledger: {
+                // ledger (live)
+                bip43Path: "m/44'/60'/i'/0/0",
+            },
+            legacy: {
+                // ledger (legacy)
+                bip43Path: "m/44'/60'/0'/i",
+            },
+        },
         coingeckoId: 'polygon-pos',
     },
     bsc: {

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -245,7 +245,17 @@ export const getBundleThunk = createThunk(
                 !discovery.availableCardanoDerivations?.includes(configNetwork.accountType);
 
             if (!hasEmptyAccount && !failed && !skipCardanoDerivation) {
-                const index = prevAccounts[0] ? prevAccounts[0].index + 1 : 0;
+                let index = prevAccounts[0] ? prevAccounts[0].index + 1 : 0;
+
+                // first index is same as Trezor
+                if (
+                    configNetwork.networkType === 'ethereum' &&
+                    accountType === 'ledger' &&
+                    index === 0
+                ) {
+                    index++;
+                }
+
                 bundle.push({
                     path: configNetwork.bip43Path.replace('i', index.toString()),
                     coin: configNetwork.symbol,

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -185,19 +185,38 @@ export const getTitleForNetwork = (symbol: NetworkSymbol) => {
     }
 };
 
-export const getAccountTypePrefix = (path: string) => {
+export const getAccountTypePrefix = (network: Network) => {
+    const { bip43Path: path, accountType } = network;
+
     if (typeof path !== 'string') return null;
     const coinType = path.split('/')[2];
-    switch (coinType) {
-        case `501'`: {
-            return 'TR_ACCOUNT_TYPE_SOLANA_BIP44_CHANGE';
+
+    // sol and dsol
+    if (coinType === "501'") {
+        if (accountType === 'ledger') {
+            return 'TR_ACCOUNT_TYPE_SOLANA_BIP44_CHANGE_LEDGER';
         }
-        default:
-            return null;
+
+        return 'TR_ACCOUNT_TYPE_SOLANA_BIP44_CHANGE';
     }
+    // evm
+    if (coinType === "60'") {
+        if (accountType === 'ledger') {
+            return 'TR_ACCOUNT_TYPE_EVM_BIP44_LEDGER';
+        }
+        if (accountType === 'legacy') {
+            return 'TR_ACCOUNT_TYPE_EVM_BIP44_LEGACY';
+        }
+
+        return 'TR_ACCOUNT_TYPE_EVM_BIP44';
+    }
+
+    return null;
 };
 
-export const getBip43Type = (path: string) => {
+export const getBip43Type = (network: Network) => {
+    const { bip43Path: path } = network;
+
     if (typeof path !== 'string') return 'unknown';
     // https://github.com/bitcoin/bips/blob/master/bip-0043.mediawiki
     const bip43 = path.split('/')[1];
@@ -219,10 +238,11 @@ export const getBip43Type = (path: string) => {
     }
 };
 
-export const getAccountTypeName = (path: string) => {
-    const accountTypePrefix = getAccountTypePrefix(path);
+export const getAccountTypeName = (network: Network) => {
+    const accountTypePrefix = getAccountTypePrefix(network);
     if (accountTypePrefix) return `${accountTypePrefix}_NAME` as const;
-    const bip43 = getBip43Type(path);
+
+    const bip43 = getBip43Type(network);
     if (bip43 === 'bip86') return 'TR_ACCOUNT_TYPE_BIP86_NAME';
     if (bip43 === 'bip84') return 'TR_ACCOUNT_TYPE_BIP84_NAME';
     if (bip43 === 'bip49') return 'TR_ACCOUNT_TYPE_BIP49_NAME';
@@ -232,10 +252,11 @@ export const getAccountTypeName = (path: string) => {
     return 'TR_ACCOUNT_TYPE_BIP44_NAME';
 };
 
-export const getAccountTypeTech = (path: string) => {
-    const accountTypePrefix = getAccountTypePrefix(path);
+export const getAccountTypeTech = (network: Network) => {
+    const accountTypePrefix = getAccountTypePrefix(network);
     if (accountTypePrefix) return `${accountTypePrefix}_TECH` as const;
-    const bip43 = getBip43Type(path);
+
+    const bip43 = getBip43Type(network);
     if (bip43 === 'bip86') return 'TR_ACCOUNT_TYPE_BIP86_TECH';
     if (bip43 === 'bip84') return 'TR_ACCOUNT_TYPE_BIP84_TECH';
     if (bip43 === 'bip49') return 'TR_ACCOUNT_TYPE_BIP49_TECH';
@@ -245,10 +266,11 @@ export const getAccountTypeTech = (path: string) => {
     return 'TR_ACCOUNT_TYPE_BIP44_TECH';
 };
 
-export const getAccountTypeDesc = (path: string) => {
-    const accountTypePrefix = getAccountTypePrefix(path);
+export const getAccountTypeDesc = (network: Network) => {
+    const accountTypePrefix = getAccountTypePrefix(network);
     if (accountTypePrefix) return `${accountTypePrefix}_DESC` as const;
-    const bip43 = getBip43Type(path);
+
+    const bip43 = getBip43Type(network);
     if (bip43 === 'bip86') return 'TR_ACCOUNT_TYPE_BIP86_DESC';
     if (bip43 === 'bip84') return 'TR_ACCOUNT_TYPE_BIP84_DESC';
     if (bip43 === 'bip49') return 'TR_ACCOUNT_TYPE_BIP49_DESC';
@@ -258,8 +280,8 @@ export const getAccountTypeDesc = (path: string) => {
     return 'TR_ACCOUNT_TYPE_BIP44_DESC';
 };
 
-export const getAccountTypeUrl = (path: string) => {
-    const bip43 = getBip43Type(path);
+export const getAccountTypeUrl = (network: Network) => {
+    const bip43 = getBip43Type(network);
     switch (bip43) {
         case 'bip86':
             return HELP_CENTER_TAPROOT_URL;


### PR DESCRIPTION
## Description

- discovery is done for Solana ledger derivation path and EVM Ledger Live and EVM Ledger Legacy derivation paths
- if you enable debug mode, you can add those accounts, otherwise they are visible only if they have some balance

TODO:
- it will report that not all coins have discovery done
  - that is caused by incorrect calculation of total accounts because first derivation path of ledger and trezor accounts in EVM is same so I skip it (by hack for now). If you add ledger account, it will have immediately number 2
- details in SOL, CARDANO and EVM accounts if more acc available?
- fw account type restriction
- improve the weird `accountUtils.ts`
- Sending to Ledger account / legacy account in send form.
- maybe some tag in account name?

## Related Issue

Resolves #8591

## Screenshots:
![Screenshot 2024-06-02 at 22 43 20](https://github.com/trezor/trezor-suite/assets/33235762/83b3b64d-a113-42ed-b6f1-a2ac67c81612)
![Screenshot 2024-06-02 at 22 43 42](https://github.com/trezor/trezor-suite/assets/33235762/897be276-e0f1-4b81-9a1a-a79c5b643700)

All accounts
![Screenshot 2024-05-29 at 9 54 20](https://github.com/trezor/trezor-suite/assets/33235762/76efb267-22a7-4171-9217-e0a97e7e0f93)
