### PR TITLE
Remove `low` fee levels from storage

### DIFF
--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -810,5 +810,15 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
 
             return tx;
         });
+
+        await updateAll(transaction, 'walletSettings', walletSettings => {
+            Object.keys(walletSettings.lastUsedFeeLevel).forEach(coin => {
+                if (walletSettings.lastUsedFeeLevel[coin].label === 'low') {
+                    delete walletSettings.lastUsedFeeLevel[coin];
+                }
+            });
+
+            return walletSettings;
+        });
     }
 };


### PR DESCRIPTION
## Description

Add a migration to remove stored `low` fee level from database, to make it compatible with #11733.

(Note: I've used already existing v44 -> v45 migration as it wasn't released yet.)

## Related Issue

Should resolve #12551

## How to reproduce and test

- use Suite <24.5.2, set `low` fee in send form and close it
- use Suite 24.5.2 and open send form; it should crash (even repeatedly)
- use Suite with this fix and open send form; it should default to `normal` fee