### PR TITLE
Sol sign empty passphrase

### DIFF
--- a/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
@@ -335,6 +335,7 @@ export const signSolanaSendFormTransactionThunk = createThunk(
                 instance: device.instance,
                 state: device.state,
             },
+            useEmptyPassphrase: device.useEmptyPassphrase,
             path: selectedAccount.path,
             serializedTx,
             additionalInfo:


### PR DESCRIPTION
## Description

Correctly pass `useEmptyPassphrase` when signing Sqlana transaction.

## Related Issue

Resolve #12052
