### PR TITLE
add date pending transctions

### DIFF
--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
@@ -131,7 +131,7 @@ export const TransactionList = ({
     const listItems = useMemo(
         () =>
             Object.entries(transactionsByDate).map(([dateKey, value], groupIndex) => {
-                const isPending = dateKey === 'pending';
+                const isPending = dateKey.startsWith('pending');
 
                 return (
                     <TransactionsGroup

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/DayHeader.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/DayHeader.tsx
@@ -36,6 +36,11 @@ const ColDate = styled(Col)`
     flex: 1;
 `;
 
+const PendingTitleWrapper = styled(Col)`
+    display: flex;
+    flex-direction: column;
+`;
+
 const ColPending = styled(Col)`
     color: ${({ theme }) => theme.TYPE_ORANGE};
     font-variant-numeric: tabular-nums;
@@ -79,14 +84,27 @@ export const DayHeader = ({
 
     const parsedDate = parseTransactionDateKey(dateKey);
     const showFiatValue = !isTestnet(symbol);
+    const pendingDate = dateKey.split('-').slice(1).join('-');
+    const parsedPendingDate = parseTransactionDateKey(pendingDate);
+    const isPending = dateKey.startsWith('pending');
 
     return (
         <Wrapper>
-            {dateKey === 'pending' ? (
-                <ColPending data-test="@transaction-group/pending/count">
-                    <Translation id="TR_PENDING_TX_HEADING" values={{ count: txsCount }} /> •{' '}
-                    {txsCount}
-                </ColPending>
+            {isPending ? (
+                <PendingTitleWrapper>
+                    <ColPending data-test="@transaction-group/pending/count">
+                        <Translation id="TR_PENDING_TX_HEADING" values={{ count: txsCount }} /> •{' '}
+                        {txsCount}
+                    </ColPending>
+                    <ColDate>
+                        <FormattedDate
+                            value={parsedPendingDate ?? undefined}
+                            day="numeric"
+                            month="long"
+                            year="numeric"
+                        />
+                    </ColDate>
+                </PendingTitleWrapper>
             ) : (
                 <>
                     <ColDate>

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -101,7 +101,7 @@ export const groupTransactionsByDate = (
                 const key =
                     !isTxPending && item.blockTime && item.blockTime > 0
                         ? keyFormatter(new Date(item.blockTime * 1000))
-                        : 'pending';
+                        : `pending-${keyFormatter(new Date(item.blockTime ? item.blockTime * 1000 : new Date()))}`;
                 const prev = r[key] ?? [];
 
                 return {


### PR DESCRIPTION
## Description

grouped transactions by date with prefix pending-{date}

## Screenshots:
![image](https://github.com/trezor/trezor-suite/assets/58292239/5696ec52-2374-4606-901c-5031633a2837)

## Problems
Sometimes the implementation is not working, the transaction.blockTime is giving me the wrong value from time to time and all the pending transactions appear at the same time. I tried to investigate a bit about the bug but could not find anything, maybe you have some suggestions.
Seems like we store them in Redux with the wrong value already and I don't see how my changes could affect that, any ideas?

