### PR TITLE
feat(suite):add date pending transactions

### DIFF
--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
@@ -131,7 +131,7 @@ export const TransactionList = ({
     const listItems = useMemo(
         () =>
             Object.entries(transactionsByDate).map(([dateKey, value], groupIndex) => {
-                const isPending = dateKey === 'pending';
+                const isPending = dateKey.startsWith('pending');
 
                 return (
                     <TransactionsGroup

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/DayHeader.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/DayHeader.tsx
@@ -36,6 +36,11 @@ const ColDate = styled(Col)`
     flex: 1;
 `;
 
+const PendingTitleWrapper = styled(Col)`
+    display: flex;
+    flex-direction: column;
+`;
+
 const ColPending = styled(Col)`
     color: ${({ theme }) => theme.TYPE_ORANGE};
     font-variant-numeric: tabular-nums;
@@ -79,14 +84,27 @@ export const DayHeader = ({
 
     const parsedDate = parseTransactionDateKey(dateKey);
     const showFiatValue = !isTestnet(symbol);
+    const pendingDate = dateKey.split('-').slice(1).join('-');
+    const parsedPendingDate = parseTransactionDateKey(pendingDate);
+    const isPending = dateKey.startsWith('pending');
 
     return (
         <Wrapper>
-            {dateKey === 'pending' ? (
-                <ColPending data-test="@transaction-group/pending/count">
-                    <Translation id="TR_PENDING_TX_HEADING" values={{ count: txsCount }} /> •{' '}
-                    {txsCount}
-                </ColPending>
+            {isPending ? (
+                <PendingTitleWrapper>
+                    <ColPending data-test="@transaction-group/pending/count">
+                        <Translation id="TR_PENDING_TX_HEADING" values={{ count: txsCount }} /> •{' '}
+                        {txsCount}
+                    </ColPending>
+                    <ColDate>
+                        <FormattedDate
+                            value={parsedPendingDate ?? undefined}
+                            day="numeric"
+                            month="long"
+                            year="numeric"
+                        />
+                    </ColDate>
+                </PendingTitleWrapper>
             ) : (
                 <>
                     <ColDate>

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -101,7 +101,7 @@ export const groupTransactionsByDate = (
                 const key =
                     !isTxPending && item.blockTime && item.blockTime > 0
                         ? keyFormatter(new Date(item.blockTime * 1000))
-                        : 'pending';
+                        : `pending-${keyFormatter(new Date(item.blockTime ? item.blockTime * 1000 : new Date()))}`;
                 const prev = r[key] ?? [];
 
                 return {


### PR DESCRIPTION
## Description
I added the date above pending transactions and grouped them by date as the normal one. So right now we have pending={date}

## Screenshots:
![image](https://github.com/trezor/trezor-suite/assets/58292239/fb2c0bee-c97f-4806-93a6-198230dc0509)

## Problems
Seems like there is an error while we store the transactions in the Redux store. Right now sometimes I see a bug where the tx.blockTime becomes the same for some of them. I don't know how my changes could affect that but I also know that we don't have it in production the same bug, not sure about it. Do you have some suggestions?
