### PR TITLE
fix(suite): exchange currency

### DIFF
--- a/packages/suite/src/actions/wallet/coinmarketExchangeActions.ts
+++ b/packages/suite/src/actions/wallet/coinmarketExchangeActions.ts
@@ -21,7 +21,13 @@ export interface ExchangeInfo {
 
 export type CoinmarketExchangeAction =
     | { type: typeof COINMARKET_EXCHANGE.SAVE_EXCHANGE_INFO; exchangeInfo: ExchangeInfo }
-    | { type: typeof COINMARKET_EXCHANGE.SAVE_QUOTE_REQUEST; request: ExchangeTradeQuoteRequest }
+    | {
+          type: typeof COINMARKET_EXCHANGE.CLEAR_QUOTE_REQUEST;
+      }
+    | {
+          type: typeof COINMARKET_EXCHANGE.SAVE_QUOTE_REQUEST;
+          request: ExchangeTradeQuoteRequest;
+      }
     | { type: typeof COINMARKET_EXCHANGE.SAVE_TRANSACTION_ID; transactionId: string }
     | { type: typeof COINMARKET_EXCHANGE.VERIFY_ADDRESS; addressVerified: string }
     | {
@@ -118,6 +124,10 @@ export const saveTrade = (
 export const saveQuoteRequest = (request: ExchangeTradeQuoteRequest): CoinmarketExchangeAction => ({
     type: COINMARKET_EXCHANGE.SAVE_QUOTE_REQUEST,
     request,
+});
+
+export const clearQuoteRequest = (): CoinmarketExchangeAction => ({
+    type: COINMARKET_EXCHANGE.CLEAR_QUOTE_REQUEST,
 });
 
 export const saveTransactionId = (transactionId: string): CoinmarketExchangeAction => ({

--- a/packages/suite/src/actions/wallet/constants/coinmarketExchangeConstants.ts
+++ b/packages/suite/src/actions/wallet/constants/coinmarketExchangeConstants.ts
@@ -1,5 +1,6 @@
 export const SAVE_EXCHANGE_INFO = '@coinmarket-exchange/save_exchange_info';
 export const SAVE_QUOTE_REQUEST = '@coinmarket-exchange/save_exchange_quote_request';
+export const CLEAR_QUOTE_REQUEST = '@coinmarket-exchange/clear_exchange_quote_request';
 export const SAVE_QUOTES = '@coinmarket-exchange/save_exchange_quotes';
 export const CLEAR_QUOTES = '@coinmarket-exchange/clear_exchange_quotes';
 export const VERIFY_ADDRESS = '@coinmarket-exchange/verify_address';

--- a/packages/suite/src/hooks/wallet/useCoinmarketExchangeOffers.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketExchangeOffers.ts
@@ -9,7 +9,7 @@ import { amountToSatoshi } from '@suite-common/wallet-utils';
 import { selectDevice } from '@suite-common/wallet-core';
 
 import invityAPI from 'src/services/suite/invityAPI';
-import { useActions, useSelector, useDevice } from 'src/hooks/suite';
+import { useActions, useSelector, useDevice, useDispatch } from 'src/hooks/suite';
 import * as coinmarketExchangeActions from 'src/actions/wallet/coinmarketExchangeActions';
 import { Account } from 'src/types/wallet';
 import {
@@ -30,6 +30,7 @@ import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
 export const useOffers = ({ selectedAccount }: UseCoinmarketExchangeFormProps) => {
     const timer = useTimer();
     const { isLocked } = useDevice();
+    const dispatch = useDispatch();
     const { account, network } = selectedAccount;
     const { shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
     const [callInProgress, setCallInProgress] = useState<boolean>(isLocked() || false);
@@ -46,7 +47,9 @@ export const useOffers = ({ selectedAccount }: UseCoinmarketExchangeFormProps) =
         saveTransactionId,
         addNotification,
         verifyAddress,
+        clearQuoteRequest,
     } = useActions({
+        clearQuoteRequest: coinmarketExchangeActions.clearQuoteRequest,
         saveTrade: coinmarketExchangeActions.saveTrade,
         openCoinmarketExchangeConfirmModal:
             coinmarketExchangeActions.openCoinmarketExchangeConfirmModal,
@@ -315,6 +318,12 @@ export const useOffers = ({ selectedAccount }: UseCoinmarketExchangeFormProps) =
             });
         }
     };
+
+    useEffect(() => {
+        return () => {
+            dispatch(clearQuoteRequest());
+        };
+    }, [clearQuoteRequest, dispatch]);
 
     return {
         callInProgress,

--- a/packages/suite/src/reducers/wallet/__tests__/coinmarketReducer.test.ts
+++ b/packages/suite/src/reducers/wallet/__tests__/coinmarketReducer.test.ts
@@ -222,6 +222,17 @@ describe('settings reducer', () => {
         });
     });
 
+    it('COINMARKET_EXCHANGE.CLEAR_QUOTE_REQUEST', () => {
+        expect(
+            reducer(undefined, {
+                type: COINMARKET_EXCHANGE.CLEAR_QUOTE_REQUEST,
+            }),
+        ).toEqual({
+            ...initialState,
+            exchange: { ...initialState.exchange, quotesRequest: undefined },
+        });
+    });
+
     it('COINMARKET_EXCHANGE.VERIFY_ADDRESS', () => {
         expect(
             reducer(undefined, {

--- a/packages/suite/src/reducers/wallet/coinmarketReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinmarketReducer.ts
@@ -66,7 +66,7 @@ interface Buy {
 
 interface Exchange {
     exchangeInfo?: ExchangeInfo;
-    quotesRequest?: ExchangeTradeQuoteRequest;
+    quotesRequest?: ExchangeTradeQuoteRequest | undefined;
     fixedQuotes: ExchangeTrade[] | undefined;
     floatQuotes: ExchangeTrade[] | undefined;
     dexQuotes: ExchangeTrade[] | undefined;
@@ -229,6 +229,9 @@ const coinmarketReducer = (
                 break;
             case COINMARKET_EXCHANGE.SAVE_QUOTE_REQUEST:
                 draft.exchange.quotesRequest = action.request;
+                break;
+            case COINMARKET_EXCHANGE.CLEAR_QUOTE_REQUEST:
+                draft.exchange.quotesRequest = undefined;
                 break;
             case COINMARKET_EXCHANGE.SAVE_QUOTES:
                 draft.exchange.fixedQuotes = action.fixedQuotes;


### PR DESCRIPTION

**Describe the bug**
Receive address identified as `BTC receive address` even its Solana or Ethereum.
Not sure when it happens, im not able to reproduce it after i tried older version.
But i had BTC,ETH and SOL enabled and all of them were identified as BTC at one time /see screenshots/



**Info:**
 - Suite version: desktop 24.5.3 (0ff3e0bd75d90719b7b36a60b3eab1c2bd3d3491)
 - Browser: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) TrezorSuite/24.5.3 Chrome/118.0.5993.159 Electron/27.3.8 Safari/537.36
 - OS: MacIntel
 - Screen: 1512x982
 - Device: Trezor T2T1 2.7.0 regular (revision 45e8a842a31e62a6d43d7f6ccac62a45e1198ef0)
 - Transport: BridgeTransport 2.0.33


**Screenshots:**
Solana:

![image](https://github.com/trezor/trezor-suite/assets/31506317/6d83f378-a038-4c39-89ac-c27c2b719b85)


Eth:

![image](https://github.com/trezor/trezor-suite/assets/31506317/5f245eaa-cafb-4dd5-b2ed-4dc5000a68d8)
