### PR TITLE
fix(connect-popup): webextension origin

### DIFF
--- a/packages/connect-popup/src/static/popup.html
+++ b/packages/connect-popup/src/static/popup.html
@@ -3239,7 +3239,23 @@
                     peer: '@trezor/connect-web',
                 },
             };
+
+            // Workaround for popup-content-script-loaded earlier than popup-loaded
+            let contentScriptLoadedPayload = null;
+            const handlePopupContentScriptLoaded = event => {
+                if (event.data.type === 'popup-content-script-loaded') {
+                    contentScriptLoadedPayload = event.data;
+                } else if (event.data.type === 'popup-loaded') {
+                    if (contentScriptLoadedPayload) {
+                        window.postMessage(contentScriptLoadedPayload, '*');
+                    }
+                    window.removeEventListener('message', handlePopupContentScriptLoaded);
+                }
+            };
+            window.addEventListener('message', handlePopupContentScriptLoaded);
+
             setTimeout(() => {
+                console.log('popup-bootstrap');
                 // Slight delay to ensure content script (if present) is initialized first
                 if (window.opener) {
                     window.opener.postMessage(message, '*');

--- a/packages/connect-webextension/src/contentScript.ts
+++ b/packages/connect-webextension/src/contentScript.ts
@@ -28,6 +28,16 @@ window.addEventListener('message', event => {
     ) {
         return;
     }
+    if (event.data?.type === POPUP.LOADED) {
+        window.postMessage(
+            {
+                type: POPUP.CONTENT_SCRIPT_LOADED,
+                payload: { ...chrome.runtime.getManifest(), id: chrome.runtime.id },
+            },
+            window.location.origin,
+        );
+    }
+
     if (event.source === window && event.data) {
         if (channelReady) {
             channel.postMessage(event.data, { usePromise: false });
@@ -39,15 +49,6 @@ window.addEventListener('message', event => {
 
 channel.init().then(() => {
     channelReady = true;
-
-    // once script is loaded. send information about the webextension that injected it into the popup
-    window.postMessage(
-        {
-            type: POPUP.CONTENT_SCRIPT_LOADED,
-            payload: { ...chrome.runtime.getManifest(), id: chrome.runtime.id },
-        },
-        window.location.origin,
-    );
 
     /**
      * Passing messages from service worker to popup


### PR DESCRIPTION
## Description

There is a problem with origin showing up as unknown in webextension (for example Rabby), caused by incorrect message order of CONTENT_SCRIPT_LOADED, where the event comes before the popup.js is ready to receive it. 

This change fixes the ordering in contentScript and adds better handling in popup.js, but also adds a workaround to popup.html that can mitigate the issue. 