### PR TITLE
Redux state seeding

### DIFF
--- a/packages/suite-desktop-api/src/api.ts
+++ b/packages/suite-desktop-api/src/api.ts
@@ -1,6 +1,7 @@
 import { ListenerMethod, SendMethod, InvokeMethod } from './methods';
 import {
     SuiteThemeVariant,
+    HandshakeInit,
     HandshakeClient,
     HandshakeElectron,
     HandshakeEvent,
@@ -68,7 +69,7 @@ export interface RendererChannels {
 // Sent by DesktopApi.[method] via ipcRenderer.invoke (./main)
 // Handled by ipcMain.handle (see packages/suite-desktop/src/modules/*)
 export interface InvokeChannels {
-    'handshake/client': () => void;
+    'handshake/client': () => HandshakeInit;
     'handshake/load-modules': (payload: HandshakeClient) => InvokeResult<HandshakeElectron>;
     'handshake/load-tor-module': () => HandshakeTorModule;
     'metadata/read': (options: { file: string }) => InvokeResult<string>;

--- a/packages/suite-desktop-api/src/messages.ts
+++ b/packages/suite-desktop-api/src/messages.ts
@@ -45,6 +45,10 @@ export type HandshakeEvent =
 
 export type HandshakeClient = any;
 
+export type HandshakeInit = {
+    statePatch?: Record<string, any>;
+};
+
 export type HandshakeTorModule = {
     shouldRunTor: boolean;
 };

--- a/packages/suite-desktop-core/src/__tests__/app-utils.test.ts
+++ b/packages/suite-desktop-core/src/__tests__/app-utils.test.ts
@@ -1,0 +1,39 @@
+import { processStatePatch } from '../libs/app-utils';
+
+const ARGS = {
+    state: '{ "d": { "e": true }, "a.c": "baz" }',
+    'state.a': '{"b": [5] }',
+    'state.a.b': '[1, 3, 8]',
+    'state.a.c': 'foobar',
+    a: 'nothing',
+    b: 'empty',
+};
+
+const FIXTURES: [string, (keyof typeof ARGS)[], any][] = [
+    ['simple', ['state.a.b', 'state.a.c'], { a: { b: [1, 3, 8], c: 'foobar' } }],
+    ['mixed', ['a', 'state.a', 'b', 'state.a.b'], { a: { b: [5, 1, 3, 8] } }],
+    [
+        'complex',
+        ['state.a.b', 'a', 'state', 'b', 'state.a'],
+        { a: { b: [1, 3, 8, 5], c: 'baz' }, d: { e: true } },
+    ],
+];
+
+jest.mock('electron', () => {
+    return {
+        app: {
+            commandLine: {
+                getSwitchValue: (arg: keyof typeof ARGS) => ARGS[arg],
+            },
+        },
+    };
+});
+
+describe('process state patch', () => {
+    FIXTURES.map(([name, args, value]) => {
+        it(name, () => {
+            process.argv = args.map(arg => `--${arg}=${ARGS[arg]}`);
+            expect(processStatePatch()).toStrictEqual(value);
+        });
+    });
+});

--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -9,7 +9,7 @@ import { APP_NAME } from './libs/constants';
 import { Store } from './libs/store';
 import { MIN_HEIGHT, MIN_WIDTH } from './libs/screen';
 import { getBuildInfo, getComputerInfo } from './libs/info';
-import { restartApp } from './libs/app-utils';
+import { restartApp, processStatePatch } from './libs/app-utils';
 import { clearAppCache, initUserData } from './libs/user-data';
 import { initSentry } from './libs/sentry';
 import { initModules, mainThreadEmitter } from './modules';
@@ -168,8 +168,9 @@ const init = async () => {
 
     ipcMain.handle('handshake/load-tor-module', () => loadTorModule());
 
+    const statePatch = processStatePatch();
     // load and wait for handshake message from renderer
-    const handshake = await hangDetect(mainWindow);
+    const handshake = await hangDetect(mainWindow, statePatch);
 
     // handle hangDetect errors
     if (handshake === 'quit') {

--- a/packages/suite-desktop-core/src/hang-detect.ts
+++ b/packages/suite-desktop-core/src/hang-detect.ts
@@ -17,7 +17,10 @@ const showDialog = async (mainWindow: BrowserWindow) => {
     return (['wait', 'quit', 'reload'] as const)[resp.response];
 };
 
-export const hangDetect = (mainWindow: BrowserWindow): Promise<HandshakeResult> => {
+export const hangDetect = (
+    mainWindow: BrowserWindow,
+    statePatch?: Record<string, any>,
+): Promise<HandshakeResult> => {
     const { logger } = global;
     let timeout: ReturnType<typeof setTimeout>;
 
@@ -36,10 +39,10 @@ export const hangDetect = (mainWindow: BrowserWindow): Promise<HandshakeResult> 
         ipcMain.handleOnce('handshake/client', () => {
             clearTimeout(timeout);
             // always resolve repeated handshakes from renderer (e.g. Ctrl+R)
-            ipcMain.handle('handshake/client', () => Promise.resolve());
+            ipcMain.handle('handshake/client', () => Promise.resolve({}));
             resolve('success');
 
-            return Promise.resolve();
+            return Promise.resolve({ statePatch });
         });
         logger.debug('init', `Load URL (${APP_SRC})`);
         mainWindow.loadURL(APP_SRC);

--- a/packages/suite-desktop-core/src/libs/app-utils.ts
+++ b/packages/suite-desktop-core/src/libs/app-utils.ts
@@ -1,5 +1,7 @@
 import { app } from 'electron';
 
+import { mergeDeepObject } from '@trezor/utils';
+
 export const restartApp = () => {
     const { logger } = global;
 
@@ -15,3 +17,22 @@ export const restartApp = () => {
     app.relaunch();
     app.quit();
 };
+
+const tryParseJson = (value: any) => {
+    try {
+        return JSON.parse(value);
+    } catch {
+        return value;
+    }
+};
+
+export const processStatePatch = () =>
+    process.argv
+        .filter(arg => /^--state[.=]/.test(arg))
+        .map(arg => arg.slice(2).split('=')[0])
+        .map(arg => [arg.slice(6), tryParseJson(app.commandLine.getSwitchValue(arg))] as const)
+        .map(([key, value]) => (key ? { [key]: value } : value))
+        .reduce<Record<string, any> | undefined>(
+            (prev, cur) => mergeDeepObject.withOptions({ dotNotation: true }, prev ?? {}, cur),
+            undefined,
+        );

--- a/packages/suite-desktop-ui/src/Main.tsx
+++ b/packages/suite-desktop-ui/src/Main.tsx
@@ -82,9 +82,8 @@ export const init = async (container: HTMLElement) => {
     root.render(<LoadingScreen />);
 
     const preloadAction = await preloadStore();
-    const store = initStore(preloadAction);
-
-    await desktopApi.handshake();
+    const { statePatch } = await desktopApi.handshake();
+    const store = initStore(preloadAction, statePatch);
 
     // start logging to file if Debug menu is active
     if (

--- a/packages/suite/src/reducers/store.ts
+++ b/packages/suite/src/reducers/store.ts
@@ -7,6 +7,7 @@ import { createLogger } from 'redux-logger';
 import { prepareFirmwareReducer } from '@suite-common/wallet-core';
 import { addLog } from '@suite-common/logger';
 import { isCodesignBuild } from '@trezor/env-utils';
+import { mergeDeepObject } from '@trezor/utils';
 
 import suiteMiddlewares from 'src/middlewares/suite';
 import walletMiddlewares from 'src/middlewares/wallet';
@@ -79,16 +80,24 @@ const devTools =
           }
         : false;
 
-export const initStore = (preloadStoreAction?: PreloadStoreAction) => {
+export const initStore = (
+    preloadStoreAction?: PreloadStoreAction,
+    statePatch?: Record<string, any>,
+) => {
     // get initial state by calling STORAGE.LOAD action with optional payload
     // payload will be processed in each reducer explicitly
     const preloadedState = preloadStoreAction
         ? rootReducer(undefined, preloadStoreAction)
         : undefined;
 
+    const patchedState =
+        preloadedState && statePatch
+            ? mergeDeepObject.withOptions({ dotNotation: true }, preloadedState, statePatch)
+            : preloadedState;
+
     return configureStore({
         reducer: rootReducer,
-        preloadedState,
+        preloadedState: patchedState,
         middleware,
         devTools,
     });

--- a/packages/suite/src/reducers/store.ts
+++ b/packages/suite/src/reducers/store.ts
@@ -80,6 +80,13 @@ const devTools =
           }
         : false;
 
+const patchConfirm = (statePatch: any) =>
+    !isCodesignBuild() ||
+    confirm(
+        `Trezor Suite is starting with partially predefined state. Press OK only if you intended to do that!\n\n` +
+            JSON.stringify(statePatch, null, 4),
+    );
+
 export const initStore = (
     preloadStoreAction?: PreloadStoreAction,
     statePatch?: Record<string, any>,
@@ -91,7 +98,7 @@ export const initStore = (
         : undefined;
 
     const patchedState =
-        preloadedState && statePatch
+        preloadedState && statePatch && patchConfirm(statePatch)
             ? mergeDeepObject.withOptions({ dotNotation: true }, preloadedState, statePatch)
             : preloadedState;
 

--- a/packages/utils/tests/mergeDeepObject.test.ts
+++ b/packages/utils/tests/mergeDeepObject.test.ts
@@ -195,4 +195,26 @@ describe('mergeDeepObject', () => {
             expect(value).toBe(1);
         });
     });
+
+    describe('dot notation', () => {
+        const fn = () => {};
+        const first = { a: { b: 1, c: 'foo' }, 'd.e': { f: null, 'g.h': 42 }, l: { m: [8] } };
+        const second = { 'a.b': 3, d: { 'e.f': fn, 'e.g': true }, 'i.j.k': undefined, 'l.m': [9] };
+        const third = { 'i.j': 'bar' };
+
+        it('dot notation off', () => {
+            const res = mergeDeepObject.withOptions({ mergeArrays: false }, first, second, third);
+            expect(res).toStrictEqual({ ...first, ...second, ...third });
+        });
+
+        it('dot notation on', () => {
+            const res = mergeDeepObject.withOptions({ dotNotation: true }, first, second, third);
+            expect(res).toStrictEqual({
+                a: { b: 3, c: 'foo' },
+                d: { e: { f: fn, g: true } },
+                i: { j: 'bar' },
+                l: { m: [8, 9] },
+            });
+        });
+    });
 });


### PR DESCRIPTION
## Description

For various reasons (e.g. e2e tests) it could be useful to start Suite with specific redux state.

- https://github.com/trezor/trezor-suite/commit/68b672d285b6f248404a4880a15c8de36fef92bc - `mergeDeepObject` util now supports dot notation: `{ a: { b: 3 }}` ≡ `{ 'a.b': 3 }`
- https://github.com/trezor/trezor-suite/commit/7ef980f92095d93ee886f4c2414bc8f04ec5f55e - added `processStatePatch` util to desktop Suite; it reads and merges all command-line flags starting with `--state` into partial redux state object, e.g. `--state.suite.settings.language=fr --state.suite.settings.autodetect.language=false`
- https://github.com/trezor/trezor-suite/commit/12e682f65f3a25d7eefb7ac777fd9e6523b0b126 - the partial state is sent to renderer as part of handshake message
- https://github.com/trezor/trezor-suite/commit/f60303224367757ab20771f4a982125bee7e0f73 - the partial state received in handshake is merged with preloaded state and passed to redux
- https://github.com/trezor/trezor-suite/commit/4ce35f06b69a3763564d5e896b52ec3ffbc80dcf - in codesign show confirmation prompt before using the partial state