### PR TITLE
fix(suite-native): redundant graph time frame dispatch

### DIFF
--- a/suite-native/graph/src/hooks.ts
+++ b/suite-native/graph/src/hooks.ts
@@ -150,9 +150,12 @@ export const useGraphForAllDeviceAccounts = ({ fiatCurrency }: CommonUseGraphPar
     );
 
     const handleSelectPortfolioTimeframe = useCallback(
-        (timeframeHours: TimeframeHoursValue) =>
-            dispatch(setPortfolioGraphTimeframe({ timeframeHours })),
-        [dispatch],
+        (timeframeHours: TimeframeHoursValue) => {
+            if (portfolioGraphTimeframe !== timeframeHours) {
+                dispatch(setPortfolioGraphTimeframe({ timeframeHours }));
+            }
+        },
+        [dispatch, portfolioGraphTimeframe],
     );
 
     useWatchTimeframeChangeForAnalytics(portfolioGraphTimeframe);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix redundant dispatch on graph timeframe where if user selects same time frame that is already selected, we dispatch action that is unnecessary. Visually there is no change, just one less call. 