### PR TITLE
fix(suite): select device model correctly

### DIFF
--- a/packages/suite/src/views/firmware/FirmwareUpdate.tsx
+++ b/packages/suite/src/views/firmware/FirmwareUpdate.tsx
@@ -2,7 +2,7 @@ import { DeviceModelInternal } from '@trezor/connect';
 
 import { FirmwareInitial } from 'src/components/firmware';
 import { closeModalApp } from 'src/actions/suite/routerActions';
-import { useDispatch, useFirmware } from 'src/hooks/suite';
+import { useDevice, useDispatch, useFirmware } from 'src/hooks/suite';
 import { FirmwareModal } from './FirmwareModal';
 
 type FirmwareUpdateProps = {
@@ -10,13 +10,16 @@ type FirmwareUpdateProps = {
 };
 
 export const FirmwareUpdate = ({ shouldSwitchFirmwareType = false }: FirmwareUpdateProps) => {
-    const { firmwareUpdate, getTargetFirmwareType, uiEvent } = useFirmware();
+    const { device } = useDevice();
+    const { firmwareUpdate, getTargetFirmwareType } = useFirmware();
     const dispatch = useDispatch();
 
-    const deviceModelInternal = uiEvent?.payload.device.features?.internal_model;
-    // Device will be wiped because Universal and Bitcoin-only firmware have different vendor headers on T2B1 or later devices.
+    const deviceModelInternal = device?.features?.internal_model;
+    // Device will be wiped because Universal and Bitcoin-only firmware have different vendor headers, except T1B1 and T2T1.
     const deviceWillBeWiped =
-        shouldSwitchFirmwareType && deviceModelInternal === DeviceModelInternal.T2B1;
+        shouldSwitchFirmwareType &&
+        deviceModelInternal &&
+        [DeviceModelInternal.T1B1, DeviceModelInternal.T2B1].includes(deviceModelInternal);
 
     const close = () => dispatch(closeModalApp());
     const installTargetFirmware = () =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- correctly select `deviceModelInternal`
  - `uiEvent` is `undefined` at this point, so `useDevice` must be used here
- make sure this works correctly for TS5 and later devices
## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/12558

## Screenshots:
![Screenshot 2024-06-03 at 13 52 01](https://github.com/trezor/trezor-suite/assets/42465546/4c9f01ab-5e52-4d93-9985-3067e86e077e)

