### PR TITLE
chore(suite-native): redux debugger max age actions

### DIFF
--- a/suite-native/state/src/store.ts
+++ b/suite-native/state/src/store.ts
@@ -24,7 +24,7 @@ const middlewares: Middleware[] = [
 const enhancers: Array<StoreEnhancer<any, any>> = [];
 
 if (__DEV__) {
-    enhancers.push(devToolsEnhancer()!);
+    enhancers.push(devToolsEnhancer({ maxAge: 150 })!);
 }
 
 export const initStore = async () =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The default `maxAge` of `redux-devtools-expo-dev-plugin` is 30 which runs out in a couple of interactions with the app so 150 should be enough for some basic debugging. 

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
