### PR TITLE
fix(suite-native): e2e tests flakiness

### DIFF
--- a/.github/workflows/test-suite-native-e2e-android.yml
+++ b/.github/workflows/test-suite-native-e2e-android.yml
@@ -52,7 +52,7 @@ jobs:
         run: yarn prebuild --platform android --clean
 
       - name: Build Detox test .apk
-        run: yarn build:e2e android.emu.release
+        run: ../../node_modules/.bin/detox build -PreactNativeArchitectures=x86_64 --configuration android.emu.release
         working-directory: ./suite-native/app
 
       - name: Save build to cache

--- a/suite-native/app/.detoxrc.js
+++ b/suite-native/app/.detoxrc.js
@@ -29,7 +29,7 @@ module.exports = {
         'android.release': {
             type: 'android.apk',
             binaryPath: 'android/app/build/outputs/apk/release/app-release.apk',
-            build: 'cd android && IS_DETOX_BUILD=true ./gradlew :app:assembleRelease :app:assembleAndroidTest -PreactNativeArchitectures=x86_64 -DtestBuildType=release',
+            build: 'cd android && IS_DETOX_BUILD=true ./gradlew :app:assembleRelease :app:assembleAndroidTest -DtestBuildType=release',
             reversePorts: [21325, 19121],
         },
     },

--- a/suite-native/app/e2e/tests/invalidAccountsImport.test.ts
+++ b/suite-native/app/e2e/tests/invalidAccountsImport.test.ts
@@ -7,6 +7,12 @@ import { onAccountImport } from '../pageObjects/accountImportActions';
 import { onMyAssets } from '../pageObjects/myAssetsActions';
 import { onTabBar } from '../pageObjects/tabBarActions';
 
+const goToBtcImportXpubScreen = async () => {
+    await onTabBar.navigateToMyAssets();
+    await onMyAssets.addAccount();
+    await onAccountImport.selectCoin({ networkSymbol: 'btc' });
+};
+
 describe('Import invalid accounts', () => {
     beforeAll(async () => {
         await openApp({ newInstance: true });
@@ -16,11 +22,10 @@ describe('Import invalid accounts', () => {
     beforeEach(async () => {
         await restartApp();
         await appIsFullyLoaded();
+        await goToBtcImportXpubScreen();
     });
     it('Import an already imported XPUB', async () => {
         // add first account
-        await onTabBar.navigateToMyAssets();
-        await onMyAssets.addAccount();
         await onAccountImport.importAccount({
             networkSymbol: 'btc',
             xpub: xpubs.btc.legacySegwit,
@@ -28,9 +33,7 @@ describe('Import invalid accounts', () => {
         });
 
         // try to add account with same xpub
-        await onTabBar.navigateToMyAssets();
-        await onMyAssets.addAccount();
-        await onAccountImport.selectCoin({ networkSymbol: 'btc' });
+        await goToBtcImportXpubScreen();
         await onAccountImport.submitXpub({ xpub: xpubs.btc.legacySegwit, isValid: true });
 
         await detoxExpect(element(by.id('@account-import/summary/account-already-imported')));
@@ -39,8 +42,6 @@ describe('Import invalid accounts', () => {
     it('Import BTC receive address', async () => {
         const btcReceiveAddress = 'bc1qunyzxr3gfcg7ggxp5vpxwm3q7t3xc52rcaupu4';
 
-        await onTabBar.navigateToMyAssets();
-        await onMyAssets.addAccount();
         await onAccountImport.selectCoin({ networkSymbol: 'btc' });
         await onAccountImport.submitXpub({ xpub: btcReceiveAddress, isValid: false });
 

--- a/suite-native/app/e2e/tests/onboardAndConnect.test.ts
+++ b/suite-native/app/e2e/tests/onboardAndConnect.test.ts
@@ -7,6 +7,8 @@ import { openApp } from '../utils';
 import { onOnboarding } from '../pageObjects/onboardingActions';
 
 const TREZOR_DEVICE_LABEL = 'Trezor T - Tester';
+// Contains only one BTC account with a single transaction to make the discovery as fast as possible.
+const SIMPLE_SEED = 'immune enlist rule measure fan swarm mandate track point menu security fan';
 const platform = device.getPlatform();
 
 describe('Go through onboarding and connect Trezor.', () => {
@@ -16,7 +18,10 @@ describe('Go through onboarding and connect Trezor.', () => {
             await TrezorUserEnvLink.api.trezorUserEnvDisconnect();
             await TrezorUserEnvLink.api.trezorUserEnvConnect();
             await TrezorUserEnvLink.api.startEmu({ wipe: true });
-            await TrezorUserEnvLink.api.setupEmu({ label: TREZOR_DEVICE_LABEL });
+            await TrezorUserEnvLink.api.setupEmu({
+                label: TREZOR_DEVICE_LABEL,
+                mnemonic: SIMPLE_SEED,
+            });
             await TrezorUserEnvLink.api.startBridge();
             await TrezorUserEnvLink.api.stopEmu();
         }
@@ -31,18 +36,11 @@ describe('Go through onboarding and connect Trezor.', () => {
         await device.terminateApp();
     });
 
-    it('Redirect from first to second screen', async () => {
+    it('Navigate to dashboard', async () => {
         await onOnboarding.finishOnboarding();
 
         if (platform === 'android') {
-            device.disableSynchronization();
             await TrezorUserEnvLink.api.startEmu();
-
-            await waitFor(element(by.id('skip-view-only-mode')))
-                .toBeVisible()
-                .withTimeout(60000); // communication between connected Trezor and app takes some time.
-
-            await element(by.id('skip-view-only-mode')).tap();
 
             await waitFor(element(by.text(TREZOR_DEVICE_LABEL)))
                 .toBeVisible()


### PR DESCRIPTION
Improve flakiness of the E2E tests:

- x86 architecture-specific build only for CI
- view-only bottom sheet removed because it's visibility was tested in wrong place (even before finishing discovery which is wrong)
