### PR TITLE
fix(transport-bridge): windows

### DIFF
--- a/packages/transport-bridge/src/core.ts
+++ b/packages/transport-bridge/src/core.ts
@@ -36,6 +36,9 @@ export const createApi = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) => 
                       usbInterface: new WebUSB({
                           allowAllDevices: true, // return all devices, not only authorized
                       }),
+
+                      // todo: possibly only for windows
+                      forceReadSerialOnConnect: true,
                   });
     } else {
         api = apiArg;

--- a/packages/transport-bridge/tests/http.test.ts
+++ b/packages/transport-bridge/tests/http.test.ts
@@ -58,6 +58,7 @@ const createTransportApi = (override = {}) =>
             });
         },
         dispose: () => {},
+        listen: () => {},
         ...override,
     }) as unknown as AbstractApi;
 

--- a/packages/transport/src/api/abstract.ts
+++ b/packages/transport/src/api/abstract.ts
@@ -35,6 +35,7 @@ export abstract class AbstractApi extends TypedEmitter<{
     'transport-interface-error': typeof ERRORS.DEVICE_NOT_FOUND | typeof ERRORS.DEVICE_UNREADABLE;
 }> {
     protected logger?: Logger;
+    protected listening: boolean = false;
 
     constructor({ logger }: AbstractApiConstructorParams) {
         super();
@@ -50,6 +51,11 @@ export abstract class AbstractApi extends TypedEmitter<{
         | typeof ERRORS.ABORTED_BY_SIGNAL
         | typeof ERRORS.UNEXPECTED_ERROR
     >;
+
+    /**
+     * start emitting `transport-interface-change` events
+     */
+    abstract listen(): void;
 
     /**
      * read from device on path

--- a/packages/transport/src/api/usb.ts
+++ b/packages/transport/src/api/usb.ts
@@ -240,7 +240,7 @@ export class UsbApi extends AbstractApi {
         return this.openInternal(path, first);
     }
 
-    public async openInternal(path: string, first: boolean) {
+    private async openInternal(path: string, first: boolean) {
         const device = this.findDevice(path);
         if (!device) {
             return this.error({ error: ERRORS.DEVICE_NOT_FOUND });

--- a/packages/transport/src/api/usb.ts
+++ b/packages/transport/src/api/usb.ts
@@ -38,10 +38,7 @@ export class UsbApi extends AbstractApi {
 
         this.usbInterface = usbInterface;
 
-        if (!this.usbInterface) {
-            return;
-        }
-
+    public listen() {
         this.usbInterface.onconnect = event => {
             this.logger?.debug(`usb: onconnect: ${this.formatDeviceForLog(event.device)}`);
             const [_hidDevices, nonHidDevices] = this.filterDevices([event.device]);

--- a/packages/transport/src/api/usb.ts
+++ b/packages/transport/src/api/usb.ts
@@ -42,6 +42,14 @@ export class UsbApi extends AbstractApi {
         this.usbInterface.onconnect = event => {
             this.logger?.debug(`usb: onconnect: ${this.formatDeviceForLog(event.device)}`);
             const [_hidDevices, nonHidDevices] = this.filterDevices([event.device]);
+
+            _hidDevices.forEach(() => {
+                // hidDevices that do not support webusb. these are very very old. we used to emit unreadable
+                // device for these but I am not sure if it is still worth the effort.
+                this.logger?.error(
+                    `usb: unreadable hid device connected. device: ${this.formatDeviceForLog(event.device)}`,
+                );
+            });
             if (nonHidDevices.length) {
                 this.devices = [...this.devices, ...this.createDevices(nonHidDevices)];
                 this.emit('transport-interface-change', this.devicesToDescriptors());

--- a/packages/transport/src/api/usb.ts
+++ b/packages/transport/src/api/usb.ts
@@ -81,6 +81,13 @@ export class UsbApi extends AbstractApi {
             productId: device.productId,
             deviceVersionMajor: device.deviceVersionMajor,
             deviceVersionMinor: device.deviceVersionMinor,
+            opened: device.opened,
+            deviceProtocol: device.deviceProtocol,
+            deviceClass: device.deviceClass,
+            deviceSubclass: device.deviceSubclass,
+            usbVersionMajor: device.usbVersionMajor,
+            usbVersionMinor: device.usbVersionMinor,
+            usbVersionSubminor: device.usbVersionSubminor,
         });
     }
 
@@ -155,7 +162,7 @@ export class UsbApi extends AbstractApi {
             this.logger?.debug('usb: device.transferIn');
             const res = await device.transferIn(ENDPOINT_ID, 64);
             this.logger?.debug(
-                `usb: device.transferIn done. status: ${res.status}, byteLength: ${res.data?.byteLength}`,
+                `usb: device.transferIn done. status: ${res.status}, byteLength: ${res.data?.byteLength}. device: ${this.formatDeviceForLog(device)}`,
             );
 
             if (!res.data) {
@@ -186,7 +193,9 @@ export class UsbApi extends AbstractApi {
             // https://wicg.github.io/webusb/#ref-for-dom-usbdevice-transferout
             this.logger?.debug('usb: device.transferOut');
             const result = await device.transferOut(ENDPOINT_ID, newArray);
-            this.logger?.debug('usb: device.transferOut done');
+            this.logger?.debug(
+                `usb: device.transferOut done. device: ${this.formatDeviceForLog(device)}`,
+            );
 
             if (result.status !== 'ok') {
                 this.logger?.error(`usb: device.transferOut status not ok: ${result.status}`);
@@ -212,6 +221,7 @@ export class UsbApi extends AbstractApi {
         // note: why for instead of scheduleAction from @trezor/utils with attempts param. this.openInternal does not throw
         // I would need to throw artificially which is not nice.
         for (let i = 0; i < 5; i++) {
+            this.logger?.debug(`usb: openDevice attempt ${i}`);
             const res = await this.openInternal(path, first);
             if (res.success) {
                 return res;
@@ -232,7 +242,7 @@ export class UsbApi extends AbstractApi {
         try {
             this.logger?.debug(`usb: device.open`);
             await device.open();
-            this.logger?.debug(`usb: device.open done`);
+            this.logger?.debug(`usb: device.open done. device: ${this.formatDeviceForLog(device)}`);
         } catch (err) {
             this.logger?.error(`usb: device.open error ${err}`);
 
@@ -246,7 +256,9 @@ export class UsbApi extends AbstractApi {
             try {
                 this.logger?.debug(`usb: device.selectConfiguration ${CONFIGURATION_ID}`);
                 await device.selectConfiguration(CONFIGURATION_ID);
-                this.logger?.debug(`usb: device.selectConfiguration done: ${CONFIGURATION_ID}`);
+                this.logger?.debug(
+                    `usb: device.selectConfiguration done: ${CONFIGURATION_ID}. device: ${this.formatDeviceForLog(device)}`,
+                );
             } catch (err) {
                 this.logger?.error(
                     `usb: device.selectConfiguration error ${err}. device: ${this.formatDeviceForLog(device)}`,
@@ -256,7 +268,9 @@ export class UsbApi extends AbstractApi {
                 // reset fails on ChromeOS and windows
                 this.logger?.debug('usb: device.reset');
                 await device.reset();
-                this.logger?.debug('usb: device.reset done');
+                this.logger?.debug(
+                    `usb: device.reset done. device: ${this.formatDeviceForLog(device)}`,
+                );
             } catch (err) {
                 this.logger?.error(
                     `usb: device.reset error ${err}. device: ${this.formatDeviceForLog(device)}`,
@@ -268,7 +282,9 @@ export class UsbApi extends AbstractApi {
             this.logger?.debug(`usb: device.claimInterface: ${INTERFACE_ID}`);
             // claim device for exclusive access by this app
             await device.claimInterface(INTERFACE_ID);
-            this.logger?.debug(`usb: device.claimInterface done: ${INTERFACE_ID}`);
+            this.logger?.debug(
+                `usb: device.claimInterface done: ${INTERFACE_ID}. device: ${this.formatDeviceForLog(device)}`,
+            );
         } catch (err) {
             this.logger?.error(
                 `usb: device.claimInterface error ${err}. device: ${this.formatDeviceForLog(device)}`,
@@ -296,7 +312,9 @@ export class UsbApi extends AbstractApi {
                 const interfaceId = INTERFACE_ID;
                 this.logger?.debug(`usb: device.releaseInterface: ${interfaceId}`);
                 await device.releaseInterface(interfaceId);
-                this.logger?.debug(`usb: device.releaseInterface done: ${interfaceId}`);
+                this.logger?.debug(
+                    `usb: device.releaseInterface done: ${interfaceId}. device: ${this.formatDeviceForLog(device)}`,
+                );
             } catch (err) {
                 this.logger?.error(
                     `usb: releaseInterface error ${err}. device: ${this.formatDeviceForLog(device)}`,
@@ -308,7 +326,9 @@ export class UsbApi extends AbstractApi {
             try {
                 this.logger?.debug(`usb: device.close`);
                 await device.close();
-                this.logger?.debug(`usb: device.close done`);
+                this.logger?.debug(
+                    `usb: device.close done. device: ${this.formatDeviceForLog(device)}`,
+                );
             } catch (err) {
                 this.logger?.debug(
                     `usb: device.close error ${err}. device: ${this.formatDeviceForLog(device)}`,

--- a/packages/transport/src/api/usb.ts
+++ b/packages/transport/src/api/usb.ts
@@ -42,8 +42,10 @@ export class UsbApi extends AbstractApi {
         this.usbInterface.onconnect = event => {
             this.logger?.debug(`usb: onconnect: ${this.formatDeviceForLog(event.device)}`);
             const [_hidDevices, nonHidDevices] = this.filterDevices([event.device]);
-            this.devices = [...this.devices, ...this.createDevices(nonHidDevices)];
-            this.emit('transport-interface-change', this.devicesToDescriptors());
+            if (nonHidDevices.length) {
+                this.devices = [...this.devices, ...this.createDevices(nonHidDevices)];
+                this.emit('transport-interface-change', this.devicesToDescriptors());
+            }
         };
 
         this.usbInterface.ondisconnect = event => {

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -24,7 +24,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
     // sessions client is a standardized interface for communicating with sessions backend
     // which can live in couple of context (shared worker, local module, websocket server etc)
     private sessionsClient: ConstructorParams['sessionsClient'];
-    private api: AbstractApi;
+    protected api: AbstractApi;
 
     constructor({ messages, api, sessionsClient, signal, logger }: ConstructorParams) {
         super({ messages, signal, logger });

--- a/packages/transport/src/transports/nodeusb.ts
+++ b/packages/transport/src/transports/nodeusb.ts
@@ -39,4 +39,10 @@ export class NodeUsbTransport extends AbstractApiTransport {
             signal,
         });
     }
+
+    public listen() {
+        this.api.listen();
+
+        return super.listen();
+    }
 }

--- a/packages/transport/src/transports/udp.ts
+++ b/packages/transport/src/transports/udp.ts
@@ -34,14 +34,7 @@ export class UdpTransport extends AbstractApiTransport {
     }
 
     public listen() {
-        const enumerateRecursive = () => {
-            if (!this.listening) return;
-
-            this.enumerateTimeout = setTimeout(() => {
-                this.enumerate().promise.finally(enumerateRecursive);
-            }, 500);
-        };
-        enumerateRecursive();
+        this.api.listen();
 
         return super.listen();
     }

--- a/packages/transport/src/transports/webusb.browser.ts
+++ b/packages/transport/src/transports/webusb.browser.ts
@@ -33,4 +33,10 @@ export class WebUsbTransport extends AbstractApiTransport {
             signal,
         });
     }
+
+    public listen() {
+        this.api.listen();
+
+        return super.listen();
+    }
 }


### PR DESCRIPTION
problem: 

In windows, node usb transport does not return serialNumber in connect event. Or to be more specific - it does return the serialNumber but only until device was worked with. After connecting device, doing for example account discovery - when I reconnect the device again, it does not have serialNumber anymore. 

This is a big problem since serialNumber is used to distinguish between multiple simultaneously connected devices on transport api layer. Practically this issue can cause api layer to delete a different device from the one that was physically disconnected. 


Commits: 
- [chore(transport): add more logs to usb](https://github.com/trezor/trezor-suite/pull/12728/commits/90594776062dc422e9c3b1ed7bf470b5026f1527)
  - just adding some logs, could be useful.
  - also it is possible to get libusb logs, `usb` [package supports this](https://github.com/node-usb/node-usb?tab=readme-ov-file#usbsetdebuglevellevel--int). these are the logs that are available via the "download detailed log" button in the old bridge status page. The question is, how do I redirect these logs into a file?  
- [chore(transport): introduce listen in abstractApi](https://github.com/trezor/trezor-suite/pull/12728/commits/3289f1da4b74dc0714dcf701ac431dbae6426b91)
  - In my opinion this is a little cleaner approach (see the removed code from core.ts in transport-bridge). 
- [chore(transport): createDevices only if there are some nonHid devices…](https://github.com/trezor/trezor-suite/pull/12728/commits/5b5b94e40abce5e672d4f341984fbcea8f79418c) 
  - a small optimization, it is not necessary to call createDevices function in case the array is empty - there is no need to emit transport-interface-change event in case there is in fact no change that could be consumed by higher layers.
- [chore(transport): log connected hid device](https://github.com/trezor/trezor-suite/pull/12728/commits/d48a27e83118e56e96e30ad70092c576be29fe70)
  - at the moment, node-bridge can't handle old hid devices. this is a known limitation and I belive product is fine with this.  However I also belive that we should propagate this information upwards to be able to show "unreadable device screen" with appropriate troubleshooting tips. Lets address this in a followup. 
  - another option would be to implement hid api as well.[ should be possible using node-hid package. ](https://www.npmjs.com/package/node-hid)
- [chore(transport): change public method to private](https://github.com/trezor/trezor-suite/pull/12728/commits/eeab7cc948fffaaa8f8dfcc4097a51761f459c17)
  - tiny change. 
- [fix(transport): make device.serialNumber available also for windows](https://github.com/trezor/trezor-suite/pull/12728/commits/3a3751133d60fe89c02246acddcd1acdb0cca56d)
  - this commit ensures that serialNumber is always awailable even for Windows.
  - unasnwered question: should we run this code on all platforms (Linux, Win, Mac) or limit it only for Win? What is better? Use the same code everywhere which is easier to test and maybe has less maintanance overhead but it comes at the cost of doing unnecessary work on some of the platforms?



Followups: 
- [ ] propagate unreadable hid device upwards.

Issues and PRs:
- might fix #12562
- might fix #12560
- based on #12682