### PR TITLE
GitBook revision update

### DIFF
--- a/packages/suite-data/src/guide/constants.ts
+++ b/packages/suite-data/src/guide/constants.ts
@@ -1,7 +1,7 @@
 import { resolve, join } from 'path';
 
 export const GITBOOK_SOURCE = 'https://github.com/trezor/trezor-suite-guide.git';
-export const GITBOOK_REVISION = '34b6868fd84f86f84de45ae9066e89326fa354a2';
+export const GITBOOK_REVISION = 'c127b4d0484adc7ec6e56b735029d6378020ec1b';
 export const TMP = join(resolve(__dirname, '../..'), 'tmp', 'guide');
 // Path to the GitBook assets. Relative to TMP.
 export const GITBOOK_ASSETS_DIR_PREFIX = '.gitbook';


### PR DESCRIPTION
Automatically generated PR to update GitBook revision, i.e. to sync the latest [trezor-suite-guide](https://github.com/trezor/trezor-suite-guide) content to Suite. Before merging, check its [commit history](https://github.com/trezor/trezor-suite-guide/commits/master). Once the pipeline finishes, you can check the result [here](https://dev.suite.sldev.cz/suite-web/chore/update-suite-guide/web/).