### PR TITLE
feat(connect): applySettings - accept all validated params

### DIFF
--- a/packages/connect/src/api/applySettings.ts
+++ b/packages/connect/src/api/applySettings.ts
@@ -14,15 +14,7 @@ export default class ApplySettings extends AbstractMethod<'applySettings', PROTO
         Assert(ApplySettingsSchema, payload);
 
         this.params = {
-            language: payload.language,
-            label: payload.label,
-            use_passphrase: payload.use_passphrase,
-            homescreen: payload.homescreen,
-            passphrase_always_on_device: payload.passphrase_always_on_device,
-            auto_lock_delay_ms: payload.auto_lock_delay_ms,
-            display_rotation: payload.display_rotation,
-            safety_checks: payload.safety_checks,
-            experimental_features: payload.experimental_features,
+            ...payload,
             _passphrase_source: payload.passphrase_source,
         };
     }


### PR DESCRIPTION

1st commit 
  - since validation is already on line 14, we may safely assign params based on payload. 
  - groundwork for https://github.com/trezor/trezor-suite/issues/12315 as this passes the newly introduced and otherwise missing param "haptic_feedback"