### PR TITLE
chore(connect-explorer): remove nextra reference from webextension

### DIFF
--- a/packages/connect-explorer/src-webextension/manifest.json
+++ b/packages/connect-explorer/src-webextension/manifest.json
@@ -1,5 +1,5 @@
 {
-    "name": "@trezor/connect-webextension-nextra",
+    "name": "@trezor/connect-webextension",
     "version": "1.0.0",
     "manifest_version": 3,
     "action": {


### PR DESCRIPTION
## Description

Remove nextra reference from webextension name. 
This should be the only visible reference left, except older changelogs. 

## Related Issue

Resolve #12670