### PR TITLE
fix(react-native-usb): implement opened WebUSBDevice state and closing device when leaving the app

### DIFF
--- a/packages/react-native-usb/android/src/main/AndroidManifest.xml
+++ b/packages/react-native-usb/android/src/main/AndroidManifest.xml
@@ -1,12 +1,19 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
     <uses-permission android:name="android.USB" />
 
     <application>
         <receiver
             android:name=".ReactNativeUsbAttachedReceiver"
-            android:exported="true">
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" />
+            </intent-filter>
+        </receiver>
+        <receiver
+            android:name=".ReactNativeUsbDetachedReceiver"
+            android:exported="false">
+            <intent-filter>
                 <action android:name="android.hardware.usb.action.USB_DEVICE_DETACHED" />
             </intent-filter>
         </receiver>

--- a/packages/react-native-usb/android/src/main/java/io/trezor/rnusb/ReactNativeUsbAttachedReceiver.kt
+++ b/packages/react-native-usb/android/src/main/java/io/trezor/rnusb/ReactNativeUsbAttachedReceiver.kt
@@ -26,7 +26,7 @@ class ReactNativeUsbAttachedReceiver() : BroadcastReceiver() {
                 intent.getParcelableExtra(UsbManager.EXTRA_DEVICE)
             }
             device?.let {
-                Log.d("ReactNativeUSB", "USB device attached: $device")
+                Log.d(LOG_TAG, "USB device attached: $device")
 
                 onDeviceConnectCallback?.invoke(device)
 

--- a/packages/react-native-usb/android/src/main/java/io/trezor/rnusb/ReactNativeUsbDetachedReceiver.kt
+++ b/packages/react-native-usb/android/src/main/java/io/trezor/rnusb/ReactNativeUsbDetachedReceiver.kt
@@ -27,7 +27,7 @@ class ReactNativeUsbDetachedReceiver() : BroadcastReceiver() {
                 intent.getParcelableExtra(UsbManager.EXTRA_DEVICE)
             }
             device?.apply {
-                Log.d("ReactNativeUSB", "USB device disconnected: $device")
+                Log.d(LOG_TAG, "USB device disconnected: $device")
 
                 onDeviceDisconnectCallback?.invoke(device.deviceName)
             }

--- a/packages/react-native-usb/android/src/main/java/io/trezor/rnusb/ReactNativeUsbModule.kt
+++ b/packages/react-native-usb/android/src/main/java/io/trezor/rnusb/ReactNativeUsbModule.kt
@@ -123,15 +123,6 @@ class ReactNativeUsbModule : Module() {
 
             ReactNativeUsbAttachedReceiver.setOnDeviceConnectCallback(onDeviceConnect)
             ReactNativeUsbDetachedReceiver.setOnDeviceDisconnectCallback(onDeviceDisconnect)
-
-            context.registerReceiver(
-                usbAttachedReceiver,
-                IntentFilter(UsbManager.ACTION_USB_DEVICE_ATTACHED)
-            )
-            context.registerReceiver(
-                usbDetachedReceiver,
-                IntentFilter(UsbManager.ACTION_USB_DEVICE_DETACHED)
-            )
         }
 
         OnActivityEntersForeground {
@@ -156,9 +147,6 @@ class ReactNativeUsbModule : Module() {
         }
 
         OnDestroy {
-            context.unregisterReceiver(usbAttachedReceiver)
-            context.unregisterReceiver(usbDetachedReceiver)
-
             ReactNativeUsbAttachedReceiver.setOnDeviceConnectCallback(null)
             ReactNativeUsbDetachedReceiver.setOnDeviceDisconnectCallback(null)
 
@@ -172,10 +160,6 @@ class ReactNativeUsbModule : Module() {
         }
 
     }
-
-    private val usbAttachedReceiver = ReactNativeUsbAttachedReceiver()
-    private val usbDetachedReceiver = ReactNativeUsbDetachedReceiver()
-
 
     private inline fun withModuleScope(promise: Promise, crossinline block: () -> Unit) =
         moduleCoroutineScope.launch {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

One more way to fix https://github.com/trezor/trezor-suite/issues/11896 🙉  This version keep the current permission flow - when you connect Trezor, Android ask you to choose if you want to open the app.

This PR unblock Trezor when Suite Lite goes into the background.

Defining `opened` state properly, Suite Lite is no longer blocking Trezor from usage in other app so it's possible to onboard via Suite Web even if Suite Lite is installed.

New UI for uninitialized device has to be implemented and I would like to use some changes from https://github.com/trezor/trezor-suite/pull/12177 to make permission handling even better in followup PR.

## Related Issue

Part of https://github.com/trezor/trezor-suite/issues/11896


## Screenshots

https://github.com/trezor/trezor-suite/assets/3729633/e99b4c3e-372c-490a-ae02-d0715bbeda94



