### PR TITLE
ci(github): fix bump-version-connect script to find out packages to release and produce right changelog

### DIFF
--- a/.github/workflows/release-connect-bump-versions.yml
+++ b/.github/workflows/release-connect-bump-versions.yml
@@ -23,6 +23,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.TREZOR_BOT_TOKEN }}
+          # Fetch all commit history because Script connect-bump-versions.ts needs them to produce CHANGELOG for packages.
+          fetch-depth: 0
+          # `ref` makes sure that we checkout the branch we are running workflow on.
+          ref: ${{ github.head_ref }}
+          # `submodules` are required to run `yarn build:libs`.
+          submodules: true
 
       - name: Setup node
         uses: actions/setup-node@v4
@@ -31,6 +37,10 @@ jobs:
 
       - name: Install dependencies
         run: yarn install
+
+      # The script connect-bump-versions.ts needs to build packages so dependencies are required.
+      - name: Build dependencies
+        run: yarn build:libs
 
       - name: Setup Git config
         run: |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes 2 things:

1. The script `connect-bump-versions.ts` was producing wrong results in CI because it was building the packages to compare with the ones in NPM without building the libs so the result were always different and it wrongly wanted always to release all the packages.
2. The script `connect-bump-versions.ts`  did not have all the git commit history so when producing the CHANGELOG for the packages to release it was only able to find the last commit, producing wrong CHANGELOGs