### PR TITLE
feat(connect-explorer): verify connectSrc works

### DIFF
--- a/packages/connect-explorer/src/actions/index.ts
+++ b/packages/connect-explorer/src/actions/index.ts
@@ -24,5 +24,6 @@ export const ON_CHANGE_CONNECT_OPTIONS = 'action__on_change_connect_options';
 export const ON_CHANGE_CONNECT_OPTION = 'action__on_change_connect_option';
 
 export const ON_HANDSHAKE_CONFIRMED = 'action__on_handshake_confirmed';
+export const ON_INIT_ERROR = 'action__on_init_error';
 
 export { SET_SCHEMA, SET_METHOD } from './methodActions';

--- a/packages/connect-explorer/src/pages/settings.mdx
+++ b/packages/connect-explorer/src/pages/settings.mdx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
 import { Button } from '@trezor/components';
+import { Callout } from 'nextra/components';
 
 import * as trezorConnectActions from '../actions/trezorConnectActions';
 import { useSelector, useActions } from '../hooks';
@@ -19,6 +20,10 @@ export const ConfirmationMessage = styled.div`
     font-weight: bold;
 `;
 
+export const ErrorMessage = styled(ConfirmationMessage)`
+    color: red;
+`;
+
 export const Settings = () => {
     const connectOptions = useSelector(state => ({
         trustedHost: state.connect?.options?.trustedHost,
@@ -26,6 +31,7 @@ export const Settings = () => {
         useCoreInPopup: state?.connect?.options?.useCoreInPopup,
     }));
 
+    const initError = useSelector(state => state.connect?.initError);
     const isHandshakeConfirmed = useSelector(state => state.connect?.isHandshakeConfirmed || false);
     const actions = useActions({
         onSubmitInit: trezorConnectActions.onSubmitInit,
@@ -60,6 +66,11 @@ export const Settings = () => {
             <Button onClick={actions.onSubmitInit} data-test="@submit-button">
                 {submitButton}
             </Button>
+            {initError && (
+                <ErrorMessage data-test="@settings/init-error">
+                    Init error: {initError}
+                </ErrorMessage>
+            )}
             {isHandshakeConfirmed && (
                 <ConfirmationMessage data-test="@settings/handshake-confirmed">
                     Handshake confirmed!
@@ -71,6 +82,11 @@ export const Settings = () => {
 };
 
 ## Settings
+
+<Callout type="error">
+    **Developers only!** This page is for development purposes only. If you don't know what you are
+    doing, don't change these settings.
+</Callout>
 
 Options for `TrezorConnect` initialization.
 

--- a/packages/connect-explorer/src/reducers/trezorConnectReducer.ts
+++ b/packages/connect-explorer/src/reducers/trezorConnectReducer.ts
@@ -8,6 +8,7 @@ type ConnectState = {
     selectedDevice?: string;
     options?: Parameters<(typeof TrezorConnect)['init']>[0];
     isHandshakeConfirmed: boolean;
+    initError?: string;
 };
 
 const initialState: ConnectState = {
@@ -15,6 +16,7 @@ const initialState: ConnectState = {
     selectedDevice: undefined,
     options: undefined,
     isHandshakeConfirmed: false,
+    initError: undefined,
 };
 
 const findDeviceIndexByPath = (devices: TrezorConnectDevice[], path: string): number =>
@@ -68,7 +70,7 @@ const onOptionChange = <T>(state: ConnectState, field: Field<T>, value: T): Conn
     return newState;
 };
 
-export default function connect(state: ConnectState = initialState, action: Action) {
+export default function connect(state: ConnectState = initialState, action: Action): ConnectState {
     switch (action.type) {
         case DEVICE.CONNECT:
         case DEVICE.CONNECT_UNACQUIRED:
@@ -95,12 +97,18 @@ export default function connect(state: ConnectState = initialState, action: Acti
         case ACTIONS.ON_CHANGE_CONNECT_OPTIONS:
             return {
                 ...state,
+                initError: undefined,
                 options: action.payload,
             };
         case ACTIONS.ON_HANDSHAKE_CONFIRMED:
             return {
                 ...state,
                 isHandshakeConfirmed: true,
+            };
+        case ACTIONS.ON_INIT_ERROR:
+            return {
+                ...state,
+                initError: action.payload,
             };
         default:
             return state;

--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -39,6 +39,7 @@ import {
 } from './view/common';
 import { isPhishingDomain } from './utils/isPhishingDomain';
 import { initLog, setLogWriter, LogWriter } from '@trezor/connect/src/utils/debug';
+import { DEFAULT_DOMAIN } from '@trezor/connect/src/data/version';
 
 const INTERVAL_CHECK_PARENT_ALIVE_MS = 1000;
 const INTERVAL_HANDSHAKE_TIMEOUT_MS = 90 * 1000;
@@ -425,7 +426,7 @@ const initCoreInPopup = async (
     // dynamically load core module
     reactEventBus.dispatch({ type: 'loading', message: 'loading core' });
 
-    const { connectSrc } = payload.settings;
+    const connectSrc = payload.settings.connectSrc ?? DEFAULT_DOMAIN;
     // core is built in a separate build step.
     const { initCoreState, initTransport } = await import(
         /* webpackIgnore: true */ `${connectSrc}js/core.js`


### PR DESCRIPTION
## Description

Adds `connectSrc` validation to Connect Explorer. This is done by checking if `js/core.js` loads as a script. 

Also add a fallback to default for `connectSrc` when loading core in popup. 

## Related Issue

Resolve #12671