### PR TITLE
fix(suite): jumping underline under tab

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/SubpageNavigation.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/SubpageNavigation.tsx
@@ -14,7 +14,6 @@ const Container = styled.div<{ $isFullWidth: boolean }>`
     top: 64px;
     display: flex;
     justify-content: flex-start;
-    align-items: center;
     gap: ${spacingsPx.sm};
     min-height: ${SUBPAGE_NAV_HEIGHT};
     background: ${({ theme }) => theme.backgroundSurfaceElevation0};


### PR DESCRIPTION
## Screenshots:
The underline should be big as under coins under each tab
![Screenshot 2024-06-06 at 13 24 18](https://github.com/trezor/trezor-suite/assets/33235762/bc7b4e09-2d2b-4e20-b592-3bcbffc9b253)
But it was not the case sometimes
![Screenshot 2024-06-06 at 13 24 14](https://github.com/trezor/trezor-suite/assets/33235762/89b5c44e-0d3a-41de-933e-9f0a8c951f94)
Now it is fixed
![Screenshot 2024-06-06 at 13 24 01](https://github.com/trezor/trezor-suite/assets/33235762/3c9802f8-25fc-400b-abc9-6adadcb893c6)
