### PR TITLE
fix(connect-webextension): use bundled build as package main

### DIFF
--- a/packages/connect-explorer/src-webextension/background/serviceWorker.ts
+++ b/packages/connect-explorer/src-webextension/background/serviceWorker.ts
@@ -1,3 +1,9 @@
 /// <reference lib="webworker" />
 
-importScripts('vendor/trezor-connect-webextension.js');
+import TrezorConnect, { DEVICE_EVENT } from '@trezor/connect-webextension';
+
+// Example use of TrezorConnect
+// Without this, the import would be removed by Webpack tree-shaking
+TrezorConnect.on(DEVICE_EVENT, (event: any) => {
+    console.log('DEVICE_EVENT', event);
+});

--- a/packages/connect-explorer/src-webextension/manifest.json
+++ b/packages/connect-explorer/src-webextension/manifest.json
@@ -6,7 +6,8 @@
         "default_popup": "extension-popup.html"
     },
     "background": {
-        "service_worker": "serviceWorker.bundle.js"
+        "service_worker": "serviceWorker.bundle.js",
+        "type": "module"
     },
     "permissions": ["scripting"],
     "host_permissions": ["http://*/*", "https://*/*"]

--- a/packages/connect-explorer/webpack/webextension.webpack.config.ts
+++ b/packages/connect-explorer/webpack/webextension.webpack.config.ts
@@ -36,10 +36,14 @@ const config: webpack.Configuration = {
             'serviceWorker.ts',
         ),
     },
+    experiments: {
+        outputModule: true,
+    },
     output: {
         filename: '[name].bundle.js',
         path: DIST,
         publicPath: './',
+        module: true,
     },
     module: {
         rules: [
@@ -60,7 +64,6 @@ const config: webpack.Configuration = {
                             '@babel/preset-typescript',
                         ],
                         plugins: [
-                            '@babel/plugin-proposal-class-properties',
                             [
                                 'babel-plugin-styled-components',
                                 {
@@ -133,6 +136,10 @@ const config: webpack.Configuration = {
             ],
         }),
     ],
+    optimization: {
+        minimize: false,
+        minimizer: [],
+    },
 };
 
 export default config;

--- a/packages/connect-webextension/README.md
+++ b/packages/connect-webextension/README.md
@@ -13,11 +13,11 @@ The @trezor/connect-webextension package provides an implementation of @trezor/c
 
 ## Using the Library
 
-At the moment only bundles `build/trezor-connect-webextension.js` and `build/trezor-connect-webextension.min.js` are published.
+We support two methods for integrating the library into your extension:
 
 ### Option 1: Using Scripting Permissions
 
-For a seamless integration, especially with background processes, modify your extension's manifest.json to include scripting permissions, specify host_permissions, and define your service worker script as shown below:
+For a seamless integration, especially with background processes, modify your extension's `manifest.json` to include scripting permissions, specify `host_permissions`, and define your service worker script as shown below:
 
 ```json
     "permissions": ["scripting"],
@@ -27,23 +27,37 @@ For a seamless integration, especially with background processes, modify your ex
     },
 ```
 
+The content script will be injected automatically by the library using the scripting permission.
+
 #### Service Worker Import:
 
-In your serviceWorker.js, use importScripts to import the library. Ensure you replace <path> with the actual path to the library file:
+In your `serviceWorker.js`, use importScripts to import the library. Ensure you replace `<path>` with the actual path to the library file:
 
 ```javascript
 importScripts('<path>/trezor-connect-webextension.js');
 ```
 
+Or if you're using ES modules:
+
+```javascript
+import TrezorConnect from '@trezor/connect-webextension';
+```
+
+The library is only available in the service worker context, so to use it in your extension's UI, you need to communicate with the service worker. This mechanism is not provided by the library, this depends on your extension's architecture.
+Also it should be noted that the service worker may be idle when the extension is not in use, so you should implement a mechanism to keep it alive or wake it up when needed.
+
 ### Option 2: Manual Content Script Injection
+
+In cases where you cannot use scripting permissions, you can configure your extension to include the content script directly.
 
 #### Bundle the Library:
 
-Manually include build/content-script.js from this package into your project's bundle.
+Manually include `build/content-script.js` from this package into your project's bundle.
+Ideally, you should do this with a build tool like Webpack, so it can be easily maintained.
 
 #### manifest.json Update:
 
-Amend your manifest.json to include the script as a content script. Replace <path> with the real path to the library file:
+Amend your manifest.json to include the script as a content script. Replace `<path>` with the real path to the library file:
 
 ```json
   "content_scripts": [
@@ -53,6 +67,8 @@ Amend your manifest.json to include the script as a content script. Replace <pat
     }
   ],
 ```
+
+After completing these steps, you can use the module in your Service Worker in the same way as described in the previous section.
 
 ## Adding your webextension to `knownHosts`
 

--- a/packages/connect-webextension/package.json
+++ b/packages/connect-webextension/package.json
@@ -20,10 +20,8 @@
         "serviceworker",
         "webextension"
     ],
-    "main": "src/index.ts",
-    "publishConfig": {
-        "main": "lib/index.js"
-    },
+    "main": "build/trezor-connect-webextension.js",
+    "types": "src/index.ts",
     "files": [
         "build/trezor-connect-webextension.js",
         "build/trezor-connect-webextension.min.js",
@@ -35,8 +33,7 @@
         "build:lib": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/replace-imports.sh ./lib",
         "build:content-script": "TS_NODE_PROJECT=\"tsconfig.lib.json\" webpack --config ./webpack/content-script.webpack.config.ts",
         "build:inline": "TS_NODE_PROJECT=\"tsconfig.lib.json\" webpack --config ./webpack/inline.webpack.config.ts",
-        "build:webextension": "TS_NODE_PROJECT=\"tsconfig.lib.json\" yarn webpack --config ./webpack/prod.webpack.config.ts",
-        "build": "yarn g:rimraf build && yarn build:content-script &&  yarn build:webextension && yarn build:inline && node ./webpack/inline-content-script.js",
+        "build": "yarn g:rimraf build && yarn build:content-script && yarn build:inline && node ./webpack/inline-content-script.js",
         "prepublish": "yarn build"
     },
     "dependencies": {

--- a/packages/connect-webextension/webpack/inline.webpack.config.ts
+++ b/packages/connect-webextension/webpack/inline.webpack.config.ts
@@ -12,7 +12,9 @@ const config: webpack.Configuration = {
     mode: 'production',
     entry: {
         'trezor-connect-webextension': path.resolve(__dirname, '../src/index.ts'),
+        // minified version doesn't include the inline content script
         'trezor-connect-webextension.min': path.resolve(__dirname, '../src/index.ts'),
+        // proxy is not published on npm
         'trezor-connect-webextension-proxy': path.resolve(__dirname, '../src/proxy/index.ts'),
         'trezor-connect-webextension-proxy.min': path.resolve(__dirname, '../src/proxy/index.ts'),
     },


### PR DESCRIPTION
## Description

Use bundled build as package main. 
This is because only the bundle has inlined content-script.

Also update `connect-webextension` to use ES Modules to test this change. 

## Related Issue

Related to #12731