### PR TITLE
Send default signature values

### DIFF
--- a/packages/coinjoin/src/client/round/transactionSigning.ts
+++ b/packages/coinjoin/src/client/round/transactionSigning.ts
@@ -88,7 +88,13 @@ const getTransactionData = (
         outputs,
         affiliateRequest: {
             ...getRoundParams(round.roundParameters),
-            ...(options.affiliationId ? getAffiliateRequest(round.affiliateRequest) : {}),
+            ...(options.affiliationId
+                ? getAffiliateRequest(round.affiliateRequest)
+                : {
+                      mask_public_key: '',
+                      signature: '',
+                      coinjoin_flags_array: [],
+                  }),
         },
     };
 };

--- a/packages/coinjoin/src/types/coordinator.ts
+++ b/packages/coinjoin/src/types/coordinator.ts
@@ -172,7 +172,7 @@ interface CoinjoinAffiliateFields {
     signature: string;
 }
 
-export interface CoinjoinAffiliateRequest extends Partial<CoinjoinAffiliateFields> {
+export interface CoinjoinAffiliateRequest extends CoinjoinAffiliateFields {
     fee_rate: number;
     no_fee_threshold: number;
     min_registrable_amount: number;

--- a/packages/suite/src/actions/wallet/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinClientActions.ts
@@ -646,7 +646,6 @@ const signCoinjoinTx =
                             useEmptyPassphrase: device?.useEmptyPassphrase,
                             inputs: tx.inputs,
                             outputs: tx.outputs,
-                            // @ts-expect-error wait for fw protobuf update
                             coinjoinRequest: tx.coinjoinRequest,
                             coin: network,
                             preauthorized: true,


### PR DESCRIPTION
## Description

`mask_public_key` and `signature` default to empty strings in case of no affil id.