### PR TITLE
fix(connect): preserve DEVICE.ACQUIRED listeners after unsuccessful workflow

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -244,10 +244,14 @@ export class Device extends TypedEmitter<DeviceEvents> {
     }
 
     async cleanup() {
+        // remove all listeners **except** DEVICE.ACQUIRED - waiting for acquired Device in DeviceList
+        const acquiredListeners = this.listeners(DEVICE.ACQUIRED);
         this.removeAllListeners();
         // make sure that Device_CallInProgress will not be thrown
         delete this.runPromise;
         await this.release();
+        // restore DEVICE.ACQUIRED listeners
+        acquiredListeners.forEach(l => this.once(DEVICE.ACQUIRED, l));
     }
 
     run(fn?: () => Promise<void>, options?: RunOptions) {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Currently unacquired => acquired works only if first attempt is successful, otherwise all listeners are removed and DEVICE.ACQUIRED is never fired again