### PR TITLE
fix(transport-bridge): pass type to listen,stable stringify comparison

### DIFF
--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -281,6 +281,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> {
                             session: d.session,
                             path: d.path,
                             product: d.product,
+                            type: d.type,
                         };
                     }
                 });
@@ -433,6 +434,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> {
                     session: d.session,
                     path: d.path,
                     product: d.product,
+                    type: d.type,
                 };
                 this.devices[d.path].activitySessionID = d.session;
             }

--- a/packages/transport-bridge/package.json
+++ b/packages/transport-bridge/package.json
@@ -20,6 +20,7 @@
         "build:lib": "yarn build:js"
     },
     "devDependencies": {
+        "@types/json-stable-stringify": "^1",
         "esbuild": "^0.20.0",
         "html-webpack-plugin": "^5.6.0",
         "pkg": "^5.8.1",
@@ -32,6 +33,7 @@
         "@trezor/theme": "workspace:*",
         "@trezor/transport": "workspace:*",
         "@trezor/utils": "workspace:*",
+        "json-stable-stringify": "^1.1.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-intl": "^6.6.2",

--- a/packages/transport-bridge/src/http.ts
+++ b/packages/transport-bridge/src/http.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import url from 'url';
+import stringify from 'json-stable-stringify';
 
 import {
     HttpServer,
@@ -73,7 +74,7 @@ export class TrezordNode {
         }
 
         const [affected, unaffected] = arrayPartition(this.listenSubscriptions, subscription => {
-            return JSON.stringify(subscription.descriptors) !== JSON.stringify(this.descriptors);
+            return stringify(subscription.descriptors) !== stringify(this.descriptors);
         });
 
         this.logger?.debug(

--- a/packages/transport/src/types/index.ts
+++ b/packages/transport/src/types/index.ts
@@ -7,7 +7,7 @@ export type Session = `${number}`;
 export type DescriptorApiLevel = {
     path: string;
     /** only used in status page */
-    type?: DEVICE_TYPE;
+    type: DEVICE_TYPE;
     /** only important for T1 over old bridge (trezord-go), defacto part of 'path'. More explanation in https://github.com/trezor/trezor-suite/compare/transport-descriptor-product */
     product?: number;
 };

--- a/packages/transport/src/utils/bridgeApiResult.ts
+++ b/packages/transport/src/utils/bridgeApiResult.ts
@@ -57,6 +57,7 @@ export function devices(res: UnknownPayload) {
                 path: o.path,
                 session: o.session,
                 product: o.product,
+                type: o.type,
                 // @ts-expect-error - this is part of response too, might add it to type later
                 vendor: o.vendor,
                 debug: o.debug,

--- a/packages/transport/tests/abstractUsb.test.ts
+++ b/packages/transport/tests/abstractUsb.test.ts
@@ -193,19 +193,19 @@ describe('Usb', () => {
             const spy = jest.fn();
             transport.on('transport-update', spy);
 
-            transport.handleDescriptorsChange([{ path: '1', session: null }]);
+            transport.handleDescriptorsChange([{ path: '1', session: null, type: 1 }]);
 
             expect(spy).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    connected: [{ path: '1', session: null }],
+                    connected: [{ path: '1', session: null, type: 1 }],
                     didUpdate: true,
-                    descriptors: [{ path: '1', session: null }],
+                    descriptors: [{ path: '1', session: null, type: 1 }],
                 }),
             );
             transport.handleDescriptorsChange([]);
             expect(spy).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    disconnected: [{ path: '1', session: null }],
+                    disconnected: [{ path: '1', session: null, type: 1 }],
                     didUpdate: true,
                     descriptors: [],
                 }),
@@ -275,7 +275,7 @@ describe('Usb', () => {
             const acquireCall = transport.acquire({ input: { path: '123', previous: null } });
 
             setTimeout(() => {
-                sessionsClient.emit('descriptors', [{ path: '321', session: '1' }]);
+                sessionsClient.emit('descriptors', [{ path: '321', session: '1', type: 1 }]);
             }, 1);
 
             const res = await acquireCall.promise;
@@ -301,7 +301,7 @@ describe('Usb', () => {
             // set some initial descriptors
             const acquireCall = transport.acquire({ input: { path: '123', previous: null } });
             setTimeout(() => {
-                sessionsClient.emit('descriptors', [{ path: '123', session: '2' }]);
+                sessionsClient.emit('descriptors', [{ path: '123', session: '2', type: 1 }]);
             }, 1);
 
             const res = await acquireCall.promise;

--- a/packages/transport/tests/sessions.test.ts
+++ b/packages/transport/tests/sessions.test.ts
@@ -86,7 +86,7 @@ describe('sessions', () => {
         const client1 = new SessionsClient({ requestFn });
         await client1.handshake();
 
-        await client1.enumerateDone({ descriptors: [{ path: '1' }] });
+        await client1.enumerateDone({ descriptors: [{ path: '1', type: 1 }] });
 
         const acquireIntent = await client1.acquireIntent({ path: '1', previous: null });
 
@@ -99,6 +99,7 @@ describe('sessions', () => {
                     {
                         path: '1',
                         session: '1',
+                        type: 1,
                     },
                 ],
             },
@@ -112,6 +113,7 @@ describe('sessions', () => {
                     {
                         path: '1',
                         session: '1',
+                        type: 1,
                     },
                 ],
             },
@@ -124,7 +126,7 @@ describe('sessions', () => {
         const client1 = new SessionsClient({ requestFn });
         await client1.handshake();
 
-        await client1.enumerateDone({ descriptors: [{ path: '1' }] });
+        await client1.enumerateDone({ descriptors: [{ path: '1', type: 1 }] });
 
         const acquire1 = await client1.acquireIntent({
             path: '1',
@@ -181,7 +183,7 @@ describe('sessions', () => {
         const client1 = new SessionsClient({ requestFn });
         await client1.handshake();
 
-        await client1.enumerateDone({ descriptors: [{ path: '1' }] });
+        await client1.enumerateDone({ descriptors: [{ path: '1', type: 1 }] });
 
         const acquire1Intent = await client1.acquireIntent({ path: '1', previous: null });
         expect(acquire1Intent).toMatchObject({

--- a/yarn.lock
+++ b/yarn.lock
@@ -11399,8 +11399,10 @@ __metadata:
     "@trezor/theme": "workspace:*"
     "@trezor/transport": "workspace:*"
     "@trezor/utils": "workspace:*"
+    "@types/json-stable-stringify": "npm:^1"
     esbuild: "npm:^0.20.0"
     html-webpack-plugin: "npm:^5.6.0"
+    json-stable-stringify: "npm:^1.1.1"
     pkg: "npm:^5.8.1"
     react: "npm:18.2.0"
     react-dom: "npm:18.2.0"
@@ -12299,6 +12301,13 @@ __metadata:
   version: 7.0.14
   resolution: "@types/json-schema@npm:7.0.14"
   checksum: 10/84b5efed51984c077f9cb7c5a3dcb8d8288ce1ae8825952b173c3506a0cfc90bc961d7f2a8847c440310d02bbd570cf918ac463d8310b0c9dce2252baa1ba4e0
+  languageName: node
+  linkType: hard
+
+"@types/json-stable-stringify@npm:^1":
+  version: 1.0.36
+  resolution: "@types/json-stable-stringify@npm:1.0.36"
+  checksum: 10/765b07589e11a3896c3d06bb9e3a9be681e7edd95adf27370df0647a91bd2bfcfaf0e091fd4a13729343b388973f73f7e789d6cc62ab988240518a2d27c4a4e2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

the new lib - we already had it long tie ago https://github.com/trezor/trezor-link/blob/master/src/lowlevel/withSharedConnections.ts#L14 and it served the very sume purpose that I am adding it now for. Previously, webusb ran neverending enumeration cycle and only not so long ago (1year maybe) we switched to events. 


Subscriptions for legacy vs node are slightly different. 

Legacy bridge

![image](https://github.com/trezor/trezor-suite/assets/30367552/9fc92aa6-66da-4370-8f38-116942ab8872)
![image](https://github.com/trezor/trezor-suite/assets/30367552/14f7bd2b-09b5-432c-bd55-74125c49e01d)


Node Bridge

![image](https://github.com/trezor/trezor-suite/assets/30367552/3e3e9fd1-a7e0-4a6d-b8fc-5bb0c31d0023)
![image](https://github.com/trezor/trezor-suite/assets/30367552/8c1369d5-2eb5-470d-8b95-da69ac9b9e95)
