### PR TITLE
fix(suite): send form AmountInput labelLeft `<p>` => `<div>`

### DIFF
--- a/packages/suite/__mocks__/usb.js
+++ b/packages/suite/__mocks__/usb.js
@@ -1,0 +1,6 @@
+// mock 'usb' package
+
+module.exports = {
+    __esModule: true,
+    WebUSB: () => {},
+};

--- a/packages/suite/src/hooks/wallet/__tests__/useSendForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useSendForm.test.tsx
@@ -27,6 +27,9 @@ global.ResizeObserver = class MockedResizeObserver {
     disconnect = jest.fn();
 };
 
+// used by `framer-motion` module
+global.scrollTo = jest.fn();
+
 // sendFormActions.signTransaction fetch ethereum definitions
 jest.mock('cross-fetch', () => ({
     __esModule: true,

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/index.tsx
@@ -45,7 +45,7 @@ const Row = styled.div`
     }
 `;
 
-const Heading = styled.p`
+const Heading = styled.div`
     display: flex;
     flex-direction: column;
     white-space: nowrap;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixing 3 errors reported by `useSendForm` unit test, also reported here #9236


1. add mock `global.scrollTo`
```
console.error
      Error: Not implemented: window.scrollTo
          at module.exports (/suite/node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/browser/not-implemented.js:9:17)
          at /suite/node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/browser/Window.js:870:7
          at checkAndConvertChangedValueTypes (/suite/node_modules/framer-motion/dist/cjs/index-legacy-18f65389.js:3911:20)
          .....
          at Object.animateTarget (/suite/node_modules/framer-motion/dist/cjs/index-legacy-18f65389.js:3202:105)
```

2. fix html tag to div in AmountInput labelLeft.
cc @tomasklim is this ok?


```
console.error
      Warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>.
          at div
          at displayName (/suite/node_modules/styled-components/src/models/StyledComponent.ts:266:26)
          at p
          at displayName (/suite/node_modules/styled-components/src/models/StyledComponent.ts:266:26)
          ....
          at output (/suite/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/index.tsx:106:26)
```

3. add global mock for `usb` module, prevent from memory leak mentioned in #9236
i believe this also speed up the tests a little bit from `66.777 s` to `54.219 s` on my machine
