### PR TITLE
chore(connect-webextension): stop publishing proxy

### DIFF
--- a/packages/connect-webextension/package.json
+++ b/packages/connect-webextension/package.json
@@ -28,7 +28,8 @@
         "build/trezor-connect-webextension.js",
         "build/trezor-connect-webextension.min.js",
         "build/content-script.js",
-        "lib/"
+        "lib/",
+        "!lib/proxy"
     ],
     "scripts": {
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Stop publishing connect-webextension proxy that was initially created only for internal use in order to be able to support connect-explorer with webextension so we can use it to run popup tests with webextension package.

This proxy to allow communication between foreground (UI) of the webextension and service worker is out of the scope of TrezorConnect and each implementer should handle it by themself.

This will require a minor release not just patch since it changes the files we publish. Along with https://github.com/trezor/trezor-suite/pull/12761

## Related Issue

Related https://github.com/trezor/trezor-suite/issues/12731