### PR TITLE
fix(suite-desktop): nixos-fix-binaries use copy of `7za`

### DIFF
--- a/nixos-fix-binaries.sh
+++ b/nixos-fix-binaries.sh
@@ -7,9 +7,9 @@ if [ -f /etc/NIXOS ] ; then
     exit 1
   fi
 
-  # replace bundled binaries in node_modules with symlinks
-
-  ln -sf "$(which 7za)" "$CURDIR"/node_modules/7zip-bin/linux/x64/7za || :
+  # replace bundled binaries in node_modules
+  # electron-builder is trying to call chmod on the 7za binary
+  cp -rf "$(which 7za)" "$CURDIR"/node_modules/7zip-bin/linux/x64/7za || :
 
   # replace bundled binaries in .cache/electron-builder with symlinks
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`yarn workspace @trezor/suite-desktop build:linux` throws error:

```
• packaging       platform=linux arch=x64 electron=27.3.8 appOutDir=build-electron/linux-unpacked
 ⨯ EROFS: read-only file system, chmod '/Workspace/suite/node_modules/7zip-bin/linux/x64/7za'  failedTask=build stackTrace=Error: EROFS: read-only file system, chmod '/Workspace/suite/node_modules/7zip-bin/linux/x64/7za'
```

because electron-builder is trying to call `chmod` on the `7za` binary which is a symlink. use copy of `7za` instead
