### PR TITLE
ci(github): remove output from step in npm workflow

### DIFF
--- a/.github/workflows/release-connect-npm.yml
+++ b/.github/workflows/release-connect-npm.yml
@@ -59,8 +59,6 @@ jobs:
 
       - name: Determine Deployment Type from version in branch
         id: determine-deployment-type
-        outputs:
-          deploymentType: ${{ steps.determine-deployment-type.outputs.deploymentType }}
         run: echo "deploymentType=$(yarn tsx ./ci/scripts/determine-deployment-type.ts ${{ needs.extract-version.outputs.version }})" >> $GITHUB_OUTPUT
 
       - name: Sanity Check - All Packages Same Deployment Type


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Outputs form step should not be defined in the step but at the level of the job.