### PR TITLE
Move ReconnectDevicePrompt to FirmwareInstallation

### DIFF
--- a/packages/suite/src/components/firmware/FirmwareInstallation.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInstallation.tsx
@@ -3,7 +3,7 @@ import { UI } from '@trezor/connect';
 
 import { Translation, WebUsbButton } from 'src/components/suite';
 import { useFirmware } from 'src/hooks/suite';
-import { FirmwareOffer, FirmwareProgressBar } from 'src/components/firmware';
+import { FirmwareOffer, FirmwareProgressBar, ReconnectDevicePrompt } from 'src/components/firmware';
 import { OnboardingStepBox } from 'src/components/onboarding';
 import { TrezorDevice } from 'src/types/suite';
 import { selectIsActionAbortable } from 'src/reducers/suite/suiteReducer';
@@ -16,15 +16,19 @@ interface FirmwareInstallationProps {
     standaloneFwUpdate?: boolean;
     // If true, information about new version is not shown, because we don't know anything about it
     customFirmware?: boolean;
+    install: () => void;
+    onPromptClose?: () => void;
     onSuccess: () => void;
 }
 
 export const FirmwareInstallation = ({
     standaloneFwUpdate,
     customFirmware,
+    install,
+    onPromptClose,
     onSuccess,
 }: FirmwareInstallationProps) => {
-    const { status, isWebUSB, uiEvent } = useFirmware();
+    const { status, isWebUSB, showReconnectPrompt, uiEvent } = useFirmware();
     const isActionAbortable = useSelector(selectIsActionAbortable);
 
     const getInnerActionComponent = () => {
@@ -52,6 +56,9 @@ export const FirmwareInstallation = ({
 
     return (
         <>
+            {showReconnectPrompt && (
+                <ReconnectDevicePrompt onClose={onPromptClose} onSuccess={install} />
+            )}
             <OnboardingStepBox
                 image="FIRMWARE"
                 heading={<Translation id="TR_INSTALL_FIRMWARE" />}

--- a/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
+++ b/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
@@ -161,7 +161,7 @@ const RebootDeviceGraphics = ({
 };
 
 interface ReconnectDevicePromptProps {
-    onClose: () => void;
+    onClose?: () => void;
     onSuccess: () => void;
 }
 
@@ -195,7 +195,8 @@ export const ReconnectDevicePrompt = ({ onClose, onSuccess }: ReconnectDevicePro
     const rebootPhase = getRebootPhase();
     const isRebootDone = rebootPhase === 'done';
     const deviceModelInternal = device?.features?.internal_model;
-    const isAbortable = isManualRebootRequired && rebootPhase == 'waiting-for-reboot';
+    const isAbortable =
+        onClose !== undefined && isManualRebootRequired && rebootPhase == 'waiting-for-reboot';
     const showWebUsbButton = rebootPhase === 'disconnected' && isWebUSB;
 
     const toNormal =

--- a/packages/suite/src/views/firmware/FirmwareModal.tsx
+++ b/packages/suite/src/views/firmware/FirmwareModal.tsx
@@ -5,12 +5,7 @@ import { acquireDevice, selectDevice } from '@suite-common/wallet-core';
 import { ConfirmOnDevice, variables } from '@trezor/components';
 
 import { closeModalApp } from 'src/actions/suite/routerActions';
-import {
-    CheckSeedStep,
-    FirmwareCloseButton,
-    FirmwareInstallation,
-    ReconnectDevicePrompt,
-} from 'src/components/firmware';
+import { CheckSeedStep, FirmwareCloseButton, FirmwareInstallation } from 'src/components/firmware';
 import { Translation, Modal } from 'src/components/suite';
 import { ConnectDevicePromptManager, OnboardingStepBox } from 'src/components/onboarding';
 import { useDispatch, useFirmware, useSelector } from 'src/hooks/suite';
@@ -57,7 +52,6 @@ export const FirmwareModal = ({
         firmwareHashInvalid,
         uiEvent,
         confirmOnDevice,
-        showReconnectPrompt,
         showConfirmationPill,
     } = useFirmware();
     const device = useSelector(selectDevice);
@@ -121,7 +115,9 @@ export const FirmwareModal = ({
                 return (
                     <FirmwareInstallation
                         standaloneFwUpdate
+                        install={install}
                         onSuccess={onClose}
+                        onPromptClose={onClose}
                         customFirmware={isCustom}
                     />
                 );
@@ -145,7 +141,6 @@ export const FirmwareModal = ({
             data-test="@firmware-modal"
             heading={<Translation id={heading} />}
         >
-            {showReconnectPrompt && <ReconnectDevicePrompt onClose={onClose} onSuccess={install} />}
             <Wrapper $isWithTopPadding={!isCancelable}>{getComponent()}</Wrapper>
         </StyledModal>
     );

--- a/packages/suite/src/views/onboarding/steps/FirmwareStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/FirmwareStep.tsx
@@ -30,6 +30,7 @@ export const FirmwareStep = () => {
         targetType,
     } = useFirmware();
 
+    const install = () => firmwareUpdate({ firmwareType: targetType });
     const goToNextStepAndResetReducer = () => {
         goToNextStep();
         resetReducer();
@@ -66,11 +67,7 @@ export const FirmwareStep = () => {
                 image="FIRMWARE"
                 heading={<Translation id="TR_FW_INSTALLATION_FAILED" />}
                 description={<Translation id="TOAST_GENERIC_ERROR" values={{ error }} />}
-                innerActions={
-                    <FirmwareRetryButton
-                        onClick={() => firmwareUpdate({ firmwareType: targetType })}
-                    />
-                }
+                innerActions={<FirmwareRetryButton onClick={install} />}
                 outerActions={<OnboardingButtonBack onClick={() => resetReducer()} />}
             />
         );
@@ -125,7 +122,9 @@ export const FirmwareStep = () => {
             return <FirmwareInitial />;
         case 'started': // called from firmwareUpdate()
         case 'done':
-            return <FirmwareInstallation onSuccess={goToNextStepAndResetReducer} />;
+            return (
+                <FirmwareInstallation install={install} onSuccess={goToNextStepAndResetReducer} />
+            );
         default:
             // 'ensure' type completeness
             throw new Error(`state "${status}" is not handled here`);


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
I created this bug in https://github.com/trezor/trezor-suite/pull/11300 by omitting `ReconnectDevicePrompt` from `FirmwareInitial`. The idea to have it in one place was good, but it must be in a component shared between Settings and Onboarding so that it can be displayed in both flows.

`ReconnectDevicePrompt` was missing in onboarding, so user didn't know they had to reconnect their device to upgrade FW.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/12528

## Screenshots:
![Screenshot 2024-06-10 at 14 48 39](https://github.com/trezor/trezor-suite/assets/42465546/a5b197c1-8056-4856-9743-1c9cacd27c46)
