### PR TITLE
Fix/missing fiat rates for txs

### DIFF
--- a/packages/suite/src/actions/suite/__tests__/initAction.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/initAction.test.ts
@@ -16,6 +16,7 @@ import {
     preloadFeeInfoThunk,
     initStakeDataThunk,
     periodicCheckStakeDataThunk,
+    updateMissingTxFiatRatesThunk,
 } from '@suite-common/wallet-core';
 import { analyticsActions, prepareAnalyticsReducer } from '@suite-common/analytics';
 import TrezorConnect from '@trezor/connect';
@@ -116,6 +117,8 @@ const fixtures: Fixture[] = [
             fetchFiatRatesThunk.pending.type,
             fetchFiatRatesThunk.fulfilled.type,
             periodicFetchFiatRatesThunk.fulfilled.type,
+            updateMissingTxFiatRatesThunk.pending.type,
+            updateMissingTxFiatRatesThunk.fulfilled.type,
             periodicCheckStakeDataThunk.pending.type,
             initStakeDataThunk.pending.type,
             SUITE.READY,
@@ -158,6 +161,8 @@ const fixtures: Fixture[] = [
             fetchFiatRatesThunk.pending.type,
             fetchFiatRatesThunk.fulfilled.type,
             periodicFetchFiatRatesThunk.fulfilled.type,
+            updateMissingTxFiatRatesThunk.pending.type,
+            updateMissingTxFiatRatesThunk.fulfilled.type,
             appChanged.type,
             ROUTER.LOCATION_CHANGE,
             periodicCheckStakeDataThunk.pending.type,
@@ -201,6 +206,8 @@ const fixtures: Fixture[] = [
             fetchFiatRatesThunk.pending.type,
             fetchFiatRatesThunk.fulfilled.type,
             periodicFetchFiatRatesThunk.fulfilled.type,
+            updateMissingTxFiatRatesThunk.pending.type,
+            updateMissingTxFiatRatesThunk.fulfilled.type,
             ROUTER.LOCATION_CHANGE,
             periodicCheckStakeDataThunk.pending.type,
             initStakeDataThunk.pending.type,

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesReducer.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesReducer.ts
@@ -86,7 +86,7 @@ export const prepareFiatRatesReducer = createReducerWithExtraDeps(
             .addCase(updateTxsFiatRatesThunk.fulfilled, (state, action) => {
                 if (!action.payload) return;
 
-                action.payload.forEach(fiatRate => {
+                action.payload.rates.forEach(fiatRate => {
                     const { tickerId, rates } = fiatRate;
                     const { localCurrency } = action.meta.arg;
                     const fiatRateKey = getFiatRateKeyFromTicker(tickerId, localCurrency);

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
@@ -32,7 +32,7 @@ type UpdateTxsFiatRatesThunkPayload = {
 export const updateTxsFiatRatesThunk = createThunk(
     `${FIAT_RATES_MODULE_PREFIX}/updateTxsRates`,
     async ({ account, txs, localCurrency }: UpdateTxsFiatRatesThunkPayload, { getState }) => {
-        if (txs?.length === 0 || isTestnet(account.symbol)) return;
+        if (txs?.length === 0 || isTestnet(account.symbol)) return { account, rates: [] };
 
         const isElectrumBackend = selectIsElectrumBackendSelected(getState(), account.symbol);
 
@@ -81,7 +81,7 @@ export const updateTxsFiatRatesThunk = createThunk(
             );
         }
 
-        return rates;
+        return { account, rates };
     },
 );
 


### PR DESCRIPTION
## Description

This should fix the problem with fiat rates not loading into a remembered wallet that was already remembered in an older version of Suite.

## Related Issue

Resolve #12762