### PR TITLE
fix(connect-common): firmware release url

### DIFF
--- a/docker/docker-compose.connect-popup-ci.yml
+++ b/docker/docker-compose.connect-popup-ci.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env
+    image: ghcr.io/trezor/trezor-user-env:c702cbb2f67ccb39573e529721cb8f1145cdd891
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.connect-popup-test.yml
+++ b/docker/docker-compose.connect-popup-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env
+    image: ghcr.io/trezor/trezor-user-env:c702cbb2f67ccb39573e529721cb8f1145cdd891
     environment:
       - DISPLAY=$DISPLAY
       - QT_X11_NO_MITSHM=1

--- a/docker/docker-compose.connect-test.yml
+++ b/docker/docker-compose.connect-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env
+    image: ghcr.io/trezor/trezor-user-env:c702cbb2f67ccb39573e529721cb8f1145cdd891
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.connect-webextension-test.yml
+++ b/docker/docker-compose.connect-webextension-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env
+    image: ghcr.io/trezor/trezor-user-env:c702cbb2f67ccb39573e529721cb8f1145cdd891
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-ci.yml
+++ b/docker/docker-compose.suite-ci.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env
+    image: ghcr.io/trezor/trezor-user-env:c702cbb2f67ccb39573e529721cb8f1145cdd891
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-desktop-ci.yml
+++ b/docker/docker-compose.suite-desktop-ci.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env
+    image: ghcr.io/trezor/trezor-user-env:c702cbb2f67ccb39573e529721cb8f1145cdd891
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-desktop-test.yml
+++ b/docker/docker-compose.suite-desktop-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env
+    image: ghcr.io/trezor/trezor-user-env:c702cbb2f67ccb39573e529721cb8f1145cdd891
     environment:
       - DISPLAY=$DISPLAY
     volumes:

--- a/docker/docker-compose.suite-dev.yml
+++ b/docker/docker-compose.suite-dev.yml
@@ -4,7 +4,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env
+    image: ghcr.io/trezor/trezor-user-env:c702cbb2f67ccb39573e529721cb8f1145cdd891
     environment:
       - DISPLAY=$DISPLAY
       - QT_X11_NO_MITSHM=1

--- a/docker/docker-compose.suite-native-ci.yml
+++ b/docker/docker-compose.suite-native-ci.yml
@@ -3,7 +3,7 @@ services:
   trezor-user-env-unix:
     network_mode: "host"
     container_name: trezor-user-env.unix
-    image: ghcr.io/trezor/trezor-user-env
+    image: ghcr.io/trezor/trezor-user-env:c702cbb2f67ccb39573e529721cb8f1145cdd891
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-test.yml
+++ b/docker/docker-compose.suite-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env
+    image: ghcr.io/trezor/trezor-user-env:c702cbb2f67ccb39573e529721cb8f1145cdd891
     environment:
       - DISPLAY=$DISPLAY
       - QT_X11_NO_MITSHM=1

--- a/docker/docker-compose.transport-test.yml
+++ b/docker/docker-compose.transport-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env
+    image: ghcr.io/trezor/trezor-user-env:c702cbb2f67ccb39573e529721cb8f1145cdd891
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/packages/connect-common/files/firmware/t2b1/releases.json
+++ b/packages/connect-common/files/firmware/t2b1/releases.json
@@ -6,8 +6,8 @@
         "min_bootloader_version": [2, 1, 1],
         "bootloader_version": [2, 1, 4],
         "translations": ["cs-CZ", "de-DE", "es-ES", "fr-FR"],
-        "url": "data/firmware/t2b1/trezor-t2b1-2.7.2.bin",
-        "url_bitcoinonly": "data/firmware/t2b1/trezor-t2b1-2.7.2-bitcoinonly.bin",
+        "url": "firmware/t2b1/trezor-t2b1-2.7.2.bin",
+        "url_bitcoinonly": "firmware/t2b1/trezor-t2b1-2.7.2-bitcoinonly.bin",
         "fingerprint": "d072560f34782faf5537aa08a48c4e24671d4c60e9c291a00bfbf12cbc425666",
         "fingerprint_bitcoinonly": "5b6e312430de9db6ad3a843e1ba311f8cff9c6a691c20c0e69b711451a729f40",
         "changelog": "* Multi-share backups can now have any number of shares. \n* Add support for repeated backups. \n* Add support for Cardano Conway certificates [Universal fw only]."

--- a/packages/connect-common/files/firmware/t2t1/releases.json
+++ b/packages/connect-common/files/firmware/t2t1/releases.json
@@ -6,8 +6,8 @@
         "min_bootloader_version": [2, 0, 0],
         "bootloader_version": [2, 1, 4],
         "translations": ["cs-CZ", "de-DE", "es-ES", "fr-FR"],
-        "url": "data/firmware/t2t1/trezor-t2t1-2.7.2.bin",
-        "url_bitcoinonly": "data/firmware/t2t1/trezor-t2t1-2.7.2-bitcoinonly.bin",
+        "url": "firmware/t2t1/trezor-t2t1-2.7.2.bin",
+        "url_bitcoinonly": "firmware/t2t1/trezor-t2t1-2.7.2-bitcoinonly.bin",
         "fingerprint": "d64fcf47a8ead6edf0329583e312136d1548d30990c29cfaa2ce7c67197babcc",
         "fingerprint_bitcoinonly": "cba515383705ec6420c54dd1ffdb33ea7ce4bb04bc6d992c2923880daa53d3e1",
         "changelog": "* Add display brightness setting. \n* Multi-share backups can now have any number of shares. \n* Add support for repeated backups. \n* Add support for Cardano Conway certificates [Universal fw only]."

--- a/packages/connect-common/files/firmware/t3t1/releases.json
+++ b/packages/connect-common/files/firmware/t3t1/releases.json
@@ -6,8 +6,8 @@
         "min_bootloader_version": [2, 1, 6],
         "bootloader_version": [2, 1, 6],
         "translations": ["cs-CZ", "de-DE", "es-ES", "fr-FR"],
-        "url": "data/firmware/t3t1/trezor-t3t1-2.7.2.bin",
-        "url_bitcoinonly": "data/firmware/t3t1/trezor-t3t1-2.7.2-bitcoinonly.bin",
+        "url": "firmware/t3t1/trezor-t3t1-2.7.2.bin",
+        "url_bitcoinonly": "firmware/t3t1/trezor-t3t1-2.7.2-bitcoinonly.bin",
         "fingerprint": "4daa5fd3c4c92ee0d76855997dde09a7ee25f4165b118c521ab10957c5fc92b0",
         "fingerprint_bitcoinonly": "246cca86b0a8cfcac6b7e6b3fcf55f543a8a9c9fd1f8ff88cd0de00640cb25eb",
         "changelog": "* Add display brightness setting. \n* Multi-share backups can now have any number of shares. \n* Add support for repeated backups. \n* Add support for Cardano Conway certificates [Universal fw only]."


### PR DESCRIPTION
## Description

Remove extra `data/` from firmware URLs in the new release

Also downgrade `trezor-user-env` to a previous version (c702cbb2f67ccb39573e529721cb8f1145cdd891), due to issues in CI with the latest.