### PR TITLE
fix(connect-webexplorer): some atributes were not passed throw the proxy

### DIFF
--- a/packages/connect-webextension/src/index.ts
+++ b/packages/connect-webextension/src/index.ts
@@ -239,8 +239,8 @@ const initProxyChannel = () => {
             () => {
                 (TrezorConnect as any)[method](payload).then((response: any) => {
                     channel.postMessage({
+                        ...response,
                         id,
-                        payload: response.payload,
                     });
                 });
             },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The `success` attribute was not pass back throw the proxy to the foreground in connect-webextension. This changes make it so it passes all the attributes.


Related https://github.com/trezor/trezor-suite/issues/12731
