### PR TITLE
feat(suite): label device select button in firmware installation

### DIFF
--- a/packages/suite/src/components/firmware/FirmwareInstallation.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInstallation.tsx
@@ -8,6 +8,17 @@ import { OnboardingStepBox } from 'src/components/onboarding';
 import { TrezorDevice } from 'src/types/suite';
 import { selectIsActionAbortable } from 'src/reducers/suite/suiteReducer';
 import { useSelector } from 'src/hooks/suite/useSelector';
+import styled from 'styled-components';
+import { spacingsPx } from '@trezor/theme';
+
+const SelectDevice = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: ${spacingsPx.lg};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
+`;
 
 interface FirmwareInstallationProps {
     cachedDevice?: TrezorDevice;
@@ -43,7 +54,12 @@ export const FirmwareInstallation = ({
             // Once in bootloader mode and once in normal mode. Without 2nd pairing step would get stuck at waiting for
             // a reboot in case of fresh device which is, from the start, in bootloader mode (thus first time paired as a bootloader device).
             // Suite won't detect such a restarted device, which will be now in normal mode, till it is paired again.
-            return <WebUsbButton />;
+            return (
+                <SelectDevice>
+                    <Translation id="TR_SELECT_TREZOR_TO_CONTINUE" />
+                    <WebUsbButton translationId="TR_SELECT_TREZOR" size="medium" icon={false} />
+                </SelectDevice>
+            );
         }
         if (status === 'done') {
             return (

--- a/packages/suite/src/components/suite/WebUsbButton.tsx
+++ b/packages/suite/src/components/suite/WebUsbButton.tsx
@@ -1,20 +1,30 @@
 import TrezorConnect from '@trezor/connect';
 import { ButtonProps, Button } from '@trezor/components';
-import { Translation } from './Translation';
+import { Translation, TranslationKey } from './Translation';
 
-export const WebUsbButton = (props: Omit<ButtonProps, 'children'>) => (
+interface WebUsbButtonProps extends Omit<ButtonProps, 'children' | 'icon'> {
+    translationId?: TranslationKey;
+    icon?: ButtonProps['icon'] | false;
+}
+
+export const WebUsbButton = ({
+    translationId = 'TR_CHECK_FOR_DEVICES',
+    icon = 'SEARCH',
+    size = 'tiny',
+    ...rest
+}: WebUsbButtonProps) => (
     <div data-test="web-usb-button">
         <Button
-            {...props}
-            icon="SEARCH"
+            {...rest}
+            icon={icon === false ? undefined : icon}
+            size={size}
             variant="primary"
             onClick={e => {
                 e.stopPropagation();
                 TrezorConnect.requestWebUSBDevice();
             }}
-            size="tiny"
         >
-            <Translation id="TR_CHECK_FOR_DEVICES" />
+            <Translation id={translationId} />
         </Button>
     </div>
 );

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -9417,4 +9417,12 @@ export default defineMessages({
         id: 'TR_CONNECT_DEVICE_PASSPHRASE_BANNER_BUTTON',
         defaultMessage: 'Manage',
     },
+    TR_SELECT_TREZOR: {
+        id: 'TR_SELECT_TREZOR',
+        defaultMessage: 'Select Trezor',
+    },
+    TR_SELECT_TREZOR_TO_CONTINUE: {
+        id: 'TR_SELECT_TREZOR_TO_CONTINUE',
+        defaultMessage: 'Please select your Trezor to continue.',
+    },
 });


### PR DESCRIPTION
## Description

Add a label to the button that appears in WebUSB mode to select device when going from or to bootloader.

## Screenshots:

Before
<img width="1313" alt="Screenshot 2024-06-11 at 12 54 22" src="https://github.com/trezor/trezor-suite/assets/8833813/ffc91774-6b97-460f-af48-dbd83cd7ed34">

After
<img width="1092" alt="Screenshot 2024-06-11 at 14 48 31" src="https://github.com/trezor/trezor-suite/assets/8833813/4bf60578-6107-4e3a-a9f3-e24bb575668e">
