### PR TITLE
fix(suite): move z-index property to outer wrapper

### DIFF
--- a/packages/suite/src/components/onboarding/OnboardingStepBox.tsx
+++ b/packages/suite/src/components/onboarding/OnboardingStepBox.tsx
@@ -12,10 +12,13 @@ import {
 import { TrezorDevice } from '@suite-common/suite-types';
 import { spacingsPx, zIndices } from '@trezor/theme';
 
+const WrapperWrapper = styled.div`
+    z-index: ${zIndices.onboardingForeground};
+`;
+
 const ConfirmWrapper = styled.div`
     margin-bottom: 20px;
     height: 62px;
-    z-index: ${zIndices.onboardingForeground};
 `;
 
 const InnerActions = styled.div`
@@ -80,7 +83,7 @@ export const OnboardingStepBox = ({
         <>
             <StyledBackdrop $show={isBackDropVisible} />
             {!disableConfirmWrapper && (
-                <div data-test="@onboarding/confirm-on-device">
+                <WrapperWrapper data-test="@onboarding/confirm-on-device">
                     {deviceModelInternal && (
                         <ConfirmWrapper>
                             <ConfirmOnDevice
@@ -100,7 +103,7 @@ export const OnboardingStepBox = ({
                             />
                         </ConfirmWrapper>
                     )}
-                </div>
+                </WrapperWrapper>
             )}
 
             <StyledCollapsibleCard


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
The z-index on `ConfirmWrapper` was ignored because another wrapper has been added.

@peter-sanderson Do you remember why the extra `div` was introduced in https://github.com/trezor/trezor-suite/pull/12652?

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/12858

## Screenshots:
before
![Screenshot 2024-06-12 at 12 54 00](https://github.com/trezor/trezor-suite/assets/42465546/4e8264c7-bbc0-48db-9f6c-77181aa77b9a)
after
![Screenshot 2024-06-12 at 12 53 29](https://github.com/trezor/trezor-suite/assets/42465546/728aa1c4-5163-49bd-bcfc-5f2ba9a18fda)

