### PR TITLE
ci(github): npm deploy when no connect dependencies

### DIFF
--- a/.github/workflows/release-connect-npm.yml
+++ b/.github/workflows/release-connect-npm.yml
@@ -55,7 +55,15 @@ jobs:
 
       - name: Get packages that need release
         id: set-packages-need-release
-        run: echo "packagesNeedRelease=$(yarn tsx ./ci/scripts/get-connect-dependencies-to-release.ts)" >> $GITHUB_OUTPUT
+        # We want this job to be successfully complete when "no-packages-to-release" since it means that
+        # there are no dependencies to release so we can continue with "deploy-npm-connect"
+        run: |
+          packages=$(yarn tsx ./ci/scripts/get-connect-dependencies-to-release.ts)
+          if [ "$packages" == "[]" ]; then
+            echo "packagesNeedRelease=[\"no-packages-to-release\"]" >> $GITHUB_OUTPUT
+          else
+            echo "packagesNeedRelease=$packages" >> $GITHUB_OUTPUT
+          fi
 
       - name: Determine Deployment Type from version in branch
         id: determine-deployment-type
@@ -79,10 +87,12 @@ jobs:
         package: ${{ fromJson(needs.identify-release-packages.outputs.packagesNeedRelease) }}
     steps:
       - uses: actions/checkout@v4
+        if: matrix.package != 'no-packages-to-release'
         with:
           ref: develop
 
       - name: Set deployment type
+        if: matrix.package != 'no-packages-to-release'
         id: set_deployment_type
         run: |
           if [ "${{ needs.identify-release-packages.outputs.deploymentType }}" == "canary" ]; then
@@ -90,7 +100,9 @@ jobs:
           else
             echo "DEPLOYMENT_TYPE=latest" >> $GITHUB_ENV
           fi
+
       - name: Deploy to NPM ${{ matrix.package }}
+        if: matrix.package != 'no-packages-to-release'
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         uses: ./.github/actions/release-connect-npm
@@ -112,6 +124,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: develop
+
       - name: Set deployment type
         id: set_deployment_type
         run: |
@@ -120,6 +133,7 @@ jobs:
           else
             echo "DEPLOYMENT_TYPE=latest" >> $GITHUB_ENV
           fi
+
       - name: Deploy to NPM ${{ matrix.package }}
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We had the issue in the stagings design of the npm release when there are not connect npm depencencies to be release because for example they were already released and we want to release only connect, connect-web and connect-webextension.


This approach makes "deploy-npm-connect-dependencies" to succeed when packagesNeedRelease is "[]" by using a dummy package "no-packages-to-release" that will make the job to complete successfully and allow job "deploy-npm-connect" to continue and at the same time have the stage deployment type that we wanted so we do not deploy connect before we make sure that  all the connect dependencies were properly deployed to NPM.