### PR TITLE
chore(connect): grooming in Device.state

### DIFF
--- a/packages/connect/src/api/getDeviceState.ts
+++ b/packages/connect/src/api/getDeviceState.ts
@@ -1,6 +1,7 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/GetDeviceState.js
 
 import { AbstractMethod } from '../core/AbstractMethod';
+import { ERRORS } from '../constants';
 
 export default class GetDeviceState extends AbstractMethod<'getDeviceState'> {
     init() {
@@ -8,8 +9,11 @@ export default class GetDeviceState extends AbstractMethod<'getDeviceState'> {
     }
 
     run() {
-        return Promise.resolve({
-            state: this.device.getExternalState(),
-        });
+        const state = this.device.getState();
+        if (!state?.staticSessionId) {
+            throw ERRORS.TypedError('Runtime', 'Device state not set');
+        }
+
+        return Promise.resolve({ state: state.staticSessionId, _state: state });
     }
 }

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -15,7 +15,7 @@ import {
 } from '../events';
 import { getHost } from '../utils/urlUtils';
 import type { Device } from '../device/Device';
-import type { FirmwareRange } from '../types';
+import type { FirmwareRange, DeviceState } from '../types';
 
 export type Payload<M> = Extract<CallMethodPayload, { method: M }> & { override?: boolean };
 export type MethodReturnType<M extends CallMethodPayload['method']> = CallMethodResponse<M>;
@@ -38,7 +38,7 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
 
     devicePath?: string;
 
-    deviceState?: string;
+    deviceState?: DeviceState;
 
     hasExpectedDeviceState: boolean;
 
@@ -108,7 +108,10 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
         this.devicePath = payload.device?.path;
         // expected state from method parameter.
         // it could be null
-        this.deviceState = payload.device?.state;
+        this.deviceState =
+            typeof payload.device?.state === 'string'
+                ? { staticSessionId: payload.device.state }
+                : payload.device?.state;
         this.hasExpectedDeviceState = payload.device
             ? Object.prototype.hasOwnProperty.call(payload.device, 'state')
             : false;

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -381,8 +381,8 @@ const inner = async (context: CoreContext, method: AbstractMethod<any>, device: 
                     // wait for user response
                     const uiResp = await uiPromise.promise;
                     if (uiResp.payload) {
-                        // reset internal device state and try again
-                        device.setInternalState(undefined);
+                        // reset sessionId and try again
+                        device.setState({ sessionId: undefined });
                         await device.initialize(method.useCardanoDerivation);
 
                         invalidDeviceState = await getInvalidDeviceState(
@@ -392,7 +392,7 @@ const inner = async (context: CoreContext, method: AbstractMethod<any>, device: 
                         );
                     } else {
                         // set new state as requested
-                        device.setExternalState(invalidDeviceState);
+                        device.setState({ staticSessionId: invalidDeviceState });
                         break;
                     }
                 }
@@ -404,7 +404,7 @@ const inner = async (context: CoreContext, method: AbstractMethod<any>, device: 
             // sendCoreMessage(ResponseMessage(method.responseID, false, { error }));
             // closePopup();
             // clear cached passphrase. it's not valid
-            device.setInternalState(undefined);
+            device.setState({ sessionId: undefined });
 
             // interrupt process and go to "final" block
             return Promise.reject(error);
@@ -601,7 +601,7 @@ const onCall = async (context: CoreContext, message: IFrameCallMessage) => {
     device.setInstance(message.payload.device?.instance);
 
     if (method.hasExpectedDeviceState) {
-        device.setExternalState(method.deviceState);
+        device.setState(method.deviceState);
     }
 
     // device is available
@@ -619,7 +619,7 @@ const onCall = async (context: CoreContext, message: IFrameCallMessage) => {
         );
     });
     device.on(DEVICE.SAVE_STATE, (state: string) => {
-        // Persist internal state only in case of core in popup
+        // Persist sessionId only in case of core in popup
         // Currently also only for webextension until we asses security implications
         if (useCoreInPopup && env === 'webextension') {
             storage.saveForOrigin(store => {
@@ -637,15 +637,15 @@ const onCall = async (context: CoreContext, message: IFrameCallMessage) => {
         }
     });
 
-    if (!device.getInternalState() && useCoreInPopup && env === 'webextension') {
-        // Restore internal state if available
+    if (!device.getState()?.sessionId && useCoreInPopup && env === 'webextension') {
+        // Restore sessionId if available
         const { preferredDevice } = storage.loadForOrigin(origin) || {};
         if (
             preferredDevice?.internalState &&
             preferredDevice?.internalStateExpiration &&
             preferredDevice.internalStateExpiration > new Date().getTime()
         ) {
-            device.setInternalState(preferredDevice.internalState);
+            device.setState({ sessionId: preferredDevice.internalState });
         }
     }
 

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -248,7 +248,7 @@ const inner = async (context: CoreContext, method: AbstractMethod<any>, device: 
         method.requireDeviceMode,
     );
     if (unexpectedMode) {
-        device.keepSession = false;
+        device.keepTransportSession = false;
         if (isUsingPopup) {
             // wait for popup handshake
             await waitForPopup(context);
@@ -905,7 +905,7 @@ const onPopupClosed = (context: CoreContext, customErrorMessage?: string) => {
     // Device was already acquired. Try to interrupt running action which will throw error from onCall try/catch block
     if (deviceList.isConnected() && deviceList.asArray().length > 0) {
         deviceList.allDevices().forEach(d => {
-            d.keepSession = false; // clear session on release
+            d.keepTransportSession = false; // clear transportSession on release
             if (d.isUsedHere()) {
                 setOverridePromise(d.interruptionFromUser(error));
             } else {

--- a/packages/connect/src/device/DeviceCommands.ts
+++ b/packages/connect/src/device/DeviceCommands.ts
@@ -90,8 +90,7 @@ export class DeviceCommands {
     device: Device;
 
     transport: Transport;
-
-    sessionId: Session;
+    transportSession: Session;
 
     disposed: boolean;
 
@@ -101,10 +100,10 @@ export class DeviceCommands {
     _cancelableRequest?: (error?: any) => void;
     _cancelableRequestBySend?: boolean;
 
-    constructor(device: Device, transport: Transport, sessionId: Session) {
+    constructor(device: Device, transport: Transport, transportSession: Session) {
         this.device = device;
         this.transport = transport;
-        this.sessionId = sessionId;
+        this.transportSession = transportSession;
         this.disposed = false;
     }
 
@@ -320,7 +319,7 @@ export class DeviceCommands {
         logger.debug('Sending', type, filterForLog(type, msg));
 
         this.callPromise = this.transport.call({
-            session: this.sessionId,
+            session: this.transportSession,
             name: type,
             data: msg,
             protocol: this.device.protocol,
@@ -373,7 +372,7 @@ export class DeviceCommands {
             // handle possible race condition
             // Bridge may have some unread message in buffer, read it
             await this.transport.receive({
-                session: this.sessionId,
+                session: this.transportSession,
                 protocol: this.device.protocol,
             }).promise;
             // throw error anyway, next call should be resolved properly
@@ -669,7 +668,7 @@ export class DeviceCommands {
         } else {
             await this.transport.send({
                 protocol: this.device.protocol,
-                session: this.sessionId,
+                session: this.transportSession,
                 name: 'Cancel',
                 data: {},
             }).promise;
@@ -680,7 +679,7 @@ export class DeviceCommands {
             // if my observations are correct, it is not necessary to transport.receive after send
             // transport.call -> transport.send -> transport call returns Failure meaning it won't be
             // returned in subsequent calls
-            // await this.transport.receive({ session: this.sessionId }).promise;
+            // await this.transport.receive({ session: this.transportSession }).promise;
         }
     }
 }

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -229,10 +229,10 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
         diff.released.forEach(descriptor => {
             const path = descriptor.path.toString();
             const device = this.devices[path];
-            const methodStillRunning = !device?.commands?.isDisposed();
+            const methodStillRunning = !device?.getCommands()?.isDisposed();
 
             if (device && methodStillRunning) {
-                device.keepSession = false;
+                device.keepTransportSession = false;
             }
         });
 
@@ -506,7 +506,8 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
                     product: d.product,
                     type: d.type,
                 };
-                this.devices[d.path].activitySessionID = d.session;
+                // TODO: is this ok? transportSession should be set only as result of acquire/release
+                // this.devices[d.path].transportSession = d.session;
             }
         });
     }

--- a/packages/connect/src/types/api/getDeviceState.ts
+++ b/packages/connect/src/types/api/getDeviceState.ts
@@ -1,7 +1,9 @@
 import type { CommonParams, Response } from '../params';
+import type { DeviceState } from '../device';
 
 export interface DeviceStateResponse {
     state: string;
+    _state: DeviceState;
 }
 
 export declare function getDeviceState(params?: CommonParams): Response<DeviceStateResponse>;

--- a/packages/connect/src/types/device.ts
+++ b/packages/connect/src/types/device.ts
@@ -29,6 +29,11 @@ export enum FirmwareType {
     Regular = 'regular',
 }
 
+export type DeviceState = {
+    sessionId?: string; // dynamic value: Features.session_id
+    staticSessionId?: string; // constant value: 1st testnet address
+};
+
 // NOTE: unavailableCapabilities is an object with information what is NOT supported by this device.
 // in ideal/expected setup this object should be empty but given setup might have exceptions.
 // key = coin shortcut lowercase (ex: btc, eth, xrp) OR field declared in coins.json "supportedFirmware.capability"
@@ -58,6 +63,7 @@ export type KnownDevice = {
     color?: string;
     status: DeviceStatus;
     mode: DeviceMode;
+    _state?: DeviceState; // TODO: breaking change in next major release
     state?: string;
     features: PROTO.Features;
     unavailableCapabilities: UnavailableCapabilities;
@@ -83,6 +89,7 @@ export type UnknownDevice = {
     color?: typeof undefined;
     status?: typeof undefined;
     mode?: typeof undefined;
+    _state?: typeof undefined;
     state?: typeof undefined;
     unavailableCapabilities?: typeof undefined;
     availableTranslations?: typeof undefined;
@@ -102,6 +109,7 @@ export type UnreadableDevice = {
     color?: typeof undefined;
     status?: typeof undefined;
     mode?: typeof undefined;
+    _state?: typeof undefined;
     state?: typeof undefined;
     unavailableCapabilities?: typeof undefined;
     availableTranslations?: typeof undefined;

--- a/packages/connect/src/types/params.ts
+++ b/packages/connect/src/types/params.ts
@@ -1,11 +1,12 @@
 // API params
 
 import { Type, TSchema, Static } from '@trezor/schema-utils';
+import { DeviceState } from './device';
 
 export interface CommonParams {
     device?: {
         path?: string;
-        state?: string;
+        state?: string | DeviceState;
         instance?: number;
     };
     useEmptyPassphrase?: boolean;


### PR DESCRIPTION
## Description

1. grooming in Device.state

- `internalState` and `externalState` joined into array of `DeviceState`
- `internalState` renamed to `state.sessionId`
- `externalState` renamed to `state.staticSessionId`
- added `Device._state` field, future form of Device.state

This is not a breaking change. connect accept both params: device.state as `string` and device.state as `DeviceState` object. Returned `_state` should replace `state` in the next major release 

2. unify names of Device fields

add prefix to distinguish `sessionId` (DeviceState) from `transportSession` (Session)

- `activitySessionID` -> `transportSession`
- `keepSession` -> `keepTransportSession`

