### PR TITLE
docs: Add WSL setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Run a dev build:
 -   `yarn suite:dev` (web app)
 -   `yarn suite:dev:desktop` (electron app)
 
+Development is also possible on WSL, [more info here](./docs/misc/WSL.md).
+
 ## **Trezor Suite Lite** @suite-native/app
 
 > To set up your dev environment for a native platform (iOS/Android) follow [these additional steps](https://github.com/trezor/trezor-suite/tree/develop/suite-native/app#prerequisites).

--- a/docs/misc/WSL.md
+++ b/docs/misc/WSL.md
@@ -1,0 +1,32 @@
+# Development on WSL
+
+Thanks to Windows Subsystem for Linux (WSL), you can run Trezor Suite dev environment on a Windows machine.
+
+## Prerequisites
+
+On Windows:
+- [Install an Ubuntu WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) _(must be v2, you may upgrade existing v1 WSL to v2)_
+- Install [USBIPD](https://learn.microsoft.com/en-us/windows/wsl/connect-usb)
+
+In WSL:
+- Run `sudo apt-get install build-essential`
+- Install these [Electron dependencies](https://www.electronjs.org/docs/latest/development/build-instructions-linux) for Linux
+- Install udev rules [as per the Trezor docs](https://trezor.io/learn/a/udev-rules)
+
+## Setup
+
+Proceed with the [general readme instructions](../../README.md#trezor-suite-trezorsuite).
+
+## Connecting USB device
+
+On Windows, run `usbipd list`, find the bus id of the Trezor device, e.g. `2-1`.
+
+Then run:
+```
+usbipd bind --busid 2-1
+usbipd attach --wsl --busid 2-1
+```
+
+In WSL, run `lsusb` to confirm the device is visible.
+
+_Note: Without udev rules, the device will be visible by `lsusb`, but not in the app._


### PR DESCRIPTION
## Description

Development of Trezor suite was found out to be viable on Windows with Ubuntu WSL, but requries additional setup.
This PR adds a guide for setting up the dev environment.