### PR TITLE
feat(connect-explorer): zoomable and dark mode illustrations

### DIFF
--- a/packages/connect-explorer/package.json
+++ b/packages/connect-explorer/package.json
@@ -39,6 +39,7 @@
         "react-dom": "^18.2.0",
         "react-inspector": "^6.0.2",
         "react-markdown": "^9.0.1",
+        "react-medium-image-zoom": "^5.2.4",
         "react-redux": "8.0.7",
         "redux": "^4.2.1",
         "redux-logger": "^3.0.6",

--- a/packages/connect-explorer/src/components/ZoomableIllustration.tsx
+++ b/packages/connect-explorer/src/components/ZoomableIllustration.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import Zoom from 'react-medium-image-zoom';
+import { useRouter } from 'next/router';
+
+import { createGlobalStyle, useTheme, styled } from 'styled-components';
+
+import 'react-medium-image-zoom/dist/styles.css';
+
+export type ZoomableIllustrationProps = React.ImgHTMLAttributes<HTMLImageElement> & {
+    darkMode?: boolean;
+};
+
+// Automatically invert colors of the image when darkMode is enabled
+const DarkModeImg = styled.img<{ darkMode?: boolean }>`
+    filter: ${({ darkMode }) => (darkMode ? 'invert(1) hue-rotate(180deg)' : 'invert(0)')};
+`;
+
+// Handle dark mode styles in react-medium-image-zoom
+const ReactMediumImageZoomStyle = createGlobalStyle<{ darkMode?: boolean }>`
+  html.dark [data-rmiz-modal-overlay="visible"] {
+    background-color: rgba(0, 0, 0, 1);
+  }
+
+  [data-rmiz-modal-img] {
+    filter: ${({ darkMode }) => (darkMode ? 'invert(1) hue-rotate(180deg)' : 'invert(0)')};
+  }
+`;
+
+export const ZoomableIllustration = (props: ZoomableIllustrationProps) => {
+    const router = useRouter();
+    const { THEME } = useTheme();
+    const darkMode = props.darkMode && THEME === 'dark';
+
+    // Automatic absolute path handling
+    const src = props?.src?.startsWith('/') ? router.basePath + props.src : props.src;
+
+    return (
+        <Zoom>
+            <ReactMediumImageZoomStyle darkMode={darkMode} />
+            <DarkModeImg {...props} src={src} darkMode={darkMode} />
+        </Zoom>
+    );
+};
+
+export default ZoomableIllustration;

--- a/packages/connect-explorer/src/pages/index.mdx
+++ b/packages/connect-explorer/src/pages/index.mdx
@@ -12,6 +12,7 @@ import { Button, Card as TrezorCard, variables } from '@trezor/components';
 import IconNode from '../components/icons/IconNode';
 import IconWeb from '../components/icons/IconWeb';
 import IconExtension from '../components/icons/IconExtension';
+import ZoomableIllustration from '../components/ZoomableIllustration';
 
 export const SectionCard = styled(TrezorCard)`
     margin-bottom: ${spacingsPx.xl};
@@ -160,7 +161,7 @@ export const ExampleHeading = styled.h3`
         </Button>
     </SdkHeading>
 
-    ![connect schema when used in node](../../public/images/schema-connect.svg)
+    <ZoomableIllustration src="/images/schema-connect.svg" darkMode alt="connect schema when used in node" />
 
     <SdkContainer>
         <SdkDescription>
@@ -197,7 +198,7 @@ export const ExampleHeading = styled.h3`
         </Button>
     </SdkHeading>
 
-    ![connect schema when used on web](../../public/images/schema-connect-web.svg)
+    <ZoomableIllustration src="/images/schema-connect-web.svg" darkMode alt="connect schema when used on web" />
 
     <SdkContainer>
         <SdkDescription>
@@ -236,7 +237,7 @@ export const ExampleHeading = styled.h3`
         </Button>
     </SdkHeading>
 
-    ![connect schema when used in webextension](../../public/images/schema-connect-webextension.svg)
+    <ZoomableIllustration src="/images/schema-connect-webextension.svg" darkMode alt="connect schema when used in webextension" />
 
     <SdkContainer>
         <SdkDescription>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10709,6 +10709,7 @@ __metadata:
     react-dom: "npm:^18.2.0"
     react-inspector: "npm:^6.0.2"
     react-markdown: "npm:^9.0.1"
+    react-medium-image-zoom: "npm:^5.2.4"
     react-redux: "npm:8.0.7"
     redux: "npm:^4.2.1"
     redux-logger: "npm:^3.0.6"
@@ -34243,6 +34244,16 @@ __metadata:
     "@types/react": ">=18"
     react: ">=18"
   checksum: 10/71ce31f200982f641d363888a26e8fb52a199a589124f20295e9be870fa3aed26fcfa14d1dc766d83df666a15cb82359291bfda207bd55d5728ff376d217e079
+  languageName: node
+  linkType: hard
+
+"react-medium-image-zoom@npm:^5.2.4":
+  version: 5.2.4
+  resolution: "react-medium-image-zoom@npm:5.2.4"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 10/fc35231b37c7d27fc7a1d6b250902d3cac8d9c784452e715f22a627bcf760b4b4576af0776a95f89ae821e6c4c3860c0fc7e143201b183894bcbc3cab7bdfd8f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Add support for zooming illustrations in Connect Explorer using `react-medium-image-zoom`. 

Add support for dark mode, by adding a invert+hue rotate filter to the illustrations.

## Related Issue

Resolve #12791
Resolve #12667

## Preview

https://dev.suite.sldev.cz/connect/feat/connect-explorer-illustrations/