### PR TITLE
fix(suite-native): error on failed initStore

### DIFF
--- a/suite-native/state/package.json
+++ b/suite-native/state/package.json
@@ -12,6 +12,7 @@
     },
     "dependencies": {
         "@reduxjs/toolkit": "1.9.5",
+        "@sentry/react-native": "5.22.3",
         "@suite-common/analytics": "workspace:*",
         "@suite-common/logger": "workspace:*",
         "@suite-common/message-system": "workspace:*",

--- a/suite-native/state/src/StoreProvider.tsx
+++ b/suite-native/state/src/StoreProvider.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, ReactNode } from 'react';
 import { Provider } from 'react-redux';
 
+import * as Sentry from '@sentry/react-native';
 import { EnhancedStore } from '@reduxjs/toolkit';
 import { Persistor, persistStore } from 'redux-persist';
 
@@ -18,10 +19,15 @@ export const StoreProvider = ({ children }: StoreProviderProps) => {
 
     useEffect(() => {
         const initStoreAsync = async () => {
-            const freshStore = await initStore();
-            const freshPersistor = persistStore(freshStore);
-            setStore(freshStore);
-            setStorePersistor(freshPersistor);
+            try {
+                const freshStore = await initStore();
+                const freshPersistor = persistStore(freshStore);
+                setStore(freshStore);
+                setStorePersistor(freshPersistor);
+            } catch (error) {
+                console.error('Init store error:', error);
+                Sentry.captureException(error);
+            }
         };
 
         initStoreAsync();

--- a/yarn.lock
+++ b/yarn.lock
@@ -9937,6 +9937,7 @@ __metadata:
   resolution: "@suite-native/state@workspace:suite-native/state"
   dependencies:
     "@reduxjs/toolkit": "npm:1.9.5"
+    "@sentry/react-native": "npm:5.22.3"
     "@suite-common/analytics": "workspace:*"
     "@suite-common/logger": "workspace:*"
     "@suite-common/message-system": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If there is any error on `initStore()`, the app doesn't display any information about it and just hangs on splash screen. This leads to troublesome debugging. Wrapping this inside a try / catch will still not work, but at least there will be error displayed to provide some information on what's wrong.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
