### PR TITLE
Coinmarket: Allow multiple slashes in `formDraftKey`

### DIFF
--- a/suite-common/wallet-utils/src/formDraftUtils.ts
+++ b/suite-common/wallet-utils/src/formDraftUtils.ts
@@ -5,9 +5,12 @@ export const getFormDraftKey = (prefix: FormDraftKeyPrefix, key: string) => `${p
 export const parseFormDraftKey = (
     formDraftKey: string,
 ): [prefix: FormDraftKeyPrefix, key: string] => {
-    const strings = formDraftKey.split('/');
-    if (strings.length === 2) {
-        return strings as [prefix: FormDraftKeyPrefix, key: string];
+    const delimiterIndex = formDraftKey.indexOf('/');
+    if (delimiterIndex < 0) {
+        throw Error('Invalid formDraftKey');
     }
-    throw Error('Invalid formDraftKey');
+    const prefix = formDraftKey.slice(0, delimiterIndex);
+    const key = formDraftKey.slice(delimiterIndex + 1);
+
+    return [prefix as FormDraftKeyPrefix, key];
 };


### PR DESCRIPTION
## Description

There are slashes in taproot account keys, so `parseFormDraftKey` sometimes failed on `formDraftKey.split('/').length === 2` check. This PR should fix it by using everything after first slash as an account key.

## Related Issue

Resolve #12927

## QA

- go to Taproot account
- go to Trade section
- type something into the form, creating a form draft
- go directly into application settings
- switch from BTC to sats or vice versa
  - before the fix, an error log should appear in the console
  - after the fix, error log should be gone