### PR TITLE
fix(connect-example): do not use proxy in example and explain more

### DIFF
--- a/packages/connect-examples/update-webextensions-sw.js
+++ b/packages/connect-examples/update-webextensions-sw.js
@@ -53,7 +53,7 @@ rootPaths.forEach(dir => {
             res.body.pipe(dest);
         });
     } else {
-        ['trezor-connect-webextension.js', 'trezor-connect-webextension-proxy.js'].forEach(p => {
+        ['trezor-connect-webextension.js'].forEach(p => {
             fs.copyFileSync(
                 path.join(__dirname, '../connect-webextension', 'build', p),
                 path.join(rootPath, buildFolder, 'vendor', p),

--- a/packages/connect-examples/webextension-mv3-sw/src/connect-manager.html
+++ b/packages/connect-examples/webextension-mv3-sw/src/connect-manager.html
@@ -8,13 +8,8 @@
     <body>
         <button id="tab">New tab</button>
         <button id="get-features" data-test="get-features">Get features</button>
-        <button id="get-address" data-test="get-address">Get address</button>
+        <button id="get-address" data-test="get-address">Get Address</button>
         <div id="result"></div>
-        <!-- TODO: try to load changing content security policy -->
-        <!-- https://developer.chrome.com/docs/extensions/mv3/manifest/content_security_policy/ -->
-        <!-- https://stackoverflow.com/questions/67439012/chrome-extension-manifest-v3-content-security-policy -->
-        <!-- <script type="text/javascript" src="https://staging-connect.trezor.io/9/trezor-connect.js"></script> -->
-        <script src="./vendor/trezor-connect-webextension-proxy.js" type="text/javascript"></script>
         <script src="./connect-manager.js" type="module"></script>
     </body>
 </html>

--- a/packages/connect-examples/webextension-mv3-sw/src/connect-manager.js
+++ b/packages/connect-examples/webextension-mv3-sw/src/connect-manager.js
@@ -1,35 +1,36 @@
-const DEFAULT_SRC = 'https://connect.trezor.io/9/';
+// This JavaScript code is running in the connect-manager.html tab of the webextension
+// and it communicates with the service worker when it needs something from Trezor device.
+// There are different ways to achieve message passing from the tab with the service-worker,
+// for more info: https://developer.chrome.com/docs/extensions/develop/concepts/messaging
 
-window.TrezorConnect.init({
-    lazyLoad: true,
-    manifest: {
-        email: 'developer@xyz.com',
-        appUrl: 'http://your.application.com',
-    },
-    connectSrc: DEFAULT_SRC,
-});
-
-const getAddressButton = document.getElementById('get-address');
-getAddressButton.addEventListener('click', () => {
-    window.TrezorConnect.getAddress({
-        showOnTrezor: true,
-        path: "m/49'/0'/0'/0/0",
-        coin: 'btc',
-    }).then(res => {
-        console.info(res);
-        document.getElementById('result').innerText = JSON.stringify(res);
+document.getElementById('get-address').addEventListener('click', () => {
+    // Send a message to the background script (service worker) with the action 'getAddress'
+    chrome.runtime.sendMessage({ action: 'getAddress' }, response => {
+        // Check if the response indicates success
+        if (response.success) {
+            console.info(response); // Log the successful response to the console
+            // Display the response in the 'result' element on the page
+            document.getElementById('result').innerText = JSON.stringify(response);
+        } else {
+            console.error(response); // Log the error response to the console
+            // Display an error message in the 'result' element on the page
+            document.getElementById('result').innerText = 'Error: ' + response.error;
+        }
     });
 });
 
-const getFeaturesButton = document.getElementById('get-features');
-getFeaturesButton.addEventListener('click', () => {
-    window.TrezorConnect.getFeatures().then(res => {
-        console.info(res);
-        document.getElementById('result').innerText = JSON.stringify(res);
+document.getElementById('get-features').addEventListener('click', () => {
+    // Send a message to the background script (service worker) with the action 'getFeatures'
+    chrome.runtime.sendMessage({ action: 'getFeatures' }, response => {
+        // Check if the response indicates success
+        if (response.success) {
+            console.info(response); // Log the successful response to the console
+            // Display the response in the 'result' element on the page
+            document.getElementById('result').innerText = JSON.stringify(response);
+        } else {
+            console.error(response); // Log the error response to the console
+            // Display an error message in the 'result' element on the page
+            document.getElementById('result').innerText = 'Error: ' + response.error;
+        }
     });
-});
-
-const newTabButton = document.getElementById('tab');
-newTabButton.addEventListener('click', () => {
-    chrome.tabs.create({ url: 'connect-manager.html' });
 });

--- a/packages/connect-examples/webextension-mv3-sw/src/popup.js
+++ b/packages/connect-examples/webextension-mv3-sw/src/popup.js
@@ -1,4 +1,8 @@
-const newTabButton = document.getElementById('tab');
-newTabButton.addEventListener('click', () => {
-    chrome.tabs.create({ url: 'connect-manager.html' });
+document.addEventListener('DOMContentLoaded', () => {
+    const newTabButton = document.getElementById('tab');
+    if (newTabButton) {
+        newTabButton.addEventListener('click', () => {
+            chrome.tabs.create({ url: 'connect-manager.html' });
+        });
+    }
 });

--- a/packages/connect-examples/webextension-mv3-sw/src/serviceWorker.js
+++ b/packages/connect-examples/webextension-mv3-sw/src/serviceWorker.js
@@ -1,28 +1,49 @@
-// import connect
+// Dynamic script loading to import the Trezor Connect script, making its functions available in this service worker.
+// This is designed to work within the service-worker context, which does not support ES6 modules natively.
+// TODO: add other example for ES6 module imports.
 importScripts('vendor/trezor-connect-webextension.js');
 
+// URL of the Trezor Connect
 const connectSrc = 'https://connect.trezor.io/9/';
 
-// call connect once extension is started. and thats all
 chrome.runtime.onInstalled.addListener(details => {
+    console.log('details', details);
+
+    // Initialize Trezor Connect with the provided manifest and settings
     TrezorConnect.init({
         manifest: {
-            email: 'meow',
+            email: 'meow@example.com',
             appUrl: 'https://yourAppUrl.com/',
         },
-        transports: ['BridgeTransport', 'WebUsbTransport'],
+        transports: ['BridgeTransport', 'WebUsbTransport'], // Transport protocols to be used
         connectSrc,
-        // This instructs connect to keep the serviceworker in the webextension alive.
-        _extendWebextensionLifetime: true,
+        _extendWebextensionLifetime: true, // Makes the service worker in @trezor/connect-webextension stay alive longer.
     });
 
+    // Event listener for Trezor device events
     TrezorConnect.on('DEVICE_EVENT', event => {
         console.log('EVENT in service worker', event);
     });
-    TrezorConnect.ethereumGetAddress({
-        path: "m/44'/60'/0'/0/0",
-        showOnTrezor: true,
-    }).then(res => {
-        console.log('RESULT in service worker', res);
+
+    // Event listener for messages from other parts of the extension
+    // This code will depend on how you handle the communication between different parts of your webextension.
+    chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+        if (message.action === 'getAddress') {
+            TrezorConnect.getAddress({
+                showOnTrezor: true,
+                path: "m/49'/0'/0'/0/0",
+                coin: 'btc',
+            }).then(res => {
+                sendResponse(res); // Send the response back to the sender
+            });
+            // Return true to indicate you want to send a response asynchronously
+            return true;
+        } else if (message.action === 'getFeatures') {
+            TrezorConnect.getFeatures().then(res => {
+                sendResponse(res); // Send the response back to the sender
+            });
+            // Return true to indicate you want to send a response asynchronously
+            return true;
+        }
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is a follow-up from https://github.com/trezor/trezor-suite/pull/12785
We do not want to publish proxy anymore so the documentation should be aligned with the options we allow.

Also I made the example developer friendly with many comments explaining what is happening and some links to more documentation.

There will be a follow-up of this one with a webextension using `@trezor/connect-webextension` with ES6 modules that will serve as a documentation of a more complex scaffolding as well as for us to test that we support properly ES6 modules exports.

## Related Issue

Related https://github.com/trezor/trezor-suite/issues/12731
