### PR TITLE
chore(connect-web): publish trezor-usb-permissions.html in NPM

### DIFF
--- a/packages/connect-examples/webextension-mv2/README.md
+++ b/packages/connect-examples/webextension-mv2/README.md
@@ -150,8 +150,9 @@ However, if you're creating a Google Chrome extension you must complete one addi
 
 ## Google Chrome WebUSB
 
-Chrome extension requires a special `trezor-usb-permissions.html` file served from the root of your extension. You can get the file [here](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-web/src/webextension/trezor-usb-permissions.html).
+Chrome extension requires a special `trezor-usb-permissions.html` file served from the root of your extension. You can get the file [here](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-web/src/webextension/trezor-usb-permissions.html) or from the NPM package in the `lib/webextension/` directory.
+
+This page imports a script that needs to be placed inside your extension at `vendor/trezor-usb-permissions.js`. You can obtain the script [here](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-web/src/webextension/trezor-usb-permissions.js) or in the same directory from the NPM package.
+This directory could be changed, but then you need to remember to change script src accordingly inside `trezor-usb-permissions.html` file.
 
 This page will be displayed in case where user is using Trezor without `Trezor Bridge` installed and `navigator.usb` is available.
-
-Lastly, you have to place [this](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-web/src/webextension/trezor-usb-permissions.js) Javascript file into your `vendor/` directory. This directory could be changed, but then you need to remember to change script src accordingly inside `trezor-usb-permissions.html` file.

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -32,7 +32,7 @@
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
         "type-check": "yarn g:tsc --build",
         "test:unit": "yarn g:jest",
-        "build:lib": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/replace-imports.sh ./lib",
+        "build:lib": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/replace-imports.sh ./lib && cp ./src/webextension/trezor-usb-permissions.html ./lib/webextension/trezor-usb-permissions.html",
         "dev": "yarn g:rimraf build && TS_NODE_PROJECT=\"tsconfig.lib.json\" yarn webpack --config ./webpack/dev.webpack.config.ts",
         "build:inline": "TS_NODE_PROJECT=\"tsconfig.lib.json\" webpack --config ./webpack/inline.webpack.config.ts",
         "build:webextension": "TS_NODE_PROJECT=\"tsconfig.lib.json\" webpack --config ./webpack/prod.webpack.config.ts",


### PR DESCRIPTION
## Description

Currently, `trezor-usb-permissions.html` is not published, which complicates things for extension authors that want to include it automatically in their build process.

This change simply copies `trezor-usb-permissions.html` to the `lib/webextension/` folder, so it can be published. `trezor-usb-permissions.js` is already published there. 

The README is also updated to reflect this