### PR TITLE
fix(staking): correct text for day count in staking modal

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/ConfirmStakeEthModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/ConfirmStakeEthModal.tsx
@@ -99,9 +99,9 @@ export const ConfirmStakeEthModal = ({
                     <Translation
                         id="TR_STAKE_ENTERING_POOL_MAY_TAKE"
                         values={{
-                            days:
+                            count:
                                 daysToAddToPoolInitial === undefined
-                                    ? '30+'
+                                    ? 'over30Days'
                                     : daysToAddToPoolInitial,
                         }}
                     />

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -8961,7 +8961,10 @@ export default defineMessages({
     },
     TR_STAKE_ENTERING_POOL_MAY_TAKE: {
         id: 'TR_STAKE_ENTERING_POOL_MAY_TAKE',
-        defaultMessage: 'Entering the staking pool may take up to {days} days',
+        defaultMessage: `{count, select,
+            over30Days {Entering the staking pool may take up to 30+ days}
+            other {Entering the staking pool may take up to {count, plural, one {# day} few {# days} other {# days}}}
+        }`,
     },
     TR_STAKE_ETH_WILL_BE_BLOCKED: {
         id: 'TR_STAKE_ETH_WILL_BE_BLOCKED',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed an issue where staking modal says 1 days and not one day in Confirm entry period modal

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here --> https://github.com/trezor/trezor-suite/issues/12893

## Screenshots:
![image](https://github.com/trezor/trezor-suite/assets/19682277/48a7b9ed-71cd-4265-8a01-fcec3187bacc)

