### PR TITLE
fix(ci): COMMIT_MESSAGE format

### DIFF
--- a/.github/workflows/test-suite-desktop-e2e.yml
+++ b/.github/workflows/test-suite-desktop-e2e.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Run and store git values for Currents
         run: |
-          echo "COMMIT_MESSAGE=$(git show -s --pretty=%B)" >> $GITHUB_ENV
+          echo "COMMIT_MESSAGE=$(git show -s --pretty=%s)" >> $GITHUB_ENV
           echo "COMMIT_EMAIL=$(git show -s --pretty=%ae)" >> $GITHUB_ENV
           echo "COMMIT_AUTHOR=$(git show -s --pretty=%an)" >> $GITHUB_ENV
           echo "COMMIT_SHA=$(git show -s --pretty=%H)" >> $GITHUB_ENV

--- a/.github/workflows/test-suite-desktop-nightly.yml
+++ b/.github/workflows/test-suite-desktop-nightly.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run and store git values for Currents
         run: |
-          echo "COMMIT_MESSAGE=$(git show -s --pretty=%B)" >> $GITHUB_ENV
+          echo "COMMIT_MESSAGE=$(git show -s --pretty=%s)" >> $GITHUB_ENV
           echo "COMMIT_EMAIL=$(git show -s --pretty=%ae)" >> $GITHUB_ENV
           echo "COMMIT_AUTHOR=$(git show -s --pretty=%an)" >> $GITHUB_ENV
           echo "COMMIT_SHA=$(git show -s --pretty=%H)" >> $GITHUB_ENV


### PR DESCRIPTION
## Description

Change COMMIT_MESSAGE format from %B (raw body) to %s (subject).
https://git-scm.com/docs/pretty-formats#Documentation/pretty-formats.txt-emsem

This solves the problem when the body has multiple lines, which causes a failure, eg. here: https://github.com/trezor/trezor-suite/actions/runs/9460182885/job/26058521948?pr=12817