### PR TITLE
Fix `selectAllPendingTransactions` with undefined transactions

### DIFF
--- a/suite-common/wallet-core/src/transactions/__fixtures__/transactionsReducer.ts
+++ b/suite-common/wallet-core/src/transactions/__fixtures__/transactionsReducer.ts
@@ -1,8 +1,16 @@
 import { testMocks } from '@suite-common/test-utils';
 
+import type { TransactionsState } from '../transactionsReducer';
+import type { transactionsActions } from '../transactionsActions';
+
 const ACCOUNT = testMocks.getWalletAccount();
 
-export const addTransaction = [
+export const addTransaction: {
+    description: string;
+    initialState: Partial<TransactionsState>;
+    actionPayload: ReturnType<typeof transactionsActions.addTransaction>['payload'];
+    result: Partial<TransactionsState>;
+}[] = [
     {
         description: 'tx exists and will NOT be replaced',
         initialState: {
@@ -147,5 +155,38 @@ export const addTransaction = [
             transactions: [testMocks.getWalletTransaction({ txid: '00' })],
         },
         result: { [ACCOUNT.key]: [testMocks.getWalletTransaction({ txid: '00' })] },
+    },
+];
+
+export const removeTransaction: {
+    description: string;
+    initialState: Partial<TransactionsState>;
+    actionPayload: ReturnType<typeof transactionsActions.removeTransaction>['payload'];
+    result: Partial<TransactionsState>;
+}[] = [
+    {
+        description: 'tx will be removed from existing account',
+        initialState: {
+            transactions: {
+                [ACCOUNT.key]: [testMocks.getWalletTransaction()],
+            },
+        },
+        actionPayload: {
+            account: ACCOUNT,
+            txs: [testMocks.getWalletTransaction()],
+        },
+        result: { [ACCOUNT.key]: [] },
+    },
+    {
+        description:
+            'removing tx from nonexistent account, must NOT add accountKey into transactions',
+        initialState: {
+            transactions: {},
+        },
+        actionPayload: {
+            account: ACCOUNT,
+            txs: [testMocks.getWalletTransaction()],
+        },
+        result: {},
     },
 ];

--- a/suite-common/wallet-core/src/transactions/__tests__/transactionsReducer.test.ts
+++ b/suite-common/wallet-core/src/transactions/__tests__/transactionsReducer.test.ts
@@ -7,20 +7,41 @@ import * as fixtures from '../__fixtures__/transactionsReducer';
 const transactionsReducer = prepareTransactionsReducer(extraDependenciesMock);
 
 describe('transactionsReducer', () => {
-    fixtures.addTransaction.forEach(f => {
-        it(f.description, () => {
-            const result = transactionsReducer(
-                {
-                    ...transactionsInitialState,
-                    ...f.initialState,
-                },
-                {
-                    type: transactionsActions.addTransaction.type,
-                    payload: f.actionPayload,
-                },
-            );
+    describe('addTransaction', () => {
+        fixtures.addTransaction.forEach(f => {
+            it(f.description, () => {
+                const result = transactionsReducer(
+                    {
+                        ...transactionsInitialState,
+                        ...f.initialState,
+                    },
+                    {
+                        type: transactionsActions.addTransaction.type,
+                        payload: f.actionPayload,
+                    },
+                );
 
-            expect(result.transactions).toEqual(f.result);
+                expect(result.transactions).toStrictEqual(f.result);
+            });
+        });
+    });
+
+    describe('removeTransaction', () => {
+        fixtures.removeTransaction.forEach(f => {
+            it(f.description, () => {
+                const result = transactionsReducer(
+                    {
+                        ...transactionsInitialState,
+                        ...f.initialState,
+                    },
+                    {
+                        type: transactionsActions.removeTransaction.type,
+                        payload: f.actionPayload,
+                    },
+                );
+
+                expect(result.transactions).toStrictEqual(f.result);
+            });
         });
     });
 });

--- a/suite-common/wallet-core/src/transactions/transactionsReducer.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsReducer.ts
@@ -107,9 +107,11 @@ export const prepareTransactionsReducer = createReducerWithExtraDeps(
             .addCase(transactionsActions.removeTransaction, (state, { payload }) => {
                 const { account, txs } = payload;
                 const transactions = state.transactions[account.key];
-                state.transactions[account.key] = transactions?.filter(
-                    tx => !txs.some(t => t.txid === tx?.txid),
-                );
+                if (transactions) {
+                    state.transactions[account.key] = transactions.filter(
+                        tx => !txs.some(t => t.txid === tx?.txid),
+                    );
+                }
             })
             .addCase(transactionsActions.addTransaction, (state, { payload }) => {
                 const { transactions, account, page, perPage } = payload;
@@ -263,7 +265,7 @@ export const selectAllPendingTransactions = (state: TransactionsRootState) => {
 
     return Object.keys(transactions).reduce(
         (response, accountKey) => {
-            response[accountKey] = transactions[accountKey].filter(isPending);
+            response[accountKey] = (transactions[accountKey] ?? []).filter(isPending);
 
             return response;
         },


### PR DESCRIPTION
## Description

I haven't reproduced the issue #12886, but from it and minified Sentry stack trace, my interpretation is following:

- sometimes during CJ discovery, account is already removed (or not added yet) and transactions are being removed from it by `cleanPendingTransactions`
- therefore, `transactions` object transforms from `{ }` to `{ [accountKey]: undefined }` (first bug)
- meanwhile, `TxDetailModal` is opened on another account, calling `selectAllPendingTransactions`
- it doesn't expect undefined value for an `accountKey` in `transactions`, so it throws (second bug)

I made these two places a bit more defensive.

## Related Issue

Hopefully resolve #12886
