### PR TITLE
chore(transport): remove enumeration intent signaling

### DIFF
--- a/packages/transport-bridge/src/core.ts
+++ b/packages/transport-bridge/src/core.ts
@@ -105,8 +105,6 @@ export const createApi = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) => 
     };
 
     const enumerate = async () => {
-        await sessionsClient.enumerateIntent();
-
         const enumerateResult = await api.enumerate();
         if (!enumerateResult.success) {
             return enumerateResult;

--- a/packages/transport/src/sessions/client.ts
+++ b/packages/transport/src/sessions/client.ts
@@ -55,9 +55,6 @@ export class SessionsClient extends TypedEmitter<{
         return this.request({ type: 'handshake' });
     }
 
-    enumerateIntent() {
-        return this.request({ type: 'enumerateIntent' });
-    }
     enumerateDone(payload: EnumerateDoneRequest) {
         return this.request({ type: 'enumerateDone', payload });
     }

--- a/packages/transport/src/sessions/types.ts
+++ b/packages/transport/src/sessions/types.ts
@@ -16,11 +16,6 @@ export type Sessions = Record<string, Descriptor>;
 export type HandshakeRequest = Record<string, never>;
 export type HandshakeResponse = BackgroundResponse<undefined>;
 
-export type EnumerateIntentRequest = Record<string, never>;
-export type EnumerateIntentResponse = BackgroundResponse<{
-    descriptors: Descriptor[];
-}>;
-
 export type EnumerateDoneRequest = {
     descriptors: DescriptorApiLevel[];
 };
@@ -88,7 +83,6 @@ export type Params = {
 
 export interface HandleMessageApi {
     handshake: () => HandshakeResponse;
-    enumerateIntent: () => EnumerateIntentResponse;
     enumerateDone: (payload: EnumerateDoneRequest) => EnumerateDoneResponse;
     acquireIntent: (payload: AcquireIntentRequest) => AcquireIntentResponse;
     acquireDone: (payload: AcquireDoneRequest) => AcquireDoneResponse;

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -70,8 +70,6 @@ export abstract class AbstractApiTransport extends AbstractTransport {
 
     public enumerate() {
         return this.scheduleAction(async () => {
-            // notify sessions background that a client is going to access usb
-            await this.sessionsClient.enumerateIntent();
             // enumerate usb api
             const enumerateResult = await this.api.enumerate();
 

--- a/packages/transport/tests/sessions.test.ts
+++ b/packages/transport/tests/sessions.test.ts
@@ -10,65 +10,6 @@ describe('sessions', () => {
         requestFn = params => background.handleMessage(params);
     });
 
-    test('concurrent enumerate', async () => {
-        const client1 = new SessionsClient({
-            requestFn,
-            registerBackgroundCallbacks: () => {},
-        });
-        const client2 = new SessionsClient({
-            requestFn,
-            registerBackgroundCallbacks: () => {},
-        });
-        const client3 = new SessionsClient({
-            requestFn,
-            registerBackgroundCallbacks: () => {},
-        });
-
-        await client1.handshake();
-        await client2.handshake();
-        await client3.handshake();
-
-        const clientPromiseResolved = [false, false, false];
-
-        const [client1Promise, client2Promise, client3Promise] = [client1, client2, client3].map(
-            async (client, index) => {
-                const res = await client.enumerateIntent();
-                clientPromiseResolved[index] = true;
-
-                return res;
-            },
-        );
-        expect(clientPromiseResolved).toEqual([false, false, false]);
-        await client1Promise;
-
-        expect(client1Promise).resolves.toMatchObject({
-            success: true,
-            id: 1,
-            payload: { sessions: {} },
-        });
-        expect(clientPromiseResolved).toEqual([true, false, false]);
-
-        expect(client1.enumerateDone({ descriptors: [] })).resolves.toMatchObject({
-            success: true,
-        });
-
-        await client2Promise;
-
-        expect(clientPromiseResolved).toEqual([true, true, false]);
-
-        expect(client2Promise).resolves.toMatchObject({ success: true });
-        expect(client2.enumerateDone({ descriptors: [] })).resolves.toMatchObject({
-            success: true,
-        });
-
-        await client3Promise;
-        expect(clientPromiseResolved).toEqual([true, true, true]);
-
-        expect(client3.enumerateDone({ descriptors: [] })).resolves.toMatchObject({
-            success: true,
-        });
-    });
-
     test('acquire without previous enumerate', async () => {
         const client1 = new SessionsClient({ requestFn });
         await client1.handshake();


### PR DESCRIPTION
A follow-up after https://github.com/trezor/trezor-suite/pull/12494

enumerating transport api should never require exclusive access by a single client, so no locks should be in place. 
