### PR TITLE
fix(suite-native): fix initial selection of portfolio tracker device

### DIFF
--- a/suite-native/device/src/middlewares/deviceMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceMiddleware.ts
@@ -12,6 +12,7 @@ import {
     selectDeviceThunk,
     selectAccountsByDeviceState,
     createDeviceInstanceThunk,
+    createImportedDeviceThunk,
 } from '@suite-common/wallet-core';
 import { FeatureFlag, selectIsFeatureFlagEnabled } from '@suite-native/feature-flags';
 import { clearAndUnlockDeviceAccessQueue } from '@suite-native/device-mutex';
@@ -46,7 +47,12 @@ export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps(
          expect that the state was already changed by the action stored in the `action` variable. */
         next(action);
 
-        if (createDeviceInstanceThunk.fulfilled.match(action)) {
+        if (
+            isAnyOf(
+                createDeviceInstanceThunk.fulfilled,
+                createImportedDeviceThunk.fulfilled,
+            )(action)
+        ) {
             dispatch(selectDeviceThunk({ device: action.payload.device }));
         }
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
On first run of the app, Wallet Switcher is empty.

This bug is only in develop, not released on production.

Portfolio device is not yet created on initial run of the app when initDevices() is called from initActions. Creating imported device before dispatching initDevices would have to be blocking and so prolonging initial loading of the app. That is why the device is selected later from the middleware.

## Screenshots:
fixing this:
![Screenshot_2024-06-18-11-03-10-837_io trezor suite debug (1)](https://github.com/trezor/trezor-suite/assets/3729633/d5afaae3-9972-4f31-a9a3-9ddce3852519)

