### PR TITLE
Reintroduce FW update analytics

### DIFF
--- a/packages/suite-analytics/src/types/events.ts
+++ b/packages/suite-analytics/src/types/events.ts
@@ -75,6 +75,7 @@ export type SuiteAnalyticsEvent =
     | {
           type: EventType.DeviceUpdateFirmware;
           payload: {
+              model: string;
               fromBlVersion: string;
               fromFwVersion: string;
               toFwVersion?: string;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
We accidentally removed the event in 24.5 (b440aee81e59121f1847dadfbb474e7c14108f30). This PR puts it back and adds the requested `model` property. [Notion](https://www.notion.so/satoshilabs/Data-Analytics-938aeb2e289f4ca18f31b1c02ab782cb) updated.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/11302
