### PR TITLE
fix(connect): don't save state with legacy passphrase

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -462,6 +462,12 @@ export class Device extends TypedEmitter<DeviceEvents> {
             delete this.internalState[this.instance];
         } else if (state !== this.internalState[this.instance]) {
             this.internalState[this.instance] = state;
+
+            if (this.useLegacyPassphrase() && this.isT1()) {
+                // T1B1 fw lower than 1.9.0, passphrase is in plain text, don't save it
+                return;
+            }
+
             this.emit(DEVICE.SAVE_STATE, state);
         }
     }


### PR DESCRIPTION
## Description

As @szymonlesisz alerted me, T1 with firmware <1.9.0 saves the passphrase in internal state. 
We don't want that to end up in plaintext in localStorage, so this adds a check for legacy T1 before saving.