### PR TITLE
chore(suite): remove arrow from all tooltips

### DIFF
--- a/packages/components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.tsx
@@ -78,7 +78,7 @@ export const Tooltip = ({
     className,
     isFullWidth = false,
     isOpen,
-    hasArrow = true,
+    hasArrow,
     appendTo,
     shift,
     zIndex = zIndices.tooltip,

--- a/packages/suite/src/views/onboarding/steps/SelectBackupType/OptionWithContent.tsx
+++ b/packages/suite/src/views/onboarding/steps/SelectBackupType/OptionWithContent.tsx
@@ -184,11 +184,5 @@ export const OptionWithContent = ({
         </Option>
     );
 
-    return tooltip !== undefined ? (
-        <Tooltip hasArrow content={tooltip}>
-            {inner}
-        </Tooltip>
-    ) : (
-        inner
-    );
+    return tooltip !== undefined ? <Tooltip content={tooltip}>{inner}</Tooltip> : inner;
 };

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/EjectButton.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/EjectButton.tsx
@@ -31,7 +31,7 @@ export const EjectButton = ({ setContentType, dataTest }: EjectButtonProps) => {
 
     return (
         <EjectContainer $elevation={elevation}>
-            <Tooltip hasArrow cursor="pointer" content={<Translation id="TR_EJECT_HEADING" />}>
+            <Tooltip cursor="pointer" content={<Translation id="TR_EJECT_HEADING" />}>
                 <Icon
                     data-test={`${dataTest}/eject-button`}
                     icon="EJECT"

--- a/packages/suite/src/views/view-only/ViewOnlyTooltip.tsx
+++ b/packages/suite/src/views/view-only/ViewOnlyTooltip.tsx
@@ -35,7 +35,6 @@ export const ViewOnlyTooltip = ({ children }: ViewOnlyTooltipProps) => {
     return (
         <Tooltip
             isOpen={isViewOnlyModeVisible === true && viewOnlyTooltipClosed === false}
-            hasArrow
             shift={{ padding: { left: 10 } }}
             zIndex={zIndices.navigationBar}
             content={


### PR DESCRIPTION
## Description

Removed arrow from tooltips since it renders incorrectly.

## Related Issue

Related #12937

## Screenshots:
<img width="424" alt="Screenshot 2024-06-19 at 11 39 50 AM" src="https://github.com/trezor/trezor-suite/assets/66002635/d080bdc0-3cbf-4016-be21-e6a124b42710">