### PR TITLE
feat(suite-native): device switcher can scroll

### DIFF
--- a/suite-native/device-manager/src/components/DeviceManagerModal.tsx
+++ b/suite-native/device-manager/src/components/DeviceManagerModal.tsx
@@ -28,6 +28,7 @@ const deviceManagerModalWrapperStyle = prepareNativeStyle(utils => ({
     backgroundColor: utils.colors.backgroundSurfaceElevation0,
     borderBottomLeftRadius: MANAGER_MODAL_BOTTOM_RADIUS,
     borderBottomRightRadius: MANAGER_MODAL_BOTTOM_RADIUS,
+    maxHeight: '80%', // based on the design
 }));
 
 const deviceSwitchWrapperStyle = prepareNativeStyle<{ insets: EdgeInsets }>(


### PR DESCRIPTION
When user has too many wallets or devices, the content of device switcher detail starts scrolling


## Related Issue

Part of #12421 

## Screenshots:

https://github.com/trezor/trezor-suite/assets/2011829/681b7b1e-ec2e-41c6-aa6b-b072f56acef0

