### PR TITLE
fix(connect-explorer): load changelog dynamically on client

### DIFF
--- a/packages/connect-explorer/package.json
+++ b/packages/connect-explorer/package.json
@@ -31,7 +31,6 @@
         "codemirror-json5": "^1.0.3",
         "json5": "^2.2.3",
         "next": "^14.1.1",
-        "next-mdx-remote": "^4.4.1",
         "next-themes": "^0.2.1",
         "nextra": "^2.13.4",
         "nextra-theme-docs": "^2.13.4",
@@ -45,8 +44,9 @@
         "redux-logger": "^3.0.6",
         "redux-thunk": "^2.4.2",
         "remark-gemoji": "^8.0.0",
-        "remark-gfm": "^3.0.1",
-        "styled-components": "^6.1.8"
+        "remark-gfm": "^4.0.0",
+        "styled-components": "^6.1.8",
+        "swr": "^2.2.5"
     },
     "devDependencies": {
         "@types/redux-logger": "^3.0.11",

--- a/packages/connect-explorer/src/pages/changelog.mdx
+++ b/packages/connect-explorer/src/pages/changelog.mdx
@@ -2,19 +2,27 @@
 icon: LOG
 ---
 
-import { useData } from 'nextra/data';
-import { serialize } from 'next-mdx-remote/serialize';
-import { MDXRemote } from 'next-mdx-remote';
 import rehypeSectionize from '@hbsnow/rehype-sectionize';
 import remarkGfm from 'remark-gfm';
 import remarkGemoji from 'remark-gemoji';
+import useSWR from 'swr';
+import Markdown from 'react-markdown';
+import { useMDXComponents } from '@trezor/connect-explorer-theme';
+import { Callout } from 'nextra/components';
 
 import { spacings } from '@trezor/theme';
 import { CollapsibleBox } from '@trezor/components';
+import { isNewer } from '@trezor/utils/src/versionUtils';
 
-export const getStaticProps = ({ params }) => {
+export const loadNPMVersions = tag => {
+    return fetch(`https://registry.npmjs.org/@trezor/connect/${tag}`)
+        .then(res => res.json())
+        .then(data => data.version);
+};
+
+export const loadChangelog = branch => {
     return fetch(
-        `https://raw.githubusercontent.com/trezor/trezor-suite/${process.env.COMMIT_HASH}/packages/connect/CHANGELOG.md`,
+        `https://raw.githubusercontent.com/trezor/trezor-suite/${branch}/packages/connect/CHANGELOG.md`,
     )
         .then(res => res.text())
         .then(content => {
@@ -25,58 +33,75 @@ export const getStaticProps = ({ params }) => {
                 /([a-f0-9]{7,10})([\),])/g,
                 `[\$1](https://github.com/trezor/trezor-suite/commit/\$1)$2`,
             );
-            const versionOverviewContent = content.substring(0, content.indexOf('##'));
-            const changelogContent = content.substring(content.indexOf('##'));
+            const versionOverview =  `## Version overview\n\n` + content.substring(0, content.indexOf('##'));
+            const changelog = content.substring(content.indexOf('##'));
 
-            return [`## Version overview\n\n` + versionOverviewContent, changelogContent];
-        })
-        .then(content => Promise.all(content.map(it=>serialize(it, {
-            mdxOptions: {
-                remarkPlugins: [remarkGfm, remarkGemoji],
-                rehypePlugins: [[rehypeSectionize]],
-            },
-        }))))
-        .then(([versionOverview, changelog]) => ({
-            props: {
-                ssg: {
-                    versionOverview,
-                    changelog,
-                },
-            },
-        }));
+            return { versionOverview, changelog };
+        });
 
 };
 
-export const VersionOverview = () => {
-    const data = useData();
-    const { versionOverview } = data;
+export const loadData = async () => {
+    const [latest, beta] = await Promise.all([
+        loadNPMVersions('latest'),
+        loadNPMVersions('beta'),
+    ]);
+    const isBetaNewer = isNewer(beta.split('-')[0], latest);
+    const newestVersion = isBetaNewer ? beta : latest;
+
+    return loadChangelog(`release/connect/${newestVersion}`);
+
+};
+
+export const MarkdownCustom = ({ children }) => {
+    const components = useMDXComponents();
 
     return (
-        <MDXRemote {...versionOverview} />
+        <Markdown
+            components={components}
+            remarkPlugins={[remarkGfm, remarkGemoji]}
+            rehypePlugins={[rehypeSectionize]}
+        >
+            {children}
+        </Markdown>
     );
 
 };
 
 export const Changelog = () => {
-    const data = useData();
-    const { changelog } = data;
+    const { data, error } = useSWR("changelog", loadData);
+    
+    if (!data) return <>Loading...</>;
+    if (error) return <Callout>
+        <MarkdownCustom>An error occurred while loading the changelog. Please [view it on GitHub](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/CHANGELOG.md).</MarkdownCustom>
+    </Callout>;
+    
+    const { changelog, versionOverview } = data;
 
     return (
-        <MDXRemote {...changelog} />
+        <>
+            <MarkdownCustom>{versionOverview}</MarkdownCustom>
+
+            <CollapsibleBox heading="What is a Canary Release?" margin={{ top: spacings.md }}>
+                <MarkdownCustom>
+                    Canary releases are beta versions available before the stable release. They provide early access to new features, improvements, and (hot)fixes, allowing developers to test their applications with the latest changes. Unlike stable versions, which are extensively tested and released less frequently, canary versions are released more often to address immediate needs, such as critical fixes or compatibility updates required by specific third-party applications or implementations.
+                </MarkdownCustom>
+
+                <MarkdownCustom>
+                    ### Why Use Canary Releases?
+                </MarkdownCustom>
+                <MarkdownCustom>
+                    *Immediate fixes*: If your application encounters a critical issue with the current stable release, a canary version might already have the necessary fix, allowing you to resolve problems more quickly.
+                </MarkdownCustom>
+                <MarkdownCustom>
+                    *Feedback Opportunity*: Using canary releases allows you to provide feedback on new features and fixes, influencing the final stable release and ensuring it works smoothly with your application. If you encounter any issue, bug, or incompatibility introduced in a Canary release, report it by creating [a new issue in our repository](https://github.com/trezor/trezor-suite/issues/new/choose).
+                </MarkdownCustom>
+            </CollapsibleBox>
+
+            <MarkdownCustom>{changelog}</MarkdownCustom>
+        </>
     );
 
 };
-
-<VersionOverview />
-
-<CollapsibleBox heading="What is a Canary Release?" margin={{ top: spacings.md }}>
-    Canary releases are beta versions available before the stable release. They provide early access to new features, improvements, and (hot)fixes, allowing developers to test their applications with the latest changes. Unlike stable versions, which are extensively tested and released less frequently, canary versions are released more often to address immediate needs, such as critical fixes or compatibility updates required by specific third-party applications or implementations.
-
-    ### Why Use Canary Releases?
-    *Immediate fixes*: If your application encounters a critical issue with the current stable release, a canary version might already have the necessary fix, allowing you to resolve problems more quickly.
-
-    *Feedback Opportunity*: Using canary releases allows you to provide feedback on new features and fixes, influencing the final stable release and ensuring it works smoothly with your application. If you encounter any issue, bug, or incompatibility introduced in a Canary release, report it by creating [a new issue in our repository](https://github.com/trezor/trezor-suite/issues/new/choose).
-
-</CollapsibleBox>
 
 <Changelog />

--- a/packages/connect-explorer/src/pages/index.mdx
+++ b/packages/connect-explorer/src/pages/index.mdx
@@ -392,7 +392,7 @@ export const ExampleHeading = styled.h3`
                     },
                 ```
 
-                For manual content script injection, you can [find more information in the README](https://github.com/trezor/trezor-suite/tree/develop/packages/connect-webextension).
+                For manual content script injection, you can [find more information in the README](/readme/connect-webextension).
 
                 ### Import in the service worker
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10608,7 +10608,6 @@ __metadata:
     html-webpack-plugin: "npm:^5.6.0"
     json5: "npm:^2.2.3"
     next: "npm:^14.1.1"
-    next-mdx-remote: "npm:^4.4.1"
     next-themes: "npm:^0.2.1"
     nextra: "npm:^2.13.4"
     nextra-theme-docs: "npm:^2.13.4"
@@ -10622,9 +10621,10 @@ __metadata:
     redux-logger: "npm:^3.0.6"
     redux-thunk: "npm:^2.4.2"
     remark-gemoji: "npm:^8.0.0"
-    remark-gfm: "npm:^3.0.1"
+    remark-gfm: "npm:^4.0.0"
     rimraf: "npm:^5.0.5"
     styled-components: "npm:^6.1.8"
+    swr: "npm:^2.2.5"
     tsx: "npm:^4.7.1"
     webpack: "npm:^5.90.1"
     webpack-cli: "npm:^5.1.4"
@@ -28577,6 +28577,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mdast-util-gfm-autolink-literal@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mdast-util-gfm-autolink-literal@npm:2.0.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    ccount: "npm:^2.0.0"
+    devlop: "npm:^1.0.0"
+    mdast-util-find-and-replace: "npm:^3.0.0"
+    micromark-util-character: "npm:^2.0.0"
+  checksum: 10/08656ea3a5b53376a3a09082c7017e4887c1dde00b2c21aee68440d47d9151485347745db49cc05138ce3b6b7760d9700362212685a3644a170344dc4330b696
+  languageName: node
+  linkType: hard
+
 "mdast-util-gfm-footnote@npm:^1.0.0":
   version: 1.0.2
   resolution: "mdast-util-gfm-footnote@npm:1.0.2"
@@ -28588,6 +28601,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mdast-util-gfm-footnote@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mdast-util-gfm-footnote@npm:2.0.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    devlop: "npm:^1.1.0"
+    mdast-util-from-markdown: "npm:^2.0.0"
+    mdast-util-to-markdown: "npm:^2.0.0"
+    micromark-util-normalize-identifier: "npm:^2.0.0"
+  checksum: 10/9a820ce66575f1dc5bcc1e3269f27777a96f462f84651e72a74319d313f8fe4043fe329169bcc80ec2f210dabb84c832c77fa386ab9b4d23c31379d9bf0f8ff6
+  languageName: node
+  linkType: hard
+
 "mdast-util-gfm-strikethrough@npm:^1.0.0":
   version: 1.0.3
   resolution: "mdast-util-gfm-strikethrough@npm:1.0.3"
@@ -28595,6 +28621,17 @@ __metadata:
     "@types/mdast": "npm:^3.0.0"
     mdast-util-to-markdown: "npm:^1.3.0"
   checksum: 10/a9c2dc3ef46be7952d13b7063a16171bba8aa266bffe6b1e7267df02a60b4fa3734115cca311e9127db8cfcbbcd68fdd92aa26152bcd0c14372c79b254e4df2f
+  languageName: node
+  linkType: hard
+
+"mdast-util-gfm-strikethrough@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mdast-util-gfm-strikethrough@npm:2.0.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    mdast-util-from-markdown: "npm:^2.0.0"
+    mdast-util-to-markdown: "npm:^2.0.0"
+  checksum: 10/b1abc137d78270540585ad94a7a4ed1630683312690b902389dae0ede50a6832e26d1be053687f49728e14fa8a379da9384342725d3beb4480fc30b12866ab37
   languageName: node
   linkType: hard
 
@@ -28610,6 +28647,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mdast-util-gfm-table@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mdast-util-gfm-table@npm:2.0.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    devlop: "npm:^1.0.0"
+    markdown-table: "npm:^3.0.0"
+    mdast-util-from-markdown: "npm:^2.0.0"
+    mdast-util-to-markdown: "npm:^2.0.0"
+  checksum: 10/a043d60d723a86f79c49cbdd1d98b80c89f4a8f9f5fa84b3880c53e132f40150972460aba9be1f44a612ef5abd6810d122c5e7e5d9c54f3ac7560cce8c305c75
+  languageName: node
+  linkType: hard
+
 "mdast-util-gfm-task-list-item@npm:^1.0.0":
   version: 1.0.2
   resolution: "mdast-util-gfm-task-list-item@npm:1.0.2"
@@ -28617,6 +28667,18 @@ __metadata:
     "@types/mdast": "npm:^3.0.0"
     mdast-util-to-markdown: "npm:^1.3.0"
   checksum: 10/958417a7d7690728b44d65127ab9189c7feaa17aea924dd56a888c781ab3abaa4eb0c209f05c4dbf203da3d0c4df8fdace4c9471b644268bfc7fc792a018a171
+  languageName: node
+  linkType: hard
+
+"mdast-util-gfm-task-list-item@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mdast-util-gfm-task-list-item@npm:2.0.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    devlop: "npm:^1.0.0"
+    mdast-util-from-markdown: "npm:^2.0.0"
+    mdast-util-to-markdown: "npm:^2.0.0"
+  checksum: 10/679a3ff09b52015c0088cd0616ccecc7cc9d250d56a8762aafdffc640f3f607bbd9fe047d3e7e7078e6a996e83f677be3bfcad7ac7260563825fa80a04f8e09d
   languageName: node
   linkType: hard
 
@@ -28632,6 +28694,21 @@ __metadata:
     mdast-util-gfm-task-list-item: "npm:^1.0.0"
     mdast-util-to-markdown: "npm:^1.0.0"
   checksum: 10/70e6cd32af94181d409f171f984f83fc18b3efe316844c62f31816f5c1612a92517b8ed766340f23e0a6d6cb0f27a8b07d288bab6619cbdbb0c5341006bcdc4d
+  languageName: node
+  linkType: hard
+
+"mdast-util-gfm@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "mdast-util-gfm@npm:3.0.0"
+  dependencies:
+    mdast-util-from-markdown: "npm:^2.0.0"
+    mdast-util-gfm-autolink-literal: "npm:^2.0.0"
+    mdast-util-gfm-footnote: "npm:^2.0.0"
+    mdast-util-gfm-strikethrough: "npm:^2.0.0"
+    mdast-util-gfm-table: "npm:^2.0.0"
+    mdast-util-gfm-task-list-item: "npm:^2.0.0"
+    mdast-util-to-markdown: "npm:^2.0.0"
+  checksum: 10/3e0c8e9982d3df6e9235d862cb4a2a02cf54d11e9e65f9d139d217e9b7973bb49ef4b8ee49ec05d29bdd9fe3e5f7efe1c3ebdf40a950e9f553dfc25235ebbcc2
   languageName: node
   linkType: hard
 
@@ -29372,6 +29449,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"micromark-extension-gfm-autolink-literal@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "micromark-extension-gfm-autolink-literal@npm:2.0.0"
+  dependencies:
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-sanitize-uri: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10/77a3a3563ab2ffcf44c774a3f0ddcc1662d664e53ff2f42a528fb53564e9307331b35d01e7942a027198eb2e958cc2825cac96e87d6c4de301f535cfcaea0dc4
+  languageName: node
+  linkType: hard
+
 "micromark-extension-gfm-footnote@npm:^1.0.0":
   version: 1.1.2
   resolution: "micromark-extension-gfm-footnote@npm:1.1.2"
@@ -29385,6 +29474,22 @@ __metadata:
     micromark-util-types: "npm:^1.0.0"
     uvu: "npm:^0.5.0"
   checksum: 10/8777073fb76d2fd01f6b2405106af6c349c1e25660c4d37cadcc61c187d71c8444870f73cefaaa67f12884d5e45c78ee3c5583561a0b330bd91c6d997113584a
+  languageName: node
+  linkType: hard
+
+"micromark-extension-gfm-footnote@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "micromark-extension-gfm-footnote@npm:2.0.0"
+  dependencies:
+    devlop: "npm:^1.0.0"
+    micromark-core-commonmark: "npm:^2.0.0"
+    micromark-factory-space: "npm:^2.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-normalize-identifier: "npm:^2.0.0"
+    micromark-util-sanitize-uri: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10/7813d226b862f84d417ff890f263961c1fdceaf4b02d543bf754e21b46b834bf524962acc9bb058af26edc65c838c194735fd858079c6340a0f217d031e0932d
   languageName: node
   linkType: hard
 
@@ -29402,6 +29507,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"micromark-extension-gfm-strikethrough@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "micromark-extension-gfm-strikethrough@npm:2.0.0"
+  dependencies:
+    devlop: "npm:^1.0.0"
+    micromark-util-chunked: "npm:^2.0.0"
+    micromark-util-classify-character: "npm:^2.0.0"
+    micromark-util-resolve-all: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10/a06470195c55c20e6c8f4ecf0208ff3b58e1e4d530b1f377a9eaad857722b891a74aacb6dbc9755716282a1807d6acb6bb1e6e92295b7cef9060ab172d4abbed
+  languageName: node
+  linkType: hard
+
 "micromark-extension-gfm-table@npm:^1.0.0":
   version: 1.0.7
   resolution: "micromark-extension-gfm-table@npm:1.0.7"
@@ -29415,12 +29534,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"micromark-extension-gfm-table@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "micromark-extension-gfm-table@npm:2.0.0"
+  dependencies:
+    devlop: "npm:^1.0.0"
+    micromark-factory-space: "npm:^2.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10/3fbdf52ba8c9d0fa2dddab2f6a669e4386ea58ff6b979de16e6d1ff4c055b7b933f138257326ee45b2b14c8319b7cdb264a9bb77330caccae176765c8a488fd0
+  languageName: node
+  linkType: hard
+
 "micromark-extension-gfm-tagfilter@npm:^1.0.0":
   version: 1.0.2
   resolution: "micromark-extension-gfm-tagfilter@npm:1.0.2"
   dependencies:
     micromark-util-types: "npm:^1.0.0"
   checksum: 10/55c7d9019d6a39efaaed2c2e40b0aaa137d2c4f9c94cac82e93f509a806c3a775e4c815b5d8e986617450b68861a19776e4b886307e83db452b393f15a837b39
+  languageName: node
+  linkType: hard
+
+"micromark-extension-gfm-tagfilter@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "micromark-extension-gfm-tagfilter@npm:2.0.0"
+  dependencies:
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10/c5e3f8cdf22e184de3f55968e6b010876a100dff31f509b7d2975f2b981a7fdda6c2d9e452238b9fe54dc51f5d7b069e86de509d421d4efbdfc9194749b3f132
   languageName: node
   linkType: hard
 
@@ -29437,6 +29578,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"micromark-extension-gfm-task-list-item@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-extension-gfm-task-list-item@npm:2.0.1"
+  dependencies:
+    devlop: "npm:^1.0.0"
+    micromark-factory-space: "npm:^2.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10/aa448eeac58e031ff863bcf40475a531c07cff10a127d77cd09ebce76922a329e1908091430102a253fc0fd79345f31273ee6a2b5a71344e4c400f532efb9472
+  languageName: node
+  linkType: hard
+
 "micromark-extension-gfm@npm:^2.0.0":
   version: 2.0.3
   resolution: "micromark-extension-gfm@npm:2.0.3"
@@ -29450,6 +29604,22 @@ __metadata:
     micromark-util-combine-extensions: "npm:^1.0.0"
     micromark-util-types: "npm:^1.0.0"
   checksum: 10/3ffd06ced4314abd0f0c72ec227f034f38dd47facbb62439ef3216d42f32433f3901d14675cf806e8d73689802a11849958b330bb5b55dd4fd5cdc64ebaf345c
+  languageName: node
+  linkType: hard
+
+"micromark-extension-gfm@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "micromark-extension-gfm@npm:3.0.0"
+  dependencies:
+    micromark-extension-gfm-autolink-literal: "npm:^2.0.0"
+    micromark-extension-gfm-footnote: "npm:^2.0.0"
+    micromark-extension-gfm-strikethrough: "npm:^2.0.0"
+    micromark-extension-gfm-table: "npm:^2.0.0"
+    micromark-extension-gfm-tagfilter: "npm:^2.0.0"
+    micromark-extension-gfm-task-list-item: "npm:^2.0.0"
+    micromark-util-combine-extensions: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10/8493d1041756bf21f9421fa6d357056bff6112aeccebc20595604686cdd908a6816765de297206457ae4c00f85fc58672bdbcbbc36820c25d561b1737af89055
   languageName: node
   linkType: hard
 
@@ -30815,7 +30985,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next-mdx-remote@npm:^4.2.1, next-mdx-remote@npm:^4.4.1":
+"next-mdx-remote@npm:^4.2.1":
   version: 4.4.1
   resolution: "next-mdx-remote@npm:4.4.1"
   dependencies:
@@ -35332,6 +35502,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"remark-gfm@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "remark-gfm@npm:4.0.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    mdast-util-gfm: "npm:^3.0.0"
+    micromark-extension-gfm: "npm:^3.0.0"
+    remark-parse: "npm:^11.0.0"
+    remark-stringify: "npm:^11.0.0"
+    unified: "npm:^11.0.0"
+  checksum: 10/9f7b17aae0e9dc79ba9c989c2a679baff7161e1831a87307cfa2e0e9b0c492bd8c1900cdf7305855b898a2a9fab9aa8e586d71ce49cbc1ea90f68b714c249c0d
+  languageName: node
+  linkType: hard
+
 "remark-math@npm:^5.1.1":
   version: 5.1.1
   resolution: "remark-math@npm:5.1.1"
@@ -38140,6 +38324,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"swr@npm:^2.2.5":
+  version: 2.2.5
+  resolution: "swr@npm:2.2.5"
+  dependencies:
+    client-only: "npm:^0.0.1"
+    use-sync-external-store: "npm:^1.2.0"
+  peerDependencies:
+    react: ^16.11.0 || ^17.0.0 || ^18.0.0
+  checksum: 10/f02b3bd5a198a0f62f9a53d7c0528c4a58aa61a43310bea169614b6e873dadb52599e856ef0775405b6aa7409835343da0cf328948aa892aa309bf4b7e7d6902
+  languageName: node
+  linkType: hard
+
 "symbol-observable@npm:^2.0.3":
   version: 2.0.3
   resolution: "symbol-observable@npm:2.0.3"
@@ -40077,12 +40273,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-sync-external-store@npm:^1.0.0":
-  version: 1.2.0
-  resolution: "use-sync-external-store@npm:1.2.0"
+"use-sync-external-store@npm:^1.0.0, use-sync-external-store@npm:^1.2.0":
+  version: 1.2.2
+  resolution: "use-sync-external-store@npm:1.2.2"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 10/a676216affc203876bd47981103f201f28c2731361bb186367e12d287a7566763213a8816910c6eb88265eccd4c230426eb783d64c373c4a180905be8820ed8e
+  checksum: 10/671e9c190aab9a8374a5d468c6ba17f52c38b6fae970110bc196fc1e2b57204149aea9619be49a1bb5207fb6e51d8afd19c3bcb94afe61813fed039821461dc0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Loads the latest changelog from Github on the client instead of statically during build. 
Before loading the changelog itself, we also get the latest versions on NPM, to find the latest release branch (beta or prod). This ensures we always show the latest changelog. 

The tradeoff is that it's not loaded instantly and not indexed by search engines, however continually updating it via CI would be more complicated.

Preview: https://dev.suite.sldev.cz/connect/fix/connect-explorer-load-changelog-dynamically/changelog/