### PR TITLE
Feat/group pending transactions by date

### DIFF
--- a/packages/suite-web/e2e/tests/wallet/pending-transactions.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/pending-transactions.test.ts
@@ -55,16 +55,16 @@ describe('Use regtest to test pending transactions', () => {
             cy.task('pressYes');
             cy.getTestElement('@modal/send').click();
 
-            cy.getTestElement('@wallet/accounts/transaction-list/group/0').within(() => {
+            cy.getTestElement('@wallet/accounts/transaction-list/pending/group/0').within(() => {
                 // pre-pending is immediately created and placed in "pending transactions group"
                 cy.getTestElement('@transaction-item/0/prepending/heading');
                 // however, after a while it is replaced by a standard pending transaction
                 cy.getTestElement(`@transaction-item/0/heading`, { timeout: 60000 }).click({
                     scrollBehavior: 'bottom',
                 });
-                // count has not changed
-                cy.getTestElement('@transaction-group/pending/count').contains(index + 1);
             });
+            // count has not changed
+            cy.getTestElement('@transaction-group/pending/count').contains(index + 1);
             cy.getTestElement('@tx-detail/txid-value').then($el => {
                 cy.task('set', { key: address, value: $el.attr('id') });
             });
@@ -73,20 +73,20 @@ describe('Use regtest to test pending transactions', () => {
         });
 
         // account 1 has 2 pending transactions (self and sent)
-        cy.getTestElement('@wallet/accounts/transaction-list/group/0').within(() => {
+        cy.getTestElement('@wallet/accounts/transaction-list/pending/group/0').within(() => {
             cy.getTestElement('@transaction-item/0/heading').contains('Sending REGTEST');
             cy.getTestElement('@transaction-item/1/heading').contains('Sending REGTEST to myself');
         });
 
         // account 2 has 1 pending transaction (receive)
         cy.getTestElement('@account-menu/regtest/normal/1').click();
-        cy.getTestElement('@wallet/accounts/transaction-list/group/0').within(() => {
+        cy.getTestElement('@wallet/accounts/transaction-list/pending/group/0').within(() => {
             cy.getTestElement('@transaction-item/0/heading').contains('Receiving REGTEST');
         });
 
         // while observing account 1, sent transaction is mined
         cy.getTestElement('@account-menu/regtest/normal/0').click();
-        cy.getTestElement('@wallet/accounts/transaction-list/group/0').within(() => {
+        cy.getTestElement('@wallet/accounts/transaction-list/pending/group/0').within(() => {
             cy.getTestElement('@transaction-item/0/heading').contains('Sending REGTEST');
             cy.getTestElement('@transaction-item/1/heading').contains('Sending REGTEST to myself');
         });
@@ -98,7 +98,7 @@ describe('Use regtest to test pending transactions', () => {
         });
         cy.wait(2000); // wait for potential notification about mined txs
         // nothing has changed
-        cy.getTestElement('@wallet/accounts/transaction-list/group/0').within(() => {
+        cy.getTestElement('@wallet/accounts/transaction-list/pending/group/0').within(() => {
             cy.getTestElement('@transaction-item/0/heading').contains('Sending REGTEST');
             cy.getTestElement('@transaction-item/1/heading').contains('Sending REGTEST to myself');
         });
@@ -114,18 +114,18 @@ describe('Use regtest to test pending transactions', () => {
             });
         });
         // which causes sent transaction to disappear, self transaction stays
-        cy.getTestElement('@wallet/accounts/transaction-list/group/0').within(() => {
+        cy.getTestElement('@wallet/accounts/transaction-list/pending/group/0').within(() => {
             cy.getTestElement('@transaction-item/0/heading').contains('Sending REGTEST to myself');
-            cy.getTestElement('@transaction-group/pending/count').contains(1);
         });
+        cy.getTestElement('@transaction-group/pending/count').contains(1);
         // and new group of transactions appears with the previously pending transaction now confirmed
-        cy.getTestElement('@wallet/accounts/transaction-list/group/1').within(() => {
+        cy.getTestElement('@wallet/accounts/transaction-list/confirmed/group/0').within(() => {
             cy.getTestElement('@transaction-item/0/heading').contains('Sent REGTEST');
         });
 
         // receive pending transaction on account2 is now mined as well
         cy.getTestElement('@account-menu/regtest/normal/1').click();
-        cy.getTestElement('@wallet/accounts/transaction-list/group/0').within(() => {
+        cy.getTestElement('@wallet/accounts/transaction-list/confirmed/group/0').within(() => {
             cy.getTestElement(`@transaction-item/0/heading`).contains('Received REGTEST');
         });
     });

--- a/packages/suite-web/e2e/tests/wallet/send-form-regtest.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/send-form-regtest.test.ts
@@ -94,7 +94,7 @@ describe('Send form for bitcoin', () => {
         cy.task('pressYes');
 
         cy.getTestElement('@modal/send').click();
-        cy.getTestElement('@wallet/accounts/transaction-list/group/0').should(
+        cy.getTestElement('@wallet/accounts/transaction-list/pending/group/0').should(
             'contain',
             'OP_RETURN (meow)',
         );

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionGroupedList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionGroupedList.tsx
@@ -1,0 +1,62 @@
+import {
+    getAccountNetwork,
+    GroupedTransactionsByDate,
+    groupJointTransactions,
+} from '@suite-common/wallet-utils';
+import { CoinjoinBatchItem } from 'src/components/wallet/TransactionItem/CoinjoinBatchItem';
+import { useSelector } from 'src/hooks/suite';
+import { Account, WalletAccountTransaction } from 'src/types/wallet';
+import { TransactionItem } from 'src/components/wallet/TransactionItem/TransactionItem';
+import { TransactionsGroup } from './TransactionsGroup/TransactionsGroup';
+import { selectLabelingDataForAccount } from 'src/reducers/suite/metadataReducer';
+import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
+
+interface TransactionGroupedListProps {
+    transactionGroups: GroupedTransactionsByDate;
+    symbol: WalletAccountTransaction['symbol'];
+    account: Account;
+    isPending: boolean;
+}
+
+export const TransactionGroupedList = ({
+    transactionGroups,
+    symbol,
+    account,
+    isPending,
+}: TransactionGroupedListProps) => {
+    const localCurrency = useSelector(selectLocalCurrency);
+    const accountMetadata = useSelector(state => selectLabelingDataForAccount(state, account.key));
+    const network = getAccountNetwork(account);
+
+    return Object.entries(transactionGroups).map(([dateKey, value], groupIndex) => (
+        <TransactionsGroup
+            key={dateKey}
+            dateKey={dateKey}
+            symbol={symbol}
+            transactions={value}
+            localCurrency={localCurrency}
+            index={groupIndex}
+        >
+            {groupJointTransactions(value).map((item, index) =>
+                item.type === 'joint-batch' ? (
+                    <CoinjoinBatchItem
+                        key={item.rounds[0].txid}
+                        transactions={item.rounds}
+                        isPending={isPending}
+                        localCurrency={localCurrency}
+                    />
+                ) : (
+                    <TransactionItem
+                        key={item.tx.txid}
+                        transaction={item.tx}
+                        isPending={isPending}
+                        accountMetadata={accountMetadata}
+                        accountKey={account.key}
+                        network={network!}
+                        index={index}
+                    />
+                ),
+            )}
+        </TransactionsGroup>
+    ));
+};

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionGroupedList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionGroupedList.tsx
@@ -35,6 +35,7 @@ export const TransactionGroupedList = ({
             symbol={symbol}
             transactions={value}
             localCurrency={localCurrency}
+            isPending={isPending}
             index={groupIndex}
         >
             {groupJointTransactions(value).map((item, index) =>

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/CommonComponents.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/CommonComponents.tsx
@@ -1,0 +1,47 @@
+import styled from 'styled-components';
+import { variables } from '@trezor/components';
+import { zIndices } from '@trezor/theme';
+import { HiddenPlaceholder } from 'src/components/suite';
+import { SUBPAGE_NAV_HEIGHT } from 'src/constants/suite/layout';
+
+export const HeaderWrapper = styled.div`
+    display: flex;
+    position: sticky;
+    background: ${({ theme }) => theme.backgroundSurfaceElevation0};
+    top: ${SUBPAGE_NAV_HEIGHT};
+    align-items: center;
+    justify-content: space-between;
+    flex: 1;
+    padding-top: 8px;
+    padding-bottom: 8px;
+    padding-right: 24px;
+    z-index: ${zIndices.secondaryStickyBar};
+`;
+
+export const Col = styled(HiddenPlaceholder)`
+    font-size: ${variables.FONT_SIZE.SMALL};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
+    font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
+`;
+
+export const ColDate = styled(Col)`
+    font-variant-numeric: tabular-nums;
+    flex: 1;
+`;
+
+export const ColPending = styled(Col)`
+    color: ${({ theme }) => theme.TYPE_ORANGE};
+    font-variant-numeric: tabular-nums;
+`;
+
+export const ColAmount = styled(Col)<{ $isVisible?: boolean }>`
+    padding-left: 16px;
+    text-align: right;
+    opacity: ${({ $isVisible }) => ($isVisible ? 1 : 0)};
+    transition: opacity 0.1s;
+`;
+
+export const ColFiat = styled(Col)`
+    padding-left: 16px;
+    text-align: right;
+`;

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/DayHeader.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/DayHeader.tsx
@@ -1,57 +1,10 @@
 import { FormattedDate } from 'react-intl';
-import styled from 'styled-components';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
-
-import { variables } from '@trezor/components';
-import { zIndices } from '@trezor/theme';
 import { useFormatters } from '@suite-common/formatters';
-import { parseTransactionDateKey, isTestnet } from '@suite-common/wallet-utils';
-
-import { Translation, HiddenPlaceholder, FormattedCryptoAmount } from 'src/components/suite';
+import { isTestnet, parseTransactionDateKey } from '@suite-common/wallet-utils';
+import { FormattedCryptoAmount, HiddenPlaceholder } from 'src/components/suite';
 import { Network } from 'src/types/wallet';
-import { SUBPAGE_NAV_HEIGHT } from 'src/constants/suite/layout';
-
-const Wrapper = styled.div`
-    display: flex;
-    position: sticky;
-    background: ${({ theme }) => theme.backgroundSurfaceElevation0};
-    top: ${SUBPAGE_NAV_HEIGHT};
-    align-items: center;
-    justify-content: space-between;
-    flex: 1;
-    padding-top: 8px;
-    padding-bottom: 8px;
-    padding-right: 24px;
-    z-index: ${zIndices.secondaryStickyBar};
-`;
-
-const Col = styled(HiddenPlaceholder)`
-    font-size: ${variables.FONT_SIZE.SMALL};
-    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
-    font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
-`;
-
-const ColDate = styled(Col)`
-    font-variant-numeric: tabular-nums;
-    flex: 1;
-`;
-
-const ColPending = styled(Col)`
-    color: ${({ theme }) => theme.TYPE_ORANGE};
-    font-variant-numeric: tabular-nums;
-`;
-
-const ColAmount = styled(Col)<{ $isVisible?: boolean }>`
-    padding-left: 16px;
-    text-align: right;
-    opacity: ${({ $isVisible }) => ($isVisible ? 1 : 0)};
-    transition: opacity 0.1s;
-`;
-
-const ColFiat = styled(Col)`
-    padding-left: 16px;
-    text-align: right;
-`;
+import { ColAmount, ColDate, ColFiat, HeaderWrapper } from './CommonComponents';
 
 interface DayHeaderProps {
     dateKey: string;
@@ -59,7 +12,6 @@ interface DayHeaderProps {
     totalAmount: BigNumber;
     totalFiatAmountPerDay: BigNumber;
     localCurrency: string;
-    txsCount?: number;
     isMissingFiatRates?: boolean;
     isHovered?: boolean;
 }
@@ -71,7 +23,6 @@ export const DayHeader = ({
     totalAmount,
     totalFiatAmountPerDay,
     localCurrency,
-    txsCount,
     isMissingFiatRates,
     isHovered,
 }: DayHeaderProps) => {
@@ -81,39 +32,30 @@ export const DayHeader = ({
     const showFiatValue = !isTestnet(symbol);
 
     return (
-        <Wrapper>
-            {dateKey === 'pending' ? (
-                <ColPending data-test="@transaction-group/pending/count">
-                    <Translation id="TR_PENDING_TX_HEADING" values={{ count: txsCount }} /> •{' '}
-                    {txsCount}
-                </ColPending>
-            ) : (
-                <>
-                    <ColDate>
-                        <FormattedDate
-                            value={parsedDate ?? undefined}
-                            day="numeric"
-                            month="long"
-                            year="numeric"
+        <HeaderWrapper>
+            <ColDate>
+                <FormattedDate
+                    value={parsedDate ?? undefined}
+                    day="numeric"
+                    month="long"
+                    year="numeric"
+                />
+            </ColDate>
+            <ColAmount $isVisible={isHovered}>
+                {totalAmount.gt(0) && <span>+</span>}
+                <FormattedCryptoAmount value={totalAmount.toFixed()} symbol={symbol} />
+            </ColAmount>
+            {showFiatValue && !isMissingFiatRates && (
+                <ColFiat>
+                    <HiddenPlaceholder>
+                        {totalFiatAmountPerDay.gt(0) && <span>+</span>}
+                        <FiatAmountFormatter
+                            currency={localCurrency}
+                            value={totalFiatAmountPerDay.toFixed()}
                         />
-                    </ColDate>
-                    <ColAmount $isVisible={isHovered}>
-                        {totalAmount.gt(0) && <span>+</span>}
-                        <FormattedCryptoAmount value={totalAmount.toFixed()} symbol={symbol} />
-                    </ColAmount>
-                    {showFiatValue && !isMissingFiatRates && (
-                        <ColFiat>
-                            <HiddenPlaceholder>
-                                {totalFiatAmountPerDay.gt(0) && <span>+</span>}
-                                <FiatAmountFormatter
-                                    currency={localCurrency}
-                                    value={totalFiatAmountPerDay.toFixed()}
-                                />
-                            </HiddenPlaceholder>
-                        </ColFiat>
-                    )}
-                </>
+                    </HiddenPlaceholder>
+                </ColFiat>
             )}
-        </Wrapper>
+        </HeaderWrapper>
     );
 };

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/DayHeader.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/DayHeader.tsx
@@ -16,7 +16,7 @@ interface DayHeaderProps {
     isHovered?: boolean;
 }
 
-// TODO: Do not show FEE for sent but not mine transactions
+// TODO: Do not show FEE for sent but not mined transactions
 export const DayHeader = ({
     dateKey,
     symbol,
@@ -31,15 +31,20 @@ export const DayHeader = ({
     const parsedDate = parseTransactionDateKey(dateKey);
     const showFiatValue = !isTestnet(symbol);
 
+    // blockTime can be undefined according to types, although I don't know when that happens.
+    const isDateValid = !isNaN(parsedDate.getTime());
+
     return (
         <HeaderWrapper>
             <ColDate>
-                <FormattedDate
-                    value={parsedDate ?? undefined}
-                    day="numeric"
-                    month="long"
-                    year="numeric"
-                />
+                {isDateValid && (
+                    <FormattedDate
+                        value={parsedDate ?? undefined}
+                        day="numeric"
+                        month="long"
+                        year="numeric"
+                    />
+                )}
             </ColDate>
             <ColAmount $isVisible={isHovered}>
                 {totalAmount.gt(0) && <span>+</span>}

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/PendingGroupHeader.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/PendingGroupHeader.tsx
@@ -1,0 +1,14 @@
+import { Translation } from 'src/components/suite';
+import { ColPending, HeaderWrapper } from './CommonComponents';
+
+type PendingGroupHeaderProps = { txsCount: number };
+
+export const PendingGroupHeader = ({ txsCount }: PendingGroupHeaderProps) => {
+    return (
+        <HeaderWrapper>
+            <ColPending data-test="@transaction-group/pending/count">
+                <Translation id="TR_PENDING_TX_HEADING" values={{ count: txsCount }} /> • {txsCount}
+            </ColPending>
+        </HeaderWrapper>
+    );
+};

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/TransactionsGroup.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/TransactionsGroup.tsx
@@ -35,6 +35,7 @@ interface TransactionsGroupProps {
     symbol: Network['symbol'];
     localCurrency: FiatCurrencyCode;
     index: number;
+    isPending: boolean;
 }
 
 export const TransactionsGroup = ({
@@ -42,6 +43,7 @@ export const TransactionsGroup = ({
     symbol,
     transactions,
     localCurrency,
+    isPending,
     children,
     index,
     ...rest
@@ -88,7 +90,7 @@ export const TransactionsGroup = ({
         <TransactionsGroupWrapper
             key={dateKey}
             onMouseEnter={() => setIsHovered(true)}
-            data-test={`@wallet/accounts/transaction-list/group/${index}`}
+            data-test={`@wallet/accounts/transaction-list/${isPending ? 'pending' : 'confirmed'}/group/${index}`}
             onMouseLeave={() => setIsHovered(false)}
             {...rest}
         >

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/TransactionsGroup.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/TransactionsGroup.tsx
@@ -98,7 +98,6 @@ export const TransactionsGroup = ({
                 isHovered={isHovered}
                 totalAmount={totalAmountPerDay}
                 totalFiatAmountPerDay={totalFiatAmountPerDay}
-                txsCount={transactions.length}
                 localCurrency={localCurrency}
                 isMissingFiatRates={isMissingFiatRates}
             />

--- a/suite-common/wallet-utils/src/__tests__/transactionUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/transactionUtils.test.ts
@@ -52,7 +52,7 @@ describe('transaction utils', () => {
             getWalletTransaction({ blockHeight: 0, blockTime: undefined }),
         ]);
         expect(groupedTxs).toEqual({
-            pending: [
+            'no-blocktime': [
                 getWalletTransaction({ blockHeight: 0, blockTime: 0 }),
                 getWalletTransaction({ blockHeight: 0, blockTime: undefined }),
             ],
@@ -85,7 +85,7 @@ describe('transaction utils', () => {
         const firstMonth = generateTransactionMonthKey(new Date(firstBlocktime * 1000));
         const secondMonth = generateTransactionMonthKey(new Date(secondBlocktime * 1000));
         expect(groupedTxs).toEqual({
-            pending: [
+            'no-blocktime': [
                 getWalletTransaction({ blockHeight: 0, blockTime: 0 }),
                 getWalletTransaction({ blockHeight: 0, blockTime: undefined }),
             ],

--- a/suite-common/wallet-utils/src/__tests__/transactionUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/transactionUtils.test.ts
@@ -43,21 +43,23 @@ describe('transaction utils', () => {
 
     it('groupTransactionsByDate - groupBy day', () => {
         const groupedTxs = groupTransactionsByDate([
+            getWalletTransaction({ blockTime: 1565792979, blockHeight: undefined }),
             getWalletTransaction({ blockTime: 1565792979, blockHeight: 5 }),
             getWalletTransaction({ blockTime: 1565792379, blockHeight: 4 }),
-            getWalletTransaction({ blockHeight: 0 }),
+            getWalletTransaction({ blockHeight: 0, blockTime: 0 }),
             getWalletTransaction({ blockTime: 1570147200, blockHeight: 2 }),
             getWalletTransaction({ blockTime: 1570127200, blockHeight: 3 }),
-            getWalletTransaction({ blockHeight: undefined }),
+            getWalletTransaction({ blockHeight: 0, blockTime: undefined }),
         ]);
         expect(groupedTxs).toEqual({
             pending: [
-                getWalletTransaction({ blockHeight: 0 }),
-                getWalletTransaction({ blockHeight: undefined }),
+                getWalletTransaction({ blockHeight: 0, blockTime: 0 }),
+                getWalletTransaction({ blockHeight: 0, blockTime: undefined }),
             ],
             '2019-10-4': [getWalletTransaction({ blockTime: 1570147200, blockHeight: 2 })],
             '2019-10-3': [getWalletTransaction({ blockTime: 1570127200, blockHeight: 3 })],
             '2019-8-14': [
+                getWalletTransaction({ blockTime: 1565792979, blockHeight: undefined }),
                 getWalletTransaction({ blockTime: 1565792979, blockHeight: 5 }),
                 getWalletTransaction({ blockTime: 1565792379, blockHeight: 4 }),
             ],
@@ -67,12 +69,13 @@ describe('transaction utils', () => {
     it('groupTransactionsByDate - groupBy month', () => {
         const groupedTxs = groupTransactionsByDate(
             [
+                getWalletTransaction({ blockTime: 1565792979, blockHeight: undefined }),
                 getWalletTransaction({ blockTime: 1565792979, blockHeight: 5 }),
                 getWalletTransaction({ blockTime: 1565792379, blockHeight: 4 }),
-                getWalletTransaction({ blockHeight: 0 }),
+                getWalletTransaction({ blockHeight: 0, blockTime: 0 }),
                 getWalletTransaction({ blockTime: 1570147200, blockHeight: 2 }),
                 getWalletTransaction({ blockTime: 1570127200, blockHeight: 3 }),
-                getWalletTransaction({ blockHeight: undefined }),
+                getWalletTransaction({ blockHeight: 0, blockTime: undefined }),
             ],
             'month',
         );
@@ -83,14 +86,15 @@ describe('transaction utils', () => {
         const secondMonth = generateTransactionMonthKey(new Date(secondBlocktime * 1000));
         expect(groupedTxs).toEqual({
             pending: [
-                getWalletTransaction({ blockHeight: 0 }),
-                getWalletTransaction({ blockHeight: undefined }),
+                getWalletTransaction({ blockHeight: 0, blockTime: 0 }),
+                getWalletTransaction({ blockHeight: 0, blockTime: undefined }),
             ],
             [firstMonth]: [
                 getWalletTransaction({ blockTime: firstBlocktime, blockHeight: 3 }),
                 getWalletTransaction({ blockTime: 1570147200, blockHeight: 2 }),
             ],
             [secondMonth]: [
+                getWalletTransaction({ blockTime: secondBlocktime, blockHeight: undefined }),
                 getWalletTransaction({ blockTime: secondBlocktime, blockHeight: 5 }),
                 getWalletTransaction({ blockTime: 1565792379, blockHeight: 4 }),
             ],

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -79,7 +79,6 @@ export const parseTransactionMonthKey = (key: MonthKey): Date => new Date(key);
 export type GroupedTransactionsByDate = Record<string, WalletAccountTransaction[]>;
 /**
  * Returns object with transactions grouped by a date. Key is a string in YYYY-MM-DD format.
- * Pending txs are assigned to key 'pending'.
  *
  * @param {WalletAccountTransaction[]} transactions
  */
@@ -98,11 +97,11 @@ export const groupTransactionsByDate = (
             .filter(transaction => !!transaction)
             .sort(sortByBlockHeight)
             .reduce<GroupedTransactionsByDate>((r, item) => {
-                // pending txs are grouped as 'pending' only if blockTime is unavailable (otherwise sorted by blockTime)
+                // pending txs are grouped as 'no-blocktime' only if blockTime is unavailable (otherwise sorted by blockTime)
                 const key =
                     item.blockTime && item.blockTime > 0
                         ? keyFormatter(new Date(item.blockTime * 1000))
-                        : 'pending';
+                        : 'no-blocktime';
                 const prev = r[key] ?? [];
 
                 return {

--- a/suite-native/transactions/package.json
+++ b/suite-native/transactions/package.json
@@ -37,6 +37,7 @@
         "@trezor/blockchain-link-types": "workspace:*",
         "@trezor/styles": "workspace:*",
         "@trezor/theme": "workspace:*",
+        "@trezor/utils": "workspace:*",
         "proxy-memoize": "2.0.2",
         "react": "18.2.0",
         "react-native": "0.74.1",

--- a/suite-native/transactions/src/components/TransactionsList/TransactionList.tsx
+++ b/suite-native/transactions/src/components/TransactionsList/TransactionList.tsx
@@ -169,7 +169,7 @@ export const TransactionList = ({
         const [pendingTxs, confirmedTxs] = arrayPartition(transactions, isPending);
         const accountTransactionsByMonth = groupTransactionsByDate(confirmedTxs, 'month');
         accountTransactionsByMonth['pending'] = [
-            ...accountTransactionsByMonth['pending'],
+            ...accountTransactionsByMonth['no-blocktime'],
             ...pendingTxs,
         ];
         const transactionMonthKeys = Object.keys(accountTransactionsByMonth) as MonthKey[];

--- a/suite-native/transactions/src/components/TransactionsList/TransactionList.tsx
+++ b/suite-native/transactions/src/components/TransactionsList/TransactionList.tsx
@@ -168,10 +168,14 @@ export const TransactionList = ({
         // TODO: display pending transactions in the correct order
         const [pendingTxs, confirmedTxs] = arrayPartition(transactions, isPending);
         const accountTransactionsByMonth = groupTransactionsByDate(confirmedTxs, 'month');
-        accountTransactionsByMonth['pending'] = [
-            ...accountTransactionsByMonth['no-blocktime'],
-            ...pendingTxs,
-        ];
+        if (pendingTxs.length || accountTransactionsByMonth['no-blocktime']) {
+            accountTransactionsByMonth['pending'] = [
+                ...(accountTransactionsByMonth['no-blocktime'] ?? []),
+                ...pendingTxs,
+            ];
+            delete accountTransactionsByMonth['no-blocktime'];
+        }
+
         const transactionMonthKeys = Object.keys(accountTransactionsByMonth) as MonthKey[];
 
         if (tokenContract) {

--- a/suite-native/transactions/tsconfig.json
+++ b/suite-native/transactions/tsconfig.json
@@ -37,6 +37,7 @@
             "path": "../../packages/blockchain-link-types"
         },
         { "path": "../../packages/styles" },
-        { "path": "../../packages/theme" }
+        { "path": "../../packages/theme" },
+        { "path": "../../packages/utils" }
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10065,6 +10065,7 @@ __metadata:
     "@trezor/blockchain-link-types": "workspace:*"
     "@trezor/styles": "workspace:*"
     "@trezor/theme": "workspace:*"
+    "@trezor/utils": "workspace:*"
     proxy-memoize: "npm:2.0.2"
     react: "npm:18.2.0"
     react-native: "npm:0.74.1"


### PR DESCRIPTION
Group pending transactions by date. Otherwise, only time is displayed which is confusing when the transaction has been in a pending state for a long time.

![Screenshot 2024-06-20 at 17 17 08](https://github.com/trezor/trezor-suite/assets/42465546/8d668f43-50e4-4a14-9d82-fef843536502)

<img width="342" alt="image" src="https://github.com/user-attachments/assets/eb98ee43-99e6-4045-853a-958c6b81e243">

