### PR TITLE
fix(suite): passphrase missmatch resets the flow now

### DIFF
--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -156,8 +156,8 @@ export class TrezorConnectDynamicImpl implements ConnectFactoryDependencies {
         return this.getTarget().requestWebUSBDevice();
     }
 
-    public cancel() {
-        return this.getTarget().cancel();
+    public cancel(error?: string) {
+        return this.getTarget().cancel(error);
     }
 
     public dispose() {

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseModal.tsx
@@ -1,12 +1,11 @@
 import { useCallback, useState } from 'react';
 
 import { PassphraseTypeCard } from '@trezor/components';
-import TrezorConnect from '@trezor/connect';
 import {
     selectIsDiscoveryAuthConfirmationRequired,
     onPassphraseSubmit,
     selectDeviceModel,
-    deviceActions,
+    cancelPassphraseSelectionThunk,
 } from '@suite-common/wallet-core';
 import { useSelector, useDispatch } from 'src/hooks/suite';
 import { Translation } from 'src/components/suite';
@@ -17,7 +16,7 @@ import { CardWithDevice } from 'src/views/suite/SwitchDevice/CardWithDevice';
 import { PassphraseDescription } from './PassphraseDescription';
 import { PassphraseWalletConfirmation } from './PassphraseWalletConfirmation';
 import { PassphraseHeading } from './PassphraseHeading';
-import { selectSuiteSettings } from '../../../../../reducers/suite/suiteReducer';
+import TrezorConnect from '@trezor/connect';
 
 interface PassphraseModalProps {
     device: TrezorDevice;
@@ -30,7 +29,6 @@ export const PassphraseModal = ({ device }: PassphraseModalProps) => {
         useSelector(selectIsDiscoveryAuthConfirmationRequired) || device.authConfirm;
 
     const deviceModel = useSelector(selectDeviceModel);
-    const settings = useSelector(selectSuiteSettings);
 
     const stateConfirmation = !!device.state;
 
@@ -43,8 +41,7 @@ export const PassphraseModal = ({ device }: PassphraseModalProps) => {
     const dispatch = useDispatch();
 
     const onCancel = () => {
-        TrezorConnect.cancel('auth-confirm-cancel'); // This auth-confirm-cancel' causes the proper cleaning of the state in deviceThunks.authConfirm()
-        dispatch(deviceActions.forgetDevice({ device, settings }));
+        TrezorConnect.cancel('auth-confirm-cancel');
     };
 
     const onSubmit = useCallback(

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseModal.tsx
@@ -5,7 +5,6 @@ import {
     selectIsDiscoveryAuthConfirmationRequired,
     onPassphraseSubmit,
     selectDeviceModel,
-    cancelPassphraseSelectionThunk,
 } from '@suite-common/wallet-core';
 import { useSelector, useDispatch } from 'src/hooks/suite';
 import { Translation } from 'src/components/suite';

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletConfirmationStep1.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletConfirmationStep1.tsx
@@ -59,13 +59,7 @@ export const PassphraseWalletConfirmationStep1 = ({
                     <Text typographyStyle="highlight">
                         <Translation id="TR_PASSPHRASE_WALLET_CONFIRMATION_STEP1_OPEN_WITH_FUNDS_DESCRIPTION" />
                     </Text>
-                    <Button
-                        isFullWidth
-                        variant="tertiary"
-                        onClick={() => {
-                            onCancel();
-                        }}
-                    >
+                    <Button isFullWidth variant="tertiary" onClick={onCancel}>
                         <Translation id="TR_PASSPHRASE_WALLET_CONFIRMATION_STEP1_OPEN_WITH_FUNDS_BUTTON" />
                     </Button>
                 </Column>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PassphraseDuplicateModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PassphraseDuplicateModal.tsx
@@ -7,6 +7,7 @@ import { useDevice, useDispatch } from 'src/hooks/suite';
 import { TrezorDevice } from 'src/types/suite';
 import { SwitchDeviceRenderer } from 'src/views/suite/SwitchDevice/SwitchDeviceRenderer';
 import { CardWithDevice } from 'src/views/suite/SwitchDevice/CardWithDevice';
+
 type PassphraseDuplicateModalProps = {
     device: TrezorDevice;
     duplicate: TrezorDevice;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PassphraseMismatchModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PassphraseMismatchModal.tsx
@@ -1,4 +1,4 @@
-import { Button, H3, Text } from '@trezor/components';
+import { Button, H3, Column, Text } from '@trezor/components';
 
 import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 import { SwitchDeviceRenderer } from 'src/views/suite/SwitchDevice/SwitchDeviceRenderer';
@@ -27,12 +27,14 @@ export const PassphraseMismatchModal = ({ onCancel }: { onCancel: () => void }) 
     return (
         <SwitchDeviceRenderer isCancelable={false} data-test="@passphrase-mismatch">
             <CardWithDevice device={device} isCloseButtonVisible={false}>
-                <H3 margin={{ top: 12 }}>
-                    <Translation id="TR_PASSPHRASE_MISMATCH" />
-                </H3>
-                <Text color="textSubdued">
-                    <Translation id="TR_PASSPHRASE_MISMATCH_DESCRIPTION" />
-                </Text>
+                <Column gap={8} margin={{ bottom: 32 }} alignItems="center">
+                    <H3 margin={{ top: 12 }}>
+                        <Translation id="TR_PASSPHRASE_MISMATCH" />
+                    </H3>
+                    <Text variant="tertiary">
+                        <Translation id="TR_PASSPHRASE_MISMATCH_DESCRIPTION" />
+                    </Text>
+                </Column>
 
                 <Button
                     variant="primary"

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PassphraseMismatchModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PassphraseMismatchModal.tsx
@@ -1,0 +1,48 @@
+import { Button, H3, Text } from '@trezor/components';
+
+import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
+import { SwitchDeviceRenderer } from 'src/views/suite/SwitchDevice/SwitchDeviceRenderer';
+import { CardWithDevice } from 'src/views/suite/SwitchDevice/CardWithDevice';
+import { Translation } from '../../../Translation';
+import { selectSuiteSettings } from '../../../../../reducers/suite/suiteReducer';
+import { deviceActions } from '@suite-common/wallet-core';
+
+export const PassphraseMismatchModal = ({ onCancel }: { onCancel: () => void }) => {
+    const { isLocked, device } = useDevice();
+    const dispatch = useDispatch();
+    const settings = useSelector(selectSuiteSettings);
+
+    const isDeviceLocked = isLocked();
+
+    if (device === undefined) {
+        return null;
+    }
+
+    const onStartOver = () => {
+        dispatch(deviceActions.forgetDevice({ device, settings }));
+        dispatch(deviceActions.selectDevice(device));
+        onCancel();
+    };
+
+    return (
+        <SwitchDeviceRenderer isCancelable={false} data-test="@passphrase-mismatch">
+            <CardWithDevice device={device} isCloseButtonVisible={false}>
+                <H3 margin={{ top: 12 }}>
+                    <Translation id="TR_PASSPHRASE_MISMATCH" />
+                </H3>
+                <Text color="textSubdued">
+                    <Translation id="TR_PASSPHRASE_MISMATCH_DESCRIPTION" />
+                </Text>
+
+                <Button
+                    variant="primary"
+                    onClick={onStartOver}
+                    isDisabled={isDeviceLocked}
+                    isFullWidth
+                >
+                    <Translation id="TR_PASSPHRASE_MISMATCH_START_OVER" />
+                </Button>
+            </CardWithDevice>
+        </SwitchDeviceRenderer>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PassphraseMismatchModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PassphraseMismatchModal.tsx
@@ -1,16 +1,14 @@
 import { Button, H3, Column, Text } from '@trezor/components';
 
-import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
+import { useDevice, useDispatch } from 'src/hooks/suite';
 import { SwitchDeviceRenderer } from 'src/views/suite/SwitchDevice/SwitchDeviceRenderer';
 import { CardWithDevice } from 'src/views/suite/SwitchDevice/CardWithDevice';
 import { Translation } from '../../../Translation';
-import { selectSuiteSettings } from '../../../../../reducers/suite/suiteReducer';
-import { deviceActions } from '@suite-common/wallet-core';
+import { passwordMismatchResetThunk } from '@suite-common/wallet-core';
 
 export const PassphraseMismatchModal = ({ onCancel }: { onCancel: () => void }) => {
     const { isLocked, device } = useDevice();
     const dispatch = useDispatch();
-    const settings = useSelector(selectSuiteSettings);
 
     const isDeviceLocked = isLocked();
 
@@ -19,8 +17,7 @@ export const PassphraseMismatchModal = ({ onCancel }: { onCancel: () => void }) 
     }
 
     const onStartOver = () => {
-        dispatch(deviceActions.forgetDevice({ device, settings }));
-        dispatch(deviceActions.selectDevice(device));
+        dispatch(passwordMismatchResetThunk({ device }));
         onCancel();
     };
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
@@ -45,6 +45,7 @@ import { openXpubModal, showXpub } from 'src/actions/wallet/publicKeyActions';
 import type { ReduxModalProps } from '../ReduxModal';
 import { CryptoSymbol } from 'invity-api';
 import { EverstakeModal } from './UnstakeModal/EverstakeModal';
+import { PassphraseMismatchModal } from './PassphraseMismatchModal';
 
 /** Modals opened as a result of user action */
 export const UserContextModal = ({
@@ -221,6 +222,8 @@ export const UserContextModal = ({
             return <EverstakeModal onCancel={onCancel} />;
         case 'copy-contract-address':
             return <CopyContractAddressModal onCancel={onCancel} contract={payload.contract} />;
+        case 'passphrase-mismatch-warning':
+            return <PassphraseMismatchModal onCancel={onCancel} />;
         default:
             return null;
     }

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3363,6 +3363,18 @@ export default defineMessages({
         defaultMessage: 'Hidden wallet #{id}',
         id: 'TR_PASSPHRASE_WALLET',
     },
+    TR_PASSPHRASE_MISMATCH: {
+        defaultMessage: 'Passphrase mismatch',
+        id: 'TR_PASSPHRASE_MISMATCH',
+    },
+    TR_PASSPHRASE_MISMATCH_DESCRIPTION: {
+        defaultMessage: 'The passphrases didn’t match. For security, start from the beginning and re-enter them carefully.',
+        id: 'TR_PASSPHRASE_MISMATCH_DESCRIPTION',
+    },
+    TR_PASSPHRASE_MISMATCH_START_OVER: {
+        defaultMessage: 'Start over',
+        id: 'TR_PASSPHRASE_MISMATCH_START_OVER',
+    },
     TR_PENDING_TX_HEADING: {
         defaultMessage: 'Pending {count, plural, one {transaction} other {transactions}}',
         description: 'Heading for the list of pending transactions',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3368,7 +3368,8 @@ export default defineMessages({
         id: 'TR_PASSPHRASE_MISMATCH',
     },
     TR_PASSPHRASE_MISMATCH_DESCRIPTION: {
-        defaultMessage: 'The passphrases didn’t match. For security, start from the beginning and re-enter them carefully.',
+        defaultMessage:
+            'The passphrases didn’t match. For security, start from the beginning and re-enter them carefully.',
         id: 'TR_PASSPHRASE_MISMATCH_DESCRIPTION',
     },
     TR_PASSPHRASE_MISMATCH_START_OVER: {

--- a/suite-common/suite-types/src/device.ts
+++ b/suite-common/suite-types/src/device.ts
@@ -32,8 +32,10 @@ export interface ExtendedDevice {
     forceRemember?: true; // device was forced to be remembered
     connected: boolean; // device is connected
     available: boolean; // device cannot be used because of features.passphrase_protection is different then expected
+
     authConfirm?: boolean; // device cannot be used because passphrase was not confirmed
     authFailed?: boolean; // device cannot be used because authorization process failed
+
     instance?: number;
     ts: number;
     buttonRequests: ButtonRequest[];

--- a/suite-common/suite-types/src/modal.ts
+++ b/suite-common/suite-types/src/modal.ts
@@ -184,4 +184,7 @@ export type UserContextPayload =
     | {
           type: 'copy-contract-address';
           contract: string;
+      }
+    | {
+          type: 'passphrase-mismatch-warning';
       };

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -662,3 +662,15 @@ export const deviceConnectThunks = createThunk<void, DeviceConnectThunksParams, 
         dispatch(deviceConnectThunksMap[type]({ device, settings }));
     },
 );
+
+export const passwordMismatchResetThunk = createThunk<void, { device: TrezorDevice }, void>(
+    `${DEVICE_MODULE_PREFIX}/passwordMismatchResetThunk`,
+    ({ device }, { dispatch, getState, extra }) => {
+        const settings = extra.selectors.selectSuiteSettings(getState());
+
+        dispatch(deviceActions.forgetDevice({ device, settings }));
+
+        const newDevice = selectDeviceSelector(getState());
+        dispatch(deviceActions.selectDevice(newDevice));
+    },
+);

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -407,13 +407,12 @@ export const startDiscoveryThunk = createThunk(
                 await dispatch(initMetadata(false));
             }
 
-            dispatch({
-                type: startDiscovery.type,
-                payload: {
+            dispatch(
+                startDiscovery({
                     ...discovery,
                     status: DiscoveryStatus.RUNNING,
-                },
-            });
+                }),
+            );
         }
 
         let { availableCardanoDerivations } = discovery;
@@ -643,9 +642,8 @@ export const createDiscoveryThunk = createThunk(
         const enabledNetworks = selectEnabledNetworks(getState());
         const networks = filterUnavailableNetworks(enabledNetworks, device).map(n => n.symbol);
 
-        dispatch({
-            type: createDiscovery.type,
-            payload: {
+        dispatch(
+            createDiscovery({
                 deviceState,
                 authConfirm: !device.useEmptyPassphrase,
                 index: 0,
@@ -655,8 +653,8 @@ export const createDiscoveryThunk = createThunk(
                 loaded: 0,
                 failed: [],
                 networks,
-            },
-        });
+            }),
+        );
     },
 );
 


### PR DESCRIPTION
Addresses the weird behavior when user mismatches the passphrase. Now it resets the flow instead of being stucked in inconsistent state