### PR TITLE
feat(react-native-usb): request usb permission when app goes foreground

### DIFF
--- a/packages/react-native-usb/android/src/main/AndroidManifest.xml
+++ b/packages/react-native-usb/android/src/main/AndroidManifest.xml
@@ -17,5 +17,10 @@
                 <action android:name="android.hardware.usb.action.USB_DEVICE_DETACHED" />
             </intent-filter>
         </receiver>
+        <receiver android:name=".ReactNativeUsbPermissionReceiver" android:exported="false">
+            <intent-filter>
+                <action android:name="io.trezor.rnusb.USB_PERMISSION" />
+            </intent-filter>
+        </receiver>
     </application>
 </manifest>

--- a/packages/react-native-usb/android/src/main/java/io/trezor/rnusb/ReactNativeUsbPermissionReceiver.kt
+++ b/packages/react-native-usb/android/src/main/java/io/trezor/rnusb/ReactNativeUsbPermissionReceiver.kt
@@ -1,0 +1,39 @@
+package io.trezor.rnusb
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.hardware.usb.UsbManager
+import android.hardware.usb.UsbDevice
+import android.os.Build
+import android.util.Log
+
+typealias OnPermissionResolved = (Boolean, UsbDevice) -> Unit
+class ReactNativeUsbPermissionReceiver() : BroadcastReceiver() {
+
+    companion object {
+        private var onDevicePermissionCallback: OnPermissionResolved? = null
+
+        fun setOnDevicePermissionCallback(callback: OnPermissionResolved?) {
+            onDevicePermissionCallback = callback
+        }
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (ACTION_USB_PERMISSION == intent.action) {
+            synchronized(this) {
+                val device: UsbDevice? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    intent.getParcelableExtra(UsbManager.EXTRA_DEVICE, UsbDevice::class.java)
+                } else {
+                    intent.getParcelableExtra(UsbManager.EXTRA_DEVICE)
+                }
+                val isPermissionGranted = intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false)
+                Log.d(LOG_TAG, "USB permission granted: $isPermissionGranted")
+
+                device?.apply {
+                    onDevicePermissionCallback?.invoke(isPermissionGranted, device)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

One more improvement towards https://github.com/trezor/trezor-suite/issues/11896 

This keeps the current dialog to select which app to open whenever Trezor is connected. But on top of that adding request permission if you then go to another Suite (or some potential 3rd party app using react-native-usb), so you can give USB permissions to multiple apps, see the video for the demonstration.

> Currently, the Suite app requests permissions for any USB device connected while the app is open. I attempted to filter this but encountered difficulties passing the ID via the constructor and decided to postpone it for later. It's not a major issue if you cancel or grant permissions for any USB device to Suite, and it seems like a very edge case to me.

## Related Issue

Related to https://github.com/trezor/trezor-suite/issues/11896

## Screenshots:
Demonstration using multiple Suite environments (production and debug versions of the app), but imagine some 3rd party app instead of one of those.
Ignore missing Connecting screen in debug, it's this known issue https://github.com/trezor/trezor-suite/issues/12976

https://github.com/trezor/trezor-suite/assets/3729633/c4381c25-ce1a-4f50-a46d-72eaaaefd208



