### PR TITLE
fix(suite-native): correct detection of selectIsDeviceUsingPassphrase

### DIFF
--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -891,7 +891,7 @@ export const selectIsDeviceUsingPassphrase = (state: DeviceRootState) => {
 
     // If device instance is higher than 1 (newly created device instance), connect returns
     // `passphrase_protection: false` in features. But we still want to treat it as passphrase protected.
-    const shouldTreatAsPassphraseProtected = device?.instance ?? 1 > 1;
+    const shouldTreatAsPassphraseProtected = (device?.instance ?? 1) > 1;
 
     return (
         (isDeviceProtectedByPassphrase && device?.useEmptyPassphrase === false) ||


### PR DESCRIPTION
Make connection screen appear for devices with allowed passphrase 

Resolve #12976

## Screenshots:

https://github.com/trezor/trezor-suite/assets/2011829/0638c355-d884-43f2-812a-e2934f76a404

