### PR TITLE
Tor with Snowflakes as experimental feature

### DIFF
--- a/packages/node-utils/src/checkFileExists.ts
+++ b/packages/node-utils/src/checkFileExists.ts
@@ -1,0 +1,20 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+/**
+ * Check if a file exists at the given path.
+ *
+ * @param {string} filePath - The path to the file to check.
+ * @returns {Promise<boolean>} - True if the path is a file, false otherwise.
+ */
+export const checkFileExists = async (filePath: string): Promise<boolean> => {
+    try {
+        const resolvedFilePath = path.resolve(filePath);
+
+        const stats = await fs.stat(resolvedFilePath);
+
+        return stats.isFile();
+    } catch {
+        return false;
+    }
+};

--- a/packages/node-utils/src/index.ts
+++ b/packages/node-utils/src/index.ts
@@ -10,3 +10,4 @@ export {
     type RequestWithParams,
     type Response,
 } from './http';
+export { checkFileExists } from './checkFileExists';

--- a/packages/node-utils/src/tests/checkFileExists.test.ts
+++ b/packages/node-utils/src/tests/checkFileExists.test.ts
@@ -1,0 +1,49 @@
+import fs from 'fs';
+import path from 'path';
+
+import { checkFileExists } from '../checkFileExists';
+
+const existingFilePath = path.join(__dirname, 'test-file.txt');
+const nonExistingFilePath = path.join(__dirname, 'non-existing-file.txt');
+const directoryPath = path.join(__dirname, 'test-directory');
+
+beforeAll(async () => {
+    await fs.promises.writeFile(existingFilePath, 'Test content');
+});
+
+afterAll(async () => {
+    try {
+        await fs.promises.unlink(existingFilePath);
+    } catch (error) {
+        console.error(error);
+    }
+    try {
+        await fs.promises.rmdir(directoryPath);
+    } catch (error) {
+        console.error(error);
+    }
+});
+
+describe('checkFileExists', () => {
+    it('should return true for an existing file', async () => {
+        const exists = await checkFileExists(existingFilePath);
+        expect(exists).toBe(true);
+    });
+
+    it('should return false for a non-existing file', async () => {
+        const exists = await checkFileExists(nonExistingFilePath);
+        expect(exists).toBe(false);
+    });
+
+    it('should return false for a directory path', async () => {
+        await fs.promises.mkdir(directoryPath);
+        const exists = await checkFileExists(directoryPath);
+        expect(exists).toBe(false);
+    });
+
+    it('should handle invalid paths gracefully', async () => {
+        const invalidPath = path.join(__dirname, 'invalid-path', 'file.txt');
+        const exists = await checkFileExists(invalidPath);
+        expect(exists).toBe(false);
+    });
+});

--- a/packages/request-manager/e2e/identities-stress.ts
+++ b/packages/request-manager/e2e/identities-stress.ts
@@ -37,9 +37,8 @@ const intervalBetweenRequests = 1000 * 20;
         controlPort,
         torDataDir,
         snowflakeBinaryPath: '',
-        shouldUseSnowflake: false,
     });
-    const torParams = torController.getTorConfiguration(processId);
+    const torParams = await torController.getTorConfiguration(processId);
     // Starting Tor process from binary.
     torRunner({
         torParams,

--- a/packages/request-manager/e2e/identities-stress.ts
+++ b/packages/request-manager/e2e/identities-stress.ts
@@ -36,6 +36,8 @@ const intervalBetweenRequests = 1000 * 20;
         port,
         controlPort,
         torDataDir,
+        snowflakeBinaryPath: '',
+        shouldUseSnowflake: false,
     });
     const torParams = torController.getTorConfiguration(processId);
     // Starting Tor process from binary.

--- a/packages/request-manager/e2e/interceptor.test.ts
+++ b/packages/request-manager/e2e/interceptor.test.ts
@@ -11,7 +11,6 @@ const port = 38835;
 const controlPort = 35527;
 const processId = process.pid;
 const snowflakeBinaryPath = '';
-const shouldUseSnowflake = false;
 
 // 1 minute before timeout, because Tor might be slow to start.
 jest.setTimeout(60000);
@@ -47,9 +46,8 @@ describe('Interceptor', () => {
             controlPort,
             torDataDir,
             snowflakeBinaryPath,
-            shouldUseSnowflake,
         });
-        const torParams = torController.getTorConfiguration(processId, false);
+        const torParams = await torController.getTorConfiguration(processId);
         // Starting Tor process from binary.
         torProcess = torRunner({
             torParams,

--- a/packages/request-manager/e2e/interceptor.test.ts
+++ b/packages/request-manager/e2e/interceptor.test.ts
@@ -10,6 +10,8 @@ const host = '127.0.0.1';
 const port = 38835;
 const controlPort = 35527;
 const processId = process.pid;
+const snowflakeBinaryPath = '';
+const shouldUseSnowflake = false;
 
 // 1 minute before timeout, because Tor might be slow to start.
 jest.setTimeout(60000);
@@ -28,7 +30,7 @@ describe('Interceptor', () => {
     let torController: TorController;
     let torIdentities: TorIdentities;
 
-    const torSettings = { running: true, host, port };
+    const torSettings = { running: true, host, port, snowflakeBinaryPath };
 
     const INTERCEPTOR = {
         handler: () => {},
@@ -44,8 +46,10 @@ describe('Interceptor', () => {
             port,
             controlPort,
             torDataDir,
+            snowflakeBinaryPath,
+            shouldUseSnowflake,
         });
-        const torParams = torController.getTorConfiguration(processId);
+        const torParams = torController.getTorConfiguration(processId, false);
         // Starting Tor process from binary.
         torProcess = torRunner({
             torParams,

--- a/packages/request-manager/e2e/torControlPort.test.ts
+++ b/packages/request-manager/e2e/torControlPort.test.ts
@@ -19,7 +19,6 @@ const host = 'localhost';
 const port = 9998;
 const controlPort = 9999;
 const snowflakeBinaryPath = '';
-const shouldUseSnowflake = false;
 
 describe('TorControlPort', () => {
     beforeAll(async () => {
@@ -42,7 +41,6 @@ describe('TorControlPort', () => {
                 controlPort,
                 torDataDir,
                 snowflakeBinaryPath,
-                shouldUseSnowflake,
             };
             const fakeListener = () => {};
             const torControlPort = new TorControlPort(options, fakeListener);
@@ -108,7 +106,6 @@ describe('TorControlPort', () => {
                 controlPort,
                 torDataDir,
                 snowflakeBinaryPath,
-                shouldUseSnowflake,
             };
             const fakeListener = () => {};
             const torControlPort = new TorControlPort(options, fakeListener);

--- a/packages/request-manager/e2e/torControlPort.test.ts
+++ b/packages/request-manager/e2e/torControlPort.test.ts
@@ -18,6 +18,8 @@ const controlAuthCookiePath = `${torDataDir}/control_auth_cookie`;
 const host = 'localhost';
 const port = 9998;
 const controlPort = 9999;
+const snowflakeBinaryPath = '';
+const shouldUseSnowflake = false;
 
 describe('TorControlPort', () => {
     beforeAll(async () => {
@@ -39,6 +41,8 @@ describe('TorControlPort', () => {
                 port,
                 controlPort,
                 torDataDir,
+                snowflakeBinaryPath,
+                shouldUseSnowflake,
             };
             const fakeListener = () => {};
             const torControlPort = new TorControlPort(options, fakeListener);
@@ -103,6 +107,8 @@ describe('TorControlPort', () => {
                 port,
                 controlPort,
                 torDataDir,
+                snowflakeBinaryPath,
+                shouldUseSnowflake,
             };
             const fakeListener = () => {};
             const torControlPort = new TorControlPort(options, fakeListener);

--- a/packages/request-manager/package.json
+++ b/packages/request-manager/package.json
@@ -12,6 +12,7 @@
         "test:stress": "ts-node  -O '{\"module\": \"commonjs\"}' ./e2e/identities-stress.ts"
     },
     "dependencies": {
+        "@trezor/node-utils": "workspace:^",
         "@trezor/utils": "workspace:*",
         "socks-proxy-agent": "6.1.1"
     },

--- a/packages/request-manager/src/types.ts
+++ b/packages/request-manager/src/types.ts
@@ -4,7 +4,6 @@ export interface TorConnectionOptions {
     controlPort: number;
     torDataDir: string;
     snowflakeBinaryPath: string;
-    shouldUseSnowflake: boolean;
 }
 
 export type TorCommandResponse =

--- a/packages/request-manager/src/types.ts
+++ b/packages/request-manager/src/types.ts
@@ -3,6 +3,8 @@ export interface TorConnectionOptions {
     port: number;
     controlPort: number;
     torDataDir: string;
+    snowflakeBinaryPath: string;
+    shouldUseSnowflake: boolean;
 }
 
 export type TorCommandResponse =

--- a/packages/request-manager/tsconfig.json
+++ b/packages/request-manager/tsconfig.json
@@ -5,5 +5,8 @@
         "outDir": "libDev"
     },
     "include": ["."],
-    "references": [{ "path": "../utils" }]
+    "references": [
+        { "path": "../node-utils" },
+        { "path": "../utils" }
+    ]
 }

--- a/packages/suite-desktop-api/src/api.ts
+++ b/packages/suite-desktop-api/src/api.ts
@@ -14,6 +14,7 @@ import {
     TorStatusEvent,
     Status,
     BridgeSettings,
+    TorSettings,
 } from './messages';
 
 // Event messages from renderer to main process
@@ -54,6 +55,7 @@ export interface RendererChannels {
     // tor
     'tor/status': TorStatusEvent;
     'tor/bootstrap': BootstrapTorEvent;
+    'tor/settings': TorSettings;
 
     // custom protocol
     'protocol/open': string;
@@ -78,6 +80,8 @@ export interface InvokeChannels {
     'metadata/rename-file': (options: { file: string; to: string }) => InvokeResult;
     'server/request-address': (route: string) => string | undefined;
     'tor/toggle': (shouldEnableTor: boolean) => InvokeResult;
+    'tor/change-settings': (payload: TorSettings) => InvokeResult;
+    'tor/get-settings': () => InvokeResult<TorSettings>;
     'bridge/toggle': () => InvokeResult;
     'bridge/get-status': () => InvokeResult<Status>;
     'bridge/change-settings': (payload: BridgeSettings) => InvokeResult;
@@ -126,6 +130,8 @@ export interface DesktopApi {
     // Tor
     getTorStatus: DesktopApiSend<'tor/get-status'>;
     toggleTor: DesktopApiInvoke<'tor/toggle'>;
+    changeTorSettings: DesktopApiInvoke<'tor/change-settings'>;
+    getTorSettings: DesktopApiInvoke<'tor/get-settings'>;
     // Store
     clearStore: DesktopApiSend<'store/clear'>;
     clearUserData: DesktopApiInvoke<'user-data/clear'>;

--- a/packages/suite-desktop-api/src/factory.ts
+++ b/packages/suite-desktop-api/src/factory.ts
@@ -112,6 +112,15 @@ export const factory = <R extends StrictIpcRenderer<any, IpcRendererEvent>>(
 
             return Promise.resolve({ success: false, error: 'invalid params' });
         },
+        getTorSettings: () => ipcRenderer.invoke('tor/get-settings'),
+
+        changeTorSettings: payload => {
+            if (validation.isObject({ snowflakeBinaryPath: 'string' }, payload)) {
+                return ipcRenderer.invoke('tor/change-settings', payload);
+            }
+
+            return Promise.resolve({ success: false, error: 'invalid params' });
+        },
 
         // Store
         clearStore: () => ipcRenderer.send('store/clear'),

--- a/packages/suite-desktop-api/src/messages.ts
+++ b/packages/suite-desktop-api/src/messages.ts
@@ -53,6 +53,10 @@ export type HandshakeTorModule = {
     shouldRunTor: boolean;
 };
 
+export type TorSettings = {
+    snowflakeBinaryPath: string;
+};
+
 export type HandshakeElectron = {
     protocol?: string;
     desktopUpdate?: {

--- a/packages/suite-desktop-api/src/validation.ts
+++ b/packages/suite-desktop-api/src/validation.ts
@@ -36,6 +36,7 @@ const validChannels: Array<keyof RendererChannels> = [
     'update/allow-prerelease',
     'tor/status',
     'tor/bootstrap',
+    'tor/settings',
     'protocol/open',
     'handshake/event',
     'bridge/status',

--- a/packages/suite-desktop-core/src/index.d.ts
+++ b/packages/suite-desktop-core/src/index.d.ts
@@ -101,7 +101,6 @@ declare type TorSettings = {
     host: string; // Hostname of the tor process through which traffic is routed
     port: number; // Port of the tor process through which traffic is routed
     snowflakeBinaryPath: string; // Path in user system to the snowflake binary
-    shouldUseSnowflake: boolean; // Tor should use snowflake pluggable transport
 };
 
 declare type BridgeSettings = {

--- a/packages/suite-desktop-core/src/index.d.ts
+++ b/packages/suite-desktop-core/src/index.d.ts
@@ -96,15 +96,13 @@ declare type UpdateSettings = {
     allowPrerelease: boolean;
 };
 
-declare type TorSettings =
-    | {
-          running: false; // Tor should be disabled
-      }
-    | {
-          running: true; // Tor should be enabled
-          host: string; // Hostname of the tor process through which traffic is routed
-          port: number; // Port of the tor process through which traffic is routed
-      };
+declare type TorSettings = {
+    running: boolean; // Tor should be enabled
+    host: string; // Hostname of the tor process through which traffic is routed
+    port: number; // Port of the tor process through which traffic is routed
+    snowflakeBinaryPath: string; // Path in user system to the snowflake binary
+    shouldUseSnowflake: boolean; // Tor should use snowflake pluggable transport
+};
 
 declare type BridgeSettings = {
     /**

--- a/packages/suite-desktop-core/src/libs/processes/TorProcess.ts
+++ b/packages/suite-desktop-core/src/libs/processes/TorProcess.ts
@@ -1,13 +1,8 @@
 import { TorController, TOR_CONTROLLER_STATUS } from '@trezor/request-manager';
 
-import { BaseProcess, Status } from './BaseProcess';
+import { TorConnectionOptions } from '@trezor/request-manager/src/types';
 
-interface TorConnectionOptions {
-    host: string;
-    port: number;
-    controlPort: number;
-    torDataDir: string;
-}
+import { BaseProcess, Status } from './BaseProcess';
 
 export type TorProcessStatus = Status & { isBootstrapping?: boolean };
 
@@ -17,6 +12,8 @@ export class TorProcess extends BaseProcess {
     controlPort: number;
     torHost: string;
     torDataDir: string;
+    snowflakeBinaryPath: string;
+    shouldUseSnowflake: boolean;
 
     constructor(options: TorConnectionOptions) {
         super('tor', 'tor');
@@ -25,13 +22,24 @@ export class TorProcess extends BaseProcess {
         this.controlPort = options.controlPort;
         this.torHost = options.host;
         this.torDataDir = options.torDataDir;
+        this.snowflakeBinaryPath = '';
+        this.shouldUseSnowflake = false;
 
         this.torController = new TorController({
             host: this.torHost,
             port: this.port,
             controlPort: this.controlPort,
             torDataDir: this.torDataDir,
+            snowflakeBinaryPath: this.snowflakeBinaryPath,
+            shouldUseSnowflake: this.shouldUseSnowflake,
         });
+    }
+
+    setTorConfig(
+        torConfig: Pick<TorConnectionOptions, 'snowflakeBinaryPath' | 'shouldUseSnowflake'>,
+    ) {
+        this.shouldUseSnowflake = torConfig.shouldUseSnowflake;
+        this.snowflakeBinaryPath = torConfig.snowflakeBinaryPath;
     }
 
     async status(): Promise<TorProcessStatus> {
@@ -46,7 +54,11 @@ export class TorProcess extends BaseProcess {
 
     async start(): Promise<void> {
         const electronProcessId = process.pid;
-        const torConfiguration = this.torController.getTorConfiguration(electronProcessId);
+        const torConfiguration = this.torController.getTorConfiguration(
+            electronProcessId,
+            this.shouldUseSnowflake,
+            this.snowflakeBinaryPath,
+        );
 
         await super.start(torConfiguration);
 

--- a/packages/suite-desktop-core/src/libs/processes/TorProcess.ts
+++ b/packages/suite-desktop-core/src/libs/processes/TorProcess.ts
@@ -1,5 +1,4 @@
 import { TorController, TOR_CONTROLLER_STATUS } from '@trezor/request-manager';
-
 import { TorConnectionOptions } from '@trezor/request-manager/src/types';
 
 import { BaseProcess, Status } from './BaseProcess';
@@ -13,7 +12,6 @@ export class TorProcess extends BaseProcess {
     torHost: string;
     torDataDir: string;
     snowflakeBinaryPath: string;
-    shouldUseSnowflake: boolean;
 
     constructor(options: TorConnectionOptions) {
         super('tor', 'tor');
@@ -23,7 +21,6 @@ export class TorProcess extends BaseProcess {
         this.torHost = options.host;
         this.torDataDir = options.torDataDir;
         this.snowflakeBinaryPath = '';
-        this.shouldUseSnowflake = false;
 
         this.torController = new TorController({
             host: this.torHost,
@@ -31,14 +28,10 @@ export class TorProcess extends BaseProcess {
             controlPort: this.controlPort,
             torDataDir: this.torDataDir,
             snowflakeBinaryPath: this.snowflakeBinaryPath,
-            shouldUseSnowflake: this.shouldUseSnowflake,
         });
     }
 
-    setTorConfig(
-        torConfig: Pick<TorConnectionOptions, 'snowflakeBinaryPath' | 'shouldUseSnowflake'>,
-    ) {
-        this.shouldUseSnowflake = torConfig.shouldUseSnowflake;
+    setTorConfig(torConfig: Pick<TorConnectionOptions, 'snowflakeBinaryPath'>) {
         this.snowflakeBinaryPath = torConfig.snowflakeBinaryPath;
     }
 
@@ -54,9 +47,8 @@ export class TorProcess extends BaseProcess {
 
     async start(): Promise<void> {
         const electronProcessId = process.pid;
-        const torConfiguration = this.torController.getTorConfiguration(
+        const torConfiguration = await this.torController.getTorConfiguration(
             electronProcessId,
-            this.shouldUseSnowflake,
             this.snowflakeBinaryPath,
         );
 

--- a/packages/suite-desktop-core/src/libs/store.ts
+++ b/packages/suite-desktop-core/src/libs/store.ts
@@ -61,7 +61,6 @@ export class Store {
             port: 9050,
             host: '127.0.0.1',
             snowflakeBinaryPath: '',
-            shouldUseSnowflake: false,
         });
     }
 

--- a/packages/suite-desktop-core/src/libs/store.ts
+++ b/packages/suite-desktop-core/src/libs/store.ts
@@ -56,7 +56,13 @@ export class Store {
     }
 
     public getTorSettings() {
-        return this.store.get('torSettings', { running: false });
+        return this.store.get('torSettings', {
+            running: false,
+            port: 9050,
+            host: '127.0.0.1',
+            snowflakeBinaryPath: '',
+            shouldUseSnowflake: false,
+        });
     }
 
     public setTorSettings(torSettings: TorSettings) {

--- a/packages/suite-desktop-core/src/modules/tor.ts
+++ b/packages/suite-desktop-core/src/modules/tor.ts
@@ -31,7 +31,6 @@ const load = async ({ mainWindow, store, mainThreadEmitter }: Dependencies) => {
         port,
         controlPort,
         torDataDir,
-        shouldUseSnowflake: initialSettings.shouldUseSnowflake,
         snowflakeBinaryPath: initialSettings.snowflakeBinaryPath,
     });
 
@@ -93,7 +92,7 @@ const load = async ({ mainWindow, store, mainThreadEmitter }: Dependencies) => {
 
     const setupTor = async (shouldEnableTor: boolean) => {
         const isTorRunning = (await tor.status()).process;
-        const { snowflakeBinaryPath, shouldUseSnowflake } = store.getTorSettings();
+        const { snowflakeBinaryPath } = store.getTorSettings();
 
         if (shouldEnableTor === isTorRunning) {
             return;
@@ -103,7 +102,7 @@ const load = async ({ mainWindow, store, mainThreadEmitter }: Dependencies) => {
             setProxy(`socks5://${host}:${port}`);
             tor.torController.on('bootstrap/event', handleBootstrapEvent);
             try {
-                tor.setTorConfig({ snowflakeBinaryPath, shouldUseSnowflake });
+                tor.setTorConfig({ snowflakeBinaryPath });
                 await tor.start();
             } catch (error) {
                 mainWindow.webContents.send('tor/bootstrap', {
@@ -131,13 +130,7 @@ const load = async ({ mainWindow, store, mainThreadEmitter }: Dependencies) => {
 
     ipcMain.handle(
         'tor/change-settings',
-        (
-            ipcEvent,
-            {
-                snowflakeBinaryPath,
-                shouldUseSnowflake,
-            }: { snowflakeBinaryPath: string; shouldUseSnowflake: boolean },
-        ) => {
+        (ipcEvent, { snowflakeBinaryPath }: { snowflakeBinaryPath: string }) => {
             validateIpcMessage(ipcEvent);
 
             try {
@@ -146,7 +139,6 @@ const load = async ({ mainWindow, store, mainThreadEmitter }: Dependencies) => {
                     host,
                     port,
                     snowflakeBinaryPath,
-                    shouldUseSnowflake,
                 });
 
                 return { success: true };

--- a/packages/suite/src/constants/suite/experimental.ts
+++ b/packages/suite/src/constants/suite/experimental.ts
@@ -2,14 +2,17 @@ import { TranslationKey } from '@suite-common/intl-types';
 
 export enum ExperimentalFeature {
     PasswordManager = 'password-manager',
+    TorSnowflake = 'tor-snowflake',
 }
 
 type FeatureIntlMap = Partial<Record<ExperimentalFeature, TranslationKey>>;
 
 export const ExperimentalFeatureTitle: FeatureIntlMap = {
     [ExperimentalFeature.PasswordManager]: 'TR_EXPERIMENTAL_PASSWORD_MANAGER',
+    [ExperimentalFeature.TorSnowflake]: 'TR_EXPERIMENTAL_TOR_SNOWFLAKE',
 };
 
 export const ExperimentalFeatureDescription: FeatureIntlMap = {
     [ExperimentalFeature.PasswordManager]: 'TR_EXPERIMENTAL_PASSWORD_MANAGER_DESCRIPTION',
+    [ExperimentalFeature.TorSnowflake]: 'TR_EXPERIMENTAL_TOR_SNOWFLAKE_DESCRIPTION',
 };

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -4083,6 +4083,27 @@ export default defineMessages({
         id: 'TR_ONION_LINKS_TITLE',
         defaultMessage: 'Open trezor.io links as .onion links',
     },
+    TR_TOR_CONFIG_SNOWFLAKE_TITLE: {
+        id: 'TR_TOR_CONFIG_SNOWFLAKE_TITLE',
+        defaultMessage: 'Tor Snowflake Binary Path',
+    },
+    TR_TOR_CONFIG_SNOWFLAKE_DESCRIPTION: {
+        id: 'TR_TOR_CONFIG_SNOWFLAKE_DESCRIPTION',
+        defaultMessage:
+            'Input the path to Tor Snowflake binary in your system. Tor should be disable to change it.',
+    },
+    TR_TOR_CONFIG_SNOWFLAKE_ERROR_PATH: {
+        id: 'TR_TOR_CONFIG_SNOWFLAKE_ERROR_PATH',
+        defaultMessage: 'Must be a valid full path.',
+    },
+    TR_TOR_CONFIG_SNOWFLAKE_UPDATE_LABEL: {
+        id: 'TR_TOR_CONFIG_SNOWFLAKE_UPDATE_LABEL',
+        defaultMessage: 'Update path',
+    },
+    TR_TOR_CONFIG_SNOWFLAKE_DISABLE_LABEL: {
+        id: 'TR_TOR_CONFIG_SNOWFLAKE_DISABLE_LABEL',
+        defaultMessage: 'Disable snowflake',
+    },
     TR_TOR_ENABLE_TITLE: {
         id: 'TR_TOR_ENABLE_TITLE',
         defaultMessage: 'Enable Tor',
@@ -5164,6 +5185,15 @@ export default defineMessages({
     TR_EXPERIMENTAL_PASSWORD_MANAGER_DESCRIPTION: {
         id: 'TR_EXPERIMENTAL_PASSWORD_MANAGER_DESCRIPTION',
         defaultMessage: 'Re-implementation of Trezor password manager webextension',
+    },
+    TR_EXPERIMENTAL_TOR_SNOWFLAKE: {
+        id: 'TR_EXPERIMENTAL_TOR_SNOWFLAKE',
+        defaultMessage: 'Tor snowflake',
+    },
+    TR_EXPERIMENTAL_TOR_SNOWFLAKE_DESCRIPTION: {
+        id: 'TR_EXPERIMENTAL_TOR_SNOWFLAKE_DESCRIPTION',
+        defaultMessage:
+            'Tor Snowflake is a system that allows people from all over the world to access censored websites and applications.',
     },
     TR_EARLY_ACCESS: {
         id: 'TR_EARLY_ACCESS',

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -126,6 +126,11 @@ export interface TorBootstrap {
     isSlow?: boolean;
 }
 
+export type TorConfig = {
+    enableSnowflake: boolean;
+    snowflakeBinaryPath: string;
+};
+
 export enum DisplayMode {
     CHUNKS = 1,
     PAGINATED_TEXT,

--- a/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
@@ -4,6 +4,7 @@ import { SettingsLayout, SettingsSection } from 'src/components/settings';
 import { Translation } from 'src/components/suite';
 import { useLayoutSize, useSelector } from 'src/hooks/suite';
 import {
+    selectHasExperimentalFeature,
     selectIsSettingsDesktopAppPromoBannerShown,
     selectTorState,
 } from 'src/reducers/suite/suiteReducer';
@@ -29,6 +30,8 @@ import { DesktopSuiteBanner } from './DesktopSuiteBanner';
 import { AddressDisplay } from './AddressDisplay';
 import { EnableViewOnly } from './EnableViewOnly';
 import { Experimental } from './Experimental';
+import { TorSnowflake } from './TorSnowflake';
+import { ExperimentalFeature } from 'src/constants/suite/experimental';
 
 export const SettingsGeneral = () => {
     const shouldShowSettingsDesktopAppPromoBanner = useSelector(
@@ -40,6 +43,9 @@ export const SettingsGeneral = () => {
     const desktopUpdate = useSelector(state => state.desktopUpdate);
     const metadata = useSelector(state => state.metadata);
     const { isMobileLayout } = useLayoutSize();
+    const torSnowflakeExperimentalFeature = useSelector(
+        selectHasExperimentalFeature(ExperimentalFeature.TorSnowflake),
+    );
 
     const hasBitcoinNetworks = NETWORKS.some(
         ({ symbol, features }) =>
@@ -75,6 +81,7 @@ export const SettingsGeneral = () => {
                 <SettingsSection title={<Translation id="TR_TOR" />} icon="TOR_MINIMAL">
                     {isDesktop() && <Tor />}
                     {isTorEnabled && <TorOnionLinks />}
+                    {isDesktop() && torSnowflakeExperimentalFeature && <TorSnowflake />}
                 </SettingsSection>
             )}
 

--- a/packages/suite/src/views/settings/SettingsGeneral/TorSnowflake.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/TorSnowflake.tsx
@@ -1,0 +1,127 @@
+import { ChangeEventHandler, useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { useSelector } from 'src/hooks/suite';
+import { selectTorState } from 'src/reducers/suite/suiteReducer';
+import { TorSettings } from '@trezor/suite-desktop-api/src/messages';
+import { TOR_SNOWFLAKE_PROJECT_URL } from '@trezor/urls';
+import { breakpointMediaQueries } from '@trezor/styles';
+import { desktopApi } from '@trezor/suite-desktop-api';
+import { Button, Input } from '@trezor/components';
+import { isFullPath } from '@trezor/utils';
+import { spacingsPx } from '@trezor/theme';
+
+import { ActionColumn, SectionItem, TextColumn, Translation } from 'src/components/suite';
+import { useTranslation } from 'src/hooks/suite';
+
+const Container = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: ${spacingsPx.sm};
+    min-width: 200px;
+
+    ${breakpointMediaQueries.below_sm} {
+        min-width: 100%;
+    }
+`;
+
+export const TorSnowflake = () => {
+    const { isTorEnabled } = useSelector(selectTorState);
+    const [torSettings, setTorSettings] = useState<TorSettings | null>(null);
+    const [hasPathChanged, setHasPathChanged] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const { translationString } = useTranslation();
+
+    useEffect(() => {
+        const fetchTorSettings = async () => {
+            const result = await desktopApi.getTorSettings();
+            if (result.success) {
+                setTorSettings(result.payload);
+            } else {
+                setError(result.error);
+            }
+        };
+
+        fetchTorSettings();
+
+        const handleTorSettingsChange = (settings: TorSettings) => setTorSettings(settings);
+        desktopApi.on('tor/settings', handleTorSettingsChange);
+
+        return () => {
+            desktopApi.removeAllListeners('tor/settings');
+        };
+    }, []);
+
+    const handleChange: ChangeEventHandler<HTMLInputElement> = ({ target: { value } }) => {
+        if (!torSettings) return;
+
+        setHasPathChanged(true);
+        if (!isFullPath(value) && value !== '') {
+            setError(translationString('TR_TOR_CONFIG_SNOWFLAKE_ERROR_PATH'));
+        } else {
+            setError(null);
+        }
+        setTorSettings(prevSettings => ({
+            ...prevSettings!,
+            snowflakeBinaryPath: value,
+        }));
+    };
+
+    const handleClick = async () => {
+        if (!torSettings || error) return;
+
+        await desktopApi.changeTorSettings({
+            ...torSettings,
+            snowflakeBinaryPath: torSettings.snowflakeBinaryPath,
+        });
+        setHasPathChanged(false);
+    };
+
+    const isUpdateDisabled =
+        !torSettings ||
+        !!error ||
+        (!isFullPath(torSettings.snowflakeBinaryPath) && torSettings.snowflakeBinaryPath !== '') ||
+        isTorEnabled ||
+        !hasPathChanged;
+
+    if (!torSettings) return null;
+
+    const buttonTranslationId =
+        torSettings.snowflakeBinaryPath === '' && hasPathChanged
+            ? 'TR_TOR_CONFIG_SNOWFLAKE_DISABLE_LABEL'
+            : 'TR_TOR_CONFIG_SNOWFLAKE_UPDATE_LABEL';
+
+    return (
+        <SectionItem data-test="@settings/general/tor/snowflake-enable">
+            <TextColumn
+                title={<Translation id="TR_TOR_CONFIG_SNOWFLAKE_TITLE" />}
+                description={<Translation id="TR_TOR_CONFIG_SNOWFLAKE_DESCRIPTION" />}
+                buttonLink={TOR_SNOWFLAKE_PROJECT_URL}
+            />
+            <ActionColumn>
+                <Container>
+                    <Input
+                        isDisabled={isTorEnabled}
+                        bottomText={error || null}
+                        value={torSettings.snowflakeBinaryPath}
+                        placeholder=""
+                        inputState={error ? 'error' : undefined}
+                        onChange={handleChange}
+                        data-test="@settings/general/tor/snowflake-binary-path"
+                        hasBottomPadding={false}
+                        size="small"
+                    />
+                    <Button
+                        onClick={handleClick}
+                        isDisabled={isUpdateDisabled}
+                        data-test="@settings/device/label-submit"
+                        size="small"
+                        isFullWidth
+                    >
+                        <Translation id={buttonTranslationId} />
+                    </Button>
+                </Container>
+            </ActionColumn>
+        </SectionItem>
+    );
+};

--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -103,6 +103,7 @@ export const CHROME_UPDATE_URL = 'https://support.google.com/chrome/answer/95414
 export const CHROME_ANDROID_URL =
     'https://play.google.com/store/apps/details?id=com.android.chrome';
 export const TOR_PROJECT_URL = 'https://www.torproject.org/';
+export const TOR_SNOWFLAKE_PROJECT_URL = 'https://snowflake.torproject.org/';
 export const ZKSNACKS_TERMS_URL =
     'https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi/Legal/Assets/LegalDocumentsWw2.txt';
 export const CROWDIN_URL = 'https://crowdin.com/project/trezor-suite';

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -44,3 +44,4 @@ export * from './logsManager';
 export * from './bigNumber';
 export * from './throttler';
 export * from './extractUrlsFromText';
+export * from './isFullPath';

--- a/packages/utils/src/isFullPath.ts
+++ b/packages/utils/src/isFullPath.ts
@@ -1,0 +1,5 @@
+export const isFullPath = (path: string) => {
+    const fullPathPattern = /^(\/|([a-zA-Z]:\\))/;
+
+    return fullPathPattern.test(path);
+};

--- a/packages/utils/tests/isFullPath.test.ts
+++ b/packages/utils/tests/isFullPath.test.ts
@@ -1,0 +1,27 @@
+import { isFullPath } from '../src/isFullPath';
+
+describe('isFullPath', () => {
+    it('should identify valid full paths', () => {
+        // Unix-like full path with extension
+        expect(isFullPath('/home/user/file.txt')).toBe(true);
+        // Windows full path with extension
+        expect(isFullPath('C:\\Users\\file.txt')).toBe(true);
+        // Unix-like full path without extension
+        expect(isFullPath('/home/user/directory')).toBe(true);
+        // Windows full path without extension
+        expect(isFullPath('C:\\Users\\directory')).toBe(true);
+    });
+
+    it('should not identify invalid or relative paths', () => {
+        // Relative path
+        expect(isFullPath('relative/path/to/file.js')).toBe(false);
+        // Simple filename with extension
+        expect(isFullPath('file.txt')).toBe(false);
+        // Random string
+        expect(isFullPath('not a path')).toBe(false);
+        // URL
+        expect(isFullPath('http://example.com')).toBe(false);
+        // Unix-like relative path
+        expect(isFullPath('./relative/path')).toBe(false);
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -11048,7 +11048,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/node-utils@workspace:*, @trezor/node-utils@workspace:packages/node-utils":
+"@trezor/node-utils@workspace:*, @trezor/node-utils@workspace:^, @trezor/node-utils@workspace:packages/node-utils":
   version: 0.0.0-use.local
   resolution: "@trezor/node-utils@workspace:packages/node-utils"
   dependencies:
@@ -11105,6 +11105,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/request-manager@workspace:packages/request-manager"
   dependencies:
+    "@trezor/node-utils": "workspace:^"
     "@trezor/utils": "workspace:*"
     socks-proxy-agent: "npm:6.1.1"
     ts-node: "npm:^10.9.1"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
In some countries ISPs have started blocking Trezor servers, in the same countries  using Tor directly is not possible, it is blocked at the ISP level as well. 

Tor snowflakes (https://snowflake.torproject.org/) is "pluggable" transport of Tor that helps user to circumvent  those prohibitions. 

* Make Tor run with snowflakes as a proxy integrated in Suite
* Repository with all the binaries https://www.torproject.org/download/tor/
* There could be a feature that will download the binary for the architecture and use it.

![image](https://github.com/user-attachments/assets/82d3cd06-da34-4979-8912-e1dbdb6c8290)


Proper documentation about what is required to run it will be added to Trezor Knowledge Base but if you are reviewing it now you can follow steps bellow to get the binary.

```
* Use it with Debian
      - Run "apt install snowflake-client"
      - Then use the path to the binary "/usr/bin/snowflake-client"

      or:
      - Download it from https://packages.debian.org/bookworm/amd64/snowflake-client/download
      - Install it like sudo dpkg -i snowflake-client_2.5.1-1+b3_amd64.deb
      - Then use the path to the binary "/usr/bin/snowflake-client"

* Use it with macOS:
      - Run "brew install snowflake"
      - Then use the path to the binary "/opt/homebrew/bin/snowflake-client"

* Use it with Windows:

      - Download Tor Browser from [here](https://www.torproject.org/dist/torbrowser/13.5.1/tor-browser-windows-x86_64-portable-13.5.1.exe).
      - Install it. By default, it installs (extracts) on the Desktop.
      - The binary is located in "C:\Users\USERNAME\Desktop\Tor Browser\Browser\TorBrowser\Tor\PluggableTransports"
```
