### PR TITLE
fix:(blockchain-link): omit solana foreign tx effects

### DIFF
--- a/packages/blockchain-link-utils/src/solana.ts
+++ b/packages/blockchain-link-utils/src/solana.ts
@@ -251,6 +251,12 @@ export const getTargets = (
                 return false;
             }
 
+            // exclude effects on foreign addresses for tx types other then sent, otherwise it
+            // leads to the foreign address being displayed next to users own address which might lead to confusion
+            if (txType !== 'sent' && effect.address !== accountAddress) {
+                return false
+            }
+
             // count in only positive effects, for `sent` tx they gonna be represented as negative, for `recv` as positive
             return effect.amount.isGreaterThan(0);
         })
@@ -356,7 +362,11 @@ export const getDetails = (
     txType: Transaction['type'],
 ): Transaction['details'] => {
     const senders = effects.filter(({ amount }) => amount.isNegative());
-    const receivers = effects.filter(({ amount }) => amount.isPositive());
+    const receivers = effects
+        .filter(({ amount }) => amount.isPositive())
+        // include positive effects only on accountAddress for tx types other then sent, otherwise it
+        // leads to foreign address being displayed next to users own address which might lead to confusion
+        .filter(({ address }) => txType !== 'sent' ? address === accountAddress : true);
 
     const getVin = ({ address, amount }: { address: string; amount?: BigNumber }, i: number) => ({
         txid: transaction.transaction.signatures[0].toString(),
@@ -527,7 +537,8 @@ export const getTokens = (
                 ...getTokenNameAndSymbol(mint, tokenDetailByMint),
                 amount,
             };
-        });
+            // consider only effects on users address
+        }).filter((effect) => effect.to === accountAddress || effect.from === accountAddress);
 
     return effects;
 };

--- a/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
+++ b/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
@@ -52,6 +52,24 @@ const instructions = {
         },
         program: 'spl-token',
     },
+    ownReceivedTokenTransfer: {
+        parsed: {
+            info: {
+                authority: 'H8TGGw7Z85w1wDxcH3aTBAyCoCYsDQZrKUim7fwtKAMs',
+                destination: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF',
+                mint: 'DH1nKg3QZStnVh4bjm8kyWfsRJkiweXcnL4j7Ug3PfYA',
+                source: '2Bwv9hYm3isiJtUJoWSiy46Na612c4xzNszp5NckWofu',
+                tokenAmount: {
+                    amount: '2',
+                    decimals: 1,
+                    uiAmount: 2,
+                    uiAmountString: '2',
+                },
+            },
+            type: 'transferChecked',
+        },
+        program: 'spl-token',
+    },
     // without mint and tokenAmount
     tokenTransferToAssociated: {
         parsed: {
@@ -218,6 +236,10 @@ const effects = {
         address: 'address2',
         amount: new BigNumber(10),
     },
+    positiveForeign: {
+        address: 'foreignAddress',
+        amount: new BigNumber(10)
+    }
 };
 
 const sampleMintToDetailMap = {
@@ -577,6 +599,23 @@ export const fixtures = {
             ],
         },
         {
+            description: 'should not return foreign address target for "recv" transaction type',
+            input: {
+                effects: [effects.positive, effects.positiveForeign],
+                txType: 'recv',
+                accountAddress: effects.positive.address,
+            },
+            expectedOutput: [
+                {
+                    n: 0,
+                    addresses: [effects.positive.address],
+                    isAddress: true,
+                    amount: effects.positive.amount.abs().toString(),
+                    isAccountTarget: true,
+                },
+            ],
+        },
+        {
             description: 'should return an empty array for "unknown" transaction type',
             input: {
                 effects: [effects.positive, effects.negative],
@@ -615,11 +654,12 @@ export const fixtures = {
     ],
     getDetails: [
         {
-            description: 'should return transaction details with valid inputs',
+            description: 'should return transaction details with valid inputs for sent',
             input: {
                 transaction: parsedTransactions.basic.transaction,
                 effects: [effects.positive, effects.negative],
                 accountAddress: effects.negative.address,
+                txType: 'sent' as const,
             },
             expectedOutput: {
                 size: parsedTransactions.basic.transaction.meta.computeUnitsConsumed,
@@ -646,6 +686,68 @@ export const fixtures = {
                         value: effects.positive.amount.abs().toString(),
                         addresses: [effects.positive.address],
                     },
+                ],
+            },
+        },
+        {
+            description: 'should return transaction details with valid inputs for recv',
+            input: {
+                transaction: parsedTransactions.basic.transaction,
+                effects: [effects.positive, effects.negative],
+                accountAddress: effects.positive.address,
+                txType: 'recv' as const,
+            },
+            expectedOutput: {
+                size: parsedTransactions.basic.transaction.meta.computeUnitsConsumed,
+                totalInput: effects.negative.amount.abs().toString(),
+                totalOutput: effects.positive.amount.abs().toString(),
+                vin: [
+                    {
+                        txid: 'txid1',
+                        version: 'legacy',
+                        isAddress: true,
+                        isAccountOwned: false,
+                        n: 0,
+                        value: effects.negative.amount.abs().toString(),
+                        addresses: [effects.negative.address],
+                    },
+                ],
+                vout: [
+                    {
+                        txid: 'txid1',
+                        version: 'legacy',
+                        isAddress: true,
+                        isAccountOwned: true,
+                        n: 0,
+                        value: effects.positive.amount.abs().toString(),
+                        addresses: [effects.positive.address],
+                    },
+                ],
+            },
+        },
+        {
+            description: 'should return transaction details with only account owned outputs',
+            input: {
+                transaction: parsedTransactions.basic.transaction,
+                effects: [effects.positive, effects.positiveForeign],
+                accountAddress: effects.positive.address,
+                txType: 'recv' as const,
+            },
+            expectedOutput: {
+                size: parsedTransactions.basic.transaction.meta.computeUnitsConsumed,
+                totalInput: new BigNumber(0).toString(),
+                totalOutput: effects.positive.amount.abs().toString(),
+                vin: [],
+                vout: [
+                    {
+                        txid: 'txid1',
+                        version: 'legacy',
+                        isAddress: true,
+                        isAccountOwned: true,
+                        n: 0,
+                        value: effects.positive.amount.abs().toString(),
+                        addresses: [effects.positive.address],
+                    }
                 ],
             },
         },
@@ -686,6 +788,28 @@ export const fixtures = {
                     name: 'So11111111111111111111111111111111111115555',
                     symbol: 'SO11111...',
                     amount: '1534951700',
+                },
+            ],
+        },
+        {
+            description: 'parses a multi token receiver transfer and omit foreign address token effect',
+            input: {
+                transaction: parsedTransactions.multiTokenTransfer.transaction,
+                accountAddress: 'H8TGGw7Z85w1wDxcH3aTBAyCoCYsDQZrKUim7fwtKAMs',
+                map: sampleMintToDetailMap,
+                tokenAccountsInfos: [],
+            },
+            expectedOutput: [
+                {
+                    type: 'recv',
+                    standard: 'SPL',
+                    from: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF',
+                    to: 'H8TGGw7Z85w1wDxcH3aTBAyCoCYsDQZrKUim7fwtKAMs',
+                    contract: 'DH1nKg3QZStnVh4bjm8kyWfsRJkiweXcnL4j7Ug3PfYA',
+                    decimals: 1,
+                    name: 'DH1nKg3QZStnVh4bjm8kyWfsRJkiweXcnL4j7Ug3PfYA',
+                    symbol: 'DH1NKG3...',
+                    amount: '2',
                 },
             ],
         },

--- a/packages/blockchain-link-utils/src/tests/solana.test.ts
+++ b/packages/blockchain-link-utils/src/tests/solana.test.ts
@@ -92,7 +92,7 @@ describe('solana/utils', () => {
                     input.transaction as SolanaValidParsedTxWithMeta,
                     input.effects,
                     input.accountAddress,
-                    'sent',
+                    input.txType,
                 );
                 expect(result).toEqual(expectedOutput);
             });


### PR DESCRIPTION
## Description
 
Previously, transaction history and tx details showed positive transaction effects also on other addresses. This could have been confusing for users, as a foreign address was shown right next to users address.

## Changes

Omit token transaction effects if sender nor receiver is the users account
Omit SOL positive transaction effects on foreign addresses for transactions other than sent

## Notes
I haven't been able to test this e2e yet, I don't have device on me and the emulator is fighting me as always. I will do it tomorrow. Until then, you can ideally test yourself and you can still check the unit tests I added which test all 3 places where the changes need to be made.