### PR TITLE
fix:(blockchain-link): omit solana foreign tx effects

### DIFF
--- a/packages/blockchain-link-utils/src/tests/solana.test.ts
+++ b/packages/blockchain-link-utils/src/tests/solana.test.ts
@@ -92,7 +92,7 @@ describe('solana/utils', () => {
                     input.transaction as SolanaValidParsedTxWithMeta,
                     input.effects,
                     input.accountAddress,
-                    'sent',
+                    input.txType,
                 );
                 expect(result).toEqual(expectedOutput);
             });


### PR DESCRIPTION
Omit token transaction effects if sender not receiver is the account Omit SOL positive transaction effects on foreign addresses for transactions other than sent

origin https://github.com/trezor/trezor-suite/pull/12993
closes #10915
