### PR TITLE
fix(connect): race condition when closing and opening popup subsequently

### DIFF
--- a/packages/connect-explorer/src/pages/_meta.json
+++ b/packages/connect-explorer/src/pages/_meta.json
@@ -5,5 +5,9 @@
     "settings": {
         "title": "Settings",
         "display": "hidden"
+    },
+    "test": {
+        "title": "Test",
+        "display": "hidden"
     }
 }

--- a/packages/connect-explorer/src/pages/test.mdx
+++ b/packages/connect-explorer/src/pages/test.mdx
@@ -1,0 +1,46 @@
+import { Button } from '@trezor/components';
+import TrezorConnect from '@trezor/connect-web';
+
+import * as trezorConnectActions from '../actions/trezorConnectActions';
+import { useActions } from '../hooks';
+
+export const InitButton = ({ label, behavior }) => {
+    const actions = useActions({
+        onSubmitInit: trezorConnectActions.onSubmitInit,
+    });
+
+    return (
+        <Button onClick={actions.onSubmitInit} data-test="@testpage/init">
+          Init
+        </Button>
+    );
+
+};
+
+export const subsequentCalls = async () => {
+    const res1 = await TrezorConnect.getFeatures();
+    console.log('Explorer - getFeatures finished', res1);
+    const res2 = await TrezorConnect.getPublicKey({
+        path: 'm/44/0/0/0',
+    });
+    console.log('Explorer - getPublicKey finished', res2);
+};
+
+export const subsequentCallsWithError = async () => {
+    const res1 = await TrezorConnect.getFeatures();
+    console.log('Explorer - getFeatures finished', res1);
+    const res2 = await TrezorConnect.getPublicKey();
+    console.log('Explorer - getPublicKey finished', res2);
+};
+
+# Test page
+
+Hidden page for testing purposes.
+
+<InitButton />
+<Button onClick={() => subsequentCalls()} data-test="@testpage/subsequentCalls">
+    Subsequent calls
+</Button>
+<Button onClick={() => subsequentCallsWithError()} data-test="@testpage/subsequentCallsWithError">
+    Subsequent calls with error
+</Button>

--- a/packages/connect-popup/e2e/tests/popup-close.test.ts
+++ b/packages/connect-popup/e2e/tests/popup-close.test.ts
@@ -404,3 +404,48 @@ test('popup should close when third party is closed', async ({ page, context }) 
     log('Wait for popup to close to consider the test successful.');
     await popupClosedPromise;
 });
+
+test('popup should behave properly with subsequent calls', async ({ page, context }) => {
+    test.skip(skipCheck);
+
+    log(`test: ${test.info().title}`);
+    await setup({ page, context });
+
+    await TrezorUserEnvLink.api.pressYes();
+    await TrezorUserEnvLink.api.pressYes();
+    await TrezorUserEnvLink.api.pressYes();
+
+    popupClosedPromise = new Promise(resolve => {
+        popup.on('close', () => resolve(undefined));
+    });
+    await popupClosedPromise;
+
+    await explorerPage.goto(formatUrl(explorerUrl, `test/index.html`));
+    await waitAndClick(explorerPage, ['@testpage/init']);
+    await waitAndClick(explorerPage, ['@testpage/subsequentCalls']);
+    log('waiting for popup open');
+
+    [popup] = await waitForPopup(browserContext, explorerPage, isWebExtension);
+
+    popupClosedPromise = new Promise(resolve => {
+        popup.on('close', () => resolve(undefined));
+    });
+    await popupClosedPromise;
+
+    log('waiting for second popup open');
+    [popup] = await waitForPopup(browserContext, explorerPage, isWebExtension);
+
+    popupClosedPromise = new Promise(resolve => {
+        popup.on('close', () => resolve(undefined));
+    });
+
+    log('waiting for permissions button');
+    await waitAndClick(popup, ['@permissions/confirm-button']);
+
+    log('waiting for confirm button');
+    await popup.waitForSelector('button.confirm', { state: 'visible' });
+    await popup.click('button.confirm');
+
+    log('Wait for popup to close to consider the test successful.');
+    await popupClosedPromise;
+});

--- a/packages/connect-web/src/popup/index.ts
+++ b/packages/connect-web/src/popup/index.ts
@@ -376,6 +376,7 @@ export class PopupManager extends EventEmitter {
                 });
             });
         } else if (data.type === POPUP.CANCEL_POPUP_REQUEST) {
+            clearTimeout(this.requestTimeout);
             if (this.popupPromise) {
                 this.close();
             }

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -1053,6 +1053,7 @@ export class Core extends EventEmitter {
                 popupPromise.resolve();
                 break;
             case POPUP.CLOSED:
+                popupPromise.clear();
                 onPopupClosed(message.payload ? message.payload.error : null);
                 break;
 


### PR DESCRIPTION
## Description

This is an error that we saw happening on Adalite.io, where they are calling GetFeatures and right after that GetAddress. 
The GetFeatures call doesn't need the popup and finishes faster than the popup fully loads. 
In this situation `POPUP.HANDHSAKE` arrives after core cleanup, so the core wrongly assumes the popup is ready for the next call. 

The solution is to clear the popup promise in response to `POPUP.CLOSED` and fix handling of `CANCEL_POPUP_REQUEST` in PopupManager when waiting for `requestTimeout`.

To catch this situation I added an E2E test to `connect-popup`.