### PR TITLE
fix(components): button group hide separator for disabled button

### DIFF
--- a/packages/components/src/components/buttons/ButtonGroup/ButtonGroup.tsx
+++ b/packages/components/src/components/buttons/ButtonGroup/ButtonGroup.tsx
@@ -27,8 +27,8 @@ const Container = styled.div<{
         border-radius: 0 ${borders.radii.full} ${borders.radii.full} 0;
     }
 
-    > button:not(:last-child),
-    > div:not(:last-child) button {
+    > button:not(:last-child, :is([disabled])),
+    > div:not(:last-child) button:not(:is([disabled])) {
         position: relative;
 
         &::after {


### PR DESCRIPTION
## Description

Removed separator for disabled button inside button group.

## Related Issue

Resolve #12907

## Screenshots:
![Screenshot 2024-06-21 at 2 36 27 PM](https://github.com/trezor/trezor-suite/assets/66002635/4a4a2845-06e1-44e4-94ff-fb2713241d5d)
