### PR TITLE
feat(connect-web): automatic fallback to core in popup

### DIFF
--- a/packages/connect-explorer/src/actions/trezorConnectActions.ts
+++ b/packages/connect-explorer/src/actions/trezorConnectActions.ts
@@ -138,8 +138,12 @@ export const init =
         const urlParams = new URLSearchParams(window.location.search);
         const useCoreInPopup = urlParams.get('core-in-popup') === 'true';
 
+        // Get default coreMode from URL params (?core-mode=auto)
+        const coreMode = (urlParams.get('core-mode') as ConnectOptions['coreMode']) || 'iframe';
+
         const connectOptions = {
             useCoreInPopup,
+            coreMode,
             transportReconnect: true,
             popup: true,
             debug: true,

--- a/packages/connect-explorer/src/pages/settings.mdx
+++ b/packages/connect-explorer/src/pages/settings.mdx
@@ -29,6 +29,7 @@ export const Settings = () => {
         trustedHost: state.connect?.options?.trustedHost,
         connectSrc: state.connect?.options?.connectSrc,
         useCoreInPopup: state?.connect?.options?.useCoreInPopup,
+        coreMode: state?.connect?.options?.coreMode,
     }));
 
     const initError = useSelector(state => state.connect?.initError);
@@ -52,6 +53,17 @@ export const Settings = () => {
             type: 'checkbox',
             key: 'useCoreInPopup',
             value: connectOptions?.useCoreInPopup || false,
+        },
+        {
+            name: 'coreMode',
+            type: 'select',
+            key: 'coreMode',
+            value: connectOptions?.coreMode || 'iframe',
+            data: [
+                { value: 'auto', label: 'Auto' },
+                { value: 'iframe', label: 'Iframe' },
+                { value: 'popup', label: 'Popup' },
+            ],
         },
         {
             name: 'connectSrc',

--- a/packages/connect-iframe/src/index.ts
+++ b/packages/connect-iframe/src/index.ts
@@ -192,6 +192,7 @@ const handleMessage = async (event: MessageEvent<CoreRequestMessage>) => {
         // UI.CHANGE_SETTINGS,
         UI.LOGIN_CHALLENGE_RESPONSE,
         TRANSPORT.DISABLE_WEBUSB,
+        TRANSPORT.GET_INFO,
     ];
 
     if (!isTrustedDomain && safeMessages.indexOf(message.type) === -1) {

--- a/packages/connect-web/src/impl/core-in-popup.ts
+++ b/packages/connect-web/src/impl/core-in-popup.ts
@@ -130,26 +130,26 @@ export class CoreInPopup implements ConnectFactoryDependencies {
             await this._popupManager.request();
         }
 
-        await this._popupManager.channel.init();
-
-        if (this._settings.env === 'webextension') {
-            // In webextension we init based on the popup promise
-            // In core this is handled in the popup manager
-            await this._popupManager.popupPromise?.promise;
-
-            this._popupManager.channel.postMessage({
-                type: POPUP.INIT,
-                payload: {
-                    settings: this._settings,
-                    useCore: true,
-                },
-            });
-        }
-
-        await this._popupManager.handshakePromise?.promise;
-
-        // post message to core in popup
         try {
+            await this._popupManager.channel.init();
+
+            if (this._settings.env === 'webextension') {
+                // In webextension we init based on the popup promise
+                // In core this is handled in the popup manager
+                await this._popupManager.popupPromise?.promise;
+
+                this._popupManager.channel.postMessage({
+                    type: POPUP.INIT,
+                    payload: {
+                        settings: this._settings,
+                        useCore: true,
+                    },
+                });
+            }
+
+            await this._popupManager.handshakePromise?.promise;
+
+            // post message to core in popup
             const response = await this._popupManager.channel.postMessage({
                 type: IFRAME.CALL,
                 payload: params,

--- a/packages/connect-web/src/utils/proxy-event-emitter.ts
+++ b/packages/connect-web/src/utils/proxy-event-emitter.ts
@@ -1,0 +1,95 @@
+import EventEmitter from 'events';
+
+/**
+ * ProxyEventEmitter is an EventEmitter that allows to use multiple EventEmitters as one
+ * This is used in connect-web to allow switching between iframe and core-in-popup implementations
+ */
+export default class ProxyEventEmitter implements EventEmitter {
+    private eventEmitters: EventEmitter[];
+
+    constructor(eventEmitters: EventEmitter[]) {
+        this.eventEmitters = eventEmitters;
+    }
+
+    emit(eventName: string | symbol, ...args: any[]): boolean {
+        this.eventEmitters.forEach(emitter => emitter.emit(eventName, ...args));
+
+        return true;
+    }
+
+    on(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        this.eventEmitters.forEach(emitter => emitter.on(eventName, listener));
+
+        return this;
+    }
+
+    off(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        this.eventEmitters.forEach(emitter => emitter.off(eventName, listener));
+
+        return this;
+    }
+
+    once(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        this.eventEmitters.forEach(emitter => emitter.once(eventName, listener));
+
+        return this;
+    }
+
+    addListener(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        this.eventEmitters.forEach(emitter => emitter.addListener(eventName, listener));
+
+        return this;
+    }
+
+    prependListener(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        this.eventEmitters.forEach(emitter => emitter.prependListener(eventName, listener));
+
+        return this;
+    }
+
+    prependOnceListener(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        this.eventEmitters.forEach(emitter => emitter.prependOnceListener(eventName, listener));
+
+        return this;
+    }
+
+    removeAllListeners(event?: string | symbol | undefined): this {
+        this.eventEmitters.forEach(emitter => emitter.removeAllListeners(event));
+
+        return this;
+    }
+
+    removeListener(eventName: string | symbol, listener: (...args: any[]) => void): this {
+        this.eventEmitters.forEach(emitter => emitter.removeListener(eventName, listener));
+
+        return this;
+    }
+
+    setMaxListeners(n: number): this {
+        this.eventEmitters.forEach(emitter => emitter.setMaxListeners(n));
+
+        return this;
+    }
+
+    // for the following methods, we just use the first EventEmitter
+    // since all EventEmitters should be in sync, the result should be the same
+    eventNames(): (string | symbol)[] {
+        return this.eventEmitters[0].eventNames();
+    }
+
+    getMaxListeners(): number {
+        return this.eventEmitters[0].getMaxListeners();
+    }
+
+    listenerCount(eventName: string | symbol, listener?: FunctionConstructor | undefined) {
+        return this.eventEmitters[0].listenerCount(eventName, listener);
+    }
+
+    rawListeners(eventName: string | symbol) {
+        return this.eventEmitters[0].rawListeners(eventName);
+    }
+
+    listeners(eventName: string | symbol) {
+        return this.eventEmitters[0].listeners(eventName);
+    }
+}

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -1069,6 +1069,10 @@ export class Core extends EventEmitter {
                 _deviceList?.enumerate();
                 break;
 
+            case TRANSPORT.GET_INFO:
+                postMessage(createResponseMessage(message.id, true, this.getTransportInfo()));
+                break;
+
             // messages from UI (popup/modal...)
             case UI.RECEIVE_DEVICE:
             case UI.RECEIVE_CONFIRMATION:
@@ -1177,7 +1181,11 @@ export class Core extends EventEmitter {
         }
 
         try {
-            if (!DataManager.getSettings('transportReconnect')) {
+            if (
+                !DataManager.getSettings('transportReconnect') ||
+                // in auto core mode, we have to wait to check if transport is available
+                DataManager.getSettings('coreMode') === 'auto'
+            ) {
                 // try only once, if it fails kill and throw initialization error
                 await initDeviceList(false);
             } else {

--- a/packages/connect/src/data/connectSettings.ts
+++ b/packages/connect/src/data/connectSettings.ts
@@ -137,6 +137,13 @@ export const parseConnectSettings = (input: Partial<ConnectSettings> = {}) => {
         settings.useCoreInPopup = input.useCoreInPopup;
     }
 
+    if (
+        typeof input.coreMode === 'string' &&
+        ['auto', 'popup', 'iframe'].includes(input.coreMode)
+    ) {
+        settings.coreMode = input.coreMode;
+    }
+
     if (typeof input._extendWebextensionLifetime === 'boolean') {
         settings._extendWebextensionLifetime = input._extendWebextensionLifetime;
     }

--- a/packages/connect/src/events/core.ts
+++ b/packages/connect/src/events/core.ts
@@ -7,6 +7,7 @@ import type {
     TransportEventMessage,
     TransportDisableWebUSB,
     TransportRequestWebUSBDevice,
+    TransportGetInfo,
 } from './transport';
 import type { UiEventMessage } from './ui-request';
 import type { UiResponseEvent } from './ui-response';
@@ -19,6 +20,7 @@ export type CoreRequestMessage =
     | PopupAnalyticsResponse
     | TransportDisableWebUSB
     | TransportRequestWebUSBDevice
+    | TransportGetInfo
     | UiResponseEvent
     | IFrameInit
     | IFrameCallMessage

--- a/packages/connect/src/events/transport.ts
+++ b/packages/connect/src/events/transport.ts
@@ -64,6 +64,12 @@ export interface TransportRequestWebUSBDevice {
     payload?: undefined;
 }
 
+export interface TransportGetInfo {
+    id: number;
+    type: typeof TRANSPORT.GET_INFO;
+    payload?: undefined;
+}
+
 export type TransportEventMessage = TransportEvent & { event: typeof TRANSPORT_EVENT };
 
 export type TransportEventListenerFn = (

--- a/packages/connect/src/types/settings.ts
+++ b/packages/connect/src/types/settings.ts
@@ -37,6 +37,7 @@ export interface ConnectSettings {
     proxy?: Proxy;
     sharedLogger?: boolean;
     useCoreInPopup?: boolean;
+    coreMode?: 'auto' | 'popup' | 'iframe';
     /* _extendWebextensionLifetime features makes the service worker in @trezor/connect-webextension stay alive longer */
     _extendWebextensionLifetime?: boolean;
 }

--- a/packages/transport/src/constants.ts
+++ b/packages/transport/src/constants.ts
@@ -29,4 +29,5 @@ export const TRANSPORT = {
     UPDATE: 'transport-update',
     DISABLE_WEBUSB: 'transport-disable_webusb',
     REQUEST_DEVICE: 'transport-request_device',
+    GET_INFO: 'transport-get_info',
 } as const;

--- a/packages/transport/src/types/apiCall.ts
+++ b/packages/transport/src/types/apiCall.ts
@@ -1,4 +1,4 @@
-import { PROTOCOL_MALFORMED } from '@trezor/protocol';
+import type { PROTOCOL_MALFORMED } from '@trezor/protocol';
 
 import * as ERRORS from '../errors';
 

--- a/packages/transport/src/types/index.ts
+++ b/packages/transport/src/types/index.ts
@@ -1,4 +1,4 @@
-import { DEVICE_TYPE } from '../api/abstract';
+import type { DEVICE_TYPE } from '../api/abstract';
 
 export * from './apiCall';
 

--- a/packages/transport/src/utils/bridgeApiCall.ts
+++ b/packages/transport/src/utils/bridgeApiCall.ts
@@ -4,7 +4,7 @@ import { success, error, unknownError } from './result';
 
 import * as ERRORS from '../errors';
 
-import { PROTOCOL_MALFORMED } from '@trezor/protocol';
+import { PROTOCOL_MALFORMED } from '@trezor/protocol/src/errors';
 import { applyBridgeApiCallHeaders } from './applyBridgeApiCallHeaders';
 
 export type HttpRequestOptions = {


### PR DESCRIPTION
## Description

Implement automatic fallback for core in popup. 

- New param `coreMode`
    - `auto` - automatically choose the best option based on the environment
    - `iframe` (default) - always use iframe, same way as before
    - `popup` - always use popup,
- Switch to popup on error (`Init_IframeBlocked`, `Init_IframeTimeout`, `Transport_Missing`, …)
- Checking for bridge state is done using a new event `TRANSPORT.GET_INFO`, which will trigger `Transport_Missing` during init if in auto mode

## Related Issue
Resolve #12488

## Followup
- Deprecate `useCoreInPopup` param
- Update documentation
- Use auto as default?