### PR TITLE
fix(suite): show more decimals for token fiat rate

### DIFF
--- a/packages/suite/src/components/suite/FiatValue.tsx
+++ b/packages/suite/src/components/suite/FiatValue.tsx
@@ -33,6 +33,7 @@ type FiatValueProps = useFiatFromCryptoValueParams & {
     showApproximationIndicator?: boolean;
     disableHiddenPlaceholder?: boolean;
     fiatAmountFormatterOptions?: FormatNumberOptions;
+    fiatRateFormatterOptions?: FormatNumberOptions;
     shouldConvert?: boolean;
     showLoadingSkeleton?: boolean;
     className?: string;
@@ -62,6 +63,7 @@ export const FiatValue = ({
     showApproximationIndicator,
     disableHiddenPlaceholder,
     fiatAmountFormatterOptions,
+    fiatRateFormatterOptions,
     shouldConvert = true,
     showLoadingSkeleton,
     isLoading,
@@ -102,7 +104,11 @@ export const FiatValue = ({
 
         const fiatRateComponent = rate ? (
             <SameWidthNums>
-                <FiatAmountFormatter currency={localCurrency} value={rate} />
+                <FiatAmountFormatter
+                    currency={localCurrency}
+                    value={rate}
+                    {...fiatRateFormatterOptions}
+                />
             </SameWidthNums>
         ) : null;
         if (!children) return fiatValueComponent;

--- a/packages/suite/src/components/suite/Ticker/PriceTicker.tsx
+++ b/packages/suite/src/components/suite/Ticker/PriceTicker.tsx
@@ -28,7 +28,16 @@ export const PriceTicker = ({ symbol, contractAddress, noEmptyStateTooltip }: Pr
     const emptyStateComponent = noEmptyStateTooltip ? <Empty>—</Empty> : <NoRatesTooltip />;
 
     return (
-        <FiatValue amount="1" symbol={symbol} tokenAddress={contractAddress} showLoadingSkeleton>
+        <FiatValue
+            amount="1"
+            symbol={symbol}
+            tokenAddress={contractAddress}
+            showLoadingSkeleton
+            fiatRateFormatterOptions={{
+                minimumFractionDigits: 0,
+                maximumFractionDigits: 4,
+            }}
+        >
             {({ rate, timestamp }) =>
                 rate && timestamp ? (
                     <LastUpdateTooltip timestamp={timestamp}>


### PR DESCRIPTION
## Description

Increased maximum fraction digits for token fiat rates.

## Related Issue

Resolve #12910

## Screenshots:
![Screenshot 2024-06-24 at 12 23 50 PM](https://github.com/trezor/trezor-suite/assets/66002635/4e6a546a-10dc-47b2-bee0-0ccc1b95f76d)
