### PR TITLE
fix(components): CollapsibleBox display none when closed

### DIFF
--- a/packages/components/src/components/CollapsibleBox/CollapsibleBox.tsx
+++ b/packages/components/src/components/CollapsibleBox/CollapsibleBox.tsx
@@ -22,10 +22,14 @@ const animationVariants = {
     closed: {
         opacity: 0,
         height: 0,
+        transitionEnd: {
+            display: 'none',
+        },
     },
     expanded: {
         opacity: 1,
         height: 'auto',
+        display: 'block',
     },
 };
 


### PR DESCRIPTION
## Description

Adds `display: none` to CollapsibleBox, with regards to the animation. 

Without this there were some issues in Connect Explorer, where the invisible content of the box would extend the body, resulting in empty space in the bottom. 

![Screenshot 2024-06-24 at 13 30 43](https://github.com/trezor/trezor-suite/assets/8833813/779b9c2d-067e-48a9-9051-cf8a0aa8035a)