### PR TITLE
fix(connect-webextension): firefox mv3

### DIFF
--- a/packages/connect-explorer/src-webextension/manifest.json
+++ b/packages/connect-explorer/src-webextension/manifest.json
@@ -7,6 +7,7 @@
     },
     "background": {
         "service_worker": "serviceWorker.bundle.js",
+        "scripts": ["serviceWorker.bundle.js"],
         "type": "module"
     },
     "permissions": ["scripting"],

--- a/packages/connect-popup/global.d.ts
+++ b/packages/connect-popup/global.d.ts
@@ -1,0 +1,3 @@
+interface Window {
+    closeWindow: () => void;
+}

--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -168,7 +168,7 @@ const handleResponseEvent = (data: MethodResponseMessage) => {
 
     // When success we can close popup.
     if (data.success) {
-        window.close();
+        window.closeWindow();
     }
 
     if (!data.success && typeof data.payload === 'object') {
@@ -187,7 +187,7 @@ const handleResponseEvent = (data: MethodResponseMessage) => {
             case 'Method_PermissionsNotGranted':
             case 'Method_Cancel':
                 // User canceled process, close popup.
-                window.close();
+                window.closeWindow();
                 break;
             default:
                 fail({
@@ -586,7 +586,6 @@ addWindowEventListener('message', handleInitMessage, false);
 addWindowEventListener('message', handleLogMessage, false);
 
 // global method used in html-inline elements
-// @ts-expect-error not defined in window
 window.closeWindow = () => {
     setTimeout(() => {
         window.postMessage(
@@ -600,5 +599,5 @@ window.closeWindow = () => {
             window.location.origin,
         );
         window.close();
-    }, 100);
+    }, 300);
 };

--- a/packages/connect-ui/global.d.ts
+++ b/packages/connect-ui/global.d.ts
@@ -2,3 +2,7 @@ declare module '*.svg' {
     const value: any;
     export = value;
 }
+
+interface Window {
+    closeWindow: () => void;
+}

--- a/packages/connect-ui/src/views/Error.tsx
+++ b/packages/connect-ui/src/views/Error.tsx
@@ -282,7 +282,7 @@ export const ErrorView = (props: ErrorViewProps) => {
                 <Button
                     data-test="@connect-ui/error-close-button"
                     variant="primary"
-                    onClick={() => window.close()}
+                    onClick={() => window.closeWindow()}
                 >
                     Close
                 </Button>

--- a/packages/connect-ui/src/views/Transport.tsx
+++ b/packages/connect-ui/src/views/Transport.tsx
@@ -14,7 +14,7 @@ export const Transport = () => (
         your Trezor device and your internet browser."
         image={<Image imageSrc={imageSrc} />}
         buttons={
-            <Link variant="nostyle" href={SUITE_BRIDGE_URL} onClick={() => window.close()}>
+            <Link variant="nostyle" href={SUITE_BRIDGE_URL} onClick={() => window.closeWindow()}>
                 <Button variant="primary" icon="EXTERNAL_LINK" iconAlignment="right">
                     Install Bridge
                 </Button>

--- a/packages/connect-web/src/channels/serviceworker-window.ts
+++ b/packages/connect-web/src/channels/serviceworker-window.ts
@@ -78,6 +78,12 @@ export class ServiceWorkerWindowChannel<
                 if (webextensionId) {
                     whitelist.push(`chrome-extension://${webextensionId}`);
                 }
+                // For Firefox the webextensionId is different from the URL
+                const webextensionUrl = chrome?.runtime?.getURL('');
+                if (webextensionUrl) {
+                    // Without trailing slash
+                    whitelist.push(webextensionUrl.slice(0, -1));
+                }
 
                 if (!origin) {
                     this.logger?.error(


### PR DESCRIPTION
## Description

In Firefox, there are additional security protections that cause the following error with our content script: 

```
Not allowed to define cross-origin object as property on [Object] or [Array] XrayWrapper
```

This is solved by cloning objects that are passed between content script and the page. 

Followup: make sure our Explorer example works on Firefox