### PR TITLE
Upload source maps to Sentry

### DIFF
--- a/.github/workflows/build-desktop-apps.yml
+++ b/.github/workflows/build-desktop-apps.yml
@@ -60,6 +60,8 @@ jobs:
           yarn workspace @trezor/transport-bridge build:lib
 
       - name: Build ${{ matrix.platform }} suite-desktop
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           yarn workspace @trezor/suite-desktop build:${{ matrix.platform }}
           bash packages/suite-desktop-core/scripts/gnupg-sign.sh
@@ -115,6 +117,8 @@ jobs:
           yarn workspace @trezor/transport-bridge build:lib
 
       - name: Build ${{env.platform}} suite-desktop
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           yarn workspace @trezor/suite-desktop build:${{env.platform}}
           bash packages/suite-desktop-core/scripts/gnupg-sign.sh

--- a/.github/workflows/build-suite-web.yml
+++ b/.github/workflows/build-suite-web.yml
@@ -61,6 +61,7 @@ jobs:
         env:
           ASSET_PREFIX: /suite-web/${{ steps.extract_branch.outputs.branch }}/web
           DESKTOP_APP_NAME: "Trezor-Suite"
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           yarn message-system-sign-config
           yarn workspace @trezor/suite-data build:lib

--- a/.github/workflows/release-suite-desktop-web-staging.yml
+++ b/.github/workflows/release-suite-desktop-web-staging.yml
@@ -176,6 +176,7 @@ jobs:
         env:
           ASSET_PREFIX: /web
           STAGING_SUITE_SERVER_URL: https://staging-suite.trezor.io
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           yarn message-system-sign-config
           yarn workspace @trezor/suite-data build:lib

--- a/.github/workflows/release-suite-desktop-web-staging.yml
+++ b/.github/workflows/release-suite-desktop-web-staging.yml
@@ -69,6 +69,8 @@ jobs:
           yarn workspace @trezor/suite-data build:lib
           yarn workspace @trezor/transport-bridge build:lib
       - name: Build ${{ matrix.platform }} suite-desktop
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           yarn workspace @trezor/suite-desktop build:${{ matrix.platform }}
           bash packages/suite-desktop-core/scripts/gnupg-sign.sh

--- a/packages/suite-build/configs/base.webpack.config.ts
+++ b/packages/suite-build/configs/base.webpack.config.ts
@@ -185,12 +185,13 @@ const config: webpack.Configuration = {
         ...(!isDev && sentryAuthToken
             ? [
                   sentryWebpackPlugin({
+                      telemetry: false,
                       org: 'satoshilabs',
                       project: 'trezor-suite',
                       authToken: sentryAuthToken,
                       release: { name: sentryRelease, cleanArtifacts: true },
                       sourcemaps: {
-                          assets: path.join(getPathForProject(project), 'build'),
+                          assets: path.join(getPathForProject(project), 'build', '**'),
                           ignore: ['static/connect'], // connect does not contain source maps for now
                       },
                   }),

--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -45,6 +45,7 @@
         "@playwright/browser-firefox": "^1.41.2",
         "@playwright/browser-webkit": "^1.41.2",
         "@playwright/test": "^1.41.2",
+        "@sentry/webpack-plugin": "^2.14.0",
         "@trezor/trezor-user-env-link": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@types/electron-localshortcut": "^3.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11111,6 +11111,7 @@ __metadata:
     "@playwright/browser-webkit": "npm:^1.41.2"
     "@playwright/test": "npm:^1.41.2"
     "@sentry/electron": "npm:^4.17.0"
+    "@sentry/webpack-plugin": "npm:^2.14.0"
     "@suite-common/message-system": "workspace:*"
     "@suite-common/sentry": "workspace:*"
     "@suite-common/suite-types": "workspace:*"


### PR DESCRIPTION
## Description

Recently, there were no source maps in Sentry which made bugfixing nearly impossible. I identified and hopefully fixed these two issues:

- `SENTRY_AUTH_TOKEN` hasn't been passed to proper Github CI jobs (probably consequence of migrating from Gitlab) so source maps uploading step was always skipped
- when `@sentry/webpack-plugin` was bumped to `2.*`, `include` path in config hasn't been properly changed to glob pattern so no files were ever found

## Commits

- https://github.com/trezor/trezor-suite/pull/13051/commits/ab4d651c671e43481179ba9868a8f34d3398db1e - `SENTRY_AUTH_TOKEN` passed to `[Build] suite-desktop apps` and `[Release] suite-desktop and suite-web staging` workflows to enable source maps for desktop builds
- https://github.com/trezor/trezor-suite/pull/13051/commits/8b09a0aa53b4e4e079c241ed3d0c4652fa95e9ba - `SENTRY_AUTH_TOKEN` passed to `[Build] suite-web` and `[Release] suite-desktop and suite-web staging` workflows to enable source maps for web builds
- https://github.com/trezor/trezor-suite/pull/13051/commits/406a04cc79a39dea94c11c7e2178c2777501ffad - path in `base.webpack.config.ts` changed to glob pattern to properly find and upload source maps
- https://github.com/trezor/trezor-suite/pull/13051/commits/6018a7a0f9208620a649cab59994f5dc0d8f3044 - `sentryWebpackPlugin` with almost identical configuration added to `core.webpack.plugin.ts` in order to enable source maps even for electron main/connect/blockchain-link code

## Followups

- it would be nice to upload source maps for both main and renderer js code in one step; that would probably require using `sentry-cli` instead of webpack plugin
- currently, source maps are separately uploaded for every platform, because even the common CI steps are not shared between corresponding jobs
- `yarn message-system-sign-config` now generates different `config.v1.ts` on every run, which makes the build process unstable, e.g. `main.[contenthash:8].js` has different name in every platform build. I believe this must be resolved before the previous one.