### PR TITLE
feat(suite): Apply new ResizableBox component to Sidebar

### DIFF
--- a/packages/components/src/components/ResizableBox/ResizableBox.stories.tsx
+++ b/packages/components/src/components/ResizableBox/ResizableBox.stories.tsx
@@ -11,7 +11,6 @@ const Container = styled.div`
 const Content = styled.div`
     background: green;
     padding: 10px;
-    border-radius: 8px;
     font-weight: 900;
     width: 100%;
     height: 100%;

--- a/packages/components/src/components/ResizableBox/ResizableBoxExamples.stories.tsx
+++ b/packages/components/src/components/ResizableBox/ResizableBoxExamples.stories.tsx
@@ -16,7 +16,6 @@ const Wrapper = styled.div`
 const Content = styled.div<{ $color: string }>`
     background: ${({ $color }) => $color};
     padding: 10px;
-    border-radius: 8px;
     font-weight: 900;
     width: 100%;
     height: 100%;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Sidebar.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Sidebar.tsx
@@ -4,35 +4,38 @@ import { DeviceSelector } from '../DeviceSelector/DeviceSelector';
 import { Navigation } from './Navigation';
 import { AccountsMenu } from 'src/components/wallet/WalletLayout/AccountsMenu/AccountsMenu';
 import { QuickActions } from './QuickActions';
-import { ElevationUp, useElevation } from '@trezor/components';
+import { ElevationUp, ResizableBox, useElevation } from '@trezor/components';
 import { SIDEBAR_WIDTH_NUMERIC } from 'src/constants/suite/layout';
-import { Elevation, mapElevationToBackground, mapElevationToBorder } from '@trezor/theme';
+import { Elevation, mapElevationToBackground, mapElevationToBorder, zIndices } from '@trezor/theme';
 
 const Container = styled.nav<{ $elevation: Elevation }>`
     display: flex;
     flex-direction: column;
     flex: 0 0 auto;
-    width: ${SIDEBAR_WIDTH_NUMERIC}px;
-    resize: horizontal;
-    min-width: 200px;
-    max-width: 400px;
     height: 100%;
     background: ${mapElevationToBackground};
     border-right: 1px solid ${mapElevationToBorder};
-    overflow: auto;
 `;
 
 export const Sidebar = () => {
     const { elevation } = useElevation();
 
     return (
-        <Container $elevation={elevation}>
-            <ElevationUp>
-                <DeviceSelector />
-                <Navigation />
-                <AccountsMenu />
-                <QuickActions />
-            </ElevationUp>
-        </Container>
+        <ResizableBox
+            directions={['right']}
+            width={SIDEBAR_WIDTH_NUMERIC}
+            minWidth={230}
+            maxWidth={400}
+            zIndex={zIndices.draggableComponent}
+        >
+            <Container $elevation={elevation}>
+                <ElevationUp>
+                    <DeviceSelector />
+                    <Navigation />
+                    <AccountsMenu />
+                    <QuickActions />
+                </ElevationUp>
+            </Container>
+        </ResizableBox>
     );
 };

--- a/packages/theme/src/zIndices.ts
+++ b/packages/theme/src/zIndices.ts
@@ -11,6 +11,7 @@ export const zIndices = {
     discoveryProgress: 41,
 
     modal: 40, // above other suite content to disable interacting with it
+    draggableComponent: 35, // sidebar, above other content to be visible when dragged, resized
     navigationBar: 30,
     expandableNavigationHeader: 21, // above EXPANDABLE_NAVIGATION to cover its box-shadow
     expandableNavigation: 20, // above PAGE_HEADER to spread over it


### PR DESCRIPTION
## Description

Replace the older way of resizing the sidebar (using simple css) with the new `ResizableBox` component to achieve better user experience. Also adjust the component itself to be able to respond according to changing the window size.
 
Responsive items in the sidebar - will probably be implemented in a followup PR.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/12955

## Videos:
**Before:**

https://github.com/trezor/trezor-suite/assets/13417815/1eb462fe-8b91-4a83-96e3-fb44fb7e1902

**After:**

https://github.com/trezor/trezor-suite/assets/13417815/de42e518-b127-4d58-8fb7-ce4694340b71


