### PR TITLE
feat(suite-native): Coin Enabling  feature flag

### DIFF
--- a/suite-native/discovery/package.json
+++ b/suite-native/discovery/package.json
@@ -25,6 +25,7 @@
         "@suite-native/config": "workspace:*",
         "@suite-native/device": "workspace:*",
         "@suite-native/device-mutex": "workspace:*",
+        "@suite-native/feature-flags": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/utils": "workspace:*",
         "proxy-memoize": "2.0.2",

--- a/suite-native/discovery/src/discoveryConfigSlice.ts
+++ b/suite-native/discovery/src/discoveryConfigSlice.ts
@@ -17,7 +17,7 @@ import { NetworkSymbol } from '@suite-common/wallet-config';
 type DiscoveryConfigState = {
     areTestnetsEnabled: boolean;
     discoveryStartTimeStamp: number | null;
-    disabledDiscoveryNetworkSymbolsForDevelopment: NetworkSymbol[];
+    enabledDiscoveryNetworkSymbols: NetworkSymbol[];
 };
 
 type DiscoveryConfigSliceRootState = {
@@ -27,12 +27,12 @@ type DiscoveryConfigSliceRootState = {
 const discoveryConfigInitialState: DiscoveryConfigState = {
     areTestnetsEnabled: false,
     discoveryStartTimeStamp: null,
-    disabledDiscoveryNetworkSymbolsForDevelopment: [],
+    enabledDiscoveryNetworkSymbols: [],
 };
 
 export const discoveryConfigPersistWhitelist: Array<keyof DiscoveryConfigState> = [
     'areTestnetsEnabled',
-    'disabledDiscoveryNetworkSymbolsForDevelopment',
+    'enabledDiscoveryNetworkSymbols',
 ];
 
 export const discoveryConfigSlice = createSlice({
@@ -45,20 +45,19 @@ export const discoveryConfigSlice = createSlice({
         setDiscoveryStartTimestamp: (state, { payload }: PayloadAction<number | null>) => {
             state.discoveryStartTimeStamp = payload;
         },
-        toggleDisabledDiscoveryNetworkSymbolsForDevelopment: (
+        toggleEnabledDiscoveryNetworkSymbols: (
             state,
             { payload }: PayloadAction<NetworkSymbol>,
         ) => {
             const networkSymbol = payload;
-            const index =
-                state.disabledDiscoveryNetworkSymbolsForDevelopment.indexOf(networkSymbol);
+            const index = state.enabledDiscoveryNetworkSymbols.indexOf(networkSymbol);
 
             if (index !== -1) {
                 // If the network is already in the list, remove it
-                state.disabledDiscoveryNetworkSymbolsForDevelopment.splice(index, 1);
+                state.enabledDiscoveryNetworkSymbols.splice(index, 1);
             } else {
                 // If the network is not in the list, add it
-                state.disabledDiscoveryNetworkSymbolsForDevelopment.push(networkSymbol);
+                state.enabledDiscoveryNetworkSymbols.push(networkSymbol);
             }
         },
     },
@@ -68,9 +67,8 @@ export const selectAreTestnetsEnabled = (state: DiscoveryConfigSliceRootState) =
     state.discoveryConfig.areTestnetsEnabled;
 export const selectDiscoveryStartTimeStamp = (state: DiscoveryConfigSliceRootState) =>
     state.discoveryConfig.discoveryStartTimeStamp;
-export const selectDisabledDiscoveryNetworkSymbolsForDevelopment = (
-    state: DiscoveryConfigSliceRootState,
-) => state.discoveryConfig.disabledDiscoveryNetworkSymbolsForDevelopment;
+export const selectEnabledDiscoveryNetworkSymbols = (state: DiscoveryConfigSliceRootState) =>
+    state.discoveryConfig.enabledDiscoveryNetworkSymbols;
 
 export const selectDiscoverySupportedNetworks = memoizeWithArgs(
     (state: DeviceRootState, areTestnetsEnabled: boolean) =>
@@ -88,6 +86,6 @@ export const selectDiscoverySupportedNetworks = memoizeWithArgs(
 export const {
     toggleAreTestnetsEnabled,
     setDiscoveryStartTimestamp,
-    toggleDisabledDiscoveryNetworkSymbolsForDevelopment,
+    toggleEnabledDiscoveryNetworkSymbols,
 } = discoveryConfigSlice.actions;
 export const discoveryConfigReducer = discoveryConfigSlice.reducer;

--- a/suite-native/discovery/tsconfig.json
+++ b/suite-native/discovery/tsconfig.json
@@ -28,6 +28,7 @@
         { "path": "../config" },
         { "path": "../device" },
         { "path": "../device-mutex" },
+        { "path": "../feature-flags" },
         { "path": "../../packages/connect" },
         { "path": "../../packages/utils" }
     ]

--- a/suite-native/feature-flags/src/featureFlagsSlice.ts
+++ b/suite-native/feature-flags/src/featureFlagsSlice.ts
@@ -8,6 +8,7 @@ export const FeatureFlag = {
     IsPassphraseEnabled: 'isPassphraseEnabled',
     IsSendEnabled: 'isSendEnabled',
     IsRegtestEnabled: 'isRegtestEnabled',
+    IsCoinEnablingActive: 'isCoinEnablingActive',
 } as const;
 export type FeatureFlag = (typeof FeatureFlag)[keyof typeof FeatureFlag];
 
@@ -22,6 +23,7 @@ export const featureFlagsInitialState: FeatureFlagsState = {
     [FeatureFlag.IsPassphraseEnabled]: isDebugEnv(),
     [FeatureFlag.IsSendEnabled]: isAndroid() && isDevelopOrDebugEnv(),
     [FeatureFlag.IsRegtestEnabled]: isDebugEnv() || isDetoxTestBuild(),
+    [FeatureFlag.IsCoinEnablingActive]: isDebugEnv(),
 };
 
 export const featureFlagsPersistedKeys: Array<keyof FeatureFlagsState> = [
@@ -29,6 +31,7 @@ export const featureFlagsPersistedKeys: Array<keyof FeatureFlagsState> = [
     FeatureFlag.IsPassphraseEnabled,
     FeatureFlag.IsSendEnabled,
     FeatureFlag.IsRegtestEnabled,
+    FeatureFlag.IsCoinEnablingActive,
 ];
 
 export const featureFlagsSlice = createSlice({

--- a/suite-native/module-dev-utils/src/components/DiscoveryCoinsFilter.tsx
+++ b/suite-native/module-dev-utils/src/components/DiscoveryCoinsFilter.tsx
@@ -3,9 +3,9 @@ import { useDispatch, useSelector } from 'react-redux';
 import { VStack, Text, HStack, Switch, Card } from '@suite-native/atoms';
 import {
     selectAreTestnetsEnabled,
-    selectDisabledDiscoveryNetworkSymbolsForDevelopment,
+    selectEnabledDiscoveryNetworkSymbols,
     selectDiscoverySupportedNetworks,
-    toggleDisabledDiscoveryNetworkSymbolsForDevelopment,
+    toggleEnabledDiscoveryNetworkSymbols,
 } from '@suite-native/discovery';
 import { DeviceRootState } from '@suite-common/wallet-core';
 import { NetworkSymbol } from '@suite-common/wallet-config';
@@ -15,12 +15,12 @@ export const DiscoveryCoinsFilter = () => {
     const networks = useSelector((state: DeviceRootState) =>
         selectDiscoverySupportedNetworks(state, areTestnetsEnabled),
     );
-    const disabledNetworkSymbols = useSelector(selectDisabledDiscoveryNetworkSymbolsForDevelopment);
+    const enabledNetworkSymbols = useSelector(selectEnabledDiscoveryNetworkSymbols);
 
     const dispatch = useDispatch();
 
     const handleSwitchChange = (network: NetworkSymbol) => {
-        dispatch(toggleDisabledDiscoveryNetworkSymbolsForDevelopment(network));
+        dispatch(toggleEnabledDiscoveryNetworkSymbols(network));
     };
 
     const uniqueNetworkSymbols = [...new Set(networks.map(n => n.symbol))];
@@ -28,14 +28,14 @@ export const DiscoveryCoinsFilter = () => {
     return (
         <Card>
             <VStack spacing="small">
-                <Text variant="titleSmall">Disable discovery of networks</Text>
+                <Text variant="titleSmall">Enable discovery of networks</Text>
                 <VStack>
                     {uniqueNetworkSymbols.map((network: NetworkSymbol) => (
                         <HStack justifyContent="space-between" key={network}>
                             <Text>{network.toUpperCase()}</Text>
                             <Switch
                                 onChange={() => handleSwitchChange(network)}
-                                isChecked={!disabledNetworkSymbols.includes(network)}
+                                isChecked={enabledNetworkSymbols.includes(network)}
                             />
                         </HStack>
                     ))}

--- a/suite-native/module-dev-utils/src/components/FeatureFlags.tsx
+++ b/suite-native/module-dev-utils/src/components/FeatureFlags.tsx
@@ -6,6 +6,7 @@ const featureFlagsTitleMap = {
     [FeatureFlagEnum.IsPassphraseEnabled]: 'Passphrase',
     [FeatureFlagEnum.IsSendEnabled]: 'Send',
     [FeatureFlagEnum.IsRegtestEnabled]: 'Regtest',
+    [FeatureFlagEnum.IsCoinEnablingActive]: 'Coin Enabling',
 } as const satisfies Record<FeatureFlagEnum, string>;
 
 const FeatureFlag = ({ featureFlag }: { featureFlag: FeatureFlagEnum }) => {

--- a/suite-native/module-dev-utils/src/screens/DevUtilsScreen.tsx
+++ b/suite-native/module-dev-utils/src/screens/DevUtilsScreen.tsx
@@ -13,6 +13,7 @@ import {
 } from '@suite-native/navigation';
 import { clearStorage } from '@suite-native/storage';
 import { getCommitHash, getSuiteVersion } from '@trezor/env-utils';
+import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
 
 import { RenderingUtils } from '../components/RenderingUtils';
 import { FeatureFlags } from '../components/FeatureFlags';
@@ -22,47 +23,51 @@ import { DevicePassphraseSwitch } from '../components/DevicePassphraseSwitch';
 
 export const DevUtilsScreen = ({
     navigation,
-}: StackProps<DevUtilsStackParamList, DevUtilsStackRoutes.DevUtils>) => (
-    <Screen screenHeader={<ScreenSubHeader content="DEV utils" />}>
-        <VStack>
-            <Card>
-                <VStack spacing="medium">
-                    {!isDebugEnv() && (
-                        <ListItem
-                            subtitle={`${getEnv()}-${getSuiteVersion()}, commit ${getCommitHash()}`}
-                            title="Build version"
-                        />
-                    )}
-                    {isDevelopOrDebugEnv() && (
-                        <Button onPress={() => navigation.navigate(DevUtilsStackRoutes.Demo)}>
-                            See Component Demo
+}: StackProps<DevUtilsStackParamList, DevUtilsStackRoutes.DevUtils>) => {
+    const [isCoinEnablingActive] = useFeatureFlag(FeatureFlag.IsCoinEnablingActive);
+
+    return (
+        <Screen screenHeader={<ScreenSubHeader content="DEV utils" />}>
+            <VStack>
+                <Card>
+                    <VStack spacing="medium">
+                        {!isDebugEnv() && (
+                            <ListItem
+                                subtitle={`${getEnv()}-${getSuiteVersion()}, commit ${getCommitHash()}`}
+                                title="Build version"
+                            />
+                        )}
+                        {isDevelopOrDebugEnv() && (
+                            <Button onPress={() => navigation.navigate(DevUtilsStackRoutes.Demo)}>
+                                See Component Demo
+                            </Button>
+                        )}
+                        <FeatureFlags />
+                        {isDevelopOrDebugEnv() && (
+                            <>
+                                <RenderingUtils />
+                                <DevicePassphraseSwitch />
+                            </>
+                        )}
+                        {isCoinEnablingActive && <DiscoveryCoinsFilter />}
+                        <Button
+                            onPress={() => {
+                                const errorMessage = `Sentry test error - ${Date.now()}`;
+                                Sentry.captureException(new Error(errorMessage));
+                                Alert.alert('Sentry error thrown', errorMessage);
+                            }}
+                        >
+                            Throw Sentry error
                         </Button>
-                    )}
-                    <FeatureFlags />
-                    {isDevelopOrDebugEnv() && (
-                        <>
-                            <RenderingUtils />
-                            <DevicePassphraseSwitch />
-                            <DiscoveryCoinsFilter />
-                        </>
-                    )}
-                    <Button
-                        onPress={() => {
-                            const errorMessage = `Sentry test error - ${Date.now()}`;
-                            Sentry.captureException(new Error(errorMessage));
-                            Alert.alert('Sentry error thrown', errorMessage);
-                        }}
-                    >
-                        Throw Sentry error
-                    </Button>
-                    <Button colorScheme="redElevation0" onPress={clearStorage}>
-                        Wipe all data
-                    </Button>
-                </VStack>
-            </Card>
-            <Card>
-                <TestnetsToggle />
-            </Card>
-        </VStack>
-    </Screen>
-);
+                        <Button colorScheme="redElevation0" onPress={clearStorage}>
+                            Wipe all data
+                        </Button>
+                    </VStack>
+                </Card>
+                <Card>
+                    <TestnetsToggle />
+                </Card>
+            </VStack>
+        </Screen>
+    );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -9281,6 +9281,7 @@ __metadata:
     "@suite-native/config": "workspace:*"
     "@suite-native/device": "workspace:*"
     "@suite-native/device-mutex": "workspace:*"
+    "@suite-native/feature-flags": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/utils": "workspace:*"
     proxy-memoize: "npm:2.0.2"


### PR DESCRIPTION
This PR introduces Coin Enabling under the feature flag and use it for discovery. It also resets what networks are being discovered on Develop.

- [x] create feature flag IsCoinEnablingActive and set it default to false
- [x] rework disabledDiscoveryNetworkSymbolsForDevelopment into whitelist
- [x] make it work the same for users without ff enabled


Resolve #13005
