### PR TITLE
test(suite-web): increase timeout to avoid flakiness

### DIFF
--- a/packages/suite-web/e2e/tests/wallet/pending-transactions.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/pending-transactions.test.ts
@@ -59,6 +59,7 @@ describe('Use regtest to test pending transactions', () => {
                 // however, after a while it is replaced by a standard pending transaction
                 cy.getTestElement(`@transaction-item/0/heading`).click({
                     scrollBehavior: 'bottom',
+                    timeout: 60000,
                 });
                 // count has not changed
                 cy.getTestElement('@transaction-group/pending/count').contains(index + 1);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This test is flaky due to transaction sometimes being fetched with a delay. See [this failed job](https://github.com/trezor/trezor-suite/actions/runs/9658897900/job/26641300896) and [successful rerun](https://github.com/trezor/trezor-suite/actions/runs/9658897900).