### PR TITLE
feat(suite-native): passphrase on device only when possible

### DIFF
--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -709,6 +709,12 @@ export const selectDeviceByState = (state: DeviceRootState, deviceState: string)
 export const selectDeviceUnavailableCapabilities = (state: DeviceRootState) =>
     state.device.selectedDevice?.unavailableCapabilities;
 
+export const selectDeviceCapabilities = (state: DeviceRootState) =>
+    selectDeviceFeatures(state)?.capabilities;
+
+export const selectHasDevicePassphraseEntryCapability = (state: DeviceRootState) =>
+    !!selectDeviceCapabilities(state)?.includes('Capability_PassphraseEntry');
+
 export const selectDeviceStatus = (state: DeviceRootState) => {
     const device = selectDevice(state);
 

--- a/suite-native/module-passphrase/src/components/PassphraseForm.tsx
+++ b/suite-native/module-passphrase/src/components/PassphraseForm.tsx
@@ -13,7 +13,12 @@ import {
 import { Button, Card, VStack, TextDivider } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { Translation } from '@suite-native/intl';
-import { deviceActions, onPassphraseSubmit, selectDevice } from '@suite-common/wallet-core';
+import {
+    deviceActions,
+    onPassphraseSubmit,
+    selectDevice,
+    selectHasDevicePassphraseEntryCapability,
+} from '@suite-common/wallet-core';
 import {
     PassphraseStackParamList,
     PassphraseStackRoutes,
@@ -54,6 +59,9 @@ export const PassphraseForm = ({ inputLabel, onFocus }: PassphraseFormProps) => 
     const { applyStyle } = useNativeStyles();
 
     const device = useSelector(selectDevice);
+    const hasDevicePassphraseEntryCapability = useSelector(
+        selectHasDevicePassphraseEntryCapability,
+    );
 
     const navigation = useNavigation<NavigationProp>();
 
@@ -108,7 +116,7 @@ export const PassphraseForm = ({ inputLabel, onFocus }: PassphraseFormProps) => 
                             </Button>
                         </Animated.View>
                     )}
-                    {!isDirty && !isInputFocused && (
+                    {!isDirty && !isInputFocused && hasDevicePassphraseEntryCapability && (
                         <Animated.View entering={FadeIn} exiting={FadeOut}>
                             <VStack>
                                 <TextDivider


### PR DESCRIPTION
Only let user insert passphrase on device when supported by actual device

## Related Issue

Resolve #12703

## Screenshots:

https://github.com/trezor/trezor-suite/assets/2011829/f3cfffc8-f481-47fd-9a0c-2192dcbe3bc0

<img src="https://github.com/trezor/trezor-suite/assets/2011829/b2fc13f9-6645-4161-aff4-dd52be4a3bd3" width=350 />


