### PR TITLE
feat(suite-native): passphrase loading has subtitle

### DIFF
--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -673,7 +673,10 @@ export const en = {
             title: 'Continue on Trezor',
             subtitle: 'Enter your passphrase on your Trezor',
         },
-        loadingTitle: 'Checking passphrase wallet for balances & transactions',
+        loading: {
+            title: 'Checking passphrase wallet for balances & transactions',
+            subtitle: 'This might take up to a minute.',
+        },
         confirmOnDevice: {
             title: 'Confirm passphrase\non your Trezor.',
             description: 'Go to your device and confirm the passphrase you’ve entered.',
@@ -696,7 +699,7 @@ export const en = {
                 button: 'Try again',
             },
             confirmEmptyWalletSheet: {
-                title: 'Passphrase best practises',
+                title: 'Passphrase best practices',
                 list: {
                     backup: 'Write it down on paper & keep it away from anything digital (no cloud, USB, internet, phone).',
                     store: 'Store it in a secure location, separate from both your wallet backup and Trezor device.',

--- a/suite-native/module-passphrase/src/screens/PassphraseLoadingScreen.tsx
+++ b/suite-native/module-passphrase/src/screens/PassphraseLoadingScreen.tsx
@@ -60,9 +60,14 @@ export const PassphraseLoadingScreen = () => {
         <PassphraseScreenWrapper>
             <VStack flex={1} justifyContent="center" alignItems="center" spacing="extraLarge">
                 <Spinner loadingState={loadingResult} onComplete={handleSuccess} />
-                <Text variant="titleSmall" textAlign="center">
-                    <Translation id="modulePassphrase.loadingTitle" />
-                </Text>
+                <VStack spacing="extraSmall">
+                    <Text variant="titleSmall" textAlign="center">
+                        <Translation id="modulePassphrase.loading.title" />
+                    </Text>
+                    <Text variant="body" textAlign="center" color="textSubdued">
+                        <Translation id="modulePassphrase.loading.subtitle" />
+                    </Text>
+                </VStack>
             </VStack>
         </PassphraseScreenWrapper>
     );


### PR DESCRIPTION
Add subtitle to passphrase loading

## Related Issue

Resolve #12719

## Screenshots:

https://github.com/trezor/trezor-suite/assets/2011829/0ed828c9-92b2-4d8b-997b-822afd0fbdbd

