### PR TITLE
Killing old bridge

### DIFF
--- a/packages/connect-popup/e2e/tests/browser-support.test.ts
+++ b/packages/connect-popup/e2e/tests/browser-support.test.ts
@@ -69,7 +69,7 @@ test('outdated-browser', async ({ browser }) => {
     log('clicking on analytics continue button');
     await waitAndClick(popup, ['@analytics/continue-button']);
     // In Firefox it should display Install Bridge page.
-    await popup.getByRole('heading', { name: 'Install Bridge' });
+    await popup.getByRole('heading', { name: "Browser can't communicate with device" });
     await popup.close({ runBeforeUnload: true });
     await page.close();
     await context.close();

--- a/packages/connect-popup/e2e/tests/transport.test.ts
+++ b/packages/connect-popup/e2e/tests/transport.test.ts
@@ -46,14 +46,20 @@ const fixtures = [
         browser: firefox,
         description: `bridge is the only available transport`,
         queryString: '',
-        expect: () => expect(popup.getByRole('heading', { name: 'Install Bridge' })).toBeVisible(),
+        expect: () =>
+            expect(
+                popup.getByRole('heading', { name: "Browser can't communicate with device" }),
+            ).toBeVisible(),
     },
     {
         browser: chromium,
         description: `iframe and host different origins: iframe mode -> bridge`,
         queryString: `?trezor-connect-src=${simulatedCrossOrigin}`,
         before: handleSimulatedCrossOrigin,
-        expect: () => expect(popup.getByRole('heading', { name: 'Install Bridge' })).toBeVisible(),
+        expect: () =>
+            expect(
+                popup.getByRole('heading', { name: "Browser can't communicate with device" }),
+            ).toBeVisible(),
     },
     {
         browser: chromium,

--- a/packages/connect-popup/src/view/selectDevice.ts
+++ b/packages/connect-popup/src/view/selectDevice.ts
@@ -11,7 +11,7 @@ import {
     WEBEXTENSION,
 } from '@trezor/connect';
 import { TREZOR_USB_DESCRIPTORS } from '@trezor/transport/src/constants';
-import { SUITE_BRIDGE_URL, SUITE_UDEV_URL, TREZOR_SUPPORT_URL } from '@trezor/urls';
+import { SUITE_URL, SUITE_UDEV_URL, TREZOR_SUPPORT_URL } from '@trezor/urls';
 import { container, getState, showView, postMessage } from './common';
 import { reactEventBus } from '@trezor/connect-ui/src/utils/eventBus';
 
@@ -192,7 +192,7 @@ export const selectDevice = (payload: UiRequestSelectDevice['payload']) => {
                 }
                 // webusb error handling (top priority)
                 if (payload.webusb) {
-                    explanationContent = `Please install <a href="${SUITE_BRIDGE_URL}" target="_blank" rel="noreferrer noopener" onclick="window.closeWindow();">Bridge</a> to use Trezor device.`;
+                    explanationContent = `An error with WebUSB occurred. Please install <a href="${SUITE_URL}" target="_blank" rel="noreferrer noopener" onclick="window.closeWindow();">Trezor Suite</a> to use Trezor device.`;
                 }
                 deviceButton.disabled = true;
                 deviceName.textContent = 'Unrecognized device';

--- a/packages/connect-ui/package.json
+++ b/packages/connect-ui/package.json
@@ -17,6 +17,7 @@
         "@trezor/connect-analytics": "workspace:*",
         "@trezor/connect-common": "workspace:*",
         "@trezor/env-utils": "workspace:*",
+        "@trezor/react-utils": "workspace:*",
         "@trezor/urls": "workspace:*",
         "react-intl": "^6.6.2"
     },

--- a/packages/connect-ui/src/components/Notification.tsx
+++ b/packages/connect-ui/src/components/Notification.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import styled from 'styled-components';
 
 import { Icon, Button } from '@trezor/components';
-import { SUITE_FIRMWARE_URL, SUITE_BRIDGE_URL, SUITE_BACKUP_URL } from '@trezor/urls';
+import { SUITE_FIRMWARE_URL, SUITE_URL, SUITE_BACKUP_URL } from '@trezor/urls';
 
 const NotificationBox = styled.div`
     background-color: ${({ color }) => color};
@@ -134,9 +134,9 @@ export const BackupNotification = () => (
 export const BridgeUpdateNotification = () => (
     <Notification
         variant="warning"
-        header="New bridge is available"
-        body=""
-        cta={{ desc: 'Update bridge', url: SUITE_BRIDGE_URL }}
+        header="Current bridge is outdated"
+        body="Trezor Bridge is no longer supported. Switch to Trezor Suite desktop for the best experience."
+        cta={{ desc: 'Install Trezor Suite', url: SUITE_URL }}
     />
 );
 

--- a/packages/connect-ui/src/views/Transport.tsx
+++ b/packages/connect-ui/src/views/Transport.tsx
@@ -1,24 +1,58 @@
-import { Button, Link, Image } from '@trezor/components';
-import type { UiEvent } from '@trezor/connect';
-import { SUITE_BRIDGE_URL } from '@trezor/urls';
+import { FormattedMessage } from 'react-intl';
+
+import { Button, Image } from '@trezor/components';
+import { type UiEvent } from '@trezor/connect';
+import { SUITE_URL, SUITE_BRIDGE_DEEPLINK } from '@trezor/urls';
+import { useWindowFocus } from '@trezor/react-utils';
 
 import { View } from '../components/View';
 import imageSrc from '../images/man_with_laptop.svg';
 
 export type TransportEventProps = Extract<UiEvent, { type: 'ui-no_transport' }>;
 
-export const Transport = () => (
-    <View
-        title="Install Bridge"
-        description="The Bridge is a communication tool, which facilitates the connection between
-        your Trezor device and your internet browser."
-        image={<Image imageSrc={imageSrc} />}
-        buttons={
-            <Link variant="nostyle" href={SUITE_BRIDGE_URL} onClick={() => window.closeWindow()}>
-                <Button variant="primary" icon="EXTERNAL_LINK" iconAlignment="right">
-                    Install Bridge
-                </Button>
-            </Link>
-        }
-    />
-);
+export const Transport = () => {
+    const windowFocused = useWindowFocus();
+    const handleOpenSuite = () => {
+        location.href = SUITE_BRIDGE_DEEPLINK;
+
+        // fallback in case deeplink does not work
+        window.setTimeout(() => {
+            if (!windowFocused.current) return;
+
+            window.open(SUITE_URL);
+        }, 500);
+    };
+
+    return (
+        <View
+            title={
+                <FormattedMessage
+                    id="TR_NO_TRANSPORT"
+                    defaultMessage="Browser can't communicate with device"
+                />
+            }
+            description={
+                <FormattedMessage
+                    id="TR_BRIDGE_NEEDED_DESCRIPTION"
+                    defaultMessage="We recommend downloading and running the Trezor Suite desktop app in the background for the best experience. Alternatively, use a supported browser that is compatible with WebUSB"
+                />
+            }
+            image={<Image imageSrc={imageSrc} />}
+            buttons={
+                <>
+                    <Button
+                        variant="primary"
+                        icon="EXTERNAL_LINK"
+                        iconAlignment="right"
+                        onClick={handleOpenSuite}
+                    >
+                        <FormattedMessage
+                            id="TR_OPEN_TREZOR_SUITE_DESKTOP"
+                            defaultMessage="Open Trezor Suite desktop app"
+                        />
+                    </Button>
+                </>
+            }
+        />
+    );
+};

--- a/packages/connect-ui/tsconfig.json
+++ b/packages/connect-ui/tsconfig.json
@@ -7,6 +7,7 @@
         { "path": "../connect-analytics" },
         { "path": "../connect-common" },
         { "path": "../env-utils" },
+        { "path": "../react-utils" },
         { "path": "../urls" }
     ]
 }

--- a/packages/react-utils/src/hooks/useWindowFocus.ts
+++ b/packages/react-utils/src/hooks/useWindowFocus.ts
@@ -1,0 +1,22 @@
+import { useEffect, useRef } from 'react';
+
+export const useWindowFocus = () => {
+    const windowFocused = useRef(true);
+    useEffect(() => {
+        const blurHandler = () => {
+            windowFocused.current = false;
+        };
+        const focusHandler = () => {
+            windowFocused.current = true;
+        };
+        window.addEventListener('blur', blurHandler);
+        window.addEventListener('focus', focusHandler);
+
+        return () => {
+            window.removeEventListener('blur', blurHandler);
+            window.removeEventListener('focus', focusHandler);
+        };
+    }, []);
+
+    return windowFocused;
+};

--- a/packages/react-utils/src/index.ts
+++ b/packages/react-utils/src/index.ts
@@ -4,4 +4,5 @@ export { useKeyPress } from './hooks/useKeyPress';
 export { useOnce } from './hooks/useOnce';
 export { useOnClickOutside } from './hooks/useOnClickOutside';
 export { useTimer } from './hooks/useTimer';
+export { useWindowFocus } from './hooks/useWindowFocus';
 export type { Timer } from './hooks/useTimer';

--- a/packages/suite-desktop-api/src/__tests__/api.test.ts
+++ b/packages/suite-desktop-api/src/__tests__/api.test.ts
@@ -70,6 +70,15 @@ describe('DesktopApi', () => {
             api.appFocus(true);
         });
 
+        it('DesktopApi.appHide', () => {
+            const spy = jest.spyOn(ipcRenderer, 'send');
+            api.appHide();
+            expect(spy).toHaveBeenCalledWith('app/hide');
+
+            // @ts-expect-error no expected params
+            api.appHide(true);
+        });
+
         it('DesktopApi.checkForUpdates', () => {
             const spy = jest.spyOn(ipcRenderer, 'send');
             api.checkForUpdates();

--- a/packages/suite-desktop-api/src/api.ts
+++ b/packages/suite-desktop-api/src/api.ts
@@ -22,6 +22,7 @@ import {
 export interface MainChannels {
     'app/restart': void;
     'app/focus': void;
+    'app/hide': void;
     'store/clear': void;
     'theme/change': SuiteThemeVariant;
     'tor/get-status': void;
@@ -101,6 +102,7 @@ export interface DesktopApi {
     // App
     appRestart: DesktopApiSend<'app/restart'>;
     appFocus: DesktopApiSend<'app/focus'>;
+    appHide: DesktopApiSend<'app/hide'>;
     // Auto-updater
     checkForUpdates: DesktopApiSend<'update/check'>;
     downloadUpdate: DesktopApiSend<'update/download'>;

--- a/packages/suite-desktop-api/src/factory.ts
+++ b/packages/suite-desktop-api/src/factory.ts
@@ -45,6 +45,7 @@ export const factory = <R extends StrictIpcRenderer<any, IpcRendererEvent>>(
         // App
         appRestart: () => ipcRenderer.send('app/restart'),
         appFocus: () => ipcRenderer.send('app/focus'),
+        appHide: () => ipcRenderer.send('app/hide'),
 
         // Auto-updater
         checkForUpdates: isManual => {

--- a/packages/suite-desktop-core/src/modules/window-controls.ts
+++ b/packages/suite-desktop-core/src/modules/window-controls.ts
@@ -84,4 +84,9 @@ export const init: Module = ({ mainWindow }) => {
         logger.debug(SERVICE_NAME, 'Focus requested');
         app.focus({ steal: true });
     });
+
+    ipcMain.on('app/hide', () => {
+        logger.debug(SERVICE_NAME, 'Hide requested');
+        app.hide();
+    });
 };

--- a/packages/suite-web/e2e/tests/suite/bridge.test.ts
+++ b/packages/suite-web/e2e/tests/suite/bridge.test.ts
@@ -1,15 +1,6 @@
 // @group_suite
 // @retry=2
 
-const systems = [
-    'Linux 64-bit (deb)',
-    'Linux 64-bit (rpm)',
-    'Linux 32-bit (deb)',
-    'Linux 32-bit (rpm)',
-    'macOS',
-    'Windows',
-];
-
 describe('Bridge page', () => {
     beforeEach(() => {
         cy.viewport(1440, 2560).resetDb();
@@ -18,17 +9,7 @@ describe('Bridge page', () => {
     it('/bridge', () => {
         cy.prefixedVisit('/bridge');
 
-        // it correctly preselects installer by system
-        cy.getTestElement('@bridge/installers/input').should('contain', systems[0]);
-
-        // there is a dropdown with installers
-        cy.getTestElement('@bridge/installers/input').click();
-
-        // select listens to keyboard events
-        cy.get('body').type('{downarrow}{downarrow}{downarrow}{downarrow}{downarrow}{enter}');
-        cy.getTestElement('@bridge/installers/input').should('contain', 'Windows');
-
-        cy.getTestElement('@modal/bridge').matchImageSnapshot('bridge-modal', {
+        cy.getTestElement('@modal/bridge').matchImageSnapshot('bridge-modal-new', {
             blackout: ['[data-test="@bridge/download-button"]'],
         });
 
@@ -37,15 +18,6 @@ describe('Bridge page', () => {
 
         // connect device prompt with webusb enabled appears
         cy.getTestElement('@connect-device-prompt');
-
-        // linux platforms show udev rules link also
-        cy.getTestElement('@connect-device-prompt/no-device-detected').click();
-
-        cy.getTestElement('@goto/udev').click();
-        cy.getTestElement('@modal/udev').matchImageSnapshot('udev-modal');
-
-        // udev rules modal is closable via close button
-        cy.getTestElement('@modal/close-button').click();
     });
 });
 

--- a/packages/suite/src/actions/suite/protocolActions.ts
+++ b/packages/suite/src/actions/suite/protocolActions.ts
@@ -1,9 +1,11 @@
 import { PROTOCOL } from './constants';
-import { getProtocolInfo, isProtocolScheme } from 'src/utils/suite/protocol';
+import { getProtocolInfo, isPaymentRequestProtocolScheme } from 'src/utils/suite/protocol';
 import type { Dispatch } from 'src/types/suite';
 import type { PROTOCOL_SCHEME } from 'src/constants/suite/protocol';
 import type { SendFormState } from 'src/reducers/suite/protocolReducer';
 import { notificationsActions } from '@suite-common/toast-notifications';
+import * as routerActions from 'src/actions/suite/routerActions';
+import { SUITE_BRIDGE_DEEPLINK } from '@trezor/urls';
 
 export type ProtocolAction =
     | {
@@ -33,7 +35,7 @@ const saveCoinProtocol = (
 export const handleProtocolRequest = (uri: string) => (dispatch: Dispatch) => {
     const protocol = getProtocolInfo(uri);
 
-    if (protocol && isProtocolScheme(protocol.scheme)) {
+    if (protocol && isPaymentRequestProtocolScheme(protocol.scheme)) {
         const { scheme, amount, address } = protocol;
 
         dispatch(saveCoinProtocol(scheme, address, amount));
@@ -46,6 +48,8 @@ export const handleProtocolRequest = (uri: string) => (dispatch: Dispatch) => {
                 autoClose: false,
             }),
         );
+    } else if (uri === SUITE_BRIDGE_DEEPLINK) {
+        dispatch(routerActions.goto('suite-bridge-requested', { params: { cancelable: true } }));
     }
 };
 

--- a/packages/suite/src/components/suite/ConnectDevicePrompt.tsx
+++ b/packages/suite/src/components/suite/ConnectDevicePrompt.tsx
@@ -71,7 +71,7 @@ const getMessageId = ({
 }) => {
     switch (prerequisite) {
         case 'transport-bridge':
-            return 'TR_TREZOR_BRIDGE_IS_NOT_RUNNING';
+            return 'TR_NO_TRANSPORT';
         case 'device-bootloader':
             return 'TR_DEVICE_CONNECTED_BOOTLOADER';
         default: {

--- a/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
+++ b/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
@@ -150,7 +150,7 @@ describe('Preloader component', () => {
         const store = initStore(getInitialState());
         const { unmount } = renderWithProviders(store, <Index app={store.getState().router.app} />);
         expect(findByTestId('@connect-device-prompt')).not.toBeNull();
-        expect(findByTestId('TR_TREZOR_BRIDGE_IS_NOT_RUNNING')).not.toBeNull();
+        expect(findByTestId('TR_NO_TRANSPORT')).not.toBeNull();
 
         unmount();
     });

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUnreadable.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUnreadable.tsx
@@ -5,7 +5,7 @@ import { isDesktop, isLinux } from '@trezor/env-utils';
 import { Translation, TroubleshootingTips, UdevDownload } from 'src/components/suite';
 import {
     TROUBLESHOOTING_TIP_BRIDGE_STATUS,
-    TROUBLESHOOTING_TIP_BRIDGE_INSTALL,
+    TROUBLESHOOTING_TIP_SUITE_DESKTOP,
     TROUBLESHOOTING_TIP_CABLE,
     TROUBLESHOOTING_TIP_USB,
     TROUBLESHOOTING_TIP_DIFFERENT_COMPUTER,
@@ -109,7 +109,7 @@ export const DeviceUnreadable = ({ device, isWebUsbTransport }: DeviceUnreadable
         return (
             <TroubleshootingTips
                 label={<Translation id="TR_TROUBLESHOOTING_UNREADABLE_WEBUSB" />}
-                items={[TROUBLESHOOTING_TIP_BRIDGE_STATUS, TROUBLESHOOTING_TIP_BRIDGE_INSTALL]}
+                items={[TROUBLESHOOTING_TIP_BRIDGE_STATUS, TROUBLESHOOTING_TIP_SUITE_DESKTOP]}
                 offerWebUsb
                 data-test="@connect-device-prompt/unreadable-hid"
             />

--- a/packages/suite/src/components/suite/PrerequisitesGuide/PrerequisitesGuide.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/PrerequisitesGuide.tsx
@@ -92,7 +92,10 @@ export const PrerequisitesGuide = ({ allowSwitchDevice }: PrerequisitesGuideProp
         <Wrapper>
             <ConnectDevicePrompt
                 connected={!!device}
-                showWarning={!!(device && deviceNeedsAttention(getStatus(device)))}
+                showWarning={
+                    !!(device && deviceNeedsAttention(getStatus(device))) ||
+                    prerequisite === 'transport-bridge'
+                }
                 allowSwitchDevice={allowSwitchDevice && devices > 1}
                 prerequisite={prerequisite}
             />

--- a/packages/suite/src/components/suite/PrerequisitesGuide/Transport.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/Transport.tsx
@@ -1,19 +1,21 @@
 import { Translation, TroubleshootingTips } from 'src/components/suite';
 import {
-    TROUBLESHOOTING_TIP_BRIDGE_STATUS,
-    TROUBLESHOOTING_TIP_BRIDGE_INSTALL,
+    TROUBLESHOOTING_TIP_SUITE_DESKTOP,
     TROUBLESHOOTING_TIP_RESTART_COMPUTER,
+    TROUBLESHOOTING_TIP_WEBUSB_ENVIRONMENT,
 } from 'src/components/suite/troubleshooting/tips';
 
 export const Transport = () => (
     // No transport layer (bridge/webUSB) is available
-    // On web it makes sense to offer downloading Trezor Bridge
+    // On web it makes sense to
+    // - offer downloading Trezor Suite desktop, or
+    // - use a browser that supports WebUSB
     // Desktop app should have Bridge transport layer available as it is built-in, if it is not available we fucked up something.
     <TroubleshootingTips
-        label={<Translation id="TR_TROUBLESHOOTING_BRIDGE_IS_NOT_RUNNING" />}
+        label={<Translation id="TR_TROUBLESHOOTING_DEVICE_NOT_DETECTED" />}
         items={[
-            TROUBLESHOOTING_TIP_BRIDGE_STATUS,
-            TROUBLESHOOTING_TIP_BRIDGE_INSTALL,
+            TROUBLESHOOTING_TIP_WEBUSB_ENVIRONMENT,
+            TROUBLESHOOTING_TIP_SUITE_DESKTOP,
             TROUBLESHOOTING_TIP_RESTART_COMPUTER,
         ]}
         data-test="@connect-device-prompt/bridge-not-running"

--- a/packages/suite/src/components/suite/modals/ModalSwitcher/ForegroundAppModal.tsx
+++ b/packages/suite/src/components/suite/modals/ModalSwitcher/ForegroundAppModal.tsx
@@ -4,7 +4,7 @@ import { Recovery } from 'src/views/recovery';
 import { Backup } from 'src/views/backup';
 import { useDispatch } from 'src/hooks/suite';
 import { closeModalApp } from 'src/actions/suite/routerActions';
-import { InstallBridge } from 'src/views/suite/bridge';
+import { BridgeUnavailable } from 'src/views/suite/bridge';
 import { UdevRules } from 'src/views/suite/udev';
 import { Version } from 'src/views/suite/version';
 import { SwitchDevice } from 'src/views/suite/SwitchDevice/SwitchDevice';
@@ -22,7 +22,7 @@ const getForegroundApp = (app: ForegroundAppRoute['app']) => {
         'firmware-type': FirmwareType,
         'firmware-custom': FirmwareCustom,
         version: Version,
-        bridge: InstallBridge,
+        bridge: BridgeUnavailable,
         'bridge-requested': BridgeRequested,
         udev: UdevRules,
         'switch-device': SwitchDevice,

--- a/packages/suite/src/components/suite/modals/ModalSwitcher/ForegroundAppModal.tsx
+++ b/packages/suite/src/components/suite/modals/ModalSwitcher/ForegroundAppModal.tsx
@@ -11,6 +11,7 @@ import { SwitchDevice } from 'src/views/suite/SwitchDevice/SwitchDevice';
 import type { ForegroundAppRoute } from 'src/types/suite';
 import { FunctionComponent } from 'react';
 import { MultiShareBackupModal } from '../ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupModal';
+import { BridgeRequested } from 'src/views/suite/bridge-requested';
 
 // would not work if defined directly in the switch
 const FirmwareType = () => <FirmwareUpdate shouldSwitchFirmwareType />;
@@ -22,6 +23,7 @@ const getForegroundApp = (app: ForegroundAppRoute['app']) => {
         'firmware-custom': FirmwareCustom,
         version: Version,
         bridge: InstallBridge,
+        'bridge-requested': BridgeRequested,
         udev: UdevRules,
         'switch-device': SwitchDevice,
         recovery: Recovery,

--- a/packages/suite/src/components/suite/troubleshooting/tips.tsx
+++ b/packages/suite/src/components/suite/troubleshooting/tips.tsx
@@ -6,6 +6,7 @@ import { useDispatch } from 'src/hooks/suite';
 import { goto } from 'src/actions/suite/routerActions';
 import { typography } from '@trezor/theme';
 import styled from 'styled-components';
+import { isWebUsb } from 'src/utils/suite/transport';
 
 const Wrapper = styled.div`
     a {
@@ -63,7 +64,7 @@ const BridgeInstall = () => {
     return (
         <Wrapper>
             <Translation
-                id="TR_TROUBLESHOOTING_TIP_BRIDGE_INSTALL_DESCRIPTION"
+                id="TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_DESCRIPTION"
                 values={{
                     a: chunks => (
                         <TrezorLink variant="underline" onClick={handleClick}>
@@ -104,9 +105,16 @@ export const TROUBLESHOOTING_TIP_BRIDGE_STATUS = {
     hide: !isWeb(),
 };
 
-export const TROUBLESHOOTING_TIP_BRIDGE_INSTALL = {
-    key: 'bridge-install',
-    heading: <Translation id="TR_TROUBLESHOOTING_TIP_BRIDGE_INSTALL_TITLE" />,
+export const TROUBLESHOOTING_TIP_WEBUSB_ENVIRONMENT = {
+    key: 'webusb-environment',
+    heading: <Translation id="TR_TROUBLESHOOTING_TIP_BROWSER_WEBUSB_TITLE" />,
+    description: <Translation id="TR_TROUBLESHOOTING_TIP_BROWSER_WEBUSB_DESCRIPTION" />,
+    hide: isWebUsb(),
+};
+
+export const TROUBLESHOOTING_TIP_SUITE_DESKTOP = {
+    key: 'suite-desktop',
+    heading: <Translation id="TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_TITLE" />,
     description: <BridgeInstall />,
     hide: !isWeb(),
 };

--- a/packages/suite/src/hooks/suite/usePreferredModal.ts
+++ b/packages/suite/src/hooks/suite/usePreferredModal.ts
@@ -15,6 +15,7 @@ const hasPriority = (route: ForegroundAppRoute) => {
         'firmware-type': true,
         'firmware-custom': true,
         bridge: true,
+        'bridge-requested': true,
         udev: true,
         version: true,
         'create-multi-share-backup': true,

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3783,10 +3783,10 @@ export default defineMessages({
         defaultMessage: 'Details',
         id: 'TR_TRANSACTION_DETAILS',
     },
-    TR_TREZOR_BRIDGE_IS_NOT_RUNNING: {
-        defaultMessage: 'Trezor Bridge is not running',
+    TR_NO_TRANSPORT: {
+        defaultMessage: "Browser can't communicate with device",
         description: '',
-        id: 'TR_TREZOR_BRIDGE_IS_NOT_RUNNING',
+        id: 'TR_NO_TRANSPORT',
     },
     TR_TRY_AGAIN: {
         defaultMessage: 'Try again',
@@ -4451,9 +4451,9 @@ export default defineMessages({
         id: 'TR_TREZOR_BRIDGE_DOWNLOAD',
         defaultMessage: 'Trezor Bridge Download',
     },
-    TR_CURRENTLY_INSTALLED_TREZOR: {
-        id: 'TR_CURRENTLY_INSTALLED_TREZOR',
-        defaultMessage: 'Currently installed: Trezor Bridge {version}',
+    TR_TREZOR_BRIDGE_RUNNING_VERSION: {
+        id: 'TR_TREZOR_BRIDGE_RUNNING_VERSION',
+        defaultMessage: 'Trezor Bridge running version {version}',
     },
     TR_OUTDATED_BRIDGE_DESKTOP: {
         id: 'TR_OUTDATED_BRIDGE_DESKTOP',
@@ -7545,9 +7545,9 @@ export default defineMessages({
         id: 'TR_DATA_ANALYTICS_CATEGORY_3_ITEM_1',
         defaultMessage: 'Language, user count, etc.',
     },
-    TR_TROUBLESHOOTING_BRIDGE_IS_NOT_RUNNING: {
-        defaultMessage: 'Steps to make sure Trezor Bridge is running',
-        id: 'TR_TROUBLESHOOTING_BRIDGE_IS_NOT_RUNNING',
+    TR_TROUBLESHOOTING_DEVICE_NOT_DETECTED: {
+        defaultMessage: 'Steps needed to make communication possible',
+        id: 'TR_TROUBLESHOOTING_DEVICE_NOT_DETECTED',
     },
     TR_TROUBLESHOOTING_TIP_BRIDGE_STATUS_TITLE: {
         defaultMessage: 'Ensure the Trezor Bridge process is running',
@@ -7557,13 +7557,30 @@ export default defineMessages({
         defaultMessage: 'Visit <a>Trezor Bridge status page</a>',
         id: 'TR_TROUBLESHOOTING_TIP_BRIDGE_STATUS_DESCRIPTION',
     },
-    TR_TROUBLESHOOTING_TIP_BRIDGE_INSTALL_TITLE: {
-        id: 'TR_TROUBLESHOOTING_TIP_BRIDGE_INSTALL_TITLE',
-        defaultMessage: 'If you can’t see Trezor Bridge running, download and install it',
+    TR_TROUBLESHOOTING_TIP_BROWSER_WEBUSB_TITLE: {
+        defaultMessage: 'Try using a browser with WebUSB support',
+        id: 'TR_TROUBLESHOOTING_TIP_BROWSER_WEBUSB_TITLE',
     },
-    TR_TROUBLESHOOTING_TIP_BRIDGE_INSTALL_DESCRIPTION: {
-        id: 'TR_TROUBLESHOOTING_TIP_BRIDGE_INSTALL_DESCRIPTION',
-        defaultMessage: '<a>Download Trezor Bridge</a>',
+    TR_TROUBLESHOOTING_TIP_BROWSER_WEBUSB_DESCRIPTION: {
+        defaultMessage:
+            'Use a chromium based browser which allows direct communication with usb devices',
+        id: 'TR_TROUBLESHOOTING_TIP_BROWSER_WEBUSB_DESCRIPTION',
+    },
+    TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_TITLE: {
+        id: 'TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_TITLE',
+        defaultMessage: 'Use Suite desktop application',
+    },
+    TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_DESCRIPTION: {
+        id: 'TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_DESCRIPTION',
+        defaultMessage: 'Run <a>Trezor Suite</a> desktop application',
+    },
+    TR_TROUBLESHOOTING_TIP_BRIDGE_BACKGROUND_TITLE: {
+        id: 'TR_TROUBLESHOOTING_TIP_BRIDGE_BACKGROUND_TITLE',
+        defaultMessage: 'You may also run Trezor Suite in background',
+    },
+    TR_TROUBLESHOOTING_TIP_BRIDGE_BACKGROUND_DESCRIPTION: {
+        id: 'TR_TROUBLESHOOTING_TIP_BRIDGE_BACKGROUND_DESCRIPTION',
+        defaultMessage: '<a>See intructions</a>',
     },
     TR_TROUBLESHOOTING_TIP_BRIDGE_USE_TITLE: {
         id: 'TR_TROUBLESHOOTING_TIP_BRIDGE_USE_TITLE',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -9498,4 +9498,13 @@ export default defineMessages({
         defaultMessage:
             'Are you sure? The device might only be used by a single application at time. If you are currently using another application with your Trezor device, make sure to finish it first.',
     },
+    TR_BRIDGE_NEEDED_DESCRIPTION: {
+        id: 'TR_BRIDGE_NEEDED_DESCRIPTION',
+        defaultMessage:
+            'We recommend downloading and running the Trezor Suite desktop app in the background for the best experience. Alternatively, use a supported browser that is compatible with WebUSB',
+    },
+    TR_OPEN_TREZOR_SUITE_DESKTOP: {
+        id: 'TR_OPEN_TREZOR_SUITE_DESKTOP',
+        defaultMessage: 'Open Trezor Suite desktop app',
+    },
 });

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -9476,4 +9476,26 @@ export default defineMessages({
         id: 'TR_SELECT_TREZOR_TO_CONTINUE',
         defaultMessage: 'Select your Trezor to continue.',
     },
+    TR_RUN_TREZOR_SUITE_IN_BACKGROUND: {
+        id: 'TR_RUN_TREZOR_SUITE_IN_BACKGROUND',
+        defaultMessage: 'Run Trezor Suite in the background',
+    },
+    TR_KEEP_RUNNING_IN_BACKGROUND: {
+        id: 'TR_KEEP_RUNNING_IN_BACKGROUND',
+        defaultMessage: 'Keep running in background',
+    },
+    TR_BRIDGE: {
+        id: 'TR_BRIDGE',
+        defaultMessage: 'Bridge',
+    },
+    TR_BRIDGE_REQUESTED_DESCRIPTION: {
+        id: 'TR_BRIDGE_REQUESTED_DESCRIPTION',
+        defaultMessage:
+            'Trezor Suite application was requested by another application in order to make the connection with your Trezor device possible. Keep this in background and all will be good.',
+    },
+    TR_BRIDGE_GO_TO_WALLET_DESCRIPTION: {
+        id: 'TR_BRIDGE_GO_TO_WALLET_DESCRIPTION',
+        defaultMessage:
+            'Are you sure? The device might only be used by a single application at time. If you are currently using another application with your Trezor device, make sure to finish it first.',
+    },
 });

--- a/packages/suite/src/utils/suite/__fixtures__/protocol.ts
+++ b/packages/suite/src/utils/suite/__fixtures__/protocol.ts
@@ -77,7 +77,7 @@ export const getProtocolInfo = [
     },
 ];
 
-export const isProtocolScheme = [
+export const isPaymentRequestProtocolScheme = [
     {
         description: 'should validate bitcoin protocol as valid',
         scheme: 'bitcoin',

--- a/packages/suite/src/utils/suite/__tests__/protocol.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/protocol.test.ts
@@ -1,6 +1,6 @@
 import { testMocks } from '@suite-common/test-utils';
 
-import { getProtocolInfo, isProtocolScheme } from 'src/utils/suite/protocol';
+import { getProtocolInfo, isPaymentRequestProtocolScheme } from 'src/utils/suite/protocol';
 import * as fixtures from '../__fixtures__/protocol';
 
 jest.doMock('@trezor/suite-analytics', () => testMocks.getAnalytics());
@@ -13,10 +13,10 @@ describe('getProtocolInfo', () => {
     });
 });
 
-describe('isProtocolScheme', () => {
-    fixtures.isProtocolScheme.forEach(f => {
+describe('isPaymentRequestProtocolScheme', () => {
+    fixtures.isPaymentRequestProtocolScheme.forEach(f => {
         it(f.description, () => {
-            expect(isProtocolScheme(f.scheme)).toEqual(f.result);
+            expect(isPaymentRequestProtocolScheme(f.scheme)).toEqual(f.result);
         });
     });
 });

--- a/packages/suite/src/utils/suite/protocol.ts
+++ b/packages/suite/src/utils/suite/protocol.ts
@@ -8,7 +8,7 @@ export type CoinProtocolInfo = {
     amount?: number;
 };
 
-export const isProtocolScheme = (scheme: string): scheme is PROTOCOL_SCHEME =>
+export const isPaymentRequestProtocolScheme = (scheme: string): scheme is PROTOCOL_SCHEME =>
     Object.values(PROTOCOL_SCHEME).includes(scheme as PROTOCOL_SCHEME);
 
 export const getProtocolInfo = (uri: string): CoinProtocolInfo | null => {
@@ -27,7 +27,7 @@ export const getProtocolInfo = (uri: string): CoinProtocolInfo | null => {
             },
         });
 
-        if (isProtocolScheme(scheme)) {
+        if (isPaymentRequestProtocolScheme(scheme)) {
             if (!pathname && !host) return null; // address may be in pathname (regular bitcoin:addr) or host (bitcoin://addr)
 
             const floatAmount = Number.parseFloat(params.amount ?? '');

--- a/packages/suite/src/views/suite/bridge-requested/index.tsx
+++ b/packages/suite/src/views/suite/bridge-requested/index.tsx
@@ -1,0 +1,96 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+import { Translation, Modal, Metadata } from 'src/components/suite';
+import { Button, Image } from '@trezor/components';
+import { goto } from 'src/actions/suite/routerActions';
+import { useDispatch, useLayout } from 'src/hooks/suite';
+import { desktopApi } from '@trezor/suite-desktop-api';
+
+const StyledModal = styled(Modal)`
+    ${Modal.BottomBar} {
+        > * {
+            flex: 1;
+            justify-content: space-between;
+        }
+    }
+`;
+
+const StyledImage = styled(Image)`
+    align-self: center;
+`;
+
+const StyledButton = styled(Button)`
+    path {
+        fill: ${({ theme }) => theme.TYPE_LIGHT_GREY};
+    }
+`;
+
+/**
+ * This component renders only in desktop version
+ */
+export const BridgeRequested = () => {
+    const [confirmGoToWallet, setConfirmGoToWallet] = useState(false);
+
+    const dispatch = useDispatch();
+
+    const goToWallet = () => dispatch(goto('wallet-index'));
+
+    const handleKeepInBackground = () => {
+        if (desktopApi.available) {
+            desktopApi.appHide();
+        }
+    };
+
+    useLayout('Bridge');
+
+    if (confirmGoToWallet) {
+        return (
+            <StyledModal
+                heading={<Translation id="TR_BRIDGE" />}
+                description={<Translation id="TR_BRIDGE_GO_TO_WALLET_DESCRIPTION" />}
+                onBackClick={() => setConfirmGoToWallet(false)}
+                bottomBarComponents={
+                    <>
+                        <Button variant="primary" onClick={goToWallet}>
+                            <Translation id="TR_YES_CONTINUE" />
+                        </Button>
+                        <Button variant="tertiary" onClick={() => setConfirmGoToWallet(false)}>
+                            <Translation id="TR_CANCEL" />
+                        </Button>
+                    </>
+                }
+            >
+                <Metadata title="Bridge | Trezor Suite" />
+            </StyledModal>
+        );
+    }
+
+    return (
+        <StyledModal
+            heading={<Translation id="TR_BRIDGE" />}
+            description={<Translation id="TR_BRIDGE_REQUESTED_DESCRIPTION" />}
+            isHeadingCentered
+            bottomBarComponents={
+                <>
+                    <StyledButton
+                        icon="ARROW_LEFT"
+                        variant="tertiary"
+                        onClick={() => setConfirmGoToWallet(true)}
+                        data-test="@bridge/goto/wallet-index"
+                    >
+                        <Translation id="TR_TAKE_ME_BACK_TO_WALLET" />
+                    </StyledButton>
+
+                    {desktopApi.available && (
+                        <StyledButton onClick={handleKeepInBackground}>
+                            <Translation id="TR_KEEP_RUNNING_IN_BACKGROUND" />
+                        </StyledButton>
+                    )}
+                </>
+            }
+        >
+            <Metadata title="Bridge | Trezor Suite" />
+            <StyledImage image="CONNECT_DEVICE" width="360" />
+        </StyledModal>
+    );
+};

--- a/packages/suite/src/views/suite/bridge/index.tsx
+++ b/packages/suite/src/views/suite/bridge/index.tsx
@@ -1,28 +1,12 @@
-import { useState } from 'react';
 import styled from 'styled-components';
-import { DATA_URL, HELP_CENTER_TOR_URL, GITHUB_BRIDGE_CHANGELOG_URL } from '@trezor/urls';
-import { Translation, TrezorLink, Modal, Metadata } from 'src/components/suite';
-import { Button, Paragraph, Link, Select, Image, variables, Spinner } from '@trezor/components';
+import { SUITE_BRIDGE_DEEPLINK, SUITE_URL } from '@trezor/urls';
+import { Translation, Modal, Metadata } from 'src/components/suite';
+import { Button } from '@trezor/components';
 import { goto } from 'src/actions/suite/routerActions';
-import { isDesktop, isWeb } from '@trezor/env-utils';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectTorState } from 'src/reducers/suite/suiteReducer';
-import { DeviceModelInternal } from '@trezor/connect';
-
-const Content = styled.div`
-    display: flex;
-    flex-direction: column;
-    text-align: center;
-    flex: 1;
-    padding: 0 74px;
-
-    /* min-width: 560px; */
-
-    @media screen and (max-width: ${variables.SCREEN_SIZE.SM}) {
-        padding: 0;
-        min-width: 0;
-    }
-`;
+import { isWebUsb } from 'src/utils/suite/transport';
+import TrezorConnect from '@trezor/connect';
+import { useWindowFocus } from '@trezor/react-utils';
 
 const StyledButton = styled(Button)`
     path {
@@ -31,200 +15,83 @@ const StyledButton = styled(Button)`
 `;
 
 const Footer = styled.div`
+    width: 100%;
     margin-top: 72px;
     display: flex;
-    padding: 0 42px;
     justify-content: space-between;
-    width: 100%;
-
-    @media screen and (max-width: ${variables.SCREEN_SIZE.SM}) {
-        padding: 0 12px;
-    }
 `;
 
-const SelectWrapper = styled(Select)`
-    width: 100%;
-`;
-
-const Download = styled.div`
-    margin: 24px auto;
-    display: flex;
-    place-content: center center;
-    flex-direction: column;
-`;
-
-const DownloadBridgeButton = styled(Button)`
-    margin-top: 12px;
-    min-width: 280px;
-`;
-
-const CenteredLoader = styled(Spinner)`
-    margin: 0 auto;
-    margin-bottom: 10px;
-`;
-
-const LoaderWrapper = styled.div`
-    margin: 15px 0 25px;
-    place-items: center center;
-
-    /* same height as content so it won't feel jumpy */
-    min-height: 98px;
-`;
-
-const Version = styled.div<{ $show: boolean }>`
-    visibility: ${({ $show }) => ($show ? 'visible' : 'hidden')};
-    margin-top: 10px;
-    font-size: ${variables.FONT_SIZE.SMALL};
-`;
-
-const BridgeDesktopNote = styled(Paragraph)`
-    margin-top: 10px;
-    font-size: ${variables.FONT_SIZE.TINY};
-`;
-
-const StyledImage = styled(Image)`
-    @media screen and (max-height: ${variables.SCREEN_SIZE.LG}) {
-        /* workaround for low height screens => hide image */
-        display: none;
-    }
-`;
-
-const Col = styled.div<{ $justify?: string }>`
-    display: flex;
-    flex: 1;
-    justify-content: ${({ $justify }) => $justify};
-`;
-
-interface Installer {
-    label: string;
-    value: string;
-    signature?: string;
-    preferred?: boolean;
-}
-
-export const InstallBridge = () => {
-    const [selectedTarget, setSelectedTarget] = useState<Installer | null>(null);
-    const { isTorEnabled } = useSelector(selectTorState);
+// it actually changes to "Install suite desktop"
+export const BridgeUnavailable = () => {
     const transport = useSelector(state => state.suite.transport);
     const dispatch = useDispatch();
 
-    const installers: Installer[] =
-        transport && transport.bridge
-            ? transport.bridge.packages.map(p => ({
-                  label: p.name,
-                  value: p.url,
-                  signature: p.signature,
-                  preferred: p.preferred,
-              }))
-            : [];
+    const windowFocused = useWindowFocus();
+    const handleOpenSuite = () => {
+        if (isWebUsb(transport)) {
+            TrezorConnect.disableWebUSB();
+        }
 
-    const preferredTarget = installers.find(i => i.preferred === true);
-    const data = {
-        currentVersion: transport?.type === 'BridgeTransport' ? transport!.version : null,
-        latestVersion: transport?.bridge ? transport.bridge.version.join('.') : null,
-        installers,
-        target: preferredTarget || installers[0],
-        uri: DATA_URL,
+        location.href = SUITE_BRIDGE_DEEPLINK;
+
+        // fallback in case deeplink does not work
+        window.setTimeout(() => {
+            if (!windowFocused.current) return;
+
+            window.open(SUITE_URL);
+        }, 500);
     };
-
-    const target = selectedTarget || data.target;
-    const isLoading = !transport;
-    const transportAvailable = transport && transport.type;
 
     const goToWallet = () => dispatch(goto('wallet-index'));
 
+    // if bridge is running, user will never be directed to this page, but since this page is accessible directly over /bridge url
+    // it makes sense to show some meaningful information here
+    if (transport?.type) {
+        // not 100%, this is true only for latest suite-desktop release
+        const isBundled = transport?.bridge?.version?.[0] === 3;
+
+        const description = isWebUsb(transport)
+            ? `Using WebUSB. No action required.`
+            : `Trezor Bridge HTTP server is running. ${isBundled ? 'Bundled' : 'Standalone'} version: ${transport?.bridge?.version.join('.')} `;
+
+        return (
+            <Modal
+                heading={<Translation id="TR_BRIDGE" />}
+                description={description}
+                data-test="@modal/bridge"
+            >
+                <Metadata title="Bridge | Trezor Suite" />
+
+                <Footer>
+                    <StyledButton
+                        icon="ARROW_LEFT"
+                        variant="tertiary"
+                        onClick={goToWallet}
+                        data-test="@bridge/goto/wallet-index"
+                    >
+                        <Translation id="TR_TAKE_ME_BACK_TO_WALLET" />
+                    </StyledButton>
+
+                    <Button onClick={handleOpenSuite}>
+                        <Translation id="TR_OPEN_TREZOR_SUITE_DESKTOP" />
+                    </Button>
+                </Footer>
+            </Modal>
+        );
+    }
+
     return (
         <Modal
-            heading={<Translation id="TR_TREZOR_BRIDGE_DOWNLOAD" />}
-            description={<Translation id="TR_NEW_COMMUNICATION_TOOL" />}
+            heading={<Translation id="TR_BRIDGE" />}
+            description={<Translation id="TR_BRIDGE_NEEDED_DESCRIPTION" />}
             data-test="@modal/bridge"
         >
-            <Metadata title="Download Bridge | Trezor Suite" />
-            <Content>
-                <Version $show={!!data.currentVersion}>
-                    <Translation
-                        id="TR_CURRENTLY_INSTALLED_TREZOR"
-                        values={{ version: data.currentVersion }}
-                    />
-                    {isDesktop() && (
-                        <BridgeDesktopNote>
-                            <Translation id="TR_OUTDATED_BRIDGE_DESKTOP" />
-                        </BridgeDesktopNote>
-                    )}
-                </Version>
-                {/* TODO: use flagship when new image available */}
-                <StyledImage image={`BRIDGE_CHECK_TREZOR_${DeviceModelInternal.T2T1}`} />
-                {isLoading ? (
-                    <LoaderWrapper data-test="@bridge/loading">
-                        <CenteredLoader size={50} />
-                        <Paragraph>
-                            <Translation id="TR_GATHERING_INFO" />
-                        </Paragraph>
-                    </LoaderWrapper>
-                ) : (
-                    <Download>
-                        <SelectWrapper
-                            isSearchable={false}
-                            isClearable={false}
-                            value={target}
-                            onChange={setSelectedTarget}
-                            options={installers}
-                            maxMenuHeight={160}
-                            data-test="@bridge/installers"
-                        />
-
-                        <TrezorLink variant="nostyle" href={`${data.uri}${target?.value}`}>
-                            <DownloadBridgeButton data-test="@bridge/download-button">
-                                <Translation
-                                    id="TR_DOWNLOAD_LATEST_BRIDGE"
-                                    values={{ version: data.latestVersion }}
-                                />
-                            </DownloadBridgeButton>
-                        </TrezorLink>
-                    </Download>
-                )}
-                {isWeb() && isTorEnabled && (
-                    <Paragraph>
-                        <TrezorLink href={HELP_CENTER_TOR_URL}>
-                            <Translation id="TR_TOR_BRIDGE" />
-                        </TrezorLink>
-                    </Paragraph>
-                )}
-            </Content>
+            <Metadata title="Bridge | Trezor Suite" />
 
             <Footer>
-                {transportAvailable && (
-                    <Col $justify="flex-start">
-                        <StyledButton
-                            icon="ARROW_LEFT"
-                            variant="tertiary"
-                            onClick={goToWallet}
-                            data-test="@bridge/goto/wallet-index"
-                        >
-                            <Translation id="TR_TAKE_ME_BACK_TO_WALLET" />
-                        </StyledButton>
-                    </Col>
-                )}
-                {!isLoading && (
-                    <>
-                        <Col $justify="center">
-                            <Link variant="nostyle" href={GITHUB_BRIDGE_CHANGELOG_URL}>
-                                <StyledButton icon="LOG" variant="tertiary">
-                                    <Translation id="TR_CHANGELOG" />
-                                </StyledButton>
-                            </Link>
-                        </Col>
-                        <Col $justify="flex-end">
-                            {data && target?.signature && (
-                                <TrezorLink variant="nostyle" href={data.uri + target.signature}>
-                                    <StyledButton icon="SIGNATURE" variant="tertiary">
-                                        <Translation id="TR_CHECK_PGP_SIGNATURE" />
-                                    </StyledButton>
-                                </TrezorLink>
-                            )}
-                        </Col>
-                    </>
-                )}
+                <Button onClick={handleOpenSuite}>
+                    <Translation id="TR_OPEN_TREZOR_SUITE_DESKTOP" />
+                </Button>
             </Footer>
         </Modal>
     );

--- a/packages/urls/src/deeplinks.ts
+++ b/packages/urls/src/deeplinks.ts
@@ -1,0 +1,1 @@
+export const SUITE_BRIDGE_DEEPLINK = 'trezorsuite://bridge-requested-by-a-3rd-party';

--- a/packages/urls/src/index.ts
+++ b/packages/urls/src/index.ts
@@ -4,5 +4,6 @@ import type * as GithubUrls from './github';
 export * from './urls';
 export * from './github';
 export * from './tor';
+export * from './deeplinks';
 
 export type Url = (typeof Urls)[keyof typeof Urls] | (typeof GithubUrls)[keyof typeof GithubUrls];

--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -12,7 +12,6 @@ export const DOCS_ANALYTICS_URL = 'https://docs.trezor.io/trezor-suite/analytics
 
 export const SUITE_URL = 'https://trezor.io/trezor-suite';
 export const SUITE_BACKUP_URL = 'https://suite.trezor.io/web/backup/';
-export const SUITE_BRIDGE_URL = 'https://suite.trezor.io/web/bridge/';
 export const SUITE_FIRMWARE_URL = 'https://suite.trezor.io/web/firmware/';
 export const SUITE_UDEV_URL = 'https://suite.trezor.io/web/udev/';
 

--- a/suite-common/suite-config/src/routes.ts
+++ b/suite-common/suite-config/src/routes.ts
@@ -30,6 +30,13 @@ export const routes = [
         params: modalAppParams,
     },
     {
+        name: 'suite-bridge-requested',
+        pattern: '/bridge-requested',
+        app: 'bridge-requested',
+        isForegroundApp: true,
+        params: modalAppParams,
+    },
+    {
         name: 'suite-bridge',
         pattern: '/bridge',
         app: 'bridge',

--- a/yarn.lock
+++ b/yarn.lock
@@ -10759,6 +10759,7 @@ __metadata:
     "@trezor/connect-analytics": "workspace:*"
     "@trezor/connect-common": "workspace:*"
     "@trezor/env-utils": "workspace:*"
+    "@trezor/react-utils": "workspace:*"
     "@trezor/urls": "workspace:*"
     "@types/react": "npm:18.2.79"
     react-intl: "npm:^6.6.2"


### PR DESCRIPTION
Updated messages in Prerequisites Guide
<img width="644" alt="Screenshot 2024-07-18 at 14 14 22" src="https://github.com/user-attachments/assets/7164315f-b4fc-4a43-8f19-300af8debd3a">
Replaced Bridge modal
<img width="735" alt="Screenshot 2024-07-18 at 14 21 21" src="https://github.com/user-attachments/assets/793908ec-1775-42b3-965a-04383036ec6b">
New modal that can be deep-linked into from web suite/Connect to start the bridge
<img width="772" alt="Screenshot 2024-07-17 at 10 12 11" src="https://github.com/user-attachments/assets/93496583-af93-4f42-806e-81b070bc845e">

## Related issues
- Resolves #9356
- Resolves #12487