### PR TITLE
Fix/tokens

### DIFF
--- a/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountNavigation.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountNavigation.tsx
@@ -43,13 +43,13 @@ export const AccountNavigation = () => {
             isHidden: false,
         },
         {
-            id: 'wallet-details',
+            id: 'wallet-tokens-coins',
             callback: () => {
-                goToWithAnalytics('wallet-details', { preserveParams: true });
+                goToWithAnalytics('wallet-tokens-coins', { preserveParams: true });
             },
-            title: <Translation id="TR_NAV_DETAILS" />,
-            isHidden: !['cardano', 'bitcoin'].includes(networkType),
-            'data-test': `@wallet/menu/wallet-details`,
+            title: <Translation id="TR_NAV_TOKENS" />,
+            isHidden: !['cardano', 'ethereum', 'solana'].includes(networkType),
+            activeRoutes: ['wallet-tokens-coins', 'wallet-tokens-hidden'],
         },
         {
             id: 'wallet-staking',
@@ -60,13 +60,13 @@ export const AccountNavigation = () => {
             isHidden: !hasNetworkFeatures(account, 'staking'),
         },
         {
-            id: 'wallet-tokens-coins',
+            id: 'wallet-details',
             callback: () => {
-                goToWithAnalytics('wallet-tokens-coins', { preserveParams: true });
+                goToWithAnalytics('wallet-details', { preserveParams: true });
             },
-            title: <Translation id="TR_NAV_TOKENS" />,
-            isHidden: !['cardano', 'ethereum', 'solana'].includes(networkType),
-            activeRoutes: ['wallet-tokens-coins', 'wallet-tokens-hidden'],
+            title: <Translation id="TR_NAV_DETAILS" />,
+            isHidden: !['cardano', 'bitcoin'].includes(networkType),
+            'data-test': `@wallet/menu/wallet-details`,
         },
     ];
 

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5751,10 +5751,6 @@ export default defineMessages({
         id: 'TR_TOKENS',
         defaultMessage: 'Tokens',
     },
-    TR_TOKENS_ADD: {
-        id: 'TR_TOKENS_ADD',
-        defaultMessage: 'Add token',
-    },
     TR_TOKENS_EMPTY: {
         id: 'TR_TOKENS_EMPTY',
         defaultMessage: 'No tokens... yet.',

--- a/packages/suite/src/views/wallet/tokens/common/NoTokens.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/NoTokens.tsx
@@ -1,31 +1,9 @@
-import { Button } from '@trezor/components';
 import { AccountExceptionLayout } from 'src/components/wallet';
-import { Translation } from 'src/components/suite';
-import { openModal } from 'src/actions/suite/modalActions';
-import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
 
 interface NoTokensProps {
     title: JSX.Element | string;
 }
 
-export const NoTokens = ({ title }: NoTokensProps) => {
-    const isDebug = useSelector(selectIsDebugModeActive);
-    const dispatch = useDispatch();
-
-    const handleButtonClick = () => dispatch(openModal({ type: 'add-token' }));
-
-    return (
-        <AccountExceptionLayout
-            title={title}
-            image="CLOUDY"
-            actionComponent={
-                isDebug ? (
-                    <Button variant="primary" onClick={handleButtonClick}>
-                        <Translation id="TR_TOKENS_ADD" />
-                    </Button>
-                ) : undefined
-            }
-        />
-    );
-};
+export const NoTokens = ({ title }: NoTokensProps) => (
+    <AccountExceptionLayout title={title} image="CLOUDY" />
+);

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -100,7 +100,7 @@ export const networks = {
             address: 'https://etc1.trezor.io/address/',
             queryString: '',
         },
-        features: ['sign-verify', 'tokens'],
+        features: ['sign-verify', 'tokens', 'coin-definitions'],
         label: 'TR_INCLUDING_TOKENS',
         customBackends: ['blockbook'],
         accountTypes: {},


### PR DESCRIPTION
## Description

- add `ETC` token definitions, they are already live
- remove `Add token` from footer of empty tokens bubble
  - not needed + it was there for all coins which is not what we want
- sort nav according to figma design, have same order for all coins
  - `Details` is less important 
  - `Tokens` are "always" there in case of non-btc-like coins
  - `Staking will also be "always" there in case of non-btc-like coins

## Screenshots:
![Screenshot 2024-06-28 at 23 15 21](https://github.com/trezor/trezor-suite/assets/33235762/e57dd986-e560-49e9-a7bb-264f7234cd16)
![Screenshot 2024-06-28 at 23 15 36](https://github.com/trezor/trezor-suite/assets/33235762/a40fc991-781c-4779-be83-5852852cbc02)
![Screenshot 2024-06-28 at 23 23 58](https://github.com/trezor/trezor-suite/assets/33235762/e6e3b774-4fb2-41a1-aeaf-5c509f60cb5c)
