### PR TITLE
fix(suite): EVM do not switch to custom fee when low balance

### DIFF
--- a/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
@@ -168,36 +168,6 @@ export const composeTransaction =
             wrappedResponse[feeLabel] = tx;
         });
 
-        // Implement adding custom fees.
-        const hasAtLeastOneValid = response.find(r => r.type !== 'error');
-        // there is no valid tx in predefinedLevels and there is no custom level
-        if (!hasAtLeastOneValid && !wrappedResponse.custom) {
-            const { minFee } = feeInfo;
-            const lastKnownFee = predefinedLevels[predefinedLevels.length - 1].feePerUnit;
-            let maxFee = new BigNumber(lastKnownFee).minus(1);
-            // generate custom levels in range from lastKnownFee - 1 to feeInfo.minFee (coinInfo in @trezor/connect)
-            const customLevels: FeeLevel[] = [];
-            while (maxFee.gte(minFee)) {
-                customLevels.push({
-                    feePerUnit: maxFee.toString(),
-                    feeLimit: predefinedLevels[0].feeLimit,
-                    label: 'custom',
-                    blocks: -1,
-                });
-                maxFee = maxFee.minus(1);
-            }
-
-            // check if any custom level is possible
-            const customLevelsResponse = customLevels.map(level =>
-                calculate(availableBalance, output, level, compareWithAmount, account.symbol),
-            );
-
-            const customValid = customLevelsResponse.findIndex(r => r.type !== 'error');
-            if (customValid >= 0) {
-                wrappedResponse.custom = customLevelsResponse[customValid];
-            }
-        }
-
         // format max (calculate sends it as satoshi)
         // update errorMessage values (symbol)
         Object.keys(wrappedResponse).forEach(key => {

--- a/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
@@ -185,36 +185,7 @@ export const composeEthereumSendFormTransactionThunk = createThunk(
             wrappedResponse[feeLabel] = tx;
         });
 
-        const hasAtLeastOneValid = response.find(r => r.type !== 'error');
-        // there is no valid tx in predefinedLevels and there is no custom level
-        if (!hasAtLeastOneValid && !wrappedResponse.custom) {
-            const { minFee } = feeInfo;
-            const lastKnownFee = predefinedLevels[predefinedLevels.length - 1].feePerUnit;
-            let maxFee = new BigNumber(lastKnownFee).minus(1);
-            // generate custom levels in range from lastKnownFee - 1 to feeInfo.minFee (coinInfo in @trezor/connect)
-            const customLevels: FeeLevel[] = [];
-            while (maxFee.gte(minFee)) {
-                customLevels.push({
-                    feePerUnit: maxFee.toString(),
-                    feeLimit: predefinedLevels[0].feeLimit,
-                    label: 'custom',
-                    blocks: -1,
-                });
-                maxFee = maxFee.minus(1);
-            }
-
-            // check if any custom level is possible
-            const customLevelsResponse = customLevels.map(level =>
-                calculate(availableBalance, output, level, tokenInfo),
-            );
-
-            const customValid = customLevelsResponse.findIndex(r => r.type !== 'error');
-            if (customValid >= 0) {
-                wrappedResponse.custom = customLevelsResponse[customValid];
-            }
-        }
-
-        // format max (calculate sends it as satoshi)
+        // format max
         // update errorMessage values (symbol)
         Object.keys(wrappedResponse).forEach(key => {
             const tx = wrappedResponse[key];


### PR DESCRIPTION
## Description

- when user wanted to stake almost "max" without pressing "max" button. It proposed him low custom gas price which result into lot of pending txs
- same logic was there for send form
- let users choose custom fee manually only if they know what they are doing

## Related Issue

Resolve #13040

## Screenshots:

This is what it did before. We do not want that. Tx most often remain stuck

https://github.com/trezor/trezor-suite/assets/33235762/22693f94-3c96-4735-8832-a822b2dee73e

