### PR TITLE
fix(type-utils): add build:lib command

### DIFF
--- a/packages/type-utils/package.json
+++ b/packages/type-utils/package.json
@@ -8,6 +8,7 @@
         "src/"
     ],
     "scripts": {
+        "build:lib": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/replace-imports.sh ./lib",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build"

--- a/packages/type-utils/tsconfig.lib.json
+++ b/packages/type-utils/tsconfig.lib.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.lib.json",
+    "compilerOptions": {
+        "outDir": "lib"
+    },
+    "include": ["./src"],
+    "references": []
+}


### PR DESCRIPTION
## Description

Add missing `build:lib` command to `@trezor/type-utils` package. This is necessary to publish on NPM in Connect.