### PR TITLE
feat(suite-desktop): set node-bridge rollout to 10%

### DIFF
--- a/packages/suite-desktop-core/src/modules/bridge.ts
+++ b/packages/suite-desktop-core/src/modules/bridge.ts
@@ -61,7 +61,7 @@ const getBridgeInstance = (store: Dependencies['store']) => {
     }
     const newBridgeRollout = store.getBridgeSettings().newBridgeRollout || 0;
     // note that this variable is duplicated with UI
-    const NEW_BRIDGE_ROLLOUT_THRESHOLD = 0;
+    const NEW_BRIDGE_ROLLOUT_THRESHOLD = 0.1;
     const legacyBridgeReasonRollout =
         !isDevEnv && !skipNewBridgeRollout && newBridgeRollout >= NEW_BRIDGE_ROLLOUT_THRESHOLD;
 

--- a/packages/suite/src/views/settings/SettingsDebug/TransportBackends.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/TransportBackends.tsx
@@ -12,7 +12,7 @@ interface Process {
 }
 
 // note that this variable is duplicated with suite-desktop-core
-const NEW_BRIDGE_ROLLOUT_THRESHOLD = 0;
+const NEW_BRIDGE_ROLLOUT_THRESHOLD = 0.1;
 
 export const TransportBackends = () => {
     const [bridgeProcess, setBridgeProcess] = useState<Process>({ service: false, process: false });


### PR DESCRIPTION
After #12728 has been merged I believe that we may strive for rolling out node-bridge publicly again.

This commit makes it accessible to 10% of the user base. 

