### PR TITLE
fix(suite): Set 100% width for CollapsibleBox/drop down

### DIFF
--- a/packages/components/src/components/CollapsibleBox/CollapsibleBox.tsx
+++ b/packages/components/src/components/CollapsibleBox/CollapsibleBox.tsx
@@ -88,6 +88,7 @@ type CollapsibleBoxContentProps = CollapsibleBoxManagedProps;
 
 const Container = styled.div<TransientFrameProps>`
     flex: 1;
+    width: 100%;
 
     ${withFrameProps}
 `;


### PR DESCRIPTION
## Description

Due to recent changes in `CollapsibleBox` component, the issue occurred regarding its width, seems that `width: 100%` was missing (since https://github.com/trezor/trezor-suite/pull/12749 was merged). Now it should be fine again.

The issue was reproduced also on Ubuntu OS, not only Mac.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/13098

## Screenshots:
**Before:**

https://github.com/trezor/trezor-suite/assets/13417815/8e159a9e-0739-4754-991b-c1dddd5d4139

**After:**

https://github.com/trezor/trezor-suite/assets/13417815/7ab21656-c47c-488b-bb96-3335d450b1de



