### PR TITLE
Chore: add data to suite

### DIFF
--- a/.github/workflows/update-connect-config.yml
+++ b/.github/workflows/update-connect-config.yml
@@ -1,0 +1,33 @@
+name: [Check] Update Config and Create PR
+
+on:
+  schedule:
+    # Runs at midnight UTC every day at 01:00 AM CET
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  update-config:
+    runs-on: ubuntu-latest
+    if: github.repository == 'trezor/trezor-suite'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.TREZOR_BOT_TOKEN }}
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Setup Git config
+        run: |
+          git config --global user.name "trezor-ci"
+          git config --global user.email "${{ secrets.TREZOR_BOT_EMAIL }}"
+
+      - name: Check for changes and create PR
+        run: yarn tsx ./scripts/ci/check-connect-data.ts

--- a/docs/packages/connect/check-connect-data.md
+++ b/docs/packages/connect/check-connect-data.md
@@ -1,0 +1,7 @@
+## @trezor/connect check data for device Authenticity
+
+This is an automatically created PR.
+
+-   [ ] Sanity check t2b1 https://github.com/trezor/data/blob/master/firmware/t2b1/authenticity.json
+-   [ ] Sanity check t3t1 https://github.com/trezor/data/blob/master/firmware/t3t1/authenticity.json
+-   [ ] Merge this PR into develop

--- a/packages/connect/src/api/firmware/verifyAuthenticityProof.ts
+++ b/packages/connect/src/api/firmware/verifyAuthenticityProof.ts
@@ -2,9 +2,9 @@ import * as crypto from 'crypto';
 import { bufferUtils } from '@trezor/utils';
 
 import { PROTO } from '../../constants';
-import { DeviceAuthenticityConfig } from '../../data/deviceAuthenticityConfig';
 import { AuthenticateDeviceResult } from '../../types/api/authenticateDevice';
 import { parseCertificate, fixSignature } from './x509certificate';
+import { DeviceAuthenticityConfig } from '../../data/deviceAuthenticityConfigTypes';
 
 // There is incomparability in results between nodejs and window SubtleCrypto api.
 // window.crypto.subtle.importKey (CryptoKey) cannot be used by `crypto-browserify`.Verify

--- a/packages/connect/src/data/deviceAuthenticityConfig.ts
+++ b/packages/connect/src/data/deviceAuthenticityConfig.ts
@@ -1,45 +1,5 @@
-import { Static, Type } from '@trezor/schema-utils';
-import { PROTO } from '../constants';
-
-type CertPubKeys = Static<typeof CertPubKeys>;
-const CertPubKeys = Type.Object({
-    rootPubKeys: Type.Array(Type.String()),
-    caPubKeys: Type.Array(Type.String()),
-});
-
-type ModelPubKeys = Static<typeof ModelPubKeys>;
-const ModelPubKeys = Type.Intersect([
-    Type.Record(
-        Type.Exclude(
-            Type.KeyOfEnum(PROTO.DeviceModelInternal),
-            Type.Union([Type.Literal('T1B1'), Type.Literal('T2T1')]),
-        ),
-        Type.Intersect([
-            CertPubKeys,
-            Type.Object({
-                debug: Type.Optional(CertPubKeys),
-            }),
-        ]),
-    ),
-    Type.Partial(
-        Type.Record(
-            Type.Exclude(
-                Type.KeyOfEnum(PROTO.DeviceModelInternal),
-                Type.Union([Type.Literal('T2B1'), Type.Literal('T3T1')]),
-            ),
-            Type.Undefined(),
-        ),
-    ),
-]);
-
-export type DeviceAuthenticityConfig = Static<typeof DeviceAuthenticityConfig>;
-export const DeviceAuthenticityConfig = Type.Intersect([
-    ModelPubKeys,
-    Type.Object({
-        version: Type.Number(),
-        timestamp: Type.String(),
-    }),
-]);
+/** THIS FILE IS AUTOMATICALLY UPDATED by script ci/scripts/check-connect-data.ts  */
+import { DeviceAuthenticityConfig } from './deviceAuthenticityConfigTypes';
 
 /**
  * How to update this config or check Sentry "Device authenticity invalid!" error? Please read this internal description:

--- a/packages/connect/src/data/deviceAuthenticityConfigTypes.ts
+++ b/packages/connect/src/data/deviceAuthenticityConfigTypes.ts
@@ -1,0 +1,42 @@
+import { Static, Type } from '@trezor/schema-utils';
+import { PROTO } from '../constants';
+
+type CertPubKeys = Static<typeof CertPubKeys>;
+const CertPubKeys = Type.Object({
+    rootPubKeys: Type.Array(Type.String()),
+    caPubKeys: Type.Array(Type.String()),
+});
+
+type ModelPubKeys = Static<typeof ModelPubKeys>;
+const ModelPubKeys = Type.Intersect([
+    Type.Record(
+        Type.Exclude(
+            Type.KeyOfEnum(PROTO.DeviceModelInternal),
+            Type.Union([Type.Literal('T1B1'), Type.Literal('T2T1')]),
+        ),
+        Type.Intersect([
+            CertPubKeys,
+            Type.Object({
+                debug: Type.Optional(CertPubKeys),
+            }),
+        ]),
+    ),
+    Type.Partial(
+        Type.Record(
+            Type.Exclude(
+                Type.KeyOfEnum(PROTO.DeviceModelInternal),
+                Type.Union([Type.Literal('T2B1'), Type.Literal('T3T1')]),
+            ),
+            Type.Undefined(),
+        ),
+    ),
+]);
+
+export type DeviceAuthenticityConfig = Static<typeof DeviceAuthenticityConfig>;
+export const DeviceAuthenticityConfig = Type.Intersect([
+    ModelPubKeys,
+    Type.Object({
+        version: Type.Number(),
+        timestamp: Type.String(),
+    }),
+]);

--- a/packages/connect/src/types/api/authenticateDevice.ts
+++ b/packages/connect/src/types/api/authenticateDevice.ts
@@ -1,6 +1,6 @@
 import { Static, Type } from '@trezor/schema-utils';
-import { DeviceAuthenticityConfig } from '../../data/deviceAuthenticityConfig';
 import type { Params, Response } from '../params';
+import { DeviceAuthenticityConfig } from '../../data/deviceAuthenticityConfigTypes';
 
 export type AuthenticateDeviceParams = Static<typeof AuthenticateDeviceParams>;
 export const AuthenticateDeviceParams = Type.Object({

--- a/scripts/ci/check-connect-data.ts
+++ b/scripts/ci/check-connect-data.ts
@@ -1,0 +1,116 @@
+import fetch from 'cross-fetch';
+import fs from 'fs-extra';
+import path from 'path';
+import { commit } from './helpers';
+
+const { exec } = require('./helpers');
+
+const AUTHENTICITY_BASE_URL = 'https://data.trezor.io';
+const authenticityPaths = {
+    T2B1: {
+        authenticity: 'firmware/t2b1/authenticity.json',
+        authenticityDev: 'firmware/t2b1/authenticity-dev.json',
+    },
+    T3T1: {
+        authenticity: 'firmware/t3t1/authenticity.json',
+        authenticityDev: 'firmware/t3t1/authenticity-dev.json',
+    },
+};
+
+const ROOT = path.join(__dirname, '..', '..');
+const CONFIG_FILE_PATH = path.join(ROOT, 'packages/connect/src/data/deviceAuthenticityConfig.ts');
+
+type AuthenticityPathsKeys = keyof typeof authenticityPaths;
+
+const fetchJSON = async (url: string) => {
+    const response = await fetch(url);
+    if (!response.ok) {
+        throw new Error(`Failed to fetch ${url}: ${response.statusText}`);
+    }
+    return response.json();
+};
+
+const updateConfigFromJSON = async () => {
+    try {
+        const devicesKeys = Object.keys(authenticityPaths) as AuthenticityPathsKeys[];
+
+        // Import the current configuration object
+        let { deviceAuthenticityConfig } = require(CONFIG_FILE_PATH);
+
+        for (const deviceKey of devicesKeys) {
+            const { authenticity, authenticityDev } = authenticityPaths[deviceKey];
+            const authenticityUrl = `${AUTHENTICITY_BASE_URL}/${authenticity}`;
+            const authenticityData = await fetchJSON(authenticityUrl);
+            const authenticityDevUrl = `${AUTHENTICITY_BASE_URL}/${authenticityDev}`;
+            const authenticityDevData = await fetchJSON(authenticityDevUrl);
+
+            deviceAuthenticityConfig[deviceKey] = {
+                rootPubKeys: authenticityData.root_pubkeys,
+                caPubKeys: authenticityData.ca_pubkeys,
+                debug: {
+                    rootPubKeys: authenticityDevData.root_pubkeys,
+                    caPubKeys: authenticityDevData.ca_pubkeys,
+                },
+            };
+        }
+
+        const updatedConfigString = `
+            /** THIS FILE IS AUTOMATICALLY UPDATED by script ci/scripts/check-connect-data.ts  */
+            import { DeviceAuthenticityConfig } from './deviceAuthenticityConfigTypes';
+
+            /**
+             * How to update this config or check Sentry "Device authenticity invalid!" error? Please read this internal description:
+             * https://www.notion.so/satoshilabs/Device-authenticity-check-b8656a0fe3ab4a0d84c61534a73de462?pvs=4
+             */
+            export const deviceAuthenticityConfig: DeviceAuthenticityConfig = ${JSON.stringify(deviceAuthenticityConfig, null, 4)};
+          `;
+
+        await fs.writeFile(CONFIG_FILE_PATH, updatedConfigString);
+
+        await exec('yarn', ['prettier', '--write', CONFIG_FILE_PATH]);
+
+        console.log('Configuration updated successfully.');
+
+        console.log('Checking if there were changes.');
+        const changes = await exec('git', ['diff', CONFIG_FILE_PATH]);
+        if (changes.stdout !== '') {
+            console.log('There were changes in keys.');
+            // There were changes in CONFIG_FILE_PATH
+            const hashChanges = await exec('git', [
+                'log',
+                '-1',
+                '--pretty=format:"%H"',
+                '--',
+                CONFIG_FILE_PATH,
+            ]);
+            // We use the hash of the changes to create branch name to avoid use a branch that already exists.
+            const branchName = `chore/update-device-authenticity-config-${hashChanges.stdout.replace(/"/g, '')}`;
+            const commitMessage = 'chore(connect): update device authenticity config';
+            await exec('git', ['checkout', '-b', branchName]);
+            commit({
+                path: ROOT,
+                message: commitMessage,
+            });
+            await exec('git', ['push', 'origin', branchName]);
+
+            await exec('gh', [
+                'pr',
+                'create',
+                '--repo',
+                'trezor/trezor-suite',
+                '--title',
+                `${commitMessage}`,
+                '--body-file',
+                'docs/packages/connect/check-connect-data.md',
+                '--base',
+                'develop',
+                '--head',
+                branchName,
+            ]);
+        }
+    } catch (error) {
+        console.error(`Error updating configuration: ${error.message}`);
+    }
+};
+
+updateConfigFromJSON();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- 04f5f4a1ae25b605e440ebf6214d0c4a91e4db9c - adds https://github.com/trezor/data as a submodule of Trezor Suite. It is a small repository so it should not be big deal, but let me know if you think otherwise
- 7d20d301367daca254342f299224f2bcdadf719e - script to update the keys automatically 

If this approach is accepted I will create a GitHub workflow that checks when trezor/data submodule is updated and create a PR with changes.

## Related Issue

Related but does not complete until we have the GitHub workflow automation https://github.com/trezor/trezor-suite/issues/12982