### PR TITLE
fix(suite): forgotten change of storage changelog

### DIFF
--- a/packages/suite/src/storage/CHANGELOG.md
+++ b/packages/suite/src/storage/CHANGELOG.md
@@ -1,12 +1,10 @@
 # Storage changelog
 
-## 47
-
--   added `device.passwords`
-
 ## 46
 
 -   added `tokenManagement`
+-   added `device.passwords`
+-   migrate Cardano accounts to a new structure
 
 ## 45
 


### PR DESCRIPTION
## Description

Both Adam and Martin bumped storage version in one version of app so I merged Martin's changes with Adam's but forgot to change changelog and add my record.

https://github.com/trezor/trezor-suite/pull/13093/commits/ae793f8dd112f81b61fbae91beb55947b21da38a