### PR TITLE
fix(suite): Display tooltip above sidebar when highlighting edge

### DIFF
--- a/packages/theme/src/zIndices.ts
+++ b/packages/theme/src/zIndices.ts
@@ -11,7 +11,7 @@ export const zIndices = {
     discoveryProgress: 41,
 
     modal: 40, // above other suite content to disable interacting with it
-    draggableComponent: 35, // sidebar, above other content to be visible when dragged, resized
+    draggableComponent: 30, // sidebar, above other content to be visible when dragged, resized
     navigationBar: 30,
     expandableNavigationHeader: 21, // above EXPANDABLE_NAVIGATION to cover its box-shadow
     expandableNavigation: 20, // above PAGE_HEADER to spread over it


### PR DESCRIPTION
## Description

Adjust default value for z-index of `ResizableBox` component used in the sidebar the way that the tooltip is displayed nicely above it, especially above the edge that is being highlighted on hover or when resizing the sidebar. 

## Related Issue

## Screenshots:
**Before:**
![z_before](https://github.com/trezor/trezor-suite/assets/13417815/383cbf53-409d-4101-bfe6-8bcb714e12d9)

**After:**
![z_after](https://github.com/trezor/trezor-suite/assets/13417815/e2130c20-fcb3-446f-b103-f058113dd739)


