### PR TITLE
fix(suite): Device status text

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceStatus.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceStatus.tsx
@@ -13,6 +13,7 @@ type DeviceStatusProps = {
     deviceNeedsRefresh?: boolean;
     device?: TrezorDevice;
     handleRefreshClick?: MouseEventHandler;
+    forceConnectionInfo?: boolean;
 };
 
 const Container = styled.div`
@@ -39,6 +40,7 @@ export const DeviceStatus = ({
     deviceNeedsRefresh = false,
     device,
     handleRefreshClick,
+    forceConnectionInfo = false,
 }: DeviceStatusProps) => {
     return (
         <Container>
@@ -53,7 +55,11 @@ export const DeviceStatus = ({
 
             {device && (
                 <DeviceDetail label={device.label}>
-                    <DeviceStatusText onRefreshClick={handleRefreshClick} device={device} />
+                    <DeviceStatusText
+                        onRefreshClick={handleRefreshClick}
+                        device={device}
+                        forceConnectionInfo={forceConnectionInfo}
+                    />
                 </DeviceDetail>
             )}
         </Container>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/SidebarDeviceStatus.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/SidebarDeviceStatus.tsx
@@ -1,5 +1,5 @@
 import { MouseEventHandler } from 'react';
-import { acquireDevice, selectDevice } from '@suite-common/wallet-core';
+import { acquireDevice, selectDevice, selectDevices } from '@suite-common/wallet-core';
 import * as deviceUtils from '@suite-common/suite-utils';
 import { TrezorDevice } from 'src/types/suite';
 import { useDispatch, useSelector } from '../../../../../hooks/suite';
@@ -19,7 +19,7 @@ const needsRefresh = (device?: TrezorDevice) => {
 
 export const SidebarDeviceStatus = () => {
     const selectedDevice = useSelector(selectDevice);
-
+    const devices = useSelector(selectDevices);
     const dispatch = useDispatch();
 
     const deviceNeedsRefresh = needsRefresh(selectedDevice);
@@ -36,6 +36,11 @@ export const SidebarDeviceStatus = () => {
     if (!selectedDevice || !selectedDeviceModelInternal) {
         return null;
     }
+    const instances = deviceUtils.getDeviceInstances(selectedDevice, devices);
+    const instancesWithState = instances.filter(i => i.state);
+
+    const isConnectionShown =
+        instancesWithState.length === 1 && selectedDevice.useEmptyPassphrase === true;
 
     return (
         <DeviceStatus
@@ -43,6 +48,7 @@ export const SidebarDeviceStatus = () => {
             deviceNeedsRefresh={deviceNeedsRefresh}
             device={selectedDevice}
             handleRefreshClick={handleRefreshClick}
+            forceConnectionInfo={isConnectionShown}
         />
     );
 };

--- a/packages/suite/src/views/suite/SwitchDevice/CardWithDevice.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/CardWithDevice.tsx
@@ -70,6 +70,7 @@ export const CardWithDevice = ({
                     device={device}
                     isCloseButtonVisible={isCloseButtonVisible}
                     onBackButtonClick={onBackButtonClick}
+                    forceConnectionInfo
                 />
 
                 {deviceWarning}

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceHeader.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceHeader.tsx
@@ -30,6 +30,7 @@ interface DeviceHeaderProps {
     isCloseButtonVisible: boolean;
     onBackButtonClick?: () => void;
     isFindTrezorVisible?: boolean;
+    forceConnectionInfo: boolean;
 }
 
 export const DeviceHeader = ({
@@ -38,6 +39,7 @@ export const DeviceHeader = ({
     isCloseButtonVisible,
     onBackButtonClick,
     isFindTrezorVisible = false,
+    forceConnectionInfo,
 }: DeviceHeaderProps) => {
     const selectedDevice = useSelector(selectDevice);
     const transport = useSelector(state => state.suite.transport);
@@ -65,7 +67,11 @@ export const DeviceHeader = ({
                 )}
 
                 {deviceModelInternal && (
-                    <DeviceStatus deviceModel={deviceModelInternal} device={device} />
+                    <DeviceStatus
+                        deviceModel={deviceModelInternal}
+                        device={device}
+                        forceConnectionInfo={forceConnectionInfo}
+                    />
                 )}
             </Row>
 

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceStatusText.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceStatusText.tsx
@@ -11,14 +11,16 @@ import { TrezorDevice } from '@suite-common/suite-types';
 type DeviceStatusTextProps = {
     onRefreshClick?: MouseEventHandler;
     device: TrezorDevice;
+    forceConnectionInfo: boolean;
 };
 
 type DeviceStatusVisible = {
     connected: boolean;
     device: TrezorDevice;
+    forceConnectionInfo: boolean;
 };
 
-const DeviceStatusVisible = ({ device, connected }: DeviceStatusVisible) => {
+const DeviceStatusVisible = ({ device, connected, forceConnectionInfo }: DeviceStatusVisible) => {
     const { walletLabel } = useSelector(state => selectLabelingDataForWallet(state, device.state));
 
     const { defaultAccountLabelString } = useWalletLabeling();
@@ -35,7 +37,7 @@ const DeviceStatusVisible = ({ device, connected }: DeviceStatusVisible) => {
             icon={connected ? 'LINK' : 'UNLINK'}
             data-test={connected ? '@deviceStatus-connected' : '@deviceStatus-disconnected'}
         >
-            {walletLabel ? (
+            {walletText && !forceConnectionInfo ? (
                 <TruncateWithTooltip delayShow={TOOLTIP_DELAY_LONG}>
                     {walletText}
                 </TruncateWithTooltip>
@@ -46,7 +48,11 @@ const DeviceStatusVisible = ({ device, connected }: DeviceStatusVisible) => {
     );
 };
 
-export const DeviceStatusText = ({ onRefreshClick, device }: DeviceStatusTextProps) => {
+export const DeviceStatusText = ({
+    onRefreshClick,
+    device,
+    forceConnectionInfo,
+}: DeviceStatusTextProps) => {
     const { connected } = device;
     const deviceStatus = deviceUtils.getStatus(device);
     const needsAttention = deviceUtils.deviceNeedsAttention(deviceStatus);
@@ -64,5 +70,11 @@ export const DeviceStatusText = ({ onRefreshClick, device }: DeviceStatusTextPro
         );
     }
 
-    return <DeviceStatusVisible connected={connected} device={device} />;
+    return (
+        <DeviceStatusVisible
+            connected={connected}
+            device={device}
+            forceConnectionInfo={forceConnectionInfo}
+        />
+    );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

1) only one standard wallet active and there are no other wallets:

<img width="572" alt="image" src="https://github.com/trezor/trezor-suite/assets/858321/d296202d-64e8-493d-980e-5cef73b8e57d">


2) passphrase wallet active (doesn't matter how many wallets are created):

<img width="418" alt="image" src="https://github.com/trezor/trezor-suite/assets/858321/cb41a563-4d3e-4051-a428-aa5c52982b62">


3) standard wallet when there are other wallets:

<img width="443" alt="image" src="https://github.com/trezor/trezor-suite/assets/858321/f7a87d69-91e7-4957-a361-07714f3e2ed0">



in modal there is always a connection info:

<img width="494" alt="image" src="https://github.com/trezor/trezor-suite/assets/858321/104db232-bc47-40d1-9843-e6f2f6f87966">

<img width="436" alt="image" src="https://github.com/trezor/trezor-suite/assets/858321/2f04441e-7864-49cd-8aff-a92dc4fcab54">

