### PR TITLE
fix(suite): BTC only button positioning

### DIFF
--- a/packages/suite/src/views/settings/SettingsCoins/FirmwareTypeSuggestion.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/FirmwareTypeSuggestion.tsx
@@ -19,6 +19,8 @@ const Row = styled.div`
 
 const StyledButton = styled(Button)`
     display: inline;
+    position: relative;
+    top: 5px;
 `;
 
 const Description = styled.div`
@@ -43,7 +45,12 @@ const FirmwareTypeSuggestionDescription = () => {
                 id={translationId}
                 values={{
                     button: chunks => (
-                        <StyledButton variant="tertiary" size="tiny" onClick={goToFirmwareType}>
+                        <StyledButton
+                            margin={{ left: 2, right: 2 }}
+                            variant="tertiary"
+                            size="tiny"
+                            onClick={goToFirmwareType}
+                        >
                             {chunks}
                         </StyledButton>
                     ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This triggered my OCD for some time, so I needed to fix it

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

before:
<img width="725" alt="Screenshot 2024-07-02 at 15 49 33" src="https://github.com/trezor/trezor-suite/assets/858321/9bc97f68-01c2-4ee0-a4b1-a0b5fe8b1e14">

after:
<img width="727" alt="image" src="https://github.com/trezor/trezor-suite/assets/858321/37e436e8-89e7-4916-8eb4-389582911452">
