### PR TITLE
chore(suite): do not remember selected fee

### DIFF
--- a/packages/suite/src/actions/settings/constants/walletSettings.ts
+++ b/packages/suite/src/actions/settings/constants/walletSettings.ts
@@ -1,6 +1,5 @@
 export const SET_LOCAL_CURRENCY = '@wallet-settings/set-local-currency';
 export const SET_HIDE_BALANCE = '@wallet-settings/hide-balance';
 export const CHANGE_NETWORKS = '@wallet-settings/change-networks';
-export const SET_LAST_USED_FEE_LEVEL = '@wallet-settings/set-last-used-fee-level';
 export const FROM_STORAGE = '@wallet-settings/from-storage';
 export const SET_BITCOIN_AMOUNT_UNITS = '@suite/set-bitcoin-amount-units';

--- a/packages/suite/src/actions/settings/walletSettingsActions.ts
+++ b/packages/suite/src/actions/settings/walletSettingsActions.ts
@@ -78,24 +78,6 @@ export const changeCoinVisibility =
         });
     };
 
-export const setLastUsedFeeLevel =
-    (feeLevel?: FeeLevel) => (dispatch: Dispatch, getState: GetState) => {
-        const { selectedAccount } = getState().wallet;
-        if (selectedAccount.status !== 'loaded') return;
-        dispatch({
-            type: WALLET_SETTINGS.SET_LAST_USED_FEE_LEVEL,
-            symbol: selectedAccount.account.symbol,
-            feeLevel,
-        });
-    };
-
-export const getLastUsedFeeLevel = () => (_: Dispatch, getState: GetState) => {
-    const { selectedAccount, settings } = getState().wallet;
-    if (selectedAccount.status !== 'loaded') return;
-
-    return settings.lastUsedFeeLevel[selectedAccount.account.symbol];
-};
-
 export const setBitcoinAmountUnits = (units: PROTO.AmountUnit): WalletSettingsAction => {
     analytics.report({
         type: EventType.SettingsGeneralChangeBitcoinUnit,

--- a/packages/suite/src/components/wallet/Fees/CustomFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/CustomFee.tsx
@@ -55,7 +55,6 @@ interface CustomFeeProps<TFieldValues extends FormState> {
     control: Control;
     setValue: UseFormSetValue<TFieldValues>;
     getValues: UseFormGetValues<TFieldValues>;
-    changeFeeLimit?: (value: string) => void;
     composedFeePerByte: string;
 }
 
@@ -64,7 +63,6 @@ export const CustomFee = <TFieldValues extends FormState>({
     feeInfo,
     register,
     control,
-    changeFeeLimit,
     composedFeePerByte,
     ...props
 }: CustomFeeProps<TFieldValues>) => {

--- a/packages/suite/src/components/wallet/Fees/Fees.tsx
+++ b/packages/suite/src/components/wallet/Fees/Fees.tsx
@@ -107,7 +107,6 @@ export interface FeesProps<TFieldValues extends FormState> {
     getValues: UseFormGetValues<TFieldValues>;
     errors: FieldErrors<TFieldValues>;
     changeFeeLevel: (level: FeeLevel['label']) => void;
-    changeFeeLimit?: (value: string) => void;
     composedLevels?: PrecomposedLevels | PrecomposedLevelsCardano;
     label?: ExtendedMessageDescriptor['id'];
     rbfForm?: boolean;
@@ -120,7 +119,6 @@ export const Fees = <TFieldValues extends FormState>({
     feeInfo,
     control,
     changeFeeLevel,
-    changeFeeLimit,
     composedLevels,
     label,
     rbfForm,
@@ -220,7 +218,6 @@ export const Fees = <TFieldValues extends FormState>({
                         register={register}
                         getValues={getValues}
                         setValue={setValue}
-                        changeFeeLimit={changeFeeLimit}
                         composedFeePerByte={
                             (transactionInfo as PrecomposedTransactionFinal)?.feePerByte
                         }

--- a/packages/suite/src/hooks/wallet/form/useFees.ts
+++ b/packages/suite/src/hooks/wallet/form/useFees.ts
@@ -1,7 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { FieldPath, UseFormReturn } from 'react-hook-form';
 import { FeeLevel } from '@trezor/connect';
-import { setLastUsedFeeLevel } from 'src/actions/settings/walletSettingsActions';
 import { useDispatch } from 'src/hooks/suite';
 import {
     FeeInfo,
@@ -80,21 +79,8 @@ export const useFees = <TFieldValues extends FormState>({
         }
 
         // compose
-        if (updateField) {
-            if (composeRequest) {
-                composeRequest(updateField);
-            }
-            // save last used fee
-            if (
-                saveLastUsedFeeRef.current &&
-                feePerUnit &&
-                !errors.feePerUnit &&
-                !errors.feeLimit
-            ) {
-                dispatch(
-                    setLastUsedFeeLevel({ label: 'custom', feePerUnit, feeLimit, blocks: -1 }),
-                );
-            }
+        if (updateField && composeRequest) {
+            composeRequest(updateField);
         }
     }, [dispatch, feePerUnit, feeLimit, errors.feePerUnit, errors.feeLimit, composeRequest]);
 
@@ -151,12 +137,6 @@ export const useFees = <TFieldValues extends FormState>({
 
         // on change callback
         if (onChange) onChange(selectedFeeRef.current, level);
-
-        // save last used fee
-        if (level !== 'custom' && saveLastUsedFeeRef.current) {
-            const nextLevel = feeInfo.levels.find(l => l.label === (level || 'normal'))!;
-            dispatch(setLastUsedFeeLevel(nextLevel));
-        }
 
         selectedFeeRef.current = selectedFee;
     };

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -8,10 +8,6 @@ import {
     saveSendFormDraftThunk,
     signAndPushSendFormTransactionThunk,
 } from 'src/actions/wallet/send/sendFormThunks';
-import {
-    getLastUsedFeeLevel,
-    setLastUsedFeeLevel,
-} from 'src/actions/settings/walletSettingsActions';
 import { goto } from 'src/actions/suite/routerActions';
 import { fillSendForm } from 'src/actions/suite/protocolActions';
 import { AppState } from 'src/types/suite';
@@ -114,25 +110,12 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
     // used in "loadDraft" useEffect and "importTransaction" callback
     const getLoadedValues = useCallback(
         (loadedState?: Partial<FormState>) => {
-            const feeEnhancement: Partial<FormState> = {};
-            if (!loadedState || !loadedState.selectedFee) {
-                const lastUsedFee = dispatch(getLastUsedFeeLevel());
-                if (lastUsedFee) {
-                    feeEnhancement.selectedFee = lastUsedFee.label;
-                    if (lastUsedFee.label === 'custom') {
-                        feeEnhancement.feePerUnit = lastUsedFee.feePerUnit;
-                        feeEnhancement.feeLimit = lastUsedFee.feeLimit;
-                    }
-                }
-            }
-
             return {
                 ...getDefaultValues(localCurrencyOption),
                 ...loadedState,
-                ...feeEnhancement,
             };
         },
-        [dispatch, localCurrencyOption],
+        [localCurrencyOption, state.network, localCurrencyOption],
     );
 
     // update custom values
@@ -211,7 +194,6 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
     const resetContext = useCallback(() => {
         setComposedLevels(undefined);
         dispatch(removeSendFormDraftThunk()); // reset draft;
-        dispatch(setLastUsedFeeLevel()); // reset last known FeeLevel
         setState(getStateFromProps(props)); // resetting state will trigger "loadDraft" useEffect block, which will reset FormState to default
     }, [dispatch, props, setComposedLevels]);
 
@@ -346,7 +328,14 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
     useEffect(() => {
         if (!draftSaveRequest) return;
         if (Object.keys(formState.errors).length === 0) {
-            dispatch(saveSendFormDraftThunk({ formState: getValues() }));
+            dispatch(
+                saveSendFormDraftThunk({
+                    formState: {
+                        ...getValues(),
+                        selectedFee: undefined,
+                    },
+                }),
+            );
         }
         setDraftSaveRequest(false);
     }, [dispatch, draftSaveRequest, setDraftSaveRequest, getValues, formState.errors]);

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -217,7 +217,6 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 case WALLET_SETTINGS.SET_HIDE_BALANCE:
                 case walletSettingsActions.setLocalCurrency.type:
                 case WALLET_SETTINGS.SET_BITCOIN_AMOUNT_UNITS:
-                case WALLET_SETTINGS.SET_LAST_USED_FEE_LEVEL:
                     api.dispatch(storageActions.saveWalletSettings());
                     break;
 

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -812,16 +812,6 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
             return tx;
         });
 
-        await updateAll(transaction, 'walletSettings', walletSettings => {
-            Object.keys(walletSettings.lastUsedFeeLevel).forEach(coin => {
-                if (walletSettings.lastUsedFeeLevel[coin].label === 'low') {
-                    delete walletSettings.lastUsedFeeLevel[coin];
-                }
-            });
-
-            return walletSettings;
-        });
-
         await updateAll(transaction, 'suiteSettings', suiteSettings => {
             // @ts-expect-error
             delete suiteSettings.flags.showDashboardT2B1PromoBanner;
@@ -884,5 +874,14 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
         });
 
         await updateAll(transaction, 'suiteSettings', suiteSettings => suiteSettings);
+    }
+    
+    if (oldVersion < 47) {
+        await updateAll(transaction, 'walletSettings', walletSettings => {
+            // @ts-expect-error
+            delete walletSettings.lastUsedFeeLevel;
+
+            return walletSettings;
+        });
     }
 };

--- a/suite-common/wallet-types/src/settings.ts
+++ b/suite-common/wallet-types/src/settings.ts
@@ -22,7 +22,4 @@ export interface WalletSettings {
     discreetMode: boolean;
     enabledNetworks: Network['symbol'][];
     bitcoinAmountUnit: PROTO.AmountUnit;
-    lastUsedFeeLevel: {
-        [key: string]: Omit<FeeLevel, 'blocks'>; // Key: Network['symbol']
-    };
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- fee is changing quite often, why would we remember chosen `custom` fee and `XYZ` values and use them again when user opens send form in 1 hour, 1 day, 1 month?

## Related Issue

Resolve #8655

## Screenshots:
