### PR TITLE
fix(connect): proceed with fw install even when language data fails t…

### DIFF
--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -358,6 +358,8 @@ export const onCallFirmwareUpdate = async ({
                       language: targetLanguage,
                       version: device.firmwareRelease.release.version,
                       internal_model: device.features.internal_model,
+                  }).catch(() => {
+                      // silent, language data is not critical, it can be updated any time later and it indeed happens inside device.updateFeatures
                   })
                 : null;
 


### PR DESCRIPTION
…o download

tested it by setting connect to download language data from some bogus url. it went through. 

![image](https://github.com/trezor/trezor-suite/assets/30367552/71647ba7-abd3-4fd0-9f0a-150fc06e4757)

is there an issue?