### PR TITLE
chore(suite-native): blacklist bsc on mobile

### DIFF
--- a/suite-native/config/src/supportedNetworks.ts
+++ b/suite-native/config/src/supportedNetworks.ts
@@ -12,7 +12,7 @@ export const orderedAccountTypes: AccountType[] = [
     'ledger',
 ];
 
-const discoveryBlacklist: NetworkSymbol[] = ['sol', 'dsol', 'matic'];
+const discoveryBlacklist: NetworkSymbol[] = ['sol', 'dsol', 'matic', 'bsc'];
 
 // All supported coins for device discovery
 export const networkSymbolsWhitelistMap = {


### PR DESCRIPTION
mobile app should not discover bsc accounts now