### PR TITLE
fix(suite): Electron Security, Disable/Limit navigation

### DIFF
--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -105,6 +105,15 @@ const init = async () => {
         });
     });
 
+    app.on('web-contents-created', (_, contents) => {
+        contents.on('will-navigate', (event, navigationUrl) => {
+            // See: https://www.electronjs.org/docs/latest/tutorial/security#13-disable-or-limit-navigation
+            // There is no situation where we do this type of redirect so we can disable it.
+            logger.error('electron', `Prevented unexpected redirect to: ${navigationUrl}`);
+            event.preventDefault();
+        });
+    });
+
     ipcMain.on('app/restart', () => {
         logger.info('main', 'App restart requested');
         restartApp();


### PR DESCRIPTION
To adhere to this recommendation https://www.electronjs.org/docs/latest/tutorial/security#13-disable-or-limit-navigation

To test this just add:

```ts
<button onClick={() => {
    location.assign('https://google.com');
}}>Click me!</button>
```

somewhere


