### PR TITLE
chore(suite): add tutorial step to onboarding for TS5

### DIFF
--- a/packages/suite/src/config/onboarding/steps.ts
+++ b/packages/suite/src/config/onboarding/steps.ts
@@ -42,7 +42,10 @@ const steps: Step[] = [
     {
         id: STEP.ID_TUTORIAL_STEP,
         stepGroup: 0,
-        supportedModels: [DeviceModelInternal.T2B1],
+        supportedModels: [
+            DeviceModelInternal.T2B1,
+            { model: DeviceModelInternal.T3T1, minFwVersion: '2.8.0' },
+        ],
         prerequisites: [...commonPrerequisites, 'device-recovery-mode', 'device-different'],
     },
     {

--- a/packages/suite/src/types/onboarding/index.ts
+++ b/packages/suite/src/types/onboarding/index.ts
@@ -2,13 +2,18 @@ import { DeviceModelInternal } from '@trezor/connect';
 import * as STEP from 'src/constants/onboarding/steps';
 import { PrerequisiteType } from 'src/utils/suite/prerequisites';
 
-export interface Step {
+type ModelWithFirmwareVersion = {
+    model: DeviceModelInternal;
+    minFwVersion: `${number}.${number}.${number}`;
+};
+
+export type Step = {
     id: AnyStepId;
     stepGroup: number | undefined;
     prerequisites?: (PrerequisiteType | 'device-different')[];
     path?: AnyPath[];
-    supportedModels?: DeviceModelInternal[];
-}
+    supportedModels?: (DeviceModelInternal | ModelWithFirmwareVersion)[];
+};
 
 // todo: remove, improve typing
 export type AnyStepId =

--- a/packages/suite/src/utils/onboarding/__tests__/steps.test.ts
+++ b/packages/suite/src/utils/onboarding/__tests__/steps.test.ts
@@ -14,7 +14,10 @@ const backupStep: Step = {
     id: STEP.ID_BACKUP_STEP,
     path: [],
     stepGroup: 1,
-    supportedModels: [DeviceModelInternal.T2B1],
+    supportedModels: [
+        DeviceModelInternal.T2B1,
+        { model: DeviceModelInternal.T3T1, minFwVersion: '2.8.0' },
+    ],
 };
 
 const stateMock = {
@@ -37,7 +40,7 @@ describe('steps', () => {
             expect(findNextStep(firmwareStep.id, stepsMock)).toEqual(backupStep);
         });
 
-        it('should throw on improrper use (no more step exists)', () => {
+        it('should throw on improper use (no more step exists)', () => {
             expect(() => findNextStep(backupStep.id, stepsMock)).toThrow('no next step exists');
         });
     });
@@ -90,6 +93,39 @@ describe('steps', () => {
                     device: {
                         selectedDevice: {
                             features: { internal_model: DeviceModelInternal.T1B1 },
+                        },
+                    },
+                })),
+            ).toEqual(false);
+        });
+
+        it('should exclude steps not supported by firmware', () => {
+            expect(
+                isStepUsed(backupStep, () => ({
+                    ...stateMock,
+                    device: {
+                        selectedDevice: {
+                            features: {
+                                internal_model: DeviceModelInternal.T3T1,
+                                major_version: 2,
+                                minor_version: 8,
+                                patch_version: 0,
+                            },
+                        },
+                    },
+                })),
+            ).toEqual(true);
+            expect(
+                isStepUsed(backupStep, () => ({
+                    ...stateMock,
+                    device: {
+                        selectedDevice: {
+                            features: {
+                                internal_model: DeviceModelInternal.T3T1,
+                                major_version: 2,
+                                minor_version: 7,
+                                patch_version: 2,
+                            },
                         },
                     },
                 })),

--- a/packages/suite/src/utils/onboarding/steps.ts
+++ b/packages/suite/src/utils/onboarding/steps.ts
@@ -1,4 +1,6 @@
 import { selectDevice } from '@suite-common/wallet-core';
+import { getFirmwareVersion } from '@trezor/device-utils';
+import { versionUtils } from '@trezor/utils';
 
 import { AnyStepId, AnyPath, Step } from 'src/types/onboarding';
 import { GetState } from 'src/types/suite';
@@ -15,7 +17,15 @@ export const isStepUsed = (step: Step, getState: GetState): boolean => {
     if (
         deviceModelInternal &&
         Array.isArray(step.supportedModels) &&
-        !step.supportedModels.includes(deviceModelInternal)
+        !(
+            step.supportedModels.includes(deviceModelInternal) ||
+            step.supportedModels.some(
+                it =>
+                    typeof it === 'object' &&
+                    it.model === deviceModelInternal &&
+                    versionUtils.isNewerOrEqual(getFirmwareVersion(device), it.minFwVersion),
+            )
+        )
     ) {
         return false;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Tutorial for TS5 was added in FW version 2.8.0. Adjusting onboarding logic.

**QA:** tutorial should be available for TS5 from version 2.8.0 and skipped for 2.7.2.
