### PR TITLE
fix(suite): Prevent sidebar width changes when being on Settings page

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Sidebar.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Sidebar.tsx
@@ -17,25 +17,31 @@ const Container = styled.nav<{ $elevation: Elevation }>`
     border-right: 1px solid ${mapElevationToBorder};
 `;
 
+const Wrapper = styled.div`
+    display: flex;
+`;
+
 export const Sidebar = () => {
     const { elevation } = useElevation();
 
     return (
-        <ResizableBox
-            directions={['right']}
-            width={SIDEBAR_WIDTH_NUMERIC}
-            minWidth={230}
-            maxWidth={400}
-            zIndex={zIndices.draggableComponent}
-        >
-            <Container $elevation={elevation}>
-                <ElevationUp>
-                    <DeviceSelector />
-                    <Navigation />
-                    <AccountsMenu />
-                    <QuickActions />
-                </ElevationUp>
-            </Container>
-        </ResizableBox>
+        <Wrapper>
+            <ResizableBox
+                directions={['right']}
+                width={SIDEBAR_WIDTH_NUMERIC}
+                minWidth={230}
+                maxWidth={400}
+                zIndex={zIndices.draggableComponent}
+            >
+                <Container $elevation={elevation}>
+                    <ElevationUp>
+                        <DeviceSelector />
+                        <Navigation />
+                        <AccountsMenu />
+                        <QuickActions />
+                    </ElevationUp>
+                </Container>
+            </ResizableBox>
+        </Wrapper>
     );
 };


### PR DESCRIPTION
## Description

 Prevent sidebar unexpected width changes when switching between _Settings_ tabs. Note that this issue is not always reproducible, depending on the size of the window and zoom level. Additionally, when happening this, it was not possible to reach the max width of the sidebar for some of the Settings tabs.

## Related Issue

Resolves https://github.com/trezor/trezor-suite/issues/13210

## Screenshots:
**Before:**

https://github.com/trezor/trezor-suite/assets/13417815/884ef5c8-5da5-40bb-8a9a-783d2c5c23fa

**After:**

https://github.com/trezor/trezor-suite/assets/13417815/27dece10-9521-4aa3-a3e6-73b05a771c89



