### PR TITLE
chore(transport): remove unnecessary return type from Usb and Udp api

### DIFF
--- a/packages/transport/src/api/abstract.ts
+++ b/packages/transport/src/api/abstract.ts
@@ -142,3 +142,9 @@ export abstract class AbstractApi extends TypedEmitter<{
         return unknownError(err, expectedErrors);
     }
 }
+
+export type AbstractApiAwaitedResult<K extends keyof AbstractApi> = AbstractApi[K] extends (
+    ...args: any[]
+) => any
+    ? Awaited<ReturnType<AbstractApi[K]>>
+    : never;

--- a/packages/transport/src/api/udp.ts
+++ b/packages/transport/src/api/udp.ts
@@ -1,8 +1,12 @@
 import UDP from 'dgram';
 import { isNotUndefined } from '@trezor/utils';
 
-import { AbstractApi, AbstractApiConstructorParams, DEVICE_TYPE } from './abstract';
-import { ResultWithTypedError } from '../types';
+import {
+    AbstractApi,
+    AbstractApiAwaitedResult,
+    AbstractApiConstructorParams,
+    DEVICE_TYPE,
+} from './abstract';
 
 import * as ERRORS from '../errors';
 
@@ -37,14 +41,7 @@ export class UdpApi extends AbstractApi {
     public write(path: string, buffer: Buffer, signal?: AbortSignal) {
         const [hostname, port] = path.split(':');
 
-        return new Promise<
-            ResultWithTypedError<
-                undefined,
-                | typeof ERRORS.INTERFACE_DATA_TRANSFER
-                | typeof ERRORS.UNEXPECTED_ERROR
-                | typeof ERRORS.ABORTED_BY_SIGNAL
-            >
-        >(resolve => {
+        return new Promise<AbstractApiAwaitedResult<'write'>>(resolve => {
             signal?.addEventListener('abort', () => {
                 resolve(
                     this.error({
@@ -77,14 +74,7 @@ export class UdpApi extends AbstractApi {
     public read(_path: string, signal?: AbortSignal) {
         this.communicating = true;
 
-        return new Promise<
-            ResultWithTypedError<
-                ArrayBuffer,
-                | typeof ERRORS.INTERFACE_DATA_TRANSFER
-                | typeof ERRORS.ABORTED_BY_TIMEOUT
-                | typeof ERRORS.ABORTED_BY_SIGNAL
-            >
-        >(resolve => {
+        return new Promise<AbstractApiAwaitedResult<'read'>>(resolve => {
             const onClear = () => {
                 // eslint-disable-next-line @typescript-eslint/no-use-before-define
                 this.interface.removeListener('error', onError);

--- a/packages/transport/src/api/udp.ts
+++ b/packages/transport/src/api/udp.ts
@@ -2,7 +2,7 @@ import UDP from 'dgram';
 import { isNotUndefined } from '@trezor/utils';
 
 import { AbstractApi, AbstractApiConstructorParams, DEVICE_TYPE } from './abstract';
-import { AsyncResultWithTypedError, ResultWithTypedError } from '../types';
+import { ResultWithTypedError } from '../types';
 
 import * as ERRORS from '../errors';
 
@@ -74,19 +74,7 @@ export class UdpApi extends AbstractApi {
         });
     }
 
-    public read(
-        _path: string,
-        signal?: AbortSignal,
-    ): AsyncResultWithTypedError<
-        ArrayBuffer,
-        | typeof ERRORS.DEVICE_NOT_FOUND
-        | typeof ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE
-        | typeof ERRORS.INTERFACE_DATA_TRANSFER
-        | typeof ERRORS.DEVICE_DISCONNECTED_DURING_ACTION
-        | typeof ERRORS.UNEXPECTED_ERROR
-        | typeof ERRORS.ABORTED_BY_TIMEOUT
-        | typeof ERRORS.ABORTED_BY_SIGNAL
-    > {
+    public read(_path: string, signal?: AbortSignal) {
         this.communicating = true;
 
         return new Promise<

--- a/packages/transport/src/api/usb.ts
+++ b/packages/transport/src/api/usb.ts
@@ -1,5 +1,5 @@
 import { AbstractApi, AbstractApiConstructorParams, DEVICE_TYPE } from './abstract';
-import { AsyncResultWithTypedError, DescriptorApiLevel } from '../types';
+import { DescriptorApiLevel } from '../types';
 import {
     CONFIGURATION_ID,
     ENDPOINT_ID,
@@ -184,18 +184,7 @@ export class UsbApi extends AbstractApi {
         }
     }
 
-    public async read(
-        path: string,
-        signal?: AbortSignal,
-    ): AsyncResultWithTypedError<
-        ArrayBuffer,
-        | typeof ERRORS.DEVICE_NOT_FOUND
-        | typeof ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE
-        | typeof ERRORS.INTERFACE_DATA_TRANSFER
-        | typeof ERRORS.DEVICE_DISCONNECTED_DURING_ACTION
-        | typeof ERRORS.ABORTED_BY_SIGNAL
-        | typeof ERRORS.UNEXPECTED_ERROR
-    > {
+    public async read(path: string, signal?: AbortSignal) {
         const device = this.findDevice(path);
         if (!device) {
             return this.error({ error: ERRORS.DEVICE_NOT_FOUND });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove unnecessary type overload from transport api `read` methods.
Type correctness is already watched by AbstractApi['read']
