### PR TITLE
Cardano token definitions fix

### DIFF
--- a/packages/blockchain-link-types/src/common.ts
+++ b/packages/blockchain-link-types/src/common.ts
@@ -160,13 +160,13 @@ export interface TokenAccount {
 
 export interface TokenInfo {
     type: string; // token type: ERC20...
-    contract: string; // token address, policy id for ADA
+    contract: string; // token address, token unit for ADA
     balance?: string; // token balance
     name?: string; // token name
     symbol?: string; // token symbol
     decimals: number; // token decimals or 0
     accounts?: TokenAccount[]; // token accounts for solana
-    unit?: string; // Cardano policy id + encoded asset name
+    policyId?: string; // Cardano policy id
     fingerprint?: string; // Cardano starting with "asset"
     // transfers: number, // total transactions?
 }

--- a/packages/blockchain-link-utils/src/blockfrost.ts
+++ b/packages/blockchain-link-utils/src/blockfrost.ts
@@ -99,11 +99,11 @@ export const transformToken = (token: AssetBalance) => {
 
     return {
         name: token.name || symbol,
-        contract: policyId,
+        contract: token.unit,
         symbol,
         decimals: token.decimals,
         fingerprint: token.fingerprint!,
-        unit: token.unit,
+        policyId,
     };
 };
 

--- a/packages/blockchain-link-utils/src/tests/fixtures/blockfrost.ts
+++ b/packages/blockchain-link-utils/src/tests/fixtures/blockfrost.ts
@@ -154,12 +154,13 @@ export default {
                 {
                     type: 'BLOCKFROST',
                     fingerprint: 'asset1hwnpal5vap799t6kkjmjf6myhse4zl2vu4ahzz',
-                    contract: 'b863bc7369f46136ac1048adb2fa7dae3af944c3bbb2be2f216a8d4f',
+                    policyId: 'b863bc7369f46136ac1048adb2fa7dae3af944c3bbb2be2f216a8d4f',
                     symbol: 'BerrySapphire',
                     name: 'Berry',
                     balance: '10',
                     decimals: 1,
-                    unit: 'b863bc7369f46136ac1048adb2fa7dae3af944c3bbb2be2f216a8d4f42657272795361707068697265',
+                    contract:
+                        'b863bc7369f46136ac1048adb2fa7dae3af944c3bbb2be2f216a8d4f42657272795361707068697265',
                 },
                 {
                     type: 'BLOCKFROST',
@@ -168,18 +169,18 @@ export default {
                     name: 'Snek',
                     balance: '4',
                     symbol: 'SNEK',
-                    contract: '279c909f348e533da5808898f87f9a14bb2c3dfbbacccd631d927a3f',
-                    unit: '279c909f348e533da5808898f87f9a14bb2c3dfbbacccd631d927a3f534e454b',
+                    policyId: '279c909f348e533da5808898f87f9a14bb2c3dfbbacccd631d927a3f',
+                    contract: '279c909f348e533da5808898f87f9a14bb2c3dfbbacccd631d927a3f534e454b',
                 },
                 {
                     type: 'BLOCKFROST',
                     fingerprint: 'asset1zvclg2cvj4e5jfz5vswf3sx0lasy79xn8cdap9',
-                    contract: '02477d7c23b4c2834b0be8ca8578dde47af0cc82a964688f6fc95a7a',
+                    policyId: '02477d7c23b4c2834b0be8ca8578dde47af0cc82a964688f6fc95a7a',
                     symbol: 'GRIC',
                     balance: '1',
                     decimals: 0,
                     name: 'GRIC',
-                    unit: '02477d7c23b4c2834b0be8ca8578dde47af0cc82a964688f6fc95a7a47524943',
+                    contract: '02477d7c23b4c2834b0be8ca8578dde47af0cc82a964688f6fc95a7a47524943',
                 },
             ],
         },
@@ -515,8 +516,9 @@ export default {
                     {
                         type: 'BLOCKFROST',
                         fingerprint: 'asset1eevmdlaz5424s3663ypw8w4vyxdlxkm3lefz06',
-                        unit: '2f712364ec46f0cf707d412106ce71ef3370f76e27fb56b6bb14708776657465726e696b4e657a6a6564656e79',
-                        contract: '2f712364ec46f0cf707d412106ce71ef3370f76e27fb56b6bb147087',
+                        contract:
+                            '2f712364ec46f0cf707d412106ce71ef3370f76e27fb56b6bb14708776657465726e696b4e657a6a6564656e79',
+                        policyId: '2f712364ec46f0cf707d412106ce71ef3370f76e27fb56b6bb147087',
                         symbol: 'veternikNezjedeny',
                         name: 'veternikNezjedeny',
                         balance: '1',
@@ -812,7 +814,9 @@ export default {
                     {
                         type: 'recv',
                         symbol: 'SNEK',
-                        contract: '2f712364ec46f0cf707d412106ce71ef3370f76e27fb56b6bb147087',
+                        policyId: '2f712364ec46f0cf707d412106ce71ef3370f76e27fb56b6bb147087',
+                        contract:
+                            '2f712364ec46f0cf707d412106ce71ef3370f76e27fb56b6bb14708776657465726e696b4e657a6a6564656e79',
                         name: 'Snek',
                         decimals: 0,
                         amount: '1',

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -846,12 +846,12 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
 
                     return {
                         balance: token.balance,
-                        contract: policyId,
+                        contract: token.contract,
                         name: token.symbol,
                         symbol: token.symbol,
                         decimals: token.decimals,
                         fingerprint: token.name,
-                        unit: token.contract,
+                        policyId,
                         type: token.type,
                     };
                 });
@@ -867,7 +867,7 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
 
                     return {
                         amount: token.amount,
-                        contract: policyId,
+                        contract: token.contract,
                         decimals: token.decimals,
                         from: token.from,
                         name: token.symbol || '',
@@ -875,7 +875,7 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
                         fingerprint: token.name,
                         to: token.to,
                         type: token.type,
-                        unit: token.contract,
+                        policyId,
                     };
                 });
             }

--- a/packages/suite/src/utils/wallet/tokenUtils.ts
+++ b/packages/suite/src/utils/wallet/tokenUtils.ts
@@ -3,7 +3,7 @@ import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { Account, Rate, TokenAddress, RatesByKey } from '@suite-common/wallet-types';
 import { TokenInfo } from '@trezor/connect';
 import { getFiatRateKey } from '@suite-common/wallet-utils';
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import { NetworkSymbol, getNetworkFeatures } from '@suite-common/wallet-config';
 import { FiatCurrencyCode } from '@suite-common/suite-config';
 import {
     EnhancedTokenInfo,
@@ -73,6 +73,8 @@ export const getTokens = (
     coinDefinitions?: TokenDefinition,
     searchQuery?: string,
 ) => {
+    const hasCoinDefinitions = getNetworkFeatures(symbol).includes('coin-definitions');
+
     const shown: EnhancedTokenInfo[] = [];
     const hidden: EnhancedTokenInfo[] = [];
     const unverified: EnhancedTokenInfo[] = [];
@@ -93,12 +95,14 @@ export const getTokens = (
 
         if (!matchesQuery) return;
 
-        if ((isKnown && !isHidden) || isShown) {
+        if (isShown) {
             shown.push(token);
-        } else if (!isKnown && !isShown) {
+        } else if (hasCoinDefinitions && !isKnown) {
             unverified.push(token);
-        } else if (isKnown && isHidden) {
+        } else if (isHidden) {
             hidden.push(token);
+        } else {
+            shown.push(token);
         }
     });
 

--- a/packages/suite/src/views/wallet/tokens/common/TokenList.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokenList.tsx
@@ -328,11 +328,7 @@ export const TokenList = ({
                                         },
                                         {
                                             key: 'contract-address',
-                                            label: translationString(
-                                                network.networkType === 'cardano'
-                                                    ? 'TR_POLICY_ID_ADDRESS'
-                                                    : 'TR_CONTRACT_ADDRESS',
-                                            ),
+                                            label: translationString('TR_CONTRACT_ADDRESS'),
                                             options: [
                                                 {
                                                     label: (
@@ -345,11 +341,7 @@ export const TokenList = ({
                                                         dispatch(
                                                             openModal({
                                                                 type: 'copy-address',
-                                                                addressType:
-                                                                    network.networkType ===
-                                                                    'cardano'
-                                                                        ? 'policyId'
-                                                                        : 'contract',
+                                                                addressType: 'contract',
                                                                 address: token.contract,
                                                             }),
                                                         ),
@@ -374,6 +366,28 @@ export const TokenList = ({
                                                                 addressType: 'fingerprint',
                                                                 address:
                                                                     token.fingerprint as string,
+                                                            }),
+                                                        ),
+                                                },
+                                            ],
+                                        },
+                                        token.policyId && {
+                                            key: 'policyId',
+                                            label: translationString('TR_POLICY_ID_ADDRESS'),
+                                            options: [
+                                                {
+                                                    label: (
+                                                        <ContractAddress>
+                                                            {token.policyId}
+                                                            <StyledIcon icon="COPY" size={14} />
+                                                        </ContractAddress>
+                                                    ),
+                                                    onClick: () =>
+                                                        dispatch(
+                                                            openModal({
+                                                                type: 'copy-address',
+                                                                addressType: 'policyId',
+                                                                address: token.policyId as string,
                                                             }),
                                                         ),
                                                 },

--- a/packages/suite/src/views/wallet/tokens/hidden-tokens/components/HiddenTokensTable.tsx
+++ b/packages/suite/src/views/wallet/tokens/hidden-tokens/components/HiddenTokensTable.tsx
@@ -11,6 +11,7 @@ import { spacings, spacingsPx } from '@trezor/theme';
 import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
 import { H3, Icon } from '@trezor/components';
 import { Text, Row } from '@trezor/components';
+import { isTestnet } from '@suite-common/wallet-utils';
 
 const Wrapper = styled.div`
     display: flex;
@@ -63,6 +64,7 @@ export const HiddenTokensTable = ({ selectedAccount, searchQuery }: HiddenTokens
             )}
             {hiddenTokensCount > 0 && (
                 <TokenList
+                    hideRates={isTestnet(account.symbol)}
                     account={account}
                     tokenStatusType={TokenManagementAction.SHOW}
                     tokens={filteredTokens.hidden}

--- a/suite-common/fiat-services/package.json
+++ b/suite-common/fiat-services/package.json
@@ -15,6 +15,7 @@
         "@suite-common/suite-config": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
+        "@trezor/blockchain-link-utils": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/utils": "workspace:*",
         "date-fns": "^2.30.0"

--- a/suite-common/fiat-services/tsconfig.json
+++ b/suite-common/fiat-services/tsconfig.json
@@ -5,6 +5,9 @@
         { "path": "../suite-config" },
         { "path": "../wallet-config" },
         { "path": "../wallet-types" },
+        {
+            "path": "../../packages/blockchain-link-utils"
+        },
         { "path": "../../packages/connect" },
         { "path": "../../packages/utils" }
     ]

--- a/suite-common/token-definitions/src/__fixtures__/utils.ts
+++ b/suite-common/token-definitions/src/__fixtures__/utils.ts
@@ -2,7 +2,7 @@ import { NetworkSymbol } from '@suite-common/wallet-config';
 
 import { DefinitionType } from '../tokenDefinitionsTypes';
 
-export const caseContractAddressForNetworkFixtures = [
+export const getContractAddressForNetworkFixtures = [
     {
         testName: 'Converts to lowercase for non-sol networks',
         networkSymbol: 'eth' as NetworkSymbol,
@@ -32,6 +32,12 @@ export const caseContractAddressForNetworkFixtures = [
         networkSymbol: 'sol' as NetworkSymbol,
         contractAddress: '',
         expected: '',
+    },
+    {
+        testName: 'Returns policy id for cardano',
+        networkSymbol: 'ada' as NetworkSymbol,
+        contractAddress: 'f43a62fdc3965df486de8a0d32fe800963589c41b38946602a0dc53541474958',
+        expected: 'f43a62fdc3965df486de8a0d32fe800963589c41b38946602a0dc535',
     },
 ];
 

--- a/suite-common/token-definitions/src/__tests__/utils.test.ts
+++ b/suite-common/token-definitions/src/__tests__/utils.test.ts
@@ -1,21 +1,21 @@
 import {
-    caseContractAddressForNetworkFixtures,
+    getContractAddressForNetworkFixtures,
     getSupportedDefinitionTypesFixtures,
     isTokenDefinitionKnownFixtures,
     buildTokenDefinitionsFromStorageFixtures,
 } from '../__fixtures__/utils';
 import {
     buildTokenDefinitionsFromStorage,
-    caseContractAddressForNetwork,
+    getContractAddressForNetwork,
     getSupportedDefinitionTypes,
     isTokenDefinitionKnown,
 } from '../tokenDefinitionsUtils';
 
-describe('caseContractAddressForNetwork', () => {
-    caseContractAddressForNetworkFixtures.forEach(
+describe('getContractAddressForNetwork', () => {
+    getContractAddressForNetworkFixtures.forEach(
         ({ testName, networkSymbol, contractAddress, expected }) => {
             test(testName, () => {
-                const result = caseContractAddressForNetwork(networkSymbol, contractAddress);
+                const result = getContractAddressForNetwork(networkSymbol, contractAddress);
                 expect(result).toBe(expected);
             });
         },

--- a/suite-common/token-definitions/src/tokenDefinitionsUtils.ts
+++ b/suite-common/token-definitions/src/tokenDefinitionsUtils.ts
@@ -1,4 +1,5 @@
 import { NetworkSymbol, getNetworkFeatures } from '@suite-common/wallet-config';
+import { parseAsset } from '@trezor/blockchain-link-utils/src/blockfrost';
 
 import {
     DefinitionType,
@@ -8,10 +9,23 @@ import {
     TokenManagementStorage,
 } from './tokenDefinitionsTypes';
 
-export const caseContractAddressForNetwork = (
+export const getContractAddressForNetwork = (
     networkSymbol: NetworkSymbol,
     contractAddress: string,
-) => (networkSymbol === 'sol' ? contractAddress : contractAddress.toLowerCase());
+) => {
+    switch (networkSymbol) {
+        case 'sol':
+        case 'dsol':
+            return contractAddress;
+        case 'ada':
+        case 'tada':
+            const { policyId } = parseAsset(contractAddress);
+
+            return policyId.toLowerCase();
+        default:
+            return contractAddress.toLowerCase();
+    }
+};
 
 export const isTokenDefinitionKnown = (
     tokenDefinitions: SimpleTokenStructure | undefined,
@@ -19,7 +33,7 @@ export const isTokenDefinitionKnown = (
     contractAddress: string,
 ) =>
     Array.isArray(tokenDefinitions)
-        ? tokenDefinitions?.includes(caseContractAddressForNetwork(networkSymbol, contractAddress))
+        ? tokenDefinitions?.includes(getContractAddressForNetwork(networkSymbol, contractAddress))
         : false;
 
 export const getSupportedDefinitionTypes = (networkSymbol: NetworkSymbol) => {

--- a/suite-common/wallet-utils/src/__fixtures__/cardanoUtils.ts
+++ b/suite-common/wallet-utils/src/__fixtures__/cardanoUtils.ts
@@ -128,7 +128,6 @@ export const transformUserOutputs = [
                 unit: '57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf391652243484f43',
                 quantity: '100',
                 decimals: 0,
-                contract: '57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf3916522',
             },
         ],
         symbol: 'ada',
@@ -156,7 +155,7 @@ export const transformUserOutputs = [
                     value: 'usd',
                     label: 'USD',
                 },
-                token: '57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf3916522',
+                token: '57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf391652243484f43',
                 label: '',
             },
             {
@@ -220,8 +219,8 @@ export const formatMaxOutputAmount = [
             symbol: 'ada',
             tokens: [
                 {
-                    contract: '57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf3916522',
-                    unit: '57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf391652243484f43',
+                    policyId: '57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf3916522',
+                    contract: '57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf391652243484f43',
                     balance: '500000',
                     decimals: 5,
                     fingerprint: 'asset1pwhywk7x54g739z3dqs245q62yu47vjh8gapjv',
@@ -243,7 +242,7 @@ export const formatMaxOutputAmount = [
             setMax: true,
             assets: [
                 {
-                    unit: '57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf3916522',
+                    unit: '57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf391652243484f43',
                     quantity: '',
                 },
             ],
@@ -252,14 +251,14 @@ export const formatMaxOutputAmount = [
             symbol: 'ada',
             tokens: [
                 {
-                    contract: '57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf3916522',
+                    policyId: '57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf3916522',
                     balance: '500000',
                     decimals: 5,
                     fingerprint: 'asset1pwhywk7x54g739z3dqs245q62yu47vjh8gapjv',
                     name: 'Nuts',
                     symbol: 'NUTS',
                     type: 'BLOCKFROST',
-                    unit: '57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf391652243484f43',
+                    contract: '57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf391652243484f43',
                 },
             ],
         },

--- a/suite-common/wallet-utils/src/cardanoUtils.ts
+++ b/suite-common/wallet-utils/src/cardanoUtils.ts
@@ -70,17 +70,13 @@ export const transformUserOutputs = (
             output.amount === '' ? undefined : networkAmountToSatoshi(output.amount, symbol);
         const tokenDecimals = accountTokens?.find(t => t.contract === output.token)?.decimals ?? 0;
 
-        // Token unit was previously contract address, it is "policy id + encoded asset name"
-        // However, unit was not compatible with fiat rates, token definitions and explorer which use just policy id
-        const tokenUnit = accountTokens?.find(t => t.contract === output.token)?.unit;
-
         return {
             address: output.address === '' ? undefined : output.address,
             amount: output.token ? undefined : amount,
             assets: output.token
                 ? [
                       {
-                          unit: tokenUnit!, // always available for Cardano
+                          unit: output.token,
                           quantity: output.amount
                               ? amountToSatoshi(output.amount, tokenDecimals)
                               : '0',

--- a/yarn.lock
+++ b/yarn.lock
@@ -8568,6 +8568,7 @@ __metadata:
     "@suite-common/suite-config": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
+    "@trezor/blockchain-link-utils": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/utils": "workspace:*"
     date-fns: "npm:^2.30.0"


### PR DESCRIPTION
## Description

- revert using policy id as contract address as it is not really needed and it was breaking send form because policy id is not unique (aha) and this solution is better (no changes to critical methods)
- fixes coins without token definitions have all tokens "legit" by default
- fiats are now fetched first for policy id, then for unit
  - coingecko mixes them together (token definitions are modified so that they use only policy ids)
- policy id is now used for token definitions (policy id is part of unit which is contract address so it works!)
- show also unit to a user

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/13169

## Screenshots:

if you compare it with  #13093 we also have fiat for banker coin! because that one uses unit and not policy id on coingecko 🙃 
![Screenshot 2024-07-04 at 13 19 40](https://github.com/trezor/trezor-suite/assets/33235762/d728faff-eaab-4980-8226-7e649aeb2e37)

(token-definitions turned on just for this screenshot)
![Screenshot 2024-07-04 at 13 19 48](https://github.com/trezor/trezor-suite/assets/33235762/23b3cb43-b9c5-494b-8ccf-c689d0ffaa83)
![Screenshot 2024-07-04 at 13 25 51](https://github.com/trezor/trezor-suite/assets/33235762/ea91d756-e4b2-4e24-a842-8e44093e76ba)


