### PR TITLE
fix(suite-native): set added account visible before go to detail

### DIFF
--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -281,8 +281,15 @@ export const fetchTransactionsPageThunk = createThunk(
             suppressBackupWarning: true,
         });
 
+        // Account might have changed during async getAccountInfo call, so we fetch current state
+        const currentAccount = selectAccountByKey(getState(), accountKey);
+
+        if (!currentAccount) {
+            throw new Error(`Account not found: ${accountKey}`);
+        }
+
         if (result && result.success) {
-            const updateAction = accountsActions.updateAccount(account, result.payload);
+            const updateAction = accountsActions.updateAccount(currentAccount, result.payload);
             const updatedAccount = updateAction.payload;
             const updatedTransactions = result.payload.history.transactions || [];
 


### PR DESCRIPTION
`fetchTransactionsPageThunk` did use old data of account to fetch transaction. The account data changed during async `getAccountInfo` call, but this change was overwritten by using the old data in `accountsActions.updateAccount`.

This PR uses fresh account data even after getAccountInfo fetch

## Related Issue

Resolve #13196

## Screenshots:

https://github.com/trezor/trezor-suite/assets/2011829/76ee012e-eaf3-4cc0-a0c4-5b91375ad7c2

