### PR TITLE
Feat/autheticate multiple devices

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AuthenticateDeviceModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AuthenticateDeviceModal.tsx
@@ -7,13 +7,13 @@ import { onCancel, openModal } from 'src/actions/suite/modalActions';
 import { DeviceAuthenticationExplainer, Modal, Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
-import { selectDeviceAuthenticity } from '@suite-common/wallet-core';
+import { selectSelectedDeviceAuthenticity } from '@suite-common/wallet-core';
 
 export const AuthenticateDeviceModal = () => {
     const [isLoading, setIsLoading] = useState(false);
     const dispatch = useDispatch();
     const isDebugModeActive = useSelector(selectIsDebugModeActive);
-    const deviceAuthenticity = useSelector(selectDeviceAuthenticity);
+    const selectedDeviceAuthenticity = useSelector(selectSelectedDeviceAuthenticity);
 
     const handleClick = async () => {
         setIsLoading(true);
@@ -22,7 +22,7 @@ export const AuthenticateDeviceModal = () => {
 
         setIsLoading(false);
 
-        if (deviceAuthenticity?.valid === false) {
+        if (selectedDeviceAuthenticity?.valid === false) {
             dispatch(openModal({ type: 'authenticate-device-fail' }));
         }
     };

--- a/packages/suite/src/views/onboarding/index.tsx
+++ b/packages/suite/src/views/onboarding/index.tsx
@@ -18,7 +18,7 @@ import * as STEP from 'src/constants/onboarding/steps';
 import { DeviceTutorial } from './steps/DeviceTutorial';
 
 export const Onboarding = () => {
-    const { activeStepId } = useOnboarding();
+    const { activeStepId, goToNextStep } = useOnboarding();
 
     const StepComponent = useMemo(() => {
         switch (activeStepId) {
@@ -27,7 +27,7 @@ export const Onboarding = () => {
                 return FirmwareStep;
             case STEP.ID_AUTHENTICATE_DEVICE_STEP:
                 // Device authenticity check
-                return DeviceAuthenticity;
+                return () => <DeviceAuthenticity goToNext={() => goToNextStep()} />;
             case STEP.ID_TUTORIAL_STEP:
                 // Device tutorial
                 return DeviceTutorial;
@@ -59,7 +59,7 @@ export const Onboarding = () => {
 
                 return () => null;
         }
-    }, [activeStepId]);
+    }, [activeStepId, goToNextStep]);
 
     const allowedModal = useFilteredModal(
         [MODAL.CONTEXT_USER],

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/DeviceAuthenticity.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/DeviceAuthenticity.tsx
@@ -8,7 +8,7 @@ import { variables } from '@trezor/components';
 import { OnboardingButtonCta, OnboardingStepBox } from 'src/components/onboarding';
 import { CollapsibleOnboardingCard } from 'src/components/onboarding/CollapsibleOnboardingCard';
 import { DeviceAuthenticationExplainer, Translation } from 'src/components/suite';
-import { useDispatch, useOnboarding, useSelector } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
 import { SecurityCheckFail } from './SecurityCheckFail';
 
@@ -22,11 +22,14 @@ const StyledExplainer = styled(DeviceAuthenticationExplainer)`
     }
 `;
 
-export const DeviceAuthenticity = () => {
+type DeviceAuthenticityProps = {
+    goToNext: () => void;
+};
+
+export const DeviceAuthenticity = ({ goToNext }: DeviceAuthenticityProps) => {
     const device = useSelector(selectDevice);
     const deviceAuthenticity = useSelector(selectDeviceAuthenticity);
     const isDebugModeActive = useSelector(selectIsDebugModeActive);
-    const { goToNextStep, goToSuite, isActive: isOnboarding } = useOnboarding();
     const dispatch = useDispatch();
     const [isLoading, setIsLoading] = useState(false);
     const [isSubmitted, setIsSubmitted] = useState(false);
@@ -75,8 +78,14 @@ export const DeviceAuthenticity = () => {
             setIsLoading(false);
             setIsSubmitted(true);
         };
-        const goToNext = () => (isOnboarding ? goToNextStep() : goToSuite());
-        const handleClick = isCheckSuccessful ? goToNext : authenticateDevice;
+
+        const handleClick = () => {
+            if (isCheckSuccessful) {
+                goToNext();
+            } else {
+                authenticateDevice();
+            }
+        };
 
         const buttonText = isCheckSuccessful ? 'TR_CONTINUE' : 'TR_START_CHECK';
 

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/DeviceAuthenticity.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/DeviceAuthenticity.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import styled from 'styled-components';
 
 import { checkDeviceAuthenticityThunk } from '@suite-common/device-authenticity';
-import { selectDevice, selectDeviceAuthenticity } from '@suite-common/wallet-core';
+import { selectDevice, selectSelectedDeviceAuthenticity } from '@suite-common/wallet-core';
 import { variables } from '@trezor/components';
 
 import { OnboardingButtonCta, OnboardingStepBox } from 'src/components/onboarding';
@@ -28,7 +28,7 @@ type DeviceAuthenticityProps = {
 
 export const DeviceAuthenticity = ({ goToNext }: DeviceAuthenticityProps) => {
     const device = useSelector(selectDevice);
-    const deviceAuthenticity = useSelector(selectDeviceAuthenticity);
+    const selectedDeviceAuthenticity = useSelector(selectSelectedDeviceAuthenticity);
     const isDebugModeActive = useSelector(selectIsDebugModeActive);
     const dispatch = useDispatch();
     const [isLoading, setIsLoading] = useState(false);
@@ -39,8 +39,8 @@ export const DeviceAuthenticity = ({ goToNext }: DeviceAuthenticityProps) => {
     const isWaitingForConfirmation = device.buttonRequests.some(
         request => request.code === 'ButtonRequest_Other',
     );
-    const isCheckFailed = isSubmitted && deviceAuthenticity?.valid === false;
-    const isCheckSuccessful = isSubmitted && deviceAuthenticity?.valid;
+    const isCheckFailed = isSubmitted && selectedDeviceAuthenticity?.valid === false;
+    const isCheckSuccessful = isSubmitted && selectedDeviceAuthenticity?.valid;
 
     const getHeadingText = () => {
         if (isCheckSuccessful) {

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheck.tsx
@@ -2,7 +2,12 @@ import { useEffect, useState } from 'react';
 import styled, { useTheme } from 'styled-components';
 
 import { getConnectedDeviceStatus } from '@suite-common/suite-utils';
-import { deviceActions, selectDevice, selectDevices } from '@suite-common/wallet-core';
+import {
+    deviceActions,
+    selectDevice,
+    selectDeviceAuthenticity,
+    selectDevices,
+} from '@suite-common/wallet-core';
 import { Icon, Tooltip, variables, H2, useElevation } from '@trezor/components';
 import { DeviceModelInternal } from '@trezor/connect';
 import { TREZOR_RESELLERS_URL, TREZOR_URL } from '@trezor/urls';
@@ -300,7 +305,7 @@ const SecurityCheckContent = ({
 export const SecurityCheck = () => {
     const device = useSelector(selectDevice);
     const devices = useSelector(selectDevices);
-    const allDevicesAutheticity = useSelector(state => state.device.deviceAuthenticity);
+    const deviceAuthenticity = useSelector(selectDeviceAuthenticity);
     const dispatch = useDispatch();
     const [isAuthenticityCheckStep, setIsAuthenticityCheckStep] = useState(false);
     const { goToSuite } = useOnboarding();
@@ -316,7 +321,7 @@ export const SecurityCheck = () => {
                 device.features?.internal_model &&
                 isAuthenticationSupportedMap[device.features.internal_model] &&
                 device.id &&
-                !allDevicesAutheticity?.[device.id],
+                !deviceAuthenticity?.[device.id],
         );
 
         if (nextDeviceToAuthenticate !== undefined) {

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -758,10 +758,13 @@ export const selectDeviceSupportedNetworks = (state: DeviceRootState) => {
 export const selectDeviceById = (state: DeviceRootState, deviceId: TrezorDevice['id']) =>
     state.device.devices.find(device => device.id === deviceId);
 
-export const selectDeviceAuthenticity = (state: DeviceRootState) => {
-    const device = selectDevice(state);
+export const selectDeviceAuthenticity = (state: DeviceRootState) => state.device.deviceAuthenticity;
 
-    return device?.id ? state.device.deviceAuthenticity?.[device.id] : undefined;
+export const selectSelectedDeviceAuthenticity = (state: DeviceRootState) => {
+    const device = selectDevice(state);
+    const deviceAuthenticity = selectDeviceAuthenticity(state);
+
+    return device?.id ? deviceAuthenticity?.[device.id] : undefined;
 };
 
 export const selectIsPortfolioTrackerDevice = (state: DeviceRootState) => {

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -525,6 +525,7 @@ export const setDeviceAuthenticity = (
 ) => {
     if (!device.id) return;
     draft.deviceAuthenticity = {
+        ...draft.deviceAuthenticity,
         [device.id]: result,
     };
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Security check now supports multiple devices at the same time. Previously, only the first selected device was checked, which could have led to skipped device authenticity checks.

Scenarios:

1) Two devices with SE connected in fresh Suite:

https://github.com/trezor/trezor-suite/assets/42465546/3e4aa1e2-cc6f-4414-bd3d-e2934a8dda2a

2) Two devices connected, the first one selected doesn't have SE:

https://github.com/trezor/trezor-suite/assets/42465546/547b1200-0c8b-41ca-81c3-54c34351d590

3) Multiple devices selected, one other than the first one selected doesn't have SE - security check for that one is skipped. I don't think it is a big deal because it is super edge case and there would be no authenticity check anyway.

