### PR TITLE
chore(suite): Coin control search copy tweak

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -6282,8 +6282,7 @@ export default defineMessages({
     },
     TR_SEARCH_UTXOS: {
         id: 'TR_SEARCH_UTXOS',
-        defaultMessage: 'Address, transaction ID, or label',
-        description: 'Placeholder text in Coin control search input',
+        defaultMessage: 'Search for a specific address, transaction ID or label',
     },
     TR_CONNECTED_TO_PROVIDER: {
         defaultMessage: 'Connected to {provider} as {user}',


### PR DESCRIPTION
DO NOT MERGE YET

Getting rid of the placeholder copy string in the Coin control search function

Resolves https://github.com/trezor/trezor-suite/pull/12543#discussion_r1660987163