### PR TITLE
transport: propagate hid devices descriptors

### DIFF
--- a/packages/transport/src/utils/bridgeApiCall.ts
+++ b/packages/transport/src/utils/bridgeApiCall.ts
@@ -98,15 +98,7 @@ export async function bridgeApiCall(options: HttpRequestOptions) {
             return error({ error: PROTOCOL_MALFORMED });
         }
 
-        return unknownError(new Error(errStr), [
-            ERRORS.DEVICE_NOT_FOUND,
-            ERRORS.HTTP_ERROR,
-            ERRORS.DEVICE_DISCONNECTED_DURING_ACTION,
-            ERRORS.OTHER_CALL_IN_PROGRESS,
-            ERRORS.SESSION_NOT_FOUND,
-            ERRORS.SESSION_WRONG_PREVIOUS,
-            // todo: list more errors from trezor-d. all can occur on this level!
-        ]);
+        return unknownError(new Error(errStr), Object.values(ERRORS));
     }
 
     return success(resParsed);


### PR DESCRIPTION
With the old bridge going out of service, we are no longer able to work with very old Trezor HID devices. We are only able to detect them but no communication is possible. 

To test this, you need an ancient device.
```
Features (126 bytes) {
    bootloader_hash: 32 bytes 0xc4c32539b4a025a8e753a4c46264285911a45fcb14f4718179e711b1ce990524,
    device_id: 'F7F53817FDC08323ECA22200',
    imported: False,
    initialized: True,
    label: 'My Trezor',
    major_version: 1,
    minor_version: 2,
    passphrase_protection: False,
    patch_version: 0,
    pin_protection: False,
    revision: 20 bytes 0xdf524b9f35fd5cdba14eaa2bf2d948e3dc75254a,
    vendor: 'bitcointrezor.com',
}
```

This PR unifies how these devices are communicated for both bridge and webusb transports. 

- c8712c05da7afaecb9bb5c730957dc546d29affa - transport now propagates descriptors even for hid devices to higher layers. connect then tries to work with these descriptors resulting into 'Unable to open device' error. which already results in creation of an 'Unreadable device'. 
- 719aa3962995396089e1a7085375a078846fe1ff - a couple of fixes were needed to make it behave the same way for node-bridge

While testing this for possible regressions I noticed a[ nasty bug](https://github.com/trezor/trezor-suite/issues/12163#issuecomment-2212429718) that we might need to address before releasing node-bridge publically

Screenshots of how it looks like in trezor suite now. cc @martykan since he is now addressing this #12487, cc @Hannsek since we might need some designs/copy. Those bullet points are not very accurate. 
<img width="622" alt="image" src="https://github.com/trezor/trezor-suite/assets/30367552/c23ad436-bfdf-4106-9a83-2947313ea0f9">

<img width="649" alt="image" src="https://github.com/trezor/trezor-suite/assets/30367552/1f9254e5-b80d-4bb3-b98d-6009ecd1901a">

