### PR TITLE
feat(suite): node bridge rollout only in EAP

### DIFF
--- a/packages/suite-desktop-core/src/modules/bridge.ts
+++ b/packages/suite-desktop-core/src/modules/bridge.ts
@@ -52,6 +52,8 @@ const start = async (bridge: BridgeProcess | TrezordNode) => {
 
 const getBridgeInstance = (store: Dependencies['store']) => {
     const legacyRequestedBySettings = store.getBridgeSettings().legacy;
+    const { allowPrerelease } = store.getUpdateSettings();
+
     const legacyRequestedByArg = bridgeLegacy || bridgeLegacyDev || bridgeLegacyTest;
 
     // handle rollout
@@ -65,7 +67,12 @@ const getBridgeInstance = (store: Dependencies['store']) => {
     const legacyBridgeReasonRollout =
         !isDevEnv && !skipNewBridgeRollout && newBridgeRollout >= NEW_BRIDGE_ROLLOUT_THRESHOLD;
 
-    if (legacyRequestedBySettings || legacyRequestedByArg || legacyBridgeReasonRollout) {
+    if (
+        legacyRequestedBySettings ||
+        legacyRequestedByArg ||
+        legacyBridgeReasonRollout ||
+        !allowPrerelease
+    ) {
         return new BridgeProcess();
     }
 

--- a/packages/suite/src/views/settings/SettingsDebug/TransportBackends.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/TransportBackends.tsx
@@ -110,7 +110,7 @@ export const TransportBackends = () => {
                 <SectionItem data-test="@settings/debug/processes/newBridgeRollout">
                     <TextColumn
                         title="New bridge rollout"
-                        description={`New bridge is being rolled out to only ${NEW_BRIDGE_ROLLOUT_THRESHOLD * 100}% of Trezor Suite instances. Your rollout score is ${((bridgeSettings.newBridgeRollout ?? 0) * 100).toFixed()}%`}
+                        description={`New bridge is being rolled out to only ${NEW_BRIDGE_ROLLOUT_THRESHOLD * 100}% of Trezor Suite instances that have applied for the Early access program. Your rollout score is ${((bridgeSettings.newBridgeRollout ?? 0) * 100).toFixed()}%`}
                     />
                 </SectionItem>
             )}


### PR DESCRIPTION
let's only allow node-bridge rollout for users who have EAP enabled. I am particularly concerned about #12163 and in general that we haven't yet tested it on a substantial number of machines.

### Screenshots

<img width="1309" alt="image" src="https://github.com/trezor/trezor-suite/assets/30367552/8db81b05-dc6d-40b2-8c50-719d503008af">

even when your rollout score is below the threshold you get the old bridge because EAP is not active (screenshot is not the best I could get but there are few red pixels visible in the bottom left corner meaning that there are no violet pixels)
<img width="1408" alt="image" src="https://github.com/trezor/trezor-suite/assets/30367552/e55f704b-0712-44db-8c16-03a3bb8cd916">


as it is now, `--skip-new-bridge-rollout` does not apply when EAP is off. not sure what should be stronger