### PR TITLE
connect: initialize should be able to timeout

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -266,6 +266,9 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
         this._runInner(fn, options).catch(err => {
             runPromise.reject(err);
+            // get rid of call promise, otherwise it stays hanging on
+            // https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/device/Device.ts#L227
+            delete this.commands?.callPromise;
         });
 
         return runPromise.promise;
@@ -336,7 +339,15 @@ export class Device extends TypedEmitter<DeviceEvents> {
             // update features
             try {
                 if (fn) {
-                    await this.initialize(!!options.useCardanoDerivation);
+                    await Promise.race([
+                        this.initialize(!!options.useCardanoDerivation),
+                        new Promise((_resolve, reject) =>
+                            setTimeout(
+                                () => reject(new Error(TRANSPORT_ERROR.ABORTED_BY_TIMEOUT)),
+                                GET_FEATURES_TIMEOUT,
+                            ),
+                        ),
+                    ]);
                 } else {
                     // do not initialize while firstRunPromise otherwise `features.session_id` could be affected
                     await Promise.race([

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -200,6 +200,27 @@ const changeDevice = (
     device: Device | TrezorDevice,
     extended?: Partial<AcquiredDevice>,
 ) => {
+    // device was initially connected as unacquired. attempt to 'use device here' resulted in unreadable device
+    if (device.type === 'unreadable' && draft.selectedDevice) {
+        const additionalFields = {
+            connected: true,
+            available: false,
+            useEmptyPassphrase: true,
+            buttonRequests: [],
+            metadata: {},
+            passwords: {},
+            ts: new Date().getTime(),
+        };
+        draft.selectedDevice = {
+            ...device,
+            ...additionalFields,
+        };
+        const index = draft.devices.findIndex(d => d.path === device.path);
+        if (index > -1) {
+            draft.devices[index] = draft.selectedDevice;
+        }
+    }
+
     // change only acquired devices
     if (!device.features) return;
 


### PR DESCRIPTION
This is a heavy draft, to be discussed with @marekrjpolak first and szymonlesisz later

- it is possible to get the device into a state where it can't be worked with. It is enumerated but any attempts to open it or to write it will remain hanging forever.  see video:

https://github.com/trezor/trezor-suite/assets/30367552/3865a13a-7b93-4d56-9a0c-488ef01103c2

I am able to reproduce this behavior through "uncooperative acquire". 1 instance of suite is doing discovery, another instance steals session. We should I am at fixing the root of the problem as well of course but on the other hand - some of the calls to the device should be timeout-able. This is something I would like to discuss with @marekrjpolak what is the right place to do this.

In the meantime I would probably add this little bandaid to fix a case where Suite stays hanged without any clear communication about what is happening. 

There are possibly controversial commits: 
- 50191b42d1ea3e714d03e72b60b3ebc646a0c07d - suite reducers did not accept change from unacquired to unreadable. 
- 717a857449b7ff68d14910930b8d15ee3762c2bf - the band aid
- e3446af9bd6a8c30b69f1c6dab2207da2e428e30 - promises clearing to be discussed. 


After all the changes it looks like this: 

https://github.com/trezor/trezor-suite/assets/30367552/fc392edb-91e7-444f-b821-0415ea22520a

### related

- #13220 handling of unreadable devices when they are connected
