### PR TITLE
fix(suite): Align PromoBanner to left to prevent overlaying Guide icon

### DIFF
--- a/packages/suite/src/views/dashboard/components/PromoBanner.tsx
+++ b/packages/suite/src/views/dashboard/components/PromoBanner.tsx
@@ -8,6 +8,7 @@ import { isWeb } from '@trezor/env-utils';
 import { useLayoutSize } from 'src/hooks/suite/useLayoutSize';
 import { HORIZONTAL_LAYOUT_PADDINGS } from 'src/constants/suite/layout';
 import { useSelector } from 'src/hooks/suite';
+import { spacingsPx } from '@trezor/theme';
 
 const Container = styled.div`
     position: absolute;
@@ -48,7 +49,9 @@ const DesktopPromoContainer = styled.div`
 
 const MobilePromoContainer = styled.div`
     ${promoContainerCss}
-    justify-content: flex-end;
+    justify-content: start;
+    margin: ${spacingsPx.sm} ${spacingsPx.xxxl} auto auto;
+    padding-bottom: ${spacingsPx.sm};
 
     ${variables.SCREEN_QUERY.MOBILE} {
         flex-direction: column;


### PR DESCRIPTION
## Description

Prevent overlaying Guide icon by PromoBanner, adjust its bottom padding and margin css values to display it nicely in the footer.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/11270

## Screenshots:
**Before:**
![icon_before](https://github.com/trezor/trezor-suite/assets/13417815/71d0a4c3-5d81-456c-b744-cb5bc4f4810f)

**After:**
Bigger zoom level:
![icon_after1](https://github.com/trezor/trezor-suite/assets/13417815/16847657-1734-4896-9158-4c3de2a2a571)
![icon_after2](https://github.com/trezor/trezor-suite/assets/13417815/1864f499-b38c-4621-b8e0-cc5248c0804f)

