### PR TITLE
feat(protobuf): update protobuf messages for newest version

### DIFF
--- a/packages/protobuf/messages.json
+++ b/packages/protobuf/messages.json
@@ -673,12 +673,10 @@
                             "id": 3
                         },
                         "mask_public_key": {
-                            "rule": "required",
                             "type": "bytes",
                             "id": 4
                         },
                         "signature": {
-                            "rule": "required",
                             "type": "bytes",
                             "id": 5
                         }
@@ -2873,75 +2871,6 @@
                 }
             }
         },
-        "CosiCommit": {
-            "fields": {
-                "address_n": {
-                    "rule": "repeated",
-                    "type": "uint32",
-                    "id": 1,
-                    "options": {
-                        "packed": false
-                    }
-                },
-                "data": {
-                    "type": "bytes",
-                    "id": 2,
-                    "options": {
-                        "deprecated": true
-                    }
-                }
-            }
-        },
-        "CosiCommitment": {
-            "fields": {
-                "commitment": {
-                    "rule": "required",
-                    "type": "bytes",
-                    "id": 1
-                },
-                "pubkey": {
-                    "rule": "required",
-                    "type": "bytes",
-                    "id": 2
-                }
-            }
-        },
-        "CosiSign": {
-            "fields": {
-                "address_n": {
-                    "rule": "repeated",
-                    "type": "uint32",
-                    "id": 1,
-                    "options": {
-                        "packed": false
-                    }
-                },
-                "data": {
-                    "rule": "required",
-                    "type": "bytes",
-                    "id": 2
-                },
-                "global_commitment": {
-                    "rule": "required",
-                    "type": "bytes",
-                    "id": 3
-                },
-                "global_pubkey": {
-                    "rule": "required",
-                    "type": "bytes",
-                    "id": 4
-                }
-            }
-        },
-        "CosiSignature": {
-            "fields": {
-                "signature": {
-                    "rule": "required",
-                    "type": "bytes",
-                    "id": 1
-                }
-            }
-        },
         "DebugLinkDecision": {
             "fields": {
                 "button": {
@@ -4592,6 +4521,10 @@
                 "recovery_type": {
                     "type": "RecoveryType",
                     "id": 53
+                },
+                "optiga_sec": {
+                    "type": "uint32",
+                    "id": 54
                 }
             },
             "nested": {
@@ -8259,22 +8192,6 @@
                     "(bitcoin_only)": true,
                     "(wire_out)": true
                 },
-                "MessageType_CosiCommit": {
-                    "(bitcoin_only)": true,
-                    "(wire_in)": true
-                },
-                "MessageType_CosiCommitment": {
-                    "(bitcoin_only)": true,
-                    "(wire_out)": true
-                },
-                "MessageType_CosiSign": {
-                    "(bitcoin_only)": true,
-                    "(wire_in)": true
-                },
-                "MessageType_CosiSignature": {
-                    "(bitcoin_only)": true,
-                    "(wire_out)": true
-                },
                 "MessageType_DebugLinkDecision": {
                     "(bitcoin_only)": true,
                     "(wire_debug_in)": true,
@@ -8853,10 +8770,6 @@
                 "MessageType_SignedIdentity": 54,
                 "MessageType_GetECDHSessionKey": 61,
                 "MessageType_ECDHSessionKey": 62,
-                "MessageType_CosiCommit": 71,
-                "MessageType_CosiCommitment": 72,
-                "MessageType_CosiSign": 73,
-                "MessageType_CosiSignature": 74,
                 "MessageType_DebugLinkDecision": 100,
                 "MessageType_DebugLinkGetState": 101,
                 "MessageType_DebugLinkState": 102,

--- a/packages/protobuf/src/messages-schema.ts
+++ b/packages/protobuf/src/messages-schema.ts
@@ -343,8 +343,8 @@ export const CoinJoinRequest = Type.Object(
         fee_rate: Type.Number(),
         no_fee_threshold: Type.Number(),
         min_registrable_amount: Type.Number(),
-        mask_public_key: Type.String(),
-        signature: Type.String(),
+        mask_public_key: Type.Optional(Type.String()),
+        signature: Type.Optional(Type.String()),
     },
     { $id: 'CoinJoinRequest' },
 );
@@ -2346,6 +2346,7 @@ export const Features = Type.Object(
         unit_packaging: Type.Optional(Type.Number()),
         haptic_feedback: Type.Optional(Type.Boolean()),
         recovery_type: Type.Optional(RecoveryType),
+        optiga_sec: Type.Optional(Type.Number()),
     },
     { $id: 'Features' },
 );

--- a/packages/protobuf/src/messages.ts
+++ b/packages/protobuf/src/messages.ts
@@ -249,8 +249,8 @@ export type CoinJoinRequest = {
     fee_rate: number;
     no_fee_threshold: number;
     min_registrable_amount: number;
-    mask_public_key: string;
-    signature: string;
+    mask_public_key?: string;
+    signature?: string;
 };
 
 // SignTx
@@ -1675,6 +1675,7 @@ export type Features = {
     unit_packaging?: number;
     haptic_feedback?: boolean;
     recovery_type?: RecoveryType;
+    optiga_sec?: number;
 };
 
 // LockDevice

--- a/packages/suite-analytics/src/types/events.ts
+++ b/packages/suite-analytics/src/types/events.ts
@@ -68,6 +68,7 @@ export type SuiteAnalyticsEvent =
               model?: string;
               firmwareRevision?: string;
               bootloaderHash?: string;
+              optiga_sec?: number;
           };
       }
     | {

--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -96,6 +96,7 @@ const analyticsMiddleware =
                             totalDevices: getPhysicalDeviceCount(selectDevices(state)),
                             language: features.language,
                             model: features.internal_model,
+                            optiga_sec: features.optiga_sec,
                         },
                     });
                 } else {


### PR DESCRIPTION
Adds a field to analytics for `optiga_sec` field. So we have reports when this counter starts to increase.

Resolves: https://github.com/trezor/trezor-suite/issues/13065


![image](https://github.com/trezor/trezor-suite/assets/152899911/89851e72-5463-4237-b14d-537f155b5fbd)
