### PR TITLE
fix(suite): remove the disabling of the sandbox in Electron

### DIFF
--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -37,9 +37,6 @@ const createMainWindow = (winBounds: WinBounds) => {
             webSecurity: !isDevEnv,
             allowRunningInsecureContent: isDevEnv,
             preload: path.join(__dirname, 'preload.js'),
-            // https://www.electronjs.org/blog/electron-20-0#default-changed-renderers-without-nodeintegration-true-are-sandboxed-by-default
-            // Node.js required for sentry-ipc, suite-desktop-api
-            sandbox: false,
         },
         icon: path.join(global.resourcesPath, 'images', 'icons', '512x512.png'),
     });


### PR DESCRIPTION
This PR enables Sandbox for the Browser process. We have done a testing for Tor & Sentry and it seems it works.

So we have not found a reason why to keep it disabled.