### PR TITLE
fix(suite): Make Eject icon bigger when asking to "Eject this wallet"

### DIFF
--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/EjectConfirmation.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/EjectConfirmation.tsx
@@ -6,7 +6,7 @@ import { deviceActions } from '@suite-common/wallet-core';
 import { analytics, EventType } from '@trezor/suite-analytics';
 import { AcquiredDevice } from '@suite-common/suite-types';
 import { MouseEventHandler, ReactNode } from 'react';
-import { spacingsPx } from '@trezor/theme';
+import { spacings, spacingsPx } from '@trezor/theme';
 import { selectSuiteSettings } from '../../../../reducers/suite/suiteReducer';
 
 const Container = styled.div`
@@ -65,6 +65,7 @@ const EjectConfirmationContainer = ({
                 <Button
                     size="small"
                     icon="EJECT"
+                    iconSize={spacings.lg}
                     onClick={handleEject}
                     variant="primary"
                     isFullWidth


### PR DESCRIPTION
## Description

Explicitly set `iconSize` prop for `Button` icon to display _EJECT_ icon properly, when asking to "Eject this wallet?".

Usually, for "small" size the icon size is set default to 16px, but for this icon we need it slightly bigger - 20px do be displayed nicely. 

## Related Issue

## Screenshots:
**Before:**
The eject icon looks cut off:
![eject_before](https://github.com/trezor/trezor-suite/assets/13417815/c9105a6d-28d7-4b8a-909a-33d47f9c7e17)
**After:**

The eject icon displayed whole, as expected:
![eject_after](https://github.com/trezor/trezor-suite/assets/13417815/8feac064-4e74-4c5c-ab9f-e888d0fce7f3)
