### PR TITLE
chore(suite): accept device update when changed from 'unacquired' to …

### DIFF
--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -206,6 +206,27 @@ const changeDevice = (
     device: Device | TrezorDevice,
     extended?: Partial<AcquiredDevice>,
 ) => {
+    // device was initially connected as unacquired. attempt to 'use device here' resulted in unreadable device
+    if (device.type === 'unreadable' && draft.selectedDevice) {
+        const additionalFields = {
+            connected: true,
+            available: false,
+            useEmptyPassphrase: true,
+            buttonRequests: [],
+            metadata: {},
+            passwords: {},
+            ts: new Date().getTime(),
+        };
+        draft.selectedDevice = {
+            ...device,
+            ...additionalFields,
+        };
+        const index = draft.devices.findIndex(d => d.path === device.path);
+        if (index > -1) {
+            draft.devices[index] = draft.selectedDevice;
+        }
+    }
+
     // change only acquired devices
     if (!device.features) return;
 


### PR DESCRIPTION
cherry-picking from #13227

you might get into a situation where device **becomes** unreadable and it can't be communicated with. it simply hangs somewhere in `device.transferOut` call. but since it wasn't unreadable some time ago, it might have been acquired by somebody and never released. 
This takes you to the screen where you have the "Use device here" button. Clicking the button triggers a connect call, which will fail (something I need yet to solve in #13277) and the device should be changed from unacquired to unreadable. 

this was not possible till now as suite would not accept changes of device that do not have features. 

discussed briefly with @szymonlesisz, he is ok with this change. May I assign someone, lets say @komret ? 