### PR TITLE
Fix/native/passphrase flow errors

### DIFF
--- a/suite-native/module-authorize-device/src/components/passphrase/PassphraseScreenHeader.tsx
+++ b/suite-native/module-authorize-device/src/components/passphrase/PassphraseScreenHeader.tsx
@@ -5,15 +5,6 @@ import { BackHandler } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 
 import { IconButton, ScreenHeaderWrapper } from '@suite-native/atoms';
-import {
-    AppTabsRoutes,
-    AuthorizeDeviceStackParamList,
-    AuthorizeDeviceStackRoutes,
-    HomeStackRoutes,
-    RootStackParamList,
-    RootStackRoutes,
-    StackToTabCompositeProps,
-} from '@suite-native/navigation';
 import { Translation } from '@suite-native/intl';
 import TrezorConnect from '@trezor/connect';
 import {
@@ -21,6 +12,15 @@ import {
     selectIsCreatingNewPassphraseWallet,
     useAuthorizationGoBack,
 } from '@suite-native/device-authorization';
+import {
+    RootStackRoutes,
+    AppTabsRoutes,
+    HomeStackRoutes,
+    AuthorizeDeviceStackParamList,
+    AuthorizeDeviceStackRoutes,
+    RootStackParamList,
+    StackToTabCompositeProps,
+} from '@suite-native/navigation';
 import { useAlert } from '@suite-native/alerts';
 
 type NavigationProp = StackToTabCompositeProps<

--- a/suite-native/module-authorize-device/src/screens/passphrase/PassphraseConfirmOnTrezorScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/passphrase/PassphraseConfirmOnTrezorScreen.tsx
@@ -17,10 +17,18 @@ import {
     selectIsDeviceConnectedAndAuthorized,
     selectIsDeviceDiscoveryActive,
 } from '@suite-common/wallet-core';
+import {
+    cancelPassphraseAndSelectStandardDeviceThunk,
+    selectHasAuthFailed,
+    selectHasVerificationCancelledError,
+    retryPassphraseAuthenticationThunk,
+    selectHasPassphraseMismatchError,
+} from '@suite-native/device-authorization';
+import { useAlert } from '@suite-native/alerts';
 
 import { DeviceT3T1Svg } from '../../assets/passphrase/DeviceT3T1Svg';
 import { PassphraseScreenWrapper } from '../../components/passphrase/PassphraseScreenWrapper';
-import { useAuthorizationSuccess } from '../../usePassphraseAuthorizationSuccess';
+import { useRedirectOnPassphraseCompletion } from '../../useRedirectOnPassphraseCompletion';
 
 type NavigationProp = StackToStackCompositeNavigationProps<
     AuthorizeDeviceStackParamList,
@@ -36,10 +44,15 @@ export const PassphraseConfirmOnTrezorScreen = () => {
     const isDeviceConnectedAndAuthorized = useSelector(selectIsDeviceConnectedAndAuthorized);
     const isDiscoveryActive = useSelector(selectIsDeviceDiscoveryActive);
     const device = useSelector(selectDevice);
+    const hasAuthorizationFailed = useSelector(selectHasAuthFailed);
+    const hasVerificationCancelledError = useSelector(selectHasVerificationCancelledError);
+    const hasPassphraseMismatchError = useSelector(selectHasPassphraseMismatchError);
+
+    const { showAlert } = useAlert();
 
     // If this screen was present during authorizing device with passphrase for some feature,
     // on success, this hook will close the stack and go back
-    useAuthorizationSuccess();
+    useRedirectOnPassphraseCompletion();
 
     useEffect(() => {
         if (isDeviceConnectedAndAuthorized && isDiscoveryActive) {
@@ -52,6 +65,44 @@ export const PassphraseConfirmOnTrezorScreen = () => {
             );
         }
     }, [device, dispatch, isDeviceConnectedAndAuthorized, isDiscoveryActive, navigation]);
+
+    useEffect(() => {
+        // User has canceled the authorization process on device (authorizeDeviceThunk rejects with auth-failed error)
+        if (hasAuthorizationFailed || hasVerificationCancelledError) {
+            dispatch(cancelPassphraseAndSelectStandardDeviceThunk());
+        }
+    }, [dispatch, hasAuthorizationFailed, hasVerificationCancelledError]);
+
+    useEffect(() => {
+        // Wrong passphrase was entered during verifying empty wallet
+        if (hasPassphraseMismatchError) {
+            showAlert({
+                title: (
+                    <Translation id="modulePassphrase.emptyPassphraseWallet.verifyEmptyWallet.passphraseMismatchAlert.title" />
+                ),
+                description: (
+                    <Translation id="modulePassphrase.emptyPassphraseWallet.verifyEmptyWallet.passphraseMismatchAlert.description" />
+                ),
+                primaryButtonTitle: (
+                    <Translation id="modulePassphrase.emptyPassphraseWallet.verifyEmptyWallet.passphraseMismatchAlert.primaryButton" />
+                ),
+                onPressPrimaryButton: () => {
+                    navigation.navigate(AuthorizeDeviceStackRoutes.PassphraseForm);
+                    dispatch(retryPassphraseAuthenticationThunk());
+                },
+                primaryButtonVariant: 'redBold',
+                secondaryButtonTitle: (
+                    <Translation id="modulePassphrase.emptyPassphraseWallet.verifyEmptyWallet.passphraseMismatchAlert.secondaryButton" />
+                ),
+                onPressSecondaryButton: () => {
+                    dispatch(cancelPassphraseAndSelectStandardDeviceThunk());
+                },
+                secondaryButtonVariant: 'redElevation0',
+                icon: 'warningTriangleLight',
+                pictogramVariant: 'red',
+            });
+        }
+    }, [dispatch, hasPassphraseMismatchError, navigation, showAlert]);
 
     return (
         <PassphraseScreenWrapper>

--- a/suite-native/module-authorize-device/src/screens/passphrase/PassphraseEnterOnTrezorScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/passphrase/PassphraseEnterOnTrezorScreen.tsx
@@ -4,12 +4,9 @@ import { useEffect } from 'react';
 import { useNavigation } from '@react-navigation/native';
 
 import {
-    AppTabsRoutes,
     AuthorizeDeviceStackParamList,
     AuthorizeDeviceStackRoutes,
-    HomeStackRoutes,
     RootStackParamList,
-    RootStackRoutes,
     StackToStackCompositeNavigationProps,
 } from '@suite-native/navigation';
 import { Box, Button, Card, CenteredTitleHeader, Text, VStack } from '@suite-native/atoms';
@@ -23,7 +20,7 @@ import {
 } from '@suite-native/device-authorization';
 import TrezorConnect from '@trezor/connect';
 
-import { useAuthorizationSuccess } from '../../usePassphraseAuthorizationSuccess';
+import { useRedirectOnPassphraseCompletion } from '../../useRedirectOnPassphraseCompletion';
 import { DeviceT3T1Svg } from '../../assets/passphrase/DeviceT3T1Svg';
 import { PassphraseContentScreenWrapper } from '../../components/passphrase/PassphraseContentScreenWrapper';
 
@@ -56,7 +53,7 @@ export const PassphraseEnterOnTrezorScreen = () => {
 
     // If this screen was present during authorizing device with passphrase for some feature,
     // on success, this hook will close the stack and go back
-    useAuthorizationSuccess();
+    useRedirectOnPassphraseCompletion();
 
     useEffect(() => {
         if (isDiscoveryActive) {
@@ -67,12 +64,6 @@ export const PassphraseEnterOnTrezorScreen = () => {
     const handleCancel = () => {
         if (isCreatingNewWalletInstance) {
             dispatch(cancelPassphraseAndSelectStandardDeviceThunk());
-            navigation.navigate(RootStackRoutes.AppTabs, {
-                screen: AppTabsRoutes.HomeStack,
-                params: {
-                    screen: HomeStackRoutes.Home,
-                },
-            });
         } else {
             TrezorConnect.cancel();
             handleGoBack();

--- a/suite-native/module-authorize-device/src/screens/passphrase/PassphraseLoadingScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/passphrase/PassphraseLoadingScreen.tsx
@@ -5,10 +5,8 @@ import { useNavigation } from '@react-navigation/native';
 
 import { VStack, Text, Spinner, SpinnerLoadingState } from '@suite-native/atoms';
 import {
-    AppTabsRoutes,
     AuthorizeDeviceStackParamList,
     AuthorizeDeviceStackRoutes,
-    HomeStackRoutes,
     RootStackParamList,
     RootStackRoutes,
     StackToStackCompositeNavigationProps,
@@ -18,7 +16,7 @@ import {
     selectIsDeviceDiscoveryActive,
 } from '@suite-common/wallet-core';
 import { Translation } from '@suite-native/intl';
-import { setIsCreatingNewWalletInstance } from '@suite-native/device-authorization';
+import { finishPassphraseFlow } from '@suite-native/device-authorization';
 
 import { PassphraseScreenWrapper } from '../../components/passphrase/PassphraseScreenWrapper';
 
@@ -47,13 +45,7 @@ export const PassphraseLoadingScreen = () => {
     const handleSuccess = () => {
         if (!isDeviceAccountless) {
             setLoadingResult('success');
-            navigation.navigate(RootStackRoutes.AppTabs, {
-                screen: AppTabsRoutes.HomeStack,
-                params: {
-                    screen: HomeStackRoutes.Home,
-                },
-            });
-            dispatch(setIsCreatingNewWalletInstance(false));
+            dispatch(finishPassphraseFlow());
         } else if (isDeviceAccountless && !isDiscoveryActive) {
             setLoadingResult('success');
             navigation.navigate(RootStackRoutes.AuthorizeDeviceStack, {

--- a/suite-native/module-authorize-device/src/screens/passphrase/PassphraseVerifyEmptyWalletScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/passphrase/PassphraseVerifyEmptyWalletScreen.tsx
@@ -1,93 +1,32 @@
 import { useDispatch } from 'react-redux';
-import { useCallback, useEffect } from 'react';
+import { useEffect } from 'react';
 
-import { useNavigation } from '@react-navigation/native';
 import { isFulfilled } from '@reduxjs/toolkit';
 
-import { useAlert } from '@suite-native/alerts';
-import {
-    AppTabsRoutes,
-    AuthorizeDeviceStackParamList,
-    AuthorizeDeviceStackRoutes,
-    HomeStackRoutes,
-    RootStackParamList,
-    RootStackRoutes,
-    StackToTabCompositeProps,
-} from '@suite-native/navigation';
 import { AlertBox, Text, VStack } from '@suite-native/atoms';
 import { Translation, useTranslate } from '@suite-native/intl';
 import {
-    cancelPassphraseAndSelectStandardDeviceThunk,
-    retryPassphraseAuthenticationThunk,
+    finishPassphraseFlow,
     verifyPassphraseOnEmptyWalletThunk,
 } from '@suite-native/device-authorization';
 
 import { PassphraseForm } from '../../components/passphrase/PassphraseForm';
 import { PassphraseContentScreenWrapper } from '../../components/passphrase/PassphraseContentScreenWrapper';
 
-type NavigationProp = StackToTabCompositeProps<
-    AuthorizeDeviceStackParamList,
-    AuthorizeDeviceStackRoutes,
-    RootStackParamList
->;
-
 export const PassphraseVerifyEmptyWalletScreen = () => {
     const dispatch = useDispatch();
 
-    const navigation = useNavigation<NavigationProp>();
-
-    const { showAlert } = useAlert();
-
     const { translate } = useTranslate();
 
-    const handleVerify = useCallback(async () => {
-        const response = await dispatch(verifyPassphraseOnEmptyWalletThunk());
-
-        if (isFulfilled(response)) {
-            navigation.navigate(RootStackRoutes.AppTabs, {
-                screen: AppTabsRoutes.HomeStack,
-                params: {
-                    screen: HomeStackRoutes.Home,
-                },
-            });
-        } else {
-            showAlert({
-                title: (
-                    <Translation id="modulePassphrase.emptyPassphraseWallet.verifyEmptyWallet.passphraseMismatchAlert.title" />
-                ),
-                description: (
-                    <Translation id="modulePassphrase.emptyPassphraseWallet.verifyEmptyWallet.passphraseMismatchAlert.description" />
-                ),
-                primaryButtonTitle: (
-                    <Translation id="modulePassphrase.emptyPassphraseWallet.verifyEmptyWallet.passphraseMismatchAlert.primaryButton" />
-                ),
-                onPressPrimaryButton: () => {
-                    navigation.navigate(AuthorizeDeviceStackRoutes.PassphraseForm);
-                    dispatch(retryPassphraseAuthenticationThunk());
-                },
-                primaryButtonVariant: 'redBold',
-                secondaryButtonTitle: (
-                    <Translation id="modulePassphrase.emptyPassphraseWallet.verifyEmptyWallet.passphraseMismatchAlert.secondaryButton" />
-                ),
-                onPressSecondaryButton: () => {
-                    dispatch(cancelPassphraseAndSelectStandardDeviceThunk());
-                    navigation.navigate(RootStackRoutes.AppTabs, {
-                        screen: AppTabsRoutes.HomeStack,
-                        params: {
-                            screen: HomeStackRoutes.Home,
-                        },
-                    });
-                },
-                secondaryButtonVariant: 'redElevation0',
-                icon: 'warningTriangleLight',
-                pictogramVariant: 'red',
-            });
-        }
-    }, [dispatch, navigation, showAlert]);
-
     useEffect(() => {
-        handleVerify();
-    }, [handleVerify]);
+        const verifyEmptyWallet = async () => {
+            const result = await dispatch(verifyPassphraseOnEmptyWalletThunk());
+            if (isFulfilled(result)) {
+                dispatch(finishPassphraseFlow());
+            }
+        };
+        verifyEmptyWallet();
+    }, [dispatch]);
 
     return (
         <PassphraseContentScreenWrapper

--- a/suite-native/module-authorize-device/src/useRedirectOnPassphraseCompletion.ts
+++ b/suite-native/module-authorize-device/src/useRedirectOnPassphraseCompletion.ts
@@ -2,21 +2,21 @@ import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 
 import {
-    selectIsCreatingNewPassphraseWallet,
     selectDeviceRequestedAuthorization,
+    selectPassphraseError,
 } from '@suite-native/device-authorization';
 import { useAuthorizationGoBack } from '@suite-native/device-authorization';
 
-export const useAuthorizationSuccess = () => {
+export const useRedirectOnPassphraseCompletion = () => {
     const hasDeviceRequestedAuthorization = useSelector(selectDeviceRequestedAuthorization);
-    const isCreatingNewWalletInstance = useSelector(selectIsCreatingNewPassphraseWallet);
+    const hasPassphraseError = useSelector(selectPassphraseError);
 
     const { handleGoBack } = useAuthorizationGoBack();
 
-    // Success state of authorizing device to be used by feature (e.g. receive address, send, etc.)
     useEffect(() => {
-        if (!hasDeviceRequestedAuthorization && !isCreatingNewWalletInstance) {
+        // If there is passphrase error, we don't want to go back, but handle errors through alerts within the flow
+        if (!hasDeviceRequestedAuthorization && !hasPassphraseError) {
             handleGoBack();
         }
-    }, [handleGoBack, hasDeviceRequestedAuthorization, isCreatingNewWalletInstance]);
+    }, [handleGoBack, hasDeviceRequestedAuthorization, hasPassphraseError]);
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Refactor redux logic of passphrase flow so that the error state is reset and edge cases are handled on appropriate screens. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/13190

## Screenshots:
https://satoshilabs.slack.com/archives/C03H2Q5MX51/p1720779497180219