### PR TITLE
feat(suite): Add cursor: not-allowed to some components when disabled

### DIFF
--- a/packages/components/src/components/AutoScalingInput/AutoScalingInput.stories.tsx
+++ b/packages/components/src/components/AutoScalingInput/AutoScalingInput.stories.tsx
@@ -1,49 +1,37 @@
-import styled from 'styled-components';
-import { AutoScalingInput as Input } from './AutoScalingInput';
-import { Meta } from '@storybook/react';
-
-const Wrapper = styled.div`
-    display: flex;
-    flex: 1;
-    flex-direction: column;
-`;
-
-const BorderAutoScalingInput = styled(Input)`
-    padding: 1px 5px;
-    border-radius: 3px;
-    border-style: solid;
-    border-width: 1px;
-`;
-
-const BorderlessAutoScalingInput = styled(Input)`
-    padding: 1px 5px;
-    border-style: solid;
-    border-width: 0;
-    background-color: #ccc;
-`;
+import { ForwardRefExoticComponent, RefAttributes } from 'react';
+import { AutoScalingInput as AutoScalingInputComponent, Props } from './AutoScalingInput';
+import { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta = {
     title: 'Form/AutoScalingInput',
+    component: AutoScalingInputComponent,
 };
 export default meta;
 
-export const AutoScalingInput = {
-    render: () => (
-        <>
-            <Wrapper>
-                <div>Border</div>
-                <BorderAutoScalingInput minWidth={130} />
-                <BorderAutoScalingInput
-                    minWidth={120}
-                    placeholder="Chancellor on the Brink of Second Bailout for Banks"
-                />
-                <div>Borderless</div>
-                <BorderlessAutoScalingInput minWidth={130} />
-                <BorderlessAutoScalingInput
-                    minWidth={120}
-                    placeholder="Chancellor on the Brink of Second Bailout for Banks"
-                />
-            </Wrapper>
-        </>
-    ),
+export const AutoScalingInput: StoryObj<
+    ForwardRefExoticComponent<Omit<Props, 'ref'> & RefAttributes<HTMLInputElement>>
+> = {
+    render: props => <AutoScalingInputComponent {...props} />,
+    args: {
+        value: undefined,
+        minWidth: 120,
+        placeholder: 'Chancellor on the Brink of Second Bailout for Banks',
+        disabled: false,
+    },
+    argTypes: {
+        value: {
+            control: { type: 'text' },
+        },
+        minWidth: {
+            control: { type: 'number' },
+        },
+        placeholder: {
+            control: { type: 'text' },
+        },
+        disabled: {
+            control: {
+                type: 'boolean',
+            },
+        },
+    },
 };

--- a/packages/components/src/components/AutoScalingInput/AutoScalingInput.tsx
+++ b/packages/components/src/components/AutoScalingInput/AutoScalingInput.tsx
@@ -43,10 +43,17 @@ const createHandleOnChangeAndApplyNewWidth =
         onChange?.(event);
     };
 
-interface Props
+export interface Props
     extends React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> {
     minWidth: number;
 }
+
+const StyledInput = styled.input`
+    &:disabled {
+        pointer-events: auto;
+        cursor: not-allowed;
+    }
+`;
 
 /**
  * TODO: This is Labeling Input and this maybe consolidated with `withEditable`
@@ -104,7 +111,7 @@ export const AutoScalingInput = forwardRef<HTMLInputElement, Props>(
                     value={props.placeholder}
                     readOnly
                 />
-                <input
+                <StyledInput
                     {...props}
                     ref={innerRef}
                     type="text"

--- a/packages/components/src/components/AutoScalingInput/AutoScalingInputExamples.stories.tsx
+++ b/packages/components/src/components/AutoScalingInput/AutoScalingInputExamples.stories.tsx
@@ -1,0 +1,49 @@
+import styled from 'styled-components';
+import { AutoScalingInput as Input } from './AutoScalingInput';
+import { Meta } from '@storybook/react';
+
+const Wrapper = styled.div`
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+`;
+
+const BorderAutoScalingInput = styled(Input)`
+    padding: 1px 5px;
+    border-radius: 3px;
+    border-style: solid;
+    border-width: 1px;
+`;
+
+const BorderlessAutoScalingInput = styled(Input)`
+    padding: 1px 5px;
+    border-style: solid;
+    border-width: 0;
+    background-color: #ccc;
+`;
+
+const meta: Meta = {
+    title: 'Form/AutoScalingInput',
+};
+export default meta;
+
+export const AutoScalingInputExamples = {
+    render: () => (
+        <>
+            <Wrapper>
+                <div>Border</div>
+                <BorderAutoScalingInput minWidth={130} />
+                <BorderAutoScalingInput
+                    minWidth={120}
+                    placeholder="Chancellor on the Brink of Second Bailout for Banks"
+                />
+                <div>Borderless</div>
+                <BorderlessAutoScalingInput minWidth={130} />
+                <BorderlessAutoScalingInput
+                    minWidth={120}
+                    placeholder="Chancellor on the Brink of Second Bailout for Banks"
+                />
+            </Wrapper>
+        </>
+    ),
+};

--- a/packages/components/src/components/buttons/Button/Button.stories.tsx
+++ b/packages/components/src/components/buttons/Button/Button.stories.tsx
@@ -22,6 +22,13 @@ export const Button: StoryObj<ButtonProps> = {
         ...framePropsStory.args,
     },
     argTypes: {
+        children: {
+            table: {
+                type: {
+                    summary: 'ReactNode',
+                },
+            },
+        },
         variant: {
             control: {
                 type: 'radio',
@@ -34,20 +41,44 @@ export const Button: StoryObj<ButtonProps> = {
             },
             options: ['large', 'medium', 'small', 'tiny'],
         },
+        isDisabled: {
+            control: {
+                type: 'boolean',
+            },
+        },
+        isLoading: {
+            control: {
+                type: 'boolean',
+            },
+        },
+        isFullWidth: {
+            control: {
+                type: 'boolean',
+            },
+        },
         icon: {
-            options: variables.ICONS,
+            options: {
+                'No icon': null,
+                ...variables.ICONS.reduce((acc, icon) => ({ ...acc, [icon]: icon }), {}),
+            },
             control: {
                 type: 'select',
             },
         },
-        iconSize: { control: 'number' },
+        iconSize: {
+            control: {
+                type: 'number',
+            },
+        },
         iconAlignment: {
             control: {
                 type: 'radio',
             },
             options: ['left', 'right'],
         },
-        title: { control: 'text' },
+        title: {
+            control: { type: 'text' },
+        },
         ...framePropsStory.argTypes,
     },
 };

--- a/packages/components/src/components/form/Range/Range.stories.tsx
+++ b/packages/components/src/components/form/Range/Range.stories.tsx
@@ -16,18 +16,49 @@ export const Range: StoryObj<RangeProps> = {
         return <RangeComponent {...args} onChange={e => updateArgs({ value: e.target.value })} />;
     },
     args: {
-        max: 100,
-        min: 0,
-        value: 21,
+        disabled: false,
         labels: [
             { component: '0', value: 0 },
             { component: '50', value: 50 },
             { component: '100', value: 100 },
         ],
+        max: 100,
+        min: 0,
+        value: 21,
     },
     argTypes: {
         disabled: {
-            control: 'boolean',
+            control: {
+                type: 'boolean',
+            },
+        },
+        labels: {
+            control: {
+                type: 'array',
+            },
+            table: {
+                type: {
+                    summary: 'Array<{ component: string; value: number }>',
+                },
+            },
+        },
+        max: {
+            control: {
+                type: 'number',
+            },
+        },
+        min: {
+            control: {
+                type: 'number',
+            },
+        },
+        value: {
+            control: {
+                type: 'number',
+            },
+        },
+        step: {
+            control: { type: 'text' },
         },
         className: {
             control: false,

--- a/packages/components/src/components/form/Range/Range.tsx
+++ b/packages/components/src/components/form/Range/Range.tsx
@@ -83,6 +83,11 @@ const Input = styled.input<{ $trackStyle?: CSSObject; disabled?: boolean }>`
             ${focusStyle}
         }
     }
+
+    &:disabled {
+        pointer-events: auto;
+        cursor: not-allowed;
+    }
 `;
 
 const Label = styled.div<{ disabled?: boolean; $width?: number }>`
@@ -123,7 +128,7 @@ export interface RangeProps {
 
 export const Range = ({
     className,
-    disabled,
+    disabled = false,
     labels,
     onLabelClick,
     trackStyle,

--- a/packages/components/src/components/form/Select/Select.stories.tsx
+++ b/packages/components/src/components/form/Select/Select.stories.tsx
@@ -29,8 +29,26 @@ export const Select: StoryObj<SelectProps> = {
 
         return <SelectComponent {...args} value={option} onChange={setOption} options={options} />;
     },
+    args: {
+        label: 'Label',
+        isClean: false,
+        isDisabled: false,
+        isSearchable: false,
+        hasBottomPadding: true,
+        size: 'large',
+        minValueWidth: 'initial',
+        menuIsOpen: undefined,
+        useKeyPressScroll: undefined,
+    },
     argTypes: {
-        isSearchable: {
+        label: {
+            table: {
+                type: {
+                    summary: 'ReactNode',
+                },
+            },
+        },
+        isClean: {
             control: {
                 type: 'boolean',
             },
@@ -40,23 +58,46 @@ export const Select: StoryObj<SelectProps> = {
                 type: 'boolean',
             },
         },
+        isSearchable: {
+            control: {
+                type: 'boolean',
+            },
+        },
         bottomText: {
             control: { type: 'text' },
         },
-        size: {
+        hasBottomPadding: {
             control: {
-                options: { 'Large (default)': null, Small: 'small' },
-                type: 'radio',
+                type: 'boolean',
             },
         },
-        label: {
+        size: {
+            control: {
+                type: 'radio',
+            },
+            options: ['large', 'small'],
+        },
+        minValueWidth: {
             control: { type: 'text' },
+        },
+        menuIsOpen: {
+            control: {
+                type: 'boolean',
+            },
+        },
+        useKeyPressScroll: {
+            control: {
+                type: 'boolean',
+            },
+        },
+        inputState: {
+            control: {
+                type: 'radio',
+            },
+            options: [null, 'warning', 'error'],
         },
         placeholder: {
             control: { type: 'text' },
         },
-    },
-    args: {
-        label: 'Label',
     },
 };

--- a/packages/components/src/components/form/Select/Select.tsx
+++ b/packages/components/src/components/form/Select/Select.tsx
@@ -217,6 +217,13 @@ const Wrapper = styled.div<WrapperProps>`
         border: none;
         z-index: ${zIndices.base};
     }
+
+    ${({ $isDisabled }) =>
+        $isDisabled &&
+        css`
+            pointer-events: auto;
+            cursor: not-allowed;
+        `}
 `;
 
 const SelectLabel = styled(Label)`
@@ -272,7 +279,7 @@ export const Select = ({
     components,
     onChange,
     placeholder,
-    isDisabled,
+    isDisabled = false,
     'data-test': dataTest,
     ...props
 }: SelectProps) => {

--- a/packages/components/src/components/form/SelectBar/SelectBar.stories.tsx
+++ b/packages/components/src/components/form/SelectBar/SelectBar.stories.tsx
@@ -12,9 +12,47 @@ const options = [
 
 const meta: Meta = {
     title: 'Form/SelectBar',
-    args: { selectedOption: 'low', label: 'fee' },
+    args: {
+        label: 'fee',
+        options,
+        selectedOption: 'low',
+        isDisabled: false,
+        isFullWidth: undefined,
+    },
+    argTypes: {
+        label: {
+            control: {
+                type: 'text',
+            },
+        },
+        options: {
+            control: {
+                type: 'array',
+            },
+            table: {
+                type: {
+                    summary: 'Array<{ label: string; value: number }>',
+                },
+            },
+        },
+        selectedOption: {
+            control: {
+                type: 'text',
+            },
+        },
+        isDisabled: {
+            control: {
+                type: 'boolean',
+            },
+        },
+        isFullWidth: {
+            control: {
+                type: 'boolean',
+            },
+        },
+    },
     component: SelectBarComponent,
-} as Meta;
+} as unknown as Meta;
 export default meta;
 
 export const SelectBar: StoryObj<SelectBarProps<string>> = {
@@ -24,13 +62,5 @@ export const SelectBar: StoryObj<SelectBarProps<string>> = {
         const setOption = (selectedOption: string) => updateArgs({ selectedOption });
 
         return <SelectBarComponent {...args} onChange={setOption} options={options} />;
-    },
-    argTypes: {
-        label: {
-            type: 'string',
-        },
-        className: { control: { disable: true } },
-        options: { control: { disable: true } },
-        selectedOption: { control: { disable: true } },
     },
 };

--- a/packages/components/src/components/form/SelectBar/SelectBar.tsx
+++ b/packages/components/src/components/form/SelectBar/SelectBar.tsx
@@ -118,7 +118,8 @@ const Option = styled.div<{ $isSelected: boolean; $isDisabled: boolean }>`
         $isDisabled &&
         css`
             color: ${({ theme }) => theme.textDisabled};
-            pointer-events: none;
+            pointer-events: auto;
+            cursor: not-allowed;
         `}
 `;
 
@@ -145,7 +146,7 @@ export const SelectBar: <V extends ValueTypes>(props: SelectBarProps<V>) => JSX.
     options,
     selectedOption,
     onChange,
-    isDisabled,
+    isDisabled = false,
     isFullWidth,
     className,
     ...rest
@@ -160,7 +161,7 @@ export const SelectBar: <V extends ValueTypes>(props: SelectBarProps<V>) => JSX.
 
     const handleOptionClick = useCallback(
         (option: Option<ValueTypes>) => () => {
-            if (option.value === selectedOptionIn) {
+            if (isDisabled || option.value === selectedOptionIn) {
                 return;
             }
 
@@ -168,7 +169,7 @@ export const SelectBar: <V extends ValueTypes>(props: SelectBarProps<V>) => JSX.
 
             onChange?.(option?.value as any);
         },
-        [selectedOptionIn, onChange],
+        [isDisabled, selectedOptionIn, onChange],
     );
 
     const handleKeyboardNav = (e: KeyboardEvent) => {

--- a/packages/components/src/components/form/Switch/Switch.stories.tsx
+++ b/packages/components/src/components/form/Switch/Switch.stories.tsx
@@ -27,14 +27,41 @@ export const Switch: StoryObj<SwitchProps> = {
         );
     },
     args: {
-        isSmall: false,
-        isDisabled: false,
+        isAlert: false,
         isChecked: false,
+        isDisabled: false,
+        isSmall: false,
         label: 'Headline',
         labelPosition: 'right',
-        isAlert: false,
     },
     argTypes: {
+        isAlert: {
+            control: {
+                type: 'boolean',
+            },
+        },
+        isChecked: {
+            control: {
+                type: 'boolean',
+            },
+        },
+        isDisabled: {
+            control: {
+                type: 'boolean',
+            },
+        },
+        isSmall: {
+            control: {
+                type: 'boolean',
+            },
+        },
+        label: {
+            table: {
+                type: {
+                    summary: 'ReactNode',
+                },
+            },
+        },
         labelPosition: {
             options: ['left', 'right'],
             control: {

--- a/packages/components/src/components/form/Switch/Switch.tsx
+++ b/packages/components/src/components/form/Switch/Switch.tsx
@@ -40,7 +40,7 @@ const Container = styled.div<{
     transition:
         background 0.2s ease 0s,
         ${focusStyleTransition};
-    cursor: ${({ $isDisabled }) => !$isDisabled && 'pointer'};
+    cursor: ${({ $isDisabled }) => ($isDisabled ? 'not-allowed' : 'pointer')};
     box-sizing: border-box;
     border: 1px solid
         ${({ theme, $isAlert }) => `${$isAlert ? theme.borderAlertRed : 'transparent'}`};
@@ -123,7 +123,7 @@ export interface SwitchProps {
 
 export const Switch = ({
     onChange,
-    isDisabled,
+    isDisabled = false,
     isAlert,
     isSmall,
     label,


### PR DESCRIPTION
## Description

Add `cursor: not-allowed` for cursor to look nicer to some more of the interactive/input components in our design system, when being disabled.

Additionally, add args and argTypes in storybook for components that are missing them so one could easily change the values of selected component's props in storybook.

This PR takes care about the following components:
- `AutoscalingInput`
- `Range`
- `Select`
- `SelectBar`
- `Switch`

Also for `Button` component, add way to choose from all the available icons in storybook, incl. choosing the option "No icon" in storybook, as the _icon_ prop is optional.

For `AutoscalingInput`, add story for playing with its props, use the existing one to just show the examples.

TODO (in followup PR):
- [ ] `Textarea`
- [ ] `IconButton`
- [ ] `PinButton`
- [ ] `TextButton`
- [ ] `TooltipButton`

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/12945

## Screenshots:
**Before:**
Example: `Label` component
![label_before](https://github.com/trezor/trezor-suite/assets/13417815/a8b7d356-9682-406c-872e-858260bcc03f)

**After:**
Example: `Label` component: updated cursor when disabled + added more controls to storybook
![label_after](https://github.com/trezor/trezor-suite/assets/13417815/88c760fe-8c8e-428d-86b7-3586d4bbba65)

Button component: now you can easily choose an icon if you want, or also not:
![icons](https://github.com/trezor/trezor-suite/assets/13417815/d3477214-b690-4fc5-9d4f-9cb22c41115a)
