### PR TITLE
fix(suite-native): unlock device mutex on callback rejection

### DIFF
--- a/suite-native/device/src/hooks/useHandleDeviceConnection.ts
+++ b/suite-native/device/src/hooks/useHandleDeviceConnection.ts
@@ -53,7 +53,9 @@ export const useHandleDeviceConnection = () => {
             !isDeviceConnectedAndAuthorized &&
             !isBiometricsOverlayVisible
         ) {
-            requestPrioritizedDeviceAccess(() => dispatch(authorizeDeviceThunk()));
+            requestPrioritizedDeviceAccess({
+                deviceCallback: () => dispatch(authorizeDeviceThunk()),
+            });
 
             // Note: Passphrase protected device (excluding empty passphrase, e. g. standard wallet with passphrase protection on device),
             // post auth navigation is handled in @suite-native/module-passphrase for custom UX flow.

--- a/suite-native/discovery/src/discoveryThunks.ts
+++ b/suite-native/discovery/src/discoveryThunks.ts
@@ -164,9 +164,10 @@ const getCardanoSupportedAccountTypesThunk = createThunk(
         if (!device) {
             return undefined;
         }
-        const availableCardanoDerivationsResponse = await requestDeviceAccess(() =>
-            dispatch(getAvailableCardanoDerivationsThunk({ deviceState, device })).unwrap(),
-        );
+        const availableCardanoDerivationsResponse = await requestDeviceAccess({
+            deviceCallback: () =>
+                dispatch(getAvailableCardanoDerivationsThunk({ deviceState, device })).unwrap(),
+        });
 
         if (availableCardanoDerivationsResponse.success) {
             return availableCardanoDerivationsResponse.payload;
@@ -302,22 +303,23 @@ export const addAndDiscoverNetworkAccountThunk = createThunk(
         const accountPath = network.bip43Path.replace('i', index.toString());
 
         // Take exclusive access to the device and hold it until fetching of the descriptors is done.
-        const deviceAccessResponse = await requestDeviceAccess(() =>
-            dispatch(
-                fetchBundleDescriptorsThunk([
-                    {
-                        path: accountPath,
-                        coin: network.symbol,
-                        index,
-                        accountType,
-                        networkType: network.networkType,
-                        derivationType: getDerivationType(accountType),
-                        suppressBackupWarning: true,
-                        skipFinalReload: true,
-                    },
-                ]),
-            ).unwrap(),
-        );
+        const deviceAccessResponse = await requestDeviceAccess({
+            deviceCallback: async () =>
+                await dispatch(
+                    fetchBundleDescriptorsThunk([
+                        {
+                            path: accountPath,
+                            coin: network.symbol,
+                            index,
+                            accountType,
+                            networkType: network.networkType,
+                            derivationType: getDerivationType(accountType),
+                            suppressBackupWarning: true,
+                            skipFinalReload: true,
+                        },
+                    ]),
+                ).unwrap(),
+        });
 
         if (!deviceAccessResponse.success) {
             return undefined;
@@ -425,9 +427,9 @@ const discoverNetworkBatchThunk = createThunk(
         }
 
         // Take exclusive access to the device and hold it until is the fetching of the descriptors done.
-        const deviceAccessResponse = await requestDeviceAccess(() =>
-            dispatch(fetchBundleDescriptorsThunk(chunkBundle)).unwrap(),
-        );
+        const deviceAccessResponse = await requestDeviceAccess({
+            deviceCallback: () => dispatch(fetchBundleDescriptorsThunk(chunkBundle)).unwrap(),
+        });
 
         if (!deviceAccessResponse.success) {
             return;

--- a/suite-native/module-connect-device/src/components/PinFormControlButtons.tsx
+++ b/suite-native/module-connect-device/src/components/PinFormControlButtons.tsx
@@ -92,7 +92,9 @@ export const PinFormControlButtons = () => {
             onPressPrimaryButton: () => {
                 if (hasDeviceAuthFailed) {
                     // Ask for new PIN entry after 3 wrong attempts.
-                    requestPrioritizedDeviceAccess(() => dispatch(authorizeDeviceThunk()));
+                    requestPrioritizedDeviceAccess({
+                        deviceCallback: () => dispatch(authorizeDeviceThunk()),
+                    });
                 }
             },
             secondaryButtonTitle: (

--- a/suite-native/module-connect-device/src/screens/ConnectAndUnlockDeviceScreen.tsx
+++ b/suite-native/module-connect-device/src/screens/ConnectAndUnlockDeviceScreen.tsx
@@ -44,7 +44,9 @@ export const ConnectAndUnlockDeviceScreen = () => {
     useEffect(() => {
         if (isFocused && device && !isDeviceAuthorized) {
             // When user cancelled the authorization, we need to authorize the device again.
-            requestPrioritizedDeviceAccess(() => dispatch(authorizeDeviceThunk()));
+            requestPrioritizedDeviceAccess({
+                deviceCallback: () => dispatch(authorizeDeviceThunk()),
+            });
         }
     }, [isDeviceAuthorized, device, dispatch, isFocused]);
 

--- a/suite-native/module-send/src/sendFormThunks.ts
+++ b/suite-native/module-send/src/sendFormThunks.ts
@@ -76,15 +76,16 @@ export const onDeviceTransactionReviewThunk = createThunk<
 
         if (!precomposedTransaction)
             return rejectWithValue('Thunk prepareTransactionForSigningThunk failed.');
-        const signTransactionResponse = await requestPrioritizedDeviceAccess(() =>
-            dispatch(
-                signTransactionThunk({
-                    formValues: formState,
-                    precomposedTransaction,
-                    selectedAccount: account,
-                }),
-            ).unwrap(),
-        );
+        const signTransactionResponse = await requestPrioritizedDeviceAccess({
+            deviceCallback: () =>
+                dispatch(
+                    signTransactionThunk({
+                        formValues: formState,
+                        precomposedTransaction,
+                        selectedAccount: account,
+                    }),
+                ).unwrap(),
+        });
 
         if (
             !signTransactionResponse.success ||

--- a/suite-native/receive/src/hooks/useAccountReceiveAddress.tsx
+++ b/suite-native/receive/src/hooks/useAccountReceiveAddress.tsx
@@ -56,16 +56,18 @@ export const useAccountReceiveAddress = (accountKey: AccountKey) => {
 
     const verifyAddressOnDevice = useCallback(async (): Promise<boolean> => {
         if (accountKey && freshAddress) {
-            const response = await requestPrioritizedDeviceAccess(() => {
-                const thunkResponse = dispatch(
-                    confirmAddressOnDeviceThunk({
-                        accountKey,
-                        addressPath: freshAddress.path,
-                        chunkify: true,
-                    }),
-                ).unwrap();
+            const response = await requestPrioritizedDeviceAccess({
+                deviceCallback: () => {
+                    const thunkResponse = dispatch(
+                        confirmAddressOnDeviceThunk({
+                            accountKey,
+                            addressPath: freshAddress.path,
+                            chunkify: true,
+                        }),
+                    ).unwrap();
 
-                return thunkResponse;
+                    return thunkResponse;
+                },
             });
 
             if (!response.success) {


### PR DESCRIPTION
When `requestDeviceAccess` or `requestPrioritizedDeviceAccess` failed, device mutex was not unlocked causing next call not receiving the lock.

