### PR TITLE
fix(suite): replace RBF tx with locktime

### DIFF
--- a/packages/suite/src/hooks/wallet/__fixtures__/useRbfForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useRbfForm.ts
@@ -1050,5 +1050,4 @@ export const composeAndSign = [
 // TODO: multiple inputs (select one for decrease)
 // TODO: custom fee + set-max (decrease)
 // TODO: mad clicking (composeDebounce)
-// TODO: with locktime
 // TODO: ethereum cases

--- a/suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts
@@ -253,6 +253,9 @@ export const signBitcoinSendFormTransactionThunk = createThunk(
         if (formValues.bitcoinLockTime) {
             signEnhancement.locktime = new BigNumber(formValues.bitcoinLockTime).toNumber();
         }
+        if (formValues.rbfParams?.locktime) {
+            signEnhancement.locktime = formValues.rbfParams.locktime;
+        }
 
         let refTxs;
 

--- a/suite-common/wallet-types/src/transaction.ts
+++ b/suite-common/wallet-types/src/transaction.ts
@@ -175,6 +175,7 @@ export interface RbfTransactionParams {
     changeAddress?: AccountAddress; // original change address
     feeRate: string; // original fee rate
     baseFee: number; // original fee
+    locktime?: number;
     ethereumNonce?: number;
     ethereumData?: string;
 }

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -656,7 +656,6 @@ const getBitcoinRbfParams = (
 
     if (!utxo.length || !outputs.length || outputs.length !== vout.length) return;
 
-    // TODO: get other params, like locktime etc.
     return {
         txid: tx.txid,
         utxo,
@@ -667,6 +666,7 @@ const getBitcoinRbfParams = (
         // of displaying fee rate is kept here
         feeRate: tx.feeRate || getFeeRate(tx),
         baseFee: parseInt(tx.fee, 10),
+        locktime: tx.lockTime,
     };
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Since [rbf is always enabled](https://github.com/trezor/trezor-suite/pull/13226) it is possible to create rbf + locktime transaction.
There was a TODO for that in RBF related actions.

 
## Steps (with user-env)
- load regtest account
- send yourself some coins using user-env
- go to send form
- set locktime to network currentBlock or lower (probably 151? verify in regtest explorer)
- enable broadcasting (nitpick: this should be enabled since broadcasting is possible)
- send some coins anywhere
- go to dashboard, and hit "replace transaction"
- go thru process
- tx should be successfully replaced 

## Resolve

bug on current develop, replacement tx is rejected with missing `nLocKTime` error
