### PR TITLE
fix(connect): handle missing language binary

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -581,6 +581,10 @@ export class Device extends TypedEmitter<DeviceEvents> {
             internal_model: this.features.internal_model,
         });
 
+        if (!downloadedBinary) {
+            throw ERRORS.TypedError('Runtime', 'changeLanguage: translation not found');
+        }
+
         return this._uploadTranslationData(downloadedBinary);
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There is a new bug in Suite Lite - Trezor ask user to confirm language change when connected and by other interactions with the device too.
<img width="400" alt="image" src="https://github.com/trezor/trezor-suite/assets/3729633/29e2e47e-290a-475e-866a-a4162687abd3">

steps to reproduce:
You have to be on previous FW version (i.e. 2.7.2) in language other than EN
Update to 2.8.0 FW
Connect Trezor to Suite Lite



Downloading language binary on Suite Lite is not working at all and failed fetch handling was missing.

This only handles the error state, so it is a workaround solution for Suite Lite - user will not see Language change screen.