### PR TITLE
feat(suite): Save sidebar width to SuiteSettings to be persisted

### DIFF
--- a/packages/components/src/components/ResizableBox/ResizableBox.tsx
+++ b/packages/components/src/components/ResizableBox/ResizableBox.tsx
@@ -19,6 +19,8 @@ export type ResizableBoxProps = {
     updateWidthOnWindowResize?: boolean;
     updateHeightOnWindowResize?: boolean;
     zIndex?: ZIndexValues;
+    onWidthResizeEnd?: (width: number) => void;
+    onHeightResizeEnd?: (height: number) => void;
 };
 
 type ResizerHandlersProps = {
@@ -182,6 +184,8 @@ export const ResizableBox = ({
     updateWidthOnWindowResize = false,
     updateHeightOnWindowResize = false,
     zIndex = zIndices.draggableComponent,
+    onWidthResizeEnd,
+    onHeightResizeEnd,
 }: ResizableBoxProps) => {
     const resizableBoxRef = useRef<HTMLDivElement>(null);
 
@@ -272,7 +276,15 @@ export const ResizableBox = ({
             }
         };
 
-        document.onmouseup = () => setIsResizing(false);
+        document.onmouseup = () => {
+            setIsResizing(false);
+            if (onWidthResizeEnd) {
+                onWidthResizeEnd(newWidth);
+            }
+            if (onHeightResizeEnd) {
+                onHeightResizeEnd(newHeight);
+            }
+        };
 
         window.onresize = () => {
             if (resizeCooldown() === true) {
@@ -292,6 +304,8 @@ export const ResizableBox = ({
         maxWidth,
         newHeight,
         newWidth,
+        onHeightResizeEnd,
+        onWidthResizeEnd,
         resizableBoxRef,
         resize,
         resizeCooldown,

--- a/packages/suite/src/actions/suite/constants/suiteConstants.ts
+++ b/packages/suite/src/actions/suite/constants/suiteConstants.ts
@@ -31,3 +31,4 @@ export const LOCK_TYPE = {
 } as const;
 export const REQUEST_DEVICE_RECONNECT = '@suite/request-device-reconnect';
 export const SET_EXPERIMENTAL_FEATURES = '@suite/set-experimental-features';
+export const SET_SIDEBAR_WIDTH = '@suite/set-sidebar-width';

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -75,7 +75,8 @@ export type SuiteAction =
           payload: Partial<AutodetectSettings>;
       }
     | { type: typeof deviceActions.requestDeviceReconnect.type }
-    | { type: typeof SUITE.SET_EXPERIMENTAL_FEATURES; payload?: ExperimentalFeature[] };
+    | { type: typeof SUITE.SET_EXPERIMENTAL_FEATURES; payload?: ExperimentalFeature[] }
+    | { type: typeof SUITE.SET_SIDEBAR_WIDTH; payload: { width: number } };
 
 export const appChanged = createAction(
     SUITE.APP_CHANGED,
@@ -128,6 +129,11 @@ export const initialRunCompleted = () => (dispatch: Dispatch, getState: GetState
         dispatch(setFlag('initialRun', false));
     }
 };
+
+export const setSidebarWidth = (payload: { width: number }): SuiteAction => ({
+    type: SUITE.SET_SIDEBAR_WIDTH,
+    payload: { width: payload.width },
+});
 
 /**
  * Triggered by `@suite-support/OnlineStatus` or `@suite-native/support/OnlineStatus`

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Sidebar.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Sidebar.tsx
@@ -5,8 +5,9 @@ import { Navigation } from './Navigation';
 import { AccountsMenu } from 'src/components/wallet/WalletLayout/AccountsMenu/AccountsMenu';
 import { QuickActions } from './QuickActions';
 import { ElevationUp, ResizableBox, useElevation } from '@trezor/components';
-import { SIDEBAR_WIDTH_NUMERIC } from 'src/constants/suite/layout';
 import { Elevation, mapElevationToBackground, mapElevationToBorder, zIndices } from '@trezor/theme';
+import { useActions, useSelector } from 'src/hooks/suite';
+import * as suiteActions from 'src/actions/suite/suiteActions';
 
 const Container = styled.nav<{ $elevation: Elevation }>`
     display: flex;
@@ -24,15 +25,21 @@ const Wrapper = styled.div`
 export const Sidebar = () => {
     const { elevation } = useElevation();
 
+    const sidebarWidth = useSelector(state => state.suite.settings.sidebarWidth);
+    const { setSidebarWidth } = useActions({
+        setSidebarWidth: (width: number) => suiteActions.setSidebarWidth({ width }),
+    });
+
     return (
         <Wrapper>
             <ResizableBox
                 directions={['right']}
-                width={SIDEBAR_WIDTH_NUMERIC}
+                width={sidebarWidth}
                 minWidth={230}
                 maxWidth={400}
                 zIndex={zIndices.draggableComponent}
                 updateHeightOnWindowResize
+                onWidthResizeEnd={setSidebarWidth}
             >
                 <Container $elevation={elevation}>
                     <ElevationUp>

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -230,6 +230,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 case SUITE.SET_ADDRESS_DISPLAY_TYPE:
                 case SUITE.SET_DEFAULT_WALLET_LOADING:
                 case SUITE.SET_AUTODETECT:
+                case SUITE.SET_SIDEBAR_WIDTH:
                 case SUITE.DEVICE_AUTHENTICITY_OPT_OUT:
                 case SUITE.EVM_CONFIRM_EXPLANATION_MODAL:
                 case SUITE.EVM_CLOSE_EXPLANATION_BANNER:

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -18,6 +18,7 @@ import { RouterRootState, selectRouter } from './routerReducer';
 import { Network } from '@suite-common/wallet-config';
 import { SuiteThemeVariant } from '@trezor/suite-desktop-api';
 import { AddressDisplayOptions, WalletType } from '@suite-common/wallet-types';
+import { SIDEBAR_WIDTH_NUMERIC } from 'src/constants/suite/layout';
 
 export interface SuiteRootState {
     suite: SuiteState;
@@ -88,6 +89,7 @@ export interface SuiteSettings {
     addressDisplayType: AddressDisplayOptions;
     defaultWalletLoading: WalletType;
     experimental?: ExperimentalFeature[];
+    sidebarWidth: number;
 }
 
 export interface SuiteState {
@@ -154,6 +156,7 @@ const initialState: SuiteState = {
         },
         addressDisplayType: AddressDisplayOptions.CHUNKED,
         defaultWalletLoading: WalletType.STANDARD,
+        sidebarWidth: SIDEBAR_WIDTH_NUMERIC,
     },
 };
 
@@ -257,6 +260,10 @@ const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteSt
                     ...draft.settings.autodetect,
                     ...action.payload,
                 };
+                break;
+
+            case SUITE.SET_SIDEBAR_WIDTH:
+                draft.settings.sidebarWidth = action.payload.width;
                 break;
 
             case TRANSPORT.START:


### PR DESCRIPTION
## Description

After resizing the sidebar on mouse up event, save the actual sidebar width so after disconnecting and reconnecting Trezor and visiting Suite again, the user can see their custom sidebar width and not the default one (280px).

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/13055

## Screenshots:
Changing the default sidebar width (for example to maximum 400px):
![change_width](https://github.com/trezor/trezor-suite/assets/13417815/ae29e3d5-303d-4401-931e-41fe568fec82)

**Before:**
After reconnecting, sidebar width back to the default:
![width_before](https://github.com/trezor/trezor-suite/assets/13417815/e4625068-ac6f-4659-9670-4470cd93408e)

**After:**
![width_after](https://github.com/trezor/trezor-suite/assets/13417815/dd9cfe17-da73-4296-a651-3cd7dfcf37dd)
