### PR TITLE
`DeviceList` revamp

### DIFF
--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -991,18 +991,7 @@ const initDeviceList = async (transportReconnect?: boolean) => {
         throw error;
     }
 
-    // if transport fails during app lifetime, try to reconnect
-    if (transportReconnect) {
-        _deviceList.once(TRANSPORT.ERROR, () => {
-            const { promise, reject } = resolveAfter(1000, null);
-            _deviceListInitReject = reject;
-            promise.then(() => {
-                initDeviceList(transportReconnect);
-            });
-        });
-    }
-
-    _deviceList.init(pendingTransportEvent);
+    _deviceList.init({ pendingTransportEvent, transportReconnect });
     await _deviceList.pendingConnection();
 };
 
@@ -1191,6 +1180,7 @@ const disableWebUSBTransport = async () => {
         // clean previous device list
         _deviceList.cleanup();
         //and init with new settings, without webusb
+        // TODO possible issue with new init not replacing the old one???
         await initDeviceList(settings.transportReconnect);
     } catch (error) {
         // do nothing

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -964,10 +964,12 @@ const handleDeviceSelectionChanges = (interruptDevice?: DeviceTyped) => {
  */
 const initDeviceList = async (transportReconnect?: boolean) => {
     try {
-        _deviceList = new DeviceList({
-            settings: DataManager.getSettings(),
-            messages: DataManager.getProtobufMessages(),
-        });
+        const { debug, transports, priority, pendingTransportEvent } = DataManager.getSettings();
+        const messages = DataManager.getProtobufMessages();
+
+        _deviceList = new DeviceList({ debug, messages, priority });
+
+        _deviceList.setTransports(transports);
 
         _deviceList.on(DEVICE.CONNECT, device => {
             handleDeviceSelectionChanges();
@@ -1013,7 +1015,7 @@ const initDeviceList = async (transportReconnect?: boolean) => {
             postMessage(createTransportMessage(TRANSPORT.START, transportType)),
         );
 
-        _deviceList.init();
+        _deviceList.init(pendingTransportEvent);
         if (_deviceList) {
             await _deviceList.waitForTransportFirstEvent();
         }

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -7,7 +7,7 @@ import { getSynchronize } from '@trezor/utils';
 import { storage } from '@trezor/connect-common';
 
 import { DataManager } from '../data/DataManager';
-import { DeviceList } from '../device/DeviceList';
+import { DeviceList, IDeviceList } from '../device/DeviceList';
 import { enhanceMessageWithAnalytics } from '../data/analyticsInfo';
 import { ERRORS } from '../constants';
 import {
@@ -41,7 +41,7 @@ import { onCallFirmwareUpdate } from './onCallFirmwareUpdate';
 
 // Public variables
 let _core: Core; // Class with event emitter
-let _deviceList: DeviceList | undefined; // Instance of DeviceList
+let _deviceList: IDeviceList; // Instance of DeviceList
 const _callMethods: AbstractMethod<any>[] = []; // generic type is irrelevant. only common functions are called at this level
 let _interactionTimeout: InteractionTimeout;
 let _deviceListInitTimeout: ReturnType<typeof setTimeout> | undefined;
@@ -98,19 +98,11 @@ const uiPromises = createUiPromiseManager(interactionTimeout);
  * @memberof Core
  */
 const initDevice = async (devicePath?: string) => {
-    if (!_deviceList) {
-        throw ERRORS.TypedError('Transport_Missing');
-    }
-
     // see initTransport.
     // if transportReconnect: true, initTransport does not wait to be finished. if there are multiple requested transports
     // in TrezorConnect.init, this method may emit UI.SELECT_DEVICE with wrong parameters (for example it thinks that it does not use weubsb although it should)
-    await _deviceList.getInitPromise();
-
-    if (!_deviceList) {
-        // Need to check again if _deviceList is still available
-        throw ERRORS.TypedError('Transport_Missing');
-    }
+    await _deviceList.pendingConnection();
+    _deviceList.assertConnected();
 
     const isWebUsb = _deviceList.transportType() === 'WebUsbTransport';
     let device: Device | typeof undefined;
@@ -161,10 +153,8 @@ const initDevice = async (devicePath?: string) => {
         // wait for popup handshake
         await waitForPopup();
 
-        // there is await above, _deviceList might have been set to undefined.
-        if (!_deviceList) {
-            throw ERRORS.TypedError('Transport_Missing');
-        }
+        // there is await above, _deviceList might have been disconnected.
+        _deviceList.assertConnected();
 
         // check again for available devices
         // there is a possible race condition before popup open
@@ -533,7 +523,7 @@ const onCall = async (message: IFrameCallMessage) => {
         return Promise.resolve();
     }
 
-    if (!_deviceList && !DataManager.getSettings('transportReconnect')) {
+    if (!_deviceList.isConnected() && !_deviceList.pendingConnection()) {
         // transport is missing try to initialize it once again
         await initDeviceList(false);
     }
@@ -681,7 +671,7 @@ const onCall = async (message: IFrameCallMessage) => {
         // corner case: Device was disconnected during authorization
         // this device_id needs to be stored and penalized with delay on future connection
         // this solves issue with U2F login (leaves space for requests from services which aren't using trezord)
-        if (_deviceList && error.code === 'Device_Disconnected') {
+        if (error.code === 'Device_Disconnected') {
             _deviceList.addAuthPenalty(device);
         }
 
@@ -690,7 +680,10 @@ const onCall = async (message: IFrameCallMessage) => {
             // thrown while acquiring device
             // it's a race condition between two tabs
             // workaround is to enumerate transport again and report changes to get a valid session number
-            if (_deviceList && error.message === TRANSPORT_ERROR.SESSION_WRONG_PREVIOUS) {
+            if (
+                _deviceList.isConnected() &&
+                error.message === TRANSPORT_ERROR.SESSION_WRONG_PREVIOUS
+            ) {
                 await _deviceList.enumerate();
             }
             messageResponse = createResponseMessage(method.responseID, false, { error });
@@ -734,10 +727,8 @@ const onCall = async (message: IFrameCallMessage) => {
                 method.dispose();
             }
 
-            if (_deviceList) {
-                if (response.success) {
-                    _deviceList.removeAuthPenalty(device);
-                }
+            if (response.success) {
+                _deviceList.removeAuthPenalty(device);
             }
 
             if (!useCoreInPopup) {
@@ -887,7 +878,7 @@ const onPopupClosed = (customErrorMessage?: string) => {
         ? ERRORS.TypedError('Method_Cancel', customErrorMessage)
         : ERRORS.TypedError('Method_Interrupted');
     // Device was already acquired. Try to interrupt running action which will throw error from onCall try/catch block
-    if (_deviceList && _deviceList.asArray().length > 0) {
+    if (_deviceList.isConnected() && _deviceList.asArray().length > 0) {
         _deviceList.allDevices().forEach(d => {
             d.keepSession = false; // clear session on release
             if (d.isUsedHere()) {
@@ -922,7 +913,7 @@ const onPopupClosed = (customErrorMessage?: string) => {
 const handleDeviceSelectionChanges = (interruptDevice?: DeviceTyped) => {
     // update list of devices in popup
     const promiseExists = uiPromises.exists(UI.RECEIVE_DEVICE);
-    if (promiseExists && _deviceList) {
+    if (promiseExists && _deviceList.isConnected()) {
         const list = _deviceList.asArray();
         const isWebUsb = _deviceList.transportType() === 'WebUsbTransport';
 
@@ -963,15 +954,11 @@ const handleDeviceSelectionChanges = (interruptDevice?: DeviceTyped) => {
  * @memberof Core
  */
 const initDeviceList = async (transportReconnect?: boolean) => {
-    const { debug, transports, priority, pendingTransportEvent } = DataManager.getSettings();
-    const messages = DataManager.getProtobufMessages();
-
-    _deviceList = new DeviceList({ debug, messages, priority });
+    const { transports, pendingTransportEvent } = DataManager.getSettings();
 
     try {
         _deviceList.setTransports(transports);
     } catch (error) {
-        _deviceList = undefined;
         postMessage(createTransportMessage(TRANSPORT.ERROR, { error }));
         throw error;
     }
@@ -1002,12 +989,10 @@ const initDeviceList = async (transportReconnect?: boolean) => {
     _deviceList.on(TRANSPORT.ERROR, error => {
         _log.warn('TRANSPORT.ERROR', error);
 
-        if (_deviceList) {
+        if (_deviceList.isConnected()) {
             _deviceList.disconnectDevices();
             _deviceList.dispose();
         }
-
-        _deviceList = undefined;
 
         postMessage(createTransportMessage(TRANSPORT.ERROR, { error }));
         // if transport fails during app lifetime, try to reconnect
@@ -1021,7 +1006,7 @@ const initDeviceList = async (transportReconnect?: boolean) => {
     });
 
     _deviceList.init(pendingTransportEvent);
-    await _deviceList.getInitPromise();
+    await _deviceList.pendingConnection();
 };
 
 /**
@@ -1054,7 +1039,9 @@ export class Core extends EventEmitter {
                  * requestWebUSBDevice in connect-web/src/index, this is used to trigger transport
                  * enumeration
                  */
-                _deviceList?.enumerate();
+                if (_deviceList.isConnected()) {
+                    _deviceList.enumerate();
+                }
                 break;
 
             case TRANSPORT.GET_INFO:
@@ -1082,10 +1069,11 @@ export class Core extends EventEmitter {
                 // like regular methods using onCall function. In onCall, disconnecting device
                 // means that call immediately returns error.
                 if (message.payload.method === 'firmwareUpdate') {
+                    _deviceList.assertConnected();
                     onCallFirmwareUpdate({
                         params: message.payload,
                         context: {
-                            deviceList: _deviceList!,
+                            deviceList: _deviceList,
                             postMessage,
                             initDevice,
                             log: _log,
@@ -1114,7 +1102,7 @@ export class Core extends EventEmitter {
         }
         this.removeAllListeners();
         this.abortController.abort();
-        if (_deviceList) {
+        if (_deviceList.isConnected()) {
             _deviceList.dispose();
         }
     }
@@ -1126,18 +1114,15 @@ export class Core extends EventEmitter {
     }
 
     getTransportInfo(): TransportInfo | undefined {
-        if (!_deviceList) {
-            return undefined;
+        if (_deviceList.isConnected()) {
+            return _deviceList.getTransportInfo();
         }
-
-        return _deviceList.getTransportInfo();
     }
 
     enumerate() {
-        if (!_deviceList) {
-            return;
+        if (_deviceList.isConnected()) {
+            _deviceList.enumerate();
         }
-        _deviceList.enumerate();
     }
 
     async init(
@@ -1150,11 +1135,15 @@ export class Core extends EventEmitter {
         }
         try {
             await DataManager.load(settings);
-            enableLog(DataManager.getSettings('debug'));
+            const { debug, priority } = DataManager.getSettings();
+            const messages = DataManager.getProtobufMessages();
+
+            enableLog(debug);
 
             // TODO NOTE: i'm leaving reference to avoid complex changes, top-level reference is used by methods above Core context
             // eslint-disable-next-line @typescript-eslint/no-this-alias
             _core = this;
+            _deviceList = new DeviceList({ debug, messages, priority });
 
             // If we're not in popup mode, set the interaction timeout to 0 (= disabled)
             _interactionTimeout = new InteractionTimeout(
@@ -1188,7 +1177,7 @@ export class Core extends EventEmitter {
 }
 
 const disableWebUSBTransport = async () => {
-    if (!_deviceList) return;
+    if (!_deviceList.isConnected()) return;
     if (_deviceList.transportType() !== 'WebUsbTransport') return;
     // override settings
     const settings = DataManager.getSettings();

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -105,7 +105,7 @@ const initDevice = async (devicePath?: string) => {
     // see initTransport.
     // if transportReconnect: true, initTransport does not wait to be finished. if there are multiple requested transports
     // in TrezorConnect.init, this method may emit UI.SELECT_DEVICE with wrong parameters (for example it thinks that it does not use weubsb although it should)
-    await _deviceList.getTransportFirstEventPromise();
+    await _deviceList.getInitPromise();
 
     if (!_deviceList) {
         // Need to check again if _deviceList is still available
@@ -995,6 +995,10 @@ const initDeviceList = async (transportReconnect?: boolean) => {
         postMessage(createDeviceMessage(DEVICE.CHANGED, device));
     });
 
+    _deviceList.on(TRANSPORT.START, transportType =>
+        postMessage(createTransportMessage(TRANSPORT.START, transportType)),
+    );
+
     _deviceList.on(TRANSPORT.ERROR, error => {
         _log.warn('TRANSPORT.ERROR', error);
 
@@ -1016,12 +1020,8 @@ const initDeviceList = async (transportReconnect?: boolean) => {
         }
     });
 
-    _deviceList.on(TRANSPORT.START, transportType =>
-        postMessage(createTransportMessage(TRANSPORT.START, transportType)),
-    );
-
     _deviceList.init(pendingTransportEvent);
-    await _deviceList.waitForTransportFirstEvent();
+    await _deviceList.getInitPromise();
 };
 
 /**

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -105,7 +105,7 @@ const initDevice = async (devicePath?: string) => {
     // see initTransport.
     // if transportReconnect: true, initTransport does not wait to be finished. if there are multiple requested transports
     // in TrezorConnect.init, this method may emit UI.SELECT_DEVICE with wrong parameters (for example it thinks that it does not use weubsb although it should)
-    await _deviceList.transportFirstEventPromise;
+    await _deviceList.getTransportFirstEventPromise();
 
     if (!_deviceList) {
         // Need to check again if _deviceList is still available

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -46,20 +46,20 @@ interface DeviceListEvents {
 
 export class DeviceList extends TypedEmitter<DeviceListEvents> {
     // @ts-expect-error has no initializer
-    transport: Transport;
+    private transport: Transport;
 
     // array of transport that might be used in this environment
-    transports: Transport[] = [];
+    private transports: Transport[] = [];
 
-    devices: { [path: string]: Device } = {};
+    private devices: { [path: string]: Device } = {};
 
-    creatingDevicesDescriptors: { [k: string]: Descriptor } = {};
+    private creatingDevicesDescriptors: { [k: string]: Descriptor } = {};
 
-    transportStartPending = 0;
+    private transportStartPending = 0;
 
-    penalizedDevices: { [deviceID: string]: number } = {};
+    private penalizedDevices: { [deviceID: string]: number } = {};
 
-    transportFirstEventPromise: Promise<void> | undefined;
+    private transportFirstEventPromise: Promise<void> | undefined;
 
     private settings: ConnectSettings;
 
@@ -331,6 +331,10 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> {
         if (this.transportStartPending === 0) {
             this.emit(TRANSPORT.START, this.getTransportInfo());
         }
+    }
+
+    getTransportFirstEventPromise() {
+        return this.transportFirstEventPromise;
     }
 
     async waitForTransportFirstEvent() {

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -236,22 +236,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> {
             }
         });
 
-        const events = [
-            {
-                d: diff.changedSessions,
-                e: DEVICE.CHANGED,
-            },
-            {
-                d: diff.acquired,
-                e: DEVICE.ACQUIRED,
-            },
-            {
-                d: diff.released,
-                e: DEVICE.RELEASED,
-            },
-        ];
-
-        events.forEach(({ d, e }) => {
+        const forEachDescriptor = (d: Descriptor[], e: keyof DeviceListEvents) => {
             d.forEach(descriptor => {
                 const path = descriptor.path.toString();
                 const device = this.devices[path];
@@ -260,7 +245,11 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> {
                     this.emit(e, device.toMessageObject());
                 }
             });
-        });
+        };
+
+        forEachDescriptor(diff.changedSessions, DEVICE.CHANGED);
+        forEachDescriptor(diff.acquired, DEVICE.ACQUIRED);
+        forEachDescriptor(diff.released, DEVICE.RELEASED);
 
         // whenever descriptors change we need to update them so that we can use them
         // in subsequent transport.acquire calls

--- a/packages/connect/src/utils/promiseUtils.ts
+++ b/packages/connect/src/utils/promiseUtils.ts
@@ -1,10 +1,13 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/utils/promiseUtils.js
 
-export const resolveAfter = (msec: number, value?: any) => {
-    let timeout: ReturnType<typeof setTimeout> | undefined;
-    const promise = new Promise<any>(resolve => {
-        timeout = setTimeout(resolve, msec, value);
-    });
+import { createDeferred } from '@trezor/utils';
 
-    return { promise, timeout };
+export const resolveAfter = <T = void>(msec: number, value?: T) => {
+    const { promise, reject, resolve } = createDeferred<T>();
+    const timeout = setTimeout(resolve, msec, value);
+
+    return {
+        promise: promise.finally(() => clearTimeout(timeout)),
+        reject,
+    };
 };

--- a/packages/transport/src/index.ts
+++ b/packages/transport/src/index.ts
@@ -14,6 +14,7 @@ protobuf.configure();
 export type { Descriptor, Session } from './types';
 export { TREZOR_USB_DESCRIPTORS, TRANSPORT } from './constants';
 
+export type { DeviceDescriptorDiff } from './transports/abstract';
 export { AbstractTransport as Transport, isTransportInstance } from './transports/abstract';
 export { AbstractApiTransport } from './transports/abstractApi';
 export { UsbApi } from './api/usb';

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -30,7 +30,7 @@ export type ReleaseInput = {
     onClose?: boolean;
 };
 
-type DeviceDescriptorDiff = {
+export type DeviceDescriptorDiff = {
     didUpdate: boolean;
     descriptors: Descriptor[];
     connected: Descriptor[];


### PR DESCRIPTION
## Description

This is part of big Connect refactoring, this time related to `DeviceList`. The goal was to make it something like a singleton, instead of destroying and recreating it whenever a transport error appears. I've tried to make very small commits so it should be relatively easy to review them.

## Commits
- https://github.com/trezor/trezor-suite/pull/13273/commits/0d0d37befb5be799664315108ac6ec74433c6c18 - making as many device list's fields private as possible
- https://github.com/trezor/trezor-suite/pull/13273/commits/5cdca733f581a5c919c7e367864ffb36c86c62e9 - separate transports creation logic from device list's constructor, so it can be moved in the next commit
- https://github.com/trezor/trezor-suite/pull/13273/commits/7d6ad626b415b5d04d83a903dc2a3afa97dc9e48 - device list constructor now doesn't create transports (well, except the default Bridge one so there's always one) so it should never throw and can live forever; transport creation logic moved to `setTransports()` which can throw without the chance to recover
- https://github.com/trezor/trezor-suite/pull/13273/commits/c65f97a061d155447521f38f70166bbf9cbf2a36 - top-level transport reconnection in core index removed because it doesn't make sense on `setTransports` fail; the only reconnection happens on `TRANSPORT.ERROR`
- https://github.com/trezor/trezor-suite/pull/13273/commits/7d651e64fd91838e79b91353a719739f7158a837 - `TRANSPORT.UPDATE` handler separated into its own method
- https://github.com/trezor/trezor-suite/pull/13273/commits/76894b55644ebeaaa2005d82bc724ea53dc100d4 - isolate waiting for devices in case of `pendingTransportEvent` into a single, well-encapsulated method
- https://github.com/trezor/trezor-suite/pull/13273/commits/606f541f3d0974aca0708ef826a0e7357d54faea - separate init method into stages (select/initialize) which throw errors when necessary, and emit appropriate transport event at the end, so `waitForFirstTransportEvent` is no longer needed
- https://github.com/trezor/trezor-suite/pull/13273/commits/bcf8bd7cf679b9386fd267b77ed4c569372d5d7e - device penalization logic separated into `authPenaltyManager`
- https://github.com/trezor/trezor-suite/pull/13273/commits/552b22cdfad7d0f266fd06a28d42d4465282f4e7 - tiny code improvement (less lines, yaay)
- https://github.com/trezor/trezor-suite/pull/13273/commits/651ccf431619ae8d88b0595f4d7c480368610936 - transport instance is now propagated into the whole `onTransportUpdate` subtree instead of using the class instance one which may or may not be there, which should make it a bit more resilient; **this subtree should be somehow separated from the class in the future**
- https://github.com/trezor/trezor-suite/pull/13273/commits/4b4cbdc81c080c6b9fe76860af154210f1973dd2 - device list can now be connected (when there is active transport) or disconnected (when there isn't); methods requiring active transport should be called only on connected device list; device list connection status is now checked in connect core instead of its presence, so it's now created only once on init
- https://github.com/trezor/trezor-suite/pull/13273/commits/10dec95103d1c0af6fe80b350085815103530e70 - device list is now cleaned up from inside on transport error instead of disposed from outside (e.g. all the listeners are preserved); therefore it can be reused
- https://github.com/trezor/trezor-suite/pull/13273/commits/b87c55f94a5245d9c2783410f175708a1c32e287 - `resolveAfter` util now returns `reject` instead of `timeout`, so it can be aborted without memory leaking (as opposed to clearing the timeout and letting the promise hang forever)
- https://github.com/trezor/trezor-suite/pull/13273/commits/a4d982fe2a2ffd3dc53410e13b7ba3960dcb14eb - transport reconnect logic moved inside device list; in case of transport error, new init promise (including delay) is immediately created and awaitable from outside; **decide what to do when init is called before the previous init finished**
- https://github.com/trezor/trezor-suite/pull/13273/commits/16ad4ac79587edc7fc92af5c84ad7a3c50317cb3 - device list initialization methods are called directly instead of wrapping them inside `initDeviceList`, which should be a bit clearer
- https://github.com/trezor/trezor-suite/pull/13273/commits/14c68b01d0334647bdaea86333629e875a8cfea1 - unit test adjustments

**MUST BE TESTED THOROUGHLY**