### PR TITLE
feat(suite): enable FullRBF (RBF for non-RBF transactions

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
@@ -2,13 +2,7 @@ import styled, { useTheme } from 'styled-components';
 import { Icon, variables, CoinLogo, H3, useElevation } from '@trezor/components';
 import { Translation, FormattedDateWithBullet } from 'src/components/suite';
 import { WalletAccountTransaction, Network } from 'src/types/wallet';
-import {
-    isTxFinal,
-    getTxIcon,
-    isPending,
-    getFeeUnits,
-    getFeeRate,
-} from '@suite-common/wallet-utils';
+import { getTxIcon, isPending, getFeeUnits, getFeeRate } from '@suite-common/wallet-utils';
 import { TransactionHeader } from 'src/components/wallet/TransactionItem/TransactionHeader';
 import { fromWei } from 'web3-utils';
 import { IOAddress } from './IOAddress';
@@ -179,7 +173,6 @@ export const BasicTxDetails = ({
     const theme = useTheme();
     // all solana txs which are fetched are already confirmed
     const isConfirmed = confirmations > 0 || tx.solanaSpecific?.status === 'confirmed';
-    const isFinal = isTxFinal(tx, confirmations);
 
     const { elevation } = useElevation();
 
@@ -284,19 +277,6 @@ export const BasicTxDetails = ({
                             {`${tx?.feeRate ? tx.feeRate : getFeeRate(tx)} ${getFeeUnits(
                                 'bitcoin',
                             )}`}
-                        </Value>
-
-                        {/* RBF Status */}
-                        <Title>
-                            <Translation id="TR_RBF_STATUS" />
-                        </Title>
-
-                        <Value>
-                            <ConfirmationStatus $confirmed={isFinal} $tiny>
-                                <Translation
-                                    id={isFinal ? 'TR_RBF_STATUS_FINAL' : 'TR_RBF_STATUS_NOT_FINAL'}
-                                />
-                            </ConfirmationStatus>
                         </Value>
                     </>
                 )}

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7047,14 +7047,6 @@ export default defineMessages({
         id: 'TR_RBF_STATUS',
         defaultMessage: 'Status',
     },
-    TR_RBF_STATUS_FINAL: {
-        id: 'TR_RBF_STATUS_FINAL',
-        defaultMessage: 'Final',
-    },
-    TR_RBF_STATUS_NOT_FINAL: {
-        id: 'TR_RBF_STATUS_NOT_FINAL',
-        defaultMessage: 'Not final',
-    },
     TR_TXID: {
         id: 'TR_TXID',
         defaultMessage: 'TX ID',

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -600,7 +600,7 @@ const getBitcoinRbfParams = (
     account: Account,
 ): RbfTransactionParams | undefined => {
     if (account.networkType !== 'bitcoin') return;
-    if (tx.type === 'recv' || !tx.rbf || !tx.details || !isPending(tx)) return; // ignore non rbf and mined transactions
+    if (tx.type === 'recv' || !tx.details || !isPending(tx)) return; // ignore mined transactions
     const { vin, vout } = tx.details;
 
     const changeAddresses = account.addresses ? account.addresses.change : [];
@@ -975,10 +975,6 @@ export const advancedSearchTransactions = (
 
     return transactions.filter(t => filteredTxIDs.has(t.txid));
 };
-
-export const isTxFinal = (tx: WalletAccountTransaction, confirmations: number) =>
-    // checks RBF status
-    !tx.rbf || confirmations > 0 || tx.solanaSpecific?.status === 'confirmed';
 
 /**
  * TODO: in case user swaps tokens on SOL/ADA, we probably say that he received SOL/ADA


### PR DESCRIPTION
As many nodes are running with `-mempoolfullrbf=1` anyway, lets allow RBF for **ANY** transactions (event those who have RBF off)

Resolves https://github.com/trezor/trezor-suite/issues/13159
Resolves https://github.com/trezor/trezor-suite/issues/11750

![image](https://github.com/trezor/trezor-suite/assets/152899911/ed8571df-8d2f-4b5f-99c5-fc75c42f29a5)
