### PR TITLE
feat(suite-native): show better message if user is navigated back from web Suite onboarding after FW installation

### DIFF
--- a/suite-native/analytics/src/events.ts
+++ b/suite-native/analytics/src/events.ts
@@ -170,7 +170,11 @@ export type SuiteNativeAnalyticsEvent =
     | {
           type: EventType.UnsupportedDevice;
           payload: {
-              deviceState: 'unsupportedFirmware' | 'noSeed' | 'bootloaderMode';
+              deviceState:
+                  | 'unsupportedFirmware'
+                  | 'noSeed'
+                  | 'bootloaderMode'
+                  | 'noSeedWithFirmware';
           };
       }
     | {

--- a/suite-native/device/src/hooks/useDetectDeviceError.tsx
+++ b/suite-native/device/src/hooks/useDetectDeviceError.tsx
@@ -132,27 +132,50 @@ export const useDetectDeviceError = () => {
             !isUnacquiredDevice &&
             !deviceError
         ) {
-            showAlert({
-                title: <Translation id="moduleDevice.noSeedModal.title" />,
-                textAlign: 'left',
-                description: <Translation id="moduleDevice.noSeedModal.description" />,
-                primaryButtonTitle: <Translation id="moduleDevice.noSeedModal.primaryButton" />,
-                primaryButtonViewLeft: 'arrowLineUpRight',
-                appendix: <UninitializedDeviceModalAppendix />,
-                onPressPrimaryButton: () => {
-                    openLink(SUITE_WEB_URL);
+            if (hasDeviceFirmwareInstalled) {
+                showAlert({
+                    title: <Translation id="moduleDevice.noSeedWithFWModal.title" />,
+                    icon: 'checkCircle',
+                    pictogramVariant: 'green',
+                    description: <Translation id="moduleDevice.noSeedWithFWModal.description" />,
+                    primaryButtonTitle: (
+                        <Translation id="moduleDevice.noSeedWithFWModal.primaryButton" />
+                    ),
+                    primaryButtonViewLeft: 'arrowLineUpRight',
+                    onPressPrimaryButton: () => {
+                        openLink(SUITE_WEB_URL);
 
-                    analytics.report({
-                        type: EventType.UnsupportedDevice,
-                        payload: { deviceState: 'noSeed' },
-                    });
-                },
-                secondaryButtonTitle: <Translation id="generic.buttons.cancel" />,
-                onPressSecondaryButton: handleDisconnect,
-                testID: '@device/errors/alert/no-seed',
-            });
+                        analytics.report({
+                            type: EventType.UnsupportedDevice,
+                            payload: { deviceState: 'noSeedWithFirmware' },
+                        });
+                    },
+                    testID: '@device/errors/alert/no-seed/firmware',
+                });
+            } else {
+                showAlert({
+                    title: <Translation id="moduleDevice.noSeedModal.title" />,
+                    textAlign: 'left',
+                    description: <Translation id="moduleDevice.noSeedModal.description" />,
+                    primaryButtonTitle: <Translation id="moduleDevice.noSeedModal.primaryButton" />,
+                    primaryButtonViewLeft: 'arrowLineUpRight',
+                    appendix: <UninitializedDeviceModalAppendix />,
+                    onPressPrimaryButton: () => {
+                        openLink(SUITE_WEB_URL);
+
+                        analytics.report({
+                            type: EventType.UnsupportedDevice,
+                            payload: { deviceState: 'noSeed' },
+                        });
+                    },
+                    secondaryButtonTitle: <Translation id="generic.buttons.cancel" />,
+                    onPressSecondaryButton: handleDisconnect,
+                    testID: '@device/errors/alert/no-seed',
+                });
+            }
         }
     }, [
+        hasDeviceFirmwareInstalled,
         isConnectedDeviceUninitialized,
         isUnacquiredDevice,
         wasDeviceEjectedByUser,

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -266,6 +266,12 @@ export const en = {
                 },
             },
         },
+        noSeedWithFWModal: {
+            title: 'Firmware installed.\nContinue in your browser to finish device setup.',
+            description:
+                'Follow the instructions in your browser and come back once setup is complete.',
+            primaryButton: 'Finish setup',
+        },
         genericErrorModal: {
             title: 'Please reconnect your Trezor device.',
             description:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

During onboarding via web Suite on phone, right after firmware installation, Trezor appears as a completely new device so new system dialog appears navigating user to Suite Lite app (it can be dismissed, but CTA is to open Suite Lite).

But onboarding is not finished at that point. We can detect that state (firmware is present) and provide better message.

(CTA button lead to new tab in browser (at least in Chrome), but I see no way how to lead to existing tab to continue there and user can open the app in that state even without having Suite Web already opened...)

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/11896 (last part: _4. New requirement: After FW installation via Web Suite_)

## Screenshots:
<img width="350" alt="image" src="https://github.com/trezor/trezor-suite/assets/3729633/1c0364c2-9cdc-4ec9-9a2d-c31186376bc1">

___

video: 
Notes for video:
- UI issues with responsivity reported in https://github.com/trezor/trezor-suite/issues/13261
- After the whole onboarding, Trezor had troubles to connect to Suite Lite right away - It is not consistent, it depends probably on state in Suite Web (i.e. running discovery), but reconnecting the device resolves it, so I don't see it as a blocker.

https://github.com/trezor/trezor-suite/assets/3729633/06e153ee-8f3e-4be4-9541-8ef5447e04e0



