### PR TITLE
fix(suite-native): e2e tests always install yarn

### DIFF
--- a/.github/workflows/test-suite-native-e2e-android.yml
+++ b/.github/workflows/test-suite-native-e2e-android.yml
@@ -95,6 +95,9 @@ jobs:
           path: node_modules
           key: node_modules-${{ github.ref }}
 
+      - name: Install Yarn dependencies
+        run: yarn install
+
       - name: Get device name from detox config file
         id: device
         run: node -e "console.log('AVD_NAME=' + require('./suite-native/app/.detoxrc').devices.emulator.device.avdName)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Yarn install is always executed in the both mobile e2e jobs, so the later one does not rely on Github cache.