### PR TITLE
ci(suite-native): nightly e2e tests

### DIFF
--- a/.github/workflows/test-suite-native-e2e-android.yml
+++ b/.github/workflows/test-suite-native-e2e-android.yml
@@ -1,5 +1,7 @@
 name: "[Test] suite-native Android E2E"
 on:
+  schedule:
+    - cron: "0 0 * * *"
   pull_request:
     paths:
       - "suite-native/**"


### PR DESCRIPTION
## Description
- suite-native e2e tests are executed every day at midnight on the `develop` branch

## Related Issue

Resolve #13288 

