### PR TITLE
fix(wallet-utils): allow tokens without symbol and valid balance

### DIFF
--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -33,6 +33,7 @@ import {
     HELP_CENTER_COINJOIN_URL,
     HELP_CENTER_TAPROOT_URL,
 } from '@trezor/urls';
+import { formatTokenSymbol } from '@trezor/blockchain-link-utils';
 
 import { toFiatCurrency } from './fiatConverterUtils';
 import { getFiatRateKey } from './fiatRatesUtils';
@@ -451,14 +452,16 @@ export const countUniqueCoins = (accounts: Account[]) => {
 export const enhanceTokens = (tokens: Account['tokens']) => {
     if (!tokens) return [];
 
-    return tokens
-        .filter(t => t.symbol && t.balance)
-        .map(t => ({
+    return tokens.map(t => {
+        const symbol = formatTokenSymbol(t.symbol || t.contract);
+
+        return {
             ...t,
-            name: t.name || t.symbol,
-            symbol: t.symbol!.toLowerCase(),
-            balance: formatAmount(t.balance!, t.decimals),
-        }));
+            name: t.name || symbol,
+            symbol: symbol.toLowerCase(),
+            balance: formatAmount(t.balance || 0, t.decimals),
+        };
+    });
 };
 
 const countAddressTransfers = (transactions: AccountTransaction[]) =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- do not filter out any tokens
- use formatter which is used also for solana and cardano in case there is missing symbol
- ignore nonsense `toLowerCase`, there is another issue for that. Symbols can be mixed case

## Related Issue

Resolve  #13322

## Screenshots:
![Screenshot 2024-07-14 at 20 30 54](https://github.com/user-attachments/assets/52d6103d-424a-40fb-a1aa-3c2982f7a75f)

