### PR TITLE
fix(suite): allow gas price decimals

### DIFF
--- a/packages/suite/src/components/wallet/Fees/CustomFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/CustomFee.tsx
@@ -131,7 +131,7 @@ export const CustomFee = <TFieldValues extends FormState>({
             }),
             // GWEI: 9 decimal places
             ethereumDecimalsLimit: validateDecimals(translationString, {
-                decimals: 2,
+                decimals: 9,
                 except: networkType !== 'ethereum',
             }),
             range: (value: string) => {

--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -1121,13 +1121,13 @@ export const setMax = [
             composedLevels: {
                 normal: {
                     type: 'final',
-                    fee: '63000000000000',
+                    fee: '69300000000000',
                     totalSpent: '10000000000000000000',
                 },
                 custom: undefined,
             },
             formValues: {
-                outputs: [{ amount: '9.999937', fiat: '10.00' }],
+                outputs: [{ amount: '9.9999307', fiat: '10.00' }],
             },
         },
     },
@@ -1153,7 +1153,7 @@ export const setMax = [
             composedLevels: {
                 normal: {
                     type: 'final',
-                    fee: '63000000000000',
+                    fee: '69300000000000',
                     totalSpent: '1000', // tokens
                 },
                 custom: undefined,
@@ -1816,7 +1816,7 @@ export const feeChange = [
                     estimateFeeCalls: 1,
                     formValues: {
                         selectedFee: 'custom' as const,
-                        feePerUnit: '3',
+                        feePerUnit: '3.3',
                         feeLimit: '21000', // default
                         estimatedFeeLimit: '21000',
                     },
@@ -1831,7 +1831,7 @@ export const feeChange = [
                     estimateFeeCalls: 2,
                     formValues: {
                         outputs: [{ amount: '1.1' }],
-                        feePerUnit: '3',
+                        feePerUnit: '3.3',
                         feeLimit: '41000', // feeLimit is switched automatically
                         estimatedFeeLimit: '41000',
                     },
@@ -1846,7 +1846,7 @@ export const feeChange = [
                     estimateFeeCalls: 2,
                     formValues: {
                         outputs: [{ amount: '1.1' }],
-                        feePerUnit: '3',
+                        feePerUnit: '3.3',
                         feeLimit: '4100',
                         estimatedFeeLimit: '41000',
                     },
@@ -1867,7 +1867,7 @@ export const feeChange = [
                     formValues: {
                         outputs: [{ amount: '1.1' }],
                         selectedFee: 'custom' as const,
-                        feePerUnit: '3',
+                        feePerUnit: '3.3',
                         feeLimit: '21009', // feeLimit is switched automatically again
                         estimatedFeeLimit: '21009',
                     },
@@ -1925,7 +1925,7 @@ export const feeChange = [
                 result: {
                     formValues: {
                         selectedFee: 'custom' as const,
-                        feePerUnit: '3',
+                        feePerUnit: '3.3',
                         feeLimit: '21',
                         estimatedFeeLimit: '21009',
                     },
@@ -1954,8 +1954,8 @@ export const feeChange = [
                     composedLevels: {
                         normal: {
                             type: 'final',
-                            fee: '63000000000000',
-                            feePerByte: '3',
+                            fee: '69300000000000',
+                            feePerByte: '3.3',
                             feeLimit: '21000', // default
                         },
                         custom: undefined, // no custom level build

--- a/packages/suite/src/hooks/wallet/useRbfForm.ts
+++ b/packages/suite/src/hooks/wallet/useRbfForm.ts
@@ -40,9 +40,7 @@ const getBitcoinFeeInfo = (info: FeeInfo, feeRate: string) => {
 
 const getEthereumFeeInfo = (info: FeeInfo, gasPrice: string) => {
     const current = new BigNumber(gasPrice);
-    const minFeeFromNetwork = new BigNumber(
-        fromWei(info.levels[0].feePerUnit, 'gwei'),
-    ).integerValue(BigNumber.ROUND_FLOOR);
+    const minFeeFromNetwork = new BigNumber(fromWei(info.levels[0].feePerUnit, 'gwei'));
 
     const getFee = () => {
         if (minFeeFromNetwork.lte(current)) {

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -161,14 +161,14 @@ export const getFeeLevels = (networkType: Network['networkType'], feeInfo: FeeIn
     });
 
     if (networkType === 'ethereum') {
-        // convert wei to gwei and floor value to avoid decimals
+        // convert wei to gwei
         return levels.map(level => {
             const gwei = new BigNumber(fromWei(level.feePerUnit, 'gwei'));
             // blockbook/geth may return 0 in feePerUnit. if this happens set at least minFee
             const feePerUnit =
                 level.label !== 'custom' && gwei.lt(feeInfo.minFee)
                     ? feeInfo.minFee.toString()
-                    : gwei.integerValue(BigNumber.ROUND_FLOOR).toString();
+                    : gwei.toString();
 
             return {
                 ...level,


### PR DESCRIPTION
## Description

- use gas price returned from Blockbook
- because of this a lot of transactions get stuck, especially nowdays staking
- gas price never gets to 1.0 but it gets to e.g. 1.3 but we floor it down, so user is stuck forever
- nowdays 1.xxx is like 30% of a day
- if we do another release 24.7.xxx it would be nice to get this there to fix staking stuck txs @MiroslavProchazka  see screen below

https://satoshilabs.slack.com/archives/C05KVPV16SV/p1720798798038199
https://etherscan.io/txsPending?a=0xD523794C879D9eC028960a231F866758e405bE34&m=hf&ps=100

## Related Issue

Resolve #12903
Resolve #13329

## Screenshots:
Eth: User gets stuck forever because on production he gets 1
![Screenshot 2024-07-14 at 23 01 37](https://github.com/user-attachments/assets/3308098a-708c-4c5e-b495-1dc2474b680a)
Production: never mined
![Screenshot 2024-07-14 at 23 04 31](https://github.com/user-attachments/assets/7237332d-8762-4fd3-809e-a7185026d83c)
Now:
![Screenshot 2024-07-14 at 23 05 19](https://github.com/user-attachments/assets/9f94a67a-0553-45c2-93c5-65ecebbc4303)


Matic:
![Screenshot 2024-07-14 at 23 01 42](https://github.com/user-attachments/assets/f61706f2-cd80-49ee-be47-ca6696132e14)
![Screenshot 2024-07-14 at 23 01 49](https://github.com/user-attachments/assets/c223f6aa-ba99-4039-8437-6e2c7b3554fd)


Mined tx:
![Screenshot 2024-07-14 at 23 34 52](https://github.com/user-attachments/assets/f799f578-17b3-4067-b992-b753bff4ce99)

