### PR TITLE
Transport bridge configure

### DIFF
--- a/packages/node-utils/src/http.ts
+++ b/packages/node-utils/src/http.ts
@@ -11,11 +11,11 @@ import { getFreePort } from './getFreePort';
 type Request = RequiredKey<http.IncomingMessage, 'url'>;
 type EventMap = { [event: string]: any };
 
-type RequestWithParams = Request & {
+export type RequestWithParams = Request & {
     params: Record<string, string>;
 };
 
-type Response = http.ServerResponse;
+export type Response = http.ServerResponse;
 
 type Next<R extends Request = RequestWithParams> = (
     request: R,

--- a/packages/node-utils/src/index.ts
+++ b/packages/node-utils/src/index.ts
@@ -7,4 +7,6 @@ export {
     parseBodyJSON,
     parseBodyText,
     type Handler,
+    type RequestWithParams,
+    type Response,
 } from './http';


### PR DESCRIPTION
while investigating #13230 I found that packages/transport-bridge does not implement the [/configure endpoint](https://github.com/trezor/trezord-go/blob/db03d99230f5b609a354e3586f1dfc0ad6da16f7/server/api/api.go#L36)

we are not using it but could be that some legacy software does. so lets keep it compatible.