### PR TITLE
fix(suite): adapting desktop tests to view-only

### DIFF
--- a/packages/suite-desktop-core/e2e/playwright.config.ts
+++ b/packages/suite-desktop-core/e2e/playwright.config.ts
@@ -12,7 +12,7 @@ const config: PlaywrightTestConfig = {
         testIdAttribute: 'data-test',
     },
     reportSlowTests: null,
-    reporter: [['list'], ['@currents/playwright']],
+    reporter: process.env.GITHUB_ACTION ? [['list'], ['@currents/playwright']] : [['list']],
     timeout: 1000 * 60 * 30,
     outputDir: path.join(__dirname, 'test-results'),
 };

--- a/packages/suite-desktop-core/e2e/support/pageActions/dashboardActions.ts
+++ b/packages/suite-desktop-core/e2e/support/pageActions/dashboardActions.ts
@@ -9,6 +9,10 @@ class DashboardActions {
         await waitForDataTestSelector(window, '@welcome/title');
         await window.getByTestId('@analytics/continue-button').click();
         await window.getByTestId('@onboarding/exit-app-button').click();
+        await window.getByTestId('@onbarding/viewOnly/enable').click();
+        const viewOnlyTooltip = window.getByTestId('@viewOnlyTooltip/gotIt');
+        await viewOnlyTooltip.waitFor({ state: 'visible' });
+        await viewOnlyTooltip.click();
     }
 
     async discoveryShouldFinish(window: Page) {
@@ -33,14 +37,15 @@ class DashboardActions {
     }
 
     async ejectWallet(deviceSwitcher: Locator, walletName: string) {
-        const wallet = await deviceSwitcher.locator(
-            '[data-test^="@switch-device/wallet-on-index"]',
-            {
-                hasText: walletName,
-            },
-        );
+        const wallet = deviceSwitcher.locator('[data-test^="@switch-device/wallet-on-index"]', {
+            hasText: walletName,
+        });
         if (await wallet.isVisible()) {
             await wallet.locator('[data-test$="eject-button"]').click();
+            await deviceSwitcher
+                .getByTestId('@switch-device/wallet-on-index/0/eject-button')
+                .click();
+            await wallet.getByTestId('@switch-device/eject').click();
         }
         await wallet.waitFor({ state: 'detached' });
     }

--- a/packages/suite-desktop-core/e2e/tests/general/eap-modal.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/general/eap-modal.test.ts
@@ -4,8 +4,9 @@ import {
     Page,
     expect as expectPlaywright,
 } from '@playwright/test';
+import { sync as rimrafSync } from 'rimraf';
 
-import { launchSuite, rmDirRecursive } from '../../support/common';
+import { launchSuite } from '../../support/common';
 import { onTopBar } from '../../support/pageActions/topBarActions';
 import { onSettingsPage } from '../../support/pageActions/settingsActions';
 
@@ -15,7 +16,7 @@ let localDataDir: string;
 
 testPlaywright.beforeAll(async () => {
     ({ electronApp, window, localDataDir } = await launchSuite());
-    rmDirRecursive(localDataDir);
+    rimrafSync(localDataDir);
 });
 
 testPlaywright.afterAll(() => {

--- a/packages/suite-desktop-core/e2e/tests/general/suite-guide.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/general/suite-guide.test.ts
@@ -4,9 +4,9 @@ import {
     ElectronApplication,
     Page,
 } from '@playwright/test';
-import * as rimraf from 'rimraf';
+import { sync as rimrafSync } from 'rimraf';
 
-import { launchSuite, rmDirRecursive } from '../../support/common';
+import { launchSuite } from '../../support/common';
 import { onSuiteGuidePage } from '../../support/pageActions/suiteGuideActions';
 
 let electronApp: ElectronApplication;
@@ -15,8 +15,7 @@ let localDataDir: string;
 
 testPlaywright.beforeAll(async () => {
     ({ electronApp, window, localDataDir } = await launchSuite());
-    rimraf.sync(localDataDir);
-    // rmDirRecursive(localDataDir);
+    rimrafSync(localDataDir);
 });
 
 testPlaywright.afterEach(async () => {

--- a/packages/suite-desktop-core/e2e/tests/general/suite-guide.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/general/suite-guide.test.ts
@@ -4,6 +4,7 @@ import {
     ElectronApplication,
     Page,
 } from '@playwright/test';
+import * as rimraf from 'rimraf';
 
 import { launchSuite, rmDirRecursive } from '../../support/common';
 import { onSuiteGuidePage } from '../../support/pageActions/suiteGuideActions';
@@ -14,7 +15,8 @@ let localDataDir: string;
 
 testPlaywright.beforeAll(async () => {
     ({ electronApp, window, localDataDir } = await launchSuite());
-    rmDirRecursive(localDataDir);
+    rimraf.sync(localDataDir);
+    // rmDirRecursive(localDataDir);
 });
 
 testPlaywright.afterEach(async () => {

--- a/packages/suite-desktop-core/e2e/tests/general/wallet-discovery.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/general/wallet-discovery.test.ts
@@ -1,8 +1,9 @@
 import { test as testPlaywright, ElectronApplication, Page } from '@playwright/test';
+import { sync as rimrafSync } from 'rimraf';
 
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link/src';
 
-import { launchSuite, rmDirRecursive } from '../../support/common';
+import { launchSuite } from '../../support/common';
 import { onDashboardPage } from '../../support/pageActions/dashboardActions';
 
 let electronApp: ElectronApplication;
@@ -17,7 +18,7 @@ testPlaywright.beforeAll(async () => {
         mnemonic: 'all all all all all all all all all all all all',
     });
     ({ electronApp, window, localDataDir } = await launchSuite());
-    rmDirRecursive(localDataDir);
+    rimrafSync(localDataDir);
 });
 
 testPlaywright.afterAll(() => {
@@ -36,6 +37,8 @@ testPlaywright('Discover a standard wallet', async () => {
     const deviceSwitcher = await onDashboardPage.openDeviceSwitcherAndReturnWindow(window);
     await onDashboardPage.ejectWallet(deviceSwitcher, 'Standard wallet');
     await onDashboardPage.addStandardWallet(window);
+
+    await window.pause();
 
     await onDashboardPage.assertHasVisibleBalanceOnFirstAccount(window, 'btc');
 });

--- a/packages/suite-desktop-core/e2e/tests/settings/electrum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/electrum.test.ts
@@ -1,8 +1,9 @@
 import { test as testPlaywright, ElectronApplication, Page } from '@playwright/test';
+import { sync as rimrafSync } from 'rimraf';
 
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
-import { launchSuite, rmDirRecursive } from '../../support/common';
+import { launchSuite } from '../../support/common';
 import { onTopBar } from '../../support/pageActions/topBarActions';
 import { onSettingsPage } from '../../support/pageActions/settingsActions';
 import { onDashboardPage } from '../../support/pageActions/dashboardActions';
@@ -21,7 +22,7 @@ testPlaywright.describe.serial('Suite works with Electrum server', () => {
             mnemonic: 'all all all all all all all all all all all all',
         });
         ({ electronApp, window, localDataDir } = await launchSuite());
-        rmDirRecursive(localDataDir);
+        rimrafSync(localDataDir);
     });
 
     testPlaywright.afterAll(() => {

--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -52,6 +52,7 @@
         "@types/electron-localshortcut": "^3.1.3",
         "electron": "27.3.8",
         "glob": "^10.3.10",
+        "rimraf": "^6.0.1",
         "terser-webpack-plugin": "^5.3.9",
         "webpack": "^5.90.1",
         "xvfb-maybe": "^0.2.1"

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
@@ -143,10 +143,9 @@ export const WalletInstance = ({
         contentType === 'disabling-view-only-ejects-wallet';
 
     return (
-        <RelativeContainer>
+        <RelativeContainer data-test={dataTestBase}>
             <EjectButton setContentType={setContentType} dataTest={dataTestBase} />
             <Card
-                data-test={dataTestBase}
                 key={`${instance.label}${instance.instance}${instance.state}`}
                 paddingType="small"
                 onClick={handleClick}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11148,6 +11148,7 @@ __metadata:
     electron-updater: "npm:6.1.8"
     glob: "npm:^10.3.10"
     openpgp: "npm:^5.11.0"
+    rimraf: "npm:^6.0.1"
     systeminformation: "npm:^5.21.24"
     terser-webpack-plugin: "npm:^5.3.9"
     webpack: "npm:^5.90.1"
@@ -23265,6 +23266,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "glob@npm:11.0.0"
+  dependencies:
+    foreground-child: "npm:^3.1.0"
+    jackspeak: "npm:^4.0.1"
+    minimatch: "npm:^10.0.0"
+    minipass: "npm:^7.1.2"
+    package-json-from-dist: "npm:^1.0.0"
+    path-scurry: "npm:^2.0.0"
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: 10/e66939201d11ae30fe97e3364ac2be5c59d6c9bfce18ac633edfad473eb6b46a7553f6f73658f67caaf6cccc1df1ae336298a45e9021fa5695fd78754cc1603e
+  languageName: node
+  linkType: hard
+
 "glob@npm:^6.0.1":
   version: 6.0.4
   resolution: "glob@npm:6.0.4"
@@ -25813,6 +25830,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jackspeak@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "jackspeak@npm:4.0.1"
+  dependencies:
+    "@isaacs/cliui": "npm:^8.0.2"
+    "@pkgjs/parseargs": "npm:^0.11.0"
+  dependenciesMeta:
+    "@pkgjs/parseargs":
+      optional: true
+  checksum: 10/b20dc0df0dbb2903e4d540ae68308ec7d1dd60944b130e867e218c98b5d77481d65ea734b6c81c812d481500076e8b3fdfccfb38fc81cb1acf165e853da3e26c
+  languageName: node
+  linkType: hard
+
 "jake@npm:^10.8.5":
   version: 10.8.5
   resolution: "jake@npm:10.8.5"
@@ -28258,6 +28288,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-cache@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "lru-cache@npm:11.0.0"
+  checksum: 10/41f36fbff8b6f199cce3e9cb2b625714f97a535dfd7f16d0988c2627f9ed4c38b6dc8f9ea7fdba19262a7c917ba41c89cad15ca3e3791fc9a2068af472b5bc8d
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^4.0.1":
   version: 4.1.5
   resolution: "lru-cache@npm:4.1.5"
@@ -30513,6 +30550,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:^10.0.0":
+  version: 10.0.1
+  resolution: "minimatch@npm:10.0.1"
+  dependencies:
+    brace-expansion: "npm:^2.0.1"
+  checksum: 10/082e7ccbc090d5f8c4e4e029255d5a1d1e3af37bda837da2b8b0085b1503a1210c91ac90d9ebfe741d8a5f286ece820a1abb4f61dc1f82ce602a055d461d93f3
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^5.0.1, minimatch@npm:^5.1.1":
   version: 5.1.6
   resolution: "minimatch@npm:5.1.6"
@@ -30631,7 +30677,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minipass@npm:^5.0.0 || ^6.0.2 || ^7.0.0, minipass@npm:^7.0.3, minipass@npm:^7.0.4":
+"minipass@npm:^5.0.0 || ^6.0.2 || ^7.0.0, minipass@npm:^7.0.3, minipass@npm:^7.0.4, minipass@npm:^7.1.2":
   version: 7.1.2
   resolution: "minipass@npm:7.1.2"
   checksum: 10/c25f0ee8196d8e6036661104bacd743785b2599a21de5c516b32b3fa2b83113ac89a2358465bc04956baab37ffb956ae43be679b2262bf7be15fce467ccd7950
@@ -32266,6 +32312,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"package-json-from-dist@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "package-json-from-dist@npm:1.0.0"
+  checksum: 10/ac706ec856a5a03f5261e4e48fa974f24feb044d51f84f8332e2af0af04fbdbdd5bbbfb9cbbe354190409bc8307c83a9e38c6672c3c8855f709afb0006a009ea
+  languageName: node
+  linkType: hard
+
 "pako@npm:^0.2.5, pako@npm:~0.2.0":
   version: 0.2.9
   resolution: "pako@npm:0.2.9"
@@ -32584,6 +32637,16 @@ __metadata:
     lru-cache: "npm:^9.1.1 || ^10.0.0"
     minipass: "npm:^5.0.0 || ^6.0.2 || ^7.0.0"
   checksum: 10/eebfb8304fef1d4f7e1486df987e4fd77413de4fce16508dea69fcf8eb318c09a6b15a7a2f4c22877cec1cb7ecbd3071d18ca9de79eeece0df874a00f1f0bdc8
+  languageName: node
+  linkType: hard
+
+"path-scurry@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "path-scurry@npm:2.0.0"
+  dependencies:
+    lru-cache: "npm:^11.0.0"
+    minipass: "npm:^7.1.2"
+  checksum: 10/285ae0c2d6c34ae91dc1d5378ede21981c9a2f6de1ea9ca5a88b5a270ce9763b83dbadc7a324d512211d8d36b0c540427d3d0817030849d97a60fa840a2c59ec
   languageName: node
   linkType: hard
 
@@ -36129,6 +36192,18 @@ __metadata:
   bin:
     rimraf: dist/esm/bin.mjs
   checksum: 10/a612c7184f96258b7d1328c486b12ca7b60aa30e04229a08bbfa7e964486deb1e9a1b52d917809311bdc39a808a4055c0f950c0280fba194ba0a09e6f0d404f6
+  languageName: node
+  linkType: hard
+
+"rimraf@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "rimraf@npm:6.0.1"
+  dependencies:
+    glob: "npm:^11.0.0"
+    package-json-from-dist: "npm:^1.0.0"
+  bin:
+    rimraf: dist/esm/bin.mjs
+  checksum: 10/0eb7edf08aa39017496c99ba675552dda11a20811ba78f8232da2ba945308c91e9cd673f95998b1a8202bc7436d33390831d23ea38ae52751038d56373ad99e2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- adapting desktop tests to match the new view-only feature

- using `rimraf` package instead of our custom `rmDirRecursive`
- adjusting pw reporter settings to require current.dev credentials only in CI