### PR TITLE
fix(transport-bridge): release interface inside /release endpoint

### DIFF
--- a/packages/transport-bridge/src/http.ts
+++ b/packages/transport-bridge/src/http.ts
@@ -251,7 +251,7 @@ export class TrezordNode {
 
                                 return res.end(str({ error: result.error }));
                             }
-                            res.end(str(result.payload));
+                            res.end(result.payload);
                         });
                 },
             ]);
@@ -268,7 +268,8 @@ export class TrezordNode {
 
                                 return res.end(str({ error: result.error }));
                             }
-                            res.end(str(result.payload));
+
+                            res.end(result.payload);
                         });
                 },
             ]);

--- a/packages/transport-bridge/src/http.ts
+++ b/packages/transport-bridge/src/http.ts
@@ -222,8 +222,6 @@ export class TrezordNode {
                     this.api
                         .release({
                             session: req.params.session as Session,
-                            // @ts-expect-error
-                            path: req.body,
                         })
                         .then(result => {
                             if (!result.success) {


### PR DESCRIPTION
resolve #13230 thanks for reporting!

the problem was that transport bridge never released its exclusive access to the device causing it to error with "DeviceBusy"

<img width="1424" alt="image" src="https://github.com/user-attachments/assets/93046a0a-509b-4d0e-8c42-d8ead0563325">

<img width="1906" alt="image" src="https://github.com/user-attachments/assets/0905edc4-fc6e-4a1a-bc29-873ea40fc6a9">
