### PR TITLE
Fix/native/remove passphrase device on pin cancel

### DIFF
--- a/suite-native/module-authorize-device/src/components/connect/ConnectDeviceScreenHeader.tsx
+++ b/suite-native/module-authorize-device/src/components/connect/ConnectDeviceScreenHeader.tsx
@@ -43,9 +43,6 @@ export const ConnectDeviceScreenHeader = ({
     const isCreatingNewWalletInstance = useSelector(selectIsCreatingNewPassphraseWallet);
 
     const handleCancel = useCallback(() => {
-        // Remove unauthorized passphrase device if it was created before prompting the PIN.
-        if (isCreatingNewWalletInstance) dispatch(cancelPassphraseAndSelectStandardDeviceThunk());
-
         if (isDiscoveryActive) {
             // Do not allow to cancel PIN entry while discovery is in progress
             showAlert({
@@ -61,6 +58,10 @@ export const ConnectDeviceScreenHeader = ({
                 onPressPrimaryButton: hideAlert,
             });
         } else {
+            // Remove unauthorized passphrase device if it was created before prompting the PIN.
+            if (isCreatingNewWalletInstance)
+                dispatch(cancelPassphraseAndSelectStandardDeviceThunk());
+
             TrezorConnect.cancel('pin-cancelled');
             if (navigation.canGoBack()) {
                 navigation.goBack();

--- a/suite-native/module-authorize-device/src/components/connect/ConnectDeviceScreenView.tsx
+++ b/suite-native/module-authorize-device/src/components/connect/ConnectDeviceScreenView.tsx
@@ -6,7 +6,7 @@ import { prepareNativeStyle, useNativeStyles, NativeStyleObject } from '@trezor/
 
 import { ConnectDeviceScreenHeader } from './ConnectDeviceScreenHeader';
 
-type ConnectDeviceSreenViewProps = {
+type ConnectDeviceScreenViewProps = {
     children: ReactNode;
     style?: NativeStyleObject;
     shouldDisplayCancelButton?: boolean;
@@ -16,11 +16,11 @@ const contentStyle = prepareNativeStyle(_ => ({
     flex: 1,
 }));
 
-export const ConnectDeviceSreenView = ({
+export const ConnectDeviceScreenView = ({
     children,
     style,
     shouldDisplayCancelButton,
-}: ConnectDeviceSreenViewProps) => {
+}: ConnectDeviceScreenViewProps) => {
     const { applyStyle } = useNativeStyles();
 
     return (

--- a/suite-native/module-authorize-device/src/components/connect/PinOnDevice.tsx
+++ b/suite-native/module-authorize-device/src/components/connect/PinOnDevice.tsx
@@ -54,7 +54,13 @@ export const PinOnDevice = ({ deviceModel }: PinOnDeviceProps) => {
         if (navigation.canGoBack() && !hasDeviceRequestedPassphrase) {
             navigation.goBack();
         }
-    }, [hasDeviceRequestedPassphrase, navigation]);
+    }, [
+        hasDeviceRequestedPassphrase,
+        hasPassphraseError,
+        isCreatingNewWalletInstance,
+        dispatch,
+        navigation,
+    ]);
 
     useEffect(() => {
         // hasDeviceRequestedPin is false when the user unlocks the device again

--- a/suite-native/module-authorize-device/src/screens/connect/ConnectingDeviceScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/connect/ConnectingDeviceScreen.tsx
@@ -6,7 +6,7 @@ import { useNativeStyles, prepareNativeStyle } from '@trezor/styles';
 import { useDelayedNavigation } from '@suite-native/device';
 import { Translation } from '@suite-native/intl';
 
-import { ConnectDeviceSreenView } from '../../components/connect/ConnectDeviceSreenView';
+import { ConnectDeviceScreenView } from '../../components/connect/ConnectDeviceScreenView';
 
 const screenStyle = prepareNativeStyle(() => ({
     justifyContent: 'center',
@@ -19,7 +19,7 @@ export const ConnectingDeviceScreen = () => {
     const { applyStyle } = useNativeStyles();
 
     return (
-        <ConnectDeviceSreenView style={applyStyle(screenStyle)} shouldDisplayCancelButton={false}>
+        <ConnectDeviceScreenView style={applyStyle(screenStyle)} shouldDisplayCancelButton={false}>
             <VStack spacing="medium" alignItems="center">
                 <ActivityIndicator size="large" />
                 <Box flexDirection="row" alignItems="center">
@@ -34,6 +34,6 @@ export const ConnectingDeviceScreen = () => {
                     <Translation id="moduleConnectDevice.connectingDeviceScreen.hodlOn" />
                 </Text>
             </VStack>
-        </ConnectDeviceSreenView>
+        </ConnectDeviceScreenView>
     );
 };

--- a/suite-native/module-authorize-device/src/screens/connect/PinScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/connect/PinScreen.tsx
@@ -4,7 +4,7 @@ import { Image, VStack } from '@suite-native/atoms';
 import { DeviceModelInternal } from '@trezor/connect';
 import { selectDeviceModel } from '@suite-common/wallet-core';
 
-import { ConnectDeviceSreenView } from '../../components/connect/ConnectDeviceSreenView';
+import { ConnectDeviceScreenView } from '../../components/connect/ConnectDeviceScreenView';
 import { PinForm } from '../../components/connect/PinForm';
 import { PinOnDevice, deviceImageMap } from '../../components/connect/PinOnDevice';
 
@@ -14,7 +14,7 @@ export const PinScreen = () => {
     if (!deviceModel) return null;
 
     return (
-        <ConnectDeviceSreenView>
+        <ConnectDeviceScreenView>
             {deviceModel === DeviceModelInternal.T1B1 ? (
                 <VStack spacing="medium" alignItems="center" flex={1} marginTop="large">
                     <Image source={deviceImageMap[deviceModel]} width={161} height={194} />
@@ -23,6 +23,6 @@ export const PinScreen = () => {
             ) : (
                 <PinOnDevice deviceModel={deviceModel} />
             )}
-        </ConnectDeviceSreenView>
+        </ConnectDeviceScreenView>
     );
 };


### PR DESCRIPTION
## Description
- on PIN cancel while adding Passphrase device, the newly created device instance is correctly removed.
## Related Issue

Resolve #13192 

## Screenshots:

https://github.com/user-attachments/assets/ad9e033e-e443-4679-839d-acdfe8432f40

