### PR TITLE
fix(suite): Make "Receive", "Buy" buttons in some screens more responsive

### DIFF
--- a/packages/suite/src/views/dashboard/components/PortfolioCard/components/Header.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/components/Header.tsx
@@ -13,7 +13,7 @@ import { spacingsPx } from '@trezor/theme';
 const Wrapper = styled.div<{ $hideBorder: boolean }>`
     display: flex;
     flex-flow: row wrap;
-    padding: 20px;
+    padding: ${spacingsPx.lg};
     ${({ $hideBorder }) =>
         !$hideBorder &&
         css`
@@ -36,10 +36,11 @@ const Right = styled.div`
 const Buttons = styled.div`
     display: flex;
     gap: ${spacingsPx.md};
+    flex-flow: row wrap;
+`;
 
-    > * {
-        min-width: 120px;
-    }
+const WalletEmptyButton = styled(Button)`
+    min-width: 120px;
 `;
 
 export interface HeaderProps {
@@ -84,16 +85,19 @@ export const Header = ({
             actions = (
                 <>
                     <Buttons>
-                        <Button onClick={receiveClickHandler} data-test="@dashboard/receive-button">
+                        <WalletEmptyButton
+                            onClick={receiveClickHandler}
+                            data-test="@dashboard/receive-button"
+                        >
                             <Translation id="TR_RECEIVE" />
-                        </Button>
-                        <Button
+                        </WalletEmptyButton>
+                        <WalletEmptyButton
                             onClick={buyClickHandler}
                             data-test="@dashboard/buy-button"
                             variant="tertiary"
                         >
                             <Translation id="TR_BUY" />
-                        </Button>
+                        </WalletEmptyButton>
                     </Buttons>
                 </>
             );

--- a/packages/suite/src/views/wallet/transactions/components/AccountEmpty.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/AccountEmpty.tsx
@@ -6,6 +6,7 @@ import { Translation } from 'src/components/suite';
 import { useDispatch } from 'src/hooks/suite';
 import { Account } from 'src/types/wallet';
 import { goto } from 'src/actions/suite/routerActions';
+import { spacingsPx } from '@trezor/theme';
 
 const Wrapper = styled.div`
     display: flex;
@@ -21,7 +22,7 @@ const StyledCard = styled(Card)`
 const Title = styled(H2)`
     text-align: center;
     font-weight: 600;
-    margin-bottom: 16px;
+    margin-bottom: ${spacingsPx.md};
 `;
 
 const Description = styled.span`
@@ -42,15 +43,13 @@ const Actions = styled.div`
     display: flex;
     justify-content: center;
     width: 100%;
-    margin-bottom: 20px;
+    margin-bottom: ${spacingsPx.lg};
+    flex-flow: row wrap;
+    gap: ${spacingsPx.md};
 `;
 
 const ActionButton = styled(Button)`
     min-width: 160px;
-
-    & + & {
-        margin-left: 20px;
-    }
 `;
 
 const Divider = styled.div`


### PR DESCRIPTION
## Description

Also use `spacingsPx` for some css padding/margin values instead, where possible.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/13261

## Screenshots:
**Before:**
![receive_before](https://github.com/user-attachments/assets/da038b3a-a655-4f3e-8930-188018065318)
![b_before](https://github.com/user-attachments/assets/13833b69-fe7a-48de-8930-af5b21c451f5)

**After:**
![receive_after](https://github.com/user-attachments/assets/0b205171-0403-4b1a-934a-a792cd85fd60)
![b_after](https://github.com/user-attachments/assets/56d64b92-a5c7-4ac4-aee2-b560e6a1d639)


