### PR TITLE
chore(wallet-core): lint warnings fix

### DIFF
--- a/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
@@ -25,12 +25,12 @@ import {
     ExternalOutput,
 } from '@suite-common/wallet-types';
 import { AddressDisplayOptions } from '@suite-common/wallet-types';
+import { getTxStakeNameByDataHex } from '@suite-common/suite-utils';
 
 import { selectDevice } from '../device/deviceReducer';
 import { selectTransactions } from '../transactions/transactionsReducer';
 import { ComposeTransactionThunkArguments, SignTransactionThunkArguments } from './sendFormTypes';
 import { SEND_MODULE_PREFIX } from './sendFormConstants';
-import { getTxStakeNameByDataHex } from '@suite-common/suite-utils';
 import { STAKE_GAS_LIMIT_RESERVE } from '../stake/stakeTypes';
 
 const calculate = (


### PR DESCRIPTION
noted some warnings in a PR 
<img width="821" alt="image" src="https://github.com/user-attachments/assets/b859b3a2-4108-4b81-927e-315c70e7dce0">

shouldn't the lint checks be turned to error instead of warning?