### PR TITLE
fix(suite): Don't show ViewOnlyTooltip when promo banner wasn't closed

### DIFF
--- a/packages/suite/src/views/settings/SettingsDebug/ViewOnlySettings.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/ViewOnlySettings.tsx
@@ -41,7 +41,10 @@ export const ViewOnlySettings = () => {
             </SectionItem>
 
             <SectionItem>
-                <TextColumn title="Set viewOnlyTooltipClosed" />
+                <TextColumn
+                    title="Set viewOnlyTooltipClosed"
+                    description="To show tooltip in the app you also need to set viewOnlyPromoClosed = true"
+                />
                 <ActionColumn>
                     <Checkbox
                         isChecked={viewOnlyTooltipClosed}

--- a/packages/suite/src/views/view-only/ViewOnlyTooltip.tsx
+++ b/packages/suite/src/views/view-only/ViewOnlyTooltip.tsx
@@ -48,8 +48,10 @@ const Content = styled.div`
 `;
 
 export const ViewOnlyTooltip = ({ children }: ViewOnlyTooltipProps) => {
-    const { viewOnlyTooltipClosed, isViewOnlyModeVisible } = useSelector(selectSuiteFlags);
+    const { viewOnlyTooltipClosed, viewOnlyPromoClosed, isViewOnlyModeVisible } =
+        useSelector(selectSuiteFlags);
     const dispatch = useDispatch();
+    const isOpen = isViewOnlyModeVisible && viewOnlyPromoClosed && !viewOnlyTooltipClosed;
 
     const handleClose = () => {
         dispatch(setFlag('viewOnlyTooltipClosed', true));
@@ -59,7 +61,7 @@ export const ViewOnlyTooltip = ({ children }: ViewOnlyTooltipProps) => {
     return (
         <Tooltip
             hasArrow
-            isOpen={isViewOnlyModeVisible === true && viewOnlyTooltipClosed === false}
+            isOpen={isOpen}
             shift={{ padding: { left: 10 } }}
             zIndex={zIndices.navigationBar}
             content={


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

https://satoshilabs.slack.com/archives/C05R69DBKSN/p1721125483638829?thread_ts=1721124444.108459&cid=C05R69DBKSN

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
