### PR TITLE
minor e2e updates

### DIFF
--- a/packages/suite-desktop-core/e2e/support/common.ts
+++ b/packages/suite-desktop-core/e2e/support/common.ts
@@ -2,7 +2,7 @@
 
 import { Page, _electron as electron } from '@playwright/test';
 import path from 'path';
-import fs from 'fs';
+import fse from 'fs-extra';
 
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
@@ -51,7 +51,7 @@ export const launchSuite = async (params: LaunchSuiteParams = {}) => {
     const localDataDir = await electronApp.evaluate(({ app }) => app.getPath('userData'));
 
     if (options.rmUserData) {
-        fs.rmSync(localDataDir, { recursive: true, force: true });
+        fse.removeSync(localDataDir);
     }
 
     return { electronApp, window, localDataDir };

--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -51,6 +51,7 @@
         "@trezor/type-utils": "workspace:*",
         "@types/electron-localshortcut": "^3.1.3",
         "electron": "27.3.8",
+        "fs-extra": "^11.2.0",
         "glob": "^10.3.10",
         "terser-webpack-plugin": "^5.3.9",
         "webpack": "^5.90.1",

--- a/packages/suite-web/e2e/support/commands.ts
+++ b/packages/suite-web/e2e/support/commands.ts
@@ -115,7 +115,9 @@ declare global {
             enableDebugMode: () => Chainable<Subject>;
             toggleDebugModeInSettings: () => Chainable<Subject>;
             text: () => Chainable<Subject>;
-            passThroughInitialRun: () => Chainable<Subject>;
+            passThroughInitialRun: (
+                params?: Parameters<typeof passThroughInitialRun>[0],
+            ) => Chainable<Subject>;
             passThroughAuthenticityCheck: () => Chainable<Subject>;
             passThroughBackup: () => Chainable<Subject>;
             passThroughBackupShamir: (shares: number, threshold: number) => Chainable<Subject>;

--- a/packages/suite-web/e2e/support/index.ts
+++ b/packages/suite-web/e2e/support/index.ts
@@ -6,7 +6,8 @@ import 'cypress-real-events';
 const app: any = window.top;
 if (!app.document.head.querySelector('[data-hide-command-log-request]')) {
     const style = app.document.createElement('style');
-    style.innerHTML = '.command-name-request, .command-name-xhr { display: none }';
+    style.innerHTML =
+        '.command-name-request, .command-name-xhr, [class*="command-name-stub-"] { display: none }';
     style.setAttribute('data-hide-command-log-request', '');
     app.document.head.appendChild(style);
 }

--- a/packages/suite-web/e2e/support/utils/shortcuts.ts
+++ b/packages/suite-web/e2e/support/utils/shortcuts.ts
@@ -7,12 +7,16 @@ import { EventPayload, Requests } from '../types';
  */
 export const toggleDeviceMenu = () => cy.getTestElement('@menu/switch-device').click();
 
-export const passThroughInitialRun = () => {
+export const passThroughInitialRun = ({ viewOnly = true } = {}) => {
     cy.getTestElement('@analytics/continue-button', { timeout: 30_000 })
         .click()
         .getTestElement('@onboarding/exit-app-button')
         .click();
-    cy.getTestElement('@onbarding/viewOnly/enable').click();
+    if (viewOnly) {
+        cy.getTestElement('@onbarding/viewOnly/enable').click();
+    } else {
+        cy.getTestElement('@onbarding/viewOnly/skip').click();
+    }
     cy.getTestElement('@viewOnlyTooltip/gotIt', { timeout: 10_000 }).should('be.visible').click();
 };
 

--- a/packages/suite-web/e2e/tests/metadata/metadata-lifecycle.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/metadata-lifecycle.test.ts
@@ -5,22 +5,22 @@ const mnemonic = 'all all all all all all all all all all all all';
 
 describe('Metadata - cancel metadata on device', () => {
     beforeEach(() => {
-        cy.viewport(1440, 2560).resetDb();
+        cy.viewport('macbook-15').resetDb();
     });
 
-    // TODO: revisit this test case when #13294 is fixed
-    it.skip('user cancels metadata on device, choice is respected on subsequent runs but only for the cancelled wallet', () => {
+    it('user cancels metadata on device, choice is respected on subsequent runs but only for the cancelled wallet', () => {
         // prepare test
-        cy.task('startEmu', { wipe: true });
+        cy.task('startEmu', { wipe: true, version: '2.7.0' });
         cy.task('setupEmu', {
             mnemonic,
+            passphrase_protection: true,
         });
         cy.task('startBridge');
         cy.task('metadataStartProvider', 'dropbox');
 
         // first go to settings, see that metadata is disabled by default.
         cy.prefixedVisit('/');
-        cy.passThroughInitialRun();
+        cy.passThroughInitialRun({ viewOnly: false });
         cy.discoveryShouldFinish();
         cy.getTestElement('@suite/menu/settings').click();
         cy.getTestElement('@settings/metadata-switch').within(() => {
@@ -33,30 +33,33 @@ describe('Metadata - cancel metadata on device', () => {
 
         // but even though metadata is disabled, on hover "add label" button appears
         cy.hoverTestElement("@metadata/accountLabel/m/84'/0'/0'/hover-container");
-        cy.getTestElement("@metadata/accountLabel/m/84'/0'/0'/add-label-button").click();
 
-        // now user cancels dialogue on device
+        // try to init metadata...
+        cy.getTestElement("@metadata/accountLabel/m/84'/0'/0'/add-label-button").click();
+        // ...but user cancels dialogue on device
         cy.getConfirmActionOnDeviceModal();
         cy.task('pressNo');
         cy.wait(501);
 
         // cancelling labeling on device actually enables labeling globally so when user reloads app,
         // metadata dialogue will be prompted. now user cancels dialogue on device again and remembers device
+
         cy.safeReload();
+        // todo: this may timeout
+
         cy.getConfirmActionOnDeviceModal();
         cy.task('pressNo');
+
+        // set wallet to remembered
         cy.getTestElement('@menu/switch-device').click();
-        cy.getTestElement('@switch-device/wallet-on-index/0/toggle-remember-switch').click({
-            force: true,
-        });
+        cy.getTestElement('@viewOnlyStatus/disabled').click();
+        cy.getTestElement('@viewOnly/radios/enabled').click();
         cy.safeReload();
-        cy.discoveryShouldFinish(); // no dialogue!
+        cy.discoveryShouldFinish(); // no dialogue, metadata keys survive together with remembered wallet!
 
         // but when user tries to add another wallet, there is enable labeling dialogue again
         cy.getTestElement('@menu/switch-device').click();
         cy.getTestElement('@switch-device/add-hidden-wallet-button').click();
-        cy.getConfirmActionOnDeviceModal();
-        cy.task('pressYes');
         cy.getTestElement('@passphrase/input').type('abc');
         cy.getTestElement('@passphrase/hidden/submit-button').click();
         cy.getTestElement('@passphrase/input').should('not.exist');
@@ -64,36 +67,43 @@ describe('Metadata - cancel metadata on device', () => {
         cy.task('pressYes');
         cy.getConfirmActionOnDeviceModal();
         cy.task('pressYes');
+        cy.getTestElement('@passphrase-confirmation/step1-open-unused-wallet-button').click();
+        cy.getTestElement('@passphrase-confirmation/step2-button').click();
         cy.getTestElement('@passphrase/input').type('abc');
-        cy.getTestElement('@passphrase/confirm-checkbox', { timeout: 20000 }).click();
         cy.getTestElement('@passphrase/hidden/submit-button').click();
+        cy.task('pressYes');
+        cy.task('pressYes');
         cy.getTestElement('@passphrase/input').should('not.exist');
-
+        cy.getConfirmActionOnDeviceModal();
+        cy.task('pressYes');
+        cy.wait(501);
         cy.getConfirmActionOnDeviceModal();
         cy.task('pressYes');
         cy.wait(501);
 
-        cy.getConfirmActionOnDeviceModal();
-        cy.task('pressYes');
-        cy.wait(501);
+        // connect to data provider modal
+        // note: since recently, the first dialogue that appeared was "enable labeling on device" are we ok with this change of order?
+        cy.getTestElement('@modal/close-button').click();
 
-        cy.getConfirmActionOnDeviceModal(); // <--- this is enable labeling dialogue
-        cy.task('pressNo');
-        cy.wait(501);
+        // cy.getConfirmActionOnDeviceModal();
+        // cy.task('pressNo');
+        // cy.wait(501);
+
         cy.getTestElement('@accounts/empty-account/receive');
 
         // forget device and reload -> enable labeling dialogue appears
-        // explanation: metadata.error is index by device.state and we treat this field as sensitive
+        // explanation: metadata.error is indexed by device.state and we treat this field as sensitive
         // as keeping it might beat users plausible deniability
         cy.getTestElement('@menu/switch-device').click();
-        cy.getTestElement('@switch-device/wallet-on-index/0/toggle-remember-switch').click({
-            force: true,
-        });
-        cy.getTestElement('@modal/close-button').click();
+
+        cy.getTestElement('@switch-device/wallet-on-index/0/eject-button').click();
+        cy.getTestElement('@switch-device/eject').click();
+        cy.getTestElement('@switch-device/wallet-on-index/0/eject-button').click();
+        cy.getTestElement('@switch-device/eject').click();
 
         cy.safeReload();
-        cy.getTestElement('@passphrase-type/standard').click();
-        cy.getConfirmActionOnDeviceModal();
+
+        cy.getConfirmActionOnDeviceModal(); // enable labeling dialogue;
         cy.task('pressNo');
     });
 });

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/ViewOnly.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/ViewOnly.tsx
@@ -73,7 +73,7 @@ export const ViewOnly = ({ setContentType, instance }: ViewOnlyProps) => {
                 <ViewOnlyRadios
                     isViewOnlyActive={isViewOnly}
                     toggleViewOnly={handleRememberChange}
-                    data-test="@viewOnly/radios"
+                    dataTest="@viewOnly/radios"
                     setContentType={setContentType}
                     device={instance}
                 />

--- a/yarn.lock
+++ b/yarn.lock
@@ -11145,6 +11145,7 @@ __metadata:
     electron-localshortcut: "npm:^3.2.1"
     electron-store: "npm:^8.1.0"
     electron-updater: "npm:6.1.8"
+    fs-extra: "npm:^11.2.0"
     glob: "npm:^10.3.10"
     openpgp: "npm:^5.11.0"
     systeminformation: "npm:^5.21.24"


### PR DESCRIPTION
two minor issues I found while working on #9130 

- muting of excessive logs output in cypress test runner did not work anymore, no wonder, we depend on cypress internals, but it is the easiest way to do it, so fuck it, fixed in 4318faa2631783834c973d790282e728ebb8ca34
- found incorrectly passed data-test attr causing `<element data-test="undefined/disable">`. fixed in c0cda0d5e6ec49f3287686cc660c3bd01cd18974
- re-enabling skipped test [d10cdde](https://github.com/trezor/trezor-suite/pull/13364/commits/d10cddea1e146d3c9d528887e5ce7806f56891f8) I want to have it working for #9130
- node fs.rmDirSync produced `Error: ENOTEMPTY: directory not empty, rmdir '/root/.config/Electron'` I don't know why, fs-extra seems to work. [664a6bc](https://github.com/trezor/trezor-suite/pull/13364/commits/664a6bc8003bc815a3c3c130b1c91a4d230b4a60)