### PR TITLE
fix(suite): Make Install firmware buttons more rensposive

### DIFF
--- a/packages/components/src/components/buttons/Button/Button.tsx
+++ b/packages/components/src/components/buttons/Button/Button.tsx
@@ -71,7 +71,7 @@ const getTypography = (size: ButtonSize) => {
 };
 
 const Content = styled.div<ContentProps>`
-    white-space: nowrap;
+    white-space: normal;
     overflow: hidden;
     text-overflow: ellipsis;
 

--- a/packages/suite/src/components/firmware/Buttons/FirmwareButtonsRow.tsx
+++ b/packages/suite/src/components/firmware/Buttons/FirmwareButtonsRow.tsx
@@ -6,7 +6,8 @@ import { breakpointMediaQueries } from '@trezor/styles';
 
 const Row = styled.div`
     display: flex;
-    gap: 20px;
+    gap: ${spacingsPx.lg};
+    flex-flow: row wrap;
 
     ${breakpointMediaQueries.lg} {
         padding-bottom: ${spacingsPx.xxxl};

--- a/packages/suite/src/components/firmware/Buttons/FirmwareInstallButton.tsx
+++ b/packages/suite/src/components/firmware/Buttons/FirmwareInstallButton.tsx
@@ -1,19 +1,13 @@
-import styled from 'styled-components';
-
 import { Button, ButtonProps, Tooltip } from '@trezor/components';
 import { Translation } from 'src/components/suite';
 import { useTranslation } from 'src/hooks/suite';
 
-const StyledButton = styled(Button)`
-    min-width: 180px;
-`;
-
 const InstallButtonCommon = (
     props: Omit<ButtonProps, 'children'> & { children?: React.ReactNode },
 ) => (
-    <StyledButton {...props} data-test="@firmware/install-button">
+    <Button {...props} data-test="@firmware/install-button">
         {props.children || <Translation id="TR_INSTALL" />}
-    </StyledButton>
+    </Button>
 );
 
 interface FirmwareInstallButtonProps extends Omit<ButtonProps, 'children'> {

--- a/packages/suite/src/components/onboarding/OnboardingStepBox.tsx
+++ b/packages/suite/src/components/onboarding/OnboardingStepBox.tsx
@@ -17,7 +17,7 @@ const WrapperWrapper = styled.div`
 `;
 
 const ConfirmWrapper = styled.div`
-    margin-bottom: 20px;
+    margin-bottom: ${spacingsPx.lg};
     height: 62px;
 `;
 
@@ -25,13 +25,12 @@ const InnerActions = styled.div`
     display: flex;
     justify-content: center;
     align-items: center;
-    margin-top: ${spacingsPx.xxl};
-    margin-bottom: ${spacingsPx.xxl};
+    margin: ${spacingsPx.xxl} auto;
 `;
 
 const OuterActions = styled.div<{ $smallMargin?: boolean }>`
     display: flex;
-    margin-top: ${({ $smallMargin }) => ($smallMargin ? '0px' : '20px')};
+    margin-top: ${({ $smallMargin }) => ($smallMargin ? '0px' : spacingsPx.lg)};
     width: 100%;
     justify-content: center;
     z-index: ${zIndices.onboardingForeground};


### PR DESCRIPTION
## Description

Also adjust `Button` component to normal wrap instead of nowrap and use `spacingsPx` for some css padding/margin values instead, where possible.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/13261

## Videos:
**Before:**

https://github.com/user-attachments/assets/e1726b17-cb52-400b-9e9f-ee6423ed5681

**After:**

https://github.com/user-attachments/assets/53ee3a94-96bc-411f-9c7b-dd43a19207ba



