### PR TITLE
feat(suite): add debug setting option to stop tor

### DIFF
--- a/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
@@ -1,4 +1,4 @@
-import { isWeb } from '@trezor/env-utils';
+import { isDesktop, isWeb } from '@trezor/env-utils';
 
 import { SettingsSection, SettingsLayout } from 'src/components/settings';
 
@@ -21,6 +21,7 @@ import { selectSuiteFlags } from 'src/reducers/suite/suiteReducer';
 import { useSelector } from 'src/hooks/suite';
 import { PreField } from './PreField';
 import { AutoStart } from './AutoStart';
+import { Tor } from './Tor';
 
 export const SettingsDebug = () => {
     const flags = useSelector(selectSuiteFlags);
@@ -67,6 +68,11 @@ export const SettingsDebug = () => {
             <SettingsSection title="Transport clients">
                 <Transport />
             </SettingsSection>
+            {isDesktop() && (
+                <SettingsSection title="Tor">
+                    <Tor />
+                </SettingsSection>
+            )}
             <SettingsSection title="Backends">
                 <Backends />
             </SettingsSection>

--- a/packages/suite/src/views/settings/SettingsDebug/Tor.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/Tor.tsx
@@ -1,0 +1,29 @@
+import { useDispatch } from 'src/hooks/suite';
+
+import { ActionColumn, ActionButton, SectionItem, TextColumn } from 'src/components/suite';
+import { toggleTor } from 'src/actions/suite/suiteActions';
+
+export const Tor = () => {
+    const dispatch = useDispatch();
+
+    return (
+        <>
+            <SectionItem data-test="@settings/debug/tor/stop">
+                <TextColumn
+                    title="Stop Tor"
+                    description="This debug setting allows you to stop Tor when it is still bootstrapping."
+                />
+                <ActionColumn>
+                    <ActionButton
+                        variant="destructive"
+                        onClick={() => {
+                            dispatch(toggleTor(false));
+                        }}
+                    >
+                        Stop Tor
+                    </ActionButton>
+                </ActionColumn>
+            </SectionItem>
+        </>
+    );
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding debug option to stop Tor.
When Tor is in bootstrap process there is no way to stop it in the current UI. When developing it is useful to be able to stop it so this allows it.