### PR TITLE
chore(connect): Add Ambire Browser Extension to knownHosts

### DIFF
--- a/packages/connect/src/data/config.ts
+++ b/packages/connect/src/data/config.ts
@@ -51,6 +51,16 @@ export const config = {
             label: 'Rabby',
             icon: '',
         },
+        {
+            origin: 'ehnpnhnhcickeknioaiodjmielfaoajd',
+            label: 'Ambire DEV',
+            icon: '',
+        },
+        {
+            origin: 'ehgjhhccekdedpbkifaojjaefeohnoea',
+            label: 'Ambire',
+            icon: '',
+        },
         { origin: 'file://', label: ' ', icon: '' },
     ],
     onionDomains: {


### PR DESCRIPTION
Add Ambire to knownHosts

## Description

I’d like to ask you to accept including Ambire’s extension IDs in the `knownHosts` in order to enhance the appearance of the permissions copy in the Trezor popup for our users who interact with Trezor.

## Related Issue
https://github.com/trezor/trezor-suite/pull/12593
https://github.com/trezor/trezor-suite/pull/11625
