### PR TITLE
feat(suite): add trade box to dashboard when account has no transactions

### DIFF
--- a/packages/suite/src/views/wallet/transactions/TradeBox/TradeBoxMenu.tsx
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/TradeBoxMenu.tsx
@@ -83,6 +83,7 @@ export const TradeBoxMenu = ({ account }: TradeBoxMenuProps) => {
                             });
                             dispatch(goto(item.route, { preserveParams: true }));
                         }}
+                        isDisabled={item.type !== 'buy' && account.empty}
                         data-test={`@coinmarket/menu/${item.route}`}
                     >
                         {item.title}

--- a/packages/suite/src/views/wallet/transactions/Transactions.tsx
+++ b/packages/suite/src/views/wallet/transactions/Transactions.tsx
@@ -105,6 +105,7 @@ export const Transactions = () => {
         return (
             <Layout selectedAccount={selectedAccount} showEmptyHeaderPlaceholder>
                 <AccountEmpty account={selectedAccount.account} />
+                <TradeBox account={account} />
             </Layout>
         );
     }


### PR DESCRIPTION
## Description

When account has no transactions, a trade box with the sell and exchange buttons disabled now appears.

## Screenshots:

<img width="1224" alt="Screenshot 2024-07-16 at 20 24 25" src="https://github.com/user-attachments/assets/9ebf2ac6-ebbc-44f8-b09d-d96040b37886">

