### PR TITLE
fix(suite): reflect hidden and shown tokens in txs history

### DIFF
--- a/suite-common/wallet-utils/src/antiFraud.ts
+++ b/suite-common/wallet-utils/src/antiFraud.ts
@@ -21,9 +21,18 @@ export const getIsFakeTokenPhishing = (
     !transaction.tokens.some(tokenTx => {
         const isNftTx = isNftTokenTransfer(tokenTx);
         const definitions = isNftTx ? tokenDefinitions?.nft?.data : tokenDefinitions?.coin?.data;
+        const hide = isNftTx ? tokenDefinitions?.nft?.hide : tokenDefinitions?.coin?.hide;
+        const show = isNftTx ? tokenDefinitions?.nft?.show : tokenDefinitions?.coin?.show;
 
-        return isTokenDefinitionKnown(definitions, transaction.symbol, tokenTx.contract);
-    }); // all tokens are unknown
+        const isHidden = hide?.includes(tokenTx.contract);
+        const isShown = show?.includes(tokenTx.contract);
+
+        return (
+            (isTokenDefinitionKnown(definitions, transaction.symbol, tokenTx.contract) ||
+                isShown) &&
+            !isHidden
+        );
+    }); // there is hidden or unknown token in tx
 
 export const getIsPhishingTransaction = (
     transaction: WalletAccountTransaction,


### PR DESCRIPTION
## Description

When user hides a token then transactions with this token will be blurred and marked as scammy. The opposite happens when user unhides an unverified or already hidden token.

## Related Issue

Resolve #13039
