### PR TITLE
Feat/native/send form redux error handling

### DIFF
--- a/packages/suite/src/actions/wallet/send/sendFormThunks.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormThunks.ts
@@ -189,11 +189,11 @@ export const signAndPushSendFormTransactionThunk = createThunk(
     `${MODULE_PREFIX}/signSendFormTransactionThunk`,
     async (
         {
-            formValues,
+            formState,
             precomposedTransaction,
             selectedAccount,
         }: {
-            formValues: FormState;
+            formState: FormState;
             precomposedTransaction: GeneralPrecomposedTransactionFinal;
             selectedAccount?: Account;
         },
@@ -204,7 +204,7 @@ export const signAndPushSendFormTransactionThunk = createThunk(
 
         const enhancedPrecomposedTransaction = await dispatch(
             enhancePrecomposedTransactionThunk({
-                transactionFormValues: formValues,
+                transactionFormValues: formState,
                 precomposedTransaction,
                 selectedAccount,
             }),
@@ -217,7 +217,7 @@ export const signAndPushSendFormTransactionThunk = createThunk(
 
         const signResponse = await dispatch(
             signTransactionThunk({
-                formValues,
+                formState,
                 precomposedTransaction: enhancedPrecomposedTransaction,
                 selectedAccount,
             }),

--- a/packages/suite/src/actions/wallet/send/sendFormThunks.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormThunks.ts
@@ -20,7 +20,6 @@ import {
 } from '@suite-common/wallet-core';
 import { isCardanoTx } from '@suite-common/wallet-utils';
 import { MetadataAddPayload } from '@suite-common/metadata-types';
-import { Unsuccessful } from '@trezor/connect';
 import { getSynchronize } from '@trezor/utils';
 
 import {
@@ -216,15 +215,15 @@ export const signAndPushSendFormTransactionThunk = createThunk(
         // this action is blocked by modalActions.preserve()
         dispatch(modalActions.preserve());
 
-        const { serializedTx } = await dispatch(
+        const signResponse = await dispatch(
             signTransactionThunk({
                 formValues,
                 precomposedTransaction: enhancedPrecomposedTransaction,
                 selectedAccount,
             }),
-        ).unwrap();
+        );
 
-        if (!serializedTx) {
+        if (isRejected(signResponse)) {
             // close modal manually since UI.CLOSE_UI.WINDOW was blocked
             dispatch(modalActions.onCancel());
 
@@ -255,7 +254,7 @@ export const signAndPushSendFormTransactionThunk = createThunk(
         );
 
         if (isRejected(pushResponse)) {
-            return pushResponse.payload as Unsuccessful;
+            return pushResponse.payload?.metadata;
         }
 
         const result = pushResponse.payload;

--- a/packages/suite/src/hooks/wallet/form/useCompose.ts
+++ b/packages/suite/src/hooks/wallet/form/useCompose.ts
@@ -83,12 +83,12 @@ export const useCompose = <TFieldValues extends FormState>({
                     return Promise.resolve(undefined);
                 }
 
-                const values = getValues();
+                const formState = getValues();
 
                 return dispatch(
                     composeSendFormTransactionFeeLevelsThunk({
-                        formValues: values,
-                        formState: state,
+                        formState,
+                        composeContext: state,
                     }),
                 ).unwrap();
             });
@@ -234,16 +234,16 @@ export const useCompose = <TFieldValues extends FormState>({
 
     // called from the UI, triggers signing process
     const sign = async () => {
-        const values = getValues();
+        const formState = getValues();
         const precomposedTransaction = composedLevels
-            ? composedLevels[values.selectedFee || 'normal']
+            ? composedLevels[formState.selectedFee || 'normal']
             : undefined;
         if (precomposedTransaction && precomposedTransaction.type === 'final') {
             // sign workflow in Actions:
             // signSendFormTransactionThunk > sign[COIN]TransactionThunk > sendFormActions.storeSignedTransaction (modal with promise decision)
             const result = await dispatch(
                 signAndPushSendFormTransactionThunk({
-                    formValues: values,
+                    formState,
                     precomposedTransaction,
                     selectedAccount,
                 }),

--- a/packages/suite/src/hooks/wallet/form/useCompose.ts
+++ b/packages/suite/src/hooks/wallet/form/useCompose.ts
@@ -5,7 +5,10 @@ import { FeeLevel } from '@trezor/connect';
 import { useDebounce } from '@trezor/react-utils';
 import { useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
 import { signAndPushSendFormTransactionThunk } from 'src/actions/wallet/send/sendFormThunks';
-import { ComposeActionContext, composeSendFormTransactionThunk } from '@suite-common/wallet-core';
+import {
+    ComposeActionContext,
+    composeSendFormTransactionFeeLevelsThunk,
+} from '@suite-common/wallet-core';
 import { findComposeErrors } from '@suite-common/wallet-utils';
 import {
     FormState,
@@ -83,7 +86,10 @@ export const useCompose = <TFieldValues extends FormState>({
                 const values = getValues();
 
                 return dispatch(
-                    composeSendFormTransactionThunk({ formValues: values, formState: state }),
+                    composeSendFormTransactionFeeLevelsThunk({
+                        formValues: values,
+                        formState: state,
+                    }),
                 ).unwrap();
             });
 

--- a/packages/suite/src/hooks/wallet/useCoinmarketRecomposeAndSign.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketRecomposeAndSign.ts
@@ -7,7 +7,7 @@ import { DEFAULT_VALUES, DEFAULT_PAYMENT } from '@suite-common/wallet-constants'
 import { FormState } from '@suite-common/wallet-types';
 import { getFeeLevels } from '@suite-common/wallet-utils';
 import type { FormOptions, SelectedAccountLoaded } from '@suite-common/wallet-types';
-import { composeSendFormTransactionThunk } from '@suite-common/wallet-core';
+import { composeSendFormTransactionFeeLevelsThunk } from '@suite-common/wallet-core';
 import { UseSendFormState } from 'src/types/wallet/sendForm';
 
 export const useCoinmarketRecomposeAndSign = () => {
@@ -74,7 +74,7 @@ export const useCoinmarketRecomposeAndSign = () => {
             // but recompute the feeLimit based on a different transaction data (for example from ethereumDataHex)
             if (recalcCustomLimit && selectedFee === 'custom') {
                 const normalLevels = await dispatch(
-                    composeSendFormTransactionThunk({
+                    composeSendFormTransactionFeeLevelsThunk({
                         formValues: { ...formValues, selectedFee: 'normal' },
                         formState: formState as UseSendFormState,
                     }),
@@ -112,7 +112,7 @@ export const useCoinmarketRecomposeAndSign = () => {
 
             // compose transaction again to recalculate fees based on real account values
             const composedLevels = await dispatch(
-                composeSendFormTransactionThunk({ formValues, formState }),
+                composeSendFormTransactionFeeLevelsThunk({ formValues, formState }),
             ).unwrap();
             if (!selectedFee || !composedLevels) {
                 dispatch(

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -254,9 +254,9 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
 
     // get response from TransactionReviewModal
     const sign = useCallback(async () => {
-        const values = getValues();
+        const formState = getValues();
         const precomposedTransaction = composedLevels
-            ? composedLevels[values.selectedFee || 'normal']
+            ? composedLevels[formState.selectedFee || 'normal']
             : undefined;
         if (precomposedTransaction && precomposedTransaction.type === 'final') {
             // sign workflow in Actions:
@@ -264,7 +264,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
             setLoading(true);
             const result = await dispatch(
                 signAndPushSendFormTransactionThunk({
-                    formValues: values,
+                    formState,
                     precomposedTransaction,
                     selectedAccount: props.selectedAccount.account,
                 }),

--- a/packages/suite/src/hooks/wallet/useSendFormCompose.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormCompose.ts
@@ -17,9 +17,10 @@ import { COMPOSE_ERROR_TYPES } from '@suite-common/wallet-constants';
 
 import { TranslationKey } from 'src/components/suite/Translation';
 import { useDispatch } from 'react-redux';
-import { composeSendFormTransactionThunk } from '@suite-common/wallet-core';
+import { composeSendFormTransactionFeeLevelsThunk } from '@suite-common/wallet-core';
 import { useTranslation } from '../suite';
 import { SendContextValues, UseSendFormState } from 'src/types/wallet/sendForm';
+import { isFulfilled } from '@reduxjs/toolkit';
 
 type Props = UseFormReturn<FormState> & {
     state: UseSendFormState;
@@ -67,7 +68,7 @@ export const useSendFormCompose = ({
             setComposedLevels(undefined);
 
             const result = await dispatch(
-                composeSendFormTransactionThunk({
+                composeSendFormTransactionFeeLevelsThunk({
                     formValues,
                     formState: {
                         account,
@@ -77,10 +78,10 @@ export const useSendFormCompose = ({
                         prison,
                     },
                 }),
-            ).unwrap();
+            );
 
-            if (result) {
-                setComposedLevels(result);
+            if (isFulfilled(result)) {
+                setComposedLevels(result.payload);
             } else {
                 // undefined result will not be processed by useEffect below, reset loader
                 setLoading(false);
@@ -118,7 +119,7 @@ export const useSendFormCompose = ({
                 setDraftSaveRequest(true);
 
                 return dispatch(
-                    composeSendFormTransactionThunk({
+                    composeSendFormTransactionFeeLevelsThunk({
                         formValues: values,
                         formState: {
                             account,
@@ -128,7 +129,7 @@ export const useSendFormCompose = ({
                             prison,
                         },
                     }),
-                ).unwrap();
+                );
             });
 
             // RACE-CONDITION NOTE:
@@ -136,9 +137,9 @@ export const useSendFormCompose = ({
             // therefore another debounce process was not called yet to interrupt current one
             // unexpected result: `updateComposedValues` is trying to work with updated/newer FormState
             if (resultID === composeRequestID.current) {
-                if (result) {
+                if (isFulfilled(result)) {
                     // set new composed transactions
-                    setComposedLevels(result);
+                    setComposedLevels(result.payload);
                 } else {
                     // result undefined: (FormState got errors or sendFormActions got errors)
                     // undefined result will not be processed by useEffect below, reset loader

--- a/packages/suite/src/hooks/wallet/useSendFormCompose.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormCompose.ts
@@ -62,15 +62,15 @@ export const useSendFormCompose = ({
     const debounce = useDebounce();
 
     const composeDraft = useCallback(
-        async (formValues: FormState) => {
+        async (formState: FormState) => {
             // start composing without debounce
             setLoading(true);
             setComposedLevels(undefined);
 
             const result = await dispatch(
                 composeSendFormTransactionFeeLevelsThunk({
-                    formValues,
-                    formState: {
+                    formState,
+                    composeContext: {
                         account,
                         network: state.network,
                         feeInfo: state.feeInfo,
@@ -114,14 +114,14 @@ export const useSendFormCompose = ({
                     return Promise.resolve(undefined);
                 }
 
-                const values = getValues();
+                const formState = getValues();
                 // save draft (it could be changed later, after composing)
                 setDraftSaveRequest(true);
 
                 return dispatch(
                     composeSendFormTransactionFeeLevelsThunk({
-                        formValues: values,
-                        formState: {
+                        formState,
+                        composeContext: {
                             account,
                             network: state.network,
                             feeInfo: state.feeInfo,

--- a/suite-common/redux-utils/src/createReducerWithExtraDeps.ts
+++ b/suite-common/redux-utils/src/createReducerWithExtraDeps.ts
@@ -1,11 +1,9 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import { ActionReducerMapBuilder, createReducer } from '@reduxjs/toolkit';
 
-import { ExtraDependencies } from './extraDependenciesType';
+import { ExtraDependenciesForReducer } from './extraDependenciesType';
 
 type NotFunction<T> = T extends Function ? never : T;
-
-type ExtraDependenciesForReducer = Pick<ExtraDependencies, 'actionTypes' | 'actions' | 'reducers'>;
 
 export const createReducerWithExtraDeps =
     <S extends NotFunction<any>>(
@@ -15,7 +13,7 @@ export const createReducerWithExtraDeps =
             extra: ExtraDependenciesForReducer,
         ) => void,
     ) =>
-    (extraDeps: ExtraDependencies) =>
+    (extraDeps: ExtraDependenciesForReducer) =>
         createReducer(initialState, builder =>
             builderCallback(builder, {
                 actionTypes: extraDeps.actionTypes,

--- a/suite-common/redux-utils/src/createSliceWithExtraDeps.ts
+++ b/suite-common/redux-utils/src/createSliceWithExtraDeps.ts
@@ -6,7 +6,8 @@ import {
     SliceCaseReducers,
 } from '@reduxjs/toolkit';
 
-import { ExtraDependencies } from './extraDependenciesType';
+import { ExtraDependenciesForReducer } from './extraDependenciesType';
+
 /*
 This is nearly same function as createSlice from redux-toolkit, but instead of generating reducer it will generate
 prepareReducer function that will be used to generate reducer. This functions accepts one argument - extra dependencies.
@@ -19,7 +20,7 @@ export const createSliceWithExtraDeps = <
     options: Omit<CreateSliceOptions<State, CaseReducers, Name>, 'extraReducers'> & {
         extraReducers: (
             builder: ActionReducerMapBuilder<State>,
-            extra: Pick<ExtraDependencies, 'actionTypes' | 'actions' | 'reducers'>,
+            extra: ExtraDependenciesForReducer,
         ) => void;
     },
 ) => {
@@ -58,7 +59,7 @@ export const createSliceWithExtraDeps = <
         },
     });
 
-    const prepareReducer = (extraDeps: ExtraDependencies) =>
+    const prepareReducer = (extraDeps: ExtraDependenciesForReducer) =>
         createSlice({
             ...options,
             extraReducers: builder => {

--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -136,6 +136,11 @@ export type ExtraDependencies = {
     };
 };
 
+export type ExtraDependenciesForReducer = Pick<
+    ExtraDependencies,
+    'actionTypes' | 'actions' | 'reducers'
+>;
+
 export type ExtraDependenciesPartial = {
     [K in keyof ExtraDependencies]?: Partial<ExtraDependencies[K]>;
 };

--- a/suite-common/wallet-core/src/send/sendFormCardanoThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormCardanoThunks.ts
@@ -30,8 +30,8 @@ export const composeCardanoTransactionFeeLevelsThunk = createThunk<
     { rejectValue: ComposeFeeLevelsError }
 >(
     `${SEND_MODULE_PREFIX}/composeBitcoinTransactionFeeLevelsThunk`,
-    async ({ formValues, formState }, { dispatch, rejectWithValue }) => {
-        const { account, feeInfo } = formState;
+    async ({ formState, composeContext }, { dispatch, rejectWithValue }) => {
+        const { account, feeInfo } = composeContext;
         const changeAddress = getUnusedChangeAddress(account);
         if (!changeAddress || !account.utxo || !account.addresses)
             return rejectWithValue({
@@ -40,19 +40,19 @@ export const composeCardanoTransactionFeeLevelsThunk = createThunk<
             });
 
         const predefinedLevels = feeInfo.levels.filter(l => l.label !== 'custom');
-        if (formValues.selectedFee === 'custom') {
+        if (formState.selectedFee === 'custom') {
             predefinedLevels.push({
                 label: 'custom',
-                feePerUnit: formValues.feePerUnit,
+                feePerUnit: formState.feePerUnit,
                 blocks: -1,
             });
         }
 
         const outputs = transformUserOutputs(
-            formValues.outputs,
+            formState.outputs,
             account.tokens,
             account.symbol,
-            formValues.setMaxOutputId,
+            formState.setMaxOutputId,
         );
 
         const addressParameters = getAddressParameters(account, changeAddress.path);
@@ -135,7 +135,7 @@ export const composeCardanoTransactionFeeLevelsThunk = createThunk<
 
 type SignCardanoTransactionThunkArguments = Omit<
     SignTransactionThunkArguments,
-    'formValues' | 'precomposedTransaction' | 'accountStatus'
+    'formState' | 'precomposedTransaction' | 'accountStatus'
 > & {
     precomposedTransaction: PrecomposedTransactionFinalCardano;
 };

--- a/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
@@ -27,9 +27,13 @@ import {
 import { AddressDisplayOptions } from '@suite-common/wallet-types';
 import { getTxStakeNameByDataHex } from '@suite-common/suite-utils';
 
-import { selectDevice } from '../device/deviceReducer';
 import { selectTransactions } from '../transactions/transactionsReducer';
-import { ComposeTransactionThunkArguments, SignTransactionThunkArguments } from './sendFormTypes';
+import {
+    ComposeTransactionThunkArguments,
+    ComposeFeeLevelsError,
+    SignTransactionThunkArguments,
+    SignTransactionError,
+} from './sendFormTypes';
 import { SEND_MODULE_PREFIX } from './sendFormConstants';
 import { STAKE_GAS_LIMIT_RESERVE } from '../stake/stakeTypes';
 
@@ -110,14 +114,22 @@ const calculate = (
     return payloadData;
 };
 
-export const composeEthereumSendFormTransactionThunk = createThunk(
-    `${SEND_MODULE_PREFIX}/composeEthereumSendFormTransactionThunk`,
-    async ({ formValues, formState }: ComposeTransactionThunkArguments, { dispatch }) => {
+export const composeEthereumTransactionFeeLevelsThunk = createThunk<
+    PrecomposedLevels,
+    ComposeTransactionThunkArguments,
+    { rejectValue: ComposeFeeLevelsError }
+>(
+    `${SEND_MODULE_PREFIX}/composeEthereumTransactionFeeLevelsThunk`,
+    async ({ formValues, formState }, { dispatch, rejectWithValue }) => {
         const { account, network, feeInfo } = formState;
-        const composeOutputs = getExternalComposeOutput(formValues, account, network);
-        if (!composeOutputs) return; // no valid Output
+        const composedOutput = getExternalComposeOutput(formValues, account, network);
+        if (!composedOutput)
+            return rejectWithValue({
+                error: 'fee-levels-compose-failed',
+                message: 'Unable to compose output.',
+            });
 
-        const { output, tokenInfo, decimals } = composeOutputs;
+        const { output, tokenInfo, decimals } = composedOutput;
         const { availableBalance } = account;
         const { address, amount } = formValues.outputs[0];
 
@@ -184,19 +196,19 @@ export const composeEthereumSendFormTransactionThunk = createThunk(
         }
 
         // wrap response into PrecomposedLevels object where key is a FeeLevel label
-        const wrappedResponse: PrecomposedLevels = {};
+        const resultLevels: PrecomposedLevels = {};
         const response = predefinedLevels.map(level =>
             calculate(availableBalance, output, level, tokenInfo),
         );
         response.forEach((tx, index) => {
             const feeLabel = predefinedLevels[index].label as FeeLevel['label'];
-            wrappedResponse[feeLabel] = tx;
+            resultLevels[feeLabel] = tx;
         });
 
         // format max
         // update errorMessage values (symbol)
-        Object.keys(wrappedResponse).forEach(key => {
-            const tx = wrappedResponse[key];
+        Object.keys(resultLevels).forEach(key => {
+            const tx = resultLevels[key];
             if (tx.type !== 'error') {
                 tx.max = tx.max ? formatAmount(tx.max, decimals) : undefined;
                 tx.estimatedFeeLimit = !customFeeLimit.isNaN()
@@ -211,31 +223,24 @@ export const composeEthereumSendFormTransactionThunk = createThunk(
             }
         });
 
-        return wrappedResponse;
+        return resultLevels;
     },
 );
 
-export const signEthereumSendFormTransactionThunk = createThunk(
+export const signEthereumSendFormTransactionThunk = createThunk<
+    { serializedTx: string },
+    SignTransactionThunkArguments,
+    { rejectValue: SignTransactionError }
+>(
     `${SEND_MODULE_PREFIX}/signEthereumSendFormTransactionThunk`,
     async (
-        { formValues, precomposedTransaction, selectedAccount }: SignTransactionThunkArguments,
-        { dispatch, getState, extra },
+        { formValues, precomposedTransaction, selectedAccount, device },
+        { getState, extra, rejectWithValue },
     ) => {
         const {
-            selectors: { selectAddressDisplayType, selectSelectedAccountStatus },
+            selectors: { selectAddressDisplayType },
         } = extra;
-        const selectedAccountStatus = selectSelectedAccountStatus(getState());
         const transactions = selectTransactions(getState());
-        const device = selectDevice(getState());
-
-        if (
-            G.isNullable(selectedAccount) ||
-            selectedAccountStatus !== 'loaded' ||
-            !device ||
-            !precomposedTransaction ||
-            precomposedTransaction.type !== 'final'
-        )
-            return;
 
         const network = getNetwork(selectedAccount.symbol);
 
@@ -244,7 +249,10 @@ export const signEthereumSendFormTransactionThunk = createThunk(
             selectedAccount.networkType !== 'ethereum' ||
             !network?.chainId
         )
-            return;
+            return rejectWithValue({
+                error: 'sign-transaction-failed',
+                message: 'Ethereum network mismatch.',
+            });
 
         const addressDisplayType = selectAddressDisplayType(getState());
 
@@ -283,7 +291,7 @@ export const signEthereumSendFormTransactionThunk = createThunk(
             nonce,
         });
 
-        const signedTx = await TrezorConnect.ethereumSignTransaction({
+        const response = await TrezorConnect.ethereumSignTransaction({
             device: {
                 path: device.path,
                 instance: device.instance,
@@ -295,19 +303,14 @@ export const signEthereumSendFormTransactionThunk = createThunk(
             chunkify: addressDisplayType === AddressDisplayOptions.CHUNKED,
         });
 
-        if (!signedTx.success) {
+        if (!response.success) {
             // catch manual error from TransactionReviewModal
-            if (signedTx.payload.error === 'tx-cancelled') return;
-            dispatch(
-                notificationsActions.addToast({
-                    type: 'sign-tx-error',
-                    error: signedTx.payload.error,
-                }),
-            );
-
-            return;
+            return rejectWithValue({
+                error: 'sign-transaction-failed',
+                message: response.payload.error,
+            });
         }
 
-        return signedTx.payload.serializedTx;
+        return { serializedTx: response.payload.serializedTx };
     },
 );

--- a/suite-common/wallet-core/src/send/sendFormRippleThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormRippleThunks.ts
@@ -94,9 +94,9 @@ export const composeRippleTransactionFeeLevelsThunk = createThunk<
     { rejectValue: ComposeFeeLevelsError }
 >(
     `${SEND_MODULE_PREFIX}/composeEthereumTransactionFeeLevelsThunk`,
-    async ({ formValues, formState }, { rejectWithValue }) => {
-        const { account, network, feeInfo } = formState;
-        const composeOutputs = getExternalComposeOutput(formValues, account, network);
+    async ({ formState, composeContext }, { rejectWithValue }) => {
+        const { account, network, feeInfo } = composeContext;
+        const composeOutputs = getExternalComposeOutput(formState, account, network);
         if (!composeOutputs)
             return rejectWithValue({
                 error: 'fee-levels-compose-failed',
@@ -105,14 +105,14 @@ export const composeRippleTransactionFeeLevelsThunk = createThunk<
 
         const { output } = composeOutputs;
         const { availableBalance } = account;
-        const { address } = formValues.outputs[0];
+        const { address } = formState.outputs[0];
 
         const predefinedLevels = feeInfo.levels.filter(l => l.label !== 'custom');
         // in case when selectedFee is set to 'custom' construct this FeeLevel from values
-        if (formValues.selectedFee === 'custom') {
+        if (formState.selectedFee === 'custom') {
             predefinedLevels.push({
                 label: 'custom',
-                feePerUnit: formValues.feePerUnit,
+                feePerUnit: formState.feePerUnit,
                 blocks: -1,
             });
         }
@@ -196,7 +196,7 @@ export const signRippleSendFormTransactionThunk = createThunk<
 >(
     `${SEND_MODULE_PREFIX}/signRippleSendFormTransactionThunk`,
     async (
-        { formValues, precomposedTransaction, selectedAccount, device },
+        { formState, precomposedTransaction, selectedAccount, device },
         { getState, extra, rejectWithValue },
     ) => {
         const {
@@ -212,12 +212,12 @@ export const signRippleSendFormTransactionThunk = createThunk<
             });
 
         const payment: RipplePayment = {
-            destination: formValues.outputs[0].address,
-            amount: networkAmountToSatoshi(formValues.outputs[0].amount, selectedAccount.symbol),
+            destination: formState.outputs[0].address,
+            amount: networkAmountToSatoshi(formState.outputs[0].amount, selectedAccount.symbol),
         };
 
-        if (formValues.rippleDestinationTag) {
-            payment.destinationTag = parseInt(formValues.rippleDestinationTag, 10);
+        if (formState.rippleDestinationTag) {
+            payment.destinationTag = parseInt(formState.rippleDestinationTag, 10);
         }
 
         const response = await TrezorConnect.rippleSignTransaction({

--- a/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
@@ -129,9 +129,9 @@ export const composeSolanaTransactionFeeLevelsThunk = createThunk<
     { rejectValue: ComposeFeeLevelsError }
 >(
     `${SEND_MODULE_PREFIX}/composeSolanaTransactionFeeLevelsThunk`,
-    async ({ formValues, formState }, { getState, rejectWithValue }) => {
-        const { account, network, feeInfo } = formState;
-        const composedOutput = getExternalComposeOutput(formValues, account, network);
+    async ({ formState, composeContext }, { getState, rejectWithValue }) => {
+        const { account, network, feeInfo } = composeContext;
+        const composedOutput = getExternalComposeOutput(formState, account, network);
         if (!composedOutput)
             return rejectWithValue({
                 error: 'fee-levels-compose-failed',
@@ -147,7 +147,7 @@ export const composeSolanaTransactionFeeLevelsThunk = createThunk<
 
         const [recipientAccountOwner, recipientTokenAccount] = tokenInfo
             ? await fetchAccountOwnerAndTokenInfoForAddress(
-                  formValues.outputs[0].address,
+                  formState.outputs[0].address,
                   account.symbol,
                   tokenInfo.contract,
               )
@@ -164,10 +164,10 @@ export const composeSolanaTransactionFeeLevelsThunk = createThunk<
             tokenInfo && tokenInfo.accounts
                 ? await buildTokenTransferTransaction(
                       account.descriptor,
-                      formValues.outputs[0].address || account.descriptor,
+                      formState.outputs[0].address || account.descriptor,
                       recipientAccountOwner || SYSTEM_PROGRAM_PUBLIC_KEY,
                       tokenInfo.contract,
-                      formValues.outputs[0].amount || '0',
+                      formState.outputs[0].amount || '0',
                       tokenInfo.decimals,
                       tokenInfo.accounts,
                       recipientTokenAccount,
@@ -186,8 +186,8 @@ export const composeSolanaTransactionFeeLevelsThunk = createThunk<
                 ? tokenTransferTxAndDestinationAddress.transaction
                 : await buildTransferTransaction(
                       account.descriptor,
-                      formValues.outputs[0].address || account.descriptor,
-                      formValues.outputs[0].amount || '0',
+                      formState.outputs[0].address || account.descriptor,
+                      formState.outputs[0].amount || '0',
                       blockhash,
                       lastValidBlockHeight,
                       dummyPriorityFeesForFeeEstimation,
@@ -270,7 +270,7 @@ export const signSolanaSendFormTransactionThunk = createThunk<
 >(
     `${SEND_MODULE_PREFIX}/signSolanaSendFormTransactionThunk`,
     async (
-        { formValues, precomposedTransaction, selectedAccount, device },
+        { formState, precomposedTransaction, selectedAccount, device },
         { getState, rejectWithValue },
     ) => {
         if (precomposedTransaction.feeLimit == null)
@@ -293,7 +293,7 @@ export const signSolanaSendFormTransactionThunk = createThunk<
 
         const [recipientAccountOwner, recipientTokenAccounts] = token
             ? await fetchAccountOwnerAndTokenInfoForAddress(
-                  formValues.outputs[0].address,
+                  formState.outputs[0].address,
                   selectedAccount.symbol,
                   token.contract,
               )
@@ -309,10 +309,10 @@ export const signSolanaSendFormTransactionThunk = createThunk<
             token && token.accounts
                 ? await buildTokenTransferTransaction(
                       selectedAccount.descriptor,
-                      formValues.outputs[0].address || selectedAccount.descriptor,
+                      formState.outputs[0].address || selectedAccount.descriptor,
                       recipientAccountOwner || SYSTEM_PROGRAM_PUBLIC_KEY,
                       token.contract,
-                      formValues.outputs[0].amount || '0',
+                      formState.outputs[0].amount || '0',
                       token.decimals,
                       token.accounts,
                       recipientTokenAccounts,
@@ -335,8 +335,8 @@ export const signSolanaSendFormTransactionThunk = createThunk<
             ? tokenTransferTxAndDestinationAddress.transaction
             : await buildTransferTransaction(
                   selectedAccount.descriptor,
-                  formValues.outputs[0].address,
-                  formValues.outputs[0].amount,
+                  formState.outputs[0].address,
+                  formState.outputs[0].amount,
                   blockhash,
                   lastValidBlockHeight,
                   {

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -138,37 +138,37 @@ type CoinSpecificComposeResponse = ActionsFromAsyncThunk<
 
 export const composeSendFormTransactionFeeLevelsThunk = createThunk<
     PrecomposedLevels | PrecomposedLevelsCardano,
-    { formValues: FormState; formState: ComposeActionContext },
+    { formState: FormState; composeContext: ComposeActionContext },
     { rejectValue: ComposeFeeLevelsError }
 >(
     `${SEND_MODULE_PREFIX}/composeSendFormTransactionThunk`,
-    async ({ formValues, formState }, { dispatch, rejectWithValue }) => {
-        const { account } = formState;
+    async ({ formState, composeContext }, { dispatch, rejectWithValue }) => {
+        const { account } = composeContext;
         let response: CoinSpecificComposeResponse | undefined;
 
         const { networkType } = account;
         if (networkType === 'bitcoin') {
             response = await dispatch(
                 composeBitcoinTransactionFeeLevelsThunk({
-                    formValues,
                     formState,
+                    composeContext,
                 }),
             );
         } else if (networkType === 'ethereum') {
             response = await dispatch(
-                composeEthereumTransactionFeeLevelsThunk({ formValues, formState }),
+                composeEthereumTransactionFeeLevelsThunk({ formState, composeContext }),
             );
         } else if (networkType === 'ripple') {
             response = await dispatch(
-                composeRippleTransactionFeeLevelsThunk({ formValues, formState }),
+                composeRippleTransactionFeeLevelsThunk({ formState, composeContext }),
             );
         } else if (networkType === 'cardano') {
             response = await dispatch(
-                composeCardanoTransactionFeeLevelsThunk({ formValues, formState }),
+                composeCardanoTransactionFeeLevelsThunk({ formState, composeContext }),
             );
         } else if (networkType === 'solana') {
             response = await dispatch(
-                composeSolanaTransactionFeeLevelsThunk({ formValues, formState }),
+                composeSolanaTransactionFeeLevelsThunk({ formState, composeContext }),
             );
         } else {
             const _exhaustiveCheck: never = networkType;
@@ -391,7 +391,7 @@ type CoinSpecificSignResponse = ActionsFromAsyncThunk<
 export const signTransactionThunk = createThunk<
     { serializedTx: string; signedTx?: BlockbookTransaction },
     {
-        formValues: FormState;
+        formState: FormState;
         precomposedTransaction: PrecomposedTransactionFinal | PrecomposedTransactionFinalCardano;
         selectedAccount: Account;
     },
@@ -399,7 +399,7 @@ export const signTransactionThunk = createThunk<
 >(
     `${SEND_MODULE_PREFIX}/signTransactionThunk`,
     async (
-        { formValues, precomposedTransaction, selectedAccount },
+        { formState, precomposedTransaction, selectedAccount },
         { dispatch, rejectWithValue, extra, getState },
     ) => {
         const {
@@ -434,7 +434,7 @@ export const signTransactionThunk = createThunk<
         } else {
             const { networkType } = selectedAccount;
             const thunkArguments = {
-                formValues,
+                formState,
                 precomposedTransaction,
                 selectedAccount,
                 device,

--- a/suite-common/wallet-core/src/send/sendFormTypes.ts
+++ b/suite-common/wallet-core/src/send/sendFormTypes.ts
@@ -6,11 +6,13 @@ import {
     ExcludedUtxos,
     FormState,
 } from '@suite-common/wallet-types';
-import { TokenInfo } from '@trezor/connect';
+import { TokenInfo, Unsuccessful } from '@trezor/connect';
 import { Network, NetworkSymbol } from '@suite-common/wallet-config';
+import { TrezorDevice } from '@suite-common/suite-types';
 
 export type SerializedTx = { tx: string; coin: NetworkSymbol };
 
+// TODO: is this still needed?
 export interface ComposeActionContext {
     account: Account;
     network: Network;
@@ -40,5 +42,23 @@ export type ComposeTransactionThunkArguments = {
 export type SignTransactionThunkArguments = {
     formValues: FormState;
     precomposedTransaction: PrecomposedTransactionFinal;
-    selectedAccount?: Account;
+    selectedAccount: Account;
+    device: TrezorDevice;
 };
+
+export type ComposeFeeLevelsError = {
+    error: 'fee-levels-compose-failed';
+    message?: string;
+};
+
+export type SignTransactionError = {
+    error: 'sign-transaction-failed';
+    message?: string;
+};
+
+export type PushTransactionError = {
+    error: 'push-transaction-failed';
+    metadata: Unsuccessful;
+};
+
+export type SendFormError = ComposeFeeLevelsError | SignTransactionError | PushTransactionError;

--- a/suite-common/wallet-core/src/send/sendFormTypes.ts
+++ b/suite-common/wallet-core/src/send/sendFormTypes.ts
@@ -35,12 +35,12 @@ export type EthTransactionData = {
 export type TransactionType = WalletAccountTransaction['type'];
 
 export type ComposeTransactionThunkArguments = {
-    formValues: FormState;
-    formState: ComposeActionContext;
+    formState: FormState;
+    composeContext: ComposeActionContext;
 };
 
 export type SignTransactionThunkArguments = {
-    formValues: FormState;
+    formState: FormState;
     precomposedTransaction: PrecomposedTransactionFinal;
     selectedAccount: Account;
     device: TrezorDevice;

--- a/suite-native/module-send/src/index.ts
+++ b/suite-native/module-send/src/index.ts
@@ -1,1 +1,2 @@
 export * from './navigation/SendStackNavigator';
+export * from './sendFormSlice';

--- a/suite-native/module-send/src/sendFormSlice.ts
+++ b/suite-native/module-send/src/sendFormSlice.ts
@@ -1,0 +1,61 @@
+import { isAnyOf } from '@reduxjs/toolkit';
+
+import { createSliceWithExtraDeps } from '@suite-common/redux-utils';
+import {
+    SendState as CommonSendState,
+    prepareSendFormReducer as prepareCommonSendFormReducer,
+    initialState as commonInitialState,
+    composeSendFormTransactionFeeLevelsThunk,
+    signTransactionThunk,
+    pushSendFormTransactionThunk,
+    SendFormError,
+} from '@suite-common/wallet-core';
+
+type NativeSendState = CommonSendState & {
+    error: null | SendFormError;
+};
+
+export type NativeSendRootState = {
+    wallet: {
+        send: NativeSendState;
+    };
+};
+
+export const initialNativeState: NativeSendState = {
+    ...commonInitialState,
+    error: null,
+};
+
+export const sendFormSlice = createSliceWithExtraDeps({
+    name: 'send',
+    initialState: initialNativeState,
+    reducers: {},
+    extraReducers: (builder, extra) => {
+        const commonSendFormReducer = prepareCommonSendFormReducer(extra);
+        builder
+            .addMatcher(
+                isAnyOf(
+                    composeSendFormTransactionFeeLevelsThunk.pending,
+                    signTransactionThunk.pending,
+                    pushSendFormTransactionThunk.pending,
+                ),
+                state => {
+                    state.error = null;
+                },
+            )
+            .addMatcher(
+                isAnyOf(
+                    composeSendFormTransactionFeeLevelsThunk.rejected,
+                    signTransactionThunk.rejected,
+                    pushSendFormTransactionThunk.rejected,
+                ),
+                (state, { payload: error }) => {
+                    state.error = error ?? null;
+                },
+            )
+            // In case that this reducer does not match the action, try to handle it by suite-common sendFormReducer.
+            .addDefaultCase((state, action) => {
+                commonSendFormReducer(state, action);
+            });
+    },
+});

--- a/suite-native/module-send/src/sendFormThunks.ts
+++ b/suite-native/module-send/src/sendFormThunks.ts
@@ -54,8 +54,8 @@ export const onDeviceTransactionReviewThunk = createThunk<
         //compose transaction with specific fee levels
         const precomposedFeeLevels = await dispatch(
             composeSendFormTransactionFeeLevelsThunk({
-                formValues: formState,
-                formState: composeContext,
+                formState,
+                composeContext,
             }),
         ).unwrap();
 
@@ -80,7 +80,7 @@ export const onDeviceTransactionReviewThunk = createThunk<
             deviceCallback: () =>
                 dispatch(
                     signTransactionThunk({
-                        formValues: formState,
+                        formState,
                         precomposedTransaction,
                         selectedAccount: account,
                     }),

--- a/suite-native/module-send/src/sendFormThunks.ts
+++ b/suite-native/module-send/src/sendFormThunks.ts
@@ -4,7 +4,7 @@ import { isRejected } from '@reduxjs/toolkit';
 import { createThunk } from '@suite-common/redux-utils';
 import {
     ComposeActionContext,
-    composeSendFormTransactionThunk,
+    composeSendFormTransactionFeeLevelsThunk,
     deviceActions,
     enhancePrecomposedTransactionThunk,
     pushSendFormTransactionThunk,
@@ -53,7 +53,7 @@ export const onDeviceTransactionReviewThunk = createThunk<
 
         //compose transaction with specific fee levels
         const precomposedFeeLevels = await dispatch(
-            composeSendFormTransactionThunk({
+            composeSendFormTransactionFeeLevelsThunk({
                 formValues: formState,
                 formState: composeContext,
             }),
@@ -112,7 +112,7 @@ export const sendTransactionAndCleanupSendFormThunk = createThunk(
         );
 
         if (isRejected(response)) {
-            return rejectWithValue(response.error ?? 'Failed to push transaction to blockchain.');
+            return rejectWithValue(response.error);
         }
 
         dispatch(sendFormActions.dispose());

--- a/suite-native/state/package.json
+++ b/suite-native/state/package.json
@@ -30,6 +30,7 @@
         "@suite-native/feature-flags": "workspace:*",
         "@suite-native/graph": "workspace:*",
         "@suite-native/message-system": "workspace:*",
+        "@suite-native/module-send": "workspace:*",
         "@suite-native/settings": "workspace:*",
         "@suite-native/storage": "workspace:*",
         "@trezor/connect": "workspace:*",

--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -8,10 +8,10 @@ import {
     prepareDeviceReducer,
     prepareDiscoveryReducer,
     prepareFiatRatesReducer,
-    prepareSendFormReducer,
     prepareTransactionsReducer,
 } from '@suite-common/wallet-core';
 import { appSettingsReducer, appSettingsPersistWhitelist } from '@suite-native/settings';
+import { sendFormSlice } from '@suite-native/module-send';
 import { logsSlice } from '@suite-common/logger';
 import {
     migrateAccountLabel,
@@ -44,7 +44,7 @@ const messageSystemReducer = prepareMessageSystemReducer(extraDependencies);
 const deviceReducer = prepareDeviceReducer(extraDependencies);
 const discoveryReducer = prepareDiscoveryReducer(extraDependencies);
 const tokenDefinitionsReducer = prepareTokenDefinitionsReducer(extraDependencies);
-const sendFormReducer = prepareSendFormReducer(extraDependencies);
+const sendFormReducer = sendFormSlice.prepareReducer(extraDependencies);
 
 export const prepareRootReducers = async () => {
     const appSettingsPersistedReducer = await preparePersistReducer({

--- a/suite-native/state/tsconfig.json
+++ b/suite-native/state/tsconfig.json
@@ -33,6 +33,7 @@
         { "path": "../feature-flags" },
         { "path": "../graph" },
         { "path": "../message-system" },
+        { "path": "../module-send" },
         { "path": "../settings" },
         { "path": "../storage" },
         { "path": "../../packages/connect" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9955,6 +9955,7 @@ __metadata:
     "@suite-native/feature-flags": "workspace:*"
     "@suite-native/graph": "workspace:*"
     "@suite-native/message-system": "workspace:*"
+    "@suite-native/module-send": "workspace:*"
     "@suite-native/settings": "workspace:*"
     "@suite-native/storage": "workspace:*"
     "@trezor/connect": "workspace:*"


### PR DESCRIPTION

## Description
- d4d1ab31bb274d4788bc404a6eb9da02c797ecd9: If a send form redux thunks fails, it resolves as a rejected with a error object as a return value.
- c1243dd17bbb7685a9d25e41b91ff5d3cbff3745: better naming of thunk arguments
- e22b23f4f7bb185e3656a49b055d20318fd21533: send form errors handled and saved in suite-native redux state


## Related Issue

Resolve #13125 

