### PR TITLE
fix(suite): update the country select component on trade dashboard

### DIFF
--- a/packages/components/src/components/form/Select/Select.tsx
+++ b/packages/components/src/components/form/Select/Select.tsx
@@ -170,7 +170,7 @@ const Wrapper = styled.div<WrapperProps>`
         flex-wrap: nowrap;
         min-width: ${({ $minValueWidth }) => $minValueWidth};
         justify-content: ${({ $isClean }) => ($isClean ? 'flex-end' : 'flex-start')};
-        padding: 0;
+        padding: 0 ${spacingsPx.xl} 0 0;
         border: none;
     }
 
@@ -179,16 +179,25 @@ const Wrapper = styled.div<WrapperProps>`
         display: flex;
         align-items: center;
         justify-content: ${({ $isClean }) => ($isClean ? 'flex-end' : 'flex-start')};
-        width: 100%;
         max-width: initial;
         color: ${({ $isDisabled, theme }) =>
             $isDisabled ? theme.textDisabled : theme.textDefault};
         border-style: none;
         transform: none;
-        margin-left: 0;
+        margin: 0;
 
         &:hover {
-            cursor: ${({ $isSearchable }) => $isSearchable && 'text'};
+            cursor: ${({ $isSearchable }) => ($isSearchable ? 'text' : 'pointer')};
+        }
+    }
+
+    .${reactSelectClassNamePrefix}__single-value + .${reactSelectClassNamePrefix}__input-container {
+        margin-left: 0;
+    }
+
+    .${reactSelectClassNamePrefix}__input-container {
+        &:hover {
+            cursor: ${({ $isSearchable }) => ($isSearchable ? 'text' : 'pointer')};
         }
     }
 

--- a/packages/suite/src/views/wallet/coinmarket/buy/components/BuyForm/Footer/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/components/BuyForm/Footer/index.tsx
@@ -7,6 +7,7 @@ import { getCountryLabelParts } from 'src/utils/wallet/coinmarket/coinmarketUtil
 import { CountryOption } from 'src/types/wallet/coinmarketCommonTypes';
 import { Translation } from 'src/components/suite';
 import { FooterWrapper, Left, Right } from 'src/views/wallet/coinmarket';
+import { spacingsPx } from '@trezor/theme';
 
 const OptionLabel = styled.div`
     display: flex;
@@ -36,6 +37,7 @@ const Label = styled.div`
     padding-top: 1px;
     color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+    margin-right: ${spacingsPx.xs};
 `;
 
 const StyledButton = styled(Button)`
@@ -76,8 +78,9 @@ const Footer = () => {
                         <StyledSelect
                             data-test="@coinmarket/buy/country-select"
                             options={regional.countriesOptions}
-                            isSearchable
+                            isSearchable={false}
                             value={value}
+                            size="small"
                             formatOptionLabel={(option: CountryOption) => {
                                 const labelParts = getCountryLabelParts(option.label);
                                 if (!labelParts) return null;
@@ -93,7 +96,6 @@ const Footer = () => {
                             }}
                             isClearable={false}
                             minValueWidth="160px"
-                            isClean
                             onChange={(selected: any) => {
                                 onChange(selected);
                                 setAmountLimits(undefined);


### PR DESCRIPTION
## Description

Updated the country select component on trade dashboard so that is more obvious it can be used to type in the country. Fixed some visual issues. Could not fix the issue where the selected country can be deleted with backspace, should be supported by the underlying react-select component (via props `isClearable` and `backspaceRemovesValue`) but custom components probably prevent it to work properly.

## Screenshots:

### Before:

<img width="1224" alt="Screenshot 2024-07-17 at 20 37 56" src="https://github.com/user-attachments/assets/6af82c92-b521-4d1f-9f8a-9be99cfaf89e">

### After:

<img width="1224" alt="Screenshot 2024-07-17 at 20 37 07" src="https://github.com/user-attachments/assets/03262cde-f6dc-4f7c-96d8-bd056bfa97bf">
