### PR TITLE
feat(suite): unhide unrecognized token confirmation

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UnhideTokenModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UnhideTokenModal.tsx
@@ -1,0 +1,62 @@
+import styled from 'styled-components';
+
+import { Translation } from 'src/components/suite';
+import { useDispatch } from 'src/hooks/suite/useDispatch';
+import { Button } from '@trezor/components';
+import { DialogModal } from '../Modal/DialogRenderer';
+import {
+    DefinitionType,
+    tokenDefinitionsActions,
+    TokenManagementAction,
+} from '@suite-common/token-definitions';
+import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
+import { useSelector } from 'src/hooks/suite';
+
+const StyledModal = styled(DialogModal)`
+    width: 600px;
+`;
+
+interface UnhideTokenModalProps {
+    address: string;
+    onCancel: () => void;
+}
+
+export const UnhideTokenModal = ({ address, onCancel }: UnhideTokenModalProps) => {
+    const account = useSelector(selectSelectedAccount);
+    const dispatch = useDispatch();
+
+    if (!account) return null;
+
+    const onUnhide = () => {
+        dispatch(
+            tokenDefinitionsActions.setTokenStatus({
+                networkSymbol: account.symbol,
+                contractAddress: address,
+                status: TokenManagementAction.SHOW,
+                type: DefinitionType.COIN,
+            }),
+        );
+        onCancel();
+    };
+
+    return (
+        <StyledModal
+            isCancelable
+            onCancel={onCancel}
+            icon="warningTriangleLight"
+            iconVariant="warning"
+            bodyHeading={<Translation id="TR_UNHIDE_TOKEN_TITLE" />}
+            text={<Translation id="TR_UNHIDE_TOKEN_TEXT" />}
+            bottomBarComponents={
+                <>
+                    <Button variant="warning" onClick={onUnhide}>
+                        <Translation id="TR_UNHIDE" />
+                    </Button>
+                    <Button variant="tertiary" onClick={onCancel}>
+                        <Translation id="TR_CANCEL" />
+                    </Button>
+                </>
+            }
+        />
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
@@ -39,6 +39,7 @@ import {
     UnstakeModal,
     ClaimModal,
     CopyAddressModal,
+    UnhideTokenModal,
 } from 'src/components/suite/modals';
 import type { AcquiredDevice } from 'src/types/suite';
 import { openXpubModal, showXpub } from 'src/actions/wallet/publicKeyActions';
@@ -228,6 +229,8 @@ export const UserContextModal = ({
                     addressType={payload.addressType}
                 />
             );
+        case 'unhide-token':
+            return <UnhideTokenModal onCancel={onCancel} address={payload.address} />;
         case 'passphrase-mismatch-warning':
             return <PassphraseMismatchModal onCancel={onCancel} />;
         default:

--- a/packages/suite/src/components/suite/modals/index.tsx
+++ b/packages/suite/src/components/suite/modals/index.tsx
@@ -48,3 +48,4 @@ export { UnstakeModal } from './ReduxModal/UserContextModal/UnstakeModal/Unstake
 export { ClaimModal } from './ReduxModal/UserContextModal/ClaimModal/ClaimModal';
 export { MultiShareBackupModal } from './ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupModal';
 export { CopyAddressModal } from './ReduxModal/CopyAddressModal';
+export { UnhideTokenModal } from './ReduxModal/UnhideTokenModal';

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2454,6 +2454,14 @@ export default defineMessages({
         defaultMessage: 'Copy',
         id: 'TR_COPY_TO_CLIPBOARD',
     },
+    TR_UNHIDE_TOKEN_TITLE: {
+        defaultMessage: 'Unhide this token?',
+        id: 'TR_UNHIDE_TOKEN_TITLE',
+    },
+    TR_UNHIDE_TOKEN_TEXT: {
+        defaultMessage: 'This token appears to be suspicious and may be a scam.',
+        id: 'TR_UNHIDE_TOKEN_TEXT',
+    },
     TR_NOT_YOUR_RECEIVE_ADDRRESS: {
         defaultMessage: "This isn't your receive address.",
         id: 'TR_NOT_YOUR_RECEIVE_ADDRRESS',

--- a/packages/suite/src/views/wallet/tokens/common/TokenList.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokenList.tsx
@@ -140,6 +140,7 @@ interface TokenListProps {
     tokenStatusType: TokenManagementAction;
     hideRates?: boolean;
     searchQuery?: string;
+    isUnverifiedTable?: boolean;
 }
 
 export const TokenList = ({
@@ -149,6 +150,7 @@ export const TokenList = ({
     tokenStatusType,
     hideRates,
     searchQuery,
+    isUnverifiedTable,
 }: TokenListProps) => {
     const dispatch = useDispatch();
     const { isMobileLayout } = useLayoutSize();
@@ -289,23 +291,14 @@ export const TokenList = ({
                                                             : true,
                                                 },
                                                 {
-                                                    label: (
-                                                        <Translation
-                                                            id={
-                                                                tokenStatusType ===
-                                                                TokenManagementAction.SHOW
-                                                                    ? 'TR_UNHIDE_TOKEN'
-                                                                    : 'TR_HIDE_TOKEN'
-                                                            }
-                                                        />
-                                                    ),
+                                                    label: <Translation id="TR_UNHIDE_TOKEN" />,
                                                     icon: 'EYE_CLOSED',
                                                     onClick: () =>
                                                         dispatch(
                                                             tokenDefinitionsActions.setTokenStatus({
                                                                 networkSymbol: network.symbol,
                                                                 contractAddress: token.contract,
-                                                                status: tokenStatusType,
+                                                                status: TokenManagementAction.HIDE,
                                                                 type: DefinitionType.COIN,
                                                             }),
                                                         ),
@@ -401,14 +394,21 @@ export const TokenList = ({
                                     <Button
                                         icon="EYE_SLASH"
                                         onClick={() =>
-                                            dispatch(
-                                                tokenDefinitionsActions.setTokenStatus({
-                                                    networkSymbol: network.symbol,
-                                                    contractAddress: token.contract,
-                                                    status: TokenManagementAction.SHOW,
-                                                    type: DefinitionType.COIN,
-                                                }),
-                                            )
+                                            isUnverifiedTable
+                                                ? dispatch(
+                                                      openModal({
+                                                          type: 'unhide-token',
+                                                          address: token.contract,
+                                                      }),
+                                                  )
+                                                : dispatch(
+                                                      tokenDefinitionsActions.setTokenStatus({
+                                                          networkSymbol: network.symbol,
+                                                          contractAddress: token.contract,
+                                                          status: TokenManagementAction.SHOW,
+                                                          type: DefinitionType.COIN,
+                                                      }),
+                                                  )
                                         }
                                         variant="tertiary"
                                         size="small"

--- a/packages/suite/src/views/wallet/tokens/hidden-tokens/components/HiddenTokensTable.tsx
+++ b/packages/suite/src/views/wallet/tokens/hidden-tokens/components/HiddenTokensTable.tsx
@@ -93,6 +93,7 @@ export const HiddenTokensTable = ({ selectedAccount, searchQuery }: HiddenTokens
                         account={account}
                         hideRates
                         tokenStatusType={TokenManagementAction.SHOW}
+                        isUnverifiedTable
                         tokens={filteredTokens.unverified}
                         network={network}
                         searchQuery={searchQuery}

--- a/suite-common/suite-types/src/modal.ts
+++ b/suite-common/suite-types/src/modal.ts
@@ -187,5 +187,9 @@ export type UserContextPayload =
           address: string;
       }
     | {
+          type: 'unhide-token';
+          address: string;
+      }
+    | {
           type: 'passphrase-mismatch-warning';
       };


### PR DESCRIPTION
## Description

When user want to unhide token inside unrecognized tokens table then a confirmation modal pops up.

Copy checked by Chris.

## Related Issue

Resolve #13336

## Screenshots:
![Screenshot 2024-07-18 at 9 29 41 AM](https://github.com/user-attachments/assets/7f476248-feca-4f4d-ac76-90955370ad77)