### PR TITLE
fix(suite): transaction search with token name, symbol or contract

### DIFF
--- a/packages/blockchain-link-types/src/blockbook-api.ts
+++ b/packages/blockchain-link-types/src/blockbook-api.ts
@@ -52,6 +52,7 @@ export interface TokenTransfer {
     value?: string;
     multiTokenValues?: MultiTokenValue[];
     fingerprint?: string;
+    policyId?: string;
     unit?: string;
 }
 export interface Vout {

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -6964,7 +6964,7 @@ export default defineMessages({
     TR_TRANSACTIONS_SEARCH_TIP_1: {
         id: 'TR_TRANSACTIONS_SEARCH_TIP_1',
         defaultMessage:
-            'Tip: You can search for transaction IDs, addresses, labels, amounts and dates.',
+            'Tip: You can search for transaction IDs, addresses, tokens, labels, amounts and dates.',
     },
     TR_TRANSACTIONS_SEARCH_TIP_2: {
         id: 'TR_TRANSACTIONS_SEARCH_TIP_2',

--- a/packages/suite/src/utils/wallet/tokenUtils.ts
+++ b/packages/suite/src/utils/wallet/tokenUtils.ts
@@ -2,7 +2,7 @@ import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { Account, Rate, TokenAddress, RatesByKey } from '@suite-common/wallet-types';
 import { TokenInfo } from '@trezor/connect';
-import { getFiatRateKey } from '@suite-common/wallet-utils';
+import { getFiatRateKey, isTokenMatchesSearch } from '@suite-common/wallet-utils';
 import { NetworkSymbol, getNetworkFeatures } from '@suite-common/wallet-config';
 import { FiatCurrencyCode } from '@suite-common/suite-config';
 import {
@@ -86,14 +86,9 @@ export const getTokens = (
         const isHidden = coinDefinitions?.hide.includes(token.contract);
         const isShown = coinDefinitions?.show.includes(token.contract);
 
-        const query = searchQuery ? searchQuery.toLowerCase() : '';
-        const matchesQuery =
-            !searchQuery ||
-            token.symbol?.toLowerCase().includes(query) ||
-            token.name?.toLowerCase().includes(query) ||
-            token.contract.toLowerCase().includes(query);
+        const query = searchQuery ? searchQuery.trim().toLowerCase() : '';
 
-        if (!matchesQuery) return;
+        if (searchQuery && !isTokenMatchesSearch(token, query)) return;
 
         if (isShown) {
             shown.push(token);

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -7,6 +7,7 @@ import {
     AccountUtxo,
     PrecomposedTransactionFinalCardano,
     TokenTransfer,
+    TokenInfo,
 } from '@trezor/connect';
 import { arrayDistinct, bufferUtils } from '@trezor/utils';
 import {
@@ -1052,4 +1053,14 @@ export const isAddressBasedNetwork = (networkType: NetworkType) => {
     const exhaustiveCheck: never = networkType;
 
     return !!exhaustiveCheck;
+};
+
+export const isTokenMatchesSearch = (token: TokenInfo, search: string) => {
+    return (
+        token.symbol?.toLowerCase().includes(search) ||
+        token.name?.toLowerCase().includes(search) ||
+        token.contract.toLowerCase().includes(search) ||
+        token.fingerprint?.toLowerCase().includes(search) ||
+        token.policyId?.toLowerCase().includes(search)
+    );
 };


### PR DESCRIPTION
## Description

Enable search by token symbol, name or contract address inside transactions.

## Related Issue

Resolve #3544

## Screenshots:
![Screenshot 2024-07-18 at 10 08 52 AM](https://github.com/user-attachments/assets/737a1b2e-28a1-4abc-bc93-7410700677f5)
