### PR TITLE
feat(suite): add staking label to coin settings

### DIFF
--- a/packages/suite/src/components/suite/CoinList/Coin.tsx
+++ b/packages/suite/src/components/suite/CoinList/Coin.tsx
@@ -3,9 +3,9 @@ import { transparentize } from 'polished';
 import styled, { css, useTheme } from 'styled-components';
 import { variables, CoinLogo, Icon } from '@trezor/components';
 import { Translation } from 'src/components/suite';
-import type { ExtendedMessageDescriptor } from 'src/types/suite';
 import type { Network } from 'src/types/wallet';
 import { typography } from '@trezor/theme';
+import { TranslationKey } from '@suite-common/intl-types';
 
 const SettingsWrapper = styled.div<{
     $toggled: boolean;
@@ -154,7 +154,7 @@ const Check = styled.div<{ $visible: boolean }>`
 interface CoinProps {
     symbol: Network['symbol'];
     name: Network['name'];
-    label?: ExtendedMessageDescriptor['id'];
+    label?: TranslationKey;
     toggled: boolean;
     disabled?: boolean;
     forceHover?: boolean;

--- a/packages/suite/src/components/suite/CoinList/CoinList.tsx
+++ b/packages/suite/src/components/suite/CoinList/CoinList.tsx
@@ -10,7 +10,7 @@ import { useDevice, useDiscovery, useSelector } from 'src/hooks/suite';
 import type { Network } from 'src/types/wallet';
 
 import { Coin } from './Coin';
-import { TranslationKey } from '@suite-common/intl-types';
+import { getCoinLabel } from 'src/utils/suite/getCoinLabel';
 
 const Wrapper = styled.div`
     width: 100%;
@@ -50,7 +50,8 @@ export const CoinList = ({
     return (
         <Wrapper>
             {networks.map(network => {
-                const { symbol, label, name, support } = network;
+                const { symbol, name, support, features, testnet: isTestnet } = network;
+                const hasCustomBackend = !!blockchain[symbol].backends.selected;
 
                 const firmwareSupportRestriction =
                     deviceModelInternal && support?.[deviceModelInternal];
@@ -75,9 +76,7 @@ export const CoinList = ({
                     getCoinUnavailabilityMessage(unavailableReason);
                 const tooltipString = discoveryTooltip || lockedTooltip || unavailabilityTooltip;
 
-                const coinLabel = blockchain[symbol].backends.selected
-                    ? 'TR_CUSTOM_BACKEND'
-                    : (label as TranslationKey);
+                const label = getCoinLabel(features, isTestnet, hasCustomBackend);
 
                 return (
                     <Tooltip
@@ -97,7 +96,7 @@ export const CoinList = ({
                         <Coin
                             symbol={symbol}
                             name={name}
-                            label={coinLabel}
+                            label={label}
                             toggled={isEnabled}
                             disabled={disabled || (settingsMode && !isEnabled)}
                             forceHover={settingsMode}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/AdvancedCoinSettingsModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/AdvancedCoinSettingsModal.tsx
@@ -4,7 +4,8 @@ import { Modal, Translation } from 'src/components/suite';
 import { NETWORKS } from 'src/config/wallet';
 import { NetworkSymbol } from 'src/types/wallet';
 import { CustomBackends } from './CustomBackends/CustomBackends';
-import { TranslationKey } from '@suite-common/intl-types';
+import { getCoinLabel } from 'src/utils/suite/getCoinLabel';
+import { useSelector } from 'src/hooks/suite';
 
 const Section = styled.div`
     display: flex;
@@ -38,11 +39,16 @@ interface AdvancedCoinSettingsModalProps {
 }
 
 export const AdvancedCoinSettingsModal = ({ coin, onCancel }: AdvancedCoinSettingsModalProps) => {
+    const blockchain = useSelector(state => state.wallet.blockchain);
     const network = NETWORKS.find(network => network.symbol === coin);
 
     if (!network) {
         return null;
     }
+
+    const { symbol, name, features, testnet: isTestnet } = network;
+    const hasCustomBackend = !!blockchain[symbol].backends.selected;
+    const label = getCoinLabel(features, isTestnet, hasCustomBackend);
 
     return (
         <Modal
@@ -50,14 +56,14 @@ export const AdvancedCoinSettingsModal = ({ coin, onCancel }: AdvancedCoinSettin
             onCancel={onCancel}
             heading={
                 <Heading>
-                    <CoinLogo symbol={network.symbol} />
+                    <CoinLogo symbol={symbol} />
 
                     <Header>
-                        <span>{network.name}</span>
+                        <span>{name}</span>
 
-                        {network.label && (
+                        {label && (
                             <Subheader>
-                                <Translation id={network.label as TranslationKey} />
+                                <Translation id={label} />
                             </Subheader>
                         )}
                     </Header>

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3219,6 +3219,10 @@ export default defineMessages({
         defaultMessage: 'Including tokens',
         id: 'TR_INCLUDING_TOKENS',
     },
+    TR_INCLUDING_TOKENS_AND_STAKING: {
+        defaultMessage: 'Incl. tokens & staking',
+        id: 'TR_INCLUDING_TOKENS_AND_STAKING',
+    },
     TR_NETWORK_ETHEREUM_CLASSIC: {
         defaultMessage: 'Ethereum Classic',
         id: 'TR_NETWORK_ETHEREUM_CLASSIC',

--- a/packages/suite/src/utils/suite/__tests__/getCoinLabel.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/getCoinLabel.test.ts
@@ -1,0 +1,18 @@
+import { getCoinLabel } from '../getCoinLabel';
+
+describe('utils/suite/getCoinLabel', () => {
+    it('should return custom backend label', () => {
+        expect(getCoinLabel(['tokens'], true, true)).toBe('TR_CUSTOM_BACKEND');
+    });
+    it('should return testnet label', () => {
+        expect(getCoinLabel(['tokens'], true, false)).toBe('TR_TESTNET_COINS_LABEL');
+    });
+    it('should return tokens label', () => {
+        expect(getCoinLabel(['tokens'], false, false)).toBe('TR_INCLUDING_TOKENS');
+    });
+    it('should return tokens and staking label', () => {
+        expect(getCoinLabel(['tokens', 'staking'], false, false)).toBe(
+            'TR_INCLUDING_TOKENS_AND_STAKING',
+        );
+    });
+});

--- a/packages/suite/src/utils/suite/getCoinLabel.ts
+++ b/packages/suite/src/utils/suite/getCoinLabel.ts
@@ -1,0 +1,21 @@
+import type { TranslationKey } from '@suite-common/intl-types';
+import type { NetworkFeature } from '@suite-common/wallet-config';
+
+export const getCoinLabel = (
+    features: NetworkFeature[],
+    isTestnet: boolean,
+    isCustomBackend: boolean,
+): TranslationKey | undefined => {
+    const hasTokens = features.includes('tokens');
+    const hasStaking = features.includes('staking');
+
+    if (isCustomBackend) {
+        return 'TR_CUSTOM_BACKEND';
+    } else if (isTestnet) {
+        return 'TR_TESTNET_COINS_LABEL';
+    } else if (hasTokens && hasStaking) {
+        return 'TR_INCLUDING_TOKENS_AND_STAKING';
+    } else if (hasTokens) {
+        return 'TR_INCLUDING_TOKENS';
+    }
+};

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -81,7 +81,6 @@ export const networks = {
             'nft-definitions',
             'staking',
         ],
-        label: 'TR_INCLUDING_TOKENS',
         customBackends: ['blockbook'],
         accountTypes: {},
         coingeckoId: 'ethereum',
@@ -101,7 +100,6 @@ export const networks = {
             queryString: '',
         },
         features: ['sign-verify', 'tokens', 'coin-definitions'],
-        label: 'TR_INCLUDING_TOKENS',
         customBackends: ['blockbook'],
         accountTypes: {},
         coingeckoId: 'ethereum-classic',
@@ -295,7 +293,6 @@ export const networks = {
             [DeviceModelInternal.T2B1]: '2.6.1',
             [DeviceModelInternal.T3T1]: '2.7.1',
         },
-        label: 'TR_INCLUDING_TOKENS',
         customBackends: ['blockfrost'],
         accountTypes: {
             legacy: {
@@ -327,7 +324,6 @@ export const networks = {
             [DeviceModelInternal.T2B1]: '2.6.4',
             [DeviceModelInternal.T3T1]: '2.7.1',
         },
-        label: 'TR_INCLUDING_TOKENS',
         customBackends: ['solana'],
         accountTypes: {},
         coingeckoId: 'solana',
@@ -339,7 +335,6 @@ export const networks = {
         bip43Path: "m/44'/60'/0'/0/i",
         decimals: 18,
         testnet: false,
-        label: 'TR_INCLUDING_TOKENS',
         explorer: {
             tx: 'https://matic2.trezor.io/tx/',
             account: 'https://matic2.trezor.io/address/',
@@ -367,7 +362,6 @@ export const networks = {
             queryString: '',
         },
         features: ['rbf', 'sign-verify', 'tokens', 'coin-definitions', 'nft-definitions'],
-        label: 'TR_INCLUDING_TOKENS',
         customBackends: ['blockbook'],
         accountTypes: {},
         coingeckoId: 'binance-smart-chain',
@@ -380,7 +374,6 @@ export const networks = {
         bip43Path: "m/84'/1'/i'",
         decimals: 8,
         testnet: true,
-        label: 'TR_TESTNET_COINS_LABEL',
         explorer: {
             tx: 'https://tbtc1.trezor.io/tx/',
             account: 'https://tbtc1.trezor.io/xpub/',
@@ -414,7 +407,6 @@ export const networks = {
         bip43Path: "m/84'/1'/i'",
         decimals: 8,
         testnet: true,
-        label: 'TR_TESTNET_COINS_LABEL',
         explorer: {
             tx: 'http://localhost:19121/tx/',
             account: 'http://localhost:19121/xpub/',
@@ -450,7 +442,6 @@ export const networks = {
         chainId: 11155111,
         decimals: 18,
         testnet: true,
-        label: 'TR_TESTNET_COINS_LABEL',
         explorer: {
             tx: 'https://sepolia1.trezor.io/tx/',
             account: 'https://sepolia1.trezor.io/address/',
@@ -470,7 +461,6 @@ export const networks = {
         chainId: 17000,
         decimals: 18,
         testnet: true,
-        label: 'TR_TESTNET_COINS_LABEL',
         explorer: {
             tx: 'https://holesky1.trezor.io/tx/',
             account: 'https://holesky1.trezor.io/address/',
@@ -489,7 +479,6 @@ export const networks = {
         bip43Path: "m/44'/144'/i'/0/0",
         decimals: 6,
         testnet: true,
-        label: 'TR_TESTNET_COINS_LABEL',
         explorer: {
             tx: 'https://test.bithomp.com/explorer/',
             account: 'https://test.bithomp.com/explorer/',
@@ -506,7 +495,6 @@ export const networks = {
         name: 'Cardano Testnet',
         networkType: 'cardano',
         bip43Path: "m/1852'/1815'/i'",
-        label: 'TR_TESTNET_COINS_LABEL',
         decimals: 6,
         testnet: true,
         features: ['tokens', 'staking'],
@@ -539,7 +527,6 @@ export const networks = {
         name: 'Solana Devnet',
         networkType: 'solana',
         bip43Path: "m/44'/501'/i'/0'",
-        label: 'TR_TESTNET_COINS_LABEL',
         decimals: 9,
         testnet: true,
         features: ['tokens' /* , 'staking' */],
@@ -594,7 +581,6 @@ export type Network = Without<NetworkValue, 'accountTypes'> & {
     isHidden?: boolean;
     chainId?: number;
     features?: NetworkFeature[];
-    label?: string[]; // Originally ExtendedMessageDescriptor['id'] but inferred type exceeds the maximum length for serialization
     support?: {
         [key in DeviceModelInternal]: string;
     };


### PR DESCRIPTION
## Description

Added staking label to supporting coins. Label is now defined using network features, not directly by a label property in the networks config.

## Screenshots:

### Before:

<img width="1224" alt="Screenshot 2024-07-18 at 11 22 41" src="https://github.com/user-attachments/assets/fe15b14f-efb5-4b35-b414-6acd9c4a7215">

### After:

<img width="1224" alt="Screenshot 2024-07-18 at 11 19 40" src="https://github.com/user-attachments/assets/e753aa2c-a89e-43f4-b4b9-bf3ade621b25">
