### PR TITLE
fix(suite): Make view only promo content screen more responsive

### DIFF
--- a/packages/suite/src/views/view-only/MacWindow.tsx
+++ b/packages/suite/src/views/view-only/MacWindow.tsx
@@ -1,4 +1,4 @@
-import { ElevationContext, useElevation } from '@trezor/components';
+import { ElevationContext, useElevation, variables } from '@trezor/components';
 import {
     Elevation,
     borders,
@@ -9,14 +9,22 @@ import {
 import { ReactNode } from 'react';
 import styled from 'styled-components';
 
+const MAC_WINDOW_HEIGHT = '184px';
+
 const Window = styled.div<{ $elevation: Elevation }>`
-    width: 258px;
-    height: 184px;
+    min-width: 258px;
+    height: ${MAC_WINDOW_HEIGHT};
     border: 1px solid ${mapElevationToBorder};
     background-color: ${mapElevationToBackground};
     border-bottom: 0;
-    border-top-left-radius: ${borders.radii.sm};
-    border-top-right-radius: ${borders.radii.sm};
+    border-radius: ${borders.radii.sm} ${borders.radii.sm} 0 0;
+    flex: 1 1 auto;
+
+    @media (max-width: ${variables.SCREEN_SIZE.SM}) {
+        height: calc(${MAC_WINDOW_HEIGHT} + ${spacingsPx.md});
+        border-radius: ${borders.radii.sm};
+        padding-bottom: ${spacingsPx.md};
+    }
 `;
 
 const WindowBar = styled.div<{ $elevation: Elevation }>`

--- a/packages/suite/src/views/view-only/ViewOnlyPromoContent.tsx
+++ b/packages/suite/src/views/view-only/ViewOnlyPromoContent.tsx
@@ -6,6 +6,7 @@ import {
     Image,
     Text,
     useElevation,
+    variables,
 } from '@trezor/components';
 import { FormattedCryptoAmount, Translation } from '../../components/suite';
 import styled from 'styled-components';
@@ -29,7 +30,7 @@ const StyledCard = styled(Card)`
     flex-direction: column;
     gap: ${spacingsPx.md};
     padding: ${spacingsPx.xxs};
-    width: 476px;
+    max-width: 476px;
 `;
 
 const Callout = styled.div`
@@ -67,6 +68,20 @@ const LargeDeviceImage = styled(DeviceImage)`
     width: 93px;
 `;
 
+const LargeDeviceImageContainer = styled.div`
+    display: flex;
+    flex: 1 1 auto;
+    align-items: center;
+    justify-content: center;
+    padding: ${spacingsPx.zero} ${spacingsPx.md};
+    width: 100%;
+    overflow: hidden;
+
+    @media (max-width: ${variables.SCREEN_SIZE.SM}) {
+        padding: ${spacingsPx.zero} ${spacingsPx.lg} ${spacingsPx.sm};
+    }
+`;
+
 const DeviceItem = styled.div`
     display: flex;
     flex-direction: row;
@@ -95,7 +110,7 @@ const IllustrativeExamplePositioning = styled.div`
     top: -10px;
     right: 10px;
     display: flex;
-    gap: 8px;
+    gap: ${spacingsPx.xs};
 `;
 const IllustrativeExampleArrowPositioning = styled.div``;
 
@@ -103,17 +118,22 @@ const StyledTop = styled.div<{ $elevation: Elevation }>`
     display: flex;
     flex-direction: row;
     background-color: ${mapElevationToBackground};
-    height: 196px;
+    min-height: 196px;
     border-radius: ${borders.radii.sm};
     padding-top: ${spacingsPx.sm};
     padding-left: ${spacingsPx.lg};
-    gap: ${spacingsPx.xxxxl};
+
+    @media (max-width: ${variables.SCREEN_SIZE.SM}) {
+        flex-flow: row wrap;
+        gap: ${spacingsPx.sm};
+        padding-right: ${spacingsPx.lg};
+    }
 `;
 
 const Bottom = styled.div`
     display: flex;
     flex-direction: column;
-    padding: ${spacingsPx.xxl} ${spacingsPx.lg} ${spacingsPx.lg} ${spacingsPx.lg};
+    padding: ${spacingsPx.lg};
     gap: ${spacingsPx.xxl};
 `;
 
@@ -126,6 +146,11 @@ const ChartText = styled.div`
 const ButtonsContainer = styled.div`
     display: flex;
     gap: ${spacingsPx.sm};
+    flex-direction: row;
+
+    @media (max-width: ${variables.SCREEN_SIZE.SM}) {
+        flex-flow: row wrap;
+    }
 `;
 
 const Top = () => {
@@ -168,8 +193,13 @@ const Top = () => {
                         </IllustrativeExamplePositioning>
                     </WindowChart>
                 </MacWindow>
+                <LargeDeviceImageContainer>
+                    <LargeDeviceImage
+                        alt="Trezor"
+                        image={`TREZOR_${selectedDeviceModelInternal}`}
+                    />
+                </LargeDeviceImageContainer>
             </ElevationContext>
-            <LargeDeviceImage alt="Trezor" image={`TREZOR_${selectedDeviceModelInternal}`} />
         </StyledTop>
     );
 };


### PR DESCRIPTION
## Description

Use `spacingsPx` for some css padding/margin values instead, where possible, add some more small adjustments.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/13261

## Screenshots:
**Before:**
![promo_before](https://github.com/user-attachments/assets/1830722d-5be3-48a5-9af9-81aaad5865ae)

**After:**
![promo_after](https://github.com/user-attachments/assets/baf2c284-64a8-4349-8daf-dbe6fa298e40)

