### PR TITLE
fix(suite-native): passphrase UI tweaks

### DIFF
--- a/suite-native/module-authorize-device/src/components/passphrase/PassphraseForm.tsx
+++ b/suite-native/module-authorize-device/src/components/passphrase/PassphraseForm.tsx
@@ -73,6 +73,7 @@ export const PassphraseForm = ({ inputLabel, onFocus }: PassphraseFormProps) => 
 
     const form = useForm<PassphraseFormValues>({
         validation: passphraseFormSchema,
+        reValidateMode: 'onSubmit',
         defaultValues: {
             passphrase: '',
         },

--- a/suite-native/module-authorize-device/src/components/passphrase/PassphraseScreenHeader.tsx
+++ b/suite-native/module-authorize-device/src/components/passphrase/PassphraseScreenHeader.tsx
@@ -70,6 +70,7 @@ export const PassphraseScreenHeader = () => {
                 secondaryButtonTitle: (
                     <Translation id="modulePassphrase.confirmOnDevice.warningSheet.secondaryButton" />
                 ),
+                secondaryButtonVariant: 'redElevation0',
             });
         } else {
             TrezorConnect.cancel();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Missing color definition for secondary button selected gray color as default. Should be red, so I'm defining it in the params.

Second commit changes revalidation mode of passphrase form. @shenkys Would like to bring this approach of validating simple 1 input forms only on submit (hiding the submit button if values are invalid). This brings inconsistency with other forms (xpub import, rename account), however it's been agreed that inconsistency is now okay with this for the purpose of having passphrase already implemented with this approach rather than re-doing other forms as well. He will create an issue to unify this.


## Screenshots:
<img width="464" alt="image" src="https://github.com/user-attachments/assets/f5b6e34c-fcd9-4007-b2c7-05dcf3546c29">


https://github.com/user-attachments/assets/85e48b40-a88d-4f90-a89a-0a642bf1f064


