### PR TITLE
fix(suite): removing obsolete security check copy

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -146,10 +146,6 @@ export default defineMessages({
         defaultMessage: 'Add wallet',
         id: 'TR_ADD_WALLET',
     },
-    TR_ADDITIONAL_SECURITY_FEATURES: {
-        defaultMessage: 'In the meantime, make sure you have completed all security steps below.',
-        id: 'TR_ADDITIONAL_SECURITY_FEATURES',
-    },
     TR_CONTRACT: {
         defaultMessage: 'Contract',
         id: 'TR_CONTRACT',

--- a/packages/suite/src/views/dashboard/components/PortfolioCard/components/EmptyWallet.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/components/EmptyWallet.tsx
@@ -35,15 +35,6 @@ const StyledImage = styled(Image)`
     margin-bottom: 24px;
 `;
 
-const SecurityItem = styled.div`
-    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
-    font-size: ${variables.FONT_SIZE.SMALL};
-
-    & + & {
-        margin-top: 12px;
-    }
-`;
-
 type EmptyWalletProps = HTMLAttributes<HTMLDivElement>;
 
 export const EmptyWallet = (props: EmptyWalletProps) => (
@@ -53,9 +44,6 @@ export const EmptyWallet = (props: EmptyWalletProps) => (
             <Title>
                 <Translation id="TR_YOUR_WALLET_IS_READY_WHAT" />
             </Title>
-            <SecurityItem>
-                <Translation id="TR_ADDITIONAL_SECURITY_FEATURES" />
-            </SecurityItem>
         </Content>
     </Wrapper>
 );


### PR DESCRIPTION
Removing obsolete security check copy since we've get rid of the security check boxes a while ago. 

Before
<img width="1220" alt="image" src="https://github.com/user-attachments/assets/0ea1f337-b509-4ae0-afed-cf674720b942">

After 
<img width="1617" alt="image" src="https://github.com/user-attachments/assets/4539af25-5b04-4762-ba11-d64e187ebfba">
