### PR TITLE
Fix/native/add new account visibility

### DIFF
--- a/suite-native/discovery/src/discoveryThunks.ts
+++ b/suite-native/discovery/src/discoveryThunks.ts
@@ -217,13 +217,25 @@ const addAccountByDescriptorThunk = createThunk(
             ...getAccountInfoDetailsLevel(bundleItem.coin),
         });
 
+        const accounts = selectDeviceAccountsForNetworkSymbolAndAccountType(
+            getState(),
+            bundleItem.coin,
+            bundleItem.accountType,
+        );
+
+        const hasEmptyAccount = accounts.some(account => account.empty);
+
         if (success) {
             dispatch(
                 accountsActions.createIndexLabeledAccount({
                     discoveryItem: bundleItem,
                     deviceState,
                     accountInfo,
-                    visible: true,
+                    // In most cases, there should be already empty account, because this thunk is called after
+                    // changing visibility of first empty hidden account.
+                    // But if there is no empty account (discovery previously failed), we should show this one.
+                    // And because of async calls, we check for empty account here and not passing the value from the previous step.
+                    visible: !hasEmptyAccount,
                 }),
             );
 

--- a/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
+++ b/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
@@ -280,7 +280,12 @@ export const useAddCoinAccount = () => {
             account => account.symbol === networkSymbol && account.accountType === accountType,
         );
 
-        const firstHiddenEmptyAccount = accounts.find(account => account.empty && !account.visible);
+        const firstHiddenEmptyAccount = pipe(
+            accounts,
+            A.filter(account => account.empty && !account.visible),
+            A.sortBy(account => account.index),
+            A.head,
+        );
 
         const canAddAccount = checkCanAddAccount(accounts);
 

--- a/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
+++ b/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
@@ -314,7 +314,10 @@ export const useAddCoinAccount = () => {
             }),
         );
 
-        if (isRejected(newAccountResult)) {
+        if (
+            !firstHiddenEmptyAccount && // Do not show error if we are just making the first hidden empty account visible
+            isRejected(newAccountResult)
+        ) {
             let screen = AppTabsRoutes.HomeStack;
             if (flowType === 'accounts') {
                 screen = AppTabsRoutes.AccountsStack;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We've changed the adding new account flow to always discover one more account in addition to appearing when a transaction comes in on it. It was supposed to be hidden, but was always visible.

Two more edge cases handled - 
- make sure to change visibility of the empty account with the lowest index (previously it could happen to show the second one)
- do not show errors if the discovery fails, because user want to see the new account and he already see it - he doesn't care about background discovery of one extra account

## Related Issue

Resolve #13435

