### PR TITLE
feat(ci): unused translations auto cleanup

### DIFF
--- a/.github/workflows/bot-crowdin-sync.yml
+++ b/.github/workflows/bot-crowdin-sync.yml
@@ -1,6 +1,13 @@
 name: "[Bot] Crowdin translations update"
 
-on: [workflow_dispatch]
+on:
+  workflow_dispatch:
+    inputs:
+      remove_unused_translations:
+        description: "Confirm removal of unused translations. Check them first in misc tests pipeline."
+        required: true
+        default: false
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -32,6 +39,9 @@ jobs:
           git checkout -B ${{ env.BRANCH_NAME }}
           yarn workspace @trezor/suite translations:download --token=${{ secrets.CROWDIN_PERSONAL_TOKEN }}
           yarn workspace @trezor/suite translations:backport-en
+          if [ "${{ github.event.inputs.remove_unused_translations }}" = "true" ]; then
+            yarn workspace @trezor/suite translations:list-unused --cleanup
+          fi
           yarn workspace @trezor/suite translations:format
           yarn workspace @trezor/suite translations:extract
           cat packages/suite-data/files/translations/master.json


### PR DESCRIPTION
## Description

Adds a `--cleanup` option to the `translations:list-unused` script, which automatically removes the unused messages from the file. 

The script also includes a `--pr` option, which will create a new branch with this change and submit a PR. 

This can be run from a new workflow in GitHub actions. The workflow is triggered manually to prevent too many PRs being created. 