### PR TITLE
fix(suite): multiple recipients fiat calculation send form

### DIFF
--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -15,13 +15,12 @@ import {
 import { goto } from 'src/actions/suite/routerActions';
 import { fillSendForm } from 'src/actions/suite/protocolActions';
 import { AppState } from 'src/types/suite';
-import { FormState, TokenAddress } from '@suite-common/wallet-types';
+import { FormState } from '@suite-common/wallet-types';
 import {
     getFeeLevels,
     getDefaultValues,
     amountToSatoshi,
     formatAmount,
-    getFiatRateKey,
 } from '@suite-common/wallet-utils';
 import { useSendFormOutputs } from './useSendFormOutputs';
 import { useSendFormFields } from './useSendFormFields';
@@ -32,7 +31,7 @@ import { PROTOCOL_TO_NETWORK } from 'src/constants/suite/protocol';
 import { useBitcoinAmountUnit } from './useBitcoinAmountUnit';
 import { useUtxoSelection } from './form/useUtxoSelection';
 import { useExcludedUtxos } from './form/useExcludedUtxos';
-import { selectCurrentFiatRates, selectFiatRatesByFiatRateKey } from '@suite-common/wallet-core';
+import { selectCurrentFiatRates } from '@suite-common/wallet-core';
 import { FiatCurrencyCode } from '@suite-common/suite-config';
 import { SendContextValues, UseSendFormState } from 'src/types/wallet/sendForm';
 
@@ -103,16 +102,6 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
 
     const { control, reset, register, getValues, formState, setValue, trigger } = useFormMethods;
 
-    const values = getValues();
-    const token = values?.outputs?.[0]?.token;
-    const fiatCurrency = values?.outputs?.[0]?.currency;
-
-    const fiatRateKey = getFiatRateKey(
-        props.selectedAccount.account.symbol,
-        fiatCurrency?.value as FiatCurrencyCode,
-        token as TokenAddress,
-    );
-    const fiatRate = useSelector(state => selectFiatRatesByFiatRateKey(state, fiatRateKey));
     const currentRates = useSelector(selectCurrentFiatRates);
 
     // register array fields (outputs array in react-hook-form)
@@ -166,7 +155,6 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
     // declare sendFormUtils, sub-hook of useSendForm
     const sendFormUtils = useSendFormFields({
         ...useFormMethods,
-        fiatRate,
         network: state.network,
     });
 
@@ -232,7 +220,6 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
         network: state.network,
         tokens: state.account.tokens,
         localCurrencyOption,
-        fiatRate,
         currentRates,
     });
 
@@ -384,7 +371,6 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
         ...state,
         ...useFormMethods,
         isLoading,
-        fiatRate,
         register,
         outputs: outputsFieldArray.fields,
         composedLevels,

--- a/packages/suite/src/hooks/wallet/useSendFormImport.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormImport.ts
@@ -30,7 +30,6 @@ export const useSendFormImport = ({
     network,
     tokens,
     localCurrencyOption,
-    fiatRate,
     currentRates,
 }: useSendFormImportProps) => {
     const dispatch = useDispatch();
@@ -100,6 +99,12 @@ export const useSendFormImport = ({
                     } else {
                         output.amount = cryptoAmount;
                     }
+
+                    const fiatRateKey = getFiatRateKey(
+                        network.symbol,
+                        itemCurrency as FiatCurrencyCode,
+                    );
+                    const fiatRate = currentRates?.[fiatRateKey];
 
                     // calculate Fiat from Amount
                     if (fiatRate?.rate) {

--- a/packages/suite/src/types/wallet/sendForm.ts
+++ b/packages/suite/src/types/wallet/sendForm.ts
@@ -14,7 +14,6 @@ import {
     Output,
     PrecomposedLevels,
     PrecomposedLevelsCardano,
-    Rate,
     WalletAccountTransaction,
 } from '@suite-common/wallet-types';
 import { FiatCurrencyCode } from '@suite-common/suite-config';
@@ -64,7 +63,6 @@ export type SendContextValues<TFormValues extends FormState = FormState> =
     UseFormReturn<TFormValues> &
         UseSendFormState & {
             isLoading: boolean;
-            fiatRate?: Rate;
             // additional fields
             outputs: Partial<Output & { id: string }>[]; // useFieldArray fields
             updateContext: (value: Partial<UseSendFormState>) => void;

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/Fiat.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/Fiat.tsx
@@ -14,16 +14,17 @@ import {
     amountToSatoshi,
     formatAmount,
     buildCurrencyOptions,
+    getFiatRateKey,
 } from '@suite-common/wallet-utils';
 import { CurrencyOption, Output } from '@suite-common/wallet-types';
 import { formInputsMaxLength } from '@suite-common/validators';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 import { NumberInput } from 'src/components/suite';
-import { useTranslation } from 'src/hooks/suite';
+import { useSelector, useTranslation } from 'src/hooks/suite';
 import { validateDecimals } from 'src/utils/suite/validation';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { FiatCurrencyCode } from '@suite-common/suite-config';
-import { updateFiatRatesThunk } from '@suite-common/wallet-core';
+import { selectFiatRatesByFiatRateKey, updateFiatRatesThunk } from '@suite-common/wallet-core';
 import { useDispatch } from 'react-redux';
 
 const Wrapper = styled.div`
@@ -44,7 +45,6 @@ export const Fiat = ({ output, outputId, labelHoverRight, labelRight }: FiatProp
     const {
         account,
         network,
-        fiatRate,
         formState: { errors },
         clearErrors,
         getDefaultValue,
@@ -73,6 +73,13 @@ export const Fiat = ({ output, outputId, labelHoverRight, labelRight }: FiatProp
     const token = findToken(account.tokens, tokenValue);
 
     const currencyValue = watch(currencyInputName);
+
+    const fiatRateKey = getFiatRateKey(
+        account.symbol,
+        currencyValue.value as FiatCurrencyCode,
+        tokenValue as TokenAddress,
+    );
+    const fiatRate = useSelector(state => selectFiatRatesByFiatRateKey(state, fiatRateKey));
 
     const recalculateFiat = (rate: number) => {
         const formattedAmount = new BigNumber(

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/index.tsx
@@ -114,7 +114,6 @@ export const Amount = ({ output, outputId }: AmountProps) => {
         getDefaultValue,
         formState: { errors },
         setValue,
-        getValues,
         setMax,
         calculateFiat,
         composeTransaction,
@@ -124,7 +123,8 @@ export const Amount = ({ output, outputId }: AmountProps) => {
     const theme = useTheme();
     const { shouldSendInSats } = useBitcoinAmountUnit(symbol);
 
-    const inputName = `outputs.${outputId}.amount` as const;
+    const amountName = `outputs.${outputId}.amount` as const;
+    const currencyName = `outputs.${outputId}.currency.value` as const;
     const tokenInputName = `outputs.${outputId}.token`;
     const isSetMaxActive = getDefaultValue('setMaxOutputId') === outputId;
     const outputError = errors.outputs ? errors.outputs[outputId] : undefined;
@@ -134,21 +134,19 @@ export const Amount = ({ output, outputId }: AmountProps) => {
     const isSetMaxVisible = isSetMaxActive && !error && !Object.keys(errors).length;
     const maxSwitchId = `outputs.${outputId}.setMax`;
 
-    const amountValue = getDefaultValue(inputName, output.amount || '');
+    const amountValue = getDefaultValue(amountName, output.amount || '');
+    const currencyValue = getDefaultValue(currencyName, output.currency?.value || '');
     const tokenValue = getDefaultValue(tokenInputName, output.token);
     const token = findToken(tokens, tokenValue);
-    const values = getValues();
-    const fiatCurrency = values?.outputs?.[0]?.currency;
 
     const currentRate = useSelector(state =>
         selectFiatRatesByFiatRateKey(
             state,
             getFiatRateKey(
                 symbol,
-                fiatCurrency?.value as FiatCurrencyCode,
+                currencyValue as FiatCurrencyCode,
                 (token?.contract || '') as TokenAddress,
             ),
-            'current',
         ),
     );
 
@@ -177,9 +175,9 @@ export const Amount = ({ output, outputId }: AmountProps) => {
 
             // calculate or reset Fiat value
             calculateFiat(outputId, value);
-            composeTransaction(inputName);
+            composeTransaction(amountName);
         },
-        [setValue, calculateFiat, composeTransaction, inputName, isSetMaxActive, outputId],
+        [setValue, calculateFiat, composeTransaction, amountName, isSetMaxActive, outputId],
     );
 
     const cryptoAmountRules = {
@@ -218,7 +216,7 @@ export const Amount = ({ output, outputId }: AmountProps) => {
 
     const onSwitchChange = () => {
         setMax(outputId, isSetMaxActive);
-        composeTransaction(inputName);
+        composeTransaction(amountName);
     };
 
     const isTokenSelected = !!token;
@@ -270,8 +268,8 @@ export const Amount = ({ output, outputId }: AmountProps) => {
                         }
                         bottomText={bottomText || null}
                         onChange={handleInputChange}
-                        name={inputName}
-                        data-test={inputName}
+                        name={amountName}
+                        data-test={amountName}
                         defaultValue={amountValue}
                         maxLength={formInputsMaxLength.amount}
                         rules={cryptoAmountRules}


### PR DESCRIPTION
## Description

Fixed incorrect fiat rate in send form when sending to multiple recipients in multiple currencies (suite always used the rate for the first currency).

## Related Issue

Resolve #13408