### PR TITLE
fix(suite): on copy device display

### DIFF
--- a/packages/suite/src/components/suite/DeviceDisplay/DisplayChunks.tsx
+++ b/packages/suite/src/components/suite/DeviceDisplay/DisplayChunks.tsx
@@ -1,7 +1,7 @@
-import { ClipboardEvent } from 'react';
 import styled from 'styled-components';
 import { DeviceDisplayText } from './DeviceDisplayText';
 import { splitStringEveryNCharacters } from '@trezor/utils';
+import { handleOnCopy } from 'src/utils/suite/deviceDisplay';
 
 const Row = styled.div<{ $isAlignedRight?: boolean }>`
     display: flex;
@@ -52,16 +52,6 @@ export const DisplayChunks = ({ isPixelType, address }: DisplayChunksProps) => {
 
     const chunks: string[] = splitStringEveryNCharacters(address, 4);
     const groupedChunks = groupByN(chunks, 4);
-
-    const handleOnCopy = (event: ClipboardEvent) => {
-        const selectedText = window.getSelection()?.toString();
-
-        if (selectedText) {
-            const processedText = selectedText.replace(/\s/g, '');
-            event?.nativeEvent?.clipboardData?.setData('text/plain', processedText);
-            event.preventDefault();
-        }
-    };
 
     return (
         <ChunksContainer onCopy={handleOnCopy} data-test="@device-display/chunked-text">

--- a/packages/suite/src/components/suite/DeviceDisplay/DisplayPaginatedText.tsx
+++ b/packages/suite/src/components/suite/DeviceDisplay/DisplayPaginatedText.tsx
@@ -6,6 +6,7 @@ import { DeviceModelInternal } from '@trezor/connect';
 import { ResultRow, parseTextToPagesAndLines } from './parseTextToPagesAndLines';
 import { DeviceDisplayText } from './DeviceDisplayText';
 import { DisplayPageSeparator } from './DisplayPageSeparator';
+import { handleOnCopy } from 'src/utils/suite/deviceDisplay';
 
 const StyledNextIcon = styled(Icon)<{ $isPixelType: boolean }>`
     display: inline-block;
@@ -87,7 +88,7 @@ export const DisplayPaginatedText = ({
     });
 
     return (
-        <Container>
+        <Container onCopy={handleOnCopy}>
             {pages.map((page, pageIndex) => {
                 const isFirstPage = pageIndex === 0;
                 const isLastPage = pageIndex === pages.length - 1;

--- a/packages/suite/src/utils/suite/deviceDisplay.ts
+++ b/packages/suite/src/utils/suite/deviceDisplay.ts
@@ -1,0 +1,11 @@
+import { ClipboardEvent } from 'react';
+
+export const handleOnCopy = (event: ClipboardEvent) => {
+    const selectedText = window.getSelection()?.toString();
+
+    if (selectedText) {
+        const processedText = selectedText.replace(/\s/g, '');
+        event?.nativeEvent?.clipboardData?.setData('text/plain', processedText);
+        event.preventDefault();
+    }
+};


### PR DESCRIPTION
## Description

Share `handleOnCopy` inside address display (chunked and paginated variants) so there are no extra whitespaces etc.

## Related Issue

Resolve #12988