### PR TITLE
Chore/token warning modals never show again checkbox

### DIFF
--- a/packages/components/src/components/modals/DialogModal/DialogModal.stories.tsx
+++ b/packages/components/src/components/modals/DialogModal/DialogModal.stories.tsx
@@ -23,13 +23,13 @@ export default meta;
 export const DialogModal: StoryObj<DialogModalProps> = {
     args: {
         bodyHeading: 'Modal heading',
-        text: 'Modal text',
+        body: 'Modal text',
         icon: 'caretCircleDown',
         bottomBarComponents: <Buttons />,
         onCancel: () => console.log('close'),
     },
     argTypes: {
-        text: {
+        body: {
             control: 'text',
         },
         headerHeading: {

--- a/packages/components/src/components/modals/DialogModal/DialogModal.tsx
+++ b/packages/components/src/components/modals/DialogModal/DialogModal.tsx
@@ -26,7 +26,7 @@ const StyledIcon = styled(Icon)<{ iconVariant: 'success' | 'warning' }>`
     border-radius: ${borders.radii.full};
 `;
 
-const Text = styled.p`
+const Body = styled.p`
     color: ${({ theme }) => theme.textSubdued};
     ${typography.hint}
 `;
@@ -47,7 +47,7 @@ export interface DialogModalProps extends PickedModalProps {
     bodyHeading?: ReactNode;
     icon?: IconName;
     iconVariant?: 'success' | 'warning';
-    text?: ReactNode;
+    body?: ReactNode;
 }
 
 export const DialogModal = ({
@@ -55,12 +55,12 @@ export const DialogModal = ({
     bodyHeading,
     icon,
     iconVariant = 'success',
-    text,
+    body,
     ...rest
 }: DialogModalProps) => (
     <Modal heading={headerHeading} {...rest}>
         {icon && <StyledIcon name={icon} size="extraLarge" iconVariant={iconVariant} />}
         {bodyHeading && <BodyHeading>{bodyHeading}</BodyHeading>}
-        <Text> {text}</Text>
+        <Body>{body}</Body>
     </Modal>
 );

--- a/packages/suite-desktop-ui/src/support/DesktopUpdater/EarlyAccessDisable.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater/EarlyAccessDisable.tsx
@@ -73,7 +73,7 @@ export const EarlyAccessDisable = ({ hideWindow }: EarlyAccessDisableProps) => {
         <DialogModal
             icon="check"
             bodyHeading={<Translation id="TR_EARLY_ACCESS_LEFT_TITLE" />}
-            text={<Translation id="TR_EARLY_ACCESS_LEFT_DESCRIPTION" />}
+            body={<Translation id="TR_EARLY_ACCESS_LEFT_DESCRIPTION" />}
             bottomBarComponents={
                 <>
                     <Link variant="nostyle" href={SUITE_URL}>

--- a/packages/suite-desktop-ui/src/support/DesktopUpdater/EarlyAccessEnable.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater/EarlyAccessEnable.tsx
@@ -54,7 +54,7 @@ export const EarlyAccessEnable = ({ hideWindow }: EarlyAccessEnableProps) => {
         <DialogModal
             icon="check"
             bodyHeading={<Translation id="TR_EARLY_ACCESS_JOINED_TITLE" />}
-            text={<Translation id="TR_EARLY_ACCESS_JOINED_DESCRIPTION" />}
+            body={<Translation id="TR_EARLY_ACCESS_JOINED_DESCRIPTION" />}
             bottomBarComponents={
                 <>
                     <Button onClick={checkForUpdates}>

--- a/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
@@ -245,6 +245,8 @@ const initialRun = [
                 viewOnlyPromoClosed: true,
                 viewOnlyTooltipClosed: true,
                 isDashboardPassphraseBannerVisible: true,
+                showCopyAddressModal: true,
+                showUnhideTokenModal: true,
             },
         },
     },

--- a/packages/suite/src/components/suite/modals/ReduxModal/CopyAddressModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/CopyAddressModal.tsx
@@ -4,9 +4,12 @@ import { notificationsActions } from '@suite-common/toast-notifications';
 
 import { Translation } from 'src/components/suite';
 import { useDispatch } from 'src/hooks/suite/useDispatch';
-import { Button } from '@trezor/components';
+import { Button, Checkbox } from '@trezor/components';
 import { DialogModal } from '../Modal/DialogRenderer';
 import { AddressType } from '@suite-common/wallet-types';
+import { spacings } from '@trezor/theme';
+import { useState } from 'react';
+import { setFlag } from 'src/actions/suite/suiteActions';
 
 const StyledModal = styled(DialogModal)`
     width: 600px;
@@ -30,9 +33,15 @@ interface CopyAddressModalProps {
 }
 
 export const CopyAddressModal = ({ address, onCancel, addressType }: CopyAddressModalProps) => {
+    const [checked, setChecked] = useState(false);
+
     const dispatch = useDispatch();
 
     const onCopyAddress = () => {
+        if (checked) {
+            dispatch(setFlag('showCopyAddressModal', false));
+        }
+
         const result = copyToClipboard(address);
         if (typeof result !== 'string') {
             dispatch(notificationsActions.addToast({ type: 'copy-to-clipboard' }));
@@ -47,7 +56,18 @@ export const CopyAddressModal = ({ address, onCancel, addressType }: CopyAddress
             icon="warningTriangleLight"
             iconVariant="warning"
             bodyHeading={<Translation id="TR_NOT_YOUR_RECEIVE_ADDRRESS" />}
-            text={<Translation id={getAddressTypeText(addressType)} />}
+            text={
+                <>
+                    <Translation id={getAddressTypeText(addressType)} />
+                    <Checkbox
+                        isChecked={checked}
+                        onClick={() => setChecked(!checked)}
+                        margin={{ top: spacings.md }}
+                    >
+                        <Translation id="TR_DO_NOT_SHOW_AGAIN" />
+                    </Checkbox>
+                </>
+            }
             bottomBarComponents={
                 <>
                     <Button variant="warning" onClick={onCopyAddress}>

--- a/packages/suite/src/components/suite/modals/ReduxModal/CopyAddressModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/CopyAddressModal.tsx
@@ -56,7 +56,7 @@ export const CopyAddressModal = ({ address, onCancel, addressType }: CopyAddress
             icon="warningTriangleLight"
             iconVariant="warning"
             bodyHeading={<Translation id="TR_NOT_YOUR_RECEIVE_ADDRRESS" />}
-            text={
+            body={
                 <>
                     <Translation id={getAddressTypeText(addressType)} />
                     <Checkbox

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/NoBackupModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/NoBackupModal.tsx
@@ -28,7 +28,7 @@ export const NoBackupModal = () => {
             onCancel={close}
             icon="warningTriangleLight"
             bodyHeading={<Translation id="TR_YOUR_TREZOR_IS_NOT_BACKED_UP" />}
-            text={<Translation id="TR_IF_YOUR_DEVICE_IS_EVER_LOST" />}
+            body={<Translation id="TR_IF_YOUR_DEVICE_IS_EVER_LOST" />}
             bottomBarComponents={
                 <>
                     <Button

--- a/packages/suite/src/components/suite/modals/ReduxModal/UnhideTokenModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UnhideTokenModal.tsx
@@ -54,7 +54,7 @@ export const UnhideTokenModal = ({ address, onCancel }: UnhideTokenModalProps) =
             icon="warningTriangleLight"
             iconVariant="warning"
             bodyHeading={<Translation id="TR_UNHIDE_TOKEN_TITLE" />}
-            text={
+            body={
                 <>
                     <Translation id="TR_UNHIDE_TOKEN_TEXT" />
                     <Checkbox

--- a/packages/suite/src/components/suite/modals/ReduxModal/UnhideTokenModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UnhideTokenModal.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 import { Translation } from 'src/components/suite';
 import { useDispatch } from 'src/hooks/suite/useDispatch';
-import { Button } from '@trezor/components';
+import { Button, Checkbox } from '@trezor/components';
 import { DialogModal } from '../Modal/DialogRenderer';
 import {
     DefinitionType,
@@ -11,6 +11,9 @@ import {
 } from '@suite-common/token-definitions';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 import { useSelector } from 'src/hooks/suite';
+import { useState } from 'react';
+import { spacings } from '@trezor/theme';
+import { setFlag } from 'src/actions/suite/suiteActions';
 
 const StyledModal = styled(DialogModal)`
     width: 600px;
@@ -22,12 +25,17 @@ interface UnhideTokenModalProps {
 }
 
 export const UnhideTokenModal = ({ address, onCancel }: UnhideTokenModalProps) => {
+    const [checked, setChecked] = useState(false);
+
     const account = useSelector(selectSelectedAccount);
     const dispatch = useDispatch();
 
     if (!account) return null;
 
     const onUnhide = () => {
+        if (checked) {
+            dispatch(setFlag('showUnhideTokenModal', false));
+        }
         dispatch(
             tokenDefinitionsActions.setTokenStatus({
                 networkSymbol: account.symbol,
@@ -46,7 +54,18 @@ export const UnhideTokenModal = ({ address, onCancel }: UnhideTokenModalProps) =
             icon="warningTriangleLight"
             iconVariant="warning"
             bodyHeading={<Translation id="TR_UNHIDE_TOKEN_TITLE" />}
-            text={<Translation id="TR_UNHIDE_TOKEN_TEXT" />}
+            text={
+                <>
+                    <Translation id="TR_UNHIDE_TOKEN_TEXT" />
+                    <Checkbox
+                        isChecked={checked}
+                        onClick={() => setChecked(!checked)}
+                        margin={{ top: spacings.md }}
+                    >
+                        <Translation id="TR_DO_NOT_SHOW_AGAIN" />
+                    </Checkbox>
+                </>
+            }
             bottomBarComponents={
                 <>
                     <Button variant="warning" onClick={onUnhide}>

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -67,6 +67,8 @@ export interface Flags {
     isDashboardPassphraseBannerVisible: boolean;
     viewOnlyPromoClosed: boolean;
     viewOnlyTooltipClosed: boolean;
+    showUnhideTokenModal: boolean;
+    showCopyAddressModal: boolean;
 }
 
 export interface EvmSettings {
@@ -127,6 +129,8 @@ const initialState: SuiteState = {
         viewOnlyPromoClosed: false,
         viewOnlyTooltipClosed: false,
         isDashboardPassphraseBannerVisible: true,
+        showCopyAddressModal: true,
+        showUnhideTokenModal: true,
     },
     evmSettings: {
         confirmExplanationModalClosed: {},
@@ -378,6 +382,12 @@ export const selectIsDashboardT3T1PromoBannerShown = (state: SuiteRootState) =>
 
 export const selectIsSettingsDesktopAppPromoBannerShown = (state: SuiteRootState) =>
     state.suite.flags.showSettingsDesktopAppPromoBanner;
+
+export const selectIsUnhideTokenModalShown = (state: SuiteRootState) =>
+    state.suite.flags.showUnhideTokenModal;
+
+export const selectIsCopyAddressModalShown = (state: SuiteRootState) =>
+    state.suite.flags.showCopyAddressModal;
 
 export const selectIsLoggedOut = (state: SuiteRootState & DeviceRootState) =>
     state.suite.flags.initialRun || state.device?.selectedDevice?.mode !== 'normal';

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -9336,6 +9336,10 @@ export default defineMessages({
         id: 'TR_SWITCH_DEVICE_EJECT_CONFIRMATION_DISABLE_VIEW_ONLY_PRIMARY_BUTTON',
         defaultMessage: 'Disable & eject',
     },
+    TR_DO_NOT_SHOW_AGAIN: {
+        id: 'TR_DO_NOT_SHOW_AGAIN',
+        defaultMessage: 'Do not show again',
+    },
     TR_VIEW_ONLY: {
         id: 'TR_VIEW_ONLY',
         defaultMessage: 'View-only',

--- a/packages/suite/src/views/password-manager/PasswordManager/PasswordEntry.tsx
+++ b/packages/suite/src/views/password-manager/PasswordManager/PasswordEntry.tsx
@@ -107,7 +107,7 @@ export const PasswordEntry = ({
             {confirmRemove != null && (
                 <DialogModal
                     bodyHeading="Remove password entry"
-                    text={`Really remove ${note || title}?`}
+                    body={`Really remove ${note || title}?`}
                     bottomBarComponents={
                         <>
                             <Button


### PR DESCRIPTION
## Description

Add checkbox to unhide token and copy address modals to never show this type of modal in the future.

I was also trying to refactor it into just one modal but for better readability I think that it is okey to have them separated.

## Related Issue

Resolve #13337

## Screenshots:
![Screenshot 2024-07-22 at 6 43 41 PM](https://github.com/user-attachments/assets/510896d9-4064-4360-85bb-e5bfbf9c9b94)
