### PR TITLE
Fiat rates missing for transactions except first 5 in Portfolio tracker or view-only

### DIFF
--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -247,7 +247,6 @@ export const fetchTransactionsPageThunk = createThunk(
         { accountKey, page, perPage, forceRefetch }: FetchTransactionsPageThunkParams,
         { dispatch, getState },
     ) => {
-        // console.log('fetchTransactionsPageThunk', accountKey, page, perPage, forceRefetch);
         const account = selectAccountByKey(getState(), accountKey);
         if (!account) {
             throw new Error(`Account not found: ${accountKey}`);


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Steps to reproduce:
1. load portfolio tracker account or view only device with more than 5 transactions in history
2. restart the app
3. check transaction history of remembered account

You will see fiat rates for first 5 transactions only and zeros for the rest. Switching fiat currency fixes it until the next restart.


solution:
always check missing fiat rates after fetching transactions


## Screenshots:
<img width="350" alt="image" src="https://github.com/user-attachments/assets/65c0fa7c-b6b7-4328-93a9-754641167498">


## Notes for QA
- Check also receiving new transaction on that account. 
- Check switching fiat currency
