### PR TITLE
fix(suite-native): always check missing fiat rates after fetching transactions via middleware

### DIFF
--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -247,7 +247,6 @@ export const fetchTransactionsPageThunk = createThunk(
         { accountKey, page, perPage, forceRefetch }: FetchTransactionsPageThunkParams,
         { dispatch, getState },
     ) => {
-        // console.log('fetchTransactionsPageThunk', accountKey, page, perPage, forceRefetch);
         const account = selectAccountByKey(getState(), accountKey);
         if (!account) {
             throw new Error(`Account not found: ${accountKey}`);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This is an alternative solution of https://github.com/trezor/trezor-suite/pull/13462

It does the same, but checking for missing fiat rates is dispatched from middleware so it applies for desktop too.

## Related Issue

Resolve #13462

