### PR TITLE
Mobile README update

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,9 @@
         "prepare-release": "./scripts/prepare-release.sh",
         "native:android": "yarn workspace @suite-native/app android",
         "native:ios": "yarn workspace @suite-native/app ios",
-        "native:prebuild": "yarn workspace @suite-native/app prebuild:clean",
+        "native:prebuild": "yarn workspace @suite-native/app prebuild",
+        "native:prebuild:clean": "yarn workspace @suite-native/app prebuild:clean",
+        "native:reverse-ports": "yarn workspace @suite-native/app reverse-ports",
         "_______ Aliases _______": "Aliases for longer commands which we often have to run manually. Names don't have to be pretty or make total sense.",
         "refs": "yarn update-project-references",
         "types": "yarn type-check",
@@ -80,6 +82,7 @@
         "a": "yarn native:android",
         "ios": "yarn native:ios",
         "p": "yarn native:prebuild",
+        "ports": "yarn native:reverse-ports",
         "s": "yarn native:start"
     },
     "lint-staged": {

--- a/suite-native/app/README.md
+++ b/suite-native/app/README.md
@@ -8,41 +8,53 @@ Generally it's recommended to follow official [React Native environment setup](h
 
 1. [Android Guide](https://reactnative.dev/docs/set-up-your-environment?os=macos&platform=android)
 2. [iOS Guide](https://reactnative.dev/docs/set-up-your-environment?os=macos&platform=ios)
-
-Make sure you have the latest version of the Xcode command line tools installed:
-
-```sh
-xcode-select --install
-```
+    - Make sure you have the latest version of the Xcode command line tools installed: `xcode-select --install`
 
 ## Before you run the app
 
-1. Run `yarn prebuild:clean` to generate `ios/` and `android/` directories. (It's necessary to re-run faster version of this command `yarn prebuild` everytime when you change branch/pull/rebase).
+1. Run `yarn native:prebuild:clean` to generate `ios/` and `android/` directories.
+    - You can prebuild for specific platform if you setup only Android/iOS: `yarn prebuild:clean --platform [android|ios]`
+    - It's necessary to re-run faster version of this command `yarn native:prebuild` (shortcut `yarn p`) on any change in native code (when you change branch/pull/rebase).
 
 ## Running app on Android
 
-1. Connect device or run emulator. For a physical device, it's recommended to use [adb over wifi](https://developer.android.com/studio/command-line/adb#connect-to-a-device-over-wi-fi-android-11+) because you will have free up a USB port to connect Trezor device.
-1. Run packager - `yarn start`
-1. Run native build - `yarn android`
-1. Reverse android emulator ports to enable communication between the app and localhost services - `yarn reverse-ports`
+1. Connect device or run emulator.
+    - For a physical device, it's recommended to use [adb over wifi](https://developer.android.com/studio/command-line/adb#connect-to-a-device-over-wi-fi-android-11+) because you will have free up a USB port to connect Trezor device.
+2. Run packager - `yarn native:start` in separate terminal window and keep it running
+3. Run native build - `yarn native:android` this takes time (~10min) and it should install and start the app at the end
+4. With emulator running, reverse android emulator ports to enable communication between the app and localhost services - `yarn native:reverse-ports`
 
 ## Running app on iOS
 
-Transport layer not working for iOS but it's possible to run app in watch-only mode. You will need Xcode and [xcode-select](https://www.freecodecamp.org/news/install-xcode-command-line-tools/).
+You need a Mac to be able to run iOS app.
 
-1. Run packager - `yarn start`
-1. Run `yarn ios` to build and run the app on iOS simulator/device
+Trezor can't be connected to iOS device via cable but it's possible to use Portfolio tracker feature for watch only wallets. You will need Xcode and [xcode-select](https://www.freecodecamp.org/news/install-xcode-command-line-tools/).
+
+1. Run packager - `yarn native:start`
+1. Run `yarn native:ios` to build and run the app on iOS simulator/device
 
 Or via Xcode (for native errors debug):
 
-1. Open `ios/TrezorSuite.xcworkspace` in Xcode
+1. Open `suite-native/app/ios/TrezorSuite.xcworkspace` in Xcode (from cli `xed suite-native/app/ios`)
 1. Hit ▶️ `Run` button
+
+## Aliases
+
+You can use shorter versions of previous script commands OR navigate to suite-native/app folder and run scripts from there.
+
+Aliases available in root folder:
+
+-   `yarn s` = yarn native:start
+-   `yarn p` = yarn native:prebuild
+-   `yarn ports` = yarn native:reverse-ports
+-   `yarn a` = yarn native:android
+-   `yarn ios` = yarn native:ios
 
 ## Troubleshooting
 
 1. For any issues with the build, try to clean the project and rebuild it:
-    - `yarn prebuild:clean`
-    - `yarn android` or `yarn ios`
-1. In case of issues with the packager, try to restart it with `yarn start --reset-cache`.
-1. Sometimes it's helpful to combine two previous points with uninstalling the app from the device/emulator.
-1. Make sure you are using pure Node or `nvm` for managing node version (other version managers like `fnm` can cause build issues on iOS).
+    - `yarn native:prebuild:clean`
+    - `yarn native:android` or `yarn native:ios`
+2. In case of issues with the packager, try to restart it with `--reset-cache` i.e (`yarn s --reset-cache`).
+3. Sometimes it's helpful to combine two previous points with uninstalling the app from the device/emulator.
+4. Make sure you are using pure Node or `nvm` for managing node version (other version managers like `fnm` can cause build issues on iOS).

--- a/suite-native/app/README.md
+++ b/suite-native/app/README.md
@@ -38,6 +38,8 @@ Or via Xcode (for native errors debug):
 1. Open `suite-native/app/ios/TrezorSuite.xcworkspace` in Xcode (from cli `xed suite-native/app/ios`)
 1. Hit ▶️ `Run` button
 
+It is also possible for development purposes to connect Trezor emulator to iOS simulator (not physical device) if you turn on the feature flag `Connect device` in DEV utils.
+
 ## Aliases
 
 You can use shorter versions of previous script commands OR navigate to suite-native/app folder and run scripts from there.
@@ -49,6 +51,12 @@ Aliases available in root folder:
 -   `yarn ports` = yarn native:reverse-ports
 -   `yarn a` = yarn native:android
 -   `yarn ios` = yarn native:ios
+
+## DEV utils
+
+You can show DEV utils on production build FOR DEVELOPMENT PURPOSES ONLY – do not use it for your personal wallets!
+
+To reveal dev menu, you have to click at least 7 times on commit hash at the bottom of About Trezor Suite Lite page.
 
 ## Troubleshooting
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Attempt to clarify first steps with suite-native by feedback from @komret. It wasn't clear that previously mentioned NPM scripts was meant to be called from `suite-native/app` folder. 

We have aliases in global package.json so I believe it's easier to use them.

BREAKING CHANGE: `yarn p` no longer call `prebuild:clean` but only `prebuild` 
