### PR TITLE
feat(staking): adjust other amount width and remove line in unstake modal

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/Options.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/Options.tsx
@@ -26,11 +26,11 @@ const RadioWrapper = styled.div`
             flex: 1 0 auto;
         }
     }
+`;
 
-    &:nth-of-type(3) {
-        & > div > div:nth-of-type(2) {
-            border-bottom: none;
-        }
+const RadioWrapperLast = styled(RadioWrapper)`
+    & > div > div:nth-of-type(2) {
+        border-bottom: none;
     }
 `;
 
@@ -149,7 +149,7 @@ export const Options = ({ symbol }: OptionsProps) => {
                 </Radio>
             </RadioWrapper>
 
-            <RadioWrapper>
+            <RadioWrapperLast>
                 <Radio
                     isChecked={isOtherAmountSelected}
                     onClick={() => {
@@ -185,7 +185,7 @@ export const Options = ({ symbol }: OptionsProps) => {
                         </TxtRight>
                     </RadioButtonLabelContent>
                 </Radio>
-            </RadioWrapper>
+            </RadioWrapperLast>
 
             {/* CSS display property is used, as conditional rendering resets form state */}
             <InputsWrapper $isShown={isOtherAmountSelected}>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/Options.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/Options.tsx
@@ -55,8 +55,7 @@ const GreenTxt = styled.span`
 `;
 
 const InputsWrapper = styled.div<{ $isShown: boolean }>`
-    max-width: 442px;
-    margin-left: auto;
+    width: 100%;
     margin-bottom: ${spacingsPx.sm};
     display: ${({ $isShown }) => ($isShown ? 'block' : 'none')};
 `;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adjust the width of the other amount input in the unstake modal.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/13382 https://github.com/trezor/trezor-suite/issues/13392

## Screenshots:
![unstake modal](https://github.com/user-attachments/assets/21bff447-f2b2-4dc0-a982-82df6db9053f)
