### PR TITLE
Fix `<LoadingContent />` animation

### DIFF
--- a/packages/components/src/components/loaders/LoadingContent/LoadingContent.tsx
+++ b/packages/components/src/components/loaders/LoadingContent/LoadingContent.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import styled, { css, useTheme } from 'styled-components';
 import { Icon } from '../../assets/Icon/Icon';
 import { Spinner } from '../Spinner/Spinner';
@@ -38,9 +38,13 @@ export const LoadingContent = ({
 }: LoadingContentProps) => {
     const theme = useTheme();
 
+    // $isLoading should always start as `false`
+    const [loading, setLoading] = useState(false);
+    useEffect(() => setLoading(isLoading), [isLoading]);
+
     return (
         <LoadingWrapper>
-            <LoaderCell $isLoading={isLoading} $size={size}>
+            <LoaderCell $isLoading={loading} $size={size}>
                 {isLoading ? (
                     <Spinner size={size} dataTest="@loading-content/loader" />
                 ) : (


### PR DESCRIPTION
## Description

Sometimes when `<LoadingContent />` component is first rendered in active state and inactivated immediately after that, it creates a visual impression that something was just loading (even if it wasn't). Now the component always start inactive so there's time to revert the animation without anyone noticing.

Cc: @komret, who found the issue