### PR TITLE
fix(connect-webextension): multiple content script extension conflicts

### DIFF
--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -360,6 +360,13 @@ const handleLogMessage = (event: MessageEvent<IFrameLogRequest>) => {
 
 const handleContentScriptLoaded = (data: PopupContentScriptLoaded) => {
     log.debug('content-script loaded', data.payload);
+    // Check if extension ID matches the popup URL
+    const urlParams = new URLSearchParams(window.location.search);
+    const targetExtensionId = urlParams.get('extension-id');
+    if (targetExtensionId && targetExtensionId !== data.payload.id) {
+        // Wrong extension ID, ignore it
+        return;
+    }
     setState({
         settings: {
             ...getState().settings!,

--- a/packages/connect-webextension/src/contentScript.ts
+++ b/packages/connect-webextension/src/contentScript.ts
@@ -1,81 +1,94 @@
 import { WindowServiceWorkerChannel } from '@trezor/connect-web/src/channels/window-serviceworker';
 import { POPUP } from '@trezor/connect/src/events/popup';
+import { CONTENT_SCRIPT_VERSION } from '@trezor/connect/src/data/version';
 
-/**
- * communication between service worker and both webextension and popup manager
- */
-const channel = new WindowServiceWorkerChannel({
-    name: 'trezor-connect',
-    channel: {
-        here: '@trezor/connect-content-script',
-        peer: '@trezor/connect-webextension',
-    },
-});
-
-/**
- * messages that were sent before the channel was initialized
- */
-const messagesQueue: any[] = [];
-let channelReady = false;
-
-/**
- * Firefox enforces some restrictions on the content script that force us to use clones of objects when passing them between the content script and the background script
- */
-function clone(obj: any) {
-    return JSON.parse(JSON.stringify(obj));
-}
-
-/*
- * Passing messages from popup to service worker
- */
-window.addEventListener('message', event => {
-    if (
-        event.data?.channel?.here === '@trezor/connect-webextension' ||
-        event.data?.type === POPUP.CONTENT_SCRIPT_LOADED
-    ) {
+function trezorContentScript() {
+    // Check if extension ID matches the popup URL
+    const urlParams = new URLSearchParams(window.location.search);
+    const targetExtensionId = urlParams.get('extension-id');
+    if (targetExtensionId && targetExtensionId !== chrome.runtime.id) {
         return;
     }
-    if (event.data?.type === POPUP.LOADED) {
-        window.postMessage(
-            {
-                type: POPUP.CONTENT_SCRIPT_LOADED,
-                payload: { ...chrome.runtime.getManifest(), id: chrome.runtime.id },
-            },
-            window.location.origin,
-        );
-    }
-
-    if (event.source === window && event.data) {
-        if (channelReady) {
-            channel.postMessage(clone(event.data), { usePromise: false });
-        } else {
-            messagesQueue.push(event.data);
-        }
-    }
-});
-
-channel.init().then(() => {
-    channelReady = true;
 
     /**
-     * Passing messages from service worker to popup
+     * communication between service worker and both webextension and popup manager
      */
-    channel.on('message', message => {
-        window.postMessage(clone(message), window.location.origin);
+    const channel = new WindowServiceWorkerChannel({
+        name: 'trezor-connect',
+        channel: {
+            here: '@trezor/connect-content-script',
+            peer: '@trezor/connect-webextension',
+        },
     });
 
-    // Send messages that have gathered before the channel was initialized
-    while (messagesQueue.length > 0) {
-        const message = messagesQueue.shift();
-        channel.postMessage(clone(message), { usePromise: false });
+    /**
+     * messages that were sent before the channel was initialized
+     */
+    const messagesQueue: any[] = [];
+    let channelReady = false;
+
+    /**
+     * Firefox enforces some restrictions on the content script that force us to use clones of objects when passing them between the content script and the background script
+     */
+    function clone(obj: any) {
+        return JSON.parse(JSON.stringify(obj));
     }
 
-    window.addEventListener('beforeunload', () => {
-        window.postMessage(
-            {
-                type: POPUP.CLOSED,
-            },
-            window.location.origin,
-        );
+    /*
+     * Passing messages from popup to service worker
+     */
+    window.addEventListener('message', event => {
+        if (event.data?.channel?.here === '@trezor/connect-webextension') {
+            return;
+        }
+        if (event.data?.type === POPUP.LOADED) {
+            window.postMessage(
+                {
+                    type: POPUP.CONTENT_SCRIPT_LOADED,
+                    payload: {
+                        ...chrome.runtime.getManifest(),
+                        id: chrome.runtime.id,
+                        contentScriptVersion: CONTENT_SCRIPT_VERSION,
+                    },
+                },
+                window.location.origin,
+            );
+        }
+
+        if (event.source === window && event.data) {
+            if (channelReady) {
+                channel.postMessage(clone(event.data), { usePromise: false });
+            } else {
+                messagesQueue.push(event.data);
+            }
+        }
     });
-});
+
+    channel.init().then(() => {
+        channelReady = true;
+
+        /**
+         * Passing messages from service worker to popup
+         */
+        channel.on('message', message => {
+            window.postMessage(clone(message), window.location.origin);
+        });
+
+        // Send messages that have gathered before the channel was initialized
+        while (messagesQueue.length > 0) {
+            const message = messagesQueue.shift();
+            channel.postMessage(clone(message), { usePromise: false });
+        }
+
+        window.addEventListener('beforeunload', () => {
+            window.postMessage(
+                {
+                    type: POPUP.CLOSED,
+                },
+                window.location.origin,
+            );
+        });
+    });
+}
+
+trezorContentScript();

--- a/packages/connect/src/data/version.ts
+++ b/packages/connect/src/data/version.ts
@@ -7,3 +7,6 @@ const isBeta = VERSION.includes('beta');
 export const DEFAULT_DOMAIN = isBeta
     ? `https://connect.trezor.io/${VERSION}/`
     : `https://connect.trezor.io/${versionN[0]}/`;
+
+// Increment with content script changes
+export const CONTENT_SCRIPT_VERSION = 1;

--- a/packages/connect/src/events/popup.ts
+++ b/packages/connect/src/events/popup.ts
@@ -79,7 +79,7 @@ export interface PopupMethodInfo {
 
 export interface PopupContentScriptLoaded {
     type: typeof POPUP.CONTENT_SCRIPT_LOADED;
-    payload: { id: string };
+    payload: { id: string; contentScriptVersion: number };
 }
 
 export interface PopupExtensionUsbPermissions {


### PR DESCRIPTION
## Description

Resolve the issue with multiple content scripts being injected at once by adding a URL paramter to popup.html, specifying the extension ID. 
There are also version and env URL parameters for futureproofing. 

The content script & popup.js then checks if their ID matches the extension ID in the URL parameter.