### PR TITLE
Feat/native/discovery improvements

### DIFF
--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -683,6 +683,12 @@ export const selectIsDeviceAuthorized = (state: DeviceRootState) => {
     return !!device?.state;
 };
 
+export const selectHasDeviceAuthConfirm = (state: DeviceRootState) => {
+    const device = selectDevice(state);
+
+    return !!device?.authConfirm;
+};
+
 export const selectIsDeviceConnectedAndAuthorized = (state: DeviceRootState) => {
     const isDeviceAuthorized = selectIsDeviceAuthorized(state);
     const deviceFeatures = selectDeviceFeatures(state);

--- a/suite-native/analytics/src/events.ts
+++ b/suite-native/analytics/src/events.ts
@@ -184,6 +184,7 @@ export type SuiteNativeAnalyticsEvent =
           payload: {
               discoveryId: string; // Used for grouping multiple events of a single discovery run together.
               loadDuration: number;
+              networkSymbols: NetworkSymbol[];
           };
       }
     | {

--- a/suite-native/discovery/src/discoverySelectors.ts
+++ b/suite-native/discovery/src/discoverySelectors.ts
@@ -5,13 +5,37 @@ import {
     selectValidTokensByDeviceStateAndNetworkSymbol,
 } from '@suite-common/token-definitions';
 import { NetworkSymbol } from '@suite-common/wallet-config';
-import { DeviceRootState } from '@suite-common/wallet-core';
+import {
+    DeviceRootState,
+    DiscoveryRootState,
+    selectDeviceAuthFailed,
+    selectDeviceDiscovery,
+    selectDeviceFirmwareVersion,
+    selectDeviceModel,
+    selectDeviceState,
+    selectHasDeviceAuthConfirm,
+    selectIsDeviceConnectedAndAuthorized,
+    selectIsDeviceInViewOnlyMode,
+    selectIsDeviceUnlocked,
+    selectIsPortfolioTrackerDevice,
+} from '@suite-common/wallet-core';
+import { LIMIT as ACCOUNTS_LIMIT } from '@suite-common/wallet-core';
 import {
     AccountsRootState,
     selectAccountsByDeviceStateAndNetworkSymbol,
     selectDeviceAccounts,
 } from '@suite-common/wallet-core';
 import { TokenSymbol, TokenAddress } from '@suite-common/wallet-types';
+import { isFirmwareVersionSupported } from '@suite-native/device';
+import { FeatureFlagsRootState } from '@suite-native/feature-flags';
+
+import {
+    DiscoveryConfigSliceRootState,
+    selectAreTestnetsEnabled,
+    selectDiscoverySupportedNetworks,
+    selectEnabledDiscoveryNetworkSymbols,
+} from './discoveryConfigSlice';
+import { getNetworksWithUnfinishedDiscovery } from './utils';
 
 export const selectDiscoveryAccountsAnalytics = (
     state: AccountsRootState & DeviceRootState & TokenDefinitionsRootState,
@@ -45,3 +69,83 @@ export const selectDiscoveryAccountsAnalytics = (
             };
         }),
     );
+
+export const selectNetworksWithUnfinishedDiscovery = (
+    state: DeviceRootState &
+        AccountsRootState &
+        FeatureFlagsRootState &
+        DiscoveryConfigSliceRootState,
+    areTestnetsEnabled: boolean,
+) => {
+    const enabledNetworkSymbols = selectEnabledDiscoveryNetworkSymbols(state, areTestnetsEnabled);
+    const accounts = selectDeviceAccounts(state);
+    const supportedNetworks = selectDiscoverySupportedNetworks(state, areTestnetsEnabled);
+
+    const enabledNetworks = supportedNetworks.filter(n => enabledNetworkSymbols.includes(n.symbol));
+
+    return getNetworksWithUnfinishedDiscovery(enabledNetworks, accounts, ACCOUNTS_LIMIT);
+};
+
+//we should run discovery when there are network symbols with unfinished discovery
+export const selectShouldRunDiscoveryForDevice = (
+    state: DeviceRootState &
+        AccountsRootState &
+        FeatureFlagsRootState &
+        DiscoveryConfigSliceRootState,
+) => {
+    // no discovery for PortfolioTracker ever
+    const isPortfolioTrackerDevice = selectIsPortfolioTrackerDevice(state);
+    if (isPortfolioTrackerDevice) {
+        return false;
+    }
+
+    const areTestnetsEnabled = selectAreTestnetsEnabled(state);
+    const networksWithUnfinishedDiscovery = selectNetworksWithUnfinishedDiscovery(
+        state,
+        areTestnetsEnabled,
+    );
+
+    return networksWithUnfinishedDiscovery.length > 0;
+};
+
+// we do not run discovery for unsupported device (e.g. old firmware, portfolio device, unauthorized), when discovery is already running or when device is in view-only mode
+export const selectCanRunDiscoveryForDevice = (
+    state: DeviceRootState &
+        AccountsRootState &
+        DiscoveryRootState &
+        FeatureFlagsRootState &
+        DiscoveryConfigSliceRootState,
+) => {
+    const deviceState = selectDeviceState(state);
+    if (!deviceState) {
+        return false;
+    }
+
+    const discovery = selectDeviceDiscovery(state);
+    const deviceModel = selectDeviceModel(state);
+    const deviceFwVersion = selectDeviceFirmwareVersion(state);
+    const isDeviceConnectedAndAuthorized = selectIsDeviceConnectedAndAuthorized(state);
+    const isPortfolioTrackerDevice = selectIsPortfolioTrackerDevice(state);
+
+    const isDeviceFirmwareVersionSupported = isFirmwareVersionSupported(
+        deviceFwVersion,
+        deviceModel,
+    );
+
+    const isDeviceInViewOnlyMode = selectIsDeviceInViewOnlyMode(state);
+    const isDeviceUnlocked = selectIsDeviceUnlocked(state);
+    const hasDeviceAuthConfirm = selectHasDeviceAuthConfirm(state);
+    const hasDeviceAuthFailed = selectDeviceAuthFailed(state);
+
+    const canRunDiscovery =
+        !discovery &&
+        isDeviceConnectedAndAuthorized &&
+        !isPortfolioTrackerDevice &&
+        !isDeviceInViewOnlyMode &&
+        isDeviceUnlocked &&
+        !hasDeviceAuthConfirm &&
+        !hasDeviceAuthFailed &&
+        isDeviceFirmwareVersionSupported;
+
+    return canRunDiscovery;
+};

--- a/suite-native/discovery/src/useIsDiscoveryDurationTooLong.tsx
+++ b/suite-native/discovery/src/useIsDiscoveryDurationTooLong.tsx
@@ -3,22 +3,25 @@ import { useSelector } from 'react-redux';
 
 import { selectIsDeviceDiscoveryActive } from '@suite-common/wallet-core';
 
-import { selectDiscoveryStartTimeStamp } from './discoveryConfigSlice';
+import { selectDiscoveryInfo } from './discoveryConfigSlice';
 
 const DISCOVERY_LENGTH_CHECK_INTERVAL = 1_000;
-const DISCOVERY_DURATION_TRESHOLD = 50_000;
+const DISCOVERY_DURATION_THRESHOLD = 50_000;
 
 export const useIsDiscoveryDurationTooLong = () => {
-    const startDiscoveryTimestamp = useSelector(selectDiscoveryStartTimeStamp);
+    const discoveryInfo = useSelector(selectDiscoveryInfo);
     const isDiscoveryActive = useSelector(selectIsDeviceDiscoveryActive);
 
     const [loadingTakesLongerThanExpected, setLoadingTakesLongerThanExpected] = useState(false);
 
     useEffect(() => {
         let interval: ReturnType<typeof setInterval>;
-        if (isDiscoveryActive && startDiscoveryTimestamp) {
+        if (isDiscoveryActive && discoveryInfo?.startTimestamp) {
             interval = setInterval(() => {
-                if (performance.now() - startDiscoveryTimestamp > DISCOVERY_DURATION_TRESHOLD) {
+                if (
+                    performance.now() - discoveryInfo.startTimestamp >
+                    DISCOVERY_DURATION_THRESHOLD
+                ) {
                     setLoadingTakesLongerThanExpected(true);
                     clearInterval(interval);
                 }
@@ -32,7 +35,7 @@ export const useIsDiscoveryDurationTooLong = () => {
                 clearInterval(interval);
             }
         };
-    }, [isDiscoveryActive, startDiscoveryTimestamp]);
+    }, [isDiscoveryActive, discoveryInfo]);
 
     return loadingTakesLongerThanExpected;
 };

--- a/suite-native/discovery/src/utils.ts
+++ b/suite-native/discovery/src/utils.ts
@@ -1,0 +1,52 @@
+import { A, F } from '@mobily/ts-belt';
+
+import { Network, AccountType, NetworkSymbol } from '@suite-common/wallet-config';
+import { Account } from '@suite-common/wallet-types';
+
+const NORMAL_ACCOUNT_TYPE = 'normal';
+
+// network uses undefined for normal type, but account uses 'normal'
+const normalizedAccountType = (accountType?: AccountType) => accountType ?? NORMAL_ACCOUNT_TYPE;
+
+const isNormalAccountType = (accountType?: AccountType) =>
+    normalizedAccountType(accountType) === NORMAL_ACCOUNT_TYPE;
+
+export const getNetworksWithUnfinishedDiscovery = (
+    enabledNetworks: readonly Network[],
+    accounts: Account[],
+    accountsLimit: number,
+) =>
+    enabledNetworks.filter(network => {
+        // there is no normal account for this network -> we should have at least one normal account even if added via Add Coin
+        if (
+            A.isEmpty(
+                accounts.filter(
+                    account =>
+                        account.symbol === network.symbol &&
+                        isNormalAccountType(account.accountType),
+                ),
+            )
+        ) {
+            return true;
+        }
+
+        const networkAccountsOfType = accounts.filter(
+            account =>
+                account.symbol === network.symbol &&
+                account.accountType === normalizedAccountType(network.accountType),
+        );
+
+        // if there is at least one visible account of this type, we should have at least one hidden account so adding funds outside of this app is detected and account shown
+        return (
+            networkAccountsOfType.length < accountsLimit &&
+            networkAccountsOfType.every(account => account.visible)
+        );
+    });
+
+export const getNetworkSymbols = (networks: readonly Network[]): NetworkSymbol[] =>
+    F.toMutable(
+        A.uniqBy(
+            networks.map(n => n.symbol),
+            F.identity,
+        ),
+    );

--- a/suite-native/module-dev-utils/src/components/DiscoveryCoinsFilter.tsx
+++ b/suite-native/module-dev-utils/src/components/DiscoveryCoinsFilter.tsx
@@ -6,16 +6,21 @@ import {
     selectEnabledDiscoveryNetworkSymbols,
     selectDiscoverySupportedNetworks,
     toggleEnabledDiscoveryNetworkSymbols,
+    DiscoveryConfigSliceRootState,
 } from '@suite-native/discovery';
 import { DeviceRootState } from '@suite-common/wallet-core';
 import { NetworkSymbol } from '@suite-common/wallet-config';
+import { FeatureFlagsRootState } from '@suite-native/feature-flags';
 
 export const DiscoveryCoinsFilter = () => {
     const areTestnetsEnabled = useSelector(selectAreTestnetsEnabled);
     const networks = useSelector((state: DeviceRootState) =>
         selectDiscoverySupportedNetworks(state, areTestnetsEnabled),
     );
-    const enabledNetworkSymbols = useSelector(selectEnabledDiscoveryNetworkSymbols);
+    const enabledNetworkSymbols = useSelector(
+        (state: DiscoveryConfigSliceRootState & DeviceRootState & FeatureFlagsRootState) =>
+            selectEnabledDiscoveryNetworkSymbols(state, areTestnetsEnabled),
+    );
 
     const dispatch = useDispatch();
 


### PR DESCRIPTION
This PR makes native discovery running on multiple occasions, autodiscovering new accounts when needed:

**The logic is built on 3 pillars:** 

- we know that we **SHOULD** run the discovery based on current accounts of the device and enabled coins
- we know whether ve **CAN** run the discovery (device is connected, not locked, discovery is not already running, etc.)
- we know on which **ACTIONS** we want to check whether we SHOULD and CAN to run the discovery only for relevant networks.

For the analytics I started to send out list of coins that are being discovered to put into perspective the measured duration of discovery process.

To check:
- logic for **SHOULD** - `selectShouldRunDiscoveryForDevice` and methods called from that
- logic for **CAN** - `selectCanRunDiscoveryForDevice`
- actions that trigger this check in `prepareDiscoveryMiddleware`

Resolve #11562