### PR TITLE
Fix/native/view only persist immediatelly

### DIFF
--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -14,6 +14,7 @@ import {
     selectDevice,
     selectHasOnlyPortfolioDevice,
 } from '../device/deviceReducer';
+import { deviceActions } from '../device/deviceActions';
 import { DiscoveryRootState, selectIsDeviceDiscoveryActive } from '../discovery/discoveryReducer';
 
 export type AccountsState = Account[];
@@ -129,6 +130,10 @@ export const prepareAccountsReducer = createReducerWithExtraDeps(
                 }
             })
             .addCase(extra.actionTypes.storageLoad, extra.reducers.storageLoadAccounts)
+            // Persistence of accounts and transactions in suite-native depends on device.remember state,
+            // but redux-persist is not checking for changes in other reducers.
+            // This is a workaround to update redux-persist state.
+            .addCase(deviceActions.rememberDevice, state => [...state])
             .addMatcher(isAnyOf(extra.actions.setAccountAddMetadata), (state, action) => {
                 const { payload } = action;
                 setMetadata(state, payload);

--- a/suite-common/wallet-core/src/device/deviceActions.ts
+++ b/suite-common/wallet-core/src/device/deviceActions.ts
@@ -39,7 +39,7 @@ const receiveAuthConfirm = createAction(
 
 const rememberDevice = createAction(
     `${DEVICE_MODULE_PREFIX}/rememberDevice`,
-    (payload: { device: TrezorDevice; remember: boolean; forceRemember: undefined | true }) => ({
+    (payload: { device: TrezorDevice; remember: boolean; forceRemember?: true }) => ({
         payload,
     }),
 );

--- a/suite-native/graph/src/slice.ts
+++ b/suite-native/graph/src/slice.ts
@@ -60,15 +60,22 @@ export const graphSlice = createSlice({
         },
     },
     extraReducers: builder => {
-        builder.addCase(deviceActions.forgetDevice, (state, action) => {
-            const deviceState = action.payload.device.state;
-            if (deviceState) {
-                state.accountToGraphTimeframeMap = filterKeysByPartialMatch(
-                    state.accountToGraphTimeframeMap,
-                    [deviceState],
-                );
-            }
-        });
+        builder
+            .addCase(deviceActions.forgetDevice, (state, action) => {
+                const deviceState = action.payload.device.state;
+                if (deviceState) {
+                    state.accountToGraphTimeframeMap = filterKeysByPartialMatch(
+                        state.accountToGraphTimeframeMap,
+                        [deviceState],
+                    );
+                }
+            })
+            .addCase(deviceActions.rememberDevice, state => {
+                // Persistence of graph depends on device.remember state,
+                // but redux-persist is not checking for changes in other reducers.
+                // This is a workaround to update redux-persist state.
+                state.accountToGraphTimeframeMap = { ...state.accountToGraphTimeframeMap };
+            });
     },
 });
 

--- a/suite-native/module-home/src/screens/HomeScreen/components/EnableViewOnlyBottomSheet.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/EnableViewOnlyBottomSheet.tsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import {
     selectDevice,
     selectIsPortfolioTrackerDevice,
-    toggleRememberDevice,
+    deviceActions,
     selectIsDeviceRemembered,
     selectIsDeviceDiscoveryActive,
 } from '@suite-common/wallet-core';
@@ -124,7 +124,7 @@ export const EnableViewOnlyBottomSheet = () => {
                 message: <Translation id="moduleSettings.viewOnly.toast.enabled" />,
                 icon: 'check',
             });
-            dispatch(toggleRememberDevice({ device }));
+            dispatch(deviceActions.rememberDevice({ device, remember: !device.remember }));
 
             analytics.report({
                 type: EventType.ViewOnlyChange,

--- a/suite-native/module-settings/src/components/ViewOnly/WalletRow.tsx
+++ b/suite-native/module-settings/src/components/ViewOnly/WalletRow.tsx
@@ -8,7 +8,6 @@ import {
     DiscoveryRootState,
     deviceActions,
     selectIsDiscoveryActiveByDeviceState,
-    toggleRememberDevice,
 } from '@suite-common/wallet-core';
 import { analytics, EventType } from '@suite-native/analytics';
 import { useAlert } from '@suite-native/alerts';
@@ -77,7 +76,7 @@ export const WalletRow = ({ device }: WalletRowProps) => {
             dispatch(deviceActions.forgetDevice({ device, settings }));
         } else {
             // device is connected or become remembered
-            dispatch(toggleRememberDevice({ device }));
+            dispatch(deviceActions.rememberDevice({ device, remember: !device.remember }));
         }
     };
 

--- a/suite-native/storage/src/transforms/utils.ts
+++ b/suite-native/storage/src/transforms/utils.ts
@@ -2,6 +2,10 @@ import { A, D, O } from '@mobily/ts-belt';
 
 import { DeviceRootState } from '@suite-common/wallet-core';
 
+/**
+ * Beware, if you want to persist some part of state outside device reducer,
+ * redux-persist will not automatically check for changes of device.remember property!
+ */
 export const selectDeviceStatesNotRemembered = (state: DeviceRootState) => {
     return A.filterMap(state.device.devices, device =>
         device.remember || !device.state ? O.None : O.Some(device.state),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Persistence of accounts, transactions and graph in suite-native depends on device.remember state, but redux-persist is not checking for changes in other reducers. This is a workaround to update redux-persist state.

This is replacing part of state with it's shallow copy so there are no actual changes but it triggers the recalculation of redux-persist state. It can be optimized to change some smaller portion of state or we can introduce some extra reducer just to handle this, but I believe it's harmless this way as it is triggered only on user action (toggling remember the wallet).

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/13485
