### PR TITLE
Move BNB to experimental features

### DIFF
--- a/packages/suite/src/constants/suite/experimental.ts
+++ b/packages/suite/src/constants/suite/experimental.ts
@@ -2,14 +2,17 @@ import { TranslationKey } from '@suite-common/intl-types';
 
 export enum ExperimentalFeature {
     PasswordManager = 'password-manager',
+    BinanceSmartChain = 'binance-smart-chain',
 }
 
 type FeatureIntlMap = Partial<Record<ExperimentalFeature, TranslationKey>>;
 
 export const ExperimentalFeatureTitle: FeatureIntlMap = {
     [ExperimentalFeature.PasswordManager]: 'TR_EXPERIMENTAL_PASSWORD_MANAGER',
+    [ExperimentalFeature.BinanceSmartChain]: 'TR_EXPERIMENTAL_NETWORK_BSC',
 };
 
 export const ExperimentalFeatureDescription: FeatureIntlMap = {
     [ExperimentalFeature.PasswordManager]: 'TR_EXPERIMENTAL_PASSWORD_MANAGER_DESCRIPTION',
+    [ExperimentalFeature.BinanceSmartChain]: 'TR_EXPERIMENTAL_NETWORK_BSC_DESCRIPTION',
 };

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5495,6 +5495,14 @@ export default defineMessages({
         id: 'TR_EXPERIMENTAL_PASSWORD_MANAGER_DESCRIPTION',
         defaultMessage: 'Re-implementation of Trezor password manager webextension',
     },
+    TR_EXPERIMENTAL_NETWORK_BSC: {
+        id: 'TR_EXPERIMENTAL_NETWORK_BSC',
+        defaultMessage: 'Binance Smart Chain',
+    },
+    TR_EXPERIMENTAL_NETWORK_BSC_DESCRIPTION: {
+        id: 'TR_EXPERIMENTAL_NETWORK_BSC_DESCRIPTION',
+        defaultMessage: 'Be aware of a few limitation - tady a tady to uprav!',
+    },
     TR_EARLY_ACCESS: {
         id: 'TR_EARLY_ACCESS',
         defaultMessage: 'Early Access Program',

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -365,7 +365,6 @@ export const networks = {
         customBackends: ['blockbook'],
         accountTypes: {},
         coingeckoId: 'binance-smart-chain',
-        isDebugOnly: true,
     },
     // testnets
     test: {


### PR DESCRIPTION
WIP 

Adding BNB to Experimental features 

Todo 

- [ ] Adjust copy for TR_EXPERIMENTAL_NETWORK_BSC_DESCRIPTION
- [ ] Make sure that BNB acc will turn of once Experimental features will be disabled(section/BNB part)
- [ ] Should we automatically add a BNB account after the user enables it in Experimental features?