### PR TITLE
fix(suite): tokens seach by token to and from

### DIFF
--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -923,7 +923,11 @@ export const simpleSearchTransactions = (
     // Find by token name, symbol or contract
     const foundTxsForToken = transactions.flatMap(transaction => {
         const hasMatchingToken = transaction.tokens.some(token => {
-            return isTokenMatchesSearch(token, search.toLowerCase());
+            return (
+                isTokenMatchesSearch(token, search.toLowerCase()) ||
+                token.to?.toLowerCase().includes(search.toLowerCase()) ||
+                token.from?.toLowerCase().includes(search.toLowerCase())
+            );
         });
 
         if (hasMatchingToken) {


### PR DESCRIPTION
## Description

There was a special type of transaction called `Deposit for` that shows `token.to` inside the transaction item. When copying this to search if found nothing. Now it's fixed and search will also use `token.to` and `token.from`

## Screenshots:
![Screenshot 2024-07-24 at 11 35 41 AM](https://github.com/user-attachments/assets/f3392024-89c5-44c4-9c0a-3ca038bd6d74)
