### PR TITLE
chore(utils): catch leaking listeners in unit tests

### DIFF
--- a/packages/utils/.eslintrc.js
+++ b/packages/utils/.eslintrc.js
@@ -2,5 +2,6 @@ module.exports = {
     rules: {
         'no-console': 'warn',
         'import/no-default-export': 'error',
+        'import/no-extraneous-dependencies': ['error', { devDependencies: true }],
     },
 };

--- a/packages/utils/JestCustomEnv.js
+++ b/packages/utils/JestCustomEnv.js
@@ -1,0 +1,17 @@
+const NodeEnvironment = require('jest-environment-node').default;
+
+class CustomEnvironment extends NodeEnvironment {
+    async setup() {
+        await super.setup();
+
+        process.on('warning', warning => {
+            if (warning.name === 'MaxListenersExceededWarning') {
+                throw new Error(
+                    'MaxListenersExceededWarning detected. If you need more, use events.setMaxListeners(desiredNumber)',
+                );
+            }
+        });
+    }
+}
+
+module.exports = CustomEnvironment;

--- a/packages/utils/jest.config.js
+++ b/packages/utils/jest.config.js
@@ -1,0 +1,8 @@
+const baseConfig = require('../../jest.config.base');
+
+module.exports = {
+    ...baseConfig,
+    collectCoverage: true,
+    collectCoverageFrom: ['src/**/*.ts'],
+    testEnvironment: './JestCustomEnv.js',
+};

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -24,7 +24,7 @@
     ],
     "scripts": {
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
-        "test:unit": "yarn g:jest --verbose -c ../../jest.config.base.js",
+        "test:unit": "yarn g:jest --verbose -c ./jest.config.js",
         "type-check": "yarn g:tsc --build tsconfig.json",
         "build:lib": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/replace-imports.sh ./lib",
         "prepublishOnly": "yarn tsx ../../scripts/prepublishNPM.js",
@@ -34,6 +34,7 @@
         "tslib": "^2.6.2"
     },
     "devDependencies": {
+        "jest-environment-node": "^29.7.0",
         "tsx": "^4.7.0"
     },
     "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11507,6 +11507,7 @@ __metadata:
   resolution: "@trezor/utils@workspace:packages/utils"
   dependencies:
     bignumber.js: "npm:^9.1.2"
+    jest-environment-node: "npm:^29.7.0"
     tsx: "npm:^4.7.0"
   peerDependencies:
     tslib: ^2.6.2


### PR DESCRIPTION
this makes unit tests in the utils package fail whenever `MaxListenersExceededWarning` should be printed