### PR TITLE
feat(suite): add unsupported coins sections to settings, onboarding a…

### DIFF
--- a/packages/suite/src/components/suite/CoinGroup/CoinGroup.tsx
+++ b/packages/suite/src/components/suite/CoinGroup/CoinGroup.tsx
@@ -1,9 +1,7 @@
 import { useState } from 'react';
 import styled from 'styled-components';
 
-import { selectDeviceSupportedNetworks } from '@suite-common/wallet-core';
-
-import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useDispatch } from 'src/hooks/suite';
 import { openModal } from 'src/actions/suite/modalActions';
 import { CoinList } from 'src/components/suite';
 import type { Network } from 'src/types/wallet';
@@ -16,24 +14,17 @@ const CoinGroupWrapper = styled.div`
 
 interface CoinGroupProps {
     networks: Network[];
-    selectedNetworks?: Network['symbol'][];
+    enabledNetworks?: Network['symbol'][];
     className?: string;
     onToggle: (symbol: Network['symbol'], toggled: boolean) => void;
 }
 
-export const CoinGroup = ({ onToggle, networks, selectedNetworks, className }: CoinGroupProps) => {
-    const deviceSupportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
-
+export const CoinGroup = ({ onToggle, networks, enabledNetworks, className }: CoinGroupProps) => {
     const [settingsMode, setSettingsMode] = useState(false);
 
     const dispatch = useDispatch();
 
-    const supportedNetworks = networks.filter(network =>
-        deviceSupportedNetworkSymbols.includes(network.symbol),
-    );
-    const isAtLeastOneActive = supportedNetworks.some(({ symbol }) =>
-        selectedNetworks?.includes(symbol),
-    );
+    const isAtLeastOneActive = networks.some(({ symbol }) => enabledNetworks?.includes(symbol));
 
     const onSettings = (symbol: Network['symbol']) => {
         setSettingsMode(false);
@@ -54,8 +45,8 @@ export const CoinGroup = ({ onToggle, networks, selectedNetworks, className }: C
                 toggleSettingsMode={toggleSettingsMode}
             />
             <CoinList
-                networks={supportedNetworks}
-                selectedNetworks={selectedNetworks}
+                networks={networks}
+                enabledNetworks={enabledNetworks}
                 settingsMode={settingsMode}
                 onToggle={settingsMode ? onSettings : onToggle}
                 onSettings={settingsMode ? undefined : onSettings}

--- a/packages/suite/src/components/suite/CoinList/CoinList.tsx
+++ b/packages/suite/src/components/suite/CoinList/CoinList.tsx
@@ -21,7 +21,7 @@ const Wrapper = styled.div`
 
 interface CoinListProps {
     networks: Network[];
-    selectedNetworks?: Network['symbol'][];
+    enabledNetworks?: Network['symbol'][];
     settingsMode?: boolean;
     onSettings?: (symbol: Network['symbol']) => void;
     onToggle: (symbol: Network['symbol'], toggled: boolean) => void;
@@ -29,7 +29,7 @@ interface CoinListProps {
 
 export const CoinList = ({
     networks,
-    selectedNetworks,
+    enabledNetworks,
     settingsMode = false,
     onSettings,
     onToggle,
@@ -64,7 +64,7 @@ export const CoinList = ({
                     ? device?.unavailableCapabilities?.[symbol]
                     : 'update-required';
 
-                const isEnabled = !!selectedNetworks?.includes(symbol);
+                const isEnabled = !!enabledNetworks?.includes(symbol);
 
                 const disabled =
                     (!settingsMode && !!unavailableReason && !isBootloaderMode) ||

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/SelectNetwork.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/SelectNetwork.tsx
@@ -35,7 +35,7 @@ export const SelectNetwork = ({
             <CoinList
                 onToggle={handleNetworkSelection}
                 networks={networks}
-                selectedNetworks={selectedNetworks}
+                enabledNetworks={selectedNetworks}
             />
         </div>
     );

--- a/packages/suite/src/constants/suite/anchors.ts
+++ b/packages/suite/src/constants/suite/anchors.ts
@@ -37,6 +37,7 @@ export const enum SettingsAnchor {
 
     Crypto = '@coin-settings/crypto',
     TestnetCrypto = '@coin-settings/testnet-crypto',
+    UnsupportedCrypto = '@coin-settings/unsupported-crypto',
 
     TranslationMode = '@debug-settings/translation-mode',
     GithubIssue = '@debug-settings/github-issue',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3404,6 +3404,15 @@ export default defineMessages({
         defaultMessage: 'TEST COIN',
         id: 'TR_TESTNET_COINS_LABEL',
     },
+    TR_UNSUPPORTED_COINS: {
+        defaultMessage: 'Supported on newer Trezors',
+        id: 'TR_UNSUPPORTED_COINS',
+    },
+    TR_UNSUPPORTED_COINS_DESCRIPTION: {
+        defaultMessage:
+            'These coins are supported on Trezor Safe family devices and the Trezor Model T.',
+        id: 'TR_UNSUPPORTED_COINS_DESCRIPTION',
+    },
     TR_THE_PIN_LAYOUT_IS_DISPLAYED: {
         defaultMessage: 'Check <b>{deviceLabel}</b> screen for the keypad layout.',
         id: 'TR_THE_PIN_LAYOUT_IS_DISPLAYED',

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -716,7 +716,7 @@ export const selectDeviceSupportedNetworks = (state: DeviceRootState) => {
     const firmwareVersion = getFirmwareVersion(device);
 
     return Object.entries(networks)
-        .map(([symbol, network]) => {
+        .filter(([symbol, network]) => {
             const support =
                 'support' in network ? (network.support as Network['support']) : undefined;
 
@@ -733,19 +733,19 @@ export const selectDeviceSupportedNetworks = (state: DeviceRootState) => {
 
             // if device does not have fw, do not show coins which are not supported by device in any case
             if (!firmwareVersion && unavailableReason === 'no-support') {
-                return null;
+                return false;
             }
             // if device has fw, do not show coins which are not supported by current fw
             if (
                 firmwareVersion &&
                 ['no-support', 'no-capability'].includes(unavailableReason || '')
             ) {
-                return null;
+                return false;
             }
 
-            return symbol;
+            return true;
         })
-        .filter(Boolean) as Network['symbol'][]; // Filter out null values
+        .map(([symbol]) => symbol as Network['symbol']);
 };
 
 export const selectDeviceById = (state: DeviceRootState, deviceId: TrezorDevice['id']) =>


### PR DESCRIPTION
Added a new unsupported coins section to coins settings, onboarding and when adding a new account. These are only visible when using a T1B1 device.

## Screenshots:

<img width="533" alt="Screenshot 2024-07-25 at 11 39 25" src="https://github.com/user-attachments/assets/148b1c47-bec5-40ff-930f-4abcdf711547">
<img width="1216" alt="Screenshot 2024-07-25 at 11 39 59" src="https://github.com/user-attachments/assets/f5b8f076-a0a1-45fb-96be-ec6967b41d95">
<img width="879" alt="Screenshot 2024-07-25 at 11 40 47" src="https://github.com/user-attachments/assets/c1b7b999-11da-43ea-adbd-9b44b6cbfbff">
