### PR TITLE
fix(suite): fix switch alignment in sidebar device selector

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
@@ -48,6 +48,7 @@ const Wrapper = styled.div<{ $isAnimationTriggered?: boolean }>`
 const InnerContainer = styled.div`
     position: relative;
     display: flex;
+    align-items: center;
     cursor: pointer;
     gap: ${spacingsPx.md};
 `;


### PR DESCRIPTION
## Screenshots:

### Before:
<img width="275" alt="Screenshot 2024-07-25 at 12 00 22" src="https://github.com/user-attachments/assets/934ce71f-0f53-4343-8f39-6e9dfe4c48af">

### After:
<img width="275" alt="Screenshot 2024-07-25 at 12 00 02" src="https://github.com/user-attachments/assets/02baf7d6-2bcc-4c9a-ae31-d94de0513f6f">

