### PR TITLE
feat(staking): add unstaking amount in transaction detail

### DIFF
--- a/packages/suite/src/components/suite/UnstakingTxAmount.tsx
+++ b/packages/suite/src/components/suite/UnstakingTxAmount.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { isUnstakeTx } from '@suite-common/suite-utils';
+import { WalletAccountTransaction } from '@suite-common/wallet-types';
+import { formatNetworkAmount } from '@suite-common/wallet-utils';
+import { getUnstakingAmount } from 'src/utils/suite/stake';
+import { FormattedCryptoAmount } from './FormattedCryptoAmount';
+
+interface UnstakingTxAmountProps {
+    transaction: WalletAccountTransaction;
+}
+
+export const UnstakingTxAmount = ({ transaction }: UnstakingTxAmountProps) => {
+    const { ethereumSpecific, symbol } = transaction;
+    const txSignature = ethereumSpecific?.parsedData?.methodId;
+
+    if (!isUnstakeTx(txSignature)) return null;
+
+    const amount = getUnstakingAmount(ethereumSpecific?.data);
+
+    if (!amount) return null;
+
+    return <FormattedCryptoAmount value={formatNetworkAmount(amount, symbol)} symbol={symbol} />;
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AdvancedTxDetails/AmountDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AdvancedTxDetails/AmountDetails.tsx
@@ -23,6 +23,7 @@ import {
     selectHistoricFiatRatesByTimestamp,
 } from '@suite-common/wallet-core';
 import { Timestamp, TokenAddress } from '@suite-common/wallet-types';
+import { isStakeTypeTx } from '@suite-common/suite-utils';
 
 const MainContainer = styled.div`
     display: flex;
@@ -71,6 +72,9 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
     const cardanoDeposit = formatCardanoDeposit(tx);
     const { selectedAccount } = useSelector(state => state.wallet);
 
+    const txSignature = tx.ethereumSpecific?.parsedData?.methodId;
+    const isStakeTypeTxNoAmount = isStakeTypeTx(txSignature) && amount.eq(0);
+
     return (
         <MainContainer>
             <AmountWrapper>
@@ -106,7 +110,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                     />
                 )}
                 {/* AMOUNT */}
-                {(tx.targets.length || tx.type === 'joint') && (
+                {!isStakeTypeTxNoAmount && (tx.targets.length || tx.type === 'joint') && (
                     <AmountRow
                         firstColumn={<Translation id="AMOUNT" />}
                         secondColumn={
@@ -178,7 +182,9 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                     <AmountRow
                         key={i}
                         firstColumn={
-                            !tx.targets.length && i === 0 ? <Translation id="AMOUNT" /> : undefined
+                            i === 0 && (!tx.targets.length || isStakeTypeTxNoAmount) ? (
+                                <Translation id="AMOUNT" />
+                            ) : undefined
                         }
                         secondColumn={
                             <FormattedCryptoAmount

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
@@ -14,6 +14,7 @@ import {
     spacingsPx,
     typography,
 } from '@trezor/theme';
+import { UnstakingTxAmount } from 'src/components/suite/UnstakingTxAmount';
 
 const Wrapper = styled.div<{ $elevation: Elevation }>`
     background: ${mapElevationToBackground};
@@ -128,6 +129,8 @@ const TxSentStatus = styled(H3)`
     overflow: hidden;
     text-overflow: ellipsis;
     color: ${({ theme }) => theme.textDefault};
+    gap: ${spacingsPx.xxs};
+    display: flex;
 `;
 
 const ConfirmationStatus = styled.div<{ $confirmed: boolean; $tiny?: boolean }>`
@@ -194,6 +197,7 @@ export const BasicTxDetails = ({
                 <TxStatus>
                     <TxSentStatus>
                         <TransactionHeader transaction={tx} isPending={isPending(tx)} />
+                        <UnstakingTxAmount transaction={tx} />
                     </TxSentStatus>
                 </TxStatus>
 

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionHeading.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionHeading.tsx
@@ -18,6 +18,8 @@ import { TransactionHeader } from './TransactionHeader';
 import { WalletAccountTransaction } from 'src/types/wallet';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { BlurWrapper } from './TransactionItemBlurWrapper';
+import { spacingsPx } from '@trezor/theme';
+import { UnstakingTxAmount } from 'src/components/suite/UnstakingTxAmount';
 
 const Wrapper = styled.span`
     display: flex;
@@ -65,6 +67,11 @@ const HelpLink = styled(TrezorLink)`
     path {
         fill: ${({ theme }) => theme.TYPE_ORANGE};
     }
+`;
+
+const HeaderWrapper = styled.div`
+    display: flex;
+    gap: ${spacingsPx.xxs};
 `;
 
 interface TransactionHeadingProps {
@@ -156,7 +163,10 @@ export const TransactionHeading = ({
                         />
                     )}
                     <BlurWrapper $isBlurred={isPhishingTransaction}>
-                        <TransactionHeader transaction={transaction} isPending={isPending} />
+                        <HeaderWrapper>
+                            <TransactionHeader transaction={transaction} isPending={isPending} />
+                            <UnstakingTxAmount transaction={transaction} />
+                        </HeaderWrapper>
                     </BlurWrapper>
                 </HeadingWrapper>
 

--- a/packages/suite/src/utils/suite/__fixtures__/stake.ts
+++ b/packages/suite/src/utils/suite/__fixtures__/stake.ts
@@ -47,6 +47,19 @@ export const transformTxFixtures = [
     },
 ];
 
+export const getUnstakingAmountFixtures = [
+    {
+        description: 'should correctly extract and convert the unstaking amount from ethereum data',
+        ethereumData: '76ec871c0000000000000000000000000000000000000000000000000000000000000001', // without 0x
+        expectedAmountWei: '1', // 0.000000000000000001 eth
+    },
+    {
+        description: 'should correctly remove 0x prefix from ethereum data',
+        ethereumData: '0x76ec871c0000000000000000000000000000000000000000000000000000000000000001', // with 0x
+        expectedAmountWei: '1', // 0.000000000000000001 eth
+    },
+];
+
 export const stakeFixture = [
     {
         description: 'should stake 0.1 eth, expect correct transaction object with correct values',

--- a/packages/suite/src/utils/suite/__tests__/stake.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/stake.test.ts
@@ -15,8 +15,10 @@ import {
     getDaysToAddToPoolInitialFixture,
     getAdjustedGasLimitConsumptionFixture,
     getEthNetworkForWalletSdkFixture,
+    getUnstakingAmountFixtures,
 } from '../__fixtures__/stake';
 import {
+    getUnstakingAmount,
     transformTx,
     stake,
     unstake,
@@ -47,6 +49,15 @@ describe('transformTx', () => {
             const result = transformTx(test.tx, test.gasPrice, test.nonce, test.chainId);
             expect(result).toEqual(test.result);
             expect(result).not.toHaveProperty('from');
+        });
+    });
+});
+
+describe('getUnstakingAmount', () => {
+    getUnstakingAmountFixtures.forEach(test => {
+        it(test.description, () => {
+            const result = getUnstakingAmount(test.ethereumData);
+            expect(result).toBe(test.expectedAmountWei);
         });
     });
 });

--- a/packages/suite/src/utils/suite/stake.ts
+++ b/packages/suite/src/utils/suite/stake.ts
@@ -7,7 +7,7 @@ import {
 import { DEFAULT_PAYMENT } from '@suite-common/wallet-constants';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { Ethereum } from '@everstake/wallet-sdk';
-import { fromWei, numberToHex, toWei } from 'web3-utils';
+import { fromWei, hexToNumberString, numberToHex, toWei } from 'web3-utils';
 import { getEthereumEstimateFeeParams, sanitizeHex } from '@suite-common/wallet-utils';
 import TrezorConnect, { EthereumTransaction, Success } from '@trezor/connect';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
@@ -555,4 +555,14 @@ export const getDaysToAddToPoolInitial = (validatorsQueue?: ValidatorsQueue) => 
     const daysToWait = secondsToDays(secondsToWait);
 
     return daysToWait <= 0 ? 1 : daysToWait;
+};
+
+export const getUnstakingAmount = (ethereumData: string | undefined): string | null => {
+    if (!ethereumData) return null;
+
+    // Check if the first two characters are '0x' and remove them if they are
+    const data = ethereumData.startsWith('0x') ? ethereumData.slice(2) : ethereumData;
+    const dataBuffer = Buffer.from(data, 'hex');
+
+    return hexToNumberString(`0x${dataBuffer.subarray(4, 36).toString('hex')}`);
 };


### PR DESCRIPTION
Display unstaking amount in transaction details

## Description

This pull request introduces a new feature to display the unstaking amount in the transaction details view. Additionally, it removes zero amount from the transaction details modal.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/13383

## Screenshots:
![image](https://github.com/user-attachments/assets/4b3a8036-0097-4fb8-aaf4-e6b96e1ca2f9)
![image](https://github.com/user-attachments/assets/9afb2cbc-8fc2-4554-9c6a-8dd80860df5e)
![image](https://github.com/user-attachments/assets/ac0191a9-cc90-4209-a4be-7beb3315640c)
