### PR TITLE
`DeviceList`/`Transport` revamp

### DIFF
--- a/packages/connect/setupJest.ts
+++ b/packages/connect/setupJest.ts
@@ -42,7 +42,7 @@ const createTransportApi = (override = {}) =>
 
 export const createTestTransport = (apiMethods = {}) => {
     const { signal } = new AbortController();
-    const sessionsBackground = new SessionsBackground({ signal });
+    const sessionsBackground = new SessionsBackground();
     const sessionsClient = new SessionsClient({
         requestFn: params => sessionsBackground.handleMessage(params),
         registerBackgroundCallbacks: onDescriptorsCallback => {

--- a/packages/connect/setupJest.ts
+++ b/packages/connect/setupJest.ts
@@ -41,7 +41,6 @@ const createTransportApi = (override = {}) =>
     }) as unknown as UsbApi;
 
 export const createTestTransport = (apiMethods = {}) => {
-    const { signal } = new AbortController();
     const sessionsBackground = new SessionsBackground();
     const sessionsClient = new SessionsClient({
         requestFn: params => sessionsBackground.handleMessage(params),
@@ -55,7 +54,6 @@ export const createTestTransport = (apiMethods = {}) => {
     const transport = new TestTransport({
         api: createTransportApi(apiMethods),
         sessionsClient,
-        signal,
     });
 
     return transport;

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -531,12 +531,8 @@ const onCallDevice = async (
     const { origin, env, useCoreInPopup } = DataManager.getSettings();
 
     if (!deviceList.isConnected() && !deviceList.pendingConnection()) {
-        const { transports, pendingTransportEvent } = DataManager.getSettings();
         // transport is missing try to initialize it once again
-        // TODO bridge transport is probably not reusable, so I can't remove this setTransports yet.
-        deviceList.setTransports(transports);
-        // TODO is pendingTransportEvent needed here?
-        deviceList.init({ pendingTransportEvent });
+        deviceList.init();
     }
     await deviceList.pendingConnection();
 

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -190,7 +190,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
                 previous: this.originalDescriptor.session,
             },
         });
-        const acquireResult = await this.acquirePromise.promise;
+        const acquireResult = await this.acquirePromise;
         this.acquirePromise = undefined;
         if (!acquireResult.success) {
             if (this.runPromise) {
@@ -225,7 +225,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
             if (this.commands) {
                 this.commands.dispose();
                 if (this.commands.callPromise) {
-                    await this.commands.callPromise.promise;
+                    await this.commands.callPromise;
                 }
             }
 
@@ -234,7 +234,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
                 path: this.originalDescriptor.path,
             });
 
-            const releaseResponse = await this.releasePromise.promise;
+            const releaseResponse = await this.releasePromise;
             this.releasePromise = undefined;
             if (releaseResponse.success) {
                 this.transportSession = null;
@@ -274,14 +274,14 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
     async override(error: Error) {
         if (this.acquirePromise) {
-            await this.acquirePromise.promise;
+            await this.acquirePromise;
         }
 
         if (this.runPromise) {
             await this.interruptionFromUser(error);
         }
         if (this.releasePromise) {
-            await this.releasePromise.promise;
+            await this.releasePromise;
         }
     }
 
@@ -327,7 +327,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
         // note: I am tempted to do this check at the beginning of device.acquire but on the other hand I would like
         // to have methods as atomic as possible and shift responsibility for deciding when to call them on the caller
         if (this.releasePromise) {
-            await this.releasePromise.promise;
+            await this.releasePromise;
         }
 
         if (!this.isUsedHere() || this.commands?.disposed || !this.getState()?.staticSessionId) {

--- a/packages/connect/src/device/DeviceCommands.ts
+++ b/packages/connect/src/device/DeviceCommands.ts
@@ -325,7 +325,7 @@ export class DeviceCommands {
             protocol: this.device.protocol,
         });
 
-        const res = await this.callPromise.promise;
+        const res = await this.callPromise;
 
         this.callPromise = undefined;
         if (!res.success) {
@@ -374,7 +374,7 @@ export class DeviceCommands {
             await this.transport.receive({
                 session: this.transportSession,
                 protocol: this.device.protocol,
-            }).promise;
+            });
             // throw error anyway, next call should be resolved properly
             throw error;
         }
@@ -649,7 +649,7 @@ export class DeviceCommands {
 
         if (!this._cancelableRequestBySend) {
             if (this.callPromise) {
-                await this.callPromise.promise;
+                await this.callPromise;
             }
 
             return;
@@ -671,10 +671,10 @@ export class DeviceCommands {
                 session: this.transportSession,
                 name: 'Cancel',
                 data: {},
-            }).promise;
+            });
 
             if (this.callPromise) {
-                await this.callPromise.promise;
+                await this.callPromise;
             }
             // if my observations are correct, it is not necessary to transport.receive after send
             // transport.call -> transport.send -> transport call returns Failure meaning it won't be

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -305,7 +305,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
     }
 
     private async selectTransport([transport, ...rest]: Transport[]): Promise<Transport> {
-        const result = await transport.init().promise;
+        const result = await transport.init();
         if (result.success) return transport;
         else if (rest.length) return this.selectTransport(rest);
         else throw new Error(result.error);
@@ -333,7 +333,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
 
         // enumerating for the first time. we intentionally postpone emitting TRANSPORT_START
         // event until we read descriptors for the first time
-        const enumerateResult = await transport.enumerate().promise;
+        const enumerateResult = await transport.enumerate();
 
         if (!enumerateResult.success) {
             throw new Error(enumerateResult.error);
@@ -477,7 +477,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
 
     // TODO this is fugly
     async enumerate(transport = this.transport) {
-        const res = await transport.enumerate().promise;
+        const res = await transport.enumerate();
 
         if (!res.success) {
             return;

--- a/packages/connect/src/device/__tests__/DeviceList.test.ts
+++ b/packages/connect/src/device/__tests__/DeviceList.test.ts
@@ -90,14 +90,13 @@ describe('DeviceList', () => {
 
     it('.init() throws async error from transport.init()', async () => {
         const transport = createTestTransport();
-        jest.spyOn(transport, 'init').mockImplementation(() => ({
-            promise: Promise.resolve({
+        jest.spyOn(transport, 'init').mockImplementation(() =>
+            Promise.resolve({
                 success: false,
                 error: 'unexpected error',
                 message: '',
             } as const),
-            abort: () => {},
-        }));
+        );
 
         list.setTransports([transport]);
         list.init({ pendingTransportEvent: true });
@@ -109,14 +108,13 @@ describe('DeviceList', () => {
 
     it('.init() throws async error from transport.enumerate()', async () => {
         const transport = createTestTransport();
-        jest.spyOn(transport, 'enumerate').mockImplementation(() => ({
-            promise: Promise.resolve({
+        jest.spyOn(transport, 'enumerate').mockImplementation(() =>
+            Promise.resolve({
                 success: false,
                 error: 'unexpected error',
                 message: '',
             } as const),
-            abort: () => {},
-        }));
+        );
 
         list.setTransports([transport]);
         list.init({ pendingTransportEvent: true });

--- a/packages/suite-web/e2e/cypress.config.ts
+++ b/packages/suite-web/e2e/cypress.config.ts
@@ -158,11 +158,7 @@ export default defineConfig({
                     return null;
                 },
                 stealBridgeSession: async () => {
-                    const abortController = new AbortController();
-                    const bridge = new BridgeTransport({
-                        messages,
-                        signal: abortController.signal,
-                    });
+                    const bridge = new BridgeTransport({ messages });
                     await bridge.init();
                     const enumerateRes = await bridge.enumerate();
                     if (!enumerateRes.success) return null;

--- a/packages/suite-web/e2e/cypress.config.ts
+++ b/packages/suite-web/e2e/cypress.config.ts
@@ -163,12 +163,12 @@ export default defineConfig({
                         messages,
                         signal: abortController.signal,
                     });
-                    await bridge.init().promise;
-                    const enumerateRes = await bridge.enumerate().promise;
+                    await bridge.init();
+                    const enumerateRes = await bridge.enumerate();
                     if (!enumerateRes.success) return null;
                     await bridge.acquire({
                         input: { path: enumerateRes.payload[0].path, previous: null },
-                    }).promise;
+                    });
 
                     return null;
                 },

--- a/packages/transport-bridge/src/core.ts
+++ b/packages/transport-bridge/src/core.ts
@@ -107,7 +107,7 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
         } catch (err) {
             logger?.debug(`core: readUtil catch: ${err.message}`);
 
-            return unknownError(err, []);
+            return unknownError(err);
         }
     };
 

--- a/packages/transport-bridge/src/core.ts
+++ b/packages/transport-bridge/src/core.ts
@@ -17,8 +17,7 @@ import { success, unknownError } from '@trezor/transport/src/utils/result';
 export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) => {
     let api: AbstractApi;
 
-    const abortController = new AbortController();
-    const sessionsBackground = new SessionsBackground({ signal: abortController.signal });
+    const sessionsBackground = new SessionsBackground();
 
     const sessionsClient = new SessionsClient({
         requestFn: args => sessionsBackground.handleMessage(args),
@@ -300,7 +299,7 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
     };
 
     const dispose = () => {
-        abortController.abort();
+        sessionsBackground.dispose();
         api.dispose();
         sessionsClient.dispose();
     };

--- a/packages/transport-native/src/nativeUsb.ts
+++ b/packages/transport-native/src/nativeUsb.ts
@@ -11,9 +11,11 @@ export class NativeUsbTransport extends AbstractApiTransport {
     // TODO: Not sure how to solve this type correctly.
     public name = 'NativeUsbTransport' as any;
 
+    private readonly sessionsBackground;
+
     constructor(params: ConstructorParameters<typeof AbstractTransport>[0]) {
         const { messages, logger, signal } = params;
-        const sessionsBackground = new SessionsBackground({ signal });
+        const sessionsBackground = new SessionsBackground();
 
         const sessionsClient = new SessionsClient({
             requestFn: args => sessionsBackground.handleMessage(args),
@@ -33,10 +35,12 @@ export class NativeUsbTransport extends AbstractApiTransport {
             sessionsClient,
             signal,
         });
+        this.sessionsBackground = sessionsBackground;
     }
 
     public listen() {
         this.api.listen();
+        this.sessionsBackground.dispose();
 
         return super.listen();
     }

--- a/packages/transport-native/src/nativeUsb.ts
+++ b/packages/transport-native/src/nativeUsb.ts
@@ -14,7 +14,7 @@ export class NativeUsbTransport extends AbstractApiTransport {
     private readonly sessionsBackground;
 
     constructor(params: ConstructorParameters<typeof AbstractTransport>[0]) {
-        const { messages, logger, signal } = params;
+        const { messages, logger } = params;
         const sessionsBackground = new SessionsBackground();
 
         const sessionsClient = new SessionsClient({
@@ -33,7 +33,6 @@ export class NativeUsbTransport extends AbstractApiTransport {
                 logger,
             }),
             sessionsClient,
-            signal,
         });
         this.sessionsBackground = sessionsBackground;
     }

--- a/packages/transport-test/e2e/bridge/bridge-complex-cases.test.ts
+++ b/packages/transport-test/e2e/bridge/bridge-complex-cases.test.ts
@@ -23,8 +23,7 @@ describe('restarting bridge', () => {
         await TrezorUserEnvLink.startEmu();
         await TrezorUserEnvLink.startBridge();
 
-        const abortController = new AbortController();
-        bridge = new BridgeTransport({ messages, signal: abortController.signal });
+        bridge = new BridgeTransport({ messages });
         await bridge.init();
 
         const enumerateResult = await bridge.enumerate();
@@ -51,8 +50,7 @@ describe('restarting bridge', () => {
         await TrezorUserEnvLink.stopBridge();
         await TrezorUserEnvLink.startEmu();
         await TrezorUserEnvLink.startBridge();
-        const abortController = new AbortController();
-        bridge = new BridgeTransport({ messages, signal: abortController.signal });
+        bridge = new BridgeTransport({ messages });
         await bridge.init();
 
         const enumerateResult = await bridge.enumerate();

--- a/packages/transport-test/e2e/bridge/bridge-complex-cases.test.ts
+++ b/packages/transport-test/e2e/bridge/bridge-complex-cases.test.ts
@@ -25,15 +25,15 @@ describe('restarting bridge', () => {
 
         const abortController = new AbortController();
         bridge = new BridgeTransport({ messages, signal: abortController.signal });
-        await bridge.init().promise;
+        await bridge.init();
 
-        const enumerateResult = await bridge.enumerate().promise;
+        const enumerateResult = await bridge.enumerate();
         assertSuccess(enumerateResult);
         descriptors = enumerateResult.payload;
 
         const acquireResult = await bridge.acquire({
             input: { path: descriptors[0].path, previous: session },
-        }).promise;
+        });
         assertSuccess(acquireResult);
         session = acquireResult.payload;
     });
@@ -46,16 +46,16 @@ describe('restarting bridge', () => {
 
     // This scenario crashes the old bridge (2.0.33) on Mac. New bridge seems to be performing correctly
     test('Bridge stops while device is acquired then starts again and client tries to force acquire device', async () => {
-        await bridge.send({ session, name: 'GetFeatures', data: {} }).promise;
+        await bridge.send({ session, name: 'GetFeatures', data: {} });
 
         await TrezorUserEnvLink.stopBridge();
         await TrezorUserEnvLink.startEmu();
         await TrezorUserEnvLink.startBridge();
         const abortController = new AbortController();
         bridge = new BridgeTransport({ messages, signal: abortController.signal });
-        await bridge.init().promise;
+        await bridge.init();
 
-        const enumerateResult = await bridge.enumerate().promise;
+        const enumerateResult = await bridge.enumerate();
         assertSuccess(enumerateResult);
         expect(enumerateResult).toMatchObject({
             success: true,
@@ -76,7 +76,7 @@ describe('restarting bridge', () => {
                 // so maybe it is not about send at all? it looks like that only one send is enough to cause it
                 previous: null,
             },
-        }).promise;
+        });
 
         // old bridge is crashed and only if using HW, not emu.
         if (!env.USE_NODE_BRIDGE && env.USE_HW) {
@@ -85,7 +85,7 @@ describe('restarting bridge', () => {
             return;
         } else {
             // new bridge received some nice fixes and now we can continue
-            const enumerateResult2 = await bridge.enumerate().promise;
+            const enumerateResult2 = await bridge.enumerate();
             expect(enumerateResult2).toMatchObject({
                 success: true,
                 payload: [

--- a/packages/transport-test/e2e/bridge/bridge.test.ts
+++ b/packages/transport-test/e2e/bridge/bridge.test.ts
@@ -17,8 +17,7 @@ describe('bridge', () => {
         await TrezorUserEnvLink.startEmu(emulatorStartOpts);
         await TrezorUserEnvLink.startBridge();
 
-        const abortController = new AbortController();
-        bridge = new BridgeTransport({ messages, signal: abortController.signal });
+        bridge = new BridgeTransport({ messages });
         await bridge.init();
 
         const enumerateResult = await bridge.enumerate();

--- a/packages/transport-test/e2e/bridge/multi-client.test.ts
+++ b/packages/transport-test/e2e/bridge/multi-client.test.ts
@@ -29,7 +29,7 @@ describe('bridge', () => {
      * set bridge1 and bridge2 descriptors and start listening
      */
     const enumerateAndListen = async () => {
-        const result = await bridge1.enumerate().promise;
+        const result = await bridge1.enumerate();
         expect(result.success).toBe(true);
 
         if (result.success) {
@@ -67,8 +67,8 @@ describe('bridge', () => {
         bridge1 = new BridgeTransport({ messages, signal: abortController.signal });
         bridge2 = new BridgeTransport({ messages, signal: abortController.signal });
 
-        await bridge1.init().promise;
-        await bridge2.init().promise;
+        await bridge1.init();
+        await bridge2.init();
     });
 
     test('2 clients. one acquires and releases, the other one is watching', async () => {
@@ -79,7 +79,7 @@ describe('bridge', () => {
 
         const session1 = await bridge1.acquire({
             input: { previous: null, path: descriptors[0].path },
-        }).promise;
+        });
         expect(session1).toEqual({
             success: true,
             payload: '1',
@@ -105,7 +105,7 @@ describe('bridge', () => {
             return;
         }
 
-        await bridge1.release({ path: descriptors[0].path, session: session1.payload }).promise;
+        await bridge1.release({ path: descriptors[0].path, session: session1.payload });
 
         await wait();
 
@@ -124,7 +124,7 @@ describe('bridge', () => {
 
         const session2 = await bridge2.acquire({
             input: { previous: null, path: descriptors[0].path },
-        }).promise;
+        });
         expect(session2).toEqual({ success: true, payload: '2' });
     });
 
@@ -136,7 +136,7 @@ describe('bridge', () => {
 
         const session1 = await bridge1.acquire({
             input: { previous: null, path: descriptors[0].path },
-        }).promise;
+        });
 
         expect(session1).toEqual({ success: true, payload: '1' });
         if (!session1.success) {
@@ -148,7 +148,7 @@ describe('bridge', () => {
         // bridge 2 steals session
         const session2 = await bridge2.acquire({
             input: { previous: session1.payload, path: descriptors[0].path },
-        }).promise;
+        });
 
         expect(session2).toEqual({ success: true, payload: '2' });
 
@@ -176,21 +176,21 @@ describe('bridge', () => {
             const { path } = descriptors[0];
             const session1 = await bridge1.acquire({
                 input: { previous: null, path },
-            }).promise;
+            });
 
             expect(session1).toEqual({ success: true, payload: '1' });
             if (!session1.success) {
                 throw new Error("session1 wasn't acquired");
             }
 
-            const receive1res = bridge1.receive({ session: session1.payload }).promise;
+            const receive1res = bridge1.receive({ session: session1.payload });
 
             await wait();
 
             // bridge 2 steals session
             const session2 = await bridge2.acquire({
                 input: { previous: session1.payload, path },
-            }).promise;
+            });
 
             expect(receive1res).resolves.toMatchObject({
                 success: false,
@@ -204,10 +204,9 @@ describe('bridge', () => {
             expect(session2).toEqual({ success: true, payload: '2' });
 
             // send ping
-            await bridge2.send({ session: session2.payload, name: 'GetFeatures', data: {} })
-                .promise;
+            await bridge2.send({ session: session2.payload, name: 'GetFeatures', data: {} });
             // receive success
-            const receive2Res = await bridge2.receive({ session: session2.payload }).promise;
+            const receive2Res = await bridge2.receive({ session: session2.payload });
 
             expect(receive2Res).toMatchObject({
                 success: true,
@@ -219,8 +218,8 @@ describe('bridge', () => {
     }
 
     test('2 clients enumerate at the same time', async () => {
-        const promise1 = bridge1.enumerate().promise;
-        const promise2 = bridge2.enumerate().promise;
+        const promise1 = bridge1.enumerate();
+        const promise2 = bridge2.enumerate();
 
         const results = await Promise.all([promise1, promise2]);
 

--- a/packages/transport-test/e2e/bridge/multi-client.test.ts
+++ b/packages/transport-test/e2e/bridge/multi-client.test.ts
@@ -63,9 +63,8 @@ describe('bridge', () => {
         await TrezorUserEnvLink.startEmu(emulatorStartOpts);
         await TrezorUserEnvLink.startBridge();
 
-        const abortController = new AbortController();
-        bridge1 = new BridgeTransport({ messages, signal: abortController.signal });
-        bridge2 = new BridgeTransport({ messages, signal: abortController.signal });
+        bridge1 = new BridgeTransport({ messages });
+        bridge2 = new BridgeTransport({ messages });
 
         await bridge1.init();
         await bridge2.init();

--- a/packages/transport/src/api/abstract.ts
+++ b/packages/transport/src/api/abstract.ts
@@ -141,7 +141,7 @@ export abstract class AbstractApi extends TypedEmitter<{
         return error(payload);
     }
 
-    protected unknownError<E extends AnyError>(err: Error, expectedErrors: E[]) {
+    protected unknownError<E extends AnyError = never>(err: Error, expectedErrors: E[] = []) {
         this.logger?.error('transport: abstract api: unknown error', err);
 
         return unknownError(err, expectedErrors);
@@ -190,7 +190,7 @@ export abstract class AbstractApi extends TypedEmitter<{
             // this should never happen, incorrectly handled error on api level. fn should not throw.
             this.logger?.error('transport: abstract api: runInIsolation error', err);
 
-            return this.unknownError(err, []);
+            return this.unknownError(err);
         } finally {
             this.lock[path] = {
                 read: lock.read ? false : this.lock[path].read,

--- a/packages/transport/src/api/usb.ts
+++ b/packages/transport/src/api/usb.ts
@@ -185,7 +185,7 @@ export class UsbApi extends AbstractApi {
                 return this.success(this.devicesToDescriptors());
             } catch (err) {
                 // this shouldn't throw
-                return this.unknownError(err, []);
+                return this.unknownError(err);
             }
         });
     }

--- a/packages/transport/src/sessions/background-browser.ts
+++ b/packages/transport/src/sessions/background-browser.ts
@@ -65,8 +65,7 @@ export const initBackgroundInBrowser = () => {
             'Unable to load background-sharedworker. Falling back to use local module. Say bye bye to tabs synchronization',
         );
 
-        const abortController = new AbortController();
-        const background = new SessionsBackground({ signal: abortController.signal });
+        const background = new SessionsBackground();
         const registerBackgroundCallbacks: RegisterBackgroundCallbacks = onDescriptorsCallback => {
             background.on('descriptors', descriptors => {
                 onDescriptorsCallback(descriptors);

--- a/packages/transport/src/sessions/background-sharedworker.ts
+++ b/packages/transport/src/sessions/background-sharedworker.ts
@@ -5,8 +5,7 @@ import { HandleMessageParams } from './types';
 
 declare let self: SharedWorkerGlobalScope;
 
-const abortController = new AbortController();
-const background = new SessionsBackground({ signal: abortController.signal });
+const background = new SessionsBackground();
 
 const ports: MessagePort[] = [];
 

--- a/packages/transport/src/sessions/background.ts
+++ b/packages/transport/src/sessions/background.ts
@@ -48,13 +48,6 @@ export class SessionsBackground extends TypedEmitter<{
     private locksTimeoutQueue: ReturnType<typeof setTimeout>[] = [];
     private lastSessionId = 0;
 
-    constructor({ signal }: { signal: AbortSignal }) {
-        super();
-        signal.addEventListener('abort', () => {
-            this.locksQueue.forEach(lock => clearTimeout(lock.id));
-        });
-    }
-
     public async handleMessage<M extends HandleMessageParams>(
         message: M,
     ): Promise<HandleMessageResponse<M>> {

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -48,7 +48,6 @@ export type DeviceDescriptorDiff = DescriptorDiffItem[];
 
 export interface AbstractTransportParams {
     messages?: Record<string, any>;
-    signal: AbortSignal;
     logger?: Logger;
     debugLink?: boolean;
 }

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -26,8 +26,8 @@ export abstract class AbstractApiTransport extends AbstractTransport {
     private sessionsClient: ConstructorParams['sessionsClient'];
     protected api: AbstractApi;
 
-    constructor({ messages, api, sessionsClient, signal, logger }: ConstructorParams) {
-        super({ messages, signal, logger });
+    constructor({ messages, api, sessionsClient, logger }: ConstructorParams) {
+        super({ messages, logger });
         this.sessionsClient = sessionsClient;
         this.api = api;
     }

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -39,7 +39,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
 
             return handshakeRes.success
                 ? this.success(undefined)
-                : this.unknownError('handshake error', []);
+                : this.unknownError('handshake error');
         });
     }
 

--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -409,7 +409,7 @@ export class BridgeTransport extends AbstractTransport {
 
             switch (endpoint) {
                 case '/':
-                    return this.unknownError(response.error, []);
+                    return this.unknownError(response.error);
                 case '/acquire':
                     return this.unknownError(response.error, [
                         ERRORS.SESSION_WRONG_PREVIOUS,
@@ -427,7 +427,7 @@ export class BridgeTransport extends AbstractTransport {
                     ]);
                 case '/enumerate':
                 case '/listen':
-                    return this.unknownError(response.error, []);
+                    return this.unknownError(response.error);
                 case '/post':
                     return this.unknownError(response.error, [
                         ERRORS.SESSION_NOT_FOUND,

--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -92,27 +92,30 @@ export class BridgeTransport extends AbstractTransport {
         this.latestVersion = latestVersion;
     }
 
-    public init() {
-        return this.scheduleAction(async signal => {
-            const response = await this.post('/', {
-                signal,
-            });
+    public init({ signal }: AbstractTransportMethodParams<'init'> = {}) {
+        return this.scheduleAction(
+            async signal => {
+                const response = await this.post('/', {
+                    signal,
+                });
 
-            if (!response.success) {
-                return response;
-            }
+                if (!response.success) {
+                    return response;
+                }
 
-            this.version = response.payload.version;
+                this.version = response.payload.version;
 
-            if (this.latestVersion) {
-                this.isOutdated = versionUtils.isNewer(this.latestVersion, this.version);
-            }
-            this.useProtocolMessages = !!response.payload.protocolMessages;
+                if (this.latestVersion) {
+                    this.isOutdated = versionUtils.isNewer(this.latestVersion, this.version);
+                }
+                this.useProtocolMessages = !!response.payload.protocolMessages;
 
-            this.stopped = false;
+                this.stopped = false;
 
-            return this.success(undefined);
-        });
+                return this.success(undefined);
+            },
+            { signal },
+        );
     }
 
     // https://github.dev/trezor/trezord-go/blob/f559ee5079679aeb5f897c65318d3310f78223ca/core/core.go#L373
@@ -155,12 +158,12 @@ export class BridgeTransport extends AbstractTransport {
     }
 
     // https://github.dev/trezor/trezord-go/blob/f559ee5079679aeb5f897c65318d3310f78223ca/core/core.go#L235
-    public enumerate() {
-        return this.scheduleAction(signal => this.post('/enumerate', { signal }));
+    public enumerate({ signal }: AbstractTransportMethodParams<'enumerate'> = {}) {
+        return this.scheduleAction(signal => this.post('/enumerate', { signal }), { signal });
     }
 
     // https://github.dev/trezor/trezord-go/blob/f559ee5079679aeb5f897c65318d3310f78223ca/core/core.go#L420
-    public acquire({ input }: AbstractTransportMethodParams<'acquire'>) {
+    public acquire({ input, signal }: AbstractTransportMethodParams<'acquire'>) {
         return this.scheduleAction(
             async signal => {
                 const previous = input.previous == null ? 'null' : input.previous;
@@ -200,38 +203,41 @@ export class BridgeTransport extends AbstractTransport {
                     delete this.listenPromise[input.path];
                 });
             },
-            undefined,
+            { signal },
             [ERRORS.DEVICE_DISCONNECTED_DURING_ACTION, ERRORS.SESSION_WRONG_PREVIOUS],
         );
     }
 
     // https://github.dev/trezor/trezord-go/blob/f559ee5079679aeb5f897c65318d3310f78223ca/core/core.go#L354
-    public release({ path, session, onClose }: AbstractTransportMethodParams<'release'>) {
-        return this.scheduleAction(signal => {
-            if (this.listening && !onClose) {
-                this.releaseUnconfirmed[path] = session;
-                this.listenPromise[path] = createDeferred();
-            }
+    public release({ path, session, onClose, signal }: AbstractTransportMethodParams<'release'>) {
+        return this.scheduleAction(
+            signal => {
+                if (this.listening && !onClose) {
+                    this.releaseUnconfirmed[path] = session;
+                    this.listenPromise[path] = createDeferred();
+                }
 
-            const releasePromise = this.post('/release', {
-                params: session,
-                signal,
-            });
-
-            if (onClose) {
-                return Promise.resolve(this.success(undefined));
-            }
-
-            if (!this.listenPromise[path]) {
-                return releasePromise;
-            }
-
-            return this.listenPromise[path].promise
-                .then(() => this.success(undefined))
-                .finally(() => {
-                    delete this.listenPromise[path];
+                const releasePromise = this.post('/release', {
+                    params: session,
+                    signal,
                 });
-        });
+
+                if (onClose) {
+                    return Promise.resolve(this.success(undefined));
+                }
+
+                if (!this.listenPromise[path]) {
+                    return releasePromise;
+                }
+
+                return this.listenPromise[path].promise
+                    .then(() => this.success(undefined))
+                    .finally(() => {
+                        delete this.listenPromise[path];
+                    });
+            },
+            { signal },
+        );
     }
 
     public releaseDevice() {
@@ -257,6 +263,7 @@ export class BridgeTransport extends AbstractTransport {
         name,
         data,
         protocol: customProtocol,
+        signal,
     }: AbstractTransportMethodParams<'call'>) {
         return this.scheduleAction(
             async signal => {
@@ -282,7 +289,7 @@ export class BridgeTransport extends AbstractTransport {
                     protocol,
                 );
             },
-            { timeout: undefined },
+            { signal, timeout: undefined },
         );
     }
 
@@ -291,31 +298,36 @@ export class BridgeTransport extends AbstractTransport {
         name,
         data,
         protocol: customProtocol,
+        signal,
     }: AbstractTransportMethodParams<'send'>) {
-        return this.scheduleAction(async signal => {
-            const protocol = this.getProtocol(customProtocol);
-            const bytes = buildMessage({
-                messages: this.messages,
-                name,
-                data,
-                encode: protocol.encode,
-            });
-            const response = await this.post('/post', {
-                params: session,
-                body: this.getRequestBody(bytes, protocol),
-                signal,
-            });
-            if (!response.success) {
-                return response;
-            }
+        return this.scheduleAction(
+            async signal => {
+                const protocol = this.getProtocol(customProtocol);
+                const bytes = buildMessage({
+                    messages: this.messages,
+                    name,
+                    data,
+                    encode: protocol.encode,
+                });
+                const response = await this.post('/post', {
+                    params: session,
+                    body: this.getRequestBody(bytes, protocol),
+                    signal,
+                });
+                if (!response.success) {
+                    return response;
+                }
 
-            return this.success(undefined);
-        });
+                return this.success(undefined);
+            },
+            { signal },
+        );
     }
 
     public receive({
         session,
         protocol: customProtocol,
+        signal,
     }: AbstractTransportMethodParams<'receive'>) {
         return this.scheduleAction(
             async signal => {
@@ -336,7 +348,7 @@ export class BridgeTransport extends AbstractTransport {
                     protocol,
                 );
             },
-            { timeout: undefined },
+            { signal, timeout: undefined },
         );
     }
 

--- a/packages/transport/src/transports/nodeusb.browser.ts
+++ b/packages/transport/src/transports/nodeusb.browser.ts
@@ -1,7 +1,7 @@
 import { AbstractTransport, AbstractTransportParams } from './abstract';
 
 import { WRONG_ENVIRONMENT } from '../errors';
-import { empty, emptyAbortable, emptySync } from '../utils/resultEmpty';
+import { empty, emptySync } from '../utils/resultEmpty';
 
 // this class loads in browser environment only in case of accidental use of NodeUsbTransport
 
@@ -13,13 +13,13 @@ export class NodeUsbTransport extends AbstractTransport {
         console.error(WRONG_ENVIRONMENT);
     }
 
-    init = emptyAbortable;
-    acquire = emptyAbortable;
-    enumerate = emptyAbortable;
-    call = emptyAbortable;
-    receive = emptyAbortable;
-    send = emptyAbortable;
-    release = emptyAbortable;
+    init = empty;
+    acquire = empty;
+    enumerate = empty;
+    call = empty;
+    receive = empty;
+    send = empty;
+    release = empty;
     stop = empty;
     releaseDevice = empty;
     listen = emptySync;

--- a/packages/transport/src/transports/nodeusb.ts
+++ b/packages/transport/src/transports/nodeusb.ts
@@ -15,7 +15,7 @@ export class NodeUsbTransport extends AbstractApiTransport {
     private readonly sessionsBackground;
 
     constructor(params: AbstractTransportParams) {
-        const { messages, logger, signal, debugLink } = params;
+        const { messages, logger, debugLink } = params;
         const sessionsBackground = new SessionsBackground();
 
         // in nodeusb there is no synchronization yet. this is a followup and needs to be decided
@@ -39,7 +39,6 @@ export class NodeUsbTransport extends AbstractApiTransport {
                 debugLink,
             }),
             sessionsClient,
-            signal,
         });
         this.sessionsBackground = sessionsBackground;
     }

--- a/packages/transport/src/transports/nodeusb.ts
+++ b/packages/transport/src/transports/nodeusb.ts
@@ -12,9 +12,11 @@ import { UsbApi } from '../api/usb';
 export class NodeUsbTransport extends AbstractApiTransport {
     public name = 'NodeUsbTransport' as const;
 
+    private readonly sessionsBackground;
+
     constructor(params: AbstractTransportParams) {
         const { messages, logger, signal, debugLink } = params;
-        const sessionsBackground = new SessionsBackground({ signal });
+        const sessionsBackground = new SessionsBackground();
 
         // in nodeusb there is no synchronization yet. this is a followup and needs to be decided
         // so far, sessionsClient has direct access to sessionBackground
@@ -39,11 +41,17 @@ export class NodeUsbTransport extends AbstractApiTransport {
             sessionsClient,
             signal,
         });
+        this.sessionsBackground = sessionsBackground;
     }
 
     public listen() {
         this.api.listen();
 
         return super.listen();
+    }
+
+    public stop() {
+        super.stop();
+        this.sessionsBackground.dispose();
     }
 }

--- a/packages/transport/src/transports/udp.browser.ts
+++ b/packages/transport/src/transports/udp.browser.ts
@@ -3,11 +3,6 @@ import { AbstractTransport } from './abstract';
 import { error } from '../utils/result';
 import { WRONG_ENVIRONMENT } from '../errors';
 
-const emptyAbortable = () => ({
-    promise: Promise.resolve(error({ error: WRONG_ENVIRONMENT })),
-    abort: () => {},
-});
-
 const empty = () => Promise.resolve(error({ error: WRONG_ENVIRONMENT }));
 
 const emptySync = () => error({ error: WRONG_ENVIRONMENT });
@@ -15,13 +10,13 @@ const emptySync = () => error({ error: WRONG_ENVIRONMENT });
 export class UdpTransport extends AbstractTransport {
     public name = 'UdpTransport' as const;
 
-    init = emptyAbortable;
-    acquire = emptyAbortable;
-    enumerate = emptyAbortable;
-    call = emptyAbortable;
-    receive = emptyAbortable;
-    send = emptyAbortable;
-    release = emptyAbortable;
+    init = empty;
+    acquire = empty;
+    enumerate = empty;
+    call = empty;
+    receive = empty;
+    send = empty;
+    release = empty;
     stop = empty;
     releaseDevice = empty;
     listen = emptySync;

--- a/packages/transport/src/transports/udp.ts
+++ b/packages/transport/src/transports/udp.ts
@@ -9,10 +9,11 @@ import { SessionsBackground } from '../sessions/background';
 export class UdpTransport extends AbstractApiTransport {
     public name = 'UdpTransport' as const;
     private enumerateTimeout: ReturnType<typeof setTimeout> | undefined;
+    private readonly sessionsBackground;
 
     constructor(params: AbstractTransportParams) {
         const { messages, logger, signal, debugLink } = params;
-        const sessionsBackground = new SessionsBackground({ signal });
+        const sessionsBackground = new SessionsBackground();
 
         // in udp there is no synchronization yet. it depends where this transport runs (node or browser)
         const sessionsClient = new SessionsClient({
@@ -31,6 +32,7 @@ export class UdpTransport extends AbstractApiTransport {
             sessionsClient,
             signal,
         });
+        this.sessionsBackground = sessionsBackground;
     }
 
     public listen() {
@@ -44,6 +46,7 @@ export class UdpTransport extends AbstractApiTransport {
             clearTimeout(this.enumerateTimeout);
             this.enumerateTimeout = undefined;
         }
+        this.sessionsBackground.dispose();
 
         return super.stop();
     }

--- a/packages/transport/src/transports/udp.ts
+++ b/packages/transport/src/transports/udp.ts
@@ -12,7 +12,7 @@ export class UdpTransport extends AbstractApiTransport {
     private readonly sessionsBackground;
 
     constructor(params: AbstractTransportParams) {
-        const { messages, logger, signal, debugLink } = params;
+        const { messages, logger, debugLink } = params;
         const sessionsBackground = new SessionsBackground();
 
         // in udp there is no synchronization yet. it depends where this transport runs (node or browser)
@@ -30,7 +30,6 @@ export class UdpTransport extends AbstractApiTransport {
             api: new UdpApi({ logger, debugLink }),
             logger,
             sessionsClient,
-            signal,
         });
         this.sessionsBackground = sessionsBackground;
     }

--- a/packages/transport/src/transports/webusb.browser.ts
+++ b/packages/transport/src/transports/webusb.browser.ts
@@ -14,7 +14,7 @@ export class WebUsbTransport extends AbstractApiTransport {
     public name = 'WebUsbTransport' as const;
 
     constructor(params: AbstractTransportParams) {
-        const { messages, logger, signal } = params;
+        const { messages, logger } = params;
         const { requestFn, registerBackgroundCallbacks } = initBackgroundInBrowser();
 
         super({
@@ -30,7 +30,6 @@ export class WebUsbTransport extends AbstractApiTransport {
                 requestFn,
                 registerBackgroundCallbacks,
             }),
-            signal,
         });
     }
 

--- a/packages/transport/src/transports/webusb.ts
+++ b/packages/transport/src/transports/webusb.ts
@@ -1,7 +1,7 @@
 import { AbstractTransport, AbstractTransportParams } from './abstract';
 
 import { WRONG_ENVIRONMENT } from '../errors';
-import { empty, emptyAbortable, emptySync } from '../utils/resultEmpty';
+import { empty, emptySync } from '../utils/resultEmpty';
 
 // this class loads in node environment only in case of accidental use of WebusbTransport
 export class WebUsbTransport extends AbstractTransport {
@@ -12,13 +12,13 @@ export class WebUsbTransport extends AbstractTransport {
         console.error(WRONG_ENVIRONMENT);
     }
 
-    init = emptyAbortable;
-    acquire = emptyAbortable;
-    enumerate = emptyAbortable;
-    call = emptyAbortable;
-    receive = emptyAbortable;
-    send = emptyAbortable;
-    release = emptyAbortable;
+    init = empty;
+    acquire = empty;
+    enumerate = empty;
+    call = empty;
+    receive = empty;
+    send = empty;
+    release = empty;
     stop = empty;
     releaseDevice = empty;
     listen = emptySync;

--- a/packages/transport/src/types/apiCall.ts
+++ b/packages/transport/src/types/apiCall.ts
@@ -23,15 +23,7 @@ export type ErrorGeneric<ErrorType> = ErrorType extends AnyError
 export type ResultWithTypedError<T, E> = Success<T> | ErrorGeneric<E>;
 export type AsyncResultWithTypedError<T, E> = Promise<Success<T> | ErrorGeneric<E>>;
 
-/**
- * Public interface of all transport methods
- * promise resolves in actual result of the call
- * abort is a reference to local AbortController.abort method
- */
-export type AbortableCall<T, E> = {
-    promise: AsyncResultWithTypedError<T, E>;
-    abort: () => void;
-};
+export type AbortableParam = { signal?: AbortSignal };
 
 export type BridgeProtocolMessage = {
     data: string;

--- a/packages/transport/src/utils/result.ts
+++ b/packages/transport/src/utils/result.ts
@@ -12,7 +12,7 @@ export const error = <E>({ error, message }: { error: E; message?: string }) => 
     message,
 });
 
-export const unknownError = <E>(err: Error, expectedErrors: E[]) => {
+export const unknownError = <E = never>(err: Error, expectedErrors: E[] = []) => {
     const expectedErr = expectedErrors.find(eE => eE === err.message);
     if (expectedErr) {
         return error({ error: expectedErr });

--- a/packages/transport/src/utils/resultEmpty.ts
+++ b/packages/transport/src/utils/resultEmpty.ts
@@ -1,11 +1,6 @@
 import { WRONG_ENVIRONMENT } from '../errors';
 import { error } from './result';
 
-export const emptyAbortable = () => ({
-    promise: Promise.resolve(error({ error: WRONG_ENVIRONMENT })),
-    abort: () => {},
-});
-
 export const empty = () => Promise.resolve(error({ error: WRONG_ENVIRONMENT }));
 
 export const emptySync = () => error({ error: WRONG_ENVIRONMENT });

--- a/packages/transport/tests/abstractUsb.test.ts
+++ b/packages/transport/tests/abstractUsb.test.ts
@@ -47,13 +47,11 @@ class TestUsbTransport extends AbstractApiTransport {
         messages,
         api,
         sessionsClient,
-        signal,
     }: ConstructorParameters<typeof AbstractApiTransport>[0]) {
         super({
             messages,
             api,
             sessionsClient,
-            signal,
         });
     }
 }
@@ -88,7 +86,6 @@ const initTest = async () => {
         api: testUsbApi,
         sessionsClient,
         messages,
-        signal: abortController.signal,
     });
     await transport.init();
 
@@ -125,7 +122,6 @@ describe('Usb', () => {
             const transport = new TestUsbTransport({
                 api: testUsbApi,
                 sessionsClient,
-                signal: new AbortController().signal,
             });
 
             // there are no loaded messages
@@ -157,7 +153,6 @@ describe('Usb', () => {
             const transport = new TestUsbTransport({
                 api: testUsbApi,
                 sessionsClient,
-                signal: abortController.signal,
             });
 
             await transport.init();

--- a/packages/transport/tests/abstractUsb.test.ts
+++ b/packages/transport/tests/abstractUsb.test.ts
@@ -92,7 +92,7 @@ const initTest = async () => {
         messages,
         signal: abortController.signal,
     });
-    await transport.init().promise;
+    await transport.init();
 
     return {
         sessionsBackground,
@@ -134,7 +134,7 @@ describe('Usb', () => {
             // there are no loaded messages
             expect(transport.getMessage()).toEqual(false);
 
-            const res = await transport.init().promise;
+            const res = await transport.init();
             expect(res).toMatchObject({
                 success: false,
             });
@@ -165,8 +165,8 @@ describe('Usb', () => {
                 signal: abortController.signal,
             });
 
-            await transport.init().promise;
-            const res = await transport.enumerate().promise;
+            await transport.init();
+            const res = await transport.enumerate();
 
             expect(res).toEqual({
                 success: false,
@@ -207,7 +207,7 @@ describe('Usb', () => {
 
         it('enumerate', async () => {
             const { transport, abortController } = await initTest();
-            const res = await transport.enumerate().promise;
+            const res = await transport.enumerate();
             expect(res).toEqual({
                 success: true,
                 payload: [
@@ -236,12 +236,11 @@ describe('Usb', () => {
             const spy = jest.fn();
             transport.on('transport-update', spy);
 
-            await transport.enumerate().promise;
+            await transport.enumerate();
 
             jest.runAllTimers();
 
-            const result = await transport.acquire({ input: { path: '123', previous: null } })
-                .promise;
+            const result = await transport.acquire({ input: { path: '123', previous: null } });
             expect(result).toEqual({
                 success: true,
                 payload: '1',
@@ -257,7 +256,7 @@ describe('Usb', () => {
 
             sessionsBackground.removeAllListeners();
 
-            const enumerateResult = await transport.enumerate().promise;
+            const enumerateResult = await transport.enumerate();
 
             expect(enumerateResult.success).toEqual(true);
             // @ts-expect-error
@@ -272,7 +271,7 @@ describe('Usb', () => {
                 sessionsClient.emit('descriptors', [{ path: '321', session: '1', type: 1 }]);
             }, 1);
 
-            const res = await acquireCall.promise;
+            const res = await acquireCall;
 
             expect(res).toMatchObject({
                 success: false,
@@ -285,7 +284,7 @@ describe('Usb', () => {
             const { transport, sessionsClient, sessionsBackground, abortController } =
                 await initTest();
             sessionsBackground.removeAllListeners();
-            const enumerateResult = await transport.enumerate().promise;
+            const enumerateResult = await transport.enumerate();
             expect(enumerateResult.success).toEqual(true);
             // @ts-expect-error
             transport.handleDescriptorsChange(enumerateResult.payload);
@@ -300,7 +299,7 @@ describe('Usb', () => {
                 ]);
             }, 1);
 
-            const res = await acquireCall.promise;
+            const res = await acquireCall;
             expect(res).toMatchObject({ success: false, error: 'wrong previous session' });
             abortController.abort();
         });
@@ -312,16 +311,15 @@ describe('Usb', () => {
                 data: {},
                 session: '1',
                 protocol: v1Protocol,
-            }).promise;
+            });
             expect(res).toEqual({ success: false, error: 'device disconnected during action' });
             abortController.abort();
         });
 
         it('call - with valid and invalid message.', async () => {
             const { transport, abortController } = await initTest();
-            await transport.enumerate().promise;
-            const acquireRes = await transport.acquire({ input: { path: '123', previous: null } })
-                .promise;
+            await transport.enumerate();
+            const acquireRes = await transport.acquire({ input: { path: '123', previous: null } });
             expect(acquireRes.success).toEqual(true);
             if (!acquireRes.success) return;
 
@@ -335,7 +333,7 @@ describe('Usb', () => {
                 data: {},
                 session: acquireRes.payload,
                 protocol: v1Protocol,
-            }).promise;
+            });
             expect(res1).toEqual({
                 success: true,
                 payload: {
@@ -351,7 +349,7 @@ describe('Usb', () => {
                 data: {},
                 session: acquireRes.payload,
                 protocol: v1Protocol,
-            }).promise;
+            });
             expect(res2).toEqual({
                 success: false,
                 error: 'unexpected error',
@@ -363,9 +361,8 @@ describe('Usb', () => {
 
         it('send and receive.', async () => {
             const { transport, abortController } = await initTest();
-            await transport.enumerate().promise;
-            const acquireRes = await transport.acquire({ input: { path: '123', previous: null } })
-                .promise;
+            await transport.enumerate();
+            const acquireRes = await transport.acquire({ input: { path: '123', previous: null } });
             expect(acquireRes.success).toEqual(true);
             if (!acquireRes.success) return;
 
@@ -377,7 +374,7 @@ describe('Usb', () => {
                 data: {},
                 session: acquireRes.payload,
                 protocol: v1Protocol,
-            }).promise;
+            });
             expect(sendRes).toEqual({
                 success: true,
                 payload: undefined,
@@ -385,7 +382,7 @@ describe('Usb', () => {
             const receiveRes = await transport.receive({
                 session: acquireRes.payload,
                 protocol: v1Protocol,
-            }).promise;
+            });
             expect(receiveRes).toEqual({
                 success: true,
                 payload: {
@@ -400,9 +397,8 @@ describe('Usb', () => {
 
         it('send protocol-v1 with custom chunkSize', async () => {
             const { transport, testUsbApi, abortController } = await initTest();
-            await transport.enumerate().promise;
-            const acquireRes = await transport.acquire({ input: { path: '123', previous: null } })
-                .promise;
+            await transport.enumerate();
+            const acquireRes = await transport.acquire({ input: { path: '123', previous: null } });
             expect(acquireRes.success).toEqual(true);
             if (!acquireRes.success) return;
 
@@ -418,7 +414,7 @@ describe('Usb', () => {
                     },
                     session: acquireRes.payload,
                     protocol: v1Protocol,
-                }).promise;
+                });
 
             // count encoded/sent chunks
             await send(); // 64 default chunkSize for usb
@@ -439,9 +435,8 @@ describe('Usb', () => {
 
         it('release', async () => {
             const { transport, abortController } = await initTest();
-            await transport.enumerate().promise;
-            const acquireRes = await transport.acquire({ input: { path: '123', previous: null } })
-                .promise;
+            await transport.enumerate();
+            const acquireRes = await transport.acquire({ input: { path: '123', previous: null } });
             expect(acquireRes.success).toEqual(true);
             if (!acquireRes.success) return;
 
@@ -452,7 +447,7 @@ describe('Usb', () => {
                 session: acquireRes.payload,
                 path: '123',
                 onClose: false,
-            }).promise;
+            });
             expect(res).toEqual({
                 success: true,
                 payload: undefined,
@@ -462,25 +457,26 @@ describe('Usb', () => {
 
         it('call - with use abort', async () => {
             const { transport, abortController } = await initTest();
-            await transport.enumerate().promise;
-            const acquireRes = await transport.acquire({ input: { path: '123', previous: null } })
-                .promise;
+            await transport.enumerate();
+            const acquireRes = await transport.acquire({ input: { path: '123', previous: null } });
             if (!acquireRes.success) return;
 
-            const { promise, abort } = transport.call({
+            const abort = new AbortController();
+            const promise = transport.call({
                 name: 'GetAddress',
                 data: {},
                 session: acquireRes.payload,
                 protocol: v1Protocol,
+                signal: abort.signal,
             });
-            abort();
+            abort.abort();
 
             expect(promise).resolves.toMatchObject({
                 success: false,
                 error: 'Aborted by signal',
             });
 
-            const { promise: promise2 } = transport.call({
+            const promise2 = transport.call({
                 name: 'GetAddress',
                 data: {},
                 session: acquireRes.payload,

--- a/packages/transport/tests/sessions.test.ts
+++ b/packages/transport/tests/sessions.test.ts
@@ -5,8 +5,7 @@ describe('sessions', () => {
     let requestFn: SessionsClient['request'];
 
     beforeEach(() => {
-        const abortController = new AbortController();
-        const background = new SessionsBackground({ signal: abortController.signal });
+        const background = new SessionsBackground();
         requestFn = params => background.handleMessage(params);
     });
 


### PR DESCRIPTION
## Description

Another part of general Connect cleanup which ideally shouldn't affect functionality in any way.

## Commits

- https://github.com/trezor/trezor-suite/pull/13512/commits/9687bb80757b4ebce3a4264b2845b9584dc15af7 - recursive listen loops in basic transports remade into proper, better readable cycles
- https://github.com/trezor/trezor-suite/pull/13512/commits/5b9b01439324ca6d5166a915b7c754c9376e49a6 - don't set new transports when reinitting device list as it shouldn't be necessary anymore
- https://github.com/trezor/trezor-suite/pull/13512/commits/27725905c26ae43c05443102d319732de478cdb7 - empty array in `unknownError` util is now optional
- https://github.com/trezor/trezor-suite/pull/13512/commits/a95f146245ae26c0ad073f70840fb4bf1e915ed0 - **MAIN COMMIT**; transport methods now return simple promise instead of `{ promise, abort }` pair; aborting (which hasn't been used yet anyway) is achieved by passing abort signal as optional param, as god intended.
- https://github.com/trezor/trezor-suite/pull/13512/commits/d41f51fd423cf54d9d3f60943f19eff4d923a15e - unit/e2e tests adjusted to the previous commit
- https://github.com/trezor/trezor-suite/pull/13512/commits/cc041f2ca3f159691162eeecc3d7b638cfbeefb9 - `SessionBackground` doesn't require abort signal as param anymore, and is aborted by calling `.dispose()` instead
- https://github.com/trezor/trezor-suite/pull/13512/commits/ac17cee24f9344a26312779ae0e194e5e70a8906 - stop passing abort signals to transports as they're unused anyway