### PR TITLE
fix(suite): Prevent calling set-sidebar-width on every click

### DIFF
--- a/packages/components/src/components/ResizableBox/ResizableBox.tsx
+++ b/packages/components/src/components/ResizableBox/ResizableBox.tsx
@@ -277,12 +277,14 @@ export const ResizableBox = ({
         };
 
         document.onmouseup = () => {
-            setIsResizing(false);
-            if (onWidthResizeEnd) {
-                onWidthResizeEnd(newWidth);
-            }
-            if (onHeightResizeEnd) {
-                onHeightResizeEnd(newHeight);
+            if (isResizing) {
+                setIsResizing(false);
+                if (onWidthResizeEnd) {
+                    onWidthResizeEnd(newWidth);
+                }
+                if (onHeightResizeEnd) {
+                    onHeightResizeEnd(newHeight);
+                }
             }
         };
 


### PR DESCRIPTION
## Description

Fix the problem by limiting `setIsResizing`, `onWidthResizeEnd`, `onHeightResizeEnd` calls for `ResizableBox` component to be executed only when really needed - at the end of resizing the component (sidebar).

## Screenshots:
**Before**:
![set_before](https://github.com/user-attachments/assets/448bdbcd-7f8e-4f11-8bd9-87ac80d462c5)

**After:**
![set_after](https://github.com/user-attachments/assets/a73790a8-1661-4efb-a8fe-bfcc379e6d21)
