### PR TITLE
feat(suite): autostart

### DIFF
--- a/packages/suite-desktop-api/src/__tests__/api.test.ts
+++ b/packages/suite-desktop-api/src/__tests__/api.test.ts
@@ -79,6 +79,12 @@ describe('DesktopApi', () => {
             api.appHide(true);
         });
 
+        it('DesktopApi.appAutoStart', () => {
+            const spy = jest.spyOn(ipcRenderer, 'send');
+            api.appAutoStart(true);
+            expect(spy).toHaveBeenCalledWith('app/auto-start', true);
+        });
+
         it('DesktopApi.checkForUpdates', () => {
             const spy = jest.spyOn(ipcRenderer, 'send');
             api.checkForUpdates();

--- a/packages/suite-desktop-api/src/api.ts
+++ b/packages/suite-desktop-api/src/api.ts
@@ -23,6 +23,7 @@ export interface MainChannels {
     'app/restart': void;
     'app/focus': void;
     'app/hide': void;
+    'app/auto-start': boolean;
     'store/clear': void;
     'theme/change': SuiteThemeVariant;
     'tor/get-status': void;
@@ -101,6 +102,7 @@ export interface DesktopApi {
     appRestart: DesktopApiSend<'app/restart'>;
     appFocus: DesktopApiSend<'app/focus'>;
     appHide: DesktopApiSend<'app/hide'>;
+    appAutoStart: DesktopApiSend<'app/auto-start'>;
     // Auto-updater
     checkForUpdates: DesktopApiSend<'update/check'>;
     downloadUpdate: DesktopApiSend<'update/download'>;

--- a/packages/suite-desktop-api/src/factory.ts
+++ b/packages/suite-desktop-api/src/factory.ts
@@ -46,6 +46,7 @@ export const factory = <R extends StrictIpcRenderer<any, IpcRendererEvent>>(
         appRestart: () => ipcRenderer.send('app/restart'),
         appFocus: () => ipcRenderer.send('app/focus'),
         appHide: () => ipcRenderer.send('app/hide'),
+        appAutoStart: (enabled: boolean) => ipcRenderer.send('app/auto-start', enabled),
 
         // Auto-updater
         checkForUpdates: isManual => {

--- a/packages/suite-desktop-core/src/modules/auto-start.ts
+++ b/packages/suite-desktop-core/src/modules/auto-start.ts
@@ -1,0 +1,58 @@
+/**
+ * Auto start handler
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { app, ipcMain } from '../typed-electron';
+
+import type { Module } from './index';
+
+export const SERVICE_NAME = 'auto-start';
+
+// Linux autostart desktop file
+const LINUX_AUTOSTART_DIR = '.config/autostart/';
+const LINUX_AUTOSTART_FILE = 'Trezor-Suite.desktop';
+const LINUX_DESKTOP = `[Desktop Entry]
+Type=Application
+Version=1.0
+Name=Trezor Suite
+Comment=Trezor Suite startup script
+Exec="${process.env.APPIMAGE || process.execPath}" --bridge-daemon
+StartupNotify=false
+Terminal=false
+`;
+
+const linuxAutoStart = (enabled: boolean) => {
+    if (enabled) {
+        fs.mkdirSync(path.join(os.homedir(), LINUX_AUTOSTART_DIR), { recursive: true });
+        fs.writeFileSync(
+            path.join(os.homedir(), LINUX_AUTOSTART_DIR, LINUX_AUTOSTART_FILE),
+            LINUX_DESKTOP,
+        );
+        fs.chmodSync(path.join(os.homedir(), LINUX_AUTOSTART_DIR, LINUX_AUTOSTART_FILE), 0o755);
+    } else {
+        fs.unlinkSync(path.join(os.homedir(), LINUX_AUTOSTART_DIR, LINUX_AUTOSTART_FILE));
+    }
+};
+
+export const init: Module = () => {
+    const { logger } = global;
+
+    ipcMain.on('app/auto-start', (_, enabled: boolean) => {
+        logger.debug(SERVICE_NAME, 'Auto start ' + (enabled ? 'enabled' : 'disabled'));
+
+        if (process.platform === 'linux') {
+            // For Linux, we use a custom implementation
+            linuxAutoStart(enabled);
+        } else {
+            // For Windows and macOS, we use native Electron API
+            app.setLoginItemSettings({
+                openAtLogin: enabled,
+                openAsHidden: true,
+                args: ['--bridge-daemon'],
+            });
+        }
+    });
+};

--- a/packages/suite-desktop-core/src/modules/index.ts
+++ b/packages/suite-desktop-core/src/modules/index.ts
@@ -33,6 +33,7 @@ import * as requestInterceptor from './request-interceptor';
 import * as coinjoin from './coinjoin';
 import * as csp from './csp';
 import * as fileProtocol from './file-protocol';
+import * as autoStart from './auto-start';
 
 // General modules (both dev & prod)
 const MODULES = [
@@ -61,6 +62,7 @@ const MODULES = [
     devTools,
     requestInterceptor,
     coinjoin,
+    autoStart,
     // Modules used only in dev/prod mode
     ...(isDevEnv ? [] : [csp, fileProtocol]),
 ];

--- a/packages/suite/src/actions/suite/constants/suiteConstants.ts
+++ b/packages/suite/src/actions/suite/constants/suiteConstants.ts
@@ -32,3 +32,4 @@ export const LOCK_TYPE = {
 export const REQUEST_DEVICE_RECONNECT = '@suite/request-device-reconnect';
 export const SET_EXPERIMENTAL_FEATURES = '@suite/set-experimental-features';
 export const SET_SIDEBAR_WIDTH = '@suite/set-sidebar-width';
+export const SET_AUTO_START = '@suite/set-auto-start';

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -76,7 +76,8 @@ export type SuiteAction =
       }
     | { type: typeof deviceActions.requestDeviceReconnect.type }
     | { type: typeof SUITE.SET_EXPERIMENTAL_FEATURES; payload?: ExperimentalFeature[] }
-    | { type: typeof SUITE.SET_SIDEBAR_WIDTH; payload: { width: number } };
+    | { type: typeof SUITE.SET_SIDEBAR_WIDTH; payload: { width: number } }
+    | { type: typeof SUITE.SET_AUTO_START; enabled?: boolean };
 
 export const appChanged = createAction(
     SUITE.APP_CHANGED,
@@ -335,3 +336,14 @@ export const lockRouter = (payload: boolean): SuiteAction => ({
     type: SUITE.LOCK_ROUTER,
     payload,
 });
+
+/**
+ * Set auto start for Suite
+ * @param enabled {boolean} - true if Suite should start automatically
+ * @returns {SuiteAction}
+ */
+export const setAutoStart = (enabled: boolean) => (dispatch: Dispatch) => {
+    desktopApi.appAutoStart(enabled);
+
+    dispatch({ type: SUITE.SET_AUTO_START, enabled });
+};

--- a/packages/suite/src/constants/suite/anchors.ts
+++ b/packages/suite/src/constants/suite/anchors.ts
@@ -14,6 +14,7 @@ export const enum SettingsAnchor {
     ClearStorage = '@general-settings/clear-storage',
     VersionWithUpdate = '@general-settings/version-with-update',
     EarlyAccess = '@general-settings/early-access',
+    AutoStart = '@general-settings/auto-start',
 
     BackupFailed = '@device-settings/backup-failed',
     BackupRecoverySeed = '@device-settings/backup-recovery-seed',

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -231,6 +231,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 case SUITE.SET_DEFAULT_WALLET_LOADING:
                 case SUITE.SET_AUTODETECT:
                 case SUITE.SET_SIDEBAR_WIDTH:
+                case SUITE.SET_AUTO_START:
                 case SUITE.DEVICE_AUTHENTICITY_OPT_OUT:
                 case SUITE.EVM_CONFIRM_EXPLANATION_MODAL:
                 case SUITE.EVM_CLOSE_EXPLANATION_BANNER:

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -91,6 +91,7 @@ export interface SuiteSettings {
     defaultWalletLoading: WalletType;
     experimental?: ExperimentalFeature[];
     sidebarWidth: number;
+    autoStart?: boolean;
 }
 
 export interface SuiteState {
@@ -266,6 +267,10 @@ const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteSt
 
             case SUITE.SET_SIDEBAR_WIDTH:
                 draft.settings.sidebarWidth = action.payload.width;
+                break;
+
+            case SUITE.SET_AUTO_START:
+                draft.settings.autoStart = action.enabled;
                 break;
 
             case TRANSPORT.START:

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -9161,4 +9161,12 @@ export default defineMessages({
         id: 'TR_OPEN_TREZOR_SUITE_DESKTOP',
         defaultMessage: 'Open Trezor Suite desktop app',
     },
+    TR_AUTO_START: {
+        id: 'TR_AUTO_START',
+        defaultMessage: 'Run Trezor Suite automatically',
+    },
+    TR_AUTO_START_DESCRIPTION: {
+        id: 'TR_AUTO_START_DESCRIPTION',
+        defaultMessage: 'Start Trezor Suite in the background when you log in to your computer.',
+    },
 });

--- a/packages/suite/src/views/settings/SettingsDebug/AutoStart.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/AutoStart.tsx
@@ -1,0 +1,40 @@
+import styled from 'styled-components';
+
+import { Switch } from '@trezor/components';
+
+import { SettingsSectionItem } from 'src/components/settings';
+import { ActionColumn, TextColumn, Translation } from 'src/components/suite';
+import { SettingsAnchor } from 'src/constants/suite/anchors';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { setAutoStart } from 'src/actions/suite/suiteActions';
+
+const PositionedSwitch = styled.div`
+    align-self: center;
+`;
+
+export const AutoStart = () => {
+    const autoStartEnabled = useSelector(state => state.suite.settings.autoStart);
+    const dispatch = useDispatch();
+
+    const handleChange = () => {
+        dispatch(setAutoStart(!autoStartEnabled));
+    };
+
+    return (
+        <SettingsSectionItem anchorId={SettingsAnchor.AutoStart}>
+            <TextColumn
+                title={<Translation id="TR_AUTO_START" />}
+                description={<Translation id="TR_AUTO_START_DESCRIPTION" />}
+            />
+            <ActionColumn>
+                <PositionedSwitch>
+                    <Switch
+                        dataTest="@autostart/toggle-switch"
+                        isChecked={!!autoStartEnabled}
+                        onChange={handleChange}
+                    />
+                </PositionedSwitch>
+            </ActionColumn>
+        </SettingsSectionItem>
+    );
+};

--- a/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
@@ -20,6 +20,7 @@ import { Backends } from './Backends';
 import { selectSuiteFlags } from 'src/reducers/suite/suiteReducer';
 import { useSelector } from 'src/hooks/suite';
 import { PreField } from './PreField';
+import { AutoStart } from './AutoStart';
 
 export const SettingsDebug = () => {
     const flags = useSelector(selectSuiteFlags);
@@ -53,6 +54,11 @@ export const SettingsDebug = () => {
             <SettingsSection title="Testing">
                 <ThrowTestingError />
             </SettingsSection>
+            {!isWeb() && (
+                <SettingsSection title="Application">
+                    <AutoStart />
+                </SettingsSection>
+            )}
             {!isWeb() && (
                 <SettingsSection title="Transport backends">
                     <TransportBackends />


### PR DESCRIPTION
## Description

Add an option to settings to start Trezor Suite automatically as a background daemon to provide bridge.
Tested on Mac, Windows, Linux

## Considerations

- Tray icon
- How this affects update process

## Related Issue

Resolve #13476