### PR TITLE
fix(suite): Prevent Add label changing transaction design on hover

### DIFF
--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
@@ -58,9 +58,6 @@ const ActionButton = styled(Button)<{ $isValueVisible?: boolean; $isVisible?: bo
     margin-left: ${({ $isValueVisible, $isVisible, isLoading }) =>
         $isValueVisible || !$isVisible || isLoading ? '12px' : '4px'};
     visibility: ${({ $isVisible }) => ($isVisible ? 'visible' : 'hidden')};
-
-    /* hack to keep button in place to prevent vertical jumping (if used display: none) */
-    width: ${({ $isVisible }) => ($isVisible ? 'auto' : '0')};
 `;
 
 // @TODO this shouldn't be Button


### PR DESCRIPTION
## Description

Remove old hacky css to prevent "Add label" changing transaction design on hover. When tried to add "display: none" to make sure if it isn't really needed, it had no any effect on the fix.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/13406

## Videos:
**Before:**

https://github.com/user-attachments/assets/6e63d8e2-47f3-40c5-ad86-ddd54037c5b0

**After:**

https://github.com/user-attachments/assets/d614e59e-6f2f-4048-832e-c509cce79779



