### PR TITLE
chore(connect-explorer): add link to new webextension example

### DIFF
--- a/packages/connect-explorer/src/pages/index.mdx
+++ b/packages/connect-explorer/src/pages/index.mdx
@@ -367,6 +367,7 @@ export const ExampleHeading = styled.h3`
         <ExamplesAside>
             <ExampleHeading>Examples:</ExampleHeading>
             - [Simple example](https://github.com/trezor/trezor-suite/tree/develop/packages/connect-examples/webextension-mv3-sw)
+            - [Example with Webpack, TS](https://github.com/trezor/trezor-suite/tree/develop/packages/connect-examples/webextension-mv3-sw-ts)
             - [Connect Explorer example](https://github.com/trezor/trezor-suite/tree/develop/packages/connect-explorer/src-webextension)
         </ExamplesAside>
     </SdkContainer>


### PR DESCRIPTION
## Description

Link to the new better `webextension-mv3-sw-ts` example from #12987 on Explorer's home page.