### PR TITLE
fix(connect-webextension): Trezor popup displaying UNDER browser extension popup on Linux (Firefox)

### DIFF
--- a/packages/connect-web/src/popup/index.ts
+++ b/packages/connect-web/src/popup/index.ts
@@ -224,7 +224,7 @@ export class PopupManager extends EventEmitter {
                 // Request coming from extension popup,
                 // create new window above instead of opening new tab
                 if (currentWindow.type !== 'normal') {
-                    chrome.windows.create({ url }, newWindow => {
+                    chrome.windows.create({ url, type: 'popup' }, newWindow => {
                         chrome.tabs.query(
                             {
                                 windowId: newWindow?.id,


### PR DESCRIPTION
## Description

When a browser extension opens its own popup (via `chrome.windows.create` as a `type: popup`) on Linux (Firefox), this window stays always on top. If the Trezor popup then gets requested within this extension popup, the Trezor popup was appearing behind the extension popup, because the Trezor's one had the default type ("normal").

This made the Trezor popup hardly accessible (visible) for the user, if one doesn't think to move away the extension popup.

With this change, when a Trezor popup gets opened from a browser extension popup, it will appear on top of the extension popup.

## Related Issue

https://github.com/trezor/trezor-suite/issues/13526