### PR TITLE
Add bootloader condition to config schema

### DIFF
--- a/suite-common/message-system/schema/config.schema.v1.json
+++ b/suite-common/message-system/schema/config.schema.v1.json
@@ -201,6 +201,11 @@
                                                 "description": "Eligible authorized vendors.",
                                                 "type": "string",
                                                 "enum": ["*", "trezor.io"]
+                                            },
+                                            "bootloaderCondition": {
+                                            "title": "Bootloader Condition",
+                                            "type": "string",
+                                            "description": "Condition to match the device bootloader version"
                                             }
                                         },
                                         "additionalProperties": false


### PR DESCRIPTION
Following up on discussion [here](https://satoshilabs.slack.com/archives/CL1D61PQF/p1720709597199789?thread_ts=1720704515.187309&cid=CL1D61PQF), I'm adding the bootloader condition to the message system schema so we can target devices with specific bootloader conditions. 