### PR TITLE
feat(coinmarket): sell form

### DIFF
--- a/packages/suite-web/src/support/Router.tsx
+++ b/packages/suite-web/src/support/Router.tsx
@@ -58,16 +58,21 @@ const components: Record<PageName, LazyExoticComponent<ComponentType<any>>> = {
     'wallet-coinmarket-buy-offers': lazy(
         () => import(/* webpackChunkName: "coinmarket" */ 'src/views/wallet/coinmarket/buy/offers'),
     ),
-    'wallet-coinmarket-sell': lazy(
-        () => import(/* webpackChunkName: "coinmarket" */ 'src/views/wallet/coinmarket/sell'),
+    'wallet-coinmarket-sell': lazy(() =>
+        import(
+            /* webpackChunkName: "coinmarket" */ 'src/views/wallet/coinmarket/sell_new/CoinmarketSellForm'
+        ).then(({ CoinmarketSellForm }) => ({ default: CoinmarketSellForm })),
     ),
     'wallet-coinmarket-sell-detail': lazy(
         () =>
-            import(/* webpackChunkName: "coinmarket" */ 'src/views/wallet/coinmarket/sell/detail'),
+            import(
+                /* webpackChunkName: "coinmarket" */ 'src/views/wallet/coinmarket/sell_new/detail'
+            ),
     ),
-    'wallet-coinmarket-sell-offers': lazy(
-        () =>
-            import(/* webpackChunkName: "coinmarket" */ 'src/views/wallet/coinmarket/sell/offers'),
+    'wallet-coinmarket-sell-offers': lazy(() =>
+        import(
+            /* webpackChunkName: "coinmarket" */ 'src/views/wallet/coinmarket/sell_new/CoinmarketSellOffers'
+        ).then(({ CoinmarketSellOffers }) => ({ default: CoinmarketSellOffers })),
     ),
     'wallet-coinmarket-exchange': lazy(
         () => import(/* webpackChunkName: "coinmarket" */ 'src/views/wallet/coinmarket/exchange'),

--- a/packages/suite/src/actions/wallet/coinmarketSellActions.ts
+++ b/packages/suite/src/actions/wallet/coinmarketSellActions.ts
@@ -23,6 +23,7 @@ export type CoinmarketSellAction =
     | { type: typeof COINMARKET_SELL.SAVE_QUOTE_REQUEST; request: SellFiatTradeQuoteRequest }
     | { type: typeof COINMARKET_SELL.SAVE_TRANSACTION_ID; transactionId?: string }
     | { type: typeof COINMARKET_SELL.SET_IS_FROM_REDIRECT; isFromRedirect: boolean }
+    | { type: typeof COINMARKET_SELL.SET_COINMARKET_ACCOUNT; account: Account }
     | {
           type: typeof COINMARKET_SELL.SAVE_QUOTES;
           quotes: SellFiatTrade[];
@@ -114,6 +115,11 @@ export const clearQuotes = (): CoinmarketSellAction => ({
 export const setIsFromRedirect = (isFromRedirect: boolean): CoinmarketSellAction => ({
     type: COINMARKET_SELL.SET_IS_FROM_REDIRECT,
     isFromRedirect,
+});
+
+export const setCoinmarketSellAccount = (account: Account): CoinmarketSellAction => ({
+    type: COINMARKET_SELL.SET_COINMARKET_ACCOUNT,
+    account,
 });
 
 // this is only a wrapper for `openDeferredModal` since it doesn't work with `bindActionCreators`

--- a/packages/suite/src/actions/wallet/constants/coinmarketSellConstants.ts
+++ b/packages/suite/src/actions/wallet/constants/coinmarketSellConstants.ts
@@ -4,3 +4,4 @@ export const SAVE_QUOTES = '@coinmarket-sell/save_quotes';
 export const CLEAR_QUOTES = '@coinmarket-sell/clear_quotes';
 export const SAVE_TRANSACTION_ID = '@coinmarket-sell/save_transaction_id';
 export const SET_IS_FROM_REDIRECT = '@coinmarket-sell/set_is_from_redirect';
+export const SET_COINMARKET_ACCOUNT = '@coinmarket-sell/set_coinmarket_account';

--- a/packages/suite/src/constants/wallet/coinmarket/form.ts
+++ b/packages/suite/src/constants/wallet/coinmarket/form.ts
@@ -1,0 +1,10 @@
+export const FORM_OUTPUT_AMOUNT = 'outputs.0.amount';
+export const FORM_CRYPTO_TOKEN = 'outputs.0.token';
+export const FORM_OUTPUT_ADDRESS = 'outputs.0.address';
+
+export const FORM_FIAT_INPUT = 'fiatInput';
+export const FORM_FIAT_CURRENCY_SELECT = 'currencySelect';
+export const FORM_CRYPTO_INPUT = 'cryptoInput';
+export const FORM_CRYPTO_CURRENCY_SELECT = 'cryptoSelect';
+export const FORM_COUNTRY_SELECT = 'countrySelect';
+export const FORM_PAYMENT_METHOD_SELECT = 'paymentMethod';

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketBuyForm.tsx
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketBuyForm.tsx
@@ -5,7 +5,6 @@ import type { BuyTrade, BuyTradeQuoteRequest } from 'invity-api';
 import { isChanged } from '@suite-common/suite-utils';
 import { amountToSatoshi, formatAmount } from '@suite-common/wallet-utils';
 import { useDidUpdate } from '@trezor/react-utils';
-import { saveCachedAccountInfo, saveQuoteRequest } from 'src/actions/wallet/coinmarketBuyActions';
 import { useActions, useDispatch, useSelector } from 'src/hooks/suite';
 import { loadInvityData } from 'src/actions/wallet/coinmarket/coinmarketCommonActions';
 import invityAPI from 'src/services/suite/invityAPI';
@@ -41,6 +40,7 @@ import { SET_MODAL_CRYPTO_CURRENCY } from 'src/actions/wallet/constants/coinmark
 import useCoinmarketPaymentMethod from 'src/hooks/wallet/coinmarket/form/useCoinmarketPaymentMethod';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 import { useCoinmarketNavigation } from 'src/hooks/wallet/useCoinmarketNavigation';
+import { FORM_PAYMENT_METHOD_SELECT } from 'src/constants/wallet/coinmarket/form';
 
 const useCoinmarketBuyForm = ({
     selectedAccount,
@@ -74,6 +74,8 @@ const useCoinmarketBuyForm = ({
         submitRequestForm,
         goto,
         savePaymentMethods,
+        saveQuoteRequest,
+        saveCachedAccountInfo,
     } = useActions({
         saveTrade: coinmarketBuyActions.saveTrade,
         saveQuotes: coinmarketBuyActions.saveQuotes,
@@ -85,6 +87,8 @@ const useCoinmarketBuyForm = ({
         verifyAddress: coinmarketBuyActions.verifyAddress,
         goto: routerActions.goto,
         savePaymentMethods: coinmarketInfoActions.savePaymentMethods,
+        saveQuoteRequest: coinmarketBuyActions.saveQuoteRequest,
+        saveCachedAccountInfo: coinmarketBuyActions.saveCachedAccountInfo,
     });
     const { navigateToBuyForm, navigateToBuyOffers } = useCoinmarketNavigation(account);
 
@@ -178,15 +182,21 @@ const useCoinmarketBuyForm = ({
     );
 
     const getQuoteRequestData = useCallback((): BuyTradeQuoteRequest => {
-        const { fiatInput, cryptoInput, currencySelect, cryptoSelect, countrySelect, wantCrypto } =
-            methods.getValues();
+        const {
+            fiatInput,
+            cryptoInput,
+            currencySelect,
+            cryptoSelect,
+            countrySelect,
+            amountInCrypto,
+        } = methods.getValues();
         const cryptoStringAmount =
             cryptoInput && shouldSendInSats
                 ? formatAmount(cryptoInput, network.decimals)
                 : cryptoInput;
 
         const request = {
-            wantCrypto,
+            wantCrypto: amountInCrypto,
             fiatCurrency: currencySelect
                 ? currencySelect?.value.toUpperCase()
                 : quotesRequest?.fiatCurrency ?? '',
@@ -224,6 +234,8 @@ const useCoinmarketBuyForm = ({
 
                 const bestQuote = quotesSuccess?.[0];
                 const bestQuotePaymentMethod = bestQuote?.paymentMethod;
+                const bestQuotePaymentMethodName =
+                    bestQuote?.paymentMethodName ?? bestQuotePaymentMethod;
                 const paymentMethodSelected = values.paymentMethod?.value;
                 const paymentMethodsFromQuotes = getPaymentMethods(quotesSuccess);
                 const isSelectedPaymentMethodAvailable =
@@ -238,9 +250,9 @@ const useCoinmarketBuyForm = ({
                 setAmountLimits(limits);
 
                 if (!paymentMethodSelected || !isSelectedPaymentMethodAvailable) {
-                    setValue('paymentMethod', {
+                    setValue(FORM_PAYMENT_METHOD_SELECT, {
                         value: bestQuotePaymentMethod ?? '',
-                        label: bestQuotePaymentMethod ?? '',
+                        label: bestQuotePaymentMethodName ?? '',
                     });
                 }
             } else {
@@ -258,6 +270,7 @@ const useCoinmarketBuyForm = ({
             getPaymentMethods,
             dispatch,
             saveQuotes,
+            saveQuoteRequest,
             savePaymentMethods,
             setValue,
         ],
@@ -343,17 +356,17 @@ const useCoinmarketBuyForm = ({
         setCallInProgress(false);
     };
 
-    const toggleWantCrypto = () => {
-        const { wantCrypto } = getValues();
+    const toggleAmountInCrypto = () => {
+        const { amountInCrypto } = getValues();
         const bestScoredQuote = quotesByPaymentMethod?.[0];
 
-        if (!wantCrypto) {
+        if (!amountInCrypto) {
             setValue('cryptoInput', bestScoredQuote?.receiveStringAmount ?? '');
         } else {
             setValue('fiatInput', bestScoredQuote?.fiatStringAmount ?? '');
         }
 
-        setValue('wantCrypto', !wantCrypto);
+        setValue('amountInCrypto', !amountInCrypto);
         setIsSubmittingHelper(true); // remove delay of sending request
     };
 
@@ -481,7 +494,7 @@ const useCoinmarketBuyForm = ({
                 isFormInvalid,
                 isLoadingOrInvalid,
 
-                toggleWantCrypto,
+                toggleAmountInCrypto,
             },
         },
         ...methods,
@@ -496,7 +509,6 @@ const useCoinmarketBuyForm = ({
         network,
         cryptoInputValue: values.cryptoInput,
         formState,
-        isDraft,
         device,
         callInProgress,
         addressVerified,

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketBuyFormDefaultValues.tsx
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketBuyFormDefaultValues.tsx
@@ -47,7 +47,7 @@ export const useCoinmarketBuyFormDefaultValues = (
             cryptoSelect: defaultCrypto,
             countrySelect: defaultCountry,
             paymentMethod: defaultPaymentMethod,
-            wantCrypto: false,
+            amountInCrypto: false,
         }),
         [
             buyInfo?.buyInfo.defaultAmountsOfFiatCurrencies,

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSellForm.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSellForm.ts
@@ -1,0 +1,807 @@
+import { useCallback, useState, useEffect, useRef } from 'react';
+import { useForm, useWatch } from 'react-hook-form';
+import type { BankAccount, SellFiatTrade, SellFiatTradeQuoteRequest } from 'invity-api';
+import useDebounce from 'react-use/lib/useDebounce';
+import {
+    getFeeLevels,
+    amountToSatoshi,
+    formatAmount,
+    getNetwork,
+} from '@suite-common/wallet-utils';
+import { useDidUpdate } from '@trezor/react-utils';
+import { isChanged } from '@suite-common/suite-utils';
+import { useActions, useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
+import invityAPI from 'src/services/suite/invityAPI';
+import {
+    getComposeAddressPlaceholder,
+    addIdsToQuotes,
+    filterQuotesAccordingTags,
+    getUnusedAddressFromAccount,
+    coinmarketGetRoundedFiatAmount,
+} from 'src/utils/wallet/coinmarket/coinmarketUtils';
+import { createQuoteLink, getAmountLimits } from 'src/utils/wallet/coinmarket/sellUtils';
+import { useFormDraft } from 'src/hooks/wallet/useFormDraft';
+import { useCoinmarketNavigation } from 'src/hooks/wallet/useCoinmarketNavigation';
+import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
+import { AmountLimits, TradeSell } from 'src/types/wallet/coinmarketCommonTypes';
+import { AddressDisplayOptions } from '@suite-common/wallet-types';
+import { selectAddressDisplayType } from 'src/reducers/suite/suiteReducer';
+import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
+import { CoinmarketTradeSellType, UseCoinmarketFormProps } from 'src/types/coinmarket/coinmarket';
+import { useFees } from 'src/hooks/wallet/form/useFees';
+import { useCompose } from 'src/hooks/wallet/form/useCompose';
+import {
+    CoinmarketSellFormContextProps,
+    CoinmarketSellFormProps,
+    CoinmarketUseSellFormStateReturnProps,
+} from 'src/types/coinmarket/coinmarketForm';
+import { useCoinmarketSellFormDefaultValues } from 'src/hooks/wallet/coinmarket/form/useCoinmarketSellFormDefaultValues';
+import useCoinmarketPaymentMethod from 'src/hooks/wallet/coinmarket/form/useCoinmarketPaymentMethod';
+import {
+    FORM_CRYPTO_INPUT,
+    FORM_FIAT_INPUT,
+    FORM_OUTPUT_ADDRESS,
+    FORM_PAYMENT_METHOD_SELECT,
+} from 'src/constants/wallet/coinmarket/form';
+import {
+    getFilteredSuccessQuotes,
+    useCoinmarketCommonOffers,
+} from 'src/hooks/wallet/coinmarket/offers/useCoinmarketCommonOffers';
+import { useCoinmarketRecomposeAndSign } from 'src/hooks/wallet/useCoinmarketRecomposeAndSign';
+import { notificationsActions } from '@suite-common/toast-notifications';
+import * as coinmarketSellActions from 'src/actions/wallet/coinmarketSellActions';
+import * as routerActions from 'src/actions/suite/routerActions';
+import * as coinmarketCommonActions from 'src/actions/wallet/coinmarket/coinmarketCommonActions';
+import * as coinmarketInfoActions from 'src/actions/wallet/coinmarketInfoActions';
+import { CoinmarketSellStepType } from 'src/types/coinmarket/coinmarketOffers';
+import { useCoinmarketSellFormState } from 'src/hooks/wallet/coinmarket/form/useCoinmarketSellFormState';
+import { useCoinmarketSellFormHelpers } from 'src/hooks/wallet/coinmarket/form/useCoinmarketSellFormHelpers';
+import { selectAccounts } from '@suite-common/wallet-core';
+import { Network } from '@suite-common/wallet-config';
+
+export const useCoinmarketSellForm = ({
+    selectedAccount,
+    offFirstRequest,
+}: UseCoinmarketFormProps): CoinmarketSellFormContextProps => {
+    const type = 'sell';
+    const dispatch = useDispatch();
+    const { sellInfo, quotesRequest, isFromRedirect, quotes, transactionId, coinmarketAccount } =
+        useSelector(state => state.wallet.coinmarket.sell);
+    const account = coinmarketAccount ?? selectedAccount.account;
+    const { translationString } = useTranslation();
+    const {
+        callInProgress,
+        selectedQuote,
+        timer,
+        device,
+        setCallInProgress,
+        setSelectedQuote,
+        checkQuotesTimer,
+    } = useCoinmarketCommonOffers<CoinmarketTradeSellType>({ selectedAccount, type });
+    const { paymentMethods, getPaymentMethods, getQuotesByPaymentMethod } =
+        useCoinmarketPaymentMethod<CoinmarketTradeSellType>();
+    const {
+        selectedFee: selectedFeeRecomposedAndSigned,
+        composed,
+        recomposeAndSign,
+    } = useCoinmarketRecomposeAndSign();
+    const {
+        goto,
+        saveTrade,
+        saveQuotes,
+        setIsFromRedirect,
+        saveQuoteRequest,
+        saveTransactionId,
+        openCoinmarketSellConfirmModal,
+        submitRequestForm,
+        saveComposedTransactionInfo,
+        loadInvityData,
+        savePaymentMethods,
+    } = useActions({
+        goto: routerActions.goto,
+        saveTrade: coinmarketSellActions.saveTrade,
+        saveQuotes: coinmarketSellActions.saveQuotes,
+        setIsFromRedirect: coinmarketSellActions.setIsFromRedirect,
+        saveQuoteRequest: coinmarketSellActions.saveQuoteRequest,
+        saveTransactionId: coinmarketSellActions.saveTransactionId,
+        openCoinmarketSellConfirmModal: coinmarketSellActions.openCoinmarketSellConfirmModal,
+        submitRequestForm: coinmarketCommonActions.submitRequestForm,
+        saveComposedTransactionInfo: coinmarketCommonActions.saveComposedTransactionInfo,
+        loadInvityData: coinmarketCommonActions.loadInvityData,
+        savePaymentMethods: coinmarketInfoActions.savePaymentMethods,
+    });
+    const accounts = useSelector(selectAccounts);
+    const { navigateToSellForm, navigateToSellOffers } = useCoinmarketNavigation(account);
+
+    const { symbol, networkType } = account;
+    const localCurrency = useSelector(selectLocalCurrency);
+    const fees = useSelector(state => state.wallet.fees);
+    const coinFees = fees[symbol];
+    const levels = getFeeLevels(networkType, coinFees);
+    const feeInfo = { ...coinFees, levels };
+    const addressDisplayType = useSelector(selectAddressDisplayType);
+    const network = getNetwork(account.symbol) as Network;
+    const { shouldSendInSats } = useBitcoinAmountUnit(symbol);
+    const localCurrencyOption = { value: localCurrency, label: localCurrency.toUpperCase() };
+    const chunkify = addressDisplayType === AddressDisplayOptions.CHUNKED;
+    const trades = useSelector(state => state.wallet.coinmarket.trades);
+    const trade = trades.find(
+        trade => trade.tradeType === 'sell' && trade.key === transactionId,
+    ) as TradeSell;
+
+    const [state, setState] = useState<CoinmarketUseSellFormStateReturnProps | undefined>(
+        undefined,
+    );
+    const [amountLimits, setAmountLimits] = useState<AmountLimits | undefined>(undefined);
+    const [sellStep, setSellStep] = useState<CoinmarketSellStepType>('BANK_ACCOUNT');
+    const [innerQuotes, setInnerQuotes] = useState<SellFiatTrade[] | undefined>(
+        getFilteredSuccessQuotes<CoinmarketTradeSellType>(quotes),
+    );
+    const [isSubmittingHelper, setIsSubmittingHelper] = useState(false);
+    const abortControllerRef = useRef<AbortController | null>(null);
+
+    const { defaultValues, defaultCountry, defaultCurrency, defaultPaymentMethod } =
+        useCoinmarketSellFormDefaultValues(
+            account,
+            sellInfo,
+            paymentMethods,
+            state?.formValues?.outputs[0].address,
+        );
+    const { saveDraft, getDraft, removeDraft } =
+        useFormDraft<CoinmarketSellFormProps>('coinmarket-sell');
+    const draft = getDraft(account.key);
+    const draftUpdated: CoinmarketSellFormProps | null = draft
+        ? {
+              ...draft,
+              fiatInput: draft.fiatInput && draft.fiatInput !== '' ? draft.fiatInput : '',
+          }
+        : null;
+    const isDraft = !!draft;
+    const methods = useForm<CoinmarketSellFormProps>({
+        mode: 'onChange',
+        defaultValues: isDraft ? draft : defaultValues,
+    });
+    const {
+        register,
+        setValue,
+        getValues,
+        setError,
+        clearErrors,
+        handleSubmit,
+        control,
+        formState,
+    } = methods;
+    const values = useWatch<CoinmarketSellFormProps>({ control });
+    const previousValues = useRef<typeof values | null>(offFirstRequest ? draftUpdated : null);
+
+    const initState = useCoinmarketSellFormState({
+        account,
+        network,
+        fees,
+        defaultValues,
+    });
+    const {
+        isLoading: isComposing,
+        composeRequest,
+        composedLevels,
+        onFeeLevelChange,
+    } = useCompose({
+        ...methods,
+        state,
+    });
+
+    // sub-hook, FeeLevels handler
+    const { changeFeeLevel, selectedFee } = useFees({
+        defaultValue: 'normal',
+        feeInfo,
+        onChange: onFeeLevelChange,
+        composeRequest,
+        ...methods,
+    });
+
+    const helpers = useCoinmarketSellFormHelpers({
+        account,
+        network,
+        methods,
+        setAmountLimits,
+        changeFeeLevel,
+        composeRequest,
+    });
+
+    const formIsValid = Object.keys(formState.errors).length === 0;
+    const hasValues = (values.fiatInput || values.cryptoInput) && !!values.currencySelect?.value;
+    const isFirstRequest = innerQuotes === undefined;
+    const noProviders = sellInfo?.sellList?.providers.length === 0;
+    const isLoading = !sellInfo?.sellList || !state?.formValues?.outputs[0].address;
+    const isFormLoading =
+        isLoading || formState.isSubmitting || isSubmittingHelper || isFirstRequest;
+    const isFormInvalid = !(formIsValid && hasValues);
+    const isLoadingOrInvalid = noProviders || isFormLoading || isFormInvalid;
+    const quotesByPaymentMethod = getQuotesByPaymentMethod(
+        innerQuotes,
+        values?.paymentMethod?.value ?? '',
+    );
+
+    const getQuotesRequest = useCallback(
+        async (request: SellFiatTradeQuoteRequest) => {
+            if (abortControllerRef.current) {
+                abortControllerRef.current.abort();
+            }
+
+            // no need to fetch quotes if amounts is not set
+            if (!request.fiatStringAmount && !request.cryptoStringAmount) {
+                timer.stop();
+
+                return;
+            }
+
+            abortControllerRef.current = new AbortController();
+            invityAPI.createInvityAPIKey(account.descriptor);
+
+            try {
+                const allQuotes = await invityAPI.getSellQuotes(
+                    request,
+                    abortControllerRef.current.signal,
+                );
+
+                return allQuotes;
+            } catch (error) {
+                console.log('Abort', error);
+            }
+        },
+        [account.descriptor, timer],
+    );
+
+    const getQuoteRequestData = useCallback((): SellFiatTradeQuoteRequest => {
+        const {
+            fiatInput,
+            cryptoInput,
+            currencySelect,
+            countrySelect,
+            cryptoSelect,
+            amountInCrypto,
+        } = methods.getValues();
+
+        const fiatStringAmount = fiatInput;
+        const cryptoStringAmount =
+            cryptoInput && shouldSendInSats
+                ? formatAmount(cryptoInput, network.decimals)
+                : cryptoInput;
+        const request: SellFiatTradeQuoteRequest = {
+            amountInCrypto,
+            cryptoCurrency: cryptoSelect?.value ?? 'BTC',
+            fiatCurrency: currencySelect.value.toUpperCase(),
+            country: countrySelect.value,
+            cryptoStringAmount,
+            fiatStringAmount,
+            flows: ['BANK_ACCOUNT', 'PAYMENT_GATE'],
+        };
+
+        return request;
+    }, [methods, network.decimals, shouldSendInSats]);
+
+    const handleChange = useCallback(
+        async (offLoading?: boolean) => {
+            setIsSubmittingHelper(!offLoading);
+            timer.loading();
+
+            const quoteRequest = getQuoteRequestData();
+            const allQuotes = await getQuotesRequest(quoteRequest);
+
+            if (Array.isArray(allQuotes)) {
+                const limits = getAmountLimits(quoteRequest, allQuotes);
+
+                const quotesDefault = filterQuotesAccordingTags<CoinmarketTradeSellType>(
+                    addIdsToQuotes<CoinmarketTradeSellType>(allQuotes, 'sell'),
+                );
+                // without errors
+                const quotesSuccess =
+                    getFilteredSuccessQuotes<CoinmarketTradeSellType>(quotesDefault) ?? [];
+
+                const bestQuote = quotesSuccess?.[0];
+                const bestQuotePaymentMethod = bestQuote?.paymentMethod;
+                const bestQuotePaymentMethodName =
+                    bestQuote?.paymentMethodName ?? bestQuotePaymentMethod;
+                const paymentMethodSelected = values.paymentMethod?.value;
+                const paymentMethodsFromQuotes = getPaymentMethods(quotesSuccess);
+                const isSelectedPaymentMethodAvailable =
+                    paymentMethodsFromQuotes.find(item => item.value === paymentMethodSelected) !==
+                    undefined;
+
+                setInnerQuotes(quotesSuccess);
+                dispatch(saveQuotes(quotesSuccess));
+                dispatch(saveQuoteRequest(quoteRequest));
+                dispatch(savePaymentMethods(paymentMethodsFromQuotes));
+                setAmountLimits(limits);
+
+                if (!paymentMethodSelected || !isSelectedPaymentMethodAvailable) {
+                    setValue(FORM_PAYMENT_METHOD_SELECT, {
+                        value: bestQuotePaymentMethod ?? '',
+                        label: bestQuotePaymentMethodName ?? '',
+                    });
+                }
+                if (!values.amountInCrypto) {
+                    // the best quote crypto amount is known after provided quotes
+                    if (bestQuote?.cryptoStringAmount) {
+                        helpers.onFiatAmountChange(bestQuote.cryptoStringAmount);
+                    }
+
+                    composeRequest(FORM_FIAT_INPUT);
+                }
+            } else {
+                setInnerQuotes([]);
+            }
+
+            timer.reset();
+            setIsSubmittingHelper(false);
+        },
+        [
+            timer,
+            helpers,
+            values.paymentMethod?.value,
+            values.amountInCrypto,
+            getPaymentMethods,
+            getQuoteRequestData,
+            getQuotesRequest,
+            dispatch,
+            saveQuotes,
+            saveQuoteRequest,
+            savePaymentMethods,
+            setValue,
+            composeRequest,
+        ],
+    );
+
+    // call change handler on every change of text inputs with debounce
+    useDebounce(
+        () => {
+            const fiatChanged = isChanged(previousValues.current?.fiatInput, values.fiatInput);
+            const cryptoChanged = isChanged(
+                previousValues.current?.cryptoInput,
+                values.cryptoInput,
+            );
+
+            if (fiatChanged || cryptoChanged) {
+                if (cryptoChanged && values.cryptoInput) {
+                    helpers.onCryptoAmountChange(values.cryptoInput);
+                }
+
+                handleSubmit(() => {
+                    handleChange();
+                })();
+
+                previousValues.current = values;
+            }
+        },
+        500,
+        [previousValues, values.fiatInput, values.cryptoInput, handleChange, handleSubmit],
+    );
+
+    // call change handler on every change of select inputs
+    useEffect(() => {
+        if (
+            isChanged(previousValues.current?.countrySelect, values.countrySelect) ||
+            isChanged(previousValues.current?.currencySelect, values.currencySelect)
+        ) {
+            handleSubmit(() => {
+                handleChange();
+            })();
+
+            previousValues.current = values;
+        }
+    }, [previousValues, values, handleChange, handleSubmit, offFirstRequest]);
+
+    const doSellTrade = async (quote: SellFiatTrade) => {
+        const provider =
+            sellInfo?.providerInfos && quote.exchange
+                ? sellInfo.providerInfos[quote.exchange]
+                : undefined;
+        if (!quotesRequest || !provider) return;
+        setCallInProgress(true);
+        // orderId is part of the quote link if redirect to payment gate with a concrete quote
+        // without the orderId the return link will point to offers
+        const orderId = provider.flow === 'PAYMENT_GATE' ? quote.orderId : undefined;
+        const returnUrl = await createQuoteLink(
+            quotesRequest,
+            account,
+            { selectedFee: selectedFeeRecomposedAndSigned, composed },
+            orderId,
+        );
+        const response = await invityAPI.doSellTrade({
+            trade: { ...quote, refundAddress: getUnusedAddressFromAccount(account).address },
+            returnUrl,
+        });
+        setCallInProgress(false);
+        if (response) {
+            if (response.trade.error && response.trade.status !== 'LOGIN_REQUEST') {
+                console.log(`[doSellTrade] ${response.trade.error}`);
+                dispatch(
+                    notificationsActions.addToast({
+                        type: 'error',
+                        error: response.trade.error,
+                    }),
+                );
+
+                return undefined;
+            }
+            if (
+                response.trade.status === 'LOGIN_REQUEST' ||
+                response.trade.status === 'SITE_ACTION_REQUEST' ||
+                (response.trade.status === 'SUBMITTED' && provider.flow === 'PAYMENT_GATE')
+            ) {
+                if (provider.flow === 'PAYMENT_GATE') {
+                    dispatch(saveTrade(response.trade, account, new Date().toISOString()));
+                    dispatch(saveTransactionId(response.trade.orderId));
+                    setSelectedQuote(response.trade);
+                    setSellStep('SEND_TRANSACTION');
+                }
+                // dispatch(submitRequestForm(response.tradeForm?.form));
+                submitRequestForm(response.tradeForm?.form);
+
+                return undefined;
+            }
+
+            return response.trade;
+        }
+        const errorMessage = 'No response from the server';
+        console.log(`[doSellTrade] ${errorMessage}`);
+        dispatch(
+            notificationsActions.addToast({
+                type: 'error',
+                error: errorMessage,
+            }),
+        );
+    };
+
+    const needToRegisterOrVerifyBankAccount = (quote: SellFiatTrade) => {
+        const provider =
+            sellInfo?.providerInfos && quote.exchange
+                ? sellInfo.providerInfos[quote.exchange]
+                : null;
+        // for BANK_ACCOUNT flow a message is shown if bank account is not verified
+        if (provider?.flow === 'BANK_ACCOUNT') {
+            return (
+                !!quote.quoteId && !(quote.bankAccounts && quote.bankAccounts.some(b => b.verified))
+            );
+        }
+
+        return false;
+    };
+
+    const goToOffers = async () => {
+        await handleChange(true);
+
+        navigateToSellOffers();
+    };
+
+    const selectQuote = async (quote: SellFiatTrade) => {
+        const provider =
+            sellInfo?.providerInfos && quote.exchange
+                ? sellInfo.providerInfos[quote.exchange]
+                : null;
+
+        if (quotesRequest) {
+            const result = await openCoinmarketSellConfirmModal(
+                provider?.companyName,
+                quote.cryptoCurrency,
+            );
+
+            if (result) {
+                // empty quoteId means the partner requests login first, requestTrade to get login screen
+                if (!quote.quoteId || needToRegisterOrVerifyBankAccount(quote)) {
+                    doSellTrade(quote);
+                } else {
+                    setSelectedQuote(quote);
+                    timer.stop();
+                }
+            }
+        }
+    };
+
+    const confirmTrade = async (bankAccount: BankAccount) => {
+        if (!selectedQuote) return;
+        const quote = { ...selectedQuote, bankAccount };
+        const response = await doSellTrade(quote);
+        if (response) {
+            setSelectedQuote(response);
+            setSellStep('SEND_TRANSACTION');
+        }
+    };
+
+    const addBankAccount = async () => {
+        if (!selectedQuote) return;
+        await doSellTrade(selectedQuote);
+    };
+
+    const sendTransaction = async () => {
+        // destinationAddress may be set by useCoinmarketWatchTrade hook to the trade object
+        const destinationAddress =
+            selectedQuote?.destinationAddress || trade?.data?.destinationAddress;
+        if (
+            selectedQuote &&
+            selectedQuote.orderId &&
+            destinationAddress &&
+            selectedQuote.cryptoStringAmount
+        ) {
+            const cryptoStringAmount = shouldSendInSats
+                ? amountToSatoshi(selectedQuote.cryptoStringAmount, network.decimals)
+                : selectedQuote.cryptoStringAmount;
+            const destinationPaymentExtraId =
+                selectedQuote.destinationPaymentExtraId || trade?.data?.destinationPaymentExtraId;
+            const result = await recomposeAndSign(
+                selectedAccount,
+                destinationAddress,
+                cryptoStringAmount,
+                destinationPaymentExtraId,
+            );
+            if (result?.success) {
+                // send txid to the server as confirmation
+                const { txid } = result.payload;
+                const quote: SellFiatTrade = {
+                    ...selectedQuote,
+                    txid,
+                    destinationAddress,
+                    destinationPaymentExtraId,
+                };
+                const response = await invityAPI.doSellConfirm(quote);
+                if (!response) {
+                    dispatch(
+                        notificationsActions.addToast({
+                            type: 'error',
+                            error: 'No response from the server',
+                        }),
+                    );
+                } else if (response.error || !response.status || !response.orderId) {
+                    dispatch(
+                        notificationsActions.addToast({
+                            type: 'error',
+                            error: response.error || 'Invalid response from the server',
+                        }),
+                    );
+                }
+
+                dispatch(saveTrade(response, account, new Date().toISOString()));
+                dispatch(saveTransactionId(selectedQuote.orderId));
+
+                goto('wallet-coinmarket-sell-detail', {
+                    params: {
+                        symbol: account.symbol,
+                        accountIndex: account.index,
+                        accountType: account.accountType,
+                    },
+                });
+            }
+        } else {
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'error',
+                    error: 'Cannot send transaction, missing data',
+                }),
+            );
+        }
+    };
+
+    const toggleAmountInCrypto = () => {
+        const { amountInCrypto } = getValues();
+        const bestScoredQuote = quotesByPaymentMethod?.[0];
+
+        if (!amountInCrypto) {
+            setValue('cryptoInput', bestScoredQuote?.cryptoStringAmount ?? '');
+        } else {
+            setValue(
+                'fiatInput',
+                bestScoredQuote?.fiatStringAmount
+                    ? coinmarketGetRoundedFiatAmount(bestScoredQuote?.fiatStringAmount)
+                    : '',
+            );
+        }
+
+        setValue('amountInCrypto', !amountInCrypto);
+        setIsSubmittingHelper(true); // remove delay of sending request
+    };
+
+    // hooks
+    useEffect(() => {
+        dispatch(loadInvityData());
+    }, [dispatch, loadInvityData]);
+
+    useEffect(() => {
+        if (!isChanged(defaultValues, values)) {
+            removeDraft(account.key);
+
+            return;
+        }
+
+        if (values.currencySelect && !values.currencySelect?.value) {
+            removeDraft(account.key);
+        }
+    }, [defaultValues, values, removeDraft, account.key]);
+
+    // react-hook-form auto register custom form fields (without HTMLElement)
+    useEffect(() => {
+        register('options');
+        register('outputs');
+        register('setMaxOutputId');
+    }, [register]);
+
+    useDidUpdate(() => {
+        const cryptoInputValue = getValues(FORM_CRYPTO_INPUT);
+        if (!cryptoInputValue) {
+            return;
+        }
+        const conversion = shouldSendInSats ? amountToSatoshi : formatAmount;
+        setValue(FORM_CRYPTO_INPUT, conversion(cryptoInputValue, network.decimals), {
+            shouldValidate: true,
+            shouldDirty: true,
+        });
+    }, [shouldSendInSats]);
+
+    useEffect(() => {
+        const setStateAsync = async (initState: CoinmarketUseSellFormStateReturnProps) => {
+            const address = await getComposeAddressPlaceholder(
+                account,
+                network,
+                device,
+                accounts,
+                chunkify,
+            );
+            if (initState.formValues && address) {
+                initState.formValues.outputs[0].address = address;
+                setValue(FORM_OUTPUT_ADDRESS, address);
+            }
+
+            setState(initState);
+        };
+
+        if (initState && initState?.account.descriptor !== state?.account.descriptor) {
+            setStateAsync(initState);
+        }
+    }, [state, initState, account, network, device, accounts, chunkify, setValue]);
+
+    useEffect(() => {
+        if (!composedLevels) return;
+        const values = getValues();
+        const { setMaxOutputId } = values;
+        const selectedFeeLevel = selectedFee || 'normal';
+        const composed = composedLevels[selectedFeeLevel];
+
+        if (!composed) return;
+
+        if (composed.type === 'final') {
+            if (typeof setMaxOutputId === 'number' && composed.max) {
+                setValue(FORM_CRYPTO_INPUT, composed.max, {
+                    shouldValidate: true,
+                    shouldDirty: true,
+                });
+                clearErrors(FORM_CRYPTO_INPUT);
+            }
+            dispatch(saveComposedTransactionInfo({ selectedFee: selectedFeeLevel, composed }));
+            setValue('estimatedFeeLimit', composed.estimatedFeeLimit, { shouldDirty: true });
+        }
+    }, [
+        composedLevels,
+        selectedFee,
+        clearErrors,
+        dispatch,
+        getValues,
+        setError,
+        setValue,
+        translationString,
+        saveComposedTransactionInfo,
+    ]);
+
+    useDebounce(
+        () => {
+            if (
+                formState.isDirty &&
+                !formState.isValidating &&
+                Object.keys(formState.errors).length === 0 &&
+                !isComposing
+            ) {
+                saveDraft(account.key, values as CoinmarketSellFormProps);
+            }
+        },
+        200,
+        [
+            saveDraft,
+            account.key,
+            values,
+            formState.errors,
+            formState.isDirty,
+            formState.isValidating,
+            isComposing,
+        ],
+    );
+
+    useEffect(() => {
+        if (!quotesRequest) {
+            navigateToSellForm();
+
+            return;
+        }
+
+        if (isFromRedirect) {
+            if (transactionId && trade) {
+                setSelectedQuote(trade.data);
+                setSellStep('SEND_TRANSACTION');
+            }
+
+            dispatch(setIsFromRedirect(false));
+        }
+
+        checkQuotesTimer(handleChange);
+    }, [
+        quotesRequest,
+        isFromRedirect,
+        timer,
+        transactionId,
+        trades,
+        trade,
+        dispatch,
+        navigateToSellForm,
+        checkQuotesTimer,
+        setSelectedQuote,
+        setIsFromRedirect,
+        handleChange,
+    ]);
+
+    // compose request on account change
+    useEffect(() => {
+        if (initState?.account.descriptor === state?.account.descriptor) {
+            composeRequest(FORM_CRYPTO_INPUT);
+        }
+    }, [composeRequest, initState?.account.descriptor, state?.account.descriptor]);
+
+    useEffect(() => {
+        return () => {
+            if (abortControllerRef.current) {
+                abortControllerRef.current.abort();
+            }
+        };
+    }, []);
+
+    return {
+        type,
+        form: {
+            state: {
+                isFormLoading,
+                isFormInvalid,
+                isLoadingOrInvalid,
+
+                toggleAmountInCrypto,
+            },
+            helpers,
+        },
+        ...methods,
+        account,
+        defaultCountry,
+        defaultCurrency,
+        defaultPaymentMethod,
+        paymentMethods,
+        sellInfo,
+        quotesRequest,
+        quotes: quotesByPaymentMethod,
+        callInProgress,
+        composedLevels,
+        localCurrencyOption,
+        feeInfo,
+        isComposing,
+        amountLimits,
+        network,
+        device,
+        timer,
+        sellStep,
+        selectedQuote,
+        changeFeeLevel,
+        composeRequest,
+        setAmountLimits,
+
+        setSellStep,
+        addBankAccount,
+        confirmTrade,
+        goToOffers,
+        needToRegisterOrVerifyBankAccount,
+        selectQuote,
+        sendTransaction,
+    };
+};

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSellFormDefaultValues.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSellFormDefaultValues.ts
@@ -1,0 +1,99 @@
+import { useMemo } from 'react';
+import { SellInfo } from 'src/actions/wallet/coinmarketSellActions';
+import { DEFAULT_PAYMENT, DEFAULT_VALUES } from '@suite-common/wallet-constants';
+import {
+    buildFiatOption,
+    coinmarketBuildAccountOptions,
+    getDefaultCountry,
+} from 'src/utils/wallet/coinmarket/coinmarketUtils';
+import { Account } from 'src/types/wallet';
+import {
+    CoinmarketAccountsOptionsGroupProps,
+    CoinmarketPaymentMethodListProps,
+} from 'src/types/coinmarket/coinmarket';
+import { formDefaultCurrency } from 'src/constants/wallet/coinmarket/formDefaults';
+import { CoinmarketSellFormDefaultValuesProps } from 'src/types/coinmarket/coinmarketForm';
+import { FormState, Output } from '@suite-common/wallet-types';
+import { selectAccountLabels } from 'src/reducers/suite/metadataReducer';
+import { useSelector } from 'src/hooks/suite';
+import { selectAccounts, selectDevice } from '@suite-common/wallet-core';
+import { useAccountLabel } from 'src/components/suite/AccountLabel';
+
+export const useCoinmarketBuildAccountGroups = (): CoinmarketAccountsOptionsGroupProps[] => {
+    const accounts = useSelector(selectAccounts);
+    const accountLabels = useSelector(selectAccountLabels);
+    const device = useSelector(selectDevice);
+    const { defaultAccountLabelString } = useAccountLabel();
+    const { symbolsInfo } = useSelector(state => state.wallet.coinmarket.info);
+
+    const groups = useMemo(
+        () =>
+            coinmarketBuildAccountOptions({
+                accounts,
+                deviceState: device?.state,
+                symbolsInfo,
+                accountLabels,
+                defaultAccountLabelString,
+            }),
+        [symbolsInfo, accounts, accountLabels, device, defaultAccountLabelString],
+    );
+
+    return groups;
+};
+
+export const useCoinmarketSellFormDefaultValues = (
+    account: Account,
+    sellInfo: SellInfo | undefined,
+    paymentMethods: CoinmarketPaymentMethodListProps[],
+    defaultAddress?: string,
+): CoinmarketSellFormDefaultValuesProps => {
+    const country = sellInfo?.sellList?.country;
+    const cryptoGroups = useCoinmarketBuildAccountGroups();
+    const cryptoOptions = cryptoGroups.flatMap(group => group.options);
+    const defaultCrypto = useMemo(
+        () => cryptoOptions.find(option => option.descriptor === account.descriptor),
+        [account.descriptor, cryptoOptions],
+    );
+    const defaultCountry = useMemo(() => getDefaultCountry(country), [country]);
+    const defaultPaymentMethod: CoinmarketPaymentMethodListProps = useMemo(
+        () =>
+            paymentMethods.find(paymentMethod => paymentMethod.value === 'creditCard') ?? {
+                value: '',
+                label: '',
+            },
+        [paymentMethods],
+    );
+    const defaultCurrency = useMemo(() => buildFiatOption(formDefaultCurrency), []);
+    const defaultPayment: Output = useMemo(
+        () => ({
+            ...DEFAULT_PAYMENT,
+            address: defaultAddress ?? defaultCrypto?.descriptor ?? '',
+            token: defaultCrypto?.contractAddress ?? '',
+        }),
+        [defaultCrypto?.contractAddress, defaultCrypto?.descriptor, defaultAddress],
+    );
+    const defaultFormState: FormState = useMemo(
+        () => ({
+            ...DEFAULT_VALUES,
+            selectedUtxos: [],
+            options: ['broadcast'],
+            outputs: [defaultPayment],
+        }),
+        [defaultPayment],
+    );
+    const defaultValues = useMemo(
+        () => ({
+            ...defaultFormState,
+            fiatInput: '',
+            cryptoInput: '',
+            currencySelect: defaultCurrency,
+            cryptoSelect: defaultCrypto,
+            countrySelect: defaultCountry,
+            paymentMethod: defaultPaymentMethod,
+            amountInCrypto: true,
+        }),
+        [defaultCurrency, defaultCrypto, defaultCountry, defaultPaymentMethod, defaultFormState],
+    );
+
+    return { defaultValues, defaultCountry, defaultCurrency, defaultPaymentMethod };
+};

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSellFormHelpers.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSellFormHelpers.ts
@@ -1,0 +1,176 @@
+import {
+    selectAccounts,
+    selectDevice,
+    selectFiatRatesByFiatRateKey,
+} from '@suite-common/wallet-core';
+import {
+    amountToSatoshi,
+    getFiatRateKey,
+    isEthereumAccountSymbol,
+    isZero,
+} from '@suite-common/wallet-utils';
+import { BigNumber } from '@trezor/utils';
+import { FiatCurrencyCode } from 'invity-api';
+import { useCallback } from 'react';
+import { setCoinmarketSellAccount } from 'src/actions/wallet/coinmarketSellActions';
+import {
+    FORM_CRYPTO_INPUT,
+    FORM_CRYPTO_TOKEN,
+    FORM_FIAT_CURRENCY_SELECT,
+    FORM_FIAT_INPUT,
+    FORM_OUTPUT_ADDRESS,
+    FORM_OUTPUT_AMOUNT,
+} from 'src/constants/wallet/coinmarket/form';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
+import { CoinmarketAccountOptionsGroupOptionProps } from 'src/types/coinmarket/coinmarket';
+import {
+    CoinmarketFormHelpersProps,
+    CoinmarketUseSellFormHelpersProps,
+} from 'src/types/coinmarket/coinmarketForm';
+import { Option } from 'src/types/wallet/coinmarketCommonTypes';
+import {
+    coinmarketGetSortedAccountsWithBalance,
+    mapTestnetSymbol,
+} from 'src/utils/wallet/coinmarket/coinmarketUtils';
+import { cryptoToNetworkSymbol } from 'src/utils/wallet/coinmarket/cryptoSymbolUtils';
+
+/**
+ * @return functions and values to handle form inputs and update fee levels
+ */
+export const useCoinmarketSellFormHelpers = ({
+    account,
+    network,
+    methods,
+    setAmountLimits,
+    changeFeeLevel,
+    composeRequest,
+}: CoinmarketUseSellFormHelpersProps): CoinmarketFormHelpersProps => {
+    const { symbol } = account;
+    const { shouldSendInSats } = useBitcoinAmountUnit(symbol);
+    const accounts = useSelector(selectAccounts);
+    const device = useSelector(selectDevice);
+    const accountsWithBalance = coinmarketGetSortedAccountsWithBalance({
+        accounts,
+        deviceState: device?.state,
+    });
+
+    const dispatch = useDispatch();
+    const { getValues, setValue, clearErrors } = methods;
+    const { outputs } = getValues();
+    const tokenAddress = outputs?.[0]?.token;
+    const tokenData = account.tokens?.find(t => t.contract === tokenAddress);
+    const isBalanceZero = tokenData
+        ? isZero(tokenData.balance || '0')
+        : isZero(account.formattedBalance);
+    const symbolForFiat = mapTestnetSymbol(symbol);
+
+    const currency: Option | undefined = getValues(FORM_FIAT_CURRENCY_SELECT);
+    const fiatRateKey = getFiatRateKey(symbolForFiat, currency?.value as FiatCurrencyCode);
+    const fiatRate = useSelector(state => selectFiatRatesByFiatRateKey(state, fiatRateKey));
+
+    // watch change in crypto amount and recalculate fees on change
+    const onCryptoAmountChange = useCallback(
+        (amount: string) => {
+            setValue('setMaxOutputId', undefined, { shouldDirty: true });
+            setValue(FORM_OUTPUT_AMOUNT, amount || '', { shouldDirty: true });
+        },
+        [setValue],
+    );
+
+    // watch change in fiat amount and recalculate fees on change
+    const onFiatAmountChange = useCallback(
+        (cryptoInput: string) => {
+            const cryptoInputValue =
+                cryptoInput && shouldSendInSats
+                    ? amountToSatoshi(cryptoInput, network.decimals)
+                    : cryptoInput;
+            setValue(FORM_OUTPUT_AMOUNT, cryptoInputValue || '', {
+                shouldDirty: true,
+                shouldValidate: false,
+            });
+        },
+        [setValue, shouldSendInSats, network.decimals],
+    );
+
+    const onCryptoCurrencyChange = useCallback(
+        (selected: CoinmarketAccountOptionsGroupOptionProps) => {
+            const networkSymbol = cryptoToNetworkSymbol(selected.value);
+            const account = accountsWithBalance.find(
+                item => item.descriptor === selected.descriptor,
+            );
+
+            setValue(FORM_OUTPUT_ADDRESS, '');
+            setValue(FORM_CRYPTO_TOKEN, selected?.contractAddress ?? null);
+
+            if (networkSymbol && isEthereumAccountSymbol(networkSymbol)) {
+                // set token address for ERC20 transaction to estimate the fees more precisely
+                setValue(FORM_OUTPUT_ADDRESS, selected?.contractAddress ?? '');
+            }
+
+            if (networkSymbol === 'sol') {
+                setValue(FORM_OUTPUT_ADDRESS, selected?.descriptor ?? '');
+            }
+
+            setValue('setMaxOutputId', undefined);
+            setValue(FORM_CRYPTO_INPUT, '');
+            setValue(FORM_FIAT_INPUT, '');
+            setAmountLimits(undefined);
+
+            if (account) {
+                dispatch(setCoinmarketSellAccount(account));
+                changeFeeLevel('normal'); // reset fee level
+            }
+        },
+        [accountsWithBalance, setValue, setAmountLimits, changeFeeLevel, dispatch],
+    );
+
+    const setRatioAmount = useCallback(
+        (divisor: number) => {
+            const amount = tokenData
+                ? new BigNumber(tokenData.balance || '0')
+                      .dividedBy(divisor)
+                      .decimalPlaces(tokenData.decimals)
+                      .toString()
+                : new BigNumber(account.formattedBalance)
+                      .dividedBy(divisor)
+                      .decimalPlaces(network.decimals)
+                      .toString();
+            const cryptoInputValue = shouldSendInSats
+                ? amountToSatoshi(amount, network.decimals)
+                : amount;
+            setValue(FORM_CRYPTO_INPUT, cryptoInputValue, { shouldDirty: true });
+            // clearErrors(FORM_CRYPTO_INPUT);
+            onCryptoAmountChange(cryptoInputValue);
+        },
+        [
+            account.formattedBalance,
+            shouldSendInSats,
+            network.decimals,
+            onCryptoAmountChange,
+            tokenData,
+            setValue,
+        ],
+    );
+
+    const setAllAmount = useCallback(() => {
+        setValue('setMaxOutputId', 0, { shouldDirty: true });
+        setValue(FORM_FIAT_INPUT, '', { shouldDirty: true });
+        setValue(FORM_OUTPUT_AMOUNT, '', { shouldDirty: true });
+        clearErrors([FORM_FIAT_INPUT, FORM_CRYPTO_INPUT]);
+        composeRequest(FORM_CRYPTO_INPUT);
+    }, [setValue, composeRequest, clearErrors]);
+
+    return {
+        isBalanceZero,
+        fiatRate,
+
+        onCryptoAmountChange,
+        onFiatAmountChange,
+        onCryptoCurrencyChange,
+        setRatioAmount,
+        setAllAmount,
+    };
+};
+
+export default useCoinmarketSellFormHelpers;

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSellFormState.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSellFormState.ts
@@ -1,0 +1,23 @@
+import { getFeeLevels } from '@suite-common/wallet-utils';
+import {
+    CoinmarketUseSellFormStateProps,
+    CoinmarketUseSellFormStateReturnProps,
+} from 'src/types/coinmarket/coinmarketForm';
+
+export const useCoinmarketSellFormState = ({
+    account,
+    network,
+    fees,
+    defaultValues,
+}: CoinmarketUseSellFormStateProps): CoinmarketUseSellFormStateReturnProps | undefined => {
+    const coinFees = fees[account.symbol];
+    const levels = getFeeLevels(account.networkType, coinFees);
+    const feeInfo = { ...coinFees, levels };
+
+    return {
+        account,
+        network,
+        feeInfo,
+        formValues: defaultValues,
+    };
+};

--- a/packages/suite/src/reducers/wallet/coinmarketReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinmarketReducer.ts
@@ -72,6 +72,7 @@ interface Sell extends CoinmarketTradeCommonProps {
     quotes: SellFiatTrade[] | undefined;
     transactionId?: string;
     isFromRedirect: boolean;
+    coinmarketAccount?: Account;
 }
 
 export interface State {
@@ -118,6 +119,7 @@ export const initialState: State = {
         quotes: [],
         transactionId: undefined,
         isFromRedirect: false,
+        coinmarketAccount: undefined,
     },
     composedTransactionInfo: {},
     trades: [],
@@ -219,6 +221,9 @@ const coinmarketReducer = (
                 break;
             case COINMARKET_SELL.SAVE_TRANSACTION_ID:
                 draft.sell.transactionId = action.transactionId;
+                break;
+            case COINMARKET_SELL.SET_COINMARKET_ACCOUNT:
+                draft.sell.coinmarketAccount = action.account;
                 break;
             case COINMARKET_COMMON.SET_LOADING:
                 draft.isLoading = action.isLoading;

--- a/packages/suite/src/services/suite/invityAPI.ts
+++ b/packages/suite/src/services/suite/invityAPI.ts
@@ -378,12 +378,15 @@ class InvityAPI {
 
     getSellQuotes = async (
         params: SellFiatTradeQuoteRequest,
+        signal?: SignalType,
     ): Promise<SellFiatTrade[] | undefined> => {
         try {
             const response: SellFiatTradeQuoteResponse = await this.request(
                 this.SELL_FIAT_QUOTES,
                 params,
                 'POST',
+                undefined,
+                signal,
             );
 
             return response;

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -1594,9 +1594,17 @@ export default defineMessages({
         defaultMessage: 'Payment method',
         id: 'TR_COINMARKET_PAYMENT_METHOD',
     },
+    TR_COINMARKET_RECEIVE_METHOD: {
+        defaultMessage: 'Receive method',
+        id: 'TR_COINMARKET_PAYMENT_METHOD',
+    },
     TR_COINMARKET_YOU_BUY: {
         defaultMessage: 'You buy',
         id: 'TR_COINMARKET_YOU_BUY',
+    },
+    TR_COINMARKET_YOU_SELL: {
+        defaultMessage: 'You sell',
+        id: 'TR_COINMARKET_YOU_SELL',
     },
     TR_COINMARKET_YOU_PAY: {
         defaultMessage: 'You pay',
@@ -1690,6 +1698,10 @@ export default defineMessages({
     TR_COINMARKET_FIAT: {
         defaultMessage: 'fiat',
         id: 'TR_COINMARKET_FIAT',
+    },
+    TR_COINMARKET_SELL: {
+        id: 'TR_COINMARKET_SELL',
+        defaultMessage: 'Sell',
     },
     TR_ADDRESS_MODAL_CLIPBOARD: {
         defaultMessage: 'Copy address',

--- a/packages/suite/src/types/coinmarket/coinmarket.ts
+++ b/packages/suite/src/types/coinmarket/coinmarket.ts
@@ -39,6 +39,7 @@ import {
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { ExtendedMessageDescriptor, TrezorDevice } from 'src/types/suite';
 import { Timer } from '@trezor/react-utils';
+import { AccountsState } from '@suite-common/wallet-core';
 
 export type UseCoinmarketProps = WithSelectedAccountLoadedProps;
 export type UseCoinmarketCommonProps = UseCoinmarketProps & {
@@ -176,4 +177,54 @@ export interface CoinmarketOptionsGroupProps {
     options: CoinmarketCryptoListProps[];
 }
 
+export interface CoinmarketGetSortedAccountsWithBalanceProps {
+    accounts: AccountsState;
+    deviceState: string | undefined;
+}
+
+export interface CoinmarketBuildAccountOptionsProps
+    extends CoinmarketGetSortedAccountsWithBalanceProps {
+    symbolsInfo: CryptoSymbolInfo[] | undefined;
+    accountLabels: Record<string, string | undefined>;
+    defaultAccountLabelString: ({
+        accountType,
+        symbol,
+        index,
+    }: {
+        accountType: Account['accountType'];
+        symbol: Account['symbol'];
+        index?: number;
+    }) => string;
+}
+
+export interface CoinmarketAccountOptionsGroupOptionProps extends CoinmarketCryptoListProps {
+    balance: string;
+    descriptor: string;
+    contractAddress?: string;
+}
+
+export interface CoinmarketAccountsOptionsGroupProps {
+    label: string;
+    options: CoinmarketAccountOptionsGroupOptionProps[];
+}
+
 export type CoinmarketFiatCurrenciesProps = Map<FiatCurrencyCode, string>;
+
+export interface CoinmarketGetAmountLabelsProps {
+    type: CoinmarketTradeType;
+    amountInCrypto: boolean;
+}
+
+type CoinmarketPayGetLabelType = Extract<
+    ExtendedMessageDescriptor['id'],
+    `TR_COINMARKET_YOU_${'PAY' | 'GET'}`
+>;
+
+export interface CoinmarketGetAmountLabelsReturnProps {
+    label1: CoinmarketPayGetLabelType;
+    label2: CoinmarketPayGetLabelType;
+    labelComparatorOffer: Extract<
+        ExtendedMessageDescriptor['id'],
+        `TR_COINMARKET_YOU_WILL_${'PAY' | 'GET'}`
+    >;
+}

--- a/packages/suite/src/types/coinmarket/coinmarketOffers.ts
+++ b/packages/suite/src/types/coinmarket/coinmarketOffers.ts
@@ -14,7 +14,7 @@ import { Timer } from '@trezor/react-utils';
 import { TradeSell } from '../wallet/coinmarketCommonTypes';
 import { SellInfo } from 'src/actions/wallet/coinmarketSellActions';
 import { CoinmarketTradeType } from './coinmarket';
-import { CoinmarketBuyFormContextProps } from './coinmarketForm';
+import { CoinmarketBuyFormContextProps, CoinmarketSellFormContextProps } from './coinmarketForm';
 
 type CoinmarketOffersContextProps = {
     type: CoinmarketTradeType;
@@ -93,7 +93,7 @@ export type CoinmarketP2pOffersContextProps = Omit<
 
 export type CoinmarketOffersMapProps = {
     buy: CoinmarketBuyFormContextProps; // temporary
-    sell: CoinmarketSellOffersContextProps;
+    sell: CoinmarketSellFormContextProps; // temporary
     exchange: CoinmarketExchangeOffersContextProps;
 };
 
@@ -101,7 +101,7 @@ export type CoinmarketOffersContextValues<T extends CoinmarketTradeType> =
     CoinmarketOffersMapProps[T];
 
 export interface CoinmarketCryptoAmountProps {
-    wantCrypto: boolean | undefined;
+    amountInCrypto: boolean | undefined;
     sendAmount: string | number | undefined;
     sendCurrency: string | undefined;
     receiveAmount: string | number | undefined;

--- a/packages/suite/src/utils/wallet/coinmarket/__fixtures__/coinmarketUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/__fixtures__/coinmarketUtils.ts
@@ -1,4 +1,5 @@
 import { DefinitionType, TokenDefinitions } from '@suite-common/token-definitions';
+import { Account } from '@suite-common/wallet-types';
 
 export const accountBtc = {
     index: 1,
@@ -55,3 +56,59 @@ export const coinDefinitions: TokenDefinitions[DefinitionType.COIN] = {
     hide: [],
     show: [],
 };
+
+export const FIXTURE_ACCOUNTS: Partial<Account>[] = [
+    {
+        deviceState: 'deviceState',
+        formattedBalance: '0',
+        tokens: [],
+        descriptor: 'descriptor1',
+        symbol: 'btc',
+    },
+    {
+        deviceState: 'deviceState',
+        formattedBalance: '0.101213',
+        tokens: [],
+        descriptor: 'descriptor2',
+        symbol: 'ltc',
+    },
+    {
+        deviceState: 'deviceState',
+        formattedBalance: '0',
+        descriptor: 'descriptor3',
+        symbol: 'eth',
+        tokens: [
+            {
+                balance: '2.76149',
+                contract: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+                decimals: 6,
+                name: 'Tether USD',
+                symbol: 'usdt',
+                type: 'ERC20',
+            },
+        ],
+    },
+    {
+        deviceState: 'no-deviceState',
+        formattedBalance: '0.101213',
+        tokens: [],
+        descriptor: 'descriptor4',
+        symbol: 'btc',
+    },
+    {
+        deviceState: 'no-deviceState',
+        formattedBalance: '0.101213',
+        symbol: 'matic',
+        tokens: [
+            {
+                balance: '2.76149',
+                contract: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+                decimals: 6,
+                name: 'Tether USD',
+                symbol: 'usdt',
+                type: 'ERC20',
+            },
+        ],
+        descriptor: 'descriptor5',
+    },
+];

--- a/packages/suite/src/utils/wallet/coinmarket/coinmarketTypingUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/coinmarketTypingUtils.ts
@@ -3,7 +3,11 @@ import {
     isCoinmarketBuyOffers,
     isCoinmarketSellOffers,
 } from 'src/hooks/wallet/coinmarket/offers/useCoinmarketCommonOffers';
-import { CoinmarketTradeDetailType, CoinmarketTradeType } from 'src/types/coinmarket/coinmarket';
+import {
+    CoinmarketTradeBuySellType,
+    CoinmarketTradeDetailType,
+    CoinmarketTradeType,
+} from 'src/types/coinmarket/coinmarket';
 import { CoinmarketFormContextValues } from 'src/types/coinmarket/coinmarketForm';
 import { CoinmarketOffersContextValues } from 'src/types/coinmarket/coinmarketOffers';
 
@@ -14,13 +18,13 @@ export const getCryptoQuoteAmountProps = (
     if (!quoteInput) return null;
 
     if (isCoinmarketBuyOffers(context)) {
-        const wantCrypto = context.quotesRequest?.wantCrypto;
+        const amountInCrypto = context.quotesRequest?.wantCrypto;
         const quote = quoteInput as BuyTrade;
 
         if (!quote || !context.quotesRequest) return null;
 
         return {
-            wantCrypto,
+            amountInCrypto,
             sendAmount: quote?.fiatStringAmount ?? '',
             sendCurrency: quote?.fiatCurrency,
             receiveAmount: quote?.receiveStringAmount ?? '',
@@ -35,7 +39,7 @@ export const getCryptoQuoteAmountProps = (
         if (!quote || !context.quotesRequest) return null;
 
         return {
-            wantCrypto: amountInCrypto,
+            amountInCrypto,
             sendAmount: quote?.fiatStringAmount ?? '',
             sendCurrency: quote?.fiatCurrency,
             receiveAmount: quote?.cryptoStringAmount ?? '',
@@ -46,7 +50,7 @@ export const getCryptoQuoteAmountProps = (
     const quote = quoteInput as ExchangeTrade;
 
     return {
-        wantCrypto: false,
+        amountInCrypto: false,
         sendAmount: quote?.sendStringAmount ?? '',
         sendCurrency: quote?.send,
         receiveAmount: quote?.receiveStringAmount ?? '',
@@ -71,5 +75,20 @@ export const getProvidersInfoProps = (
 
     return {
         providers: context.exchangeInfo?.providerInfos,
+    };
+};
+
+export const getFiatCurrenciesProps = (
+    context: CoinmarketFormContextValues<CoinmarketTradeBuySellType>,
+) => {
+    if (isCoinmarketSellOffers(context)) {
+        return {
+            supportedFiatCurrencies: context.sellInfo?.supportedFiatCurrencies,
+        };
+    }
+
+    return {
+        supportedFiatCurrencies: context.buyInfo?.supportedFiatCurrencies,
+        defaultAmountsOfFiatCurrencies: context.buyInfo?.buyInfo.defaultAmountsOfFiatCurrencies,
     };
 };

--- a/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
@@ -19,8 +19,14 @@ import {
     isTokenDefinitionKnown,
 } from '@suite-common/token-definitions';
 import {
+    CoinmarketAccountOptionsGroupOptionProps,
+    CoinmarketAccountsOptionsGroupProps,
+    CoinmarketBuildAccountOptionsProps,
     CoinmarketBuildOptionsProps,
     CoinmarketCryptoListProps,
+    CoinmarketGetAmountLabelsProps,
+    CoinmarketGetAmountLabelsReturnProps,
+    CoinmarketGetSortedAccountsWithBalanceProps,
     CoinmarketOptionsGroupProps,
     CoinmarketTradeBuySellDetailMapProps,
     CoinmarketTradeBuySellType,
@@ -38,6 +44,7 @@ import CryptoCategories, {
     CryptoCategoryD,
     CryptoCategoryE,
 } from 'src/constants/wallet/coinmarket/cryptoCategories';
+import { sortByCoin } from '@suite-common/wallet-utils';
 
 /** @deprecated */
 const suiteToInvitySymbols: {
@@ -384,3 +391,129 @@ export const coinmarketBuildCryptoOptions = ({
 
     return groups;
 };
+
+export const coinmarketGetSortedAccountsWithBalance = ({
+    accounts,
+    deviceState,
+}: CoinmarketGetSortedAccountsWithBalanceProps) => {
+    if (!deviceState) return [];
+
+    const accountSorted = sortByCoin(accounts.filter(a => a.deviceState === deviceState));
+    const accountsWithBalance = accountSorted.filter(account => {
+        const accountWithBalance = account.formattedBalance !== '0';
+        const tokens = account.tokens?.filter(token => token.balance !== '0');
+
+        return accountWithBalance || (tokens && tokens?.length > 0);
+    });
+
+    return accountsWithBalance;
+};
+
+export const coinmarketBuildAccountOptions = ({
+    symbolsInfo,
+    deviceState,
+    accounts,
+    accountLabels,
+    defaultAccountLabelString,
+}: CoinmarketBuildAccountOptionsProps): CoinmarketAccountsOptionsGroupProps[] => {
+    const accountsWithBalance = coinmarketGetSortedAccountsWithBalance({
+        accounts,
+        deviceState,
+    });
+
+    const groups: CoinmarketAccountsOptionsGroupProps[] = accountsWithBalance.map(account => {
+        const {
+            descriptor,
+            tokens,
+            symbol: accountSymbol,
+            formattedBalance,
+            index,
+            accountType,
+        } = account;
+
+        const groupLabel =
+            accountLabels[account.key] ??
+            defaultAccountLabelString({
+                accountType,
+                symbol: accountSymbol,
+                index,
+            });
+        const foundSymbolInfo = symbolsInfo?.find(
+            item => item.symbol === networkToCryptoSymbol(accountSymbol),
+        );
+
+        const options: CoinmarketAccountOptionsGroupOptionProps[] = [
+            {
+                value: foundSymbolInfo?.symbol ?? (accountSymbol.toUpperCase() as CryptoSymbol),
+                label: accountSymbol.toUpperCase(),
+                cryptoName: foundSymbolInfo?.name ?? null,
+                descriptor,
+                balance: formattedBalance ?? '',
+            },
+        ];
+
+        // add crypto tokens to options
+        if (tokens && tokens.length > 0) {
+            tokens.forEach(token => {
+                const { symbol, balance, contract } = token;
+                if (!symbol || !balance || balance === '0') {
+                    return;
+                }
+
+                const tokenCryptoSymbol = tokenToCryptoSymbol(symbol, account.symbol);
+                if (!tokenCryptoSymbol) {
+                    return;
+                }
+
+                const tokenSymbolInfo = symbolsInfo?.find(
+                    item => item.symbol === tokenCryptoSymbol,
+                );
+
+                options.push({
+                    value: tokenSymbolInfo?.symbol ?? (symbol as CryptoSymbol),
+                    label: symbol.toUpperCase(),
+                    cryptoName: tokenSymbolInfo?.name ?? null,
+                    contractAddress: contract,
+                    descriptor,
+                    balance: balance ?? '',
+                });
+            });
+        }
+
+        return {
+            label: groupLabel,
+            options,
+        };
+    });
+
+    return groups;
+};
+
+export const coinmarketGetAmountLabels = ({
+    type,
+    amountInCrypto,
+}: CoinmarketGetAmountLabelsProps): CoinmarketGetAmountLabelsReturnProps => {
+    if (type === 'sell') {
+        return {
+            label1: amountInCrypto ? 'TR_COINMARKET_YOU_PAY' : 'TR_COINMARKET_YOU_GET',
+            label2: amountInCrypto ? 'TR_COINMARKET_YOU_GET' : 'TR_COINMARKET_YOU_PAY',
+            labelComparatorOffer: amountInCrypto
+                ? 'TR_COINMARKET_YOU_WILL_GET'
+                : 'TR_COINMARKET_YOU_WILL_PAY',
+        };
+    }
+
+    return {
+        label1: amountInCrypto ? 'TR_COINMARKET_YOU_GET' : 'TR_COINMARKET_YOU_PAY',
+        label2: amountInCrypto ? 'TR_COINMARKET_YOU_PAY' : 'TR_COINMARKET_YOU_GET',
+        labelComparatorOffer: amountInCrypto
+            ? 'TR_COINMARKET_YOU_WILL_PAY'
+            : 'TR_COINMARKET_YOU_WILL_GET',
+    };
+};
+
+/**
+ * Rounding up to two decimal places
+ */
+export const coinmarketGetRoundedFiatAmount = (amount: string): string =>
+    new BigNumber(amount).toFixed(2, BigNumber.ROUND_HALF_UP);

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputCountry.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputCountry.tsx
@@ -4,7 +4,6 @@ import regional from 'src/constants/wallet/coinmarket/regional';
 import { CountryOption } from 'src/types/wallet/coinmarketCommonTypes';
 import { getCountryLabelParts } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import styled from 'styled-components';
-import { CoinmarketTradeBuyType } from 'src/types/coinmarket/coinmarket';
 import { useCoinmarketFormContext } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonForm';
 import { spacingsPx } from '@trezor/theme';
 import CoinmarketFormInputLabel from 'src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputLabel';
@@ -14,6 +13,7 @@ import {
     CoinmarketFormOption,
     CoinmarketFormOptionLabel,
 } from 'src/views/wallet/coinmarket';
+import { FORM_COUNTRY_SELECT } from 'src/constants/wallet/coinmarket/form';
 
 const FlagContainer = styled.div`
     position: relative;
@@ -34,22 +34,20 @@ const FlagWrapper = styled(Flag)`
 `;
 
 const CoinmarketFormInputCountry = ({ className, label }: CoinmarketFormInputProps) => {
-    const { control, setAmountLimits, defaultCountry } =
-        useCoinmarketFormContext<CoinmarketTradeBuyType>();
-    const countrySelect = 'countrySelect';
+    const { control, setAmountLimits, defaultCountry } = useCoinmarketFormContext();
 
     return (
         <CoinmarketFormInput className={className}>
             <CoinmarketFormInputLabel label={label} />
             <Controller
-                name={countrySelect}
+                name={FORM_COUNTRY_SELECT}
                 defaultValue={defaultCountry}
                 control={control}
                 render={({ field: { onChange, value } }) => (
                     <Select
                         value={value}
                         options={regional.countriesOptions}
-                        onChange={(selected: any) => {
+                        onChange={selected => {
                             onChange(selected);
                             setAmountLimits(undefined);
                         }}

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputCurrency.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputCurrency.tsx
@@ -1,11 +1,18 @@
-import { fiatCurrencies } from '@suite-common/suite-config';
 import { Select } from '@trezor/components';
 import { Controller } from 'react-hook-form';
+import { FORM_FIAT_CURRENCY_SELECT, FORM_FIAT_INPUT } from 'src/constants/wallet/coinmarket/form';
 import { useCoinmarketFormContext } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonForm';
-import { CoinmarketTradeBuyType } from 'src/types/coinmarket/coinmarket';
 import { FiatCurrencyOption } from 'src/types/wallet/coinmarketCommonTypes';
+import { getFiatCurrenciesProps } from 'src/utils/wallet/coinmarket/coinmarketTypingUtils';
 import { buildFiatOption } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import { CoinmarketFormOption, CoinmarketFormOptionLabel } from 'src/views/wallet/coinmarket';
+import styled from 'styled-components';
+
+const SelectWrapper = styled(Select)`
+    .react-select__value-container {
+        padding: 0;
+    }
+`;
 
 interface CoinmarketFormInputCurrencyProps {
     className?: string;
@@ -20,31 +27,30 @@ const CoinmarketFormInputCurrency = ({
     size = 'large',
     isDarkLabel = false,
 }: CoinmarketFormInputCurrencyProps) => {
-    const fiatInput = 'fiatInput';
-    const currencySelect = 'currencySelect';
+    const context = useCoinmarketFormContext();
+    const { defaultCurrency, control, setAmountLimits, setValue } = context;
 
-    const { defaultCurrency, control, buyInfo, setAmountLimits, setValue } =
-        useCoinmarketFormContext<CoinmarketTradeBuyType>();
+    const fiatCurrencies = getFiatCurrenciesProps(context);
+    const currencies = fiatCurrencies?.supportedFiatCurrencies ?? [];
 
     return (
         <Controller
-            name={currencySelect}
+            name={FORM_FIAT_CURRENCY_SELECT}
             defaultValue={defaultCurrency}
             control={control}
             render={({ field: { onChange, value } }) => (
-                <Select
+                <SelectWrapper
                     value={value}
                     onChange={(selected: FiatCurrencyOption) => {
                         onChange(selected);
                         setAmountLimits(undefined);
                         setValue(
-                            fiatInput,
-                            buyInfo?.buyInfo.defaultAmountsOfFiatCurrencies.get(selected.value),
+                            FORM_FIAT_INPUT,
+                            fiatCurrencies?.defaultAmountsOfFiatCurrencies?.get(selected.value) ??
+                                '',
                         );
                     }}
-                    options={Object.keys(fiatCurrencies)
-                        .filter(c => buyInfo?.supportedFiatCurrencies.has(c))
-                        .map((currency: string) => buildFiatOption(currency))}
+                    options={[...currencies].map(currency => buildFiatOption(currency)) ?? []}
                     formatOptionLabel={option => {
                         return (
                             <CoinmarketFormOption>

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputFiatCrypto/CoinmarketFormInputCrypto.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputFiatCrypto/CoinmarketFormInputCrypto.tsx
@@ -9,13 +9,13 @@ import {
 import { getInputState } from '@suite-common/wallet-utils';
 import { formInputsMaxLength } from '@suite-common/validators';
 import { useCoinmarketFormContext } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonForm';
-import { CoinmarketTradeBuyType } from 'src/types/coinmarket/coinmarket';
 import { useFormatters } from '@suite-common/formatters';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 import { useEffect } from 'react';
 import { CoinmarketFormInputProps } from 'src/types/coinmarket/coinmarketForm';
 import { cryptoToCoinSymbol } from 'src/utils/wallet/coinmarket/cryptoSymbolUtils';
 import { CoinmarketFormOptionLabel } from 'src/views/wallet/coinmarket';
+import { FORM_CRYPTO_INPUT, FORM_FIAT_INPUT } from 'src/constants/wallet/coinmarket/form';
 
 const CoinmarketFormInputCrypto = ({ className }: CoinmarketFormInputProps) => {
     const { translationString } = useTranslation();
@@ -29,11 +29,9 @@ const CoinmarketFormInputCrypto = ({ className }: CoinmarketFormInputProps) => {
         trigger,
         clearErrors,
         getValues,
-    } = useCoinmarketFormContext<CoinmarketTradeBuyType>();
+    } = useCoinmarketFormContext();
     const { shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
-
-    const fiatInput = 'fiatInput';
-    const cryptoInput = 'cryptoInput';
+    const { cryptoSelect } = getValues();
 
     const cryptoInputRules = {
         validate: {
@@ -50,26 +48,26 @@ const CoinmarketFormInputCrypto = ({ className }: CoinmarketFormInputProps) => {
 
     useEffect(() => {
         if (amountLimits) {
-            trigger([cryptoInput]);
+            trigger([FORM_CRYPTO_INPUT]);
         }
     }, [amountLimits, trigger]);
 
     return (
         <NumberInput
-            name={cryptoInput}
+            name={FORM_CRYPTO_INPUT}
             onChange={() => {
-                clearErrors(fiatInput);
+                clearErrors(FORM_FIAT_INPUT);
             }}
-            inputState={getInputState(errors.cryptoInput)}
+            inputState={getInputState(errors[FORM_CRYPTO_INPUT])}
             control={control}
             rules={cryptoInputRules}
             maxLength={formInputsMaxLength.amount}
-            bottomText={errors[cryptoInput]?.message || null}
+            bottomText={errors[FORM_CRYPTO_INPUT]?.message || null}
             className={className}
             hasBottomPadding={false}
             innerAddon={
                 <CoinmarketFormOptionLabel>
-                    {cryptoToCoinSymbol(getValues().cryptoSelect.value)}
+                    {cryptoToCoinSymbol(cryptoSelect?.value)}
                 </CoinmarketFormOptionLabel>
             }
             data-test="@coinmarket/form/crypto-input"

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputFiatCrypto/CoinmarketFormInputFiat.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputFiatCrypto/CoinmarketFormInputFiat.tsx
@@ -4,10 +4,21 @@ import { validateDecimals, validateMin } from 'src/utils/suite/validation';
 import { getInputState } from '@suite-common/wallet-utils';
 import { formInputsMaxLength } from '@suite-common/validators';
 import { useCoinmarketFormContext } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonForm';
-import { CoinmarketTradeBuyType } from 'src/types/coinmarket/coinmarket';
 import { useDidUpdate } from '@trezor/react-utils';
 import CoinmarketFormInputCurrency from 'src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputCurrency';
 import { CoinmarketFormInputProps } from 'src/types/coinmarket/coinmarketForm';
+import { FORM_CRYPTO_INPUT, FORM_FIAT_INPUT } from 'src/constants/wallet/coinmarket/form';
+import styled from 'styled-components';
+
+const CoinmarketFormInputCurrencyWrapper = styled(CoinmarketFormInputCurrency)`
+    width: 64px;
+
+    .react-select__indicators {
+        position: absolute;
+        top: 7px;
+        right: 4px;
+    }
+`;
 
 const CoinmarketFormInputFiat = ({ className }: CoinmarketFormInputProps) => {
     const { translationString } = useTranslation();
@@ -18,9 +29,7 @@ const CoinmarketFormInputFiat = ({ className }: CoinmarketFormInputProps) => {
         amountLimits,
         trigger,
         clearErrors,
-    } = useCoinmarketFormContext<CoinmarketTradeBuyType>();
-    const fiatInput = 'fiatInput';
-    const cryptoInput = 'cryptoInput';
+    } = useCoinmarketFormContext();
 
     const fiatInputRules = {
         validate: {
@@ -46,23 +55,23 @@ const CoinmarketFormInputFiat = ({ className }: CoinmarketFormInputProps) => {
     };
 
     useDidUpdate(() => {
-        trigger('fiatInput');
+        trigger(FORM_FIAT_INPUT);
     }, [amountLimits?.maxFiat, amountLimits?.minFiat, trigger]);
 
     if (!account) return null;
 
     return (
         <NumberInput
-            name={fiatInput}
+            name={FORM_FIAT_INPUT}
             onChange={() => {
-                clearErrors(cryptoInput);
+                clearErrors(FORM_CRYPTO_INPUT);
             }}
-            inputState={getInputState(errors.fiatInput)}
+            inputState={getInputState(errors[FORM_FIAT_INPUT])}
             control={control}
             rules={fiatInputRules}
             maxLength={formInputsMaxLength.amount}
-            bottomText={errors[fiatInput]?.message || null}
-            innerAddon={<CoinmarketFormInputCurrency />}
+            bottomText={errors[FORM_FIAT_INPUT]?.message || null}
+            innerAddon={<CoinmarketFormInputCurrencyWrapper />}
             hasBottomPadding={false}
             className={className}
             data-test="@coinmarket/form/fiat-input"

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputFiatCrypto/CoinmarketFormInputFiatCrypto.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputFiatCrypto/CoinmarketFormInputFiatCrypto.tsx
@@ -1,6 +1,5 @@
-import { useSelector, useTranslation } from 'src/hooks/suite';
+import { useTranslation } from 'src/hooks/suite';
 import { useCoinmarketFormContext } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonForm';
-import { CoinmarketTradeBuyType } from 'src/types/coinmarket/coinmarket';
 import { CoinmarketFormInputFiatCryptoProps } from 'src/types/coinmarket/coinmarketForm';
 import CoinmarketFormSwitcherCryptoFiat from 'src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormSwitcherCryptoFiat';
 import { cryptoToCoinSymbol } from 'src/utils/wallet/coinmarket/cryptoSymbolUtils';
@@ -8,41 +7,39 @@ import CoinmarketFormInputFiat from 'src/views/wallet/coinmarket/common/Coinmark
 import { CoinmarketFormInput } from 'src/views/wallet/coinmarket';
 import CoinmarketFormInputLabel from 'src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputLabel';
 import CoinmarketFormInputCrypto from 'src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputFiatCrypto/CoinmarketFormInputCrypto';
+import { coinmarketGetAmountLabels } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 
 const CoinmarketFormInputFiatCrypto = ({
     className,
     showLabel = true,
 }: CoinmarketFormInputFiatCryptoProps) => {
     const { translationString } = useTranslation();
-    const account = useSelector(state => state.wallet.selectedAccount.account);
     const {
+        type,
         form: {
-            state: { isFormLoading, toggleWantCrypto },
+            state: { isFormLoading, toggleAmountInCrypto },
         },
         getValues,
-    } = useCoinmarketFormContext<CoinmarketTradeBuyType>();
-    const { wantCrypto } = getValues();
-
-    if (!account) return null;
+    } = useCoinmarketFormContext();
+    const { amountInCrypto, cryptoSelect } = getValues();
+    const amountLabels = coinmarketGetAmountLabels({ type, amountInCrypto });
 
     return (
         <CoinmarketFormInput className={className}>
             {showLabel ? (
-                <CoinmarketFormInputLabel
-                    label={wantCrypto ? 'TR_COINMARKET_YOU_GET' : 'TR_COINMARKET_YOU_PAY'}
-                >
+                <CoinmarketFormInputLabel label={amountLabels.label1}>
                     <CoinmarketFormSwitcherCryptoFiat
                         symbol={
-                            !wantCrypto
-                                ? cryptoToCoinSymbol(getValues().cryptoSelect.value)
+                            !amountInCrypto
+                                ? cryptoToCoinSymbol(cryptoSelect?.value)
                                 : translationString('TR_COINMARKET_FIAT')
                         }
                         isDisabled={isFormLoading}
-                        toggleWantCrypto={toggleWantCrypto}
+                        toggleAmountInCrypto={toggleAmountInCrypto}
                     />
                 </CoinmarketFormInputLabel>
             ) : null}
-            {wantCrypto ? <CoinmarketFormInputCrypto /> : <CoinmarketFormInputFiat />}
+            {amountInCrypto ? <CoinmarketFormInputCrypto /> : <CoinmarketFormInputFiat />}
         </CoinmarketFormInput>
     );
 };

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputPaymentMethod.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputPaymentMethod.tsx
@@ -1,9 +1,6 @@
 import { Controller } from 'react-hook-form';
 import { Select } from '@trezor/components';
-import {
-    CoinmarketPaymentMethodListProps,
-    CoinmarketTradeBuyType,
-} from 'src/types/coinmarket/coinmarket';
+import { CoinmarketPaymentMethodListProps } from 'src/types/coinmarket/coinmarket';
 import { useCoinmarketFormContext } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonForm';
 import { CoinmarketFormInputProps } from 'src/types/coinmarket/coinmarketForm';
 import CoinmarketFormInputLabel from 'src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputLabel';
@@ -15,6 +12,7 @@ import {
 } from 'src/views/wallet/coinmarket';
 import { CoinmarketPaymentPlainType } from 'src/views/wallet/coinmarket/common/CoinmarketPaymentPlainType';
 import CoinmarketFormInputLoader from 'src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputLoader';
+import { FORM_PAYMENT_METHOD_SELECT } from 'src/constants/wallet/coinmarket/form';
 
 const CoinmarketFormInputPaymentMethod = ({ className, label }: CoinmarketFormInputProps) => {
     const {
@@ -24,16 +22,16 @@ const CoinmarketFormInputPaymentMethod = ({ className, label }: CoinmarketFormIn
         form: {
             state: { isFormLoading, isFormInvalid },
         },
-    } = useCoinmarketFormContext<CoinmarketTradeBuyType>();
+    } = useCoinmarketFormContext();
 
     return (
         <CoinmarketFormInput className={className}>
             <CoinmarketFormInputLabel label={label} />
             <CoinmarketFormInputInner>
                 <Controller
-                    name="paymentMethod"
+                    name={FORM_PAYMENT_METHOD_SELECT}
                     defaultValue={defaultPaymentMethod}
-                    control={control}
+                    control={control as any} // FIXME: any
                     render={({ field: { onChange, value } }) => (
                         <Select
                             value={value}
@@ -41,22 +39,20 @@ const CoinmarketFormInputPaymentMethod = ({ className, label }: CoinmarketFormIn
                                 onChange(selected);
                             }}
                             options={paymentMethods}
-                            formatOptionLabel={(option: CoinmarketPaymentMethodListProps) => {
-                                return (
-                                    <CoinmarketFormOption>
-                                        <CoinmarketFormOptionLabel>
-                                            {option.value !== '' ? (
-                                                <CoinmarketPaymentPlainType
-                                                    method={option.value}
-                                                    methodName={option.label}
-                                                />
-                                            ) : (
-                                                <div>{option.label}</div>
-                                            )}
-                                        </CoinmarketFormOptionLabel>
-                                    </CoinmarketFormOption>
-                                );
-                            }}
+                            formatOptionLabel={(option: CoinmarketPaymentMethodListProps) => (
+                                <CoinmarketFormOption>
+                                    <CoinmarketFormOptionLabel>
+                                        {option.value !== '' ? (
+                                            <CoinmarketPaymentPlainType
+                                                method={option.value}
+                                                methodName={option.label}
+                                            />
+                                        ) : (
+                                            <div>{option.label}</div>
+                                        )}
+                                    </CoinmarketFormOptionLabel>
+                                </CoinmarketFormOption>
+                            )}
                             data-test="@coinmarket/form/payment-method-select"
                             isClearable={false}
                             isSearchable

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormSwitcherCryptoFiat.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormSwitcherCryptoFiat.tsx
@@ -4,18 +4,18 @@ import { CoinmarketTextButton } from 'src/views/wallet/coinmarket';
 interface CoinmarketFormSwitcherCryptoFiatProps {
     symbol: string;
     isDisabled: boolean;
-    toggleWantCrypto: () => void;
+    toggleAmountInCrypto: () => void;
 }
 
 const CoinmarketFormSwitcherCryptoFiat = ({
     symbol,
     isDisabled,
-    toggleWantCrypto,
+    toggleAmountInCrypto,
 }: CoinmarketFormSwitcherCryptoFiatProps) => (
     <CoinmarketTextButton
         size="small"
         onClick={() => {
-            toggleWantCrypto();
+            toggleAmountInCrypto();
         }}
         type="button"
         isDisabled={isDisabled}

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInputs.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInputs.tsx
@@ -1,9 +1,75 @@
+import { spacingsPx } from '@trezor/theme';
+import { Fees } from 'src/components/wallet/Fees/Fees';
+import { useCoinmarketFormContext } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonForm';
+import { isCoinmarketSellOffers } from 'src/hooks/wallet/coinmarket/offers/useCoinmarketCommonOffers';
+import { CoinmarketFractionButtons } from 'src/views/wallet/coinmarket/common';
 import CoinmarketFormInputAccount from 'src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputAccount';
+import CoinmarketFormInputAccountActive from 'src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputAccountActive';
 import CoinmarketFormInputCountry from 'src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputCountry';
 import CoinmarketFormInputFiatCrypto from 'src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputFiatCrypto/CoinmarketFormInputFiatCrypto';
 import CoinmarketFormInputPaymentMethod from 'src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputPaymentMethod';
+import styled from 'styled-components';
+
+const CoinmarketFeesWrapper = styled.div`
+    margin-bottom: ${spacingsPx.md};
+`;
+
+const CoinmarketFormInputFiatCryptoSellWrapper = styled(CoinmarketFormInputFiatCrypto)`
+    padding-bottom: ${spacingsPx.xs};
+`;
+
+const CoinmarketFractionButtonsWrapper = styled(CoinmarketFractionButtons)`
+    margin-bottom: ${spacingsPx.xl};
+`;
 
 const CoinmarketFormInputs = () => {
+    const context = useCoinmarketFormContext();
+
+    if (isCoinmarketSellOffers(context)) {
+        const {
+            control,
+            feeInfo,
+            account,
+            composedLevels,
+            formState: { errors },
+            form: { helpers },
+            register,
+            setValue,
+            getValues,
+            changeFeeLevel,
+        } = context;
+        const { amountInCrypto } = getValues();
+
+        return (
+            <>
+                <CoinmarketFormInputAccountActive label="TR_COINMARKET_YOU_SELL" />
+                <CoinmarketFormInputFiatCryptoSellWrapper />
+                {amountInCrypto && (
+                    <CoinmarketFractionButtonsWrapper
+                        disabled={helpers.isBalanceZero}
+                        onFractionClick={helpers.setRatioAmount}
+                        onAllClick={helpers.setAllAmount}
+                    />
+                )}
+                <CoinmarketFeesWrapper>
+                    <Fees
+                        control={control}
+                        feeInfo={feeInfo}
+                        account={account}
+                        composedLevels={composedLevels}
+                        errors={errors}
+                        register={register}
+                        setValue={setValue}
+                        getValues={getValues}
+                        changeFeeLevel={changeFeeLevel}
+                    />
+                </CoinmarketFeesWrapper>
+                <CoinmarketFormInputPaymentMethod label="TR_COINMARKET_RECEIVE_METHOD" />
+                <CoinmarketFormInputCountry label="TR_COINMARKET_COUNTRY" />
+            </>
+        );
+    }
+
     return (
         <>
             <CoinmarketFormInputAccount label="TR_COINMARKET_YOU_BUY" />

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormOfferItem.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormOfferItem.tsx
@@ -1,7 +1,7 @@
 import { Badge, Spinner } from '@trezor/components';
 import { borders, spacingsPx, typography } from '@trezor/theme';
 import styled from 'styled-components';
-import { BuyTrade } from 'invity-api';
+import { BuyTrade, SellFiatTrade } from 'invity-api';
 import { Translation } from 'src/components/suite';
 import { CoinmarketUtilsProvidersProps } from 'src/types/coinmarket/coinmarket';
 import { CoinmarketUtilsProvider } from 'src/views/wallet/coinmarket/common/CoinmarketUtils/CoinmarketUtilsProvider';
@@ -33,10 +33,10 @@ const CoinmarketSpinnerWrapper = styled(Spinner)`
 `;
 
 interface CoinmarketFormOfferItemProps {
-    bestQuote: BuyTrade | undefined;
+    bestQuote: BuyTrade | SellFiatTrade | undefined;
     isFormLoading: boolean;
     isFormInvalid: boolean;
-    providers: CoinmarketUtilsProvidersProps;
+    providers: CoinmarketUtilsProvidersProps | undefined;
     isBestRate?: boolean;
 }
 

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketFractionButtons.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketFractionButtons.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { Button } from '@trezor/components';
 import { Translation } from 'src/components/suite';
+import { spacingsPx } from '@trezor/theme';
 
 const Wrapper = styled.div`
     display: flex;
@@ -12,7 +13,7 @@ const SmallButton = styled(Button).attrs(props => ({
     type: 'button',
     size: 'small',
 }))`
-    margin-right: 10px;
+    margin-right: ${spacingsPx.sm};
 `;
 
 interface CoinmarketFractionButtonsProps {
@@ -28,7 +29,7 @@ export const CoinmarketFractionButtons = ({
     onAllClick,
     className,
 }: CoinmarketFractionButtonsProps) => (
-    <Wrapper className={className}>
+    <Wrapper className={className} data-test="@coinmarket/form/fraction-buttons">
         <SmallButton isDisabled={disabled} onClick={() => onFractionClick(4)}>
             1/4
         </SmallButton>

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketOffers/CoinmarketOffersItem.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketOffers/CoinmarketOffersItem.tsx
@@ -160,7 +160,7 @@ const CoinmarketOffersItem = ({ quote, isBestRate }: CoinmarketOffersItemProps) 
                             isLoading={callInProgress}
                             isDisabled={!!quote.error || callInProgress}
                             onClick={() => selectQuote(quote)}
-                            data-test="@coinmarket/buy/offers/get-this-deal-button"
+                            data-test="@coinmarket/offers/get-this-deal-button"
                         >
                             <Translation
                                 id={

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOffer.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOffer.tsx
@@ -3,9 +3,14 @@ import { Card } from '@trezor/components';
 import { useCoinmarketFormContext } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonForm';
 import { spacingsPx } from '@trezor/theme';
 import { SCREEN_QUERY } from '@trezor/components/src/config/variables';
-import { CoinmarketTradeBuyType } from 'src/types/coinmarket/coinmarket';
 import CoinmarketSelectedOfferVerify from 'src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOfferVerify';
 import { CoinmarketSelectedOfferInfo } from 'src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOfferInfo';
+import { getProvidersInfoProps } from 'src/utils/wallet/coinmarket/coinmarketTypingUtils';
+import {
+    isCoinmarketBuyOffers,
+    isCoinmarketSellOffers,
+} from 'src/hooks/wallet/coinmarket/offers/useCoinmarketCommonOffers';
+import CoinmarketSelectedOfferSell from 'src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOfferSell/CoinmarketSelectedOfferSell';
 
 const Wrapper = styled.div`
     display: flex;
@@ -22,19 +27,25 @@ const StyledCard = styled(Card)`
 `;
 
 export const CoinmarketSelectedOffer = () => {
-    const { selectedQuote, buyInfo } = useCoinmarketFormContext<CoinmarketTradeBuyType>();
+    const context = useCoinmarketFormContext();
+    const { selectedQuote } = context;
+    const { providers } = getProvidersInfoProps(context);
 
     if (!selectedQuote) return null;
 
     return (
         <Wrapper>
-            <StyledCard>
-                <CoinmarketSelectedOfferVerify />
-            </StyledCard>
-            <CoinmarketSelectedOfferInfo
-                selectedQuote={selectedQuote}
-                providers={buyInfo?.providerInfos}
-            />
+            {isCoinmarketBuyOffers(context) && (
+                <StyledCard>
+                    <CoinmarketSelectedOfferVerify />
+                </StyledCard>
+            )}
+            {isCoinmarketSellOffers(context) && (
+                <StyledCard>
+                    <CoinmarketSelectedOfferSell />
+                </StyledCard>
+            )}
+            <CoinmarketSelectedOfferInfo selectedQuote={selectedQuote} providers={providers} />
         </Wrapper>
     );
 };

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOfferSell/CoinmarketSelectedOfferSell.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOfferSell/CoinmarketSelectedOfferSell.tsx
@@ -1,0 +1,40 @@
+import { Fragment } from 'react';
+import { useCoinmarketFormContext } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonForm';
+import { CoinmarketTradeSellType } from 'src/types/coinmarket/coinmarket';
+import CoinmarketSelectedOfferBankAccount from 'src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOfferSell/CoinmarketSelectedOfferSellBankAccount';
+import CoinmarketSelectedOfferSellTransaction from 'src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOfferSell/CoinmarketSelectedOfferSellTransaction';
+import CoinmarketSelectedOfferStepper, {
+    CoinmarketSelectedOfferStepperItemProps,
+} from 'src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOfferStepper';
+
+const CoinmarketSelectedOfferSell = () => {
+    const { sellStep } = useCoinmarketFormContext<CoinmarketTradeSellType>();
+
+    const steps: (CoinmarketSelectedOfferStepperItemProps & {
+        component: JSX.Element | null;
+    })[] = [
+        {
+            step: 'BANK_ACCOUNT',
+            translationId: 'TR_SELL_BANK_ACCOUNT_STEP',
+            isActive: sellStep === 'BANK_ACCOUNT',
+            component: <CoinmarketSelectedOfferBankAccount />,
+        },
+        {
+            step: 'SEND_TRANSACTION',
+            translationId: 'TR_SELL_CONFIRM_SEND_STEP',
+            isActive: sellStep === 'SEND_TRANSACTION',
+            component: <CoinmarketSelectedOfferSellTransaction />,
+        },
+    ];
+
+    return (
+        <>
+            <CoinmarketSelectedOfferStepper steps={steps} />
+            {steps.map((step, index) => (
+                <Fragment key={index}>{step.isActive && step.component}</Fragment>
+            ))}
+        </>
+    );
+};
+
+export default CoinmarketSelectedOfferSell;

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOfferSell/CoinmarketSelectedOfferSellBankAccount.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOfferSell/CoinmarketSelectedOfferSellBankAccount.tsx
@@ -1,0 +1,203 @@
+import { useState } from 'react';
+import styled, { useTheme } from 'styled-components';
+import { QuestionTooltip, Translation } from 'src/components/suite';
+import { Button, Select, Icon } from '@trezor/components';
+import { BankAccount } from 'invity-api';
+import { formatIban } from 'src/utils/wallet/coinmarket/sellUtils';
+import { CoinmarketTradeSellType } from 'src/types/coinmarket/coinmarket';
+import { useCoinmarketFormContext } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonForm';
+import { fontWeights, spacingsPx, typography } from '@trezor/theme';
+
+const Wrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    margin-top: ${spacingsPx.xs};
+`;
+
+const CardContent = styled.div`
+    display: flex;
+    flex-direction: column;
+    padding: ${spacingsPx.xl};
+`;
+
+const Label = styled.div`
+    display: flex;
+    align-items: center;
+    font-weight: ${fontWeights.medium};
+`;
+
+const StyledQuestionTooltip = styled(QuestionTooltip)`
+    padding-left: ${spacingsPx.xxxs};
+`;
+
+const CustomLabel = styled(Label)`
+    padding: ${spacingsPx.sm} 0;
+    color: ${({ theme }) => theme.textSubdued};
+`;
+
+const LabelText = styled.div``;
+
+const Option = styled.div`
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    padding: 0 0 0 ${spacingsPx.xxs};
+    width: 100%;
+`;
+
+const AccountInfo = styled.div`
+    display: flex;
+    flex-direction: column;
+    flex: 2;
+`;
+
+const AccountName = styled.div`
+    display: flex;
+    color: ${({ theme }) => theme.textSubdued};
+`;
+
+const AccountNumber = styled.div`
+    display: flex;
+    font-weight: ${fontWeights.medium};
+`;
+
+const AccountVerified = styled.div`
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    ${typography.label}
+    color: ${({ theme }) => theme.textPrimaryDefault};
+`;
+
+const AccountNotVerified = styled(AccountVerified)`
+    color: ${({ theme }) => theme.textSubdued};
+`;
+
+const ButtonWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding-top: ${spacingsPx.lg};
+    border-top: 1px solid ${({ theme }) => theme.borderElevation1};
+    margin: ${spacingsPx.lg} 0;
+`;
+
+const Row = styled.div`
+    margin: ${spacingsPx.xxs} 0;
+    display: flex;
+
+    .react-select__value-container {
+        padding-right: ${spacingsPx.lg};
+    }
+`;
+
+const Left = styled.div`
+    display: flex;
+    flex: 1;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+`;
+
+const Right = styled.div`
+    display: flex;
+`;
+
+const RegisterAnother = styled(Button)`
+    align-self: center;
+`;
+
+const StyledButton = styled(Button)`
+    display: flex;
+    min-width: 200px;
+`;
+
+const StyledIcon = styled(Icon)`
+    margin-right: ${spacingsPx.xxxs};
+`;
+
+const CoinmarketSelectedOfferSellBankAccount = () => {
+    const theme = useTheme();
+    const { callInProgress, confirmTrade, addBankAccount, selectedQuote } =
+        useCoinmarketFormContext<CoinmarketTradeSellType>();
+    const [bankAccount, setBankAccount] = useState<BankAccount | undefined>(
+        selectedQuote?.bankAccounts ? selectedQuote?.bankAccounts[0] : undefined,
+    );
+
+    if (!selectedQuote || !selectedQuote.bankAccounts) return null;
+
+    const { bankAccounts } = selectedQuote;
+
+    return (
+        <Wrapper>
+            <CardContent>
+                <Row>
+                    <Left>
+                        <CustomLabel>
+                            <LabelText>
+                                <Translation id="TR_SELL_BANK_ACCOUNT" />
+                            </LabelText>
+                            <StyledQuestionTooltip tooltip="TR_SELL_BANK_ACCOUNT_TOOLTIP" />
+                        </CustomLabel>
+                    </Left>
+                    <Right>
+                        <RegisterAnother
+                            variant="tertiary"
+                            icon="PLUS"
+                            data-test="add-output"
+                            onClick={addBankAccount}
+                        >
+                            <Translation id="TR_SELL_ADD_BANK_ACCOUNT" />
+                        </RegisterAnother>
+                    </Right>
+                </Row>
+                <Row>
+                    <Select
+                        onChange={(selected: BankAccount) => {
+                            setBankAccount(selected);
+                        }}
+                        value={bankAccount}
+                        isClearable={false}
+                        options={bankAccounts}
+                        minValueWidth="70px"
+                        formatOptionLabel={(option: BankAccount) => (
+                            <Option>
+                                <AccountInfo>
+                                    <AccountName>{option.holder}</AccountName>
+                                    <AccountNumber>{formatIban(option.bankAccount)}</AccountNumber>
+                                </AccountInfo>
+                                {option.verified ? (
+                                    <AccountVerified>
+                                        <StyledIcon
+                                            color={theme.TYPE_GREEN}
+                                            size={15}
+                                            icon="CHECK"
+                                        />
+                                        <Translation id="TR_SELL_BANK_ACCOUNT_VERIFIED" />
+                                    </AccountVerified>
+                                ) : (
+                                    <AccountNotVerified>
+                                        <Translation id="TR_SELL_BANK_ACCOUNT_NOT_VERIFIED" />
+                                    </AccountNotVerified>
+                                )}
+                            </Option>
+                        )}
+                        isDisabled={bankAccounts.length < 2}
+                    />
+                </Row>
+            </CardContent>
+            <ButtonWrapper>
+                <StyledButton
+                    isLoading={callInProgress}
+                    onClick={() => {
+                        if (bankAccount) confirmTrade(bankAccount);
+                    }}
+                    isDisabled={callInProgress || !bankAccount}
+                >
+                    <Translation id="TR_SELL_GO_TO_TRANSACTION" />
+                </StyledButton>
+            </ButtonWrapper>
+        </Wrapper>
+    );
+};
+
+export default CoinmarketSelectedOfferSellBankAccount;

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOfferSell/CoinmarketSelectedOfferSellTransaction.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOfferSell/CoinmarketSelectedOfferSellTransaction.tsx
@@ -1,0 +1,146 @@
+import styled from 'styled-components';
+import { Translation, AccountLabeling } from 'src/components/suite';
+import { Button, Spinner } from '@trezor/components';
+import { useCoinmarketWatchTrade } from 'src/hooks/wallet/coinmarket/useCoinmarketWatchTrade';
+import { CoinmarketTradeSellType } from 'src/types/coinmarket/coinmarket';
+import { useCoinmarketFormContext } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonForm';
+import { fontWeights, spacingsPx, typography } from '@trezor/theme';
+
+const Wrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    margin-top: ${spacingsPx.sm};
+`;
+
+const WaitingWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 60px ${spacingsPx.lg};
+    flex-direction: column;
+`;
+
+const LabelText = styled.div`
+    ${typography.label}
+    color: ${({ theme }) => theme.textSubdued};
+`;
+
+const Value = styled.div`
+    ${typography.body}
+    color: ${({ theme }) => theme.textDefault};
+`;
+
+const ButtonWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding-top: ${spacingsPx.lg};
+    border-top: 1px solid ${({ theme }) => theme.borderElevation1};
+    margin: ${spacingsPx.lg} 0;
+`;
+
+const Row = styled.div`
+    margin: ${spacingsPx.xl};
+`;
+
+const Address = styled.div``;
+
+const StyledButton = styled(Button)`
+    display: flex;
+    min-width: 200px;
+`;
+
+const Title = styled.div`
+    margin-top: ${spacingsPx.xl};
+    font-weight: ${fontWeights.semiBold};
+`;
+
+const CoinmarketSelectedOfferSellTransaction = () => {
+    const { account, callInProgress, selectedQuote, sellInfo, sendTransaction, trade } =
+        useCoinmarketFormContext<CoinmarketTradeSellType>();
+    useCoinmarketWatchTrade({
+        account,
+        trade,
+    });
+    const t = trade?.data || selectedQuote;
+
+    if (!t || !t.exchange) return null;
+
+    const {
+        exchange,
+        destinationAddress,
+        destinationPaymentExtraId,
+        destinationPaymentExtraIdDescription,
+        status,
+    } = t;
+    const providerName = sellInfo?.providerInfos[exchange]?.companyName || exchange;
+
+    return (
+        <Wrapper>
+            {status === 'SEND_CRYPTO' && destinationAddress ? (
+                <>
+                    <Row>
+                        <LabelText>
+                            <Translation id="TR_SELL_SEND_FROM" />
+                        </LabelText>
+                        <Value>
+                            <AccountLabeling account={account} />
+                        </Value>
+                    </Row>
+                    <Row>
+                        <LabelText>
+                            <Translation id="TR_SELL_SEND_TO" values={{ providerName }} />
+                        </LabelText>
+                        <Value>
+                            <Address>{destinationAddress}</Address>
+                        </Value>
+                    </Row>
+                    {destinationPaymentExtraId && (
+                        <Row>
+                            <LabelText>
+                                {destinationPaymentExtraIdDescription?.name ? (
+                                    <Translation
+                                        id="TR_SELL_EXTRA_FIELD"
+                                        values={{
+                                            extraFieldName:
+                                                destinationPaymentExtraIdDescription.name,
+                                        }}
+                                    />
+                                ) : (
+                                    <Translation id="DESTINATION_TAG" />
+                                )}
+                            </LabelText>
+                            <Value>
+                                <Address>{destinationPaymentExtraId}</Address>
+                            </Value>
+                        </Row>
+                    )}
+
+                    <ButtonWrapper>
+                        <StyledButton isLoading={callInProgress} onClick={sendTransaction}>
+                            <Translation id="TR_SELL_CONFIRM_ON_TREZOR_SEND" />
+                        </StyledButton>
+                    </ButtonWrapper>
+                </>
+            ) : (
+                <WaitingWrapper>
+                    <Spinner />
+                    <Title>
+                        <Translation
+                            id="TR_SELL_DETAIL_WAITING_FOR_SEND_CRYPTO"
+                            values={{ providerName }}
+                        />
+                    </Title>
+                    <Value>
+                        <Translation
+                            id="TR_SELL_DETAIL_WAITING_FOR_SEND_CRYPTO_INFO"
+                            values={{ providerName }}
+                        />
+                    </Value>
+                </WaitingWrapper>
+            )}
+        </Wrapper>
+    );
+};
+
+export default CoinmarketSelectedOfferSellTransaction;

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOfferStepper.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOfferStepper.tsx
@@ -1,0 +1,73 @@
+import { Icon } from '@trezor/components';
+import { spacingsPx, typography } from '@trezor/theme';
+import { Fragment } from 'react';
+import { Translation } from 'src/components/suite';
+import { ExtendedMessageDescriptor } from 'src/types/suite';
+import styled, { useTheme } from 'styled-components';
+
+const Header = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: ${spacingsPx.lg} ${spacingsPx.xl};
+    border-bottom: 1px solid ${({ theme }) => theme.borderElevation1};
+`;
+
+const Step = styled.div<{
+    $active: boolean;
+}>`
+    display: flex;
+    flex: 1;
+    justify-content: center;
+    ${typography.body}
+    color: ${({ $active, theme }) => ($active ? theme.textPrimaryDefault : theme.textSubdued)};
+`;
+
+const StepWrap = styled.div`
+    display: flex;
+    flex: 1;
+`;
+
+const Arrow = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    margin: 0 ${spacingsPx.xl};
+`;
+
+export interface CoinmarketSelectedOfferStepperItemProps {
+    step: string;
+    translationId: ExtendedMessageDescriptor['id'];
+    isActive: boolean;
+}
+
+interface CoinmarketSelectedOfferStepperProps {
+    steps: CoinmarketSelectedOfferStepperItemProps[];
+}
+
+const CoinmarketSelectedOfferStepper = ({ steps }: CoinmarketSelectedOfferStepperProps) => {
+    const theme = useTheme();
+
+    return (
+        <Header>
+            {steps.map((step, index) => (
+                <Fragment key={index}>
+                    <StepWrap>
+                        <Step $active={step.isActive}>
+                            <Translation id={step.translationId} />
+                        </Step>
+                    </StepWrap>
+                    {index < steps.length - 1 && (
+                        <Arrow>
+                            <Icon icon="ARROW_RIGHT" color={theme.iconSubdued} />
+                        </Arrow>
+                    )}
+                </Fragment>
+            ))}
+        </Header>
+    );
+};
+
+export default CoinmarketSelectedOfferStepper;

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOfferVerify.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOfferVerify.tsx
@@ -57,6 +57,7 @@ const Row = styled.div`
     margin: 12px 0;
 `;
 
+// TODO: refactor with exchange redesign
 const CoinmarketSelectedOfferVerify = () => {
     const { translationString } = useTranslation();
     const { callInProgress, device, verifyAddress, selectedQuote, addressVerified, goToPayment } =

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOfferVerifyOptions.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOfferVerifyOptions.tsx
@@ -53,6 +53,7 @@ const AccountType = styled.span`
     padding-left: 5px;
 `;
 
+// TODO: refactor with exchange redesign
 const CoinmarketSelectedOfferVerifyOptions = ({
     receiveNetwork,
     selectAccountOptions,

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketUtils/CoinmarketUtilsPrice.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketUtils/CoinmarketUtilsPrice.tsx
@@ -5,6 +5,8 @@ import { spacingsPx, typography } from '@trezor/theme';
 import { Translation } from 'src/components/suite';
 import { FONT_SIZE, SCREEN_QUERY } from '@trezor/components/src/config/variables';
 import { CoinmarketCryptoAmountProps } from 'src/types/coinmarket/coinmarketOffers';
+import { coinmarketGetAmountLabels } from 'src/utils/wallet/coinmarket/coinmarketUtils';
+import { useCoinmarketOffersContext } from 'src/hooks/wallet/coinmarket/offers/useCoinmarketCommonOffers';
 
 const PriceWrap = styled.div``;
 
@@ -31,22 +33,29 @@ const PriceValue = styled.div`
 `;
 
 const CoinmarketUtilsPrice = ({
-    wantCrypto,
+    amountInCrypto,
     sendAmount,
     sendCurrency,
     receiveAmount,
     receiveCurrency,
 }: CoinmarketCryptoAmountProps) => {
+    const { type } = useCoinmarketOffersContext();
+
     return (
         <PriceWrap>
             <PriceTitle>
                 <Translation
-                    id={wantCrypto ? 'TR_COINMARKET_YOU_WILL_PAY' : 'TR_COINMARKET_YOU_WILL_GET'}
+                    id={
+                        coinmarketGetAmountLabels({
+                            type,
+                            amountInCrypto: !!amountInCrypto,
+                        }).labelComparatorOffer
+                    }
                 />
             </PriceTitle>
             <PriceValueWrap>
                 <PriceValue>
-                    {wantCrypto ? (
+                    {amountInCrypto ? (
                         <CoinmarketFiatAmount amount={sendAmount} currency={sendCurrency} />
                     ) : (
                         <>

--- a/packages/suite/src/views/wallet/coinmarket/sell/offers/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/offers/index.tsx
@@ -8,7 +8,7 @@ const OffersIndex = (props: UseCoinmarketProps) => {
     const coinmarketSellOffers = useCoinmarketSellOffers(props);
 
     return (
-        <CoinmarketOffersContext.Provider value={coinmarketSellOffers}>
+        <CoinmarketOffersContext.Provider value={coinmarketSellOffers as any}>
             <Offers />
         </CoinmarketOffersContext.Provider>
     );

--- a/packages/suite/src/views/wallet/coinmarket/sell_new/CoinmarketSellForm.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell_new/CoinmarketSellForm.tsx
@@ -1,0 +1,22 @@
+import { withSelectedAccountLoaded } from 'src/components/wallet';
+import { UseCoinmarketProps } from 'src/types/coinmarket/coinmarket';
+import { CoinmarketFormContext } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonForm';
+import CoinmarketFormLayout from 'src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormLayout';
+import CoinmarketLayout from 'src/views/wallet/coinmarket/common/CoinmarketLayoutNew/CoinmarketLayout';
+import { useCoinmarketSellForm } from 'src/hooks/wallet/coinmarket/form/useCoinmarketSellForm';
+
+const CoinmarketSellFormComponent = (props: UseCoinmarketProps) => {
+    const coinmarketSellContextValues = useCoinmarketSellForm(props);
+
+    return (
+        <CoinmarketLayout selectedAccount={props.selectedAccount}>
+            <CoinmarketFormContext.Provider value={coinmarketSellContextValues}>
+                <CoinmarketFormLayout />
+            </CoinmarketFormContext.Provider>
+        </CoinmarketLayout>
+    );
+};
+
+export const CoinmarketSellForm = withSelectedAccountLoaded(CoinmarketSellFormComponent, {
+    title: 'TR_NAV_SELL',
+});

--- a/packages/suite/src/views/wallet/coinmarket/sell_new/CoinmarketSellOffers.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell_new/CoinmarketSellOffers.tsx
@@ -1,0 +1,33 @@
+import { withSelectedAccountLoaded } from 'src/components/wallet';
+import { UseCoinmarketProps } from 'src/types/coinmarket/coinmarket';
+import { CoinmarketOffersContext } from 'src/hooks/wallet/coinmarket/offers/useCoinmarketCommonOffers';
+import { CoinmarketFormContext } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonForm';
+import { useCoinmarketSellForm } from 'src/hooks/wallet/coinmarket/form/useCoinmarketSellForm';
+import { PageHeader } from 'src/components/suite/layouts/SuiteLayout';
+import { useLayout } from 'src/hooks/suite';
+import { CoinmarketFooter } from 'src/views/wallet/coinmarket/common';
+import CoinmarketOffers from 'src/views/wallet/coinmarket/common/CoinmarketOffers/CoinmarketOffers';
+import { CoinmarketSelectedOffer } from 'src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOffer';
+
+const CoinmarketSellOffersComponent = (props: UseCoinmarketProps) => {
+    const coinmarketSellFormContextValues = useCoinmarketSellForm({
+        ...props,
+        offFirstRequest: true,
+    });
+    const { selectedQuote } = coinmarketSellFormContextValues;
+
+    useLayout('Trezor Suite | Trade', () => <PageHeader backRoute="wallet-coinmarket-sell" />);
+
+    // CoinmarketOffersContext.Provider is temporary FIX
+    return (
+        <CoinmarketFormContext.Provider value={coinmarketSellFormContextValues}>
+            <CoinmarketOffersContext.Provider value={coinmarketSellFormContextValues}>
+                {!selectedQuote ? <CoinmarketOffers /> : <CoinmarketSelectedOffer />}
+                <CoinmarketFooter />
+            </CoinmarketOffersContext.Provider>
+        </CoinmarketFormContext.Provider>
+    );
+};
+export const CoinmarketSellOffers = withSelectedAccountLoaded(CoinmarketSellOffersComponent, {
+    title: 'TR_NAV_SELL',
+});

--- a/packages/suite/src/views/wallet/coinmarket/sell_new/components/CoinmarketSellOfferInfo.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell_new/components/CoinmarketSellOfferInfo.tsx
@@ -1,23 +1,17 @@
 import styled from 'styled-components';
-import { BuyTrade, BuyProviderInfo, SellFiatTrade } from 'invity-api';
-import { variables } from '@trezor/components';
+import { SellFiatTrade, SellProviderInfo } from 'invity-api';
+
+import { variables, CoinLogo } from '@trezor/components';
 import {
     CoinmarketPaymentType,
     CoinmarketProviderInfo,
     CoinmarketTransactionId,
 } from 'src/views/wallet/coinmarket/common';
-import { Translation } from 'src/components/suite';
+import { Account } from 'src/types/wallet';
+import { Translation, AccountLabeling } from 'src/components/suite';
 import { CoinmarketCryptoAmount } from 'src/views/wallet/coinmarket/common/CoinmarketCryptoAmount';
 import { CoinmarketFiatAmount } from 'src/views/wallet/coinmarket/common/CoinmarketFiatAmount';
-import {
-    cryptoToCoinSymbol,
-    cryptoToNetworkSymbol,
-    isCryptoSymbolToken,
-} from 'src/utils/wallet/coinmarket/cryptoSymbolUtils';
-import CoinmarketCoinImage from 'src/views/wallet/coinmarket/common/CoinmarketCoinImage';
-import { getCryptoQuoteAmountProps } from 'src/utils/wallet/coinmarket/coinmarketTypingUtils';
-import { useCoinmarketFormContext } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonForm';
-import { coinmarketGetAmountLabels } from 'src/utils/wallet/coinmarket/coinmarketUtils';
+import { cryptoToCoinSymbol } from 'src/utils/wallet/coinmarket/cryptoSymbolUtils';
 
 const Wrapper = styled.div`
     display: flex;
@@ -36,10 +30,6 @@ const Header = styled.div`
     margin-bottom: 5px;
     padding: 15px 24px;
     max-width: 340px;
-`;
-
-const HeaderLogo = styled(CoinmarketCoinImage)`
-    width: 24px;
 `;
 
 const AccountText = styled.div`
@@ -87,7 +77,6 @@ const Row = styled.div`
 
 const Dark = styled.div`
     display: flex;
-    align-items: center;
     justify-content: flex-end;
     flex: 1;
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
@@ -100,70 +89,61 @@ const RowWithBorder = styled(Row)`
     padding-bottom: 10px;
 `;
 
-const Amount = styled.span`
-    padding-left: 5px;
-`;
-
-const InvityCoinLogo = styled(CoinmarketCoinImage)`
-    height: 16px;
-`;
-
 const TransactionIdWrapper = styled.div`
     padding-left: 40px;
     max-width: 350px;
 `;
 
-interface CoinmarketSelectedOfferInfoProps {
-    selectedQuote: BuyTrade | SellFiatTrade;
+interface CoinmarketSellOfferInfoProps {
+    selectedQuote: SellFiatTrade;
     transactionId?: string;
     providers?: {
-        [name: string]: BuyProviderInfo;
+        [name: string]: SellProviderInfo;
     };
+    account: Account;
 }
 
-// TODO: refactor with exchange redesign
-export const CoinmarketSelectedOfferInfo = ({
+export const CoinmarketSellOfferInfo = ({
     selectedQuote,
     transactionId,
     providers,
-}: CoinmarketSelectedOfferInfoProps) => {
-    const context = useCoinmarketFormContext();
-    const { type } = context;
-    const cryptoAmountProps = getCryptoQuoteAmountProps(selectedQuote, context);
-    const { exchange, paymentMethod, paymentMethodName, fiatCurrency, fiatStringAmount } =
-        selectedQuote;
-
-    const currency = cryptoAmountProps?.receiveCurrency
-        ? cryptoToCoinSymbol(cryptoAmountProps.receiveCurrency)
-        : undefined;
-    const network =
-        cryptoAmountProps?.receiveCurrency && isCryptoSymbolToken(cryptoAmountProps.receiveCurrency)
-            ? cryptoToNetworkSymbol(cryptoAmountProps.receiveCurrency)?.toUpperCase()
-            : null;
-    const amountLabels = coinmarketGetAmountLabels({ type, amountInCrypto: true });
+    account,
+}: CoinmarketSellOfferInfoProps) => {
+    const {
+        cryptoStringAmount,
+        cryptoCurrency,
+        exchange,
+        paymentMethod,
+        paymentMethodName,
+        fiatCurrency,
+        fiatStringAmount,
+    } = selectedQuote;
 
     return (
-        <Wrapper data-test="@coinmarket/offer/info">
+        <Wrapper>
             <Info>
                 <Header>
-                    <HeaderLogo symbol={currency} />
+                    <CoinLogo symbol={account.symbol} size={16} />
                     <AccountText>
-                        {network ? (
-                            <Translation
-                                id="TR_COINMARKET_TOKEN_NETWORK"
-                                values={{
-                                    tokenName: currency,
-                                    networkName: network,
-                                }}
-                            />
-                        ) : (
-                            currency
-                        )}
+                        <AccountLabeling account={account} />
                     </AccountText>
                 </Header>
                 <Row>
                     <LeftColumn>
-                        <Translation id={amountLabels.label2} />
+                        <Translation id="TR_SELL_SPEND" />
+                    </LeftColumn>
+                    <RightColumn>
+                        <Dark>
+                            <CoinmarketCryptoAmount
+                                amount={cryptoStringAmount}
+                                symbol={cryptoToCoinSymbol(cryptoCurrency!)}
+                            />
+                        </Dark>
+                    </RightColumn>
+                </Row>
+                <RowWithBorder>
+                    <LeftColumn>
+                        <Translation id="TR_SELL_RECEIVE" />
                     </LeftColumn>
                     <RightColumn>
                         <Dark>
@@ -173,26 +153,10 @@ export const CoinmarketSelectedOfferInfo = ({
                             />
                         </Dark>
                     </RightColumn>
-                </Row>
-                <RowWithBorder>
-                    <LeftColumn>
-                        <Translation id={amountLabels.label1} />
-                    </LeftColumn>
-                    <RightColumn>
-                        <Dark>
-                            <InvityCoinLogo symbol={currency} />
-                            <Amount>
-                                <CoinmarketCryptoAmount
-                                    amount={cryptoAmountProps?.receiveAmount}
-                                    symbol={currency}
-                                />
-                            </Amount>
-                        </Dark>
-                    </RightColumn>
                 </RowWithBorder>
                 <Row>
                     <LeftColumn>
-                        <Translation id="TR_BUY_PROVIDER" />
+                        <Translation id="TR_SELL_PROVIDER" />
                     </LeftColumn>
                     <RightColumn>
                         <CoinmarketProviderInfo exchange={exchange} providers={providers} />
@@ -200,7 +164,7 @@ export const CoinmarketSelectedOfferInfo = ({
                 </Row>
                 <Row>
                     <LeftColumn>
-                        <Translation id="TR_BUY_PAID_BY" />
+                        <Translation id="TR_SELL_PAID_BY" />
                     </LeftColumn>
                     <RightColumn>
                         <CoinmarketPaymentType

--- a/packages/suite/src/views/wallet/coinmarket/sell_new/detail/Detail/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell_new/detail/Detail/index.tsx
@@ -1,0 +1,84 @@
+import styled from 'styled-components';
+
+import { Card, variables } from '@trezor/components';
+import { PageHeader } from 'src/components/suite/layouts/SuiteLayout';
+import { goto } from 'src/actions/suite/routerActions';
+import { useDispatch, useLayout } from 'src/hooks/suite';
+import PaymentPending from '../components/PaymentPending';
+import PaymentSuccessful from '../components/PaymentSuccessful';
+import PaymentFailed from '../components/PaymentFailed';
+import { CoinmarketSellOfferInfo } from '../../components/CoinmarketSellOfferInfo';
+import { useCoinmarketDetailContext } from 'src/hooks/wallet/coinmarket/useCoinmarketDetail';
+import { tradeFinalStatuses } from 'src/hooks/wallet/coinmarket/useCoinmarketWatchTrade';
+import { CoinmarketTradeSellType } from 'src/types/coinmarket/coinmarket';
+
+const Wrapper = styled.div`
+    display: flex;
+    margin-top: 20px;
+
+    @media screen and (max-width: ${variables.SCREEN_SIZE.LG}) {
+        flex-direction: column;
+    }
+`;
+
+const StyledCard = styled(Card)`
+    flex: 1;
+    padding: 0;
+`;
+
+const CoinmarketDetail = () => {
+    useLayout('Trezor Suite | Trade', () => <PageHeader backRoute="wallet-coinmarket-sell" />);
+
+    const { account, trade, info } = useCoinmarketDetailContext<CoinmarketTradeSellType>();
+    const dispatch = useDispatch();
+
+    // if trade not found, it is because user refreshed the page and stored transactionId got removed
+    // go to the default coinmarket page, the trade is shown there in the previous trades
+    if (!trade) {
+        dispatch(
+            goto('wallet-coinmarket-sell', {
+                params: {
+                    symbol: account.symbol,
+                    accountIndex: account.index,
+                    accountType: account.accountType,
+                },
+            }),
+        );
+
+        return null;
+    }
+
+    const tradeStatus = trade?.data?.status || 'PENDING';
+    const sellFiatTradeFinalStatuses = tradeFinalStatuses['sell'];
+    const showPending = !sellFiatTradeFinalStatuses.includes(tradeStatus);
+
+    const exchange = trade?.data?.exchange;
+    const provider =
+        info && info.providerInfos && exchange ? info.providerInfos[exchange] : undefined;
+    const supportUrlTemplate = provider?.statusUrl || provider?.supportUrl;
+    const supportUrl = supportUrlTemplate?.replace('{{orderId}}', trade?.data?.orderId || '');
+
+    return (
+        <Wrapper>
+            <StyledCard>
+                {tradeStatus === 'SUCCESS' && <PaymentSuccessful account={account} />}
+                {sellFiatTradeFinalStatuses.includes(tradeStatus) && tradeStatus !== 'SUCCESS' && (
+                    <PaymentFailed
+                        account={account}
+                        transactionId={trade.key}
+                        supportUrl={supportUrl}
+                    />
+                )}
+                {showPending && <PaymentPending supportUrl={supportUrl} />}
+            </StyledCard>
+            <CoinmarketSellOfferInfo
+                account={account}
+                providers={info?.providerInfos}
+                selectedQuote={trade.data}
+                transactionId={trade.key}
+            />
+        </Wrapper>
+    );
+};
+
+export default CoinmarketDetail;

--- a/packages/suite/src/views/wallet/coinmarket/sell_new/detail/components/PaymentFailed/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell_new/detail/components/PaymentFailed/index.tsx
@@ -1,0 +1,83 @@
+import styled from 'styled-components';
+
+import { Button, variables, Link, Image } from '@trezor/components';
+import { CoinmarketTransactionId } from 'src/views/wallet/coinmarket/common';
+import { useDispatch } from 'src/hooks/suite';
+import { Account } from 'src/types/wallet';
+import { Translation } from 'src/components/suite/Translation';
+import { goto } from 'src/actions/suite/routerActions';
+
+const Wrapper = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 60px 20px;
+    flex-direction: column;
+`;
+
+const Title = styled.div`
+    margin-top: 25px;
+    font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
+`;
+
+const Description = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
+    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+    margin: 17px 0 10px;
+    max-width: 310px;
+    text-align: center;
+`;
+
+const StyledLink = styled(Link)`
+    margin-top: 30px;
+    margin-bottom: 30px;
+`;
+
+interface PaymentFailedProps {
+    transactionId?: string;
+    supportUrl?: string;
+    account: Account;
+}
+
+const PaymentFailed = ({ transactionId, supportUrl, account }: PaymentFailedProps) => {
+    const dispatch = useDispatch();
+
+    const goToSell = () =>
+        dispatch(
+            goto('wallet-coinmarket-sell', {
+                params: {
+                    symbol: account.symbol,
+                    accountIndex: account.index,
+                    accountType: account.accountType,
+                },
+            }),
+        );
+
+    return (
+        <Wrapper>
+            <Image image="UNI_ERROR" />
+            <Title>
+                <Translation id="TR_SELL_DETAIL_ERROR_TITLE" />
+            </Title>
+            <Description>
+                <Translation id="TR_SELL_DETAIL_ERROR_TEXT" />
+            </Description>
+            {transactionId && <CoinmarketTransactionId transactionId={transactionId} />}
+            {supportUrl && (
+                <StyledLink href={supportUrl} target="_blank">
+                    <Button variant="tertiary">
+                        <Translation id="TR_SELL_DETAIL_ERROR_SUPPORT" />
+                    </Button>
+                </StyledLink>
+            )}
+            <Button onClick={goToSell}>
+                <Translation id="TR_SELL_DETAIL_ERROR_BUTTON" />
+            </Button>
+        </Wrapper>
+    );
+};
+
+export default PaymentFailed;

--- a/packages/suite/src/views/wallet/coinmarket/sell_new/detail/components/PaymentPending/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell_new/detail/components/PaymentPending/index.tsx
@@ -1,0 +1,42 @@
+import styled from 'styled-components';
+import { variables, Spinner, Button, Link } from '@trezor/components';
+import { Translation } from 'src/components/suite/Translation';
+
+const Wrapper = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 60px 20px;
+    flex-direction: column;
+`;
+
+const Title = styled.div`
+    margin-top: 25px;
+    font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
+`;
+
+const StyledLink = styled(Link)`
+    margin-top: 50px;
+`;
+
+interface PaymentConvertingProps {
+    supportUrl?: string;
+}
+
+const PaymentConverting = ({ supportUrl }: PaymentConvertingProps) => (
+    <Wrapper>
+        <Spinner />
+        <Title>
+            <Translation id="TR_SELL_DETAIL_PENDING_TITLE" />
+        </Title>
+        {supportUrl && (
+            <StyledLink href={supportUrl} target="_blank">
+                <Button variant="tertiary">
+                    <Translation id="TR_SELL_DETAIL_PENDING_SUPPORT" />
+                </Button>
+            </StyledLink>
+        )}
+    </Wrapper>
+);
+
+export default PaymentConverting;

--- a/packages/suite/src/views/wallet/coinmarket/sell_new/detail/components/PaymentSuccessful/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell_new/detail/components/PaymentSuccessful/index.tsx
@@ -1,0 +1,90 @@
+import styled from 'styled-components';
+import { Button, variables, Image } from '@trezor/components';
+import { Translation } from 'src/components/suite';
+import { useDispatch } from 'src/hooks/suite';
+import { Account } from 'src/types/wallet';
+import { goto } from 'src/actions/suite/routerActions';
+import { borders } from '@trezor/theme';
+
+const Wrapper = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 60px 20px;
+    flex-direction: column;
+`;
+
+const Title = styled.div`
+    margin-top: 25px;
+    font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
+`;
+
+const Description = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
+    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+    margin: 17px 0 30px;
+    max-width: 310px;
+    text-align: center;
+`;
+
+const FixedRate = styled.div`
+    display: flex;
+    flex-direction: column;
+    background-color: ${({ theme }) => theme.BG_GREY};
+    padding: 14px 18px;
+    border-radius: ${borders.radii.xs};
+    margin-bottom: 30px;
+`;
+const FixedRateHeader = styled.div`
+    font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
+    font-size: ${variables.FONT_SIZE.SMALL};
+`;
+const FixedRateMessage = styled.div`
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
+`;
+interface PaymentSuccessfulProps {
+    account: Account;
+}
+
+const PaymentSuccessful = ({ account }: PaymentSuccessfulProps) => {
+    const dispatch = useDispatch();
+
+    const goToSell = () =>
+        dispatch(
+            goto('wallet-coinmarket-sell', {
+                params: {
+                    symbol: account.symbol,
+                    accountIndex: account.index,
+                    accountType: account.accountType,
+                },
+            }),
+        );
+
+    return (
+        <Wrapper>
+            <Image image="COINMARKET_SUCCESS" />
+            <Title>
+                <Translation id="TR_SELL_DETAIL_SUCCESS_TITLE" />
+            </Title>
+            <Description>
+                <Translation id="TR_SELL_DETAIL_SUCCESS_TEXT" />
+            </Description>
+            <FixedRate>
+                <FixedRateHeader>
+                    <Translation id="TR_SELL_DETAIL_SUCCESS_FIXED_RATE_HEADER" />
+                </FixedRateHeader>
+                <FixedRateMessage>
+                    <Translation id="TR_SELL_DETAIL_SUCCESS_FIXED_RATE_MESSAGE" />
+                </FixedRateMessage>
+            </FixedRate>
+            <Button onClick={goToSell}>
+                <Translation id="TR_SELL_DETAIL_SUCCESS_BUTTON" />
+            </Button>
+        </Wrapper>
+    );
+};
+
+export default PaymentSuccessful;

--- a/packages/suite/src/views/wallet/coinmarket/sell_new/detail/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell_new/detail/index.tsx
@@ -1,0 +1,33 @@
+import styled from 'styled-components';
+import Detail from './Detail';
+import { withSelectedAccountLoaded } from 'src/components/wallet';
+import {
+    CoinmarketDetailContext,
+    useCoinmarketDetail,
+} from 'src/hooks/wallet/coinmarket/useCoinmarketDetail';
+import { UseCoinmarketProps } from 'src/types/coinmarket/coinmarket';
+
+const Wrapper = styled.div`
+    display: flex;
+    width: 100%;
+    flex-direction: column;
+`;
+
+const DetailIndex = (props: UseCoinmarketProps) => {
+    const coinmarketDetailContext = useCoinmarketDetail({
+        selectedAccount: props.selectedAccount,
+        tradeType: 'sell',
+    });
+
+    return (
+        <CoinmarketDetailContext.Provider value={coinmarketDetailContext}>
+            <Wrapper>
+                <Detail />
+            </Wrapper>
+        </CoinmarketDetailContext.Provider>
+    );
+};
+
+export default withSelectedAccountLoaded(DetailIndex, {
+    title: 'TR_NAV_SELL',
+});


### PR DESCRIPTION
# Intro
- Redesign Sell form in coinmarket
- From dropdown will be the same as Exchange (i.e. list of existing accounts and their crypto wallets with balances)
- Old files are still in the codebase (for checking the difference)

## Design before
<img width="1213" alt="obrazek" src="https://github.com/user-attachments/assets/13f9314a-b759-4b57-9782-f8aa17e38033">

## Design after
![obrazek](https://github.com/user-attachments/assets/1363be6a-b25b-4c33-be9b-60674f2df422)


Figma design: https://www.figma.com/design/xSW1knAjH25SfOmqSdNioY/Trade?node-id=6416-49846&m=dev