### PR TITLE
Chore: transport ArrayBuffer -> Buffer

### DIFF
--- a/packages/protocol/src/protocol-bridge/decode.ts
+++ b/packages/protocol/src/protocol-bridge/decode.ts
@@ -14,12 +14,11 @@ const readHeader = (buffer: Buffer) => {
 };
 
 export const decode: TransportProtocolDecode = bytes => {
-    const buffer = Buffer.from(bytes);
-    const { messageType, length } = readHeader(buffer);
+    const { messageType, length } = readHeader(bytes);
 
     return {
         messageType,
         length,
-        payload: buffer.subarray(HEADER_SIZE),
+        payload: bytes.subarray(HEADER_SIZE),
     };
 };

--- a/packages/protocol/src/protocol-v1/decode.ts
+++ b/packages/protocol/src/protocol-v1/decode.ts
@@ -21,7 +21,6 @@ const readHeaderChunked = (buffer: Buffer) => {
 };
 
 // Parses first raw input that comes from Trezor and returns some information about the whole message.
-// [compatibility]: accept Buffer just like decode does. But this would require changes in lower levels
 export const decode: TransportProtocolDecode = bytes => {
     // note: the occasionally appearing error "Attempt to access memory outside buffer bounds" comes from here in certain cases
     // when usb.transferIn (read) did not receive any data but resolved with success. bytes has byteLength 0 in this case.
@@ -29,8 +28,7 @@ export const decode: TransportProtocolDecode = bytes => {
         console.error('protocol-v1: decode: received empty buffer');
     }
 
-    const buffer = Buffer.from(bytes);
-    const { magic, sharp1, sharp2, messageType, length } = readHeaderChunked(buffer);
+    const { magic, sharp1, sharp2, messageType, length } = readHeaderChunked(bytes);
 
     if (
         magic !== MESSAGE_MAGIC_HEADER_BYTE ||
@@ -44,6 +42,6 @@ export const decode: TransportProtocolDecode = bytes => {
     return {
         length,
         messageType,
-        payload: buffer.subarray(HEADER_SIZE),
+        payload: bytes.subarray(HEADER_SIZE),
     };
 };

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -1,4 +1,4 @@
-export type TransportProtocolDecode = (bytes: ArrayBuffer) => {
+export type TransportProtocolDecode = (bytes: Buffer) => {
     length: number;
     messageType: number | string;
     payload: Buffer;

--- a/packages/transport-bridge/src/core.ts
+++ b/packages/transport-bridge/src/core.ts
@@ -61,9 +61,7 @@ export const createApi = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) => 
         data: string;
         signal: AbortSignal;
     }) => {
-        const { messageType, payload } = protocolBridge.decode(
-            new Uint8Array(Buffer.from(data, 'hex')),
-        );
+        const { messageType, payload } = protocolBridge.decode(Buffer.from(data, 'hex'));
 
         const encodedMessage = protocolV1.encode(payload, { messageType });
         const chunks = createChunks(

--- a/packages/transport/src/api/abstract.ts
+++ b/packages/transport/src/api/abstract.ts
@@ -66,7 +66,7 @@ export abstract class AbstractApi extends TypedEmitter<{
         path: string,
         signal?: AbortSignal,
     ): AsyncResultWithTypedError<
-        ArrayBuffer,
+        Buffer,
         | typeof ERRORS.DEVICE_NOT_FOUND
         | typeof ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE
         | typeof ERRORS.INTERFACE_DATA_TRANSFER

--- a/packages/transport/src/api/usb.ts
+++ b/packages/transport/src/api/usb.ts
@@ -181,7 +181,7 @@ export class UsbApi extends AbstractApi {
                 return this.error({ error: ERRORS.INTERFACE_DATA_TRANSFER });
             }
 
-            return this.success(res.data.buffer);
+            return this.success(Buffer.from(res.data.buffer));
         } catch (err) {
             this.logger?.error(`usb: device.transferIn error ${err}`);
             if (err.message === INTERFACE_DEVICE_DISCONNECTED) {

--- a/packages/transport/src/utils/receive.ts
+++ b/packages/transport/src/utils/receive.ts
@@ -5,7 +5,7 @@ import { TransportProtocol } from '@trezor/protocol';
 
 async function receiveRest(
     result: Buffer,
-    receiver: () => Promise<ArrayBuffer>,
+    receiver: () => Promise<Buffer>,
     offset: number,
     expectedLength: number,
     chunkHeader: Buffer,
@@ -24,7 +24,7 @@ async function receiveRest(
     return receiveRest(result, receiver, length, expectedLength, chunkHeader);
 }
 
-export async function receive(receiver: () => Promise<ArrayBuffer>, protocol: TransportProtocol) {
+export async function receive(receiver: () => Promise<Buffer>, protocol: TransportProtocol) {
     const data = await receiver();
     const { length, messageType, payload } = protocol.decode(data);
     const result = Buffer.alloc(length);
@@ -41,7 +41,7 @@ export async function receive(receiver: () => Promise<ArrayBuffer>, protocol: Tr
 
 export async function receiveAndParse(
     messages: Root,
-    receiver: () => Promise<ArrayBuffer>,
+    receiver: () => Promise<Buffer>,
     protocol: TransportProtocol,
 ) {
     const { messageType, payload } = await receive(receiver, protocol);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Forgotten todo, return `Buffer` instead of `ArrayBuffer` from transport api read (nodeusb/webusb)
