### PR TITLE
fix(connect-explorer): don't validate connectSrc in webextension

### DIFF
--- a/packages/connect-explorer/next.config.mjs
+++ b/packages/connect-explorer/next.config.mjs
@@ -41,6 +41,7 @@ export default withNextra({
                 ),
                 'process.env.COMMIT_HASH': JSON.stringify(commitHash),
                 'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+                'process.env.BUILD_TARGET': JSON.stringify(process.env.BUILD_TARGET),
             }),
         );
 

--- a/packages/connect-explorer/src/actions/trezorConnectActions.ts
+++ b/packages/connect-explorer/src/actions/trezorConnectActions.ts
@@ -46,6 +46,12 @@ const isRelativePath = (path: string) => {
 
 const testLoadingScript = (src: string) => {
     return new Promise((resolve, reject) => {
+        if (process.env.BUILD_TARGET === 'webextension') {
+            // Webextension does not support loading scripts in this way, we skip this check
+            resolve(null);
+
+            return;
+        }
         const script = document.createElement('script');
         script.src = src;
         script.type = 'module';

--- a/packages/connect-explorer/src/actions/trezorConnectActions.ts
+++ b/packages/connect-explorer/src/actions/trezorConnectActions.ts
@@ -142,7 +142,7 @@ export const init =
 
         // Get default coreMode from URL params (?core-mode=auto)
         const urlParams = new URLSearchParams(window.location.search);
-        const coreMode = (urlParams.get('core-mode') as ConnectOptions['coreMode']) || 'iframe';
+        const coreMode = (urlParams.get('core-mode') as ConnectOptions['coreMode']) || 'auto';
 
         const connectOptions = {
             coreMode,

--- a/packages/connect-explorer/src/pages/settings.mdx
+++ b/packages/connect-explorer/src/pages/settings.mdx
@@ -51,7 +51,7 @@ export const Settings = () => {
             name: 'coreMode',
             type: 'select',
             key: 'coreMode',
-            value: connectOptions?.coreMode || 'iframe',
+            value: connectOptions?.coreMode || 'auto',
             data: [
                 { value: 'auto', label: 'Auto' },
                 { value: 'iframe', label: 'Iframe' },

--- a/packages/connect-popup/e2e/tests/transport.test.ts
+++ b/packages/connect-popup/e2e/tests/transport.test.ts
@@ -49,12 +49,14 @@ const fixtures = [
         expect: () =>
             expect(
                 popup.getByRole('heading', { name: "Browser can't communicate with device" }),
-            ).toBeVisible(),
+            ).toBeVisible({
+                timeout: 30000,
+            }),
     },
     {
         browser: chromium,
         description: `iframe and host different origins: iframe mode -> bridge`,
-        queryString: `?trezor-connect-src=${simulatedCrossOrigin}`,
+        queryString: `?trezor-connect-src=${simulatedCrossOrigin}&core-mode=iframe`,
         before: handleSimulatedCrossOrigin,
         expect: () =>
             expect(


### PR DESCRIPTION
## Description

Don't validate connectSrc in webextension, where it's not possible to execute external scripts dynamically 