### PR TITLE
fix(connect): longer timeout for getFeatures due to suite-native performance issue

### DIFF
--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -44,6 +44,7 @@ export const extraDependencies: ExtraDependencies = mergeDeepObject(extraDepende
             lazyLoad: false,
             transportReconnect: false,
             debug: false,
+            env: 'react-native',
             popup: false,
             manifest: {
                 email: 'info@trezor.io',


### PR DESCRIPTION



<!--- Provide a general summary of your changes in the Title above -->

## Description

During app start of Suite Lite, get features could takes longer than 3s depending on view-only wallets and the phone. This is a workaround for now, we should investigate why it takes so long.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/13456
