### PR TITLE
Tiny transport fixes

### DIFF
--- a/packages/connect/src/device/DeviceCommands.ts
+++ b/packages/connect/src/device/DeviceCommands.ts
@@ -375,7 +375,7 @@ export class DeviceCommands {
             await this.transport.receive({
                 session: this.sessionId,
                 protocol: this.device.protocol,
-            });
+            }).promise;
             // throw error anyway, next call should be resolved properly
             throw error;
         }

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -359,8 +359,9 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
         transport.handleDescriptorsChange(descriptors);
         transport.listen();
 
-        if (descriptors.length > 0 && initParams.pendingTransportEvent) {
-            await this.waitForDevices(descriptors.length, 10000);
+        const awaitedDevices = descriptors.length - Object.keys(this.devices).length;
+        if (awaitedDevices > 0 && initParams.pendingTransportEvent) {
+            await this.waitForDevices(awaitedDevices, 10000);
         }
 
         return transport;
@@ -382,7 +383,6 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
 
         const onDeviceConnect = () => {
             transportStartPending--;
-            clearTimeout(autoResolveTransportEventTimeout);
             if (transportStartPending === 0) {
                 resolve();
             }


### PR DESCRIPTION
## Description

- correctly await unacquired devices in case of `pendingTransportEvent`
- don't clear autoresolve timeout after first connected device
- correctly await transport.receive in case of invalid call response