### PR TITLE
Fix karma test patterns

### DIFF
--- a/docker/docker-connect-test.sh
+++ b/docker/docker-connect-test.sh
@@ -138,7 +138,7 @@ run() {
   if [ $DOCKER = true ]; then
     runDocker
   else
-    $SCRIPT "$PATTERN"
+    $SCRIPT
   fi
 
 }

--- a/packages/connect/e2e/karma.config.js
+++ b/packages/connect/e2e/karma.config.js
@@ -1,22 +1,6 @@
 const path = require('path');
 const webpack = require('webpack');
 
-// karma doesn't have support of filter by filename pattern.
-// create custom filter from the arguments to have the same behavior in jest and karma.
-// assuming that tests are triggered by `yarn test:karma:production filename1 filename2 ...` command
-const getTestPattern = () => {
-    const root = path.resolve(__dirname, './tests');
-    const basename = __filename.split('/').reverse()[0];
-    const pos = process.argv.indexOf(`e2e/${basename}`);
-    if (process.argv[pos + 1]) {
-        // if yes add full path
-        return process.argv.slice(pos + 1).map(f => `${root}/**/${f}.test.ts`);
-    }
-
-    // else return all glob patter for all tests
-    return [`${root}/**/*.test.ts`];
-};
-
 module.exports = config => {
     config.set({
         basePath: path.resolve(__dirname, '../..'), // NOTE: "[monorepo-root]/packages", to have access to other packages
@@ -84,7 +68,10 @@ module.exports = config => {
                 served: true,
                 nocache: false,
             },
-        ].concat(getTestPattern()),
+            ...(process.env.TESTS_PATTERN || '*')
+                .split(' ')
+                .map(pattern => path.resolve(__dirname, `./tests/**/${pattern.trim()}.test.ts`)),
+        ],
 
         webpackMiddleware: {
             stats: 'errors-only',

--- a/packages/connect/e2e/tests/device/override.test.ts
+++ b/packages/connect/e2e/tests/device/override.test.ts
@@ -13,21 +13,22 @@ describe('TrezorConnect override param', () => {
         await initTrezorConnect(controller);
     });
 
+    afterEach(async () => {
+        await new Promise(resolve => setTimeout(resolve, 1000));
+    });
+
     afterAll(async () => {
         controller.dispose();
         await TrezorConnect.dispose();
     });
 
-    for (const delay of [1, 10, 100, 300, 500, 1000, 1500]) {
+    [1, 10, 100, 300, 500, 1000, 1500].forEach(delay => {
         it(`override previous call after ${delay}ms`, async () => {
             TrezorConnect.removeAllListeners();
 
-            TrezorConnect.getAddress({
+            const overriden = TrezorConnect.getAddress({
                 path: "m/44'/1'/0'/0/0",
                 showOnTrezor: true,
-            }).then(response => {
-                expect(response.success).toBe(false);
-                expect(response.payload).toMatchObject({ code: 'Method_Override' });
             });
 
             await new Promise(resolve => setTimeout(resolve, delay));
@@ -38,7 +39,10 @@ describe('TrezorConnect override param', () => {
                 showOnTrezor: false,
             });
             expect(address.success).toBe(true);
-            await new Promise(resolve => setTimeout(resolve, 1000));
+
+            const response = await overriden;
+            expect(response.success).toBe(false);
+            expect(response.payload).toMatchObject({ code: 'Method_Override' });
         });
-    }
+    });
 });

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -194,6 +194,10 @@ const initDevice = async (devicePath?: string) => {
                 device = _deviceList.getDevice(payload.device.path);
             }
         }
+    } else if (uiPromises.exists(UI.RECEIVE_DEVICE)) {
+        // In case of second method call quickly after the first one, wait for device selection
+        // (if created during the first call) even if showDeviceSelection is false now
+        await uiPromises.get(UI.RECEIVE_DEVICE);
     }
 
     if (!device) {


### PR DESCRIPTION
## Description

While (<strike>un</strike>successfully) tried to fix some e2e test, I've found out that a) despite also being passed as env variables, Karma is reading test patterns from command-line args, and b) given that the pattern passed to `indexOf` is never found (= returns -1), **all the command-line args are used for building test patterns**. It resulted in nonsensical patterns like this:
```
/trezor-suite/packages/connect/e2e/tests/**/trezor-suite/node_modules/ts-node/dist/bin.js.test.ts
/trezor-suite/packages/connect/e2e/tests/**/trezor-suite/packages/connect/e2e/run.ts.test.ts
/trezor-suite/packages/connect/e2e/tests/**/web.test.ts
```

Now only `process.env.TESTS_PATTERN` is used. The downside is that it's a bit harder to run only selected tests locally and manually as it's not possible to pass them to `yarn workspace @trezor/connect test:e2e:web` as params. But nobody probably used it like this anyway?

## Bug description

In case of second Connect call soon after the first one, it was possible for the second method to get ahead of the first one. The reason is that while the first call waits for `showDeviceSelection`'s `UI.RECEIVE_DEVICE` event (`DEVICE.CONNECT` event under the hood), the second call can continue just with acquired device (= `getFeatures` was called, but the initial run wasn't necessarily finished). Now every call waits for `UI.RECEIVE_DEVICE` **if the promise already exists**, which should be relatively safe.