### PR TITLE
fix(connect): remove superfluous space from error message

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -375,7 +375,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
                 return Promise.reject(
                     ERRORS.TypedError(
                         'Device_InitializeFailed',
-                        `Initialize failed: ${error.message} ${
+                        `Initialize failed: ${error.message}${
                             error.code ? `, code: ${error.code}` : ''
                         }`,
                     ),


### PR DESCRIPTION
fix #13560 found while checking on #13555

Probably the most influential PR I ever made. 

<img width="490" alt="image" src="https://github.com/user-attachments/assets/39dad39b-084e-420c-ac22-6b34c35db478">
