### PR TITLE
fix(connect-web): clean up in popupmanager when useUi=false

### DIFF
--- a/packages/connect-web/src/popup/index.ts
+++ b/packages/connect-web/src/popup/index.ts
@@ -390,6 +390,7 @@ export class PopupManager extends EventEmitter {
             if (this.popupPromise) {
                 this.close();
             }
+            this.unlock();
         } else if (data.type === UI.CLOSE_UI_WINDOW) {
             this.clear(false);
         }


### PR DESCRIPTION
## Description

Fix issue with calls following a non-UI call such as getSettings, where the PopupManager was not being unlocked. 

## Related Issue

Resolve #8252