### PR TITLE
fix(connect): display devices without GetFeatures support as fw requi…

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -357,7 +357,10 @@ export class Device extends TypedEmitter<DeviceEvents> {
                     ]);
                 }
             } catch (error) {
-                if (!this.inconsistent && error.message === 'GetFeatures timeout') {
+                if (
+                    !this.inconsistent &&
+                    (error.message === 'GetFeatures timeout' || error.message === 'Unknown message')
+                ) {
                     // handling corner-case T1B1 + bootloader < 1.4.0 (above)
                     // if GetFeatures fails try again
                     // this time add empty "fn" param to force Initialize message


### PR DESCRIPTION
device bootloader 1.2.5, connected to suite (in normal mode, not bootloader, bootloader seems to be handled correctly)

before 
 ![image](https://github.com/user-attachments/assets/f4f0dff4-69b3-4973-99a6-6f6b5ab2da7e)


after - using old bridge, it should still be able to update such devices. 
<img width="877" alt="image" src="https://github.com/user-attachments/assets/c737cbd2-d9fc-4ada-8146-5052d1e66e72">


related #13555 #13561