### PR TITLE
fix(suite-native): fix navigating from Connect and Unlock screen when device is connected

### DIFF
--- a/suite-native/device-manager/src/components/DeviceList.tsx
+++ b/suite-native/device-manager/src/components/DeviceList.tsx
@@ -13,6 +13,7 @@ import {
 import { analytics, EventType } from '@suite-native/analytics';
 import {
     selectDevice,
+    selectIsDeviceConnected,
     selectInstacelessUnselectedDevices,
     selectIsDeviceDiscoveryActive,
 } from '@suite-common/wallet-core';
@@ -100,17 +101,17 @@ const listStaticStyle = prepareNativeStyle(utils => ({
     ...utils.boxShadows.small,
 }));
 
-const calculateHeight = (deviceCount: number, isDiscoveryActive: boolean) => {
+const calculateHeight = (deviceCount: number, isConnectButtonVisible: boolean) => {
     'worklet';
 
     const otherDevicesHeight = deviceCount * ITEM_HEIGHT;
 
     const separatorHeight =
-        deviceCount > 0 && !isDiscoveryActive
+        deviceCount > 0 && isConnectButtonVisible
             ? 2 * SEPARATOR_VERTICAL_PADDING + SEPARATOR_HEIGHT
             : 0;
 
-    const buttonHeight = isDiscoveryActive ? 0 : BUTTON_PADDING_TOP + BUTTON_HEIGHT;
+    const buttonHeight = isConnectButtonVisible ? BUTTON_PADDING_TOP + BUTTON_HEIGHT : 0;
 
     const h =
         MANAGER_MODAL_BOTTOM_RADIUS + //top margin for radius
@@ -131,10 +132,12 @@ export const DeviceList = ({ isVisible, onSelectDevice }: DeviceListProps) => {
     const device = useSelector(selectDevice);
     const notSelectedInstancelessDevices = useSelector(selectInstacelessUnselectedDevices);
     const isDiscoveryActive = useSelector(selectIsDeviceDiscoveryActive);
+    const isDeviceConnected = useSelector(selectIsDeviceConnected);
     const opacity = useSharedValue(0);
     const height = useSharedValue(0);
 
     const hasUnselectedDevices = notSelectedInstancelessDevices.length > 0;
+    const isConnectButtonVisible = !isDiscoveryActive && !isDeviceConnected;
 
     const handleConnectDevice = () => {
         if (device) {
@@ -151,7 +154,7 @@ export const DeviceList = ({ isVisible, onSelectDevice }: DeviceListProps) => {
     };
 
     const listAnimatedStyle = useAnimatedStyle(() => {
-        const h = calculateHeight(notSelectedInstancelessDevices.length, isDiscoveryActive);
+        const h = calculateHeight(notSelectedInstancelessDevices.length, isConnectButtonVisible);
 
         height.value = isVisible ? h : 0;
         opacity.value = isVisible ? 1 : 0;
@@ -177,7 +180,7 @@ export const DeviceList = ({ isVisible, onSelectDevice }: DeviceListProps) => {
                             ),
                     )}
                 </Box>
-                {!isDiscoveryActive && (
+                {isConnectButtonVisible && (
                     <ConnectButton
                         isDividerVisible={hasUnselectedDevices}
                         onPress={handleConnectDevice}

--- a/suite-native/device-manager/src/components/DeviceList.tsx
+++ b/suite-native/device-manager/src/components/DeviceList.tsx
@@ -163,7 +163,7 @@ export const DeviceList = ({ isVisible, onSelectDevice }: DeviceListProps) => {
             opacity: withTiming(opacity.value, { duration: ANIMATION_DURATION }),
             height: withTiming(height.value, { duration: ANIMATION_DURATION }),
         };
-    }, [isVisible]);
+    }, [isVisible, isConnectButtonVisible]);
 
     return (
         <Animated.View style={listAnimatedStyle}>


### PR DESCRIPTION

## Description

Navigate out of Connect & Unlock screen if selected device is connected.
Also hide the button to Connect & Unlock screen if selected device is already connected to prevent immediate navigation back...

I use `goBack` instead of navigating to dashboard to keep it more general and allow to go back to settings, where the Device Switcher is also available.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/13198

## Screenshots:

https://github.com/user-attachments/assets/59c8f380-bb0f-4222-bac7-941a3fcb8e93


