### PR TITLE
fix(suite-native): handle font scale to make elements visible

### DIFF
--- a/suite-native/device-manager/src/components/DeviceAction.tsx
+++ b/suite-native/device-manager/src/components/DeviceAction.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 import { Pressable } from 'react-native';
 
-import { HStack } from '@suite-native/atoms';
+import { HStack, ACCESSIBILITY_FONTSIZE_MULTIPLIER } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 type DeviceActionProps = {
@@ -16,7 +16,7 @@ const contentStyle = prepareNativeStyle(utils => ({
     paddingHorizontal: utils.spacings.medium,
     paddingVertical: 12,
     alignItems: 'center',
-    height: 44,
+    height: 44 * ACCESSIBILITY_FONTSIZE_MULTIPLIER,
     gap: utils.spacings.small,
     backgroundColor: utils.colors.backgroundSurfaceElevation1,
     borderWidth: utils.borders.widths.small,

--- a/suite-native/device-manager/src/components/DeviceItem/DeviceItemContent.tsx
+++ b/suite-native/device-manager/src/components/DeviceItem/DeviceItemContent.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 
-import { HStack, Box } from '@suite-native/atoms';
+import { HStack, Box, ACCESSIBILITY_FONTSIZE_MULTIPLIER } from '@suite-native/atoms';
 import { Translation, useTranslate } from '@suite-native/intl';
 import {
     selectDeviceByState,
@@ -31,7 +31,7 @@ export type DeviceItemContentProps = {
 
 const contentWrapperStyle = prepareNativeStyle<{ height: number }>((utils, { height }) => ({
     flexShrink: 1,
-    height,
+    height: height * ACCESSIBILITY_FONTSIZE_MULTIPLIER,
     alignItems: 'center',
     spacing: utils.spacings.medium,
 }));

--- a/suite-native/device-manager/src/components/DeviceList.tsx
+++ b/suite-native/device-manager/src/components/DeviceList.tsx
@@ -16,7 +16,13 @@ import {
     selectInstacelessUnselectedDevices,
     selectIsDeviceDiscoveryActive,
 } from '@suite-common/wallet-core';
-import { Button, Box, TextDivider, VStack } from '@suite-native/atoms';
+import {
+    Button,
+    Box,
+    TextDivider,
+    VStack,
+    ACCESSIBILITY_FONTSIZE_MULTIPLIER,
+} from '@suite-native/atoms';
 import { TrezorDevice } from '@suite-common/suite-types';
 import { Translation } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
@@ -44,8 +50,8 @@ type ConnectButtonProps = {
 const ANIMATION_DURATION = 300;
 
 const DEVICE_LIST_TOP_MARGIN = 300; // This is so the bg is consistent even if the device list is dragged down while scrolling
-const ITEM_HEIGHT = 66;
-const BUTTON_HEIGHT = 48;
+const ITEM_HEIGHT = 66 * ACCESSIBILITY_FONTSIZE_MULTIPLIER;
+const BUTTON_HEIGHT = 48 * ACCESSIBILITY_FONTSIZE_MULTIPLIER;
 const BUTTON_PADDING_TOP = 8;
 const PADDING_TOP = 12;
 const PADDING_BOTTOM = 16;

--- a/suite-native/device-manager/src/components/DeviceManagerContent.tsx
+++ b/suite-native/device-manager/src/components/DeviceManagerContent.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { Dimensions, ScrollView } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { HStack, VStack } from '@suite-native/atoms';
+import { VStack, Stack, ACCESSIBILITY_FONTSIZE_MULTIPLIER } from '@suite-native/atoms';
 import {
     PORTFOLIO_TRACKER_DEVICE_ID,
     selectDevice,
@@ -106,10 +106,15 @@ export const DeviceManagerContent = () => {
                 {!isPortfolioTrackerDevice && (
                     <VStack spacing={12} paddingTop="large">
                         <WalletList onSelectDevice={handleSelectDevice} />
-                        <HStack style={applyStyle(deviceButtonsStyle)}>
+                        <Stack
+                            orientation={
+                                ACCESSIBILITY_FONTSIZE_MULTIPLIER > 1 ? 'vertical' : 'horizontal'
+                            }
+                            style={applyStyle(deviceButtonsStyle)}
+                        >
                             <DeviceInfoButton showAsFullWidth={!isAddHiddenWalletButtonVisible} />
                             {isAddHiddenWalletButtonVisible && <AddHiddenWalletButton />}
-                        </HStack>
+                        </Stack>
                     </VStack>
                 )}
             </ScrollView>


### PR DESCRIPTION

## Description

Quick fixes only, not perfect.

## Screenshots:

___

BEFORE

https://github.com/user-attachments/assets/75b8d94f-b154-4e39-93dc-10fb35babe98

<img width="346" alt="image" src="https://github.com/user-attachments/assets/c4a41df5-d84b-409b-8560-39b93311c0e3">
<img width="347" alt="image" src="https://github.com/user-attachments/assets/d8b96525-b56b-4c76-ab02-8d79c258221f">

___

AFTER

https://github.com/user-attachments/assets/bf6c7c2c-6f82-4cb9-80b8-9f4709d62aa8

<img width="347" alt="image" src="https://github.com/user-attachments/assets/1aeb19f9-ada5-4fb0-be97-534b19e38962">


