### PR TITLE
Fix/transport usb abort

### DIFF
--- a/packages/transport-test/e2e/api/utils.ts
+++ b/packages/transport-test/e2e/api/utils.ts
@@ -16,7 +16,12 @@ export const buildMessage = (message: keyof typeof MESSAGES) => {
 export const assertMessage = (message: Buffer, expected: keyof typeof MESSAGES) => {
     const assertedChunk = message.toString('hex').substring(0, MAGIC.length + 2);
     if (assertedChunk !== `${MAGIC}${MESSAGES[expected]}`) {
-        throw new Error(error(`Expected message ${expected} but got ${assertedChunk}`));
+        const unexpected = Object.entries(MESSAGES).find(
+            ([, v]) => v === assertedChunk.replace(MAGIC, ''),
+        )?.[0];
+        throw new Error(
+            error(`Expected message ${expected} but got ${unexpected || assertedChunk}`),
+        );
     }
 };
 export function assertSuccess(result: any): asserts result is { success: true; payload: any } {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. fix memory leak (MaxListenersExceededWarning: Possible EventTarget memory leak detected. 11 abort listeners added to [AbortSignal]) in case when received/send message >= 10 chunks. i've tested it on DebugLinkGetState (require custom FW build) but i suppose it could be tested on some SignMessage (?)

2. fix endless read (device.transferIn) when aborted. testing scenario:
 - call transport.read
 - cancel transport read using abort signal
 - call transport.call('GetFeaures', {})
 
 
 NOTE: commit 2 needs more testing on different environments (windows, linux, mac, chromeos, webusb atd)  
