### PR TITLE
feat(solana): validate solana amount with rent

### DIFF
--- a/docs/packages/suite/send.md
+++ b/docs/packages/suite/send.md
@@ -50,6 +50,7 @@
 -   AMOUNT_IS_LESS_THAN_RESERVE (XRP only: trying to send less XRP than required reserve to the empty account)
 -   AMOUNT_IS_NOT_IN_RANGE_DECIMALS (amount with invalid decimal places)
 -   AMOUNT_IS_NOT_INTEGER (ERC20 only: token doesn't accept decimal places)
+-   REMAINING_BALANCE_LESS_THAN_RENT (solana only: account has to keep a minimal balance equal to rent)
 
 ---
 

--- a/packages/blockchain-link-types/src/common.ts
+++ b/packages/blockchain-link-types/src/common.ts
@@ -206,6 +206,7 @@ export interface AccountInfo {
         };
         // SOL
         owner?: string; // The Solana program owning the account
+        rent?: number; // The rent required for the account to opened
     };
     page?: {
         // blockbook and blockfrost

--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -190,6 +190,9 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
 
     const balance = await api.getBalance(publicKey);
 
+    // https://solana.stackexchange.com/a/13102
+    const rent = await api.getMinimumBalanceForRentExemption(accountInfo?.data.byteLength || 0);
+
     const account: AccountInfo = {
         descriptor: payload.descriptor,
         balance: balance.toString(),
@@ -213,6 +216,7 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
             ? {
                   misc: {
                       owner: accountInfo.owner.toString(),
+                      rent,
                   },
               }
             : {}),

--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -123,7 +123,9 @@ export const SOL_ACCOUNT = {
         key: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF-sol-deviceState',
         balance: '10000000000', // 10 SOL
         availableBalance: '10000000000', // 10 SOL
-        misc: {},
+        misc: {
+            rent: 10,
+        },
         history: {},
         tokens: [],
     },

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5595,6 +5595,11 @@ export default defineMessages({
         defaultMessage: 'Not enough {symbol} to cover transaction fee',
         id: 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE',
     },
+    REMAINING_BALANCE_LESS_THAN_RENT: {
+        defaultMessage:
+            'Sending this amount would leave your account with {remainingSolBalance} SOL, balance of a non-empty account has to be more then {rent} SOL',
+        id: 'REMAINING_BALANCE_LESS_THAN_RENT',
+    },
     OP_RETURN: {
         id: 'OP_RETURN',
         defaultMessage: 'OP RETURN',

--- a/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
@@ -54,9 +54,9 @@ const calculate = (
     }
 
     // total SOL spent (amount + fee), in case of SPL token only the fee
-    const totalSpent = new BigNumber(calculateTotal(token ? '0' : amount, feeInLamports));
+    const totalSolSpent = new BigNumber(calculateTotal(token ? '0' : amount, feeInLamports));
 
-    if (totalSpent.isGreaterThan(availableBalance)) {
+    if (totalSolSpent.isGreaterThan(availableBalance)) {
         const error = token ? 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE' : 'AMOUNT_IS_NOT_ENOUGH';
 
         // errorMessage declared later
@@ -65,7 +65,7 @@ const calculate = (
 
     const payloadData: PrecomposedTransaction = {
         type: 'nonfinal',
-        totalSpent: token ? amount : totalSpent.toString(),
+        totalSpent: token ? amount : totalSolSpent.toString(),
         max,
         fee: feeInLamports,
         feePerByte: feeLevel.feePerUnit,

--- a/suite-common/wallet-types/src/account.ts
+++ b/suite-common/wallet-types/src/account.ts
@@ -59,7 +59,9 @@ type AccountNetworkSpecific =
       }
     | {
           networkType: 'solana';
-          misc: undefined;
+          misc: {
+              rent?: number;
+          };
           marker: undefined;
           page: AccountInfo['page'];
       };

--- a/suite-common/wallet-types/src/transaction.ts
+++ b/suite-common/wallet-types/src/transaction.ts
@@ -29,7 +29,8 @@ type PrecomposedTransactionErrorExtended =
               | 'AMOUNT_IS_NOT_ENOUGH'
               | 'AMOUNT_IS_TOO_LOW'
               | 'AMOUNT_IS_LESS_THAN_RESERVE'
-              | 'TR_STAKE_NOT_ENOUGH_FUNDS';
+              | 'TR_STAKE_NOT_ENOUGH_FUNDS'
+              | 'REMAINING_BALANCE_LESS_THAN_RENT';
       };
 
 export type PrecomposedTransactionCardanoNonFinal =

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -745,7 +745,7 @@ export const getAccountSpecific = (
     if (networkType === 'solana') {
         return {
             networkType,
-            misc: undefined,
+            misc: { rent: misc?.rent },
             marker: undefined,
             page: accountInfo.page,
         };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 
- fetch necessary rent for non-empty solana accounts
- validate in send modal that remaining solana will be zero or more than rent 

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
