### PR TITLE
fix(suite-native): open links via useOpenLink to catch errors

### DIFF
--- a/suite-native/link/src/useOpenLink.ts
+++ b/suite-native/link/src/useOpenLink.ts
@@ -6,19 +6,30 @@ import { useToast } from '@suite-native/toasts';
 export const useOpenLink = () => {
     const { showToast } = useToast();
 
+    const showErrorToast = useCallback(() => {
+        showToast({
+            variant: 'error',
+            icon: 'warningTriangle',
+            message: 'Unable to open the link',
+        });
+    }, [showToast]);
+
     const handleOpenLink = useCallback(
         async (href: string) => {
             try {
+                const canOpenURL = await Linking.canOpenURL(href);
+
+                if (!canOpenURL) {
+                    showErrorToast();
+
+                    return;
+                }
                 await Linking.openURL(href);
             } catch {
-                showToast({
-                    variant: 'error',
-                    icon: 'warningTriangle',
-                    message: 'Unable to open the link',
-                });
+                showErrorToast();
             }
         },
-        [showToast],
+        [showErrorToast],
     );
 
     return handleOpenLink;

--- a/suite-native/message-system/src/components/FeatureMessageScreen.tsx
+++ b/suite-native/message-system/src/components/FeatureMessageScreen.tsx
@@ -1,4 +1,3 @@
-import { Linking } from 'react-native';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { A, G } from '@mobily/ts-belt';
@@ -9,6 +8,7 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { Variant } from '@suite-common/suite-types';
 import { messageSystemActions, selectActiveFeatureMessages } from '@suite-common/message-system';
 import { Translation } from '@suite-native/intl';
+import { useOpenLink } from '@suite-native/link';
 
 const screenStyle = prepareNativeStyle(utils => ({
     flexGrow: 1,
@@ -48,6 +48,7 @@ const iconVariantMap = {
 
 export const FeatureMessageScreen = () => {
     const dispatch = useDispatch();
+    const openLink = useOpenLink();
 
     const activeFeatureMessages = useSelector(selectActiveFeatureMessages);
     const firstFeatureMessage = A.head(activeFeatureMessages);
@@ -81,7 +82,7 @@ export const FeatureMessageScreen = () => {
 
     const handleCtaPress = () => {
         if (isExternalCta && ctaLink) {
-            Linking.openURL(ctaLink);
+            openLink(ctaLink);
         } else {
             // TODO: handle internal link once we introduce them
         }

--- a/suite-native/transactions/src/screens/TransactionDetailScreen.tsx
+++ b/suite-native/transactions/src/screens/TransactionDetailScreen.tsx
@@ -1,6 +1,5 @@
 import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { Linking } from 'react-native';
 
 import { Box, Button, Divider, VStack } from '@suite-native/atoms';
 import {
@@ -20,6 +19,7 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { analytics, EventType } from '@suite-native/analytics';
 import { EthereumTokenTransfer, WalletAccountTransaction } from '@suite-native/ethereum-tokens';
 import { TokenAddress, TokenSymbol } from '@suite-common/wallet-types';
+import { useOpenLink } from '@suite-native/link';
 
 import { TransactionDetailHeader } from '../components/TransactionDetail/TransactionDetailHeader';
 import { TransactionDetailData } from '../components/TransactionDetail/TransactionDetailData';
@@ -34,6 +34,7 @@ export const TransactionDetailScreen = ({
 }: StackProps<RootStackParamList, RootStackRoutes.TransactionDetail>) => {
     const { applyStyle, utils } = useNativeStyles();
     const { txid, accountKey, tokenTransfer } = route.params;
+    const openLink = useOpenLink();
     const transaction = useSelector((state: TransactionsRootState) =>
         selectTransactionByTxidAndAccountKey(state, txid, accountKey),
     ) as WalletAccountTransaction;
@@ -58,7 +59,7 @@ export const TransactionDetailScreen = ({
     const handleOpenBlockchain = () => {
         if (!blockchainExplorer) return;
         analytics.report({ type: EventType.TransactionDetailExploreInBlockchain });
-        Linking.openURL(`${blockchainExplorer.tx}${transaction.txid}`);
+        openLink(`${blockchainExplorer.tx}${transaction.txid}`);
     };
 
     const isTokenTransaction = !!tokenTransfer;


### PR DESCRIPTION
Open links via useOpenLink and show toast on failed links.


Resolve [#105](https://github.com/trezor/trezor-suite-private/issues/105)