### PR TITLE
docs(suite-desktop): use mac-arm as default in build instructions

### DIFF
--- a/packages/suite-desktop/README.md
+++ b/packages/suite-desktop/README.md
@@ -42,13 +42,15 @@ _Note: On Debian, CentOS and similar distributions you might need to add a `--no
 yarn workspace @trezor/suite-desktop build:mac
 ```
 
-Go to `./packages/suite-desktop/build-electron/mac` and open the app
+Go to `./packages/suite-desktop/build-electron/mac-arm64` and open the app
 
 or start the app from terminal:
 
 ```
-./packages/suite-desktop/build-electron/mac/Trezor\ Suite.app/Contents/MacOS/Trezor\ Suite
+./packages/suite-desktop/build-electron/mac-arm64/Trezor\ Suite.app/Contents/MacOS/Trezor\ Suite
 ```
+
+Drop the `-arm64` suffix if you are using an Intel Mac.
 
 ### Windows
 


### PR DESCRIPTION
Most people have ARM Macs now, this makes it easier to copy-paste the commands.