### PR TITLE
Chore/transport bridge types

### DIFF
--- a/packages/node-utils/src/index.ts
+++ b/packages/node-utils/src/index.ts
@@ -6,7 +6,8 @@ export {
     allowReferers,
     parseBodyJSON,
     parseBodyText,
-    type Handler,
+    type RequestHandler,
+    type ParamsValidatorHandler,
     type RequestWithParams,
     type Response,
 } from './http';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Some typescript black magic to get strongly typed request handlers with params and body validation.

Resolve: https://github.com/trezor/trezor-suite/issues/13593

Rules:
- params validator (ParamsValidatorHandler) needs to be defined as first handler on the list, otherwise `request.params` will be `unknown`
- body types are inherited from the next-to-last handler, if it is not defined then `request.body` will be `unknown`
- last handler (ResolveHandler) does not have `next` (3rd) argument

TODO:
- [x] params validators
- [x] body validators
- [x] parseBodyJSON on error (marked as TODO)



