### PR TITLE
fix(connect-web): don't fallback to core in popup with no webusb

### DIFF
--- a/packages/connect-web/src/impl/core-in-iframe.ts
+++ b/packages/connect-web/src/impl/core-in-iframe.ts
@@ -180,7 +180,11 @@ export class CoreInIframe implements ConnectFactoryDependencies {
             iframe.postMessage({ id: promiseId, type: TRANSPORT.GET_INFO });
             const response = await promise;
             this._log.debug('Bridge availability response', response);
-            if (response.payload === undefined) {
+            if (
+                response.payload === undefined &&
+                navigator.usb &&
+                this._settings.transports?.includes('WebUsbTransport')
+            ) {
                 throw ERRORS.TypedError('Transport_Missing');
             }
         }


### PR DESCRIPTION
## Description

Slight afterthought with `coreMode: auto`. 

When using a browser that doesn't support webUSB or when it's explicitly disabled by settings, we shouldn't switch to popup since it doesn't provide any benefit. 

If there are iframe loading issues it will still switch. 

Also cleans up the error handling function. 