### PR TITLE
refactor(suite): refactor frameProps

### DIFF
--- a/packages/components/src/components/Badge/Badge.stories.tsx
+++ b/packages/components/src/components/Badge/Badge.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { Badge as BadgeComponent, BadgeProps, allowedFrameProps } from './Badge';
+import { Badge as BadgeComponent, BadgeProps, allowedBadgeFrameProps } from './Badge';
 import { getFramePropsStory } from '../common/frameProps';
 
 const meta: Meta = {
@@ -11,7 +11,7 @@ export default meta;
 export const Badge: StoryObj<BadgeProps> = {
     args: {
         children: 'Badge label',
-        ...getFramePropsStory(allowedFrameProps).args,
+        ...getFramePropsStory(allowedBadgeFrameProps).args,
     },
-    argTypes: getFramePropsStory(allowedFrameProps).argTypes,
+    argTypes: getFramePropsStory(allowedBadgeFrameProps).argTypes,
 };

--- a/packages/components/src/components/Badge/Badge.stories.tsx
+++ b/packages/components/src/components/Badge/Badge.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { Badge as BadgeComponent, BadgeProps } from './Badge';
-import { framePropsStory } from '../common/frameProps';
+import { Badge as BadgeComponent, BadgeProps, allowedFrameProps } from './Badge';
+import { getFramePropsStory } from '../common/frameProps';
 
 const meta: Meta = {
     title: 'Misc/Badge',
@@ -11,7 +11,7 @@ export default meta;
 export const Badge: StoryObj<BadgeProps> = {
     args: {
         children: 'Badge label',
-        ...framePropsStory.args,
+        ...getFramePropsStory(allowedFrameProps).args,
     },
-    argTypes: framePropsStory.argTypes,
+    argTypes: getFramePropsStory(allowedFrameProps).argTypes,
 };

--- a/packages/components/src/components/Badge/Badge.tsx
+++ b/packages/components/src/components/Badge/Badge.tsx
@@ -5,12 +5,16 @@ import { Icon } from '@suite-common/icons/src/webComponents';
 import { borders, Color, CSSColor, spacings, spacingsPx, typography } from '@trezor/theme';
 import { focusStyleTransition, getFocusShadowStyle } from '../../utils/utils';
 import type { UISize, UIVariant } from '../../config/types';
-import { FrameProps, TransientFrameProps, withFrameProps } from '../common/frameProps';
+import { FrameProps, withFrameProps } from '../common/frameProps';
+import { TransientProps } from '../../utils/transientProps';
+
+export const allowedFrameProps: (keyof FrameProps)[] = ['margin'];
+type AllowedFrameProps = Pick<FrameProps, (typeof allowedFrameProps)[number]>;
 
 type BadgeSize = Extract<UISize, 'tiny' | 'small' | 'medium'>;
 type BadgeVariant = Extract<UIVariant, 'primary' | 'tertiary' | 'destructive'>;
 
-export type BadgeProps = FrameProps & {
+export type BadgeProps = AllowedFrameProps & {
     size?: BadgeSize;
     variant?: BadgeVariant;
     isDisabled?: boolean;
@@ -31,7 +35,7 @@ type BadgeContainerProps = {
     $variant: BadgeVariant;
     $hasAlert: boolean;
     $inline: boolean;
-} & TransientFrameProps;
+} & TransientProps<AllowedFrameProps>;
 
 const mapVariantToBackgroundColor = ({ $variant, theme }: MapArgs): CSSColor => {
     const colorMap: Record<BadgeVariant, Color> = {

--- a/packages/components/src/components/Badge/Badge.tsx
+++ b/packages/components/src/components/Badge/Badge.tsx
@@ -5,10 +5,10 @@ import { Icon } from '@suite-common/icons/src/webComponents';
 import { borders, Color, CSSColor, spacings, spacingsPx, typography } from '@trezor/theme';
 import { focusStyleTransition, getFocusShadowStyle } from '../../utils/utils';
 import type { UISize, UIVariant } from '../../config/types';
-import { FrameProps, withFrameProps } from '../common/frameProps';
+import { FrameProps, FramePropsKeys, withFrameProps } from '../common/frameProps';
 import { TransientProps } from '../../utils/transientProps';
 
-export const allowedBadgeFrameProps: (keyof FrameProps)[] = ['margin'];
+export const allowedBadgeFrameProps: FramePropsKeys[] = ['margin'];
 type AllowedFrameProps = Pick<FrameProps, (typeof allowedBadgeFrameProps)[number]>;
 
 type BadgeSize = Extract<UISize, 'tiny' | 'small' | 'medium'>;

--- a/packages/components/src/components/Badge/Badge.tsx
+++ b/packages/components/src/components/Badge/Badge.tsx
@@ -8,8 +8,8 @@ import type { UISize, UIVariant } from '../../config/types';
 import { FrameProps, withFrameProps } from '../common/frameProps';
 import { TransientProps } from '../../utils/transientProps';
 
-export const allowedFrameProps: (keyof FrameProps)[] = ['margin'];
-type AllowedFrameProps = Pick<FrameProps, (typeof allowedFrameProps)[number]>;
+export const allowedBadgeFrameProps: (keyof FrameProps)[] = ['margin'];
+type AllowedFrameProps = Pick<FrameProps, (typeof allowedBadgeFrameProps)[number]>;
 
 type BadgeSize = Extract<UISize, 'tiny' | 'small' | 'medium'>;
 type BadgeVariant = Extract<UIVariant, 'primary' | 'tertiary' | 'destructive'>;

--- a/packages/components/src/components/Box/Box.stories.tsx
+++ b/packages/components/src/components/Box/Box.stories.tsx
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
 import { Meta, StoryObj } from '@storybook/react';
-import { Box as BoxComponent } from './Box';
+import { allowedFrameProps, Box as BoxComponent } from './Box';
 import { FONT_WEIGHT } from '../../config/variables';
-import { framePropsStory } from '../common/frameProps';
+import { getFramePropsStory } from '../common/frameProps';
 
 const Text = styled.div`
     font-weight: ${FONT_WEIGHT.DEMI_BOLD};
@@ -42,6 +42,6 @@ export const Box: StoryObj = {
             </Wrapper>
         </>
     ),
-    args: framePropsStory.args,
-    argTypes: framePropsStory.argTypes,
+    args: getFramePropsStory(allowedFrameProps).args,
+    argTypes: getFramePropsStory(allowedFrameProps).argTypes,
 };

--- a/packages/components/src/components/Box/Box.stories.tsx
+++ b/packages/components/src/components/Box/Box.stories.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { Meta, StoryObj } from '@storybook/react';
-import { allowedFrameProps, Box as BoxComponent } from './Box';
+import { allowedBoxFrameProps, Box as BoxComponent } from './Box';
 import { FONT_WEIGHT } from '../../config/variables';
 import { getFramePropsStory } from '../common/frameProps';
 
@@ -42,6 +42,6 @@ export const Box: StoryObj = {
             </Wrapper>
         </>
     ),
-    args: getFramePropsStory(allowedFrameProps).args,
-    argTypes: getFramePropsStory(allowedFrameProps).argTypes,
+    args: getFramePropsStory(allowedBoxFrameProps).args,
+    argTypes: getFramePropsStory(allowedBoxFrameProps).argTypes,
 };

--- a/packages/components/src/components/Box/Box.tsx
+++ b/packages/components/src/components/Box/Box.tsx
@@ -32,14 +32,17 @@ const mapVariantToBackgroundColor = ({ variant, theme }: MapArgs): CSSColor => {
     return theme[colorMap[variant]];
 };
 
-export type BoxProps = FrameProps & {
+export const allowedFrameProps: (keyof FrameProps)[] = ['margin', 'maxWidth'];
+type AllowedFrameProps = Pick<FrameProps, (typeof allowedFrameProps)[number]>;
+
+export type BoxProps = AllowedFrameProps & {
     variant?: BoxVariant;
     children: ReactNode;
     forceElevation?: Elevation;
 };
 
 const Wrapper = styled.div<
-    { $variant?: BoxVariant; $elevation: Elevation } & TransientProps<FrameProps>
+    { $variant?: BoxVariant; $elevation: Elevation } & TransientProps<AllowedFrameProps>
 >`
     display: flex;
     align-items: center;

--- a/packages/components/src/components/Box/Box.tsx
+++ b/packages/components/src/components/Box/Box.tsx
@@ -32,8 +32,8 @@ const mapVariantToBackgroundColor = ({ variant, theme }: MapArgs): CSSColor => {
     return theme[colorMap[variant]];
 };
 
-export const allowedFrameProps: (keyof FrameProps)[] = ['margin', 'maxWidth'];
-type AllowedFrameProps = Pick<FrameProps, (typeof allowedFrameProps)[number]>;
+export const allowedBoxFrameProps: (keyof FrameProps)[] = ['margin', 'maxWidth'];
+type AllowedFrameProps = Pick<FrameProps, (typeof allowedBoxFrameProps)[number]>;
 
 export type BoxProps = AllowedFrameProps & {
     variant?: BoxVariant;

--- a/packages/components/src/components/Box/Box.tsx
+++ b/packages/components/src/components/Box/Box.tsx
@@ -11,7 +11,7 @@ import {
 } from '@trezor/theme';
 import { ElevationContext, useElevation } from '../ElevationContext/ElevationContext';
 import { UIVariant } from '../../config/types';
-import { FrameProps, withFrameProps } from '../common/frameProps';
+import { FrameProps, FramePropsKeys, withFrameProps } from '../common/frameProps';
 import { TransientProps, makePropsTransient } from '../../utils/transientProps';
 
 type BoxVariant = Extract<UIVariant, 'primary' | 'warning' | 'destructive' | 'info'>;
@@ -32,7 +32,7 @@ const mapVariantToBackgroundColor = ({ variant, theme }: MapArgs): CSSColor => {
     return theme[colorMap[variant]];
 };
 
-export const allowedBoxFrameProps: (keyof FrameProps)[] = ['margin', 'maxWidth'];
+export const allowedBoxFrameProps: FramePropsKeys[] = ['margin', 'maxWidth'];
 type AllowedFrameProps = Pick<FrameProps, (typeof allowedBoxFrameProps)[number]>;
 
 export type BoxProps = AllowedFrameProps & {

--- a/packages/components/src/components/Card/Card.stories.tsx
+++ b/packages/components/src/components/Card/Card.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { Card as CardComponent, allowedFrameProps } from './Card';
+import { Card as CardComponent, allowedCardFrameProps } from './Card';
 import { getFramePropsStory } from '../common/frameProps';
 
 const meta: Meta = {
@@ -13,7 +13,7 @@ export const Card: StoryObj = {
         children: 'Some content',
         label: '',
         paddingType: 'normal',
-        ...getFramePropsStory(allowedFrameProps).args,
+        ...getFramePropsStory(allowedCardFrameProps).args,
     },
     argTypes: {
         paddingType: {
@@ -22,6 +22,6 @@ export const Card: StoryObj = {
                 type: 'radio',
             },
         },
-        ...getFramePropsStory(allowedFrameProps).argTypes,
+        ...getFramePropsStory(allowedCardFrameProps).argTypes,
     },
 };

--- a/packages/components/src/components/Card/Card.stories.tsx
+++ b/packages/components/src/components/Card/Card.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { Card as CardComponent } from './Card';
-import { framePropsStory } from '../common/frameProps';
+import { Card as CardComponent, allowedFrameProps } from './Card';
+import { getFramePropsStory } from '../common/frameProps';
 
 const meta: Meta = {
     title: 'Misc/Card',
@@ -13,7 +13,7 @@ export const Card: StoryObj = {
         children: 'Some content',
         label: '',
         paddingType: 'normal',
-        ...framePropsStory.args,
+        ...getFramePropsStory(allowedFrameProps).args,
     },
     argTypes: {
         paddingType: {
@@ -22,6 +22,6 @@ export const Card: StoryObj = {
                 type: 'radio',
             },
         },
-        ...framePropsStory.argTypes,
+        ...getFramePropsStory(allowedFrameProps).argTypes,
     },
 };

--- a/packages/components/src/components/Card/Card.tsx
+++ b/packages/components/src/components/Card/Card.tsx
@@ -16,8 +16,8 @@ type MapArgs = {
     $paddingType: PaddingType;
 };
 
-export const allowedFrameProps: (keyof FrameProps)[] = ['margin', 'maxWidth'];
-type AllowedFrameProps = Pick<FrameProps, (typeof allowedFrameProps)[number]>;
+export const allowedCardFrameProps: (keyof FrameProps)[] = ['margin', 'maxWidth'];
+type AllowedFrameProps = Pick<FrameProps, (typeof allowedCardFrameProps)[number]>;
 
 const mapPaddingTypeToLabelPadding = ({ $paddingType }: MapArgs): number | string => {
     const paddingMap: Record<PaddingType, number | string> = {

--- a/packages/components/src/components/Card/Card.tsx
+++ b/packages/components/src/components/Card/Card.tsx
@@ -2,7 +2,7 @@ import { forwardRef, HTMLAttributes, ReactNode } from 'react';
 import styled, { css } from 'styled-components';
 import { borders, Elevation, mapElevationToBackground, spacingsPx } from '@trezor/theme';
 import { ElevationContext, useElevation } from '../ElevationContext/ElevationContext';
-import { FrameProps, withFrameProps } from '../../components/common/frameProps';
+import { FrameProps, FramePropsKeys, withFrameProps } from '../../components/common/frameProps';
 import { makePropsTransient, TransientProps } from '../../utils/transientProps';
 import { AccessabilityProps, withAccessabilityProps } from '../common/accessabilityProps';
 
@@ -12,7 +12,7 @@ type MapArgs = {
     $paddingType: PaddingType;
 };
 
-export const allowedCardFrameProps: (keyof FrameProps)[] = ['margin', 'maxWidth'];
+export const allowedCardFrameProps: FramePropsKeys[] = ['margin', 'maxWidth'];
 type AllowedFrameProps = Pick<FrameProps, (typeof allowedCardFrameProps)[number]>;
 
 const mapPaddingTypeToLabelPadding = ({ $paddingType }: MapArgs): number | string => {

--- a/packages/components/src/components/Card/Card.tsx
+++ b/packages/components/src/components/Card/Card.tsx
@@ -2,11 +2,7 @@ import { forwardRef, HTMLAttributes, ReactNode } from 'react';
 import styled, { css } from 'styled-components';
 import { borders, Elevation, mapElevationToBackground, spacingsPx } from '@trezor/theme';
 import { ElevationContext, useElevation } from '../ElevationContext/ElevationContext';
-import {
-    FrameProps,
-    TransientFrameProps,
-    withFrameProps,
-} from '../../components/common/frameProps';
+import { FrameProps, withFrameProps } from '../../components/common/frameProps';
 import { makePropsTransient, TransientProps } from '../../utils/transientProps';
 import { AccessabilityProps, withAccessabilityProps } from '../common/accessabilityProps';
 
@@ -56,7 +52,7 @@ const CardContainer = styled.div<
         $elevation: Elevation;
         $paddingType: PaddingType;
         $isClickable: boolean;
-    } & TransientFrameProps
+    } & TransientProps<AllowedFrameProps>
 >`
     display: flex;
     width: 100%;

--- a/packages/components/src/components/Card/Card.tsx
+++ b/packages/components/src/components/Card/Card.tsx
@@ -7,7 +7,7 @@ import {
     TransientFrameProps,
     withFrameProps,
 } from '../../components/common/frameProps';
-import { makePropsTransient } from '../../utils/transientProps';
+import { makePropsTransient, TransientProps } from '../../utils/transientProps';
 import { AccessabilityProps, withAccessabilityProps } from '../common/accessabilityProps';
 
 type PaddingType = 'small' | 'none' | 'normal';
@@ -15,6 +15,9 @@ type PaddingType = 'small' | 'none' | 'normal';
 type MapArgs = {
     $paddingType: PaddingType;
 };
+
+export const allowedFrameProps: (keyof FrameProps)[] = ['margin', 'maxWidth'];
+type AllowedFrameProps = Pick<FrameProps, (typeof allowedFrameProps)[number]>;
 
 const mapPaddingTypeToLabelPadding = ({ $paddingType }: MapArgs): number | string => {
     const paddingMap: Record<PaddingType, number | string> = {
@@ -35,7 +38,7 @@ const mapPaddingTypeToPadding = ({ $paddingType }: MapArgs): number | string => 
     return paddingMap[$paddingType];
 };
 
-const Container = styled.div<TransientFrameProps>`
+const Container = styled.div<TransientProps<AllowedFrameProps>>`
     border-radius: ${borders.radii.md};
     background: ${({ theme }) => theme.backgroundTertiaryDefaultOnElevation0};
     padding: ${spacingsPx.xxxs};
@@ -90,7 +93,7 @@ const CardContainer = styled.div<
     ${withFrameProps}
 `;
 
-export type CardProps = FrameProps &
+export type CardProps = AllowedFrameProps &
     AccessabilityProps & {
         paddingType?: PaddingType;
         onMouseEnter?: HTMLAttributes<HTMLDivElement>['onMouseEnter'];

--- a/packages/components/src/components/CollapsibleBox/CollapsibleBox.stories.tsx
+++ b/packages/components/src/components/CollapsibleBox/CollapsibleBox.stories.tsx
@@ -1,7 +1,10 @@
 import styled from 'styled-components';
 import { Meta, StoryObj } from '@storybook/react';
 
-import { CollapsibleBox as CollapsibleBoxComponent, allowedFrameProps } from './CollapsibleBox';
+import {
+    CollapsibleBox as CollapsibleBoxComponent,
+    allowedCollapsibleBoxFrameProps,
+} from './CollapsibleBox';
 import { action } from '@storybook/addon-actions';
 import { getFramePropsStory } from '../common/frameProps';
 
@@ -21,7 +24,7 @@ export const CollapsibleBox: StoryObj = {
         children: <Content>Some content</Content>,
         isOpen: undefined,
         onToggle: action('onToggle'),
-        ...getFramePropsStory(allowedFrameProps).args,
+        ...getFramePropsStory(allowedCollapsibleBoxFrameProps).args,
     },
     argTypes: {
         heading: {
@@ -51,6 +54,6 @@ export const CollapsibleBox: StoryObj = {
         },
         children: { control: { disable: true } },
         onCollapse: { control: { disable: true } },
-        ...getFramePropsStory(allowedFrameProps).argTypes,
+        ...getFramePropsStory(allowedCollapsibleBoxFrameProps).argTypes,
     },
 };

--- a/packages/components/src/components/CollapsibleBox/CollapsibleBox.stories.tsx
+++ b/packages/components/src/components/CollapsibleBox/CollapsibleBox.stories.tsx
@@ -1,9 +1,9 @@
 import styled from 'styled-components';
 import { Meta, StoryObj } from '@storybook/react';
 
-import { CollapsibleBox as CollapsibleBoxComponent } from './CollapsibleBox';
+import { CollapsibleBox as CollapsibleBoxComponent, allowedFrameProps } from './CollapsibleBox';
 import { action } from '@storybook/addon-actions';
-import { framePropsStory } from '../common/frameProps';
+import { getFramePropsStory } from '../common/frameProps';
 
 const Content = styled.div`
     width: 200px;
@@ -21,7 +21,7 @@ export const CollapsibleBox: StoryObj = {
         children: <Content>Some content</Content>,
         isOpen: undefined,
         onToggle: action('onToggle'),
-        ...framePropsStory.args,
+        ...getFramePropsStory(allowedFrameProps).args,
     },
     argTypes: {
         heading: {
@@ -51,6 +51,6 @@ export const CollapsibleBox: StoryObj = {
         },
         children: { control: { disable: true } },
         onCollapse: { control: { disable: true } },
-        ...framePropsStory.argTypes,
+        ...getFramePropsStory(allowedFrameProps).argTypes,
     },
 };

--- a/packages/components/src/components/CollapsibleBox/CollapsibleBox.tsx
+++ b/packages/components/src/components/CollapsibleBox/CollapsibleBox.tsx
@@ -12,7 +12,11 @@ import {
 import { Icon } from '@suite-common/icons/src/webComponents';
 import { motionEasing } from '../../config/motion';
 import { ElevationUp, useElevation } from './../ElevationContext/ElevationContext';
-import { FrameProps, TransientFrameProps, withFrameProps } from '../common/frameProps';
+import { FrameProps, withFrameProps } from '../common/frameProps';
+import { TransientProps } from '../../utils/transientProps';
+
+export const allowedFrameProps: (keyof FrameProps)[] = ['margin'];
+type AllowedFrameProps = Pick<FrameProps, (typeof allowedFrameProps)[number]>;
 
 const ANIMATION_DURATION = 0.4;
 
@@ -53,7 +57,7 @@ type ContentProps = {
 
 export type CollapsibleBoxProps = CollapsibleBoxManagedProps | CollapsibleBoxUnmanagedProps;
 
-type CollapsibleBoxCommon = {
+type CollapsibleBoxCommon = AllowedFrameProps & {
     heading?: ReactNode;
     subHeading?: ReactNode;
     paddingType?: 'none' | 'normal' | 'large';
@@ -62,7 +66,6 @@ type CollapsibleBoxCommon = {
     children?: ReactNode;
     isIconFlipped?: boolean; // Open upwards, affects the icon rotation
     hasDivider?: boolean;
-    margin?: FrameProps['margin'];
     onAnimationComplete?: (isOpen: boolean) => void;
     'data-test'?: string;
     /** @deprecated */
@@ -86,7 +89,7 @@ type CollapsibleBoxUnmanagedProps = CollapsibleBoxCommon & {
 
 type CollapsibleBoxContentProps = CollapsibleBoxManagedProps;
 
-const Container = styled.div<TransientFrameProps>`
+const Container = styled.div<TransientProps<AllowedFrameProps>>`
     flex: 1;
     width: 100%;
 

--- a/packages/components/src/components/CollapsibleBox/CollapsibleBox.tsx
+++ b/packages/components/src/components/CollapsibleBox/CollapsibleBox.tsx
@@ -12,10 +12,10 @@ import {
 import { Icon } from '@suite-common/icons/src/webComponents';
 import { motionEasing } from '../../config/motion';
 import { ElevationUp, useElevation } from './../ElevationContext/ElevationContext';
-import { FrameProps, withFrameProps } from '../common/frameProps';
+import { FrameProps, FramePropsKeys, withFrameProps } from '../common/frameProps';
 import { TransientProps } from '../../utils/transientProps';
 
-export const allowedCollapsibleBoxFrameProps: (keyof FrameProps)[] = ['margin'];
+export const allowedCollapsibleBoxFrameProps: FramePropsKeys[] = ['margin'];
 type AllowedFrameProps = Pick<FrameProps, (typeof allowedCollapsibleBoxFrameProps)[number]>;
 
 const ANIMATION_DURATION = 0.4;

--- a/packages/components/src/components/CollapsibleBox/CollapsibleBox.tsx
+++ b/packages/components/src/components/CollapsibleBox/CollapsibleBox.tsx
@@ -15,8 +15,8 @@ import { ElevationUp, useElevation } from './../ElevationContext/ElevationContex
 import { FrameProps, withFrameProps } from '../common/frameProps';
 import { TransientProps } from '../../utils/transientProps';
 
-export const allowedFrameProps: (keyof FrameProps)[] = ['margin'];
-type AllowedFrameProps = Pick<FrameProps, (typeof allowedFrameProps)[number]>;
+export const allowedCollapsibleBoxFrameProps: (keyof FrameProps)[] = ['margin'];
+type AllowedFrameProps = Pick<FrameProps, (typeof allowedCollapsibleBoxFrameProps)[number]>;
 
 const ANIMATION_DURATION = 0.4;
 

--- a/packages/components/src/components/Divider/Divider.stories.tsx
+++ b/packages/components/src/components/Divider/Divider.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { Divider as DividerComponent } from '../../index';
+import { Divider as DividerComponent, allowedFrameProps } from './Divider';
 import styled from 'styled-components';
-import { framePropsStory } from '../common/frameProps';
+import { getFramePropsStory } from '../common/frameProps';
 
 const Container = styled.div`
     width: 200px;
@@ -22,7 +22,7 @@ export const Divider: StoryObj = {
     ),
     args: {
         orientation: 'horizontal',
-        ...framePropsStory.args,
+        ...getFramePropsStory(allowedFrameProps).args,
     },
     argTypes: {
         orientation: {
@@ -37,6 +37,6 @@ export const Divider: StoryObj = {
         color: {
             type: 'string',
         },
-        ...framePropsStory.argTypes,
+        ...getFramePropsStory(allowedFrameProps).argTypes,
     },
 };

--- a/packages/components/src/components/Divider/Divider.stories.tsx
+++ b/packages/components/src/components/Divider/Divider.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { Divider as DividerComponent, allowedFrameProps } from './Divider';
+import { Divider as DividerComponent, allowedDividerFrameProps } from './Divider';
 import styled from 'styled-components';
 import { getFramePropsStory } from '../common/frameProps';
 
@@ -22,7 +22,7 @@ export const Divider: StoryObj = {
     ),
     args: {
         orientation: 'horizontal',
-        ...getFramePropsStory(allowedFrameProps).args,
+        ...getFramePropsStory(allowedDividerFrameProps).args,
     },
     argTypes: {
         orientation: {
@@ -37,6 +37,6 @@ export const Divider: StoryObj = {
         color: {
             type: 'string',
         },
-        ...getFramePropsStory(allowedFrameProps).argTypes,
+        ...getFramePropsStory(allowedDividerFrameProps).argTypes,
     },
 };

--- a/packages/components/src/components/Divider/Divider.tsx
+++ b/packages/components/src/components/Divider/Divider.tsx
@@ -1,10 +1,10 @@
 import styled from 'styled-components';
 import { Color, Elevation, mapElevationToBorder, spacings } from '@trezor/theme';
 import { useElevation } from '../ElevationContext/ElevationContext';
-import { FrameProps, withFrameProps } from '../common/frameProps';
+import { FrameProps, FramePropsKeys, withFrameProps } from '../common/frameProps';
 import { TransientProps } from '../../utils/transientProps';
 
-export const allowedDividerFrameProps: (keyof FrameProps)[] = ['margin'];
+export const allowedDividerFrameProps: FramePropsKeys[] = ['margin'];
 type AllowedFrameProps = Pick<FrameProps, (typeof allowedDividerFrameProps)[number]>;
 type DividerOrientation = 'horizontal' | 'vertical';
 

--- a/packages/components/src/components/Divider/Divider.tsx
+++ b/packages/components/src/components/Divider/Divider.tsx
@@ -4,8 +4,8 @@ import { useElevation } from '../ElevationContext/ElevationContext';
 import { FrameProps, withFrameProps } from '../common/frameProps';
 import { TransientProps } from '../../utils/transientProps';
 
-export const allowedFrameProps: (keyof FrameProps)[] = ['margin'];
-type AllowedFrameProps = Pick<FrameProps, (typeof allowedFrameProps)[number]>;
+export const allowedDividerFrameProps: (keyof FrameProps)[] = ['margin'];
+type AllowedFrameProps = Pick<FrameProps, (typeof allowedDividerFrameProps)[number]>;
 type DividerOrientation = 'horizontal' | 'vertical';
 
 type DividerProps = AllowedFrameProps & {

--- a/packages/components/src/components/Divider/Divider.tsx
+++ b/packages/components/src/components/Divider/Divider.tsx
@@ -1,15 +1,17 @@
 import styled from 'styled-components';
 import { Color, Elevation, mapElevationToBorder, spacings } from '@trezor/theme';
 import { useElevation } from '../ElevationContext/ElevationContext';
-import { FrameProps, TransientFrameProps, withFrameProps } from '../common/frameProps';
+import { FrameProps, withFrameProps } from '../common/frameProps';
+import { TransientProps } from '../../utils/transientProps';
 
+export const allowedFrameProps: (keyof FrameProps)[] = ['margin'];
+type AllowedFrameProps = Pick<FrameProps, (typeof allowedFrameProps)[number]>;
 type DividerOrientation = 'horizontal' | 'vertical';
 
-type DividerProps = {
+type DividerProps = AllowedFrameProps & {
     orientation?: DividerOrientation;
     strokeWidth?: number;
     color?: Color;
-    margin?: FrameProps['margin'];
 };
 
 const Line = styled.div<
@@ -18,7 +20,7 @@ const Line = styled.div<
         $strokeWidth: DividerProps['strokeWidth'];
         $color: DividerProps['color'];
         $orientation: DividerOrientation;
-    } & TransientFrameProps
+    } & TransientProps<AllowedFrameProps>
 >`
     ${({ $orientation, $strokeWidth }) =>
         $orientation === 'vertical'

--- a/packages/components/src/components/Flex/Flex.stories.tsx
+++ b/packages/components/src/components/Flex/Flex.stories.tsx
@@ -6,7 +6,7 @@ import {
     flexWrap,
     Row as RowComponent,
     Column as ColumnComponent,
-    allowedFrameProps,
+    allowedFlexFrameProps,
 } from './Flex';
 import { spacings } from '@trezor/theme';
 import styled from 'styled-components';
@@ -40,7 +40,7 @@ const args: Partial<FlexProps> = {
     gap: 8,
     flexWrap: 'wrap',
     isReversed: false,
-    ...getFramePropsStory(allowedFrameProps).args,
+    ...getFramePropsStory(allowedFlexFrameProps).args,
 };
 const argTypes: Partial<ArgTypes<FlexProps>> = {
     justifyContent: {
@@ -73,7 +73,7 @@ const argTypes: Partial<ArgTypes<FlexProps>> = {
             type: 'select',
         },
     },
-    ...getFramePropsStory(allowedFrameProps).argTypes,
+    ...getFramePropsStory(allowedFlexFrameProps).argTypes,
 };
 
 const meta: Meta = {

--- a/packages/components/src/components/Flex/Flex.stories.tsx
+++ b/packages/components/src/components/Flex/Flex.stories.tsx
@@ -6,10 +6,11 @@ import {
     flexWrap,
     Row as RowComponent,
     Column as ColumnComponent,
+    allowedFrameProps,
 } from './Flex';
 import { spacings } from '@trezor/theme';
 import styled from 'styled-components';
-import { framePropsStory } from '../common/frameProps';
+import { getFramePropsStory } from '../common/frameProps';
 
 const Container = styled.div`
     width: 100%;
@@ -39,7 +40,7 @@ const args: Partial<FlexProps> = {
     gap: 8,
     flexWrap: 'wrap',
     isReversed: false,
-    ...framePropsStory.args,
+    ...getFramePropsStory(allowedFrameProps).args,
 };
 const argTypes: Partial<ArgTypes<FlexProps>> = {
     justifyContent: {
@@ -72,7 +73,7 @@ const argTypes: Partial<ArgTypes<FlexProps>> = {
             type: 'select',
         },
     },
-    ...framePropsStory.argTypes,
+    ...getFramePropsStory(allowedFrameProps).argTypes,
 };
 
 const meta: Meta = {

--- a/packages/components/src/components/Flex/Flex.tsx
+++ b/packages/components/src/components/Flex/Flex.tsx
@@ -1,9 +1,9 @@
 import { SpacingValues } from '@trezor/theme';
 import styled from 'styled-components';
-import { FrameProps, withFrameProps } from '../common/frameProps';
+import { FrameProps, FramePropsKeys, withFrameProps } from '../common/frameProps';
 import { makePropsTransient, TransientProps } from '../../utils/transientProps';
 
-export const allowedFlexFrameProps: (keyof FrameProps)[] = ['margin', 'width', 'height'];
+export const allowedFlexFrameProps: FramePropsKeys[] = ['margin', 'width', 'height'];
 type AllowedFrameProps = Pick<FrameProps, (typeof allowedFlexFrameProps)[number]>;
 
 export const flexDirection = ['column', 'row'] as const;

--- a/packages/components/src/components/Flex/Flex.tsx
+++ b/packages/components/src/components/Flex/Flex.tsx
@@ -3,8 +3,8 @@ import styled from 'styled-components';
 import { FrameProps, withFrameProps } from '../common/frameProps';
 import { makePropsTransient, TransientProps } from '../../utils/transientProps';
 
-export const allowedFrameProps: (keyof FrameProps)[] = ['margin', 'width', 'height'];
-type AllowedFrameProps = Pick<FrameProps, (typeof allowedFrameProps)[number]>;
+export const allowedFlexFrameProps: (keyof FrameProps)[] = ['margin', 'width', 'height'];
+type AllowedFrameProps = Pick<FrameProps, (typeof allowedFlexFrameProps)[number]>;
 
 export const flexDirection = ['column', 'row'] as const;
 export const flexWrap = ['nowrap', 'wrap', 'wrap-reverse'] as const;

--- a/packages/components/src/components/Flex/Flex.tsx
+++ b/packages/components/src/components/Flex/Flex.tsx
@@ -1,7 +1,10 @@
 import { SpacingValues } from '@trezor/theme';
 import styled from 'styled-components';
-import { FrameProps, TransientFrameProps, withFrameProps } from '../common/frameProps';
-import { makePropsTransient } from '../../utils/transientProps';
+import { FrameProps, withFrameProps } from '../common/frameProps';
+import { makePropsTransient, TransientProps } from '../../utils/transientProps';
+
+export const allowedFrameProps: (keyof FrameProps)[] = ['margin', 'width', 'height'];
+type AllowedFrameProps = Pick<FrameProps, (typeof allowedFrameProps)[number]>;
 
 export const flexDirection = ['column', 'row'] as const;
 export const flexWrap = ['nowrap', 'wrap', 'wrap-reverse'] as const;
@@ -41,7 +44,7 @@ export type Flex = string | number;
 export type FlexWrap = (typeof flexWrap)[number];
 
 const Container = styled.div<
-    TransientFrameProps & {
+    TransientProps<AllowedFrameProps> & {
         $gap: SpacingValues;
         $justifyContent: FlexJustifyContent;
         $alignItems: FlexAlignItems;
@@ -62,7 +65,7 @@ const Container = styled.div<
     ${withFrameProps}
 `;
 
-export type FlexProps = FrameProps & {
+export type FlexProps = AllowedFrameProps & {
     gap?: SpacingValues;
     justifyContent?: FlexJustifyContent;
     alignItems?: FlexAlignItems;
@@ -85,9 +88,13 @@ const Flex = ({
     flexWrap = 'nowrap',
     isReversed = false,
     className,
+    width,
+    height,
 }: FlexProps) => {
     const frameProps = {
         margin,
+        width,
+        height,
     };
 
     return (

--- a/packages/components/src/components/Warning/Warning.stories.tsx
+++ b/packages/components/src/components/Warning/Warning.stories.tsx
@@ -1,7 +1,8 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { Warning as WarningComponent, WarningProps, variables } from '../../index';
+import { allowedFrameProps } from './Warning';
 import styled from 'styled-components';
-import { framePropsStory } from '../common/frameProps';
+import { getFramePropsStory } from '../common/frameProps';
 
 const Wrapper = styled.div`
     display: flex;
@@ -38,7 +39,7 @@ export const Warning: StoryObj<WarningProps> = {
         withIcon: true,
         variant: 'warning',
         icon: undefined,
-        ...framePropsStory.args,
+        ...getFramePropsStory(allowedFrameProps).args,
     },
     argTypes: {
         className: {
@@ -50,6 +51,6 @@ export const Warning: StoryObj<WarningProps> = {
                 type: 'select',
             },
         },
-        ...framePropsStory.argTypes,
+        ...getFramePropsStory(allowedFrameProps).argTypes,
     },
 };

--- a/packages/components/src/components/Warning/Warning.stories.tsx
+++ b/packages/components/src/components/Warning/Warning.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { Warning as WarningComponent, WarningProps, variables } from '../../index';
-import { allowedFrameProps } from './Warning';
+import { allowedWarningFrameProps } from './Warning';
 import styled from 'styled-components';
 import { getFramePropsStory } from '../common/frameProps';
 
@@ -39,7 +39,7 @@ export const Warning: StoryObj<WarningProps> = {
         withIcon: true,
         variant: 'warning',
         icon: undefined,
-        ...getFramePropsStory(allowedFrameProps).args,
+        ...getFramePropsStory(allowedWarningFrameProps).args,
     },
     argTypes: {
         className: {
@@ -51,6 +51,6 @@ export const Warning: StoryObj<WarningProps> = {
                 type: 'select',
             },
         },
-        ...getFramePropsStory(allowedFrameProps).argTypes,
+        ...getFramePropsStory(allowedWarningFrameProps).argTypes,
     },
 };

--- a/packages/components/src/components/Warning/Warning.tsx
+++ b/packages/components/src/components/Warning/Warning.tsx
@@ -13,24 +13,26 @@ import {
     typography,
 } from '@trezor/theme';
 import { UIVariant } from '../../config/types';
-import { useElevation } from '../..';
-import { FrameProps, TransientFrameProps, withFrameProps } from '../common/frameProps';
+import { TransientProps, useElevation } from '../..';
+import { FrameProps, withFrameProps } from '../common/frameProps';
+
+export const allowedFrameProps: (keyof FrameProps)[] = ['margin'];
+type AllowedFrameProps = Pick<FrameProps, (typeof allowedFrameProps)[number]>;
 
 export type WarningVariant = Extract<
     UIVariant,
     'primary' | 'secondary' | 'info' | 'warning' | 'destructive' | 'tertiary'
 >;
 
-export interface WarningProps {
+export type WarningProps = AllowedFrameProps & {
     children: ReactNode;
     className?: string;
     variant?: WarningVariant;
     withIcon?: boolean;
     icon?: IconType;
     filled?: boolean;
-    margin?: FrameProps['margin'];
     dataTest?: string;
-}
+};
 
 type MapArgs = {
     $variant: WarningVariant;
@@ -89,7 +91,7 @@ const mapVariantToIcon = ({ $variant }: Pick<MapArgs, '$variant'>): IconType => 
     return iconMap[$variant];
 };
 
-type WrapperParams = TransientFrameProps & {
+type WrapperParams = TransientProps<AllowedFrameProps> & {
     $variant: WarningVariant;
     $withIcon?: boolean;
     $elevation: Elevation;

--- a/packages/components/src/components/Warning/Warning.tsx
+++ b/packages/components/src/components/Warning/Warning.tsx
@@ -14,9 +14,9 @@ import {
 } from '@trezor/theme';
 import { UIVariant } from '../../config/types';
 import { TransientProps, useElevation } from '../..';
-import { FrameProps, withFrameProps } from '../common/frameProps';
+import { FrameProps, FramePropsKeys, withFrameProps } from '../common/frameProps';
 
-export const allowedWarningFrameProps: (keyof FrameProps)[] = ['margin'];
+export const allowedWarningFrameProps: FramePropsKeys[] = ['margin'];
 type AllowedFrameProps = Pick<FrameProps, (typeof allowedWarningFrameProps)[number]>;
 
 export type WarningVariant = Extract<

--- a/packages/components/src/components/Warning/Warning.tsx
+++ b/packages/components/src/components/Warning/Warning.tsx
@@ -16,8 +16,8 @@ import { UIVariant } from '../../config/types';
 import { TransientProps, useElevation } from '../..';
 import { FrameProps, withFrameProps } from '../common/frameProps';
 
-export const allowedFrameProps: (keyof FrameProps)[] = ['margin'];
-type AllowedFrameProps = Pick<FrameProps, (typeof allowedFrameProps)[number]>;
+export const allowedWarningFrameProps: (keyof FrameProps)[] = ['margin'];
+type AllowedFrameProps = Pick<FrameProps, (typeof allowedWarningFrameProps)[number]>;
 
 export type WarningVariant = Extract<
     UIVariant,

--- a/packages/components/src/components/buttons/Button/Button.stories.tsx
+++ b/packages/components/src/components/buttons/Button/Button.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { Button as ButtonComponent, ButtonProps } from './Button';
-import { framePropsStory } from '../../common/frameProps';
+import { allowedFrameProps, Button as ButtonComponent, ButtonProps } from './Button';
+import { getFramePropsStory } from '../../common/frameProps';
 import { variables } from '../../../config';
 
 const meta: Meta = {
@@ -19,7 +19,7 @@ export const Button: StoryObj<ButtonProps> = {
         isFullWidth: false,
         iconAlignment: 'left',
         title: 'Button title',
-        ...framePropsStory.args,
+        ...getFramePropsStory(allowedFrameProps).args,
     },
     argTypes: {
         children: {
@@ -79,6 +79,6 @@ export const Button: StoryObj<ButtonProps> = {
         title: {
             control: { type: 'text' },
         },
-        ...framePropsStory.argTypes,
+        ...getFramePropsStory(allowedFrameProps).argTypes,
     },
 };

--- a/packages/components/src/components/buttons/Button/Button.stories.tsx
+++ b/packages/components/src/components/buttons/Button/Button.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { allowedFrameProps, Button as ButtonComponent, ButtonProps } from './Button';
+import { allowedButtonFrameProps, Button as ButtonComponent, ButtonProps } from './Button';
 import { getFramePropsStory } from '../../common/frameProps';
 import { variables } from '../../../config';
 
@@ -19,7 +19,7 @@ export const Button: StoryObj<ButtonProps> = {
         isFullWidth: false,
         iconAlignment: 'left',
         title: 'Button title',
-        ...getFramePropsStory(allowedFrameProps).args,
+        ...getFramePropsStory(allowedButtonFrameProps).args,
     },
     argTypes: {
         children: {
@@ -79,6 +79,6 @@ export const Button: StoryObj<ButtonProps> = {
         title: {
             control: { type: 'text' },
         },
-        ...getFramePropsStory(allowedFrameProps).argTypes,
+        ...getFramePropsStory(allowedButtonFrameProps).argTypes,
     },
 };

--- a/packages/components/src/components/buttons/Button/Button.tsx
+++ b/packages/components/src/components/buttons/Button/Button.tsx
@@ -14,10 +14,13 @@ import {
 } from '../buttonStyleUtils';
 import { focusStyleTransition, getFocusShadowStyle } from '../../../utils/utils';
 import { useElevation } from '../../ElevationContext/ElevationContext';
-import { makePropsTransient } from '../../../utils/transientProps';
-import { FrameProps, TransientFrameProps, withFrameProps } from '../../common/frameProps';
+import { makePropsTransient, TransientProps } from '../../../utils/transientProps';
+import { FrameProps, withFrameProps } from '../../common/frameProps';
 
-type ButtonContainerProps = TransientFrameProps & {
+export const allowedFrameProps: (keyof FrameProps)[] = ['margin'];
+type AllowedFrameProps = Pick<FrameProps, (typeof allowedFrameProps)[number]>;
+
+type ButtonContainerProps = TransientProps<AllowedFrameProps> & {
     $variant: ButtonVariant;
     $size: ButtonSize;
     $iconAlignment?: IconAlignment;
@@ -84,7 +87,7 @@ type SelectedHTMLButtonProps = Pick<
 >;
 
 export type ButtonProps = SelectedHTMLButtonProps &
-    FrameProps & {
+    AllowedFrameProps & {
         variant?: ButtonVariant;
         size?: ButtonSize;
         isDisabled?: boolean;

--- a/packages/components/src/components/buttons/Button/Button.tsx
+++ b/packages/components/src/components/buttons/Button/Button.tsx
@@ -17,8 +17,8 @@ import { useElevation } from '../../ElevationContext/ElevationContext';
 import { makePropsTransient, TransientProps } from '../../../utils/transientProps';
 import { FrameProps, withFrameProps } from '../../common/frameProps';
 
-export const allowedFrameProps: (keyof FrameProps)[] = ['margin'];
-type AllowedFrameProps = Pick<FrameProps, (typeof allowedFrameProps)[number]>;
+export const allowedButtonFrameProps: (keyof FrameProps)[] = ['margin'];
+type AllowedFrameProps = Pick<FrameProps, (typeof allowedButtonFrameProps)[number]>;
 
 type ButtonContainerProps = TransientProps<AllowedFrameProps> & {
     $variant: ButtonVariant;

--- a/packages/components/src/components/buttons/Button/Button.tsx
+++ b/packages/components/src/components/buttons/Button/Button.tsx
@@ -15,9 +15,9 @@ import {
 import { focusStyleTransition, getFocusShadowStyle } from '../../../utils/utils';
 import { useElevation } from '../../ElevationContext/ElevationContext';
 import { makePropsTransient, TransientProps } from '../../../utils/transientProps';
-import { FrameProps, withFrameProps } from '../../common/frameProps';
+import { FrameProps, FramePropsKeys, withFrameProps } from '../../common/frameProps';
 
-export const allowedButtonFrameProps: (keyof FrameProps)[] = ['margin'];
+export const allowedButtonFrameProps: FramePropsKeys[] = ['margin'];
 type AllowedFrameProps = Pick<FrameProps, (typeof allowedButtonFrameProps)[number]>;
 
 type ButtonContainerProps = TransientProps<AllowedFrameProps> & {

--- a/packages/components/src/components/common/frameProps.tsx
+++ b/packages/components/src/components/common/frameProps.tsx
@@ -65,6 +65,7 @@ export const getFramePropsStory = (allowedFrameProps: Array<keyof FrameProps>) =
                 table: {
                     category: 'Frame props',
                 },
+                type: key === 'margin' ? 'object' : 'number',
             },
         }),
         {},

--- a/packages/components/src/components/common/frameProps.tsx
+++ b/packages/components/src/components/common/frameProps.tsx
@@ -16,6 +16,7 @@ export type FrameProps = {
     height?: string | number;
     maxHeight?: string | number;
 };
+export type FramePropsKeys = keyof FrameProps;
 
 type TransientFrameProps = TransientProps<FrameProps>;
 
@@ -57,7 +58,7 @@ export const withFrameProps = ({
     `;
 };
 
-export const getFramePropsStory = (allowedFrameProps: Array<keyof FrameProps>) => {
+export const getFramePropsStory = (allowedFrameProps: Array<FramePropsKeys>) => {
     const argTypes = allowedFrameProps.reduce(
         (acc, key) => ({
             ...acc,

--- a/packages/components/src/components/common/frameProps.tsx
+++ b/packages/components/src/components/common/frameProps.tsx
@@ -17,7 +17,7 @@ export type FrameProps = {
     maxHeight?: string | number;
 };
 
-export type TransientFrameProps = TransientProps<FrameProps>;
+type TransientFrameProps = TransientProps<FrameProps>;
 
 const getValueWithUnit = (value: string | number) =>
     typeof value === 'string' ? value : `${value}px`;

--- a/packages/components/src/components/common/frameProps.tsx
+++ b/packages/components/src/components/common/frameProps.tsx
@@ -11,12 +11,24 @@ type Margin = {
 
 export type FrameProps = {
     margin?: Margin;
-    maxWidth?: string;
+    width?: string | number;
+    maxWidth?: string | number;
+    height?: string | number;
+    maxHeight?: string | number;
 };
 
 export type TransientFrameProps = TransientProps<FrameProps>;
 
-export const withFrameProps = ({ $margin, $maxWidth }: TransientFrameProps) => {
+const getValueWithUnit = (value: string | number) =>
+    typeof value === 'string' ? value : `${value}px`;
+
+export const withFrameProps = ({
+    $margin,
+    $maxWidth,
+    $height,
+    $width,
+    $maxHeight,
+}: TransientFrameProps) => {
     return css`
         ${$margin &&
         css`
@@ -28,20 +40,53 @@ export const withFrameProps = ({ $margin, $maxWidth }: TransientFrameProps) => {
 
         ${$maxWidth &&
         css`
-            max-width: ${$maxWidth};
+            max-width: ${getValueWithUnit($maxWidth)};
+        `};
+        ${$maxHeight &&
+        css`
+            max-height: ${getValueWithUnit($maxHeight)};
+        `};
+        ${$width &&
+        css`
+            width: ${getValueWithUnit($width)};
+        `};
+        ${$height &&
+        css`
+            height: ${getValueWithUnit($height)};
         `};
     `;
 };
 
-export const framePropsStory = {
-    args: {
-        margin: { top: undefined, right: undefined, bottom: undefined, left: undefined },
-    },
-    argTypes: {
-        margin: {
-            table: {
-                category: 'Frame props',
+export const getFramePropsStory = (allowedFrameProps: Array<keyof FrameProps>) => {
+    const argTypes = allowedFrameProps.reduce(
+        (acc, key) => ({
+            ...acc,
+            [key]: {
+                table: {
+                    category: 'Frame props',
+                },
             },
+        }),
+        {},
+    );
+
+    return {
+        args: {
+            ...(allowedFrameProps.includes('margin')
+                ? {
+                      margin: {
+                          top: undefined,
+                          right: undefined,
+                          bottom: undefined,
+                          left: undefined,
+                      },
+                  }
+                : {}),
+            ...(allowedFrameProps.includes('width') ? { width: undefined } : {}),
+            ...(allowedFrameProps.includes('height') ? { height: undefined } : {}),
+            ...(allowedFrameProps.includes('maxWidth') ? { maxWidth: undefined } : {}),
+            ...(allowedFrameProps.includes('maxHeight') ? { maxHeight: undefined } : {}),
         },
-    },
+        argTypes,
+    };
 };

--- a/packages/components/src/components/form/Checkbox/Checkbox.stories.tsx
+++ b/packages/components/src/components/form/Checkbox/Checkbox.stories.tsx
@@ -1,7 +1,11 @@
 import { useArgs } from '@storybook/client-api';
 import { Meta, StoryObj } from '@storybook/react';
 
-import { Checkbox as CheckboxComponent, CheckboxProps, allowedFrameProps } from './Checkbox';
+import {
+    Checkbox as CheckboxComponent,
+    CheckboxProps,
+    allowedCheckboxFrameProps,
+} from './Checkbox';
 import { getFramePropsStory } from '../../common/frameProps';
 
 const meta: Meta = {
@@ -33,7 +37,7 @@ export const Checkbox: StoryObj<CheckboxProps> = {
         isChecked: false,
         isDisabled: false,
         labelAlignment: 'right',
-        ...getFramePropsStory(allowedFrameProps).args,
+        ...getFramePropsStory(allowedCheckboxFrameProps).args,
     },
 
     argTypes: {
@@ -49,6 +53,6 @@ export const Checkbox: StoryObj<CheckboxProps> = {
             },
             options: ['left', 'right'],
         },
-        ...getFramePropsStory(allowedFrameProps).argTypes,
+        ...getFramePropsStory(allowedCheckboxFrameProps).argTypes,
     },
 };

--- a/packages/components/src/components/form/Checkbox/Checkbox.stories.tsx
+++ b/packages/components/src/components/form/Checkbox/Checkbox.stories.tsx
@@ -1,8 +1,8 @@
 import { useArgs } from '@storybook/client-api';
 import { Meta, StoryObj } from '@storybook/react';
 
-import { Checkbox as CheckboxComponent, CheckboxProps } from './Checkbox';
-import { framePropsStory } from '../../common/frameProps';
+import { Checkbox as CheckboxComponent, CheckboxProps, allowedFrameProps } from './Checkbox';
+import { getFramePropsStory } from '../../common/frameProps';
 
 const meta: Meta = {
     title: 'Form/Checkbox',
@@ -33,7 +33,7 @@ export const Checkbox: StoryObj<CheckboxProps> = {
         isChecked: false,
         isDisabled: false,
         labelAlignment: 'right',
-        ...framePropsStory.args,
+        ...getFramePropsStory(allowedFrameProps).args,
     },
 
     argTypes: {
@@ -49,6 +49,6 @@ export const Checkbox: StoryObj<CheckboxProps> = {
             },
             options: ['left', 'right'],
         },
-        ...framePropsStory.argTypes,
+        ...getFramePropsStory(allowedFrameProps).argTypes,
     },
 };

--- a/packages/components/src/components/form/Checkbox/Checkbox.tsx
+++ b/packages/components/src/components/form/Checkbox/Checkbox.tsx
@@ -6,10 +6,10 @@ import { KEYBOARD_CODE } from '../../../constants/keyboardEvents';
 import { Icon } from '../../assets/Icon/Icon';
 import { getFocusShadowStyle } from '../../../utils/utils';
 import { UIHorizontalAlignment, UIVariant } from '../../../config/types';
-import { FrameProps, withFrameProps } from '../../common/frameProps';
+import { FrameProps, FramePropsKeys, withFrameProps } from '../../common/frameProps';
 import { makePropsTransient, TransientProps } from '../../../utils/transientProps';
 
-export const allowedCheckboxFrameProps: (keyof FrameProps)[] = ['margin'];
+export const allowedCheckboxFrameProps: FramePropsKeys[] = ['margin'];
 type AllowedFrameProps = Pick<FrameProps, (typeof allowedCheckboxFrameProps)[number]>;
 
 interface VariantStyles {

--- a/packages/components/src/components/form/Checkbox/Checkbox.tsx
+++ b/packages/components/src/components/form/Checkbox/Checkbox.tsx
@@ -6,8 +6,11 @@ import { KEYBOARD_CODE } from '../../../constants/keyboardEvents';
 import { Icon } from '../../assets/Icon/Icon';
 import { getFocusShadowStyle } from '../../../utils/utils';
 import { UIHorizontalAlignment, UIVariant } from '../../../config/types';
-import { FrameProps, TransientFrameProps, withFrameProps } from '../../common/frameProps';
-import { makePropsTransient } from '../../../utils/transientProps';
+import { FrameProps, withFrameProps } from '../../common/frameProps';
+import { makePropsTransient, TransientProps } from '../../../utils/transientProps';
+
+export const allowedFrameProps: (keyof FrameProps)[] = ['margin'];
+type AllowedFrameProps = Pick<FrameProps, (typeof allowedFrameProps)[number]>;
 
 interface VariantStyles {
     background: Color;
@@ -61,7 +64,7 @@ export const variantStyles: Record<CheckboxVariant, VariantStyles> = {
     },
 };
 
-type ContainerProps = TransientFrameProps & {
+type ContainerProps = TransientProps<AllowedFrameProps> & {
     $isDisabled?: boolean;
     $labelAlignment?: LabelAlignment;
 };
@@ -151,7 +154,7 @@ export const HiddenInput = styled.input`
 export type CheckboxVariant = Extract<UIVariant, 'primary' | 'destructive' | 'warning'>;
 export type LabelAlignment = Extract<UIHorizontalAlignment, 'left' | 'right'>;
 
-export type CheckboxProps = {
+export type CheckboxProps = AllowedFrameProps & {
     variant?: CheckboxVariant;
     isChecked?: boolean;
     isDisabled?: boolean;
@@ -160,7 +163,7 @@ export type CheckboxProps = {
     'data-test'?: string;
     className?: string;
     children?: ReactNode;
-} & Pick<FrameProps, 'margin'>;
+};
 
 export const Checkbox = ({
     variant = 'primary',

--- a/packages/components/src/components/form/Checkbox/Checkbox.tsx
+++ b/packages/components/src/components/form/Checkbox/Checkbox.tsx
@@ -9,8 +9,8 @@ import { UIHorizontalAlignment, UIVariant } from '../../../config/types';
 import { FrameProps, withFrameProps } from '../../common/frameProps';
 import { makePropsTransient, TransientProps } from '../../../utils/transientProps';
 
-export const allowedFrameProps: (keyof FrameProps)[] = ['margin'];
-type AllowedFrameProps = Pick<FrameProps, (typeof allowedFrameProps)[number]>;
+export const allowedCheckboxFrameProps: (keyof FrameProps)[] = ['margin'];
+type AllowedFrameProps = Pick<FrameProps, (typeof allowedCheckboxFrameProps)[number]>;
 
 interface VariantStyles {
     background: Color;

--- a/packages/components/src/components/loaders/Spinner/Spinner.stories.tsx
+++ b/packages/components/src/components/loaders/Spinner/Spinner.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { Spinner as SpinnerComponent, SpinnerProps } from './Spinner';
+import { Spinner as SpinnerComponent, SpinnerProps, allowedSpinnerFrameProps } from './Spinner';
+import { getFramePropsStory } from '../../common/frameProps';
 
 const meta: Meta = {
     title: 'Loaders/Spinner',
@@ -10,11 +11,13 @@ export default meta;
 export const Default: StoryObj<SpinnerProps> = {
     args: {
         size: 50,
+        ...getFramePropsStory(allowedSpinnerFrameProps).args,
     },
     argTypes: {
         className: {
             control: false,
         },
+        ...getFramePropsStory(allowedSpinnerFrameProps).argTypes,
     },
 };
 
@@ -23,11 +26,13 @@ export const Success: StoryObj<SpinnerProps> = {
         size: 50,
         hasFinished: true,
         hasStartAnimation: true,
+        ...getFramePropsStory(allowedSpinnerFrameProps).args,
     },
     argTypes: {
         className: {
             control: false,
         },
+        ...getFramePropsStory(allowedSpinnerFrameProps).argTypes,
     },
 };
 
@@ -36,10 +41,12 @@ export const Error: StoryObj<SpinnerProps> = {
         size: 50,
         hasError: true,
         hasStartAnimation: true,
+        ...getFramePropsStory(allowedSpinnerFrameProps).args,
     },
     argTypes: {
         className: {
             control: false,
         },
+        ...getFramePropsStory(allowedSpinnerFrameProps).argTypes,
     },
 };

--- a/packages/components/src/components/loaders/Spinner/Spinner.tsx
+++ b/packages/components/src/components/loaders/Spinner/Spinner.tsx
@@ -5,10 +5,10 @@ import animationStart from './animationData/refresh-spinner-start.json';
 import animationMiddle from './animationData/refresh-spinner-middle.json';
 import animationEnd from './animationData/refresh-spinner-end-success.json';
 import animationWarn from './animationData/refresh-spinner-end-warning.json';
-import { withFrameProps, FrameProps } from '../../common/frameProps';
+import { withFrameProps, FrameProps, FramePropsKeys } from '../../common/frameProps';
 import { TransientProps } from '../../../utils/transientProps';
 
-export const allowedSpinnerFrameProps: (keyof FrameProps)[] = ['margin'];
+export const allowedSpinnerFrameProps: FramePropsKeys[] = ['margin'];
 type AllowedFrameProps = Pick<FrameProps, (typeof allowedSpinnerFrameProps)[number]>;
 
 const StyledLottie = styled(Lottie)<

--- a/packages/components/src/components/loaders/Spinner/Spinner.tsx
+++ b/packages/components/src/components/loaders/Spinner/Spinner.tsx
@@ -5,13 +5,17 @@ import animationStart from './animationData/refresh-spinner-start.json';
 import animationMiddle from './animationData/refresh-spinner-middle.json';
 import animationEnd from './animationData/refresh-spinner-end-success.json';
 import animationWarn from './animationData/refresh-spinner-end-warning.json';
-import { TransientFrameProps, withFrameProps, FrameProps } from '../../common/frameProps';
+import { withFrameProps, FrameProps } from '../../common/frameProps';
+import { TransientProps } from '../../../utils/transientProps';
+
+export const allowedSpinnerFrameProps: (keyof FrameProps)[] = ['margin'];
+type AllowedFrameProps = Pick<FrameProps, (typeof allowedSpinnerFrameProps)[number]>;
 
 const StyledLottie = styled(Lottie)<
     {
         size: SpinnerProps['size'];
         $isGrey: SpinnerProps['isGrey'];
-    } & TransientFrameProps
+    } & TransientProps<AllowedFrameProps>
 >`
     width: ${({ size }) => `${size}px`};
     height: ${({ size }) => `${size}px`};
@@ -20,7 +24,7 @@ const StyledLottie = styled(Lottie)<
     ${withFrameProps}
 `;
 
-export interface SpinnerProps {
+export type SpinnerProps = AllowedFrameProps & {
     size?: number;
     isGrey?: boolean;
     hasStartAnimation?: boolean;
@@ -28,8 +32,7 @@ export interface SpinnerProps {
     hasError?: boolean;
     className?: string;
     dataTest?: string;
-    margin?: FrameProps['margin'];
-}
+};
 
 export const Spinner = ({
     size = 100,

--- a/packages/components/src/components/typography/Heading/Heading.stories.tsx
+++ b/packages/components/src/components/typography/Heading/Heading.stories.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { Meta, StoryObj } from '@storybook/react';
-import { H1, H2, H3 } from '../../../index';
-import { framePropsStory } from '../../common/frameProps';
+import { H1, H2, H3, allowedFrameProps } from './Heading';
+import { getFramePropsStory } from '../../common/frameProps';
 
 const Wrapper = styled.div`
     display: flex;
@@ -21,6 +21,6 @@ export const Heading: StoryObj = {
             <H3>This is heading 3</H3>
         </Wrapper>
     ),
-    args: framePropsStory.args,
-    argTypes: framePropsStory.argTypes,
+    args: getFramePropsStory(allowedFrameProps).args,
+    argTypes: getFramePropsStory(allowedFrameProps).argTypes,
 };

--- a/packages/components/src/components/typography/Heading/Heading.stories.tsx
+++ b/packages/components/src/components/typography/Heading/Heading.stories.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { Meta, StoryObj } from '@storybook/react';
-import { H1, H2, H3, allowedFrameProps } from './Heading';
+import { H1, H2, H3, allowedHeadingFrameProps } from './Heading';
 import { getFramePropsStory } from '../../common/frameProps';
 
 const Wrapper = styled.div`
@@ -21,6 +21,6 @@ export const Heading: StoryObj = {
             <H3>This is heading 3</H3>
         </Wrapper>
     ),
-    args: getFramePropsStory(allowedFrameProps).args,
-    argTypes: getFramePropsStory(allowedFrameProps).argTypes,
+    args: getFramePropsStory(allowedHeadingFrameProps).args,
+    argTypes: getFramePropsStory(allowedHeadingFrameProps).argTypes,
 };

--- a/packages/components/src/components/typography/Heading/Heading.tsx
+++ b/packages/components/src/components/typography/Heading/Heading.tsx
@@ -4,8 +4,8 @@ import { Color, TypographyStyle, typography } from '@trezor/theme';
 import { FrameProps, withFrameProps } from '../../common/frameProps';
 import { makePropsTransient, TransientProps } from '../../../utils/transientProps';
 
-export const allowedFrameProps: (keyof FrameProps)[] = ['margin'];
-type AllowedFrameProps = Pick<FrameProps, (typeof allowedFrameProps)[number]>;
+export const allowedHeadingFrameProps: (keyof FrameProps)[] = ['margin'];
+type AllowedFrameProps = Pick<FrameProps, (typeof allowedHeadingFrameProps)[number]>;
 
 type Align = 'left' | 'center' | 'right';
 

--- a/packages/components/src/components/typography/Heading/Heading.tsx
+++ b/packages/components/src/components/typography/Heading/Heading.tsx
@@ -1,8 +1,11 @@
 import styled from 'styled-components';
 
 import { Color, TypographyStyle, typography } from '@trezor/theme';
-import { FrameProps, TransientFrameProps, withFrameProps } from '../../common/frameProps';
-import { makePropsTransient } from '../../../utils/transientProps';
+import { FrameProps, withFrameProps } from '../../common/frameProps';
+import { makePropsTransient, TransientProps } from '../../../utils/transientProps';
+
+export const allowedFrameProps: (keyof FrameProps)[] = ['margin'];
+type AllowedFrameProps = Pick<FrameProps, (typeof allowedFrameProps)[number]>;
 
 type Align = 'left' | 'center' | 'right';
 
@@ -13,7 +16,7 @@ type BasicProps = {
     onClick?: () => void;
 };
 
-type HeadingProps = TransientFrameProps &
+type HeadingProps = TransientProps<AllowedFrameProps> &
     BasicProps & {
         $typographyStyle: TypographyStyle;
         $color?: Color;
@@ -26,7 +29,7 @@ const Heading = styled.h1<HeadingProps>`
     ${withFrameProps}
 `;
 
-type HProps = FrameProps & BasicProps & { color?: Color };
+type HProps = AllowedFrameProps & BasicProps & { color?: Color };
 
 export const H1 = ({ margin, color, ...props }: HProps) => (
     <Heading

--- a/packages/components/src/components/typography/Heading/Heading.tsx
+++ b/packages/components/src/components/typography/Heading/Heading.tsx
@@ -1,10 +1,10 @@
 import styled from 'styled-components';
 
 import { Color, TypographyStyle, typography } from '@trezor/theme';
-import { FrameProps, withFrameProps } from '../../common/frameProps';
+import { FrameProps, FramePropsKeys, withFrameProps } from '../../common/frameProps';
 import { makePropsTransient, TransientProps } from '../../../utils/transientProps';
 
-export const allowedHeadingFrameProps: (keyof FrameProps)[] = ['margin'];
+export const allowedHeadingFrameProps: FramePropsKeys[] = ['margin'];
 type AllowedFrameProps = Pick<FrameProps, (typeof allowedHeadingFrameProps)[number]>;
 
 type Align = 'left' | 'center' | 'right';

--- a/packages/suite/src/components/suite/layouts/WelcomeLayout/WelcomeLayout.tsx
+++ b/packages/suite/src/components/suite/layouts/WelcomeLayout/WelcomeLayout.tsx
@@ -11,6 +11,7 @@ import {
     ElevationUp,
     ElevationDown,
     ElevationContext,
+    Column,
 } from '@trezor/components';
 import { useOnce } from '@trezor/react-utils';
 import { Translation } from 'src/components/suite';
@@ -27,6 +28,7 @@ import { useGuide } from 'src/hooks/guide';
 import { MAX_ONBOARDING_WIDTH } from 'src/constants/suite/layout';
 import { NavSettings } from './NavSettings';
 import { Elevation, mapElevationToBackground, spacingsPx } from '@trezor/theme';
+import { TrafficLightOffset } from '../../TrafficLightOffset';
 
 const Wrapper = styled.div`
     display: flex;
@@ -59,10 +61,6 @@ const WelcomeWrapper = styled.div<{ $elevation: Elevation }>`
 `;
 
 const MotionWelcome = styled(motion.div)`
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    display: flex;
     height: 100%;
     overflow: hidden;
     min-width: 380px;
@@ -145,32 +143,36 @@ const Left = () => {
                             transition: { duration: 0.3, bounce: 0 },
                         }}
                     >
-                        <Expander data-test="@welcome/title">
-                            <TrezorLogo type="symbol" width="57px" />
-                        </Expander>
+                        <TrafficLightOffset>
+                            <Column justifyContent="center" alignItems="center" height="100%">
+                                <Expander data-test="@welcome/title">
+                                    <TrezorLogo type="symbol" width="57px" />
+                                </Expander>
 
-                        <LinksContainer>
-                            {isWeb() && (
-                                <TrezorLink type="hint" variant="nostyle" href={SUITE_URL}>
-                                    <Button
-                                        variant="tertiary"
-                                        icon="EXTERNAL_LINK"
-                                        iconAlignment="right"
-                                    >
-                                        <Translation id="TR_ONBOARDING_DOWNLOAD_DESKTOP_APP" />
-                                    </Button>
-                                </TrezorLink>
-                            )}
-                            <TrezorLink type="hint" variant="nostyle" href={TREZOR_URL}>
-                                <Button
-                                    variant="tertiary"
-                                    icon="EXTERNAL_LINK"
-                                    iconAlignment="right"
-                                >
-                                    trezor.io
-                                </Button>
-                            </TrezorLink>
-                        </LinksContainer>
+                                <LinksContainer>
+                                    {isWeb() && (
+                                        <TrezorLink type="hint" variant="nostyle" href={SUITE_URL}>
+                                            <Button
+                                                variant="tertiary"
+                                                icon="EXTERNAL_LINK"
+                                                iconAlignment="right"
+                                            >
+                                                <Translation id="TR_ONBOARDING_DOWNLOAD_DESKTOP_APP" />
+                                            </Button>
+                                        </TrezorLink>
+                                    )}
+                                    <TrezorLink type="hint" variant="nostyle" href={TREZOR_URL}>
+                                        <Button
+                                            variant="tertiary"
+                                            icon="EXTERNAL_LINK"
+                                            iconAlignment="right"
+                                        >
+                                            trezor.io
+                                        </Button>
+                                    </TrezorLink>
+                                </LinksContainer>
+                            </Column>
+                        </TrafficLightOffset>
                     </MotionWelcome>
                 )}
             </AnimatePresence>

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewEvmExplanation.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewEvmExplanation.tsx
@@ -2,25 +2,14 @@ import { Warning } from '@trezor/components';
 import { Translation } from 'src/components/suite';
 import { Account } from 'src/types/wallet';
 import { networks } from '@suite-common/wallet-config';
-import {
-    FrameProps,
-    TransientFrameProps,
-    withFrameProps,
-} from '@trezor/components/src/components/common/frameProps';
-import styled from 'styled-components';
-
-const Wrapper = styled.div<TransientFrameProps>`
-    ${withFrameProps}
-`;
+import { spacings } from '@trezor/theme';
 
 type TransactionReviewEvmExplanationProps = {
     account: Account;
-    margin?: FrameProps['margin'];
 };
 
 export const TransactionReviewEvmExplanation = ({
     account,
-    margin,
 }: TransactionReviewEvmExplanationProps) => {
     const network = networks[account.symbol];
 
@@ -29,16 +18,14 @@ export const TransactionReviewEvmExplanation = ({
     }
 
     return (
-        <Wrapper $margin={margin}>
-            <Warning>
-                <Translation
-                    id="TR_EVM_EXPLANATION_SEND_MODAL_DESCRIPTION"
-                    values={{
-                        network: network.name,
-                        b: text => <b>{text}</b>,
-                    }}
-                />
-            </Warning>
-        </Wrapper>
+        <Warning margin={{ top: spacings.sm }}>
+            <Translation
+                id="TR_EVM_EXPLANATION_SEND_MODAL_DESCRIPTION"
+                values={{
+                    network: network.name,
+                    b: text => <b>{text}</b>,
+                }}
+            />
+        </Warning>
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
@@ -20,7 +20,6 @@ import { Modal, Translation } from 'src/components/suite';
 import { TransactionReviewSummary } from './TransactionReviewSummary';
 import { TransactionReviewOutputList } from './TransactionReviewOutputList/TransactionReviewOutputList';
 import { TransactionReviewEvmExplanation } from './TransactionReviewEvmExplanation';
-import { spacings } from '@trezor/theme';
 import { getTxStakeNameByDataHex } from '@suite-common/suite-utils';
 
 const StyledModal = styled(Modal)`
@@ -169,10 +168,7 @@ export const TransactionReviewModalContent = ({
                 setIsSending={() => setIsSending(true)}
                 ethereumStakeType={ethereumStakeType || undefined}
             />
-            <TransactionReviewEvmExplanation
-                account={selectedAccount.account}
-                margin={{ top: spacings.sm }}
-            />
+            <TransactionReviewEvmExplanation account={selectedAccount.account} />
         </StyledModal>
     );
 };

--- a/packages/suite/src/views/settings/SettingsDevice/SettingsDevice.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/SettingsDevice.tsx
@@ -54,6 +54,7 @@ export const SettingsDevice = () => {
     const deviceRemembered = isDeviceRemembered(device) && !device?.connected;
     const bitcoinOnlyDevice = isBitcoinOnlyDevice(device);
 
+    console.log('______', device, transport);
     if (deviceSettingsUnavailable(device, transport)) {
         return (
             <SettingsLayout>

--- a/packages/suite/src/views/settings/SettingsDevice/SettingsDevice.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/SettingsDevice.tsx
@@ -54,7 +54,6 @@ export const SettingsDevice = () => {
     const deviceRemembered = isDeviceRemembered(device) && !device?.connected;
     const bitcoinOnlyDevice = isBitcoinOnlyDevice(device);
 
-    console.log('______', device, transport);
     if (deviceSettingsUnavailable(device, transport)) {
         return (
             <SettingsLayout>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- do not allow all frame props for each DS component 
  - for example I can set that `Warning` component shouldn't have `width` prop but it can have `margin` 
- it automatically shows only all allowed frame props in storybook for each component
- add `height, width, maxHeight` to frame props
- delete bad usage of frame props in `TransactionReviewEvmExplanation`

not very related to frameprops:
- fix issue when user can't move with window on mac

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
