### PR TITLE
fix(suite-native): fix assign to read-only property shadowOffset error

### DIFF
--- a/suite-native/biometrics/src/components/BiometricsIcon.tsx
+++ b/suite-native/biometrics/src/components/BiometricsIcon.tsx
@@ -18,7 +18,7 @@ const iconWrapperStyle = prepareNativeStyle(
 
         extend: {
             condition: showShadow,
-            style: utils.boxShadows.small,
+            style: { ...utils.boxShadows.small },
         },
     }),
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In debug mode, biometrics was not working, always got this error:

`Cannot assign to read-only property 'shadowOffset'`

## Screenshots:
<img width="374" alt="image" src="https://github.com/user-attachments/assets/aa06e431-72fc-4a93-b9f3-56a0ec248bd2">

