### PR TITLE
connect explorer - method processing visual feedback

### DIFF
--- a/packages/components/src/components/buttons/Button/Button.tsx
+++ b/packages/components/src/components/buttons/Button/Button.tsx
@@ -131,7 +131,7 @@ export const Button = ({
         />
     ) : null;
 
-    const Loader = <Spinner size={getIconSize(size)} />;
+    const Loader = <Spinner size={getIconSize(size)} dataTest={`${rest['data-test']}/spinner`} />;
 
     return (
         <ButtonContainer

--- a/packages/components/src/components/loaders/Spinner/Spinner.tsx
+++ b/packages/components/src/components/loaders/Spinner/Spinner.tsx
@@ -87,7 +87,7 @@ export const Spinner = ({
             className={className}
             $margin={margin}
             {...getProps()}
-            data-test={dataTest}
+            data-test={dataTest ? dataTest : `@spinner`}
         />
     );
 };

--- a/packages/connect-explorer/src/actions/methodActions.ts
+++ b/packages/connect-explorer/src/actions/methodActions.ts
@@ -15,6 +15,7 @@ export const REMOVE_BATCH = 'method_remove_batch';
 export const SET_UNION = 'method_set_union';
 export const RESPONSE = 'method_response';
 export const SET_MANUAL_MODE = 'method_set_manual_mode';
+export const SET_METHOD_PROCESSING = 'method_set_processing';
 
 export type MethodAction =
     | { type: typeof SET_METHOD; methodConfig: any }
@@ -25,8 +26,8 @@ export type MethodAction =
     | { type: typeof REMOVE_BATCH; field: Field<any>; batch: any[] }
     | { type: typeof SET_UNION; field: Field<any>; current: any }
     | { type: typeof RESPONSE; response: any }
-    | { type: typeof SET_MANUAL_MODE; manualMode: boolean };
-
+    | { type: typeof SET_MANUAL_MODE; manualMode: boolean }
+    | { type: typeof SET_METHOD_PROCESSING; payload: boolean };
 export const onSetMethod = (methodConfig: any) => ({
     type: SET_METHOD,
     methodConfig,
@@ -81,7 +82,7 @@ export const onSetManualMode = (manualMode: boolean) => ({
 export const onSubmit = () => async (dispatch: Dispatch, getState: GetState) => {
     const { method } = getState();
     if (!method?.name) throw new Error('method name not specified');
-
+    dispatch({ type: SET_METHOD_PROCESSING, payload: true });
     const connectMethod = TrezorConnect[method.name];
     if (typeof connectMethod !== 'function') {
         dispatch(
@@ -97,7 +98,7 @@ export const onSubmit = () => async (dispatch: Dispatch, getState: GetState) => 
     const response = await connectMethod({
         ...method.params,
     });
-
+    dispatch({ type: SET_METHOD_PROCESSING, payload: false });
     dispatch(onResponse(response));
 };
 

--- a/packages/connect-explorer/src/components/Method.tsx
+++ b/packages/connect-explorer/src/components/Method.tsx
@@ -5,7 +5,7 @@ import { useState, useCallback, useEffect } from 'react';
 import styled, { useTheme } from 'styled-components';
 import { CopyToClipboard } from 'nextra/components';
 
-import { Button as TrezorButton, H3, Card } from '@trezor/components';
+import { Button as TrezorButton, ButtonProps, H3, Card } from '@trezor/components';
 import { spacingsPx } from '@trezor/theme';
 
 import type { Field, FieldWithBundle, FieldWithUnion } from '../types';
@@ -225,6 +225,26 @@ export const VerifyButton = ({ name, onClick }: VerifyButtonProps) => {
     return <Button onClick={() => onClick(verifyUrls[index])}>Verify response</Button>;
 };
 
+type SubmitButtonProps = {
+    onClick: ButtonProps['onClick'];
+    isFullWidth?: ButtonProps['isFullWidth'];
+    isLoading: ButtonProps['isLoading'];
+    text?: string;
+};
+
+const SubmitButton = ({ onClick, text, isFullWidth, isLoading }: SubmitButtonProps) => {
+    return (
+        <Button
+            onClick={onClick}
+            data-test="@submit-button"
+            isFullWidth={isFullWidth}
+            isLoading={isLoading}
+        >
+            {text || 'Submit'}
+        </Button>
+    );
+};
+
 export const Method = () => {
     const theme = useTheme();
     const { method } = useSelector(state => ({
@@ -243,9 +263,11 @@ export const Method = () => {
 
     const { onSubmit } = actions;
 
-    const { name, submitButton, fields, javascriptCode, response, schema, manualMode } = method;
+    const { name, submitButton, fields, javascriptCode, response, schema, manualMode, processing } =
+        method;
 
     const [code, setCode] = useState('');
+
     const codeChange = useCallback(
         (val: string) => {
             setCode(val);
@@ -274,6 +296,12 @@ export const Method = () => {
         />
     ) : null;
 
+    const buttonProps: SubmitButtonProps = {
+        onClick: onSubmit,
+        text: submitButton,
+        isLoading: processing,
+    };
+
     return (
         <MethodContent $manualMode={manualMode}>
             <div>
@@ -284,9 +312,8 @@ export const Method = () => {
                         <CopyWrapper>
                             <CopyToClipboard getValue={() => javascriptCode ?? ''} />
                         </CopyWrapper>
-                        <Button onClick={onSubmit} data-test="@submit-button">
-                            {submitButton}
-                        </Button>
+
+                        <SubmitButton {...buttonProps} />
                     </Container>
                 ) : (
                     getFields(fields, { actions })
@@ -301,9 +328,7 @@ export const Method = () => {
                                 <CopyToClipboard getValue={() => javascriptCode ?? ''} />
                             </CopyWrapper>
                             <pre>{javascriptCode}</pre>
-                            <Button onClick={onSubmit} data-test="@submit-button" isFullWidth>
-                                {submitButton}
-                            </Button>
+                            <SubmitButton {...buttonProps} isFullWidth />
                         </Container>
                     )}
                     <Container data-test="@response">

--- a/packages/connect-explorer/src/components/ParamsTable.tsx
+++ b/packages/connect-explorer/src/components/ParamsTable.tsx
@@ -110,17 +110,17 @@ export const ParamsTable = ({ schema, topLevelSchema, descriptions }: ParamsTabl
     const common = { topLevelSchema: topLevelSchemaCurrent, descriptions };
     if (schema[Kind] === 'Union') {
         return schema.anyOf?.map((param: TSchema, i: number) => (
-            <>
+            <div key={i}>
                 {i > 0 && <h3>or</h3>}
                 <ParamsTable key={i} schema={param} {...common} />
-            </>
+            </div>
         ));
     } else if (schema[Kind] === 'Intersect') {
         return schema.allOf?.map((param: TSchema, i: number) => (
-            <>
+            <div key={i}>
                 {i > 0 && <h3>and</h3>}
-                <ParamsTable key={i} schema={param} {...common} />
-            </>
+                <ParamsTable schema={param} {...common} />
+            </div>
         ));
     } else if (schema[Kind] === 'Object') {
         return Object.entries(schema.properties)?.map(([name, value]: [string, any]) => (

--- a/packages/connect-explorer/src/reducers/methodCommon.ts
+++ b/packages/connect-explorer/src/reducers/methodCommon.ts
@@ -14,6 +14,7 @@ export interface MethodState {
     addressValidation?: boolean;
     schema?: TSchema;
     manualMode?: boolean;
+    processing: boolean;
 }
 
 export const initialState: MethodState = {
@@ -25,6 +26,7 @@ export const initialState: MethodState = {
     response: undefined,
     addressValidation: false,
     manualMode: false,
+    processing: false,
 };
 
 // Converts the fields into a params object

--- a/packages/connect-explorer/src/reducers/methodReducer.ts
+++ b/packages/connect-explorer/src/reducers/methodReducer.ts
@@ -8,6 +8,7 @@ import {
     SET_SCHEMA,
     SET_UNION,
     SET_MANUAL_MODE,
+    SET_METHOD_PROCESSING,
 } from '../actions/methodActions';
 import { isFieldBasic, type Action, type Field } from '../types';
 import {
@@ -141,6 +142,12 @@ export default function method(state: MethodState = initialState, action: Action
             return {
                 ...state,
                 manualMode: action.manualMode,
+            };
+
+        case SET_METHOD_PROCESSING:
+            return {
+                ...state,
+                processing: action.payload,
             };
 
         default:

--- a/packages/connect-popup/e2e/support/helpers.ts
+++ b/packages/connect-popup/e2e/support/helpers.ts
@@ -118,6 +118,7 @@ export const openPopup = (
     }
     triggerPopup.push(explorerPage.click("div[data-test='@api-playground/collapsible-box']"));
     triggerPopup.push(explorerPage.click("button[data-test='@submit-button']"));
+    triggerPopup.push(explorerPage.waitForSelector("[data-test='@submit-button/spinner']"));
 
     return Promise.all(triggerPopup) as Promise<Page[]>;
 };

--- a/packages/connect-popup/e2e/tests/analytics.test.ts
+++ b/packages/connect-popup/e2e/tests/analytics.test.ts
@@ -10,14 +10,14 @@ test.beforeAll(async () => {
 });
 
 test('reporting', async ({ page }) => {
-    await TrezorUserEnvLink.api.stopBridge();
-    await TrezorUserEnvLink.api.stopEmu();
-    await TrezorUserEnvLink.api.startEmu({
+    await TrezorUserEnvLink.stopBridge();
+    await TrezorUserEnvLink.stopEmu();
+    await TrezorUserEnvLink.startEmu({
         wipe: true,
         save_screenshots: true,
     });
 
-    await TrezorUserEnvLink.api.setupEmu({
+    await TrezorUserEnvLink.setupEmu({
         mnemonic: 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle',
         pin: '',
         passphrase_protection: true,
@@ -26,7 +26,7 @@ test('reporting', async ({ page }) => {
     });
     await TrezorUserEnvLink.send({ type: 'emulator-allow-unsafe-paths' });
 
-    await TrezorUserEnvLink.api.startBridge();
+    await TrezorUserEnvLink.startBridge();
 
     await page.goto(`${url}#/method/getAddress`);
 

--- a/packages/connect-popup/e2e/tests/browser-support.test.ts
+++ b/packages/connect-popup/e2e/tests/browser-support.test.ts
@@ -28,8 +28,8 @@ const openPopup = async (page: Page) =>
 
 test.beforeAll(async () => {
     await TrezorUserEnvLink.connect();
-    await TrezorUserEnvLink.api.stopBridge();
-    await TrezorUserEnvLink.api.stopEmu();
+    await TrezorUserEnvLink.stopBridge();
+    await TrezorUserEnvLink.stopEmu();
 });
 
 test('unsupported browser', async ({ browser }) => {

--- a/packages/connect-popup/e2e/tests/methods.test.ts
+++ b/packages/connect-popup/e2e/tests/methods.test.ts
@@ -64,21 +64,21 @@ filteredFixtures.forEach(f => {
         // FIXME: always reset for now, due to flaky tests with bridge bug
         if (true || JSON.stringify(device) !== JSON.stringify(f.device) || retry) {
             device = f.device;
-            await TrezorUserEnvLink.api.stopBridge();
-            await TrezorUserEnvLink.api.stopEmu();
-            await TrezorUserEnvLink.api.startEmu({
+            await TrezorUserEnvLink.stopBridge();
+            await TrezorUserEnvLink.stopEmu();
+            await TrezorUserEnvLink.startEmu({
                 wipe: true,
                 save_screenshots: true,
             });
             // @ts-expect-error
             if (!f.device.wiped) {
                 // @ts-expect-error
-                await TrezorUserEnvLink.api.setupEmu({
+                await TrezorUserEnvLink.setupEmu({
                     ...f.device,
                 });
                 await TrezorUserEnvLink.send({ type: 'emulator-allow-unsafe-paths' });
             }
-            await TrezorUserEnvLink.api.startBridge();
+            await TrezorUserEnvLink.startBridge();
         }
 
         const screenshotsPath = await ensureDirectoryExists(`./e2e/screenshots/${f.url}`);

--- a/packages/connect-popup/e2e/tests/passphrase.test.ts
+++ b/packages/connect-popup/e2e/tests/passphrase.test.ts
@@ -32,15 +32,15 @@ test.beforeAll(async () => {
 
 test.beforeEach(async ({ page }) => {
     log('beforeEach', 'stopBridge');
-    await TrezorUserEnvLink.api.stopBridge();
+    await TrezorUserEnvLink.stopBridge();
     log('beforeEach', 'stopEmu');
-    await TrezorUserEnvLink.api.stopEmu();
+    await TrezorUserEnvLink.stopEmu();
     log('beforeEach', 'startEmu');
-    await TrezorUserEnvLink.api.startEmu({
+    await TrezorUserEnvLink.startEmu({
         wipe: true,
     });
     log('beforeEach', 'setupEmu');
-    await TrezorUserEnvLink.api.setupEmu({
+    await TrezorUserEnvLink.setupEmu({
         mnemonic: 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle',
         pin: '',
         passphrase_protection: true,
@@ -48,7 +48,7 @@ test.beforeEach(async ({ page }) => {
         needs_backup: false,
     });
     log('beforeEach', 'startBridge');
-    await TrezorUserEnvLink.api.startBridge(bridgeVersion);
+    await TrezorUserEnvLink.startBridge(bridgeVersion);
 
     log('beforeEach', 'getting contexts');
     const contexts = await getContexts(page, url, isWebExtension);
@@ -124,15 +124,15 @@ test('input passphrase in popup and device accepts it', async () => {
 
     log('accepting to see passphrase');
     // Accept to see Passphrase.
-    await TrezorUserEnvLink.api.pressYes();
+    await TrezorUserEnvLink.pressYes();
 
     log('confirming passphrase is correct');
     // Confirm Passphrase is correct.
-    await TrezorUserEnvLink.api.pressYes();
+    await TrezorUserEnvLink.pressYes();
 
     log('confirming right address is displayed');
     // Confirm right address is displayed.
-    await TrezorUserEnvLink.api.pressYes();
+    await TrezorUserEnvLink.pressYes();
 });
 
 test('introduce passphrase in popup and device rejects it', async () => {
@@ -167,10 +167,10 @@ test('introduce passphrase in popup and device rejects it', async () => {
     await waitAndClick(popup, ['@passphrase/hidden/submit-button']);
 
     // Accept to see Passphrase.
-    await TrezorUserEnvLink.api.pressYes();
+    await TrezorUserEnvLink.pressYes();
 
     // Cancel Passphrase is incorrect.
-    await TrezorUserEnvLink.api.pressNo();
+    await TrezorUserEnvLink.pressNo();
 
     await waitAndClick(popup, ['@connect-ui/error-close-button']);
 
@@ -200,13 +200,13 @@ test('introduce passphrase successfully next time should not ask for it', async 
     await waitAndClick(popup, ['@passphrase/hidden/submit-button']);
 
     // Accept to see Passphrase.
-    await TrezorUserEnvLink.api.pressYes();
+    await TrezorUserEnvLink.pressYes();
 
     // Confirm Passphrase is correct.
-    await TrezorUserEnvLink.api.pressYes();
+    await TrezorUserEnvLink.pressYes();
 
     // Confirm right address is displayed.
-    await TrezorUserEnvLink.api.pressYes();
+    await TrezorUserEnvLink.pressYes();
 
     // Wait for submit button
     await waitAndClick(explorerPage, ['@api-playground/collapsible-box']);
@@ -248,13 +248,13 @@ test('introduce passphrase successfully reload 3rd party it should ask again for
     await waitAndClick(popup, ['@passphrase/hidden/submit-button']);
 
     // Accept to see Passphrase.
-    await TrezorUserEnvLink.api.pressYes();
+    await TrezorUserEnvLink.pressYes();
 
     // Confirm Passphrase is correct.
-    await TrezorUserEnvLink.api.pressYes();
+    await TrezorUserEnvLink.pressYes();
 
     // Confirm right address is displayed.
-    await TrezorUserEnvLink.api.pressYes();
+    await TrezorUserEnvLink.pressYes();
 
     // Wait for success message before reloading page.
     await explorerPage.waitForSelector('text=success: true');
@@ -316,9 +316,9 @@ test('passphrase mismatch', async ({ page }) => {
     log('submitting passphrase');
     await waitAndClick(popup, ['@passphrase/hidden/submit-button']);
     // Accept to see Passphrase.
-    await TrezorUserEnvLink.api.pressYes();
+    await TrezorUserEnvLink.pressYes();
     // Confirm Passphrase is correct.
-    await TrezorUserEnvLink.api.pressYes();
+    await TrezorUserEnvLink.pressYes();
 
     log('waiting and click for invalid passphrase try again button');
     await waitAndClick(popup, ['@invalid-passphrase/try-again']);
@@ -331,13 +331,13 @@ test('passphrase mismatch', async ({ page }) => {
     await waitAndClick(popup, ['@passphrase/hidden/submit-button']);
 
     // Accept to see Passphrase.
-    await TrezorUserEnvLink.api.pressYes();
+    await TrezorUserEnvLink.pressYes();
 
     // Confirm Passphrase is correct.
-    await TrezorUserEnvLink.api.pressYes();
+    await TrezorUserEnvLink.pressYes();
 
     // Confirm right address is displayed.
-    await TrezorUserEnvLink.api.pressYes();
+    await TrezorUserEnvLink.pressYes();
 
     // Wait for element in connect-explorer before reloading it.
     await waitAndClick(page, ['@api-playground/collapsible-box']);
@@ -386,13 +386,13 @@ test('passphrase mismatch', async ({ page }) => {
     await waitAndClick(popup, ['@passphrase/hidden/submit-button']);
 
     // Accept to see Passphrase.
-    await TrezorUserEnvLink.api.pressYes();
+    await TrezorUserEnvLink.pressYes();
     // Confirm Passphrase is correct.
-    await TrezorUserEnvLink.api.pressYes();
+    await TrezorUserEnvLink.pressYes();
 
     // It display mismatch error, and we accept to use this passphrase.
     await waitAndClick(popup, ['@invalid-passphrase/use-this-passphrase']);
 
     // Confirm right address is displayed.
-    await TrezorUserEnvLink.api.pressYes();
+    await TrezorUserEnvLink.pressYes();
 });

--- a/packages/connect-popup/e2e/tests/permissions.test.ts
+++ b/packages/connect-popup/e2e/tests/permissions.test.ts
@@ -8,11 +8,11 @@ let popup: Page;
 
 test.beforeAll(async () => {
     await TrezorUserEnvLink.connect();
-    await TrezorUserEnvLink.api.stopEmu();
-    await TrezorUserEnvLink.api.stopBridge();
-    await TrezorUserEnvLink.api.startEmu({ wipe: true });
-    await TrezorUserEnvLink.api.setupEmu({ passphrase_protection: false });
-    await TrezorUserEnvLink.api.startBridge();
+    await TrezorUserEnvLink.stopEmu();
+    await TrezorUserEnvLink.stopBridge();
+    await TrezorUserEnvLink.startEmu({ wipe: true });
+    await TrezorUserEnvLink.setupEmu({ passphrase_protection: false });
+    await TrezorUserEnvLink.startBridge();
 });
 
 const fixtures = [

--- a/packages/connect-popup/e2e/tests/popup-close-legacy.test.ts
+++ b/packages/connect-popup/e2e/tests/popup-close-legacy.test.ts
@@ -43,19 +43,19 @@ test.beforeEach(async ({ page }) => {
     requests = [];
     responses = [];
     releasePromise = createDeferred();
-    await TrezorUserEnvLink.api.stopBridge();
-    await TrezorUserEnvLink.api.stopEmu();
-    await TrezorUserEnvLink.api.startEmu({
+    await TrezorUserEnvLink.stopBridge();
+    await TrezorUserEnvLink.stopEmu();
+    await TrezorUserEnvLink.startEmu({
         wipe: true,
     });
-    await TrezorUserEnvLink.api.setupEmu({
+    await TrezorUserEnvLink.setupEmu({
         mnemonic: 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle',
         pin: '',
         passphrase_protection: false,
         label: 'My Trevor',
         needs_backup: false,
     });
-    await TrezorUserEnvLink.api.startBridge(BRIDGE_VERSION);
+    await TrezorUserEnvLink.startBridge(BRIDGE_VERSION);
     log('beforeEach', 'go to: ', `${url}#/method/verifyMessage`);
     await page.goto(`${url}#/method/verifyMessage`);
     log('beforeEach', 'waitForSelector: ', "button[data-test='@submit-button']");
@@ -190,7 +190,7 @@ test(`device disconnected during device interaction with bridge version ${BRIDGE
 
     log('user canceled interaction on device');
     // user canceled interaction on device
-    await TrezorUserEnvLink.api.stopEmu();
+    await TrezorUserEnvLink.stopEmu();
     await page.waitForTimeout(WAIT_AFTER_TEST);
 
     responses.forEach(response => {
@@ -209,7 +209,7 @@ test(`device disconnected during device interaction with bridge version ${BRIDGE
 
     await page.waitForSelector('text=device disconnected during action');
 
-    await TrezorUserEnvLink.api.startEmu();
+    await TrezorUserEnvLink.startEmu();
 });
 
 test.skip(`popup is reloaded by user. bridge version ${BRIDGE_VERSION}`, async () => {
@@ -226,9 +226,9 @@ test.skip(`popup is reloaded by user. bridge version ${BRIDGE_VERSION}`, async (
 test.skip('when user cancels permissions in popup it closes automatically', async ({ page }) => {
     log('start', test.info().title);
 
-    await TrezorUserEnvLink.api.pressYes();
-    await TrezorUserEnvLink.api.pressYes();
-    await TrezorUserEnvLink.api.pressYes();
+    await TrezorUserEnvLink.pressYes();
+    await TrezorUserEnvLink.pressYes();
+    await TrezorUserEnvLink.pressYes();
 
     popupClosedPromise = new Promise(resolve => {
         popup.on('close', () => resolve(undefined));
@@ -262,9 +262,9 @@ test.skip('when user cancels Export Bitcoin address dialog in popup it closes au
 }) => {
     log('start', test.info().title);
 
-    await TrezorUserEnvLink.api.pressYes();
-    await TrezorUserEnvLink.api.pressYes();
-    await TrezorUserEnvLink.api.pressYes();
+    await TrezorUserEnvLink.pressYes();
+    await TrezorUserEnvLink.pressYes();
+    await TrezorUserEnvLink.pressYes();
 
     popupClosedPromise = new Promise(resolve => {
         popup.on('close', () => resolve(undefined));

--- a/packages/connect-popup/e2e/tests/popup-close.test.ts
+++ b/packages/connect-popup/e2e/tests/popup-close.test.ts
@@ -39,15 +39,15 @@ test.beforeAll(async () => {
 
 const setup = async ({ page, context }: { page: Page; context?: BrowserContext }) => {
     log('beforeEach', 'stopBridge');
-    await TrezorUserEnvLink.api.stopBridge();
+    await TrezorUserEnvLink.stopBridge();
     log('beforeEach', 'stopEmu');
-    await TrezorUserEnvLink.api.stopEmu();
+    await TrezorUserEnvLink.stopEmu();
     log('beforeEach', 'startEmu');
-    await TrezorUserEnvLink.api.startEmu({
+    await TrezorUserEnvLink.startEmu({
         wipe: true,
     });
     log('beforeEach', 'setupEmu');
-    await TrezorUserEnvLink.api.setupEmu({
+    await TrezorUserEnvLink.setupEmu({
         mnemonic: 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle',
         pin: '',
         passphrase_protection: false,
@@ -55,7 +55,7 @@ const setup = async ({ page, context }: { page: Page; context?: BrowserContext }
         needs_backup: false,
     });
     log('beforeEach', 'startBridge');
-    await TrezorUserEnvLink.api.startBridge();
+    await TrezorUserEnvLink.startBridge();
 
     const contexts = await getContexts(page, url, isWebExtension);
 
@@ -181,7 +181,7 @@ test(`device disconnected during device interaction`, async ({ page, context }) 
     await setup({ page, context });
 
     log('user canceled interaction on device');
-    await TrezorUserEnvLink.api.stopEmu();
+    await TrezorUserEnvLink.stopEmu();
     await explorerPage.waitForTimeout(WAIT_AFTER_TEST);
 
     try {
@@ -205,9 +205,9 @@ test('when user cancels permissions in popup it closes automatically', async ({
     log(`test: ${test.info().title}`);
     await setup({ page, context });
 
-    await TrezorUserEnvLink.api.pressYes();
-    await TrezorUserEnvLink.api.pressYes();
-    await TrezorUserEnvLink.api.pressYes();
+    await TrezorUserEnvLink.pressYes();
+    await TrezorUserEnvLink.pressYes();
+    await TrezorUserEnvLink.pressYes();
 
     popupClosedPromise = new Promise(resolve => {
         popup.on('close', () => resolve(undefined));
@@ -249,9 +249,9 @@ test('device dialogue cancelled IN POPUP by user', async ({ page, context }) => 
     log(`test: ${test.info().title}`);
     await setup({ page, context });
 
-    await TrezorUserEnvLink.api.pressYes();
-    await TrezorUserEnvLink.api.pressYes();
-    await TrezorUserEnvLink.api.pressYes();
+    await TrezorUserEnvLink.pressYes();
+    await TrezorUserEnvLink.pressYes();
+    await TrezorUserEnvLink.pressYes();
 
     popupClosedPromise = new Promise(resolve => {
         popup.on('close', () => resolve(undefined));
@@ -293,8 +293,8 @@ test('popup should close and open new one when popup is in error state and user 
     await setup({ page, context });
 
     log('rejecting request in device by pressing no');
-    await TrezorUserEnvLink.api.pressNo();
-    await TrezorUserEnvLink.api.pressYes();
+    await TrezorUserEnvLink.pressNo();
+    await TrezorUserEnvLink.pressYes();
 
     log('waiting for error page is displayed');
     await findElementByDataTest(popup, '@connect-ui/error');
@@ -324,9 +324,9 @@ test('popup should be focused when a call is in progress and user triggers new c
     log(`test: ${test.info().title}`);
     await setup({ page, context });
 
-    await TrezorUserEnvLink.api.pressYes();
-    await TrezorUserEnvLink.api.pressYes();
-    await TrezorUserEnvLink.api.pressYes();
+    await TrezorUserEnvLink.pressYes();
+    await TrezorUserEnvLink.pressYes();
+    await TrezorUserEnvLink.pressYes();
 
     popupClosedPromise = new Promise(resolve => {
         popup.on('close', () => resolve(undefined));
@@ -358,7 +358,7 @@ test('popup should be focused when a call is in progress and user triggers new c
     await waitAndClick(popup, ['@export-address/confirm-button']);
 
     // Confirm right address is displayed.
-    await TrezorUserEnvLink.api.pressYes();
+    await TrezorUserEnvLink.pressYes();
 
     // Popup should be closed now.
     await popupClosedPromise;
@@ -374,9 +374,9 @@ test('popup should close when third party is closed', async ({ page, context }) 
 
     // We need to skip the after flow because this test closes 3rd party window and there is not window to continue with.
     test.info().annotations.push({ type: 'skip-after-flow' });
-    await TrezorUserEnvLink.api.pressYes();
-    await TrezorUserEnvLink.api.pressYes();
-    await TrezorUserEnvLink.api.pressYes();
+    await TrezorUserEnvLink.pressYes();
+    await TrezorUserEnvLink.pressYes();
+    await TrezorUserEnvLink.pressYes();
 
     popupClosedPromise = new Promise(resolve => {
         popup.on('close', () => resolve(undefined));
@@ -411,9 +411,9 @@ test('popup should behave properly with subsequent calls', async ({ page, contex
     log(`test: ${test.info().title}`);
     await setup({ page, context });
 
-    await TrezorUserEnvLink.api.pressYes();
-    await TrezorUserEnvLink.api.pressYes();
-    await TrezorUserEnvLink.api.pressYes();
+    await TrezorUserEnvLink.pressYes();
+    await TrezorUserEnvLink.pressYes();
+    await TrezorUserEnvLink.pressYes();
 
     popupClosedPromise = new Promise(resolve => {
         popup.on('close', () => resolve(undefined));

--- a/packages/connect-popup/e2e/tests/popup-close.test.ts
+++ b/packages/connect-popup/e2e/tests/popup-close.test.ts
@@ -352,7 +352,12 @@ test('popup should be focused when a call is in progress and user triggers new c
     await waitAndClick(popup, ['@permissions/confirm-button']);
 
     // Click in 3rd party to trigger new call. But instead of new call it should focus on open popup.
-    await waitAndClick(explorerPage, ['@submit-button']);
+    await explorerPage.waitForSelector(`[data-test='@submit-button']`, { state: 'visible' });
+    await explorerPage.click(`[data-test='@submit-button']`, {
+        // submit button is disabled in connect-explorer if there is a call in progress. we want to simulate what happens if 3rd party
+        // does not respect this and tries to call connect-api again.
+        force: true,
+    });
 
     // Popup should keep its reference and state so we should be able to find confirm button for export-address.
     await waitAndClick(popup, ['@export-address/confirm-button']);

--- a/packages/connect-popup/e2e/tests/popup-pages.test.ts
+++ b/packages/connect-popup/e2e/tests/popup-pages.test.ts
@@ -41,19 +41,19 @@ test.afterEach(async () => {
 test('popup should display error page when device disconnected and debug mode', async ({
     page,
 }) => {
-    await TrezorUserEnvLink.api.stopBridge();
-    await TrezorUserEnvLink.api.stopEmu();
-    await TrezorUserEnvLink.api.startEmu({
+    await TrezorUserEnvLink.stopBridge();
+    await TrezorUserEnvLink.stopEmu();
+    await TrezorUserEnvLink.startEmu({
         wipe: true,
     });
-    await TrezorUserEnvLink.api.setupEmu({
+    await TrezorUserEnvLink.setupEmu({
         mnemonic: 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle',
         pin: '',
         passphrase_protection: false,
         label: 'My Trevor',
         needs_backup: false,
     });
-    await TrezorUserEnvLink.api.startBridge(bridgeVersion);
+    await TrezorUserEnvLink.startBridge(bridgeVersion);
 
     log('generating contexts');
     const { explorerPage, explorerUrl, browserContext } = await getContexts(
@@ -93,7 +93,7 @@ test('popup should display error page when device disconnected and debug mode', 
     await popup.waitForSelector("div[data-test='@permissions']");
 
     log('stopEmu');
-    await TrezorUserEnvLink.api.stopEmu();
+    await TrezorUserEnvLink.stopEmu();
     log('waiting for popup error page');
     await popup.waitForSelector("div[data-test='@connect-ui/error']");
 });
@@ -105,19 +105,19 @@ test('log page should contain logs from shared worker', async ({ page, context }
             errorLogs.push(message.text());
         }
     });
-    await TrezorUserEnvLink.api.stopBridge();
-    await TrezorUserEnvLink.api.stopEmu();
-    await TrezorUserEnvLink.api.startEmu({
+    await TrezorUserEnvLink.stopBridge();
+    await TrezorUserEnvLink.stopEmu();
+    await TrezorUserEnvLink.startEmu({
         wipe: true,
     });
-    await TrezorUserEnvLink.api.setupEmu({
+    await TrezorUserEnvLink.setupEmu({
         mnemonic: 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle',
         pin: '',
         passphrase_protection: false,
         label: 'My Trevor',
         needs_backup: false,
     });
-    await TrezorUserEnvLink.api.startBridge(bridgeVersion);
+    await TrezorUserEnvLink.startBridge(bridgeVersion);
 
     log('generating contexts');
     const { explorerPage, explorerUrl, browserContext } = await getContexts(

--- a/packages/connect-popup/e2e/tests/transport.test.ts
+++ b/packages/connect-popup/e2e/tests/transport.test.ts
@@ -37,8 +37,8 @@ let popup: Page;
 
 test.beforeAll(async () => {
     await TrezorUserEnvLink.connect();
-    await TrezorUserEnvLink.api.stopBridge();
-    await TrezorUserEnvLink.api.stopEmu();
+    await TrezorUserEnvLink.stopBridge();
+    await TrezorUserEnvLink.stopEmu();
 });
 
 const fixtures = [

--- a/packages/connect-popup/e2e/tests/transport.test.ts
+++ b/packages/connect-popup/e2e/tests/transport.test.ts
@@ -129,6 +129,7 @@ fixtures.forEach(f => {
         [popup] = await Promise.all([
             context.waitForEvent('page'),
             page.locator("button[data-test='@submit-button']").click({ timeout: 30000 }),
+            page.waitForSelector("[data-test='@submit-button/spinner']"),
         ]);
         log('waiting for analytics');
         await waitAndClick(popup, ['@analytics/continue-button']);

--- a/packages/connect-popup/e2e/tests/unchained.test.ts
+++ b/packages/connect-popup/e2e/tests/unchained.test.ts
@@ -117,12 +117,12 @@ const signTransaction = async (page: Page, iteration: number) => {
 };
 
 test.beforeEach(async () => {
-    await TrezorUserEnvLink.api.stopBridge();
-    await TrezorUserEnvLink.api.stopEmu();
-    await TrezorUserEnvLink.api.startEmu({
+    await TrezorUserEnvLink.stopBridge();
+    await TrezorUserEnvLink.stopEmu();
+    await TrezorUserEnvLink.startEmu({
         wipe: true,
     });
-    await TrezorUserEnvLink.api.setupEmu({
+    await TrezorUserEnvLink.setupEmu({
         mnemonic:
             'merge alley lucky axis penalty manage latin gasp virus captain wheel deal chase fragile chapter boss zero dirt stadium tooth physical valve kid plunge',
         pin: '',
@@ -130,7 +130,7 @@ test.beforeEach(async () => {
         label: 'My Trevor',
         needs_backup: false,
     });
-    await TrezorUserEnvLink.api.startBridge();
+    await TrezorUserEnvLink.startBridge();
 });
 
 /**

--- a/packages/connect/e2e/common.setup.js
+++ b/packages/connect/e2e/common.setup.js
@@ -15,9 +15,6 @@ const emulatorStartOpts = process.env.emulatorStartOpts || global.emulatorStartO
 const firmware = emulatorStartOpts.version;
 
 const getController = name => {
-    TrezorUserEnvLink.on('error', error => {
-        console.error('TrezorUserEnvLink WS error', error);
-    });
     TrezorUserEnvLink.on('disconnect', () => {
         console.error('TrezorUserEnvLink WS disconnected');
     });
@@ -43,21 +40,21 @@ const setup = async (TrezorUserEnvLink, options) => {
 
     if (!options.mnemonic) return true; // skip setup if test is not using the device (composeTransaction)
 
-    await TrezorUserEnvLink.api.stopEmu();
+    await TrezorUserEnvLink.stopEmu();
 
     // after bridge is stopped, trezor-user-env automatically resolves to use udp transport.
     // this is actually good as we avoid possible race conditions when setting up emulator for
     // the test using the same transport
-    await TrezorUserEnvLink.api.stopBridge();
+    await TrezorUserEnvLink.stopBridge();
 
-    await TrezorUserEnvLink.api.startEmu(emulatorStartOpts);
+    await TrezorUserEnvLink.startEmu(emulatorStartOpts);
 
     const mnemonic =
         typeof options.mnemonic === 'string' && options.mnemonic.indexOf(' ') > 0
             ? options.mnemonic
             : MNEMONICS[options.mnemonic];
 
-    await TrezorUserEnvLink.api.setupEmu({
+    await TrezorUserEnvLink.setupEmu({
         mnemonic,
         pin: options.pin || '',
         passphrase_protection: !!options.passphrase_protection,
@@ -78,7 +75,7 @@ const setup = async (TrezorUserEnvLink, options) => {
     TrezorUserEnvLink.state = options;
 
     // after all is done, start bridge again
-    await TrezorUserEnvLink.api.startBridge();
+    await TrezorUserEnvLink.startBridge();
 };
 
 const initTrezorConnect = async (TrezorUserEnvLink, options) => {

--- a/packages/connect/e2e/tests/device/methods.test.ts
+++ b/packages/connect/e2e/tests/device/methods.test.ts
@@ -58,6 +58,9 @@ describe(`TrezorConnect methods`, () => {
                         // single test may require a different setup
                         await setup(controller, t.setup || testCase.setup);
 
+                        if (!controller.options) {
+                            controller.options = {};
+                        }
                         controller.options.name = t.description;
                         // @ts-expect-error, string + params union
                         const result = await TrezorConnect[testCase.method](t.params);

--- a/packages/suite-desktop-core/e2e/support/common.ts
+++ b/packages/suite-desktop-core/e2e/support/common.ts
@@ -19,7 +19,7 @@ export const launchSuite = async (params: LaunchSuiteParams = {}) => {
     const appDir = path.join(__dirname, '../../../suite-desktop');
     const desiredLogLevel = process.env.LOGLEVEL ?? 'error';
     // TODO: Find out why currently pw fails to see node-bridge so we default to legacy bridge.
-    await TrezorUserEnvLink.api.startBridge();
+    await TrezorUserEnvLink.startBridge();
     const electronApp = await electron.launch({
         cwd: appDir,
         args: [

--- a/packages/suite-desktop-core/e2e/tests/general/cardano-discovery.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/general/cardano-discovery.test.ts
@@ -17,9 +17,9 @@ let electronApp: ElectronApplication;
 let window: Page;
 
 testPlaywright.beforeAll(async () => {
-    await TrezorUserEnvLink.api.trezorUserEnvConnect();
-    await TrezorUserEnvLink.api.startEmu({ wipe: true });
-    await TrezorUserEnvLink.api.setupEmu({
+    await TrezorUserEnvLink.connect();
+    await TrezorUserEnvLink.startEmu({ wipe: true });
+    await TrezorUserEnvLink.setupEmu({
         needs_backup: true,
         mnemonic:
             'cloth trim improve bag pigeon party wave mechanic beyond clean cake maze protect left assist carry guitar bridge nest faith critic excuse tooth dutch',
@@ -29,7 +29,7 @@ testPlaywright.beforeAll(async () => {
 
 testPlaywright.afterAll(() => {
     electronApp.close();
-    TrezorUserEnvLink.api.stopEmu();
+    TrezorUserEnvLink.stopEmu();
 });
 
 /**

--- a/packages/suite-desktop-core/e2e/tests/general/wallet-discovery.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/general/wallet-discovery.test.ts
@@ -9,9 +9,9 @@ let electronApp: ElectronApplication;
 let window: Page;
 
 testPlaywright.beforeAll(async () => {
-    await TrezorUserEnvLink.api.trezorUserEnvConnect();
-    await TrezorUserEnvLink.api.startEmu({ wipe: true });
-    await TrezorUserEnvLink.api.setupEmu({
+    await TrezorUserEnvLink.connect();
+    await TrezorUserEnvLink.startEmu({ wipe: true });
+    await TrezorUserEnvLink.setupEmu({
         needs_backup: true,
         mnemonic: 'all all all all all all all all all all all all',
     });

--- a/packages/suite-desktop-core/e2e/tests/settings/electrum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/electrum.test.ts
@@ -12,10 +12,10 @@ let window: Page;
 
 testPlaywright.describe.serial('Suite works with Electrum server', () => {
     testPlaywright.beforeAll(async () => {
-        await TrezorUserEnvLink.api.stopBridge();
-        await TrezorUserEnvLink.api.trezorUserEnvConnect();
-        await TrezorUserEnvLink.api.startEmu({ wipe: true });
-        await TrezorUserEnvLink.api.setupEmu({
+        await TrezorUserEnvLink.stopBridge();
+        await TrezorUserEnvLink.connect();
+        await TrezorUserEnvLink.startEmu({ wipe: true });
+        await TrezorUserEnvLink.setupEmu({
             needs_backup: true,
             mnemonic: 'all all all all all all all all all all all all',
         });

--- a/packages/suite-desktop-core/e2e/tests/spawn-bridge.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/spawn-bridge.test.ts
@@ -8,8 +8,8 @@ testPlaywright.describe.serial('Bridge', () => {
     testPlaywright.beforeAll(async () => {
         // We make sure that bridge from trezor-user-env is stopped.
         // So we properly test the electron app starting node-bridge module.
-        await TrezorUserEnvLink.api.trezorUserEnvConnect();
-        await TrezorUserEnvLink.api.stopBridge();
+        await TrezorUserEnvLink.connect();
+        await TrezorUserEnvLink.stopBridge();
     });
 
     testPlaywright('App spawns bundled bridge and stops it after app quit', async ({ request }) => {

--- a/packages/suite-web/e2e/cypress.config.ts
+++ b/packages/suite-web/e2e/cypress.config.ts
@@ -241,11 +241,32 @@ export default defineConfig({
                 get({ key }: { key: string }): any {
                     return store[key];
                 },
-                ...TrezorUserEnvLink.api,
-                async setupEmu(opts: Parameters<typeof TrezorUserEnvLink.api.setupEmu>[0]) {
-                    await TrezorUserEnvLink.api.setupEmu(opts);
+                trezorUserEnvDisconnect() {
+                    return TrezorUserEnvLink.disconnect();
+                },
+                trezorUserEnvConnect() {
+                    return TrezorUserEnvLink.connect();
+                },
+                ...(() => {
+                    return Object.getOwnPropertyNames(
+                        Object.getPrototypeOf(TrezorUserEnvLink),
+                    ).reduce((acc, key) => {
+                        // @ts-expect-error
+                        if (typeof TrezorUserEnvLink[key] === 'function') {
+                            return {
+                                ...acc,
+                                // @ts-expect-error
+                                [key]: TrezorUserEnvLink[key].bind(TrezorUserEnvLink),
+                            };
+                        }
 
-                    return TrezorUserEnvLink.api.startBridge();
+                        return acc;
+                    }, {});
+                })(),
+                async setupEmu(opts: Parameters<typeof TrezorUserEnvLink.setupEmu>[0]) {
+                    await TrezorUserEnvLink.setupEmu(opts);
+
+                    return TrezorUserEnvLink.startBridge();
                 },
             });
         },

--- a/packages/trezor-user-env-link/package.json
+++ b/packages/trezor-user-env-link/package.json
@@ -12,9 +12,11 @@
     "dependencies": {
         "@trezor/utils": "workspace:*",
         "cross-fetch": "^4.0.0",
+        "semver": "^7.6.0",
         "ws": "^8.18.0"
     },
     "devDependencies": {
+        "@types/semver": "^7.5.6",
         "@types/ws": "^8.5.5"
     }
 }

--- a/packages/trezor-user-env-link/src/index.ts
+++ b/packages/trezor-user-env-link/src/index.ts
@@ -1,1 +1,2 @@
-export * from './websocket-client';
+export * from './api';
+export * from './types';

--- a/packages/trezor-user-env-link/src/types.ts
+++ b/packages/trezor-user-env-link/src/types.ts
@@ -1,0 +1,4 @@
+/** device model as expected by trezor-user-env */
+export type Model = 'T3T1' | '1' | '2' | 'R';
+
+export type Firmwares = Record<Model, string[]>;

--- a/suite-native/app/e2e/tests/onboardAndConnect.test.ts
+++ b/suite-native/app/e2e/tests/onboardAndConnect.test.ts
@@ -15,15 +15,15 @@ describe('Go through onboarding and connect Trezor.', () => {
     beforeAll(async () => {
         if (platform === 'android') {
             // Prepare Trezor device for test scenario and turn it off.
-            await TrezorUserEnvLink.api.trezorUserEnvDisconnect();
-            await TrezorUserEnvLink.api.trezorUserEnvConnect();
-            await TrezorUserEnvLink.api.startEmu({ wipe: true });
-            await TrezorUserEnvLink.api.setupEmu({
+            await TrezorUserEnvLink.disconnect();
+            await TrezorUserEnvLink.connect();
+            await TrezorUserEnvLink.startEmu({ wipe: true });
+            await TrezorUserEnvLink.setupEmu({
                 label: TREZOR_DEVICE_LABEL,
                 mnemonic: SIMPLE_SEED,
             });
-            await TrezorUserEnvLink.api.startBridge();
-            await TrezorUserEnvLink.api.stopEmu();
+            await TrezorUserEnvLink.startBridge();
+            await TrezorUserEnvLink.stopEmu();
         }
 
         await openApp({ newInstance: true });
@@ -31,7 +31,7 @@ describe('Go through onboarding and connect Trezor.', () => {
 
     afterAll(async () => {
         if (platform === 'android') {
-            await TrezorUserEnvLink.api.stopEmu();
+            await TrezorUserEnvLink.stopEmu();
         }
         await device.terminateApp();
     });
@@ -40,7 +40,7 @@ describe('Go through onboarding and connect Trezor.', () => {
         await onOnboarding.finishOnboarding();
 
         if (platform === 'android') {
-            await TrezorUserEnvLink.api.startEmu();
+            await TrezorUserEnvLink.startEmu();
 
             await waitFor(element(by.text(TREZOR_DEVICE_LABEL)))
                 .toBeVisible()

--- a/suite-native/app/e2e/tests/regtestPOC.test.ts
+++ b/suite-native/app/e2e/tests/regtestPOC.test.ts
@@ -26,7 +26,7 @@ describe('Regtest integration proof of concept.', () => {
         const amountToSend = 42;
 
         // send transaction of 42 BTC and mine it
-        await TrezorUserEnvLink.api.sendToAddressAndMineBlock({
+        await TrezorUserEnvLink.sendToAddressAndMineBlock({
             address: 'bcrt1qjf6qnquchwl6drvrf2ar73l6p9m3gzwlev9qd4',
             btc_amount: amountToSend,
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -11587,8 +11587,10 @@ __metadata:
   resolution: "@trezor/trezor-user-env-link@workspace:packages/trezor-user-env-link"
   dependencies:
     "@trezor/utils": "workspace:*"
+    "@types/semver": "npm:^7.5.6"
     "@types/ws": "npm:^8.5.5"
     cross-fetch: "npm:^4.0.0"
+    semver: "npm:^7.6.0"
     ws: "npm:^8.18.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
While working on #13493 I noticed a [particular connect-popup test failing ](https://github.com/trezor/trezor-suite/actions/runs/10215128459/job/28264136363?pr=13493#step:5:914) although I don't think I have made changes that may cause this. 
When debugging it locally, I observed a considerable delay between clicking the submit button in the connect-explorer and the connect popup opening.

This PR doesn't solve the issue. It just adds a spinner to the button to provide users with some basic UX feedback in case this happens (my first impression was that tests for some reason don' click the button).

Interestingly, nightly pipelines are mostly green https://github.com/trezor/trezor-suite/actions/workflows/test-connect-popup.yml?query=branch%3Adevelop while in all other branches they have way lower success rate https://github.com/trezor/trezor-suite/actions/workflows/test-connect-popup.yml. Could it be a race happening when runners are under stress? 