### PR TITLE
chore(suite-native): FIREBASE_TOKEN replaced by GOOGLE_APPLICATION_CREDENTIALS

### DIFF
--- a/suite-native/app/eas-post-success.sh
+++ b/suite-native/app/eas-post-success.sh
@@ -11,8 +11,7 @@ distribute_develop_apk() {
         --project pc-api-4710771878548015996-769 \
         --app 1:191883890128:android:625bcdab76b3b3a644bdd5 \
         --groups "develop-testers" \
-        --release-notes "$release_notes" \
-        --token "$FIREBASE_TOKEN"
+        --release-notes "$release_notes"
 }
 
 create_release_draft() {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Attempt to fix android distribution of develop build to firebase.

FIREBASE_TOKEN replaced by GOOGLE_APPLICATION_CREDENTIALS that is not passed as param, but used from environment variable.


