### PR TITLE
fix(suite): Hide "Default wallet loading" if Passphrase is off

### DIFF
--- a/packages/suite/src/views/settings/SettingsDevice/SettingsDevice.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/SettingsDevice.tsx
@@ -53,6 +53,7 @@ export const SettingsDevice = () => {
     const isNormalMode = !bootloaderMode && !initializeMode;
     const deviceRemembered = isDeviceRemembered(device) && !device?.connected;
     const bitcoinOnlyDevice = isBitcoinOnlyDevice(device);
+    const isPassphraseProtectionOn = Boolean(device?.features?.passphrase_protection);
 
     if (deviceSettingsUnavailable(device, transport)) {
         return (
@@ -130,12 +131,14 @@ export const SettingsDevice = () => {
                 </SettingsSection>
             )}
 
-            <SettingsSection
-                title={<Translation id="TR_DEVICE_SETTINGS_WALLET_LOADING" />}
-                icon="APP"
-            >
-                <DefaultWalletLoading />
-            </SettingsSection>
+            {isPassphraseProtectionOn && (
+                <SettingsSection
+                    title={<Translation id="TR_DEVICE_SETTINGS_WALLET_LOADING" />}
+                    icon="APP"
+                >
+                    <DefaultWalletLoading />
+                </SettingsSection>
+            )}
 
             <SettingsSection title={<Translation id="TR_FIRMWARE" />} icon="FIRMWARE">
                 <FirmwareVersion isDeviceLocked={isDeviceLocked} />


### PR DESCRIPTION
## Description

Hide "Default wallet loading" from _Settings_ if "Passphrase" is off as it does not make sense to show.
## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/13522

## Screenshots:
**Before:**
Displaying "Default wallet loading" while "Passphrase" is off:
![wallet_before](https://github.com/user-attachments/assets/2f865004-f74e-4afe-9752-7ae5b5546802)

**After:**
"Default wallet loading" not displayed while "Passphrase" off:
![wallet_after](https://github.com/user-attachments/assets/ebc47728-331e-466e-923b-96370ddf50bd)

When passphrase enabled, "Default wallet loading" displayed as expected (while "Passphrase" not displayed in Settings):
![wallet_after2](https://github.com/user-attachments/assets/d11b493e-aa87-463a-b930-7f598e944664)

