### PR TITLE
fix(suite): layout height not reflecting browser UI on mobile

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx
@@ -34,7 +34,7 @@ export const PageWrapper = styled.div`
     display: flex;
     flex: 1;
     flex-direction: column;
-    height: 100vh;
+    height: 100dvh;
     overflow-x: hidden;
 `;
 


### PR DESCRIPTION
Layout height was set using viewport height units (vh) which do not reflect browser UI elements.

## Screenshots:

Screenshots not available as mobile testing is not currently possible (?)