### PR TITLE
chore(connect-popup): allow on mobile

### DIFF
--- a/docker/docker-compose.connect-popup-ci.yml
+++ b/docker/docker-compose.connect-popup-ci.yml
@@ -23,6 +23,7 @@ services:
       - TEST_FILE=$TEST_FILE
       - IS_WEBEXTENSION=$IS_WEBEXTENSION
       - CORE_IN_POPUP=$CORE_IN_POPUP
+      - MOBILE=$MOBILE
       - TREZOR_CONNECT_SRC=$TREZOR_CONNECT_SRC
     working_dir: /e2e
     command: bash -c "npx playwright install && yarn workspace @trezor/connect-popup test:e2e $TEST_FILE"

--- a/docker/docker-compose.connect-popup-test.yml
+++ b/docker/docker-compose.connect-popup-test.yml
@@ -34,6 +34,7 @@ services:
       - TEST_FILE=$TEST_FILE
       - IS_WEBEXTENSION=$IS_WEBEXTENSION
       - CORE_IN_POPUP=$CORE_IN_POPUP
+      - MOBILE=$MOBILE
       - TREZOR_CONNECT_SRC=$TREZOR_CONNECT_SRC
     working_dir: /trezor-suite
     command: bash -c "docker/wait-for-200.sh http://localhost:8088/index.html && yarn workspace @trezor/connect-popup test:e2e $TEST_FILE"

--- a/docker/docker-connect-popup-ci.sh
+++ b/docker/docker-connect-popup-ci.sh
@@ -8,5 +8,6 @@ export URL=$URL
 export TREZOR_CONNECT_SRC=$TREZOR_CONNECT_SRC
 export CORE_IN_POPUP=$CORE_IN_POPUP
 export IS_WEBEXTENSION=$IS_WEBEXTENSION
+export MOBILE=$MOBILE
 
 docker compose -f ./docker/docker-compose.connect-popup-ci.yml up --build --abort-on-container-exit

--- a/docker/docker-connect-popup-test.sh
+++ b/docker/docker-connect-popup-test.sh
@@ -8,5 +8,6 @@ export TEST_FILE=$1
 export TREZOR_CONNECT_SRC=http://localhost:8088/
 export CORE_IN_POPUP=$CORE_IN_POPUP
 export IS_WEBEXTENSION=$IS_WEBEXTENSION
+export MOBILE=$MOBILE
 
 docker compose -f ./docker/docker-compose.connect-popup-test.yml up --build --abort-on-container-exit

--- a/packages/connect-explorer/src/components/Method.tsx
+++ b/packages/connect-explorer/src/components/Method.tsx
@@ -5,7 +5,7 @@ import { useState, useCallback, useEffect } from 'react';
 import styled, { useTheme } from 'styled-components';
 import { CopyToClipboard } from 'nextra/components';
 
-import { Button as TrezorButton, ButtonProps, H3, Card } from '@trezor/components';
+import { Button as TrezorButton, ButtonProps, H3, Card, variables } from '@trezor/components';
 import { spacingsPx } from '@trezor/theme';
 
 import type { Field, FieldWithBundle, FieldWithUnion } from '../types';
@@ -145,6 +145,10 @@ export const MethodContent = styled.div<{ $manualMode?: boolean }>(
     display: grid;
     grid-template-columns: ${$manualMode ? '3fr 2fr' : '2fr 3fr'};
     gap: 20px;
+
+    @media screen and (max-width: ${variables.SCREEN_SIZE.MD}) {
+        grid-template-columns: 1fr;
+    }
 
     & > div {
         /* CSS grid obscurities */

--- a/packages/connect-popup/e2e/playwright.config.ts
+++ b/packages/connect-popup/e2e/playwright.config.ts
@@ -9,7 +9,7 @@ const config: PlaywrightTestConfig = {
         headless: process.env.HEADLESS === 'true',
         ignoreHTTPSErrors: true,
         trace: 'retain-on-failure',
-        ...devices['Desktop Chrome'],
+        ...devices[process.env.MOBILE ? 'Pixel 7' : 'Desktop Chrome'],
     },
 };
 export default config;

--- a/packages/connect-popup/e2e/tests/browser-support.test.ts
+++ b/packages/connect-popup/e2e/tests/browser-support.test.ts
@@ -48,7 +48,7 @@ test('unsupported browser', async ({ browser }) => {
     await context.close();
 });
 
-test('outdated-browser', async ({ browser }) => {
+test('outdated browser', async ({ browser }) => {
     const context = await browser.newContext({
         userAgent:
             'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:100.0) Gecko/20100101 Firefox/50.0',
@@ -76,27 +76,35 @@ test('outdated-browser', async ({ browser }) => {
 });
 
 // test mobile browsers
-test.describe(() => {
-    const fixtures = [
-        { desc: 'iPhone', device: iPhone },
-        { desc: 'android', device: android },
-    ];
-    for (const f of fixtures) {
-        test(`env: web, device: mobile/${f.desc} => not allowed `, async ({ browser }) => {
-            const context = await browser.newContext({
-                ...f.device,
-            });
-            const page = await context.newPage();
-            await page.goto(formatUrl(url, `methods/bitcoin/getPublicKey/`));
+test(`env: web, device: mobile/iPhone => not allowed `, async ({ browser }) => {
+    const context = await browser.newContext({
+        ...iPhone,
+    });
+    const page = await context.newPage();
+    await page.goto(formatUrl(url, `methods/bitcoin/getPublicKey/`));
 
-            popup = await openPopup(page);
-            // unfortunately webusb now does not work for connect-popup, so mobile chrome won't run even if it technically could
-            await popup.waitForSelector('text=Smartphones not supported yet');
-            await popup.screenshot({ path: `${dir}/mobile-${f.desc}-not-supported.png` });
+    popup = await openPopup(page);
+    // unfortunately webusb now does not work for connect-popup, so mobile chrome won't run even if it technically could
+    await popup.waitForSelector('text=Smartphones not supported yet');
+    await popup.screenshot({ path: `${dir}/mobile-iphone-not-supported.png` });
 
-            await popup.click('text=Close');
-            await page.close();
-            await context.close();
-        });
-    }
+    await popup.click('text=Close');
+    await page.close();
+    await context.close();
+});
+
+test(`env: web, device: mobile/Android => allowed `, async ({ browser }) => {
+    const context = await browser.newContext({
+        ...android,
+    });
+    const page = await context.newPage();
+    await page.goto(formatUrl(url, `methods/bitcoin/getPublicKey/`));
+
+    popup = await openPopup(page);
+
+    await popup.waitForSelector('text=Connect Trezor to continue');
+    await popup.screenshot({ path: `${dir}/mobile-android-supported.png` });
+
+    await page.close();
+    await context.close();
 });

--- a/packages/connect-popup/src/static/popup.css
+++ b/packages/connect-popup/src/static/popup.css
@@ -85,8 +85,8 @@ section {
     display: none;
 }
 p {
-    font-size: 12px;
-    font-weight: 300;
+    font-size: 15px;
+    font-weight: 400;
     color: #757575;
 }
 h2 {
@@ -96,7 +96,7 @@ h2 {
     text-rendering: optimizeLegibility;
 }
 h3 {
-    font-size: 16px;
+    font-size: 19px;
     font-weight: 600;
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
@@ -111,18 +111,6 @@ textarea:focus {
 #__lpform_input_idx_0_numspan,
 #__lpform_input_idx_0 {
     display: none;
-}
-@media screen and (min-width: 768px) {
-    p {
-        font-size: 15px;
-        font-weight: 400px;
-    }
-    h2 {
-        font-size: 22px;
-    }
-    h3 {
-        font-size: 19px;
-    }
 }
 a:not(.button),
 a:visited {
@@ -165,7 +153,7 @@ a.button,
 button {
     padding: 12px 24px;
     border-radius: 3px;
-    font-size: 14px;
+    font-size: 16px;
     font-weight: 300;
     cursor: pointer;
     background: #01b757;
@@ -222,7 +210,6 @@ a.button.confirm,
 button.confirm {
     width: 100%;
     padding: 12px;
-    font-size: 14px;
     color: #ffffff;
     background-color: #01b757;
 }
@@ -230,7 +217,6 @@ a.button.cancel,
 button.cancel {
     width: 100%;
     padding: 12px;
-    font-size: 14px;
     color: #757575;
     background-color: transparent;
     border: 1px solid #757575;
@@ -272,7 +258,7 @@ button.check-devices .plus::after {
 }
 a.button.check-devices .text,
 button.check-devices .text {
-    font-size: 14px;
+    font-size: 16px;
     color: #00ab51;
 }
 a.button.check-devices:hover,
@@ -336,20 +322,6 @@ a.button.notification-button:hover,
 button.notification-button:hover {
     color: white;
     background-color: #eb8a00;
-}
-@media screen and (min-width: 768px) {
-    a.button,
-    button {
-        font-size: 16px;
-    }
-    a.button.confirm,
-    button.confirm {
-        font-size: 16px;
-    }
-    a.button.cancel,
-    button.cancel {
-        font-size: 16px;
-    }
 }
 header {
     position: fixed;
@@ -428,7 +400,7 @@ input[type='password']:focus {
     line-height: 1;
     cursor: pointer;
     font-weight: 300;
-    font-size: 12px;
+    font-size: 14px;
     color: #757575;
 }
 .custom-checkbox input {
@@ -499,11 +471,6 @@ input[type='password']:focus {
 }
 .custom-checkbox.align-left .indicator:after {
     top: 0px;
-}
-@media screen and (min-width: 768px) {
-    .custom-checkbox {
-        font-size: 14px;
-    }
 }
 .loader {
     position: relative;
@@ -971,6 +938,10 @@ footer a:visited:hover {
     main {
         flex-direction: column;
         min-height: none;
+    }
+    #react {
+        /* override element style set in JS */
+        flex: none !important;
     }
     section,
     aside {
@@ -2117,7 +2088,7 @@ section > div .divider span:after {
     align-items: center;
     color: #1e7ff0;
     font-weight: 300;
-    font-size: 12px;
+    font-size: 14px;
 }
 .permissions .info-icon {
     width: 28px;
@@ -2157,9 +2128,6 @@ section > div .divider span:after {
 @media screen and (min-width: 768px) {
     .permissions {
         height: 500px;
-    }
-    .permissions .permission-item .content {
-        font-size: 14px;
     }
 }
 @media screen and (max-width: 639px) {

--- a/packages/connect-popup/src/view/browser.ts
+++ b/packages/connect-popup/src/view/browser.ts
@@ -5,9 +5,9 @@ import { storage } from '@trezor/connect-common';
 import { container, showView } from './common';
 
 export const initBrowserView = (systemInfo: SystemInfo): Promise<boolean> => {
-    if (systemInfo?.os.mobile) {
-        // popup is not supported on mobile devices
-        // webusb is now available only on trezor.io domains and bridge can't be installed on mobile
+    if (systemInfo?.os.mobile && !systemInfo?.browser.supported) {
+        // popup can now support smartphones that have WebUSB support (e.g. Android with Chrome)
+        // browsers that are not supported will get rejected
         showView('smartphones-not-supported');
 
         return Promise.resolve(false);

--- a/packages/connect-ui/src/views/Passphrase.tsx
+++ b/packages/connect-ui/src/views/Passphrase.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { analytics, EventType } from '@trezor/connect-analytics';
 import { UI, UiEvent, CoreRequestMessage } from '@trezor/connect';
 import { variables } from '@trezor/components';
+import { spacingsPx } from '@trezor/theme';
 
 import { View } from '../components/View';
 import { PassphraseTypeCard } from '../components/Passphrase/PassphraseTypeCard';
@@ -16,7 +17,7 @@ const Wrapper = styled.div`
     width: 600px;
 
     @media screen and (max-width: ${variables.SCREEN_SIZE.MD}) {
-        width: 100%;
+        width: calc(100vw - ${spacingsPx.xxxl});
     }
 `;
 


### PR DESCRIPTION
## Description

Allow using Connect popup on mobile browsers & devices that support WebUSB, such as Chrome on Android. 
Adjust styling, use same font size as desktop (in my opinion the old mobile font was too small, these days phones have plenty of space and resolution).
Add test for methods on mobile.  