### PR TITLE
feat(suite): add learn more buttons to exp features

### DIFF
--- a/packages/suite/src/constants/suite/experimental.ts
+++ b/packages/suite/src/constants/suite/experimental.ts
@@ -1,4 +1,5 @@
 import { TranslationKey } from '@suite-common/intl-types';
+import { EXPERIMENTAL_PASSWORD_MANAGER_KB_URL, TOR_SNOWFLAKE_KB_URL } from '@trezor/urls';
 
 export enum ExperimentalFeature {
     PasswordManager = 'password-manager',
@@ -15,4 +16,9 @@ export const ExperimentalFeatureTitle: FeatureIntlMap = {
 export const ExperimentalFeatureDescription: FeatureIntlMap = {
     [ExperimentalFeature.PasswordManager]: 'TR_EXPERIMENTAL_PASSWORD_MANAGER_DESCRIPTION',
     [ExperimentalFeature.TorSnowflake]: 'TR_EXPERIMENTAL_TOR_SNOWFLAKE_DESCRIPTION',
+};
+
+export const ExperimentalFeatureKnowledgeBaseUrl = {
+    [ExperimentalFeature.PasswordManager]: EXPERIMENTAL_PASSWORD_MANAGER_KB_URL,
+    [ExperimentalFeature.TorSnowflake]: TOR_SNOWFLAKE_KB_URL,
 };

--- a/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
@@ -1,7 +1,8 @@
 import styled from 'styled-components';
 import { AnimatePresence, motion } from 'framer-motion';
-import { Checkbox, Switch, Icon, variables } from '@trezor/components';
+import { Checkbox, Switch, Icon, variables, Row } from '@trezor/components';
 import { spacingsPx } from '@trezor/theme';
+import { EXPERIMENTAL_FEATURES_KB_URL } from '@trezor/urls';
 
 import { SUITE } from 'src/actions/suite/constants';
 import { ActionColumn, SectionItem, TextColumn, Translation } from 'src/components/suite';
@@ -9,6 +10,7 @@ import {
     ExperimentalFeature,
     ExperimentalFeatureTitle,
     ExperimentalFeatureDescription,
+    ExperimentalFeatureKnowledgeBaseUrl,
 } from 'src/constants/suite/experimental';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
@@ -42,6 +44,7 @@ const FeatureLine = ({ feature, features }: FeatureLineProps) => {
     const checked = features.includes(feature);
     const titleId = ExperimentalFeatureTitle[feature];
     const descId = ExperimentalFeatureDescription[feature];
+    const url = ExperimentalFeatureKnowledgeBaseUrl[feature];
 
     const onChangeFeature = () =>
         dispatch({
@@ -54,6 +57,8 @@ const FeatureLine = ({ feature, features }: FeatureLineProps) => {
             <TextColumn
                 title={titleId ? <Translation id={titleId} /> : feature}
                 description={descId && <Translation id={descId} />}
+                buttonLink={url}
+                buttonTitle={<Translation id="TR_LEARN_MORE" />}
             />
             <ActionColumn>
                 <Checkbox isChecked={checked} onClick={onChangeFeature} />
@@ -96,12 +101,15 @@ export const Experimental = () => {
                     description={
                         <>
                             <Warning>
-                                <Icon icon="WARNING" size={14} variant="tertiary" />
-                                <Translation id="TR_EXPERIMENTAL_FEATURES_WARNING" />
+                                <Row gap={12}>
+                                    <Icon icon="WARNING" size={14} variant="tertiary" />
+                                    <Translation id="TR_EXPERIMENTAL_FEATURES_WARNING" />
+                                </Row>
                             </Warning>
                             <Translation id="TR_EXPERIMENTAL_FEATURES_DESCRIPTION" />
                         </>
                     }
+                    buttonLink={EXPERIMENTAL_FEATURES_KB_URL}
                 />
                 <ActionColumn>
                     <Switch isChecked={!!features} onChange={onSwitchExperimental} />

--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -104,6 +104,11 @@ export const CHROME_ANDROID_URL =
     'https://play.google.com/store/apps/details?id=com.android.chrome';
 export const TOR_PROJECT_URL = 'https://www.torproject.org/';
 export const TOR_SNOWFLAKE_PROJECT_URL = 'https://snowflake.torproject.org/';
+export const TOR_SNOWFLAKE_KB_URL = 'https://trezor.io/learn/a/tor-snowflake-in-trezor-suite';
+export const EXPERIMENTAL_FEATURES_KB_URL =
+    'https://trezor.io/learn/a/experimental-features-in-trezor-suite';
+export const EXPERIMENTAL_PASSWORD_MANAGER_KB_URL =
+    'https://trezor.io/learn/a/retrieve-dropbox-passwords-from-password-manager';
 export const ZKSNACKS_TERMS_URL =
     'https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi/Legal/Assets/LegalDocumentsWw2.txt';
 export const CROWDIN_URL = 'https://crowdin.com/project/trezor-suite';


### PR DESCRIPTION
Adding Learn more buttons to Experimental features so we can redirect users directly to the KB articles about the respective features. 

FYI the urls does not exist at this moment, so it will return you error. It will work once KB articles will be published. 


![image](https://github.com/user-attachments/assets/2ec54c13-c2d8-4398-88f2-60d52e86fecc)
