### PR TITLE
feat(suite): Rework Welcome screen left sidebar, make it smaller

### DIFF
--- a/packages/components/src/components/buttons/Button/Button.tsx
+++ b/packages/components/src/components/buttons/Button/Button.tsx
@@ -26,6 +26,7 @@ type ButtonContainerProps = TransientProps<AllowedFrameProps> & {
     $hasIcon?: boolean;
     $isFullWidth?: boolean;
     $isSubtle: boolean;
+    $borderRadius?: string;
 };
 
 export const ButtonContainer = styled.button<ButtonContainerProps>`
@@ -36,7 +37,7 @@ export const ButtonContainer = styled.button<ButtonContainerProps>`
     gap: ${({ $hasIcon }) => $hasIcon && spacingsPx.xs};
     padding: ${({ $size }) => getPadding($size, true)};
     width: ${({ $isFullWidth }) => $isFullWidth && '100%'};
-    border-radius: ${borders.radii.full};
+    border-radius: ${({ $borderRadius }) => $borderRadius};
     transition:
         ${focusStyleTransition},
         background 0.1s ease-out;
@@ -98,6 +99,7 @@ export type ButtonProps = SelectedHTMLButtonProps &
         iconAlignment?: IconAlignment;
         children: React.ReactNode;
         title?: string;
+        borderRadius?: string;
         className?: string;
         'data-testid'?: string;
     };
@@ -113,6 +115,7 @@ export const Button = ({
     iconSize,
     iconAlignment = 'left',
     type = 'button',
+    borderRadius = borders.radii.full,
     children,
     margin,
     ...rest
@@ -145,6 +148,7 @@ export const Button = ({
             $isSubtle={isSubtle}
             type={type}
             $hasIcon={!!icon || isLoading}
+            $borderRadius={borderRadius}
             {...rest}
             onClick={isDisabled ? undefined : rest?.onClick}
             {...makePropsTransient(frameProps)}

--- a/packages/components/src/components/buttons/IconButton/IconButton.tsx
+++ b/packages/components/src/components/buttons/IconButton/IconButton.tsx
@@ -10,6 +10,9 @@ import { Tooltip } from '../../Tooltip/Tooltip';
 const IconButtonContainer = styled(ButtonContainer)`
     position: relative;
     padding: ${({ $size }) => getPadding($size, false)};
+    ${({ $borderRadius }) => $borderRadius && `border-radius: ${$borderRadius};`};
+    ${({ $width }) => $width && `width: ${$width};`};
+    ${({ $height }) => $height && `height: ${$height};`};
 `;
 
 const Label = styled.span<{ $isDisabled: boolean }>`
@@ -75,10 +78,13 @@ export const IconButton = ({
                 disabled={isDisabled || isLoading}
                 onClick={handleClick}
                 $isSubtle={isSubtle}
+                $borderRadius={rest.borderRadius}
+                $width={rest.width}
+                $height={rest.height}
                 {...rest}
             >
-                {!isLoading && icon && IconComponent}
                 {isLoading && Loader}
+                {!isLoading && icon && IconComponent}
 
                 {bottomLabel && <Label $isDisabled={isDisabled}>{bottomLabel}</Label>}
             </IconButtonContainer>

--- a/packages/components/src/components/buttons/buttonStyleUtils.ts
+++ b/packages/components/src/components/buttons/buttonStyleUtils.ts
@@ -7,10 +7,9 @@ import { hexToRgba } from '@suite-common/suite-utils';
 const SUBTLE_ALPHA = 0.12;
 const SUBTLE_ALPHA_HOVER = 0.2;
 
-export type ButtonVariant = Extract<
-    UIVariant,
-    'primary' | 'secondary' | 'tertiary' | 'info' | 'warning' | 'destructive'
->;
+export type ButtonVariant =
+    | Extract<UIVariant, 'primary' | 'secondary' | 'tertiary' | 'info' | 'warning' | 'destructive'>
+    | 'welcome';
 export type ButtonSize = Extract<UISize, 'large' | 'medium' | 'small' | 'tiny'>;
 export type IconAlignment = Extract<UIHorizontalAlignment, 'left' | 'right'>;
 
@@ -122,6 +121,13 @@ export const useVariantStyle = (
             text: theme.textOnRed,
             textSubtle: theme.textAlertRed,
         },
+        welcome: {
+            background: theme.backgroundSurfaceElevation1,
+            backgroundSubtle: theme.backgroundSurfaceElevationNegative,
+            backgroundHover: theme.backgroundSurfaceElevation1,
+            fill: 'black',
+            fillSubtle: theme.iconSubdued,
+        },
     };
 
     const colors = variantsColors[variant];
@@ -131,12 +137,16 @@ export const useVariantStyle = (
             ? colors.backgroundSubtle
             : colors.background};
         color: ${isSubtle && colors.textSubtle ? colors.textSubtle : colors.text};
+        ${colors.fill &&
+        colors.fillSubtle &&
+        `path { fill: ${isSubtle ? colors.fillSubtle : colors.fill}}`};
 
         &:hover,
         &:active {
             background: ${isSubtle && colors.backgroundSubtleHover
                 ? colors.backgroundSubtleHover
                 : colors.backgroundHover};
+            ${colors.fill && `path { fill: ${colors.fill}}`};
         }
     `;
 };

--- a/packages/suite/src/components/settings/SettingsLayout.tsx
+++ b/packages/suite/src/components/settings/SettingsLayout.tsx
@@ -16,7 +16,7 @@ type SettingsLayoutProps = {
     ['data-testid']?: string;
 };
 
-const SettingsHeader = () => {
+export const SettingsHeader = () => {
     const isDebugModeActive = useSelector(selectIsDebugModeActive);
 
     const dispatch = useDispatch();

--- a/packages/suite/src/components/suite/Preloader/Preloader.tsx
+++ b/packages/suite/src/components/suite/Preloader/Preloader.tsx
@@ -23,6 +23,8 @@ import { selectDevice } from '@suite-common/wallet-core';
 import { DeviceCompromised } from '../SecurityCheck/DeviceCompromised';
 import { RouterAppWithParams } from '../../../constants/suite/routes';
 import { Feature, selectIsFeatureDisabled } from '@suite-common/message-system';
+import { WelcomeSidebar } from '../layouts/WelcomeLayout/WelcomeSidebar';
+import styled from 'styled-components';
 
 const ROUTES_TO_SKIP_REVISION_CHECK: RouterAppWithParams['app'][] = [
     'settings',
@@ -30,6 +32,11 @@ const ROUTES_TO_SKIP_REVISION_CHECK: RouterAppWithParams['app'][] = [
     'firmware-type',
     'firmware-custom',
 ];
+
+const LeftWrapper = styled.div`
+    display: flex;
+    flex-direction: row;
+`;
 
 const getFullscreenApp = (route: AppState['router']['route']): FC | undefined => {
     switch (route?.app) {
@@ -147,7 +154,14 @@ export const Preloader = ({ children }: PreloaderProps) => {
 
     // if a device is not connected or initialized
     if (isLoggedOut) {
-        return <LoggedOutLayout>{children}</LoggedOutLayout>;
+        if (router.route?.app === 'settings') {
+            return (
+                <LeftWrapper>
+                    <WelcomeSidebar />
+                    <LoggedOutLayout>{children}</LoggedOutLayout>
+                </LeftWrapper>
+            );
+        } else return <LoggedOutLayout>{children}</LoggedOutLayout>;
     }
 
     // everything is set.

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/SettingsName.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/SettingsName.tsx
@@ -1,13 +1,11 @@
 import { useState } from 'react';
 import styled from 'styled-components';
 import { desktopApi } from '@trezor/suite-desktop-api';
-import { IconButton } from '@trezor/components';
 import { spacingsPx } from '@trezor/theme';
 import { setDebugMode } from 'src/actions/suite/suiteActions';
 import { Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectIsDebugModeActive, selectIsLoggedOut } from 'src/reducers/suite/suiteReducer';
-import { goto } from 'src/actions/suite/routerActions';
+import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
 import { HeaderHeading } from './BasicName';
 
 const Container = styled.div`
@@ -18,7 +16,6 @@ const Container = styled.div`
 
 export const SettingsName = () => {
     const isDebugModeActive = useSelector(selectIsDebugModeActive);
-    const isLoggedOut = useSelector(selectIsLoggedOut);
 
     // show debug menu item after 5 clicks on "Settings" heading
     const [clickCounter, setClickCounter] = useState<number>(0);
@@ -47,20 +44,8 @@ export const SettingsName = () => {
         }
     };
 
-    const handleBackClick = () => dispatch(goto('suite-start'));
-
     return (
         <Container>
-            {isLoggedOut && (
-                <IconButton
-                    icon="ARROW_LEFT"
-                    variant="tertiary"
-                    size="medium"
-                    onClick={handleBackClick}
-                    data-testid="@settings/menu/close"
-                />
-            )}
-
             <HeaderHeading onClick={handleTitleClick} data-testid="@settings/menu/title">
                 <Translation id="TR_SETTINGS" />
             </HeaderHeading>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/CheckIcon.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/CheckIcon.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import styled, { useTheme } from 'styled-components';
+import { borders, CSSColor } from '@trezor/theme';
+import { Icon } from '@trezor/components';
+
+const IconWrapper = styled.div<{ $background: CSSColor }>`
+    position: absolute;
+    bottom: 50%;
+    left: 50%;
+    background: ${({ $background }) => $background};
+    border-radius: ${borders.radii.full};
+`;
+
+type CheckIconProps = {
+    isTorContainerHoveredOrFocused?: boolean;
+};
+
+export const CheckIcon = ({ isTorContainerHoveredOrFocused = false }: CheckIconProps) => {
+    const theme = useTheme();
+    const background = isTorContainerHoveredOrFocused
+        ? theme.backgroundTertiaryPressedOnElevation0
+        : theme.backgroundSurfaceElevationNegative;
+
+    return (
+        <IconWrapper $background={background}>
+            <Icon icon="CHECK_ACTIVE" size={12} color={theme.iconPrimaryDefault} />
+        </IconWrapper>
+    );
+};

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions.tsx
@@ -1,7 +1,7 @@
-import styled, { useTheme } from 'styled-components';
+import styled from 'styled-components';
 import { Icon, Tooltip } from '@trezor/components';
 import { isDesktop } from '@trezor/env-utils';
-import { borders, spacingsPx, typography } from '@trezor/theme';
+import { spacingsPx, typography } from '@trezor/theme';
 import { useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
 import { goto } from 'src/actions/suite/routerActions';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
@@ -13,6 +13,8 @@ import { ActionButton } from './ActionButton';
 import { NavBackends } from './NavBackends';
 import { HelperIcons } from './HelperIcons';
 import { useEnabledBackends } from '../utils';
+import { TorContainerWithCheckIcon } from './TorContainerWithCheckIcon';
+import { CheckIcon } from './CheckIcon';
 
 const Container = styled.div`
     display: flex;
@@ -45,41 +47,16 @@ const Label = styled.span`
     color: ${({ theme }) => theme.textSubdued};
 `;
 
-const StyledCheckIcon = styled(Icon)`
-    position: absolute;
-    bottom: 50%;
-    left: 50%;
-    background: ${({ theme }) => theme.backgroundSurfaceElevationNegative};
-    border-radius: ${borders.radii.full};
-`;
-
-const TorToggleContainer = styled.div`
-    position: relative;
-    width: 100%;
-
-    &:hover,
-    &:focus-within {
-        ${StyledCheckIcon} {
-            background-color: ${({ theme }) => theme.backgroundTertiaryPressedOnElevation0};
-        }
-    }
-`;
-
 export const QuickActions = () => {
     const isDiscreetModeActive = useSelector(selectIsDiscreteModeActive);
-    const { isTorEnabled, isTorLoading } = useSelector(selectTorState);
+    const { isTorLoading } = useSelector(selectTorState);
     const dispatch = useDispatch();
     const { translationString } = useTranslation();
-    const theme = useTheme();
     const handleDiscreetModeClick = () => dispatch(setDiscreetMode(!isDiscreetModeActive));
     const enabledBackends = useEnabledBackends();
     const translationLabel = isDiscreetModeActive ? 'TR_SHOW_BALANCES' : 'TR_HIDE_BALANCES';
     const isCustomBackendIconVisible = enabledBackends.length > 0;
     const isTorIconVisible = isDesktop();
-
-    const CheckIcon = () => (
-        <StyledCheckIcon icon="CHECK_ACTIVE" size={12} color={theme.iconPrimaryDefault} />
-    );
 
     return (
         <Container>
@@ -106,24 +83,19 @@ export const QuickActions = () => {
                                 </>
                             </Tooltip>
                         )}
-                        {isTorIconVisible && (
-                            <TorToggleContainer>
-                                <ActionButton
-                                    icon="TOR"
-                                    title={translationString('TR_TOR')}
-                                    isLoading={isTorLoading}
-                                    onClick={() =>
-                                        dispatch(
-                                            goto('settings-index', { anchor: SettingsAnchor.Tor }),
-                                        )
-                                    }
-                                    size="small"
-                                    variant="tertiary"
-                                />
 
-                                {isTorEnabled && <CheckIcon />}
-                            </TorToggleContainer>
-                        )}
+                        <TorContainerWithCheckIcon>
+                            <ActionButton
+                                icon="TOR"
+                                title={translationString('TR_TOR')}
+                                isLoading={isTorLoading}
+                                onClick={() =>
+                                    dispatch(goto('settings-index', { anchor: SettingsAnchor.Tor }))
+                                }
+                                size="small"
+                                variant="tertiary"
+                            />
+                        </TorContainerWithCheckIcon>
 
                         <ActionButton
                             title={translationString(translationLabel)}

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/TorContainerWithCheckIcon.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/TorContainerWithCheckIcon.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { isDesktop } from '@trezor/env-utils';
+import { selectTorState } from 'src/reducers/suite/suiteReducer';
+import { useSelector } from 'react-redux';
+import { CheckIcon } from './CheckIcon';
+
+const TorToggleContainer = styled.div`
+    position: relative;
+    width: 100%;
+`;
+
+type TorContainerWithCheckIconProps = {
+    children?: React.ReactNode;
+};
+
+export const TorContainerWithCheckIcon = ({ children }: TorContainerWithCheckIconProps) => {
+    const { isTorEnabled } = useSelector(selectTorState);
+    const isTorIconVisible = isDesktop();
+    const [isTorContainerHoveredOrFocused, setIsTorContainerHoveredOrFocused] = useState(false);
+
+    const onTorContainerChange = (value: boolean) => () => setIsTorContainerHoveredOrFocused(value);
+
+    if (isTorIconVisible) {
+        return (
+            <TorToggleContainer
+                onMouseEnter={onTorContainerChange(true)}
+                onMouseLeave={onTorContainerChange(false)}
+                onFocus={onTorContainerChange(true)}
+                onBlur={onTorContainerChange(false)}
+            >
+                {children}
+                {isTorEnabled && (
+                    <CheckIcon isTorContainerHoveredOrFocused={isTorContainerHoveredOrFocused} />
+                )}
+            </TorToggleContainer>
+        );
+    }
+
+    return <></>;
+};

--- a/packages/suite/src/components/suite/layouts/WelcomeLayout/WelcomeLayout.tsx
+++ b/packages/suite/src/components/suite/layouts/WelcomeLayout/WelcomeLayout.tsx
@@ -1,34 +1,22 @@
 import { ReactNode } from 'react';
 import styled from 'styled-components';
-import { AnimatePresence, motion } from 'framer-motion';
 
 import {
-    TrezorLogo,
-    Button,
     variables,
     SVG_IMAGES,
     useElevation,
     ElevationUp,
-    ElevationDown,
     ElevationContext,
-    Column,
 } from '@trezor/components';
-import { useOnce } from '@trezor/react-utils';
-import { Translation } from 'src/components/suite';
 // importing directly, otherwise unit tests fail, seems to be a styled-components issue
-import { TrezorLink } from 'src/components/suite/TrezorLink';
 import { useSelector } from 'src/hooks/suite';
 import { selectBannerMessage } from '@suite-common/message-system';
 import { MessageSystemBanner } from 'src/components/suite/banners';
-import { isWeb } from '@trezor/env-utils';
-import { TREZOR_URL, SUITE_URL } from '@trezor/urls';
 import { resolveStaticPath } from '@suite-common/suite-utils';
 import { GuideButton, GuideRouter } from 'src/components/guide';
-import { useGuide } from 'src/hooks/guide';
 import { MAX_ONBOARDING_WIDTH } from 'src/constants/suite/layout';
-import { NavSettings } from './NavSettings';
 import { Elevation, mapElevationToBackground, spacingsPx } from '@trezor/theme';
-import { TrafficLightOffset } from '../../TrafficLightOffset';
+import { WelcomeSidebar } from './WelcomeSidebar';
 
 const Wrapper = styled.div`
     display: flex;
@@ -41,39 +29,6 @@ const Body = styled.div`
     display: flex;
     width: 100%;
     height: 100%;
-`;
-
-const Expander = styled.div`
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    flex: 1;
-    margin-top: 96px;
-`;
-
-const WelcomeWrapper = styled.div<{ $elevation: Elevation }>`
-    background-color: ${mapElevationToBackground};
-
-    @media (max-width: ${variables.SCREEN_SIZE.MD}) {
-        display: none;
-    }
-`;
-
-const MotionWelcome = styled(motion.div)`
-    height: 100%;
-    overflow: hidden;
-    min-width: 380px;
-    max-width: 660px;
-`;
-
-const LinksContainer = styled.div`
-    bottom: 0;
-    display: flex;
-    margin: ${spacingsPx.xl};
-    align-items: center;
-    flex-flow: row wrap;
-    gap: ${spacingsPx.md};
 `;
 
 const Content = styled.div<{ $elevation: Elevation }>`
@@ -96,11 +51,6 @@ const Content = styled.div<{ $elevation: Elevation }>`
     }
 `;
 
-const SettingsWrapper = styled.div`
-    position: absolute;
-    align-self: flex-end;
-`;
-
 const ChildrenWrapper = styled.div`
     display: flex;
     flex: 1;
@@ -115,80 +65,11 @@ interface WelcomeLayoutProps {
     children: ReactNode;
 }
 
-const Left = () => {
-    const { elevation } = useElevation();
-
-    const { isGuideOpen, isGuideOnTop } = useGuide();
-
-    // do not animate welcome bar on initial load
-    const isFirstRender = useOnce(true, false);
-
-    return (
-        <WelcomeWrapper $elevation={elevation}>
-            <AnimatePresence>
-                {(!isGuideOpen || isGuideOnTop) && (
-                    <MotionWelcome
-                        initial={{
-                            width: isFirstRender ? '40vw' : 0,
-                            minWidth: isFirstRender ? '380px' : 0,
-                        }}
-                        animate={{
-                            width: '40vw',
-                            minWidth: '380px',
-                            transition: { duration: 0.3, bounce: 0 },
-                        }}
-                        exit={{
-                            width: 0,
-                            minWidth: 0,
-                            transition: { duration: 0.3, bounce: 0 },
-                        }}
-                    >
-                        <TrafficLightOffset>
-                            <Column justifyContent="center" alignItems="center" height="100%">
-                                <Expander data-testid="@welcome/title">
-                                    <TrezorLogo type="symbol" width="57px" />
-                                </Expander>
-
-                                <LinksContainer>
-                                    {isWeb() && (
-                                        <TrezorLink type="hint" variant="nostyle" href={SUITE_URL}>
-                                            <Button
-                                                variant="tertiary"
-                                                icon="EXTERNAL_LINK"
-                                                iconAlignment="right"
-                                            >
-                                                <Translation id="TR_ONBOARDING_DOWNLOAD_DESKTOP_APP" />
-                                            </Button>
-                                        </TrezorLink>
-                                    )}
-                                    <TrezorLink type="hint" variant="nostyle" href={TREZOR_URL}>
-                                        <Button
-                                            variant="tertiary"
-                                            icon="EXTERNAL_LINK"
-                                            iconAlignment="right"
-                                        >
-                                            trezor.io
-                                        </Button>
-                                    </TrezorLink>
-                                </LinksContainer>
-                            </Column>
-                        </TrafficLightOffset>
-                    </MotionWelcome>
-                )}
-            </AnimatePresence>
-        </WelcomeWrapper>
-    );
-};
-
 const Right = ({ children }: { children: ReactNode }) => {
     const { elevation } = useElevation();
 
     return (
         <Content $elevation={elevation}>
-            <SettingsWrapper>
-                <NavSettings />
-            </SettingsWrapper>
-
             <ChildrenWrapper>
                 <ElevationUp>{children}</ElevationUp>
             </ChildrenWrapper>
@@ -207,9 +88,7 @@ export const WelcomeLayout = ({ children }: WelcomeLayoutProps) => {
                 {bannerMessage && <MessageSystemBanner message={bannerMessage} />}
 
                 <Body data-testid="@welcome-layout/body">
-                    <ElevationDown>
-                        <Left />
-                    </ElevationDown>
+                    <WelcomeSidebar />
 
                     <Right>{children}</Right>
 

--- a/packages/suite/src/components/suite/layouts/WelcomeLayout/WelcomeSidebar.tsx
+++ b/packages/suite/src/components/suite/layouts/WelcomeLayout/WelcomeSidebar.tsx
@@ -1,0 +1,155 @@
+import { Column, IconButton, variables } from '@trezor/components';
+import { setDiscreetMode } from 'src/actions/settings/walletSettingsActions';
+import { goto } from 'src/actions/suite/routerActions';
+import { useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
+import { selectIsDiscreteModeActive } from 'src/reducers/wallet/settingsReducer';
+import { TrafficLightOffset } from '../../TrafficLightOffset';
+import styled from 'styled-components';
+import { borders, spacingsPx } from '@trezor/theme';
+import { Translation } from '../../Translation';
+import { useCallback, useEffect, useState } from 'react';
+import { SettingsAnchor } from 'src/constants/suite/anchors';
+import { selectTorState } from 'src/reducers/suite/suiteReducer';
+import { useLocation } from 'react-router-dom';
+import { ButtonVariant } from '@trezor/components/src/components/buttons/buttonStyleUtils';
+import { removeSettingsFromUrl } from './utils';
+import { TorContainerWithCheckIcon } from '../SuiteLayout/Sidebar/TorContainerWithCheckIcon';
+
+type ActivePage = 'trezor' | 'settings';
+
+const WELCOME_SIDEBAR_WIDTH = 84;
+const WELCOME_ICON_SIZE = 40;
+
+const WelcomeWrapper = styled.div`
+    background-color: ${({ theme }) => theme.backgroundSurfaceElevationNegative};
+    border-right: 1px solid ${({ theme }) => theme.borderElevation0};
+
+    @media (max-width: ${variables.SCREEN_SIZE.MD}) {
+        display: none;
+    }
+`;
+
+const LeftContainer = styled.div`
+    padding: ${spacingsPx.xs};
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    height: 100%;
+`;
+
+const LeftWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: ${spacingsPx.xs};
+`;
+
+type ExtraIconButtonProps = {
+    variant: ButtonVariant;
+    borderRadius: string;
+    width: number;
+    height: number;
+};
+
+const extraIconButtonProps = (): ExtraIconButtonProps => {
+    return {
+        variant: 'welcome',
+        borderRadius: borders.radii.sm,
+        width: WELCOME_ICON_SIZE,
+        height: WELCOME_ICON_SIZE,
+    };
+};
+
+export const WelcomeSidebar = () => {
+    const dispatch = useDispatch();
+    const { translationString } = useTranslation();
+    const isDiscreetModeActive = useSelector(selectIsDiscreteModeActive);
+    const translationLabel = isDiscreetModeActive ? 'TR_SHOW_BALANCES' : 'TR_HIDE_BALANCES';
+    const { isTorLoading } = useSelector(selectTorState);
+    const [activePage, setActivePage] = useState<ActivePage>('trezor');
+    const location = useLocation();
+
+    const handleDiscreetModeClick = () => dispatch(setDiscreetMode(!isDiscreetModeActive));
+
+    const handleClickTrezor = () => {
+        setActivePage('trezor');
+        dispatch(goto('suite-start'));
+        const updatedUrl = removeSettingsFromUrl(window.location.pathname);
+        window.location.pathname = updatedUrl;
+        location.pathname = removeSettingsFromUrl(location.pathname);
+    };
+
+    const handleClickSettings = useCallback(() => {
+        setActivePage('settings');
+        dispatch(goto('settings-index'));
+    }, [dispatch]);
+
+    const handleClickTor = () => {
+        setActivePage('settings');
+        dispatch(
+            goto('settings-index', {
+                anchor: SettingsAnchor.Tor,
+            }),
+        );
+    };
+
+    useEffect(() => {
+        if (
+            window.location.pathname.includes('settings') ||
+            location.pathname.includes('settings')
+        ) {
+            setActivePage('settings');
+        }
+    }, [location.pathname]);
+
+    return (
+        <WelcomeWrapper>
+            <TrafficLightOffset>
+                <Column
+                    justifyContent="center"
+                    alignItems="center"
+                    height="100%"
+                    width={WELCOME_SIDEBAR_WIDTH}
+                >
+                    <LeftContainer>
+                        <LeftWrapper>
+                            <IconButton
+                                label={<Translation id="TR_CONNECT" />}
+                                icon="TREZOR_LOGO"
+                                isSubtle={activePage !== 'trezor'}
+                                onClick={handleClickTrezor}
+                                {...extraIconButtonProps()}
+                            />
+                            <IconButton
+                                label={<Translation id="TR_SETTINGS" />}
+                                icon="SETTINGS"
+                                isSubtle={activePage !== 'settings'}
+                                onClick={handleClickSettings}
+                                {...extraIconButtonProps()}
+                            />
+                        </LeftWrapper>
+
+                        <LeftWrapper>
+                            <IconButton
+                                label={translationString(translationLabel)}
+                                icon={isDiscreetModeActive ? 'SHOW' : 'HIDE'}
+                                onClick={handleDiscreetModeClick}
+                                isSubtle
+                                {...extraIconButtonProps()}
+                            />
+                            <TorContainerWithCheckIcon>
+                                <IconButton
+                                    label={translationString('TR_TOR')}
+                                    icon="TOR"
+                                    isLoading={isTorLoading}
+                                    onClick={handleClickTor}
+                                    isSubtle
+                                    {...extraIconButtonProps()}
+                                />
+                            </TorContainerWithCheckIcon>
+                        </LeftWrapper>
+                    </LeftContainer>
+                </Column>
+            </TrafficLightOffset>
+        </WelcomeWrapper>
+    );
+};

--- a/packages/suite/src/components/suite/layouts/WelcomeLayout/utils.ts
+++ b/packages/suite/src/components/suite/layouts/WelcomeLayout/utils.ts
@@ -1,0 +1,8 @@
+export const removeSettingsFromUrl = (url: string): string => {
+    const settingsIndex = url.indexOf('settings');
+    if (settingsIndex !== -1) {
+        return url.slice(0, settingsIndex);
+    }
+
+    return url;
+};


### PR DESCRIPTION
## Description

Rework Welcome screen left sidebar, make it smaller, add appropriate icons according to the new design.

Additionally refactor `CheckIcon` used for indicating enabling/disabling Tor in Sidebar layout - prevent inheriting styles from `Icon` component, use it for Welcome screen too, create and use new related components.

Design [here](https://www.figma.com/design/U7XRtJkKpGl3eVhxgiKts5/Connect-Trezor?node-id=6050-9463&t=fxBQxL49QaQKhkDp-0)

TODO:
- [x] add correct style of the sidebar icons, on hover, also when active
- [x] add labels to icons, to Trezor icon add "Connect"
- [x] remove unnecessary animation
- [x] use default 84px width because of Mac
- [x] display correct page when clicking back on Trezor icon (we are anywhere except _Settings_)
- [x] when being on _Settings_, don't display unnecessary "Back" button
- [x] add footer icons: Hide/Show balances, enable/disable Tor, make icons work
- [ ] make the icon spinner when enabling/disabling Tor bigger
- [ ] test on Mac

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/13521

## Videos:
**Before** (Desktop app):

https://github.com/user-attachments/assets/54e237ea-067e-4181-927b-22408b5b1a9d

**After** (Desktop app):

https://github.com/user-attachments/assets/71157e7e-ce97-4dc1-9015-fc401ea11a4c





