### PR TITLE
chore(suite): tpm visible only in debug

### DIFF
--- a/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
@@ -11,6 +11,7 @@ import {
     ExperimentalFeatureDescription,
 } from 'src/constants/suite/experimental';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
 
 const FeatureLineWrapper = styled.div`
     display: flex;
@@ -80,6 +81,8 @@ const motionDivProps = {
 
 export const Experimental = () => {
     const features = useSelector(state => state.suite.settings.experimental);
+    const isDebug = useSelector(selectIsDebugModeActive);
+
     const dispatch = useDispatch();
 
     const onSwitchExperimental = () =>
@@ -110,9 +113,15 @@ export const Experimental = () => {
             <AnimatePresence>
                 {features && Object.keys(ExperimentalFeature).length && (
                     <motion.div {...motionDivProps}>
-                        {Object.values(ExperimentalFeature).map(feature => (
-                            <FeatureLine key={feature} feature={feature} features={features} />
-                        ))}
+                        {Object.values(ExperimentalFeature).map(feature => {
+                            // not very systematic way how to exclude some features but freeze is happening
+                            if (feature === ExperimentalFeature.PasswordManager && !isDebug)
+                                return null;
+
+                            return (
+                                <FeatureLine key={feature} feature={feature} features={features} />
+                            );
+                        })}
                     </motion.div>
                 )}
             </AnimatePresence>


### PR DESCRIPTION
As per @MiroslavProchazka request. TPM is now visible only in debug. I did it in the simplest and fastest way possible and I guess it will not be exactly to @marekrjpolak taste. So we might want to revisit it later

<img width="924" alt="image" src="https://github.com/user-attachments/assets/3c0cfbf5-cadb-4546-9a7b-b4cea1833a27">

<img width="924" alt="image" src="https://github.com/user-attachments/assets/1ca4c0fd-bf7b-435f-849a-b201492650c7">
