### PR TITLE
fix(suite): removing data-test since wrong and not used

### DIFF
--- a/packages/suite/src/views/settings/SettingsGeneral/TorSnowflake.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/TorSnowflake.tsx
@@ -107,14 +107,12 @@ export const TorSnowflake = () => {
                         placeholder=""
                         inputState={error ? 'error' : undefined}
                         onChange={handleChange}
-                        data-test="@settings/general/tor/snowflake-binary-path"
                         hasBottomPadding={false}
                         size="small"
                     />
                     <Button
                         onClick={handleClick}
                         isDisabled={isUpdateDisabled}
-                        data-test="@settings/device/label-submit"
                         size="small"
                         isFullWidth
                     >


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I realized the `data-test` in packages/suite/src/views/settings/SettingsGeneral/TorSnowflake.tsx was wrong `@settings/device/label-submit` and I was going to fix it but since it is not used in any test, let's get rid of them.