### PR TITLE
fix(suite): Fix QR code background in dark mode

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, ReactNode } from 'react';
-import styled, { useTheme } from 'styled-components';
+import styled from 'styled-components';
 
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { Button, ConfirmOnDevice, ModalProps, Tooltip, variables } from '@trezor/components';
@@ -15,7 +15,7 @@ import { DeviceDisconnected } from './DeviceDisconnected';
 import { TransactionReviewStepIndicator } from '../TransactionReviewModal/TransactionReviewOutputList/TransactionReviewStepIndicator';
 import { TransactionReviewOutputElement } from '../TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement';
 import { Account } from '@suite-common/wallet-types';
-import { borders } from '@trezor/theme';
+import { borders, palette } from '@trezor/theme';
 import { getNetworkFeatures } from '@suite-common/wallet-config';
 
 const Wrapper = styled.div`
@@ -47,7 +47,6 @@ const Right = styled.div`
 
 const StyledQrCode = styled(QrCode)`
     border-radius: ${borders.radii.sm};
-    background: ${({ theme }) => theme.BG_GREY};
     padding: 32px;
     max-height: 100%;
     width: 300px;
@@ -96,7 +95,6 @@ export const ConfirmValueModal = ({
     const modalContext = useSelector(state => state.modal.context);
     const isActionAbortable = useSelector(selectIsActionAbortable);
     const dispatch = useDispatch();
-    const theme = useTheme();
 
     const canConfirmOnDevice = !!(device?.connected && device?.available);
     const addressConfirmed = isConfirmed || !canConfirmOnDevice;
@@ -135,6 +133,9 @@ export const ConfirmValueModal = ({
         }
     }, [canConfirmOnDevice, dispatch, isConfirmed, modalContext, validateOnDevice]);
 
+    // QR code needs constant colors, not light/dark theme colors
+    const qrCodeFgColor = addressConfirmed ? palette.lightGray1000 : palette.lightGray700;
+
     return (
         <StyledModal
             isCancelable={isCancelable}
@@ -158,7 +159,7 @@ export const ConfirmValueModal = ({
                     <StyledQrCode
                         value={value}
                         bgColor="transparent"
-                        fgColor={addressConfirmed ? theme.iconDefault : theme.iconSubdued}
+                        fgColor={qrCodeFgColor}
                         showMessage={!addressConfirmed}
                     />
                     <Right>


### PR DESCRIPTION
## Description

There are two occurrences of `QrCode` component in suite:
- `PromoBanner` uses default `QrCode` colors, works as intended
- `ConfirmValueModal` used colors from theme to override `QrCode`, will use constant colors instead

## Related Issue

Resolve #13083

## Screenshots:

Dark mode before & after:

### ConfirmValueModal _unconfirmed_
![image](https://github.com/user-attachments/assets/8c5ee991-fa5e-405a-aa6e-93856c676cb7)
![image](https://github.com/user-attachments/assets/7741b730-f2c3-4dc8-bbb0-91082e2fbd49)

### ConfirmValueModal _confirmed_
![image](https://github.com/user-attachments/assets/c3d30eb7-6775-401b-9f3d-763a895a147d)
![image](https://github.com/user-attachments/assets/3a0b0cd6-8d53-491b-9f08-2ad5fbf472ff)


### PromoBanner
![image](https://github.com/user-attachments/assets/3c5a9b69-f4ef-44b5-86ff-2452550401b8)
![image](https://github.com/user-attachments/assets/4269730b-bc2c-4832-b2f2-6d78fd8dc566)
