### PR TITLE
fix(suite-native): e2e GH runner storage

### DIFF
--- a/.github/workflows/test-suite-native-e2e-android.yml
+++ b/.github/workflows/test-suite-native-e2e-android.yml
@@ -24,6 +24,17 @@ jobs:
         with:
           submodules: "true"
 
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # The free GH runner has limited disk space, so we need to uninstall some preinstalled tools.
+          dotnet: true
+          haskell: true
+          tool-cache: false
+          android: false
+          swap-storage: false
+          large-packages: false
+
       - name: Install node and yarn
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Description

Fixes native E2E test action. 
[[LINK]](https://github.com/trezor/trezor-suite/actions/runs/10265060997?pr=13665) to successful run.
