### PR TITLE
fix(suite): fix type error in knowledgebaseurls

### DIFF
--- a/packages/suite/src/constants/suite/experimental.ts
+++ b/packages/suite/src/constants/suite/experimental.ts
@@ -21,7 +21,7 @@ export const ExperimentalFeatureDescription: FeatureIntlMap = {
     [ExperimentalFeature.TorSnowflake]: 'TR_EXPERIMENTAL_TOR_SNOWFLAKE_DESCRIPTION',
 };
 
-export const ExperimentalFeatureKnowledgeBaseUrl = {
+export const ExperimentalFeatureKnowledgeBaseUrl: Partial<Record<ExperimentalFeature, string>> = {
     [ExperimentalFeature.PasswordManager]: EXPERIMENTAL_PASSWORD_MANAGER_KB_URL,
     [ExperimentalFeature.TorSnowflake]: TOR_SNOWFLAKE_KB_URL,
 };


### PR DESCRIPTION
Fixing tiny mistake in `experimental.ts` that was causing type check errors.