### PR TITLE
Misc fixes

### DIFF
--- a/packages/connect/e2e/common.setup.js
+++ b/packages/connect/e2e/common.setup.js
@@ -38,14 +38,13 @@ const setup = async (TrezorUserEnvLink, options) => {
         return true;
     }
 
-    if (!options.mnemonic) return true; // skip setup if test is not using the device (composeTransaction)
-
     await TrezorUserEnvLink.stopEmu();
-
     // after bridge is stopped, trezor-user-env automatically resolves to use udp transport.
     // this is actually good as we avoid possible race conditions when setting up emulator for
     // the test using the same transport
     await TrezorUserEnvLink.stopBridge();
+
+    if (!options.mnemonic) return true; // skip setup if test is not using the device (composeTransaction)
 
     await TrezorUserEnvLink.startEmu(emulatorStartOpts);
 

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -410,11 +410,15 @@ export abstract class AbstractTransport extends TypedEmitter<{
         const diff = this.getDiff(nextDescriptors);
         this.logger?.debug('nextDescriptors', nextDescriptors, 'diff', diff);
 
+        // even when there is no change from our point of view (see diff.didUpdate) it makes sense to update local descriptors because the
+        // last descriptors we handled might in fact be different to what we have saved locally from the previous update. the reason is that
+        // legacy bridge backends might be working with a different set of fields (eg. debug, debugSession). and we need to save this since
+        // we need to pass this data to the next /listen call
+        this.descriptors = nextDescriptors;
+
         if (!diff.didUpdate) {
             return;
         }
-
-        this.descriptors = nextDescriptors;
 
         Object.keys(this.listenPromise).forEach(path => {
             const descriptor = diff.descriptors.find(device => device.path === path);

--- a/packages/transport/src/types/index.ts
+++ b/packages/transport/src/types/index.ts
@@ -10,10 +10,16 @@ export type DescriptorApiLevel = {
     type: DEVICE_TYPE;
     /** only important for T1 over old bridge (trezord-go), defacto part of 'path'. More explanation in https://github.com/trezor/trezor-suite/compare/transport-descriptor-product */
     product?: number;
+    /** only reported by old bridge */
+    vendor?: number;
 };
 
 export type Descriptor = DescriptorApiLevel & {
     session: null | Session;
+    /** only reported by old bridge */
+    debugSession?: null | Session;
+    /** only reported by old bridge */
+    debug?: boolean;
 };
 
 export interface Logger {

--- a/packages/transport/src/utils/bridgeApiResult.ts
+++ b/packages/transport/src/utils/bridgeApiResult.ts
@@ -58,7 +58,6 @@ export function devices(res: UnknownPayload) {
                 session: o.session,
                 product: o.product,
                 type: o.type,
-                // @ts-expect-error - this is part of response too, might add it to type later
                 vendor: o.vendor,
                 debug: o.debug,
                 debugSession: o.debugSession,


### PR DESCRIPTION
- [b419e00](https://github.com/trezor/trezor-suite/pull/13668/commits/b419e008c17c2037abf5c1193d1a2a02fce769ac) although suite/connect does not work with debug sessions, old bridge still returns them. This means that if we don't update local descriptors, any subsequent subscription to /listen endpoint is immediately resolved by bridge because what we sent does not match the state of bridge backend. This change updates descriptors locally even if from the point of view of connect they did not change.
- [935ac91](https://github.com/trezor/trezor-suite/pull/13668/commits/935ac916abebf193ae85ad2ba9c69823be6e70a2) 
  - this change https://github.com/trezor/trezor-suite/pull/13559/commits/0d8b2f3e7997421498982789ed6047dcd8e70db2 introduced a race condition that sometimes happen in karma tests, probably because of random tests ordering. roughly described what happens: 1. device is connected and being loaded under the hood GetFeatures is sent, 2. a method which does not need device (composeTransaction) is resolved, 3. Features from 2 not received yet, 4. another test method that now needs device is triggered. And it stays hanging on the newly added wait 
  - it can be  mitigated by not starting emulator for tests suites that don't work with it. 