### PR TITLE
chore(suite): don't run second process with autostart

### DIFF
--- a/packages/ipc-proxy/src/__tests__/mockedElectron.ts
+++ b/packages/ipc-proxy/src/__tests__/mockedElectron.ts
@@ -1,8 +1,8 @@
 import { EventEmitter } from 'events';
 
-import { ElectionIpcMainInvokeEvent } from '../proxy-handler';
+import { ElectronIpcMainInvokeEvent } from '../proxy-handler';
 
-const ipcMainEvent: ElectionIpcMainInvokeEvent = {
+const ipcMainEvent: ElectronIpcMainInvokeEvent = {
     senderFrame: {
         url: 'http://localhost:8000/',
     },

--- a/packages/ipc-proxy/src/__tests__/validateIpcMessage.test.ts
+++ b/packages/ipc-proxy/src/__tests__/validateIpcMessage.test.ts
@@ -1,4 +1,4 @@
-import { ElectionIpcMainInvokeEvent } from '../proxy-handler';
+import { ElectronIpcMainInvokeEvent } from '../proxy-handler';
 import { validateIpcMessage } from '../validateIpcMessage';
 
 const createSenderFrame = (url: string) => ({ senderFrame: { url } });
@@ -35,7 +35,7 @@ describe(validateIpcMessage.name, () => {
 
     it('fails for invalid senderFrame', () => {
         const subject = () => {
-            validateIpcMessage({} as ElectionIpcMainInvokeEvent);
+            validateIpcMessage({} as ElectronIpcMainInvokeEvent);
         };
 
         expect(subject).toThrow('Invalid ipcEvent: {}');

--- a/packages/ipc-proxy/src/proxy-handler.ts
+++ b/packages/ipc-proxy/src/proxy-handler.ts
@@ -43,7 +43,7 @@ interface IpcMainHandlers<Api> {
     '/invoke': Parameters<ApiUnion<Api>>; // methodName, ...params
 }
 
-export interface ElectionIpcMainInvokeEvent {
+export interface ElectronIpcMainInvokeEvent {
     senderFrame: {
         url: string;
     };
@@ -60,14 +60,14 @@ interface ElectronIpcMain<Api> {
         channel: `${Key}${K}`,
         listener: (event: ElectronIpcMainEvent, args: IpcMainEvents<Api>[K]) => void,
     ): any;
-    on(channel: string, listener: (event: ElectionIpcMainInvokeEvent, ...args: any[]) => void): any; // just to type compatibility with original Electron.IpcMain
+    on(channel: string, listener: (event: ElectronIpcMainInvokeEvent, ...args: any[]) => void): any; // just to type compatibility with original Electron.IpcMain
     handle<K extends keyof IpcMainHandlers<Api>, Key extends string>(
         channel: `${Key}${K}`,
-        listener: (event: ElectionIpcMainInvokeEvent, args: IpcMainHandlers<Api>[K]) => void,
+        listener: (event: ElectronIpcMainInvokeEvent, args: IpcMainHandlers<Api>[K]) => void,
     ): any;
     handle(
         channel: string,
-        listener: (event: ElectionIpcMainInvokeEvent, ...args: any[]) => void,
+        listener: (event: ElectronIpcMainInvokeEvent, ...args: any[]) => void,
     ): any;
     removeAllListeners: (event?: string) => any;
     eventNames: () => (string | symbol)[];

--- a/packages/ipc-proxy/src/validateIpcMessage.ts
+++ b/packages/ipc-proxy/src/validateIpcMessage.ts
@@ -1,7 +1,7 @@
-import { ElectionIpcMainInvokeEvent } from './proxy-handler';
+import { ElectronIpcMainInvokeEvent } from './proxy-handler';
 
 // ipcEvent: Electron.IpcMainInvokeEvent
-export const validateIpcMessage = (ipcEvent: ElectionIpcMainInvokeEvent) => {
+export const validateIpcMessage = (ipcEvent: ElectronIpcMainInvokeEvent) => {
     if (ipcEvent?.senderFrame && 'url' in ipcEvent.senderFrame) {
         const parsedUrl = new URL(ipcEvent.senderFrame.url);
 

--- a/packages/suite-desktop-core/src/hang-detect.ts
+++ b/packages/suite-desktop-core/src/hang-detect.ts
@@ -1,7 +1,7 @@
 import { BrowserWindow, dialog } from 'electron';
 
 import { validateIpcMessage } from '@trezor/ipc-proxy';
-import { ElectionIpcMainInvokeEvent } from '@trezor/ipc-proxy/src/proxy-handler';
+import { ElectronIpcMainInvokeEvent } from '@trezor/ipc-proxy/src/proxy-handler';
 
 import { ipcMain } from './typed-electron';
 import { APP_SRC } from './libs/constants';
@@ -22,7 +22,7 @@ const showDialog = async (mainWindow: BrowserWindow) => {
 
 export const hangDetect = (mainWindow: BrowserWindow, statePatch?: Record<string, any>) => {
     const { logger } = global;
-    const handshakeHandler = (ipcEvent: ElectionIpcMainInvokeEvent) => {
+    const handshakeHandler = (ipcEvent: ElectronIpcMainInvokeEvent) => {
         validateIpcMessage(ipcEvent);
 
         return Promise.resolve({});

--- a/packages/suite-desktop-core/src/libs/app-utils.ts
+++ b/packages/suite-desktop-core/src/libs/app-utils.ts
@@ -14,6 +14,7 @@ export const restartApp = () => {
         options.args.unshift('--appimage-extract-and-run');
     }
 
+    app.removeAllListeners('before-quit');
     app.relaunch();
     app.quit();
 };

--- a/packages/suite-desktop-core/src/libs/main-window-proxy.ts
+++ b/packages/suite-desktop-core/src/libs/main-window-proxy.ts
@@ -1,0 +1,29 @@
+import { TypedEmitter } from '@trezor/utils';
+
+import { StrictBrowserWindow } from '../typed-electron';
+
+interface MainWindowProxyEvents {
+    init: (instance: StrictBrowserWindow) => void;
+    destroy: (instance: StrictBrowserWindow) => void;
+}
+
+export class MainWindowProxy extends TypedEmitter<MainWindowProxyEvents> {
+    private instance?: StrictBrowserWindow;
+
+    setInstance(instance: StrictBrowserWindow) {
+        this.destroyInstance();
+        this.instance = instance;
+        this.emit('init', instance);
+    }
+
+    destroyInstance() {
+        if (this.instance) {
+            this.emit('destroy', this.instance);
+            this.instance = undefined;
+        }
+    }
+
+    getInstance() {
+        return this.instance;
+    }
+}

--- a/packages/suite-desktop-core/src/modules/bridge.ts
+++ b/packages/suite-desktop-core/src/modules/bridge.ts
@@ -192,6 +192,7 @@ const load = async (bridge: BridgeInterface, store: Dependencies['store']) => {
 
 type BridgeModule = ({ store }: Pick<Dependencies, 'store'>) => {
     onLoad: () => void;
+    onQuit: () => Promise<void>;
 };
 
 export const init: BridgeModule = ({ store }) => {

--- a/packages/suite-desktop-core/src/modules/coinjoin.ts
+++ b/packages/suite-desktop-core/src/modules/coinjoin.ts
@@ -23,7 +23,7 @@ export const SERVICE_NAME = '@trezor/coinjoin';
 const CLIENT_CHANNEL = 'CoinjoinClient';
 const BACKEND_CHANNEL = 'CoinjoinBackend';
 
-export const init: Module = ({ mainWindow, store, mainThreadEmitter }) => {
+export const init: Module = ({ mainWindowProxy, store, mainThreadEmitter }) => {
     const { logger } = global;
 
     const backends: ThreadProxy<CoinjoinBackend>[] = [];
@@ -232,7 +232,9 @@ export const init: Module = ({ mainWindow, store, mainThreadEmitter }) => {
         await dispose();
     };
 
-    mainWindow.webContents.on('did-start-loading', dispose);
+    mainWindowProxy.on('init', mainWindow => {
+        mainWindow.webContents.on('did-start-loading', dispose);
+    });
     ipcMain.once('app/restart', dispose);
 
     return { onLoad: registerProxies, onQuit };

--- a/packages/suite-desktop-core/src/modules/crash-recover.ts
+++ b/packages/suite-desktop-core/src/modules/crash-recover.ts
@@ -13,23 +13,25 @@ const unexpectedReasons = [
 
 export const SERVICE_NAME = 'crash-recover';
 
-export const init: Module = ({ mainWindow }) => {
+export const init: Module = ({ mainWindowProxy }) => {
     // Check if the renderer process got unexpectedly terminated
-    mainWindow.webContents.on('render-process-gone', (_, { reason }) => {
-        if (unexpectedReasons.includes(reason)) {
-            // Note: No need to log this, the event logger already takes care of that
-            const result = dialog.showMessageBoxSync(mainWindow, {
-                type: 'error',
-                message: `Render process terminated unexpectedly (reason: ${reason}).`,
-                buttons: ['Quit', 'Restart'],
-            });
+    mainWindowProxy.on('init', mainWindow => {
+        mainWindow.webContents.on('render-process-gone', (_, { reason }) => {
+            if (unexpectedReasons.includes(reason)) {
+                // Note: No need to log this, the event logger already takes care of that
+                const result = dialog.showMessageBoxSync(mainWindow, {
+                    type: 'error',
+                    message: `Render process terminated unexpectedly (reason: ${reason}).`,
+                    buttons: ['Quit', 'Restart'],
+                });
 
-            // Restart
-            if (result === 1) {
-                restartApp();
-            } else {
-                app.quit();
+                // Restart
+                if (result === 1) {
+                    restartApp();
+                } else {
+                    app.quit();
+                }
             }
-        }
+        });
     });
 };

--- a/packages/suite-desktop-core/src/modules/custom-protocols.ts
+++ b/packages/suite-desktop-core/src/modules/custom-protocols.ts
@@ -9,7 +9,7 @@ import type { Module } from './index';
 
 export const SERVICE_NAME = 'custom-protocols';
 
-export const init: Module = ({ mainWindow }) => {
+export const init: Module = ({ mainWindowProxy }) => {
     const { logger } = global;
 
     const protocols = process.env.PROTOCOLS as unknown as string[];
@@ -18,7 +18,7 @@ export const init: Module = ({ mainWindow }) => {
     const sendProtocolInfo = (protocol: string) => {
         if (isValidProtocol(protocol, protocols)) {
             logger.debug(SERVICE_NAME, `Send custom protocol to browser window: ${protocol}`);
-            mainWindow.webContents.send('protocol/open', protocol);
+            mainWindowProxy.getInstance()?.webContents.send('protocol/open', protocol);
         }
     };
 
@@ -52,10 +52,11 @@ export const init: Module = ({ mainWindow }) => {
 
         logger.debug(SERVICE_NAME, 'App is running and handling custom protocol (macOS)');
 
-        if (mainWindow.isMinimized()) {
-            mainWindow.restore();
+        const mainWindow = mainWindowProxy.getInstance();
+        if (mainWindow?.isMinimized()) {
+            mainWindow?.restore();
         } else {
-            mainWindow.focus();
+            mainWindow?.focus();
         }
 
         sendProtocolInfo(url);

--- a/packages/suite-desktop-core/src/modules/dev-tools.ts
+++ b/packages/suite-desktop-core/src/modules/dev-tools.ts
@@ -11,8 +11,8 @@ const openDevToolsFlag = app.commandLine.hasSwitch('open-devtools');
 
 export const SERVICE_NAME = 'dev-tools';
 
-export const init: Module = ({ mainWindow }) => {
+export const init: Module = ({ mainWindowProxy }) => {
     if (isDevEnv || openDevToolsFlag) {
-        mainWindow.webContents.openDevTools();
+        mainWindowProxy.getInstance()?.webContents.openDevTools();
     }
 };

--- a/packages/suite-desktop-core/src/modules/event-logging/contents.ts
+++ b/packages/suite-desktop-core/src/modules/event-logging/contents.ts
@@ -6,60 +6,65 @@ const logUI = app.commandLine.hasSwitch('log-ui');
 
 export const SERVICE_NAME = 'content';
 
-export const init: Module = ({ mainWindow }) => {
+export const init: Module = ({ mainWindowProxy }) => {
     const { logger } = global;
 
-    mainWindow.webContents.on('did-fail-load', (_, errorCode, errorDescription, validatedUrl) => {
-        logger.error(
-            SERVICE_NAME,
-            `Failure to load ${validatedUrl} (${errorCode} - ${errorDescription})`,
+    mainWindowProxy.on('init', mainWindow => {
+        mainWindow.webContents.on(
+            'did-fail-load',
+            (_, errorCode, errorDescription, validatedUrl) => {
+                logger.error(
+                    SERVICE_NAME,
+                    `Failure to load ${validatedUrl} (${errorCode} - ${errorDescription})`,
+                );
+            },
         );
-    });
 
-    mainWindow.webContents.on('will-navigate', (_, url) => {
-        logger.info(SERVICE_NAME, `Navigate to ${url}`);
-    });
+        mainWindow.webContents.on('will-navigate', (_, url) => {
+            logger.info(SERVICE_NAME, `Navigate to ${url}`);
+        });
 
-    mainWindow.webContents.on('render-process-gone', (_, { reason }) => {
-        logger.error(SERVICE_NAME, `Render process gone (reason: ${reason})`);
-    });
+        mainWindow.webContents.on('render-process-gone', (_, { reason }) => {
+            logger.error(SERVICE_NAME, `Render process gone (reason: ${reason})`);
+        });
 
-    let unresponsiveStart = 0;
-    mainWindow.webContents.on('unresponsive', () => {
-        unresponsiveStart = +new Date();
-        logger.warn(SERVICE_NAME, 'Unresponsive');
-    });
+        let unresponsiveStart = 0;
+        mainWindow.webContents.on('unresponsive', () => {
+            unresponsiveStart = +new Date();
+            logger.warn(SERVICE_NAME, 'Unresponsive');
+        });
 
-    mainWindow.webContents.on('responsive', () => {
-        if (unresponsiveStart !== 0) {
-            logger.warn(
-                SERVICE_NAME,
-                `Responsive again after ${(+new Date() - unresponsiveStart / 1000).toFixed(1)}s`,
-            );
-            unresponsiveStart = 0;
+        mainWindow.webContents.on('responsive', () => {
+            if (unresponsiveStart !== 0) {
+                logger.warn(
+                    SERVICE_NAME,
+                    `Responsive again after ${(+new Date() - unresponsiveStart / 1000).toFixed(1)}s`,
+                );
+                unresponsiveStart = 0;
+            }
+        });
+
+        mainWindow.webContents.on('devtools-opened', () => {
+            logger.info(SERVICE_NAME, `Dev tools opened`);
+        });
+
+        mainWindow.webContents.on('devtools-closed', () => {
+            logger.info(SERVICE_NAME, `Dev tools closed`);
+        });
+
+        if (logUI) {
+            const levels = ['debug', 'info', 'warn', 'error'] as const;
+            mainWindow.webContents.on('console-message', (_, level, message, line, sourceId) => {
+                const method = levels[level];
+                if (!method) return;
+                if (message.startsWith('%c')) return; // ignore redux-logger
+                if (message.startsWith('console.groupEnd')) return; // ignore redux-logger
+
+                logger[method](
+                    'ui-log',
+                    method !== 'error' ? message : [message, `${sourceId}:${line}`],
+                );
+            });
         }
     });
-
-    mainWindow.webContents.on('devtools-opened', () => {
-        logger.info(SERVICE_NAME, `Dev tools opened`);
-    });
-
-    mainWindow.webContents.on('devtools-closed', () => {
-        logger.info(SERVICE_NAME, `Dev tools closed`);
-    });
-
-    if (logUI) {
-        const levels = ['debug', 'info', 'warn', 'error'] as const;
-        mainWindow.webContents.on('console-message', (_, level, message, line, sourceId) => {
-            const method = levels[level];
-            if (!method) return;
-            if (message.startsWith('%c')) return; // ignore redux-logger
-            if (message.startsWith('console.groupEnd')) return; // ignore redux-logger
-
-            logger[method](
-                'ui-log',
-                method !== 'error' ? message : [message, `${sourceId}:${line}`],
-            );
-        });
-    }
 };

--- a/packages/suite-desktop-core/src/modules/event-logging/process.ts
+++ b/packages/suite-desktop-core/src/modules/event-logging/process.ts
@@ -7,6 +7,7 @@ export const init: Module = () => {
 
     process.on('uncaughtException', e => {
         logger.error('exception', e.message);
+        if (e.stack) logger.error('exception', e.stack);
     });
 
     process.on('unhandledRejection', (e: Error) => {

--- a/packages/suite-desktop-core/src/modules/external-links.ts
+++ b/packages/suite-desktop-core/src/modules/external-links.ts
@@ -10,56 +10,58 @@ import type { Module } from './index';
 
 export const SERVICE_NAME = 'external-links';
 
-export const init: Module = ({ mainWindow, store }) => {
+export const init: Module = ({ mainWindowProxy, store }) => {
     const { logger } = global;
 
-    mainWindow.webContents.setWindowOpenHandler((details: HandlerDetails) => {
-        const { url } = details;
-        const { protocol } = new URL(url);
+    mainWindowProxy.on('init', mainWindow => {
+        mainWindow.webContents.setWindowOpenHandler((details: HandlerDetails) => {
+            const { url } = details;
+            const { protocol } = new URL(url);
 
-        // https://benjamin-altpeter.de/shell-openexternal-dangers/
-        if (!config.allowedProtocols.includes(protocol)) {
-            logger.error(SERVICE_NAME, `Protocol '${protocol}' not allowed`);
+            // https://benjamin-altpeter.de/shell-openexternal-dangers/
+            if (!config.allowedProtocols.includes(protocol)) {
+                logger.error(SERVICE_NAME, `Protocol '${protocol}' not allowed`);
 
-            return { action: 'deny' };
-        }
-
-        if (config.oauthUrls.some(u => url.startsWith(u))) {
-            logger.info(SERVICE_NAME, `${url} was allowed (OAuth list)`);
-        }
-
-        if (url !== mainWindow.webContents.getURL()) {
-            const torSettings = store.getTorSettings();
-            if (torSettings.running) {
-                // TODO: Replace with in-app modal
-                const result = dialog.showMessageBoxSync(mainWindow, {
-                    type: 'warning',
-                    message: `The following URL is going to be opened in your browser\n\n${url}`,
-                    buttons: ['Cancel', 'Continue'],
-                });
-                const cancel = result === 0;
-                logger.info(
-                    SERVICE_NAME,
-                    `${url} was ${cancel ? 'not ' : ''}allowed by user in TOR mode`,
-                );
-
-                if (cancel) {
-                    // do nothing
-                    return { action: 'deny' };
-                }
+                return { action: 'deny' };
             }
-            logger.info(SERVICE_NAME, `${url} opened in default browser`);
-        }
 
-        // open URL in the user's default browser instead of headless browser window
-        shell.openExternal(url).catch(err =>
-            dialog.showMessageBoxSync(mainWindow, {
-                type: 'error',
-                message: `${err} ${url}`,
-            }),
-        );
+            if (config.oauthUrls.some(u => url.startsWith(u))) {
+                logger.info(SERVICE_NAME, `${url} was allowed (OAuth list)`);
+            }
 
-        // do not open headless browser window
-        return { action: 'deny' };
+            if (url !== mainWindow.webContents.getURL()) {
+                const torSettings = store.getTorSettings();
+                if (torSettings.running) {
+                    // TODO: Replace with in-app modal
+                    const result = dialog.showMessageBoxSync(mainWindow, {
+                        type: 'warning',
+                        message: `The following URL is going to be opened in your browser\n\n${url}`,
+                        buttons: ['Cancel', 'Continue'],
+                    });
+                    const cancel = result === 0;
+                    logger.info(
+                        SERVICE_NAME,
+                        `${url} was ${cancel ? 'not ' : ''}allowed by user in TOR mode`,
+                    );
+
+                    if (cancel) {
+                        // do nothing
+                        return { action: 'deny' };
+                    }
+                }
+                logger.info(SERVICE_NAME, `${url} opened in default browser`);
+            }
+
+            // open URL in the user's default browser instead of headless browser window
+            shell.openExternal(url).catch(err =>
+                dialog.showMessageBoxSync(mainWindow, {
+                    type: 'error',
+                    message: `${err} ${url}`,
+                }),
+            );
+
+            // do not open headless browser window
+            return { action: 'deny' };
+        });
     });
 };

--- a/packages/suite-desktop-core/src/modules/file-protocol.ts
+++ b/packages/suite-desktop-core/src/modules/file-protocol.ts
@@ -10,7 +10,7 @@ import type { Module } from './index';
 
 export const SERVICE_NAME = 'file-protocol';
 
-export const init: Module = ({ mainWindow }) => {
+export const init: Module = ({ mainWindowProxy }) => {
     // Point to the right directory for file protocol requests
     session.defaultSession.protocol.interceptFileProtocol(FILE_PROTOCOL, (request, callback) => {
         let url = request.url.substring(FILE_PROTOCOL.length + 1);
@@ -19,7 +19,9 @@ export const init: Module = ({ mainWindow }) => {
     });
 
     // Refresh if it failed to load
-    mainWindow.webContents.on('did-fail-load', () => {
-        mainWindow.loadURL(APP_SRC);
+    mainWindowProxy.on('init', mainWindow => {
+        mainWindow.webContents.on('did-fail-load', () => {
+            mainWindow.loadURL(APP_SRC);
+        });
     });
 };

--- a/packages/suite-desktop-core/src/modules/http-receiver.ts
+++ b/packages/suite-desktop-core/src/modules/http-receiver.ts
@@ -10,7 +10,7 @@ import type { Module } from './index';
 
 export const SERVICE_NAME = 'http-receiver';
 
-export const init: Module = ({ mainWindow }) => {
+export const init: Module = ({ mainWindowProxy }) => {
     const { logger } = global;
     let httpReceiver: ReturnType<typeof createHttpReceiver> | null = null;
 
@@ -26,7 +26,7 @@ export const init: Module = ({ mainWindow }) => {
         receiver.on('server/listening', () => {
             // when httpReceiver accepted oauth response
             receiver.on('oauth/response', message => {
-                mainWindow.webContents.send('oauth/response', message);
+                mainWindowProxy.getInstance()?.webContents.send('oauth/response', message);
                 app.focus();
             });
 

--- a/packages/suite-desktop-core/src/modules/index.ts
+++ b/packages/suite-desktop-core/src/modules/index.ts
@@ -21,7 +21,6 @@ import * as windowControls from './window-controls';
 import * as theme from './theme';
 import * as httpReceiverModule from './http-receiver';
 import * as metadata from './metadata';
-import * as bridge from './bridge';
 import * as customProtocols from './custom-protocols';
 import * as autoUpdater from './auto-updater';
 import * as store from './store';
@@ -52,7 +51,6 @@ const MODULES = [
     theme,
     httpReceiverModule,
     metadata,
-    bridge,
     customProtocols,
     autoUpdater,
     store,

--- a/packages/suite-desktop-core/src/modules/menu.ts
+++ b/packages/suite-desktop-core/src/modules/menu.ts
@@ -7,26 +7,29 @@ import type { Module } from './index';
 
 export const SERVICE_NAME = 'menu';
 
-export const init: Module = ({ mainWindow }) => {
+export const init: Module = ({ mainWindowProxy }) => {
     const { logger } = global;
 
     Menu.setApplicationMenu(buildMainMenu());
-    mainWindow.setMenuBarVisibility(false);
+    mainWindowProxy.on('init', mainWindow => {
+        mainWindow.setMenuBarVisibility(false);
 
-    mainWindow.webContents.on('context-menu', (_, props) => {
-        const isTextSelected = Boolean(props.selectionText) && props.selectionText.trim() !== '';
-        logger.debug(SERVICE_NAME, [
-            'Context menu:',
-            `- Editable: ${b2t(props.isEditable)}`,
-            `- Text Selected: ${b2t(isTextSelected)}`,
-        ]);
+        mainWindow.webContents.on('context-menu', (_, props) => {
+            const isTextSelected =
+                Boolean(props.selectionText) && props.selectionText.trim() !== '';
+            logger.debug(SERVICE_NAME, [
+                'Context menu:',
+                `- Editable: ${b2t(props.isEditable)}`,
+                `- Text Selected: ${b2t(isTextSelected)}`,
+            ]);
 
-        if (props.isEditable) {
-            // right click on the input/textarea should open a context menu with text editing options (copy, cut, paste,...)
-            inputMenu.popup();
-        } else if (isTextSelected) {
-            // right click with active text selection should open context menu with a copy option
-            selectionMenu.popup();
-        }
+            if (props.isEditable) {
+                // right click on the input/textarea should open a context menu with text editing options (copy, cut, paste,...)
+                inputMenu.popup();
+            } else if (isTextSelected) {
+                // right click with active text selection should open context menu with a copy option
+                selectionMenu.popup();
+            }
+        });
     });
 };

--- a/packages/suite-desktop-core/src/modules/request-interceptor.ts
+++ b/packages/suite-desktop-core/src/modules/request-interceptor.ts
@@ -15,7 +15,7 @@ import type { Module } from './index';
 
 export const SERVICE_NAME = 'request-interceptor';
 
-export const init: Module = ({ mainWindow, store, mainThreadEmitter }) => {
+export const init: Module = ({ mainWindowProxy, store, mainThreadEmitter }) => {
     const { logger } = global;
 
     const requestInterceptorEventHandler = (event: InterceptedEvent) => {
@@ -30,7 +30,7 @@ export const init: Module = ({ mainWindow, store, mainThreadEmitter }) => {
         }
         if (event.type === 'NETWORK_MISBEHAVING') {
             logger.debug(SERVICE_NAME, 'networks is misbehaving');
-            mainWindow.webContents.send('tor/status', {
+            mainWindowProxy.getInstance()?.webContents.send('tor/status', {
                 type: TorStatus.Misbehaving,
             });
         }

--- a/packages/suite-desktop-core/src/modules/shortcuts.ts
+++ b/packages/suite-desktop-core/src/modules/shortcuts.ts
@@ -6,43 +6,45 @@ import type { Module } from './index';
 
 export const SERVICE_NAME = 'shortcuts';
 
-export const init: Module = ({ mainWindow }) => {
+export const init: Module = ({ mainWindowProxy }) => {
     const { logger } = global;
 
-    const openDevToolsShortcuts = ['F12', 'CommandOrControl+Shift+I', 'CommandOrControl+Alt+I'];
-    openDevToolsShortcuts.forEach(shortcut => {
-        electronLocalshortcut.register(mainWindow, shortcut, () => {
-            logger.info(SERVICE_NAME, `${shortcut} pressed to open/close DevTools`);
+    mainWindowProxy.on('init', mainWindow => {
+        const openDevToolsShortcuts = ['F12', 'CommandOrControl+Shift+I', 'CommandOrControl+Alt+I'];
+        openDevToolsShortcuts.forEach(shortcut => {
+            electronLocalshortcut.register(mainWindow, shortcut, () => {
+                logger.info(SERVICE_NAME, `${shortcut} pressed to open/close DevTools`);
 
-            if (mainWindow.webContents.isDevToolsOpened()) {
-                mainWindow.webContents.closeDevTools();
-            } else {
-                mainWindow.webContents.openDevTools();
-            }
+                if (mainWindow.webContents.isDevToolsOpened()) {
+                    mainWindow.webContents.closeDevTools();
+                } else {
+                    mainWindow.webContents.openDevTools();
+                }
+            });
         });
-    });
 
-    const reloadAppShortcuts = ['F5', 'CommandOrControl+R'];
-    reloadAppShortcuts.forEach(shortcut => {
-        electronLocalshortcut.register(mainWindow, shortcut, () => {
-            logger.info(SERVICE_NAME, `${shortcut} pressed to reload app`);
-            mainWindow.webContents.reload();
+        const reloadAppShortcuts = ['F5', 'CommandOrControl+R'];
+        reloadAppShortcuts.forEach(shortcut => {
+            electronLocalshortcut.register(mainWindow, shortcut, () => {
+                logger.info(SERVICE_NAME, `${shortcut} pressed to reload app`);
+                mainWindow.webContents.reload();
+            });
         });
-    });
 
-    const hardReloadAppShortcuts = ['Shift+F5', 'CommandOrControl+Shift+R'];
-    hardReloadAppShortcuts.forEach(shortcut => {
-        electronLocalshortcut.register(mainWindow, shortcut, () => {
-            logger.info(SERVICE_NAME, `${shortcut} pressed to hard reload app`);
-            mainWindow.webContents.reloadIgnoringCache();
+        const hardReloadAppShortcuts = ['Shift+F5', 'CommandOrControl+Shift+R'];
+        hardReloadAppShortcuts.forEach(shortcut => {
+            electronLocalshortcut.register(mainWindow, shortcut, () => {
+                logger.info(SERVICE_NAME, `${shortcut} pressed to hard reload app`);
+                mainWindow.webContents.reloadIgnoringCache();
+            });
         });
-    });
 
-    const restartAppShortcuts = ['Option+F5', 'Alt+F5', 'Option+Shift+R', 'Alt+Shift+R'];
-    restartAppShortcuts.forEach(shortcut => {
-        electronLocalshortcut.register(mainWindow, shortcut, () => {
-            logger.info(SERVICE_NAME, `${shortcut} pressed to restart app`);
-            restartApp();
+        const restartAppShortcuts = ['Option+F5', 'Alt+F5', 'Option+Shift+R', 'Alt+Shift+R'];
+        restartAppShortcuts.forEach(shortcut => {
+            electronLocalshortcut.register(mainWindow, shortcut, () => {
+                logger.info(SERVICE_NAME, `${shortcut} pressed to restart app`);
+                restartApp();
+            });
         });
     });
 };

--- a/packages/suite-desktop-core/src/modules/tor.ts
+++ b/packages/suite-desktop-core/src/modules/tor.ts
@@ -16,7 +16,7 @@ import { app, ipcMain } from '../typed-electron';
 
 import type { Dependencies } from './index';
 
-const load = async ({ mainWindow, store, mainThreadEmitter }: Dependencies) => {
+const load = async ({ mainWindowProxy, store, mainThreadEmitter }: Dependencies) => {
     const { logger } = global;
     const host = '127.0.0.1';
     const port = await getFreePort();
@@ -60,14 +60,14 @@ const load = async ({ mainWindow, store, mainThreadEmitter }: Dependencies) => {
             type = TorStatus.Disabled;
         }
         mainThreadEmitter.emit('module/tor-status-update', type);
-        mainWindow.webContents.send('tor/status', {
+        mainWindowProxy.getInstance()?.webContents.send('tor/status', {
             type,
         });
     };
 
     const handleBootstrapEvent = (bootstrapEvent: BootstrapEvent) => {
         if (bootstrapEvent.type === 'slow') {
-            mainWindow.webContents.send('tor/bootstrap', {
+            mainWindowProxy.getInstance()?.webContents.send('tor/bootstrap', {
                 type: 'slow',
             });
         }
@@ -86,7 +86,7 @@ const load = async ({ mainWindow, store, mainThreadEmitter }: Dependencies) => {
                 },
             };
 
-            mainWindow.webContents.send('tor/bootstrap', event);
+            mainWindowProxy.getInstance()?.webContents.send('tor/bootstrap', event);
         }
     };
 
@@ -105,7 +105,7 @@ const load = async ({ mainWindow, store, mainThreadEmitter }: Dependencies) => {
                 tor.setTorConfig({ snowflakeBinaryPath });
                 await tor.start();
             } catch (error) {
-                mainWindow.webContents.send('tor/bootstrap', {
+                mainWindowProxy.getInstance()?.webContents.send('tor/bootstrap', {
                     type: 'error',
                     message: error.message,
                 });
@@ -117,7 +117,7 @@ const load = async ({ mainWindow, store, mainThreadEmitter }: Dependencies) => {
                 tor.torController.removeAllListeners();
             }
         } else {
-            mainWindow.webContents.send('tor/status', {
+            mainWindowProxy.getInstance()?.webContents.send('tor/status', {
                 type: TorStatus.Disabling,
             });
             setProxy('');
@@ -145,7 +145,9 @@ const load = async ({ mainWindow, store, mainThreadEmitter }: Dependencies) => {
             } catch (error) {
                 return { success: false, error };
             } finally {
-                mainWindow.webContents.send('tor/settings', store.getTorSettings());
+                mainWindowProxy
+                    .getInstance()
+                    ?.webContents.send('tor/settings', store.getTorSettings());
             }
         },
     );

--- a/packages/suite-desktop-core/src/modules/window-controls.ts
+++ b/packages/suite-desktop-core/src/modules/window-controls.ts
@@ -7,78 +7,80 @@ import type { Module } from './index';
 
 export const SERVICE_NAME = 'window-control';
 
-export const init: Module = ({ mainWindow }) => {
+export const init: Module = ({ mainWindowProxy }) => {
     const { logger } = global;
 
-    if (process.platform === 'darwin') {
-        // macOS specific window behavior
-        // it is common for applications and their context menu to stay active until the user quits explicitly
-        // with Cmd + Q or right-click > Quit from the context menu.
+    mainWindowProxy.on('init', mainWindow => {
+        if (process.platform === 'darwin') {
+            // macOS specific window behavior
+            // it is common for applications and their context menu to stay active until the user quits explicitly
+            // with Cmd + Q or right-click > Quit from the context menu.
 
-        // restore window after click on the Dock icon
-        app.on('activate', () => {
-            logger.info(SERVICE_NAME, 'Showing main window on activate');
-            mainWindow.show();
+            // restore window after click on the Dock icon
+            app.on('activate', () => {
+                logger.info(SERVICE_NAME, 'Showing main window on activate');
+                mainWindow.show();
+            });
+            // hide window to the Dock
+            // this event listener will be removed by app.on('before-quit')
+            mainWindow.on('close', event => {
+                logger.info(SERVICE_NAME, 'Hiding the app after the main window has been closed');
+
+                event.preventDefault();
+                // this is a workaround for black screen issue when trying to close an maximized window
+                if (mainWindow.isFullScreen()) {
+                    mainWindow.once('leave-full-screen', () => mainWindow.hide());
+                    mainWindow.setFullScreen(false);
+                } else {
+                    mainWindow.hide();
+                    app.hide();
+                }
+            });
+        } else {
+            // other platform just kills the app
+            app.on('window-all-closed', () => {
+                logger.info(SERVICE_NAME, 'Quitting app after all windows have been closed');
+                app.quit();
+            });
+        }
+
+        mainWindow.on('page-title-updated', evt => {
+            evt.preventDefault();
         });
-        // hide window to the Dock
-        // this event listener will be removed by app.on('before-quit')
-        mainWindow.on('close', event => {
-            logger.info(SERVICE_NAME, 'Hiding the app after the main window has been closed');
 
-            event.preventDefault();
-            // this is a workaround for black screen issue when trying to close an maximized window
-            if (mainWindow.isFullScreen()) {
-                mainWindow.once('leave-full-screen', () => mainWindow.hide());
-                mainWindow.setFullScreen(false);
-            } else {
-                mainWindow.hide();
-                app.hide();
+        mainWindow.on('maximize', () => {
+            logger.debug(SERVICE_NAME, 'Maximize');
+        });
+
+        mainWindow.on('unmaximize', () => {
+            logger.debug(SERVICE_NAME, 'Unmaximize');
+        });
+
+        mainWindow.on('enter-full-screen', () => {
+            // do not log on Linux as it is triggered constantly with each movement in fullscreen mode
+            if (process.platform !== 'linux') {
+                logger.debug(SERVICE_NAME, 'Enter full screen');
             }
         });
-    } else {
-        // other platform just kills the app
-        app.on('window-all-closed', () => {
-            logger.info(SERVICE_NAME, 'Quitting app after all windows have been closed');
-            app.quit();
+
+        mainWindow.on('leave-full-screen', () => {
+            // do not log on Linux as it is triggered constantly with each movement in windowed mode
+            if (process.platform !== 'linux') {
+                logger.debug(SERVICE_NAME, 'Leave full screen');
+            }
         });
-    }
 
-    mainWindow.on('page-title-updated', evt => {
-        evt.preventDefault();
-    });
+        mainWindow.on('moved', () => {
+            logger.debug(SERVICE_NAME, 'Moved');
+        });
 
-    mainWindow.on('maximize', () => {
-        logger.debug(SERVICE_NAME, 'Maximize');
-    });
+        mainWindow.on('focus', () => {
+            logger.debug(SERVICE_NAME, 'Focus');
+        });
 
-    mainWindow.on('unmaximize', () => {
-        logger.debug(SERVICE_NAME, 'Unmaximize');
-    });
-
-    mainWindow.on('enter-full-screen', () => {
-        // do not log on Linux as it is triggered constantly with each movement in fullscreen mode
-        if (process.platform !== 'linux') {
-            logger.debug(SERVICE_NAME, 'Enter full screen');
-        }
-    });
-
-    mainWindow.on('leave-full-screen', () => {
-        // do not log on Linux as it is triggered constantly with each movement in windowed mode
-        if (process.platform !== 'linux') {
-            logger.debug(SERVICE_NAME, 'Leave full screen');
-        }
-    });
-
-    mainWindow.on('moved', () => {
-        logger.debug(SERVICE_NAME, 'Moved');
-    });
-
-    mainWindow.on('focus', () => {
-        logger.debug(SERVICE_NAME, 'Focus');
-    });
-
-    mainWindow.on('blur', () => {
-        logger.debug(SERVICE_NAME, 'Blur');
+        mainWindow.on('blur', () => {
+            logger.debug(SERVICE_NAME, 'Blur');
+        });
     });
 
     ipcMain.on('app/focus', () => {
@@ -88,6 +90,6 @@ export const init: Module = ({ mainWindow }) => {
 
     ipcMain.on('app/hide', () => {
         logger.debug(SERVICE_NAME, 'Hide requested');
-        mainWindow.hide();
+        mainWindowProxy.getInstance()?.hide();
     });
 };

--- a/packages/suite-desktop-core/src/modules/window-controls.ts
+++ b/packages/suite-desktop-core/src/modules/window-controls.ts
@@ -31,6 +31,7 @@ export const init: Module = ({ mainWindow }) => {
                 mainWindow.once('leave-full-screen', () => mainWindow.hide());
                 mainWindow.setFullScreen(false);
             } else {
+                mainWindow.hide();
                 app.hide();
             }
         });


### PR DESCRIPTION
## Description

This changes the way the UI is launched when using autostart. 

Before this change, the Node bridge daemon and the UI would run on 2 separate processes independently, which wastes some memory.

After this change, only 1 process runs. When a start of a second process is attempted, the first process continues to initialize the UI if running in daemon mode. If the UI was already initialized, it will resume. 
Upon closing the app doesn't quit, but hides the UI to keep the node bridge running. 

Core functionality tested on MacOS, Win, Linux, but needs more thorough testing.
I did also test auto update on MacOS and it was working.