### PR TITLE
Chore/fix url type

### DIFF
--- a/packages/suite/src/components/wallet/InputError.tsx
+++ b/packages/suite/src/components/wallet/InputError.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 
 import { Button } from '@trezor/components';
 import { LearnMoreButton } from '../suite/LearnMoreButton';
+import { Url } from '@trezor/urls';
 
 const Wrapper = styled.div`
     display: flex;
@@ -11,7 +12,7 @@ const Wrapper = styled.div`
 `;
 
 interface InputErrorProps {
-    button?: { onClick: MouseEventHandler<HTMLButtonElement>; text: string } | { url: string };
+    button?: { onClick: MouseEventHandler<HTMLButtonElement>; text: string } | { url: Url };
     message?: string;
 }
 

--- a/packages/suite/src/components/wallet/InputError.tsx
+++ b/packages/suite/src/components/wallet/InputError.tsx
@@ -4,17 +4,21 @@ import styled from 'styled-components';
 import { Button } from '@trezor/components';
 import { LearnMoreButton } from '../suite/LearnMoreButton';
 import { Url } from '@trezor/urls';
+import { spacingsPx } from '@trezor/theme';
 
 const Wrapper = styled.div`
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: ${spacingsPx.xs};
 `;
 
-interface InputErrorProps {
-    button?: { onClick: MouseEventHandler<HTMLButtonElement>; text: string } | { url: Url };
+type ButtonProps = { onClick: MouseEventHandler<HTMLButtonElement>; text: string };
+type LinkProps = { url: Url };
+
+export type InputErrorProps = {
+    button?: ButtonProps | LinkProps;
     message?: string;
-}
+};
 
 export const InputError = ({ button, message }: InputErrorProps) => (
     <Wrapper>

--- a/packages/suite/src/constants/suite/experimental.ts
+++ b/packages/suite/src/constants/suite/experimental.ts
@@ -1,5 +1,5 @@
 import { TranslationKey } from '@suite-common/intl-types';
-import { EXPERIMENTAL_PASSWORD_MANAGER_KB_URL, TOR_SNOWFLAKE_KB_URL } from '@trezor/urls';
+import { EXPERIMENTAL_PASSWORD_MANAGER_KB_URL, TOR_SNOWFLAKE_KB_URL, Url } from '@trezor/urls';
 
 export enum ExperimentalFeature {
     BnbSmartChain = 'bnb-smart-chain',
@@ -21,7 +21,7 @@ export const ExperimentalFeatureDescription: FeatureIntlMap = {
     [ExperimentalFeature.TorSnowflake]: 'TR_EXPERIMENTAL_TOR_SNOWFLAKE_DESCRIPTION',
 };
 
-export const ExperimentalFeatureKnowledgeBaseUrl: Partial<Record<ExperimentalFeature, string>> = {
+export const ExperimentalFeatureKnowledgeBaseUrl: Partial<Record<ExperimentalFeature, Url>> = {
     [ExperimentalFeature.PasswordManager]: EXPERIMENTAL_PASSWORD_MANAGER_KB_URL,
     [ExperimentalFeature.TorSnowflake]: TOR_SNOWFLAKE_KB_URL,
 };

--- a/packages/suite/src/utils/suite/__fixtures__/device.ts
+++ b/packages/suite/src/utils/suite/__fixtures__/device.ts
@@ -530,7 +530,7 @@ const getCheckBackupUrl = [
     {
         description: 'Missing device',
         device: undefined,
-        result: '',
+        result: undefined,
     },
     {
         description: 'Device set',
@@ -566,7 +566,7 @@ const getFirmwareDowngradeUrl = [
     {
         description: 'Missing device',
         device: undefined,
-        result: '',
+        result: undefined,
     },
     {
         description: 'Device set',

--- a/packages/suite/src/views/recovery/index.tsx
+++ b/packages/suite/src/views/recovery/index.tsx
@@ -187,7 +187,7 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
                             title={<Translation id="TR_DRY_RUN_CHECK_ITEM_TITLE" />}
                             description={<Translation id="TR_DRY_RUN_CHECK_ITEM_DESCRIPTION" />}
                             isChecked={understood}
-                            link={<LearnMoreButton url={learnMoreUrl} />}
+                            link={learnMoreUrl && <LearnMoreButton url={learnMoreUrl} />}
                             onClick={() => setUnderstood(!understood)}
                         />
                     </>

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Address/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Address/index.tsx
@@ -23,6 +23,7 @@ import { useSendFormContext } from 'src/hooks/wallet';
 import { getProtocolInfo } from 'src/utils/suite/protocol';
 import { PROTOCOL_TO_NETWORK } from 'src/constants/suite/protocol';
 import { InputError } from 'src/components/wallet';
+import { InputErrorProps } from 'src/components/wallet/InputError';
 
 const Container = styled.div`
     position: relative;
@@ -126,10 +127,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
         }
     }, [amountInputName, composeTransaction, dispatch, inputName, setValue, symbol]);
 
-    const getValidationButtonProps = ():
-        | { url: (typeof URLS)[NonNullable<ReturnType<typeof isAddressDeprecated>>] }
-        | { onClick: () => void; text: string }
-        | undefined => {
+    const getValidationButtonProps = (): InputErrorProps['button'] => {
         switch (addressError?.type) {
             case 'deprecated':
                 if (addressDeprecatedUrl) {

--- a/packages/urls/src/github.ts
+++ b/packages/urls/src/github.ts
@@ -1,10 +1,12 @@
 const GITHUB_REPO_INFO = {
     owner: 'trezor',
     repo: 'trezor-suite',
-};
+} as const;
 
-export const GITHUB_REPO_URL = `https://github.com/${GITHUB_REPO_INFO.owner}/${GITHUB_REPO_INFO.repo}`;
-export const GITHUB_API_REPO_URL = `https://api.github.com/repos/${GITHUB_REPO_INFO.owner}/${GITHUB_REPO_INFO.repo}`;
+export const GITHUB_REPO_URL =
+    `https://github.com/${GITHUB_REPO_INFO.owner}/${GITHUB_REPO_INFO.repo}` as const;
+export const GITHUB_API_REPO_URL =
+    `https://api.github.com/repos/${GITHUB_REPO_INFO.owner}/${GITHUB_REPO_INFO.repo}` as const;
 
 export const GITHUB_ROADMAP_URL = 'https://github.com/orgs/trezor/projects/28?fullscreen=true';
 export const GITHUB_FW_COMMIT_URL = 'https://github.com/trezor/trezor-firmware/commit/';

--- a/packages/urls/src/index.ts
+++ b/packages/urls/src/index.ts
@@ -1,9 +1,10 @@
-import type * as Urls from './urls';
-import type * as GithubUrls from './github';
+import * as Urls from './urls';
+import * as GithubUrls from './github';
 
 export * from './urls';
 export * from './github';
 export * from './tor';
 export * from './deeplinks';
 
-export type Url = (typeof Urls)[keyof typeof Urls] | (typeof GithubUrls)[keyof typeof GithubUrls];
+type AllUrls = typeof Urls & typeof GithubUrls;
+export type Url = AllUrls[keyof AllUrls];

--- a/suite-common/suite-utils/src/device.ts
+++ b/suite-common/suite-utils/src/device.ts
@@ -247,7 +247,7 @@ export const getCheckBackupUrl = (device?: TrezorDevice) => {
     const deviceModelInternal = device?.features?.internal_model;
 
     if (!deviceModelInternal) {
-        return '';
+        return undefined;
     }
 
     return URLS[`HELP_CENTER_DRY_RUN_${deviceModelInternal}_URL`];
@@ -267,7 +267,7 @@ export const getFirmwareDowngradeUrl = (device?: TrezorDevice) => {
     const deviceModelInternal = device?.features?.internal_model;
 
     if (!deviceModelInternal) {
-        return '';
+        return undefined;
     }
 
     return URLS[`HELP_CENTER_FW_DOWNGRADE_${deviceModelInternal}_URL`];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Dynamic Urls must be typed `as const`, otherwise the `Url` type changes to `string`.

The tighter type helped me found a bug where an href was set to the URL key instead of value. This can be tested with address `1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa`. on Bitcoin Cash.

## Screenshots
![Screenshot 2024-08-06 at 19 24 36](https://github.com/user-attachments/assets/a54e012f-597f-41c5-802a-2d44f5eabdce)
before:
![Screenshot 2024-08-06 at 19 25 27](https://github.com/user-attachments/assets/1f8c378d-382c-4d1b-ace3-7909c8fd857f)

after:
![Screenshot 2024-08-06 at 19 24 44](https://github.com/user-attachments/assets/636fc765-bf0a-4260-a124-b65ead44228d)
