### PR TITLE
feat(suite): Hide portfolio tooltip when BTC only

### DIFF
--- a/packages/suite/src/views/dashboard/components/PortfolioCard/index.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/index.tsx
@@ -8,7 +8,7 @@ import {
     Translation,
 } from 'src/components/suite';
 import { DashboardSection } from 'src/components/dashboard';
-import { useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
+import { useDevice, useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
 import { useFastAccounts } from 'src/hooks/wallet';
 import { goto } from 'src/actions/suite/routerActions';
 import { setFlag } from 'src/actions/suite/suiteActions';
@@ -20,6 +20,7 @@ import { EmptyWallet } from './components/EmptyWallet';
 import { DashboardGraph } from './components/DashboardGraph';
 import { selectCurrentFiatRates } from '@suite-common/wallet-core';
 import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
+import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 
 const Body = styled.div`
     align-items: center;
@@ -52,6 +53,7 @@ const PortfolioCard = memo(() => {
     const accounts = useFastAccounts();
     const { dashboardGraphHidden } = useSelector(s => s.suite.flags);
     const dispatch = useDispatch();
+    const { device } = useDevice();
 
     const isDeviceEmpty = useMemo(() => accounts.every(a => a.empty), [accounts]);
     const fiatAmount = getTotalFiatBalance(accounts, localCurrency, currentFiatRates).toString();
@@ -88,6 +90,7 @@ const PortfolioCard = memo(() => {
 
     const showMissingDataTooltip =
         showGraphControls &&
+        !hasBitcoinOnlyFirmware(device) &&
         !!accounts.some(
             account =>
                 account.history &&


### PR DESCRIPTION
## Description

Add having universal firmware as one of the conditions for displaying the Portfolio tooltip.

## Related Issue

Resolve #11615

## Screenshots:

When all other conditions to display tooltip are met, and:

is universal firmware:
![image](https://github.com/user-attachments/assets/907f8c9c-410b-4dad-91ad-70b24e0d318f)
is BTC-only firmware:
![image](https://github.com/user-attachments/assets/70c860fd-4629-4cb6-bd07-3fb58d52b0a5)