### PR TITLE
test(suite-desktop): improve assertion granularity (select input)

### DIFF
--- a/.github/workflows/test-suite-web-e2e.yml
+++ b/.github/workflows/test-suite-web-e2e.yml
@@ -13,6 +13,7 @@ on:
     paths-ignore:
       - "suite-native/**"
       - "packages/connect*/**"
+      - "packages/suite-desktop*/**"
       - "packages/react-native-usb/**"
       # ignore unrelated github workflows config files
       - ".github/workflows/connect*"

--- a/packages/suite-desktop-core/e2e/support/pageActions/suiteGuideActions.ts
+++ b/packages/suite-desktop-core/e2e/support/pageActions/suiteGuideActions.ts
@@ -19,13 +19,17 @@ class SuiteGuide {
     }
 
     async selectLocationInApp(window: Page, desiredLocation: string) {
-        const suggestionDropdown = await window.getByTestId('@guide/feedback/suggestion-dropdown');
+        const suggestionDropdown = window.getByTestId('@guide/feedback/suggestion-dropdown');
         await suggestionDropdown.waitFor({ state: 'visible' });
         await suggestionDropdown.click();
-        await clickDataTest(
+        clickDataTest(
             window,
             `@guide/feedback/suggestion-dropdown/select/option/${desiredLocation.toLowerCase()}`,
         );
+        // assert that select value was changed correctly.
+        expectPlaywright(
+            window.locator('[data-test="@guide/feedback/suggestion-dropdown/select/input"]'),
+        ).toHaveText(desiredLocation);
     }
 
     async fillInSuggestionForm(window: Page, reportText: string) {


### PR DESCRIPTION
suite-desktop tests are extremely [flaky again.](https://github.com/trezor/trezor-suite/actions/workflows/test-suite-desktop-nightly.yml?query=branch%3Adevelop). 

in 4b450a0cc47be96a932dea1233ab9d2e6f56f9a9 I am just improving assertion in the critical spot so that it is apparent just from the log output what is wrong there.

<img width="1179" alt="image" src="https://github.com/user-attachments/assets/14762d2a-f3c3-45ad-8bbf-d3802d393919">

the problem is that after selecting an option in the Select component dropdown something wrong happens which only makes the dropdown disappear and no value is selected. cc @jvaclavik could it be somewhere in the component itself?

this problem is not limit only to suite-desktop tests, in suite-web cypress tests I have experienced it as well. 

cc @komret @andrcj 