### PR TITLE
feat(suite-native): account purge and discovery on coin enabling

### DIFF
--- a/suite-native/coin-enabling/src/components/DiscoveryCoinsFilter.tsx
+++ b/suite-native/coin-enabling/src/components/DiscoveryCoinsFilter.tsx
@@ -1,4 +1,5 @@
 import { useDispatch } from 'react-redux';
+import { useEffect } from 'react';
 
 import { VStack, Text, HStack, Switch, Card } from '@suite-native/atoms';
 import { NetworkSymbol } from '@suite-common/wallet-config';
@@ -9,7 +10,12 @@ import { useCoinEnabling } from '../hooks/useCoinEnabling';
 export const DiscoveryCoinsFilter = () => {
     const dispatch = useDispatch();
 
-    const { enabledNetworkSymbols, availableNetworks } = useCoinEnabling();
+    const { enabledNetworkSymbols, availableNetworks, applyDiscoveryChanges } = useCoinEnabling();
+
+    useEffect(() => {
+        // This will run when the component is unmounted (leaving the screen) and trigger the applyDiscoveryChanges function
+        return () => applyDiscoveryChanges();
+    }, [applyDiscoveryChanges]);
 
     const uniqueNetworkSymbols = [...new Set(availableNetworks.map(n => n.symbol))];
 

--- a/suite-native/coin-enabling/src/hooks/useCoinEnabling.tsx
+++ b/suite-native/coin-enabling/src/hooks/useCoinEnabling.tsx
@@ -1,28 +1,27 @@
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
+import { useCallback } from 'react';
 
-import { FeatureFlag, FeatureFlagsRootState, useFeatureFlag } from '@suite-native/feature-flags';
+import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
 import {
-    selectAreTestnetsEnabled,
     selectEnabledDiscoveryNetworkSymbols,
     selectDiscoverySupportedNetworks,
-    DiscoveryConfigSliceRootState,
+    discoveryCheckThunk,
 } from '@suite-native/discovery';
-import { DeviceRootState } from '@suite-common/wallet-core';
+import { disableAccountsThunk } from '@suite-common/wallet-core';
 
 export const useCoinEnabling = () => {
     const [isCoinEnablingActive] = useFeatureFlag(FeatureFlag.IsCoinEnablingActive);
-    const areTestnetsEnabled = useSelector(selectAreTestnetsEnabled);
-    const availableNetworks = useSelector((state: DeviceRootState) =>
-        selectDiscoverySupportedNetworks(state, areTestnetsEnabled),
-    );
-    const enabledNetworkSymbols = useSelector(
-        (state: DiscoveryConfigSliceRootState & DeviceRootState & FeatureFlagsRootState) =>
-            selectEnabledDiscoveryNetworkSymbols(state, areTestnetsEnabled),
-    );
+    const dispatch = useDispatch();
 
-    const applyDiscoveryChanges = () => {
-        // TODO: remove disabled network accounts and run discovery check
-    };
+    const availableNetworks = useSelector(selectDiscoverySupportedNetworks);
+    const enabledNetworkSymbols = useSelector(selectEnabledDiscoveryNetworkSymbols);
+
+    const applyDiscoveryChanges = useCallback(() => {
+        // remove disabled networks accounts
+        dispatch(disableAccountsThunk());
+        // check whether to start discovery and start if needed
+        dispatch(discoveryCheckThunk());
+    }, [dispatch]);
 
     return {
         isCoinEnablingActive,

--- a/suite-native/discovery/src/discoveryMiddleware.ts
+++ b/suite-native/discovery/src/discoveryMiddleware.ts
@@ -35,7 +35,7 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
         ) {
             dispatch(
                 startDescriptorPreloadedDiscoveryThunk({
-                    areTestnetsEnabled: true,
+                    forcedAreTestnetsEnabled: areTestnetsEnabled,
                 }),
             );
         }
@@ -48,7 +48,6 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
         if (authorizeDeviceThunk.fulfilled.match(action) && isDeviceFirmwareVersionSupported) {
             dispatch(
                 startDescriptorPreloadedDiscoveryThunk({
-                    areTestnetsEnabled,
                     forcedDeviceState: action.payload.state,
                 }),
             );

--- a/suite-native/discovery/src/discoverySelectors.ts
+++ b/suite-native/discovery/src/discoverySelectors.ts
@@ -31,7 +31,6 @@ import { FeatureFlagsRootState } from '@suite-native/feature-flags';
 
 import {
     DiscoveryConfigSliceRootState,
-    selectAreTestnetsEnabled,
     selectDiscoverySupportedNetworks,
     selectEnabledDiscoveryNetworkSymbols,
 } from './discoveryConfigSlice';
@@ -75,11 +74,14 @@ export const selectNetworksWithUnfinishedDiscovery = (
         AccountsRootState &
         FeatureFlagsRootState &
         DiscoveryConfigSliceRootState,
-    areTestnetsEnabled: boolean,
+    forcedAreTestnetsEnabled?: boolean,
 ) => {
-    const enabledNetworkSymbols = selectEnabledDiscoveryNetworkSymbols(state, areTestnetsEnabled);
+    const enabledNetworkSymbols = selectEnabledDiscoveryNetworkSymbols(
+        state,
+        forcedAreTestnetsEnabled,
+    );
     const accounts = selectDeviceAccounts(state);
-    const supportedNetworks = selectDiscoverySupportedNetworks(state, areTestnetsEnabled);
+    const supportedNetworks = selectDiscoverySupportedNetworks(state, forcedAreTestnetsEnabled);
 
     const enabledNetworks = supportedNetworks.filter(n => enabledNetworkSymbols.includes(n.symbol));
 
@@ -99,11 +101,7 @@ export const selectShouldRunDiscoveryForDevice = (
         return false;
     }
 
-    const areTestnetsEnabled = selectAreTestnetsEnabled(state);
-    const networksWithUnfinishedDiscovery = selectNetworksWithUnfinishedDiscovery(
-        state,
-        areTestnetsEnabled,
-    );
+    const networksWithUnfinishedDiscovery = selectNetworksWithUnfinishedDiscovery(state);
 
     return networksWithUnfinishedDiscovery.length > 0;
 };

--- a/suite-native/discovery/src/discoveryThunks.ts
+++ b/suite-native/discovery/src/discoveryThunks.ts
@@ -26,11 +26,7 @@ import { DiscoveryStatus } from '@suite-common/wallet-constants';
 import { requestDeviceAccess } from '@suite-native/device-mutex';
 import { analytics, EventType } from '@suite-native/analytics';
 
-import {
-    selectAreTestnetsEnabled,
-    selectDiscoveryInfo,
-    setDiscoveryInfo,
-} from './discoveryConfigSlice';
+import { selectDiscoveryInfo, setDiscoveryInfo } from './discoveryConfigSlice';
 import {
     selectCanRunDiscoveryForDevice,
     selectDiscoveryAccountsAnalytics,
@@ -575,9 +571,9 @@ export const startDescriptorPreloadedDiscoveryThunk = createThunk(
     `${DISCOVERY_MODULE_PREFIX}/startDescriptorPreloadedDiscoveryThunk`,
     async (
         {
-            areTestnetsEnabled,
+            forcedAreTestnetsEnabled,
             forcedDeviceState, // device state can be pushed from outside (e.g. in middleware when fetched from action)
-        }: { areTestnetsEnabled: boolean; forcedDeviceState?: string },
+        }: { forcedAreTestnetsEnabled?: boolean; forcedDeviceState?: string },
         { dispatch, getState },
     ) => {
         const deviceState = forcedDeviceState ?? selectDeviceState(getState());
@@ -609,7 +605,7 @@ export const startDescriptorPreloadedDiscoveryThunk = createThunk(
 
         const networksWithUnfinishedDiscovery = selectNetworksWithUnfinishedDiscovery(
             getState(),
-            areTestnetsEnabled,
+            forcedAreTestnetsEnabled,
         );
 
         // Start tracking duration and networks for analytics purposes
@@ -649,8 +645,6 @@ export const discoveryCheckThunk = createThunk(
         { dispatch, getState },
         // eslint-disable-next-line require-await
     ) => {
-        const areTestnetsEnabled = selectAreTestnetsEnabled(getState());
-
         // check whether we consider some network not to be fully discovered
         const shouldRunDiscoveryForDevice = selectShouldRunDiscoveryForDevice(getState());
 
@@ -658,11 +652,7 @@ export const discoveryCheckThunk = createThunk(
         const canRunDiscoveryForDevice = selectCanRunDiscoveryForDevice(getState());
 
         if (canRunDiscoveryForDevice && shouldRunDiscoveryForDevice) {
-            dispatch(
-                startDescriptorPreloadedDiscoveryThunk({
-                    areTestnetsEnabled,
-                }),
-            );
+            dispatch(startDescriptorPreloadedDiscoveryThunk({}));
         }
     },
 );

--- a/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
+++ b/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
@@ -19,7 +19,6 @@ import {
 import { useAlert } from '@suite-native/alerts';
 import {
     addAndDiscoverNetworkAccountThunk,
-    selectAreTestnetsEnabled,
     selectDiscoverySupportedNetworks,
     NORMAL_ACCOUNT_TYPE,
 } from '@suite-native/discovery';
@@ -72,10 +71,8 @@ export const useAddCoinAccount = () => {
     const dispatch = useDispatch();
     const { translate } = useTranslate();
     const openLink = useOpenLink();
-    const areTestnetsEnabled = useSelector(selectAreTestnetsEnabled);
-    const supportedNetworks = useSelector((state: DeviceRootState) =>
-        selectDiscoverySupportedNetworks(state, areTestnetsEnabled),
-    );
+
+    const supportedNetworks = useSelector(selectDiscoverySupportedNetworks);
     const deviceAccounts = useSelector((state: AccountsRootState & DeviceRootState) =>
         selectDeviceAccounts(state),
     );

--- a/suite-native/state/package.json
+++ b/suite-native/state/package.json
@@ -22,7 +22,6 @@
         "@suite-common/token-definitions": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-native/blockchain": "workspace:*",
-        "@suite-native/config": "workspace:*",
         "@suite-native/device": "workspace:*",
         "@suite-native/device-authorization": "workspace:*",
         "@suite-native/discovery": "workspace:*",

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -4,12 +4,12 @@ import * as Device from 'expo-device';
 
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import { extraDependenciesMock } from '@suite-common/test-utils';
-import { discoverySupportedNetworks } from '@suite-native/config';
 import { selectDevices } from '@suite-common/wallet-core';
 import { selectFiatCurrencyCode, setFiatCurrency } from '@suite-native/settings';
 import { PROTO } from '@trezor/connect';
 import { mergeDeepObject } from '@trezor/utils';
 import { NativeUsbTransport } from '@trezor/transport-native';
+import { selectEnabledDiscoveryNetworkSymbols } from '@suite-native/discovery';
 
 const deviceType = Device.isDevice ? 'device' : 'emulator';
 
@@ -25,7 +25,7 @@ const transports = transportsPerDeviceType[deviceType];
 
 export const extraDependencies: ExtraDependencies = mergeDeepObject(extraDependenciesMock, {
     selectors: {
-        selectEnabledNetworks: () => discoverySupportedNetworks,
+        selectEnabledNetworks: selectEnabledDiscoveryNetworkSymbols,
         selectBitcoinAmountUnit: () => PROTO.AmountUnit.BITCOIN,
         selectLocalCurrency: selectFiatCurrencyCode,
         selectDevices,

--- a/suite-native/state/tsconfig.json
+++ b/suite-native/state/tsconfig.json
@@ -25,7 +25,6 @@
             "path": "../../suite-common/wallet-core"
         },
         { "path": "../blockchain" },
-        { "path": "../config" },
         { "path": "../device" },
         { "path": "../device-authorization" },
         { "path": "../discovery" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10092,7 +10092,6 @@ __metadata:
     "@suite-common/token-definitions": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-native/blockchain": "workspace:*"
-    "@suite-native/config": "workspace:*"
     "@suite-native/device": "workspace:*"
     "@suite-native/device-authorization": "workspace:*"
     "@suite-native/discovery": "workspace:*"


### PR DESCRIPTION
- [x] When leaving Coin enabling screen in settings, run discovery for enabled networks
- [x] disabled coin accounts are removed from current and view only devices at the same moment

## Related Issue

Resolve #13547

## Screenshots:
https://github.com/user-attachments/assets/2edbd194-e26a-4b27-826d-a662769d658c

