### PR TITLE
test(suite): Unify data-testid attrs for E2E

### DIFF
--- a/packages/components/src/components/CollapsibleBox/CollapsibleBox.tsx
+++ b/packages/components/src/components/CollapsibleBox/CollapsibleBox.tsx
@@ -67,7 +67,7 @@ type CollapsibleBoxCommon = AllowedFrameProps & {
     isIconFlipped?: boolean; // Open upwards, affects the icon rotation
     hasDivider?: boolean;
     onAnimationComplete?: (isOpen: boolean) => void;
-    'data-test'?: string;
+    'data-testid'?: string;
     /** @deprecated */
     className?: string;
 };
@@ -208,7 +208,7 @@ const CollapsibleBoxContent = ({
     margin,
     className,
     onAnimationComplete,
-    'data-test': dataTest,
+    'data-testid': dataTest,
 }: CollapsibleBoxContentProps) => {
     const { elevation } = useElevation();
 
@@ -240,7 +240,7 @@ const CollapsibleBoxContent = ({
                         }}
                         name="caretCircleDown"
                         size="medium"
-                        dataTest={`@collapsible-box/icon-${isOpen ? 'expanded' : 'collapsed'}`}
+                        data-testid={`@collapsible-box/icon-${isOpen ? 'expanded' : 'collapsed'}`}
                     />
                 </IconWrapper>
             </Header>
@@ -257,7 +257,7 @@ const CollapsibleBoxContent = ({
                         ease: isOpen ? motionEasing.exit : motionEasing.enter,
                     },
                 }}
-                data-test="@collapsible-box/body"
+                data-testid="@collapsible-box/body"
             >
                 <Content
                     $elevation={elevation}
@@ -273,7 +273,7 @@ const CollapsibleBoxContent = ({
 
     const containerProps = {
         $margin: margin,
-        'data-test': dataTest,
+        'data-testid': dataTest,
         className,
     };
 

--- a/packages/components/src/components/ConfirmOnDevice/ConfirmOnDevice.tsx
+++ b/packages/components/src/components/ConfirmOnDevice/ConfirmOnDevice.tsx
@@ -68,7 +68,7 @@ export interface ConfirmOnDeviceProps {
 export const ConfirmOnDevice = ({ isConfirmed, ...rest }: ConfirmOnDeviceProps) => (
     <Wrapper
         $animation={isConfirmed ? AnimationDirection.Down : AnimationDirection.Up}
-        data-test="@prompts/confirm-on-device"
+        data-testid="@prompts/confirm-on-device"
     >
         <ElevationUp>
             <ConfirmOnDeviceContent {...rest} />

--- a/packages/components/src/components/ConfirmOnDevice/ConfirmOnDeviceContent.tsx
+++ b/packages/components/src/components/ConfirmOnDevice/ConfirmOnDeviceContent.tsx
@@ -138,7 +138,9 @@ export const ConfirmOnDeviceContent = ({
                 <Title>{title}</Title>
 
                 {successText && hasSteps && activeStep > steps && (
-                    <Success data-test="@prompts/confirm-on-device/success">{successText}</Success>
+                    <Success data-testid="@prompts/confirm-on-device/success">
+                        {successText}
+                    </Success>
                 )}
 
                 {hasSteps && activeStep <= steps && (
@@ -147,7 +149,7 @@ export const ConfirmOnDeviceContent = ({
                             <Step
                                 key={step}
                                 $isActive={isStepActive(index, activeStep)}
-                                data-test={`@prompts/confirm-on-device/step/${index}${
+                                data-testid={`@prompts/confirm-on-device/step/${index}${
                                     isStepActive(index, activeStep) ? '/active' : ''
                                 }`}
                             />
@@ -162,7 +164,7 @@ export const ConfirmOnDeviceContent = ({
                         <Close
                             $elevation={elevation}
                             onClick={onCancel}
-                            data-test="@confirm-on-device/close-button"
+                            data-testid="@confirm-on-device/close-button"
                         >
                             <Icon icon="CROSS" size={16} color={theme.textOnTertiary} />
                         </Close>

--- a/packages/components/src/components/DataAnalytics.tsx
+++ b/packages/components/src/components/DataAnalytics.tsx
@@ -127,7 +127,7 @@ export const DataAnalytics = ({
     const [trackingEnabled, setTrackingEnabled] = useState<boolean>(isInitialTrackingEnabled);
 
     return (
-        <StyledCard data-test="@analytics/consent" className={className}>
+        <StyledCard data-testid="@analytics/consent" className={className}>
             <Wrapper>
                 <ContentWrapper>
                     <Heading>
@@ -171,7 +171,7 @@ export const DataAnalytics = ({
                         <Switch
                             isChecked={trackingEnabled}
                             onChange={() => setTrackingEnabled(!trackingEnabled)}
-                            dataTest="@analytics/toggle-switch"
+                            data-testid="@analytics/toggle-switch"
                         />
                         <Label>
                             <FormattedMessage
@@ -184,7 +184,7 @@ export const DataAnalytics = ({
 
                 <ButtonWrapper>
                     <StyledButton
-                        data-test="@analytics/continue-button"
+                        data-testid="@analytics/continue-button"
                         onClick={() => onConfirm(trackingEnabled)}
                     >
                         <FormattedMessage id="TR_CONFIRM" defaultMessage="Confirm" />

--- a/packages/components/src/components/Dropdown/Dropdown.tsx
+++ b/packages/components/src/components/Dropdown/Dropdown.tsx
@@ -75,7 +75,7 @@ export type DropdownProps = Omit<MenuProps, 'setToggled'> & {
     renderOnClickPosition?: boolean;
     onToggle?: (isToggled: boolean) => void;
     className?: string;
-    'data-test'?: string;
+    'data-testid'?: string;
     children?: ((isToggled: boolean) => ReactElement<any>) | ReactElement<any>;
 };
 
@@ -100,7 +100,7 @@ export const Dropdown = forwardRef(
             onToggle,
             className,
             children,
-            'data-test': dataTest,
+            'data-testid': dataTest,
         }: DropdownProps,
         ref,
     ) => {
@@ -208,7 +208,7 @@ export const Dropdown = forwardRef(
                 onClick={e => e.stopPropagation()}
                 $isToggled={isToggled}
                 isDisabled={isDisabled}
-                data-test={dataTest}
+                data-testid={dataTest}
             />
         );
 

--- a/packages/components/src/components/Dropdown/Menu.tsx
+++ b/packages/components/src/components/Dropdown/Menu.tsx
@@ -159,7 +159,7 @@ export type DropdownMenuItemProps = {
     isDisabled?: boolean;
     isHidden?: boolean;
     separatorBefore?: boolean;
-    'data-test'?: string;
+    'data-testid'?: string;
 };
 
 type MenuItemComponentProps = DropdownMenuItemProps & {
@@ -178,7 +178,7 @@ const MenuItem = ({
     setToggled,
     isKeyboardSelected,
     onMouseOver,
-    'data-test': dataTest,
+    'data-testid': dataTest,
     separatorBefore,
 }: MenuItemComponentProps) => {
     const { elevation } = useElevation();
@@ -203,7 +203,7 @@ const MenuItem = ({
             $isFocused={isKeyboardSelected}
             onMouseOver={onMouseOver}
             $separatorBefore={separatorBefore}
-            data-test={dataTest}
+            data-testid={dataTest}
         >
             {icon && <Icon icon={icon} size={spacings.md} />}
             <span>{label}</span>

--- a/packages/components/src/components/Passphrase/EnterOnTrezorButton.tsx
+++ b/packages/components/src/components/Passphrase/EnterOnTrezorButton.tsx
@@ -25,7 +25,7 @@ export const EnterOnTrezorButton = ({ submit, value, deviceModel }: EnterOnTrezo
         <Card
             paddingType="small"
             onClick={() => submit(value, true)}
-            data-test="@passphrase/enter-on-device-button"
+            data-testid="@passphrase/enter-on-device-button"
         >
             <Row gap={spacings.lg} alignItems="center" justifyContent="space-between">
                 {deviceModel && <Image alt="Trezor" image={`TREZOR_${deviceModel}`} height={34} />}

--- a/packages/components/src/components/Passphrase/PassphraseTypeCard.tsx
+++ b/packages/components/src/components/Passphrase/PassphraseTypeCard.tsx
@@ -125,7 +125,7 @@ export const PassphraseTypeCard = (props: PassphraseTypeCardProps) => {
                     setHiddenWalletTouched(true);
                 }
             }}
-            data-test={`@passphrase-type/${type}`}
+            data-testid={`@passphrase-type/${type}`}
         >
             <Item>
                 {!singleColModal && (

--- a/packages/components/src/components/Passphrase/PassphraseTypeCardContent.tsx
+++ b/packages/components/src/components/Passphrase/PassphraseTypeCardContent.tsx
@@ -134,7 +134,7 @@ export const PassphraseTypeCardContent = ({
                             {/* Show passphrase input */}
                             <Description>
                                 <PassphraseInput
-                                    data-test="@passphrase/input"
+                                    data-testid="@passphrase/input"
                                     placeholder={intl.formatMessage({
                                         defaultMessage: 'Enter passphrase',
                                         id: 'TR_ENTER_PASSPHRASE',
@@ -169,7 +169,7 @@ export const PassphraseTypeCardContent = ({
                                                 }
                                                 setShowPassword(!showPassword);
                                             }}
-                                            data-test="@passphrase/show-toggle"
+                                            data-testid="@passphrase/show-toggle"
                                         />
                                     }
                                 />
@@ -189,7 +189,7 @@ export const PassphraseTypeCardContent = ({
                             {(singleColModal || hiddenWalletTouched) && (
                                 <motion.div {...motionConfig.motionAnimation.expand}>
                                     <ActionButton
-                                        data-test={`@passphrase/${
+                                        data-testid={`@passphrase/${
                                             type === 'hidden' ? 'hidden' : 'standard'
                                         }/submit-button`}
                                         isDisabled={isPassphraseEmpty || isPassphraseTooLong}

--- a/packages/components/src/components/Passphrase/PassphraseTypeCardHeading.tsx
+++ b/packages/components/src/components/Passphrase/PassphraseTypeCardHeading.tsx
@@ -69,7 +69,7 @@ export const PassphraseTypeCardHeading = ({
             <Column justifyContent="center" flex="1">
                 <WalletTitle
                     $withMargin={type === 'hidden'}
-                    data-test={type === 'hidden' && '@tooltip/passphrase-tooltip'}
+                    data-testid={type === 'hidden' && '@tooltip/passphrase-tooltip'}
                 >
                     {type === 'hidden' ? (
                         <Tooltip

--- a/packages/components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.tsx
@@ -105,7 +105,7 @@ export const Tooltip = ({
                 </TooltipTrigger>
 
                 <TooltipContent
-                    data-test="@tooltip"
+                    data-testid="@tooltip"
                     style={{ zIndex }}
                     arrowRender={hasArrow ? TooltipArrow : undefined}
                     appendTo={appendTo}

--- a/packages/components/src/components/Warning/Warning.tsx
+++ b/packages/components/src/components/Warning/Warning.tsx
@@ -29,7 +29,7 @@ export type WarningProps = AllowedFrameProps & {
     withIcon?: boolean;
     icon?: IconType;
     filled?: boolean;
-    dataTest?: string;
+    'data-testid'?: string;
 };
 
 type WrapperParams = TransientProps<AllowedFrameProps> & {
@@ -74,7 +74,7 @@ export const Warning = ({
     filled = true,
     margin,
     rightContent,
-    dataTest,
+    'data-testid': dataTest,
 }: WarningProps) => {
     const theme = useTheme();
     const { elevation } = useElevation();
@@ -87,7 +87,7 @@ export const Warning = ({
             $elevation={elevation}
             $filled={filled}
             $margin={margin}
-            data-test={dataTest}
+            data-testid={dataTest}
         >
             {withIcon && (
                 <Icon

--- a/packages/components/src/components/assets/CoinLogo/coinLogos.stories.tsx
+++ b/packages/components/src/components/assets/CoinLogo/coinLogos.stories.tsx
@@ -35,7 +35,7 @@ export const All: StoryObj = {
                 {variables.COINS.map((coin: CoinType) => (
                     <Icon key={coin}>
                         <CoinName>{coin}</CoinName>
-                        <CoinLogo symbol={coin} data-test={`coin-${coin}`} size={64} />
+                        <CoinLogo symbol={coin} data-testid={`coin-${coin}`} size={64} />
                     </Icon>
                 ))}
             </WrapperIcons>

--- a/packages/components/src/components/assets/Flag/flags.stories.tsx
+++ b/packages/components/src/components/assets/Flag/flags.stories.tsx
@@ -47,7 +47,7 @@ export const All: StoryFn = () => {
                     <Text>{country}</Text>
                     <Flag
                         country={country}
-                        data-test={`icon-${country.toLowerCase().replace('_', '-')}`}
+                        data-testid={`icon-${country.toLowerCase().replace('_', '-')}`}
                     />
                 </FlagWrapper>
             ))}

--- a/packages/components/src/components/assets/Icon/Icon.tsx
+++ b/packages/components/src/components/assets/Icon/Icon.tsx
@@ -99,7 +99,7 @@ export type IconProps = SVGAttributes<HTMLDivElement> & {
     size?: number;
     hoverColor?: string;
     useCursorPointer?: boolean;
-    'data-test'?: string;
+    'data-testid'?: string;
 } & ExclusiveColorOrVariant;
 
 export const Icon = forwardRef(
@@ -115,7 +115,7 @@ export const Icon = forwardRef(
             onClick,
             onMouseEnter,
             onMouseLeave,
-            'data-test': dataTest,
+            'data-testid': dataTest,
         }: IconProps,
         ref?: Ref<HTMLDivElement>,
     ) => (
@@ -129,7 +129,7 @@ export const Icon = forwardRef(
             ref={ref}
             $useCursorPointer={onClick !== undefined || useCursorPointer}
             {...(variant !== undefined ? { $variant: variant } : { $color: color })}
-            data-test={dataTest}
+            data-testid={dataTest}
         >
             <ReactSVG
                 src={ICONS[icon]}

--- a/packages/components/src/components/assets/Icon/icons.stories.tsx
+++ b/packages/components/src/components/assets/Icon/icons.stories.tsx
@@ -36,7 +36,7 @@ export const All = () => (
         {variables.ICONS.map((icon: IconType) => (
             <IconWrapper key={icon}>
                 <IconText>{icon}</IconText>
-                <Icon icon={icon} data-test={`icon-${icon.toLowerCase().replace('_', '-')}`} />
+                <Icon icon={icon} data-testid={`icon-${icon.toLowerCase().replace('_', '-')}`} />
             </IconWrapper>
         ))}
     </Wrapper>

--- a/packages/components/src/components/assets/TrezorLogo/TrezorLogo.tsx
+++ b/packages/components/src/components/assets/TrezorLogo/TrezorLogo.tsx
@@ -22,7 +22,7 @@ export interface TrezorLogoProps {
     type: TrezorLogoType;
     width?: string | number;
     height?: string | number;
-    'data-test'?: string;
+    'data-testid'?: string;
 }
 
 const Loading = () => <span className="loading" />;

--- a/packages/components/src/components/assets/TrezorLogo/trezorLogos.stories.tsx
+++ b/packages/components/src/components/assets/TrezorLogo/trezorLogos.stories.tsx
@@ -27,20 +27,24 @@ export const All: StoryObj = {
                 <TrezorLogo
                     type="horizontal"
                     width="200px"
-                    data-test="trezor-logo-horizontal-black"
+                    data-testid="trezor-logo-horizontal-black"
                 />
-                <TrezorLogo type="vertical" width="120px" data-test="trezor-logo-vertical-black" />
-                <TrezorLogo type="symbol" width="50px" data-test="trezor-logo-symbol-black" />
-                <TrezorLogo type="suite" width="200px" data-test="trezor-suite-logo-black" />
+                <TrezorLogo
+                    type="vertical"
+                    width="120px"
+                    data-testid="trezor-logo-vertical-black"
+                />
+                <TrezorLogo type="symbol" width="50px" data-testid="trezor-logo-symbol-black" />
+                <TrezorLogo type="suite" width="200px" data-testid="trezor-suite-logo-black" />
                 <TrezorLogo
                     type="suite_square"
                     width="50px"
-                    data-test="trezor-suite-square-logo-white"
+                    data-testid="trezor-suite-square-logo-white"
                 />
                 <TrezorLogo
                     type="suite_compact"
                     width="200px"
-                    data-test="trezor-suite-compact-logo-white"
+                    data-testid="trezor-suite-compact-logo-white"
                 />
             </LogoWrapper>
         </StoryColumn>

--- a/packages/components/src/components/buttons/Button/Button.tsx
+++ b/packages/components/src/components/buttons/Button/Button.tsx
@@ -99,7 +99,7 @@ export type ButtonProps = SelectedHTMLButtonProps &
         children: React.ReactNode;
         title?: string;
         className?: string;
-        'data-test'?: string;
+        'data-testid'?: string;
     };
 
 export const Button = ({
@@ -131,7 +131,9 @@ export const Button = ({
         />
     ) : null;
 
-    const Loader = <Spinner size={getIconSize(size)} dataTest={`${rest['data-test']}/spinner`} />;
+    const Loader = (
+        <Spinner size={getIconSize(size)} data-testid={`${rest['data-testid']}/spinner`} />
+    );
 
     return (
         <ButtonContainer

--- a/packages/components/src/components/buttons/Button/buttons.stories.tsx
+++ b/packages/components/src/components/buttons/Button/buttons.stories.tsx
@@ -24,7 +24,7 @@ export const All: StoryFn = () => (
             <StoryColumn key={variant} minWidth={350} maxWidth={420}>
                 <Button
                     variant={variant}
-                    data-test={`button-${variant}`}
+                    data-testid={`button-${variant}`}
                     onClick={() => {
                         console.log('click');
                     }}
@@ -34,7 +34,7 @@ export const All: StoryFn = () => (
                 <Button
                     variant={variant}
                     size="medium"
-                    data-test={`button-${variant}`}
+                    data-testid={`button-${variant}`}
                     onClick={() => {
                         console.log('click');
                     }}
@@ -44,7 +44,7 @@ export const All: StoryFn = () => (
                 <Button
                     variant={variant}
                     size="small"
-                    data-test={`button-${variant}`}
+                    data-testid={`button-${variant}`}
                     onClick={() => {
                         console.log('click');
                     }}
@@ -54,7 +54,7 @@ export const All: StoryFn = () => (
 
                 <Button
                     variant={variant}
-                    data-test={`button-${variant}-icon`}
+                    data-testid={`button-${variant}-icon`}
                     icon="PALETTE"
                     onClick={() => {
                         console.log('click');
@@ -64,22 +64,22 @@ export const All: StoryFn = () => (
                 </Button>
                 <Button
                     variant={variant}
-                    data-test={`button-${variant}-icon-right`}
+                    data-testid={`button-${variant}-icon-right`}
                     iconAlignment="right"
                     icon="PLUS"
                 >
                     {capitalizeFirstLetter(variant)} icon right
                 </Button>
-                <Button variant={variant} data-test={`button-${variant}-loading`} isLoading>
+                <Button variant={variant} data-testid={`button-${variant}-loading`} isLoading>
                     {capitalizeFirstLetter(variant)} loading
                 </Button>
-                <Button variant={variant} data-test={`button-${variant}-full-width`} isFullWidth>
+                <Button variant={variant} data-testid={`button-${variant}-full-width`} isFullWidth>
                     {capitalizeFirstLetter(variant)} full width
                 </Button>
                 <Button
                     variant={variant}
                     isDisabled
-                    data-test={`button-${variant}-disabled`}
+                    data-testid={`button-${variant}-disabled`}
                     onClick={() => {
                         console.log('click');
                     }}

--- a/packages/components/src/components/buttons/IconButton/IconButtons.stories.tsx
+++ b/packages/components/src/components/buttons/IconButton/IconButtons.stories.tsx
@@ -19,7 +19,7 @@ export const IconButtons: StoryObj = {
                     <IconButton
                         icon="PALETTE"
                         variant={variant}
-                        data-test={`button-${variant}`}
+                        data-testid={`button-${variant}`}
                         onClick={() => {
                             console.log('click');
                         }}
@@ -28,7 +28,7 @@ export const IconButtons: StoryObj = {
                         icon="PALETTE"
                         variant={variant}
                         size="medium"
-                        data-test={`button-${variant}`}
+                        data-testid={`button-${variant}`}
                         onClick={() => {
                             console.log('click');
                         }}
@@ -38,7 +38,7 @@ export const IconButtons: StoryObj = {
                         icon="PALETTE"
                         variant={variant}
                         size="small"
-                        data-test={`button-${variant}`}
+                        data-testid={`button-${variant}`}
                         onClick={() => {
                             console.log('click');
                         }}
@@ -46,7 +46,7 @@ export const IconButtons: StoryObj = {
 
                     <IconButton
                         variant={variant}
-                        data-test={`button-${variant}-icon`}
+                        data-testid={`button-${variant}-icon`}
                         icon="PALETTE"
                         label={<span>Label</span>}
                         onClick={() => {
@@ -57,7 +57,7 @@ export const IconButtons: StoryObj = {
                     <IconButton
                         icon="PALETTE"
                         variant={variant}
-                        data-test={`button-${variant}-loading`}
+                        data-testid={`button-${variant}-loading`}
                         isLoading
                     />
 
@@ -65,7 +65,7 @@ export const IconButtons: StoryObj = {
                         icon="PALETTE"
                         variant={variant}
                         isDisabled
-                        data-test={`button-${variant}-disabled`}
+                        data-testid={`button-${variant}-disabled`}
                         onClick={() => {
                             console.log('click');
                         }}
@@ -75,7 +75,7 @@ export const IconButtons: StoryObj = {
                         bottomLabel={<span>Bottom Label</span>}
                         variant={variant}
                         isDisabled
-                        data-test={`button-${variant}-disabled`}
+                        data-testid={`button-${variant}-disabled`}
                         onClick={() => {
                             console.log('click');
                         }}

--- a/packages/components/src/components/buttons/TextButton/TextButtons.stories.tsx
+++ b/packages/components/src/components/buttons/TextButton/TextButtons.stories.tsx
@@ -12,7 +12,7 @@ export const All: StoryFn = () => (
     <>
         <StoryColumn minWidth={350} maxWidth={420}>
             <TextButton
-                data-test="text-button"
+                data-testid="text-button"
                 onClick={() => {
                     console.log('click');
                 }}
@@ -21,7 +21,7 @@ export const All: StoryFn = () => (
             </TextButton>
             <TextButton
                 size="medium"
-                data-test="text-button"
+                data-testid="text-button"
                 onClick={() => {
                     console.log('click');
                 }}
@@ -31,7 +31,7 @@ export const All: StoryFn = () => (
 
             <TextButton
                 size="small"
-                data-test="text-button"
+                data-testid="text-button"
                 onClick={() => {
                     console.log('click');
                 }}
@@ -40,7 +40,7 @@ export const All: StoryFn = () => (
             </TextButton>
 
             <TextButton
-                data-test="text-button-icon"
+                data-testid="text-button-icon"
                 icon="GHOST"
                 onClick={() => {
                     console.log('click');
@@ -49,14 +49,14 @@ export const All: StoryFn = () => (
                 Text Button Icon
             </TextButton>
 
-            <TextButton icon="GHOST" data-test="text-button-loading" isLoading>
+            <TextButton icon="GHOST" data-testid="text-button-loading" isLoading>
                 Text Button loading
             </TextButton>
 
             <TextButton
                 icon="GHOST"
                 isDisabled
-                data-test="text-button-disabled"
+                data-testid="text-button-disabled"
                 onClick={() => {
                     console.log('click');
                 }}

--- a/packages/components/src/components/form/Checkbox/Checkbox.tsx
+++ b/packages/components/src/components/form/Checkbox/Checkbox.tsx
@@ -160,7 +160,7 @@ export type CheckboxProps = AllowedFrameProps & {
     isDisabled?: boolean;
     labelAlignment?: LabelAlignment;
     onClick: EventHandler<SyntheticEvent>;
-    'data-test'?: string;
+    'data-testid'?: string;
     className?: string;
     children?: ReactNode;
 };
@@ -171,7 +171,7 @@ export const Checkbox = ({
     isDisabled = false,
     labelAlignment = 'right',
     onClick,
-    'data-test': dataTest,
+    'data-testid': dataTest,
     className,
     children,
     margin,
@@ -197,7 +197,7 @@ export const Checkbox = ({
             $labelAlignment={labelAlignment}
             onClick={isDisabled ? undefined : onClick}
             onKeyUp={handleKeyUp}
-            data-test={dataTest}
+            data-testid={dataTest}
             className={className}
             {...makePropsTransient(frameProps)}
         >

--- a/packages/components/src/components/form/Input/Input.tsx
+++ b/packages/components/src/components/form/Input/Input.tsx
@@ -93,7 +93,7 @@ export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 
     isDisabled?: boolean;
     size?: InputSize;
     className?: string;
-    dataTest?: string;
+    'data-testid'?: string;
     inputState?: InputState; // TODO: do we need this? we only have the error state right now
     innerAddonAlign?: innerAddonAlignment;
     hasBottomPadding?: boolean;
@@ -117,7 +117,7 @@ const Input = ({
     bottomText,
     size = 'large',
     isDisabled,
-    dataTest,
+    'data-testid': dataTest,
     showClearButton,
     placeholder,
     onClear,
@@ -191,7 +191,7 @@ const Input = ({
                     $rightAddonWidth={rightAddonWidth}
                     $isWithLabel={!!label}
                     placeholder={placeholder || ''} // needed for uncontrolled inputs
-                    data-test={dataTest}
+                    data-testid={dataTest}
                     {...rest}
                 />
 

--- a/packages/components/src/components/form/Radio/Radio.tsx
+++ b/packages/components/src/components/form/Radio/Radio.tsx
@@ -103,7 +103,7 @@ export interface RadioProps {
     isDisabled?: boolean;
     labelAlignment?: LabelAlignment;
     onClick: EventHandler<SyntheticEvent>;
-    'data-test'?: string;
+    'data-testid'?: string;
     children?: ReactNode;
 }
 
@@ -113,7 +113,7 @@ export const Radio = ({
     labelAlignment,
     isDisabled = false,
     onClick,
-    'data-test': dataTest,
+    'data-testid': dataTest,
     children,
 }: RadioProps) => {
     const handleKeyUp = (event: KeyboardEvent<HTMLElement>) => {
@@ -132,7 +132,7 @@ export const Radio = ({
             $isDisabled={isDisabled}
             $labelAlignment={labelAlignment}
             data-checked={isChecked}
-            data-test={dataTest}
+            data-testid={dataTest}
         >
             <HiddenInput
                 type="radio"

--- a/packages/components/src/components/form/Select/Select.tsx
+++ b/packages/components/src/components/form/Select/Select.tsx
@@ -262,7 +262,7 @@ interface CommonProps extends Omit<ReactSelectProps<Option>, 'onChange'> {
     minValueWidth?: string; // TODO: should be probably removed
     inputState?: InputState;
     onChange?: (value: Option, ref?: SelectInstance<Option, boolean> | null) => void;
-    'data-test'?: string;
+    'data-testid'?: string;
 }
 
 // Make sure isSearchable can't be defined if useKeyPressScroll===true
@@ -289,7 +289,7 @@ export const Select = ({
     onChange,
     placeholder,
     isDisabled = false,
-    'data-test': dataTest,
+    'data-testid': dataTest,
     ...props
 }: SelectProps) => {
     const selectRef = useRef<SelectInstance<Option, boolean>>(null);
@@ -322,10 +322,10 @@ export const Select = ({
     const memoizedComponents = useMemo(
         () => ({
             Control: (controlProps: ControlComponentProps) => (
-                <Control {...controlProps} dataTest={dataTest} />
+                <Control {...controlProps} data-testid={dataTest} />
             ),
             Option: (optionProps: OptionComponentProps) => (
-                <Option {...optionProps} dataTest={dataTest} />
+                <Option {...optionProps} data-testid={dataTest} />
             ),
             GroupHeading,
             ...components,

--- a/packages/components/src/components/form/Select/customComponents.tsx
+++ b/packages/components/src/components/form/Select/customComponents.tsx
@@ -2,17 +2,17 @@ import { components, ControlProps, OptionProps, GroupHeadingProps } from 'react-
 import type { Option as OptionType } from './Select';
 
 export interface ControlComponentProps extends ControlProps<OptionType, boolean> {
-    dataTest?: string;
+    'data-testid'?: string;
 }
 
-export const Control = ({ dataTest, ...controlProps }: ControlComponentProps) => (
+export const Control = ({ 'data-testid': dataTest, ...controlProps }: ControlComponentProps) => (
     <components.Control
         {...controlProps}
         innerProps={
             dataTest
                 ? ({
                       ...controlProps.innerProps,
-                      'data-test': `${dataTest}/input`,
+                      'data-testid': `${dataTest}/input`,
                   } as ControlProps<OptionType>['innerProps'])
                 : controlProps.innerProps
         }
@@ -20,16 +20,16 @@ export const Control = ({ dataTest, ...controlProps }: ControlComponentProps) =>
 );
 
 export interface OptionComponentProps extends OptionProps<OptionType, boolean> {
-    dataTest?: string;
+    'data-testid'?: string;
 }
 
-export const Option = ({ dataTest, ...optionProps }: OptionComponentProps) => (
+export const Option = ({ 'data-testid': dataTest, ...optionProps }: OptionComponentProps) => (
     <components.Option
         {...optionProps}
         innerProps={
             {
                 ...optionProps.innerProps,
-                'data-test': `${dataTest}/option/${
+                'data-testid': `${dataTest}/option/${
                     typeof optionProps.data.value === 'string'
                         ? optionProps.data.value
                         : optionProps.label

--- a/packages/components/src/components/form/SelectBar/SelectBar.tsx
+++ b/packages/components/src/components/form/SelectBar/SelectBar.tsx
@@ -224,7 +224,7 @@ export const SelectBar: <V extends ValueTypes>(props: SelectBarProps<V>) => JSX.
                                 ? selectedOptionIn === option.value
                                 : false
                         }
-                        data-test={`select-bar/${String(option.value)}`}
+                        data-testid={`select-bar/${String(option.value)}`}
                     >
                         <span>{option.label}</span>
                         <WidthMock>{option.label}</WidthMock>

--- a/packages/components/src/components/form/Switch/Switch.tsx
+++ b/packages/components/src/components/form/Switch/Switch.tsx
@@ -117,7 +117,7 @@ export interface SwitchProps {
     isAlert?: boolean;
     isSmall?: boolean; // TODO: legacy prop
     className?: string;
-    dataTest?: string;
+    'data-testid'?: string;
     labelPosition?: Extract<UIHorizontalAlignment, 'left' | 'right'>;
 }
 
@@ -127,7 +127,7 @@ export const Switch = ({
     isAlert,
     isSmall,
     label,
-    dataTest,
+    'data-testid': dataTest,
     isChecked,
     className,
     labelPosition = 'right',
@@ -149,7 +149,7 @@ export const Switch = ({
                     e.preventDefault();
                     handleChange();
                 }}
-                data-test={dataTest}
+                data-testid={dataTest}
                 $isSmall={isSmall}
             >
                 <Handle

--- a/packages/components/src/components/form/Textarea/Textarea.tsx
+++ b/packages/components/src/components/form/Textarea/Textarea.tsx
@@ -83,7 +83,7 @@ export interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElemen
     hasBottomPadding?: boolean;
     value?: string;
     characterCount?: CharacterCountProps['characterCount'];
-    'data-test'?: string;
+    'data-testid'?: string;
 }
 
 export const Textarea = ({
@@ -101,7 +101,7 @@ export const Textarea = ({
     labelRight,
     characterCount,
     hasBottomPadding = true,
-    'data-test': dataTest,
+    'data-testid': dataTest,
     ...rest
 }: TextareaProps) => {
     const [isHovered, setIsHovered] = useState(false);
@@ -130,7 +130,7 @@ export const Textarea = ({
                     disabled={isDisabled}
                     $inputState={inputState}
                     rows={rows}
-                    data-test={dataTest}
+                    data-testid={dataTest}
                     placeholder={placeholder || ''} // needed for uncontrolled inputs
                     ref={innerRef}
                     value={value}

--- a/packages/components/src/components/form/form.stories.tsx
+++ b/packages/components/src/components/form/form.stories.tsx
@@ -38,10 +38,10 @@ export const All: StoryObj = {
             <StoryColumn minWidth={520}>
                 <Heading>Input</Heading>
                 <SubHeading>Default</SubHeading>
-                <Input value="Default input with select" dataTest="input-default" />
+                <Input value="Default input with select" data-testid="input-default" />
                 <Input
                     value="Input with select"
-                    dataTest="input-select"
+                    data-testid="input-select"
                     innerAddon={
                         <Select
                             isClean
@@ -55,42 +55,46 @@ export const All: StoryObj = {
                         />
                     }
                 />
-                <Input size="small" value="Small input" dataTest="input-default-small" />
-                <Input inputState="error" value="Input with error" dataTest="input-default-error" />
+                <Input size="small" value="Small input" data-testid="input-default-small" />
+                <Input
+                    inputState="error"
+                    value="Input with error"
+                    data-testid="input-default-error"
+                />
                 <Input
                     inputState="warning"
                     value="Input with warning"
-                    dataTest="input-default-warning"
+                    data-testid="input-default-warning"
                 />
-                <Input isDisabled value="Disabled input" dataTest="input-default-disabled" />
+                <Input isDisabled value="Disabled input" data-testid="input-default-disabled" />
                 <SubHeading>Monospace with button</SubHeading>
                 <Input
                     value="0x3Ebf31732F5A987b4f130Eb359B0975EBcbd68c8"
-                    dataTest="input-block-monospace-button"
+                    data-testid="input-block-monospace-button"
                 />
                 <SubHeading>Partially hidden</SubHeading>
                 <Input
                     value="0x3Ebf31732F5A987b4f130Eb359B0975EBcbd68c8"
-                    dataTest="input-block-monospace-hidden"
+                    data-testid="input-block-monospace-hidden"
                 />
                 <SubHeading>With label &amp; bottom text</SubHeading>
-                <Input value="Input label" dataTest="input-label" bottomText="bottom text" />
+                <Input value="Input label" data-testid="input-label" bottomText="bottom text" />
                 <Input
                     size="small"
                     value="Small input label"
-                    dataTest="input-small-label"
+                    data-testid="input-small-label"
                     bottomText="bottom text"
                 />
                 <Input
                     inputState="error"
                     value="Input label with error"
-                    dataTest="input-error-label"
+                    data-testid="input-error-label"
                     bottomText="bottom text"
                 />
                 <Input
                     inputState="warning"
                     value="Input label with warning"
-                    dataTest="input-warning-label"
+                    data-testid="input-warning-label"
                     bottomText="bottom text"
                     labelHoverRight={
                         <Button variant="tertiary" icon="QR" onClick={() => {}}>
@@ -101,7 +105,7 @@ export const All: StoryObj = {
                 <Input
                     isDisabled
                     value="Disabled input label"
-                    dataTest="input-disabled-label"
+                    data-testid="input-disabled-label"
                     label={<Label>label</Label>}
                     bottomText="bottom text"
                 />
@@ -130,7 +134,7 @@ export const All: StoryObj = {
 
                 <SubHeading>Off</SubHeading>
                 <Switch
-                    dataTest="switch-off"
+                    data-testid="switch-off"
                     onChange={() => {}}
                     isChecked={false}
                     label="Headline"
@@ -138,7 +142,7 @@ export const All: StoryObj = {
 
                 <SubHeading>Off disabled</SubHeading>
                 <Switch
-                    dataTest="switch-off-disabled"
+                    data-testid="switch-off-disabled"
                     isDisabled
                     onChange={() => {}}
                     isChecked={false}
@@ -150,13 +154,13 @@ export const All: StoryObj = {
                     isChecked
                     onChange={() => {}}
                     isDisabled
-                    dataTest="switch-on"
+                    data-testid="switch-on"
                     label="Headline"
                 />
 
                 <SubHeading>On disabled</SubHeading>
                 <Switch
-                    dataTest="switch-on-disabled"
+                    data-testid="switch-on-disabled"
                     isDisabled
                     onChange={() => {}}
                     isChecked
@@ -168,7 +172,7 @@ export const All: StoryObj = {
                     onChange={() => {}}
                     isChecked={false}
                     isSmall
-                    dataTest="switch-off-small"
+                    data-testid="switch-off-small"
                     label="Headline"
                 />
 
@@ -178,7 +182,7 @@ export const All: StoryObj = {
                     onChange={() => {}}
                     isChecked={false}
                     isSmall
-                    dataTest="switch-off-small-disabled"
+                    data-testid="switch-off-small-disabled"
                     label="Headline"
                 />
 
@@ -187,7 +191,7 @@ export const All: StoryObj = {
                     onChange={() => {}}
                     isChecked
                     isSmall
-                    dataTest="switch-on-small"
+                    data-testid="switch-on-small"
                     label="Headline"
                 />
 
@@ -197,7 +201,7 @@ export const All: StoryObj = {
                     onChange={() => {}}
                     isChecked
                     isSmall
-                    dataTest="switch-on-small-disabled"
+                    data-testid="switch-on-small-disabled"
                     label="Headline"
                 />
 
@@ -206,7 +210,7 @@ export const All: StoryObj = {
                     onChange={() => {}}
                     isChecked={false}
                     isAlert
-                    dataTest="switch-off-alert"
+                    data-testid="switch-off-alert"
                     label="Headline"
                 />
 
@@ -216,7 +220,7 @@ export const All: StoryObj = {
                     onChange={() => {}}
                     isChecked={false}
                     isAlert
-                    dataTest="switch-off-alert-disabled"
+                    data-testid="switch-off-alert-disabled"
                     label="Headline"
                 />
 
@@ -225,7 +229,7 @@ export const All: StoryObj = {
                     onChange={() => {}}
                     isChecked
                     isAlert
-                    dataTest="switch-on-alert"
+                    data-testid="switch-on-alert"
                     label="Headline"
                 />
 
@@ -235,29 +239,29 @@ export const All: StoryObj = {
                     onChange={() => {}}
                     isChecked
                     isAlert
-                    dataTest="switch-on-alert-disabled"
+                    data-testid="switch-on-alert-disabled"
                     label="Headline"
                 />
             </StoryColumn>
             <StoryColumn maxWidth={200}>
                 <Heading>Checkbox</Heading>
                 <SubHeading>Unchecked</SubHeading>
-                <Checkbox onClick={() => {}} data-test="checkbox">
+                <Checkbox onClick={() => {}} data-testid="checkbox">
                     Label
                 </Checkbox>
                 <SubHeading>Checked</SubHeading>
-                <Checkbox onClick={() => {}} isChecked data-test="checkbox-checked">
+                <Checkbox onClick={() => {}} isChecked data-testid="checkbox-checked">
                     Label
                 </Checkbox>
             </StoryColumn>
             <StoryColumn maxWidth={200}>
                 <Heading>Radio Buttons</Heading>
                 <SubHeading>Unchecked</SubHeading>
-                <Radio onClick={() => {}} data-test="radio-button">
+                <Radio onClick={() => {}} data-testid="radio-button">
                     Label
                 </Radio>
                 <SubHeading>Checked</SubHeading>
-                <Radio onClick={() => {}} isChecked data-test="radio-button-checked">
+                <Radio onClick={() => {}} isChecked data-testid="radio-button-checked">
                     Label
                 </Radio>
             </StoryColumn>

--- a/packages/components/src/components/loaders/LoadingContent/LoadingContent.tsx
+++ b/packages/components/src/components/loaders/LoadingContent/LoadingContent.tsx
@@ -69,7 +69,7 @@ export const LoadingContent = ({
                 {isSpinnerVisible && (
                     <Spinner
                         size={size}
-                        dataTest="@loading-content/loader"
+                        data-testid="@loading-content/loader"
                         hasStartAnimation
                         hasFinished={!isLoading && isSuccessful}
                         hasError={!isLoading && !isSuccessful}

--- a/packages/components/src/components/loaders/Spinner/Spinner.tsx
+++ b/packages/components/src/components/loaders/Spinner/Spinner.tsx
@@ -31,7 +31,7 @@ export type SpinnerProps = AllowedFrameProps & {
     hasFinished?: boolean;
     hasError?: boolean;
     className?: string;
-    dataTest?: string;
+    'data-testid'?: string;
 };
 
 export const Spinner = ({
@@ -41,7 +41,7 @@ export const Spinner = ({
     hasFinished,
     hasError,
     className,
-    dataTest,
+    'data-testid': dataTest,
     margin,
 }: SpinnerProps) => {
     const [hasStarted, setHasStarted] = useState(false);
@@ -87,7 +87,7 @@ export const Spinner = ({
             className={className}
             $margin={margin}
             {...getProps()}
-            data-test={dataTest ? dataTest : `@spinner`}
+            data-testid={dataTest ? dataTest : `@spinner`}
         />
     );
 };

--- a/packages/components/src/components/modals/DialogModal/DialogModal.stories.tsx
+++ b/packages/components/src/components/modals/DialogModal/DialogModal.stories.tsx
@@ -44,7 +44,7 @@ export const DialogModal: StoryObj<DialogModalProps> = {
         className: {
             control: 'none',
         },
-        'data-test': {
+        'data-testid': {
             control: 'none',
         },
         icon: {

--- a/packages/components/src/components/modals/DialogModal/DialogModal.tsx
+++ b/packages/components/src/components/modals/DialogModal/DialogModal.tsx
@@ -39,7 +39,7 @@ type PickedModalProps = Pick<
     | 'currentProgressBarStep'
     | 'totalProgressBarSteps'
     | 'className'
-    | 'data-test'
+    | 'data-testid'
 >;
 
 export interface DialogModalProps extends PickedModalProps {

--- a/packages/components/src/components/modals/Modal/Modal.stories.tsx
+++ b/packages/components/src/components/modals/Modal/Modal.stories.tsx
@@ -79,7 +79,7 @@ export const Modal: StoryObj<ModalProps> = {
         className: {
             control: 'none',
         },
-        'data-test': {
+        'data-testid': {
             control: 'none',
         },
     },

--- a/packages/components/src/components/modals/Modal/Modal.tsx
+++ b/packages/components/src/components/modals/Modal/Modal.tsx
@@ -194,7 +194,7 @@ interface ModalProps {
     headerComponent?: ReactNode;
     className?: string;
     hasBackdropCancel?: boolean;
-    'data-test'?: string;
+    'data-testid'?: string;
 }
 
 const Modal = ({
@@ -215,7 +215,7 @@ const Modal = ({
     currentProgressBarStep,
     headerComponent,
     className,
-    'data-test': dataTest = '@modal',
+    'data-testid': dataTest = '@modal',
 }: ModalProps) => {
     const [componentsWidth, setComponentsWidth] = useState<number>();
     const theme = useTheme();
@@ -250,7 +250,7 @@ const Modal = ({
 
             <Container
                 onClick={e => e.stopPropagation()} // needed because of the Backdrop implementation
-                data-test={dataTest}
+                data-testid={dataTest}
                 className={className}
             >
                 {(!!onBackClick || !!heading || showHeaderActions) && (
@@ -304,7 +304,7 @@ const Modal = ({
                                     <IconButton
                                         variant="tertiary"
                                         icon="CROSS"
-                                        data-test="@modal/close-button"
+                                        data-testid="@modal/close-button"
                                         onClick={onCancel}
                                         size={HEADING_SIZES[headingSize].buttonSize}
                                     />

--- a/packages/components/src/components/typography/Heading/Heading.tsx
+++ b/packages/components/src/components/typography/Heading/Heading.tsx
@@ -11,7 +11,7 @@ type Align = 'left' | 'center' | 'right';
 
 type BasicProps = {
     children: React.ReactNode;
-    'data-test'?: string;
+    'data-testid'?: string;
     align?: Align;
     onClick?: () => void;
 };

--- a/packages/components/src/components/typography/Link/Link.tsx
+++ b/packages/components/src/components/typography/Link/Link.tsx
@@ -54,7 +54,7 @@ interface LinkProps {
     variant?: 'default' | 'nostyle' | 'underline'; // Todo: refactor, variant has different meaning in our design system
     icon?: IconProps['icon'];
     iconProps?: IconProps;
-    'data-test'?: string;
+    'data-testid'?: string;
 }
 
 const Link = ({
@@ -64,7 +64,7 @@ const Link = ({
     iconProps,
     type,
     onClick,
-    'data-test': dataTest,
+    'data-testid': dataTest,
     children,
     className,
     variant,
@@ -84,7 +84,7 @@ const Link = ({
             href={href}
             target={target || '_blank'}
             rel="noreferrer noopener"
-            data-test={dataTest}
+            data-testid={dataTest}
             onClick={(e: MouseEvent<any>) => {
                 e.stopPropagation();
                 onClick?.(e);

--- a/packages/components/src/components/typography/Paragraph/Paragraph.tsx
+++ b/packages/components/src/components/typography/Paragraph/Paragraph.tsx
@@ -5,7 +5,7 @@ import { typography, TypographyStyle } from '@trezor/theme';
 export type ParagraphProps = {
     typographyStyle?: TypographyStyle;
     className?: string; // Used for color, margins etc. while typography properties should be set via type prop.
-    'data-test'?: string;
+    'data-testid'?: string;
     children: React.ReactNode;
 };
 
@@ -17,10 +17,10 @@ const P = styled.div<{ $typographyStyle: TypographyStyle }>`
 export const Paragraph = ({
     className,
     typographyStyle = 'body',
-    'data-test': dataTest,
+    'data-testid': dataTest,
     children,
 }: ParagraphProps) => (
-    <P className={className} $typographyStyle={typographyStyle} data-test={dataTest}>
+    <P className={className} $typographyStyle={typographyStyle} data-testid={dataTest}>
         {children}
     </P>
 );

--- a/packages/components/src/components/typography/typography.stories.tsx
+++ b/packages/components/src/components/typography/typography.stories.tsx
@@ -10,11 +10,11 @@ export default meta;
 export const All: StoryFn = () => (
     <>
         <StoryColumn>
-            <H1 data-test="heading-1">Heading 1</H1>
-            <H2 data-test="heading-2">Heading 2</H2>
+            <H1 data-testid="heading-1">Heading 1</H1>
+            <H2 data-testid="heading-2">Heading 2</H2>
         </StoryColumn>
         <StoryColumn>
-            <Paragraph data-test="paragraph-default">
+            <Paragraph data-testid="paragraph-default">
                 default
                 <br />
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a ante quis lectus
@@ -22,49 +22,49 @@ export const All: StoryFn = () => (
                 interdum eros, eget placerat lorem pulvinar in. Ut elit orci, rhoncus eu porta vel,
                 feugiat vel mi.
             </Paragraph>
-            <Paragraph typographyStyle="titleLarge" data-test="paragraph-titleLarge">
+            <Paragraph typographyStyle="titleLarge" data-testid="paragraph-titleLarge">
                 type="titleLarge" <br />
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a ante quis lectus
                 eleifend rutrum. Aenean tincidunt odio vel fermentum ultricies. Sed suscipit
                 interdum eros, eget placerat lorem pulvinar in. Ut elit orci, rhoncus eu porta vel,
                 feugiat vel mi.
             </Paragraph>
-            <Paragraph typographyStyle="titleMedium" data-test="paragraph-titleMedium">
+            <Paragraph typographyStyle="titleMedium" data-testid="paragraph-titleMedium">
                 type="titleMedium" <br />
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a ante quis lectus
                 eleifend rutrum. Aenean tincidunt odio vel fermentum ultricies. Sed suscipit
                 interdum eros, eget placerat lorem pulvinar in. Ut elit orci, rhoncus eu porta vel,
                 feugiat vel mi.
             </Paragraph>
-            <Paragraph typographyStyle="titleSmall" data-test="paragraph-titleSmall">
+            <Paragraph typographyStyle="titleSmall" data-testid="paragraph-titleSmall">
                 type ="titleSmall" <br />
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a ante quis lectus
                 eleifend rutrum. Aenean tincidunt odio vel fermentum ultricies. Sed suscipit
                 interdum eros, eget placerat lorem pulvinar in. Ut elit orci, rhoncus eu porta vel,
                 feugiat vel mi.
             </Paragraph>
-            <Paragraph typographyStyle="highlight" data-test="paragraph-highlight">
+            <Paragraph typographyStyle="highlight" data-testid="paragraph-highlight">
                 type="highlight" <br />
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a ante quis lectus
                 eleifend rutrum. Aenean tincidunt odio vel fermentum ultricies. Sed suscipit
                 interdum eros, eget placerat lorem pulvinar in. Ut elit orci, rhoncus eu porta vel,
                 feugiat vel mi.
             </Paragraph>
-            <Paragraph typographyStyle="callout" data-test="paragraph-callout">
+            <Paragraph typographyStyle="callout" data-testid="paragraph-callout">
                 type="callout" <br />
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a ante quis lectus
                 eleifend rutrum. Aenean tincidunt odio vel fermentum ultricies. Sed suscipit
                 interdum eros, eget placerat lorem pulvinar in. Ut elit orci, rhoncus eu porta vel,
                 feugiat vel mi.
             </Paragraph>
-            <Paragraph typographyStyle="hint" data-test="paragraph-hint">
+            <Paragraph typographyStyle="hint" data-testid="paragraph-hint">
                 type="hint" <br />
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a ante quis lectus
                 eleifend rutrum. Aenean tincidunt odio vel fermentum ultricies. Sed suscipit
                 interdum eros, eget placerat lorem pulvinar in. Ut elit orci, rhoncus eu porta vel,
                 feugiat vel mi.
             </Paragraph>
-            <Paragraph typographyStyle="label" data-test="paragraph-label">
+            <Paragraph typographyStyle="label" data-testid="paragraph-label">
                 type="label" <br />
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a ante quis lectus
                 eleifend rutrum. Aenean tincidunt odio vel fermentum ultricies. Sed suscipit
@@ -72,13 +72,13 @@ export const All: StoryFn = () => (
                 feugiat vel mi.
             </Paragraph>
 
-            <Paragraph data-test="paragraph-link">
+            <Paragraph data-testid="paragraph-link">
                 Default text with <Link href="/">link</Link>.
             </Paragraph>
-            <Paragraph typographyStyle="hint" data-test="paragraph-link-hint">
+            <Paragraph typographyStyle="hint" data-testid="paragraph-link-hint">
                 Hint text with <Link href="/">link</Link>.
             </Paragraph>
-            <Paragraph typographyStyle="label" data-test="paragraph-link-label">
+            <Paragraph typographyStyle="label" data-testid="paragraph-link-label">
                 Label text with <Link href="/">link</Link>.
             </Paragraph>
         </StoryColumn>

--- a/packages/connect-examples/webextension-mv2/src/connect-manager.html
+++ b/packages/connect-examples/webextension-mv2/src/connect-manager.html
@@ -6,7 +6,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     </head>
     <body>
-        <button id="get-address" data-test="get-address">Get Address</button>
+        <button id="get-address" data-testid="get-address">Get Address</button>
         <div id="result"></div>
         <script src="./connect-manager.js" type="module"></script>
     </body>

--- a/packages/connect-examples/webextension-mv2/src/connect-manager.js
+++ b/packages/connect-examples/webextension-mv2/src/connect-manager.js
@@ -19,7 +19,7 @@ chrome.runtime.onMessage.addListener((message, sender) => {
         document.getElementById('result').innerText = JSON.stringify(data);
     } else if (type === 'connectLoaded') {
         const connectLoaded = document.createElement('div');
-        connectLoaded.setAttribute('data-test', 'connect-loaded');
+        connectLoaded.setAttribute('data-testid', 'connect-loaded');
         connectLoaded.innerText = 'TrezorConnect is loaded';
         connectLoaded.style.display = 'block';
         document.body.appendChild(connectLoaded);

--- a/packages/connect-examples/webextension-mv3-sw-ts/src/connect-manager.html
+++ b/packages/connect-examples/webextension-mv3-sw-ts/src/connect-manager.html
@@ -6,8 +6,8 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     </head>
     <body>
-        <button id="get-features" data-test="get-features">Get features</button>
-        <button id="get-address" data-test="get-address">Get Address</button>
+        <button id="get-features" data-testid="get-features">Get features</button>
+        <button id="get-address" data-testid="get-address">Get Address</button>
         <div id="result"></div>
         <script src="./connect-manager.js" type="module"></script>
     </body>

--- a/packages/connect-examples/webextension-mv3-sw/src/connect-manager.html
+++ b/packages/connect-examples/webextension-mv3-sw/src/connect-manager.html
@@ -7,8 +7,8 @@
     </head>
     <body>
         <button id="tab">New tab</button>
-        <button id="get-features" data-test="get-features">Get features</button>
-        <button id="get-address" data-test="get-address">Get Address</button>
+        <button id="get-features" data-testid="get-features">Get features</button>
+        <button id="get-address" data-testid="get-address">Get Address</button>
         <div id="result"></div>
         <script src="./connect-manager.js" type="module"></script>
     </body>

--- a/packages/connect-examples/webextension-mv3/src/connect-manager.html
+++ b/packages/connect-examples/webextension-mv3/src/connect-manager.html
@@ -7,8 +7,8 @@
     </head>
     <body>
         <button id="tab">New tab</button>
-        <button id="get-features" data-test="get-features">Get features</button>
-        <button id="get-address" data-test="get-address">Get address</button>
+        <button id="get-features" data-testid="get-features">Get features</button>
+        <button id="get-address" data-testid="get-address">Get address</button>
         <div id="result"></div>
         <!-- TODO: try to load changing content security policy -->
         <!-- https://developer.chrome.com/docs/extensions/mv3/manifest/content_security_policy/ -->

--- a/packages/connect-explorer-theme/src/components/menu.tsx
+++ b/packages/connect-explorer-theme/src/components/menu.tsx
@@ -187,7 +187,7 @@ export function Menu({
                     menuPortalTarget={typeof document !== 'undefined' ? document.body : undefined}
                     menuShouldScrollIntoView={false}
                     maxMenuHeight={400}
-                    data-test="@select-coin"
+                    data-testid="@select-coin"
                 />
             </SelectWrapper>
             <MenuInner

--- a/packages/connect-explorer-theme/src/components/navbar.tsx
+++ b/packages/connect-explorer-theme/src/components/navbar.tsx
@@ -105,7 +105,7 @@ export function Navbar({ flatDirectories, items }: NavBarProps): ReactElement {
                         <Anchor
                             href={typeof config.logoLink === 'string' ? config.logoLink : '/'}
                             className="nx-flex nx-items-center hover:nx-opacity-75 ltr:nx-mr-auto rtl:nx-ml-auto"
-                            data-test="@navbar-logo"
+                            data-testid="@navbar-logo"
                         >
                             <TrezorLogo type="horizontal" width={150} />
                         </Anchor>

--- a/packages/connect-explorer/src/components/ApiPlayground.tsx
+++ b/packages/connect-explorer/src/components/ApiPlayground.tsx
@@ -131,7 +131,7 @@ export const ApiPlayground = ({ options }: ApiPlaygroundProps) => {
                 heading="Method testing tool"
                 paddingType="large"
                 isIconFlipped
-                data-test="@api-playground/collapsible-box"
+                data-testid="@api-playground/collapsible-box"
             >
                 <OptionsRow $manualMode={manualMode}>
                     <div>

--- a/packages/connect-explorer/src/components/Method.tsx
+++ b/packages/connect-explorer/src/components/Method.tsx
@@ -88,7 +88,7 @@ export const getField = (field: Field<any> | FieldWithBundle<any>, props: Props)
         case 'number':
             return (
                 <Input
-                    dataTest={`@input/${field.name}`}
+                    data-testid={`@input/${field.name}`}
                     key={field.name}
                     field={field}
                     onChange={props.actions.onFieldChange}
@@ -100,7 +100,7 @@ export const getField = (field: Field<any> | FieldWithBundle<any>, props: Props)
         case 'checkbox':
             return (
                 <Checkbox
-                    data-test={`@checkbox/${field.name}`}
+                    data-testid={`@checkbox/${field.name}`}
                     key={field.name}
                     field={field}
                     onChange={props.actions.onFieldChange}
@@ -240,7 +240,7 @@ const SubmitButton = ({ onClick, text, isFullWidth, isLoading }: SubmitButtonPro
     return (
         <Button
             onClick={onClick}
-            data-test="@submit-button"
+            data-testid="@submit-button"
             isFullWidth={isFullWidth}
             isLoading={isLoading}
         >
@@ -326,7 +326,7 @@ export const Method = () => {
             <div>
                 <Sticky>
                     {!manualMode && (
-                        <Container data-test="@code">
+                        <Container data-testid="@code">
                             <Heading>Method with params</Heading>
                             <CopyWrapper>
                                 <CopyToClipboard getValue={() => javascriptCode ?? ''} />
@@ -335,7 +335,7 @@ export const Method = () => {
                             <SubmitButton {...buttonProps} isFullWidth />
                         </Container>
                     )}
-                    <Container data-test="@response">
+                    <Container data-testid="@response">
                         <Heading>Response</Heading>
                         <CopyWrapper>
                             <CopyToClipboard getValue={() => JSON.stringify(response, null, 2)} />

--- a/packages/connect-explorer/src/components/fields/CoinSelect.tsx
+++ b/packages/connect-explorer/src/components/fields/CoinSelect.tsx
@@ -12,7 +12,7 @@ interface CoinSelectProps {
 const CoinSelect = ({ field, onChange }: CoinSelectProps) => (
     <Row>
         <Select
-            data-test={`@select/${field.name}`}
+            data-testid={`@select/${field.name}`}
             label={field.name}
             value={field.data!.find(d => d.value === field.value)}
             onChange={({ value }) => {

--- a/packages/connect-explorer/src/components/fields/Input.tsx
+++ b/packages/connect-explorer/src/components/fields/Input.tsx
@@ -6,13 +6,13 @@ import { Row } from './Row';
 interface InputProps {
     onChange: (field: FieldBasic<any>, value: string) => void;
     field: FieldBasic<any>;
-    dataTest?: string;
+    'data-testid'?: string;
 }
 
-const Input = ({ dataTest, field, onChange }: InputProps) => (
+const Input = ({ 'data-testid': dataTest, field, onChange }: InputProps) => (
     <Row>
         <InputComponent
-            dataTest={dataTest}
+            data-testid={dataTest}
             label={field.name}
             value={field.value}
             onChange={event => onChange(field, event.target.value)}

--- a/packages/connect-explorer/src/pages/settings.mdx
+++ b/packages/connect-explorer/src/pages/settings.mdx
@@ -69,21 +69,21 @@ export const Settings = () => {
     return (
         <SettingsContent>
             {fields.map(field => getField(field, { actions }))}
-            <Button onClick={actions.onSubmitInit} data-test="@submit-button">
+            <Button onClick={actions.onSubmitInit} data-testid="@submit-button">
                 {submitButton}
             </Button>
             {initError && (
-                <ErrorMessage data-test="@settings/init-error">
+                <ErrorMessage data-testid="@settings/init-error">
                     Init error: {initError}
                 </ErrorMessage>
             )}
             {isInitSuccess && (
-                <ConfirmationMessage data-test="@settings/init-success">
+                <ConfirmationMessage data-testid="@settings/init-success">
                     Init success!
                 </ConfirmationMessage>
             )}
             {isHandshakeConfirmed && (
-                <ConfirmationMessage data-test="@settings/handshake-confirmed">
+                <ConfirmationMessage data-testid="@settings/handshake-confirmed">
                     Handshake confirmed!
                 </ConfirmationMessage>
             )}

--- a/packages/connect-explorer/src/pages/test.mdx
+++ b/packages/connect-explorer/src/pages/test.mdx
@@ -10,7 +10,7 @@ export const InitButton = ({ label, behavior }) => {
     });
 
     return (
-        <Button onClick={actions.onSubmitInit} data-test="@testpage/init">
+        <Button onClick={actions.onSubmitInit} data-testid="@testpage/init">
           Init
         </Button>
     );
@@ -38,9 +38,9 @@ export const subsequentCallsWithError = async () => {
 Hidden page for testing purposes.
 
 <InitButton />
-<Button onClick={() => subsequentCalls()} data-test="@testpage/subsequentCalls">
+<Button onClick={() => subsequentCalls()} data-testid="@testpage/subsequentCalls">
     Subsequent calls
 </Button>
-<Button onClick={() => subsequentCallsWithError()} data-test="@testpage/subsequentCallsWithError">
+<Button onClick={() => subsequentCallsWithError()} data-testid="@testpage/subsequentCallsWithError">
     Subsequent calls with error
 </Button>

--- a/packages/connect-popup/e2e/support/helpers.ts
+++ b/packages/connect-popup/e2e/support/helpers.ts
@@ -4,16 +4,16 @@ import { BrowserContext, chromium, Page } from '@playwright/test';
 // Waits and clicks for an array on buttons in serial order.
 export const waitAndClick = async (page: Page, buttons: string[]) => {
     for (const button of buttons) {
-        await page.waitForSelector(`[data-test='${button}']`, { state: 'visible' });
-        await page.click(`[data-test='${button}']`);
+        await page.waitForSelector(`[data-testid='${button}']`, { state: 'visible' });
+        await page.click(`[data-testid='${button}']`);
     }
 };
 
 // Helper to use data-test attributes to find elements.
-export const findElementByDataTest = async (page: Page, dataTest: string, timeout?: number) => {
-    await page.waitForSelector(`[data-test='${dataTest}']`, { state: 'visible', timeout });
+export const findElementByDataTest = async (page: Page, dataTestId: string, timeout?: number) => {
+    await page.waitForSelector(`[data-testid='${dataTestId}']`, { state: 'visible', timeout });
 
-    return page.$(`[data-test='${dataTest}']`);
+    return page.$(`[data-testid='${dataTestId}']`);
 };
 
 export const log = (...val: string[]) => {
@@ -116,15 +116,15 @@ export const openPopup = (
     } else {
         triggerPopup.push(explorerPage.waitForEvent('popup'));
     }
-    triggerPopup.push(explorerPage.click("div[data-test='@api-playground/collapsible-box']"));
-    triggerPopup.push(explorerPage.click("button[data-test='@submit-button']"));
-    triggerPopup.push(explorerPage.waitForSelector("[data-test='@submit-button/spinner']"));
+    triggerPopup.push(explorerPage.click("div[data-testid='@api-playground/collapsible-box']"));
+    triggerPopup.push(explorerPage.click("button[data-testid='@submit-button']"));
+    triggerPopup.push(explorerPage.waitForSelector("[data-testid='@submit-button/spinner']"));
 
     return Promise.all(triggerPopup) as Promise<Page[]>;
 };
 
 export const checkHasLogs = async (logPage: Page) => {
-    const locator = await logPage.locator("button[data-test='@log-container/download-button']");
+    const locator = await logPage.locator("button[data-testid='@log-container/download-button']");
     if (await locator.isVisible()) {
         return true;
     }
@@ -135,7 +135,7 @@ export const checkHasLogs = async (logPage: Page) => {
 export const downloadLogs = async (logPage: Page, downloadLogPath: string) => {
     const [download] = await Promise.all([
         logPage.waitForEvent('download'), // wait for download to start
-        logPage.click("button[data-test='@log-container/download-button']"),
+        logPage.click("button[data-testid='@log-container/download-button']"),
     ]);
 
     await download.saveAs(downloadLogPath);
@@ -152,13 +152,13 @@ export const setConnectSettings = async (
     await explorerPage.goto(formatUrl(explorerUrl, `settings/index.html`));
     /*if (isWebExtension) {
         // When webextension and using service-worker we need to wait for handshake is confirmed with proxy.
-        await explorerPage.waitForSelector("div[data-test='@settings/handshake-confirmed']");
+        await explorerPage.waitForSelector("div[data-testid='@settings/handshake-confirmed']");
     }*/
     if (trustedHost) {
         await waitAndClick(explorerPage, ['@checkbox/trustedHost']);
     }
     if (connectSrc) {
-        (await explorerPage.waitForSelector("input[data-test='@input/connectSrc']")).fill(
+        (await explorerPage.waitForSelector("input[data-testid='@input/connectSrc']")).fill(
             connectSrc,
         );
     }

--- a/packages/connect-popup/e2e/tests/__fixtures__/methods.ts
+++ b/packages/connect-popup/e2e/tests/__fixtures__/methods.ts
@@ -84,11 +84,11 @@ const getAddress = [
         views: [
             confirmExportAddressScreen,
             {
-                selector: '[data-test="@passphrase/enter-on-device-button"]',
+                selector: '[data-testid="@passphrase/enter-on-device-button"]',
                 screenshot: {
                     name: 'passhprase-screen',
                 },
-                next: '[data-test="@passphrase/enter-on-device-button"]',
+                next: '[data-testid="@passphrase/enter-on-device-button"]',
             },
             {
                 selector: '.passphrase-on-device >> visible=true',
@@ -236,7 +236,7 @@ const signMessage = [
         device: initializedDevice,
         views: [
             {
-                selector: '[data-test="@info-panel"]', // does not have a special screen
+                selector: '[data-testid="@info-panel"]', // does not have a special screen
                 screenshot: {
                     name: 'sign-message',
                 },
@@ -245,7 +245,7 @@ const signMessage = [
                 },
             },
             {
-                selector: '[data-test="@info-panel"]',
+                selector: '[data-testid="@info-panel"]',
                 nextEmu: {
                     type: 'emulator-press-yes',
                 },

--- a/packages/connect-popup/e2e/tests/analytics.test.ts
+++ b/packages/connect-popup/e2e/tests/analytics.test.ts
@@ -31,12 +31,12 @@ test('reporting', async ({ page }) => {
     await page.goto(`${url}#/method/getAddress`);
 
     await waitAndClick(page, ['@api-playground/collapsible-box']);
-    await page.waitForSelector("button[data-test='@submit-button']", { state: 'visible' });
+    await page.waitForSelector("button[data-testid='@submit-button']", { state: 'visible' });
     const [popup] = await Promise.all([
         // It is important to call waitForEvent before click to set up waiting.
         page.waitForEvent('popup'),
         // Opens popup.
-        page.click("button[data-test='@submit-button']"),
+        page.click("button[data-testid='@submit-button']"),
     ]);
     await popup.waitForLoadState('load');
 
@@ -53,11 +53,11 @@ test('reporting', async ({ page }) => {
     // analytics events sent yet
     expect(requests.length).toEqual(0);
 
-    await popup.waitForSelector("div[data-test='@analytics/consent']", {
+    await popup.waitForSelector("div[data-testid='@analytics/consent']", {
         state: 'visible',
         timeout: 40000,
     });
-    await popup.click("button[data-test='@analytics/continue-button']");
+    await popup.click("button[data-testid='@analytics/continue-button']");
 
     // analytics is now enabled, events should be sent now
     expect(requests.length).toBeGreaterThan(0);
@@ -66,14 +66,14 @@ test('reporting', async ({ page }) => {
     // should be saved in local storage
     expect(localStorage.search('"tracking_enabled\\":true')).toBeTruthy();
 
-    await popup.click("div[data-test='@analytics/settings']");
+    await popup.click("div[data-testid='@analytics/settings']");
 
     // disable analytics
-    await popup.click("div[data-test='@analytics/toggle-switch']");
+    await popup.click("div[data-testid='@analytics/toggle-switch']");
 
     requests = [];
 
-    await popup.click("button[data-test='@analytics/continue-button']");
+    await popup.click("button[data-testid='@analytics/continue-button']");
 
     // disable analytics event is sent
     expect(requests.length).toBe(1);

--- a/packages/connect-popup/e2e/tests/browser-support.test.ts
+++ b/packages/connect-popup/e2e/tests/browser-support.test.ts
@@ -21,8 +21,8 @@ const openPopup = async (page: Page) =>
             // It is important to call waitForEvent before click to set up waiting.
             page.waitForEvent('popup'),
             // Opens popup.
-            page.click("div[data-test='@api-playground/collapsible-box']"),
-            page.click("button[data-test='@submit-button']"),
+            page.click("div[data-testid='@api-playground/collapsible-box']"),
+            page.click("button[data-testid='@submit-button']"),
         ])
     )[0];
 
@@ -39,7 +39,7 @@ test('unsupported browser', async ({ browser }) => {
     const page = await context.newPage();
     await page.goto(formatUrl(url, `methods/bitcoin/getPublicKey/`));
     await waitAndClick(page, ['@api-playground/collapsible-box']);
-    await page.waitForSelector("button[data-test='@submit-button']", { state: 'visible' });
+    await page.waitForSelector("button[data-testid='@submit-button']", { state: 'visible' });
     popup = await openPopup(page);
     await popup.waitForSelector('text=Unsupported browser');
     await popup.screenshot({ path: `${dir}/browser-not-supported.png` });
@@ -56,7 +56,7 @@ test('outdated browser', async ({ browser }) => {
     const page = await context.newPage();
     await page.goto(formatUrl(url, `methods/bitcoin/getPublicKey/`));
     await waitAndClick(page, ['@api-playground/collapsible-box']);
-    await page.waitForSelector("button[data-test='@submit-button']", { state: 'visible' });
+    await page.waitForSelector("button[data-testid='@submit-button']", { state: 'visible' });
     popup = await openPopup(page);
     await popup.waitForLoadState('load');
     await popup.waitForSelector('text=Outdated browser');

--- a/packages/connect-popup/e2e/tests/methods.test.ts
+++ b/packages/connect-popup/e2e/tests/methods.test.ts
@@ -110,16 +110,16 @@ filteredFixtures.forEach(f => {
         await explorerPage.goto(fullUrl);
 
         // expand method tester
-        await explorerPage.click("[data-test='@api-playground/collapsible-box']");
+        await explorerPage.click("[data-testid='@api-playground/collapsible-box']");
 
         // screenshot request
         log(f.url, 'screenshot @trezor/connect call params');
 
-        const code = explorerPage.locator('[data-test="@code"]');
+        const code = explorerPage.locator('[data-testid="@code"]');
         await code.screenshot({ path: `${screenshotsPath}/1-request.png` });
 
         log(f.url, 'submitting in connect explorer');
-        await explorerPage.waitForSelector("button[data-test='@submit-button']", {
+        await explorerPage.waitForSelector("button[data-testid='@submit-button']", {
             state: 'visible',
         });
         log(f.url, 'waiting for popup promise');
@@ -128,11 +128,11 @@ filteredFixtures.forEach(f => {
         log(f.url, 'popup promise resolved');
 
         log(f.url, 'waiting for confirm analytics');
-        await popup.waitForSelector("button[data-test='@analytics/continue-button']", {
+        await popup.waitForSelector("button[data-testid='@analytics/continue-button']", {
             state: 'visible',
             timeout: 40000,
         });
-        await popup.click("button[data-test='@analytics/continue-button']");
+        await popup.click("button[data-testid='@analytics/continue-button']");
 
         if (isWebExtension || isCoreInPopup) {
             log(f.url, 'waiting for select device');
@@ -153,7 +153,7 @@ filteredFixtures.forEach(f => {
         const methodName = await popup.evaluate(() => {
             return (document as Document)
                 ?.querySelector('#react')
-                ?.shadowRoot?.querySelector("aside[data-test='@info-panel'] h2")?.textContent;
+                ?.shadowRoot?.querySelector("aside[data-testid='@info-panel'] h2")?.textContent;
         });
         expect(methodName).not.toBe(undefined);
         expect(methodName).not.toBe('');
@@ -204,7 +204,7 @@ filteredFixtures.forEach(f => {
 
         // screenshot response
         log(f.url, 'screenshot response');
-        const response = explorerPage.locator('[data-test="@response"]');
+        const response = explorerPage.locator('[data-testid="@response"]');
         await response.screenshot({ path: `${screenshotsPath}/4-response.png` });
         log(f.url, 'method finished');
     });

--- a/packages/connect-popup/e2e/tests/passphrase.test.ts
+++ b/packages/connect-popup/e2e/tests/passphrase.test.ts
@@ -115,9 +115,9 @@ test('input passphrase in popup and device accepts it', async () => {
     await waitAndClick(popup, ['@permissions/confirm-button', '@export-address/confirm-button']);
 
     log('typing passphrase');
-    (await popup.waitForSelector("input[data-test='@passphrase/input']", { timeout: 40000 })).type(
-        'abc',
-    );
+    (
+        await popup.waitForSelector("input[data-testid='@passphrase/input']", { timeout: 40000 })
+    ).type('abc');
 
     log('submitting passphrase');
     await waitAndClick(popup, ['@passphrase/hidden/submit-button']);
@@ -162,7 +162,7 @@ test('introduce passphrase in popup and device rejects it', async () => {
     log('waiting for confirm permissions button');
     await waitAndClick(popup, ['@permissions/confirm-button', '@export-address/confirm-button']);
 
-    (await popup.waitForSelector("input[data-test='@passphrase/input']")).type('abc');
+    (await popup.waitForSelector("input[data-testid='@passphrase/input']")).type('abc');
 
     await waitAndClick(popup, ['@passphrase/hidden/submit-button']);
 
@@ -195,7 +195,7 @@ test('introduce passphrase successfully next time should not ask for it', async 
     log('waiting for confirm permissions button');
     await waitAndClick(popup, ['@permissions/confirm-button', '@export-address/confirm-button']);
 
-    (await popup.waitForSelector("input[data-test='@passphrase/input']")).type('abc');
+    (await popup.waitForSelector("input[data-testid='@passphrase/input']")).type('abc');
 
     await waitAndClick(popup, ['@passphrase/hidden/submit-button']);
 
@@ -243,7 +243,7 @@ test('introduce passphrase successfully reload 3rd party it should ask again for
     log('waiting and click confirm permissions button');
     await waitAndClick(popup, ['@permissions/confirm-button', '@export-address/confirm-button']);
 
-    (await popup.waitForSelector("input[data-test='@passphrase/input']")).type('abc');
+    (await popup.waitForSelector("input[data-testid='@passphrase/input']")).type('abc');
 
     await waitAndClick(popup, ['@passphrase/hidden/submit-button']);
 
@@ -273,7 +273,7 @@ test('introduce passphrase successfully reload 3rd party it should ask again for
     await waitAndClick(popup, ['@permissions/confirm-button', '@export-address/confirm-button']);
 
     // Popup should go to passphrase screen
-    await popup.waitForSelector("input[data-test='@passphrase/input']");
+    await popup.waitForSelector("input[data-testid='@passphrase/input']");
 });
 
 test('passphrase mismatch', async ({ page }) => {
@@ -312,7 +312,7 @@ test('passphrase mismatch', async ({ page }) => {
 
     log('typing passphrase');
     // use different passphrase (not corresponding to device.state)
-    (await popup.waitForSelector("input[data-test='@passphrase/input']")).type('cba');
+    (await popup.waitForSelector("input[data-testid='@passphrase/input']")).type('cba');
     log('submitting passphrase');
     await waitAndClick(popup, ['@passphrase/hidden/submit-button']);
     // Accept to see Passphrase.
@@ -325,7 +325,7 @@ test('passphrase mismatch', async ({ page }) => {
 
     log('typing passphrase');
     // Input right passphrase.
-    (await popup.waitForSelector("input[data-test='@passphrase/input']")).type('abc');
+    (await popup.waitForSelector("input[data-testid='@passphrase/input']")).type('abc');
 
     log('submitting passphrase');
     await waitAndClick(popup, ['@passphrase/hidden/submit-button']);
@@ -381,7 +381,7 @@ test('passphrase mismatch', async ({ page }) => {
     await waitAndClick(popup, ['@permissions/confirm-button', '@export-address/confirm-button']);
 
     // Use different passphrase (not corresponding to device.state)
-    (await popup.waitForSelector("input[data-test='@passphrase/input']")).type('cba');
+    (await popup.waitForSelector("input[data-testid='@passphrase/input']")).type('cba');
 
     await waitAndClick(popup, ['@passphrase/hidden/submit-button']);
 

--- a/packages/connect-popup/e2e/tests/permissions.test.ts
+++ b/packages/connect-popup/e2e/tests/permissions.test.ts
@@ -32,7 +32,7 @@ const fixtures = [
             'iframe and host same origins but with settings to NOT trustedHost -> show permissions',
         queryString: '',
         setTrustedHost: false,
-        expect: () => popup.waitForSelector("[data-test='@permissions/confirm-button']"),
+        expect: () => popup.waitForSelector("[data-testid='@permissions/confirm-button']"),
     },
 ];
 
@@ -42,13 +42,13 @@ fixtures.forEach(f => {
         const page = await browserInstance.newPage();
         await setConnectSettings(page, url, { trustedHost: f.setTrustedHost }, false);
 
-        await page.click("a[data-test='@navbar-logo']");
+        await page.click("a[data-testid='@navbar-logo']");
         await page.click("a[href$='/methods/bitcoin/verifyMessage/']");
         await waitAndClick(page, ['@api-playground/collapsible-box']);
 
         [popup] = await Promise.all([
             page.waitForEvent('popup'),
-            page.click("button[data-test='@submit-button']"),
+            page.click("button[data-testid='@submit-button']"),
         ]);
 
         await f.expect();

--- a/packages/connect-popup/e2e/tests/popup-close-legacy.test.ts
+++ b/packages/connect-popup/e2e/tests/popup-close-legacy.test.ts
@@ -58,8 +58,8 @@ test.beforeEach(async ({ page }) => {
     await TrezorUserEnvLink.startBridge(BRIDGE_VERSION);
     log('beforeEach', 'go to: ', `${url}#/method/verifyMessage`);
     await page.goto(`${url}#/method/verifyMessage`);
-    log('beforeEach', 'waitForSelector: ', "button[data-test='@submit-button']");
-    await page.waitForSelector("button[data-test='@submit-button']", { state: 'visible' });
+    log('beforeEach', 'waitForSelector: ', "button[data-testid='@submit-button']");
+    await page.waitForSelector("button[data-testid='@submit-button']", { state: 'visible' });
 
     // Subscribe to 'request' and 'response' events.
     page.on('request', request => {
@@ -91,16 +91,16 @@ test.beforeEach(async ({ page }) => {
     log('beforeEach', 'waitForEvent: ', 'popup');
     [popup] = await Promise.all([
         page.waitForEvent('popup'),
-        page.click("button[data-test='@submit-button']"),
+        page.click("button[data-testid='@submit-button']"),
     ]);
 
     log('beforeEach', 'waitForLoadState: ', 'load');
-    await popup.waitForSelector("button[data-test='@analytics/continue-button']", {
+    await popup.waitForSelector("button[data-testid='@analytics/continue-button']", {
         state: 'visible',
         timeout: 40000,
     });
-    log('beforeEach', 'click: ', "button[data-test='@analytics/continue-button']");
-    await popup.click("button[data-test='@analytics/continue-button']");
+    log('beforeEach', 'click: ', "button[data-testid='@analytics/continue-button']");
+    await popup.click("button[data-testid='@analytics/continue-button']");
 
     popupClosedPromise = new Promise(resolve => {
         popup.on('close', () => resolve(undefined));
@@ -124,12 +124,12 @@ test.beforeEach(async ({ page }) => {
 test.afterEach(async ({ page }) => {
     log('afterEach', `goto: ${url}#/method/verifyMessage`);
     await page.goto(`${url}#/method/verifyMessage`);
-    log('afterEach', 'waitForSelector: ', "button[data-test='@submit-button']");
-    await page.waitForSelector("button[data-test='@submit-button']", { state: 'visible' });
+    log('afterEach', 'waitForSelector: ', "button[data-testid='@submit-button']");
+    await page.waitForSelector("button[data-testid='@submit-button']", { state: 'visible' });
     log('afterEach', 'waitForEvent: ', 'popup');
     [popup] = await Promise.all([
         page.waitForEvent('popup'),
-        page.click("button[data-test='@submit-button']"),
+        page.click("button[data-testid='@submit-button']"),
     ]);
 
     log('afterEach', 'waitForLoadState: ', 'load');
@@ -219,7 +219,7 @@ test.skip(`popup is reloaded by user. bridge version ${BRIDGE_VERSION}`, async (
     await popup.reload();
     // after popup is reload, communication is lost, there is only infinite loader
     log('waiting for infinite loader');
-    await popup.waitForSelector('div[data-test="@connect-ui/loader"]');
+    await popup.waitForSelector('div[data-testid="@connect-ui/loader"]');
     // todo: there is no message into client about the fact that popup was unloaded
 });
 
@@ -237,11 +237,11 @@ test.skip('when user cancels permissions in popup it closes automatically', asyn
     await popupClosedPromise;
 
     await page.goto(`${url}#/method/getAddress`);
-    await page.waitForSelector("button[data-test='@submit-button']", { state: 'visible' });
+    await page.waitForSelector("button[data-testid='@submit-button']", { state: 'visible' });
 
     [popup] = await Promise.all([
         page.waitForEvent('popup'),
-        page.click("button[data-test='@submit-button']"),
+        page.click("button[data-testid='@submit-button']"),
     ]);
 
     popupClosedPromise = new Promise(resolve => {
@@ -250,9 +250,9 @@ test.skip('when user cancels permissions in popup it closes automatically', asyn
 
     await popup.waitForLoadState('load');
     await popup.waitForSelector('button.confirm', { state: 'visible', timeout: 40000 });
-    await popup.waitForSelector("button[data-test='@permissions/confirm-button']");
+    await popup.waitForSelector("button[data-testid='@permissions/confirm-button']");
     // We are testing that when cancel permissions, popup is closed automatically.
-    await popup.click("button[data-test='@permissions/cancel-button']");
+    await popup.click("button[data-testid='@permissions/cancel-button']");
     // Wait for popup to close.
     await popupClosedPromise;
 });
@@ -273,10 +273,10 @@ test.skip('when user cancels Export Bitcoin address dialog in popup it closes au
     await popupClosedPromise;
 
     await page.goto(`${url}#/method/getAddress`);
-    await page.waitForSelector("button[data-test='@submit-button']", { state: 'visible' });
+    await page.waitForSelector("button[data-testid='@submit-button']", { state: 'visible' });
     [popup] = await Promise.all([
         page.waitForEvent('popup'),
-        page.click("button[data-test='@submit-button']"),
+        page.click("button[data-testid='@submit-button']"),
     ]);
     popupClosedPromise = new Promise(resolve => {
         popup.on('close', () => resolve(undefined));
@@ -284,11 +284,11 @@ test.skip('when user cancels Export Bitcoin address dialog in popup it closes au
 
     await popup.waitForLoadState('load');
     await popup.waitForSelector('button.confirm', { state: 'visible', timeout: 40000 });
-    await popup.waitForSelector("button[data-test='@permissions/confirm-button']");
-    await popup.click("button[data-test='@permissions/confirm-button']");
-    await popup.waitForSelector("button[data-test='@export-address/cancel-button']");
+    await popup.waitForSelector("button[data-testid='@permissions/confirm-button']");
+    await popup.click("button[data-testid='@permissions/confirm-button']");
+    await popup.waitForSelector("button[data-testid='@export-address/cancel-button']");
     // We are testing that when cancel Export Bitcoin address, popup is closed automatically.
-    await popup.click("button[data-test='@export-address/cancel-button']");
+    await popup.click("button[data-testid='@export-address/cancel-button']");
     // Wait for popup to close.
     await popupClosedPromise;
 });

--- a/packages/connect-popup/e2e/tests/popup-close.test.ts
+++ b/packages/connect-popup/e2e/tests/popup-close.test.ts
@@ -80,7 +80,7 @@ const setup = async ({ page, context }: { page: Page; context?: BrowserContext }
     await explorerPage.click("a[href$='/methods/bitcoin/verifyMessage/']");
     await waitAndClick(explorerPage, ['@api-playground/collapsible-box']);
 
-    await explorerPage.waitForSelector("button[data-test='@submit-button']", {
+    await explorerPage.waitForSelector("button[data-testid='@submit-button']", {
         state: 'visible',
     });
 
@@ -88,12 +88,12 @@ const setup = async ({ page, context }: { page: Page; context?: BrowserContext }
     [popup] = await openPopup(browserContext, explorerPage, isWebExtension);
 
     log('beforeEach', 'waiting for analytics confirm button');
-    await popup.waitForSelector("button[data-test='@analytics/continue-button']", {
+    await popup.waitForSelector("button[data-testid='@analytics/continue-button']", {
         state: 'visible',
         timeout: 40000,
     });
     log('beforeEach', 'clicking on analytics confirm button');
-    await popup.click("button[data-test='@analytics/continue-button']");
+    await popup.click("button[data-testid='@analytics/continue-button']");
 
     popupClosedPromise = new Promise(resolve => {
         popup.on('close', () => resolve(undefined));
@@ -169,7 +169,7 @@ test(`device dialog canceled ON DEVICE by user`, async ({ page, context }) => {
 
     await explorerPage.waitForTimeout(WAIT_AFTER_TEST);
 
-    await popup.click("button[data-test='@connect-ui/error-close-button']");
+    await popup.click("button[data-testid='@connect-ui/error-close-button']");
 
     await popupClosedPromise;
 
@@ -186,7 +186,7 @@ test(`device disconnected during device interaction`, async ({ page, context }) 
 
     try {
         log('waiting to click @connect-ui/error-close-button');
-        await popup.click("button[data-test='@connect-ui/error-close-button']");
+        await popup.click("button[data-testid='@connect-ui/error-close-button']");
     } catch (error) {
         // Sometimes this crashes with error that the page is already closed.
     }
@@ -216,8 +216,8 @@ test('when user cancels permissions in popup it closes automatically', async ({
     await popupClosedPromise;
 
     await explorerPage.goto(formatUrl(explorerUrl, `methods/bitcoin/getAddress/index.html`));
-    await explorerPage.click("[data-test='@api-playground/collapsible-box']");
-    await explorerPage.waitForSelector("button[data-test='@submit-button']", {
+    await explorerPage.click("[data-testid='@api-playground/collapsible-box']");
+    await explorerPage.waitForSelector("button[data-testid='@submit-button']", {
         state: 'visible',
     });
 
@@ -236,9 +236,9 @@ test('when user cancels permissions in popup it closes automatically', async ({
     }
 
     await popup.waitForSelector('button.confirm', { state: 'visible', timeout: 40000 });
-    await popup.waitForSelector("button[data-test='@permissions/confirm-button']");
+    await popup.waitForSelector("button[data-testid='@permissions/confirm-button']");
     // We are testing that when cancel permissions, popup is closed automatically.
-    await popup.click("button[data-test='@permissions/cancel-button']");
+    await popup.click("button[data-testid='@permissions/cancel-button']");
     // Wait for popup to close.
     await popupClosedPromise;
 });
@@ -260,8 +260,8 @@ test('device dialogue cancelled IN POPUP by user', async ({ page, context }) => 
     await popupClosedPromise;
 
     await explorerPage.goto(formatUrl(explorerUrl, `methods/bitcoin/getAddress/index.html`));
-    await explorerPage.click("[data-test='@api-playground/collapsible-box']");
-    await explorerPage.waitForSelector("button[data-test='@submit-button']", {
+    await explorerPage.click("[data-testid='@api-playground/collapsible-box']");
+    await explorerPage.waitForSelector("button[data-testid='@submit-button']", {
         state: 'visible',
     });
 
@@ -273,11 +273,11 @@ test('device dialogue cancelled IN POPUP by user', async ({ page, context }) => 
 
     await popup.waitForLoadState('load');
     await popup.waitForSelector('button.confirm', { state: 'visible', timeout: 40000 });
-    await popup.waitForSelector("button[data-test='@permissions/confirm-button']");
-    await popup.click("button[data-test='@permissions/confirm-button']");
-    await popup.waitForSelector("button[data-test='@export-address/cancel-button']");
+    await popup.waitForSelector("button[data-testid='@permissions/confirm-button']");
+    await popup.click("button[data-testid='@permissions/confirm-button']");
+    await popup.waitForSelector("button[data-testid='@export-address/cancel-button']");
     // We are testing that when cancel Export Bitcoin address, popup is closed automatically.
-    await popup.click("button[data-test='@export-address/cancel-button']");
+    await popup.click("button[data-testid='@export-address/cancel-button']");
     // Wait for popup to close.
     await popupClosedPromise;
 });
@@ -335,8 +335,8 @@ test('popup should be focused when a call is in progress and user triggers new c
     await popupClosedPromise;
 
     await explorerPage.goto(formatUrl(explorerUrl, `methods/bitcoin/getAddress/index.html`));
-    await explorerPage.click("[data-test='@api-playground/collapsible-box']");
-    await explorerPage.waitForSelector("button[data-test='@submit-button']", {
+    await explorerPage.click("[data-testid='@api-playground/collapsible-box']");
+    await explorerPage.waitForSelector("button[data-testid='@submit-button']", {
         state: 'visible',
     });
 
@@ -347,13 +347,13 @@ test('popup should be focused when a call is in progress and user triggers new c
         popup.on('close', () => resolve(undefined));
     });
 
-    await popup.waitForSelector("button[data-test='@permissions/confirm-button']");
+    await popup.waitForSelector("button[data-testid='@permissions/confirm-button']");
 
     await waitAndClick(popup, ['@permissions/confirm-button']);
 
     // Click in 3rd party to trigger new call. But instead of new call it should focus on open popup.
-    await explorerPage.waitForSelector(`[data-test='@submit-button']`, { state: 'visible' });
-    await explorerPage.click(`[data-test='@submit-button']`, {
+    await explorerPage.waitForSelector(`[data-testid='@submit-button']`, { state: 'visible' });
+    await explorerPage.click(`[data-testid='@submit-button']`, {
         // submit button is disabled in connect-explorer if there is a call in progress. we want to simulate what happens if 3rd party
         // does not respect this and tries to call connect-api again.
         force: true,
@@ -390,8 +390,8 @@ test('popup should close when third party is closed', async ({ page, context }) 
     await popupClosedPromise;
 
     await explorerPage.goto(formatUrl(explorerUrl, `methods/bitcoin/getAddress/index.html`));
-    await explorerPage.click("[data-test='@api-playground/collapsible-box']");
-    await explorerPage.waitForSelector("button[data-test='@submit-button']", {
+    await explorerPage.click("[data-testid='@api-playground/collapsible-box']");
+    await explorerPage.waitForSelector("button[data-testid='@submit-button']", {
         state: 'visible',
     });
     log('waiting for popup open');

--- a/packages/connect-popup/e2e/tests/popup-pages.test.ts
+++ b/packages/connect-popup/e2e/tests/popup-pages.test.ts
@@ -75,27 +75,29 @@ test('popup should display error page when device disconnected and debug mode', 
 
     log('waiting for explorer to load');
     await waitAndClick(page, ['@api-playground/collapsible-box']);
-    await page.waitForSelector("div[data-test='@api-playground/collapsible-box']");
-    await explorerPage.waitForSelector("button[data-test='@submit-button']", { state: 'visible' });
+    await page.waitForSelector("div[data-testid='@api-playground/collapsible-box']");
+    await explorerPage.waitForSelector("button[data-testid='@submit-button']", {
+        state: 'visible',
+    });
 
     log('opening popup');
     [popup] = await openPopup(persistentContext, explorerPage, isWebExtension);
 
     log('waiting for popup analytics to load');
-    await popup.waitForSelector("button[data-test='@analytics/continue-button']", {
+    await popup.waitForSelector("button[data-testid='@analytics/continue-button']", {
         state: 'visible',
         timeout: 40000,
     });
     log('clicking on analytics continue button');
-    await popup.click("button[data-test='@analytics/continue-button']");
+    await popup.click("button[data-testid='@analytics/continue-button']");
 
     log('waiting for permissions');
-    await popup.waitForSelector("div[data-test='@permissions']");
+    await popup.waitForSelector("div[data-testid='@permissions']");
 
     log('stopEmu');
     await TrezorUserEnvLink.stopEmu();
     log('waiting for popup error page');
-    await popup.waitForSelector("div[data-test='@connect-ui/error']");
+    await popup.waitForSelector("div[data-testid='@connect-ui/error']");
 });
 
 test('log page should contain logs from shared worker', async ({ page, context }) => {
@@ -152,7 +154,7 @@ test('log page should contain logs from shared worker', async ({ page, context }
     log(`loaded: ${logsUrl}`);
 
     log('waiting for download-button to be visible');
-    await logsPage.waitForSelector("button[data-test='@log-container/download-button']", {
+    await logsPage.waitForSelector("button[data-testid='@log-container/download-button']", {
         state: 'visible',
         timeout: 40 * 1000,
     });
@@ -160,7 +162,7 @@ test('log page should contain logs from shared worker', async ({ page, context }
     log('clicking download button and waiting for download to start');
     const [download] = await Promise.all([
         logsPage.waitForEvent('download'), // wait for download to start
-        logsPage.click("button[data-test='@log-container/download-button']"),
+        logsPage.click("button[data-testid='@log-container/download-button']"),
     ]);
 
     log('download started');

--- a/packages/connect-popup/e2e/tests/transport.test.ts
+++ b/packages/connect-popup/e2e/tests/transport.test.ts
@@ -121,15 +121,15 @@ fixtures.forEach(f => {
         await page.goto(formatUrl(url, `methods/bitcoin/verifyMessage/${f.queryString}`));
         log('waiting for explorer to load');
         await waitAndClick(page, ['@api-playground/collapsible-box']);
-        await page.waitForSelector("button[data-test='@submit-button']", {
+        await page.waitForSelector("button[data-testid='@submit-button']", {
             state: 'visible',
         });
 
         log('opening popup');
         [popup] = await Promise.all([
             context.waitForEvent('page'),
-            page.locator("button[data-test='@submit-button']").click({ timeout: 30000 }),
-            page.waitForSelector("[data-test='@submit-button/spinner']"),
+            page.locator("button[data-testid='@submit-button']").click({ timeout: 30000 }),
+            page.waitForSelector("[data-testid='@submit-button/spinner']"),
         ]);
         log('waiting for analytics');
         await waitAndClick(popup, ['@analytics/continue-button']);

--- a/packages/connect-popup/e2e/tests/unchained.test.ts
+++ b/packages/connect-popup/e2e/tests/unchained.test.ts
@@ -12,11 +12,11 @@ test.beforeAll(async () => {
 });
 
 const handleAnalyticsConfirm = async (popup: Page) => {
-    await popup.waitForSelector("button[data-test='@analytics/continue-button']", {
+    await popup.waitForSelector("button[data-testid='@analytics/continue-button']", {
         state: 'visible',
         timeout: 40000,
     });
-    await popup.click("button[data-test='@analytics/continue-button']");
+    await popup.click("button[data-testid='@analytics/continue-button']");
 };
 
 /**

--- a/packages/connect-popup/e2e/tests/webextension-example.test.ts
+++ b/packages/connect-popup/e2e/tests/webextension-example.test.ts
@@ -82,18 +82,18 @@ test('Basic web extension MV2', async () => {
     await page.goto(`chrome-extension://${extensionId}/connect-manager.html`);
 
     // Wait for connect to be ready.
-    await page.waitForSelector("div[data-test='connect-loaded']");
+    await page.waitForSelector("div[data-testid='connect-loaded']");
 
-    await page.waitForSelector("button[data-test='get-address']");
-    await page.click("button[data-test='get-address']");
+    await page.waitForSelector("button[data-testid='get-address']");
+    await page.click("button[data-testid='get-address']");
 
     const popup = await browserContext.waitForEvent('page');
     await popup.waitForLoadState('load');
-    await popup.waitForSelector("button[data-test='@analytics/continue-button']", {
+    await popup.waitForSelector("button[data-testid='@analytics/continue-button']", {
         state: 'visible',
         timeout: 40000,
     });
-    await popup.click("button[data-test='@analytics/continue-button']");
+    await popup.click("button[data-testid='@analytics/continue-button']");
 
     await popup.waitForSelector('button.confirm', { state: 'visible', timeout: 40000 });
     await popup.click('button.confirm');
@@ -137,16 +137,16 @@ test('Basic web extension MV3', async () => {
     await page.goto(`chrome-extension://${extensionId}/connect-manager.html`);
     await page.screenshot({ path: `${dir}/web-extension-mv3-1.png` });
 
-    await (await page.waitForSelector("button[data-test='get-address']")).click();
+    await (await page.waitForSelector("button[data-testid='get-address']")).click();
 
     const popup = await browserContext.waitForEvent('page');
     await popup.waitForLoadState('load');
 
-    await popup.waitForSelector("button[data-test='@analytics/continue-button']", {
+    await popup.waitForSelector("button[data-testid='@analytics/continue-button']", {
         state: 'visible',
         timeout: 40000,
     });
-    await popup.click("button[data-test='@analytics/continue-button']");
+    await popup.click("button[data-testid='@analytics/continue-button']");
 
     await popup.waitForSelector('button.confirm', { state: 'visible', timeout: 40000 });
     await popup.click('button.confirm');

--- a/packages/connect-popup/src/log.tsx
+++ b/packages/connect-popup/src/log.tsx
@@ -70,7 +70,7 @@ const DownloadButton = ({ array, filename }: { array: any[]; filename: string })
     };
 
     return (
-        <Button data-test="@log-container/download-button" onClick={downloadArrayAsFile}>
+        <Button data-testid="@log-container/download-button" onClick={downloadArrayAsFile}>
             Download Logs
         </Button>
     );
@@ -149,7 +149,7 @@ const DebugCenter = () => {
             {logs.length > 0 ? (
                 <View
                     title="Logs"
-                    data-test="@connect-logs/logs"
+                    data-testid="@connect-logs/logs"
                     buttons={
                         <DownloadButton
                             array={orderByTimestamp(logs)}
@@ -165,7 +165,7 @@ const DebugCenter = () => {
                 </View>
             ) : (
                 <Wrapper>
-                    <StyledP data-test="@connect-logs/no-logs">
+                    <StyledP data-testid="@connect-logs/no-logs">
                         Waiting for an app to connect
                     </StyledP>
                 </Wrapper>

--- a/packages/connect-popup/src/static/popup.html
+++ b/packages/connect-popup/src/static/popup.html
@@ -275,7 +275,7 @@
             <!-- Passphrase: END -->
 
             <!-- invalid passphrase -->
-            <div data-test="@invalid-passphrase" class="invalid-passphrase">
+            <div data-testid="@invalid-passphrase" class="invalid-passphrase">
                 <div>
                     <h3>Passphrase doesn't match</h3>
                     <p>Looks like You have set a different passphrase</p>
@@ -475,11 +475,11 @@
                 </div>
 
                 <div class="buttons">
-                    <button data-test="@invalid-passphrase/try-again" class="confirm retry">
+                    <button data-testid="@invalid-passphrase/try-again" class="confirm retry">
                         No, Try again
                     </button>
                     <button
-                        data-test="@invalid-passphrase/use-this-passphrase"
+                        data-testid="@invalid-passphrase/use-this-passphrase"
                         class="cancel useCurrent"
                         tabindex="4"
                     >
@@ -490,7 +490,7 @@
             <!-- invalid passphrase: END -->
 
             <!-- Permissions -->
-            <div data-test="@permissions" class="permissions">
+            <div data-testid="@permissions" class="permissions">
                 <h3>Allow<span class="host-name"></span>permissions to:</h3>
 
                 <div class="list-wrapper">
@@ -511,10 +511,10 @@
                     >
                 </div>
                 <div class="buttons">
-                    <button data-test="@permissions/confirm-button" class="confirm">
+                    <button data-testid="@permissions/confirm-button" class="confirm">
                         Allow once for this session
                     </button>
-                    <button data-test="@permissions/cancel-button" class="cancel">Cancel</button>
+                    <button data-testid="@permissions/cancel-button" class="cancel">Cancel</button>
                 </div>
             </div>
             <!-- Permissions: END -->
@@ -2772,7 +2772,7 @@
             <!-- No backup confirmation: END -->
 
             <!-- Export address -->
-            <div data-test="@export-address" class="export-address">
+            <div data-testid="@export-address" class="export-address">
                 <div>
                     <h3></h3>
                 </div>
@@ -3067,16 +3067,18 @@
                     </svg>
                 </div>
                 <div class="buttons">
-                    <button data-test="@export-address/confirm-button" class="confirm">
+                    <button data-testid="@export-address/confirm-button" class="confirm">
                         Export
                     </button>
-                    <button data-test="@export-address/cancel-button" class="cancel">Cancel</button>
+                    <button data-testid="@export-address/cancel-button" class="cancel">
+                        Cancel
+                    </button>
                 </div>
             </div>
             <!-- Export address: END -->
 
             <!-- Check address on device -->
-            <div data-test="@check-address-on-device" class="check-address">
+            <div data-testid="@check-address-on-device" class="check-address">
                 <svg width="12px" height="35px" viewBox="0 0 20 57">
                     <g stroke="none" stroke-width="1" fill="none" transform="translate(1, 1)">
                         <path

--- a/packages/connect-ui/src/components/FloatingMenu.tsx
+++ b/packages/connect-ui/src/components/FloatingMenu.tsx
@@ -23,7 +23,7 @@ const IconWrapper = styled.div`
 type FloatingMenuProps = { onShowAnalyticsConsent: () => void };
 
 export const FloatingMenu = ({ onShowAnalyticsConsent }: FloatingMenuProps) => (
-    <IconWrapper onClick={onShowAnalyticsConsent} data-test="@analytics/settings">
+    <IconWrapper onClick={onShowAnalyticsConsent} data-testid="@analytics/settings">
         <Icon icon="SETTINGS" size={22} color={colors.TYPE_DARK_GREY} />
     </IconWrapper>
 );

--- a/packages/connect-ui/src/components/InfoPanel.tsx
+++ b/packages/connect-ui/src/components/InfoPanel.tsx
@@ -74,7 +74,7 @@ interface InfoPanelProps {
 
 export const InfoPanel = ({ method, origin, hostLabel, topSlot }: InfoPanelProps) => (
     <>
-        <Aside data-test="@info-panel">
+        <Aside data-testid="@info-panel">
             {/*  notifications appear hear */}
             {topSlot && topSlot}
 

--- a/packages/connect-ui/src/components/Loader.tsx
+++ b/packages/connect-ui/src/components/Loader.tsx
@@ -99,7 +99,7 @@ interface LoaderProps {
     message?: string;
 }
 export const Loader = ({ message }: LoaderProps) => (
-    <StyledLoaderWrapper data-test="@connect-ui/loader">
+    <StyledLoaderWrapper data-testid="@connect-ui/loader">
         <StyledLoader>
             <Circular>
                 <svg

--- a/packages/connect-ui/src/components/Passphrase/EnterOnTrezorButton.tsx
+++ b/packages/connect-ui/src/components/Passphrase/EnterOnTrezorButton.tsx
@@ -24,7 +24,7 @@ export const EnterOnTrezorButton = ({ submit, value, deviceModel }: EnterOnTrezo
         <Card
             paddingType="small"
             onClick={() => submit(value, true)}
-            data-test="@passphrase/enter-on-device-button"
+            data-testid="@passphrase/enter-on-device-button"
         >
             <Row gap={spacings.lg} alignItems="center" justifyContent="space-between">
                 {deviceModel && <Image alt="Trezor" image={`TREZOR_${deviceModel}`} height={34} />}

--- a/packages/connect-ui/src/components/Passphrase/PassphraseTypeCard.tsx
+++ b/packages/connect-ui/src/components/Passphrase/PassphraseTypeCard.tsx
@@ -276,7 +276,7 @@ export const PassphraseTypeCard = (props: PassphraseTypeCardLegacyProps) => {
                     setHiddenWalletTouched(true);
                 }
             }}
-            data-test={`@passphrase-type/${props.type}`}
+            data-testid={`@passphrase-type/${props.type}`}
         >
             {!props.singleColModal && (
                 // only used to show options in modal where user selects wallet type
@@ -293,7 +293,9 @@ export const PassphraseTypeCard = (props: PassphraseTypeCardLegacyProps) => {
                         <Col>
                             <WalletTitle
                                 $withMargin={props.type === 'hidden'}
-                                data-test={props.type === 'hidden' && '@tooltip/passphrase-tooltip'}
+                                data-testid={
+                                    props.type === 'hidden' && '@tooltip/passphrase-tooltip'
+                                }
                             >
                                 {props.type === 'hidden' ? (
                                     <Tooltip
@@ -336,7 +338,7 @@ export const PassphraseTypeCard = (props: PassphraseTypeCardLegacyProps) => {
                         {/* Show passphrase input */}
                         <InputWrapper $hasTopMargin={props.authConfirmation}>
                             <PassphraseInput
-                                data-test="@passphrase/input"
+                                data-testid="@passphrase/input"
                                 placeholder={intl.formatMessage({
                                     defaultMessage: 'Enter passphrase',
                                     id: 'TR_ENTER_PASSPHRASE',
@@ -367,7 +369,7 @@ export const PassphraseTypeCard = (props: PassphraseTypeCardLegacyProps) => {
                                             }
                                             setShowPassword(!showPassword);
                                         }}
-                                        data-test="@passphrase/show-toggle"
+                                        data-testid="@passphrase/show-toggle"
                                     />
                                 }
                             />
@@ -384,7 +386,7 @@ export const PassphraseTypeCard = (props: PassphraseTypeCardLegacyProps) => {
                 // Checkbox if user fully understands what's happening when confirming empty passphrase
                 <Content>
                     <Checkbox
-                        data-test="@passphrase/confirm-checkbox"
+                        data-testid="@passphrase/confirm-checkbox"
                         onClick={() => setEnabled(!enabled)}
                         isChecked={enabled}
                     >
@@ -403,7 +405,7 @@ export const PassphraseTypeCard = (props: PassphraseTypeCardLegacyProps) => {
                         {(props.singleColModal || hiddenWalletTouched) && (
                             <motion.div {...motionAnimation.expand}>
                                 <ActionButton
-                                    data-test={`@passphrase/${
+                                    data-testid={`@passphrase/${
                                         props.type === 'hidden' ? 'hidden' : 'standard'
                                     }/submit-button`}
                                     isDisabled={!enabled || isTooLong}
@@ -422,7 +424,7 @@ export const PassphraseTypeCard = (props: PassphraseTypeCardLegacyProps) => {
                                 variant="tertiary"
                                 onClick={() => submit(value, true)}
                                 isFullWidth
-                                data-test="@passphrase/enter-on-device-button"
+                                data-testid="@passphrase/enter-on-device-button"
                             >
                                 <FormattedMessage
                                     id="TR_ENTER_PASSPHRASE_ON_DEVICE"

--- a/packages/connect-ui/src/components/Passphrase/PassphraseTypeCardContent.tsx
+++ b/packages/connect-ui/src/components/Passphrase/PassphraseTypeCardContent.tsx
@@ -140,7 +140,7 @@ export const PassphraseTypeCardContent = ({
                             {/* Show passphrase input */}
                             <Description>
                                 <PassphraseInput
-                                    data-test="@passphrase/input"
+                                    data-testid="@passphrase/input"
                                     placeholder={intl.formatMessage({
                                         defaultMessage: 'Enter passphrase',
                                         id: 'TR_ENTER_PASSPHRASE',
@@ -175,7 +175,7 @@ export const PassphraseTypeCardContent = ({
                                                 }
                                                 setShowPassword(!showPassword);
                                             }}
-                                            data-test="@passphrase/show-toggle"
+                                            data-testid="@passphrase/show-toggle"
                                         />
                                     }
                                 />
@@ -195,7 +195,7 @@ export const PassphraseTypeCardContent = ({
                             {(singleColModal || hiddenWalletTouched) && (
                                 <motion.div {...motionAnimation.expand}>
                                     <ActionButton
-                                        data-test={`@passphrase/${
+                                        data-testid={`@passphrase/${
                                             type === 'hidden' ? 'hidden' : 'standard'
                                         }/submit-button`}
                                         isDisabled={isPassphraseEmpty || isPassphraseTooLong}

--- a/packages/connect-ui/src/components/Passphrase/PassphraseTypeCardHeading.tsx
+++ b/packages/connect-ui/src/components/Passphrase/PassphraseTypeCardHeading.tsx
@@ -70,7 +70,7 @@ export const PassphraseTypeCardHeading = ({
             <Column justifyContent="center" flex="1">
                 <WalletTitle
                     $withMargin={type === 'hidden'}
-                    data-test={type === 'hidden' && '@tooltip/passphrase-tooltip'}
+                    data-testid={type === 'hidden' && '@tooltip/passphrase-tooltip'}
                 >
                     {type === 'hidden' ? (
                         <Tooltip

--- a/packages/connect-ui/src/views/Error.tsx
+++ b/packages/connect-ui/src/views/Error.tsx
@@ -246,7 +246,7 @@ export const ErrorView = (props: ErrorViewProps) => {
     const tips = getTroubleshootingTips(props);
 
     return (
-        <View data-test="@connect-ui/error">
+        <View data-testid="@connect-ui/error">
             <InnerWrapper>
                 <H>Error</H>
 
@@ -280,7 +280,7 @@ export const ErrorView = (props: ErrorViewProps) => {
                 </TipsContainer>
 
                 <Button
-                    data-test="@connect-ui/error-close-button"
+                    data-testid="@connect-ui/error-close-button"
                     variant="primary"
                     onClick={() => window.closeWindow()}
                 >

--- a/packages/suite-data/src/browser-detection/index.ts
+++ b/packages/suite-data/src/browser-detection/index.ts
@@ -61,11 +61,11 @@ window.addEventListener('load', () => {
                 <br>
                 To keep your funds safe, we recommend using the latest version of a supported browser.
                 </p>
-                <p class=${style.continueButton} id="continue-to-suite" data-test="@continue-to-suite">Continue at my own risk</p>`
+                <p class=${style.continueButton} id="continue-to-suite" data-testid="@continue-to-suite">Continue at my own risk</p>`
             : '';
 
     const getMainHtml = (props: MainHtmlProps) => `
-    <div id="unsupported-browser" class="${style.container}" data-test="@browser-detect">
+    <div id="unsupported-browser" class="${style.container}" data-testid="@browser-detect">
         <h1 class="${style.title}">${props.title}</h1>
         <p class="${style.subtitle}">${props.subtitle}</p>
         ${getSupportedDevicesList(props)}

--- a/packages/suite-desktop-core/e2e/playwright.config.ts
+++ b/packages/suite-desktop-core/e2e/playwright.config.ts
@@ -9,7 +9,7 @@ const config: PlaywrightTestConfig = {
         trace: 'on',
         video: 'on',
         screenshot: 'on',
-        testIdAttribute: 'data-test',
+        testIdAttribute: 'data-testid',
     },
     reportSlowTests: null,
     reporter: process.env.GITHUB_ACTION ? [['list'], ['@currents/playwright']] : [['list']],

--- a/packages/suite-desktop-core/e2e/support/common.ts
+++ b/packages/suite-desktop-core/e2e/support/common.ts
@@ -65,8 +65,8 @@ export const launchSuite = async (params: LaunchSuiteParams = {}) => {
 };
 
 export const waitForDataTestSelector = (window: Page, selector: string, options = {}) =>
-    window.waitForSelector(`[data-test="${selector}"]`, options);
+    window.waitForSelector(`[data-testid="${selector}"]`, options);
 
 export const clickDataTest = async (window: Page, selector: string) => {
-    await window.locator(`[data-test="${selector}"]`).click();
+    await window.locator(`[data-testid="${selector}"]`).click();
 };

--- a/packages/suite-desktop-core/e2e/support/pageActions/dashboardActions.ts
+++ b/packages/suite-desktop-core/e2e/support/pageActions/dashboardActions.ts
@@ -35,10 +35,12 @@ class DashboardActions {
 
     async ejectWallet(window: Page, walletIndex: number = 0) {
         const wallet = window.locator(
-            `[data-test="@switch-device/wallet-on-index/${walletIndex}"]`,
+            `[data-testid="@switch-device/wallet-on-index/${walletIndex}"]`,
         );
-        await window.locator('[data-test="@switch-device/wallet-on-index/0/eject-button"]').click();
-        await window.locator('[data-test="@switch-device/eject"]').click();
+        await window
+            .locator('[data-testid="@switch-device/wallet-on-index/0/eject-button"]')
+            .click();
+        await window.locator('[data-testid="@switch-device/eject"]').click();
         await wallet.waitFor({ state: 'detached' });
     }
 

--- a/packages/suite-desktop-core/e2e/support/pageActions/settingsActions.ts
+++ b/packages/suite-desktop-core/e2e/support/pageActions/settingsActions.ts
@@ -39,7 +39,7 @@ class SettingsActions {
         }
         await window.getByTestId(`@settings/menu/${desiredLocation}`).click();
         await window
-            .locator(`[data-test="${desiredLocationTestid}"]`)
+            .locator(`[data-testid="${desiredLocationTestid}"]`)
             // TODO: fix data-testid selectors in the app
             // .getByTestId(desiredLocationTestid)
             .waitFor({ state: 'visible', timeout: 10_000 });

--- a/packages/suite-desktop-core/e2e/support/pageActions/suiteGuideActions.ts
+++ b/packages/suite-desktop-core/e2e/support/pageActions/suiteGuideActions.ts
@@ -28,7 +28,7 @@ class SuiteGuide {
         );
         // assert that select value was changed correctly.
         expectPlaywright(
-            window.locator('[data-test="@guide/feedback/suggestion-dropdown/select/input"]'),
+            window.locator('[data-testid="@guide/feedback/suggestion-dropdown/select/input"]'),
         ).toHaveText(desiredLocation);
     }
 
@@ -63,9 +63,9 @@ class SuiteGuide {
 
     async closeGuide(window: Page) {
         // since there's a possibility of a notification, we first check for it
-        const suiteNotification = await window.locator('[data-test*="@toast"]').first();
+        const suiteNotification = await window.locator('[data-testid*="@toast"]').first();
         if (await suiteNotification.isVisible()) {
-            await suiteNotification.locator('[data-test$="close"]').click();
+            await suiteNotification.locator('[data-testid$="close"]').click();
             await suiteNotification.waitFor({ state: 'detached' });
         }
         await window.getByTestId('@guide/button-close').click();
@@ -75,7 +75,7 @@ class SuiteGuide {
     async lookupArticle(window: Page, article: string) {
         await window.getByTestId('@guide/search').fill(article);
         await window.getByTestId('@guide/search/results').waitFor({ state: 'visible' });
-        await window.locator('[data-test^="@guide/node"]', { hasText: article }).click();
+        await window.locator('[data-testid^="@guide/node"]', { hasText: article }).click();
     }
 
     // asserts

--- a/packages/suite-desktop-core/e2e/support/pageActions/walletActions.ts
+++ b/packages/suite-desktop-core/e2e/support/pageActions/walletActions.ts
@@ -23,7 +23,7 @@ class WalletActions {
     }
     // asserts
     async getAccountsCount(window: Page, network: string) {
-        return await window.locator(`[data-test*="@account-menu/${network}"][tabindex]`).count();
+        return await window.locator(`[data-testid*="@account-menu/${network}"][tabindex]`).count();
     }
 }
 

--- a/packages/suite-desktop-core/e2e/tests/spawn-tor.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/spawn-tor.test.ts
@@ -6,26 +6,26 @@ import { NetworkAnalyzer } from '../support/networkAnalyzer';
 const timeout = 1000 * 60 * 5; // 5 minutes because it takes a while to start tor.
 
 const turnOnTorInSettings = async (window: Page, shouldEnableTor = true) => {
-    await window.click('[data-test="@suite/menu/settings"]');
-    await window.waitForSelector('[data-test="@settings/general/tor-switch"]');
+    await window.click('[data-testid="@suite/menu/settings"]');
+    await window.waitForSelector('[data-testid="@settings/general/tor-switch"]');
     const torIAlreadyEnabled = await window.isChecked(
-        '[data-test="@settings/general/tor-switch"] > input',
+        '[data-testid="@settings/general/tor-switch"] > input',
     );
     if ((shouldEnableTor && torIAlreadyEnabled) || (!shouldEnableTor && !torIAlreadyEnabled)) {
         // If tor is already enabled, we return early.
         return;
     }
 
-    await window.click('[data-test="@settings/general/tor-switch"]');
-    await window.waitForSelector('[data-test="@loading-content/loader"]', {
+    await window.click('[data-testid="@settings/general/tor-switch"]');
+    await window.waitForSelector('[data-testid="@loading-content/loader"]', {
         state: 'visible',
     });
-    await window.waitForSelector('[data-test="@loading-content/loader"]', {
+    await window.waitForSelector('[data-testid="@loading-content/loader"]', {
         state: 'detached',
         timeout,
     });
     await expectPlaywright(
-        window.locator('[data-test="@settings/general/tor-switch"] > input'),
+        window.locator('[data-testid="@settings/general/tor-switch"] > input'),
     ).toBeChecked();
 
     await window.waitForTimeout(1000);
@@ -43,11 +43,11 @@ testPlaywright.describe.skip('Tor loading screen', () => {
 
         suite = await launchSuite();
 
-        await suite.window.waitForSelector('[data-test="@tor-loading-screen"]', {
+        await suite.window.waitForSelector('[data-testid="@tor-loading-screen"]', {
             state: 'visible',
         });
 
-        await suite.window.waitForSelector('[data-test="@welcome/title"]', { timeout });
+        await suite.window.waitForSelector('[data-testid="@welcome/title"]', { timeout });
 
         suite.electronApp.close();
     });
@@ -69,11 +69,11 @@ testPlaywright.describe.skip('Tor loading screen', () => {
             // Start network analyzer after making sure tor is going to be running.
             networkAnalyzer.start();
 
-            await suite.window.waitForSelector('[data-test="@tor-loading-screen"]', {
+            await suite.window.waitForSelector('[data-testid="@tor-loading-screen"]', {
                 state: 'visible',
             });
 
-            await suite.window.waitForSelector('[data-test="@welcome/title"]', { timeout });
+            await suite.window.waitForSelector('[data-testid="@welcome/title"]', { timeout });
             networkAnalyzer.stop();
             const requests = networkAnalyzer.getRequests();
             requests.forEach(request => {
@@ -95,17 +95,17 @@ testPlaywright.describe.skip('Tor loading screen', () => {
 
         suite = await launchSuite();
 
-        await suite.window.waitForSelector('[data-test="@tor-loading-screen"]', {
+        await suite.window.waitForSelector('[data-testid="@tor-loading-screen"]', {
             state: 'visible',
         });
-        await suite.window.click('[data-test="@tor-loading-screen/disable-button"]');
+        await suite.window.click('[data-testid="@tor-loading-screen/disable-button"]');
 
         // disabling loader appears and disappears
         suite.window.locator('text=Disabling Tor');
-        await suite.window.click('[data-test="@suite/menu/settings"]');
+        await suite.window.click('[data-testid="@suite/menu/settings"]');
 
         await expectPlaywright(
-            suite.window.locator('[data-test="@settings/general/tor-switch"] > input'),
+            suite.window.locator('[data-testid="@settings/general/tor-switch"] > input'),
         ).not.toBeChecked();
 
         suite.electronApp.close();

--- a/packages/suite-desktop-ui/src/support/DesktopUpdater/EarlyAccessEnable.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater/EarlyAccessEnable.tsx
@@ -63,7 +63,7 @@ export const EarlyAccessEnable = ({ hideWindow }: EarlyAccessEnableProps) => {
                     <Button
                         onClick={hideWindow}
                         variant="tertiary"
-                        data-test="@settings/early-access-skip-button"
+                        data-testid="@settings/early-access-skip-button"
                     >
                         <Translation id="TR_EARLY_ACCESS_SKIP_CHECK" />
                     </Button>
@@ -85,7 +85,7 @@ export const EarlyAccessEnable = ({ hideWindow }: EarlyAccessEnableProps) => {
                     <Button
                         onClick={allowPrerelease}
                         isDisabled={!understood}
-                        data-test="@settings/early-access-confirm-button"
+                        data-testid="@settings/early-access-confirm-button"
                     >
                         <Translation id="TR_EARLY_ACCESS_ENABLE_CONFIRM" />
                     </Button>
@@ -105,7 +105,7 @@ export const EarlyAccessEnable = ({ hideWindow }: EarlyAccessEnableProps) => {
             </DescriptionWrapper>
             <Divider />
             <Checkbox
-                data-test="@settings/early-access-confirm-check"
+                data-testid="@settings/early-access-confirm-check"
                 title={
                     <Paragraph typographyStyle="highlight">
                         <Translation id="TR_EARLY_ACCESS_ENABLE_CONFIRM_CHECK" />

--- a/packages/suite-desktop-ui/src/support/screens/TorLoadingScreen.tsx
+++ b/packages/suite-desktop-ui/src/support/screens/TorLoadingScreen.tsx
@@ -28,7 +28,7 @@ export const TorLoadingScreen = ({ callback }: TorLoadingScreenProps) => {
 
     return (
         <ThemeProvider>
-            <Wrapper data-test="@tor-loading-screen">
+            <Wrapper data-testid="@tor-loading-screen">
                 <TorLoader ModalWrapper={StyledModal} callback={callback} />
             </Wrapper>
         </ThemeProvider>

--- a/packages/suite-web/e2e/support/utils/assertions.ts
+++ b/packages/suite-web/e2e/support/utils/assertions.ts
@@ -19,7 +19,7 @@ export const discoveryShouldFinish = () => {
 export const discoveryMightAppearAndShouldFinish = () => {
     cy.wait(1000); // after one second, discovery would have started if it was supposed to.
     cy.get('body').then($body => {
-        if ($body.find('[data-test="@wallet/discovery-progress-bar"]').length > 0) {
+        if ($body.find('[data-testid="@wallet/discovery-progress-bar"]').length > 0) {
             discoveryShouldFinish();
         }
     });

--- a/packages/suite-web/e2e/support/utils/selectors.ts
+++ b/packages/suite-web/e2e/support/utils/selectors.ts
@@ -1,11 +1,11 @@
 /**
- * Just like cy.get() but will return element specified with 'data-test=' attribute.
+ * Just like cy.get() but will return element specified with 'data-testid=' attribute.
  *
  * @example any element <div data=test="my-fancy-attr-name" />
  * cy.getTestElement('my-fancy-attr-name')
  *
  * @example example Select element
- * <Select data-test="send/fee-select" options=[{label: 'foo', value: 'bla'}] />
+ * <Select data-testid="send/fee-select" options=[{label: 'foo', value: 'bla'}] />
  *
  *  - will get input
  *  getTestElement('send/fee-select/input')
@@ -15,7 +15,7 @@
  */
 
 export const getTestElement = (selector: string, options?: Parameters<typeof cy.get>[1]) =>
-    cy.get(`[data-test="${selector}"]`, options);
+    cy.get(`[data-testid="${selector}"]`, options);
 
 export const getConfirmActionOnDeviceModal = () =>
     cy.getTestElement('@suite/modal/confirm-action-on-device');

--- a/packages/suite-web/e2e/support/utils/shortcuts.ts
+++ b/packages/suite-web/e2e/support/utils/shortcuts.ts
@@ -121,9 +121,9 @@ export const createAccountFromMyAccounts = (coin: string, label: string) => {
     //     cy.getTestElement('@account-menu/add-account').should('be.visible').click();
     // }
     cy.getTestElement('@modal').should('be.visible');
-    cy.get(`[data-test="@settings/wallet/network/${coin}"]`).should('be.visible').click();
+    cy.get(`[data-testid="@settings/wallet/network/${coin}"]`).should('be.visible').click();
     cy.getTestElement('@add-account-type/select/input').click();
-    cy.get(`[data-test="@add-account-type/select/option/${label}"]`).click();
+    cy.get(`[data-testid="@add-account-type/select/option/${label}"]`).click();
     cy.getTestElement('@add-account').click();
 };
 
@@ -181,15 +181,17 @@ export const changeViewOnlyState = (walletIndex: number, desiredState: 'enabled'
     // get the wallet container
     cy.getTestElement(`@switch-device/wallet-on-index/${walletIndex}`).then(walletContainer => {
         // check if change is even necessary
-        if (!walletContainer.find(`[data-test="@viewOnlyStatus/${desiredState}"]`).length) {
+        if (!walletContainer.find(`[data-testid="@viewOnlyStatus/${desiredState}"]`).length) {
             // if it is, open view-only settings container and change the state
-            cy.wrap(walletContainer).find('[data-test="@collapsible-box/icon-collapsed"]').click();
             cy.wrap(walletContainer)
-                .find('[data-test="@collapsible-box/body"]')
+                .find('[data-testid="@collapsible-box/icon-collapsed"]')
+                .click();
+            cy.wrap(walletContainer)
+                .find('[data-testid="@collapsible-box/body"]')
                 .should('be.visible');
-            cy.wrap(walletContainer).find(`[data-test$="/${desiredState}"]`).click();
+            cy.wrap(walletContainer).find(`[data-testid$="/${desiredState}"]`).click();
             // close it to match the initial state
-            cy.wrap(walletContainer).find('[data-test="@collapsible-box/icon-expanded"]').click();
+            cy.wrap(walletContainer).find('[data-testid="@collapsible-box/icon-expanded"]').click();
         }
     });
 };

--- a/packages/suite-web/e2e/tests/settings/application-log.test.ts
+++ b/packages/suite-web/e2e/tests/settings/application-log.test.ts
@@ -22,7 +22,7 @@ describe('ApplicationLog', () => {
         cy.getTestElement('@log/export-button');
         // cypress open todo: implement match-image snapshot. blackout stopped working properly
         cy.getTestElement('@modal/application-log').screenshot('log-modal', {
-            blackout: ['[data-test="@log/content"]'],
+            blackout: ['[data-testid="@log/content"]'],
         });
 
         // todo: check it really exports something;

--- a/packages/suite-web/e2e/tests/settings/safety-checks.test.ts
+++ b/packages/suite-web/e2e/tests/settings/safety-checks.test.ts
@@ -27,14 +27,14 @@ describe('Safety Checks Settings', () => {
         });
 
         // There should be two radio buttons, one checked and one not.
-        cy.get('[data-test*="@radio-button"]').should('have.length', 2);
-        cy.get('[data-test*="@radio-button"][data-checked="true"]').should('have.length', 1);
-        cy.get('[data-test*="@radio-button"][data-checked="false"]').should('have.length', 1);
+        cy.get('[data-testid*="@radio-button"]').should('have.length', 2);
+        cy.get('[data-testid*="@radio-button"][data-checked="true"]').should('have.length', 1);
+        cy.get('[data-testid*="@radio-button"][data-checked="false"]').should('have.length', 1);
 
-        cy.get('[data-test*="@radio-button"][data-checked="false"]').click();
+        cy.get('[data-testid*="@radio-button"][data-checked="false"]').click();
         // After switching the value, there should still be one checked and one unchecked.
-        cy.get('[data-test*="@radio-button"][data-checked="true"]').should('have.length', 1);
-        cy.get('[data-test*="@radio-button"][data-checked="false"]').should('have.length', 1);
+        cy.get('[data-testid*="@radio-button"][data-checked="true"]').should('have.length', 1);
+        cy.get('[data-testid*="@radio-button"][data-checked="false"]').should('have.length', 1);
     });
 
     it('Apply button is enabled only when value is changed', () => {
@@ -44,7 +44,7 @@ describe('Safety Checks Settings', () => {
         });
 
         cy.getTestElement('@safety-checks-apply').should('have.attr', 'disabled');
-        cy.get('[data-test*="@radio-button"][data-checked="false"]').click();
+        cy.get('[data-testid*="@radio-button"][data-checked="false"]').click();
         cy.getTestElement('@safety-checks-apply').should('not.have.attr', 'disabled');
     });
 
@@ -54,10 +54,10 @@ describe('Safety Checks Settings', () => {
         });
         // Don't assume the device is set to any particular value.
         // Just switch to the one that is not currently checked.
-        cy.get('[data-test*="@radio-button"][data-checked="false"]')
+        cy.get('[data-testid*="@radio-button"][data-checked="false"]')
             .click()
             .then(b => {
-                const targetValue = b.attr('data-test');
+                const targetValue = b.attr('data-testid');
                 console.log(`Changing safety_checks to ${targetValue})`);
                 cy.getTestElement('@safety-checks-apply').click();
                 cy.getTestElement('@suite/modal/confirm-action-on-device');
@@ -66,7 +66,7 @@ describe('Safety Checks Settings', () => {
                 cy.getTestElement('@settings/device/safety-checks-button').click({
                     scrollBehavior: 'bottom',
                 });
-                cy.get(`[data-test="${targetValue}"]`)
+                cy.get(`[data-testid="${targetValue}"]`)
                     .invoke('attr', 'data-checked')
                     .should('eq', 'true');
             });

--- a/packages/suite-web/e2e/tests/suite/bridge.test.ts
+++ b/packages/suite-web/e2e/tests/suite/bridge.test.ts
@@ -10,7 +10,7 @@ describe('Bridge page', () => {
         cy.prefixedVisit('/bridge');
 
         cy.getTestElement('@modal/bridge').matchImageSnapshot('bridge-modal-new', {
-            blackout: ['[data-test="@bridge/download-button"]'],
+            blackout: ['[data-testid="@bridge/download-button"]'],
         });
 
         // user may exit bridge page and use webusb

--- a/packages/suite-web/e2e/tests/suite/database-migration.test.ts
+++ b/packages/suite-web/e2e/tests/suite/database-migration.test.ts
@@ -32,7 +32,7 @@ describe('Database migration', () => {
         const baseUrl = 'https://dev.suite.sldev.cz/suite-web';
         const btcAddressInputSelector = 'outputs[0].address';
         const workaroundBtcAddressInputSelector = 'outputs.0.address';
-        const hiddenWalletSelector = '[data-test^="@switch-device/wallet-on-index"]';
+        const hiddenWalletSelector = '[data-testid^="@switch-device/wallet-on-index"]';
         cy.viewport(1440, 2560);
         cy.task('startEmu', { wipe: true });
         cy.task('setupEmu', {
@@ -91,15 +91,15 @@ describe('Database migration', () => {
         cy.getTestElement('@wallet/menu/close-button').last().click();
 
         // check and store address of first btc tx
-        cy.get('[data-test^="@metadata/outputLabel"] > span').should('be.visible');
-        cy.get('[data-test^="@metadata/outputLabel"] > span')
+        cy.get('[data-testid^="@metadata/outputLabel"] > span').should('be.visible');
+        cy.get('[data-testid^="@metadata/outputLabel"] > span')
             .first()
             .invoke('text')
             .as('firstTxLabel');
         // remember the wallet
         cy.getTestElement('@menu/switch-device').click();
         cy.contains(hiddenWalletSelector, 'Hidden wallet #1')
-            .find('[data-test*="toggle-remember-switch"]')
+            .find('[data-testid*="toggle-remember-switch"]')
             .click()
             .find('input')
             .should('be.checked');
@@ -119,10 +119,10 @@ describe('Database migration', () => {
 
         cy.getTestElement('@switch-device/cancel-button').click();
 
-        cy.get('[data-test^="@metadata/outputLabel"]').first().should('be.visible');
+        cy.get('[data-testid^="@metadata/outputLabel"]').first().should('be.visible');
 
         // check the first tx and verify it against the stored one
-        cy.get('[data-test^="@metadata/outputLabel"]')
+        cy.get('[data-testid^="@metadata/outputLabel"]')
             .first()
             .invoke('text')
             .then(readFirstTx => {

--- a/packages/suite-web/e2e/tests/suite/guide.test.ts
+++ b/packages/suite-web/e2e/tests/suite/guide.test.ts
@@ -61,7 +61,7 @@ describe('Test Guide', () => {
         cy.getTestElement('@guide/button-feedback').click();
         // cypress open todo: panel is probably animated, we need to wait until it is fully expanded
         cy.getTestElement('@guide/panel').screenshot('guide-side-panel', {
-            blackout: ['[data-test="@guide/support/version"]'],
+            blackout: ['[data-testid="@guide/support/version"]'],
         });
     });
 });

--- a/packages/suite-web/e2e/tests/suite/passphrase-cardano.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase-cardano.test.ts
@@ -38,9 +38,9 @@ describe('Passphrase with cardano', () => {
         // TODO: refactor using data-tests
         cy.getTestElement('@switch-device/wallet-on-index/1').then(wallet => {
             cy.wrap(wallet)
-                .find('[data-test="@collapsible-box/icon-collapsed"]')
+                .find('[data-testid="@collapsible-box/icon-collapsed"]')
                 .click({ scrollBehavior: 'bottom' });
-            cy.wrap(wallet).find('[data-test$="/enabled"]').should('be.visible').click();
+            cy.wrap(wallet).find('[data-testid$="/enabled"]').should('be.visible').click();
         });
 
         cy.getTestElement('@switch-device/cancel-button').first().click();

--- a/packages/suite-web/e2e/tests/suite/passphrase.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase.test.ts
@@ -79,7 +79,7 @@ describe('Passphrase', () => {
         // click reveal address
         cy.getTestElement('@wallet/receive/reveal-address-button').click();
         cy.getTestElement('@device-display/chunked-text')
-            .find('[data-test*="chunk"]')
+            .find('[data-testid*="chunk"]')
             .then(chunks => {
                 let fullAddress = '';
                 // @ts-expect-error
@@ -118,7 +118,7 @@ describe('Passphrase', () => {
         cy.getTestElement('@wallet/receive/reveal-address-button').should('not.be.disabled');
         cy.getTestElement('@wallet/receive/reveal-address-button').click();
         cy.getTestElement('@device-display/chunked-text')
-            .find('[data-test*="chunk"]')
+            .find('[data-testid*="chunk"]')
             .then(chunks => {
                 let fullAddress = '';
                 // @ts-expect-error
@@ -151,7 +151,7 @@ describe('Passphrase', () => {
 
         // should display confirm passphrase modal
         cy.getTestElement('@device-display/chunked-text')
-            .find('[data-test*="chunk"]')
+            .find('[data-testid*="chunk"]')
             .then(chunks => {
                 let fullAddress = '';
                 // @ts-expect-error

--- a/packages/suite-web/e2e/tests/suite/safety-checks-warning.test.ts
+++ b/packages/suite-web/e2e/tests/suite/safety-checks-warning.test.ts
@@ -40,7 +40,7 @@ describe('safety_checks Warning For PromptTemporarily', () => {
         cy.getTestElement('@settings/device/safety-checks-button').click({
             scrollBehavior: 'bottom',
         });
-        cy.get(`[data-test="@radio-button-prompt"]`).click();
+        cy.get(`[data-testid="@radio-button-prompt"]`).click();
         cy.getTestElement('@safety-checks-apply').click();
         cy.getTestElement('@prompts/confirm-on-device');
         cy.task('pressYes');
@@ -67,7 +67,7 @@ describe('safety_checks Warning For PromptTemporarily', () => {
         cy.getTestElement('@settings/device/safety-checks-button').click({
             scrollBehavior: 'bottom',
         });
-        cy.get('[data-test="@radio-button-strict"]').click();
+        cy.get('[data-testid="@radio-button-strict"]').click();
         cy.getTestElement('@safety-checks-apply').click();
         cy.getTestElement('@prompts/confirm-on-device');
         cy.task('pressYes');
@@ -82,7 +82,7 @@ describe('safety_checks Warning For PromptTemporarily', () => {
         cy.getTestElement('@settings/device/safety-checks-button').click({
             scrollBehavior: 'bottom',
         });
-        cy.get('[data-test="@radio-button-strict"]').click();
+        cy.get('[data-testid="@radio-button-strict"]').click();
         cy.getTestElement('@safety-checks-apply').click();
         cy.getTestElement('@prompts/confirm-on-device');
         cy.task('pressYes');
@@ -92,7 +92,7 @@ describe('safety_checks Warning For PromptTemporarily', () => {
         cy.getTestElement('@settings/device/safety-checks-button').click({
             scrollBehavior: 'bottom',
         });
-        cy.get(`[data-test="@radio-button-prompt"]`).click();
+        cy.get(`[data-testid="@radio-button-prompt"]`).click();
         cy.getTestElement('@safety-checks-apply').click();
         cy.getTestElement('@prompts/confirm-on-device');
         cy.task('pressYes');

--- a/packages/suite-web/e2e/tests/wallet/add-account-types.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/add-account-types.test.ts
@@ -78,7 +78,7 @@ describe('Account types suite', () => {
                 // for a specific type of BTC acc, get the current number of accounts
                 cy.getTestElement(`@account-menu/${type}/group`)
                     .children()
-                    .not(`[data-test="@account-menu/account-item-skeleton"]`)
+                    .not(`[data-testid="@account-menu/account-item-skeleton"]`)
                     .then(specificAccounts => {
                         const numberOfAccounts1 = specificAccounts.length;
 
@@ -88,7 +88,7 @@ describe('Account types suite', () => {
                         // for a specific type of BTC acc, get the current number of accounts again for comparison
                         cy.getTestElement(`@account-menu/${type}/group`)
                             .children()
-                            .not(`[data-test="@account-menu/account-item-skeleton"]`)
+                            .not(`[data-testid="@account-menu/account-item-skeleton"]`)
                             .then(specificAccounts => {
                                 const numberOfAccounts2 = specificAccounts.length;
                                 expect(numberOfAccounts2).to.be.equal(numberOfAccounts1 + 1);
@@ -132,19 +132,19 @@ describe('Account types suite', () => {
         coins.forEach((coin: NetworkSymbol) => {
             onAccountsPage.applyCoinFilter(coin);
             // get the element containing all accounts
-            cy.get(`[type="normal"] [data-test*="@account-menu/${coin}/normal"]`).then(
+            cy.get(`[type="normal"] [data-testid*="@account-menu/${coin}/normal"]`).then(
                 currentAccounts => {
                     const numberOfAccounts1 = currentAccounts.length;
 
                     cy.getTestElement('@account-menu/add-account').should('be.visible').click();
                     cy.getTestElement('@modal').should('be.visible');
-                    cy.get(`[data-test="@settings/wallet/network/${coin}"]`)
+                    cy.get(`[data-testid="@settings/wallet/network/${coin}"]`)
                         .should('be.visible')
                         .click();
                     cy.getTestElement('@add-account').click();
                     cy.discoveryShouldFinish();
 
-                    cy.get(`[type="normal"] [data-test*="@account-menu/${coin}/normal"]`).then(
+                    cy.get(`[type="normal"] [data-testid*="@account-menu/${coin}/normal"]`).then(
                         newAccounts => {
                             const numberOfAccounts2 = newAccounts.length;
                             expect(numberOfAccounts2).to.be.equal(numberOfAccounts1 + 1);

--- a/packages/suite/src/components/backup/AfterBackupCheckboxes.tsx
+++ b/packages/suite/src/components/backup/AfterBackupCheckboxes.tsx
@@ -19,21 +19,21 @@ export const AfterBackupCheckboxes = () => {
     return (
         <CheckboxWrapper>
             <CheckItem
-                data-test="@backup/check-item/wrote-seed-properly"
+                data-testid="@backup/check-item/wrote-seed-properly"
                 onClick={() => dispatch(toggleCheckboxByKey('wrote-seed-properly'))}
                 title={<Translation id="TR_BACKUP_CHECKBOX_1_TITLE" />}
                 description={<Translation id="TR_BACKUP_CHECKBOX_1_DESCRIPTION" />}
                 isChecked={isChecked('wrote-seed-properly')}
             />
             <CheckItem
-                data-test="@backup/check-item/made-no-digital-copy"
+                data-testid="@backup/check-item/made-no-digital-copy"
                 onClick={() => dispatch(toggleCheckboxByKey('made-no-digital-copy'))}
                 title={<Translation id="TR_BACKUP_CHECKBOX_2_TITLE" />}
                 description={<Translation id="TR_BACKUP_CHECKBOX_2_DESCRIPTION" />}
                 isChecked={isChecked('made-no-digital-copy')}
             />
             <CheckItem
-                data-test="@backup/check-item/will-hide-seed"
+                data-testid="@backup/check-item/will-hide-seed"
                 onClick={() => dispatch(toggleCheckboxByKey('will-hide-seed'))}
                 title={<Translation id="TR_BACKUP_CHECKBOX_3_TITLE" />}
                 description={<Translation id="TR_BACKUP_CHECKBOX_3_DESCRIPTION" />}

--- a/packages/suite/src/components/backup/BackupSeedCard.tsx
+++ b/packages/suite/src/components/backup/BackupSeedCard.tsx
@@ -85,7 +85,7 @@ interface BackupSeedCardProps {
     icon: IconProps['icon'];
     isChecked: boolean;
     onClick: () => void;
-    ['data-test']: string;
+    ['data-testid']: string;
 }
 
 export const BackupSeedCard = ({
@@ -93,7 +93,7 @@ export const BackupSeedCard = ({
     icon,
     isChecked,
     onClick,
-    'data-test': dataTest,
+    'data-testid': dataTest,
 }: BackupSeedCardProps) => {
     const theme = useTheme();
 
@@ -103,7 +103,7 @@ export const BackupSeedCard = ({
     };
 
     return (
-        <Container forceElevation={2} $checked={isChecked} data-test={dataTest}>
+        <Container forceElevation={2} $checked={isChecked} data-testid={dataTest}>
             <Content>
                 <IconWrapper>
                     <Icon icon={icon} color={theme.iconDefault} />

--- a/packages/suite/src/components/backup/BackupSeedCards.tsx
+++ b/packages/suite/src/components/backup/BackupSeedCards.tsx
@@ -77,7 +77,7 @@ export const BackupSeedCards = () => {
                 {items.map(item => (
                     <StyledBackupSeedCard
                         // TODO: change data-test, checkbox keys to something more generic, independent of actual content
-                        data-test={`@backup/check-item/${item.key}`}
+                        data-testid={`@backup/check-item/${item.key}`}
                         key={item.key}
                         onClick={() => dispatch(toggleCheckboxByKey(item.key))}
                         label={item.label}

--- a/packages/suite/src/components/backup/PreBackupCheckboxes.tsx
+++ b/packages/suite/src/components/backup/PreBackupCheckboxes.tsx
@@ -24,21 +24,21 @@ export const PreBackupCheckboxes = () => {
     return (
         <CheckboxWrapper>
             <CheckItem
-                data-test="@backup/check-item/has-enough-time"
+                data-testid="@backup/check-item/has-enough-time"
                 onClick={() => dispatch(toggleCheckboxByKey('has-enough-time'))}
                 title={<Translation id="TR_I_HAVE_ENOUGH_TIME_TO_DO" />}
                 description={<Translation id="TR_ONCE_YOU_BEGIN_THIS_PROCESS" />}
                 isChecked={isChecked('has-enough-time')}
             />
             <CheckItem
-                data-test="@backup/check-item/is-in-private"
+                data-testid="@backup/check-item/is-in-private"
                 onClick={() => dispatch(toggleCheckboxByKey('is-in-private'))}
                 title={<Translation id="TR_I_AM_IN_SAFE_PRIVATE_OR" />}
                 description={<Translation id="TR_MAKE_SURE_NO_ONE_CAN_PEEK" />}
                 isChecked={isChecked('is-in-private')}
             />
             <CheckItem
-                data-test="@backup/check-item/understands-what-seed-is"
+                data-testid="@backup/check-item/understands-what-seed-is"
                 onClick={() => dispatch(toggleCheckboxByKey('understands-what-seed-is'))}
                 title={<Translation id="TR_I_UNDERSTAND_SEED_IS_IMPORTANT" />}
                 description={<Translation id="TR_BACKUP_SEED_IS_ULTIMATE" />}

--- a/packages/suite/src/components/firmware/Buttons/FirmwareContinueButton.tsx
+++ b/packages/suite/src/components/firmware/Buttons/FirmwareContinueButton.tsx
@@ -8,7 +8,7 @@ const StyledButton = styled(Button)`
 `;
 
 export const FirmwareContinueButton = (props: Omit<ButtonProps, 'children'>) => (
-    <StyledButton {...props} data-test="@firmware/continue-button">
+    <StyledButton {...props} data-testid="@firmware/continue-button">
         <Translation id="TR_CONTINUE" />
     </StyledButton>
 );

--- a/packages/suite/src/components/firmware/Buttons/FirmwareInstallButton.tsx
+++ b/packages/suite/src/components/firmware/Buttons/FirmwareInstallButton.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'src/hooks/suite';
 const InstallButtonCommon = (
     props: Omit<ButtonProps, 'children'> & { children?: React.ReactNode },
 ) => (
-    <Button {...props} data-test="@firmware/install-button">
+    <Button {...props} data-testid="@firmware/install-button">
         {props.children || <Translation id="TR_INSTALL" />}
     </Button>
 );

--- a/packages/suite/src/components/firmware/Buttons/FirmwareRetryButton.tsx
+++ b/packages/suite/src/components/firmware/Buttons/FirmwareRetryButton.tsx
@@ -4,7 +4,7 @@ import { Button, ButtonProps } from '@trezor/components';
 import { Translation } from 'src/components/suite';
 
 export const FirmwareRetryButton = (props: Omit<ButtonProps, 'children'>) => (
-    <Button {...props} data-test="@firmware/retry-button">
+    <Button {...props} data-testid="@firmware/retry-button">
         <Translation id="TR_RETRY" />
     </Button>
 );

--- a/packages/suite/src/components/firmware/CheckSeedStep.tsx
+++ b/packages/suite/src/components/firmware/CheckSeedStep.tsx
@@ -129,7 +129,7 @@ export const CheckSeedStep = ({ onClose, onSuccess, willBeWiped }: CheckSeedStep
                 <FirmwareButtonsRow withCancelButton={willBeWiped} onClose={onClose}>
                     <Button
                         onClick={onSuccess}
-                        data-test="@firmware/confirm-seed-button"
+                        data-testid="@firmware/confirm-seed-button"
                         isDisabled={!device?.connected || !isChecked}
                     >
                         <Translation id={willBeWiped ? 'TR_WIPE_AND_REINSTALL' : 'TR_CONTINUE'} />
@@ -147,7 +147,7 @@ export const CheckSeedStep = ({ onClose, onSuccess, willBeWiped }: CheckSeedStep
             <StyledCheckbox
                 isChecked={isChecked}
                 onClick={handleCheckboxClick}
-                data-test="@firmware/confirm-seed-checkbox"
+                data-testid="@firmware/confirm-seed-checkbox"
             >
                 {checkbox}
             </StyledCheckbox>

--- a/packages/suite/src/components/firmware/FirmwareInitial.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInitial.tsx
@@ -343,7 +343,7 @@ export const FirmwareInitial = ({
                             goToNextStep();
                             updateAnalytics({ firmware: 'skip' });
                         }}
-                        data-test="@firmware/skip-button"
+                        data-testid="@firmware/skip-button"
                     >
                         <Translation id="TR_SKIP_UPDATE" />
                     </OnboardingButtonSkip>

--- a/packages/suite/src/components/firmware/FirmwareInstallation.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInstallation.tsx
@@ -63,7 +63,11 @@ export const FirmwareInstallation = ({
         }
         if (status === 'done') {
             return (
-                <Button variant="primary" onClick={onSuccess} data-test="@firmware/continue-button">
+                <Button
+                    variant="primary"
+                    onClick={onSuccess}
+                    data-testid="@firmware/continue-button"
+                >
                     <Translation id={standaloneFwUpdate ? 'TR_CLOSE' : 'TR_CONTINUE'} />
                 </Button>
             );

--- a/packages/suite/src/components/firmware/FirmwareOffer.tsx
+++ b/packages/suite/src/components/firmware/FirmwareOffer.tsx
@@ -82,7 +82,7 @@ export const FirmwareOffer = ({ customFirmware, targetFirmwareType }: FirmwareOf
     const futureFirmwareType = getSuiteFirmwareTypeString(targetFirmwareType);
 
     const nextVersionElement = (
-        <Version $isNew data-test="@firmware/offer-version/new">
+        <Version $isNew data-testid="@firmware/offer-version/new">
             {futureFirmwareType ? translationString(futureFirmwareType) : ''}
             {nextVersion ? ` ${nextVersion}` : ''}
             {!customFirmware && useDevkit ? ' DEVKIT' : ''}

--- a/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
+++ b/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
@@ -113,14 +113,19 @@ interface ReconnectStepProps {
     order?: number;
     active: boolean;
     children: ReactNode;
-    dataTest: string;
+    'data-testid'?: string;
 }
 
-const ReconnectStep = ({ order, active, dataTest, children }: ReconnectStepProps) => (
+const ReconnectStep = ({
+    order,
+    active,
+    'data-testid': dataTest,
+    children,
+}: ReconnectStepProps) => (
     <BulletPointWrapper>
         {order && <BulletPointNumber $active={active}>{order}</BulletPointNumber>}
 
-        <BulletPointText $active={active} data-test={active ? dataTest : undefined}>
+        <BulletPointText $active={active} data-testid={active ? dataTest : undefined}>
             {children}
         </BulletPointText>
     </BulletPointWrapper>
@@ -251,7 +256,7 @@ export const ReconnectDevicePrompt = ({ onClose, onSuccess }: ReconnectDevicePro
         >
             {isAbortable && <StyledAbortButton onAbort={onClose} />}
 
-            <Wrapper data-test="@firmware/reconnect-device">
+            <Wrapper data-testid="@firmware/reconnect-device">
                 {!isRebootDone && (
                     <RebootDeviceGraphics
                         device={uiEvent?.payload.device}
@@ -272,7 +277,7 @@ export const ReconnectDevicePrompt = ({ onClose, onSuccess }: ReconnectDevicePro
                                     <ReconnectStep
                                         order={1}
                                         active={rebootPhase !== 'disconnected'}
-                                        dataTest="@firmware/disconnect-message"
+                                        data-testid="@firmware/disconnect-message"
                                     >
                                         <Translation id="TR_DISCONNECT_YOUR_DEVICE" />
                                     </ReconnectStep>
@@ -281,7 +286,7 @@ export const ReconnectDevicePrompt = ({ onClose, onSuccess }: ReconnectDevicePro
                                     <ReconnectStep
                                         order={2}
                                         active={rebootPhase === 'disconnected'}
-                                        dataTest="@firmware/connect-in-bootloader-message"
+                                        data-testid="@firmware/connect-in-bootloader-message"
                                     >
                                         <Translation id={getSecondStep()} />
                                     </ReconnectStep>
@@ -298,7 +303,7 @@ export const ReconnectDevicePrompt = ({ onClose, onSuccess }: ReconnectDevicePro
                         </>
                     ) : (
                         <>
-                            <Button onClick={onSuccess} data-test="@firmware/install-button">
+                            <Button onClick={onSuccess} data-testid="@firmware/install-button">
                                 <Translation id="TR_INSTALL" />
                             </Button>
                         </>

--- a/packages/suite/src/components/guide/Feedback.tsx
+++ b/packages/suite/src/components/guide/Feedback.tsx
@@ -237,9 +237,9 @@ export const Feedback = ({ type }: FeedbackProps) => {
                         <Headline>
                             <Translation id="TR_GUIDE_FEEDBACK_CATEGORY_HEADLINE" />
                         </Headline>
-                        <SelectWrapper data-test="@guide/feedback/suggestion-dropdown">
+                        <SelectWrapper data-testid="@guide/feedback/suggestion-dropdown">
                             <Select
-                                data-test="@guide/feedback/suggestion-dropdown/select"
+                                data-testid="@guide/feedback/suggestion-dropdown/select"
                                 isSearchable={false}
                                 defaultValue={category && categoryToOption(category)}
                                 options={Object.keys(feedbackCategories).map(category =>
@@ -266,7 +266,7 @@ export const Feedback = ({ type }: FeedbackProps) => {
                                     key={item.id}
                                     $selected={rating?.id === item.id}
                                     onClick={() => setRating(item)}
-                                    data-test={`@guide/feedback/suggestion/${item.id}`}
+                                    data-testid={`@guide/feedback/suggestion/${item.id}`}
                                 >
                                     {item.value}
                                 </RatingItem>
@@ -292,7 +292,7 @@ export const Feedback = ({ type }: FeedbackProps) => {
                         setDescription(e.target.value)
                     }
                     characterCount
-                    data-test="@guide/feedback/suggestion-form"
+                    data-testid="@guide/feedback/suggestion-form"
                     maxLength={MESSAGE_CHARACTER_LIMIT}
                 />
 
@@ -303,7 +303,7 @@ export const Feedback = ({ type }: FeedbackProps) => {
                         (type === 'SUGGESTION' && rating === undefined) ||
                         (type === 'BUG' && category === undefined)
                     }
-                    data-test="@guide/feedback/submit-button"
+                    data-testid="@guide/feedback/submit-button"
                 >
                     <Translation id="TR_GUIDE_FEEDBACK_SEND_REPORT" />
                 </Submit>

--- a/packages/suite/src/components/guide/Guide.tsx
+++ b/packages/suite/src/components/guide/Guide.tsx
@@ -85,7 +85,7 @@ export const Guide = () => {
             <FeedbackBorder />
             <FeedbackLinkWrapper>
                 <FeedbackButton
-                    data-test="@guide/button-feedback"
+                    data-testid="@guide/button-feedback"
                     onClick={handleFeedbackButtonClick}
                 >
                     <Icon icon="USERS" size={24} color={theme.iconOnTertiary} />

--- a/packages/suite/src/components/guide/GuideButton.tsx
+++ b/packages/suite/src/components/guide/GuideButton.tsx
@@ -39,7 +39,7 @@ export const GuideButton = () => {
     return (
         <FreeFocusInside>
             <Wrapper
-                data-test="@guide/button-open"
+                data-testid="@guide/button-open"
                 onClick={openGuide}
                 $isGuideOpen={isGuideOpen}
                 $elevation={elevation}

--- a/packages/suite/src/components/guide/GuideCategories.tsx
+++ b/packages/suite/src/components/guide/GuideCategories.tsx
@@ -35,7 +35,7 @@ export const GuideCategories = ({ node, label }: GuideCategoriesProps) => {
     return (
         <Section>
             {label && <SectionHeading>{label}</SectionHeading>}
-            <Nodes data-test="@guide/nodes">
+            <Nodes data-testid="@guide/nodes">
                 {node.children.map(child => (
                     <GuideNode key={child.id} node={child} />
                 ))}

--- a/packages/suite/src/components/guide/GuideCategory.tsx
+++ b/packages/suite/src/components/guide/GuideCategory.tsx
@@ -63,7 +63,7 @@ export const GuideCategory = () => {
                         <SectionHeading>
                             <Translation id="TR_GUIDE_ARTICLES" />
                         </SectionHeading>
-                        <Nodes data-test="@guide/nodes">
+                        <Nodes data-testid="@guide/nodes">
                             {pages.map(page => (
                                 <GuideNode key={page.id} node={page} />
                             ))}

--- a/packages/suite/src/components/guide/GuideHeader.tsx
+++ b/packages/suite/src/components/guide/GuideHeader.tsx
@@ -88,10 +88,10 @@ export const GuideHeader = ({ back, label, useBreadcrumb }: GuideHeaderProps) =>
                         icon="ARROW_LEFT_LONG"
                         onClick={goBack}
                         variant="tertiary"
-                        data-test="@guide/button-back"
+                        data-testid="@guide/button-back"
                     />
 
-                    {label && <Label data-test="@guide/label">{label}</Label>}
+                    {label && <Label data-testid="@guide/label">{label}</Label>}
                 </>
             )}
             {!useBreadcrumb && !back && label && <MainLabel>{label}</MainLabel>}
@@ -102,7 +102,7 @@ export const GuideHeader = ({ back, label, useBreadcrumb }: GuideHeaderProps) =>
                 icon="ARROW_RIGHT_LINE"
                 variant="tertiary"
                 onClick={handleClose}
-                data-test="@guide/button-close"
+                data-testid="@guide/button-close"
                 size="medium"
             />
         </HeaderWrapper>

--- a/packages/suite/src/components/guide/GuideNode.tsx
+++ b/packages/suite/src/components/guide/GuideNode.tsx
@@ -96,7 +96,7 @@ export const GuideNode = ({ node, description }: GuideNodeProps) => {
 
     if (node.type === 'page') {
         return (
-            <PageNodeButton data-test={`@guide/node${node.id}`} onClick={navigateToNode}>
+            <PageNodeButton data-testid={`@guide/node${node.id}`} onClick={navigateToNode}>
                 <PageNodeButtonIcon icon="ARTICLE" size={20} color={theme.TYPE_LIGHT_GREY} />
                 {label}
             </PageNodeButton>
@@ -105,7 +105,7 @@ export const GuideNode = ({ node, description }: GuideNodeProps) => {
 
     if (node.type === 'category') {
         return (
-            <CategoryNodeButton data-test={`@guide/category${node.id}`} onClick={navigateToNode}>
+            <CategoryNodeButton data-testid={`@guide/category${node.id}`} onClick={navigateToNode}>
                 {node.image && <Image src={resolveStaticPath(node.image)} />}
                 {label}
             </CategoryNodeButton>

--- a/packages/suite/src/components/guide/GuideRouter.tsx
+++ b/packages/suite/src/components/guide/GuideRouter.tsx
@@ -75,7 +75,7 @@ export const GuideRouter = () => {
                 <AnimatePresence>
                     {isGuideOpen && (
                         <MotionGuide
-                            data-test="@guide/panel"
+                            data-testid="@guide/panel"
                             initial={{
                                 width: isFirstRender ? variables.LAYOUT_SIZE.GUIDE_PANEL_WIDTH : 0,
                             }}

--- a/packages/suite/src/components/guide/GuideSearch.tsx
+++ b/packages/suite/src/components/guide/GuideSearch.tsx
@@ -81,11 +81,11 @@ export const GuideSearch = ({ pageRoot, setSearchActive }: GuideSearchProps) => 
                 showClearButton="always"
                 onClear={() => setQuery('')}
                 innerAddon={loading ? <Spinner size={24} /> : <Icon icon="SEARCH" size={24} />}
-                data-test="@guide/search"
+                data-testid="@guide/search"
             />
 
             {searchResult.length ? (
-                <PageFoundList data-test="@guide/search/results">
+                <PageFoundList data-testid="@guide/search/results">
                     {searchResult.map(({ page, preview }) => (
                         <GuideNode
                             key={page.id}
@@ -97,7 +97,7 @@ export const GuideSearch = ({ pageRoot, setSearchActive }: GuideSearchProps) => 
             ) : (
                 query &&
                 !loading && (
-                    <NoResults data-test="@guide/search/no-results">
+                    <NoResults data-testid="@guide/search/no-results">
                         <Translation id="TR_ACCOUNT_SEARCH_NO_RESULTS" />
                     </NoResults>
                 )

--- a/packages/suite/src/components/guide/HeaderBreadcrumb.tsx
+++ b/packages/suite/src/components/guide/HeaderBreadcrumb.tsx
@@ -106,7 +106,7 @@ export const HeaderBreadcrumb = () => {
                         navigateToGuideDashboard();
                     }
                 }}
-                data-test="@guide/header-breadcrumb/previous-category-link"
+                data-testid="@guide/header-breadcrumb/previous-category-link"
             >
                 {grandParentNode ? (
                     getNodeTitle(grandParentNode, language)
@@ -123,7 +123,7 @@ export const HeaderBreadcrumb = () => {
                         navigateToCategory(parentNode);
                     }
                 }}
-                data-test="@guide/header-breadcrumb/category-link"
+                data-testid="@guide/header-breadcrumb/category-link"
             >
                 {parentNode && getNodeTitle(parentNode, language)}
             </CategoryLink>

--- a/packages/suite/src/components/guide/OpenGuideFromTooltip.tsx
+++ b/packages/suite/src/components/guide/OpenGuideFromTooltip.tsx
@@ -26,16 +26,19 @@ const OpenGuideLink = styled.span`
 
 type OpenGuideFromTooltipProps = {
     id: string;
-    dataTest?: string;
+    'data-testid'?: string;
 };
 
-export const OpenGuideFromTooltip = ({ id, dataTest }: OpenGuideFromTooltipProps) => {
+export const OpenGuideFromTooltip = ({
+    id,
+    'data-testid': dataTest,
+}: OpenGuideFromTooltipProps) => {
     const { openNodeById } = useGuideOpenNode();
     const theme = useTheme();
 
     return (
         <OpenGuideLink
-            data-test={dataTest}
+            data-testid={dataTest}
             onClick={(e: MouseEvent<any>) => {
                 e.stopPropagation();
                 openNodeById(id);

--- a/packages/suite/src/components/guide/SupportFeedbackSelection.tsx
+++ b/packages/suite/src/components/guide/SupportFeedbackSelection.tsx
@@ -147,7 +147,7 @@ export const SupportFeedbackSelection = () => {
                     <SectionButton
                         onClick={handleBugButtonClick}
                         $hasBackground
-                        data-test="@guide/feedback/bug"
+                        data-testid="@guide/feedback/bug"
                     >
                         <ButtonImage
                             src={resolveStaticPath('images/png/recovery@2x.png')}
@@ -167,7 +167,7 @@ export const SupportFeedbackSelection = () => {
                     <SectionButton
                         onClick={handleFeedbackButtonClick}
                         $hasBackground
-                        data-test="@guide/feedback/suggestion"
+                        data-testid="@guide/feedback/suggestion"
                     >
                         <ButtonImage
                             src={resolveStaticPath('images/png/understand@2x.png')}
@@ -192,7 +192,7 @@ export const SupportFeedbackSelection = () => {
                     </SectionHeader>
 
                     <StyledLink href={TREZOR_FORUM_URL} variant="nostyle">
-                        <SectionButton data-test="@guide/forum">
+                        <SectionButton data-testid="@guide/forum">
                             <Label>
                                 <LabelHeadline>
                                     <Translation id="TR_GUIDE_FORUM" />
@@ -206,7 +206,7 @@ export const SupportFeedbackSelection = () => {
                     </StyledLink>
 
                     <StyledLink href={TREZOR_SUPPORT_URL} variant="nostyle">
-                        <SectionButton data-test="@guide/support">
+                        <SectionButton data-testid="@guide/support">
                             <Label>
                                 <LabelHeadline>
                                     <Translation id="TR_GUIDE_SUPPORT" />
@@ -218,7 +218,7 @@ export const SupportFeedbackSelection = () => {
                 </Section>
 
                 <Details>
-                    <DetailItem data-test="@guide/support/version">
+                    <DetailItem data-testid="@guide/support/version">
                         <Translation id="TR_APP" />
                         :&nbsp;
                         {!isDevEnv && appUpToDate ? (

--- a/packages/suite/src/components/onboarding/Buttons/OnboardingButtonBack.tsx
+++ b/packages/suite/src/components/onboarding/Buttons/OnboardingButtonBack.tsx
@@ -3,7 +3,7 @@ import { Translation } from 'src/components/suite';
 
 export const OnboardingButtonBack = (props: Omit<ButtonProps, 'children'>) => (
     <Button
-        data-test="@onboarding/back-button"
+        data-testid="@onboarding/back-button"
         variant="tertiary"
         size="small"
         icon="ARROW_LEFT"

--- a/packages/suite/src/components/onboarding/Buttons/OnboardingButtonSkip.tsx
+++ b/packages/suite/src/components/onboarding/Buttons/OnboardingButtonSkip.tsx
@@ -11,7 +11,7 @@ const StyledSpan = styled.span`
 `;
 
 export const OnboardingButtonSkip = (props: HtmlHTMLAttributes<HTMLSpanElement>) => (
-    <StyledSpan data-test="@onboarding/skip-button" {...props}>
+    <StyledSpan data-testid="@onboarding/skip-button" {...props}>
         {props.children}
     </StyledSpan>
 );

--- a/packages/suite/src/components/onboarding/CollapsibleOnboardingCard.tsx
+++ b/packages/suite/src/components/onboarding/CollapsibleOnboardingCard.tsx
@@ -213,7 +213,7 @@ export const CollapsibleOnboardingCard = ({
             $withImage={!!image}
             $nested={nested}
             onClick={expandable && !expanded ? onToggle : undefined}
-            data-test="@components/collapsible-box"
+            data-testid="@components/collapsible-box"
             {...rest}
         >
             <motion.div

--- a/packages/suite/src/components/onboarding/OnboardingLayout.tsx
+++ b/packages/suite/src/components/onboarding/OnboardingLayout.tsx
@@ -144,7 +144,7 @@ export const OnboardingLayout = ({ children }: OnboardingLayoutProps) => {
             <Wrapper>
                 {bannerMessage && <MessageSystemBanner message={bannerMessage} />}
 
-                <Body data-test="@onboarding-layout/body">
+                <Body data-testid="@onboarding-layout/body">
                     <ScrollingWrapper>
                         <ModalContextProvider>
                             <ContentWrapper id="layout-scroll">

--- a/packages/suite/src/components/onboarding/OnboardingStepBox.tsx
+++ b/packages/suite/src/components/onboarding/OnboardingStepBox.tsx
@@ -82,7 +82,7 @@ export const OnboardingStepBox = ({
         <>
             <StyledBackdrop $show={isBackDropVisible} />
             {!disableConfirmWrapper && (
-                <WrapperWrapper data-test="@onboarding/confirm-on-device">
+                <WrapperWrapper data-testid="@onboarding/confirm-on-device">
                     {deviceModelInternal && (
                         <ConfirmWrapper>
                             <ConfirmOnDevice

--- a/packages/suite/src/components/onboarding/SkipStepConfirmation.tsx
+++ b/packages/suite/src/components/onboarding/SkipStepConfirmation.tsx
@@ -62,7 +62,7 @@ export const SkipStepConfirmation = ({ onCancel }: SkipStepConfirmationProps) =>
                     </Button>
                     <Button
                         variant="tertiary"
-                        data-test="@onboarding/skip-button-confirm"
+                        data-testid="@onboarding/skip-button-confirm"
                         onClick={handleSkipStepConfirm}
                     >
                         {text}

--- a/packages/suite/src/components/recovery/SelectRecoveryType.tsx
+++ b/packages/suite/src/components/recovery/SelectRecoveryType.tsx
@@ -12,7 +12,7 @@ export const SelectRecoveryType = ({ onSelect }: SelectRecoveryTypeProps) => (
             icon="SEED_SINGLE"
             heading={<Translation id="TR_BASIC_RECOVERY" />}
             description={<Translation id="TR_BASIC_RECOVERY_OPTION" />}
-            data-test="@recover/select-type/basic"
+            data-testid="@recover/select-type/basic"
         />
         <OptionsDivider />
         <OnboardingOption
@@ -20,7 +20,7 @@ export const SelectRecoveryType = ({ onSelect }: SelectRecoveryTypeProps) => (
             icon="SEED_SHAMIR"
             heading={<Translation id="TR_ADVANCED_RECOVERY" />}
             description={<Translation id="TR_ADVANCED_RECOVERY_OPTION" />}
-            data-test="@recover/select-type/advanced"
+            data-testid="@recover/select-type/advanced"
         />
     </OptionsWrapper>
 );

--- a/packages/suite/src/components/recovery/SelectWordCount.tsx
+++ b/packages/suite/src/components/recovery/SelectWordCount.tsx
@@ -19,7 +19,7 @@ export const SelectWordCount = ({ onSelect }: SelectWordCountProps) => (
                 onSelect(12);
             }}
             heading={<Translation id="TR_WORDS" values={{ count: '12' }} />}
-            data-test="@recover/select-count/12"
+            data-testid="@recover/select-count/12"
         />
         <OptionsDivider />
         <StyledOption
@@ -27,7 +27,7 @@ export const SelectWordCount = ({ onSelect }: SelectWordCountProps) => (
                 onSelect(18);
             }}
             heading={<Translation id="TR_WORDS" values={{ count: '18' }} />}
-            data-test="@recover/select-count/18"
+            data-testid="@recover/select-count/18"
         />
         <OptionsDivider />
         <StyledOption
@@ -35,7 +35,7 @@ export const SelectWordCount = ({ onSelect }: SelectWordCountProps) => (
                 onSelect(24);
             }}
             heading={<Translation id="TR_WORDS" values={{ count: '24' }} />}
-            data-test="@recover/select-count/24"
+            data-testid="@recover/select-count/24"
         />
     </OptionsWrapper>
 );

--- a/packages/suite/src/components/settings/DeviceBanner.tsx
+++ b/packages/suite/src/components/settings/DeviceBanner.tsx
@@ -56,7 +56,7 @@ export const DeviceBanner = ({ title, description }: DeviceBannerProps) => {
     const isWebUsbTransport = isWebUsb(transport);
 
     return (
-        <Wrapper data-test="@settings/device/disconnected-device-banner">
+        <Wrapper data-testid="@settings/device/disconnected-device-banner">
             <StyledLottieAnimation
                 type="CONNECT"
                 shape="CIRCLE"

--- a/packages/suite/src/components/settings/SettingsLayout.tsx
+++ b/packages/suite/src/components/settings/SettingsLayout.tsx
@@ -13,7 +13,7 @@ import { Translation } from 'src/components/suite';
 type SettingsLayoutProps = {
     title?: string;
     children?: ReactNode;
-    ['data-test']?: string;
+    ['data-testid']?: string;
 };
 
 const SettingsHeader = () => {
@@ -27,21 +27,21 @@ const SettingsHeader = () => {
                 id: 'settings-index',
                 title: <Translation id="TR_GENERAL" />,
                 position: 'primary',
-                'data-test': '@settings/menu/general',
+                'data-testid': '@settings/menu/general',
                 callback: () => dispatch(goto('settings-index', { preserveParams: true })),
             },
             {
                 id: 'settings-device',
                 title: <Translation id="TR_DEVICE" />,
                 position: 'primary',
-                'data-test': '@settings/menu/device',
+                'data-testid': '@settings/menu/device',
                 callback: () => dispatch(goto('settings-device', { preserveParams: true })),
             },
             {
                 id: 'settings-coins',
                 title: <Translation id="TR_COINS" />,
                 position: 'primary',
-                'data-test': '@settings/menu/wallet',
+                'data-testid': '@settings/menu/wallet',
                 callback: () => dispatch(goto('settings-coins', { preserveParams: true })),
             },
             {
@@ -49,7 +49,7 @@ const SettingsHeader = () => {
                 title: <Translation id="TR_DEBUG_SETTINGS" />,
                 position: 'primary',
                 isHidden: !isDebugModeActive,
-                'data-test': '@settings/menu/debug',
+                'data-testid': '@settings/menu/debug',
                 callback: () => dispatch(goto('settings-debug', { preserveParams: true })),
             },
         ],
@@ -64,13 +64,17 @@ const SettingsHeader = () => {
     );
 };
 
-export const SettingsLayout = ({ title, children, 'data-test': dataTest }: SettingsLayoutProps) => {
+export const SettingsLayout = ({
+    title,
+    children,
+    'data-testid': dataTest,
+}: SettingsLayoutProps) => {
     useLayout(title || 'Settings', SettingsHeader);
 
     const { isDiscoveryRunning } = useDiscovery();
 
     return (
-        <div data-test={dataTest}>
+        <div data-testid={dataTest}>
             <SettingsLoading isPresent={isDiscoveryRunning} />
             <>{children}</>
         </div>

--- a/packages/suite/src/components/settings/SettingsSectionItem.tsx
+++ b/packages/suite/src/components/settings/SettingsSectionItem.tsx
@@ -13,7 +13,7 @@ export const SettingsSectionItem = ({ anchorId, children }: SettingsSectionItemP
     const { anchorRef, shouldHighlight } = useAnchor(anchorId);
 
     return (
-        <SectionItem data-test={anchorId} ref={anchorRef} shouldHighlight={shouldHighlight}>
+        <SectionItem data-testid={anchorId} ref={anchorRef} shouldHighlight={shouldHighlight}>
             {children}
         </SectionItem>
     );

--- a/packages/suite/src/components/suite/AmountUnitSwitchWrapper.tsx
+++ b/packages/suite/src/components/suite/AmountUnitSwitchWrapper.tsx
@@ -57,7 +57,7 @@ export const AmountUnitSwitchWrapper = ({ symbol, children }: AmountUnitSwitchWr
         >
             <Container
                 onClick={handleToggleBitcoinAmountUnits}
-                data-test={`amount-unit-switch/${symbol}`}
+                data-testid={`amount-unit-switch/${symbol}`}
             >
                 {children}
             </Container>

--- a/packages/suite/src/components/suite/BundleLoader.tsx
+++ b/packages/suite/src/components/suite/BundleLoader.tsx
@@ -14,7 +14,7 @@ const LoaderWrapper = styled.div`
 `;
 
 export const BundleLoader = () => (
-    <LoaderWrapper data-test="@suite/bundle-loader">
+    <LoaderWrapper data-testid="@suite/bundle-loader">
         <Spinner size={64} isGrey={false} />
     </LoaderWrapper>
 );

--- a/packages/suite/src/components/suite/ChangeDeviceLabel.tsx
+++ b/packages/suite/src/components/suite/ChangeDeviceLabel.tsx
@@ -78,14 +78,14 @@ export const ChangeDeviceLabel = ({
                 placeholder={placeholder}
                 inputState={error ? 'error' : undefined}
                 onChange={handleChange}
-                data-test="@settings/device/label-input"
+                data-testid="@settings/device/label-input"
                 hasBottomPadding={false}
                 size={isVertical ? 'small' : 'large'}
             />
             <Button
                 onClick={handleClick}
                 isDisabled={isDisabled}
-                data-test="@settings/device/label-submit"
+                data-testid="@settings/device/label-submit"
                 size={isVertical ? 'small' : 'large'}
                 isFullWidth
             >

--- a/packages/suite/src/components/suite/CoinBalance.tsx
+++ b/packages/suite/src/components/suite/CoinBalance.tsx
@@ -11,6 +11,6 @@ export const CoinBalance = ({ value, symbol }: CoinBalanceProps) => (
         value={value}
         symbol={symbol}
         isBalance
-        data-test={`@wallet/coin-balance/value-${symbol}`}
+        data-testid={`@wallet/coin-balance/value-${symbol}`}
     />
 );

--- a/packages/suite/src/components/suite/CoinList/Coin.tsx
+++ b/packages/suite/src/components/suite/CoinList/Coin.tsx
@@ -188,7 +188,7 @@ export const Coin = ({
             $forceHover={forceHover}
             $hasSettings={!!onSettings}
             onClick={onToggle}
-            data-test={`@settings/wallet/network/${symbol}`}
+            data-testid={`@settings/wallet/network/${symbol}`}
             data-active={toggled}
         >
             <ImageWrapper>
@@ -210,7 +210,7 @@ export const Coin = ({
             <SettingsWrapper
                 onClick={onSettingsClick}
                 $toggled={toggled}
-                data-test={`@settings/wallet/network/${symbol}/advance`}
+                data-testid={`@settings/wallet/network/${symbol}/advance`}
             >
                 <Icon icon="SETTINGS" />
             </SettingsWrapper>

--- a/packages/suite/src/components/suite/ConnectDevicePrompt.tsx
+++ b/packages/suite/src/components/suite/ConnectDevicePrompt.tsx
@@ -140,7 +140,7 @@ export const ConnectDevicePrompt = ({
             initial={{ opacity: 0, y: -50 }}
             animate={{ opacity: 1, y: -0 }}
             transition={{ delay: 0.2, duration: 0.6, ease: motionEasing.enter }}
-            data-test="@connect-device-prompt"
+            data-testid="@connect-device-prompt"
         >
             <ElevationUp>
                 <ConnectImage connected={connected} showWarning={showWarning} />

--- a/packages/suite/src/components/suite/DeviceDisplay/DisplayChunks.tsx
+++ b/packages/suite/src/components/suite/DeviceDisplay/DisplayChunks.tsx
@@ -42,7 +42,7 @@ export const DisplayChunks = ({ isPixelType, address }: DisplayChunksProps) => {
                     <DeviceDisplayText
                         $isPixelType={isPixelType}
                         key={chunkIndex}
-                        data-test="chunk"
+                        data-testid="chunk"
                     >
                         {chunk}
                     </DeviceDisplayText>
@@ -54,7 +54,7 @@ export const DisplayChunks = ({ isPixelType, address }: DisplayChunksProps) => {
     const groupedChunks = groupByN(chunks, 4);
 
     return (
-        <ChunksContainer onCopy={handleOnCopy} data-test="@device-display/chunked-text">
+        <ChunksContainer onCopy={handleOnCopy} data-testid="@device-display/chunked-text">
             {showChunksInRows(groupedChunks)}
         </ChunksContainer>
     );

--- a/packages/suite/src/components/suite/DeviceDisplay/DisplayPaginatedText.tsx
+++ b/packages/suite/src/components/suite/DeviceDisplay/DisplayPaginatedText.tsx
@@ -96,7 +96,7 @@ export const DisplayPaginatedText = ({
                 return (
                     <Page
                         key={`page-${pageIndex}`}
-                        data-test={isFirstPage ? '@device-display/paginated-text' : undefined}
+                        data-testid={isFirstPage ? '@device-display/paginated-text' : undefined}
                     >
                         {page.rows.map((row, index) => (
                             <Row

--- a/packages/suite/src/components/suite/DeviceDisplay/DisplaySinglePageWrapText.tsx
+++ b/packages/suite/src/components/suite/DeviceDisplay/DisplaySinglePageWrapText.tsx
@@ -15,7 +15,10 @@ export const DisplaySinglePageWrapText = ({
     isPixelType,
     text,
 }: DisplaySinglePageWrapTextProps) => (
-    <DeviceDisplayText $isPixelType={isPixelType} data-test="@device-display/single-page-wrap-text">
+    <DeviceDisplayText
+        $isPixelType={isPixelType}
+        data-testid="@device-display/single-page-wrap-text"
+    >
         <TextWrapper $isPixelType={isPixelType}>{text}</TextWrapper>
     </DeviceDisplayText>
 );

--- a/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
+++ b/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
@@ -32,7 +32,7 @@ export interface FormattedCryptoAmountProps {
     signValue?: SignValue;
     disableHiddenPlaceholder?: boolean;
     isRawString?: boolean;
-    'data-test'?: string;
+    'data-testid'?: string;
     className?: string;
 }
 
@@ -43,7 +43,7 @@ export const FormattedCryptoAmount = ({
     signValue,
     disableHiddenPlaceholder,
     isRawString,
-    'data-test': dataTest,
+    'data-testid': dataTest,
     className,
 }: FormattedCryptoAmountProps) => {
     const locale = useSelector(selectLanguage);
@@ -89,7 +89,7 @@ export const FormattedCryptoAmount = ({
     const content = (
         <Container className={className}>
             {!!signValue && <Sign value={signValue} />}
-            <Value data-test={dataTest}>{formattedValue}</Value>
+            <Value data-testid={dataTest}>{formattedValue}</Value>
             {formattedSymbol && <BlurUrls text={'\u00A0' + formattedSymbol} />}
         </Container>
     );

--- a/packages/suite/src/components/suite/HiddenPlaceholder.tsx
+++ b/packages/suite/src/components/suite/HiddenPlaceholder.tsx
@@ -27,7 +27,7 @@ export interface HiddenPlaceholderProps {
     enforceIntensity?: number;
     children: ReactNode;
     className?: string;
-    ['data-test']?: string;
+    ['data-testid']?: string;
 }
 
 export const HiddenPlaceholder = ({
@@ -60,7 +60,7 @@ export const HiddenPlaceholder = ({
             $intensity={enforceIntensity !== undefined ? enforceIntensity : automaticIntensity}
             className={className}
             ref={ref}
-            data-test={rest['data-test']}
+            data-testid={rest['data-testid']}
         >
             {children}
         </Wrapper>

--- a/packages/suite/src/components/suite/HomescreenGallery.tsx
+++ b/packages/suite/src/components/suite/HomescreenGallery.tsx
@@ -72,7 +72,7 @@ export const HomescreenGallery = ({ onConfirm }: HomescreenGalleryProps) => {
                 <BackgroundGalleryWrapper>
                     {homescreens[deviceModelInternal].map(image => (
                         <BackgroundImageBW64x128
-                            data-test={`@modal/gallery/bw_64x128/${image}`}
+                            data-testid={`@modal/gallery/bw_64x128/${image}`}
                             key={image}
                             id={image}
                             onClick={e =>
@@ -87,7 +87,7 @@ export const HomescreenGallery = ({ onConfirm }: HomescreenGalleryProps) => {
                 <BackgroundGalleryWrapper>
                     {homescreens[deviceModelInternal].map(image => (
                         <BackgroundImageColor240x240
-                            data-test={`@modal/gallery/color_240x240/${image}`}
+                            data-testid={`@modal/gallery/color_240x240/${image}`}
                             key={image}
                             id={image}
                             onClick={e =>

--- a/packages/suite/src/components/suite/Loading.tsx
+++ b/packages/suite/src/components/suite/Loading.tsx
@@ -15,7 +15,7 @@ type LoadingProps = {
 };
 
 export const Loading = ({ className }: LoadingProps) => (
-    <LoaderWrapper data-test="@suite/loading" className={className}>
+    <LoaderWrapper data-testid="@suite/loading" className={className}>
         <Spinner size={80} isGrey={false} hasStartAnimation={true} />
     </LoaderWrapper>
 );

--- a/packages/suite/src/components/suite/NotificationCard.tsx
+++ b/packages/suite/src/components/suite/NotificationCard.tsx
@@ -27,7 +27,7 @@ interface NotificationCardProps {
     isLoading?: boolean;
     button?: ButtonType;
     className?: string;
-    ['data-test']?: string;
+    ['data-testid']?: string;
     icon?: IconType;
 }
 
@@ -148,7 +148,7 @@ export const NotificationCard = ({
             $variant={variant}
             className={className}
             $elevation={elevation}
-            data-test={props['data-test']}
+            data-testid={props['data-testid']}
         >
             <ElevationUp>
                 <IconWrapper>

--- a/packages/suite/src/components/suite/PinMatrix/PinInput/PinInput.tsx
+++ b/packages/suite/src/components/suite/PinMatrix/PinInput/PinInput.tsx
@@ -143,7 +143,7 @@ export const PinInput = ({ isSubmitting, onPinSubmit }: PinInputProps) => {
     }, [onPinAdd, onPinBackspace, submit]);
 
     return (
-        <Wrapper data-test="@pin">
+        <Wrapper data-testid="@pin">
             <InputWrapper>
                 <InputPin value={pin} onDeleteClick={() => onPinBackspace()} />
             </InputWrapper>
@@ -152,19 +152,19 @@ export const PinInput = ({ isSubmitting, onPinSubmit }: PinInputProps) => {
                     $blur={isSubmitting}
                     data-value="7"
                     onClick={() => onPinAdd('7')}
-                    data-test="@pin/input/7"
+                    data-testid="@pin/input/7"
                 />
                 <StyledPinButton
                     $blur={isSubmitting}
                     data-value="8"
                     onClick={() => onPinAdd('8')}
-                    data-test="@pin/input/8"
+                    data-testid="@pin/input/8"
                 />
                 <StyledPinButton
                     $blur={isSubmitting}
                     data-value="9"
                     onClick={() => onPinAdd('9')}
-                    data-test="@pin/input/9"
+                    data-testid="@pin/input/9"
                 />
             </PinRow>
             <PinRow>
@@ -172,19 +172,19 @@ export const PinInput = ({ isSubmitting, onPinSubmit }: PinInputProps) => {
                     $blur={isSubmitting}
                     data-value="4"
                     onClick={() => onPinAdd('4')}
-                    data-test="@pin/input/4"
+                    data-testid="@pin/input/4"
                 />
                 <StyledPinButton
                     $blur={isSubmitting}
                     data-value="5"
                     onClick={() => onPinAdd('5')}
-                    data-test="@pin/input/5"
+                    data-testid="@pin/input/5"
                 />
                 <StyledPinButton
                     $blur={isSubmitting}
                     data-value="6"
                     onClick={() => onPinAdd('6')}
-                    data-test="@pin/input/6"
+                    data-testid="@pin/input/6"
                 />
             </PinRow>
             <PinRow>
@@ -192,20 +192,20 @@ export const PinInput = ({ isSubmitting, onPinSubmit }: PinInputProps) => {
                     $blur={isSubmitting}
                     data-value="1"
                     onClick={() => onPinAdd('1')}
-                    data-test="@pin/input/1"
+                    data-testid="@pin/input/1"
                 />
 
                 <StyledPinButton
                     $blur={isSubmitting}
                     data-value="2"
                     onClick={() => onPinAdd('2')}
-                    data-test="@pin/input/2"
+                    data-testid="@pin/input/2"
                 />
                 <StyledPinButton
                     $blur={isSubmitting}
                     data-value="3"
                     onClick={() => onPinAdd('3')}
-                    data-test="@pin/input/3"
+                    data-testid="@pin/input/3"
                 />
             </PinRow>
 
@@ -216,7 +216,7 @@ export const PinInput = ({ isSubmitting, onPinSubmit }: PinInputProps) => {
                     isDisabled={isSubmitting}
                     isFullWidth
                     onClick={submit}
-                    data-test="@pin/submit-button"
+                    data-testid="@pin/submit-button"
                 >
                     <Translation id={getTranslationId()} />
                 </Button>

--- a/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
+++ b/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
@@ -9,7 +9,7 @@ import { DeepPartial } from '@trezor/type-utils';
 
 // render only Translation.id in data-test attribute
 jest.mock('src/components/suite/Translation', () => ({
-    Translation: ({ id }: any) => <div data-test={id}>{id}</div>,
+    Translation: ({ id }: any) => <div data-testid={id}>{id}</div>,
 }));
 
 // @trezor/connect fetching ethereum definitions
@@ -22,17 +22,17 @@ jest.mock('cross-fetch', () => ({
 
 // jest.mock('@firmware-components/ReconnectDevicePrompt', () => ({
 //     __esModule: true, // export as module
-//     default: ({ children }: any) => <div data-test="box">{children}</div>,
+//     default: ({ children }: any) => <div data-testid="box">{children}</div>,
 // }));
 // jest.mock('src/components/onboarding/DeviceAnimation', () => ({
 //     __esModule: true, // export as module
-//     default: ({ children }: any) => <div data-test="box">{children}</div>,
+//     default: ({ children }: any) => <div data-testid="box">{children}</div>,
 // }));
 // do not render animations
 // jest.mock('lottie-react', () => ({
 //     // Lottie: ({ trezorVersion }: any) => <div>{trezorVersion}</div>,
 //     __esModule: true, // export as module
-//     default: ({ trezorVersion }: any) => <div data-test="lottie-image">{trezorVersion}</div>,
+//     default: ({ trezorVersion }: any) => <div data-testid="lottie-image">{trezorVersion}</div>,
 // }));
 // jest.mock('react-use/lib/useMeasure', () => ({
 //     // Lottie: ({ trezorVersion }: any) => <div>{trezorVersion}</div>,

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceAcquire.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceAcquire.tsx
@@ -19,7 +19,7 @@ export const DeviceAcquire = () => {
     };
 
     const ctaButton = (
-        <Button data-test="@device-acquire" isLoading={isDeviceLocked} onClick={handleClick}>
+        <Button data-testid="@device-acquire" isLoading={isDeviceLocked} onClick={handleClick}>
             <Translation id="TR_ACQUIRE_DEVICE" />
         </Button>
     );

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceConnect.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceConnect.tsx
@@ -32,8 +32,8 @@ export const DeviceConnect = ({ isWebUsbTransport }: DeviceConnectProps) => {
         <TroubleshootingTips
             label={<Translation id="TR_STILL_DONT_SEE_YOUR_TREZOR" />}
             items={items}
-            cta={isWebUsbTransport ? <WebUsbButton data-test="@webusb-button" /> : undefined}
-            data-test="@connect-device-prompt/no-device-detected"
+            cta={isWebUsbTransport ? <WebUsbButton data-testid="@webusb-button" /> : undefined}
+            data-testid="@connect-device-prompt/no-device-detected"
         />
     );
 };

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceInitialize.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceInitialize.tsx
@@ -22,7 +22,7 @@ export const DeviceInitialize = () => {
         <TroubleshootingTips
             label={<Translation id="TR_DEVICE_NOT_INITIALIZED" />}
             cta={
-                <Button data-test="@button/go-to-onboarding" onClick={handleCtaClick}>
+                <Button data-testid="@button/go-to-onboarding" onClick={handleCtaClick}>
                     <Translation id="TR_GO_TO_ONBOARDING" />
                 </Button>
             }

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUnreadable.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUnreadable.tsx
@@ -30,7 +30,7 @@ const UdevWeb = () => (
                 description: <UdevDownload />,
             },
         ]}
-        data-test="@connect-device-prompt/unreadable-udev"
+        data-testid="@connect-device-prompt/unreadable-udev"
     />
 );
 
@@ -66,7 +66,7 @@ const UdevDesktop = () => {
                 opened={false}
                 label={<Translation id="TR_RECONNECT_IN_NORMAL" />}
                 items={[]}
-                data-test="@connect-device-prompt/unreadable-udev"
+                data-testid="@connect-device-prompt/unreadable-udev"
             />
         );
     }
@@ -92,7 +92,7 @@ const UdevDesktop = () => {
                     noBullet: true,
                 },
             ]}
-            data-test="@connect-device-prompt/unreadable-udev"
+            data-testid="@connect-device-prompt/unreadable-udev"
         />
     );
 };
@@ -111,7 +111,7 @@ export const DeviceUnreadable = ({ device, isWebUsbTransport }: DeviceUnreadable
                 label={<Translation id="TR_TROUBLESHOOTING_UNREADABLE_WEBUSB" />}
                 items={[TROUBLESHOOTING_TIP_BRIDGE_STATUS, TROUBLESHOOTING_TIP_SUITE_DESKTOP]}
                 offerWebUsb
-                data-test="@connect-device-prompt/unreadable-hid"
+                data-testid="@connect-device-prompt/unreadable-hid"
             />
         );
     }
@@ -135,7 +135,7 @@ export const DeviceUnreadable = ({ device, isWebUsbTransport }: DeviceUnreadable
                 TROUBLESHOOTING_TIP_DIFFERENT_COMPUTER,
             ]}
             offerWebUsb={isWebUsbTransport}
-            data-test="@connect-device-prompt/unreadable-unknown"
+            data-testid="@connect-device-prompt/unreadable-unknown"
         />
     );
 };

--- a/packages/suite/src/components/suite/PrerequisitesGuide/Transport.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/Transport.tsx
@@ -18,6 +18,6 @@ export const Transport = () => (
             TROUBLESHOOTING_TIP_SUITE_DESKTOP,
             TROUBLESHOOTING_TIP_RESTART_COMPUTER,
         ]}
-        data-test="@connect-device-prompt/bridge-not-running"
+        data-testid="@connect-device-prompt/bridge-not-running"
     />
 );

--- a/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
@@ -31,7 +31,7 @@ export const DeviceCompromised = () => {
 
     return (
         <WelcomeLayout>
-            <Card data-test="@device-compromised">
+            <Card data-testid="@device-compromised">
                 <SecurityCheckFail />
             </Card>
         </WelcomeLayout>

--- a/packages/suite/src/components/suite/TorLoader/TorLoader.tsx
+++ b/packages/suite/src/components/suite/TorLoader/TorLoader.tsx
@@ -88,7 +88,7 @@ export const TorLoader = ({ callback, ModalWrapper }: TorLoadingScreenProps) => 
             bottomBarComponents={
                 isTorError && (
                     <StyledButton
-                        data-test="@tor-loading-screen/try-again-button"
+                        data-testid="@tor-loading-screen/try-again-button"
                         icon="REFRESH"
                         onClick={tryAgain}
                     >

--- a/packages/suite/src/components/suite/TorLoader/TorProgressBar.tsx
+++ b/packages/suite/src/components/suite/TorLoader/TorProgressBar.tsx
@@ -134,7 +134,7 @@ export const TorProgressBar = ({
 
                 {!isTorDisabling && (
                     <DisableButton
-                        data-test="@tor-loading-screen/disable-button"
+                        data-testid="@tor-loading-screen/disable-button"
                         variant="secondary"
                         onClick={disableTor}
                     >

--- a/packages/suite/src/components/suite/WebUsbButton.tsx
+++ b/packages/suite/src/components/suite/WebUsbButton.tsx
@@ -19,7 +19,7 @@ export const WebUsbButton = ({
     variant = 'primary',
     ...rest
 }: WebUsbButtonProps) => (
-    <div data-test="web-usb-button">
+    <div data-testid="web-usb-button">
         <Button
             {...rest}
             icon={icon === false ? undefined : icon}
@@ -38,7 +38,7 @@ export const WebUsbIconButton = ({
     variant = 'primary',
     ...rest
 }: WebUsbButtonProps) => (
-    <div data-test="web-usb-button">
+    <div data-testid="web-usb-button">
         <Tooltip content={<Translation id={translationId} />}>
             <IconButton
                 {...rest}

--- a/packages/suite/src/components/suite/WordInput.tsx
+++ b/packages/suite/src/components/suite/WordInput.tsx
@@ -88,7 +88,7 @@ export const WordInput = memo(() => {
                     trim: true,
                     matchFrom: 'start',
                 })}
-                data-test="@word-input-select"
+                data-testid="@word-input-select"
             />
         </SelectWrapper>
     );

--- a/packages/suite/src/components/suite/WordInputAdvanced.tsx
+++ b/packages/suite/src/components/suite/WordInputAdvanced.tsx
@@ -141,7 +141,7 @@ export const WordInputAdvanced = ({ count }: WordInputAdvancedProps) => {
                             <PinButton
                                 data-value="1"
                                 onClick={() => onSubmit('1')}
-                                data-test="@recovery/word-input-advanced/1"
+                                data-testid="@recovery/word-input-advanced/1"
                             />
                             <PinButton data-value="2" onClick={() => onSubmit('2')} />
                             <PinButton data-value="3" onClick={() => onSubmit('3')} />
@@ -163,7 +163,7 @@ export const WordInputAdvanced = ({ count }: WordInputAdvancedProps) => {
                             <PinButton
                                 data-value="2"
                                 onClick={() => onSubmit('1')}
-                                data-test="@recovery/word-input-advanced/1"
+                                data-testid="@recovery/word-input-advanced/1"
                             />
                             <PinButton data-value="3" onClick={() => onSubmit('3')} />
                         </Row>

--- a/packages/suite/src/components/suite/banners/Banner.tsx
+++ b/packages/suite/src/components/suite/banners/Banner.tsx
@@ -12,11 +12,11 @@ interface BannerProps {
     action?: {
         label: ReactNode | string;
         onClick: () => void;
-        'data-test': string;
+        'data-testid': string;
     };
     dismissal?: {
         onClick: () => void;
-        'data-test': string;
+        'data-testid': string;
     };
     className?: string;
 }
@@ -142,7 +142,7 @@ export const Banner = ({ body, variant, action, dismissal, className }: BannerPr
                         size="tiny"
                         variant="tertiary"
                         onClick={action.onClick}
-                        data-test={action['data-test']}
+                        data-testid={action['data-testid']}
                     >
                         {action.label}
                     </Button>
@@ -154,7 +154,7 @@ export const Banner = ({ body, variant, action, dismissal, className }: BannerPr
                             icon="CROSS"
                             color={getForegroundColor(variant, theme)}
                             onClick={dismissal.onClick}
-                            data-test={dismissal['data-test']}
+                            data-testid={dismissal['data-testid']}
                         />
                     </CancelWrapper>
                 )}

--- a/packages/suite/src/components/suite/banners/MessageSystemBanner.tsx
+++ b/packages/suite/src/components/suite/banners/MessageSystemBanner.tsx
@@ -49,7 +49,7 @@ export const MessageSystemBanner = ({ message }: MessageSystemBannerProps) => {
         return {
             label: label[language] || label.en,
             onClick: onClick!,
-            'data-test': `@message-system/${id}/cta`,
+            'data-testid': `@message-system/${id}/cta`,
         };
     }, [id, cta, dispatch, language, isTorEnabled, torOnionLinks]);
 
@@ -59,7 +59,7 @@ export const MessageSystemBanner = ({ message }: MessageSystemBannerProps) => {
         return {
             onClick: () =>
                 dispatch(messageSystemActions.dismissMessage({ id, category: 'banner' })),
-            'data-test': `@message-system/${id}/dismiss`,
+            'data-testid': `@message-system/${id}/dismiss`,
         };
     }, [id, dismissible, dispatch]);
 

--- a/packages/suite/src/components/suite/banners/SuiteBanners/FailedBackupBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/FailedBackupBanner.tsx
@@ -10,7 +10,7 @@ export const FailedBackup = () => {
     const action = {
         label: <Translation id="TR_CONTINUE" />,
         onClick: () => dispatch(goto('settings-device', { anchor: SettingsAnchor.BackupFailed })),
-        'data-test': '@notification/failed-backup/cta',
+        'data-testid': '@notification/failed-backup/cta',
     };
 
     return (

--- a/packages/suite/src/components/suite/banners/SuiteBanners/NoBackupBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/NoBackupBanner.tsx
@@ -10,7 +10,7 @@ export const NoBackup = () => {
     const action = {
         label: <Translation id="TR_CREATE_BACKUP" />,
         onClick: () => dispatch(goto('backup-index')),
-        'data-test': '@notification/no-backup/button',
+        'data-testid': '@notification/no-backup/button',
     };
 
     const translation = `${translationString(

--- a/packages/suite/src/components/suite/banners/SuiteBanners/SafetyChecksBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/SafetyChecksBanner.tsx
@@ -20,7 +20,7 @@ export const SafetyChecksBanner = ({ onDismiss }: SafetyChecksBannerProps) => {
                     anchor: SettingsAnchor.SafetyChecks,
                 }),
             ),
-        'data-test': '@banner/safety-checks/button',
+        'data-testid': '@banner/safety-checks/button',
     };
 
     return (
@@ -32,7 +32,7 @@ export const SafetyChecksBanner = ({ onDismiss }: SafetyChecksBannerProps) => {
                 onDismiss
                     ? {
                           onClick: onDismiss,
-                          'data-test': '@banner/safety-checks/dismiss',
+                          'data-testid': '@banner/safety-checks/dismiss',
                       }
                     : undefined
             }

--- a/packages/suite/src/components/suite/banners/SuiteBanners/TranslationModeBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/TranslationModeBanner.tsx
@@ -8,7 +8,7 @@ export const TranslationMode = () => (
         action={{
             label: 'Turn off',
             onClick: () => setTranslationMode(false),
-            'data-test': '@notification/translation-mode/button',
+            'data-testid': '@notification/translation-mode/button',
         }}
     />
 );

--- a/packages/suite/src/components/suite/banners/SuiteBanners/UpdateBridgeBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/UpdateBridgeBanner.tsx
@@ -9,7 +9,7 @@ export const UpdateBridge = () => {
     const action = {
         label: <Translation id="TR_SHOW_DETAILS" />,
         onClick: () => dispatch(goto('suite-bridge')),
-        'data-test': '@notification/update-bridge/button',
+        'data-testid': '@notification/update-bridge/button',
     };
 
     return (

--- a/packages/suite/src/components/suite/banners/SuiteBanners/UpdateFirmwareBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/UpdateFirmwareBanner.tsx
@@ -9,7 +9,7 @@ export const UpdateFirmware = () => {
     const action = {
         label: <Translation id="TR_SHOW_DETAILS" />,
         onClick: () => dispatch(goto('firmware-index')),
-        'data-test': '@notification/update-firmware/button',
+        'data-testid': '@notification/update-firmware/button',
     };
 
     return (

--- a/packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipBase.tsx
+++ b/packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipBase.tsx
@@ -164,7 +164,7 @@ export const GraphTooltipBase = (props: GraphTooltipBaseProps) => {
         <CustomTooltipWrapper
             $positionX={props.coordinate!.x!}
             $boxWidth={props.viewBox!.width!}
-            data-test="@dashboard/customtooltip"
+            data-testid="@dashboard/customtooltip"
         >
             <Row>
                 <Title>{date && formatDate(date, dateFormat)}</Title>

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
@@ -121,7 +121,7 @@ const ButtonLikeLabel = ({
     defaultVisibleValue,
     onSubmit,
     onBlur,
-    'data-test': dataTest,
+    'data-testid': dataTest,
 }: ExtendedProps) => {
     const EditableButton = useMemo(() => withEditable(RelativeButton), []);
 
@@ -131,7 +131,7 @@ const ButtonLikeLabel = ({
                 // @ts-expect-error todo: hm this needs some clever generic
                 variant="tertiary"
                 icon="TAG"
-                data-test={dataTest}
+                data-testid={dataTest}
                 originalValue={payload.value ?? defaultEditableValue}
                 onSubmit={onSubmit}
                 onBlur={onBlur}
@@ -142,7 +142,7 @@ const ButtonLikeLabel = ({
 
     if (payload.value) {
         return (
-            <LabelButton variant="tertiary" icon="TAG" data-test={dataTest} size="tiny">
+            <LabelButton variant="tertiary" icon="TAG" data-testid={dataTest} size="tiny">
                 <Inline>
                     <LabelValue>{payload.value} </LabelValue>
                     {/* This is the defaultVisibleValue which shows up after you hover over the label name: */}
@@ -162,7 +162,7 @@ const TextLikeLabel = ({
     defaultVisibleValue,
     defaultEditableValue,
     payload,
-    'data-test': dataTest,
+    'data-testid': dataTest,
     onSubmit,
     onBlur,
     updateFlag,
@@ -172,7 +172,7 @@ const TextLikeLabel = ({
     if (editActive) {
         return (
             <EditableLabel
-                data-test={dataTest}
+                data-testid={dataTest}
                 originalValue={payload.value ?? defaultEditableValue}
                 onSubmit={onSubmit}
                 onBlur={onBlur}
@@ -183,7 +183,7 @@ const TextLikeLabel = ({
 
     if (payload.value) {
         return (
-            <Label data-test={dataTest}>
+            <Label data-testid={dataTest}>
                 <LabelValue>{payload.value}</LabelValue>
             </Label>
         );
@@ -302,7 +302,7 @@ export const MetadataLabeling = ({
         {
             onClick: () => activateEdit(),
             label: l10nLabelling.edit,
-            'data-test': `edit-label`, // hack: This will be prefixed in the withDropdown()
+            'data-testid': `edit-label`, // hack: This will be prefixed in the withDropdown()
         },
     ];
 
@@ -359,7 +359,7 @@ export const MetadataLabeling = ({
     // metadata is still initiating, on hover, show only disabled button with spinner
     if (metadata.initiating)
         return (
-            <LabelContainer data-test={labelContainerDataTest}>
+            <LabelContainer data-testid={labelContainerDataTest}>
                 {defaultVisibleValue}
                 <ActionButton variant="tertiary" isDisabled isLoading size="tiny">
                     <Translation id="TR_LOADING" />
@@ -376,7 +376,7 @@ export const MetadataLabeling = ({
 
     return (
         <LabelContainer
-            data-test={labelContainerDataTest}
+            data-testid={labelContainerDataTest}
             onClick={e => editActive && e.stopPropagation()}
         >
             {payload.type === 'outputLabel' ? (
@@ -385,7 +385,7 @@ export const MetadataLabeling = ({
                         editActive={editActive}
                         onSubmit={onSubmit || defaultOnSubmit}
                         onBlur={handleBlur}
-                        data-test={dataTestBase}
+                        data-testid={dataTestBase}
                         payload={payload}
                         defaultEditableValue={defaultEditableValue}
                         defaultVisibleValue={defaultVisibleValue}
@@ -393,7 +393,7 @@ export const MetadataLabeling = ({
                     />
                     {showOutputLabelActionButton && (
                         <ActionButton
-                            data-test={`${dataTestBase}/add-label-button`}
+                            data-testid={`${dataTestBase}/add-label-button`}
                             variant="tertiary"
                             icon={!actionButtonsDisabled ? 'TAG' : undefined}
                             isLoading={actionButtonsDisabled}
@@ -419,7 +419,7 @@ export const MetadataLabeling = ({
                         editActive={editActive}
                         onSubmit={onSubmit || defaultOnSubmit}
                         onBlur={handleBlur}
-                        data-test={dataTestBase}
+                        data-testid={dataTestBase}
                         payload={payload}
                         defaultEditableValue={defaultEditableValue}
                         defaultVisibleValue={defaultVisibleValue}
@@ -427,7 +427,7 @@ export const MetadataLabeling = ({
                     />
                     {showActionButton && (
                         <ActionButton
-                            data-test={
+                            data-testid={
                                 payload.value
                                     ? `${dataTestBase}/edit-label-button`
                                     : `${dataTestBase}/add-label-button`
@@ -452,7 +452,7 @@ export const MetadataLabeling = ({
             {showSuccess && !editActive && (
                 <SuccessButton
                     variant="tertiary"
-                    data-test={`${dataTestBase}/success`}
+                    data-testid={`${dataTestBase}/success`}
                     icon="CHECK"
                     size="tiny"
                 >

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/definitions.ts
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/definitions.ts
@@ -20,5 +20,5 @@ export interface ExtendedProps extends Props {
     editActive: boolean;
     onSubmit: (value: string | undefined) => void;
     onBlur: () => void;
-    'data-test': string;
+    'data-testid': string;
 }

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/withDropdown.tsx
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/withDropdown.tsx
@@ -30,7 +30,7 @@ export const withDropdown = (WrappedComponent: FC<ExtendedProps>) => (props: Pro
                 key: 'key',
                 options: props.dropdownOptions.map(it => ({
                     ...it,
-                    'data-test': `${props['data-test']}/dropdown/${it['data-test']}`, // hack: this shall be refactored somehow
+                    'data-testid': `${props['data-testid']}/dropdown/${it['data-testid']}`, // hack: this shall be refactored somehow
                 })),
             },
         ]}

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/withEditable.tsx
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/withEditable.tsx
@@ -93,7 +93,7 @@ export const withEditable =
                     <Editable
                         minWidth={20}
                         ref={divRef}
-                        data-test="@metadata/input"
+                        data-testid="@metadata/input"
                         value={value}
                         // onBlur={onBlur}
                         onChange={event => {
@@ -117,7 +117,7 @@ export const withEditable =
                         <Icon
                             useCursorPointer
                             size={14}
-                            data-test="@metadata/submit"
+                            data-testid="@metadata/submit"
                             icon="CHECK"
                             onClick={e => {
                                 e.stopPropagation();
@@ -131,7 +131,7 @@ export const withEditable =
                         <Icon
                             useCursorPointer
                             size={14}
-                            data-test="@metadata/cancel"
+                            data-testid="@metadata/cancel"
                             icon="CROSS"
                             onClick={e => {
                                 e.stopPropagation();

--- a/packages/suite/src/components/suite/layouts/LoggedOutLayout.tsx
+++ b/packages/suite/src/components/suite/layouts/LoggedOutLayout.tsx
@@ -34,17 +34,17 @@ export const LoggedOutLayout = ({ children }: LoggedOutLayout) => {
     return (
         <ElevationContext baseElevation={-1}>
             <TrafficLightOffset>
-                <Wrapper ref={wrapperRef} data-test="@logged-out-layout">
+                <Wrapper ref={wrapperRef} data-testid="@logged-out-layout">
                     <PageWrapper>
                         <ModalContextProvider>
                             <Metadata title={title} />
                             <ModalSwitcher />
 
                             <LayoutContext.Provider value={setLayoutPayload}>
-                                <Body data-test="@suite-layout/body">
+                                <Body data-testid="@suite-layout/body">
                                     <Columns>
                                         <AppWrapper
-                                            data-test="@app"
+                                            data-testid="@app"
                                             ref={scrollRef}
                                             id="layout-scroll"
                                         >

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
@@ -108,7 +108,7 @@ export const DeviceSelector = () => {
                 <InnerContainer
                     onClick={handleSwitchDeviceClick}
                     tabIndex={0}
-                    data-test="@menu/switch-device"
+                    data-testid="@menu/switch-device"
                 >
                     <SidebarDeviceStatus />
 

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/MobileMenu/MobileActionItem.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/MobileMenu/MobileActionItem.tsx
@@ -82,7 +82,7 @@ interface CommonProps extends Pick<HTMLAttributes<HTMLDivElement>, 'onClick'> {
     label: ReactNode;
     isActive?: boolean;
     indicator?: IndicatorStatus;
-    'data-test'?: string;
+    'data-testid'?: string;
 }
 
 interface CustomIconComponentProps extends CommonProps {
@@ -105,7 +105,7 @@ export const MobileActionItem = ({
     isActive,
     label,
     onClick,
-    'data-test': dataTest,
+    'data-testid': dataTest,
 }: MobileActionItemProps) => {
     const theme = useTheme();
 
@@ -143,7 +143,7 @@ export const MobileActionItem = ({
     );
 
     return (
-        <MobileWrapper data-test={dataTest} onClick={onClick}>
+        <MobileWrapper data-testid={dataTest} onClick={onClick}>
             <MobileIconWrapper>{Content}</MobileIconWrapper>
             <Label $isActive={isActive}>{label}</Label>
         </MobileWrapper>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/MobileMenu/MobileMenuActions.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/MobileMenu/MobileMenuActions.tsx
@@ -78,7 +78,7 @@ export const MobileMenuActions = ({ closeMobileNavigation }: MobileMenuActionsPr
 
             <MobileActionItem
                 label={<Translation id="TR_NOTIFICATIONS" />}
-                data-test="@suite/menu/notifications-index"
+                data-testid="@suite/menu/notifications-index"
                 onClick={() => action('notifications-index')}
                 isActive={getIfTabIsActive(['notifications-index'])}
                 icon="NOTIFICATION"
@@ -87,14 +87,14 @@ export const MobileMenuActions = ({ closeMobileNavigation }: MobileMenuActionsPr
 
             <MobileActionItem
                 label={<Translation id="TR_GUIDE_VIEW_HEADLINE_LEARN_AND_DISCOVER" />}
-                data-test="@suite/menu/guide-index"
+                data-testid="@suite/menu/guide-index"
                 onClick={handleOpenGuide}
                 icon="LIGHTBULB"
             />
 
             <MobileActionItem
                 label={<Translation id="TR_SETTINGS" />}
-                data-test="@suite/menu/settings-index"
+                data-testid="@suite/menu/settings-index"
                 onClick={() => action('settings-index')}
                 isActive={getIfTabIsActive([
                     'settings-index',

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/MobileMenu/MobileNavigation.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/MobileMenu/MobileNavigation.tsx
@@ -94,7 +94,7 @@ export const MobileNavigation = ({ closeMobileNavigation }: MobileNavigationProp
                 return (
                     <HoverAnimation isHoverable={!isActive} key={route}>
                         <MenuItem
-                            data-test={`@suite/menu/${route}`}
+                            data-testid={`@suite/menu/${route}`}
                             onClick={() => {
                                 if (!isDisabled) {
                                     if (route === 'wallet-index') {

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActions.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActions.tsx
@@ -28,7 +28,7 @@ type ActionItem = {
     icon?: IconProps['icon'];
     callback: () => void;
     title: JSX.Element;
-    'data-test'?: string;
+    'data-testid'?: string;
     isHidden?: boolean;
 };
 
@@ -82,7 +82,7 @@ export const HeaderActions = () => {
                     <Dropdown
                         alignMenu="bottom-right"
                         isDisabled={isAccountLoading}
-                        data-test="@wallet/menu/extra-dropdown"
+                        data-testid="@wallet/menu/extra-dropdown"
                         items={[
                             {
                                 key: 'extra',
@@ -91,7 +91,7 @@ export const HeaderActions = () => {
                                         key: item.id,
                                         onClick: isAccountLoading ? undefined : item.callback,
                                         label: item.title,
-                                        'data-test': `@wallet/menu/${item.id}`,
+                                        'data-testid': `@wallet/menu/${item.id}`,
                                     }),
                                 ),
                             },
@@ -107,7 +107,7 @@ export const HeaderActions = () => {
                         onClick={() => {
                             goToWithAnalytics('wallet-coinmarket-buy', { preserveParams: true });
                         }}
-                        data-test="@wallet/menu/wallet-coinmarket-buy"
+                        data-testid="@wallet/menu/wallet-coinmarket-buy"
                         variant="tertiary"
                         size="small"
                         isDisabled={isAccountLoading}
@@ -125,7 +125,7 @@ export const HeaderActions = () => {
                         onClick={() => {
                             goToWithAnalytics('wallet-send', { preserveParams: true });
                         }}
-                        data-test="@wallet/menu/wallet-send"
+                        data-testid="@wallet/menu/wallet-send"
                         variant={isDeviceConnected ? 'primary' : 'tertiary'}
                     >
                         <Translation id="TR_NAV_SEND" />
@@ -137,7 +137,7 @@ export const HeaderActions = () => {
                         onClick={() => {
                             goToWithAnalytics('wallet-receive', { preserveParams: true });
                         }}
-                        data-test="@wallet/menu/wallet-receive"
+                        data-testid="@wallet/menu/wallet-receive"
                         variant={isDeviceConnected ? 'primary' : 'tertiary'}
                     >
                         <Translation id="TR_NAV_RECEIVE" />

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountSubpageName.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountSubpageName.tsx
@@ -42,7 +42,7 @@ export const AccountSubpageName = ({
                 variant="tertiary"
                 size="medium"
                 onClick={handleBackClick}
-                data-test="@account-subpage/back"
+                data-testid="@account-subpage/back"
             />
             <AccountDetails selectedAccount={selectedAccount} isBalanceShown />
         </Container>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/SettingsName.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/SettingsName.tsx
@@ -57,11 +57,11 @@ export const SettingsName = () => {
                     variant="tertiary"
                     size="medium"
                     onClick={handleBackClick}
-                    data-test="@settings/menu/close"
+                    data-testid="@settings/menu/close"
                 />
             )}
 
-            <HeaderHeading onClick={handleTitleClick} data-test="@settings/menu/title">
+            <HeaderHeading onClick={handleTitleClick} data-testid="@settings/menu/title">
                 <Translation id="TR_SETTINGS" />
             </HeaderHeading>
         </Container>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx
@@ -39,14 +39,14 @@ const navItems: Array<NavigationItemProps & { CustomComponent?: FC<NavigationIte
         icon: 'settings',
         goToRoute: 'settings-index',
         routes: ['settings-index', 'settings-device', 'settings-coins', 'settings-debug'],
-        dataTest: '@suite/menu/settings',
+        'data-testid': '@suite/menu/settings',
     },
     {
         nameId: 'TR_PASSWORD_MANAGER',
         icon: 'ghost',
         goToRoute: 'password-manager-index',
         routes: ['password-manager-index'],
-        dataTest: '@suite/menu/password-manager',
+        'data-testid': '@suite/menu/password-manager',
         CustomComponent: PasswordManagerNavItem,
     },
 ];

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/NavigationItem.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/NavigationItem.tsx
@@ -70,7 +70,7 @@ export interface NavigationItemProps {
     goToRoute?: Route['name'];
     preserveParams?: boolean;
     isActive?: boolean;
-    dataTest?: string;
+    'data-testid'?: string;
     className?: string;
     values?: ExtendedMessageDescriptor['values'];
     iconSize?: IconSize;
@@ -83,7 +83,7 @@ export const NavigationItem = ({
     routes,
     goToRoute,
     isActive,
-    dataTest,
+    'data-testid': dataTest,
     className,
     values,
     preserveParams,
@@ -108,7 +108,7 @@ export const NavigationItem = ({
         <Container
             $isActive={isActive || isActiveRoute}
             onClick={handleClick}
-            data-test={dataTest || `@suite/menu/${goToRoute}`}
+            data-testid={dataTest || `@suite/menu/${goToRoute}`}
             className={className}
             tabIndex={0}
             $elevation={elevation}

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions.tsx
@@ -88,7 +88,7 @@ export const QuickActions = () => {
                 {!isCustomBackendIconVisible && !isTorIconVisible ? (
                     <DescreetContainer
                         onClick={handleDiscreetModeClick}
-                        data-test="@quickActions/hideBalances"
+                        data-testid="@quickActions/hideBalances"
                     >
                         <Icon size={16} icon={isDiscreetModeActive ? 'HIDE' : 'SHOW'} />
                         <Label>{translationString(translationLabel)} </Label>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/SubpageNavigation.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/SubpageNavigation.tsx
@@ -62,7 +62,7 @@ export type NavigationItem = {
     id: Route['name'];
     callback: () => void;
     title: JSX.Element;
-    'data-test'?: string;
+    'data-testid'?: string;
     isHidden?: boolean;
     activeRoutes?: TabRoute[];
 };
@@ -101,7 +101,7 @@ export const SubpageNavigation = ({ items, className }: SubpageNavigationProps) 
                                         $isActive={isActive}
                                         $isNavigationDisabled={isAccountLoading}
                                         onClick={onClick}
-                                        data-test={item['data-test']}
+                                        data-testid={item['data-testid']}
                                     >
                                         {title}
                                     </StyledNavLink>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx
@@ -115,7 +115,7 @@ export const SuiteLayout = ({ children }: SuiteLayoutProps) => {
 
     return (
         <ElevationContext baseElevation={-1}>
-            <Wrapper ref={wrapperRef} data-test="@suite-layout">
+            <Wrapper ref={wrapperRef} data-testid="@suite-layout">
                 <PageWrapper>
                     <ModalContextProvider>
                         <Metadata title={title} />
@@ -129,7 +129,7 @@ export const SuiteLayout = ({ children }: SuiteLayoutProps) => {
                         <DiscoveryProgress />
 
                         <LayoutContext.Provider value={setLayoutPayload}>
-                            <Body data-test="@suite-layout/body">
+                            <Body data-testid="@suite-layout/body">
                                 <Columns>
                                     {!isMobileLayout && (
                                         <ElevationDown>
@@ -139,7 +139,7 @@ export const SuiteLayout = ({ children }: SuiteLayoutProps) => {
                                     <MainBar>
                                         <SuiteBanners />
                                         <AppWrapper
-                                            data-test="@app"
+                                            data-testid="@app"
                                             ref={scrollRef}
                                             id={SCROLL_WRAPPER_ID}
                                         >

--- a/packages/suite/src/components/suite/layouts/WelcomeLayout/NavSettings.tsx
+++ b/packages/suite/src/components/suite/layouts/WelcomeLayout/NavSettings.tsx
@@ -15,7 +15,7 @@ export const NavSettings = () => {
             size="medium"
             variant="tertiary"
             onClick={handleClick}
-            data-test="@suite/menu/settings"
+            data-testid="@suite/menu/settings"
         />
     );
 };

--- a/packages/suite/src/components/suite/layouts/WelcomeLayout/WelcomeLayout.tsx
+++ b/packages/suite/src/components/suite/layouts/WelcomeLayout/WelcomeLayout.tsx
@@ -145,7 +145,7 @@ const Left = () => {
                     >
                         <TrafficLightOffset>
                             <Column justifyContent="center" alignItems="center" height="100%">
-                                <Expander data-test="@welcome/title">
+                                <Expander data-testid="@welcome/title">
                                     <TrezorLogo type="symbol" width="57px" />
                                 </Expander>
 
@@ -206,7 +206,7 @@ export const WelcomeLayout = ({ children }: WelcomeLayoutProps) => {
             <Wrapper>
                 {bannerMessage && <MessageSystemBanner message={bannerMessage} />}
 
-                <Body data-test="@welcome-layout/body">
+                <Body data-testid="@welcome-layout/body">
                     <ElevationDown>
                         <Left />
                     </ElevationDown>

--- a/packages/suite/src/components/suite/modals/AbortButton.tsx
+++ b/packages/suite/src/components/suite/modals/AbortButton.tsx
@@ -85,7 +85,7 @@ export const AbortButton = ({ onAbort, className }: AbortButtonProps) => {
     return (
         <AbortContainer
             key="@modal/close-button" // passed in array
-            data-test="@modal/close-button"
+            data-testid="@modal/close-button"
             onClick={onAbort}
             className={className}
         >

--- a/packages/suite/src/components/suite/modals/ModalSwitcher/DiscoveryLoader.tsx
+++ b/packages/suite/src/components/suite/modals/ModalSwitcher/DiscoveryLoader.tsx
@@ -21,7 +21,7 @@ export const DiscoveryLoader = () => {
     if (!device) return null;
 
     return (
-        <SwitchDeviceRenderer isCancelable={false} data-test="@discovery/loader">
+        <SwitchDeviceRenderer isCancelable={false} data-testid="@discovery/loader">
             <CardWithDevice device={device} isFullHeaderVisible={false}>
                 <Expand>
                     <Spinner size={80} isGrey={false} margin={{ bottom: 48 }} />

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
@@ -75,7 +75,7 @@ export const ConfirmAddressModal = ({ addressPath, value, ...props }: ConfirmAdd
             copyButtonText={<Translation id="TR_ADDRESS_MODAL_CLIPBOARD" />}
             validateOnDevice={validateAddress}
             value={value}
-            copyButtonDataTest="@metadata/copy-address-button"
+            data-testid="@metadata/copy-address-button"
             displayMode={displayMode}
             {...props}
         />

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
@@ -71,7 +71,7 @@ export interface ConfirmValueModalProps extends Pick<ModalProps, 'onCancel' | 'h
     copyButtonText: ReactNode;
     stepLabel: ReactNode;
     confirmStepLabel: ReactNode;
-    copyButtonDataTest?: string;
+    'data-testid'?: string;
     isConfirmed?: boolean;
     validateOnDevice: () => ThunkAction;
     value: string;
@@ -81,7 +81,7 @@ export interface ConfirmValueModalProps extends Pick<ModalProps, 'onCancel' | 'h
 export const ConfirmValueModal = ({
     account,
     copyButtonText,
-    copyButtonDataTest,
+    'data-testid': copyButtonDataTest,
     stepLabel,
     confirmStepLabel,
     heading,
@@ -174,7 +174,7 @@ export const ConfirmValueModal = ({
                             <StyledButton
                                 isDisabled={!addressConfirmed}
                                 onClick={copy}
-                                data-test={copyButtonDataTest}
+                                data-testid={copyButtonDataTest}
                             >
                                 {copyButtonText}
                             </StyledButton>

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/NoBackupModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/NoBackupModal.tsx
@@ -34,7 +34,7 @@ export const NoBackupModal = () => {
                     <Button
                         variant="destructive"
                         onClick={confirm}
-                        data-test="@no-backup/take-risk-button"
+                        data-testid="@no-backup/take-risk-button"
                     >
                         <Translation id="TR_CONTINUE_ANYWAY" />
                     </Button>

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmActionModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmActionModal.tsx
@@ -25,7 +25,7 @@ interface ConfirmActionProps extends DevicePromptModalProps {
 }
 
 export const ConfirmActionModal = ({ device, ...rest }: ConfirmActionProps) => (
-    <StyledDevicePromptModal data-test="@suite/modal/confirm-action-on-device" {...rest}>
+    <StyledDevicePromptModal data-testid="@suite/modal/confirm-action-on-device" {...rest}>
         <StyledDeviceConfirmImage device={device} />
 
         <StyledH1>

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmFingerprintModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmFingerprintModal.tsx
@@ -22,7 +22,7 @@ export const ConfirmFingerprintModal = ({ device, ...rest }: ConfirmFingerprintP
             />
         }
         heading={<Translation id="TR_CHECK_FINGERPRINT" />}
-        data-test="@suite/modal/confirm-fingerprint-on-device"
+        data-testid="@suite/modal/confirm-fingerprint-on-device"
         {...rest}
     >
         <Fingerprint device={device} />

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/DevicePromptModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/DevicePromptModal.tsx
@@ -38,7 +38,7 @@ export interface DevicePromptModalProps {
     onAbort?: () => void;
     className?: string;
     children?: ReactNode;
-    'data-test'?: string;
+    'data-testid'?: string;
 }
 
 const DevicePromptModalRenderer = ({

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseModal.tsx
@@ -106,7 +106,7 @@ export const PassphraseModal = ({ device }: PassphraseModalProps) => {
                         deviceModel={deviceModel ?? undefined}
                         learnMoreTooltipOnClick={
                             <OpenGuideFromTooltip
-                                dataTest="@tooltip/guideAnchor"
+                                data-testid="@tooltip/guideAnchor"
                                 id="/1_initialize-and-secure-your-trezor/6_passphrase.md"
                             />
                         }
@@ -141,7 +141,7 @@ export const PassphraseModal = ({ device }: PassphraseModalProps) => {
                     deviceModel={deviceModel ?? undefined}
                     learnMoreTooltipOnClick={
                         <OpenGuideFromTooltip
-                            dataTest="@tooltip/guideAnchor"
+                            data-testid="@tooltip/guideAnchor"
                             id="/1_initialize-and-secure-your-trezor/6_passphrase.md"
                         />
                     }

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseOnDeviceModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseOnDeviceModal.tsx
@@ -41,7 +41,10 @@ export const PassphraseOnDeviceModal = ({ device }: PassphraseOnDeviceModalProps
         useSelector(selectIsDiscoveryAuthConfirmationRequired) || device.authConfirm;
 
     return (
-        <StyledDevicePromptModal isAbortable={false} data-test="@modal/enter-passphrase-on-device">
+        <StyledDevicePromptModal
+            isAbortable={false}
+            data-testid="@modal/enter-passphrase-on-device"
+        >
             <StyledDeviceConfirmImage device={device} />
 
             <StyledH2>

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseSourceModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseSourceModal.tsx
@@ -33,7 +33,7 @@ export const PassphraseSourceModal = ({ device }: PassphraseSourceModalProps) =>
     return (
         <StyledDevicePromptModal
             isPillShown={!authConfirmation}
-            data-test={
+            data-testid={
                 authConfirmation ? '@modal/confirm-empty-hidden-wallet' : '@modal/passphrase-source'
             }
         >

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletConfirmationStep1.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletConfirmationStep1.tsx
@@ -9,13 +9,13 @@ import { Dispatch } from 'react';
 type PassphraseWalletConfirmationStep1Props = {
     setContentType: Dispatch<React.SetStateAction<ContentType>>;
     onRetry: () => void;
-    dataTest?: string;
+    'data-testid'?: string;
 };
 
 export const PassphraseWalletConfirmationStep1 = ({
     setContentType,
     onRetry,
-    dataTest,
+    'data-testid': dataTest,
 }: PassphraseWalletConfirmationStep1Props) => (
     <>
         <PassphraseHeading>
@@ -33,7 +33,7 @@ export const PassphraseWalletConfirmationStep1 = ({
                                 variant="info"
                                 iconAlignment="right"
                                 icon="EXTERNAL_LINK"
-                                data-test={dataTest}
+                                data-testid={dataTest}
                             >
                                 <Translation id="TR_PASSPHRASE_WALLET_CONFIRMATION_STEP1_HINT_LINK" />
                             </Button>
@@ -52,7 +52,7 @@ export const PassphraseWalletConfirmationStep1 = ({
                         onClick={() => {
                             setContentType('step2');
                         }}
-                        data-test="@passphrase-confirmation/step1-open-unused-wallet-button"
+                        data-testid="@passphrase-confirmation/step1-open-unused-wallet-button"
                     >
                         <Translation id="TR_PASSPHRASE_WALLET_CONFIRMATION_STEP1_OPEN_UNUSED_WALLET_BUTTON" />
                     </Button>
@@ -67,7 +67,7 @@ export const PassphraseWalletConfirmationStep1 = ({
                         isFullWidth
                         variant="tertiary"
                         onClick={onRetry}
-                        data-test="@passphrase-confirmation/step1-retry-button"
+                        data-testid="@passphrase-confirmation/step1-retry-button"
                     >
                         <Translation id="TR_PASSPHRASE_WALLET_CONFIRMATION_STEP1_OPEN_WITH_FUNDS_BUTTON" />
                     </Button>

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletConfirmationStep2.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletConfirmationStep2.tsx
@@ -50,7 +50,7 @@ export const PassphraseWalletConfirmationStep2 = ({
                 setContentType('step3');
             }}
             margin={{ top: 12 }}
-            data-test="@passphrase-confirmation/step2-button"
+            data-testid="@passphrase-confirmation/step2-button"
         >
             <Translation id="TR_PASSPHRASE_WALLET_CONFIRMATION_STEP2_BUTTON" />
         </Button>

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletConfirmationStep3.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletConfirmationStep3.tsx
@@ -42,7 +42,7 @@ export const PassphraseWalletConfirmationStep3 = ({
                 deviceModel={deviceModel ?? undefined}
                 learnMoreTooltipOnClick={
                     <OpenGuideFromTooltip
-                        dataTest="@tooltip/guideAnchor"
+                        data-testid="@tooltip/guideAnchor"
                         id="/1_initialize-and-secure-your-trezor/6_passphrase.md"
                     />
                 }

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PinModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PinModal.tsx
@@ -40,7 +40,7 @@ export const PinModal = ({ device, ...rest }: PinModalProps) => {
             }
             onCancel={onCancel}
             isCancelable
-            data-test="@modal/pin"
+            data-testid="@modal/pin"
             $isExtended={isModalExtended}
             {...rest}
         >

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/WordModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/WordModal.tsx
@@ -13,7 +13,7 @@ export const WordModal = (props: ModalProps) => {
 
     return (
         <StyledModal
-            data-test="@recovery/word"
+            data-testid="@recovery/word"
             heading={<Translation id="TR_FOLLOW_INSTRUCTIONS_ON_DEVICE" />}
             description={
                 <>

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
@@ -241,7 +241,7 @@ export const TransactionReviewOutputList = ({
                 <RightBottom>
                     {broadcastEnabled ? (
                         <StyledButton
-                            data-test="@modal/send"
+                            data-testid="@modal/send"
                             isDisabled={!signedTx}
                             isLoading={isSending}
                             onClick={handleSend}
@@ -253,7 +253,7 @@ export const TransactionReviewOutputList = ({
                             <StyledButton
                                 isDisabled={!signedTx}
                                 onClick={handleCopy}
-                                data-test="@send/copy-raw-transaction"
+                                data-testid="@send/copy-raw-transaction"
                             >
                                 <Translation id="COPY_TRANSACTION_TO_CLIPBOARD" />
                             </StyledButton>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeSelect.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeSelect.tsx
@@ -53,7 +53,7 @@ export const AccountTypeSelect = ({
     return (
         <>
             <Select
-                data-test="@add-account-type/select"
+                data-testid="@add-account-type/select"
                 label={<Translation id="TR_ACCOUNT_TYPE" />}
                 isSearchable={false}
                 isClearable={false}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddButton.tsx
@@ -20,7 +20,7 @@ export const AddButton = ({
         isDisabled={!!disabledMessage}
         size="small"
         onClick={handleClick}
-        data-test="@add-account"
+        data-testid="@add-account"
         {...buttonProps}
     >
         <Translation id="TR_ADD_NETWORK_ACCOUNT" values={{ network: networkName }} />

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -239,7 +239,7 @@ export const AddAccountModal = ({ device, onCancel, symbol, noRedirect }: AddAcc
                                           />
                                       </>
                                   }
-                                  data-test="@modal/account/activate_more_coins"
+                                  data-testid="@modal/account/activate_more_coins"
                                   margin={{ top: spacings.md }}
                               >
                                   <CoinList
@@ -261,7 +261,7 @@ export const AddAccountModal = ({ device, onCancel, symbol, noRedirect }: AddAcc
                                           />
                                       </>
                                   }
-                                  data-test="@modal/account/activate_more_coins"
+                                  data-testid="@modal/account/activate_more_coins"
                                   margin={{ top: spacings.md }}
                               >
                                   <CoinList

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/BackendTypeSelect.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/BackendTypeSelect.tsx
@@ -35,7 +35,7 @@ const useBackendOptions = (network: Network) =>
                                 id="TR_BACKEND_CUSTOM_SERVERS"
                                 values={{
                                     type: (
-                                        <Capitalize data-test={`@settings/advance/${backend}`}>
+                                        <Capitalize data-testid={`@settings/advance/${backend}`}>
                                             {backend}
                                         </Capitalize>
                                     ),
@@ -63,7 +63,7 @@ export const BackendTypeSelect = ({ network, value, onChange }: BackendTypeSelec
             value={backendOptions.find(option => option.value === value)}
             onChange={changeType}
             options={backendOptions}
-            data-test="@settings/advance/select-type"
+            data-testid="@settings/advance/select-type"
         />
     ) : null;
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/CustomBackends.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/CustomBackends.tsx
@@ -149,7 +149,7 @@ export const CustomBackends = ({ network, onCancel }: CustomBackendsProps) => {
 
                 {editable && (
                     <Input
-                        data-test={`@settings/advance/${name}`}
+                        data-testid={`@settings/advance/${name}`}
                         placeholder={placeholder}
                         inputState={error ? 'error' : undefined}
                         bottomText={error?.message || null}
@@ -162,7 +162,7 @@ export const CustomBackends = ({ network, onCancel }: CustomBackendsProps) => {
                     <AddUrlButton
                         variant="tertiary"
                         icon="PLUS"
-                        data-test="@settings/advance/button/add"
+                        data-testid="@settings/advance/button/add"
                         onClick={() => {
                             addUrl(value);
                             reset();
@@ -185,7 +185,7 @@ export const CustomBackends = ({ network, onCancel }: CustomBackendsProps) => {
                     variant="primary"
                     onClick={onSaveClick}
                     isDisabled={!!error}
-                    data-test="@settings/advance/button/save"
+                    data-testid="@settings/advance/button/save"
                 >
                     <Translation id="TR_CONFIRM" />
                 </SaveButton>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApplicationLogModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApplicationLogModal.tsx
@@ -75,14 +75,14 @@ export const ApplicationLogModal = ({ onCancel }: ApplicationLogModalProps) => {
             onCancel={onCancel}
             heading={<Translation id="TR_LOG" />}
             description={<Translation id="LOG_DESCRIPTION" />}
-            data-test="@modal/application-log"
+            data-testid="@modal/application-log"
             bottomBarComponents={
-                <Button variant="secondary" onClick={download} data-test="@log/export-button">
+                <Button variant="secondary" onClick={download} data-testid="@log/export-button">
                     <Translation id="TR_EXPORT_TO_FILE" />
                 </Button>
             }
         >
-            <LogWrapper ref={htmlElement} data-test="@log/content">
+            <LogWrapper ref={htmlElement} data-testid="@log/content">
                 {log}
             </LogWrapper>
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CoinmarketTermsModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CoinmarketTermsModal.tsx
@@ -114,7 +114,7 @@ export const CoinmarketTermsModal = ({
             bottomBarComponents={
                 <FooterContent>
                     <Button
-                        data-test={`@coinmarket/${lowercaseType}/offers/buy-terms-confirm-button`}
+                        data-testid={`@coinmarket/${lowercaseType}/offers/buy-terms-confirm-button`}
                         onClick={() => {
                             decision.resolve(true);
                             onCancel();

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DeviceAuthenticityOptOutModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DeviceAuthenticityOptOutModal.tsx
@@ -16,7 +16,7 @@ export const DeviceAuthenticityOptOutModal = ({ onCancel }: DeviceAuthenticityOp
             headingKey="TR_DEVICE_AUTHENTICITY_OPT_OUT_MODAL_HEADING"
             checkboxLabelKey="TR_DEVICE_AUTHENTICITY_OPT_OUT_MODAL_CHECKBOX_TITLE"
             confirmKey="TR_DEVICE_AUTHENTICITY_OPT_OUT_MODAL_BUTTON"
-            data-test="@device-authenticity"
+            data-testid="@device-authenticity"
             onChange={({ isDisabled }) => dispatch(deviceAuthenticityOptOut(isDisabled))}
             onCancel={onCancel}
         >

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/FirmwareRevisionOptOutModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/FirmwareRevisionOptOutModal.tsx
@@ -17,7 +17,7 @@ export const FirmwareRevisionOptOutModal = ({ onCancel }: DeviceAuthenticityOptO
             headingKey="TR_DEVICE_FIRMWARE_REVISION_CHECK_MODAL_HEADING"
             checkboxLabelKey="TR_DEVICE_FIRMWARE_REVISION_CHECK_MODAL_CHECKBOX_TITLE"
             confirmKey="TR_DEVICE_FIRMWARE_REVISION_CHECK_MODAL_BUTTON"
-            data-test="@device-firmware-revision"
+            data-testid="@device-firmware-revision"
             onChange={({ isDisabled }) => dispatch(checkFirmwareRevision({ isDisabled }))}
         >
             <Column gap={16}>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MetadataProviderModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MetadataProviderModal.tsx
@@ -86,7 +86,7 @@ export const MetadataProviderModal = ({ onCancel, decision }: MetadataProviderMo
             isCancelable
             onCancel={onModalCancel}
             heading={<Translation id="METADATA_MODAL_HEADING" />}
-            data-test="@modal/metadata-provider"
+            data-testid="@modal/metadata-provider"
             bottomBarComponents={
                 <Wrapper>
                     <StyledButton
@@ -94,7 +94,7 @@ export const MetadataProviderModal = ({ onCancel, decision }: MetadataProviderMo
                         onClick={() => connect('dropbox')}
                         isLoading={isLoading === 'dropbox'}
                         isDisabled={!!isLoading}
-                        data-test="@modal/metadata-provider/dropbox-button"
+                        data-testid="@modal/metadata-provider/dropbox-button"
                         icon="DROPBOX"
                     >
                         <Translation id="TR_DROPBOX" />
@@ -106,7 +106,7 @@ export const MetadataProviderModal = ({ onCancel, decision }: MetadataProviderMo
                             onClick={() => connect('google')}
                             isLoading={isLoading === 'google'}
                             isDisabled={!!isLoading}
-                            data-test="@modal/metadata-provider/google-button"
+                            data-testid="@modal/metadata-provider/google-button"
                             icon="GOOGLE_DRIVE"
                         >
                             <Translation id="TR_GOOGLE_DRIVE" />
@@ -120,7 +120,7 @@ export const MetadataProviderModal = ({ onCancel, decision }: MetadataProviderMo
                             onClick={() => connect('fileSystem')}
                             isLoading={isLoading === 'fileSystem'}
                             isDisabled={!!isLoading}
-                            data-test="@modal/metadata-provider/file-system-button"
+                            data-testid="@modal/metadata-provider/file-system-button"
                         >
                             <Translation id="TR_LOCAL_FILE_SYSTEM" />
                         </StyledButton>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/OptOutModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/OptOutModal.tsx
@@ -31,7 +31,7 @@ type OptOutModalProps = {
     headingKey: TranslationKey;
     confirmKey: TranslationKey;
     checkboxLabelKey: TranslationKey;
-    'data-test': string;
+    'data-testid': string;
     onChange: (props: { isDisabled: boolean }) => void;
     children: ReactNode;
 };
@@ -41,7 +41,7 @@ export const OptOutModal = ({
     headingKey,
     confirmKey,
     checkboxLabelKey,
-    'data-test': dataTest,
+    'data-testid': dataTest,
     onChange,
     children,
 }: OptOutModalProps) => {
@@ -62,7 +62,7 @@ export const OptOutModal = ({
                     variant="destructive"
                     onClick={handleTurningOffRevisionCheck}
                     isDisabled={!isConfirmed}
-                    data-test={`${dataTest}/opt-out-button`}
+                    data-testid={`${dataTest}/opt-out-button`}
                 >
                     <Translation id={confirmKey} />
                 </Button>
@@ -77,7 +77,7 @@ export const OptOutModal = ({
                     title={<Translation id={checkboxLabelKey} />}
                     isChecked={isConfirmed}
                     onClick={() => setIsConfirmed(!isConfirmed)}
-                    data-test={`${dataTest}/checkbox`}
+                    data-testid={`${dataTest}/checkbox`}
                 />
             </CheckboxWrapper>
         </StyledModal>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PassphraseDuplicateModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PassphraseDuplicateModal.tsx
@@ -25,7 +25,7 @@ export const PassphraseDuplicateModal = ({ device, duplicate }: PassphraseDuplic
     return (
         <SwitchDeviceRenderer isCancelable={false}>
             <CardWithDevice device={device} isFullHeaderVisible={false}>
-                <H3 margin={{ top: 12 }} data-test="@passphrase-duplicate-header">
+                <H3 margin={{ top: 12 }} data-testid="@passphrase-duplicate-header">
                     <Translation id="TR_WALLET_DUPLICATE_TITLE" />
                 </H3>
                 <Text color="textSubdued">

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PassphraseMismatchModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PassphraseMismatchModal.tsx
@@ -29,7 +29,7 @@ export const PassphraseMismatchModal = ({ onCancel }: { onCancel: () => void }) 
     };
 
     return (
-        <SwitchDeviceRenderer isCancelable={false} data-test="@passphrase-mismatch">
+        <SwitchDeviceRenderer isCancelable={false} data-testid="@passphrase-mismatch">
             <CardWithDevice device={selectDevice} isFullHeaderVisible={false}>
                 <Column gap={8} margin={{ bottom: 32 }} alignItems="center">
                     <H3 margin={{ top: 12 }}>
@@ -45,7 +45,7 @@ export const PassphraseMismatchModal = ({ onCancel }: { onCancel: () => void }) 
                     onClick={onStartOver}
                     isDisabled={isDeviceLocked}
                     isFullWidth
-                    data-test="@passphrase-mismatch/start-over"
+                    data-testid="@passphrase-mismatch/start-over"
                 >
                     <Translation id="TR_PASSPHRASE_MISMATCH_START_OVER" />
                 </Button>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PinMismatchModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PinMismatchModal.tsx
@@ -24,10 +24,10 @@ export const PinMismatchModal = (props: ModalProps) => {
             // need to pass props when cloning this inside nested modal
             {...props}
             heading={<Translation id="TR_PIN_MISMATCH_HEADING" />}
-            data-test="@pin-mismatch"
+            data-testid="@pin-mismatch"
         >
             <StyledImage image="UNI_ERROR" />
-            <Button onClick={onTryAgain} data-test="@pin-mismatch/try-again-button">
+            <Button onClick={onTryAgain} data-testid="@pin-mismatch/try-again-button">
                 <Translation id="TR_TRY_AGAIN" />
             </Button>
         </StyledModal>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/SafetyChecksModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/SafetyChecksModal.tsx
@@ -51,7 +51,7 @@ export const SafetyChecksModal = ({ onCancel }: ModalProps) => {
                     onClick={confirm}
                     // Only allow confirming when the value will be changed.
                     isDisabled={isLocked() || level === device?.features?.safety_checks}
-                    data-test="@safety-checks-apply"
+                    data-testid="@safety-checks-apply"
                 >
                     <Translation id="TR_CONFIRM" />
                 </StyledButton>
@@ -61,7 +61,7 @@ export const SafetyChecksModal = ({ onCancel }: ModalProps) => {
                 <Radio
                     isChecked={level === 'Strict'}
                     onClick={() => setLevel('Strict')}
-                    data-test="@radio-button-strict"
+                    data-testid="@radio-button-strict"
                 >
                     <RadioInner>
                         <H3>
@@ -76,7 +76,7 @@ export const SafetyChecksModal = ({ onCancel }: ModalProps) => {
                     // For the purpose of this modal consider `PromptAlways` as identical to `PromptTemporarily`.
                     isChecked={level === 'PromptTemporarily' || level === 'PromptAlways'}
                     onClick={() => setLevel('PromptTemporarily')}
-                    data-test="@radio-button-prompt"
+                    data-testid="@radio-button-prompt"
                 >
                     <RadioInner>
                         <H3>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/DecreasedOutputs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/DecreasedOutputs.tsx
@@ -115,7 +115,7 @@ export const DecreasedOutputs = () => {
         <AnimatePresence initial>
             <motion.div {...motionAnimation.expand}>
                 <GreyCard>
-                    <WarnHeader data-test="@send/decreased-outputs">
+                    <WarnHeader data-testid="@send/decreased-outputs">
                         <Translation id={decreaseWarning} />
                     </WarnHeader>
                     <OutputsWrapper>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ReplaceTxButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ReplaceTxButton.tsx
@@ -26,7 +26,7 @@ export const ReplaceTxButton = () => {
     return (
         <Wrapper>
             <StyledButton
-                data-test="@send/replace-tx-button"
+                data-testid="@send/replace-tx-button"
                 isDisabled={isDisabled || isLoading}
                 onClick={signTransaction}
             >

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/IOAddress.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/IOAddress.tsx
@@ -97,7 +97,7 @@ export const IOAddress = ({
         <HiddenPlaceholder>
             <TextOverflowContainer
                 onMouseLeave={() => setIsClicked(false)}
-                data-test="@tx-detail/txid-value"
+                data-testid="@tx-detail/txid-value"
                 id={txAddress}
                 $shouldAllowCopy={shouldAllowCopy}
             >

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WipeDeviceModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WipeDeviceModal.tsx
@@ -61,7 +61,7 @@ export const WipeDeviceModal = ({ onCancel }: WipeDeviceModalProps) => {
                     variant="destructive"
                     onClick={handleWipeDevice}
                     isDisabled={isLocked() || !checkbox1 || !checkbox2}
-                    data-test="@wipe/wipe-button"
+                    data-testid="@wipe/wipe-button"
                 >
                     <Translation id="TR_DEVICE_SETTINGS_BUTTON_WIPE_DEVICE" />
                 </Button>
@@ -76,14 +76,14 @@ export const WipeDeviceModal = ({ onCancel }: WipeDeviceModalProps) => {
                         description={<Translation id="TR_WIPE_DEVICE_CHECKBOX_1_DESCRIPTION" />}
                         isChecked={checkbox1}
                         onClick={() => setCheckbox1(!checkbox1)}
-                        data-test="@wipe/checkbox-1"
+                        data-testid="@wipe/checkbox-1"
                     />
                     <CheckItem
                         title={<Translation id="TR_WIPE_DEVICE_CHECKBOX_2_TITLE" />}
                         description={<Translation id="TR_WIPE_DEVICE_CHECKBOX_2_DESCRIPTION" />}
                         isChecked={checkbox2}
                         onClick={() => setCheckbox2(!checkbox2)}
-                        data-test="@wipe/checkbox-2"
+                        data-testid="@wipe/checkbox-2"
                     />
                 </Col>
             </CheckItems>

--- a/packages/suite/src/components/suite/notifications/ToastNotification.tsx
+++ b/packages/suite/src/components/suite/notifications/ToastNotification.tsx
@@ -98,7 +98,7 @@ const ToastNotification = ({
     );
 
     return (
-        <Wrapper data-test={dataTestBase} $variant={variant} $isTall={isTall} ref={wrapperRef}>
+        <Wrapper data-testid={dataTestBase} $variant={variant} $isTall={isTall} ref={wrapperRef}>
             {defaultIcon && typeof defaultIcon === 'string' ? (
                 <Icon icon={defaultIcon} size={24} color={getVariantColor(variant)} />
             ) : (
@@ -120,7 +120,7 @@ const ToastNotification = ({
                     icon="CROSS"
                     hoverColor={theme.TYPE_LIGHTER_GREY}
                     onClick={handleCancelClick}
-                    data-test={`${dataTestBase}/close`}
+                    data-testid={`${dataTestBase}/close`}
                 />
             )}
         </Wrapper>

--- a/packages/suite/src/components/suite/troubleshooting/TroubleshootingTips.tsx
+++ b/packages/suite/src/components/suite/troubleshooting/TroubleshootingTips.tsx
@@ -87,7 +87,7 @@ interface TroubleshootingTipsProps {
     items: Item[];
     offerWebUsb?: boolean;
     opened?: boolean;
-    'data-test'?: string;
+    'data-testid'?: string;
 }
 
 export const TroubleshootingTips = ({
@@ -96,7 +96,7 @@ export const TroubleshootingTips = ({
     cta,
     offerWebUsb,
     opened,
-    'data-test': dataTest,
+    'data-testid': dataTest,
 }: TroubleshootingTipsProps) => {
     const { elevation } = useElevation();
 
@@ -125,14 +125,14 @@ export const TroubleshootingTips = ({
             heading={cta}
             iconLabel={label}
             defaultIsOpen={opened}
-            data-test={dataTest || '@onboarding/expand-troubleshooting-tips'}
+            data-testid={dataTest || '@onboarding/expand-troubleshooting-tips'}
         >
             {items.length > 0 && <Items>{memoizedItems}</Items>}
 
             {offerWebUsb && !isAndroid() && (
                 <StyledButton
                     variant="secondary"
-                    data-test="@onboarding/try-bridge-button"
+                    data-testid="@onboarding/try-bridge-button"
                     onClick={() => TrezorConnect.disableWebUSB()}
                 >
                     <Translation id="TR_DISABLE_WEBUSB_TRY_BRIDGE" />

--- a/packages/suite/src/components/suite/troubleshooting/tips/UdevDescription.tsx
+++ b/packages/suite/src/components/suite/troubleshooting/tips/UdevDescription.tsx
@@ -25,7 +25,7 @@ export const UdevDescription = () => {
                         <TrezorLink
                             variant="underline"
                             onClick={handleClick}
-                            data-test="@goto/udev"
+                            data-testid="@goto/udev"
                         >
                             {chunks}
                         </TrezorLink>

--- a/packages/suite/src/components/wallet/AnimationWrapper.tsx
+++ b/packages/suite/src/components/wallet/AnimationWrapper.tsx
@@ -7,7 +7,7 @@ interface AnimationWrapperProps {
     onAnimationStart?: () => void;
     onUpdate?: (latest: { [key: string]: ReactText }) => void;
     onAnimationComplete?: () => void;
-    dataTest?: string;
+    'data-testid'?: string;
 }
 
 export const AnimationWrapper = ({
@@ -16,7 +16,7 @@ export const AnimationWrapper = ({
     onAnimationStart,
     onUpdate,
     onAnimationComplete,
-    dataTest,
+    'data-testid': dataTest,
 }: AnimationWrapperProps) => {
     const collapsed = { overflow: 'hidden', height: 0 };
 
@@ -38,7 +38,7 @@ export const AnimationWrapper = ({
                     onUpdate={onUpdate}
                     onAnimationComplete={onAnimationComplete}
                     transition={transition}
-                    data-test={dataTest}
+                    data-testid={dataTest}
                 >
                     {children}
                 </motion.div>

--- a/packages/suite/src/components/wallet/DiscoveryProgress.tsx
+++ b/packages/suite/src/components/wallet/DiscoveryProgress.tsx
@@ -15,6 +15,9 @@ export const DiscoveryProgress = () => {
     if (!discovery || !isDiscoveryRunning) return null;
 
     return (
-        <StyledProgressBar value={calculateProgress()} data-test="@wallet/discovery-progress-bar" />
+        <StyledProgressBar
+            value={calculateProgress()}
+            data-testid="@wallet/discovery-progress-bar"
+        />
     );
 };

--- a/packages/suite/src/components/wallet/Fees/CustomFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/CustomFee.tsx
@@ -181,7 +181,7 @@ export const CustomFee = <TFieldValues extends FormState>({
                         label={<Translation id="TR_GAS_LIMIT" />}
                         inputState={getInputState(feeLimitError)}
                         name={FEE_LIMIT}
-                        data-test={FEE_LIMIT}
+                        data-testid={FEE_LIMIT}
                         onChange={changeFeeLimit}
                         rules={feeLimitRules}
                     />
@@ -194,7 +194,7 @@ export const CustomFee = <TFieldValues extends FormState>({
                     inputState={getInputState(feePerUnitError)}
                     innerAddon={<Units>{feeUnits}</Units>}
                     name={FEE_PER_UNIT}
-                    data-test={FEE_PER_UNIT}
+                    data-testid={FEE_PER_UNIT}
                     rules={feeRules}
                     bottomText={feePerUnitError?.message || null}
                 />

--- a/packages/suite/src/components/wallet/Pagination.tsx
+++ b/packages/suite/src/components/wallet/Pagination.tsx
@@ -98,7 +98,7 @@ export const Pagination = ({
                 calculatedPages.map(i => (
                     <PageItem
                         key={i}
-                        data-test={`@wallet/accounts/pagination/${i}`}
+                        data-testid={`@wallet/accounts/pagination/${i}`}
                         data-test-activated={i === currentPage ?? 'true'}
                         onClick={() => onPageSelected(i)}
                         $isActive={i === currentPage}
@@ -114,7 +114,7 @@ export const Pagination = ({
                         // https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318
                         <PageItem
                             key={i}
-                            data-test={`@wallet/accounts/pagination/${i + 1}`}
+                            data-testid={`@wallet/accounts/pagination/${i + 1}`}
                             onClick={() => onPageSelected(i + 1)}
                         >
                             {i + 1}

--- a/packages/suite/src/components/wallet/SearchAction.tsx
+++ b/packages/suite/src/components/wallet/SearchAction.tsx
@@ -53,7 +53,7 @@ export interface SearchProps {
     setExpanded: Dispatch<SetStateAction<boolean>>;
     setSearch: Dispatch<SetStateAction<string>>;
     onSearch: (event: ChangeEvent<HTMLInputElement>) => void;
-    dataTest?: string;
+    'data-testid'?: string;
 }
 
 export const SearchAction = ({
@@ -64,7 +64,7 @@ export const SearchAction = ({
     setExpanded,
     setSearch,
     onSearch,
-    dataTest,
+    'data-testid': dataTest,
 }: SearchProps) => {
     const theme = useTheme();
     const inputRef = useRef<HTMLInputElement | null>(null);
@@ -101,7 +101,7 @@ export const SearchAction = ({
 
             <StyledInput
                 $isExpanded={isExpanded}
-                data-test={dataTest}
+                data-testid={dataTest}
                 size="small"
                 innerRef={inputRef}
                 innerAddon={

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionHeading.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionHeading.tsx
@@ -141,7 +141,7 @@ export const TransactionHeading = ({
                 onMouseLeave={() => setHeadingIsHovered(false)}
                 onClick={onClick}
             >
-                <HeadingWrapper data-test={`${dataTestBase}/heading`}>
+                <HeadingWrapper data-testid={`${dataTestBase}/heading`}>
                     {isPhishingTransaction && (
                         <TooltipSymbol
                             content={

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
@@ -206,7 +206,7 @@ export const TransactionTarget = ({
                         {
                             onClick: copyAddress,
                             label: <Translation id="TR_ADDRESS_MODAL_CLIPBOARD" />,
-                            'data-test': 'copy-address', // hack: This will be prefixed in the withDropdown()
+                            'data-testid': 'copy-address', // hack: This will be prefixed in the withDropdown()
                         },
                     ]}
                     payload={{

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/AuthConfirmFailed.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/AuthConfirmFailed.tsx
@@ -18,7 +18,7 @@ export const AuthConfirmFailed = () => {
                 onClick: handleClick,
                 isLoading: isLocked(),
                 icon: 'REFRESH',
-                'data-test': '@passphrase-mismatch/retry-button',
+                'data-testid': '@passphrase-mismatch/retry-button',
                 children: <Translation id="TR_AUTH_CONFIRM_FAILED_RETRY" />,
             }}
         >

--- a/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountNavigation.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountNavigation.tsx
@@ -66,7 +66,7 @@ export const AccountNavigation = () => {
             },
             title: <Translation id="TR_NAV_DETAILS" />,
             isHidden: !['cardano', 'bitcoin'].includes(networkType),
-            'data-test': `@wallet/menu/wallet-details`,
+            'data-testid': `@wallet/menu/wallet-details`,
         },
     ];
 

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountGroup.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountGroup.tsx
@@ -115,12 +115,12 @@ export const AccountGroup = forwardRef(
                         <Header
                             $isOpen={isOpen}
                             onClick={!keepOpen ? onClick : undefined}
-                            data-test={`@account-menu/${type}`}
+                            data-testid={`@account-menu/${type}`}
                         >
                             <ChevronContainer>
                                 {!keepOpen && (
                                     <ChevronIcon
-                                        data-test="@account-menu/arrow"
+                                        data-testid="@account-menu/arrow"
                                         $isActive={isOpen}
                                         size={18}
                                         color={theme.iconSubdued}
@@ -136,7 +136,7 @@ export const AccountGroup = forwardRef(
                 <AnimationWrapper
                     opened={isOpen}
                     onUpdate={onUpdate}
-                    dataTest={`@account-menu/${type}/group`}
+                    data-testid={`@account-menu/${type}/group`}
                 >
                     {children}
                 </AnimationWrapper>

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem.tsx
@@ -226,13 +226,13 @@ export const AccountItem = forwardRef(
                 $isGroupSelected={isGroupSelected}
                 ref={ref}
                 onClick={handleHeaderClick}
-                data-test={dataTestKey}
+                data-testid={dataTestKey}
                 tabIndex={0}
             >
                 <Left>{getLeftComponent()}</Left>
                 <Right>
                     <Row>
-                        <AccountName $isSelected={isSelected} data-test={`${dataTestKey}/label`}>
+                        <AccountName $isSelected={isSelected} data-testid={`${dataTestKey}/label`}>
                             <AccountLabelContainer>
                                 {type === 'coin' && (
                                     <AccountLabel

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemSkeleton.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemSkeleton.tsx
@@ -20,7 +20,7 @@ export const AccountItemSkeleton = () => {
     const { shouldAnimate } = useLoadingSkeleton();
 
     return (
-        <Wrapper data-test="@account-menu/account-item-skeleton">
+        <Wrapper data-testid="@account-menu/account-item-skeleton">
             <Left>
                 <SkeletonCircle size="24px" />
             </Left>

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSearchBox.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSearchBox.tsx
@@ -51,7 +51,7 @@ export const AccountSearchBox = () => {
                 placeholder={translationString('TR_SEARCH')}
                 showClearButton="always"
                 onClear={onClear}
-                data-test="@account-menu/search-input"
+                data-testid="@account-menu/search-input"
             />
         </InputWrapper>
     );

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenu.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenu.tsx
@@ -72,7 +72,7 @@ export const AccountsMenu = () => {
                     {!isEmpty && <AccountSearchBox />}
                     <AddAccountButton
                         isFullWidth={isEmpty}
-                        data-test="@account-menu/add-account"
+                        data-testid="@account-menu/add-account"
                         device={device}
                     />
                 </Row>

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/CoinsFilter.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/CoinsFilter.tsx
@@ -89,7 +89,7 @@ export const CoinsFilter = () => {
                         >
                             <motion.div key={network} {...coinAnimcationConfig} layout>
                                 <StyledCoinLogo
-                                    data-test={`@account-menu/filter/${network}`}
+                                    data-testid={`@account-menu/filter/${network}`}
                                     symbol={network}
                                     size={16}
                                     data-test-activated={coinFilter === network}

--- a/packages/suite/src/support/tests/hooksHelper.tsx
+++ b/packages/suite/src/support/tests/hooksHelper.tsx
@@ -40,14 +40,14 @@ export function findByTestId(id: RegExp): HTMLElement[];
 export function findByTestId(id: any) {
     if (typeof id === 'string') {
         return screen.getByText((_, element) => {
-            const attrValue = element?.getAttribute('data-test');
+            const attrValue = element?.getAttribute('data-testid');
 
             return attrValue ? attrValue === id : false;
         });
     }
 
     return screen.getAllByText((_, element) => {
-        const attrValue = element?.getAttribute('data-test');
+        const attrValue = element?.getAttribute('data-testid');
 
         return attrValue ? id.test(attrValue) : false;
     });

--- a/packages/suite/src/views/backup/index.tsx
+++ b/packages/suite/src/views/backup/index.tsx
@@ -49,7 +49,7 @@ type CloseButtonProps = {
 const CloseButton = ({ onClick, variant }: CloseButtonProps) => (
     <StyledButton
         onClick={onClick}
-        data-test="@backup/close-button"
+        data-testid="@backup/close-button"
         variant="tertiary"
         icon="CROSS"
     >
@@ -98,7 +98,7 @@ export const Backup = ({ cancelable, onCancel }: ForegroundAppProps) => {
                 heading={<Translation id="TR_RECONNECT_HEADER" />}
                 isCancelable
                 onCancel={onCancel}
-                data-test="@backup/no-device"
+                data-testid="@backup/no-device"
             >
                 <StyledImage image="CONNECT_DEVICE" width="360" />
             </Modal>
@@ -125,7 +125,7 @@ export const Backup = ({ cancelable, onCancel }: ForegroundAppProps) => {
                 {device.features.unfinished_backup ? (
                     <VerticalCenter>
                         <StyledImage image="UNI_ERROR" />
-                        <StyledP data-test="@backup/already-failed-message">
+                        <StyledP data-testid="@backup/already-failed-message">
                             <Translation id="BACKUP_BACKUP_ALREADY_FAILED_DESCRIPTION" />
                             <TrezorLink icon="EXTERNAL_LINK" href={HELP_CENTER_RECOVERY_ISSUES_URL}>
                                 <Translation id="TR_LEARN_MORE" />
@@ -135,7 +135,7 @@ export const Backup = ({ cancelable, onCancel }: ForegroundAppProps) => {
                 ) : (
                     <VerticalCenter>
                         <StyledImage image="UNI_SUCCESS" />
-                        <StyledP data-test="@backup/already-finished-message">
+                        <StyledP data-testid="@backup/already-finished-message">
                             <Translation id="BACKUP_BACKUP_ALREADY_FINISHED_DESCRIPTION" />
                         </StyledP>
                     </VerticalCenter>
@@ -157,7 +157,7 @@ export const Backup = ({ cancelable, onCancel }: ForegroundAppProps) => {
         <StyledModal
             isCancelable={cancelable}
             onCancel={onCancel}
-            data-test="@backup"
+            data-testid="@backup"
             heading={getModalHeading(backup.status)}
             totalProgressBarSteps={nonErrorBackupStatuses.length}
             currentProgressBarStep={currentProgressBarStep}
@@ -166,7 +166,7 @@ export const Backup = ({ cancelable, onCancel }: ForegroundAppProps) => {
                     {backup.status === 'initial' && (
                         <>
                             <StyledButton
-                                data-test="@backup/start-button"
+                                data-testid="@backup/start-button"
                                 onClick={() => dispatch(backupDevice(backupParams))}
                                 isDisabled={!canStart(backup.userConfirmed, locks)}
                             >
@@ -189,7 +189,7 @@ export const Backup = ({ cancelable, onCancel }: ForegroundAppProps) => {
                                 <>
                                     <CloseButton onClick={onCancel} variant="TR_SKIP_PIN" />
                                     <StyledButton
-                                        data-test="@backup/continue-to-pin-button"
+                                        data-testid="@backup/continue-to-pin-button"
                                         isDisabled={!canContinue(backup.userConfirmed)}
                                         onClick={() => {
                                             onCancel();
@@ -222,7 +222,7 @@ export const Backup = ({ cancelable, onCancel }: ForegroundAppProps) => {
 
             {backup.status === 'finished' && (
                 <>
-                    <StyledP typographyStyle="hint" data-test="@backup/success-message">
+                    <StyledP typographyStyle="hint" data-testid="@backup/success-message">
                         <Translation id="TR_BACKUP_FINISHED_TEXT" />
                     </StyledP>
                     <AfterBackupCheckboxes />
@@ -233,7 +233,7 @@ export const Backup = ({ cancelable, onCancel }: ForegroundAppProps) => {
                 <Row justifyContent="center">
                     <VerticalCenter>
                         <StyledImage image="UNI_ERROR" />
-                        <StyledP data-test="@backup/error-message">{backup.error}</StyledP>
+                        <StyledP data-testid="@backup/error-message">{backup.error}</StyledP>
                     </VerticalCenter>
                 </Row>
             )}

--- a/packages/suite/src/views/dashboard/components/AssetsView/components/AssetCard.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsView/components/AssetCard.tsx
@@ -179,7 +179,7 @@ export const AssetCard = ({
                     </div>
                     <CoinmarketBuyButton
                         symbol={symbol}
-                        dataTest={`@dashboard/assets/grid/${symbol}/buy-button`}
+                        data-testid={`@dashboard/assets/grid/${symbol}/buy-button`}
                     />
                 </BuyContainerCard>
             )}

--- a/packages/suite/src/views/dashboard/components/AssetsView/components/AssetRow.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsView/components/AssetRow.tsx
@@ -165,7 +165,7 @@ export const AssetRow = memo(
                 {!failed ? (
                     <CryptoBalanceWrapper
                         $isLastRow={isLastRow}
-                        data-test={`@asset-card/${symbol}/balance`}
+                        data-testid={`@asset-card/${symbol}/balance`}
                     >
                         <FiatBalanceWrapper>
                             <FiatValue amount={cryptoValue} symbol={symbol} />
@@ -199,7 +199,7 @@ export const AssetRow = memo(
                     {!isTestnet(symbol) && (
                         <CoinmarketBuyButton
                             symbol={symbol}
-                            dataTest={`@dashboard/assets/table/${symbol}/buy-button`}
+                            data-testid={`@dashboard/assets/table/${symbol}/buy-button`}
                         />
                     )}
                     <StyledArrowIcon size={16} icon="ARROW_RIGHT_LONG" color={theme.iconSubdued} />

--- a/packages/suite/src/views/dashboard/components/AssetsView/index.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsView/index.tsx
@@ -159,14 +159,14 @@ export const AssetsView = () => {
                                 icon="PLUS"
                                 size="small"
                                 onClick={goToCoinsSettings}
-                                data-test="@dashboard/assets/enable-more-coins"
+                                data-testid="@dashboard/assets/enable-more-coins"
                             >
                                 <Translation id="TR_ENABLE_MORE_COINS" />
                             </StyledAddAccountButton>
                         )}
                         <Icon
                             icon="TABLE"
-                            data-test="@dashboard/assets/table-icon"
+                            data-testid="@dashboard/assets/table-icon"
                             onClick={setTable}
                             color={
                                 !dashboardAssetsGridMode
@@ -176,7 +176,7 @@ export const AssetsView = () => {
                         />
                         <Icon
                             icon="GRID"
-                            data-test="@dashboard/assets/grid-icon"
+                            data-testid="@dashboard/assets/grid-icon"
                             onClick={setGrid}
                             color={
                                 dashboardAssetsGridMode

--- a/packages/suite/src/views/dashboard/components/CoinmarketBuyButton.tsx
+++ b/packages/suite/src/views/dashboard/components/CoinmarketBuyButton.tsx
@@ -8,10 +8,10 @@ import { MouseEvent } from 'react';
 
 interface BuyButtonProps {
     symbol: NetworkSymbol;
-    dataTest: string;
+    'data-testid'?: string;
 }
 
-export const CoinmarketBuyButton = ({ symbol, dataTest }: BuyButtonProps) => {
+export const CoinmarketBuyButton = ({ symbol, 'data-testid': dataTest }: BuyButtonProps) => {
     const dispatch = useDispatch();
     const { setCoinFilter, setSearchString } = useAccountSearch();
 
@@ -41,7 +41,7 @@ export const CoinmarketBuyButton = ({ symbol, dataTest }: BuyButtonProps) => {
     };
 
     return (
-        <Button onClick={onClick} variant="tertiary" data-test={dataTest} size="small">
+        <Button onClick={onClick} variant="tertiary" data-testid={dataTest} size="small">
             <Translation id="TR_BUY_BUY" />
         </Button>
     );

--- a/packages/suite/src/views/dashboard/components/PortfolioCard/components/DashboardGraph.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/components/DashboardGraph.tsx
@@ -125,7 +125,7 @@ export const DashboardGraph = memo(({ accounts }: DashboardGraphProps) => {
     }, [dispatch, isLoading, selectedDeviceState, selectedRange]);
 
     return (
-        <Wrapper data-test="@dashboard/graph">
+        <Wrapper data-testid="@dashboard/graph">
             <GraphWrapper>
                 {allFailed ? (
                     <ErrorMessage>

--- a/packages/suite/src/views/dashboard/components/PortfolioCard/components/EmptyWallet.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/components/EmptyWallet.tsx
@@ -38,7 +38,7 @@ const StyledImage = styled(Image)`
 type EmptyWalletProps = HTMLAttributes<HTMLDivElement>;
 
 export const EmptyWallet = (props: EmptyWalletProps) => (
-    <Wrapper {...props} data-test="@dashboard/wallet-ready">
+    <Wrapper {...props} data-testid="@dashboard/wallet-ready">
         <StyledImage image="UNI_SUCCESS" />
         <Content>
             <Title>

--- a/packages/suite/src/views/dashboard/components/PortfolioCard/components/Exception.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/components/Exception.tsx
@@ -68,7 +68,7 @@ const Container = ({ title, description, cta, dataTestBase }: ContainerProps) =>
     const actions = Array.isArray(cta) ? cta : [cta];
 
     return (
-        <Wrapper data-test={`@exception/${dataTestBase}`}>
+        <Wrapper data-testid={`@exception/${dataTestBase}`}>
             <StyledImage image="UNI_ERROR" />
             <Title>
                 <Translation id={title} />
@@ -90,7 +90,7 @@ const Container = ({ title, description, cta, dataTestBase }: ContainerProps) =>
                         icon={a.icon || 'PLUS'}
                         isLoading={isLocked()}
                         onClick={a.action}
-                        data-test={`@exception/${dataTestBase}/${a.variant || 'primary'}-button`}
+                        data-testid={`@exception/${dataTestBase}/${a.variant || 'primary'}-button`}
                     >
                         <Translation id={a.label || 'TR_RETRY'} />
                     </Button>

--- a/packages/suite/src/views/dashboard/components/PortfolioCard/components/Header.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/components/Header.tsx
@@ -87,13 +87,13 @@ export const Header = ({
                     <Buttons>
                         <WalletEmptyButton
                             onClick={receiveClickHandler}
-                            data-test="@dashboard/receive-button"
+                            data-testid="@dashboard/receive-button"
                         >
                             <Translation id="TR_RECEIVE" />
                         </WalletEmptyButton>
                         <WalletEmptyButton
                             onClick={buyClickHandler}
-                            data-test="@dashboard/buy-button"
+                            data-testid="@dashboard/buy-button"
                             variant="tertiary"
                         >
                             <Translation id="TR_BUY" />

--- a/packages/suite/src/views/dashboard/components/PortfolioCard/index.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/index.tsx
@@ -72,7 +72,7 @@ const PortfolioCard = memo(() => {
         body = dashboardGraphHidden ? null : (
             <SkeletonTransactionsGraphWrapper>
                 <Wrapper>
-                    <GraphSkeleton data-test="@dashboard/loading" />
+                    <GraphSkeleton data-testid="@dashboard/loading" />
                 </Wrapper>
             </SkeletonTransactionsGraphWrapper>
         );

--- a/packages/suite/src/views/dashboard/components/SecurityCard.tsx
+++ b/packages/suite/src/views/dashboard/components/SecurityCard.tsx
@@ -114,7 +114,7 @@ export const SecurityCard = ({ variant, icon, heading, description, cta }: Secur
                                     size="small"
                                     {...(cta.dataTest
                                         ? {
-                                              'data-test': `@dashboard/security-card/${cta.dataTest}/button`,
+                                              'data-testid': `@dashboard/security-card/${cta.dataTest}/button`,
                                           }
                                         : {})}
                                 >
@@ -137,7 +137,7 @@ export const SecurityCard = ({ variant, icon, heading, description, cta }: Secur
                                     size="small"
                                     {...(cta.dataTest
                                         ? {
-                                              'data-test': `@dashboard/security-card/${cta.dataTest}/button`,
+                                              'data-testid': `@dashboard/security-card/${cta.dataTest}/button`,
                                           }
                                         : {})}
                                 >

--- a/packages/suite/src/views/dashboard/index.tsx
+++ b/packages/suite/src/views/dashboard/index.tsx
@@ -25,7 +25,7 @@ export const Dashboard = () => {
     useLayout('Home', PageHeader);
 
     return (
-        <Wrapper data-test="@dashboard/index">
+        <Wrapper data-testid="@dashboard/index">
             <DashboardPassphraseBanner />
             <PortfolioCard />
             <T3T1PromoBanner />

--- a/packages/suite/src/views/firmware/FirmwareModal.tsx
+++ b/packages/suite/src/views/firmware/FirmwareModal.tsx
@@ -138,7 +138,7 @@ export const FirmwareModal = ({
                 )
             }
             onCancel={onClose}
-            data-test="@firmware-modal"
+            data-testid="@firmware-modal"
             heading={<Translation id={heading} />}
         >
             <Wrapper $isWithTopPadding={!isCancelable}>{getComponent()}</Wrapper>

--- a/packages/suite/src/views/onboarding/UnexpectedState/components/IsSameDevice.tsx
+++ b/packages/suite/src/views/onboarding/UnexpectedState/components/IsSameDevice.tsx
@@ -24,7 +24,7 @@ const IsSameDevice = () => {
                         enableOnboardingReducer(true);
                     }}
                     variant="secondary"
-                    data-test="@onboarding/unexpected-state/is-same/start-over-button"
+                    data-testid="@onboarding/unexpected-state/is-same/start-over-button"
                 >
                     <Translation id="TR_START_AGAIN" />
                 </Button>

--- a/packages/suite/src/views/onboarding/steps/Backup.tsx
+++ b/packages/suite/src/views/onboarding/steps/Backup.tsx
@@ -74,7 +74,7 @@ export const BackupStep = () => {
                     description={<Translation id="TR_ONBOARDING_BACKUP_SUBHEADING" />}
                     innerActions={
                         <OnboardingButtonCta
-                            data-test="@backup/start-button"
+                            data-testid="@backup/start-button"
                             onClick={handleBackup}
                             isDisabled={!canContinue(backup.userConfirmed, locks)}
                         >
@@ -83,7 +83,7 @@ export const BackupStep = () => {
                     }
                     outerActions={
                         <OnboardingButtonSkip
-                            data-test="@onboarding/exit-app-button"
+                            data-testid="@onboarding/exit-app-button"
                             onClick={handleSkip}
                         >
                             <Translation id="TR_SKIP_BACKUP" />
@@ -114,7 +114,7 @@ export const BackupStep = () => {
                     description={<Translation id="TR_BACKUP_FINISHED_TEXT" />}
                     innerActions={
                         <OnboardingButtonCta
-                            data-test="@backup/close-button"
+                            data-testid="@backup/close-button"
                             onClick={() => dispatch(goToNextStep())}
                             isDisabled={!canContinue(backup.userConfirmed)}
                         >

--- a/packages/suite/src/views/onboarding/steps/BasicSettings/TorSection.tsx
+++ b/packages/suite/src/views/onboarding/steps/BasicSettings/TorSection.tsx
@@ -47,7 +47,7 @@ export const TorSection = ({ torStatus }: TorSectionProps) => {
             </Label>
             <SwitchWrapper>
                 <Switch
-                    dataTest="@onboarding/tor-switch"
+                    data-testid="@onboarding/tor-switch"
                     isChecked={isChecked}
                     isDisabled={isTorLoading}
                     onChange={handleChange}

--- a/packages/suite/src/views/onboarding/steps/BasicSettings/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/BasicSettings/index.tsx
@@ -33,7 +33,7 @@ const BasicSettings = () => {
             outerActions={
                 <AdvancedSetup>
                     <OnboardingButtonCta
-                        data-test="@onboarding/coins/continue-button"
+                        data-testid="@onboarding/coins/continue-button"
                         onClick={() => {
                             goToNextStep();
                         }}

--- a/packages/suite/src/views/onboarding/steps/CreateOrRecover.tsx
+++ b/packages/suite/src/views/onboarding/steps/CreateOrRecover.tsx
@@ -19,7 +19,7 @@ const CreateOrRecoverStep = () => {
             <OptionsWrapper>
                 <OnboardingOption
                     icon="NEW"
-                    data-test="@onboarding/path-create-button"
+                    data-testid="@onboarding/path-create-button"
                     onClick={() => {
                         addPath(STEP.PATH_CREATE);
                         goToNextStep();
@@ -30,7 +30,7 @@ const CreateOrRecoverStep = () => {
                 <OptionsDivider />
                 <OnboardingOption
                     icon="RECOVER"
-                    data-test="@onboarding/path-recovery-button"
+                    data-testid="@onboarding/path-recovery-button"
                     onClick={() => {
                         addPath(STEP.PATH_RECOVERY);
                         goToNextStep();

--- a/packages/suite/src/views/onboarding/steps/Final.tsx
+++ b/packages/suite/src/views/onboarding/steps/Final.tsx
@@ -130,7 +130,7 @@ export const FinalStep = () => {
 
     return (
         <OnboardingStepBox
-            data-test="@onboarding/final"
+            data-testid="@onboarding/final"
             device={isWaitingForConfirm ? device : undefined}
             isActionAbortable={isActionAbortable}
         >
@@ -205,7 +205,7 @@ export const FinalStep = () => {
 
                     <EnterSuiteButton
                         variant="primary"
-                        data-test="@onboarding/exit-app-button"
+                        data-testid="@onboarding/exit-app-button"
                         onClick={() => {
                             goToSuite(true);
 

--- a/packages/suite/src/views/onboarding/steps/Pin.tsx
+++ b/packages/suite/src/views/onboarding/steps/Pin.tsx
@@ -82,11 +82,11 @@ const SetPinStep = () => {
                 image="PIN"
                 key="pin-mismatch" // to properly rerender in translation mode
                 heading={<Translation id="TR_PIN_MISMATCH_HEADING" />}
-                data-test="@pin-mismatch"
+                data-testid="@pin-mismatch"
                 innerActions={
                     <OnboardingButtonCta
                         onClick={onTryAgain}
-                        data-test="@pin-mismatch/try-again-button"
+                        data-testid="@pin-mismatch/try-again-button"
                     >
                         <Translation id="TR_TRY_AGAIN" />
                     </OnboardingButtonCta>
@@ -105,7 +105,7 @@ const SetPinStep = () => {
                 description={<Translation id="TR_PIN_SET_SUCCESS" />}
                 outerActions={
                     <OnboardingButtonCta
-                        data-test="@onboarding/pin/continue-button"
+                        data-testid="@onboarding/pin/continue-button"
                         onClick={() => goToNextStep()}
                     >
                         <Translation id="TR_CONTINUE" />
@@ -136,7 +136,7 @@ const SetPinStep = () => {
                     // "Create a pin" button to start the process, continue button after the pin is set (as outerAction), no primary CTA during the setup procedure on T2T1
                     !showConfirmationPrompt ? (
                         <OnboardingButtonCta
-                            data-test="@onboarding/set-pin-button"
+                            data-testid="@onboarding/set-pin-button"
                             onClick={setPin}
                         >
                             <Translation id="TR_SET_PIN" />
@@ -147,7 +147,10 @@ const SetPinStep = () => {
                     // show skip button only if we are not done yet with setting up the pin (state is other than success state)
                     // and if confirmation prompt is not active (I guess there is no point showing back btn which can't be clicked because it is under the modal)
                     !showConfirmationPrompt ? (
-                        <OnboardingButtonSkip data-test="@onboarding/skip-button" onClick={skipPin}>
+                        <OnboardingButtonSkip
+                            data-testid="@onboarding/skip-button"
+                            onClick={skipPin}
+                        >
                             <Translation id="TR_SKIP" />
                         </OnboardingButtonSkip>
                     ) : undefined

--- a/packages/suite/src/views/onboarding/steps/Recovery/RecoveryStepBox.tsx
+++ b/packages/suite/src/views/onboarding/steps/Recovery/RecoveryStepBox.tsx
@@ -54,7 +54,7 @@ const RecoveryStepBox = (props: OnboardingStepBoxProps) => {
                 isBackButtonVisible() ? (
                     <OnboardingButtonBack
                         onClick={() => handleBack()}
-                        data-test="@onboarding/recovery/back-button"
+                        data-testid="@onboarding/recovery/back-button"
                     />
                 ) : undefined
             }

--- a/packages/suite/src/views/onboarding/steps/Recovery/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Recovery/index.tsx
@@ -76,7 +76,7 @@ export const RecoveryStep = () => {
                 }
                 innerActions={
                     <OnboardingButtonCta
-                        data-test="@onboarding/recovery/start-button"
+                        data-testid="@onboarding/recovery/start-button"
                         onClick={recoverDevice}
                     >
                         <Translation id="TR_START_RECOVERY" />
@@ -166,7 +166,7 @@ export const RecoveryStep = () => {
                 heading={<Translation id="TR_WALLET_RECOVERED_FROM_SEED" />}
                 innerActions={
                     <OnboardingButtonCta
-                        data-test="@onboarding/recovery/continue-button"
+                        data-testid="@onboarding/recovery/continue-button"
                         onClick={handleClick}
                     >
                         <Translation id="TR_CONTINUE" />
@@ -184,7 +184,7 @@ export const RecoveryStep = () => {
                 description={<Translation id="TR_RECOVERY_ERROR" values={{ error }} />}
                 innerActions={
                     <OnboardingButtonCta
-                        data-test="@onboarding/recovery/retry-button"
+                        data-testid="@onboarding/recovery/retry-button"
                         onClick={
                             deviceModelInternal === DeviceModelInternal.T1B1
                                 ? resetReducer

--- a/packages/suite/src/views/onboarding/steps/ResetDevice.tsx
+++ b/packages/suite/src/views/onboarding/steps/ResetDevice.tsx
@@ -157,7 +157,7 @@ export const ResetDeviceStep = () => {
                                     onOpen={() => updateAnalytics({ wasSelectTypeOpened: true })}
                                     onSelect={setBackupType}
                                     isDisabled={isDeviceLocked}
-                                    data-test="@onboarding/select-seed-type-open-dialog"
+                                    data-testid="@onboarding/select-seed-type-open-dialog"
                                 />
                                 <Divider />
                             </>
@@ -167,7 +167,7 @@ export const ResetDeviceStep = () => {
                                 variant="primary"
                                 isDisabled={isDeviceLocked}
                                 onClick={() => handleSubmit(backupType)}
-                                data-test="@onboarding/select-seed-type-confirm"
+                                data-testid="@onboarding/select-seed-type-confirm"
                             >
                                 <Translation id="TR_ONBOARDING_SELECT_SEED_TYPE_CONFIRM" />
                             </Button>

--- a/packages/suite/src/views/onboarding/steps/Security.tsx
+++ b/packages/suite/src/views/onboarding/steps/Security.tsx
@@ -23,7 +23,7 @@ const SecurityStep = () => {
                 description={<Translation id="TR_YOUR_WALLET_IS_ALMOST_READY_DESCRIPTION" />}
                 innerActions={
                     <OnboardingButtonCta
-                        data-test="@onboarding/create-backup-button"
+                        data-testid="@onboarding/create-backup-button"
                         onClick={() => {
                             goToNextStep();
                         }}
@@ -33,7 +33,7 @@ const SecurityStep = () => {
                 }
                 outerActions={
                     <OnboardingButtonSkip
-                        data-test="@onboarding/skip-backup"
+                        data-testid="@onboarding/skip-backup"
                         onClick={() => {
                             setShowSkipConfirmation(true);
                             updateAnalytics({ backup: 'skip' });

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/DeviceAuthenticity.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/DeviceAuthenticity.tsx
@@ -94,7 +94,7 @@ export const DeviceAuthenticity = ({ goToNext }: DeviceAuthenticityProps) => {
                 onClick={handleClick}
                 isDisabled={isLoading}
                 isLoading={isLoading}
-                data-test={
+                data-testid={
                     isCheckSuccessful
                         ? '@authenticity-check/continue-button'
                         : `@authenticity-check/start-button`

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheck.tsx
@@ -279,7 +279,7 @@ const SecurityCheckContent = ({
                 </StyledSecurityCheckButton>
                 {initialized ? (
                     <StyledSecurityCheckButton
-                        data-test="@onboarding/exit-app-button"
+                        data-testid="@onboarding/exit-app-button"
                         onClick={handleContinueButtonClick}
                     >
                         <Translation id="TR_YES_CONTINUE" />
@@ -287,7 +287,7 @@ const SecurityCheckContent = ({
                 ) : (
                     <SecurityCheckButtonWithSecondLine
                         onClick={handleSetupButtonClick}
-                        data-test="@analytics/continue-button"
+                        data-testid="@analytics/continue-button"
                     >
                         <Translation id={primaryButtonTopText} />
                         <TimeEstimateWrapper>

--- a/packages/suite/src/views/onboarding/steps/SelectBackupType/OptionWithContent.tsx
+++ b/packages/suite/src/views/onboarding/steps/SelectBackupType/OptionWithContent.tsx
@@ -90,7 +90,7 @@ type OptionProps = {
     children: ReactNode;
     onSelect: () => void;
     isChecked: boolean;
-    'data-test'?: string;
+    'data-testid'?: string;
     disabled?: boolean;
 };
 
@@ -98,7 +98,7 @@ const Option = ({
     children,
     onSelect,
     isChecked,
-    'data-test': dataTest,
+    'data-testid': dataTest,
     disabled,
 }: OptionProps) => (
     <OptionStyled
@@ -109,7 +109,7 @@ const Option = ({
         <Radio
             isChecked={isChecked}
             onClick={onSelect}
-            data-test={dataTest}
+            data-testid={dataTest}
             isDisabled={disabled}
         />
         {children}
@@ -166,7 +166,7 @@ export const OptionWithContent = ({
         <Option
             onSelect={() => onSelect(value)}
             isChecked={selected === value}
-            data-test={`@onboarding/select-seed-type-${value}`}
+            data-testid={`@onboarding/select-seed-type-${value}`}
             disabled={disabled}
         >
             <OptionText>

--- a/packages/suite/src/views/onboarding/steps/SelectBackupType/SelectBackupType.tsx
+++ b/packages/suite/src/views/onboarding/steps/SelectBackupType/SelectBackupType.tsx
@@ -84,7 +84,7 @@ type SelectBackupTypeProps = {
     isDisabled: boolean;
     selected: BackupType;
     onSelect: (value: BackupType) => void;
-    'data-test'?: string;
+    'data-testid'?: string;
     onOpen: () => void;
 };
 
@@ -92,7 +92,7 @@ export const SelectBackupType = ({
     selected,
     onSelect,
     isDisabled,
-    'data-test': dataTest,
+    'data-testid': dataTest,
     onOpen,
 }: SelectBackupTypeProps) => {
     const { elevation } = useElevation();
@@ -146,7 +146,7 @@ export const SelectBackupType = ({
                             onOpen();
                         }}
                     >
-                        <OptionText data-test={dataTest}>
+                        <OptionText data-testid={dataTest}>
                             <Text variant="tertiary" typographyStyle="hint">
                                 <Translation id="TR_ONBOARDING_BACKUP_TYPE" />
                             </Text>

--- a/packages/suite/src/views/recovery/index.tsx
+++ b/packages/suite/src/views/recovery/index.tsx
@@ -104,7 +104,7 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
                 heading={<Translation id="TR_RECONNECT_HEADER" />}
                 isCancelable
                 onCancel={onCancel}
-                data-test="@recovery/no-device"
+                data-testid="@recovery/no-device"
             >
                 <StyledImage image="CONNECT_DEVICE" width="360" />
             </Modal>
@@ -121,7 +121,7 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
                             : dispatch(checkSeed())
                     }
                     isDisabled={!understood || isLocked()}
-                    data-test="@recovery/start-button"
+                    data-testid="@recovery/start-button"
                 >
                     <Translation id="TR_START" />
                 </StyledButton>
@@ -183,7 +183,7 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
                         </StepsContainer>
 
                         <CheckItem
-                            data-test="@recovery/user-understands-checkbox"
+                            data-testid="@recovery/user-understands-checkbox"
                             title={<Translation id="TR_DRY_RUN_CHECK_ITEM_TITLE" />}
                             description={<Translation id="TR_DRY_RUN_CHECK_ITEM_DESCRIPTION" />}
                             isChecked={understood}
@@ -228,7 +228,7 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
                 return !recovery.error ? (
                     <VerticalCenter>
                         <StatusImage image="UNI_SUCCESS" />
-                        <H2 data-test="@recovery/success-title">
+                        <H2 data-testid="@recovery/success-title">
                             <Translation id="TR_SEED_CHECK_SUCCESS_TITLE" />
                         </H2>
                         <StyledP typographyStyle="hint">

--- a/packages/suite/src/views/settings/SettingsDebug/AutoStart.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/AutoStart.tsx
@@ -29,7 +29,7 @@ export const AutoStart = () => {
             <ActionColumn>
                 <PositionedSwitch>
                     <Switch
-                        dataTest="@autostart/toggle-switch"
+                        data-testid="@autostart/toggle-switch"
                         isChecked={!!autoStartEnabled}
                         onChange={handleChange}
                     />

--- a/packages/suite/src/views/settings/SettingsDebug/CheckFirmwareAuthenticity.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/CheckFirmwareAuthenticity.tsx
@@ -24,7 +24,7 @@ export const CheckFirmwareAuthenticity = () => {
 
     return (
         <>
-            <SectionItem data-test="@settings/debug/check-firmware-authenticity">
+            <SectionItem data-testid="@settings/debug/check-firmware-authenticity">
                 <TextColumn
                     title="Check firmware authenticity"
                     description="Download firmware binary from data.trezor.io and compare its hash with firmware hash provided by Trezor device."
@@ -39,7 +39,7 @@ export const CheckFirmwareAuthenticity = () => {
                     </Button>
                 </ActionColumn>
             </SectionItem>
-            <SectionItem data-test="@settings/debug/check-firmware-authenticity-on-connect/switch">
+            <SectionItem data-testid="@settings/debug/check-firmware-authenticity-on-connect/switch">
                 <TextColumn
                     title="Check firmware authenticity regularly"
                     description="Carry out firmware authenticity check every time you authorize Trezor device"

--- a/packages/suite/src/views/settings/SettingsDebug/CoinjoinApi.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/CoinjoinApi.tsx
@@ -63,7 +63,7 @@ const CoordinatorServer = ({
     const networkName = networks[symbol].name;
 
     return (
-        <SectionItem data-test={`@settings/debug/coinjoin/${symbol}`}>
+        <SectionItem data-testid={`@settings/debug/coinjoin/${symbol}`}>
             <TextColumn
                 title={`${networkName}`}
                 description={
@@ -79,7 +79,7 @@ const CoordinatorServer = ({
                     onChange={({ value }) => onChange(symbol, value)}
                     value={selectedOption}
                     options={options}
-                    data-test={`@settings/debug/coinjoin/${symbol}/server-select`}
+                    data-testid={`@settings/debug/coinjoin/${symbol}/server-select`}
                 />
             </ActionColumn>
         </SectionItem>

--- a/packages/suite/src/views/settings/SettingsDebug/DeviceAuthenticity.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/DeviceAuthenticity.tsx
@@ -12,7 +12,7 @@ export const DeviceAuthenticity = () => {
         dispatch(setDebugMode({ isUnlockedBootloaderAllowed: state }));
 
     return (
-        <SectionItem data-test="@settings/debug/device-authenticity/switch">
+        <SectionItem data-testid="@settings/debug/device-authenticity/switch">
             <TextColumn
                 title="Allow unlocked bootloader"
                 description="Skip device authenticity check when bootloader is unlocked."

--- a/packages/suite/src/views/settings/SettingsDebug/Devkit.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/Devkit.tsx
@@ -13,7 +13,7 @@ export const Devkit = () => {
     };
 
     return (
-        <SectionItem data-test="@settings/debug/firmware-devkit/switch">
+        <SectionItem data-testid="@settings/debug/firmware-devkit/switch">
             <TextColumn
                 title="Devkit"
                 description="Offer devkit versions of firmware binaries. Never install regular firmware on devkit and vice versa! Use this only if you know what you are doing."

--- a/packages/suite/src/views/settings/SettingsDebug/ThrowTestingError.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/ThrowTestingError.tsx
@@ -3,7 +3,7 @@ import { ActionButton, ActionColumn, SectionItem, TextColumn } from 'src/compone
 // TODO add possibility to throw testing error from Electron main process
 
 export const ThrowTestingError = () => (
-    <SectionItem data-test="@settings/debug/throw-testing-error">
+    <SectionItem data-testid="@settings/debug/throw-testing-error">
         <TextColumn
             title="Throw testing error"
             description="Throw testing error to debug issues reporting to Sentry"

--- a/packages/suite/src/views/settings/SettingsDebug/Transport.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/Transport.tsx
@@ -42,7 +42,7 @@ export const Transport = () => {
 
     return (
         <>
-            <SectionItem data-test="@settings/debug/transport">
+            <SectionItem data-testid="@settings/debug/transport">
                 <TextColumn
                     title="Transport clients"
                     description="You may override TrezorConnect default settings here. Select your preferred transport clients that are to be used. You will need to reload after changes"
@@ -51,7 +51,7 @@ export const Transport = () => {
             {/* todo: make it drag and drop sortable */}
             {transports.map(transport => (
                 <SectionItem
-                    data-test={`@settings/debug/transport/${transport.name}`}
+                    data-testid={`@settings/debug/transport/${transport.name}`}
                     key={transport.name}
                 >
                     <TextColumn

--- a/packages/suite/src/views/settings/SettingsDebug/TransportBackends.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/TransportBackends.tsx
@@ -58,13 +58,13 @@ export const TransportBackends = () => {
 
     return (
         <>
-            <SectionItem data-test="@settings/debug/processes">
+            <SectionItem data-testid="@settings/debug/processes">
                 <TextColumn
                     title="Transport backends"
                     description="You may need to restart your application after changes are made."
                 />
             </SectionItem>
-            <SectionItem data-test="@settings/debug/processes/Bridge">
+            <SectionItem data-testid="@settings/debug/processes/Bridge">
                 <TextColumn title="Bridge running" />
                 <ActionColumn>
                     <Checkbox
@@ -75,7 +75,7 @@ export const TransportBackends = () => {
                     />
                 </ActionColumn>
             </SectionItem>
-            <SectionItem data-test="@settings/debug/processes/bridgeLegacy">
+            <SectionItem data-testid="@settings/debug/processes/bridgeLegacy">
                 <TextColumn
                     title="Use legacy bridge"
                     description="Legacy trezord-go will be spawned as a subprocess"
@@ -92,7 +92,7 @@ export const TransportBackends = () => {
                     />
                 </ActionColumn>
             </SectionItem>
-            <SectionItem data-test="@settings/debug/processes/runOnStartUp">
+            <SectionItem data-testid="@settings/debug/processes/runOnStartUp">
                 <TextColumn title="Run on startup" />
                 <ActionColumn>
                     <Checkbox
@@ -107,7 +107,7 @@ export const TransportBackends = () => {
                 </ActionColumn>
             </SectionItem>
             {!isDevEnv && (
-                <SectionItem data-test="@settings/debug/processes/newBridgeRollout">
+                <SectionItem data-testid="@settings/debug/processes/newBridgeRollout">
                     <TextColumn
                         title="New bridge rollout"
                         description={`New bridge is being rolled out to only ${NEW_BRIDGE_ROLLOUT_THRESHOLD * 100}% of Trezor Suite instances that have applied for the Early access program. Your rollout score is ${((bridgeSettings.newBridgeRollout ?? 0) * 100).toFixed()}%`}

--- a/packages/suite/src/views/settings/SettingsDebug/TriggerHighlight.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/TriggerHighlight.tsx
@@ -7,7 +7,7 @@ export const TriggerHighlight = () => {
     const dispatch = useDispatch();
 
     return (
-        <SectionItem data-test="@settings/debug/github">
+        <SectionItem data-testid="@settings/debug/github">
             <TextColumn
                 title="Trigger highlight"
                 description="Goes to the anchor in the application and highlights it. This allows testing of this functionality with custom anchor."

--- a/packages/suite/src/views/settings/SettingsDevice/AutoLock.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/AutoLock.tsx
@@ -69,7 +69,7 @@ export const AutoLock = ({ isDeviceLocked }: AutoLockProps) => {
                         option => autoLockDelay && autoLockDelay / 1000 === option.value,
                     )}
                     isDisabled={isDeviceLocked}
-                    data-test="@settings/auto-lock-select"
+                    data-testid="@settings/auto-lock-select"
                 />
             </ActionColumn>
         </SettingsSectionItem>

--- a/packages/suite/src/views/settings/SettingsDevice/BackupRecoverySeed.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/BackupRecoverySeed.tsx
@@ -27,7 +27,7 @@ export const BackupRecoverySeed = ({ isDeviceLocked }: BackupRecoverySeedProps) 
             />
             <ActionColumn>
                 <ActionButton
-                    data-test="@settings/device/create-backup-button"
+                    data-testid="@settings/device/create-backup-button"
                     onClick={handleClick}
                     isDisabled={isDeviceLocked || !needsBackup}
                 >

--- a/packages/suite/src/views/settings/SettingsDevice/Brightness.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/Brightness.tsx
@@ -38,7 +38,7 @@ export const Brightness = ({ isDeviceLocked }: DeviceLabelProps) => {
                     onClick={handleClick}
                     isDisabled={isDeviceLocked}
                     variant="secondary"
-                    data-test="@settings/device/brightness-switch"
+                    data-testid="@settings/device/brightness-switch"
                 >
                     <Translation id="TR_DEVICE_SETTINGS_BRIGHTNESS_BUTTON" />
                 </ActionButton>

--- a/packages/suite/src/views/settings/SettingsDevice/ChangeLanguage.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/ChangeLanguage.tsx
@@ -47,7 +47,7 @@ export const ChangeLanguage = ({ isDeviceLocked }: ChangeLanguageProps) => {
                     options={languageOptions}
                     onChange={onChange}
                     isDisabled={isDeviceLocked}
-                    data-test="@settings/device/firmware-language-select"
+                    data-testid="@settings/device/firmware-language-select"
                 />
             </ActionColumn>
         </SettingsSectionItem>

--- a/packages/suite/src/views/settings/SettingsDevice/CheckRecoverySeed.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/CheckRecoverySeed.tsx
@@ -28,7 +28,7 @@ export const CheckRecoverySeed = ({ isDeviceLocked }: CheckRecoverySeedProps) =>
             />
             <ActionColumn>
                 <ActionButton
-                    data-test="@settings/device/check-seed-button"
+                    data-testid="@settings/device/check-seed-button"
                     onClick={handleClick}
                     isDisabled={isDeviceLocked || needsBackup}
                     variant="secondary"

--- a/packages/suite/src/views/settings/SettingsDevice/CustomFirmware.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/CustomFirmware.tsx
@@ -27,7 +27,7 @@ export const CustomFirmware = () => {
                     onClick={openModal}
                     variant="destructive"
                     isDisabled={isDeviceLocked}
-                    data-test="@settings/device/custom-firmware-modal-button"
+                    data-testid="@settings/device/custom-firmware-modal-button"
                 >
                     <Translation id="TR_DEVICE_SETTINGS_CUSTOM_FIRMWARE_BUTTON" />
                 </ActionButton>

--- a/packages/suite/src/views/settings/SettingsDevice/DeviceAuthenticityOptOut.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/DeviceAuthenticityOptOut.tsx
@@ -51,7 +51,7 @@ export const DeviceAuthenticityOptOut = () => {
                 <ActionButton
                     onClick={handleClick}
                     variant={isDeviceAuthenticityCheckDisabled ? 'primary' : 'destructive'}
-                    data-test="@settings/device/open-device-authenticity-opt-out-modal-button"
+                    data-testid="@settings/device/open-device-authenticity-opt-out-modal-button"
                 >
                     <Translation
                         id={

--- a/packages/suite/src/views/settings/SettingsDevice/DisplayRotation.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/DisplayRotation.tsx
@@ -54,7 +54,7 @@ export const DisplayRotation = ({ isDeviceLocked }: DisplayRotationProps) => {
                                     },
                                 });
                             }}
-                            data-test={`@settings/device/rotation-button/${variant.value}`}
+                            data-testid={`@settings/device/rotation-button/${variant.value}`}
                         >
                             {variant.label}
                         </Button>

--- a/packages/suite/src/views/settings/SettingsDevice/FirmwareRevisionCheck.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/FirmwareRevisionCheck.tsx
@@ -48,7 +48,7 @@ export const FirmwareRevisionCheck = () => {
                 <ActionButton
                     onClick={handleClick}
                     variant={isFirmwareRevisionCheckDisabled ? 'primary' : 'destructive'}
-                    data-test="@settings/device/open-firmware-revision-check-modal-button"
+                    data-testid="@settings/device/open-firmware-revision-check-modal-button"
                 >
                     <Translation
                         id={

--- a/packages/suite/src/views/settings/SettingsDevice/FirmwareTypeChange.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/FirmwareTypeChange.tsx
@@ -87,7 +87,7 @@ export const FirmwareTypeChange = ({ isDeviceLocked }: FirmwareTypeProps) => {
                     <ActionButton
                         variant="secondary"
                         onClick={handleAction}
-                        data-test="@settings/device/switch-fw-type-button"
+                        data-testid="@settings/device/switch-fw-type-button"
                         isDisabled={isDeviceLocked}
                     >
                         <Translation

--- a/packages/suite/src/views/settings/SettingsDevice/FirmwareVersion.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/FirmwareVersion.tsx
@@ -122,7 +122,7 @@ export const FirmwareVersion = ({ isDeviceLocked }: FirmwareVersionProps) => {
                 <ActionButton
                     variant="secondary"
                     onClick={handleUpdate}
-                    data-test="@settings/device/update-button"
+                    data-testid="@settings/device/update-button"
                     isDisabled={isDeviceLocked}
                 >
                     <Translation

--- a/packages/suite/src/views/settings/SettingsDevice/HapticFeedback.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/HapticFeedback.tsx
@@ -44,7 +44,7 @@ export const HapticFeedback = ({ isDeviceLocked }: DeviceLabelProps) => {
                     isChecked={hapticEnabled}
                     onChange={handleChange}
                     isDisabled={isDeviceLocked}
-                    dataTest="@settings/device/haptic-switch"
+                    data-testid="@settings/device/haptic-switch"
                 />
             </ActionColumn>
         </SettingsSectionItem>

--- a/packages/suite/src/views/settings/SettingsDevice/Homescreen.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/Homescreen.tsx
@@ -140,7 +140,7 @@ export const Homescreen = ({ isDeviceLocked }: HomescreenProps) => {
                                 onClick={() => fileInputElement?.current?.click()}
                                 isDisabled={isDeviceLocked || !isSupportedHomescreen}
                                 variant="secondary"
-                                data-test="@settings/device/homescreen-upload"
+                                data-testid="@settings/device/homescreen-upload"
                                 key="@settings/device/homescreen-upload"
                             >
                                 <Translation id="TR_DEVICE_SETTINGS_HOMESCREEN_UPLOAD_IMAGE" />
@@ -148,7 +148,7 @@ export const Homescreen = ({ isDeviceLocked }: HomescreenProps) => {
                             <Button
                                 onClick={openGallery}
                                 isDisabled={isDeviceLocked || !isSupportedHomescreen}
-                                data-test="@settings/device/homescreen-gallery"
+                                data-testid="@settings/device/homescreen-gallery"
                                 key="@settings/device/homescreen-gallery"
                                 variant="secondary"
                             >

--- a/packages/suite/src/views/settings/SettingsDevice/MultiShareBackup.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/MultiShareBackup.tsx
@@ -61,7 +61,7 @@ export const MultiShareBackup = ({ isDeviceLocked }: { isDeviceLocked: boolean }
             <ActionColumn>
                 <ActionButton
                     variant="secondary"
-                    data-test="@settings/device/create-multi-share-backup-button"
+                    data-testid="@settings/device/create-multi-share-backup-button"
                     onClick={handleClick}
                     isDisabled={isDeviceLocked}
                 >

--- a/packages/suite/src/views/settings/SettingsDevice/Passphrase.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/Passphrase.tsx
@@ -42,7 +42,7 @@ export const Passphrase = ({ isDeviceLocked }: PassphraseProps) => {
                 <Switch
                     isChecked={passphraseProtection}
                     onChange={handleChange}
-                    dataTest="@settings/device/passphrase-switch"
+                    data-testid="@settings/device/passphrase-switch"
                     isDisabled={isDeviceLocked}
                 />
             </ActionColumn>

--- a/packages/suite/src/views/settings/SettingsDevice/PinProtection.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/PinProtection.tsx
@@ -38,7 +38,7 @@ export const PinProtection = ({ isDeviceLocked }: PinProtectionProps) => {
                     isChecked={!!pinProtection}
                     onChange={handleChange}
                     isDisabled={isDeviceLocked}
-                    dataTest="@settings/device/pin-switch"
+                    data-testid="@settings/device/pin-switch"
                 />
             </ActionColumn>
         </SettingsSectionItem>

--- a/packages/suite/src/views/settings/SettingsDevice/SafetyChecks.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/SafetyChecks.tsx
@@ -23,7 +23,7 @@ export const SafetyChecks = ({ isDeviceLocked }: SafetyChecksProps) => {
                 <ActionButton
                     variant="secondary"
                     onClick={handleClick}
-                    data-test="@settings/device/safety-checks-button"
+                    data-testid="@settings/device/safety-checks-button"
                     isDisabled={isDeviceLocked}
                 >
                     <Translation id="TR_DEVICE_SETTINGS_SAFETY_CHECKS_BUTTON" />

--- a/packages/suite/src/views/settings/SettingsDevice/WipeDevice.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/WipeDevice.tsx
@@ -24,7 +24,7 @@ export const WipeDevice = ({ isDeviceLocked }: WipeDeviceProps) => {
                     onClick={handleClick}
                     variant="destructive"
                     isDisabled={isDeviceLocked}
-                    data-test="@settings/device/open-wipe-modal-button"
+                    data-testid="@settings/device/open-wipe-modal-button"
                 >
                     <Translation id="TR_DEVICE_SETTINGS_BUTTON_WIPE_DEVICE" />
                 </ActionButton>

--- a/packages/suite/src/views/settings/SettingsGeneral/Analytics.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Analytics.tsx
@@ -25,7 +25,7 @@ export const Analytics = () => {
             <ActionColumn>
                 <PositionedSwitch>
                     <Switch
-                        dataTest="@analytics/toggle-switch"
+                        data-testid="@analytics/toggle-switch"
                         isChecked={!!userAllowedTracking}
                         onChange={() => {
                             if (userAllowedTracking) {

--- a/packages/suite/src/views/settings/SettingsGeneral/BitcoinAmountUnit.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/BitcoinAmountUnit.tsx
@@ -26,7 +26,7 @@ export const BitcoinAmountUnit = () => {
                     }}
                     options={UNIT_OPTIONS}
                     onChange={handleUnitsChange}
-                    data-test="@settings/btc-units-select"
+                    data-testid="@settings/btc-units-select"
                 />
             </ActionColumn>
         </SettingsSectionItem>

--- a/packages/suite/src/views/settings/SettingsGeneral/ClearStorage.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/ClearStorage.tsx
@@ -34,7 +34,7 @@ export const ClearStorage = () => {
                 <ActionButton
                     onClick={handleClick}
                     variant="secondary"
-                    data-test="@settings/reset-app-button"
+                    data-testid="@settings/reset-app-button"
                 >
                     <Translation id="TR_CLEAR_STORAGE" />
                 </ActionButton>

--- a/packages/suite/src/views/settings/SettingsGeneral/ConnectLabelingProvider.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/ConnectLabelingProvider.tsx
@@ -19,7 +19,7 @@ export const ConnectLabelingProvider = () => {
                 <ActionButton
                     variant="secondary"
                     onClick={handleClick}
-                    data-test="@settings/metadata/connect-provider-button"
+                    data-testid="@settings/metadata/connect-provider-button"
                 >
                     <Translation id="TR_CONNECT" />
                 </ActionButton>

--- a/packages/suite/src/views/settings/SettingsGeneral/DesktopSuiteBanner.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/DesktopSuiteBanner.tsx
@@ -135,7 +135,7 @@ export const DesktopSuiteBanner = () => {
                         size={18}
                         icon="CROSS"
                         onClick={handleClose}
-                        data-test="@banner/install-desktop-suite/close-button"
+                        data-testid="@banner/install-desktop-suite/close-button"
                     />
 
                     <StyledImage image="TREZOR_PATTERN" width={140} />

--- a/packages/suite/src/views/settings/SettingsGeneral/DisconnectLabelingProvider.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/DisconnectLabelingProvider.tsx
@@ -51,7 +51,7 @@ export const DisconnectLabelingProvider = () => {
                 <ActionButton
                     variant="secondary"
                     onClick={handleClick}
-                    data-test="@settings/metadata/disconnect-provider-button"
+                    data-testid="@settings/metadata/disconnect-provider-button"
                 >
                     <Translation id="TR_DISCONNECT" />
                 </ActionButton>

--- a/packages/suite/src/views/settings/SettingsGeneral/EarlyAccess.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/EarlyAccess.tsx
@@ -52,7 +52,7 @@ export const EarlyAccess = () => {
                 <ActionButton
                     onClick={setupEarlyAccess}
                     variant="secondary"
-                    data-test="@settings/early-access-join-button"
+                    data-testid="@settings/early-access-join-button"
                 >
                     <Translation
                         id={

--- a/packages/suite/src/views/settings/SettingsGeneral/EnableViewOnly.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/EnableViewOnly.tsx
@@ -24,7 +24,7 @@ export const EnableViewOnly = () => {
     const isDeviceConnected = device?.connected && device?.available;
 
     return (
-        <SectionItem data-test="@settings/device/enable-view-only">
+        <SectionItem data-testid="@settings/device/enable-view-only">
             <TextColumn
                 title={<Translation id="TR_DEVICE_SETTINGS_ENABLE_VIEW_ONLY_TITLE" />}
                 description={<Translation id="TR_DEVICE_SETTINGS_ENABLE_VIEW_ONLY_DESC" />}

--- a/packages/suite/src/views/settings/SettingsGeneral/Fiat.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Fiat.tsx
@@ -39,7 +39,7 @@ export const Fiat = () => {
                     onChange={handleChange}
                     value={value}
                     options={options}
-                    data-test="@settings/fiat-select"
+                    data-testid="@settings/fiat-select"
                 />
             </ActionColumn>
         </SettingsSectionItem>

--- a/packages/suite/src/views/settings/SettingsGeneral/Labeling.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Labeling.tsx
@@ -65,7 +65,7 @@ export const Labeling = () => {
                 >
                     <Switch
                         isDisabled={isDisabled || metadata.initiating}
-                        dataTest="@settings/metadata-switch"
+                        data-testid="@settings/metadata-switch"
                         isChecked={metadata.enabled}
                         onChange={handleSwitchClick}
                     />

--- a/packages/suite/src/views/settings/SettingsGeneral/Language.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Language.tsx
@@ -105,7 +105,7 @@ export const Language = () => {
                     options={options}
                     onChange={onChange}
                     isDisabled={isTranslationMode()}
-                    data-test="@settings/language-select"
+                    data-testid="@settings/language-select"
                 />
             </ActionColumn>
         </SettingsSectionItem>

--- a/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
@@ -56,7 +56,7 @@ export const SettingsGeneral = () => {
     const isProviderConnected = useSelector(selectSelectedProviderForLabels);
 
     return (
-        <SettingsLayout data-test="@settings/index">
+        <SettingsLayout data-testid="@settings/index">
             {isWeb() && !isMobileLayout && shouldShowSettingsDesktopAppPromoBanner && (
                 <DesktopSuiteBanner />
             )}

--- a/packages/suite/src/views/settings/SettingsGeneral/ShowApplicationLog.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/ShowApplicationLog.tsx
@@ -20,7 +20,7 @@ export const ShowApplicationLog = () => {
                 <ActionButton
                     onClick={handleClick}
                     variant="secondary"
-                    data-test="@settings/show-log-button"
+                    data-testid="@settings/show-log-button"
                 >
                     <Translation id="TR_SHOW_LOG" />
                 </ActionButton>

--- a/packages/suite/src/views/settings/SettingsGeneral/Theme.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Theme.tsx
@@ -96,7 +96,7 @@ export const Theme = () => {
                     value={selectedValue}
                     options={optionGroups}
                     onChange={onChange}
-                    data-test="@theme/color-scheme-select"
+                    data-testid="@theme/color-scheme-select"
                 />
             </ActionColumn>
         </SettingsSectionItem>

--- a/packages/suite/src/views/settings/SettingsGeneral/Tor.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Tor.tsx
@@ -70,7 +70,7 @@ export const Tor = () => {
             />
             <ActionColumn>
                 <Switch
-                    dataTest="@settings/general/tor-switch"
+                    data-testid="@settings/general/tor-switch"
                     isChecked={isTorEnabled || torStatus === TorStatus.Enabling}
                     isDisabled={isTorLoading}
                     onChange={handleTorSwitch}

--- a/packages/suite/src/views/settings/SettingsGeneral/TorOnionLinks.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/TorOnionLinks.tsx
@@ -31,7 +31,7 @@ export const TorOnionLinks = () => {
             />
             <ActionColumn>
                 <Switch
-                    dataTest="@settings/general/onion-links-switch"
+                    data-testid="@settings/general/onion-links-switch"
                     isChecked={torOnionLinks}
                     onChange={handleChange}
                 />

--- a/packages/suite/src/views/settings/SettingsGeneral/TorSnowflake.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/TorSnowflake.tsx
@@ -92,7 +92,7 @@ export const TorSnowflake = () => {
             : 'TR_TOR_CONFIG_SNOWFLAKE_UPDATE_LABEL';
 
     return (
-        <SectionItem data-test="@settings/general/tor/snowflake-enable">
+        <SectionItem data-testid="@settings/general/tor/snowflake-enable">
             <TextColumn
                 title={<Translation id="TR_TOR_CONFIG_SNOWFLAKE_TITLE" />}
                 description={<Translation id="TR_TOR_CONFIG_SNOWFLAKE_DESCRIPTION" />}

--- a/packages/suite/src/views/start/SuiteStart.tsx
+++ b/packages/suite/src/views/start/SuiteStart.tsx
@@ -11,7 +11,7 @@ const Content = styled.div`
 
 export const SuiteStart = () => (
     <WelcomeLayout>
-        <Content data-test="@onboarding/welcome">
+        <Content data-testid="@onboarding/welcome">
             <StartContent />
         </Content>
     </WelcomeLayout>

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/AddWalletButton.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/AddWalletButton.tsx
@@ -57,7 +57,7 @@ export const AddWalletButton = ({ device, instances, onCancel }: AddWalletButton
                 <Column flex={1} gap={spacings.xs}>
                     {!emptyPassphraseWalletExists && (
                         <Button
-                            data-test="@switch-device/add-wallet-button"
+                            data-testid="@switch-device/add-wallet-button"
                             variant="tertiary"
                             isFullWidth
                             icon="PLUS"
@@ -70,7 +70,7 @@ export const AddWalletButton = ({ device, instances, onCancel }: AddWalletButton
 
                     {isPassphraseProtectionEnabled && (
                         <Button
-                            data-test="@switch-device/add-hidden-wallet-button"
+                            data-testid="@switch-device/add-hidden-wallet-button"
                             variant="tertiary"
                             isFullWidth
                             icon="PLUS"

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceConnectionText.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceConnectionText.tsx
@@ -23,7 +23,7 @@ const TextRow = styled.div`
 type DeviceConnectionTextProps = {
     onClick?: () => void;
     variant: IconVariant;
-    'data-test'?: string;
+    'data-testid'?: string;
     icon: IconType;
     children: ReactNode;
     isAction?: boolean;
@@ -32,12 +32,12 @@ type DeviceConnectionTextProps = {
 export const DeviceConnectionText = ({
     onClick,
     variant,
-    'data-test': dataTest,
+    'data-testid': dataTest,
     children,
     icon,
     isAction,
 }: DeviceConnectionTextProps) => (
-    <Container $isAction={isAction} onClick={onClick} data-test={dataTest}>
+    <Container $isAction={isAction} onClick={onClick} data-testid={dataTest}>
         <TextRow>
             <Icon icon={icon} size={12} variant={variant} />
             <Text variant={variant}>{children} </Text>

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceHeader.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceHeader.tsx
@@ -64,7 +64,7 @@ export const DeviceHeader = ({
                         onClick={onBackButtonClick}
                         variant="tertiary"
                         size="small"
-                        data-test="@switch-device/back-button"
+                        data-testid="@switch-device/back-button"
                     />
                 )}
 
@@ -101,7 +101,7 @@ export const DeviceHeader = ({
                                 size="small"
                                 variant="tertiary"
                                 onClick={() => onCancel?.()}
-                                data-test="@switch-device/cancel-button"
+                                data-testid="@switch-device/cancel-button"
                             />
                         </motion.div>
                     </Tooltip>

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceStatusText.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceStatusText.tsx
@@ -35,7 +35,7 @@ const DeviceStatusVisible = ({ device, connected, forceConnectionInfo }: DeviceS
         <DeviceConnectionText
             variant={connected ? 'primary' : 'tertiary'}
             icon={connected ? 'LINK' : 'UNLINK'}
-            data-test={connected ? '@deviceStatus-connected' : '@deviceStatus-disconnected'}
+            data-testid={connected ? '@deviceStatus-connected' : '@deviceStatus-disconnected'}
         >
             {walletText && !forceConnectionInfo ? (
                 <TruncateWithTooltip delayShow={TOOLTIP_DELAY_LONG}>
@@ -62,7 +62,7 @@ export const DeviceStatusText = ({
             <DeviceConnectionText
                 variant="warning"
                 icon="REFRESH"
-                data-test={connected ? '@deviceStatus-connected' : '@deviceStatus-disconnected'}
+                data-testid={connected ? '@deviceStatus-connected' : '@deviceStatus-disconnected'}
                 isAction
             >
                 <Translation id="TR_SOLVE_ISSUE" />

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceWarning.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceWarning.tsx
@@ -27,7 +27,7 @@ export const DeviceWarning = ({
                     button={{
                         children: <Translation id="TR_SOLVE_ISSUE" />,
                         onClick: onSolveIssueClick,
-                        'data-test': `@switch-device/${device.path}/solve-issue-button`,
+                        'data-testid': `@switch-device/${device.path}/solve-issue-button`,
                         isDisabled: isLocked,
                     }}
                 >

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/EjectButton.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/EjectButton.tsx
@@ -16,10 +16,10 @@ const EjectContainer = styled.div<{ $elevation: Elevation }>`
 
 interface EjectButtonProps {
     setContentType: (contentType: ContentType) => void;
-    dataTest?: string;
+    'data-testid'?: string;
 }
 
-export const EjectButton = ({ setContentType, dataTest }: EjectButtonProps) => {
+export const EjectButton = ({ setContentType, 'data-testid': dataTest }: EjectButtonProps) => {
     const theme = useTheme();
 
     const onEjectClick = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
@@ -33,7 +33,7 @@ export const EjectButton = ({ setContentType, dataTest }: EjectButtonProps) => {
         <EjectContainer $elevation={elevation}>
             <Tooltip cursor="pointer" content={<Translation id="TR_EJECT_HEADING" />}>
                 <Icon
-                    data-test={`${dataTest}/eject-button`}
+                    data-testid={`${dataTest}/eject-button`}
                     icon="EJECT"
                     size={22}
                     color={theme.TYPE_LIGHT_GREY}

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/EjectConfirmation.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/EjectConfirmation.tsx
@@ -69,7 +69,7 @@ const EjectConfirmationContainer = ({
                     onClick={handleEject}
                     variant="primary"
                     isFullWidth
-                    data-test="@switch-device/eject"
+                    data-testid="@switch-device/eject"
                 >
                     {primaryButtonLabel}
                 </Button>
@@ -78,7 +78,7 @@ const EjectConfirmationContainer = ({
                     onClick={onCancel}
                     variant="tertiary"
                     isFullWidth
-                    data-test="@switch-device/cancelEject"
+                    data-testid="@switch-device/cancelEject"
                 >
                     <Translation id="TR_SWITCH_DEVICE_EJECT_CONFIRMATION_CANCEL_BUTTON" />
                 </Button>

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/ViewOnly.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/ViewOnly.tsx
@@ -13,7 +13,7 @@ import { AcquiredDevice } from '@suite-common/suite-types';
 type ViewOnlyProps = {
     setContentType: (contentType: ContentType) => void;
     instance: AcquiredDevice;
-    dataTest?: string;
+    'data-testid'?: string;
 };
 
 const ViewOnlyContainer = styled.div`
@@ -46,7 +46,7 @@ export const ViewOnly = ({ setContentType, instance }: ViewOnlyProps) => {
 
     return (
         <ViewOnlyContainer
-            data-test={`@viewOnlyStatus/${isViewOnly ? 'enabled' : 'disabled'}`}
+            data-testid={`@viewOnlyStatus/${isViewOnly ? 'enabled' : 'disabled'}`}
             onClick={e => {
                 e.stopPropagation();
             }}
@@ -73,7 +73,7 @@ export const ViewOnly = ({ setContentType, instance }: ViewOnlyProps) => {
                 <ViewOnlyRadios
                     isViewOnlyActive={isViewOnly}
                     toggleViewOnly={handleRememberChange}
-                    dataTest="@viewOnly/radios"
+                    data-testid="@viewOnly/radios"
                     setContentType={setContentType}
                     device={instance}
                 />

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/ViewOnlyRadios.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/ViewOnlyRadios.tsx
@@ -9,7 +9,7 @@ import { AcquiredDevice } from '@suite-common/suite-types';
 type ViewOnlyRadiosProps = {
     isViewOnlyActive: boolean;
     toggleViewOnly: () => void;
-    dataTest?: string;
+    'data-testid'?: string;
     setContentType: (contentType: ContentType) => void;
     device: AcquiredDevice;
 };
@@ -18,7 +18,7 @@ type ViewOnlyRadioProps = {
     children: React.ReactNode;
     onClick: () => void;
     isChecked: boolean;
-    dataTest?: string;
+    'data-testid'?: string;
 };
 const Container = styled.div`
     display: flex;
@@ -56,7 +56,7 @@ export const ViewOnlyRadio = ({
     children,
     onClick,
     isChecked,
-    dataTest,
+    'data-testid': dataTest,
 }: ViewOnlyRadioProps) => {
     const { elevation } = useElevation();
     const theme = useTheme();
@@ -69,14 +69,14 @@ export const ViewOnlyRadio = ({
                     {children}
                 </Text>
             </Left>
-            <Radio onClick={onClick} isChecked={isChecked} data-test={dataTest} />
+            <Radio onClick={onClick} isChecked={isChecked} data-testid={dataTest} />
         </Item>
     );
 };
 export const ViewOnlyRadios = ({
     isViewOnlyActive,
     toggleViewOnly,
-    dataTest,
+    'data-testid': dataTest,
     setContentType,
     device,
 }: ViewOnlyRadiosProps) => {
@@ -101,7 +101,7 @@ export const ViewOnlyRadios = ({
                 title={<Translation id="TR_VIEW_ONLY_RADIOS_ENABLED_TITLE" />}
                 onClick={() => handleConfirm(true)}
                 isChecked={isViewOnlyActive}
-                dataTest={`${dataTest}/enabled`}
+                data-testid={`${dataTest}/enabled`}
             >
                 <Translation
                     id="TR_VIEW_ONLY_RADIOS_ENABLED_DESCRIPTION"
@@ -114,7 +114,7 @@ export const ViewOnlyRadios = ({
                 title={<Translation id="TR_VIEW_ONLY_RADIOS_DISABLED_TITLE" />}
                 onClick={() => handleConfirm(false)}
                 isChecked={!isViewOnlyActive}
-                dataTest={`${dataTest}/disabled`}
+                data-testid={`${dataTest}/disabled`}
             >
                 <Translation
                     id="TR_VIEW_ONLY_RADIOS_DISABLED_DESCRIPTION"

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
@@ -143,8 +143,8 @@ export const WalletInstance = ({
         contentType === 'disabling-view-only-ejects-wallet';
 
     return (
-        <RelativeContainer data-test={dataTestBase}>
-            <EjectButton setContentType={setContentType} dataTest={dataTestBase} />
+        <RelativeContainer data-testid={dataTestBase}>
+            <EjectButton setContentType={setContentType} data-testid={dataTestBase} />
             <Card
                 key={`${instance.label}${instance.instance}${instance.state}`}
                 paddingType="small"

--- a/packages/suite/src/views/suite/SwitchDevice/SwitchDeviceModal.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/SwitchDeviceModal.tsx
@@ -9,7 +9,7 @@ type SwitchDeviceModalProps = {
     isCancelable?: boolean;
     onBackClick?: () => void;
     onCancel?: () => void;
-    'data-test'?: string;
+    'data-testid'?: string;
     isAnimationEnabled?: boolean;
 };
 
@@ -35,7 +35,7 @@ export const SwitchDeviceModal = ({
     children,
     onCancel,
     isAnimationEnabled,
-    'data-test': dataTest = '@modal',
+    'data-testid': dataTest = '@modal',
 }: SwitchDeviceModalProps) => {
     useEvent('keydown', (e: KeyboardEvent) => {
         if (onCancel && e.key === 'Escape') {
@@ -47,7 +47,7 @@ export const SwitchDeviceModal = ({
         <TrafficLightOffset>
             <Container
                 onClick={e => e.stopPropagation()} // needed because of the Backdrop implementation
-                data-test={dataTest}
+                data-testid={dataTest}
             >
                 <DeviceItemsWrapper>
                     <motion.div

--- a/packages/suite/src/views/suite/bridge-requested/index.tsx
+++ b/packages/suite/src/views/suite/bridge-requested/index.tsx
@@ -76,7 +76,7 @@ export const BridgeRequested = () => {
                         icon="ARROW_LEFT"
                         variant="tertiary"
                         onClick={() => setConfirmGoToWallet(true)}
-                        data-test="@bridge/goto/wallet-index"
+                        data-testid="@bridge/goto/wallet-index"
                     >
                         <Translation id="TR_TAKE_ME_BACK_TO_WALLET" />
                     </StyledButton>

--- a/packages/suite/src/views/suite/bridge/index.tsx
+++ b/packages/suite/src/views/suite/bridge/index.tsx
@@ -42,7 +42,7 @@ export const BridgeUnavailable = () => {
             <Modal
                 heading={<Translation id="TR_BRIDGE" />}
                 description={description}
-                data-test="@modal/bridge"
+                data-testid="@modal/bridge"
             >
                 <Metadata title="Bridge | Trezor Suite" />
 
@@ -51,7 +51,7 @@ export const BridgeUnavailable = () => {
                         icon="ARROW_LEFT"
                         variant="tertiary"
                         onClick={goToWallet}
-                        data-test="@bridge/goto/wallet-index"
+                        data-testid="@bridge/goto/wallet-index"
                     >
                         <Translation id="TR_TAKE_ME_BACK_TO_WALLET" />
                     </StyledButton>
@@ -68,7 +68,7 @@ export const BridgeUnavailable = () => {
         <Modal
             heading={<Translation id="TR_BRIDGE" />}
             description={<Translation id="TR_BRIDGE_NEEDED_DESCRIPTION" />}
-            data-test="@modal/bridge"
+            data-testid="@modal/bridge"
         >
             <Metadata title="Bridge | Trezor Suite" />
 

--- a/packages/suite/src/views/suite/udev/index.tsx
+++ b/packages/suite/src/views/suite/udev/index.tsx
@@ -12,7 +12,7 @@ const Wrapper = styled.div`
 
 export const UdevRules = ({ onCancel }: ForegroundAppProps) => (
     <Modal
-        data-test="@modal/udev"
+        data-testid="@modal/udev"
         isCancelable
         onCancel={onCancel}
         heading={<Translation id="TR_UDEV_DOWNLOAD_TITLE" />}

--- a/packages/suite/src/views/suite/version/index.tsx
+++ b/packages/suite/src/views/suite/version/index.tsx
@@ -14,15 +14,15 @@ const Line = styled.div`
 `;
 
 export const Version = () => (
-    <Modal data-test="@modal/version">
+    <Modal data-testid="@modal/version">
         <Wrapper>
             <Paragraph typographyStyle="callout">APPLICATION VERSION</Paragraph>
-            <H2 data-test="@version/number">{getSuiteVersion()}</H2>
+            <H2 data-testid="@version/number">{getSuiteVersion()}</H2>
             <Line />
             <Paragraph typographyStyle="callout">LAST COMMIT HASH</Paragraph>
             <Link
                 href={`https://github.com/trezor/trezor-suite/commits/${getCommitHash()}`}
-                data-test="@version/commit-hash-link"
+                data-testid="@version/commit-hash-link"
             >
                 <H2>{getCommitHash()}</H2>
             </Link>

--- a/packages/suite/src/views/view-only/ViewOnlyPromo.tsx
+++ b/packages/suite/src/views/view-only/ViewOnlyPromo.tsx
@@ -12,7 +12,7 @@ const Content = styled.div`
 export const ViewOnlyPromo = () => {
     return (
         <WelcomeLayout>
-            <Content data-test="@onboarding/view-only-promo">
+            <Content data-testid="@onboarding/view-only-promo">
                 <ViewOnlyPromoContent />
             </Content>
         </WelcomeLayout>

--- a/packages/suite/src/views/view-only/ViewOnlyPromoContent.tsx
+++ b/packages/suite/src/views/view-only/ViewOnlyPromoContent.tsx
@@ -239,7 +239,7 @@ const Buttons = () => {
                 variant="primary"
                 isFullWidth
                 onClick={onYes}
-                data-test="@onboarding/viewOnly/enable"
+                data-testid="@onboarding/viewOnly/enable"
             >
                 <Translation id="TR_VIEW_ONLY_PROMO_YES" />
             </Button>
@@ -247,7 +247,7 @@ const Buttons = () => {
                 variant="tertiary"
                 isFullWidth
                 onClick={onNo}
-                data-test="@onboarding/viewOnly/skip"
+                data-testid="@onboarding/viewOnly/skip"
             >
                 <Translation id="TR_VIEW_ONLY_PROMO_NOT_NOW" />
             </Button>

--- a/packages/suite/src/views/view-only/ViewOnlyTooltip.tsx
+++ b/packages/suite/src/views/view-only/ViewOnlyTooltip.tsx
@@ -82,7 +82,7 @@ export const ViewOnlyTooltip = ({ children }: ViewOnlyTooltipProps) => {
                         variant="tertiary"
                         size="small"
                         onClick={handleClose}
-                        data-test="@viewOnlyTooltip/gotIt"
+                        data-testid="@viewOnlyTooltip/gotIt"
                     >
                         <Translation id="TR_GOT_IT_BUTTON" />
                     </Button>

--- a/packages/suite/src/views/wallet/anonymize/components/CoinjoinConfirmation.tsx
+++ b/packages/suite/src/views/wallet/anonymize/components/CoinjoinConfirmation.tsx
@@ -175,7 +175,7 @@ export const CoinjoinConfirmation = ({ account }: CoinjoinConfirmationProps) => 
                 <StyledCheckbox
                     isChecked={termsConfirmed}
                     onClick={toggleTermsConfirmation}
-                    data-test="@coinjoin/checkbox"
+                    data-testid="@coinjoin/checkbox"
                 >
                     <Translation
                         id="TR_TERMS_AND_PRIVACY_CONFIRMATION"

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketFeaturedOffers/CoinmarketFeaturedOffersItem.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketFeaturedOffers/CoinmarketFeaturedOffersItem.tsx
@@ -156,7 +156,7 @@ const CoinmarketFeaturedOffersItem = ({
                             isLoading={callInProgress}
                             isDisabled={!!quote.error || callInProgress}
                             onClick={() => selectQuote(quote)}
-                            data-test="@coinmarket/featured-offers/get-this-deal-button"
+                            data-testid="@coinmarket/featured-offers/get-this-deal-button"
                         >
                             {actionButtonText(context, quote)}
                         </StyledButton>

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputAccount.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputAccount.tsx
@@ -94,7 +94,7 @@ const CoinmarketFormInputAccount = <
                                 </CoinmarketFormOption>
                             );
                         }}
-                        data-test="@coinmarket/form/account-select"
+                        data-testid="@coinmarket/form/account-select"
                         isClearable={false}
                         isSearchable
                     />

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputAccountActive.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputAccountActive.tsx
@@ -80,7 +80,7 @@ const CoinmarketFormInputAccountActive = ({ label }: CoinmarketFormInputDefaultP
                                 </CoinmarketFormOption>
                             );
                         }}
-                        data-test="@coinmarket/form/account-select-active"
+                        data-testid="@coinmarket/form/account-select-active"
                         isClearable={false}
                         isSearchable
                     />

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputCountry.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputCountry.tsx
@@ -68,7 +68,7 @@ const CoinmarketFormInputCountry = ({ label }: CoinmarketFormInputDefaultProps) 
                                 </CoinmarketFormOption>
                             );
                         }}
-                        data-test="@coinmarket/form/country-select"
+                        data-testid="@coinmarket/form/country-select"
                         isClearable={false}
                         minValueWidth="160px"
                         isSearchable

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputCurrency.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputCurrency.tsx
@@ -66,7 +66,7 @@ const CoinmarketFormInputCurrency = ({
                             </CoinmarketFormOptionLabel>
                         </CoinmarketFormOption>
                     )}
-                    data-test="@coinmarket/form/fiat-currency-select"
+                    data-testid="@coinmarket/form/fiat-currency-select"
                     minValueWidth="58px"
                     isClearable={false}
                     isClean={isClean}

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputFiatCrypto/CoinmarketFormInputCrypto.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputFiatCrypto/CoinmarketFormInputCrypto.tsx
@@ -82,7 +82,7 @@ const CoinmarketFormInputCrypto = <TFieldValues extends FieldValues>({
                     )}
                 </CoinmarketFormOptionLabel>
             }
-            data-test="@coinmarket/form/crypto-input"
+            data-testid="@coinmarket/form/crypto-input"
         />
     );
 };

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputFiatCrypto/CoinmarketFormInputFiat.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputFiatCrypto/CoinmarketFormInputFiat.tsx
@@ -95,7 +95,7 @@ const CoinmarketFormInputFiat = <TFieldValues extends FieldValues>({
             bottomText={fiatInputError?.message || null}
             innerAddon={<CoinmarketFormInputCurrencyWrapper />}
             hasBottomPadding={false}
-            data-test="@coinmarket/form/fiat-input"
+            data-testid="@coinmarket/form/fiat-input"
         />
     );
 };

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputPaymentMethod.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputPaymentMethod.tsx
@@ -56,7 +56,7 @@ const CoinmarketFormInputPaymentMethod = ({ label }: CoinmarketFormInputDefaultP
                                     </CoinmarketFormOptionLabel>
                                 </CoinmarketFormOption>
                             )}
-                            data-test="@coinmarket/form/payment-method-select"
+                            data-testid="@coinmarket/form/payment-method-select"
                             isClearable={false}
                             isSearchable
                             isDisabled={isFormInvalid}

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormOffer.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormOffer.tsx
@@ -119,7 +119,7 @@ const CoinmarketFormOffer = () => {
                     size="medium"
                     isDisabled={state.isLoadingOrInvalid}
                     isLoading={isCompareLoading}
-                    data-test="@coinmarket/form/compare-button"
+                    data-testid="@coinmarket/form/compare-button"
                 >
                     <Translation id="TR_COINMARKET_COMPARE_OFFERS" />
                 </CoinmarketFormOfferHeaderButton>
@@ -160,7 +160,7 @@ const CoinmarketFormOffer = () => {
                 }}
                 isFullWidth
                 isDisabled={state.isLoadingOrInvalid || !bestScoredQuote}
-                data-test={`@coinmarket/form/${type}-button`}
+                data-testid={`@coinmarket/form/${type}-button`}
             >
                 <Translation id={type === 'sell' ? 'TR_COINMARKET_SELL' : 'TR_BUY'} />
             </Button>

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketFractionButtons.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketFractionButtons.tsx
@@ -29,7 +29,7 @@ export const CoinmarketFractionButtons = ({
     onAllClick,
     className,
 }: CoinmarketFractionButtonsProps) => (
-    <Wrapper className={className} data-test="@coinmarket/form/fraction-buttons">
+    <Wrapper className={className} data-testid="@coinmarket/form/fraction-buttons">
         <SmallButton isDisabled={disabled} onClick={() => onFractionClick(4)}>
             1/4
         </SmallButton>

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketHeader/CoinmarketHeaderFilter.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketHeader/CoinmarketHeaderFilter.tsx
@@ -29,7 +29,7 @@ const CoinmarketHeaderFilter = () => {
     const context = useCoinmarketOffersContext<CoinmarketTradeBuySellType>();
 
     return (
-        <Wrapper data-test="@coinmarket/filter">
+        <Wrapper data-testid="@coinmarket/filter">
             {isCoinmarketBuyOffers(context) ? (
                 <InputWrapper>
                     <CoinmarketFormInputFiatCrypto<CoinmarketBuyFormProps>

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketLayoutNavigation.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketLayoutNavigation.tsx
@@ -50,7 +50,7 @@ export const CoinmarketLayoutNavigation = () => {
         icon: IconName;
     }) => (
         <NavListItem
-            data-test={`@coinmarket/menu/${route}`}
+            data-testid={`@coinmarket/menu/${route}`}
             nameId={title}
             isActive={routeName === route}
             icon={icon}

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayoutNew/CoinmarketLayoutNavigation/CoinmarketLayoutNavigationItem.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayoutNew/CoinmarketLayoutNavigation/CoinmarketLayoutNavigationItem.tsx
@@ -77,7 +77,7 @@ const CoinmarketLayoutNavigationItem = ({
                 variant="tertiary"
                 title={title}
                 onClick={handleTransactionRoute}
-                data-test={`@coinmarket/menu/${transactionsRoute}`}
+                data-testid={`@coinmarket/menu/${transactionsRoute}`}
             >
                 <Translation id={title} />
             </ButtonWrapper>
@@ -86,7 +86,7 @@ const CoinmarketLayoutNavigationItem = ({
 
     return (
         <NavListItemWrapper
-            data-test={`@coinmarket/menu/${route}`}
+            data-testid={`@coinmarket/menu/${route}`}
             nameId={title}
             isActive={routeName === route}
             icon={icon ?? 'receive'}

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketOffers/CoinmarketOffersItem.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketOffers/CoinmarketOffersItem.tsx
@@ -159,7 +159,7 @@ const CoinmarketOffersItem = ({ quote, isBestRate }: CoinmarketOffersItemProps) 
                             isLoading={callInProgress}
                             isDisabled={!!quote.error || callInProgress}
                             onClick={() => selectQuote(quote)}
-                            data-test="@coinmarket/offers/get-this-deal-button"
+                            data-testid="@coinmarket/offers/get-this-deal-button"
                         >
                             <Translation
                                 id={

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOfferInfo.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOfferInfo.tsx
@@ -136,7 +136,7 @@ export const CoinmarketSelectedOfferInfo = ({
     const amountLabels = coinmarketGetAmountLabels({ type, amountInCrypto: true });
 
     return (
-        <Wrapper data-test="@coinmarket/offer/info">
+        <Wrapper data-testid="@coinmarket/offer/info">
             <Info>
                 <Header>
                     <CoinmarketCoinImage symbol={currency} size="large" />

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOfferSell/CoinmarketSelectedOfferSellBankAccount.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOfferSell/CoinmarketSelectedOfferSellBankAccount.tsx
@@ -152,7 +152,7 @@ const CoinmarketSelectedOfferSellBankAccount = () => {
                         <RegisterAnother
                             variant="tertiary"
                             icon="PLUS"
-                            data-test="add-output"
+                            data-testid="add-output"
                             onClick={addBankAccount}
                         >
                             <Translation id="TR_SELL_ADD_BANK_ACCOUNT" />

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOfferVerify.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOfferVerify.tsx
@@ -164,7 +164,7 @@ const CoinmarketSelectedOfferVerify = () => {
                     {(!addressVerified || addressVerified !== address) &&
                         selectedAccountOption.account && (
                             <Button
-                                data-test="@coinmarket/offer/confirm-on-trezor-button"
+                                data-testid="@coinmarket/offer/confirm-on-trezor-button"
                                 isLoading={callInProgress}
                                 isDisabled={callInProgress}
                                 onClick={() => {
@@ -183,7 +183,7 @@ const CoinmarketSelectedOfferVerify = () => {
                     {((addressVerified && addressVerified === address) ||
                         selectedAccountOption?.type === 'NON_SUITE') && (
                         <Button
-                            data-test="@coinmarket/offer/continue-transaction-button"
+                            data-testid="@coinmarket/offer/continue-transaction-button"
                             isLoading={callInProgress}
                             onClick={() => {
                                 if (address) {

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/CoinmarketExchangeOfferInfo.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/CoinmarketExchangeOfferInfo.tsx
@@ -227,7 +227,7 @@ export const CoinmarketExchangeOfferInfo = ({
                         <CoinmarketProviderInfo
                             exchange={exchange}
                             providers={exchangeInfo?.providerInfos}
-                            data-test="@CoinmarketExchangeProviderInfo"
+                            data-testid="@CoinmarketExchangeProviderInfo"
                         />
                     </RightColumn>
                 </Row>

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Footer/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Footer/index.tsx
@@ -33,7 +33,7 @@ const Footer = () => {
                     }
                     isLoading={formState.isSubmitting || isComposing}
                     type="submit"
-                    data-test="@coinmarket/exchange/compare-button"
+                    data-testid="@coinmarket/exchange/compare-button"
                 >
                     <Translation id="TR_EXCHANGE_SHOW_OFFERS" />
                 </StyledButton>

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/FiatInput/FiatSelect/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/FiatInput/FiatSelect/index.tsx
@@ -46,7 +46,7 @@ const FiatSelect = () => {
                         }
                         setAmountLimits(undefined);
                     }}
-                    data-test="@coinmarket/exchange/fiat-select"
+                    data-testid="@coinmarket/exchange/fiat-select"
                     value={value}
                     isClearable={false}
                     options={buildCurrencyOptions(value)}

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/FiatInput/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/FiatInput/index.tsx
@@ -56,7 +56,7 @@ const FiatInput = () => {
             rules={fiatInputRules}
             bottomText={fiatError?.message || null}
             innerAddon={<FiatSelect />}
-            data-test="@coinmarket/exchange/fiat-input"
+            data-testid="@coinmarket/exchange/fiat-input"
         />
     );
 };

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/ReceiveCryptoSelect/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/ReceiveCryptoSelect/index.tsx
@@ -156,7 +156,7 @@ const ReceiveCryptoSelect = () => {
                             exchangeInfo,
                             tokenData?.symbol,
                         )}
-                        data-test="@coinmarket/exchange/receive-crypto-select"
+                        data-testid="@coinmarket/exchange/receive-crypto-select"
                         minValueWidth="70px"
                         formatOptionLabel={(
                             option: ReturnType<typeof buildOptions>[number]['options'][number],

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/SendCryptoInput/SendCryptoSelect/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/SendCryptoInput/SendCryptoSelect/index.tsx
@@ -109,7 +109,7 @@ const SendCryptoSelect = () => {
                     isDisabled={!hasNetworkTypeTradableTokens(account.networkType)}
                     minValueWidth="58px"
                     isClean
-                    data-test="@coinmarket/exchange/crypto-currency-select"
+                    data-testid="@coinmarket/exchange/crypto-currency-select"
                 />
             )}
         />

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/SendCryptoInput/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/SendCryptoInput/index.tsx
@@ -83,7 +83,7 @@ const SendCryptoInput = ({ isWithRate }: SendCryptoInputProps) => {
     return (
         <StyledInput
             control={control}
-            data-test="@coinmarket/exchange/crypto-input"
+            data-testid="@coinmarket/exchange/crypto-input"
             onChange={value => {
                 updateFiatValue(value);
                 clearErrors(FIAT_INPUT);

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/index.tsx
@@ -167,7 +167,7 @@ const Inputs = () => {
                         disabled={isBalanceZero}
                         onFractionClick={setRatioAmount}
                         onAllClick={setAllAmount}
-                        data-test="@coinmarket/exchange/fiat-input"
+                        data-testid="@coinmarket/exchange/fiat-input"
                     />
                 </Right>
             </Row>

--- a/packages/suite/src/views/wallet/coinmarket/exchange/detail/components/PaymentSuccessful/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/detail/components/PaymentSuccessful/index.tsx
@@ -56,7 +56,10 @@ const PaymentSuccessful = ({ account }: PaymentSuccessfulProps) => {
             <Description>
                 <Translation id="TR_EXCHANGE_DETAIL_SUCCESS_TEXT" />
             </Description>
-            <Button data-test="@coinmarket/exchange/payment/back-to-account" onClick={handleClick}>
+            <Button
+                data-testid="@coinmarket/exchange/payment/back-to-account"
+                onClick={handleClick}
+            >
                 <Translation id="TR_EXCHANGE_DETAIL_SUCCESS_BUTTON" />
             </Button>
         </Wrapper>

--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/SendSwapTransaction/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/SendSwapTransaction/index.tsx
@@ -298,7 +298,7 @@ const SendSwapTransactionComponent = () => {
                                     size="small"
                                     inputState={customSlippageError && 'error'}
                                     name="CustomSlippage"
-                                    data-test="CustomSlippage"
+                                    data-testid="CustomSlippage"
                                     onChange={changeCustomSlippage}
                                 />
                             </RightColumn>

--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/SendTransaction/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/SendTransaction/index.tsx
@@ -67,7 +67,7 @@ const SendTransactionComponent = () => {
 
             <ButtonWrapper>
                 <Button
-                    data-test="@coinmarket/exchange/offers/confirm-on-trezor-and-send"
+                    data-testid="@coinmarket/exchange/offers/confirm-on-trezor-and-send"
                     isLoading={callInProgress}
                     onClick={sendTransaction}
                 >

--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/VerifyAddress/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/VerifyAddress/index.tsx
@@ -249,7 +249,7 @@ const VerifyAddressComponent = () => {
                     {(!addressVerified || addressVerified !== address) &&
                         selectedAccountOption.account && (
                             <Button
-                                data-test="@coinmarket/exchange/offers/confirm-on-trezor-button"
+                                data-testid="@coinmarket/exchange/offers/confirm-on-trezor-button"
                                 isLoading={callInProgress}
                                 isDisabled={callInProgress}
                                 onClick={() => {
@@ -268,7 +268,7 @@ const VerifyAddressComponent = () => {
                     {((addressVerified && addressVerified === address) ||
                         selectedAccountOption?.type === 'NON_SUITE') && (
                         <Button
-                            data-test="@coinmarket/exchange/offers/continue-transaction-button"
+                            data-testid="@coinmarket/exchange/offers/continue-transaction-button"
                             isLoading={callInProgress}
                             onClick={() => {
                                 if (address) {

--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/index.tsx
@@ -126,7 +126,7 @@ const SelectedOffer = () => {
                 account={account}
                 exchangeInfo={exchangeInfo}
                 receiveAccount={receiveAccount}
-                data-test="@coinmarket/exchange/offers/coinmarket-exchange-offer-info"
+                data-testid="@coinmarket/exchange/offers/coinmarket-exchange-offer-info"
             />
         </Wrapper>
     );

--- a/packages/suite/src/views/wallet/coinmarket/exchange_new/components/ExchangeForm/CoinmarketExchangeOfferInfo.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange_new/components/ExchangeForm/CoinmarketExchangeOfferInfo.tsx
@@ -227,7 +227,7 @@ export const CoinmarketExchangeOfferInfo = ({
                         <CoinmarketProviderInfo
                             exchange={exchange}
                             providers={exchangeInfo?.providerInfos}
-                            data-test="@CoinmarketExchangeProviderInfo"
+                            data-testid="@CoinmarketExchangeProviderInfo"
                         />
                     </RightColumn>
                 </Row>

--- a/packages/suite/src/views/wallet/coinmarket/exchange_new/components/ExchangeForm/Footer/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange_new/components/ExchangeForm/Footer/index.tsx
@@ -33,7 +33,7 @@ const Footer = () => {
                     }
                     isLoading={formState.isSubmitting || isComposing}
                     type="submit"
-                    data-test="@coinmarket/exchange/compare-button"
+                    data-testid="@coinmarket/exchange/compare-button"
                 >
                     <Translation id="TR_EXCHANGE_SHOW_OFFERS" />
                 </StyledButton>

--- a/packages/suite/src/views/wallet/coinmarket/exchange_new/components/ExchangeForm/Inputs/FiatInput/FiatSelect/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange_new/components/ExchangeForm/Inputs/FiatInput/FiatSelect/index.tsx
@@ -46,7 +46,7 @@ const FiatSelect = () => {
                         }
                         setAmountLimits(undefined);
                     }}
-                    data-test="@coinmarket/exchange/fiat-select"
+                    data-testid="@coinmarket/exchange/fiat-select"
                     value={value}
                     isClearable={false}
                     options={buildCurrencyOptions(value)}

--- a/packages/suite/src/views/wallet/coinmarket/exchange_new/components/ExchangeForm/Inputs/FiatInput/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange_new/components/ExchangeForm/Inputs/FiatInput/index.tsx
@@ -56,7 +56,7 @@ const FiatInput = () => {
             rules={fiatInputRules}
             bottomText={fiatError?.message || null}
             innerAddon={<FiatSelect />}
-            data-test="@coinmarket/exchange/fiat-input"
+            data-testid="@coinmarket/exchange/fiat-input"
         />
     );
 };

--- a/packages/suite/src/views/wallet/coinmarket/exchange_new/components/ExchangeForm/Inputs/ReceiveCryptoSelect/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange_new/components/ExchangeForm/Inputs/ReceiveCryptoSelect/index.tsx
@@ -156,7 +156,7 @@ const ReceiveCryptoSelect = () => {
                             exchangeInfo,
                             tokenData?.symbol,
                         )}
-                        data-test="@coinmarket/exchange/receive-crypto-select"
+                        data-testid="@coinmarket/exchange/receive-crypto-select"
                         minValueWidth="70px"
                         formatOptionLabel={(
                             option: ReturnType<typeof buildOptions>[number]['options'][number],

--- a/packages/suite/src/views/wallet/coinmarket/exchange_new/components/ExchangeForm/Inputs/SendCryptoInput/SendCryptoSelect/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange_new/components/ExchangeForm/Inputs/SendCryptoInput/SendCryptoSelect/index.tsx
@@ -110,7 +110,7 @@ const SendCryptoSelect = () => {
                     isDisabled={!hasNetworkTypeTradableTokens(account.networkType)}
                     minValueWidth="58px"
                     isClean
-                    data-test="@coinmarket/exchange/crypto-currency-select"
+                    data-testid="@coinmarket/exchange/crypto-currency-select"
                 />
             )}
         />

--- a/packages/suite/src/views/wallet/coinmarket/exchange_new/components/ExchangeForm/Inputs/SendCryptoInput/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange_new/components/ExchangeForm/Inputs/SendCryptoInput/index.tsx
@@ -90,7 +90,7 @@ const SendCryptoInput = ({ isWithRate }: SendCryptoInputProps) => {
     return (
         <StyledInput
             control={control}
-            data-test="@coinmarket/exchange/crypto-input"
+            data-testid="@coinmarket/exchange/crypto-input"
             onChange={value => {
                 updateFiatValue(value);
                 clearErrors(FIAT_INPUT);

--- a/packages/suite/src/views/wallet/coinmarket/exchange_new/components/ExchangeForm/Inputs/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange_new/components/ExchangeForm/Inputs/index.tsx
@@ -167,7 +167,7 @@ const Inputs = () => {
                         disabled={isBalanceZero}
                         onFractionClick={setRatioAmount}
                         onAllClick={setAllAmount}
-                        data-test="@coinmarket/exchange/fiat-input"
+                        data-testid="@coinmarket/exchange/fiat-input"
                     />
                 </Right>
             </Row>

--- a/packages/suite/src/views/wallet/coinmarket/exchange_new/detail/components/PaymentSuccessful/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange_new/detail/components/PaymentSuccessful/index.tsx
@@ -56,7 +56,10 @@ const PaymentSuccessful = ({ account }: PaymentSuccessfulProps) => {
             <Description>
                 <Translation id="TR_EXCHANGE_DETAIL_SUCCESS_TEXT" />
             </Description>
-            <Button data-test="@coinmarket/exchange/payment/back-to-account" onClick={handleClick}>
+            <Button
+                data-testid="@coinmarket/exchange/payment/back-to-account"
+                onClick={handleClick}
+            >
                 <Translation id="TR_EXCHANGE_DETAIL_SUCCESS_BUTTON" />
             </Button>
         </Wrapper>

--- a/packages/suite/src/views/wallet/coinmarket/exchange_new/offers/Offers/SelectedOffer/components/SendSwapTransaction/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange_new/offers/Offers/SelectedOffer/components/SendSwapTransaction/index.tsx
@@ -298,7 +298,7 @@ const SendSwapTransactionComponent = () => {
                                     size="small"
                                     inputState={customSlippageError && 'error'}
                                     name="CustomSlippage"
-                                    data-test="CustomSlippage"
+                                    data-testid="CustomSlippage"
                                     onChange={changeCustomSlippage}
                                 />
                             </RightColumn>

--- a/packages/suite/src/views/wallet/coinmarket/exchange_new/offers/Offers/SelectedOffer/components/SendTransaction/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange_new/offers/Offers/SelectedOffer/components/SendTransaction/index.tsx
@@ -67,7 +67,7 @@ const SendTransactionComponent = () => {
 
             <ButtonWrapper>
                 <Button
-                    data-test="@coinmarket/exchange/offers/confirm-on-trezor-and-send"
+                    data-testid="@coinmarket/exchange/offers/confirm-on-trezor-and-send"
                     isLoading={callInProgress}
                     onClick={sendTransaction}
                 >

--- a/packages/suite/src/views/wallet/coinmarket/exchange_new/offers/Offers/SelectedOffer/components/VerifyAddress/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange_new/offers/Offers/SelectedOffer/components/VerifyAddress/index.tsx
@@ -249,7 +249,7 @@ const VerifyAddressComponent = () => {
                     {(!addressVerified || addressVerified !== address) &&
                         selectedAccountOption.account && (
                             <Button
-                                data-test="@coinmarket/exchange/offers/confirm-on-trezor-button"
+                                data-testid="@coinmarket/exchange/offers/confirm-on-trezor-button"
                                 isLoading={callInProgress}
                                 isDisabled={callInProgress}
                                 onClick={() => {
@@ -268,7 +268,7 @@ const VerifyAddressComponent = () => {
                     {((addressVerified && addressVerified === address) ||
                         selectedAccountOption?.type === 'NON_SUITE') && (
                         <Button
-                            data-test="@coinmarket/exchange/offers/continue-transaction-button"
+                            data-testid="@coinmarket/exchange/offers/continue-transaction-button"
                             isLoading={callInProgress}
                             onClick={() => {
                                 if (address) {

--- a/packages/suite/src/views/wallet/coinmarket/exchange_new/offers/Offers/SelectedOffer/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange_new/offers/Offers/SelectedOffer/index.tsx
@@ -126,7 +126,7 @@ const SelectedOffer = () => {
                 account={account}
                 exchangeInfo={exchangeInfo}
                 receiveAccount={receiveAccount}
-                data-test="@coinmarket/exchange/offers/coinmarket-exchange-offer-info"
+                data-testid="@coinmarket/exchange/offers/coinmarket-exchange-offer-info"
             />
         </Wrapper>
     );

--- a/packages/suite/src/views/wallet/coinmarket/sell/offers/Offers/SelectedOffer/components/SelectBankAccount.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/offers/Offers/SelectedOffer/components/SelectBankAccount.tsx
@@ -136,7 +136,7 @@ export const SelectBankAccount = () => {
                         <RegisterAnother
                             variant="tertiary"
                             icon="PLUS"
-                            data-test="add-output"
+                            data-testid="add-output"
                             onClick={addBankAccount}
                         >
                             <Translation id="TR_SELL_ADD_BANK_ACCOUNT" />

--- a/packages/suite/src/views/wallet/details/index.tsx
+++ b/packages/suite/src/views/wallet/details/index.tsx
@@ -150,7 +150,7 @@ const Details = () => {
                             <ActionColumn>
                                 <StyledActionButton
                                     variant="secondary"
-                                    data-test="@wallets/details/show-xpub-button"
+                                    data-testid="@wallets/details/show-xpub-button"
                                     onClick={handleXpubClick}
                                     isDisabled={disabled}
                                     isLoading={locked}

--- a/packages/suite/src/views/wallet/receive/components/ConnectDevicePromo.tsx
+++ b/packages/suite/src/views/wallet/receive/components/ConnectDevicePromo.tsx
@@ -15,7 +15,7 @@ const ConnectDevicePromo = ({ title, description }: ConnectDevicePromoProps) => 
         selectedDevice?.features?.internal_model || DEFAULT_FLAGSHIP_MODEL;
 
     return (
-        <Warning variant="warning" withIcon={false} dataTest="@warning/trezorNotConnected">
+        <Warning variant="warning" withIcon={false} data-testid="@warning/trezorNotConnected">
             <Row alignItems="center" justifyContent="space-between" gap={12} flex="1">
                 <Column alignItems="start">
                     <Text typographyStyle="highlight" variant="warning">

--- a/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
+++ b/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
@@ -159,7 +159,7 @@ export const FreshAddress = ({
     };
 
     const buttonRevealAddressProps = {
-        'data-test': '@wallet/receive/reveal-address-button',
+        'data-testid': '@wallet/receive/reveal-address-button',
         onClick: handleAddressReveal,
         isDisabled: disabled || locked || coinjoinDisallowReveal || !firstFreshAddress,
         isLoading: locked,

--- a/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
+++ b/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
@@ -121,7 +121,7 @@ const Item = ({ addr, locked, symbol, onClick, metadataPayload, index }: ItemPro
     return (
         <>
             <GridItemAddress
-                data-test={`@wallet/receive/used-address/${index}`}
+                data-testid={`@wallet/receive/used-address/${index}`}
                 onMouseEnter={() => setIsHovered(true)}
                 onMouseLeave={() => setIsHovered(false)}
             >
@@ -145,7 +145,7 @@ const Item = ({ addr, locked, symbol, onClick, metadataPayload, index }: ItemPro
             >
                 <AddressActions $isVisible={isHovered}>
                     <Button
-                        data-test={`@wallet/receive/reveal-address-button/${index}`}
+                        data-testid={`@wallet/receive/reveal-address-button/${index}`}
                         variant="tertiary"
                         isDisabled={locked}
                         isLoading={locked}
@@ -263,7 +263,7 @@ export const UsedAddresses = ({
                             icon="ARROW_DOWN"
                             iconAlignment="right"
                             onClick={() => setLimit(limit + 20)}
-                            data-test="@wallet/receive/used-address/show-more"
+                            data-testid="@wallet/receive/used-address/show-more"
                         >
                             <Translation id="TR_SHOW_MORE" />
                         </Button>

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/BitcoinOptions.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/BitcoinOptions.tsx
@@ -120,7 +120,7 @@ export const BitcoinOptions = () => {
                                     toggleOption('bitcoinLockTime');
                                     composeTransaction();
                                 }}
-                                data-test="add-locktime-button"
+                                data-testid="add-locktime-button"
                             >
                                 <Translation id="LOCKTIME_ADD" />
                             </StyledButton>
@@ -145,7 +145,7 @@ export const BitcoinOptions = () => {
                                 toggleOption('broadcast');
                                 composeTransaction();
                             }}
-                            data-test="broadcast-button"
+                            data-testid="broadcast-button"
                             isDisabled={isBroadcastDisabled}
                         >
                             <Inline>
@@ -168,7 +168,7 @@ export const BitcoinOptions = () => {
                                 size="small"
                                 icon="COIN_CONTROL"
                                 onClick={toggleUtxoSelection}
-                                data-test="coin-control-button"
+                                data-testid="coin-control-button"
                             >
                                 <Inline>
                                     <Translation id="TR_COIN_CONTROL" />
@@ -184,7 +184,7 @@ export const BitcoinOptions = () => {
                         variant="tertiary"
                         size="small"
                         icon="PLUS"
-                        data-test="add-output"
+                        data-testid="add-output"
                         onClick={addOutput}
                         isFullWidth
                     >

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSearch.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSearch.tsx
@@ -42,7 +42,7 @@ export const UtxoSearch = ({ searchQuery, setSearch, setSelectedPage }: UtxoSear
     return (
         <Container>
             <Input
-                data-test="@wallet/send/search-icon"
+                data-testid="@wallet/send/search-icon"
                 innerRef={inputRef}
                 innerAddon={<Icon icon="SEARCH" size={16} color={theme.iconSubdued} />}
                 placeholder={translationString('TR_SEARCH_UTXOS')}

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/Locktime/Locktime.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/Locktime/Locktime.tsx
@@ -94,7 +94,7 @@ export const Locktime = ({ close }: LocktimeProps) => {
                     <IconButton icon="CROSS" size="tiny" variant="tertiary" onClick={close} />
                 }
                 bottomText={error?.message || null}
-                data-test="locktime-input"
+                data-testid="locktime-input"
             />
         </Card>
     );

--- a/packages/suite/src/views/wallet/send/Options/CardanoOptions.tsx
+++ b/packages/suite/src/views/wallet/send/Options/CardanoOptions.tsx
@@ -29,7 +29,7 @@ export const CardanoOptions = () => {
                 variant="tertiary"
                 size="small"
                 icon="PLUS"
-                data-test="add-output"
+                data-testid="add-output"
                 onClick={addOutput}
             >
                 <Translation id="RECIPIENT_ADD" />

--- a/packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumData.tsx
+++ b/packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumData.tsx
@@ -103,7 +103,7 @@ export const EthereumData = ({ close }: EthereumDataProps) => {
         <Wrapper>
             <Textarea
                 inputState={getInputState(asciiError)}
-                data-test={inputAsciiName}
+                data-testid={inputAsciiName}
                 defaultValue={asciiValue}
                 maxLength={formInputsMaxLength.ethData}
                 bottomText={asciiError?.message || null}
@@ -114,7 +114,7 @@ export const EthereumData = ({ close }: EthereumDataProps) => {
             <Space> = </Space>
             <Textarea
                 inputState={getInputState(hexError)}
-                data-test={inputHexName}
+                data-testid={inputHexName}
                 defaultValue={hexValue}
                 maxLength={formInputsMaxLength.ethData}
                 bottomText={hexError?.message || null}
@@ -122,7 +122,7 @@ export const EthereumData = ({ close }: EthereumDataProps) => {
                     <Icon
                         size={20}
                         icon="CROSS"
-                        data-test="send/close-ethereum-data"
+                        data-testid="send/close-ethereum-data"
                         onClick={handleClose}
                     />
                 }

--- a/packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumOptions.tsx
+++ b/packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumOptions.tsx
@@ -51,7 +51,7 @@ export const EthereumOptions = () => {
                             variant="tertiary"
                             size="small"
                             icon="DATA"
-                            data-test="send/open-ethereum-data"
+                            data-testid="send/open-ethereum-data"
                             onClick={toggleData}
                         >
                             <Translation id="DATA_ETH_ADD" />
@@ -64,7 +64,7 @@ export const EthereumOptions = () => {
                         variant="tertiary"
                         size="small"
                         icon="BROADCAST"
-                        data-test="send/broadcast"
+                        data-testid="send/broadcast"
                         onClick={toggleBroadcast}
                     >
                         <Translation id="BROADCAST" />

--- a/packages/suite/src/views/wallet/send/Options/RippleOptions/DestinationTag.tsx
+++ b/packages/suite/src/views/wallet/send/Options/RippleOptions/DestinationTag.tsx
@@ -41,7 +41,7 @@ export const DestinationTag = ({ close }: DestinationTagProps) => {
     return (
         <Input
             inputState={getInputState(error)}
-            data-test={inputName}
+            data-testid={inputName}
             defaultValue={inputValue}
             maxLength={formInputsMaxLength.xrpDestinationTag}
             label={<Translation id="DESTINATION_TAG" />}

--- a/packages/suite/src/views/wallet/send/Outputs/Address.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Address.tsx
@@ -274,7 +274,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                             icon="CROSS"
                             size="tiny"
                             variant="tertiary"
-                            data-test={`outputs.${outputId}.remove`}
+                            data-testid={`outputs.${outputId}.remove`}
                             onClick={() => {
                                 removeOutput(outputId);
                                 // compose by first Output
@@ -293,7 +293,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                         addressBottomText
                     )
                 }
-                data-test={inputName}
+                data-testid={inputName}
                 defaultValue={addressValue}
                 maxLength={formInputsMaxLength.address}
                 innerRef={inputRef}

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
@@ -234,7 +234,7 @@ export const Amount = ({ output, outputId }: AmountProps) => {
             hideOnLargeScreens={hideOnLargeScreens}
             hideOnSmallScreens={hideOnSmallScreens}
             isSetMaxActive={isSetMaxActive}
-            dataTest={!hideOnSmallScreens ? maxSwitchId : ''}
+            data-testid={!hideOnSmallScreens ? maxSwitchId : ''}
             onChange={onSwitchChange}
         />
     );
@@ -269,7 +269,7 @@ export const Amount = ({ output, outputId }: AmountProps) => {
                         bottomText={bottomText || null}
                         onChange={handleInputChange}
                         name={amountName}
-                        data-test={amountName}
+                        data-testid={amountName}
                         defaultValue={amountValue}
                         maxLength={formInputsMaxLength.amount}
                         rules={cryptoAmountRules}

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/FiatInput.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/FiatInput.tsx
@@ -190,7 +190,7 @@ export const FiatInput = ({ output, outputId, labelHoverRight, labelRight }: Fia
             isSearchable
             minValueWidth="58px"
             isClean
-            data-test={currencyInputName}
+            data-testid={currencyInputName}
             onChange={async (selected: CurrencyOption) => {
                 // propagate changes to FormState
                 onChange(selected);
@@ -228,7 +228,7 @@ export const FiatInput = ({ output, outputId, labelHoverRight, labelRight }: Fia
                 inputState={inputState}
                 onChange={handleChange}
                 name={fiatInputName}
-                data-test={fiatInputName}
+                data-testid={fiatInputName}
                 defaultValue={fiatValue}
                 maxLength={formInputsMaxLength.fiat}
                 rules={rules}

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/SendMaxSwitch.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/SendMaxSwitch.tsx
@@ -32,13 +32,13 @@ interface SendMaxSwitchProps {
     hideOnLargeScreens?: boolean;
     hideOnSmallScreens?: boolean;
     isSetMaxActive: boolean;
-    dataTest: string;
+    'data-testid'?: string;
     onChange: () => void;
 }
 
 export const SendMaxSwitch = ({
     isSetMaxActive,
-    dataTest,
+    'data-testid': dataTest,
     onChange,
     hideOnLargeScreens,
     hideOnSmallScreens,
@@ -48,7 +48,7 @@ export const SendMaxSwitch = ({
         $hideOnSmallScreens={hideOnSmallScreens}
         labelPosition="left"
         isChecked={isSetMaxActive}
-        dataTest={dataTest}
+        data-testid={dataTest}
         isSmall
         onChange={onChange}
         label={<Translation id="AMOUNT_SEND_MAX" />}

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/TokenSelect.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/TokenSelect.tsx
@@ -158,7 +158,7 @@ export const TokenSelect = ({ output, outputId }: TokenSelectProps) => {
         <Controller
             control={control}
             name={tokenInputName}
-            data-test={tokenInputName}
+            data-testid={tokenInputName}
             defaultValue={tokenValue}
             render={({ field: { onChange } }) => (
                 <Select
@@ -194,7 +194,7 @@ export const TokenSelect = ({ output, outputId }: TokenSelectProps) => {
                         // compose (could be prevented because of Amount error from re-validation above)
                         composeTransaction(amountInputName);
                     }}
-                    data-test="@amount-select"
+                    data-testid="@amount-select"
                 />
             )}
         />

--- a/packages/suite/src/views/wallet/send/Outputs/OpReturn.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/OpReturn.tsx
@@ -107,7 +107,7 @@ export const OpReturn = ({ outputId }: { outputId: number }) => {
             <Inputs>
                 <StyledTextarea
                     inputState={getInputState(asciiError)}
-                    data-test={inputAsciiName}
+                    data-testid={inputAsciiName}
                     defaultValue={asciiValue}
                     maxLength={formInputsMaxLength.opReturn}
                     bottomText={asciiError?.message || null}
@@ -118,7 +118,7 @@ export const OpReturn = ({ outputId }: { outputId: number }) => {
                 <Space> = </Space>
                 <StyledTextarea
                     inputState={getInputState(hexError)}
-                    data-test={inputHexName}
+                    data-testid={inputHexName}
                     defaultValue={hexValue}
                     maxLength={formInputsMaxLength.opReturn}
                     bottomText={hexError?.message || null}

--- a/packages/suite/src/views/wallet/send/SendHeader.tsx
+++ b/packages/suite/src/views/wallet/send/SendHeader.tsx
@@ -28,14 +28,14 @@ export const SendHeader = () => {
     const opreturnOutput = (outputs || []).find(o => o.type === 'opreturn');
     const options: Array<DropdownMenuItemProps> = [
         {
-            'data-test': '@send/header-dropdown/opreturn',
+            'data-testid': '@send/header-dropdown/opreturn',
             onClick: addOpReturn,
             label: <Translation id="OP_RETURN_ADD" />,
             isDisabled: !!opreturnOutput,
             isHidden: networkType !== 'bitcoin',
         },
         {
-            'data-test': '@send/header-dropdown/import',
+            'data-testid': '@send/header-dropdown/import',
             onClick: () => {
                 loadTransaction();
             },
@@ -43,7 +43,7 @@ export const SendHeader = () => {
             isHidden: networkType !== 'bitcoin',
         },
         {
-            'data-test': '@send/header-dropdown/raw',
+            'data-testid': '@send/header-dropdown/raw',
             onClick: () => {
                 dispatch(sendFormActions.sendRaw(true));
             },
@@ -61,7 +61,7 @@ export const SendHeader = () => {
                         size="small"
                         variant="tertiary"
                         onClick={resetContext}
-                        data-test="clear-form"
+                        data-testid="clear-form"
                     >
                         <Translation id="TR_CLEAR_ALL" />
                     </ClearButton>
@@ -69,7 +69,7 @@ export const SendHeader = () => {
 
                 <Dropdown
                     alignMenu="bottom-right"
-                    data-test="@send/header-dropdown"
+                    data-testid="@send/header-dropdown"
                     items={[
                         {
                             key: 'header',

--- a/packages/suite/src/views/wallet/send/SendRaw.tsx
+++ b/packages/suite/src/views/wallet/send/SendRaw.tsx
@@ -110,7 +110,7 @@ export const SendRaw = ({ account }: SendRawProps) => {
 
             <StyledTextarea
                 inputState={inputState}
-                data-test={INPUT_NAME}
+                data-testid={INPUT_NAME}
                 defaultValue={inputValue}
                 bottomText={error?.message || null}
                 label={<Translation id="RAW_TRANSACTION" />}

--- a/packages/suite/src/views/wallet/send/TotalSent/ReviewButton.tsx
+++ b/packages/suite/src/views/wallet/send/TotalSent/ReviewButton.tsx
@@ -170,7 +170,7 @@ export const ReviewButton = () => {
             <ButtonReview
                 $isRed={anonymityWarningChecked}
                 tooltipContent={tooltipContent}
-                data-test="@send/review-button"
+                data-testid="@send/review-button"
                 isDisabled={isDisabled || isLoading}
                 onClick={signTransaction}
             >

--- a/packages/suite/src/views/wallet/send/index.tsx
+++ b/packages/suite/src/views/wallet/send/index.tsx
@@ -89,7 +89,7 @@ const SendLoaded = ({ children, selectedAccount }: SendLoadedProps) => {
             <SendContext.Provider value={sendContextValues}>
                 <SendHeader />
 
-                <FormGrid data-test="@wallet/send/outputs-and-options">
+                <FormGrid data-testid="@wallet/send/outputs-and-options">
                     <Outputs disableAnim={!!children} />
                     <Options />
                     <SendFees />

--- a/packages/suite/src/views/wallet/sign-verify/components/ButtonRow.tsx
+++ b/packages/suite/src/views/wallet/sign-verify/components/ButtonRow.tsx
@@ -116,7 +116,7 @@ export const ButtonRow = ({
                     iconSize={20}
                     isDisabled={isTrezorLocked}
                     isLoading={isSubmitting}
-                    data-test="@sign-verify/submit"
+                    data-testid="@sign-verify/submit"
                 >
                     <Translation id={isSignPage ? 'TR_SIGN' : 'TR_VERIFY'} />
                 </StyledButton>

--- a/packages/suite/src/views/wallet/sign-verify/components/Navigation.tsx
+++ b/packages/suite/src/views/wallet/sign-verify/components/Navigation.tsx
@@ -31,13 +31,13 @@ export const Navigation = ({ page, setPage }: NavigationProps) => (
             title="TR_SIGN_MESSAGE"
             active={page === 'sign'}
             onClick={() => setPage('sign')}
-            data-test="@sign-verify/navigation/sign"
+            data-testid="@sign-verify/navigation/sign"
         />
         <NavigationTab
             title="TR_VERIFY_MESSAGE"
             active={page === 'verify'}
             onClick={() => setPage('verify')}
-            data-test="@sign-verify/navigation/verify"
+            data-testid="@sign-verify/navigation/verify"
         />
     </Container>
 );

--- a/packages/suite/src/views/wallet/sign-verify/components/NavigationTab.tsx
+++ b/packages/suite/src/views/wallet/sign-verify/components/NavigationTab.tsx
@@ -58,14 +58,14 @@ export interface NavigationTabProps {
     values?: ExtendedMessageDescriptor['values'];
     badge?: ExtendedMessageDescriptor['id'];
     onClick: () => void;
-    'data-test'?: string;
+    'data-testid'?: string;
 }
 
 export const NavigationTab = (props: NavigationTabProps) => {
     const { active, title, onClick, values, badge } = props;
 
     return (
-        <NavLink $active={active} onClick={onClick} data-test={props['data-test']}>
+        <NavLink $active={active} onClick={onClick} data-testid={props['data-testid']}>
             <NavLinkText>
                 <Translation id={title} values={values} />
                 {badge && (

--- a/packages/suite/src/views/wallet/sign-verify/components/SignAddressInput.tsx
+++ b/packages/suite/src/views/wallet/sign-verify/components/SignAddressInput.tsx
@@ -25,7 +25,7 @@ const Option = ({ data, value, isFocused, innerProps, ...rest }: any) => (
         isFocused={isFocused}
         innerProps={{
             ...innerProps,
-            'data-test': `@sign-verify/sign-address/option/${value}`,
+            'data-testid': `@sign-verify/sign-address/option/${value}`,
         }}
         {...rest}
     >

--- a/packages/suite/src/views/wallet/sign-verify/index.tsx
+++ b/packages/suite/src/views/wallet/sign-verify/index.tsx
@@ -158,7 +158,7 @@ const SignVerify = () => {
         label: translationString('TR_SIGNATURE'),
         inputState: getInputState(formErrors.signature) as ReturnType<typeof getInputState>,
         bottomText: signatureError,
-        'data-test': '@sign-verify/signature',
+        'data-testid': '@sign-verify/signature',
         innerRef: signatureRef,
         ...signatureField,
     };
@@ -223,7 +223,7 @@ const SignVerify = () => {
                             }}
                             bottomText={messageError || null}
                             rows={4}
-                            data-test="@sign-verify/message"
+                            data-testid="@sign-verify/message"
                             innerRef={messageRef}
                             {...messageField}
                         />
@@ -238,7 +238,7 @@ const SignVerify = () => {
                                 revealedAddresses={revealedAddresses}
                                 inputState={getInputState(formErrors.path)}
                                 bottomText={pathError || null}
-                                data-test="@sign-verify/sign-address"
+                                data-testid="@sign-verify/sign-address"
                                 {...pathField}
                             />
                         ) : (
@@ -248,7 +248,7 @@ const SignVerify = () => {
                                 type="text"
                                 inputState={getInputState(formErrors.address)}
                                 bottomText={addressError || null}
-                                data-test="@sign-verify/select-address"
+                                data-testid="@sign-verify/select-address"
                                 {...addressField}
                             />
                         )}
@@ -261,7 +261,7 @@ const SignVerify = () => {
                                     </Tooltip>
                                 }
                                 options={formatOptions}
-                                data-test="@sign-verify/format"
+                                data-testid="@sign-verify/format"
                                 {...isElectrumField}
                             />
                         )}

--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/StakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/StakingCard.tsx
@@ -164,7 +164,7 @@ export const StakingCard = ({
                         </AmountHeading>
 
                         <TrimmedCryptoAmount
-                            data-test="@account/staking/pending"
+                            data-testid="@account/staking/pending"
                             value={totalPendingStakeBalance}
                             symbol={selectedAccount?.symbol}
                         />
@@ -186,7 +186,7 @@ export const StakingCard = ({
                     </AmountHeading>
 
                     <TrimmedCryptoAmount
-                        data-test="@account/staking/staked"
+                        data-testid="@account/staking/staked"
                         value={depositedBalance}
                         symbol={selectedAccount?.symbol}
                     />
@@ -207,7 +207,7 @@ export const StakingCard = ({
                     </AmountHeading>
 
                     <TrimmedCryptoAmount
-                        data-test="@account/staking/rewards"
+                        data-testid="@account/staking/rewards"
                         value={restakedReward}
                         symbol={selectedAccount?.symbol}
                         isRewards
@@ -244,7 +244,7 @@ export const StakingCard = ({
                         </AmountHeading>
 
                         <TrimmedCryptoAmount
-                            data-test="@account/staking/unstaking"
+                            data-testid="@account/staking/unstaking"
                             value={withdrawTotalAmount}
                             symbol={selectedAccount?.symbol}
                         />

--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/TrimmedCryptoAmount.tsx
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/TrimmedCryptoAmount.tsx
@@ -21,7 +21,7 @@ interface TrimmedCryptoAmountProps {
     symbol: string;
     maxDecimalPlaces?: number;
     isRewards?: boolean;
-    'data-test'?: string;
+    'data-testid'?: string;
 }
 
 export const TrimmedCryptoAmount = ({
@@ -29,7 +29,7 @@ export const TrimmedCryptoAmount = ({
     symbol,
     maxDecimalPlaces = DEFAULT_MAX_DECIMAL_PLACES,
     isRewards,
-    'data-test': dataTest,
+    'data-testid': dataTest,
 }: TrimmedCryptoAmountProps) => {
     const hasDecimals = value.toString().includes('.');
 
@@ -39,7 +39,7 @@ export const TrimmedCryptoAmount = ({
                 value={value}
                 symbol={symbol}
                 $isRewards={isRewards}
-                data-test={dataTest}
+                data-testid={dataTest}
             />
         );
     }
@@ -50,7 +50,7 @@ export const TrimmedCryptoAmount = ({
     return (
         <Tooltip content={<StyledFormattedCryptoAmount value={value} symbol={symbol} $isSmall />}>
             <StyledFormattedCryptoAmount
-                data-test={dataTest}
+                data-testid={dataTest}
                 value={trimmedAmount}
                 symbol={symbol}
                 $isRewards={isRewards}

--- a/packages/suite/src/views/wallet/tokens/common/TokensLayout/TokensLayoutNavigation.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensLayout/TokensLayoutNavigation.tsx
@@ -157,7 +157,7 @@ export const TokensLayoutNavigation = ({
                     setExpanded={setExpanded}
                     setSearch={setSearchQuery}
                     onSearch={e => setSearchQuery(e.target.value)}
-                    dataTest="@wallet/accounts/search-icon"
+                    data-testid="@wallet/accounts/search-icon"
                 />
                 {showAddToken && (
                     <IconButton

--- a/packages/suite/src/views/wallet/transactions/TradeBox/TradeBoxMenu.tsx
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/TradeBoxMenu.tsx
@@ -84,7 +84,7 @@ export const TradeBoxMenu = ({ account }: TradeBoxMenuProps) => {
                             dispatch(goto(item.route, { preserveParams: true }));
                         }}
                         isDisabled={item.type !== 'buy' && account.empty}
-                        data-test={`@coinmarket/menu/${item.route}`}
+                        data-testid={`@coinmarket/menu/${item.route}`}
                     >
                         {item.title}
                     </StyledButton>

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
@@ -155,7 +155,7 @@ export const TransactionList = ({
                     isExportable={isExportable}
                 />
             }
-            data-test="@wallet/accounts/transaction-list"
+            data-testid="@wallet/accounts/transaction-list"
         >
             {account.accountType === 'coinjoin' && !isSearching && (
                 <TransactionCandidates accountKey={account.key} />

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/ExportAction.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/ExportAction.tsx
@@ -110,22 +110,22 @@ export const ExportAction = ({ account, searchQuery, accountMetadata }: ExportAc
                         {
                             label: <Translation id="TR_EXPORT_AS" values={{ as: 'CSV' }} />,
                             onClick: () => runExport('csv'),
-                            'data-test': `${dataTest}/csv`,
+                            'data-testid': `${dataTest}/csv`,
                         },
                         {
                             label: <Translation id="TR_EXPORT_AS" values={{ as: 'PDF' }} />,
                             onClick: () => runExport('pdf'),
-                            'data-test': `${dataTest}/pdf`,
+                            'data-testid': `${dataTest}/pdf`,
                         },
                         {
                             label: <Translation id="TR_EXPORT_AS" values={{ as: 'JSON' }} />,
                             onClick: () => runExport('json'),
-                            'data-test': `${dataTest}/json`,
+                            'data-testid': `${dataTest}/json`,
                         },
                     ],
                 },
             ]}
-            data-test={`${dataTest}/dropdown`}
+            data-testid={`${dataTest}/dropdown`}
         />
     );
 };

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/TransactionListActions.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/TransactionListActions.tsx
@@ -81,7 +81,7 @@ export const TransactionListActions = ({
                 setExpanded={setExpanded}
                 setSearch={setSearch}
                 onSearch={onSearch}
-                dataTest="@wallet/accounts/search-icon"
+                data-testid="@wallet/accounts/search-icon"
             />
             {isExportable && (
                 <ExportAction

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/PendingGroupHeader.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/PendingGroupHeader.tsx
@@ -6,7 +6,7 @@ type PendingGroupHeaderProps = { txsCount: number };
 export const PendingGroupHeader = ({ txsCount }: PendingGroupHeaderProps) => {
     return (
         <HeaderWrapper>
-            <ColPending data-test="@transaction-group/pending/count">
+            <ColPending data-testid="@transaction-group/pending/count">
                 <Translation id="TR_PENDING_TX_HEADING" values={{ count: txsCount }} /> • {txsCount}
             </ColPending>
         </HeaderWrapper>

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/TransactionsGroup.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/TransactionsGroup.tsx
@@ -90,7 +90,7 @@ export const TransactionsGroup = ({
         <TransactionsGroupWrapper
             key={dateKey}
             onMouseEnter={() => setIsHovered(true)}
-            data-test={`@wallet/accounts/transaction-list/${isPending ? 'pending' : 'confirmed'}/group/${index}`}
+            data-testid={`@wallet/accounts/transaction-list/${isPending ? 'pending' : 'confirmed'}/group/${index}`}
             onMouseLeave={() => setIsHovered(false)}
             {...rest}
         >

--- a/packages/suite/src/views/wallet/transactions/components/AccountEmpty.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/AccountEmpty.tsx
@@ -107,7 +107,7 @@ export const AccountEmpty = ({ account }: AccountEmptyProps) => {
 
                 <Actions>
                     <ActionButton
-                        data-test="@accounts/empty-account/receive"
+                        data-testid="@accounts/empty-account/receive"
                         variant="primary"
                         onClick={handleNavigateToReceivePage}
                     >
@@ -115,7 +115,7 @@ export const AccountEmpty = ({ account }: AccountEmptyProps) => {
                     </ActionButton>
 
                     <ActionButton
-                        data-test="@accounts/empty-account/buy"
+                        data-testid="@accounts/empty-account/buy"
                         variant="primary"
                         onClick={handleNavigateToBuyPage}
                     >

--- a/suite-common/icons/src/webComponents/Icon.web.tsx
+++ b/suite-common/icons/src/webComponents/Icon.web.tsx
@@ -43,7 +43,7 @@ type WebIconProps = Omit<IconProps, 'color'> & {
     color?: CSSColor | Color;
     onClick?: () => void;
     className?: string;
-    dataTest?: string;
+    'data-testid'?: string;
 };
 
 export const Icon = ({
@@ -52,7 +52,7 @@ export const Icon = ({
     color = 'iconDefault',
     onClick,
     className,
-    dataTest,
+    'data-testid': dataTest,
 }: WebIconProps) => {
     const theme = useTheme();
 
@@ -93,7 +93,7 @@ export const Icon = ({
             src={icons[name]}
             beforeInjection={handleInjection}
             className={className}
-            data-test={dataTest}
+            data-testid={dataTest}
         />
     );
 };

--- a/suite-native/atoms/src/types.ts
+++ b/suite-native/atoms/src/types.ts
@@ -1,7 +1,7 @@
 export type TestProps = {
     ['data-testid']?: never;
     ['data-test']?: never;
-    ['data-test-id']?: never;
+    ['data-testid']?: never;
     ['data-testId']?: never;
     ['data-testID']?: string;
 };


### PR DESCRIPTION
## Description

For Cypress and Playwright E2E tests, do following:

- 93634092192824e34222c2a56601680bd848b1c7 refactor all usages of `data-test` to `data-testid`
- 15bb29c4bb96998ba959aa2f48a9dafb7fc53deb when the value is passed through props, refactor prop names from `dataTest` or such to  `data-testid`

## Related Issue

Resolve #13247