### PR TITLE
fix(suite): fix condition for experimental urls

### DIFF
--- a/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
@@ -55,14 +55,12 @@ const FeatureLine = ({ feature, features }: FeatureLineProps) => {
 
     return (
         <FeatureLineWrapper>
-            {url && (
-                <TextColumn
-                    title={titleId ? <Translation id={titleId} /> : feature}
-                    description={descId && <Translation id={descId} />}
-                    buttonLink={url}
-                    buttonTitle={<Translation id="TR_LEARN_MORE" />}
-                />
-            )}
+            <TextColumn
+                title={titleId ? <Translation id={titleId} /> : feature}
+                description={descId && <Translation id={descId} />}
+                buttonLink={url}
+                buttonTitle={<Translation id="TR_LEARN_MORE" />}
+            />
             <ActionColumn>
                 <Checkbox isChecked={checked} onClick={onChangeFeature} />
             </ActionColumn>


### PR DESCRIPTION
Fixing condition for Experimental url in Experimental.tsx so BNB could be there 🧊 
![Snímek obrazovky 2024-08-07 v 15 53 18](https://github.com/user-attachments/assets/e68c5ef2-6330-4c12-b3eb-ae6077e69251)
