### PR TITLE
Feat/transport bridge protocol message

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -1,7 +1,7 @@
 // original file https://github.com/trezor/connect/blob/develop/src/js/device/Device.js
 import { versionUtils, createDeferred, Deferred, TypedEmitter } from '@trezor/utils';
 import { Session } from '@trezor/transport';
-import { TransportProtocol, v1 as v1Protocol, bridge as bridgeProtocol } from '@trezor/protocol';
+import { TransportProtocol, v1 as v1Protocol } from '@trezor/protocol';
 import { DeviceCommands, PassphrasePromptResponse } from './DeviceCommands';
 import { PROTO, ERRORS, NETWORK } from '../constants';
 import { DEVICE, DeviceButtonRequestPayload, UI } from '../events';
@@ -154,11 +154,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
     constructor(transport: Transport, descriptor: Descriptor) {
         super();
 
-        if (transport.name === 'BridgeTransport') {
-            this.protocol = bridgeProtocol;
-        } else {
-            this.protocol = v1Protocol;
-        }
+        this.protocol = v1Protocol;
 
         // === immutable properties
         this.transport = transport;

--- a/packages/protocol/src/protocol-bridge/index.ts
+++ b/packages/protocol/src/protocol-bridge/index.ts
@@ -1,2 +1,3 @@
 export * from './decode';
 export * from './encode';
+export const name = 'bridge';

--- a/packages/protocol/src/protocol-v1/index.ts
+++ b/packages/protocol/src/protocol-v1/index.ts
@@ -1,2 +1,3 @@
 export * from './decode';
 export * from './encode';
+export const name = 'v1';

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -14,6 +14,7 @@ export type TransportProtocolEncode = (
 ) => Buffer;
 
 export interface TransportProtocol {
+    name: 'bridge' | 'v1';
     encode: TransportProtocolEncode;
     decode: TransportProtocolDecode;
     getChunkHeader: (data: Buffer) => Buffer;

--- a/packages/transport-bridge/src/http.ts
+++ b/packages/transport-bridge/src/http.ts
@@ -13,6 +13,7 @@ import {
     Response,
 } from '@trezor/node-utils';
 import { Descriptor, Session } from '@trezor/transport/src/types';
+import { validateProtocolMessage } from '@trezor/transport/src/utils/bridgeProtocolMessage';
 import { Log, arrayPartition, Throttler } from '@trezor/utils';
 import { AbstractApi } from '@trezor/transport/src/api/abstract';
 
@@ -22,14 +23,15 @@ const defaults = {
     port: 21325,
 };
 
-const str = (value: Record<string, any> | string) => JSON.stringify(value);
+const str = (value: Record<string, any> | string) =>
+    typeof value === 'string' ? value : JSON.stringify(value);
 
 const validateDescriptorsJSON: RequestHandler<JSON, Descriptor[]> = (request, response, next) => {
     if (Array.isArray(request.body)) {
         next({ ...request, body: request.body }, response);
     } else {
         response.statusCode = 400;
-        response.end(JSON.stringify({ error: 'Invalid body' }));
+        response.end(str({ error: 'Invalid body' }));
     }
 };
 
@@ -45,7 +47,7 @@ const validateAcquireParams: ParamsValidatorHandler<{
         next(request as Parameters<typeof next>[0], response);
     } else {
         response.statusCode = 400;
-        response.end(JSON.stringify({ error: 'Invalid params' }));
+        response.end(str({ error: 'Invalid params' }));
     }
 };
 
@@ -56,9 +58,28 @@ const validateSessionParams: ParamsValidatorHandler<{
         next(request as Parameters<typeof next>[0], response);
     } else {
         response.statusCode = 400;
-        response.end(JSON.stringify({ error: 'Invalid params' }));
+        response.end(str({ error: 'Invalid params' }));
     }
 };
+
+const validateProtocolMessageBody =
+    (
+        withData: boolean,
+        protocolMessages: boolean,
+    ): RequestHandler<string, ReturnType<typeof validateProtocolMessage>> =>
+    (request, response, next) => {
+        try {
+            const body = validateProtocolMessage(request.body, withData);
+            if (!protocolMessages && body.protocol) {
+                throw new Error('BridgeProtocolMessage support is disabled');
+            }
+
+            return next({ ...request, body }, response);
+        } catch (error) {
+            response.statusCode = 400;
+            response.end(str({ error: error.message }));
+        }
+    };
 
 export class TrezordNode {
     /** versioning, baked in by webpack */
@@ -77,6 +98,7 @@ export class TrezordNode {
     core: ReturnType<typeof createCore>;
     logger: Log;
     assetPrefix: string;
+    protocolMessages: boolean;
     throttler = new Throttler(500);
 
     constructor({
@@ -84,11 +106,13 @@ export class TrezordNode {
         api,
         assetPrefix = '',
         logger,
+        protocolMessages,
     }: {
         port: number;
         api: 'usb' | 'udp' | AbstractApi;
         assetPrefix?: string;
         logger: Log;
+        protocolMessages?: boolean;
     }) {
         this.port = port || defaults.port;
         this.logger = logger;
@@ -99,6 +123,7 @@ export class TrezordNode {
         this.core = createCore(api, this.logger);
 
         this.assetPrefix = assetPrefix;
+        this.protocolMessages = protocolMessages ?? true;
     }
 
     private resolveListenSubscriptions(descriptors: Descriptor[]) {
@@ -148,6 +173,7 @@ export class TrezordNode {
         res.end(
             str({
                 version: this.version,
+                protocolMessages: this.protocolMessages,
             }),
         );
     }
@@ -278,12 +304,13 @@ export class TrezordNode {
             app.post('/call/:session', [
                 validateSessionParams,
                 parseBodyText,
+                validateProtocolMessageBody(true, this.protocolMessages),
                 (req, res) => {
                     const signal = this.createAbortSignal(res);
                     this.core
                         .call({
+                            ...req.body,
                             session: req.params.session,
-                            data: req.body,
                             signal,
                         })
                         .then(result => {
@@ -292,36 +319,21 @@ export class TrezordNode {
 
                                 return res.end(str({ error: result.error }));
                             }
-                            res.end(result.payload);
+                            res.end(str(result.payload));
                         });
                 },
             ]);
 
             app.post('/read/:session', [
                 validateSessionParams,
-                (req, res) => {
-                    const signal = this.createAbortSignal(res);
-                    this.core.receive({ session: req.params.session, signal }).then(result => {
-                        if (!result.success) {
-                            res.statusCode = 400;
-
-                            return res.end(str({ error: result.error }));
-                        }
-
-                        res.end(result.payload);
-                    });
-                },
-            ]);
-
-            app.post('/post/:session', [
-                validateSessionParams,
                 parseBodyText,
+                validateProtocolMessageBody(false, this.protocolMessages),
                 (req, res) => {
                     const signal = this.createAbortSignal(res);
                     this.core
-                        .send({
+                        .receive({
+                            ...req.body,
                             session: req.params.session,
-                            data: req.body,
                             signal,
                         })
                         .then(result => {
@@ -330,7 +342,30 @@ export class TrezordNode {
 
                                 return res.end(str({ error: result.error }));
                             }
-                            res.end();
+                            res.end(str(result.payload));
+                        });
+                },
+            ]);
+
+            app.post('/post/:session', [
+                validateSessionParams,
+                parseBodyText,
+                validateProtocolMessageBody(true, this.protocolMessages),
+                (req, res) => {
+                    const signal = this.createAbortSignal(res);
+                    this.core
+                        .send({
+                            ...req.body,
+                            session: req.params.session,
+                            signal,
+                        })
+                        .then(result => {
+                            if (!result.success) {
+                                res.statusCode = 400;
+
+                                return res.end(str({ error: result.error }));
+                            }
+                            res.end(str(result.payload));
                         });
                 },
             ]);

--- a/packages/transport-bridge/tests/http.test.ts
+++ b/packages/transport-bridge/tests/http.test.ts
@@ -117,6 +117,309 @@ describe('http', () => {
         await anotherInstance.stop();
     });
 
+    describe('BridgeProtocolMessage', () => {
+        const GET_FEATURES = '000000000000'; // Initialize message-in
+        const FEATURES = '00110000000c1002180020006000aa010154'; // Features message-out
+
+        const setupTrezordNode = async (params?: Parameters<typeof createTrezordNode>[0]) => {
+            const trezordNode = createTrezordNode({
+                port: await getFreePort(),
+                ...params,
+            });
+            await trezordNode.start();
+            const url = trezordNode.server?.getRouteAddress('/') || '/';
+
+            await bridgeApiCall({
+                url: `${url}enumerate`,
+                method: 'POST',
+            });
+            await bridgeApiCall({
+                url: `${url}acquire/1/null`,
+                method: 'POST',
+            });
+
+            return { trezordNode, url };
+        };
+
+        it('POST / getInfo with protocolMessage flag enabled', async () => {
+            const { trezordNode, url } = await setupTrezordNode();
+            const response = await bridgeApiCall({
+                url,
+                method: 'POST',
+            });
+            if (!response.success) {
+                throw new Error(response.error + ' ' + response.message);
+            }
+            expect(response.payload).toEqual({
+                version: trezordNode.version,
+                protocolMessages: true,
+            });
+            await trezordNode.stop();
+        });
+
+        it('POST / getInfo with protocolMessage flag disabled', async () => {
+            const { trezordNode, url } = await setupTrezordNode({ protocolMessages: false });
+            const response = await bridgeApiCall({
+                url,
+                method: 'POST',
+            });
+            if (!response.success) {
+                throw new Error(response.error + ' ' + response.message);
+            }
+            expect(response.payload).toEqual({
+                version: trezordNode.version,
+                protocolMessages: false,
+            });
+            await trezordNode.stop();
+        });
+
+        it('/call protocolMessage validation', async () => {
+            const { trezordNode, url } = await setupTrezordNode();
+
+            let res;
+            // no protocol, legacy way
+            res = await bridgeApiCall({
+                url: `${url}call/1`,
+                method: 'POST',
+                body: GET_FEATURES,
+            });
+            if (!res.success) {
+                throw new Error(res.error + ' ' + res.message);
+            }
+            expect(res.payload).toBe(FEATURES);
+            // invalid legacy message (not a hex)
+            res = await bridgeApiCall({
+                url: `${url}call/1`,
+                method: 'POST',
+                body: 'not a hex',
+            });
+            expect(res.success).toBe(false);
+
+            // protocol bridge, json response without magic header
+            res = await bridgeApiCall({
+                url: `${url}call/1`,
+                method: 'POST',
+                body: JSON.stringify({ protocol: 'bridge', data: GET_FEATURES }),
+            });
+            if (!res.success) {
+                throw new Error(res.error + ' ' + res.message);
+            }
+            expect(res.payload).toEqual({
+                protocol: 'bridge',
+                data: FEATURES,
+            });
+
+            // protocol v1, json response with magic header
+            res = await bridgeApiCall({
+                url: `${url}call/1`,
+                method: 'POST',
+                body: JSON.stringify({ protocol: 'v1', data: '3f2323' + GET_FEATURES }),
+            });
+            if (!res.success) {
+                throw new Error(res.error);
+            }
+            expect(res.payload).toEqual({
+                protocol: 'v1',
+                data: '3f2323' + FEATURES,
+            });
+
+            // invalid protocol name (protocol v0)
+            res = await bridgeApiCall({
+                url: `${url}call/1`,
+                method: 'POST',
+                body: JSON.stringify({ protocol: 'v0', message: '00' }),
+            });
+            expect(res.success).toBe(false);
+
+            // invalid protocol message (not a hex)
+            res = await bridgeApiCall({
+                url: `${url}call/1`,
+                method: 'POST',
+                body: JSON.stringify({ protocol: 'v1', message: 'not a hex' }),
+            });
+            expect(res.success).toBe(false);
+
+            // invalid protocol message (malformed json)
+            res = await bridgeApiCall({
+                url: `${url}call/1`,
+                method: 'POST',
+                body: '',
+            });
+            expect(res.success).toBe(false);
+            res = await bridgeApiCall({
+                url: `${url}call/1`,
+                method: 'POST',
+            });
+            expect(res.success).toBe(false);
+            res = await bridgeApiCall({
+                url: `${url}call/1`,
+                method: 'POST',
+                // @ts-expect-error
+                body: null,
+            });
+            expect(res.success).toBe(false);
+
+            await trezordNode.stop();
+        });
+
+        it('/post protocolMessage validation', async () => {
+            const { trezordNode, url } = await setupTrezordNode();
+
+            let res;
+            // no protocol, legacy way
+            res = await bridgeApiCall({
+                url: `${url}post/1`,
+                method: 'POST',
+                body: GET_FEATURES,
+            });
+            if (!res.success) {
+                throw new Error(res.error + ' ' + res.message);
+            }
+            expect(res.payload).toBe('');
+            // invalid legacy message (not a hex)
+            res = await bridgeApiCall({
+                url: `${url}post/1`,
+                method: 'POST',
+                body: 'not a hex',
+            });
+            expect(res.success).toBe(false);
+
+            // protocol bridge, json response without magic header
+            res = await bridgeApiCall({
+                url: `${url}post/1`,
+                method: 'POST',
+                body: JSON.stringify({ protocol: 'bridge', data: GET_FEATURES }),
+            });
+            if (!res.success) {
+                throw new Error(res.error + ' ' + res.message);
+            }
+            expect(res.payload).toEqual({
+                protocol: 'bridge',
+                data: '',
+            });
+
+            // protocol v1, json response with magic header
+            res = await bridgeApiCall({
+                url: `${url}post/1`,
+                method: 'POST',
+                body: JSON.stringify({ protocol: 'v1', data: '3f2323' + GET_FEATURES }),
+            });
+            if (!res.success) {
+                throw new Error(res.error + ' ' + res.message);
+            }
+            expect(res.payload).toEqual({
+                protocol: 'v1',
+                data: '',
+            });
+
+            // invalid protocol name (protocol v0)
+            res = await bridgeApiCall({
+                url: `${url}post/1`,
+                method: 'POST',
+                body: JSON.stringify({ protocol: 'v0', data: '00' }),
+            });
+            expect(res).toMatchObject({
+                success: false,
+                message: 'Invalid BridgeProtocolMessage protocol',
+            });
+
+            // invalid protocol message (not a hex)
+            res = await bridgeApiCall({
+                url: `${url}post/1`,
+                method: 'POST',
+                body: JSON.stringify({ protocol: 'v1', data: 'not a hex' }),
+            });
+            expect(res).toMatchObject({
+                success: false,
+                message: 'Invalid BridgeProtocolMessage data',
+            });
+
+            // invalid protocol message (malformed json)
+            res = await bridgeApiCall({
+                url: `${url}post/1`,
+                method: 'POST',
+                body: '',
+            });
+            expect(res).toMatchObject({
+                success: false,
+                message: 'Invalid BridgeProtocolMessage body',
+            });
+            res = await bridgeApiCall({
+                url: `${url}post/1`,
+                method: 'POST',
+            });
+            expect(res).toMatchObject({
+                success: false,
+                message: 'Invalid BridgeProtocolMessage body',
+            });
+            res = await bridgeApiCall({
+                url: `${url}post/1`,
+                method: 'POST',
+                // @ts-expect-error
+                body: null,
+            });
+            expect(res).toMatchObject({
+                success: false,
+                message: 'Invalid BridgeProtocolMessage body',
+            });
+
+            await trezordNode.stop();
+        });
+
+        it('/read protocolMessage validation', async () => {
+            const { trezordNode, url } = await setupTrezordNode();
+
+            let res;
+            // no protocol, legacy way
+            res = await bridgeApiCall({
+                url: `${url}read/1`,
+                method: 'POST',
+            });
+            if (!res.success) {
+                throw new Error(res.error + ' ' + res.message);
+            }
+            expect(res.payload).toBe(FEATURES);
+
+            // protocol bridge, json response without magic header
+            res = await bridgeApiCall({
+                url: `${url}read/1`,
+                method: 'POST',
+                body: JSON.stringify({ protocol: 'bridge' }),
+            });
+            if (!res.success) {
+                throw new Error(res.error + ' ' + res.message);
+            }
+            expect(res.payload).toEqual({
+                protocol: 'bridge',
+                data: FEATURES,
+            });
+
+            // protocol v1, json response with magic header
+            res = await bridgeApiCall({
+                url: `${url}read/1`,
+                method: 'POST',
+                body: JSON.stringify({ protocol: 'v1' }),
+            });
+            if (!res.success) {
+                throw new Error(res.error + ' ' + res.message);
+            }
+            expect(res.payload).toEqual({
+                protocol: 'v1',
+                data: '3f2323' + FEATURES,
+            });
+
+            // invalid protocol name (protocol v0)
+            res = await bridgeApiCall({
+                url: `${url}read/1`,
+                method: 'POST',
+                body: JSON.stringify({ protocol: 'v0' }),
+            });
+            expect(res.success).toBe(false);
+
+            await trezordNode.stop();
+        });
+    });
+
     describe('endpoints', () => {
         ['GET /', 'GET /status'].forEach(endpoint => {
             it(endpoint, async () => {
@@ -158,7 +461,10 @@ describe('http', () => {
             if (!response.success) {
                 throw new Error(response.error);
             }
-            expect(response.payload).toEqual({ version: trezordNode.version });
+            expect(response.payload).toEqual({
+                version: trezordNode.version,
+                protocolMessages: true,
+            });
             await trezordNode.stop();
         });
 

--- a/packages/transport/src/types/apiCall.ts
+++ b/packages/transport/src/types/apiCall.ts
@@ -1,4 +1,4 @@
-import type { PROTOCOL_MALFORMED } from '@trezor/protocol';
+import type { PROTOCOL_MALFORMED, TransportProtocol } from '@trezor/protocol';
 
 import * as ERRORS from '../errors';
 
@@ -31,4 +31,9 @@ export type AsyncResultWithTypedError<T, E> = Promise<Success<T> | ErrorGeneric<
 export type AbortableCall<T, E> = {
     promise: AsyncResultWithTypedError<T, E>;
     abort: () => void;
+};
+
+export type BridgeProtocolMessage = {
+    data: string;
+    protocol?: TransportProtocol['name'];
 };

--- a/packages/transport/src/utils/bridgeApiResult.ts
+++ b/packages/transport/src/utils/bridgeApiResult.ts
@@ -3,6 +3,7 @@
 import type { Descriptor, Session } from '../types';
 
 import { success, error } from './result';
+import { validateProtocolMessage } from './bridgeProtocolMessage';
 import * as ERRORS from '../errors';
 
 type UnknownPayload = string | Record<string, unknown>;
@@ -20,8 +21,9 @@ export function info(res: UnknownPayload) {
         return error({ error: ERRORS.WRONG_RESULT_TYPE });
     }
     const configured = !!res.configured;
+    const protocolMessages = !!res.protocolMessages;
 
-    return success({ version, configured });
+    return success({ version, configured, protocolMessages });
 }
 
 export function version(res: UnknownPayload) {
@@ -79,11 +81,19 @@ export function acquire(res: UnknownPayload) {
 }
 
 export function call(res: UnknownPayload) {
-    if (!isString(res)) {
+    try {
+        return success(validateProtocolMessage(res, true));
+    } catch (e) {
         return error({ error: ERRORS.WRONG_RESULT_TYPE });
     }
+}
 
-    return success(res);
+export function post(res: UnknownPayload) {
+    try {
+        return success(validateProtocolMessage(res, false));
+    } catch (e) {
+        return error({ error: ERRORS.WRONG_RESULT_TYPE });
+    }
 }
 
 export function empty(res: UnknownPayload) {

--- a/packages/transport/src/utils/bridgeProtocolMessage.ts
+++ b/packages/transport/src/utils/bridgeProtocolMessage.ts
@@ -1,0 +1,77 @@
+import type { TransportProtocol } from '@trezor/protocol';
+import type { BridgeProtocolMessage } from '../types';
+
+// validate expected body:
+// - string with hex (legacy bridge /call and /read results)
+// - empty string (legacy bridge /write result, withMessage == false)
+// - json string (protocol message)
+// - parsed json string (parsed protocol message)
+export function validateProtocolMessage(body: unknown, withData = true): BridgeProtocolMessage {
+    const isHex = (s: string) => /^[0-9A-Fa-f]+$/g.test(s); // TODO: trezor/utils accepts 0x prefix (eth)
+    const isValidProtocol = (s: any): s is BridgeProtocolMessage['protocol'] =>
+        s === 'v1' || s === 'bridge';
+
+    // Legacy bridge results
+    if (typeof body === 'string') {
+        if ((withData && isHex(body)) || (!withData && !body.length)) {
+            return {
+                data: body,
+            };
+        }
+    }
+
+    let json: Record<string, any> | undefined | null;
+    if (typeof body === 'object') {
+        json = body;
+    } else {
+        try {
+            json = JSON.parse(body as any);
+        } catch {
+            // silent, resolved below
+        }
+    }
+
+    if (!json) {
+        throw new Error('Invalid BridgeProtocolMessage body');
+    }
+
+    // validate BridgeProtocolMessage['protocol']
+    if (typeof json.protocol !== 'string' || !isValidProtocol(json.protocol)) {
+        throw new Error('Invalid BridgeProtocolMessage protocol');
+    }
+    // optionally validate BridgeProtocolMessage['data]
+    if (withData && (typeof json.data !== 'string' || !isHex(json.data))) {
+        throw new Error('Invalid BridgeProtocolMessage data');
+    }
+
+    return {
+        protocol: json.protocol,
+        data: json.data,
+    };
+}
+
+export function createProtocolMessage(
+    body: unknown,
+    protocol?: TransportProtocol | TransportProtocol['name'],
+) {
+    let data;
+    if (Buffer.isBuffer(body)) {
+        data = body.toString('hex');
+    }
+    if (typeof body === 'string') {
+        data = body;
+    }
+    if (typeof data !== 'string') {
+        data = '';
+    }
+
+    // Legacy bridge message
+    if (!protocol) {
+        return data;
+    }
+
+    return JSON.stringify({
+        protocol: typeof protocol === 'string' ? protocol : protocol.name,
+        data,
+    });
+}

--- a/packages/transport/tests/bridgeProtocolMessage.test.ts
+++ b/packages/transport/tests/bridgeProtocolMessage.test.ts
@@ -1,0 +1,67 @@
+import { BridgeProtocolMessage } from '../src/types';
+import { validateProtocolMessage } from '../src/utils/bridgeProtocolMessage';
+
+type Fixture = {
+    description: string;
+    params: Parameters<typeof validateProtocolMessage>;
+} & ({ result: BridgeProtocolMessage } | { throws: string });
+
+const fixtures: Fixture[] = [
+    {
+        description: 'valid hex, with data=true',
+        params: ['09AF', true],
+        result: { data: '09AF' },
+    },
+    {
+        description: 'empty body with data=true',
+        params: ['', true],
+        throws: 'Invalid BridgeProtocolMessage body',
+    },
+    {
+        description: 'empty body with data=false',
+        params: ['', false],
+        result: { data: '' },
+    },
+    {
+        description: 'parsable and valid protocol message as a string',
+        params: ['{"protocol":"v1","data":"123"}'],
+        result: { protocol: 'v1', data: '123' },
+    },
+    {
+        description: 'parsable and invalid protocol message as a string',
+        params: ['{"protocol":"v1","data":123}'],
+        throws: 'Invalid BridgeProtocolMessage data',
+    },
+    {
+        description: 'parsable but with invalid protocol',
+        params: ['{"protocol":"foo-bar","data":"123"}'],
+        throws: 'Invalid BridgeProtocolMessage protocol',
+    },
+    {
+        description: 'not-parsable protocol message as a string',
+        params: ['{}}{{"protocol":"v1","data":""}'],
+        throws: 'Invalid BridgeProtocolMessage body',
+    },
+    {
+        description: 'object with valid protocol message',
+        params: [{ protocol: 'v1', data: '123' }],
+        result: { protocol: 'v1', data: '123' },
+    },
+    {
+        description: 'object with invalid protocol message',
+        params: [{ protocol: 'foo-bar', data: '123' }],
+        throws: 'Invalid BridgeProtocolMessage protocol',
+    },
+];
+
+describe('bridgeProtocolMessage', () => {
+    fixtures.forEach(f => {
+        it(f.description, () => {
+            if ('throws' in f) {
+                expect(() => validateProtocolMessage(...f.params)).toThrow(f.throws);
+            } else {
+                expect(validateProtocolMessage(...f.params)).toEqual(f.result);
+            }
+        });
+    });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Prerequisite for `THP` (protocol v2)

Goal:
To be able to pass additional data (protocol name + protocol state in the future) in `/call`, `/post` and `/read` requests.
This also simplifies workflow a little. `TrezordNode` doesnt have to translate from protocol-bridge to protocol-v1 (received data) and from protocol-v1 to protocol-bridge (sent data)

format:
```
BridgeProtocolMessage = {
    protocol: 'v1',
    data: '000000',
}
```

- `TrezordNode` 
  - accept and validate JSON body (BridgeProtocolMessage) in `/call`, `/post` and `/read` requests
  - send new flag `protocolMessages` in getInfo `/` request
  - `procolMessages` flag is enabled by default 

- `TransportBridge`
  - if possible (if bridgeInfo.protocolMessage == true) send and receive body as JSON (BridgeProtocolMessage)
  
 - `TrezorConnect`
   - use protocol v1 as default