### PR TITLE
fix: technically a type error for remmebered devices, where authenticityChecks can be undefined

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -147,7 +147,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
     availableTranslations: string[] = [];
 
-    authenticityChecks: KnownDevice['authenticityChecks'] = {
+    authenticityChecks: NonNullable<KnownDevice['authenticityChecks']> = {
         firmwareRevision: null,
     };
 

--- a/packages/connect/src/types/device.ts
+++ b/packages/connect/src/types/device.ts
@@ -62,7 +62,7 @@ export type KnownDevice = {
     features: PROTO.Features;
     unavailableCapabilities: UnavailableCapabilities;
     availableTranslations: string[];
-    authenticityChecks: {
+    authenticityChecks?: {
         firmwareRevision: FirmwareRevisionCheckResult | null;
         // Maybe add FirmwareHashCheck result here?
         // Maybe add AuthenticityCheck result here?

--- a/packages/suite/src/components/suite/Preloader/Preloader.tsx
+++ b/packages/suite/src/components/suite/Preloader/Preloader.tsx
@@ -77,11 +77,16 @@ export const Preloader = ({ children }: PreloaderProps) => {
         selectedDevice.connected === true &&
         !isFirmwareRevisionCheckDisabled
     ) {
-        const failedChecks = Object.values(selectedDevice.authenticityChecks).filter(
-            // If `check` is null, it means that it was not performed yet.
-            // If Suite is offline and we cannot perform check, the error banner shows to urge user to go online.
-            check => check?.success === false && check?.error !== 'cannot-perform-check-offline',
-        );
+        const failedChecks =
+            selectedDevice.authenticityChecks !== undefined
+                ? Object.values(selectedDevice.authenticityChecks).filter(
+                      // If `check` is null, it means that it was not performed yet.
+                      // If Suite is offline and we cannot perform check, the error banner shows to urge user to go online.
+                      check =>
+                          check?.success === false &&
+                          check?.error !== 'cannot-perform-check-offline',
+                  )
+                : [];
 
         if (failedChecks.length > 0) {
             return <DeviceCompromised />;

--- a/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
@@ -12,7 +12,7 @@ export const DeviceCompromised = () => {
     const revision = device?.features?.revision;
     const version = getFirmwareVersion(device);
     const authenticityError =
-        device?.features && device.authenticityChecks.firmwareRevision?.success === false
+        device?.features && device.authenticityChecks?.firmwareRevision?.success === false
             ? device.authenticityChecks.firmwareRevision?.error
             : undefined;
 

--- a/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
@@ -59,6 +59,7 @@ export const SuiteBanners = () => {
     } else if (
         !isFirmwareRevisionCheckDisabled &&
         device?.features &&
+        device?.authenticityChecks !== undefined &&
         device?.authenticityChecks.firmwareRevision !== null && // check was performed
         device?.authenticityChecks.firmwareRevision.success === false &&
         device?.authenticityChecks.firmwareRevision.error === 'cannot-perform-check-offline' // but it was not possible to finish it (user is offline & revision not found locally)


### PR DESCRIPTION
Fix for `authenticityChecks` on device to be optional as remembered wallets don't have it. 

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/13704
