### PR TITLE
Connect Core without global state

### DIFF
--- a/packages/connect/src/core/__tests__/Core.test.ts
+++ b/packages/connect/src/core/__tests__/Core.test.ts
@@ -18,7 +18,7 @@ describe('Core', () => {
         });
 
         const coreManager = initCoreState();
-        await expect(() => coreManager.getOrInit(getSettings(), jest.fn())).rejects.toThrow(
+        await expect(coreManager.getOrInit(getSettings(), jest.fn())).rejects.toThrow(
             'DataManager init error',
         );
 
@@ -48,13 +48,13 @@ describe('Core', () => {
     it('successful getOrInit', async () => {
         const coreManager = initCoreState();
         const eventsSpy = jest.fn();
-        const core = await coreManager.getOrInit(getSettings(), eventsSpy);
+        await coreManager.getOrInit(getSettings(), eventsSpy);
         // no events emitted before initialization
         expect(eventsSpy).toHaveBeenCalledTimes(0);
         await new Promise(resolve => setTimeout(resolve, 1));
         // device + transport events emitted in next tick
         expect(eventsSpy).toHaveBeenCalledTimes(4);
 
-        core.dispose();
+        coreManager.dispose();
     });
 });

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -44,7 +44,6 @@ let _core: Core; // Class with event emitter
 let _deviceList: IDeviceList; // Instance of DeviceList
 const _callMethods: AbstractMethod<any>[] = []; // generic type is irrelevant. only common functions are called at this level
 let _interactionTimeout: InteractionTimeout;
-let _deviceListInitReject: ((e: Error) => void) | undefined;
 let _overridePromise: Promise<void> | undefined;
 
 const methodSynchronize = getSynchronize();
@@ -1077,7 +1076,6 @@ export class Core extends EventEmitter {
 
     dispose() {
         disposeBackend();
-        _deviceListInitReject?.(new Error('Disposed during initialization'));
         this.removeAllListeners();
         this.abortController.abort();
         _deviceList.dispose();

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -42,7 +42,6 @@ import { onCallFirmwareUpdate } from './onCallFirmwareUpdate';
 // Public variables
 let _overridePromise: Promise<void> | undefined;
 
-const methodSynchronize = getSynchronize();
 let waitForFirstMethod = createDeferred();
 
 // custom log
@@ -456,7 +455,7 @@ const onCall = async (context: CoreContext, message: IFrameCallMessage) => {
         );
     }
 
-    const { uiPromises, deviceList, callMethods, sendCoreMessage } = context;
+    const { uiPromises, deviceList, callMethods, methodSynchronize, sendCoreMessage } = context;
     const responseID = message.id;
     const origin = DataManager.getSettings('origin')!;
     const env = DataManager.getSettings('env')!;
@@ -1002,6 +1001,7 @@ export class Core extends EventEmitter {
     private abortController = new AbortController();
     private callMethods: AbstractMethod<any>[] = []; // generic type is irrelevant. only common functions are called at this level
     private popupPromise = createPopupPromiseManager();
+    private methodSynchronize = getSynchronize();
     private uiPromises = createUiPromiseManager(() =>
         startInteractionTimeout(this.getCoreContext()),
     );
@@ -1038,6 +1038,7 @@ export class Core extends EventEmitter {
             interactionTimeout: this.interactionTimeout,
             deviceList: this.deviceList,
             callMethods: this.callMethods,
+            methodSynchronize: this.methodSynchronize,
             sendCoreMessage: this.sendCoreMessage.bind(this),
         };
     }
@@ -1137,7 +1138,7 @@ export class Core extends EventEmitter {
     async getCurrentMethod() {
         await waitForFirstMethod.promise;
 
-        return await methodSynchronize(() => this.callMethods[0]);
+        return await this.methodSynchronize(() => this.callMethods[0]);
     }
 
     getTransportInfo(): TransportInfo | undefined {

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -66,7 +66,6 @@ interface DeviceListEvents {
 
 export interface IDeviceList {
     isConnected(): this is DeviceList;
-    assertConnected(): asserts this is DeviceList;
     pendingConnection(): Promise<void> | undefined;
     setTransports: DeviceList['setTransports'];
     addAuthPenalty: DeviceList['addAuthPenalty'];
@@ -76,6 +75,12 @@ export interface IDeviceList {
     init: DeviceList['init'];
     dispose: DeviceList['dispose'];
 }
+
+export const assertDeviceListConnected: (
+    deviceList: IDeviceList,
+) => asserts deviceList is DeviceList = deviceList => {
+    if (!deviceList.isConnected()) throw ERRORS.TypedError('Transport_Missing');
+};
 
 type ConstructorParams = Pick<ConnectSettings, 'priority' | 'debug'> & {
     messages: Record<string, any>;
@@ -103,10 +108,6 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
 
     isConnected(): this is DeviceList {
         return !!this.transport;
-    }
-
-    assertConnected(): asserts this is DeviceList {
-        if (!this.transport) throw ERRORS.TypedError('Transport_Missing');
     }
 
     pendingConnection() {


### PR DESCRIPTION
Occasionally, unit/e2e tests were failing because of global state shared between two tests.

This PR moved top-level global variables from `connect/core/index` file one by one into `Core` class and propagates them through the functions as `CoreContext`. Therefore, two Core instances shouldn't interfere any more (at least on Connect level, on device/transport levels it's a whole different story).

Seems to be working, but still **must be carefully tested as some behavior could've (wrongfully) been dependent on the shared state**.