### PR TITLE
feat(suite): account type badges

### DIFF
--- a/packages/components/src/components/Badge/Badge.tsx
+++ b/packages/components/src/components/Badge/Badge.tsx
@@ -11,7 +11,7 @@ import { TransientProps } from '../../utils/transientProps';
 export const allowedBadgeFrameProps: FramePropsKeys[] = ['margin'];
 type AllowedFrameProps = Pick<FrameProps, (typeof allowedBadgeFrameProps)[number]>;
 
-type BadgeSize = Extract<UISize, 'tiny' | 'small' | 'medium'>;
+export type BadgeSize = Extract<UISize, 'tiny' | 'small' | 'medium'>;
 type BadgeVariant = Extract<UIVariant, 'primary' | 'tertiary' | 'destructive'>;
 
 export type BadgeProps = AllowedFrameProps & {

--- a/packages/components/src/components/form/BottomText.tsx
+++ b/packages/components/src/components/form/BottomText.tsx
@@ -1,8 +1,5 @@
-import styled, { keyframes, useTheme } from 'styled-components';
-import { CSSColor, Color, spacingsPx, typography } from '@trezor/theme';
-import { Icon } from '@suite-common/icons/src/webComponents';
-import { IconName } from '@suite-common/icons';
-
+import styled, { keyframes } from 'styled-components';
+import { spacingsPx, typography } from '@trezor/theme';
 import { getInputStateTextColor } from './InputStyles';
 import { ReactNode } from 'react';
 import { InputState } from './inputTypes';
@@ -35,26 +32,19 @@ export const Container = styled.div<{ $inputState?: InputState; $isDisabled?: bo
 interface BottomTextProps {
     inputState?: InputState;
     isDisabled?: boolean;
-    icon?: IconName;
+    iconComponent?: ReactNode;
     children: ReactNode;
 }
 
 export const BottomText = ({
     inputState,
     isDisabled,
-    icon = 'warningCircle',
+    iconComponent,
     children,
 }: BottomTextProps) => {
-    const theme = useTheme();
-
-    const iconColor: Color | CSSColor = isDisabled
-        ? 'iconDisabled'
-        : getInputStateTextColor(inputState, theme);
-
     return (
         <Container $inputState={inputState} $isDisabled={isDisabled}>
-            {icon && <Icon name={icon} size="medium" color={iconColor} />}
-
+            {iconComponent}
             {children}
         </Container>
     );

--- a/packages/components/src/components/form/Input/Input.tsx
+++ b/packages/components/src/components/form/Input/Input.tsx
@@ -16,7 +16,6 @@ import { InputState, InputSize } from '../inputTypes';
 import { TopAddons } from '../TopAddons';
 import { useElevation } from '../../ElevationContext/ElevationContext';
 import { UIHorizontalAlignment } from '../../../config/types';
-import { IconName } from '@suite-common/icons';
 
 const Wrapper = styled.div<{ $width?: number; $hasBottomPadding: boolean }>`
     display: inline-flex;
@@ -91,7 +90,7 @@ export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 
      * @description pass `null` if bottom text can be `undefined`
      */
     bottomText?: ReactNode;
-    bottomTextIcon?: IconName;
+    bottomTextIconComponent?: ReactNode;
     isDisabled?: boolean;
     size?: InputSize;
     className?: string;
@@ -115,9 +114,9 @@ const Input = ({
     labelRight,
     labelHoverRight,
     innerAddon,
+    bottomTextIconComponent,
     innerAddonAlign = 'right',
     bottomText,
-    bottomTextIcon,
     size = 'large',
     isDisabled,
     'data-testid': dataTest,
@@ -206,7 +205,11 @@ const Input = ({
             </InputWrapper>
 
             {bottomText && (
-                <BottomText inputState={inputState} isDisabled={isDisabled} icon={bottomTextIcon}>
+                <BottomText
+                    inputState={inputState}
+                    isDisabled={isDisabled}
+                    iconComponent={bottomTextIconComponent}
+                >
                     {bottomText}
                 </BottomText>
             )}

--- a/packages/suite/src/components/suite/AccountLabel.tsx
+++ b/packages/suite/src/components/suite/AccountLabel.tsx
@@ -1,9 +1,11 @@
 import styled from 'styled-components';
 import { getTitleForNetwork, getTitleForCoinjoinAccount } from '@suite-common/wallet-utils';
-import { Account } from 'src/types/wallet';
-import { TOOLTIP_DELAY_LONG, TruncateWithTooltip } from '@trezor/components';
+import { BadgeSize, Row, TOOLTIP_DELAY_LONG, TruncateWithTooltip } from '@trezor/components';
 import { useCallback } from 'react';
 import { useTranslation } from '../../hooks/suite';
+import { spacings } from '@trezor/theme';
+import { AccountSymbol, AccountType } from '@suite-common/wallet-types';
+import { AccountTypeBadge } from './AccountTypeBadge';
 
 const TabularNums = styled.span`
     font-variant-numeric: tabular-nums;
@@ -13,9 +15,11 @@ const TabularNums = styled.span`
 
 export interface AccountLabelProps {
     accountLabel?: string;
-    accountType: Account['accountType'];
-    symbol: Account['symbol'];
+    accountType: AccountType;
+    symbol: AccountSymbol;
     index?: number;
+    showAccountTypeBadge?: boolean;
+    accountTypeBadgeSize?: BadgeSize;
 }
 
 export const useAccountLabel = () => {
@@ -27,8 +31,8 @@ export const useAccountLabel = () => {
             symbol,
             index = 0,
         }: {
-            accountType: Account['accountType'];
-            symbol: Account['symbol'];
+            accountType: AccountType;
+            symbol: AccountSymbol;
             index?: number;
         }) => {
             if (accountType === 'coinjoin') {
@@ -37,7 +41,7 @@ export const useAccountLabel = () => {
 
             return translationString('LABELING_ACCOUNT', {
                 networkName: translationString(getTitleForNetwork(symbol)), // Bitcoin, Ethereum, ...
-                index: index + 1, // this is the number which shows after hash, e.g. Ethereum #3
+                index: index + 1, // This is the number which shows after hash, e.g. Ethereum #3
             });
         },
         [translationString],
@@ -50,7 +54,9 @@ export const useAccountLabel = () => {
 
 export const AccountLabel = ({
     accountLabel,
-    accountType,
+    accountType = 'normal',
+    showAccountTypeBadge,
+    accountTypeBadgeSize = 'medium',
     symbol,
     index = 0,
 }: AccountLabelProps) => {
@@ -59,14 +65,24 @@ export const AccountLabel = ({
     if (accountLabel) {
         return (
             <TruncateWithTooltip delayShow={TOOLTIP_DELAY_LONG}>
-                <TabularNums>{accountLabel}</TabularNums>
+                <Row gap={spacings.sm}>
+                    <TabularNums>{accountLabel}</TabularNums>
+                    {showAccountTypeBadge && (
+                        <AccountTypeBadge accountType={accountType} size={accountTypeBadgeSize} />
+                    )}
+                </Row>
             </TruncateWithTooltip>
         );
     }
 
     return (
         <TruncateWithTooltip delayShow={TOOLTIP_DELAY_LONG}>
-            {defaultAccountLabelString({ accountType, symbol, index })}
+            <Row gap={spacings.sm}>
+                {defaultAccountLabelString({ accountType, symbol, index })}
+                {showAccountTypeBadge && (
+                    <AccountTypeBadge accountType={accountType} size={accountTypeBadgeSize} />
+                )}
+            </Row>
         </TruncateWithTooltip>
     );
 };

--- a/packages/suite/src/components/suite/AccountTypeBadge.tsx
+++ b/packages/suite/src/components/suite/AccountTypeBadge.tsx
@@ -1,0 +1,23 @@
+import { AccountType, UppercaseAccountType } from '@suite-common/wallet-types';
+import { toUppercaseType } from '@suite-common/suite-utils';
+import { Badge, BadgeSize } from '@trezor/components';
+import { Translation } from './Translation';
+
+type AccountTypeBadgeProps = {
+    accountType?: AccountType;
+    size?: BadgeSize;
+};
+
+export const AccountTypeBadge = ({ accountType, size = 'medium' }: AccountTypeBadgeProps) => {
+    if (!accountType || accountType === 'normal') {
+        return null;
+    }
+
+    const accountTypeUppercase: UppercaseAccountType = toUppercaseType(accountType);
+
+    return (
+        <Badge size={size}>
+            <Translation id={`TR_ACCOUNT_TYPE_${accountTypeUppercase}`} />
+        </Badge>
+    );
+};

--- a/packages/suite/src/components/suite/labeling/AccountLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/AccountLabeling.tsx
@@ -8,12 +8,19 @@ import { useSelector } from 'src/hooks/suite';
 import { selectLabelingDataForAccount } from 'src/reducers/suite/metadataReducer';
 
 import { WalletLabeling } from './WalletLabeling';
+import { BadgeProps } from '@trezor/components';
 
 interface AccountProps {
     account: WalletAccount | WalletAccount[];
+    accountTypeBadgeSize?: BadgeProps['size'];
+    showAccountTypeBadge?: boolean;
 }
 
-export const AccountLabeling = ({ account }: AccountProps) => {
+export const AccountLabeling = ({
+    account,
+    accountTypeBadgeSize,
+    showAccountTypeBadge,
+}: AccountProps) => {
     const device = useSelector(selectDevice);
     const devices = useSelector(selectDevices);
 
@@ -30,6 +37,8 @@ export const AccountLabeling = ({ account }: AccountProps) => {
             accountType={accountType}
             symbol={symbol}
             index={index}
+            showAccountTypeBadge={showAccountTypeBadge}
+            accountTypeBadgeSize={accountTypeBadgeSize}
         />
     );
 
@@ -42,7 +51,7 @@ export const AccountLabeling = ({ account }: AccountProps) => {
                     <WalletLabeling
                         device={accountDevice}
                         shouldUseDeviceLabel={!isSelectedDevice(device, accountDevice)}
-                    />{' '}
+                    />
                     {accountLabel}
                 </span>
             );

--- a/packages/suite/src/components/suite/labeling/AddressLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/AddressLabeling.tsx
@@ -3,11 +3,11 @@ import { useSelector } from 'src/hooks/suite';
 import { AccountLabeling } from './AccountLabeling';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 
-interface AddressLabelingProps {
+type AddressLabelingProps = {
     networkSymbol: NetworkSymbol;
     address?: string | null;
     knownOnly?: boolean;
-}
+};
 
 export const AddressLabeling = ({ networkSymbol, address, knownOnly }: AddressLabelingProps) => {
     const accounts = useSelector(state => state.wallet.accounts);
@@ -22,5 +22,11 @@ export const AddressLabeling = ({ networkSymbol, address, knownOnly }: AddressLa
         return !knownOnly ? <span>{address}</span> : null;
     }
 
-    return <AccountLabeling account={relevantAccounts[0]} />;
+    return (
+        <AccountLabeling
+            account={relevantAccounts[0]}
+            accountTypeBadgeSize="small"
+            showAccountTypeBadge
+        />
+    );
 };

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useMemo, useRef } from 'react';
 import styled from 'styled-components';
 
-import { Button, DropdownMenuItemProps } from '@trezor/components';
+import { Button, DropdownMenuItemProps, Row } from '@trezor/components';
 import { useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
 import { addMetadata, init, setEditing } from 'src/actions/suite/metadataLabelingActions';
 import { MetadataAddPayload } from 'src/types/suite/metadata';
@@ -14,6 +14,7 @@ import {
     selectIsLabelingInitPossible,
 } from 'src/reducers/suite/metadataReducer';
 import type { Timeout } from '@trezor/type-utils';
+import { AccountTypeBadge } from '../../AccountTypeBadge';
 
 const LabelValue = styled.div`
     overflow: hidden;
@@ -158,6 +159,7 @@ const ButtonLikeLabel = ({
 };
 
 const TextLikeLabel = ({
+    accountType,
     editActive,
     defaultVisibleValue,
     defaultEditableValue,
@@ -169,22 +171,30 @@ const TextLikeLabel = ({
 }: ExtendedProps) => {
     const EditableLabel = useMemo(() => withEditable(RelativeLabel), []);
 
+    const isAccountLabel = payload.type === 'accountLabel';
+
     if (editActive) {
         return (
-            <EditableLabel
-                data-testid={dataTest}
-                originalValue={payload.value ?? defaultEditableValue}
-                onSubmit={onSubmit}
-                onBlur={onBlur}
-                updateFlag={updateFlag}
-            />
+            <Row gap={12}>
+                <EditableLabel
+                    data-testid={dataTest}
+                    originalValue={payload.value ?? defaultEditableValue}
+                    onSubmit={onSubmit}
+                    onBlur={onBlur}
+                    updateFlag={updateFlag}
+                />
+                {isAccountLabel && <AccountTypeBadge accountType={accountType} />}
+            </Row>
         );
     }
 
     if (payload.value) {
         return (
             <Label data-testid={dataTest}>
-                <LabelValue>{payload.value}</LabelValue>
+                <Row gap={12}>
+                    <LabelValue>{payload.value}</LabelValue>
+                    {isAccountLabel && <AccountTypeBadge accountType={accountType} />}
+                </Row>
             </Label>
         );
     }
@@ -240,6 +250,7 @@ const getLocalizedActions = (type: MetadataAddPayload['type']) => {
  */
 export const MetadataLabeling = ({
     payload,
+    accountType,
     dropdownOptions,
     defaultEditableValue,
     defaultVisibleValue,
@@ -279,18 +290,18 @@ export const MetadataLabeling = ({
     const editActive = metadata.editing === payload.defaultValue;
 
     const activateEdit = () => {
-        // when clicking on inline input edit, ensure that everything needed is already ready
+        // When clicking on inline input edit, ensure that everything needed is already ready.
         if (
-            // isn't initiation in progress?
+            // Isn't initiation in progress?
             !metadata.initiating &&
-            // is there something that needs to be initiated?
+            // Is there something that needs to be initiated?
             !isLabelingAvailable
         ) {
             dispatch(
                 init(
-                    // provide force=true argument (user wants to enable metadata)
+                    // Provide force=true argument (user wants to enable metadata).
                     true,
-                    // if this is wallet(device) label, provide unique identifier entityKey which equals to device.state
+                    // If this is wallet(device) label, provide unique identifier entityKey which equals to device.state.
                     deviceState,
                 ),
             );
@@ -302,7 +313,7 @@ export const MetadataLabeling = ({
         {
             onClick: () => activateEdit(),
             label: l10nLabelling.edit,
-            'data-testid': `edit-label`, // hack: This will be prefixed in the withDropdown()
+            'data-testid': `edit-label`, // Hack: This will be prefixed in the withDropdown()
         },
     ];
 
@@ -326,7 +337,7 @@ export const MetadataLabeling = ({
             }),
         );
         // payload.defaultValue might change during next render, this comparison
-        // ensures that success state does not appear if it is no longer relevant
+        // ensures that success state does not appear if it is no longer relevant.
         if (isSubscribedToSubmitResult.current === payload.defaultValue) {
             setPending(false);
             if (result) {
@@ -348,7 +359,7 @@ export const MetadataLabeling = ({
 
     const labelContainerDataTest = `${dataTestBase}/hover-container`;
 
-    // should "add label"/"edit label" button be visible
+    // Should "add label"/"edit label" button be visible?
     const showActionButton =
         !isDisabled &&
         (isLabelingAvailable || isLabelingInitPossible) &&
@@ -356,7 +367,7 @@ export const MetadataLabeling = ({
         !editActive;
     const isVisible = pending || visible;
 
-    // metadata is still initiating, on hover, show only disabled button with spinner
+    // Metadata is still initiating, on hover, show only disabled button with spinner.
     if (metadata.initiating)
         return (
             <LabelContainer data-testid={labelContainerDataTest}>
@@ -403,9 +414,9 @@ export const MetadataLabeling = ({
                             $isValueVisible={!!payload.value}
                             onClick={e => {
                                 e.stopPropagation();
-                                // by clicking on add label button, metadata.editing field is set
+                                // By clicking on add label button, metadata.editing field is set
                                 // to default value of whatever may be labeled (address, etc..)
-                                // this way we ensure that only one field may be active at time
+                                // this way we ensure that only one field may be active at time.
                                 activateEdit();
                             }}
                         >
@@ -417,6 +428,7 @@ export const MetadataLabeling = ({
                 <>
                     <TextLikeLabel
                         editActive={editActive}
+                        accountType={accountType}
                         onSubmit={onSubmit || defaultOnSubmit}
                         onBlur={handleBlur}
                         data-testid={dataTestBase}

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/definitions.ts
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/definitions.ts
@@ -1,8 +1,10 @@
 import { ReactNode } from 'react';
 import { DropdownMenuItemProps } from '@trezor/components';
 import { MetadataAddPayload } from 'src/types/suite/metadata';
+import { AccountType } from '@suite-common/wallet-types';
 
 export interface Props {
+    accountType?: AccountType;
     defaultVisibleValue?: ReactNode;
     defaultEditableValue?: string;
     payload: MetadataAddPayload;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountDetails.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountDetails.tsx
@@ -99,8 +99,10 @@ export const AccountDetails = ({ selectedAccount, isBalanceShown }: AccountDetai
         <DetailsContainer $isBalanceShown={isBalanceShown} $shouldAnimate={shouldAnimate}>
             <AccountHeading $isBalanceShown={isBalanceShown}>
                 <MetadataLabeling
+                    accountType={accountType}
                     defaultVisibleValue={
                         <AccountLabel
+                            showAccountTypeBadge
                             accountLabel={selectedAccountLabels.accountLabel}
                             accountType={accountType}
                             symbol={selectedAccount.symbol}

--- a/packages/suite/src/components/wallet/Fees/CustomFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/CustomFee.tsx
@@ -1,5 +1,5 @@
 import { BigNumber } from '@trezor/utils/src/bigNumber';
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 import {
     Control,
     FieldErrors,
@@ -24,6 +24,8 @@ import { BottomText } from '@trezor/components/src/components/form/BottomText';
 import { spacings, spacingsPx } from '@trezor/theme';
 import { HELP_CENTER_TRANSACTION_FEES_URL } from '@trezor/urls';
 import { LearnMoreButton } from 'src/components/suite/LearnMoreButton';
+import { Icon } from '@suite-common/icons/src/webComponents';
+import { getInputStateTextColor } from '@trezor/components';
 
 const Wrapper = styled.div`
     display: flex;
@@ -69,6 +71,7 @@ export const CustomFee = <TFieldValues extends FormState>({
     ...props
 }: CustomFeeProps<TFieldValues>) => {
     const { translationString } = useTranslation();
+    const theme = useTheme();
 
     // Type assertion allowing to make the component reusable, see https://stackoverflow.com/a/73624072.
     const { getValues, setValue } = props as unknown as UseFormReturn<FormState>;
@@ -105,7 +108,7 @@ export const CustomFee = <TFieldValues extends FormState>({
 
     const sharedRules = {
         required: translationString('CUSTOM_FEE_IS_NOT_SET'),
-        // allow decimals in ETH since GWEI is not a satoshi
+        // Allow decimals in ETH since GWEI is not a satoshi.
         validate: (value: string) => {
             if (['bitcoin', 'ethereum'].includes(networkType) && !isInteger(value)) {
                 return translationString('CUSTOM_FEE_IS_NOT_INTEGER');
@@ -132,7 +135,7 @@ export const CustomFee = <TFieldValues extends FormState>({
                 decimals: 2,
                 except: networkType !== 'bitcoin',
             }),
-            // GWEI: 9 decimal places
+            // GWEI: 9 decimal places.
             ethereumDecimalsLimit: validateDecimals(translationString, {
                 decimals: 9,
                 except: networkType !== 'ethereum',
@@ -205,7 +208,16 @@ export const CustomFee = <TFieldValues extends FormState>({
             </Wrapper>
             {useFeeLimit && feeLimitError?.message ? (
                 <div style={{ marginTop: '-1.5rem' }}>
-                    <BottomText inputState="error">
+                    <BottomText
+                        inputState="error"
+                        iconComponent={
+                            <Icon
+                                name="warningCircle"
+                                size="medium"
+                                color={getInputStateTextColor('error', theme)}
+                            />
+                        }
+                    >
                         <InputError
                             message={feeLimitError?.message}
                             button={validationButtonProps}

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2682,6 +2682,41 @@ export default defineMessages({
         defaultMessage: 'Ledger accounts',
         id: 'TR_CARDANO_LEDGER_ACCOUNTS',
     },
+    TR_ACCOUNT_TYPE_LEGACY: {
+        defaultMessage: 'Legacy',
+        id: 'TR_ACCOUNT_TYPE_LEGACY',
+        dynamic: true,
+    },
+    TR_ACCOUNT_TYPE_TAPROOT: {
+        defaultMessage: 'Taproot',
+        id: 'TR_ACCOUNT_TYPE_TAPROOT',
+        dynamic: true,
+    },
+    TR_ACCOUNT_TYPE_COINJOIN: {
+        defaultMessage: 'Coinjoin',
+        id: 'TR_ACCOUNT_TYPE_COINJOIN',
+        dynamic: true,
+    },
+    TR_ACCOUNT_TYPE_LEDGER: {
+        defaultMessage: 'Ledger',
+        id: 'TR_ACCOUNT_TYPE_LEDGER',
+        dynamic: true,
+    },
+    TR_ACCOUNT_TYPE_IMPORTED: {
+        defaultMessage: 'Imported',
+        id: 'TR_ACCOUNT_TYPE_IMPORTED',
+        dynamic: true,
+    },
+    TR_ACCOUNT_TYPE_NORMAL: {
+        defaultMessage: 'Normal',
+        id: 'TR_ACCOUNT_TYPE_NORMAL',
+        dynamic: true,
+    },
+    TR_ACCOUNT_TYPE_SEGWIT: {
+        defaultMessage: 'Legacy SegWit',
+        id: 'TR_ACCOUNT_TYPE_SEGWIT',
+        dynamic: true,
+    },
     TR_LOG: {
         defaultMessage: 'Application log',
         description: 'application event and error',

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOfferVerifyOptionsItem.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOfferVerifyOptionsItem.tsx
@@ -36,11 +36,6 @@ const AccountName = styled.div`
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 
-const AccountType = styled.span`
-    color: ${({ theme }) => theme.legacy.TYPE_LIGHT_GREY};
-    padding-left: ${spacingsPx.xxs};
-`;
-
 const CoinmarketSelectedOfferVerifyOptionsItem = ({
     option,
     receiveNetwork,
@@ -63,12 +58,11 @@ const CoinmarketSelectedOfferVerifyOptionsItem = ({
                 <AccountWrapper>
                     <Column alignItems="flex-start">
                         <AccountName>
-                            <AccountLabeling account={option.account} />
-                            <AccountType>
-                                {option.account.accountType !== 'normal'
-                                    ? option.account.accountType
-                                    : ''}
-                            </AccountType>
+                            <AccountLabeling
+                                account={option.account}
+                                accountTypeBadgeSize="small"
+                                showAccountTypeBadge
+                            />
                         </AccountName>
                         <Amount>
                             <CryptoWrapper>

--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/SendSwapTransaction/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/SendSwapTransaction/index.tsx
@@ -4,6 +4,7 @@ import { Translation, AccountLabeling, FormattedCryptoAmount } from 'src/compone
 import {
     Button,
     IconLegacy,
+    getInputStateTextColor,
     Input,
     Paragraph,
     SelectBar,
@@ -18,6 +19,7 @@ import { TranslationKey } from '@suite-common/intl-types';
 import { spacingsPx } from '@trezor/theme';
 import { useCoinmarketOffersContext } from 'src/hooks/wallet/coinmarket/offers/useCoinmarketCommonOffers';
 import { CoinmarketTradeExchangeType } from 'src/types/coinmarket/coinmarket';
+import { Icon } from '@suite-common/icons/src/webComponents';
 
 const Wrapper = styled.div`
     display: flex;
@@ -313,7 +315,16 @@ const SendSwapTransactionComponent = () => {
                         )}
                     </PaddedColumns>
                     {customSlippageError?.message ? (
-                        <BottomText inputState={customSlippageError && 'error'}>
+                        <BottomText
+                            inputState={customSlippageError && 'error'}
+                            iconComponent={
+                                <Icon
+                                    name="warningCircle"
+                                    size="medium"
+                                    color={getInputStateTextColor('error', theme)}
+                                />
+                            }
+                        >
                             <Translation id={customSlippageError?.message} />
                         </BottomText>
                     ) : null}

--- a/packages/suite/src/views/wallet/coinmarket/exchange_new/offers/Offers/SelectedOffer/components/SendSwapTransaction/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange_new/offers/Offers/SelectedOffer/components/SendSwapTransaction/index.tsx
@@ -18,6 +18,8 @@ import { TranslationKey } from '@suite-common/intl-types';
 import { spacingsPx } from '@trezor/theme';
 import { useCoinmarketOffersContext } from 'src/hooks/wallet/coinmarket/offers/useCoinmarketCommonOffers';
 import { CoinmarketTradeExchangeType } from 'src/types/coinmarket/coinmarket';
+import { Icon } from '@suite-common/icons/src/webComponents';
+import { getInputStateTextColor } from '@trezor/components';
 
 const Wrapper = styled.div`
     display: flex;
@@ -313,7 +315,16 @@ const SendSwapTransactionComponent = () => {
                         )}
                     </PaddedColumns>
                     {customSlippageError?.message ? (
-                        <BottomText inputState={customSlippageError && 'error'}>
+                        <BottomText
+                            inputState={customSlippageError && 'error'}
+                            iconComponent={
+                                <Icon
+                                    name="warningCircle"
+                                    size="medium"
+                                    color={getInputStateTextColor('error', theme)}
+                                />
+                            }
+                        >
                             <Translation id={customSlippageError?.message} />
                         </BottomText>
                     ) : null}

--- a/packages/suite/src/views/wallet/send/Outputs/Address.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Address.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useState } from 'react';
 import { checkAddressCheckSum, toChecksumAddress } from 'web3-utils';
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 
-import { Input, Button, IconButton } from '@trezor/components';
+import { Input, Button, IconButton, CoinLogo, getInputStateTextColor } from '@trezor/components';
+import { Icon } from '@suite-common/icons/src/webComponents';
 import { capitalizeFirstLetter } from '@trezor/utils';
 import * as URLS from '@trezor/urls';
 import { notificationsActions } from '@suite-common/toast-notifications';
@@ -33,6 +34,7 @@ import { Row } from '@trezor/components';
 
 import { HELP_CENTER_EVM_ADDRESS_CHECKSUM } from '@trezor/urls';
 import { spacings } from '@trezor/theme';
+
 const Container = styled.div`
     position: relative;
 `;
@@ -77,8 +79,8 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
     const { descriptor, networkType, symbol } = account;
     const inputName = `outputs.${outputId}.address` as const;
     // NOTE: compose errors are always associated with the amount.
-    // if address is not valid then compose process will never be triggered,
-    // however if address is changed compose process may return `AMOUNT_IS_NOT_ENOUGH` which should appear under the amount filed
+    // If address is not valid then compose process will never be triggered,
+    // however if address is changed compose process may return `AMOUNT_IS_NOT_ENOUGH` which should appear under the amount filed.
     const amountInputName = `outputs.${outputId}.amount` as const;
     const outputError = errors.outputs ? errors.outputs[outputId] : undefined;
     const addressError = outputError ? outputError.address : undefined;
@@ -89,6 +91,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
     const options = getDefaultValue('options', []);
     const broadcastEnabled = options.includes('broadcast');
     const isOnline = useSelector(state => state.suite.online);
+    const theme = useTheme();
     const getInputErrorState = () => {
         if (hasAddressChecksummed) {
             return 'primary';
@@ -217,7 +220,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                     return translationString('RECIPIENT_IS_NOT_VALID');
                 }
             },
-            // eth addresses are valid without checksum but Trezor displays them as checksummed
+            // Eth addresses are valid without checksum but Trezor displays them as checksummed.
             checksum: async (address: string) => {
                 if (networkType === 'ethereum' && !checkAddressCheckSum(address)) {
                     if (isOnline) {
@@ -240,8 +243,8 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                                 return;
                             }
 
-                            // 2. If the address is not checksummed at all and not found in blockbook.
-                            // offer to checksum it with a button
+                            // 2. If the address is not checksummed at all and not found in blockbook
+                            // offer to checksum it with a button.
                             if (!hasHistory && address === address.toLowerCase()) {
                                 return translationString('TR_ETH_ADDRESS_NOT_USED_NOT_CHECKSUMMED');
                             }
@@ -259,7 +262,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
         },
     });
 
-    // required for the correct functionality of bottom text in the input
+    // Required for the correct functionality of bottom text in the input.
     const addressLabelComponent = (
         <AddressLabeling address={addressValue} knownOnly networkSymbol={symbol} />
     );
@@ -301,9 +304,23 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
         return addressBottomText;
     };
 
-    const getBottomTextIcon = () => {
+    const getBottomTextIconComponent = () => {
         if (hasAddressChecksummed) {
-            return 'check';
+            return <Icon name="check" size="medium" color="iconDisabled" />;
+        }
+
+        if (isAddressWithLabel) {
+            return <CoinLogo symbol={symbol} size={16} />;
+        }
+
+        if (addressError) {
+            return (
+                <Icon
+                    name="warningCircle"
+                    size="medium"
+                    color={getInputStateTextColor('error', theme)}
+                />
+            );
         }
 
         return undefined;
@@ -322,7 +339,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                                     type: 'outputLabel',
                                     entityKey: account.key,
                                     // txid is not known at this moment. metadata is only saved
-                                    // along with other sendForm data and processed in sendFormActions
+                                    // along with other sendForm data and processed in sendFormActions.
                                     txid: 'will-be-replaced',
                                     outputIndex: outputId,
                                     defaultValue: `${outputId}`,
@@ -375,7 +392,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                     ) : undefined
                 }
                 bottomText={getBottomText()}
-                bottomTextIcon={getBottomTextIcon()}
+                bottomTextIconComponent={getBottomTextIconComponent()}
                 data-testid={inputName}
                 defaultValue={addressValue}
                 maxLength={formInputsMaxLength.address}

--- a/suite-common/suite-utils/src/index.ts
+++ b/suite-common/suite-utils/src/index.ts
@@ -7,4 +7,5 @@ export * from './comparison';
 export * from './txsPerPage';
 export * from './stake';
 export * from './parseFirmwareChangelog';
+export * from './uppercaseType';
 export { hexToRgba } from './hexToRgba';

--- a/suite-common/suite-utils/src/uppercaseType.ts
+++ b/suite-common/suite-utils/src/uppercaseType.ts
@@ -1,0 +1,3 @@
+export function toUppercaseType<T extends string>(value: T): Uppercase<T> {
+    return value.toUpperCase() as Uppercase<T>;
+}

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -646,9 +646,24 @@ export const getTestnetSymbols = () => getTestnets().map(n => n.symbol);
 export const isBlockbookBasedNetwork = (symbol: NetworkSymbol) =>
     networks[symbol]?.customBackends.some(backend => backend === 'blockbook');
 
+export const isDebugOnlyAccountType = (
+    accountType: AccountType,
+    symbol?: NetworkSymbol,
+): boolean => {
+    if (!symbol) return false;
+
+    const network = networks?.[symbol];
+
+    if (!network) return false;
+
+    const accountTypeInfo = (network.accountTypes as Record<AccountType, Network>)[accountType];
+
+    return !!accountTypeInfo?.isDebugOnlyAccountType;
+};
+
 export const getNetworkType = (symbol: NetworkSymbol) => networks[symbol]?.networkType;
 
-// takes into account just network features, not features for specific accountTypes
+// Takes into account just network features, not features for specific accountTypes.
 export const getNetworkFeatures = (symbol: NetworkSymbol) =>
     networks[symbol]?.features as unknown as NetworkFeature;
 

--- a/suite-common/wallet-types/src/account.ts
+++ b/suite-common/wallet-types/src/account.ts
@@ -110,6 +110,9 @@ export type Account = {
     AccountNetworkSpecific;
 
 export type AccountType = Account['accountType'];
+export type AccountSymbol = Account['symbol'];
+
+export type UppercaseAccountType = Uppercase<AccountType>;
 
 export type WalletParams =
     | NonNullable<{


### PR DESCRIPTION
Add account type badges next to account name to non-default accounts 

## Description



## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/13737

## Screenshots:

![image](https://github.com/user-attachments/assets/ebb87817-1efa-4fd1-a28a-b1ebd913a60d)


Scrolled:

![image](https://github.com/user-attachments/assets/972041a5-4c54-47df-a4e4-1de5992b639e)

Sending to self: 

![image](https://github.com/user-attachments/assets/1170acd1-b1ee-4fc5-9b02-41a957218bd6)

Trading: 

![image](https://github.com/user-attachments/assets/066a16b3-1800-4eb2-8e5d-40f10684dce8)



