### PR TITLE
fix(suite-native): remove odd space in device switcher

### DIFF
--- a/suite-native/device-manager/src/components/DeviceManagerModal.tsx
+++ b/suite-native/device-manager/src/components/DeviceManagerModal.tsx
@@ -1,4 +1,4 @@
-import { GestureResponderEvent, Modal, Pressable } from 'react-native';
+import { GestureResponderEvent, Modal, Pressable, StatusBar } from 'react-native';
 import { ReactNode } from 'react';
 import { useSafeAreaInsets, EdgeInsets } from 'react-native-safe-area-context';
 import Animated, { FadeIn, SlideInUp } from 'react-native-reanimated';
@@ -33,7 +33,7 @@ const deviceManagerModalWrapperStyle = prepareNativeStyle(utils => ({
 
 const deviceSwitchWrapperStyle = prepareNativeStyle<{ insets: EdgeInsets }>(
     (utils, { insets }) => ({
-        paddingTop: insets.top + utils.spacings.large,
+        paddingTop: insets.top + (StatusBar.currentHeight ?? 0),
         backgroundColor: utils.colors.backgroundSurfaceElevation1,
         borderBottomLeftRadius: MANAGER_MODAL_BOTTOM_RADIUS,
         borderBottomRightRadius: MANAGER_MODAL_BOTTOM_RADIUS,


### PR DESCRIPTION
remove odd space from top of opened device switcher

## Related Issue

Resolve #[13599](https://github.com/trezor/trezor-suite/issues/13599)

## Screenshots:
<img width="382" src="https://github.com/user-attachments/assets/2691c3af-482e-4e0c-b573-631247f03dfe">
<img width="382" src="https://github.com/user-attachments/assets/302539b2-6e45-4b8c-ada2-47ad7e60feec">
