### PR TITLE
fix(suite): polish copy in exp section

### DIFF
--- a/packages/suite-data/files/translations/en.json
+++ b/packages/suite-data/files/translations/en.json
@@ -948,7 +948,7 @@
   "TR_EXPERIMENTAL_FEATURES": "Experimental",
   "TR_EXPERIMENTAL_FEATURES_ALLOW": "Experimental features",
   "TR_EXPERIMENTAL_FEATURES_DESCRIPTION": "For experienced users only. Use at your own risk.\nSelect which experimental features to enable in Trezor Suite to experience the latest advancements and innovations.",
-  "TR_EXPERIMENTAL_FEATURES_WARNING": "Note, these features are in testing, may be unstable, and might not have long-term support.",
+  "TR_EXPERIMENTAL_FEATURES_WARNING": "For experienced users only. Use at your own risk. These features are in testing, may be unstable, and might not have long-term support.",
   "TR_EXPERIMENTAL_PASSWORD_MANAGER": "Migrate Dropbox passwords",
   "TR_EXPERIMENTAL_PASSWORD_MANAGER_DESCRIPTION": "A utility for retrieving passwords stored on Dropbox and secured by Trezor, designed for former Chrome extension users of Trezor Password Manager.",
   "TR_EXPERIMENTAL_TOR_SNOWFLAKE": "Tor Snowflake",

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5332,12 +5332,7 @@ export default defineMessages({
     TR_EXPERIMENTAL_FEATURES_WARNING: {
         id: 'TR_EXPERIMENTAL_FEATURES_WARNING',
         defaultMessage:
-            'Note, these features are in testing, may be unstable, and might not have long-term support.',
-    },
-    TR_EXPERIMENTAL_FEATURES_DESCRIPTION: {
-        id: 'TR_EXPERIMENTAL_FEATURES_DESCRIPTION',
-        defaultMessage:
-            'For experienced users only. Use at your own risk.\nSelect which experimental features to enable in Trezor Suite to experience the latest advancements and innovations.',
+            'For experienced users only. Use at your own risk. These features are in testing, may be unstable, and might not have long-term support.',
     },
     TR_EXPERIMENTAL_BNB_SMART_CHAIN: {
         id: 'TR_EXPERIMENTAL_BNB_SMART_CHAIN',

--- a/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
@@ -102,15 +102,12 @@ export const Experimental = () => {
                 <TextColumn
                     title={<Translation id="TR_EXPERIMENTAL_FEATURES_ALLOW" />}
                     description={
-                        <>
-                            <Warning>
-                                <Row gap={12}>
-                                    <Icon icon="WARNING" size={14} variant="tertiary" />
-                                    <Translation id="TR_EXPERIMENTAL_FEATURES_WARNING" />
-                                </Row>
-                            </Warning>
-                            <Translation id="TR_EXPERIMENTAL_FEATURES_DESCRIPTION" />
-                        </>
+                        <Warning>
+                            <Row gap={12}>
+                                <Icon icon="WARNING" size={14} variant="tertiary" />
+                                <Translation id="TR_EXPERIMENTAL_FEATURES_WARNING" />
+                            </Row>
+                        </Warning>
                     }
                     buttonLink={EXPERIMENTAL_FEATURES_KB_URL}
                 />


### PR DESCRIPTION
Adjusting copy in Experimental features

Before
![image](https://github.com/user-attachments/assets/a7cbce14-e65b-4dce-b185-5ebe33120224)

After 
![image](https://github.com/user-attachments/assets/ef862733-c901-4794-99bb-a5b87fec2594)
