### PR TITLE
Feat/ledger derivations path evm

### DIFF
--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountGroup.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountGroup.tsx
@@ -40,6 +40,7 @@ const Header = styled.header<{ $isOpen: boolean; onClick?: () => void }>`
     align-items: center;
     ${typography.label}
     color: ${({ theme }) => theme.textSubdued};
+    height: 40px;
 
     &:hover {
         ${ChevronIcon} {

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeForm.ts
@@ -674,7 +674,7 @@ export const useCoinmarketExchangeForm = ({
                 n =>
                     n.symbol === receiveNetwork &&
                     !unavailableCapabilities[n.symbol] &&
-                    ((n.isDebugOnly && isDebug) || !n.isDebugOnly),
+                    ((n.isDebugOnlyNetwork && isDebug) || !n.isDebugOnlyNetwork),
             );
             if (receiveNetworks.length > 0) {
                 // get accounts of the current symbol belonging to the current device

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketVerifyAccount.tsx
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketVerifyAccount.tsx
@@ -73,7 +73,7 @@ const getSuiteReceiveAccounts = ({
             n =>
                 n.symbol === receiveNetwork &&
                 !unavailableCapabilities[n.symbol] &&
-                ((n.isDebugOnly && isDebug) || !n.isDebugOnly),
+                ((n.isDebugOnlyNetwork && isDebug) || !n.isDebugOnlyNetwork),
         );
         if (receiveNetworks.length > 0) {
             // get accounts of the current symbol belonging to the current device

--- a/packages/suite/src/hooks/wallet/coinmarket/offers/useCoinmarketExchangeOffers.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/offers/useCoinmarketExchangeOffers.ts
@@ -154,7 +154,7 @@ export const useCoinmarketExchangeOffers = ({
                 n =>
                     n.symbol === receiveNetwork &&
                     !unavailableCapabilities[n.symbol] &&
-                    ((n.isDebugOnly && isDebug) || !n.isDebugOnly) &&
+                    ((n.isDebugOnlyNetwork && isDebug) || !n.isDebugOnlyNetwork) &&
                     (bnbExperimentalFeature || n.symbol !== 'bnb'),
             );
             if (receiveNetworks.length > 0) {

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -86,10 +86,12 @@ export const networks = {
             ledger: {
                 // ledger (live), #1 acc is same as Trezor, so it is skipped
                 bip43Path: "m/44'/60'/i'/0/0",
+                isDebugOnlyAccountType: true,
             },
             legacy: {
                 // ledger (legacy)
                 bip43Path: "m/44'/60'/0'/i",
+                isDebugOnlyAccountType: true,
             },
         },
         coingeckoId: 'ethereum',
@@ -307,10 +309,12 @@ export const networks = {
             legacy: {
                 // icarus-trezor derivation
                 bip43Path: "m/1852'/1815'/i'",
+                isDebugOnlyAccountType: true,
             },
             ledger: {
                 // ledger derivation
                 bip43Path: "m/1852'/1815'/i'",
+                isDebugOnlyAccountType: true,
             },
         },
         coingeckoId: 'cardano',
@@ -338,6 +342,7 @@ export const networks = {
             ledger: {
                 // bip44Change - Ledger Live
                 bip43Path: "m/44'/501'/i'",
+                isDebugOnlyAccountType: true,
             },
         },
         coingeckoId: 'solana',
@@ -362,6 +367,7 @@ export const networks = {
             ledger: {
                 // ledger (live), #1 acc is same as Trezor, so it is skipped
                 bip43Path: "m/44'/60'/i'/0/0",
+                isDebugOnlyAccountType: true,
             },
         },
         coingeckoId: 'polygon-pos',
@@ -386,6 +392,7 @@ export const networks = {
             ledger: {
                 // ledger (live), #1 acc is same as Trezor, so it is skipped
                 bip43Path: "m/44'/60'/i'/0/0",
+                isDebugOnlyAccountType: true,
             },
         },
         coingeckoId: 'binance-smart-chain',
@@ -455,7 +462,7 @@ export const networks = {
                 bip43Path: "m/44'/1'/i'",
             },
         },
-        isDebugOnly: true,
+        isDebugOnlyNetwork: true,
         coingeckoId: undefined,
     },
     tsep: {
@@ -607,7 +614,8 @@ export type Network = Without<NetworkValue, 'accountTypes'> & {
     support?: {
         [key in DeviceModelInternal]: string;
     };
-    isDebugOnly?: boolean;
+    isDebugOnlyNetwork?: boolean;
+    isDebugOnlyAccountType?: boolean;
     coingeckoId?: string;
 };
 
@@ -631,13 +639,13 @@ export const getMainnets = (debug = false, bnb = false) =>
         n =>
             !n.accountType &&
             !n.testnet &&
-            (!n.isDebugOnly || debug) &&
+            (!n.isDebugOnlyNetwork || debug) &&
             (bnb || n.symbol !== 'bnb'),
     );
 
 export const getTestnets = (debug = false) =>
     networksCompatibility.filter(
-        n => !n.accountType && n.testnet === true && (!n.isDebugOnly || debug),
+        n => !n.accountType && n.testnet === true && (!n.isDebugOnlyNetwork || debug),
     );
 
 export const getAllNetworkSymbols = () => networksCompatibility.map(n => n.symbol);

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -82,7 +82,16 @@ export const networks = {
             'staking',
         ],
         customBackends: ['blockbook'],
-        accountTypes: {},
+        accountTypes: {
+            ledger: {
+                // ledger (live), #1 acc is same as Trezor, so it is skipped
+                bip43Path: "m/44'/60'/i'/0/0",
+            },
+            legacy: {
+                // ledger (legacy)
+                bip43Path: "m/44'/60'/0'/i",
+            },
+        },
         coingeckoId: 'ethereum',
     },
     etc: {
@@ -349,7 +358,12 @@ export const networks = {
         },
         features: ['rbf', 'sign-verify', 'tokens', 'coin-definitions', 'nft-definitions'],
         customBackends: ['blockbook'],
-        accountTypes: {},
+        accountTypes: {
+            ledger: {
+                // ledger (live), #1 acc is same as Trezor, so it is skipped
+                bip43Path: "m/44'/60'/i'/0/0",
+            },
+        },
         coingeckoId: 'polygon-pos',
     },
     bnb: {
@@ -368,7 +382,12 @@ export const networks = {
         },
         features: ['rbf', 'sign-verify', 'tokens', 'coin-definitions', 'nft-definitions'],
         customBackends: ['blockbook'],
-        accountTypes: {},
+        accountTypes: {
+            ledger: {
+                // ledger (live), #1 acc is same as Trezor, so it is skipped
+                bip43Path: "m/44'/60'/i'/0/0",
+            },
+        },
         coingeckoId: 'binance-smart-chain',
     },
     // testnets

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -246,8 +246,14 @@ export const getBundleThunk = createThunk(
 
             if (!hasEmptyAccount && !failed && !skipCardanoDerivation) {
                 const index = prevAccounts[0] ? prevAccounts[0].index + 1 : 0;
+                const isEvmLedgerDerivationPath =
+                    configNetwork.networkType === 'ethereum' &&
+                    configNetwork.accountType === 'ledger';
+
+                const pathIndex = (index + (isEvmLedgerDerivationPath ? 1 : 0)).toString();
+
                 bundle.push({
-                    path: configNetwork.bip43Path.replace('i', index.toString()),
+                    path: configNetwork.bip43Path.replace('i', pathIndex),
                     coin: configNetwork.symbol,
                     identity: tryGetAccountIdentity({
                         networkType: configNetwork.networkType,

--- a/suite-native/accounts/src/tests/selectors.test.ts
+++ b/suite-native/accounts/src/tests/selectors.test.ts
@@ -79,7 +79,7 @@ describe('groupAccountsByNetworkAccountType', () => {
             'Bitcoin Legacy Segwit accounts': [{ symbol: 'btc', accountType: 'segwit' }],
             'Bitcoin Legacy accounts': [{ symbol: 'btc', accountType: 'legacy' }],
             'Bitcoin Taproot accounts': [{ symbol: 'btc', accountType: 'taproot' }],
-            'Ethereum accounts': [{ symbol: 'eth', accountType: 'normal' }],
+            'Ethereum default accounts': [{ symbol: 'eth', accountType: 'normal' }],
             'Litecoin Legacy Segwit accounts': [{ symbol: 'ltc', accountType: 'segwit' }],
         });
     });

--- a/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
+++ b/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
@@ -96,14 +96,14 @@ export const useAddCoinAccount = () => {
         const availableTypes: Map<NetworkSymbol, [AccountType, ...AccountType[]]> = new Map();
 
         Object.keys(networks).forEach(symbol => {
-            // for Cardano only allow latest account type and coinjoin is not supported
+            // for Cardano and Ethereum only allow latest account type and coinjoin and ledger are not supported
             const types = Object.keys(networks[symbol].accountTypes).filter(
                 t => !['coinjoin', 'imported', 'ledger'].includes(t),
             ) as AccountType[];
 
             availableTypes.set(symbol as NetworkSymbol, [
                 NORMAL_ACCOUNT_TYPE,
-                ...(symbol === 'ada' ? [] : types),
+                ...(['ada', 'eth'].includes(symbol) ? [] : types),
             ]);
         });
 


### PR DESCRIPTION
## Description

- do discovery of ledger live accounts for all EVMs
- do discovery of ledger legacy accounts for ETH
- allow to add non-bitcoin coin account type when debug mode is on
- fix jumping of account label chevron
- skip first evm ledger account as it is same as trezor

- add account type in debug mode looks broken, the texts are wrong, but the logic works, there is another issue https://github.com/trezor/trezor-suite/issues/13736 to fix it 

## Related Issue

resolve https://github.com/trezor/trezor-suite/issues/8591
resolve #13733

## Screenshots:
non-debug
<img width="498" alt="Screenshot 2024-08-09 at 15 49 19" src="https://github.com/user-attachments/assets/1d323d47-9fd3-4ae0-b0ac-e7b950fec443">

debug

<img width="510" alt="Screenshot 2024-08-09 at 15 49 08" src="https://github.com/user-attachments/assets/283a3cd0-4b41-4a63-bd7d-a8d39dee9923">

![Screenshot 2024-08-09 at 15 43 21](https://github.com/user-attachments/assets/75113896-0f4a-4756-904d-df14585b9f7d)

![Screenshot 2024-08-09 at 16 24 13](https://github.com/user-attachments/assets/71a2b67d-dbbf-4d32-b4a2-0377442244a3)
