### PR TITLE
fix(suite): add pading above network symbol

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -27,6 +27,7 @@ import { DeviceModelInternal } from '@trezor/connect';
 
 const StyledModal = styled(Modal)`
     width: 480px;
+    padding-top: 4px;
     text-align: left;
 `;
 


### PR DESCRIPTION
Adding padding so the CoinLogo does not touch border of the modal

BTW maybe I've added the padding also in some other places by this change, please someone from usability team check it first before merging. Diki

Before
![image](https://github.com/user-attachments/assets/ba28be6a-4107-4e39-a737-46789f34192c)






After
<img width="594" alt="image" src="https://github.com/user-attachments/assets/24f70ac2-e985-4c09-8e67-38192dc473d6">
