### PR TITLE
feat(coin-icons): change network separator

### DIFF
--- a/.github/workflows/release-suite-coin-icons.yml
+++ b/.github/workflows/release-suite-coin-icons.yml
@@ -6,9 +6,9 @@ permissions:
 
 on:
   workflow_dispatch:
-  # schedule:
-  # Runs at midnight UTC every day at 01:00 AM CET
-  # - cron: "0 0 * * *"
+  schedule:
+    # Runs at midnight UTC every day at 01:00 AM CET
+    - cron: "0 0 * * *"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/suite-common/icons/scripts/downloadCryptoIcons.ts
+++ b/suite-common/icons/scripts/downloadCryptoIcons.ts
@@ -69,7 +69,7 @@ const updateIcon = async (coin: CoinListData) => {
             );
             if (platforms.length > 0) {
                 platforms.forEach(([platform, contract]) => {
-                    const name = `${platform}_${contract}`;
+                    const name = `${platform}--${contract}`;
                     const fileName = `${encodeURIComponent(name)}${size !== '1x' ? `@${size}` : ''}.webp`;
                     const destinationFile = join(FILES_CRYPTOICONS_PATH, fileName);
 


### PR DESCRIPTION
Changing network separator to be compatible with invity coin ids
Enable cron schedule

From `[platform]_[contract_address]` to `[platform]--[contract_address]`
## Related Issue

#13630

