### PR TITLE
fix(connect): Fix expected revisionId for T2T1 2.3.0

### DIFF
--- a/packages/connect/src/device/__tests__/calculateRevisionForDevice.test.ts
+++ b/packages/connect/src/device/__tests__/calculateRevisionForDevice.test.ts
@@ -10,7 +10,7 @@ describe(calculateRevisionForDevice.name, () => {
         ).toBe('dd4671a5104952ef505d28d1f9e94d1484b4607a');
     });
 
-    it('shortens the hash for `version > 2.3.0` && `version <= 2.4.0` to 9 characters', () => {
+    it('shortens the hash for `version > 2.2.0` && `version <= 2.4.0` to 9 characters', () => {
         expect(
             calculateRevisionForDevice({
                 version: [2, 4, 0],

--- a/packages/connect/src/device/calculateRevisionForDevice.ts
+++ b/packages/connect/src/device/calculateRevisionForDevice.ts
@@ -14,7 +14,7 @@ export const calculateRevisionForDevice = ({
         return commitRevision;
     }
 
-    if (isNewer(version, '2.3.0')) {
+    if (isNewer(version, '2.2.0')) {
         return commitRevision.slice(0, 9);
     }
 


### PR DESCRIPTION
## Description

T2T1 with firmware >= 2.3.0 and firmware <= 2.4.0 returns only first 9 chars of revisionId instead of full, but `connect` expected 2.3.0 to be full.

:arrow_right:  Change the interval to include 2.3.0 (make it >2.2.0, which is the previous version)

## Related issue

Fix after https://github.com/trezor/trezor-suite-private/issues/104