### PR TITLE
fix(connect): Matching firmware version online

### DIFF
--- a/packages/connect/src/device/__tests__/checkFirmwareRevision.test.ts
+++ b/packages/connect/src/device/__tests__/checkFirmwareRevision.test.ts
@@ -61,11 +61,30 @@ describe(checkFirmwareRevision.name, () => {
             expected: { success: false, error: 'revision-mismatch' },
         },
         {
-            it: 'fails when firmware version is not found locally, and also not in the online release',
+            it: 'passes when firmware version is not found locally, but found in the online release',
             httpRequestMock: () => Promise.resolve(ONLINE_RELEASES_JSON_MOCK),
             params: createDevicePrams({
                 deviceRevision: '1eb0eb9d91b092e571aac63db4ebff2a07fd8a1f',
                 expectedRevision: undefined, // firmware not known by local releases.json file
+            }),
+            expected: { success: true },
+        },
+        {
+            it: 'fails when firmware version is not found locally, found in the online release, but does NOT match',
+            httpRequestMock: () => Promise.resolve(ONLINE_RELEASES_JSON_MOCK),
+            params: createDevicePrams({
+                deviceRevision: '1234567890987654321',
+                expectedRevision: undefined, // firmware not known by local releases.json file
+            }),
+            expected: { success: false, error: 'revision-mismatch' },
+        },
+        {
+            it: 'fails when firmware version is not found locally, and also not in the online release',
+            httpRequestMock: () => Promise.resolve(ONLINE_RELEASES_JSON_MOCK),
+            params: createDevicePrams({
+                deviceRevision: '1234567890987654321',
+                firmwareVersion: [2, 9, 9], // completely unrecognized version
+                expectedRevision: undefined,
             }),
             expected: { success: false, error: 'firmware-version-unknown' },
         },

--- a/packages/connect/src/device/checkFirmwareRevision.ts
+++ b/packages/connect/src/device/checkFirmwareRevision.ts
@@ -1,3 +1,4 @@
+import { isEqual } from '@trezor/utils/src/versionUtils';
 import { PROTO } from '../constants';
 import { downloadReleasesMetadata } from '../data/downloadReleasesMetadata';
 import { FirmwareRelease, VersionArray } from '../types';
@@ -15,7 +16,7 @@ const getOnlineReleaseMetadata = async ({
 }: GetOnlineReleaseMetadataParams): Promise<FirmwareRelease | undefined> => {
     const onlineReleases = await downloadReleasesMetadata({ internal_model: internalModel });
 
-    return onlineReleases.find(onlineRelease => onlineRelease.version === firmwareVersion);
+    return onlineReleases.find(onlineRelease => isEqual(onlineRelease.version, firmwareVersion));
 };
 
 const failFirmwareRevisionCheck = (


### PR DESCRIPTION
## Description

Checking firmware revision **online** (when not found locally) is currently broken.

Current code downloads json and tries to find an entry where `[2,8,1] === [2,8,1]`, but in JS, byVal comparison of arrays with different ref is always `false`.

:arrow_right: use our `isEqual` function which is for this exact purpose.

## Related issue

Fix after https://github.com/trezor/trezor-suite-private/issues/104