### PR TITLE
feat(suite): Check firmware for all models

### DIFF
--- a/packages/connect/src/device/__tests__/checkFirmwareRevision.test.ts
+++ b/packages/connect/src/device/__tests__/checkFirmwareRevision.test.ts
@@ -102,13 +102,17 @@ describe(checkFirmwareRevision.name, () => {
             expected: { success: false, error: 'cannot-perform-check-offline' },
         },
         {
-            it: "doesn't check anything for new versions with security chip (not implemented yet)",
-            params: createDevicePrams({
-                deviceRevision: '1eb0eb9d91b092e571aac63db4ebff2a07fd8a1f',
-                expectedRevision: 'cde8f31ec2ddcb7d35e36edbcf8a71dda983a9ea',
-                internalModel: DeviceModelInternal.T3B1,
-            }),
+            it: 'passes also for a different device',
+            params: createDevicePrams({ internalModel: DeviceModelInternal.T3T1 }),
             expected: { success: true },
+        },
+        {
+            it: 'fails also for a different device',
+            params: createDevicePrams({
+                internalModel: DeviceModelInternal.T3T1,
+                expectedRevision: '1234567890987654321',
+            }),
+            expected: { success: false, error: 'revision-mismatch' },
         },
     ])(`$it`, async ({ params, expected, httpRequestMock }) => {
         if (httpRequestMock !== undefined) {

--- a/packages/connect/src/device/checkFirmwareRevision.ts
+++ b/packages/connect/src/device/checkFirmwareRevision.ts
@@ -2,7 +2,7 @@ import { isEqual } from '@trezor/utils/src/versionUtils';
 import { PROTO } from '../constants';
 import { downloadReleasesMetadata } from '../data/downloadReleasesMetadata';
 import { FirmwareRelease, VersionArray } from '../types';
-import { DeviceModelInternal, FirmwareRevisionCheckResult } from '../types/device';
+import { FirmwareRevisionCheckResult } from '../types/device';
 import { calculateRevisionForDevice } from './calculateRevisionForDevice';
 
 type GetOnlineReleaseMetadataParams = {
@@ -59,10 +59,6 @@ export const checkFirmwareRevision = async ({
     deviceRevision,
     expectedRevision,
 }: CheckFirmwareRevisionParams): Promise<FirmwareRevisionCheckResult> => {
-    if (internalModel !== DeviceModelInternal.T2T1 && internalModel !== DeviceModelInternal.T1B1) {
-        return { success: true }; // For newer devices we are covered by secure element anyway
-    }
-
     if (expectedRevision === undefined) {
         if (firmwareVersion.length !== 3) {
             return failFirmwareRevisionCheck('firmware-version-unknown');

--- a/packages/suite-web/e2e/tests/settings/t2b1-device-settings.test.ts
+++ b/packages/suite-web/e2e/tests/settings/t2b1-device-settings.test.ts
@@ -9,7 +9,7 @@
 
 describe('T2B1 - Device settings', () => {
     const startEmuOpts = {
-        version: '2-main',
+        version: '2-latest',
         model: 'T2B1',
         wipe: true,
     };

--- a/packages/suite/src/views/settings/SettingsDevice/SettingsDevice.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/SettingsDevice.tsx
@@ -89,7 +89,6 @@ export const SettingsDevice = () => {
     const deviceModelInternal = device.features.internal_model;
 
     const supportsDeviceAuthentication = SUPPORTS_DEVICE_AUTHENTICITY_CHECK[deviceModelInternal];
-    const supportsFirmwareRevisionCheck = !supportsDeviceAuthentication; // Older devices with no secure element
 
     return (
         <SettingsLayout>
@@ -179,7 +178,7 @@ export const SettingsDevice = () => {
                 {isNormalMode && <WipeCode isDeviceLocked={isDeviceLocked} />}
                 <CustomFirmware />
                 {supportsDeviceAuthentication && <DeviceAuthenticityOptOut />}
-                {supportsFirmwareRevisionCheck && <FirmwareRevisionCheck />}
+                <FirmwareRevisionCheck />
             </SettingsSection>
         </SettingsLayout>
     );


### PR DESCRIPTION
Check firmware revisionsIds also for T2B1 and T3T1

## Description

Although the new models have a hw authenticity chip, we would like to also check revision Ids also, as we do for T1B1 and T2T1, as an additional layer of security. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite-private/issues/109

## Screenshots:

Running T2B1 or T3T1 on latest `trezor-user-env`, but choosing `2-main`, gets you ghost (like all the other "main" versions):
<img src="https://github.com/user-attachments/assets/3eb54170-8008-4d0a-b6c9-bb848d66b137" width="500" />

For those models, in settings there is now both Turn off firmware revision check & device check:
<img src="https://github.com/user-attachments/assets/036ef397-6c6a-4bce-afc6-15fe25f3211f" width="500" />
 
