### PR TITLE
fix(staking): staking tx in staking tab

### DIFF
--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/Transactions.tsx
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/Transactions.tsx
@@ -2,17 +2,22 @@ import { TransactionList } from 'src/views/wallet/transactions/TransactionList/T
 import { useSelector } from 'src/hooks/suite';
 import {
     selectAccountStakeTypeTransactions,
+    selectAreAllTransactionsLoaded,
     selectIsLoadingAccountTransactions,
 } from '@suite-common/wallet-core';
 
 export const Transactions = () => {
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
+    const accountKey = selectedAccount.account?.key ?? '';
+
     const transactionsIsLoading = useSelector(state =>
-        selectIsLoadingAccountTransactions(state, selectedAccount.account?.key || null),
+        selectIsLoadingAccountTransactions(state, accountKey),
     );
-    const stakeTxs = useSelector(state =>
-        selectAccountStakeTypeTransactions(state, selectedAccount.account?.key || ''),
+    const areAllTransactionsLoaded = useSelector(state =>
+        selectAreAllTransactionsLoaded(state, accountKey),
     );
+
+    const stakeTxs = useSelector(state => selectAccountStakeTypeTransactions(state, accountKey));
 
     if (selectedAccount.status !== 'loaded' || stakeTxs.length < 1) {
         return null;
@@ -25,7 +30,7 @@ export const Transactions = () => {
             account={account}
             transactions={stakeTxs}
             symbol={account.symbol}
-            isLoading={transactionsIsLoading}
+            isLoading={transactionsIsLoading || !areAllTransactionsLoaded}
             customTotalItems={stakeTxs.length}
             isExportable={false}
         />

--- a/suite-common/wallet-core/src/transactions/transactionsReducer.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsReducer.ts
@@ -226,6 +226,11 @@ export const selectIsLoadingAccountTransactions = (
 export const selectTransactions = (state: TransactionsRootState) =>
     state.wallet.transactions.transactions;
 
+export const selectAreAllTransactionsLoaded = (
+    state: TransactionsRootState,
+    accountKey: AccountKey | null,
+) => state.wallet.transactions.fetchStatusDetail?.[accountKey ?? '']?.areAllTransactionsLoaded;
+
 /**
  * The list is not sorted here because it may contain null values as placeholders
  * for transactions that have not been fetched yet. (This affects pagination.)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updated the logic to ensure that all staking transactions are correctly displayed, regardless of the number of general transactions the user has. This change ensures that active users can now see their staking transactions as expected.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/12827

## Screenshots:
