### PR TITLE
feat(suite): Add message system toggle for revision check

### DIFF
--- a/packages/suite/src/components/suite/Preloader/Preloader.tsx
+++ b/packages/suite/src/components/suite/Preloader/Preloader.tsx
@@ -22,6 +22,7 @@ import { ViewOnlyPromo } from 'src/views/view-only/ViewOnlyPromo';
 import { selectDevice } from '@suite-common/wallet-core';
 import { DeviceCompromised } from '../SecurityCheck/DeviceCompromised';
 import { RouterAppWithParams } from '../../../constants/suite/routes';
+import { Feature, selectIsFeatureDisabled } from '@suite-common/message-system';
 
 const ROUTES_TO_SKIP_REVISION_CHECK: RouterAppWithParams['app'][] = [
     'settings',
@@ -56,6 +57,9 @@ export const Preloader = ({ children }: PreloaderProps) => {
     const selectedDevice = useSelector(selectDevice);
     const { initialRun, viewOnlyPromoClosed } = useSelector(selectSuiteFlags);
     const { isFirmwareRevisionCheckDisabled } = useSelector(state => state.suite.settings);
+    const isFirmwareRevisionCheckDisabledByMessageSystem = useSelector(state =>
+        selectIsFeatureDisabled(state, Feature.firmwareRevisionCheck),
+    );
 
     const dispatch = useDispatch();
 
@@ -84,7 +88,8 @@ export const Preloader = ({ children }: PreloaderProps) => {
             !ROUTES_TO_SKIP_REVISION_CHECK.includes(router.route?.app)) &&
         selectedDevice?.features &&
         selectedDevice.connected === true &&
-        !isFirmwareRevisionCheckDisabled
+        !isFirmwareRevisionCheckDisabled &&
+        !isFirmwareRevisionCheckDisabledByMessageSystem
     ) {
         const failedChecks =
             selectedDevice.authenticityChecks !== undefined

--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -22,6 +22,7 @@ export const Feature = {
     ethStake: 'eth.staking.stake',
     ethUnstake: 'eth.staking.unstake',
     ethClaim: 'eth.staking.claim',
+    firmwareRevisionCheck: 'security.firmware.check',
 } as const;
 
 export type FeatureDomain = (typeof Feature)[keyof typeof Feature];


### PR DESCRIPTION
Add a listener for `firmwarerevisioncheck` feature, which is not yet added to message config, so after this PR, the firmware revision check is  **still turned on**, this just prepares a method to shut it down quickly.

It is then turned off just like if user turns it off manually in Device settings.

## Description

When we release the firmware check, we need a way to quickly shut it down in case of problems - if we customer support gets a flurry of false positives.

#13794 will turn it off globally just like if user turns it off manually in Device settings.

## :warning: Contingency plan :scream:

Merge & deploy #13794 to turn off firmware revision check.

## Related Issue

https://github.com/trezor/trezor-suite-private/issues/104