### PR TITLE
chore: update electron and related desktop deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
         "type-fest": "2.12.2",
         "bcrypto": "5.4.0",
         "react": "18.2.0",
-        "electron": "27.3.8",
+        "electron": "30.3.1",
         "webpack": "^5.93.0",
         "html-webpack-plugin": "^5.6.0",
         "@types/node": "20.12.7",

--- a/packages/connect-examples/electron-main-process/package.json
+++ b/packages/connect-examples/electron-main-process/package.json
@@ -55,7 +55,7 @@
         "@trezor/connect": "workspace:*"
     },
     "devDependencies": {
-        "electron": "27.3.8",
+        "electron": "30.3.1",
         "electron-builder": "24.13.3"
     }
 }

--- a/packages/connect-examples/electron-renderer-with-assets/package.json
+++ b/packages/connect-examples/electron-renderer-with-assets/package.json
@@ -60,7 +60,7 @@
         "babel-loader": "^9.1.3",
         "concurrently": "^8.2.2",
         "copy-webpack-plugin": "^12.0.2",
-        "electron": "27.3.8",
+        "electron": "30.3.1",
         "electron-builder": "24.13.3",
         "html-webpack-plugin": "^5.6.0",
         "terser-webpack-plugin": "^5.3.9",

--- a/packages/connect-examples/electron-renderer-with-popup/package.json
+++ b/packages/connect-examples/electron-renderer-with-popup/package.json
@@ -52,7 +52,7 @@
         }
     },
     "devDependencies": {
-        "electron": "27.3.8",
+        "electron": "30.3.1",
         "electron-builder": "24.13.3"
     }
 }

--- a/packages/suite-build/configs/desktop.webpack.config.ts
+++ b/packages/suite-build/configs/desktop.webpack.config.ts
@@ -17,7 +17,7 @@ const baseDirUI = getPathForProject('desktop-ui');
 const baseDir = getPathForProject('desktop');
 
 const config: webpack.Configuration = {
-    target: 'browserslist:Chrome >= 124', // Electron 31 is running on chromium 124
+    target: 'browserslist:Chrome >= 124', // Electron 30 is running on chromium 124
     entry: [path.join(baseDirUI, 'src', 'index.tsx')],
     output: {
         path: path.join(baseDir, 'build'),

--- a/packages/suite-build/configs/desktop.webpack.config.ts
+++ b/packages/suite-build/configs/desktop.webpack.config.ts
@@ -17,7 +17,7 @@ const baseDirUI = getPathForProject('desktop-ui');
 const baseDir = getPathForProject('desktop');
 
 const config: webpack.Configuration = {
-    target: 'browserslist:Chrome >= 115', // Electron 26 is running on chromium 116 (browserlist doesn't know 116 yet)
+    target: 'browserslist:Chrome >= 124', // Electron 31 is running on chromium 124
     entry: [path.join(baseDirUI, 'src', 'index.tsx')],
     output: {
         path: path.join(baseDir, 'build'),

--- a/packages/suite-desktop-api/package.json
+++ b/packages/suite-desktop-api/package.json
@@ -19,6 +19,6 @@
         "type-check": "yarn g:tsc --build tsconfig.json"
     },
     "dependencies": {
-        "electron": "27.3.8"
+        "electron": "30.3.1"
     }
 }

--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -14,7 +14,7 @@
         "test:e2e": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts"
     },
     "dependencies": {
-        "@sentry/electron": "^4.17.0",
+        "@sentry/electron": "^4.24.0",
         "@suite-common/message-system": "workspace:*",
         "@suite-common/sentry": "workspace:*",
         "@suite-common/suite-constants": "workspace:^",
@@ -34,14 +34,14 @@
         "@trezor/utils": "workspace:*",
         "chalk": "^4.1.2",
         "electron-localshortcut": "^3.2.1",
-        "electron-store": "^8.1.0",
-        "electron-updater": "6.1.8",
-        "openpgp": "^5.11.0",
-        "systeminformation": "^5.21.24"
+        "electron-store": "8.2.0",
+        "electron-updater": "6.3.3",
+        "openpgp": "^5.11.2",
+        "systeminformation": "^5.23.4"
     },
     "devDependencies": {
         "@currents/playwright": "^1.3.1",
-        "@electron/notarize": "2.2.1",
+        "@electron/notarize": "2.4.0",
         "@playwright/browser-chromium": "^1.45.3",
         "@playwright/browser-firefox": "^1.45.3",
         "@playwright/browser-webkit": "^1.45.3",
@@ -50,7 +50,7 @@
         "@trezor/trezor-user-env-link": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@types/electron-localshortcut": "^3.1.3",
-        "electron": "27.3.8",
+        "electron": "30.3.1",
         "fs-extra": "^11.2.0",
         "glob": "^10.3.10",
         "terser-webpack-plugin": "^5.3.9",

--- a/packages/suite-desktop-ui/package.json
+++ b/packages/suite-desktop-ui/package.json
@@ -12,7 +12,7 @@
         "lint:styles": "npx stylelint './src/**/*{.ts,.tsx}' --cache --config ../../.stylelintrc"
     },
     "dependencies": {
-        "@sentry/electron": "^4.17.0",
+        "@sentry/electron": "^4.24.0",
         "@suite-common/formatters": "workspace:*",
         "@suite-common/sentry": "workspace:*",
         "@suite-common/suite-types": "workspace:*",

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -25,13 +25,13 @@
     "dependencies": {
         "blake-hash": "^2.0.0",
         "electron-localshortcut": "^3.2.1",
-        "electron-store": "^8.1.0",
-        "electron-updater": "6.1.8",
+        "electron-store": "8.2.0",
+        "electron-updater": "6.3.3",
         "usb": "^2.11.0"
     },
     "devDependencies": {
-        "@electron/notarize": "2.2.1",
-        "electron": "27.3.8",
+        "@electron/notarize": "2.4.0",
+        "electron": "30.3.1",
         "electron-builder": "24.13.3",
         "glob": "^10.3.10"
     }

--- a/shell.nix
+++ b/shell.nix
@@ -1,14 +1,14 @@
-# the last successful build of nixos-unstable as of 2023-10-30
+# pinned to nixos-24.05 on commit https://github.com/NixOS/nixpkgs/commit/4a92571f9207810b559c9eac203d1f4d79830073
 with import
   (builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/08b9151ed40350725eb40b1fe96b0b86304a654b.tar.gz";
-    sha256 = "09k701xi2zlxdzvsa276b4vs8h4vjjshlaik25bfv1hkrwm30s56";
+    url = "https://github.com/NixOS/nixpkgs/archive/4a92571f9207810b559c9eac203d1f4d79830073.tar.gz";
+    sha256 = "0sp7qjbb7dvrh4zvd40i6y7jwsd1v1qj44f0c95q88g7fikda8gq";
   })
 { };
 
 let
   # unstable packages
-  electron = electron_27; # use the same version as defined in packages/suite-desktop/package.json
+  electron = electron_30; # use the same version as defined in packages/suite-desktop/package.json
   nodejs = nodejs_20;
   # use older gcc. 10.2.0 with glibc 2.32 for node_modules bindings.
   # electron-builder is packing the app with glibc 2.32, bindings should not be compiled with newer version.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2434,6 +2434,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@electron/notarize@npm:2.4.0":
+  version: 2.4.0
+  resolution: "@electron/notarize@npm:2.4.0"
+  dependencies:
+    debug: "npm:^4.1.1"
+    fs-extra: "npm:^9.0.1"
+    promise-retry: "npm:^2.0.1"
+  checksum: 10/fe97ac96e6cc93dae2cd5095bd157f5d9cb49c1a9606f0cb06216518e1c15fcfa76923de3d541544b63c5ff985c1ae43065453197a284352df95599e635877ac
+  languageName: node
+  linkType: hard
+
 "@electron/osx-sign@npm:1.0.5":
   version: 1.0.5
   resolution: "@electron/osx-sign@npm:1.0.5"
@@ -7369,6 +7380,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry-internal/feedback@npm:7.112.0":
+  version: 7.112.0
+  resolution: "@sentry-internal/feedback@npm:7.112.0"
+  dependencies:
+    "@sentry/core": "npm:7.112.0"
+    "@sentry/types": "npm:7.112.0"
+    "@sentry/utils": "npm:7.112.0"
+  checksum: 10/94af57d978287fa1ad3dca0351d0b249ad5f2b1a8d05b8466e7a9a66f0011d0c5946d8ba791b9f7da6551930a6a70df2463c5a78d3b21ea79c21d596cb7022e2
+  languageName: node
+  linkType: hard
+
 "@sentry-internal/feedback@npm:7.113.0":
   version: 7.113.0
   resolution: "@sentry-internal/feedback@npm:7.113.0"
@@ -7380,14 +7402,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry-internal/feedback@npm:7.92.0":
-  version: 7.92.0
-  resolution: "@sentry-internal/feedback@npm:7.92.0"
+"@sentry-internal/replay-canvas@npm:7.112.0":
+  version: 7.112.0
+  resolution: "@sentry-internal/replay-canvas@npm:7.112.0"
   dependencies:
-    "@sentry/core": "npm:7.92.0"
-    "@sentry/types": "npm:7.92.0"
-    "@sentry/utils": "npm:7.92.0"
-  checksum: 10/37cd3356d64b5069d66e25610959415d3a3fdb98ee060a355da3113d1c59d04e83803ec9cf09e669e0fbe42d8df246fed72d298c321ca1c64ccc9ea473497071
+    "@sentry/core": "npm:7.112.0"
+    "@sentry/replay": "npm:7.112.0"
+    "@sentry/types": "npm:7.112.0"
+    "@sentry/utils": "npm:7.112.0"
+  checksum: 10/b315fbaa9550b2740fd9fda9d03b891d1ef7512f54ba8e949cf35eed843d67d9de9be9b3b50f216b88925cebecb2d8bec47e01c29d61e8cac22ac84c321f4bfa
   languageName: node
   linkType: hard
 
@@ -7403,6 +7426,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry-internal/tracing@npm:7.112.0":
+  version: 7.112.0
+  resolution: "@sentry-internal/tracing@npm:7.112.0"
+  dependencies:
+    "@sentry/core": "npm:7.112.0"
+    "@sentry/types": "npm:7.112.0"
+    "@sentry/utils": "npm:7.112.0"
+  checksum: 10/004f7da5602698861d0f295eb6c0d03f1169b1b1cd9e20d93cb5c1f31329ff5c4aba973d0bdfd4c44782a2269fa427191cc0f8bb12f375a433c06dc22119cc56
+  languageName: node
+  linkType: hard
+
 "@sentry-internal/tracing@npm:7.113.0":
   version: 7.113.0
   resolution: "@sentry-internal/tracing@npm:7.113.0"
@@ -7414,21 +7448,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry-internal/tracing@npm:7.92.0":
-  version: 7.92.0
-  resolution: "@sentry-internal/tracing@npm:7.92.0"
-  dependencies:
-    "@sentry/core": "npm:7.92.0"
-    "@sentry/types": "npm:7.92.0"
-    "@sentry/utils": "npm:7.92.0"
-  checksum: 10/7f9f348a64aed69e8484a956de50acb069d99daf802d4059749636d7974b1f758c3f9d50346521c18d6c71a65b94b83e0b8e08e6b7d66f367666671091bd74ab
-  languageName: node
-  linkType: hard
-
 "@sentry/babel-plugin-component-annotate@npm:2.14.0":
   version: 2.14.0
   resolution: "@sentry/babel-plugin-component-annotate@npm:2.14.0"
   checksum: 10/4fe01b7ff9bf5380e4996ecdf352cceaeecf66e5a4a9e8f31c8e70beac3245a440004e42827f5321c45975f32a0f0d66ded6b673baef2a3848d877e83c4a77b8
+  languageName: node
+  linkType: hard
+
+"@sentry/browser@npm:7.112.0":
+  version: 7.112.0
+  resolution: "@sentry/browser@npm:7.112.0"
+  dependencies:
+    "@sentry-internal/feedback": "npm:7.112.0"
+    "@sentry-internal/replay-canvas": "npm:7.112.0"
+    "@sentry-internal/tracing": "npm:7.112.0"
+    "@sentry/core": "npm:7.112.0"
+    "@sentry/integrations": "npm:7.112.0"
+    "@sentry/replay": "npm:7.112.0"
+    "@sentry/types": "npm:7.112.0"
+    "@sentry/utils": "npm:7.112.0"
+  checksum: 10/fa938eca5e10c4d6eda8a4250e8c7a39bcce6bfd2a690b21881362c4e71c279408869efa48e97d7cf44ec4190901d0862aeee41ac31fb98436193b38f1e5b156
   languageName: node
   linkType: hard
 
@@ -7445,20 +7484,6 @@ __metadata:
     "@sentry/types": "npm:7.113.0"
     "@sentry/utils": "npm:7.113.0"
   checksum: 10/2f6753c76b6c363449c16b2b47c09186d6f49acde6a6ed8fd70246c6da2127c462244b0baba333645c6e74bc7ba4e0489c1c0d100d3878906a9580f62b6c58bd
-  languageName: node
-  linkType: hard
-
-"@sentry/browser@npm:7.92.0":
-  version: 7.92.0
-  resolution: "@sentry/browser@npm:7.92.0"
-  dependencies:
-    "@sentry-internal/feedback": "npm:7.92.0"
-    "@sentry-internal/tracing": "npm:7.92.0"
-    "@sentry/core": "npm:7.92.0"
-    "@sentry/replay": "npm:7.92.0"
-    "@sentry/types": "npm:7.92.0"
-    "@sentry/utils": "npm:7.92.0"
-  checksum: 10/55fda183b35913eaf7e7cc69f1bec41f9f64167310b437ddcf06114a9bb6bc83014ed835fb6257ddc669da1a0a5e6a093f34c8ea313eb97f929a769334ebac42
   languageName: node
   linkType: hard
 
@@ -7566,6 +7591,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry/core@npm:7.112.0":
+  version: 7.112.0
+  resolution: "@sentry/core@npm:7.112.0"
+  dependencies:
+    "@sentry/types": "npm:7.112.0"
+    "@sentry/utils": "npm:7.112.0"
+  checksum: 10/e2147f63430e71ac6b05341e335016b7bbf2cbff2fae3244a12d6f27fb5ee63295426d8cf7967369b4cd6996961b14261c98cbfca44af60cdcfaa4d6e083c6f4
+  languageName: node
+  linkType: hard
+
 "@sentry/core@npm:7.113.0, @sentry/core@npm:^7.100.1":
   version: 7.113.0
   resolution: "@sentry/core@npm:7.113.0"
@@ -7576,28 +7611,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/core@npm:7.92.0":
-  version: 7.92.0
-  resolution: "@sentry/core@npm:7.92.0"
+"@sentry/electron@npm:^4.24.0":
+  version: 4.24.0
+  resolution: "@sentry/electron@npm:4.24.0"
   dependencies:
-    "@sentry/types": "npm:7.92.0"
-    "@sentry/utils": "npm:7.92.0"
-  checksum: 10/1477820b0a0a7efb5d092faefb9958a4b9d24a8dfe55ddfb72e80d4db3e0ff6e6277297d247c2dbc09dbcf1150b58dfa933e1911789bc3b9ba8fd0d73f2c56ca
-  languageName: node
-  linkType: hard
-
-"@sentry/electron@npm:^4.17.0":
-  version: 4.17.0
-  resolution: "@sentry/electron@npm:4.17.0"
-  dependencies:
-    "@sentry/browser": "npm:7.92.0"
-    "@sentry/core": "npm:7.92.0"
-    "@sentry/node": "npm:7.92.0"
-    "@sentry/types": "npm:7.92.0"
-    "@sentry/utils": "npm:7.92.0"
+    "@sentry/browser": "npm:7.112.0"
+    "@sentry/core": "npm:7.112.0"
+    "@sentry/node": "npm:7.112.0"
+    "@sentry/types": "npm:7.112.0"
+    "@sentry/utils": "npm:7.112.0"
     deepmerge: "npm:4.3.0"
     tslib: "npm:^2.5.0"
-  checksum: 10/89e992675d6aedf11d19ee987d8cb2cfb703118df592670fe80f7ceaf88627afcae57af5cd685ec3fff55593f063b0f380808ed56b91570c12b297ad87d71686
+  checksum: 10/be07917cbc168a957c73b0103e03b7b3f4129ec6b9d90d20837500d9fa279b8248484e3057943a2aab1465a5c40fd42fe62b887cb715613a2ff1087ec0756ad4
   languageName: node
   linkType: hard
 
@@ -7609,6 +7634,18 @@ __metadata:
     "@sentry/types": "npm:7.113.0"
     "@sentry/utils": "npm:7.113.0"
   checksum: 10/e2cc8d01ddf49a0ef4277527d37266d9ed7ff7e8db155c44cd08510116a2d4965da85eb864853ce330246132fc6afdf19604a830eb7b8109e849798b3c25cd99
+  languageName: node
+  linkType: hard
+
+"@sentry/integrations@npm:7.112.0":
+  version: 7.112.0
+  resolution: "@sentry/integrations@npm:7.112.0"
+  dependencies:
+    "@sentry/core": "npm:7.112.0"
+    "@sentry/types": "npm:7.112.0"
+    "@sentry/utils": "npm:7.112.0"
+    localforage: "npm:^1.8.1"
+  checksum: 10/1945921b548444898396838e4ed9a027d282756ff5ee370c75bb638cca177d89438068e77cdd3bd73053707704d03c5f52eb5845e3f2b0402e2d0fee6b299f3d
   languageName: node
   linkType: hard
 
@@ -7624,16 +7661,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/node@npm:7.92.0, @sentry/node@npm:^7.60.0":
-  version: 7.92.0
-  resolution: "@sentry/node@npm:7.92.0"
+"@sentry/node@npm:7.112.0, @sentry/node@npm:^7.60.0":
+  version: 7.112.0
+  resolution: "@sentry/node@npm:7.112.0"
   dependencies:
-    "@sentry-internal/tracing": "npm:7.92.0"
-    "@sentry/core": "npm:7.92.0"
-    "@sentry/types": "npm:7.92.0"
-    "@sentry/utils": "npm:7.92.0"
-    https-proxy-agent: "npm:^5.0.0"
-  checksum: 10/24314b431bb04615e622939e195e8bb3c4d909214eb92b47c7a2f49aa5fe1af356b897679f5b2941f377a9597ed032ec48e70ac1bd698738ffc17d0d7a00568d
+    "@sentry-internal/tracing": "npm:7.112.0"
+    "@sentry/core": "npm:7.112.0"
+    "@sentry/integrations": "npm:7.112.0"
+    "@sentry/types": "npm:7.112.0"
+    "@sentry/utils": "npm:7.112.0"
+  checksum: 10/a1859ec7c9dd22762f5bd91eaa048b81df0958cfdc62001bdc2f0fd0c833981f16d99ed2622e393ac8c6b5706ac84b734fa24b0e9b52e5e329b488b2b35c5130
   languageName: node
   linkType: hard
 
@@ -7677,6 +7714,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry/replay@npm:7.112.0":
+  version: 7.112.0
+  resolution: "@sentry/replay@npm:7.112.0"
+  dependencies:
+    "@sentry-internal/tracing": "npm:7.112.0"
+    "@sentry/core": "npm:7.112.0"
+    "@sentry/types": "npm:7.112.0"
+    "@sentry/utils": "npm:7.112.0"
+  checksum: 10/8bf71f8c3062e1b53ca479bf7704edc288735dee3807c0cac5ad81a765fbeec94aab7cdb0da56c934818f87a413048056a5187b8dd5f184d55c13e742043bc47
+  languageName: node
+  linkType: hard
+
 "@sentry/replay@npm:7.113.0":
   version: 7.113.0
   resolution: "@sentry/replay@npm:7.113.0"
@@ -7689,22 +7738,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/replay@npm:7.92.0":
-  version: 7.92.0
-  resolution: "@sentry/replay@npm:7.92.0"
-  dependencies:
-    "@sentry-internal/tracing": "npm:7.92.0"
-    "@sentry/core": "npm:7.92.0"
-    "@sentry/types": "npm:7.92.0"
-    "@sentry/utils": "npm:7.92.0"
-  checksum: 10/981c59b15e61cac11e1049224713797721e6176d7a8e2b3e0bfcafb1bcc60e2d79f0d5ac446d85abe122c57f1ac16a7513ee12fce5ce0d8c4ebb3cef5f73d417
-  languageName: node
-  linkType: hard
-
 "@sentry/types@npm:7.92.0":
   version: 7.92.0
   resolution: "@sentry/types@npm:7.92.0"
   checksum: 10/b44fb4ac67dc80946483ae8197b542cfea34a509caaaadb7c3e5788ddb3913b357fa36d4c69905a05fa24ca1ac44f0297d9a14e733f30ee55aa565eb193c87ff
+  languageName: node
+  linkType: hard
+
+"@sentry/utils@npm:7.112.0":
+  version: 7.112.0
+  resolution: "@sentry/utils@npm:7.112.0"
+  dependencies:
+    "@sentry/types": "npm:7.112.0"
+  checksum: 10/38928fae204dc7f4ae23ee1323652c07fac3196c3a6048571c32c6d7feb0abf130354f6b7711d9d655efd8c548d91e314ce1dbc7f673b16a1db75251eba01fe3
   languageName: node
   linkType: hard
 
@@ -7714,15 +7760,6 @@ __metadata:
   dependencies:
     "@sentry/types": "npm:7.113.0"
   checksum: 10/e18054d298497d9f63561b478f4b8e80d188cbf2c26cabacea6a15c9bbcfe03c8f0c9ee0a809c410cba2e5f621c89ea3bfa0efc88ea482019573fe4a6843ea90
-  languageName: node
-  linkType: hard
-
-"@sentry/utils@npm:7.92.0":
-  version: 7.92.0
-  resolution: "@sentry/utils@npm:7.92.0"
-  dependencies:
-    "@sentry/types": "npm:7.92.0"
-  checksum: 10/701b7195e9b7374c0fcdb5eaef597c5644e6ad38b79c4db47b5e3a7f4ddf92ae16746fc2605adcc228d38405fd1ef020cc19921c842ab5aa9fb49ec0cb13f419
   languageName: node
   linkType: hard
 
@@ -11314,7 +11351,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/suite-desktop-api@workspace:packages/suite-desktop-api"
   dependencies:
-    electron: "npm:27.3.8"
+    electron: "npm:30.3.1"
   languageName: unknown
   linkType: soft
 
@@ -11323,12 +11360,12 @@ __metadata:
   resolution: "@trezor/suite-desktop-core@workspace:packages/suite-desktop-core"
   dependencies:
     "@currents/playwright": "npm:^1.3.1"
-    "@electron/notarize": "npm:2.2.1"
+    "@electron/notarize": "npm:2.4.0"
     "@playwright/browser-chromium": "npm:^1.45.3"
     "@playwright/browser-firefox": "npm:^1.45.3"
     "@playwright/browser-webkit": "npm:^1.45.3"
     "@playwright/test": "npm:^1.45.3"
-    "@sentry/electron": "npm:^4.17.0"
+    "@sentry/electron": "npm:^4.24.0"
     "@sentry/webpack-plugin": "npm:^2.14.0"
     "@suite-common/message-system": "workspace:*"
     "@suite-common/sentry": "workspace:*"
@@ -11351,14 +11388,14 @@ __metadata:
     "@trezor/utils": "workspace:*"
     "@types/electron-localshortcut": "npm:^3.1.3"
     chalk: "npm:^4.1.2"
-    electron: "npm:27.3.8"
+    electron: "npm:30.3.1"
     electron-localshortcut: "npm:^3.2.1"
-    electron-store: "npm:^8.1.0"
-    electron-updater: "npm:6.1.8"
+    electron-store: "npm:8.2.0"
+    electron-updater: "npm:6.3.3"
     fs-extra: "npm:^11.2.0"
     glob: "npm:^10.3.10"
-    openpgp: "npm:^5.11.0"
-    systeminformation: "npm:^5.21.24"
+    openpgp: "npm:^5.11.2"
+    systeminformation: "npm:^5.23.4"
     terser-webpack-plugin: "npm:^5.3.9"
     webpack: "npm:^5.93.0"
     xvfb-maybe: "npm:^0.2.1"
@@ -11369,7 +11406,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/suite-desktop-ui@workspace:packages/suite-desktop-ui"
   dependencies:
-    "@sentry/electron": "npm:^4.17.0"
+    "@sentry/electron": "npm:^4.24.0"
     "@suite-common/formatters": "workspace:*"
     "@suite-common/sentry": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
@@ -11399,13 +11436,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/suite-desktop@workspace:packages/suite-desktop"
   dependencies:
-    "@electron/notarize": "npm:2.2.1"
+    "@electron/notarize": "npm:2.4.0"
     blake-hash: "npm:^2.0.0"
-    electron: "npm:27.3.8"
+    electron: "npm:30.3.1"
     electron-builder: "npm:24.13.3"
     electron-localshortcut: "npm:^3.2.1"
-    electron-store: "npm:^8.1.0"
-    electron-updater: "npm:6.1.8"
+    electron-store: "npm:8.2.0"
+    electron-updater: "npm:6.3.3"
     glob: "npm:^10.3.10"
     usb: "npm:^2.11.0"
   languageName: unknown
@@ -16122,16 +16159,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"builder-util-runtime@npm:9.2.3":
-  version: 9.2.3
-  resolution: "builder-util-runtime@npm:9.2.3"
-  dependencies:
-    debug: "npm:^4.3.4"
-    sax: "npm:^1.2.4"
-  checksum: 10/15f9618af1a2224d0ade19fa7dca12f80bc2ceeb4fc89242f2505b44f58d13d3439bb08a5bec865bb0f8e930fa57bd112d9ee9024f22f1654925ffe2bed3925b
-  languageName: node
-  linkType: hard
-
 "builder-util-runtime@npm:9.2.4":
   version: 9.2.4
   resolution: "builder-util-runtime@npm:9.2.4"
@@ -16139,6 +16166,16 @@ __metadata:
     debug: "npm:^4.3.4"
     sax: "npm:^1.2.4"
   checksum: 10/6b4b6518f8859a90cd6b49ff8053134d731438a588496e5f517ec6d12baef3f1a1c74aaa3142f9d4c61979fca1addc3e47432a956c122cfad582b2145a3df077
+  languageName: node
+  linkType: hard
+
+"builder-util-runtime@npm:9.2.5":
+  version: 9.2.5
+  resolution: "builder-util-runtime@npm:9.2.5"
+  dependencies:
+    debug: "npm:^4.3.4"
+    sax: "npm:^1.2.4"
+  checksum: 10/89c1e67c286ad5dd039abd56af91b3fa3d01eb62ce16c07e8d496a06eb0ed9ce015870d83dd919ffa387a32d47f9080923958672fc993154c8a184c6b1a78adc
   languageName: node
   linkType: hard
 
@@ -17494,7 +17531,7 @@ __metadata:
   resolution: "connect-example-electron-main@workspace:packages/connect-examples/electron-main-process"
   dependencies:
     "@trezor/connect": "workspace:*"
-    electron: "npm:27.3.8"
+    electron: "npm:30.3.1"
     electron-builder: "npm:24.13.3"
   languageName: unknown
   linkType: soft
@@ -17503,7 +17540,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "connect-example-electron-renderer-popup@workspace:packages/connect-examples/electron-renderer-with-popup"
   dependencies:
-    electron: "npm:27.3.8"
+    electron: "npm:30.3.1"
     electron-builder: "npm:24.13.3"
   languageName: unknown
   linkType: soft
@@ -17516,7 +17553,7 @@ __metadata:
     babel-loader: "npm:^9.1.3"
     concurrently: "npm:^8.2.2"
     copy-webpack-plugin: "npm:^12.0.2"
-    electron: "npm:27.3.8"
+    electron: "npm:30.3.1"
     electron-builder: "npm:24.13.3"
     html-webpack-plugin: "npm:^5.6.0"
     terser-webpack-plugin: "npm:^5.3.9"
@@ -19960,13 +19997,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-store@npm:^8.1.0":
-  version: 8.1.0
-  resolution: "electron-store@npm:8.1.0"
+"electron-store@npm:8.2.0":
+  version: 8.2.0
+  resolution: "electron-store@npm:8.2.0"
   dependencies:
     conf: "npm:^10.2.0"
     type-fest: "npm:^2.17.0"
-  checksum: 10/bb29f12e5649b2d163b503f99a11e43782df5de8dc0d6a0b8950bdb5250a932b90f6a671d59dc1bd982102be0f3d58f348bd4732cfa4a7769a8270b525e97121
+  checksum: 10/8bdc30100e3dc79f778783d5a1581ee955c5b348df329a9e5ded00a12c9394820528b690ad5af5910749fb3e0d4a55c4c9b2e722bdfe6ba95b9de570d6f1e9fb
   languageName: node
   linkType: hard
 
@@ -19977,11 +20014,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-updater@npm:6.1.8":
-  version: 6.1.8
-  resolution: "electron-updater@npm:6.1.8"
+"electron-updater@npm:6.3.3":
+  version: 6.3.3
+  resolution: "electron-updater@npm:6.3.3"
   dependencies:
-    builder-util-runtime: "npm:9.2.3"
+    builder-util-runtime: "npm:9.2.5"
     fs-extra: "npm:^10.1.0"
     js-yaml: "npm:^4.1.0"
     lazy-val: "npm:^1.0.5"
@@ -19989,20 +20026,20 @@ __metadata:
     lodash.isequal: "npm:^4.5.0"
     semver: "npm:^7.3.8"
     tiny-typed-emitter: "npm:^2.1.0"
-  checksum: 10/55783c3e787b59d08156399b614814233089eaff7a298bb8488a9b848e4275e3ccedfa6731fc8633ab89a8dc94fafd282a7a23c6dbf7f20ae844aa2519e78a96
+  checksum: 10/8209e007d06345658bc1544ab97b308caf8a4a2c3551bb8007ae057c389400a55aad97cdb8036e38c4edd56417f9d33e4b28b74712fe2aad677f79cd6535bdbf
   languageName: node
   linkType: hard
 
-"electron@npm:27.3.8":
-  version: 27.3.8
-  resolution: "electron@npm:27.3.8"
+"electron@npm:30.3.1":
+  version: 30.3.1
+  resolution: "electron@npm:30.3.1"
   dependencies:
     "@electron/get": "npm:^2.0.0"
-    "@types/node": "npm:^18.11.18"
+    "@types/node": "npm:^20.9.0"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10/6641233fe6f24ce35a5254a33ff98463228ff3c6b120f22c1303d93e2e51cec543b3e3f31e02407025f34ef1595af510be6239be3a6bca013067cc9dac837793
+  checksum: 10/e39ffe9f29f687c064df00fece892ca9d3bb20d54ee5ebe17fc050d0af9ef335b2bf961878f00f91ab65d4948d8ef348a528578e25bcba5094636f80675ef675
   languageName: node
   linkType: hard
 
@@ -32376,12 +32413,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openpgp@npm:^5.11.0":
-  version: 5.11.0
-  resolution: "openpgp@npm:5.11.0"
+"openpgp@npm:^5.11.2":
+  version: 5.11.2
+  resolution: "openpgp@npm:5.11.2"
   dependencies:
     asn1.js: "npm:^5.0.0"
-  checksum: 10/8976520c5e22f0af833739dfbb20b2ebdc23973f593ab045e32053a7ff075768712d7b1129bbc50ae71a65b1cfb06e3afecee69b96403166a0be937ff4c448d0
+  checksum: 10/75052f8b89aa946d2b927f2a679d57671b2da5bf3dab1a223b9ba54305635ce37a86cb2ea274d0dcd830511e3fe1bae16d85259e907f56ec31219c4367c311a8
   languageName: node
   linkType: hard
 
@@ -38928,12 +38965,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"systeminformation@npm:^5.21.24":
-  version: 5.21.24
-  resolution: "systeminformation@npm:5.21.24"
+"systeminformation@npm:^5.23.4":
+  version: 5.23.4
+  resolution: "systeminformation@npm:5.23.4"
   bin:
     systeminformation: lib/cli.js
-  checksum: 10/3796b8474c25420f2fb7dc91b55e5f30050f9eaa01351ed6cfb56569d9789e19245985a9cd65e4b9adcdf13baa5148f2a722e1792d940e8e9ab32872226a53cd
+  checksum: 10/ab2c51d9755ba9a9ece3cc67fedf7079860345b6c6e687c10d5b18d5ff48602675ef8b330accf2a1a16cef434f84caeaab00b804e451fd7e3c17868252cd3749
   conditions: (os=darwin | os=linux | os=win32 | os=freebsd | os=openbsd | os=netbsd | os=sunos | os=android)
   languageName: node
   linkType: hard
@@ -39932,9 +39969,9 @@ __metadata:
   linkType: hard
 
 "tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:^2.5.0, tslib@npm:^2.5.3, tslib@npm:^2.6.2":
-  version: 2.6.2
-  resolution: "tslib@npm:2.6.2"
-  checksum: 10/bd26c22d36736513980091a1e356378e8b662ded04204453d353a7f34a4c21ed0afc59b5f90719d4ba756e581a162ecbf93118dc9c6be5acf70aa309188166ca
+  version: 2.6.3
+  resolution: "tslib@npm:2.6.3"
+  checksum: 10/52109bb681f8133a2e58142f11a50e05476de4f075ca906d13b596ae5f7f12d30c482feb0bff167ae01cfc84c5803e575a307d47938999246f5a49d174fc558c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -16541,9 +16541,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001578, caniuse-lite@npm:^1.0.30001579, caniuse-lite@npm:^1.0.30001587":
-  version: 1.0.30001597
-  resolution: "caniuse-lite@npm:1.0.30001597"
-  checksum: 10/44a268113faeee51e249cbcb3924dc3765f26cd527a134e3bb720ed20d50abd8b9291500a88beee061cc03ae9f15ddc9045d57e30d25a98efeaff4f7bb8965c1
+  version: 1.0.30001651
+  resolution: "caniuse-lite@npm:1.0.30001651"
+  checksum: 10/fe4857b2a91a9cb77993eec9622de68bea0df17c31cb9584ca5c562f64bb3b8fda316d898aa3b1ee3ee9f7d80f6bf13c42acb09d9a56a1a6c64afaf7381472fa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

- update electron as we are running 4 months deprecated version
  -  to version 30 (newest is 31) but not available in nix register 
- update electron-updater as there is security issue
- `@sentry/electron` and `electron-store` not updated as they migrated to ESM
