### PR TITLE
fix(staking): fee reserve advice when min amount

### DIFF
--- a/packages/suite/src/hooks/wallet/useStakeEthForm.ts
+++ b/packages/suite/src/hooks/wallet/useStakeEthForm.ts
@@ -191,7 +191,7 @@ export const useStakeEthForm = ({ selectedAccount }: UseStakeFormsProps): StakeC
             if (
                 cryptoValue.gt(balanceMinusFee.minus(MIN_ETH_FOR_WITHDRAWALS)) &&
                 cryptoValue.lt(balanceMinusFee) &&
-                cryptoValue.gt(MIN_ETH_AMOUNT_FOR_STAKING)
+                cryptoValue.gte(MIN_ETH_AMOUNT_FOR_STAKING)
             ) {
                 setIsAdviceForWithdrawalWarningShown(true);
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Implemented a change to ensure the staking fee reserve advice is now shown, even when the minimum amount is typed.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/13750

## Screenshots:
![recommendation_banner](https://github.com/user-attachments/assets/33d8b87c-a955-402d-8f78-08006851ff4a)
