### PR TITLE
docs(core): Update message system docs

### DIFF
--- a/docs/features/message-system.md
+++ b/docs/features/message-system.md
@@ -6,6 +6,8 @@ Message system was implemented to allow sending emergency messages to Trezor Sui
 
 [Issue on Github](https://github.com/trezor/trezor-suite/issues/2752)
 
+[Notion for production deployment](https://www.notion.so/satoshilabs/Message-system-production-release-c0ac4275461f4755bc9050ff2de57425)
+
 ## Types of in-app messages
 
 There are multiple ways of displaying message to a user:
@@ -261,9 +263,7 @@ Structure of config, types and optionality of specific keys can be found in the 
                  // Used only for feature
                 "feature": [
                     {
-                        "domain": [
-                          "coinjoin"
-                        ],
+                        "domain": "coinjoin",
                         "flag": false
                     }
                 ]


### PR DESCRIPTION
- add a link to notion page (for internal users only)
- fix feature domain
  - from code it does not seem it supports an array of domains, [see here](https://github.com/trezor/trezor-suite/blob/8e34af745877441eba83c14b879494457753dd68/suite-common/message-system/src/messageSystemSelectors.ts#L84-L86)