### PR TITLE
fix(ci): connect release node env

### DIFF
--- a/.github/actions/release-connect/action.yml
+++ b/.github/actions/release-connect/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: "Configures if to upload built artifacts"
     type: string
     required: false
+  nodeEnv:
+    description: "Node environment"
+    type: string
+    required: true
 
 runs:
   using: "composite"
@@ -58,6 +62,8 @@ runs:
 
     - name: Build connect-web
       shell: bash
+      env:
+        NODE_ENV: ${{ inputs.nodeEnv }}
       run: |
         yarn workspace @trezor/connect-web build
 
@@ -67,11 +73,15 @@ runs:
 
     - name: Build connect-iframe
       shell: bash
+      env:
+        NODE_ENV: ${{ inputs.nodeEnv }}
       run: |
         yarn workspace @trezor/connect-iframe build
 
     - name: Build connect-popup
       shell: bash
+      env:
+        NODE_ENV: ${{ inputs.nodeEnv }}
       run: |
         yarn workspace @trezor/connect-popup build
 

--- a/.github/workflows/release-connect-v9-staging.yml
+++ b/.github/workflows/release-connect-v9-staging.yml
@@ -68,6 +68,7 @@ jobs:
           serverPath: ${{ needs.extract-version.outputs.version }}
           buildArtifacts: "true"
           uploadArtifacts: "true"
+          nodeEnv: "production"
 
   # This job deploys to staging-connect.trezor.io/9
   deploy-staging-v9:
@@ -94,5 +95,7 @@ jobs:
           awsRegion: "eu-central-1"
           serverHostname: "staging-connect.trezor.io"
           serverPath: "9"
-          buildArtifacts: "true"
-          uploadArtifacts: "true"
+          nodeEnv: "production"
+          # don't upload artifacts in both jobs, this causes a conflict
+          buildArtifacts: "false"
+          uploadArtifacts: "false"

--- a/.github/workflows/test-connect-popup.yml
+++ b/.github/workflows/test-connect-popup.yml
@@ -64,6 +64,7 @@ jobs:
           serverPath: "connect/${{ needs.extract-branch.outputs.branch }}"
           uploadArtifacts: "true"
           buildArtifacts: "true"
+          nodeEnv: "development"
 
   methods:
     needs: [build-deploy]


### PR DESCRIPTION
## Description

With the move to GitHub CI, the `NODE_ENV` environment variable wasn’t being set correctly on Connect, which was causing problems with our analytics and potentially other environment-dependent features. 
This PR ensures the environment is being set to production for releases and development for testing. 

Also, this PR addresses a conflict in the staging action where build artifacts were being uploaded twice, causing it to fail. 