### PR TITLE
transport usb api - leaking abort listeners

### DIFF
--- a/JestCustomEnv.js
+++ b/JestCustomEnv.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
 const NodeEnvironment = require('jest-environment-node').default;
 
 class CustomEnvironment extends NodeEnvironment {

--- a/package.json
+++ b/package.json
@@ -141,6 +141,8 @@
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "jest": "29.7.0",
+        "jest-environment-jsdom": "29.7.0",
+        "jest-environment-node": "29.7.0",
         "jest-expo": "^50.0.2",
         "metro-react-native-babel-preset": "0.77.0",
         "nx": "^18.0.3",

--- a/packages/address-validator/package.json
+++ b/packages/address-validator/package.json
@@ -19,7 +19,6 @@
         "lodash": "^4.17.15"
     },
     "devDependencies": {
-        "jest-environment-jsdom": "29.7.0",
         "rimraf": "^6.0.1"
     }
 }

--- a/packages/transport/jest.config.js
+++ b/packages/transport/jest.config.js
@@ -6,4 +6,5 @@ module.exports = {
     collectCoverage: true,
     collectCoverageFrom: ['src/**/*.ts'],
     watchPathIgnorePatterns: ['<rootDir>/libDev', '<rootDir>/lib'],
+    testEnvironment: '../../JestCustomEnv.js',
 };

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -58,6 +58,7 @@
         "@types/sharedworker": "^0.0.111",
         "@types/w3c-web-usb": "^1.0.10",
         "jest": "29.7.0",
+        "jest-environment-node": "^29.7.0",
         "ts-node": "^10.9.1",
         "tsx": "^4.16.3"
     },

--- a/packages/transport/tests/apiUdp.test.ts
+++ b/packages/transport/tests/apiUdp.test.ts
@@ -43,10 +43,18 @@ describe('api/udp', () => {
     });
 
     it('write aborted', async () => {
+        let listeners = 0;
+
         jest.spyOn(UDP, 'createSocket').mockImplementation(() =>
             createUdpSocketMock({
                 send: (...args: any[]) => {
                     setTimeout(() => args[3](), 200);
+                },
+                addListener: () => {
+                    listeners++;
+                },
+                removeListener: () => {
+                    listeners--;
                 },
             }),
         );
@@ -61,6 +69,7 @@ describe('api/udp', () => {
         const result = await promise;
         if (result.success) throw new Error('Unexpected success');
         expect(result.error).toContain('Aborted by signal');
+        expect(listeners).toBe(0);
     });
 
     it('enumerate aborted', async () => {

--- a/packages/utils/jest.config.js
+++ b/packages/utils/jest.config.js
@@ -4,5 +4,5 @@ module.exports = {
     ...baseConfig,
     collectCoverage: true,
     collectCoverageFrom: ['src/**/*.ts'],
-    testEnvironment: './JestCustomEnv.js',
+    testEnvironment: '../../JestCustomEnv.js',
 };

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -34,7 +34,6 @@
         "tslib": "^2.6.2"
     },
     "devDependencies": {
-        "jest-environment-node": "^29.7.0",
         "tsx": "^4.16.3"
     },
     "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10579,7 +10579,6 @@ __metadata:
     cbor-js: "npm:^0.1.0"
     crc: "npm:^3.8.0"
     groestl-hash-js: "npm:1.0.0"
-    jest-environment-jsdom: "npm:29.7.0"
     jssha: "npm:2.3.1"
     lodash: "npm:^4.17.15"
     rimraf: "npm:^6.0.1"
@@ -11714,6 +11713,7 @@ __metadata:
     "@types/w3c-web-usb": "npm:^1.0.10"
     cross-fetch: "npm:^4.0.0"
     jest: "npm:29.7.0"
+    jest-environment-node: "npm:^29.7.0"
     long: "npm:^4.0.0"
     protobufjs: "npm:7.2.6"
     ts-node: "npm:^10.9.1"
@@ -11754,7 +11754,6 @@ __metadata:
   resolution: "@trezor/utils@workspace:packages/utils"
   dependencies:
     bignumber.js: "npm:^9.1.2"
-    jest-environment-node: "npm:^29.7.0"
     tsx: "npm:^4.16.3"
   peerDependencies:
     tslib: ^2.6.2
@@ -26438,7 +26437,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-environment-node@npm:^29.6.3, jest-environment-node@npm:^29.7.0":
+"jest-environment-node@npm:29.7.0, jest-environment-node@npm:^29.6.3, jest-environment-node@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-environment-node@npm:29.7.0"
   dependencies:
@@ -39756,6 +39755,8 @@ __metadata:
     eslint-plugin-react: "npm:^7.33.2"
     eslint-plugin-react-hooks: "npm:^4.6.0"
     jest: "npm:29.7.0"
+    jest-environment-jsdom: "npm:29.7.0"
+    jest-environment-node: "npm:29.7.0"
     jest-expo: "npm:^50.0.2"
     metro-react-native-babel-preset: "npm:0.77.0"
     nx: "npm:^18.0.3"


### PR DESCRIPTION
- cherry-picked https://github.com/trezor/trezor-suite/pull/13570/commits originaly created by @szymonlesisz 
- added some more tests tweaking. now unit tests in transport package would fail should node emit "Error: MaxListenersExceededWarning detected." warning.

the question now - packages/transport/JestCustomEnv.js is now duplicated (the same file is in pacakges/utils). where do we put it instead?[ root?]([608b955](https://github.com/trezor/trezor-suite/pull/13810/commits/608b95595378c44be8f52aee3a3c135cbd8a8c18))