### PR TITLE
chore(mobile): minor graph improvements

### DIFF
--- a/suite-common/graph/src/tests/balanceHistoryUtils.test.ts
+++ b/suite-common/graph/src/tests/balanceHistoryUtils.test.ts
@@ -1,3 +1,5 @@
+import { TokenAddress } from '@suite-common/wallet-types';
+
 import { btcAccountBalanceHistoryResult, btcAccountTransactions } from './__fixtures__/btc';
 import { xrpAccountTransactions, xrpBalanceHistoryResult } from './__fixtures__/xrp';
 import {
@@ -110,7 +112,9 @@ describe('Account balance movement history', () => {
                 item => item.time >= from && item.time <= to,
             );
 
-            expect(balanceHistory.tokens[token]).toMatchObject(filteredBalanceHistory);
+            expect(balanceHistory.tokens[token as TokenAddress]).toMatchObject(
+                filteredBalanceHistory,
+            );
         }
     });
 });

--- a/suite-common/graph/src/types.ts
+++ b/suite-common/graph/src/types.ts
@@ -73,7 +73,7 @@ export type AccountHistoryMovementItem = {
 export type AccountHistoryMovement = {
     main: AccountHistoryMovementItem[];
     tokens: {
-        [contract: string]: AccountHistoryMovementItem[];
+        [contract: TokenAddress]: AccountHistoryMovementItem[];
     };
 };
 

--- a/suite-native/graph/src/components/Graph.tsx
+++ b/suite-native/graph/src/components/Graph.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { PixelRatio } from 'react-native';
 
 import * as Haptics from 'expo-haptics';
 
@@ -55,6 +56,14 @@ const graphStyle = prepareNativeStyle(_ => ({
 
 const triggerHaptics = () => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+};
+
+const BASE_LINE_THICKNESS = 1.5;
+
+const getAccessibilityLineThickness = () => {
+    const fontScale = PixelRatio.getFontScale();
+
+    return Math.max(BASE_LINE_THICKNESS, BASE_LINE_THICKNESS * fontScale);
 };
 
 export const Graph = <TGraphPoint extends FiatGraphPoint>({
@@ -139,7 +148,7 @@ export const Graph = <TGraphPoint extends FiatGraphPoint>({
                 EventComponent={TransactionEvent}
                 EventTooltipComponent={TransactionEventTooltip}
                 onEventHover={triggerHaptics}
-                lineThickness={2}
+                lineThickness={getAccessibilityLineThickness()}
                 loading={delayedLoading}
                 loadingLineColor={colors.borderDashed}
                 blurOverlay={showBlurredGraph}

--- a/suite-native/graph/src/components/TransactionEventTooltip.tsx
+++ b/suite-native/graph/src/components/TransactionEventTooltip.tsx
@@ -55,6 +55,8 @@ const TooltipContainerStyle = prepareNativeStyle<{ x: number; y: number }>((_, {
 
 const TooltipCardStyle = prepareNativeStyle(utils => ({
     paddingVertical: 1.5 * utils.spacings.small,
+    // fade in/out animation doesn't work for elevation (shadow) on Android
+    elevation: 0,
 }));
 
 const TokenAmountTooltipFormatter = ({

--- a/suite-native/graph/src/hooks.ts
+++ b/suite-native/graph/src/hooks.ts
@@ -73,7 +73,7 @@ const checkAndReportGraphError = (error: string | null) => {
 export const useGraphForSingleAccount = ({
     accountKey,
     fiatCurrency,
-    tokensFilter = [],
+    tokensFilter,
     hideMainAccount = false,
 }: CommonUseGraphParams & Omit<AccountItem, 'coin' | 'descriptor'>) => {
     const dispatch = useDispatch();


### PR DESCRIPTION

## Description

Some minor improvements to graph visual:
- disable elevation for balance popup on Android because it looks ugly with animation
- make line little-bit thinner to match Figma more closely + reflect accessibility font-size settings

![Simulator Screenshot - iPhone 14 Pro - 2024-08-14 at 15 16 04](https://github.com/user-attachments/assets/ebbd1b60-d546-4f5f-8e85-157817f9ce74)
![Simulator Screenshot - iPhone 14 Pro - 2024-08-14 at 15 16 14](https://github.com/user-attachments/assets/1817509e-4e4e-41e1-80b8-bd8c99f4cda8)



## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
