### PR TITLE
fix(components): Align ButtonGroup height consistently

### DIFF
--- a/packages/components/src/components/buttons/ButtonGroup/ButtonGroup.tsx
+++ b/packages/components/src/components/buttons/ButtonGroup/ButtonGroup.tsx
@@ -11,7 +11,7 @@ const Container = styled.div<{
 }>`
     position: relative;
     display: flex;
-    align-items: center;
+    align-items: stretch;
 
     button {
         border-radius: 0;

--- a/packages/components/src/components/buttons/ButtonGroup/ButtonGroups.stories.tsx
+++ b/packages/components/src/components/buttons/ButtonGroup/ButtonGroups.stories.tsx
@@ -65,6 +65,14 @@ export const ButtonGroups: StoryObj = {
                 <IconButton icon="TWO_USERS" />
                 <IconButton icon="BACKEND" />
             </ButtonGroup>
+
+            <ButtonGroup>
+                <Button>Button</Button>
+                <Button>
+                    A very long Lorem ipsum dolor sit amet, which wraps to many lines, but the
+                    buttons have consistent height
+                </Button>
+            </ButtonGroup>
         </StoryColumn>
     ),
 };


### PR DESCRIPTION
## Description

Change ButtonGroup behavior, so that all its children have the height of the tallest one. 

This is required to fix a bug in Settings > Device > Homescreen, where two buttons in a ButtonGroup have a different height and their edges are misaligned.

Add a new storybook entry to demonstrate it.

## Related Issue

Resolve #13583

## Screenshots:

**Storybook before:**

![sb be4](https://github.com/user-attachments/assets/8ca6dccc-daf2-42b8-9cd4-7ca0d131810c)

**Storybook after:**

![sb after](https://github.com/user-attachments/assets/3bb9c991-9d82-4e9b-ace6-1f20ee7d53de)

**Settings > Device > Homescreen before:**

![app be4](https://github.com/user-attachments/assets/89cce7d3-7d26-4612-ab28-981a910d284d)

**Settings > Device > Homescreen after:**

![app after](https://github.com/user-attachments/assets/8edb7f95-a17a-4a30-a441-64ed49e8a839)

**All other usages of ButtonGroup (visually unchanged)** 
 
![TokenRow](https://github.com/user-attachments/assets/f31d48b1-910e-472b-a82b-a1751fb4004a)
![PageHeader](https://github.com/user-attachments/assets/6c1e86a8-e3df-415b-bd68-3a01f5f0f784)
