### PR TITLE
fix(suite): Disable Check device button when disconnected

### DIFF
--- a/packages/suite/src/views/settings/SettingsDevice/AuthenticateDevice.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/AuthenticateDevice.tsx
@@ -10,7 +10,11 @@ import {
 } from 'src/components/suite';
 import { useDispatch } from 'src/hooks/suite';
 
-export const AuthenticateDevice = () => {
+interface AuthenticateDeviceProps {
+    isDeviceLocked: boolean;
+}
+
+export const AuthenticateDevice = ({ isDeviceLocked }: AuthenticateDeviceProps) => {
     const dispatch = useDispatch();
 
     const handleClick = () => dispatch(openModal({ type: 'authenticate-device' }));
@@ -23,7 +27,7 @@ export const AuthenticateDevice = () => {
                 buttonLink={HELP_CENTER_DEVICE_AUTHENTICATION}
             />
             <ActionColumn>
-                <ActionButton variant="secondary" onClick={handleClick}>
+                <ActionButton variant="secondary" onClick={handleClick} isDisabled={isDeviceLocked}>
                     <Translation id="TR_CHECK_ORIGIN" />
                 </ActionButton>
             </ActionColumn>

--- a/packages/suite/src/views/settings/SettingsDevice/SettingsDevice.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/SettingsDevice.tsx
@@ -158,7 +158,9 @@ export const SettingsDevice = () => {
                         {pinProtection && <ChangePin isDeviceLocked={isDeviceLocked} />}
                         <Passphrase isDeviceLocked={isDeviceLocked} />
                         {safetyChecks && <SafetyChecks isDeviceLocked={isDeviceLocked} />}
-                        {supportsDeviceAuthentication && <AuthenticateDevice />}
+                        {supportsDeviceAuthentication && (
+                            <AuthenticateDevice isDeviceLocked={isDeviceLocked} />
+                        )}
                     </SettingsSection>
 
                     <SettingsSection title={<Translation id="TR_PERSONALIZATION" />} icon="PALETTE">


### PR DESCRIPTION
Check device button, which is available for T2B1 and T3T1, only works when the device is connected, otherwise it gets you stuck in infinite loader, so disable it when the device is disconnected. 

## Related Issue

Resolve #11643 

## Screenshots:

### Connected (T3T1):

![connected](https://github.com/user-attachments/assets/b729419b-73ea-4d56-ab5c-04c826a349c1)


### Disconnected (T3T1):

![disconnected](https://github.com/user-attachments/assets/bd271286-8dee-4c8d-b4ca-a87394d197fb)
