### PR TITLE
fix(suite): Disable Activate Coins button when disconnected

### DIFF
--- a/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
@@ -6,7 +6,7 @@ import {
     startDiscoveryThunk,
     selectDeviceModel,
 } from '@suite-common/wallet-core';
-import { Button, motionEasing } from '@trezor/components';
+import { Button, motionEasing, Tooltip } from '@trezor/components';
 import { DeviceModelInternal } from '@trezor/connect';
 import type { Network } from 'src/types/wallet';
 
@@ -31,8 +31,9 @@ import { FirmwareTypeSuggestion } from './FirmwareTypeSuggestion';
 import { spacingsPx } from '@trezor/theme';
 import { selectSuiteFlags } from '../../../reducers/suite/suiteReducer';
 
-const StyledButton = styled(Button)`
+const DiscoveryButtonWrapper = styled.div`
     margin-top: ${spacingsPx.xl};
+    width: fit-content;
 `;
 
 const StyledSettingsSection = styled(SettingsSection)`
@@ -91,7 +92,8 @@ export const SettingsCoins = () => {
     const { mainnets, testnets, enabledNetworks, setEnabled } = useEnabledNetworks();
     const deviceSupportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
     const deviceModel = useSelector(selectDeviceModel);
-    const { device } = useDevice();
+    const { device, isLocked } = useDevice();
+    const isDeviceLocked = !!device && isLocked();
     const dispatch = useDispatch();
     const { isDiscoveryRunning } = useDiscovery();
 
@@ -197,9 +199,19 @@ export const SettingsCoins = () => {
             <AnimatePresence>
                 {isDiscoveryButtonVisible && (
                     <motion.div {...animation} key="discover-button">
-                        <StyledButton onClick={startDiscovery}>
-                            <Translation id="TR_DISCOVERY_NEW_COINS" />
-                        </StyledButton>
+                        <DiscoveryButtonWrapper>
+                            <Tooltip
+                                content={
+                                    isDeviceLocked ? (
+                                        <Translation id="TR_CONNECT_YOUR_DEVICE" />
+                                    ) : null
+                                }
+                            >
+                                <Button onClick={startDiscovery} isDisabled={isDeviceLocked}>
+                                    <Translation id="TR_DISCOVERY_NEW_COINS" />
+                                </Button>
+                            </Tooltip>
+                        </DiscoveryButtonWrapper>
                     </motion.div>
                 )}
             </AnimatePresence>


### PR DESCRIPTION
When you select new coins but disconnect device before discovery, the button stays clickable but does not work.

## Description

- disable the button when there is discovery pending but device is disconnected
- add a tooltip
  - the tooltip is just my improvement idea - for consistency with the coin buttons
  - there are no design requirements AFAIK
  - ofc I am not a copywriter, so I chose an existing translation string 
  - if you think I was too bold choosing a tooltip message, I can remove it
- incidental fix of eslint warning for design system overloading

## Related Issue

Part 1/2 of #12074

## Screenshots:

discovery (Activate coins) button when disconnected and hovered on:
![ActivateCoins disconnected](https://github.com/user-attachments/assets/d2b0fd63-b35b-4e72-ade1-7fe261790a20)
