### PR TITLE
fix(mobile): reverse order of transactions

### DIFF
--- a/suite-native/transactions/src/components/TransactionsList/TransactionList.tsx
+++ b/suite-native/transactions/src/components/TransactionsList/TransactionList.tsx
@@ -82,7 +82,7 @@ const sortKeysPendingFirst = (a: string, b: string) => {
     const dateA = new Date(a);
     const dateB = new Date(b);
 
-    return dateA.getTime() - dateB.getTime();
+    return dateB.getTime() - dateA.getTime();
 };
 
 const sortPendingTransactions = (a: WalletAccountTransaction, b: WalletAccountTransaction) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Transactions was sorted from oldest on top but we want newest on top.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
