### PR TITLE
feat(suite-native): coin enabling init setup flow PoC

### DIFF
--- a/suite-native/app/src/navigation/RootStackNavigator.tsx
+++ b/suite-native/app/src/navigation/RootStackNavigator.tsx
@@ -21,6 +21,7 @@ import { AuthorizeDeviceStackNavigator } from '@suite-native/module-authorize-de
 import { AddCoinAccountStackNavigator } from '@suite-native/module-add-accounts';
 import { DeviceInfoModalScreen, useHandleDeviceConnection } from '@suite-native/device';
 import { SendStackNavigator } from '@suite-native/module-send';
+import { CoinEnablingInitScreen } from '@suite-native/coin-enabling';
 
 import { AppTabNavigator } from './AppTabNavigator';
 
@@ -76,6 +77,12 @@ export const RootStackNavigator = () => {
                 name={RootStackRoutes.AddCoinAccountStack}
                 component={AddCoinAccountStackNavigator}
             />
+            <RootStack.Group screenOptions={{ animation: 'slide_from_bottom' }}>
+                <RootStack.Screen
+                    name={RootStackRoutes.CoinEnablingInit}
+                    component={CoinEnablingInitScreen}
+                />
+            </RootStack.Group>
             <RootStack.Screen name={RootStackRoutes.ReceiveModal} component={ReceiveModalScreen} />
             <RootStack.Screen name={RootStackRoutes.DeviceInfo} component={DeviceInfoModalScreen} />
             <RootStack.Screen

--- a/suite-native/coin-enabling/package.json
+++ b/suite-native/coin-enabling/package.json
@@ -11,6 +11,8 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
+        "@mobily/ts-belt": "^3.13.1",
+        "@react-navigation/native": "6.1.17",
         "@reduxjs/toolkit": "1.9.5",
         "@suite-common/icons": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
@@ -20,11 +22,14 @@
         "@suite-native/discovery": "workspace:*",
         "@suite-native/feature-flags": "workspace:*",
         "@suite-native/intl": "workspace:*",
+        "@suite-native/navigation": "workspace:*",
         "@suite-native/theme": "workspace:*",
         "@suite-native/toasts": "workspace:*",
         "@trezor/styles": "workspace:*",
         "react": "18.2.0",
         "react-native": "0.74.1",
+        "react-native-reanimated": "3.11.0",
+        "react-native-safe-area-context": "4.10.3",
         "react-native-svg": "15.3.0",
         "react-redux": "8.0.7"
     }

--- a/suite-native/coin-enabling/src/components/DiscoveryCoinsFilter.tsx
+++ b/suite-native/coin-enabling/src/components/DiscoveryCoinsFilter.tsx
@@ -1,4 +1,6 @@
-import { useEffect } from 'react';
+import { useCallback } from 'react';
+
+import { useFocusEffect } from '@react-navigation/native';
 
 import { VStack, Text } from '@suite-native/atoms';
 import { NetworkSymbol } from '@suite-common/wallet-config';
@@ -9,16 +11,20 @@ import { useCoinEnabling } from '../hooks/useCoinEnabling';
 import { NetworkSymbolSwitchItem } from './NetworkSymbolSwitchItem';
 
 type DiscoveryCoinsFilterProps = {
-    isToastEnabled?: boolean;
+    allowDeselectLastCoin?: boolean; // If true, the last coin can be deselected
 };
 
-export const DiscoveryCoinsFilter = ({ isToastEnabled = true }: DiscoveryCoinsFilterProps) => {
+export const DiscoveryCoinsFilter = ({
+    allowDeselectLastCoin = false,
+}: DiscoveryCoinsFilterProps) => {
     const { enabledNetworkSymbols, availableNetworks, applyDiscoveryChanges } = useCoinEnabling();
 
-    useEffect(() => {
-        // This will run when the component is unmounted (leaving the screen) and trigger the applyDiscoveryChanges function
-        return () => applyDiscoveryChanges();
-    }, [applyDiscoveryChanges]);
+    useFocusEffect(
+        useCallback(() => {
+            // run on leaving the screen
+            return () => applyDiscoveryChanges();
+        }, [applyDiscoveryChanges]),
+    );
 
     const uniqueNetworkSymbols = [...new Set(availableNetworks.map(n => n.symbol))];
 
@@ -29,7 +35,7 @@ export const DiscoveryCoinsFilter = ({ isToastEnabled = true }: DiscoveryCoinsFi
                     key={networkSymbol}
                     networkSymbol={networkSymbol}
                     isEnabled={enabledNetworkSymbols.includes(networkSymbol)}
-                    isToastEnabled={isToastEnabled}
+                    allowDeselectLastCoin={allowDeselectLastCoin}
                 />
             ))}
             <VStack paddingTop="small" paddingBottom="extraLarge" alignItems="center">

--- a/suite-native/coin-enabling/src/components/NetworkSymbolSwitchItem.tsx
+++ b/suite-native/coin-enabling/src/components/NetworkSymbolSwitchItem.tsx
@@ -92,7 +92,6 @@ export const NetworkSymbolSwitchItem = ({
                         values={{ coin: _ => name }}
                     />
                 ),
-                icon: 'check',
             });
         }
         dispatch(toggleEnabledDiscoveryNetworkSymbol(networkSymbol));

--- a/suite-native/coin-enabling/src/components/NetworkSymbolSwitchItem.tsx
+++ b/suite-native/coin-enabling/src/components/NetworkSymbolSwitchItem.tsx
@@ -1,5 +1,5 @@
 import { TouchableOpacity, View } from 'react-native';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { CryptoIcon } from '@suite-common/icons';
 import { networks, NetworkSymbol } from '@suite-common/wallet-config';
@@ -9,13 +9,14 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { useToast } from '@suite-native/toasts';
 import { Translation } from '@suite-native/intl';
 import { useAlert } from '@suite-native/alerts';
+import { selectIsDeviceConnected } from '@suite-common/wallet-core';
 
 import { useCoinEnabling } from '../hooks/useCoinEnabling';
 
 type NetworkSymbolProps = {
     networkSymbol: NetworkSymbol;
     isEnabled: boolean;
-    isToastEnabled: boolean;
+    allowDeselectLastCoin: boolean;
 };
 
 const wrapperStyle = prepareNativeStyle<{ isEnabled: boolean }>((utils, { isEnabled }) => ({
@@ -43,9 +44,10 @@ const iconWrapperStyle = prepareNativeStyle(utils => ({
 export const NetworkSymbolSwitchItem = ({
     networkSymbol,
     isEnabled,
-    isToastEnabled,
+    allowDeselectLastCoin,
 }: NetworkSymbolProps) => {
     const dispatch = useDispatch();
+    const isDeviceConnected = useSelector(selectIsDeviceConnected);
     const { applyStyle } = useNativeStyles();
     const { showToast } = useToast();
     const { enabledNetworkSymbols } = useCoinEnabling();
@@ -67,6 +69,7 @@ export const NetworkSymbolSwitchItem = ({
     const handleEnabledChange = (isChecked: boolean) => {
         if (
             !isChecked &&
+            !allowDeselectLastCoin &&
             enabledNetworkSymbols.length === 1 &&
             enabledNetworkSymbols.includes(networkSymbol)
         ) {
@@ -75,7 +78,7 @@ export const NetworkSymbolSwitchItem = ({
             return;
         }
 
-        if (isToastEnabled) {
+        if (!isDeviceConnected) {
             showToast({
                 variant: 'default',
                 message: isChecked ? (

--- a/suite-native/coin-enabling/src/index.ts
+++ b/suite-native/coin-enabling/src/index.ts
@@ -1,3 +1,4 @@
 export * from './components/DiscoveryCoinsFilter';
 export * from './components/BtcOnlyCoinEnablingContent';
 export * from './hooks/useCoinEnabling';
+export * from './screens/CoinEnablingInitScreen';

--- a/suite-native/coin-enabling/src/screens/CoinEnablingInitScreen.tsx
+++ b/suite-native/coin-enabling/src/screens/CoinEnablingInitScreen.tsx
@@ -1,0 +1,77 @@
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useDispatch } from 'react-redux';
+import Animated, { SlideInDown, SlideOutDown } from 'react-native-reanimated';
+import { useCallback } from 'react';
+
+import { A } from '@mobily/ts-belt';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
+
+import { Screen } from '@suite-native/navigation';
+import { Box, Button, Text, VStack } from '@suite-native/atoms';
+import { setIsCoinEnablingInitFinished } from '@suite-native/discovery';
+import { Translation } from '@suite-native/intl';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+
+import { DiscoveryCoinsFilter } from '../components/DiscoveryCoinsFilter';
+import { useCoinEnabling } from '../hooks/useCoinEnabling';
+
+const buttonStyle = prepareNativeStyle<{ bottomInset: number }>((utils, { bottomInset }) => ({
+    bottom: bottomInset,
+    left: 0,
+    right: 0,
+    paddingHorizontal: utils.spacings.medium,
+}));
+
+export const CoinEnablingInitScreen = () => {
+    const dispatch = useDispatch();
+    const navigation = useNavigation();
+
+    const { applyStyle } = useNativeStyles();
+    const { bottom: bottomInset } = useSafeAreaInsets();
+    const { enabledNetworkSymbols } = useCoinEnabling();
+
+    const handleSave = () => {
+        dispatch(setIsCoinEnablingInitFinished(true));
+        navigation.goBack();
+    };
+
+    useFocusEffect(
+        useCallback(() => {
+            // mark coin init as finished if there are enabled coins on leaving the screen
+            return () => {
+                if (enabledNetworkSymbols.length > 0) {
+                    dispatch(setIsCoinEnablingInitFinished(true));
+                }
+            };
+        }, [dispatch, enabledNetworkSymbols.length]),
+    );
+
+    return (
+        <>
+            <Screen>
+                <VStack paddingHorizontal="small">
+                    <VStack paddingBottom="extraLarge">
+                        <Text variant="titleSmall" color="textSubdued">
+                            <Translation id="moduleHome.coinEnabling.title" />
+                        </Text>
+                        <Text color="textSubdued">
+                            <Translation id="moduleHome.coinEnabling.subtitle" />
+                        </Text>
+                    </VStack>
+                    <Box flex={1}>
+                        <DiscoveryCoinsFilter allowDeselectLastCoin={true} />
+                    </Box>
+                </VStack>
+            </Screen>
+            <Box style={applyStyle(buttonStyle, { bottomInset })}>
+                {A.isNotEmpty(enabledNetworkSymbols) && (
+                    <Animated.View entering={SlideInDown} exiting={SlideOutDown}>
+                        <Button onPress={handleSave}>
+                            <Translation id="moduleHome.coinEnabling.button" />
+                        </Button>
+                    </Animated.View>
+                )}
+            </Box>
+        </>
+    );
+};

--- a/suite-native/coin-enabling/tsconfig.json
+++ b/suite-native/coin-enabling/tsconfig.json
@@ -14,6 +14,7 @@
         { "path": "../discovery" },
         { "path": "../feature-flags" },
         { "path": "../intl" },
+        { "path": "../navigation" },
         { "path": "../theme" },
         { "path": "../toasts" },
         { "path": "../../packages/styles" }

--- a/suite-native/discovery/src/discoveryConfigSlice.ts
+++ b/suite-native/discovery/src/discoveryConfigSlice.ts
@@ -29,6 +29,7 @@ type DiscoveryInfo = {
 type DiscoveryConfigState = {
     areTestnetsEnabled: boolean;
     discoveryInfo: DiscoveryInfo | null;
+    isCoinEnablingInitFinished: boolean;
     enabledDiscoveryNetworkSymbols: NetworkSymbol[];
 };
 
@@ -39,11 +40,13 @@ export type DiscoveryConfigSliceRootState = {
 const discoveryConfigInitialState: DiscoveryConfigState = {
     areTestnetsEnabled: false,
     discoveryInfo: null,
+    isCoinEnablingInitFinished: false,
     enabledDiscoveryNetworkSymbols: [],
 };
 
 export const discoveryConfigPersistWhitelist: Array<keyof DiscoveryConfigState> = [
     'areTestnetsEnabled',
+    'isCoinEnablingInitFinished',
     'enabledDiscoveryNetworkSymbols',
 ];
 
@@ -68,6 +71,12 @@ export const discoveryConfigSlice = createSlice({
                 // If the network is not in the list, add it
                 state.enabledDiscoveryNetworkSymbols.push(networkSymbol);
             }
+        },
+        setEnabledDiscoveryNetworkSymbols: (state, { payload }: PayloadAction<NetworkSymbol[]>) => {
+            state.enabledDiscoveryNetworkSymbols = payload;
+        },
+        setIsCoinEnablingInitFinished: (state, { payload }: PayloadAction<boolean>) => {
+            state.isCoinEnablingInitFinished = payload;
         },
     },
 });
@@ -109,6 +118,17 @@ export const selectDiscoveryNetworkSymbols = memoizeWithArgs(
     { size: 2 },
 );
 
+export const selectIsCoinEnablingInitFinished = (
+    state: DiscoveryConfigSliceRootState & FeatureFlagsRootState,
+) => {
+    const isCoinEnablingActive = selectIsFeatureFlagEnabled(
+        state,
+        FeatureFlag.IsCoinEnablingActive,
+    );
+
+    return isCoinEnablingActive ? state.discoveryConfig.isCoinEnablingInitFinished : true;
+};
+
 export const selectEnabledDiscoveryNetworkSymbols = memoizeWithArgs(
     (
         state: DiscoveryConfigSliceRootState & DeviceRootState & FeatureFlagsRootState,
@@ -132,6 +152,11 @@ export const selectEnabledDiscoveryNetworkSymbols = memoizeWithArgs(
     { size: 2 },
 );
 
-export const { toggleAreTestnetsEnabled, setDiscoveryInfo, toggleEnabledDiscoveryNetworkSymbol } =
-    discoveryConfigSlice.actions;
+export const {
+    toggleAreTestnetsEnabled,
+    setDiscoveryInfo,
+    toggleEnabledDiscoveryNetworkSymbol,
+    setEnabledDiscoveryNetworkSymbols,
+    setIsCoinEnablingInitFinished,
+} = discoveryConfigSlice.actions;
 export const discoveryConfigReducer = discoveryConfigSlice.reducer;

--- a/suite-native/discovery/src/discoverySelectors.ts
+++ b/suite-native/discovery/src/discoverySelectors.ts
@@ -33,6 +33,7 @@ import {
     DiscoveryConfigSliceRootState,
     selectDiscoverySupportedNetworks,
     selectEnabledDiscoveryNetworkSymbols,
+    selectIsCoinEnablingInitFinished,
 } from './discoveryConfigSlice';
 import { getNetworksWithUnfinishedDiscovery } from './utils';
 
@@ -119,6 +120,7 @@ export const selectCanRunDiscoveryForDevice = (
         return false;
     }
 
+    const isCoinEnablingInitFinished = selectIsCoinEnablingInitFinished(state);
     const discovery = selectDeviceDiscovery(state);
     const deviceModel = selectDeviceModel(state);
     const deviceFwVersion = selectDeviceFirmwareVersion(state);
@@ -135,7 +137,8 @@ export const selectCanRunDiscoveryForDevice = (
     const hasDeviceAuthConfirm = selectHasDeviceAuthConfirm(state);
     const hasDeviceAuthFailed = selectDeviceAuthFailed(state);
 
-    const canRunDiscovery =
+    return (
+        isCoinEnablingInitFinished &&
         !discovery &&
         isDeviceConnectedAndAuthorized &&
         !isPortfolioTrackerDevice &&
@@ -143,7 +146,6 @@ export const selectCanRunDiscoveryForDevice = (
         isDeviceUnlocked &&
         !hasDeviceAuthConfirm &&
         !hasDeviceAuthFailed &&
-        isDeviceFirmwareVersionSupported;
-
-    return canRunDiscovery;
+        isDeviceFirmwareVersionSupported
+    );
 };

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -81,6 +81,12 @@ export const en = {
                 enable: 'Enable',
             },
         },
+        coinEnabling: {
+            title: 'Choose coins you want to use with your Trezor.',
+            subtitle:
+                'The more coins are enabled, the more it takes to load the app. You can always add more later.',
+            button: 'Confirm selection',
+        },
     },
     accountList: {
         numberOfTokens: '+{numberOfTokens} tokens',
@@ -525,8 +531,8 @@ export const en = {
             bottomNote:
                 'Didn’t find what you’re looking for? Check if it’s not a token running one of the listed coin’s network.',
             toasts: {
-                coinEnabled: '<coin></coin> accounts will load for\nconnected Trezor.',
-                coinDisabled: '<coin></coin> accounts will be removed',
+                coinEnabled: '<coin></coin> will load once you connect Trezor.',
+                coinDisabled: '<coin></coin> disabled',
             },
             btcOnly: {
                 title: 'This device is BTC only.',

--- a/suite-native/module-home/package.json
+++ b/suite-native/module-home/package.json
@@ -12,6 +12,7 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
+        "@mobily/ts-belt": "^3.13.1",
         "@react-navigation/native": "6.1.17",
         "@react-navigation/native-stack": "6.9.26",
         "@reduxjs/toolkit": "1.9.5",
@@ -22,6 +23,7 @@
         "@suite-native/atoms": "workspace:*",
         "@suite-native/biometrics": "workspace:*",
         "@suite-native/blockchain": "workspace:*",
+        "@suite-native/coin-enabling": "workspace:*",
         "@suite-native/device": "workspace:*",
         "@suite-native/device-manager": "workspace:*",
         "@suite-native/discovery": "workspace:*",

--- a/suite-native/module-home/src/hooks/useCoinEnablingInitialCheck.tsx
+++ b/suite-native/module-home/src/hooks/useCoinEnablingInitialCheck.tsx
@@ -1,0 +1,87 @@
+import { useSelector, useDispatch } from 'react-redux';
+import { useEffect, useRef } from 'react';
+
+import { A } from '@mobily/ts-belt';
+import { useNavigation } from '@react-navigation/native';
+
+import {
+    selectDevice,
+    selectIsPortfolioTrackerDevice,
+    selectIsBitcoinOnlyDevice,
+    selectIsDeviceUnlocked,
+} from '@suite-common/wallet-core';
+import { selectViewOnlyDevicesAccountsNetworkSymbols } from '@suite-native/device';
+import { useCoinEnabling } from '@suite-native/coin-enabling';
+import {
+    selectIsCoinEnablingInitFinished,
+    setEnabledDiscoveryNetworkSymbols,
+    setIsCoinEnablingInitFinished,
+} from '@suite-native/discovery';
+import {
+    RootStackParamList,
+    RootStackRoutes,
+    StackNavigationProps,
+} from '@suite-native/navigation';
+
+export const useCoinEnablingInitialCheck = () => {
+    const dispatch = useDispatch();
+    const navigation =
+        useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes.CoinEnablingInit>>();
+    const { isCoinEnablingActive, applyDiscoveryChanges } = useCoinEnabling();
+    const device = useSelector(selectDevice);
+    const isDeviceUnlocked = useSelector(selectIsDeviceUnlocked);
+    const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
+    const isBitcoinOnlyDevice = useSelector(selectIsBitcoinOnlyDevice);
+    const isCoinEnablingInitFinished = useSelector(selectIsCoinEnablingInitFinished);
+    const viewOnlyDevicesAccountsNetworkSymbols = useSelector(
+        selectViewOnlyDevicesAccountsNetworkSymbols,
+    );
+    const wasInitScreenShown = useRef(false);
+
+    useEffect(() => {
+        if (
+            isCoinEnablingActive &&
+            !isCoinEnablingInitFinished &&
+            isDeviceUnlocked &&
+            !!device?.connected &&
+            !isPortfolioTrackerDevice &&
+            !wasInitScreenShown.current
+        ) {
+            let timeoutId: ReturnType<typeof setTimeout>;
+            //if btc only device, just run discovery and do not show the UI
+            if (isBitcoinOnlyDevice) {
+                dispatch(setIsCoinEnablingInitFinished(true));
+                applyDiscoveryChanges();
+            } else {
+                wasInitScreenShown.current = true;
+                // if there are remembered accounts, enable their networks
+                if (A.isNotEmpty(viewOnlyDevicesAccountsNetworkSymbols)) {
+                    dispatch(
+                        setEnabledDiscoveryNetworkSymbols(viewOnlyDevicesAccountsNetworkSymbols),
+                    );
+                }
+                timeoutId = setTimeout(
+                    () => navigation.navigate(RootStackRoutes.CoinEnablingInit),
+                    4000,
+                );
+            }
+
+            return () => {
+                if (timeoutId) {
+                    clearTimeout(timeoutId);
+                }
+            };
+        }
+    }, [
+        applyDiscoveryChanges,
+        isDeviceUnlocked,
+        device?.connected,
+        dispatch,
+        isBitcoinOnlyDevice,
+        isCoinEnablingActive,
+        isCoinEnablingInitFinished,
+        isPortfolioTrackerDevice,
+        navigation,
+        viewOnlyDevicesAccountsNetworkSymbols,
+    ]);
+};

--- a/suite-native/module-home/src/screens/HomeScreen/HomeScreen.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/HomeScreen.tsx
@@ -17,6 +17,7 @@ import { PortfolioContent } from './components/PortfolioContent';
 import { useHomeRefreshControl } from './useHomeRefreshControl';
 import { EnableViewOnlyBottomSheet } from './components/EnableViewOnlyBottomSheet';
 import { PortfolioGraphRef } from './components/PortfolioGraph';
+import { useCoinEnablingInitialCheck } from '../../hooks/useCoinEnablingInitialCheck';
 
 export const HomeScreen = () => {
     const isEmptyDevice = useSelector(selectIsEmptyDevice);
@@ -34,6 +35,8 @@ export const HomeScreen = () => {
         isEmptyDevice,
         portfolioContentRef,
     });
+
+    useCoinEnablingInitialCheck();
 
     return (
         <Screen

--- a/suite-native/module-home/tsconfig.json
+++ b/suite-native/module-home/tsconfig.json
@@ -11,6 +11,7 @@
         { "path": "../atoms" },
         { "path": "../biometrics" },
         { "path": "../blockchain" },
+        { "path": "../coin-enabling" },
         { "path": "../device" },
         { "path": "../device-manager" },
         { "path": "../discovery" },

--- a/suite-native/module-settings/package.json
+++ b/suite-native/module-settings/package.json
@@ -30,6 +30,7 @@
         "@suite-native/coin-enabling": "workspace:*",
         "@suite-native/config": "workspace:*",
         "@suite-native/device-manager": "workspace:*",
+        "@suite-native/discovery": "workspace:*",
         "@suite-native/feature-flags": "workspace:*",
         "@suite-native/intl": "workspace:*",
         "@suite-native/link": "workspace:*",

--- a/suite-native/module-settings/src/screens/SettingsCoinEnablingScreen.tsx
+++ b/suite-native/module-settings/src/screens/SettingsCoinEnablingScreen.tsx
@@ -1,4 +1,7 @@
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
+import { useCallback } from 'react';
+
+import { useFocusEffect } from '@react-navigation/native';
 
 import { Screen, ScreenSubHeader } from '@suite-native/navigation';
 import { Translation, useTranslate } from '@suite-native/intl';
@@ -9,13 +12,27 @@ import {
 } from '@suite-native/coin-enabling';
 import { Box, Text } from '@suite-native/atoms';
 import { selectIsBitcoinOnlyDevice } from '@suite-common/wallet-core';
+import { setIsCoinEnablingInitFinished } from '@suite-native/discovery';
 
 export const SettingsCoinEnablingScreen = () => {
+    const dispatch = useDispatch();
+
     const { translate } = useTranslate();
-    const { availableNetworks } = useCoinEnabling();
+    const { availableNetworks, enabledNetworkSymbols } = useCoinEnabling();
     const isBitcoinOnlyDevice = useSelector(selectIsBitcoinOnlyDevice);
 
     const showBtcOnly = availableNetworks.length === 1 && isBitcoinOnlyDevice;
+
+    useFocusEffect(
+        useCallback(() => {
+            // mark coin init as finished if there are enabled coins on leaving the screen
+            return () => {
+                if (enabledNetworkSymbols.length > 0) {
+                    dispatch(setIsCoinEnablingInitFinished(true));
+                }
+            };
+        }, [dispatch, enabledNetworkSymbols.length]),
+    );
 
     return (
         <Screen

--- a/suite-native/module-settings/tsconfig.json
+++ b/suite-native/module-settings/tsconfig.json
@@ -25,6 +25,7 @@
         { "path": "../coin-enabling" },
         { "path": "../config" },
         { "path": "../device-manager" },
+        { "path": "../discovery" },
         { "path": "../feature-flags" },
         { "path": "../intl" },
         { "path": "../link" },

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -158,6 +158,6 @@ export type RootStackParamList = {
     [RootStackRoutes.AccountDetail]: AccountDetailParams;
     [RootStackRoutes.DeviceInfo]: undefined;
     [RootStackRoutes.AddCoinAccountStack]: NavigatorScreenParams<AddCoinAccountStackParamList>;
-    // [RootStackRoutes.PassphraseStack]: NavigatorScreenParams<PassphraseStackParamList>;
     [RootStackRoutes.SendStack]: NavigatorScreenParams<SendStackParamList>;
+    [RootStackRoutes.CoinEnablingInit]: undefined;
 };

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -11,7 +11,7 @@ export enum RootStackRoutes {
     SendStack = 'SendStack',
     DeviceInfo = 'DeviceInfo',
     AddCoinAccountStack = 'AddCoinAccountStack',
-    PassphraseStack = 'PassphraseStack',
+    CoinEnablingInit = 'CoinEnablingInit',
 }
 
 export enum AppTabsRoutes {

--- a/suite-native/toasts/src/components/Toast.tsx
+++ b/suite-native/toasts/src/components/Toast.tsx
@@ -23,13 +23,22 @@ type ToastStyle = {
     iconColor: Color;
 };
 
-const ToastContainerStyle = prepareNativeStyle<{ backgroundColor: Color }>(
-    (utils, { backgroundColor }) => ({
+const ToastContainerStyle = prepareNativeStyle<{ backgroundColor: Color; hasIcon: boolean }>(
+    (utils, { backgroundColor, hasIcon }) => ({
         backgroundColor: utils.colors[backgroundColor],
         paddingVertical: utils.spacings.extraSmall,
         paddingLeft: utils.spacings.extraSmall,
         paddingRight: utils.spacings.medium,
         borderRadius: utils.borders.radii.round,
+        extend: [
+            {
+                condition: !hasIcon,
+                style: {
+                    paddingLeft: utils.spacings.medium,
+                    paddingVertical: 14,
+                },
+            },
+        ],
     }),
 );
 
@@ -37,7 +46,7 @@ const IconContainerStyle = prepareNativeStyle<{
     backgroundColor: Color;
     isDefaultVariant: boolean;
 }>((utils, { backgroundColor, isDefaultVariant }) => ({
-    padding: utils.spacings.small * 1.5,
+    padding: 12,
     borderRadius: utils.borders.radii.round,
     backgroundColor: utils.transparentize(
         isDefaultVariant ? 0.75 : 0,
@@ -95,18 +104,22 @@ export const Toast = ({ toast }: ToastProps) => {
         <Animated.View
             entering={FadeIn.duration(TOAST_ANIMATION_DURATION)}
             exiting={FadeOut.duration(TOAST_ANIMATION_DURATION)}
-            style={applyStyle(ToastContainerStyle, { backgroundColor })}
+            style={applyStyle(ToastContainerStyle, { backgroundColor, hasIcon: !!icon })}
         >
             <HStack spacing={12} alignItems="center">
-                <Box
-                    style={applyStyle(IconContainerStyle, {
-                        backgroundColor: iconBackgroundColor,
-                        isDefaultVariant: variant === 'default',
-                    })}
-                >
-                    <Icon name={icon} color={iconColor} size="medium" />
-                </Box>
-                <Text color={textColor}>{message}</Text>
+                {icon && (
+                    <Box
+                        style={applyStyle(IconContainerStyle, {
+                            backgroundColor: iconBackgroundColor,
+                            isDefaultVariant: variant === 'default',
+                        })}
+                    >
+                        <Icon name={icon} color={iconColor} size="medium" />
+                    </Box>
+                )}
+                <Text color={textColor} variant="hint">
+                    {message}
+                </Text>
             </HStack>
         </Animated.View>
     );

--- a/suite-native/toasts/src/toastsAtoms.ts
+++ b/suite-native/toasts/src/toastsAtoms.ts
@@ -9,7 +9,7 @@ export type ToastVariant = 'default' | 'success' | 'warning' | 'error' | 'info';
 
 export type Toast = {
     id: number;
-    icon: IconName;
+    icon?: IconName;
     variant: ToastVariant;
     message: ReactNode;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9544,6 +9544,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/coin-enabling@workspace:suite-native/coin-enabling"
   dependencies:
+    "@mobily/ts-belt": "npm:^3.13.1"
+    "@react-navigation/native": "npm:6.1.17"
     "@reduxjs/toolkit": "npm:1.9.5"
     "@suite-common/icons": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
@@ -9553,11 +9555,14 @@ __metadata:
     "@suite-native/discovery": "workspace:*"
     "@suite-native/feature-flags": "workspace:*"
     "@suite-native/intl": "workspace:*"
+    "@suite-native/navigation": "workspace:*"
     "@suite-native/theme": "workspace:*"
     "@suite-native/toasts": "workspace:*"
     "@trezor/styles": "workspace:*"
     react: "npm:18.2.0"
     react-native: "npm:0.74.1"
+    react-native-reanimated: "npm:3.11.0"
+    react-native-safe-area-context: "npm:4.10.3"
     react-native-svg: "npm:15.3.0"
     react-redux: "npm:8.0.7"
   languageName: unknown
@@ -10028,6 +10033,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/module-home@workspace:suite-native/module-home"
   dependencies:
+    "@mobily/ts-belt": "npm:^3.13.1"
     "@react-navigation/native": "npm:6.1.17"
     "@react-navigation/native-stack": "npm:6.9.26"
     "@reduxjs/toolkit": "npm:1.9.5"
@@ -10038,6 +10044,7 @@ __metadata:
     "@suite-native/atoms": "workspace:*"
     "@suite-native/biometrics": "workspace:*"
     "@suite-native/blockchain": "workspace:*"
+    "@suite-native/coin-enabling": "workspace:*"
     "@suite-native/device": "workspace:*"
     "@suite-native/device-manager": "workspace:*"
     "@suite-native/discovery": "workspace:*"
@@ -10160,6 +10167,7 @@ __metadata:
     "@suite-native/coin-enabling": "workspace:*"
     "@suite-native/config": "workspace:*"
     "@suite-native/device-manager": "workspace:*"
+    "@suite-native/discovery": "workspace:*"
     "@suite-native/feature-flags": "workspace:*"
     "@suite-native/intl": "workspace:*"
     "@suite-native/link": "workspace:*"


### PR DESCRIPTION
When device is connected or view only devices are remembered and current device pin is entered:

- [x] if device is BTC only and no coin is enabled, enable btc automatically and run discovery
- [x] if there are view only devices, show wip UI for coin enabling and preselect union of all account coins across all remembered devices
- [x] else show wip coin enabling UI to that forces one coin to be selected to continue
- [x] make sure the flow works correctly when coinEnabling feature flag is both enabled and disabled

(UI is almost final, but fine tuning will be in the next PR)

## Related Issue

Resolve #13033 

## Screenshots:

https://github.com/user-attachments/assets/3e87599e-3e9f-4b85-bb7d-208bfdcbb72e

