### PR TITLE
fix(suite): switch icons in show balance

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions.tsx
@@ -85,6 +85,7 @@ export const QuickActions = () => {
             <Icon name="checkActive" size={12} color={theme.iconPrimaryDefault} />
         </IconWrapper>
     );
+    const icon = isDiscreetModeActive ? 'show' : 'hide';
 
     return (
         <Container>
@@ -95,7 +96,7 @@ export const QuickActions = () => {
                         onClick={handleDiscreetModeClick}
                         data-testid="@quickActions/hideBalances"
                     >
-                        <Icon size={16} name={isDiscreetModeActive ? 'hide' : 'show'} />
+                        <Icon size={16} name={icon} />
                         <Label>{translationString(translationLabel)} </Label>
                     </DescreetContainer>
                 ) : (
@@ -132,7 +133,7 @@ export const QuickActions = () => {
 
                         <ActionButton
                             title={translationString(translationLabel)}
-                            icon={isDiscreetModeActive ? 'hide' : 'show'}
+                            icon={icon}
                             onClick={handleDiscreetModeClick}
                             variant="tertiary"
                             size="small"


### PR DESCRIPTION
Updating the icons in the Hide/Show balance section to reflect the state after the action (click) is executed.

Before 

https://github.com/user-attachments/assets/508dda9f-0fbf-4e87-ab8d-2071d5d1bd0b





After 

https://github.com/user-attachments/assets/849a196c-afcf-4fa1-8443-4aff9b8cc3b3



