### PR TITLE
test(e2e): enabling node bridge in desktop tests

### DIFF
--- a/packages/suite-desktop-core/e2e/support/common.ts
+++ b/packages/suite-desktop-core/e2e/support/common.ts
@@ -25,9 +25,9 @@ export const launchSuite = async (params: LaunchSuiteParams = {}) => {
         args: [
             path.join(appDir, './dist/app.js'),
             `--log-level=${desiredLogLevel}`,
-            // '--bridge-node-test',
+            '--bridge-node-test',
             // uncomment to use legacy bridge
-            '--bridge-legacy-test',
+            // '--bridge-legacy-test',
         ],
         // when testing electron, video needs to be setup like this. it works locally but not in docker
         // recordVideo: { dir: 'test-results' },


### PR DESCRIPTION
- reenabling node bridge usage instead of the legacy one