### PR TITLE
feat(suite-native): dashboard networks always in same order

### DIFF
--- a/suite-native/app/e2e/pageObjects/onboardingActions.ts
+++ b/suite-native/app/e2e/pageObjects/onboardingActions.ts
@@ -1,4 +1,4 @@
-import { expect as detoxExpect } from 'detox';
+import { scrollUntilVisible } from '../utils';
 
 const platform = device.getPlatform();
 
@@ -22,7 +22,7 @@ class OnOnboardingActions {
             await element(by.id('@onboarding/TrackBalances/nextBtn')).tap();
         }
 
-        await detoxExpect(element(by.id('@onboarding/UserDataConsent/allow'))).toBeVisible();
+        await scrollUntilVisible(by.id(`@onboarding/UserDataConsent/allow`));
         await element(by.id('@onboarding/UserDataConsent/allow')).tap();
 
         try {

--- a/suite-native/assets/package.json
+++ b/suite-native/assets/package.json
@@ -11,6 +11,7 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
+        "@mobily/ts-belt": "^3.13.1",
         "@react-navigation/native": "6.1.17",
         "@suite-common/assets": "workspace:*",
         "@suite-common/icons": "workspace:*",
@@ -20,6 +21,7 @@
         "@suite-common/wallet-utils": "workspace:*",
         "@suite-native/accounts": "workspace:*",
         "@suite-native/atoms": "workspace:*",
+        "@suite-native/config": "workspace:*",
         "@suite-native/formatters": "workspace:*",
         "@suite-native/intl": "workspace:*",
         "@suite-native/navigation": "workspace:*",

--- a/suite-native/assets/tsconfig.json
+++ b/suite-native/assets/tsconfig.json
@@ -18,6 +18,7 @@
         },
         { "path": "../accounts" },
         { "path": "../atoms" },
+        { "path": "../config" },
         { "path": "../formatters" },
         { "path": "../intl" },
         { "path": "../navigation" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9261,6 +9261,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/assets@workspace:suite-native/assets"
   dependencies:
+    "@mobily/ts-belt": "npm:^3.13.1"
     "@react-navigation/native": "npm:6.1.17"
     "@suite-common/assets": "workspace:*"
     "@suite-common/icons": "workspace:*"
@@ -9270,6 +9271,7 @@ __metadata:
     "@suite-common/wallet-utils": "workspace:*"
     "@suite-native/accounts": "workspace:*"
     "@suite-native/atoms": "workspace:*"
+    "@suite-native/config": "workspace:*"
     "@suite-native/formatters": "workspace:*"
     "@suite-native/intl": "workspace:*"
     "@suite-native/navigation": "workspace:*"


### PR DESCRIPTION
On dashboard always show networks in the same order no matter when the network wall enabled

## Related Issue

Resolve #13766
