### PR TITLE
docs: Fix URL for Crowdin workflow

### DIFF
--- a/docs/features/localization.md
+++ b/docs/features/localization.md
@@ -119,7 +119,7 @@ To join the ranks of translators follow [Crowdin contributions](https://www.noti
 
 ### With the automated CI job from GitHub.
 
-Navigate to the [Crowdin translations update](https://github.com/trezor/trezor-suite/actions/workflows/crowdin_sync.yml) action and trigger manual job with a base branch `develop`
+Navigate to the [Crowdin translations update](https://github.com/trezor/trezor-suite/actions/workflows/bot-crowdin-sync.yml) action and trigger manual job with a base branch `develop`
 Before triggering the job, make sure there is no pull request already opened with the title `Crowdin translations update`
 
 Action will create a pull request with the title `Crowdin translations update`, review it and merge.


### PR DESCRIPTION
Fix URL for github workflow "Crowdin translations update", which was renamed.