### PR TITLE
fix(suite-data): unused translations log each message

### DIFF
--- a/.github/workflows/test-misc.yml
+++ b/.github/workflows/test-misc.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/test-misc.yml"
+  workflow_dispatch:
 
 jobs:
   urls-health:

--- a/packages/suite-data/src/translations/list-unused.ts
+++ b/packages/suite-data/src/translations/list-unused.ts
@@ -67,8 +67,10 @@ for (const message in messages) {
 }
 
 if (unused.length) {
-    console.log('there are unused messages!');
-    console.log(unused);
+    console.log('there are unused messages:');
+    for (const message of unused) {
+        console.log(message);
+    }
 
     if (process.argv.includes('--cleanup')) {
         console.log('cleaning up...');


### PR DESCRIPTION
## Description

Change the printing of unused translations to log each one individually, instead of the array. 
Before it could get cut off in case of too many messages.