### PR TITLE
feat(suite-desktop-core): async before quit handling

### DIFF
--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -14,7 +14,7 @@ import { getBuildInfo, getComputerInfo } from './libs/info';
 import { restartApp, processStatePatch } from './libs/app-utils';
 import { clearAppCache, initUserData } from './libs/user-data';
 import { initSentry } from './libs/sentry';
-import { Dependencies, initModules, mainThreadEmitter } from './modules';
+import { initModules, mainThreadEmitter } from './modules';
 import { init as initTorModule } from './modules/tor';
 import { init as initBridgeModule } from './modules/bridge';
 import { createInterceptor } from './libs/request-interceptor';
@@ -131,10 +131,8 @@ const init = async () => {
         logger.info('main', 'App is hidden, starting bridge only');
         app.dock?.hide(); // hide dock icon on macOS
         app.releaseSingleInstanceLock(); // allow user to open new instance with UI
-        const loadBridgeModule = initBridgeModule({ store } as Dependencies); // bridge module only needs store
-        if (loadBridgeModule) {
-            loadBridgeModule(null);
-        }
+        const { onLoad: loadBridgeModule } = initBridgeModule({ store }); // bridge module only needs store
+        loadBridgeModule();
 
         return;
     }
@@ -165,7 +163,7 @@ const init = async () => {
 
     // init modules
     const interceptor = createInterceptor();
-    const loadModules = initModules({
+    const { loadModules } = initModules({
         mainWindow,
         store,
         interceptor,
@@ -193,7 +191,7 @@ const init = async () => {
 
     // Tor module initializes separated from general `initModules` because Tor is different
     // since it is allowed to fail and then the user decides whether to `try again` or `disable`.
-    const loadTorModule = initTorModule({
+    const { onLoad: loadTorModule } = initTorModule({
         mainWindow,
         store,
         interceptor,

--- a/packages/suite-desktop-core/src/modules/auto-updater.ts
+++ b/packages/suite-desktop-core/src/modules/auto-updater.ts
@@ -268,7 +268,7 @@ export const init: Module = ({ mainWindow, store }) => {
     });
 
     // Enable feature on FE once it's ready
-    return (): HandshakeElectron['desktopUpdate'] => {
+    const onLoad = (): HandshakeElectron['desktopUpdate'] => {
         // if there is savedCurrentVersion in store (it doesn't have to be there as it was added in later versions)
         // and if it does not match current application version it means that application got updated and the new version
         // is run for the first time.
@@ -295,4 +295,6 @@ export const init: Module = ({ mainWindow, store }) => {
                     : undefined,
         };
     };
+
+    return { onLoad };
 };

--- a/packages/suite-desktop-core/src/modules/bridge.ts
+++ b/packages/suite-desktop-core/src/modules/bridge.ts
@@ -11,7 +11,7 @@ import { BridgeProcess } from '../libs/processes/BridgeProcess';
 import { b2t } from '../libs/utils';
 import { ThreadProxy } from '../libs/thread-proxy';
 
-import type { Module, Dependencies } from './index';
+import type { Dependencies } from './index';
 
 const bridgeLegacy = app.commandLine.hasSwitch('bridge-legacy');
 const bridgeLegacyDev = app.commandLine.hasSwitch('bridge-legacy-dev');
@@ -116,7 +116,7 @@ const shouldUseLegacyBridge = (store: Dependencies['store']) => {
     );
 };
 
-const load = async ({ store }: Dependencies) => {
+const load = async ({ store }: Pick<Dependencies, 'store'>) => {
     const { logger } = global;
     const bridge = shouldUseLegacyBridge(store) ? new BridgeProcess() : new TrezordNodeProcess();
 
@@ -200,10 +200,14 @@ const load = async ({ store }: Dependencies) => {
     }
 };
 
-export const init: Module = dependencies => {
+type BridgeModule = ({ store }: Pick<Dependencies, 'store'>) => {
+    onLoad: () => void;
+};
+
+export const init: BridgeModule = dependencies => {
     let loaded = false;
 
-    return () => {
+    const onLoad = () => {
         if (loaded) return;
         loaded = true;
 
@@ -212,4 +216,6 @@ export const init: Module = dependencies => {
             logger.error(SERVICE_NAME, `Failed to load: ${err.message}`);
         });
     };
+
+    return { onLoad };
 };

--- a/packages/suite-desktop-core/src/modules/coinjoin.ts
+++ b/packages/suite-desktop-core/src/modules/coinjoin.ts
@@ -2,7 +2,7 @@
  * Uses @trezor/coinjoin package in nodejs context
  */
 
-import { app, ipcMain } from 'electron';
+import { ipcMain } from 'electron';
 import { captureMessage, withScope } from '@sentry/electron';
 
 import { coinjoinReportTag, coinjoinNetworkTag } from '@suite-common/sentry';
@@ -207,7 +207,7 @@ export const init: Module = ({ mainWindow, store, mainThreadEmitter }) => {
         };
     };
 
-    const dispose = () => {
+    const dispose = async () => {
         backends.forEach(b => b.dispose());
         backends.splice(0, backends.length);
 
@@ -224,14 +224,16 @@ export const init: Module = ({ mainWindow, store, mainThreadEmitter }) => {
         clients.splice(0, clients.length);
 
         unregisterProxies();
-        logger.info(SERVICE_NAME, 'Stopping (app quit)');
-        synchronize(killCoinjoinProcess);
+        await synchronize(killCoinjoinProcess);
         powerSaveBlocker.stopBlockingPowerSave();
     };
 
-    app.on('before-quit', dispose);
+    const onQuit = async () => {
+        await dispose();
+    };
+
     mainWindow.webContents.on('did-start-loading', dispose);
     ipcMain.once('app/restart', dispose);
 
-    return { onLoad: registerProxies };
+    return { onLoad: registerProxies, onQuit };
 };

--- a/packages/suite-desktop-core/src/modules/coinjoin.ts
+++ b/packages/suite-desktop-core/src/modules/coinjoin.ts
@@ -233,5 +233,5 @@ export const init: Module = ({ mainWindow, store, mainThreadEmitter }) => {
     mainWindow.webContents.on('did-start-loading', dispose);
     ipcMain.once('app/restart', dispose);
 
-    return registerProxies;
+    return { onLoad: registerProxies };
 };

--- a/packages/suite-desktop-core/src/modules/custom-protocols.ts
+++ b/packages/suite-desktop-core/src/modules/custom-protocols.ts
@@ -78,7 +78,7 @@ export const init: Module = ({ mainWindow }) => {
             logger.debug(SERVICE_NAME, 'App is launched via custom protocol (Linux, Windows)');
 
             if (isValidProtocol(argv[1], protocols)) {
-                return firstRunOnly(argv[1]);
+                return { onLoad: firstRunOnly(argv[1]) };
             }
         }
     }
@@ -86,7 +86,7 @@ export const init: Module = ({ mainWindow }) => {
     // App is launched via custom protocol (macOS)
     if (global.customProtocolUrl) {
         if (isValidProtocol(global.customProtocolUrl, protocols)) {
-            return firstRunOnly(global.customProtocolUrl);
+            return { onLoad: firstRunOnly(global.customProtocolUrl) };
         }
     }
 };

--- a/packages/suite-desktop-core/src/modules/http-receiver.ts
+++ b/packages/suite-desktop-core/src/modules/http-receiver.ts
@@ -14,7 +14,7 @@ export const init: Module = ({ mainWindow }) => {
     const { logger } = global;
     let httpReceiver: ReturnType<typeof createHttpReceiver> | null = null;
 
-    return async () => {
+    const onLoad = async () => {
         if (httpReceiver) {
             return httpReceiver.getInfo();
         }
@@ -62,4 +62,6 @@ export const init: Module = ({ mainWindow }) => {
 
         return receiver.getInfo();
     };
+
+    return { onLoad };
 };

--- a/packages/suite-desktop-core/src/modules/http-receiver.ts
+++ b/packages/suite-desktop-core/src/modules/http-receiver.ts
@@ -45,11 +45,6 @@ export const init: Module = ({ mainWindow }) => {
             });
         });
 
-        app.on('before-quit', () => {
-            logger.info(SERVICE_NAME, 'Stopping server (app quit)');
-            receiver.stop();
-        });
-
         // when httpReceiver was asked to provide current address for given pathname
         ipcMain.handle('server/request-address', (ipcEvent, pathname) => {
             validateIpcMessage(ipcEvent);
@@ -63,5 +58,9 @@ export const init: Module = ({ mainWindow }) => {
         return receiver.getInfo();
     };
 
-    return { onLoad };
+    const onQuit = async () => {
+        await httpReceiver?.stop();
+    };
+
+    return { onLoad, onQuit };
 };

--- a/packages/suite-desktop-core/src/modules/tor.ts
+++ b/packages/suite-desktop-core/src/modules/tor.ts
@@ -239,12 +239,14 @@ const load = async ({ mainWindow, store, mainThreadEmitter }: Dependencies) => {
     }
 };
 
-type TorModule = (dependencies: Dependencies) => () => Promise<HandshakeTorModule>;
+type TorModule = (dependencies: Dependencies) => {
+    onLoad: () => Promise<HandshakeTorModule>;
+};
 
 export const init: TorModule = dependencies => {
     let loaded = false;
 
-    return async () => {
+    const onLoad = async () => {
         if (loaded) return { shouldRunTor: false };
 
         loaded = true;
@@ -255,4 +257,6 @@ export const init: TorModule = dependencies => {
             shouldRunTor: torSettings.running,
         };
     };
+
+    return { onLoad };
 };

--- a/packages/suite-desktop-core/src/modules/trezor-connect.ts
+++ b/packages/suite-desktop-core/src/modules/trezor-connect.ts
@@ -1,4 +1,4 @@
-import { app, ipcMain } from 'electron';
+import { ipcMain } from 'electron';
 
 import TrezorConnect from '@trezor/connect';
 import { createIpcProxyHandler, IpcProxyHandlerOptions } from '@trezor/ipc-proxy';
@@ -48,15 +48,15 @@ export const init: Module = ({ store }) => {
 
     const unregisterProxy = createIpcProxyHandler(ipcMain, 'TrezorConnect', ipcProxyOptions);
 
-    app.on('before-quit', () => {
-        unregisterProxy();
-        TrezorConnect.dispose();
-    });
-
     const onLoad = () => {
         // reset previous instance, possible left over after renderer refresh (F5)
         TrezorConnect.dispose();
     };
 
-    return { onLoad };
+    const onQuit = () => {
+        unregisterProxy();
+        TrezorConnect.dispose();
+    };
+
+    return { onLoad, onQuit };
 };

--- a/packages/suite-desktop-core/src/modules/trezor-connect.ts
+++ b/packages/suite-desktop-core/src/modules/trezor-connect.ts
@@ -53,8 +53,10 @@ export const init: Module = ({ store }) => {
         TrezorConnect.dispose();
     });
 
-    return () => {
+    const onLoad = () => {
         // reset previous instance, possible left over after renderer refresh (F5)
         TrezorConnect.dispose();
     };
+
+    return { onLoad };
 };

--- a/packages/suite-desktop-core/src/modules/user-data.ts
+++ b/packages/suite-desktop-core/src/modules/user-data.ts
@@ -26,5 +26,7 @@ export const init: Module = () => {
         return userData.open(directory);
     });
 
-    return () => userData.getInfo();
+    const onLoad = () => userData.getInfo();
+
+    return { onLoad };
 };


### PR DESCRIPTION
## Description

This PR adds a new system to allow modules to hook into the `before-quit` event and do some asynchronous work before exiting. 

It uses the following events:
- `module/quit-handler-register`: used by other modules to register themselves to handle the quit event
- `module/quit-handler-request`: used to broadcast that the app is about to quit
- `module/quit-handler-ack`: used by other modules to acknowledge they processed the quit event

This is a prerequisite to allow modules such as bridge to perform async cleanup operations and for the single process daemon mode, where we want to have more control over when to actually fully quit the process. 