### PR TITLE
chore(suite): Optimize webpack dev server

### DIFF
--- a/packages/suite-build/configs/dev.webpack.config.ts
+++ b/packages/suite-build/configs/dev.webpack.config.ts
@@ -21,6 +21,10 @@ const config: webpack.Configuration = {
         filename: 'js/[name].js',
         chunkFilename: 'js/[id].js',
     },
+    watchOptions: {
+        // reduce number of file watchers; for HMR it is not necessary to watch both source code & node_modules
+        ignored: /node_modules/,
+    },
     plugins: [
         new WebpackPluginServe({
             port: DEV_PORTS[project],


### PR DESCRIPTION
## Description

Configure webpack for dev server to **not** watch `node_modules`, as it creates unnecessary amount of file watchers, potentially degrading performance. This is suggested [by webpack](https://webpack.js.org/configuration/watch/#watchoptionsignored).

Specifically, this may sometimes cause issues on Linux Ubuntu, where there is default limit of 65536 file watchers in the `inotify` service, and running suite dev server may exceed it. Though even after this PR, [increasing the limit](https://stackoverflow.com/questions/55763428/react-native-error-enospc-system-limit-for-number-of-file-watchers-reached/55763478#55763478) may be necessary for linux devs. Our codebase is just that big :open_mouth:

## Related Issue

[Slack discussion](https://satoshilabs.slack.com/archives/G019WLX2P7B/p1720697642356569?thread_ts=1720686830.567509&cid=G019WLX2P7B) (for internal users only)