### PR TITLE
fix(suite-native): interrupted discovery might have been considered finished

### DIFF
--- a/suite-native/discovery/src/utils.ts
+++ b/suite-native/discovery/src/utils.ts
@@ -8,38 +8,24 @@ const NORMAL_ACCOUNT_TYPE = 'normal';
 // network uses undefined for normal type, but account uses 'normal'
 const normalizedAccountType = (accountType?: AccountType) => accountType ?? NORMAL_ACCOUNT_TYPE;
 
-const isNormalAccountType = (accountType?: AccountType) =>
-    normalizedAccountType(accountType) === NORMAL_ACCOUNT_TYPE;
-
 export const getNetworksWithUnfinishedDiscovery = (
     enabledNetworks: readonly Network[],
     accounts: Account[],
     accountsLimit: number,
 ) =>
     enabledNetworks.filter(network => {
-        // there is no normal account for this network -> we should have at least one normal account even if added via Add Coin
-        if (
-            A.isEmpty(
-                accounts.filter(
-                    account =>
-                        account.symbol === network.symbol &&
-                        isNormalAccountType(account.accountType),
-                ),
-            )
-        ) {
-            return true;
-        }
-
         const networkAccountsOfType = accounts.filter(
             account =>
                 account.symbol === network.symbol &&
                 account.accountType === normalizedAccountType(network.accountType),
         );
 
-        // if there is at least one visible account of this type, we should have at least one hidden account so adding funds outside of this app is detected and account shown
+        // if there is no account for this network -> we should have at least one account even if added via Add Coin
+        // or if there is at least one visible account of this type, we should have at least one hidden account so adding funds outside of this app is detected and account shown
         return (
-            networkAccountsOfType.length < accountsLimit &&
-            networkAccountsOfType.every(account => account.visible)
+            A.isEmpty(networkAccountsOfType) ||
+            (networkAccountsOfType.length < accountsLimit &&
+                networkAccountsOfType.every(account => account.visible))
         );
     });
 


### PR DESCRIPTION
Fixing wrong logic for marking network discovery finished. previously it worked for newly enabled coin, but interrupted discovery failed once default (normal) account for the coin was discovered.

## Description

Now we check whether each enabled network has at least one invisible account added to consider network discovery finished

## Related Issue

Resolve #13854

