### PR TITLE
chore(suite): change url in security check fail

### DIFF
--- a/packages/suite/src/components/suite/SecurityCheck/SecurityCheckFail.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/SecurityCheckFail.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 import { H2, Row, Text, useElevation } from '@trezor/components';
 import { Elevation, mapElevationToBorder, spacings, spacingsPx } from '@trezor/theme';
-import { TREZOR_SUPPORT_URL } from '@trezor/urls';
+import { TREZOR_SUPPORT_FW_CHECK_FAILED } from '@trezor/urls';
 
 import { Translation, TrezorLink } from 'src/components/suite';
 import { SecurityChecklist } from '../../../views/onboarding/steps/SecurityCheck/SecurityChecklist';
@@ -40,7 +40,7 @@ const checklistItems = [
     },
 ] as const;
 
-const supportChatUrl = `${TREZOR_SUPPORT_URL}#open-chat`;
+const supportChatUrl = `${TREZOR_SUPPORT_FW_CHECK_FAILED}#open-chat`;
 
 interface SecurityCheckFailProps {
     goBack?: () => void;

--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -92,6 +92,8 @@ export const HELP_CENTER_EVM_ADDRESS_CHECKSUM =
     'https://trezor.io/learn/a/evm-address-checksum-in-trezor-suite';
 export const HELP_CENTER_FIRMWARE_REVISION_CHECK =
     'https://trezor.io/learn/a/trezor-firmware-revision-check';
+export const TREZOR_SUPPORT_FW_CHECK_FAILED =
+    'trezor.io/support/a/trezor-firmware-revision-check-failed';
 
 export const INVITY_URL = 'https://invity.io/';
 export const INVITY_SCHEDULE_OF_FEES = 'https://blog.invity.io/schedule-of-fees';


### PR DESCRIPTION

Changing the URL for Device authenticity fail + Firmware revision fail events, which will start dedicated chat-bot flow asking user to fill in several information rightaway. 