### PR TITLE
feat(suite-native): for coin enabling show first empty account

### DIFF
--- a/suite-native/discovery/src/discoveryThunks.ts
+++ b/suite-native/discovery/src/discoveryThunks.ts
@@ -25,6 +25,7 @@ import { AccountType, Network, NetworkSymbol, getNetworkType } from '@suite-comm
 import { DiscoveryStatus } from '@suite-common/wallet-constants';
 import { requestDeviceAccess } from '@suite-native/device-mutex';
 import { analytics, EventType } from '@suite-native/analytics';
+import { FeatureFlag, selectIsFeatureFlagEnabled } from '@suite-native/feature-flags';
 
 import { selectDiscoveryInfo, setDiscoveryInfo } from './discoveryConfigSlice';
 import {
@@ -293,13 +294,25 @@ const discoverAccountsByDescriptorThunk = createThunk(
                 if (accountInfo.empty) {
                     isFinalRound = true;
                 }
+                const isCoinEnablingActive = selectIsFeatureFlagEnabled(
+                    getState(),
+                    FeatureFlag.IsCoinEnablingActive,
+                );
+
+                const isVisible =
+                    // If the account is not empty, it should be visible.
+                    !accountInfo.empty ||
+                    // If the feature flag is enabled, first normal account should be visible.
+                    (isCoinEnablingActive &&
+                        bundleItem.accountType === 'normal' &&
+                        bundleItem.index === 0);
 
                 dispatch(
                     accountsActions.createIndexLabeledAccount({
                         discoveryItem: bundleItem,
                         deviceState,
                         accountInfo,
-                        visible: !accountInfo.empty,
+                        visible: isVisible,
                     }),
                 );
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

If coin enabling is enabled discover at least first normal account even if it is empty

## Related Issue

Resolve #13844

## Screenshots:


https://github.com/user-attachments/assets/560c2deb-0ca7-4883-b7bf-1202829f7545


