### PR TITLE
chore: update trezor-user-env

### DIFF
--- a/.github/workflows/template-connect-test-params.yml
+++ b/.github/workflows/template-connect-test-params.yml
@@ -16,7 +16,7 @@ on:
         required: false
         default: "2-latest"
       testFirmwareModel:
-        description: "Firmware model for the tests (example: R)"
+        description: "Firmware model for the tests (example: T3T1)"
         type: "string"
         required: false
       nodeEnvironment:
@@ -30,7 +30,7 @@ on:
         required: false
         default: true
       testDescription:
-        description: "A description to make test title more descriptive (example: 2-latest-R)"
+        description: "A description to make test title more descriptive (example: T3T1-latest)"
         type: "string"
         required: false
         default: ""

--- a/docker/docker-connect-test.sh
+++ b/docker/docker-connect-test.sh
@@ -20,10 +20,9 @@ set -euo pipefail
 
 ENVIRONMENT=$1
 
-if [[ "$ENVIRONMENT" != "web" && "$ENVIRONMENT" != "node" ]];
-    then
-        echo "either 'web' or 'node' must be specified as the first argument"
-        exit 1
+if [[ "$ENVIRONMENT" != "web" && "$ENVIRONMENT" != "node" ]]; then
+  echo "either 'web' or 'node' must be specified as the first argument"
+  exit 1
 fi
 
 show_usage() {
@@ -35,7 +34,7 @@ show_usage() {
   echo "  -D PATH  Set path to docker executable. Can be replaced with \`podman\`. default: docker"
   echo "  -e       All methods except excluded, example: applySettings,signTransaction"
   echo "  -p       Test pattern"
-  echo "  -f       Use specific firmware version, example: 2.1.4, 1.8.0 default: 2-main"
+  echo "  -f       Use specific firmware version, example: 2.1.4, 1.8.0 default: -main"
   echo "  -i       Included methods only, example: applySettings,signTransaction"
   echo "  -s       actual test script. default: 'yarn test:integration'"
   echo "  -u       Firmware url"
@@ -106,11 +105,10 @@ shift $((OPTIND - 1))
 
 export DOCKER_PATH
 
-if [[ $ENVIRONMENT == "node" ]];
-  then
-    SCRIPT="yarn workspace @trezor/connect test:e2e:node"
-  else
-    SCRIPT="yarn workspace @trezor/connect test:e2e:web"
+if [[ $ENVIRONMENT == "node" ]]; then
+  SCRIPT="yarn workspace @trezor/connect test:e2e:node"
+else
+  SCRIPT="yarn workspace @trezor/connect test:e2e:web"
 fi
 
 # export essential process.env variables

--- a/packages/connect-popup/e2e/tests/passphrase.test.ts
+++ b/packages/connect-popup/e2e/tests/passphrase.test.ts
@@ -11,7 +11,7 @@ import {
 } from '../support/helpers';
 
 const url = process.env.URL || 'http://localhost:8088/';
-const bridgeVersion = '2.0.31';
+const bridgeVersion = '2.0.33';
 
 const isWebExtension = process.env.IS_WEBEXTENSION === 'true';
 const isCoreInPopup = process.env.CORE_IN_POPUP === 'true';

--- a/packages/connect-popup/e2e/tests/popup-close-legacy.test.ts
+++ b/packages/connect-popup/e2e/tests/popup-close-legacy.test.ts
@@ -3,7 +3,7 @@ import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 import { createDeferred, Deferred } from '@trezor/utils';
 import { log } from '../support/helpers';
 
-const BRIDGE_VERSION = '2.0.31';
+const BRIDGE_VERSION = '2.0.33';
 const WAIT_AFTER_TEST = 3000; // how long test should wait for more potential trezord requests
 const CONNECT_LEGACY_VERSION = '9.0.10';
 

--- a/packages/connect-popup/e2e/tests/popup-pages.test.ts
+++ b/packages/connect-popup/e2e/tests/popup-pages.test.ts
@@ -13,7 +13,7 @@ import fs from 'fs';
 
 const url = process.env.URL || 'http://localhost:8088/';
 
-const bridgeVersion = '2.0.31';
+const bridgeVersion = '2.0.33';
 // popup window reference
 let popup: Page;
 let persistentContext: BrowserContext | undefined;

--- a/packages/connect-popup/e2e/tests/webextension-example.test.ts
+++ b/packages/connect-popup/e2e/tests/webextension-example.test.ts
@@ -12,27 +12,19 @@ test.beforeAll(async () => {
 
 test.beforeEach(async () => {
     await TrezorUserEnvLink.connect();
-    await TrezorUserEnvLink.send({
-        type: 'bridge-stop',
-    });
-    await TrezorUserEnvLink.send({
-        type: 'emulator-stop',
-    });
-    await TrezorUserEnvLink.send({
-        type: 'emulator-start',
+    await TrezorUserEnvLink.stopBridge();
+    await TrezorUserEnvLink.stopEmu();
+    await TrezorUserEnvLink.startEmu({
         wipe: true,
     });
-    await TrezorUserEnvLink.send({
-        type: 'emulator-setup',
+    await TrezorUserEnvLink.setupEmu({
         mnemonic: 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle',
         pin: '',
         passphrase_protection: false,
         label: 'My Trevor',
         needs_backup: false,
     });
-    await TrezorUserEnvLink.send({
-        type: 'bridge-start',
-    });
+    await TrezorUserEnvLink.startBridge();
 });
 
 const getBrowserContext = async (pathToExtension: string) => {
@@ -103,10 +95,7 @@ test('Basic web extension MV2', async () => {
 
     await popup.waitForSelector('text=3AnYTd2FGxJLNKL1AzxfW3FJMntp9D2KKX');
 
-    await Promise.all([
-        popup.waitForEvent('close'),
-        TrezorUserEnvLink.send({ type: 'emulator-press-yes' }),
-    ]);
+    await Promise.all([popup.waitForEvent('close'), TrezorUserEnvLink.pressYes()]);
 
     await page.waitForSelector('text=3AnYTd2FGxJLNKL1AzxfW3FJMntp9D2KKX');
 
@@ -156,10 +145,7 @@ test('Basic web extension MV3', async () => {
 
     await popup.waitForSelector('text=3AnYTd2FGxJLNKL1AzxfW3FJMntp9D2KKX');
 
-    await Promise.all([
-        popup.waitForEvent('close'),
-        TrezorUserEnvLink.send({ type: 'emulator-press-yes' }),
-    ]);
+    await Promise.all([popup.waitForEvent('close'), TrezorUserEnvLink.pressYes()]);
 
     await browserContext.close();
 });

--- a/packages/suite-web/e2e/tests/analytics/events.test.ts
+++ b/packages/suite-web/e2e/tests/analytics/events.test.ts
@@ -23,7 +23,7 @@ describe('Analytics Events', () => {
         cy.getTestElement('@analytics/toggle-switch').click({ force: true });
         cy.getTestElement('@settings/menu/close').click();
 
-        cy.task('startEmu', { wipe: true, version: '2.6.0' });
+        cy.task('startEmu', { wipe: true, model: 'T2T1', version: '2.6.0' });
         cy.task('setupEmu', {
             needs_backup: false,
             mnemonic: 'all all all all all all all all all all all all',

--- a/packages/suite-web/e2e/tests/backup/t2t1-fail.test.ts
+++ b/packages/suite-web/e2e/tests/backup/t2t1-fail.test.ts
@@ -8,7 +8,7 @@ let requests: Requests;
 
 describe('Backup fail', () => {
     beforeEach(() => {
-        cy.task('startEmu', { wipe: true });
+        cy.task('startEmu', { wipe: true, model: 'T2T1' });
         cy.task('setupEmu', { needs_backup: true });
         cy.task('startBridge');
         cy.viewport(1440, 2560).resetDb();

--- a/packages/suite-web/e2e/tests/backup/t2t1-misc.test.ts
+++ b/packages/suite-web/e2e/tests/backup/t2t1-misc.test.ts
@@ -3,7 +3,7 @@
 
 describe('Backup misc', () => {
     beforeEach(() => {
-        cy.task('startEmu', { wipe: true });
+        cy.task('startEmu', { wipe: true, model: 'T2T1' });
         cy.task('setupEmu', { needs_backup: true });
         cy.task('startBridge');
 

--- a/packages/suite-web/e2e/tests/backup/t2t1-success.test.ts
+++ b/packages/suite-web/e2e/tests/backup/t2t1-success.test.ts
@@ -8,7 +8,7 @@ let requests: Requests;
 
 describe('Backup success', () => {
     beforeEach(() => {
-        cy.task('startEmu', { wipe: true });
+        cy.task('startEmu', { wipe: true, model: 'T2T1', version: '2.8.1' });
         cy.task('setupEmu', {
             needs_backup: true,
             mnemonic: 'all all all all all all all all all all all all',
@@ -37,6 +37,7 @@ describe('Backup success', () => {
         cy.getTestElement('@backup/start-button').click();
         cy.getConfirmActionOnDeviceModal();
 
+        cy.task('pressYes');
         cy.task('pressYes');
         cy.task('swipeEmu', 'up');
         cy.task('swipeEmu', 'up');

--- a/packages/suite-web/e2e/tests/firmware/firmware.test.ts
+++ b/packages/suite-web/e2e/tests/firmware/firmware.test.ts
@@ -8,7 +8,7 @@ describe('Firmware', () => {
     });
 
     it(`Firmware 2.5.2 outdated notification banner should open firmware update modal`, () => {
-        cy.task('startEmu', { wipe: true, version: '2.5.2' });
+        cy.task('startEmu', { wipe: true, model: 'T2T1', version: '2.5.2' });
         cy.task('setupEmu');
         cy.task('startBridge');
         cy.prefixedVisit('/');

--- a/packages/suite-web/e2e/tests/metadata/metadata-lifecycle.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/metadata-lifecycle.test.ts
@@ -10,7 +10,7 @@ describe('Metadata - cancel metadata on device', () => {
 
     it('user cancels metadata on device, choice is respected on subsequent runs but only for the cancelled wallet', () => {
         // prepare test
-        cy.task('startEmu', { wipe: true, version: '2.7.0' });
+        cy.task('startEmu', { wipe: true, model: 'T2T1', version: '2.7.0' });
         cy.task('setupEmu', {
             mnemonic,
             passphrase_protection: true,

--- a/packages/suite-web/e2e/tests/onboarding/t1b1-create-wallet.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/t1b1-create-wallet.test.ts
@@ -11,7 +11,7 @@ describe('Onboarding - create wallet', () => {
     // todo: skipping for it is too flaky..
     // after calling "resetDevice" we almost always receive "device disconnected during action" which is error sent by bridge.
     it.skip('Success (basic)', () => {
-        cy.task('startEmu', { version: '1-latest', wipe: true });
+        cy.task('startEmu', { model: 'T1B1', version: '1-latest', wipe: true });
         cy.getTestElement('@analytics/continue-button').click();
         cy.getTestElement('@analytics/continue-button').click();
         cy.getTestElement('@firmware/continue-button').click();

--- a/packages/suite-web/e2e/tests/onboarding/t1b1-recovery-advanced.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/t1b1-recovery-advanced.test.ts
@@ -3,7 +3,7 @@
 
 describe('Onboarding - recover wallet T1B1', () => {
     beforeEach(() => {
-        cy.task('startEmu', { version: '1-latest', wipe: true });
+        cy.task('startEmu', { model: 'T1B1', version: '1-latest', wipe: true });
         cy.task('startBridge');
 
         cy.viewport(1440, 2560).resetDb();
@@ -33,7 +33,7 @@ describe('Onboarding - recover wallet T1B1', () => {
         cy.wait(501);
         cy.task('stopEmu');
         cy.getTestElement('@connect-device-prompt', { timeout: 20000 });
-        cy.task('startEmu', { version: '1-latest' });
+        cy.task('startEmu', { model: 'T1B1', version: '1-latest' });
 
         cy.getTestElement('@onboarding/recovery/retry-button').click();
         cy.getTestElement('@recover/select-count/12').click();

--- a/packages/suite-web/e2e/tests/onboarding/t1b1-recovery-basic.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/t1b1-recovery-basic.test.ts
@@ -4,7 +4,7 @@
 // todo: this started to fail mysteriously after merging new base image. Skipping it for now and will investigate.
 describe.skip('Onboarding - recover wallet T1B1', () => {
     before(() => {
-        cy.task('startEmu', { version: '1-latest', wipe: true });
+        cy.task('startEmu', { model: 'T1B1', version: '1-latest', wipe: true });
         cy.task('startBridge');
 
         cy.viewport(1440, 2560).resetDb();

--- a/packages/suite-web/e2e/tests/onboarding/t2t1-create-wallet.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/t2t1-create-wallet.test.ts
@@ -13,7 +13,7 @@ describe('Onboarding - create wallet', () => {
         // note: this is an example of test that can not be parametrized to be both integration (isolated) test and e2e test.
         // the problem is that it always needs to run the newest possible emulator. If this was pinned to use emulator which is currently
         // in production, and we locally bumped emulator version, we would get into a screen saying "update your firmware" and the test would fail.
-        cy.task('startEmu', { wipe: true, version: '2-master' });
+        cy.task('startEmu', { wipe: true, model: 'T2T1', version: '2-main' });
         cy.getTestElement('@analytics/continue-button').click();
         cy.getTestElement('@analytics/continue-button').click();
         cy.getTestElement('@firmware/continue-button').click();

--- a/packages/suite-web/e2e/tests/onboarding/t2t1-recovery-fail.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/t2t1-recovery-fail.test.ts
@@ -9,9 +9,9 @@ describe('Onboarding - recover wallet T2T1', () => {
         // note: this is an example of test that can not be parametrized to be both integration (isolated) test and e2e test.
         // the problem is that it always needs to run the newest possible emulator. If this was pinned to use emulator which is currently
         // in production, and we locally bumped emulator version, we would get into a screen saying "update your firmware" and the test would fail.
-        cy.task('startEmu', { wipe: true, version: '2-master' });
+        cy.task('startEmu', { wipe: true, model: 'T2T1', version: '2-main' });
 
-        // Disable revision check. On emulator '2-master' it wont pass as it is unreleased version
+        // Disable revision check. On emulator '2-main' it wont pass as it is unreleased version
         cy.getTestElement('@device-compromised').should('be.visible');
         cy.getTestElement('@suite/menu/settings').click();
         cy.getTestElement('@settings/menu/device').click();

--- a/packages/suite-web/e2e/tests/onboarding/t2t1-recovery-persistence.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/t2t1-recovery-persistence.test.ts
@@ -49,7 +49,7 @@ const shareTwoOfThree = [
 describe('Onboarding - T2T1 in recovery mode', () => {
     beforeEach(() => {
         cy.task('startBridge');
-        cy.task('startEmu', { wipe: true, version: '2.4.3' });
+        cy.task('startEmu', { wipe: true, model: 'T2T1', version: '2.5.3' });
         cy.resetDb();
         cy.viewport(1440, 2560);
         cy.prefixedVisit('/');
@@ -82,7 +82,7 @@ describe('Onboarding - T2T1 in recovery mode', () => {
         cy.safeReload();
 
         // now suite has reloaded. database is wiped.
-        cy.task('startEmu', { wipe: false, version: '2.4.3' });
+        cy.task('startEmu', { wipe: false, model: 'T2T1', version: '2.5.3' });
         // analytics opt-out again
         cy.getTestElement('@analytics/continue-button').click();
         cy.getTestElement('@analytics/continue-button').click();
@@ -121,7 +121,7 @@ describe('Onboarding - T2T1 in recovery mode', () => {
         cy.task('stopEmu');
         cy.wait(501);
         cy.getTestElement('@connect-device-prompt', { timeout: 30000 });
-        cy.task('startEmu', { wipe: false, version: '2.4.3' });
+        cy.task('startEmu', { wipe: false, model: 'T2T1', version: '2.5.3' });
         cy.getTestElement('@onboarding/confirm-on-device');
         cy.wait(501);
         cy.task('pressYes');

--- a/packages/suite-web/e2e/tests/onboarding/t2t1-recovery-success.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/t2t1-recovery-success.test.ts
@@ -7,7 +7,7 @@ describe('Onboarding - recover wallet T2T1', () => {
         cy.viewport(1440, 2560).resetDb();
         cy.prefixedVisit('/');
 
-        cy.task('startEmu', { wipe: true, version: '2.5.3' });
+        cy.task('startEmu', { wipe: true, model: 'T2T1', version: '2.5.3' });
         cy.getTestElement('@analytics/continue-button').click();
         cy.getTestElement('@analytics/continue-button').click();
 

--- a/packages/suite-web/e2e/tests/recovery/t1b1-dry-run.test.ts
+++ b/packages/suite-web/e2e/tests/recovery/t1b1-dry-run.test.ts
@@ -2,7 +2,7 @@
 
 describe.skip('Recovery - dry run', () => {
     beforeEach(() => {
-        cy.task('startEmu', { version: '1-latest', wipe: true });
+        cy.task('startEmu', { model: 'T1B1', version: '1-latest', wipe: true });
         cy.wait(2000);
         cy.task('setupEmu', { needs_backup: false });
         cy.task('startBridge');

--- a/packages/suite-web/e2e/tests/settings/t1b1-device-settings.test.ts
+++ b/packages/suite-web/e2e/tests/settings/t1b1-device-settings.test.ts
@@ -5,7 +5,7 @@
 // udp transport in suite and trying to enable this test again.
 describe.skip('T1B1 - Device settings', () => {
     beforeEach(() => {
-        cy.task('startEmu', { version: '1-latest', wipe: true });
+        cy.task('startEmu', { model: 'T1B1', version: '1-latest', wipe: true });
         cy.task('setupEmu', { needs_backup: false });
         cy.task('startBridge');
     });

--- a/packages/suite-web/e2e/tests/settings/t2b1-device-settings.test.ts
+++ b/packages/suite-web/e2e/tests/settings/t2b1-device-settings.test.ts
@@ -10,7 +10,7 @@
 describe('T2B1 - Device settings', () => {
     const startEmuOpts = {
         version: '2-main',
-        model: 'R', // TODO: T2B1 DeviceModelInternal
+        model: 'T2B1',
         wipe: true,
     };
 

--- a/packages/suite-web/e2e/tests/settings/t2t1-device-settings.test.ts
+++ b/packages/suite-web/e2e/tests/settings/t2t1-device-settings.test.ts
@@ -66,7 +66,7 @@ describe('T2T1 - Device settings', () => {
     });
 
     it('unable to change homescreen in firmware < 2.5.4', () => {
-        cy.task('startEmu', { wipe: true, version: '2.5.3' });
+        cy.task('startEmu', { wipe: true, model: 'T2T1', version: '2.5.3' });
         cy.task('setupEmu');
 
         cy.prefixedVisit('/');
@@ -82,7 +82,7 @@ describe('T2T1 - Device settings', () => {
     });
 
     it('able to change homescreen in firmware >= 2.5.4', () => {
-        cy.task('startEmu', { wipe: true, version: '2-main' });
+        cy.task('startEmu', { wipe: true, model: 'T2T1', version: '2-main' });
         cy.task('setupEmu');
 
         cy.prefixedVisit('/');

--- a/packages/suite-web/e2e/tests/suite/passphrase-cancel.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase-cancel.test.ts
@@ -2,8 +2,9 @@
 // @retry=2
 
 const testedVersions = [
-    '2-latest',
-    '1.11.2', // Todo: fix latest version to return proper revision hash (it reports possibly FAKE device now)
+    // Todo: fix latest version to return proper revision hash (it reports possibly FAKE device now)
+    { version: '2-latest', model: 'T2T1' },
+    { version: '1.11.2', model: 'T1B1' },
 ];
 
 describe('Passphrase cancel', () => {
@@ -12,8 +13,8 @@ describe('Passphrase cancel', () => {
     });
 
     testedVersions.forEach(version => {
-        it(version, () => {
-            cy.task('startEmu', { wipe: true, version });
+        it(version.model + '_' + version.version, () => {
+            cy.task('startEmu', { wipe: true, ...version });
             cy.task('setupEmu', {
                 mnemonic: 'all all all all all all all all all all all all',
                 passphrase_protection: true,

--- a/packages/transport-test/e2e/bridge/bridge.test.ts
+++ b/packages/transport-test/e2e/bridge/bridge.test.ts
@@ -7,7 +7,7 @@ import { pathLength, descriptor as expectedDescriptor } from './expect';
 // todo: introduce global jest config for e2e
 jest.setTimeout(60000);
 
-const emulatorStartOpts = { version: '2-main', wipe: true };
+const emulatorStartOpts = { model: 'T2T1', version: '2-main', wipe: true } as const;
 
 describe('bridge', () => {
     beforeAll(async () => {

--- a/packages/transport-test/e2e/bridge/multi-client.test.ts
+++ b/packages/transport-test/e2e/bridge/multi-client.test.ts
@@ -20,7 +20,7 @@ const getDescriptor = (descriptor: any): Descriptor => ({
     ...descriptor,
 });
 
-const emulatorStartOpts = { version: '2-main', wipe: true };
+const emulatorStartOpts = { model: 'T2T1', version: '2-main', wipe: true } as const;
 
 describe('bridge', () => {
     let bridge1: BridgeTransport;

--- a/packages/trezor-user-env-link/src/api.ts
+++ b/packages/trezor-user-env-link/src/api.ts
@@ -56,6 +56,7 @@ export class TrezorUserEnvLinkClass extends TypedEmitter<WebsocketClientEvents> 
     private client: WebsocketClient;
     public firmwares?: Firmwares;
     private defaultFirmware?: string;
+    private defaultModel: Model = 'T2T1';
 
     // todo: remove later, used in some of the tests
     public send: WebsocketClient['send'];
@@ -69,7 +70,7 @@ export class TrezorUserEnvLinkClass extends TypedEmitter<WebsocketClientEvents> 
             // select the highest version from the list of available firmwares.
             // this is the version that is likely to be the newest production.
             this.defaultFirmware = semverRSort(
-                this.firmwares['2'].filter(fw => semverValid(fw)),
+                this.firmwares[this.defaultModel].filter(fw => semverValid(fw)),
             )[0];
         });
 
@@ -139,6 +140,7 @@ export class TrezorUserEnvLinkClass extends TypedEmitter<WebsocketClientEvents> 
     async startEmu(arg?: StartEmu) {
         const params = {
             type: 'emulator-start',
+            model: this.defaultModel,
             version: this.defaultFirmware || '2-main',
             ...arg,
         };

--- a/packages/trezor-user-env-link/src/types.ts
+++ b/packages/trezor-user-env-link/src/types.ts
@@ -1,4 +1,4 @@
 /** device model as expected by trezor-user-env */
-export type Model = 'T3T1' | '1' | '2' | 'R';
+export type Model = 'T1B1' | 'T2T1' | 'T2B1' | 'T3T1';
 
 export type Firmwares = Record<Model, string[]>;

--- a/scripts/ci/connect-test-matrix-generator.js
+++ b/scripts/ci/connect-test-matrix-generator.js
@@ -86,7 +86,7 @@ const canaryFirmware = {
 
 const otherDevices = {
     firmwares: ['2-latest'],
-    models: ['R', 'T3T1'],
+    models: ['T2B1', 'T3T1'],
     tests: [
         ...Object.values(groups).filter(
             // management, btc-others are specified below


### PR DESCRIPTION
## Description

Update trezor-user-env with latest changes from https://github.com/trezor/trezor-user-env/pull/253

With this change, versions such as `2-latest` are no longer used. Instead the model must be provided and version is specified independently - eg. `model: 'T2T1', version: '-latest'`