### PR TITLE
fix(suite): do not override BigNumber config as it is set to 1e9 anyway

### DIFF
--- a/packages/suite/src/components/suite/NumberInput.tsx
+++ b/packages/suite/src/components/suite/NumberInput.tsx
@@ -59,14 +59,7 @@ const cleanValueString = (value: string, locale: Locale) => {
         cleanedValue = cleanedValue.slice(0, cleanedValue.length - 1);
     }
 
-    if (cleanedValue) {
-        // do not convert to the exponential format to avoid unexpected results
-        BigNumber.config({ EXPONENTIAL_AT: 20 });
-
-        cleanedValue = new BigNumber(cleanedValue).toFixed();
-    }
-
-    return cleanedValue;
+    return cleanedValue ? new BigNumber(cleanedValue).toFixed() : cleanedValue;
 };
 
 const DECIMAL_SEPARATORS = [',', '.'];


### PR DESCRIPTION
## Description

- in case user used number input and he staked big amount of ETH, it broke his app 
- it is not required to change the config anymore as we do it globaly to pretty big number
- as it goes to release, I wanted to keep it as safe as possible

**How to test this?**
- extend `ETH staking` e2e test to first go into send form, fill really long number into amount form (need to be valid), has to be more than 21 numbers and then navigate to staking dashboard with the mocked data in the existing test (the account has 1234 ETH, so you should be able to fill that long amount)

## Related Issue

Resolve sentry issue
![Screenshot 2024-08-19 at 11 42 13](https://github.com/user-attachments/assets/3a8cee3a-d898-4c01-99b7-5cc124726449)
