### PR TITLE
test(connect): randomize node tests

### DIFF
--- a/.github/workflows/template-connect-test-params.yml
+++ b/.github/workflows/template-connect-test-params.yml
@@ -34,6 +34,11 @@ on:
         type: "string"
         required: false
         default: ""
+      testRandomizedOrder:
+        description: "Tests will be run in randomized order"
+        type: "boolean"
+        required: false
+        default: false
 
 jobs:
   node:
@@ -59,7 +64,9 @@ jobs:
         run: echo "ADDITIONAL_ARGS=$ADDITIONAL_ARGS -m ${{ inputs.testFirmwareModel }}" >> "$GITHUB_ENV"
       - if: ${{ inputs.methods }}
         run: echo "ADDITIONAL_ARGS=$ADDITIONAL_ARGS -i ${{ inputs.methods }}" >> "$GITHUB_ENV"
-      - run: './docker/docker-connect-test.sh node -p "${{ inputs.testPattern }}" -f "${{ inputs.testsFirmware }}" -r $ADDITIONAL_ARGS'
+      - if: ${{ inputs.testRandomizedOrder }}
+        run: echo "ADDITIONAL_ARGS=$ADDITIONAL_ARGS -r" >> "$GITHUB_ENV"
+      - run: './docker/docker-connect-test.sh node -p "${{ inputs.testPattern }}" -f "${{ inputs.testsFirmware }}" $ADDITIONAL_ARGS'
 
   web:
     name: "web-${{ inputs.testDescription }}"

--- a/.github/workflows/template-connect-test-params.yml
+++ b/.github/workflows/template-connect-test-params.yml
@@ -59,7 +59,7 @@ jobs:
         run: echo "ADDITIONAL_ARGS=$ADDITIONAL_ARGS -m ${{ inputs.testFirmwareModel }}" >> "$GITHUB_ENV"
       - if: ${{ inputs.methods }}
         run: echo "ADDITIONAL_ARGS=$ADDITIONAL_ARGS -i ${{ inputs.methods }}" >> "$GITHUB_ENV"
-      - run: './docker/docker-connect-test.sh node -p "${{ inputs.testPattern }}" -f "${{ inputs.testsFirmware }}" $ADDITIONAL_ARGS'
+      - run: './docker/docker-connect-test.sh node -p "${{ inputs.testPattern }}" -f "${{ inputs.testsFirmware }}" -r $ADDITIONAL_ARGS'
 
   web:
     name: "web-${{ inputs.testDescription }}"

--- a/.github/workflows/test-connect.yml
+++ b/.github/workflows/test-connect.yml
@@ -69,7 +69,8 @@ jobs:
     outputs:
       dailyMatrix: ${{ steps.set-matrix-daily.outputs.dailyMatrix }}
       otherDevicesMatrix: ${{ steps.set-matrix-other-devices.outputs.otherDevicesMatrix }}
-      legacyCanaryFirmwareMatrix: ${{ steps.set-matrix-legacy-canary-firmware.outputs.legacyCanaryFirmwareMatrix }}
+      legacyFirmwareMatrix: ${{ steps.set-matrix-legacy-firmware.outputs.legacyFirmwareMatrix }}
+      canaryFirmwareMatrix: ${{ steps.set-matrix-canary-firmware.outputs.canaryFirmwareMatrix }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -78,17 +79,21 @@ jobs:
         id: set-matrix-daily
         run: echo "dailyMatrix=$(node ./scripts/ci/connect-test-matrix-generator.js daily)" >> $GITHUB_OUTPUT
 
+      - name: Set legacy devices matrix
+        id: set-matrix-legacy-firmware
+        run: echo "legacyFirmwareMatrix=$(node ./scripts/ci/connect-test-matrix-generator.js legacyFirmware)" >> $GITHUB_OUTPUT
+
+      - name: Set canary devices matrix
+        id: set-matrix-canary-firmware
+        run: echo "canaryFirmwareMatrix=$(node ./scripts/ci/connect-test-matrix-generator.js canaryFirmware)" >> $GITHUB_OUTPUT
+
       - name: Set other devices matrix
         id: set-matrix-other-devices
         run: echo "otherDevicesMatrix=$(node ./scripts/ci/connect-test-matrix-generator.js otherDevices)" >> $GITHUB_OUTPUT
 
-      - name: Set other devices matrix
-        id: set-matrix-legacy-canary-firmware
-        run: echo "legacyCanaryFirmwareMatrix=$(node ./scripts/ci/connect-test-matrix-generator.js legacyCanaryFirmware)" >> $GITHUB_OUTPUT
-
-  connect-daily:
+  connect-PR:
     needs: [build, set-matrix]
-    name: daily-${{ matrix.name }}
+    name: PR-${{ matrix.name }}
     uses: ./.github/workflows/template-connect-test-params.yml
     with:
       testPattern: ${{ matrix.pattern }}
@@ -99,10 +104,27 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.set-matrix.outputs.dailyMatrix) }}
 
-  connect-legacy-canary-firmware:
+  connect-randomized-order:
     needs: [build, set-matrix]
     if: github.event_name == 'schedule' &&  github.repository == 'trezor/trezor-suite'
-    name: legacy-canary-${{ matrix.name }}
+    name: randomized-${{ matrix.name }}
+    uses: ./.github/workflows/template-connect-test-params.yml
+    with:
+      testPattern: ${{ matrix.pattern }}
+      methods: ${{ matrix.methods }}
+      testsFirmware: ${{ matrix.firmware }}
+      testDescription: ${{ matrix.name }}-${{ matrix.firmware }}
+      testRandomizedOrder: true
+      webEnvironment: false
+      nodeEnvironment: true
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.set-matrix.outputs.dailyMatrix) }}
+
+  connect-legacy-firmware:
+    needs: [build, set-matrix]
+    if: github.event_name == 'schedule' &&  github.repository == 'trezor/trezor-suite'
+    name: legacy-${{ matrix.name }}
     uses: ./.github/workflows/template-connect-test-params.yml
     with:
       testPattern: ${{ matrix.pattern }}
@@ -111,7 +133,21 @@ jobs:
       testDescription: ${{ matrix.name }}-${{ matrix.firmware }}
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.set-matrix.outputs.legacyCanaryFirmwareMatrix) }}
+      matrix: ${{ fromJson(needs.set-matrix.outputs.legacyFirmwareMatrix) }}
+
+  connect-canary-firmware:
+    needs: [build, set-matrix]
+    if: github.event_name == 'schedule' &&  github.repository == 'trezor/trezor-suite'
+    name: canary-${{ matrix.name }}
+    uses: ./.github/workflows/template-connect-test-params.yml
+    with:
+      testPattern: ${{ matrix.pattern }}
+      methods: ${{ matrix.methods }}
+      testsFirmware: ${{ matrix.firmware }}
+      testDescription: ${{ matrix.name }}-${{ matrix.firmware }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.set-matrix.outputs.canaryFirmwareMatrix) }}
 
   connect-other-devices:
     needs: [build, set-matrix]
@@ -123,8 +159,8 @@ jobs:
       methods: ${{ matrix.methods }}
       testsFirmware: ${{ matrix.firmware }}
       testFirmwareModel: ${{ matrix.model }}
-      nodeEnvironment: ${{ matrix.nodeEnvironment }}
-      webEnvironment: ${{ matrix.webEnvironment }}
+      nodeEnvironment: true
+      webEnvironment: false
       testDescription: ${{ matrix.name }}-${{ matrix.firmware }}-${{ matrix.model }}
     strategy:
       fail-fast: false

--- a/docker/docker-compose.connect-test.yml
+++ b/docker/docker-compose.connect-test.yml
@@ -6,7 +6,7 @@ services:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp
     network_mode: bridge
-
+  # todo: this is probably not necessary to run these tests in its dedicated container
   test-run:
     image: registry.gitlab.com/satoshilabs/trezor/trezor-suite/base:latest
     environment:
@@ -18,6 +18,7 @@ services:
       - TESTS_PATTERN=$TESTS_PATTERN
       - TESTS_USE_TX_CACHE=$TESTS_USE_TX_CACHE
       - TESTS_USE_WS_CACHE=$TESTS_USE_WS_CACHE
+      - TESTS_RANDOM=$TESTS_RANDOM
     depends_on:
       - trezor-user-env-unix
     network_mode: service:trezor-user-env-unix

--- a/docker/docker-connect-test.sh
+++ b/docker/docker-connect-test.sh
@@ -40,6 +40,7 @@ show_usage() {
   echo "  -s       actual test script. default: 'yarn test:integration'"
   echo "  -u       Firmware url"
   echo "  -m       Firmware model, example: R'"
+  echo "  -r       Randomize test order (node only)"
 }
 
 # default options
@@ -54,10 +55,11 @@ USE_TX_CACHE=true
 USE_WS_CACHE=true
 PATTERN=""
 FIRMWARE_MODEL=""
+RANDOMIZE=false
 
 # user options
 OPTIND=2
-while getopts ":p:i:e:f:u:m:D:hdc" opt; do
+while getopts ":p:i:e:f:u:m:D:hdcr" opt; do
   case $opt in
   d)
     DOCKER=false
@@ -86,6 +88,9 @@ while getopts ":p:i:e:f:u:m:D:hdc" opt; do
     ;;
   m)
     FIRMWARE_MODEL=$OPTARG
+    ;;
+  r)
+    RANDOMIZE=true
     ;;
   h) # Script usage
     show_usage
@@ -118,6 +123,7 @@ export TESTS_PATTERN=$PATTERN
 export TESTS_SCRIPT=$SCRIPT
 export TESTS_FIRMWARE_URL=$FIRMWARE_URL
 export TESTS_FIRMWARE_MODEL=$FIRMWARE_MODEL
+export TESTS_RANDOM=$RANDOMIZE
 
 runDocker() {
   docker compose -f ./docker/docker-compose.connect-test.yml up --abort-on-container-exit
@@ -134,6 +140,7 @@ run() {
   echo "  Excluded methods: ${EXCLUDED_METHODS}"
   echo "  TxCache: ${USE_TX_CACHE}"
   echo "  WsCache: ${USE_WS_CACHE}"
+  echo "  Random: ${RANDOMIZE}"
 
   if [ $DOCKER = true ]; then
     runDocker

--- a/packages/connect/e2e/run.ts
+++ b/packages/connect/e2e/run.ts
@@ -92,6 +92,14 @@ const getEmulatorOptions = (availableFirmwares: Firmwares) => {
     if (process.argv[2] === 'node') {
         // eslint-disable-next-line no-console
         console.log('jest version: ', getJestVersion());
+
+        if (process.env.TESTS_RANDOM === 'true') {
+            // @ts-expect-error
+            argv.showSeed = true;
+            // @ts-expect-error
+            argv.randomize = true;
+        }
+
         // @ts-expect-error
         const { results } = await runCLI(argv, [__dirname]).catch(err => {
             console.error(err);

--- a/scripts/ci/connect-test-matrix-generator.js
+++ b/scripts/ci/connect-test-matrix-generator.js
@@ -66,40 +66,29 @@ const groups = {
         methods: 'binanceGetAddress,binanceGetPublicKey,binanceSignTransaction',
     },
 };
+
 const daily = {
     firmwares: ['2-latest'],
-    tests: [
-        groups.api,
-        groups.management,
-        groups.btcSign,
-        groups.btcOthers,
-        groups.stellar,
-        groups.cardano,
-        groups.eos,
-        groups.ethereum,
-        groups.nem,
-        groups.ripple,
-        groups.tezos,
-        groups.binance,
-    ],
+    tests: [...Object.values(groups)],
 };
 
-const legacyCanaryFirmware = {
-    firmwares: ['2.3.0', '2-main'],
+const legacyFirmware = {
+    firmwares: ['2.3.0'],
     tests: daily.tests
         // Cardano supports >=2.6.0
         .filter(test => test.name !== 'cardano'),
+};
+
+const canaryFirmware = {
+    firmwares: ['2-main'],
+    tests: daily.tests,
 };
 
 const otherDevices = {
     firmwares: ['2-latest'],
     models: ['R', 'T3T1'],
     tests: [
-        {
-            ...groups.api,
-            webEnvironment: true,
-            nodeEnvironment: true,
-        },
+        ...Object.values(groups).filter(g => g.name !== 'management' && g.name !== 'btc-others'),
         {
             ...groups.management,
             methods: groups.management.methods
@@ -107,8 +96,6 @@ const otherDevices = {
                 // getFeatures test is not abstract enough to serve all models
                 .filter(m => m !== 'getFeatures')
                 .join(','),
-            webEnvironment: false,
-            nodeEnvironment: true,
         },
         {
             ...groups.btcOthers,
@@ -117,38 +104,6 @@ const otherDevices = {
                 // getAddress (decred) does not work for model R
                 .filter(m => m !== 'getAddress')
                 .join(','),
-            webEnvironment: false,
-            nodeEnvironment: true,
-        },
-        {
-            ...groups.stellar,
-            webEnvironment: false,
-            nodeEnvironment: true,
-        },
-        {
-            ...groups.cardano,
-            webEnvironment: false,
-            nodeEnvironment: true,
-        },
-        {
-            ...groups.ethereum,
-            webEnvironment: false,
-            nodeEnvironment: true,
-        },
-        {
-            ...groups.ripple,
-            webEnvironment: false,
-            nodeEnvironment: true,
-        },
-        {
-            ...groups.tezos,
-            webEnvironment: false,
-            nodeEnvironment: true,
-        },
-        {
-            ...groups.binance,
-            webEnvironment: false,
-            nodeEnvironment: true,
         },
     ],
 };
@@ -165,8 +120,9 @@ const prepareTest = ({ firmwares, tests, models }) => {
 
 const testData = {
     daily,
+    legacyFirmware,
+    canaryFirmware,
     otherDevices,
-    legacyCanaryFirmware,
 };
 
 const args = process.argv.slice(2);


### PR DESCRIPTION
- tests in branches - no random - we want to have maximum stability, randomization turned of for karma in https://github.com/trezor/trezor-suite/pull/13863
- tests in nightly - random to get maximum coverage. 

<img width="613" alt="image" src="https://github.com/user-attachments/assets/4e407c8d-70cd-4b41-a52a-fbfb8ebe98c3">

in nightly there are now:

canary fw tests:

<img width="511" alt="image" src="https://github.com/user-attachments/assets/5e189738-00ed-4ba1-a88c-eaf2d36e6322">

legacy fw tests:

<img width="314" alt="image" src="https://github.com/user-attachments/assets/314aed73-a3d2-4a06-9be8-96b4e19107ca">

randomized tests:

<img width="585" alt="image" src="https://github.com/user-attachments/assets/1f45baee-1155-4e94-afad-2a5a6f0e1076">

other devices tests - ts3 and ts5, only in node. 