### PR TITLE
fix(connect-web): run closeInterval for useCoreInPopup

### DIFF
--- a/packages/connect-web/src/popup/index.ts
+++ b/packages/connect-web/src/popup/index.ts
@@ -184,11 +184,6 @@ export class PopupManager extends EventEmitter {
         const url = this.buildPopupUrl(src);
         this.openWrapper(url);
 
-        if (this.settings.useCoreInPopup) {
-            // Timeout not used in Core mode, we can't run showPopupRequest with no DOM
-            return;
-        }
-
         this.closeInterval = setInterval(() => {
             if (!this.popupWindow) return;
             if (this.popupWindow.mode === 'tab' && this.popupWindow.tab.id) {


### PR DESCRIPTION
## Description

In PopupManager there is a function `closeInterval`, which periodically checks if the popup window is actually open. 
This logic was skipped for `useCoreInPopup`, which resulted in slower handling of closed popups, with this change it's enabled again.

## Related Issue

Resolve #13856