### PR TITLE
fix(staking): error duplication in unstake modal

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/Inputs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/Inputs.tsx
@@ -9,7 +9,7 @@ import { variables } from '@trezor/components/src/config';
 import { validateDecimals, validateLimitsBigNum, validateMin } from 'src/utils/suite/validation';
 import { useUnstakeEthFormContext } from 'src/hooks/wallet/useUnstakeEthForm';
 import { useFormatters } from '@suite-common/formatters';
-import { getInputState } from '@suite-common/wallet-utils';
+import { getInputState, getNonComposeErrorMessage } from '@suite-common/wallet-utils';
 
 const HStack = styled.div`
     display: flex;
@@ -74,7 +74,7 @@ export const Inputs = () => {
                 rules={cryptoInputRules}
                 maxLength={formInputsMaxLength.amount}
                 innerAddon={<InputAddon>{symbol}</InputAddon>}
-                bottomText={errors[CRYPTO_INPUT]?.message ?? null}
+                bottomText={getNonComposeErrorMessage(errors[CRYPTO_INPUT])}
                 inputState={getInputState(cryptoError || fiatError)}
                 onChange={value => {
                     onCryptoAmountChange(value);
@@ -94,7 +94,7 @@ export const Inputs = () => {
                         rules={fiatInputRules}
                         maxLength={formInputsMaxLength.fiat}
                         innerAddon={<InputAddon>{localCurrency}</InputAddon>}
-                        bottomText={errors[FIAT_INPUT]?.message ?? null}
+                        bottomText={getNonComposeErrorMessage(errors[FIAT_INPUT])}
                         inputState={getInputState(fiatError || cryptoError)}
                         onChange={value => {
                             onFiatAmountChange(value);

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/UnstakeEthForm.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/UnstakeEthForm.tsx
@@ -74,6 +74,9 @@ export const UnstakeEthForm = () => {
     const isDisabled =
         !(formIsValid && hasValues) || isSubmitting || isLocked() || !device?.available;
 
+    const inputError = errors[CRYPTO_INPUT] || errors[FIAT_INPUT];
+    const showError = inputError && inputError.type === 'compose';
+
     return (
         <form onSubmit={handleSubmit(signTx)}>
             {canClaim && (
@@ -92,10 +95,8 @@ export const UnstakeEthForm = () => {
             <Options symbol={symbol} />
 
             <WarningsWrapper>
-                {errors[CRYPTO_INPUT] && (
-                    <StyledWarning variant="destructive">
-                        {errors[CRYPTO_INPUT]?.message}
-                    </StyledWarning>
+                {showError && (
+                    <StyledWarning variant="destructive">{inputError?.message}</StyledWarning>
                 )}
             </WarningsWrapper>
 

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -189,6 +189,9 @@ export const getInputState = (
     }
 };
 
+export const getNonComposeErrorMessage = (error: FieldError | undefined) =>
+    (error?.type !== 'compose' && error?.message) ?? null;
+
 export const isLowAnonymityWarning = (error?: Merge<FieldError, FieldErrorsImpl<Output>>) =>
     error?.amount?.type === COMPOSE_ERROR_TYPES.ANONYMITY;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed an issue where the error message was duplicated in unstake modal. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/13753

## Screenshots:
![image](https://github.com/user-attachments/assets/00295d01-7568-40bc-ba23-652730064662)
