### PR TITLE
test(connect): fix tests to correctly pick test files

### DIFF
--- a/packages/connect/e2e/jest.config.ts
+++ b/packages/connect/e2e/jest.config.ts
@@ -20,6 +20,6 @@ export default {
     bail: true,
     testEnvironment: 'node',
     globals: {},
-    watchPathIgnorePatterns: ['<rootDir>/libDev'],
-    testPathIgnorePatterns: ['<rootDir>/libDev'],
+    watchPathIgnorePatterns: ['<rootDir>/libDev', '<rootDir>/lib', '<rootDir>/src'],
+    testPathIgnorePatterns: ['<rootDir>/libDev', '<rootDir>/lib', '<rootDir>/src'],
 };

--- a/packages/connect/e2e/run.ts
+++ b/packages/connect/e2e/run.ts
@@ -93,9 +93,12 @@ const getEmulatorOptions = (availableFirmwares: Firmwares) => {
         // eslint-disable-next-line no-console
         console.log('jest version: ', getJestVersion());
         // @ts-expect-error
-        const { results } = await runCLI(argv, [__dirname]);
+        const { results } = await runCLI(argv, [__dirname]).catch(err => {
+            console.error(err);
+            process.exit(1);
+        });
 
-        process.exit(results.numFailedTests);
+        process.exit(results.numFailedTestSuites);
     } else if (process.argv[2] === 'web') {
         const { parseConfig } = karma.config;
         const { Server } = karma;


### PR DESCRIPTION
tests in connect were incorrectly matching non-tests files
https://github.com/trezor/trezor-suite/actions/runs/10444906035/job/28931786469#step:9:1697

this should be fixed in 9efbe0cc3347922aec5aebd2ad63a6b76aa26e5e

also I noticed a problem that when all the tests fail (or the test suite fails to run), our tests are still green. this is why the problem above went unnoticed. [e6a1e7b](https://github.com/trezor/trezor-suite/pull/13874/commits/e6a1e7b172c6a3848d7e2a8d3b4857fcff97c1d5) should be fixing it. 
- run where it failed correctly https://github.com/trezor/trezor-suite/actions/runs/10453335826/job/28943650060?pr=13874