### PR TITLE
Set connection status default to online

### DIFF
--- a/suite-native/connection-status/src/useIsOfflineBannerVisible.tsx
+++ b/suite-native/connection-status/src/useIsOfflineBannerVisible.tsx
@@ -6,7 +6,9 @@ import { selectIsOnboardingFinished } from '@suite-native/settings';
 
 export const useIsOfflineBannerVisible = () => {
     const isOnboardingFinished = useSelector(selectIsOnboardingFinished);
-    const { isConnected } = useNetInfo();
+    const { isInternetReachable } = useNetInfo();
 
-    return !isConnected && isOnboardingFinished;
+    const isReachable = isInternetReachable ?? true;
+
+    return !isReachable && isOnboardingFinished;
 };


### PR DESCRIPTION
Connection status default (on app start) is online so we don't show offline banner before connection is checked

Requires retest of #13597 