### PR TITLE
feat(transport): add DebugLink support to NodeUsbTransport and UdpTransport

### DIFF
--- a/packages/transport/src/api/udp.ts
+++ b/packages/transport/src/api/udp.ts
@@ -18,9 +18,11 @@ export class UdpApi extends AbstractApi {
 
     private enumerationTimeout: ReturnType<typeof setTimeout> | undefined;
     private enumerateAbortController = new AbortController();
+    private debugLink?: boolean;
 
-    constructor({ logger }: AbstractApiConstructorParams) {
+    constructor({ logger, debugLink }: AbstractApiConstructorParams & { debugLink?: boolean }) {
         super({ logger });
+        this.debugLink = debugLink;
     }
 
     listen() {
@@ -160,7 +162,7 @@ export class UdpApi extends AbstractApi {
 
     public async enumerate(signal?: AbortSignal) {
         // in theory we could support multiple devices, but we don't yet
-        const paths = ['127.0.0.1:21324'];
+        const paths = this.debugLink ? ['127.0.0.1:21325'] : ['127.0.0.1:21324'];
 
         try {
             const enumerateResult = await Promise.all(

--- a/packages/transport/src/constants.ts
+++ b/packages/transport/src/constants.ts
@@ -2,6 +2,8 @@
 export const CONFIGURATION_ID = 1;
 export const INTERFACE_ID = 0;
 export const ENDPOINT_ID = 1;
+export const DEBUGLINK_INTERFACE_ID = 1;
+export const DEBUGLINK_ENDPOINT_ID = 2;
 export const T1_HID_VENDOR = 0x534c;
 
 const T1_HID_PRODUCT = 0x0001;

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -48,6 +48,7 @@ export interface AbstractTransportParams {
     messages?: Record<string, any>;
     signal: AbortSignal;
     logger?: Logger;
+    debugLink?: boolean;
 }
 
 export const isTransportInstance = (transport?: AbstractTransport) => {

--- a/packages/transport/src/transports/nodeusb.ts
+++ b/packages/transport/src/transports/nodeusb.ts
@@ -13,7 +13,7 @@ export class NodeUsbTransport extends AbstractApiTransport {
     public name = 'NodeUsbTransport' as const;
 
     constructor(params: AbstractTransportParams) {
-        const { messages, logger, signal } = params;
+        const { messages, logger, signal, debugLink } = params;
         const sessionsBackground = new SessionsBackground({ signal });
 
         // in nodeusb there is no synchronization yet. this is a followup and needs to be decided
@@ -34,6 +34,7 @@ export class NodeUsbTransport extends AbstractApiTransport {
                     allowAllDevices: true, // return all devices, not only authorized
                 }),
                 logger,
+                debugLink,
             }),
             sessionsClient,
             signal,

--- a/packages/transport/src/transports/udp.ts
+++ b/packages/transport/src/transports/udp.ts
@@ -11,7 +11,7 @@ export class UdpTransport extends AbstractApiTransport {
     private enumerateTimeout: ReturnType<typeof setTimeout> | undefined;
 
     constructor(params: AbstractTransportParams) {
-        const { messages, logger, signal } = params;
+        const { messages, logger, signal, debugLink } = params;
         const sessionsBackground = new SessionsBackground({ signal });
 
         // in udp there is no synchronization yet. it depends where this transport runs (node or browser)
@@ -26,7 +26,7 @@ export class UdpTransport extends AbstractApiTransport {
 
         super({
             messages,
-            api: new UdpApi({ logger }),
+            api: new UdpApi({ logger, debugLink }),
             logger,
             sessionsClient,
             signal,


### PR DESCRIPTION
…

<!--- Provide a general summary of your changes in the Title above -->

## Description

Add support for `DebugLink` messages.
Using debug link interface would not break current workflow (like SignTx) and make it possible to send `DebugLinkDecisions`

useful for testing on physical device (debug link build FW) and emulator without `trezor-user-env`

## TODO and to discuss:
- [ ] add tests
- [ ] add support to `WebUsbTransport` ?
- [ ] add support to `transport-bridge/TrezordNode` ? (add /debug endpoints like in old bridge) ?
- [ ]  should it be possible to run a Transport with and without `debugLink` simultaneously? (then `debugLink` param should be passed to each api method: open, close, read, write)
