### PR TITLE
fix(suite): add dynamic property to coinmarket strings

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -1742,10 +1742,12 @@ export default defineMessages({
     TR_COINMARKET_FEATURED_OFFER_PAYMENT_METHOD_BUY_LABEL: {
         defaultMessage: 'Payment:',
         id: 'TR_COINMARKET_FEATURED_OFFER_PAYMENT_METHOD_BUY_LABEL',
+        dynamic: true,
     },
     TR_COINMARKET_FEATURED_OFFER_PAYMENT_METHOD_SELL_LABEL: {
         defaultMessage: 'Receive method:',
         id: 'TR_COINMARKET_FEATURED_OFFER_PAYMENT_METHOD_SELL_LABEL',
+        dynamic: true,
     },
     TR_COINMARKET_FEATURED_OFFER_BUY: {
         defaultMessage: 'Buy',


### PR DESCRIPTION
Adding `dynamic=true` property to "TR_COINMARKET_FEATURED_OFFER_PAYMENT_METHOD_BUY_LABEL" and  "TR_COINMARKET_FEATURED_OFFER_PAYMENT_METHOD_SELL_LABEL" as they are used dynamically in the code. Otherwise crowdin sync would delete them. 

cc @adderpositive reminder for the future :) :D 