### PR TITLE
fix(suite): select overlapping with modal

### DIFF
--- a/packages/components/src/components/form/Select/Select.tsx
+++ b/packages/components/src/components/form/Select/Select.tsx
@@ -34,10 +34,11 @@ const reactSelectClassNamePrefix = 'react-select';
 const createSelectStyle = (
     theme: DefaultTheme,
     elevation: Elevation,
+    isRenderedInModal: boolean,
 ): StylesConfig<Option, boolean> => ({
     menuPortal: base => ({
         ...base,
-        zIndex: zIndices.modal /* Necessary to be visible inside a Modal */,
+        zIndex: isRenderedInModal ? zIndices.modal : zIndices.selectMenu,
     }),
     // menu styles are here because of the portal
     menu: base => ({
@@ -51,7 +52,6 @@ const createSelectStyle = (
         borderRadius: borders.radii.md,
         background: theme.backgroundSurfaceElevation1,
         boxShadow: theme.boxShadowElevated,
-        zIndex: zIndices.modal,
         animation: `${DROPDOWN_MENU.getName()} 0.15s ease-in-out`,
         listStyleType: 'none',
         overflow: 'hidden',
@@ -298,6 +298,7 @@ export const Select = ({
     const theme = useTheme();
     const onKeyDown = useOnKeyDown(selectRef, useKeyPressScroll);
     const menuPortalTarget = useDetectPortalTarget(selectRef);
+    const isRenderedInModal = menuPortalTarget !== null;
 
     const handleOnChange = useCallback<Required<ReactSelectProps>['onChange']>(
         (value, { action }) => {
@@ -355,7 +356,7 @@ export const Select = ({
                 closeMenuOnScroll={closeMenuOnScroll}
                 menuPosition="fixed" // Required for closeMenuOnScroll to work properly when near page bottom
                 menuPortalTarget={menuPortalTarget}
-                styles={createSelectStyle(theme, elevation)}
+                styles={createSelectStyle(theme, elevation, isRenderedInModal)}
                 onChange={handleOnChange}
                 isSearchable={isSearchable}
                 menuIsOpen={menuIsOpen}

--- a/packages/theme/src/zIndices.ts
+++ b/packages/theme/src/zIndices.ts
@@ -18,6 +18,7 @@ export const zIndices = {
     pageHeader: 11, // above STICKY_BAR to hide it when the page is on top
     stickyBar: 10, // above page content to scroll over it
     secondaryStickyBar: 9, // below STICKY_BAR so that it can hide beneath it when no longer needed
+    selectMenu: 3,
     onboardingForeground: 2, // for handling multiple layers on the onboarding page
     base: 1, // above static content to be fully visible
 } as const;


### PR DESCRIPTION
Selects had z-index set to the same value as modals because of the case when they were rendered inside of one. This could cause an overlap when a modal was opened while a select outside the modal was active. 

## Screenshots:

### Before:
<img width="652" alt="Screenshot 2024-08-20 at 20 46 41" src="https://github.com/user-attachments/assets/9928ece9-01bb-4d10-b461-7177ee5bfc0c">

### After:
<img width="652" alt="Screenshot 2024-08-20 at 20 45 06" src="https://github.com/user-attachments/assets/df747812-8b3b-446c-b599-af0bf8292ec6">

