### PR TITLE
Transport misc improvements

### DIFF
--- a/packages/transport-test/e2e/api/api.test.ts
+++ b/packages/transport-test/e2e/api/api.test.ts
@@ -97,7 +97,7 @@ const runTests = async () => {
         // concurrent enumeration triggered couple of lines below works correctly
         await sharedTest('concurrent enumerate - as the first operation', () =>
             // todo: 3 doesn't work in node!!! FIX
-            concurrentEnumerate(typeof window === 'undefined' ? 3 : 1),
+            concurrentEnumerate(typeof window !== 'undefined' ? 3 : 1),
         );
         await getConnectedDevicePath();
 

--- a/packages/transport-test/e2e/bridge/bridge.test.ts
+++ b/packages/transport-test/e2e/bridge/bridge.test.ts
@@ -10,24 +10,15 @@ jest.setTimeout(60000);
 const emulatorStartOpts = { model: 'T2T1', version: '2-main', wipe: true } as const;
 
 describe('bridge', () => {
-    beforeAll(async () => {
-        await TrezorUserEnvLink.connect();
-    });
-
-    afterAll(async () => {
-        await TrezorUserEnvLink.stopEmu();
-        await TrezorUserEnvLink.stopBridge();
-        TrezorUserEnvLink.disconnect();
-    });
-
     let bridge: any;
     let devices: any[];
     let session: any;
-    beforeEach(async () => {
-        // await TrezorUserEnvLink.stopEmu();
-        await TrezorUserEnvLink.stopBridge();
+
+    beforeAll(async () => {
+        await TrezorUserEnvLink.connect();
         await TrezorUserEnvLink.startEmu(emulatorStartOpts);
         await TrezorUserEnvLink.startBridge();
+
         const abortController = new AbortController();
         bridge = new BridgeTransport({ messages, signal: abortController.signal });
         await bridge.init().promise;
@@ -49,12 +40,19 @@ describe('bridge', () => {
 
         devices = enumerateResult.payload;
 
-        const acquireResult = await bridge.acquire({ input: { path: devices[0].path } }).promise;
+        const acquireResult = await bridge.acquire({ input: { path: devices[0].path, session } })
+            .promise;
         expect(acquireResult).toEqual({
             success: true,
             payload: '1',
         });
         session = acquireResult.payload;
+    });
+
+    afterAll(async () => {
+        await TrezorUserEnvLink.stopEmu();
+        await TrezorUserEnvLink.stopBridge();
+        TrezorUserEnvLink.disconnect();
     });
 
     test(`call(GetFeatures)`, async () => {

--- a/packages/transport-test/e2e/bridge/bridge.test.ts
+++ b/packages/transport-test/e2e/bridge/bridge.test.ts
@@ -4,9 +4,6 @@ import { BridgeTransport } from '@trezor/transport';
 import { controller as TrezorUserEnvLink } from './controller';
 import { pathLength, descriptor as expectedDescriptor } from './expect';
 
-// todo: introduce global jest config for e2e
-jest.setTimeout(60000);
-
 const emulatorStartOpts = { model: 'T2T1', version: '2-main', wipe: true } as const;
 
 describe('bridge', () => {

--- a/packages/transport-test/e2e/bridge/jest.config.ts
+++ b/packages/transport-test/e2e/bridge/jest.config.ts
@@ -21,6 +21,7 @@ export const config: Config = {
     bail: true,
     testEnvironment: 'node',
     globals: {},
+    testTimeout: 60000,
 };
 
 // eslint-disable-next-line import/no-default-export

--- a/packages/transport-test/e2e/bridge/multi-client.test.ts
+++ b/packages/transport-test/e2e/bridge/multi-client.test.ts
@@ -4,9 +4,6 @@ import { BridgeTransport, Descriptor } from '@trezor/transport';
 import { controller as TrezorUserEnvLink } from './controller';
 import { descriptor as fixtureDescriptor } from './expect';
 
-// todo: introduce global jest config for e2e
-jest.setTimeout(60000);
-
 const wait = (ms = 1000) =>
     new Promise(resolve => {
         setTimeout(() => {

--- a/packages/transport/src/api/usb.ts
+++ b/packages/transport/src/api/usb.ts
@@ -187,7 +187,7 @@ export class UsbApi extends AbstractApi {
                 `usb: device.transferIn done. status: ${res.status}, byteLength: ${res.data?.byteLength}. device: ${this.formatDeviceForLog(device)}`,
             );
 
-            if (!res.data) {
+            if (!res.data?.byteLength) {
                 return this.error({ error: ERRORS.INTERFACE_DATA_TRANSFER });
             }
 


### PR DESCRIPTION
couple of already mergable cherry-picks from #13790

 - adds more usability to transport-tests - no need to reconnect device all the time. 
 -  it is probably unexpected to read an empty buffer from transport USB API. Nowadays, if this happens, you will fail somewhere on a higher layer where the response is being processed. 
 - move jest.setTimeout to config