### PR TITLE
Feat(suite): Enhance HiddenPlaceholder

### DIFF
--- a/packages/react-utils/jest.config.js
+++ b/packages/react-utils/jest.config.js
@@ -1,0 +1,8 @@
+const baseConfig = require('../../jest.config.base');
+
+module.exports = {
+    ...baseConfig,
+    collectCoverage: true,
+    collectCoverageFrom: ['src/**/*.ts'],
+    testEnvironment: '../../JestCustomEnv.js',
+};

--- a/packages/react-utils/package.json
+++ b/packages/react-utils/package.json
@@ -7,6 +7,7 @@
     "main": "src/index",
     "scripts": {
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "test:unit": "yarn g:jest --verbose -c ./jest.config.js",
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build"
     },

--- a/packages/react-utils/src/index.ts
+++ b/packages/react-utils/src/index.ts
@@ -6,3 +6,4 @@ export { useOnClickOutside } from './hooks/useOnClickOutside';
 export { useTimer } from './hooks/useTimer';
 export { useWindowFocus } from './hooks/useWindowFocus';
 export type { Timer } from './hooks/useTimer';
+export { rewriteReactNodeRecursively } from './rewriteReactNodeRecursively';

--- a/packages/react-utils/src/rewriteReactNodeRecursively.ts
+++ b/packages/react-utils/src/rewriteReactNodeRecursively.ts
@@ -1,0 +1,37 @@
+import { ReactNode, isValidElement, cloneElement, Key } from 'react';
+
+type RewriteReactNodeRecursivelyCallback = (stringSubNode: string) => string;
+
+/**
+ * Recursively crawls ReactNode and applies callback on all string subnodes
+ * @param node ReactNode to be recursively crawled & modified
+ * @param callback function to be applied on all string subnodes
+ * @param reactKey optional React key applied on the root node, if it is a ReactElement. Used internally.
+ * @returns modified ReactNode
+ */
+export const rewriteReactNodeRecursively = (
+    node: ReactNode,
+    callback: RewriteReactNodeRecursivelyCallback,
+    reactKey?: Key,
+): ReactNode => {
+    if (typeof node === 'string') return callback(node);
+    if (typeof node === 'number') return callback(node.toString());
+
+    if (Array.isArray(node)) {
+        return node.map((child, index) => {
+            const newReactKey: Key | undefined = isValidElement(child)
+                ? child.key ?? index
+                : undefined;
+
+            return rewriteReactNodeRecursively(child, callback, newReactKey);
+        });
+    }
+
+    if (isValidElement(node)) {
+        const rewrittenChildren = rewriteReactNodeRecursively(node.props.children, callback);
+
+        return cloneElement(node, { ...node.props, key: reactKey, children: rewrittenChildren });
+    }
+
+    return node;
+};

--- a/packages/react-utils/tests/__snapshots__/rewriteReactNodeRecursively.test.tsx.snap
+++ b/packages/react-utils/tests/__snapshots__/rewriteReactNodeRecursively.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`rewriteReactNodeRecursively should recursively rewrite string subnodes in a ReactElement 1`] = `
+<span>
+  This is barbar, 
+  <i>
+    it has a bar
+  </i>
+  .
+</span>
+`;

--- a/packages/react-utils/tests/rewriteReactNodeRecursively.test.tsx
+++ b/packages/react-utils/tests/rewriteReactNodeRecursively.test.tsx
@@ -1,0 +1,55 @@
+import { rewriteReactNodeRecursively } from '../src/rewriteReactNodeRecursively';
+
+describe('rewriteReactNodeRecursively', () => {
+    const callback = (stringSubNode: string) => stringSubNode.replace(/foo/g, 'bar');
+
+    it('should rewrite a string subnode', () => {
+        const inputNode = 'This is foobar.';
+        const expectedNode = 'This is barbar.';
+        expect(rewriteReactNodeRecursively(inputNode, callback)).toBe(expectedNode);
+    });
+
+    it('should cast a number subnode to string and rewrite it', () => {
+        const callbackForNumbers = (stringifiedNumber: string) =>
+            stringifiedNumber.replace(/34/g, '***');
+        const inputNode = 123456;
+        const expectedNode = '12***56';
+        expect(rewriteReactNodeRecursively(inputNode, callbackForNumbers)).toBe(expectedNode);
+    });
+
+    it('should return the node if it is a primitive other than string or number', () => {
+        expect(rewriteReactNodeRecursively(null, callback)).toBe(null);
+        expect(rewriteReactNodeRecursively(undefined, callback)).toBe(undefined);
+        expect(rewriteReactNodeRecursively(true, callback)).toBe(true);
+    });
+
+    it('should rewrite all string subnodes in an array', () => {
+        const inputNode = ['This is foobar.', 'It has a foo.'];
+        const expectedNode = ['This is barbar.', 'It has a bar.'];
+        expect(rewriteReactNodeRecursively(inputNode, callback)).toEqual(expectedNode);
+    });
+
+    it('should recursively rewrite string subnodes in a ReactElement', () => {
+        const inputNode = (
+            <span>
+                This is foobar, <i>it has a foo</i>.
+            </span>
+        );
+        expect(rewriteReactNodeRecursively(inputNode, callback)).toMatchSnapshot();
+    });
+
+    it('should iterate through a collection of ReactNodes, preserving keys or setting them to index if necessary', () => {
+        const inputNode = [
+            // eslint-disable-next-line react/jsx-key
+            <span>Foo does not have key!.</span>,
+            <span key="id234">This is foo with key.</span>,
+            false,
+        ] as const;
+
+        const result = rewriteReactNodeRecursively(inputNode, callback) as typeof inputNode;
+
+        expect(result.length).toBe(3);
+        expect(result[0].key).toBe('0');
+        expect(result[1].key).toBe('id234');
+    });
+});

--- a/packages/suite/src/components/suite/HiddenPlaceholder.tsx
+++ b/packages/suite/src/components/suite/HiddenPlaceholder.tsx
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components';
 import { useSelector } from 'src/hooks/suite';
 import { selectIsDiscreteModeActive } from 'src/reducers/wallet/settingsReducer';
 import { rewriteReactNodeRecursively } from '@trezor/react-utils';
-import { redactNumericalSubstring } from '@suite-common/wallet-utils';
+import { redactNumericalSubstring, RedactNumbersContext } from '@suite-common/wallet-utils';
 
 interface WrapperProps {
     $intensity: number;
@@ -41,6 +41,8 @@ export const HiddenPlaceholder = ({
     const ref = useRef<HTMLSpanElement>(null);
     const [automaticIntensity, setAutomaticIntensity] = useState(10);
     const discreetMode = useSelector(selectIsDiscreteModeActive);
+    const [isHovered, setIsHovered] = useState(false);
+    const shouldRedactNumbers = discreetMode && !isHovered;
 
     useEffect(() => {
         if (ref.current === null) {
@@ -64,21 +66,25 @@ export const HiddenPlaceholder = ({
     */
     const modifiedChildren = useMemo(
         () =>
-            discreetMode
+            shouldRedactNumbers
                 ? rewriteReactNodeRecursively(children, redactNumericalSubstring)
                 : children,
-        [children, discreetMode],
+        [children, shouldRedactNumbers],
     );
 
     return (
         <Wrapper
+            onMouseEnter={() => setIsHovered(true)}
+            onMouseLeave={() => setIsHovered(false)}
             $discreetMode={discreetMode}
             $intensity={enforceIntensity !== undefined ? enforceIntensity : automaticIntensity}
             className={className}
             ref={ref}
             data-testid={dataTestId}
         >
-            {modifiedChildren}
+            <RedactNumbersContext.Provider value={{ shouldRedactNumbers }}>
+                {modifiedChildren}
+            </RedactNumbersContext.Provider>
         </Wrapper>
     );
 };

--- a/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.ts
+++ b/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.ts
@@ -1,7 +1,11 @@
 import { A } from '@mobily/ts-belt';
 
 import { networks, NetworkSymbol } from '@suite-common/wallet-config';
-import { amountToSatoshi, formatAmount } from '@suite-common/wallet-utils';
+import {
+    amountToSatoshi,
+    formatAmount,
+    redactNumericalSubstring,
+} from '@suite-common/wallet-utils';
 import { PROTO } from '@trezor/connect';
 
 import { makeFormatter } from '../makeFormatter';
@@ -47,7 +51,7 @@ export const prepareCryptoAmountFormatter = (config: FormatterConfig) =>
                 isEllipsisAppended = true,
             },
         ) => {
-            const { bitcoinAmountUnit } = config;
+            const { bitcoinAmountUnit, discreetMode } = config;
 
             const decimals = networks[symbol!]?.decimals || 0;
 
@@ -84,10 +88,10 @@ export const prepareCryptoAmountFormatter = (config: FormatterConfig) =>
             if (withSymbol) {
                 const NetworkSymbolFormatter = prepareNetworkSymbolFormatter(config);
 
-                return `${formattedValue} ${NetworkSymbolFormatter.format(symbol!)}`;
+                formattedValue = `${formattedValue} ${NetworkSymbolFormatter.format(symbol!)}`;
             }
 
-            return formattedValue;
+            return discreetMode ? redactNumericalSubstring(formattedValue) : formattedValue;
         },
         'CryptoAmountFormatter',
     );

--- a/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.ts
+++ b/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.ts
@@ -50,8 +50,9 @@ export const prepareCryptoAmountFormatter = (config: FormatterConfig) =>
                 maxDisplayedDecimals = 8,
                 isEllipsisAppended = true,
             },
+            shouldRedactNumbers,
         ) => {
-            const { bitcoinAmountUnit, discreetMode } = config;
+            const { bitcoinAmountUnit } = config;
 
             const decimals = networks[symbol!]?.decimals || 0;
 
@@ -91,7 +92,7 @@ export const prepareCryptoAmountFormatter = (config: FormatterConfig) =>
                 formattedValue = `${formattedValue} ${NetworkSymbolFormatter.format(symbol!)}`;
             }
 
-            return discreetMode ? redactNumericalSubstring(formattedValue) : formattedValue;
+            return shouldRedactNumbers ? redactNumericalSubstring(formattedValue) : formattedValue;
         },
         'CryptoAmountFormatter',
     );

--- a/suite-common/formatters/src/formatters/prepareFiatAmountFormatter.ts
+++ b/suite-common/formatters/src/formatters/prepareFiatAmountFormatter.ts
@@ -1,6 +1,7 @@
 import { FormatNumberOptions } from '@formatjs/intl';
 
 import { BigNumber } from '@trezor/utils/src/bigNumber';
+import { redactNumericalSubstring } from '@suite-common/wallet-utils';
 
 import { makeFormatter } from '../makeFormatter';
 import { FormatterConfig } from '../types';
@@ -15,23 +16,29 @@ export const prepareFiatAmountFormatter = (config: FormatterConfig) =>
         string | null,
         FiatAmountFormatterDataContext<FormatNumberOptions>
     >((value, dataContext) => {
-        const { intl, fiatCurrency } = config;
+        const { intl, fiatCurrency, discreetMode } = config;
+
         const { style, currency, minimumFractionDigits, maximumFractionDigits } = dataContext;
         const fiatValue = new BigNumber(value);
+        const currencyForDisplay = currency ?? fiatCurrency;
 
         if (fiatValue.isNaN()) {
             return null;
         }
 
+        let formattedValue: string = '';
+
         if (fiatValue.gt(Number.MAX_SAFE_INTEGER)) {
-            return `${value} ${currency ?? fiatCurrency}`;
+            formattedValue = `${value} ${currencyForDisplay}`;
         }
 
-        return intl.formatNumber(fiatValue.toNumber(), {
+        formattedValue = intl.formatNumber(fiatValue.toNumber(), {
             ...dataContext,
             style: style || 'currency',
-            currency: currency ?? fiatCurrency,
+            currency: currencyForDisplay,
             minimumFractionDigits: minimumFractionDigits ?? 2,
             maximumFractionDigits: maximumFractionDigits ?? 2,
         });
+
+        return discreetMode ? redactNumericalSubstring(formattedValue) : formattedValue;
     }, 'FiatAmountFormatter');

--- a/suite-common/formatters/src/formatters/prepareFiatAmountFormatter.ts
+++ b/suite-common/formatters/src/formatters/prepareFiatAmountFormatter.ts
@@ -15,8 +15,8 @@ export const prepareFiatAmountFormatter = (config: FormatterConfig) =>
         string | number,
         string | null,
         FiatAmountFormatterDataContext<FormatNumberOptions>
-    >((value, dataContext) => {
-        const { intl, fiatCurrency, discreetMode } = config;
+    >((value, dataContext, shouldRedactNumbers) => {
+        const { intl, fiatCurrency } = config;
 
         const { style, currency, minimumFractionDigits, maximumFractionDigits } = dataContext;
         const fiatValue = new BigNumber(value);
@@ -40,5 +40,5 @@ export const prepareFiatAmountFormatter = (config: FormatterConfig) =>
             maximumFractionDigits: maximumFractionDigits ?? 2,
         });
 
-        return discreetMode ? redactNumericalSubstring(formattedValue) : formattedValue;
+        return shouldRedactNumbers ? redactNumericalSubstring(formattedValue) : formattedValue;
     }, 'FiatAmountFormatter');

--- a/suite-common/formatters/src/makeFormatter.tsx
+++ b/suite-common/formatters/src/makeFormatter.tsx
@@ -1,3 +1,5 @@
+import { useShouldRedactNumbers } from '@suite-common/wallet-utils';
+
 export type DataContext = Record<string, unknown>;
 
 interface FormatDefinition<TInput, TOutput, TDataContext extends DataContext> {
@@ -6,6 +8,8 @@ interface FormatDefinition<TInput, TOutput, TDataContext extends DataContext> {
         value: TInput,
         /** Additional data context to be used by the formatter. */
         dataContext: Partial<TDataContext>,
+        /** Whether a component above has requested to redact the numbers for discreet mode */
+        shouldRedactNumbers?: boolean,
     ): TOutput;
 }
 
@@ -40,11 +44,11 @@ export const makeFormatter = <TInput, TOutput, TDataContext extends DataContext 
     format: FormatDefinition<TInput, TOutput, TDataContext>,
     displayName = 'Formatter',
 ): Formatter<TInput, TOutput, TDataContext> => {
-    const formatter: Formatter<TInput, TOutput, TDataContext> = props =>
-        <>{format(props.value, props)}</> ?? null;
-    formatter.displayName = displayName;
+    const FormatterComponent: Formatter<TInput, TOutput, TDataContext> = props =>
+        <>{format(props.value, props, useShouldRedactNumbers())}</> ?? null;
+    FormatterComponent.displayName = displayName;
 
-    formatter.format = (value, dataContext = {}) => format(value, dataContext);
+    FormatterComponent.format = (value, dataContext = {}) => format(value, dataContext);
 
-    return formatter;
+    return FormatterComponent;
 };

--- a/suite-common/wallet-utils/src/__tests__/discreetModeUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/discreetModeUtils.test.ts
@@ -1,0 +1,21 @@
+import { DISCREET_PLACEHOLDER, redactNumericalSubstring } from '../discreetModeUtils';
+
+describe('redactNumericalSubstring', () => {
+    it('replaces sole stringified number with placeholder', () => {
+        expect(redactNumericalSubstring('123')).toBe(DISCREET_PLACEHOLDER);
+        expect(redactNumericalSubstring('0.001234')).toBe(DISCREET_PLACEHOLDER);
+        expect(redactNumericalSubstring('-9,876,543.210001')).toBe(DISCREET_PLACEHOLDER);
+        expect(redactNumericalSubstring('-.1')).toBe(DISCREET_PLACEHOLDER);
+    });
+
+    it('redacts only the number, not an accompanying symboll', () => {
+        expect(redactNumericalSubstring('CZK 123')).toBe(`CZK ${DISCREET_PLACEHOLDER}`);
+        expect(redactNumericalSubstring('0.001234 BTC')).toBe(`${DISCREET_PLACEHOLDER} BTC`);
+        expect(redactNumericalSubstring('-9,876,543.210001€')).toBe(`${DISCREET_PLACEHOLDER}€`);
+    });
+
+    it('does not replace non-numerical strings', () => {
+        expect(redactNumericalSubstring('foo')).toBe('foo');
+        expect(redactNumericalSubstring('. , -.')).toBe('. , -.');
+    });
+});

--- a/suite-common/wallet-utils/src/__tests__/discreetModeUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/discreetModeUtils.test.ts
@@ -1,17 +1,25 @@
-import { DISCREET_PLACEHOLDER, redactNumericalSubstring } from '../discreetModeUtils';
+import { redactNumericalSubstring } from '../discreetModeUtils';
+
+const MAX_PLACEHOLDER = '####'; // placeholder with maximal length of 4 characters
 
 describe('redactNumericalSubstring', () => {
     it('replaces sole stringified number with placeholder', () => {
-        expect(redactNumericalSubstring('123')).toBe(DISCREET_PLACEHOLDER);
-        expect(redactNumericalSubstring('0.001234')).toBe(DISCREET_PLACEHOLDER);
-        expect(redactNumericalSubstring('-9,876,543.210001')).toBe(DISCREET_PLACEHOLDER);
-        expect(redactNumericalSubstring('-.1')).toBe(DISCREET_PLACEHOLDER);
+        expect(redactNumericalSubstring('123')).toBe('###');
+        expect(redactNumericalSubstring('0.001234')).toBe(MAX_PLACEHOLDER);
+        expect(redactNumericalSubstring('-9,876,543.210001')).toBe(MAX_PLACEHOLDER);
+        expect(redactNumericalSubstring('-.1')).toBe('###');
     });
 
     it('redacts only the number, not an accompanying symboll', () => {
-        expect(redactNumericalSubstring('CZK 123')).toBe(`CZK ${DISCREET_PLACEHOLDER}`);
-        expect(redactNumericalSubstring('0.001234 BTC')).toBe(`${DISCREET_PLACEHOLDER} BTC`);
-        expect(redactNumericalSubstring('-9,876,543.210001€')).toBe(`${DISCREET_PLACEHOLDER}€`);
+        expect(redactNumericalSubstring('CZK 123')).toBe(`CZK ###`);
+        expect(redactNumericalSubstring('0.001234 BTC')).toBe(`${MAX_PLACEHOLDER} BTC`);
+        expect(redactNumericalSubstring('-9,876,543.210001€')).toBe(`${MAX_PLACEHOLDER}€`);
+    });
+
+    it('redacts all number occurrences', () => {
+        expect(redactNumericalSubstring('CZK 123 is 12345 satoshi')).toBe(
+            `CZK ### is ${MAX_PLACEHOLDER} satoshi`,
+        );
     });
 
     it('does not replace non-numerical strings', () => {

--- a/suite-common/wallet-utils/src/discreetModeUtils.ts
+++ b/suite-common/wallet-utils/src/discreetModeUtils.ts
@@ -1,7 +1,8 @@
-export const DISCREET_PLACEHOLDER = '####';
+import { createContext, useContext } from 'react';
+
+export const DISCREET_PLACEHOLDER = '###';
 
 const numericalSubstringRegex = /[\d\-\.,]*\d+[\.\d]*/g;
-
 /**
  * Search the input for a numerical substring and replace it with DISCREET_PLACEHOLDER.
  * @param value whole string value, usually number with symbol
@@ -9,3 +10,14 @@ const numericalSubstringRegex = /[\d\-\.,]*\d+[\.\d]*/g;
  */
 export const redactNumericalSubstring = (value: string): string =>
     value.replace(numericalSubstringRegex, DISCREET_PLACEHOLDER);
+
+type RedactNumbersContextData = { shouldRedactNumbers: boolean };
+export const RedactNumbersContext = createContext<RedactNumbersContextData>({
+    shouldRedactNumbers: false,
+});
+/**
+ * Determine whether we are under a component which currently requests to redact the numbers for discreet mode (see HiddenPlaceholder).
+ * @returns shouldRedactNumbers whether numbers should be redacted in displayed output
+ */
+export const useShouldRedactNumbers = () =>
+    useContext(RedactNumbersContext)?.shouldRedactNumbers ?? false;

--- a/suite-common/wallet-utils/src/discreetModeUtils.ts
+++ b/suite-common/wallet-utils/src/discreetModeUtils.ts
@@ -1,0 +1,11 @@
+export const DISCREET_PLACEHOLDER = '####';
+
+const numericalSubstringRegex = /[\d\-\.,]*\d+[\.\d]*/g;
+
+/**
+ * Search the input for a numerical substring and replace it with DISCREET_PLACEHOLDER.
+ * @param value whole string value, usually number with symbol
+ * @returns redacted string
+ */
+export const redactNumericalSubstring = (value: string): string =>
+    value.replace(numericalSubstringRegex, DISCREET_PLACEHOLDER);

--- a/suite-common/wallet-utils/src/discreetModeUtils.ts
+++ b/suite-common/wallet-utils/src/discreetModeUtils.ts
@@ -1,15 +1,24 @@
 import { createContext, useContext } from 'react';
 
-export const DISCREET_PLACEHOLDER = '###';
-
 const numericalSubstringRegex = /[\d\-\.,]*\d+[\.\d]*/g;
 /**
  * Search the input for a numerical substring and replace it with DISCREET_PLACEHOLDER.
  * @param value whole string value, usually number with symbol
  * @returns redacted string
  */
-export const redactNumericalSubstring = (value: string): string =>
-    value.replace(numericalSubstringRegex, DISCREET_PLACEHOLDER);
+export const redactNumericalSubstring = (value: string): string => {
+    const PLACEHOLDER_CHAR = '#';
+    const MAX_PLACEHOLDER_LENGTH = 4;
+
+    const matches = value.match(numericalSubstringRegex);
+    if (!matches) return value;
+
+    return matches.reduce((redactedValue, match) => {
+        const newLength = Math.min(MAX_PLACEHOLDER_LENGTH, match.length);
+
+        return redactedValue.replace(match, PLACEHOLDER_CHAR.repeat(newLength));
+    }, value);
+};
 
 type RedactNumbersContextData = { shouldRedactNumbers: boolean };
 export const RedactNumbersContext = createContext<RedactNumbersContextData>({

--- a/suite-common/wallet-utils/src/index.ts
+++ b/suite-common/wallet-utils/src/index.ts
@@ -3,6 +3,7 @@ export * from './backendUtils';
 export * from './balanceUtils';
 export * from './cardanoUtils';
 export * from './csvParserUtils';
+export * from './discreetModeUtils';
 export * from './ethUtils';
 export * from './fiatConverterUtils';
 export * from './fiatRatesUtils';


### PR DESCRIPTION
Discreet mode currently leaves numerical values blurred, but technically still possible to decypher.
Enhance it to actually replace the characters with `####`, making them completely illegible.

## Description

TODO. WIP

- originally I tried to replace the number with random characters 
  - then I tried replacing it with constant four characters `####`
  - it does not work for short strings - when the `####` is wider than 0, it leads to horrible flickering if you hover at certain place
  - instead it replaces with as many `#` as per original length, but max 4
  - still not ideal, at some places it can still flicker, TBD

## Related Issue

Resolve #10567

## Screenshots:

Uncovered numbers for reference:
![uncovered](https://github.com/user-attachments/assets/d67d7dc2-1e04-422f-bf68-f56f047f2343)
Original, only blurred, but you can kinda discern the numbers:
![only blurred](https://github.com/user-attachments/assets/fa1b7e8f-7b19-4ba0-8248-800872efa4e3)
Blured and redacted:
![blurred and redacted](https://github.com/user-attachments/assets/8f3de478-a7a3-426d-864e-a12487890202)
Blured and redacted onhover:
![blurred and redacted onhover](https://github.com/user-attachments/assets/31596679-b422-4db1-8a5c-996d8d19d085)