### PR TITLE
chore(suite-desktop-core): TrezordNode in ThreadProxy

### DIFF
--- a/packages/suite-desktop-core/src/modules/coinjoin.ts
+++ b/packages/suite-desktop-core/src/modules/coinjoin.ts
@@ -72,11 +72,11 @@ export const init: Module = ({ mainWindow, store, mainThreadEmitter }) => {
             await backend.run({ ...settings, torSettings: store.getTorSettings() });
             backends.push(backend);
 
-            backend.on('interceptor', (event: InterceptedEvent) =>
+            backend.subscribe('interceptor', (event: InterceptedEvent) =>
                 mainThreadEmitter.emit('module/request-interceptor', event),
             );
 
-            backend.on('log', ({ level, payload }) => {
+            backend.subscribe('log', ({ level, payload }) => {
                 if (level === 'error') {
                     sentryError(settings.network, payload);
                 }
@@ -87,7 +87,7 @@ export const init: Module = ({ mainWindow, store, mainThreadEmitter }) => {
                 backend.request('setTorSettings', [torSettings]),
             );
 
-            backend.on('disposed', unsubscribeTorSettingsChange);
+            backend.watch('disposed', unsubscribeTorSettingsChange);
 
             return {
                 onRequest: (method, params) => {
@@ -104,12 +104,12 @@ export const init: Module = ({ mainWindow, store, mainThreadEmitter }) => {
                 onAddListener: (eventName, listener) => {
                     logger.debug(SERVICE_NAME, `${BACKEND_CHANNEL} add listener ${eventName}`);
 
-                    return backend.on(eventName, listener);
+                    return backend.subscribe(eventName, listener);
                 },
                 onRemoveListener: (eventName: any) => {
                     logger.debug(SERVICE_NAME, `${BACKEND_CHANNEL} remove listener ${eventName}`);
 
-                    return backend.removeAllListeners(eventName) as any;
+                    return backend.unsubscribe(eventName) as any;
                 },
             };
         },

--- a/packages/suite-desktop-core/src/threads/bridge.ts
+++ b/packages/suite-desktop-core/src/threads/bridge.ts
@@ -1,0 +1,34 @@
+import { TrezordNode } from '@trezor/transport-bridge';
+
+import { createThread } from '../libs/thread';
+import { Logger } from '../libs/logger';
+import { convertILoggerToLog } from '../utils/IloggerToLog';
+
+export interface TrezordNodeSettings {
+    port: number;
+    api: 'usb' | 'udp';
+}
+
+const init = (settings: TrezordNodeSettings) =>
+    new TrezordNode({
+        ...settings,
+        assetPrefix: '../../build/node-bridge',
+        /**
+         * We need a different instance from the global logger instance. Because we want to save bridge logs to memory
+         * to make them available from bridge status page.
+         */
+        logger: convertILoggerToLog(
+            new Logger('debug', {
+                writeToDisk: false,
+                writeToMemory: true,
+                // by default, bridge logs are not printed to console to avoid too much noise. The other reason why this is set to false
+                // is that global logger has logic of turning it on and off depending on 'debug' mode (see logger/config message) and we don't have this implemented here
+                // it would require putting bridgeLogger to the global scope which might be perceived as controversial
+                writeToConsole: false,
+                dedupeTimeout: 0,
+            }),
+            { serviceName: 'trezord-node' },
+        ),
+    });
+
+createThread(init);

--- a/packages/transport-bridge/src/http.ts
+++ b/packages/transport-bridge/src/http.ts
@@ -163,7 +163,7 @@ export class TrezordNode {
             });
         });
 
-        return new Promise<void>(resolve => {
+        return new Promise<void>((resolve, reject) => {
             this.logger.info('Starting Trezor Bridge HTTP server');
             const app = new HttpServer({
                 port: this.port,
@@ -428,10 +428,12 @@ export class TrezordNode {
 
             app.post('/configure', [this.handleInfo.bind(this)]);
 
-            app.start().then(() => {
-                this.server = app;
-                resolve();
-            });
+            app.start()
+                .then(() => {
+                    this.server = app;
+                    resolve();
+                })
+                .catch(reject);
         });
     }
 


### PR DESCRIPTION
## Description

Utilize ThreadProxy (which is also used for coinjoin) to run TrezordNode in a separate thread. 

Needs some more testing & maybe polishing.