### PR TITLE
feat(suite-native): netinfo isConnected and reachabiltyUrl

### DIFF
--- a/suite-native/connection-status/src/useIsOfflineBannerVisible.tsx
+++ b/suite-native/connection-status/src/useIsOfflineBannerVisible.tsx
@@ -6,9 +6,11 @@ import { selectIsOnboardingFinished } from '@suite-native/settings';
 
 export const useIsOfflineBannerVisible = () => {
     const isOnboardingFinished = useSelector(selectIsOnboardingFinished);
-    const { isInternetReachable } = useNetInfo();
+    const { isConnected: isNetInfoConnected } = useNetInfo({
+        reachabilityUrl: 'https://cdn.trezor.io/204',
+    });
 
-    const isReachable = isInternetReachable ?? true;
+    const isConnected = isNetInfoConnected ?? true;
 
-    return !isReachable && isOnboardingFinished;
+    return !isConnected && isOnboardingFinished;
 };


### PR DESCRIPTION
Reverting back to isConnected instead of `isInternetReachable` because it behaves odd in testing and setting `reachabilityUrl` to `https://cdn.trezor.io/204`.

## Related Issue

Resolve #13597 

