### PR TITLE
fix(connect): Device cancelable prompts (pin, word, passphrase)

### DIFF
--- a/packages/connect/e2e/README.md
+++ b/packages/connect/e2e/README.md
@@ -17,6 +17,16 @@ you may use the following params:
 -i <in case -p methods, use -i to filter one connect method, such as -i binanceGetAddress>
 ```
 
+## karma test
+
+Browser console is not visible in the terminal. Use KARMA_SINGLE_RUN env variable and debug test at http://localhost:8099/debug.html in your favorite browser.
+
+For local changes to take effect build connect-iframe or connect-web depending where they were made and restart test.
+
+```
+TESTS_PATTERN="init" KARMA_SINGLE_RUN=false yarn workspace @trezor/connect test:e2e:web
+```
+
 ## Transactions cache
 
 Bitcoin-like coins `signTransaction` method require additional data about transactions referenced from used inputs.

--- a/packages/connect/e2e/__fixtures__/stellarSignTransaction.ts
+++ b/packages/connect/e2e/__fixtures__/stellarSignTransaction.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/prefer-ts-expect-error */
 // @ts-ignore
 import commonFixtures from '../../../../submodules/trezor-common/tests/fixtures/stellar/sign_tx.json';
-import { Messages } from '@trezor/transport/src';
+import * as Messages from '@trezor/protobuf/src/messages';
 
 // operations are in protobuf format (snake_case)
 

--- a/packages/connect/e2e/karma.config.js
+++ b/packages/connect/e2e/karma.config.js
@@ -2,31 +2,24 @@ const path = require('path');
 const webpack = require('webpack');
 
 module.exports = config => {
+    const singleRun = process.env.KARMA_SINGLE_RUN === 'false' ? false : true;
+
     config.set({
         basePath: path.resolve(__dirname, '../..'), // NOTE: "[monorepo-root]/packages", to have access to other packages
         hostname: 'localhost',
         port: 8099,
         autoWatch: false,
-        // to debug locally set single run to false and go to http://localhost:8099/debug.html
-        // for local changes to take effect build connect-iframe and connect-web
-        singleRun: true,
+        singleRun,
 
         client: {
             captureConsole: true,
             clearContext: true,
             useIframe: false,
             runInParent: true,
-            mocha: {
-                bail: true,
-            },
             // uncomment to disable random ordering of tests
             jasmine: {
                 random: false,
             },
-        },
-        browserConsoleLogOptions: {
-            terminal: true,
-            level: '',
         },
         browsers: [
             // 'Chrome',
@@ -74,7 +67,7 @@ module.exports = config => {
             },
             ...(process.env.TESTS_PATTERN || '*')
                 .split(' ')
-                .map(pattern => path.resolve(__dirname, `./tests/**/${pattern.trim()}.test.ts`)),
+                .map(pattern => path.resolve(__dirname, `./tests/**/${pattern.trim()}*.ts`)),
         ],
 
         webpackMiddleware: {

--- a/packages/connect/e2e/karma.plugin.js
+++ b/packages/connect/e2e/karma.plugin.js
@@ -11,25 +11,26 @@ function CustomReporter(rootConfig, logger) {
             log.info('Running @trezor/connect tests...');
             log.info('FW:', process.env.TESTS_FIRMWARE);
             log.info('Methods:', process.env.TESTS_INCLUDED_METHODS || 'All');
-        },
-
-        onSpecStart: (_browser, spec) => {
-            log.warn('onSpecStart', spec);
+            log.info('Pattern:', process.env.TESTS_PATTERN || '*');
         },
 
         onSpecComplete: (_browser, spec) => {
-            log.info(spec.success ? '✓' : '✖', spec.fullName);
-            if (!spec.success) {
-                log.info(spec);
+            if (spec.skipped) {
+                log.warn('○ skipped', spec.fullName);
+            } else if (spec.success) {
+                log.info('✓', spec.fullName);
+            } else {
+                log.error('✖', spec.fullName);
+                log.error(spec);
             }
         },
 
         onRunComplete: () => {
-            log.warn('onRunComplete');
+            log.info('onRunComplete');
         },
 
         onExit: done => {
-            log.warn('onExit');
+            log.info('onExit');
             done();
         },
     };

--- a/packages/connect/e2e/karma.setup.js
+++ b/packages/connect/e2e/karma.setup.js
@@ -59,6 +59,8 @@ jasmine.getEnv().beforeAll(() => {
     });
 });
 
+it.skip = xit;
+it.only = fit;
 // expect is missing "any" matcher
 expect.any = jasmine.any;
 

--- a/packages/connect/e2e/tests/device/cancel.test.ts
+++ b/packages/connect/e2e/tests/device/cancel.test.ts
@@ -1,0 +1,232 @@
+import { StartEmu, SetupEmu } from '@trezor/trezor-user-env-link';
+import { getController, initTrezorConnect } from '../../common.setup';
+import TrezorConnect from '../../../src';
+
+const getAddress = (showOnTrezor: boolean, coin: string = 'regtest') => {
+    return TrezorConnect.getAddress({
+        path: "m/84'/1'/0'/0/0",
+        coin,
+        showOnTrezor,
+    });
+};
+
+const passphraseHandler = (value: string) => () => {
+    TrezorConnect.uiResponse({
+        type: 'ui-receive_passphrase',
+        payload: {
+            passphraseOnDevice: false,
+            value,
+        },
+    });
+    TrezorConnect.removeAllListeners('ui-request_passphrase');
+};
+
+const addressHandler = () => () => {
+    TrezorConnect.uiResponse({
+        type: 'ui-receive_confirmation',
+        payload: true,
+    });
+    TrezorConnect.removeAllListeners('ui-request_confirmation');
+};
+
+const assertGetAddressWorks = async () => {
+    // validate that further communication is possible without any glitch
+    TrezorConnect.on('ui-request_passphrase', passphraseHandler(''));
+    TrezorConnect.on('ui-request_confirmation', addressHandler());
+    const getAddressResponse = await getAddress(false, 'testnet');
+    expect(getAddressResponse).toMatchObject({
+        success: true,
+        payload: { address: 'tb1qnspxpr2xj9s2jt6qlhuvdnxw6q55jvygcf89r2' },
+    });
+};
+
+describe('TrezorConnect.cancel', () => {
+    const controller = getController();
+
+    const setupTest = async ({
+        setupParams,
+        bridgeVersion,
+    }: {
+        setupParams: SetupEmu & StartEmu;
+        bridgeVersion: string;
+    }) => {
+        await controller.stopBridge();
+        await controller.stopEmu();
+        await controller.startEmu({ wipe: true, ...setupParams });
+        await controller.setupEmu(setupParams);
+        await controller.startBridge(bridgeVersion);
+
+        await initTrezorConnect(controller, { debug: true });
+    };
+
+    beforeAll(async () => {
+        await controller.connect();
+    });
+
+    afterAll(async () => {
+        await TrezorConnect.dispose();
+        controller.dispose();
+    });
+
+    [
+        // '2.0.27', // todo: 2.0.27 is removed from trezor-user-env
+        '2.0.33',
+        // '3.0.0' // todo: add support in trezor-user-env
+    ].forEach(bridgeVersion => {
+        describe(`Bridge ${bridgeVersion}`, () => {
+            afterEach(async () => {
+                await TrezorConnect.dispose();
+                await controller.stopEmu();
+                await controller.stopBridge();
+            });
+
+            // the goal is to run this test couple of times to uncover possible race conditions/flakiness
+            it(`GetAddress - ButtonRequest_Address - Cancel `, async () => {
+                await setupTest({
+                    setupParams: {},
+                    bridgeVersion,
+                });
+
+                TrezorConnect.removeAllListeners();
+                const getAddressCall = getAddress(true);
+                await new Promise<void>(resolve => {
+                    TrezorConnect.on('button', event => {
+                        if (event.code === 'ButtonRequest_Address') {
+                            resolve();
+                        }
+                    });
+                });
+
+                TrezorConnect.cancel('Cancel reason');
+
+                const response = await getAddressCall;
+
+                expect(response).toMatchObject({
+                    success: false,
+                    payload: {
+                        error: 'Cancel reason',
+                        code: 'Method_Cancel',
+                    },
+                });
+
+                // TODO: here I would like to continue and validate that I can communicate after a cancelled call
+                // await assertGetAddressWorks();
+
+                // but this sometimes fails (nodejs) with, probably a race condition
+                //   success: false,
+                //   payload: {
+                //     error: 'Initialize failed: Unexpected message, code: Failure_UnexpectedMessage',
+                //     code: 'Device_InitializeFailed'
+                //   }
+            });
+
+            it('Synchronous Cancel', async () => {
+                await setupTest({
+                    setupParams: {},
+                    bridgeVersion,
+                });
+
+                TrezorConnect.removeAllListeners();
+                const getAddressCall = getAddress(true);
+
+                // almost synchronous, TODO: core methodSynchronize race-condition in nodejs (works in web)
+                await new Promise(resolve => setTimeout(resolve, 1));
+
+                TrezorConnect.cancel('Cancel reason');
+
+                const response = await getAddressCall;
+
+                expect(response).toMatchObject({
+                    success: false,
+                    payload: {
+                        error: 'Cancel reason',
+                    },
+                });
+
+                // todo: this test doesn't work properly
+                // getAddressCall is rejected while device is acquiring workflow continues...
+                // assertion will result with "device call in progress"
+                // await assertGetAddressWorks();
+            });
+
+            it('Passphrase request - Cancel', async () => {
+                await setupTest({
+                    setupParams: {
+                        passphrase_protection: true,
+                    },
+                    bridgeVersion,
+                });
+
+                const getAddressCall = getAddress(true);
+                await new Promise<void>(resolve => {
+                    TrezorConnect.on('ui-request_passphrase', () => resolve());
+                });
+                TrezorConnect.cancel();
+
+                const response = await getAddressCall;
+
+                expect(response.success).toEqual(false);
+
+                await assertGetAddressWorks();
+            });
+
+            // todo: this should be conditionalTest(['2'])
+            it('Pin request - Cancel', async () => {
+                await setupTest({
+                    setupParams: {
+                        version: '1-latest',
+                        model: 'T1B1',
+                        pin: '1234',
+                    },
+                    bridgeVersion,
+                });
+                // T1 needs to be restarted for settings to be applied (pin)
+                await controller.stopEmu();
+                await controller.startEmu({ version: '1-latest', model: 'T1B1' });
+
+                const pinPromise = new Promise<void>(resolve => {
+                    TrezorConnect.on('ui-request_pin', () => {
+                        resolve();
+                    });
+                });
+                const getAddressCall = getAddress(true);
+                await pinPromise;
+                TrezorConnect.cancel();
+
+                const response = await getAddressCall;
+
+                expect(response.success).toEqual(false);
+
+                // assertGetAddressWorks will not work without providing pin
+                const feat = await TrezorConnect.getFeatures();
+                expect(feat.payload).toMatchObject({ initialized: true });
+            });
+
+            // todo: this should be conditionalTest(['2'])
+            it('Word request - Cancel', async () => {
+                await controller.startEmu({ version: '1-latest', model: 'T1B1', wipe: true });
+                await controller.startBridge(bridgeVersion);
+                await initTrezorConnect(controller);
+
+                const wordPromise = new Promise<void>(resolve => {
+                    TrezorConnect.on('ui-request_word', () => resolve());
+                });
+                const recoveryDeviceCall = TrezorConnect.recoveryDevice({
+                    passphrase_protection: false,
+                    pin_protection: false,
+                });
+
+                await wordPromise;
+                TrezorConnect.cancel();
+
+                const response = await recoveryDeviceCall;
+
+                expect(response.success).toEqual(false);
+
+                // assertGetAddressWorks will not work here, device is not initialized
+                const feat = await TrezorConnect.getFeatures();
+                expect(feat.payload).toMatchObject({ initialized: false });
+            });
+        });
+    });
+});

--- a/packages/connect/e2e/tests/device/override.test.ts
+++ b/packages/connect/e2e/tests/device/override.test.ts
@@ -5,16 +5,11 @@ import { getController, setup, initTrezorConnect } from '../../common.setup';
 const controller = getController();
 
 describe('TrezorConnect override param', () => {
-    beforeEach(async () => {
-        await TrezorConnect.dispose();
+    beforeAll(async () => {
         await setup(controller, {
             mnemonic: 'mnemonic_all',
         });
         await initTrezorConnect(controller);
-    });
-
-    afterEach(async () => {
-        await new Promise(resolve => setTimeout(resolve, 1000));
     });
 
     afterAll(async () => {

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -808,9 +808,12 @@ const onDevicePinHandler =
             createUiMessage(UI.REQUEST_PIN, { device: device.toMessageObject(), type }),
         );
         // wait for pin
-        const uiResp = await uiPromise.promise;
-        // callback.apply(null, [null, pin]);
-        callback(null, uiResp.payload);
+        try {
+            const uiResp = await uiPromise.promise;
+            callback(uiResp.payload);
+        } catch (error) {
+            callback(null, error);
+        }
     };
 
 const onDeviceWordHandler =
@@ -825,8 +828,12 @@ const onDeviceWordHandler =
             createUiMessage(UI.REQUEST_WORD, { device: device.toMessageObject(), type }),
         );
         // wait for word
-        const uiResp = await uiPromise.promise;
-        callback(null, uiResp.payload);
+        try {
+            const uiResp = await uiPromise.promise;
+            callback(uiResp.payload);
+        } catch (error) {
+            callback(null, error);
+        }
     };
 
 /**
@@ -849,14 +856,12 @@ const onDevicePassphraseHandler =
             createUiMessage(UI.REQUEST_PASSPHRASE, { device: device.toMessageObject() }),
         );
         // wait for passphrase
-        const uiResp = await uiPromise.promise;
-        const { value, passphraseOnDevice, save } = uiResp.payload;
-        // send as PassphrasePromptResponse
-        callback({
-            passphrase: value.normalize('NFKD'),
-            passphraseOnDevice,
-            cache: save,
-        });
+        try {
+            const uiResp = await uiPromise.promise;
+            callback(uiResp.payload);
+        } catch (error) {
+            callback(null, error);
+        }
     };
 
 /**
@@ -869,8 +874,7 @@ const onDevicePassphraseHandler =
 const onEmptyPassphraseHandler =
     (): DeviceEvents['passphrase'] =>
     (...[_, callback]) => {
-        // send as PassphrasePromptResponse
-        callback({ passphrase: '' });
+        callback({ value: '' });
     };
 
 /**

--- a/packages/connect/src/device/DeviceCommands.ts
+++ b/packages/connect/src/device/DeviceCommands.ts
@@ -3,7 +3,7 @@
 import { randomBytes } from 'crypto';
 import { Transport, Session } from '@trezor/transport';
 import { MessagesSchema as Messages } from '@trezor/protobuf';
-import { versionUtils } from '@trezor/utils';
+import { createTimeoutPromise, versionUtils } from '@trezor/utils';
 import { ERRORS } from '../constants';
 import { DEVICE } from '../events';
 import * as hdnodeUtils from '../utils/hdnodeUtils';
@@ -17,7 +17,7 @@ import type { CoinInfo, BitcoinNetworkInfo, Network } from '../types';
 import type { HDNodeResponse } from '../types/api/getPublicKey';
 import { Assert } from '@trezor/schema-utils';
 import { resolveDescriptorForTaproot } from './resolveDescriptorForTaproot';
-import { promptPin, promptPassphrase, promptWord } from './prompts';
+import { promptPin, promptPassphrase, promptWord, cancelPrompt } from './prompts';
 
 type MessageType = Messages.MessageType;
 type MessageKey = keyof MessageType;
@@ -90,9 +90,6 @@ export class DeviceCommands {
     disposed: boolean;
 
     callPromise?: ReturnType<Transport['call']>;
-
-    // see DeviceCommands.cancel
-    _cancelableRequestBySend?: boolean;
 
     constructor(device: Device, transport: Transport, transportSession: Session) {
         this.device = device;
@@ -385,7 +382,7 @@ export class DeviceCommands {
     }
 
     _filterCommonTypes(res: DefaultPayloadMessage): Promise<DefaultPayloadMessage> {
-        this._cancelableRequestBySend = false;
+        this.device.clearCancelableAction();
 
         if (res.type === 'Failure') {
             const { code } = res.message;
@@ -417,7 +414,7 @@ export class DeviceCommands {
         }
 
         if (res.type === 'ButtonRequest') {
-            this._cancelableRequestBySend = true;
+            this.device.setCancelableAction(() => this.cancelWithFallback());
 
             if (res.message.code === 'ButtonRequest_PassphraseEntry') {
                 this.device.emit(DEVICE.PASSPHRASE_ON_DEVICE);
@@ -554,45 +551,37 @@ export class DeviceCommands {
         );
     }
 
+    async cancelWithFallback() {
+        const { name, version } = this.transport;
+        if (name === 'BridgeTransport' && !versionUtils.isNewer(version, '2.0.28')) {
+            /**
+             * Bridge version =< 2.0.28 throws "other call in progress" error.
+             * as workaround takeover transportSession (acquire) before sending Cancel, this will resolve previous pending call.
+             */
+            try {
+                // UI_EVENT is send right before ButtonAck, make sure that ButtonAck is sent
+                await createTimeoutPromise(1);
+                await this.device.acquire();
+                await cancelPrompt(this.device, false);
+            } catch (err) {
+                // ignore whatever happens
+            }
+        } else {
+            return cancelPrompt(this.device, false);
+        }
+    }
+
     async cancel() {
         if (this.disposed) {
             return;
         }
         this.dispose();
-
-        if (!this._cancelableRequestBySend) {
-            if (this.callPromise) {
-                await this.callPromise;
-            }
-
-            return;
-        }
-        /**
-         * Bridge version =< 2.0.28 has a bug that doesn't permit it to cancel
-         * user interactions in progress, so we have to do it manually.
-         */
-        const { name, version } = this.transport;
-        if (name === 'BridgeTransport' && !versionUtils.isNewer(version, '2.0.28')) {
+        if (this.callPromise) {
             try {
-                await this.device.legacyForceRelease();
-            } catch (err) {
-                // ignore
-            }
-        } else {
-            await this.transport.send({
-                protocol: this.device.protocol,
-                session: this.transportSession,
-                name: 'Cancel',
-                data: {},
-            });
-
-            if (this.callPromise) {
                 await this.callPromise;
+            } catch {
+                // do nothing
             }
-            // if my observations are correct, it is not necessary to transport.receive after send
-            // transport.call -> transport.send -> transport call returns Failure meaning it won't be
-            // returned in subsequent calls
-            // await this.transport.receive({ session: this.transportSession }).promise;
         }
     }
 }

--- a/packages/connect/src/device/prompts.ts
+++ b/packages/connect/src/device/prompts.ts
@@ -1,0 +1,89 @@
+import { Messages, TRANSPORT_ERROR } from '@trezor/transport';
+
+import { ERRORS } from '../constants';
+import { DEVICE } from '../events';
+import type { Device, DeviceEvents } from './Device';
+
+export type PromptCallback<T> = (response: T | null, error?: Error) => void;
+
+type PromptEvents = typeof DEVICE.PIN | typeof DEVICE.PASSPHRASE | typeof DEVICE.WORD;
+// infer all args of Device.emit but one (callback)
+type PromptArgs<T extends unknown[]> = T extends readonly [...infer Args, any] ? Args : never;
+// infer last arg of Device.emit (callback)
+type CallbackArgFn<T extends unknown[]> = T extends readonly [...unknown[], infer Cb] ? Cb : never;
+type AnyFn = (...args: any[]) => any;
+type DeviceEventArgs<K extends keyof DeviceEvents> = DeviceEvents[K] extends AnyFn
+    ? PromptArgs<Parameters<DeviceEvents[K]>>
+    : never;
+type DeviceEventCallback<K extends keyof DeviceEvents> = DeviceEvents[K] extends AnyFn
+    ? CallbackArgFn<Parameters<DeviceEvents[K]>>
+    : never;
+
+export const cancelPrompt = (device: Device, expectResponse = true) => {
+    if (!device.transportSession) {
+        // device disconnected or acquired by someone else
+        return Promise.resolve({
+            success: false,
+            error: TRANSPORT_ERROR.SESSION_NOT_FOUND,
+        } as const);
+    }
+
+    const cancelArgs = {
+        session: device.transportSession,
+        name: 'Cancel',
+        data: {},
+        protocol: device.protocol,
+    };
+
+    return expectResponse ? device.transport.call(cancelArgs) : device.transport.send(cancelArgs);
+};
+
+const prompt = <E extends PromptEvents>(event: E, ...[device, ...args]: DeviceEventArgs<E>) => {
+    // return non nullable first arg of PromptCallback<E>
+    return new Promise<NonNullable<Parameters<DeviceEventCallback<E>>[0]>>((resolve, reject) => {
+        const cancelAndReject = (error?: Error) =>
+            cancelPrompt(device).then(onCancel =>
+                reject(
+                    error ||
+                        new Error(
+                            onCancel.success
+                                ? (onCancel.payload?.message.message as string)
+                                : onCancel.error,
+                        ),
+                ),
+            );
+
+        if (device.listenerCount(event) > 0) {
+            device.setCancelableAction(cancelAndReject);
+
+            const callback = (...[response, error]: Parameters<DeviceEventCallback<E>>) => {
+                device.clearCancelableAction();
+                if (error || response == null) {
+                    cancelAndReject(error);
+                } else {
+                    resolve(response);
+                }
+            };
+
+            const emitArgs = [event, device, ...args, callback] as unknown as Parameters<
+                typeof device.emit<E>
+            >;
+
+            device.emit(...emitArgs);
+        } else {
+            cancelAndReject(ERRORS.TypedError('Runtime', `${event} callback not configured`));
+        }
+    });
+};
+
+export const promptPassphrase = (device: Device) => {
+    return prompt(DEVICE.PASSPHRASE, device);
+};
+
+export const promptPin = (device: Device, type?: Messages.PinMatrixRequestType) => {
+    return prompt(DEVICE.PIN, device, type);
+};
+
+export const promptWord = (device: Device, type: Messages.WordRequestType) => {
+    return prompt(DEVICE.WORD, device, type);
+};

--- a/packages/connect/src/events/ui-response.ts
+++ b/packages/connect/src/events/ui-response.ts
@@ -49,21 +49,23 @@ export interface UiResponseDevice {
 
 export interface UiResponsePin {
     type: typeof UI_RESPONSE.RECEIVE_PIN;
-    payload: string;
+    payload: string | undefined;
 }
 
 export interface UiResponseWord {
     type: typeof UI_RESPONSE.RECEIVE_WORD;
-    payload: string;
+    payload: string | undefined;
 }
 
 export interface UiResponsePassphrase {
     type: typeof UI_RESPONSE.RECEIVE_PASSPHRASE;
-    payload: {
-        value: string;
-        passphraseOnDevice?: boolean;
-        save?: boolean;
-    };
+    payload:
+        | {
+              value: string;
+              passphraseOnDevice?: boolean;
+              save?: boolean;
+          }
+        | undefined;
 }
 
 export interface UiResponsePassphraseAction {

--- a/packages/trezor-user-env-link/src/api.ts
+++ b/packages/trezor-user-env-link/src/api.ts
@@ -7,7 +7,7 @@ import { TypedEmitter } from '@trezor/utils';
 
 import { Model, Firmwares } from './types';
 import { WebsocketClient, WebsocketClientEvents } from './websocket-client';
-interface SetupEmu {
+export interface SetupEmu {
     mnemonic?: string;
     pin?: string;
     passphrase_protection?: boolean;

--- a/scripts/ci/connect-test-matrix-generator.js
+++ b/scripts/ci/connect-test-matrix-generator.js
@@ -4,7 +4,7 @@ const groups = {
     api: {
         name: 'api',
         pattern:
-            'init authorizeCoinjoin cancelCoinjoinAuthorization passphrase unlockPath setBusy override checkFirmwareAuthenticity keepSession',
+            'init authorizeCoinjoin cancelCoinjoinAuthorization passphrase unlockPath setBusy override checkFirmwareAuthenticity keepSession cancel.test',
         methods: '',
     },
     management: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix unreported (?) behavior: calling `Cancel` on device when promptPin, promptPassphrase, promptWord is rejected or `TrezorConnect.cancel` was invoked.

Changes:
- unify all mentioned prompt functions and moved to standalone module.
- each prompt calls Cancel when rejected
- each prompt assigns cancelableRequest to the `Device`
- when prompt is resolved/rejected cancelableRequest is cleared from the `Device`
- when TrezorConnect.cancel is called cancelableRequest is invoked (call Cancel then reject prompt promise)

Lets test and discuss :)

resolve https://github.com/trezor/trezor-suite/issues/14507 (maybe it won't resolve everything, I just want to trigger QA :P)
