### PR TITLE
fix(staking): max with low amount

### DIFF
--- a/packages/suite/src/components/suite/FormFractionButtons.tsx
+++ b/packages/suite/src/components/suite/FormFractionButtons.tsx
@@ -2,10 +2,7 @@ import styled from 'styled-components';
 import { Translation } from 'src/components/suite';
 import { Button, Tooltip } from '@trezor/components';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
-import {
-    MIN_ETH_AMOUNT_FOR_STAKING,
-    MIN_ETH_BALANCE_FOR_STAKING,
-} from 'src/constants/suite/ethStaking';
+import { MIN_ETH_AMOUNT_FOR_STAKING } from 'src/constants/suite/ethStaking';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 
 const Flex = styled.div`
@@ -50,7 +47,7 @@ export const FormFractionButtons = ({
     const is25PercentDisabled = isDisabled || isFractionButtonDisabled(4);
     const is50PercentDisabled = isDisabled || isFractionButtonDisabled(2);
     const isMaxDisabled =
-        isDisabled || new BigNumber(totalAmount || '0').lt(MIN_ETH_BALANCE_FOR_STAKING);
+        isDisabled || new BigNumber(totalAmount || '0').lt(MIN_ETH_AMOUNT_FOR_STAKING);
 
     return (
         <Flex>

--- a/packages/suite/src/components/suite/FormFractionButtons.tsx
+++ b/packages/suite/src/components/suite/FormFractionButtons.tsx
@@ -53,16 +53,17 @@ export const FormFractionButtons = ({
         <Flex>
             <Tooltip
                 content={
-                    <Translation
-                        id="TR_STAKE_MIN_AMOUNT_TOOLTIP"
-                        values={{
-                            amount: MIN_ETH_AMOUNT_FOR_STAKING.toString(),
-                            symbol: symbol.toUpperCase(),
-                        }}
-                    />
+                    is10PercentDisabled && (
+                        <Translation
+                            id="TR_STAKE_MIN_AMOUNT_TOOLTIP"
+                            values={{
+                                amount: MIN_ETH_AMOUNT_FOR_STAKING.toString(),
+                                symbol: symbol.toUpperCase(),
+                            }}
+                        />
+                    )
                 }
                 cursor="pointer"
-                disabled={!is10PercentDisabled}
             >
                 <TinyButton isDisabled={is10PercentDisabled} onClick={() => setRatioAmount(10)}>
                     10%
@@ -70,16 +71,17 @@ export const FormFractionButtons = ({
             </Tooltip>
             <Tooltip
                 content={
-                    <Translation
-                        id="TR_STAKE_MIN_AMOUNT_TOOLTIP"
-                        values={{
-                            amount: MIN_ETH_AMOUNT_FOR_STAKING.toString(),
-                            symbol: symbol.toUpperCase(),
-                        }}
-                    />
+                    is25PercentDisabled && (
+                        <Translation
+                            id="TR_STAKE_MIN_AMOUNT_TOOLTIP"
+                            values={{
+                                amount: MIN_ETH_AMOUNT_FOR_STAKING.toString(),
+                                symbol: symbol.toUpperCase(),
+                            }}
+                        />
+                    )
                 }
                 cursor="pointer"
-                disabled={!is25PercentDisabled}
             >
                 <TinyButton isDisabled={is25PercentDisabled} onClick={() => setRatioAmount(4)}>
                     25%
@@ -87,16 +89,17 @@ export const FormFractionButtons = ({
             </Tooltip>
             <Tooltip
                 content={
-                    <Translation
-                        id="TR_STAKE_MIN_AMOUNT_TOOLTIP"
-                        values={{
-                            amount: MIN_ETH_AMOUNT_FOR_STAKING.toString(),
-                            symbol: symbol.toUpperCase(),
-                        }}
-                    />
+                    is50PercentDisabled && (
+                        <Translation
+                            id="TR_STAKE_MIN_AMOUNT_TOOLTIP"
+                            values={{
+                                amount: MIN_ETH_AMOUNT_FOR_STAKING.toString(),
+                                symbol: symbol.toUpperCase(),
+                            }}
+                        />
+                    )
                 }
                 cursor="pointer"
-                disabled={!is50PercentDisabled}
             >
                 <TinyButton isDisabled={is50PercentDisabled} onClick={() => setRatioAmount(2)}>
                     50%
@@ -104,16 +107,17 @@ export const FormFractionButtons = ({
             </Tooltip>
             <Tooltip
                 content={
-                    <Translation
-                        id="TR_STAKE_MIN_AMOUNT_TOOLTIP"
-                        values={{
-                            amount: MIN_ETH_AMOUNT_FOR_STAKING.toString(),
-                            symbol: symbol.toUpperCase(),
-                        }}
-                    />
+                    isMaxDisabled && (
+                        <Translation
+                            id="TR_STAKE_MIN_AMOUNT_TOOLTIP"
+                            values={{
+                                amount: MIN_ETH_AMOUNT_FOR_STAKING.toString(),
+                                symbol: symbol.toUpperCase(),
+                            }}
+                        />
+                    )
                 }
                 cursor="pointer"
-                disabled={!is50PercentDisabled}
             >
                 <TinyButton isDisabled={isDisabled || isMaxDisabled} onClick={setMax}>
                     <Translation id="TR_STAKE_MAX" />

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/Inputs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/Inputs.tsx
@@ -69,22 +69,6 @@ export const Inputs = () => {
 
     const shouldShowAmountForWithdrawalWarning =
         isLessAmountForWithdrawalWarningShown || isAmountForWithdrawalWarningShown;
-    const amountForWithdrawalTranslation = isLessAmountForWithdrawalWarningShown ? (
-        <Translation
-            id="TR_STAKE_LEFT_SMALL_AMOUNT_FOR_WITHDRAWAL"
-            values={{
-                symbol: account.symbol.toUpperCase(),
-            }}
-        />
-    ) : (
-        <Translation
-            id="TR_STAKE_LEFT_AMOUNT_FOR_WITHDRAWAL"
-            values={{
-                amount: MIN_ETH_FOR_WITHDRAWALS.toString(),
-                symbol: account.symbol.toUpperCase(),
-            }}
-        />
-    );
 
     return (
         <Column>
@@ -123,7 +107,19 @@ export const Inputs = () => {
             )}
 
             {shouldShowAmountForWithdrawalWarning && (
-                <Banner variant="info">{amountForWithdrawalTranslation}</Banner>
+                <Banner variant="info">
+                    <Translation
+                        id={
+                            isLessAmountForWithdrawalWarningShown
+                                ? 'TR_STAKE_LEFT_SMALL_AMOUNT_FOR_WITHDRAWAL'
+                                : 'TR_STAKE_LEFT_AMOUNT_FOR_WITHDRAWAL'
+                        }
+                        values={{
+                            amount: MIN_ETH_FOR_WITHDRAWALS.toString(),
+                            symbol: account.symbol.toUpperCase(),
+                        }}
+                    />
+                </Banner>
             )}
 
             {isAdviceForWithdrawalWarningShown && (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/Inputs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/Inputs.tsx
@@ -127,7 +127,7 @@ export const Inputs = () => {
             )}
 
             {isAdviceForWithdrawalWarningShown && (
-                <Banner variant="info" margin={{ top: spacings.md }}>
+                <Banner variant="info">
                     <Translation
                         id="TR_STAKE_RECOMMENDED_AMOUNT_FOR_WITHDRAWALS"
                         values={{

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/Inputs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/Inputs.tsx
@@ -14,7 +14,7 @@ import {
 } from 'src/utils/suite/validation';
 import { FIAT_INPUT, CRYPTO_INPUT } from 'src/types/wallet/stakeForms';
 import { MIN_ETH_FOR_WITHDRAWALS } from 'src/constants/suite/ethStaking';
-import { spacings, spacingsPx } from '@trezor/theme';
+import { spacingsPx } from '@trezor/theme';
 import { validateStakingMax } from 'src/utils/suite/stake';
 
 const IconWrapper = styled.div`
@@ -36,6 +36,7 @@ export const Inputs = () => {
         onFiatAmountChange,
         localCurrency,
         isAmountForWithdrawalWarningShown,
+        isLessAmountForWithdrawalWarningShown,
         isAdviceForWithdrawalWarningShown,
         currentRate,
     } = useStakeEthFormContext();
@@ -65,6 +66,25 @@ export const Inputs = () => {
             }),
         },
     };
+
+    const shouldShowAmountForWithdrawalWarning =
+        isLessAmountForWithdrawalWarningShown || isAmountForWithdrawalWarningShown;
+    const amountForWithdrawalTranslation = isLessAmountForWithdrawalWarningShown ? (
+        <Translation
+            id="TR_STAKE_LEFT_SMALL_AMOUNT_FOR_WITHDRAWAL"
+            values={{
+                symbol: account.symbol.toUpperCase(),
+            }}
+        />
+    ) : (
+        <Translation
+            id="TR_STAKE_LEFT_AMOUNT_FOR_WITHDRAWAL"
+            values={{
+                amount: MIN_ETH_FOR_WITHDRAWALS.toString(),
+                symbol: account.symbol.toUpperCase(),
+            }}
+        />
+    );
 
     return (
         <Column>
@@ -102,17 +122,10 @@ export const Inputs = () => {
                 </>
             )}
 
-            {isAmountForWithdrawalWarningShown && (
-                <Banner variant="info" margin={{ top: spacings.md }}>
-                    <Translation
-                        id="TR_STAKE_LEFT_AMOUNT_FOR_WITHDRAWAL"
-                        values={{
-                            amount: MIN_ETH_FOR_WITHDRAWALS.toString(),
-                            symbol: account.symbol.toUpperCase(),
-                        }}
-                    />
-                </Banner>
+            {shouldShowAmountForWithdrawalWarning && (
+                <Banner variant="info">{amountForWithdrawalTranslation}</Banner>
             )}
+
             {isAdviceForWithdrawalWarningShown && (
                 <Banner variant="info" margin={{ top: spacings.md }}>
                     <Translation

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -8697,6 +8697,11 @@ export default defineMessages({
         id: 'TR_STAKE_LEFT_AMOUNT_FOR_WITHDRAWAL',
         defaultMessage: 'We’ve left {amount} {symbol} out so you can pay for withdrawal fees.',
     },
+    TR_STAKE_LEFT_SMALL_AMOUNT_FOR_WITHDRAWAL: {
+        id: 'TR_STAKE_LEFT_SMALL_AMOUNT_FOR_WITHDRAWAL',
+        defaultMessage:
+            'We’ve left a small amount of {symbol} out so you can pay for withdrawal fees.',
+    },
     TR_STAKE_RECOMMENDED_AMOUNT_FOR_WITHDRAWALS: {
         id: 'TR_STAKE_RECOMMENDED_AMOUNT_FOR_WITHDRAWALS',
         defaultMessage:

--- a/suite-common/wallet-core/src/stake/stakeTypes.ts
+++ b/suite-common/wallet-core/src/stake/stakeTypes.ts
@@ -97,6 +97,7 @@ export type StakeContextValues = UseFormReturn<StakeFormState> &
         isDraft: boolean;
         amountLimits: AmountLimitsString;
         isAmountForWithdrawalWarningShown: boolean;
+        isLessAmountForWithdrawalWarningShown: boolean;
         isAdviceForWithdrawalWarningShown: boolean;
         isConfirmModalOpen: boolean;
         onCryptoAmountChange: (amount: string) => void;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updated the logic to allow the use of the Max button even when the balance is less than 0.13 ETH. Also, the max button is now enabled when the user amount  is >=0.1 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/13316

## Screenshots:
![image](https://github.com/user-attachments/assets/8df523ed-858a-4988-9cfd-034da9022886)
