### PR TITLE
feat(suite): update safety checks modal to use new modal component

### DIFF
--- a/packages/components/src/components/form/Checkbox/Checkbox.stories.tsx
+++ b/packages/components/src/components/form/Checkbox/Checkbox.stories.tsx
@@ -37,6 +37,7 @@ export const Checkbox: StoryObj<CheckboxProps> = {
         isChecked: false,
         isDisabled: false,
         labelAlignment: 'right',
+        verticalAlignment: 'top',
         ...getFramePropsStory(allowedCheckboxFrameProps).args,
     },
 
@@ -52,6 +53,12 @@ export const Checkbox: StoryObj<CheckboxProps> = {
                 type: 'radio',
             },
             options: ['left', 'right'],
+        },
+        verticalAlignment: {
+            control: {
+                type: 'radio',
+            },
+            options: ['top', 'center'],
         },
         ...getFramePropsStory(allowedCheckboxFrameProps).argTypes,
     },

--- a/packages/components/src/components/form/Checkbox/Checkbox.tsx
+++ b/packages/components/src/components/form/Checkbox/Checkbox.tsx
@@ -5,7 +5,7 @@ import { borders, Color, spacingsPx, typography } from '@trezor/theme';
 import { KEYBOARD_CODE } from '../../../constants/keyboardEvents';
 import { Icon } from '../../Icon/Icon';
 import { getFocusShadowStyle } from '../../../utils/utils';
-import { UIHorizontalAlignment, UIVariant } from '../../../config/types';
+import { UIHorizontalAlignment, UIVerticalAlignment, UIVariant } from '../../../config/types';
 import { FrameProps, FramePropsKeys, withFrameProps } from '../../../utils/frameProps';
 import { makePropsTransient, TransientProps } from '../../../utils/transientProps';
 
@@ -67,12 +67,14 @@ export const variantStyles: Record<CheckboxVariant, VariantStyles> = {
 type ContainerProps = TransientProps<AllowedFrameProps> & {
     $isDisabled?: boolean;
     $labelAlignment?: LabelAlignment;
+    $verticalAlignment?: VerticalAlignment;
 };
 
 export const Container = styled.div<ContainerProps>`
     display: flex;
-    align-items: flex-start;
-    gap: ${spacingsPx.xs};
+    align-items: ${({ $verticalAlignment }) =>
+        $verticalAlignment === 'top' ? 'flex-start' : 'center'};
+    gap: ${spacingsPx.sm};
     flex-direction: ${({ $labelAlignment }) => $labelAlignment === 'left' && 'row-reverse'};
     pointer-events: ${({ $isDisabled }) => $isDisabled && 'none'};
     cursor: ${({ $isDisabled }) => ($isDisabled ? 'default' : 'pointer')};
@@ -153,12 +155,14 @@ export const HiddenInput = styled.input`
 
 export type CheckboxVariant = Extract<UIVariant, 'primary' | 'destructive' | 'warning'>;
 export type LabelAlignment = Extract<UIHorizontalAlignment, 'left' | 'right'>;
+export type VerticalAlignment = Extract<UIVerticalAlignment, 'top' | 'center'>;
 
 export type CheckboxProps = AllowedFrameProps & {
     variant?: CheckboxVariant;
     isChecked?: boolean;
     isDisabled?: boolean;
     labelAlignment?: LabelAlignment;
+    verticalAlignment?: VerticalAlignment;
     onClick: EventHandler<SyntheticEvent>;
     'data-testid'?: string;
     className?: string;
@@ -170,6 +174,7 @@ export const Checkbox = ({
     isChecked,
     isDisabled = false,
     labelAlignment = 'right',
+    verticalAlignment = 'top',
     onClick,
     'data-testid': dataTest,
     className,
@@ -195,6 +200,7 @@ export const Checkbox = ({
         <Container
             $isDisabled={isDisabled}
             $labelAlignment={labelAlignment}
+            $verticalAlignment={verticalAlignment}
             onClick={isDisabled ? undefined : onClick}
             onKeyUp={handleKeyUp}
             data-testid={dataTest}

--- a/packages/components/src/components/form/Radio/Radio.stories.tsx
+++ b/packages/components/src/components/form/Radio/Radio.stories.tsx
@@ -37,6 +37,8 @@ export const RadioButton: StoryObj<RadioProps> = {
         variant: 'primary',
         isChecked: false,
         isDisabled: false,
+        labelAlignment: 'right',
+        verticalAlignment: 'top',
     },
     argTypes: {
         variant: {
@@ -49,7 +51,13 @@ export const RadioButton: StoryObj<RadioProps> = {
             control: {
                 type: 'radio',
             },
-            options: [null, 'left', 'right'],
+            options: ['left', 'right'],
+        },
+        verticalAlignment: {
+            control: {
+                type: 'radio',
+            },
+            options: ['top', 'center'],
         },
     },
 };

--- a/packages/components/src/components/form/Radio/Radio.tsx
+++ b/packages/components/src/components/form/Radio/Radio.tsx
@@ -8,6 +8,7 @@ import {
     CheckboxVariant,
     Label,
     LabelAlignment,
+    VerticalAlignment,
     variantStyles,
     Container,
     HiddenInput,
@@ -102,6 +103,7 @@ export interface RadioProps {
     isChecked?: boolean;
     isDisabled?: boolean;
     labelAlignment?: LabelAlignment;
+    verticalAlignment?: VerticalAlignment;
     onClick: EventHandler<SyntheticEvent>;
     'data-testid'?: string;
     children?: ReactNode;
@@ -110,7 +112,8 @@ export interface RadioProps {
 export const Radio = ({
     variant = 'primary',
     isChecked,
-    labelAlignment,
+    labelAlignment = 'right',
+    verticalAlignment = 'top',
     isDisabled = false,
     onClick,
     'data-testid': dataTest,
@@ -131,6 +134,7 @@ export const Radio = ({
             onKeyUp={handleKeyUp}
             $isDisabled={isDisabled}
             $labelAlignment={labelAlignment}
+            $verticalAlignment={verticalAlignment}
             data-checked={isChecked}
             data-testid={dataTest}
         >

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/SafetyChecksModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/SafetyChecksModal.tsx
@@ -1,32 +1,18 @@
 import { useState } from 'react';
-import styled from 'styled-components';
 import { useDevice, useDispatch } from 'src/hooks/suite';
-import { Radio, Button, H3, Paragraph, Warning } from '@trezor/components';
-import { Translation, Modal, ModalProps } from 'src/components/suite';
+import {
+    Radio,
+    Paragraph,
+    Warning,
+    NewModal,
+    NewModalProps,
+    Column,
+    Card,
+    Text,
+} from '@trezor/components';
+import { Translation } from 'src/components/suite';
 import { applySettings } from 'src/actions/settings/deviceSettingsActions';
-
-const StyledButton = styled(Button)`
-    min-width: 230px;
-`;
-
-const OptionsWrapper = styled.div`
-    width: 100%;
-    text-align: left;
-
-    & > * + * {
-        margin-top: 40px;
-    }
-`;
-
-const RadioInner = styled.div`
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-`;
-
-const WarningWrapper = styled.div`
-    margin: 12px 0;
-`;
+import { spacings } from '@trezor/theme';
 
 /**
  * A Modal that allows user to set the `safety_checks` feature of connected Trezor.
@@ -34,7 +20,7 @@ const WarningWrapper = styled.div`
  * The third value, `PromptAlways`, is considered an advanced feature that can be
  * set only via command line and trezor-lib.
  */
-export const SafetyChecksModal = ({ onCancel }: ModalProps) => {
+export const SafetyChecksModal = ({ onCancel }: NewModalProps) => {
     const { device, isLocked } = useDevice();
     const [level, setLevel] = useState(device?.features?.safety_checks || undefined);
     const dispatch = useDispatch();
@@ -42,57 +28,65 @@ export const SafetyChecksModal = ({ onCancel }: ModalProps) => {
     const confirm = () => dispatch(applySettings({ safety_checks: level }));
 
     return (
-        <Modal
-            isCancelable
+        <NewModal
             onCancel={onCancel}
             heading={<Translation id="TR_SAFETY_CHECKS_MODAL_TITLE" />}
-            bottomBarComponents={
-                <StyledButton
-                    onClick={confirm}
-                    // Only allow confirming when the value will be changed.
-                    isDisabled={isLocked() || level === device?.features?.safety_checks}
-                    data-testid="@safety-checks-apply"
-                >
-                    <Translation id="TR_CONFIRM" />
-                </StyledButton>
+            variant="warning"
+            size="small"
+            bottomContent={
+                <>
+                    <NewModal.Button
+                        onClick={confirm}
+                        // Only allow confirming when the value will be changed.
+                        isDisabled={isLocked() || level === device?.features?.safety_checks}
+                        data-testid="@safety-checks-apply"
+                    >
+                        <Translation id="TR_CONFIRM" />
+                    </NewModal.Button>
+                    <NewModal.Button variant="tertiary" onClick={onCancel}>
+                        <Translation id="TR_CANCEL" />
+                    </NewModal.Button>
+                </>
             }
         >
-            <OptionsWrapper>
-                <Radio
-                    isChecked={level === 'Strict'}
-                    onClick={() => setLevel('Strict')}
-                    data-testid="@radio-button-strict"
-                >
-                    <RadioInner>
-                        <H3>
-                            <Translation id="TR_SAFETY_CHECKS_STRICT_LEVEL" />
-                        </H3>
-                        <Paragraph typographyStyle="hint">
-                            <Translation id="TR_SAFETY_CHECKS_STRICT_LEVEL_DESC" />
-                        </Paragraph>
-                    </RadioInner>
-                </Radio>
-                <Radio
-                    // For the purpose of this modal consider `PromptAlways` as identical to `PromptTemporarily`.
-                    isChecked={level === 'PromptTemporarily' || level === 'PromptAlways'}
-                    onClick={() => setLevel('PromptTemporarily')}
-                    data-testid="@radio-button-prompt"
-                >
-                    <RadioInner>
-                        <H3>
-                            <Translation id="TR_SAFETY_CHECKS_PROMPT_LEVEL" />
-                        </H3>
-                        <WarningWrapper>
-                            <Warning icon>
-                                <Translation id="TR_SAFETY_CHECKS_PROMPT_LEVEL_WARNING" />
-                            </Warning>
-                        </WarningWrapper>
-                        <Paragraph typographyStyle="hint">
-                            <Translation id="TR_SAFETY_CHECKS_PROMPT_LEVEL_DESC" />
-                        </Paragraph>
-                    </RadioInner>
-                </Radio>
-            </OptionsWrapper>
-        </Modal>
+            <Warning icon>
+                <Translation id="TR_SAFETY_CHECKS_PROMPT_LEVEL_WARNING" />
+            </Warning>
+            <Card margin={{ top: spacings.md }}>
+                <Column gap={spacings.xl} alignItems="flex-start">
+                    <Radio
+                        isChecked={level === 'Strict'}
+                        onClick={() => setLevel('Strict')}
+                        data-testid="@radio-button-strict"
+                        verticalAlignment="center"
+                    >
+                        <Column alignItems="flex-start">
+                            <Text typographyStyle="highlight">
+                                <Translation id="TR_SAFETY_CHECKS_STRICT_LEVEL" />
+                            </Text>
+                            <Paragraph typographyStyle="hint">
+                                <Translation id="TR_SAFETY_CHECKS_STRICT_LEVEL_DESC" />
+                            </Paragraph>
+                        </Column>
+                    </Radio>
+                    <Radio
+                        // For the purpose of this modal consider `PromptAlways` as identical to `PromptTemporarily`.
+                        isChecked={level === 'PromptTemporarily' || level === 'PromptAlways'}
+                        onClick={() => setLevel('PromptTemporarily')}
+                        data-testid="@radio-button-prompt"
+                        verticalAlignment="center"
+                    >
+                        <Column alignItems="flex-start">
+                            <Text typographyStyle="highlight">
+                                <Translation id="TR_SAFETY_CHECKS_PROMPT_LEVEL" />
+                            </Text>
+                            <Paragraph typographyStyle="hint">
+                                <Translation id="TR_SAFETY_CHECKS_PROMPT_LEVEL_DESC" />
+                            </Paragraph>
+                        </Column>
+                    </Radio>
+                </Column>
+            </Card>
+        </NewModal>
     );
 };


### PR DESCRIPTION
## Screenshots:

### Before:
<img width="761" alt="Screenshot 2024-08-22 at 12 17 21" src="https://github.com/user-attachments/assets/d3c06493-e01b-42fb-b973-e671ac086770">

### After:
<img width="685" alt="Screenshot 2024-08-22 at 16 41 18" src="https://github.com/user-attachments/assets/20e6e5ef-42ea-4c84-b8df-857e35fb7fc7">





