### PR TITLE
fix(suite-native): if cardano is on, discovery ends too early

### DIFF
--- a/suite-native/discovery/src/discoveryThunks.ts
+++ b/suite-native/discovery/src/discoveryThunks.ts
@@ -511,13 +511,15 @@ const discoverNetworkBatchThunk = createThunk(
 
 export const createDescriptorPreloadedDiscoveryThunk = createThunk(
     `${DISCOVERY_MODULE_PREFIX}/createDescriptorPreloadedDiscoveryThunk`,
-    async (
+    (
         {
             deviceState,
             networks,
+            availableCardanoDerivations,
         }: {
             deviceState: string;
             networks: readonly Network[];
+            availableCardanoDerivations: ('normal' | 'legacy' | 'ledger')[] | undefined;
         },
         { dispatch, getState },
     ) => {
@@ -525,15 +527,6 @@ export const createDescriptorPreloadedDiscoveryThunk = createThunk(
 
         if (!device) {
             return;
-        }
-
-        let availableCardanoDerivations: ('normal' | 'legacy' | 'ledger')[] | undefined;
-        if (networks.some(network => network.networkType === 'cardano')) {
-            availableCardanoDerivations = await dispatch(
-                getCardanoSupportedAccountTypesThunk({
-                    deviceState,
-                }),
-            ).unwrap();
         }
 
         const runningDiscovery = selectDeviceDiscovery(getState());
@@ -545,16 +538,7 @@ export const createDescriptorPreloadedDiscoveryThunk = createThunk(
             return;
         }
 
-        const networksSymbols = networks
-            .filter(
-                // Skip Cardano account types that device does not support
-                network =>
-                    network.networkType !== 'cardano' ||
-                    ((availableCardanoDerivations ?? []) as string[]).includes(
-                        (network.accountType ?? NORMAL_ACCOUNT_TYPE) as string,
-                    ),
-            )
-            .map(network => network.symbol);
+        const networksSymbols = networks.map(network => network.symbol);
 
         const discoveryNetworksTotalCount = networksSymbols.length;
 
@@ -629,10 +613,29 @@ export const startDescriptorPreloadedDiscoveryThunk = createThunk(
             }),
         );
 
+        // Some cardano derivation are not supported by the device. We need to filter them out.
+        let availableCardanoDerivations: ('normal' | 'legacy' | 'ledger')[] = [];
+        if (networksWithUnfinishedDiscovery.some(network => network.networkType === 'cardano')) {
+            availableCardanoDerivations =
+                (await dispatch(
+                    getCardanoSupportedAccountTypesThunk({
+                        deviceState,
+                    }),
+                ).unwrap()) ?? [];
+        }
+        const networksFiltered = networksWithUnfinishedDiscovery.filter(
+            network =>
+                network.networkType !== 'cardano' ||
+                (availableCardanoDerivations as string[]).includes(
+                    (network.accountType ?? NORMAL_ACCOUNT_TYPE) as string,
+                ),
+        );
+
         await dispatch(
             createDescriptorPreloadedDiscoveryThunk({
                 deviceState,
-                networks: networksWithUnfinishedDiscovery,
+                networks: networksFiltered,
+                availableCardanoDerivations,
             }),
         );
 
@@ -643,7 +646,7 @@ export const startDescriptorPreloadedDiscoveryThunk = createThunk(
         }
 
         // Start discovery for every network account type.
-        networksWithUnfinishedDiscovery.forEach(network => {
+        networksFiltered.forEach(network => {
             dispatch(discoverNetworkBatchThunk({ deviceState, network }));
         });
     },


### PR DESCRIPTION
Discovery can end before all the networks are discovered if Cardano is discovered and adding one more network.


## Description

If Cardano is enabled (default state for everyone) for device with unsupported derivation, this one is not included into the count for started discovery, but `createDescriptorPreloadedDiscoveryThunk` is being run for it. This can cause count being off by 1 in `finishNetworkTypeDiscoveryThunk` meaning the discovery will end before the last network is being discovered.

Before, the check for this was in the `createDescriptorPreloadedDiscoveryThunk` and this PR moves the check to `startDescriptorPreloadedDiscoveryThunk` and uses correct list of networks to discover for both creating the discovery in the redux and running the discovery for each network

## Related Issue

Resolve #13954


https://github.com/user-attachments/assets/6c78b804-a1ea-4d07-8be4-524be083e855


