### PR TITLE
chore(repo): add Nx config for depcheck

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -53,6 +53,10 @@
             "inputs": ["default", "{workspaceRoot}/.stylelintrc"],
             "outputs": ["{projectRoot}/.stylelintcache"],
             "cache": true
+        },
+        "depcheck": {
+            "inputs": ["default"],
+            "cache": true
         }
     },
     "affected": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Depcheck should be much faster now because:
1. It's cached
2. It's run only for modified packages (previously for modified packages and their dependants)

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
