### PR TITLE
feat(components): table

### DIFF
--- a/packages/components/src/components/Table/Table.stories.tsx
+++ b/packages/components/src/components/Table/Table.stories.tsx
@@ -1,0 +1,40 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import { Table as TableComponent, allowedTableFrameProps } from './Table';
+import { getFramePropsStory } from '../../utils/frameProps';
+
+const EXAMPLE_TOKENS = [
+    { name: 'USDT', balance: '10', price: '$1,00' },
+    { name: 'USDC', balance: '100', price: '$1,00' },
+    { name: 'MANA', balance: '20', price: '$2,15' },
+];
+
+const meta: Meta = {
+    title: 'Table',
+} as Meta;
+export default meta;
+
+export const Table: StoryObj = {
+    render: props => (
+        <TableComponent {...props}>
+            <TableComponent.HeaderRow>
+                <TableComponent.HeaderCell>Token</TableComponent.HeaderCell>
+                <TableComponent.HeaderCell $alignRight>Balance</TableComponent.HeaderCell>
+                <TableComponent.HeaderCell>Price</TableComponent.HeaderCell>
+            </TableComponent.HeaderRow>
+            {EXAMPLE_TOKENS.map((token, i) => (
+                <TableComponent.Row key={i}>
+                    <TableComponent.Cell>{token.name}</TableComponent.Cell>
+                    <TableComponent.Cell $alignRight>{token.balance}</TableComponent.Cell>
+                    <TableComponent.Cell>{token.price}</TableComponent.Cell>
+                </TableComponent.Row>
+            ))}
+        </TableComponent>
+    ),
+    args: {
+        ...getFramePropsStory(allowedTableFrameProps).args,
+    },
+    argTypes: {
+        ...getFramePropsStory(allowedTableFrameProps).argTypes,
+    },
+};

--- a/packages/components/src/components/Table/Table.tsx
+++ b/packages/components/src/components/Table/Table.tsx
@@ -1,0 +1,46 @@
+import { ReactNode } from 'react';
+import styled from 'styled-components';
+
+import { borders, Elevation, mapElevationToBackground } from '@trezor/theme';
+
+import { TableHeader } from './TableHeader';
+import { TableCell, TableCellProps } from './TableCell';
+import { TableRow } from './TableRow';
+import { useElevation } from '../ElevationContext/ElevationContext';
+import { FrameProps, FramePropsKeys, withFrameProps } from '../../utils/frameProps';
+import { TransientProps } from '../../utils/transientProps';
+
+export const allowedTableFrameProps: FramePropsKeys[] = ['margin'];
+type AllowedFrameProps = Pick<FrameProps, (typeof allowedTableFrameProps)[number]>;
+
+const Container = styled.table<{ $elevation: Elevation } & TransientProps<AllowedFrameProps>>`
+    display: flex;
+    width: 100%;
+    flex-direction: column;
+    background: ${mapElevationToBackground};
+    border-radius: ${borders.radii.md};
+    box-shadow: ${({ theme, $elevation }) => $elevation === 1 && theme.boxShadowBase};
+
+    ${withFrameProps}
+`;
+
+interface TableProps {
+    children: ReactNode;
+}
+
+export const Table = ({ children }: TableProps) => {
+    const { elevation } = useElevation();
+
+    return <Container $elevation={elevation}>{children}</Container>;
+};
+
+Table.Row = TableRow;
+Table.Cell = TableCell;
+Table.HeaderRow = TableHeader;
+Table.HeaderCell = (props: TableCellProps) => (
+    <TableCell $isHeader {...props}>
+        {props.children}
+    </TableCell>
+);
+
+export default Table;

--- a/packages/components/src/components/Table/TableCell.tsx
+++ b/packages/components/src/components/Table/TableCell.tsx
@@ -1,0 +1,26 @@
+import { spacingsPx, typography } from '@trezor/theme';
+import { ReactNode } from 'react';
+import styled, { css } from 'styled-components';
+
+export interface TableCellProps {
+    children: ReactNode;
+    $alignRight?: boolean;
+    $isHeader?: boolean;
+}
+
+export const TableCell = styled(({ $isHeader, $alignRight, ...props }: TableCellProps) =>
+    $isHeader ? <th {...props} /> : <td {...props} />,
+)<TableCellProps>`
+    ${({ $isHeader }) => ($isHeader ? typography.hint : typography.body)}
+    color: ${({ theme, $isHeader }) => ($isHeader ? theme.textSubdued : theme.textDefault)};
+    display: flex;
+    align-items: center;
+    justify-self: left;
+
+    ${({ $alignRight }) =>
+        $alignRight &&
+        css`
+            justify-self: right;
+            padding-right: ${spacingsPx.xxxl};
+        `}
+`;

--- a/packages/components/src/components/Table/TableHeader.tsx
+++ b/packages/components/src/components/Table/TableHeader.tsx
@@ -1,0 +1,25 @@
+import { ReactNode } from 'react';
+import styled from 'styled-components';
+
+import { Elevation, mapElevationToBorder, spacingsPx } from '@trezor/theme';
+
+import { useElevation } from '../ElevationContext/ElevationContext';
+
+export const Header = styled.thead<{ $elevation: Elevation }>`
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: 1fr;
+    align-items: center;
+    padding: ${spacingsPx.sm} ${spacingsPx.xl};
+    border-bottom: 1px solid ${mapElevationToBorder};
+`;
+
+export interface TableHeaderProps {
+    children: ReactNode;
+}
+
+export const TableHeader = ({ children }: TableHeaderProps) => {
+    const { elevation } = useElevation();
+
+    return <Header $elevation={elevation}>{children}</Header>;
+};

--- a/packages/components/src/components/Table/TableRow.tsx
+++ b/packages/components/src/components/Table/TableRow.tsx
@@ -1,0 +1,30 @@
+import { ReactNode } from 'react';
+import styled from 'styled-components';
+
+import { Elevation, mapElevationToBorder, spacingsPx } from '@trezor/theme';
+
+import { useElevation } from '../ElevationContext/ElevationContext';
+
+export const Row = styled.tr<{ $elevation: Elevation }>`
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: 1fr;
+    align-items: center;
+    margin: 0 ${spacingsPx.xl};
+    padding: ${spacingsPx.lg} 0;
+    border-bottom: 1px solid ${mapElevationToBorder};
+
+    &:last-child {
+        border-bottom: none;
+    }
+`;
+
+export interface TableRowProps {
+    children: ReactNode;
+}
+
+export const TableRow = ({ children }: TableRowProps) => {
+    const { elevation } = useElevation();
+
+    return <Row $elevation={elevation}>{children}</Row>;
+};


### PR DESCRIPTION
## Description

Created a basic table components ([inspiration from chakra-ui](https://v2.chakra-ui.com/docs/components/table/usage)). Just wanted to keep the naming more self-describing than just `THead`, `Tr`, ..., ...

Futuru usage will be for dashboard assets, tokens and collectibles. Maybe I will find there some places where I can improve the general components to better suite the usage.

## Screenshots:
<img width="624" alt="Screenshot 2024-08-26 at 8 49 11 AM" src="https://github.com/user-attachments/assets/e9d54ae2-20b5-4ea8-bbb0-b984f006128a">
