### PR TITLE
feat(suite): refresh on connection return

### DIFF
--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -513,8 +513,9 @@ class SolanaWorker extends BaseWorker<SolanaAPI> {
 
     private lazyTokens = createLazy(() => solanaUtils.getTokenMetadata());
 
-    tryConnect(url: string): Promise<SolanaAPI> {
+    async tryConnect(url: string): Promise<SolanaAPI> {
         const api = new Connection(url, { wsEndpoint: url.replace('https', 'wss') });
+        await api.getLatestBlockhash('finalized');
         this.post({ id: -1, type: RESPONSES.CONNECTED });
 
         return Promise.resolve(api);

--- a/packages/suite/src/middlewares/suite/suiteMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/suiteMiddleware.ts
@@ -10,6 +10,7 @@ import {
     handleDeviceConnect,
     handleDeviceDisconnect,
     observeSelectedDevice,
+    restartDiscoveryThunk,
     selectDeviceThunk,
 } from '@suite-common/wallet-core';
 import { notificationsActions } from '@suite-common/toast-notifications';
@@ -104,6 +105,12 @@ const suite =
                 break;
             case SUITE.REQUEST_AUTH_CONFIRM:
                 api.dispatch(authConfirm());
+                break;
+            case SUITE.ONLINE_STATUS:
+                // Restart discovery to reconnect to backends when user goes offline -> online.
+                if (action.payload === true) {
+                    api.dispatch(restartDiscoveryThunk());
+                }
                 break;
             default:
                 break;

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -1651,6 +1651,10 @@ export default defineMessages({
         defaultMessage: 'Connect',
         id: 'TR_CONNECT',
     },
+    TR_CONNECTION_LOST: {
+        defaultMessage: 'Connection lost',
+        id: 'TR_CONNECTION_LOST',
+    },
     TR_DISCONNECT: {
         defaultMessage: 'Disconnect',
         id: 'TR_DISCONNECT',

--- a/packages/suite/src/views/dashboard/components/PortfolioCard/components/Exception.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/components/Exception.tsx
@@ -107,10 +107,19 @@ interface ExceptionProps {
     discovery?: Discovery;
 }
 
+const getAccountError = (accountError: string) => {
+    if (accountError === 'All backends are down') {
+        return <Translation id="TR_CONNECTION_LOST" />;
+    }
+
+    return accountError;
+};
+
 const discoveryFailedMessage = (discovery?: Discovery) => {
     if (!discovery) return '';
     if (discovery.error) return <div>{discovery.error}</div>;
-    // group all failed networks into array of errors
+
+    // Group all failed networks into array of errors.
     const networkError: string[] = [];
     const details = discovery.failed.reduce((value, account) => {
         const n = accountUtils.getNetwork(account.symbol)!;
@@ -119,7 +128,7 @@ const discoveryFailedMessage = (discovery?: Discovery) => {
 
         return value.concat(
             <div key={account.symbol}>
-                {n.name}: {account.error}
+                {n.name}: {getAccountError(account.error)}
             </div>,
         );
     }, [] as JSX.Element[]);


### PR DESCRIPTION
## Description

Changed message to the translated string "Connection lost". Set up suite redux middleware to refresh on offline -> online.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/13913

## Screenshots:

![image](https://github.com/user-attachments/assets/578467a0-61d8-4139-88b4-6b0dd75c787e)
