### PR TITLE
fix(suite): useCallback in Icon.web to control rerenders

### DIFF
--- a/suite-common/icons/src/webComponents/Icon.web.tsx
+++ b/suite-common/icons/src/webComponents/Icon.web.tsx
@@ -1,5 +1,5 @@
 import { ReactSVG } from 'react-svg';
-import { MouseEvent } from 'react';
+import { MouseEvent, useCallback } from 'react';
 
 import styled, { css, useTheme } from 'styled-components';
 
@@ -58,34 +58,43 @@ export const Icon = ({
 
     const iconSize = getIconSize(size);
 
-    const handleOnKeyDown = (e: React.KeyboardEvent) => {
-        if (e.key === 'Enter' || e.key === ' ') {
+    const handleOnKeyDown = useCallback(
+        (e: React.KeyboardEvent) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                onClick?.();
+            }
+        },
+        [onClick],
+    );
+
+    const handleInjection = useCallback(
+        (svg: SVGSVGElement) => {
+            const strokeColor = isCSSColor(color) ? color : theme[color];
+
+            svg.querySelectorAll('path')?.forEach(path => {
+                if (path.hasAttribute('fill')) {
+                    path.setAttribute('fill', strokeColor);
+                }
+                if (path.hasAttribute('stroke')) {
+                    path.setAttribute('stroke', strokeColor);
+                }
+            });
+            svg.setAttribute('width', `${iconSize}px`);
+            svg.setAttribute('height', `${iconSize}px`);
+        },
+        [color, iconSize, theme],
+    );
+
+    const handleClick = useCallback(
+        (e: MouseEvent<any>) => {
             onClick?.();
-        }
-    };
 
-    const handleInjection = (svg: SVGSVGElement) => {
-        const strokeColor = isCSSColor(color) ? color : theme[color];
-
-        svg.querySelectorAll('path')?.forEach(path => {
-            if (path.hasAttribute('fill')) {
-                path.setAttribute('fill', strokeColor);
-            }
-            if (path.hasAttribute('stroke')) {
-                path.setAttribute('stroke', strokeColor);
-            }
-        });
-        svg.setAttribute('width', `${iconSize}px`);
-        svg.setAttribute('height', `${iconSize}px`);
-    };
-
-    const handleClick = (e: MouseEvent<any>) => {
-        onClick?.();
-
-        // We need to stop default/propagation in case the icon is rendered in popup/modal so it won't close it.
-        e.preventDefault();
-        e.stopPropagation();
-    };
+            // We need to stop default/propagation in case the icon is rendered in popup/modal so it won't close it.
+            e.preventDefault();
+            e.stopPropagation();
+        },
+        [onClick],
+    );
 
     return (
         <SVG


### PR DESCRIPTION
Fix React crashing ( :scream: ) at Coinmarket Sell page caused by excessive rerenders (maximum updates reached).

## Description

- [Sentry error](https://satoshilabs.sentry.io/issues/5747219007/?project=5193825&referrer=github_integration)
  - Web only, not desktop!
  - URL `/accounts/coinmarket/sell#/btc/0/normal`
- It might not be apparent at first glance how the cause is connected to the consequence
  - See [the error in console](https://github.com/user-attachments/files/16757791/react.error.txt), which hints at `ReactSVG` component used in `Icon.web`
- The error description hint is misleading
  - it is not caused an infinite loop caused by incorrectly used hooks
  - It's really just ordinary rerenders, but too much of them..
- Missing `useCallback` reduced _some_ unnecessary rerenders
- :thinking:  This is just the tip of iceberg. Our codebase often lacks memoization, so it will probably pop up again

## Related Issue

Resolve #13970

## Screenshots:

![react crash](https://github.com/user-attachments/assets/9a58ad0e-d749-44b4-a1cf-42a7f810f928)


