### PR TITLE
Resetting transport on error

### DIFF
--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -333,7 +333,18 @@ export abstract class AbstractTransport extends TypedEmitter<{
     /**
      * Stop transport = remove all listeners + try to release session + cancel all requests
      */
-    abstract stop(): void;
+    stop() {
+        this.removeAllListeners();
+        this.stopped = true;
+        this.listening = false;
+        this.abortController.abort();
+        this.abortController = new AbortController();
+        this.descriptors = [];
+        this.acquiredUnconfirmed = {};
+        this.listenPromise = {};
+        this.releaseUnconfirmed = {};
+        this.releasePromise = undefined;
+    }
 
     private getDiff(nextDescriptors: Descriptor[]): DeviceDescriptorDiff {
         const connected = nextDescriptors.filter(

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -332,10 +332,9 @@ export abstract class AbstractApiTransport extends AbstractTransport {
     }
 
     stop() {
+        super.stop();
         this.api.on('transport-interface-change', () => {
             this.logger?.debug('device connected after transport stopped');
         });
-        this.stopped = true;
-        this.abortController.abort();
     }
 }

--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -315,9 +315,8 @@ export class BridgeTransport extends AbstractTransport {
     }
 
     public stop() {
-        this.stopped = true;
-        this.listening = false;
-        this.abortController.abort();
+        super.stop();
+        this.acquirePromise = undefined;
     }
 
     /**


### PR DESCRIPTION
## Description

While reviewing #13916 I've found out that in #13273 I accidentally broke reconnection in case of failing transport: When transport throws an error, its class instance is reused instead of recreated, but `AbortController` stays aborted. Now all instance members should be resetted on `transport.stop()` call.