### PR TITLE
feat(wallet-core): disableAccountsThunk can exclude portfolio accounts

### DIFF
--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -37,7 +37,9 @@ export const disableAccountsThunk = createThunk(
             .filter(n => !enabledNetworks.includes(n.symbol) || n.isHidden)
             .map(n => n.symbol);
         // find accounts for disabled networks
-        const accountsToRemove = accounts.filter(a => disabledNetworks.includes(a.symbol));
+        const accountsToRemove = accounts.filter(
+            a => disabledNetworks.includes(a.symbol) && !a.imported,
+        );
 
         if (accountsToRemove.length) {
             dispatch(accountsActions.removeAccount(accountsToRemove));


### PR DESCRIPTION
Previously disabling coin removed Portfolio tracker accounts, it should stay there now.

## Related Issue

Resolve #13986

## Screenshots:

https://github.com/user-attachments/assets/0c24bc49-dd58-4ed4-9763-272fbb8b733e

