### PR TITLE
feat(suite): display details page for all networks

### DIFF
--- a/packages/components/src/components/Badge/Badge.tsx
+++ b/packages/components/src/components/Badge/Badge.tsx
@@ -16,6 +16,7 @@ type BadgeVariant = Extract<UIVariant, 'primary' | 'tertiary' | 'destructive'>;
 export type BadgeProps = AllowedFrameProps & {
     size?: BadgeSize;
     variant?: BadgeVariant;
+    onElevation?: boolean;
     isDisabled?: boolean;
     icon?: IconName;
     hasAlert?: boolean;
@@ -26,6 +27,7 @@ export type BadgeProps = AllowedFrameProps & {
 
 type MapArgs = {
     $variant: BadgeVariant;
+    $onElevation?: boolean;
     theme: DefaultTheme;
 };
 
@@ -34,12 +36,13 @@ type BadgeContainerProps = {
     $variant: BadgeVariant;
     $hasAlert: boolean;
     $inline: boolean;
+    $onElevation: boolean;
 } & TransientProps<AllowedFrameProps>;
 
-const mapVariantToBackgroundColor = ({ $variant, theme }: MapArgs): CSSColor => {
+const mapVariantToBackgroundColor = ({ $variant, $onElevation, theme }: MapArgs): CSSColor => {
     const colorMap: Record<BadgeVariant, Color> = {
         primary: 'backgroundPrimarySubtleOnElevation0',
-        tertiary: 'backgroundNeutralSubtleOnElevation0',
+        tertiary: `backgroundNeutralSubtleOnElevation${$onElevation ? 1 : 0}`,
         destructive: 'backgroundAlertRedSubtleOnElevation0',
     };
 
@@ -113,6 +116,7 @@ const Content = styled.span<{ $isDisabled: boolean; $variant: BadgeVariant; $siz
 export const Badge = ({
     size = 'medium',
     variant = 'tertiary',
+    onElevation,
     isDisabled,
     icon,
     hasAlert,
@@ -128,6 +132,7 @@ export const Badge = ({
             $size={size}
             $variant={variant}
             $hasAlert={!!hasAlert}
+            $onElevation={!!onElevation}
             className={className}
             $margin={margin}
             $inline={inline === true}

--- a/packages/suite/src/components/suite/AccountLabel.tsx
+++ b/packages/suite/src/components/suite/AccountLabel.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from '../../hooks/suite';
 import { spacings } from '@trezor/theme';
 import { AccountType, NetworkSymbol } from '@suite-common/wallet-config';
 import { AccountTypeBadge } from './AccountTypeBadge';
+import { Bip43Path, NetworkType } from '@suite-common/wallet-config';
 
 const TabularNums = styled.span`
     font-variant-numeric: tabular-nums;
@@ -20,6 +21,8 @@ export interface AccountLabelProps {
     index?: number;
     showAccountTypeBadge?: boolean;
     accountTypeBadgeSize?: BadgeSize;
+    path?: Bip43Path;
+    networkType?: NetworkType;
 }
 
 export const useAccountLabel = () => {
@@ -55,6 +58,8 @@ export const useAccountLabel = () => {
 export const AccountLabel = ({
     accountLabel,
     accountType = 'normal',
+    path,
+    networkType,
     showAccountTypeBadge,
     accountTypeBadgeSize = 'medium',
     symbol,
@@ -68,7 +73,12 @@ export const AccountLabel = ({
                 <Row gap={spacings.sm}>
                     <TabularNums>{accountLabel}</TabularNums>
                     {showAccountTypeBadge && (
-                        <AccountTypeBadge accountType={accountType} size={accountTypeBadgeSize} />
+                        <AccountTypeBadge
+                            accountType={accountType}
+                            size={accountTypeBadgeSize}
+                            path={path}
+                            networkType={networkType}
+                        />
                     )}
                 </Row>
             </TruncateWithTooltip>
@@ -80,7 +90,12 @@ export const AccountLabel = ({
             <Row gap={spacings.sm}>
                 {defaultAccountLabelString({ accountType, symbol, index })}
                 {showAccountTypeBadge && (
-                    <AccountTypeBadge accountType={accountType} size={accountTypeBadgeSize} />
+                    <AccountTypeBadge
+                        accountType={accountType}
+                        size={accountTypeBadgeSize}
+                        path={path}
+                        networkType={networkType}
+                    />
                 )}
             </Row>
         </TruncateWithTooltip>

--- a/packages/suite/src/components/suite/AccountTypeBadge.tsx
+++ b/packages/suite/src/components/suite/AccountTypeBadge.tsx
@@ -1,24 +1,38 @@
-import { UppercaseAccountType } from '@suite-common/wallet-types';
-import { AccountType } from '@suite-common/wallet-config';
-import { toUppercaseType } from '@suite-common/suite-utils';
 import { Badge, BadgeSize } from '@trezor/components';
 import { Translation } from './Translation';
+import { getAccountTypeName } from '@suite-common/wallet-utils';
+import { AccountType, Bip43Path, NetworkType } from '@suite-common/wallet-config';
 
 type AccountTypeBadgeProps = {
     accountType?: AccountType;
+    path?: Bip43Path;
+    networkType?: NetworkType;
+    onElevation?: boolean;
     size?: BadgeSize;
+    shouldDisplayNormalType?: boolean;
 };
 
-export const AccountTypeBadge = ({ accountType, size = 'medium' }: AccountTypeBadgeProps) => {
-    if (!accountType || accountType === 'normal') {
+export const AccountTypeBadge = ({
+    accountType,
+    path,
+    networkType,
+    size = 'medium',
+    onElevation = false,
+    shouldDisplayNormalType = false,
+}: AccountTypeBadgeProps) => {
+    if (!accountType || !networkType) {
         return null;
     }
 
-    const accountTypeUppercase: UppercaseAccountType = toUppercaseType(accountType);
+    if (!shouldDisplayNormalType && accountType === 'normal') {
+        return null;
+    }
+
+    const accountTypeName = getAccountTypeName({ path, accountType, networkType });
 
     return (
-        <Badge size={size}>
-            <Translation id={`TR_ACCOUNT_TYPE_${accountTypeUppercase}`} />
+        <Badge size={size} onElevation={onElevation}>
+            {accountTypeName ? <Translation id={accountTypeName} /> : null}
         </Badge>
     );
 };

--- a/packages/suite/src/components/suite/labeling/AccountLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/AccountLabeling.tsx
@@ -25,7 +25,7 @@ export const AccountLabeling = ({
     const devices = useSelector(selectDevices);
 
     const accounts = !Array.isArray(account) ? [account] : account;
-    const { symbol, index, accountType, key } = accounts[0];
+    const { symbol, index, accountType, key, path, networkType } = accounts[0];
 
     const labels = useSelector(state => selectLabelingDataForAccount(state, key));
 
@@ -39,6 +39,8 @@ export const AccountLabeling = ({
             index={index}
             showAccountTypeBadge={showAccountTypeBadge}
             accountTypeBadgeSize={accountTypeBadgeSize}
+            path={path}
+            networkType={networkType}
         />
     );
 

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
@@ -164,6 +164,8 @@ const ButtonLikeLabel = ({
 
 const TextLikeLabel = ({
     accountType,
+    networkType,
+    path,
     editActive,
     defaultVisibleValue,
     defaultEditableValue,
@@ -187,7 +189,13 @@ const TextLikeLabel = ({
                     onBlur={onBlur}
                     updateFlag={updateFlag}
                 />
-                {isAccountLabel && <AccountTypeBadge accountType={accountType} />}
+                {isAccountLabel && (
+                    <AccountTypeBadge
+                        accountType={accountType}
+                        networkType={networkType}
+                        path={path}
+                    />
+                )}
             </Row>
         );
     }
@@ -197,7 +205,13 @@ const TextLikeLabel = ({
             <Label data-testid={dataTest}>
                 <Row gap={12}>
                     <LabelValue>{payload.value}</LabelValue>
-                    {isAccountLabel && <AccountTypeBadge accountType={accountType} />}
+                    {isAccountLabel && (
+                        <AccountTypeBadge
+                            accountType={accountType}
+                            networkType={networkType}
+                            path={path}
+                        />
+                    )}
                 </Row>
             </Label>
         );
@@ -255,6 +269,8 @@ const getLocalizedActions = (type: MetadataAddPayload['type']) => {
 export const MetadataLabeling = ({
     payload,
     accountType,
+    networkType,
+    path,
     dropdownOptions,
     defaultEditableValue,
     defaultVisibleValue,
@@ -437,10 +453,13 @@ export const MetadataLabeling = ({
                         onBlur={handleBlur}
                         data-testid={dataTestBase}
                         payload={payload}
+                        networkType={networkType}
+                        path={path}
                         defaultEditableValue={defaultEditableValue}
                         defaultVisibleValue={defaultVisibleValue}
                         updateFlag={updateFlag}
                     />
+
                     {showActionButton && (
                         <ActionButton
                             data-testid={

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/definitions.ts
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/definitions.ts
@@ -2,9 +2,12 @@ import { ReactNode } from 'react';
 import { DropdownMenuItemProps } from '@trezor/components';
 import { MetadataAddPayload } from 'src/types/suite/metadata';
 import { AccountType } from '@suite-common/wallet-config';
+import { NetworkType } from '@suite-common/wallet-config';
 
 export interface Props {
     accountType?: AccountType;
+    networkType?: NetworkType;
+    path?: string;
     defaultVisibleValue?: ReactNode;
     defaultEditableValue?: string;
     payload: MetadataAddPayload;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountDetails.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountDetails.tsx
@@ -101,6 +101,8 @@ export const AccountDetails = ({ selectedAccount, isBalanceShown }: AccountDetai
             <AccountHeading $isBalanceShown={isBalanceShown}>
                 <MetadataLabeling
                     accountType={accountType}
+                    networkType={selectedAccount.networkType}
+                    path={path}
                     defaultVisibleValue={
                         <AccountLabel
                             showAccountTypeBadge
@@ -108,6 +110,8 @@ export const AccountDetails = ({ selectedAccount, isBalanceShown }: AccountDetai
                             accountType={accountType}
                             symbol={selectedAccount.symbol}
                             index={index}
+                            path={path}
+                            networkType={selectedAccount.networkType}
                         />
                     }
                     payload={{

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeDescription.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeDescription.tsx
@@ -1,35 +1,51 @@
-import styled from 'styled-components';
-import { Paragraph } from '@trezor/components';
 import { Bip43Path } from '@suite-common/wallet-config';
 import { Translation } from 'src/components/suite';
-import { getAccountTypeDesc, getAccountTypeUrl } from '@suite-common/wallet-utils';
-import { spacingsPx } from '@trezor/theme';
+import {
+    getAccountTypeDesc,
+    getAccountTypeUrl,
+    getTitleForNetwork,
+} from '@suite-common/wallet-utils';
 import { LearnMoreButton } from 'src/components/suite/LearnMoreButton';
-
-// eslint-disable-next-line local-rules/no-override-ds-component
-const Info = styled(Paragraph)`
-    margin: ${spacingsPx.md} 0 ${spacingsPx.xs};
-`;
+import { AccountType } from '@suite-common/wallet-config';
+import { NetworkType } from '@suite-common/wallet-config';
+import { useTranslation } from 'src/hooks/suite';
+import { Column } from '@trezor/components';
+import { spacings } from '@trezor/theme';
+import { Account } from '@suite-common/wallet-types';
 
 interface AccountTypeDescriptionProps {
     bip43Path: Bip43Path;
-    hasMultipleAccountTypes: boolean;
+    accountType?: AccountType;
+    symbol?: Account['symbol'];
+    networkType?: NetworkType;
 }
 
 export const AccountTypeDescription = ({
     bip43Path,
-    hasMultipleAccountTypes,
+    accountType,
+    symbol,
+    networkType,
 }: AccountTypeDescriptionProps) => {
-    if (!hasMultipleAccountTypes) return null;
+    const { translationString } = useTranslation();
     const accountTypeUrl = getAccountTypeUrl(bip43Path);
-    const accountTypeDesc = getAccountTypeDesc(bip43Path);
+    const accountTypeDescId = getAccountTypeDesc({ path: bip43Path, accountType, networkType });
+
+    const renderAccountTypeDesc = () => {
+        if (symbol && accountType === 'normal' && networkType === 'ethereum') {
+            const value = getTitleForNetwork(symbol);
+
+            return (
+                <Translation id={accountTypeDescId} values={{ value: translationString(value) }} />
+            );
+        }
+
+        return <Translation id={accountTypeDescId} />;
+    };
 
     return (
-        <>
-            <Info>
-                <Translation id={accountTypeDesc} />
-            </Info>
+        <Column alignItems="flex-start" gap={spacings.sm}>
+            {renderAccountTypeDesc()}
             {accountTypeUrl && <LearnMoreButton url={accountTypeUrl} />}
-        </>
+        </Column>
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -196,6 +196,8 @@ export const AddAccountModal = ({ device, onCancel, symbol, noRedirect }: AddAcc
                           selectedAccountType={selectedAccount}
                           accountTypes={accountTypes}
                           onSelectAccountType={setSelectedAccount}
+                          networkType={selectedNetwork.networkType}
+                          symbol={selectedNetwork.symbol}
                       />
                   ),
                   onBackClick: () => setSelectedNetwork(undefined),

--- a/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountNavigation.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountNavigation.tsx
@@ -65,7 +65,6 @@ export const AccountNavigation = () => {
                 goToWithAnalytics('wallet-details', { preserveParams: true });
             },
             title: <Translation id="TR_NAV_DETAILS" />,
-            isHidden: !['cardano', 'bitcoin'].includes(networkType),
             'data-testid': `@wallet/menu/wallet-details`,
         },
     ];

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3646,6 +3646,36 @@ export default defineMessages({
         defaultMessage:
             'Legacy uses simpler transaction formats but may result in higher transaction fees and lacks the efficiency and features found in newer address types.',
     },
+    TR_ACCOUNT_TYPE_LEDGER_DESC: {
+        id: 'TR_ACCOUNT_TYPE_LEDGER_DESC',
+        defaultMessage:
+            'Ledger accounts are compatible with Ledger Live derivation paths, enabling smooth  migration from Ledger to Trezor.',
+    },
+    TR_ACCOUNT_TYPE_LEGACY_DESC: {
+        id: 'TR_ACCOUNT_TYPE_LEGACY_DESC',
+        defaultMessage:
+            'Legacy accounts are compatible with Ledger Legacy derivation paths, enabling smooth migration from Ledger to Trezor.',
+    },
+    TR_ACCOUNT_TYPE_NORMAL_EVM_DESC: {
+        id: 'TR_ACCOUNT_TYPE_NORMAL_EVM_DESC',
+        defaultMessage:
+            'The current and most widely accepted method of generating and managing {value} addresses ensures interoperability, security, and support for all types of tokens.',
+    },
+    TR_ACCOUNT_TYPE_NORMAL_SOLANA_DESC: {
+        id: 'TR_ACCOUNT_TYPE_NORMAL_SOLANA_DESC',
+        defaultMessage:
+            'The current and most widely accepted method of generating and managing Solana addresses ensures interoperability, security, and support for SOL and SPL tokens.',
+    },
+    TR_ACCOUNT_TYPE_NORMAL_CARDANO_DESC: {
+        id: 'TR_ACCOUNT_TYPE_CARDANO_DESC',
+        defaultMessage:
+            'The current and most widely accepted method of generating and managing Cardano addresses ensures interoperability, security, and support for all types of tokens.',
+    },
+    TR_ACCOUNT_TYPE_NORMAL_XRP_DESC: {
+        id: 'TR_ACCOUNT_TYPE_XRP_DESC',
+        defaultMessage:
+            'XRP is a digital currency that enables fast, low-cost cross-border payments without relying on traditional mining, using a consensus ledger for quick transaction confirmations.',
+    },
     TR_ACCOUNT_DETAILS_XPUB_HEADER: {
         id: 'TR_ACCOUNT_DETAILS_XPUB_HEADER',
         defaultMessage: 'Public key (XPUB)',

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputAccount.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputAccount.tsx
@@ -76,6 +76,7 @@ export const CoinmarketFormInputAccount = <
                                     {group.label}
                                     <AccountTypeBadge
                                         accountType={group.options[0].accountType}
+                                        networkType={group.options[0].value}
                                         size="small"
                                     />
                                 </Row>

--- a/suite-common/metadata-types/src/metadataTypes.ts
+++ b/suite-common/metadata-types/src/metadataTypes.ts
@@ -35,6 +35,8 @@ export type MetadataAddPayload = { skipSave?: boolean } & (
           entityKey: string;
           defaultValue: string;
           value?: string;
+          networkType?: string;
+          path?: string;
       }
     | {
           type: 'walletLabel';

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -19,6 +19,7 @@ import {
     Network,
     networks,
     AccountType,
+    Bip43Path,
 } from '@suite-common/wallet-config';
 import {
     Account,
@@ -222,7 +223,36 @@ export const getBip43Type = (path: string) => {
     }
 };
 
-export const getAccountTypeName = (path: string) => {
+type getAccountTypeNameProps = {
+    path?: Bip43Path;
+    networkType?: NetworkType;
+    accountType?: AccountType;
+};
+
+export const getAccountTypeName = ({ path, accountType, networkType }: getAccountTypeNameProps) => {
+    if (!networkType) return null;
+    if (networkType !== 'bitcoin') {
+        switch (accountType?.toLowerCase()) {
+            case 'ledger':
+                return 'TR_ACCOUNT_TYPE_LEDGER';
+            case 'legacy':
+                return 'TR_ACCOUNT_TYPE_LEGACY';
+            case 'normal':
+                return 'TR_ACCOUNT_TYPE_NORMAL';
+        }
+    } else {
+        switch (accountType?.toLowerCase()) {
+            case 'segwit':
+                return 'TR_ACCOUNT_TYPE_SEGWIT';
+            case 'taproot':
+                return 'TR_ACCOUNT_TYPE_TAPROOT';
+            case 'normal':
+                return 'TR_ACCOUNT_TYPE_BIP84_NAME';
+            case 'legacy':
+                return 'TR_ACCOUNT_TYPE_LEGACY';
+        }
+    }
+    if (!path) return null;
     const accountTypePrefix = getAccountTypePrefix(path);
     if (accountTypePrefix) return `${accountTypePrefix}_NAME` as const;
     const bip43 = getBip43Type(path);
@@ -235,7 +265,7 @@ export const getAccountTypeName = (path: string) => {
     return 'TR_ACCOUNT_TYPE_BIP44_NAME';
 };
 
-export const getAccountTypeTech = (path: string) => {
+export const getAccountTypeTech = (path: Bip43Path) => {
     const accountTypePrefix = getAccountTypePrefix(path);
     if (accountTypePrefix) return `${accountTypePrefix}_TECH` as const;
     const bip43 = getBip43Type(path);
@@ -248,15 +278,46 @@ export const getAccountTypeTech = (path: string) => {
     return 'TR_ACCOUNT_TYPE_BIP44_TECH';
 };
 
-export const getAccountTypeDesc = (path: string) => {
+type getAccountTypeDescProps = {
+    path: Bip43Path;
+    accountType?: AccountType;
+    networkType?: NetworkType;
+};
+
+export const getAccountTypeDesc = ({ path, accountType, networkType }: getAccountTypeDescProps) => {
+    switch (accountType?.toLowerCase()) {
+        case 'ledger':
+            return 'TR_ACCOUNT_TYPE_LEDGER_DESC';
+        case 'legacy':
+            return 'TR_ACCOUNT_TYPE_LEGACY_DESC';
+    }
+
+    switch (networkType?.toLowerCase()) {
+        case 'ethereum':
+            return 'TR_ACCOUNT_TYPE_NORMAL_EVM_DESC';
+        case 'solana':
+            return 'TR_ACCOUNT_TYPE_NORMAL_SOLANA_DESC';
+        case 'cardano':
+            return 'TR_ACCOUNT_TYPE_NORMAL_CARDANO_DESC';
+        case 'ripple':
+            return 'TR_ACCOUNT_TYPE_NORMAL_XRP_DESC';
+    }
+
     const accountTypePrefix = getAccountTypePrefix(path);
     if (accountTypePrefix) return `${accountTypePrefix}_DESC` as const;
     const bip43 = getBip43Type(path);
-    if (bip43 === 'bip86') return 'TR_ACCOUNT_TYPE_BIP86_DESC';
-    if (bip43 === 'bip84') return 'TR_ACCOUNT_TYPE_BIP84_DESC';
-    if (bip43 === 'bip49') return 'TR_ACCOUNT_TYPE_BIP49_DESC';
-    if (bip43 === 'shelley') return 'TR_ACCOUNT_TYPE_SHELLEY_DESC';
-    if (bip43 === 'slip25') return 'TR_ACCOUNT_TYPE_SLIP25_DESC';
+    switch (bip43) {
+        case 'bip86':
+            return 'TR_ACCOUNT_TYPE_BIP86_DESC';
+        case 'bip84':
+            return 'TR_ACCOUNT_TYPE_BIP84_DESC';
+        case 'bip49':
+            return 'TR_ACCOUNT_TYPE_BIP49_DESC';
+        case 'shelley':
+            return 'TR_ACCOUNT_TYPE_SHELLEY_DESC';
+        case 'slip25':
+            return 'TR_ACCOUNT_TYPE_SLIP25_DESC';
+    }
 
     return 'TR_ACCOUNT_TYPE_BIP44_DESC';
 };


### PR DESCRIPTION
## Description

- Add details page to all the missing networks
- Add accoun type description when adding a new account. 

Texts to be used in details page for each network: 
https://www.notion.so/satoshilabs/Account-Details-page-9b2ecff33ed94a3593dcd3cdf5c97a3b

Which accounts should have an xpub section [source
](https://support.koinly.io/en/articles/9489974-how-to-get-the-xpub-from-different-wallets-brd-ledger-jaxx-etc)

## Related Issue

Resolve  https://github.com/trezor/trezor-suite/issues/13735 https://github.com/trezor/trezor-suite/issues/13736

## Screenshots:

Ethereum details:
<img width="1034" alt="image" src="https://github.com/user-attachments/assets/450fa285-47d6-49e6-8475-2fb1ce9538c1">


Ethereum Ledger details (badge is added to all account type descriptions including normal):
<img width="1034" alt="image" src="https://github.com/user-attachments/assets/bd8adbf4-1763-485a-b5b5-55c35cc694b2">


Ethereum classic details: 
<img width="1021" alt="image" src="https://github.com/user-attachments/assets/a27259e8-09ae-4b75-abbe-529d7259acf7">


XRP details:
<img width="1021" alt="image" src="https://github.com/user-attachments/assets/3993c17f-8938-4ea0-a8c8-f1df80bde208">


Cardano details: 
<img width="1021" alt="image" src="https://github.com/user-attachments/assets/cc81829a-f4fe-449c-ad85-815af9253abc">


Solana details:
<img width="1021" alt="image" src="https://github.com/user-attachments/assets/6ec8a824-787a-4092-8978-da6a1a43509e">


 
### Add New Account: 

Ethereum: 
<img width="629" alt="image" src="https://github.com/user-attachments/assets/fb73162d-1583-4a74-91a5-53725916899b">
<img width="629" alt="image" src="https://github.com/user-attachments/assets/5246c71a-058c-4d55-91c4-7d207a8c229d">
<img width="629" alt="image" src="https://github.com/user-attachments/assets/2c8899f1-e0df-4235-ad94-e46be6c5cb1b">
<img width="629" alt="image" src="https://github.com/user-attachments/assets/351246c5-051b-4bde-98e0-d9fa20b65afc">


Cardano: 
<img width="629" alt="image" src="https://github.com/user-attachments/assets/2b065172-08ad-4e4b-8d68-606ab39c1ce7">
<img width="629" alt="image" src="https://github.com/user-attachments/assets/caf20d2c-ff45-406a-9e79-e0d0a62d13c8">
(Legacy and Ledger same as Ethereum)

Solana:
<img width="629" alt="image" src="https://github.com/user-attachments/assets/91416c18-f030-4123-ad49-b4eac43456ee">
<img width="629" alt="image" src="https://github.com/user-attachments/assets/c61a8fbd-178f-4635-b4f9-e952a0b85a4f">
(Ledger same as Ethereum)




