### PR TITLE
Turn off password manager feature on every start

### DIFF
--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -325,7 +325,11 @@ export const saveSuiteSettings = () => async (_dispatch: Dispatch, getState: Get
     db.addItem(
         'suiteSettings',
         {
-            settings: suite.settings,
+            settings: {
+                ...suite.settings,
+                // Temporary measure to always start Suite with password manager off
+                experimental: suite.settings.experimental?.filter(e => e !== 'password-manager'),
+            },
             flags: suite.flags,
             evmSettings: suite.evmSettings,
         },

--- a/packages/suite/src/constants/suite/experimental.ts
+++ b/packages/suite/src/constants/suite/experimental.ts
@@ -23,7 +23,6 @@ export const EXPERIMENTAL_FEATURES: Record<ExperimentalFeature, ExperimentalFeat
     'password-manager': {
         title: 'TR_EXPERIMENTAL_PASSWORD_MANAGER',
         description: 'TR_EXPERIMENTAL_PASSWORD_MANAGER_DESCRIPTION',
-        isDisabled: ({ isDebug }) => !isDebug,
         knowledgeBaseUrl: EXPERIMENTAL_PASSWORD_MANAGER_KB_URL,
     },
     'automatic-update': {


### PR DESCRIPTION
## Description

As demanded, `password-manager` experimental feature from now on cannot be turned on persisently, so in exchange it may be accessible outside debug mode.