### PR TITLE
chore(suite-native): memoize expensive selector to save CPU during graph loading

### DIFF
--- a/suite-native/tokens/src/ethereumTokensSelectors.ts
+++ b/suite-native/tokens/src/ethereumTokensSelectors.ts
@@ -1,5 +1,5 @@
 import { A, G, pipe } from '@mobily/ts-belt';
-import { memoizeWithArgs } from 'proxy-memoize';
+import { memoizeWithArgs, memoize } from 'proxy-memoize';
 
 import {
     AccountsRootState,
@@ -206,16 +206,16 @@ export const selectIsEthereumAccountWithTokensWithFiatRates = (
     return selectNumberOfEthereumAccountTokensWithFiatRates(state, ethereumAccountKey) > 0;
 };
 
-export const selectNumberOfUniqueEthereumTokensPerDevice = (
-    state: AccountsRootState & DeviceRootState & FiatRatesRootState & SettingsSliceRootState,
-) => {
-    const accounts = selectVisibleDeviceAccounts(state);
+export const selectNumberOfUniqueEthereumTokensPerDevice = memoize(
+    (state: AccountsRootState & DeviceRootState & FiatRatesRootState & SettingsSliceRootState) => {
+        const accounts = selectVisibleDeviceAccounts(state);
 
-    return pipe(
-        accounts,
-        A.map(account => selectEthereumAccountsTokensWithFiatRates(state, account.key)),
-        A.flat,
-        A.uniqBy(token => token.contract),
-        A.length,
-    );
-};
+        return pipe(
+            accounts,
+            A.map(account => selectEthereumAccountsTokensWithFiatRates(state, account.key)),
+            A.flat,
+            A.uniqBy(token => token.contract),
+            A.length,
+        );
+    },
+);


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Very small step to optimize app lagging during graph loading of account with lot of transactions. Just saving CPU by memoizing non-trivial selector.

## Related Issue

related to https://github.com/trezor/trezor-suite/issues/13821

## Screenshots:
without memoization:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/84e0a94c-e353-4652-acf2-90aa8bd1fd75">

with memoization:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/a44a3787-93ce-4f29-9dd4-c084e5e19bdf">

