### PR TITLE
Feat/followup account badges

### DIFF
--- a/packages/suite/src/types/coinmarket/coinmarket.ts
+++ b/packages/suite/src/types/coinmarket/coinmarket.ts
@@ -39,7 +39,7 @@ import {
     CryptoCategoryD,
     CryptoCategoryE,
 } from 'src/constants/wallet/coinmarket/cryptoCategories';
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import { AccountType, NetworkSymbol } from '@suite-common/wallet-config';
 import { ExtendedMessageDescriptor, TrezorDevice } from 'src/types/suite';
 import { Timer } from '@trezor/react-utils';
 import { AccountsState } from '@suite-common/wallet-core';
@@ -214,6 +214,7 @@ export interface CoinmarketAccountOptionsGroupOptionProps extends CoinmarketCryp
     balance: string;
     descriptor: string;
     contractAddress?: string;
+    accountType?: AccountType;
 }
 
 export interface CoinmarketAccountsOptionsGroupProps {

--- a/packages/suite/src/utils/wallet/coinmarket/__tests__/coinmarketUtils.test.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/__tests__/coinmarketUtils.test.ts
@@ -397,6 +397,7 @@ describe('coinmarket utils', () => {
                 label,
                 options: [
                     {
+                        accountType: undefined,
                         balance: '0',
                         cryptoName: 'Bitcoin',
                         descriptor: 'descriptor1',
@@ -409,6 +410,7 @@ describe('coinmarket utils', () => {
                 label,
                 options: [
                     {
+                        accountType: undefined,
                         balance: '0.101213',
                         cryptoName: 'Litecoin',
                         descriptor: 'descriptor2',
@@ -421,6 +423,7 @@ describe('coinmarket utils', () => {
                 label,
                 options: [
                     {
+                        accountType: undefined,
                         balance: '0',
                         cryptoName: 'Ethereum',
                         descriptor: 'descriptor3',
@@ -428,6 +431,7 @@ describe('coinmarket utils', () => {
                         value: 'ETH',
                     },
                     {
+                        accountType: undefined,
                         balance: '2230',
                         contractAddress: '0x1234123412341234123412341234123412341236',
                         cryptoName: null,
@@ -441,6 +445,7 @@ describe('coinmarket utils', () => {
                 label,
                 options: [
                     {
+                        accountType: undefined,
                         balance: '250',
                         cryptoName: null,
                         descriptor: 'descriptor6',

--- a/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
@@ -443,6 +443,7 @@ export const coinmarketBuildAccountOptions = ({
                 cryptoName: foundSymbolInfo?.name ?? null,
                 descriptor,
                 balance: formattedBalance ?? '',
+                accountType: account.accountType,
             },
         ];
         // add crypto tokens to options
@@ -488,6 +489,7 @@ export const coinmarketBuildAccountOptions = ({
                     cryptoName: tokenSymbolInfo?.name ?? null,
                     contractAddress: contract,
                     descriptor,
+                    accountType,
                     balance: balance ?? '',
                 });
             });

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputAccountActive.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputAccountActive.tsx
@@ -3,7 +3,7 @@ import {
     isCryptoSymbolToken,
 } from 'src/utils/wallet/coinmarket/cryptoSymbolUtils';
 import { Control, Controller } from 'react-hook-form';
-import { Select, useElevation } from '@trezor/components';
+import { Row, Select, useElevation } from '@trezor/components';
 import { useCoinmarketFormContext } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonForm';
 import {
     CoinmarketAccountOptionsGroupOptionProps,
@@ -27,6 +27,8 @@ import { useCoinmarketBuildAccountGroups } from 'src/hooks/wallet/coinmarket/for
 import { CoinmarketFormOptionIcon } from 'src/views/wallet/coinmarket/common/CoinmarketCoinImage';
 import { HiddenPlaceholder } from 'src/components/suite';
 import { createFilter } from 'react-select';
+import { AccountTypeBadge } from 'src/components/suite/AccountTypeBadge';
+import { spacings } from '@trezor/theme';
 
 const CoinmarketFormInputAccountActive = ({ label }: CoinmarketFormInputDefaultProps) => {
     const {
@@ -58,7 +60,13 @@ const CoinmarketFormInputAccountActive = ({ label }: CoinmarketFormInputDefaultP
                         })}
                         formatGroupLabel={group => (
                             <CoinmarketFormOptionGroupLabel>
-                                {group.label}
+                                <Row gap={spacings.xs}>
+                                    {group.label}
+                                    <AccountTypeBadge
+                                        accountType={group.options[0].accountType}
+                                        size="small"
+                                    />
+                                </Row>
                             </CoinmarketFormOptionGroupLabel>
                         )}
                         formatOptionLabel={(option: CoinmarketAccountOptionsGroupOptionProps) => {


### PR DESCRIPTION
Followup on https://github.com/trezor/trezor-suite/pull/13723

## Description

Added account type badges to sell section in trade.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/13737

## Screenshots:

<img width="365" alt="image" src="https://github.com/user-attachments/assets/3b4c648f-83a0-419f-8ccf-0063d3fa8dee">


