### PR TITLE
chore(wallet-utils): Typecheck networksConfig declaration

### DIFF
--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -3,7 +3,7 @@ import TrezorConnect from '@trezor/connect';
 import { promiseAllSequence } from '@trezor/utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { isDevEnv } from '@suite-common/suite-utils';
-import { Network, NetworkSymbol } from '@suite-common/wallet-config';
+import { NetworkCompatible, NetworkSymbol } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
 import {
     accountsActions,
@@ -550,7 +550,7 @@ const handleError = (error: string) => (dispatch: Dispatch) => {
 };
 
 export const createCoinjoinAccount =
-    (network: Network) => async (dispatch: Dispatch, getState: GetState) => {
+    (network: NetworkCompatible) => async (dispatch: Dispatch, getState: GetState) => {
         if (network.accountType !== 'coinjoin') {
             throw new Error('createCoinjoinAccount: invalid account type');
         }

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddButton.tsx
@@ -1,11 +1,11 @@
 import { ReactNode } from 'react';
 import { ButtonProps, Tooltip, NewModal } from '@trezor/components';
 import { Translation } from 'src/components/suite';
-import { Network } from '@suite-common/wallet-config';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 
 interface AddButtonProps extends Omit<ButtonProps, 'children'> {
     disabledMessage: ReactNode;
-    networkName: Network['name'];
+    networkName: NetworkCompatible['name'];
 }
 
 export const AddButton = ({ disabledMessage, networkName, ...buttonProps }: AddButtonProps) => (

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketBuyForm.tsx
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketBuyForm.tsx
@@ -39,7 +39,7 @@ import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 import { useCoinmarketNavigation } from 'src/hooks/wallet/useCoinmarketNavigation';
 import { FORM_PAYMENT_METHOD_SELECT } from 'src/constants/wallet/coinmarket/form';
 import { useCoinmarketSatsSwitcher } from 'src/hooks/wallet/coinmarket/form/useCoinmarketSatsSwitcher';
-import { Network } from '@suite-common/wallet-config';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import { cryptoToNetworkSymbol } from 'src/utils/wallet/coinmarket/cryptoSymbolUtils';
 import { useCoinmarketLoadData } from 'src/hooks/wallet/coinmarket/useCoinmarketLoadData';
 
@@ -149,7 +149,7 @@ const useCoinmarketBuyForm = ({
     // based on selected cryptoSymbol, because of using for validation cryptoInput
     const network = getNetwork(
         cryptoToNetworkSymbol(values.cryptoSelect?.value ?? 'BTC') ?? 'btc',
-    ) as Network;
+    ) as NetworkCompatible;
     const { toggleAmountInCrypto } = useCoinmarketSatsSwitcher({
         account,
         methods,

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeForm.ts
@@ -60,7 +60,7 @@ import {
 import * as coinmarketExchangeActions from 'src/actions/wallet/coinmarketExchangeActions';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { useCoinmarketRecomposeAndSign } from 'src/hooks/wallet/useCoinmarketRecomposeAndSign';
-import { Network, networksCompatibility } from '@suite-common/wallet-config';
+import { NetworkCompatible, networksCompatibility } from '@suite-common/wallet-config';
 import { SET_MODAL_CRYPTO_CURRENCY } from 'src/actions/wallet/constants/coinmarketCommonConstants';
 import useCoinmarketExchangeFormHelpers from 'src/hooks/wallet/coinmarket/form/useCoinmarketExchangeFormHelpers';
 import { useCoinmarketLoadData } from 'src/hooks/wallet/coinmarket/useCoinmarketLoadData';
@@ -135,7 +135,7 @@ export const useCoinmarketExchangeForm = ({
     const coinFees = fees[symbol];
     const levels = getFeeLevels(networkType, coinFees);
     const feeInfo = { ...coinFees, levels };
-    const network = getNetwork(account.symbol) as Network;
+    const network = getNetwork(account.symbol) as NetworkCompatible;
 
     const { getDraft, saveDraft, removeDraft } =
         useFormDraft<CoinmarketExchangeFormProps>('coinmarket-exchange');

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSellForm.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSellForm.ts
@@ -55,7 +55,7 @@ import { CoinmarketSellStepType } from 'src/types/coinmarket/coinmarketOffers';
 import { useCoinmarketCommonFormState } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonFormState';
 import { useCoinmarketSellFormHelpers } from 'src/hooks/wallet/coinmarket/form/useCoinmarketSellFormHelpers';
 import { selectAccounts } from '@suite-common/wallet-core';
-import { Network } from '@suite-common/wallet-config';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import { useCoinmarketSatsSwitcher } from 'src/hooks/wallet/coinmarket/form/useCoinmarketSatsSwitcher';
 import { useCoinmarketLoadData } from 'src/hooks/wallet/coinmarket/useCoinmarketLoadData';
 
@@ -132,7 +132,7 @@ export const useCoinmarketSellForm = ({
     const levels = getFeeLevels(networkType, coinFees);
     const feeInfo = { ...coinFees, levels };
     const addressDisplayType = useSelector(selectAddressDisplayType);
-    const network = getNetwork(account.symbol) as Network;
+    const network = getNetwork(account.symbol) as NetworkCompatible;
     const { shouldSendInSats } = useBitcoinAmountUnit(symbol);
     const localCurrencyOption = { value: localCurrency, label: localCurrency.toUpperCase() };
     const chunkify = addressDisplayType === AddressDisplayOptions.CHUNKED;

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -15,7 +15,7 @@ import { ExperimentalFeature } from 'src/constants/suite/experimental';
 import { Action, Lock, TorBootstrap, TorStatus } from 'src/types/suite';
 import { getExcludedPrerequisites, getPrerequisiteName } from 'src/utils/suite/prerequisites';
 import { RouterRootState, selectRouter } from './routerReducer';
-import { Network } from '@suite-common/wallet-config';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import { SuiteThemeVariant } from '@trezor/suite-desktop-api';
 import { AddressDisplayOptions, WalletType } from '@suite-common/wallet-types';
 import { SIDEBAR_WIDTH_NUMERIC } from 'src/constants/suite/layout';
@@ -72,8 +72,10 @@ export interface Flags {
 }
 
 export interface EvmSettings {
-    confirmExplanationModalClosed: Partial<Record<Network['symbol'], Record<string, boolean>>>;
-    explanationBannerClosed: Partial<Record<Network['symbol'], boolean>>;
+    confirmExplanationModalClosed: Partial<
+        Record<NetworkCompatible['symbol'], Record<string, boolean>>
+    >;
+    explanationBannerClosed: Partial<Record<NetworkCompatible['symbol'], boolean>>;
 }
 
 export interface PrefillFields {

--- a/packages/suite/src/types/wallet/index.ts
+++ b/packages/suite/src/types/wallet/index.ts
@@ -21,7 +21,7 @@ import { CoinmarketInfoAction } from 'src/actions/wallet/coinmarketInfoActions';
 import { tokenDefinitionsActions } from '@suite-common/token-definitions/src/tokenDefinitionsActions';
 
 // reexport
-export type { Network, NetworkSymbol } from '@suite-common/wallet-config';
+export type { NetworkCompatible as Network, NetworkSymbol } from '@suite-common/wallet-config';
 export type { Icon } from './iconTypes';
 export type { BackendType, CustomBackend } from './backend';
 export type { TickerId } from 'src/types/wallet/fiatRates';

--- a/packages/suite/src/types/wallet/sendForm.ts
+++ b/packages/suite/src/types/wallet/sendForm.ts
@@ -1,7 +1,7 @@
 import { Dispatch, SetStateAction } from 'react';
 import { FieldPath, UseFormReturn } from 'react-hook-form';
 
-import { Network } from '@suite-common/wallet-config';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import { AccountUtxo, FeeLevel, PROTO } from '@trezor/connect';
 
 import {
@@ -23,7 +23,7 @@ export type ExportFileType = 'csv' | 'pdf' | 'json';
 // local state of @wallet-hooks/useSendForm
 export type UseSendFormState = {
     account: Account;
-    network: Network;
+    network: NetworkCompatible;
     coinFees: FeeInfo;
     localCurrencyOption: { value: FiatCurrencyCode; label: Uppercase<FiatCurrencyCode> };
     feeInfo: FeeInfo;

--- a/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
+++ b/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
@@ -5,7 +5,7 @@ import { fromWei } from 'web3-utils';
 import { FiatCurrencyCode } from '@suite-common/suite-config';
 import { trezorLogo } from '@suite-common/suite-constants';
 import { TokenDefinitions } from '@suite-common/token-definitions';
-import { Network } from '@suite-common/wallet-config';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import {
     ExportFileType,
     RatesByTimestamps,
@@ -32,7 +32,7 @@ type AccountTransactionForExports = Omit<WalletAccountTransaction, 'targets'> & 
 };
 
 type Data = {
-    coin: Network['symbol'];
+    coin: NetworkCompatible['symbol'];
     accountName: string;
     type: ExportFileType;
     transactions: AccountTransactionForExports[];
@@ -73,11 +73,11 @@ const timeFormat = {
     timeZoneName: 'shortOffset',
 } as const;
 
-const formatIfDefined = (amount: string | undefined, symbol: Network['symbol']) =>
+const formatIfDefined = (amount: string | undefined, symbol: NetworkCompatible['symbol']) =>
     amount ? formatNetworkAmount(amount, symbol) : undefined;
 
 const formatAmounts =
-    (symbol: Network['symbol']) =>
+    (symbol: NetworkCompatible['symbol']) =>
     (tx: AccountTransactionForExports): AccountTransactionForExports => ({
         ...tx,
         tokens: tx.tokens.map(token => ({

--- a/packages/suite/src/views/dashboard/components/AssetsView/components/AssetCardInfo.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsView/components/AssetCardInfo.tsx
@@ -1,4 +1,4 @@
-import { Network } from '@suite-common/wallet-config';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import React from 'react';
 import styled from 'styled-components';
 import { AssetFiatBalance } from '@suite-common/assets';
@@ -14,7 +14,7 @@ const Flex = styled.div`
 `;
 
 interface AssetInfoProps {
-    network: Network;
+    network: NetworkCompatible;
     assetsFiatBalances?: AssetFiatBalance[];
     index?: number;
 }

--- a/packages/suite/src/views/dashboard/components/AssetsView/components/AssetCoinName.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsView/components/AssetCoinName.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { Network } from '@suite-common/wallet-config';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import { selectVisibleNonEmptyDeviceAccountsByNetworkSymbol } from '@suite-common/wallet-core';
 import { Icon, SkeletonRectangle } from '@trezor/components';
 import { spacingsPx, typography } from '@trezor/theme';
@@ -25,7 +25,7 @@ const WalletNumber = styled.div`
 `;
 
 interface AssetCoinNameProps {
-    network: Network;
+    network: NetworkCompatible;
 }
 
 export const AssetCoinName = ({ network }: AssetCoinNameProps) => {

--- a/packages/suite/src/views/dashboard/components/AssetsView/components/AssetTable.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsView/components/AssetTable.tsx
@@ -1,7 +1,7 @@
 import { AssetFiatBalance } from '@suite-common/assets';
 import { AssetRow, AssetRowSkeleton } from './AssetRow';
 import { AssetTableHeader } from './AssetTableHeader';
-import { Network } from '@suite-common/wallet-config';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 import styled from 'styled-components';
 import { spacingsPx } from '@trezor/theme';
@@ -14,7 +14,7 @@ const Table = styled.div`
 
 export interface AssetTableRowType {
     symbol: string;
-    network: Network;
+    network: NetworkCompatible;
     assetBalance: BigNumber;
     assetFailed: boolean;
 }

--- a/packages/suite/src/views/wallet/tokens/common/TokensList/TokenList.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensList/TokenList.tsx
@@ -3,7 +3,7 @@ import { Card, Icon } from '@trezor/components';
 import { Translation } from 'src/components/suite';
 import { spacingsPx, typography } from '@trezor/theme';
 import { Account } from '@suite-common/wallet-types';
-import { Network } from '@suite-common/wallet-config';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import { EnhancedTokenInfo, TokenManagementAction } from '@suite-common/token-definitions';
 import { useState } from 'react';
 import { AnimationWrapper } from 'src/components/wallet/AnimationWrapper';
@@ -64,7 +64,7 @@ interface TokenListProps {
     account: Account;
     tokensWithBalance: EnhancedTokenInfo[];
     tokensWithoutBalance: EnhancedTokenInfo[];
-    network: Network;
+    network: NetworkCompatible;
     tokenStatusType: TokenManagementAction;
     hideRates?: boolean;
     searchQuery?: string;

--- a/packages/suite/src/views/wallet/tokens/common/TokensList/TokenRow.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensList/TokenRow.tsx
@@ -2,7 +2,7 @@ import styled, { css } from 'styled-components';
 
 import { selectDevice } from '@suite-common/wallet-core';
 import { Account, AddressType, TokenAddress } from '@suite-common/wallet-types';
-import { Network } from '@suite-common/wallet-config';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import {
     DefinitionType,
     EnhancedTokenInfo,
@@ -110,7 +110,7 @@ const StyledIcon = styled(Icon)`
     margin-left: ${spacingsPx.xxs};
 `;
 
-const getTokenExplorerUrl = (network: Network, token: EnhancedTokenInfo) => {
+const getTokenExplorerUrl = (network: NetworkCompatible, token: EnhancedTokenInfo) => {
     const explorerUrl =
         network.networkType === 'cardano' ? network.explorer.token : network.explorer.account;
 
@@ -124,7 +124,7 @@ const getTokenExplorerUrl = (network: Network, token: EnhancedTokenInfo) => {
 interface TokenRowProps {
     account: Account;
     token: EnhancedTokenInfo;
-    network: Network;
+    network: NetworkCompatible;
     tokenStatusType: TokenManagementAction;
     hideRates?: boolean;
     isUnverifiedTable?: boolean;

--- a/suite-common/message-system/src/messageSystemUtils.ts
+++ b/suite-common/message-system/src/messageSystemUtils.ts
@@ -21,7 +21,7 @@ import type {
     Device,
     Environment,
 } from '@suite-common/suite-types';
-import type { Network } from '@suite-common/wallet-config';
+import type { NetworkCompatible } from '@suite-common/wallet-config';
 import type { TransportInfo } from '@trezor/connect';
 import {
     getBootloaderVersion,
@@ -56,7 +56,7 @@ export const categorizeMessages = (messages: Message[]): ValidMessagesPayload =>
 
 type CurrentSettings = {
     tor: boolean;
-    enabledNetworks: Network['symbol'][];
+    enabledNetworks: NetworkCompatible['symbol'][];
 };
 
 type Options = {

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -653,7 +653,10 @@ export const networks = {
 type InferredNetworks = typeof networks;
 type InferredNetwork = InferredNetworks[NetworkSymbol];
 
-export type Network = Without<InferredNetwork, 'accountTypes'> & {
+/**
+ * @deprecated Old network object interface for backwards copatibility.
+ */
+export type NetworkCompatible = Without<InferredNetwork, 'accountTypes'> & {
     symbol: NetworkSymbol;
     accountType?: AccountType;
     backendType?: BackendType;
@@ -673,7 +676,7 @@ export type Network = Without<InferredNetwork, 'accountTypes'> & {
 // Transforms the network object into the previously used format so we don't have to change
 // every occurence. We could gradually start to use the network object directly and in the end
 // this could be removed.
-export const networksCompatibility: Network[] = Object.entries(networks).flatMap(
+export const networksCompatibility: NetworkCompatible[] = Object.entries(networks).flatMap(
     ([symbol, { accountTypes, ...network }]) => [
         { symbol, ...network },
         ...Object.entries(accountTypes).map(([accountType, networkOverride]) => ({
@@ -719,7 +722,9 @@ export const isDebugOnlyAccountType = (
 
     if (!network) return false;
 
-    const accountTypeInfo = (network.accountTypes as Record<AccountType, Network>)[accountType];
+    const accountTypeInfo = (network.accountTypes as Record<AccountType, NetworkCompatible>)[
+        accountType
+    ];
 
     return !!accountTypeInfo?.isDebugOnlyAccountType;
 };

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -1,5 +1,101 @@
 import { DeviceModelInternal } from '@trezor/connect';
-import type { Keys, Without } from '@trezor/type-utils';
+import type { Without } from '@trezor/type-utils';
+
+export type NetworkSymbol =
+    | 'btc'
+    | 'ltc'
+    | 'eth'
+    | 'etc'
+    | 'xrp'
+    | 'bch'
+    | 'btg'
+    | 'dash'
+    | 'dgb'
+    | 'doge'
+    | 'nmc'
+    | 'vtc'
+    | 'zec'
+    | 'ada'
+    | 'sol'
+    | 'matic'
+    | 'bnb'
+    | 'test'
+    | 'regtest'
+    | 'tsep'
+    | 'thol'
+    | 'txrp'
+    | 'tada'
+    | 'dsol';
+
+export type NetworkType = 'bitcoin' | 'ethereum' | 'ripple' | 'cardano' | 'solana';
+
+type UtilityAccountType = 'normal' | 'imported'; // reserved accountTypes to stand in for a real accountType
+type RealAccountType = 'legacy' | 'segwit' | 'coinjoin' | 'taproot' | 'ledger';
+export type AccountType = UtilityAccountType | RealAccountType;
+
+export const TREZOR_CONNECT_BACKENDS = [
+    'blockbook',
+    'electrum',
+    'ripple',
+    'blockfrost',
+    'solana',
+] as const;
+export const NON_STANDARD_BACKENDS = ['coinjoin'] as const;
+
+type TrezorConnectBackendType = (typeof TREZOR_CONNECT_BACKENDS)[number];
+type NonStandardBackendType = (typeof NON_STANDARD_BACKENDS)[number];
+export type BackendType = TrezorConnectBackendType | NonStandardBackendType;
+
+export type NetworkFeature =
+    | 'rbf'
+    | 'sign-verify'
+    | 'amount-unit'
+    | 'tokens'
+    | 'staking'
+    | 'coin-definitions'
+    | 'nft-definitions';
+
+export type Explorer = {
+    tx: string;
+    account: string;
+    address: string;
+    nft?: string;
+    token?: string;
+    queryString?: string;
+};
+
+export type Account = {
+    bip43Path: string;
+    backendType?: BackendType;
+    features?: NetworkFeature[];
+    isDebugOnlyAccountType?: boolean;
+};
+
+// template types serve only to check if `networks` satisfies it. Exact type is inferred below
+export type NetworkAccountTypes = Partial<Record<AccountType, Account>>;
+
+export type NetworkDeviceSupport = Partial<Record<DeviceModelInternal, string>>;
+
+export type Network = {
+    name: string;
+    networkType: NetworkType;
+    bip43Path: string;
+    decimals: number;
+    testnet: boolean;
+    explorer: Explorer;
+    accountTypes: NetworkAccountTypes;
+    isHidden?: boolean; // not used here, but supported elsewhere
+    chainId?: number;
+    features?: NetworkFeature[];
+    customBackends?: BackendType[];
+    support?: NetworkDeviceSupport;
+    isDebugOnlyNetwork?: boolean;
+    coingeckoId?: string;
+};
+
+export type Networks = {
+    [key in NetworkSymbol]: Network;
+};
 
 export const networks = {
     btc: {
@@ -552,45 +648,12 @@ export const networks = {
         accountTypes: {},
         coingeckoId: undefined,
     },
-} as const;
+} as const satisfies Networks;
 
-export const TREZOR_CONNECT_BACKENDS = [
-    'blockbook',
-    'electrum',
-    'ripple',
-    'blockfrost',
-    'solana',
-] as const;
-export const NON_STANDARD_BACKENDS = ['coinjoin'] as const;
+type InferredNetworks = typeof networks;
+type InferredNetwork = InferredNetworks[NetworkSymbol];
 
-export type BackendType =
-    | (typeof TREZOR_CONNECT_BACKENDS)[number]
-    | (typeof NON_STANDARD_BACKENDS)[number];
-
-type Networks = typeof networks;
-export type NetworkSymbol = keyof Networks;
-export type NetworkType = Network['networkType'];
-type NetworkValue = Networks[NetworkSymbol];
-export type AccountType = Keys<NetworkValue['accountTypes']> | 'imported' | 'taproot' | 'normal';
-export type NetworkFeature =
-    | 'rbf'
-    | 'sign-verify'
-    | 'amount-unit'
-    | 'tokens'
-    | 'staking'
-    | 'coin-definitions'
-    | 'nft-definitions';
-
-export type Explorer = {
-    tx: string;
-    account: string;
-    address: string;
-    nft?: string;
-    token?: string;
-    queryString?: string;
-};
-
-export type Network = Without<NetworkValue, 'accountTypes'> & {
+export type Network = Without<InferredNetwork, 'accountTypes'> & {
     symbol: NetworkSymbol;
     accountType?: AccountType;
     backendType?: BackendType;

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -9,7 +9,7 @@ import {
     getFirmwareVersionArray,
     isBitcoinOnlyDevice,
 } from '@trezor/device-utils';
-import { Network, networks } from '@suite-common/wallet-config';
+import { NetworkCompatible, networks } from '@suite-common/wallet-config';
 import { versionUtils } from '@trezor/utils';
 import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
 import { TrezorDevice, AcquiredDevice, ButtonRequest } from '@suite-common/suite-types';
@@ -728,7 +728,9 @@ export const selectDeviceSupportedNetworks = (state: DeviceRootState) => {
     return Object.entries(networks)
         .filter(([symbol, network]) => {
             const support =
-                'support' in network ? (network.support as Network['support']) : undefined;
+                'support' in network
+                    ? (network.support as NetworkCompatible['support'])
+                    : undefined;
 
             const firmwareSupportRestriction =
                 deviceModelInternal && support?.[deviceModelInternal];
@@ -755,7 +757,7 @@ export const selectDeviceSupportedNetworks = (state: DeviceRootState) => {
 
             return true;
         })
-        .map(([symbol]) => symbol as Network['symbol']);
+        .map(([symbol]) => symbol as NetworkCompatible['symbol']);
 };
 
 export const selectDeviceById = (state: DeviceRootState, deviceId: TrezorDevice['id']) =>

--- a/suite-common/wallet-core/src/send/sendFormTypes.ts
+++ b/suite-common/wallet-core/src/send/sendFormTypes.ts
@@ -7,7 +7,7 @@ import {
     FormState,
 } from '@suite-common/wallet-types';
 import { TokenInfo, Unsuccessful } from '@trezor/connect';
-import { Network, NetworkSymbol } from '@suite-common/wallet-config';
+import { NetworkCompatible, NetworkSymbol } from '@suite-common/wallet-config';
 import { TrezorDevice } from '@suite-common/suite-types';
 
 export type SerializedTx = { tx: string; coin: NetworkSymbol };
@@ -15,7 +15,7 @@ export type SerializedTx = { tx: string; coin: NetworkSymbol };
 // TODO: is this still needed?
 export interface ComposeActionContext {
     account: Account;
-    network: Network;
+    network: NetworkCompatible;
     feeInfo: FeeInfo;
     excludedUtxos?: ExcludedUtxos;
     prison?: Record<string, unknown>;

--- a/suite-common/wallet-core/src/stake/stakeTypes.ts
+++ b/suite-common/wallet-core/src/stake/stakeTypes.ts
@@ -1,6 +1,6 @@
 import { UseFormReturn, FormState as ReactHookFormState } from 'react-hook-form';
 
-import { Network, NetworkSymbol, getNetworkFeatures } from '@suite-common/wallet-config';
+import { NetworkCompatible, NetworkSymbol, getNetworkFeatures } from '@suite-common/wallet-config';
 import {
     Account,
     Rate,
@@ -79,7 +79,7 @@ export interface AmountLimitsString {
 
 export interface BaseStakeContextValues {
     account: Account;
-    network: Network;
+    network: NetworkCompatible;
     localCurrency: FiatCurrencyCode;
     composedLevels?: PrecomposedLevels;
     isComposing: boolean;

--- a/suite-common/wallet-types/src/account.ts
+++ b/suite-common/wallet-types/src/account.ts
@@ -1,4 +1,4 @@
-import { Network, BackendType, NetworkSymbol } from '@suite-common/wallet-config';
+import { NetworkCompatible, BackendType, NetworkSymbol } from '@suite-common/wallet-config';
 import { AccountEntityKeys } from '@suite-common/metadata-types';
 import { AccountInfo, PROTO, TokenInfo } from '@trezor/connect';
 import {
@@ -87,7 +87,7 @@ export type Account = {
     unlockPath?: PROTO.UnlockPath; // parameter used to unlock SLIP-25/coinjoin keychain
     descriptor: string;
     descriptorChecksum?: string;
-    accountType: NonNullable<Network['accountType']>;
+    accountType: NonNullable<NetworkCompatible['accountType']>;
     symbol: NetworkSymbol;
     empty: boolean;
     visible: boolean;

--- a/suite-common/wallet-types/src/discovery.ts
+++ b/suite-common/wallet-types/src/discovery.ts
@@ -1,6 +1,6 @@
 import { ObjectValues } from '@trezor/type-utils';
 import { DiscoveryStatus } from '@suite-common/wallet-constants';
-import { Network } from '@suite-common/wallet-config';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import { Deferred } from '@trezor/utils';
 
 import { Account, AccountBackendSpecific } from './account';
@@ -15,13 +15,13 @@ export interface Discovery {
     status: ObjectValues<typeof DiscoveryStatus>;
     // coins which failed to load
     failed: {
-        symbol: Network['symbol'];
+        symbol: NetworkCompatible['symbol'];
         index: number;
-        accountType: NonNullable<Network['accountType']>;
+        accountType: NonNullable<NetworkCompatible['accountType']>;
         error: string;
         fwException?: string;
     }[];
-    networks: Network['symbol'][];
+    networks: NetworkCompatible['symbol'][];
     running?: Deferred<void>;
     error?: string;
     errorCode?: string | number;

--- a/suite-common/wallet-types/src/selectedAccount.ts
+++ b/suite-common/wallet-types/src/selectedAccount.ts
@@ -1,4 +1,4 @@
-import { Network } from '@suite-common/wallet-config';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 
 import { Discovery } from './discovery';
 import { Account, WalletParams } from './account';
@@ -12,7 +12,7 @@ export interface SelectedAccountLoading {
         | 'auth' // Waiting for device.state
         | 'account-loading'; // Waiting for account
     account?: Account;
-    network?: Network;
+    network?: NetworkCompatible;
     discovery?: Discovery;
     params?: WalletParams;
 }
@@ -21,7 +21,7 @@ export interface SelectedAccountLoaded {
     status: 'loaded';
     loader?: undefined;
     account: Account;
-    network: Network;
+    network: NetworkCompatible;
     discovery: Discovery;
     params: WalletParams;
     // blockchain?: any; // TODO:
@@ -35,7 +35,7 @@ export type SelectedAccountException =
           status: 'exception';
           loader: 'auth-failed' | 'discovery-error' | 'discovery-empty'; // No network enabled in settings
           account?: undefined;
-          network?: Network;
+          network?: NetworkCompatible;
           discovery?: Discovery;
           params?: WalletParams;
       }
@@ -46,7 +46,7 @@ export type SelectedAccountException =
               | 'account-not-enabled' // Requested account network is not enabled in settings
               | 'account-not-exists'; // Requested account network is not listed in networksCompatibility
           account?: undefined;
-          network: Network;
+          network: NetworkCompatible;
           discovery: Discovery;
           params: WalletParams;
       };

--- a/suite-common/wallet-types/src/settings.ts
+++ b/suite-common/wallet-types/src/settings.ts
@@ -1,4 +1,4 @@
-import { Network } from '@suite-common/wallet-config';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import { FeeLevel, PROTO } from '@trezor/connect';
 import { FiatCurrencyCode } from '@suite-common/suite-config';
 
@@ -20,7 +20,7 @@ export type WalletType = (typeof WalletType)[keyof typeof WalletType];
 export interface WalletSettings {
     localCurrency: FiatCurrencyCode;
     discreetMode: boolean;
-    enabledNetworks: Network['symbol'][];
+    enabledNetworks: NetworkCompatible['symbol'][];
     bitcoinAmountUnit: PROTO.AmountUnit;
     lastUsedFeeLevel: {
         [key: string]: Omit<FeeLevel, 'blocks'>; // Key: Network['symbol']

--- a/suite-common/wallet-types/src/transaction.ts
+++ b/suite-common/wallet-types/src/transaction.ts
@@ -12,7 +12,7 @@ import {
     PrecomposedTransactionNonFinalCardano as PrecomposedTransactionCardanoConnectResponseNonFinal,
     PrecomposedTransactionFinalCardano as PrecomposedTransactionCardanoConnectResponseFinal,
 } from '@trezor/connect';
-import { Network, NetworkSymbol } from '@suite-common/wallet-config';
+import { NetworkCompatible, NetworkSymbol } from '@suite-common/wallet-config';
 import { TranslationKey } from '@suite-common/intl-types';
 
 import { Account } from './account';
@@ -191,7 +191,7 @@ export interface SignTransactionData {
     account: Account;
     address: string;
     amount: string;
-    network: Network;
+    network: NetworkCompatible;
     destinationTag?: string;
     transactionInfo: PrecomposedTransactionFinal | null;
 }
@@ -202,7 +202,7 @@ export interface ComposeTransactionData {
     feeInfo: FeeInfo;
     feePerUnit: string;
     feeLimit: string;
-    network: Network;
+    network: NetworkCompatible;
     selectedFee: FeeLevel['label'];
     isMaxActive: boolean;
     address?: string;

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -12,7 +12,7 @@ import {
 import { arrayDistinct, bufferUtils } from '@trezor/utils';
 import {
     networksCompatibility,
-    Network,
+    NetworkCompatible,
     NetworkFeature,
     NetworkSymbol,
     NetworkType,
@@ -418,7 +418,7 @@ export const getAllAccounts = (deviceState: string | typeof undefined, accounts:
     return accounts.filter(a => a.deviceState === deviceState && a.visible);
 };
 
-export const getNetwork = (symbol: string): Network | null =>
+export const getNetwork = (symbol: string): NetworkCompatible | null =>
     networksCompatibility.find(c => c.symbol === symbol) || null;
 
 export const getAccountNetwork = ({
@@ -725,7 +725,7 @@ export const isAccountOutdated = (account: Account, freshInfo: AccountInfo) => {
 // Used in accountActions and failed accounts
 export const getAccountSpecific = (
     accountInfo: Partial<AccountInfo>,
-    networkType: Network['networkType'],
+    networkType: NetworkCompatible['networkType'],
 ) => {
     const { misc } = accountInfo;
     if (networkType === 'ripple') {

--- a/suite-common/wallet-utils/src/cardanoUtils.ts
+++ b/suite-common/wallet-utils/src/cardanoUtils.ts
@@ -8,7 +8,7 @@ import {
     StakePool,
 } from '@suite-common/wallet-types';
 import { CARDANO, CardanoCertificate, CardanoOutput, PROTO } from '@trezor/connect';
-import { Network } from '@suite-common/wallet-config';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 
 import {
     amountToSatoshi,
@@ -17,7 +17,7 @@ import {
     networkAmountToSatoshi,
 } from './accountUtils';
 
-export const getDerivationType = (accountType: Network['accountType']) => {
+export const getDerivationType = (accountType: NetworkCompatible['accountType']) => {
     switch (accountType) {
         case 'normal':
             return 1;

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -11,7 +11,7 @@ import { fromWei, numberToHex, padLeft, toWei } from 'web3-utils';
 
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { fiatCurrencies } from '@suite-common/suite-config';
-import { Network, NetworkType } from '@suite-common/wallet-config';
+import { NetworkCompatible, NetworkType } from '@suite-common/wallet-config';
 import { EthereumTransaction, TokenInfo, ComposeOutput, PROTO } from '@trezor/connect';
 import {
     COMPOSE_ERROR_TYPES,
@@ -153,7 +153,7 @@ export const prepareEthereumTransaction = (txInfo: EthTransactionData) => {
     return result;
 };
 
-export const getFeeLevels = (networkType: Network['networkType'], feeInfo: FeeInfo) => {
+export const getFeeLevels = (networkType: NetworkCompatible['networkType'], feeInfo: FeeInfo) => {
     const levels = feeInfo.levels.concat({
         label: 'custom',
         feePerUnit: '0',
@@ -323,7 +323,7 @@ export const getBitcoinComposeOutputs = (
 export const getExternalComposeOutput = (
     values: Partial<FormState>,
     account: Account,
-    network: Network,
+    network: NetworkCompatible,
 ) => {
     if (!values || !Array.isArray(values.outputs) || !values.outputs[0]) return;
     const out = values.outputs[0];

--- a/suite-native/config/src/supportedNetworks.ts
+++ b/suite-native/config/src/supportedNetworks.ts
@@ -1,7 +1,12 @@
 import { A } from '@mobily/ts-belt';
 
 import { isTestnet } from '@suite-common/wallet-utils';
-import { Network, NetworkSymbol, getMainnets, getTestnets } from '@suite-common/wallet-config';
+import {
+    NetworkCompatible,
+    NetworkSymbol,
+    getMainnets,
+    getTestnets,
+} from '@suite-common/wallet-config';
 import { AccountType } from '@suite-common/wallet-types';
 
 export const orderedAccountTypes: AccountType[] = [
@@ -43,7 +48,7 @@ export const discoverySupportedNetworks = [
     ...networkSymbolsWhitelistMap.testnet,
 ];
 
-export const sortNetworks = (networks: Network[]) =>
+export const sortNetworks = (networks: NetworkCompatible[]) =>
     A.sort(networks, (a, b) => {
         const aOrder = discoverySupportedNetworks.indexOf(a.symbol) ?? Number.MAX_SAFE_INTEGER;
         const bOrder = discoverySupportedNetworks.indexOf(b.symbol) ?? Number.MAX_SAFE_INTEGER;
@@ -60,7 +65,7 @@ export const filterTestnetNetworks = (
     return networkSymbols.filter(networkSymbol => !isTestnet(networkSymbol));
 };
 
-export const filterBlacklistedNetworks = (networks: Network[]) =>
+export const filterBlacklistedNetworks = (networks: NetworkCompatible[]) =>
     networks.filter(network => !discoveryBlacklist.includes(network.symbol));
 
 export const portfolioTrackerMainnets = sortNetworks(

--- a/suite-native/discovery/src/discoveryThunks.ts
+++ b/suite-native/discovery/src/discoveryThunks.ts
@@ -21,7 +21,12 @@ import { selectIsAccountAlreadyDiscovered } from '@suite-native/accounts';
 import TrezorConnect from '@trezor/connect';
 import { Account, DiscoveryItem } from '@suite-common/wallet-types';
 import { getDerivationType, tryGetAccountIdentity } from '@suite-common/wallet-utils';
-import { AccountType, Network, NetworkSymbol, getNetworkType } from '@suite-common/wallet-config';
+import {
+    AccountType,
+    NetworkCompatible,
+    NetworkSymbol,
+    getNetworkType,
+} from '@suite-common/wallet-config';
 import { DiscoveryStatus } from '@suite-common/wallet-constants';
 import { requestDeviceAccess } from '@suite-native/device-mutex';
 import { analytics, EventType } from '@suite-native/analytics';
@@ -331,7 +336,7 @@ const discoverAccountsByDescriptorThunk = createThunk(
 export const addAndDiscoverNetworkAccountThunk = createThunk<
     Account,
     {
-        network: Network;
+        network: NetworkCompatible;
         deviceState: string;
     },
     { rejectValue: string }
@@ -416,7 +421,7 @@ const discoverNetworkBatchThunk = createThunk(
         }: {
             deviceState: string;
             round?: number;
-            network: Network;
+            network: NetworkCompatible;
         },
         { dispatch, getState },
     ) => {
@@ -529,7 +534,7 @@ export const createDescriptorPreloadedDiscoveryThunk = createThunk(
             availableCardanoDerivations,
         }: {
             deviceState: string;
-            networks: readonly Network[];
+            networks: readonly NetworkCompatible[];
             availableCardanoDerivations: ('normal' | 'legacy' | 'ledger')[] | undefined;
         },
         { dispatch, getState },

--- a/suite-native/discovery/src/utils.ts
+++ b/suite-native/discovery/src/utils.ts
@@ -1,6 +1,6 @@
 import { A, F } from '@mobily/ts-belt';
 
-import { Network, AccountType, NetworkSymbol } from '@suite-common/wallet-config';
+import { NetworkCompatible, AccountType, NetworkSymbol } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
 
 const NORMAL_ACCOUNT_TYPE = 'normal';
@@ -9,7 +9,7 @@ const NORMAL_ACCOUNT_TYPE = 'normal';
 const normalizedAccountType = (accountType?: AccountType) => accountType ?? NORMAL_ACCOUNT_TYPE;
 
 export const getNetworksWithUnfinishedDiscovery = (
-    enabledNetworks: readonly Network[],
+    enabledNetworks: readonly NetworkCompatible[],
     accounts: Account[],
     accountsLimit: number,
 ) =>
@@ -29,7 +29,7 @@ export const getNetworksWithUnfinishedDiscovery = (
         );
     });
 
-export const getNetworkSymbols = (networks: readonly Network[]): NetworkSymbol[] =>
+export const getNetworkSymbols = (networks: readonly NetworkCompatible[]): NetworkSymbol[] =>
     F.toMutable(
         A.uniqBy(
             networks.map(n => n.symbol),


### PR DESCRIPTION
1st of many PRs to refactor & cleanup `networksConfig`.

- Implement a generic type check for declaration of `networks`
- Rename old Network type to NetworkCompatibility
  - lots of changes across the rpo, but only TS, so no need to QA

## Description

Currently `networks` have type inferred from its value, and readonly. IMHO we want to keep that.

But currently it lacks any typechecking when declaring it, so any mistake will just silently carry on to the inferred type:

```
export const networks = {
    btc: {
        name: 'Bitcoin',
        BAD_PROPERTY: "lol",
        networkType: 'bitcoin',
```

This PR adds a kind of generic template type which is not exported, we will still rely on exact type inferrence from value for convenient DX, but serves to type check the declaration.

## Related Issue

Part of #13839