### PR TITLE
fix(suite-native): display fiat value skeleton while fiat rates are loading

### DIFF
--- a/suite-common/assets/src/utils.ts
+++ b/suite-common/assets/src/utils.ts
@@ -1,5 +1,5 @@
 export interface AssetFiatBalance {
-    fiatBalance: string;
+    fiatBalance: string | null;
     symbol: string;
 }
 export interface AssetFiatBalanceWithPercentage extends AssetFiatBalance {

--- a/suite-native/assets/src/components/AssetItem.tsx
+++ b/suite-native/assets/src/components/AssetItem.tsx
@@ -30,7 +30,7 @@ type AssetItemProps = {
     cryptoCurrencyValue: string;
     iconName: CryptoIconName;
     onPress?: (symbol: NetworkSymbol) => void;
-    fiatBalance: string;
+    fiatBalance: string | null;
     fiatPercentage: number;
     fiatPercentageOffset: number;
 };

--- a/suite-native/formatters/src/components/FiatAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/FiatAmountFormatter.tsx
@@ -1,4 +1,4 @@
-import { TextProps } from '@suite-native/atoms';
+import { BoxSkeleton, TextProps } from '@suite-native/atoms';
 import { useFormatters } from '@suite-common/formatters';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { isTestnet } from '@suite-common/wallet-utils';
@@ -21,9 +21,12 @@ export const FiatAmountFormatter = ({
 }: FiatAmountFormatterProps) => {
     const { FiatAmountFormatter: formatter } = useFormatters();
 
-    const isTestnetValue = !!network && isTestnet(network);
-
-    if (!value || isTestnetValue) return <EmptyAmountText />;
+    if (!!network && isTestnet(network)) {
+        return <EmptyAmountText />;
+    }
+    if (value === null) {
+        return <BoxSkeleton width={48} height={24} />;
+    }
 
     const formattedValue = formatter.format(value);
 

--- a/suite-native/graph/src/components/GraphFiatBalance.tsx
+++ b/suite-native/graph/src/components/GraphFiatBalance.tsx
@@ -1,0 +1,58 @@
+import { Atom, useAtomValue } from 'jotai';
+
+import { FiatGraphPoint } from '@suite-common/graph';
+import { BoxSkeleton, DiscreetTextTrigger, HStack } from '@suite-native/atoms';
+import { FiatBalanceFormatter } from '@suite-native/formatters';
+
+import { GraphDateFormatter } from './GraphDateFormatter';
+import { PriceChangeIndicator } from './PriceChangeIndicator';
+
+type BalanceProps = {
+    selectedPointAtom: Atom<FiatGraphPoint>;
+};
+
+type GraphFiatBalanceProps = BalanceProps & {
+    referencePointAtom: Atom<FiatGraphPoint | null>;
+    percentageChangeAtom: Atom<number>;
+    hasPriceIncreasedAtom: Atom<boolean>;
+};
+
+const Balance = ({ selectedPointAtom }: BalanceProps) => {
+    const point = useAtomValue(selectedPointAtom);
+    const fiatValue = String(point.value);
+
+    return (
+        <DiscreetTextTrigger>
+            <FiatBalanceFormatter value={fiatValue} />
+        </DiscreetTextTrigger>
+    );
+};
+
+export const GraphFiatBalance = ({
+    selectedPointAtom,
+    referencePointAtom,
+    percentageChangeAtom,
+    hasPriceIncreasedAtom,
+}: GraphFiatBalanceProps) => {
+    const firstGraphPoint = useAtomValue(referencePointAtom);
+
+    if (!firstGraphPoint) {
+        return <BoxSkeleton width={120} height={73} />;
+    }
+
+    return (
+        <>
+            <Balance selectedPointAtom={selectedPointAtom} />
+            <HStack alignItems="center" style={{ height: 24 }}>
+                <GraphDateFormatter
+                    firstPointDate={firstGraphPoint.date}
+                    selectedPointAtom={selectedPointAtom}
+                />
+                <PriceChangeIndicator
+                    hasPriceIncreasedAtom={hasPriceIncreasedAtom}
+                    percentageChangeAtom={percentageChangeAtom}
+                />
+            </HStack>
+        </>
+    );
+};

--- a/suite-native/graph/src/index.ts
+++ b/suite-native/graph/src/index.ts
@@ -3,5 +3,4 @@ export * from './components/TimeSwitch';
 export * from './utils';
 export * from './hooks';
 export * from './slice';
-export * from './components/GraphDateFormatter';
-export * from './components/PriceChangeIndicator';
+export * from './components/GraphFiatBalance';

--- a/suite-native/module-accounts-management/src/accountDetailGraphAtoms.ts
+++ b/suite-native/module-accounts-management/src/accountDetailGraphAtoms.ts
@@ -1,0 +1,29 @@
+import { atom } from 'jotai';
+
+import { FiatGraphPointWithCryptoBalance } from '@suite-common/graph/libDev/src';
+import { percentageDiff } from '@suite-native/graph';
+
+export const emptyGraphPoint: FiatGraphPointWithCryptoBalance = {
+    value: 0,
+    date: new Date(0),
+    cryptoBalance: '0',
+};
+
+export const selectedPointAtom = atom<FiatGraphPointWithCryptoBalance>(emptyGraphPoint);
+
+// reference is usually first point, same as Revolut does in their app
+export const referencePointAtom = atom<FiatGraphPointWithCryptoBalance | null>(null);
+
+export const percentageChangeAtom = atom(get => {
+    const selectedPoint = get(selectedPointAtom);
+    const referencePoint = get(referencePointAtom);
+    if (!referencePoint) return 0;
+
+    return percentageDiff(referencePoint.value, selectedPoint.value);
+});
+
+export const hasPriceIncreasedAtom = atom(get => {
+    const percentageChange = get(percentageChangeAtom);
+
+    return percentageChange >= 0;
+});

--- a/suite-native/module-accounts-management/src/components/AccountDetailGraph.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountDetailGraph.tsx
@@ -10,11 +10,8 @@ import { selectFiatCurrencyCode } from '@suite-native/settings';
 import { FiatGraphPointWithCryptoBalance } from '@suite-common/graph';
 import { TokenAddress } from '@suite-common/wallet-types';
 
-import {
-    AccountDetailGraphHeader,
-    referencePointAtom,
-    selectedPointAtom,
-} from './AccountDetailGraphHeader';
+import { AccountDetailGraphHeader } from './AccountDetailGraphHeader';
+import { referencePointAtom, selectedPointAtom } from '../accountDetailGraphAtoms';
 
 type AccountDetailGraphProps = {
     accountKey: string;

--- a/suite-native/module-accounts-management/src/components/AccountDetailGraphHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountDetailGraphHeader.tsx
@@ -1,47 +1,28 @@
+import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 
-import { atom, useAtomValue } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 
-import { FiatGraphPointWithCryptoBalance } from '@suite-common/graph';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { AccountKey, TokenAddress, TokenSymbol } from '@suite-common/wallet-types';
-import { DiscreetTextTrigger, HStack, Text, VStack } from '@suite-native/atoms';
+import { DiscreetTextTrigger, VStack } from '@suite-native/atoms';
 import { selectEthereumAccountTokenSymbol } from '@suite-native/tokens';
-import { FiatBalanceFormatter } from '@suite-native/formatters';
-import { GraphDateFormatter, PriceChangeIndicator, percentageDiff } from '@suite-native/graph';
+import { GraphFiatBalance } from '@suite-native/graph';
 
 import { AccountDetailCryptoValue } from './AccountDetailCryptoValue';
+import {
+    emptyGraphPoint,
+    hasPriceIncreasedAtom,
+    percentageChangeAtom,
+    referencePointAtom,
+    selectedPointAtom,
+} from '../accountDetailGraphAtoms';
 
 type AccountBalanceProps = {
     accountKey: AccountKey;
     tokenAddress?: TokenAddress;
 };
-
-const emptyGraphPoint: FiatGraphPointWithCryptoBalance = {
-    value: 0,
-    date: new Date(0),
-    cryptoBalance: '0',
-};
-
-export const selectedPointAtom = atom<FiatGraphPointWithCryptoBalance>(emptyGraphPoint);
-
-// reference is usually first point, same as Revolut does in their app
-export const referencePointAtom = atom<FiatGraphPointWithCryptoBalance | null>(null);
-
-const percentageChangeAtom = atom(get => {
-    const selectedPoint = get(selectedPointAtom);
-    const referencePoint = get(referencePointAtom);
-    if (!referencePoint) return 0;
-
-    return percentageDiff(referencePoint.value, selectedPoint.value);
-});
-
-const hasPriceIncreasedAtom = atom(get => {
-    const percentageChange = get(percentageChangeAtom);
-
-    return percentageChange >= 0;
-});
 
 const CryptoBalance = ({
     accountSymbol,
@@ -66,26 +47,17 @@ const CryptoBalance = ({
     );
 };
 
-const FiatBalance = () => {
-    const selectedPoint = useAtomValue(selectedPointAtom);
-
-    return (
-        <DiscreetTextTrigger>
-            <FiatBalanceFormatter value={String(selectedPoint.value)} />
-        </DiscreetTextTrigger>
-    );
-};
-
 export const AccountDetailGraphHeader = ({ accountKey, tokenAddress }: AccountBalanceProps) => {
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
-
     const tokenSymbol = useSelector((state: AccountsRootState) =>
         selectEthereumAccountTokenSymbol(state, accountKey, tokenAddress),
     );
+    const setPoint = useSetAtom(selectedPointAtom);
 
-    const firstGraphPoint = useAtomValue(referencePointAtom);
+    // Reset selected point on unmount so that it doesn't display on device change
+    useEffect(() => () => setPoint(emptyGraphPoint), [setPoint]);
 
     if (!account) return null;
 
@@ -96,23 +68,12 @@ export const AccountDetailGraphHeader = ({ accountKey, tokenAddress }: AccountBa
                 tokenSymbol={tokenSymbol}
                 tokenAddress={tokenAddress}
             />
-            <FiatBalance />
-            <HStack alignItems="center">
-                {firstGraphPoint ? (
-                    <>
-                        <GraphDateFormatter
-                            firstPointDate={firstGraphPoint.date}
-                            selectedPointAtom={selectedPointAtom}
-                        />
-                        <PriceChangeIndicator
-                            hasPriceIncreasedAtom={hasPriceIncreasedAtom}
-                            percentageChangeAtom={percentageChangeAtom}
-                        />
-                    </>
-                ) : (
-                    <Text>{' ' /* just placeholder to avoid layout shift */}</Text>
-                )}
-            </HStack>
+            <GraphFiatBalance
+                selectedPointAtom={selectedPointAtom}
+                referencePointAtom={referencePointAtom}
+                percentageChangeAtom={percentageChangeAtom}
+                hasPriceIncreasedAtom={hasPriceIncreasedAtom}
+            />
         </VStack>
     );
 };

--- a/suite-native/module-home/package.json
+++ b/suite-native/module-home/package.json
@@ -28,7 +28,6 @@
         "@suite-native/device-manager": "workspace:*",
         "@suite-native/discovery": "workspace:*",
         "@suite-native/feature-flags": "workspace:*",
-        "@suite-native/formatters": "workspace:*",
         "@suite-native/graph": "workspace:*",
         "@suite-native/intl": "workspace:*",
         "@suite-native/navigation": "workspace:*",

--- a/suite-native/module-home/src/screens/HomeScreen/components/PortfolioGraph.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/PortfolioGraph.tsx
@@ -8,11 +8,8 @@ import { selectFiatCurrencyCode } from '@suite-native/settings';
 import { VStack } from '@suite-native/atoms';
 import { useIsDiscoveryDurationTooLong } from '@suite-native/discovery';
 
-import {
-    PortfolioGraphHeader,
-    referencePointAtom,
-    selectedPointAtom,
-} from './PortfolioGraphHeader';
+import { PortfolioGraphHeader } from './PortfolioGraphHeader';
+import { referencePointAtom, selectedPointAtom } from '../portfolioGraphAtoms';
 
 export type PortfolioGraphRef = {
     refetchGraph: () => Promise<void>;

--- a/suite-native/module-home/src/screens/HomeScreen/portfolioGraphAtoms.ts
+++ b/suite-native/module-home/src/screens/HomeScreen/portfolioGraphAtoms.ts
@@ -1,0 +1,32 @@
+import { atom } from 'jotai';
+
+import { FiatGraphPoint, FiatGraphPointWithCryptoBalance } from '@suite-common/graph';
+import { percentageDiff } from '@suite-native/graph';
+
+const emptyGraphPoint: FiatGraphPointWithCryptoBalance = {
+    value: 0,
+    date: new Date(0),
+    cryptoBalance: '0',
+};
+
+// use atomic jotai structure for absolute minimum re-renders and maximum performance
+// otherwise graph will be freezing on slower device while point swipe gesture
+export const selectedPointAtom = atom<FiatGraphPoint>(emptyGraphPoint);
+
+// reference is usually first point, same as Revolut does in their app
+export const referencePointAtom = atom<FiatGraphPoint | null>(null);
+
+export const percentageChangeAtom = atom(get => {
+    const selectedPoint = get(selectedPointAtom);
+    const referencePoint = get(referencePointAtom);
+
+    if (!referencePoint) return 0;
+
+    return percentageDiff(referencePoint.value, selectedPoint.value);
+});
+
+export const hasPriceIncreasedAtom = atom(get => {
+    const percentageChange = get(percentageChangeAtom);
+
+    return percentageChange >= 0;
+});

--- a/suite-native/module-home/tsconfig.json
+++ b/suite-native/module-home/tsconfig.json
@@ -16,7 +16,6 @@
         { "path": "../device-manager" },
         { "path": "../discovery" },
         { "path": "../feature-flags" },
-        { "path": "../formatters" },
         { "path": "../graph" },
         { "path": "../intl" },
         { "path": "../navigation" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10182,7 +10182,6 @@ __metadata:
     "@suite-native/device-manager": "workspace:*"
     "@suite-native/discovery": "workspace:*"
     "@suite-native/feature-flags": "workspace:*"
-    "@suite-native/formatters": "workspace:*"
     "@suite-native/graph": "workspace:*"
     "@suite-native/intl": "workspace:*"
     "@suite-native/navigation": "workspace:*"


### PR DESCRIPTION
Make sure we handle fiat values as `null` until fiat rates are loaded.

## Related Issue

Resolve #13299

## Screenshots:

https://github.com/user-attachments/assets/c3f89c0f-47ff-4a42-9b79-1d34884bae0f

