### PR TITLE
fix(transport): UdpApi trigger transport-interface-change event

### DIFF
--- a/packages/transport-test/e2e/bridge/controller.ts
+++ b/packages/transport-test/e2e/bridge/controller.ts
@@ -115,8 +115,8 @@ class Controller extends TrezorUserEnvLinkClass {
 
         return scheduleAction(
             async () => {
-                const devices = await webusb.getDevices();
-                if (devices.filter(d => d.productName === 'TREZOR').length === expected) {
+                const devices = (await webusb.getDevices()).filter(d => d.productName === 'TREZOR');
+                if (devices.length === expected) {
                     return null;
                 }
                 throw new Error('Condition not met');

--- a/packages/transport-test/e2e/bridge/multi-client.test.ts
+++ b/packages/transport-test/e2e/bridge/multi-client.test.ts
@@ -295,4 +295,27 @@ describe('bridge', () => {
             },
         ]);
     });
+
+    test(`connect/disconnect device - get transport-update events`, async () => {
+        const eventSpy = jest.fn();
+        bridge1.on('transport-update', eventSpy);
+        await TrezorUserEnvLink.stopEmu();
+
+        expect(eventSpy).toHaveBeenCalledTimes(0);
+
+        bridge1.listen();
+
+        const waitForUpdateEvent = () =>
+            new Promise(resolve => {
+                bridge1.once('transport-update', resolve);
+            });
+
+        TrezorUserEnvLink.startEmu(emulatorStartOpts);
+        await waitForUpdateEvent();
+        expect(eventSpy).toHaveBeenCalledTimes(1);
+
+        TrezorUserEnvLink.stopEmu();
+        await waitForUpdateEvent();
+        expect(eventSpy).toHaveBeenCalledTimes(2);
+    });
 });


### PR DESCRIPTION
fix missing device disconnect or late device connect events

<!--- Provide a general summary of your changes in the Title above -->

## Description
Turns out `UdpApi` never emits `transport-interface-change` therefore `device-disconnect` or late `device-connect` was never reported 