### PR TITLE
feat(suite-native): use enabled networks for msg system settings validation

### DIFF
--- a/suite-native/message-system/package.json
+++ b/suite-native/message-system/package.json
@@ -20,6 +20,7 @@
         "@suite-common/wallet-core": "workspace:*",
         "@suite-native/atoms": "workspace:*",
         "@suite-native/connection-status": "workspace:*",
+        "@suite-native/discovery": "workspace:*",
         "@suite-native/intl": "workspace:*",
         "@suite-native/link": "workspace:*",
         "@trezor/styles": "workspace:*",

--- a/suite-native/message-system/src/messageSystemMiddleware.ts
+++ b/suite-native/message-system/src/messageSystemMiddleware.ts
@@ -7,12 +7,17 @@ import {
     getValidMessages,
     selectMessageSystemConfig,
 } from '@suite-common/message-system';
-import { deviceActions, selectAccountsSymbols, selectDevice } from '@suite-common/wallet-core';
+import { deviceActions, selectDevice } from '@suite-common/wallet-core';
+import {
+    selectEnabledDiscoveryNetworkSymbols,
+    toggleEnabledDiscoveryNetworkSymbol,
+} from '@suite-native/discovery';
 
 const isAnyOfMessageSystemAffectingActions = isAnyOf(
     messageSystemActions.fetchSuccessUpdate,
     deviceActions.selectDevice,
     deviceActions.connectDevice,
+    toggleEnabledDiscoveryNetworkSymbol,
 );
 
 export const messageSystemMiddleware = createMiddleware((action, { next, dispatch, getState }) => {
@@ -23,7 +28,7 @@ export const messageSystemMiddleware = createMiddleware((action, { next, dispatc
     if (isAnyOfMessageSystemAffectingActions(action)) {
         const config = selectMessageSystemConfig(getState());
         const device = selectDevice(getState());
-        const enabledNetworks = selectAccountsSymbols(getState());
+        const enabledNetworks = selectEnabledDiscoveryNetworkSymbols(getState());
 
         const validMessages = getValidMessages(config, {
             device,

--- a/suite-native/message-system/tsconfig.json
+++ b/suite-native/message-system/tsconfig.json
@@ -17,6 +17,7 @@
         },
         { "path": "../atoms" },
         { "path": "../connection-status" },
+        { "path": "../discovery" },
         { "path": "../intl" },
         { "path": "../link" },
         { "path": "../../packages/styles" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9978,6 +9978,7 @@ __metadata:
     "@suite-common/wallet-core": "workspace:*"
     "@suite-native/atoms": "workspace:*"
     "@suite-native/connection-status": "workspace:*"
+    "@suite-native/discovery": "workspace:*"
     "@suite-native/intl": "workspace:*"
     "@suite-native/link": "workspace:*"
     "@trezor/styles": "workspace:*"


### PR DESCRIPTION
Only show coin related messages to users with enabled coin.

I tested this locally.

## Related Issue

Resolve #13470

