### PR TITLE
chore(suite): Remove reexport of network types

### DIFF
--- a/packages/suite/src/actions/settings/walletSettingsActions.ts
+++ b/packages/suite/src/actions/settings/walletSettingsActions.ts
@@ -1,6 +1,6 @@
 import * as suiteActions from 'src/actions/suite/suiteActions';
 import { Dispatch, GetState } from 'src/types/suite';
-import type { Network } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import { createAction } from '@reduxjs/toolkit';
 
 import { UNIT_ABBREVIATIONS } from '@suite-common/suite-constants';
@@ -21,7 +21,7 @@ export const setLocalCurrency = createAction(
 
 export const changeNetworks = createAction(
     WALLET_SETTINGS.CHANGE_NETWORKS,
-    (payload: Network['symbol'][]) => ({
+    (payload: NetworkCompatible['symbol'][]) => ({
         payload,
     }),
 );
@@ -32,7 +32,7 @@ export type WalletSettingsAction =
     | { type: typeof WALLET_SETTINGS.SET_HIDE_BALANCE; toggled: boolean }
     | {
           type: typeof WALLET_SETTINGS.SET_LAST_USED_FEE_LEVEL;
-          symbol: Network['symbol'];
+          symbol: NetworkCompatible['symbol'];
           feeLevel?: FeeLevel;
       }
     | {
@@ -58,7 +58,7 @@ export const setDiscreetMode = (toggled: boolean) => (dispatch: Dispatch, getSta
 };
 
 export const changeCoinVisibility =
-    (symbol: Network['symbol'], shouldBeVisible: boolean) =>
+    (symbol: NetworkCompatible['symbol'], shouldBeVisible: boolean) =>
     (dispatch: Dispatch, getState: GetState) => {
         let { enabledNetworks } = getState().wallet.settings;
         const isAlreadyHidden = enabledNetworks.find(coin => coin === symbol);

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -15,7 +15,8 @@ import {
     serializeCoinjoinAccount,
 } from 'src/utils/suite/storage';
 import type { AppState, Dispatch, GetState, TrezorDevice } from 'src/types/suite';
-import type { Account, Network } from 'src/types/wallet';
+import type { Account } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import type { FormState, RatesByTimestamps } from '@suite-common/wallet-types';
 import type { Trade } from 'src/types/wallet/coinmarketCommonTypes';
 import type { PreloadStoreAction } from 'src/support/suite/preloadStore';
@@ -309,7 +310,7 @@ export const saveWalletSettings = () => async (_dispatch: Dispatch, getState: Ge
 };
 
 export const saveBackend =
-    (coin: Network['symbol']) => async (_dispatch: Dispatch, getState: GetState) => {
+    (coin: NetworkCompatible['symbol']) => async (_dispatch: Dispatch, getState: GetState) => {
         if (!(await db.isAccessible())) return;
         await db.addItem(
             'backendSettings',

--- a/packages/suite/src/components/suite/AmountUnitSwitchWrapper.tsx
+++ b/packages/suite/src/components/suite/AmountUnitSwitchWrapper.tsx
@@ -2,7 +2,7 @@ import { MouseEvent, ReactNode } from 'react';
 import styled from 'styled-components';
 import { TOOLTIP_DELAY_NONE, TOOLTIP_DELAY_NORMAL, Tooltip } from '@trezor/components';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
-import { NetworkSymbol } from 'src/types/wallet';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import { Translation } from './Translation';
 import { mediaQueries } from '@trezor/styles';
 

--- a/packages/suite/src/components/suite/CoinGroup/CoinGroup.tsx
+++ b/packages/suite/src/components/suite/CoinGroup/CoinGroup.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { useDispatch } from 'src/hooks/suite';
 import { openModal } from 'src/actions/suite/modalActions';
 import { CoinList } from 'src/components/suite';
-import type { Network } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 
 import { CoinGroupHeader } from './CoinGroupHeader';
 
@@ -13,10 +13,10 @@ const CoinGroupWrapper = styled.div`
 `;
 
 interface CoinGroupProps {
-    networks: Network[];
-    enabledNetworks?: Network['symbol'][];
+    networks: NetworkCompatible[];
+    enabledNetworks?: NetworkCompatible['symbol'][];
     className?: string;
-    onToggle: (symbol: Network['symbol'], toggled: boolean) => void;
+    onToggle: (symbol: NetworkCompatible['symbol'], toggled: boolean) => void;
 }
 
 export const CoinGroup = ({ onToggle, networks, enabledNetworks, className }: CoinGroupProps) => {
@@ -26,7 +26,7 @@ export const CoinGroup = ({ onToggle, networks, enabledNetworks, className }: Co
 
     const isAtLeastOneActive = networks.some(({ symbol }) => enabledNetworks?.includes(symbol));
 
-    const onSettings = (symbol: Network['symbol']) => {
+    const onSettings = (symbol: NetworkCompatible['symbol']) => {
         setSettingsMode(false);
         dispatch(
             openModal({

--- a/packages/suite/src/components/suite/CoinList/Coin.tsx
+++ b/packages/suite/src/components/suite/CoinList/Coin.tsx
@@ -3,7 +3,7 @@ import { transparentize } from 'polished';
 import styled, { css, useTheme } from 'styled-components';
 import { variables, CoinLogo, Icon } from '@trezor/components';
 import { Translation } from 'src/components/suite';
-import type { Network } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import { typography } from '@trezor/theme';
 import { TranslationKey } from '@suite-common/intl-types';
 
@@ -152,8 +152,8 @@ const Check = styled.div<{ $visible: boolean }>`
 `;
 
 interface CoinProps {
-    symbol: Network['symbol'];
-    name: Network['name'];
+    symbol: NetworkCompatible['symbol'];
+    name: NetworkCompatible['name'];
     label?: TranslationKey;
     toggled: boolean;
     disabled?: boolean;

--- a/packages/suite/src/components/suite/CoinList/CoinList.tsx
+++ b/packages/suite/src/components/suite/CoinList/CoinList.tsx
@@ -7,7 +7,7 @@ import { versionUtils } from '@trezor/utils';
 
 import { Translation } from 'src/components/suite';
 import { useDevice, useDiscovery, useSelector } from 'src/hooks/suite';
-import type { Network } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 
 import { Coin } from './Coin';
 import { getCoinLabel } from 'src/utils/suite/getCoinLabel';
@@ -20,11 +20,11 @@ const Wrapper = styled.div`
 `;
 
 interface CoinListProps {
-    networks: Network[];
-    enabledNetworks?: Network['symbol'][];
+    networks: NetworkCompatible[];
+    enabledNetworks?: NetworkCompatible['symbol'][];
     settingsMode?: boolean;
-    onSettings?: (symbol: Network['symbol']) => void;
-    onToggle: (symbol: Network['symbol'], toggled: boolean) => void;
+    onSettings?: (symbol: NetworkCompatible['symbol']) => void;
+    onToggle: (symbol: NetworkCompatible['symbol'], toggled: boolean) => void;
 }
 
 export const CoinList = ({

--- a/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
+++ b/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { HiddenPlaceholder, Sign } from 'src/components/suite';
-import { NetworkSymbol } from 'src/types/wallet';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import { useSelector } from 'src/hooks/suite';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 

--- a/packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipAccount.tsx
+++ b/packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipAccount.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { TooltipProps } from 'recharts';
 import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
-import { NetworkSymbol } from 'src/types/wallet';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 
 import { Formatters, useFormatters } from '@suite-common/formatters';
 

--- a/packages/suite/src/components/suite/graph/TransactionsGraph/GraphYAxisTick.tsx
+++ b/packages/suite/src/components/suite/graph/TransactionsGraph/GraphYAxisTick.tsx
@@ -2,7 +2,7 @@ import { useTheme } from 'styled-components';
 import { useRef, useLayoutEffect } from 'react';
 import { FormattedCryptoAmount } from 'src/components/suite';
 import { useFormatters } from '@suite-common/formatters';
-import { NetworkSymbol } from 'src/types/wallet';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 
 interface CommonProps {
     setWidth: (n: number) => void;

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
@@ -3,7 +3,7 @@ import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { Translation } from 'src/components/suite';
 import { formatNetworkAmount, formatAmount, isTestnet } from '@suite-common/wallet-utils';
 import { BTC_LOCKTIME_VALUE } from '@suite-common/wallet-constants';
-import { Network, NetworkSymbol } from 'src/types/wallet';
+import { NetworkCompatible, NetworkSymbol } from '@suite-common/wallet-config';
 import { ReviewOutput } from '@suite-common/wallet-types';
 import {
     TransactionReviewStepIndicator,
@@ -49,7 +49,7 @@ const getDisplayModeStringsMap = (): Record<
 
 export type TransactionReviewOutputProps = {
     state: TransactionReviewStepIndicatorProps['state'];
-    symbol: Network['symbol'];
+    symbol: NetworkCompatible['symbol'];
     account: Account;
     isRbf: boolean;
     ethereumStakeType?: StakeType;

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
@@ -3,7 +3,8 @@ import styled from 'styled-components';
 
 import { variables } from '@trezor/components';
 import { FiatValue, FormattedCryptoAmount, Translation } from 'src/components/suite';
-import { Network, Account, NetworkSymbol } from 'src/types/wallet';
+import { Account } from 'src/types/wallet';
+import { NetworkCompatible, NetworkSymbol } from '@suite-common/wallet-config';
 import { TokenInfo } from '@trezor/connect';
 import { amountToSatoshi } from '@suite-common/wallet-utils';
 import { TransactionReviewStepIndicatorProps } from './TransactionReviewStepIndicator';
@@ -141,7 +142,7 @@ export type TransactionReviewOutputElementProps = {
     indicator?: JSX.Element;
     lines: OutputElementLine[];
     cryptoSymbol?: NetworkSymbol;
-    fiatSymbol?: Network['symbol'];
+    fiatSymbol?: NetworkCompatible['symbol'];
     fiatVisible?: boolean;
     token?: TokenInfo;
     account?: Account;

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
@@ -6,7 +6,8 @@ import { formatDuration } from '@suite-common/suite-utils';
 import { borders, spacingsPx, typography } from '@trezor/theme';
 import { TranslationKey } from '@suite-common/intl-types';
 import { Translation, FormattedCryptoAmount, AccountLabel } from 'src/components/suite';
-import { Account, Network } from 'src/types/wallet';
+import { Account } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import { GeneralPrecomposedTransactionFinal, StakeType } from '@suite-common/wallet-types';
 import { useSelector } from 'src/hooks/suite/useSelector';
 import { selectLabelingDataForSelectedAccount } from 'src/reducers/suite/metadataReducer';
@@ -203,7 +204,7 @@ interface TransactionReviewSummaryProps {
     estimateTime?: number;
     tx: GeneralPrecomposedTransactionFinal;
     account: Account;
-    network: Network;
+    network: NetworkCompatible;
     broadcast?: boolean;
     detailsOpen: boolean;
     onDetailsClick: () => void;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeDescription.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeDescription.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { Paragraph } from '@trezor/components';
-import { Network } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import { Translation } from 'src/components/suite';
 import { getAccountTypeDesc, getAccountTypeUrl } from '@suite-common/wallet-utils';
 import { spacingsPx } from '@trezor/theme';
@@ -11,7 +11,7 @@ const Info = styled(Paragraph)`
 `;
 
 interface AccountTypeDescriptionProps {
-    bip43Path: Network['bip43Path'];
+    bip43Path: NetworkCompatible['bip43Path'];
     hasMultipleAccountTypes: boolean;
 }
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeSelect.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeSelect.tsx
@@ -3,7 +3,7 @@ import { Select } from '@trezor/components';
 import { Translation } from 'src/components/suite/Translation';
 import { getAccountTypeName, getAccountTypeTech } from '@suite-common/wallet-utils';
 import { AccountTypeDescription } from './AccountTypeDescription';
-import { Network } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import { typography } from '@trezor/theme';
 
 const LabelWrapper = styled.div`
@@ -19,7 +19,7 @@ const TypeInfo = styled.div`
     ${typography.label}
 `;
 
-const buildAccountTypeOption = (network: Network) =>
+const buildAccountTypeOption = (network: NetworkCompatible) =>
     ({
         value: network,
         label: network.accountType || 'normal',
@@ -38,9 +38,9 @@ const formatLabel = (option: Option) => (
 );
 
 interface AccountTypeSelectProps {
-    network: Network;
-    accountTypes: Network[];
-    onSelectAccountType: (network: Network) => void;
+    network: NetworkCompatible;
+    accountTypes: NetworkCompatible[];
+    onSelectAccountType: (network: NetworkCompatible) => void;
 }
 
 export const AccountTypeSelect = ({

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddAccountButton.tsx
@@ -3,7 +3,8 @@ import { useCallback } from 'react';
 import { analytics, EventType } from '@trezor/suite-analytics';
 import { UnavailableCapability } from '@trezor/connect';
 import { selectDevice } from '@suite-common/wallet-core';
-import { Account, Network } from 'src/types/wallet';
+import { Account } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import { Translation } from 'src/components/suite';
 import { useAccountSearch, useSelector } from 'src/hooks/suite';
 import { AddCoinjoinAccountButton } from './AddCoinjoinAccountButton';
@@ -51,7 +52,7 @@ const verifyAvailability = ({
 };
 
 interface AddAccountButtonProps {
-    network: Network;
+    network: NetworkCompatible;
     emptyAccounts: Account[];
     onEnableAccount: (account: Account) => void;
 }

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddCoinjoinAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddCoinjoinAccountButton.tsx
@@ -12,7 +12,8 @@ import { useSelector, useDispatch } from 'src/hooks/suite';
 import { createCoinjoinAccount } from 'src/actions/wallet/coinjoinAccountActions';
 import { toggleTor } from 'src/actions/suite/suiteActions';
 import { openDeferredModal, openModal } from 'src/actions/suite/modalActions';
-import { Account, Network, NetworkSymbol } from 'src/types/wallet';
+import { Account } from 'src/types/wallet';
+import { NetworkCompatible, NetworkSymbol } from '@suite-common/wallet-config';
 import { selectTorState } from 'src/reducers/suite/suiteReducer';
 
 import { AddButton } from './AddButton';
@@ -45,7 +46,7 @@ const verifyAvailability = ({
 };
 
 interface AddCoinjoinAccountProps {
-    network: Network;
+    network: NetworkCompatible;
 }
 
 export const AddCoinjoinAccountButton = ({ network }: AddCoinjoinAccountProps) => {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -7,12 +7,16 @@ import {
     selectDeviceModel,
 } from '@suite-common/wallet-core';
 import { arrayPartition } from '@trezor/utils';
-import { networksCompatibility, NetworkSymbol } from '@suite-common/wallet-config';
+import {
+    networksCompatibility,
+    NetworkCompatible,
+    NetworkSymbol,
+} from '@suite-common/wallet-config';
 import { CollapsibleBox, NewModal } from '@trezor/components';
 import { FirmwareType } from '@trezor/connect';
 import { spacings, spacingsPx } from '@trezor/theme';
 import { Translation, CoinList, TooltipSymbol } from 'src/components/suite';
-import { Account, Network } from 'src/types/wallet';
+import { Account } from 'src/types/wallet';
 import { TrezorDevice } from 'src/types/suite';
 import { useSelector, useDispatch } from 'src/hooks/suite';
 import { changeCoinVisibility } from 'src/actions/settings/walletSettingsActions';
@@ -49,7 +53,7 @@ export const AddAccountModal = ({ device, onCancel, symbol, noRedirect }: AddAcc
 
     const { mainnets, testnets, enabledNetworks: enabledNetworkSymbols } = useEnabledNetworks();
 
-    const getNetworks = (networks: Network[], getUnsupported = false) =>
+    const getNetworks = (networks: NetworkCompatible[], getUnsupported = false) =>
         networks.filter(
             ({ symbol }) => getUnsupported !== supportedNetworkSymbols.includes(symbol),
         );
@@ -74,7 +78,7 @@ export const AddAccountModal = ({ device, onCancel, symbol, noRedirect }: AddAcc
             ? bitcoinNetwork
             : undefined;
 
-    const [selectedNetwork, setSelectedNetwork] = useState<Network | undefined>(
+    const [selectedNetwork, setSelectedNetwork] = useState<NetworkCompatible | undefined>(
         preselectedNetwork || bitcoinOnlyDefaultNetworkSelection,
     );
 
@@ -120,7 +124,7 @@ export const AddAccountModal = ({ device, onCancel, symbol, noRedirect }: AddAcc
 
     const selectedNetworks = selectedNetwork ? [selectedNetwork.symbol] : [];
 
-    const selectNetwork = (symbol?: Network['symbol']) => {
+    const selectNetwork = (symbol?: NetworkCompatible['symbol']) => {
         if (symbol) {
             const networkToSelect = networksCompatibility.find(n => n.symbol === symbol);
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/SelectNetwork.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/SelectNetwork.tsx
@@ -1,11 +1,10 @@
 import styled from 'styled-components';
 
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import { NetworkCompatible, NetworkSymbol } from '@suite-common/wallet-config';
 import { Paragraph } from '@trezor/components';
 import { spacingsPx } from '@trezor/theme';
 
 import { CoinList } from 'src/components/suite';
-import type { Network } from 'src/types/wallet';
 
 const Title = styled(Paragraph)`
     color: ${({ theme }) => theme.textSubdued};
@@ -14,7 +13,7 @@ const Title = styled(Paragraph)`
 
 type SelectNetworkProps = {
     heading: React.ReactNode;
-    networks: Network[];
+    networks: NetworkCompatible[];
     selectedNetworks: NetworkSymbol[];
     handleNetworkSelection: (symbol?: NetworkSymbol) => void;
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/AdvancedCoinSettingsModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/AdvancedCoinSettingsModal.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { CoinLogo, variables } from '@trezor/components';
 import { Modal, Translation } from 'src/components/suite';
-import { NetworkSymbol } from 'src/types/wallet';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import { CustomBackends } from './CustomBackends/CustomBackends';
 import { getCoinLabel } from 'src/utils/suite/getCoinLabel';
 import { useSelector } from 'src/hooks/suite';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/BackendTypeSelect.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/BackendTypeSelect.tsx
@@ -5,14 +5,14 @@ import { Select } from '@trezor/components';
 import { Translation } from 'src/components/suite';
 import { isDesktop } from '@trezor/env-utils';
 
-import type { Network } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import type { BackendOption } from 'src/hooks/settings/backends';
 
 const Capitalize = styled.span`
     text-transform: capitalize;
 `;
 
-const useBackendOptions = (network: Network) =>
+const useBackendOptions = (network: NetworkCompatible) =>
     useMemo(
         () =>
             ['default', ...network.customBackends]
@@ -48,7 +48,7 @@ const useBackendOptions = (network: Network) =>
     );
 
 type BackendTypeSelectProps = {
-    network: Network;
+    network: NetworkCompatible;
     value: BackendOption;
     onChange: (type: BackendOption) => void;
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/ConnectionInfo.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/ConnectionInfo.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import { Paragraph } from '@trezor/components';
 import { useSelector } from 'src/hooks/suite';
 import { Translation } from 'src/components/suite/Translation';
-import type { Network } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 
 const Wrapper = styled(Paragraph)`
     display: flex;
@@ -11,7 +11,7 @@ const Wrapper = styled(Paragraph)`
 `;
 
 interface ConnectionInfoProps {
-    coin: Network['symbol'];
+    coin: NetworkCompatible['symbol'];
 }
 
 const ConnectionInfo = ({ coin }: ConnectionInfoProps) => {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/CustomBackends.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/CustomBackends.tsx
@@ -10,7 +10,7 @@ import ConnectionInfo from './ConnectionInfo';
 import { BackendInput } from './BackendInput';
 import { BackendTypeSelect } from './BackendTypeSelect';
 import { TorModal, TorResult } from './TorModal';
-import type { Network } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import { selectTorState } from 'src/reducers/suite/suiteReducer';
 import { spacings } from '@trezor/theme';
 
@@ -55,7 +55,7 @@ const TransparentCollapsibleBox = styled(CollapsibleBox)`
 `;
 
 interface CustomBackendsProps {
-    network: Network;
+    network: NetworkCompatible;
     onCancel: () => void;
 }
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DisableTorModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DisableTorModal.tsx
@@ -9,7 +9,7 @@ import { Modal, Translation } from 'src/components/suite';
 import { useDispatch } from 'src/hooks/suite';
 import { isOnionUrl } from 'src/utils/suite/tor';
 import { useCustomBackends } from 'src/hooks/settings/backends';
-import type { Network } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import { AdvancedCoinSettingsModal } from 'src/components/suite/modals';
 
 const BackendRowWrapper = styled.div`
@@ -49,7 +49,7 @@ const CoinUrls = styled.span`
 `;
 
 interface BackendRowProps {
-    coin: Network['symbol'];
+    coin: NetworkCompatible['symbol'];
     urls: string[];
     onSettings: () => void;
 }
@@ -85,7 +85,7 @@ type DisableTorModalProps = Omit<Extract<UserContextPayload, { type: 'disable-to
 
 export const DisableTorModal = ({ onCancel, decision }: DisableTorModalProps) => {
     const dispatch = useDispatch();
-    const [coin, setCoin] = useState<Network['symbol']>();
+    const [coin, setCoin] = useState<NetworkCompatible['symbol']>();
     const onionBackends = useCustomBackends().filter(({ urls }) => urls.every(isOnionUrl));
 
     const onDisableTor = () => {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AdvancedTxDetails/AdvancedTxDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AdvancedTxDetails/AdvancedTxDetails.tsx
@@ -4,7 +4,7 @@ import { Translation } from 'src/components/suite';
 import { useElevation, variables } from '@trezor/components';
 import { isTestnet } from '@suite-common/wallet-utils';
 import { WalletAccountTransaction, ChainedTransactions } from '@suite-common/wallet-types';
-import { Network } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import { AmountDetails } from './AmountDetails';
 import { IODetails } from './IODetails/IODetails';
 import { ChainedTxs } from '../ChainedTxs';
@@ -50,7 +50,7 @@ export type TabID = 'amount' | 'io' | 'chained';
 
 interface AdvancedTxDetailsProps {
     defaultTab?: TabID;
-    network: Network;
+    network: NetworkCompatible;
     tx: WalletAccountTransaction;
     chainedTxs?: ChainedTransactions;
     explorerUrl: string;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AdvancedTxDetails/AmountDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AdvancedTxDetails/AmountDetails.tsx
@@ -2,7 +2,8 @@ import styled from 'styled-components';
 import { variables } from '@trezor/components';
 import { Translation, FormattedCryptoAmount, FiatValue, FormattedDate } from 'src/components/suite';
 import { AmountRow } from './AmountRow';
-import { NetworkSymbol, WalletAccountTransaction } from 'src/types/wallet';
+import { WalletAccountTransaction } from 'src/types/wallet';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import {
     formatAmount,
     formatCardanoDeposit,

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
@@ -1,7 +1,8 @@
 import styled, { useTheme } from 'styled-components';
 import { Icon, variables, CoinLogo, H3, useElevation } from '@trezor/components';
 import { Translation, FormattedDateWithBullet } from 'src/components/suite';
-import { WalletAccountTransaction, Network } from 'src/types/wallet';
+import { WalletAccountTransaction } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import { getTxIcon, isPending, getFeeUnits, getFeeRate } from '@suite-common/wallet-utils';
 import { TransactionHeader } from 'src/components/wallet/TransactionItem/TransactionHeader';
 import { fromWei } from 'web3-utils';
@@ -156,7 +157,7 @@ const IconPlaceholder = styled.span`
 
 interface BasicTxDetailsProps {
     tx: WalletAccountTransaction;
-    network: Network;
+    network: NetworkCompatible;
     confirmations: number;
     explorerUrl: string;
     explorerUrlQueryString?: string;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChainedTxs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChainedTxs.tsx
@@ -5,7 +5,7 @@ import { ChainedTransactions } from '@suite-common/wallet-types';
 
 import { TrezorLink, Translation } from 'src/components/suite';
 import { TransactionItem } from 'src/components/wallet/TransactionItem/TransactionItem';
-import { Network } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import { AffectedTransactionItem } from './ChangeFee/AffectedTransactionItem';
 
 const Wrapper = styled.div`
@@ -52,7 +52,7 @@ const StyledAffectedTransactionItem = styled(AffectedTransactionItem)`
 
 interface ChainedTxsProps {
     txs: ChainedTransactions;
-    network: Network;
+    network: NetworkCompatible;
     explorerUrl: string;
 }
 

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/CoinProtocolRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/CoinProtocolRenderer.tsx
@@ -9,16 +9,17 @@ import { Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { PROTOCOL_TO_NETWORK } from 'src/constants/suite/protocol';
 import type { NotificationRendererProps } from 'src/components/suite';
-import type { Network } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import { ConditionalActionRenderer } from './ConditionalActionRenderer';
 
 const Row = styled.span`
     display: flex;
 `;
 
-const getIcon = (symbol?: Network['symbol']) => symbol && <CoinLogo symbol={symbol} size={24} />;
+const getIcon = (symbol?: NetworkCompatible['symbol']) =>
+    symbol && <CoinLogo symbol={symbol} size={24} />;
 
-const useActionAllowed = (path: string, network?: Network['symbol']) => {
+const useActionAllowed = (path: string, network?: NetworkCompatible['symbol']) => {
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
     const pathMatch = useRouteMatch(`${process.env.ASSET_PREFIX || ''}${path}`);
 

--- a/packages/suite/src/components/wallet/Fees/FeeDetails.tsx
+++ b/packages/suite/src/components/wallet/Fees/FeeDetails.tsx
@@ -4,7 +4,7 @@ import { FeeLevel } from '@trezor/connect';
 import { Translation } from 'src/components/suite';
 import { getFeeUnits } from '@suite-common/wallet-utils';
 import { formatDuration } from '@suite-common/suite-utils';
-import { Network } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 
 import { useState, useEffect } from 'react';
 import {
@@ -32,7 +32,7 @@ const FeeItem = styled.span`
 `;
 
 interface DetailsProps {
-    networkType: Network['networkType'];
+    networkType: NetworkCompatible['networkType'];
     selectedLevel: FeeLevel;
     // fields below are validated as false-positives, eslint claims that they are not used...
 

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
@@ -8,7 +8,8 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 import { openModal } from 'src/actions/suite/modalActions';
 import { formatNetworkAmount, isTestnet, isTxFeePaid } from '@suite-common/wallet-utils';
 import { AccountLabels } from 'src/types/suite/metadata';
-import { Network, WalletAccountTransaction } from 'src/types/wallet';
+import { WalletAccountTransaction } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import { TransactionTypeIcon } from './TransactionTypeIcon';
 import { TransactionHeading } from './TransactionHeading';
 import {
@@ -82,7 +83,7 @@ interface TransactionItemProps {
     isActionDisabled?: boolean; // Used in "chained transactions" transaction detail modal
     accountMetadata?: AccountLabels;
     accountKey: string;
-    network: Network;
+    network: NetworkCompatible;
     className?: string;
     index: number;
 }

--- a/packages/suite/src/components/wallet/WalletLayout/AccountException/AccountNotEnabled.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountException/AccountNotEnabled.tsx
@@ -1,11 +1,11 @@
 import { changeCoinVisibility } from 'src/actions/settings/walletSettingsActions';
 import { useDevice, useDispatch } from 'src/hooks/suite';
-import { Network } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import { Translation } from 'src/components/suite';
 import { AccountExceptionLayout } from 'src/components/wallet';
 
 interface AccountNotEnabledProps {
-    network: Network;
+    network: NetworkCompatible;
 }
 
 /**

--- a/packages/suite/src/constants/suite/protocol.ts
+++ b/packages/suite/src/constants/suite/protocol.ts
@@ -1,4 +1,4 @@
-import type { Network } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 
 export enum PROTOCOL_SCHEME {
     BITCOIN = 'bitcoin',
@@ -18,7 +18,9 @@ export enum PROTOCOL_SCHEME {
     CARDANO = 'cardano',
 }
 
-export const PROTOCOL_TO_NETWORK: Partial<{ [key in PROTOCOL_SCHEME]: Network['symbol'] }> = {
+export const PROTOCOL_TO_NETWORK: Partial<{
+    [key in PROTOCOL_SCHEME]: NetworkCompatible['symbol'];
+}> = {
     [PROTOCOL_SCHEME.BITCOIN]: 'btc',
     [PROTOCOL_SCHEME.LITECOIN]: 'ltc',
     [PROTOCOL_SCHEME.BITCOIN_CASH]: 'bch',

--- a/packages/suite/src/constants/suite/routes.ts
+++ b/packages/suite/src/constants/suite/routes.ts
@@ -2,7 +2,7 @@ import { ArrayElement } from '@trezor/type-utils';
 import { Route } from '@suite-common/suite-types';
 import { routes } from '@suite-common/suite-config';
 
-import { Network } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import { RouteParams } from 'src/utils/suite/router';
 
 export type SettingsBackRoute = {
@@ -11,9 +11,9 @@ export type SettingsBackRoute = {
 };
 
 type RouteParamsTypes = {
-    symbol: Network['symbol'];
+    symbol: NetworkCompatible['symbol'];
     accountIndex: number;
-    accountType: NonNullable<Network['accountType']>;
+    accountType: NonNullable<NetworkCompatible['accountType']>;
     cancelable: boolean;
     contractAddress?: string;
 };

--- a/packages/suite/src/hooks/settings/backends/useBackendReconnection.ts
+++ b/packages/suite/src/hooks/settings/backends/useBackendReconnection.ts
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react';
 import { reconnectBlockchainThunk } from '@suite-common/wallet-core';
 
 import { useDispatch } from 'src/hooks/suite';
-import { NetworkSymbol } from 'src/types/wallet';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 
 export const useBackendReconnection = (
     coin: NetworkSymbol,

--- a/packages/suite/src/hooks/settings/backends/useBackendsForm.ts
+++ b/packages/suite/src/hooks/settings/backends/useBackendsForm.ts
@@ -7,7 +7,8 @@ import { isUrl } from '@trezor/utils';
 import { isOnionUrl } from 'src/utils/suite/tor';
 import { blockchainActions } from '@suite-common/wallet-core';
 import { isElectrumUrl } from '@suite-common/wallet-utils';
-import type { Network, BackendType } from 'src/types/wallet';
+import type { BackendType } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import { BackendSettings } from '@suite-common/wallet-types';
 
 export type BackendOption = BackendType | 'default';
@@ -32,7 +33,7 @@ const validateUrl = (type: BackendOption, value: string) => {
     }
 };
 
-const getUrlPlaceholder = (coin: Network['symbol'], type: BackendOption) => {
+const getUrlPlaceholder = (coin: NetworkCompatible['symbol'], type: BackendOption) => {
     switch (type) {
         case 'blockbook':
             return `https://${coin}1.trezor.io/`;
@@ -48,7 +49,7 @@ const getUrlPlaceholder = (coin: Network['symbol'], type: BackendOption) => {
 };
 
 const useBackendUrlInput = (
-    coin: Network['symbol'],
+    coin: NetworkCompatible['symbol'],
     type: BackendOption,
     currentUrls: string[],
 ) => {
@@ -91,7 +92,7 @@ const useBackendUrlInput = (
 };
 
 const getStoredState = (
-    coin: Network['symbol'],
+    coin: NetworkCompatible['symbol'],
     type?: BackendOption,
     urls?: BackendSettings['urls'],
 ): BackendsFormData => ({
@@ -99,7 +100,7 @@ const getStoredState = (
     urls: (type && type !== 'default' && urls?.[type]) || [],
 });
 
-export const useBackendsForm = (coin: Network['symbol']) => {
+export const useBackendsForm = (coin: NetworkCompatible['symbol']) => {
     const backends = useSelector(state => state.wallet.blockchain[coin].backends);
     const dispatch = useDispatch();
     const initial = getStoredState(coin, backends.selected, backends.urls);

--- a/packages/suite/src/hooks/settings/backends/useDefaultUrls.ts
+++ b/packages/suite/src/hooks/settings/backends/useDefaultUrls.ts
@@ -1,9 +1,9 @@
 import { useState, useEffect } from 'react';
 import TrezorConnect, { BlockchainLink } from '@trezor/connect';
-import type { Network } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 
 export const useDefaultUrls = (
-    coin: Network['symbol'],
+    coin: NetworkCompatible['symbol'],
 ): { defaultUrls: string[]; isLoading: boolean } => {
     const [link, setLink] = useState<BlockchainLink>();
     const [isLoading, setIsLoading] = useState(false);

--- a/packages/suite/src/hooks/settings/useEnabledNetworks.ts
+++ b/packages/suite/src/hooks/settings/useEnabledNetworks.ts
@@ -1,6 +1,6 @@
 import { useSelector, useActions } from 'src/hooks/suite';
 import { changeCoinVisibility } from 'src/actions/settings/walletSettingsActions';
-import type { Network } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 
 import { getMainnets, getTestnets } from '@suite-common/wallet-config';
 import {
@@ -9,10 +9,10 @@ import {
 } from 'src/reducers/suite/suiteReducer';
 
 type EnabledNetworks = {
-    mainnets: Network[];
-    testnets: Network[];
-    enabledNetworks: Network['symbol'][];
-    setEnabled: (symbol: Network['symbol'], enabled: boolean) => void;
+    mainnets: NetworkCompatible[];
+    testnets: NetworkCompatible[];
+    enabledNetworks: NetworkCompatible['symbol'][];
+    setEnabled: (symbol: NetworkCompatible['symbol'], enabled: boolean) => void;
 };
 
 export const useEnabledNetworks = (): EnabledNetworks => {

--- a/packages/suite/src/hooks/suite/useFiatFromCryptoValue.ts
+++ b/packages/suite/src/hooks/suite/useFiatFromCryptoValue.ts
@@ -1,6 +1,6 @@
 import { useSelector } from 'src/hooks/suite';
 
-import { Network } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import { getFiatRateKey, toFiatCurrency } from '@suite-common/wallet-utils';
 import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
 import { selectFiatRatesByFiatRateKey } from '@suite-common/wallet-core';
@@ -10,7 +10,7 @@ import { TokenTransfer } from '@trezor/blockchain-link-types';
 
 interface CommonOwnProps {
     amount: string;
-    symbol: Network['symbol'] | TokenTransfer['symbol'];
+    symbol: NetworkCompatible['symbol'] | TokenTransfer['symbol'];
     tokenAddress?: TokenAddress;
     fiatCurrency?: string;
 }

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSatsSwitcher.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSatsSwitcher.ts
@@ -3,7 +3,7 @@ import { amountToSatoshi, formatAmount } from '@suite-common/wallet-utils';
 import { useDidUpdate } from '@trezor/react-utils';
 import { FORM_CRYPTO_INPUT, FORM_FIAT_INPUT } from 'src/constants/wallet/coinmarket/form';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
-import { Network } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import { coinmarketGetRoundedFiatAmount } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 
 interface UseCoinmarketSatsSwitcherProps {
@@ -11,7 +11,7 @@ interface UseCoinmarketSatsSwitcherProps {
     methods: any;
     quoteCryptoAmount: string | undefined;
     quoteFiatAmount: string | undefined;
-    network: Network | null;
+    network: NetworkCompatible | null;
 }
 
 /**

--- a/packages/suite/src/hooks/wallet/sign-verify/useSignVerifyForm.ts
+++ b/packages/suite/src/hooks/wallet/sign-verify/useSignVerifyForm.ts
@@ -4,14 +4,15 @@ import { yup } from '@suite-common/validators';
 import { isAddressValid } from '@suite-common/wallet-utils';
 import { yupResolver } from '@hookform/resolvers/yup';
 
-import type { Account, Network } from 'src/types/wallet';
+import type { Account } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 
 export const MAX_LENGTH_MESSAGE = 1024;
 export const MAX_LENGTH_SIGNATURE = 255;
 
 type SignVerifyContext = {
     isSignPage: boolean;
-    accountNetwork: Network['symbol'];
+    accountNetwork: NetworkCompatible['symbol'];
 };
 
 const signVerifySchema = yup.object({

--- a/packages/suite/src/hooks/wallet/useBitcoinAmountUnit.ts
+++ b/packages/suite/src/hooks/wallet/useBitcoinAmountUnit.ts
@@ -4,7 +4,7 @@ import { selectDeviceUnavailableCapabilities } from '@suite-common/wallet-core';
 import { useSelector } from 'src/hooks/suite/useSelector';
 import { useActions } from 'src/hooks/suite/useActions';
 import * as walletSettingsActions from 'src/actions/settings/walletSettingsActions';
-import { NetworkSymbol } from 'src/types/wallet';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import { networksCompatibility } from '@suite-common/wallet-config';
 
 export const useBitcoinAmountUnit = (symbol?: NetworkSymbol) => {

--- a/packages/suite/src/middlewares/wallet/__fixtures__/coinjoinMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/__fixtures__/coinjoinMiddleware.ts
@@ -9,7 +9,8 @@ import { ROUTER, SUITE } from 'src/actions/suite/constants';
 import { COINJOIN } from 'src/actions/wallet/constants';
 import { CoinjoinState } from 'src/reducers/wallet/coinjoinReducer';
 import { CoinjoinAccount, CoinjoinSession } from 'src/types/wallet/coinjoin';
-import { Account, NetworkSymbol } from 'src/types/wallet';
+import { Account } from 'src/types/wallet';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import { RouterState } from 'src/reducers/suite/routerReducer';
 
 const DEVICE_A = {

--- a/packages/suite/src/services/coinjoin/coinjoinService.ts
+++ b/packages/suite/src/services/coinjoin/coinjoinService.ts
@@ -2,7 +2,7 @@ import { CoinjoinBackend, CoinjoinClient, CoinjoinPrisonInmate } from '@trezor/c
 import { createIpcProxy } from '@trezor/ipc-proxy';
 import { PartialRecord } from '@trezor/type-utils';
 import { isDesktop } from '@trezor/env-utils';
-import { NetworkSymbol } from 'src/types/wallet';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import { CoinjoinNetworksConfig, getCoinjoinConfig } from './config';
 
 const loadInstance = (settings: ReturnType<typeof getCoinjoinConfig>) => {

--- a/packages/suite/src/storage/definitions.ts
+++ b/packages/suite/src/storage/definitions.ts
@@ -8,7 +8,8 @@ import type { MetadataState } from 'src/types/suite/metadata';
 import type { Trade } from 'src/types/wallet/coinmarketCommonTypes';
 import type { MessageState } from '@suite-common/message-system';
 import type { MessageSystem } from '@suite-common/suite-types';
-import type { Account, Discovery, Network, WalletAccountTransaction } from 'src/types/wallet';
+import type { Account, Discovery, WalletAccountTransaction } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import type { CoinjoinAccount, CoinjoinDebugSettings } from 'src/types/wallet/coinjoin';
 import type { BackendSettings, WalletSettings } from '@suite-common/wallet-types';
 import type { StorageUpdateMessage } from '@trezor/suite-storage';
@@ -54,7 +55,7 @@ export interface SuiteDBSchema extends DBSchema {
         value: WalletSettings;
     };
     backendSettings: {
-        key: Network['symbol'];
+        key: NetworkCompatible['symbol'];
         value: BackendSettings;
     };
     devices: {

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -3,7 +3,7 @@ import { toWei } from 'web3-utils';
 import { isDesktop } from '@trezor/env-utils';
 import type { State } from 'src/reducers/wallet/settingsReducer';
 import type { CustomBackend, BlockbookUrl } from 'src/types/wallet/backend';
-import type { Network } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 
 import type { BackendSettings } from '@suite-common/wallet-types';
 import type { OnUpgradeFunc } from '@trezor/suite-storage';
@@ -19,7 +19,7 @@ import { parseAsset } from '@trezor/blockchain-link-utils/src/blockfrost';
 
 type WalletWithBackends = {
     backends?: Partial<{
-        [coin in Network['symbol']]: Omit<CustomBackend, 'coin'>;
+        [coin in NetworkCompatible['symbol']]: Omit<CustomBackend, 'coin'>;
     }>;
 };
 
@@ -297,7 +297,7 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
                             [type]: urls,
                         },
                     };
-                    backendSettings.add(settings, coin as Network['symbol']);
+                    backendSettings.add(settings, coin as NetworkCompatible['symbol']);
                 });
 
                 return rest;

--- a/packages/suite/src/types/coinmarket/coinmarketForm.ts
+++ b/packages/suite/src/types/coinmarket/coinmarketForm.ts
@@ -9,7 +9,8 @@ import {
     CoinmarketTradeSellType,
     CoinmarketTradeType,
 } from 'src/types/coinmarket/coinmarket';
-import type { Account, Network } from 'src/types/wallet';
+import type { Account } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import type { BuyInfo } from 'src/actions/wallet/coinmarketBuyActions';
 import type { FieldValues, UseFormReturn, FieldPath } from 'react-hook-form';
 import type {
@@ -112,7 +113,7 @@ export interface CoinmarketCommonFormProps {
     callInProgress: boolean;
     timer: Timer;
     account: Account;
-    network: Network;
+    network: NetworkCompatible;
 
     goToOffers: () => Promise<void>;
 }
@@ -285,7 +286,7 @@ export interface CoinmarketFormInputCurrencyProps extends CoinmarketFormInputCom
 
 export interface CoinmarketUseFormHelpersProps {
     account: Account;
-    network: Network;
+    network: NetworkCompatible;
     setAmountLimits: (limits?: AmountLimits) => void;
     changeFeeLevel: (level: FeeLevel['label']) => void;
     composeRequest: SendContextValues<SellFormState>['composeTransaction'];
@@ -327,7 +328,7 @@ export interface CoinmarketUseCommonFormStateProps<
     T extends CoinmarketSellFormProps | CoinmarketExchangeFormProps,
 > {
     account: Account;
-    network: Network;
+    network: NetworkCompatible;
     fees: FeesState;
     defaultValues?: T;
 }
@@ -336,7 +337,7 @@ export interface CoinmarketUseCommonFormStateReturnProps<
     T extends CoinmarketSellFormProps | CoinmarketExchangeFormProps,
 > {
     account: Account;
-    network: Network;
+    network: NetworkCompatible;
     feeInfo: FeeInfo;
     formValues?: T;
 }

--- a/packages/suite/src/types/coinmarket/coinmarketVerify.ts
+++ b/packages/suite/src/types/coinmarket/coinmarketVerify.ts
@@ -1,4 +1,5 @@
-import type { Account, NetworkSymbol } from 'src/types/wallet';
+import type { Account } from 'src/types/wallet';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import { CryptoSymbol } from 'invity-api';
 import { UseFormReturn } from 'react-hook-form';
 import { AccountAddress } from '@trezor/connect';

--- a/packages/suite/src/types/wallet/coinmarketExchangeForm.ts
+++ b/packages/suite/src/types/wallet/coinmarketExchangeForm.ts
@@ -1,6 +1,7 @@
 import type { AppState } from 'src/types/suite';
 import type { FormState as ReactHookFormState, UseFormReturn } from 'react-hook-form';
-import type { Account, Network } from 'src/types/wallet';
+import type { Account } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import type { FeeLevel } from '@trezor/connect';
 import type { ExchangeInfo } from 'src/actions/wallet/coinmarketExchangeActions';
 import type {
@@ -44,7 +45,7 @@ export interface ExchangeFormContextValues extends UseFormReturn<ExchangeFormSta
     isLoading: boolean;
     updateFiatValue: (amount: string) => void;
     noProviders: boolean;
-    network: Network;
+    network: NetworkCompatible;
     feeInfo: FeeInfo;
     removeDraft: (key: string) => void;
     formState: ReactHookFormState<ExchangeFormState>;

--- a/packages/suite/src/types/wallet/coinmarketSellForm.ts
+++ b/packages/suite/src/types/wallet/coinmarketSellForm.ts
@@ -1,6 +1,7 @@
 import type { AppState } from 'src/types/suite';
 import type { FormState as ReactHookFormState, UseFormReturn } from 'react-hook-form';
-import type { Account, Network } from 'src/types/wallet';
+import type { Account } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import type { FeeLevel } from '@trezor/connect';
 import type { SellInfo } from 'src/actions/wallet/coinmarketSellActions';
 import type {
@@ -50,7 +51,7 @@ export type SellFormContextValues = UseFormReturn<SellFormState> & {
     quotesRequest: AppState['wallet']['coinmarket']['sell']['quotesRequest'];
     isLoading: boolean;
     noProviders: boolean;
-    network: Network;
+    network: NetworkCompatible;
     feeInfo: FeeInfo;
     onCryptoAmountChange: (amount: string) => void;
     onFiatAmountChange: (amount: string) => void;

--- a/packages/suite/src/types/wallet/index.ts
+++ b/packages/suite/src/types/wallet/index.ts
@@ -21,7 +21,6 @@ import { CoinmarketInfoAction } from 'src/actions/wallet/coinmarketInfoActions';
 import { tokenDefinitionsActions } from '@suite-common/token-definitions/src/tokenDefinitionsActions';
 
 // reexport
-export type { NetworkCompatible as Network, NetworkSymbol } from '@suite-common/wallet-config';
 export type { Icon } from './iconTypes';
 export type { BackendType, CustomBackend } from './backend';
 export type { TickerId } from 'src/types/wallet/fiatRates';

--- a/packages/suite/src/utils/suite/__tests__/stake.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/stake.test.ts
@@ -50,7 +50,7 @@ import {
 } from '@trezor/connect/src/types/api/blockchainEstimateFee';
 import { WalletAccountTransaction } from '@suite-common/wallet-types';
 import { ValidatorsQueue } from '@suite-common/wallet-core';
-import { NetworkSymbol } from 'src/types/wallet';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 
 describe('transformTx', () => {
     transformTxFixtures.forEach(test => {

--- a/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
@@ -1,4 +1,5 @@
-import { Account, Network } from 'src/types/wallet';
+import { Account } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import TrezorConnect, { TokenInfo } from '@trezor/connect';
 import regional from 'src/constants/wallet/coinmarket/regional';
 import { TrezorDevice } from 'src/types/suite';
@@ -183,7 +184,7 @@ export const getCountryLabelParts = (label: string) => {
 
 export const getComposeAddressPlaceholder = async (
     account: Account,
-    network: Network,
+    network: NetworkCompatible,
     device?: TrezorDevice,
     accounts?: Account[],
     chunkify?: boolean,
@@ -241,7 +242,7 @@ export const getComposeAddressPlaceholder = async (
     }
 };
 
-export const mapTestnetSymbol = (symbol: Network['symbol']) => {
+export const mapTestnetSymbol = (symbol: NetworkCompatible['symbol']) => {
     if (symbol === 'test') return 'btc';
     if (symbol === 'tsep') return 'eth';
     if (symbol === 'thol') return 'eth';

--- a/packages/suite/src/views/dashboard/components/AssetsView/components/AssetCard.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsView/components/AssetCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled, { useTheme } from 'styled-components';
-import { Network } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 
 import {
     AmountUnitSwitchWrapper,
@@ -85,7 +85,7 @@ const FailedContainer = styled.div`
 `;
 
 interface AssetCardProps {
-    network: Network;
+    network: NetworkCompatible;
     failed: boolean;
     cryptoValue: string;
     assetsFiatBalances: AssetFiatBalance[];

--- a/packages/suite/src/views/dashboard/components/AssetsView/components/AssetRow.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsView/components/AssetRow.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
 import styled, { useTheme } from 'styled-components';
-import { Network } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import { Icon, variables, SkeletonRectangle } from '@trezor/components';
 import {
     AmountUnitSwitchWrapper,
@@ -125,7 +125,7 @@ const StyledIcon = styled(Icon)`
 `;
 
 interface AssetTableProps {
-    network: Network;
+    network: NetworkCompatible;
     failed: boolean;
     cryptoValue: string;
     isLastRow?: boolean;

--- a/packages/suite/src/views/dashboard/components/CoinmarketBuyButton.tsx
+++ b/packages/suite/src/views/dashboard/components/CoinmarketBuyButton.tsx
@@ -1,6 +1,6 @@
 import * as routerActions from 'src/actions/suite/routerActions';
 import { Button } from '@trezor/components';
-import { NetworkSymbol } from 'src/types/wallet';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import { Translation } from 'src/components/suite';
 import { useDispatch, useAccountSearch } from 'src/hooks/suite';
 import { EventType, analytics } from '@trezor/suite-analytics';

--- a/packages/suite/src/views/onboarding/steps/BasicSettings/BasicSettingsStepBox.tsx
+++ b/packages/suite/src/views/onboarding/steps/BasicSettings/BasicSettingsStepBox.tsx
@@ -8,7 +8,7 @@ import { spacings } from '@trezor/theme';
 import { selectDeviceSupportedNetworks, selectDeviceModel } from '@suite-common/wallet-core';
 import { useSelector } from 'src/hooks/suite';
 import { DeviceModelInternal } from '@trezor/connect';
-import type { Network } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 
 const Separator = styled.hr`
     height: 1px;
@@ -24,7 +24,7 @@ export const BasicSettingsStepBox = (props: OnboardingStepBoxProps) => {
     const deviceSupportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
     const deviceModel = useSelector(selectDeviceModel);
 
-    const getNetworks = (networks: Network[], getUnsupported = false) =>
+    const getNetworks = (networks: NetworkCompatible[], getUnsupported = false) =>
         networks.filter(
             ({ symbol }) => getUnsupported !== deviceSupportedNetworkSymbols.includes(symbol),
         );

--- a/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
@@ -8,7 +8,7 @@ import {
 } from '@suite-common/wallet-core';
 import { Button, motionEasing, Tooltip } from '@trezor/components';
 import { DeviceModelInternal } from '@trezor/connect';
-import type { Network } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 
 import {
     DeviceBanner,
@@ -101,7 +101,7 @@ export const SettingsCoins = () => {
         deviceSupportedNetworkSymbols.includes(enabledNetwork),
     );
 
-    const getNetworks = (networks: Network[], getUnsupported = false) =>
+    const getNetworks = (networks: NetworkCompatible[], getUnsupported = false) =>
         networks.filter(
             ({ symbol }) => getUnsupported !== deviceSupportedNetworkSymbols.includes(symbol),
         );

--- a/packages/suite/src/views/settings/SettingsDebug/Backends.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/Backends.tsx
@@ -8,7 +8,7 @@ import { ConnectionStatus } from '@suite-common/wallet-types';
 import { SectionItem, StatusLight, Translation } from 'src/components/suite';
 import { useEnabledNetworks } from 'src/hooks/settings/useEnabledNetworks';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { NetworkSymbol } from 'src/types/wallet';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import { selectNetworkBlockchainInfo } from '@suite-common/wallet-core';
 import { useBackendReconnection } from 'src/hooks/settings/backends';
 import { openModal } from 'src/actions/suite/modalActions';

--- a/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
+++ b/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
@@ -5,7 +5,7 @@ import { AccountAddress } from '@trezor/connect';
 import { Card, Button, GradientOverlay, Column } from '@trezor/components';
 import { Translation, MetadataLabeling, FormattedCryptoAmount } from 'src/components/suite';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
-import { Network } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import { AppState } from 'src/types/suite';
 import { MetadataAddPayload } from 'src/types/suite/metadata';
 import { showAddress } from 'src/actions/wallet/receiveActions';
@@ -96,7 +96,7 @@ interface ItemProps {
     index: number;
     addr: AccountAddress;
     locked: boolean;
-    symbol: Network['symbol'];
+    symbol: NetworkCompatible['symbol'];
     metadataPayload: MetadataAddPayload;
     onClick: () => void;
 }

--- a/packages/suite/src/views/wallet/transactions/CoinjoinSummary/BalancePrivacyBreakdown/CryptoAmountWithHeader.tsx
+++ b/packages/suite/src/views/wallet/transactions/CoinjoinSummary/BalancePrivacyBreakdown/CryptoAmountWithHeader.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { variables } from '@trezor/components';
 import { FiatValue } from 'src/components/suite/FiatValue';
 import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
-import { NetworkSymbol } from 'src/types/wallet';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
 
 const Container = styled.div`

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/DayHeader.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/DayHeader.tsx
@@ -3,12 +3,12 @@ import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { useFormatters } from '@suite-common/formatters';
 import { isTestnet, parseTransactionDateKey } from '@suite-common/wallet-utils';
 import { FormattedCryptoAmount, HiddenPlaceholder } from 'src/components/suite';
-import { Network } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import { ColAmount, ColDate, ColFiat, HeaderWrapper } from './CommonComponents';
 
 interface DayHeaderProps {
     dateKey: string;
-    symbol: Network['symbol'];
+    symbol: NetworkCompatible['symbol'];
     totalAmount: BigNumber;
     totalFiatAmountPerDay: BigNumber;
     localCurrency: string;

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/TransactionsGroup.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/TransactionsGroup.tsx
@@ -1,6 +1,7 @@
 import { useState, ReactNode } from 'react';
 import styled from 'styled-components';
-import { Network, WalletAccountTransaction } from 'src/types/wallet';
+import { WalletAccountTransaction } from 'src/types/wallet';
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import { DayHeader } from './DayHeader';
 import {
     getFiatRateKey,
@@ -32,7 +33,7 @@ interface TransactionsGroupProps {
     dateKey: string;
     transactions: WalletAccountTransaction[];
     children?: ReactNode;
-    symbol: Network['symbol'];
+    symbol: NetworkCompatible['symbol'];
     localCurrency: FiatCurrencyCode;
     index: number;
     isPending: boolean;


### PR DESCRIPTION
2nd of many PRs to refactor & cleanup `networksConfig`: TS cleanup _(no changes in runtime JS)_.

## Description
- Remove reexport of types from `@suite-common/wallet-config` in file [src/types/wallet/index.ts (diff)](https://github.com/trezor/trezor-suite/pull/14040/files#diff-f46245044cf1799a7c753c45f2750e15558e6d263548cb5d80c84b786b659b31).
- Instead, import from `@suite-common/wallet-config`  directly.

## Related Issue

Part of #13839
