### PR TITLE
doc(connect-explorer): step by step tutorial to build webextension using @trezor/connect-webextension

### DIFF
--- a/packages/connect-explorer-theme/src/components/menu.tsx
+++ b/packages/connect-explorer-theme/src/components/menu.tsx
@@ -326,6 +326,7 @@ export function FolderImpl({ item, anchors }: FolderProps): ReactElement {
                     title: item.title,
                     type: item.type,
                     route: item.route,
+                    icon: item.kind === 'MdxPage' && item.frontMatter?.icon,
                 })}
                 <ArrowRightIcon
                     className="nx-h-[18px] nx-min-w-[18px] nx-rounded-sm nx-p-0.5 hover:nx-bg-gray-800/5 dark:hover:nx-bg-gray-100/5"

--- a/packages/connect-explorer/next-env.d.ts
+++ b/packages/connect-explorer/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/packages/connect-explorer/src/components/GuideIndex.tsx
+++ b/packages/connect-explorer/src/components/GuideIndex.tsx
@@ -1,0 +1,57 @@
+import { getPagesUnderRoute } from 'nextra/context';
+import Link from 'next/link';
+import { ReactNode } from 'react';
+
+import { Card as TrezorCard, H3, Paragraph, Button } from '@trezor/components';
+import styled from 'styled-components';
+import { spacingsPx } from '@trezor/theme';
+
+const SectionCard = styled(TrezorCard)`
+    margin-bottom: ${spacingsPx.xl};
+`;
+
+const BottomRow = styled.div`
+    margin-top: ${spacingsPx.sm};
+`;
+
+interface Page {
+    route: string;
+    meta?: {
+        title?: string;
+    };
+    frontMatter?: {
+        title?: string;
+        description?: string;
+        date?: string;
+    };
+    name: string;
+}
+
+export default function GuideIndex(): ReactNode {
+    const pages: Page[] = getPagesUnderRoute('/guides');
+
+    return pages.map(page => {
+        return (
+            <Link
+                href={page.route}
+                style={{ color: 'inherit', textDecoration: 'none' }}
+                key={page.route}
+            >
+                <SectionCard>
+                    <H3>{page.meta?.title || page.frontMatter?.title || page.name}</H3>
+                    <Paragraph>{page.frontMatter?.description}</Paragraph>
+                    <BottomRow>
+                        <Button
+                            variant="primary"
+                            size="tiny"
+                            icon="arrowRight"
+                            iconAlignment="right"
+                        >
+                            Read more
+                        </Button>
+                    </BottomRow>
+                </SectionCard>
+            </Link>
+        );
+    });
+}

--- a/packages/connect-explorer/src/pages/guides.mdx
+++ b/packages/connect-explorer/src/pages/guides.mdx
@@ -1,0 +1,12 @@
+---
+title: Guides
+searchable: false
+icon: book
+auto_sections: false
+---
+
+import GuideIndex from '../components/GuideIndex';
+
+# Trezor Connect Guides
+
+<GuideIndex />

--- a/packages/connect-explorer/src/pages/guides/webextension-implementation-tutorial.mdx
+++ b/packages/connect-explorer/src/pages/guides/webextension-implementation-tutorial.mdx
@@ -1,0 +1,437 @@
+---
+auto_sections: false
+description: Create a webextension that interacts with Trezor devices using TypeScript and Webpack
+---
+
+import styled from 'styled-components';
+
+import { spacingsPx } from '@trezor/theme';
+import { Card as TrezorCard } from '@trezor/components';
+export const SectionCard = styled(TrezorCard)`
+    margin-bottom: ${spacingsPx.xl};
+`;
+
+# Create a webextension that interacts with Trezor devices using TypeScript and Webpack
+
+<SectionCard>
+    ## Introduction
+
+    In this tutorial, you will learn how to create a web extension that utilizes the @trezor/connect-webextension library.
+    By the end of this guide, you will have a functional web extension running in Chrome.
+
+</SectionCard>
+
+<SectionCard>
+    ## Prerequisites
+    Before you begin, ensure you have the following installed on your machine:
+
+    - [Node.js](https://nodejs.org/en) (we are using version 20.12.2)
+    - [Yarn](https://yarnpkg.com/) (package manager)
+    - A code editor (e.g., Visual Studio Code)
+
+</SectionCard>
+
+<SectionCard>
+    ## Set Up Your Project
+
+    1. Create a New Directory for Your Project: Open your terminal
+    and create a new directory for your web extension project.
+
+    ```bash
+    mkdir my-trezor-extension
+    cd my-trezor-extension
+    ```
+
+    2. Initialize a New NPM Project: Run the following command to create a
+    new package.json file.
+
+    ```bash
+    npm init -y
+    ```
+
+</SectionCard>
+
+<SectionCard>
+    ## Install Dependencies
+
+    To install the required packages, run the following commands in your project directory:
+
+    * Install the Trezor Connect WebExtension library:
+
+    ```bash
+    npm install @trezor/connect-webextension
+    ```
+
+    * Install development dependencies for TypeScript, Webpack, and other tools:
+
+    ```bash
+    npm install --save-dev babel-loader @babel/preset-typescript webpack html-webpack-plugin copy-webpack-plugin typescript @types/chrome
+    ```
+
+</SectionCard>
+
+<SectionCard>
+    ## Configure Typescript
+
+    Create `tsconfig.json` in the root directory:
+
+    ```json
+        {
+            "compilerOptions": {
+                "types": ["chrome"]
+            },
+        }
+    ```
+
+    You can add more typescript configurations you like but it should work just like that.
+
+</SectionCard>
+
+<SectionCard>
+    ## Create a `src` directory
+    Inside your `src` directory create a file `service-worker.ts` that will load `@trezor/connect-webextension`:
+
+    ```typescript
+    /// <reference lib="webworker" />
+
+    // Reference the Web Worker library, allowing TypeScript to recognize service worker globals
+
+    // Import using ES6 module TrezorConnect and the DEVICE_EVENT constant from the Trezor Connect WebExtension package
+    import TrezorConnect, { DEVICE_EVENT, DeviceEventMessage } from '@trezor/connect-webextension';
+
+    // URL of the Trezor Connect
+    const connectSrc = 'https://connect.trezor.io/9/';
+
+    chrome.runtime.onInstalled.addListener((details: chrome.runtime.InstalledDetails) => {
+        console.log('details', details);
+
+        // Initialize Trezor Connect with the provided manifest and settings
+        TrezorConnect.init({
+            manifest: {
+                email: 'meow@example.com',
+                appUrl: 'https://yourAppUrl.com/',
+            },
+            transports: ['WebUsbTransport'], // Transport protocols to be used
+            connectSrc,
+            _extendWebextensionLifetime: true, // Makes the service worker in @trezor/connect-webextension stay alive longer.
+        });
+
+        // Event listener for Trezor device events
+        TrezorConnect.on(DEVICE_EVENT, (event: DeviceEventMessage) => {
+            console.log('EVENT in service worker', event);
+        });
+
+        // Event listener for messages from other parts of the extension
+        // This code will depend on how you handle the communication between different parts of your webextension.
+        chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+            if (message.action === 'getAddress') {
+                TrezorConnect.getAddress({
+                    showOnTrezor: true,
+                    path: "m/49'/0'/0'/0/0",
+                    coin: 'btc',
+                }).then(res => {
+                    sendResponse(res); // Send the response back to the sender
+                });
+                // Return true to indicate you want to send a response asynchronously
+                return true;
+            } else if (message.action === 'getFeatures') {
+                TrezorConnect.getFeatures().then(res => {
+                    sendResponse(res); // Send the response back to the sender
+                });
+                // Return true to indicate you want to send a response asynchronously
+                return true;
+            }
+        });
+
+    });
+
+    ````
+
+    So far your directory looks like:
+
+    ```
+    node_modules
+    src
+        service-worker.ts
+    package-lock.json
+    package.json
+    tsconfig.json
+    ```
+
+</SectionCard>
+
+<SectionCard>
+    ## Create tab that will communicate with service-worker
+    The library `@trezor/connect-webextension` is running in the service-worker because it allows the webextension to have
+    a persistent reference.
+    So if we want our front-end part of the webextension to be able to communicate with service-worker one way we can do it
+    is by using `chrome.runtime.sendMessage` and `chrome.runtime.onMessage.addListener`. Nontheless you can find other
+    ways how to do it in:  https://developer.chrome.com/docs/extensions/develop/concepts/messaging
+
+    * Create file `src/connect-manager.html`:
+
+    ```html
+    <!doctype html>
+    <html lang="en">
+        <head>
+            <meta charset="UTF-8" />
+            <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+            <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        </head>
+        <body>
+            <button id="get-features" data-testid="get-features">Get features</button>
+            <button id="get-address" data-testid="get-address">Get Address</button>
+            <div id="result"></div>
+            <script src="./connect-manager.js" type="module"></script>
+        </body>
+    </html>
+    ```
+
+    * Create file `src/connect-manager.ts`:
+
+    ```typescript
+    const result = document.getElementById('result');
+    const getAddress = document.getElementById('get-address');
+    if (getAddress) {
+        getAddress.addEventListener('click', () => {
+            // Send a message to the background script (service worker) with the action 'getAddress'
+            chrome.runtime.sendMessage({ action: 'getAddress' }, response => {
+                // Check if the response indicates success
+
+                if (response.success) {
+                    console.info(response); // Log the successful response to the console
+                    // Display the response in the 'result' element on the page
+                    if (result) {
+                        result.innerText = JSON.stringify(response);
+                    }
+                } else {
+                    console.error(response); // Log the error response to the console
+                    // Display an error message in the 'result' element on the page
+                    if (result) {
+                        result.innerText = 'Error: ' + response.error;
+                    }
+                }
+            });
+        });
+    }
+
+    const getFeatures = document.getElementById('get-features');
+    if (getFeatures) {
+        getFeatures.addEventListener('click', () => {
+            // Send a message to the background script (service worker) with the action 'getFeatures'
+            chrome.runtime.sendMessage({ action: 'getFeatures' }, response => {
+                // Check if the response indicates success
+                if (response.success) {
+                    console.info(response); // Log the successful response to the console
+                    // Display the response in the 'result' element on the page
+                    if (result) {
+                        result.innerText = JSON.stringify(response);
+                    }
+                } else {
+                    console.error(response); // Log the error response to the console
+                    // Display an error message in the 'result' element on the page
+                    if (result) {
+                        result.innerText = 'Error: ' + response.error;
+                    }
+                }
+            });
+        });
+    }
+    ```
+
+</SectionCard>
+
+<SectionCard>
+    ## Create webextension Popup window to be able to open the tab connect-manager.html
+
+    * Create file `src/popup.html`:
+
+    ```html
+    <!doctype html>
+    <html lang="en">
+        <head>
+            <meta charset="UTF-8" />
+            <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+            <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        </head>
+        <body>
+            <button id="tab">Connect manager</button>
+            <script src="./popup.js" type="module"></script>
+        </body>
+    </html>
+    ```
+
+    * Create file `src/popup.ts` that will just open connect-manager.html:
+
+    ```typescript
+    document.addEventListener('DOMContentLoaded', () => {
+        const newTabButton = document.getElementById('tab');
+        if (newTabButton) {
+            newTabButton.addEventListener('click', () => {
+                chrome.tabs.create({ url: 'connect-manager.html' });
+            });
+        }
+    });
+    ```
+
+</SectionCard>
+
+<SectionCard>
+    ## Create `manifest.json` for the webextension:
+
+    ```json
+    {
+        "name": "my-trezor-extension",
+        "version": "1.0.0",
+        "manifest_version": 3,
+        "action": {
+            "default_popup": "popup.html"
+        },
+        "background": {
+            "service_worker": "service-worker.js"
+        },
+        "permissions": ["scripting"],
+        "host_permissions": [
+            "*://connect.trezor.io/9/*",
+        ]
+    }
+    ```
+
+</SectionCard>
+
+<SectionCard>
+    ## Configure `webpack` to build the project:
+
+    * Create `webpack.config.js` file that contains:
+
+
+    ```js
+    const path = require('path');
+    const HtmlWebpackPlugin = require('html-webpack-plugin');
+    const CopyWebpackPlugin = require('copy-webpack-plugin');
+
+    module.exports = {
+        entry: {
+            popup: './src/popup.ts',
+            'service-worker': './src/service-worker.ts',
+            'connect-manager': './src/connect-manager.ts',
+        },
+        output: {
+            path: path.resolve(__dirname, 'build'),
+            filename: '[name].js',
+        },
+        resolve: {
+            extensions: ['.ts', '.js'],
+        },
+        module: {
+            rules: [
+                {
+                    test: /\.js$/,
+                    exclude: /node_modules/,
+                    use: ['babel-loader'],
+                },
+                {
+                    test: /\.ts$/,
+                    exclude: /node_modules/,
+                    use: {
+                        loader: 'babel-loader',
+                        options: {
+                            presets: ['@babel/preset-typescript'],
+                        },
+                    },
+                },
+            ],
+        },
+        plugins: [
+            new HtmlWebpackPlugin({
+                template: './src/popup.html',
+                filename: 'popup.html',
+                chunks: ['popup'],
+            }),
+            new HtmlWebpackPlugin({
+                template: './src/connect-manager.html',
+                filename: 'connect-manager.html',
+                chunks: ['connect-manager'],
+            }),
+            new CopyWebpackPlugin({
+                patterns: [{ from: 'src/manifest.json', to: 'manifest.json' }],
+            }),
+        ],
+        mode: 'development',
+        devtool: 'inline-source-map',
+    };
+    ```
+
+</SectionCard>
+<SectionCard>
+    ## Update `pacakge.json` scripts for building project:
+
+    * Execute the following commands in order to prepare the web extension:
+
+    ```json
+        ...
+        "scripts": {
+            "build": "webpack --mode production"
+        },
+        ...
+    ```
+
+</SectionCard>
+
+<SectionCard>
+    ## Your directory should look like:
+
+    ```
+    node_modules
+    src
+        connect-manager.html
+        connect-manager.ts
+        manifest.json
+        popup.html
+        popup.ts
+        service-worker.ts
+    pacakge-lock.json
+    package.json
+    tsconfig.json
+    ```
+
+</SectionCard>
+
+<SectionCard>
+    ## Build the project:
+
+    * Run the command from the "script" in package.json
+
+    ```
+    npm run build
+    ```
+
+    It will create new folder called `build`, as previously configured in `webpack.config.js` you can use
+    that folder to load the webextension in Google Chrome browser as explain in the next step.
+
+</SectionCard>
+
+<SectionCard>
+    ## Load the Web Extension in Chrome
+
+    * Open Google Chrome and navigate to the extensions page by entering the following URL in the address bar:
+
+    ```URL
+    chrome://extensions
+    ```
+
+    * Enable Developer Mode:
+
+    In the top right corner of the extensions page, toggle the "Developer mode" switch to enable it.
+
+    * Load Unpacked Extension:
+
+    Click on the "Load unpacked" button and select the directory where your web extension is located. This should be:
+
+    ```path
+    my-trezor-webextension/build
+    ```
+
+    Your extension should now be loaded and visible in the list of extensions.
+
+</SectionCard>

--- a/packages/connect-explorer/src/pages/index.mdx
+++ b/packages/connect-explorer/src/pages/index.mdx
@@ -160,6 +160,8 @@ export const ExampleHeading = styled.h3`
 
     <SdkContainer>
         <SdkDescription>
+            #### About
+
             In Node.js the core SDK is loaded as a JavaScript module without any specificities.
         </SdkDescription>
         <ExamplesAside>
@@ -253,6 +255,8 @@ export const ExampleHeading = styled.h3`
 
     <SdkContainer>
         <SdkDescription>
+            #### About
+
             `@trezor/connect-web` imports only a thin layer with API description into your 3rd party application. When initiated, it injects iframe containing core SDK logic from trezor.io
             into your app. User input, if needed, is served by popup.html page opened on trezor.io on behalf of your application. This way users input such as pin or passphrase is isolated from you and persistent connection between your app and core SDK is kept so events such as device connected/disconnected or blockchain subscriptions are available.
         </SdkDescription>
@@ -358,11 +362,28 @@ export const ExampleHeading = styled.h3`
 
     <SdkContainer>
         <SdkDescription>
+            #### About
             In case of `@trezor/connect-webextension`, TrezorConnect object is created in a service worker.
             In this env we can't inject iframe so in order to uphold the same security model as with
             `@trezor/connect-web` we open popup.html and load core SDK logic into it. This however does not
             build persistent connection between SDK and 3rd party application meaning that events cannot be
             used.
+
+            #### Learn step-by-step
+            Learn how to integrate the @trezor/connect-webextension package into a Chrome extension,
+            allowing secure connection to Trezor hardware wallets.
+            By the end, you'll have a fully functional web extension.
+
+            <Button
+                as={Link}
+                variant="tertiary"
+                className="nx-mt-4 nx-mb-8"
+                size="small"
+                icon="ARTICLE"
+                target="_self"
+                href="/guides/webextension-implementation-tutorial">
+                Open Tutorial  →
+            </Button>
         </SdkDescription>
         <ExamplesAside>
             <ExampleHeading>Examples:</ExampleHeading>


### PR DESCRIPTION
## Description

Adding a step by step tutorial to create a webextension that uses `@trezor/connect-webextension` with the help of TypeScript and Webpack.

The path in connect-explorer has to be decided still.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/13604

## Build

https://dev.suite.sldev.cz/connect/doc/tutorial-for-connect-webextension/


