### PR TITLE
feat(connect-popup): call method via URL params

### DIFF
--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -599,6 +599,7 @@ addWindowEventListener('message', handleLogMessage, false);
 
 // global method used in html-inline elements
 window.closeWindow = () => {
+    if (urlParams.get('method')) return;
     setTimeout(() => {
         window.postMessage(
             {
@@ -613,3 +614,61 @@ window.closeWindow = () => {
         window.close();
     }, 300);
 };
+
+// POC get method from search param
+// http://localhost:8088/popup.html?method=getAddress&params=%7B%22path%22:%22m/49%27/0%27/0%27/0/0%22%7D&callback=https://httpbin.org/get
+const urlParams = new URLSearchParams(window.location.search);
+const method = urlParams.get('method');
+if (method) {
+    const settings = parseConnectSettings(
+        {
+            connectSrc: location.href.split('popup.html')[0], // testing
+            debug: true,
+            transports: ['WebUsbTransport', 'BridgeTransport'],
+        },
+        window.origin, // TODO set origin properly, while allowing WebUSB cross-origin
+    );
+    console.log('settings', settings);
+    addWindowEventListener(
+        'message',
+        (event: MessageEvent<any>) => {
+            console.log('event', event.data);
+            if (event.data.type === POPUP.CORE_LOADED) {
+                handleMessageInCoreMode({
+                    data: {
+                        type: POPUP.HANDSHAKE,
+                        payload: {
+                            settings,
+                        },
+                    },
+                } as any);
+                handleMessageInCoreMode({
+                    data: {
+                        id: 1,
+                        type: IFRAME.CALL,
+                        payload: {
+                            method,
+                            ...(urlParams.get('params')
+                                ? JSON.parse(urlParams.get('params')!)
+                                : undefined),
+                        },
+                    },
+                } as any);
+            }
+            if (event.data.type === RESPONSE_EVENT) {
+                console.log('response', event.data);
+                const callback = urlParams.get('callback');
+                if (callback) {
+                    location.href = `${callback}?response=${encodeURIComponent(JSON.stringify(event.data.payload))}`;
+                }
+            }
+        },
+        false,
+    );
+    await init({
+        settings,
+        systemInfo: getSystemInfo(config.supportedBrowsers),
+        useBroadcastChannel: false,
+        useCore: true,
+    });
+}


### PR DESCRIPTION
## Description

This idea came from discussion about using deep links for Connect on mobile. 
If we have a HTTPS URL for Connect, which is handled by deep linking into the app, it's a good idea to some fallback content if the user doesn't have the app installed and opens it in a browser.
 
So I prepared a POC to support this same deep linking flow with Connect Popup, that could be used for desktop. 

With this change popup.html now supports the following URL parameters:
- method - name of method that is called
- params - JSON payload for the method
- callback - URL to where the response is redirected

For example:

https://dev.suite.sldev.cz/connect/feat/connect-popup-via-url-params/popup.html?method=getAddress&params=%7B%22path%22:%22m/49%27/0%27/0%27/0/0%22%7D&callback=https://httpbin.org/get