### PR TITLE
Enable user interaction after a revision check check fails

### DIFF
--- a/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
@@ -15,6 +15,7 @@ export const DeviceCompromised = () => {
 
     const revision = device?.features?.revision;
     const version = getFirmwareVersion(device);
+    const vendor = device?.features?.fw_vendor;
     const authenticityError =
         device?.features && device.authenticityChecks?.firmwareRevision?.success === false
             ? device.authenticityChecks.firmwareRevision?.error
@@ -28,7 +29,7 @@ export const DeviceCompromised = () => {
     };
 
     useEffect(() => {
-        const contextData = { revision, version, authenticityError };
+        const contextData = { revision, version, vendor, authenticityError };
 
         withSentryScope(scope => {
             scope.setLevel('error');
@@ -38,7 +39,7 @@ export const DeviceCompromised = () => {
                 scope,
             );
         });
-    }, [revision, version, authenticityError]);
+    }, [authenticityError, revision, vendor, version]);
 
     return (
         <WelcomeLayout>

--- a/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
@@ -1,12 +1,16 @@
-import { WelcomeLayout } from 'src/components/suite';
-import { SecurityCheckFail } from '../SecurityCheck/SecurityCheckFail';
-import { Card } from '@trezor/components';
 import { useEffect } from 'react';
-import { captureSentryMessage, withSentryScope } from '../../../utils/suite/sentry';
-import { useDevice } from '../../../hooks/suite';
+
+import { Card } from '@trezor/components';
 import { getFirmwareVersion } from '@trezor/device-utils';
 
+import { WelcomeLayout } from 'src/components/suite';
+import { useDevice, useDispatch } from 'src/hooks/suite';
+import { captureSentryMessage, withSentryScope } from 'src/utils/suite/sentry';
+import { SecurityCheckFail } from '../SecurityCheck/SecurityCheckFail';
+import { deviceActions } from '@suite-common/wallet-core';
+
 export const DeviceCompromised = () => {
+    const dispatch = useDispatch();
     const { device } = useDevice();
 
     const revision = device?.features?.revision;
@@ -15,6 +19,13 @@ export const DeviceCompromised = () => {
         device?.features && device.authenticityChecks?.firmwareRevision?.success === false
             ? device.authenticityChecks.firmwareRevision?.error
             : undefined;
+
+    const goToSuite = () => {
+        // Condition to satisfy TypeScript, device.id is always defined at this point.
+        if (device?.id) {
+            dispatch(deviceActions.dismissFirmwareRevisionCheck(device.id));
+        }
+    };
 
     useEffect(() => {
         const contextData = { revision, version, authenticityError };
@@ -32,7 +43,7 @@ export const DeviceCompromised = () => {
     return (
         <WelcomeLayout>
             <Card data-testid="@device-compromised">
-                <SecurityCheckFail />
+                <SecurityCheckFail goBack={goToSuite} />
             </Card>
         </WelcomeLayout>
     );

--- a/packages/suite/src/components/suite/SecurityCheck/SecurityCheckFail.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/SecurityCheckFail.tsx
@@ -78,12 +78,17 @@ const supportChatUrl = `${TREZOR_SUPPORT_URL}#open-chat`;
 
 interface SecurityCheckFailProps {
     goBack?: () => void;
+    useSoftMessaging?: boolean;
 }
 
-export const SecurityCheckFail = ({ goBack }: SecurityCheckFailProps) => {
-    const heading = goBack ? 'TR_DEVICE_COMPROMISED_HEADING_SOFT' : 'TR_DEVICE_COMPROMISED_HEADING';
-    const text = goBack ? 'TR_DEVICE_COMPROMISED_TEXT_SOFT' : 'TR_DEVICE_COMPROMISED_TEXT';
-    const items = goBack ? softChecklistItems : checklistItems;
+export const SecurityCheckFail = ({ goBack, useSoftMessaging }: SecurityCheckFailProps) => {
+    const heading = useSoftMessaging
+        ? 'TR_DEVICE_COMPROMISED_HEADING_SOFT'
+        : 'TR_DEVICE_COMPROMISED_HEADING';
+    const text = useSoftMessaging
+        ? 'TR_DEVICE_COMPROMISED_TEXT_SOFT'
+        : 'TR_DEVICE_COMPROMISED_TEXT';
+    const items = useSoftMessaging ? softChecklistItems : checklistItems;
 
     return (
         <SecurityCheckLayout isFailed>

--- a/packages/suite/src/components/suite/SecurityCheck/SecurityCheckFail.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/SecurityCheckFail.tsx
@@ -40,21 +40,6 @@ const checklistItems = [
     },
 ] as const;
 
-const softChecklistItems = [
-    {
-        icon: 'plugs',
-        content: <Translation id="TR_DISCONNECT_DEVICE_SOFT" />,
-    },
-    {
-        icon: 'hand',
-        content: <Translation id="TR_AVOID_USING_DEVICE_SOFT" />,
-    },
-    {
-        icon: 'chat',
-        content: <Translation id="TR_USE_CHAT_SOFT" values={{ b: chunks => <b>{chunks}</b> }} />,
-    },
-] as const;
-
 const supportChatUrl = `${TREZOR_SUPPORT_URL}#open-chat`;
 
 interface SecurityCheckFailProps {
@@ -69,7 +54,6 @@ export const SecurityCheckFail = ({ goBack, useSoftMessaging }: SecurityCheckFai
     const text = useSoftMessaging
         ? 'TR_DEVICE_COMPROMISED_TEXT_SOFT'
         : 'TR_DEVICE_COMPROMISED_TEXT';
-    const items = useSoftMessaging ? softChecklistItems : checklistItems;
 
     const { elevation } = useElevation();
 
@@ -83,7 +67,7 @@ export const SecurityCheckFail = ({ goBack, useSoftMessaging }: SecurityCheckFai
                     <Translation id={text} />
                 </Text>
             </TopSection>
-            <SecurityChecklist items={items} />
+            <SecurityChecklist items={checklistItems} />
             <Row flexWrap="wrap" gap={spacings.xl} width="100%">
                 {goBack && (
                     <StyledSecurityCheckButton variant="tertiary" onClick={goBack}>

--- a/packages/suite/src/components/suite/SecurityCheck/SecurityCheckFail.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/SecurityCheckFail.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
-import { H2, variables } from '@trezor/components';
+import { H2, Row, Text, useElevation } from '@trezor/components';
+import { Elevation, mapElevationToBorder, spacings, spacingsPx } from '@trezor/theme';
 import { TREZOR_SUPPORT_URL } from '@trezor/urls';
 
 import { Translation, TrezorLink } from 'src/components/suite';
@@ -8,30 +9,10 @@ import { SecurityChecklist } from '../../../views/onboarding/steps/SecurityCheck
 import { SecurityCheckButton } from '../../../views/onboarding/steps/SecurityCheck/SecurityCheckButton';
 import { SecurityCheckLayout } from './SecurityCheckLayout';
 
-const TopSection = styled.div`
-    border-bottom: 1px solid ${({ theme }) => theme.legacy.STROKE_GREY};
-    margin-top: 8px;
-    padding-bottom: 24px;
-    width: 100%;
-`;
-
-// eslint-disable-next-line local-rules/no-override-ds-component
-const StyledH2 = styled(H2)`
-    font-size: 28px;
-    font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
-    max-width: 300px;
-`;
-
-const Text = styled.div`
-    color: ${({ theme }) => theme.legacy.TYPE_LIGHT_GREY};
-    font-size: ${variables.FONT_SIZE.NORMAL};
-    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-`;
-
-const Buttons = styled.div`
-    display: flex;
-    flex-wrap: wrap;
-    gap: 24px;
+const TopSection = styled.div<{ $elevation: Elevation }>`
+    border-bottom: 1px solid ${mapElevationToBorder};
+    margin-top: ${spacingsPx.xs};
+    padding-bottom: ${spacingsPx.xl};
     width: 100%;
 `;
 
@@ -90,18 +71,20 @@ export const SecurityCheckFail = ({ goBack, useSoftMessaging }: SecurityCheckFai
         : 'TR_DEVICE_COMPROMISED_TEXT';
     const items = useSoftMessaging ? softChecklistItems : checklistItems;
 
+    const { elevation } = useElevation();
+
     return (
         <SecurityCheckLayout isFailed>
-            <TopSection>
-                <StyledH2>
+            <TopSection $elevation={elevation}>
+                <H2>
                     <Translation id={heading} />
-                </StyledH2>
-                <Text>
+                </H2>
+                <Text variant="tertiary">
                     <Translation id={text} />
                 </Text>
             </TopSection>
             <SecurityChecklist items={items} />
-            <Buttons>
+            <Row flexWrap="wrap" gap={spacings.xl} width="100%">
                 {goBack && (
                     <StyledSecurityCheckButton variant="tertiary" onClick={goBack}>
                         <Translation id="TR_BACK" />
@@ -112,7 +95,7 @@ export const SecurityCheckFail = ({ goBack, useSoftMessaging }: SecurityCheckFai
                         <Translation id="TR_CONTACT_TREZOR_SUPPORT" />
                     </StyledSecurityCheckButton>
                 </StyledTrezorLink>
-            </Buttons>
+            </Row>
         </SecurityCheckLayout>
     );
 };

--- a/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareRevisionCheckBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareRevisionCheckBanner.tsx
@@ -1,0 +1,36 @@
+import { selectDevice } from '@suite-common/wallet-core';
+import { Warning } from '@trezor/components';
+import { HELP_CENTER_FIRMWARE_REVISION_CHECK } from '@trezor/urls';
+
+import { Translation, TrezorLink } from 'src/components/suite';
+import { useSelector } from 'src/hooks/suite';
+
+export const FirmwareRevisionCheckBanner = () => {
+    const device = useSelector(selectDevice);
+
+    const wasOffline =
+        device?.features &&
+        device.authenticityChecks?.firmwareRevision?.success === false &&
+        device.authenticityChecks.firmwareRevision.error === 'cannot-perform-check-offline';
+    const message = wasOffline
+        ? 'TR_DEVICE_FIRMWARE_REVISION_CHECK_UNABLE_TO_PERFORM'
+        : 'TR_FIRMWARE_REVISION_CHECK_FAILED';
+
+    return (
+        <Warning
+            icon
+            variant="destructive"
+            rightContent={
+                !wasOffline && (
+                    <TrezorLink variant="nostyle" href={HELP_CENTER_FIRMWARE_REVISION_CHECK}>
+                        <Warning.Button iconAlignment="right">
+                            <Translation id="TR_LEARN_MORE" />
+                        </Warning.Button>
+                    </TrezorLink>
+                )
+            }
+        >
+            <Translation id={message} />
+        </Warning>
+    );
+};

--- a/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
@@ -1,14 +1,14 @@
 import { useState, useEffect } from 'react';
 import styled from 'styled-components';
 
-import { isDesktop } from '@trezor/env-utils';
 import { selectBannerMessage } from '@suite-common/message-system';
 import { selectDevice } from '@suite-common/wallet-core';
+import { isDesktop } from '@trezor/env-utils';
+import { spacingsPx } from '@trezor/theme';
 
 import { isTranslationMode } from 'src/utils/suite/l10n';
 import { useSelector } from 'src/hooks/suite';
 import { MAX_CONTENT_WIDTH } from 'src/constants/suite/layout';
-
 import { MessageSystemBanner } from '../MessageSystemBanner';
 import { NoConnectionBanner } from './NoConnectionBanner';
 import { UpdateBridge } from './UpdateBridgeBanner';
@@ -18,8 +18,7 @@ import { FailedBackup } from './FailedBackupBanner';
 import { SafetyChecksBanner } from './SafetyChecksBanner';
 import { TranslationMode } from './TranslationModeBanner';
 import { FirmwareHashMismatch } from './FirmwareHashMismatchBanner';
-import { UnableToPerformRevisionCheck } from './UnableToPerformRevisionCheck';
-import { spacingsPx } from '@trezor/theme';
+import { FirmwareRevisionCheckBanner } from './FirmwareRevisionCheckBanner';
 
 const Container = styled.div<{ $isVisible?: boolean }>`
     width: 100%;
@@ -64,12 +63,11 @@ export const SuiteBanners = () => {
     } else if (
         !isFirmwareRevisionCheckDisabled &&
         device?.features &&
-        device?.authenticityChecks !== undefined &&
-        device?.authenticityChecks.firmwareRevision !== null && // check was performed
-        device?.authenticityChecks.firmwareRevision.success === false &&
-        device?.authenticityChecks.firmwareRevision.error === 'cannot-perform-check-offline' // but it was not possible to finish it (user is offline & revision not found locally)
+        device.authenticityChecks !== undefined &&
+        device.authenticityChecks.firmwareRevision !== null && // check was performed
+        device.authenticityChecks.firmwareRevision.success === false
     ) {
-        banner = <UnableToPerformRevisionCheck />;
+        banner = <FirmwareRevisionCheckBanner />;
         priority = 91;
     } else if (device?.features?.unfinished_backup) {
         banner = <FailedBackup />;

--- a/packages/suite/src/components/suite/banners/SuiteBanners/UnableToPerformRevisionCheck.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/UnableToPerformRevisionCheck.tsx
@@ -1,8 +1,0 @@
-import { Translation } from 'src/components/suite';
-import { Warning } from '@trezor/components';
-
-export const UnableToPerformRevisionCheck = () => (
-    <Warning icon variant="destructive">
-        <Translation id="TR_DEVICE_FIRMWARE_REVISION_CHECK_UNABLE_TO_PERFORM" />
-    </Warning>
-);

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -4356,6 +4356,10 @@ export default defineMessages({
         defaultMessage:
             'To create additional addresses for a coinjoin account, you must ensure that you have already received bitcoin at the initial address.',
     },
+    TR_RECEIVE_ADDRESS_SECURITY_CHECK_FAILED: {
+        id: 'TR_RECEIVE_ADDRESS_SECURITY_CHECK_FAILED',
+        defaultMessage: 'Your device may have been compromised. Do not send funds to it.',
+    },
     RECEIVE_ADDRESS_LIMIT_REACHED: {
         id: 'RECEIVE_ADDRESS_LIMIT_REACHED',
         defaultMessage: "You've reached the maximum limit of 21 fresh, unused addresses",
@@ -6982,6 +6986,10 @@ export default defineMessages({
         id: 'TR_DEVICE_FIRMWARE_REVISION_CHECK_MODAL_DESCRIPTION_3',
         defaultMessage:
             'Trezor Support will never ask you to turn off the firmware revision check. This feature is designed to protect your security.',
+    },
+    TR_FIRMWARE_REVISION_CHECK_FAILED: {
+        id: 'TR_FIRMWARE_REVISION_CHECK_FAILED',
+        defaultMessage: 'Firmware revision check failed. Your Trezor may be counterfeit.',
     },
     TR_DEVICE_FIRMWARE_REVISION_CHECK_UNABLE_TO_PERFORM: {
         id: 'TR_DEVICE_FIRMWARE_REVISION_CHECK_UNABLE_TO_PERFORM',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -6813,18 +6813,6 @@ export default defineMessages({
         id: 'TR_USE_CHAT',
         defaultMessage: 'Click below and use the <b>Chat</b> option on the next page.',
     },
-    TR_DISCONNECT_DEVICE_SOFT: {
-        id: 'TR_DISCONNECT_DEVICE_SOFT',
-        defaultMessage: 'Disconnect your device from your laptop or computer.',
-    },
-    TR_AVOID_USING_DEVICE_SOFT: {
-        id: 'TR_AVOID_USING_DEVICE_SOFT',
-        defaultMessage: 'Avoid using this device or sending any funds to it.',
-    },
-    TR_USE_CHAT_SOFT: {
-        id: 'TR_USE_CHAT_SOFT',
-        defaultMessage: 'Click below and use the <b>Chat</b> option on the next screen.',
-    },
     TR_CONTACT_TREZOR_SUPPORT: {
         id: 'TR_CONTACT_TREZOR_SUPPORT',
         defaultMessage: 'Contact Trezor Support',

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheck.tsx
@@ -257,7 +257,7 @@ const SecurityCheckContent = ({
     }, [initialized, isRecoveryInProgress, updateAnalytics]);
 
     return isFailed ? (
-        <SecurityCheckFail goBack={toggleView} />
+        <SecurityCheckFail useSoftMessaging goBack={toggleView} />
     ) : (
         <SecurityCheckLayout>
             <Content>

--- a/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
+++ b/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
@@ -8,7 +8,11 @@ import { useDispatch, useSelector } from 'src/hooks/suite/';
 
 import { Button, Card, variables, H2, Tooltip, GradientOverlay } from '@trezor/components';
 import { getFirstFreshAddress } from '@suite-common/wallet-utils';
-import { AccountsRootState, selectIsAccountUtxoBased } from '@suite-common/wallet-core';
+import {
+    AccountsRootState,
+    selectFailedSecurityChecks,
+    selectIsAccountUtxoBased,
+} from '@suite-common/wallet-core';
 import { networks } from '@suite-common/wallet-config';
 import { EvmExplanationBox } from 'src/components/wallet/EvmExplanationBox';
 import { spacingsPx, typography } from '@trezor/theme';
@@ -126,6 +130,7 @@ export const FreshAddress = ({
     const isAccountUtxoBased = useSelector((state: AccountsRootState) =>
         selectIsAccountUtxoBased(state, account?.key ?? ''),
     );
+    const hasFailedSecurityChecks = useSelector(selectFailedSecurityChecks).length > 0;
     const dispatch = useDispatch();
 
     const firstFreshAddress = useMemo(() => {
@@ -157,6 +162,9 @@ export const FreshAddress = ({
         if (!firstFreshAddress) {
             return <Translation id="RECEIVE_ADDRESS_LIMIT_REACHED" />;
         }
+        if (hasFailedSecurityChecks) {
+            return <Translation id="TR_RECEIVE_ADDRESS_SECURITY_CHECK_FAILED" />;
+        }
 
         return null;
     };
@@ -164,7 +172,12 @@ export const FreshAddress = ({
     const buttonRevealAddressProps = {
         'data-testid': '@wallet/receive/reveal-address-button',
         onClick: handleAddressReveal,
-        isDisabled: disabled || locked || coinjoinDisallowReveal || !firstFreshAddress,
+        isDisabled:
+            disabled ||
+            locked ||
+            coinjoinDisallowReveal ||
+            !firstFreshAddress ||
+            hasFailedSecurityChecks,
         isLoading: locked,
     };
 

--- a/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
+++ b/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
@@ -2,17 +2,18 @@ import { useState } from 'react';
 import styled from 'styled-components';
 
 import { AccountAddress } from '@trezor/connect';
-import { Card, Button, GradientOverlay, Column } from '@trezor/components';
-import { Translation, MetadataLabeling, FormattedCryptoAmount } from 'src/components/suite';
-import { formatNetworkAmount } from '@suite-common/wallet-utils';
+import { Card, Button, Column, GradientOverlay, Tooltip } from '@trezor/components';
+import { spacings, spacingsPx, typography } from '@trezor/theme';
 import { NetworkCompatible } from '@suite-common/wallet-config';
+import { selectFailedSecurityChecks } from '@suite-common/wallet-core';
+import { formatNetworkAmount } from '@suite-common/wallet-utils';
+
+import { Translation, MetadataLabeling, FormattedCryptoAmount } from 'src/components/suite';
 import { AppState } from 'src/types/suite';
 import { MetadataAddPayload } from 'src/types/suite/metadata';
 import { showAddress } from 'src/actions/wallet/receiveActions';
-import { useDispatch } from 'src/hooks/suite/';
-import { useSelector } from 'src/hooks/suite/useSelector';
+import { useDispatch, useSelector } from 'src/hooks/suite/';
 import { selectLabelingDataForSelectedAccount } from 'src/reducers/suite/metadataReducer';
-import { spacings, spacingsPx, typography } from '@trezor/theme';
 
 const GridTable = styled.div`
     display: grid;
@@ -103,14 +104,16 @@ interface ItemProps {
 }
 
 const Item = ({ addr, locked, symbol, onClick, metadataPayload, index }: ItemProps) => {
-    // Currently used addresses are always partially hidden
-    // The only place where full address is shown is confirm-addr modal
-
+    const hasFailedSecurityChecks = useSelector(selectFailedSecurityChecks).length > 0;
     const [isHovered, setIsHovered] = useState(false);
 
     const amount = formatNetworkAmount(addr.received || '0', symbol);
     const fresh = !addr.transfers;
     const address = addr.address.substring(0, 20);
+    const isDisabled = locked || hasFailedSecurityChecks;
+    const tooltipContent = isDisabled ? (
+        <Translation id="TR_RECEIVE_ADDRESS_SECURITY_CHECK_FAILED" />
+    ) : null;
 
     return (
         <>
@@ -138,16 +141,18 @@ const Item = ({ addr, locked, symbol, onClick, metadataPayload, index }: ItemPro
                 onMouseLeave={() => setIsHovered(false)}
             >
                 <AddressActions $isVisible={isHovered}>
-                    <Button
-                        data-testid={`@wallet/receive/reveal-address-button/${index}`}
-                        variant="tertiary"
-                        isDisabled={locked}
-                        isLoading={locked}
-                        onClick={onClick}
-                        size="tiny"
-                    >
-                        <Translation id="TR_REVEAL_ADDRESS" />
-                    </Button>
+                    <Tooltip content={tooltipContent}>
+                        <Button
+                            data-testid={`@wallet/receive/reveal-address-button/${index}`}
+                            variant="tertiary"
+                            isDisabled={isDisabled}
+                            isLoading={locked}
+                            onClick={onClick}
+                            size="tiny"
+                        >
+                            <Translation id="TR_REVEAL_ADDRESS" />
+                        </Button>
+                    </Tooltip>
                 </AddressActions>
             </GridItemRevealAddress>
 

--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -90,6 +90,8 @@ export const HELP_CENTER_TRANSACTION_FEES_URL =
     'https://trezor.io/learn/a/transaction-fees-in-trezor-suite';
 export const HELP_CENTER_EVM_ADDRESS_CHECKSUM =
     'https://trezor.io/learn/a/evm-address-checksum-in-trezor-suite';
+export const HELP_CENTER_FIRMWARE_REVISION_CHECK =
+    'https://trezor.io/learn/a/trezor-firmware-revision-check';
 
 export const INVITY_URL = 'https://invity.io/';
 export const INVITY_SCHEDULE_OF_FEES = 'https://blog.invity.io/schedule-of-fees';

--- a/suite-common/wallet-core/src/device/deviceActions.ts
+++ b/suite-common/wallet-core/src/device/deviceActions.ts
@@ -80,11 +80,17 @@ export const removeButtonRequests = createAction(
     }),
 );
 
+const dismissFirmwareRevisionCheck = createAction(
+    `${DEVICE_MODULE_PREFIX}/dismissFirmwareRevisionCheck`,
+    (payload: string) => ({ payload }),
+);
+
 export const deviceActions = {
     connectDevice,
     connectUnacquiredDevice,
     deviceChanged,
     deviceDisconnect,
+    dismissFirmwareRevisionCheck,
     updatePassphraseMode,
     receiveAuthConfirm,
     rememberDevice,

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -3,7 +3,7 @@ import { isAnyOf } from '@reduxjs/toolkit';
 
 import * as deviceUtils from '@suite-common/suite-utils';
 import { getDeviceInstances, getStatus } from '@suite-common/suite-utils';
-import { Device, Features, UI } from '@trezor/connect';
+import { Device, Features, FirmwareRevisionCheckResult, UI } from '@trezor/connect';
 import {
     getFirmwareVersion,
     getFirmwareVersionArray,
@@ -31,16 +31,15 @@ export type State = {
     devices: TrezorDevice[];
     selectedDevice?: TrezorDevice;
     deviceAuthenticity?: Record<string, StoredAuthenticateDeviceResult>;
+    dismissedSecurityChecks?: {
+        firmwareRevision?: string[];
+    };
 };
 
 const initialState: State = { devices: [], selectedDevice: undefined };
 
 export type DeviceRootState = {
-    device: {
-        devices: TrezorDevice[];
-        selectedDevice?: TrezorDevice;
-        deviceAuthenticity?: State['deviceAuthenticity'];
-    };
+    device: State;
 };
 
 // Use the negated form as it better fits the call sites.
@@ -586,6 +585,18 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(initialState, (bu
         .addCase(deviceAuthenticityActions.result, (state, { payload }) => {
             setDeviceAuthenticity(state, payload.device, payload.result);
         })
+        .addCase(deviceActions.dismissFirmwareRevisionCheck, (state, { payload }) => {
+            if (!state.dismissedSecurityChecks) {
+                state.dismissedSecurityChecks = {};
+            }
+            if (!state.dismissedSecurityChecks.firmwareRevision) {
+                state.dismissedSecurityChecks.firmwareRevision = [];
+            }
+            state.dismissedSecurityChecks.firmwareRevision = [
+                payload,
+                ...state.dismissedSecurityChecks.firmwareRevision,
+            ];
+        })
         .addCase(extra.actionTypes.setDeviceMetadata, extra.reducers.setDeviceMetadataReducer)
         .addCase(
             extra.actionTypes.setDeviceMetadataPasswords,
@@ -770,6 +781,27 @@ export const selectSelectedDeviceAuthenticity = (state: DeviceRootState) => {
     const deviceAuthenticity = selectDeviceAuthenticity(state);
 
     return device?.id ? deviceAuthenticity?.[device.id] : undefined;
+};
+
+export const selectFailedSecurityChecks = (state: DeviceRootState) => {
+    const device = selectDevice(state);
+
+    return device && 'authenticityChecks' in device && device.authenticityChecks !== undefined
+        ? Object.values(device.authenticityChecks).filter(
+              // If `check` is null, it means that it was not performed yet.
+              // If Suite is offline and we cannot perform check, the error banner shows to urge user to go online.
+              (check): check is FirmwareRevisionCheckResult =>
+                  check?.success === false && check?.error !== 'cannot-perform-check-offline',
+          )
+        : [];
+};
+
+export const selectIsFirmwareRevisionCheckDismissed = (state: DeviceRootState): boolean => {
+    const device = selectDevice(state);
+
+    return !!(
+        device?.id && state.device.dismissedSecurityChecks?.firmwareRevision?.includes(device.id)
+    );
 };
 
 export const selectIsPortfolioTrackerDevice = (state: DeviceRootState) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This should allow users with a scammy firmware to access Suite and attempt to send funds away. Generating new addresses is disabled.

@MiroslavProchazka please check copy. Note that the instructions in the initial modal don't explicitly guide you to send funds away from it (I am not saying it has to be there).

<!--- Describe your changes in detail -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite-private/issues/110

## Screenshots:
![Screenshot 2024-08-30 at 17 09 43](https://github.com/user-attachments/assets/4f481bcd-78ce-4970-96c5-5fdef94a60df)
![Screenshot 2024-08-30 at 17 09 55](https://github.com/user-attachments/assets/490d3f92-bd87-484f-85af-39103d4513ac)
![Screenshot 2024-08-30 at 17 10 08](https://github.com/user-attachments/assets/ec92641c-2cd1-4f1c-82aa-036015a3f307)
![Screenshot 2024-08-30 at 17 10 16](https://github.com/user-attachments/assets/84e34ce2-939a-49e7-8478-2f8653f979e1)
