### PR TITLE
chore(suite): Add error rule for not overriding components and product-components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -295,7 +295,11 @@ module.exports = {
             'error',
             { blankLine: 'always', prev: '*', next: 'return' },
         ],
-        'local-rules/no-override-ds-component': ['warn', { packageName: '@trezor/components' }],
+        'local-rules/no-override-ds-component': ['error', { packageName: '@trezor/components' }],
+        'local-rules/no-override-ds-component': [
+            'error',
+            { packageName: '@trezor/product-components' },
+        ],
     },
     overrides: [
         {

--- a/packages/components/src/components/AutoScalingInput/AutoScalingInputExamples.stories.tsx
+++ b/packages/components/src/components/AutoScalingInput/AutoScalingInputExamples.stories.tsx
@@ -8,6 +8,7 @@ const Wrapper = styled.div`
     flex-direction: column;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const BorderAutoScalingInput = styled(Input)`
     padding: 1px 5px;
     border-radius: 3px;
@@ -15,6 +16,7 @@ const BorderAutoScalingInput = styled(Input)`
     border-width: 1px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const BorderlessAutoScalingInput = styled(Input)`
     padding: 1px 5px;
     border-style: solid;

--- a/packages/components/src/components/DataAnalytics.tsx
+++ b/packages/components/src/components/DataAnalytics.tsx
@@ -30,6 +30,7 @@ const ButtonWrapper = styled.div`
     align-self: center;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     min-width: 180px;
 `;

--- a/packages/components/src/components/NewModal/NewModal.tsx
+++ b/packages/components/src/components/NewModal/NewModal.tsx
@@ -61,6 +61,7 @@ const HeadingContainer = styled.div`
     overflow: hidden;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Heading = styled(H3)`
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/packages/components/src/components/Note/Note.tsx
+++ b/packages/components/src/components/Note/Note.tsx
@@ -11,6 +11,7 @@ const Row = styled.div`
     gap: ${spacingsPx.xs};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledParagraph = styled(Paragraph)<{ $color?: string }>`
     color: ${({ $color }) => $color};
 `;

--- a/packages/components/src/components/RotateDeviceImage/RotateDeviceImage.tsx
+++ b/packages/components/src/components/RotateDeviceImage/RotateDeviceImage.tsx
@@ -12,6 +12,7 @@ export type RotateDeviceImageProps = {
     animationWidth?: string;
 };
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledImage = styled(Image)`
     /* do not apply the darkening filter in dark mode on device images */
     filter: none;

--- a/packages/components/src/components/buttons/TooltipButton/TooltipButton.tsx
+++ b/packages/components/src/components/buttons/TooltipButton/TooltipButton.tsx
@@ -5,6 +5,7 @@ import { Button, ButtonProps } from '../Button/Button';
 import { spacingsPx } from '@trezor/theme';
 import { Icon } from '../../Icon/Icon';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     position: relative;
     padding-inline: ${spacingsPx.xxl};

--- a/packages/components/src/components/modals/Modal/Modal.tsx
+++ b/packages/components/src/components/modals/Modal/Modal.tsx
@@ -54,6 +54,7 @@ const Header = styled.header<HeaderProps>`
 `;
 
 const BACK_ICON_WIDTH = spacingsPx.xxxl;
+// eslint-disable-next-line local-rules/no-override-ds-component
 const BackIcon = styled(Icon)`
     position: relative;
     width: ${BACK_ICON_WIDTH};
@@ -94,6 +95,7 @@ type HeadingSize = keyof typeof HEADING_SIZES;
 
 type HeadingProps = { $isWithIcon?: boolean; $headingSize: HeadingSize };
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Heading = styled(H3)<HeadingProps>`
     ${({ $isWithIcon }) =>
         $isWithIcon &&

--- a/packages/components/src/components/skeletons/SkeletonSpread.tsx
+++ b/packages/components/src/components/skeletons/SkeletonSpread.tsx
@@ -5,6 +5,7 @@ export interface SkeletonSpreadProps extends SkeletonStackProps {
     $spaceAround?: boolean;
 }
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 export const SkeletonSpread = styled(SkeletonStack)<SkeletonSpreadProps>`
     justify-content: ${props => (props.$spaceAround ? 'space-around' : 'space-between')};
 `;

--- a/packages/connect-explorer/src/components/ApiPlayground.tsx
+++ b/packages/connect-explorer/src/components/ApiPlayground.tsx
@@ -39,6 +39,7 @@ const ApiPlaygroundWrapper = styled.div`
     } */
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const CollapsibleBoxStyled = styled(CollapsibleBox)`
     margin: 0;
     border: 0;

--- a/packages/connect-explorer/src/components/CommonParamsLink.tsx
+++ b/packages/connect-explorer/src/components/CommonParamsLink.tsx
@@ -6,6 +6,7 @@ const Floating = styled.div`
     margin-top: -2rem;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledLink = styled(Link)`
     color: ${({ theme }) => theme.textPrimaryDefault};
     text-decoration: underline;

--- a/packages/connect-explorer/src/components/Method.tsx
+++ b/packages/connect-explorer/src/components/Method.tsx
@@ -181,6 +181,7 @@ const Container = styled.div`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Heading = styled(H3)`
     font-size: 16px;
     font-weight: 600;
@@ -211,6 +212,7 @@ const Sticky = styled.div`
     width: 100%;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Button = styled(TrezorButton)`
     margin-top: ${spacingsPx.sm};
 `;

--- a/packages/connect-explorer/src/components/Param.tsx
+++ b/packages/connect-explorer/src/components/Param.tsx
@@ -54,6 +54,8 @@ const ParamType = styled.div<{
         text-decoration: underline;
     `}
 `;
+
+// eslint-disable-next-line local-rules/no-override-ds-component
 const ParamBadge = styled(Badge)`
     cursor: default;
 `;

--- a/packages/connect-explorer/src/components/fields/BatchWrapper.tsx
+++ b/packages/connect-explorer/src/components/fields/BatchWrapper.tsx
@@ -9,6 +9,7 @@ interface BatchWrapperProps {
     onRemove: () => void;
 }
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Wrapper = styled(Card)`
     display: flex;
     flex-direction: row;

--- a/packages/connect-explorer/src/pages/index.mdx
+++ b/packages/connect-explorer/src/pages/index.mdx
@@ -21,9 +21,9 @@ import IconWeb from '../components/icons/IconWeb';
 import IconExtension from '../components/icons/IconExtension';
 import ZoomableIllustration from '../components/ZoomableIllustration';
 
-export const SectionCard = styled(TrezorCard)`
-    margin-bottom: ${spacingsPx.xl};
-`;
+export const SectionCard = ({ children }) => (
+    <TrezorCard margin={{ bottom: spacings.xl }}>{children}</TrezorCard>
+);
 
 export const SdkHeading = styled.h2`
     display: flex;
@@ -137,19 +137,19 @@ export const ExampleHeading = styled.h3`
         <IconNode />
         <SdkName>Node.js</SdkName>
         <SdkTag></SdkTag>
-        <Button 
+        <Button
             as={Link}
-            variant="tertiary" 
-            size="small" 
-            icon="ARTICLE" 
+            variant="tertiary"
+            size="small"
+            icon="ARTICLE"
             href="/readme/connect">
             README
         </Button>
-        <Button 
-            as="a" 
-            variant="tertiary" 
-            size="small" 
-            icon="GITHUB" 
+        <Button
+            as="a"
+            variant="tertiary"
+            size="small"
+            icon="GITHUB"
             href="https://github.com/trezor/trezor-suite/tree/develop/packages/connect"
             target="_blank">
             View on Github
@@ -230,19 +230,19 @@ export const ExampleHeading = styled.h3`
         <IconWeb />
         <SdkName>Web</SdkName>
         <SdkTag>DOM required</SdkTag>
-        <Button 
+        <Button
             as={Link}
-            variant="tertiary" 
-            size="small" 
-            icon="ARTICLE" 
+            variant="tertiary"
+            size="small"
+            icon="ARTICLE"
             href="/readme/connect-web">
             README
         </Button>
-        <Button 
-            as="a" 
-            variant="tertiary" 
-            size="small" 
-            icon="GITHUB" 
+        <Button
+            as="a"
+            variant="tertiary"
+            size="small"
+            icon="GITHUB"
             href="https://github.com/trezor/trezor-suite/tree/develop/packages/connect-web"
             target="_blank">
             View on Github
@@ -335,19 +335,19 @@ export const ExampleHeading = styled.h3`
         <IconExtension />
         <SdkName>Web extension</SdkName>
         <SdkTag>Using service worker</SdkTag>
-        <Button 
+        <Button
             as={Link}
-            variant="tertiary" 
-            size="small" 
-            icon="ARTICLE" 
+            variant="tertiary"
+            size="small"
+            icon="ARTICLE"
             href="/readme/connect-webextension">
             README
         </Button>
-        <Button 
-            as="a" 
-            variant="tertiary" 
-            size="small" 
-            icon="GITHUB" 
+        <Button
+            as="a"
+            variant="tertiary"
+            size="small"
+            icon="GITHUB"
             href="https://github.com/trezor/trezor-suite/tree/develop/packages/connect-webextension"
             target="_blank">
             View on Github

--- a/packages/connect-popup/src/log.tsx
+++ b/packages/connect-popup/src/log.tsx
@@ -30,6 +30,7 @@ const Layout = styled.div`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledP = styled(Paragraph)`
     margin: 0 20%;
     color: #757575;

--- a/packages/connect-ui/src/components/AnalyticsConsentWrapper.tsx
+++ b/packages/connect-ui/src/components/AnalyticsConsentWrapper.tsx
@@ -7,6 +7,7 @@ const Wrapper = styled.div`
     animation: ${animations.FADE_IN} 0.15s ease-in-out;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledDataAnalytics = styled(DataAnalytics)`
     box-shadow: 0 0 6px 1px #e3e3e3;
 `;

--- a/packages/connect-ui/src/components/Notification.tsx
+++ b/packages/connect-ui/src/components/Notification.tsx
@@ -43,6 +43,7 @@ const NotificationCta = styled.div`
     padding-top: 8px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     width: 100%;
     border: 1px solid #eb8a00;

--- a/packages/connect-ui/src/components/Passphrase/PassphraseTypeCard.tsx
+++ b/packages/connect-ui/src/components/Passphrase/PassphraseTypeCard.tsx
@@ -112,6 +112,7 @@ const Spacer = styled.div`
     margin: ${spacingsPx.md} 0;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const PassphraseInput = styled(Input)`
     input {
         color: ${({ theme }) => theme.textSubdued};
@@ -130,6 +131,7 @@ const Actions = styled.div`
     justify-content: center;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const ActionButton = styled(Button)`
     margin-top: ${spacingsPx.xs};
 

--- a/packages/connect-ui/src/components/Passphrase/PassphraseTypeCardContent.tsx
+++ b/packages/connect-ui/src/components/Passphrase/PassphraseTypeCardContent.tsx
@@ -21,6 +21,7 @@ import { useKeyPress } from '@trezor/react-utils';
 import { WalletType } from './types';
 import { DOT } from './consts';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const PassphraseInput = styled(Input)`
     input {
         color: ${({ theme }) => theme.textSubdued};
@@ -35,6 +36,7 @@ const Actions = styled.div`
     justify-content: center;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const ActionButton = styled(Button)`
     margin-top: ${spacingsPx.xs};
 

--- a/packages/connect-ui/src/components/Passphrase/PassphraseTypeCardHeading.tsx
+++ b/packages/connect-ui/src/components/Passphrase/PassphraseTypeCardHeading.tsx
@@ -27,6 +27,7 @@ const Description = styled.div<{ $hasTopMargin?: boolean }>`
     ${typography.label}
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const ArrowCol = styled(Column)`
     flex: 0 0 auto;
     height: 100%;

--- a/packages/connect-ui/src/components/View.tsx
+++ b/packages/connect-ui/src/components/View.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import { H3, Paragraph, variables } from '@trezor/components';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Title = styled(H3)`
     font-size: 19px;
     color: #333;
@@ -11,6 +12,7 @@ const Title = styled(H3)`
     text-align: center;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledP = styled(Paragraph)`
     margin: 0 20%;
     color: #757575;

--- a/packages/connect-ui/src/views/Error.tsx
+++ b/packages/connect-ui/src/views/Error.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import { Button, CollapsibleBox, colors, Icon, IconName, variables } from '@trezor/components';
 import { isFirefox } from '@trezor/env-utils';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const WhiteCollapsibleBox = styled(CollapsibleBox)`
     background: ${({ theme }) => theme.legacy.BG_WHITE};
     width: 500px;

--- a/packages/product-components/src/components/ConfirmOnDevice/ConfirmOnDeviceContent.tsx
+++ b/packages/product-components/src/components/ConfirmOnDevice/ConfirmOnDeviceContent.tsx
@@ -84,6 +84,7 @@ const Step = styled.div<{ $isActive: boolean }>`
         `}
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledRotateDeviceImage = styled(RotateDeviceImage)`
     height: 34px;
 `;

--- a/packages/product-components/src/components/PassphraseTypeCard/PassphraseTypeCardContent.tsx
+++ b/packages/product-components/src/components/PassphraseTypeCard/PassphraseTypeCardContent.tsx
@@ -18,6 +18,7 @@ import { ChangeEvent, MutableRefObject, ReactNode, RefObject } from 'react';
 import { WalletType } from './types';
 import { DOT } from './consts';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const PassphraseInput = styled(Input)`
     input {
         color: ${({ theme }) => theme.textSubdued};
@@ -32,6 +33,7 @@ const Actions = styled.div`
     justify-content: center;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const ActionButton = styled(Button)`
     margin-top: ${spacingsPx.xs};
 

--- a/packages/product-components/src/components/PassphraseTypeCard/PassphraseTypeCardHeading.tsx
+++ b/packages/product-components/src/components/PassphraseTypeCard/PassphraseTypeCardHeading.tsx
@@ -24,6 +24,7 @@ const Description = styled.div<{ $hasTopMargin?: boolean }>`
     ${typography.label}
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const ArrowCol = styled(Column)`
     flex: 0 0 auto;
     height: 100%;

--- a/packages/suite-desktop-ui/src/support/DesktopUpdater/Available.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater/Available.tsx
@@ -9,6 +9,7 @@ import { useDispatch } from 'src/hooks/suite';
 import { getReleaseUrl } from 'src/services/github';
 import { download } from 'src/actions/suite/desktopUpdateActions';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const GreenH2 = styled(H2)`
     text-align: left;
     color: ${({ theme }) => theme.legacy.TYPE_GREEN};
@@ -23,6 +24,7 @@ const ChangelogWrapper = styled.div`
     padding: 16px 20px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledLink = styled(Link)`
     align-self: start;
 `;

--- a/packages/suite-desktop-ui/src/support/DesktopUpdater/Downloading.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater/Downloading.tsx
@@ -28,11 +28,13 @@ const TotalData = styled.span`
     color: ${({ theme }) => theme.legacy.TYPE_LIGHT_GREY};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Text = styled(H2)`
     color: ${({ theme }) => theme.legacy.TYPE_DARK_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledProgressBar = styled(ProgressBar)`
     margin-top: 16px;
 `;

--- a/packages/suite-desktop-ui/src/support/DesktopUpdater/EarlyAccessDisable.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater/EarlyAccessDisable.tsx
@@ -24,6 +24,7 @@ const StyledModal = styled(Modal)`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const LinkButton = styled(Button)`
     width: 100%;
 `;

--- a/packages/suite-desktop-ui/src/support/DesktopUpdater/styles.ts
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater/styles.ts
@@ -39,11 +39,13 @@ export const ButtonWrapper = styled.div`
     padding-top: 24px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 export const Title = styled(H2)`
     padding-top: 24px;
     padding-bottom: 12px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 export const Description = styled(Paragraph)`
     font-size: ${variables.FONT_SIZE.SMALL};
     color: ${({ theme }) => theme.legacy.TYPE_LIGHT_GREY};

--- a/packages/suite-desktop-ui/src/support/screens/TorLoadingScreen.tsx
+++ b/packages/suite-desktop-ui/src/support/screens/TorLoadingScreen.tsx
@@ -15,6 +15,7 @@ const Wrapper = styled.div`
     gap: 16px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledModal = styled(Modal)`
     max-width: 600px;
 `;

--- a/packages/suite/src/components/backup/BackupSeedCard.tsx
+++ b/packages/suite/src/components/backup/BackupSeedCard.tsx
@@ -3,6 +3,7 @@ import styled, { useTheme } from 'styled-components';
 import { variables, Checkbox, Card, Icon, IconName } from '@trezor/components';
 import { spacingsPx, typography } from '@trezor/theme';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledCheckbox = styled(Checkbox)`
     /* so the entire card acts as a checkbox */
     position: absolute;
@@ -28,6 +29,7 @@ const StyledCheckbox = styled(Checkbox)`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Container = styled(Card)<{ $checked: boolean }>`
     position: relative;
 

--- a/packages/suite/src/components/dashboard/DashboardSection.tsx
+++ b/packages/suite/src/components/dashboard/DashboardSection.tsx
@@ -12,6 +12,7 @@ const Header = styled.div`
     padding-bottom: 25px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Title = styled(H3)`
     display: flex;
     align-items: center;

--- a/packages/suite/src/components/firmware/Buttons/FirmwareContinueButton.tsx
+++ b/packages/suite/src/components/firmware/Buttons/FirmwareContinueButton.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { Button, ButtonProps } from '@trezor/components';
 import { Translation } from 'src/components/suite';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     min-width: 180px;
 `;

--- a/packages/suite/src/components/firmware/CheckSeedStep.tsx
+++ b/packages/suite/src/components/firmware/CheckSeedStep.tsx
@@ -11,6 +11,7 @@ import { goto } from 'src/actions/suite/routerActions';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { spacingsPx } from '@trezor/theme';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledCheckbox = styled(Checkbox)`
     margin: ${spacingsPx.md} 0;
 `;

--- a/packages/suite/src/components/firmware/FirmwareProgressBar.tsx
+++ b/packages/suite/src/components/firmware/FirmwareProgressBar.tsx
@@ -24,6 +24,8 @@ const Label = styled.div`
     margin-right: ${spacingsPx.lg};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
+
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledProgressBar = styled(ProgressBar)`
     display: flex;
     margin-right: ${spacingsPx.lg};

--- a/packages/suite/src/components/firmware/FirmwareSwitchWarning.tsx
+++ b/packages/suite/src/components/firmware/FirmwareSwitchWarning.tsx
@@ -11,6 +11,7 @@ const Row = styled.div`
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledImage = styled(Image)`
     width: 48px;
 `;

--- a/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
+++ b/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
@@ -80,6 +80,7 @@ const CenteredPointText = styled(BulletPointText)`
     text-align: center;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledDeviceAnimation = styled(DeviceAnimation)`
     flex: 0 0 220px;
     width: 220px;
@@ -96,6 +97,7 @@ const StyledConfirmImage = styled(DeviceConfirmImage)`
     height: 200px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Heading = styled(H2)`
     margin-bottom: 16px;
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};

--- a/packages/suite/src/components/firmware/SelectCustomFirmware.tsx
+++ b/packages/suite/src/components/firmware/SelectCustomFirmware.tsx
@@ -24,6 +24,7 @@ const StyledDropZone = styled(DropZone)`
     min-height: 120px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const InstallButton = styled(Button)`
     margin: ${spacingsPx.xxl} auto 0;
 `;

--- a/packages/suite/src/components/guide/Feedback.tsx
+++ b/packages/suite/src/components/guide/Feedback.tsx
@@ -29,6 +29,7 @@ const Headline = styled.div`
     width: 100%;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Submit = styled(Button)`
     width: 100%;
     margin: 0 0 20px;
@@ -80,6 +81,7 @@ const AnonymousDataItem = styled.li`
     color: ${({ theme }) => theme.legacy.TYPE_DARK_GREY};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledTextarea = styled(Textarea)`
     margin-bottom: ${spacingsPx.md};
 `;

--- a/packages/suite/src/components/guide/GuideHint.tsx
+++ b/packages/suite/src/components/guide/GuideHint.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { Warning } from '@trezor/components';
 import { typography } from '@trezor/theme';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledWarning = styled(Warning)`
     background: ${({ theme }) => theme.backgroundSurfaceElevation1};
     color: ${({ theme }) => theme.textDefault};

--- a/packages/suite/src/components/guide/GuideRouter.tsx
+++ b/packages/suite/src/components/guide/GuideRouter.tsx
@@ -31,6 +31,7 @@ const smoothBlur = keyframes`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledBackdrop = styled(Backdrop)`
     animation: ${smoothBlur} 0.3s ease-in forwards;
     z-index: ${zIndices.guide};

--- a/packages/suite/src/components/guide/SupportFeedbackSelection.tsx
+++ b/packages/suite/src/components/guide/SupportFeedbackSelection.tsx
@@ -49,6 +49,7 @@ const SectionButton = styled.button<{ $hasBackground?: boolean }>`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledLink = styled(Link)`
     width: 100%;
 `;
@@ -72,6 +73,7 @@ const DetailItem = styled.div`
     align-items: center;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledIcon = styled(Icon)`
     padding: 0 6px;
 `;

--- a/packages/suite/src/components/onboarding/Buttons/OnboardingButtonCta.tsx
+++ b/packages/suite/src/components/onboarding/Buttons/OnboardingButtonCta.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { Button, ButtonProps } from '@trezor/components';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     min-width: 180px;
 `;

--- a/packages/suite/src/components/onboarding/CollapsibleOnboardingCard.tsx
+++ b/packages/suite/src/components/onboarding/CollapsibleOnboardingCard.tsx
@@ -130,6 +130,7 @@ const ChildrenWrapper = styled.div`
     align-items: center;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Heading = styled(H2)<{ $withDescription?: boolean }>`
     font-size: 28px;
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};

--- a/packages/suite/src/components/onboarding/Hologram.tsx
+++ b/packages/suite/src/components/onboarding/Hologram.tsx
@@ -21,6 +21,7 @@ const AnimationWrapper = styled.div`
     margin: 8px 0;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledWarning = styled(Warning)`
     ${typography.hint}
 

--- a/packages/suite/src/components/onboarding/OnboardingStepBox.tsx
+++ b/packages/suite/src/components/onboarding/OnboardingStepBox.tsx
@@ -37,6 +37,7 @@ const OuterActions = styled.div<{ $smallMargin?: boolean }>`
     z-index: ${zIndices.onboardingForeground};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 export const StyledBackdrop = styled(Backdrop)<{ $show: boolean }>`
     transition: all 0.3s;
     opacity: ${({ $show }) => ($show ? '1' : '0')};

--- a/packages/suite/src/components/settings/DeviceBanner.tsx
+++ b/packages/suite/src/components/settings/DeviceBanner.tsx
@@ -7,6 +7,7 @@ import { isWebUsb } from 'src/utils/suite/transport';
 import { WebUsbButton } from 'src/components/suite/WebUsbButton';
 import { spacings } from '@trezor/theme';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledLottieAnimation = styled(LottieAnimation)`
     margin: 8px 16px 8px 0;
     min-width: 64px;
@@ -20,6 +21,7 @@ const Column = styled.div`
     width: 100%;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Title = styled(Paragraph)`
     display: flex;
     flex-direction: row;

--- a/packages/suite/src/components/settings/SettingsSection.tsx
+++ b/packages/suite/src/components/settings/SettingsSection.tsx
@@ -30,6 +30,7 @@ const Title = styled.div`
     gap: ${spacingsPx.sm};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Description = styled(Paragraph)`
     padding-left: ${spacings.xl + spacings.sm}px;
     color: ${({ theme }) => theme.textSubdued};

--- a/packages/suite/src/components/suite/CheckItem.tsx
+++ b/packages/suite/src/components/suite/CheckItem.tsx
@@ -5,6 +5,7 @@ import { Checkbox, variables } from '@trezor/components';
 
 const { FONT_SIZE } = variables;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledCheckbox = styled(Checkbox)`
     padding-left: 0;
     align-items: flex-start;

--- a/packages/suite/src/components/suite/ConnectDevicePrompt.tsx
+++ b/packages/suite/src/components/suite/ConnectDevicePrompt.tsx
@@ -56,6 +56,7 @@ const Text = styled.div`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledLottieAnimation = styled(LottieAnimation)<{ $elevation: Elevation }>`
     background: ${mapElevationToBackground};
 `;

--- a/packages/suite/src/components/suite/DeviceDisplay/DisplayPaginatedText.tsx
+++ b/packages/suite/src/components/suite/DeviceDisplay/DisplayPaginatedText.tsx
@@ -8,11 +8,13 @@ import { DisplayPageSeparator } from './DisplayPageSeparator';
 import { handleOnCopy } from 'src/utils/suite/deviceDisplay';
 import { Icon, IconName } from '@trezor/components';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledNextIcon = styled(Icon)<{ $isPixelType: boolean }>`
     display: inline-block;
     margin-left: ${({ $isPixelType }) => ($isPixelType ? '12px' : '24px')};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledContinuesIcon = styled(Icon)<{ $isPixelType: boolean }>`
     display: inline-block;
     margin-right: ${({ $isPixelType }) => ($isPixelType ? '12px' : '24px')};

--- a/packages/suite/src/components/suite/DeviceMatrixExplanation.tsx
+++ b/packages/suite/src/components/suite/DeviceMatrixExplanation.tsx
@@ -44,6 +44,7 @@ const ItemText = styled.div`
     text-align: left;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledImage = styled(Image)`
     height: 40px;
 `;

--- a/packages/suite/src/components/suite/Error.tsx
+++ b/packages/suite/src/components/suite/Error.tsx
@@ -37,10 +37,12 @@ const Separator = styled.div`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     margin: 6px 12px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const GenericMessage = styled(Paragraph)`
     margin-bottom: 10px;
     text-align: center;

--- a/packages/suite/src/components/suite/FormFractionButtons.tsx
+++ b/packages/suite/src/components/suite/FormFractionButtons.tsx
@@ -13,6 +13,7 @@ const Flex = styled.div`
     gap: 4px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const TinyButton = styled(Button).attrs(props => ({
     ...props,
     variant: 'tertiary',

--- a/packages/suite/src/components/suite/PinMatrix/PinInput/InputPin.tsx
+++ b/packages/suite/src/components/suite/PinMatrix/PinInput/InputPin.tsx
@@ -3,6 +3,7 @@ import styled, { useTheme } from 'styled-components';
 import { variables, Icon, Input } from '@trezor/components';
 import { spacingsPx } from '@trezor/theme';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledInput = styled(Input)`
     input {
         letter-spacing: ${spacingsPx.xs};

--- a/packages/suite/src/components/suite/PinMatrix/PinInput/PinInput.tsx
+++ b/packages/suite/src/components/suite/PinMatrix/PinInput/PinInput.tsx
@@ -36,6 +36,7 @@ const PinFooter = styled.div`
     flex-direction: column;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledPinButton = styled(PinButton)<{ $blur?: boolean }>`
     ${props =>
         props.$blur &&

--- a/packages/suite/src/components/suite/QrCode.tsx
+++ b/packages/suite/src/components/suite/QrCode.tsx
@@ -29,6 +29,7 @@ const Message = styled.div`
     white-space: nowrap;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledIcon = styled(Icon)`
     display: inline-block;
     margin-left: 5px;
@@ -39,6 +40,7 @@ const SpanToResetWhitespace = styled.span`
     white-space: normal;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledTooltip = styled(Tooltip)`
     display: inline-block;
 `;

--- a/packages/suite/src/components/suite/QuestionTooltip.tsx
+++ b/packages/suite/src/components/suite/QuestionTooltip.tsx
@@ -8,6 +8,7 @@ const Wrapper = styled.div`
     align-items: center;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Label = styled(H3)`
     margin-right: 4px;
     color: ${({ theme }) => theme.legacy.TYPE_DARK_GREY};

--- a/packages/suite/src/components/suite/SecurityCheck/SecurityCheckFail.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/SecurityCheckFail.tsx
@@ -15,6 +15,7 @@ const TopSection = styled.div`
     width: 100%;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledH2 = styled(H2)`
     font-size: 28px;
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};

--- a/packages/suite/src/components/suite/SecurityCheck/SecurityCheckLayout.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/SecurityCheckLayout.tsx
@@ -27,6 +27,7 @@ const ImageWrapper = styled.div`
     padding: 32px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledImage = styled(Image)`
     max-height: 300px;
 

--- a/packages/suite/src/components/suite/StakingFeature.tsx
+++ b/packages/suite/src/components/suite/StakingFeature.tsx
@@ -4,11 +4,13 @@ import { H3, Paragraph, variables } from '@trezor/components';
 import { IconBorderedWrapper } from 'src/components/suite';
 import { spacingsPx } from '@trezor/theme';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledH3 = styled(H3)<{ $size?: string }>`
     margin-top: ${spacingsPx.lg};
     font-size: ${({ $size }) => $size === 'small' && variables.FONT_SIZE.NORMAL};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const GreyP = styled(Paragraph)`
     color: ${({ theme }) => theme.textSubdued};
 `;

--- a/packages/suite/src/components/suite/TooltipSymbol.tsx
+++ b/packages/suite/src/components/suite/TooltipSymbol.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react';
 import styled from 'styled-components';
 import { Icon, IconName, Tooltip } from '@trezor/components';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const InlineTooltip = styled(Tooltip)`
     display: inline-block;
     margin: 0 4px;

--- a/packages/suite/src/components/suite/TorLoader/TorLoader.tsx
+++ b/packages/suite/src/components/suite/TorLoader/TorLoader.tsx
@@ -11,6 +11,7 @@ import { toggleTor, updateTorStatus } from 'src/actions/suite/suiteActions';
 import { Button, ModalProps } from '@trezor/components';
 import { TorProgressBar } from './TorProgressBar';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     width: 150px;
 `;

--- a/packages/suite/src/components/suite/TorLoader/TorProgressBar.tsx
+++ b/packages/suite/src/components/suite/TorLoader/TorProgressBar.tsx
@@ -40,6 +40,7 @@ const MessageSlowWrapper = styled(MessageWrapper)`
     margin-top: 28px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const DisableButton = styled(Button)`
     margin-left: 10px;
     border: 1px solid ${({ theme }) => theme.legacy.STROKE_GREY};
@@ -58,6 +59,7 @@ const Percentage = styled.span`
     height: 24px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledProgressBar = styled(ProgressBar)`
     display: flex;
     margin: 0 20px;

--- a/packages/suite/src/components/suite/UdevDownload.tsx
+++ b/packages/suite/src/components/suite/UdevDownload.tsx
@@ -39,6 +39,7 @@ const Manual = styled(Download)`
     border-top: 1px solid ${({ theme }) => theme.legacy.STROKE_GREY};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     margin-left: 12px;
     min-width: 280px;

--- a/packages/suite/src/components/suite/WordInputAdvanced.tsx
+++ b/packages/suite/src/components/suite/WordInputAdvanced.tsx
@@ -26,6 +26,7 @@ const Row = styled.div`
     justify-content: space-evenly;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Backspace = styled(Button)`
     margin: 8px;
 `;

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/MetadataLabeling.tsx
@@ -51,10 +51,12 @@ const Label = styled.div`
     position: relative;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const LabelButton = styled(Button)`
     overflow: hidden;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const ActionButton = styled(Button)<{ $isValueVisible?: boolean; $isVisible?: boolean }>`
     margin-left: ${({ $isValueVisible, $isVisible, isLoading }) =>
         $isValueVisible || !$isVisible || isLoading ? '12px' : '4px'};
@@ -62,6 +64,7 @@ const ActionButton = styled(Button)<{ $isValueVisible?: boolean; $isVisible?: bo
 `;
 
 // @TODO this shouldn't be Button
+// eslint-disable-next-line local-rules/no-override-ds-component
 const SuccessButton = styled(Button)`
     cursor: wait;
     margin-left: 12px;
@@ -98,6 +101,7 @@ const LabelContainer = styled.div`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const RelativeButton = styled(Button)`
     padding-bottom: 4px;
     padding-top: 4px;

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/withDropdown.tsx
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/withDropdown.tsx
@@ -5,6 +5,7 @@ import { Dropdown } from '@trezor/components';
 import { ExtendedProps } from './definitions';
 import { RequiredKey } from '@trezor/type-utils';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledDropdown = styled(Dropdown)`
     display: flex;
     flex-direction: row;

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/withEditable.tsx
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/withEditable.tsx
@@ -28,6 +28,7 @@ const IconListWrapper = styled.div`
 
 // To inherit everything so the input looks like the text we want to edit
 // However, we need to reset some properties: for example margin and padding to not duplicate spacings
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Editable = styled(AutoScalingInput)`
     all: inherit;
     margin: 0;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/CoinjoinBars/CoinjoinStatusBar.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/CoinjoinBars/CoinjoinStatusBar.tsx
@@ -54,6 +54,7 @@ const Container = styled.div<{ $isClickable: boolean }>`
         `}
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledProgressPie = styled(ProgressPie)`
     margin-right: ${SPACING}px;
 `;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceStatus.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceStatus.tsx
@@ -28,6 +28,7 @@ const DeviceWrapper = styled.div<{ $isLowerOpacity: boolean }>`
     opacity: ${({ $isLowerOpacity }) => $isLowerOpacity && 0.4};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledRotateDeviceImage = styled(RotateDeviceImage)`
     width: 24px;
 

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountDetails.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountDetails.tsx
@@ -17,7 +17,7 @@ import { selectLabelingDataForSelectedAccount } from 'src/reducers/suite/metadat
 
 const rotateIn = keyframes`
     from {
-        transform: translateY(100%); 
+        transform: translateY(100%);
         opacity: 0;
     }
     to {
@@ -52,6 +52,7 @@ const DetailsContainer = styled.div<{ $isBalanceShown: boolean; $shouldAnimate: 
         0.3s forwards;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const AccountHeading = styled(H2)<{ $isBalanceShown: boolean }>`
     display: flex;
     align-items: center;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/BasicName.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/BasicName.tsx
@@ -3,6 +3,7 @@ import { H2 } from '@trezor/components';
 import { TranslationKey } from '@suite-common/intl-types';
 import { Translation } from 'src/components/suite';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 export const HeaderHeading = styled(H2)`
     display: flex;
     align-items: center;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/ActionButton.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/ActionButton.tsx
@@ -8,6 +8,7 @@ interface ActionButtonProps extends IconButtonProps {
     className?: string;
 }
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 export const Button = styled(IconButton)`
     border-radius: ${borders.radii.sm};
 `;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/NavBackends.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/NavBackends.tsx
@@ -11,6 +11,7 @@ import { ActionButton } from './ActionButton';
 import { openModal } from 'src/actions/suite/modalActions';
 import { spacingsPx, typography } from '@trezor/theme';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledDropdown = styled(Dropdown)`
     display: block;
     width: 100%;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/NotificationDropdown.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/NotificationDropdown.tsx
@@ -26,6 +26,7 @@ const StyledNavigationItem = styled(NavigationItem)`
         `}
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledDropdown = styled(Dropdown)`
     width: 100%;
 `;

--- a/packages/suite/src/components/suite/modals/AbortButton.tsx
+++ b/packages/suite/src/components/suite/modals/AbortButton.tsx
@@ -58,6 +58,7 @@ const AbortContainer = styled.div`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const CloseIcon = styled(Icon)`
     position: absolute;
     left: 0;

--- a/packages/suite/src/components/suite/modals/ConfirmEvmExplanationModal.tsx
+++ b/packages/suite/src/components/suite/modals/ConfirmEvmExplanationModal.tsx
@@ -10,6 +10,7 @@ import { TranslationKey } from 'src/components/suite/Translation';
 import { SUITE } from 'src/actions/suite/constants';
 import { spacingsPx } from '@trezor/theme';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledImage = styled(Image)`
     width: 100%;
     height: 100%;
@@ -20,6 +21,7 @@ const StyledModal = styled(Modal)`
     width: 390px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     flex-grow: 1;
     margin-top: ${spacingsPx.xxl};
@@ -30,6 +32,7 @@ const Content = styled.div`
     flex-direction: column;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Title = styled(H3)`
     margin-bottom: ${spacingsPx.xs};
     text-align: left;
@@ -48,6 +51,7 @@ const ImageWrapper = styled.div`
     margin-bottom: ${spacingsPx.xxl};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const ImageCoinLogoCommon = styled(CoinLogo)`
     position: absolute;
     width: auto;

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmActionModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmActionModal.tsx
@@ -14,6 +14,7 @@ const StyledDeviceConfirmImage = styled(DeviceConfirmImage)`
     margin-top: -30px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledH1 = styled(H2)`
     margin-top: 12px;
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/DevicePromptModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/DevicePromptModal.tsx
@@ -15,6 +15,7 @@ import { ModalEnvironment } from '../../ModalEnvironment';
 import { Modal } from '../../Modal/Modal';
 import { ConfirmOnDevice } from '@trezor/product-components';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledTrezorModal = styled(TrezorModal)`
     ${Modal.Header} {
         padding: 24px 24px 0;

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseOnDeviceModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseOnDeviceModal.tsx
@@ -17,6 +17,7 @@ const StyledDeviceConfirmImage = styled(DeviceConfirmImage)`
     margin-top: -30px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledH2 = styled(H2)`
     margin-top: 12px;
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseSourceModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseSourceModal.tsx
@@ -13,6 +13,7 @@ const StyledDevicePromptModal = styled(DevicePromptModal)`
     width: 360px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledH2 = styled(H2)`
     margin-top: 12px;
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
@@ -62,6 +62,7 @@ const RightBottom = styled.div`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     display: flex;
     flex: 1;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeDescription.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeDescription.tsx
@@ -6,6 +6,7 @@ import { getAccountTypeDesc, getAccountTypeUrl } from '@suite-common/wallet-util
 import { spacingsPx } from '@trezor/theme';
 import { LearnMoreButton } from 'src/components/suite/LearnMoreButton';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Info = styled(Paragraph)`
     margin: ${spacingsPx.md} 0 ${spacingsPx.xs};
 `;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/SelectNetwork.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/SelectNetwork.tsx
@@ -6,6 +6,7 @@ import { spacingsPx } from '@trezor/theme';
 
 import { CoinList } from 'src/components/suite';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Title = styled(Paragraph)`
     color: ${({ theme }) => theme.textSubdued};
     margin-bottom: ${spacingsPx.sm};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/ConnectionInfo.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/ConnectionInfo.tsx
@@ -4,6 +4,7 @@ import { useSelector } from 'src/hooks/suite';
 import { Translation } from 'src/components/suite/Translation';
 import { NetworkCompatible } from '@suite-common/wallet-config';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Wrapper = styled(Paragraph)`
     display: flex;
     flex-direction: column;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/CustomBackends.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/CustomBackends.tsx
@@ -24,11 +24,13 @@ const Wrapper = styled.div`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const AddUrlButton = styled(Button)`
     align-self: end;
     margin-top: 0;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Heading = styled(H3)`
     display: flex;
     align-items: center;
@@ -41,12 +43,14 @@ const TooltipContent = styled.div`
     flex-direction: column;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const SaveButton = styled(Button)`
     width: 200px;
     margin-top: 30px;
     align-self: center;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const TransparentCollapsibleBox = styled(CollapsibleBox)`
     background: ${({ theme }) => theme.backgroundSurfaceElevation2};
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/TorModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/TorModal.tsx
@@ -9,6 +9,7 @@ const StyledModal = styled(Modal)`
     width: 550px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Content = styled(Paragraph)`
     margin: 16px 0;
 `;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CancelCoinjoinModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CancelCoinjoinModal.tsx
@@ -10,6 +10,7 @@ const StyledModal = styled(Modal)`
     width: 435px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     flex: 1;
 `;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimEthForm.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimEthForm.tsx
@@ -27,6 +27,7 @@ const GreenTxt = styled.span`
     color: ${({ theme }) => theme.textPrimaryDefault};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledWarning = styled(Warning)`
     margin: ${spacingsPx.sm} 0 ${spacingsPx.sm} 0;
     justify-content: flex-start;
@@ -40,6 +41,7 @@ const ClaimingPeriodWrapper = styled.div`
     border-top: 1px solid ${({ theme }) => theme.borderElevation2};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const GreyP = styled(Paragraph)`
     color: ${({ theme }) => theme.textSubdued};
 `;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CoinmarketTermsModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CoinmarketTermsModal.tsx
@@ -123,7 +123,7 @@ export const CoinmarketTermsModal = ({
                 </Row>
                 <Row alignItems="center">
                     <IconWrapper $backgroundColor="#e8f3fa">
-                        <Icon size={24} name={`checkActive`} color="#1d88c5" />
+                        <Icon size={24} name="checkActive" color="#1d88c5" />
                     </IconWrapper>
 
                     <ContentWrapper>
@@ -140,7 +140,7 @@ export const CoinmarketTermsModal = ({
                 </Row>
                 <Row alignItems="center">
                     <IconWrapper $backgroundColor="#f9f4e6">
-                        <Icon size={24} name={`pencil`} color="#c19009" />
+                        <Icon size={24} name="pencil" color="#c19009" />
                     </IconWrapper>
                     <ContentWrapper>
                         <Text typographyStyle="highlight">

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedModal.tsx
@@ -13,6 +13,7 @@ const StyledModal = styled(Modal)`
     width: 520px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     flex-grow: 1;
 `;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CriticalCoinjoinPhaseModal/AutoStopButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CriticalCoinjoinPhaseModal/AutoStopButton.tsx
@@ -11,6 +11,7 @@ import { borders, typography } from '@trezor/theme';
 
 const TRANSITION_CONFIG = '0.1s ease';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledIcon = styled(Icon)<{ $isActivated: boolean }>`
     position: absolute;
     left: 6px;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DisableTorModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DisableTorModal.tsx
@@ -69,11 +69,13 @@ const BackendRow = ({ coin, urls, onSettings }: BackendRowProps) => (
     </BackendRowWrapper>
 );
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Title = styled(H3)`
     text-align: left;
     margin-bottom: 12px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Description = styled(Paragraph)`
     text-align: left;
     margin-bottom: 16px;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DisableTorStopCoinjoinModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DisableTorStopCoinjoinModal.tsx
@@ -9,6 +9,7 @@ const SmallModal = styled(Modal)`
     width: 560px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Description = styled(Paragraph)`
     text-align: left;
     margin-bottom: 16px;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ImportTransactionModal/DelimiterForm.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ImportTransactionModal/DelimiterForm.tsx
@@ -18,6 +18,7 @@ const Label = styled.span`
     white-space: nowrap;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledInput = styled(Input)`
     width: 120px;
 `;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MetadataProviderModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MetadataProviderModal.tsx
@@ -26,6 +26,7 @@ const Error = styled.div`
 
 // todo: can't use button from @trezor/components directly, probably inconsistent design again
 // background-color is not even in components color palette
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     padding: 10px;
     font-size: ${FONT_SIZE.NORMAL};
@@ -35,6 +36,7 @@ const StyledButton = styled(Button)`
 `;
 
 // todo: typography shall be unified and these ad hoc styles removed..
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledP = styled(Paragraph)`
     color: ${({ theme }) => theme.legacy.TYPE_DARK_GREY};
 `;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/BackupInstructionsCard.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/BackupInstructionsCard.tsx
@@ -4,6 +4,7 @@ import styled, { css } from 'styled-components';
 import { Card, Icon, IconName } from '@trezor/components';
 import { borders, spacingsPx } from '@trezor/theme';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledCard = styled(Card)<{ $isHorizontal: boolean }>`
     align-items: center;
     gap: ${spacingsPx.md};
@@ -18,6 +19,7 @@ const StyledCard = styled(Card)<{ $isHorizontal: boolean }>`
               `}
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledIcon = styled(Icon)<{ $isCircled: boolean }>`
     ${({ $isCircled }) =>
         $isCircled &&

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/BackupInstructionsStep.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/BackupInstructionsStep.tsx
@@ -25,6 +25,7 @@ const StepNumber = styled.div<{ $subdued?: boolean; $isDone?: boolean }>`
     color: ${({ theme, $subdued }) => ($subdued === true ? theme.textSubdued : undefined)};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledParagraph = styled(Paragraph)`
     font-variant-numeric: tabular-nums;
     text-align: center;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupStep1FirstInfo.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupStep1FirstInfo.tsx
@@ -7,6 +7,7 @@ import { spacingsPx } from '@trezor/theme';
 import { Translation } from 'src/components/suite';
 import { Body, Section } from './multiShareModalLayout';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledImage = styled(Image)`
     margin-bottom: ${spacingsPx.md};
 `;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupStep5Done.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupStep5Done.tsx
@@ -34,6 +34,7 @@ const IconQuestionWrapper = styled.div`
     left: 25px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const TextDiv = styled(Text)`
     display: block;
 `;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/OptOutModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/OptOutModal.tsx
@@ -17,6 +17,7 @@ const StyledModal = styled(Modal)`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const WarningImage = styled(Image)`
     margin: ${spacingsPx.xl} 0;
 `;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PinMismatchModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PinMismatchModal.tsx
@@ -4,6 +4,7 @@ import { Translation, Modal, ModalProps } from 'src/components/suite';
 import { changePin } from 'src/actions/settings/deviceSettingsActions';
 import { useDispatch } from 'src/hooks/suite';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledImage = styled(Image)`
     margin: 48px auto;
 `;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/QrScannerModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/QrScannerModal.tsx
@@ -55,6 +55,7 @@ const Error = styled.div`
     padding: 10px 0;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const ErrorTitle = styled(Paragraph)`
     text-align: center;
     color: ${colors.legacy.TYPE_RED};
@@ -68,6 +69,7 @@ const IconWrapper = styled.div`
     margin-bottom: 40px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const ActionButton = styled(Button)`
     min-width: 200px;
 `;
@@ -87,6 +89,7 @@ const StyledQrReader = styled(QrReader)`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledTextarea = styled(Textarea)`
     height: 100%;
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/RequestEnableTorModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/RequestEnableTorModal.tsx
@@ -14,6 +14,7 @@ const SmallModal = styled(Modal)`
     width: 560px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Description = styled(Paragraph)`
     text-align: left;
     margin-bottom: 16px;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AdvancedTxDetails/IODetails/IODetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AdvancedTxDetails/IODetails/IODetails.tsx
@@ -27,6 +27,7 @@ const Wrapper = styled.div`
     ${blurFix}
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledCollapsibleBox = styled(CollapsibleBox)<{ $elevation: Elevation }>`
     overflow: auto;
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
@@ -126,6 +126,7 @@ const ConfirmationStatusWrapper = styled.div`
     justify-content: flex-end;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const TxSentStatus = styled(H3)`
     overflow: hidden;
     text-overflow: ellipsis;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/GreyCard.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/GreyCard.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react';
 import styled from 'styled-components';
 import { Card, Column } from '@trezor/components';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Wrapper = styled(Card)`
     text-align: left;
     background-color: ${({ theme }) => theme.legacy.BG_GREY};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ReplaceTxButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ReplaceTxButton.tsx
@@ -10,6 +10,7 @@ const Wrapper = styled.div`
     margin-top: 22px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     min-width: 30%;
 `;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnecoCoinjoinModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnecoCoinjoinModal.tsx
@@ -36,6 +36,7 @@ const Explanation = styled.i`
     font-size: ${variables.FONT_SIZE.SMALL};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const AgreeButton = styled(Button)`
     background: ${({ theme }) => theme.legacy.TYPE_DARK_ORANGE};
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/Options.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/Options.tsx
@@ -11,6 +11,7 @@ import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReduce
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { getAccountEverstakeStakingPool } from '@suite-common/wallet-utils';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const GreyP = styled(Paragraph)`
     color: ${({ theme }) => theme.textSubdued};
 `;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/UnstakeEthForm.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/UnstakeEthForm.tsx
@@ -13,6 +13,7 @@ import { selectValidatorsQueueData } from '@suite-common/wallet-core';
 import { getAccountEverstakeStakingPool } from '@suite-common/wallet-utils';
 import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const GreyP = styled(Paragraph)`
     color: ${({ theme }) => theme.textSubdued};
 `;
@@ -25,6 +26,7 @@ const DividerWrapper = styled.div`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledWarning = styled(Warning)`
     justify-content: flex-start;
 `;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WipeDeviceModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WipeDeviceModal.tsx
@@ -32,6 +32,7 @@ const StyledModal = styled(Modal)`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const WarningImage = styled(Image)`
     margin: 24px 0;
 `;

--- a/packages/suite/src/components/suite/notifications/Notifications/NotificationGroup/NotificationGroup.tsx
+++ b/packages/suite/src/components/suite/notifications/Notifications/NotificationGroup/NotificationGroup.tsx
@@ -28,6 +28,7 @@ const EmptyHeadline = styled.div`
     margin: 10px 0 6px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const EmptyDescriptionP = styled(Paragraph)`
     color: ${({ theme }) => theme.legacy.TYPE_LIGHT_GREY};
 `;

--- a/packages/suite/src/components/suite/notifications/Notifications/NotificationGroup/NotificationList/NotificationView.tsx
+++ b/packages/suite/src/components/suite/notifications/Notifications/NotificationGroup/NotificationList/NotificationView.tsx
@@ -33,6 +33,7 @@ const Text = styled.div`
     white-space: break-spaces;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const ActionButton = styled(Button)`
     min-width: 80px;
     align-self: center;

--- a/packages/suite/src/components/suite/notifications/ToastNotification.tsx
+++ b/packages/suite/src/components/suite/notifications/ToastNotification.tsx
@@ -30,6 +30,7 @@ const Message = styled.div`
     color: ${({ theme }) => theme.legacy.TYPE_DARK_GREY};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)<{ $action: NotificationViewProps['action'] }>`
     ${({ $action }) =>
         (!$action?.position || $action.position === 'right') &&

--- a/packages/suite/src/components/suite/troubleshooting/TroubleshootingTips.tsx
+++ b/packages/suite/src/components/suite/troubleshooting/TroubleshootingTips.tsx
@@ -68,6 +68,7 @@ const FooterText = styled.span`
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     margin: 0 20px 20px;
 `;

--- a/packages/suite/src/components/wallet/AccountExceptionLayout.tsx
+++ b/packages/suite/src/components/wallet/AccountExceptionLayout.tsx
@@ -11,6 +11,7 @@ import {
     Column,
 } from '@trezor/components';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Title = styled(H2)`
     text-align: center;
     font-weight: 600;
@@ -24,6 +25,7 @@ const Description = styled.span`
     color: ${({ theme }) => theme.legacy.TYPE_LIGHT_GREY};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledImage = styled(Image)`
     width: auto;
     height: 80px;
@@ -38,6 +40,7 @@ const Actions = styled.div`
     margin-bottom: 20px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const ActionButton = styled(Button)`
     min-width: 160px;
 

--- a/packages/suite/src/components/wallet/CoinjoinAccountDiscoveryProgress/CoinjoinAccountDiscoveryProgress.tsx
+++ b/packages/suite/src/components/wallet/CoinjoinAccountDiscoveryProgress/CoinjoinAccountDiscoveryProgress.tsx
@@ -32,6 +32,7 @@ const Subheader = styled.div`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const DiscoveryProgress = styled(ProgressBar)`
     max-width: 440px;
     margin: 18px 0 28px;
@@ -50,11 +51,13 @@ const FactHeading = styled.div`
     text-transform: uppercase;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const SparksIcon = styled(Icon)`
     margin-right: 4px;
     padding-bottom: 2px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledLottieAnimation = styled(LottieAnimation)`
     margin: -32px -8px -32px -20px;
 

--- a/packages/suite/src/components/wallet/DiscoveryProgress.tsx
+++ b/packages/suite/src/components/wallet/DiscoveryProgress.tsx
@@ -4,6 +4,7 @@ import { useDiscovery } from 'src/hooks/suite';
 import { ProgressBar } from '@trezor/components';
 import { zIndices } from '@trezor/theme';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledProgressBar = styled(ProgressBar)`
     height: 0;
     z-index: ${zIndices.discoveryProgress};

--- a/packages/suite/src/components/wallet/EvmExplanationBox.tsx
+++ b/packages/suite/src/components/wallet/EvmExplanationBox.tsx
@@ -4,6 +4,7 @@ import { Elevation, mapElevationToBackground } from '@trezor/theme';
 import { HTMLAttributes, ReactNode, forwardRef } from 'react';
 import styled, { css } from 'styled-components';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const EvmExplanationBoxWrapper = styled(Card)<{ $caret?: boolean; $elevation: Elevation }>`
     position: relative;
     display: flex;

--- a/packages/suite/src/components/wallet/Fees/CustomFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/CustomFee.tsx
@@ -41,6 +41,7 @@ const Units = styled.div`
     color: ${({ theme }) => theme.legacy.TYPE_LIGHT_GREY};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledNote = styled(Note)`
     text-align: left;
 `;

--- a/packages/suite/src/components/wallet/Fees/Fees.tsx
+++ b/packages/suite/src/components/wallet/Fees/Fees.tsx
@@ -79,6 +79,7 @@ const StyledSelectBar = styled(SelectBar<FeeLevel['label']>)`
     margin-top: ${spacingsPx.lg};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const HelperTextWrapper = styled(Paragraph)`
     color: ${({ theme }) => theme.textSubdued};
     font-size: ${variables.FONT_SIZE.SMALL};

--- a/packages/suite/src/components/wallet/SearchAction.tsx
+++ b/packages/suite/src/components/wallet/SearchAction.tsx
@@ -28,6 +28,7 @@ const StyledTooltipSymbol = styled(TooltipSymbol)<{ $isExpanded: boolean }>`
 
 const INPUT_WIDTH = '38px';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledInput = styled(Input)<{ $isExpanded: boolean }>`
     width: ${({ $isExpanded }) => ($isExpanded ? '210px' : INPUT_WIDTH)};
     margin-right: ${spacingsPx.xs};

--- a/packages/suite/src/components/wallet/TransactionItem/CoinjoinBatchItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/CoinjoinBatchItem.tsx
@@ -100,6 +100,7 @@ const Round = ({ transaction }: { transaction: WalletAccountTransaction }) => {
     );
 };
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledCollapsibleBox = styled(CollapsibleBox)<{ $isPending: boolean }>`
     background-color: ${({ theme }) => theme.legacy.BG_WHITE};
     box-shadow: none;

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
@@ -36,6 +36,7 @@ import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReduce
 import { getInstantStakeType } from 'src/utils/suite/stake';
 import { isStakeTypeTx } from '@suite-common/suite-utils';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Wrapper = styled(Card)<{
     $isPending: boolean;
     $shouldHighlight: boolean;
@@ -65,6 +66,7 @@ const Body = styled.div`
     width: 100%;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const ExpandButton = styled(Button)`
     justify-content: flex-start;
     align-self: flex-start;

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTypeIcon.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTypeIcon.tsx
@@ -9,6 +9,7 @@ const IconsWrapper = styled.div<{ $isJoint: boolean }>`
     transform: ${({ $isJoint }) => $isJoint && 'translate(2px, 0)'};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const ClockIcon = styled(Icon)`
     position: absolute;
     top: -2px;

--- a/packages/suite/src/components/wallet/WalletLayout/AccountException/AccountException.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountException/AccountException.tsx
@@ -16,6 +16,7 @@ const Wrapper = styled.div`
     height: 100%;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Title = styled(H2)`
     display: flex;
     text-align: center;

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountGroup.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountGroup.tsx
@@ -23,6 +23,7 @@ const ChevronContainer = styled.div`
     width: ${spacingsPx.xxxl};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const ChevronIcon = styled(Icon)<{ $isActive: boolean }>`
     padding: ${spacingsPx.sm};
     border-radius: 50%;

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemSkeleton.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemSkeleton.tsx
@@ -10,6 +10,7 @@ const Wrapper = styled.div`
     flex: 1;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledSkeletonStack = styled(SkeletonStack)`
     > :last-child {
         margin-bottom: 0;

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSearchBox.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSearchBox.tsx
@@ -10,6 +10,7 @@ const InputWrapper = styled.div<{ $showCoinFilter: boolean }>`
     flex: 1;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledInput = styled(Input)`
     input {
         /* to line up with the coin filter  */

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/CoinsFilter.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/CoinsFilter.tsx
@@ -7,6 +7,7 @@ import { selectDevice } from '@suite-common/wallet-core';
 
 import { useSelector, useAccountSearch } from 'src/hooks/suite';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledCoinLogo = styled(CoinLogo)<{ $isSelected?: boolean }>`
     display: block;
     border-radius: ${borders.radii.full};

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/MobileAccountsMenu.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/MobileAccountsMenu.tsx
@@ -49,6 +49,7 @@ const Search = styled.div`
     background: ${({ theme }) => theme.backgroundSurfaceElevationNegative};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Heading = styled(H2)<{ $isInline?: boolean }>`
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     color: ${({ theme }) => theme.legacy.TYPE_DARK_GREY};
@@ -84,6 +85,7 @@ const ExpandedMobileWrapper = styled.div`
     padding-bottom: 16px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledIcon = styled(Icon)<{ $isActive: boolean }>`
     transform: ${({ $isActive }) => ($isActive ? 'rotate(0deg)' : 'rotate(180deg)')};
 `;

--- a/packages/suite/src/components/wallet/WalletLayout/CoinjoinAccountDiscovery/RememberWallet.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/CoinjoinAccountDiscovery/RememberWallet.tsx
@@ -5,6 +5,7 @@ import { spacings, spacingsPx } from '@trezor/theme';
 import { Card, Image, Note, Paragraph, Row, Switch } from '@trezor/components';
 import { Translation } from 'src/components/suite';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledImage = styled(Image)`
     align-self: flex-start;
 `;
@@ -15,6 +16,7 @@ const Middle = styled.div`
     gap: ${spacingsPx.xxs};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledSwitch = styled(Switch)`
     margin-left: auto;
 `;

--- a/packages/suite/src/support/suite/screens/LoadingScreen.tsx
+++ b/packages/suite/src/support/suite/screens/LoadingScreen.tsx
@@ -19,6 +19,7 @@ const Loader = styled(Loading)`
     flex: 0;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const LoadingText = styled(Paragraph)`
     height: 0;
 `;

--- a/packages/suite/src/views/backup/index.tsx
+++ b/packages/suite/src/views/backup/index.tsx
@@ -15,14 +15,17 @@ import type { ForegroundAppProps } from 'src/types/suite';
 import type { BackupStatus } from 'src/actions/backup/backupActions';
 import { selectBackup } from 'src/reducers/backup/backupReducer';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     width: 224px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledP = styled(Paragraph)`
     color: ${({ theme }) => theme.legacy.TYPE_LIGHT_GREY};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledImage = styled(Image)`
     margin-bottom: 24px;
     align-self: center;

--- a/packages/suite/src/views/dashboard/components/AssetsView/components/ArrowIcon.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsView/components/ArrowIcon.tsx
@@ -2,6 +2,7 @@ import { Icon } from '@trezor/components';
 import { spacingsPx } from '@trezor/theme';
 import styled, { css } from 'styled-components';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 export const ArrowIcon = styled(Icon)`
     transition: opacity 0.1s;
     margin: ${spacingsPx.xs};

--- a/packages/suite/src/views/dashboard/components/AssetsView/components/AssetCard.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsView/components/AssetCard.tsx
@@ -24,6 +24,7 @@ import { AssetCardInfo, AssetCardInfoSkeleton } from './AssetCardInfo';
 import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
 import { useFiatFromCryptoValue } from 'src/hooks/suite/useFiatFromCryptoValue';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledCard = styled(Card)`
     transition: box-shadow 0.2s;
 
@@ -37,6 +38,7 @@ const Content = styled.div`
     flex: 1;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const WarningIcon = styled(Icon)`
     padding-left: ${spacingsPx.xxs};
     padding-bottom: ${spacingsPx.xxxs};
@@ -47,6 +49,7 @@ const FiatAmount = styled.div`
     align-content: flex-end;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const IntegerValue = styled(H2)`
     font-variant-numeric: tabular-nums;
     line-height: 34px;

--- a/packages/suite/src/views/dashboard/components/AssetsView/components/AssetRow.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsView/components/AssetRow.tsx
@@ -115,10 +115,12 @@ const StyledArrowIcon = styled(ArrowIcon)`
     margin: 0 ${spacingsPx.md};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const SkeletonRectangleLast = styled(SkeletonRectangle)`
     margin-right: ${spacingsPx.md};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledIcon = styled(Icon)`
     padding-left: 4px;
     padding-bottom: 2px;

--- a/packages/suite/src/views/dashboard/components/PortfolioCard/components/EmptyWallet.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/components/EmptyWallet.tsx
@@ -21,6 +21,7 @@ const Content = styled.div`
     align-items: center;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Title = styled(H3)`
     color: ${({ theme }) => theme.legacy.TYPE_DARK_GREY};
     margin-bottom: 30px;
@@ -30,6 +31,7 @@ const Title = styled(H3)`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledImage = styled(Image)`
     display: flex;
     margin-bottom: 24px;

--- a/packages/suite/src/views/dashboard/components/PortfolioCard/components/Exception.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/components/Exception.tsx
@@ -27,6 +27,7 @@ const Wrapper = styled.div`
     width: 100%;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Title = styled(H3)`
     color: ${({ theme }) => theme.legacy.TYPE_DARK_GREY};
 `;
@@ -37,6 +38,7 @@ const Description = styled.div`
     text-align: center;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledImage = styled(Image)`
     margin: 24px 0;
 `;

--- a/packages/suite/src/views/dashboard/components/PortfolioCard/components/Header.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/components/Header.tsx
@@ -39,6 +39,7 @@ const Buttons = styled.div`
     flex-flow: row wrap;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const WalletEmptyButton = styled(Button)`
     min-width: 120px;
 `;

--- a/packages/suite/src/views/dashboard/components/PortfolioCard/index.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/index.tsx
@@ -30,6 +30,7 @@ const Body = styled.div`
     flex: 1;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledDropdown = styled(Dropdown)`
     display: flex;
     height: 38px;

--- a/packages/suite/src/views/dashboard/components/PromoBanner.tsx
+++ b/packages/suite/src/views/dashboard/components/PromoBanner.tsx
@@ -74,6 +74,7 @@ const StyledLink = styled(TrezorLink)`
     margin-left: auto;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const DesktopLinkButton = styled(Button)`
     background: ${({ theme }) => theme.legacy.STROKE_GREY};
     color: ${({ theme }) => theme.legacy.TYPE_DARK_GREY};
@@ -97,6 +98,7 @@ const BadgeContainer = styled.div`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledTooltip = styled(Tooltip)`
     display: flex;
 
@@ -106,6 +108,7 @@ const StyledTooltip = styled(Tooltip)`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Badge = styled(Image)<{ $isHighlighted: boolean }>`
     max-width: unset;
     opacity: ${({ $isHighlighted }) => ($isHighlighted ? 1 : 0.6)};
@@ -113,6 +116,7 @@ const Badge = styled(Image)<{ $isHighlighted: boolean }>`
     cursor: pointer;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StoreTitle = styled(Image)<{ $isDark: boolean }>`
     display: block;
     margin: 2px auto 6px;

--- a/packages/suite/src/views/dashboard/components/StakeEthCard/StakeEthCard.tsx
+++ b/packages/suite/src/views/dashboard/components/StakeEthCard/StakeEthCard.tsx
@@ -36,6 +36,7 @@ const Body = styled.div`
     padding: ${spacingsPx.xxl} ${spacingsPx.xxl} 0 ${spacingsPx.xxl};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const CardTitle = styled(H3)`
     color: ${({ theme }) => theme.textPrimaryDefault};
     line-height: 23px;

--- a/packages/suite/src/views/dashboard/components/StakeEthCard/components/Footer.tsx
+++ b/packages/suite/src/views/dashboard/components/StakeEthCard/components/Footer.tsx
@@ -16,6 +16,7 @@ const Wrapper = styled.div`
     gap: ${spacingsPx.xs};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledP = styled(Paragraph)`
     font-size: ${variables.FONT_SIZE.TINY};
     color: ${({ theme }) => theme.textSubdued};
@@ -32,6 +33,7 @@ const Right = styled.div`
     gap: ${spacingsPx.xs};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const ButtonTertiary = styled(Button)`
     padding: 9px 22px;
     font-size: ${variables.FONT_SIZE.NORMAL};

--- a/packages/suite/src/views/dashboard/components/T3T1PromoBanner.tsx
+++ b/packages/suite/src/views/dashboard/components/T3T1PromoBanner.tsx
@@ -104,6 +104,7 @@ const ProductsImageWrapper = styled.div`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const ProductsImage = styled(Image)`
     position: absolute;
     max-width: none;
@@ -149,6 +150,7 @@ const LinkButtonShopNow = styled(TrezorLink)`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const ButtonShopNow = styled(Button)`
     background-color: #9be887;
     width: 100%;
@@ -162,6 +164,7 @@ const ButtonShopNow = styled(Button)`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const ButtonClose = styled(IconButton)`
     grid-column: 4;
     grid-row: 2;

--- a/packages/suite/src/views/onboarding/steps/Backup.tsx
+++ b/packages/suite/src/views/onboarding/steps/Backup.tsx
@@ -23,6 +23,7 @@ import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { selectIsActionAbortable } from 'src/reducers/suite/suiteReducer';
 import * as onboardingActions from 'src/actions/onboarding/onboardingActions';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledImage = styled(Image)`
     flex: 1;
 `;

--- a/packages/suite/src/views/onboarding/steps/Final.tsx
+++ b/packages/suite/src/views/onboarding/steps/Final.tsx
@@ -69,6 +69,7 @@ const SetupActions = styled.div`
     flex-flow: row wrap;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const EnterSuiteButton = styled(Button)`
     height: 64px;
     min-width: 280px;

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheck.tsx
@@ -50,6 +50,7 @@ const DeviceName = styled.div`
     margin-top: 12px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledH2 = styled(H2)`
     font-size: 28px;
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
@@ -113,6 +114,7 @@ const StyledTrezorLink = styled(TrezorLink)`
     color: ${({ theme }) => theme.legacy.TYPE_LIGHT_GREY};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledTooltip = styled(Tooltip)`
     display: inline-block;
 `;

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheckButton.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheckButton.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 
 import { Button, ButtonProps } from '@trezor/components';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     min-height: 53px;
 `;

--- a/packages/suite/src/views/recovery/index.tsx
+++ b/packages/suite/src/views/recovery/index.tsx
@@ -31,6 +31,7 @@ const StyledModal = styled(Modal)`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     width: 224px;
 `;
@@ -39,10 +40,12 @@ const StepsContainer = styled.div`
     margin: 40px 0;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledP = styled(Paragraph)`
     color: ${({ theme }) => theme.legacy.TYPE_LIGHT_GREY};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledImage = styled(Image)`
     margin-bottom: 24px;
     align-self: center;
@@ -52,10 +55,12 @@ const LeftAlignedP = styled(StyledP)`
     text-align: left;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StatusImage = styled(Image)`
     padding-bottom: 24px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StatusTitle = styled(H2)`
     margin: 0 0 12px;
 `;

--- a/packages/suite/src/views/settings/SettingsDebug/CoinjoinApi.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/CoinjoinApi.tsx
@@ -14,6 +14,7 @@ const StyledActionSelect = styled(ActionSelect)`
     min-width: 256px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     margin-left: 8px;
 `;

--- a/packages/suite/src/views/settings/SettingsDevice/FirmwareVersion.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/FirmwareVersion.tsx
@@ -28,6 +28,7 @@ const Version = styled.div`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const VersionTooltip = styled(Tooltip)`
     display: inline-flex;
 `;

--- a/packages/suite/src/views/settings/SettingsGeneral/DesktopSuiteBanner.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/DesktopSuiteBanner.tsx
@@ -22,6 +22,7 @@ const Container = styled(motion.div)`
     overflow: hidden;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const CloseButton = styled(Icon)`
     position: absolute;
     right: 16px;
@@ -49,6 +50,7 @@ const CloseButton = styled(Icon)`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledImage = styled(Image)`
     margin-right: 24px;
 
@@ -71,6 +73,7 @@ const TextContainer = styled.div`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     background: ${({ theme }) => theme.legacy.BG_WHITE};
     color: ${({ theme }) => theme.legacy.TYPE_GREEN};

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/AddWalletButton.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/AddWalletButton.tsx
@@ -16,6 +16,7 @@ const AddWallet = styled.div`
     margin-top: 10px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledTooltip = styled(Tooltip)`
     width: 100%;
 `;

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceDetail.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceDetail.tsx
@@ -11,6 +11,7 @@ const Container = styled.div`
     align-self: center;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const DeviceLabel = styled(TruncateWithTooltip)`
     ${typography.body};
     margin-bottom: -${spacingsPx.xxs};

--- a/packages/suite/src/views/suite/bridge-requested/index.tsx
+++ b/packages/suite/src/views/suite/bridge-requested/index.tsx
@@ -15,10 +15,12 @@ const StyledModal = styled(Modal)`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledImage = styled(Image)`
     align-self: center;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     path {
         fill: ${({ theme }) => theme.legacy.TYPE_LIGHT_GREY};

--- a/packages/suite/src/views/suite/bridge/index.tsx
+++ b/packages/suite/src/views/suite/bridge/index.tsx
@@ -7,6 +7,7 @@ import { isWebUsb } from 'src/utils/suite/transport';
 import { useOpenSuiteDesktop } from 'src/hooks/suite/useOpenSuiteDesktop';
 import { DATA_URL } from '@trezor/urls';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     path {
         fill: ${({ theme }) => theme.legacy.TYPE_LIGHT_GREY};

--- a/packages/suite/src/views/view-only/ViewOnlyPromoContent.tsx
+++ b/packages/suite/src/views/view-only/ViewOnlyPromoContent.tsx
@@ -49,14 +49,17 @@ const Circle = ({ children }: { children: ReactNode }) => {
     return <StyledCircle $elevation={elevation}>{children}</StyledCircle>;
 };
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const DeviceImage = styled(Image)`
     object-fit: contain;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const SmallDeviceImage = styled(DeviceImage)`
     width: 18px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const LargeDeviceImage = styled(DeviceImage)`
     width: 93px;
 `;

--- a/packages/suite/src/views/wallet/anonymize/components/CoinjoinConfirmation.tsx
+++ b/packages/suite/src/views/wallet/anonymize/components/CoinjoinConfirmation.tsx
@@ -26,6 +26,7 @@ import {
 import { useCoinjoinSessionBlockers } from 'src/hooks/coinjoin/useCoinjoinSessionBlockers';
 import { Tile, TileProps } from './Tile';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const TopRow = styled(H3)`
     display: flex;
     justify-content: space-between;
@@ -45,6 +46,7 @@ const FeeWrapper = styled.div`
     padding: ${spacingsPx.md} 0;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const FeeHeading = styled(Paragraph)`
     color: ${({ theme }) => theme.textSubdued};
 `;
@@ -67,10 +69,12 @@ const Tiles = styled.div`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledCheckbox = styled(Checkbox)`
     ${typography.highlight}
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     margin: ${spacingsPx.xl} auto 0;
 

--- a/packages/suite/src/views/wallet/anonymize/components/Tile.tsx
+++ b/packages/suite/src/views/wallet/anonymize/components/Tile.tsx
@@ -9,6 +9,7 @@ const containerGridStyle = css`
     gap: 0 14px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Container = styled(Card)`
     background: ${({ theme }) => theme.legacy.BG_GREY};
     box-shadow: none;
@@ -30,6 +31,7 @@ const imageGridStyle = css`
     grid-row: 1/3;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledImage = styled(Image)`
     ${variables.SCREEN_QUERY.BELOW_LAPTOP} {
         ${imageGridStyle}

--- a/packages/suite/src/views/wallet/coinmarket/buy/detail/components/PaymentFailed/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/detail/components/PaymentFailed/index.tsx
@@ -29,10 +29,12 @@ const Description = styled.div`
     text-align: center;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledLink = styled(Link)`
     margin-bottom: 30px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     margin-top: 30px;
 `;

--- a/packages/suite/src/views/wallet/coinmarket/buy/detail/components/PaymentProcessing/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/detail/components/PaymentProcessing/index.tsx
@@ -15,6 +15,7 @@ const Title = styled.div`
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledLink = styled(Link)`
     margin-top: 50px;
 `;

--- a/packages/suite/src/views/wallet/coinmarket/buy/detail/components/WaitingForUser/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/detail/components/WaitingForUser/index.tsx
@@ -32,6 +32,7 @@ const Description = styled.div`
     text-align: center;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const PaymentButton = styled(Button)`
     margin-top: 30px;
 `;

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketFeaturedOffers/CoinmarketFeaturedOffersItem.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketFeaturedOffers/CoinmarketFeaturedOffersItem.tsx
@@ -65,6 +65,7 @@ const OfferBadgeWrap = styled.div`
     flex-wrap: wrap;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const OfferBadge = styled(Badge)`
     margin-right: ${spacingsPx.xs};
     margin-bottom: ${spacingsPx.xs};
@@ -77,6 +78,7 @@ const OfferBadgeInfo = styled.div`
     color: ${({ theme }) => theme.textSubdued};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     width: 168px;
 

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketFooter/CoinmarketFooter.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketFooter/CoinmarketFooter.tsx
@@ -61,6 +61,7 @@ const BoxRight = styled.div`
     align-items: center;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const InvityLink = styled(Link)`
     display: flex;
     flex: 1;
@@ -90,6 +91,7 @@ const linkStyle = css`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledLink = styled(Link)`
     ${linkStyle}
 `;

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketFooter/CoinmarketProvidedByInvity.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketFooter/CoinmarketProvidedByInvity.tsx
@@ -10,6 +10,7 @@ const Wrapper = styled.div`
     color: ${({ theme }) => theme.legacy.TYPE_LIGHT_GREY};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledLink = styled(Link)`
     display: flex;
     flex: 1;

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputCountry.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputCountry.tsx
@@ -24,6 +24,7 @@ const FlagContainer = styled.div`
     margin-right: ${spacingsPx.xs};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const FlagWrapper = styled(Flag)`
     position: absolute;
     top: 0;

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputCurrency.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputCurrency.tsx
@@ -14,6 +14,7 @@ import { buildFiatOption } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import { CoinmarketFormOption, CoinmarketFormOptionLabel } from 'src/views/wallet/coinmarket';
 import styled from 'styled-components';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const SelectWrapper = styled(Select)`
     /* stylelint-disable selector-class-pattern */
     .react-select__value-container {

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormLayout.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormLayout.tsx
@@ -16,6 +16,7 @@ const CoinmarketFormLayoutWrapper = styled.form`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const CoinmarketFormInputsWrapper = styled(Card)`
     padding: ${spacingsPx.xl} ${spacingsPx.xl} ${spacingsPx.lg};
     width: 60%;
@@ -30,6 +31,8 @@ const CoinmarketFormInputsWrapper = styled(Card)`
         padding-bottom: ${spacingsPx.zero};
     }
 `;
+
+// eslint-disable-next-line local-rules/no-override-ds-component
 const CoinmarketFormOfferWrapper = styled(Card)`
     padding: ${spacingsPx.xl} ${spacingsPx.xl} ${spacingsPx.xxxl};
     width: 37%;

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormOffer.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormOffer.tsx
@@ -38,6 +38,8 @@ const CoinmarketFormOfferHeader = styled.div`
     }
 `;
 const CoinmarketFormOfferHeaderText = styled.div``;
+
+// eslint-disable-next-line local-rules/no-override-ds-component
 const CoinmarketFormOfferHeaderButton = styled(TextButton)`
     ${typography.hint};
     margin-top: ${spacingsPx.xxxs};

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormOfferItem.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormOfferItem.tsx
@@ -31,6 +31,7 @@ const CoinmarketFormOfferSpinnerText = styled.div<{ $withoutSpinner?: boolean }>
     text-align: center;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const CoinmarketSpinnerWrapper = styled(Spinner)`
     flex: none;
     margin: 0 ${spacingsPx.xs};

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketFractionButtons.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketFractionButtons.tsx
@@ -9,6 +9,7 @@ const Wrapper = styled.div`
     position: relative;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const SmallButton = styled(Button).attrs(props => ({
     ...props,
     variant: 'tertiary',

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketHeader/CoinmarketHeader.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketHeader/CoinmarketHeader.tsx
@@ -32,6 +32,7 @@ const HeaderTop = styled.div`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const HeaderH2 = styled(H2)`
     flex: auto;
     width: 100%;

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketHeader/CoinmarketHeaderSummary.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketHeader/CoinmarketHeaderSummary.tsx
@@ -19,11 +19,13 @@ const SummaryWrap = styled.div`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledIcon = styled(Icon)`
     padding: 0 ${spacingsPx.sm};
     margin: 0 ${spacingsPx.lg};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const TextWrap = styled(H2)`
     ${SCREEN_QUERY.BELOW_TABLET} {
         font-size: ${variables.FONT_SIZE.H2};

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketAccountTransactions/CoinmarketAccountTransactions.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketAccountTransactions/CoinmarketAccountTransactions.tsx
@@ -26,6 +26,7 @@ const NoTransactions = styled.div`
     color: ${({ theme }) => theme.legacy.TYPE_LIGHT_GREY};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledH2 = styled(H2)`
     flex-direction: column;
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayoutNew/CoinmarketLayoutNavigation/CoinmarketLayoutNavigationItem.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayoutNew/CoinmarketLayoutNavigation/CoinmarketLayoutNavigationItem.tsx
@@ -43,6 +43,7 @@ const NavListItemWrapper = styled(NavigationItem)`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const ButtonWrapper = styled(Button)`
     margin-left: auto;
 

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketOffers/CoinmarketOffersItem.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketOffers/CoinmarketOffersItem.tsx
@@ -85,6 +85,7 @@ const OfferBadgeWrap = styled.div`
     flex-wrap: wrap;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const OfferBadge = styled(Badge)`
     margin-right: ${spacingsPx.xs};
     margin-bottom: ${spacingsPx.xs};
@@ -97,6 +98,7 @@ const OfferBadgeInfo = styled.div`
     color: ${({ theme }) => theme.textSubdued};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     width: 180px;
 

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketRefreshTime.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketRefreshTime.tsx
@@ -13,6 +13,7 @@ const Wrapper = styled.div`
     flex: none;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const ProgressPieWrap = styled(ProgressPie)`
     flex: none;
 `;

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOfferSell/CoinmarketSelectedOfferSellBankAccount.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOfferSell/CoinmarketSelectedOfferSellBankAccount.tsx
@@ -111,15 +111,18 @@ const Right = styled.div`
     display: flex;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const RegisterAnother = styled(Button)`
     align-self: center;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     display: flex;
     min-width: 200px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledIcon = styled(Icon)`
     margin-right: ${spacingsPx.xxxs};
 `;

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOfferSell/CoinmarketSelectedOfferSellTransaction.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOfferSell/CoinmarketSelectedOfferSellTransaction.tsx
@@ -45,6 +45,7 @@ const Row = styled.div`
 
 const Address = styled.div``;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     display: flex;
     min-width: 200px;

--- a/packages/suite/src/views/wallet/coinmarket/common/ConfirmedOnTrezor.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/ConfirmedOnTrezor.tsx
@@ -17,6 +17,7 @@ const Confirmed = styled.div`
     gap: 10px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledRotateDeviceImage = styled(RotateDeviceImage)`
     height: 34px;
 `;

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Footer/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Footer/index.tsx
@@ -11,6 +11,7 @@ const Center = styled.div`
     justify-content: center;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     min-width: 200px;
     margin-left: 20px;

--- a/packages/suite/src/views/wallet/coinmarket/exchange/detail/components/PaymentConverting/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/detail/components/PaymentConverting/index.tsx
@@ -15,6 +15,7 @@ const Title = styled.div`
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledLink = styled(Link)`
     margin-top: 50px;
 `;

--- a/packages/suite/src/views/wallet/coinmarket/exchange/detail/components/PaymentFailed/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/detail/components/PaymentFailed/index.tsx
@@ -31,6 +31,7 @@ const Description = styled.div`
     text-align: center;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledLink = styled(Link)`
     margin-top: 30px;
     margin-bottom: 30px;

--- a/packages/suite/src/views/wallet/coinmarket/exchange/detail/components/PaymentKYC/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/detail/components/PaymentKYC/index.tsx
@@ -32,6 +32,7 @@ const Description = styled.div`
     text-align: center;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledLink = styled(Link)`
     margin-top: 5px;
     margin-bottom: 20px;

--- a/packages/suite/src/views/wallet/coinmarket/exchange/detail/components/PaymentSending/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/detail/components/PaymentSending/index.tsx
@@ -15,6 +15,7 @@ const Title = styled.div`
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledLink = styled(Link)`
     margin-top: 50px;
 `;

--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/SendSwapTransaction/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/SendSwapTransaction/index.tsx
@@ -107,6 +107,7 @@ const SlippageSettingsButton = styled.button`
     line-height: 1;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledInput = styled(Input)`
     align-self: center;
     margin-left: ${spacingsPx.xs};

--- a/packages/suite/src/views/wallet/coinmarket/exchange_new/components/ExchangeForm/Footer/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange_new/components/ExchangeForm/Footer/index.tsx
@@ -11,6 +11,7 @@ const Center = styled.div`
     justify-content: center;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     min-width: 200px;
     margin-left: 20px;

--- a/packages/suite/src/views/wallet/coinmarket/exchange_new/detail/components/PaymentConverting/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange_new/detail/components/PaymentConverting/index.tsx
@@ -15,6 +15,7 @@ const Title = styled.div`
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledLink = styled(Link)`
     margin-top: 50px;
 `;

--- a/packages/suite/src/views/wallet/coinmarket/exchange_new/detail/components/PaymentFailed/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange_new/detail/components/PaymentFailed/index.tsx
@@ -31,6 +31,7 @@ const Description = styled.div`
     text-align: center;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledLink = styled(Link)`
     margin-top: 30px;
     margin-bottom: 30px;

--- a/packages/suite/src/views/wallet/coinmarket/exchange_new/detail/components/PaymentKYC/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange_new/detail/components/PaymentKYC/index.tsx
@@ -32,6 +32,7 @@ const Description = styled.div`
     text-align: center;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledLink = styled(Link)`
     margin-top: 5px;
     margin-bottom: 20px;

--- a/packages/suite/src/views/wallet/coinmarket/exchange_new/detail/components/PaymentSending/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange_new/detail/components/PaymentSending/index.tsx
@@ -15,6 +15,7 @@ const Title = styled.div`
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledLink = styled(Link)`
     margin-top: 50px;
 `;

--- a/packages/suite/src/views/wallet/coinmarket/exchange_new/offers/Offers/SelectedOffer/components/SendSwapTransaction/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange_new/offers/Offers/SelectedOffer/components/SendSwapTransaction/index.tsx
@@ -99,6 +99,7 @@ const SlippageSettingsButton = styled.button`
     line-height: 1;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledInput = styled(Input)`
     align-self: center;
     margin-left: ${spacingsPx.xs};

--- a/packages/suite/src/views/wallet/coinmarket/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/index.tsx
@@ -54,6 +54,7 @@ export const Middle = styled.div<ResponsiveSize>`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 export const StyledIcon = styled(Icon)<ResponsiveSize>`
     @media screen and (max-width: ${props => variables.SCREEN_SIZE[props.$responsiveSize]}) {
         transform: rotate(90deg);
@@ -81,6 +82,7 @@ export const FooterWrapper = styled.div`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 export const StyledSelectBar = styled(SelectBar)`
     width: 100%;
 
@@ -89,6 +91,7 @@ export const StyledSelectBar = styled(SelectBar)`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 export const CoinmarketParagraph = styled(Paragraph)`
     text-align: center;
     color: ${({ theme }) => theme.legacy.TYPE_LIGHT_GREY};
@@ -146,6 +149,7 @@ export const CoinmarketFormOptionNetwork = styled.div<{ $elevation: Elevation }>
     border-radius: 4px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 export const CoinmarketTextButton = styled(TextButton)`
     position: relative;
     padding: 0;
@@ -161,6 +165,7 @@ export const CoinmarketAmountContainer = styled.div`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 export const CoinmarketAmountWrapper = styled(H2)`
     display: flex;
     align-items: center;

--- a/packages/suite/src/views/wallet/coinmarket/sell/components/SellForm/Footer/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/components/SellForm/Footer/index.tsx
@@ -37,6 +37,7 @@ const Label = styled.div`
     color: ${({ theme }) => theme.legacy.TYPE_LIGHT_GREY};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     display: flex;
     min-width: 200px;
@@ -49,6 +50,7 @@ const StyledButton = styled(Button)`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledSelect = styled(Select)`
     width: max-content;
 `;

--- a/packages/suite/src/views/wallet/coinmarket/sell/detail/components/PaymentFailed/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/detail/components/PaymentFailed/index.tsx
@@ -31,6 +31,7 @@ const Description = styled.div`
     text-align: center;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledLink = styled(Link)`
     margin-top: 30px;
     margin-bottom: 30px;

--- a/packages/suite/src/views/wallet/coinmarket/sell/detail/components/PaymentPending/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/detail/components/PaymentPending/index.tsx
@@ -15,6 +15,7 @@ const Title = styled.div`
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledLink = styled(Link)`
     margin-top: 50px;
 `;

--- a/packages/suite/src/views/wallet/coinmarket/sell/offers/Offers/SelectedOffer/components/SelectBankAccount.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/offers/Offers/SelectedOffer/components/SelectBankAccount.tsx
@@ -96,10 +96,12 @@ const Right = styled.div`
     display: flex;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const RegisterAnother = styled(Button)`
     align-self: center;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     display: flex;
     min-width: 200px;

--- a/packages/suite/src/views/wallet/coinmarket/sell/offers/Offers/SelectedOffer/components/SendTransaction.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/offers/Offers/SelectedOffer/components/SendTransaction.tsx
@@ -46,6 +46,7 @@ const Row = styled.div`
 
 const Address = styled.div``;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     display: flex;
     min-width: 200px;

--- a/packages/suite/src/views/wallet/coinmarket/sell_new/detail/components/PaymentFailed/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell_new/detail/components/PaymentFailed/index.tsx
@@ -31,6 +31,7 @@ const Description = styled.div`
     text-align: center;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledLink = styled(Link)`
     margin-top: 30px;
     margin-bottom: 30px;

--- a/packages/suite/src/views/wallet/coinmarket/sell_new/detail/components/PaymentPending/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell_new/detail/components/PaymentPending/index.tsx
@@ -15,6 +15,7 @@ const Title = styled.div`
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledLink = styled(Link)`
     margin-top: 50px;
 `;

--- a/packages/suite/src/views/wallet/coinmarket/skeleton/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/skeleton/index.tsx
@@ -43,6 +43,7 @@ const StyledLeft = styled(Left)`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledSkeletonRectangle = styled(SkeletonRectangle)`
     margin-bottom: 27px;
 `;

--- a/packages/suite/src/views/wallet/details/CoinjoinLogs.tsx
+++ b/packages/suite/src/views/wallet/details/CoinjoinLogs.tsx
@@ -7,6 +7,7 @@ import { useAnchor } from 'src/hooks/suite/useAnchor';
 import { CoinjoinLogsAnchor } from 'src/constants/suite/anchors';
 import { anchorOutlineStyles } from 'src/utils/suite/anchor';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const SetupCard = styled(Card)<{ $shouldHighlight?: boolean }>`
     position: relative;
     overflow: hidden;

--- a/packages/suite/src/views/wallet/details/CoinjoinSetup/SetupSlider/SliderInput.tsx
+++ b/packages/suite/src/views/wallet/details/CoinjoinSetup/SetupSlider/SliderInput.tsx
@@ -14,6 +14,7 @@ const LevelContainer = styled.div`
     width: 64px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Level = styled(Input)`
     input {
         background: none;

--- a/packages/suite/src/views/wallet/details/CoinjoinSetup/SkipRoundsSetup.tsx
+++ b/packages/suite/src/views/wallet/details/CoinjoinSetup/SkipRoundsSetup.tsx
@@ -31,6 +31,7 @@ const Text = styled.p`
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledSwitch = styled(Switch)`
     margin-top: 10px;
 `;

--- a/packages/suite/src/views/wallet/receive/components/CoinjoinReceiveWarning.tsx
+++ b/packages/suite/src/views/wallet/receive/components/CoinjoinReceiveWarning.tsx
@@ -10,6 +10,7 @@ const Container = styled.div`
     margin-bottom: 16px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const InfoIcon = styled(Icon)`
     width: 18px;
     height: 18px;
@@ -44,6 +45,7 @@ const WarningList = styled.ul`
     padding-left: 16px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     background: ${({ theme }) => theme.legacy.TYPE_DARK_ORANGE};
 

--- a/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
+++ b/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
@@ -13,6 +13,7 @@ import { networks } from '@suite-common/wallet-config';
 import { EvmExplanationBox } from 'src/components/wallet/EvmExplanationBox';
 import { spacingsPx, typography } from '@trezor/theme';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledCard = styled(Card)`
     width: 100%;
     flex-flow: row wrap;
@@ -38,6 +39,7 @@ const AddressContainer = styled.div`
     flex: 1;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     min-width: 220px;
     margin-left: ${spacingsPx.lg};
@@ -50,6 +52,7 @@ const FreshAddressWrapper = styled.div`
     margin-top: ${spacingsPx.xs};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledFreshAddress = styled(H2)`
     color: ${({ theme }) => theme.textDefault};
 `;

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/BitcoinOptions.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/BitcoinOptions.tsx
@@ -39,6 +39,7 @@ const Left = styled.div`
     flex-wrap: wrap;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const AddRecipientButton = styled(Button)`
     align-self: center;
 `;
@@ -47,6 +48,7 @@ const Right = styled.div`
     display: flex;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     margin: 4px 8px 4px 0;
 `;

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/CoinControl.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/CoinControl.tsx
@@ -36,6 +36,7 @@ const GreyText = styled.div`
     color: ${({ theme }) => theme.textSubdued};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledSwitch = styled(Switch)`
     margin: 0 14px 0 auto;
 `;

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelection.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelection.tsx
@@ -48,6 +48,7 @@ const DetailPartVisibleOnHover = styled.div<{ $alwaysVisible?: boolean }>`
         `};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledCheckbox = styled(Checkbox)`
     margin-top: ${spacingsPx.xxxs};
     margin-right: ${spacingsPx.xs};
@@ -117,6 +118,7 @@ const StyledCryptoAmount = styled(FormattedCryptoAmount)`
     white-space: nowrap;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const TransactionDetailButton = styled(TextButton)`
     color: ${({ theme }) => theme.textSubdued};
 
@@ -126,6 +128,7 @@ const TransactionDetailButton = styled(TextButton)`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledFluidSpinner = styled(Spinner)`
     margin-right: ${spacingsPx.xs};
 `;

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList.tsx
@@ -33,6 +33,7 @@ const Description = styled.div`
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledIcon = styled(Icon)<{ $backgroundColor?: string }>`
     background: ${({ $backgroundColor }) =>
         $backgroundColor && transparentize(0.9, $backgroundColor)};

--- a/packages/suite/src/views/wallet/send/Options/CardanoOptions.tsx
+++ b/packages/suite/src/views/wallet/send/Options/CardanoOptions.tsx
@@ -14,6 +14,7 @@ const Wrapper = styled.div`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const AddRecipientButton = styled(Button)`
     ${variables.SCREEN_QUERY.BELOW_TABLET} {
         width: 100%;

--- a/packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumOptions.tsx
+++ b/packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumOptions.tsx
@@ -19,6 +19,7 @@ const Left = styled.div`
     justify-content: flex-start;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     margin-right: 8px;
 

--- a/packages/suite/src/views/wallet/send/Options/RippleOptions/RippleOptions.tsx
+++ b/packages/suite/src/views/wallet/send/Options/RippleOptions/RippleOptions.tsx
@@ -18,6 +18,7 @@ const Left = styled.div`
     justify-content: flex-start;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     margin-right: 8px;
 `;

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
@@ -72,6 +72,7 @@ const TokenBalanceValue = styled.span`
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledTransferIcon = styled(Icon)`
     margin: 0 20px 46px;
     align-self: end;

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/SendMaxSwitch.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/SendMaxSwitch.tsx
@@ -4,6 +4,7 @@ import { spacingsPx } from '@trezor/theme';
 import { Translation } from 'src/components/suite';
 import styled, { css } from 'styled-components';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledSwitch = styled(Switch)<{
     $hideOnLargeScreens?: boolean;
     $hideOnSmallScreens?: boolean;

--- a/packages/suite/src/views/wallet/send/Outputs/OpReturn.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/OpReturn.tsx
@@ -29,6 +29,7 @@ const Inputs = styled.div`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledTextarea = styled(Textarea)`
     > :nth-child(1) {
         border-color: ${({ theme }) => theme.borderElevation2};

--- a/packages/suite/src/views/wallet/send/SendHeader.tsx
+++ b/packages/suite/src/views/wallet/send/SendHeader.tsx
@@ -8,6 +8,7 @@ import { sendFormActions } from '@suite-common/wallet-core';
 import { FADE_IN } from '@trezor/components/src/config/animations';
 import { ConnectDeviceSendPromo } from 'src/views/wallet/receive/components/ConnectDevicePromo';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const ClearButton = styled(Button)`
     animation: ${FADE_IN} 0.16s;
 `;

--- a/packages/suite/src/views/wallet/send/SendRaw.tsx
+++ b/packages/suite/src/views/wallet/send/SendRaw.tsx
@@ -11,16 +11,19 @@ import { Account } from 'src/types/wallet';
 import { OpenGuideFromTooltip } from 'src/components/guide';
 import { spacingsPx } from '@trezor/theme';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledCard = styled(Card)`
     position: relative;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const CloseIcon = styled(Icon)`
     position: absolute;
     right: ${spacingsPx.md};
     top: ${spacingsPx.md};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledTextarea = styled(Textarea)`
     margin: ${spacingsPx.md} 0 ${spacingsPx.lg};
 
@@ -30,6 +33,7 @@ const StyledTextarea = styled(Textarea)`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const SendButton = styled(Button)`
     margin: 0 auto;
     min-width: 120px;

--- a/packages/suite/src/views/wallet/send/TotalSent/ReviewButton.tsx
+++ b/packages/suite/src/views/wallet/send/TotalSent/ReviewButton.tsx
@@ -15,10 +15,12 @@ const Container = styled.div`
     gap: ${spacingsPx.md};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledWarning = styled(Warning)`
     justify-content: flex-start;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const ButtonReview = styled(TooltipButton)<{ $isRed: boolean }>`
     background: ${({ $isRed, theme }) => $isRed && theme.legacy.BUTTON_RED};
     display: flex;

--- a/packages/suite/src/views/wallet/send/TotalSent/TotalSent.tsx
+++ b/packages/suite/src/views/wallet/send/TotalSent/TotalSent.tsx
@@ -6,6 +6,7 @@ import { Translation, FiatValue, FormattedCryptoAmount } from 'src/components/su
 import { ReviewButton } from './ReviewButton';
 import { spacingsPx } from '@trezor/theme';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledCard = styled(Card)`
     position: sticky;
     top: 60px;

--- a/packages/suite/src/views/wallet/sign-verify/components/ButtonRow.tsx
+++ b/packages/suite/src/views/wallet/sign-verify/components/ButtonRow.tsx
@@ -29,6 +29,7 @@ export const Row = styled.div`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)`
     width: 170px;
 

--- a/packages/suite/src/views/wallet/sign-verify/components/HiddenAddressRow.tsx
+++ b/packages/suite/src/views/wallet/sign-verify/components/HiddenAddressRow.tsx
@@ -3,6 +3,7 @@ import { GradientOverlay, useElevation } from '@trezor/components';
 import type { AddressItem } from 'src/hooks/wallet/sign-verify/useSignAddressOptions';
 import { borders, nextElevation, spacingsPx } from '@trezor/theme';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledGradientOverlay = styled(GradientOverlay)`
     margin: -${spacingsPx.xs};
     border-radius: ${borders.radii.xxs};

--- a/packages/suite/src/views/wallet/sign-verify/index.tsx
+++ b/packages/suite/src/views/wallet/sign-verify/index.tsx
@@ -61,6 +61,7 @@ const FormatDescription = styled.p`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledSelectBar = styled(SelectBar)`
     margin: ${spacingsPx.sm} 0 ${spacingsPx.lg};
 
@@ -86,6 +87,7 @@ const Divider = styled.div`
     background: ${({ theme }) => theme.legacy.STROKE_GREY};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const CopyButton = styled(Button)`
     position: absolute;
     right: 0;

--- a/packages/suite/src/views/wallet/staking/components/CardanoPrimitives.ts
+++ b/packages/suite/src/views/wallet/staking/components/CardanoPrimitives.ts
@@ -6,6 +6,7 @@ export const Heading = styled.div`
     padding-left: 5px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 export const StyledH2 = styled(H2)`
     display: flex;
     flex-direction: row;

--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/EmptyStakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/EmptyStakingCard.tsx
@@ -10,11 +10,13 @@ import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReduce
 import { selectPoolStatsApyData } from '@suite-common/wallet-core';
 import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledP = styled(Paragraph)`
     margin-top: ${spacingsPx.xs};
     color: ${({ theme }) => theme.textSubdued};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const GreenP = styled(Paragraph)`
     color: ${({ theme }) => theme.textPrimaryDefault};
 `;
@@ -44,6 +46,7 @@ const FlexRowChild = styled.div`
     flex: 1 0 200px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledTooltip = styled(Tooltip)`
     width: fit-content;
 `;

--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/StakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/StakingCard.tsx
@@ -53,6 +53,7 @@ const ButtonsWrapper = styled.div`
     flex-wrap: wrap;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button).attrs(props => ({
     ...props,
     variant: 'tertiary',

--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/claim/ClaimReadyCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/claim/ClaimReadyCard.tsx
@@ -22,6 +22,7 @@ const StyledCard = styled.div`
     overflow: hidden;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledIcon = styled(Icon)`
     transform: rotate(20deg);
 `;
@@ -56,6 +57,7 @@ const InfoHeading = styled.div`
     margin-bottom: ${spacingsPx.sm};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledP = styled(Paragraph)`
     font-size: ${variables.FONT_SIZE.H2};
     line-height: 24px;

--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/styled.ts
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/styled.ts
@@ -6,11 +6,13 @@ export const CardBottomContent = styled.div`
     margin-top: ${spacingsPx.lg};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 export const AccentP = styled(Paragraph)`
     color: ${({ theme }) => theme.textDefault};
     font-size: ${variables.FONT_SIZE.H2};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 export const GreyP = styled(Paragraph)`
     color: ${({ theme }) => theme.textSubdued};
     font-size: ${variables.FONT_SIZE.SMALL};

--- a/packages/suite/src/views/wallet/tokens/common/BlurUrls.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/BlurUrls.tsx
@@ -5,6 +5,7 @@ import { BlurWrapper } from 'src/components/wallet/TransactionItem/TransactionIt
 import { Translation } from 'src/components/suite';
 import { extractUrlsFromText } from '@trezor/utils';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledTooltip = styled(Tooltip)`
     display: inline-block;
 `;

--- a/packages/suite/src/views/wallet/tokens/common/TokensList/TokenList.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensList/TokenList.tsx
@@ -9,6 +9,7 @@ import { useState } from 'react';
 import { AnimationWrapper } from 'src/components/wallet/AnimationWrapper';
 import { TokenRow } from './TokenRow';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Table = styled(Card)`
     word-break: break-all;
 `;
@@ -32,6 +33,7 @@ const NoResults = styled.div`
     text-align: center;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const ChevronIcon = styled(Icon)<{ $isActive: boolean }>`
     padding: ${spacingsPx.sm};
     border-radius: 50%;

--- a/packages/suite/src/views/wallet/tokens/common/TokensList/TokenRow.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensList/TokenRow.tsx
@@ -105,6 +105,7 @@ const ContractAddress = styled.div`
     white-space: wrap;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledIcon = styled(Icon)`
     display: inline-block;
     margin-left: ${spacingsPx.xxs};

--- a/packages/suite/src/views/wallet/transactions/CoinjoinExplanation/CoinjoinExplanation.tsx
+++ b/packages/suite/src/views/wallet/transactions/CoinjoinExplanation/CoinjoinExplanation.tsx
@@ -10,6 +10,7 @@ import { CoinjoinProcessStep, CoinjoinProcessStepProps } from './CoinjoinProcess
 import { spacings, spacingsPx, typography } from '@trezor/theme';
 import { LearnMoreButton } from 'src/components/suite/LearnMoreButton';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Container = styled(Card)`
     background: ${({ theme }) => theme.backgroundTertiaryDefaultOnElevation0};
 `;
@@ -22,6 +23,7 @@ const Heading = styled.div`
     ${typography.hint};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Steps = styled(Card)`
     box-shadow: none;
     display: grid;

--- a/packages/suite/src/views/wallet/transactions/CoinjoinExplanation/CoinjoinProcessStep.tsx
+++ b/packages/suite/src/views/wallet/transactions/CoinjoinExplanation/CoinjoinProcessStep.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { H3, Image, ImageType, Paragraph, variables } from '@trezor/components';
 import { Translation } from 'src/components/suite/Translation';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledImage = styled(Image)`
     margin: -8px;
 
@@ -13,6 +14,7 @@ const StyledImage = styled(Image)`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StepNumber = styled(Paragraph)`
     margin: 24px 0 6px;
     color: ${({ theme }) => theme.textSubdued};
@@ -23,6 +25,7 @@ const StepNumber = styled(Paragraph)`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StepTitle = styled(H3)`
     margin-bottom: 20px;
 
@@ -34,6 +37,7 @@ const StepTitle = styled(H3)`
     }
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StepDescription = styled(Paragraph)`
     color: ${({ theme }) => theme.legacy.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};

--- a/packages/suite/src/views/wallet/transactions/CoinjoinSummary/BalancePrivacyBreakdown/BalancePrivacyBreakdown.tsx
+++ b/packages/suite/src/views/wallet/transactions/CoinjoinSummary/BalancePrivacyBreakdown/BalancePrivacyBreakdown.tsx
@@ -30,6 +30,7 @@ const PrivateBalanceHeading = styled.span`
 `;
 
 // svg padding offset
+// eslint-disable-next-line local-rules/no-override-ds-component
 const CheckIcon = styled(Icon)`
     width: 15px;
     height: 15px;

--- a/packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinStatusWheel/CoinjoinProgressContent.tsx
+++ b/packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinStatusWheel/CoinjoinProgressContent.tsx
@@ -44,6 +44,7 @@ const ProgressPercentage = styled.p`
     ${typography.titleMedium}
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledLoader = styled(Spinner)`
     opacity: 0.4;
 `;

--- a/packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinStatusWheel/CoinjoinStatusWheel.tsx
+++ b/packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinStatusWheel/CoinjoinStatusWheel.tsx
@@ -9,6 +9,7 @@ import { useDispatch } from 'src/hooks/suite';
 import { stopCoinjoinSession } from 'src/actions/wallet/coinjoinClientActions';
 import { typography } from '@trezor/theme';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Container = styled(Card)<{ $isWide?: boolean }>`
     position: relative;
     display: flex;
@@ -23,6 +24,7 @@ const Container = styled(Card)<{ $isWide?: boolean }>`
     text-align: center;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StopButton = styled(Button)`
     /* 23px button height + 7 margin = 30 height of StatusMessage */
     margin-top: 7px;

--- a/packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinSummary.tsx
+++ b/packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinSummary.tsx
@@ -9,6 +9,7 @@ const Container = styled.div`
     margin-bottom: 32px;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Heading = styled(H3)`
     margin-bottom: 28px;
 `;

--- a/packages/suite/src/views/wallet/transactions/TradeBox/TradeBox.tsx
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/TradeBox.tsx
@@ -8,6 +8,7 @@ import { TradeBoxMenu } from './TradeBoxMenu';
 import { TradeBoxPrices } from './TradeBoxPrices';
 import { getTitleForNetwork } from '@suite-common/wallet-utils';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledCard = styled(Card)`
     flex-flow: row wrap;
     align-items: center;

--- a/packages/suite/src/views/wallet/transactions/TradeBox/TradeBoxMenu.tsx
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/TradeBoxMenu.tsx
@@ -15,6 +15,7 @@ const Wrapper = styled.div`
     gap: ${spacingsPx.sm};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledButton = styled(Button)<{ $isHideable: boolean }>`
     ${({ $isHideable }) =>
         $isHideable &&

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionCandidates.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionCandidates.tsx
@@ -23,6 +23,7 @@ const Header = styled.div`
     z-index: ${zIndices.secondaryStickyBar};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Wrapper = styled(Card)`
     display: flex;
     flex-direction: row;

--- a/packages/suite/src/views/wallet/transactions/components/AccountEmpty.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/AccountEmpty.tsx
@@ -14,6 +14,7 @@ const Wrapper = styled.div`
     align-items: center;
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const Title = styled(H2)`
     text-align: center;
     font-weight: 600;
@@ -26,6 +27,7 @@ const Description = styled.span`
     color: ${({ theme }) => theme.legacy.TYPE_LIGHT_GREY};
 `;
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 const StyledImage = styled(Image)`
     width: auto;
     height: 80px;

--- a/packages/transport-bridge/src/ui/components/Card.tsx
+++ b/packages/transport-bridge/src/ui/components/Card.tsx
@@ -1,7 +1,8 @@
 import styled from 'styled-components';
 
-import { Card as ComponentsCard } from '@trezor/components/src/components/Card/Card';
+import { Card as ComponentsCard } from '@trezor/components';
 
+// eslint-disable-next-line local-rules/no-override-ds-component
 export const Card = styled(ComponentsCard)`
     margin: 8px 0;
 `;

--- a/suite-native/react-native-graph/src/AnimatedLineGraph.tsx
+++ b/suite-native/react-native-graph/src/AnimatedLineGraph.tsx
@@ -30,6 +30,8 @@ import {
     Shadow,
 } from '@shopify/react-native-skia';
 
+import { hexToRgba } from '@suite-common/suite-utils';
+
 import type { AnimatedLineGraphProps, GraphEventWithCords } from './LineGraphProps';
 import { SelectionDot as DefaultSelectionDot } from './SelectionDot';
 import {
@@ -47,7 +49,6 @@ import { DefaultGraphEvent } from './DefaultGraphEvent';
 import { useEventTooltipProps } from './hooks/useEventTooltipProps';
 import { LoadingLine } from './LoadingLine';
 import { BlurOverlay } from './BlurOverlay';
-import { hexToRgba } from '@suite-common/suite-utils';
 
 const INDICATOR_RADIUS = 7;
 const INDICATOR_BORDER_MULTIPLIER = 1.3;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- overriding components is now throwing error, not just warning
- all existing occurrences have comment for disabling this rule as exception (it's going to be refactored later)
- add rule also for product-components


This allows not seeing 300+ warnings during checking every PR

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
