### PR TITLE
fix(suite): change misleading copy mentioning browser in desktop debu…

### DIFF
--- a/packages/suite/src/components/suite/ConnectDevicePrompt.tsx
+++ b/packages/suite/src/components/suite/ConnectDevicePrompt.tsx
@@ -9,6 +9,7 @@ import {
     ElevationUp,
     Icon,
 } from '@trezor/components';
+import { isDesktop } from '@trezor/env-utils';
 import { Translation } from 'src/components/suite';
 import { useDevice, useDispatch } from 'src/hooks/suite';
 import { goto } from 'src/actions/suite/routerActions';
@@ -72,7 +73,7 @@ const getMessageId = ({
 }) => {
     switch (prerequisite) {
         case 'transport-bridge':
-            return 'TR_NO_TRANSPORT';
+            return isDesktop() ? 'TR_NO_TRANSPORT_DESKTOP' : 'TR_NO_TRANSPORT';
         case 'device-bootloader':
             return 'TR_DEVICE_CONNECTED_BOOTLOADER';
         default: {

--- a/packages/suite/src/components/suite/troubleshooting/tips/index.tsx
+++ b/packages/suite/src/components/suite/troubleshooting/tips/index.tsx
@@ -18,7 +18,7 @@ export const TROUBLESHOOTING_TIP_WEBUSB_ENVIRONMENT = {
     key: 'webusb-environment',
     heading: <Translation id="TR_TROUBLESHOOTING_TIP_BROWSER_WEBUSB_TITLE" />,
     description: <Translation id="TR_TROUBLESHOOTING_TIP_BROWSER_WEBUSB_DESCRIPTION" />,
-    hide: isWebUsb(),
+    hide: isWebUsb() || !isWeb(),
 };
 
 export const TROUBLESHOOTING_TIP_SUITE_DESKTOP = {

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3370,6 +3370,11 @@ export default defineMessages({
         description: '',
         id: 'TR_NO_TRANSPORT',
     },
+    TR_NO_TRANSPORT_DESKTOP: {
+        defaultMessage: "App can't communicate with device",
+        description: 'similar to TR_NO_TRANSPORT but for desktop',
+        id: 'TR_NO_TRANSPORT_DESKTOP',
+    },
     TR_TRY_AGAIN: {
         defaultMessage: 'Try again',
         description: 'Try to run the process again',


### PR DESCRIPTION
based on discussion here https://satoshilabs.slack.com/archives/CKZHV2G13/p1724747991665409

the screen you will see when for whatever reason bridge dies (or does not start) while using desktop application.

<img width="883" alt="image" src="https://github.com/user-attachments/assets/24ee1012-7473-47b0-bb72-250540277e8c">
