### PR TITLE
fix(suite): account exception refresh button icon

### DIFF
--- a/packages/suite/src/views/dashboard/components/PortfolioCard/components/Exception.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/components/Exception.tsx
@@ -138,6 +138,7 @@ export const Exception = ({ exception, discovery }: ExceptionProps) => {
                     description="TR_ACCOUNT_EXCEPTION_AUTH_ERROR_DESC"
                     cta={{
                         action: () => dispatch(authorizeDeviceThunk()),
+                        icon: 'refresh',
                     }}
                     dataTestBase={exception.type}
                 />
@@ -146,7 +147,10 @@ export const Exception = ({ exception, discovery }: ExceptionProps) => {
             return (
                 <Container
                     title="TR_AUTH_CONFIRM_FAILED_TITLE"
-                    cta={{ action: () => dispatch(authConfirm()) }}
+                    cta={{
+                        action: () => dispatch(authConfirm()),
+                        icon: 'refresh',
+                    }}
                     dataTestBase={exception.type}
                 />
             );


### PR DESCRIPTION
## Description

Minor UI pet peeve with the refresh button icon that appears during account exceptions on PortfolioCard

## Screenshots:

Before
<img width="720" alt="Screenshot 2024-09-02 at 10 09 05" src="https://github.com/user-attachments/assets/2192ca17-fee4-4545-ae99-c0a03e44f6ee">

After
<img width="720" alt="Screenshot 2024-09-02 at 10 10 50" src="https://github.com/user-attachments/assets/ed8d1f13-ea2d-4a2b-a047-961d37e92034">
