### PR TITLE
fix(connect-examples): add asterisk to match popup urls for content script

### DIFF
--- a/packages/connect-examples/webextension-mv2/README.md
+++ b/packages/connect-examples/webextension-mv2/README.md
@@ -81,7 +81,7 @@ Basic implementation is the same for both Google Chrome & Firefox. However, few 
             "content_scripts": [
                 {
                 "matches": [
-                    "*://connect.trezor.io/*/popup.html"
+                    "*://connect.trezor.io/*/popup.html*"
                 ],
                 "js": ["trezor-content-script.js"]
                 }

--- a/packages/connect-examples/webextension-mv2/src/manifest-firefox.json
+++ b/packages/connect-examples/webextension-mv2/src/manifest-firefox.json
@@ -27,7 +27,7 @@
     "content_scripts": [
         {
             "matches": [
-                "*://connect.trezor.io/9/popup.html",
+                "*://connect.trezor.io/9/popup.html*",
                 "*://suite.corp.sldev.cz/*",
                 "*://dev.suite.sldev.cz/*",
                 "*://staging-connect.trezor.io/*"

--- a/packages/connect-examples/webextension-mv2/src/manifest.json
+++ b/packages/connect-examples/webextension-mv2/src/manifest.json
@@ -20,7 +20,7 @@
     "content_scripts": [
         {
             "matches": [
-                "*://connect.trezor.io/9/popup.html",
+                "*://connect.trezor.io/9/popup.html*",
                 "*://suite.corp.sldev.cz/*",
                 "*://dev.suite.sldev.cz/*",
                 "*://staging-connect.trezor.io/*"

--- a/packages/connect-examples/webextension-mv3/src/manifest.json
+++ b/packages/connect-examples/webextension-mv3/src/manifest.json
@@ -8,7 +8,7 @@
     "content_scripts": [
         {
             "matches": [
-                "*://connect.trezor.io/9/popup.html",
+                "*://connect.trezor.io/9/popup.html*",
                 "*://suite.corp.sldev.cz/*",
                 "*://dev.suite.sldev.cz/*",
                 "*://staging-connect.trezor.io/*"

--- a/packages/connect-web/src/webextension/README.md
+++ b/packages/connect-web/src/webextension/README.md
@@ -54,7 +54,7 @@ Basic implementation is same for both Google Chrome & Firefox. However, few addi
             "content_scripts": [
                 {
                 "matches": [
-                    "*://connect.trezor.io/*/popup.html"
+                    "*://connect.trezor.io/*/popup.html*"
                 ],
                 "js": ["trezor-content-script.js"]
                 }


### PR DESCRIPTION
## Description

I encountered an issue with Firefox, where the content script wouldn't load on the popup page. 
This is because we added URL parameters that pass additional information to the popup page and Firefox needs an extra asterisk at the end for the URL to fit the match expression. 

So this PR updates the match URLs in all examples where we use it.