### PR TITLE
fix(suite-desktop-core): await bridge module load

### DIFF
--- a/packages/suite-desktop-core/src/modules/bridge.ts
+++ b/packages/suite-desktop-core/src/modules/bridge.ts
@@ -4,6 +4,7 @@
 import { TrezordNode } from '@trezor/transport-bridge';
 import { isDevEnv } from '@suite-common/suite-utils';
 import { validateIpcMessage } from '@trezor/ipc-proxy';
+import { scheduleAction } from '@trezor/utils';
 
 import { app, ipcMain } from '../typed-electron';
 import { BridgeProcess } from '../libs/processes/BridgeProcess';
@@ -205,7 +206,10 @@ export const init: Module = dependencies => {
     return () => {
         if (loaded) return;
         loaded = true;
-        // TODO intentionally not awaited to mimic previous behavior, resolve later!
-        load(dependencies);
+
+        return scheduleAction(() => load(dependencies), { timeout: 3000 }).catch(err => {
+            // Error ignored, user will see transport error afterwards
+            logger.error(SERVICE_NAME, `Failed to load: ${err.message}`);
+        });
     };
 };


### PR DESCRIPTION
## Description

Bridge module loading was previously not awaited, according to a comment - to mimic previous behavior. 

However this can sometimes cause the "No transport" screen to appear for a short time while the app is starting up. 
Awaiting the module solves this.