### PR TITLE
chore(wallet-config): FIle reorganisation (extract types)

### DIFF
--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -1,102 +1,14 @@
 import { DeviceModelInternal } from '@trezor/connect';
 import type { Without } from '@trezor/type-utils';
 
-export type NetworkSymbol =
-    | 'btc'
-    | 'ltc'
-    | 'eth'
-    | 'etc'
-    | 'xrp'
-    | 'bch'
-    | 'btg'
-    | 'dash'
-    | 'dgb'
-    | 'doge'
-    | 'nmc'
-    | 'vtc'
-    | 'zec'
-    | 'ada'
-    | 'sol'
-    | 'matic'
-    | 'bnb'
-    | 'test'
-    | 'regtest'
-    | 'tsep'
-    | 'thol'
-    | 'txrp'
-    | 'tada'
-    | 'dsol';
-
-export type NetworkType = 'bitcoin' | 'ethereum' | 'ripple' | 'cardano' | 'solana';
-
-type UtilityAccountType = 'normal' | 'imported'; // reserved accountTypes to stand in for a real accountType
-type RealAccountType = 'legacy' | 'segwit' | 'coinjoin' | 'taproot' | 'ledger';
-export type AccountType = UtilityAccountType | RealAccountType;
-
-export const TREZOR_CONNECT_BACKENDS = [
-    'blockbook',
-    'electrum',
-    'ripple',
-    'blockfrost',
-    'solana',
-] as const;
-export const NON_STANDARD_BACKENDS = ['coinjoin'] as const;
-
-type TrezorConnectBackendType = (typeof TREZOR_CONNECT_BACKENDS)[number];
-type NonStandardBackendType = (typeof NON_STANDARD_BACKENDS)[number];
-export type BackendType = TrezorConnectBackendType | NonStandardBackendType;
-
-export type NetworkFeature =
-    | 'rbf'
-    | 'sign-verify'
-    | 'amount-unit'
-    | 'tokens'
-    | 'staking'
-    | 'coin-definitions'
-    | 'nft-definitions';
-
-export type Explorer = {
-    tx: string;
-    account: string;
-    address: string;
-    nft?: string;
-    token?: string;
-    queryString?: string;
-};
-
-export type Account = {
-    bip43Path: string;
-    backendType?: BackendType;
-    features?: NetworkFeature[];
-    isDebugOnlyAccountType?: boolean;
-};
-
-// template types serve only to check if `networks` satisfies it. Exact type is inferred below
-export type NetworkAccountTypes = Partial<Record<AccountType, Account>>;
-
-export type NetworkDeviceSupport = Partial<Record<DeviceModelInternal, string>>;
-
-export type Network = {
-    symbol: NetworkSymbol;
-    name: string;
-    networkType: NetworkType;
-    bip43Path: string;
-    decimals: number;
-    testnet: boolean;
-    explorer: Explorer;
-    accountTypes: NetworkAccountTypes;
-    isHidden?: boolean; // not used here, but supported elsewhere
-    chainId?: number;
-    features: NetworkFeature[];
-    customBackends: BackendType[];
-    support?: NetworkDeviceSupport;
-    isDebugOnlyNetwork?: boolean;
-    coingeckoId?: string;
-};
-
-export type Networks = {
-    [key in NetworkSymbol]: Network;
-};
+import {
+    AccountType,
+    BackendType,
+    Explorer,
+    NetworkFeature,
+    Networks,
+    NetworkSymbol,
+} from './types';
 
 export const networks = {
     btc: {

--- a/suite-common/wallet-config/src/types.ts
+++ b/suite-common/wallet-config/src/types.ts
@@ -1,9 +1,98 @@
-import { networks, NetworkSymbol } from './networksConfig';
+import { DeviceModelInternal } from '@trezor/connect';
 
-export const isNetworkSymbol = (symbol: NetworkSymbol | string): symbol is NetworkSymbol =>
-    symbol in networks;
+export type NetworkSymbol =
+    | 'btc'
+    | 'ltc'
+    | 'eth'
+    | 'etc'
+    | 'xrp'
+    | 'bch'
+    | 'btg'
+    | 'dash'
+    | 'dgb'
+    | 'doge'
+    | 'nmc'
+    | 'vtc'
+    | 'zec'
+    | 'ada'
+    | 'sol'
+    | 'matic'
+    | 'bnb'
+    | 'test'
+    | 'regtest'
+    | 'tsep'
+    | 'thol'
+    | 'txrp'
+    | 'tada'
+    | 'dsol';
 
-export const isEthereumBasedNetwork = (
-    network: (typeof networks)[NetworkSymbol],
-): network is (typeof networks)[NetworkSymbol] & { chainId: number } =>
-    network.networkType === 'ethereum';
+export type NetworkType = 'bitcoin' | 'ethereum' | 'ripple' | 'cardano' | 'solana';
+
+type UtilityAccountType = 'normal' | 'imported'; // reserved accountTypes to stand in for a real accountType
+type RealAccountType = 'legacy' | 'segwit' | 'coinjoin' | 'taproot' | 'ledger';
+export type AccountType = UtilityAccountType | RealAccountType;
+
+export const TREZOR_CONNECT_BACKENDS = [
+    'blockbook',
+    'electrum',
+    'ripple',
+    'blockfrost',
+    'solana',
+] as const;
+export const NON_STANDARD_BACKENDS = ['coinjoin'] as const;
+
+type TrezorConnectBackendType = (typeof TREZOR_CONNECT_BACKENDS)[number];
+type NonStandardBackendType = (typeof NON_STANDARD_BACKENDS)[number];
+export type BackendType = TrezorConnectBackendType | NonStandardBackendType;
+
+export type NetworkFeature =
+    | 'rbf'
+    | 'sign-verify'
+    | 'amount-unit'
+    | 'tokens'
+    | 'staking'
+    | 'coin-definitions'
+    | 'nft-definitions';
+
+export type Explorer = {
+    tx: string;
+    account: string;
+    address: string;
+    nft?: string;
+    token?: string;
+    queryString?: string;
+};
+
+export type Account = {
+    bip43Path: string;
+    backendType?: BackendType;
+    features?: NetworkFeature[];
+    isDebugOnlyAccountType?: boolean;
+};
+
+// template types serve only to check if `networks` satisfies it. Exact type is inferred below
+export type NetworkAccountTypes = Partial<Record<AccountType, Account>>;
+
+export type NetworkDeviceSupport = Partial<Record<DeviceModelInternal, string>>;
+
+export type Network = {
+    symbol: NetworkSymbol;
+    name: string;
+    networkType: NetworkType;
+    bip43Path: string;
+    decimals: number;
+    testnet: boolean;
+    explorer: Explorer;
+    accountTypes: NetworkAccountTypes;
+    isHidden?: boolean; // not used here, but supported elsewhere
+    chainId?: number;
+    features: NetworkFeature[];
+    customBackends: BackendType[];
+    support?: NetworkDeviceSupport;
+    isDebugOnlyNetwork?: boolean;
+    coingeckoId?: string;
+};
+
+export type Networks = {
+    [key in NetworkSymbol]: Network;
+};

--- a/suite-common/wallet-config/src/utils.ts
+++ b/suite-common/wallet-config/src/utils.ts
@@ -1,12 +1,5 @@
-import {
-    AccountType,
-    Networks,
-    Network,
-    NetworkFeature,
-    networks,
-    networksCompatibility,
-    NetworkSymbol,
-} from './networksConfig';
+import { networks, networksCompatibility } from './networksConfig';
+import { AccountType, Network, NetworkFeature, Networks, NetworkSymbol } from './types';
 
 const networksCollection: Network[] = Object.values(networks);
 
@@ -69,3 +62,6 @@ export const getNetworkFeatures = (symbol: NetworkSymbol) =>
     networks[symbol]?.features as unknown as NetworkFeature;
 
 export const getCoingeckoId = (symbol: NetworkSymbol) => networks[symbol]?.coingeckoId;
+
+export const isNetworkSymbol = (symbol: NetworkSymbol | string): symbol is NetworkSymbol =>
+    networks.hasOwnProperty(symbol);


### PR DESCRIPTION
4th of many PRs to refactor & cleanup `networksConfig`: 

## Description

- move types from `networkConfig.ts` into `types.ts`
- move type guard functions from `types.ts` to `utils.ts`
  - it'd create circular dependency, but more importantly they're not really types, so they don't belong there!
  - remove unused `isEthereumBasedNetwork`

## Related Issue

Part of #13839