### PR TITLE
fix: storage middleware fiat rates error

### DIFF
--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -106,15 +106,18 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 )(action)
             ) {
                 const { account } = action.payload;
-                const device = findAccountDevice(account, selectDevices(api.getState()));
-                const historicRates = selectHistoricFiatRates(api.getState());
-                // update only historic rates for remembered device
-                if (isDeviceRemembered(device)) {
-                    storageActions.removeAccountHistoricRates(account.key);
-                    if (historicRates) {
-                        api.dispatch(
-                            storageActions.saveAccountHistoricRates(account.key, historicRates),
-                        );
+                // TS doesn't know return type of updateTxsFiatRatesThunk.fulfilled, investigate why
+                if (account) {
+                    const device = findAccountDevice(account, selectDevices(api.getState()));
+                    const historicRates = selectHistoricFiatRates(api.getState());
+                    // update only historic rates for remembered device
+                    if (isDeviceRemembered(device)) {
+                        storageActions.removeAccountHistoricRates(account.key);
+                        if (historicRates) {
+                            api.dispatch(
+                                storageActions.saveAccountHistoricRates(account.key, historicRates),
+                            );
+                        }
                     }
                 }
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Simple fix but it's concerning that TS didn't complain and it seems that it didn't know return type of `updateTxsFiatRatesThunk.fulfilled` sadly I don't have time to investigate it now.

Also it seems that this code may be not needed anyway because of recent fiat rates refactor, maybe @AdamSchinzel should investigate it.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
