### PR TITLE
feat: improve token definitions perf

### DIFF
--- a/suite-common/token-definitions/src/tokenDefinitionsSelectors.ts
+++ b/suite-common/token-definitions/src/tokenDefinitionsSelectors.ts
@@ -26,12 +26,12 @@ export const selectCoinDefinition = (
     state: TokenDefinitionsRootState,
     networkSymbol: NetworkSymbol,
     contractAddress: TokenAddress,
-) =>
-    isTokenDefinitionKnown(
-        state.tokenDefinitions?.[networkSymbol]?.coin?.data,
-        networkSymbol,
-        contractAddress,
-    );
+) => {
+    const coinDefinitions = state.tokenDefinitions?.[networkSymbol]?.coin?.data;
+    const isKnown = isTokenDefinitionKnown(coinDefinitions, networkSymbol, contractAddress);
+
+    return isKnown;
+};
 
 export const selectIsSpecificCoinDefinitionKnown = (
     state: TokenDefinitionsRootState,

--- a/suite-common/token-definitions/src/tokenDefinitionsUtils.ts
+++ b/suite-common/token-definitions/src/tokenDefinitionsUtils.ts
@@ -14,6 +14,9 @@ export const getContractAddressForNetwork = (
     contractAddress: string,
 ) => {
     switch (networkSymbol) {
+        case 'eth':
+            // Specyfing most common network as first case improves performance little bit
+            return contractAddress.toLowerCase();
         case 'sol':
         case 'dsol':
             return contractAddress;
@@ -27,14 +30,23 @@ export const getContractAddressForNetwork = (
     }
 };
 
+// Using Set greatly improves performance of this function because of O(1) complexity instead of O(n) for Array.includes
+const tokenDefinitionsMap = new Map<SimpleTokenStructure, Set<string>>();
 export const isTokenDefinitionKnown = (
     tokenDefinitions: SimpleTokenStructure | undefined,
     networkSymbol: NetworkSymbol,
     contractAddress: string,
-) =>
-    Array.isArray(tokenDefinitions)
-        ? tokenDefinitions?.includes(getContractAddressForNetwork(networkSymbol, contractAddress))
-        : false;
+) => {
+    if (!tokenDefinitions) return false;
+
+    if (!tokenDefinitionsMap.has(tokenDefinitions)) {
+        tokenDefinitionsMap.set(tokenDefinitions, new Set(tokenDefinitions));
+    }
+
+    const contractAddressForNetwork = getContractAddressForNetwork(networkSymbol, contractAddress);
+
+    return tokenDefinitionsMap.get(tokenDefinitions)?.has(contractAddressForNetwork);
+};
 
 export const getSupportedDefinitionTypes = (networkSymbol: NetworkSymbol) => {
     const isCoinDefinitionsEnabled = getNetworkFeatures(networkSymbol).includes('coin-definitions');

--- a/suite-native/tokens/src/ethereumTokensSelectors.ts
+++ b/suite-native/tokens/src/ethereumTokensSelectors.ts
@@ -213,7 +213,7 @@ export const selectNumberOfUniqueEthereumTokensPerDevice = memoize(
     (state: AccountsRootState & DeviceRootState & TokenDefinitionsRootState) => {
         return pipe(
             selectUniqueEtheruemTokens(state),
-            A.filter(tokenAddress => selectCoinDefinition(state, 'eth', tokenAddress)),
+            A.filter(tokenAddress => !!selectCoinDefinition(state, 'eth', tokenAddress)),
             A.length,
         );
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR greatly improves performance of checking token definitions. There is something about ~100x speedup. For big accounts with few hundreds token this result to about `70ms -> 1.5ms`, for really huge account with 2k tokens it was about `8000ms -> 70ms`

For nerds: `Array.includes` is `O(n)`, but `Set.has` is `O(1)`

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
