### PR TITLE
fix(connect-explorer): diagrams dark mode regression

### DIFF
--- a/packages/connect-explorer/src/components/ZoomableIllustration.tsx
+++ b/packages/connect-explorer/src/components/ZoomableIllustration.tsx
@@ -28,7 +28,8 @@ const ReactMediumImageZoomStyle = createGlobalStyle<{ $darkMode?: boolean }>`
 
 export const ZoomableIllustration = (props: ZoomableIllustrationProps) => {
     const router = useRouter();
-    const { THEME } = useTheme();
+    const theme = useTheme();
+    const { THEME } = theme.legacy;
     const darkMode = props.$darkMode && THEME === 'dark';
 
     // Automatic absolute path handling


### PR DESCRIPTION
## Description

Tiny fix for a theme change that broke dark mode in diagrams in Connect Explorer