### PR TITLE
transport - nitpicks

### DIFF
--- a/packages/transport/src/sessions/background.ts
+++ b/packages/transport/src/sessions/background.ts
@@ -21,11 +21,12 @@ import type {
     GetPathBySessionRequest,
     HandleMessageParams,
     HandleMessageResponse,
-    Sessions,
 } from './types';
 import type { Descriptor, Success } from '../types';
 
 import * as ERRORS from '../errors';
+
+type DescriptorsDict = Record<string, Descriptor>;
 
 // in nodeusb, enumeration operation takes ~3 seconds
 const lockDuration = 1000 * 4;
@@ -40,7 +41,7 @@ export class SessionsBackground extends TypedEmitter<{
     /**
      * Dictionary where key is path and value is Descriptor
      */
-    private descriptors: Sessions = {};
+    private descriptors: DescriptorsDict = {};
 
     // if lock is set, somebody is doing something with device. we have to wait
     private locksQueue: { id: ReturnType<typeof setTimeout>; dfd: Deferred<void> }[] = [];
@@ -171,7 +172,7 @@ export class SessionsBackground extends TypedEmitter<{
 
         // new "unconfirmed" descriptors are  broadcasted. we can't yet update this.sessions object as it needs
         // to stay as it is. we can not allow 2 clients sending session:null to proceed. this way only one gets through
-        const unconfirmedSessions: Sessions = JSON.parse(JSON.stringify(this.descriptors));
+        const unconfirmedSessions: DescriptorsDict = JSON.parse(JSON.stringify(this.descriptors));
 
         this.lastSessionId++;
         unconfirmedSessions[payload.path].session = `${this.lastSessionId}`;

--- a/packages/transport/src/sessions/types.ts
+++ b/packages/transport/src/sessions/types.ts
@@ -11,8 +11,6 @@ import * as ERRORS from '../errors';
 type BackgroundResponseWithError<T, E> = ResultWithTypedError<T, E> & { id: number };
 type BackgroundResponse<T> = Success<T> & { id: number };
 
-export type Sessions = Record<string, Descriptor>;
-
 export type HandshakeRequest = Record<string, never>;
 export type HandshakeResponse = BackgroundResponse<undefined>;
 


### PR DESCRIPTION
It should be 100% refactoring. Nitpicks.

- [1973c59](https://github.com/trezor/trezor-suite/pull/14086/commits/1973c59a1d4334977f0f543d66d2fab25e022c65) - export type from types.ts that was used only in one place. So I moved it to the place where it is consumed and renamed it to something more intelligible
- [ef0ae67](https://github.com/trezor/trezor-suite/pull/14086/commits/ef0ae67394a42b742d7e8be6e4a81b5938369f80) - there were 2 functions doing basically the same thing so I merged them into one.