### PR TITLE
fix(suite-desktop-core): update autostart file on linux each launch

### DIFF
--- a/packages/suite-desktop-core/src/modules/auto-start.ts
+++ b/packages/suite-desktop-core/src/modules/auto-start.ts
@@ -42,7 +42,6 @@ export const init: Module = () => {
 
     ipcMain.on('app/auto-start', (_, enabled: boolean) => {
         logger.debug(SERVICE_NAME, 'Auto start ' + (enabled ? 'enabled' : 'disabled'));
-
         if (process.platform === 'linux') {
             // For Linux, we use a custom implementation
             linuxAutoStart(enabled);
@@ -55,4 +54,20 @@ export const init: Module = () => {
             });
         }
     });
+
+    return {
+        onLoad: () => {
+            // Update autostart file on Linux, since the AppImage might have been moved
+            if (process.platform === 'linux') {
+                const autostartFile = path.join(
+                    os.homedir(),
+                    LINUX_AUTOSTART_DIR,
+                    LINUX_AUTOSTART_FILE,
+                );
+                if (fs.existsSync(autostartFile)) {
+                    linuxAutoStart(true);
+                }
+            }
+        },
+    };
 };


### PR DESCRIPTION
## Description

On Linux there is no clear install location for the executable, the user can decide to move the AppImage at any time. 
So with this change, the executable path in the autostart file will be updated on every start. 