### PR TITLE
fix(suite): Button minWidth

### DIFF
--- a/packages/components/src/components/buttons/Button/Button.tsx
+++ b/packages/components/src/components/buttons/Button/Button.tsx
@@ -16,7 +16,7 @@ import { makePropsTransient, TransientProps } from '../../../utils/transientProp
 import { FrameProps, FramePropsKeys, withFrameProps } from '../../../utils/frameProps';
 import { Icon, IconName } from '../../Icon/Icon';
 
-export const allowedButtonFrameProps: FramePropsKeys[] = ['margin'];
+export const allowedButtonFrameProps = ['margin', 'minWidth'] as const satisfies FramePropsKeys[];
 type AllowedFrameProps = Pick<FrameProps, (typeof allowedButtonFrameProps)[number]>;
 
 type ButtonContainerProps = TransientProps<AllowedFrameProps> & {
@@ -117,6 +117,7 @@ export const Button = ({
     type = 'button',
     children,
     margin,
+    minWidth,
     textWrap = true,
     ...rest
 }: ButtonProps) => {
@@ -148,6 +149,7 @@ export const Button = ({
             $isSubtle={isSubtle}
             type={type}
             $hasIcon={!!icon || isLoading}
+            $minWidth={minWidth}
             {...rest}
             onClick={isDisabled ? undefined : rest?.onClick}
             {...makePropsTransient(frameProps)}

--- a/packages/suite/src/views/wallet/transactions/components/AccountEmpty.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/AccountEmpty.tsx
@@ -116,6 +116,7 @@ export const AccountEmpty = ({ account }: AccountEmptyProps) => {
                             variant="primary"
                             onClick={handleNavigateToBuyPage}
                             minWidth={160}
+                            maxWidth={200} // now it throws TS error as it should :-)
                         >
                             <Translation id="TR_BUY_NETWORK" values={{ network: networkSymbol }} />
                         </Button>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

These `Buttons` in `AccountEmpty` should have 160 min width:
![image](https://github.com/user-attachments/assets/9481f711-6398-4dae-96c9-e2ea23305db3)


React error currently thrown:

![image](https://github.com/user-attachments/assets/75a647b2-2a77-438a-b080-a80e02d598dd)
