### PR TITLE
fix(transport): improve types

### DIFF
--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -74,6 +74,21 @@ export const isTransportInstance = (transport?: AbstractTransport) => {
 
 const getKey = ({ path, product }: Descriptor) => `${path}${product}`;
 
+type ReadWriteError =
+    | typeof ERRORS.HTTP_ERROR
+    | typeof ERRORS.WRONG_RESULT_TYPE
+    | typeof ERRORS.OTHER_CALL_IN_PROGRESS
+    | typeof PROTOCOL_MALFORMED
+    | typeof ERRORS.DEVICE_DISCONNECTED_DURING_ACTION
+    | typeof ERRORS.UNEXPECTED_ERROR
+    | typeof ERRORS.SESSION_NOT_FOUND
+    | typeof ERRORS.ABORTED_BY_TIMEOUT
+    | typeof ERRORS.ABORTED_BY_SIGNAL
+    | typeof ERRORS.WRONG_ENVIRONMENT
+    | typeof ERRORS.DEVICE_NOT_FOUND
+    | typeof ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE
+    | typeof ERRORS.INTERFACE_DATA_TRANSFER;
+
 export abstract class AbstractTransport extends TypedEmitter<{
     [TRANSPORT.UPDATE]: DeviceDescriptorDiff;
     [TRANSPORT.ERROR]:
@@ -268,21 +283,7 @@ export abstract class AbstractTransport extends TypedEmitter<{
         name: string;
         data: Record<string, unknown>;
         protocol?: TransportProtocol;
-    }): AbortableCall<
-        undefined,
-        | typeof ERRORS.DEVICE_DISCONNECTED_DURING_ACTION
-        // bridge
-        | typeof ERRORS.HTTP_ERROR
-        | typeof ERRORS.WRONG_RESULT_TYPE
-        | typeof ERRORS.OTHER_CALL_IN_PROGRESS
-        // webusb + bridge
-        | typeof PROTOCOL_MALFORMED
-        | typeof ERRORS.UNEXPECTED_ERROR
-        | typeof ERRORS.SESSION_NOT_FOUND
-        | typeof ERRORS.ABORTED_BY_TIMEOUT
-        | typeof ERRORS.ABORTED_BY_SIGNAL
-        | typeof ERRORS.WRONG_ENVIRONMENT
-    >;
+    }): AbortableCall<undefined, ReadWriteError>;
 
     /**
      * Only read from transport
@@ -291,21 +292,7 @@ export abstract class AbstractTransport extends TypedEmitter<{
         path?: string;
         session: Session;
         protocol?: TransportProtocol;
-    }): AbortableCall<
-        MessageFromTrezor,
-        // bridge
-        | typeof ERRORS.HTTP_ERROR
-        | typeof ERRORS.WRONG_RESULT_TYPE
-        | typeof ERRORS.OTHER_CALL_IN_PROGRESS
-        // webusb + bridge
-        | typeof PROTOCOL_MALFORMED
-        | typeof ERRORS.DEVICE_DISCONNECTED_DURING_ACTION
-        | typeof ERRORS.UNEXPECTED_ERROR
-        | typeof ERRORS.SESSION_NOT_FOUND
-        | typeof ERRORS.ABORTED_BY_TIMEOUT
-        | typeof ERRORS.ABORTED_BY_SIGNAL
-        | typeof ERRORS.WRONG_ENVIRONMENT
-    >;
+    }): AbortableCall<MessageFromTrezor, ReadWriteError>;
 
     /**
      * Send and read after that
@@ -315,24 +302,7 @@ export abstract class AbstractTransport extends TypedEmitter<{
         name: string;
         data: Record<string, unknown>;
         protocol?: TransportProtocol;
-    }): AbortableCall<
-        MessageFromTrezor,
-        // bridge
-        | typeof ERRORS.HTTP_ERROR
-        | typeof ERRORS.WRONG_RESULT_TYPE
-        | typeof ERRORS.OTHER_CALL_IN_PROGRESS
-        // webusb + bridge
-        | typeof ERRORS.DEVICE_DISCONNECTED_DURING_ACTION
-        | typeof PROTOCOL_MALFORMED
-        | typeof ERRORS.UNEXPECTED_ERROR
-        | typeof ERRORS.ABORTED_BY_TIMEOUT
-        | typeof ERRORS.ABORTED_BY_SIGNAL
-        | typeof ERRORS.WRONG_ENVIRONMENT
-        // webusb
-        | typeof ERRORS.DEVICE_NOT_FOUND
-        | typeof ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE
-        | typeof ERRORS.INTERFACE_DATA_TRANSFER
-    >;
+    }): AbortableCall<MessageFromTrezor, ReadWriteError>;
 
     /**
      * Stop transport = remove all listeners + try to release session + cancel all requests

--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -283,13 +283,12 @@ export class BridgeTransport extends AbstractTransport {
                 if (!response.success) {
                     return response;
                 }
-                const message = await receiveAndParse(
+
+                return receiveAndParse(
                     this.messages,
-                    () => Promise.resolve(Buffer.from(response.payload.data, 'hex')),
+                    () => Promise.resolve(this.success(Buffer.from(response.payload.data, 'hex'))),
                     protocol,
                 );
-
-                return this.success(message);
             },
             { timeout: undefined },
         );
@@ -338,13 +337,12 @@ export class BridgeTransport extends AbstractTransport {
                 if (!response.success) {
                     return response;
                 }
-                const message = await receiveAndParse(
+
+                return receiveAndParse(
                     this.messages,
-                    () => Promise.resolve(Buffer.from(response.payload.data, 'hex')),
+                    () => Promise.resolve(this.success(Buffer.from(response.payload.data, 'hex'))),
                     protocol,
                 );
-
-                return this.success(message);
             },
             { timeout: undefined },
         );

--- a/packages/transport/src/utils/send.ts
+++ b/packages/transport/src/utils/send.ts
@@ -57,5 +57,5 @@ export const sendChunks = async <T, E>(
         }
     }
 
-    return { success: true as const };
+    return { success: true as const, payload: undefined };
 };

--- a/packages/transport/tests/abstractUsb.test.ts
+++ b/packages/transport/tests/abstractUsb.test.ts
@@ -317,7 +317,7 @@ describe('Usb', () => {
             abortController.abort();
         });
 
-        it('call - with valid message.', async () => {
+        it('call - with valid and invalid message.', async () => {
             const { transport, abortController } = await initTest();
             await transport.enumerate().promise;
             const acquireRes = await transport.acquire({ input: { path: '123', previous: null } })
@@ -330,13 +330,13 @@ describe('Usb', () => {
             expect(transport.getMessage('GetAddress')).toEqual(true);
 
             // doesn't really matter what what message we send
-            const res = await transport.call({
+            const res1 = await transport.call({
                 name: 'GetAddress',
                 data: {},
                 session: acquireRes.payload,
                 protocol: v1Protocol,
             }).promise;
-            expect(res).toEqual({
+            expect(res1).toEqual({
                 success: true,
                 payload: {
                     type: 'Success',
@@ -345,6 +345,19 @@ describe('Usb', () => {
                     },
                 },
             });
+
+            const res2 = await transport.call({
+                name: 'Foo-bar message',
+                data: {},
+                session: acquireRes.payload,
+                protocol: v1Protocol,
+            }).promise;
+            expect(res2).toEqual({
+                success: false,
+                error: 'unexpected error',
+                message: 'no such type: Foo-bar message',
+            });
+
             abortController.abort();
         });
 

--- a/packages/transport/tests/build-receive.test.ts
+++ b/packages/transport/tests/build-receive.test.ts
@@ -110,12 +110,16 @@ describe('encoding json -> protobuf -> json', () => {
                 expect(result.length).toBeGreaterThanOrEqual(28 + length);
                 const decoded = await receiveAndParse(
                     parsedMessages,
-                    () => Promise.resolve(result),
+                    () => Promise.resolve({ success: true, payload: result }),
                     bridgeProtocol,
                 );
+                if (!decoded.success) {
+                    throw new Error('Decoding failed');
+                }
+                const { type, message } = decoded.payload;
                 // then decode message and check, whether decoded message matches original json
-                expect(decoded.type).toEqual(f.name);
-                expect(decoded.message).toEqual(f.in);
+                expect(type).toEqual(f.name);
+                expect(message).toEqual(f.in);
             });
 
             test('v1Protocol: buildMessage - createChunks - receiveAndParse', async () => {
@@ -137,13 +141,17 @@ describe('encoding json -> protobuf -> json', () => {
                     () => {
                         i++;
 
-                        return Promise.resolve(chunks[i]);
+                        return Promise.resolve({ success: true, payload: chunks[i] });
                     },
                     v1Protocol,
                 );
+                if (!decoded.success) {
+                    throw new Error('Decoding failed');
+                }
+                const { type, message } = decoded.payload;
                 // then decode message and check, whether decoded message matches original json
-                expect(decoded.type).toEqual(f.name);
-                expect(decoded.message).toEqual(f.in);
+                expect(type).toEqual(f.name);
+                expect(message).toEqual(f.in);
             });
         });
     });


### PR DESCRIPTION
couple of improvements in types and error handling in @trezor/transport package. should be discussed with @szymonlesisz 

For example getting rid of `{ success: false, error: string }` 
<img width="566" alt="image" src="https://github.com/user-attachments/assets/f8ebbb14-76af-47d8-ba52-e66506e7fae9">

Discussion points:
- top-level members of transport API (call, send, receive) should always catch potential errors and return { success: false, error: 'unexpected-error'}. for transport classes (webusb/bridge/etc) it is defined here https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/transports/abstract.ts#L508
- node-bridge: [final catch should be this one](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/api/abstract.ts#L190) and calls down the call stack such as readUtil and writeUtil now don't need to catch errors themselves. Also couple of throws were replaced with { success: false } for better type clarity.