### PR TITLE
feat(suite): Add anchor to Button if it's needed

### DIFF
--- a/packages/components/src/components/buttons/Button/Button.stories.tsx
+++ b/packages/components/src/components/buttons/Button/Button.stories.tsx
@@ -14,6 +14,9 @@ export default meta;
 export const Button: StoryObj<ButtonProps> = {
     args: {
         children: 'Button label',
+        onClick: () => null,
+        href: undefined,
+        target: undefined,
         variant: 'primary',
         size: 'medium',
         isDisabled: false,
@@ -31,6 +34,12 @@ export const Button: StoryObj<ButtonProps> = {
                     summary: 'ReactNode',
                 },
             },
+        },
+        href: {
+            description: `HTML based href. This creates also anchor from button element.`,
+        },
+        target: {
+            description: `HTML based target. Related only for href attribute.`,
         },
         variant: {
             control: {

--- a/packages/components/src/components/buttons/Button/Button.tsx
+++ b/packages/components/src/components/buttons/Button/Button.tsx
@@ -26,6 +26,7 @@ type ButtonContainerProps = TransientProps<AllowedFrameProps> & {
     $hasIcon?: boolean;
     $isFullWidth?: boolean;
     $isSubtle: boolean;
+    as?: 'a' | 'button';
     $borderRadius?: typeof borders.radii.sm | typeof borders.radii.full; // Do not allow all, we want consistency
 };
 
@@ -87,8 +88,16 @@ type SelectedHTMLButtonProps = Pick<
     'onClick' | 'onMouseOver' | 'onMouseLeave' | 'type' | 'tabIndex'
 >;
 
+type ExclusiveAProps =
+    | { href?: undefined; target?: undefined }
+    | {
+          href?: string;
+          target?: string;
+      };
+
 export type ButtonProps = SelectedHTMLButtonProps &
-    AllowedFrameProps & {
+    AllowedFrameProps &
+    ExclusiveAProps & {
         variant?: ButtonVariant;
         isSubtle?: boolean;
         size?: ButtonSize;
@@ -118,6 +127,8 @@ export const Button = ({
     type = 'button',
     children,
     margin,
+    target,
+    href,
     textWrap = true,
     ...rest
 }: ButtonProps) => {
@@ -139,8 +150,12 @@ export const Button = ({
         <Spinner size={getIconSize(size)} data-testid={`${rest['data-testid']}/spinner`} />
     );
 
+    const isLink = href !== undefined;
+
     return (
         <ButtonContainer
+            as={isLink ? 'a' : 'button'}
+            href={href}
             $variant={variant}
             $size={size}
             $iconAlignment={iconAlignment}

--- a/packages/suite/src/components/suite/LearnMoreButton.tsx
+++ b/packages/suite/src/components/suite/LearnMoreButton.tsx
@@ -1,15 +1,10 @@
 import { ReactNode } from 'react';
-import styled from 'styled-components';
 
 import { Button, ButtonProps } from '@trezor/components';
 
-import { Translation, TrezorLink } from 'src/components/suite';
+import { Translation } from 'src/components/suite';
 import { Url } from '@trezor/urls';
-
-const StyledTrezorLink = styled(TrezorLink)`
-    /* Prevents the link from overflowing the button in a flex container so that it cannot be open by clicking next to it */
-    width: fit-content;
-`;
+import { useExternalLink } from '../../hooks/suite';
 
 interface LearnMoreButtonProps extends Omit<ButtonProps, 'children'> {
     url: Url;
@@ -23,15 +18,15 @@ export const LearnMoreButton = ({
     url,
     ...buttonProps
 }: LearnMoreButtonProps) => (
-    <StyledTrezorLink variant="nostyle" href={url} className={className}>
-        <Button
-            variant="tertiary"
-            size={size}
-            icon="externalLink"
-            iconAlignment="right"
-            {...buttonProps}
-        >
-            {children || <Translation id="TR_LEARN_MORE" />}
-        </Button>
-    </StyledTrezorLink>
+    <Button
+        href={useExternalLink(url)}
+        variant="tertiary"
+        size={size}
+        icon="externalLink"
+        iconAlignment="right"
+        className={className}
+        {...buttonProps}
+    >
+        {children || <Translation id="TR_LEARN_MORE" />}
+    </Button>
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This allows us to prevent components where `button` is inside of `a` like this one:
![image](https://github.com/user-attachments/assets/48d213f2-e37f-4f61-acdd-b77902c87665)


## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
