### PR TITLE
fix(suite-native): move coin enabling init check to navigator

### DIFF
--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -20,6 +20,7 @@
         "reverse-ports": "adb reverse tcp:8081 tcp:8081 && adb reverse tcp:21325 tcp:21325 && adb reverse tcp:19121 tcp:19121"
     },
     "dependencies": {
+        "@mobily/ts-belt": "^3.13.1",
         "@react-native-community/netinfo": "11.3.2",
         "@react-native/metro-config": "0.75.2",
         "@react-navigation/bottom-tabs": "6.6.1",

--- a/suite-native/app/src/navigation/RootStackNavigator.tsx
+++ b/suite-native/app/src/navigation/RootStackNavigator.tsx
@@ -24,11 +24,13 @@ import { SendStackNavigator } from '@suite-native/module-send';
 import { CoinEnablingInitScreen } from '@suite-native/coin-enabling';
 
 import { AppTabNavigator } from './AppTabNavigator';
+import { useCoinEnablingInitialCheck } from '../hooks/useCoinEnablingInitialCheck';
 
 const RootStack = createNativeStackNavigator<RootStackParamList>();
 
 export const RootStackNavigator = () => {
     useHandleDeviceConnection();
+    useCoinEnablingInitialCheck();
 
     const isOnboardingFinished = useSelector(selectIsOnboardingFinished);
 

--- a/suite-native/coin-enabling/src/coinEnablingSelectors.ts
+++ b/suite-native/coin-enabling/src/coinEnablingSelectors.ts
@@ -1,8 +1,10 @@
 import {
     DeviceRootState,
     selectDevice,
+    selectIsDeviceConnectedAndAuthorized,
     selectIsDeviceUnlocked,
     selectIsPortfolioTrackerDevice,
+    selectIsUnacquiredDevice,
 } from '@suite-common/wallet-core';
 import {
     DiscoveryConfigSliceRootState,
@@ -17,11 +19,15 @@ export const selectShouldShowCoinEnablingInitFlow = (
     const isDeviceUnlocked = selectIsDeviceUnlocked(state);
     const isPortfolioTrackerDevice = selectIsPortfolioTrackerDevice(state);
     const isCoinEnablingInitFinished = selectIsCoinEnablingInitFinished(state);
+    const isDeviceConnectedAndAuthorized = selectIsDeviceConnectedAndAuthorized(state);
+    const isUnacquiredDevice = selectIsUnacquiredDevice(state);
 
     return (
         !isCoinEnablingInitFinished &&
         !!device?.connected &&
         isDeviceUnlocked &&
-        !isPortfolioTrackerDevice
+        !isPortfolioTrackerDevice &&
+        isDeviceConnectedAndAuthorized &&
+        !isUnacquiredDevice
     );
 };

--- a/suite-native/feature-flags/src/featureFlagsSlice.ts
+++ b/suite-native/feature-flags/src/featureFlagsSlice.ts
@@ -22,7 +22,7 @@ export const featureFlagsInitialState: FeatureFlagsState = {
     [FeatureFlag.IsDeviceConnectEnabled]: isAndroid() || isDebugEnv(),
     [FeatureFlag.IsSendEnabled]: isAndroid() && isDevelopOrDebugEnv(),
     [FeatureFlag.IsRegtestEnabled]: isDebugEnv() || isDetoxTestBuild(),
-    [FeatureFlag.IsCoinEnablingActive]: false,
+    [FeatureFlag.IsCoinEnablingActive]: isDevelopOrDebugEnv() && !isDetoxTestBuild(),
     [FeatureFlag.IsPolygonEnabled]: false,
 };
 

--- a/suite-native/module-home/package.json
+++ b/suite-native/module-home/package.json
@@ -12,7 +12,6 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
-        "@mobily/ts-belt": "^3.13.1",
         "@react-navigation/native": "6.1.18",
         "@react-navigation/native-stack": "6.11.0",
         "@reduxjs/toolkit": "1.9.5",
@@ -23,7 +22,6 @@
         "@suite-native/atoms": "workspace:*",
         "@suite-native/biometrics": "workspace:*",
         "@suite-native/blockchain": "workspace:*",
-        "@suite-native/coin-enabling": "workspace:*",
         "@suite-native/device": "workspace:*",
         "@suite-native/device-manager": "workspace:*",
         "@suite-native/discovery": "workspace:*",

--- a/suite-native/module-home/src/screens/HomeScreen/HomeScreen.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/HomeScreen.tsx
@@ -17,7 +17,6 @@ import { PortfolioContent } from './components/PortfolioContent';
 import { useHomeRefreshControl } from './useHomeRefreshControl';
 import { EnableViewOnlyBottomSheet } from './components/EnableViewOnlyBottomSheet';
 import { PortfolioGraphRef } from './components/PortfolioGraph';
-import { useCoinEnablingInitialCheck } from '../../hooks/useCoinEnablingInitialCheck';
 
 export const HomeScreen = () => {
     const isEmptyDevice = useSelector(selectIsEmptyDevice);
@@ -35,8 +34,6 @@ export const HomeScreen = () => {
         isEmptyDevice,
         portfolioContentRef,
     });
-
-    useCoinEnablingInitialCheck();
 
     return (
         <Screen

--- a/suite-native/module-home/tsconfig.json
+++ b/suite-native/module-home/tsconfig.json
@@ -11,7 +11,6 @@
         { "path": "../atoms" },
         { "path": "../biometrics" },
         { "path": "../blockchain" },
-        { "path": "../coin-enabling" },
         { "path": "../device" },
         { "path": "../device-manager" },
         { "path": "../discovery" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9488,6 +9488,7 @@ __metadata:
     "@babel/core": "npm:^7.20.0"
     "@babel/plugin-transform-export-namespace-from": "npm:^7.23.4"
     "@config-plugins/detox": "npm:^8.0.0"
+    "@mobily/ts-belt": "npm:^3.13.1"
     "@react-native-community/netinfo": "npm:11.3.2"
     "@react-native/babel-preset": "npm:^0.75.2"
     "@react-native/metro-config": "npm:0.75.2"
@@ -10168,7 +10169,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/module-home@workspace:suite-native/module-home"
   dependencies:
-    "@mobily/ts-belt": "npm:^3.13.1"
     "@react-navigation/native": "npm:6.1.18"
     "@react-navigation/native-stack": "npm:6.11.0"
     "@reduxjs/toolkit": "npm:1.9.5"
@@ -10179,7 +10179,6 @@ __metadata:
     "@suite-native/atoms": "workspace:*"
     "@suite-native/biometrics": "workspace:*"
     "@suite-native/blockchain": "workspace:*"
-    "@suite-native/coin-enabling": "workspace:*"
     "@suite-native/device": "workspace:*"
     "@suite-native/device-manager": "workspace:*"
     "@suite-native/discovery": "workspace:*"


### PR DESCRIPTION
- [x] Trigger init screen from any location
- [x] prevent dismissing init screen by hw back while no network is selected
- [x] enable coin enabling for develop and debug
- [x] improve checks for showing init UI 

## Related Issue

Part of #13819
