### PR TITLE
Chore(suite): Use new Networks in AddAccountModal

### DIFF
--- a/packages/suite/src/components/suite/CoinGroup/CoinGroup.tsx
+++ b/packages/suite/src/components/suite/CoinGroup/CoinGroup.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { useDispatch } from 'src/hooks/suite';
 import { openModal } from 'src/actions/suite/modalActions';
 import { CoinList } from 'src/components/suite';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { Network, NetworkSymbol } from '@suite-common/wallet-config';
 
 import { CoinGroupHeader } from './CoinGroupHeader';
 
@@ -13,10 +13,10 @@ const CoinGroupWrapper = styled.div`
 `;
 
 interface CoinGroupProps {
-    networks: NetworkCompatible[];
-    enabledNetworks?: NetworkCompatible['symbol'][];
+    networks: Network[];
+    enabledNetworks?: NetworkSymbol[];
     className?: string;
-    onToggle: (symbol: NetworkCompatible['symbol'], toggled: boolean) => void;
+    onToggle: (symbol: NetworkSymbol, toggled: boolean) => void;
 }
 
 export const CoinGroup = ({ onToggle, networks, enabledNetworks, className }: CoinGroupProps) => {
@@ -26,7 +26,7 @@ export const CoinGroup = ({ onToggle, networks, enabledNetworks, className }: Co
 
     const isAtLeastOneActive = networks.some(({ symbol }) => enabledNetworks?.includes(symbol));
 
-    const onSettings = (symbol: NetworkCompatible['symbol']) => {
+    const onSettings = (symbol: NetworkSymbol) => {
         setSettingsMode(false);
         dispatch(
             openModal({

--- a/packages/suite/src/components/suite/CoinList/Coin.tsx
+++ b/packages/suite/src/components/suite/CoinList/Coin.tsx
@@ -3,7 +3,7 @@ import { transparentize } from 'polished';
 import styled, { css, useTheme } from 'styled-components';
 import { variables, CoinLogo, Icon } from '@trezor/components';
 import { Translation } from 'src/components/suite';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import { typography } from '@trezor/theme';
 import { TranslationKey } from '@suite-common/intl-types';
 
@@ -152,8 +152,8 @@ const Check = styled.div<{ $visible: boolean }>`
 `;
 
 interface CoinProps {
-    symbol: NetworkCompatible['symbol'];
-    name: NetworkCompatible['name'];
+    symbol: NetworkSymbol;
+    name: string;
     label?: TranslationKey;
     toggled: boolean;
     disabled?: boolean;

--- a/packages/suite/src/components/suite/CoinList/CoinList.tsx
+++ b/packages/suite/src/components/suite/CoinList/CoinList.tsx
@@ -7,7 +7,7 @@ import { versionUtils } from '@trezor/utils';
 
 import { Translation } from 'src/components/suite';
 import { useDevice, useDiscovery, useSelector } from 'src/hooks/suite';
-import { Network, NetworkCompatible, NetworkSymbol } from '@suite-common/wallet-config';
+import { Network, NetworkSymbol } from '@suite-common/wallet-config';
 
 import { Coin } from './Coin';
 import { getCoinLabel } from 'src/utils/suite/getCoinLabel';
@@ -20,7 +20,7 @@ const Wrapper = styled.div`
 `;
 
 interface CoinListProps {
-    networks: Network[] | NetworkCompatible[]; // CoinList only uses what they have in common, so it's interchangeable
+    networks: Network[];
     enabledNetworks?: NetworkSymbol[];
     settingsMode?: boolean;
     onSettings?: (symbol: NetworkSymbol) => void;

--- a/packages/suite/src/components/suite/CoinList/CoinList.tsx
+++ b/packages/suite/src/components/suite/CoinList/CoinList.tsx
@@ -7,7 +7,7 @@ import { versionUtils } from '@trezor/utils';
 
 import { Translation } from 'src/components/suite';
 import { useDevice, useDiscovery, useSelector } from 'src/hooks/suite';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { Network, NetworkCompatible, NetworkSymbol } from '@suite-common/wallet-config';
 
 import { Coin } from './Coin';
 import { getCoinLabel } from 'src/utils/suite/getCoinLabel';
@@ -20,11 +20,11 @@ const Wrapper = styled.div`
 `;
 
 interface CoinListProps {
-    networks: NetworkCompatible[];
-    enabledNetworks?: NetworkCompatible['symbol'][];
+    networks: Network[] | NetworkCompatible[]; // CoinList only uses what they have in common, so it's interchangeable
+    enabledNetworks?: NetworkSymbol[];
     settingsMode?: boolean;
-    onSettings?: (symbol: NetworkCompatible['symbol']) => void;
-    onToggle: (symbol: NetworkCompatible['symbol'], toggled: boolean) => void;
+    onSettings?: (symbol: NetworkSymbol) => void;
+    onToggle: (symbol: NetworkSymbol, toggled: boolean) => void;
 }
 
 export const CoinList = ({

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeDescription.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeDescription.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { Paragraph } from '@trezor/components';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { Bip43Path } from '@suite-common/wallet-config';
 import { Translation } from 'src/components/suite';
 import { getAccountTypeDesc, getAccountTypeUrl } from '@suite-common/wallet-utils';
 import { spacingsPx } from '@trezor/theme';
@@ -12,7 +12,7 @@ const Info = styled(Paragraph)`
 `;
 
 interface AccountTypeDescriptionProps {
-    bip43Path: NetworkCompatible['bip43Path'];
+    bip43Path: Bip43Path;
     hasMultipleAccountTypes: boolean;
 }
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeSelect.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeSelect.tsx
@@ -3,7 +3,7 @@ import { Select } from '@trezor/components';
 import { Translation } from 'src/components/suite/Translation';
 import { getAccountTypeName, getAccountTypeTech } from '@suite-common/wallet-utils';
 import { AccountTypeDescription } from './AccountTypeDescription';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { NetworkAccount } from '@suite-common/wallet-config';
 import { typography } from '@trezor/theme';
 
 const LabelWrapper = styled.div`
@@ -19,12 +19,11 @@ const TypeInfo = styled.div`
     ${typography.label}
 `;
 
-const buildAccountTypeOption = (network: NetworkCompatible) =>
+const buildAccountTypeOption = (account: NetworkAccount) =>
     ({
-        value: network,
-        label: network.accountType || 'normal',
+        value: account,
+        label: account.accountType,
     }) as const;
-
 type Option = ReturnType<typeof buildAccountTypeOption>;
 
 const formatLabel = (option: Option) => (
@@ -38,17 +37,21 @@ const formatLabel = (option: Option) => (
 );
 
 interface AccountTypeSelectProps {
-    network: NetworkCompatible;
-    accountTypes: NetworkCompatible[];
-    onSelectAccountType: (network: NetworkCompatible) => void;
+    accountTypes: NetworkAccount[];
+    onSelectAccountType: (account: NetworkAccount) => void;
+    selectedAccountType?: NetworkAccount;
 }
 
 export const AccountTypeSelect = ({
-    network,
+    selectedAccountType,
     accountTypes,
     onSelectAccountType,
 }: AccountTypeSelectProps) => {
     const options = accountTypes.map(buildAccountTypeOption);
+    // the default, 'normal' account type is expected to be the first one
+    const defaultAccountType = accountTypes[0];
+
+    const bip43PathToDescribe = selectedAccountType?.bip43Path ?? defaultAccountType.bip43Path;
 
     return (
         <>
@@ -57,13 +60,13 @@ export const AccountTypeSelect = ({
                 label={<Translation id="TR_ACCOUNT_TYPE" />}
                 isSearchable={false}
                 isClearable={false}
-                value={buildAccountTypeOption(network || accountTypes[0])}
+                value={buildAccountTypeOption(selectedAccountType ?? defaultAccountType)}
                 options={options}
                 formatOptionLabel={formatLabel}
                 onChange={(option: Option) => onSelectAccountType(option.value)}
             />
             <AccountTypeDescription
-                bip43Path={network.bip43Path}
+                bip43Path={bip43PathToDescribe}
                 hasMultipleAccountTypes={accountTypes && accountTypes?.length > 1}
             />
         </>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddAccountButton.tsx
@@ -4,7 +4,7 @@ import { analytics, EventType } from '@trezor/suite-analytics';
 import { UnavailableCapability } from '@trezor/connect';
 import { selectDevice } from '@suite-common/wallet-core';
 import { Account } from 'src/types/wallet';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { Network, NetworkAccount } from '@suite-common/wallet-config';
 import { Translation } from 'src/components/suite';
 import { useAccountSearch, useSelector } from 'src/hooks/suite';
 import { AddCoinjoinAccountButton } from './AddCoinjoinAccountButton';
@@ -52,7 +52,8 @@ const verifyAvailability = ({
 };
 
 interface AddAccountButtonProps {
-    network: NetworkCompatible;
+    network: Network;
+    selectedAccount?: NetworkAccount;
     emptyAccounts: Account[];
     onEnableAccount: (account: Account) => void;
 }
@@ -61,15 +62,16 @@ const AddDefaultAccountButton = ({
     emptyAccounts,
     onEnableAccount,
     network,
+    selectedAccount,
 }: AddAccountButtonProps) => {
-    const account = emptyAccounts[emptyAccounts.length - 1];
+    const defaultAccount = emptyAccounts[emptyAccounts.length - 1];
     const device = useSelector(selectDevice);
 
     const { setCoinFilter, setSearchString, coinFilter } = useAccountSearch();
 
     const handleClick = useCallback(() => {
-        const { accountType: type, path, symbol } = account;
-        onEnableAccount(account);
+        const { accountType: type, path, symbol } = defaultAccount;
+        onEnableAccount(defaultAccount);
         // reset search string in account search box
         setSearchString(undefined);
         if (coinFilter && coinFilter !== symbol) {
@@ -85,15 +87,15 @@ const AddDefaultAccountButton = ({
                 symbol,
             },
         });
-    }, [account, onEnableAccount, setSearchString, setCoinFilter, coinFilter]);
+    }, [defaultAccount, onEnableAccount, setSearchString, setCoinFilter, coinFilter]);
 
-    const unavailableCapability = network.accountType
-        ? device?.unavailableCapabilities?.[network.accountType]
+    const unavailableCapability = selectedAccount?.accountType
+        ? device?.unavailableCapabilities?.[selectedAccount?.accountType]
         : undefined;
 
     const disabledMessage = verifyAvailability({
         emptyAccounts,
-        account,
+        account: defaultAccount,
         unavailableCapability,
     });
 
@@ -108,16 +110,18 @@ const AddDefaultAccountButton = ({
 
 export const AddAccountButton = ({
     network,
+    selectedAccount,
     emptyAccounts,
     onEnableAccount,
 }: AddAccountButtonProps) => {
-    switch (network.accountType) {
+    switch (selectedAccount?.accountType) {
         case 'coinjoin':
-            return <AddCoinjoinAccountButton network={network} />;
+            return <AddCoinjoinAccountButton network={network} selectedAccount={selectedAccount} />;
         default:
             return (
                 <AddDefaultAccountButton
                     network={network}
+                    selectedAccount={selectedAccount}
                     emptyAccounts={emptyAccounts}
                     onEnableAccount={onEnableAccount}
                 />

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddButton.tsx
@@ -1,11 +1,11 @@
 import { ReactNode } from 'react';
 import { ButtonProps, Tooltip, NewModal } from '@trezor/components';
 import { Translation } from 'src/components/suite';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { Network } from '@suite-common/wallet-config';
 
 interface AddButtonProps extends Omit<ButtonProps, 'children'> {
     disabledMessage: ReactNode;
-    networkName: NetworkCompatible['name'];
+    networkName: Network['name'];
 }
 
 export const AddButton = ({ disabledMessage, networkName, ...buttonProps }: AddButtonProps) => (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddCoinjoinAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddCoinjoinAccountButton.tsx
@@ -13,7 +13,12 @@ import { createCoinjoinAccount } from 'src/actions/wallet/coinjoinAccountActions
 import { toggleTor } from 'src/actions/suite/suiteActions';
 import { openDeferredModal, openModal } from 'src/actions/suite/modalActions';
 import { Account } from 'src/types/wallet';
-import { NetworkCompatible, NetworkSymbol } from '@suite-common/wallet-config';
+import {
+    Network,
+    NetworkAccount,
+    NetworkCompatible,
+    NetworkSymbol,
+} from '@suite-common/wallet-config';
 import { selectTorState } from 'src/reducers/suite/suiteReducer';
 
 import { AddButton } from './AddButton';
@@ -46,10 +51,11 @@ const verifyAvailability = ({
 };
 
 interface AddCoinjoinAccountProps {
-    network: NetworkCompatible;
+    network: Network;
+    selectedAccount: NetworkAccount;
 }
 
-export const AddCoinjoinAccountButton = ({ network }: AddCoinjoinAccountProps) => {
+export const AddCoinjoinAccountButton = ({ network, selectedAccount }: AddCoinjoinAccountProps) => {
     const [isLoading, setIsLoading] = useState(false);
 
     const { isTorEnabled } = useSelector(selectTorState);
@@ -65,7 +71,7 @@ export const AddCoinjoinAccountButton = ({ network }: AddCoinjoinAccountProps) =
         a =>
             a.deviceState === device?.state &&
             a.symbol === network.symbol &&
-            a.accountType === network.accountType,
+            a.accountType === selectedAccount.accountType,
     );
 
     const disabledMessage = verifyAvailability({
@@ -74,9 +80,15 @@ export const AddCoinjoinAccountButton = ({ network }: AddCoinjoinAccountProps) =
         unavailableCapabilities: device.unavailableCapabilities,
     });
 
+    // TODO refactor createCoinjoinAccount
+    const networkCompatible = {
+        ...network,
+        ...selectedAccount, // adds accountType, overrides Bip43Path and other properties
+    } as unknown as NetworkCompatible;
+
     const onCreateCoinjoinAccountClick = async () => {
         const createAccount = async () => {
-            await dispatch(createCoinjoinAccount(network));
+            await dispatch(createCoinjoinAccount(networkCompatible));
             setIsLoading(false);
         };
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/SelectNetwork.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/SelectNetwork.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { NetworkCompatible, NetworkSymbol } from '@suite-common/wallet-config';
+import { Network, NetworkSymbol } from '@suite-common/wallet-config';
 import { Paragraph } from '@trezor/components';
 import { spacingsPx } from '@trezor/theme';
 
@@ -14,7 +14,7 @@ const Title = styled(Paragraph)`
 
 type SelectNetworkProps = {
     heading: React.ReactNode;
-    networks: NetworkCompatible[];
+    networks: Network[];
     selectedNetworks: NetworkSymbol[];
     handleNetworkSelection: (symbol?: NetworkSymbol) => void;
 };

--- a/packages/suite/src/hooks/settings/useEnabledNetworks.ts
+++ b/packages/suite/src/hooks/settings/useEnabledNetworks.ts
@@ -1,21 +1,56 @@
 import { useSelector, useActions } from 'src/hooks/suite';
 import { changeCoinVisibility } from 'src/actions/settings/walletSettingsActions';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import {
+    getMainnetsCompatible,
+    getTestnetsCompatible,
+    Network,
+    NetworkCompatible,
+    NetworkSymbol,
+} from '@suite-common/wallet-config';
 
-import { getMainnetsCompatible, getTestnetsCompatible } from '@suite-common/wallet-config';
+import { getMainnets, getTestnets } from '@suite-common/wallet-config';
 import {
     selectHasExperimentalFeature,
     selectIsDebugModeActive,
 } from 'src/reducers/suite/suiteReducer';
 
 type EnabledNetworks = {
+    mainnets: Network[];
+    testnets: Network[];
+    enabledNetworks: NetworkSymbol[];
+    setEnabled: (symbol: NetworkSymbol, enabled: boolean) => void;
+};
+
+export const useEnabledNetworks = (): EnabledNetworks => {
+    const enabledNetworks = useSelector(state => state.wallet.settings.enabledNetworks);
+    const isDebug = useSelector(selectIsDebugModeActive);
+    const bnbExperimentalFeature = useSelector(selectHasExperimentalFeature('bnb-smart-chain'));
+
+    const mainnets = getMainnets(isDebug, bnbExperimentalFeature);
+
+    const testnets = getTestnets(isDebug);
+
+    const { setEnabled } = useActions({
+        setEnabled: changeCoinVisibility,
+    });
+
+    return {
+        mainnets,
+        testnets,
+        enabledNetworks,
+        setEnabled,
+    };
+};
+
+// TODO refactor all usages of this hook to use the new one
+type EnabledNetworksCompatible = {
     mainnets: NetworkCompatible[];
     testnets: NetworkCompatible[];
     enabledNetworks: NetworkCompatible['symbol'][];
     setEnabled: (symbol: NetworkCompatible['symbol'], enabled: boolean) => void;
 };
 
-export const useEnabledNetworks = (): EnabledNetworks => {
+export const useEnabledNetworksCompatible = (): EnabledNetworksCompatible => {
     const enabledNetworks = useSelector(state => state.wallet.settings.enabledNetworks);
     const isDebug = useSelector(selectIsDebugModeActive);
     const bnbExperimentalFeature = useSelector(selectHasExperimentalFeature('bnb-smart-chain'));

--- a/packages/suite/src/hooks/settings/useEnabledNetworks.ts
+++ b/packages/suite/src/hooks/settings/useEnabledNetworks.ts
@@ -1,14 +1,7 @@
-import { useSelector, useActions } from 'src/hooks/suite';
+import { Network, NetworkSymbol, getMainnets, getTestnets } from '@suite-common/wallet-config';
 import { changeCoinVisibility } from 'src/actions/settings/walletSettingsActions';
-import {
-    getMainnetsCompatible,
-    getTestnetsCompatible,
-    Network,
-    NetworkCompatible,
-    NetworkSymbol,
-} from '@suite-common/wallet-config';
+import { useActions, useSelector } from 'src/hooks/suite';
 
-import { getMainnets, getTestnets } from '@suite-common/wallet-config';
 import {
     selectHasExperimentalFeature,
     selectIsDebugModeActive,
@@ -29,35 +22,6 @@ export const useEnabledNetworks = (): EnabledNetworks => {
     const mainnets = getMainnets(isDebug, bnbExperimentalFeature);
 
     const testnets = getTestnets(isDebug);
-
-    const { setEnabled } = useActions({
-        setEnabled: changeCoinVisibility,
-    });
-
-    return {
-        mainnets,
-        testnets,
-        enabledNetworks,
-        setEnabled,
-    };
-};
-
-// TODO refactor all usages of this hook to use the new one
-type EnabledNetworksCompatible = {
-    mainnets: NetworkCompatible[];
-    testnets: NetworkCompatible[];
-    enabledNetworks: NetworkCompatible['symbol'][];
-    setEnabled: (symbol: NetworkCompatible['symbol'], enabled: boolean) => void;
-};
-
-export const useEnabledNetworksCompatible = (): EnabledNetworksCompatible => {
-    const enabledNetworks = useSelector(state => state.wallet.settings.enabledNetworks);
-    const isDebug = useSelector(selectIsDebugModeActive);
-    const bnbExperimentalFeature = useSelector(selectHasExperimentalFeature('bnb-smart-chain'));
-
-    const mainnets = getMainnetsCompatible(isDebug, bnbExperimentalFeature);
-
-    const testnets = getTestnetsCompatible(isDebug);
 
     const { setEnabled } = useActions({
         setEnabled: changeCoinVisibility,

--- a/packages/suite/src/views/onboarding/steps/BasicSettings/BasicSettingsStepBox.tsx
+++ b/packages/suite/src/views/onboarding/steps/BasicSettings/BasicSettingsStepBox.tsx
@@ -2,13 +2,13 @@ import { useEffect } from 'react';
 import styled from 'styled-components';
 import { OnboardingStepBox, OnboardingStepBoxProps } from 'src/components/onboarding';
 import { CoinGroup, TooltipSymbol, Translation } from 'src/components/suite';
-import { useEnabledNetworksCompatible } from 'src/hooks/settings/useEnabledNetworks';
+import { useEnabledNetworks } from 'src/hooks/settings/useEnabledNetworks';
 import { CollapsibleBox } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 import { selectDeviceSupportedNetworks, selectDeviceModel } from '@suite-common/wallet-core';
 import { useSelector } from 'src/hooks/suite';
 import { DeviceModelInternal } from '@trezor/connect';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { Network } from '@suite-common/wallet-config';
 
 const Separator = styled.hr`
     height: 1px;
@@ -20,11 +20,11 @@ const Separator = styled.hr`
 `;
 
 export const BasicSettingsStepBox = (props: OnboardingStepBoxProps) => {
-    const { mainnets, testnets, enabledNetworks, setEnabled } = useEnabledNetworksCompatible();
+    const { mainnets, testnets, enabledNetworks, setEnabled } = useEnabledNetworks();
     const deviceSupportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
     const deviceModel = useSelector(selectDeviceModel);
 
-    const getNetworks = (networks: NetworkCompatible[], getUnsupported = false) =>
+    const getNetworks = (networks: Network[], getUnsupported = false) =>
         networks.filter(
             ({ symbol }) => getUnsupported !== deviceSupportedNetworkSymbols.includes(symbol),
         );

--- a/packages/suite/src/views/onboarding/steps/BasicSettings/BasicSettingsStepBox.tsx
+++ b/packages/suite/src/views/onboarding/steps/BasicSettings/BasicSettingsStepBox.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import styled from 'styled-components';
 import { OnboardingStepBox, OnboardingStepBoxProps } from 'src/components/onboarding';
 import { CoinGroup, TooltipSymbol, Translation } from 'src/components/suite';
-import { useEnabledNetworks } from 'src/hooks/settings/useEnabledNetworks';
+import { useEnabledNetworksCompatible } from 'src/hooks/settings/useEnabledNetworks';
 import { CollapsibleBox } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 import { selectDeviceSupportedNetworks, selectDeviceModel } from '@suite-common/wallet-core';
@@ -20,7 +20,7 @@ const Separator = styled.hr`
 `;
 
 export const BasicSettingsStepBox = (props: OnboardingStepBoxProps) => {
-    const { mainnets, testnets, enabledNetworks, setEnabled } = useEnabledNetworks();
+    const { mainnets, testnets, enabledNetworks, setEnabled } = useEnabledNetworksCompatible();
     const deviceSupportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
     const deviceModel = useSelector(selectDeviceModel);
 

--- a/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
@@ -8,7 +8,7 @@ import {
 } from '@suite-common/wallet-core';
 import { Button, motionEasing, Tooltip } from '@trezor/components';
 import { DeviceModelInternal } from '@trezor/connect';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { Network } from '@suite-common/wallet-config';
 
 import {
     DeviceBanner,
@@ -17,7 +17,7 @@ import {
     SettingsSectionItem,
 } from 'src/components/settings';
 import { CoinGroup, TooltipSymbol, Translation } from 'src/components/suite';
-import { useEnabledNetworksCompatible } from 'src/hooks/settings/useEnabledNetworks';
+import { useEnabledNetworks } from 'src/hooks/settings/useEnabledNetworks';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import {
     useDevice,
@@ -89,7 +89,7 @@ const getDiscoveryButtonAnimationConfig = (isConfirmed: boolean): MotionProps =>
 export const SettingsCoins = () => {
     const { firmwareTypeBannerClosed } = useSelector(selectSuiteFlags);
     const isDiscoveryButtonVisible = useRediscoveryNeeded();
-    const { mainnets, testnets, enabledNetworks, setEnabled } = useEnabledNetworksCompatible();
+    const { mainnets, testnets, enabledNetworks, setEnabled } = useEnabledNetworks();
     const deviceSupportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
     const deviceModel = useSelector(selectDeviceModel);
     const { device, isLocked } = useDevice();
@@ -101,7 +101,7 @@ export const SettingsCoins = () => {
         deviceSupportedNetworkSymbols.includes(enabledNetwork),
     );
 
-    const getNetworks = (networks: NetworkCompatible[], getUnsupported = false) =>
+    const getNetworks = (networks: Network[], getUnsupported = false) =>
         networks.filter(
             ({ symbol }) => getUnsupported !== deviceSupportedNetworkSymbols.includes(symbol),
         );

--- a/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
@@ -17,7 +17,7 @@ import {
     SettingsSectionItem,
 } from 'src/components/settings';
 import { CoinGroup, TooltipSymbol, Translation } from 'src/components/suite';
-import { useEnabledNetworks } from 'src/hooks/settings/useEnabledNetworks';
+import { useEnabledNetworksCompatible } from 'src/hooks/settings/useEnabledNetworks';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import {
     useDevice,
@@ -89,7 +89,7 @@ const getDiscoveryButtonAnimationConfig = (isConfirmed: boolean): MotionProps =>
 export const SettingsCoins = () => {
     const { firmwareTypeBannerClosed } = useSelector(selectSuiteFlags);
     const isDiscoveryButtonVisible = useRediscoveryNeeded();
-    const { mainnets, testnets, enabledNetworks, setEnabled } = useEnabledNetworks();
+    const { mainnets, testnets, enabledNetworks, setEnabled } = useEnabledNetworksCompatible();
     const deviceSupportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
     const deviceModel = useSelector(selectDeviceModel);
     const { device, isLocked } = useDevice();

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -27,18 +27,22 @@ export const networks = {
         customBackends: ['blockbook', 'electrum'],
         accountTypes: {
             coinjoin: {
+                accountType: 'coinjoin',
                 bip43Path: "m/10025'/0'/i'/1'", // https://github.com/satoshilabs/slips/blob/master/slip-0025.md#public-key-derivation
                 backendType: 'coinjoin', // use non-standard backend
                 features: ['rbf', 'amount-unit'], // no sign-verify
             },
             taproot: {
+                accountType: 'taproot',
                 bip43Path: "m/86'/0'/i'",
                 features: ['rbf', 'amount-unit'], // no sign-verify
             },
             segwit: {
+                accountType: 'segwit',
                 bip43Path: "m/49'/0'/i'",
             },
             legacy: {
+                accountType: 'legacy',
                 bip43Path: "m/44'/0'/i'",
             },
         },
@@ -61,9 +65,11 @@ export const networks = {
         customBackends: ['blockbook'],
         accountTypes: {
             segwit: {
+                accountType: 'segwit',
                 bip43Path: "m/49'/2'/i'",
             },
             legacy: {
+                accountType: 'legacy',
                 bip43Path: "m/44'/2'/i'",
             },
         },
@@ -96,11 +102,13 @@ export const networks = {
         accountTypes: {
             ledger: {
                 // ledger (live), #1 acc is same as Trezor, so it is skipped
+                accountType: 'ledger',
                 bip43Path: "m/44'/60'/i'/0/0",
                 isDebugOnlyAccountType: true,
             },
             legacy: {
                 // ledger (legacy)
+                accountType: 'legacy',
                 bip43Path: "m/44'/60'/0'/i",
                 isDebugOnlyAccountType: true,
             },
@@ -181,6 +189,7 @@ export const networks = {
         customBackends: ['blockbook'],
         accountTypes: {
             legacy: {
+                accountType: 'legacy',
                 bip43Path: "m/44'/156'/i'",
             },
         },
@@ -221,6 +230,7 @@ export const networks = {
         customBackends: ['blockbook'],
         accountTypes: {
             legacy: {
+                accountType: 'legacy',
                 bip43Path: "m/44'/20'/i'",
             },
         },
@@ -279,9 +289,11 @@ export const networks = {
         customBackends: ['blockbook'],
         accountTypes: {
             segwit: {
+                accountType: 'segwit',
                 bip43Path: "m/49'/28'/i'",
             },
             legacy: {
+                accountType: 'legacy',
                 bip43Path: "m/44'/28'/i'",
             },
         },
@@ -330,11 +342,13 @@ export const networks = {
         accountTypes: {
             legacy: {
                 // icarus-trezor derivation, differs from default just for 24 words seed
+                accountType: 'legacy',
                 bip43Path: "m/1852'/1815'/i'",
                 isDebugOnlyAccountType: true,
             },
             ledger: {
                 // ledger derivation
+                accountType: 'ledger',
                 bip43Path: "m/1852'/1815'/i'",
                 isDebugOnlyAccountType: true,
             },
@@ -364,6 +378,7 @@ export const networks = {
         accountTypes: {
             ledger: {
                 // bip44Change - Ledger Live
+                accountType: 'ledger',
                 bip43Path: "m/44'/501'/i'",
                 isDebugOnlyAccountType: true,
             },
@@ -390,6 +405,7 @@ export const networks = {
         accountTypes: {
             ledger: {
                 // ledger (live), #1 acc is same as Trezor, so it is skipped
+                accountType: 'ledger',
                 bip43Path: "m/44'/60'/i'/0/0",
                 isDebugOnlyAccountType: true,
             },
@@ -416,6 +432,7 @@ export const networks = {
         accountTypes: {
             ledger: {
                 // ledger (live), #1 acc is same as Trezor, so it is skipped
+                accountType: 'ledger',
                 bip43Path: "m/44'/60'/i'/0/0",
                 isDebugOnlyAccountType: true,
             },
@@ -440,18 +457,22 @@ export const networks = {
         customBackends: ['blockbook', 'electrum'],
         accountTypes: {
             coinjoin: {
+                accountType: 'coinjoin',
                 bip43Path: "m/10025'/1'/i'/1'", // https://github.com/satoshilabs/slips/blob/master/slip-0025.md#public-key-derivation
                 backendType: 'coinjoin', // use non-standard backend
                 features: ['rbf', 'amount-unit'], // no sign-verify
             },
             taproot: {
+                accountType: 'taproot',
                 bip43Path: "m/86'/1'/i'",
                 features: ['rbf', 'amount-unit'], // no sign-verify
             },
             segwit: {
+                accountType: 'segwit',
                 bip43Path: "m/49'/1'/i'",
             },
             legacy: {
+                accountType: 'legacy',
                 bip43Path: "m/44'/1'/i'",
             },
         },
@@ -474,18 +495,22 @@ export const networks = {
         customBackends: ['blockbook', 'electrum'],
         accountTypes: {
             coinjoin: {
+                accountType: 'coinjoin',
                 bip43Path: "m/10025'/1'/i'/1'", // https://github.com/satoshilabs/slips/blob/master/slip-0025.md#public-key-derivation
                 backendType: 'coinjoin', // use non-standard backend
                 features: ['rbf', 'amount-unit'], // no sign-verify
             },
             taproot: {
+                accountType: 'taproot',
                 bip43Path: "m/86'/1'/i'",
                 features: ['rbf', 'amount-unit'], // no sign-verify
             },
             segwit: {
+                accountType: 'segwit',
                 bip43Path: "m/49'/1'/i'",
             },
             legacy: {
+                accountType: 'legacy',
                 bip43Path: "m/44'/1'/i'",
             },
         },
@@ -575,10 +600,12 @@ export const networks = {
         accountTypes: {
             legacy: {
                 // icarus-trezor derivation
+                accountType: 'legacy',
                 bip43Path: "m/1852'/1815'/i'",
             },
             ledger: {
                 // ledger derivation
+                accountType: 'ledger',
                 bip43Path: "m/1852'/1815'/i'",
             },
         },

--- a/suite-common/wallet-config/src/types.ts
+++ b/suite-common/wallet-config/src/types.ts
@@ -54,6 +54,8 @@ export type NetworkFeature =
     | 'coin-definitions'
     | 'nft-definitions';
 
+export type Bip43Path = string; // TODO define a more specific type
+
 export type Explorer = {
     tx: string;
     account: string;
@@ -63,23 +65,26 @@ export type Explorer = {
     queryString?: string;
 };
 
-export type Account = {
-    bip43Path: string;
+type NetworkAccountWithSpecificKey<TKey extends AccountType> = {
+    accountType: TKey;
+    bip43Path: Bip43Path;
     backendType?: BackendType;
     features?: NetworkFeature[];
     isDebugOnlyAccountType?: boolean;
 };
+export type NetworkAccount = NetworkAccountWithSpecificKey<AccountType>;
 
-// template types serve only to check if `networks` satisfies it. Exact type is inferred below
-export type NetworkAccountTypes = Partial<Record<AccountType, Account>>;
+export type NetworkAccountTypes = Partial<{
+    [key in AccountType]: NetworkAccountWithSpecificKey<key>;
+}>;
 
 export type NetworkDeviceSupport = Partial<Record<DeviceModelInternal, string>>;
 
-export type Network = {
-    symbol: NetworkSymbol;
+type NetworkWithSpecificKey<TKey extends NetworkSymbol> = {
+    symbol: TKey;
     name: string;
     networkType: NetworkType;
-    bip43Path: string;
+    bip43Path: Bip43Path;
     decimals: number;
     testnet: boolean;
     explorer: Explorer;
@@ -93,7 +98,8 @@ export type Network = {
     coingeckoId?: string;
     coingeckoNativeId?: string;
 };
+export type Network = NetworkWithSpecificKey<NetworkSymbol>;
 
 export type Networks = {
-    [key in NetworkSymbol]: Network;
+    [key in NetworkSymbol]: NetworkWithSpecificKey<key>;
 };


### PR DESCRIPTION
Part 1 of refactoring usages of deprecated `networksCompatibility` to `networks`,
including corresponding types & utility functions such as `getMainnets`, `getTestnets`.

## Description

The usages are very interconnected, so refactoring one usage creates incompatibility and the refactoring propagates, unless I make temporary compatibility "fix" at the interfaces.

:eyes:  For easier orientation in CR, this was the "path" I took (not listing the simple cases, only where I had to refactor logic):

- `AddAccountModal`
  - `useEnabledNetworks` and all its usages, all simple
  - `AccountTypeSelect`
  - `AddAccountButton`
    - `AddCoinjoinAccountButton`

## Related Issue

Part of #13839

## Screenshots

All of the steps of Add Account modal work as before:

![activate new network](https://github.com/user-attachments/assets/3394fb90-7853-4fe8-9ece-0bbf91729a84)
![existing network selection](https://github.com/user-attachments/assets/8f3e47ec-c2d7-4af5-bba7-b528cb643d0e)
![account type select](https://github.com/user-attachments/assets/ad263351-f4b4-4ec5-a913-edaaa854da2a)
![add account](https://github.com/user-attachments/assets/6c90a047-8e87-4ac5-90cf-4a413d954981)
