### PR TITLE
Change default bitcoin like network fee unit to sat/vB

### DIFF
--- a/packages/suite-web/e2e/tests/coinmarket/exchange.test.ts
+++ b/packages/suite-web/e2e/tests/coinmarket/exchange.test.ts
@@ -175,7 +175,7 @@ describe.skip('Coinmarket exchange', () => {
                     .first()
                     .should('contain.text', 'REGTEST');
             });
-        cy.getTestElement('@modal').within(() => cy.contains('1 sat/B'));
+        cy.getTestElement('@modal').within(() => cy.contains('1 sat/vB'));
         cy.task('pressYes');
         cy.task('pressYes');
         cy.getTestElement('@modal/send').should('not.be.disabled').click();

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -201,7 +201,7 @@ export const getFeeUnits = (networkType: NetworkType) => {
     if (networkType === 'cardano') return 'Lovelaces/B';
     if (networkType === 'solana') return 'Lamports';
 
-    return 'sat/B';
+    return 'sat/vB';
 };
 
 export const getFee = (networkType: NetworkType, tx: GeneralPrecomposedTransactionFinal) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We were still using `sat/B` as a fee unit. After SegWit it should be changed for `sat/vB` for Bitcoin.

 On mempool.space, there is `sat/vB`, on Blockbook we use `sat/vByte`. You can find someone using `sats/vByte`, but that is basically the same.
 In firmware we also show `sat/vB`.

> This will change the displayed unit in Suite for all bitcoin-like coins including Litecoin (where lit/vB is more common) or those without SegWit. Separation per network would need more refactoring.


## Screenshots:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/88fb2b6b-7cb2-449b-979c-ac4e46d2c4bd">
<img width="600" alt="image" src="https://github.com/user-attachments/assets/a9da81b8-fe19-43f5-b671-cf92bb53a1e9">
<img width="232" alt="image" src="https://github.com/user-attachments/assets/d5be5266-eee9-41c6-99aa-e2131f84c7c1">

