### PR TITLE
chore(suite): use NetworkSymbol type directly

### DIFF
--- a/packages/suite/src/actions/settings/walletSettingsActions.ts
+++ b/packages/suite/src/actions/settings/walletSettingsActions.ts
@@ -1,6 +1,6 @@
 import * as suiteActions from 'src/actions/suite/suiteActions';
 import { Dispatch, GetState } from 'src/types/suite';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import { createAction } from '@reduxjs/toolkit';
 
 import { UNIT_ABBREVIATIONS } from '@suite-common/suite-constants';
@@ -21,7 +21,7 @@ export const setLocalCurrency = createAction(
 
 export const changeNetworks = createAction(
     WALLET_SETTINGS.CHANGE_NETWORKS,
-    (payload: NetworkCompatible['symbol'][]) => ({
+    (payload: NetworkSymbol[]) => ({
         payload,
     }),
 );
@@ -32,7 +32,7 @@ export type WalletSettingsAction =
     | { type: typeof WALLET_SETTINGS.SET_HIDE_BALANCE; toggled: boolean }
     | {
           type: typeof WALLET_SETTINGS.SET_LAST_USED_FEE_LEVEL;
-          symbol: NetworkCompatible['symbol'];
+          symbol: NetworkSymbol;
           feeLevel?: FeeLevel;
       }
     | {
@@ -58,7 +58,7 @@ export const setDiscreetMode = (toggled: boolean) => (dispatch: Dispatch, getSta
 };
 
 export const changeCoinVisibility =
-    (symbol: NetworkCompatible['symbol'], shouldBeVisible: boolean) =>
+    (symbol: NetworkSymbol, shouldBeVisible: boolean) =>
     (dispatch: Dispatch, getState: GetState) => {
         let { enabledNetworks } = getState().wallet.settings;
         const isAlreadyHidden = enabledNetworks.find(coin => coin === symbol);

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -17,7 +17,7 @@ import {
 } from 'src/utils/suite/storage';
 import type { AppState, Dispatch, GetState, TrezorDevice } from 'src/types/suite';
 import type { Account } from 'src/types/wallet';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import type { FormState, RatesByTimestamps } from '@suite-common/wallet-types';
 import type { Trade } from 'src/types/wallet/coinmarketCommonTypes';
 import type { PreloadStoreAction } from 'src/support/suite/preloadStore';
@@ -27,7 +27,6 @@ import { selectCoinjoinAccountByKey } from 'src/reducers/wallet/coinjoinReducer'
 
 import { STORAGE } from './constants';
 import { MetadataState } from '@suite-common/metadata-types';
-import { NetworkSymbol } from '@suite-common/wallet-config';
 import { DefinitionType, TokenManagementAction } from '@suite-common/token-definitions';
 import { selectSuiteSettings } from '../../reducers/suite/suiteReducer';
 
@@ -311,7 +310,7 @@ export const saveWalletSettings = () => async (_dispatch: Dispatch, getState: Ge
 };
 
 export const saveBackend =
-    (coin: NetworkCompatible['symbol']) => async (_dispatch: Dispatch, getState: GetState) => {
+    (coin: NetworkSymbol) => async (_dispatch: Dispatch, getState: GetState) => {
         if (!(await db.isAccessible())) return;
         await db.addItem(
             'backendSettings',

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
@@ -3,7 +3,7 @@ import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { Translation } from 'src/components/suite';
 import { formatNetworkAmount, formatAmount, isTestnet } from '@suite-common/wallet-utils';
 import { BTC_LOCKTIME_VALUE } from '@suite-common/wallet-constants';
-import { NetworkCompatible, NetworkSymbol } from '@suite-common/wallet-config';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import { ReviewOutput } from '@suite-common/wallet-types';
 import {
     TransactionReviewStepIndicator,
@@ -49,7 +49,7 @@ const getDisplayModeStringsMap = (): Record<
 
 export type TransactionReviewOutputProps = {
     state: TransactionReviewStepIndicatorProps['state'];
-    symbol: NetworkCompatible['symbol'];
+    symbol: NetworkSymbol;
     account: Account;
     isRbf: boolean;
     ethereumStakeType?: StakeType;

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { variables } from '@trezor/components';
 import { FiatValue, FormattedCryptoAmount, Translation } from 'src/components/suite';
 import { Account } from 'src/types/wallet';
-import { NetworkCompatible, NetworkSymbol } from '@suite-common/wallet-config';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import { TokenInfo } from '@trezor/connect';
 import { amountToSatoshi } from '@suite-common/wallet-utils';
 import { TransactionReviewStepIndicatorProps } from './TransactionReviewStepIndicator';
@@ -142,7 +142,7 @@ export type TransactionReviewOutputElementProps = {
     indicator?: JSX.Element;
     lines: OutputElementLine[];
     cryptoSymbol?: NetworkSymbol;
-    fiatSymbol?: NetworkCompatible['symbol'];
+    fiatSymbol?: NetworkSymbol;
     fiatVisible?: boolean;
     token?: TokenInfo;
     account?: Account;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/ConnectionInfo.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/ConnectionInfo.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import { Paragraph } from '@trezor/components';
 import { useSelector } from 'src/hooks/suite';
 import { Translation } from 'src/components/suite/Translation';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 
 // eslint-disable-next-line local-rules/no-override-ds-component
 const Wrapper = styled(Paragraph)`
@@ -12,7 +12,7 @@ const Wrapper = styled(Paragraph)`
 `;
 
 interface ConnectionInfoProps {
-    coin: NetworkCompatible['symbol'];
+    coin: NetworkSymbol;
 }
 
 const ConnectionInfo = ({ coin }: ConnectionInfoProps) => {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DisableTorModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DisableTorModal.tsx
@@ -9,7 +9,7 @@ import { Modal, Translation } from 'src/components/suite';
 import { useDispatch } from 'src/hooks/suite';
 import { isOnionUrl } from 'src/utils/suite/tor';
 import { useCustomBackends } from 'src/hooks/settings/backends';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import { AdvancedCoinSettingsModal } from 'src/components/suite/modals';
 
 const BackendRowWrapper = styled.div`
@@ -49,7 +49,7 @@ const CoinUrls = styled.span`
 `;
 
 interface BackendRowProps {
-    coin: NetworkCompatible['symbol'];
+    coin: NetworkSymbol;
     urls: string[];
     onSettings: () => void;
 }
@@ -87,7 +87,7 @@ type DisableTorModalProps = Omit<Extract<UserContextPayload, { type: 'disable-to
 
 export const DisableTorModal = ({ onCancel, decision }: DisableTorModalProps) => {
     const dispatch = useDispatch();
-    const [coin, setCoin] = useState<NetworkCompatible['symbol']>();
+    const [coin, setCoin] = useState<NetworkSymbol>();
     const onionBackends = useCustomBackends().filter(({ urls }) => urls.every(isOnionUrl));
 
     const onDisableTor = () => {

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/CoinProtocolRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/CoinProtocolRenderer.tsx
@@ -9,17 +9,16 @@ import { Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { PROTOCOL_TO_NETWORK } from 'src/constants/suite/protocol';
 import type { NotificationRendererProps } from 'src/components/suite';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import { ConditionalActionRenderer } from './ConditionalActionRenderer';
 
 const Row = styled.span`
     display: flex;
 `;
 
-const getIcon = (symbol?: NetworkCompatible['symbol']) =>
-    symbol && <CoinLogo symbol={symbol} size={24} />;
+const getIcon = (symbol?: NetworkSymbol) => symbol && <CoinLogo symbol={symbol} size={24} />;
 
-const useActionAllowed = (path: string, network?: NetworkCompatible['symbol']) => {
+const useActionAllowed = (path: string, network?: NetworkSymbol) => {
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
     const pathMatch = useRouteMatch(`${process.env.ASSET_PREFIX || ''}${path}`);
 

--- a/packages/suite/src/constants/suite/protocol.ts
+++ b/packages/suite/src/constants/suite/protocol.ts
@@ -1,4 +1,4 @@
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 
 export enum PROTOCOL_SCHEME {
     BITCOIN = 'bitcoin',
@@ -19,7 +19,7 @@ export enum PROTOCOL_SCHEME {
 }
 
 export const PROTOCOL_TO_NETWORK: Partial<{
-    [key in PROTOCOL_SCHEME]: NetworkCompatible['symbol'];
+    [key in PROTOCOL_SCHEME]: NetworkSymbol;
 }> = {
     [PROTOCOL_SCHEME.BITCOIN]: 'btc',
     [PROTOCOL_SCHEME.LITECOIN]: 'ltc',

--- a/packages/suite/src/constants/suite/routes.ts
+++ b/packages/suite/src/constants/suite/routes.ts
@@ -2,7 +2,7 @@ import { ArrayElement } from '@trezor/type-utils';
 import { Route } from '@suite-common/suite-types';
 import { routes } from '@suite-common/suite-config';
 
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { NetworkCompatible, NetworkSymbol } from '@suite-common/wallet-config';
 import { RouteParams } from 'src/utils/suite/router';
 
 export type SettingsBackRoute = {
@@ -11,7 +11,7 @@ export type SettingsBackRoute = {
 };
 
 type RouteParamsTypes = {
-    symbol: NetworkCompatible['symbol'];
+    symbol: NetworkSymbol;
     accountIndex: number;
     accountType: NonNullable<NetworkCompatible['accountType']>;
     cancelable: boolean;

--- a/packages/suite/src/hooks/settings/backends/useBackendsForm.ts
+++ b/packages/suite/src/hooks/settings/backends/useBackendsForm.ts
@@ -7,7 +7,7 @@ import { isUrl } from '@trezor/utils';
 import { isOnionUrl } from 'src/utils/suite/tor';
 import { blockchainActions } from '@suite-common/wallet-core';
 import { isElectrumUrl } from '@suite-common/wallet-utils';
-import { NetworkCompatible, BackendType } from '@suite-common/wallet-config';
+import { NetworkSymbol, BackendType } from '@suite-common/wallet-config';
 import { BackendSettings } from '@suite-common/wallet-types';
 
 export type BackendOption = BackendType | 'default';
@@ -32,7 +32,7 @@ const validateUrl = (type: BackendOption, value: string) => {
     }
 };
 
-const getUrlPlaceholder = (coin: NetworkCompatible['symbol'], type: BackendOption) => {
+const getUrlPlaceholder = (coin: NetworkSymbol, type: BackendOption) => {
     switch (type) {
         case 'blockbook':
             return `https://${coin}1.trezor.io/`;
@@ -47,11 +47,7 @@ const getUrlPlaceholder = (coin: NetworkCompatible['symbol'], type: BackendOptio
     }
 };
 
-const useBackendUrlInput = (
-    coin: NetworkCompatible['symbol'],
-    type: BackendOption,
-    currentUrls: string[],
-) => {
+const useBackendUrlInput = (coin: NetworkSymbol, type: BackendOption, currentUrls: string[]) => {
     const {
         register,
         watch,
@@ -91,7 +87,7 @@ const useBackendUrlInput = (
 };
 
 const getStoredState = (
-    coin: NetworkCompatible['symbol'],
+    coin: NetworkSymbol,
     type?: BackendOption,
     urls?: BackendSettings['urls'],
 ): BackendsFormData => ({
@@ -99,7 +95,7 @@ const getStoredState = (
     urls: (type && type !== 'default' && urls?.[type]) || [],
 });
 
-export const useBackendsForm = (coin: NetworkCompatible['symbol']) => {
+export const useBackendsForm = (coin: NetworkSymbol) => {
     const backends = useSelector(state => state.wallet.blockchain[coin].backends);
     const dispatch = useDispatch();
     const initial = getStoredState(coin, backends.selected, backends.urls);

--- a/packages/suite/src/hooks/settings/backends/useDefaultUrls.ts
+++ b/packages/suite/src/hooks/settings/backends/useDefaultUrls.ts
@@ -1,9 +1,9 @@
 import { useState, useEffect } from 'react';
 import TrezorConnect, { BlockchainLink } from '@trezor/connect';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 
 export const useDefaultUrls = (
-    coin: NetworkCompatible['symbol'],
+    coin: NetworkSymbol,
 ): { defaultUrls: string[]; isLoading: boolean } => {
     const [link, setLink] = useState<BlockchainLink>();
     const [isLoading, setIsLoading] = useState(false);

--- a/packages/suite/src/hooks/suite/useFiatFromCryptoValue.ts
+++ b/packages/suite/src/hooks/suite/useFiatFromCryptoValue.ts
@@ -1,16 +1,15 @@
 import { useSelector } from 'src/hooks/suite';
 
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import { getFiatRateKey, toFiatCurrency } from '@suite-common/wallet-utils';
 import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
 import { selectFiatRatesByFiatRateKey } from '@suite-common/wallet-core';
-import { NetworkSymbol } from '@suite-common/wallet-config';
 import { TokenAddress } from '@suite-common/wallet-types';
 import { TokenTransfer } from '@trezor/blockchain-link-types';
 
 interface CommonOwnProps {
     amount: string;
-    symbol: NetworkCompatible['symbol'] | TokenTransfer['symbol'];
+    symbol: NetworkSymbol | TokenTransfer['symbol'];
     tokenAddress?: TokenAddress;
     fiatCurrency?: string;
 }

--- a/packages/suite/src/hooks/wallet/sign-verify/useSignVerifyForm.ts
+++ b/packages/suite/src/hooks/wallet/sign-verify/useSignVerifyForm.ts
@@ -5,14 +5,14 @@ import { isAddressValid } from '@suite-common/wallet-utils';
 import { yupResolver } from '@hookform/resolvers/yup';
 
 import type { Account } from 'src/types/wallet';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 
 export const MAX_LENGTH_MESSAGE = 1024;
 export const MAX_LENGTH_SIGNATURE = 255;
 
 type SignVerifyContext = {
     isSignPage: boolean;
-    accountNetwork: NetworkCompatible['symbol'];
+    accountNetwork: NetworkSymbol;
 };
 
 const signVerifySchema = yup.object({

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -15,7 +15,7 @@ import { ExperimentalFeature } from 'src/constants/suite/experimental';
 import { Action, Lock, TorBootstrap, TorStatus } from 'src/types/suite';
 import { getExcludedPrerequisites, getPrerequisiteName } from 'src/utils/suite/prerequisites';
 import { RouterRootState, selectRouter } from './routerReducer';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import { SuiteThemeVariant } from '@trezor/suite-desktop-api';
 import { AddressDisplayOptions, WalletType } from '@suite-common/wallet-types';
 import { SIDEBAR_WIDTH_NUMERIC } from 'src/constants/suite/layout';
@@ -72,10 +72,8 @@ export interface Flags {
 }
 
 export interface EvmSettings {
-    confirmExplanationModalClosed: Partial<
-        Record<NetworkCompatible['symbol'], Record<string, boolean>>
-    >;
-    explanationBannerClosed: Partial<Record<NetworkCompatible['symbol'], boolean>>;
+    confirmExplanationModalClosed: Partial<Record<NetworkSymbol, Record<string, boolean>>>;
+    explanationBannerClosed: Partial<Record<NetworkSymbol, boolean>>;
 }
 
 export interface PrefillFields {

--- a/packages/suite/src/storage/definitions.ts
+++ b/packages/suite/src/storage/definitions.ts
@@ -9,7 +9,7 @@ import type { Trade } from 'src/types/wallet/coinmarketCommonTypes';
 import type { MessageState } from '@suite-common/message-system';
 import type { MessageSystem } from '@suite-common/suite-types';
 import type { Account, Discovery, WalletAccountTransaction } from 'src/types/wallet';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import type { CoinjoinAccount, CoinjoinDebugSettings } from 'src/types/wallet/coinjoin';
 import type { BackendSettings, WalletSettings } from '@suite-common/wallet-types';
 import type { StorageUpdateMessage } from '@trezor/suite-storage';
@@ -55,7 +55,7 @@ export interface SuiteDBSchema extends DBSchema {
         value: WalletSettings;
     };
     backendSettings: {
-        key: NetworkCompatible['symbol'];
+        key: NetworkSymbol;
         value: BackendSettings;
     };
     devices: {

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -3,7 +3,7 @@ import { toWei } from 'web3-utils';
 import { isDesktop } from '@trezor/env-utils';
 import type { State } from 'src/reducers/wallet/settingsReducer';
 import type { CustomBackend, BlockbookUrl } from 'src/types/wallet/backend';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 
 import type { BackendSettings } from '@suite-common/wallet-types';
 import type { OnUpgradeFunc } from '@trezor/suite-storage';
@@ -19,7 +19,7 @@ import { parseAsset } from '@trezor/blockchain-link-utils/src/blockfrost';
 
 type WalletWithBackends = {
     backends?: Partial<{
-        [coin in NetworkCompatible['symbol']]: Omit<CustomBackend, 'coin'>;
+        [coin in NetworkSymbol]: Omit<CustomBackend, 'coin'>;
     }>;
 };
 
@@ -297,7 +297,7 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
                             [type]: urls,
                         },
                     };
-                    backendSettings.add(settings, coin as NetworkCompatible['symbol']);
+                    backendSettings.add(settings, coin as NetworkSymbol);
                 });
 
                 return rest;

--- a/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
@@ -1,10 +1,6 @@
 import { Account } from 'src/types/wallet';
-import { NetworkCompatible } from '@suite-common/wallet-config';
-import TrezorConnect from '@trezor/connect';
-import regional from 'src/constants/wallet/coinmarket/regional';
-import { ExtendedMessageDescriptor, TrezorDevice } from 'src/types/suite';
-import { BuyTrade, SellFiatTrade, CryptoId } from 'invity-api';
 import {
+    NetworkCompatible,
     NetworkSymbol,
     getCoingeckoId,
     getNetworkByCoingeckoId,
@@ -13,6 +9,10 @@ import {
     networks,
     networksCompatibility,
 } from '@suite-common/wallet-config';
+import TrezorConnect from '@trezor/connect';
+import regional from 'src/constants/wallet/coinmarket/regional';
+import { ExtendedMessageDescriptor, TrezorDevice } from 'src/types/suite';
+import { BuyTrade, SellFiatTrade, CryptoId } from 'invity-api';
 import {
     DefinitionType,
     getContractAddressForNetwork,
@@ -197,7 +197,7 @@ export const getComposeAddressPlaceholder = async (
     }
 };
 
-export const mapTestnetSymbol = (symbol: NetworkCompatible['symbol']) => {
+export const mapTestnetSymbol = (symbol: NetworkSymbol) => {
     if (symbol === 'test') return 'btc';
     if (symbol === 'tsep') return 'eth';
     if (symbol === 'thol') return 'eth';

--- a/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
+++ b/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
@@ -5,7 +5,7 @@ import { fromWei } from 'web3-utils';
 import { FiatCurrencyCode } from '@suite-common/suite-config';
 import { trezorLogo } from '@suite-common/suite-constants';
 import { TokenDefinitions } from '@suite-common/token-definitions';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import {
     ExportFileType,
     RatesByTimestamps,
@@ -32,7 +32,7 @@ type AccountTransactionForExports = Omit<WalletAccountTransaction, 'targets'> & 
 };
 
 type Data = {
-    coin: NetworkCompatible['symbol'];
+    coin: NetworkSymbol;
     accountName: string;
     type: ExportFileType;
     transactions: AccountTransactionForExports[];
@@ -73,11 +73,11 @@ const timeFormat = {
     timeZoneName: 'shortOffset',
 } as const;
 
-const formatIfDefined = (amount: string | undefined, symbol: NetworkCompatible['symbol']) =>
+const formatIfDefined = (amount: string | undefined, symbol: NetworkSymbol) =>
     amount ? formatNetworkAmount(amount, symbol) : undefined;
 
 const formatAmounts =
-    (symbol: NetworkCompatible['symbol']) =>
+    (symbol: NetworkSymbol) =>
     (tx: AccountTransactionForExports): AccountTransactionForExports => ({
         ...tx,
         tokens: tx.tokens.map(token => ({

--- a/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
+++ b/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { AccountAddress } from '@trezor/connect';
 import { Card, Button, Column, GradientOverlay, Tooltip } from '@trezor/components';
 import { spacings, spacingsPx, typography } from '@trezor/theme';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import { selectFailedSecurityChecks } from '@suite-common/wallet-core';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
 
@@ -98,7 +98,7 @@ interface ItemProps {
     index: number;
     addr: AccountAddress;
     locked: boolean;
-    symbol: NetworkCompatible['symbol'];
+    symbol: NetworkSymbol;
     metadataPayload: MetadataAddPayload;
     onClick: () => void;
 }

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/DayHeader.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/DayHeader.tsx
@@ -3,12 +3,12 @@ import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { useFormatters } from '@suite-common/formatters';
 import { isTestnet, parseTransactionDateKey } from '@suite-common/wallet-utils';
 import { FormattedCryptoAmount, HiddenPlaceholder } from 'src/components/suite';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import { ColAmount, ColDate, ColFiat, HeaderWrapper } from './CommonComponents';
 
 interface DayHeaderProps {
     dateKey: string;
-    symbol: NetworkCompatible['symbol'];
+    symbol: NetworkSymbol;
     totalAmount: BigNumber;
     totalFiatAmountPerDay: BigNumber;
     localCurrency: string;

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/TransactionsGroup.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/TransactionsGroup.tsx
@@ -1,7 +1,7 @@
 import { useState, ReactNode } from 'react';
 import styled from 'styled-components';
 import { WalletAccountTransaction } from 'src/types/wallet';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import { DayHeader } from './DayHeader';
 import {
     getFiatRateKey,
@@ -33,7 +33,7 @@ interface TransactionsGroupProps {
     dateKey: string;
     transactions: WalletAccountTransaction[];
     children?: ReactNode;
-    symbol: NetworkCompatible['symbol'];
+    symbol: NetworkSymbol;
     localCurrency: FiatCurrencyCode;
     index: number;
     isPending: boolean;

--- a/suite-common/message-system/src/messageSystemUtils.ts
+++ b/suite-common/message-system/src/messageSystemUtils.ts
@@ -21,7 +21,7 @@ import type {
     Device,
     Environment,
 } from '@suite-common/suite-types';
-import type { NetworkCompatible } from '@suite-common/wallet-config';
+import type { NetworkSymbol } from '@suite-common/wallet-config';
 import type { TransportInfo } from '@trezor/connect';
 import {
     getBootloaderVersion,
@@ -56,7 +56,7 @@ export const categorizeMessages = (messages: Message[]): ValidMessagesPayload =>
 
 type CurrentSettings = {
     tor: boolean;
-    enabledNetworks: NetworkCompatible['symbol'][];
+    enabledNetworks: NetworkSymbol[];
 };
 
 type Options = {

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -9,7 +9,7 @@ import {
     getFirmwareVersionArray,
     isBitcoinOnlyDevice,
 } from '@trezor/device-utils';
-import { NetworkCompatible, networks } from '@suite-common/wallet-config';
+import { NetworkCompatible, NetworkSymbol, networks } from '@suite-common/wallet-config';
 import { versionUtils } from '@trezor/utils';
 import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
 import { TrezorDevice, AcquiredDevice, ButtonRequest } from '@suite-common/suite-types';
@@ -768,7 +768,7 @@ export const selectDeviceSupportedNetworks = (state: DeviceRootState) => {
 
             return true;
         })
-        .map(([symbol]) => symbol as NetworkCompatible['symbol']);
+        .map(([symbol]) => symbol as NetworkSymbol);
 };
 
 export const selectDeviceById = (state: DeviceRootState, deviceId: TrezorDevice['id']) =>

--- a/suite-common/wallet-types/src/discovery.ts
+++ b/suite-common/wallet-types/src/discovery.ts
@@ -1,6 +1,6 @@
 import { ObjectValues } from '@trezor/type-utils';
 import { DiscoveryStatus } from '@suite-common/wallet-constants';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { NetworkCompatible, NetworkSymbol } from '@suite-common/wallet-config';
 import { Deferred } from '@trezor/utils';
 
 import { Account, AccountBackendSpecific } from './account';
@@ -15,13 +15,13 @@ export interface Discovery {
     status: ObjectValues<typeof DiscoveryStatus>;
     // coins which failed to load
     failed: {
-        symbol: NetworkCompatible['symbol'];
+        symbol: NetworkSymbol;
         index: number;
         accountType: NonNullable<NetworkCompatible['accountType']>;
         error: string;
         fwException?: string;
     }[];
-    networks: NetworkCompatible['symbol'][];
+    networks: NetworkSymbol[];
     running?: Deferred<void>;
     error?: string;
     errorCode?: string | number;

--- a/suite-common/wallet-types/src/settings.ts
+++ b/suite-common/wallet-types/src/settings.ts
@@ -1,4 +1,4 @@
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import { FeeLevel, PROTO } from '@trezor/connect';
 import { FiatCurrencyCode } from '@suite-common/suite-config';
 
@@ -20,7 +20,7 @@ export type WalletType = (typeof WalletType)[keyof typeof WalletType];
 export interface WalletSettings {
     localCurrency: FiatCurrencyCode;
     discreetMode: boolean;
-    enabledNetworks: NetworkCompatible['symbol'][];
+    enabledNetworks: NetworkSymbol[];
     bitcoinAmountUnit: PROTO.AmountUnit;
     lastUsedFeeLevel: {
         [key: string]: Omit<FeeLevel, 'blocks'>; // Key: Network['symbol']


### PR DESCRIPTION
No runtime changes, only mass-replace type `NetworkCompatible['symbol']` with equivalent `NetworkSymbol`. 

## Related Issue

Part of #13839