### PR TITLE
chore(suite): use new Networks in coinjoin

### DIFF
--- a/packages/suite/src/actions/wallet/__fixtures__/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/coinjoinAccountActions.ts
@@ -22,9 +22,11 @@ export const createCoinjoinAccount = [
     {
         description: 'unsupported coinjoin client',
         params: {
-            symbol: 'ltc', // only btc is supported in tests
-            networkType: 'bitcoin',
-            accountType: 'coinjoin',
+            network: {
+                symbol: 'ltc', // only btc is supported in tests
+                networkType: 'bitcoin',
+            },
+            account: { accountType: 'coinjoin' },
         },
         result: {
             actions: [
@@ -43,9 +45,13 @@ export const createCoinjoinAccount = [
             },
         },
         params: {
-            symbol: 'btc',
-            networkType: 'bitcoin',
-            accountType: 'coinjoin',
+            network: {
+                symbol: 'btc',
+                networkType: 'bitcoin',
+            },
+            account: {
+                accountType: 'coinjoin',
+            },
         },
         result: {
             actions: [
@@ -72,10 +78,14 @@ export const createCoinjoinAccount = [
             },
         ],
         params: {
-            symbol: 'btc',
-            networkType: 'bitcoin',
-            accountType: 'coinjoin',
-            bip43Path: "m/10025'/1'/i'/1'",
+            network: {
+                symbol: 'btc',
+                networkType: 'bitcoin',
+            },
+            account: {
+                accountType: 'coinjoin',
+                bip43Path: "m/10025'/1'/i'/1'",
+            },
         },
         result: {
             actions: [
@@ -110,10 +120,14 @@ export const createCoinjoinAccount = [
             },
         ],
         params: {
-            symbol: 'btc',
-            networkType: 'bitcoin',
-            accountType: 'coinjoin',
-            bip43Path: "m/10025'/1'/i'/1'",
+            network: {
+                symbol: 'btc',
+                networkType: 'bitcoin',
+            },
+            account: {
+                accountType: 'coinjoin',
+                bip43Path: "m/10025'/1'/i'/1'",
+            },
         },
         result: {
             actions: [

--- a/packages/suite/src/actions/wallet/__tests__/coinjoinAccountActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/coinjoinAccountActions.test.ts
@@ -70,7 +70,12 @@ describe('coinjoinAccountActions', () => {
             testMocks.setTrezorConnectFixtures(f.connect);
             jest.spyOn(console, 'log').mockImplementation(() => {});
 
-            await store.dispatch(coinjoinAccountActions.createCoinjoinAccount(f.params as any)); // params are incomplete
+            await store.dispatch(
+                coinjoinAccountActions.createCoinjoinAccount(
+                    f.params.network as any,
+                    f.params.account as any,
+                ),
+            ); // params are incomplete
 
             const actions = store.getActions();
             expect(actions.map(a => a.type)).toEqual(f.result.actions);

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddCoinjoinAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddCoinjoinAccountButton.tsx
@@ -13,12 +13,7 @@ import { createCoinjoinAccount } from 'src/actions/wallet/coinjoinAccountActions
 import { toggleTor } from 'src/actions/suite/suiteActions';
 import { openDeferredModal, openModal } from 'src/actions/suite/modalActions';
 import { Account } from 'src/types/wallet';
-import {
-    Network,
-    NetworkAccount,
-    NetworkCompatible,
-    NetworkSymbol,
-} from '@suite-common/wallet-config';
+import { Network, NetworkAccount, NetworkSymbol } from '@suite-common/wallet-config';
 import { selectTorState } from 'src/reducers/suite/suiteReducer';
 
 import { AddButton } from './AddButton';
@@ -80,15 +75,9 @@ export const AddCoinjoinAccountButton = ({ network, selectedAccount }: AddCoinjo
         unavailableCapabilities: device.unavailableCapabilities,
     });
 
-    // TODO refactor createCoinjoinAccount
-    const networkCompatible = {
-        ...network,
-        ...selectedAccount, // adds accountType, overrides Bip43Path and other properties
-    } as unknown as NetworkCompatible;
-
     const onCreateCoinjoinAccountClick = async () => {
         const createAccount = async () => {
-            await dispatch(createCoinjoinAccount(networkCompatible));
+            await dispatch(createCoinjoinAccount(network, selectedAccount));
             setIsLoading(false);
         };
 


### PR DESCRIPTION
Refactoring deprecated `networksCompatibility` to `networks` in `createCoinjoinAccount`.

## Description

Follow-up to #14109, where Add Account Modal was refactored.
In order to split the PRs, `createCoinjoinAccount` was refactored here (with a temporary fix placed in-between, now removed).

## Related Issue

Part of #13839
