### PR TITLE
test(transport-test): add test case

### DIFF
--- a/packages/transport-test/e2e/bridge/multi-client.test.ts
+++ b/packages/transport-test/e2e/bridge/multi-client.test.ts
@@ -331,4 +331,22 @@ describe('bridge', () => {
 
         expect(eventSpy).toHaveBeenCalledTimes(2);
     });
+
+    // todo: is it expected?
+    test(`enumerate - listen - no transport-update event`, async () => {
+        const eventSpy = jest.fn();
+        bridge1.on('transport-update', eventSpy);
+
+        await TrezorUserEnvLink.startEmu(emulatorStartOpts);
+        expect(eventSpy).toHaveBeenCalledTimes(0);
+
+        await bridge1.enumerate().promise;
+        expect(eventSpy).toHaveBeenCalledTimes(0);
+
+        bridge1.listen();
+        await wait(); // wait a little for potential events
+
+        /// this is flaky at least for node-bridge + hw!!!! sometimes 1 sometimes 0
+        expect(eventSpy).toHaveBeenCalledTimes(1);
+    });
 });

--- a/packages/transport-test/e2e/bridge/multi-client.test.ts
+++ b/packages/transport-test/e2e/bridge/multi-client.test.ts
@@ -310,12 +310,11 @@ describe('bridge', () => {
                 bridge1.once('transport-update', resolve);
             });
 
-        TrezorUserEnvLink.startEmu(emulatorStartOpts);
-        await waitForUpdateEvent();
+        await Promise.all([TrezorUserEnvLink.startEmu(emulatorStartOpts), waitForUpdateEvent()]);
         expect(eventSpy).toHaveBeenCalledTimes(1);
 
-        TrezorUserEnvLink.stopEmu();
-        await waitForUpdateEvent();
+        await Promise.all([TrezorUserEnvLink.stopEmu(), waitForUpdateEvent()]);
+
         expect(eventSpy).toHaveBeenCalledTimes(2);
     });
 });


### PR DESCRIPTION
followup after #14028

it turned out that there is probably some difference between old and new bridge in behaviour of `listen` that might be affecting #13780