### PR TITLE
fix(suite-native): tweak fiat amount skeletons to prevent layout shift

### DIFF
--- a/suite-native/atoms/src/Skeleton/BoxSkeleton.tsx
+++ b/suite-native/atoms/src/Skeleton/BoxSkeleton.tsx
@@ -18,19 +18,36 @@ import {
 } from '@shopify/react-native-skia';
 
 import { useNativeStyles } from '@trezor/styles';
-import { nativeBorders } from '@trezor/theme';
+import { Color, nativeBorders } from '@trezor/theme';
+
+import { SurfaceElevation } from '../types';
 
 type BoxSkeletonProps = {
     height: number;
     width: number;
+    elevation?: SurfaceElevation;
     borderRadius?: number;
 };
 
 const ANIMATION_DURATION = 1200;
 
+const elevationToGradientColors = {
+    0: [
+        'backgroundSurfaceElevation0',
+        'backgroundSurfaceElevationNegative',
+        'backgroundSurfaceElevation0',
+    ],
+    1: [
+        'backgroundSurfaceElevation1',
+        'backgroundSurfaceElevationNegative',
+        'backgroundSurfaceElevation1',
+    ],
+} as const satisfies Record<SurfaceElevation, Color[]>;
+
 export const BoxSkeleton = ({
     height,
     width,
+    elevation = '1',
     borderRadius = nativeBorders.radii.small,
 }: BoxSkeletonProps) => {
     const {
@@ -55,12 +72,8 @@ export const BoxSkeleton = ({
     }, [width, height, borderRadius]);
 
     const gradientColors = useMemo(
-        () => [
-            colors.backgroundSurfaceElevation1,
-            colors.backgroundSurfaceElevationNegative,
-            colors.backgroundSurfaceElevation1,
-        ],
-        [colors],
+        () => elevationToGradientColors[elevation].map(color => colors[color]),
+        [colors, elevation],
     );
 
     return (

--- a/suite-native/formatters/src/components/EmptyAmountSkeleton.tsx
+++ b/suite-native/formatters/src/components/EmptyAmountSkeleton.tsx
@@ -1,0 +1,13 @@
+import { BoxSkeleton, HStack } from '@suite-native/atoms';
+
+import { EmptyAmountText } from './EmptyAmountText';
+
+export const EmptyAmountSkeleton = () => {
+    // Usage of EmptyAmountText ensures the correct line height.
+    return (
+        <HStack alignItems="center">
+            <EmptyAmountText />
+            <BoxSkeleton width={48} height={20} />
+        </HStack>
+    );
+};

--- a/suite-native/formatters/src/components/FiatAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/FiatAmountFormatter.tsx
@@ -1,9 +1,10 @@
-import { BoxSkeleton, TextProps } from '@suite-native/atoms';
+import { TextProps } from '@suite-native/atoms';
 import { useFormatters } from '@suite-common/formatters';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { isTestnet } from '@suite-common/wallet-utils';
 
 import { FormatterProps } from '../types';
+import { EmptyAmountSkeleton } from './EmptyAmountSkeleton';
 import { EmptyAmountText } from './EmptyAmountText';
 import { AmountText } from './AmountText';
 
@@ -25,7 +26,7 @@ export const FiatAmountFormatter = ({
         return <EmptyAmountText />;
     }
     if (value === null) {
-        return <BoxSkeleton width={48} height={24} />;
+        return <EmptyAmountSkeleton />;
     }
 
     const formattedValue = formatter.format(value);

--- a/suite-native/graph/src/components/GraphFiatBalance.tsx
+++ b/suite-native/graph/src/components/GraphFiatBalance.tsx
@@ -1,8 +1,9 @@
 import { Atom, useAtomValue } from 'jotai';
 
 import { FiatGraphPoint } from '@suite-common/graph';
-import { BoxSkeleton, DiscreetTextTrigger, HStack } from '@suite-native/atoms';
+import { Box, BoxSkeleton, DiscreetTextTrigger, HStack, VStack } from '@suite-native/atoms';
 import { FiatBalanceFormatter } from '@suite-native/formatters';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { GraphDateFormatter } from './GraphDateFormatter';
 import { PriceChangeIndicator } from './PriceChangeIndicator';
@@ -15,6 +16,20 @@ type GraphFiatBalanceProps = BalanceProps & {
     referencePointAtom: Atom<FiatGraphPoint | null>;
     percentageChangeAtom: Atom<number>;
     hasPriceIncreasedAtom: Atom<boolean>;
+};
+
+const wrapperStyle = prepareNativeStyle(_ => ({
+    height: 72, // Hardcoded because of some margin magic in FiatBalanceFormatter.
+    alignItems: 'center',
+}));
+
+const Skeleton = () => {
+    return (
+        <VStack alignItems="center" spacing="small">
+            <BoxSkeleton elevation="0" width={180} height={44} />
+            <BoxSkeleton elevation="0" width={140} height={20} />
+        </VStack>
+    );
 };
 
 const Balance = ({ selectedPointAtom }: BalanceProps) => {
@@ -34,16 +49,17 @@ export const GraphFiatBalance = ({
     percentageChangeAtom,
     hasPriceIncreasedAtom,
 }: GraphFiatBalanceProps) => {
+    const { applyStyle } = useNativeStyles();
     const firstGraphPoint = useAtomValue(referencePointAtom);
 
     if (!firstGraphPoint) {
-        return <BoxSkeleton width={120} height={73} />;
+        return <Skeleton />;
     }
 
     return (
-        <>
+        <Box style={applyStyle(wrapperStyle)}>
             <Balance selectedPointAtom={selectedPointAtom} />
-            <HStack alignItems="center" style={{ height: 24 }}>
+            <HStack alignItems="center">
                 <GraphDateFormatter
                     firstPointDate={firstGraphPoint.date}
                     selectedPointAtom={selectedPointAtom}
@@ -53,6 +69,6 @@ export const GraphFiatBalance = ({
                     percentageChangeAtom={percentageChangeAtom}
                 />
             </HStack>
-        </>
+        </Box>
     );
 };

--- a/suite-native/graph/src/hooks.ts
+++ b/suite-native/graph/src/hooks.ts
@@ -29,6 +29,7 @@ import {
     setAccountGraphTimeframe,
     setPortfolioGraphTimeframe,
 } from './slice';
+import { A } from '@mobily/ts-belt';
 
 const useWatchTimeframeChangeForAnalytics = (
     timeframeHours: TimeframeHoursValue,
@@ -187,6 +188,7 @@ export const useGraphForAllDeviceAccounts = ({ fiatCurrency }: CommonUseGraphPar
 
     return {
         ...graphForAccounts,
+        isAnyMainnetAccountPresent: A.isNotEmpty(accounts),
         timeframe: portfolioGraphTimeframe,
         onSelectTimeFrame: handleSelectPortfolioTimeframe,
     };

--- a/suite-native/module-home/src/screens/HomeScreen/components/PortfolioGraph.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/PortfolioGraph.tsx
@@ -19,10 +19,17 @@ export const PortfolioGraph = forwardRef<PortfolioGraphRef>((_props, ref) => {
     const fiatCurrencyCode = useSelector(selectFiatCurrencyCode);
     const loadingTakesLongerThanExpected = useIsDiscoveryDurationTooLong();
 
-    const { graphPoints, error, isLoading, refetch, onSelectTimeFrame, timeframe } =
-        useGraphForAllDeviceAccounts({
-            fiatCurrency: fiatCurrencyCode,
-        });
+    const {
+        graphPoints,
+        error,
+        isLoading,
+        isAnyMainnetAccountPresent,
+        refetch,
+        onSelectTimeFrame,
+        timeframe,
+    } = useGraphForAllDeviceAccounts({
+        fiatCurrency: fiatCurrencyCode,
+    });
     const setSelectedPoint = useSetAtom(selectedPointAtom);
     const setReferencePoint = useSetAtom(referencePointAtom);
 
@@ -48,7 +55,7 @@ export const PortfolioGraph = forwardRef<PortfolioGraphRef>((_props, ref) => {
 
     return (
         <VStack spacing="large" testID="@home/portfolio/graph">
-            <PortfolioGraphHeader />
+            {isAnyMainnetAccountPresent ? <PortfolioGraphHeader /> : null}
             <Graph
                 points={graphPoints}
                 loading={isLoading}


### PR DESCRIPTION
Also one big skeleton for fiat balance was split into two smaller ones.

## Related Issue

Resolve #13299

## Screenshots:
![graph](https://github.com/user-attachments/assets/8132efd5-6907-4bfb-91a5-cbf4c677b7b4)
![accounts](https://github.com/user-attachments/assets/37c384a3-1591-4601-afb5-2e74fa9cfe2a)
