### PR TITLE
test(suite-desktop-core): bridge daemon e2e

### DIFF
--- a/.github/workflows/test-suite-desktop-e2e.yml
+++ b/.github/workflows/test-suite-desktop-e2e.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - TEST_FILE: "spawn-bridge suite-guide wallet-discovery"
+          - TEST_FILE: "spawn-bridge spawn-bridge-daemon suite-guide wallet-discovery"
             CONTAINERS: "trezor-user-env-unix"
           - TEST_FILE: "electrum"
             CONTAINERS: "trezor-user-env-unix electrum-regtest"

--- a/packages/suite-desktop-core/e2e/tests/spawn-bridge-daemon.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/spawn-bridge-daemon.test.ts
@@ -1,0 +1,63 @@
+import { test as testPlaywright, expect as expectPlaywright } from '@playwright/test';
+
+import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
+import { createTimeoutPromise } from '@trezor/utils';
+
+import { launchSuite, launchSuiteElectronApp, waitForDataTestSelector } from '../support/common';
+
+testPlaywright.describe.serial('Bridge', () => {
+    testPlaywright.beforeAll(async () => {
+        // We make sure that bridge from trezor-user-env is stopped.
+        // So we properly test the electron app starting node-bridge module.
+        await TrezorUserEnvLink.connect();
+        await TrezorUserEnvLink.stopBridge();
+    });
+
+    testPlaywright('App in daemon mode spawns bridge', async ({ request }) => {
+        const daemonApp = await launchSuiteElectronApp({
+            bridgeDaemon: true,
+            bridgeLegacyTest: false,
+        });
+
+        // 3s timeout for bridge to start
+        await createTimeoutPromise(3000);
+
+        // bridge is running
+        const bridgeRes1 = await request.get('http://127.0.0.1:21325/status/');
+        await expectPlaywright(bridgeRes1).toBeOK();
+
+        // launch UI
+        const suite = await launchSuite();
+        const title = await suite.window.title();
+        expectPlaywright(title).toContain('Trezor Suite');
+
+        // We wait for `@welcome/title` or `@dashboard/graph` since
+        // one or the other will be display depending on the state of the app
+        // due to previously run tests. And both means the same for the porpoise of this test.
+        // Bridge should be ready to check `/status` endpoint.
+        await Promise.race([
+            waitForDataTestSelector(suite.window, '@welcome/title'),
+            waitForDataTestSelector(suite.window, '@dashboard/graph'),
+        ]);
+
+        // bridge is still running
+        const bridgeRes2 = await request.get('http://127.0.0.1:21325/status/');
+        await expectPlaywright(bridgeRes2).toBeOK();
+
+        await suite.electronApp.close();
+
+        // bridge is still running
+        const bridgeRes3 = await request.get('http://127.0.0.1:21325/status/');
+        await expectPlaywright(bridgeRes3).toBeOK();
+
+        await daemonApp.close();
+
+        // bridge is not running
+        try {
+            await request.get('http://127.0.0.1:21325/status/');
+            throw new Error('should have thrown!');
+        } catch (err) {
+            // ok
+        }
+    });
+});

--- a/packages/suite-desktop-core/src/modules/bridge.ts
+++ b/packages/suite-desktop-core/src/modules/bridge.ts
@@ -105,8 +105,9 @@ const shouldUseLegacyBridge = (store: Dependencies['store']) => {
     const newBridgeRollout = store.getBridgeSettings().newBridgeRollout || 0;
     // note that this variable is duplicated with UI
     const NEW_BRIDGE_ROLLOUT_THRESHOLD = 1;
-    const legacyBridgeReasonRollout =
-        !isDevEnv && !skipNewBridgeRollout && newBridgeRollout >= NEW_BRIDGE_ROLLOUT_THRESHOLD;
+    const legacyBridgeReasonRollout = !isDevEnv && newBridgeRollout >= NEW_BRIDGE_ROLLOUT_THRESHOLD;
+
+    if (skipNewBridgeRollout && !legacyRequestedByArg) return false;
 
     return (
         legacyRequestedBySettings ||


### PR DESCRIPTION
## Description

Add a basic E2E test for bridge daemon. It starts the background process, checks the bridge status, then starts the UI and checks its status. It then exits the UI and checks the bridge is still running. 