### PR TITLE
Fix inactive button when device check is disabled

### DIFF
--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheck.tsx
@@ -324,9 +324,7 @@ export const SecurityCheck = () => {
         }
 
         if (nextDeviceToAuthenticate !== undefined) {
-            if (setIsAuthenticityCheckStep) {
-                setIsAuthenticityCheckStep(false);
-            }
+            setIsAuthenticityCheckStep(false);
             dispatch(deviceActions.selectDevice(nextDeviceToAuthenticate));
         } else {
             goToSuite();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`goToSuiteOrNextDevice` did not take `isDeviceAuthenticityCheckDisabled` into account so it just kept reselecting the same device.

I am still not too happy with this, I want the function to select the next device regardless of it supporting authenticity check or not. I will try to do that later, this is just a quick fix.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/14088

## Screenshots:
