### PR TITLE
fix(transport): node-bridge udp reports same value in descriptor.prod…

### DIFF
--- a/packages/transport-test/e2e/bridge/expect.ts
+++ b/packages/transport-test/e2e/bridge/expect.ts
@@ -6,8 +6,9 @@ const { USE_HW, USE_NODE_BRIDGE } = env;
 
 const debug = USE_NODE_BRIDGE ? undefined : USE_HW ? false : true;
 const debugSession = USE_NODE_BRIDGE ? undefined : null;
+
 const path = USE_NODE_BRIDGE ? expect.any(String) : '1';
-const product = USE_HW ? 21441 : USE_NODE_BRIDGE ? undefined : 0;
+const product = USE_HW ? 21441 : 0;
 const vendor = USE_NODE_BRIDGE ? undefined : USE_HW ? 4617 : 0;
 const type =
     USE_NODE_BRIDGE && USE_HW

--- a/packages/transport/src/api/udp.ts
+++ b/packages/transport/src/api/udp.ts
@@ -169,7 +169,7 @@ export class UdpApi extends AbstractApi {
             const enumerateResult = await Promise.all(
                 paths.map(path =>
                     this.ping(path, signal).then(pinged =>
-                        pinged ? { path, type: DEVICE_TYPE.TypeEmulator } : undefined,
+                        pinged ? { path, type: DEVICE_TYPE.TypeEmulator, product: 0 } : undefined,
                     ),
                 ),
             ).then(res => res.filter(isNotUndefined));


### PR DESCRIPTION
step by step removing differences between hw vs emu and new vs old recorded in packages/transport-test/e2e/bridge/expect.ts