### PR TITLE
test(connect): remove ADDRESS_N utility from tests

### DIFF
--- a/packages/connect/e2e/__fixtures__/signMessage.ts
+++ b/packages/connect/e2e/__fixtures__/signMessage.ts
@@ -1,5 +1,3 @@
-const { ADDRESS_N } = global.TestUtils;
-
 // vectors from https://github.com/trezor/trezor-firmware/blob/main/tests/device_tests/test_msg_signmessage.py
 
 const legacyResults = [
@@ -20,7 +18,7 @@ export default {
             description: 'BTC: p2pkh',
             params: {
                 coin: 'Bitcoin',
-                path: ADDRESS_N("m/44'/0'/0'/0/0"),
+                path: "m/44'/0'/0'/0/0",
                 message: 'This is an example of a signed message.',
             },
             result: {
@@ -35,7 +33,7 @@ export default {
             description: 'BTC: p2sh (segwit)',
             params: {
                 coin: 'Bitcoin',
-                path: ADDRESS_N("m/49'/0'/0'/0/0"),
+                path: "m/49'/0'/0'/0/0",
                 message: 'This is an example of a signed message.',
             },
             result: {
@@ -50,7 +48,7 @@ export default {
             description: 'BTC: bech32 (segwit-native)',
             params: {
                 coin: 'Bitcoin',
-                path: ADDRESS_N("m/84'/0'/0'/0/0"),
+                path: "m/84'/0'/0'/0/0",
                 message: 'This is an example of a signed message.',
             },
             result: {
@@ -65,7 +63,7 @@ export default {
             description: 'BTC: long message',
             params: {
                 coin: 'Bitcoin',
-                path: ADDRESS_N("m/44'/0'/0'/0/0"),
+                path: "m/44'/0'/0'/0/0",
                 message: 'VeryLongMessage!'.repeat(64),
             },
             result: {
@@ -80,7 +78,7 @@ export default {
             description: 'BTC: p2sh long message',
             params: {
                 coin: 'Bitcoin',
-                path: ADDRESS_N("m/49'/0'/0'/0/0"),
+                path: "m/49'/0'/0'/0/0",
                 message: 'VeryLongMessage!'.repeat(64),
             },
             result: {
@@ -95,7 +93,7 @@ export default {
             description: 'BTC: bech32 long message',
             params: {
                 coin: 'Bitcoin',
-                path: ADDRESS_N("m/84'/0'/0'/0/0"),
+                path: "m/84'/0'/0'/0/0",
                 message: 'VeryLongMessage!'.repeat(64),
             },
             result: {
@@ -110,7 +108,7 @@ export default {
         //     description: 'NFKD message',
         //     params: {
         //         coin: 'Bitcoin',
-        //         path: ADDRESS_N("m/44'/0'/0'/0/1"),
+        //         path: "m/44'/0'/0'/0/1",
         //         // message: 'Pr\u030ci\u0301s\u030cerne\u030c z\u030clut\u030couc\u030cky\u0301 ku\u030an\u030c u\u0301pe\u030cl d\u030ca\u0301belske\u0301 o\u0301dy za\u0301ker\u030cny\u0301 uc\u030cen\u030c be\u030cz\u030ci\u0301 pode\u0301l zo\u0301ny u\u0301lu\u030a',
         //         message: 'Příšerně žluťoučký kůň úpěl ďábelské ódy zákeřný učeň běží podél zóny úlů',
         //     },
@@ -123,7 +121,7 @@ export default {
             description: 'NFC message',
             params: {
                 coin: 'Bitcoin',
-                path: ADDRESS_N("m/44'/0'/0'/0/1"),
+                path: "m/44'/0'/0'/0/1",
                 message:
                     'P\u0159\xed\u0161ern\u011b \u017elu\u0165ou\u010dk\xfd k\u016f\u0148 \xfap\u011bl \u010f\xe1belsk\xe9 \xf3dy z\xe1ke\u0159n\xfd u\u010de\u0148 b\u011b\u017e\xed pod\xe9l z\xf3ny \xfal\u016f',
             },
@@ -139,7 +137,7 @@ export default {
             description: 'TESTNET: p2pkh',
             params: {
                 coin: 'Testnet',
-                path: ADDRESS_N("m/44'/1'/0'/0/0"),
+                path: "m/44'/1'/0'/0/0",
                 message: 'This is an example of a signed message.',
             },
             result: {
@@ -154,7 +152,7 @@ export default {
             description: 'TESTNET: p2sh',
             params: {
                 coin: 'Testnet',
-                path: ADDRESS_N("m/49'/1'/0'/0/0"),
+                path: "m/49'/1'/0'/0/0",
                 message: 'This is an example of a signed message.',
             },
             result: {
@@ -169,7 +167,7 @@ export default {
             description: 'TESTNET: bech32',
             params: {
                 coin: 'Testnet',
-                path: ADDRESS_N("m/84'/1'/0'/0/0"),
+                path: "m/84'/1'/0'/0/0",
                 message: 'This is an example of a signed message.',
             },
             result: {
@@ -184,7 +182,7 @@ export default {
             description: 'BCH',
             params: {
                 coin: 'Bcash',
-                path: ADDRESS_N("m/44'/145'/0'/0/0"),
+                path: "m/44'/145'/0'/0/0",
                 message: 'This is an example of a signed message.',
             },
             result: {
@@ -199,7 +197,7 @@ export default {
             description: 'BTC no_script_type p2pkh',
             params: {
                 coin: 'Bitcoin',
-                path: ADDRESS_N("m/44'/0'/0'/0/0"),
+                path: "m/44'/0'/0'/0/0",
                 message: 'This is an example of a signed message.',
                 no_script_type: true,
             },
@@ -216,7 +214,7 @@ export default {
             description: 'BTC no_script_type p2sh',
             params: {
                 coin: 'Bitcoin',
-                path: ADDRESS_N("m/49'/0'/0'/0/0"),
+                path: "m/49'/0'/0'/0/0",
                 message: 'This is an example of a signed message.',
                 no_script_type: true,
             },
@@ -233,7 +231,7 @@ export default {
             description: 'BTC no_script_type p2wpkh',
             params: {
                 coin: 'Bitcoin',
-                path: ADDRESS_N("m/84'/0'/0'/0/0"),
+                path: "m/84'/0'/0'/0/0",
                 message: 'This is an example of a signed message.',
                 no_script_type: true,
             },

--- a/packages/connect/e2e/__fixtures__/signTransaction.ts
+++ b/packages/connect/e2e/__fixtures__/signTransaction.ts
@@ -1,4 +1,4 @@
-const { ADDRESS_N, TX_CACHE } = global.TestUtils;
+const { TX_CACHE } = global.TestUtils;
 
 // vectors from https://github.com/trezor/trezor-firmware/blob/main/tests/device_tests/test_msg_signtx.py
 
@@ -32,7 +32,7 @@ export default {
             params: {
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/0'/5'/0/9"),
+                        address_n: "m/44'/0'/5'/0/9",
                         prev_hash:
                             '0dac366fd8a67b2a89fbb0d31086e7acded7a5bbf9ef9daa935bc873229ef5b5',
                         prev_index: 0,
@@ -59,7 +59,7 @@ export default {
             params: {
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/1'/0'/0/0"),
+                        address_n: "m/44'/1'/0'/0/0",
                         prev_hash:
                             'e5040e1bc1ae7667ffb9e5248e90b2fb93cd9150234151ce90e14ab2f5933bcd',
                         prev_index: 0,
@@ -73,7 +73,7 @@ export default {
                         script_type: 'PAYTOADDRESS',
                     },
                     {
-                        address_n: ADDRESS_N("m/44'/1'/0'/1/0"),
+                        address_n: "m/44'/1'/0'/1/0",
                         amount: '900000',
                         script_type: 'PAYTOADDRESS',
                     },
@@ -91,7 +91,7 @@ export default {
             params: {
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/1'/0'/0/7"),
+                        address_n: "m/44'/1'/0'/0/7",
                         prev_hash:
                             '25fee583181847cbe9d9fd9a483a8b8626c99854a72d01de848ef40508d0f3bc',
                         prev_index: 0,
@@ -118,7 +118,7 @@ export default {
             params: {
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/0'/0'/0/5"),
+                        address_n: "m/44'/0'/0'/0/5",
                         prev_hash:
                             '50f6f1209ca92d7359564be803cb2c932cde7d370f7cee50fd1fad6790f6206d',
                         prev_index: 1,
@@ -127,7 +127,7 @@ export default {
                 ],
                 outputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/0'/0'/1/3"),
+                        address_n: "m/44'/0'/0'/1/3",
                         amount: '30000',
                         script_type: 'PAYTOADDRESS',
                     },
@@ -150,7 +150,7 @@ export default {
             params: {
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/1'/1'/0/21"),
+                        address_n: "m/44'/1'/1'/0/21",
                         prev_hash:
                             'bb5169091f09e833e155b291b662019df56870effe388c626221c5ea84274bc4',
                         prev_index: 0,
@@ -169,7 +169,7 @@ export default {
                         script_type: 'PAYTOADDRESS',
                     },
                     {
-                        address_n: ADDRESS_N("m/44'/1'/1'/1/21"),
+                        address_n: "m/44'/1'/1'/1/21",
                         amount: 1183825 - 100100 - 100100 - 10000,
                         script_type: 'PAYTOADDRESS',
                     },
@@ -187,14 +187,14 @@ export default {
             params: {
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/0'/0'/0/55"),
+                        address_n: "m/44'/0'/0'/0/55",
                         prev_hash:
                             'ac4ca0e7827a1228f44449cb57b4b9a809a667ca044dc43bb124627fed4bc10a',
                         prev_index: 1,
                         amount: 10000,
                     },
                     {
-                        address_n: ADDRESS_N("m/44'/0'/0'/1/7"),
+                        address_n: "m/44'/0'/0'/1/7",
                         prev_hash:
                             'ac4ca0e7827a1228f44449cb57b4b9a809a667ca044dc43bb124627fed4bc10a',
                         prev_index: 0,
@@ -203,7 +203,7 @@ export default {
                 ],
                 outputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/0'/0'/1/8"),
+                        address_n: "m/44'/0'/0'/1/8",
                         amount: 71790,
                         script_type: 'PAYTOADDRESS',
                     },
@@ -230,7 +230,7 @@ export default {
             params: {
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/1'/0'/0/0"),
+                        address_n: "m/44'/1'/0'/0/0",
                         prev_hash:
                             '58d56a5d1325cf83543ee4c87fd73a784e4ba1499ced574be359fa2bdcb9ac8e',
                         prev_index: 1,
@@ -253,7 +253,7 @@ export default {
                 coin: 'Bitcoin',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/0'/0'/0/10"),
+                        address_n: "m/44'/0'/0'/0/10",
                         prev_hash:
                             '1f326f65768d55ef146efbb345bd87abe84ac7185726d0457a026fc347a26ef3',
                         prev_index: 0,
@@ -281,7 +281,7 @@ export default {
                 coin: 'Bitcoin',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/0'/0'/0/0"),
+                        address_n: "m/44'/0'/0'/0/0",
                         prev_hash:
                             'd5f65ee80147b4bcc70b75e4bbf2d7382021b871bd8867ef8fa525ef50864882',
                         prev_index: 0,
@@ -305,7 +305,7 @@ export default {
                 coin: 'Testnet',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/1'/0'/0/0"),
+                        address_n: "m/44'/1'/0'/0/0",
                         prev_hash:
                             '005f6f7ff4b70aa09a15b3bc36607d378fad104c4efa4f0a1c8e970538622b3e',
                         prev_index: 0,
@@ -333,7 +333,7 @@ export default {
                 coin: 'Testnet',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/1'/0'/0/0"),
+                        address_n: "m/44'/1'/0'/0/0",
                         prev_hash:
                             'e5040e1bc1ae7667ffb9e5248e90b2fb93cd9150234151ce90e14ab2f5933bcd',
                         prev_index: 0,
@@ -348,13 +348,13 @@ export default {
                     },
                     {
                         // change
-                        address_n: ADDRESS_N("m/44'/1'/0'/1/0"),
+                        address_n: "m/44'/1'/0'/1/0",
                         amount: '900000',
                         script_type: 'PAYTOADDRESS',
                     },
                     {
                         // change
-                        address_n: ADDRESS_N("m/44'/1'/0'/1/1"),
+                        address_n: "m/44'/1'/0'/1/1",
                         amount: '10000',
                         script_type: 'PAYTOADDRESS',
                     },
@@ -372,7 +372,7 @@ export default {
                 coin: 'testnet',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/1'/0'/0/2"),
+                        address_n: "m/44'/1'/0'/0/2",
                         prev_hash:
                             '58d56a5d1325cf83543ee4c87fd73a784e4ba1499ced574be359fa2bdcb9ac8e',
                         prev_index: 0,
@@ -399,7 +399,7 @@ export default {
                 coin: 'testnet',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/1'/0'/0/6"),
+                        address_n: "m/44'/1'/0'/0/6",
                         prev_hash:
                             '074b0070939db4c2635c1bef0c8e68412ccc8d3c8782137547c7a2bbde073fc0',
                         prev_index: 1,
@@ -426,7 +426,7 @@ export default {
                 coin: 'Testnet',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/1'/0'/0/0"),
+                        address_n: "m/44'/1'/0'/0/0",
                         prev_hash:
                             'e5040e1bc1ae7667ffb9e5248e90b2fb93cd9150234151ce90e14ab2f5933bcd',
                         prev_index: 0,
@@ -441,7 +441,7 @@ export default {
                     },
                     {
                         // change on main chain is allowed => treated as a change
-                        address_n: ADDRESS_N("m/44'/1'/0'/0/0"),
+                        address_n: "m/44'/1'/0'/0/0",
                         amount: '900000',
                         script_type: 'PAYTOADDRESS',
                     },

--- a/packages/connect/e2e/__fixtures__/signTransactionBcash.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionBcash.ts
@@ -1,4 +1,4 @@
-const { ADDRESS_N, TX_CACHE } = global.TestUtils;
+const { TX_CACHE } = global.TestUtils;
 
 export default {
     method: 'signTransaction',
@@ -12,7 +12,7 @@ export default {
                 coin: 'Bcash',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/145'/0'/0/0"),
+                        address_n: "m/44'/145'/0'/0/0",
                         amount: '1995344',
                         prev_hash:
                             'bc37c28dfb467d2ecb50261387bf752a3977d7e5337915071bb4151e6b711a78',
@@ -22,7 +22,7 @@ export default {
                 ],
                 outputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/145'/0'/1/0"),
+                        address_n: "m/44'/145'/0'/1/0",
                         amount: '1896050',
                         script_type: 'PAYTOADDRESS',
                     },
@@ -48,7 +48,7 @@ export default {
                 coin: 'Bcash',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/145'/0'/1/0"),
+                        address_n: "m/44'/145'/0'/1/0",
                         amount: '1896050',
                         prev_hash:
                             '502e8577b237b0152843a416f8f1ab0c63321b1be7a8cad7bf5c5c216fcf062c',
@@ -56,7 +56,7 @@ export default {
                         script_type: 'SPENDADDRESS',
                     },
                     {
-                        address_n: ADDRESS_N("m/44'/145'/0'/0/1"),
+                        address_n: "m/44'/145'/0'/0/1",
                         amount: '73452',
                         prev_hash:
                             '502e8577b237b0152843a416f8f1ab0c63321b1be7a8cad7bf5c5c216fcf062c',
@@ -88,7 +88,7 @@ export default {
                 coin: 'Bcash',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/145'/0'/1/0"),
+                        address_n: "m/44'/145'/0'/1/0",
                         amount: '1896050',
                         prev_hash:
                             '502e8577b237b0152843a416f8f1ab0c63321b1be7a8cad7bf5c5c216fcf062c',
@@ -96,7 +96,7 @@ export default {
                         script_type: 'SPENDADDRESS',
                     },
                     {
-                        address_n: ADDRESS_N("m/44'/145'/0'/0/1"),
+                        address_n: "m/44'/145'/0'/0/1",
                         amount: '73452',
                         prev_hash:
                             '502e8577b237b0152843a416f8f1ab0c63321b1be7a8cad7bf5c5c216fcf062c',

--- a/packages/connect/e2e/__fixtures__/signTransactionBech32.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionBech32.ts
@@ -1,4 +1,4 @@
-const { ADDRESS_N, TX_CACHE } = global.TestUtils;
+const { TX_CACHE } = global.TestUtils;
 
 export default {
     method: 'signTransaction',
@@ -12,7 +12,7 @@ export default {
                 coin: 'Testnet',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/84'/1'/0'/0/0"),
+                        address_n: "m/84'/1'/0'/0/0",
                         amount: '129999867',
                         prev_hash:
                             'e294c4c172c3d87991b0369e45d6af8584be92914d01e3060fad1ed31d12ff00',
@@ -33,7 +33,7 @@ export default {
                         script_type: 'PAYTOADDRESS',
                     },
                     {
-                        address_n: ADDRESS_N("m/84'/1'/0'/1/0"),
+                        address_n: "m/84'/1'/0'/1/0",
                         amount: '99999694',
                         script_type: 'PAYTOWITNESS',
                     },
@@ -55,7 +55,7 @@ export default {
                 coin: 'Testnet',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/84'/1'/0'/0/0"),
+                        address_n: "m/84'/1'/0'/0/0",
                         amount: '100000',
                         prev_hash:
                             '70f9871eb03a38405cfd7a01e0e1448678132d815e2c9f552ad83ae23969509e',
@@ -64,7 +64,7 @@ export default {
                         sequence: 4294967293,
                     },
                     {
-                        address_n: ADDRESS_N("m/84'/1'/0'/1/1"),
+                        address_n: "m/84'/1'/0'/1/1",
                         amount: '19899859',
                         prev_hash:
                             '70f9871eb03a38405cfd7a01e0e1448678132d815e2c9f552ad83ae23969509e',
@@ -73,7 +73,7 @@ export default {
                         sequence: 4294967293,
                     },
                     {
-                        address_n: ADDRESS_N("m/84'/1'/0'/0/1"),
+                        address_n: "m/84'/1'/0'/0/1",
                         amount: '99999474',
                         prev_hash:
                             'f405b50dff7053f3697f485f95fe1c0f6a4f5e52446281b4ef470c2762a15dae',
@@ -108,7 +108,7 @@ export default {
                 coin: 'Testnet',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/84'/1'/0'/1/4"),
+                        address_n: "m/84'/1'/0'/1/4",
                         amount: '7802513',
                         prev_hash:
                             'ae0949b1b050ac6f92c7d9c1570f2f06c21a997eef8be9ef5edc2a38cb92a879',
@@ -124,7 +124,7 @@ export default {
                         script_type: 'PAYTOOPRETURN',
                     },
                     {
-                        address_n: ADDRESS_N("m/84'/1'/0'/1/5"),
+                        address_n: "m/84'/1'/0'/1/5",
                         amount: '7802363',
                         script_type: 'PAYTOWITNESS',
                     },

--- a/packages/connect/e2e/__fixtures__/signTransactionBgold.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionBgold.ts
@@ -1,4 +1,4 @@
-const { ADDRESS_N, TX_CACHE } = global.TestUtils;
+const { TX_CACHE } = global.TestUtils;
 
 const legacyResults = [
     {
@@ -23,7 +23,7 @@ export default {
                 coin: 'Bgold',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/156'/0'/0/0"),
+                        address_n: "m/44'/156'/0'/0/0",
                         amount: '1252382934',
                         prev_hash:
                             '6f0398f8bac639312afc2e40210ce5253535f92326167f40e1f38dd7047b00ec',
@@ -33,7 +33,7 @@ export default {
                 ],
                 outputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/156'/0'/1/0"),
+                        address_n: "m/44'/156'/0'/1/0",
                         amount: '1896050',
                         script_type: 'PAYTOADDRESS',
                     },
@@ -57,7 +57,7 @@ export default {
                 coin: 'Bgold',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/156'/0'/0/0"),
+                        address_n: "m/44'/156'/0'/0/0",
                         amount: '1252382934',
                         prev_hash:
                             '6f0398f8bac639312afc2e40210ce5253535f92326167f40e1f38dd7047b00ec',
@@ -65,7 +65,7 @@ export default {
                         script_type: 'SPENDADDRESS',
                     },
                     {
-                        address_n: ADDRESS_N("m/44'/156'/0'/0/1"),
+                        address_n: "m/44'/156'/0'/0/1",
                         amount: '38448607',
                         prev_hash:
                             'aae50f8dc1c19c35517e5bbc2214d38e1ce4b4ff7cb3151b5b31bf0f723f8e06',
@@ -94,7 +94,7 @@ export default {
                 coin: 'Bgold',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/49'/156'/0'/1/0"),
+                        address_n: "m/49'/156'/0'/1/0",
                         amount: '1252382934',
                         prev_hash:
                             'db7239c358352c10996115b3de9e3f37ea0a97be4ea8c4b9e08996e257a21d0e',
@@ -128,7 +128,7 @@ export default {
                 coin: 'Bgold',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/49'/156'/0'/1/0"),
+                        address_n: "m/49'/156'/0'/1/0",
                         amount: '1252382934',
                         prev_hash:
                             'db7239c358352c10996115b3de9e3f37ea0a97be4ea8c4b9e08996e257a21d0e',
@@ -143,7 +143,7 @@ export default {
                         script_type: 'PAYTOADDRESS',
                     },
                     {
-                        address_n: ADDRESS_N("m/49'/156'/0'/1/0"),
+                        address_n: "m/49'/156'/0'/1/0",
                         amount: '1240071934',
                         script_type: 'PAYTOP2SHWITNESS',
                     },
@@ -162,7 +162,7 @@ export default {
                 coin: 'Bgold',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/49'/156'/1'/1/0"),
+                        address_n: "m/49'/156'/1'/1/0",
                         prev_hash:
                             '7f1f6bfe8d5a23e038c58bdcf47e6eb3b5ddb93300176b273564951105206b39',
                         prev_index: 0,

--- a/packages/connect/e2e/__fixtures__/signTransactionDash.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionDash.ts
@@ -1,4 +1,4 @@
-const { ADDRESS_N, TX_CACHE } = global.TestUtils;
+const { TX_CACHE } = global.TestUtils;
 
 // vectors from https://github.com/trezor/trezor-firmware/blob/main/tests/device_tests/test_msg_signtx_dash.py
 
@@ -23,7 +23,7 @@ export default {
                 coin: 'Dash',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/5'/0'/0/0"),
+                        address_n: "m/44'/5'/0'/0/0",
                         prev_hash:
                             '24522992fb42f85d2d43efa3a1ddb98de23ed28583e19128e6e200a9fa6bc665',
                         prev_index: 1,
@@ -51,7 +51,7 @@ export default {
                 coin: 'Dash',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/5'/0'/0/0"),
+                        address_n: "m/44'/5'/0'/0/0",
                         prev_hash:
                             '15575a1c874bd60a819884e116c42e6791c8283ce1fc3b79f0d18531a61bbb8a',
                         prev_index: 1,
@@ -60,7 +60,7 @@ export default {
                 ],
                 outputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/5'/0'/1/0"),
+                        address_n: "m/44'/5'/0'/1/0",
                         amount: '4000000000',
                         script_type: 'PAYTOADDRESS',
                     },
@@ -87,7 +87,7 @@ export default {
                 coin: 'Dash',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/5'/0'/0/0"),
+                        address_n: "m/44'/5'/0'/0/0",
                         prev_hash:
                             'adb43bcd8fc99d6ed353c30ca8e5bd5996cd7bcf719bd4253f103dfb7227f6ed',
                         prev_index: 0,

--- a/packages/connect/e2e/__fixtures__/signTransactionDecred.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionDecred.ts
@@ -1,4 +1,4 @@
-const { ADDRESS_N, TX_CACHE } = global.TestUtils;
+const { TX_CACHE } = global.TestUtils;
 
 const legacyResults = [
     {
@@ -21,7 +21,7 @@ export default {
                 coin: 'tdcr',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/1'/0'/0/0"),
+                        address_n: "m/44'/1'/0'/0/0",
                         amount: '200000000',
                         prev_hash:
                             '4d8acde26d5efc7f5df1b3cdada6b11027616520c883e09c919b88f0f0cb6410',
@@ -50,7 +50,7 @@ export default {
                 coin: 'tdcr',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/1'/0'/0/0"),
+                        address_n: "m/44'/1'/0'/0/0",
                         amount: '200000000',
                         prev_hash:
                             '4d8acde26d5efc7f5df1b3cdada6b11027616520c883e09c919b88f0f0cb6410',
@@ -58,7 +58,7 @@ export default {
                         decred_tree: 0,
                     },
                     {
-                        address_n: ADDRESS_N("m/44'/1'/0'/0/0"),
+                        address_n: "m/44'/1'/0'/0/0",
                         amount: '200000000',
                         prev_hash:
                             'f341fde6a78c2e150619d1c5ecbd90fabeb9e278024cc38ea4190d0b4a6d61d8',
@@ -66,7 +66,7 @@ export default {
                         decred_tree: 0,
                     },
                     {
-                        address_n: ADDRESS_N("m/44'/1'/0'/0/1"),
+                        address_n: "m/44'/1'/0'/0/1",
                         amount: '200000000',
                         prev_hash:
                             '5f3a7d29623eba20788e967439c1ccf122688589dfc07cddcedd1b27dc14b568',
@@ -82,7 +82,7 @@ export default {
                     },
                     {
                         // TsaSFRwfN9muW5F6ZX36iSksc9hruiC5F97
-                        address_n: ADDRESS_N("m/44'/1'/0'/1/0"),
+                        address_n: "m/44'/1'/0'/1/0",
                         amount: '100000000',
                         script_type: 'PAYTOADDRESS',
                     },
@@ -104,7 +104,7 @@ export default {
                 coin: 'tdcr',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/1'/0'/0/0"),
+                        address_n: "m/44'/1'/0'/0/0",
                         amount: '200000000',
                         prev_hash:
                             '4d8acde26d5efc7f5df1b3cdada6b11027616520c883e09c919b88f0f0cb6410',
@@ -119,7 +119,7 @@ export default {
                         script_type: 'PAYTOADDRESS',
                     },
                     {
-                        address_n: ADDRESS_N("m/44'/1'/0'/0/0"),
+                        address_n: "m/44'/1'/0'/0/0",
                         amount: '200000000',
                         script_type: 'PAYTOADDRESS',
                     },
@@ -147,7 +147,7 @@ export default {
                 coin: 'tdcr',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/1'/0'/0/0"),
+                        address_n: "m/44'/1'/0'/0/0",
                         amount: '200000000',
                         prev_hash:
                             'f8e2f2b4eab772f6e3743cba92db341f64b84d9c16ae375c7690fbf0bf02fc7b',
@@ -156,7 +156,7 @@ export default {
                         decred_tree: 1,
                     },
                     {
-                        address_n: ADDRESS_N("m/44'/1'/0'/0/0"),
+                        address_n: "m/44'/1'/0'/0/0",
                         amount: '200000000',
                         prev_hash:
                             '51bc9c71f10a81eef3caedb5333062eb4b1f70998adf02916fe98fdc04c572e8',
@@ -200,7 +200,7 @@ export default {
         //         coin: 'tdcr',
         //         inputs: [
         //             {
-        //                 address_n: ADDRESS_N("m/48'/1'/0'/0'/0/0"),
+        //                 address_n: "m/48'/1'/0'/0'/0/0",
         //                 script_type: 'SPENDMULTISIG',
         //                 amount: '200000000',
         //                 prev_hash:
@@ -227,7 +227,7 @@ export default {
         //                 },
         //             },
         //             {
-        //                 address_n: ADDRESS_N("m/48'/1'/0'/0'/0/1"),
+        //                 address_n: "m/48'/1'/0'/0'/0/1",
         //                 script_type: 'SPENDMULTISIG',
         //                 amount: '200000000',
         //                 prev_hash:
@@ -256,7 +256,7 @@ export default {
         //         ],
         //         outputs: [
         //             {
-        //                 address_n: ADDRESS_N('m/1/0'),
+        //                 address_n: 'm/1/0',
         //                 amount: '99900000',
         //                 script_type: 'PAYTOADDRESS',
         //             },

--- a/packages/connect/e2e/__fixtures__/signTransactionDoge.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionDoge.ts
@@ -1,4 +1,4 @@
-const { ADDRESS_N, TX_CACHE } = global.TestUtils;
+const { TX_CACHE } = global.TestUtils;
 
 export default {
     method: 'signTransaction',
@@ -15,7 +15,7 @@ export default {
                 coin: 'Doge',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/3'/0'/1/0"),
+                        address_n: "m/44'/3'/0'/1/0",
                         amount: '11351855244633976',
                         prev_hash:
                             '0a4cb7d5c27455333701f0e53812e4be56a0272ad7f168279acfed7b065ee118',
@@ -29,7 +29,7 @@ export default {
                         script_type: 'PAYTOADDRESS',
                     },
                     {
-                        address_n: ADDRESS_N("m/44'/3'/0'/1/0"),
+                        address_n: "m/44'/3'/0'/1/0",
                         amount: '10000000000000000',
                         script_type: 'PAYTOADDRESS',
                     },

--- a/packages/connect/e2e/__fixtures__/signTransactionExternal.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionExternal.ts
@@ -1,6 +1,6 @@
 // fixures: https://github.com/trezor/trezor-firmware/blob/main/tests/device_tests/bitcoin/test_signtx_external.py
 
-const { ADDRESS_N, TX_CACHE } = global.TestUtils;
+const { TX_CACHE } = global.TestUtils;
 
 export default {
     method: 'signTransaction',
@@ -28,7 +28,7 @@ export default {
                             '473044022054fa66bfe1de1c850d59840f165143a66075bae78be3a6bc2809d1ac09431d380220019ecb086e16384f18cbae09b02bd2dce18763cd06454d33d93630561250965e0121030e669acac1f280d1ddf441cd2ba5e97417bf2689e4bbec86df4f831bf9f7ffd0',
                     },
                     {
-                        address_n: ADDRESS_N("m/44'/1'/0'/0/1"),
+                        address_n: "m/44'/1'/0'/0/1",
                         amount: '600000000',
                         prev_hash:
                             'd830b877c3d9237a0a68be88825a296da01ac282a2efd2f671d8f17f15117b74',
@@ -36,7 +36,7 @@ export default {
                     },
                     // same set of inputs, but reversed external type. produces same result
                     // {
-                    //     address_n: ADDRESS_N("m/44'/1'/0'/0/0"),
+                    //     address_n: "m/44'/1'/0'/0/0",
                     //     amount: '31000000',
                     //     prev_hash:
                     //         'e5040e1bc1ae7667ffb9e5248e90b2fb93cd9150234151ce90e14ab2f5933bcd',
@@ -60,7 +60,7 @@ export default {
                         script_type: 'PAYTOADDRESS',
                     },
                     {
-                        address_n: ADDRESS_N("m/44'/1'/0'/1/0"),
+                        address_n: "m/44'/1'/0'/1/0",
                         amount: '10990000', // 31000000 + 600000000 - 620000000 - 10000
                         script_type: 'PAYTOADDRESS',
                     },
@@ -93,7 +93,7 @@ export default {
                             '024830450221009962940c7524c8dee6807d76e0ce1ba4a943604db0bce61357dabe5a4ce2d93a022014fa33769e33eb7e6051d9db28f06cff7ead6c7013839cc26c43f887736a9af1012103e7bfe10708f715e8538c92d46ca50db6f657bbc455b7494e6a0303ccdb868b79',
                     },
                     {
-                        address_n: ADDRESS_N("m/84'/1'/0'/0/0"),
+                        address_n: "m/84'/1'/0'/0/0",
                         amount: '10000',
                         prev_hash:
                             'ec16dc5a539c5d60001a7471c37dbb0b5294c289c77df8bd07870b30d73e2231',
@@ -139,7 +139,7 @@ export default {
                 coin: 'Testnet',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/84'/1'/0'/0/0"),
+                        address_n: "m/84'/1'/0'/0/0",
                         amount: '100000',
                         prev_hash:
                             '70f9871eb03a38405cfd7a01e0e1448678132d815e2c9f552ad83ae23969509e',
@@ -165,7 +165,7 @@ export default {
                         script_type: 'PAYTOADDRESS',
                     },
                     {
-                        address_n: ADDRESS_N("m/84'/1'/0'/1/0"),
+                        address_n: "m/84'/1'/0'/1/0",
                         amount: '59000', // 100000 + 10000 - 50000 - 1000
                         script_type: 'PAYTOWITNESS',
                     },
@@ -191,7 +191,7 @@ export default {
                 coin: 'Testnet',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/84'/1'/0'/0/0"),
+                        address_n: "m/84'/1'/0'/0/0",
                         amount: '10000',
                         prev_hash:
                             'ec16dc5a539c5d60001a7471c37dbb0b5294c289c77df8bd07870b30d73e2231',
@@ -238,7 +238,7 @@ export default {
                 coin: 'Testnet',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/86'/1'/0'/0/1"),
+                        address_n: "m/86'/1'/0'/0/1",
                         amount: 13000,
                         prev_hash:
                             '1010b25957a30110377a33bd3b0bd39045b3cc488d0e534d1ea5ec238812c0fc',
@@ -265,7 +265,7 @@ export default {
                         script_type: 'PAYTOADDRESS',
                     },
                     {
-                        address_n: ADDRESS_N("m/86'/1'/0'/1/0"),
+                        address_n: "m/86'/1'/0'/1/0",
                         amount: 4600,
                         script_type: 'PAYTOTAPROOT',
                     },
@@ -312,7 +312,7 @@ export default {
                             '534c001900016b2055d8190244b2ed2d46513c40658a574d3bc2deb6969c0535bb818b44d2c4000247304402201b0a2cd9398f5f3b63e624bb960436a45bdacbd5174b29a47ed3f659b2d4137b022007f8981f476216e012a04956ce77a483cdbff2905227b103a48a15e61379c43d012103505f0d82bbdd251511591b34f36ad5eea37d3220c2b81a1189084431ddb3aa3d',
                     },
                     {
-                        address_n: ADDRESS_N("m/84'/1'/0'/0/0"),
+                        address_n: "m/84'/1'/0'/0/0",
                         amount: '10000',
                         prev_hash:
                             'ec16dc5a539c5d60001a7471c37dbb0b5294c289c77df8bd07870b30d73e2231',
@@ -367,7 +367,7 @@ export default {
                             '534c001900015f6c298a141152b5aef9ef31badea5ceaf9f628a968bed0a14d5ad660761cf1c00014022269a1567cb4f892d0702e6be1175de8b892eda26ffde896d2d240814a747e0b574819431c9c8c95c364f15f447019fe3d4dcc6229110d0598f0265af2b5945',
                     },
                     {
-                        address_n: ADDRESS_N("m/86'/1'/0'/0/0"),
+                        address_n: "m/86'/1'/0'/0/0",
                         amount: '6456',
                         prev_hash:
                             '4012d9abb675243758b8f2cfd0042ce9a6c1459aaf5327dcac16c80f9eff1cbf',

--- a/packages/connect/e2e/__fixtures__/signTransactionKomodo.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionKomodo.ts
@@ -1,4 +1,4 @@
-const { ADDRESS_N, TX_CACHE } = global.TestUtils;
+const { TX_CACHE } = global.TestUtils;
 
 export default {
     method: 'signTransaction',
@@ -17,7 +17,7 @@ export default {
                 locktime: 1563046072,
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/141'/0'/0/0"),
+                        address_n: "m/44'/141'/0'/0/0",
                         prev_hash:
                             '2807c5b126ec8e2b078cab0f12e4c8b4ce1d7724905f8ebef8dca26b0c8e0f1d',
                         prev_index: 0,
@@ -49,7 +49,7 @@ export default {
                 locktime: 0x5d2af1f2,
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/141'/0'/0/0"),
+                        address_n: "m/44'/141'/0'/0/0",
                         prev_hash:
                             '7b28bd91119e9776f0d4ebd80e570165818a829bbf4477cd1afe5149dbcd34b1',
                         prev_index: 0,

--- a/packages/connect/e2e/__fixtures__/signTransactionMultisig.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionMultisig.ts
@@ -1,4 +1,4 @@
-const { ADDRESS_N, TX_CACHE } = global.TestUtils;
+const { TX_CACHE } = global.TestUtils;
 
 // fixtures: https://github.com/trezor/trezor-firmware/blob/main/tests/device_tests/test_multisig.py
 
@@ -47,7 +47,7 @@ export default {
                 coin: 'testnet',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/48'/1'/1'/0'/0/0"),
+                        address_n: "m/48'/1'/1'/0'/0/0",
                         prev_hash:
                             '6b07c1321b52d9c85743f9695e13eb431b41708cdf4e1585258d51208e5b93fc',
                         prev_index: 0,
@@ -80,7 +80,7 @@ export default {
                 coin: 'testnet',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/48'/1'/3'/0'/0/0"),
+                        address_n: "m/48'/1'/3'/0'/0/0",
                         prev_hash:
                             '6b07c1321b52d9c85743f9695e13eb431b41708cdf4e1585258d51208e5b93fc',
                         prev_index: 0,
@@ -115,7 +115,7 @@ export default {
                 coin: 'testnet',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/48'/1'/1'/0'/0/14"),
+                        address_n: "m/48'/1'/1'/0'/0/14",
                         prev_hash:
                             '0d5b5648d47b5650edea1af3d47bbe5624213abb577cf1b1c96f98321f75cdbc',
                         prev_index: 0,
@@ -168,7 +168,7 @@ export default {
                 coin: 'testnet',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/48'/1'/1'/0'/0/0"),
+                        address_n: "m/48'/1'/1'/0'/0/0",
                         prev_hash:
                             '0d5b5648d47b5650edea1af3d47bbe5624213abb577cf1b1c96f98321f75cdbc',
                         prev_index: 0,

--- a/packages/connect/e2e/__fixtures__/signTransactionMultisigChange.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionMultisigChange.ts
@@ -1,4 +1,4 @@
-const { ADDRESS_N, TX_CACHE } = global.TestUtils;
+const { TX_CACHE } = global.TestUtils;
 
 const xpubExt1 =
     'tpubDADHV9u9Y6gkggintTdMjJE3be58zKNLhpxBQyuEM6Pwx3sN9JVLmMCMN4DNVwL9AKec27z5TaWcWuHzMXiGAtcra5DjwWbvppGX4gaEGVN';
@@ -106,7 +106,7 @@ export default {
                         script_type: 'PAYTOADDRESS',
                     },
                     {
-                        address_n: ADDRESS_N("m/45'/0/1/1"),
+                        address_n: "m/45'/0/1/1",
                         amount: '44000000',
                         script_type: 'PAYTOADDRESS',
                     },
@@ -125,12 +125,12 @@ export default {
                 inputs: [input1, input2],
                 outputs: [
                     {
-                        address_n: ADDRESS_N("m/45'/0/1/0"),
+                        address_n: "m/45'/0/1/0",
                         amount: '40000000',
                         script_type: 'PAYTOADDRESS',
                     },
                     {
-                        address_n: ADDRESS_N("m/45'/0/1/1"),
+                        address_n: "m/45'/0/1/1",
                         amount: '44000000',
                         script_type: 'PAYTOADDRESS',
                     },

--- a/packages/connect/e2e/__fixtures__/signTransactionPaymentRequest.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionPaymentRequest.ts
@@ -1,6 +1,6 @@
 // fixtures: https://github.com/trezor/trezor-firmware/blob/main/tests/device_tests/bitcoin/test_signtx_payreq.py
 
-const { ADDRESS_N, TX_CACHE } = global.TestUtils;
+const { TX_CACHE } = global.TestUtils;
 
 export default {
     method: 'signTransaction',
@@ -18,7 +18,7 @@ export default {
                 coin: 'Testnet',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/84'/1'/0'/0/0"),
+                        address_n: "m/84'/1'/0'/0/0",
                         amount: 12300000,
                         prev_hash:
                             'b223a7123d0d1e64ee7924617be88d0ccbe745fefca1bcf286ea2158e80593e2',
@@ -41,7 +41,7 @@ export default {
                     },
                     {
                         // tb1qkvwu9g3k2pdxewfqr7syz89r3gj557l3uuf9r9
-                        address_n: ADDRESS_N("m/84'/1'/0'/0/0"),
+                        address_n: "m/84'/1'/0'/0/0",
                         amount: 12300000 - 5000000 - 2000000 - 11000,
                         script_type: 'PAYTOWITNESS',
                         payment_req_index: 0,

--- a/packages/connect/e2e/__fixtures__/signTransactionPeercoin.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionPeercoin.ts
@@ -1,4 +1,4 @@
-const { ADDRESS_N, TX_CACHE } = global.TestUtils;
+const { TX_CACHE } = global.TestUtils;
 
 export default {
     method: 'signTransaction',
@@ -14,7 +14,7 @@ export default {
                 timestamp: 1573209226,
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/6'/0'/0/0"),
+                        address_n: "m/44'/6'/0'/0/0",
                         prev_hash:
                             '41b29ad615d8eea40a4654a052d18bb10cd08f203c351f4d241f88b031357d3d',
                         prev_index: 0,
@@ -44,7 +44,7 @@ export default {
                 timestamp: 1573218223,
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/6'/0'/0/0"),
+                        address_n: "m/44'/6'/0'/0/0",
                         prev_hash:
                             '41b29ad615d8eea40a4654a052d18bb10cd08f203c351f4d241f88b031357d3d',
                         prev_index: 0,
@@ -53,7 +53,7 @@ export default {
                 ],
                 outputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/6'/0'/0/1"),
+                        address_n: "m/44'/6'/0'/0/1",
                         amount: '900000',
                         script_type: 'PAYTOADDRESS',
                     },

--- a/packages/connect/e2e/__fixtures__/signTransactionReplace.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionReplace.ts
@@ -1,4 +1,4 @@
-const { ADDRESS_N, TX_CACHE } = global.TestUtils;
+const { TX_CACHE } = global.TestUtils;
 
 export default {
     method: 'signTransaction',
@@ -12,7 +12,7 @@ export default {
                 coin: 'Bitcoin',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/0'/0'/0/4"),
+                        address_n: "m/44'/0'/0'/0/4",
                         amount: '174998',
                         prev_index: 0,
                         prev_hash:
@@ -24,7 +24,7 @@ export default {
                 ],
                 outputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/0'/0'/1/2"),
+                        address_n: "m/44'/0'/0'/1/2",
                         script_type: 'PAYTOADDRESS',
                         amount: '109998', // 174998 - 50000 - 15000
                         orig_hash:
@@ -53,7 +53,7 @@ export default {
                 coin: 'Testnet',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/49'/1'/0'/0/4"),
+                        address_n: "m/49'/1'/0'/0/4",
                         amount: '100000',
                         script_type: 'SPENDP2SHWITNESS',
                         prev_hash:
@@ -64,7 +64,7 @@ export default {
                         orig_index: 0,
                     },
                     {
-                        address_n: ADDRESS_N("m/49'/1'/0'/0/3"),
+                        address_n: "m/49'/1'/0'/0/3",
                         amount: '998060',
                         script_type: 'SPENDP2SHWITNESS',
                         prev_hash:
@@ -98,7 +98,7 @@ export default {
                 coin: 'Testnet',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/84'/1'/0'/0/2"),
+                        address_n: "m/84'/1'/0'/0/2",
                         amount: '20000000',
                         script_type: 'SPENDWITNESS',
                         prev_hash:
@@ -121,7 +121,7 @@ export default {
                         orig_index: 0,
                     },
                     {
-                        address_n: ADDRESS_N("m/84'/1'/0'/1/1"),
+                        address_n: "m/84'/1'/0'/1/1",
                         amount: '19899800', // 20000000 - 100000 - 200
                         script_type: 'PAYTOWITNESS',
                         orig_hash:
@@ -144,7 +144,7 @@ export default {
                 coin: 'Testnet',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/49'/1'/0'/0/4"),
+                        address_n: "m/49'/1'/0'/0/4",
                         amount: '100000',
                         script_type: 'SPENDP2SHWITNESS',
                         prev_hash:
@@ -155,7 +155,7 @@ export default {
                         orig_index: 0,
                     },
                     {
-                        address_n: ADDRESS_N("m/49'/1'/0'/0/8"),
+                        address_n: "m/49'/1'/0'/0/8",
                         amount: '4973340',
                         script_type: 'SPENDP2SHWITNESS',
                         prev_hash:
@@ -166,7 +166,7 @@ export default {
                         orig_index: 0,
                     },
                     {
-                        address_n: ADDRESS_N("m/49'/1'/0'/0/3"),
+                        address_n: "m/49'/1'/0'/0/3",
                         amount: '998060',
                         script_type: 'SPENDP2SHWITNESS',
                         prev_hash:
@@ -177,7 +177,7 @@ export default {
                         orig_index: 1,
                     },
                     {
-                        address_n: ADDRESS_N("m/49'/1'/0'/0/9"),
+                        address_n: "m/49'/1'/0'/0/9",
                         amount: '839318869',
                         script_type: 'SPENDP2SHWITNESS',
                         prev_hash:
@@ -205,7 +205,7 @@ export default {
                         orig_index: 0,
                     },
                     {
-                        address_n: ADDRESS_N("m/49'/1'/0'/1/0"),
+                        address_n: "m/49'/1'/0'/1/0",
                         // 100000 + 4973340 + 998060 + 839318869 - 100000000 - 1000000 - 94500
                         amount: '744295769',
                         script_type: 'PAYTOP2SHWITNESS',
@@ -224,7 +224,7 @@ export default {
                 coin: 'Testnet',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/84'/1'/1'/0/14"),
+                        address_n: "m/84'/1'/1'/0/14",
                         amount: '1000000',
                         script_type: 'SPENDWITNESS',
                         prev_hash:
@@ -246,7 +246,7 @@ export default {
                         orig_index: 0,
                     },
                     {
-                        address_n: ADDRESS_N("m/84'/1'/1'/1/10"),
+                        address_n: "m/84'/1'/1'/1/10",
                         // 1000000 - 150 - 150
                         amount: '999700',
                         script_type: 'PAYTOWITNESS',
@@ -268,7 +268,7 @@ export default {
                 coin: 'Testnet',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/84'/1'/0'/0/65"),
+                        address_n: "m/84'/1'/0'/0/65",
                         amount: '10000',
                         script_type: 'SPENDWITNESS',
                         prev_hash:
@@ -280,7 +280,7 @@ export default {
                         sequence: 4294967293,
                     },
                     {
-                        address_n: ADDRESS_N("m/84'/1'/0'/0/66"),
+                        address_n: "m/84'/1'/0'/0/66",
                         amount: '100000',
                         script_type: 'SPENDWITNESS',
                         prev_hash:
@@ -299,7 +299,7 @@ export default {
                         orig_index: 0,
                     },
                     {
-                        address_n: ADDRESS_N("m/84'/1'/0'/1/0"),
+                        address_n: "m/84'/1'/0'/1/0",
                         // (10000 + 100000) - 9890 - 400 (new fee)
                         amount: '99710',
                         script_type: 'PAYTOWITNESS',
@@ -319,7 +319,7 @@ export default {
                 coin: 'Testnet',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/49'/1'/0'/0/4"),
+                        address_n: "m/49'/1'/0'/0/4",
                         amount: '100000',
                         script_type: 'SPENDP2SHWITNESS',
                         prev_hash:
@@ -330,7 +330,7 @@ export default {
                         orig_index: 0,
                     },
                     {
-                        address_n: ADDRESS_N("m/49'/1'/0'/0/3"),
+                        address_n: "m/49'/1'/0'/0/3",
                         amount: '998060',
                         script_type: 'SPENDP2SHWITNESS',
                         prev_hash:
@@ -365,7 +365,7 @@ export default {
                 coin: 'Testnet',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/86'/1'/0'/1/0"),
+                        address_n: "m/86'/1'/0'/1/0",
                         amount: '4600',
                         script_type: 'SPENDTAPROOT',
                         prev_hash:

--- a/packages/connect/e2e/__fixtures__/signTransactionSegwit.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionSegwit.ts
@@ -1,4 +1,4 @@
-const { ADDRESS_N, TX_CACHE } = global.TestUtils;
+const { TX_CACHE } = global.TestUtils;
 
 export default {
     method: 'signTransaction',
@@ -12,7 +12,7 @@ export default {
                 coin: 'Testnet',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/49'/1'/0'/1/0"),
+                        address_n: "m/49'/1'/0'/1/0",
                         amount: '123456789',
                         prev_hash:
                             '20912f98ea3ed849042efed0fdac8cb4fc301961c5988cba56902d8ffb61c337',
@@ -45,7 +45,7 @@ export default {
                 coin: 'Testnet',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/49'/1'/0'/1/0"),
+                        address_n: "m/49'/1'/0'/1/0",
                         amount: '123456789',
                         prev_hash:
                             '20912f98ea3ed849042efed0fdac8cb4fc301961c5988cba56902d8ffb61c337',
@@ -60,7 +60,7 @@ export default {
                         script_type: 'PAYTOADDRESS',
                     },
                     {
-                        address_n: ADDRESS_N("m/49'/1'/0'/1/0"),
+                        address_n: "m/49'/1'/0'/1/0",
                         amount: '111145789',
                         script_type: 'PAYTOP2SHWITNESS',
                     },
@@ -78,7 +78,7 @@ export default {
                 coin: 'Testnet',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/49'/1'/1'/1/0"),
+                        address_n: "m/49'/1'/1'/1/0",
                         prev_hash:
                             '338e2d02e0eaf8848e38925904e51546cf22e58db5b1860c4a0e72b69c56afe5',
                         prev_index: 0,

--- a/packages/connect/e2e/__fixtures__/signTransactionTaproot.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionTaproot.ts
@@ -1,6 +1,6 @@
 // fixures: https://github.com/trezor/trezor-firmware/blob/main/tests/device_tests/bitcoin/test_signtx_taproot.py
 
-const { ADDRESS_N, TX_CACHE } = global.TestUtils;
+const { TX_CACHE } = global.TestUtils;
 
 export default {
     method: 'signTransaction',
@@ -16,7 +16,7 @@ export default {
                 coin: 'Testnet',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/86'/1'/0'/1/0"),
+                        address_n: "m/86'/1'/0'/1/0",
                         amount: 4600,
                         prev_hash:
                             'ec519494bea3746bd5fbdd7a15dac5049a873fa674c67e596d46505b9b835425',
@@ -46,7 +46,7 @@ export default {
                 coin: 'Testnet',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/86'/1'/0'/0/0"),
+                        address_n: "m/86'/1'/0'/0/0",
                         amount: 6800,
                         prev_hash:
                             'c96621a96668f7dd505c4deb9ee2b2038503a5daa4888242560e9b640cca8819',
@@ -54,7 +54,7 @@ export default {
                         script_type: 'SPENDTAPROOT',
                     },
                     {
-                        address_n: ADDRESS_N("m/86'/1'/0'/0/1"),
+                        address_n: "m/86'/1'/0'/0/1",
                         amount: 13000,
                         prev_hash:
                             'c96621a96668f7dd505c4deb9ee2b2038503a5daa4888242560e9b640cca8819',
@@ -69,7 +69,7 @@ export default {
                         script_type: 'PAYTOADDRESS',
                     },
                     {
-                        address_n: ADDRESS_N("m/86'/1'/0'/1/0"),
+                        address_n: "m/86'/1'/0'/1/0",
                         amount: 6800 + 13000 - 200 - 15000,
                         script_type: 'PAYTOTAPROOT',
                     },
@@ -88,7 +88,7 @@ export default {
                 coin: 'Testnet',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/49'/1'/1'/0/0"),
+                        address_n: "m/49'/1'/1'/0/0",
                         amount: 20000,
                         prev_hash:
                             '8c3ea7a10ab6d289119b722ec8c27b70c17c722334ced31a0370d782e4b6775d',
@@ -96,7 +96,7 @@ export default {
                         script_type: 'SPENDP2SHWITNESS',
                     },
                     {
-                        address_n: ADDRESS_N("m/84'/1'/1'/0/0"),
+                        address_n: "m/84'/1'/1'/0/0",
                         amount: 15000,
                         prev_hash:
                             '7956f1de3e7362b04115b64a31f0b6822c50dd6c08d78398f392a0ac3f0e357b',
@@ -104,7 +104,7 @@ export default {
                         script_type: 'SPENDWITNESS',
                     },
                     {
-                        address_n: ADDRESS_N("m/86'/1'/1'/0/0"),
+                        address_n: "m/86'/1'/1'/0/0",
                         amount: 4450,
                         prev_hash:
                             '901593bed347678d9762fdee728c35dc4ec3cfdc3728a4d72dcaab3751122e85',
@@ -112,7 +112,7 @@ export default {
                         script_type: 'SPENDTAPROOT',
                     },
                     {
-                        address_n: ADDRESS_N("m/44'/1'/1'/0/0"),
+                        address_n: "m/44'/1'/1'/0/0",
                         amount: 10000,
                         prev_hash:
                             '3ac32e90831d79385eee49d6030a2123cd9d009fe8ffc3d470af9a6a777a119b',

--- a/packages/connect/e2e/__fixtures__/signTransactionZcash.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionZcash.ts
@@ -1,4 +1,4 @@
-const { ADDRESS_N, TX_CACHE } = global.TestUtils;
+const { TX_CACHE } = global.TestUtils;
 
 export default {
     method: 'signTransaction',
@@ -14,13 +14,13 @@ export default {
                 coin: 'Zcash',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/133'/0'/0/2"),
+                        address_n: "m/44'/133'/0'/0/2",
                         prev_hash:
                             '84533aa6244bcee68040d851dc4f502838ed3fd9ce838e2e48dbf440e7f4df2a',
                         prev_index: 0,
                     },
                     {
-                        address_n: ADDRESS_N("m/44'/133'/0'/1/0"),
+                        address_n: "m/44'/133'/0'/1/0",
                         prev_hash:
                             '84533aa6244bcee68040d851dc4f502838ed3fd9ce838e2e48dbf440e7f4df2a',
                         prev_index: 1,
@@ -48,7 +48,7 @@ export default {
                 coin: 'Zcash',
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/133'/0'/0/0"),
+                        address_n: "m/44'/133'/0'/0/0",
                         prev_hash:
                             '29d25589db4623d1a33c58745b8f95b131f49841c79dcd171847d0d7e9e2dc3a',
                         prev_index: 0,
@@ -80,14 +80,14 @@ export default {
                 branchId: 0x5ba81b19,
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/133'/0'/0/2"),
+                        address_n: "m/44'/133'/0'/0/2",
                         prev_hash:
                             '6df53ccdc6fa17e1cd248f7ec57e86178d6f96f2736bdf978602992b5850ac79',
                         prev_index: 1,
                         amount: '5748208',
                     },
                     {
-                        address_n: ADDRESS_N("m/44'/133'/0'/1/0"),
+                        address_n: "m/44'/133'/0'/1/0",
                         prev_hash:
                             'e7e1d11992e8fcb88e051e59c2917d78dd9fcd857ee042e0263e995590f02ee3',
                         prev_index: 0,
@@ -96,7 +96,7 @@ export default {
                 ],
                 outputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/133'/0'/2/0"),
+                        address_n: "m/44'/133'/0'/2/0",
                         amount: '9800000',
                         script_type: 'PAYTOADDRESS',
                     },
@@ -132,7 +132,7 @@ export default {
                 branchId: 0x76b809bb,
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/133'/0'/0/2"),
+                        address_n: "m/44'/133'/0'/0/2",
                         prev_hash:
                             '4264f5f339c9fd498976dabb6d7b8819e112d25a0c1770a0f3ee81de525de8f8',
                         prev_index: 0,
@@ -166,7 +166,7 @@ export default {
                 branchId: 0x76b809bb,
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/1'/0'/0/7"),
+                        address_n: "m/44'/1'/0'/0/7",
                         prev_hash:
                             '4b6cecb81c825180786ebe07b65bcc76078afc5be0f1c64e08d764005012380d',
                         prev_index: 0,
@@ -199,7 +199,7 @@ export default {
                 branchId: 0x2bb40e60,
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/1'/0'/0/4"),
+                        address_n: "m/44'/1'/0'/0/4",
                         prev_hash:
                             '86850826b043dd9826b4700c555c06bc8b5713938b4e47cb5ecd60679c6d81dc',
                         prev_index: 1,
@@ -232,7 +232,7 @@ export default {
                 // branchId: 0xc2d6d0b4,
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/1'/0'/0/7"),
+                        address_n: "m/44'/1'/0'/0/7",
                         prev_hash:
                             '4b6cecb81c825180786ebe07b65bcc76078afc5be0f1c64e08d764005012380d',
                         prev_index: 0,
@@ -265,7 +265,7 @@ export default {
                 // branchId: 0xc2d6d0b4,
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/1'/0'/0/9"),
+                        address_n: "m/44'/1'/0'/0/9",
                         prev_hash:
                             'f9231f2d6cdcd86b4892c95a5d2045bacd81f4060e8127073456fbb7b7b51568',
                         prev_index: 0,
@@ -298,7 +298,7 @@ export default {
                 // branchId: 0xc2d6d0b4,
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/1'/0'/0/0"),
+                        address_n: "m/44'/1'/0'/0/0",
                         prev_hash:
                             'c5309bd6a18f6bf374918b1c96e872af02e80d678c53d37547de03048ace79bf',
                         prev_index: 0,
@@ -312,7 +312,7 @@ export default {
                         script_type: 'PAYTOADDRESS',
                     },
                     {
-                        address_n: ADDRESS_N("m/44'/1'/0'/0/0"),
+                        address_n: "m/44'/1'/0'/0/0",
                         amount: 4134720 - 1000000 - 2000,
                         script_type: 'PAYTOADDRESS',
                     },
@@ -336,7 +336,7 @@ export default {
                 // branchId: 0xc2d6d0b4,
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/44'/1'/0'/0/0"),
+                        address_n: "m/44'/1'/0'/0/0",
                         prev_hash:
                             'e3820602226974b1dd87b7113cc8aea8c63e5ae29293991e7bfa80c126930368',
                         prev_index: 0,
@@ -379,7 +379,7 @@ export default {
                 // branchId: 0xc2d6d0b4,
                 inputs: [
                     {
-                        address_n: ADDRESS_N("m/48'/1'/1'/0'/0/0"),
+                        address_n: "m/48'/1'/1'/0'/0/0",
                         prev_hash:
                             '431b68c170799a1ba9a936f9bde4ba1fb5606b0ab0a770012875a23d23ba72a3',
                         prev_index: 0,

--- a/packages/connect/e2e/common.setup.js
+++ b/packages/connect/e2e/common.setup.js
@@ -1,7 +1,6 @@
 import TrezorConnect from '../src';
 import { versionUtils } from '@trezor/utils';
 import { UI } from '../src/events';
-import { toHardened, getHDPath } from '../src/utils/pathUtils';
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
 const MNEMONICS = {
@@ -196,9 +195,4 @@ global.Trezor = {
     initTrezorConnect,
 };
 
-const ADDRESS_N = getHDPath;
-
-global.TestUtils = {
-    ...global.TestUtils,
-    ADDRESS_N,
-};
+global.TestUtils = { ...global.TestUtils };

--- a/packages/connect/e2e/tests/device/authorizeCoinjoin.test.ts
+++ b/packages/connect/e2e/tests/device/authorizeCoinjoin.test.ts
@@ -1,7 +1,6 @@
 import TrezorConnect from '../../../src';
 
 const { getController, setup, conditionalTest, initTrezorConnect } = global.Trezor;
-const { ADDRESS_N } = global.TestUtils;
 
 const controller = getController('applyFlags');
 
@@ -37,7 +36,7 @@ describe('TrezorConnect.authorizeCoinjoin', () => {
     conditionalTest(['1', '<2.5.4'], 'Coinjoin success', async () => {
         // unlocked path is required for tx validation
         const unlockPath = await TrezorConnect.unlockPath({
-            path: ADDRESS_N("m/10025'"),
+            path: "m/10025'",
         });
         if (!unlockPath.success) throw new Error(unlockPath.payload.error);
 
@@ -46,7 +45,7 @@ describe('TrezorConnect.authorizeCoinjoin', () => {
             maxRounds: 2,
             maxCoordinatorFeeRate: 500000, // 5% => 0.005 * 10**8;
             maxFeePerKvbyte: 3500,
-            path: ADDRESS_N("m/10025'/1'/0'/1'"),
+            path: "m/10025'/1'/0'/1'",
             coin: 'Testnet',
             scriptType: 'SPENDTAPROOT',
         });
@@ -67,7 +66,7 @@ describe('TrezorConnect.authorizeCoinjoin', () => {
 
         const proof = await TrezorConnect.getOwnershipProof({
             coin: 'Testnet',
-            path: ADDRESS_N("m/10025'/1'/0'/1'/1/0"),
+            path: "m/10025'/1'/0'/1'/1/0",
             scriptType: 'SPENDTAPROOT',
             userConfirmation: true, // ButtonRequest is not emitted because of preauthorization
             commitmentData,
@@ -106,7 +105,7 @@ describe('TrezorConnect.authorizeCoinjoin', () => {
                 },
                 // # NOTE: FAKE input tx
                 {
-                    address_n: ADDRESS_N("m/10025'/1'/0'/1'/1/0"),
+                    address_n: "m/10025'/1'/0'/1'/1/0",
                     prev_hash: 'f982c0a283bd65a59aa89eded9e48f2a3319cb80361dfab4cf6192a03badb60a',
                     prev_index: 1,
                     amount: 7289000,
@@ -124,14 +123,14 @@ describe('TrezorConnect.authorizeCoinjoin', () => {
                 // Our coinjoined output.
                 {
                     // tb1phkcspf88hge86djxgtwx2wu7ddghsw77d6sd7txtcxncu0xpx22shcydyf
-                    address_n: ADDRESS_N("m/10025'/1'/0'/1'/1/1"),
+                    address_n: "m/10025'/1'/0'/1'/1/1",
                     amount: 50000,
                     script_type: 'PAYTOTAPROOT',
                 },
                 // Our change output.
                 {
                     // tb1qr5p6f5sk09sms57ket074vywfymuthlgud7xyx
-                    address_n: ADDRESS_N("m/10025'/1'/0'/1'/1/2"),
+                    address_n: "m/10025'/1'/0'/1'/1/2",
                     amount: 7289000 - 50000 - 36445 - 490,
                     script_type: 'PAYTOTAPROOT',
                 },
@@ -221,7 +220,7 @@ describe('TrezorConnect.authorizeCoinjoin', () => {
             maxRounds: 2,
             maxCoordinatorFeeRate: 500000, // 5% => 0.005 * 10**8;
             maxFeePerKvbyte: 3500,
-            path: ADDRESS_N("m/10025'/1'/0'/1'"),
+            path: "m/10025'/1'/0'/1'",
             coin: 'Testnet',
             scriptType: 'SPENDTAPROOT',
         } as const;

--- a/packages/connect/e2e/tests/device/cancelCoinjoinAuthorization.test.ts
+++ b/packages/connect/e2e/tests/device/cancelCoinjoinAuthorization.test.ts
@@ -1,6 +1,5 @@
 import TrezorConnect, { Success, PROTO, Unsuccessful } from '../../../src';
 
-const { ADDRESS_N } = global.TestUtils;
 const { getController, setup, conditionalTest, initTrezorConnect } = global.Trezor;
 
 describe('TrezorConnect.cancelCoinjoinAuthorization', () => {
@@ -29,7 +28,7 @@ describe('TrezorConnect.cancelCoinjoinAuthorization', () => {
             maxRounds: 2,
             maxCoordinatorFeeRate: 500000, // 5% => 0.005 * 10**8;
             maxFeePerKvbyte: 3500,
-            path: ADDRESS_N("m/10025'/1'/0'/1'"),
+            path: "m/10025'/1'/0'/1'",
             coin: 'Testnet',
             scriptType: 'SPENDTAPROOT',
         });
@@ -42,7 +41,7 @@ describe('TrezorConnect.cancelCoinjoinAuthorization', () => {
 
         const proof = await TrezorConnect.getOwnershipProof({
             coin: 'Testnet',
-            path: ADDRESS_N("m/10025'/1'/0'/1'/1/0"),
+            path: "m/10025'/1'/0'/1'/1/0",
             scriptType: 'SPENDTAPROOT',
             userConfirmation: true,
             commitmentData,
@@ -59,7 +58,7 @@ describe('TrezorConnect.cancelCoinjoinAuthorization', () => {
 
         const proof2 = await TrezorConnect.getOwnershipProof({
             coin: 'Testnet',
-            path: ADDRESS_N("m/10025'/1'/0'/1'/1/0"),
+            path: "m/10025'/1'/0'/1'/1/0",
             scriptType: 'SPENDTAPROOT',
             userConfirmation: true,
             commitmentData,

--- a/packages/connect/e2e/tests/device/passphrase.test.ts
+++ b/packages/connect/e2e/tests/device/passphrase.test.ts
@@ -1,7 +1,6 @@
 import TrezorConnect from '../../../src';
 
 const { getController, setup, conditionalTest, initTrezorConnect } = global.Trezor;
-const { ADDRESS_N } = global.TestUtils;
 
 const controller = getController();
 
@@ -32,8 +31,8 @@ describe('TrezorConnect passphrase', () => {
     });
 
     it('Using multiple passphrases at the same time', async () => {
-        const XPUB_PATH = ADDRESS_N("m/84'/0'/0'");
-        const ADDRESS_PATH = ADDRESS_N("m/84'/0'/0'/0/0");
+        const XPUB_PATH = "m/84'/0'/0'";
+        const ADDRESS_PATH = "m/84'/0'/0'/0/0";
         // get state of default wallet with empty passphrase
         const walletDefault = await TrezorConnect.getDeviceState({
             device: {
@@ -138,7 +137,7 @@ describe('TrezorConnect passphrase', () => {
                 instance: 0,
                 state: walletA.payload.state, // NOTE: state from different wallet/instance
             },
-            path: ADDRESS_N("m/84'/0'/0'/0/0"),
+            path: "m/84'/0'/0'/0/0",
             showOnTrezor: false,
         });
         expect(invalidState.payload).toMatchObject({
@@ -173,7 +172,7 @@ describe('TrezorConnect passphrase', () => {
                 instance: 0,
                 state: walletA.payload.state,
             },
-            path: ADDRESS_N("m/84'/0'/0'"),
+            path: "m/84'/0'/0'",
         });
         // same xpub as walletA from previous test case enforced on instance 0
         expect(xpubA.payload).toMatchObject({

--- a/packages/connect/e2e/tests/device/unlockPath.test.ts
+++ b/packages/connect/e2e/tests/device/unlockPath.test.ts
@@ -1,7 +1,6 @@
 import TrezorConnect from '../../../src';
 
 const { getController, setup, conditionalTest, initTrezorConnect } = global.Trezor;
-const { ADDRESS_N } = global.TestUtils;
 
 const controller = getController('unlockPath');
 
@@ -167,8 +166,7 @@ describe('TrezorConnect.unlockPath', () => {
         const params = {
             inputs: [
                 {
-                    // address_n: "m/10025'/1'/0'/1'/1/0",
-                    address_n: ADDRESS_N("m/10025'/1'/0'/1'/1/0"),
+                    address_n: "m/10025'/1'/0'/1'/1/0",
                     amount: 7289000,
                     prev_hash: 'f982c0a283bd65a59aa89eded9e48f2a3319cb80361dfab4cf6192a03badb60a',
                     prev_index: 1,
@@ -179,8 +177,7 @@ describe('TrezorConnect.unlockPath', () => {
                 // Our change output.
                 {
                     // tb1pchruvduckkwuzm5hmytqz85emften5dnmkqu9uhfxwfywaqhuu0qjggqyp
-                    // address_n: "m/10025'/1'/0'/1'/1/2",
-                    address_n: ADDRESS_N("m/10025'/1'/0'/1'/1/2"),
+                    address_n: "m/10025'/1'/0'/1'/1/2",
                     amount: 7289000 - 50000 - 400,
                     script_type: 'PAYTOTAPROOT' as const,
                 },


### PR DESCRIPTION
connect accepts `address_n` in string format

follow up for https://github.com/trezor/trezor-suite/commit/82910e0766eb23ed7731f6fa1519e449a3ccfdf5
