### PR TITLE
fix(coinmarket): update receive select

### DIFF
--- a/packages/suite/src/constants/wallet/coinmarket/form.ts
+++ b/packages/suite/src/constants/wallet/coinmarket/form.ts
@@ -18,6 +18,7 @@ export const FORM_RECEIVE_CRYPTO_CURRENCY_SELECT = 'receiveCryptoSelect';
 
 export const FORM_DEFAULT_PAYMENT_METHOD = 'creditCard';
 export const FORM_DEFAULT_CRYPTO_CURRENCY = 'bitcoin';
+export const FORM_DEFAULT_CRYPTO_SECONDARY_CURRENCY = 'ethereum';
 export const FORM_DEFAULT_FIAT_CURRENCY = 'eur';
 
 export const FORM_RATE_TYPE = 'rateType';

--- a/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketFormActions.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketFormActions.ts
@@ -19,10 +19,12 @@ import {
     FORM_OUTPUT_CURRENCY,
     FORM_OUTPUT_FIAT,
     FORM_OUTPUT_MAX,
+    FORM_RECEIVE_CRYPTO_CURRENCY_SELECT,
     FORM_SEND_CRYPTO_CURRENCY_SELECT,
 } from 'src/constants/wallet/coinmarket/form';
 import { useSelector } from 'src/hooks/suite';
 import { useCoinmarketFiatValues } from 'src/hooks/wallet/coinmarket/form/common/useCoinmarketFiatValues';
+import { useCoinmarketInfo } from 'src/hooks/wallet/coinmarket/useCoinmarketInfo';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 import { CoinmarketAccountOptionsGroupOptionProps } from 'src/types/coinmarket/coinmarket';
 import {
@@ -37,6 +39,7 @@ import {
     cryptoIdToNetworkSymbol,
     getNetworkDecimals,
 } from 'src/utils/wallet/coinmarket/coinmarketUtils';
+import { coinmarketGetExchangeReceiveCryptoId } from 'src/utils/wallet/coinmarket/exchangeUtils';
 
 /**
  * shareable sub-hook used in useCoinmarketSellForm & useCoinmarketExchangeForm
@@ -64,6 +67,7 @@ export const useCoinmarketFormActions = <T extends CoinmarketSellExchangeFormPro
         deviceState: device?.state,
     });
     const [isUsedFractionButton, setIsUsedFractionButton] = useState(false);
+    const { buildDefaultCryptoOption } = useCoinmarketInfo();
 
     const { getValues, setValue, clearErrors, handleSubmit, control } =
         methods as unknown as UseFormReturn<CoinmarketSellExchangeFormProps>;
@@ -159,6 +163,24 @@ export const useCoinmarketFormActions = <T extends CoinmarketSellExchangeFormPro
         [coinmarketFiatValues, networkDecimals, setValue, shouldSendInSats],
     );
 
+    const setExchangeReceiveCrypto = (selected: CoinmarketAccountOptionsGroupOptionProps) => {
+        if (type !== 'exchange') return;
+
+        const valuesTyped = values as CoinmarketExchangeFormProps;
+
+        if (selected.value === valuesTyped?.receiveCryptoSelect?.value) {
+            const receiveCryptoSelect = coinmarketGetExchangeReceiveCryptoId(
+                selected.value,
+                valuesTyped?.receiveCryptoSelect?.value,
+            );
+
+            setValue(
+                FORM_RECEIVE_CRYPTO_CURRENCY_SELECT,
+                buildDefaultCryptoOption(receiveCryptoSelect),
+            );
+        }
+    };
+
     const onCryptoCurrencyChange = async (selected: CoinmarketAccountOptionsGroupOptionProps) => {
         const networkSymbol = cryptoIdToNetworkSymbol(selected.value);
         const cryptoSelectedCurrent = getValues(FORM_SEND_CRYPTO_CURRENCY_SELECT);
@@ -195,6 +217,7 @@ export const useCoinmarketFormActions = <T extends CoinmarketSellExchangeFormPro
         );
 
         setAccountOnChange(account);
+        setExchangeReceiveCrypto(selected);
 
         changeFeeLevel('normal'); // reset fee level
     };

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeForm.ts
@@ -22,6 +22,7 @@ import {
     getUnusedAddressFromAccount,
 } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import {
+    coinmarketGetExchangeReceiveCryptoId,
     getAmountLimits,
     getCexQuotesByRateType,
     getSuccessQuotesOrdered,
@@ -63,6 +64,7 @@ import { CoinmarketExchangeStepType } from 'src/types/coinmarket/coinmarketOffer
 import { useCoinmarketModalCrypto } from 'src/hooks/wallet/coinmarket/form/common/useCoinmarketModalCrypto';
 import { NetworkCompatible } from '@suite-common/wallet-config';
 import { useCoinmarketAccount } from 'src/hooks/wallet/coinmarket/form/common/useCoinmarketAccount';
+import { useCoinmarketInfo } from 'src/hooks/wallet/coinmarket/useCoinmarketInfo';
 
 export const useCoinmarketExchangeForm = ({
     selectedAccount,
@@ -87,6 +89,7 @@ export const useCoinmarketExchangeForm = ({
     });
     const { callInProgress, timer, device, setCallInProgress, checkQuotesTimer } =
         useCoinmarketCommonOffers({ selectedAccount, type });
+    const { buildDefaultCryptoOption } = useCoinmarketInfo();
 
     const dispatch = useDispatch();
     const { recomposeAndSign } = useCoinmarketRecomposeAndSign();
@@ -143,10 +146,15 @@ export const useCoinmarketExchangeForm = ({
         if (!draft) return null;
         if (isNotFormPage) return draft;
 
+        const defaultReceiveCryptoSelect = coinmarketGetExchangeReceiveCryptoId(
+            defaultValues.sendCryptoSelect?.value,
+            draft.receiveCryptoSelect?.value,
+        );
+
         return {
             ...defaultValues,
             amountInCrypto: draft.amountInCrypto,
-            receiveCryptoSelect: draft.receiveCryptoSelect,
+            receiveCryptoSelect: buildDefaultCryptoOption(defaultReceiveCryptoSelect),
             rateType: draft.rateType,
             exchangeType: draft.exchangeType,
         };

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeFormDefaultValues.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeFormDefaultValues.ts
@@ -15,10 +15,13 @@ import {
 import { FormState, Output } from '@suite-common/wallet-types';
 import { useCoinmarketBuildAccountGroups } from 'src/hooks/wallet/coinmarket/form/useCoinmarketSellFormDefaultValues';
 import { FORM_EXCHANGE_CEX, FORM_RATE_FIXED } from 'src/constants/wallet/coinmarket/form';
+import { useCoinmarketInfo } from 'src/hooks/wallet/coinmarket/useCoinmarketInfo';
+import { coinmarketGetExchangeReceiveCryptoId } from 'src/utils/wallet/coinmarket/exchangeUtils';
 
 export const useCoinmarketExchangeFormDefaultValues = (
     account: Account,
 ): CoinmarketExchangeFormDefaultValuesProps => {
+    const { buildDefaultCryptoOption } = useCoinmarketInfo();
     const localCurrency = useSelector(selectLocalCurrency);
     const defaultCurrency = useMemo(() => buildFiatOption(localCurrency), [localCurrency]);
     const cryptoGroups = useCoinmarketBuildAccountGroups('exchange');
@@ -31,6 +34,13 @@ export const useCoinmarketExchangeFormDefaultValues = (
                     cryptoIdToNetworkSymbol(option.value) === account.symbol,
             ),
         [account.descriptor, account.symbol, cryptoOptions],
+    );
+    const defaultReceiveCryptoSelect = useMemo(
+        () =>
+            buildDefaultCryptoOption(
+                coinmarketGetExchangeReceiveCryptoId(defaultSendCryptoSelect?.value),
+            ),
+        [buildDefaultCryptoOption, defaultSendCryptoSelect?.value],
     );
 
     const defaultPayment: Output = useMemo(
@@ -54,11 +64,11 @@ export const useCoinmarketExchangeFormDefaultValues = (
             ...defaultFormState,
             amountInCrypto: true,
             sendCryptoSelect: defaultSendCryptoSelect,
-            receiveCryptoSelect: null,
+            receiveCryptoSelect: defaultReceiveCryptoSelect,
             rateType: FORM_RATE_FIXED as RateType,
             exchangeType: FORM_EXCHANGE_CEX as ExchangeType,
         }),
-        [defaultFormState, defaultSendCryptoSelect],
+        [defaultFormState, defaultSendCryptoSelect, defaultReceiveCryptoSelect],
     );
 
     return { defaultValues, defaultCurrency };

--- a/packages/suite/src/utils/wallet/coinmarket/__tests__/exchangeUtils.test.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/__tests__/exchangeUtils.test.ts
@@ -1,5 +1,7 @@
+import { CryptoId } from 'invity-api';
 import * as fixtures from '../__fixtures__/exchangeUtils';
 import {
+    coinmarketGetExchangeReceiveCryptoId,
     getAmountLimits,
     getStatusMessage,
     getSuccessQuotesOrdered,
@@ -172,5 +174,27 @@ describe('coinmarket/exchange utils', () => {
         expect(getStatusMessage('KYC')).toBe('TR_EXCHANGE_STATUS_KYC');
         expect(getStatusMessage('ERROR')).toBe('TR_EXCHANGE_STATUS_ERROR');
         expect(getStatusMessage('SUCCESS')).toBe('TR_EXCHANGE_STATUS_SUCCESS');
+    });
+
+    it('coinmarketGetExchangeReceiveCryptoId', () => {
+        // default cryptoId
+        expect(coinmarketGetExchangeReceiveCryptoId('bitcoin' as CryptoId)).toBe('ethereum');
+        expect(coinmarketGetExchangeReceiveCryptoId('litecoin' as CryptoId)).toBe('bitcoin');
+        expect(
+            coinmarketGetExchangeReceiveCryptoId(
+                'ethereum--0x0000000000085d4780b73119b644ae5ecd22b376' as CryptoId,
+            ),
+        ).toBe('bitcoin');
+
+        // already selected
+        expect(
+            coinmarketGetExchangeReceiveCryptoId('bitcoin' as CryptoId, 'bitcoin' as CryptoId),
+        ).toBe('ethereum');
+        expect(
+            coinmarketGetExchangeReceiveCryptoId(
+                'bitcoin' as CryptoId,
+                'ethereum--0x0000000000085d4780b73119b644ae5ecd22b376' as CryptoId,
+            ),
+        ).toBe('ethereum--0x0000000000085d4780b73119b644ae5ecd22b376');
     });
 });

--- a/packages/suite/src/utils/wallet/coinmarket/exchangeUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/exchangeUtils.ts
@@ -1,8 +1,13 @@
 import { ExchangeInfo } from 'src/actions/wallet/coinmarketExchangeActions';
 import { CryptoAmountLimits } from 'src/types/wallet/coinmarketCommonTypes';
-import { ExchangeTrade, ExchangeTradeStatus } from 'invity-api';
+import { CryptoId, ExchangeTrade, ExchangeTradeStatus } from 'invity-api';
 import { RateType } from 'src/types/coinmarket/coinmarketForm';
-import { FORM_RATE_FIXED, FORM_RATE_FLOATING } from 'src/constants/wallet/coinmarket/form';
+import {
+    FORM_DEFAULT_CRYPTO_CURRENCY,
+    FORM_DEFAULT_CRYPTO_SECONDARY_CURRENCY,
+    FORM_RATE_FIXED,
+    FORM_RATE_FLOATING,
+} from 'src/constants/wallet/coinmarket/form';
 
 // loop through quotes and if all quotes are either with error below minimum or over maximum, return error message
 export const getAmountLimits = (quotes: ExchangeTrade[]): CryptoAmountLimits | undefined => {
@@ -103,4 +108,21 @@ export const getStatusMessage = (status: ExchangeTradeStatus) => {
         default:
             return 'TR_EXCHANGE_STATUS_CONFIRMING';
     }
+};
+
+export const coinmarketGetExchangeReceiveCryptoId = (
+    sendCryptoId: CryptoId | undefined,
+    receiveCryptoId?: CryptoId | undefined,
+): CryptoId => {
+    const getReceivedDefaultCryptoId = (cryptoId: CryptoId | undefined) => {
+        if (cryptoId === FORM_DEFAULT_CRYPTO_CURRENCY)
+            return FORM_DEFAULT_CRYPTO_SECONDARY_CURRENCY as CryptoId;
+
+        return FORM_DEFAULT_CRYPTO_CURRENCY as CryptoId;
+    };
+
+    if (sendCryptoId === receiveCryptoId) return getReceivedDefaultCryptoId(receiveCryptoId);
+    if (receiveCryptoId) return receiveCryptoId;
+
+    return getReceivedDefaultCryptoId(sendCryptoId);
 };

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputCryptoSelect.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputCryptoSelect.tsx
@@ -43,16 +43,17 @@ export const CoinmarketFormInputCryptoSelect = <
 
     const [isOpen, setIsOpen] = useState(false);
     const [isFocus, setIsFocus] = useState(false);
+    const sendCryptoSelectValue = isCoinmarketExchangeOffers(context)
+        ? (context.getValues()?.sendCryptoSelect?.value as CryptoId)
+        : null;
 
     const options = useMemo(
         () =>
             buildCryptoOptions(
                 supportedCryptoCurrencies ?? new Set(),
-                isCoinmarketExchangeOffers(context) && context.getValues()?.sendCryptoSelect?.value
-                    ? new Set([context.getValues()?.sendCryptoSelect?.value as CryptoId])
-                    : new Set(),
+                sendCryptoSelectValue ? new Set([sendCryptoSelectValue]) : new Set(),
             ),
-        [buildCryptoOptions, supportedCryptoCurrencies, context],
+        [buildCryptoOptions, supportedCryptoCurrencies, sendCryptoSelectValue],
     );
 
     return (


### PR DESCRIPTION
## Issue
1. Select the default cryptocurrency in `To` input
the default is BTC if you select ETH account - BTC will select

2. Update `To` input on `From` change
If you select the same value in the 'From' dropdown as in the 'To' dropdown, the 'To' dropdown will be updated according to the condition above.

3. Select options re-render fix

## Design
### Before
![image](https://github.com/user-attachments/assets/de068b0c-2dce-46d8-b246-a258a6844ce2)

### After
![image](https://github.com/user-attachments/assets/829ca2a7-2083-42e2-8070-7c4a44e4aeae)


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/14133
