### PR TITLE
feat(suite-native) improve coin enabling flow

### DIFF
--- a/suite-native/module-settings/package.json
+++ b/suite-native/module-settings/package.json
@@ -30,6 +30,7 @@
         "@suite-native/biometrics": "workspace:*",
         "@suite-native/coin-enabling": "workspace:*",
         "@suite-native/config": "workspace:*",
+        "@suite-native/device": "workspace:*",
         "@suite-native/device-manager": "workspace:*",
         "@suite-native/discovery": "workspace:*",
         "@suite-native/feature-flags": "workspace:*",

--- a/suite-native/module-settings/src/screens/SettingsCoinEnablingScreen.tsx
+++ b/suite-native/module-settings/src/screens/SettingsCoinEnablingScreen.tsx
@@ -1,5 +1,5 @@
 import { useDispatch, useSelector } from 'react-redux';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { View } from 'react-native';
 
 import { useFocusEffect } from '@react-navigation/native';
@@ -13,10 +13,12 @@ import { selectIsBitcoinOnlyDevice } from '@suite-common/wallet-core';
 import {
     selectDiscoverySupportedNetworks,
     selectEnabledDiscoveryNetworkSymbols,
+    setEnabledDiscoveryNetworkSymbols,
     setIsCoinEnablingInitFinished,
 } from '@suite-native/discovery';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { hexToRgba } from '@suite-common/suite-utils';
+import { selectViewOnlyDevicesAccountsNetworkSymbols } from '@suite-native/device';
 
 const GRADIENT_HEIGHT = 40;
 
@@ -40,9 +42,20 @@ export const SettingsCoinEnablingScreen = () => {
     const enabledNetworkSymbols = useSelector(selectEnabledDiscoveryNetworkSymbols);
     const availableNetworks = useSelector(selectDiscoverySupportedNetworks);
     const isBitcoinOnlyDevice = useSelector(selectIsBitcoinOnlyDevice);
+    const viewOnlyDevicesAccountsNetworkSymbols = useSelector(
+        selectViewOnlyDevicesAccountsNetworkSymbols,
+    );
 
     //testnets can be enabled and we want to show networks that case
     const showNetworks = availableNetworks.length > 1 || !isBitcoinOnlyDevice;
+
+    useEffect(() => {
+        // in case the user has view only devices and gets to the settings
+        // before the Coin Enabling has been initialized, we need to set the networks
+        if (enabledNetworkSymbols.length === 0) {
+            dispatch(setEnabledDiscoveryNetworkSymbols(viewOnlyDevicesAccountsNetworkSymbols));
+        }
+    }, [enabledNetworkSymbols.length, dispatch, viewOnlyDevicesAccountsNetworkSymbols]);
 
     useFocusEffect(
         useCallback(() => {

--- a/suite-native/module-settings/tsconfig.json
+++ b/suite-native/module-settings/tsconfig.json
@@ -29,6 +29,7 @@
         { "path": "../biometrics" },
         { "path": "../coin-enabling" },
         { "path": "../config" },
+        { "path": "../device" },
         { "path": "../device-manager" },
         { "path": "../discovery" },
         { "path": "../feature-flags" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10312,6 +10312,7 @@ __metadata:
     "@suite-native/biometrics": "workspace:*"
     "@suite-native/coin-enabling": "workspace:*"
     "@suite-native/config": "workspace:*"
+    "@suite-native/device": "workspace:*"
     "@suite-native/device-manager": "workspace:*"
     "@suite-native/discovery": "workspace:*"
     "@suite-native/feature-flags": "workspace:*"


### PR DESCRIPTION
- [x] Make sure showing the UI works correctly with biometric prompt
- [X] preselect networks for view only devices when user enters Coin enabling in settings before initial setup takes place and dont go through initial setup after any network is enabled this way.

## Related Issue

Resolve #13819
