### PR TITLE
feat(coinmarket): add analytics on confirm transaction

### DIFF
--- a/packages/suite-analytics/src/constants.ts
+++ b/packages/suite-analytics/src/constants.ts
@@ -43,6 +43,8 @@ export enum EventType {
 
     CoinjoinAnonymityGain = 'coinjoin/anonymity-gain',
 
+    CoinmarketConfirmTrade = 'trade/confirm-trade',
+
     MenuNotificationsToggle = 'menu/notifications/toggle',
     MenuToggleDiscreet = 'menu/toggle-discreet',
 

--- a/packages/suite-analytics/src/types/events.ts
+++ b/packages/suite-analytics/src/types/events.ts
@@ -161,6 +161,12 @@ export type SuiteAnalyticsEvent =
           };
       }
     | {
+          type: EventType.CoinmarketConfirmTrade;
+          payload: {
+              type: 'buy' | 'sell' | 'exchange';
+          };
+      }
+    | {
           type: EventType.AccountsTransactionsExport;
           payload: {
               symbol: string;

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketBuyForm.tsx
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketBuyForm.tsx
@@ -48,6 +48,7 @@ import { useCoinmarketCurrencySwitcher } from 'src/hooks/wallet/coinmarket/form/
 import { useCoinmarketModalCrypto } from 'src/hooks/wallet/coinmarket/form/common/useCoinmarketModalCrypto';
 import { useCoinmarketInfo } from 'src/hooks/wallet/coinmarket/useCoinmarketInfo';
 import { networks } from '@suite-common/wallet-config';
+import { analytics, EventType } from '@trezor/suite-analytics';
 
 const useCoinmarketBuyForm = ({
     selectedAccount,
@@ -348,6 +349,13 @@ const useCoinmarketBuyForm = ({
     const confirmTrade = async (address: string) => {
         setCallInProgress(true);
         if (!selectedQuote) return;
+
+        analytics.report({
+            type: EventType.CoinmarketConfirmTrade,
+            payload: {
+                type,
+            },
+        });
 
         const returnUrl = await createTxLink(selectedQuote, account);
         const quote = { ...selectedQuote, receiveAddress: address };

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeForm.ts
@@ -60,6 +60,7 @@ import { useCoinmarketModalCrypto } from 'src/hooks/wallet/coinmarket/form/commo
 import { networks } from '@suite-common/wallet-config';
 import { useCoinmarketAccount } from 'src/hooks/wallet/coinmarket/form/common/useCoinmarketAccount';
 import { useCoinmarketInfo } from 'src/hooks/wallet/coinmarket/useCoinmarketInfo';
+import { analytics, EventType } from '@trezor/suite-analytics';
 
 export const useCoinmarketExchangeForm = ({
     selectedAccount,
@@ -353,6 +354,13 @@ export const useCoinmarketExchangeForm = ({
     };
 
     const confirmTrade = async (address: string, extraField?: string, trade?: ExchangeTrade) => {
+        analytics.report({
+            type: EventType.CoinmarketConfirmTrade,
+            payload: {
+                type,
+            },
+        });
+
         let ok = false;
         const { address: refundAddress } = getUnusedAddressFromAccount(account);
         if (!trade) {

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSellForm.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSellForm.ts
@@ -48,6 +48,7 @@ import { useCoinmarketCurrencySwitcher } from 'src/hooks/wallet/coinmarket/form/
 import { networks } from '@suite-common/wallet-config';
 import { useCoinmarketAccount } from 'src/hooks/wallet/coinmarket/form/common/useCoinmarketAccount';
 import { useCoinmarketInfo } from 'src/hooks/wallet/coinmarket/useCoinmarketInfo';
+import { analytics, EventType } from '@trezor/suite-analytics';
 
 export const useCoinmarketSellForm = ({
     selectedAccount,
@@ -455,6 +456,14 @@ export const useCoinmarketSellForm = ({
 
     const confirmTrade = async (bankAccount: BankAccount) => {
         if (!selectedQuote) return;
+
+        analytics.report({
+            type: EventType.CoinmarketConfirmTrade,
+            payload: {
+                type,
+            },
+        });
+
         const quote = { ...selectedQuote, bankAccount };
         const response = await doSellTrade(quote);
         if (response) {

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketVerify/CoinmarketVerify.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketVerify/CoinmarketVerify.tsx
@@ -247,7 +247,6 @@ export const CoinmarketVerify = ({ coinmarketVerifyAccount, currency }: Coinmark
                             isLoading={callInProgress}
                             onClick={() => {
                                 if (address) {
-                                    confirmTrade(address);
                                     confirmTrade(address, extraField);
                                 }
                             }}


### PR DESCRIPTION
## Description
```
{
  c_v=23.11.0&
  c_type=trade/confirm-trade&
  c_commit=9745dbb7a78674007258f39cfa144dfdcd8aeb59&
  c_instance_id=Z04wNMyHlf&
  c_session_id=Z7qeBw8mBM&
  c_timestamp=1698763630371&
  c_message_id=kXxNerHCt2&
  type=sell
}
```
- `c_type` - `trade/confirm-trade`
- `type` - `buy|sell|exchange` - depending on which flow (exchange remains as an exchange for swap flow, to be consistent with other events)
- should be only triggered when user-approved analytics consent

### Trigger
- When a user clicks on “Finish transaction” button in Buy, Sell or Swap flow regardless of API response.

## Info
Resolve https://github.com/trezor/trezor-suite/issues/14157