### PR TITLE
Remove `SecurityCheckButton`

### DIFF
--- a/packages/components/src/components/buttons/Button/Button.tsx
+++ b/packages/components/src/components/buttons/Button/Button.tsx
@@ -160,6 +160,7 @@ export const Button = ({
     return (
         <ButtonContainer
             as={isLink ? 'a' : 'button'}
+            target={isLink ? target || '_blank' : undefined}
             href={href}
             $variant={variant}
             $size={size}

--- a/packages/suite/src/components/suite/SecurityCheck/SecurityCheckFail.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/SecurityCheckFail.tsx
@@ -1,12 +1,11 @@
 import styled from 'styled-components';
 
-import { H2, Row, Text, useElevation } from '@trezor/components';
+import { Button, H2, Row, Text, useElevation } from '@trezor/components';
 import { Elevation, mapElevationToBorder, spacings, spacingsPx } from '@trezor/theme';
 import { TREZOR_SUPPORT_FW_CHECK_FAILED } from '@trezor/urls';
 
 import { Translation, TrezorLink } from 'src/components/suite';
 import { SecurityChecklist } from '../../../views/onboarding/steps/SecurityCheck/SecurityChecklist';
-import { SecurityCheckButton } from '../../../views/onboarding/steps/SecurityCheck/SecurityCheckButton';
 import { SecurityCheckLayout } from './SecurityCheckLayout';
 
 const TopSection = styled.div<{ $elevation: Elevation }>`
@@ -19,10 +18,6 @@ const TopSection = styled.div<{ $elevation: Elevation }>`
 const StyledTrezorLink = styled(TrezorLink)`
     /* flex-grow has no effect on a link, display is set to contents so that it can be read from the child */
     display: contents;
-`;
-
-const StyledSecurityCheckButton = styled(SecurityCheckButton)`
-    flex-grow: 1;
 `;
 
 const checklistItems = [
@@ -70,14 +65,14 @@ export const SecurityCheckFail = ({ goBack, useSoftMessaging }: SecurityCheckFai
             <SecurityChecklist items={checklistItems} />
             <Row flexWrap="wrap" gap={spacings.xl} width="100%">
                 {goBack && (
-                    <StyledSecurityCheckButton variant="tertiary" onClick={goBack}>
+                    <Button variant="tertiary" onClick={goBack}>
                         <Translation id="TR_BACK" />
-                    </StyledSecurityCheckButton>
+                    </Button>
                 )}
                 <StyledTrezorLink variant="nostyle" href={supportChatUrl}>
-                    <StyledSecurityCheckButton>
+                    <Button>
                         <Translation id="TR_CONTACT_TREZOR_SUPPORT" />
-                    </StyledSecurityCheckButton>
+                    </Button>
                 </StyledTrezorLink>
             </Row>
         </SecurityCheckLayout>

--- a/packages/suite/src/components/suite/SecurityCheck/SecurityCheckFail.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/SecurityCheckFail.tsx
@@ -1,23 +1,21 @@
 import styled from 'styled-components';
 
-import { Button, H2, Row, Text, useElevation } from '@trezor/components';
-import { Elevation, mapElevationToBorder, spacings, spacingsPx } from '@trezor/theme';
+import { Button, Divider, H2, Row, Text } from '@trezor/components';
+import { spacings, spacingsPx } from '@trezor/theme';
 import { TREZOR_SUPPORT_FW_CHECK_FAILED } from '@trezor/urls';
 
-import { Translation, TrezorLink } from 'src/components/suite';
+import { Translation } from 'src/components/suite';
 import { SecurityChecklist } from '../../../views/onboarding/steps/SecurityCheck/SecurityChecklist';
 import { SecurityCheckLayout } from './SecurityCheckLayout';
 
-const TopSection = styled.div<{ $elevation: Elevation }>`
-    border-bottom: 1px solid ${mapElevationToBorder};
+const TopSection = styled.div`
     margin-top: ${spacingsPx.xs};
-    padding-bottom: ${spacingsPx.xl};
+    margin-bottom: ${spacingsPx.xl};
     width: 100%;
 `;
 
-const StyledTrezorLink = styled(TrezorLink)`
-    /* flex-grow has no effect on a link, display is set to contents so that it can be read from the child */
-    display: contents;
+const Flex = styled.div`
+    flex: 1;
 `;
 
 const checklistItems = [
@@ -50,30 +48,29 @@ export const SecurityCheckFail = ({ goBack, useSoftMessaging }: SecurityCheckFai
         ? 'TR_DEVICE_COMPROMISED_TEXT_SOFT'
         : 'TR_DEVICE_COMPROMISED_TEXT';
 
-    const { elevation } = useElevation();
-
     return (
         <SecurityCheckLayout isFailed>
-            <TopSection $elevation={elevation}>
-                <H2>
+            <TopSection>
+                <H2 margin={{ bottom: spacings.sm }}>
                     <Translation id={heading} />
                 </H2>
                 <Text variant="tertiary">
                     <Translation id={text} />
                 </Text>
             </TopSection>
+            <Divider margin={{ top: spacings.zero, bottom: spacings.xl }} />
             <SecurityChecklist items={checklistItems} />
             <Row flexWrap="wrap" gap={spacings.xl} width="100%">
                 {goBack && (
-                    <Button variant="tertiary" onClick={goBack}>
+                    <Button variant="tertiary" onClick={goBack} size="large">
                         <Translation id="TR_BACK" />
                     </Button>
                 )}
-                <StyledTrezorLink variant="nostyle" href={supportChatUrl}>
-                    <Button>
+                <Flex>
+                    <Button href={supportChatUrl} isFullWidth size="large">
                         <Translation id="TR_CONTACT_TREZOR_SUPPORT" />
                     </Button>
-                </StyledTrezorLink>
+                </Flex>
             </Row>
         </SecurityCheckLayout>
     );

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheck.tsx
@@ -4,7 +4,7 @@ import styled, { useTheme } from 'styled-components';
 import { getConnectedDeviceStatus } from '@suite-common/suite-utils';
 import { AcquiredDevice } from '@suite-common/suite-types';
 import { deviceActions, selectDevice, selectDevices } from '@suite-common/wallet-core';
-import { Column, Icon, H2, Text, Tooltip, useElevation } from '@trezor/components';
+import { useElevation, Button, Column, Icon, H2, Text, Tooltip } from '@trezor/components';
 import { Elevation, mapElevationToBorder, spacingsPx, typography } from '@trezor/theme';
 import { TREZOR_RESELLERS_URL, TREZOR_URL } from '@trezor/urls';
 
@@ -19,7 +19,6 @@ import { SecurityCheckFail } from 'src/components/suite/SecurityCheck/SecurityCh
 import { selectIsOnboardingActive } from 'src/reducers/onboarding/onboardingReducer';
 import { selectSuiteFlags } from 'src/reducers/suite/suiteReducer';
 import { SecurityChecklist } from './SecurityChecklist';
-import { SecurityCheckButton } from './SecurityCheckButton';
 import { DeviceAuthenticity } from './DeviceAuthenticity';
 
 const StyledCard = styled(CollapsibleOnboardingCard)`
@@ -69,18 +68,8 @@ const Buttons = styled.div<{ $elevation: Elevation }>`
     display: flex;
     flex-wrap: wrap;
     gap: ${spacingsPx.xl};
-    justify-content: space-between;
     padding-top: ${spacingsPx.xl};
     border-top: 2px solid ${mapElevationToBorder};
-    width: 100%;
-`;
-
-const StyledSecurityCheckButton = styled(SecurityCheckButton)`
-    flex-grow: 1;
-`;
-
-const SecurityCheckButtonWithSecondLine = styled(StyledSecurityCheckButton)`
-    flex-direction: column;
 `;
 
 const StyledTrezorLink = styled(TrezorLink)`
@@ -231,27 +220,29 @@ const SecurityCheckContent = ({
                 <SecurityChecklist items={checklistItems} />
             </Column>
             <Buttons $elevation={elevation}>
-                <StyledSecurityCheckButton variant="tertiary" onClick={toggleView}>
+                <Button variant="tertiary" onClick={toggleView}>
                     <Translation id={secondaryButtonText} />
-                </StyledSecurityCheckButton>
+                </Button>
                 {initialized ? (
-                    <StyledSecurityCheckButton
+                    <Button
                         data-testid="@onboarding/exit-app-button"
                         onClick={handleContinueButtonClick}
                     >
                         <Translation id="TR_YES_CONTINUE" />
-                    </StyledSecurityCheckButton>
+                    </Button>
                 ) : (
-                    <SecurityCheckButtonWithSecondLine
+                    <Button
                         onClick={handleSetupButtonClick}
                         data-testid="@analytics/continue-button"
                     >
-                        <Translation id={primaryButtonTopText} />
-                        <TimeEstimateWrapper>
-                            <Icon size={12} name="clock" color={theme.iconOnPrimary} />
-                            <Translation id="TR_TAKES_N_MINUTES" />
-                        </TimeEstimateWrapper>
-                    </SecurityCheckButtonWithSecondLine>
+                        <Column>
+                            <Translation id={primaryButtonTopText} />
+                            <TimeEstimateWrapper>
+                                <Icon size={12} name="clock" color={theme.iconOnPrimary} />
+                                <Translation id="TR_TAKES_N_MINUTES" />
+                            </TimeEstimateWrapper>
+                        </Column>
+                    </Button>
                 )}
             </Buttons>
         </SecurityCheckLayout>

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheck.tsx
@@ -4,8 +4,8 @@ import styled, { useTheme } from 'styled-components';
 import { getConnectedDeviceStatus } from '@suite-common/suite-utils';
 import { AcquiredDevice } from '@suite-common/suite-types';
 import { deviceActions, selectDevice, selectDevices } from '@suite-common/wallet-core';
-import { useElevation, Button, Column, Icon, H2, Text, Tooltip } from '@trezor/components';
-import { Elevation, mapElevationToBorder, spacingsPx, typography } from '@trezor/theme';
+import { Button, Column, Icon, H2, Text, Tooltip, Divider } from '@trezor/components';
+import { spacings, spacingsPx, typography } from '@trezor/theme';
 import { TREZOR_RESELLERS_URL, TREZOR_URL } from '@trezor/urls';
 
 import { goto } from 'src/actions/suite/routerActions';
@@ -26,10 +26,8 @@ const StyledCard = styled(CollapsibleOnboardingCard)`
     padding: ${spacingsPx.md};
 `;
 
-const DeviceNameSection = styled.div<{ $elevation: Elevation }>`
-    border-bottom: 1px solid ${mapElevationToBorder};
+const DeviceNameSection = styled.div`
     margin: ${spacingsPx.xs} 0 ${spacingsPx.xl};
-    padding-bottom: ${spacingsPx.xl};
     width: 100%;
 `;
 
@@ -54,6 +52,10 @@ const Underline = styled.span`
     }
 `;
 
+const Flex = styled.div`
+    flex: 1;
+`;
+
 const TimeEstimateWrapper = styled.div`
     ${typography.label}
     display: flex;
@@ -64,12 +66,10 @@ const TimeEstimateWrapper = styled.div`
     margin-top: 1px;
 `;
 
-const Buttons = styled.div<{ $elevation: Elevation }>`
+const Buttons = styled.div`
     display: flex;
     flex-wrap: wrap;
     gap: ${spacingsPx.xl};
-    padding-top: ${spacingsPx.xl};
-    border-top: 2px solid ${mapElevationToBorder};
 `;
 
 const StyledTrezorLink = styled(TrezorLink)`
@@ -159,8 +159,6 @@ const SecurityCheckContent = ({
     const theme = useTheme();
     const dispatch = useDispatch();
 
-    const { elevation } = useElevation();
-
     const deviceStatus = getConnectedDeviceStatus(device);
     const initialized = deviceStatus === 'initialized';
     const isRecoveryInProgress = recovery.status === 'in-progress';
@@ -205,7 +203,7 @@ const SecurityCheckContent = ({
     ) : (
         <SecurityCheckLayout>
             <Column alignItems="flex-start">
-                <DeviceNameSection $elevation={elevation}>
+                <DeviceNameSection>
                     <Text variant="tertiary">
                         <Translation id="TR_YOU_HAVE_CONNECTED" />
                     </Text>
@@ -214,36 +212,43 @@ const SecurityCheckContent = ({
                         <Translation id="TR_CONNECTED_DIFFERENT_DEVICE" />
                     </OnboardingButtonSkip>
                 </DeviceNameSection>
-                <H2>
+                <Divider margin={{ top: spacings.zero, bottom: spacings.xl }} />
+                <H2 margin={{ top: spacings.md }}>
                     <Translation id={headingText} />
                 </H2>
                 <SecurityChecklist items={checklistItems} />
             </Column>
-            <Buttons $elevation={elevation}>
-                <Button variant="tertiary" onClick={toggleView}>
+            <Buttons>
+                <Button variant="tertiary" onClick={toggleView} size="large">
                     <Translation id={secondaryButtonText} />
                 </Button>
-                {initialized ? (
-                    <Button
-                        data-testid="@onboarding/exit-app-button"
-                        onClick={handleContinueButtonClick}
-                    >
-                        <Translation id="TR_YES_CONTINUE" />
-                    </Button>
-                ) : (
-                    <Button
-                        onClick={handleSetupButtonClick}
-                        data-testid="@analytics/continue-button"
-                    >
-                        <Column>
-                            <Translation id={primaryButtonTopText} />
-                            <TimeEstimateWrapper>
-                                <Icon size={12} name="clock" color={theme.iconOnPrimary} />
-                                <Translation id="TR_TAKES_N_MINUTES" />
-                            </TimeEstimateWrapper>
-                        </Column>
-                    </Button>
-                )}
+                <Flex>
+                    {initialized ? (
+                        <Button
+                            data-testid="@onboarding/exit-app-button"
+                            onClick={handleContinueButtonClick}
+                            isFullWidth
+                            size="large"
+                        >
+                            <Translation id="TR_YES_CONTINUE" />
+                        </Button>
+                    ) : (
+                        <Button
+                            onClick={handleSetupButtonClick}
+                            data-testid="@analytics/continue-button"
+                            isFullWidth
+                            size="large"
+                        >
+                            <Column>
+                                <Translation id={primaryButtonTopText} />
+                                <TimeEstimateWrapper>
+                                    <Icon size={12} name="clock" color={theme.iconOnPrimary} />
+                                    <Translation id="TR_TAKES_N_MINUTES" />
+                                </TimeEstimateWrapper>
+                            </Column>
+                        </Button>
+                    )}
+                </Flex>
             </Buttons>
         </SecurityCheckLayout>
     );

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheckButton.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheckButton.tsx
@@ -1,3 +1,0 @@
-import { Button, ButtonProps } from '@trezor/components';
-
-export const SecurityCheckButton = (props: ButtonProps) => <Button {...props} />;

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityChecklist.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityChecklist.tsx
@@ -20,7 +20,7 @@ export const SecurityChecklist = ({ items }: SecurityChecklistProps) => {
         <Column
             alignItems="flex-start"
             gap={spacings.xl}
-            margin={{ top: spacings.xl, bottom: spacings.xl }}
+            margin={{ top: spacings.xl, bottom: spacings.xxxxl }}
         >
             {items.map(item => (
                 <Row key={item.icon} gap={spacings.xl}>

--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -93,7 +93,7 @@ export const HELP_CENTER_EVM_ADDRESS_CHECKSUM =
 export const HELP_CENTER_FIRMWARE_REVISION_CHECK =
     'https://trezor.io/learn/a/trezor-firmware-revision-check';
 export const TREZOR_SUPPORT_FW_CHECK_FAILED =
-    'trezor.io/support/a/trezor-firmware-revision-check-failed';
+    'https://trezor.io/support/a/trezor-firmware-revision-check-failed';
 
 export const INVITY_URL = 'https://invity.io/';
 export const INVITY_SCHEDULE_OF_FEES = 'https://blog.invity.io/schedule-of-fees';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
The `SecurityCheckButton` had a set `height` so that it does not change height when switching between `SecurityCheck` and `SecurityCheckFail` (when you click the secondary button). This broke during Suite redesign when `Button` changed its default height.

I think we actually don't need it to keep a constant height between the views so I deleted it to keep things simple.

I also changed the button layout to resemble that of Suite modals. However, it doesn't look great, does it? Maybe we should consider adding `flex` or `flexGrow` etc. to `frameProps`, @jvaclavik?

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
Before:
![Screenshot 2024-09-05 at 16 45 27](https://github.com/user-attachments/assets/50ddb1b9-df5c-4629-b82c-37a3c53028b5)
After:
![Screenshot 2024-09-05 at 16 46 19](https://github.com/user-attachments/assets/a41db788-7214-4b11-92cc-1f62acf7a003)
