### PR TITLE
fix(suite-native): add missing bottom margin to discovery assets loader

### DIFF
--- a/suite-native/assets/src/components/DiscoveryAssetsLoader.tsx
+++ b/suite-native/assets/src/components/DiscoveryAssetsLoader.tsx
@@ -32,7 +32,7 @@ export const DiscoveryAssetsLoader = ({ numberOfAssets }: { numberOfAssets: numb
                 <ListItemSkeleton key={i} />
             ))}
 
-            <HStack justifyContent="center">
+            <HStack justifyContent="center" marginBottom="medium">
                 <Icon size="mediumLarge" name="trezor" />
                 <Text variant="callout">{discoveryProgressText}</Text>
             </HStack>


### PR DESCRIPTION
## Related Issue

Partially resolves #14090

## Screenshots:
![image](https://github.com/user-attachments/assets/22762110-01b8-4b5f-873f-884c6ac9ce96)
