### PR TITLE
Enable displaying receive addresses when revision check is failed but disabled

### DIFF
--- a/packages/suite/src/components/suite/Preloader/Preloader.tsx
+++ b/packages/suite/src/components/suite/Preloader/Preloader.tsx
@@ -13,20 +13,16 @@ import {
     selectPrerequisite,
     selectIsLoggedOut,
     selectSuiteFlags,
+    selectIsFirmwareRevisionCheckEnabledAndFailed,
 } from 'src/reducers/suite/suiteReducer';
 import { SuiteStart } from 'src/views/start/SuiteStart';
 import { PrerequisitesGuide } from '../PrerequisitesGuide/PrerequisitesGuide';
 import { LoggedOutLayout } from '../layouts/LoggedOutLayout';
 import { WelcomeLayout } from '../layouts/WelcomeLayout/WelcomeLayout';
 import { ViewOnlyPromo } from 'src/views/view-only/ViewOnlyPromo';
-import {
-    selectDevice,
-    selectFailedSecurityChecks,
-    selectIsFirmwareRevisionCheckDismissed,
-} from '@suite-common/wallet-core';
+import { selectDevice, selectIsFirmwareRevisionCheckDismissed } from '@suite-common/wallet-core';
 import { DeviceCompromised } from '../SecurityCheck/DeviceCompromised';
 import { RouterAppWithParams } from '../../../constants/suite/routes';
-import { Feature, selectIsFeatureDisabled } from '@suite-common/message-system';
 
 const ROUTES_TO_SKIP_REVISION_CHECK: RouterAppWithParams['app'][] = [
     'settings',
@@ -60,11 +56,7 @@ export const Preloader = ({ children }: PreloaderProps) => {
     const isLoggedOut = useSelector(selectIsLoggedOut);
     const selectedDevice = useSelector(selectDevice);
     const { initialRun, viewOnlyPromoClosed } = useSelector(selectSuiteFlags);
-    const hasFailedSecurityChecks = useSelector(selectFailedSecurityChecks).length > 0;
-    const { isFirmwareRevisionCheckDisabled } = useSelector(state => state.suite.settings);
-    const isFirmwareRevisionCheckDisabledByMessageSystem = useSelector(state =>
-        selectIsFeatureDisabled(state, Feature.firmwareRevisionCheck),
-    );
+    const isRevisionCheckFailed = useSelector(selectIsFirmwareRevisionCheckEnabledAndFailed);
     const isFirmwareRevisionCheckDismissed = useSelector(selectIsFirmwareRevisionCheckDismissed);
 
     const dispatch = useDispatch();
@@ -92,12 +84,8 @@ export const Preloader = ({ children }: PreloaderProps) => {
     if (
         (router.route?.app === undefined ||
             !ROUTES_TO_SKIP_REVISION_CHECK.includes(router.route?.app)) &&
-        selectedDevice?.features &&
-        selectedDevice.connected === true &&
-        !isFirmwareRevisionCheckDisabled &&
-        !isFirmwareRevisionCheckDisabledByMessageSystem &&
         !isFirmwareRevisionCheckDismissed &&
-        hasFailedSecurityChecks
+        isRevisionCheckFailed
     ) {
         return <DeviceCompromised />;
     }

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -1,7 +1,13 @@
 import produce from 'immer';
 
-import { discoveryActions, DeviceRootState, selectDevice } from '@suite-common/wallet-core';
 import type { InvityServerEnvironment } from '@suite-common/invity';
+import {
+    Feature,
+    MessageSystemRootState,
+    selectIsFeatureDisabled,
+} from '@suite-common/message-system';
+import { isDeviceAcquired } from '@suite-common/suite-utils';
+import { discoveryActions, DeviceRootState, selectDevice } from '@suite-common/wallet-core';
 import { versionUtils } from '@trezor/utils';
 import { isWeb } from '@trezor/env-utils';
 import { TRANSPORT, TransportInfo, ConnectSettings } from '@trezor/connect';
@@ -430,5 +436,29 @@ export const selectSuiteSettings = (state: SuiteRootState) => ({
 export const selectHasExperimentalFeature =
     (feature: ExperimentalFeature) => (state: SuiteRootState) =>
         state.suite.settings.experimental?.includes(feature) ?? false;
+
+export const selectIsFirmwareRevisionCheckEnabledAndFailed = (
+    state: SuiteRootState & DeviceRootState & MessageSystemRootState,
+) => {
+    const { isFirmwareRevisionCheckDisabled } = state.suite.settings;
+    const isFirmwareRevisionCheckDisabledByMessageSystem = selectIsFeatureDisabled(
+        state,
+        Feature.firmwareRevisionCheck,
+    );
+
+    if (isFirmwareRevisionCheckDisabled || isFirmwareRevisionCheckDisabledByMessageSystem) {
+        return false;
+    }
+
+    const device = selectDevice(state);
+
+    return (
+        isDeviceAcquired(device) &&
+        // If `check` is null, it means that it was not performed yet.
+        device.authenticityChecks?.firmwareRevision?.success === false &&
+        // If Suite is offline and we cannot perform check, the error banner shows to urge user to go online.
+        device.authenticityChecks.firmwareRevision.error !== 'cannot-perform-check-offline'
+    );
+};
 
 export default suiteReducer;

--- a/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
+++ b/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
@@ -1,21 +1,17 @@
 import { useMemo } from 'react';
-
 import styled from 'styled-components';
+
 import { Translation, QuestionTooltip, ReadMoreLink } from 'src/components/suite';
 import { AppState } from 'src/types/suite';
 import { showAddress } from 'src/actions/wallet/receiveActions';
 import { useDispatch, useSelector } from 'src/hooks/suite/';
-
 import { Button, Card, variables, H2, Tooltip, GradientOverlay } from '@trezor/components';
 import { getFirstFreshAddress } from '@suite-common/wallet-utils';
-import {
-    AccountsRootState,
-    selectFailedSecurityChecks,
-    selectIsAccountUtxoBased,
-} from '@suite-common/wallet-core';
+import { AccountsRootState, selectIsAccountUtxoBased } from '@suite-common/wallet-core';
 import { networks } from '@suite-common/wallet-config';
 import { EvmExplanationBox } from 'src/components/wallet/EvmExplanationBox';
 import { spacingsPx, typography } from '@trezor/theme';
+import { selectIsFirmwareRevisionCheckEnabledAndFailed } from 'src/reducers/suite/suiteReducer';
 
 // eslint-disable-next-line local-rules/no-override-ds-component
 const StyledCard = styled(Card)`
@@ -130,7 +126,7 @@ export const FreshAddress = ({
     const isAccountUtxoBased = useSelector((state: AccountsRootState) =>
         selectIsAccountUtxoBased(state, account?.key ?? ''),
     );
-    const hasFailedSecurityChecks = useSelector(selectFailedSecurityChecks).length > 0;
+    const isRevisionCheckFailed = useSelector(selectIsFirmwareRevisionCheckEnabledAndFailed);
     const dispatch = useDispatch();
 
     const firstFreshAddress = useMemo(() => {
@@ -162,7 +158,7 @@ export const FreshAddress = ({
         if (!firstFreshAddress) {
             return <Translation id="RECEIVE_ADDRESS_LIMIT_REACHED" />;
         }
-        if (hasFailedSecurityChecks) {
+        if (isRevisionCheckFailed) {
             return <Translation id="TR_RECEIVE_ADDRESS_SECURITY_CHECK_FAILED" />;
         }
 
@@ -177,7 +173,7 @@ export const FreshAddress = ({
             locked ||
             coinjoinDisallowReveal ||
             !firstFreshAddress ||
-            hasFailedSecurityChecks,
+            isRevisionCheckFailed,
         isLoading: locked,
     };
 

--- a/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
+++ b/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
@@ -5,7 +5,6 @@ import { AccountAddress } from '@trezor/connect';
 import { Card, Button, Column, GradientOverlay, Tooltip } from '@trezor/components';
 import { spacings, spacingsPx, typography } from '@trezor/theme';
 import { NetworkSymbol } from '@suite-common/wallet-config';
-import { selectFailedSecurityChecks } from '@suite-common/wallet-core';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
 
 import { Translation, MetadataLabeling, FormattedCryptoAmount } from 'src/components/suite';
@@ -14,6 +13,7 @@ import { MetadataAddPayload } from 'src/types/suite/metadata';
 import { showAddress } from 'src/actions/wallet/receiveActions';
 import { useDispatch, useSelector } from 'src/hooks/suite/';
 import { selectLabelingDataForSelectedAccount } from 'src/reducers/suite/metadataReducer';
+import { selectIsFirmwareRevisionCheckEnabledAndFailed } from 'src/reducers/suite/suiteReducer';
 
 const GridTable = styled.div`
     display: grid;
@@ -104,14 +104,14 @@ interface ItemProps {
 }
 
 const Item = ({ addr, locked, symbol, onClick, metadataPayload, index }: ItemProps) => {
-    const hasFailedSecurityChecks = useSelector(selectFailedSecurityChecks).length > 0;
+    const isRevisionCheckFailed = useSelector(selectIsFirmwareRevisionCheckEnabledAndFailed);
     const [isHovered, setIsHovered] = useState(false);
 
     const amount = formatNetworkAmount(addr.received || '0', symbol);
     const fresh = !addr.transfers;
     const address = addr.address.substring(0, 20);
-    const isDisabled = locked || hasFailedSecurityChecks;
-    const tooltipContent = hasFailedSecurityChecks ? (
+    const isDisabled = locked || isRevisionCheckFailed;
+    const tooltipContent = isRevisionCheckFailed ? (
         <Translation id="TR_RECEIVE_ADDRESS_SECURITY_CHECK_FAILED" />
     ) : null;
 

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -3,7 +3,7 @@ import { isAnyOf } from '@reduxjs/toolkit';
 
 import * as deviceUtils from '@suite-common/suite-utils';
 import { getDeviceInstances, getStatus } from '@suite-common/suite-utils';
-import { Device, Features, FirmwareRevisionCheckResult, UI } from '@trezor/connect';
+import { Device, Features, UI } from '@trezor/connect';
 import {
     getFirmwareVersion,
     getFirmwareVersionArray,
@@ -781,19 +781,6 @@ export const selectSelectedDeviceAuthenticity = (state: DeviceRootState) => {
     const deviceAuthenticity = selectDeviceAuthenticity(state);
 
     return device?.id ? deviceAuthenticity?.[device.id] : undefined;
-};
-
-export const selectFailedSecurityChecks = (state: DeviceRootState) => {
-    const device = selectDevice(state);
-
-    return device && 'authenticityChecks' in device && device.authenticityChecks !== undefined
-        ? Object.values(device.authenticityChecks).filter(
-              // If `check` is null, it means that it was not performed yet.
-              // If Suite is offline and we cannot perform check, the error banner shows to urge user to go online.
-              (check): check is FirmwareRevisionCheckResult =>
-                  check?.success === false && check?.error !== 'cannot-perform-check-offline',
-          )
-        : [];
 };
 
 export const selectIsFirmwareRevisionCheckDismissed = (state: DeviceRootState): boolean => {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
The button to display address is disabled when firmware revision check has failed. However, the original implementation didn't take into account the option to disabled the check. Now, if the check is disabled (but it still fails under the hood), you should be able to generate a new address and display used addresses.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/14084 (see https://github.com/trezor/trezor-suite/issues/14084#issuecomment-2328000550)

