### PR TITLE
test(suite): Add data-testid on AccountItem staking+tokens

### DIFF
--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemsGroup.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemsGroup.tsx
@@ -88,6 +88,7 @@ export const AccountItemsGroup = ({
                         formattedBalance={stakingBalance}
                         isGroup
                         isGroupSelected={selected}
+                        dataTestKey={`${dataTestKey}/staking`}
                     />
                 </Wrapper>
             )}
@@ -103,6 +104,7 @@ export const AccountItemsGroup = ({
                         isGroupSelected={selected}
                         customFiatValue={tokensFiatBalance}
                         tokens={tokens}
+                        dataTestKey={`${dataTestKey}/tokens`}
                     />
                 </Wrapper>
             )}


### PR DESCRIPTION
## Description

Add `data-testid` on tokens and staking in account side menu, where it was previously missing.

Previously, only the main account had
`data-testid = @account-menu/eth/normal/0`
Now staking and tokens have:
`data-testid = @account-menu/eth/normal/0/staking`
`data-testid = @account-menu/eth/normal/0/tokens`

## Related Issue

Requested by QA team

## Screenshots

![image](https://github.com/user-attachments/assets/49b478e6-8fce-4434-8272-d7b5c48167dc)
