### PR TITLE
connect - deviceCommands - tiny types changes

### DIFF
--- a/packages/connect/src/api/eos/eosSignTx.ts
+++ b/packages/connect/src/api/eos/eosSignTx.ts
@@ -6,7 +6,7 @@ import type {
     EosTxAction as $EosTxAction,
     EosAuthorization as $EosAuthorization,
 } from '../../types/api/eos';
-import type { TypedCall, TypedResponseMessage } from '../../device/DeviceCommands';
+import type { TypedCall } from '../../device/DeviceCommands';
 
 type Action = $EosTxAction; // | $EosActionCommon & { name: string; data: string };
 
@@ -361,7 +361,8 @@ const processTxRequest = async (
 ): Promise<PROTO.EosSignedTx> => {
     const action = actions[index];
     const lastOp = index + 1 >= actions.length;
-    let ack: TypedResponseMessage<'EosTxActionRequest'>;
+    let ack: { type: 'EosTxActionRequest'; message: PROTO.EosTxActionRequest };
+
     const requestedDataSize = message.data_size;
 
     if (action.unknown) {

--- a/packages/connect/src/device/DeviceCommands.ts
+++ b/packages/connect/src/device/DeviceCommands.ts
@@ -20,7 +20,7 @@ import { resolveDescriptorForTaproot } from './resolveDescriptorForTaproot';
 
 type MessageType = Messages.MessageType;
 type MessageKey = keyof MessageType;
-export type TypedPayload<T extends MessageKey> = {
+type TypedPayload<T extends MessageKey> = {
     type: T;
     message: MessageType[T];
 };


### PR DESCRIPTION
Yesterday I was discussing with @marekrjpolak that we could get rid of try catch in [DeviceList.handle](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/device/DeviceList.ts#L526) and start consuming strongly typed errors there. To achieve this, it would probably be helpful to start digging the tunnel also from the opposite direction by solving this https://github.com/trezor/trezor-suite/issues/5301 

9308cb08ecd99fa1a9ba8bbde0b2f38aff81f637 - just renaming locally defined types in DeviceCommands. I didn't like (and found confusing) using word "response" in type which can be in fact both response and params. 
ab44945b0577e9eab5a14e770152a413174abeee - making these types strictly local. first step for transferring them somewhere else

then I realized that it is quite a big traktor to achieve. For example it would require changing DeviceCommands.typedCall in the way that it doesn't throw, and this would require changes almost everywhere. so I stopped here 😄. However, doing #5301 itself should still be achievable.