### PR TITLE
docs(connect-explorer): add more ways to test getAccountInfo

### DIFF
--- a/packages/connect-explorer/src/pages/methods/bitcoin/getAccountInfo.mdx
+++ b/packages/connect-explorer/src/pages/methods/bitcoin/getAccountInfo.mdx
@@ -10,8 +10,22 @@ import { ParamsTable } from '../../../components/ParamsTable';
         {
             title: 'GetAccountInfo',
             legacyConfig: getAccountInfo[0],
+        },
+        {
             title: 'GetAccountInfo (xpub)',
             legacyConfig: getAccountInfo[1],
+        },
+        {
+            title: 'GetAccountInfo (bundle)',
+            legacyConfig: getAccountInfo[2],
+        },
+        {
+            title: 'GetAccountInfo (discovery)',
+            legacyConfig: getAccountInfo[3],
+        },
+        {
+            title: 'GetAccountInfo (advanced)',
+            legacyConfig: getAccountInfo[4],
         },
     ]}
 />


### PR DESCRIPTION
## Description

The method tester in getAccountInfo was not set up correctly, this PR adds all the ways to call the method. 