### PR TITLE
chore(suite): use new Networks in coinmarket

### DIFF
--- a/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketComposeTransaction.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketComposeTransaction.ts
@@ -1,7 +1,8 @@
+import { NetworkCompatible } from '@suite-common/wallet-config';
 import { COMPOSE_ERROR_TYPES } from '@suite-common/wallet-constants';
 import { selectAccounts, selectDevice } from '@suite-common/wallet-core';
 import { AddressDisplayOptions } from '@suite-common/wallet-types';
-import { getFeeLevels } from '@suite-common/wallet-utils';
+import { getFeeLevels, getNetwork } from '@suite-common/wallet-utils';
 import { useEffect, useMemo, useState } from 'react';
 import { UseFormReturn } from 'react-hook-form';
 import { saveComposedTransactionInfo } from 'src/actions/wallet/coinmarket/coinmarketCommonActions';
@@ -42,7 +43,13 @@ export const useCoinmarketComposeTransaction = <T extends CoinmarketSellExchange
     const coinFees = fees[symbol];
     const levels = getFeeLevels(networkType, coinFees);
     const feeInfo = useMemo(() => ({ ...coinFees, levels }), [coinFees, levels]);
-    const initState = useMemo(() => ({ account, network, feeInfo }), [account, network, feeInfo]);
+    const initState = useMemo(() => {
+        // TODO remove NetworkCompatible type
+        // getNetwork is guaranteed to find a NetworkCompatible, as it is called with symbol from an existing Network
+        const networkCompatible = getNetwork(network.symbol) as NetworkCompatible;
+
+        return { account, network: networkCompatible, feeInfo };
+    }, [account, network.symbol, feeInfo]);
     const outputAddress = values?.outputs?.[0].address;
     const [state, setState] = useState<CoinmarketUseComposeTransactionStateProps>(initState);
 

--- a/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketCurrencySwitcher.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketCurrencySwitcher.ts
@@ -1,4 +1,4 @@
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { Network } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
 import { amountToSatoshi, formatAmount } from '@suite-common/wallet-utils';
 import { useDidUpdate } from '@trezor/react-utils';
@@ -25,7 +25,7 @@ interface CoinmarketUseCurrencySwitcherProps<T extends CoinmarketAllFormProps> {
     methods: UseFormReturn<T>;
     quoteCryptoAmount: string | undefined;
     quoteFiatAmount: string | undefined;
-    network: NetworkCompatible | null;
+    network: Network | null;
     inputNames: {
         cryptoInput: typeof FORM_CRYPTO_INPUT | typeof FORM_OUTPUT_AMOUNT;
         fiatInput: typeof FORM_FIAT_INPUT | typeof FORM_OUTPUT_FIAT;

--- a/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketFiatValues.tsx
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketFiatValues.tsx
@@ -1,12 +1,7 @@
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import { networks, NetworkSymbol } from '@suite-common/wallet-config';
 import { selectFiatRatesByFiatRateKey, updateFiatRatesThunk } from '@suite-common/wallet-core';
 import { FiatRatesResult, Rate, Timestamp, TokenAddress } from '@suite-common/wallet-types';
-import {
-    amountToSatoshi,
-    getFiatRateKey,
-    getNetwork,
-    toFiatCurrency,
-} from '@suite-common/wallet-utils';
+import { amountToSatoshi, getFiatRateKey, toFiatCurrency } from '@suite-common/wallet-utils';
 import { CryptoId, FiatCurrencyCode } from 'invity-api';
 import { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -57,7 +52,7 @@ export const useCoinmarketFiatValues = ({
     );
     const fiatRate = useSelector(state => selectFiatRatesByFiatRateKey(state, fiatRateKey));
 
-    const network = getNetwork(networkSymbol);
+    const network = networks[networkSymbol];
     const { shouldSendInSats } = useBitcoinAmountUnit(networkSymbol);
 
     const fiatRatesUpdater = useCallback(
@@ -89,7 +84,7 @@ export const useCoinmarketFiatValues = ({
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    if (!network || !accountBalance || !fiatCurrency) return null;
+    if (!accountBalance || !fiatCurrency) return null;
 
     const decimals = getNetworkDecimals(network?.decimals);
     const formattedBalance = shouldSendInSats

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketBuyForm.tsx
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketBuyForm.tsx
@@ -3,7 +3,7 @@ import { useForm, useWatch } from 'react-hook-form';
 import useDebounce from 'react-use/lib/useDebounce';
 import type { BuyTrade, BuyTradeQuoteRequest, CryptoId } from 'invity-api';
 import { isChanged } from '@suite-common/suite-utils';
-import { formatAmount, getNetwork } from '@suite-common/wallet-utils';
+import { formatAmount } from '@suite-common/wallet-utils';
 import { useActions, useDispatch, useSelector } from 'src/hooks/suite';
 import invityAPI from 'src/services/suite/invityAPI';
 import {
@@ -47,6 +47,7 @@ import { useCoinmarketLoadData } from 'src/hooks/wallet/coinmarket/useCoinmarket
 import { useCoinmarketCurrencySwitcher } from 'src/hooks/wallet/coinmarket/form/common/useCoinmarketCurrencySwitcher';
 import { useCoinmarketModalCrypto } from 'src/hooks/wallet/coinmarket/form/common/useCoinmarketModalCrypto';
 import { useCoinmarketInfo } from 'src/hooks/wallet/coinmarket/useCoinmarketInfo';
+import { networks } from '@suite-common/wallet-config';
 
 const useCoinmarketBuyForm = ({
     selectedAccount,
@@ -153,7 +154,7 @@ const useCoinmarketBuyForm = ({
     const network =
         cryptoIdToNetwork(
             (values.cryptoSelect?.value as CryptoId) ?? FORM_DEFAULT_CRYPTO_CURRENCY,
-        ) ?? getNetwork('btc')!;
+        ) ?? networks.btc;
 
     const { toggleAmountInCrypto } = useCoinmarketCurrencySwitcher({
         account,

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeForm.ts
@@ -7,12 +7,7 @@ import type {
     FiatCurrencyCode,
 } from 'invity-api';
 import useDebounce from 'react-use/lib/useDebounce';
-import {
-    amountToSatoshi,
-    formatAmount,
-    getNetwork,
-    toFiatCurrency,
-} from '@suite-common/wallet-utils';
+import { amountToSatoshi, formatAmount, toFiatCurrency } from '@suite-common/wallet-utils';
 import { isChanged } from '@suite-common/suite-utils';
 import { useActions, useDispatch, useSelector } from 'src/hooks/suite';
 import invityAPI from 'src/services/suite/invityAPI';
@@ -62,7 +57,7 @@ import { useCoinmarketCurrencySwitcher } from 'src/hooks/wallet/coinmarket/form/
 import { useCoinmarketFiatValues } from './common/useCoinmarketFiatValues';
 import { CoinmarketExchangeStepType } from 'src/types/coinmarket/coinmarketOffers';
 import { useCoinmarketModalCrypto } from 'src/hooks/wallet/coinmarket/form/common/useCoinmarketModalCrypto';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { networks } from '@suite-common/wallet-config';
 import { useCoinmarketAccount } from 'src/hooks/wallet/coinmarket/form/common/useCoinmarketAccount';
 import { useCoinmarketInfo } from 'src/hooks/wallet/coinmarket/useCoinmarketInfo';
 
@@ -135,7 +130,7 @@ export const useCoinmarketExchangeForm = ({
 
     const { symbol } = account;
     const { shouldSendInSats } = useBitcoinAmountUnit(symbol);
-    const network = getNetwork(account.symbol) as NetworkCompatible;
+    const network = networks[account.symbol];
 
     const { defaultCurrency, defaultValues } = useCoinmarketExchangeFormDefaultValues(account);
     const exchangeDraftKey = 'coinmarket-exchange';

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSellForm.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSellForm.ts
@@ -2,7 +2,7 @@ import { useCallback, useState, useEffect, useRef } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 import type { BankAccount, CryptoId, SellFiatTrade, SellFiatTradeQuoteRequest } from 'invity-api';
 import useDebounce from 'react-use/lib/useDebounce';
-import { amountToSatoshi, formatAmount, getNetwork } from '@suite-common/wallet-utils';
+import { amountToSatoshi, formatAmount } from '@suite-common/wallet-utils';
 import { isChanged } from '@suite-common/suite-utils';
 import { useActions, useDispatch, useSelector } from 'src/hooks/suite';
 import invityAPI from 'src/services/suite/invityAPI';
@@ -45,7 +45,7 @@ import { useCoinmarketFormActions } from 'src/hooks/wallet/coinmarket/form/commo
 import { useCoinmarketLoadData } from 'src/hooks/wallet/coinmarket/useCoinmarketLoadData';
 import { useCoinmarketComposeTransaction } from 'src/hooks/wallet/coinmarket/form/common/useCoinmarketComposeTransaction';
 import { useCoinmarketCurrencySwitcher } from 'src/hooks/wallet/coinmarket/form/common/useCoinmarketCurrencySwitcher';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { networks } from '@suite-common/wallet-config';
 import { useCoinmarketAccount } from 'src/hooks/wallet/coinmarket/form/common/useCoinmarketAccount';
 import { useCoinmarketInfo } from 'src/hooks/wallet/coinmarket/useCoinmarketInfo';
 
@@ -112,7 +112,7 @@ export const useCoinmarketSellForm = ({
 
     const { symbol } = account;
     const localCurrency = useSelector(selectLocalCurrency);
-    const network = getNetwork(account.symbol) as NetworkCompatible;
+    const network = networks[account.symbol];
     const { shouldSendInSats } = useBitcoinAmountUnit(symbol);
     const localCurrencyOption = { value: localCurrency, label: localCurrency.toUpperCase() };
     const trades = useSelector(state => state.wallet.coinmarket.trades);

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketVerifyAccount.tsx
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketVerifyAccount.tsx
@@ -1,4 +1,4 @@
-import { isDebugOnlyAccountType, networksCompatibility } from '@suite-common/wallet-config';
+import { isDebugOnlyAccountType, Network, networks } from '@suite-common/wallet-config';
 import { selectDevice } from '@suite-common/wallet-core';
 import { CryptoId } from 'invity-api';
 import { useEffect, useMemo, useState } from 'react';
@@ -73,8 +73,8 @@ const getSuiteReceiveAccounts = ({
         const unavailableCapabilities = device?.unavailableCapabilities ?? {};
 
         // Is the symbol supported by the suite and the device natively?
-        const receiveNetworks = networksCompatibility.filter(
-            n =>
+        const receiveNetworks = Object.values(networks).filter(
+            (n: Network) =>
                 n.symbol === receiveNetwork &&
                 !unavailableCapabilities[n.symbol] &&
                 ((n.isDebugOnlyNetwork && isDebug) || !n.isDebugOnlyNetwork),

--- a/packages/suite/src/types/coinmarket/coinmarketForm.ts
+++ b/packages/suite/src/types/coinmarket/coinmarketForm.ts
@@ -14,7 +14,7 @@ import {
     CoinmarketTradeType,
 } from 'src/types/coinmarket/coinmarket';
 import type { Account } from 'src/types/wallet';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { Network, NetworkCompatible } from '@suite-common/wallet-config';
 import type { BuyInfo } from 'src/actions/wallet/coinmarketBuyActions';
 import type { FieldValues, UseFormReturn, FieldPath } from 'react-hook-form';
 import type {
@@ -128,7 +128,7 @@ export interface CoinmarketCommonFormProps {
     callInProgress: boolean;
     timer: Timer;
     account: Account;
-    network: NetworkCompatible;
+    network: Network;
 
     goToOffers: () => Promise<void>;
 }
@@ -333,7 +333,7 @@ export interface CoinmarketUseFormActionsReturnProps {
 
 export interface CoinmarketUseComposeTransactionProps<T extends CoinmarketSellExchangeFormProps> {
     account: Account;
-    network: NetworkCompatible;
+    network: Network;
     methods: UseFormReturn<T>;
     values: T;
 }

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketAddressOptions.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketAddressOptions.tsx
@@ -13,8 +13,9 @@ import { useSelector } from 'src/hooks/suite';
 import { CoinmarketBuyAddressOptionsType } from 'src/types/coinmarket/coinmarketOffers';
 import { CoinmarketBalance } from 'src/views/wallet/coinmarket/common/CoinmarketBalance';
 import { spacingsPx, typography } from '@trezor/theme';
-import { formatAmount, getNetwork } from '@suite-common/wallet-utils';
+import { formatAmount } from '@suite-common/wallet-utils';
 import { getNetworkDecimals } from 'src/utils/wallet/coinmarket/coinmarketUtils';
+import { networks } from '@suite-common/wallet-config';
 
 const AddressWrapper = styled.div`
     display: flex;
@@ -108,7 +109,7 @@ export const CoinmarketAddressOptions = <TFieldValues extends CoinmarketBuyAddre
                         if (!accountAddress || !account || !receiveSymbol) return null;
 
                         const networkDecimals = getNetworkDecimals(
-                            getNetwork(account.symbol)?.decimals,
+                            networks[account.symbol].decimals,
                         );
                         const balance = accountAddress.balance
                             ? formatAmount(accountAddress.balance, networkDecimals)

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketBalance.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketBalance.tsx
@@ -1,6 +1,6 @@
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import { networks, NetworkSymbol } from '@suite-common/wallet-config';
 import { TokenAddress } from '@suite-common/wallet-types';
-import { amountToSatoshi, getNetwork } from '@suite-common/wallet-utils';
+import { amountToSatoshi } from '@suite-common/wallet-utils';
 import { typography } from '@trezor/theme';
 import { FiatValue, HiddenPlaceholder, Translation } from 'src/components/suite';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
@@ -34,7 +34,7 @@ export const CoinmarketBalance = ({
 }: CoinmarketBalanceProps) => {
     const { shouldSendInSats } = useBitcoinAmountUnit(networkSymbol);
     const balanceCurrency = coinmarketGetAccountLabel(cryptoSymbolLabel ?? '', shouldSendInSats);
-    const networkDecimals = getNetworkDecimals(getNetwork(networkSymbol)?.decimals);
+    const networkDecimals = getNetworkDecimals(networks[networkSymbol].decimals);
     const stringBalance = !isNaN(Number(balance)) ? balance : '0';
     const formattedBalance =
         stringBalance && shouldSendInSats


### PR DESCRIPTION
## Description

Refactoring deprecated `networksCompatibility` to `networks`  in Coin Market.

`getComposeAddressPlaceholder` might require testing, but I'd say that if TS checks out, this will work as before.

## Related Issue

Part of #13839