### PR TITLE
ci(docker): get rid of trezor-suite gitlab image

### DIFF
--- a/docker/docker-compose.connect-test.yml
+++ b/docker/docker-compose.connect-test.yml
@@ -5,24 +5,4 @@ services:
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp
-    network_mode: bridge
-  # todo: this is probably not necessary to run these tests in its dedicated container
-  test-run:
-    image: registry.gitlab.com/satoshilabs/trezor/trezor-suite/base:latest
-    environment:
-      - TESTS_FIRMWARE=$TESTS_FIRMWARE
-      - TESTS_FIRMWARE_MODEL=$TESTS_FIRMWARE_MODEL
-      - TESTS_FIRMWARE_URL=$TESTS_FIRMWARE_URL
-      - TESTS_INCLUDED_METHODS=$TESTS_INCLUDED_METHODS
-      - TESTS_EXCLUDED_METHODS=$TESTS_EXCLUDED_METHODS
-      - TESTS_PATTERN=$TESTS_PATTERN
-      - TESTS_USE_TX_CACHE=$TESTS_USE_TX_CACHE
-      - TESTS_USE_WS_CACHE=$TESTS_USE_WS_CACHE
-      - TESTS_RANDOM=$TESTS_RANDOM
-    depends_on:
-      - trezor-user-env-unix
-    network_mode: service:trezor-user-env-unix
-    working_dir: /trezor-suite
-    command: bash -c "$TESTS_SCRIPT $TESTS_PATTERN"
-    volumes:
-      - ../:/trezor-suite
+    network_mode: host

--- a/docker/docker-connect-test.sh
+++ b/docker/docker-connect-test.sh
@@ -48,8 +48,6 @@ FIRMWARE_URL=""
 INCLUDED_METHODS=""
 EXCLUDED_METHODS=""
 DOCKER=true
-# TODO: DOCKER_PATH appears unused. Remove or export?
-DOCKER_PATH="docker"
 USE_TX_CACHE=true
 USE_WS_CACHE=true
 PATTERN=""
@@ -58,13 +56,10 @@ RANDOMIZE=false
 
 # user options
 OPTIND=2
-while getopts ":p:i:e:f:u:m:D:hdcr" opt; do
+while getopts ":p:i:e:f:u:m:hdcr" opt; do
   case $opt in
   d)
     DOCKER=false
-    ;;
-  D)
-    DOCKER_PATH="$OPTARG"
     ;;
   c)
     USE_TX_CACHE=false
@@ -103,8 +98,6 @@ while getopts ":p:i:e:f:u:m:D:hdcr" opt; do
 done
 shift $((OPTIND - 1))
 
-export DOCKER_PATH
-
 if [[ $ENVIRONMENT == "node" ]]; then
   SCRIPT="yarn workspace @trezor/connect test:e2e:node"
 else
@@ -124,7 +117,7 @@ export TESTS_FIRMWARE_MODEL=$FIRMWARE_MODEL
 export TESTS_RANDOM=$RANDOMIZE
 
 runDocker() {
-  docker compose -f ./docker/docker-compose.connect-test.yml up --abort-on-container-exit
+  docker compose -f ./docker/docker-compose.connect-test.yml up -d
 }
 
 run() {
@@ -142,10 +135,10 @@ run() {
 
   if [ $DOCKER = true ]; then
     runDocker
-  else
-    $SCRIPT
+
   fi
 
+  $SCRIPT
 }
 
 run


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When running CI in GitLab we were using docker image "registry.gitlab.com/satoshilabs/trezor/trezor-suite/base:latest" but now it is not needed anymore. 
So with this PR I am getting rid of that image and simplifying a bit the process.


