### PR TITLE
fix: sessions backround sharedworker truly shared

### DIFF
--- a/packages/connect-iframe/webpack/base.webpack.config.ts
+++ b/packages/connect-iframe/webpack/base.webpack.config.ts
@@ -23,14 +23,6 @@ export const config: webpack.Configuration = {
     module: {
         rules: [
             {
-                test: (input: string) => input.includes('background-sharedworker'),
-                loader: 'worker-loader',
-                options: {
-                    worker: 'SharedWorker',
-                    filename: './workers/sessions-background-sharedworker.[contenthash].js',
-                },
-            },
-            {
                 test: /sharedLoggerWorker.ts/i,
                 use: [
                     {

--- a/packages/connect-iframe/webpack/prod.webpack.config.ts
+++ b/packages/connect-iframe/webpack/prod.webpack.config.ts
@@ -10,6 +10,13 @@ const config: webpack.Configuration = {
     // common instructions that are able to build correctly imports from @trezor/connect (reusing this in popup)
     entry: {
         iframe: path.resolve(__dirname, '../src/index.ts'),
+        ['sessions-background-sharedworker']: {
+            filename: 'workers/[name].js',
+            import: path.resolve(
+                __dirname,
+                '../../transport/src/sessions/background-sharedworker.ts',
+            ),
+        },
     },
     output: {
         filename: 'js/[name].[contenthash].js',

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -1192,7 +1192,7 @@ export class Core extends EventEmitter {
 
         try {
             await DataManager.load(settings);
-            const { debug, priority } = DataManager.getSettings();
+            const { debug, priority, _sessionsBackgroundUrl } = DataManager.getSettings();
             const messages = DataManager.getProtobufMessages();
 
             enableLog(debug);
@@ -1206,6 +1206,7 @@ export class Core extends EventEmitter {
                 debug,
                 messages,
                 priority,
+                _sessionsBackgroundUrl,
             });
             initDeviceList(this.getCoreContext());
 

--- a/packages/connect/src/data/connectSettings.ts
+++ b/packages/connect/src/data/connectSettings.ts
@@ -144,5 +144,9 @@ export const parseConnectSettings = (input: Partial<ConnectSettings> = {}) => {
         settings._extendWebextensionLifetime = input._extendWebextensionLifetime;
     }
 
+    if (typeof input._sessionsBackgroundUrl === 'string') {
+        settings._sessionsBackgroundUrl = input._sessionsBackgroundUrl;
+    }
+
     return settings;
 };

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -338,7 +338,9 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
     }
 
     private async selectTransport([transport, ...rest]: Transport[]): Promise<Transport> {
-        const result = await transport.init();
+        const result = await transport.init({
+            sessionsBackgroundUrl: this.transportCommonArgs._sessionsBackgroundUrl,
+        });
         if (result.success) return transport;
         else if (rest.length) return this.selectTransport(rest);
         else throw new Error(result.error);

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -120,15 +120,11 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
 
         const transportLogger = initLog('@trezor/transport', debug);
 
-        // todo: this should be passed from above
-        const abortController = new AbortController();
-
         this.authPenaltyManager = createAuthPenaltyManager(priority);
         this.transportCommonArgs = {
             messages,
             logger: transportLogger,
-            signal: abortController.signal,
-            _sessionsBackgroundUrl,
+            sessionsBackgroundUrl: _sessionsBackgroundUrl,
         };
 
         this.transports = [
@@ -338,9 +334,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
     }
 
     private async selectTransport([transport, ...rest]: Transport[]): Promise<Transport> {
-        const result = await transport.init({
-            sessionsBackgroundUrl: this.transportCommonArgs._sessionsBackgroundUrl,
-        });
+        const result = await transport.init();
         if (result.success) return transport;
         else if (rest.length) return this.selectTransport(rest);
         else throw new Error(result.error);

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -82,7 +82,7 @@ export const assertDeviceListConnected: (
     if (!deviceList.isConnected()) throw ERRORS.TypedError('Transport_Missing');
 };
 
-type ConstructorParams = Pick<ConnectSettings, 'priority' | 'debug'> & {
+type ConstructorParams = Pick<ConnectSettings, 'priority' | 'debug' | '_sessionsBackgroundUrl'> & {
     messages: Record<string, any>;
 };
 type InitParams = Pick<ConnectSettings, 'pendingTransportEvent' | 'transportReconnect'>;
@@ -115,7 +115,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
         return this.initPromise;
     }
 
-    constructor({ messages, priority, debug }: ConstructorParams) {
+    constructor({ messages, priority, debug, _sessionsBackgroundUrl }: ConstructorParams) {
         super();
 
         const transportLogger = initLog('@trezor/transport', debug);
@@ -128,6 +128,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
             messages,
             logger: transportLogger,
             signal: abortController.signal,
+            _sessionsBackgroundUrl,
         };
 
         this.transports = [

--- a/packages/connect/src/types/settings.ts
+++ b/packages/connect/src/types/settings.ts
@@ -26,6 +26,11 @@ export interface ConnectSettingsPublic {
     coreMode?: 'auto' | 'popup' | 'iframe';
     /* _extendWebextensionLifetime features makes the service worker in @trezor/connect-webextension stay alive longer */
     _extendWebextensionLifetime?: boolean;
+    /**
+     * for internal use only!
+     * in some exotic setups (suite-web where iframe is embedded locally), you might need to tell connect where it should search for sessions background shared-worker
+     */
+    _sessionsBackgroundUrl?: string;
     deeplinkOpen?: (url: string) => void;
     deeplinkCallbackUrl?: string;
     deeplinkUrl?: string;

--- a/packages/transport-bridge/src/core.ts
+++ b/packages/transport-bridge/src/core.ts
@@ -19,11 +19,11 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
 
     const sessionsBackground = new SessionsBackground();
 
-    const sessionsClient = new SessionsClient({
+    const sessionsClient = new SessionsClient();
+    sessionsClient.init({
         requestFn: args => sessionsBackground.handleMessage(args),
         registerBackgroundCallbacks: () => {},
     });
-
     sessionsBackground.on('descriptors', descriptors => {
         sessionsClient.emit('descriptors', descriptors);
     });

--- a/packages/transport-native/src/nativeUsb.ts
+++ b/packages/transport-native/src/nativeUsb.ts
@@ -1,16 +1,9 @@
 import { WebUSB } from '@trezor/react-native-usb';
-import {
-    Transport as AbstractTransport,
-    AbstractApiTransport,
-    SessionsBackground,
-    UsbApi,
-} from '@trezor/transport';
+import { Transport as AbstractTransport, AbstractApiTransport, UsbApi } from '@trezor/transport';
 
 export class NativeUsbTransport extends AbstractApiTransport {
     // TODO: Not sure how to solve this type correctly.
     public name = 'NativeUsbTransport' as any;
-
-    private readonly sessionsBackground = new SessionsBackground();
 
     constructor(params: ConstructorParameters<typeof AbstractTransport>[0]) {
         const { messages, logger } = params;
@@ -24,29 +17,8 @@ export class NativeUsbTransport extends AbstractApiTransport {
         });
     }
 
-    public init() {
-        return this.scheduleAction(async () => {
-            // in NativeUsbTransport there is no synchronization and probably never will be.
-            // sessionsClient is talking to sessionsBackground directly
-            this.sessionsClient.init({
-                requestFn: args => this.sessionsBackground.handleMessage(args),
-                registerBackgroundCallbacks: () => {},
-            });
-
-            this.sessionsBackground.on('descriptors', descriptors => {
-                this.sessionsClient.emit('descriptors', descriptors);
-            });
-
-            const handshakeRes = await this.sessionsClient.handshake();
-            this.stopped = !handshakeRes.success;
-
-            return handshakeRes;
-        });
-    }
-
     public listen() {
         this.api.listen();
-        this.sessionsBackground.dispose();
 
         return super.listen();
     }

--- a/packages/transport/src/sessions/background-browser.ts
+++ b/packages/transport/src/sessions/background-browser.ts
@@ -25,17 +25,15 @@ export const initBackgroundInBrowser = async (
     registerBackgroundCallbacks: RegisterBackgroundCallbacks;
 }> => {
     try {
-        const url = sessionsBackgroundUrl;
-
         // fetch to validate - failed fetch via SharedWorker constructor does not throw. It even hangs resulting in all kinds of weird behaviors
-        await fetch(url, { method: 'HEAD' }).then(response => {
+        await fetch(sessionsBackgroundUrl, { method: 'HEAD' }).then(response => {
             if (!response.ok) {
                 throw new Error(
-                    'Failed to fetch sessions-background SharedWorker from url: ' + url,
+                    `Failed to fetch sessions-background SharedWorker from url: ${sessionsBackgroundUrl}`,
                 );
             }
         });
-        const background = new SharedWorker(url, {
+        const background = new SharedWorker(sessionsBackgroundUrl, {
             name: '@trezor/connect-web transport sessions worker',
         });
 

--- a/packages/transport/src/sessions/client.ts
+++ b/packages/transport/src/sessions/client.ts
@@ -51,31 +51,31 @@ export class SessionsClient extends TypedEmitter<{
         }
     }
 
-    handshake() {
+    public handshake() {
         return this.request({ type: 'handshake' });
     }
-    enumerateDone(payload: EnumerateDoneRequest) {
+    public enumerateDone(payload: EnumerateDoneRequest) {
         return this.request({ type: 'enumerateDone', payload });
     }
-    acquireIntent(payload: AcquireIntentRequest) {
+    public acquireIntent(payload: AcquireIntentRequest) {
         return this.request({ type: 'acquireIntent', payload });
     }
-    acquireDone(payload: AcquireDoneRequest) {
+    public acquireDone(payload: AcquireDoneRequest) {
         return this.request({ type: 'acquireDone', payload });
     }
-    releaseIntent(payload: ReleaseIntentRequest) {
+    public releaseIntent(payload: ReleaseIntentRequest) {
         return this.request({ type: 'releaseIntent', payload });
     }
-    releaseDone(payload: ReleaseDoneRequest) {
+    public releaseDone(payload: ReleaseDoneRequest) {
         return this.request({ type: 'releaseDone', payload });
     }
-    getSessions() {
+    public getSessions() {
         return this.request({ type: 'getSessions' });
     }
-    getPathBySession(payload: GetPathBySessionRequest) {
+    public getPathBySession(payload: GetPathBySessionRequest) {
         return this.request({ type: 'getPathBySession', payload });
     }
-    dispose() {
+    public dispose() {
         this.removeAllListeners('descriptors');
 
         return this.request({ type: 'dispose' });

--- a/packages/transport/src/sessions/client.ts
+++ b/packages/transport/src/sessions/client.ts
@@ -21,22 +21,26 @@ export class SessionsClient extends TypedEmitter<{
     descriptors: Descriptor[];
 }> {
     // request method responsible for communication with sessions background.
-    private request: SessionsBackground['handleMessage'];
+    private request: SessionsBackground['handleMessage'] = () => {
+        throw new Error('SessionsClient: request method not provided');
+    };
 
     // used only for debugging - discriminating sessions clients in sessions background log
     private caller = getWeakRandomId(3);
-    private id: number;
+    private id: number = 0;
 
-    constructor({
+    public init({
         requestFn,
         registerBackgroundCallbacks,
     }: {
         requestFn: SessionsBackground['handleMessage'];
         registerBackgroundCallbacks?: RegisterBackgroundCallbacks;
     }) {
-        super();
         this.id = 0;
         this.request = params => {
+            if (!requestFn) {
+                throw new Error('SessionsClient: requestFn not provided');
+            }
             params.caller = this.caller;
             params.id = this.id;
             this.id++;

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -179,11 +179,7 @@ export abstract class AbstractTransport extends TransportEmitter {
     /**
      * Tries to initiate transport. Transport might not be available e.g. bridge not running.
      */
-    abstract init(
-        params?: AbortableParam & {
-            sessionsBackgroundUrl?: string;
-        },
-    ): AsyncResultWithTypedError<
+    abstract init(params?: AbortableParam): AsyncResultWithTypedError<
         undefined,
         // webusb only
         | typeof ERRORS.SESSION_BACKGROUND_TIMEOUT

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -179,7 +179,11 @@ export abstract class AbstractTransport extends TransportEmitter {
     /**
      * Tries to initiate transport. Transport might not be available e.g. bridge not running.
      */
-    abstract init(params?: AbortableParam): AsyncResultWithTypedError<
+    abstract init(
+        params?: AbortableParam & {
+            sessionsBackgroundUrl?: string;
+        },
+    ): AsyncResultWithTypedError<
         undefined,
         // webusb only
         | typeof ERRORS.SESSION_BACKGROUND_TIMEOUT

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -15,7 +15,6 @@ import { Session } from '../types';
 
 interface ConstructorParams extends AbstractTransportParams {
     api: AbstractApi;
-    sessionsClient: (typeof SessionsClient)['prototype'];
 }
 
 /**
@@ -24,12 +23,11 @@ interface ConstructorParams extends AbstractTransportParams {
 export abstract class AbstractApiTransport extends AbstractTransport {
     // sessions client is a standardized interface for communicating with sessions backend
     // which can live in couple of context (shared worker, local module, websocket server etc)
-    private sessionsClient: ConstructorParams['sessionsClient'];
+    protected sessionsClient = new SessionsClient();
     protected api: AbstractApi;
 
-    constructor({ messages, api, sessionsClient, logger }: ConstructorParams) {
+    constructor({ messages, api, logger }: ConstructorParams) {
         super({ messages, logger });
-        this.sessionsClient = sessionsClient;
         this.api = api;
     }
 

--- a/packages/transport/src/transports/nodeusb.ts
+++ b/packages/transport/src/transports/nodeusb.ts
@@ -1,7 +1,6 @@
 import { WebUSB } from 'usb';
 import { AbstractTransportParams } from './abstract';
 import { AbstractApiTransport } from './abstractApi';
-import { SessionsBackground } from '../sessions/background';
 import { UsbApi } from '../api/usb';
 
 // notes:
@@ -10,8 +9,6 @@ import { UsbApi } from '../api/usb';
 
 export class NodeUsbTransport extends AbstractApiTransport {
     public name = 'NodeUsbTransport' as const;
-
-    private readonly sessionsBackground = new SessionsBackground();
 
     constructor(params: AbstractTransportParams) {
         const { messages, logger, debugLink } = params;
@@ -28,34 +25,9 @@ export class NodeUsbTransport extends AbstractApiTransport {
         });
     }
 
-    public init() {
-        return this.scheduleAction(async () => {
-            // in nodeusb there is no synchronization yet. this is a followup and needs to be decided
-            // so far, sessionsClient has direct access to sessionBackground
-            this.sessionsClient.init({
-                requestFn: args => this.sessionsBackground.handleMessage(args),
-                registerBackgroundCallbacks: () => {},
-            });
-
-            this.sessionsBackground.on('descriptors', descriptors => {
-                this.sessionsClient.emit('descriptors', descriptors);
-            });
-
-            const handshakeRes = await this.sessionsClient.handshake();
-            this.stopped = !handshakeRes.success;
-
-            return handshakeRes;
-        });
-    }
-
     public listen() {
         this.api.listen();
 
         return super.listen();
-    }
-
-    public stop() {
-        super.stop();
-        this.sessionsBackground.dispose();
     }
 }

--- a/packages/transport/src/transports/udp.ts
+++ b/packages/transport/src/transports/udp.ts
@@ -3,11 +3,9 @@ import { AbstractTransportParams } from './abstract';
 import { UdpApi } from '../api/udp';
 import { AbstractApiTransport } from './abstractApi';
 
-import { SessionsBackground } from '../sessions/background';
 export class UdpTransport extends AbstractApiTransport {
     public name = 'UdpTransport' as const;
     private enumerateTimeout: ReturnType<typeof setTimeout> | undefined;
-    private readonly sessionsBackground = new SessionsBackground();
 
     constructor(params: AbstractTransportParams) {
         const { messages, logger, debugLink } = params;
@@ -16,25 +14,6 @@ export class UdpTransport extends AbstractApiTransport {
             messages,
             api: new UdpApi({ logger, debugLink }),
             logger,
-        });
-    }
-
-    public init() {
-        return this.scheduleAction(async () => {
-            // in udp there is no synchronization.
-            this.sessionsClient.init({
-                requestFn: args => this.sessionsBackground.handleMessage(args),
-                registerBackgroundCallbacks: () => {},
-            });
-
-            this.sessionsBackground.on('descriptors', descriptors => {
-                this.sessionsClient.emit('descriptors', descriptors);
-            });
-
-            const handshakeRes = await this.sessionsClient.handshake();
-            this.stopped = !handshakeRes.success;
-
-            return handshakeRes;
         });
     }
 
@@ -49,7 +28,6 @@ export class UdpTransport extends AbstractApiTransport {
             clearTimeout(this.enumerateTimeout);
             this.enumerateTimeout = undefined;
         }
-        this.sessionsBackground.dispose();
 
         return super.stop();
     }

--- a/packages/transport/src/transports/webusb.browser.ts
+++ b/packages/transport/src/transports/webusb.browser.ts
@@ -1,8 +1,10 @@
-import { AbstractTransportParams } from './abstract';
+import { AbstractTransportMethodParams, AbstractTransportParams } from './abstract';
 import { AbstractApiTransport } from './abstractApi';
 import { UsbApi } from '../api/usb';
 
 import { initBackgroundInBrowser } from '../sessions/background-browser';
+
+type WebUsbTransportParams = AbstractTransportParams & { sessionsBackgroundUrl?: string };
 
 /**
  * WebUsbTransport
@@ -12,9 +14,9 @@ import { initBackgroundInBrowser } from '../sessions/background-browser';
 export class WebUsbTransport extends AbstractApiTransport {
     public name = 'WebUsbTransport' as const;
 
-    constructor(params: AbstractTransportParams) {
-        const { messages, logger } = params;
+    private readonly sessionsBackgroundUrl;
 
+    constructor({ messages, logger, sessionsBackgroundUrl }: WebUsbTransportParams) {
         super({
             messages,
             api: new UsbApi({
@@ -23,23 +25,28 @@ export class WebUsbTransport extends AbstractApiTransport {
             }),
             logger,
         });
+        this.sessionsBackgroundUrl = sessionsBackgroundUrl;
     }
 
-    public init({ sessionsBackgroundUrl }: { sessionsBackgroundUrl: string }) {
-        return this.scheduleAction(async () => {
-            const { requestFn, registerBackgroundCallbacks } =
-                await initBackgroundInBrowser(sessionsBackgroundUrl);
-            // sessions client initiated with a request fn facilitating communication with a session backend (shared worker in case of webusb)
-            this.sessionsClient.init({
-                requestFn,
-                registerBackgroundCallbacks,
-            });
+    public init({ signal }: AbstractTransportMethodParams<'init'> = {}) {
+        return this.scheduleAction(
+            async () => {
+                const { sessionsBackgroundUrl } = this;
+                const { requestFn, registerBackgroundCallbacks } =
+                    await initBackgroundInBrowser(sessionsBackgroundUrl);
+                // sessions client initiated with a request fn facilitating communication with a session backend (shared worker in case of webusb)
+                this.sessionsClient.init({
+                    requestFn,
+                    registerBackgroundCallbacks,
+                });
 
-            const handshakeRes = await this.sessionsClient.handshake();
-            this.stopped = !handshakeRes.success;
+                const handshakeRes = await this.sessionsClient.handshake();
+                this.stopped = !handshakeRes.success;
 
-            return handshakeRes;
-        });
+                return handshakeRes;
+            },
+            { signal },
+        );
     }
 
     public listen() {

--- a/packages/transport/tests/sessions.test.ts
+++ b/packages/transport/tests/sessions.test.ts
@@ -11,7 +11,8 @@ describe('sessions', () => {
     });
 
     test('acquire without previous enumerate', async () => {
-        const client1 = new SessionsClient({ requestFn });
+        const client1 = new SessionsClient();
+        client1.init({ requestFn });
         await client1.handshake();
 
         const acquireIntent = await client1.acquireIntent({
@@ -27,7 +28,8 @@ describe('sessions', () => {
     });
 
     test('acquire', async () => {
-        const client1 = new SessionsClient({ requestFn });
+        const client1 = new SessionsClient();
+        client1.init({ requestFn });
         await client1.handshake();
 
         await client1.enumerateDone({ descriptors: [{ path: PathInternal('abc'), type: 1 }] });
@@ -71,7 +73,8 @@ describe('sessions', () => {
     test('acquire', async () => {
         expect.assertions(3);
 
-        const client1 = new SessionsClient({ requestFn });
+        const client1 = new SessionsClient();
+        client1.init({ requestFn });
         await client1.handshake();
 
         await client1.enumerateDone({ descriptors: [{ path: PathInternal('1'), type: 1 }] });
@@ -128,7 +131,8 @@ describe('sessions', () => {
     });
 
     test('acquire - release - acquire', async () => {
-        const client1 = new SessionsClient({ requestFn });
+        const client1 = new SessionsClient();
+        client1.init({ requestFn });
         await client1.handshake();
 
         await client1.enumerateDone({ descriptors: [{ path: PathInternal('1'), type: 1 }] });

--- a/suite-common/connect-init/package.json
+++ b/suite-common/connect-init/package.json
@@ -15,9 +15,11 @@
         "@reduxjs/toolkit": "1.9.5",
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
+        "@suite-common/suite-utils": "workspace:^",
         "@suite-common/test-utils": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@trezor/connect": "workspace:*",
+        "@trezor/env-utils": "workspace:^",
         "@trezor/utils": "workspace:*"
     },
     "devDependencies": {

--- a/suite-common/connect-init/tsconfig.json
+++ b/suite-common/connect-init/tsconfig.json
@@ -4,9 +4,11 @@
     "references": [
         { "path": "../redux-utils" },
         { "path": "../suite-types" },
+        { "path": "../suite-utils" },
         { "path": "../test-utils" },
         { "path": "../wallet-core" },
         { "path": "../../packages/connect" },
+        { "path": "../../packages/env-utils" },
         { "path": "../../packages/utils" }
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9067,9 +9067,11 @@ __metadata:
     "@reduxjs/toolkit": "npm:1.9.5"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
+    "@suite-common/suite-utils": "workspace:^"
     "@suite-common/test-utils": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@trezor/connect": "workspace:*"
+    "@trezor/env-utils": "workspace:^"
     "@trezor/utils": "workspace:*"
     redux-mock-store: "npm:^1.5.4"
     redux-thunk: "npm:^2.4.2"
@@ -9288,7 +9290,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@suite-common/suite-utils@workspace:*, @suite-common/suite-utils@workspace:suite-common/suite-utils":
+"@suite-common/suite-utils@workspace:*, @suite-common/suite-utils@workspace:^, @suite-common/suite-utils@workspace:suite-common/suite-utils":
   version: 0.0.0-use.local
   resolution: "@suite-common/suite-utils@workspace:suite-common/suite-utils"
   dependencies:
@@ -11557,7 +11559,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/env-utils@workspace:*, @trezor/env-utils@workspace:packages/env-utils":
+"@trezor/env-utils@workspace:*, @trezor/env-utils@workspace:^, @trezor/env-utils@workspace:packages/env-utils":
   version: 0.0.0-use.local
   resolution: "@trezor/env-utils@workspace:packages/env-utils"
   dependencies:


### PR DESCRIPTION
## Description

Connect-iframe has been bundled into suite-web since the very beginning. This, however, caused a problem: the shared workers used for synchronizing device access between tabs were not really shared (between suite-web and connect) because there were two of them at the same time.

The tldr change by this PR is that from now on the single source of the sharedworker is @trezor/connect-web deployment and suite-web may be merely pointed to it. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/12002

## Screenshots:

note: screenshots are outdated. I changed the naming later. 

Before: 
<img width="758" alt="image" src="https://github.com/user-attachments/assets/a8e32773-9980-4653-a75d-12e728c27e5d">

After:
<img width="926" alt="image" src="https://github.com/user-attachments/assets/8c513f80-c358-44aa-a7e0-026ed25986de">

## Test env

- sldev suite-web https://dev.suite.sldev.cz/suite-web/shared-sharedworker/web/
- sldev connect-exp https://dev.suite.sldev.cz/connect/shared-sharedworker/methods/bitcoin/getAddress/
