### PR TITLE
Improved descriptor diff on transport layer

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -821,6 +821,15 @@ export class Device extends TypedEmitter<DeviceEvents> {
         return null;
     }
 
+    updateDescriptor(descriptor: Descriptor) {
+        this.originalDescriptor = {
+            session: descriptor.session,
+            path: descriptor.path,
+            product: descriptor.product,
+            type: descriptor.type,
+        };
+    }
+
     async dispose() {
         this.removeAllListeners();
         if (this.isUsedHere() && this.transportSession) {

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -272,12 +272,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
         diff.descriptors.forEach(d => {
             this.creatingDevicesDescriptors[d.path] = d;
             if (this.devices[d.path]) {
-                this.devices[d.path].originalDescriptor = {
-                    session: d.session,
-                    path: d.path,
-                    product: d.product,
-                    type: d.type,
-                };
+                this.devices[d.path].updateDescriptor(d);
             }
         });
     }
@@ -500,12 +495,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
 
         res.payload.forEach(d => {
             if (this.devices[d.path]) {
-                this.devices[d.path].originalDescriptor = {
-                    session: d.session,
-                    path: d.path,
-                    product: d.product,
-                    type: d.type,
-                };
+                this.devices[d.path].updateDescriptor(d);
                 // TODO: is this ok? transportSession should be set only as result of acquire/release
                 // this.devices[d.path].transportSession = d.session;
             }

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -573,7 +573,6 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
                 await this.handle(descriptor, transport);
             }
         }
-        delete this.creatingDevicesDescriptors[path];
     }
 
     private async _takeAndCreateDevice(descriptor: Descriptor, transport: Transport) {

--- a/packages/transport-test/e2e/bridge/multi-client.test.ts
+++ b/packages/transport-test/e2e/bridge/multi-client.test.ts
@@ -93,32 +93,12 @@ describe('bridge', () => {
             session: '1',
         });
 
-        expect(bride1spy).toHaveBeenLastCalledWith('transport-update', {
-            acquired: [expectedDescriptor1],
-            acquiredByMyself: [expectedDescriptor1], // difference here
-            acquiredElsewhere: [],
-            changedSessions: [expectedDescriptor1],
-            connected: [],
-            descriptors: [expectedDescriptor1],
-            didUpdate: true,
-            disconnected: [],
-            released: [],
-            releasedByMyself: [],
-            releasedElsewhere: [],
-        });
-        expect(bride2spy).toHaveBeenLastCalledWith('transport-update', {
-            acquired: [expectedDescriptor1],
-            acquiredByMyself: [],
-            acquiredElsewhere: [expectedDescriptor1], // difference here
-            changedSessions: [expectedDescriptor1],
-            connected: [],
-            descriptors: [expectedDescriptor1],
-            didUpdate: true,
-            disconnected: [],
-            released: [],
-            releasedByMyself: [],
-            releasedElsewhere: [],
-        });
+        expect(bride1spy).toHaveBeenLastCalledWith('transport-update', [
+            { type: 'acquired', subtype: 'here', descriptor: expectedDescriptor1 },
+        ]);
+        expect(bride2spy).toHaveBeenLastCalledWith('transport-update', [
+            { type: 'acquired', subtype: 'elsewhere', descriptor: expectedDescriptor1 },
+        ]);
 
         expect(session1.success).toBe(true);
         if (!session1.success) {
@@ -134,33 +114,13 @@ describe('bridge', () => {
             session: null,
         });
 
-        expect(bride1spy).toHaveBeenLastCalledWith('transport-update', {
-            acquired: [],
-            acquiredByMyself: [],
-            acquiredElsewhere: [],
-            changedSessions: [expectedDescriptor2],
-            connected: [],
-            descriptors: [expectedDescriptor2],
-            didUpdate: true,
-            disconnected: [],
-            released: [expectedDescriptor2],
-            releasedByMyself: [expectedDescriptor2], // difference here
-            releasedElsewhere: [],
-        });
+        expect(bride1spy).toHaveBeenLastCalledWith('transport-update', [
+            { type: 'released', subtype: 'here', descriptor: expectedDescriptor2 },
+        ]);
 
-        expect(bride2spy).toHaveBeenLastCalledWith('transport-update', {
-            acquired: [],
-            acquiredByMyself: [],
-            acquiredElsewhere: [],
-            changedSessions: [expectedDescriptor2],
-            connected: [],
-            descriptors: [expectedDescriptor2],
-            didUpdate: true,
-            disconnected: [],
-            released: [expectedDescriptor2],
-            releasedByMyself: [],
-            releasedElsewhere: [expectedDescriptor2], // difference here
-        });
+        expect(bride2spy).toHaveBeenLastCalledWith('transport-update', [
+            { type: 'released', subtype: 'elsewhere', descriptor: expectedDescriptor2 },
+        ]);
 
         const session2 = await bridge2.acquire({
             input: { previous: null, path: descriptors[0].path },
@@ -199,33 +159,13 @@ describe('bridge', () => {
 
         await wait(); // wait for event to be propagated
 
-        expect(bride1spy).toHaveBeenLastCalledWith('transport-update', {
-            acquired: [expectedDescriptor],
-            acquiredByMyself: [],
-            acquiredElsewhere: [expectedDescriptor],
-            changedSessions: [expectedDescriptor],
-            connected: [],
-            descriptors: [expectedDescriptor],
-            didUpdate: true,
-            disconnected: [],
-            released: [],
-            releasedByMyself: [],
-            releasedElsewhere: [],
-        });
+        expect(bride1spy).toHaveBeenLastCalledWith('transport-update', [
+            { type: 'acquired', subtype: 'elsewhere', descriptor: expectedDescriptor },
+        ]);
 
-        expect(bride2spy).toHaveBeenLastCalledWith('transport-update', {
-            acquired: [expectedDescriptor],
-            acquiredByMyself: [expectedDescriptor],
-            acquiredElsewhere: [],
-            changedSessions: [expectedDescriptor],
-            connected: [],
-            descriptors: [expectedDescriptor],
-            didUpdate: true,
-            disconnected: [],
-            released: [],
-            releasedByMyself: [],
-            releasedElsewhere: [],
-        });
+        expect(bride2spy).toHaveBeenLastCalledWith('transport-update', [
+            { type: 'acquired', subtype: 'here', descriptor: expectedDescriptor },
+        ]);
     });
 
     // todo: udp not implemented correctly yet in new bridge

--- a/packages/transport/tests/abstractUsb.test.ts
+++ b/packages/transport/tests/abstractUsb.test.ts
@@ -195,21 +195,13 @@ describe('Usb', () => {
 
             transport.handleDescriptorsChange([{ path: '1', session: null, type: 1 }]);
 
-            expect(spy).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    connected: [{ path: '1', session: null, type: 1 }],
-                    didUpdate: true,
-                    descriptors: [{ path: '1', session: null, type: 1 }],
-                }),
-            );
+            expect(spy).toHaveBeenCalledWith([
+                { type: 'connected', descriptor: { path: '1', session: null, type: 1 } },
+            ]);
             transport.handleDescriptorsChange([]);
-            expect(spy).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    disconnected: [{ path: '1', session: null, type: 1 }],
-                    didUpdate: true,
-                    descriptors: [],
-                }),
-            );
+            expect(spy).toHaveBeenCalledWith([
+                { type: 'disconnected', descriptor: { path: '1', session: null, type: 1 } },
+            ]);
             abortController.abort();
         });
 
@@ -303,7 +295,9 @@ describe('Usb', () => {
             // set some initial descriptors
             const acquireCall = transport.acquire({ input: { path: '123', previous: null } });
             setTimeout(() => {
-                sessionsClient.emit('descriptors', [{ path: '123', session: '2', type: 1 }]);
+                sessionsClient.emit('descriptors', [
+                    { path: '123', session: '2', type: 1, product: 21441 },
+                ]);
             }, 1);
 
             const res = await acquireCall.promise;


### PR DESCRIPTION
## Description

While trying to fix error with missing `originalDescriptor` on device (probable reason was removing `creatingDevicesDescriptors` and race condition), I tried to refactor diff format sent by `TRANSPORT.UPDATE` a bit. The followup step should probably be to implement some synchronization for simultaneous updates of one device.

**Food for thought:**
- Is it ok that unchanged descriptors aren't now sent to `DeviceList` via update event?
- Main identifier of a device is now path + product for all cases, not just connected/disconnected. Because of that, e.g. unit test must've been adjusted (before this change, one device could've been e.g. `connected` and `acquiredElsewhere` at the same iteration, now it cannot be both). Is it ok?

## Related Issue

Could resolve #13973
