### PR TITLE
chore(suite): new bridge rollout logic

### DIFF
--- a/docs/packages/suite-desktop.md
+++ b/docs/packages/suite-desktop.md
@@ -96,7 +96,6 @@ Available flags:
 | `--open-devtools`     | Open DevTools on app launch.                                                                                                                                                           |
 | `--pre-release`       | Tells the auto-updater to fetch pre-release updates.                                                                                                                                   |
 | `--bridge-legacy`     | Use Legacy (trezord-go) Bridge implementation                                                                                                                                          |
-| `--bridge-legacy-dev` | Instruct legacy (trezord-go) Bridge to support emulator (starts Bridge with `-e 21324`).                                                                                               |
 | `--bridge-dev`        | Instruct Bridge to support emulator on port 21324                                                                                                                                      |
 | `--log-level=NAME`    | Set the logging level. Available levels are [name (value)]: error (1), warn (2), info(3), debug (4). All logs with a value equal or lower to the selected log level will be displayed. |
 | `--log-write`         | Write log to disk                                                                                                                                                                      |

--- a/packages/suite-desktop-core/e2e/support/common.ts
+++ b/packages/suite-desktop-core/e2e/support/common.ts
@@ -31,7 +31,7 @@ export const launchSuiteElectronApp = async (params: LaunchSuiteParams = {}) => 
         args: [
             path.join(appDir, './dist/app.js'),
             `--log-level=${desiredLogLevel}`,
-            ...(options.bridgeLegacyTest ? ['--bridge-legacy-test'] : []),
+            ...(options.bridgeLegacyTest ? ['--bridge-legacy', '--bridge-test'] : []),
             ...(options.bridgeDaemon ? ['--bridge-daemon', '--skip-new-bridge-rollout'] : []),
         ],
         // when testing electron, video needs to be setup like this. it works locally but not in docker

--- a/packages/suite/src/views/settings/SettingsDebug/TransportBackends.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/TransportBackends.tsx
@@ -6,15 +6,18 @@ import { desktopApi } from '@trezor/suite-desktop-api';
 import { ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
 import { BridgeSettings } from '@trezor/suite-desktop-api/src/messages';
 import { isDevEnv } from '@suite-common/suite-utils';
+import { useSelector } from 'src/hooks/suite';
+
 interface Process {
     service: boolean;
     process: boolean;
 }
 
 // note that this variable is duplicated with suite-desktop-core
-const NEW_BRIDGE_ROLLOUT_THRESHOLD = 1;
+const NEW_BRIDGE_ROLLOUT_THRESHOLD = 0;
 
 export const TransportBackends = () => {
+    const allowPrerelease = useSelector(state => state.desktopUpdate.allowPrerelease);
     const [bridgeProcess, setBridgeProcess] = useState<Process>({ service: false, process: false });
     const [bridgeSettings, setBridgeSettings] = useState<BridgeSettings | null>(null);
     const [error, setError] = useState<string | null>(null);
@@ -110,7 +113,11 @@ export const TransportBackends = () => {
                 <SectionItem data-testid="@settings/debug/processes/newBridgeRollout">
                     <TextColumn
                         title="New bridge rollout"
-                        description={`New bridge is being rolled out to ${NEW_BRIDGE_ROLLOUT_THRESHOLD * 100}% of Trezor Suite instances that have applied for the Early access program.`}
+                        description={
+                            allowPrerelease
+                                ? 'New bridge is rolled out to all Trezor Suite instances that are in the Early access program.'
+                                : `New bridge is rolled out to ${NEW_BRIDGE_ROLLOUT_THRESHOLD * 100} % of Trezor Suite instances outside of Early access. Your rollout score is ${((bridgeSettings.newBridgeRollout ?? 0) * 100).toFixed()}%`
+                        }
                     />
                 </SectionItem>
             )}


### PR DESCRIPTION
## Description

This PR does the following: 

- Always uses Node-bridge for EAP users. Rollout % logic is now being used for non-EAP, currently set at 0%.  
- Uses Node-bridge in dev environment by default
- Removes combined options such as `--bridge-legacy-dev`, `--bridge-legacy-test` (use eg. `--bridge-legacy --bridge-test` instead)