### PR TITLE
fix(suite-native): use default letter spacing

### DIFF
--- a/packages/theme/src/typography.ts
+++ b/packages/theme/src/typography.ts
@@ -22,14 +22,12 @@ type TypographyStyleDefinition = {
     fontSize: number;
     lineHeight: number;
     fontWeight: FontWeightValue;
-    letterSpacing: number;
     fontFamily?: string;
 };
 
 export type NativeTypographyStyleDefinition = {
     fontSize: number;
     lineHeight: number;
-    letterSpacing: number;
     fontFamily: string;
 };
 
@@ -42,49 +40,41 @@ export const typographyStylesBase: Record<TypographyStyle, TypographyStyleDefini
         fontSize: 48,
         lineHeight: 53,
         fontWeight: fontWeights.medium,
-        letterSpacing: 0.4,
     },
     titleMedium: {
         fontSize: 34,
         lineHeight: 37,
         fontWeight: fontWeights.medium,
-        letterSpacing: -1.4,
     },
     titleSmall: {
         fontSize: 22,
         lineHeight: 32,
         fontWeight: fontWeights.medium,
-        letterSpacing: -0.3,
     },
     highlight: {
         fontSize: 16,
         lineHeight: 24,
         fontWeight: fontWeights.semiBold,
-        letterSpacing: -0.4,
     },
     body: {
         fontSize: 16,
         lineHeight: 24,
         fontWeight: fontWeights.medium,
-        letterSpacing: -0.4,
     },
     callout: {
         fontSize: 14,
         lineHeight: 20,
         fontWeight: fontWeights.semiBold,
-        letterSpacing: -0.3,
     },
     hint: {
         fontSize: 14,
         lineHeight: 20,
         fontWeight: fontWeights.medium,
-        letterSpacing: -0.3,
     },
     label: {
         fontSize: 12,
         lineHeight: 18,
         fontWeight: fontWeights.medium,
-        letterSpacing: -0.1,
     },
 };
 
@@ -107,7 +97,6 @@ const prepareTypography = (): TypographyStyles =>
             font-size: ${value.fontSize}px;
             line-height: ${value.lineHeight}px;
             font-weight: ${value.fontWeight};
-            letter-spacing: ${value.letterSpacing}px;
             `,
         ]),
     ) as TypographyStyles;

--- a/suite-native/atoms/src/Input/Input.tsx
+++ b/suite-native/atoms/src/Input/Input.tsx
@@ -128,9 +128,6 @@ const inputWrapperStyle = prepareNativeStyle<InputWrapperStyleProps>(
 const inputStyle = prepareNativeStyle<InputStyleProps>(
     (utils, { isLabelDisplayed, isLeftIconDisplayed, isRightIconDisplayed, isDisabled }) => ({
         ...utils.typography.body,
-        // letterSpacing from `typography.body` is making strange layout jumps on Android while filling the input.
-        // This resets it to the default TextInput value.
-        letterSpacing: 0,
         alignItems: 'center',
         justifyContent: 'center',
         minHeight: INPUT_TEXT_HEIGHT,

--- a/suite-native/formatters/src/components/AccountAddressFormatter.tsx
+++ b/suite-native/formatters/src/components/AccountAddressFormatter.tsx
@@ -1,42 +1,24 @@
-import { Platform } from 'react-native';
 import { useSelector } from 'react-redux';
 
 import { AccountsRootState, selectAccountLabel } from '@suite-common/wallet-core';
 import { Text, TextProps } from '@suite-native/atoms';
 import { AccountKey } from '@suite-common/wallet-types';
-import { prepareNativeStyle, useNativeStyles, mergeNativeStyleObjects } from '@trezor/styles';
 
 import { FormatterProps } from '../types';
 
 type AccountAddressFormatterProps = FormatterProps<AccountKey> & TextProps;
-
-const addressStyle = prepareNativeStyle(_ => ({
-    // ellipsizeMode="middle" is not working on Android with negative letterSpacing defined in @trezor/theme typography.
-    extend: {
-        condition: Platform.OS === 'android',
-        style: {
-            letterSpacing: 0,
-        },
-    },
-}));
 
 export const AccountAddressFormatter = ({
     value,
     style,
     ...rest
 }: AccountAddressFormatterProps) => {
-    const { applyStyle } = useNativeStyles();
     const accountLabel = useSelector((state: AccountsRootState) =>
         selectAccountLabel(state, value),
     );
 
-    const baseAddressStyle = applyStyle(addressStyle);
-    const mergedAddressStyle = style
-        ? mergeNativeStyleObjects([style, baseAddressStyle])
-        : baseAddressStyle;
-
     return (
-        <Text numberOfLines={1} ellipsizeMode="middle" style={mergedAddressStyle} {...rest}>
+        <Text numberOfLines={1} ellipsizeMode="middle" style={style} {...rest}>
             {accountLabel || value}
         </Text>
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

POC solution to see how default letter spacing looks like.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/14177

## Screenshots:
<img width="374" alt="image" src="https://github.com/user-attachments/assets/a1b8d0c3-8b24-4e85-a550-b6ea81e00ff5">

