### PR TITLE
fix(suite): Fix traffic light padding

### DIFF
--- a/packages/suite/src/components/suite/TrafficLightOffset.tsx
+++ b/packages/suite/src/components/suite/TrafficLightOffset.tsx
@@ -18,8 +18,8 @@ const FixForNotBeingAbleToDragWindow = styled.div`
     width: 100%;
 `;
 
-const Container = styled.div<{ $hasTopPadding?: boolean; $offset: number }>`
-    ${({ $hasTopPadding, $offset }) => $hasTopPadding && `padding-top: ${$offset}px;`}
+const Container = styled.div<{ $offset: number }>`
+    ${({ $offset }) => `padding-top: ${$offset}px;`}
     width: 100%;
     height: 100%;
 `;
@@ -29,14 +29,12 @@ export const TrafficLightOffset = ({ children, offset = 35, isVisible = true }: 
     const isMac = isMacOs();
     const isDesktopApp = isDesktop();
 
-    if (!isVisible) return children;
+    if (!isVisible || !isMac || !isDesktopApp) return children;
 
     return (
         <>
             <FixForNotBeingAbleToDragWindow />
-            <Container $hasTopPadding={isMac && isDesktopApp} $offset={offset}>
-                {children}
-            </Container>
+            <Container $offset={offset}>{children}</Container>
         </>
     );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Whole component should not be visible on web without mac

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

after
<img width="939" alt="image" src="https://github.com/user-attachments/assets/bcdd7cc4-cbb1-4929-a803-f2fbb7b5cef7">
