### PR TITLE
chore: update socks-proxy-agent from 6.1.1 to 8.0.4

### DIFF
--- a/packages/blockchain-link-types/package.json
+++ b/packages/blockchain-link-types/package.json
@@ -22,8 +22,7 @@
     "dependencies": {
         "@solana/web3.js": "^1.95.0",
         "@trezor/type-utils": "workspace:*",
-        "@trezor/utxo-lib": "workspace:*",
-        "socks-proxy-agent": "8.0.4"
+        "@trezor/utxo-lib": "workspace:*"
     },
     "devDependencies": {
         "tsx": "^4.16.3"

--- a/packages/blockchain-link-types/package.json
+++ b/packages/blockchain-link-types/package.json
@@ -23,7 +23,7 @@
         "@solana/web3.js": "^1.95.0",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utxo-lib": "workspace:*",
-        "socks-proxy-agent": "6.1.1"
+        "socks-proxy-agent": "8.0.4"
     },
     "devDependencies": {
         "tsx": "^4.16.3"

--- a/packages/blockchain-link-types/src/common.ts
+++ b/packages/blockchain-link-types/src/common.ts
@@ -1,4 +1,6 @@
-import type { SocksProxyAgentOptions } from 'socks-proxy-agent';
+import type tls from 'tls';
+import type { Url } from 'url';
+import type { SocksProxy } from 'socks';
 
 import type { Transaction as BlockbookTransaction, VinVout } from './blockbook';
 import type {
@@ -9,6 +11,24 @@ import type {
 } from './blockbook-api';
 
 /* Common types used in both params and responses */
+
+type AgentOptions = {
+    timeout?: number | undefined;
+};
+
+interface BaseSocksProxyAgentOptions {
+    host?: string | null;
+    port?: string | number | null;
+    username?: string | null;
+    tls?: tls.ConnectionOptions | null;
+}
+
+// todo: connect10 here we are using the old `SocksProxyAgentOptions` from older version of socks-proxy-agent
+// but we keep the old API so we do not introduce breaking changes.
+interface SocksProxyAgentOptions
+    extends AgentOptions,
+        BaseSocksProxyAgentOptions,
+        Partial<Omit<Url & SocksProxy, keyof BaseSocksProxyAgentOptions>> {}
 
 export interface BlockchainSettings {
     name: string;

--- a/packages/blockchain-link-types/src/common.ts
+++ b/packages/blockchain-link-types/src/common.ts
@@ -1,6 +1,4 @@
 import type tls from 'tls';
-import type { Url } from 'url';
-import type { SocksProxy } from 'socks';
 
 import type { Transaction as BlockbookTransaction, VinVout } from './blockbook';
 import type {
@@ -21,14 +19,15 @@ interface BaseSocksProxyAgentOptions {
     port?: string | number | null;
     username?: string | null;
     tls?: tls.ConnectionOptions | null;
+    ipaddress?: string;
+    type: 4 | 5;
+    userId?: string;
+    password?: string;
 }
 
 // todo: connect10 here we are using the old `SocksProxyAgentOptions` from older version of socks-proxy-agent
 // but we keep the old API so we do not introduce breaking changes.
-interface SocksProxyAgentOptions
-    extends AgentOptions,
-        BaseSocksProxyAgentOptions,
-        Partial<Omit<Url & SocksProxy, keyof BaseSocksProxyAgentOptions>> {}
+interface SocksProxyAgentOptions extends AgentOptions, BaseSocksProxyAgentOptions {}
 
 export interface BlockchainSettings {
     name: string;

--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -86,7 +86,7 @@
         "@types/web": "^0.0.162",
         "events": "^3.3.0",
         "ripple-lib": "^1.10.1",
-        "socks-proxy-agent": "6.1.1",
+        "socks-proxy-agent": "8.0.4",
         "ws": "^8.18.0"
     },
     "peerDependencies": {

--- a/packages/blockchain-link/src/workers/electrum/sockets/tor.ts
+++ b/packages/blockchain-link/src/workers/electrum/sockets/tor.ts
@@ -17,7 +17,7 @@ export class TorSocket extends SocketBase {
     protected async openSocket(listener: SocketListener) {
         const { host, port } = this;
         const socket = await this.proxyAgent
-            .callback(null as any, { host, port, timeout: this.timeout, secureEndpoint: false })
+            .connect(null as any, { host, port, timeout: this.timeout, secureEndpoint: false })
             .catch(e => {
                 listener.onError(e);
                 throw e;

--- a/packages/coinjoin/tests/tools/benchmark-test.ts
+++ b/packages/coinjoin/tests/tools/benchmark-test.ts
@@ -15,7 +15,7 @@ const TIMEOUT = 20000;
 const [bestKnownHash, batchSizeString = '500', torSocket = ''] = process.argv.slice(2);
 const batchSize = Number(batchSizeString);
 const [host, port] = torSocket.split(':');
-const agent = host && port ? new SocksProxyAgent({ host, port }) : undefined;
+const agent = host && port ? new SocksProxyAgent(`socks://${host}:${port}`) : undefined;
 
 // Copied from request-manager to remove disallowed headers because of Wasabi
 const stripHeaders = () => {

--- a/packages/request-manager/package.json
+++ b/packages/request-manager/package.json
@@ -14,7 +14,7 @@
     "dependencies": {
         "@trezor/node-utils": "workspace:^",
         "@trezor/utils": "workspace:*",
-        "socks-proxy-agent": "6.1.1"
+        "socks-proxy-agent": "8.0.4"
     },
     "devDependencies": {
         "ts-node": "^10.9.1",

--- a/packages/request-manager/src/torIdentities.ts
+++ b/packages/request-manager/src/torIdentities.ts
@@ -29,13 +29,11 @@ export class TorIdentities {
         const { host, port } = this.getTorSettings();
 
         // TODO clean agents when host/port changes?
-
         if (!this.identities[user]) {
-            this.identities[user] = new SocksProxyAgent({
-                hostname: host,
-                port,
-                userId: user,
-                password: password || user,
+            const socksServerUrl = new URL(`socks://${host}:${port}`);
+            socksServerUrl.username = user;
+            socksServerUrl.password = password;
+            this.identities[user] = new SocksProxyAgent(socksServerUrl, {
                 timeout,
             });
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11139,7 +11139,7 @@ __metadata:
     "@solana/web3.js": "npm:^1.95.0"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utxo-lib": "workspace:*"
-    socks-proxy-agent: "npm:6.1.1"
+    socks-proxy-agent: "npm:8.0.4"
     tsx: "npm:^4.16.3"
   peerDependencies:
     tslib: ^2.6.2
@@ -11180,7 +11180,7 @@ __metadata:
     fs-extra: "npm:^11.2.0"
     html-webpack-plugin: "npm:^5.6.0"
     ripple-lib: "npm:^1.10.1"
-    socks-proxy-agent: "npm:6.1.1"
+    socks-proxy-agent: "npm:8.0.4"
     tiny-worker: "npm:^2.3.0"
     tsx: "npm:^4.16.3"
     webpack: "npm:^5.94.0"
@@ -11763,7 +11763,7 @@ __metadata:
   dependencies:
     "@trezor/node-utils": "workspace:^"
     "@trezor/utils": "workspace:*"
-    socks-proxy-agent: "npm:6.1.1"
+    socks-proxy-agent: "npm:8.0.4"
     ts-node: "npm:^10.9.1"
     ws: "npm:^8.18.0"
   languageName: unknown
@@ -14759,12 +14759,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"agent-base@npm:^7.0.2, agent-base@npm:^7.1.0":
-  version: 7.1.0
-  resolution: "agent-base@npm:7.1.0"
+"agent-base@npm:^7.0.2, agent-base@npm:^7.1.0, agent-base@npm:^7.1.1":
+  version: 7.1.1
+  resolution: "agent-base@npm:7.1.1"
   dependencies:
     debug: "npm:^4.3.4"
-  checksum: 10/f7828f991470a0cc22cb579c86a18cbae83d8a3cbed39992ab34fc7217c4d126017f1c74d0ab66be87f71455318a8ea3e757d6a37881b8d0f2a2c6aa55e5418f
+  checksum: 10/c478fec8f79953f118704d007a38f2a185458853f5c45579b9669372bd0e12602e88dc2ad0233077831504f7cd6fcc8251c383375bba5eaaf563b102938bda26
   languageName: node
   linkType: hard
 
@@ -25977,6 +25977,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ip-address@npm:^9.0.5":
+  version: 9.0.5
+  resolution: "ip-address@npm:9.0.5"
+  dependencies:
+    jsbn: "npm:1.1.0"
+    sprintf-js: "npm:^1.1.3"
+  checksum: 10/1ed81e06721af012306329b31f532b5e24e00cb537be18ddc905a84f19fe8f83a09a1699862bf3a1ec4b9dea93c55a3fa5faf8b5ea380431469df540f38b092c
+  languageName: node
+  linkType: hard
+
 "ip-regex@npm:^2.1.0":
   version: 2.1.0
   resolution: "ip-regex@npm:2.1.0"
@@ -27706,6 +27716,13 @@ __metadata:
   version: 3.1.14
   resolution: "jsan@npm:3.1.14"
   checksum: 10/960cd5059bfb50a9c86d391d7bb5173eaf748e8a1b0794892d929f894045dbbdee61c03f1dad4d5b8fc21f924a8e217ed05598adf9339a56b46ab0433a2206f1
+  languageName: node
+  linkType: hard
+
+"jsbn@npm:1.1.0":
+  version: 1.1.0
+  resolution: "jsbn@npm:1.1.0"
+  checksum: 10/bebe7ae829bbd586ce8cbe83501dd8cb8c282c8902a8aeeed0a073a89dc37e8103b1244f3c6acd60278bcbfe12d93a3f83c9ac396868a3b3bbc3c5e5e3b648ef
   languageName: node
   linkType: hard
 
@@ -38474,14 +38491,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"socks-proxy-agent@npm:6.1.1":
-  version: 6.1.1
-  resolution: "socks-proxy-agent@npm:6.1.1"
+"socks-proxy-agent@npm:8.0.4":
+  version: 8.0.4
+  resolution: "socks-proxy-agent@npm:8.0.4"
   dependencies:
-    agent-base: "npm:^6.0.2"
-    debug: "npm:^4.3.1"
-    socks: "npm:^2.6.1"
-  checksum: 10/53fb7d34bf3e5ed9cf4de73bf5c18b351d75c4a8757a0c0e384c2a7c86adf688e5f5e8f72eee7bc6c01ff619458f621ccf9d172bc986adb05f10fa0c9599c39e
+    agent-base: "npm:^7.1.1"
+    debug: "npm:^4.3.4"
+    socks: "npm:^2.8.3"
+  checksum: 10/c8e7c2b398338b49a0a0f4d2bae5c0602aeeca6b478b99415927b6c5db349ca258448f2c87c6958ebf83eea17d42cbc5d1af0bfecb276cac10b9658b0f07f7d7
   languageName: node
   linkType: hard
 
@@ -38496,13 +38513,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"socks@npm:^2.6.1, socks@npm:^2.6.2":
-  version: 2.7.1
-  resolution: "socks@npm:2.7.1"
+"socks@npm:^2.6.2, socks@npm:^2.8.3":
+  version: 2.8.3
+  resolution: "socks@npm:2.8.3"
   dependencies:
-    ip: "npm:^2.0.0"
+    ip-address: "npm:^9.0.5"
     smart-buffer: "npm:^4.2.0"
-  checksum: 10/5074f7d6a13b3155fa655191df1c7e7a48ce3234b8ccf99afa2ccb56591c195e75e8bb78486f8e9ea8168e95a29573cbaad55b2b5e195160ae4d2ea6811ba833
+  checksum: 10/ffcb622c22481dfcd7589aae71fbfd71ca34334064d181df64bf8b7feaeee19706aba4cffd1de35cc7bbaeeaa0af96be2d7f40fcbc7bc0ab69533a7ae9ffc4fb
   languageName: node
   linkType: hard
 
@@ -38733,10 +38750,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sprintf-js@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "sprintf-js@npm:1.1.2"
-  checksum: 10/0044322a252b36bffc3d8a462a4882de57830e18d37d1cc000104ff4744b512d6a9b1ca6240e7ad141a987a1eaad071668fe12d11c496c11d3641c4797a6cf3f
+"sprintf-js@npm:^1.1.2, sprintf-js@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "sprintf-js@npm:1.1.3"
+  checksum: 10/e7587128c423f7e43cc625fe2f87e6affdf5ca51c1cc468e910d8aaca46bb44a7fbcfa552f787b1d3987f7043aeb4527d1b99559e6621e01b42b3f45e5a24cbb
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11139,7 +11139,6 @@ __metadata:
     "@solana/web3.js": "npm:^1.95.0"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utxo-lib": "workspace:*"
-    socks-proxy-agent: "npm:8.0.4"
     tsx: "npm:^4.16.3"
   peerDependencies:
     tslib: ^2.6.2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
update socks-proxy-agent from 6.1.1 to 8.0.4

* https://github.com/trezor/trezor-suite/pull/14202/commits/69ed9d5ade051c666e17f2a731df9f5b5b398108#diff-49f49f01ad60f5c7fc2414cb881d318ffe90f54838287ee5c847e6981fa12162L28 - Define type `SocksProxyAgentOptions` in order to keep the same API that we had before and not introduce breaking changes.
* https://github.com/trezor/trezor-suite/pull/14202/commits/933fab2e08a9af3ca66a5003df66b884fe5b6399#diff-fe77c9995deb7c750724b7d0de5b926f9942a35be2b8d3ae54eb2255a7aee63bR144 - transforming the previous API to the new one to work with new version o `SocksProxyAgent`.
## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/14179
