### PR TITLE
chore(transport-test): adjust usb api node fixture

### DIFF
--- a/packages/transport-test/e2e/api/api.test.ts
+++ b/packages/transport-test/e2e/api/api.test.ts
@@ -93,11 +93,10 @@ const runTests = async () => {
             });
         };
 
-        // interestingly, in node, concurrent enumeration does not work if triggered as the first interaction with connected device.
-        // concurrent enumeration triggered couple of lines below works correctly
+        // interestingly, in node, concurrent enumeration did not work if triggered as the first interaction with connected device.
+        // this had already been fixed. keeping the test here for reference.
         await sharedTest('concurrent enumerate - as the first operation', () =>
-            // todo: 3 doesn't work in node!!! FIX
-            concurrentEnumerate(typeof window !== 'undefined' ? 3 : 1),
+            concurrentEnumerate(3),
         );
         await getConnectedDevicePath();
 


### PR DESCRIPTION
after some of the recent changes node.js transport usb api tests it seems to work in the same way as their webusb counterpart.

yarn workspace @trezor/transport-test test:e2e:api:browser:hw