### PR TITLE
fix(coinmarket): coinmarket amount wrapper

### DIFF
--- a/packages/suite/src/views/wallet/coinmarket/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/index.tsx
@@ -4,7 +4,6 @@ import {
     SelectBar,
     Paragraph,
     TextButton,
-    H2,
     Card,
     Spinner,
     Icon,
@@ -227,12 +226,12 @@ export const CoinmarketAmountContainer = styled.div`
     }
 `;
 
-// eslint-disable-next-line local-rules/no-override-ds-component
-export const CoinmarketAmountWrapper = styled(H2)`
+export const CoinmarketAmountWrapper = styled.div`
     display: flex;
     align-items: center;
     flex-wrap: wrap;
     gap: ${spacingsPx.xs};
+    ${typography.titleMedium}
     line-height: unset;
 
     ${SCREEN_QUERY.BELOW_DESKTOP} {

--- a/packages/suite/src/views/wallet/coinmarket/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/index.tsx
@@ -233,6 +233,7 @@ export const CoinmarketAmountWrapper = styled.div`
     gap: ${spacingsPx.xs};
     ${typography.titleMedium}
     line-height: unset;
+    padding: ${spacingsPx.xxxs} ${spacingsPx.zero};
 
     ${SCREEN_QUERY.BELOW_DESKTOP} {
         font-size: 28px;
@@ -253,6 +254,7 @@ export const CoinmarketAmountWrapperText = styled.div`
     font-variant-numeric: tabular-nums;
     overflow: hidden;
     text-overflow: ellipsis;
+    line-height: 1;
 `;
 
 export const CoinmarketInfoLeftColumn = styled.div`


### PR DESCRIPTION
## Describe the bug
`You get` section on latest develop has a misplaced token icon. Also fixed cropped amount.

## Before
<img width="403" alt="Screenshot 2024-09-09 at 11 51 41" src="https://github.com/user-attachments/assets/11478ae9-3359-47ea-9d16-e4317e472862">
<img width="1123" alt="Screenshot 2024-09-09 at 11 44 46" src="https://github.com/user-attachments/assets/7845c082-9c96-4b9b-8eb1-823e76455e94">

![image](https://github.com/user-attachments/assets/688bdff6-4eb3-4e75-8673-594c81d958fa)

## After
![image](https://github.com/user-attachments/assets/3ca1a135-4759-4274-9e88-dc00283a47f8)
<img width="441" alt="obrazek" src="https://github.com/user-attachments/assets/7b4ea810-d17b-442c-a359-20817ca0adbf">



## Related Issue
Resolve https://github.com/trezor/trezor-suite/issues/14206
Resolve https://github.com/trezor/trezor-suite/issues/14306
