### PR TITLE
transport masked path

### DIFF
--- a/packages/transport-bridge/src/core.ts
+++ b/packages/transport-bridge/src/core.ts
@@ -138,7 +138,11 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
             return acquireIntentResult;
         }
 
-        const openDeviceResult = await api.openDevice(acquireInput.path, true, acquireInput.signal);
+        const openDeviceResult = await api.openDevice(
+            acquireIntentResult.payload.path,
+            true,
+            acquireInput.signal,
+        );
         logger?.debug(`core: openDevice: result: ${JSON.stringify(openDeviceResult)}`);
 
         if (!openDeviceResult.success) {

--- a/packages/transport-bridge/src/http.ts
+++ b/packages/transport-bridge/src/http.ts
@@ -12,7 +12,7 @@ import {
     RequestWithParams,
     Response,
 } from '@trezor/node-utils';
-import { Descriptor, Session } from '@trezor/transport/src/types';
+import { Descriptor, PathPublic, Session } from '@trezor/transport/src/types';
 import { validateProtocolMessage } from '@trezor/transport/src/utils/bridgeProtocolMessage';
 import { Log, arrayPartition, Throttler } from '@trezor/utils';
 import { AbstractApi } from '@trezor/transport/src/api/abstract';
@@ -36,11 +36,12 @@ const validateDescriptorsJSON: RequestHandler<JSON, Descriptor[]> = (request, re
 };
 
 const validateAcquireParams: ParamsValidatorHandler<{
-    path: string;
+    path: PathPublic;
     previous: Session | 'null';
 }> = (request, response, next) => {
     if (
         typeof request.params.path === 'string' &&
+        /^[1-9][0-9]*$/.test(request.params.path) &&
         typeof request.params.previous === 'string' &&
         /^\d+$|^null$/.test(request.params.previous)
     ) {

--- a/packages/transport-test/e2e/bridge/expect.ts
+++ b/packages/transport-test/e2e/bridge/expect.ts
@@ -14,11 +14,12 @@ const vendor = USE_HW ? 4617 : 0;
 const type = USE_NODE_BRIDGE ? expect.toBeOneOf(Object.values(DEVICE_TYPE)) : undefined;
 
 /**
+ * internal path has variable length
  * emu            '127.0.0.1:21324' (15)
- * hw old bridge  '1' (1)
  * hw new bridge  '185B982B5F37F9D96706EC49' (24)
+ * but it is masked using a growing sequence of numbers starting from 1
  */
-export const pathLength = USE_HW && USE_NODE_BRIDGE ? 24 : !USE_HW && USE_NODE_BRIDGE ? 15 : 1;
+export const pathLength = 1;
 
 export const descriptor = { debug, debugSession, path, product, vendor, type };
 

--- a/packages/transport/src/sessions/background.ts
+++ b/packages/transport/src/sessions/background.ts
@@ -22,11 +22,11 @@ import type {
     HandleMessageParams,
     HandleMessageResponse,
 } from './types';
-import type { Descriptor, Success } from '../types';
+import type { Descriptor, PathInternal, PathPublic, Success } from '../types';
 
 import * as ERRORS from '../errors';
 
-type DescriptorsDict = Record<string, Descriptor>;
+type DescriptorsDict = Record<PathInternal, Descriptor>;
 
 // in nodeusb, enumeration operation takes ~3 seconds
 const lockDuration = 1000 * 4;
@@ -42,11 +42,13 @@ export class SessionsBackground extends TypedEmitter<{
      * Dictionary where key is path and value is Descriptor
      */
     private descriptors: DescriptorsDict = {};
+    private pathInternalPathPublicMap: Record<PathInternal, PathPublic> = {};
 
     // if lock is set, somebody is doing something with device. we have to wait
     private locksQueue: { id: ReturnType<typeof setTimeout>; dfd: Deferred<void> }[] = [];
     private locksTimeoutQueue: ReturnType<typeof setTimeout>[] = [];
     private lastSessionId = 0;
+    private lastPathId = 0;
 
     public async handleMessage<M extends HandleMessageParams>(
         message: M,
@@ -95,6 +97,9 @@ export class SessionsBackground extends TypedEmitter<{
 
             return result;
         } catch (err) {
+            // if you are running this in a Sharedworker, you will find logs from here in chrome://inspect/#workers
+            console.error('Session background error', err);
+
             // catch unexpected errors and notify client.
             // background should never stay in "hanged" state
             return {
@@ -118,18 +123,25 @@ export class SessionsBackground extends TypedEmitter<{
      * - caller informs about current descriptors
      */
     private enumerateDone(payload: EnumerateDoneRequest) {
-        const disconnectedDevices = this.filterDisconnectedDevices(
-            Object.values(this.descriptors),
-            payload.descriptors.map(d => d.path), // which paths are occupied paths after last interface read
+        const disconnectedDevices = Object.keys(this.descriptors).filter(
+            pathInternal => !payload.descriptors.find(d => d.path === pathInternal),
         );
 
         disconnectedDevices.forEach(d => {
-            delete this.descriptors[d.path];
+            delete this.descriptors[d];
+            delete this.pathInternalPathPublicMap[d];
         });
 
         payload.descriptors.forEach(d => {
+            if (!this.pathInternalPathPublicMap[d.path]) {
+                this.pathInternalPathPublicMap[d.path] = `${(this.lastPathId += 1)}`;
+            }
             if (!this.descriptors[d.path]) {
-                this.descriptors[d.path] = { ...d, session: null };
+                this.descriptors[d.path] = {
+                    ...d,
+                    path: this.pathInternalPathPublicMap[d.path],
+                    session: null,
+                };
             }
         });
 
@@ -144,20 +156,26 @@ export class SessionsBackground extends TypedEmitter<{
      * acquire intent
      */
     private async acquireIntent(payload: AcquireIntentRequest) {
-        const previous = this.descriptors[payload.path]?.session;
+        const pathInternal = this.getInternal(payload.path);
+
+        if (!pathInternal) {
+            return this.error(ERRORS.DESCRIPTOR_NOT_FOUND);
+        }
+
+        const previous = this.descriptors[pathInternal]?.session;
 
         if (payload.previous && payload.previous !== previous) {
             return this.error(ERRORS.SESSION_WRONG_PREVIOUS);
         }
 
-        if (!this.descriptors[payload.path]) {
+        if (!this.descriptors[pathInternal]) {
             return this.error(ERRORS.DESCRIPTOR_NOT_FOUND);
         }
 
         await this.waitInQueue();
 
         // in case there are 2 simultaneous acquireIntents, one goes through, the other one waits and gets error here
-        if (previous !== this.descriptors[payload.path]?.session) {
+        if (previous !== this.descriptors[pathInternal]?.session) {
             this.clearLock();
 
             return this.error(ERRORS.SESSION_WRONG_PREVIOUS);
@@ -168,10 +186,11 @@ export class SessionsBackground extends TypedEmitter<{
         const unconfirmedSessions: DescriptorsDict = JSON.parse(JSON.stringify(this.descriptors));
 
         this.lastSessionId++;
-        unconfirmedSessions[payload.path].session = `${this.lastSessionId}`;
+        unconfirmedSessions[pathInternal].session = `${this.lastSessionId}`;
 
         return this.success({
-            session: unconfirmedSessions[payload.path].session,
+            session: unconfirmedSessions[pathInternal].session,
+            path: pathInternal,
             descriptors: Object.values(unconfirmedSessions),
         });
     }
@@ -182,10 +201,12 @@ export class SessionsBackground extends TypedEmitter<{
      */
     private acquireDone(payload: AcquireDoneRequest) {
         this.clearLock();
-        if (!this.descriptors[payload.path]) {
+        const pathInternal = this.getInternal(payload.path);
+
+        if (!pathInternal || !this.descriptors[pathInternal]) {
             return this.error(ERRORS.DESCRIPTOR_NOT_FOUND);
         }
-        this.descriptors[payload.path].session = `${this.lastSessionId}`;
+        this.descriptors[pathInternal].session = `${this.lastSessionId}`;
 
         return Promise.resolve(
             this.success({
@@ -220,12 +241,9 @@ export class SessionsBackground extends TypedEmitter<{
     }
 
     private getPathBySession({ session }: GetPathBySessionRequest) {
-        let path: string | undefined;
-        Object.keys(this.descriptors).forEach(pathKey => {
-            if (this.descriptors[pathKey]?.session === session) {
-                path = pathKey;
-            }
-        });
+        const path = Object.keys(this.descriptors).find(
+            pathKey => this.descriptors[pathKey]?.session === session,
+        );
 
         if (!path) {
             return this.error(ERRORS.SESSION_NOT_FOUND);
@@ -276,10 +294,6 @@ export class SessionsBackground extends TypedEmitter<{
         await this.waitForUnlocked(myIndex);
     }
 
-    private filterDisconnectedDevices(prevDevices: Descriptor[], paths: string[]) {
-        return prevDevices.filter(d => !paths.find(p => d.path === p));
-    }
-
     private success<T>(payload: T): Success<T> {
         return {
             success: true as const,
@@ -292,6 +306,12 @@ export class SessionsBackground extends TypedEmitter<{
             success: false as const,
             error,
         };
+    }
+
+    private getInternal(pathPublic: PathPublic): PathInternal | undefined {
+        return Object.keys(this.pathInternalPathPublicMap).find(
+            internal => this.pathInternalPathPublicMap[internal] === pathPublic,
+        );
     }
 
     dispose() {

--- a/packages/transport/src/sessions/types.ts
+++ b/packages/transport/src/sessions/types.ts
@@ -5,6 +5,8 @@ import type {
     ResultWithTypedError,
     Session,
     Success,
+    PathPublic,
+    PathInternal,
 } from '../types';
 import * as ERRORS from '../errors';
 
@@ -25,12 +27,12 @@ export type EnumerateDoneResponse = BackgroundResponse<{
 export type AcquireIntentRequest = AcquireInput;
 
 export type AcquireIntentResponse = BackgroundResponseWithError<
-    { session: Session },
+    { session: Session; path: PathInternal },
     typeof ERRORS.SESSION_WRONG_PREVIOUS | typeof ERRORS.DESCRIPTOR_NOT_FOUND
 >;
 
 export type AcquireDoneRequest = {
-    path: string;
+    path: PathPublic;
 };
 
 export type AcquireDoneResponse = BackgroundResponseWithError<
@@ -45,12 +47,12 @@ export interface ReleaseIntentRequest {
 }
 
 export type ReleaseIntentResponse = BackgroundResponseWithError<
-    { path: string },
+    { path: PathInternal },
     typeof ERRORS.SESSION_NOT_FOUND
 >;
 
 export interface ReleaseDoneRequest {
-    path: string;
+    path: PathInternal;
 }
 
 export type ReleaseDoneResponse = BackgroundResponse<{
@@ -67,7 +69,7 @@ export interface GetPathBySessionRequest {
 
 export type GetPathBySessionResponse = BackgroundResponseWithError<
     {
-        path: string;
+        path: PathInternal;
     },
     typeof ERRORS.SESSION_NOT_FOUND
 >;

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -19,6 +19,7 @@ import {
     Success,
     AnyError,
     Logger,
+    PathPublic,
 } from '../types';
 import { success, error, unknownError } from '../utils/result';
 
@@ -26,12 +27,12 @@ import * as ERRORS from '../errors';
 import { ACTION_TIMEOUT, TRANSPORT } from '../constants';
 
 export type AcquireInput = {
-    path: string;
+    path: PathPublic;
     previous: Session | null;
 };
 
 export type ReleaseInput = {
-    path: string;
+    path: PathPublic;
     session: Session;
     onClose?: boolean;
 };

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -112,7 +112,11 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                 this.acquiredUnconfirmed[path] = acquireIntentResponse.payload.session;
 
                 const reset = !!input.previous;
-                const openDeviceResult = await this.api.openDevice(path, reset, signal);
+                const openDeviceResult = await this.api.openDevice(
+                    acquireIntentResponse.payload.path,
+                    reset,
+                    signal,
+                );
 
                 if (!openDeviceResult.success) {
                     if (this.listenPromise[path]) {

--- a/packages/transport/src/types/index.ts
+++ b/packages/transport/src/types/index.ts
@@ -4,8 +4,11 @@ export * from './apiCall';
 
 export type Session = `${number}`;
 
+export type PathInternal = string;
+export type PathPublic = `${number}`;
+
 export type DescriptorApiLevel = {
-    path: string;
+    path: PathInternal;
     /** only used in status page */
     type: DEVICE_TYPE;
     /** only important for T1 over old bridge (trezord-go), defacto part of 'path'. More explanation in https://github.com/trezor/trezor-suite/compare/transport-descriptor-product */
@@ -14,7 +17,8 @@ export type DescriptorApiLevel = {
     vendor?: number;
 };
 
-export type Descriptor = DescriptorApiLevel & {
+export type Descriptor = Omit<DescriptorApiLevel, 'path'> & {
+    path: PathPublic;
     session: null | Session;
     /** only reported by old bridge */
     debugSession?: null | Session;

--- a/packages/transport/tests/abstractUsb.test.ts
+++ b/packages/transport/tests/abstractUsb.test.ts
@@ -202,14 +202,14 @@ describe('Usb', () => {
                 success: true,
                 payload: [
                     {
-                        path: '123',
+                        path: '1',
                         session: null,
                         type: 1,
                         product: 21441,
                         vendor: 4617,
                     },
                     {
-                        path: 'bootloader1',
+                        path: '2',
                         session: null,
                         type: 1,
                         product: 21441,
@@ -230,7 +230,7 @@ describe('Usb', () => {
 
             jest.runAllTimers();
 
-            const result = await transport.acquire({ input: { path: '123', previous: null } });
+            const result = await transport.acquire({ input: { path: '1', previous: null } });
             expect(result).toEqual({
                 success: true,
                 payload: '1',
@@ -254,7 +254,7 @@ describe('Usb', () => {
             transport.listen();
 
             // set some initial descriptors
-            const acquireCall = transport.acquire({ input: { path: '123', previous: null } });
+            const acquireCall = transport.acquire({ input: { path: '1', previous: null } });
 
             setTimeout(() => {
                 sessionsClient.emit('descriptors', [{ path: '321', session: '1', type: 1 }]);
@@ -280,10 +280,10 @@ describe('Usb', () => {
             transport.listen();
 
             // set some initial descriptors
-            const acquireCall = transport.acquire({ input: { path: '123', previous: null } });
+            const acquireCall = transport.acquire({ input: { path: '1', previous: null } });
             setTimeout(() => {
                 sessionsClient.emit('descriptors', [
-                    { path: '123', session: '2', type: 1, product: 21441 },
+                    { path: '1', session: '2', type: 1, product: 21441 },
                 ]);
             }, 1);
 
@@ -307,7 +307,7 @@ describe('Usb', () => {
         it('call - with valid and invalid message.', async () => {
             const { transport, sessionsBackground } = await initTest();
             await transport.enumerate();
-            const acquireRes = await transport.acquire({ input: { path: '123', previous: null } });
+            const acquireRes = await transport.acquire({ input: { path: '1', previous: null } });
             expect(acquireRes.success).toEqual(true);
             if (!acquireRes.success) return;
 
@@ -350,7 +350,7 @@ describe('Usb', () => {
         it('send and receive.', async () => {
             const { transport, sessionsBackground } = await initTest();
             await transport.enumerate();
-            const acquireRes = await transport.acquire({ input: { path: '123', previous: null } });
+            const acquireRes = await transport.acquire({ input: { path: '1', previous: null } });
             expect(acquireRes.success).toEqual(true);
             if (!acquireRes.success) return;
 
@@ -386,7 +386,7 @@ describe('Usb', () => {
         it('send protocol-v1 with custom chunkSize', async () => {
             const { transport, testUsbApi, sessionsBackground } = await initTest();
             await transport.enumerate();
-            const acquireRes = await transport.acquire({ input: { path: '123', previous: null } });
+            const acquireRes = await transport.acquire({ input: { path: '1', previous: null } });
             expect(acquireRes.success).toEqual(true);
             if (!acquireRes.success) return;
 
@@ -424,7 +424,7 @@ describe('Usb', () => {
         it('release', async () => {
             const { transport, sessionsBackground } = await initTest();
             await transport.enumerate();
-            const acquireRes = await transport.acquire({ input: { path: '123', previous: null } });
+            const acquireRes = await transport.acquire({ input: { path: '1', previous: null } });
             expect(acquireRes.success).toEqual(true);
             if (!acquireRes.success) return;
 
@@ -446,7 +446,7 @@ describe('Usb', () => {
         it('call - with use abort', async () => {
             const { transport, sessionsBackground } = await initTest();
             await transport.enumerate();
-            const acquireRes = await transport.acquire({ input: { path: '123', previous: null } });
+            const acquireRes = await transport.acquire({ input: { path: '1', previous: null } });
             if (!acquireRes.success) return;
 
             const abort = new AbortController();

--- a/packages/transport/tests/sessions.test.ts
+++ b/packages/transport/tests/sessions.test.ts
@@ -26,7 +26,7 @@ describe('sessions', () => {
         const client1 = new SessionsClient({ requestFn });
         await client1.handshake();
 
-        await client1.enumerateDone({ descriptors: [{ path: '1', type: 1 }] });
+        await client1.enumerateDone({ descriptors: [{ path: 'abc', type: 1 }] });
 
         const acquireIntent = await client1.acquireIntent({ path: '1', previous: null });
 
@@ -35,9 +35,10 @@ describe('sessions', () => {
             id: 2,
             payload: {
                 session: '1',
+                path: 'abc', // <= pathInternal
                 descriptors: [
                     {
-                        path: '1',
+                        path: '1', // <= pathPublic
                         session: '1',
                         type: 1,
                     },


### PR DESCRIPTION
follow-up after #14126 and #14143 in the branch of quests that should result in having 0 differences between old and new bridge API. 

This time it is about masking the device serial number with a plain `${number}` placeholder, originally probably as a countermeasure against sniffing/tracking for Trezors by malicious software installed in users' computers.

In some very wild scenarios, this could also affect #13780
I wanted to test whether it still works with multiple devices connected but I apparently broke it recently see #14221

before: 
<img width="396" alt="image" src="https://github.com/user-attachments/assets/189571be-c9d0-4849-a448-26a4339daa66">

after: 
<img width="441" alt="image" src="https://github.com/user-attachments/assets/0976b6d5-85b1-4f0e-b79b-d3966d74e287">
