### PR TITLE
Passphrase flow checks device for empty and not for visible accounts

### DIFF
--- a/suite-native/device-manager/src/components/PortfolioTrackerDeviceManagerContent.tsx
+++ b/suite-native/device-manager/src/components/PortfolioTrackerDeviceManagerContent.tsx
@@ -11,7 +11,7 @@ import {
     RootStackRoutes,
     StackToStackCompositeNavigationProps,
 } from '@suite-native/navigation';
-import { selectIsEmptyDevice } from '@suite-common/wallet-core';
+import { selectIsDiscoveredDeviceAccountless } from '@suite-common/wallet-core';
 import { useOpenLink } from '@suite-native/link';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
@@ -37,7 +37,7 @@ export const PortfolioTrackerDeviceManagerContent = () => {
     const openLink = useOpenLink();
     const { applyStyle } = useNativeStyles();
 
-    const isEmptyDevice = useSelector(selectIsEmptyDevice);
+    const isDiscoveredDeviceAccountless = useSelector(selectIsDiscoveredDeviceAccountless);
 
     const navigation = useNavigation<NavigationProp>();
 
@@ -73,7 +73,7 @@ export const PortfolioTrackerDeviceManagerContent = () => {
     const syncButtonTitle = (
         <Translation
             id={
-                isEmptyDevice
+                isDiscoveredDeviceAccountless
                     ? 'deviceManager.syncCoinsButton.syncMyCoins'
                     : 'deviceManager.syncCoinsButton.syncAnother'
             }

--- a/suite-native/device/src/selectors.ts
+++ b/suite-native/device/src/selectors.ts
@@ -13,7 +13,7 @@ import {
     selectDeviceModel,
     selectIsConnectedDeviceUninitialized,
     selectIsDeviceConnectedAndAuthorized,
-    selectIsEmptyDevice,
+    selectIsDiscoveredDeviceAccountless,
     selectIsUnacquiredDevice,
     PORTFOLIO_TRACKER_DEVICE_ID,
     selectDevices,
@@ -45,9 +45,9 @@ export const selectIsDeviceReadyToUseAndAuthorized = (
 ) => {
     const isDeviceReadyToUse = selectIsDeviceReadyToUse(state);
     const isDeviceConnectedAndAuthorized = selectIsDeviceConnectedAndAuthorized(state);
-    const isEmptyDevice = selectIsEmptyDevice(state);
+    const isDiscoveredDeviceAccountless = selectIsDiscoveredDeviceAccountless(state);
 
-    return isDeviceReadyToUse && isDeviceConnectedAndAuthorized && !isEmptyDevice;
+    return isDeviceReadyToUse && isDeviceConnectedAndAuthorized && !isDiscoveredDeviceAccountless;
 };
 
 export const selectDeviceError = (

--- a/suite-native/module-authorize-device/src/screens/passphrase/PassphraseLoadingScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/passphrase/PassphraseLoadingScreen.tsx
@@ -11,10 +11,7 @@ import {
     RootStackRoutes,
     StackToStackCompositeNavigationProps,
 } from '@suite-native/navigation';
-import {
-    selectIsDeviceAccountless,
-    selectIsDeviceDiscoveryActive,
-} from '@suite-common/wallet-core';
+import { selectIsDeviceNotEmpty, selectIsDeviceDiscoveryActive } from '@suite-common/wallet-core';
 import { Translation } from '@suite-native/intl';
 import { finishPassphraseFlow } from '@suite-native/device-authorization';
 import { EventType, analytics } from '@suite-native/analytics';
@@ -32,27 +29,25 @@ export const PassphraseLoadingScreen = () => {
 
     const dispatch = useDispatch();
 
-    const isDeviceAccountless = useSelector(selectIsDeviceAccountless);
+    const isDeviceNotEmpty = useSelector(selectIsDeviceNotEmpty);
     const isDiscoveryActive = useSelector(selectIsDeviceDiscoveryActive);
 
     const [loadingResult, setLoadingResult] = useState<SpinnerLoadingState>('idle');
 
     useEffect(() => {
-        if (!isDeviceAccountless || (isDeviceAccountless && !isDiscoveryActive)) {
+        if (!isDiscoveryActive && isDeviceNotEmpty !== null) {
             setLoadingResult('success');
         }
-    }, [isDeviceAccountless, isDiscoveryActive]);
+    }, [isDiscoveryActive, isDeviceNotEmpty]);
 
     const handleSuccess = () => {
-        if (!isDeviceAccountless) {
-            setLoadingResult('success');
+        if (isDeviceNotEmpty) {
             analytics.report({
                 type: EventType.PassphraseFlowFinished,
                 payload: { isEmptyWallet: false },
             });
             dispatch(finishPassphraseFlow());
-        } else if (isDeviceAccountless && !isDiscoveryActive) {
-            setLoadingResult('success');
+        } else {
             navigation.navigate(RootStackRoutes.AuthorizeDeviceStack, {
                 screen: AuthorizeDeviceStackRoutes.PassphraseEmptyWallet,
             });

--- a/suite-native/module-home/src/screens/HomeScreen/HomeScreen.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/HomeScreen.tsx
@@ -2,10 +2,10 @@ import { useRef } from 'react';
 import { useSelector } from 'react-redux';
 
 import {
-    selectIsEmptyDevice,
     selectIsDeviceAuthorized,
     selectDeviceAuthFailed,
     selectIsDeviceUnlocked,
+    selectIsDiscoveredDeviceAccountless,
 } from '@suite-common/wallet-core';
 import { DeviceManagerScreenHeader } from '@suite-native/device-manager';
 import { Screen } from '@suite-native/navigation';
@@ -19,19 +19,19 @@ import { EnableViewOnlyBottomSheet } from './components/EnableViewOnlyBottomShee
 import { PortfolioGraphRef } from './components/PortfolioGraph';
 
 export const HomeScreen = () => {
-    const isEmptyDevice = useSelector(selectIsEmptyDevice);
+    const isDiscoveredDeviceAccountless = useSelector(selectIsDiscoveredDeviceAccountless);
     const isDeviceAuthorized = useSelector(selectIsDeviceAuthorized);
     const isDeviceAuthFailed = useSelector(selectDeviceAuthFailed);
     const isDeviceUnlocked = useSelector(selectIsDeviceUnlocked);
     const isEmptyHomeRendererShown =
-        isEmptyDevice && // There has to be no accounts and discovery not active.
+        isDiscoveredDeviceAccountless && // There has to be no accounts and discovery not active.
         (isDeviceAuthorized || // Initial state is empty portfolio device, that is authorized.
             isDeviceAuthFailed || // When user click cancel on PIN entry or it fails from other reason.
             !isDeviceUnlocked); // When user click cancel, it takes some time before isDeviceAuthFailed is set.
 
     const portfolioContentRef = useRef<PortfolioGraphRef>(null);
     const refreshControl = useHomeRefreshControl({
-        isEmptyDevice,
+        isDiscoveredDeviceAccountless,
         portfolioContentRef,
     });
 

--- a/suite-native/module-home/src/screens/HomeScreen/useHomeRefreshControl.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/useHomeRefreshControl.tsx
@@ -8,10 +8,10 @@ import { useNativeStyles } from '@trezor/styles';
 import { PortfolioGraphRef } from './components/PortfolioGraph';
 
 export const useHomeRefreshControl = ({
-    isEmptyDevice,
+    isDiscoveredDeviceAccountless,
     portfolioContentRef,
 }: {
-    isEmptyDevice: boolean;
+    isDiscoveredDeviceAccountless: boolean;
     portfolioContentRef: React.MutableRefObject<PortfolioGraphRef | null>;
 }) => {
     const [isRefreshing, setIsRefreshing] = useState(false);
@@ -34,7 +34,7 @@ export const useHomeRefreshControl = ({
     }, [dispatch, portfolioContentRef]);
 
     const refreshControl = useMemo(() => {
-        if (isEmptyDevice) return undefined;
+        if (isDiscoveredDeviceAccountless) return undefined;
 
         return (
             <RefreshControl
@@ -43,7 +43,7 @@ export const useHomeRefreshControl = ({
                 colors={[colors.backgroundPrimaryDefault]}
             />
         );
-    }, [isEmptyDevice, handleRefresh, colors, isRefreshing]);
+    }, [isDiscoveredDeviceAccountless, handleRefresh, colors, isRefreshing]);
 
     return refreshControl;
 };


### PR DESCRIPTION
- Passphrase flow previously checked accounts visibility, now it checks if account is empty instead.
- I also renamed `selectIsEmptyDevice` to `selectIsDiscoveredAccountlessDevice` because that is what it actually returns.

Resolve #14208

## Screenshots:
https://github.com/user-attachments/assets/300c2a20-f02b-4d33-b966-a8c13cbfa900


