### PR TITLE
fix(suite): fix symbol formatting of review txs value

### DIFF
--- a/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
+++ b/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
@@ -89,7 +89,12 @@ export const FormattedCryptoAmount = ({
         <Container className={className}>
             {!!signValue && <Sign value={signValue} />}
             <Value data-testid={dataTest}>{formattedValue}</Value>
-            {formattedSymbol && <BlurUrls text={'\u00A0' + formattedSymbol} />}
+            {formattedSymbol && (
+                <>
+                    {' '}
+                    <BlurUrls text={formattedSymbol} />
+                </>
+            )}
         </Container>
     );
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
@@ -70,7 +70,6 @@ const Headline = styled.div`
     font-size: 16px;
     font-weight: 600;
     margin-top: 20px;
-    word-break: break-all;
 `;
 
 const AccountWrapper = styled.div`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix wrapping of Coin/Token symbol when reviewing a transaction. This is a follow up PR on #14200.

## Related Issue

Resolve #13603.

## Screenshots:

before:
<img width="864" alt="image" src="https://github.com/user-attachments/assets/1fda6ce6-0a5f-4578-a827-c2de45ce4be9">


after changes:
<img width="865" alt="image" src="https://github.com/user-attachments/assets/d3100cb2-8496-4b7a-ae21-ca78f127cda2">
