### PR TITLE
Display warning if the address entered in Send Form is a contract address. Ethereum  mainnet only.

### DIFF
--- a/packages/components/src/components/form/BottomText.tsx
+++ b/packages/components/src/components/form/BottomText.tsx
@@ -60,7 +60,7 @@ export const BottomText = ({
                     (iconName && (
                         <Icon name={iconName} size="medium" variant={variant as IconVariant} />
                     ))}
-                <Text variant={variant as TextVariant} typographyStyle="hint" as="div">
+                <Text variant={variant as TextVariant} typographyStyle="hint" as="div" flex="auto">
                     {children}
                 </Text>
             </Row>

--- a/packages/suite/src/components/wallet/Fees/CustomFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/CustomFee.tsx
@@ -166,7 +166,7 @@ export const CustomFee = <TFieldValues extends FormState>({
                             feeLimitError?.message ? (
                                 <InputError
                                     message={feeLimitError?.message}
-                                    button={validationButtonProps}
+                                    buttonProps={validationButtonProps}
                                 />
                             ) : null
                         }

--- a/packages/suite/src/components/wallet/InputError.tsx
+++ b/packages/suite/src/components/wallet/InputError.tsx
@@ -7,23 +7,23 @@ import { spacings } from '@trezor/theme';
 import { LearnMoreButton } from '../suite/LearnMoreButton';
 
 type ButtonProps = { onClick: MouseEventHandler<HTMLButtonElement>; text: string };
-type LinkProps = { url: Url };
 
 export type InputErrorProps = {
-    button?: ButtonProps | LinkProps;
+    buttonProps?: ButtonProps;
+    learnMoreUrl?: Url;
     message?: string;
 };
 
-export const InputError = ({ button, message }: InputErrorProps) => (
+export const InputError = ({ buttonProps, learnMoreUrl, message }: InputErrorProps) => (
     <Row gap={spacings.xs} justifyContent="space-between" flex="1">
-        <Paragraph>{message}</Paragraph>
-        {button &&
-            ('url' in button ? (
-                <LearnMoreButton url={button.url} />
-            ) : (
-                <Button size="tiny" variant="tertiary" onClick={button.onClick} textWrap={false}>
-                    {button.text}
-                </Button>
-            ))}
+        <Row gap={spacings.xs}>
+            <Paragraph>{message}</Paragraph>
+            {learnMoreUrl && <LearnMoreButton url={learnMoreUrl} />}
+        </Row>
+        {buttonProps?.text && (
+            <Button size="tiny" variant="tertiary" onClick={buttonProps.onClick}>
+                {buttonProps.text}
+            </Button>
+        )}
     </Row>
 );

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2036,6 +2036,14 @@ export default defineMessages({
         defaultMessage: 'Unable to verify address history. Check that the address is correct.',
         id: 'TR_ETH_ADDRESS_CANT_VERIFY_HISTORY',
     },
+    TR_EVM_ADDRESS_IS_CONTRACT: {
+        defaultMessage: 'You are sending funds to a contract address.',
+        id: 'TR_EVM_ADDRESS_IS_CONTRACT',
+    },
+    TR_I_UNDERSTAND_THE_RISK: {
+        defaultMessage: 'I understand',
+        id: 'TR_I_UNDERSTAND_THE_RISK',
+    },
     TR_NEEDS_ATTENTION_BOOTLOADER: {
         defaultMessage: 'Trezor is in Bootloader mode.',
         id: 'TR_NEEDS_ATTENTION_BOOTLOADER',

--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -107,6 +107,8 @@ export const HELP_CENTER_TRANSACTION_FEES_URL: Url =
     'https://trezor.io/learn/a/transaction-fees-in-trezor-suite';
 export const HELP_CENTER_EVM_ADDRESS_CHECKSUM: Url =
     'https://trezor.io/learn/a/evm-address-checksum-in-trezor-suite';
+export const HELP_CENTER_EVM_SEND_TO_CONTRACT_URL =
+    'https://trezor.io/support/a/where-is-my-ethereum';
 export const HELP_CENTER_FIRMWARE_REVISION_CHECK: Url =
     'https://trezor.io/learn/a/trezor-firmware-revision-check';
 export const HELP_CENTER_REPLACE_BY_FEE: Url =

--- a/suite-common/wallet-utils/src/validationUtils.ts
+++ b/suite-common/wallet-utils/src/validationUtils.ts
@@ -1,6 +1,11 @@
+import { UseFormSetValue } from 'react-hook-form';
+
+import { toChecksumAddress } from 'web3-utils';
+
 import addressValidator from '@trezor/address-validator';
 import { getTestnetSymbols } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
+import { AccountInfo } from '@trezor/blockchain-link-types';
 
 const getNetworkType = (symbol: Account['symbol']) => {
     if (symbol === 'regtest') return symbol;
@@ -86,4 +91,27 @@ export const isHexValid = (value: string, prefix?: string) => {
     if (!/^[0-9A-Fa-f]+$/.test(value)) return false;
 
     return true;
+};
+
+export const checkIsAddressNotUsedNotChecksummed = (
+    address: string,
+    history: AccountInfo['history'],
+    inputName: string,
+    setValue: UseFormSetValue<any>,
+    setHasAddressChecksummed: (value: boolean) => void,
+) => {
+    const hasHistory = history.total !== 0;
+
+    if (hasHistory) {
+        setValue(inputName, toChecksumAddress(address), { shouldValidate: true });
+        setHasAddressChecksummed(true);
+
+        return false;
+    }
+
+    if (!hasHistory && address === address.toLowerCase()) {
+        return true;
+    }
+
+    return false;
 };


### PR DESCRIPTION
## Description

Implemented only on Ethereum mainnet accounts. 
If the user enters a contract address, he can proceed with sending only after pressing the "I understand the risk" button

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/7244

## Screenshots:

<img width="735" alt="Screenshot 2024-12-16 at 15 01 13" src="https://github.com/user-attachments/assets/322f85f6-2379-499e-82d0-6a66f1d5fb18" />


