### PR TITLE
fix(suite-native): after coin enabling is enabled, show relevant normal accounts

### DIFF
--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -287,6 +287,16 @@ export const selectAccountsByNetworkAndDeviceState = memoizeWithArgs(
     },
 );
 
+export const selectFirstNormalAccountForNetworkSymbol = memoizeWithArgs(
+    (state: AccountsRootState & DeviceRootState, networkSymbol: NetworkSymbol) =>
+        selectDeviceAccountsForNetworkSymbolAndAccountType(state, networkSymbol, 'normal').filter(
+            account => account.index === 0,
+        )[0] ?? null,
+    {
+        size: Object.keys(networks).length,
+    },
+);
+
 export const selectAccountLabel = (
     state: AccountsRootState,
     accountKey?: AccountKey,


### PR DESCRIPTION
When checking for discovery updates, make sure that first normal account is visible for enabled networks when coin enabling is active.

This might be needed in case user has View only device from before coin enabling was active in such case the first normal account can be invisible. We need to make it visible.

## Related Issue

Resolve #14225
