### PR TITLE
fix(coinmarket): send and verify modals

### DIFF
--- a/packages/suite/src/actions/wallet/coinmarket/coinmarketCommonActions.ts
+++ b/packages/suite/src/actions/wallet/coinmarket/coinmarketCommonActions.ts
@@ -42,12 +42,28 @@ export type CoinmarketCommonAction =
     | {
           type: typeof COINMARKET_COMMON.SET_MODAL_CRYPTO_CURRENCY;
           modalCryptoId: CryptoId | undefined;
+      }
+    | {
+          type: typeof COINMARKET_COMMON.SET_MODAL_ACCOUNT;
+          modalAccount: Account | undefined;
       };
 
 type FormState = {
     cryptoInput?: string;
     outputs?: Output[];
 };
+
+/**
+ * Set modalAccount to retrieve the correct account in modals.
+ * Used in ConfirmAddressModal and TransactionReviewModalContent through selectAccountIncludingChosenInCoinmarket.
+ * Unset in middleware after modal is closed.
+ */
+export const setCoinmarketModalAccount = (
+    modalAccount: Account | undefined,
+): CoinmarketCommonAction => ({
+    type: COINMARKET_COMMON.SET_MODAL_ACCOUNT,
+    modalAccount,
+});
 
 export const verifyAddress =
     (
@@ -65,6 +81,8 @@ export const verifyAddress =
         address = address ?? accountAddress.address;
         path = path ?? accountAddress.path;
         if (!path || !address) return;
+
+        dispatch(setCoinmarketModalAccount(account));
 
         const addressDisplayType = selectAddressDisplayType(getState());
 

--- a/packages/suite/src/actions/wallet/coinmarketExchangeActions.ts
+++ b/packages/suite/src/actions/wallet/coinmarketExchangeActions.ts
@@ -36,7 +36,7 @@ export type CoinmarketExchangeAction =
           quote: ExchangeTrade | undefined;
       }
     | { type: typeof COINMARKET_EXCHANGE.CLEAR_QUOTES }
-    | { type: typeof COINMARKET_EXCHANGE.SET_COINMARKET_ACCOUNT; account: Account }
+    | { type: typeof COINMARKET_EXCHANGE.SET_COINMARKET_ACCOUNT; account: Account | undefined }
     | {
           type: typeof COINMARKET_COMMON.SAVE_TRADE;
           date: string;
@@ -148,7 +148,9 @@ export const clearQuotes = (): CoinmarketExchangeAction => ({
 export const verifyAddress = (account: Account, address?: string, path?: string) =>
     verifyExchangeAddress(account, address, path, COINMARKET_EXCHANGE.VERIFY_ADDRESS);
 
-export const setCoinmarketExchangeAccount = (account: Account): CoinmarketExchangeAction => ({
+export const setCoinmarketExchangeAccount = (
+    account: Account | undefined,
+): CoinmarketExchangeAction => ({
     type: COINMARKET_EXCHANGE.SET_COINMARKET_ACCOUNT,
     account,
 });

--- a/packages/suite/src/actions/wallet/coinmarketSellActions.ts
+++ b/packages/suite/src/actions/wallet/coinmarketSellActions.ts
@@ -23,7 +23,7 @@ export type CoinmarketSellAction =
     | { type: typeof COINMARKET_SELL.SAVE_QUOTE_REQUEST; request: SellFiatTradeQuoteRequest }
     | { type: typeof COINMARKET_SELL.SAVE_TRANSACTION_ID; transactionId?: string }
     | { type: typeof COINMARKET_SELL.SET_IS_FROM_REDIRECT; isFromRedirect: boolean }
-    | { type: typeof COINMARKET_SELL.SET_COINMARKET_ACCOUNT; account: Account }
+    | { type: typeof COINMARKET_SELL.SET_COINMARKET_ACCOUNT; account: Account | undefined }
     | {
           type: typeof COINMARKET_SELL.SAVE_QUOTES;
           quotes: SellFiatTrade[];
@@ -126,7 +126,7 @@ export const setIsFromRedirect = (isFromRedirect: boolean): CoinmarketSellAction
     isFromRedirect,
 });
 
-export const setCoinmarketSellAccount = (account: Account): CoinmarketSellAction => ({
+export const setCoinmarketSellAccount = (account: Account | undefined): CoinmarketSellAction => ({
     type: COINMARKET_SELL.SET_COINMARKET_ACCOUNT,
     account,
 });

--- a/packages/suite/src/actions/wallet/constants/coinmarketCommonConstants.ts
+++ b/packages/suite/src/actions/wallet/constants/coinmarketCommonConstants.ts
@@ -3,3 +3,4 @@ export const SAVE_TRADE = '@coinmarket-common/save_trade';
 export const LOAD_DATA = '@coinmarket-common/load_data';
 export const SET_LOADING = '@coinmarket-common/set_loading';
 export const SET_MODAL_CRYPTO_CURRENCY = '@coinmarket-common/set_modal_crypto_currency';
+export const SET_MODAL_ACCOUNT = '@coinmarket-common/set_modal_account';

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
@@ -7,7 +7,7 @@ import {
 } from 'src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal';
 import { useDisplayMode, useSelector } from 'src/hooks/suite';
 import { useCoinmarketInfo } from 'src/hooks/wallet/coinmarket/useCoinmarketInfo';
-import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
+import { selectAccountIncludingChosenInCoinmarket } from 'src/reducers/wallet/selectedAccountReducer';
 import { cryptoIdToNetworkSymbol } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 
 interface ConfirmAddressModalProps
@@ -16,7 +16,7 @@ interface ConfirmAddressModalProps
 }
 
 export const ConfirmAddressModal = ({ addressPath, value, ...props }: ConfirmAddressModalProps) => {
-    const account = useSelector(selectSelectedAccount);
+    const account = useSelector(selectAccountIncludingChosenInCoinmarket);
     const { modalCryptoId } = useSelector(state => state.wallet.coinmarket);
     const displayMode = useDisplayMode({ type: 'address' });
     const { cryptoIdToCoinSymbol } = useCoinmarketInfo();

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
@@ -7,7 +7,7 @@ import { borders, spacingsPx, typography } from '@trezor/theme';
 import { TranslationKey } from '@suite-common/intl-types';
 import { Translation, FormattedCryptoAmount, AccountLabel } from 'src/components/suite';
 import { Account } from 'src/types/wallet';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { Network } from '@suite-common/wallet-config';
 import { GeneralPrecomposedTransactionFinal, StakeType } from '@suite-common/wallet-types';
 import { useSelector } from 'src/hooks/suite/useSelector';
 import { selectLabelingDataForSelectedAccount } from 'src/reducers/suite/metadataReducer';
@@ -204,7 +204,7 @@ interface TransactionReviewSummaryProps {
     estimateTime?: number;
     tx: GeneralPrecomposedTransactionFinal;
     account: Account;
-    network: NetworkCompatible;
+    network: Network;
     broadcast?: boolean;
     detailsOpen: boolean;
     onDetailsClick: () => void;

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeForm.ts
@@ -48,6 +48,7 @@ import {
     useCoinmarketCommonOffers,
 } from 'src/hooks/wallet/coinmarket/offers/useCoinmarketCommonOffers';
 import * as coinmarketExchangeActions from 'src/actions/wallet/coinmarketExchangeActions';
+import * as coinmarketCommonActions from 'src/actions/wallet/coinmarket/coinmarketCommonActions';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { useCoinmarketRecomposeAndSign } from 'src/hooks/wallet/useCoinmarketRecomposeAndSign';
 import { useCoinmarketLoadData } from 'src/hooks/wallet/coinmarket/useCoinmarketLoadData';
@@ -61,6 +62,7 @@ import { networks } from '@suite-common/wallet-config';
 import { useCoinmarketAccount } from 'src/hooks/wallet/coinmarket/form/common/useCoinmarketAccount';
 import { useCoinmarketInfo } from 'src/hooks/wallet/coinmarket/useCoinmarketInfo';
 import { analytics, EventType } from '@trezor/suite-analytics';
+import { setCoinmarketModalAccount } from 'src/actions/wallet/coinmarket/coinmarketCommonActions';
 
 export const useCoinmarketExchangeForm = ({
     selectedAccount,
@@ -127,6 +129,7 @@ export const useCoinmarketExchangeForm = ({
         verifyAddress: coinmarketExchangeActions.verifyAddress,
         saveSelectedQuote: coinmarketExchangeActions.saveSelectedQuote,
         setCoinmarketExchangeAccount: coinmarketExchangeActions.setCoinmarketExchangeAccount,
+        setCoinmarketModalAccount: coinmarketCommonActions.setCoinmarketModalAccount,
     });
 
     const { symbol } = account;
@@ -430,7 +433,7 @@ export const useCoinmarketExchangeForm = ({
             // swap can use different swap paths when mining tx than when estimating tx
             // the geth gas estimate may be too low
             const result = await recomposeAndSign(
-                selectedAccount.account,
+                account,
                 selectedQuote.dexTx.to,
                 selectedQuote.dexTx.value,
                 selectedQuote.partnerPaymentExtraId,
@@ -463,6 +466,8 @@ export const useCoinmarketExchangeForm = ({
     };
 
     const sendTransaction = async () => {
+        dispatch(setCoinmarketModalAccount(account));
+
         if (selectedQuote?.isDex) {
             sendDexTransaction();
 
@@ -478,7 +483,7 @@ export const useCoinmarketExchangeForm = ({
                 ? amountToSatoshi(selectedQuote.sendStringAmount, network.decimals)
                 : selectedQuote.sendStringAmount;
             const result = await recomposeAndSign(
-                selectedAccount.account,
+                account,
                 selectedQuote.sendAddress,
                 sendStringAmount,
                 selectedQuote.partnerPaymentExtraId,

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSellForm.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSellForm.ts
@@ -471,6 +471,8 @@ export const useCoinmarketSellForm = ({
     };
 
     const sendTransaction = async () => {
+        dispatch(coinmarketCommonActions.setCoinmarketModalAccount(account));
+
         // destinationAddress may be set by useCoinmarketWatchTrade hook to the trade object
         const destinationAddress =
             selectedQuote?.destinationAddress || trade?.data?.destinationAddress;

--- a/packages/suite/src/middlewares/wallet/__tests__/coinmarketMiddleware.test.ts
+++ b/packages/suite/src/middlewares/wallet/__tests__/coinmarketMiddleware.test.ts
@@ -7,6 +7,11 @@ import { Action } from 'src/types/suite';
 import { COINMARKET_COMMON } from 'src/actions/wallet/constants';
 import invityAPI from 'src/services/suite/invityAPI';
 import suiteReducer from 'src/reducers/suite/suiteReducer';
+import { accounts } from 'src/reducers/wallet/__fixtures__/transactionConstants';
+import routerReducer, { RouterState } from 'src/reducers/suite/routerReducer';
+import modalReducer, { State as ModalState } from 'src/reducers/suite/modalReducer';
+import { MODAL, ROUTER } from 'src/actions/suite/constants';
+import { UI } from '@trezor/connect';
 
 jest.mock('src/services/suite/invityAPI');
 invityAPI.setInvityServersEnvironment = () => {};
@@ -21,6 +26,22 @@ export const ACCOUNT = {
     descriptor: 'btc-descriptor',
 };
 
+const COINMARKET_EXCHANGE_ROUTE = {
+    anchor: undefined,
+    app: 'wallet',
+    hash: '/btc/0/normal',
+    loaded: true,
+    params: { symbol: 'btc', accountIndex: 0, accountType: 'normal' },
+    pathname: '/accounts/coinmarket/exchange',
+    route: {
+        name: 'wallet-coinmarket-exchange',
+        pattern: '/accounts/coinmarket/exchange',
+        app: 'wallet',
+    },
+    settingsBackRoute: { name: 'wallet-index', params: undefined },
+    url: '/accounts/coinmarket/exchange#/btc/0/normal',
+};
+
 type CoinmarketState = ReturnType<typeof coinmarketReducer>;
 type SelectedAccountState = ReturnType<typeof selectedAccountReducer>;
 type SuiteState = ReturnType<typeof suiteReducer>;
@@ -28,6 +49,8 @@ interface Args {
     coinmarket?: CoinmarketState;
     selectedAccount?: SelectedAccountState;
     settings?: SuiteState['settings'];
+    router?: RouterState;
+    modal?: ModalState;
 }
 
 export const getInitialState = ({ coinmarket, selectedAccount }: Args = {}) => ({
@@ -61,6 +84,21 @@ export const getInitialState = ({ coinmarket, selectedAccount }: Args = {}) => (
         } as any,
         { type: 'foo' } as any,
     ),
+    router: routerReducer(
+        {
+            loaded: false,
+            url: '/',
+            pathname: '/',
+            app: 'unknown',
+            route: undefined,
+            params: undefined,
+            settingsBackRoute: {
+                name: 'suite-index',
+            },
+        } as RouterState,
+        {} as Action,
+    ),
+    modal: modalReducer({ context: MODAL.CONTEXT_NONE }, {} as Action),
 });
 
 type State = ReturnType<typeof getInitialState>;
@@ -71,15 +109,28 @@ const initStore = (state: State) => {
     const store = mockStore(state);
     store.subscribe(() => {
         const action = store.getActions().pop();
-        const { coinmarket, selectedAccount } = store.getState().wallet;
-        const { settings } = store.getState().suite;
-        store.getState().wallet = {
+        const state = store.getState();
+        const { coinmarket, selectedAccount } = state.wallet;
+        const { settings } = state.suite;
+        state.wallet = {
             coinmarket: coinmarketReducer(coinmarket, action),
             selectedAccount: selectedAccountReducer(selectedAccount, action),
         };
-        store.getState().suite = suiteReducer(
+        state.suite = suiteReducer(
             {
                 settings,
+            } as any,
+            action,
+        );
+        state.router = routerReducer(
+            {
+                ...state.router,
+            } as any,
+            action,
+        );
+        state.modal = modalReducer(
+            {
+                ...state.modal,
             } as any,
             action,
         );
@@ -175,5 +226,100 @@ describe('coinmarketMiddleware', () => {
         expect(store.getActions()).toEqual([{ type: COINMARKET_COMMON.LOAD_DATA }]);
         expect(getCurrentAccountDescriptorMock).toHaveBeenCalledTimes(1);
         expect(setInvityServersEnvironmentMock).toHaveBeenCalledTimes(0);
+    });
+
+    it('Test of cleaning modalAccount property after receive modal is closed', () => {
+        const store = initStore(
+            getInitialState({
+                coinmarket: {
+                    ...initialState,
+                    modalAccount: accounts[0],
+                    lastLoadedTimestamp: Date.now(),
+                },
+            }),
+        );
+
+        // go to coinmarket
+        store.dispatch({
+            type: ROUTER.LOCATION_CHANGE,
+            payload: COINMARKET_EXCHANGE_ROUTE,
+        });
+
+        // open modal
+        store.dispatch({
+            type: UI.REQUEST_BUTTON,
+            payload: {
+                context: MODAL.CONTEXT_DEVICE,
+                code: 'ButtonRequest_Address',
+            },
+        });
+
+        // close modal
+        store.dispatch({
+            type: UI.CLOSE_UI_WINDOW,
+        });
+
+        expect(store.getState().wallet.coinmarket.modalAccount).toEqual(undefined);
+    });
+
+    it('Test of cleaning modalAccount property after send modal is closed', () => {
+        const store = initStore(
+            getInitialState({
+                coinmarket: {
+                    ...initialState,
+                    modalAccount: accounts[0],
+                    lastLoadedTimestamp: Date.now(),
+                },
+            }),
+        );
+
+        // go to coinmarket
+        store.dispatch({
+            type: ROUTER.LOCATION_CHANGE,
+            payload: COINMARKET_EXCHANGE_ROUTE,
+        });
+
+        // open modal
+        store.dispatch({
+            type: UI.REQUEST_BUTTON,
+            payload: {
+                context: MODAL.CONTEXT_DEVICE,
+                code: 'ButtonRequest_SignTx',
+            },
+        });
+
+        // close modal
+        store.dispatch({
+            type: MODAL.CLOSE,
+        });
+
+        expect(store.getState().wallet.coinmarket.modalAccount).toEqual(undefined);
+    });
+
+    it('Test of cleaning coinmarketAccount property', () => {
+        const store = initStore(
+            getInitialState({
+                coinmarket: {
+                    ...initialState,
+                    exchange: {
+                        ...initialState.exchange,
+                        coinmarketAccount: accounts[0],
+                    },
+                    sell: {
+                        ...initialState.sell,
+                        coinmarketAccount: accounts[0],
+                    },
+                },
+            }),
+        );
+
+        // go to coinmarket
+        store.dispatch({
+            type: ROUTER.LOCATION_CHANGE,
+            payload: COINMARKET_EXCHANGE_ROUTE,
+        });
+
+        expect(store.getState().wallet.coinmarket.sell.coinmarketAccount).toBe(accounts[0]);
+        expect(store.getState().wallet.coinmarket.exchange.coinmarketAccount).toEqual(undefined);
     });
 });

--- a/packages/suite/src/reducers/wallet/__tests__/coinmarketReducer.test.ts
+++ b/packages/suite/src/reducers/wallet/__tests__/coinmarketReducer.test.ts
@@ -45,6 +45,28 @@ describe('settings reducer', () => {
         ).toEqual(initialState);
     });
 
+    it('COINMARKET_COMMON.SET_MODAL_ACCOUNT', () => {
+        expect(
+            reducer(undefined, {
+                type: COINMARKET_COMMON.SET_MODAL_ACCOUNT,
+                modalAccount: accounts[0],
+            }),
+        ).toEqual({
+            ...initialState,
+            modalAccount: accounts[0],
+        });
+
+        expect(
+            reducer(undefined, {
+                type: COINMARKET_COMMON.SET_MODAL_ACCOUNT,
+                modalAccount: undefined,
+            }),
+        ).toEqual({
+            ...initialState,
+            modalAccount: undefined,
+        });
+    });
+
     it('COINMARKET_COMMON.SET_MODAL_CRYPTO_CURRENCY', () => {
         expect(
             reducer(undefined, {

--- a/packages/suite/src/reducers/wallet/coinmarketReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinmarketReducer.ts
@@ -89,6 +89,7 @@ export interface State {
     composedTransactionInfo: ComposedTransactionInfo;
     trades: Trade[];
     modalCryptoId: CryptoId | undefined;
+    modalAccount: Account | undefined;
     isLoading: boolean;
     lastLoadedTimestamp: number;
 }
@@ -135,6 +136,7 @@ export const initialState: State = {
     composedTransactionInfo: {},
     trades: [],
     isLoading: false,
+    modalAccount: undefined,
     modalCryptoId: undefined,
     lastLoadedTimestamp: 0,
 };
@@ -252,6 +254,9 @@ const coinmarketReducer = (
             case COINMARKET_COMMON.SET_LOADING:
                 draft.isLoading = action.isLoading;
                 draft.lastLoadedTimestamp = action.lastLoadedTimestamp;
+                break;
+            case COINMARKET_COMMON.SET_MODAL_ACCOUNT:
+                draft.modalAccount = action.modalAccount;
                 break;
             case COINMARKET_COMMON.SET_MODAL_CRYPTO_CURRENCY:
                 draft.modalCryptoId = action.modalCryptoId;

--- a/packages/suite/src/reducers/wallet/selectedAccountReducer.ts
+++ b/packages/suite/src/reducers/wallet/selectedAccountReducer.ts
@@ -2,12 +2,19 @@ import { accountsActions } from '@suite-common/wallet-core';
 import type { Action } from 'src/types/suite';
 import type { SelectedAccountStatus } from '@suite-common/wallet-types';
 import { MIN_ETH_BALANCE_FOR_STAKING } from 'src/constants/suite/ethStaking';
+import { State as CoinmarketState } from 'src/reducers/wallet/coinmarketReducer';
 
 export type State = SelectedAccountStatus;
 
 export type SelectedAccountRootState = {
     wallet: {
         selectedAccount: SelectedAccountStatus;
+    };
+};
+
+export type SelectedAccountRootStateWithCoinmarket = SelectedAccountRootState & {
+    wallet: {
+        coinmarket: CoinmarketState;
     };
 };
 
@@ -49,5 +56,23 @@ export const selectSelectedAccountHasSufficientEthForStaking = (
 
 export const selectIsSelectedAccountLoaded = (state: SelectedAccountRootState) =>
     state.wallet.selectedAccount.status === 'loaded';
+
+/**
+ * Mainly used for common modals, also used in the Coinmarket section.
+ * @returns account from coinmarket if it's set, otherwise account from the store
+ */
+export const selectAccountIncludingChosenInCoinmarket = (
+    state: SelectedAccountRootStateWithCoinmarket,
+) => {
+    const { modalAccount } = state.wallet.coinmarket;
+
+    if (modalAccount) {
+        return modalAccount;
+    }
+
+    const selectedAccount = selectSelectedAccount(state);
+
+    return selectedAccount;
+};
 
 export default selectedAccountReducer;

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketUtils/CoinmarketUtilsKyc.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketUtils/CoinmarketUtilsKyc.tsx
@@ -1,12 +1,7 @@
-import { Icon, Row, Text, Tooltip } from '@trezor/components';
+import { Banner, Icon, Tooltip } from '@trezor/components';
 import { useTheme } from 'styled-components';
 import { Translation } from 'src/components/suite';
-import {
-    CoinmarketWarning,
-    TooltipIcon,
-    TooltipText,
-    TooltipWrap,
-} from 'src/views/wallet/coinmarket';
+import { TooltipIcon, TooltipText, TooltipWrap } from 'src/views/wallet/coinmarket';
 import { CoinmarketExchangeProvidersInfoProps } from 'src/types/coinmarket/coinmarket';
 import { ExchangeKYCType } from 'invity-api';
 import {
@@ -15,7 +10,6 @@ import {
     KYC_NO_REFUND,
     KYC_YES_REFUND,
 } from 'src/constants/wallet/coinmarket/kyc';
-import { spacings } from '@trezor/theme';
 
 interface CoinmarketUtilsProviderProps {
     exchange?: string;
@@ -69,12 +63,5 @@ export const CoinmarketUtilsKyc = ({
         );
     }
 
-    return (
-        <CoinmarketWarning>
-            <Row alignItems="flex-start" gap={spacings.sm}>
-                <Icon name="info" size="large" color={theme.textAlertYellow} />
-                <Text>{kycPolicyTranslation}</Text>
-            </Row>
-        </CoinmarketWarning>
-    );
+    return <Banner icon="info">{kycPolicyTranslation}</Banner>;
 };

--- a/packages/suite/src/views/wallet/coinmarket/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/index.tsx
@@ -10,7 +10,6 @@ import {
     Icon,
 } from '@trezor/components';
 import {
-    borders,
     Elevation,
     mapElevationToBackground,
     nativeTypography,
@@ -349,13 +348,6 @@ export const TooltipText = styled.div<{ $isYellow?: boolean }>`
             $isYellow ? theme.textAlertYellow : theme.textDefault};
         transition: background 0.15s;
     }
-`;
-
-export const CoinmarketWarning = styled.div`
-    padding: ${spacingsPx.sm};
-    border: 1px solid ${({ theme }) => theme.backgroundAlertYellowSubtleOnElevationNegative};
-    border-radius: ${borders.radii.sm};
-    background-color: ${({ theme }) => theme.backgroundAlertYellowSubtleOnElevation1};
 `;
 
 export const CoinmarketTestWrapper = styled.div``;


### PR DESCRIPTION
# 1. An incorrectly selected account in the verify step
## Describe the bug
Instead of the currently selected Trezor account, the account from the exchange form should be selected.

## Expected behavior
You should be able to interact with an ETH account, not a Polygon account in the send modal.

## How to reproduce
1. Choose Polygon account
2. Go to Trade-Exchange
3. Choose `From` ETH
4. Choose `To` USDT and some `Amount` to proceed with the trade
5. Continue to `Confirm on Trezor & send` in the trade

## Screenshot
![image (1)](https://github.com/user-attachments/assets/759595df-11bf-4b35-ac8f-e79cc1004f56)
![image (2)](https://github.com/user-attachments/assets/84d0ca5d-2e63-4be0-aa14-3f3f6d9418b7)

## Correct behavior
![image](https://github.com/user-attachments/assets/74f39bda-660c-41f7-b854-65b340ce73a8)

## Related Issue
Resolve https://github.com/trezor/trezor-suite/issues/14218

# 2. An incorrect account is selected in the Send modal form
## Describe the bug
Incorrect account selected in the Verify step – this can be recognized by the presence of 'Including tokens' when buying BTC.

## Expected behavior
There should be selected the correct account and should not be visible `Including tokens` subheading.

## How to reproduce
1. Choose an ETH account
2. Go to Trade-Buy
3. Choose `You buy` BTC
4. Select `Buy`
5. Click on `Confirm on Trezor` (verify)

## Buggy
![image](https://github.com/user-attachments/assets/051d988b-49d6-4576-b2e4-540eca06e1c4)

## Expected behavior
![image](https://github.com/user-attachments/assets/4d9a05e3-1e9d-4256-a181-73396f62a1be)

## Related Issue
Resolve https://github.com/trezor/trezor-suite/issues/14231

# Other info
Please also check if the Send form is not affected.