### PR TITLE
feat(message-system):  add native testing message for enabled vtc coin

### DIFF
--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,8 +1,65 @@
 {
     "version": 1,
-    "timestamp": "2024-08-028T00:00:00+00:00",
-    "sequence": 62,
+    "timestamp": "2024-09-10T00:00:00+00:00",
+    "sequence": 63,
     "actions": [
+        {
+            "conditions": [
+                {
+                    "environment": {
+                        "desktop": "!",
+                        "mobile": ">=24.9.1",
+                        "web": "!"
+                    },
+                    "settings": [
+                        {
+                            "vtc": true
+                        }
+                    ]
+                }
+            ],
+            "message": {
+                "id": "e15ce56e-6b99-4f88-8acbe-38b9bc5dabeb",
+                "priority": 93,
+                "dismissible": true,
+                "variant": "warning",
+                "category": "banner",
+                "content": {
+                    "en-GB": "This is message about VTC",
+                    "en": "This is message about VTC",
+                    "es": "This is message about VTC",
+                    "cs": "This is message about VTC",
+                    "ru": "This is message about VTC",
+                    "ja": "This is message about VTC",
+                    "hu": "This is message about VTC",
+                    "it": "This is message about VTC",
+                    "fr": "This is message about VTC",
+                    "de": "This is message about VTC",
+                    "tr": "This is message about VTC",
+                    "pt": "This is message about VTC",
+                    "uk": "This is message about VTC"
+                },
+                "cta": {
+                    "action": "external-link",
+                    "link": "https://trezor.io/coins/vertcoin",
+                    "label": {
+                        "en-GB": "Learn More",
+                        "en": "Learn More",
+                        "es": "Más Información",
+                        "cs": "Více Informací",
+                        "ru": "Подробнее",
+                        "ja": "詳細はこちら",
+                        "hu": "További Információ",
+                        "it": "Scopri di Più",
+                        "fr": "En Savoir Plus",
+                        "de": "Mehr Erfahren",
+                        "tr": "Daha Fazla Bilgi",
+                        "pt": "Saiba Mais",
+                        "uk": "Дізнатись більше"
+                    }
+                }
+            }
+        },
         {
             "conditions": [
                 {


### PR DESCRIPTION
Agreed with @STew790 this adds message for mobil with enabled VTC to test #13470

⚠️ Should be released for `DEV` and removed after testing.

[In notion](https://www.notion.so/satoshilabs/Testing-native-message-for-enabled-coins-f660f921403e4d888c1d1b548e54448b)