### PR TITLE
test(suite-desktop-core): check bridge version running in app

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/spawn-bridge.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/spawn-bridge.test.ts
@@ -5,6 +5,7 @@ import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 import { launchSuite, waitForDataTestSelector } from '../support/common';
 
 testPlaywright.describe.serial('Bridge', () => {
+    const expectedBridgeVersion = '2.0.33';
     testPlaywright.beforeAll(async () => {
         // We make sure that bridge from trezor-user-env is stopped.
         // So we properly test the electron app starting node-bridge module.
@@ -29,6 +30,16 @@ testPlaywright.describe.serial('Bridge', () => {
         // bridge is running
         const bridgeRes1 = await request.get('http://127.0.0.1:21325/status/');
         await expectPlaywright(bridgeRes1).toBeOK();
+
+        const response = await request.post('http://127.0.0.1:21325/', {
+            headers: {
+                Origin: 'https://wallet.trezor.io',
+            },
+        });
+
+        const json = await response.json();
+        const { version } = json;
+        expectPlaywright(version).toEqual(expectedBridgeVersion);
 
         await suite.electronApp.close();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This changes check that the version of Bridge running when Trezor Suite app is running is the right one.

## Related Issue

Related to PR https://github.com/trezor/trezor-suite/pull/13984
