### PR TITLE
test(suite-desktop-core): bridge runs when apps reloads

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/spawn-bridge.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/spawn-bridge.test.ts
@@ -41,6 +41,13 @@ testPlaywright.describe.serial('Bridge', () => {
         const { version } = json;
         expectPlaywright(version).toEqual(expectedBridgeVersion);
 
+        // bridge is running after renderer window is refreshed
+        await suite.window.reload();
+        await suite.window.title();
+        // bridge is running
+        const bridgeRes2 = await request.get('http://127.0.0.1:21325/status/');
+        await expectPlaywright(bridgeRes2).toBeOK();
+
         await suite.electronApp.close();
 
         // bridge is not running


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add tests cases to test bridge runs when apps reloads.

I keep the todo `    // todo: add test case when INTERNAL bridge is killed and auto-restarted` as a follow-up.

## Related Issue

Resolve  https://github.com/trezor/trezor-suite/pull/13984/
