### PR TITLE
chore(message-system): allow to release message system on DEVELOP environment from any branch

### DIFF
--- a/.github/workflows/release-suite-config.yml
+++ b/.github/workflows/release-suite-config.yml
@@ -36,13 +36,13 @@ jobs:
           role-to-assume: ${{ github.event.inputs.environment == 'develop-message' && 'arn:aws:iam::538326561891:role/gh_actions_suite_develop_message' || 'arn:aws:iam::538326561891:role/gh_actions_suite_production_message' }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Build and sign ${{ github.event.inputs.environment }} config
-        if: ${{ github.event.inputs.environment == 'develop-message' && github.ref == 'refs/heads/develop' }}
+      - name: Build and sign develop message-system config file
+        if: ${{ github.event.inputs.environment == 'develop-message' }}
         run: |
           yarn install
           yarn message-system-sign-config
 
-      - name: Build and sign ${{ github.event.inputs.environment }} message-system config file
+      - name: Build and sign production message-system config file
         if: ${{ github.event.inputs.environment == 'production-message' && github.ref == 'refs/heads/develop' }}
         env:
           IS_CODESIGN_BUILD: "true"
@@ -51,14 +51,14 @@ jobs:
           yarn install
           yarn message-system-sign-config
 
-      - name: Upload ${{ github.event.inputs.environment }} message-system config file
-        if: ${{ github.ref == 'refs/heads/develop' }}
+      - name: Uploaddevelop message-system config file
+        if: ${{ github.event.inputs.environment == 'develop-message' }}
         run: |
-          if [ '${{ github.event.inputs.environment }}' == 'production-message' ]
-          then
-            aws s3 cp suite-common/message-system/files/config.v1.jws s3://data.trezor.io/config/stable/config.v1.jws --cache-control no-cache
-            aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_ID} --paths '/config/stable/*'
-          else
-            aws s3 cp suite-common/message-system/files/config.v1.jws s3://data.trezor.io/config/develop/config.v1.jws --cache-control no-cache
-            aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_ID} --paths '/config/develop/*'
-          fi
+          aws s3 cp suite-common/message-system/files/config.v1.jws s3://data.trezor.io/config/develop/config.v1.jws --cache-control no-cache
+          aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_ID} --paths '/config/develop/*'
+
+      - name: Upload production message-system config file
+        if: ${{ github.event.inputs.environment == 'production-message' && github.ref == 'refs/heads/develop' }}
+        run: |
+          aws s3 cp suite-common/message-system/files/config.v1.jws s3://data.trezor.io/config/stable/config.v1.jws --cache-control no-cache
+          aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_ID} --paths '/config/stable/*'


### PR DESCRIPTION

## Description

- Allow to release message system on DEVELOP environment from any branch.
- Keep production release restricted to develop.

Just an idea for simplified testing, I see no point in restricting releases to develop environment from develop branch. If we can release it from any branch, it could prevent unintentional production release of testing message like https://github.com/trezor/trezor-suite/pull/14233
