### PR TITLE
fix(suite-native): show amount error message even if field not dirty

### DIFF
--- a/suite-native/module-send/src/components/AmountErrorMessage.tsx
+++ b/suite-native/module-send/src/components/AmountErrorMessage.tsx
@@ -4,13 +4,11 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { getOutputFieldName } from '../utils';
 
-const MESSAGE_DEFAULT_OFFSET = 110;
-const MESSAGE_FIATLESS_OFFSET = 62;
-
-const errorStyle = prepareNativeStyle<{ isFiatDisplayed: boolean }>((_, { isFiatDisplayed }) => ({
-    position: 'absolute',
-    top: isFiatDisplayed ? MESSAGE_DEFAULT_OFFSET : MESSAGE_FIATLESS_OFFSET,
-}));
+const errorStyle = prepareNativeStyle<{ isFiatDisplayed: boolean }>(
+    (utils, { isFiatDisplayed }) => ({
+        marginHorizontal: isFiatDisplayed ? utils.spacings.medium : 0,
+    }),
+);
 
 export const AmountErrorMessage = ({
     outputIndex,
@@ -23,9 +21,9 @@ export const AmountErrorMessage = ({
     const amountField = useField({
         name: getOutputFieldName(outputIndex, 'amount'),
     });
-    const { isDirty, errorMessage } = amountField;
+    const { errorMessage } = amountField;
 
-    if (!isDirty || !errorMessage) return null;
+    if (!errorMessage) return null;
 
     return (
         <Hint variant="error" style={applyStyle(errorStyle, { isFiatDisplayed })}>

--- a/suite-native/module-send/src/components/AmountInputs.tsx
+++ b/suite-native/module-send/src/components/AmountInputs.tsx
@@ -29,8 +29,8 @@ const SCALE_UNFOCUSED = 0.9;
 const TRANSLATE_Y_FOCUSED = 0;
 const TRANSLATE_Y_UNFOCUSED = 55;
 
-const DEFAULT_INPUTS_WRAPPER_HEIGHT = 116;
-const FIATLESS_INPUTS_WRAPPER_HEIGHT = 80;
+const DEFAULT_INPUTS_WRAPPER_HEIGHT = 108;
+const FIATLESS_INPUTS_WRAPPER_HEIGHT = 60;
 
 const inputsWrapperStyle = prepareNativeStyle<{ isFiatDisplayed: boolean }>(
     (_, { isFiatDisplayed }) => ({
@@ -105,7 +105,6 @@ export const AmountInputs = ({ index, accountKey }: AmountInputProps) => {
                     isDisabled={!isCryptoSelected}
                     networkSymbol={networkSymbol}
                 />
-
                 {isFiatDisplayed && (
                     <>
                         <SwitchAmountsButton onPress={handleSwitchInputs} />
@@ -119,8 +118,8 @@ export const AmountInputs = ({ index, accountKey }: AmountInputProps) => {
                         />
                     </>
                 )}
-                <AmountErrorMessage outputIndex={index} isFiatDisplayed={isFiatDisplayed} />
             </Box>
+            <AmountErrorMessage outputIndex={index} isFiatDisplayed={isFiatDisplayed} />
         </VStack>
     );
 };


### PR DESCRIPTION
Also the margin around the error message was fixed. It's still not 1:1 with the design but it's way better. 

## Related Issue

Resolve #14071

## Screenshots:

![mainnet](https://github.com/user-attachments/assets/788028ff-35b9-4f86-81af-639375f9d664)
![testnet](https://github.com/user-attachments/assets/a94aa79c-bce3-4e73-ac1a-d782a26b05d8)

