### PR TITLE
fix(transport): node bridge version parsing issue

### DIFF
--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -105,7 +105,11 @@ export class BridgeTransport extends AbstractTransport {
             this.version = response.payload.version;
 
             if (this.latestVersion) {
-                this.isOutdated = versionUtils.isNewer(this.latestVersion, this.version);
+                this.isOutdated = versionUtils.isNewer(
+                    this.latestVersion,
+                    // node bridge version is in format "3.0.0-bundled.24.10.0"
+                    this.version.split('-')[0],
+                );
             }
             this.useProtocolMessages = !!response.payload.protocolMessages;
 


### PR DESCRIPTION
## Description

Fix version parsing for Node Bridge. 
Since #14153 the Node Bridge version is reported in format such as "3.0.0-bundled.24.10.0".

However in `BridgeTransport` there is some logic to check if the version is outdated and it fails to parse it.
So with this PR we throw away the part behind the dash.