### PR TITLE
fix(suite-native): check btc firmware instead of btc only device for coin enabling

### DIFF
--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -7,6 +7,7 @@ import { Device, Features, UI } from '@trezor/connect';
 import {
     getFirmwareVersion,
     getFirmwareVersionArray,
+    hasBitcoinOnlyFirmware,
     isBitcoinOnlyDevice,
 } from '@trezor/device-utils';
 import { NetworkDeviceSupport, NetworkSymbol, networks } from '@suite-common/wallet-config';
@@ -957,5 +958,10 @@ export const selectInstacelessUnselectedDevices = memoize((state: DeviceRootStat
     return deviceUtils.getSortedDevicesWithoutInstances(allDevices, device?.id);
 });
 
+// Bitcoin only Trezor with bitcoin-only firmware
 export const selectIsBitcoinOnlyDevice = (state: DeviceRootState) =>
     isBitcoinOnlyDevice(selectDevice(state));
+
+// Any Trezor that has BTC only firmware
+export const selectHasBitcoinOnlyFirmware = (state: DeviceRootState) =>
+    hasBitcoinOnlyFirmware(selectDevice(state));

--- a/suite-native/app/src/hooks/useCoinEnablingInitialCheck.tsx
+++ b/suite-native/app/src/hooks/useCoinEnablingInitialCheck.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef } from 'react';
 import { A } from '@mobily/ts-belt';
 import { useNavigation } from '@react-navigation/native';
 
-import { selectIsBitcoinOnlyDevice } from '@suite-common/wallet-core';
+import { selectHasBitcoinOnlyFirmware } from '@suite-common/wallet-core';
 import { selectViewOnlyDevicesAccountsNetworkSymbols } from '@suite-native/device';
 import { selectShouldShowCoinEnablingInitFlow } from '@suite-native/coin-enabling';
 import {
@@ -27,7 +27,7 @@ export const useCoinEnablingInitialCheck = () => {
         useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes.CoinEnablingInit>>();
     const [isCoinEnablingActive] = useFeatureFlag(FeatureFlag.IsCoinEnablingActive);
 
-    const isBitcoinOnlyDevice = useSelector(selectIsBitcoinOnlyDevice);
+    const hasBitcoinOnlyFirmware = useSelector(selectHasBitcoinOnlyFirmware);
     const isOnboardingFinished = useSelector(selectIsOnboardingFinished);
     const shouldShowCoinEnablingInitFlow = useSelector(selectShouldShowCoinEnablingInitFlow);
     const viewOnlyDevicesAccountsNetworkSymbols = useSelector(
@@ -43,7 +43,7 @@ export const useCoinEnablingInitialCheck = () => {
         if (shouldShowCoinEnablingInitFlow && canShowCoinEnablingInitFlow) {
             let timeoutId: ReturnType<typeof setTimeout>;
             //if btc only device, just run discovery for btc and do not show the UI
-            if (isBitcoinOnlyDevice) {
+            if (hasBitcoinOnlyFirmware) {
                 dispatch(setEnabledDiscoveryNetworkSymbols(['btc']));
                 dispatch(setIsCoinEnablingInitFinished(true));
                 dispatch(applyDiscoveryChangesThunk());
@@ -68,7 +68,7 @@ export const useCoinEnablingInitialCheck = () => {
         }
     }, [
         dispatch,
-        isBitcoinOnlyDevice,
+        hasBitcoinOnlyFirmware,
         isCoinEnablingActive,
         navigation,
         viewOnlyDevicesAccountsNetworkSymbols,

--- a/suite-native/module-settings/src/screens/SettingsCoinEnablingScreen.tsx
+++ b/suite-native/module-settings/src/screens/SettingsCoinEnablingScreen.tsx
@@ -9,9 +9,9 @@ import { Screen, ScreenSubHeader } from '@suite-native/navigation';
 import { useTranslate } from '@suite-native/intl';
 import { BtcOnlyCoinEnablingContent, DiscoveryCoinsFilter } from '@suite-native/coin-enabling';
 import { Box } from '@suite-native/atoms';
-import { selectIsBitcoinOnlyDevice } from '@suite-common/wallet-core';
+import { selectHasBitcoinOnlyFirmware } from '@suite-common/wallet-core';
 import {
-    selectDiscoverySupportedNetworks,
+    selectDiscoveryNetworkSymbols,
     selectEnabledDiscoveryNetworkSymbols,
     setEnabledDiscoveryNetworkSymbols,
     setIsCoinEnablingInitFinished,
@@ -40,14 +40,14 @@ export const SettingsCoinEnablingScreen = () => {
     const { translate } = useTranslate();
 
     const enabledNetworkSymbols = useSelector(selectEnabledDiscoveryNetworkSymbols);
-    const availableNetworks = useSelector(selectDiscoverySupportedNetworks);
-    const isBitcoinOnlyDevice = useSelector(selectIsBitcoinOnlyDevice);
+    const availableNetworkSymbols = useSelector(selectDiscoveryNetworkSymbols);
+    const hasBitcoinOnlyFirmware = useSelector(selectHasBitcoinOnlyFirmware);
     const viewOnlyDevicesAccountsNetworkSymbols = useSelector(
         selectViewOnlyDevicesAccountsNetworkSymbols,
     );
 
     //testnets can be enabled and we want to show networks that case
-    const showNetworks = availableNetworks.length > 1 || !isBitcoinOnlyDevice;
+    const showNetworks = availableNetworkSymbols.length > 1 || !hasBitcoinOnlyFirmware;
 
     useEffect(() => {
         // in case the user has view only devices and gets to the settings


### PR DESCRIPTION
Fix for correct behaviour of coin enabling when user has BTC only firmware.

- Using `hasBitcoinOnlyFirmware` that check firmware, instead of previos `selectIsBitcoinOnlyDevice` that checks device. 
- Checking symbols count instead of networks to show correct UI in settings


Resolve #14255