### PR TITLE
chore(suite): add release notes to 24.9.x

### DIFF
--- a/packages/suite-desktop/releaseNotes/release-notes.md
+++ b/packages/suite-desktop/releaseNotes/release-notes.md
@@ -1,13 +1,11 @@
-### 🚀 New features
-
--   Enhanced protection against counterfeit devices for Trezor Model One and Trezor Model T.
--   New official languages added: Brazilian Portuguese, Italian, and Turkish.
-
 ### 🎨 Improvements
 
--   Reworked Buy & Sell features for improved user experience.
+-   The Exchange feature in the Trade section has been redesigned for easier use and improved deal offers.
+-   Expanded the number of available tokens for buy, sell, and exchange (2000+ tokens).
+-   Status icons in the bottom left menu have been updated for better clarity.
+-   Some modal windows have been redesigned for better consistency with the app.
+-   Improved discovery and clear identification of non-standard account types.
 
 ### 🔧 Bug fixes
 
 -   Various small improvements and bug fixes.
--   Resolved the missing fixed/floating rates in the Exchange feature.


### PR DESCRIPTION
Adding release notes to upcoming 24.9.x release


<img width="1082" alt="image" src="https://github.com/user-attachments/assets/afa22b5a-6d7f-4558-a2a2-7b73949a996a">

<img width="1339" alt="image" src="https://github.com/user-attachments/assets/d734df24-dc05-4bd1-8efb-0315d56bfbbc">

