### PR TITLE
fix(coinmarket): DCA wrong colors for store icons for Light color scheme

### DIFF
--- a/packages/suite/src/views/wallet/coinmarket/DCA/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/DCA/index.tsx
@@ -101,7 +101,7 @@ const FeatureItem = ({ icon, featureNumber }: FeatureItemProps) => (
 
 const DCALanding = (props: UseCoinmarketProps) => {
     const currentTheme = useSelector(state => state.suite.settings.theme.variant);
-    const isLightTheme = currentTheme === 'light';
+    const isLightTheme = currentTheme !== 'dark';
 
     return (
         <CoinmarketLayout selectedAccount={props.selectedAccount}>


### PR DESCRIPTION
Resolves https://github.com/trezor/trezor-suite/issues/14257

## Description
Wrong store icons color when "Light" color scheme is active.

Cause: Color scheme "Light" and "System" (even when it is light) have different state values (`standard` vs `light`).

## Before
https://github.com/user-attachments/assets/6a1c10b6-23e0-4357-bc76-6e26f0f2a8f9

## After
<img width="1181" alt="Screenshot 2024-09-10 at 15 58 00" src="https://github.com/user-attachments/assets/2c8db33d-1aae-45bc-82ea-9125c03d49fa">


