### PR TITLE
fix(suite-native): check discovery existence instead of whether it is active

### DIFF
--- a/suite-native/accounts/src/components/AddAccountsButton.tsx
+++ b/suite-native/accounts/src/components/AddAccountsButton.tsx
@@ -12,7 +12,7 @@ import {
 } from '@suite-native/navigation';
 import { IconButton } from '@suite-native/atoms';
 import {
-    selectDeviceDiscovery,
+    selectHasDeviceDiscovery,
     selectIsDeviceInViewOnlyMode,
     selectIsPortfolioTrackerDevice,
 } from '@suite-common/wallet-core';
@@ -30,13 +30,13 @@ export const AddAccountButton = ({ flowType, testID }: AddAccountButtonProps) =>
         useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes.AccountsImport>>();
 
     const isSelectedDevicePortfolioTracker = useSelector(selectIsPortfolioTrackerDevice);
-    const discovery = useSelector(selectDeviceDiscovery);
+    const hasDiscovery = useSelector(selectHasDeviceDiscovery);
     const [isDeviceConnectEnabled] = useFeatureFlag(FeatureFlag.IsDeviceConnectEnabled);
     const { showViewOnlyAddAccountAlert } = useAccountAlerts();
     const isDeviceInViewOnlyMode = useSelector(selectIsDeviceInViewOnlyMode);
 
     const shouldShowAddAccountButton =
-        isSelectedDevicePortfolioTracker || (isDeviceConnectEnabled && !discovery);
+        isSelectedDevicePortfolioTracker || (isDeviceConnectEnabled && !hasDiscovery);
 
     const navigateToImportScreen = () => {
         navigation.navigate(RootStackRoutes.AccountsImport, {

--- a/suite-native/assets/src/components/Assets.tsx
+++ b/suite-native/assets/src/components/Assets.tsx
@@ -6,7 +6,7 @@ import { useNavigation } from '@react-navigation/native';
 
 import { useSelectorDeepComparison } from '@suite-common/redux-utils';
 import { NetworkSymbol } from '@suite-common/wallet-config';
-import { selectIsDeviceAuthorized, selectIsDeviceDiscoveryActive } from '@suite-common/wallet-core';
+import { selectIsDeviceAuthorized, selectHasDeviceDiscovery } from '@suite-common/wallet-core';
 import { OnSelectAccount } from '@suite-native/accounts';
 import { Card } from '@suite-native/atoms';
 import {
@@ -33,9 +33,9 @@ export const Assets = () => {
 
     const deviceNetworks = useSelectorDeepComparison(selectDeviceNetworksWithAssets);
 
-    const isDiscoveryActive = useSelector(selectIsDeviceDiscoveryActive);
+    const hasDiscovery = useSelector(selectHasDeviceDiscovery);
     const isDeviceAuthorized = useSelector(selectIsDeviceAuthorized);
-    const isLoading = isDiscoveryActive || !isDeviceAuthorized;
+    const isLoading = hasDiscovery || !isDeviceAuthorized;
 
     const [selectedAssetSymbol, setSelectedAssetSymbol] = useState<NetworkSymbol | null>(null);
 

--- a/suite-native/device-manager/src/components/DeviceList.tsx
+++ b/suite-native/device-manager/src/components/DeviceList.tsx
@@ -15,7 +15,7 @@ import {
     selectDevice,
     selectIsDeviceConnected,
     selectInstacelessUnselectedDevices,
-    selectIsDeviceDiscoveryActive,
+    selectHasDeviceDiscovery,
 } from '@suite-common/wallet-core';
 import {
     Button,
@@ -131,13 +131,13 @@ export const DeviceList = ({ isVisible, onSelectDevice }: DeviceListProps) => {
     const { setIsDeviceManagerVisible } = useDeviceManager();
     const device = useSelector(selectDevice);
     const notSelectedInstancelessDevices = useSelector(selectInstacelessUnselectedDevices);
-    const isDiscoveryActive = useSelector(selectIsDeviceDiscoveryActive);
+    const hasDiscovery = useSelector(selectHasDeviceDiscovery);
     const isDeviceConnected = useSelector(selectIsDeviceConnected);
     const opacity = useSharedValue(0);
     const height = useSharedValue(0);
 
     const hasUnselectedDevices = notSelectedInstancelessDevices.length > 0;
-    const isConnectButtonVisible = !isDiscoveryActive && !isDeviceConnected;
+    const isConnectButtonVisible = !hasDiscovery && !isDeviceConnected;
 
     const handleConnectDevice = () => {
         if (device) {

--- a/suite-native/device-manager/src/components/DeviceManagerContent.tsx
+++ b/suite-native/device-manager/src/components/DeviceManagerContent.tsx
@@ -8,7 +8,7 @@ import {
     PORTFOLIO_TRACKER_DEVICE_ID,
     selectDevice,
     selectDeviceThunk,
-    selectIsDeviceDiscoveryActive,
+    selectHasDeviceDiscovery,
     selectIsPortfolioTrackerDevice,
 } from '@suite-common/wallet-core';
 import { EventType, analytics } from '@suite-native/analytics';
@@ -46,7 +46,7 @@ export const DeviceManagerContent = () => {
 
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
 
-    const isDiscoveryActive = useSelector(selectIsDeviceDiscoveryActive);
+    const hasDiscovery = useSelector(selectHasDeviceDiscovery);
     const device = useSelector(selectDevice);
     const { setIsDeviceManagerVisible } = useDeviceManager();
 
@@ -79,7 +79,7 @@ export const DeviceManagerContent = () => {
     const scrollViewTopOffset = insets.top + utils.spacings.large + HEADER_HEIGHT;
     const scrollViewMaxHeight = CONTENT_MAX_HEIGHT - scrollViewTopOffset;
 
-    const isAddHiddenWalletButtonVisible = !isDiscoveryActive && device?.connected;
+    const isAddHiddenWalletButtonVisible = !hasDiscovery && device?.connected;
 
     return (
         <DeviceManagerModal

--- a/suite-native/discovery/src/discoverySelectors.ts
+++ b/suite-native/discovery/src/discoverySelectors.ts
@@ -13,7 +13,7 @@ import {
     selectAccountsByNetworkAndDeviceState,
     selectDeviceAccounts,
     selectDeviceAuthFailed,
-    selectDeviceDiscovery,
+    selectHasDeviceDiscovery,
     selectDeviceFirmwareVersion,
     selectDeviceModel,
     selectDeviceState,
@@ -152,7 +152,7 @@ export const selectCanRunDiscoveryForDevice = (
     }
 
     const isCoinEnablingInitFinished = selectIsCoinEnablingInitFinished(state);
-    const discovery = selectDeviceDiscovery(state);
+    const hasDiscovery = selectHasDeviceDiscovery(state);
     const deviceModel = selectDeviceModel(state);
     const deviceFwVersion = selectDeviceFirmwareVersion(state);
     const isDeviceConnectedAndAuthorized = selectIsDeviceConnectedAndAuthorized(state);
@@ -170,7 +170,7 @@ export const selectCanRunDiscoveryForDevice = (
 
     return (
         isCoinEnablingInitFinished &&
-        !discovery &&
+        !hasDiscovery &&
         isDeviceConnectedAndAuthorized &&
         !isPortfolioTrackerDevice &&
         !isDeviceInViewOnlyMode &&

--- a/suite-native/discovery/src/discoveryThunks.ts
+++ b/suite-native/discovery/src/discoveryThunks.ts
@@ -18,6 +18,7 @@ import {
     selectDeviceState,
     disableAccountsThunk,
     selectFirstNormalAccountForNetworkSymbol,
+    selectHasDeviceDiscovery,
 } from '@suite-common/wallet-core';
 import { selectIsAccountAlreadyDiscovered } from '@suite-native/accounts';
 import TrezorConnect from '@trezor/connect';
@@ -551,8 +552,8 @@ export const createDescriptorPreloadedDiscoveryThunk = createThunk(
             return;
         }
 
-        const runningDiscovery = selectDeviceDiscovery(getState());
-        if (runningDiscovery) {
+        const hasDiscovery = selectHasDeviceDiscovery(getState());
+        if (hasDiscovery) {
             console.warn(
                 `Warning discovery for device ${deviceState} already exists. Skipping discovery.`,
             );
@@ -607,8 +608,8 @@ export const startDescriptorPreloadedDiscoveryThunk = createThunk(
 
         const device = selectDeviceByState(getState(), deviceState);
 
-        const discovery1 = selectDeviceDiscovery(getState());
-        if (discovery1) {
+        const hasDiscovery1 = selectHasDeviceDiscovery(getState());
+        if (hasDiscovery1) {
             console.warn(
                 `Warning: discovery for device ${deviceState} already exists. Skipping discovery.`,
             );
@@ -662,8 +663,8 @@ export const startDescriptorPreloadedDiscoveryThunk = createThunk(
         );
 
         // We need to check again here because it's possible that things changed in the meantime because async thunks
-        const discovery2 = selectDeviceDiscovery(getState());
-        if (!discovery2) {
+        const hasDiscovery2 = selectHasDeviceDiscovery(getState());
+        if (!hasDiscovery2) {
             return;
         }
 

--- a/suite-native/discovery/src/useIsDiscoveryDurationTooLong.tsx
+++ b/suite-native/discovery/src/useIsDiscoveryDurationTooLong.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 
-import { selectIsDeviceDiscoveryActive } from '@suite-common/wallet-core';
+import { selectHasDeviceDiscovery } from '@suite-common/wallet-core';
 
 import { selectDiscoveryInfo } from './discoveryConfigSlice';
 
@@ -10,13 +10,13 @@ const DISCOVERY_DURATION_THRESHOLD = 50_000;
 
 export const useIsDiscoveryDurationTooLong = () => {
     const discoveryInfo = useSelector(selectDiscoveryInfo);
-    const isDiscoveryActive = useSelector(selectIsDeviceDiscoveryActive);
+    const hasDiscovery = useSelector(selectHasDeviceDiscovery);
 
     const [loadingTakesLongerThanExpected, setLoadingTakesLongerThanExpected] = useState(false);
 
     useEffect(() => {
         let interval: ReturnType<typeof setInterval>;
-        if (isDiscoveryActive && discoveryInfo?.startTimestamp) {
+        if (hasDiscovery && discoveryInfo?.startTimestamp) {
             interval = setInterval(() => {
                 if (
                     performance.now() - discoveryInfo.startTimestamp >
@@ -35,7 +35,7 @@ export const useIsDiscoveryDurationTooLong = () => {
                 clearInterval(interval);
             }
         };
-    }, [isDiscoveryActive, discoveryInfo]);
+    }, [hasDiscovery, discoveryInfo]);
 
     return loadingTakesLongerThanExpected;
 };

--- a/suite-native/module-add-accounts/src/screens/AddCoinDiscoveryRunningScreen.tsx
+++ b/suite-native/module-add-accounts/src/screens/AddCoinDiscoveryRunningScreen.tsx
@@ -12,7 +12,7 @@ import {
     AccountsRootState,
     DeviceRootState,
     selectDeviceAccountsByNetworkSymbol,
-    selectDeviceDiscovery,
+    selectHasDeviceDiscovery,
 } from '@suite-common/wallet-core';
 import {
     applyDiscoveryChangesThunk,
@@ -30,7 +30,7 @@ export const AddCoinDiscoveryRunningScreen = ({ route }) => {
         selectDeviceAccountsByNetworkSymbol(state, networkSymbol),
     );
 
-    const discovery = useSelector(selectDeviceDiscovery);
+    const hasDiscovery = useSelector(selectHasDeviceDiscovery);
     const enabledNetworkSymbols = useSelector(selectEnabledDiscoveryNetworkSymbols);
     const { navigateToSuccessorScreen, clearNetworkWithTypeToBeAdded } = useAddCoinAccount();
     const [loadingResult, setLoadingResult] = useState<SpinnerLoadingState>('idle');
@@ -47,7 +47,7 @@ export const AddCoinDiscoveryRunningScreen = ({ route }) => {
     const handleFinish = () => {
         const normalAccounts = accounts.filter(a => a.accountType === 'normal');
         const nonEmptyAccounts = accounts.filter(a => !a.empty);
-        if (!discovery) {
+        if (!hasDiscovery) {
             if (accounts.length > 0) {
                 setLoadingResult('success');
             }
@@ -69,16 +69,23 @@ export const AddCoinDiscoveryRunningScreen = ({ route }) => {
             networkSymbol &&
             !enabledNetworkSymbols.includes(networkSymbol) &&
             accounts.length === 0 &&
-            !discovery
+            !hasDiscovery
         ) {
             dispatch(toggleEnabledDiscoveryNetworkSymbol(networkSymbol));
             dispatch(applyDiscoveryChangesThunk());
         }
 
-        if (accounts.length > 0 && !discovery) {
+        if (accounts.length > 0 && !hasDiscovery) {
             setLoadingResult('success');
         }
-    }, [accounts.length, discovery, dispatch, enabledNetworkSymbols, loadingResult, networkSymbol]);
+    }, [
+        accounts.length,
+        hasDiscovery,
+        dispatch,
+        enabledNetworkSymbols,
+        loadingResult,
+        networkSymbol,
+    ]);
 
     return (
         <Screen>

--- a/suite-native/module-authorize-device/src/components/connect/ConnectDeviceScreenHeader.tsx
+++ b/suite-native/module-authorize-device/src/components/connect/ConnectDeviceScreenHeader.tsx
@@ -14,7 +14,7 @@ import {
 import { Box, IconButton, ScreenHeaderWrapper } from '@suite-native/atoms';
 import { useAlert } from '@suite-native/alerts';
 import { Translation } from '@suite-native/intl';
-import { selectIsDeviceDiscoveryActive } from '@suite-common/wallet-core';
+import { selectHasDeviceDiscovery } from '@suite-common/wallet-core';
 import {
     cancelPassphraseAndSelectStandardDeviceThunk,
     selectIsCreatingNewPassphraseWallet,
@@ -40,12 +40,12 @@ export const ConnectDeviceScreenHeader = ({
     const navigation = useNavigation<NavigationProp>();
     const { showAlert, hideAlert } = useAlert();
 
-    const isDiscoveryActive = useSelector(selectIsDeviceDiscoveryActive);
+    const hasDiscovery = useSelector(selectHasDeviceDiscovery);
     const isCreatingNewWalletInstance = useSelector(selectIsCreatingNewPassphraseWallet);
     const hasDeviceRequestedPin = useSelector(selectDeviceRequestedPin);
 
     const handleCancel = useCallback(() => {
-        if (isDiscoveryActive) {
+        if (hasDiscovery) {
             // Do not allow to cancel PIN entry while discovery is in progress
             showAlert({
                 title: <Translation id="moduleConnectDevice.pinCanceledDuringDiscovery.title" />,
@@ -75,7 +75,7 @@ export const ConnectDeviceScreenHeader = ({
     }, [
         dispatch,
         hideAlert,
-        isDiscoveryActive,
+        hasDiscovery,
         navigation,
         showAlert,
         isCreatingNewWalletInstance,

--- a/suite-native/module-authorize-device/src/screens/passphrase/PassphraseConfirmOnTrezorScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/passphrase/PassphraseConfirmOnTrezorScreen.tsx
@@ -15,7 +15,7 @@ import {
     deviceActions,
     selectDevice,
     selectIsDeviceConnectedAndAuthorized,
-    selectIsDeviceDiscoveryActive,
+    selectHasDeviceDiscovery,
 } from '@suite-common/wallet-core';
 import { useHandlePassphraseMismatch } from '@suite-native/device-authorization';
 
@@ -35,7 +35,7 @@ export const PassphraseConfirmOnTrezorScreen = () => {
     const navigation = useNavigation<NavigationProp>();
 
     const isDeviceConnectedAndAuthorized = useSelector(selectIsDeviceConnectedAndAuthorized);
-    const isDiscoveryActive = useSelector(selectIsDeviceDiscoveryActive);
+    const hasDiscovery = useSelector(selectHasDeviceDiscovery);
     const device = useSelector(selectDevice);
 
     // If this screen was present during authorizing device with passphrase for some feature,
@@ -45,7 +45,7 @@ export const PassphraseConfirmOnTrezorScreen = () => {
     useHandlePassphraseMismatch();
 
     useEffect(() => {
-        if (isDeviceConnectedAndAuthorized && isDiscoveryActive) {
+        if (isDeviceConnectedAndAuthorized && hasDiscovery) {
             navigation.navigate(AuthorizeDeviceStackRoutes.PassphraseLoading);
             dispatch(
                 deviceActions.removeButtonRequests({
@@ -54,7 +54,7 @@ export const PassphraseConfirmOnTrezorScreen = () => {
                 }),
             );
         }
-    }, [device, dispatch, isDeviceConnectedAndAuthorized, isDiscoveryActive, navigation]);
+    }, [device, dispatch, isDeviceConnectedAndAuthorized, hasDiscovery, navigation]);
 
     return (
         <PassphraseScreenWrapper>

--- a/suite-native/module-authorize-device/src/screens/passphrase/PassphraseEnterOnTrezorScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/passphrase/PassphraseEnterOnTrezorScreen.tsx
@@ -10,7 +10,7 @@ import {
     StackToStackCompositeNavigationProps,
 } from '@suite-native/navigation';
 import { Box, Button, Card, CenteredTitleHeader, Text, VStack } from '@suite-native/atoms';
-import { selectIsDeviceDiscoveryActive } from '@suite-common/wallet-core';
+import { selectHasDeviceDiscovery } from '@suite-common/wallet-core';
 import { Translation } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import {
@@ -45,7 +45,7 @@ export const PassphraseEnterOnTrezorScreen = () => {
 
     const { applyStyle } = useNativeStyles();
 
-    const isDiscoveryActive = useSelector(selectIsDeviceDiscoveryActive);
+    const hasDiscovery = useSelector(selectHasDeviceDiscovery);
 
     const isCreatingNewWalletInstance = useSelector(selectIsCreatingNewPassphraseWallet);
 
@@ -60,10 +60,10 @@ export const PassphraseEnterOnTrezorScreen = () => {
     useHandlePassphraseMismatch();
 
     useEffect(() => {
-        if (isDiscoveryActive) {
+        if (hasDiscovery) {
             navigation.navigate(AuthorizeDeviceStackRoutes.PassphraseLoading);
         }
-    }, [isDiscoveryActive, navigation]);
+    }, [hasDiscovery, navigation]);
 
     const handleCancel = () => {
         if (isCreatingNewWalletInstance) {

--- a/suite-native/module-home/src/screens/HomeScreen/components/EnableViewOnlyBottomSheet.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/EnableViewOnlyBottomSheet.tsx
@@ -6,7 +6,7 @@ import {
     selectIsPortfolioTrackerDevice,
     deviceActions,
     selectIsDeviceRemembered,
-    selectIsDeviceDiscoveryActive,
+    selectHasDeviceDiscovery,
 } from '@suite-common/wallet-core';
 import { analytics, EventType } from '@suite-native/analytics';
 import { BottomSheet, Box, Button, CenteredTitleHeader, VStack } from '@suite-native/atoms';
@@ -46,7 +46,7 @@ export const EnableViewOnlyBottomSheet = () => {
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const viewOnlyCancelationTimestamp = useSelector(selectViewOnlyCancelationTimestamp);
     const isDeviceRemembered = useSelector(selectIsDeviceRemembered);
-    const isDiscoveryActive = useSelector(selectIsDeviceDiscoveryActive);
+    const hasDiscovery = useSelector(selectHasDeviceDiscovery);
     const { showToast } = useToast();
     const [isVisible, setIsVisible] = useState(false);
     const [isAvailableBiometrics, setIsAvailableBiometrics] = useState(false);
@@ -73,7 +73,7 @@ export const EnableViewOnlyBottomSheet = () => {
         !isDeviceRemembered &&
         isDeviceReadyToUseAndAuthorized &&
         !isPortfolioTrackerDevice &&
-        !isDiscoveryActive &&
+        !hasDiscovery &&
         !viewOnlyCancelationTimestamp &&
         (isBiometricsInitialSetupFinished || !isAvailableBiometrics);
 

--- a/suite-native/module-home/src/screens/HomeScreen/components/PortfolioGraphHeader.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/PortfolioGraphHeader.tsx
@@ -2,7 +2,7 @@ import { useSelector } from 'react-redux';
 
 import { Box, VStack } from '@suite-native/atoms';
 import { GraphFiatBalance } from '@suite-native/graph';
-import { selectIsDeviceDiscoveryActive, selectIsDeviceAuthorized } from '@suite-common/wallet-core';
+import { selectHasDeviceDiscovery, selectIsDeviceAuthorized } from '@suite-common/wallet-core';
 
 import {
     hasPriceIncreasedAtom,
@@ -12,9 +12,9 @@ import {
 } from '../portfolioGraphAtoms';
 
 export const PortfolioGraphHeader = () => {
-    const isDiscoveryActive = useSelector(selectIsDeviceDiscoveryActive);
+    const hasDiscovery = useSelector(selectHasDeviceDiscovery);
     const isDeviceAuthorized = useSelector(selectIsDeviceAuthorized);
-    const isLoading = isDiscoveryActive || !isDeviceAuthorized;
+    const isLoading = hasDiscovery || !isDeviceAuthorized;
 
     return (
         <Box>

--- a/suite-native/module-settings/src/components/ViewOnly/WalletRow.tsx
+++ b/suite-native/module-settings/src/components/ViewOnly/WalletRow.tsx
@@ -4,10 +4,8 @@ import { Button, HStack, Loader, Text } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
     ConnectDeviceSettings,
-    DeviceRootState,
-    DiscoveryRootState,
     deviceActions,
-    selectIsDiscoveryActiveByDeviceState,
+    selectHasDeviceDiscovery,
 } from '@suite-common/wallet-core';
 import { analytics, EventType } from '@suite-native/analytics';
 import { useAlert } from '@suite-native/alerts';
@@ -33,9 +31,7 @@ export const WalletRow = ({ device }: WalletRowProps) => {
     const { showAlert, hideAlert } = useAlert();
     const { showToast } = useToast();
     const { applyStyle } = useNativeStyles();
-    const isDeviceDiscoveryActive = useSelector((state: DiscoveryRootState & DeviceRootState) =>
-        selectIsDiscoveryActiveByDeviceState(state, device.state),
-    );
+    const hasDiscovery = useSelector(selectHasDeviceDiscovery);
 
     const walletNameLabel = device.useEmptyPassphrase ? (
         <Translation id="moduleSettings.viewOnly.wallet.standard" />
@@ -107,7 +103,7 @@ export const WalletRow = ({ device }: WalletRowProps) => {
         });
     };
 
-    const showToggleButton = device.remember || !isDeviceDiscoveryActive;
+    const showToggleButton = device.remember || !hasDiscovery;
 
     return (
         <HStack key={device.instance} style={applyStyle(walletRowStyle)}>


### PR DESCRIPTION
Replace `selectIsDeviceDiscoveryActive` with `selectHasDeviceDiscovery` to check whether there is a discovery, because if Cardano was enabled, the discovery could have been changed to `STOPPED` by cardano derivation thunk and this caused our UI not to behave correctly while waiting for discovery to finish.

On mobile, we dont rely on discovery being active, because we delete the object once it finishes so we dont need to check the state and existence check is sufficient.
