### PR TITLE
fix(coinmarket): exclude unsupported networks by address validator in trade section

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -123,7 +123,7 @@
         "@testing-library/react": "14.2.1",
         "@testing-library/user-event": "14.5.2",
         "@types/file-saver": "^2.0.6",
-        "@types/invity-api": "^1.1.0",
+        "@types/invity-api": "^1.1.1",
         "@types/jws": "^3.2.10",
         "@types/pako": "^2.0.3",
         "@types/pdfmake": "^0.2.9",

--- a/packages/suite/src/reducers/wallet/__tests__/coinmarketReducer.test.ts
+++ b/packages/suite/src/reducers/wallet/__tests__/coinmarketReducer.test.ts
@@ -71,7 +71,9 @@ describe('settings reducer', () => {
         const info: InfoResponse = {
             platforms: {
                 ethereum: {
+                    id: 'ethereum',
                     name: 'Ethereum',
+                    nativeCoinSymbol: 'eth',
                 },
             },
             coins: {

--- a/packages/suite/src/types/coinmarket/coinmarket.ts
+++ b/packages/suite/src/types/coinmarket/coinmarket.ts
@@ -155,6 +155,7 @@ export type CoinmarketUtilsProvidersProps = {
 export interface CoinmarketInfoProps {
     cryptoIdToPlatformName: (cryptoId: CryptoId) => string | undefined;
     cryptoIdToCoinSymbol: (cryptoId: CryptoId) => string | undefined;
+    cryptoIdToNativeCoinSymbol: (cryptoId: CryptoId) => string | undefined;
     buildCryptoOptions: (
         cryptoIds: Set<CryptoId>,
         excludedCryptoIds?: Set<CryptoId>,

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketVerify/CoinmarketVerify.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketVerify/CoinmarketVerify.tsx
@@ -67,7 +67,7 @@ interface CoinmarketVerifyProps {
 
 export const CoinmarketVerify = ({ coinmarketVerifyAccount, currency }: CoinmarketVerifyProps) => {
     const { translationString } = useTranslation();
-    const { cryptoIdToCoinSymbol } = useCoinmarketInfo();
+    const { cryptoIdToCoinSymbol, cryptoIdToNativeCoinSymbol } = useCoinmarketInfo();
     const context = useCoinmarketFormContext<CoinmarketTradeBuyExchangeType>();
     const { callInProgress, device, verifyAddress, addressVerified, confirmTrade } = context;
     const exchangeQuote = isCoinmarketExchangeOffers(context) ? context.selectedQuote : null;
@@ -100,7 +100,8 @@ export const CoinmarketVerify = ({ coinmarketVerifyAccount, currency }: Coinmark
         required: translationString('TR_EXCHANGE_RECEIVING_ADDRESS_REQUIRED'),
         validate: value => {
             if (selectedAccountOption?.type === 'NON_SUITE' && currency) {
-                if (value && !addressValidator.validate(value, currency)) {
+                const symbol = cryptoIdToNativeCoinSymbol(currency);
+                if (value && !addressValidator.validate(value, symbol)) {
                     return translationString('TR_EXCHANGE_RECEIVING_ADDRESS_INVALID');
                 }
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11982,7 +11982,7 @@ __metadata:
     "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@types/file-saver": "npm:^2.0.6"
-    "@types/invity-api": "npm:^1.1.0"
+    "@types/invity-api": "npm:^1.1.1"
     "@types/jws": "npm:^3.2.10"
     "@types/pako": "npm:^2.0.3"
     "@types/pdfmake": "npm:^0.2.9"
@@ -12890,10 +12890,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/invity-api@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@types/invity-api@npm:1.1.0"
-  checksum: 10/f064254b8f2ec153de9a64f46a21729d5d409a2f226c031b3a83f52338f5350e77df4fba9525ec72ca55344e9e17a961cbf790b8679e2fe5ef2fb1d35415e20b
+"@types/invity-api@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@types/invity-api@npm:1.1.1"
+  checksum: 10/8f6a5ee51ed774aab1b0ddd1b79431ee6a92d4818e164418af8885aea27b4df64b572e57f2e91c8f7f93f3c71bbfd1e339e66025a3f48474cafba72248ea7f1d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

1. Exclude unsupported networks by address validator in buy/exchange sections in crypto dropdowns
2. Pass the right symbol into address validator

## Related Issue

Resolve #14249

## Screenshots:
### Before
![image](https://github.com/user-attachments/assets/0d4a0ba2-f499-4344-b134-a5d50ba183e6)
![image](https://github.com/user-attachments/assets/79164900-a943-481e-81b8-84799ac5ee75)

### After
![image](https://github.com/user-attachments/assets/7b5168fc-28a6-43e2-a76f-7bc8a56eabad)
![image](https://github.com/user-attachments/assets/8c9507fc-6175-43d8-95bb-f7d1978cf4ed)

