### PR TITLE
fix(suite-native): let passphrase flow finish sooner if some account is found

### DIFF
--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -16,7 +16,11 @@ import {
     selectHasOnlyPortfolioDevice,
 } from '../device/deviceReducer';
 import { deviceActions } from '../device/deviceActions';
-import { DiscoveryRootState, selectIsDeviceDiscoveryActive } from '../discovery/discoveryReducer';
+import {
+    DiscoveryRootState,
+    selectHasDeviceDiscovery,
+    selectIsDeviceDiscoveryActive,
+} from '../discovery/discoveryReducer';
 
 export type AccountsState = Account[];
 
@@ -424,11 +428,17 @@ export const selectIsDeviceNotEmpty = (
 ) => {
     const deviceState = selectDeviceState(state);
     const nonEmptyAccounts = selectNonEmptyDeviceAccounts(state);
-    const isDeviceDiscoveryActive = selectIsDeviceDiscoveryActive(state);
+    const hasDiscovery = selectHasDeviceDiscovery(state);
 
-    if ((isDeviceDiscoveryActive || !deviceState) && A.isEmpty(nonEmptyAccounts)) {
+    const isNotEmpty = A.isNotEmpty(nonEmptyAccounts);
+
+    if (isNotEmpty) {
+        return true;
+    }
+
+    if (hasDiscovery || !deviceState) {
         return null;
     }
 
-    return A.isNotEmpty(nonEmptyAccounts);
+    return isNotEmpty;
 };

--- a/suite-common/wallet-core/src/discovery/discoveryReducer.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryReducer.ts
@@ -127,3 +127,6 @@ export const selectIsDiscoveryAuthConfirmationRequired = (
             discovery.status === DiscoveryStatus.COMPLETED)
     );
 };
+
+export const selectHasDeviceDiscovery = (state: DiscoveryRootState & DeviceRootState) =>
+    !!selectDeviceDiscovery(state);

--- a/suite-native/module-authorize-device/src/screens/passphrase/PassphraseLoadingScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/passphrase/PassphraseLoadingScreen.tsx
@@ -11,7 +11,7 @@ import {
     RootStackRoutes,
     StackToStackCompositeNavigationProps,
 } from '@suite-native/navigation';
-import { selectIsDeviceNotEmpty, selectIsDeviceDiscoveryActive } from '@suite-common/wallet-core';
+import { selectIsDeviceNotEmpty } from '@suite-common/wallet-core';
 import { Translation } from '@suite-native/intl';
 import { finishPassphraseFlow } from '@suite-native/device-authorization';
 import { EventType, analytics } from '@suite-native/analytics';
@@ -30,15 +30,14 @@ export const PassphraseLoadingScreen = () => {
     const dispatch = useDispatch();
 
     const isDeviceNotEmpty = useSelector(selectIsDeviceNotEmpty);
-    const isDiscoveryActive = useSelector(selectIsDeviceDiscoveryActive);
 
     const [loadingResult, setLoadingResult] = useState<SpinnerLoadingState>('idle');
 
     useEffect(() => {
-        if (!isDiscoveryActive && isDeviceNotEmpty !== null) {
+        if (isDeviceNotEmpty !== null) {
             setLoadingResult('success');
         }
-    }, [isDiscoveryActive, isDeviceNotEmpty]);
+    }, [isDeviceNotEmpty]);
 
     const handleSuccess = () => {
         if (isDeviceNotEmpty) {


### PR DESCRIPTION
Before, it waited for discovery to end. Now it takes you to dashboard as soon as first account is discovered of i no is discovered you wait for discovery to finish. 


https://github.com/user-attachments/assets/afdc5121-df01-415c-aebd-2ab7fd60d5e2

