### PR TITLE
fix(suite): rename normal to default

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2735,9 +2735,9 @@ export default defineMessages({
         id: 'TR_ACCOUNT_TYPE_IMPORTED',
         dynamic: true,
     },
-    TR_ACCOUNT_TYPE_NORMAL: {
-        defaultMessage: 'Normal',
-        id: 'TR_ACCOUNT_TYPE_NORMAL',
+    TR_ACCOUNT_TYPE_DEFAULT: {
+        defaultMessage: 'Default',
+        id: 'TR_ACCOUNT_TYPE_DEFAULT',
         dynamic: true,
     },
     TR_ACCOUNT_TYPE_SEGWIT: {

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -238,7 +238,7 @@ export const getAccountTypeName = ({ path, accountType, networkType }: getAccoun
             case 'legacy':
                 return 'TR_ACCOUNT_TYPE_LEGACY';
             case 'normal':
-                return 'TR_ACCOUNT_TYPE_NORMAL';
+                return 'TR_ACCOUNT_TYPE_DEFAULT';
         }
     } else {
         switch (accountType?.toLowerCase()) {


### PR DESCRIPTION
## Description

Rename normal account type badge to default in details page. As agreed with @Hannsek 

## Screenshots:
 
 Before:
 
![image](https://github.com/user-attachments/assets/11072292-ebe2-46c3-b77f-d888bc6c089a)

After:

![image](https://github.com/user-attachments/assets/da79cbf5-14e9-4b4a-8cbd-43db5ed2b460)
