### PR TITLE
Chore(suite): use new Networks in various suite components

### DIFF
--- a/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
+++ b/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { HiddenPlaceholder, Sign } from 'src/components/suite';
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import { isNetworkSymbol, Network, networks, NetworkSymbol } from '@suite-common/wallet-config';
 import { useSelector } from 'src/hooks/suite';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 
@@ -13,7 +13,6 @@ import {
 import { isSignValuePositive } from '@suite-common/formatters';
 import { selectLanguage } from 'src/reducers/suite/suiteReducer';
 import { BlurUrls } from 'src/views/wallet/tokens/common/BlurUrls';
-import { networksCompatibility } from '@suite-common/wallet-config';
 
 const Container = styled.span`
     max-width: 100%;
@@ -55,8 +54,9 @@ export const FormattedCryptoAmount = ({
     }
 
     const lowerCaseSymbol = symbol?.toLowerCase();
-    const { features: networkFeatures, testnet: isTestnet } =
-        networksCompatibility.find(network => network.symbol === lowerCaseSymbol) ?? {};
+    const matchedNetwork: Network | undefined =
+        lowerCaseSymbol && isNetworkSymbol(lowerCaseSymbol) ? networks[lowerCaseSymbol] : undefined;
+    const { features: networkFeatures, testnet: isTestnet } = matchedNetwork ?? {};
 
     const areSatsSupported = !!networkFeatures?.includes('amount-unit');
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/AdvancedCoinSettingsModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/AdvancedCoinSettingsModal.tsx
@@ -1,11 +1,10 @@
 import styled from 'styled-components';
 import { CoinLogo, variables } from '@trezor/components';
 import { Modal, Translation } from 'src/components/suite';
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import { networks, NetworkSymbol } from '@suite-common/wallet-config';
 import { CustomBackends } from './CustomBackends/CustomBackends';
 import { getCoinLabel } from 'src/utils/suite/getCoinLabel';
 import { useSelector } from 'src/hooks/suite';
-import { networksCompatibility } from '@suite-common/wallet-config';
 
 const Section = styled.div`
     display: flex;
@@ -40,11 +39,7 @@ interface AdvancedCoinSettingsModalProps {
 
 export const AdvancedCoinSettingsModal = ({ coin, onCancel }: AdvancedCoinSettingsModalProps) => {
     const blockchain = useSelector(state => state.wallet.blockchain);
-    const network = networksCompatibility.find(network => network.symbol === coin);
-
-    if (!network) {
-        return null;
-    }
+    const network = networks[coin];
 
     const { symbol, name, features, testnet: isTestnet } = network;
     const hasCustomBackend = !!blockchain[symbol].backends.selected;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/BackendTypeSelect.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/BackendTypeSelect.tsx
@@ -5,14 +5,14 @@ import { Select } from '@trezor/components';
 import { Translation } from 'src/components/suite';
 import { isDesktop } from '@trezor/env-utils';
 
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { Network } from '@suite-common/wallet-config';
 import type { BackendOption } from 'src/hooks/settings/backends';
 
 const Capitalize = styled.span`
     text-transform: capitalize;
 `;
 
-const useBackendOptions = (network: NetworkCompatible) =>
+const useBackendOptions = (network: Network) =>
     useMemo(
         () =>
             ['default', ...network.customBackends]
@@ -48,7 +48,7 @@ const useBackendOptions = (network: NetworkCompatible) =>
     );
 
 type BackendTypeSelectProps = {
-    network: NetworkCompatible;
+    network: Network;
     value: BackendOption;
     onChange: (type: BackendOption) => void;
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/CustomBackends.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/CustomBackends.tsx
@@ -10,7 +10,7 @@ import ConnectionInfo from './ConnectionInfo';
 import { BackendInput } from './BackendInput';
 import { BackendTypeSelect } from './BackendTypeSelect';
 import { TorModal, TorResult } from './TorModal';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { Network } from '@suite-common/wallet-config';
 import { selectTorState } from 'src/reducers/suite/suiteReducer';
 import { spacings } from '@trezor/theme';
 
@@ -59,7 +59,7 @@ const TransparentCollapsibleBox = styled(CollapsibleBox)`
 `;
 
 interface CustomBackendsProps {
-    network: NetworkCompatible;
+    network: Network;
     onCancel: () => void;
 }
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AdvancedTxDetails/AdvancedTxDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AdvancedTxDetails/AdvancedTxDetails.tsx
@@ -4,7 +4,7 @@ import { Translation } from 'src/components/suite';
 import { useElevation, variables } from '@trezor/components';
 import { isTestnet } from '@suite-common/wallet-utils';
 import { WalletAccountTransaction, ChainedTransactions } from '@suite-common/wallet-types';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { AccountType, Network } from '@suite-common/wallet-config';
 import { AmountDetails } from './AmountDetails';
 import { IODetails } from './IODetails/IODetails';
 import { ChainedTxs } from '../ChainedTxs';
@@ -50,7 +50,8 @@ export type TabID = 'amount' | 'io' | 'chained';
 
 interface AdvancedTxDetailsProps {
     defaultTab?: TabID;
-    network: NetworkCompatible;
+    network: Network;
+    accountType: AccountType;
     tx: WalletAccountTransaction;
     chainedTxs?: ChainedTransactions;
     explorerUrl: string;
@@ -60,6 +61,7 @@ interface AdvancedTxDetailsProps {
 export const AdvancedTxDetails = ({
     defaultTab,
     network,
+    accountType,
     tx,
     chainedTxs,
     explorerUrl,
@@ -74,7 +76,14 @@ export const AdvancedTxDetails = ({
     } else if (selectedTab === 'io' && network.networkType !== 'ripple') {
         content = <IODetails tx={tx} isPhishingTransaction={isPhishingTransaction} />;
     } else if (selectedTab === 'chained' && chainedTxs) {
-        content = <ChainedTxs txs={chainedTxs} explorerUrl={explorerUrl} network={network} />;
+        content = (
+            <ChainedTxs
+                txs={chainedTxs}
+                explorerUrl={explorerUrl}
+                network={network}
+                accountType={accountType}
+            />
+        );
     }
     const { elevation } = useElevation();
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
@@ -2,7 +2,7 @@ import styled, { useTheme } from 'styled-components';
 import { Icon, variables, CoinLogo, H3, useElevation } from '@trezor/components';
 import { Translation, FormattedDateWithBullet } from 'src/components/suite';
 import { WalletAccountTransaction } from 'src/types/wallet';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { Network } from '@suite-common/wallet-config';
 import { getTxIcon, isPending, getFeeUnits, getFeeRate } from '@suite-common/wallet-utils';
 import { TransactionHeader } from 'src/components/wallet/TransactionItem/TransactionHeader';
 import { fromWei } from 'web3-utils';
@@ -158,7 +158,7 @@ const IconPlaceholder = styled.span`
 
 interface BasicTxDetailsProps {
     tx: WalletAccountTransaction;
-    network: NetworkCompatible;
+    network: Network;
     confirmations: number;
     explorerUrl: string;
     explorerUrlQueryString?: string;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChainedTxs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChainedTxs.tsx
@@ -5,7 +5,7 @@ import { ChainedTransactions } from '@suite-common/wallet-types';
 
 import { TrezorLink, Translation } from 'src/components/suite';
 import { TransactionItem } from 'src/components/wallet/TransactionItem/TransactionItem';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { AccountType, Network } from '@suite-common/wallet-config';
 import { AffectedTransactionItem } from './ChangeFee/AffectedTransactionItem';
 
 const Wrapper = styled.div`
@@ -52,11 +52,12 @@ const StyledAffectedTransactionItem = styled(AffectedTransactionItem)`
 
 interface ChainedTxsProps {
     txs: ChainedTransactions;
-    network: NetworkCompatible;
+    network: Network;
+    accountType: AccountType;
     explorerUrl: string;
 }
 
-export const ChainedTxs = ({ txs, network, explorerUrl }: ChainedTxsProps) => (
+export const ChainedTxs = ({ txs, network, accountType, explorerUrl }: ChainedTxsProps) => (
     <Wrapper>
         <Header>
             <Translation id="TR_AFFECTED_TXS_HEADER" />
@@ -73,6 +74,7 @@ export const ChainedTxs = ({ txs, network, explorerUrl }: ChainedTxsProps) => (
                     key={tx.txid}
                     transaction={tx}
                     network={network}
+                    accountType={accountType}
                     isPending
                     isActionDisabled
                     accountKey={`${tx.descriptor}-${tx.symbol}-${tx.deviceState}`}

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
@@ -9,7 +9,7 @@ import { openModal } from 'src/actions/suite/modalActions';
 import { formatNetworkAmount, isTestnet, isTxFeePaid } from '@suite-common/wallet-utils';
 import { AccountLabels } from 'src/types/suite/metadata';
 import { WalletAccountTransaction } from 'src/types/wallet';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { AccountType, Network } from '@suite-common/wallet-config';
 import { TransactionTypeIcon } from './TransactionTypeIcon';
 import { TransactionHeading } from './TransactionHeading';
 import {
@@ -85,7 +85,8 @@ interface TransactionItemProps {
     isActionDisabled?: boolean; // Used in "chained transactions" transaction detail modal
     accountMetadata?: AccountLabels;
     accountKey: string;
-    network: NetworkCompatible;
+    network: Network;
+    accountType: AccountType;
     className?: string;
     index: number;
 }
@@ -98,6 +99,7 @@ export const TransactionItem = memo(
         isActionDisabled,
         isPending,
         network,
+        accountType,
         className,
         index,
     }: TransactionItemProps) => {
@@ -106,6 +108,8 @@ export const TransactionItem = memo(
         const [nestedItemIsHovered, setNestedItemIsHovered] = useState(false);
 
         const { descriptor: address, symbol } = useSelector(selectSelectedAccount) || {};
+
+        const networkFeatures = network.accountTypes[accountType]?.features ?? network.features;
 
         const dispatch = useDispatch();
         const { anchorRef, shouldHighlight } = useAnchor(
@@ -411,7 +415,7 @@ export const TransactionItem = memo(
                         </NextRow>
                         {!isActionDisabled &&
                             transaction.rbfParams &&
-                            network.features?.includes('rbf') &&
+                            networkFeatures?.includes('rbf') &&
                             !transaction?.deadline && (
                                 <NextRow>
                                     <Button

--- a/packages/suite/src/views/dashboard/components/AssetsView/components/AssetCard.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsView/components/AssetCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled, { useTheme } from 'styled-components';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { Network } from '@suite-common/wallet-config';
 
 import {
     AmountUnitSwitchWrapper,
@@ -88,7 +88,7 @@ const FailedContainer = styled.div`
 `;
 
 interface AssetCardProps {
-    network: NetworkCompatible;
+    network: Network;
     failed: boolean;
     cryptoValue: string;
     assetsFiatBalances: AssetFiatBalance[];

--- a/packages/suite/src/views/dashboard/components/AssetsView/components/AssetCardInfo.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsView/components/AssetCardInfo.tsx
@@ -1,4 +1,4 @@
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { Network } from '@suite-common/wallet-config';
 import React from 'react';
 import styled from 'styled-components';
 import { AssetFiatBalance } from '@suite-common/assets';
@@ -14,7 +14,7 @@ const Flex = styled.div`
 `;
 
 interface AssetInfoProps {
-    network: NetworkCompatible;
+    network: Network;
     assetsFiatBalances?: AssetFiatBalance[];
     index?: number;
 }

--- a/packages/suite/src/views/dashboard/components/AssetsView/components/AssetCoinName.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsView/components/AssetCoinName.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { Network } from '@suite-common/wallet-config';
 import { selectVisibleNonEmptyDeviceAccountsByNetworkSymbol } from '@suite-common/wallet-core';
 import { Icon, SkeletonRectangle } from '@trezor/components';
 import { spacingsPx, typography } from '@trezor/theme';
@@ -25,12 +25,12 @@ const WalletNumber = styled.div`
 `;
 
 interface AssetCoinNameProps {
-    network: NetworkCompatible;
+    network: Network;
 }
 
 export const AssetCoinName = ({ network }: AssetCoinNameProps) => {
     const { symbol, name } = network;
-    const selectedAccounts = useSelector((state: any) =>
+    const selectedAccounts = useSelector(state =>
         selectVisibleNonEmptyDeviceAccountsByNetworkSymbol(state, symbol),
     );
 

--- a/packages/suite/src/views/dashboard/components/AssetsView/components/AssetRow.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsView/components/AssetRow.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
 import styled, { useTheme } from 'styled-components';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { Network } from '@suite-common/wallet-config';
 import { Icon, variables, SkeletonRectangle } from '@trezor/components';
 import {
     AmountUnitSwitchWrapper,
@@ -127,7 +127,7 @@ const StyledIcon = styled(Icon)`
 `;
 
 interface AssetTableProps {
-    network: NetworkCompatible;
+    network: Network;
     failed: boolean;
     cryptoValue: string;
     isLastRow?: boolean;

--- a/packages/suite/src/views/dashboard/components/AssetsView/components/AssetTable.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsView/components/AssetTable.tsx
@@ -1,7 +1,7 @@
 import { AssetFiatBalance } from '@suite-common/assets';
 import { AssetRow, AssetRowSkeleton } from './AssetRow';
 import { AssetTableHeader } from './AssetTableHeader';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { Network } from '@suite-common/wallet-config';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 import styled from 'styled-components';
 import { spacingsPx } from '@trezor/theme';
@@ -15,7 +15,7 @@ const Table = styled.div`
 
 export interface AssetTableRowType {
     symbol: string;
-    network: NetworkCompatible;
+    network: Network;
     assetBalance: BigNumber;
     assetFailed: boolean;
 }

--- a/packages/suite/src/views/dashboard/components/AssetsView/index.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsView/index.tsx
@@ -19,7 +19,7 @@ import { AssetFiatBalance } from '@suite-common/assets';
 import { getFiatRateKey, toFiatCurrency } from '@suite-common/wallet-utils';
 import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
 import { AssetTable, AssetTableRowType } from './components/AssetTable';
-import { networksCompatibility, NetworkSymbol } from '@suite-common/wallet-config';
+import { networks, Network, NetworkSymbol } from '@suite-common/wallet-config';
 
 const InfoMessage = styled.div`
     padding: ${spacingsPx.md} ${spacingsPx.xl};
@@ -90,11 +90,11 @@ export const AssetsView = () => {
         assets[a.symbol].push(a);
     });
 
-    const networks = Object.keys(assets);
+    const assetNetworkSymbols = Object.keys(assets) as NetworkSymbol[];
 
-    const assetsData: AssetTableRowType[] = networks
+    const assetsData: AssetTableRowType[] = assetNetworkSymbols
         .map(symbol => {
-            const network = networksCompatibility.find(n => n.symbol === symbol && !n.accountType);
+            const network: Network = networks[symbol];
             if (!network) {
                 console.error('unknown network');
 
@@ -115,7 +115,8 @@ export const AssetsView = () => {
     const assetsFiatBalances = useAssetsFiatBalances(assetsData, assets);
     const discoveryStatus = getDiscoveryStatus();
     const discoveryInProgress = discoveryStatus && discoveryStatus.status === 'loading';
-    const isError = discoveryStatus && discoveryStatus.status === 'exception' && !networks.length;
+    const isError =
+        discoveryStatus && discoveryStatus.status === 'exception' && !assetNetworkSymbols.length;
 
     const goToCoinsSettings = () => dispatch(goto('settings-coins'));
     const setTable = () => dispatch(setFlag('dashboardAssetsGridMode', false));

--- a/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
@@ -29,7 +29,7 @@ import { DesktopSuiteBanner } from './DesktopSuiteBanner';
 import { AddressDisplay } from './AddressDisplay';
 import { EnableViewOnly } from './EnableViewOnly';
 import { Experimental } from './Experimental';
-import { networksCompatibility } from '@suite-common/wallet-config';
+import { networks, NetworkFeature } from '@suite-common/wallet-config';
 import { TorSnowflake } from './TorSnowflake';
 import { AutomaticUpdate } from './AutomaticUpdate';
 
@@ -47,10 +47,11 @@ export const SettingsGeneral = () => {
         selectHasExperimentalFeature('tor-snowflake'),
     );
 
-    const hasBitcoinNetworks = networksCompatibility.some(
-        ({ symbol, features }) =>
-            enabledNetworks.includes(symbol) && features?.includes('amount-unit'),
-    );
+    const hasBitcoinNetworks = enabledNetworks.some(symbol => {
+        const networkFeatures: NetworkFeature[] = networks[symbol].features;
+
+        return networkFeatures.includes('amount-unit');
+    });
 
     const isMetadataEnabled = metadata.enabled && !metadata.initiating;
     const isProviderConnected = useSelector(selectSelectedProviderForLabels);

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionGroupedList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionGroupedList.tsx
@@ -1,8 +1,5 @@
-import {
-    getAccountNetwork,
-    GroupedTransactionsByDate,
-    groupJointTransactions,
-} from '@suite-common/wallet-utils';
+import { GroupedTransactionsByDate, groupJointTransactions } from '@suite-common/wallet-utils';
+import { networks, Network } from '@suite-common/wallet-config';
 import { CoinjoinBatchItem } from 'src/components/wallet/TransactionItem/CoinjoinBatchItem';
 import { useSelector } from 'src/hooks/suite';
 import { Account, WalletAccountTransaction } from 'src/types/wallet';
@@ -26,7 +23,7 @@ export const TransactionGroupedList = ({
 }: TransactionGroupedListProps) => {
     const localCurrency = useSelector(selectLocalCurrency);
     const accountMetadata = useSelector(state => selectLabelingDataForAccount(state, account.key));
-    const network = getAccountNetwork(account);
+    const network: Network = networks[symbol];
 
     return Object.entries(transactionGroups).map(([dateKey, value], groupIndex) => (
         <TransactionsGroup
@@ -53,7 +50,8 @@ export const TransactionGroupedList = ({
                         isPending={isPending}
                         accountMetadata={accountMetadata}
                         accountKey={account.key}
-                        network={network!}
+                        network={network}
+                        accountType={account.accountType}
                         index={index}
                     />
                 ),


### PR DESCRIPTION
Refactoring deprecated `networksCompatibility` to `networks`  in various low-hanging fruit components.

## Description

- https://github.com/trezor/trezor-suite/pull/14280/commits/29048c16eff60cb734cdee0cff74418aa98a0283 Bump fee for a pending transaction (should be displayed if network OR account supports it)
- https://github.com/trezor/trezor-suite/pull/14280/commits/1466854b4baba08c894d5da613917a43b18b0ad1 Backend selection modal
- https://github.com/trezor/trezor-suite/pull/14280/commits/6da7b0e1369e4ad4619cb8c1e3c8d1f51f6e03a5 FormattedCryptoAmount
- https://github.com/trezor/trezor-suite/pull/14280/commits/475cbeea0bfef22335c4cf7200e81445002d1328 Conditionally displaying the option for btc/sat units, if you enabled a network that supports it
- https://github.com/trezor/trezor-suite/pull/14280/commits/94874251941cfe961c59b591cd425b63c5202b34 Dashboard Assets overview

## Related Issue

Part of #13839

## Screenshots:

All those seem to work as before:

![image](https://github.com/user-attachments/assets/c7dc399f-dd49-422d-9fd1-6891a1906d96)
![image](https://github.com/user-attachments/assets/a41b9af0-5a40-4a28-8b8a-04a6dc037918)


![image](https://github.com/user-attachments/assets/fc4d98f3-9bc2-4285-baa0-8b985672ddc0)


![image](https://github.com/user-attachments/assets/85c0f373-185a-4a31-983c-ebbe468a2233)
![image](https://github.com/user-attachments/assets/5b176dec-6416-48c3-909a-41685524cbb3)

[Screencast from 2024-09-11 13-22-31.webm](https://github.com/user-attachments/assets/f8ba5b52-d546-4432-a449-aae36eb34121)

![image](https://github.com/user-attachments/assets/116ee620-8178-4e7e-a766-ba5b52ca5db6)
