### PR TITLE
chore(suite-native): use new Networks structure

### DIFF
--- a/suite-common/wallet-config/src/types.ts
+++ b/suite-common/wallet-config/src/types.ts
@@ -1,4 +1,5 @@
 import { DeviceModelInternal } from '@trezor/connect';
+import { RequiredKey } from '@trezor/type-utils';
 
 export type NetworkSymbol =
     | 'btc'
@@ -73,6 +74,7 @@ type NetworkAccountWithSpecificKey<TKey extends AccountType> = {
     isDebugOnlyAccountType?: boolean;
 };
 export type NetworkAccount = NetworkAccountWithSpecificKey<AccountType>;
+export type NormalizedNetworkAccount = RequiredKey<NetworkAccount, 'features'>;
 
 export type NetworkAccountTypes = Partial<{
     [key in AccountType]: NetworkAccountWithSpecificKey<key>;

--- a/suite-common/wallet-config/src/utils.ts
+++ b/suite-common/wallet-config/src/utils.ts
@@ -1,5 +1,14 @@
 import { networks, networksCompatibility } from './networksConfig';
-import { AccountType, Network, NetworkFeature, Networks, NetworkSymbol } from './types';
+import {
+    AccountType,
+    Network,
+    NetworkFeature,
+    Networks,
+    NetworkSymbol,
+    NormalizedNetworkAccount,
+} from './types';
+
+export const NORMAL_ACCOUNT_TYPE = 'normal' satisfies AccountType;
 
 /**
  * array from `networks` as a `Network[]` type instead of inferred type
@@ -35,6 +44,23 @@ export const getTestnets = (debug = false) =>
     networksCollection.filter(n => n.testnet === true && (!n.isDebugOnlyNetwork || debug));
 
 export const getTestnetSymbols = () => getTestnets().map(n => n.symbol);
+
+/**
+ * For a given network, return a collection of accounts incl. 'normal', and with missing properties backfilled from 'normal'
+ */
+export const normalizeNetworkAccounts = (network: Network): NormalizedNetworkAccount[] => {
+    const normalAccount: NormalizedNetworkAccount = {
+        accountType: NORMAL_ACCOUNT_TYPE,
+        bip43Path: network.bip43Path,
+        features: network.features,
+    };
+    const alternativeAccounts = Object.values(network.accountTypes).map(account => ({
+        ...normalAccount,
+        ...account,
+    }));
+
+    return [normalAccount, ...alternativeAccounts];
+};
 
 export const isBlockbookBasedNetwork = (symbol: NetworkSymbol) =>
     networks[symbol]?.customBackends.some(backend => backend === 'blockbook');

--- a/suite-common/wallet-config/src/utils.ts
+++ b/suite-common/wallet-config/src/utils.ts
@@ -1,4 +1,4 @@
-import { networks, networksCompatibility } from './networksConfig';
+import { networks } from './networksConfig';
 import {
     AccountType,
     Network,
@@ -14,26 +14,6 @@ export const NORMAL_ACCOUNT_TYPE = 'normal' satisfies AccountType;
  * array from `networks` as a `Network[]` type instead of inferred type
  */
 export const networksCollection: Network[] = Object.values(networks);
-
-/**
- * @deprecated See `networksCompatibility`
- */
-export const getMainnetsCompatible = (debug = false, bnb = false) =>
-    networksCompatibility.filter(
-        n =>
-            !n.accountType &&
-            !n.testnet &&
-            (!n.isDebugOnlyNetwork || debug) &&
-            (bnb || n.symbol !== 'bnb'),
-    );
-
-/**
- * @deprecated See `networksCompatibility`
- */
-export const getTestnetsCompatible = (debug = false) =>
-    networksCompatibility.filter(
-        n => !n.accountType && n.testnet === true && (!n.isDebugOnlyNetwork || debug),
-    );
 
 export const getMainnets = (debug = false, bnb = false) =>
     networksCollection.filter(

--- a/suite-native/config/src/supportedNetworks.ts
+++ b/suite-native/config/src/supportedNetworks.ts
@@ -3,10 +3,10 @@ import { A } from '@mobily/ts-belt';
 import { isTestnet } from '@suite-common/wallet-utils';
 import {
     AccountType,
-    NetworkCompatible,
+    Network,
     NetworkSymbol,
-    getMainnetsCompatible,
-    getTestnetsCompatible,
+    getMainnets,
+    getTestnets,
 } from '@suite-common/wallet-config';
 
 export const orderedAccountTypes: AccountType[] = [
@@ -48,7 +48,7 @@ export const discoverySupportedNetworks = [
     ...networkSymbolsWhitelistMap.testnet,
 ];
 
-export const sortNetworks = (networks: NetworkCompatible[]) =>
+export const sortNetworks = (networks: Network[]) =>
     A.sort(networks, (a, b) => {
         const aOrder = discoverySupportedNetworks.indexOf(a.symbol) ?? Number.MAX_SAFE_INTEGER;
         const bOrder = discoverySupportedNetworks.indexOf(b.symbol) ?? Number.MAX_SAFE_INTEGER;
@@ -65,24 +65,21 @@ export const filterTestnetNetworks = (
     return networkSymbols.filter(networkSymbol => !isTestnet(networkSymbol));
 };
 
-export const filterBlacklistedNetworks = (
-    networks: NetworkCompatible[],
-    allowList: NetworkSymbol[],
-) =>
+export const filterBlacklistedNetworks = (networks: Network[], allowList: NetworkSymbol[]) =>
     networks.filter(
         network =>
             !discoveryBlacklist.includes(network.symbol) || allowList.includes(network.symbol),
     );
 
 export const portfolioTrackerMainnets = sortNetworks(
-    getMainnetsCompatible()
+    getMainnets()
         .filter(network => networkSymbolsWhitelistMap.mainnet.includes(network.symbol))
         .filter(network => !portfolioTrackerBlacklist.includes(network.symbol)),
 ).map(network => network.symbol);
 
 const getPortfolioTrackerTestnets = () => {
     return sortNetworks(
-        getTestnetsCompatible().filter(network =>
+        getTestnets().filter(network =>
             networkSymbolsWhitelistMap.testnet.includes(network.symbol),
         ),
     ).map(network => network.symbol);

--- a/suite-native/discovery/src/discoveryConfigSlice.ts
+++ b/suite-native/discovery/src/discoveryConfigSlice.ts
@@ -19,8 +19,6 @@ import {
     selectIsFeatureFlagEnabled,
 } from '@suite-native/feature-flags';
 
-import { getNetworkSymbols } from './utils';
-
 type DiscoveryInfo = {
     startTimestamp: number;
     networkSymbols: NetworkSymbol[];
@@ -115,7 +113,7 @@ export const selectDiscoveryNetworkSymbols = memoizeWithArgs(
     ) => {
         const supportedNetworks = selectDiscoverySupportedNetworks(state, forcedAreTestnetsEnabled);
 
-        return getNetworkSymbols(supportedNetworks);
+        return supportedNetworks.map(n => n.symbol);
     },
     { size: 2 },
 );

--- a/suite-native/discovery/src/discoverySelectors.ts
+++ b/suite-native/discovery/src/discoverySelectors.ts
@@ -4,7 +4,7 @@ import {
     selectIsSpecificCoinDefinitionKnown,
     TokenDefinitionsRootState,
 } from '@suite-common/token-definitions';
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import { AccountType, NetworkSymbol } from '@suite-common/wallet-config';
 import {
     LIMIT as ACCOUNTS_LIMIT,
     AccountsRootState,
@@ -107,6 +107,7 @@ export const selectNetworksWithUnfinishedDiscovery = (
         FeatureFlagsRootState &
         DiscoveryConfigSliceRootState,
     forcedAreTestnetsEnabled?: boolean,
+    availableCardanoDerivations?: AccountType[],
 ) => {
     const enabledNetworkSymbols = selectDeviceEnabledDiscoveryNetworkSymbols(
         state,
@@ -117,7 +118,12 @@ export const selectNetworksWithUnfinishedDiscovery = (
 
     const enabledNetworks = supportedNetworks.filter(n => enabledNetworkSymbols.includes(n.symbol));
 
-    return getNetworksWithUnfinishedDiscovery(enabledNetworks, accounts, ACCOUNTS_LIMIT);
+    return getNetworksWithUnfinishedDiscovery({
+        enabledNetworks,
+        accounts,
+        accountsLimit: ACCOUNTS_LIMIT,
+        availableCardanoDerivations,
+    });
 };
 
 //we should run discovery when there are network symbols with unfinished discovery

--- a/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
+++ b/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
@@ -5,7 +5,12 @@ import { A, pipe } from '@mobily/ts-belt';
 import { isRejected } from '@reduxjs/toolkit';
 import { CommonActions, useNavigation } from '@react-navigation/native';
 
-import { AccountType, NetworkSymbol, networks } from '@suite-common/wallet-config';
+import {
+    AccountType,
+    NetworkSymbol,
+    networks,
+    NORMAL_ACCOUNT_TYPE,
+} from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
 import {
     AccountsRootState,
@@ -18,8 +23,6 @@ import {
 } from '@suite-common/wallet-core';
 import {
     addAndDiscoverNetworkAccountThunk,
-    selectDiscoverySupportedNetworks,
-    NORMAL_ACCOUNT_TYPE,
     selectDeviceEnabledDiscoveryNetworkSymbols,
     selectDiscoveryNetworkSymbols,
 } from '@suite-native/discovery';
@@ -73,7 +76,6 @@ export const useAddCoinAccount = () => {
     const dispatch = useDispatch();
     const { translate } = useTranslate();
 
-    const supportedNetworks = useSelector(selectDiscoverySupportedNetworks);
     const supportedNetworkSymbols = useSelector(selectDiscoveryNetworkSymbols);
     const deviceAccounts = useSelector((state: AccountsRootState & DeviceRootState) =>
         selectDeviceAccounts(state),
@@ -121,24 +123,6 @@ export const useAddCoinAccount = () => {
     }: {
         networkSymbol: NetworkSymbol;
     }) => availableNetworkAccountTypes.get(networkSymbol) ?? [NORMAL_ACCOUNT_TYPE];
-
-    const getNetworkToAdd = ({
-        networkSymbol,
-        accountType,
-    }: {
-        networkSymbol: NetworkSymbol;
-        accountType?: AccountType;
-    }) => {
-        const type = accountType ?? NORMAL_ACCOUNT_TYPE;
-
-        return supportedNetworks.filter(
-            network =>
-                network.symbol === networkSymbol &&
-                (type === NORMAL_ACCOUNT_TYPE
-                    ? network.accountType === undefined
-                    : network.accountType === type),
-        )[0];
-    };
 
     const getAccountTypeToBeAddedName = () =>
         networkSymbolWithTypeToBeAdded
@@ -258,7 +242,7 @@ export const useAddCoinAccount = () => {
             return;
         }
 
-        const network = getNetworkToAdd({ networkSymbol, accountType });
+        const network = networks[networkSymbol];
 
         //If the account already exists, but is invisible, make it visible
         if (firstHiddenEmptyAccount) {
@@ -275,6 +259,7 @@ export const useAddCoinAccount = () => {
         const newAccountResult = await dispatch(
             addAndDiscoverNetworkAccountThunk({
                 network,
+                accountType,
                 deviceState: device.state,
             }),
         );


### PR DESCRIPTION
Refactoring deprecated `networksCompatibility` to `networks` + related utils in Suite Native

## Description

- 8f0270267d714f747542facdee446861ef20ed69 add a new helper to make working with account types easier & less confusing
- 35616d6c0270ad8ad24976d0f204aa801e49f56e
  - refactor account discovery
  - update adding coinjoin account
  - keep backwards compatibility for suite, until it is refactored there too 

## Related Issue

Part of #13839

## Screenshots

Discovered accounts at Android - the same screenshot on develop & this branch: :heavy_check_mark: 
![Screenshot from 2024-09-19 09-39-05](https://github.com/user-attachments/assets/8256fda9-3eff-4107-a279-6501aab732e1)

To be really sure discovery works the same under the hood, I console logged [discoveryNetworksTotalCount (TOTAL)](https://github.com/trezor/trezor-suite/blob/b92c24e0f3a100b1c17fa3ff3856b5b2c9240860/suite-native/discovery/src/discoveryThunks.ts#L569), [finishedNetworksCount (LOADED)](https://github.com/trezor/trezor-suite/blob/b92c24e0f3a100b1c17fa3ff3856b5b2c9240860/suite-native/discovery/src/discoveryThunks.ts#L125) and [network+accountType? when dispatching new discovery](https://github.com/trezor/trezor-suite/blob/b92c24e0f3a100b1c17fa3ff3856b5b2c9240860/suite-native/discovery/src/discoveryThunks.ts#L698).
These are the results - I verifed they are the same at develop & this branch: :heavy_check_mark: 
[accountDiscovery.txt](https://github.com/user-attachments/files/17055704/accountDiscovery.txt)
