### PR TITLE
Support semver labels in version utils

### DIFF
--- a/packages/connect/e2e/common.setup.ts
+++ b/packages/connect/e2e/common.setup.ts
@@ -155,46 +155,36 @@ export const skipTest = (rules: string[]) => {
     const rule = rules
         .filter(skip => skip.substring(0, 1) === fwModel || skip.substring(1, 2) === fwModel) // filter rules only for current model
         .find(skip => {
-            if (!skip.search('.') && skip === fwModel) {
-                // global model
-                return true;
+            // global model
+            if (!skip.includes('.')) {
+                return skip === fwModel;
             }
 
             // is within range
-            const [from, to] = skip.split('-');
-            if (
-                !fwMaster &&
-                from &&
-                to &&
-                versionUtils.isNewerOrEqual(firmware, from) &&
-                !versionUtils.isNewer(firmware, to)
-            ) {
-                return true;
+            if (skip.includes('-')) {
+                const [from, to] = skip.split('-');
+
+                return (
+                    !fwMaster &&
+                    from &&
+                    to &&
+                    versionUtils.isNewerOrEqual(firmware, from) &&
+                    !versionUtils.isNewer(firmware, to)
+                );
             }
 
-            if (
-                !fwMaster &&
-                skip.startsWith('<') &&
-                !versionUtils.isNewerOrEqual(firmware, skip.substring(1))
-            ) {
-                // lower
-                return true;
-            }
-            if (
-                (fwMaster && skip.startsWith('>')) ||
-                (!fwMaster &&
-                    skip.startsWith('>') &&
-                    versionUtils.isNewer(firmware, skip.substring(1)))
-            ) {
-                // greater
-                return true;
-            }
-            if (!fwMaster && versionUtils.isEqual(firmware, skip)) {
-                // exact
-                return true;
+            // lower
+            if (skip.startsWith('<')) {
+                return !fwMaster && !versionUtils.isNewerOrEqual(firmware, skip.substring(1));
             }
 
-            return false;
+            // greater
+            if (skip.startsWith('>')) {
+                return fwMaster || versionUtils.isNewer(firmware, skip.substring(1));
+            }
+
+            // exact
+            return !fwMaster && versionUtils.isEqual(firmware, skip);
         });
 
     return rule;

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -251,7 +251,9 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
             return UI.FIRMWARE_NOT_SUPPORTED;
         }
 
-        const version = device.getVersion().join('.');
+        const version = device.getVersion();
+        if (!version) return;
+
         if (
             device.firmwareStatus === 'required' ||
             !versionUtils.isNewerOrEqual(version, range.min)

--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -105,11 +105,7 @@ export class BridgeTransport extends AbstractTransport {
             this.version = response.payload.version;
 
             if (this.latestVersion) {
-                this.isOutdated = versionUtils.isNewer(
-                    this.latestVersion,
-                    // node bridge version is in format "3.0.0-bundled.24.10.0"
-                    this.version.split('-')[0],
-                );
+                this.isOutdated = versionUtils.isNewer(this.latestVersion, this.version);
             }
             this.useProtocolMessages = !!response.payload.protocolMessages;
 

--- a/packages/utils/tests/versionUtils.test.ts
+++ b/packages/utils/tests/versionUtils.test.ts
@@ -6,89 +6,44 @@ import {
     isVersionArray,
 } from '../src/versionUtils';
 
-describe('versionUtils', () => {
-    describe('isNewer', () => {
-        // older
-        it('it should return false [0, 0, 1] [0, 0, 2]', () => {
-            const result = isNewer([1, 0, 1], [1, 0, 2]);
-            expect(result).toBe(false);
-        });
+const fixture = [
+    [[1, 0, 0], '1.0.0-beta'],
+    [[1, 0, 1]],
+    [[1, 0, 2], '1.0.2'],
+    [[1, 1, 1]],
+    [[1, 20, 1], '1.20.1-prerelase', '1.20.1-foo.4.5.6'],
+    [[2, 1, 1]],
+] satisfies ([number, number, number] | string)[][];
 
-        it('it should return false [0, 1, 1] [0, 2, 1]', () => {
-            const result = isNewer([1, 1, 1], [1, 2, 1]);
-            expect(result).toBe(false);
-        });
-
-        it('it should return false [1, 1, 1] [2, 1, 1]', () => {
-            const result = isNewer([1, 1, 1], [2, 1, 1]);
-            expect(result).toBe(false);
-        });
-
-        it('it should return false [1, 0, 0], [1, 0, 1]', () => {
-            const result = isNewer([1, 0, 0], [1, 0, 1]);
-            expect(result).toBe(false);
-        });
-
-        // newer
-        it('it should return true [0, 0, 2] [0, 0, 1]', () => {
-            const result = isNewer([1, 0, 2], [1, 0, 1]);
-            expect(result).toBe(true);
-        });
-
-        it('it should return true [0, 2, 1] [0, 1, 1]', () => {
-            const result = isNewer([1, 2, 1], [1, 1, 1]);
-            expect(result).toBe(true);
-        });
-
-        it('it should return true [2, 1, 1] [1, 1, 1]', () => {
-            const result = isNewer([2, 1, 1], [1, 1, 1]);
-            expect(result).toBe(true);
-        });
-
-        it('it should return true [1, 0, 1], [1, 0, 0]', () => {
-            const result = isNewer([1, 0, 1], [1, 0, 0]);
-            expect(result).toBe(true);
-        });
-
-        // equal
-        it('it should return false [1, 1, 1] [1, 1, 1]', () => {
-            const result = isNewer([1, 1, 1], [1, 1, 1]);
-            expect(result).toEqual(false);
+const testMatrix = (
+    testCase: (first: any, second: any) => any,
+    expectedResult: (firstIndex: number, secondIndex: number) => boolean,
+) => {
+    fixture.forEach((firstSet, firstIndex) => {
+        fixture.forEach((secondSet, secondIndex) => {
+            firstSet.forEach(first => {
+                secondSet.forEach(second => {
+                    const expected = expectedResult(firstIndex, secondIndex);
+                    it(`${first} and ${second} should return ${expected}`, () => {
+                        expect(testCase(first, second)).toBe(expected);
+                    });
+                });
+            });
         });
     });
+};
 
-    describe('isEqual', () => {
-        it('it should return false [1, 0, 0], [1, 0, 1]', () => {
-            const result = isEqual([1, 0, 0], [1, 0, 1]);
-            expect(result).toBe(false);
-        });
-
-        it('it should return false [1, 0, 1], [1, 0, 0]', () => {
-            const result = isEqual([1, 0, 1], [1, 0, 0]);
-            expect(result).toBe(false);
-        });
-
-        it('it should return true [1, 1, 1], [1, 1, 1]', () => {
-            const result = isEqual([1, 1, 1], [1, 1, 1]);
-            expect(result).toBe(true);
-        });
+describe('versionUtils', () => {
+    describe('isNewer', () => {
+        testMatrix(isNewer, (a, b) => a > b);
     });
 
     describe('isNewerOrEqual', () => {
-        it('it should return false [1, 0, 0], [1, 0, 1]', () => {
-            const result = isNewerOrEqual([1, 0, 0], [1, 0, 1]);
-            expect(result).toBe(false);
-        });
+        testMatrix(isNewerOrEqual, (a, b) => a >= b);
+    });
 
-        it('it should return true [1, 0, 1], [1, 0, 0]', () => {
-            const result = isNewerOrEqual([1, 0, 1], [1, 0, 0]);
-            expect(result).toBe(true);
-        });
-
-        it('it should return true [1, 1, 1], [1, 1, 1]', () => {
-            const result = isNewerOrEqual([1, 1, 1], [1, 1, 1]);
-            expect(result).toBe(true);
-        });
+    describe('isEqual', () => {
+        testMatrix(isEqual, (a, b) => a === b);
     });
 
     describe('normalizeVersion', () => {


### PR DESCRIPTION
## Description

Even with #14252, Suite is sometimes still failing to properly compare new `3.0.0-bundled.24.10` Bridge version format. Therefore I extended `versionUtils` to be able to parse (and ignore) these semver labels, and, while I was in it, refactored the utils a bit.

The last commit removes the changes from #14252, which is optional. It's perfectly ok to leave it there.
