### PR TITLE
Fix/reconnect to normal

### DIFF
--- a/packages/components/src/components/animations/DeviceAnimation.tsx
+++ b/packages/components/src/components/animations/DeviceAnimation.tsx
@@ -105,7 +105,7 @@ export const DeviceAnimation = forwardRef<HTMLVideoElement, DeviceAnimationProps
                     >
                         <source
                             src={resolveStaticPath(
-                                `videos/device/trezor_${DeviceModelInternal.T1B1.toLowerCase()}_${type.toLowerCase()}${theme}.webm`,
+                                `videos/device/trezor_${DeviceModelInternal.T1B1.toLowerCase()}_${type.toLowerCase()}${themeSuffix}.webm`,
                             )}
                             type="video/webm"
                         />

--- a/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
+++ b/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
@@ -144,18 +144,27 @@ const RebootDeviceGraphics = ({
 
     const deviceModelInternal = device?.features?.internal_model;
 
-    // T1B1 bootloader before firmware version 1.8.0 can only be invoked by holding both buttons
-    const deviceFwVersion = device?.features ? getFirmwareVersion(device) : '';
-    const type =
-        deviceModelInternal === DeviceModelInternal.T1B1 &&
-        semver.valid(deviceFwVersion) &&
-        semver.satisfies(deviceFwVersion, '<1.8.0')
-            ? 'BOOTLOADER_TWO_BUTTONS'
-            : 'BOOTLOADER';
+    const getRebootType = () => {
+        // Used during intermediary update on T1B1.
+        if (device?.mode === 'bootloader') {
+            return 'NORMAL';
+        }
+        // T1B1 bootloader before firmware version 1.8.0 can only be invoked by holding both buttons.
+        const deviceFwVersion = device?.features ? getFirmwareVersion(device) : '';
+        if (
+            deviceModelInternal === DeviceModelInternal.T1B1 &&
+            semver.valid(deviceFwVersion) &&
+            semver.satisfies(deviceFwVersion, '<1.8.0')
+        ) {
+            return 'BOOTLOADER_TWO_BUTTONS';
+        }
+
+        return 'BOOTLOADER';
+    };
 
     return (
         <StyledDeviceAnimation
-            type={type}
+            type={getRebootType()}
             height="220px"
             width="220px"
             shape="ROUNDED"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use correct animation when rebooting to normal mode during intermediary firmware update. Previously, the animation depicted reboot to bootloader with the left button clicked.

QA: You'll need a devkit to test this and possibly old Bridge for Suite to be able to communicate with the device.

Note: `AbortButton` should be fixed [elsewhere](https://github.com/trezor/trezor-suite/issues/14260).

## Screenshots:
![Screenshot 2024-09-11 at 15 11 11](https://github.com/user-attachments/assets/79679731-7508-45d7-a12e-4602de217648)

