### PR TITLE
fix(coinmarket): show DCA page only for Bitcoin accounts #14290

### DIFF
--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketLayout.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketLayout.tsx
@@ -74,7 +74,7 @@ export const CoinmarketLayout = ({
                 )}
             </WalletSubpageHeading>
 
-            <CoinmarketLayoutNavigation />
+            <CoinmarketLayoutNavigation selectedAccount={selectedAccount} />
 
             <Layout>
                 <CardWrapper>

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayoutNew/CoinmarketLayout.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayoutNew/CoinmarketLayout.tsx
@@ -29,7 +29,7 @@ const CoinmarketLayout = ({ children, selectedAccount }: CoinmarketLayoutProps) 
     <WalletLayout title="TR_NAV_TRADE" isSubpage account={selectedAccount}>
         <CoinmarketWrapper>
             <WalletSubpageHeading title="TR_NAV_TRADE" />
-            <CoinmarketLayoutNavigation />
+            <CoinmarketLayoutNavigation selectedAccount={selectedAccount} />
             <CoinmarketFormWrapper>{children}</CoinmarketFormWrapper>
             <CoinmarketFooter />
         </CoinmarketWrapper>

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayoutNew/CoinmarketLayoutNavigation/CoinmarketLayoutNavigation.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayoutNew/CoinmarketLayoutNavigation/CoinmarketLayoutNavigation.tsx
@@ -6,6 +6,7 @@ import { Divider } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 import regional from 'src/constants/wallet/coinmarket/regional';
 import { getIsTorEnabled } from 'src/utils/suite/tor';
+import { SelectedAccountLoaded } from '@suite-common/wallet-types';
 
 const List = styled.div`
     display: flex;
@@ -17,10 +18,15 @@ const SeparatorWrapper = styled.div`
     height: 42px;
 `;
 
-const CoinmarketLayoutNavigation = () => {
+interface CoinmarketLayoutNavigationProps {
+    selectedAccount: SelectedAccountLoaded;
+}
+
+const CoinmarketLayoutNavigation = ({ selectedAccount }: CoinmarketLayoutNavigationProps) => {
     const { device } = useDevice();
     const isBitcoinOnly = device?.firmwareType === FirmwareType.BitcoinOnly;
 
+    const isBtcAccount = selectedAccount.account.symbol === 'btc';
     const torStatus = useSelector(state => state.suite.torStatus);
     const isTorEnabled = getIsTorEnabled(torStatus);
     const country = useSelector(
@@ -28,7 +34,7 @@ const CoinmarketLayoutNavigation = () => {
             state.wallet.coinmarket.buy.buyInfo?.buyInfo?.country ??
             state.wallet.coinmarket.sell.sellInfo?.sellList?.country,
     );
-    const isInEEA = Boolean(!isTorEnabled && country && regional.isInEEA(country));
+    const showDCA = Boolean(isBtcAccount && !isTorEnabled && country && regional.isInEEA(country));
 
     return (
         <List>
@@ -51,7 +57,7 @@ const CoinmarketLayoutNavigation = () => {
                 />
             ) : null}
 
-            {isInEEA ? (
+            {showDCA ? (
                 <>
                     <SeparatorWrapper>
                         <Divider


### PR DESCRIPTION
## Description

Show DCA only for Bitcoin accounts.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/14290
