### PR TITLE
fix(suite-native): fix extra line breaks on some Android phones

### DIFF
--- a/suite-native/formatters/package.json
+++ b/suite-native/formatters/package.json
@@ -21,6 +21,7 @@
         "@suite-common/wallet-utils": "workspace:*",
         "@suite-native/atoms": "workspace:*",
         "@suite-native/settings": "workspace:*",
+        "@trezor/env-utils": "workspace:*",
         "@trezor/styles": "workspace:*",
         "@trezor/utils": "workspace:*",
         "react": "18.2.0",

--- a/suite-native/formatters/src/components/AmountText.tsx
+++ b/suite-native/formatters/src/components/AmountText.tsx
@@ -1,14 +1,31 @@
 import { DiscreetText, Text, TextProps } from '@suite-native/atoms';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+import { isAndroid } from '@trezor/env-utils';
 
 type AmountTextProps = {
     isDiscreetText?: boolean;
     value: string | null;
 } & TextProps;
 
-export const AmountText = ({ value, isDiscreetText = true, ...textProps }: AmountTextProps) => {
-    if (isDiscreetText) {
-        return <DiscreetText {...textProps}>{value}</DiscreetText>;
-    }
+const amountTextStyle = prepareNativeStyle(_ => ({
+    // Because of this RN issue https://github.com/facebook/react-native/issues/46436
+    // turning off custom letter spacing for amounts on Android.
+    extend: {
+        condition: isAndroid(),
+        style: {
+            letterSpacing: 0,
+        },
+    },
+}));
 
-    return <Text {...textProps}>{value}</Text>;
+export const AmountText = ({ value, isDiscreetText = true, ...textProps }: AmountTextProps) => {
+    const { applyStyle } = useNativeStyles();
+
+    const TextComponent = isDiscreetText ? DiscreetText : Text;
+
+    return (
+        <TextComponent style={applyStyle(amountTextStyle)} {...textProps}>
+            {value}
+        </TextComponent>
+    );
 };

--- a/suite-native/formatters/tsconfig.json
+++ b/suite-native/formatters/tsconfig.json
@@ -22,6 +22,7 @@
         },
         { "path": "../atoms" },
         { "path": "../settings" },
+        { "path": "../../packages/env-utils" },
         { "path": "../../packages/styles" },
         { "path": "../../packages/utils" }
     ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -9918,6 +9918,7 @@ __metadata:
     "@suite-common/wallet-utils": "workspace:*"
     "@suite-native/atoms": "workspace:*"
     "@suite-native/settings": "workspace:*"
+    "@trezor/env-utils": "workspace:*"
     "@trezor/styles": "workspace:*"
     "@trezor/utils": "workspace:*"
     react: "npm:18.2.0"


### PR DESCRIPTION
## Description

On some Android devices (reported from Xiaomi) there were extra line breaks on some places i.e. portfolio balance, dashboard asset fiat value.

Only some specific values had that bug and only on some font scales.

Bug reported https://github.com/facebook/react-native/issues/46436

~As a workaround automatic font scaling is disabled and handled manually.~ (Didn't work well, just line breaking on other places.)

As a workaround custom letter spacing is disabled for crypto and fiat values on Android.

## Related Issue

Resolve [#14177](https://github.com/trezor/trezor-suite/issues/14177)


## Notes for QA

- Test different system font scales.
