### PR TITLE
fix(coinmarket): fix crypto ticker in receive dropdown

### DIFF
--- a/packages/suite/src/hooks/wallet/coinmarket/useCoinmarketInfo.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/useCoinmarketInfo.ts
@@ -30,6 +30,8 @@ export const useCoinmarketInfo = (): CoinmarketInfoProps => {
         [platforms],
     );
 
+    const cryptoIdToCoinName = useCallback((cryptoId: CryptoId) => coins[cryptoId]?.name, [coins]);
+
     const cryptoIdToNativeCoinSymbol = useCallback(
         (cryptoId: CryptoId) => {
             const { networkId } = parseCryptoId(cryptoId);
@@ -119,6 +121,7 @@ export const useCoinmarketInfo = (): CoinmarketInfoProps => {
 
     return {
         cryptoIdToPlatformName,
+        cryptoIdToCoinName,
         cryptoIdToCoinSymbol,
         cryptoIdToNativeCoinSymbol,
         buildCryptoOptions,

--- a/packages/suite/src/types/coinmarket/coinmarket.ts
+++ b/packages/suite/src/types/coinmarket/coinmarket.ts
@@ -154,6 +154,7 @@ export type CoinmarketUtilsProvidersProps = {
 
 export interface CoinmarketInfoProps {
     cryptoIdToPlatformName: (cryptoId: CryptoId) => string | undefined;
+    cryptoIdToCoinName: (cryptoId: CryptoId) => string | undefined;
     cryptoIdToCoinSymbol: (cryptoId: CryptoId) => string | undefined;
     cryptoIdToNativeCoinSymbol: (cryptoId: CryptoId) => string | undefined;
     buildCryptoOptions: (

--- a/packages/suite/src/types/coinmarket/coinmarketVerify.ts
+++ b/packages/suite/src/types/coinmarket/coinmarketVerify.ts
@@ -38,18 +38,14 @@ export interface CoinmarketVerifyAccountReturnProps {
     onChangeAccount: (account: CoinmarketVerifyFormAccountOptionProps) => void;
 }
 
-export type CoinmarketVerifyOptionsProps = Pick<
+export type CoinmarketVerifyOptionsProps = { receiveNetwork: CryptoId } & Pick<
     CoinmarketVerifyAccountReturnProps,
-    | 'receiveNetwork'
-    | 'selectAccountOptions'
-    | 'selectedAccountOption'
-    | 'onChangeAccount'
-    | 'isMenuOpen'
+    'selectAccountOptions' | 'selectedAccountOption' | 'onChangeAccount' | 'isMenuOpen'
 >;
 
 export interface CoinmarketVerifyOptionsItemProps {
     option: CoinmarketVerifyFormAccountOptionProps;
-    receiveNetwork: CryptoId | undefined;
+    receiveNetwork: CryptoId;
 }
 
 export interface CoinmarketGetSuiteReceiveAccountsProps {

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketVerify/CoinmarketVerify.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketVerify/CoinmarketVerify.tsx
@@ -75,7 +75,6 @@ export const CoinmarketVerify = ({ coinmarketVerifyAccount, currency }: Coinmark
         form,
         selectedAccountOption,
         accountAddress,
-        receiveNetwork,
         selectAccountOptions,
         isMenuOpen,
         getTranslationIds,
@@ -144,7 +143,7 @@ export const CoinmarketVerify = ({ coinmarketVerifyAccount, currency }: Coinmark
                         />
                     </CustomLabel>
                     <CoinmarketVerifyOptions
-                        receiveNetwork={receiveNetwork ?? currency}
+                        receiveNetwork={currency}
                         selectedAccountOption={selectedAccountOption}
                         selectAccountOptions={selectAccountOptions}
                         isMenuOpen={isMenuOpen}

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketVerify/CoinmarketVerifyOptions.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketVerify/CoinmarketVerifyOptions.tsx
@@ -1,9 +1,11 @@
 import { Select } from '@trezor/components';
 import { Translation } from 'src/components/suite';
+import { useCoinmarketInfo } from 'src/hooks/wallet/coinmarket/useCoinmarketInfo';
 import {
     CoinmarketVerifyOptionsProps,
     CoinmarketVerifyFormAccountOptionProps,
 } from 'src/types/coinmarket/coinmarketVerify';
+import { parseCryptoId } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import { CoinmarketVerifyOptionsItem } from 'src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketVerify/CoinmarketVerifyOptionsItem';
 
 export const CoinmarketVerifyOptions = ({
@@ -12,23 +14,36 @@ export const CoinmarketVerifyOptions = ({
     selectedAccountOption,
     isMenuOpen,
     onChangeAccount,
-}: CoinmarketVerifyOptionsProps) => (
-    <Select
-        onChange={(selected: CoinmarketVerifyFormAccountOptionProps) => onChangeAccount(selected)}
-        value={selectedAccountOption}
-        isClearable={false}
-        options={selectAccountOptions}
-        minValueWidth="70px"
-        formatOptionLabel={option => (
-            <CoinmarketVerifyOptionsItem option={option} receiveNetwork={receiveNetwork} />
-        )}
-        menuIsOpen={isMenuOpen}
-        isDisabled={selectAccountOptions.length === 1}
-        placeholder={
-            <Translation
-                id="TR_EXCHANGE_SELECT_RECEIVE_ACCOUNT"
-                values={{ symbol: receiveNetwork?.toUpperCase() }}
-            />
-        }
-    />
-);
+}: CoinmarketVerifyOptionsProps) => {
+    const { cryptoIdToPlatformName, cryptoIdToCoinName } = useCoinmarketInfo();
+
+    const { networkId, contractAddress } = parseCryptoId(receiveNetwork);
+    const networkName = contractAddress
+        ? cryptoIdToPlatformName(networkId)
+        : cryptoIdToCoinName(networkId);
+
+    return (
+        <Select
+            onChange={(selected: CoinmarketVerifyFormAccountOptionProps) =>
+                onChangeAccount(selected)
+            }
+            value={selectedAccountOption}
+            isClearable={false}
+            options={selectAccountOptions}
+            minValueWidth="70px"
+            formatOptionLabel={option => (
+                <CoinmarketVerifyOptionsItem option={option} receiveNetwork={receiveNetwork} />
+            )}
+            menuIsOpen={isMenuOpen}
+            isDisabled={selectAccountOptions.length === 1}
+            placeholder={
+                <Translation
+                    id="TR_EXCHANGE_SELECT_RECEIVE_ACCOUNT"
+                    values={{
+                        symbol: networkName,
+                    }}
+                />
+            }
+        />
+    );
+};

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketVerify/CoinmarketVerifyOptionsItem.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketVerify/CoinmarketVerifyOptionsItem.tsx
@@ -1,7 +1,9 @@
 import { CoinLogo, Column, Icon, Row, variables } from '@trezor/components';
 import { spacingsPx } from '@trezor/theme';
 import { AccountLabeling, Translation } from 'src/components/suite';
+import { useCoinmarketInfo } from 'src/hooks/wallet/coinmarket/useCoinmarketInfo';
 import { CoinmarketVerifyOptionsItemProps } from 'src/types/coinmarket/coinmarketVerify';
+import { parseCryptoId } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import { CoinmarketBalance } from 'src/views/wallet/coinmarket/common/CoinmarketBalance';
 import styled, { useTheme } from 'styled-components';
 
@@ -22,6 +24,7 @@ export const CoinmarketVerifyOptionsItem = ({
     option,
     receiveNetwork,
 }: CoinmarketVerifyOptionsItemProps) => {
+    const { cryptoIdToPlatformName, cryptoIdToCoinName } = useCoinmarketInfo();
     const theme = useTheme();
     const iconSize = 24;
 
@@ -56,6 +59,12 @@ export const CoinmarketVerifyOptionsItem = ({
             </Row>
         );
     }
+
+    const { networkId, contractAddress } = parseCryptoId(receiveNetwork);
+    const networkName = contractAddress
+        ? cryptoIdToPlatformName(networkId)
+        : cryptoIdToCoinName(networkId);
+
     if (option.type === 'ADD_SUITE') {
         return (
             <Row>
@@ -69,7 +78,7 @@ export const CoinmarketVerifyOptionsItem = ({
                         <Translation
                             id="TR_EXCHANGE_CREATE_SUITE_ACCOUNT"
                             values={{
-                                symbol: receiveNetwork?.toUpperCase(),
+                                symbol: networkName,
                             }}
                         />
                     </Column>
@@ -90,7 +99,7 @@ export const CoinmarketVerifyOptionsItem = ({
                     <Translation
                         id="TR_EXCHANGE_USE_NON_SUITE_ACCOUNT"
                         values={{
-                            symbol: receiveNetwork?.toUpperCase(),
+                            symbol: networkName,
                         }}
                     />
                 </Column>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We don't have symbols for all networks outside suite, instead we'll use a network name.

## Related Issue

Resolve #14182

## Screenshots:
### Before
<img width="713" alt="image" src="https://github.com/user-attachments/assets/bfd3c9bc-665e-4a3d-a7c8-90667b528837">

### After
![image](https://github.com/user-attachments/assets/55eb26b4-9ac1-427b-a704-94af5cfba99d)
![image](https://github.com/user-attachments/assets/a13f140f-60a4-4f23-a87b-e773bb5dd5f5)
![image](https://github.com/user-attachments/assets/0b647388-7d43-4b52-9f03-6e592b700ae9)



