### PR TITLE
fix(suite): deeplink handling with extra slashes

### DIFF
--- a/packages/suite-desktop-core/src/modules/window-controls.ts
+++ b/packages/suite-desktop-core/src/modules/window-controls.ts
@@ -87,6 +87,6 @@ export const init: Module = ({ mainWindow }) => {
 
     ipcMain.on('app/hide', () => {
         logger.debug(SERVICE_NAME, 'Hide requested');
-        app.hide();
+        mainWindow.hide();
     });
 };

--- a/packages/suite/src/actions/suite/protocolActions.ts
+++ b/packages/suite/src/actions/suite/protocolActions.ts
@@ -48,7 +48,7 @@ export const handleProtocolRequest = (uri: string) => (dispatch: Dispatch) => {
                 autoClose: false,
             }),
         );
-    } else if (uri === SUITE_BRIDGE_DEEPLINK) {
+    } else if (uri?.startsWith(SUITE_BRIDGE_DEEPLINK)) {
         dispatch(routerActions.goto('suite-bridge-requested', { params: { cancelable: true } }));
     }
 };

--- a/packages/suite/src/utils/suite/__fixtures__/protocol.ts
+++ b/packages/suite/src/utils/suite/__fixtures__/protocol.ts
@@ -9,6 +9,24 @@ export const getProtocolInfo = [
         },
     },
     {
+        description: 'should handle slash at end',
+        uri: 'bitcoin:3QmuBaZrJNCxc5Xs7aGzZUK8RirUT8jRKf/?amount=0.1',
+        result: {
+            scheme: 'bitcoin',
+            address: '3QmuBaZrJNCxc5Xs7aGzZUK8RirUT8jRKf',
+            amount: 0.1,
+        },
+    },
+    {
+        description: 'should handle slashes after scheme and at end',
+        uri: 'bitcoin://3QmuBaZrJNCxc5Xs7aGzZUK8RirUT8jRKf/?amount=0.1',
+        result: {
+            scheme: 'bitcoin',
+            address: '3QmuBaZrJNCxc5Xs7aGzZUK8RirUT8jRKf',
+            amount: 0.1,
+        },
+    },
+    {
         description: 'should parse Dogecoin URI when address and amount are both available',
         uri: 'dogecoin:DDogepartyxxxxxxxxxxxxxxxxxxw1dfzr?amount=0.1',
         result: {

--- a/packages/suite/src/utils/suite/protocol.ts
+++ b/packages/suite/src/utils/suite/protocol.ts
@@ -11,6 +11,8 @@ export type CoinProtocolInfo = {
 export const isPaymentRequestProtocolScheme = (scheme: string): scheme is PROTOCOL_SCHEME =>
     Object.values(PROTOCOL_SCHEME).includes(scheme as PROTOCOL_SCHEME);
 
+const removeLeadingTrailingSlashes = (text: string) => text.replace(/^\/{0,2}|\/$/g, '');
+
 export const getProtocolInfo = (uri: string): CoinProtocolInfo | null => {
     const url = parseUri(uri);
 
@@ -33,9 +35,12 @@ export const getProtocolInfo = (uri: string): CoinProtocolInfo | null => {
             const floatAmount = Number.parseFloat(params.amount ?? '');
             const amount = !Number.isNaN(floatAmount) && floatAmount > 0 ? floatAmount : undefined;
 
+            const address =
+                removeLeadingTrailingSlashes(pathname) || removeLeadingTrailingSlashes(host);
+
             return {
                 scheme,
-                address: pathname?.replace('//', '') || host,
+                address,
                 amount,
             };
         }


### PR DESCRIPTION
## Description

On Windows, the system adds trailing slash to deeplinks to make them more proper. 
This is not handled well by Suite, for example the bridge requested page is not opened or the slash is added to the address.

With this change they are removed during parsing.

Also included is a commit with a minor change for hiding the window on Windows. 