### PR TITLE
Fix/native/issues with unsupported coins

### DIFF
--- a/suite-native/coin-enabling/src/components/DiscoveryCoinsFilter.tsx
+++ b/suite-native/coin-enabling/src/components/DiscoveryCoinsFilter.tsx
@@ -10,7 +10,7 @@ import { Icon } from '@suite-common/icons-deprecated';
 import {
     applyDiscoveryChangesThunk,
     selectDiscoverySupportedNetworks,
-    selectEnabledDiscoveryNetworkSymbols,
+    selectDeviceEnabledDiscoveryNetworkSymbols,
 } from '@suite-native/discovery';
 
 import { NetworkSymbolSwitchItem } from './NetworkSymbolSwitchItem';
@@ -25,7 +25,7 @@ export const DiscoveryCoinsFilter = ({
     allowChangeAnalytics = true,
 }: DiscoveryCoinsFilterProps) => {
     const dispatch = useDispatch();
-    const enabledNetworkSymbols = useSelector(selectEnabledDiscoveryNetworkSymbols);
+    const enabledNetworkSymbols = useSelector(selectDeviceEnabledDiscoveryNetworkSymbols);
     const availableNetworks = useSelector(selectDiscoverySupportedNetworks);
 
     useFocusEffect(

--- a/suite-native/coin-enabling/src/components/NetworkSymbolSwitchItem.tsx
+++ b/suite-native/coin-enabling/src/components/NetworkSymbolSwitchItem.tsx
@@ -5,7 +5,7 @@ import { CryptoIcon } from '@suite-common/icons-deprecated';
 import { networks, NetworkSymbol } from '@suite-common/wallet-config';
 import { Card, HStack, Text, Switch, VStack } from '@suite-native/atoms';
 import {
-    selectEnabledDiscoveryNetworkSymbols,
+    selectDeviceEnabledDiscoveryNetworkSymbols,
     toggleEnabledDiscoveryNetworkSymbol,
 } from '@suite-native/discovery';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
@@ -57,7 +57,7 @@ export const NetworkSymbolSwitchItem = ({
 }: NetworkSymbolSwitchItemProps) => {
     const dispatch = useDispatch();
     const isDeviceConnected = useSelector(selectIsDeviceConnected);
-    const enabledNetworkSymbols = useSelector(selectEnabledDiscoveryNetworkSymbols);
+    const enabledNetworkSymbols = useSelector(selectDeviceEnabledDiscoveryNetworkSymbols);
     const { applyStyle } = useNativeStyles();
     const { showToast } = useToast();
     const { showAlert } = useAlert();

--- a/suite-native/coin-enabling/src/screens/CoinEnablingInitScreen.tsx
+++ b/suite-native/coin-enabling/src/screens/CoinEnablingInitScreen.tsx
@@ -11,7 +11,7 @@ import { Screen } from '@suite-native/navigation';
 import { Box, Button, Text, VStack } from '@suite-native/atoms';
 import {
     applyDiscoveryChangesThunk,
-    selectEnabledDiscoveryNetworkSymbols,
+    selectDeviceEnabledDiscoveryNetworkSymbols,
     setIsCoinEnablingInitFinished,
 } from '@suite-native/discovery';
 import { Translation } from '@suite-native/intl';
@@ -67,7 +67,7 @@ export const CoinEnablingInitScreen = () => {
     const navigation = useNavigation();
 
     const { applyStyle, utils } = useNativeStyles();
-    const enabledNetworkSymbols = useSelector(selectEnabledDiscoveryNetworkSymbols);
+    const enabledNetworkSymbols = useSelector(selectDeviceEnabledDiscoveryNetworkSymbols);
 
     const handleSave = () => {
         dispatch(setIsCoinEnablingInitFinished(true));

--- a/suite-native/device/src/index.ts
+++ b/suite-native/device/src/index.ts
@@ -2,7 +2,6 @@ export * from './middlewares/deviceMiddleware';
 export * from './middlewares/buttonRequestMiddleware';
 export * from './hooks/useHandleDeviceConnection';
 export * from './hooks/useDetectDeviceError';
-export * from './hooks/useDelayedNavigation';
 export * from './hooks/useReportDeviceConnectToAnalytics';
 export * from './screens/DeviceInfoModalScreen';
 export * from './components/ConnectDeviceAnimation';

--- a/suite-native/discovery/src/discoveryConfigSlice.ts
+++ b/suite-native/discovery/src/discoveryConfigSlice.ts
@@ -131,7 +131,12 @@ export const selectIsCoinEnablingInitFinished = (
     return isCoinEnablingActive ? state.discoveryConfig.isCoinEnablingInitFinished : true;
 };
 
-export const selectEnabledDiscoveryNetworkSymbols = memoizeWithArgs(
+// this includes all networks, including those that are not supported by current device
+export const selectEnabledDiscoveryNetworkSymbols = (state: DiscoveryConfigSliceRootState) =>
+    state.discoveryConfig.enabledDiscoveryNetworkSymbols;
+
+// this includes only networks supported by current device
+export const selectDeviceEnabledDiscoveryNetworkSymbols = memoizeWithArgs(
     (
         state: DiscoveryConfigSliceRootState & DeviceRootState & FeatureFlagsRootState,
         forcedAreTestnetsEnabled?: boolean,

--- a/suite-native/discovery/src/discoverySelectors.ts
+++ b/suite-native/discovery/src/discoverySelectors.ts
@@ -30,7 +30,7 @@ import { FeatureFlagsRootState } from '@suite-native/feature-flags';
 import {
     DiscoveryConfigSliceRootState,
     selectDiscoverySupportedNetworks,
-    selectEnabledDiscoveryNetworkSymbols,
+    selectDeviceEnabledDiscoveryNetworkSymbols,
     selectIsCoinEnablingInitFinished,
 } from './discoveryConfigSlice';
 import { getNetworksWithUnfinishedDiscovery } from './utils';
@@ -108,7 +108,7 @@ export const selectNetworksWithUnfinishedDiscovery = (
         DiscoveryConfigSliceRootState,
     forcedAreTestnetsEnabled?: boolean,
 ) => {
-    const enabledNetworkSymbols = selectEnabledDiscoveryNetworkSymbols(
+    const enabledNetworkSymbols = selectDeviceEnabledDiscoveryNetworkSymbols(
         state,
         forcedAreTestnetsEnabled,
     );

--- a/suite-native/discovery/src/discoveryThunks.ts
+++ b/suite-native/discovery/src/discoveryThunks.ts
@@ -37,7 +37,7 @@ import { FeatureFlag, selectIsFeatureFlagEnabled } from '@suite-native/feature-f
 
 import {
     selectDiscoveryInfo,
-    selectEnabledDiscoveryNetworkSymbols,
+    selectDeviceEnabledDiscoveryNetworkSymbols,
     setDiscoveryInfo,
 } from './discoveryConfigSlice';
 import {
@@ -710,7 +710,8 @@ export const applyDiscoveryChangesThunk = createThunk(
         // This might be needed in case user has View only device from before coin enabling was active
         // in such case the first normal account can be invisible. We need to make it visible.
         if (isCoinEnablingActive) {
-            const enabledDiscoveryNetworkSymbols = selectEnabledDiscoveryNetworkSymbols(getState());
+            const enabledDiscoveryNetworkSymbols =
+                selectDeviceEnabledDiscoveryNetworkSymbols(getState());
             enabledDiscoveryNetworkSymbols.forEach(networkSymbol => {
                 const firstNormalAccount = selectFirstNormalAccountForNetworkSymbol(
                     getState(),

--- a/suite-native/message-system/src/messageSystemMiddleware.ts
+++ b/suite-native/message-system/src/messageSystemMiddleware.ts
@@ -9,7 +9,7 @@ import {
 } from '@suite-common/message-system';
 import { deviceActions, selectDevice } from '@suite-common/wallet-core';
 import {
-    selectEnabledDiscoveryNetworkSymbols,
+    selectDeviceEnabledDiscoveryNetworkSymbols,
     toggleEnabledDiscoveryNetworkSymbol,
 } from '@suite-native/discovery';
 
@@ -28,7 +28,7 @@ export const messageSystemMiddleware = createMiddleware((action, { next, dispatc
     if (isAnyOfMessageSystemAffectingActions(action)) {
         const config = selectMessageSystemConfig(getState());
         const device = selectDevice(getState());
-        const enabledNetworks = selectEnabledDiscoveryNetworkSymbols(getState());
+        const enabledNetworks = selectDeviceEnabledDiscoveryNetworkSymbols(getState());
 
         const validMessages = getValidMessages(config, {
             device,

--- a/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
+++ b/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
@@ -20,7 +20,7 @@ import {
     addAndDiscoverNetworkAccountThunk,
     selectDiscoverySupportedNetworks,
     NORMAL_ACCOUNT_TYPE,
-    selectEnabledDiscoveryNetworkSymbols,
+    selectDeviceEnabledDiscoveryNetworkSymbols,
     selectDiscoveryNetworkSymbols,
 } from '@suite-native/discovery';
 import { TxKeyPath, useTranslate } from '@suite-native/intl';
@@ -80,7 +80,7 @@ export const useAddCoinAccount = () => {
     );
     const device = useSelector(selectDevice);
     const isDeviceInViewOnlyMode = useSelector(selectIsDeviceInViewOnlyMode);
-    const enabledDiscoveryNetworkSymbols = useSelector(selectEnabledDiscoveryNetworkSymbols);
+    const enabledDiscoveryNetworkSymbols = useSelector(selectDeviceEnabledDiscoveryNetworkSymbols);
 
     const navigation = useNavigation<AddCoinAccountNavigationProps>();
 

--- a/suite-native/module-add-accounts/src/screens/AddCoinDiscoveryRunningScreen.tsx
+++ b/suite-native/module-add-accounts/src/screens/AddCoinDiscoveryRunningScreen.tsx
@@ -16,7 +16,7 @@ import {
 } from '@suite-common/wallet-core';
 import {
     applyDiscoveryChangesThunk,
-    selectEnabledDiscoveryNetworkSymbols,
+    selectDeviceEnabledDiscoveryNetworkSymbols,
     toggleEnabledDiscoveryNetworkSymbol,
 } from '@suite-native/discovery';
 
@@ -31,7 +31,7 @@ export const AddCoinDiscoveryRunningScreen = ({ route }) => {
     );
 
     const hasDiscovery = useSelector(selectHasDeviceDiscovery);
-    const enabledNetworkSymbols = useSelector(selectEnabledDiscoveryNetworkSymbols);
+    const enabledNetworkSymbols = useSelector(selectDeviceEnabledDiscoveryNetworkSymbols);
     const { navigateToSuccessorScreen, clearNetworkWithTypeToBeAdded } = useAddCoinAccount();
     const [loadingResult, setLoadingResult] = useState<SpinnerLoadingState>('idle');
 

--- a/suite-native/module-authorize-device/package.json
+++ b/suite-native/module-authorize-device/package.json
@@ -23,6 +23,7 @@
         "@suite-native/device": "workspace:*",
         "@suite-native/device-authorization": "workspace:*",
         "@suite-native/device-mutex": "workspace:*",
+        "@suite-native/discovery": "workspace:*",
         "@suite-native/forms": "workspace:*",
         "@suite-native/intl": "workspace:*",
         "@suite-native/link": "workspace:*",

--- a/suite-native/module-authorize-device/src/screens/connect/ConnectingDeviceScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/connect/ConnectingDeviceScreen.tsx
@@ -3,10 +3,10 @@ import { ActivityIndicator } from 'react-native';
 import { Text, VStack, Box } from '@suite-native/atoms';
 import { Icon } from '@suite-common/icons-deprecated';
 import { useNativeStyles, prepareNativeStyle } from '@trezor/styles';
-import { useDelayedNavigation } from '@suite-native/device';
 import { Translation } from '@suite-native/intl';
 
 import { ConnectDeviceScreenView } from '../../components/connect/ConnectDeviceScreenView';
+import { useOnDeviceReadyNavigation } from '../../hooks/useOnDeviceReadyNavigation';
 
 const screenStyle = prepareNativeStyle(() => ({
     justifyContent: 'center',
@@ -15,7 +15,7 @@ const screenStyle = prepareNativeStyle(() => ({
 }));
 
 export const ConnectingDeviceScreen = () => {
-    useDelayedNavigation();
+    useOnDeviceReadyNavigation();
     const { applyStyle } = useNativeStyles();
 
     return (

--- a/suite-native/module-authorize-device/tsconfig.json
+++ b/suite-native/module-authorize-device/tsconfig.json
@@ -17,6 +17,7 @@
         { "path": "../device" },
         { "path": "../device-authorization" },
         { "path": "../device-mutex" },
+        { "path": "../discovery" },
         { "path": "../forms" },
         { "path": "../intl" },
         { "path": "../link" },

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -25,6 +25,8 @@ const transports = transportsPerDeviceType[deviceType];
 
 export const extraDependencies: ExtraDependencies = mergeDeepObject(extraDependenciesMock, {
     selectors: {
+        // using all enabled networks even those current device does not support,
+        // otherwise disableAccountsThunk might erase accounts not supported by current device
         selectEnabledNetworks: selectEnabledDiscoveryNetworkSymbols,
         selectBitcoinAmountUnit: () => PROTO.AmountUnit.BITCOIN,
         selectLocalCurrency: selectFiatCurrencyCode,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10171,6 +10171,7 @@ __metadata:
     "@suite-native/device": "workspace:*"
     "@suite-native/device-authorization": "workspace:*"
     "@suite-native/device-mutex": "workspace:*"
+    "@suite-native/discovery": "workspace:*"
     "@suite-native/forms": "workspace:*"
     "@suite-native/intl": "workspace:*"
     "@suite-native/link": "workspace:*"


### PR DESCRIPTION
 - dont use only enabled coins supported by current device for deleting unselected networks
 - hide device loading for devices with no enabled supported coin

## Related Issue

Resolve #14289

## Screenshots:

https://github.com/user-attachments/assets/bc0668c2-e6d7-4c88-b300-dd5e43557aab

