### PR TITLE
fix(suite): do not show number of hidden tokens in case it is zero

### DIFF
--- a/packages/suite/src/views/wallet/tokens/common/TokensLayout/TokensLayoutNavigation.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensLayout/TokensLayoutNavigation.tsx
@@ -81,7 +81,7 @@ const Item = ({
     title: TranslationKey;
     icon: IconName;
     currentRoute?: Route['name'];
-    count: number;
+    count?: number;
 }) => (
     <NavListItem
         nameId={title}
@@ -147,7 +147,7 @@ export const TokensLayoutNavigation = ({
                     route="wallet-tokens-hidden"
                     title="TR_HIDDEN"
                     icon="hide"
-                    count={tokens.hiddenWithBalance.length}
+                    count={tokens.hiddenWithBalance.length || undefined}
                     currentRoute={routeName}
                 />
             </List>


### PR DESCRIPTION
## Description

- do not show `0` next to `Hidden` tokens in case there are no hidden tokens with balance available
  - unverified tokens are not counted into this and that's why it is better to omit `0`

## Related Issue

## Screenshots:
Before:
<img width="780" alt="Screenshot 2024-09-12 at 7 52 30" src="https://github.com/user-attachments/assets/d70439f0-edef-4b78-8877-2acbf02838e3">

After:
no tokens with balance hidden
<img width="1157" alt="Screenshot 2024-09-12 at 7 49 26" src="https://github.com/user-attachments/assets/2c9577ad-aaff-4987-bca4-527d45fbb6a2">

<img width="1162" alt="Screenshot 2024-09-12 at 7 49 41" src="https://github.com/user-attachments/assets/85191cfc-b4df-4c82-8687-2904be5273f2">

1 token with balance hidden
<img width="1161" alt="Screenshot 2024-09-12 at 7 49 49" src="https://github.com/user-attachments/assets/ed79da77-9cf3-48d4-9275-60bafffc4308">
