### PR TITLE
chore(suite-native): set fixed firebase CLI version for android dev build distribution

### DIFF
--- a/suite-native/app/eas-post-success.sh
+++ b/suite-native/app/eas-post-success.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+FIREBASE_VERSION="${FIREBASE_VERSION:-v13.16.0}"
+
 distribute_develop_apk() {
     # Install Firebase CLI
-    curl -sL https://firebase.tools | bash
+    curl -sL https://firebase.tools | sed "s/latest/$FIREBASE_VERSION/" | bash
 
     release_notes="Last commit hash: $EAS_BUILD_GIT_COMMIT_HASH"
     echo "$EAS_BUILD_GIT_COMMIT_HASH"


### PR DESCRIPTION

## Description

- Because of this issue https://github.com/firebase/firebase-tools/issues/7648 android dev builds are now failing https://expo.dev/accounts/trezorcompany/projects/trezor-suite-develop/builds
- But sounds safer to use fixed version. Downside is we would need to update manually.
