### PR TITLE
chore(connect-common): add FW 2.8.3 binaries

### DIFF
--- a/packages/connect-common/files/firmware/t3b1/releases.json
+++ b/packages/connect-common/files/firmware/t3b1/releases.json
@@ -1,1 +1,22 @@
-[]
+[
+    {
+        "required": false,
+        "version": [2, 8, 3],
+        "min_firmware_version": [2, 8, 3],
+        "min_bootloader_version": [2, 1, 8],
+        "bootloader_version": [2, 1, 8],
+        "translations": ["cs-CZ", "de-DE", "es-ES", "fr-FR", "it-IT", "pt-PT"],
+        "url": "firmware/t3b1/trezor-t3b1-2.8.3.bin",
+        "url_bitcoinonly": "firmware/t3b1/trezor-t3b1-2.8.3-bitcoinonly.bin",
+        "fingerprint": "b659bdc5ddce208d46ce649fc7a8995ae49541c7c41a88ddaac5dfc038ffb5de",
+        "fingerprint_bitcoinonly": "070a61b2a8653e4f9857810b6610d0a15f76ba627c7b6e5654a6de9a1c529049",
+        "firmware_revision": "7f373ae71eca855dd41b4a0fdcc7cadaa13a8281",
+        "changelog": [
+            "## Changed",
+            "- Renamed MATIC to POL, following a network upgrade",
+            "## Fixed",
+            "- Fix persistent word when going to previous word during recovery process.",
+            "- Fix display orientation south. "
+        ]
+    }
+]

--- a/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.8.3-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.8.3-bitcoinonly.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e392c9ad81d42b7966b2aff247fe91da5b742bf146c60381dbc5e47efe4dde2
+size 998912

--- a/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.8.3.bin
+++ b/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.8.3.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e751d8b712f0f30e0fc0bad285d609c196cbd4fb1cbcd281aa08ed871d3d0e28
+size 1357824

--- a/packages/connect-common/files/firmware/t3t1/releases.json
+++ b/packages/connect-common/files/firmware/t3t1/releases.json
@@ -1,6 +1,32 @@
 [
     {
         "required": false,
+        "version": [2, 8, 3],
+        "min_firmware_version": [2, 7, 2],
+        "min_bootloader_version": [2, 1, 6],
+        "bootloader_version": [2, 1, 8],
+        "translations": ["cs-CZ", "de-DE", "es-ES", "fr-FR", "it-IT", "pt-PT"],
+        "url": "firmware/t3t1/trezor-t3t1-2.8.3.bin",
+        "url_bitcoinonly": "firmware/t3t1/trezor-t3t1-2.8.3-bitcoinonly.bin",
+        "fingerprint": "0de51126c17cc0ac623800638dc851c0abd5b787cad5f3aa5843ea2c4cf8248a",
+        "fingerprint_bitcoinonly": "9eaf99a9420d2a3b9377102eb06b938f5a1886ecb06cccde7fd3cb7a39e1abd7",
+        "firmware_revision": "7f373ae71eca855dd41b4a0fdcc7cadaa13a8281",
+        "changelog": [
+            "## Added",
+            "- Added reassuring screen when entering empty passphrase on device.",
+            "- Improved ETH send and staking flow.",
+            "- Redesigned FIDO2 UI.",
+
+            "## Changed",
+            "- Renamed MATIC to POL, following a network upgrade",
+
+            "## Fixed",
+            "- Fix persistent word when going to previous word during recovery process.",
+            "- Added missing info about remaining shares in super-shamir recovery."
+        ]
+    },
+    {
+        "required": false,
         "version": [2, 8, 1],
         "min_firmware_version": [2, 7, 2],
         "min_bootloader_version": [2, 1, 6],

--- a/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.1-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.1-bitcoinonly.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e4a5eb35540471683154f056d53d29787a22e9abf1f734368a383452e3c28a63
-size 1269760

--- a/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.1.bin
+++ b/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.1.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8fa9e7bfbfa37b5d11e4da4776ae4635fb3f6afda3e592206ddc3246cda7092a
-size 1629696

--- a/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.3-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.3-bitcoinonly.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49996a1a602f08809427cf3b959f3c70eeef1fcfd45f267bd6d058496a4cc37e
+size 1172992

--- a/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.3.bin
+++ b/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.3.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f68696478e09d7bf8b8f5181413d8a5386b37571dc2f5ed8511a24f4c1d35b7
+size 1555456


### PR DESCRIPTION
Adding new FW binaries for FW 2.8.2 release - T3T1 only

Changelog [source](https://www.notion.so/satoshilabs/Simplify-generated-changelog-d68b837e69e341c8bef0b7c683e28a1e?pvs=4)

Source PR form data repository [here](https://github.com/trezor/data/pull/100/commits)