### PR TITLE
fix(suite-native): camera permissions restored

### DIFF
--- a/suite-native/app/app.config.ts
+++ b/suite-native/app/app.config.ts
@@ -88,7 +88,6 @@ const getPlugins = (): ExpoPlugins => {
                 photosPermission:
                     'Allow $(PRODUCT_NAME) to access your photos to let you import QR code images.',
                 microphonePermission: false,
-                cameraPermission: false,
             },
         ],
         [


### PR DESCRIPTION
Removing cameraPermission directive from `expo-image-picker` because it was blocking camera across the whole app (so not even QR code scanner worked), not only this particular library.

