### PR TITLE
feat(coinmarket): possibility to proceed with unverified address

### DIFF
--- a/packages/suite-data/files/translations/en.json
+++ b/packages/suite-data/files/translations/en.json
@@ -1700,6 +1700,7 @@
   "TR_SHOW_MORE_ADDRESSES": "Show more ({count})",
   "TR_SHOW_UNVERIFIED_ADDRESS": "Show unverified address",
   "TR_SHOW_UNVERIFIED_XPUB": "Show unverified public key",
+  "TR_PROCEED_UNVERIFIED_ADDRESS": "Proceed with unverified address",
   "TR_SIDEBAR_ADD_COIN": "Add a coin",
   "TR_SIGN": "Sign",
   "TR_SIGNATURE": "Signature",

--- a/packages/suite/src/actions/wallet/coinmarket/__fixtures__/coinmarketCommonActions/verifyAddress.ts
+++ b/packages/suite/src/actions/wallet/coinmarket/__fixtures__/coinmarketCommonActions/verifyAddress.ts
@@ -124,9 +124,8 @@ export const VERIFY_BUY_ADDRESS_FIXTURES = [
             action: {
                 type: MODAL.OPEN_USER_CONTEXT,
                 payload: {
-                    type: 'unverified-address',
+                    type: 'unverified-address-proceed',
                     value: XRP_ACCOUNT.descriptor,
-                    addressPath: XRP_ACCOUNT.path,
                 },
             },
         },

--- a/packages/suite/src/actions/wallet/coinmarket/coinmarketCommonActions.ts
+++ b/packages/suite/src/actions/wallet/coinmarket/coinmarketCommonActions.ts
@@ -92,9 +92,8 @@ export const verifyAddress =
         if (!connected || !available) {
             dispatch(
                 modalActions.openModal({
-                    type: 'unverified-address',
+                    type: 'unverified-address-proceed',
                     value: address,
-                    addressPath: path,
                 }),
             );
 

--- a/packages/suite/src/actions/wallet/coinmarketBuyActions.ts
+++ b/packages/suite/src/actions/wallet/coinmarketBuyActions.ts
@@ -30,7 +30,7 @@ export type CoinmarketBuyAction =
     | { type: typeof COINMARKET_BUY.SET_IS_FROM_REDIRECT; isFromRedirect: boolean }
     | { type: typeof COINMARKET_BUY.SAVE_TRANSACTION_DETAIL_ID; transactionId: string }
     | { type: typeof COINMARKET_BUY.SAVE_QUOTE_REQUEST; request: BuyTradeQuoteRequest }
-    | { type: typeof COINMARKET_BUY.VERIFY_ADDRESS; addressVerified: string }
+    | { type: typeof COINMARKET_BUY.VERIFY_ADDRESS; addressVerified: string | undefined }
     | {
           type: typeof COINMARKET_BUY.SAVE_CACHED_ACCOUNT_INFO;
           symbol: Account['symbol'];

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedAddressModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedAddressModal.tsx
@@ -1,10 +1,9 @@
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 
-import { ModalProps } from '@trezor/components';
 import { openAddressModal, showAddress } from 'src/actions/wallet/receiveActions';
 import { ConfirmUnverifiedModal } from './ConfirmUnverifiedModal';
 
-interface ConfirmUnverifiedAddressModalProps extends Required<Pick<ModalProps, 'onCancel'>> {
+interface ConfirmUnverifiedAddressModalProps {
     addressPath: string;
     value: string;
 }
@@ -13,15 +12,17 @@ export const ConfirmUnverifiedAddressModal = ({
     addressPath,
     value,
 }: ConfirmUnverifiedAddressModalProps) => {
-    const verifyAddress = useCallback(() => showAddress(addressPath, value), [addressPath, value]);
+    const verifyProcess = useCallback(() => showAddress(addressPath, value), [addressPath, value]);
     const showUnverifiedAddress = () => openAddressModal({ addressPath, value });
 
     return (
         <ConfirmUnverifiedModal
-            showUnverifiedButtonText="TR_SHOW_UNVERIFIED_ADDRESS"
+            action={{
+                event: showUnverifiedAddress,
+                title: 'TR_SHOW_UNVERIFIED_ADDRESS',
+            }}
+            verifyProcess={verifyProcess}
             warningText="TR_ADDRESS_PHISHING_WARNING"
-            verify={verifyAddress}
-            showUnverified={showUnverifiedAddress}
         />
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedProceedModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedProceedModal.tsx
@@ -1,0 +1,27 @@
+import { ConfirmUnverifiedModal } from './ConfirmUnverifiedModal';
+import { COINMARKET_BUY } from 'src/actions/wallet/constants';
+import { Dispatch } from 'src/types/suite';
+
+interface ConfirmUnverifiedProceedModalProps {
+    value: string;
+}
+
+export const ConfirmUnverifiedProceedModal = ({ value }: ConfirmUnverifiedProceedModalProps) => {
+    const proceedWithUnverifiedAddress = () => (dispatch: Dispatch) => {
+        dispatch({
+            type: COINMARKET_BUY.VERIFY_ADDRESS,
+            addressVerified: value,
+        });
+    };
+
+    return (
+        <ConfirmUnverifiedModal
+            action={{
+                event: proceedWithUnverifiedAddress,
+                title: 'TR_PROCEED_UNVERIFIED_ADDRESS',
+                closeAfterEventTriggered: true,
+            }}
+            warningText="TR_ADDRESS_PHISHING_WARNING"
+        />
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedXpubModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedXpubModal.tsx
@@ -1,0 +1,20 @@
+import { useCallback } from 'react';
+
+import { ConfirmUnverifiedModal } from './ConfirmUnverifiedModal';
+import { openXpubModal, showXpub } from 'src/actions/wallet/publicKeyActions';
+
+export const ConfirmUnverifiedXpubModal = () => {
+    const event = useCallback(() => openXpubModal(), []);
+    const verifyProcess = useCallback(() => showXpub(), []);
+
+    return (
+        <ConfirmUnverifiedModal
+            action={{
+                event,
+                title: 'TR_SHOW_UNVERIFIED_XPUB',
+            }}
+            verifyProcess={verifyProcess}
+            warningText="TR_XPUB_PHISHING_WARNING"
+        />
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
@@ -27,8 +27,6 @@ import {
     CriticalCoinjoinPhaseModal,
     CoinjoinSuccessModal,
     MoreRoundsNeededModal,
-    ConfirmUnverifiedModal,
-    ConfirmUnverifiedAddressModal,
     UnecoCoinjoinModal,
     AuthenticateDeviceModal,
     AuthenticateDeviceFailModal,
@@ -39,9 +37,11 @@ import {
     ClaimModal,
     CopyAddressModal,
     UnhideTokenModal,
+    ConfirmUnverifiedAddressModal,
+    ConfirmUnverifiedXpubModal,
+    ConfirmUnverifiedProceedModal,
 } from 'src/components/suite/modals';
 import type { AcquiredDevice } from 'src/types/suite';
-import { openXpubModal, showXpub } from 'src/actions/wallet/publicKeyActions';
 import type { ReduxModalProps } from '../ReduxModal';
 import { CryptoId } from 'invity-api';
 import { EverstakeModal } from './UnstakeModal/EverstakeModal';
@@ -74,18 +74,12 @@ export const UserContextModal = ({
                 <ConfirmUnverifiedAddressModal
                     addressPath={payload.addressPath}
                     value={payload.value}
-                    onCancel={onCancel}
                 />
             );
         case 'unverified-xpub':
-            return (
-                <ConfirmUnverifiedModal
-                    showUnverifiedButtonText="TR_SHOW_UNVERIFIED_XPUB"
-                    warningText="TR_XPUB_PHISHING_WARNING"
-                    verify={showXpub}
-                    showUnverified={openXpubModal}
-                />
-            );
+            return <ConfirmUnverifiedXpubModal />;
+        case 'unverified-address-proceed':
+            return <ConfirmUnverifiedProceedModal value={payload.value} />;
         case 'address':
             return <ConfirmAddressModal {...payload} onCancel={onCancel} />;
         case 'xpub':

--- a/packages/suite/src/components/suite/modals/index.tsx
+++ b/packages/suite/src/components/suite/modals/index.tsx
@@ -18,6 +18,8 @@ export { ImportTransactionModal } from './ReduxModal/UserContextModal/ImportTran
 export { ConfirmEvmExplanationModal } from './ConfirmEvmExplanationModal';
 export { ConfirmUnverifiedModal } from './ReduxModal/UserContextModal/ConfirmUnverifiedModal';
 export { ConfirmUnverifiedAddressModal } from './ReduxModal/UserContextModal/ConfirmUnverifiedAddressModal';
+export { ConfirmUnverifiedXpubModal } from './ReduxModal/UserContextModal/ConfirmUnverifiedXpubModal';
+export { ConfirmUnverifiedProceedModal } from './ReduxModal/UserContextModal/ConfirmUnverifiedProceedModal';
 export { AddAccountModal } from './ReduxModal/UserContextModal/AddAccountModal/AddAccountModal';
 export { QrScannerModal } from './ReduxModal/UserContextModal/QrScannerModal';
 export { BackgroundGalleryModal } from './ReduxModal/UserContextModal/BackgroundGalleryModal';

--- a/packages/suite/src/reducers/wallet/coinmarketReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinmarketReducer.ts
@@ -59,14 +59,14 @@ interface Buy extends CoinmarketTradeCommonProps {
         symbol?: Account['symbol'];
         shouldSubmit?: boolean;
     };
-    addressVerified?: string;
+    addressVerified: string | undefined;
 }
 
 interface Exchange extends CoinmarketTradeCommonProps {
     exchangeInfo?: ExchangeInfo;
     quotesRequest?: ExchangeTradeQuoteRequest;
     quotes: ExchangeTrade[] | undefined;
-    addressVerified?: string;
+    addressVerified: string | undefined;
     coinmarketAccount?: Account;
     selectedQuote: ExchangeTrade | undefined;
 }

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -340,6 +340,10 @@ export default defineMessages({
         id: 'TR_COINMARKET_SWAP_DEX_MODAL_TERMS_6',
         dynamic: true,
     },
+    TR_CONFIRM_ADDRESS: {
+        defaultMessage: 'Confirm address',
+        id: 'TR_CONFIRM_ADDRESS',
+    },
     TR_EXCHANGE_STATUS_ERROR: {
         defaultMessage: 'Rejected',
         id: 'TR_EXCHANGE_STATUS_ERROR',
@@ -3290,6 +3294,10 @@ export default defineMessages({
     TR_SHOW_UNVERIFIED_XPUB: {
         defaultMessage: 'Show unverified public key',
         id: 'TR_SHOW_UNVERIFIED_XPUB',
+    },
+    TR_PROCEED_UNVERIFIED_ADDRESS: {
+        defaultMessage: 'Proceed with unverified address',
+        id: 'TR_PROCEED_UNVERIFIED_ADDRESS',
     },
     TR_SIGN: {
         defaultMessage: 'Sign',

--- a/suite-common/suite-types/src/modal.ts
+++ b/suite-common/suite-types/src/modal.ts
@@ -18,6 +18,10 @@ export type UserContextPayload =
           type: 'unverified-xpub';
       }
     | {
+          type: 'unverified-address-proceed';
+          value: string;
+      }
+    | {
           type: 'address';
           value: string;
           addressPath: string;


### PR DESCRIPTION
## Issue

When a user gets to the second step in the Buy flow where they select a specific address to receive crypto and the Trezor is disconnected, Suite only allows to Show an unverified address and copy it so the user is stuck.

### Design before
![obrazek](https://github.com/user-attachments/assets/f794728e-f44f-42ee-bc97-fc52909227c1)

## Solution
Instead of “Show unverified address” in this dialog show “Proceed with unverified address” button, close the dialog, and allow a user to proceed to the partner’s checkout.

### Design after
![obrazek](https://github.com/user-attachments/assets/00c23e99-96d2-4de5-9dfb-d1128050f901)
![obrazek](https://github.com/user-attachments/assets/c052533b-d520-4705-a75a-2225360bde67)

## Related
Resolve https://github.com/trezor/trezor-suite/issues/14310
