### PR TITLE
fix(suite-native): do not display fiat amount for testnet coins

### DIFF
--- a/suite-native/formatters/src/components/CryptoToFiatAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/CryptoToFiatAmountFormatter.tsx
@@ -1,17 +1,15 @@
 import { TextProps } from '@suite-native/atoms';
 import { NetworkSymbol } from '@suite-common/wallet-config';
-import { useFormatters } from '@suite-common/formatters';
 
 import { FormatterProps } from '../types';
-import { AmountText } from './AmountText';
 import { useFiatFromCryptoValue } from '../hooks/useFiatFromCryptoValue';
+import { FiatAmountFormatter } from './FiatAmountFormatter';
 
 type CryptoToFiatAmountFormatterProps = FormatterProps<string | null> &
     TextProps & {
         network: NetworkSymbol;
         historicRate?: number;
         useHistoricRate?: boolean;
-        isDiscreetText?: boolean;
         isBalance?: boolean;
     };
 
@@ -20,12 +18,9 @@ export const CryptoToFiatAmountFormatter = ({
     network,
     historicRate,
     useHistoricRate,
-    isDiscreetText = true,
     isBalance = false,
     ...textProps
 }: CryptoToFiatAmountFormatterProps) => {
-    const { FiatAmountFormatter } = useFormatters();
-
     const fiatValue = useFiatFromCryptoValue({
         network,
         historicRate,
@@ -34,7 +29,5 @@ export const CryptoToFiatAmountFormatter = ({
         cryptoValue: value,
     });
 
-    const formattedFiatValue = FiatAmountFormatter.format(fiatValue ?? '0');
-
-    return <AmountText value={formattedFiatValue} isDiscreetText={isDiscreetText} {...textProps} />;
+    return <FiatAmountFormatter network={network} value={fiatValue} {...textProps} />;
 };


### PR DESCRIPTION
## Screenshots:
<img width="352" alt="image" src="https://github.com/user-attachments/assets/42964d03-0b16-4cb4-ad27-ebdd3afbabc8">
<img width="352" alt="image" src="https://github.com/user-attachments/assets/f9f21497-3532-4dbc-9f7a-c832d9e4b91e">
<img width="352" alt="image" src="https://github.com/user-attachments/assets/5383e5b9-4caf-4a5c-8518-3b821f574cf6">
