### PR TITLE
fix(coinmarket): responsive menu and icons 

### DIFF
--- a/packages/suite-web/e2e/tests/coinmarket/buy.test.ts
+++ b/packages/suite-web/e2e/tests/coinmarket/buy.test.ts
@@ -93,7 +93,7 @@ describe('Coinmarket buy', () => {
         cy.task('setupEmu', { needs_backup: false });
         cy.task('startBridge');
 
-        cy.viewport(1024, 768).resetDb();
+        cy.viewport(1200, 768).resetDb();
         cy.interceptInvityApi();
         cy.prefixedVisit('/', {
             onBeforeLoad: (win: Window) => {

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActions.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActions.tsx
@@ -124,7 +124,7 @@ export const HeaderActions = () => {
             {isCoinmarketAvailable && (
                 <AppNavigationTooltip>
                     <ButtonComponent
-                        icon="coinVertical"
+                        icon="currencyCircleDollar"
                         onClick={() => {
                             goToWithAnalytics('wallet-coinmarket-buy', { preserveParams: true });
                         }}
@@ -136,7 +136,7 @@ export const HeaderActions = () => {
                         <Translation id="TR_COINMARKET_BUY_AND_SELL" />
                     </ButtonComponent>
                     <ButtonComponent
-                        icon="arrowsClockwise"
+                        icon="arrowsLeftRight"
                         onClick={() => {
                             goToWithAnalytics('wallet-coinmarket-exchange', {
                                 preserveParams: true,

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActions.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActions.tsx
@@ -9,6 +9,7 @@ import {
     IconButton,
     IconButtonProps,
     IconName,
+    variables,
 } from '@trezor/components';
 import { spacingsPx } from '@trezor/theme';
 import { hasNetworkFeatures } from '@suite-common/wallet-utils';
@@ -23,6 +24,13 @@ const Container = styled.div`
     display: flex;
     align-items: center;
     gap: ${spacingsPx.xxs};
+`;
+
+// instant without computing the layout
+const ShowOnLargeDesktopWrapper = styled.div`
+    ${variables.SCREEN_QUERY.BELOW_DESKTOP} {
+        display: none;
+    }
 `;
 
 type ActionItem = {
@@ -63,6 +71,8 @@ export const HeaderActions = () => {
 
     const dispatch = useDispatch();
     const { device } = useDevice();
+    const layoutSize = useSelector(state => state.resize.size);
+    const showCoinmarketButtons = layoutSize === 'XLARGE';
 
     const accountType = account?.accountType || routerParams?.accountType || '';
 
@@ -86,6 +96,15 @@ export const HeaderActions = () => {
             icon: 'pencilUnderscored',
             // show dots when acc missing as they are hidden only in case of XRP
             isHidden: account ? !hasNetworkFeatures(account, 'sign-verify') : false,
+        },
+        {
+            id: 'wallet-coinmarket-buy',
+            callback: () => {
+                goToWithAnalytics('wallet-coinmarket-buy', { preserveParams: true });
+            },
+            title: <Translation id="TR_COINMARKET_BUY_AND_SELL" />,
+            icon: 'currencyCircleDollar',
+            isHidden: showCoinmarketButtons,
         },
     ];
 
@@ -123,18 +142,22 @@ export const HeaderActions = () => {
 
             {isCoinmarketAvailable && (
                 <AppNavigationTooltip>
-                    <ButtonComponent
-                        icon="currencyCircleDollar"
-                        onClick={() => {
-                            goToWithAnalytics('wallet-coinmarket-buy', { preserveParams: true });
-                        }}
-                        data-testid="@wallet/menu/wallet-coinmarket-buy"
-                        variant="tertiary"
-                        size="small"
-                        isDisabled={isAccountLoading}
-                    >
-                        <Translation id="TR_COINMARKET_BUY_AND_SELL" />
-                    </ButtonComponent>
+                    <ShowOnLargeDesktopWrapper>
+                        <ButtonComponent
+                            icon="currencyCircleDollar"
+                            onClick={() => {
+                                goToWithAnalytics('wallet-coinmarket-buy', {
+                                    preserveParams: true,
+                                });
+                            }}
+                            data-testid="@wallet/menu/wallet-coinmarket-buy"
+                            variant="tertiary"
+                            size="small"
+                            isDisabled={isAccountLoading}
+                        >
+                            <Translation id="TR_COINMARKET_BUY_AND_SELL" />
+                        </ButtonComponent>
+                    </ShowOnLargeDesktopWrapper>
                     <ButtonComponent
                         icon="arrowsLeftRight"
                         onClick={() => {

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketLayoutNavigation.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketLayoutNavigation.tsx
@@ -67,7 +67,7 @@ export const CoinmarketLayoutNavigation = () => {
                 <Item
                     route="wallet-coinmarket-exchange"
                     title="TR_COINMARKET_SWAP"
-                    icon="arrowsClockwise"
+                    icon="arrowsLeftRight"
                 />
             ) : null}
         </List>

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayoutNew/CoinmarketLayoutNavigation/CoinmarketLayoutNavigation.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayoutNew/CoinmarketLayoutNavigation/CoinmarketLayoutNavigation.tsx
@@ -53,7 +53,7 @@ const CoinmarketLayoutNavigation = ({ selectedAccount }: CoinmarketLayoutNavigat
                 <CoinmarketLayoutNavigationItem
                     route="wallet-coinmarket-exchange"
                     title="TR_COINMARKET_SWAP"
-                    icon="arrowsClockwise"
+                    icon="arrowsLeftRight"
                 />
             ) : null}
 


### PR DESCRIPTION
## Issues
### Responsive
- When decreasing the screen width, the Send + Receive buttons should always remain visible. The Buy, Sell, and Swap buttons should disappear first into a dots. The Send + Receive buttons must be the last to wrap.
- Buttons should not wrap vertically like this.
![image](https://github.com/user-attachments/assets/8a404f40-c438-4a7a-a37e-105f7bc8d68f)
<img width="808" alt="image" src="https://github.com/user-attachments/assets/47b8afc2-1f51-4bd8-b649-39dc823861b6">

### Icons
- Icons need to be different (the coin icon is used elsewhere, and the refresh icon should not be used for Swap).”
<img width="547" alt="image" src="https://github.com/user-attachments/assets/ef1ceead-b047-4671-b6e5-740ae7fb0ff0">


## After fix
![obrazek](https://github.com/user-attachments/assets/3161512d-63f9-4638-8a9c-b694ab099cd8)
![obrazek](https://github.com/user-attachments/assets/90381882-0f8b-492c-a42a-9e8175090599)
![obrazek](https://github.com/user-attachments/assets/8f663003-fe3b-4f90-9dda-9211e9019f49)
- hidden `Buy & Sell` under 1200px of device window width, it's in the submenu (`...`) 

## Related issues
Resolve https://github.com/trezor/trezor-suite/issues/14331
