### PR TITLE
fix(coinmarket): switch off coinjoin

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -38,6 +38,7 @@ interface AddAccountProps {
     symbol?: NetworkSymbol;
     noRedirect?: boolean;
     isCoinjoinDisabled?: boolean;
+    isBackClickDisabled?: boolean;
 }
 
 export const AddAccountModal = ({
@@ -46,6 +47,7 @@ export const AddAccountModal = ({
     symbol,
     noRedirect,
     isCoinjoinDisabled,
+    isBackClickDisabled,
 }: AddAccountProps) => {
     const accounts = useSelector(state => state.wallet.accounts);
     const supportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
@@ -209,7 +211,9 @@ export const AddAccountModal = ({
                           symbol={selectedNetwork.symbol}
                       />
                   ),
-                  onBackClick: () => setSelectedNetwork(undefined),
+                  onBackClick: !isBackClickDisabled
+                      ? () => setSelectedNetwork(undefined)
+                      : undefined,
               }
             : {
                   heading: <Translation id="TR_ADD_ACCOUNT" />,

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -37,9 +37,16 @@ interface AddAccountProps {
     onCancel: () => void;
     symbol?: NetworkSymbol;
     noRedirect?: boolean;
+    isCoinjoinDisabled?: boolean;
 }
 
-export const AddAccountModal = ({ device, onCancel, symbol, noRedirect }: AddAccountProps) => {
+export const AddAccountModal = ({
+    device,
+    onCancel,
+    symbol,
+    noRedirect,
+    isCoinjoinDisabled,
+}: AddAccountProps) => {
     const accounts = useSelector(state => state.wallet.accounts);
     const supportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
     const app = useSelector(state => state.router.app);
@@ -102,7 +109,7 @@ export const AddAccountModal = ({ device, onCancel, symbol, noRedirect }: AddAcc
           )
         : [];
 
-    const isCoinjoinVisible = isCoinjoinPublic || isDebug;
+    const isCoinjoinVisible = (isCoinjoinPublic || isDebug) && !isCoinjoinDisabled;
 
     const getAvailableAccountTypes = (network: Network) => {
         const defaultAccount: NetworkAccount = {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
@@ -64,6 +64,7 @@ export const UserContextModal = ({
                     device={payload.device as AcquiredDevice}
                     symbol={payload.symbol}
                     noRedirect={payload.noRedirect}
+                    isCoinjoinDisabled={payload.isCoinjoinDisabled}
                     onCancel={onCancel}
                 />
             );

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
@@ -65,6 +65,7 @@ export const UserContextModal = ({
                     symbol={payload.symbol}
                     noRedirect={payload.noRedirect}
                     isCoinjoinDisabled={payload.isCoinjoinDisabled}
+                    isBackClickDisabled={payload.isBackClickDisabled}
                     onCancel={onCancel}
                 />
             );

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketVerifyAccount.tsx
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketVerifyAccount.tsx
@@ -91,6 +91,7 @@ const getSuiteReceiveAccounts = ({
         const isVisibleAccount = (account: Account) => account.visible;
         const isFirstNormalAccount = (account: Account) =>
             account.accountType === 'normal' && account.index === 0;
+        const isCoinjoinAccount = (account: Account) => account.accountType === 'coinjoin';
 
         if (receiveNetworks.length > 0) {
             // Get accounts of the current symbol belonging to the current device.
@@ -98,6 +99,7 @@ const getSuiteReceiveAccounts = ({
                 account =>
                     isSameDevice(account) &&
                     isSameNetwork(account) &&
+                    !isCoinjoinAccount(account) &&
                     (isDebugAndIsAccountDebugOnly(account) || isNotDebugOnlyAccount(account)) &&
                     (isNotEmptyAccount(account) ||
                         isVisibleAccount(account) ||
@@ -177,6 +179,7 @@ const useCoinmarketVerifyAccount = ({
                     device,
                     symbol: receiveNetwork,
                     noRedirect: true,
+                    isCoinjoinDisabled: true,
                 }),
             );
 

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketVerifyAccount.tsx
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketVerifyAccount.tsx
@@ -180,6 +180,7 @@ const useCoinmarketVerifyAccount = ({
                     symbol: receiveNetwork,
                     noRedirect: true,
                     isCoinjoinDisabled: true,
+                    isBackClickDisabled: true,
                 }),
             );
 

--- a/packages/suite/src/utils/wallet/coinmarket/__fixtures__/coinmarketUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/__fixtures__/coinmarketUtils.ts
@@ -65,6 +65,7 @@ export const FIXTURE_ACCOUNTS: Partial<Account>[] = [
         descriptor: 'descriptor1',
         symbol: 'btc',
         visible: true,
+        accountType: 'normal',
     },
     {
         deviceState: '1stTestnetAddress@device_id:0',
@@ -73,6 +74,7 @@ export const FIXTURE_ACCOUNTS: Partial<Account>[] = [
         descriptor: 'descriptor2',
         symbol: 'ltc',
         visible: true,
+        accountType: 'normal',
     },
     {
         deviceState: '1stTestnetAddress@device_id:0',
@@ -80,6 +82,7 @@ export const FIXTURE_ACCOUNTS: Partial<Account>[] = [
         descriptor: 'descriptor3',
         symbol: 'eth',
         visible: true,
+        accountType: 'normal',
         tokens: [
             // unsupported token
             {
@@ -117,6 +120,7 @@ export const FIXTURE_ACCOUNTS: Partial<Account>[] = [
         descriptor: 'descriptor4',
         symbol: 'btc',
         visible: true,
+        accountType: 'normal',
     },
     {
         deviceState: '1stTestnet@device_id:0',
@@ -134,6 +138,7 @@ export const FIXTURE_ACCOUNTS: Partial<Account>[] = [
             },
         ],
         descriptor: 'descriptor5',
+        accountType: 'normal',
     },
     {
         deviceState: '1stTestnetAddress@device_id:0',
@@ -152,6 +157,7 @@ export const FIXTURE_ACCOUNTS: Partial<Account>[] = [
             },
         ],
         descriptor: 'descriptor6',
+        accountType: 'normal',
     },
     {
         deviceState: '1stTestnetAddress@device_id:0',
@@ -170,5 +176,15 @@ export const FIXTURE_ACCOUNTS: Partial<Account>[] = [
             },
         ],
         descriptor: 'descriptor6',
+        accountType: 'normal',
+    },
+    {
+        deviceState: '1stTestnetAddress@device_id:0',
+        formattedBalance: '1',
+        tokens: [],
+        descriptor: 'descriptor7',
+        symbol: 'btc',
+        visible: true,
+        accountType: 'coinjoin',
     },
 ];

--- a/packages/suite/src/utils/wallet/coinmarket/__tests__/coinmarketUtils.test.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/__tests__/coinmarketUtils.test.ts
@@ -181,7 +181,7 @@ describe('coinmarket utils', () => {
                 label,
                 options: [
                     {
-                        accountType: undefined,
+                        accountType: 'normal',
                         balance: '0',
                         cryptoName: 'Bitcoin',
                         descriptor: 'descriptor1',
@@ -195,7 +195,7 @@ describe('coinmarket utils', () => {
                 label,
                 options: [
                     {
-                        accountType: undefined,
+                        accountType: 'normal',
                         balance: '0.101213',
                         cryptoName: 'Litecoin',
                         descriptor: 'descriptor2',
@@ -209,7 +209,7 @@ describe('coinmarket utils', () => {
                 label,
                 options: [
                     {
-                        accountType: undefined,
+                        accountType: 'normal',
                         balance: '0',
                         cryptoName: 'Ethereum',
                         descriptor: 'descriptor3',
@@ -218,7 +218,7 @@ describe('coinmarket utils', () => {
                         decimals: 18,
                     },
                     {
-                        accountType: undefined,
+                        accountType: 'normal',
                         balance: '2230',
                         contractAddress: '0x1234123412341234123412341234123412341236',
                         cryptoName: 'VeChain',
@@ -233,7 +233,7 @@ describe('coinmarket utils', () => {
                 label,
                 options: [
                     {
-                        accountType: undefined,
+                        accountType: 'normal',
                         balance: '250',
                         cryptoName: 'Polygon PoS',
                         descriptor: 'descriptor6',

--- a/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
@@ -288,7 +288,11 @@ export const coinmarketGetSortedAccounts = ({
 }: CoinmarketGetSortedAccountsProps) => {
     if (!deviceState) return [];
 
-    return sortByCoin(accounts.filter(a => a.deviceState === deviceState && a.visible));
+    return sortByCoin(
+        accounts.filter(
+            a => a.deviceState === deviceState && a.visible && a.accountType !== 'coinjoin',
+        ),
+    );
 };
 
 export const coinmarketBuildAccountOptions = ({

--- a/suite-common/suite-types/src/modal.ts
+++ b/suite-common/suite-types/src/modal.ts
@@ -39,6 +39,7 @@ export type UserContextPayload =
           symbol?: Account['symbol'];
           noRedirect?: boolean;
           isCoinjoinDisabled?: boolean;
+          isBackClickDisabled?: boolean;
       }
     | {
           type: 'device-background-gallery';

--- a/suite-common/suite-types/src/modal.ts
+++ b/suite-common/suite-types/src/modal.ts
@@ -38,6 +38,7 @@ export type UserContextPayload =
           device: TrezorDevice;
           symbol?: Account['symbol'];
           noRedirect?: boolean;
+          isCoinjoinDisabled?: boolean;
       }
     | {
           type: 'device-background-gallery';


### PR DESCRIPTION
## Description
 Disable coinjoin account in the trade section when trying to buy/exchange BTC. Also if a coinjoin account is already active, it will not be visible in the select list of discovered accounts.

## Related Issue
Resolve https://github.com/trezor/trezor-suite/issues/14303