### PR TITLE
fix(suite-native): make cardano discovery work correct

### DIFF
--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -302,6 +302,7 @@ export const getAvailableCardanoDerivationsThunk = createThunk(
             keepSession: true,
             skipFinalReload: true,
             path: "m/1852'/1815'/0'",
+            useCardanoDerivation: true,
         };
         const icarusPubKeyResult = await TrezorConnect.cardanoGetPublicKey({
             ...commonParams,


### PR DESCRIPTION
Cardano discovery can fail on Connect methods to get derivations being called with `useCardanoDerivation === false` making discovery to set to stopped state and graph behave odd.

BY calling getFeatures, cardanoConnectPatch is applied and connect starts using useCardanoDerivation set to true. 

The other change makes sure that even if derivation fetch fails it does not set discovery state to stopped not making graph on mobile behave strange
