### PR TITLE
feat(suite-native): send form normal fee level validation

### DIFF
--- a/suite-native/module-send/src/components/FeeOptionsList.tsx
+++ b/suite-native/module-send/src/components/FeeOptionsList.tsx
@@ -1,4 +1,4 @@
-import { D } from '@mobily/ts-belt';
+import { D, pipe } from '@mobily/ts-belt';
 
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { GeneralPrecomposedLevels } from '@suite-common/wallet-types';
@@ -15,7 +15,11 @@ export const FeeOptionsList = ({
     networkSymbol: NetworkSymbol;
 }) => {
     // Remove custom fee level from the list. It is not supported in the first version of the send flow.
-    const predefinedFeeLevels = D.filterWithKey(feeLevels, key => key !== 'custom');
+    const predefinedFeeLevels = pipe(
+        feeLevels,
+        D.filter(value => value.type === 'final'), // for now are the invalid fee levels hidden. Will be revisited in issue: https://github.com/trezor/trezor-suite/issues/14240
+        D.filterWithKey(key => key !== 'custom'),
+    );
 
     return (
         <Card>


### PR DESCRIPTION
## Description
- normal fee level is now part of send form validation schema
- If user selects an send amount X, where `(X + normal fee) > available balance` form shows error and user can not continue until he lowers the amount

## Related Issue

Resolve #13782 
## Screenshots:
