### PR TITLE
chore(suite-native): show testnet fiat amounts as plain zero

### DIFF
--- a/suite-native/formatters/src/components/FiatAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/FiatAmountFormatter.tsx
@@ -7,8 +7,8 @@ import { isTestnet } from '@suite-common/wallet-utils';
 
 import { FormatterProps } from '../types';
 import { EmptyAmountSkeleton } from './EmptyAmountSkeleton';
-import { EmptyAmountText } from './EmptyAmountText';
 import { AmountText } from './AmountText';
+import { TestnetFiatAmount } from './TestnetFiatAmount';
 
 type FiatAmountFormatterProps = FormatterProps<string | null> &
     TextProps & {
@@ -21,7 +21,7 @@ export const FiatAmountFormatter = React.memo(
         const { FiatAmountFormatter: formatter } = useFormatters();
 
         if (!!network && isTestnet(network)) {
-            return <EmptyAmountText />;
+            return <TestnetFiatAmount />;
         }
         if (value === null) {
             return <EmptyAmountSkeleton />;

--- a/suite-native/formatters/src/components/TestnetFiatAmount.tsx
+++ b/suite-native/formatters/src/components/TestnetFiatAmount.tsx
@@ -1,0 +1,3 @@
+import { Text } from '@suite-native/atoms';
+
+export const TestnetFiatAmount = () => <Text>0</Text>;

--- a/suite-native/transactions/src/components/TransactionsList/TransactionListItem.tsx
+++ b/suite-native/transactions/src/components/TransactionsList/TransactionListItem.tsx
@@ -8,7 +8,7 @@ import {
 } from '@suite-native/formatters';
 import { Box } from '@suite-native/atoms';
 import { AccountsRootState, selectIsTestnetAccount } from '@suite-common/wallet-core';
-import { EmptyAmountText } from '@suite-native/formatters/src/components/EmptyAmountText';
+import { TestnetFiatAmount } from '@suite-native/formatters/src/components/TestnetFiatAmount';
 import { WalletAccountTransaction } from '@suite-native/tokens';
 
 import { useTransactionFiatRate } from '../../hooks/useTransactionFiatRate';
@@ -40,7 +40,7 @@ export const TransactionListItemValues = ({
     return (
         <>
             {isTestnetAccount ? (
-                <EmptyAmountText />
+                <TestnetFiatAmount />
             ) : (
                 <Box flexDirection="row">
                     <SignValueFormatter value={getTransactionValueSign(transaction.type)} />


### PR DESCRIPTION
The blank space looks as a bug when testing some layouts.

## Screenshots:
<img width="352" alt="image" src="https://github.com/user-attachments/assets/8aba99af-8e62-4d5d-9c01-17068099171e">
<img width="352" alt="image" src="https://github.com/user-attachments/assets/cc2e93b5-b5fc-404f-ab9e-0a5b69ab616f">
<img width="352" alt="image" src="https://github.com/user-attachments/assets/84432b36-590c-4829-b9b7-9c57f2d26a23">

![image](https://github.com/user-attachments/assets/c9dda6c1-a19a-46c3-b746-4407dfb0d6c5)