### PR TITLE
Chore(suite): use new Networks in suite utils

### DIFF
--- a/packages/suite/src/hooks/wallet/useBitcoinAmountUnit.ts
+++ b/packages/suite/src/hooks/wallet/useBitcoinAmountUnit.ts
@@ -4,8 +4,7 @@ import { selectDeviceUnavailableCapabilities } from '@suite-common/wallet-core';
 import { useSelector } from 'src/hooks/suite/useSelector';
 import { useActions } from 'src/hooks/suite/useActions';
 import * as walletSettingsActions from 'src/actions/settings/walletSettingsActions';
-import { NetworkSymbol } from '@suite-common/wallet-config';
-import { networksCompatibility } from '@suite-common/wallet-config';
+import { getNetworkOptional, NetworkSymbol } from '@suite-common/wallet-config';
 
 export const useBitcoinAmountUnit = (symbol?: NetworkSymbol) => {
     const bitcoinAmountUnit = useSelector(state => state.wallet.settings.bitcoinAmountUnit);
@@ -20,11 +19,7 @@ export const useBitcoinAmountUnit = (symbol?: NetworkSymbol) => {
 
     const areUnitsSupportedByDevice = !unavailableCapabilities?.amountUnit;
 
-    const areUnitsSupportedByNetwork =
-        symbol &&
-        networksCompatibility
-            .find(({ symbol: networkSymbol }) => networkSymbol === symbol)
-            ?.features?.includes('amount-unit');
+    const areUnitsSupportedByNetwork = getNetworkOptional(symbol)?.features.includes('amount-unit');
 
     return {
         bitcoinAmountUnit,

--- a/packages/suite/src/utils/suite/router.ts
+++ b/packages/suite/src/utils/suite/router.ts
@@ -1,5 +1,5 @@
 import { Route } from '@suite-common/suite-types';
-import { networksCompatibility } from '@suite-common/wallet-config';
+import { isAccountOfNetwork, getNetworkOptional } from '@suite-common/wallet-config';
 import { WalletParams as CommonWalletParams } from '@suite-common/wallet-types';
 
 import routes, { RouterAppWithParams } from 'src/constants/suite/routes';
@@ -49,20 +49,22 @@ export const getApp = (url: string) => {
 const validateWalletParams = (url: string): CommonWalletParams => {
     const [, hash] = stripPrefixedURL(url).split('#');
     if (!hash) return;
-    const [symbol, index, type] = hash.split('/').filter(p => p.length > 0);
-    if (!symbol || !index) return;
-    const network = networksCompatibility.find(
-        n => n.symbol === symbol && (n.accountType || 'normal') === (type || 'normal'),
-    );
+    const [symbol, index, rawAccountType] = hash.split('/').filter(p => p.length > 0);
+    if (!index) return;
 
+    const network = getNetworkOptional(symbol);
     if (!network) return;
+
+    const accountType = rawAccountType || 'normal';
+    if (!isAccountOfNetwork(network, accountType)) return;
+
     const accountIndex = parseInt(index, 10);
     if (Number.isNaN(accountIndex)) return;
 
     return {
         symbol: network.symbol,
         accountIndex,
-        accountType: network.accountType || 'normal',
+        accountType,
     };
 };
 

--- a/suite-common/formatters/src/formatters/prepareNetworkSymbolFormatter.ts
+++ b/suite-common/formatters/src/formatters/prepareNetworkSymbolFormatter.ts
@@ -1,5 +1,5 @@
 import { UNIT_ABBREVIATIONS } from '@suite-common/suite-constants';
-import { networksCompatibility, NetworkSymbol } from '@suite-common/wallet-config';
+import { getNetwork, NetworkSymbol } from '@suite-common/wallet-config';
 
 import { FormatterConfig } from '../types';
 import { makeFormatter } from '../makeFormatter';
@@ -12,8 +12,7 @@ export const prepareNetworkSymbolFormatter = (config: FormatterConfig) =>
             const { bitcoinAmountUnit } = config;
             const { areAmountUnitsEnabled = true } = dataContext;
 
-            const { features: networkFeatures, testnet: isTestnet } =
-                networksCompatibility.find(network => network.symbol === symbol) ?? {};
+            const { features: networkFeatures, testnet: isTestnet } = getNetwork(symbol);
             const areAmountUnitsSupported = !!networkFeatures?.includes('amount-unit');
             let formattedSymbol = symbol.toUpperCase();
 

--- a/suite-common/formatters/src/formatters/tests/prepareCryptoAmountFormatter.test.ts
+++ b/suite-common/formatters/src/formatters/tests/prepareCryptoAmountFormatter.test.ts
@@ -1,4 +1,3 @@
-import { NetworkSymbol } from '@suite-common/wallet-config';
 import { PROTO } from '@trezor/connect';
 
 import { prepareCryptoAmountFormatter } from '../prepareCryptoAmountFormatter';
@@ -74,32 +73,6 @@ describe('CryptoAmountFormatter', () => {
                 }),
             ).toBe('0.00014898… ETH');
         });
-
-        it('Unknown network with symbol', () => {
-            expect(
-                CryptoAmountFormatter.format('300', {
-                    symbol: 'unknown' as NetworkSymbol,
-                }),
-            ).toBe('300 UNKNOWN');
-        });
-
-        it('Unknown network without symbol', () => {
-            expect(
-                CryptoAmountFormatter.format('300', {
-                    symbol: 'unknown' as NetworkSymbol,
-                    withSymbol: false,
-                }),
-            ).toBe('300');
-        });
-
-        it('Unknown network balance with symbol', () => {
-            expect(
-                CryptoAmountFormatter.format('300', {
-                    symbol: 'unknown' as NetworkSymbol,
-                    isBalance: true,
-                }),
-            ).toBe('300 UNKNOWN');
-        });
     });
 
     describe('Formats correctly to Sats units', () => {
@@ -144,32 +117,6 @@ describe('CryptoAmountFormatter', () => {
                     isBalance: false,
                 }),
             ).toBe('0.00014898… ETH');
-        });
-
-        it('Unknown network with symbol', () => {
-            expect(
-                CryptoAmountFormatterSats.format('300', {
-                    symbol: 'unknown' as NetworkSymbol,
-                }),
-            ).toBe('300 UNKNOWN');
-        });
-
-        it('Unknown network without symbol', () => {
-            expect(
-                CryptoAmountFormatterSats.format('300', {
-                    symbol: 'unknown' as NetworkSymbol,
-                    withSymbol: false,
-                }),
-            ).toBe('300');
-        });
-
-        it('Unknown network balance with symbol', () => {
-            expect(
-                CryptoAmountFormatterSats.format('300', {
-                    symbol: 'unknown' as NetworkSymbol,
-                    isBalance: true,
-                }),
-            ).toBe('300 UNKNOWN');
         });
     });
 });

--- a/suite-common/wallet-config/src/utils.ts
+++ b/suite-common/wallet-config/src/utils.ts
@@ -75,6 +75,12 @@ export const getNetwork = (symbol: NetworkSymbol): Network => networks[symbol];
 export const getNetworkOptional = (symbol?: string) =>
     symbol && isNetworkSymbol(symbol) ? getNetwork(symbol) : undefined;
 
+export const isAccountOfNetwork = (
+    network: Network,
+    accountType: string,
+): accountType is AccountType =>
+    network.accountTypes.hasOwnProperty(accountType) || accountType === 'normal';
+
 export const getNetworkByCoingeckoId = (coingeckoId: string) =>
     networksCollection.find(n => n.coingeckoId === coingeckoId);
 


### PR DESCRIPTION
## Description

Refactoring deprecated `networksCompatibility` to `networks` in these low-hanging-fruit files:
- https://github.com/trezor/trezor-suite/pull/14359/commits/3e4116897cd3d7999300e89ab59761617899945f `useBitcoinAmountUnit`
- https://github.com/trezor/trezor-suite/pull/14359/commits/9a883b85ce93b4a3387e5b3a9c02759dff1c33f9 `router`
- https://github.com/trezor/trezor-suite/pull/14359/commits/00aa985e2fbe158e4edbde349f9da20f96e8488b `prepareNetworkSymbolFormatter`

:information_source: I think the 1st and 3rd don't need testing, but I did test the `router` on suite web to be sure: these routes load the specific accounts as they should:
- http://localhost:8000/accounts#/btc
- http://localhost:8000/accounts#/btc/0
- http://localhost:8000/accounts#/eth/0/normal
- http://localhost:8000/accounts#/btc/1/taproot
- http://localhost:8000/accounts#/asdf/3 (fallback to first account, same as http://localhost:8000/accounts)

## Related Issue

Part of #13839
