### PR TITLE
fix(connect): firmware update do not release

### DIFF
--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -88,6 +88,7 @@ const waitForReconnectedDevice = async (
                 i,
             }),
         );
+
         await createTimeoutPromise(2000);
         try {
             const path = deviceList.getFirstDevicePath();
@@ -379,6 +380,9 @@ export const onCallFirmwareUpdate = async ({
                   })
                 : null;
 
+        const disconnectedPromise = new Promise(resolve => {
+            deviceList.once('device-disconnect', resolve);
+        });
         if (!languageBlob) {
             await device.getCommands().typedCall('RebootToBootloader', 'Success', rebootParams);
         } else {
@@ -410,7 +414,11 @@ export const onCallFirmwareUpdate = async ({
                 );
             }
         }
-        await device.release();
+        log.info(
+            'onCallFirmwareUpdate',
+            'waiting for disconnected event after rebootToBootloader...',
+        );
+        await disconnectedPromise;
 
         // This delay is crucial see https://github.com/trezor/trezor-firmware/issues/1983
         if (device.features.major_version === 1) {


### PR DESCRIPTION
this change https://github.com/trezor/trezor-suite/pull/14092/files#diff-c3affa910cc3a7ed65bcf910b11dc07b7407c5ba91394f76b80f14677a3c14faR371 introduced a problem with node-bridge. Surprisingly, it doesn't affect webusb. 

During fw update, device.release is called also after the reebootToBootloader call. https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/core/onCallFirmwareUpdate.ts#L413 and node-usb implementation is not very good at handling edgecases such as doing something with device and it disappears at the same time. We realized that we probably don't need to call release. The session is cleared with the disconnected device anyway, so we can just wait for the device to vanish and that's it. 

resolve #14337