### PR TITLE
Chore(suite): new wallet-config utils & cleanup

### DIFF
--- a/packages/coinjoin/src/backend/CoinjoinBackend.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackend.ts
@@ -8,7 +8,7 @@ import { scanAccount } from './scanAccount';
 import { getAccountInfo } from './getAccountInfo';
 import { createPendingTransaction } from './createPendingTx';
 import { deriveAddresses, isTaprootAddress } from './backendUtils';
-import { getNetwork } from '../utils/settingsUtils';
+import { getCoinjoinNetwork } from '../utils/settingsUtils';
 import type { CoinjoinBackendSettings, LogEvent, Logger, LogLevel } from '../types';
 import type {
     ScanAccountParams,
@@ -37,7 +37,7 @@ export class CoinjoinBackend extends TypedEmitter<Events> {
     constructor(settings: CoinjoinBackendSettings) {
         super();
         this.settings = Object.freeze(settings);
-        this.network = getNetwork(settings.network);
+        this.network = getCoinjoinNetwork(settings.network);
         const logger = this.getLogger();
         this.client = new CoinjoinBackendClient({ ...settings, logger });
         this.mempool = new CoinjoinMempoolController({

--- a/packages/coinjoin/src/client/CoinjoinClient.ts
+++ b/packages/coinjoin/src/client/CoinjoinClient.ts
@@ -4,7 +4,7 @@ import { Status } from './Status';
 import { Account } from './Account';
 import { CoinjoinPrison } from './CoinjoinPrison';
 import { CoinjoinRound } from './CoinjoinRound';
-import { getNetwork } from '../utils/settingsUtils';
+import { getCoinjoinNetwork } from '../utils/settingsUtils';
 import { redacted } from '../utils/redacted';
 import { analyzeTransactions, AnalyzeTransactionsResult } from './analyzeTransactions';
 import type {
@@ -31,7 +31,7 @@ export class CoinjoinClient extends TypedEmitter<CoinjoinClientEvents> {
         super();
         this.settings = Object.freeze(settings);
         this.logger = this.getLogger();
-        this.network = getNetwork(settings.network);
+        this.network = getCoinjoinNetwork(settings.network);
         this.abortController = new AbortController();
 
         this.status = new Status(settings);

--- a/packages/coinjoin/src/utils/settingsUtils.ts
+++ b/packages/coinjoin/src/utils/settingsUtils.ts
@@ -2,7 +2,7 @@ import { networks } from '@trezor/utxo-lib';
 
 import { CoinjoinBackendSettings } from '../types';
 
-export const getNetwork = (network: CoinjoinBackendSettings['network']) => {
+export const getCoinjoinNetwork = (network: CoinjoinBackendSettings['network']) => {
     switch (network) {
         case 'btc':
             return networks.bitcoin;

--- a/packages/coinjoin/tests/tools/anonymity-test.ts
+++ b/packages/coinjoin/tests/tools/anonymity-test.ts
@@ -4,7 +4,7 @@ import fs from 'fs';
 import http from 'http';
 
 import { getAnonymityScores } from '../../src/client/analyzeTransactions';
-import { getNetwork } from '../../src/utils/settingsUtils';
+import { getCoinjoinNetwork } from '../../src/utils/settingsUtils';
 import { getAccountInfo, getAccountInfoParams } from './discovery';
 
 const [network, descriptor] = process.argv.slice(2);
@@ -92,7 +92,7 @@ const CACHE_PARAMS = `${CACHE_DIR}/anonymityScoreParams.json`;
     const anonScores = await getAnonymityScores(transactions, {
         // middlewareUrl: 'http://localhost:8081/client/',
         middlewareUrl: 'http://localhost:37128/',
-        network: getNetwork(network as any),
+        network: getCoinjoinNetwork(network as any),
         signal: new AbortController().signal,
         logger: {
             debug: () => {},

--- a/packages/suite/src/actions/wallet/cardanoStakingActions.ts
+++ b/packages/suite/src/actions/wallet/cardanoStakingActions.ts
@@ -5,7 +5,11 @@ import { PendingStakeTx, PoolsResponse, CardanoNetwork } from 'src/types/wallet/
 import { Account, WalletAccountTransaction } from 'src/types/wallet';
 import { Dispatch, GetState } from 'src/types/suite';
 import { getUnixTime } from 'date-fns';
-import { isPending, getAccountTransactions, getNetwork } from '@suite-common/wallet-utils';
+import {
+    isPending,
+    getAccountTransactions,
+    getNetworkCompatible,
+} from '@suite-common/wallet-utils';
 import { CARDANO_DEFAULT_TTL_OFFSET } from '@suite-common/wallet-constants';
 import { transactionsActions } from '@suite-common/wallet-core';
 
@@ -55,7 +59,7 @@ export const validatePendingTxOnBlock =
         // After sending staking tx (delegation or withdrawal) user needs to wait few blocks til the tx appears on the blockchain.
         // To prevent the user from sending multiple staking tx we need to track that we are waiting for confirmation for the tx that was already sent.
         // As a failsafe, we will reset `pendingStakeTx` after tx expires (ttl is set to 2 hours), allowing user to retry the action.
-        const network = getNetwork(block.coin.shortcut.toLowerCase());
+        const network = getNetworkCompatible(block.coin.shortcut.toLowerCase());
         if (!network || network.networkType !== 'cardano') return;
 
         const accounts = getState().wallet.accounts.filter(

--- a/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
+++ b/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { HiddenPlaceholder, Sign } from 'src/components/suite';
-import { isNetworkSymbol, Network, networks, NetworkSymbol } from '@suite-common/wallet-config';
+import { getNetworkOptional, NetworkSymbol } from '@suite-common/wallet-config';
 import { useSelector } from 'src/hooks/suite';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 
@@ -54,9 +54,8 @@ export const FormattedCryptoAmount = ({
     }
 
     const lowerCaseSymbol = symbol?.toLowerCase();
-    const matchedNetwork: Network | undefined =
-        lowerCaseSymbol && isNetworkSymbol(lowerCaseSymbol) ? networks[lowerCaseSymbol] : undefined;
-    const { features: networkFeatures, testnet: isTestnet } = matchedNetwork ?? {};
+    const { features: networkFeatures, testnet: isTestnet } =
+        getNetworkOptional(lowerCaseSymbol) ?? {};
 
     const areSatsSupported = !!networkFeatures?.includes('amount-unit');
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Button, NewModal } from '@trezor/components';
 import { HELP_CENTER_ZERO_VALUE_ATTACKS } from '@trezor/urls';
 import { isPending, findChainedTransactions, getAccountKey } from '@suite-common/wallet-utils';
-import { networks, Network } from '@suite-common/wallet-config';
+import { getNetwork } from '@suite-common/wallet-config';
 import { useSelector } from 'src/hooks/suite';
 import {
     selectAccountByKey,
@@ -89,7 +89,7 @@ export const TxDetailModal = ({ tx, rbfForm, onCancel }: TxDetailModalProps) => 
         selectTransactionConfirmations(state, tx.txid, accountKey),
     );
     const account = useSelector(state => selectAccountByKey(state, accountKey)) as Account;
-    const network: Network = networks[account.symbol];
+    const network = getNetwork(account.symbol);
     const networkFeatures = network.accountTypes[account.accountType]?.features ?? network.features;
 
     const isPhishingTransaction = useSelector(state =>

--- a/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountNavigation.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountNavigation.tsx
@@ -1,7 +1,7 @@
 import { WalletParams } from 'src/types/wallet';
 import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { getNetwork, hasNetworkFeatures } from '@suite-common/wallet-utils';
+import { getNetworkCompatible, hasNetworkFeatures } from '@suite-common/wallet-utils';
 import { goto } from 'src/actions/suite/routerActions';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 import { EventType, analytics } from '@trezor/suite-analytics';
@@ -20,7 +20,7 @@ export const AccountNavigation = () => {
     const routerParams = useSelector(state => state.router.params) as WalletParams;
     const dispatch = useDispatch();
 
-    const network = getNetwork(routerParams?.symbol || '');
+    const network = getNetworkCompatible(routerParams?.symbol || '');
     const networkType = account?.networkType || network?.networkType || '';
 
     const goToWithAnalytics = (...[routeName, options]: Parameters<typeof goto>) => {

--- a/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketComposeTransaction.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketComposeTransaction.ts
@@ -2,7 +2,7 @@ import { NetworkCompatible } from '@suite-common/wallet-config';
 import { COMPOSE_ERROR_TYPES } from '@suite-common/wallet-constants';
 import { selectAccounts, selectDevice } from '@suite-common/wallet-core';
 import { AddressDisplayOptions } from '@suite-common/wallet-types';
-import { getFeeLevels, getNetwork } from '@suite-common/wallet-utils';
+import { getFeeLevels, getNetworkCompatible } from '@suite-common/wallet-utils';
 import { useEffect, useMemo, useState } from 'react';
 import { UseFormReturn } from 'react-hook-form';
 import { saveComposedTransactionInfo } from 'src/actions/wallet/coinmarket/coinmarketCommonActions';
@@ -46,7 +46,7 @@ export const useCoinmarketComposeTransaction = <T extends CoinmarketSellExchange
     const initState = useMemo(() => {
         // TODO remove NetworkCompatible type
         // getNetwork is guaranteed to find a NetworkCompatible, as it is called with symbol from an existing Network
-        const networkCompatible = getNetwork(network.symbol) as NetworkCompatible;
+        const networkCompatible = getNetworkCompatible(network.symbol) as NetworkCompatible;
 
         return { account, network: networkCompatible, feeInfo };
     }, [account, network.symbol, feeInfo]);

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketVerifyAccount.tsx
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketVerifyAccount.tsx
@@ -1,4 +1,4 @@
-import { isDebugOnlyAccountType, Network, networks } from '@suite-common/wallet-config';
+import { isDebugOnlyAccountType, Network, networksCollection } from '@suite-common/wallet-config';
 import { selectDevice } from '@suite-common/wallet-core';
 import { useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -72,7 +72,7 @@ const getSuiteReceiveAccounts = ({
         const unavailableCapabilities = device?.unavailableCapabilities ?? {};
 
         // Is the symbol supported by the suite and the device natively?
-        const receiveNetworks = Object.values(networks).filter(
+        const receiveNetworks = networksCollection.filter(
             (n: Network) =>
                 n.symbol === receiveNetwork &&
                 !unavailableCapabilities[n.symbol] &&

--- a/packages/suite/src/hooks/wallet/useCoinmarketRecomposeAndSign.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketRecomposeAndSign.ts
@@ -5,7 +5,7 @@ import { signAndPushSendFormTransactionThunk } from 'src/actions/wallet/send/sen
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { DEFAULT_VALUES, DEFAULT_PAYMENT } from '@suite-common/wallet-constants';
 import { FormState } from '@suite-common/wallet-types';
-import { getFeeLevels, getNetwork } from '@suite-common/wallet-utils';
+import { getFeeLevels, getNetworkCompatible } from '@suite-common/wallet-utils';
 import type { Account, FormOptions } from '@suite-common/wallet-types';
 import { composeSendFormTransactionFeeLevelsThunk } from '@suite-common/wallet-core';
 
@@ -28,7 +28,7 @@ export const useCoinmarketRecomposeAndSign = () => {
             ethereumAdjustGasLimit?: string,
             options: FormOptions[] = ['broadcast'],
         ) => {
-            const network = getNetwork(account.symbol);
+            const network = getNetworkCompatible(account.symbol);
 
             if (!network) return;
 

--- a/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
@@ -19,7 +19,7 @@ import { AssetFiatBalance } from '@suite-common/assets';
 import { getFiatRateKey, toFiatCurrency } from '@suite-common/wallet-utils';
 import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
 import { AssetTable, AssetTableRowType } from './AssetTable/AssetTable';
-import { networks, Network, NetworkSymbol } from '@suite-common/wallet-config';
+import { NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 
 const InfoMessage = styled.div`
     padding: ${spacingsPx.md} ${spacingsPx.xl};
@@ -94,7 +94,7 @@ export const AssetsView = () => {
 
     const assetsData: AssetTableRowType[] = assetNetworkSymbols
         .map(symbol => {
-            const network: Network = networks[symbol];
+            const network = getNetwork(symbol);
             if (!network) {
                 console.error('unknown network');
 

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardException.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardException.tsx
@@ -117,7 +117,7 @@ const discoveryFailedMessage = (discovery?: Discovery) => {
     // Group all failed networks into array of errors.
     const networkError: string[] = [];
     const details = discovery.failed.reduce((value, account) => {
-        const n = accountUtils.getNetwork(account.symbol)!;
+        const n = accountUtils.getNetworkCompatible(account.symbol)!;
         if (networkError.includes(account.symbol)) return value;
         networkError.push(account.symbol);
 

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionGroupedList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionGroupedList.tsx
@@ -1,5 +1,5 @@
 import { GroupedTransactionsByDate, groupJointTransactions } from '@suite-common/wallet-utils';
-import { networks, Network } from '@suite-common/wallet-config';
+import { getNetwork } from '@suite-common/wallet-config';
 import { CoinjoinBatchItem } from 'src/components/wallet/TransactionItem/CoinjoinBatchItem';
 import { useSelector } from 'src/hooks/suite';
 import { Account, WalletAccountTransaction } from 'src/types/wallet';
@@ -23,7 +23,7 @@ export const TransactionGroupedList = ({
 }: TransactionGroupedListProps) => {
     const localCurrency = useSelector(selectLocalCurrency);
     const accountMetadata = useSelector(state => selectLabelingDataForAccount(state, account.key));
-    const network: Network = networks[symbol];
+    const network = getNetwork(symbol);
 
     return Object.entries(transactionGroups).map(([dateKey, value], groupIndex) => (
         <TransactionsGroup

--- a/packages/suite/src/views/wallet/transactions/components/NoTransactions.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/NoTransactions.tsx
@@ -2,14 +2,14 @@ import { Button } from '@trezor/components';
 import { AccountExceptionLayout } from 'src/components/wallet';
 import { Translation, TrezorLink } from 'src/components/suite';
 import { Account } from 'src/types/wallet';
-import { getNetwork } from '@suite-common/wallet-utils';
+import { getNetworkCompatible } from '@suite-common/wallet-utils';
 
 interface NoTransactionsProps {
     account: Account;
 }
 
 export const NoTransactions = ({ account }: NoTransactionsProps) => {
-    const network = getNetwork(account.symbol)!;
+    const network = getNetworkCompatible(account.symbol)!;
 
     const explorerUrl = `${network.explorer.account}${account.descriptor}${network.explorer.queryString ?? ''}`;
 

--- a/suite-common/formatters/src/formatters/NetworkNameFormatter.ts
+++ b/suite-common/formatters/src/formatters/NetworkNameFormatter.ts
@@ -1,9 +1,9 @@
 import { NetworkSymbol } from '@suite-common/wallet-config';
-import { getNetwork } from '@suite-common/wallet-utils';
+import { getNetworkCompatible } from '@suite-common/wallet-utils';
 
 import { makeFormatter } from '../makeFormatter';
 
 export const NetworkNameFormatter = makeFormatter<NetworkSymbol, string>(
-    value => getNetwork(value)?.name || value,
+    value => getNetworkCompatible(value)?.name || value,
     'NetworkNameFormatter',
 );

--- a/suite-common/wallet-config/src/utils.ts
+++ b/suite-common/wallet-config/src/utils.ts
@@ -1,7 +1,10 @@
 import { networks, networksCompatibility } from './networksConfig';
 import { AccountType, Network, NetworkFeature, Networks, NetworkSymbol } from './types';
 
-const networksCollection: Network[] = Object.values(networks);
+/**
+ * array from `networks` as a `Network[]` type instead of inferred type
+ */
+export const networksCollection: Network[] = Object.values(networks);
 
 /**
  * @deprecated See `networksCompatibility`
@@ -30,10 +33,6 @@ export const getMainnets = (debug = false, bnb = false) =>
 
 export const getTestnets = (debug = false) =>
     networksCollection.filter(n => n.testnet === true && (!n.isDebugOnlyNetwork || debug));
-
-export const ethereumTypeNetworkSymbols = networksCollection
-    .filter(n => n.networkType === 'ethereum')
-    .map(n => n.symbol);
 
 export const getTestnetSymbols = () => getTestnets().map(n => n.symbol);
 

--- a/suite-common/wallet-config/src/utils.ts
+++ b/suite-common/wallet-config/src/utils.ts
@@ -65,6 +65,16 @@ export const getCoingeckoId = (symbol: NetworkSymbol) => networks[symbol]?.coing
 export const isNetworkSymbol = (symbol: NetworkSymbol | string): symbol is NetworkSymbol =>
     networks.hasOwnProperty(symbol);
 
+/**
+ * Get network object by symbol as a generic `Network` type.
+ * If you need the exact inferred type, use `networks[symbol]` directly.
+ * @param symbol
+ */
+export const getNetwork = (symbol: NetworkSymbol): Network => networks[symbol];
+
+export const getNetworkOptional = (symbol?: string) =>
+    symbol && isNetworkSymbol(symbol) ? getNetwork(symbol) : undefined;
+
 export const getNetworkByCoingeckoId = (coingeckoId: string) =>
     networksCollection.find(n => n.coingeckoId === coingeckoId);
 

--- a/suite-common/wallet-core/src/blockchain/blockchainReducer.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainReducer.ts
@@ -4,7 +4,7 @@ import { memoizeWithArgs } from 'proxy-memoize';
 import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
 import { BackendType, networksCompatibility, NetworkSymbol } from '@suite-common/wallet-config';
 import { Blockchain, BlockchainNetworks } from '@suite-common/wallet-types';
-import { getNetwork } from '@suite-common/wallet-utils';
+import { getNetworkCompatible } from '@suite-common/wallet-utils';
 import {
     BLOCKCHAIN as TREZOR_CONNECT_BLOCKCHAIN_ACTIONS,
     BlockchainBlock,
@@ -71,7 +71,7 @@ const writeIdentityConnection = (
 };
 
 const connect = (draft: BlockchainState, info: BlockchainInfo) => {
-    const network = getNetwork(info.coin.shortcut.toLowerCase());
+    const network = getNetworkCompatible(info.coin.shortcut.toLowerCase());
     if (!network) return;
 
     if (info.identity) {
@@ -133,7 +133,7 @@ const error = (draft: BlockchainState, payload: BlockchainError) => {
         identity,
         coin: { shortcut: symbol },
     } = payload;
-    const network = getNetwork(symbol.toLowerCase());
+    const network = getNetworkCompatible(symbol.toLowerCase());
     if (!network) return;
 
     if (identity) {
@@ -150,7 +150,7 @@ const error = (draft: BlockchainState, payload: BlockchainError) => {
 };
 
 const update = (draft: BlockchainState, block: BlockchainBlock) => {
-    const network = getNetwork(block.coin.shortcut.toLowerCase());
+    const network = getNetworkCompatible(block.coin.shortcut.toLowerCase());
     if (!network) return;
 
     draft[network.symbol] = {
@@ -161,7 +161,7 @@ const update = (draft: BlockchainState, block: BlockchainBlock) => {
 };
 
 const reconnecting = (draft: BlockchainState, payload: BlockchainReconnecting) => {
-    const network = getNetwork(payload.coin.shortcut.toLowerCase());
+    const network = getNetworkCompatible(payload.coin.shortcut.toLowerCase());
     if (!network) return;
 
     if (payload.identity) {

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -9,7 +9,7 @@ import {
     getAreSatoshisUsed,
     getBackendFromSettings,
     getCustomBackends,
-    getNetwork,
+    getNetworkCompatible,
     isTrezorConnectBackendType,
     shouldUseIdentities,
     getAccountIdentity,
@@ -101,7 +101,7 @@ export const updateFeeInfoThunk = createThunk(
         const {
             selectors: { selectFeeInfo },
         } = extra;
-        const network = getNetwork(symbol.toLowerCase());
+        const network = getNetworkCompatible(symbol.toLowerCase());
         if (!network) return;
         const blockchainInfo = selectNetworkBlockchainInfo(network.symbol)(getState());
         const feeInfo = selectFeeInfo(network.symbol)(getState());
@@ -348,7 +348,7 @@ export const syncAccountsWithBlockchainThunk = createThunk(
 export const onBlockchainConnectThunk = createThunk(
     `${BLOCKCHAIN_MODULE_PREFIX}/onBlockchainConnectThunk`,
     async (symbol: string, { dispatch }) => {
-        const network = getNetwork(symbol.toLowerCase());
+        const network = getNetworkCompatible(symbol.toLowerCase());
         if (!network) return;
 
         await dispatch(
@@ -365,7 +365,7 @@ export const onBlockMinedThunk = createThunk(
     `${BLOCKCHAIN_MODULE_PREFIX}/onBlockMinedThunk`,
     (block: BlockchainBlock, { dispatch }) => {
         const symbol = block.coin.shortcut.toLowerCase();
-        const network = getNetwork(symbol);
+        const network = getNetworkCompatible(symbol);
 
         if (!isNetworkSymbol(symbol)) {
             return;
@@ -441,7 +441,7 @@ export const onBlockchainNotificationThunk = createThunk(
 export const onBlockchainDisconnectThunk = createThunk(
     `${BLOCKCHAIN_MODULE_PREFIX}/onBlockchainDisconnectThunk`,
     (error: BlockchainError, { getState }) => {
-        const network = getNetwork(error.coin.shortcut.toLowerCase());
+        const network = getNetworkCompatible(error.coin.shortcut.toLowerCase());
         if (!network) return;
 
         const blockchain = selectBlockchainState(getState());

--- a/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
@@ -14,7 +14,7 @@ import {
     amountToSatoshi,
     formatAmount,
     isPending,
-    getNetwork,
+    getNetworkCompatible,
     getAccountIdentity,
 } from '@suite-common/wallet-utils';
 import { createThunk } from '@suite-common/redux-utils';
@@ -242,7 +242,7 @@ export const signEthereumSendFormTransactionThunk = createThunk<
         } = extra;
         const transactions = selectTransactions(getState());
 
-        const network = getNetwork(selectedAccount.symbol);
+        const network = getNetworkCompatible(selectedAccount.symbol);
 
         if (
             G.isNullable(network) ||

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -26,7 +26,7 @@ import {
     formatNetworkAmount,
     getPendingAccount,
     isCardanoTx,
-    getNetwork,
+    getNetworkCompatible,
     tryGetAccountIdentity,
 } from '@suite-common/wallet-utils';
 import TrezorConnect, { Success } from '@trezor/connect';
@@ -512,7 +512,7 @@ export const enhancePrecomposedTransactionThunk = createThunk<
         { getState, dispatch, rejectWithValue },
     ) => {
         const device = selectDevice(getState());
-        const selectedAccountNetwork = getNetwork(selectedAccount.symbol);
+        const selectedAccountNetwork = getNetworkCompatible(selectedAccount.symbol);
         if (!device) return rejectWithValue('Device not found');
 
         // native RBF is available since FW 1.9.4/2.3.5

--- a/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
@@ -10,7 +10,7 @@ import {
     getBip43Type,
     getFiatValue,
     getFirstFreshAddress,
-    getNetwork,
+    getNetworkCompatible,
     getTitleForNetwork,
     getTitleForCoinjoinAccount,
     getUtxoFromSignedTransaction,
@@ -138,13 +138,13 @@ describe('account utils', () => {
     });
 
     it('getSelectedNetwork', () => {
-        const res = getNetwork('btc');
+        const res = getNetworkCompatible('btc');
         if (res) {
             expect(res.name).toEqual('Bitcoin');
         } else {
             expect(res).toBeNull();
         }
-        expect(getNetwork('doesntexist')).toBeNull();
+        expect(getNetworkCompatible('doesntexist')).toBeNull();
     });
 
     it('getAccountKey', () => {

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -16,10 +16,10 @@ import {
     NetworkFeature,
     NetworkSymbol,
     NetworkType,
-    Network,
     networks,
     AccountType,
     Bip43Path,
+    getNetwork,
 } from '@suite-common/wallet-config';
 import {
     Account,
@@ -488,7 +488,7 @@ export const getAllAccounts = (deviceState: string | typeof undefined, accounts:
 };
 
 /**
- * @deprecated use directly networks[symbol], you can import { networks } from '@suite-common/wallet-config'
+ * @deprecated use `networks[symbol]` (exact type) or `getNetwork` (generic type) from '@suite-common/wallet-config'
  */
 export const getNetworkCompatible = (symbol: string): NetworkCompatible | null =>
     networksCompatibility.find(c => c.symbol === symbol) || null;
@@ -1079,7 +1079,7 @@ export const getNetworkAccountFeatures = ({
     symbol,
     accountType,
 }: Pick<Account, 'symbol' | 'accountType'>): NetworkFeature[] => {
-    const matchedNetwork: Network = networks[symbol];
+    const matchedNetwork = getNetwork(symbol);
 
     return accountType === 'normal'
         ? matchedNetwork.features

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -490,7 +490,7 @@ export const getAllAccounts = (deviceState: string | typeof undefined, accounts:
 /**
  * @deprecated use directly networks[symbol], you can import { networks } from '@suite-common/wallet-config'
  */
-export const getNetwork = (symbol: string): NetworkCompatible | null =>
+export const getNetworkCompatible = (symbol: string): NetworkCompatible | null =>
     networksCompatibility.find(c => c.symbol === symbol) || null;
 
 export const getAccountNetwork = ({

--- a/suite-native/accounts/src/utils.ts
+++ b/suite-native/accounts/src/utils.ts
@@ -3,7 +3,7 @@ import { A, D, G } from '@mobily/ts-belt';
 import { AccountType, networks } from '@suite-common/wallet-config';
 import { formattedAccountTypeMap } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
-import { getNetwork } from '@suite-common/wallet-utils';
+import { getNetworkCompatible } from '@suite-common/wallet-utils';
 import { discoverySupportedNetworks, orderedAccountTypes } from '@suite-native/config';
 
 const accountTypeToSectionHeader: Readonly<Partial<Record<AccountType, string>>> = {
@@ -24,7 +24,7 @@ export const isFilterValueMatchingAccount = (account: Account, filterValue: stri
 
     if (isMatchingLabel) return true;
 
-    const accountNetwork = getNetwork(account.symbol);
+    const accountNetwork = getNetworkCompatible(account.symbol);
     const isMatchingNetworkName = accountNetwork?.name.toLowerCase().includes(lowerCaseFilterValue);
 
     if (isMatchingNetworkName) return true;

--- a/suite-native/blockchain/src/blockchainThunks.ts
+++ b/suite-native/blockchain/src/blockchainThunks.ts
@@ -9,7 +9,7 @@ import {
     subscribeBlockchainThunk,
 } from '@suite-common/wallet-core';
 import { AccountKey } from '@suite-common/wallet-types';
-import { getNetwork } from '@suite-common/wallet-utils';
+import { getNetworkCompatible } from '@suite-common/wallet-utils';
 import { BlockchainNotification } from '@trezor/connect';
 
 const BLOCKCHAIN_MODULE_PREFIX = '@suite-native/blockchain';
@@ -67,7 +67,7 @@ export const syncAllAccountsWithBlockchainThunk = createThunk(
 export const onBlockchainConnectThunk = createThunk(
     `${BLOCKCHAIN_MODULE_PREFIX}/onBlockchainConnectThunk`,
     async ({ symbol }: { symbol: string }, { dispatch }) => {
-        const network = getNetwork(symbol.toLowerCase());
+        const network = getNetworkCompatible(symbol.toLowerCase());
         if (!network) return;
 
         await dispatch(

--- a/suite-native/module-send/src/screens/SendOutputsScreen.tsx
+++ b/suite-native/module-send/src/screens/SendOutputsScreen.tsx
@@ -24,7 +24,7 @@ import {
     StackNavigationProps,
     StackProps,
 } from '@suite-native/navigation';
-import { getNetwork } from '@suite-common/wallet-utils';
+import { getNetworkCompatible } from '@suite-common/wallet-utils';
 import { Box, Button } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { useToast } from '@suite-native/toasts';
@@ -135,7 +135,7 @@ export const SendOutputsScreen = ({
         if (account) dispatch(updateFeeInfoThunk(account.symbol));
     }, [account, dispatch]);
 
-    const network = getNetwork(account!.symbol);
+    const network = getNetworkCompatible(account!.symbol);
 
     if (!account || !networkFeeInfo || !device || !network) return null;
 

--- a/suite-native/settings/src/settingsSlice.ts
+++ b/suite-native/settings/src/settingsSlice.ts
@@ -2,7 +2,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 import { PROTO } from '@trezor/connect';
 import { FiatCurrencyCode } from '@suite-common/suite-config';
-import { Network, networks, NetworkSymbol } from '@suite-common/wallet-config';
+import { getNetwork, NetworkSymbol } from '@suite-common/wallet-config';
 
 export interface AppSettingsState {
     isOnboardingFinished: boolean;
@@ -69,7 +69,7 @@ export const selectIsAmountInSats = (
         return false;
     }
 
-    const network: Network = networks[networkSymbol];
+    const network = getNetwork(networkSymbol);
     const isAmountUnitSupported = network && network.features.includes('amount-unit');
 
     return isAmountUnitSupported && selectAreSatsAmountUnit(state);


### PR DESCRIPTION
As part of refactoring oc deprecated `networksCompatibility` to `networks`, create new utils :hammer_and_wrench:  and cleanup :broom: 

## Description

- https://github.com/trezor/trezor-suite/pull/14362/commits/5b1a7517554b6e377f44d966280cc46bd1e472a1 tiny tweak: export `networksCollection`, so we don't have to `Object.values(networks)`
- https://github.com/trezor/trezor-suite/pull/14362/commits/de203c199ed7b58013eac60192b724f728f35922 rename the already-deprecated `getNetworks` to `getNetworksCompatible` to prevent confusion
- https://github.com/trezor/trezor-suite/pull/14362/commits/ac4233afc4770bc8e067470299a0e7cb7b5d0839 rename `getNetwork` to `getCoinjoinNetwork` to prevent confusion _(that has nothing to do with the refactoring)_
- https://github.com/trezor/trezor-suite/pull/14362/commits/09c91fb83278317d09039abdf7aabe0e370b0af1 create new `getNetwork` and `getNetworkOptional`, and use them
  - the main goal of this PR; at first I didn't think it's necessary, but it has proven its use-case [a few times already](https://github.com/trezor/trezor-suite/pull/14280#discussion_r1754056627) 

:information_source: PR makes no logic changes, just renaming & moving code to new fn, so `tsc` should be sufficient as QA.

## Related Issue

Part of #13839