### PR TITLE
chore(blockchain-link): replace deprecated Solana api call

### DIFF
--- a/packages/blockchain-link/src/workers/solana/transactionConfirmation.ts
+++ b/packages/blockchain-link/src/workers/solana/transactionConfirmation.ts
@@ -19,10 +19,11 @@ const tryConfirmBySignatureStatus = async (
 
     let currentBlockHeight = await getCurrentBlockHeight();
     while (currentBlockHeight <= lastValidBlockHeight) {
-        const signatureStatus = await api.getSignatureStatus(signature);
+        const signatureStatuses = await api.getSignatureStatuses([signature]);
         if (
-            signatureStatus.value != null &&
-            signatureStatus.value.confirmationStatus === COMMITMENT
+            signatureStatuses.value.length === 1 &&
+            signatureStatuses.value[0] != null &&
+            signatureStatuses.value[0].confirmationStatus === COMMITMENT
         ) {
             return signature;
         }


### PR DESCRIPTION
Resolves https://github.com/trezor/trezor-suite/issues/14343.

[Some Solana RPC calls are being removed](https://github.com/trezor/trezor-suite/issues/14343). Of those Suite only uses [`getSignatureStatus`](https://solana.com/docs/rpc/deprecated/getsignaturestatus). This PR replaces `getSignatureStatus` with [`getSignatureStatuses`](https://solana.com/docs/rpc/http/getsignaturestatuses).