### PR TITLE
chore(suite-native): remove deprecated iconset from Demo screen to prevent crashes

### DIFF
--- a/suite-native/module-dev-utils/package.json
+++ b/suite-native/module-dev-utils/package.json
@@ -15,7 +15,6 @@
         "@sentry/react-native": "5.31.1",
         "@suite-common/icons-deprecated": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
-        "@suite-common/wallet-types": "workspace:*",
         "@suite-native/atoms": "workspace:*",
         "@suite-native/config": "workspace:*",
         "@suite-native/discovery": "workspace:*",

--- a/suite-native/module-dev-utils/src/screens/DemoScreen.tsx
+++ b/suite-native/module-dev-utils/src/screens/DemoScreen.tsx
@@ -30,10 +30,9 @@ import {
 } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { Screen, ScreenSubHeader } from '@suite-native/navigation';
-import { CryptoIcon, tokenIcons, Icon, IconName, icons } from '@suite-common/icons-deprecated';
+import { CryptoIcon, Icon } from '@suite-common/icons-deprecated';
 import { isDevelopOrDebugEnv } from '@suite-native/config';
 import { TypographyStyle } from '@trezor/theme';
-import { TokenAddress } from '@suite-common/wallet-types';
 
 const inputStackStyle = prepareNativeStyle(utils => ({
     borderRadius: utils.borders.radii.medium,
@@ -359,40 +358,6 @@ export const DemoScreen = () => {
                                 }
                             />
                         </VStack>
-                    </Box>
-                    <Box marginTop="medium">
-                        <Text variant="titleMedium">Icons</Text>
-                        <Box flexWrap="wrap" flexDirection="row">
-                            {Object.keys(icons).map((icon: string) => (
-                                <Box
-                                    key={icon}
-                                    marginRight="large"
-                                    marginBottom="large"
-                                    justifyContent="center"
-                                    alignItems="center"
-                                >
-                                    <Icon name={icon as IconName} />
-                                    <Text>{icon}</Text>
-                                </Box>
-                            ))}
-                        </Box>
-                    </Box>
-                    <Box marginTop="medium">
-                        <Text variant="titleMedium">Token Icons</Text>
-                        <HStack
-                            flexWrap="wrap"
-                            flexDirection="row"
-                            marginVertical="medium"
-                            alignItems="center"
-                            justifyContent="center"
-                        >
-                            {Object.keys(tokenIcons).map((iconContract: string) => (
-                                <CryptoIcon
-                                    key={iconContract}
-                                    symbol={iconContract as TokenAddress}
-                                />
-                            ))}
-                        </HStack>
                     </Box>
                     <VStack marginTop="medium">
                         <Text variant="titleMedium">Skeleton</Text>

--- a/suite-native/module-dev-utils/tsconfig.json
+++ b/suite-native/module-dev-utils/tsconfig.json
@@ -8,9 +8,6 @@
         {
             "path": "../../suite-common/wallet-core"
         },
-        {
-            "path": "../../suite-common/wallet-types"
-        },
         { "path": "../atoms" },
         { "path": "../config" },
         { "path": "../discovery" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10195,7 +10195,6 @@ __metadata:
     "@sentry/react-native": "npm:5.31.1"
     "@suite-common/icons-deprecated": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
-    "@suite-common/wallet-types": "workspace:*"
     "@suite-native/atoms": "workspace:*"
     "@suite-native/config": "workspace:*"
     "@suite-native/discovery": "workspace:*"


### PR DESCRIPTION


## Description

Quick fix to prevent crashes on Demo screen (especially in simulator). 