### PR TITLE
chore(suite-native): get rid of ios email warnings about missing entitlement

### DIFF
--- a/suite-native/app/app.config.ts
+++ b/suite-native/app/app.config.ts
@@ -194,6 +194,9 @@ export default ({ config }: ConfigContext): ExpoConfig => {
                 },
                 UIRequiredDeviceCapabilities: ['armv7'],
             },
+            entitlements: {
+                'aps-environment': 'development',
+            },
         },
         plugins: getPlugins(),
         extra: {


### PR DESCRIPTION

## Description

I'm not 100% sure, but I believe it should fix this email warning for every dev build:

<img width="700" alt="image" src="https://github.com/user-attachments/assets/c5fa8452-bd87-4a48-9e71-e44d47c8532f">

