### PR TITLE
chore(suite): refactor usages of deprecated getNetworkCompatible

### DIFF
--- a/packages/suite/src/actions/wallet/cardanoStakingActions.ts
+++ b/packages/suite/src/actions/wallet/cardanoStakingActions.ts
@@ -5,13 +5,10 @@ import { PendingStakeTx, PoolsResponse, CardanoNetwork } from 'src/types/wallet/
 import { Account, WalletAccountTransaction } from 'src/types/wallet';
 import { Dispatch, GetState } from 'src/types/suite';
 import { getUnixTime } from 'date-fns';
-import {
-    isPending,
-    getAccountTransactions,
-    getNetworkCompatible,
-} from '@suite-common/wallet-utils';
+import { isPending, getAccountTransactions } from '@suite-common/wallet-utils';
 import { CARDANO_DEFAULT_TTL_OFFSET } from '@suite-common/wallet-constants';
 import { transactionsActions } from '@suite-common/wallet-core';
+import { getNetworkOptional } from '@suite-common/wallet-config';
 
 export type CardanoStakingAction =
     | { type: typeof CARDANO_STAKING.ADD_PENDING_STAKE_TX; pendingStakeTx: PendingStakeTx }
@@ -59,7 +56,7 @@ export const validatePendingTxOnBlock =
         // After sending staking tx (delegation or withdrawal) user needs to wait few blocks til the tx appears on the blockchain.
         // To prevent the user from sending multiple staking tx we need to track that we are waiting for confirmation for the tx that was already sent.
         // As a failsafe, we will reset `pendingStakeTx` after tx expires (ttl is set to 2 hours), allowing user to retry the action.
-        const network = getNetworkCompatible(block.coin.shortcut.toLowerCase());
+        const network = getNetworkOptional(block.coin.shortcut.toLowerCase());
         if (!network || network.networkType !== 'cardano') return;
 
         const accounts = getState().wallet.accounts.filter(

--- a/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountNavigation.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountNavigation.tsx
@@ -1,7 +1,8 @@
 import { WalletParams } from 'src/types/wallet';
 import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { getNetworkCompatible, hasNetworkFeatures } from '@suite-common/wallet-utils';
+import { hasNetworkFeatures } from '@suite-common/wallet-utils';
+import { getNetworkOptional } from '@suite-common/wallet-config';
 import { goto } from 'src/actions/suite/routerActions';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 import { EventType, analytics } from '@trezor/suite-analytics';
@@ -20,7 +21,7 @@ export const AccountNavigation = () => {
     const routerParams = useSelector(state => state.router.params) as WalletParams;
     const dispatch = useDispatch();
 
-    const network = getNetworkCompatible(routerParams?.symbol || '');
+    const network = getNetworkOptional(routerParams?.symbol);
     const networkType = account?.networkType || network?.networkType || '';
 
     const goToWithAnalytics = (...[routeName, options]: Parameters<typeof goto>) => {

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardException.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardException.tsx
@@ -7,7 +7,7 @@ import {
     authorizeDeviceThunk,
     restartDiscoveryThunk as restartDiscovery,
 } from '@suite-common/wallet-core';
-import * as accountUtils from '@suite-common/wallet-utils';
+import { getNetwork } from '@suite-common/wallet-config';
 import { variables, Button, H3, Image, IconName } from '@trezor/components';
 import { Discovery } from '@suite-common/wallet-types';
 
@@ -117,13 +117,13 @@ const discoveryFailedMessage = (discovery?: Discovery) => {
     // Group all failed networks into array of errors.
     const networkError: string[] = [];
     const details = discovery.failed.reduce((value, account) => {
-        const n = accountUtils.getNetworkCompatible(account.symbol)!;
+        const network = getNetwork(account.symbol);
         if (networkError.includes(account.symbol)) return value;
         networkError.push(account.symbol);
 
         return value.concat(
             <div key={account.symbol}>
-                {n.name}: {getAccountError(account.error)}
+                {network.name}: {getAccountError(account.error)}
             </div>,
         );
     }, [] as JSX.Element[]);

--- a/packages/suite/src/views/wallet/transactions/components/NoTransactions.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/NoTransactions.tsx
@@ -2,14 +2,14 @@ import { Button } from '@trezor/components';
 import { AccountExceptionLayout } from 'src/components/wallet';
 import { Translation, TrezorLink } from 'src/components/suite';
 import { Account } from 'src/types/wallet';
-import { getNetworkCompatible } from '@suite-common/wallet-utils';
+import { getNetwork } from '@suite-common/wallet-config';
 
 interface NoTransactionsProps {
     account: Account;
 }
 
 export const NoTransactions = ({ account }: NoTransactionsProps) => {
-    const network = getNetworkCompatible(account.symbol)!;
+    const network = getNetwork(account.symbol);
 
     const explorerUrl = `${network.explorer.account}${account.descriptor}${network.explorer.queryString ?? ''}`;
 

--- a/suite-common/formatters/src/formatters/NetworkNameFormatter.ts
+++ b/suite-common/formatters/src/formatters/NetworkNameFormatter.ts
@@ -1,9 +1,8 @@
-import { NetworkSymbol } from '@suite-common/wallet-config';
-import { getNetworkCompatible } from '@suite-common/wallet-utils';
+import { getNetwork, NetworkSymbol } from '@suite-common/wallet-config';
 
 import { makeFormatter } from '../makeFormatter';
 
 export const NetworkNameFormatter = makeFormatter<NetworkSymbol, string>(
-    value => getNetworkCompatible(value)?.name || value,
+    value => getNetwork(value).name,
     'NetworkNameFormatter',
 );

--- a/suite-common/wallet-core/src/blockchain/blockchainReducer.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainReducer.ts
@@ -2,9 +2,13 @@ import { PayloadAction } from '@reduxjs/toolkit';
 import { memoizeWithArgs } from 'proxy-memoize';
 
 import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
-import { BackendType, networksCompatibility, NetworkSymbol } from '@suite-common/wallet-config';
+import {
+    BackendType,
+    getNetworkOptional,
+    networksCompatibility,
+    NetworkSymbol,
+} from '@suite-common/wallet-config';
 import { Blockchain, BlockchainNetworks } from '@suite-common/wallet-types';
-import { getNetworkCompatible } from '@suite-common/wallet-utils';
 import {
     BLOCKCHAIN as TREZOR_CONNECT_BLOCKCHAIN_ACTIONS,
     BlockchainBlock,
@@ -71,7 +75,7 @@ const writeIdentityConnection = (
 };
 
 const connect = (draft: BlockchainState, info: BlockchainInfo) => {
-    const network = getNetworkCompatible(info.coin.shortcut.toLowerCase());
+    const network = getNetworkOptional(info.coin.shortcut.toLowerCase());
     if (!network) return;
 
     if (info.identity) {
@@ -133,7 +137,7 @@ const error = (draft: BlockchainState, payload: BlockchainError) => {
         identity,
         coin: { shortcut: symbol },
     } = payload;
-    const network = getNetworkCompatible(symbol.toLowerCase());
+    const network = getNetworkOptional(symbol.toLowerCase());
     if (!network) return;
 
     if (identity) {
@@ -150,7 +154,7 @@ const error = (draft: BlockchainState, payload: BlockchainError) => {
 };
 
 const update = (draft: BlockchainState, block: BlockchainBlock) => {
-    const network = getNetworkCompatible(block.coin.shortcut.toLowerCase());
+    const network = getNetworkOptional(block.coin.shortcut.toLowerCase());
     if (!network) return;
 
     draft[network.symbol] = {
@@ -161,7 +165,7 @@ const update = (draft: BlockchainState, block: BlockchainBlock) => {
 };
 
 const reconnecting = (draft: BlockchainState, payload: BlockchainReconnecting) => {
-    const network = getNetworkCompatible(payload.coin.shortcut.toLowerCase());
+    const network = getNetworkOptional(payload.coin.shortcut.toLowerCase());
     if (!network) return;
 
     if (payload.identity) {

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -1,5 +1,10 @@
 import { createThunk } from '@suite-common/redux-utils';
-import { isNetworkSymbol, networksCompatibility, NetworkSymbol } from '@suite-common/wallet-config';
+import {
+    getNetworkOptional,
+    isNetworkSymbol,
+    networksCompatibility,
+    NetworkSymbol,
+} from '@suite-common/wallet-config';
 import {
     findAccountDevice,
     findAccountsByDescriptor,
@@ -9,7 +14,6 @@ import {
     getAreSatoshisUsed,
     getBackendFromSettings,
     getCustomBackends,
-    getNetworkCompatible,
     isTrezorConnectBackendType,
     shouldUseIdentities,
     getAccountIdentity,
@@ -101,7 +105,7 @@ export const updateFeeInfoThunk = createThunk(
         const {
             selectors: { selectFeeInfo },
         } = extra;
-        const network = getNetworkCompatible(symbol.toLowerCase());
+        const network = getNetworkOptional(symbol.toLowerCase());
         if (!network) return;
         const blockchainInfo = selectNetworkBlockchainInfo(network.symbol)(getState());
         const feeInfo = selectFeeInfo(network.symbol)(getState());
@@ -348,7 +352,7 @@ export const syncAccountsWithBlockchainThunk = createThunk(
 export const onBlockchainConnectThunk = createThunk(
     `${BLOCKCHAIN_MODULE_PREFIX}/onBlockchainConnectThunk`,
     async (symbol: string, { dispatch }) => {
-        const network = getNetworkCompatible(symbol.toLowerCase());
+        const network = getNetworkOptional(symbol.toLowerCase());
         if (!network) return;
 
         await dispatch(
@@ -365,7 +369,7 @@ export const onBlockMinedThunk = createThunk(
     `${BLOCKCHAIN_MODULE_PREFIX}/onBlockMinedThunk`,
     (block: BlockchainBlock, { dispatch }) => {
         const symbol = block.coin.shortcut.toLowerCase();
-        const network = getNetworkCompatible(symbol);
+        const network = getNetworkOptional(symbol);
 
         if (!isNetworkSymbol(symbol)) {
             return;
@@ -441,7 +445,7 @@ export const onBlockchainNotificationThunk = createThunk(
 export const onBlockchainDisconnectThunk = createThunk(
     `${BLOCKCHAIN_MODULE_PREFIX}/onBlockchainDisconnectThunk`,
     (error: BlockchainError, { getState }) => {
-        const network = getNetworkCompatible(error.coin.shortcut.toLowerCase());
+        const network = getNetworkOptional(error.coin.shortcut.toLowerCase());
         if (!network) return;
 
         const blockchain = selectBlockchainState(getState());

--- a/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
@@ -1,5 +1,4 @@
 import { toWei } from 'web3-utils';
-import { G } from '@mobily/ts-belt';
 
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 import TrezorConnect, { FeeLevel, TokenInfo } from '@trezor/connect';
@@ -14,7 +13,6 @@ import {
     amountToSatoshi,
     formatAmount,
     isPending,
-    getNetworkCompatible,
     getAccountIdentity,
 } from '@suite-common/wallet-utils';
 import { createThunk } from '@suite-common/redux-utils';
@@ -25,6 +23,7 @@ import {
     ExternalOutput,
 } from '@suite-common/wallet-types';
 import { AddressDisplayOptions } from '@suite-common/wallet-types';
+import { getNetwork } from '@suite-common/wallet-config';
 import { getTxStakeNameByDataHex } from '@suite-common/suite-utils';
 
 import { selectTransactions } from '../transactions/transactionsReducer';
@@ -242,13 +241,9 @@ export const signEthereumSendFormTransactionThunk = createThunk<
         } = extra;
         const transactions = selectTransactions(getState());
 
-        const network = getNetworkCompatible(selectedAccount.symbol);
+        const network = getNetwork(selectedAccount.symbol);
 
-        if (
-            G.isNullable(network) ||
-            selectedAccount.networkType !== 'ethereum' ||
-            !network?.chainId
-        )
+        if (selectedAccount.networkType !== 'ethereum' || !network.chainId)
             return rejectWithValue({
                 error: 'sign-transaction-failed',
                 message: 'Ethereum network mismatch.',

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -16,7 +16,7 @@ import {
     PrecomposedTransactionFinalRbf,
 } from '@suite-common/wallet-types';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import { getNetwork, NetworkSymbol } from '@suite-common/wallet-config';
 import {
     hasNetworkFeatures,
     amountToSatoshi,
@@ -26,7 +26,6 @@ import {
     formatNetworkAmount,
     getPendingAccount,
     isCardanoTx,
-    getNetworkCompatible,
     tryGetAccountIdentity,
 } from '@suite-common/wallet-utils';
 import TrezorConnect, { Success } from '@trezor/connect';
@@ -512,7 +511,7 @@ export const enhancePrecomposedTransactionThunk = createThunk<
         { getState, dispatch, rejectWithValue },
     ) => {
         const device = selectDevice(getState());
-        const selectedAccountNetwork = getNetworkCompatible(selectedAccount.symbol);
+        const selectedAccountNetwork = getNetwork(selectedAccount.symbol);
         if (!device) return rejectWithValue('Device not found');
 
         // native RBF is available since FW 1.9.4/2.3.5
@@ -559,7 +558,7 @@ export const enhancePrecomposedTransactionThunk = createThunk<
             !isCardanoTx(selectedAccount, enhancedPrecomposedTransaction) &&
             selectedAccount.networkType === 'ethereum' &&
             enhancedPrecomposedTransaction.token?.contract &&
-            selectedAccountNetwork?.chainId
+            selectedAccountNetwork.chainId
         ) {
             const isTokenKnown = await fetch(
                 `https://data.trezor.io/firmware/eth-definitions/chain-id/${

--- a/suite-native/accounts/src/utils.ts
+++ b/suite-native/accounts/src/utils.ts
@@ -1,9 +1,8 @@
 import { A, D, G } from '@mobily/ts-belt';
 
-import { AccountType, networks } from '@suite-common/wallet-config';
+import { AccountType, getNetwork, networks } from '@suite-common/wallet-config';
 import { formattedAccountTypeMap } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
-import { getNetworkCompatible } from '@suite-common/wallet-utils';
 import { discoverySupportedNetworks, orderedAccountTypes } from '@suite-native/config';
 
 const accountTypeToSectionHeader: Readonly<Partial<Record<AccountType, string>>> = {
@@ -24,8 +23,8 @@ export const isFilterValueMatchingAccount = (account: Account, filterValue: stri
 
     if (isMatchingLabel) return true;
 
-    const accountNetwork = getNetworkCompatible(account.symbol);
-    const isMatchingNetworkName = accountNetwork?.name.toLowerCase().includes(lowerCaseFilterValue);
+    const accountNetwork = getNetwork(account.symbol);
+    const isMatchingNetworkName = accountNetwork.name.toLowerCase().includes(lowerCaseFilterValue);
 
     if (isMatchingNetworkName) return true;
 

--- a/suite-native/blockchain/package.json
+++ b/suite-native/blockchain/package.json
@@ -15,7 +15,6 @@
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
-        "@suite-common/wallet-utils": "workspace:*",
         "@trezor/connect": "workspace:*"
     }
 }

--- a/suite-native/blockchain/src/blockchainThunks.ts
+++ b/suite-native/blockchain/src/blockchainThunks.ts
@@ -1,5 +1,5 @@
 import { createThunk } from '@suite-common/redux-utils';
-import { NetworkSymbol, isNetworkSymbol } from '@suite-common/wallet-config';
+import { NetworkSymbol, isNetworkSymbol, getNetworkOptional } from '@suite-common/wallet-config';
 import {
     blockchainActions,
     fetchAndUpdateAccountThunk,
@@ -9,7 +9,6 @@ import {
     subscribeBlockchainThunk,
 } from '@suite-common/wallet-core';
 import { AccountKey } from '@suite-common/wallet-types';
-import { getNetworkCompatible } from '@suite-common/wallet-utils';
 import { BlockchainNotification } from '@trezor/connect';
 
 const BLOCKCHAIN_MODULE_PREFIX = '@suite-native/blockchain';
@@ -67,7 +66,7 @@ export const syncAllAccountsWithBlockchainThunk = createThunk(
 export const onBlockchainConnectThunk = createThunk(
     `${BLOCKCHAIN_MODULE_PREFIX}/onBlockchainConnectThunk`,
     async ({ symbol }: { symbol: string }, { dispatch }) => {
-        const network = getNetworkCompatible(symbol.toLowerCase());
+        const network = getNetworkOptional(symbol.toLowerCase());
         if (!network) return;
 
         await dispatch(

--- a/suite-native/blockchain/tsconfig.json
+++ b/suite-native/blockchain/tsconfig.json
@@ -14,9 +14,6 @@
         {
             "path": "../../suite-common/wallet-types"
         },
-        {
-            "path": "../../suite-common/wallet-utils"
-        },
         { "path": "../../packages/connect" }
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9711,7 +9711,6 @@ __metadata:
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
-    "@suite-common/wallet-utils": "workspace:*"
     "@trezor/connect": "workspace:*"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Refactoring deprecated [getNetworkCompatible](https://github.com/trezor/trezor-suite/blob/722f5c99d35a53488f00b2ff46c7b500d813b31f/suite-common/wallet-utils/src/accountUtils.ts#L490-L494) to either [getNetwork, or getNetworkOptional](https://github.com/trezor/trezor-suite/blob/722f5c99d35a53488f00b2ff46c7b500d813b31f/suite-common/wallet-config/src/utils.ts#L73-L76)

## Description

`getNetworkCompatible`, which returns deprecated `NetworkCompatible`, is swapped for either:
- `getNetwork` if symbol is guaranteed to be `NetworkSymbol` type, then return `Network` and remove need for nullable handling :slightly_smiling_face: 
- `getNetworkOptional` if we can't be sure, then return `Network | undefined` _(as before)_

:information_source: Most occurrences were refactored - only the simple cases, where it doesn't change anything (the subsequent code consumes only those properties of `Network` which are common with `NetworkCompatible`).
Only several usages are waiting for a future refactoring.

## Related Issue

Part of #13839

## Screenshots:

It's quite straightforward refactoring, but still I selected a few easy-to-test places:

`AccountNavigation` still has correct tabs as per network's features 
![AccountNavigation](https://github.com/user-attachments/assets/bae8f00a-c57d-4b4d-9af1-d5891e8d4685)

`PortfolioCardException` reproducible with Tor + localhost REGTEST :upside_down_face: 
![PortfolioCardException regtest + tor](https://github.com/user-attachments/assets/fc3d04d0-1d36-4ebc-99bb-ef6b7c06827e)

`NoTransaction` not reproducible, had to comment code to get it, but the blockchain link still works:  
![NoTransaction](https://github.com/user-attachments/assets/6637fe52-98c8-4a79-840f-079df0577e95)
