### PR TITLE
chore(ci): use larger workers for android builds to prevent failing

### DIFF
--- a/suite-native/app/eas.json
+++ b/suite-native/app/eas.json
@@ -14,7 +14,8 @@
                 "distribution": "store"
             },
             "android": {
-                "distribution": "internal"
+                "distribution": "internal",
+                "resourceClass": "large"
             }
         },
         "production": {
@@ -23,7 +24,8 @@
             },
             "autoIncrement": true,
             "android": {
-                "credentialsSource": "remote"
+                "credentialsSource": "remote",
+                "resourceClass": "large"
             },
             "ios": {
                 "credentialsSource": "remote"


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

- Android builds are failing quite often. Let's try it on bigger workers, and pay the bigger price ($2 instead of $1 per android build).

https://expo.dev/accounts/trezorcompany/projects/trezor-suite-develop/builds