### PR TITLE
feat(connect): return device info with method response

### DIFF
--- a/packages/connect-common/src/messageChannel/abstract.ts
+++ b/packages/connect-common/src/messageChannel/abstract.ts
@@ -165,7 +165,7 @@ export abstract class AbstractMessageChannel<
             message = message.data;
         }
 
-        const { channel, id, type, payload, success } = message;
+        const { channel, id, type, ...data } = message;
 
         // Don't verify channel in legacy mode
         if (!this.legacyMode) {
@@ -201,7 +201,7 @@ export abstract class AbstractMessageChannel<
         }
 
         if (this.messagePromises[id]) {
-            this.messagePromises[id].resolve({ id, payload, success });
+            this.messagePromises[id].resolve({ id, ...data });
             delete this.messagePromises[id];
         }
         const messagePromisesLength = Object.keys(this.messagePromises).length;

--- a/packages/connect-web/src/impl/core-in-iframe.ts
+++ b/packages/connect-web/src/impl/core-in-iframe.ts
@@ -19,7 +19,7 @@ import {
     CoreEventMessage,
     CallMethodPayload,
 } from '@trezor/connect/src/events';
-import type { ConnectSettings, Manifest } from '@trezor/connect/src/types';
+import type { ConnectSettings, DeviceIdentity, Manifest } from '@trezor/connect/src/types';
 import { ConnectFactoryDependencies, factory } from '@trezor/connect/src/factory';
 import { Log, initLog } from '@trezor/connect/src/utils/debug';
 import { config } from '@trezor/connect/src/data/config';
@@ -36,7 +36,12 @@ export class CoreInIframe implements ConnectFactoryDependencies {
 
     private _log: Log;
     private _popupManager?: popup.PopupManager;
-    private _messagePromises: DeferredManager<{ id: number; success: boolean; payload: any }>;
+    private _messagePromises: DeferredManager<{
+        id: number;
+        success: boolean;
+        payload: any;
+        device?: DeviceIdentity;
+    }>;
 
     private readonly boundHandleMessage = this.handleMessage.bind(this);
     private readonly boundDispose = this.dispose.bind(this);
@@ -96,8 +101,13 @@ export class CoreInIframe implements ConnectFactoryDependencies {
 
         switch (message.event) {
             case RESPONSE_EVENT: {
-                const { id = 0, success, payload } = message;
-                const resolved = this._messagePromises.resolve(id, { id, success, payload });
+                const { id = 0, success, payload, device } = message;
+                const resolved = this._messagePromises.resolve(id, {
+                    id,
+                    success,
+                    payload,
+                    device,
+                });
                 if (!resolved) this._log.warn(`Unknown message id ${id}`);
                 break;
             }

--- a/packages/connect-web/src/impl/core-in-popup.ts
+++ b/packages/connect-web/src/impl/core-in-popup.ts
@@ -164,7 +164,11 @@ export class CoreInPopup implements ConnectFactoryDependencies {
                     this._popupManager.clear();
                 }
 
-                return response;
+                return {
+                    success: response.success,
+                    payload: response.payload,
+                    device: response.device,
+                };
             }
 
             throw ERRORS.TypedError('Method_NoResponse');

--- a/packages/connect/e2e/tests/device/passphrase.test.ts
+++ b/packages/connect/e2e/tests/device/passphrase.test.ts
@@ -51,8 +51,15 @@ describe('TrezorConnect passphrase', () => {
             useEmptyPassphrase: true,
             path: XPUB_PATH,
         });
+        if (!xpub.success) {
+            throw new Error(`getPublicKey exception: ${xpub.payload.error}`);
+        }
         expect(xpub.payload).toMatchObject({
             xpub: 'xpub6DDUPHpUo4pcy43iJeZjbSVWGav1SMMmuWdMHiGtkK8rhKmfbomtkwW6GKs1GGAKehT6QRocrmda3WWxXawpjmwaUHfFRXuKrXSapdckEYF',
+        });
+        expect(xpub.device).toMatchObject({
+            instance: 0,
+            state: walletDefault.payload._state,
         });
 
         // get state of walletA using passphrase "a"
@@ -73,8 +80,15 @@ describe('TrezorConnect passphrase', () => {
             },
             path: XPUB_PATH,
         });
+        if (!xpubA.success) {
+            throw new Error(`getPublicKey A exception: ${xpubA.payload.error}`);
+        }
         expect(xpubA.payload).toMatchObject({
             xpub: 'xpub6CixwCVCacLWy2pdyzvcWATbm8cHRqLkmC3B335NzEVx3DBMG8mhoqyJzm62Qkv3UyN4haP7xnihe7ZR134vVGY8pjAHtGgiyD139Ro29N8',
+        });
+        expect(xpubA.device).toMatchObject({
+            instance: 1,
+            state: walletA.payload._state,
         });
 
         // get state of walletB using passphrase "b"
@@ -94,8 +108,15 @@ describe('TrezorConnect passphrase', () => {
             },
             path: XPUB_PATH,
         });
+        if (!xpubB.success) {
+            throw new Error(`getPublicKey B exception: ${xpubB.payload.error}`);
+        }
         expect(xpubB.payload).toMatchObject({
             xpub: 'xpub6CUsAXLNQXX9oGjwXi2EjL1Hp8BMPSKXsgdRHv5pgPoqb9CxncThcup7YAsbYcKMgRqDbedLCNUWzD7JhPVsEc82yYz15AYR35UGiUkXtWa',
+        });
+        expect(xpubB.device).toMatchObject({
+            instance: 2,
+            state: walletB.payload._state,
         });
 
         // generate addresses from 3 different wallets in random order using same derivation path

--- a/packages/connect/src/api/bitcoin/inputs.ts
+++ b/packages/connect/src/api/bitcoin/inputs.ts
@@ -62,7 +62,7 @@ export const enhanceTrezorInputs = (
 ) => {
     inputs.forEach(input => {
         if (!input.amount) {
-            console.warn('TrezorConnect.singTransaction deprecation: missing input amount.');
+            console.warn('TrezorConnect.signTransaction deprecation: missing input amount.');
             const refTx = rawTxs.find(t => t.getId() === input.prev_hash);
             if (refTx && refTx.outs[input.prev_index]) {
                 input.amount = refTx.outs[input.prev_index].value;

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -427,7 +427,7 @@ const inner = async (context: CoreContext, method: AbstractMethod<any>, device: 
     try {
         const response = await method.run();
 
-        return createResponseMessage(method.responseID, true, response);
+        return createResponseMessage(method.responseID, true, response, device);
     } catch (error) {
         return Promise.reject(error);
     }

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -667,7 +667,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
         return response.message;
     }
 
-    _updateFeatures(feat: Features) {
+    private _updateFeatures(feat: Features) {
         const capabilities = parseCapabilities(feat);
         feat.capabilities = capabilities;
         // GetFeatures doesn't return 'session_id'

--- a/packages/connect/src/events/call.ts
+++ b/packages/connect/src/events/call.ts
@@ -1,7 +1,8 @@
 import { serializeError } from '../constants/errors';
 import type { IFRAME } from './iframe';
 import type { TrezorConnect } from '../types/api';
-import type { CommonParams } from '../types/params';
+import type { CommonParams, DeviceIdentity } from '../types/params';
+import { Device } from '../device/Device';
 
 // conditionally unwrap TrezorConnect api method Success<T> response
 type UnwrappedResponse<T> =
@@ -58,12 +59,14 @@ export interface MethodResponseMessage {
     id: number;
     success: boolean;
     payload: CallMethodResponse<keyof CallApi>;
+    device?: DeviceIdentity;
 }
 
 export const createResponseMessage = (
     id: number,
     success: boolean,
     payload: any,
+    device?: Device,
 ): MethodResponseMessage => ({
     event: RESPONSE_EVENT,
     type: RESPONSE_EVENT,
@@ -71,4 +74,11 @@ export const createResponseMessage = (
     success,
 
     payload: success ? payload : serializeError(payload),
+    device: device
+        ? {
+              path: device?.originalDescriptor.path,
+              state: device?.getState(),
+              instance: device?.instance,
+          }
+        : undefined,
 });

--- a/packages/connect/src/events/core.ts
+++ b/packages/connect/src/events/core.ts
@@ -47,6 +47,7 @@ export const parseMessage = <T extends CoreRequestMessage | CoreEventMessage = n
         event: messageData.event,
         type: messageData.type,
         payload: messageData.payload,
+        device: messageData.device,
     };
 
     if (typeof messageData.id === 'number') {

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -61,8 +61,8 @@ const onCoreEvent = (message: CoreEventMessage) => {
 
     switch (event) {
         case RESPONSE_EVENT: {
-            const { id = 0, success } = message;
-            const resolved = messagePromises.resolve(id, { id, success, payload });
+            const { id = 0, success, device } = message;
+            const resolved = messagePromises.resolve(id, { id, success, payload, device });
             if (!resolved) _log.warn(`Unknown message id ${id}`);
             break;
         }

--- a/packages/connect/src/types/params.ts
+++ b/packages/connect/src/types/params.ts
@@ -3,12 +3,14 @@
 import { Type, TSchema, Static } from '@trezor/schema-utils';
 import { DeviceState } from './device';
 
+export interface DeviceIdentity {
+    path?: string;
+    state?: string | DeviceState;
+    instance?: number;
+}
+
 export interface CommonParams {
-    device?: {
-        path?: string;
-        state?: string | DeviceState;
-        instance?: number;
-    };
+    device?: DeviceIdentity;
     useEmptyPassphrase?: boolean;
     useEventListener?: boolean; // this param is set automatically in factory
     allowSeedlessDevice?: boolean;
@@ -44,7 +46,11 @@ export interface Success<T> {
     payload: T;
 }
 
-export type Response<T> = Promise<Success<T> | Unsuccessful>;
+export interface SuccessWithDevice<T> extends Success<T> {
+    device?: DeviceIdentity;
+}
+
+export type Response<T> = Promise<SuccessWithDevice<T> | Unsuccessful>;
 
 export type DerivationPath = string | number[];
 export const DerivationPath = Type.Union([Type.String(), Type.Array(Type.Number())], {


### PR DESCRIPTION
## Description

Return additional info about device along with response payload. 
This is especially useful for core-in-popup or mobile, due to the lack of device events.

Eg.

```
{
  "id": 2,
  "success": true,
  "payload": {
    ...
  },
  "device": {
    "path": "E97D0BCE6A73CC77DDBA324D",
    "state": {
      "sessionId": "...",
      "staticSessionId": "abc@xyz:0"
    },
    "instance": 0
  }
}
```