### PR TITLE
fix(suite): Fix dashboard passphrase banner button size

### DIFF
--- a/packages/suite/src/views/dashboard/DashboardPassphraseBanner.tsx
+++ b/packages/suite/src/views/dashboard/DashboardPassphraseBanner.tsx
@@ -60,12 +60,13 @@ export const DashboardPassphraseBanner = () => {
                         icon="asterisk"
                         rightContent={
                             <Row gap={8}>
-                                <Button onClick={handleManageClick}>
+                                <Button onClick={handleManageClick} size="small">
                                     <Translation id="TR_CONNECT_DEVICE_PASSPHRASE_BANNER_BUTTON" />
                                 </Button>
                                 <IconButton
                                     icon="x"
                                     variant="tertiary"
+                                    size="small"
                                     onClick={() => {
                                         setIsVisible(false);
                                     }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

before
<img width="1177" alt="Screenshot 2024-09-17 at 12 00 30" src="https://github.com/user-attachments/assets/dd5f948a-3e48-460e-ad1e-283c83e2b84b">

after
<img width="1178" alt="Screenshot 2024-09-17 at 12 01 00" src="https://github.com/user-attachments/assets/4c6eb3a8-f5e7-482e-b32c-87da61d756cb">
