### PR TITLE
fix(suite): fix t3b1 homescreen name

### DIFF
--- a/packages/suite/src/components/suite/HomescreenGallery.tsx
+++ b/packages/suite/src/components/suite/HomescreenGallery.tsx
@@ -51,7 +51,9 @@ export const HomescreenGallery = ({ onConfirm }: HomescreenGalleryProps) => {
         if (isLocked()) return;
 
         // original image is the default image already available in device, set it by empty string
-        const isOriginalImage = image === `original_${deviceModelInternal.toLowerCase()}`;
+        const isOriginalImage =
+            image ===
+            `original_${(deviceModelInternal === DeviceModelInternal.T2B1 ? DeviceModelInternal.T3B1 : deviceModelInternal).toLowerCase()}`;
 
         const hex = isOriginalImage ? '' : await imagePathToHex(imagePath, deviceModelInternal);
 

--- a/packages/suite/src/constants/suite/homescreens.ts
+++ b/packages/suite/src/constants/suite/homescreens.ts
@@ -1,7 +1,7 @@
 import { DeviceModelInternal } from '@trezor/connect';
 
 const safe3Homescreens = [
-    'original_t2b1', // note - has to be first
+    'original_t3b1', // note - has to be first
     'blank',
     'circleweb',
     'circuit',


### PR DESCRIPTION
Both T2B1 and T3B1 should use `original_t3b1.png` as default screen. File `original_t2b1` does not exist.

Before:
![Screenshot 2024-09-17 at 13 12 01](https://github.com/user-attachments/assets/c1ae765f-3dcc-4fb5-861d-9a81117a7f13)

After:
![Screenshot 2024-09-17 at 13 17 48](https://github.com/user-attachments/assets/24aaf40c-fd5c-41f0-b952-6dfea7f984cf)
