### PR TITLE
fix(connect): keepSession with changing useCardanoDerivation

### DIFF
--- a/packages/connect/e2e/tests/device/keepSession.test.ts
+++ b/packages/connect/e2e/tests/device/keepSession.test.ts
@@ -1,0 +1,42 @@
+import TrezorConnect from '../../../src';
+
+import { getController, setup, conditionalTest, initTrezorConnect } from '../../common.setup';
+
+const controller = getController();
+
+describe('keepSession common param', () => {
+    beforeAll(async () => {
+        await TrezorConnect.dispose();
+        await setup(controller, {
+            mnemonic: 'mnemonic_all',
+        });
+        await initTrezorConnect(controller);
+    });
+
+    afterAll(async () => {
+        controller.dispose();
+        await TrezorConnect.dispose();
+    });
+
+    conditionalTest(['1', '<2.3.2'], 'keepSession with changing useCardanoDerivation', async () => {
+        const noDerivation = await TrezorConnect.getAccountDescriptor({
+            coin: 'ada',
+            path: "m/1852'/1815'/0'/0/0",
+            useCardanoDerivation: false,
+            keepSession: true,
+        });
+        if (noDerivation.success) throw new Error('noDerivation should not succeed');
+        expect(noDerivation.payload.error).toBe(
+            'Cardano derivation is not enabled for this session',
+        );
+
+        const enableDerivation = await TrezorConnect.getAccountDescriptor({
+            coin: 'ada',
+            path: "m/1852'/1815'/0'/0/0",
+            useCardanoDerivation: true,
+            keepSession: true,
+        });
+        if (!enableDerivation.success) throw new Error(enableDerivation.payload.error);
+        expect(enableDerivation.payload.descriptor).toBeDefined();
+    });
+});

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -148,6 +148,8 @@ export class Device extends TypedEmitter<DeviceEvents> {
         firmwareRevision: null,
     };
 
+    private useCardanoDerivation = false;
+
     constructor(transport: Transport, descriptor: Descriptor) {
         super();
 
@@ -331,7 +333,12 @@ export class Device extends TypedEmitter<DeviceEvents> {
             await this.releasePromise;
         }
 
-        if (!this.isUsedHere() || this.commands?.disposed || !this.getState()?.staticSessionId) {
+        if (
+            !this.isUsedHere() ||
+            this.commands?.disposed ||
+            !this.getState()?.staticSessionId ||
+            this.useCardanoDerivation != !!options.useCardanoDerivation
+        ) {
             // acquire session
             await this.acquire();
 
@@ -516,6 +523,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
             // If the user has BIP-39 seed, and Initialize(derive_cardano=True) is not sent,
             // all Cardano calls will fail because the root secret will not be available.
             payload.derive_cardano = useCardanoDerivation;
+            this.useCardanoDerivation = useCardanoDerivation;
             if (sessionId) {
                 payload.session_id = sessionId;
             }

--- a/scripts/ci/connect-test-matrix-generator.js
+++ b/scripts/ci/connect-test-matrix-generator.js
@@ -4,7 +4,7 @@ const groups = {
     api: {
         name: 'api',
         pattern:
-            'init authorizeCoinjoin cancelCoinjoinAuthorization passphrase unlockPath setBusy override checkFirmwareAuthenticity',
+            'init authorizeCoinjoin cancelCoinjoinAuthorization passphrase unlockPath setBusy override checkFirmwareAuthenticity keepSession',
         methods: '',
     },
     management: {


### PR DESCRIPTION
## Description

Make changing `useCardanoDerivation` work with `keepSession`.
Previously the issue was that initialize was not called again with the existing session. 
Now we keep track of the current `useCardanoDerivation` setting and we call initialize again if it's changed.

## Related Issue

Resolve #14369