### PR TITLE
chore(connect): device state saving refactor

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -32,6 +32,7 @@ import {
 import { models } from '../data/models';
 import { getLanguage } from '../data/getLanguage';
 import { checkFirmwareRevision } from './checkFirmwareRevision';
+import { IStateStorage } from './StateStorage';
 
 // custom log
 const _log = initLog('Device');
@@ -83,7 +84,6 @@ export interface DeviceEvents {
     [DEVICE.PASSPHRASE_ON_DEVICE]: () => void;
     [DEVICE.BUTTON]: (device: Device, payload: DeviceButtonRequestPayload) => void;
     [DEVICE.ACQUIRED]: () => void;
-    [DEVICE.SAVE_STATE]: (state: string) => void;
 }
 
 /**
@@ -131,6 +131,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
     // DeviceState list [this.instance]: DeviceState | undefined
     private state: DeviceState[] = [];
+    private stateStorage?: IStateStorage = undefined;
 
     unavailableCapabilities: UnavailableCapabilities = {};
 
@@ -476,9 +477,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
             };
 
             this.state[this.instance] = newState;
-            if (newState.sessionId && newState.sessionId !== prevState?.sessionId) {
-                this.emit(DEVICE.SAVE_STATE, newState.sessionId);
-            }
+            this.stateStorage?.saveState(this, newState);
         }
     }
 
@@ -523,6 +522,11 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
         const { message } = await this.getCommands().typedCall('Initialize', 'Features', payload);
         this._updateFeatures(message);
+    }
+
+    initStorage(storage: IStateStorage) {
+        this.stateStorage = storage;
+        this.setState(storage.loadState(this));
     }
 
     async getFeatures() {

--- a/packages/connect/src/device/StateStorage.ts
+++ b/packages/connect/src/device/StateStorage.ts
@@ -1,0 +1,50 @@
+import { DeviceState } from '../types';
+import { Device } from './Device';
+import { storage } from '@trezor/connect-common';
+
+export interface IStateStorage {
+    saveState(device: Device, state: DeviceState): void;
+    loadState(device: Device): DeviceState | undefined;
+}
+
+// Storage class meant to be used in webextension environment
+export class WebextensionStateStorage implements IStateStorage {
+    origin: string;
+
+    constructor(origin: string) {
+        this.origin = origin;
+    }
+
+    loadState(device: Device) {
+        if (!device.getState()?.sessionId) {
+            const { preferredDevice } = storage.loadForOrigin(this.origin) || {};
+            if (
+                preferredDevice?.internalState &&
+                preferredDevice?.internalStateExpiration &&
+                preferredDevice.internalStateExpiration > new Date().getTime()
+            ) {
+                return { sessionId: preferredDevice.internalState };
+            }
+        }
+
+        return undefined;
+    }
+
+    saveState(device: Device, state: DeviceState) {
+        // Expiration is based on auto lock delay, but minimum is 15 minutes
+        const expirationDelay = Math.max(1000 * 60 * 15, device.features.auto_lock_delay_ms ?? 0);
+        storage.saveForOrigin(store => {
+            return {
+                ...store,
+                preferredDevice: store.preferredDevice
+                    ? {
+                          ...store.preferredDevice,
+                          state: state.staticSessionId,
+                          internalState: state.sessionId,
+                          internalStateExpiration: Date.now() + expirationDelay,
+                      }
+                    : undefined,
+            };
+        }, this.origin);
+    }
+}

--- a/packages/connect/src/events/device.ts
+++ b/packages/connect/src/events/device.ts
@@ -14,7 +14,6 @@ export const DEVICE = {
     ACQUIRED: 'device-acquired',
     RELEASED: 'device-released',
     USED_ELSEWHERE: 'device-used_elsewhere',
-    SAVE_STATE: 'device-save_state',
 
     LOADING: 'device-loading',
 


### PR DESCRIPTION
## Description

Refactor code handling device state/session saving into a new interface called `IStateStorage`, which is passed to Device from core. 
The current main implementation is `WebextensionStateStorage`, used with `connect-webextension`.

This also changes the state expiration delay, now it's based on auto lock delay, but the minimum is 15 minutes. 

The parameters in storage are not renamed due to compatibility. 

## Related Issue

Resolve #14344