### PR TITLE
feat(suite): disable tx bumpfee except lowestnonc

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -9157,4 +9157,9 @@ export default defineMessages({
         defaultMessage:
             'Setting a low fee might cause your transaction to fail or experience significant delays.',
     },
+    TR_BUMP_FEE_DISABLED_TOOLTIP: {
+        id: 'TR_BUMP_FEE_DISABLED_TOOLTIP',
+        defaultMessage:
+            'To speed up your transactions, increase the fee on the oldest (by nonce) pending transaction in the queue. Transactions must be confirmed in order. <a>Learn more</a>',
+    },
 });

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionGroupedList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionGroupedList.tsx
@@ -1,4 +1,8 @@
-import { GroupedTransactionsByDate, groupJointTransactions } from '@suite-common/wallet-utils';
+import {
+    getTransactionWithLowestNonce,
+    GroupedTransactionsByDate,
+    groupJointTransactions,
+} from '@suite-common/wallet-utils';
 import { getNetwork } from '@suite-common/wallet-config';
 import { CoinjoinBatchItem } from 'src/components/wallet/TransactionItem/CoinjoinBatchItem';
 import { useSelector } from 'src/hooks/suite';
@@ -24,6 +28,9 @@ export const TransactionGroupedList = ({
     const localCurrency = useSelector(selectLocalCurrency);
     const accountMetadata = useSelector(state => selectLabelingDataForAccount(state, account.key));
     const network = getNetwork(symbol);
+
+    const transactionWithLowestNonce: WalletAccountTransaction | null =
+        getTransactionWithLowestNonce(transactionGroups);
 
     return Object.entries(transactionGroups).map(([dateKey, value], groupIndex) => (
         <TransactionsGroup
@@ -53,6 +60,11 @@ export const TransactionGroupedList = ({
                         network={network}
                         accountType={account.accountType}
                         index={index}
+                        disableBumpFee={
+                            network.networkType === 'ethereum'
+                                ? item.tx.txid !== transactionWithLowestNonce?.txid
+                                : false
+                        }
                     />
                 ),
             )}

--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -103,6 +103,8 @@ export const HELP_CENTER_EVM_ADDRESS_CHECKSUM: Url =
     'https://trezor.io/learn/a/evm-address-checksum-in-trezor-suite';
 export const HELP_CENTER_FIRMWARE_REVISION_CHECK: Url =
     'https://trezor.io/learn/a/trezor-firmware-revision-check';
+export const HELP_CENTER_REPLACE_BY_FEE: Url =
+    'https://trezor.io/learn/a/replace-by-fee-rbf-ethereum';
 
 export const INVITY_URL: Url = 'https://invity.io/';
 export const INVITY_SCHEDULE_OF_FEES: Url = 'https://blog.invity.io/schedule-of-fees';

--- a/suite-common/wallet-utils/src/__tests__/transactionUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/transactionUtils.test.ts
@@ -18,6 +18,7 @@ import {
     MonthKey,
     generateTransactionMonthKey,
     groupTokensTransactionsByContractAddress,
+    getTransactionWithLowestNonce,
 } from '../transactionUtils';
 
 const { getWalletTransaction } = testMocks;
@@ -99,6 +100,41 @@ describe('transaction utils', () => {
                 getWalletTransaction({ blockTime: 1565792379, blockHeight: 4 }),
             ],
         });
+    });
+
+    it('getTransactionWithLowestNonce - ethereum network', () => {
+        const transactionGroups = {
+            '2019-10-3': [getWalletTransaction({ ethereumSpecific: { nonce: 1 } as any })],
+            '2019-10-4': [
+                getWalletTransaction({
+                    ethereumSpecific: { nonce: 0 },
+                } as any),
+            ],
+            '2019-8-14': [
+                getWalletTransaction({ ethereumSpecific: { nonce: 2 } as any }),
+                getWalletTransaction({ ethereumSpecific: { nonce: 3 } as any }),
+            ],
+        };
+
+        const transactionWithLowestNonce: WalletAccountTransaction | null =
+            getTransactionWithLowestNonce(transactionGroups);
+
+        expect(transactionWithLowestNonce).toStrictEqual(
+            getWalletTransaction({ ethereumSpecific: { nonce: 0 } as any }),
+        );
+    });
+
+    it('getTransactionWithLowestNonce - non ethereum network', () => {
+        const transactionGroups = {
+            '2019-10-4': [getWalletTransaction()],
+            '2019-10-3': [getWalletTransaction()],
+            '2019-8-14': [getWalletTransaction(), getWalletTransaction()],
+        };
+
+        const transactionWithLowestNonce: WalletAccountTransaction | null =
+            getTransactionWithLowestNonce(transactionGroups);
+
+        expect(transactionWithLowestNonce).toStrictEqual(null);
     });
 
     it('groupJointTransactions', () => {

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -1034,3 +1034,21 @@ export const groupTokensTransactionsByContractAddress = (
 
     return groupedTokensTxs;
 };
+
+export const getTransactionWithLowestNonce = (
+    transactionGroups: GroupedTransactionsByDate,
+): WalletAccountTransaction | null =>
+    Object.values(transactionGroups)
+        .flat()
+        .reduce<WalletAccountTransaction | null>((lowestNonceTransaction, transaction) => {
+            if (!transaction.ethereumSpecific) return null;
+            const currentNonce = Number(transaction.ethereumSpecific?.nonce);
+            if (
+                lowestNonceTransaction === null ||
+                currentNonce < Number(lowestNonceTransaction.ethereumSpecific?.nonce)
+            ) {
+                lowestNonceTransaction = transaction;
+            }
+
+            return lowestNonceTransaction;
+        }, null);


### PR DESCRIPTION
## Description

Disable all the bump fees buttons except the transaction with the lowest nonce (the oldest transaction). Tooltip is displayed only on the disabled buttons.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/13529

## Screenshots:

<img width="1015" alt="image" src="https://github.com/user-attachments/assets/42bf78e5-1907-40bf-917b-98e09cbfe71b">

