### PR TITLE
Chore: finish networks refactoring

### DIFF
--- a/packages/suite/src/actions/wallet/__fixtures__/discoveryActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/discoveryActions.ts
@@ -299,7 +299,8 @@ export const unavailableCapabilities = [
             unavailableCapabilities: { xrp: 'no-capability', taproot: 'no-support' },
         }),
         networks: ['btc', 'xrp'],
-        discoveryNetworks: ['btc', 'btc', 'btc'],
+        discoveryNetworks: ['btc'],
+        discoveryMaxTotal: 30,
     },
     {
         description: 'UnavailableCapability: Only LTC',
@@ -310,6 +311,7 @@ export const unavailableCapabilities = [
         }),
         networks: ['ltc'],
         discoveryNetworks: [],
+        discoveryMaxTotal: 0,
     },
     {
         description: 'UnavailableCapability: Device without features',
@@ -319,5 +321,6 @@ export const unavailableCapabilities = [
         }),
         networks: ['xrp'],
         discoveryNetworks: ['xrp'],
+        discoveryMaxTotal: 10,
     },
 ];

--- a/packages/suite/src/actions/wallet/__tests__/discoveryActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/discoveryActions.test.ts
@@ -362,6 +362,7 @@ describe('Discovery Actions', () => {
 
             const discovery = store.getState().wallet.discovery[0];
             expect(discovery.networks).toEqual(f.discoveryNetworks);
+            expect(discovery.total).toEqual(f.discoveryMaxTotal);
         });
     });
 

--- a/packages/suite/src/actions/wallet/selectedAccountActions.ts
+++ b/packages/suite/src/actions/wallet/selectedAccountActions.ts
@@ -6,8 +6,8 @@ import {
     discoveryActions,
     deviceActions,
 } from '@suite-common/wallet-core';
-import { getAccountNetwork } from '@suite-common/wallet-utils';
 import { SelectedAccountStatus } from '@suite-common/wallet-types';
+import { networks } from '@suite-common/wallet-config';
 import { DiscoveryStatus } from '@suite-common/wallet-constants';
 import * as comparisonUtils from '@suite-common/suite-utils';
 
@@ -62,7 +62,7 @@ const getAccountState = (state: AppState): SelectedAccountStatus => {
                   symbol: discovery.networks[0],
               };
 
-    const network = getAccountNetwork(params)!;
+    const network = networks[params.symbol];
 
     // account cannot exists since requested network is not selected in settings/wallet
     if (!discovery.networks.find(n => n === network.symbol)) {

--- a/packages/suite/src/components/wallet/WalletLayout/AccountException/AccountNotEnabled.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountException/AccountNotEnabled.tsx
@@ -1,11 +1,11 @@
 import { changeCoinVisibility } from 'src/actions/settings/walletSettingsActions';
 import { useDevice, useDispatch } from 'src/hooks/suite';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { Network } from '@suite-common/wallet-config';
 import { Translation } from 'src/components/suite';
 import { AccountExceptionLayout } from 'src/components/wallet';
 
 interface AccountNotEnabledProps {
-    network: NetworkCompatible;
+    network: Network;
 }
 
 /**

--- a/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketComposeTransaction.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketComposeTransaction.ts
@@ -1,8 +1,7 @@
-import { NetworkCompatible } from '@suite-common/wallet-config';
 import { COMPOSE_ERROR_TYPES } from '@suite-common/wallet-constants';
 import { selectAccounts, selectDevice } from '@suite-common/wallet-core';
 import { AddressDisplayOptions } from '@suite-common/wallet-types';
-import { getFeeLevels, getNetworkCompatible } from '@suite-common/wallet-utils';
+import { getFeeLevels } from '@suite-common/wallet-utils';
 import { useEffect, useMemo, useState } from 'react';
 import { UseFormReturn } from 'react-hook-form';
 import { saveComposedTransactionInfo } from 'src/actions/wallet/coinmarket/coinmarketCommonActions';
@@ -43,13 +42,7 @@ export const useCoinmarketComposeTransaction = <T extends CoinmarketSellExchange
     const coinFees = fees[symbol];
     const levels = getFeeLevels(networkType, coinFees);
     const feeInfo = useMemo(() => ({ ...coinFees, levels }), [coinFees, levels]);
-    const initState = useMemo(() => {
-        // TODO remove NetworkCompatible type
-        // getNetwork is guaranteed to find a NetworkCompatible, as it is called with symbol from an existing Network
-        const networkCompatible = getNetworkCompatible(network.symbol) as NetworkCompatible;
-
-        return { account, network: networkCompatible, feeInfo };
-    }, [account, network.symbol, feeInfo]);
+    const initState = useMemo(() => ({ account, network, feeInfo }), [account, network, feeInfo]);
     const outputAddress = values?.outputs?.[0].address;
     const [state, setState] = useState<CoinmarketUseComposeTransactionStateProps>(initState);
 

--- a/packages/suite/src/hooks/wallet/useCoinmarketRecomposeAndSign.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketRecomposeAndSign.ts
@@ -5,7 +5,8 @@ import { signAndPushSendFormTransactionThunk } from 'src/actions/wallet/send/sen
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { DEFAULT_VALUES, DEFAULT_PAYMENT } from '@suite-common/wallet-constants';
 import { FormState } from '@suite-common/wallet-types';
-import { getFeeLevels, getNetworkCompatible } from '@suite-common/wallet-utils';
+import { getFeeLevels } from '@suite-common/wallet-utils';
+import { networks } from '@suite-common/wallet-config';
 import type { Account, FormOptions } from '@suite-common/wallet-types';
 import { composeSendFormTransactionFeeLevelsThunk } from '@suite-common/wallet-core';
 
@@ -28,9 +29,7 @@ export const useCoinmarketRecomposeAndSign = () => {
             ethereumAdjustGasLimit?: string,
             options: FormOptions[] = ['broadcast'],
         ) => {
-            const network = getNetworkCompatible(account.symbol);
-
-            if (!network) return;
+            const network = networks[account.symbol];
 
             if (!composed) {
                 dispatch(

--- a/packages/suite/src/types/coinmarket/coinmarketForm.ts
+++ b/packages/suite/src/types/coinmarket/coinmarketForm.ts
@@ -14,7 +14,7 @@ import {
     CoinmarketTradeType,
 } from 'src/types/coinmarket/coinmarket';
 import type { Account } from 'src/types/wallet';
-import { Network, NetworkCompatible } from '@suite-common/wallet-config';
+import { Network } from '@suite-common/wallet-config';
 import type { BuyInfo } from 'src/actions/wallet/coinmarketBuyActions';
 import type { FieldValues, UseFormReturn, FieldPath } from 'react-hook-form';
 import type {
@@ -362,7 +362,7 @@ export interface CoinmarketUseComposeTransactionProps<T extends CoinmarketSellEx
 
 export interface CoinmarketUseComposeTransactionStateProps {
     account: Account;
-    network: NetworkCompatible;
+    network: Network;
     feeInfo: FeeInfo;
 }
 

--- a/packages/suite/src/types/wallet/coinmarketExchangeForm.ts
+++ b/packages/suite/src/types/wallet/coinmarketExchangeForm.ts
@@ -1,7 +1,7 @@
 import type { AppState } from 'src/types/suite';
 import type { FormState as ReactHookFormState, UseFormReturn } from 'react-hook-form';
 import type { Account } from 'src/types/wallet';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { Network } from '@suite-common/wallet-config';
 import type { FeeLevel } from '@trezor/connect';
 import type { ExchangeInfo } from 'src/actions/wallet/coinmarketExchangeActions';
 import type {
@@ -43,7 +43,7 @@ export interface ExchangeFormContextValues extends UseFormReturn<ExchangeFormSta
     isLoading: boolean;
     updateFiatValue: (amount: string) => void;
     noProviders: boolean;
-    network: NetworkCompatible;
+    network: Network;
     feeInfo: FeeInfo;
     removeDraft: (key: string) => void;
     formState: ReactHookFormState<ExchangeFormState>;

--- a/packages/suite/src/types/wallet/coinmarketSellForm.ts
+++ b/packages/suite/src/types/wallet/coinmarketSellForm.ts
@@ -1,7 +1,7 @@
 import type { AppState } from 'src/types/suite';
 import type { FormState as ReactHookFormState, UseFormReturn } from 'react-hook-form';
 import type { Account } from 'src/types/wallet';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { Network } from '@suite-common/wallet-config';
 import type { FeeLevel } from '@trezor/connect';
 import type { SellInfo } from 'src/actions/wallet/coinmarketSellActions';
 import type {
@@ -51,7 +51,7 @@ export type SellFormContextValues = UseFormReturn<SellFormState> & {
     quotesRequest: AppState['wallet']['coinmarket']['sell']['quotesRequest'];
     isLoading: boolean;
     noProviders: boolean;
-    network: NetworkCompatible;
+    network: Network;
     feeInfo: FeeInfo;
     onCryptoAmountChange: (amount: string) => void;
     onFiatAmountChange: (amount: string) => void;

--- a/packages/suite/src/types/wallet/sendForm.ts
+++ b/packages/suite/src/types/wallet/sendForm.ts
@@ -1,7 +1,7 @@
 import { Dispatch, SetStateAction } from 'react';
 import { FieldPath, UseFormReturn } from 'react-hook-form';
 
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { Network } from '@suite-common/wallet-config';
 import { AccountUtxo, FeeLevel, PROTO } from '@trezor/connect';
 
 import {
@@ -23,7 +23,7 @@ export type ExportFileType = 'csv' | 'pdf' | 'json';
 // local state of @wallet-hooks/useSendForm
 export type UseSendFormState = {
     account: Account;
-    network: NetworkCompatible;
+    network: Network;
     coinFees: FeeInfo;
     localCurrencyOption: { value: FiatCurrencyCode; label: Uppercase<FiatCurrencyCode> };
     feeInfo: FeeInfo;

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 import { selectDevice } from '@suite-common/wallet-core';
 import { Account, AddressType, TokenAddress } from '@suite-common/wallet-types';
-import { NetworkCompatible, getCoingeckoId } from '@suite-common/wallet-config';
+import { Network, getCoingeckoId } from '@suite-common/wallet-config';
 import {
     DefinitionType,
     EnhancedTokenInfo,
@@ -67,7 +67,7 @@ const IconWrapper = styled.div`
     margin-left: ${spacingsPx.xxs};
 `;
 
-const getTokenExplorerUrl = (network: NetworkCompatible, token: EnhancedTokenInfo) => {
+const getTokenExplorerUrl = (network: Network, token: EnhancedTokenInfo) => {
     const explorerUrl =
         network.networkType === 'cardano' ? network.explorer.token : network.explorer.account;
     const contractAddress = network.networkType === 'cardano' ? token.fingerprint : token.contract;
@@ -79,7 +79,7 @@ const getTokenExplorerUrl = (network: NetworkCompatible, token: EnhancedTokenInf
 interface TokenRowProps {
     account: Account;
     token: EnhancedTokenInfo;
-    network: NetworkCompatible;
+    network: Network;
     tokenStatusType: TokenManagementAction;
     hideRates?: boolean;
     isUnverifiedTable?: boolean;

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokensTable.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokensTable.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import styled from 'styled-components';
 
 import { Account } from '@suite-common/wallet-types';
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { Network } from '@suite-common/wallet-config';
 import { EnhancedTokenInfo, TokenManagementAction } from '@suite-common/token-definitions';
 import { spacings } from '@trezor/theme';
 import { Icon, Table, Paragraph, Card, Row, Text } from '@trezor/components';
@@ -23,7 +23,7 @@ interface TokensTableProps {
     account: Account;
     tokensWithBalance: EnhancedTokenInfo[];
     tokensWithoutBalance: EnhancedTokenInfo[];
-    network: NetworkCompatible;
+    network: Network;
     tokenStatusType: TokenManagementAction;
     hideRates?: boolean;
     searchQuery?: string;

--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -22,7 +22,7 @@ import {
     WalletAccountTransaction,
     BlockchainNetworks,
 } from '@suite-common/wallet-types';
-import { networksCompatibility } from '@suite-common/wallet-config';
+import { networksCollection } from '@suite-common/wallet-config';
 
 // in-memory implementation of indexedDB
 import 'fake-indexeddb/auto';
@@ -558,8 +558,7 @@ const intlMock = {
     formatMessage: (s: any) => s.defaultMessage,
 };
 
-const mockedBlockchainNetworks = networksCompatibility.reduce((result, network) => {
-    if (network.accountType) return result;
+const mockedBlockchainNetworks = networksCollection.reduce((result, network) => {
     result[network.symbol] = {
         connected: false,
         explorer: network.explorer,

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -1,14 +1,6 @@
 import { DeviceModelInternal } from '@trezor/connect';
-import type { Without } from '@trezor/type-utils';
 
-import {
-    AccountType,
-    BackendType,
-    Explorer,
-    NetworkFeature,
-    Networks,
-    NetworkSymbol,
-} from './types';
+import { Networks } from './types';
 
 export const networks = {
     btc: {
@@ -641,44 +633,3 @@ export const networks = {
         coingeckoNativeId: undefined,
     },
 } as const satisfies Networks;
-
-type InferredNetworks = typeof networks;
-type InferredNetwork = InferredNetworks[NetworkSymbol];
-
-/**
- * @deprecated Old network object interface for backwards copatibility.
- */
-type NetworkCompatible = Without<InferredNetwork, 'accountTypes'> & {
-    symbol: NetworkSymbol;
-    accountType?: AccountType;
-    backendType?: BackendType;
-    testnet?: boolean;
-    isHidden?: boolean;
-    chainId?: number;
-    features?: NetworkFeature[];
-    support?: {
-        [key in DeviceModelInternal]: string;
-    };
-    isDebugOnlyNetwork?: boolean;
-    isDebugOnlyAccountType?: boolean;
-    explorer: Explorer;
-    coingeckoId?: string;
-};
-
-/**
- * @deprecated Please use `networks` instead.
- * Transforms the network object into the previously used format so we don't have to change
- * every occurence. We could gradually start to use the network object directly and in the end
- * this could be removed.
- */
-export const networksCompatibility: NetworkCompatible[] = Object.values(networks).flatMap(
-    ({ symbol, accountTypes, ...network }) => [
-        { symbol, ...network },
-        ...Object.entries(accountTypes).map(([accountType, networkOverride]) => ({
-            symbol,
-            accountType,
-            ...network,
-            ...networkOverride,
-        })),
-    ],
-);

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -648,7 +648,7 @@ type InferredNetwork = InferredNetworks[NetworkSymbol];
 /**
  * @deprecated Old network object interface for backwards copatibility.
  */
-export type NetworkCompatible = Without<InferredNetwork, 'accountTypes'> & {
+type NetworkCompatible = Without<InferredNetwork, 'accountTypes'> & {
     symbol: NetworkSymbol;
     accountType?: AccountType;
     backendType?: BackendType;

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -1,6 +1,6 @@
 import TrezorConnect, { AccountInfo, TokenInfo } from '@trezor/connect';
 import { Account, AccountKey } from '@suite-common/wallet-types';
-import { networksCompatibility } from '@suite-common/wallet-config';
+import { networksCollection } from '@suite-common/wallet-config';
 import {
     analyzeTransactions,
     findAccountDevice,
@@ -33,7 +33,7 @@ export const disableAccountsThunk = createThunk(
         const accounts = selectAccounts(getState());
         const enabledNetworks = selectEnabledNetworks(getState());
         // find disabled networks
-        const disabledNetworks = networksCompatibility
+        const disabledNetworks = networksCollection
             .filter(n => !enabledNetworks.includes(n.symbol) || n.isHidden)
             .map(n => n.symbol);
         // find accounts for disabled networks

--- a/suite-common/wallet-core/src/blockchain/blockchainReducer.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainReducer.ts
@@ -5,7 +5,7 @@ import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
 import {
     BackendType,
     getNetworkOptional,
-    networksCompatibility,
+    networksCollection,
     NetworkSymbol,
 } from '@suite-common/wallet-config';
 import { Blockchain, BlockchainNetworks } from '@suite-common/wallet-types';
@@ -35,9 +35,8 @@ const initialStatePredefined: Partial<BlockchainState> = {};
 export type BlockchainRootState = { wallet: { blockchain: BlockchainState } };
 
 // fill initial state, those values will be changed by BLOCKCHAIN.UPDATE_FEE action
-export const blockchainInitialState: BlockchainNetworks = networksCompatibility.reduce(
+export const blockchainInitialState: BlockchainNetworks = networksCollection.reduce(
     (state, network) => {
-        if (network.accountType) return state;
         state[network.symbol] = {
             connected: false,
             explorer: network.explorer,

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -2,7 +2,7 @@ import { createThunk } from '@suite-common/redux-utils';
 import {
     getNetworkOptional,
     isNetworkSymbol,
-    networksCompatibility,
+    networksCollection,
     NetworkSymbol,
 } from '@suite-common/wallet-config';
 import {
@@ -62,7 +62,7 @@ export const preloadFeeInfoThunk = createThunk(
     `${BLOCKCHAIN_MODULE_PREFIX}/preloadFeeInfoThunk`,
     async (_, { dispatch }) => {
         // Fetch default fee levels
-        const networks = networksCompatibility.filter(n => !n.isHidden && !n.accountType);
+        const networks = networksCollection.filter(n => !n.isHidden);
         const promises = networks.map(network =>
             TrezorConnect.blockchainEstimateFee({
                 coin: network.symbol,

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -88,13 +88,18 @@ const calculateProgress =
         // reconstruct networks from discovery symbols, because we need to iterate through accounts
         const networksToCount = filterUnavailableNetworks(discovery.networks, device);
 
+        // number of Cardano type coins which are activated and able to be discovered
+        const numberOfCardanoCoins = discovery.networks.filter(
+            symbol => symbol === 'ada' || symbol === 'tada',
+        ).length;
+
         const { numberOfNonCardano, numberOfCardano } = networksToCount.reduce(
             (acc, network) => {
                 const { symbol } = network;
 
                 // increment the appropriate counter as per symbol foreach normalized account (normal as well as all alternative accounts)
                 filterUnavailableAccountTypes(network, device).forEach(() => {
-                    if (symbol === 'ada') acc.numberOfCardano += 1;
+                    if (symbol === 'ada' || symbol === 'tada') acc.numberOfCardano += 1;
                     else acc.numberOfNonCardano += 1;
                 });
 
@@ -107,14 +112,17 @@ const calculateProgress =
         //
         // 1) Cardano added - When Cardano is included, discovery.availableCardanoDerivations may vary (2 to 3 based on device seed length).
         //    This object might be undefined if discovery hasn't been completed yet.
-        //    To ensure the "activate coins" button appears, we set it to 1 if Cardano is enabled.
+        //    To ensure the "activate coins" button appears, we set it to numberOfCardano.
+        //    numberOfCardano is 1 or 2, depending on which Cardano networks are enabled (ada, tada).
         //
         // 2) Cardano removed - When Cardano is removed, discovery.availableCardanoDerivations might still hold a value.
         //    However, due to Math.min, it correctly resolves to 0 since numberOfCardano is 0.
         //
 
         const numberOfCardanoTotal = Math.min(
-            discovery.availableCardanoDerivations?.length ?? numberOfCardano ? 1 : 0,
+            discovery.availableCardanoDerivations?.length ?? numberOfCardano
+                ? numberOfCardanoCoins
+                : 0,
             numberOfCardano,
         );
 

--- a/suite-common/wallet-core/src/fees/feesReducer.ts
+++ b/suite-common/wallet-core/src/fees/feesReducer.ts
@@ -1,6 +1,6 @@
 import { createReducer } from '@reduxjs/toolkit';
 
-import { NetworkSymbol, networksCompatibility } from '@suite-common/wallet-config';
+import { NetworkSymbol, networksCollection } from '@suite-common/wallet-config';
 import { FeeInfo, FeeLevelLabel } from '@suite-common/wallet-types';
 import { formatDuration } from '@suite-common/suite-utils';
 import { FeeLevel } from '@trezor/connect';
@@ -18,8 +18,7 @@ export type FeesRootState = {
 };
 
 // fill initial state, those values will be changed by BLOCKCHAIN.UPDATE_FEE action
-const initialState = networksCompatibility.reduce((state, network) => {
-    if (network.accountType) return state;
+const initialState = networksCollection.reduce((state, network) => {
     state[network.symbol] = {
         blockHeight: 0,
         blockTime: 10,

--- a/suite-common/wallet-core/src/send/sendFormTypes.ts
+++ b/suite-common/wallet-core/src/send/sendFormTypes.ts
@@ -7,7 +7,7 @@ import {
     FormState,
 } from '@suite-common/wallet-types';
 import { TokenInfo, Unsuccessful } from '@trezor/connect';
-import { NetworkCompatible, NetworkSymbol } from '@suite-common/wallet-config';
+import { Network, NetworkSymbol } from '@suite-common/wallet-config';
 import { TrezorDevice } from '@suite-common/suite-types';
 
 export type SerializedTx = { tx: string; coin: NetworkSymbol };
@@ -15,7 +15,7 @@ export type SerializedTx = { tx: string; coin: NetworkSymbol };
 // TODO: is this still needed?
 export interface ComposeActionContext {
     account: Account;
-    network: NetworkCompatible;
+    network: Network;
     feeInfo: FeeInfo;
     excludedUtxos?: ExcludedUtxos;
     prison?: Record<string, unknown>;

--- a/suite-common/wallet-core/src/stake/stakeTypes.ts
+++ b/suite-common/wallet-core/src/stake/stakeTypes.ts
@@ -1,6 +1,6 @@
 import { UseFormReturn, FormState as ReactHookFormState } from 'react-hook-form';
 
-import { NetworkCompatible, NetworkSymbol, getNetworkFeatures } from '@suite-common/wallet-config';
+import { Network, NetworkSymbol, getNetworkFeatures } from '@suite-common/wallet-config';
 import {
     Account,
     Rate,
@@ -79,7 +79,7 @@ export interface AmountLimitsString {
 
 export interface BaseStakeContextValues {
     account: Account;
-    network: NetworkCompatible;
+    network: Network;
     localCurrency: FiatCurrencyCode;
     composedLevels?: PrecomposedLevels;
     isComposing: boolean;

--- a/suite-common/wallet-types/src/selectedAccount.ts
+++ b/suite-common/wallet-types/src/selectedAccount.ts
@@ -1,4 +1,4 @@
-import { NetworkCompatible } from '@suite-common/wallet-config';
+import { Network } from '@suite-common/wallet-config';
 
 import { Discovery } from './discovery';
 import { Account, WalletParams } from './account';
@@ -12,7 +12,7 @@ export interface SelectedAccountLoading {
         | 'auth' // Waiting for device.state
         | 'account-loading'; // Waiting for account
     account?: Account;
-    network?: NetworkCompatible;
+    network?: Network;
     discovery?: Discovery;
     params?: WalletParams;
 }
@@ -21,7 +21,7 @@ export interface SelectedAccountLoaded {
     status: 'loaded';
     loader?: undefined;
     account: Account;
-    network: NetworkCompatible;
+    network: Network;
     discovery: Discovery;
     params: WalletParams;
     // blockchain?: any; // TODO:
@@ -35,7 +35,7 @@ export type SelectedAccountException =
           status: 'exception';
           loader: 'auth-failed' | 'discovery-error' | 'discovery-empty'; // No network enabled in settings
           account?: undefined;
-          network?: NetworkCompatible;
+          network?: Network;
           discovery?: Discovery;
           params?: WalletParams;
       }
@@ -44,9 +44,9 @@ export type SelectedAccountException =
           loader:
               | 'account-not-loaded' // Account discovery failed
               | 'account-not-enabled' // Requested account network is not enabled in settings
-              | 'account-not-exists'; // Requested account network is not listed in networksCompatibility
+              | 'account-not-exists'; // Requested account network is not listed in `networks` (@suite-common/wallet-config)
           account?: undefined;
-          network: NetworkCompatible;
+          network: Network;
           discovery: Discovery;
           params: WalletParams;
       };

--- a/suite-common/wallet-types/src/transaction.ts
+++ b/suite-common/wallet-types/src/transaction.ts
@@ -13,7 +13,7 @@ import {
     PrecomposedTransactionFinalCardano as PrecomposedTransactionCardanoConnectResponseFinal,
     StaticSessionId,
 } from '@trezor/connect';
-import { NetworkCompatible, NetworkSymbol } from '@suite-common/wallet-config';
+import { Network, NetworkSymbol } from '@suite-common/wallet-config';
 import { TranslationKey } from '@suite-common/intl-types';
 
 import { Account } from './account';
@@ -192,7 +192,7 @@ export interface SignTransactionData {
     account: Account;
     address: string;
     amount: string;
-    network: NetworkCompatible;
+    network: Network;
     destinationTag?: string;
     transactionInfo: PrecomposedTransactionFinal | null;
 }
@@ -203,7 +203,7 @@ export interface ComposeTransactionData {
     feeInfo: FeeInfo;
     feePerUnit: string;
     feeLimit: string;
-    network: NetworkCompatible;
+    network: Network;
     selectedFee: FeeLevel['label'];
     isMaxActive: boolean;
     address?: string;

--- a/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
@@ -10,7 +10,6 @@ import {
     getBip43Type,
     getFiatValue,
     getFirstFreshAddress,
-    getNetworkCompatible,
     getTitleForNetwork,
     getTitleForCoinjoinAccount,
     getUtxoFromSignedTransaction,
@@ -135,16 +134,6 @@ describe('account utils', () => {
                 state: '1stTestnet@device_id:0',
             }),
         );
-    });
-
-    it('getSelectedNetwork', () => {
-        const res = getNetworkCompatible('btc');
-        if (res) {
-            expect(res.name).toEqual('Bitcoin');
-        } else {
-            expect(res).toBeNull();
-        }
-        expect(getNetworkCompatible('doesntexist')).toBeNull();
     });
 
     it('getAccountKey', () => {

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -11,8 +11,6 @@ import {
 } from '@trezor/connect';
 import { arrayDistinct, bufferUtils } from '@trezor/utils';
 import {
-    networksCompatibility,
-    NetworkCompatible,
     NetworkFeature,
     NetworkSymbol,
     NetworkType,
@@ -486,20 +484,6 @@ export const getAllAccounts = (deviceState: string | typeof undefined, accounts:
 
     return accounts.filter(a => a.deviceState === deviceState && a.visible);
 };
-
-/**
- * @deprecated use `networks[symbol]` (exact type) or `getNetwork` (generic type) from '@suite-common/wallet-config'
- */
-export const getNetworkCompatible = (symbol: string): NetworkCompatible | null =>
-    networksCompatibility.find(c => c.symbol === symbol) || null;
-
-export const getAccountNetwork = ({
-    symbol,
-    accountType,
-}: Pick<Account, 'symbol' | 'accountType'>) =>
-    networksCompatibility.find(
-        n => n.symbol === symbol && (n.accountType || 'normal') === accountType,
-    );
 
 /**
  * Returns a string used as an index to separate txs for given account inside a transactions reducer

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -11,7 +11,7 @@ import { fromWei, numberToHex, padLeft, toWei } from 'web3-utils';
 
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { fiatCurrencies } from '@suite-common/suite-config';
-import { Network, NetworkCompatible, NetworkType } from '@suite-common/wallet-config';
+import { Network, NetworkType } from '@suite-common/wallet-config';
 import { EthereumTransaction, TokenInfo, ComposeOutput, PROTO } from '@trezor/connect';
 import {
     COMPOSE_ERROR_TYPES,
@@ -323,7 +323,7 @@ export const getBitcoinComposeOutputs = (
 export const getExternalComposeOutput = (
     values: Partial<FormState>,
     account: Account,
-    network: NetworkCompatible | Network, // only properties common to both are accessed here
+    network: Network,
 ) => {
     if (!values || !Array.isArray(values.outputs) || !values.outputs[0]) return;
     const out = values.outputs[0];

--- a/suite-native/module-send/src/screens/SendOutputsScreen.tsx
+++ b/suite-native/module-send/src/screens/SendOutputsScreen.tsx
@@ -24,7 +24,7 @@ import {
     StackNavigationProps,
     StackProps,
 } from '@suite-native/navigation';
-import { getNetworkCompatible } from '@suite-common/wallet-utils';
+import { getNetwork } from '@suite-common/wallet-config';
 import { Box, Button } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { useToast } from '@suite-native/toasts';
@@ -98,7 +98,7 @@ export const SendOutputsScreen = ({
         selectSendFormDraftByAccountKey(state, accountKey),
     );
 
-    const network = account ? getNetworkCompatible(account.symbol) : null;
+    const network = account ? getNetwork(account.symbol) : null;
 
     const form = useForm<SendOutputsFormValues>({
         validation: sendOutputsFormValidationSchema,

--- a/suite-native/module-send/src/sendFormThunks.ts
+++ b/suite-native/module-send/src/sendFormThunks.ts
@@ -2,6 +2,7 @@ import { G } from '@mobily/ts-belt';
 import { isFulfilled, isRejected } from '@reduxjs/toolkit';
 
 import { createThunk } from '@suite-common/redux-utils';
+import { getNetwork } from '@suite-common/wallet-config';
 import {
     PushTransactionError,
     deviceActions,
@@ -22,7 +23,7 @@ import {
     FormState,
     GeneralPrecomposedTransactionFinal,
 } from '@suite-common/wallet-types';
-import { getNetworkCompatible, hasNetworkFeatures } from '@suite-common/wallet-utils';
+import { hasNetworkFeatures } from '@suite-common/wallet-utils';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 
 const SEND_MODULE_PREFIX = '@suite-native/send';
@@ -140,9 +141,9 @@ export const calculateMaxAmountWithNormalFeeThunk = createThunk<
         if (!account) throw new Error('Account not found.');
 
         const networkFeeInfo = selectNetworkFeeInfo(getState(), account.symbol);
-        const network = getNetworkCompatible(account.symbol);
+        const network = getNetwork(account.symbol);
 
-        if (!network || !networkFeeInfo) throw new Error('Network fees not found.');
+        if (!networkFeeInfo) throw new Error('Network fees not found.');
 
         const response = await dispatch(
             composeSendFormTransactionFeeLevelsThunk({


### PR DESCRIPTION
Finish refactoring of old `networksCompatible` to `networks` :tada:

## Description

- 342638d3792077b5fb5031a195442433ad320c9e the heavy lifting :muscle: These changes had to be done together, as they are tightly interlinked:
  - refactor `selectedAccount` state
  - refactor discovery (a lot of logic changed!) 
  - all the easy stuff related to either discovery || selected account
- 3332ef75f45f96c05155d19e033170e3c0acd4c5 nuke legacy code :broom: :bucket: :radioactive:
- d0a25d92d563e08cf2c462d27c8705bffcd9851c incidental fix of pre-existing discovery bug :bug: with `tada` :tada: , discovery would seemingly never finish


## Related Issue

Resolve #13839 , finally :relaxed: :tada:

## Screenshots:

I tested in app that the discovery works as before: all accounts are discovered & unfinished/in progress is indicated correctly. But to be **really** sure, I console logged [`loaded` and `total` at `calculateProgress#L150`](https://github.com/trezor/trezor-suite/blob/d0a25d92d563e08cf2c462d27c8705bffcd9851c/suite-common/wallet-core/src/discovery/discoveryThunks.ts#L150)
- I activated every coin except `tada` on T2T1 w/ academic seed, and this is how the discovery progressed on this branch vs. develop: [discovery.test.txt](https://github.com/user-attachments/files/17060772/discovery.test.txt)
 (it's the same, both converged on `65 / 65` :heavy_check_mark: )
- I verified the same with another wallet with even more accounts, both converged on `92 / 92`
- before :tada: :bug: was solved, it'd converge on for example `16 / 36`, indicating unfinished discovery forever:
![tada bug](https://github.com/user-attachments/assets/434bfd21-a640-4cd1-8ca5-96b4f64c2e24)
