### PR TITLE
Revert "chore(suite-native): get rid of ios email warnings about missing entitlement"

### DIFF
--- a/suite-native/app/app.config.ts
+++ b/suite-native/app/app.config.ts
@@ -194,9 +194,6 @@ export default ({ config }: ConfigContext): ExpoConfig => {
                 },
                 UIRequiredDeviceCapabilities: ['armv7'],
             },
-            entitlements: {
-                'aps-environment': 'development',
-            },
         },
         plugins: getPlugins(),
         extra: {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Reverting https://github.com/trezor/trezor-suite/pull/14373

It didn't and couldn't help, see https://github.com/expo/fyi/blob/main/apns-entitlement-sdk-51.md