### PR TITLE
test(trezor-user-env-link): share common mnemonics in e2e tests

### DIFF
--- a/packages/connect-popup/e2e/tests/analytics.test.ts
+++ b/packages/connect-popup/e2e/tests/analytics.test.ts
@@ -18,7 +18,6 @@ test('reporting', async ({ page }) => {
     });
 
     await TrezorUserEnvLink.setupEmu({
-        mnemonic: 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle',
         pin: '',
         passphrase_protection: true,
         label: 'My Trevor',

--- a/packages/connect-popup/e2e/tests/passphrase.test.ts
+++ b/packages/connect-popup/e2e/tests/passphrase.test.ts
@@ -41,7 +41,6 @@ test.beforeEach(async ({ page }) => {
     });
     log('beforeEach', 'setupEmu');
     await TrezorUserEnvLink.setupEmu({
-        mnemonic: 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle',
         pin: '',
         passphrase_protection: true,
         label: 'My Trevor',

--- a/packages/connect-popup/e2e/tests/popup-close-legacy.test.ts
+++ b/packages/connect-popup/e2e/tests/popup-close-legacy.test.ts
@@ -49,7 +49,6 @@ test.beforeEach(async ({ page }) => {
         wipe: true,
     });
     await TrezorUserEnvLink.setupEmu({
-        mnemonic: 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle',
         pin: '',
         passphrase_protection: false,
         label: 'My Trevor',

--- a/packages/connect-popup/e2e/tests/popup-close.test.ts
+++ b/packages/connect-popup/e2e/tests/popup-close.test.ts
@@ -48,7 +48,6 @@ const setup = async ({ page, context }: { page: Page; context?: BrowserContext }
     });
     log('beforeEach', 'setupEmu');
     await TrezorUserEnvLink.setupEmu({
-        mnemonic: 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle',
         pin: '',
         passphrase_protection: false,
         label: 'My Trevor',

--- a/packages/connect-popup/e2e/tests/popup-pages.test.ts
+++ b/packages/connect-popup/e2e/tests/popup-pages.test.ts
@@ -47,7 +47,6 @@ test('popup should display error page when device disconnected and debug mode', 
         wipe: true,
     });
     await TrezorUserEnvLink.setupEmu({
-        mnemonic: 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle',
         pin: '',
         passphrase_protection: false,
         label: 'My Trevor',
@@ -113,7 +112,6 @@ test('log page should contain logs from shared worker', async ({ page, context }
         wipe: true,
     });
     await TrezorUserEnvLink.setupEmu({
-        mnemonic: 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle',
         pin: '',
         passphrase_protection: false,
         label: 'My Trevor',

--- a/packages/connect-popup/e2e/tests/webextension-example.test.ts
+++ b/packages/connect-popup/e2e/tests/webextension-example.test.ts
@@ -18,7 +18,6 @@ test.beforeEach(async () => {
         wipe: true,
     });
     await TrezorUserEnvLink.setupEmu({
-        mnemonic: 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle',
         pin: '',
         passphrase_protection: false,
         label: 'My Trevor',

--- a/packages/connect/e2e/common.setup.ts
+++ b/packages/connect/e2e/common.setup.ts
@@ -5,15 +5,9 @@ import {
     TrezorUserEnvLink,
     type TrezorUserEnvLinkClass,
     StartEmu,
+    MNEMONICS,
 } from '@trezor/trezor-user-env-link';
 import { ApplySettings } from '@trezor/protobuf/src/messages-schema';
-
-const MNEMONICS = {
-    mnemonic_all: 'all all all all all all all all all all all all',
-    mnemonic_12: 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle',
-    mnemonic_abandon:
-        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
-};
 
 const emulatorStartOpts =
     (process.env.emulatorStartOpts as StartEmu) || global.emulatorStartOpts || {};
@@ -60,11 +54,7 @@ export const setup = async (
 
     await TrezorUserEnvLink.startEmu(emulatorStartOpts);
 
-    const mnemonic =
-        typeof options.mnemonic === 'string' && options.mnemonic.indexOf(' ') > 0
-            ? options.mnemonic
-            : //   @ts-expect-error
-              MNEMONICS[options.mnemonic] || MNEMONICS.mnemonic_all;
+    const mnemonic = options.mnemonic || MNEMONICS.mnemonic_all;
 
     await TrezorUserEnvLink.setupEmu({
         ...options,

--- a/packages/suite-desktop-core/e2e/tests/general/wallet-discovery.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/general/wallet-discovery.test.ts
@@ -1,6 +1,6 @@
 import { test as testPlaywright, ElectronApplication, Page } from '@playwright/test';
 
-import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link/src';
+import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
 import { launchSuite } from '../../support/common';
 import { onDashboardPage } from '../../support/pageActions/dashboardActions';
@@ -13,7 +13,7 @@ testPlaywright.beforeAll(async () => {
     await TrezorUserEnvLink.startEmu({ wipe: true });
     await TrezorUserEnvLink.setupEmu({
         needs_backup: true,
-        mnemonic: 'all all all all all all all all all all all all',
+        mnemonic: 'mnemonic_all',
     });
     ({ electronApp, window } = await launchSuite());
 });

--- a/packages/suite-desktop-core/e2e/tests/settings/electrum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/electrum.test.ts
@@ -17,7 +17,7 @@ testPlaywright.describe.serial('Suite works with Electrum server', () => {
         await TrezorUserEnvLink.startEmu({ wipe: true });
         await TrezorUserEnvLink.setupEmu({
             needs_backup: true,
-            mnemonic: 'all all all all all all all all all all all all',
+            mnemonic: 'mnemonic_all',
         });
         ({ electronApp, window } = await launchSuite());
     });

--- a/packages/suite-web/e2e/tests/analytics/events.test.ts
+++ b/packages/suite-web/e2e/tests/analytics/events.test.ts
@@ -27,7 +27,6 @@ describe('Analytics Events', () => {
         cy.task('startEmu', { wipe: true, model: 'T2T1', version: '2.6.0' });
         cy.task('setupEmu', {
             needs_backup: false,
-            mnemonic: 'all all all all all all all all all all all all',
             passphrase_protection: true,
         });
 
@@ -89,7 +88,6 @@ describe('Analytics Events', () => {
         cy.task('startEmu', { wipe: true });
         cy.task('setupEmu', {
             needs_backup: false,
-            mnemonic: 'all all all all all all all all all all all all',
         });
         cy.task('startBridge');
 

--- a/packages/suite-web/e2e/tests/backup/t2t1-success.test.ts
+++ b/packages/suite-web/e2e/tests/backup/t2t1-success.test.ts
@@ -11,7 +11,7 @@ describe('Backup success', () => {
         cy.task('startEmu', { wipe: true, model: 'T2T1', version: '2.8.1' });
         cy.task('setupEmu', {
             needs_backup: true,
-            mnemonic: 'all all all all all all all all all all all all',
+            mnemonic: 'mnemonic_all',
         });
         cy.task('startBridge');
 

--- a/packages/suite-web/e2e/tests/dashboard/assets.test.ts
+++ b/packages/suite-web/e2e/tests/dashboard/assets.test.ts
@@ -11,7 +11,6 @@ describe('Assets', () => {
         cy.task('startEmu', { wipe: true });
         cy.task('setupEmu', {
             needs_backup: true,
-            mnemonic: 'all all all all all all all all all all all all',
         });
         cy.task('startBridge');
 

--- a/packages/suite-web/e2e/tests/dashboard/dashboard.test.ts
+++ b/packages/suite-web/e2e/tests/dashboard/dashboard.test.ts
@@ -6,7 +6,6 @@ describe('Dashboard', () => {
         cy.task('startEmu', { wipe: true });
         cy.task('setupEmu', {
             needs_backup: true,
-            mnemonic: 'all all all all all all all all all all all all',
         });
         cy.task('startBridge');
 

--- a/packages/suite-web/e2e/tests/metadata/account-metadata.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/account-metadata.test.ts
@@ -14,9 +14,7 @@ Hovering over fields that may be labeled shows "add label" button upon which is 
     it(provider, () => {
         // prepare test
         cy.task('startEmu', { wipe: true });
-        cy.task('setupEmu', {
-            mnemonic: 'all all all all all all all all all all all all',
-        });
+        cy.task('setupEmu', { mnemonic: 'mnemonic_all' });
         cy.task(`metadataStartProvider`, provider);
 
         cy.prefixedVisit('/', {

--- a/packages/suite-web/e2e/tests/metadata/address-metadata.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/address-metadata.test.ts
@@ -15,9 +15,7 @@ describe('Metadata - address labeling', () => {
     it(provider, () => {
         // prepare test
         cy.task('startEmu', { wipe: true });
-        cy.task('setupEmu', {
-            mnemonic: 'all all all all all all all all all all all all',
-        });
+        cy.task('setupEmu', { mnemonic: 'mnemonic_all' });
         cy.task('startBridge');
         cy.task('metadataStartProvider', provider);
         cy.prefixedVisit('/', {

--- a/packages/suite-web/e2e/tests/metadata/dropbox-api-errors.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/dropbox-api-errors.test.ts
@@ -10,9 +10,7 @@ describe('Dropbox api errors', () => {
 
     it('Malformed token', () => {
         cy.task('startEmu', { wipe: true });
-        cy.task('setupEmu', {
-            mnemonic: 'all all all all all all all all all all all all',
-        });
+        cy.task('setupEmu', { mnemonic: 'mnemonic_all' });
         cy.task('startBridge');
         cy.task('metadataStartProvider', 'dropbox');
         // prepare some initial files
@@ -72,9 +70,7 @@ describe('Dropbox api errors', () => {
 
     it('Success after retrying GET request', () => {
         cy.task('startEmu', { wipe: true });
-        cy.task('setupEmu', {
-            mnemonic: 'all all all all all all all all all all all all',
-        });
+        cy.task('setupEmu', { mnemonic: 'mnemonic_all' });
         cy.task('startBridge');
         cy.task('metadataStartProvider', 'dropbox');
         // prepare some initial files
@@ -148,9 +144,7 @@ describe('Dropbox api errors', () => {
 
     it('Incomplete data returned from provider', () => {
         cy.task('startEmu', { wipe: true });
-        cy.task('setupEmu', {
-            mnemonic: 'all all all all all all all all all all all all',
-        });
+        cy.task('setupEmu', { mnemonic: 'mnemonic_all' });
         cy.task('startBridge');
         cy.task('metadataStartProvider', 'dropbox');
         // prepare some initial files

--- a/packages/suite-web/e2e/tests/metadata/google-api-errors.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/google-api-errors.test.ts
@@ -9,9 +9,7 @@ describe('Google api errors', () => {
     beforeEach(() => {
         cy.viewport(1440, 2560).resetDb();
         cy.task('startEmu', { wipe: true });
-        cy.task('setupEmu', {
-            mnemonic: 'all all all all all all all all all all all all',
-        });
+        cy.task('setupEmu', { mnemonic: 'mnemonic_all' });
         cy.task('startBridge');
         cy.task('metadataStartProvider', provider);
         cy.prefixedVisit('/', {

--- a/packages/suite-web/e2e/tests/metadata/interval-fetching.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/interval-fetching.test.ts
@@ -28,9 +28,7 @@ describe('Metadata - suite is watching cloud provider and syncs periodically', (
         it(`${f.provider}-${f.desc}`, () => {
             // prepare test
             cy.task('startEmu', { wipe: true });
-            cy.task('setupEmu', {
-                mnemonic: 'all all all all all all all all all all all all',
-            });
+            cy.task('setupEmu', { mnemonic: 'mnemonic_all' });
             cy.task('startBridge');
             cy.task('metadataStartProvider', f.provider);
             cy.clock();

--- a/packages/suite-web/e2e/tests/metadata/metadata-lifecycle.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/metadata-lifecycle.test.ts
@@ -1,8 +1,6 @@
 // @group_metadata
 // @retry=2
 
-const mnemonic = 'all all all all all all all all all all all all';
-
 describe('Metadata - cancel metadata on device', () => {
     beforeEach(() => {
         cy.viewport('macbook-15').resetDb();
@@ -12,7 +10,7 @@ describe('Metadata - cancel metadata on device', () => {
         // prepare test
         cy.task('startEmu', { wipe: true, model: 'T2T1', version: '2.7.0' });
         cy.task('setupEmu', {
-            mnemonic,
+            mnemonic: 'mnemonic_all',
             passphrase_protection: true,
         });
         cy.task('startBridge');

--- a/packages/suite-web/e2e/tests/metadata/output-labeling.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/output-labeling.test.ts
@@ -18,9 +18,7 @@ describe('Metadata - Output labeling', () => {
                 '@metadata/outputLabel/1d7a8556bb5bda4895596c52017b98c9af29eda10770865e845d3848aa222d1c-0/add-label-button';
             // prepare test
             cy.task('startEmu', { wipe: true });
-            cy.task('setupEmu', {
-                mnemonic: 'all all all all all all all all all all all all',
-            });
+            cy.task('setupEmu', { mnemonic: 'mnemonic_all' });
             cy.task('startBridge');
             cy.task('metadataStartProvider', provider);
 

--- a/packages/suite-web/e2e/tests/metadata/remembered-device.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/remembered-device.test.ts
@@ -31,9 +31,7 @@ describe(
                 // prepare test
                 cy.task('stopBridge');
                 cy.task('startEmu', { wipe: true });
-                cy.task('setupEmu', {
-                    mnemonic: 'all all all all all all all all all all all all',
-                });
+                cy.task('setupEmu', { mnemonic: 'mnemonic_all' });
                 cy.task('startBridge');
                 cy.task('metadataStartProvider', f.provider);
                 cy.task('metadataSetFileContent', {

--- a/packages/suite-web/e2e/tests/metadata/switching-providers.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/switching-providers.test.ts
@@ -12,9 +12,7 @@ describe(`Metadata - switching between cloud providers`, () => {
     it('Start with one and switch to another', () => {
         // prepare test
         cy.task('startEmu', { wipe: true });
-        cy.task('setupEmu', {
-            mnemonic: 'all all all all all all all all all all all all',
-        });
+        cy.task('setupEmu', { mnemonic: 'mnemonic_all' });
         cy.task('startBridge');
         cy.task(`metadataStartProvider`, 'dropbox');
         cy.task(`metadataStartProvider`, 'google');

--- a/packages/suite-web/e2e/tests/metadata/wallet-metadata.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/wallet-metadata.test.ts
@@ -6,7 +6,6 @@ import { rerouteMetadataToMockProvider, stubOpen } from '../../stubs/metadata';
 const firmwares = ['2.3.0', '2-main'] as const;
 const provider = 'dropbox';
 
-const mnemonic = 'all all all all all all all all all all all all';
 // state corresponding to all seed
 const standardWalletState = 'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@355C817510C0EABF2F147145:1';
 // state corresponding to "wallet for drugs"
@@ -23,7 +22,7 @@ describe.skip('Metadata - wallet labeling', () => {
             // prepare test
             cy.task('startEmu', { wipe: true });
             cy.task('setupEmu', {
-                mnemonic,
+                mnemonic: 'mnemonic_all',
                 passphrase_protection: true,
             });
             cy.task('startBridge');

--- a/packages/suite-web/e2e/tests/recovery/t2t1-dry-run-persistence.test.ts
+++ b/packages/suite-web/e2e/tests/recovery/t2t1-dry-run-persistence.test.ts
@@ -4,9 +4,7 @@
 describe('Recovery - dry run', () => {
     beforeEach(() => {
         cy.task('startEmu', { wipe: true });
-        cy.task('setupEmu', {
-            mnemonic: 'all all all all all all all all all all all all',
-        });
+        cy.task('setupEmu', { mnemonic: 'mnemonic_all' });
         cy.task('startBridge');
         cy.viewport(1440, 2560).resetDb();
     });

--- a/packages/suite-web/e2e/tests/suite/bug-report-form.test.ts
+++ b/packages/suite-web/e2e/tests/suite/bug-report-form.test.ts
@@ -6,7 +6,7 @@ import { onSuiteGuide } from '../../support/pageObjects/suiteGuideObject';
 describe('Stories of bug report forms', () => {
     beforeEach(() => {
         cy.task('startEmu', { wipe: true });
-        cy.task('setupEmu', { mnemonic: 'all all all all all all all all all all all all' });
+        cy.task('setupEmu', { mnemonic: 'mnemonic_all' });
 
         cy.task('startBridge');
         cy.viewport(1440, 2560).resetDb();

--- a/packages/suite-web/e2e/tests/suite/database-migration.test.ts
+++ b/packages/suite-web/e2e/tests/suite/database-migration.test.ts
@@ -34,7 +34,6 @@ describe('Database migration', () => {
         cy.viewport(1440, 2560);
         cy.task('startEmu', { wipe: true });
         cy.task('setupEmu', {
-            mnemonic: 'all all all all all all all all all all all all',
             passphrase_protection: true,
         });
         cy.task('startBridge');

--- a/packages/suite-web/e2e/tests/suite/passphrase-cancel.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase-cancel.test.ts
@@ -16,7 +16,7 @@ describe('Passphrase cancel', () => {
         it(version.model + '_' + version.version, () => {
             cy.task('startEmu', { wipe: true, ...version });
             cy.task('setupEmu', {
-                mnemonic: 'all all all all all all all all all all all all',
+                mnemonic: 'mnemonic_all',
                 passphrase_protection: true,
             });
             cy.task('startBridge');

--- a/packages/suite-web/e2e/tests/suite/passphrase-cardano.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase-cardano.test.ts
@@ -8,7 +8,7 @@ describe('Passphrase with cardano', () => {
     beforeEach(() => {
         cy.task('startEmu', { wipe: true });
         cy.task('setupEmu', {
-            mnemonic: 'all all all all all all all all all all all all',
+            mnemonic: 'mnemonic_all',
             passphrase_protection: true,
         });
         cy.task('startBridge');

--- a/packages/suite-web/e2e/tests/suite/passphrase-input.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase-input.test.ts
@@ -6,7 +6,7 @@ describe('Passphrase', () => {
         // note that versions before 2.3.1 don't have passphrase caching, this means that returning
         // back to passphrase that was used before in the session would require to type the passphrase again
         cy.task('startEmu', { wipe: true });
-        cy.task('setupEmu', { mnemonic: 'all all all all all all all all all all all all' });
+        cy.task('setupEmu', { mnemonic: 'mnemonic_all' });
         cy.task('startBridge');
 
         cy.viewport(1440, 2560).resetDb();

--- a/packages/suite-web/e2e/tests/suite/passphrase.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase.test.ts
@@ -14,7 +14,7 @@ describe('Passphrase', () => {
         // back to passphrase that was used before in the session would require to type the passphrase again
         cy.task('startEmu', { wipe: true });
         cy.task('setupEmu', {
-            mnemonic: 'all all all all all all all all all all all all',
+            mnemonic: 'mnemonic_all',
             passphrase_protection: true,
         });
         cy.task('startBridge');

--- a/packages/suite-web/e2e/tests/suite/tooltip.test.ts
+++ b/packages/suite-web/e2e/tests/suite/tooltip.test.ts
@@ -29,7 +29,7 @@ export {};
 describe.skip('Test tooltip conditional rendering', () => {
     beforeEach(() => {
         cy.task('startEmu', { wipe: true });
-        cy.task('setupEmu', { mnemonic: 'all all all all all all all all all all all all' });
+        cy.task('setupEmu', { mnemonic: 'mnemonic_all' });
         cy.task('startBridge');
         cy.viewport(1440, 2560).resetDb();
         cy.prefixedVisit('/');

--- a/packages/suite-web/e2e/tests/wallet/coin-balance.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/coin-balance.test.ts
@@ -8,7 +8,7 @@ describe('Dashboard with regtest', () => {
         cy.task('startEmu', { wipe: true });
         cy.task('setupEmu', {
             needs_backup: true,
-            mnemonic: 'all all all all all all all all all all all all',
+            mnemonic: 'mnemonic_all',
         });
         cy.task('startBridge');
         cy.task('sendToAddressAndMineBlock', {

--- a/packages/suite-web/e2e/tests/wallet/custom-blockbook-discovery.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/custom-blockbook-discovery.test.ts
@@ -6,7 +6,7 @@ describe('Custom-blockbook-discovery', () => {
         cy.task('startEmu', { wipe: true });
         cy.task('setupEmu', {
             needs_backup: true,
-            mnemonic: 'all all all all all all all all all all all all',
+            mnemonic: 'mnemonic_all',
         });
         cy.task('startBridge');
 

--- a/packages/suite-web/e2e/tests/wallet/overview-and-transactions.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/overview-and-transactions.test.ts
@@ -8,7 +8,7 @@ describe('Overview and transactions check', () => {
         cy.task('startEmu', { wipe: true });
         cy.task('setupEmu', {
             needs_backup: false,
-            mnemonic: 'all all all all all all all all all all all all',
+            mnemonic: 'mnemonic_all',
         });
         cy.task('startBridge');
 

--- a/packages/suite-web/e2e/tests/wallet/pending-transactions.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/pending-transactions.test.ts
@@ -8,9 +8,7 @@ describe('Use regtest to test pending transactions', () => {
 
     beforeEach(() => {
         cy.task('startEmu', { wipe: true });
-        cy.task('setupEmu', {
-            mnemonic: 'all all all all all all all all all all all all',
-        });
+        cy.task('setupEmu', { mnemonic: 'mnemonic_all' });
         cy.task('startBridge');
         cy.viewport(1440, 2560).resetDb();
         cy.prefixedVisit('/');

--- a/packages/suite-web/e2e/tests/wallet/send-form-regtest.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/send-form-regtest.test.ts
@@ -8,7 +8,7 @@ describe('Send form for bitcoin', () => {
         cy.task('startEmu', { wipe: true });
         cy.task('setupEmu', {
             needs_backup: true,
-            mnemonic: 'all all all all all all all all all all all all',
+            mnemonic: 'mnemonic_all',
         });
         cy.task('startBridge');
         cy.viewport(1440, 2560).resetDb();

--- a/packages/suite-web/e2e/tests/wallet/sign-and-verify-eth.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/sign-and-verify-eth.test.ts
@@ -1,7 +1,6 @@
 // @group_wallet
 // @retry=2
 
-const SEED_SIGN = 'all all all all all all all all all all all all';
 const MESSAGE_SIGN = 'hello world';
 const SIGNATURE_SIGN =
     '0a172eaac00636dbc124c170e5afa7665cdeed65b59449ee1bbb6e57b1cfbf7971a1c88b48cacd17ec585918cd849c36a016e99ecfd757b947c732e7470b9b3d1b';
@@ -12,7 +11,7 @@ describe('Sign and verify ETH', () => {
         cy.task('startEmu', { wipe: true });
         cy.task('setupEmu', {
             needs_backup: false,
-            mnemonic: SEED_SIGN,
+            mnemonic: 'mnemonic_all',
         });
         cy.task('startBridge');
 

--- a/packages/suite-web/e2e/tests/wallet/sign-and-verify.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/sign-and-verify.test.ts
@@ -1,7 +1,6 @@
 // @group_wallet
 // @retry=2
 
-const SEED = 'all all all all all all all all all all all all';
 const PATH = "m/84'/0'/0'/0/3";
 const ADDRESS = 'bc1q6hr68ewf72l6r7cj6ut286x0xkwg5706jq450u';
 const MESSAGE = 'hello world';
@@ -13,7 +12,7 @@ const ELECTRUM_SIGNATURE =
 describe('Sign and verify', () => {
     beforeEach(() => {
         cy.task('startEmu', { wipe: true });
-        cy.task('setupEmu', { mnemonic: SEED });
+        cy.task('setupEmu', { mnemonic: 'mnemonic_all' });
         cy.task('startBridge');
 
         cy.viewport(1440, 2560).resetDb();

--- a/packages/trezor-user-env-link/src/api.ts
+++ b/packages/trezor-user-env-link/src/api.ts
@@ -54,13 +54,20 @@ interface ReadAndConfirmShamirMnemonicEmu {
     threshold: number;
 }
 
+export const MNEMONICS = {
+    mnemonic_all: 'all all all all all all all all all all all all',
+    mnemonic_12: 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle',
+    mnemonic_abandon:
+        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+};
+
 export class TrezorUserEnvLinkClass extends TypedEmitter<WebsocketClientEvents> {
     private client: WebsocketClient;
     public firmwares?: Firmwares;
     private defaultFirmware?: string;
     private defaultModel: Model = 'T2T1';
 
-    public currentEmulatorSetup: Partial<SetupEmu> = {};
+    public currentEmulatorSetup?: Partial<SetupEmu> = {};
     public currentEmulatorSettings: Partial<ApplySettings> = {};
 
     // todo: remove later, used in some of the tests
@@ -85,19 +92,25 @@ export class TrezorUserEnvLinkClass extends TypedEmitter<WebsocketClientEvents> 
         this.send = this.client.send.bind(this.client);
     }
 
-    public async setupEmu(options: SetupEmu) {
+    public async setupEmu(options?: SetupEmu) {
         const defaults = {
-            // some random empty seed. most of the test don't need any account history so it is better not to slow them down with all all seed
-            mnemonic:
-                'alcohol woman abuse must during monitor noble actual mixed trade anger aisle',
             pin: '',
             passphrase_protection: false,
             label: 'My Trevor',
             needs_backup: false,
         };
+
+        // fallback to empty seed. most of the test don't need any account history so it is better not to slow them down with all all seed
+        const mnemonic =
+            typeof options?.mnemonic === 'string' && options.mnemonic.indexOf(' ') > 0
+                ? options.mnemonic
+                : //   @ts-expect-error
+                  MNEMONICS[options?.mnemonic] || MNEMONICS.mnemonic_12;
+
         const finalOptions = {
             ...defaults,
             ...options,
+            mnemonic,
         };
 
         if (JSON.stringify(this.currentEmulatorSetup) === JSON.stringify(finalOptions)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
# 🧹 in e2e tests
- share `MNEMONICS` from `TrezorUserEnvLink` 
- allow aliases (moved from connect common.setup)
- use default `mnemonic_all` in cypress (suite-web) tests
