### PR TITLE
fix(connect): fw releases value for custom device model

### DIFF
--- a/packages/connect/src/data/__tests__/firmwareInfo.test.ts
+++ b/packages/connect/src/data/__tests__/firmwareInfo.test.ts
@@ -13,6 +13,9 @@ describe('data/firmwareInfo', () => {
             url: expect.any(String),
             url_bitcoinonly: expect.any(String),
         });
+
+        // custom model
+        expect(getReleases(2000 as any)).toEqual([]);
     });
 
     test('getFirmwareStatus', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Addition to https://github.com/trezor/trezor-suite/commit/0915d889312b572b2f2bfdbe70f9dcc847096e3a

Custom models doesn't have defined releases, this leads to unexpected runtime errors like [here](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/device/Device.ts#L569) or [here](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/api/checkFirmwareAuthenticity.ts#L35).

- added empty array fallback for `getReleases` fn
- fixed types of `releases` (could be undefined)
