### PR TITLE
transport-bridge: resolving listen subscriptions

### DIFF
--- a/packages/transport-bridge/src/http.ts
+++ b/packages/transport-bridge/src/http.ts
@@ -132,13 +132,7 @@ export class TrezordNode {
         this.protocolMessages = protocolMessages ?? true;
     }
 
-    private resolveListenSubscriptions(descriptors: Descriptor[]) {
-        this.descriptors = descriptors;
-
-        if (!this.listenSubscriptions.length) {
-            return;
-        }
-
+    private checkAffectedSubscriptions() {
         const [aborted, notAborted] = arrayPartition(this.listenSubscriptions, subscription => {
             return subscription.res.destroyed;
         });
@@ -161,6 +155,16 @@ export class TrezordNode {
             subscription.res.end(str(this.descriptors));
         });
         this.listenSubscriptions = unaffected;
+    }
+
+    private resolveListenSubscriptions(nextDescriptors: Descriptor[]) {
+        this.descriptors = nextDescriptors;
+
+        if (!this.listenSubscriptions.length) {
+            return;
+        }
+
+        this.checkAffectedSubscriptions();
     }
 
     private createAbortSignal(res: Response) {
@@ -263,6 +267,7 @@ export class TrezordNode {
                         req,
                         res,
                     });
+                    this.checkAffectedSubscriptions();
                 },
             ]);
 

--- a/packages/transport-bridge/tests/http.test.ts
+++ b/packages/transport-bridge/tests/http.test.ts
@@ -738,7 +738,7 @@ describe('http', () => {
             });
 
             test('listen aborted using client.dispose', async () => {
-                const { server, client, onListenResolvedSpy, onDebugLogSpy } =
+                const { server, client, onListenResolvedSpy } =
                     await createServerAndListeningClient();
 
                 client.dispose();
@@ -746,12 +746,6 @@ describe('http', () => {
 
                 expect(onListenResolvedSpy).not.toHaveBeenCalled();
                 await server.stop();
-
-                // this test assertion is little fragile, in case somebody adds more debug logs, we might start getting different results
-                expect(onDebugLogSpy).toHaveBeenNthCalledWith(
-                    1,
-                    'http: resolving listen subscriptions. n of aborted subscriptions: 1',
-                );
             });
         });
     });

--- a/packages/transport-test/e2e/bridge/bridge-listen.test.ts
+++ b/packages/transport-test/e2e/bridge/bridge-listen.test.ts
@@ -1,0 +1,43 @@
+import * as messages from '@trezor/protobuf/messages.json';
+import { BridgeTransport } from '@trezor/transport';
+
+import { controller as TrezorUserEnvLink } from './controller';
+import { descriptor as expectedDescriptor } from './expect';
+import { assertSuccess } from '../api/utils';
+
+const emulatorStartOpts = { model: 'T2T1', version: '2-main', wipe: true } as const;
+
+describe('bridge', () => {
+    beforeAll(async () => {
+        await TrezorUserEnvLink.connect();
+        await TrezorUserEnvLink.stopBridge();
+        await TrezorUserEnvLink.startEmu(emulatorStartOpts);
+    });
+
+    afterAll(async () => {
+        await TrezorUserEnvLink.stopEmu();
+        await TrezorUserEnvLink.stopBridge();
+        TrezorUserEnvLink.disconnect();
+    });
+
+    // special case of listen. for happy-path listen fixtures referer to multi-client.test.ts
+    test('listen - bridge already has some descriptors, client subscribes with non-matching descriptors', async () => {
+        await TrezorUserEnvLink.startBridge();
+        const bridge = new BridgeTransport({ messages });
+        await bridge.init();
+        const enumerateResult = await bridge.enumerate();
+        assertSuccess(enumerateResult);
+        bridge.handleDescriptorsChange([]);
+        const brideSpy = jest.spyOn(bridge, 'emit');
+        bridge.listen();
+        await new Promise(resolve => setTimeout(resolve, 100));
+        expect(brideSpy).toHaveBeenCalledWith('transport-update', [
+            {
+                descriptor: { ...expectedDescriptor, session: null },
+                type: 'connected',
+            },
+        ]);
+        bridge.removeAllListeners('transport-update');
+        jest.clearAllMocks();
+    });
+});


### PR DESCRIPTION
One more difference between the old and new bridge was spotted. If the `/listen` request body is different from the current state of descriptors in node-bridge, it should respond immediately with its latest state. 

possibly resolves #14285