### PR TITLE
feat(connect): push tx permission

### DIFF
--- a/packages/connect-popup/src/view/permissions.ts
+++ b/packages/connect-popup/src/view/permissions.ts
@@ -8,14 +8,12 @@ const getPermissionText = (permissionType: string, _deviceName: string) => {
     switch (permissionType) {
         case 'read':
             return 'Read public keys from Trezor device';
-        case 'read-meta':
-            return 'Read metadata from Trezor device';
         case 'write':
             return 'Prepare Trezor device for transaction and data signing';
-        case 'write-meta':
-            return 'Write metadata to Trezor device';
         case 'management':
             return 'Modify device settings';
+        case 'push_tx':
+            return 'Broadcast transaction to the network';
         case 'custom-message':
             return 'Run custom operations';
         default:
@@ -31,6 +29,8 @@ const getPermissionTooltipText = (permissionType: string) => {
             return 'Permission needed to execute operations, such as composing a transaction, after your confirmation.';
         case 'management':
             return 'Permission needed to change device settings, such as PIN, passphrase, label or seed.';
+        case 'push_tx':
+            return 'Permission needed to broadcast a signed transaction to the network.';
         case 'custom-message':
             return 'Development tool. Use at your own risk. Allows service to send arbitrary data to your Trezor device.';
         default:

--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -119,6 +119,10 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
             push: typeof payload.push === 'boolean' ? payload.push : false,
             total,
         };
+
+        if (this.params.push) {
+            this.requiredPermissions.push('push_tx');
+        }
     }
 
     get info() {

--- a/packages/connect/src/api/pushTransaction.ts
+++ b/packages/connect/src/api/pushTransaction.ts
@@ -16,7 +16,7 @@ type Params = {
 
 export default class PushTransaction extends AbstractMethod<'pushTransaction', Params> {
     init() {
-        this.requiredPermissions = [];
+        this.requiredPermissions = ['push_tx'];
         this.useUi = false;
         this.useDevice = false;
 

--- a/packages/connect/src/api/signTransaction.ts
+++ b/packages/connect/src/api/signTransaction.ts
@@ -151,6 +151,10 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
         };
 
         this.params.options = enhanceSignTx(this.params.options, coinInfo);
+
+        if (this.params.push) {
+            this.requiredPermissions.push('push_tx');
+        }
     }
 
     get info() {

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -21,6 +21,9 @@ import { ERRORS } from '../constants';
 export type Payload<M> = Extract<CallMethodPayload, { method: M }> & { override?: boolean };
 export type MethodReturnType<M extends CallMethodPayload['method']> = CallMethodResponse<M>;
 
+export type MethodPermission = 'read' | 'write' | 'management' | 'push_tx';
+export type DeviceMode = typeof UI.SEEDLESS | typeof UI.BOOTLOADER | typeof UI.INITIALIZE;
+
 export const DEFAULT_FIRMWARE_RANGE: FirmwareRange = {
     T1B1: { min: '1.0.0', max: '0' },
     T2T1: { min: '2.0.0', max: '0' },
@@ -100,11 +103,11 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
 
     firmwareRange: FirmwareRange;
 
-    requiredPermissions: string[];
+    requiredPermissions: MethodPermission[];
 
-    allowDeviceMode: string[]; // used in device management (like ResetDevice allow !UI.INITIALIZED)
+    allowDeviceMode: DeviceMode[]; // used in device management (like ResetDevice allow !UI.INITIALIZED)
 
-    requireDeviceMode: string[];
+    requireDeviceMode: DeviceMode[];
 
     network: NETWORK.NetworkType;
 

--- a/packages/connect/src/events/ui-request.ts
+++ b/packages/connect/src/events/ui-request.ts
@@ -8,6 +8,7 @@ import type { Device, CoinInfo, BitcoinNetworkInfo, SelectFeeLevel } from '../ty
 import type { DiscoveryAccountType, DiscoveryAccount } from '../types/account';
 import type { MessageFactoryFn } from '../types/utils';
 import type { DeviceButtonRequest } from './device';
+import { MethodPermission } from '../core/AbstractMethod';
 
 export const UI_EVENT = 'UI_EVENT';
 export const UI_REQUEST = {
@@ -159,7 +160,7 @@ export interface UiRequestSetOperation {
 export interface UiRequestPermission {
     type: typeof UI_REQUEST.REQUEST_PERMISSION;
     payload: {
-        permissions: string[];
+        permissions: MethodPermission[];
         device: Device;
     };
 }


### PR DESCRIPTION
## Description

This PR introduces a separate permission in Connect methods that are pushing (broadcasting) transactions to the network. 
This is especially useful with the upcoming deeplinks, since it could be a security risk to push transactions from untrusted sources.