### PR TITLE
docs(suite-native): tips for building on Linux

### DIFF
--- a/suite-native/app/README.md
+++ b/suite-native/app/README.md
@@ -7,6 +7,7 @@ Trezor Suite native application.
 Generally it's recommended to follow official [React Native environment setup](https://reactnative.dev/docs/set-up-your-environment) guide.
 
 1. [Android Guide](https://reactnative.dev/docs/set-up-your-environment?os=macos&platform=android)
+    - If you have Linux, install `watchman` preferably using Homebrew (others methods seem to be unmaintained)
 2. [iOS Guide](https://reactnative.dev/docs/set-up-your-environment?os=macos&platform=ios)
     - Make sure you have the latest version of the Xcode command line tools installed: `xcode-select --install`
 
@@ -66,3 +67,4 @@ To reveal dev menu, you have to click at least 7 times on commit hash at the bot
 2. In case of issues with the packager, try to restart it with `--reset-cache` i.e (`yarn s --reset-cache`).
 3. Sometimes it's helpful to combine two previous points with uninstalling the app from the device/emulator.
 4. Make sure you are using pure Node or `nvm` for managing node version (other version managers like `fnm` can cause build issues on iOS).
+5. `npx react-native doctor` may help to identify issues with your environment, though not every check _has_ to pass


### PR DESCRIPTION
## Description

Add tips to `suite-native` docs for building app on Linux.

The `watchman` thing was a slight annoyance - react native docs lead to [watchman docs](https://facebook.github.io/watchman/docs/install#buildinstall), which talks about `.deb` package but they don't release it anymore! There is apt package but the docs literally tell you not to use it. You can find older `.deb` release, but it didn't work because of unobtainable dependency :see_no_evil:  or you can build from source, which I didn't feel like doing, or homebrew for Linux.
:beer: worked very fine so I'd recommend it :heavy_check_mark: Rant over.

There is also an issue of installing OpenJDK, but the link from React Native docs is sufficient - I was just wary of installing something called [Adoptium Temurin](https://adoptium.net/temurin/releases/?arch=x64&os=linux&version=17), but that's what it's called these days I guess :shrug: 