### PR TITLE
android e2e pipeline fix

### DIFF
--- a/.github/workflows/test-suite-native-e2e-android.yml
+++ b/.github/workflows/test-suite-native-e2e-android.yml
@@ -56,8 +56,7 @@ jobs:
         run: |
           echo -e "\nenableScripts: false" >> .yarnrc.yml
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          yarn workspaces focus @suite-native/app
-          yarn workspaces focus @suite-common/message-system
+          yarn install
 
       - name: Setup Java
         uses: actions/setup-java@v4
@@ -122,7 +121,7 @@ jobs:
         run: |
           echo -e "\nenableScripts: false" >> .yarnrc.yml
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          yarn workspaces focus @suite-native/app
+          yarn install
 
       - name: Get device name from detox config file
         id: device

--- a/.github/workflows/test-suite-native-e2e-android.yml
+++ b/.github/workflows/test-suite-native-e2e-android.yml
@@ -7,6 +7,7 @@ on:
       - "suite-native/**"
       - "suite-common/**"
       - "packages/connect/**"
+      - ".github/workflows/test-suite-native-e2e-android.yml"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Prevent `command not found: expo` error on prebuild step.

I'm not sure why expo is missing in node_modules on CI, trying the same locally (deleting node_modules, disabling scripts and hardening for yarn and install using focus) it worked fine 🤷