### PR TITLE
feat(suite-native): allow to use plural syntax and use it for Token/Tokens message

### DIFF
--- a/scripts/list-outdated-dependencies/mobile-dependencies.txt
+++ b/scripts/list-outdated-dependencies/mobile-dependencies.txt
@@ -67,3 +67,4 @@ yup
 metro
 metro-react-native-babel-preset
 jest-expo
+intl-pluralrules

--- a/suite-native/intl/package.json
+++ b/suite-native/intl/package.json
@@ -13,6 +13,7 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
+        "intl-pluralrules": "^2.0.1",
         "react": "18.2.0",
         "react-intl": "^6.6.8"
     }

--- a/suite-native/intl/src/IntlProvider.tsx
+++ b/suite-native/intl/src/IntlProvider.tsx
@@ -1,5 +1,8 @@
 import { IntlProvider as ReactIntlProvider } from 'react-intl';
 
+// Polyfill to support plural syntax
+import 'intl-pluralrules';
+
 import { en } from './en';
 
 // flatten object to single level deep like { a: { b: { c: 1 } } } => { 'a.b.c': 1 }

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -85,7 +85,7 @@ export const en = {
         },
     },
     accountList: {
-        numberOfTokens: '+{numberOfTokens} Tokens',
+        numberOfTokens: '+{numberOfTokens, plural, one{1 Token} other{# Tokens}}',
         tokens: 'Tokens',
     },
     assets: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9998,6 +9998,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/intl@workspace:suite-native/intl"
   dependencies:
+    intl-pluralrules: "npm:^2.0.1"
     react: "npm:18.2.0"
     react-intl: "npm:^6.6.8"
   languageName: unknown
@@ -25757,6 +25758,13 @@ __metadata:
     "@formatjs/icu-messageformat-parser": "npm:2.7.8"
     tslib: "npm:^2.4.0"
   checksum: 10/01692e92671b00d2423a7db405e6bb8e42bea52445dec931abaa8a8c47e3a7da17dddd3cd0faa33cb6a614370ea230b2c3980ae106cafa8b760e50ac4db0952f
+  languageName: node
+  linkType: hard
+
+"intl-pluralrules@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "intl-pluralrules@npm:2.0.1"
+  checksum: 10/562964d81c4477ab0b66e051c31cdbb2ca599307ffdfdc88a1e16d2cf137e481082b90d5ad81f9d2d5f6767ec5528d764a44462f6752109ac035c04604973e23
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add polyfill so we can use plural syntax in translations and not hack it via JS.

## Related Issue

Resolve #14433

## Screenshots:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/27b97836-6ca4-4c10-b5c4-528c8d83f6ad">

