### PR TITLE
Fix: webextension guides issue

### DIFF
--- a/packages/connect-examples/webextension-mv3-sw-ts/src/service-worker.ts
+++ b/packages/connect-examples/webextension-mv3-sw-ts/src/service-worker.ts
@@ -2,7 +2,7 @@
 // Reference the Web Worker library, allowing TypeScript to recognize service worker globals
 
 // Import using ES6 module TrezorConnect and the DEVICE_EVENT constant from the Trezor Connect WebExtension package
-import TrezorConnect, { DEVICE_EVENT, DeviceEventMessage } from '@trezor/connect-webextension';
+import TrezorConnect from '@trezor/connect-webextension';
 
 // URL of the Trezor Connect
 const connectSrc = 'https://connect.trezor.io/9/';
@@ -19,11 +19,6 @@ chrome.runtime.onInstalled.addListener((details: chrome.runtime.InstalledDetails
         transports: ['BridgeTransport', 'WebUsbTransport'], // Transport protocols to be used
         connectSrc,
         _extendWebextensionLifetime: true, // Makes the service worker in @trezor/connect-webextension stay alive longer.
-    });
-
-    // Event listener for Trezor device events
-    TrezorConnect.on(DEVICE_EVENT, (event: DeviceEventMessage) => {
-        console.log('EVENT in service worker', event);
     });
 
     // Event listener for messages from other parts of the extension

--- a/packages/connect-examples/webextension-mv3-sw/src/serviceWorker.js
+++ b/packages/connect-examples/webextension-mv3-sw/src/serviceWorker.js
@@ -19,11 +19,6 @@ chrome.runtime.onInstalled.addListener(details => {
         _extendWebextensionLifetime: true, // Makes the service worker in @trezor/connect-webextension stay alive longer.
     });
 
-    // Event listener for Trezor device events
-    TrezorConnect.on('DEVICE_EVENT', event => {
-        console.log('EVENT in service worker', event);
-    });
-
     // Event listener for messages from other parts of the extension
     // This code will depend on how you handle the communication between different parts of your webextension.
     chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {

--- a/packages/connect-explorer/src/pages/guides/webextension-implementation-tutorial.mdx
+++ b/packages/connect-explorer/src/pages/guides/webextension-implementation-tutorial.mdx
@@ -116,11 +116,6 @@ export const SectionCard = styled(TrezorCard)`
             _extendWebextensionLifetime: true, // Makes the service worker in @trezor/connect-webextension stay alive longer.
         });
 
-        // Event listener for Trezor device events
-        TrezorConnect.on(DEVICE_EVENT, (event: DeviceEventMessage) => {
-            console.log('EVENT in service worker', event);
-        });
-
         // Event listener for messages from other parts of the extension
         // This code will depend on how you handle the communication between different parts of your webextension.
         chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removing event handler from service worker examples and connect-explorer guide.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/14453

