### PR TITLE
feat(suite-native): send navigation improvements

### DIFF
--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -679,6 +679,7 @@ export const en = {
     transactions: {
         title: 'Transactions',
         receive: 'Receive',
+        send: 'Send',
         status: { pending: 'Pending', confirmed: 'Confirmed' },
         phishing: {
             badge: 'Caution!',

--- a/suite-native/module-accounts-management/package.json
+++ b/suite-native/module-accounts-management/package.json
@@ -27,6 +27,7 @@
         "@suite-native/analytics": "workspace:*",
         "@suite-native/atoms": "workspace:*",
         "@suite-native/device-manager": "workspace:*",
+        "@suite-native/feature-flags": "workspace:*",
         "@suite-native/formatters": "workspace:*",
         "@suite-native/forms": "workspace:*",
         "@suite-native/graph": "workspace:*",

--- a/suite-native/module-accounts-management/tsconfig.json
+++ b/suite-native/module-accounts-management/tsconfig.json
@@ -26,6 +26,7 @@
         { "path": "../analytics" },
         { "path": "../atoms" },
         { "path": "../device-manager" },
+        { "path": "../feature-flags" },
         { "path": "../formatters" },
         { "path": "../forms" },
         { "path": "../graph" },

--- a/suite-native/module-home/src/screens/HomeScreen/components/PortfolioContent.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/PortfolioContent.tsx
@@ -10,7 +10,6 @@ import {
     AccountsImportStackRoutes,
     RootStackParamList,
     RootStackRoutes,
-    SendStackRoutes,
     StackNavigationProps,
 } from '@suite-native/navigation';
 import { selectIsPortfolioTrackerDevice } from '@suite-common/wallet-core';
@@ -24,7 +23,6 @@ export const PortfolioContent = forwardRef<PortfolioGraphRef>((_props, ref) => {
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
 
     const [isUsbDeviceConnectFeatureEnabled] = useFeatureFlag(FeatureFlag.IsDeviceConnectEnabled);
-    const [isSendEnabled] = useFeatureFlag(FeatureFlag.IsSendEnabled);
 
     const handleImportAssets = () => {
         navigation.navigate(RootStackRoutes.AccountsImport, {
@@ -34,10 +32,6 @@ export const PortfolioContent = forwardRef<PortfolioGraphRef>((_props, ref) => {
 
     const handleReceive = () => {
         navigation.navigate(RootStackRoutes.ReceiveModal, { closeActionType: 'back' });
-    };
-
-    const handleSend = () => {
-        navigation.navigate(RootStackRoutes.SendStack, { screen: SendStackRoutes.SendAccounts });
     };
 
     return (
@@ -73,12 +67,6 @@ export const PortfolioContent = forwardRef<PortfolioGraphRef>((_props, ref) => {
                             </Button>
                         </Box>
                     </>
-                )}
-                {/* TODO: remove this button when there is a proper design of the send flow ready */}
-                {isSendEnabled && (
-                    <Button size="large" onPress={handleSend}>
-                        Send crypto
-                    </Button>
                 )}
             </VStack>
         </VStack>

--- a/suite-native/module-send/src/components/AddressReviewStepList.tsx
+++ b/suite-native/module-send/src/components/AddressReviewStepList.tsx
@@ -6,10 +6,12 @@ import { isRejected } from '@reduxjs/toolkit';
 import { useNavigation, useRoute } from '@react-navigation/native';
 
 import {
+    RootStackParamList,
+    RootStackRoutes,
     SendStackParamList,
     SendStackRoutes,
-    StackNavigationProps,
     StackProps,
+    StackToStackCompositeNavigationProps,
 } from '@suite-native/navigation';
 import { Button, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
@@ -29,7 +31,11 @@ const OVERLAY_INITIAL_POSITION = 75;
 const LIST_VERTICAL_SPACING = nativeSpacings.medium;
 
 type RouteProps = StackProps<SendStackParamList, SendStackRoutes.SendAddressReview>['route'];
-type NavigationProps = StackNavigationProps<SendStackParamList, SendStackRoutes.SendAddressReview>;
+type NavigationProps = StackToStackCompositeNavigationProps<
+    SendStackParamList,
+    SendStackRoutes.SendOutputsReview,
+    RootStackParamList
+>;
 
 export const AddressReviewStepList = () => {
     const route = useRoute<RouteProps>();
@@ -84,7 +90,10 @@ export const AddressReviewStepList = () => {
                     icon: 'closeCircle',
                 });
 
-                navigation.popToTop();
+                navigation.navigate(RootStackRoutes.AccountDetail, {
+                    accountKey,
+                    closeActionType: 'back',
+                });
             }
         }
     };

--- a/suite-native/module-send/src/components/OutputsReviewFooter.tsx
+++ b/suite-native/module-send/src/components/OutputsReviewFooter.tsx
@@ -35,6 +35,12 @@ const navigateToAccountDetail = ({
                 },
             },
             {
+                name: RootStackRoutes.AccountDetail,
+                params: {
+                    accountKey,
+                },
+            },
+            {
                 name: RootStackRoutes.TransactionDetail,
                 params: {
                     accountKey,

--- a/suite-native/module-send/src/screens/SendOutputsReviewScreen.tsx
+++ b/suite-native/module-send/src/screens/SendOutputsReviewScreen.tsx
@@ -2,8 +2,16 @@ import { useDispatch } from 'react-redux';
 import { useEffect } from 'react';
 
 import { isFulfilled } from '@reduxjs/toolkit';
+import { useNavigation } from '@react-navigation/native';
 
-import { SendStackParamList, SendStackRoutes, StackProps } from '@suite-native/navigation';
+import {
+    RootStackParamList,
+    RootStackRoutes,
+    SendStackParamList,
+    SendStackRoutes,
+    StackProps,
+    StackToStackCompositeNavigationProps,
+} from '@suite-native/navigation';
 import { VStack } from '@suite-native/atoms';
 import { cancelSignSendFormTransactionThunk } from '@suite-common/wallet-core';
 import { useTranslate } from '@suite-native/intl';
@@ -15,13 +23,19 @@ import { cleanupSendFormThunk } from '../sendFormThunks';
 import { SendScreen } from '../components/SendScreen';
 import { SendScreenSubHeader } from '../components/SendScreenSubHeader';
 
+type NavigationProps = StackToStackCompositeNavigationProps<
+    SendStackParamList,
+    SendStackRoutes.SendOutputsReview,
+    RootStackParamList
+>;
+
 export const SendOutputsReviewScreen = ({
     route,
-    navigation,
 }: StackProps<SendStackParamList, SendStackRoutes.SendOutputsReview>) => {
     const { accountKey } = route.params;
     const { translate } = useTranslate();
     const dispatch = useDispatch();
+    const navigation = useNavigation<NavigationProps>();
 
     useEffect(() => {
         const unsubscribe = navigation.addListener('beforeRemove', async e => {
@@ -35,7 +49,10 @@ export const SendOutputsReviewScreen = ({
                 return;
             }
             dispatch(cleanupSendFormThunk({ accountKey }));
-            navigation.popToTop();
+            navigation.navigate(RootStackRoutes.AccountDetail, {
+                accountKey,
+                closeActionType: 'back',
+            });
         });
 
         return unsubscribe;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10115,6 +10115,7 @@ __metadata:
     "@suite-native/analytics": "workspace:*"
     "@suite-native/atoms": "workspace:*"
     "@suite-native/device-manager": "workspace:*"
+    "@suite-native/feature-flags": "workspace:*"
     "@suite-native/formatters": "workspace:*"
     "@suite-native/forms": "workspace:*"
     "@suite-native/graph": "workspace:*"


### PR DESCRIPTION
## Description

- [x] the send button is removed from dashboard (It will stay this way until we do not support send for all the networks)
- [x] user is able to enter the send flow from the account detail --> redirect directly to the send form (with particular account selected)
- [x] user is not allowed to entry the send flow from portfolio tracker accounts 
- [x] If user clicks on a close button while is on device review in progress, he is redirected to the place from where he entered the send flow (account detail ATM)

## Related Issue

Resolve #13765 

## Screenshots:
![Screenshot 2024-09-23 at 10 36 49](https://github.com/user-attachments/assets/965754c2-cd43-40f6-9c8e-20a8a0a692b8)

