### PR TITLE
fix(connect-explorer): fix typo in webextension guide

### DIFF
--- a/packages/connect-explorer/src/pages/guides/webextension-implementation-tutorial.mdx
+++ b/packages/connect-explorer/src/pages/guides/webextension-implementation-tutorial.mdx
@@ -359,7 +359,7 @@ export const SectionCard = styled(TrezorCard)`
 
 </SectionCard>
 <SectionCard>
-    ## Update `pacakge.json` scripts for building project:
+    ## Update `package.json` scripts for building project:
 
     * Execute the following commands in order to prepare the web extension:
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Little typo form `pacakge.json` to `package.json`.

Thanks @evgenysl 