### PR TITLE
Feat/empty device label

### DIFF
--- a/packages/connect/src/types/device.ts
+++ b/packages/connect/src/types/device.ts
@@ -57,6 +57,7 @@ export type KnownDevice = {
     type: 'acquired';
     id: string | null;
     path: string;
+    /** @deprecated, use features.label instead */
     label: string;
     error?: typeof undefined;
     firmware: DeviceFirmwareStatus;
@@ -82,6 +83,7 @@ export type UnknownDevice = {
     type: 'unacquired';
     id?: null;
     path: string;
+    /** @deprecated, use features.label instead */
     label: string;
     error?: typeof undefined;
     features?: typeof undefined;
@@ -102,6 +104,7 @@ export type UnreadableDevice = {
     type: 'unreadable';
     id?: null;
     path: string;
+    /** @deprecated, use features.label instead */
     label: string;
     error: string;
     features?: typeof undefined;

--- a/packages/suite/src/actions/settings/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/deviceSettingsActions.ts
@@ -156,7 +156,6 @@ export const resetDevice =
 
         const defaults = {
             strength: DEVICE.DEFAULT_STRENGTH[device.features.internal_model],
-            label: DEVICE.DEFAULT_LABEL,
             skip_backup: DEVICE.DEFAULT_SKIP_BACKUP,
             passphrase_protection: DEVICE.DEFAULT_PASSPHRASE_PROTECTION,
         };

--- a/packages/suite/src/components/firmware/CheckSeedStep.tsx
+++ b/packages/suite/src/components/firmware/CheckSeedStep.tsx
@@ -2,14 +2,15 @@ import { useState } from 'react';
 import styled from 'styled-components';
 
 import { Button, Checkbox, variables } from '@trezor/components';
-import { useDevice, useDispatch } from 'src/hooks/suite';
+import { spacingsPx } from '@trezor/theme';
+import { selectDeviceLabelOrName } from '@suite-common/wallet-core';
+import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 import { Translation } from 'src/components/suite';
 import { OnboardingStepBox } from 'src/components/onboarding';
 import { FirmwareButtonsRow } from './Buttons/FirmwareButtonsRow';
 import { FirmwareSwitchWarning } from './FirmwareSwitchWarning';
 import { goto } from 'src/actions/suite/routerActions';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
-import { spacingsPx } from '@trezor/theme';
 
 // eslint-disable-next-line local-rules/no-override-ds-component
 const StyledCheckbox = styled(Checkbox)`
@@ -44,6 +45,7 @@ type CheckSeedStepProps = {
 };
 
 export const CheckSeedStep = ({ onClose, onSuccess, willBeWiped }: CheckSeedStepProps) => {
+    const deviceLabel = useSelector(selectDeviceLabelOrName);
     const dispatch = useDispatch();
     const { device } = useDevice();
     const [isChecked, setIsChecked] = useState(false);
@@ -55,10 +57,7 @@ export const CheckSeedStep = ({ onClose, onSuccess, willBeWiped }: CheckSeedStep
             !device?.features?.unfinished_backup;
 
         const noBackupHeading = (
-            <Translation
-                id="TR_DEVICE_LABEL_IS_NOT_BACKED_UP"
-                values={{ deviceLabel: device?.label }}
-            />
+            <Translation id="TR_DEVICE_LABEL_IS_NOT_BACKED_UP" values={{ deviceLabel }} />
         );
 
         if (willBeWiped) {

--- a/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
+++ b/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
@@ -7,11 +7,12 @@ import { H2, Button, variables, DeviceAnimation } from '@trezor/components';
 import { DEVICE, Device, DeviceModelInternal, UI } from '@trezor/connect';
 import { Modal, Translation, WebUsbButton } from 'src/components/suite';
 import { DeviceConfirmImage } from 'src/components/suite/DeviceConfirmImage';
-import { useDevice, useFirmware } from 'src/hooks/suite';
+import { useDevice, useFirmware, useSelector } from 'src/hooks/suite';
 import { AbortButton } from 'src/components/suite/modals/AbortButton';
 import { ConfirmOnDevice } from '@trezor/product-components';
 import { TranslationKey } from '@suite-common/intl-types';
 import { spacings } from '@trezor/theme';
+import { selectDeviceLabelOrName } from '@suite-common/wallet-core';
 
 const StyledModal = styled(Modal)`
     width: 600px;
@@ -180,6 +181,7 @@ interface ReconnectDevicePromptProps {
 }
 
 export const ReconnectDevicePrompt = ({ onClose, onSuccess }: ReconnectDevicePromptProps) => {
+    const deviceLabel = useSelector(selectDeviceLabelOrName);
     const { showManualReconnectPrompt, isWebUSB, status, uiEvent } = useFirmware();
     const { device } = useDevice();
 
@@ -312,7 +314,7 @@ export const ReconnectDevicePrompt = ({ onClose, onSuccess }: ReconnectDevicePro
                                 <CenteredPointText>
                                     <Translation
                                         id="TR_CONFIRM_ACTION_ON_YOUR"
-                                        values={{ deviceLabel: device?.label }}
+                                        values={{ deviceLabel }}
                                     />
                                 </CenteredPointText>
                             )}

--- a/packages/suite/src/components/suite/ChangeDeviceLabel.tsx
+++ b/packages/suite/src/components/suite/ChangeDeviceLabel.tsx
@@ -40,7 +40,7 @@ export const ChangeDeviceLabel = ({
     const { device } = useDevice();
     const dispatch = useDispatch();
 
-    const [label, setLabel] = useState(device?.label === placeholder ? '' : device?.label);
+    const [label, setLabel] = useState(deviceLabel ?? '');
     const [error, setError] = useState<string | null>(null);
 
     const handleChange: ChangeEventHandler<HTMLInputElement> = ({ target: { value } }) => {

--- a/packages/suite/src/components/suite/ChangeDeviceLabel.tsx
+++ b/packages/suite/src/components/suite/ChangeDeviceLabel.tsx
@@ -4,12 +4,13 @@ import styled from 'styled-components';
 
 import { Button, Input } from '@trezor/components';
 import { Translation } from 'src/components/suite';
-import { useDevice, useDispatch, useTranslation } from 'src/hooks/suite';
+import { useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
 import { applySettings } from 'src/actions/settings/deviceSettingsActions';
 import { MAX_LABEL_LENGTH } from 'src/constants/suite/device';
 import { isAscii } from '@trezor/utils';
 import { spacingsPx } from '@trezor/theme';
 import { breakpointMediaQueries } from '@trezor/styles';
+import { selectDeviceLabel, selectDeviceName } from '@suite-common/wallet-core';
 
 const Container = styled.div<{ $isVertical?: boolean }>`
     display: flex;
@@ -25,19 +26,18 @@ const Container = styled.div<{ $isVertical?: boolean }>`
 
 interface ChangeDeviceLabelProps {
     isDeviceLocked: boolean;
-    placeholder?: string;
     isVertical?: boolean;
     onClick?: () => void;
 }
 
 export const ChangeDeviceLabel = ({
     isDeviceLocked,
-    placeholder,
     isVertical,
     onClick,
 }: ChangeDeviceLabelProps) => {
     const { translationString } = useTranslation();
-    const { device } = useDevice();
+    const deviceLabel = useSelector(selectDeviceLabel);
+    const deviceName = useSelector(selectDeviceName);
     const dispatch = useDispatch();
 
     const [label, setLabel] = useState(deviceLabel ?? '');
@@ -67,8 +67,8 @@ export const ChangeDeviceLabel = ({
         onClick?.();
     };
 
-    const isDisabled =
-        isDeviceLocked || (!placeholder && label === device?.label) || !!error || !label;
+    const isDisabled = isDeviceLocked || !label || label === deviceLabel || !!error;
+    const placeholder = deviceLabel ? undefined : deviceName;
 
     return (
         <Container $isVertical={isVertical}>

--- a/packages/suite/src/components/suite/labeling/WalletLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/WalletLabeling.tsx
@@ -4,6 +4,7 @@ import { useSelector } from 'src/hooks/suite/useSelector';
 import { selectLabelingDataForWallet } from 'src/reducers/suite/metadataReducer';
 import { useCallback } from 'react';
 import styled from 'styled-components';
+import { selectDeviceLabelOrName } from '@suite-common/wallet-core';
 
 interface WalletLabellingProps {
     device: TrezorDevice;
@@ -34,6 +35,7 @@ export const useWalletLabeling = () => {
 
 export const useGetWalletLabel = ({ device, shouldUseDeviceLabel }: WalletLabellingProps) => {
     const { defaultAccountLabelString } = useWalletLabeling();
+    const deviceLabel = useSelector(selectDeviceLabelOrName);
     const { walletLabel } = useSelector(state => selectLabelingDataForWallet(state, device.state));
 
     let label: string | undefined;
@@ -44,7 +46,7 @@ export const useGetWalletLabel = ({ device, shouldUseDeviceLabel }: WalletLabell
     }
 
     if (shouldUseDeviceLabel) {
-        return <>{`${device.label} ${label}`}</>;
+        return <>{`${deviceLabel} ${label}`}</>;
     }
 
     if (!label) return null;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceStatus.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceStatus.tsx
@@ -7,6 +7,8 @@ import { TrezorDevice } from 'src/types/suite';
 import { spacingsPx } from '@trezor/theme';
 import { RotateDeviceImage } from '@trezor/components';
 import { DeviceStatusText } from 'src/views/suite/SwitchDevice/DeviceItem/DeviceStatusText';
+import { selectDeviceLabelOrName } from '@suite-common/wallet-core';
+import { useSelector } from 'src/hooks/suite';
 
 type DeviceStatusProps = {
     deviceModel: DeviceModelInternal;
@@ -43,6 +45,8 @@ export const DeviceStatus = ({
     handleRefreshClick,
     forceConnectionInfo = false,
 }: DeviceStatusProps) => {
+    const deviceLabel = useSelector(selectDeviceLabelOrName);
+
     return (
         <Container>
             <DeviceWrapper $isLowerOpacity={deviceNeedsRefresh}>
@@ -55,7 +59,7 @@ export const DeviceStatus = ({
             </DeviceWrapper>
 
             {device && (
-                <DeviceDetail label={device.label}>
+                <DeviceDetail label={deviceLabel}>
                     <DeviceStatusText
                         onRefreshClick={handleRefreshClick}
                         device={device}

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
@@ -12,7 +12,7 @@ import {
     Card,
 } from '@trezor/components';
 import { copyToClipboard } from '@trezor/dom-utils';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectDevice, selectDeviceLabelOrName } from '@suite-common/wallet-core';
 import { selectIsActionAbortable } from 'src/reducers/suite/suiteReducer';
 import { QrCode } from 'src/components/suite/QrCode';
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -54,6 +54,7 @@ export const ConfirmValueModal = ({
     const device = useSelector(selectDevice);
     const modalContext = useSelector(state => state.modal.context);
     const isActionAbortable = useSelector(selectIsActionAbortable);
+    const deviceLabel = useSelector(selectDeviceLabelOrName);
     const dispatch = useDispatch();
 
     const canConfirmOnDevice = !!(device?.connected && device?.available);
@@ -117,7 +118,7 @@ export const ConfirmValueModal = ({
                             <Paragraph typographyStyle="hint">
                                 <Translation
                                     id="TR_DEVICE_LABEL_IS_NOT_CONNECTED"
-                                    values={{ deviceLabel: device?.label }}
+                                    values={{ deviceLabel }}
                                 />
                             </Paragraph>
                             <Paragraph typographyStyle="label">

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseOnDeviceModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseOnDeviceModal.tsx
@@ -3,7 +3,10 @@ import { useIntl } from 'react-intl';
 
 import { H2, NewModal, Paragraph } from '@trezor/components';
 import { ConfirmOnDevice } from '@trezor/product-components';
-import { selectIsDiscoveryAuthConfirmationRequired } from '@suite-common/wallet-core';
+import {
+    selectDeviceLabelOrName,
+    selectIsDiscoveryAuthConfirmationRequired,
+} from '@suite-common/wallet-core';
 import TrezorConnect from '@trezor/connect';
 import { spacings } from '@trezor/theme';
 
@@ -30,6 +33,7 @@ export const PassphraseOnDeviceModal = ({ device }: PassphraseOnDeviceModalProps
     const intl = useIntl();
     const authConfirmation =
         useSelector(selectIsDiscoveryAuthConfirmationRequired) || device.authConfirm;
+    const deviceLabel = useSelector(selectDeviceLabelOrName);
 
     const onCancel = () => TrezorConnect.cancel(intl.formatMessage(messages.TR_CANCELLED));
 
@@ -53,7 +57,7 @@ export const PassphraseOnDeviceModal = ({ device }: PassphraseOnDeviceModalProps
                                 ? 'TR_CONFIRM_EMPTY_HIDDEN_WALLET_ON'
                                 : 'TR_ENTER_PASSPHRASE_ON_DEVICE_LABEL'
                         }
-                        values={{ deviceLabel: device.label }}
+                        values={{ deviceLabel }}
                     />
                 </H2>
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseSourceModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseSourceModal.tsx
@@ -1,7 +1,10 @@
 import styled from 'styled-components';
 
 import { H2, variables } from '@trezor/components';
-import { selectIsDiscoveryAuthConfirmationRequired } from '@suite-common/wallet-core';
+import {
+    selectDeviceLabelOrName,
+    selectIsDiscoveryAuthConfirmationRequired,
+} from '@suite-common/wallet-core';
 
 import { Translation } from 'src/components/suite/Translation';
 import { DeviceConfirmImage } from 'src/components/suite';
@@ -30,6 +33,7 @@ interface PassphraseSourceModalProps {
 export const PassphraseSourceModal = ({ device }: PassphraseSourceModalProps) => {
     const authConfirmation =
         useSelector(selectIsDiscoveryAuthConfirmationRequired) || device.authConfirm;
+    const deviceLabel = useSelector(selectDeviceLabelOrName);
 
     return (
         <StyledDevicePromptModal
@@ -47,7 +51,7 @@ export const PassphraseSourceModal = ({ device }: PassphraseSourceModalProps) =>
                             ? 'TR_CONFIRM_PASSPHRASE_SOURCE'
                             : 'TR_SELECT_PASSPHRASE_SOURCE'
                     }
-                    values={{ deviceLabel: device.label }}
+                    values={{ deviceLabel }}
                 />
             </StyledH2>
         </StyledDevicePromptModal>

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PinInvalidModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PinInvalidModal.tsx
@@ -1,9 +1,11 @@
 import styled from 'styled-components';
 
+import { selectDeviceLabelOrName } from '@suite-common/wallet-core';
 import { Paragraph } from '@trezor/components';
 import { Translation } from 'src/components/suite/Translation';
 import { DeviceConfirmImage, Modal, ModalProps } from 'src/components/suite';
 import { TrezorDevice } from 'src/types/suite';
+import { useSelector } from 'src/hooks/suite';
 
 const Divider = styled.div`
     margin-bottom: 10px;
@@ -17,17 +19,19 @@ interface PinInvalidModalProps extends ModalProps {
     device: TrezorDevice;
 }
 
-export const PinInvalidModal = ({ device, ...rest }: PinInvalidModalProps) => (
-    <StyledModal
-        heading={
-            <Translation id="TR_ENTERED_PIN_NOT_CORRECT" values={{ deviceLabel: device.label }} />
-        }
-        {...rest}
-    >
-        <DeviceConfirmImage device={device} />
-        <Divider />
-        <Paragraph typographyStyle="hint">
-            <Translation id="TR_RETRYING_DOT_DOT" />
-        </Paragraph>
-    </StyledModal>
-);
+export const PinInvalidModal = ({ device, ...rest }: PinInvalidModalProps) => {
+    const deviceLabel = useSelector(selectDeviceLabelOrName);
+
+    return (
+        <StyledModal
+            heading={<Translation id="TR_ENTERED_PIN_NOT_CORRECT" values={{ deviceLabel }} />}
+            {...rest}
+        >
+            <DeviceConfirmImage device={device} />
+            <Divider />
+            <Paragraph typographyStyle="hint">
+                <Translation id="TR_RETRYING_DOT_DOT" />
+            </Paragraph>
+        </StyledModal>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PinModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PinModal.tsx
@@ -1,10 +1,12 @@
 import TrezorConnect from '@trezor/connect';
 import styled from 'styled-components';
 
+import { selectDeviceLabelOrName } from '@suite-common/wallet-core';
 import { Modal, ModalProps, PinMatrix, Translation } from 'src/components/suite';
 import { PIN_MATRIX_MAX_WIDTH } from 'src/components/suite/PinMatrix/PinMatrix';
 import { usePin } from 'src/hooks/suite/usePinModal';
 import { TrezorDevice } from 'src/types/suite';
+import { useSelector } from 'src/hooks/suite';
 
 const StyledModal = styled(Modal)<{ $isExtended: boolean }>`
     width: unset;
@@ -22,6 +24,7 @@ interface PinModalProps extends ModalProps {
 }
 
 export const PinModal = ({ device, ...rest }: PinModalProps) => {
+    const deviceLabel = useSelector(selectDeviceLabelOrName);
     const { isRequestingNewPinCode, isWipeCode, isPinInvalid, isModalExtended } = usePin();
 
     if (!device.features) return null;
@@ -35,7 +38,7 @@ export const PinModal = ({ device, ...rest }: PinModalProps) => {
             description={
                 <Translation
                     id="TR_THE_PIN_LAYOUT_IS_DISPLAYED"
-                    values={{ deviceLabel: device.label, b: text => <b>{text}</b> }}
+                    values={{ deviceLabel, b: text => <b>{text}</b> }}
                 />
             }
             onCancel={onCancel}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedModal.tsx
@@ -4,10 +4,11 @@ import styled from 'styled-components';
 import { applySettings } from 'src/actions/settings/deviceSettingsActions';
 import { Translation, Modal } from 'src/components/suite';
 import { TranslationKey } from 'src/components/suite/Translation';
-import { useDevice, useDispatch } from 'src/hooks/suite';
+import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 import { ThunkAction } from 'src/types/suite';
 import { Button } from '@trezor/components';
 import { onCancel } from 'src/actions/suite/modalActions';
+import { selectDeviceLabelOrName } from '@suite-common/wallet-core';
 
 const StyledModal = styled(Modal)`
     width: 520px;
@@ -31,6 +32,7 @@ export const ConfirmUnverifiedModal = ({
     verify,
     warningText,
 }: ConfirmUnverifiedModalProps) => {
+    const deviceLabel = useSelector(selectDeviceLabelOrName);
     const dispatch = useDispatch();
     const { device, isLocked } = useDevice();
 
@@ -65,7 +67,7 @@ export const ConfirmUnverifiedModal = ({
 
     return (
         <StyledModal
-            heading={<Translation id={deviceStatus} values={{ deviceLabel: device.label }} />}
+            heading={<Translation id={deviceStatus} values={{ deviceLabel }} />}
             isCancelable
             onCancel={close}
             description={

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
@@ -1,6 +1,8 @@
 import type { ComponentType } from 'react';
+import { useSelector } from 'react-redux';
 
 import { AUTH_DEVICE, type NotificationEntry } from '@suite-common/toast-notifications';
+import { selectDeviceLabelOrName } from '@suite-common/wallet-core';
 import { DEVICE } from '@trezor/connect';
 
 import { NotificationViewProps } from 'src/components/suite';
@@ -62,6 +64,8 @@ export const NotificationRenderer = ({
     notification,
     render,
 }: NotificationRendererProps): JSX.Element => {
+    const deviceLabel = useSelector(selectDeviceLabelOrName);
+
     switch (notification.type) {
         case 'acquire-error':
             return error(render, notification, 'TOAST_ACQUIRE_ERROR');
@@ -223,7 +227,7 @@ export const NotificationRenderer = ({
                     variant="info"
                     message="EVENT_DEVICE_CONNECT"
                     messageValues={{
-                        label: notification.device.label,
+                        label: deviceLabel,
                     }}
                 />
             );

--- a/packages/suite/src/constants/suite/device.ts
+++ b/packages/suite/src/constants/suite/device.ts
@@ -1,6 +1,5 @@
 import { DeviceModelInternal } from '@trezor/connect';
 
-export const DEFAULT_LABEL = 'My Trezor';
 export const MAX_LABEL_LENGTH = 16;
 export const DEFAULT_PASSPHRASE_PROTECTION = true;
 export const DEFAULT_SKIP_BACKUP = true;

--- a/packages/suite/src/views/onboarding/steps/Final.tsx
+++ b/packages/suite/src/views/onboarding/steps/Final.tsx
@@ -14,7 +14,6 @@ import {
 import { Translation, HomescreenGallery } from 'src/components/suite';
 import { OnboardingStepBox } from 'src/components/onboarding';
 import { useDevice, useOnboarding, useSelector } from 'src/hooks/suite';
-import { DEFAULT_LABEL } from 'src/constants/suite/device';
 import { isHomescreenSupportedOnDevice } from 'src/utils/suite/homescreen';
 import { selectIsActionAbortable } from 'src/reducers/suite/suiteReducer';
 import { ChangeDeviceLabel } from 'src/components/suite/ChangeDeviceLabel';
@@ -196,11 +195,7 @@ export const FinalStep = () => {
                     )}
                     {state === 'rename' && (
                         <SetupActions>
-                            <ChangeDeviceLabel
-                                placeholder={DEFAULT_LABEL}
-                                onClick={onClick}
-                                isDeviceLocked={isDeviceLocked}
-                            />
+                            <ChangeDeviceLabel onClick={onClick} isDeviceLocked={isDeviceLocked} />
                         </SetupActions>
                     )}
 

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
@@ -150,7 +150,7 @@ export const WalletInstance = ({
         <RelativeContainer data-testid={dataTestBase}>
             <EjectButton setContentType={setContentType} data-testid={dataTestBase} />
             <Card
-                key={`${instance.label}${instance.instance}${instance.state}`}
+                key={`${instance.instance}${instance.state}`}
                 paddingType="small"
                 onClick={handleClick}
                 tabIndex={0}

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -796,12 +796,6 @@ export const selectIsPortfolioTrackerDevice = (state: DeviceRootState) => {
     return device?.id === PORTFOLIO_TRACKER_DEVICE_ID;
 };
 
-export const selectDeviceLabelById = (state: DeviceRootState, id: TrezorDevice['id']) => {
-    const device = selectDeviceById(state, id);
-
-    return device?.label ?? null;
-};
-
 export const selectDeviceNameById = (
     state: DeviceRootState,
     id: TrezorDevice['id'],
@@ -812,9 +806,27 @@ export const selectDeviceNameById = (
 };
 
 export const selectDeviceLabel = (state: DeviceRootState) => {
-    const selectedDevice = selectDevice(state);
+    const device = selectDevice(state);
 
-    return selectDeviceLabelById(state, selectedDevice?.id);
+    return device?.features?.label;
+};
+
+export const selectDeviceName = (state: DeviceRootState) => {
+    const device = selectDevice(state);
+
+    return device?.name;
+};
+
+export const selectDeviceLabelOrName = (state: DeviceRootState): string => {
+    const deviceLabel = selectDeviceLabel(state);
+
+    if (deviceLabel) {
+        return deviceLabel;
+    }
+
+    const deviceName = selectDeviceName(state);
+
+    return deviceName ?? '';
 };
 
 export const selectDeviceId = (state: DeviceRootState) => {

--- a/suite-native/device-manager/src/components/DeviceItem/DeviceItemContent.tsx
+++ b/suite-native/device-manager/src/components/DeviceItem/DeviceItemContent.tsx
@@ -8,6 +8,7 @@ import {
     DeviceRootState,
     PORTFOLIO_TRACKER_DEVICE_ID,
     selectHasOnlyEmptyPortfolioTracker,
+    selectDeviceLabelOrName,
 } from '@suite-common/wallet-core';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { TypographyStyle } from '@trezor/theme';
@@ -66,7 +67,7 @@ export const DeviceItemContent = React.memo(
             return {
                 id: d.id,
                 name: d.name,
-                label: d.label,
+                label: selectDeviceLabelOrName(state),
                 walletNumber: d.walletNumber,
                 useEmptyPassphrase: d.useEmptyPassphrase,
             };

--- a/suite-native/device/src/screens/DeviceInfoModalScreen.tsx
+++ b/suite-native/device/src/screens/DeviceInfoModalScreen.tsx
@@ -26,10 +26,10 @@ import {
 } from '@suite-native/navigation';
 import {
     selectDevice,
+    selectDeviceLabel,
     selectDeviceModel,
     selectDeviceReleaseInfo,
     selectIsPortfolioTrackerDevice,
-    selectDeviceLabel,
 } from '@suite-common/wallet-core';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { Translation, useTranslate } from '@suite-native/intl';
@@ -136,7 +136,7 @@ export const DeviceInfoModalScreen = () => {
                     <HStack spacing="large">
                         <Image width={92} height={151} source={deviceImageMap[deviceModel]} />
                         <VStack spacing="extraSmall" justifyContent="center">
-                            <Text variant="titleSmall">{deviceLabel}</Text>
+                            {deviceLabel && <Text variant="titleSmall">{deviceLabel}</Text>}
                             <Text variant="label" color="textSubdued">
                                 {device?.name}
                             </Text>

--- a/suite-native/module-settings/src/components/ViewOnly/DevicesManagement.tsx
+++ b/suite-native/module-settings/src/components/ViewOnly/DevicesManagement.tsx
@@ -42,7 +42,7 @@ export const DevicesManagement = ({ onPressAbout }: AboutProps) => {
                             )}
                             <Box>
                                 <Text variant="highlight" color="textDefault">
-                                    {firstDevice.label}
+                                    {firstDevice.features.label || firstDevice.name}
                                 </Text>
                                 <HStack alignItems="center" spacing="small">
                                     <ConnectionDot isConnected={firstDevice.connected} />

--- a/suite-native/module-settings/src/components/ViewOnly/WalletRow.tsx
+++ b/suite-native/module-settings/src/components/ViewOnly/WalletRow.tsx
@@ -5,6 +5,7 @@ import { Translation } from '@suite-native/intl';
 import {
     ConnectDeviceSettings,
     deviceActions,
+    selectDeviceLabelOrName,
     selectHasDeviceDiscovery,
 } from '@suite-common/wallet-core';
 import { analytics, EventType } from '@suite-native/analytics';
@@ -32,6 +33,7 @@ export const WalletRow = ({ device }: WalletRowProps) => {
     const { showToast } = useToast();
     const { applyStyle } = useNativeStyles();
     const hasDiscovery = useSelector(selectHasDeviceDiscovery);
+    const deviceLabel = useSelector(selectDeviceLabelOrName);
 
     const walletNameLabel = device.useEmptyPassphrase ? (
         <Translation id="moduleSettings.viewOnly.wallet.standard" />
@@ -87,7 +89,7 @@ export const WalletRow = ({ device }: WalletRowProps) => {
             description: (
                 <Translation
                     id="moduleSettings.viewOnly.disableDialog.subtitle"
-                    values={{ device: device.label }}
+                    values={{ device: deviceLabel }}
                 />
             ),
             primaryButtonTitle: (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Do not set device label automatically, it can only be set by user action (previously it was set when creating a new wallet to "My Trezor".
- If device label is not set, display device name instead (e.g. Trezor Safe 5).
<!--- Describe your changes in detail -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/12881

## Screenshots:
### Before:
![Screenshot 2024-09-23 at 13 25 54](https://github.com/user-attachments/assets/8a05c215-63db-423e-a813-69b0bfe02c43)
![Screenshot 2024-09-23 at 13 58 41](https://github.com/user-attachments/assets/93e80301-bb10-41da-b244-0c7462fd93e2)
![Screenshot 2024-09-23 at 13 58 57](https://github.com/user-attachments/assets/7358be0f-bb9b-4d08-88a5-8f84950cf9e4)

### After:
![Screenshot 2024-09-23 at 15 51 20](https://github.com/user-attachments/assets/3451ffb2-8387-4022-8a0b-588450bb2b0b)
![Screenshot 2024-09-23 at 13 58 28](https://github.com/user-attachments/assets/2e442b3a-8714-4ab0-a4d9-40945c905cb8)
This is not value but placeholder:
![Screenshot 2024-09-23 at 16 25 00](https://github.com/user-attachments/assets/5867754a-ec77-4be3-8ae7-f8d781913078)
