### PR TITLE
feat(connect-deeplink): deeplinkUrl setting (for app linking)

### DIFF
--- a/packages/connect-deeplink/src/index.ts
+++ b/packages/connect-deeplink/src/index.ts
@@ -19,7 +19,7 @@ export class TrezorConnectDeeplink implements ConnectFactoryDependencies {
     private _settings: ConnectSettings;
     private messagePromises: Record<number, Deferred<any>> = {};
     private messageID = 0;
-    private schema = 'trezorsuitelite';
+    private defaultDeeplinkUrl = 'trezorsuitelite://connect';
 
     public constructor() {
         this._settings = {
@@ -48,6 +48,7 @@ export class TrezorConnectDeeplink implements ConnectFactoryDependencies {
             ...parseConnectSettings({ ...this._settings, ...settings }),
             deeplinkOpen: settings.deeplinkOpen,
             deeplinkCallbackUrl: settings.deeplinkCallbackUrl,
+            deeplinkUrl: settings.deeplinkUrl || this.defaultDeeplinkUrl,
         };
 
         return Promise.resolve();
@@ -166,7 +167,7 @@ export class TrezorConnectDeeplink implements ConnectFactoryDependencies {
     }
 
     private buildUrl(method: string, params: any, callback: string) {
-        return `${this.schema}://connect?method=${method}&params=${encodeURIComponent(
+        return `${this._settings.deeplinkUrl}?method=${method}&params=${encodeURIComponent(
             JSON.stringify(params),
         )}&callback=${encodeURIComponent(callback)}`;
     }

--- a/packages/connect-examples/deeplink-expo/App.tsx
+++ b/packages/connect-examples/deeplink-expo/App.tsx
@@ -35,6 +35,7 @@ export const App = () => {
                 Linking.openURL(url);
             },
             deeplinkCallbackUrl: Linking.createURL('/connect'),
+            // deeplinkUrl: 'https://dev.suite.sldev.cz/connect/develop/deeplink/',
         });
     };
 

--- a/packages/connect-popup/src/deeplink.tsx
+++ b/packages/connect-popup/src/deeplink.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import styled, { ThemeProvider } from 'styled-components';
+import { createRoot } from 'react-dom/client';
+
+import { ErrorBoundary } from '@trezor/connect-ui/src/support/ErrorBoundary';
+import { GlobalStyle } from '@trezor/connect-ui/src/support/GlobalStyle';
+import { InfoPanel } from '@trezor/connect-ui/src/components/InfoPanel';
+import { View } from '@trezor/connect-ui/src/components/View';
+import { Button, Paragraph, intermediaryTheme } from '@trezor/components';
+
+interface ReactWrapperProps {
+    children: React.ReactNode;
+}
+
+const ThemeWrapper = ({ children }: ReactWrapperProps) => (
+    <ThemeProvider theme={intermediaryTheme.light}>{children}</ThemeProvider>
+);
+
+const Layout = styled.div`
+    display: flex;
+    flex: 1;
+    height: 100%;
+
+    @media (max-width: 639px) {
+        flex-direction: column;
+    }
+`;
+
+// eslint-disable-next-line local-rules/no-override-ds-component
+const StyledP = styled(Paragraph)`
+    margin: 0 20%;
+    color: #757575;
+`;
+
+const DeeplinkFallback = () => {
+    return (
+        <>
+            <View
+                title="Download Mobile App"
+                data-testid="@connect-deeplink"
+                buttons={
+                    <>
+                        <Button variant="primary" onClick={() => window.close()}>
+                            Close
+                        </Button>
+                    </>
+                }
+            >
+                <StyledP>
+                    You have opened a deep link to the Trezor Connect mobile application. Please
+                    install the application from{' '}
+                    <a href="https://play.google.com/store/apps/details?id=io.trezor.suite">
+                        Google Play
+                    </a>
+                    {' or '}
+                    <a href="https://apps.apple.com/app/id1631884497">App Store</a>.
+                </StyledP>
+            </View>
+        </>
+    );
+};
+
+const App = () => (
+    <ErrorBoundary>
+        <GlobalStyle />
+        <ThemeWrapper>
+            <Layout>
+                <InfoPanel method="Trezor Connect Deep Link" origin={window.origin} />
+                <DeeplinkFallback />
+            </Layout>
+        </ThemeWrapper>
+    </ErrorBoundary>
+);
+
+const renderUI = () => {
+    const deeplinkReact = document.getElementById('deeplink-react');
+    deeplinkReact!.style.height = '100%';
+    const root = createRoot(deeplinkReact!);
+    const Component = <App />;
+    console.log('renderUI', deeplinkReact);
+
+    root.render(Component);
+};
+
+renderUI();

--- a/packages/connect-popup/src/static/deeplink.html
+++ b/packages/connect-popup/src/static/deeplink.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+        <meta
+            name="viewport"
+            content="width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=0"
+        />
+        <title>TrezorConnect | Trezor</title>
+        <meta name="description" content="" />
+        <meta name="keywords" content="" />
+        <meta name="author" content="Trezor info@trezor.io" />
+        <meta name="robots" content="noindex, nofollow" />
+        <meta name="title" content="Trezor Connect" />
+        <meta name="theme-color" content="#ffffff" />
+        <meta http-equiv="Pragma" content="no-cache" />
+        <meta http-equiv="Expires" content="-1" />
+        <link href="../popup.css" rel="stylesheet" />
+        <link rel="icon" type="image/png" href="../images/favicon.png" />
+        <!-- suite-like fonts -->
+        <link media="all" rel="stylesheet" href="../fonts/fonts.css" />
+    </head>
+    <body>
+        <div id="deeplink-react"></div>
+
+        <script type="text/javascript" async="false">
+            const pageScript = document.createElement('script');
+            pageScript.setAttribute('type', 'text/javascript');
+            pageScript.setAttribute('src', '../<%= htmlWebpackPlugin.files.js[0] %>');
+            pageScript.setAttribute('async', 'false');
+            document.body.appendChild(pageScript);
+        </script>
+    </body>
+</html>

--- a/packages/connect-popup/webpack/prod.webpack.config.ts
+++ b/packages/connect-popup/webpack/prod.webpack.config.ts
@@ -18,6 +18,7 @@ const config: webpack.Configuration = {
     entry: {
         popup: path.resolve(__dirname, '../src/index.tsx'),
         log: path.resolve(__dirname, '../src/log.tsx'),
+        deeplink: path.resolve(__dirname, '../src/deeplink.tsx'),
     },
     output: {
         filename: 'js/[name].[contenthash].js',
@@ -78,6 +79,14 @@ const config: webpack.Configuration = {
             chunks: ['popup'],
             template: `${STATIC_SRC}/popup.html`,
             filename: 'popup.html',
+            inject: false,
+            minify: false,
+            urls: URLS,
+        }),
+        new HtmlWebpackPlugin({
+            chunks: ['deeplink'],
+            template: `${STATIC_SRC}/deeplink.html`,
+            filename: 'deeplink/index.html',
             inject: false,
             minify: false,
             urls: URLS,

--- a/packages/connect/src/types/settings.ts
+++ b/packages/connect/src/types/settings.ts
@@ -28,6 +28,7 @@ export interface ConnectSettingsPublic {
     _extendWebextensionLifetime?: boolean;
     deeplinkOpen?: (url: string) => void;
     deeplinkCallbackUrl?: string;
+    deeplinkUrl?: string;
 }
 
 // internal part, not to be accepted from .init()

--- a/suite-native/app/app.config.ts
+++ b/suite-native/app/app.config.ts
@@ -168,6 +168,29 @@ export default ({ config }: ConfigContext): ExpoConfig => {
                 monochromeImage: './assets/appIcon_android.png',
                 ...appIconAndroid,
             },
+            intentFilters:
+                buildType === 'production'
+                    ? []
+                    : [
+                          {
+                              action: 'VIEW',
+                              autoVerify: true,
+                              data: [
+                                  {
+                                      scheme: 'https',
+                                      host: 'dev.suite.sldev.cz',
+                                      pathPattern: '/connect/.*/deeplink/.*',
+                                  },
+                                  {
+                                      scheme: 'https',
+                                      host: 'dev.suite.sldev.cz',
+                                      // for branches with a slash in the name
+                                      pathPattern: '/connect/.*/.*/deeplink/.*',
+                                  },
+                              ],
+                              category: ['BROWSABLE', 'DEFAULT'],
+                          },
+                      ],
         },
         ios: {
             bundleIdentifier,


### PR DESCRIPTION
## Description

Add `deeplinkUrl` setting to allow changing the URL to Suite. 
Add intent filters for opening the app from https://dev.suite.sldev.cz/connect/.../deeplink/
Update example app URL for testing
Add [fallback page](https://dev.suite.sldev.cz/connect/feat/native-connect-popup-deeplink-url/deeplink/) for deeplinks (telling user to download app)