### PR TITLE
test(suite): fix failing desktop E2E

### DIFF
--- a/packages/suite-desktop-core/e2e/support/common.ts
+++ b/packages/suite-desktop-core/e2e/support/common.ts
@@ -6,6 +6,9 @@ import fse from 'fs-extra';
 
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
+// specific version of legacy bridge is requested & expected
+export const LEGACY_BRIDGE_VERSION = '2.0.33';
+
 type LaunchSuiteParams = {
     rmUserData?: boolean;
     bridgeLegacyTest?: boolean;
@@ -24,7 +27,7 @@ export const launchSuiteElectronApp = async (params: LaunchSuiteParams = {}) => 
     const desiredLogLevel = process.env.LOGLEVEL ?? 'error';
     if (!options.bridgeDaemon) {
         // TODO: Find out why currently pw fails to see node-bridge so we default to legacy bridge.
-        await TrezorUserEnvLink.startBridge();
+        await TrezorUserEnvLink.startBridge(LEGACY_BRIDGE_VERSION);
     }
     const electronApp = await electron.launch({
         cwd: appDir,

--- a/packages/suite-desktop-core/e2e/tests/spawn-bridge.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/spawn-bridge.test.ts
@@ -2,11 +2,10 @@ import { test as testPlaywright, expect as expectPlaywright } from '@playwright/
 
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
-import { launchSuite, waitForDataTestSelector } from '../support/common';
+import { launchSuite, LEGACY_BRIDGE_VERSION, waitForDataTestSelector } from '../support/common';
 import { onDashboardPage } from '../support/pageActions/dashboardActions';
 
 testPlaywright.describe.serial('Bridge', () => {
-    const expectedBridgeVersion = '2.0.33';
     testPlaywright.beforeEach(async () => {
         // We make sure that bridge from trezor-user-env is stopped.
         // So we properly test the electron app starting node-bridge module.
@@ -40,7 +39,7 @@ testPlaywright.describe.serial('Bridge', () => {
 
         const json = await response.json();
         const { version } = json;
-        expectPlaywright(version).toEqual(expectedBridgeVersion);
+        expectPlaywright(version).toEqual(LEGACY_BRIDGE_VERSION);
 
         // bridge is running after renderer window is refreshed
         await suite.window.reload();
@@ -65,7 +64,7 @@ testPlaywright.describe.serial('Bridge', () => {
         async () => {
             await TrezorUserEnvLink.startEmu({ wipe: true, version: '2-latest', model: 'T2T1' });
             await TrezorUserEnvLink.setupEmu({});
-            await TrezorUserEnvLink.startBridge();
+            await TrezorUserEnvLink.startBridge(LEGACY_BRIDGE_VERSION);
 
             const suite = await launchSuite();
             await suite.window.title();
@@ -76,7 +75,7 @@ testPlaywright.describe.serial('Bridge', () => {
 
             await waitForDataTestSelector(suite.window, '@connect-device-prompt');
 
-            await TrezorUserEnvLink.startBridge();
+            await TrezorUserEnvLink.startBridge(LEGACY_BRIDGE_VERSION);
             await waitForDataTestSelector(suite.window, '@dashboard/index');
         },
     );


### PR DESCRIPTION
## Description

In desktop-core-e2e (playwright tests), request specific bridge version, because trezor-user-env now offers node-bridge as latest, in order to [fix failing tests](https://github.com/trezor/trezor-suite/actions/workflows/test-suite-desktop-e2e.yml)