### PR TITLE
Feat/desktop user agent

### DIFF
--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -80,6 +80,7 @@
         "@solana/web3.js": "^1.95.0",
         "@trezor/blockchain-link-types": "workspace:*",
         "@trezor/blockchain-link-utils": "workspace:*",
+        "@trezor/env-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
         "@trezor/utxo-lib": "workspace:*",
         "@types/web": "^0.0.162",

--- a/packages/blockchain-link/src/workers/blockbook/websocket.ts
+++ b/packages/blockchain-link/src/workers/blockbook/websocket.ts
@@ -21,6 +21,7 @@ import type {
 } from '@trezor/blockchain-link-types/src/params';
 
 import { BaseWebsocket } from '../baseWebsocket';
+import { getSuiteVersion } from '@trezor/env-utils';
 
 interface BlockbookEvents {
     block: BlockNotification;
@@ -52,7 +53,7 @@ export class BlockbookAPI extends BaseWebsocket<BlockbookEvents> {
             agent: this.options.agent,
             headers: {
                 Origin: 'https://node.trezor.io',
-                'User-Agent': 'Trezor Suite',
+                'User-Agent': `Trezor Suite ${getSuiteVersion()}`,
                 ...this.options.headers,
             },
         });

--- a/packages/blockchain-link/src/workers/blockfrost/websocket.ts
+++ b/packages/blockchain-link/src/workers/blockfrost/websocket.ts
@@ -12,6 +12,7 @@ import type {
 } from '@trezor/blockchain-link-types/src/params';
 
 import { BaseWebsocket } from '../baseWebsocket';
+import { getSuiteVersion } from '@trezor/env-utils';
 
 interface BlockfrostEvents {
     block: BlockContent;
@@ -25,6 +26,11 @@ export class BlockfrostAPI extends BaseWebsocket<BlockfrostEvents> {
         // options are not used in web builds (see ./src/utils/ws)
         return new WebSocket(url, {
             agent: this.options.agent,
+            headers: {
+                Origin: 'https://node.trezor.io',
+                'User-Agent': `Trezor Suite ${getSuiteVersion()}`,
+                ...this.options.headers,
+            },
         });
     }
 

--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -26,6 +26,7 @@ import {
 import { TOKEN_ACCOUNT_LAYOUT } from './tokenUtils';
 import { getBaseFee, getPriorityFee } from './fee';
 import { confirmTransactionWithResubmit } from './transactionConfirmation';
+import { getSuiteVersion } from '@trezor/env-utils';
 
 export type SolanaAPI = Connection;
 
@@ -514,7 +515,13 @@ class SolanaWorker extends BaseWorker<SolanaAPI> {
     private lazyTokens = createLazy(() => solanaUtils.getTokenMetadata());
 
     async tryConnect(url: string): Promise<SolanaAPI> {
-        const api = new Connection(url, { wsEndpoint: url.replace('https', 'wss') });
+        const api = new Connection(url, {
+            wsEndpoint: url.replace('https', 'wss'),
+            httpHeaders: {
+                Origin: 'https://node.trezor.io',
+                'User-Agent': `Trezor Suite ${getSuiteVersion()}`,
+            },
+        });
         await api.getLatestBlockhash('finalized');
         this.post({ id: -1, type: RESPONSES.CONNECTED });
 

--- a/packages/blockchain-link/tsconfig.json
+++ b/packages/blockchain-link/tsconfig.json
@@ -9,6 +9,7 @@
     "references": [
         { "path": "../blockchain-link-types" },
         { "path": "../blockchain-link-utils" },
+        { "path": "../env-utils" },
         { "path": "../utils" },
         { "path": "../utxo-lib" },
         { "path": "../e2e-utils" },

--- a/packages/blockchain-link/tsconfig.lib.json
+++ b/packages/blockchain-link/tsconfig.lib.json
@@ -14,6 +14,9 @@
             "path": "../blockchain-link-utils"
         },
         {
+            "path": "../env-utils"
+        },
+        {
             "path": "../utils"
         },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11066,6 +11066,7 @@ __metadata:
     "@trezor/blockchain-link-types": "workspace:*"
     "@trezor/blockchain-link-utils": "workspace:*"
     "@trezor/e2e-utils": "workspace:*"
+    "@trezor/env-utils": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@trezor/utxo-lib": "workspace:*"


### PR DESCRIPTION
## Description

- add Suite version to user agent of requests going from desktop app 
- version is correctly added to the user agent

If needed, we can change the hardcoded `Trezor Suite` name to a dynamic value in the future.

## Related Issue


## Screenshots:
Cloudflare:
![Screenshot 2024-09-24 at 10 18 20](https://github.com/user-attachments/assets/f441577a-1703-44c8-a8bd-304aff61b903)
