### PR TITLE
chore(tenv): always set the bridge version when calling tenv, 2.0.33 if not set

### DIFF
--- a/packages/trezor-user-env-link/src/api.ts
+++ b/packages/trezor-user-env-link/src/api.ts
@@ -61,6 +61,8 @@ export const MNEMONICS = {
         'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
 };
 
+export const DEFAULT_BRIDGE_VERSION = '2.0.33';
+
 export class TrezorUserEnvLinkClass extends TypedEmitter<WebsocketClientEvents> {
     private client: WebsocketClient;
     public firmwares?: Firmwares;
@@ -157,7 +159,7 @@ export class TrezorUserEnvLinkClass extends TypedEmitter<WebsocketClientEvents> 
 
         return null;
     }
-    async startBridge(version?: string) {
+    async startBridge(version = DEFAULT_BRIDGE_VERSION) {
         await this.client.send({ type: 'bridge-start', version });
 
         return null;


### PR DESCRIPTION
Should minimize future issues with changing the bridges in `tenv`

Potentially, the `2.0.33` could be an exportable constant, and tests can use it as an expected version (couple tests currently hardcode `2.0.33`)