### PR TITLE
fix(suite-common): sanitise fetching graph history rates for empty account

### DIFF
--- a/suite-common/graph/src/graphDataFetching.ts
+++ b/suite-common/graph/src/graphDataFetching.ts
@@ -409,6 +409,19 @@ export const getMultipleAccountBalanceHistoryWithFiat = async ({
             findOldestBalanceMovementTimestamp,
             fromUnixTime,
         );
+
+        // if there were no balance movements at all,
+        // findOldestBalanceMovementTimestamp resulted with start date being the same as end date
+        // use 1 year into past and return zeroes for the range
+        if (startOfTimeFrameDate.getTime() === endOfTimeFrameDate.getTime()) {
+            let startDate = startOfTimeFrameDate;
+            startDate.setDate(startDate.getHours() - 8760);
+
+            return [
+                ...getTimestampsInTimeFrame(startDate, endOfTimeFrameDate, numberOfPoints - 1),
+                getUnixTime(endOfTimeFrameDate),
+            ].map(t => ({ date: fromUnixTime(t), value: 0 }));
+        }
     }
 
     // Last timestamp must be endOfTimeFrameDate because blockchainGetAccountBalanceHistory it's not always reliable for coins like ETH.


### PR DESCRIPTION
When no start timestamp was selected for wallet with only empty accounts, it threw range error. This was because `getTimestampsInTimeFrame` would receive equal start date and end date. This can happen only if user has no account with txn history at all.  

So in such case I check and change the start date to 1y ago, to work the same as when such option(1y) is  selected.


## Related Issue

Resolve #14502

## Screenshots:
<img width=300 src="https://github.com/user-attachments/assets/a5bbfcc8-bcb4-4d3a-a54d-e5d9b0dcbbad" />
