### PR TITLE
fix(suite): header alignment in accounts menu

### DIFF
--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountGroup.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountGroup.tsx
@@ -6,6 +6,8 @@ import { Account } from 'src/types/wallet';
 import { AnimationWrapper } from '../../AnimationWrapper';
 import { spacingsPx, spacings, typography } from '@trezor/theme';
 
+const ICON_SIZE = 18;
+
 const IconWrapper = styled.div<{ $isActive: boolean }>`
     padding: ${spacingsPx.xs};
     border-radius: 50%;
@@ -20,7 +22,7 @@ const Header = styled.header<{ $isOpen: boolean; onClick?: () => void }>`
     top: 0;
     z-index: 30;
     display: flex;
-    gap: ${spacings.sm - 2}px;
+    gap: ${spacings.sm - 1}px;
     padding: 0 ${spacingsPx.sm};
     cursor: ${props => (props.onClick ? 'pointer' : 'default')};
     background-color: ${({ theme }) => theme.backgroundSurfaceElevationNegative};
@@ -38,7 +40,7 @@ const Header = styled.header<{ $isOpen: boolean; onClick?: () => void }>`
 
 const HeadingWrapper = styled.div`
     &:only-child {
-        padding-left: ${spacingsPx.xxs};
+        padding-left: ${spacings.sm + spacings.md + ICON_SIZE - 1}px;
     }
 `;
 
@@ -113,7 +115,7 @@ export const AccountGroup = ({
                         <IconWrapper $isActive={isOpen}>
                             <Icon
                                 data-testid="@account-menu/arrow"
-                                size={18}
+                                size={ICON_SIZE}
                                 variant="tertiary"
                                 name="chevronDown"
                             />


### PR DESCRIPTION
## Screenshots:

### Before
<img width="333" alt="Screenshot 2024-09-24 at 14 02 29" src="https://github.com/user-attachments/assets/58c1943f-f400-4248-8d65-73ad780744f8">

### After
<img width="333" alt="Screenshot 2024-09-24 at 14 01 29" src="https://github.com/user-attachments/assets/4211a3b6-a674-4721-8c82-688335b0e78f">

