### PR TITLE
Refactor `QrScannerModal`, remove unused `allowPaste` prop

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
@@ -99,13 +99,7 @@ export const UserContextModal = ({
         case 'firmware-revision-opt-out':
             return <FirmwareRevisionOptOutModal onCancel={onCancel} />;
         case 'qr-reader':
-            return (
-                <QrScannerModal
-                    decision={payload.decision}
-                    allowPaste={payload.allowPaste}
-                    onCancel={onCancel}
-                />
-            );
+            return <QrScannerModal decision={payload.decision} onCancel={onCancel} />;
         case 'transaction-detail':
             return <TxDetailModal {...payload} onCancel={onCancel} />;
         case 'passphrase-duplicate':

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3196,10 +3196,6 @@ export default defineMessages({
         description: 'Title for the Scan QR modal dialog',
         id: 'TR_SCAN_QR_CODE',
     },
-    TR_PASTE_URI: {
-        defaultMessage: 'Paste URI',
-        id: 'TR_PASTE_URI',
-    },
     TR_YOUR_WALLET_SUCCESSFULLY_CREATED: {
         defaultMessage: 'Wallet successfully created',
         id: 'TR_YOUR_WALLET_SUCCESSFULLY_CREATED',

--- a/suite-common/suite-types/src/modal.ts
+++ b/suite-common/suite-types/src/modal.ts
@@ -8,7 +8,6 @@ export type UserContextPayload =
     | {
           type: 'qr-reader';
           decision: Deferred<string>;
-          allowPaste?: boolean;
       }
     | {
           type: 'unverified-address';


### PR DESCRIPTION
## Description
Refactoring I made as a preparation for https://github.com/trezor/trezor-suite/issues/13460. The `allowPaste` prop was not used. Removing some legacy styling.

**QA:** Just refactoring and design update (see pictures below).