### PR TITLE
Finetune install connect test

### DIFF
--- a/.github/workflows/test-misc.yml
+++ b/.github/workflows/test-misc.yml
@@ -62,8 +62,10 @@ jobs:
         with:
           submodules: true
 
-      - run: ./packages/connect/e2e/test-npm-install.sh
-      - run: ./packages/connect/e2e/test-yarn-install.sh
+      - run: ./packages/connect/e2e/test-npm-install.sh beta
+      - run: ./packages/connect/e2e/test-npm-install.sh latest
+      - run: ./packages/connect/e2e/test-yarn-install.sh beta
+      - run: ./packages/connect/e2e/test-yarn-install.sh latest
 
   test-unit:
     runs-on: ubuntu-latest

--- a/packages/connect-explorer/package.json
+++ b/packages/connect-explorer/package.json
@@ -14,7 +14,7 @@
     "dependencies": {
         "@codemirror/state": "^6.4.1",
         "@hbsnow/rehype-sectionize": "^1.0.7",
-        "@sinclair/typebox": "^0.33.7",
+        "@sinclair/typebox": "^0.33.12",
         "@trezor/components": "workspace:^",
         "@trezor/connect": "workspace:^",
         "@trezor/connect-explorer-theme": "workspace:^",

--- a/packages/connect/e2e/test-npm-install.sh
+++ b/packages/connect/e2e/test-npm-install.sh
@@ -13,11 +13,10 @@ mkdir connect-implementation
 cd connect-implementation
 npm init -y
 npm install tslib --save # peer dependency
-npm install @trezor/connect --save
-npm install @trezor/connect-web --save
+npm install @trezor/connect@"$1" --save
+npm install @trezor/connect-web@"$1" --save
 
 cat package.json
 
-echo "const TrezorConnect = require('@trezor/connect')" > ./index.js
+echo "const TrezorConnect = require('@trezor/connect')" >./index.js
 node index.js
-

--- a/packages/connect/e2e/test-yarn-install.sh
+++ b/packages/connect/e2e/test-yarn-install.sh
@@ -21,5 +21,5 @@ yarn add @trezor/connect@"$1"
 echo import TrezorConnect from \"@trezor/connect\" >index.ts
 
 # compile with typescript
-yarn add typescript@5.3.2
-yarn tsc ./index.ts --types node --esModuleInterop
+yarn add typescript@5.5.4
+yarn tsc ./index.ts --types node --types w3c-web-usb --esModuleInterop

--- a/packages/connect/e2e/test-yarn-install.sh
+++ b/packages/connect/e2e/test-yarn-install.sh
@@ -16,9 +16,9 @@ npm init -y
 touch yarn.lock
 
 # install connect package
-yarn add @trezor/connect
+yarn add @trezor/connect@"$1"
 # prepare minimal typescript implementation
-echo import TrezorConnect from \"@trezor/connect\" > index.ts
+echo import TrezorConnect from \"@trezor/connect\" >index.ts
 
 # compile with typescript
 yarn add typescript@5.3.2

--- a/packages/connect/tsconfig.lib.json
+++ b/packages/connect/tsconfig.lib.json
@@ -26,9 +26,6 @@
             "path": "../protocol"
         },
         {
-            "path": "../schema-utils"
-        },
-        {
             "path": "../transport"
         },
         {

--- a/packages/protobuf/tsconfig.lib.json
+++ b/packages/protobuf/tsconfig.lib.json
@@ -4,9 +4,5 @@
         "outDir": "lib"
     },
     "include": ["./src"],
-    "references": [
-        {
-            "path": "../schema-utils"
-        }
-    ]
+    "references": []
 }

--- a/scripts/updateProjectReferences.ts
+++ b/scripts/updateProjectReferences.ts
@@ -18,9 +18,9 @@ const rootTsConfigLocation = path.join(__dirname, '..', 'tsconfig.json');
         .array('typings')
         .boolean('test') as any;
 
-    const readOnlyGlobs = argv.readOnly || [];
-    const ignoreGlobs = argv.ignore || [];
-    const typingPaths = argv.typings || [];
+    const readOnlyGlobs: string[] = argv.readOnly || [];
+    const ignoreGlobs: string[] = argv.ignore || [];
+    const typingPaths: string[] = argv.typings || [];
     const isTesting = argv.test || false;
 
     const rootConfig = JSON.parse(fs.readFileSync(rootTsConfigLocation).toString());
@@ -131,7 +131,11 @@ const rootTsConfigLocation = path.join(__dirname, '..', 'tsconfig.json');
                         fs.readFileSync(workspaceLibConfigPath).toString(),
                     );
 
-                    workspaceLibConfig.references = nextWorkspaceReferences;
+                    workspaceLibConfig.references = nextWorkspaceReferences.filter(
+                        // Don't include reference to schema-utils due to issues with the @sinclair/typebox library
+                        // When using a reference it results in incorrect imports
+                        ({ path }) => path !== '../schema-utils',
+                    );
 
                     if (
                         !readOnlyGlobs.some((path: string) => minimatch(workspace.location, path))

--- a/yarn.lock
+++ b/yarn.lock
@@ -8201,13 +8201,13 @@ __metadata:
   linkType: hard
 
 "@sinclair/typebox-codegen@npm:^0.10.4":
-  version: 0.10.4
-  resolution: "@sinclair/typebox-codegen@npm:0.10.4"
+  version: 0.10.5
+  resolution: "@sinclair/typebox-codegen@npm:0.10.5"
   dependencies:
     "@sinclair/typebox": "npm:^0.33.1"
     prettier: "npm:^2.8.7"
     typescript: "npm:^5.4.5"
-  checksum: 10/31b0096221082fec84d07d12d57a5a013f1eb0c1b59534c3c7f15f504d4469fc191388c2fc53898ca94ed16a1d4218fd6975e3d88833b06bbe4eb4d668480b9f
+  checksum: 10/99d3a370735b42f875297bc707fdbb6925d4151a297963a62e6a1721dd2ffebd925ebda146fac646ee3b59351d29cf58f25fb287ecc9a940010e902744af2592
   languageName: node
   linkType: hard
 
@@ -8218,10 +8218,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sinclair/typebox@npm:^0.33.1, @sinclair/typebox@npm:^0.33.7":
-  version: 0.33.9
-  resolution: "@sinclair/typebox@npm:0.33.9"
-  checksum: 10/0ff01966523bf346f1294b3301c998ab9b304dfb518f06466f6a70bc1ccd956e37a93d9c800e9f86e3b056bbfa61865783be2d73700dbbe7d2f897b00b8d2dd6
+"@sinclair/typebox@npm:^0.33.1, @sinclair/typebox@npm:^0.33.12, @sinclair/typebox@npm:^0.33.7":
+  version: 0.33.12
+  resolution: "@sinclair/typebox@npm:0.33.12"
+  checksum: 10/3b868a540480a914fb05e939fd875f1db9d078671038786394d8ac21f1cb12f2e5e25f0cc1092925f613821d0a959a14c8c8ad35a4064639822ce5f7b83ce380
   languageName: node
   linkType: hard
 
@@ -11226,7 +11226,7 @@ __metadata:
   dependencies:
     "@codemirror/state": "npm:^6.4.1"
     "@hbsnow/rehype-sectionize": "npm:^1.0.7"
-    "@sinclair/typebox": "npm:^0.33.7"
+    "@sinclair/typebox": "npm:^0.33.12"
     "@trezor/components": "workspace:^"
     "@trezor/connect": "workspace:^"
     "@trezor/connect-explorer-theme": "workspace:^"


### PR DESCRIPTION
there is a [test](https://github.com/trezor/trezor-suite/actions/runs/11024014375/job/30616416523) that connect is installable from npm, types work, and we didn't screw up. 

the problem is that it is now falling in CI so we might have screwed up actually. 


to get this information earlier, I suggest extending it also to beta channel. 

the problem is that I don't understand what is going on there right now. Maybe @martykan got some clue 

<img width="931" alt="image" src="https://github.com/user-attachments/assets/435fc0cd-1b70-4225-ab90-b6168fa94339">