### PR TITLE
Fix/support chat url

### DIFF
--- a/packages/suite/src/components/suite/SecurityCheck/SecurityCheckFail.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/SecurityCheckFail.tsx
@@ -1,8 +1,9 @@
 import styled from 'styled-components';
 
+import { TranslationKey } from '@suite-common/intl-types';
 import { Button, Divider, H2, Row, Text } from '@trezor/components';
 import { spacings, spacingsPx } from '@trezor/theme';
-import { TREZOR_SUPPORT_FW_CHECK_FAILED } from '@trezor/urls';
+import { TREZOR_SUPPORT_FW_CHECK_FAILED, Url } from '@trezor/urls';
 
 import { Translation } from 'src/components/suite';
 import { SecurityChecklist } from '../../../views/onboarding/steps/SecurityCheck/SecurityChecklist';
@@ -33,20 +34,20 @@ const checklistItems = [
     },
 ] as const;
 
-const supportChatUrl = `${TREZOR_SUPPORT_FW_CHECK_FAILED}#open-chat`;
-
 interface SecurityCheckFailProps {
     goBack?: () => void;
-    useSoftMessaging?: boolean;
+    heading?: TranslationKey;
+    text?: TranslationKey;
+    supportUrl?: Url;
 }
 
-export const SecurityCheckFail = ({ goBack, useSoftMessaging }: SecurityCheckFailProps) => {
-    const heading = useSoftMessaging
-        ? 'TR_DEVICE_COMPROMISED_HEADING_SOFT'
-        : 'TR_DEVICE_COMPROMISED_HEADING';
-    const text = useSoftMessaging
-        ? 'TR_DEVICE_COMPROMISED_TEXT_SOFT'
-        : 'TR_DEVICE_COMPROMISED_TEXT';
+export const SecurityCheckFail = ({
+    goBack,
+    heading = 'TR_DEVICE_COMPROMISED_HEADING',
+    text = 'TR_DEVICE_COMPROMISED_TEXT',
+    supportUrl = TREZOR_SUPPORT_FW_CHECK_FAILED,
+}: SecurityCheckFailProps) => {
+    const chatUrl = `${supportUrl}#open-chat`;
 
     return (
         <SecurityCheckLayout isFailed>
@@ -67,7 +68,7 @@ export const SecurityCheckFail = ({ goBack, useSoftMessaging }: SecurityCheckFai
                     </Button>
                 )}
                 <Flex>
-                    <Button href={supportChatUrl} isFullWidth size="large">
+                    <Button href={chatUrl} isFullWidth size="large">
                         <Translation id="TR_CONTACT_TREZOR_SUPPORT" />
                     </Button>
                 </Flex>

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheck.tsx
@@ -6,7 +6,12 @@ import { AcquiredDevice } from '@suite-common/suite-types';
 import { deviceActions, selectDevice, selectDevices } from '@suite-common/wallet-core';
 import { Button, Column, Icon, H2, Text, Tooltip, Divider } from '@trezor/components';
 import { spacings, spacingsPx, typography } from '@trezor/theme';
-import { TREZOR_RESELLERS_URL, TREZOR_URL } from '@trezor/urls';
+import {
+    TREZOR_RESELLERS_URL,
+    TREZOR_SUPPORT_FW_ALREADY_INSTALLED,
+    TREZOR_SUPPORT_IS_MY_DEVICE_SAFE,
+    TREZOR_URL,
+} from '@trezor/urls';
 
 import { goto } from 'src/actions/suite/routerActions';
 import { useDispatch, useLayoutSize, useOnboarding, useSelector } from 'src/hooks/suite';
@@ -170,6 +175,9 @@ const SecurityCheckContent = ({
     const headingText = isFirmwareInstalled
         ? 'TR_USED_TREZOR_BEFORE'
         : 'TR_ONBOARDING_DEVICE_CHECK';
+    const supportUrl = isFirmwareInstalled
+        ? TREZOR_SUPPORT_FW_ALREADY_INSTALLED
+        : TREZOR_SUPPORT_IS_MY_DEVICE_SAFE;
 
     const checklistItems = isFirmwareInstalled
         ? firmwareInstalledChecklist
@@ -199,7 +207,12 @@ const SecurityCheckContent = ({
     }, [initialized, isRecoveryInProgress, updateAnalytics]);
 
     return isFailed ? (
-        <SecurityCheckFail useSoftMessaging goBack={toggleView} />
+        <SecurityCheckFail
+            goBack={toggleView}
+            heading="TR_DEVICE_COMPROMISED_HEADING_SOFT"
+            text="TR_DEVICE_COMPROMISED_TEXT_SOFT"
+            supportUrl={supportUrl}
+        />
     ) : (
         <SecurityCheckLayout>
             <Column alignItems="flex-start">

--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -27,6 +27,10 @@ export const TREZOR_SUPPORT_RECOVERY_ISSUES_URL: Url =
     'https://trezor.io/support/a/trezor-recovery-issues';
 export const TREZOR_SUPPORT_FW_CHECK_FAILED: Url =
     'https://trezor.io/support/a/trezor-firmware-revision-check-failed';
+export const TREZOR_SUPPORT_FW_ALREADY_INSTALLED: Url =
+    'https://trezor.io/support/a/firmware-is-already-installed';
+export const TREZOR_SUPPORT_IS_MY_DEVICE_SAFE: Url =
+    'https://trezor.io/support/a/is-my-device-safe-to-use';
 
 export const HELP_CENTER_PIN_URL: Url =
     'https://trezor.io/learn/a/pin-protection-on-trezor-devices';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Pick correct support URL depending on situation.

- User has doubts about device packaging at the start f onboarding => https://trezor.io/support/a/is-my-device-safe-to-use
- Suite is fresh but device has firmware is already installed => https://trezor.io/support/a/firmware-is-already-installed
- A firmware revision or device authenticity check fails => https://trezor.io/support/a/trezor-firmware-revision-check-failed (temporarily redirected to https://trezor.io/support/a/firmware-is-already-installed)

## Screenshots:
![Screenshot 2024-09-25 at 12 09 53](https://github.com/user-attachments/assets/48d130b0-f63b-4fe5-bb34-685657b160f6)

