### PR TITLE
Feat(suite): Enhance discreet mode

### DIFF
--- a/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
+++ b/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
@@ -14,6 +14,8 @@ import { isSignValuePositive } from '@suite-common/formatters';
 import { selectLanguage } from 'src/reducers/suite/suiteReducer';
 import { BlurUrls } from 'src/views/wallet/tokens/common/BlurUrls';
 
+import { RedactNumericalValue } from './RedactNumericalValue';
+
 const Container = styled.span`
     max-width: 100%;
 `;
@@ -82,13 +84,20 @@ export const FormattedCryptoAmount = ({
     if (isRawString) {
         const displayedSignValue = signValue ? `${isSignValuePositive(signValue) ? '+' : '-'}` : '';
 
-        return <>{`${displayedSignValue} ${formattedValue} ${formattedSymbol}`}</>;
+        return (
+            <>
+                {displayedSignValue} <RedactNumericalValue value={formattedValue} />{' '}
+                {formattedSymbol}
+            </>
+        );
     }
 
     const content = (
         <Container className={className}>
             {!!signValue && <Sign value={signValue} />}
-            <Value data-testid={dataTest}>{formattedValue}</Value>
+            <Value data-testid={dataTest}>
+                <RedactNumericalValue value={formattedValue} />
+            </Value>
             {formattedSymbol && (
                 <>
                     {' '}

--- a/packages/suite/src/components/suite/HiddenPlaceholder.tsx
+++ b/packages/suite/src/components/suite/HiddenPlaceholder.tsx
@@ -1,15 +1,18 @@
-import { ReactNode, useEffect, useRef, useState } from 'react';
+import { ReactNode, useLayoutEffect, useRef, useState } from 'react';
 import styled, { css } from 'styled-components';
 import { useSelector } from 'src/hooks/suite';
 import { selectIsDiscreteModeActive } from 'src/reducers/wallet/settingsReducer';
+import { RedactNumbersContext } from '@suite-common/wallet-utils';
 
-interface WrapperProps {
+type WrapperProps = {
     $intensity: number;
     $discreetMode: boolean;
-}
+    $minWidth?: number;
+};
 
 const Wrapper = styled.span<WrapperProps>`
     font-variant-numeric: tabular-nums;
+    display: inline-block;
 
     ${({ $intensity, $discreetMode }: WrapperProps) =>
         $discreetMode &&
@@ -21,29 +24,49 @@ const Wrapper = styled.span<WrapperProps>`
                 filter: none;
             }
         `}
+
+    ${({ $minWidth }: WrapperProps) =>
+        $minWidth &&
+        css`
+            min-width: ${$minWidth}px;
+        `}
 `;
 
-export interface HiddenPlaceholderProps {
+export type HiddenPlaceholderProps = {
     enforceIntensity?: number;
     children: ReactNode;
     className?: string;
     ['data-testid']?: string;
-}
+};
 
+/**
+ * Wrapper for sensitive information, which should be hidden in discreet mode.
+ * ATTENTION: this is only half of the functionality, see also RedactNumericalValue
+ *
+ * HiddenPlaceholder does following:
+ * 1) applies CSS blur, which is removed on hover
+ * 2) through RedactNumbersContext it passes information downstream, so the content itself can be redacted
+ * 3) to prevent flickering on hover, it upholds min-width of redacted content when it is uncovered
+ *
+ * Note: content cannot be changed centrally here, it's responsibility of downstream components,
+ * they may consume the context using useShouldRedactNumbers(), or use RedactNumericalValue helper
+ */
 export const HiddenPlaceholder = ({
     children,
     enforceIntensity,
     className,
-    ...rest
+    'data-testid': dataTestId,
 }: HiddenPlaceholderProps) => {
     const ref = useRef<HTMLSpanElement>(null);
     const [automaticIntensity, setAutomaticIntensity] = useState(10);
-    const discreetMode = useSelector(selectIsDiscreteModeActive);
+    const [wrapperMinWidth, setWrapperMinWidth] = useState<undefined | number>(undefined);
+    const [isHovered, setIsHovered] = useState(false);
 
-    useEffect(() => {
-        if (ref.current === null) {
-            return;
-        }
+    const discreetMode = useSelector(selectIsDiscreteModeActive);
+    const shouldRedactNumbers = discreetMode && !isHovered;
+
+    useLayoutEffect(() => {
+        if (ref.current === null) return;
 
         const fontSize = Number(
             window
@@ -54,15 +77,33 @@ export const HiddenPlaceholder = ({
         setAutomaticIntensity(fontSize / 5);
     }, []);
 
+    // we only need to handle the case when revealed content is smaller than redacted, not vice versa.
+    // in such case, onMouseEnter shrinks content, and it may immediately onMouseLeave even when cursor is still.
+    const onMouseEnter = () => {
+        setIsHovered(true);
+        if (ref?.current) {
+            setWrapperMinWidth(ref.current.getBoundingClientRect().width);
+        }
+    };
+    const onMouseLeave = () => {
+        setIsHovered(false);
+        setWrapperMinWidth(undefined);
+    };
+
     return (
         <Wrapper
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
             $discreetMode={discreetMode}
             $intensity={enforceIntensity !== undefined ? enforceIntensity : automaticIntensity}
+            $minWidth={wrapperMinWidth}
             className={className}
             ref={ref}
-            data-testid={rest['data-testid']}
+            data-testid={dataTestId}
         >
-            {children}
+            <RedactNumbersContext.Provider value={{ shouldRedactNumbers }}>
+                {children}
+            </RedactNumbersContext.Provider>
         </Wrapper>
     );
 };

--- a/packages/suite/src/components/suite/HiddenPlaceholder.tsx
+++ b/packages/suite/src/components/suite/HiddenPlaceholder.tsx
@@ -8,11 +8,12 @@ type WrapperProps = {
     $intensity: number;
     $discreetMode: boolean;
     $minWidth?: number;
+    $disableKeepingWidth?: boolean;
 };
 
 const Wrapper = styled.span<WrapperProps>`
     font-variant-numeric: tabular-nums;
-    display: inline-block;
+    display: inline;
 
     ${({ $intensity, $discreetMode }: WrapperProps) =>
         $discreetMode &&
@@ -25,9 +26,11 @@ const Wrapper = styled.span<WrapperProps>`
             }
         `}
 
-    ${({ $minWidth }: WrapperProps) =>
-        $minWidth &&
+    ${({ $minWidth, $disableKeepingWidth }: WrapperProps) =>
+        !!$minWidth &&
+        !$disableKeepingWidth &&
         css`
+            display: inline-block;
             min-width: ${$minWidth}px;
         `}
 `;
@@ -36,7 +39,8 @@ export type HiddenPlaceholderProps = {
     enforceIntensity?: number;
     children: ReactNode;
     className?: string;
-    ['data-testid']?: string;
+    disableKeepingWidth?: boolean;
+    'data-testid'?: string;
 };
 
 /**
@@ -55,6 +59,7 @@ export const HiddenPlaceholder = ({
     children,
     enforceIntensity,
     className,
+    disableKeepingWidth,
     'data-testid': dataTestId,
 }: HiddenPlaceholderProps) => {
     const ref = useRef<HTMLSpanElement>(null);
@@ -96,6 +101,7 @@ export const HiddenPlaceholder = ({
             onMouseLeave={onMouseLeave}
             $discreetMode={discreetMode}
             $intensity={enforceIntensity !== undefined ? enforceIntensity : automaticIntensity}
+            $disableKeepingWidth={disableKeepingWidth}
             $minWidth={wrapperMinWidth}
             className={className}
             ref={ref}

--- a/packages/suite/src/components/suite/RedactNumericalValue.tsx
+++ b/packages/suite/src/components/suite/RedactNumericalValue.tsx
@@ -1,0 +1,12 @@
+import { redactNumericalSubstring, useShouldRedactNumbers } from '@suite-common/wallet-utils';
+
+type RedactNumbersProps = {
+    value: string | number;
+};
+
+/**
+ * Helper that redacts sensitive content, if it should be hidden in discreet mode.
+ * It is effective only when wrapped by HiddenPlaceholder upstream.
+ */
+export const RedactNumericalValue = ({ value }: RedactNumbersProps) =>
+    useShouldRedactNumbers() ? redactNumericalSubstring(value) : value;

--- a/packages/suite/src/components/suite/index.tsx
+++ b/packages/suite/src/components/suite/index.tsx
@@ -27,6 +27,7 @@ import { FormattedNftAmount } from './FormattedNftAmount';
 import { Sign } from './Sign';
 import { TrezorLink } from './TrezorLink';
 import { ReadMoreLink } from './ReadMoreLink';
+import { RedactNumericalValue } from './RedactNumericalValue';
 import { Modal, ModalProps } from './modals/Modal/Modal';
 import { FormattedDate } from './FormattedDate';
 import { FormattedDateWithBullet } from './FormattedDateWithBullet';
@@ -81,6 +82,7 @@ export {
     PriceTicker,
     Sign,
     ReadMoreLink,
+    RedactNumericalValue,
     TrezorLink,
     Modal,
     FormattedDate,

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/IOAddress.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/IOAddress.tsx
@@ -93,8 +93,9 @@ export const IOAddress = ({
         return null;
     }
 
+    // HiddenPlaceholder disableKeepingWidth: it isn't needed (no numbers to redact), but inline-block disrupts overflow behavior
     return (
-        <HiddenPlaceholder>
+        <HiddenPlaceholder disableKeepingWidth>
             <TextOverflowContainer
                 onMouseLeave={() => setIsClicked(false)}
                 data-testid="@tx-detail/txid-value"

--- a/packages/suite/src/components/wallet/FiatHeader.tsx
+++ b/packages/suite/src/components/wallet/FiatHeader.tsx
@@ -1,6 +1,7 @@
 import { useFormatters } from '@suite-common/formatters';
 import { typography } from '@trezor/theme';
 import { HiddenPlaceholder } from 'src/components/suite';
+import { RedactNumericalValue } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
 import { selectLanguage } from 'src/reducers/suite/suiteReducer';
 import styled from 'styled-components';
@@ -47,10 +48,12 @@ export const FiatHeader = ({ size, fiatAmount, localCurrency }: FiatHeaderProps)
     return (
         <HiddenPlaceholder enforceIntensity={10}>
             <ValueWrapper>
-                <WholeValue $size={size}>{whole}</WholeValue>
+                <WholeValue $size={size}>
+                    <RedactNumericalValue value={whole} />
+                </WholeValue>
                 <DecimalValue $size={size}>
                     {separator}
-                    {fractional}
+                    <RedactNumericalValue value={fractional} />
                 </DecimalValue>
             </ValueWrapper>
         </HiddenPlaceholder>

--- a/packages/suite/src/components/wallet/FiatHeader.tsx
+++ b/packages/suite/src/components/wallet/FiatHeader.tsx
@@ -1,9 +1,11 @@
 import { useFormatters } from '@suite-common/formatters';
 import { typography } from '@trezor/theme';
+import { useShouldRedactNumbers } from '@suite-common/wallet-utils';
 import { HiddenPlaceholder } from 'src/components/suite';
 import { RedactNumericalValue } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
 import { selectLanguage } from 'src/reducers/suite/suiteReducer';
+import { PropsWithChildren } from 'react';
 import styled from 'styled-components';
 
 const ValueWrapper = styled.div`
@@ -26,11 +28,15 @@ const DecimalValue = styled.div<{ $size: 'large' | 'medium' }>`
     color: ${({ theme }) => theme.textSubdued};
 `;
 
-interface FiatHeaderProps {
+type FiatHeaderProps = {
     size: 'large' | 'medium';
     fiatAmount: string;
     localCurrency: string;
-}
+};
+
+// redacted value placeholder doesn't have to be displayed twice, display it only for whole value
+const HideRedactedValue = ({ children }: PropsWithChildren) =>
+    useShouldRedactNumbers() ? null : children;
 
 export const FiatHeader = ({ size, fiatAmount, localCurrency }: FiatHeaderProps) => {
     const language = useSelector(selectLanguage);
@@ -51,10 +57,12 @@ export const FiatHeader = ({ size, fiatAmount, localCurrency }: FiatHeaderProps)
                 <WholeValue $size={size}>
                     <RedactNumericalValue value={whole} />
                 </WholeValue>
-                <DecimalValue $size={size}>
-                    {separator}
-                    <RedactNumericalValue value={fractional} />
-                </DecimalValue>
+                <HideRedactedValue>
+                    <DecimalValue $size={size}>
+                        {separator}
+                        {fractional}
+                    </DecimalValue>
+                </HideRedactedValue>
             </ValueWrapper>
         </HiddenPlaceholder>
     );

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokensTable.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokensTable.tsx
@@ -42,6 +42,10 @@ export const TokensTable = ({
 }: TokensTableProps) => {
     const [isZeroBalanceOpen, setIsZeroBalanceOpen] = useState(false);
 
+    // first two columns have fixed width, the rest have variable width
+    // in case of 2nd column, it's due to HiddenPlaceholder - it changes content width when hovered
+    const colWidths = ['250px', '250px'];
+
     return (
         <Card paddingType="none" overflow="hidden">
             {tokensWithBalance.length === 0 && tokensWithoutBalance.length === 0 && searchQuery ? (
@@ -53,7 +57,7 @@ export const TokensTable = ({
                     <Translation id="TR_NO_SEARCH_RESULTS" />
                 </Paragraph>
             ) : (
-                <Table margin={{ top: spacings.xs, bottom: spacings.xs }} colWidths={['250px']}>
+                <Table margin={{ top: spacings.xs, bottom: spacings.xs }} colWidths={colWidths}>
                     <Table.Header>
                         <Table.Row>
                             <Table.Cell>

--- a/packages/suite/src/views/wallet/transactions/components/SummaryCards.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/SummaryCards.tsx
@@ -9,6 +9,7 @@ import { variables } from '@trezor/components';
 import { InfoCard } from './InfoCard';
 import { AggregatedAccountHistory, GraphRange } from 'src/types/wallet/graph';
 import { sumFiatValueMap } from 'src/utils/wallet/graph';
+import { DISCREET_PLACEHOLDER, useShouldRedactNumbers } from '@suite-common/wallet-utils';
 
 const InfoCardsWrapper = styled.div`
     display: grid;
@@ -53,6 +54,13 @@ const DateWrapper = styled.span`
     white-space: nowrap;
 `;
 
+const NumberOfTransactions = ({ value }: { value: number }) => (
+    <Translation
+        id="TR_N_TRANSACTIONS"
+        values={{ value: useShouldRedactNumbers() ? DISCREET_PLACEHOLDER : value }}
+    />
+);
+
 export const SummaryCards = ({
     selectedRange,
     data,
@@ -84,7 +92,7 @@ export const SummaryCards = ({
                 isLoading={isLoading}
                 value={
                     <HiddenPlaceholder>
-                        <Translation id="TR_N_TRANSACTIONS" values={{ value: numOfTransactions }} />
+                        <NumberOfTransactions value={numOfTransactions} />
                     </HiddenPlaceholder>
                 }
                 secondaryValue={

--- a/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.ts
+++ b/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.ts
@@ -1,7 +1,11 @@
 import { A } from '@mobily/ts-belt';
 
 import { networks, NetworkSymbol } from '@suite-common/wallet-config';
-import { amountToSatoshi, formatAmount } from '@suite-common/wallet-utils';
+import {
+    amountToSatoshi,
+    formatAmount,
+    redactNumericalSubstring,
+} from '@suite-common/wallet-utils';
 import { PROTO } from '@trezor/connect';
 
 import { makeFormatter } from '../makeFormatter';
@@ -46,6 +50,7 @@ export const prepareCryptoAmountFormatter = (config: FormatterConfig) =>
                 maxDisplayedDecimals = 8,
                 isEllipsisAppended = true,
             },
+            shouldRedactNumbers,
         ) => {
             const { bitcoinAmountUnit } = config;
 
@@ -84,10 +89,10 @@ export const prepareCryptoAmountFormatter = (config: FormatterConfig) =>
             if (withSymbol) {
                 const NetworkSymbolFormatter = prepareNetworkSymbolFormatter(config);
 
-                return `${formattedValue} ${NetworkSymbolFormatter.format(symbol!)}`;
+                formattedValue = `${formattedValue} ${NetworkSymbolFormatter.format(symbol!)}`;
             }
 
-            return formattedValue;
+            return shouldRedactNumbers ? redactNumericalSubstring(formattedValue) : formattedValue;
         },
         'CryptoAmountFormatter',
     );

--- a/suite-common/formatters/src/formatters/prepareFiatAmountFormatter.ts
+++ b/suite-common/formatters/src/formatters/prepareFiatAmountFormatter.ts
@@ -10,34 +10,41 @@ export type FiatAmountFormatterDataContext<T> = {
     [K in keyof T]: T[K];
 };
 
+const handleBigNumberFormatting = (
+    value: string | number,
+    dataContext: FiatAmountFormatterDataContext<FormatNumberOptions>,
+    config: FormatterConfig,
+) => {
+    const { intl, fiatCurrency } = config;
+    const { style, currency, minimumFractionDigits, maximumFractionDigits } = dataContext;
+    const fiatValue = new BigNumber(value);
+    const currencyForDisplay = currency ?? fiatCurrency;
+
+    if (fiatValue.gt(Number.MAX_SAFE_INTEGER)) {
+        return `${value} ${currencyForDisplay}`;
+    }
+
+    return intl.formatNumber(fiatValue.toNumber(), {
+        ...dataContext,
+        style: style || 'currency',
+        currency: currencyForDisplay,
+        minimumFractionDigits: minimumFractionDigits ?? 2,
+        maximumFractionDigits: maximumFractionDigits ?? 2,
+    });
+};
+
 export const prepareFiatAmountFormatter = (config: FormatterConfig) =>
     makeFormatter<
         string | number,
         string | null,
         FiatAmountFormatterDataContext<FormatNumberOptions>
     >((value, dataContext, shouldRedactNumbers) => {
-        const { intl, fiatCurrency } = config;
-        const { style, currency, minimumFractionDigits, maximumFractionDigits } = dataContext;
         const fiatValue = new BigNumber(value);
-        const currencyForDisplay = currency ?? fiatCurrency;
-
         if (fiatValue.isNaN()) {
             return null;
         }
 
-        let formattedValue: string = '';
-
-        if (fiatValue.gt(Number.MAX_SAFE_INTEGER)) {
-            formattedValue = `${value} ${currencyForDisplay}`;
-        } else {
-            formattedValue = intl.formatNumber(fiatValue.toNumber(), {
-                ...dataContext,
-                style: style || 'currency',
-                currency: currencyForDisplay,
-                minimumFractionDigits: minimumFractionDigits ?? 2,
-                maximumFractionDigits: maximumFractionDigits ?? 2,
-            });
-        }
+        const formattedValue = handleBigNumberFormatting(value, dataContext, config);
 
         return shouldRedactNumbers ? redactNumericalSubstring(formattedValue) : formattedValue;
     }, 'FiatAmountFormatter');

--- a/suite-common/formatters/src/makeFormatter.tsx
+++ b/suite-common/formatters/src/makeFormatter.tsx
@@ -1,3 +1,5 @@
+import { useShouldRedactNumbers } from '@suite-common/wallet-utils';
+
 export type DataContext = Record<string, unknown>;
 
 interface FormatDefinition<TInput, TOutput, TDataContext extends DataContext> {
@@ -6,6 +8,8 @@ interface FormatDefinition<TInput, TOutput, TDataContext extends DataContext> {
         value: TInput,
         /** Additional data context to be used by the formatter. */
         dataContext: Partial<TDataContext>,
+        /** Whether a component above has requested to redact the numbers for discreet mode */
+        shouldRedactNumbers?: boolean,
     ): TOutput;
 }
 
@@ -40,11 +44,11 @@ export const makeFormatter = <TInput, TOutput, TDataContext extends DataContext 
     format: FormatDefinition<TInput, TOutput, TDataContext>,
     displayName = 'Formatter',
 ): Formatter<TInput, TOutput, TDataContext> => {
-    const formatter: Formatter<TInput, TOutput, TDataContext> = props =>
-        <>{format(props.value, props)}</> ?? null;
-    formatter.displayName = displayName;
+    const FormatterComponent: Formatter<TInput, TOutput, TDataContext> = props =>
+        <>{format(props.value, props, useShouldRedactNumbers())}</> ?? null;
+    FormatterComponent.displayName = displayName;
 
-    formatter.format = (value, dataContext = {}) => format(value, dataContext);
+    FormatterComponent.format = (value, dataContext = {}) => format(value, dataContext);
 
-    return formatter;
+    return FormatterComponent;
 };

--- a/suite-common/wallet-utils/src/__tests__/discreetModeUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/discreetModeUtils.test.ts
@@ -1,0 +1,28 @@
+import { DISCREET_PLACEHOLDER, redactNumericalSubstring } from '../discreetModeUtils';
+
+describe('redactNumericalSubstring', () => {
+    it('replaces sole number with placeholder', () => {
+        expect(redactNumericalSubstring(123)).toBe(DISCREET_PLACEHOLDER);
+        expect(redactNumericalSubstring('123')).toBe(DISCREET_PLACEHOLDER);
+        expect(redactNumericalSubstring('0.001234')).toBe(DISCREET_PLACEHOLDER);
+        expect(redactNumericalSubstring('-9,876,543.210001')).toBe(DISCREET_PLACEHOLDER);
+        expect(redactNumericalSubstring('-.1')).toBe(DISCREET_PLACEHOLDER);
+    });
+
+    it('redacts only the number, not an accompanying symboll', () => {
+        expect(redactNumericalSubstring('CZK 123')).toBe(`CZK ${DISCREET_PLACEHOLDER}`);
+        expect(redactNumericalSubstring('0.001234 BTC')).toBe(`${DISCREET_PLACEHOLDER} BTC`);
+        expect(redactNumericalSubstring('-9,876,543.210001€')).toBe(`${DISCREET_PLACEHOLDER}€`);
+    });
+
+    it('does not replace non-numerical strings', () => {
+        expect(redactNumericalSubstring('foo')).toBe('foo');
+        expect(redactNumericalSubstring('. , -.')).toBe('. , -.');
+    });
+
+    it('replaces multiple numerical substring', () => {
+        expect(redactNumericalSubstring('Selling 0.001234 BTC yields 123 CZK')).toBe(
+            `Selling ${DISCREET_PLACEHOLDER} BTC yields ${DISCREET_PLACEHOLDER} CZK`,
+        );
+    });
+});

--- a/suite-common/wallet-utils/src/discreetModeUtils.ts
+++ b/suite-common/wallet-utils/src/discreetModeUtils.ts
@@ -1,0 +1,30 @@
+import { createContext, useContext } from 'react';
+
+export const DISCREET_PLACEHOLDER = '###';
+
+const numericalSubstringRegex = /[\d\-.,]*\d+[.\d]*/g;
+/**
+ * Search the input for all numerical substrings and replace them with DISCREET_PLACEHOLDER.
+ * @param value whole string value, usually number with symbol, or just number
+ * @returns redacted string
+ */
+export const redactNumericalSubstring = (value: string | number): string =>
+    String(value).replace(numericalSubstringRegex, DISCREET_PLACEHOLDER);
+
+type RedactNumbersContextData = { shouldRedactNumbers: boolean };
+
+/**
+ * Context to inform all components in tree below that they should redact numbers in the displayed output.
+ */
+export const RedactNumbersContext = createContext<RedactNumbersContextData>({
+    shouldRedactNumbers: false,
+});
+
+/**
+ * Determine whether we are under a component which currently requests to redact the numbers for discreet mode.
+ * It may only return true if the component is wrapped in HiddenPlaceholder upstream.
+ * See also a helper RedactNumericalValue
+ * @returns shouldRedactNumbers whether numbers should be redacted in displayed output
+ */
+export const useShouldRedactNumbers = () =>
+    useContext(RedactNumbersContext)?.shouldRedactNumbers ?? false;

--- a/suite-common/wallet-utils/src/index.ts
+++ b/suite-common/wallet-utils/src/index.ts
@@ -3,6 +3,7 @@ export * from './backendUtils';
 export * from './balanceUtils';
 export * from './cardanoUtils';
 export * from './csvParserUtils';
+export * from './discreetModeUtils';
 export * from './ethUtils';
 export * from './fiatConverterUtils';
 export * from './fiatRatesUtils';


### PR DESCRIPTION
Discreet mode currently leaves numerical values blurred, but technically still possible to decypher.
Enhance it to actually replace the characters with `###`, making them completely illegible.

## Description

**Most of stuff done in 1035518754db3258f5e38c272b97a46f17151e5f:**

- HiddenPlaceholder now creates a context to inform components downstream that they should redact numbers
  - unfortunately it has to be responsibility of downstream components to change the content to `###`.
  - I attempted a centralized solution in [#13914](https://github.com/trezor/trezor-suite/pull/13914), and it was a dead-end :disappointed: 
- create helpers `RedactNumericalValue` and `useShouldRedactNumbers', utilize them in several such components
  - update it in `formatters`, `FiatHeader`, `FormattedCryptoAmounts`, `SummaryCards`
  - some of those components are broadly used, and may not be used within `HiddenPlaceholder` at all
  - but _if they are_ under downstream of `HiddenPlaceholder`, they will now redact numbers

**Tweaks:**
- 654893c82f4ed513ce3a4328b4bea5d65e96c47c Slightly refactor `FiatHeader` so it displays `###` only once, not twice
- 130d6c94e673211c3ed920d05a80d670c93d72e3 Allow `disableKeepingWidth`, because in order for it to work, it needs   `display:inline-block`, but that breaks text overflow in `TxDetailModal/IOAddress.tsx` (also it's unnecessary there)

**Occurrences:**

I verified all of the usages of `HiddenPlaceholder`, and _on main parts_ of the app they now do the `###`, not just blur :heavy_check_mark:

Still not done in some less mission-critical components, can be done subsequently: :construction:
[CardanoRewards](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/staking/components/CardanoRewards.tsx), [CoinmarketBalance](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/coinmarket/common/CoinmarketBalance.tsx), [CoinmarketFormInputAccountOption](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputAccountOption.tsx), [SellTransaction](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketAccountTransactions/SellTransaction.tsx), [BuyTransaction](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketAccountTransactions/BuyTransaction.tsx)

## Related Issue

Resolve #10567

## Screenshots:

Video showing it in action with hover behavior.
This is without cad5c662dabdf3c7eb7ca14271fcefe400e1e220, so blur is toned down, and bg is applied so you can see the widths..
EDIT: sry the video is outdated 🤦‍♂️ the "7 transactions" are now "### transactions"

[discreet.webm](https://github.com/user-attachments/assets/7e6f08c1-f124-455a-b2ee-78572c5ac940)
