### PR TITLE
chore(suite-native): build develop only on native change

### DIFF
--- a/.github/workflows/release-suite-native-develop.yml
+++ b/.github/workflows/release-suite-native-develop.yml
@@ -9,16 +9,13 @@ on:
       - "suite-common/**"
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   build:
     if: github.repository == 'trezor/trezor-suite' || github.repository == 'trezor/trezor-suite-private'
     name: Install and build
     environment: develop-suite-native
     runs-on: ubuntu-latest
+    concurrency: fingerprint-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
     env:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
@@ -34,16 +31,20 @@ jobs:
           token: ${{ secrets.EXPO_TOKEN }}
       - name: Install libs
         run: yarn workspaces focus @suite-native/app
-      - name: Build on EAS Android
-        run: eas build
+      - name: Build on EAS Android if fingerprint changed
+        uses: expo/expo-github-action/preview-build@main
+        with:
+          command: eas build
           --platform android
           --profile develop
           --non-interactive
           --no-wait
           --message ${{ github.sha }}
         working-directory: suite-native/app
-      - name: Build on EAS iOS
-        run: eas build
+      - name: Build on EAS iOS if fingerprint changed
+        uses: expo/expo-github-action/preview-build@main
+        with:
+          command: eas build
           --platform ios
           --profile develop
           --non-interactive
@@ -51,3 +52,11 @@ jobs:
           --no-wait
           --message ${{ github.sha }}
         working-directory: suite-native/app
+      - name: Create preview update
+        uses: expo/expo-github-action/preview@v8
+        working-directory: suite-native/app
+        with:
+          command: eas update
+          --branch develop 
+          --channel develop 
+          -message ${{ github.sha }}

--- a/.github/workflows/release-suite-native-preview-update.yml
+++ b/.github/workflows/release-suite-native-preview-update.yml
@@ -1,0 +1,49 @@
+name: "[Release] suite-native preview update"
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    paths:
+      - "suite-native/**"
+      - "suite-common/**"
+  workflow_dispatch:
+
+  jobs:
+    update:
+      if: github.repository == 'trezor/trezor-suite' || github.repository == 'trezor/trezor-suite-private'
+    name: EAS Update
+    environment: develop-suite-native
+    runs-on: ubuntu-latest
+    concurrency: fingerprint-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    env:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: yarn
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+      - name: Install libs
+        run: yarn workspaces focus @suite-native/app
+
+      - name: Create preview builds if fingerprint changed
+        uses: expo/expo-github-action/preview-build@main
+        working-directory: suite-native/app
+        with:
+          command: eas build --profile preview --platform all --non-interactive --no-wait
+
+      - name: Create preview update
+        uses: expo/expo-github-action/preview@v8
+        working-directory: suite-native/app
+        with:
+          command: eas update --auto

--- a/scripts/list-outdated-dependencies/mobile-dependencies.txt
+++ b/scripts/list-outdated-dependencies/mobile-dependencies.txt
@@ -47,6 +47,7 @@ expo-secure-store
 expo-splash-screen
 expo-status-bar
 expo-system-ui
+expo-updates
 jotai
 lottie-react-native
 react-native-gesture-handler

--- a/suite-native/app/.fingerprintignore
+++ b/suite-native/app/.fingerprintignore
@@ -1,0 +1,3 @@
+ios/**/*
+
+!ios/Podfile.lock

--- a/suite-native/app/app.config.ts
+++ b/suite-native/app/app.config.ts
@@ -153,6 +153,16 @@ export default ({ config }: ConfigContext): ExpoConfig => {
         slug: appSlugs[buildType],
         owner: 'trezorcompany',
         version: suiteNativeVersion,
+        runtimeVersion: {
+            policy: 'fingerprint',
+        },
+        ...(buildType === 'develop'
+            ? {
+                  updates: {
+                      url: `https://u.expo.dev/${projectId}`,
+                  },
+              }
+            : {}),
         orientation: 'portrait',
         splash: {
             image: './assets/splash_icon.png',

--- a/suite-native/app/eas.json
+++ b/suite-native/app/eas.json
@@ -20,6 +20,16 @@
                 "resourceClass": "large"
             }
         },
+        "preview": {
+            "env": {
+                "EXPO_PUBLIC_ENVIRONMENT": "develop",
+                "EXPO_PUBLIC_CODESIGN_BUILD": "false"
+            },
+            "autoIncrement": true,
+            "developmentClient": true,
+            "credentialsSource": "remote",
+            "distribution": "internal"
+        },
         "production": {
             "env": {
                 "EXPO_PUBLIC_ENVIRONMENT": "production",

--- a/suite-native/app/eas.json
+++ b/suite-native/app/eas.json
@@ -10,6 +10,7 @@
                 "EXPO_PUBLIC_ENVIRONMENT": "develop",
                 "EXPO_PUBLIC_CODESIGN_BUILD": "false"
             },
+            "channel": "develop",
             "autoIncrement": true,
             "ios": {
                 "distribution": "store"

--- a/suite-native/app/eas.json
+++ b/suite-native/app/eas.json
@@ -12,6 +12,7 @@
             },
             "channel": "develop",
             "autoIncrement": true,
+            "developmentClient": true,
             "ios": {
                 "distribution": "store"
             },

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -94,6 +94,7 @@
         "expo-splash-screen": "0.27.5",
         "expo-status-bar": "1.12.1",
         "expo-system-ui": "3.0.7",
+        "expo-updates": "0.25.24",
         "lottie-react-native": "6.7.2",
         "node-libs-browser": "^2.2.1",
         "react": "18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3947,6 +3947,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@expo/fingerprint@npm:^0.10.2":
+  version: 0.10.3
+  resolution: "@expo/fingerprint@npm:0.10.3"
+  dependencies:
+    "@expo/spawn-async": "npm:^1.7.2"
+    chalk: "npm:^4.1.2"
+    debug: "npm:^4.3.4"
+    find-up: "npm:^5.0.0"
+    minimatch: "npm:^3.0.4"
+    p-limit: "npm:^3.1.0"
+    resolve-from: "npm:^5.0.0"
+    semver: "npm:^7.6.0"
+  bin:
+    fingerprint: bin/cli.js
+  checksum: 10/fc39ed83ac9e2c9f9c9903f85ca5bb3b920740ffaa6b2a742af6563c1bec431b4c56c20f595c0b9931cf645e952dcc2f5deba948b60deacde510e695f27000f6
+  languageName: node
+  linkType: hard
+
 "@expo/fingerprint@npm:^0.6.0":
   version: 0.6.0
   resolution: "@expo/fingerprint@npm:0.6.0"
@@ -9618,6 +9636,7 @@ __metadata:
     expo-splash-screen: "npm:0.27.5"
     expo-status-bar: "npm:1.12.1"
     expo-system-ui: "npm:3.0.7"
+    expo-updates: "npm:0.25.24"
     jest: "npm:^29.7.0"
     lottie-react-native: "npm:6.7.2"
     metro: "npm:0.80.11"
@@ -15009,6 +15028,13 @@ __metadata:
   version: 1.0.0
   resolution: "arg@npm:1.0.0"
   checksum: 10/a4cbea033cee9a5ff0be251d5fe8e18db23c22c80c3ea5effe2ee8cbf0b9a93cbffa466cb63b6325b2f87485326219b6080fa038a630ec97d20b6d9918980309
+  languageName: node
+  linkType: hard
+
+"arg@npm:4.1.0":
+  version: 4.1.0
+  resolution: "arg@npm:4.1.0"
+  checksum: 10/dc0e1ea7f0adee7871c456bd57f06fb9f8c2ccd91fd0537c73b66f3fa0c9697ccdfc25b358a417a3ab263c062aac0ef2df3a5523433861fe6277cb2ff769a9bc
   languageName: node
   linkType: hard
 
@@ -22323,6 +22349,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expo-eas-client@npm:~0.12.0":
+  version: 0.12.0
+  resolution: "expo-eas-client@npm:0.12.0"
+  checksum: 10/84f9f00fc7343e1ef38499a8c09644435bac5c09cf6f0c62386dbeaf506062ece82959a8216e2e0765cf3d8ac165548babb0d9e3b012cf560c7becb0409e67b0
+  languageName: node
+  linkType: hard
+
 "expo-file-system@npm:~17.0.1":
   version: 17.0.1
   resolution: "expo-file-system@npm:17.0.1"
@@ -22505,6 +22538,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expo-structured-headers@npm:~3.8.0":
+  version: 3.8.0
+  resolution: "expo-structured-headers@npm:3.8.0"
+  checksum: 10/8d723dc76e96e4190469695e9a2a833a66eb908689cb63aac244f67ff63d2d111b761592ce9f50d67d12bcd38f31cc5bf385fc582a37c51bd0aef379e4ec451a
+  languageName: node
+  linkType: hard
+
 "expo-system-ui@npm:3.0.7":
   version: 3.0.7
   resolution: "expo-system-ui@npm:3.0.7"
@@ -22523,6 +22563,33 @@ __metadata:
   peerDependencies:
     expo: "*"
   checksum: 10/2a86ec6d001b75a5788970e01bbcc9d8fb5afe228bb7b38035282b6c381dbb87d5dc21fb36d4260f63d5cb13f060e0af86dc79b5f880310398d0870ca96e7c2c
+  languageName: node
+  linkType: hard
+
+"expo-updates@npm:0.25.24":
+  version: 0.25.24
+  resolution: "expo-updates@npm:0.25.24"
+  dependencies:
+    "@expo/code-signing-certificates": "npm:0.0.5"
+    "@expo/config": "npm:~9.0.0-beta.0"
+    "@expo/config-plugins": "npm:~8.0.8"
+    "@expo/fingerprint": "npm:^0.10.2"
+    "@expo/spawn-async": "npm:^1.7.2"
+    arg: "npm:4.1.0"
+    chalk: "npm:^4.1.2"
+    expo-eas-client: "npm:~0.12.0"
+    expo-manifests: "npm:~0.14.0"
+    expo-structured-headers: "npm:~3.8.0"
+    expo-updates-interface: "npm:~0.16.2"
+    fast-glob: "npm:^3.3.2"
+    fbemitter: "npm:^3.0.0"
+    ignore: "npm:^5.3.1"
+    resolve-from: "npm:^5.0.0"
+  peerDependencies:
+    expo: "*"
+  bin:
+    expo-updates: bin/cli.js
+  checksum: 10/b283c7bb648538aba0213a6738d2a47e534506481f44a70083cfe23c2352c2043a2279dc2802a4badd365949320de1920b0433254da2ebb75d7fd83b8f926a0e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Do develop native build only if necessary to save builds on EAS. Keep it distributed via Firebase/Testflight so we don't need to register every ios device.

## Related Issue

Followup of https://github.com/trezor/trezor-suite/pull/14530
Resolve https://github.com/trezor/trezor-suite/issues/14467

