### PR TITLE
fix(suite-desktop): fix bridge controls in debug menu

### DIFF
--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -18,7 +18,7 @@ import { clearAppCache, initUserData } from './libs/user-data';
 import { initSentry } from './libs/sentry';
 import { initModules, mainThreadEmitter } from './modules';
 import { init as initTorModule } from './modules/tor';
-import { init as initBridgeModule } from './modules/bridge';
+import { init as initBridgeModule, initUi as initBridgeUi } from './modules/bridge';
 import { createInterceptor } from './libs/request-interceptor';
 import { hangDetect } from './hang-detect';
 import { Logger } from './libs/logger';
@@ -181,6 +181,13 @@ const initUi = async ({
     // init modules
     const interceptor = createInterceptor();
     const { loadModules, quitModules } = initModules({
+        mainWindowProxy,
+        store,
+        interceptor,
+        mainThreadEmitter,
+    });
+    // TODO: each module probably should have 2 exports - one to be initiated in the main layer and one to be initiated in UI layer?
+    initBridgeUi({
         mainWindowProxy,
         store,
         interceptor,

--- a/packages/suite/src/views/settings/SettingsDebug/TransportBackends.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/TransportBackends.tsx
@@ -18,6 +18,7 @@ const NEW_BRIDGE_ROLLOUT_THRESHOLD = 0;
 
 export const TransportBackends = () => {
     const allowPrerelease = useSelector(state => state.desktopUpdate.allowPrerelease);
+    const transport = useSelector(state => state.suite.transport);
     const [bridgeProcess, setBridgeProcess] = useState<Process>({ service: false, process: false });
     const [bridgeSettings, setBridgeSettings] = useState<BridgeSettings | null>(null);
     const [error, setError] = useState<string | null>(null);
@@ -68,10 +69,15 @@ export const TransportBackends = () => {
                 />
             </SectionItem>
             <SectionItem data-testid="@settings/debug/processes/Bridge">
-                <TextColumn title="Bridge running" />
+                <TextColumn
+                    title="Bridge server"
+                    description={
+                        transport?.version ? `version: ${transport.version}` : 'not running'
+                    }
+                />
                 <ActionColumn>
                     <Checkbox
-                        isChecked={bridgeProcess.process === true}
+                        isChecked={bridgeProcess.process}
                         onClick={() => {
                             desktopApi.toggleBridge();
                         }}
@@ -80,7 +86,7 @@ export const TransportBackends = () => {
             </SectionItem>
             <SectionItem data-testid="@settings/debug/processes/bridgeLegacy">
                 <TextColumn
-                    title="Use legacy bridge"
+                    title="Use legacy Bridge"
                     description="Legacy trezord-go will be spawned as a subprocess"
                 />
                 <ActionColumn>
@@ -96,7 +102,10 @@ export const TransportBackends = () => {
                 </ActionColumn>
             </SectionItem>
             <SectionItem data-testid="@settings/debug/processes/runOnStartUp">
-                <TextColumn title="Run on startup" />
+                <TextColumn
+                    title="Run on startup"
+                    description="This is useful for testing of other Transport clients"
+                />
                 <ActionColumn>
                     <Checkbox
                         isChecked={!bridgeSettings.doNotStartOnStartup}


### PR DESCRIPTION
<img width="872" alt="image" src="https://github.com/user-attachments/assets/2340e754-944e-4e6c-8a4b-dae4dcc20e64">

fixing bridge controls in debug menu. this feature might be useful for some old T ones edgecase handling - turning on legacy bridge instead of the new bridge in the runtime of application. cc @MiroslavProchazka that we are able to achieve that, eg we detected unreadable device, we give you a button "use old bridge". 

resolve #13587