### PR TITLE
chore(suite): update mission dependencies: electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
         "type-fest": "4.24.0",
         "bcrypto": "5.4.0",
         "react": "18.2.0",
-        "electron": "30.3.1",
+        "electron": "31.6.0",
         "@types/node": "20.12.7",
         "@types/react": "18.2.55",
         "bn.js": "5.2.1"

--- a/packages/connect-examples/electron-main-process/package.json
+++ b/packages/connect-examples/electron-main-process/package.json
@@ -55,7 +55,7 @@
         "@trezor/connect": "workspace:*"
     },
     "devDependencies": {
-        "electron": "30.3.1",
+        "electron": "31.6.0",
         "electron-builder": "25.0.5"
     }
 }

--- a/packages/connect-examples/electron-renderer-with-assets/package.json
+++ b/packages/connect-examples/electron-renderer-with-assets/package.json
@@ -60,7 +60,7 @@
         "babel-loader": "^9.1.3",
         "concurrently": "^8.2.2",
         "copy-webpack-plugin": "^12.0.2",
-        "electron": "30.3.1",
+        "electron": "31.6.0",
         "electron-builder": "25.0.5",
         "html-webpack-plugin": "^5.6.0",
         "terser-webpack-plugin": "^5.3.9",

--- a/packages/connect-examples/electron-renderer-with-popup/package.json
+++ b/packages/connect-examples/electron-renderer-with-popup/package.json
@@ -52,7 +52,7 @@
         }
     },
     "devDependencies": {
-        "electron": "30.3.1",
+        "electron": "31.6.0",
         "electron-builder": "25.0.5"
     }
 }

--- a/packages/suite-desktop-api/package.json
+++ b/packages/suite-desktop-api/package.json
@@ -19,6 +19,6 @@
         "type-check": "yarn g:tsc --build tsconfig.json"
     },
     "dependencies": {
-        "electron": "30.3.1"
+        "electron": "31.6.0"
     }
 }

--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -50,7 +50,7 @@
         "@trezor/trezor-user-env-link": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@types/electron-localshortcut": "^3.1.3",
-        "electron": "30.3.1",
+        "electron": "31.6.0",
         "fs-extra": "^11.2.0",
         "glob": "^10.3.10",
         "terser-webpack-plugin": "^5.3.9",

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -31,7 +31,7 @@
     },
     "devDependencies": {
         "@electron/notarize": "2.4.0",
-        "electron": "30.3.1",
+        "electron": "31.6.0",
         "electron-builder": "25.0.5",
         "glob": "^10.3.10"
     }

--- a/shell.nix
+++ b/shell.nix
@@ -8,7 +8,7 @@ with import
 
 let
   # unstable packages
-  electron = electron_30; # use the same version as defined in packages/suite-desktop/package.json
+  electron = electron_31; # use the same version as defined in packages/suite-desktop/package.json
   nodejs = nodejs_20;
   # use older gcc. 10.2.0 with glibc 2.32 for node_modules bindings.
   # electron-builder is packing the app with glibc 2.32, bindings should not be compiled with newer version.

--- a/yarn.lock
+++ b/yarn.lock
@@ -11776,7 +11776,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/suite-desktop-api@workspace:packages/suite-desktop-api"
   dependencies:
-    electron: "npm:30.3.1"
+    electron: "npm:31.6.0"
   languageName: unknown
   linkType: soft
 
@@ -11813,7 +11813,7 @@ __metadata:
     "@trezor/utils": "workspace:*"
     "@types/electron-localshortcut": "npm:^3.1.3"
     chalk: "npm:^4.1.2"
-    electron: "npm:30.3.1"
+    electron: "npm:31.6.0"
     electron-localshortcut: "npm:^3.2.1"
     electron-store: "npm:8.2.0"
     electron-updater: "npm:6.3.4"
@@ -11863,7 +11863,7 @@ __metadata:
   dependencies:
     "@electron/notarize": "npm:2.4.0"
     blake-hash: "npm:^2.0.0"
-    electron: "npm:30.3.1"
+    electron: "npm:31.6.0"
     electron-builder: "npm:25.0.5"
     electron-localshortcut: "npm:^3.2.1"
     electron-store: "npm:8.2.0"
@@ -17954,7 +17954,7 @@ __metadata:
   resolution: "connect-example-electron-main@workspace:packages/connect-examples/electron-main-process"
   dependencies:
     "@trezor/connect": "workspace:*"
-    electron: "npm:30.3.1"
+    electron: "npm:31.6.0"
     electron-builder: "npm:25.0.5"
   languageName: unknown
   linkType: soft
@@ -17963,7 +17963,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "connect-example-electron-renderer-popup@workspace:packages/connect-examples/electron-renderer-with-popup"
   dependencies:
-    electron: "npm:30.3.1"
+    electron: "npm:31.6.0"
     electron-builder: "npm:25.0.5"
   languageName: unknown
   linkType: soft
@@ -17976,7 +17976,7 @@ __metadata:
     babel-loader: "npm:^9.1.3"
     concurrently: "npm:^8.2.2"
     copy-webpack-plugin: "npm:^12.0.2"
-    electron: "npm:30.3.1"
+    electron: "npm:31.6.0"
     electron-builder: "npm:25.0.5"
     html-webpack-plugin: "npm:^5.6.0"
     terser-webpack-plugin: "npm:^5.3.9"
@@ -20452,16 +20452,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:30.3.1":
-  version: 30.3.1
-  resolution: "electron@npm:30.3.1"
+"electron@npm:31.6.0":
+  version: 31.6.0
+  resolution: "electron@npm:31.6.0"
   dependencies:
     "@electron/get": "npm:^2.0.0"
     "@types/node": "npm:^20.9.0"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10/e39ffe9f29f687c064df00fece892ca9d3bb20d54ee5ebe17fc050d0af9ef335b2bf961878f00f91ab65d4948d8ef348a528578e25bcba5094636f80675ef675
+  checksum: 10/ef304dd279a6f01143de000d3be420bde8f6feb5b72387c2b22e64fd97e1d5b80a0e82e4f2dee660b36a8a682e4f9cbcd2e6d2f73f5e7ba4e84d8bfb03c1d8e2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Update `electron` from 30 to 31 

:information_source:  Note: it is present in nixos repository [[1]](https://github.com/NixOS/nixpkgs/blob/0cfa0d860b6ec2c5113909d569e0868062bd9c30/pkgs/top-level/all-packages.nix#L17367), [[2]](https://github.com/NixOS/nixpkgs/blob/f4c846aee8e1e29062aa8514d5e0ab270f4ec2f9/pkgs/top-level/all-packages.nix#L17985), but for some reason it is not searchable [through nixos web interface](https://search.nixos.org/packages?channel=24.05&show=electron&from=0&size=50&sort=relevance&type=packages&query=electron).

:eye: Besides CI checks :heavy_check_mark: , I have tested: local suite:dev, suite:dev:desktop, linux build :heavy_check_mark: 