### PR TITLE
fix(wallet-utils): Fix getNetworkAccountFeatures fallback

### DIFF
--- a/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
@@ -228,11 +228,9 @@ describe('account utils', () => {
 
     it('getNetworkAccountFeatures', () => {
         const btcAcc = getWalletAccount({ symbol: 'btc' });
-
         const btcTaprootAcc = getWalletAccount({ symbol: 'btc', accountType: 'taproot' });
-
+        const btcLegacy = getWalletAccount({ symbol: 'btc', accountType: 'legacy' });
         const ethAcc = getWalletAccount();
-
         const coinjoinAcc = getWalletAccount({ symbol: 'regtest', accountType: 'coinjoin' });
 
         expect(getNetworkAccountFeatures(btcAcc)).toEqual(['rbf', 'sign-verify', 'amount-unit']);
@@ -246,6 +244,8 @@ describe('account utils', () => {
             'staking',
         ]);
         expect(getNetworkAccountFeatures(coinjoinAcc)).toEqual(['rbf', 'amount-unit']);
+        // when account does not have features defined, take them from root network object
+        expect(getNetworkAccountFeatures(btcLegacy)).toEqual(getNetworkAccountFeatures(btcAcc));
     });
 
     it('hasNetworkFeatures', () => {

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -1081,9 +1081,7 @@ export const getNetworkAccountFeatures = ({
 }: Pick<Account, 'symbol' | 'accountType'>): NetworkFeature[] => {
     const matchedNetwork = getNetwork(symbol);
 
-    return accountType === 'normal'
-        ? matchedNetwork.features
-        : matchedNetwork.accountTypes[accountType]?.features ?? [];
+    return matchedNetwork.accountTypes[accountType]?.features ?? matchedNetwork.features;
 };
 
 export const hasNetworkFeatures = (


### PR DESCRIPTION
## Description

- Fix behavior of  `wallet-utils` `getNetworkAccountFeatures` in case of account which doesn't have `features` defined - in that case, use root network features instead of `[]`.
- Update test to cover this (it didn't)

I broke this in #14150 :hear_no_evil: 

