### PR TITLE
suite-native: Blur phishing txns

### DIFF
--- a/suite-native/atoms/src/DiscreetText/DiscreetText.tsx
+++ b/suite-native/atoms/src/DiscreetText/DiscreetText.tsx
@@ -11,6 +11,7 @@ import { useDiscreetMode } from './useDiscreetMode';
 
 export type DiscreetTextProps = TextProps & {
     children?: string | null;
+    isForcedDiscreetMode?: boolean;
 };
 
 const textStyle = prepareNativeStyle((_, { isDiscreetMode }) => ({
@@ -24,6 +25,7 @@ export const DiscreetText = ({
     ellipsizeMode,
     adjustsFontSizeToFit,
     style = {},
+    isForcedDiscreetMode,
     ...restTextProps
 }: DiscreetTextProps) => {
     const { applyStyle } = useNativeStyles();
@@ -38,10 +40,11 @@ export const DiscreetText = ({
 
     const { fontSize } = typographyStylesBase[variant];
     if (!children) return null;
+    const showAsDiscreet = isDiscreetMode || !!isForcedDiscreetMode;
 
     return (
         <Box>
-            {isDiscreetMode && (
+            {showAsDiscreet && (
                 <DiscreetCanvas
                     width={width}
                     height={height}
@@ -61,7 +64,7 @@ export const DiscreetText = ({
                     adjustsFontSizeToFit={adjustsFontSizeToFit}
                     style={mergeNativeStyleObjects([
                         style,
-                        applyStyle(textStyle, { isDiscreetMode }),
+                        applyStyle(textStyle, { isDiscreetMode: showAsDiscreet }),
                     ])}
                     {...restTextProps}
                 >

--- a/suite-native/formatters/src/components/AmountText.tsx
+++ b/suite-native/formatters/src/components/AmountText.tsx
@@ -4,6 +4,7 @@ import { isAndroid } from '@trezor/env-utils';
 
 type AmountTextProps = {
     isDiscreetText?: boolean;
+    isForcedDiscreetMode?: boolean;
     value: string | null;
 } & TextProps;
 
@@ -18,13 +19,13 @@ const amountTextStyle = prepareNativeStyle(_ => ({
     },
 }));
 
-export const AmountText = ({ value, isDiscreetText = true, ...textProps }: AmountTextProps) => {
+export const AmountText = ({ value, isDiscreetText = true, ...otherProps }: AmountTextProps) => {
     const { applyStyle } = useNativeStyles();
 
     const TextComponent = isDiscreetText ? DiscreetText : Text;
 
     return (
-        <TextComponent style={applyStyle(amountTextStyle)} {...textProps}>
+        <TextComponent style={applyStyle(amountTextStyle)} {...otherProps}>
             {value}
         </TextComponent>
     );

--- a/suite-native/formatters/src/components/CryptoAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/CryptoAmountFormatter.tsx
@@ -17,6 +17,7 @@ type CryptoToFiatAmountFormatterProps = FormatterProps<string | null | number> &
         isBalance?: boolean;
         isDiscreetText?: boolean;
         decimals?: number;
+        isForcedDiscreetMode?: boolean;
     };
 
 export const CryptoAmountFormatter = React.memo(
@@ -28,7 +29,7 @@ export const CryptoAmountFormatter = React.memo(
         variant = 'hint',
         color = 'textSubdued',
         decimals,
-        ...textProps
+        ...otherProps
     }: CryptoToFiatAmountFormatterProps) => {
         const { CryptoAmountFormatter: formatter } = useFormatters();
 
@@ -61,7 +62,7 @@ export const CryptoAmountFormatter = React.memo(
                 isDiscreetText={isDiscreetText}
                 variant={variant}
                 color={color}
-                {...textProps}
+                {...otherProps}
             />
         );
     },

--- a/suite-native/formatters/src/components/CryptoToFiatAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/CryptoToFiatAmountFormatter.tsx
@@ -11,6 +11,7 @@ type CryptoToFiatAmountFormatterProps = FormatterProps<string | null> &
         historicRate?: number;
         useHistoricRate?: boolean;
         isBalance?: boolean;
+        isForcedDiscreetMode?: boolean;
     };
 
 export const CryptoToFiatAmountFormatter = ({
@@ -19,7 +20,7 @@ export const CryptoToFiatAmountFormatter = ({
     historicRate,
     useHistoricRate,
     isBalance = false,
-    ...textProps
+    ...otherProps
 }: CryptoToFiatAmountFormatterProps) => {
     const fiatValue = useFiatFromCryptoValue({
         network,
@@ -29,5 +30,5 @@ export const CryptoToFiatAmountFormatter = ({
         cryptoValue: value,
     });
 
-    return <FiatAmountFormatter network={network} value={fiatValue} {...textProps} />;
+    return <FiatAmountFormatter network={network} value={fiatValue} {...otherProps} />;
 };

--- a/suite-native/formatters/src/components/EthereumTokenAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/EthereumTokenAmountFormatter.tsx
@@ -10,6 +10,7 @@ type EthereumTokenAmountFormatterProps = {
     symbol: TokenSymbol | null;
     isDiscreetText?: boolean;
     decimals?: number;
+    isForcedDiscreetMode?: boolean;
 } & FormatterProps<number | string> &
     TextProps;
 

--- a/suite-native/formatters/src/components/EthereumTokenToFiatAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/EthereumTokenToFiatAmountFormatter.tsx
@@ -15,6 +15,7 @@ type EthereumTokenToFiatAmountFormatterProps = {
     signValue?: SignValue;
     historicRate?: number;
     useHistoricRate?: boolean;
+    isForcedDiscreetMode?: boolean;
 } & FormatterProps<number | string> &
     TextProps;
 

--- a/suite-native/formatters/src/components/FiatAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/FiatAmountFormatter.tsx
@@ -14,10 +14,11 @@ type FiatAmountFormatterProps = FormatterProps<string | null> &
     TextProps & {
         network?: NetworkSymbol;
         isDiscreetText?: boolean;
+        isForcedDiscreetMode?: boolean;
     };
 
 export const FiatAmountFormatter = React.memo(
-    ({ network, value, isDiscreetText = true, ...textProps }: FiatAmountFormatterProps) => {
+    ({ network, value, isDiscreetText = true, ...otherProps }: FiatAmountFormatterProps) => {
         const { FiatAmountFormatter: formatter } = useFormatters();
 
         if (!!network && isTestnet(network)) {
@@ -29,6 +30,8 @@ export const FiatAmountFormatter = React.memo(
 
         const formattedValue = formatter.format(value);
 
-        return <AmountText value={formattedValue} isDiscreetText={isDiscreetText} {...textProps} />;
+        return (
+            <AmountText value={formattedValue} isDiscreetText={isDiscreetText} {...otherProps} />
+        );
     },
 );

--- a/suite-native/formatters/src/components/FiatBalanceFormatter.tsx
+++ b/suite-native/formatters/src/components/FiatBalanceFormatter.tsx
@@ -9,7 +9,7 @@ import { EmptyAmountText } from './EmptyAmountText';
 import { AmountText } from './AmountText';
 import { parseBalanceAmount } from '../utils';
 
-type BalanceFormatterProps = FormatterProps<string | null>;
+type BalanceFormatterProps = FormatterProps<string | null> & { isForcedDiscreetMode?: boolean };
 
 const wholeNumberStyle = prepareNativeStyle(utils => ({
     flexShrink: 1,
@@ -17,7 +17,7 @@ const wholeNumberStyle = prepareNativeStyle(utils => ({
     textAlign: 'center',
 }));
 
-export const FiatBalanceFormatter = ({ value }: BalanceFormatterProps) => {
+export const FiatBalanceFormatter = ({ value, isForcedDiscreetMode }: BalanceFormatterProps) => {
     const { applyStyle } = useNativeStyles();
     const { FiatAmountFormatter: formatter } = useFormatters();
 
@@ -36,9 +36,15 @@ export const FiatBalanceFormatter = ({ value }: BalanceFormatterProps) => {
                 value={wholeNumber}
                 variant="titleLarge"
                 isDiscreetText
+                isForcedDiscreetMode={isForcedDiscreetMode}
                 style={applyStyle(wholeNumberStyle)}
             />
-            <AmountText value={decimalNumber} variant="titleSmall" isDiscreetText />
+            <AmountText
+                value={decimalNumber}
+                variant="titleSmall"
+                isDiscreetText
+                isForcedDiscreetMode={isForcedDiscreetMode}
+            />
         </Box>
     );
 };

--- a/suite-native/transactions/src/components/TransactionsList/TokenTransferListItem.tsx
+++ b/suite-native/transactions/src/components/TransactionsList/TokenTransferListItem.tsx
@@ -1,9 +1,13 @@
+import { useSelector } from 'react-redux';
+
 import { AccountKey } from '@suite-common/wallet-types';
 import {
     EthereumTokenAmountFormatter,
     EthereumTokenToFiatAmountFormatter,
 } from '@suite-native/formatters';
 import { EthereumTokenTransfer, WalletAccountTransaction } from '@suite-native/tokens';
+import { selectIsPhishingTransaction, TransactionsRootState } from '@suite-common/wallet-core';
+import { TokenDefinitionsRootState } from '@suite-common/token-definitions';
 
 import { useTransactionFiatRate } from '../../hooks/useTransactionFiatRate';
 import { TransactionListItemContainer } from './TransactionListItemContainer';
@@ -34,6 +38,11 @@ export const TokenTransferListItemValues = ({
         tokenAddress: tokenTransfer.contract,
     });
 
+    const isPhishingTransaction = useSelector(
+        (state: TokenDefinitionsRootState & TransactionsRootState) =>
+            selectIsPhishingTransaction(state, transaction.txid, accountKey),
+    );
+
     return (
         <>
             <EthereumTokenToFiatAmountFormatter
@@ -45,6 +54,7 @@ export const TokenTransferListItemValues = ({
                 ellipsizeMode="tail"
                 historicRate={historicRate}
                 useHistoricRate
+                isForcedDiscreetMode={isPhishingTransaction}
             />
             <EthereumTokenAmountFormatter
                 value={tokenTransfer.amount}
@@ -52,6 +62,7 @@ export const TokenTransferListItemValues = ({
                 decimals={tokenTransfer.decimals}
                 numberOfLines={1}
                 ellipsizeMode="tail"
+                isForcedDiscreetMode={isPhishingTransaction}
             />
         </>
     );

--- a/suite-native/transactions/src/components/TransactionsList/TransactionListItem.tsx
+++ b/suite-native/transactions/src/components/TransactionsList/TransactionListItem.tsx
@@ -7,9 +7,15 @@ import {
     SignValueFormatter,
 } from '@suite-native/formatters';
 import { Box } from '@suite-native/atoms';
-import { AccountsRootState, selectIsTestnetAccount } from '@suite-common/wallet-core';
+import {
+    AccountsRootState,
+    selectIsPhishingTransaction,
+    selectIsTestnetAccount,
+    TransactionsRootState,
+} from '@suite-common/wallet-core';
 import { EmptyAmountText } from '@suite-native/formatters/src/components/EmptyAmountText';
 import { WalletAccountTransaction } from '@suite-native/tokens';
+import { TokenDefinitionsRootState } from '@suite-common/token-definitions';
 
 import { useTransactionFiatRate } from '../../hooks/useTransactionFiatRate';
 import { TokenTransferListItem } from './TokenTransferListItem';
@@ -35,6 +41,11 @@ export const TransactionListItemValues = ({
         selectIsTestnetAccount(state, accountKey),
     );
 
+    const isPhishingTransaction = useSelector(
+        (state: TokenDefinitionsRootState & TransactionsRootState) =>
+            selectIsPhishingTransaction(state, transaction.txid, accountKey),
+    );
+
     const historicRate = useTransactionFiatRate({ accountKey, transaction });
 
     return (
@@ -44,12 +55,12 @@ export const TransactionListItemValues = ({
             ) : (
                 <Box flexDirection="row">
                     <SignValueFormatter value={getTransactionValueSign(transaction.type)} />
-
                     <CryptoToFiatAmountFormatter
                         value={transaction.amount}
                         network={transaction.symbol}
                         historicRate={historicRate}
                         useHistoricRate
+                        isForcedDiscreetMode={isPhishingTransaction}
                     />
                 </Box>
             )}
@@ -60,6 +71,7 @@ export const TransactionListItemValues = ({
                 isBalance={false}
                 numberOfLines={1}
                 adjustsFontSizeToFit
+                isForcedDiscreetMode={isPhishingTransaction}
             />
         </>
     );
@@ -85,6 +97,8 @@ export const TransactionListItem = ({
                 txid={transaction.txid}
                 tokenTransfer={transaction.tokens[0]}
                 includedCoinsCount={transaction.tokens.length - 1}
+                isFirst={isFirst}
+                isLast={isLast}
             />
         );
 

--- a/suite-native/transactions/src/components/TransactionsList/TransactionListItemContainer.tsx
+++ b/suite-native/transactions/src/components/TransactionsList/TransactionListItemContainer.tsx
@@ -12,7 +12,7 @@ import {
     RootStackRoutes,
     StackNavigationProps,
 } from '@suite-native/navigation';
-import { Badge, Box, HStack, Text } from '@suite-native/atoms';
+import { Badge, Box, DiscreetText, HStack, Text } from '@suite-native/atoms';
 import { useFormatters } from '@suite-common/formatters';
 import {
     selectIsPhishingTransaction,
@@ -166,8 +166,10 @@ export const TransactionListItemContainer = ({
     );
 
     const iconColor: Color = isTransactionPending ? 'backgroundAlertYellowBold' : 'iconSubdued';
-    const coinSymbol = tokenTransfer?.contract ?? networkSymbol;
+    const coinSymbol = isPhishingTransaction ? undefined : tokenTransfer?.contract ?? networkSymbol;
     const transactionTitle = getTransactionTitle(transactionType, isTransactionPending);
+
+    const DateTextComponent = isPhishingTransaction ? DiscreetText : Text;
 
     return (
         <TouchableOpacity
@@ -196,9 +198,10 @@ export const TransactionListItemContainer = ({
                         </Box>
                         {hasIncludedCoins && <Badge label={includedCoinsLabel} size="small" />}
                     </HStack>
-                    <Text variant="hint" color="textSubdued">
-                        <DateTimeFormatter value={transactionBlockTime} />
-                    </Text>
+
+                    <DateTextComponent isForcedDiscreetMode={isPhishingTransaction}>
+                        {DateTimeFormatter.format(transactionBlockTime)}
+                    </DateTextComponent>
                 </Box>
             </Box>
             <Box style={applyStyle(valuesContainerStyle)}>{children}</Box>


### PR DESCRIPTION
- fixed bad rounded corners for eth token txns
- blur phishing txns in the list using DiscreetText

Visual approved by @sime 

For testing you can [comment this row](https://github.com/trezor/trezor-suite/blob/ffaf7286b3b433452fb6480b46d7405d07b6463b/suite-native/tokens/src/ethereumTokensSelectors.ts#L137) and use all seed `Ethereum #1` account, in detail select `Include tokens` and there will be one phishing txn. According to discussion with @sime we keep current setup for visibility of txn so no change in filtering was done.

## Related Issue

Resolve #13241

## Screenshots:
<img width=280 src="https://github.com/user-attachments/assets/a73c80c9-6db9-4fe7-b46f-0557ec1553b7" />

