### PR TITLE
Run tests with node bridge

### DIFF
--- a/packages/connect/e2e/common.setup.ts
+++ b/packages/connect/e2e/common.setup.ts
@@ -78,7 +78,7 @@ export const setup = async (
     TrezorUserEnvLink.state = options;
 
     // after all is done, start bridge again
-    await TrezorUserEnvLink.startBridge();
+    await TrezorUserEnvLink.startBridge('node');
 };
 
 export const initTrezorConnect = async (

--- a/packages/trezor-user-env-link/src/api.ts
+++ b/packages/trezor-user-env-link/src/api.ts
@@ -159,7 +159,7 @@ export class TrezorUserEnvLinkClass extends TypedEmitter<WebsocketClientEvents> 
 
         return null;
     }
-    async startBridge(version = DEFAULT_BRIDGE_VERSION) {
+    async startBridge(version: '2.0.32' | '2.0.33' | 'node' = DEFAULT_BRIDGE_VERSION) {
         await this.client.send({ type: 'bridge-start', version });
 
         return null;


### PR DESCRIPTION
node-bridge should be available in trezor-user-env since https://github.com/trezor/trezor-user-env/pull/261/files
but it still doesn't work, something is missing and I am not sure yet what it is. It can't see device yet. 
<img width="731" alt="image" src="https://github.com/user-attachments/assets/9ebbf2cd-3399-4fb5-927f-b2ae95fb4bc0">

<img width="913" alt="image" src="https://github.com/user-attachments/assets/ee25c552-0e95-4a91-872d-6296241a89b3">

one of the problems might be missing ui files for the status page. 
<img width="230" alt="image" src="https://github.com/user-attachments/assets/2f76944c-4e80-4e1c-b439-0ce353c9f24b">

The end game goal is to start using it in our tests instead of trezord-go.