### PR TITLE
fix(connect): replace import for @sinclair/typebox due to TS issue

### DIFF
--- a/scripts/replace-imports.sh
+++ b/scripts/replace-imports.sh
@@ -24,3 +24,14 @@ if grep -Rl "$SEARCH_PATTERN" "$1"; then
 else
     echo "All occurrences of '@trezor/*/src' have been successfully replaced."
 fi
+
+# Patch for Typebox import issue, where TS uses an ESM import path, but our package is CommonJS
+# @sinclair/typebox/build/esm/index.mjs -> @sinclair/typebox
+
+REGEX="s/@sinclair\/typebox\/build\/esm\/index.mjs/@sinclair\/typebox/g"
+
+if [[ "$OS" == "Darwin" ]]; then
+    find "$1" -type f -exec sed -i '' -E "$REGEX" {} +
+else
+    find "$1" -type f -exec sed -i -E "$REGEX" {} +
+fi


### PR DESCRIPTION
## Description

There is a prevailing issue with the imports for `@sinclair/typebox` in TypeScript declaration files that are published in the build library output, which is causing issues with using the library by 3rd parties.  

It's importing `@sinclair/typebox/build/esm/index.mjs`, however this doesn't work properly since our published package is CommonJS, not ESM. 

This PR adds a patch via the `replace-imports.sh` script, which replaces `@sinclair/typebox/build/esm/index.mjs` -> `@sinclair/typebox`.