### PR TITLE
feat(suite): add learn more button to fw revision check settings

### DIFF
--- a/packages/suite/src/views/settings/SettingsDevice/FirmwareRevisionCheck.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/FirmwareRevisionCheck.tsx
@@ -8,7 +8,7 @@ import {
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { openModal } from 'src/actions/suite/modalActions';
 import { checkFirmwareRevision } from 'src/actions/suite/suiteActions';
-
+import { HELP_CENTER_FIRMWARE_REVISION_CHECK } from '@trezor/urls';
 export const FirmwareRevisionCheck = () => {
     const dispatch = useDispatch();
     const isFirmwareRevisionCheckDisabled = useSelector(
@@ -43,6 +43,7 @@ export const FirmwareRevisionCheck = () => {
                         }
                     />
                 }
+                buttonLink={HELP_CENTER_FIRMWARE_REVISION_CHECK}
             />
             <ActionColumn>
                 <ActionButton


### PR DESCRIPTION
Resolve: https://github.com/trezor/trezor-suite/issues/14557

<img width="1332" alt="image" src="https://github.com/user-attachments/assets/4ee883eb-8155-4b67-b424-9c5186815c6b">

Learn more button leads to https://trezor.io/learn/a/trezor-firmware-revision-check