### PR TITLE
fix(suite-native): wrong alignment of + and - on some places

### DIFF
--- a/suite-native/formatters/src/components/EthereumTokenToFiatAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/EthereumTokenToFiatAmountFormatter.tsx
@@ -1,4 +1,4 @@
-import { TextProps, Text } from '@suite-native/atoms';
+import { TextProps, Box } from '@suite-native/atoms';
 import { useFormatters } from '@suite-common/formatters';
 import { TokenAddress } from '@suite-common/wallet-types';
 import { SignValue } from '@suite-common/suite-types';
@@ -44,10 +44,16 @@ export const EthereumTokenToFiatAmountFormatter = ({
     const formattedFiatValue = FiatAmountFormatter.format(fiatValue ?? 0);
 
     return signValue ? (
-        <Text ellipsizeMode={ellipsizeMode} numberOfLines={numberOfLines}>
+        <Box flexDirection="row">
             <SignValueFormatter value={signValue} />
-            <AmountText value={formattedFiatValue} isDiscreetText={isDiscreetText} {...rest} />
-        </Text>
+            <AmountText
+                value={formattedFiatValue}
+                isDiscreetText={isDiscreetText}
+                ellipsizeMode={ellipsizeMode}
+                numberOfLines={numberOfLines}
+                {...rest}
+            />
+        </Box>
     ) : (
         <AmountText
             value={formattedFiatValue}

--- a/suite-native/graph/src/components/TransactionEventTooltip.tsx
+++ b/suite-native/graph/src/components/TransactionEventTooltip.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 
 import { G, N } from '@mobily/ts-belt';
 
-import { Card, Text } from '@suite-native/atoms';
+import { Card, Box, Text } from '@suite-native/atoms';
 import {
     CryptoAmountFormatter,
     EthereumTokenAmountFormatter,
@@ -111,7 +111,7 @@ const EventTooltipRow = ({
         <Text variant="label" color="textSubdued">
             {title}
         </Text>
-        <Text>
+        <Box flexDirection="row">
             <SignValueFormatter value={signValue} variant="label" />
             {!tokenAddress ? (
                 <CryptoAmountFormatter
@@ -129,7 +129,7 @@ const EventTooltipRow = ({
                     value={value}
                 />
             )}
-        </Text>
+        </Box>
     </>
 );
 


### PR DESCRIPTION
Some `SignValueFormatter` objects were misaligned due to being wrapped in Text.

## Related Issue

Resolve #14548

## Screenshots:
OLD:
<img width="250"  src="https://github.com/user-attachments/assets/7252f6d4-afc7-4e72-84e4-702a139a1858"> <img width="250"  src="https://github.com/user-attachments/assets/1c4f5857-10e8-47de-87a3-6d883163b94a">
NEW:
<img width="250"  src="https://github.com/user-attachments/assets/0d46e4d1-3160-444f-b937-8eace56ba488"> <img width="250"  src="https://github.com/user-attachments/assets/02efca38-3f75-4176-8ae7-883e6b7f2022">
