### PR TITLE
fix(suite): fix padding in basic tx details

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
@@ -229,7 +229,7 @@ export const BasicTxDetails = ({
             <Grid>
                 {/* MINED TIME */}
                 <Title>
-                    <Icon name="calendar" size={10} />
+                    <Icon name="calendar" size={10} margin={{ right: spacings.xs }} />
                     {isConfirmed ? (
                         <Translation id="TR_MINED_TIME" />
                     ) : (
@@ -252,7 +252,7 @@ export const BasicTxDetails = ({
 
                 {/* TX ID */}
                 <Title>
-                    <Icon name="biometric" size={10} />
+                    <Icon name="biometric" size={10} margin={{ right: spacings.xs }} />
                     <Translation id="TR_TXID" />
                 </Title>
 
@@ -287,13 +287,13 @@ export const BasicTxDetails = ({
                 {tx.ethereumSpecific && (
                     <>
                         <Title>
-                            <Icon name="gas" size={10} />
+                            <Icon name="gas" size={10} margin={{ right: spacings.xs }} />
                             <Translation id="TR_GAS_LIMIT" />
                         </Title>
                         <Value>{tx.ethereumSpecific.gasLimit}</Value>
 
                         <Title>
-                            <Icon name="gas" size={10} />
+                            <Icon name="gas" size={10} margin={{ right: spacings.xs }} />
                             <Translation id="TR_GAS_USED" />
                         </Title>
                         <Value>
@@ -305,7 +305,7 @@ export const BasicTxDetails = ({
                         </Value>
 
                         <Title>
-                            <Icon name="gas" size={10} />
+                            <Icon name="gas" size={10} margin={{ right: spacings.xs }} />
                             <Translation id="TR_GAS_PRICE" />
                         </Title>
                         <Value>{`${fromWei(tx.ethereumSpecific?.gasPrice ?? '0', 'gwei')} ${getFeeUnits(
@@ -316,7 +316,7 @@ export const BasicTxDetails = ({
                             <IconPlaceholder>#</IconPlaceholder>
                             <Translation id="TR_NONCE" />
                         </Title>
-                        <Value>{tx.ethereumSpecific.nonce}</Value>
+                        <Value>{tx.ethereumSpecific?.nonce}</Value>
                     </>
                 )}
             </Grid>


### PR DESCRIPTION
Resolve: https://github.com/trezor/trezor-suite/issues/14597
Fixing padding next to the icons in the TX detail

Before
<img width="767" alt="image" src="https://github.com/user-attachments/assets/65411133-f09c-47bc-8016-8eef60a51dc4">


After
<img width="776" alt="image" src="https://github.com/user-attachments/assets/0f73b72c-075c-46d1-8d7b-28455478af9a">
