### PR TITLE
Improve error handling in firmware revision check

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -570,10 +570,12 @@ export class Device extends TypedEmitter<DeviceEvents> {
         if (
             // The check was not yet performed
             this.authenticityChecks.firmwareRevision === null ||
-            // The check was performed, but outcome cannot be surely determined (Suite is offline)
+            // The check was performed, but outcome cannot be surely determined (Suite is offline or there was an unexpected error)
             // -> recheck on every getFeatures() until the result is known
             (this.authenticityChecks.firmwareRevision.success === false &&
-                this.authenticityChecks.firmwareRevision.error === 'cannot-perform-check-offline')
+                ['cannot-perform-check-offline', 'other-error'].includes(
+                    this.authenticityChecks.firmwareRevision.error,
+                ))
         ) {
             await this.checkFirmwareRevision();
         }

--- a/packages/connect/src/device/__tests__/checkFirmwareRevision.test.ts
+++ b/packages/connect/src/device/__tests__/checkFirmwareRevision.test.ts
@@ -101,7 +101,7 @@ describe.each(DeviceNames)(`${checkFirmwareRevision.name} for device %s`, intern
             expected: { success: false, error: 'cannot-perform-check-offline' },
         },
         {
-            it: 'fails with a generic error message when there is an error when reading the online verison of releases.json',
+            it: 'fails with a generic error message when there is an error when reading the online version of releases.json',
             httpRequestMock: () => {
                 throw new Error('There is an unexpected error!');
             },

--- a/packages/connect/src/device/checkFirmwareRevision.ts
+++ b/packages/connect/src/device/checkFirmwareRevision.ts
@@ -59,7 +59,6 @@ export const checkFirmwareRevision = async ({
     deviceRevision,
     expectedRevision,
 }: CheckFirmwareRevisionParams): Promise<FirmwareRevisionCheckResult> => {
-    console.log(expectedRevision);
     if (expectedRevision === undefined) {
         if (firmwareVersion.length !== 3) {
             return failFirmwareRevisionCheck('firmware-version-unknown');
@@ -70,7 +69,6 @@ export const checkFirmwareRevision = async ({
                 firmwareVersion,
                 internalModel,
             });
-            console.log('onlineRelease', onlineRelease);
 
             if (onlineRelease?.firmware_revision === undefined) {
                 return failFirmwareRevisionCheck('firmware-version-unknown');

--- a/packages/connect/src/types/device.ts
+++ b/packages/connect/src/types/device.ts
@@ -42,15 +42,17 @@ export type DeviceState = {
 // key = coin shortcut lowercase (ex: btc, eth, xrp) OR field declared in coins.json "supportedFirmware.capability"
 export type UnavailableCapabilities = { [key: string]: UnavailableCapability };
 
+export type FirmwareRevisionCheckError =
+    | 'revision-mismatch'
+    | 'firmware-version-unknown'
+    | 'cannot-perform-check-offline' // suite offline & release version not found locally => we cannot check with `data.trezor.io`
+    | 'other-error'; // incorrect URL, cannot parse JSON, etc.
+
 export type FirmwareRevisionCheckResult =
     | { success: true }
     | {
           success: false;
-          error:
-              | 'revision-mismatch'
-              | 'firmware-version-unknown'
-              | 'firmware-version-unknown'
-              | 'cannot-perform-check-offline'; // suite offline & release version not found locally => we cannot check with `data.trezor.io`
+          error: FirmwareRevisionCheckError;
       };
 
 export type KnownDevice = {

--- a/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareRevisionCheckBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareRevisionCheckBanner.tsx
@@ -1,20 +1,32 @@
+import { TranslationKey } from '@suite-common/intl-types';
+import { isDeviceAcquired } from '@suite-common/suite-utils';
 import { selectDevice } from '@suite-common/wallet-core';
 import { Banner } from '@trezor/components';
+import { FirmwareRevisionCheckError } from '@trezor/connect';
 import { HELP_CENTER_FIRMWARE_REVISION_CHECK } from '@trezor/urls';
 
 import { Translation, TrezorLink } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
 
+const messages: Record<FirmwareRevisionCheckError, TranslationKey> = {
+    'cannot-perform-check-offline': 'TR_DEVICE_FIRMWARE_REVISION_CHECK_UNABLE_TO_PERFORM',
+    'other-error': 'TR_FIRMWARE_REVISION_CHECK_OTHER_ERROR',
+    'revision-mismatch': 'TR_FIRMWARE_REVISION_CHECK_FAILED',
+    'firmware-version-unknown': 'TR_FIRMWARE_REVISION_CHECK_FAILED',
+};
+
 export const FirmwareRevisionCheckBanner = () => {
     const device = useSelector(selectDevice);
 
+    if (
+        !isDeviceAcquired(device) ||
+        device.authenticityChecks?.firmwareRevision?.success !== false
+    ) {
+        return null;
+    }
+
     const wasOffline =
-        device?.features &&
-        device.authenticityChecks?.firmwareRevision?.success === false &&
         device.authenticityChecks.firmwareRevision.error === 'cannot-perform-check-offline';
-    const message = wasOffline
-        ? 'TR_DEVICE_FIRMWARE_REVISION_CHECK_UNABLE_TO_PERFORM'
-        : 'TR_FIRMWARE_REVISION_CHECK_FAILED';
 
     return (
         <Banner
@@ -30,7 +42,7 @@ export const FirmwareRevisionCheckBanner = () => {
                 )
             }
         >
-            <Translation id={message} />
+            <Translation id={messages[device.authenticityChecks.firmwareRevision.error]} />
         </Banner>
     );
 };

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -456,8 +456,10 @@ export const selectIsFirmwareRevisionCheckEnabledAndFailed = (
         isDeviceAcquired(device) &&
         // If `check` is null, it means that it was not performed yet.
         device.authenticityChecks?.firmwareRevision?.success === false &&
-        // If Suite is offline and we cannot perform check, the error banner shows to urge user to go online.
-        device.authenticityChecks.firmwareRevision.error !== 'cannot-perform-check-offline'
+        // If Suite is offline and cannot perform check or there is some unexpected error, an error banner is shown but Suite is otherwise unaffected.
+        !['cannot-perform-check-offline', 'other-error'].includes(
+            device.authenticityChecks.firmwareRevision.error,
+        )
     );
 };
 

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7112,6 +7112,10 @@ export default defineMessages({
         defaultMessage:
             "Firmware revision check couldn't be performed. Go online to verify your firmware version.",
     },
+    TR_FIRMWARE_REVISION_CHECK_OTHER_ERROR: {
+        id: 'TR_FIRMWARE_REVISION_CHECK_OTHER_ERROR',
+        defaultMessage: 'Firmware revision check could not be performed.',
+    },
     TR_ONBOARDING_COINS_STEP: {
         id: 'TR_ONBOARDING_COINS_STEP',
         defaultMessage: 'Activate coins',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Previously, whenever there was an error while downloading and reading the remote `releases.json` file, the user would be instructed to go online. This message is misleading when there is some other cause for an error such as incorrect URL or incorrectly formatted JSON file.

It would be nice to log these types of errors to Sentry, but then we'd have to store the stack trace somewhere temporarily before firing the event... maybe next step.

Copy could be improved and the [KB article](https://trezor.io/learn/a/trezor-firmware-revision-check) updated.

**QA:** This cannot be tested without some code modification. But you can test that I did not break the original flow.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
![Screenshot 2024-09-30 at 14 35 12](https://github.com/user-attachments/assets/940f796a-f4c9-45a9-ab18-7a17834fa458)


