### PR TITLE
chore(suite): unreadable device tips improvements

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -129,6 +129,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
     public readonly protocol: TransportProtocol;
     private readonly transportPath;
     private readonly transportSessionOwner;
+    private readonly transportDescriptorType;
     private session;
     private isLocalSession;
 
@@ -216,6 +217,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
         this.transport = transport;
         this.transportPath = descriptor.path;
         this.transportSessionOwner = descriptor.sessionOwner;
+        this.transportDescriptorType = descriptor.type;
 
         this.session = descriptor.session;
         this.isLocalSession = false;
@@ -1143,6 +1145,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
                 type: 'unreadable',
                 error: this.unreadableError, // provide error details
                 label: 'Unreadable device',
+                transportDescriptorType: this.transportDescriptorType,
             };
         }
         if (this.isUnacquired()) {

--- a/packages/connect/src/types/device.ts
+++ b/packages/connect/src/types/device.ts
@@ -1,3 +1,4 @@
+import { Descriptor } from '@trezor/transport';
 import type { PROTO } from '../constants';
 import type { ReleaseInfo } from './firmware';
 
@@ -97,6 +98,7 @@ export type KnownDevice = BaseDevice & {
         // Maybe add AuthenticityCheck result here?
     };
     transportSessionOwner?: undefined;
+    transportDescriptorType?: typeof undefined;
 };
 
 export type UnknownDevice = BaseDevice & {
@@ -117,6 +119,7 @@ export type UnknownDevice = BaseDevice & {
     unavailableCapabilities?: typeof undefined;
     availableTranslations?: typeof undefined;
     transportSessionOwner?: string;
+    transportDescriptorType?: typeof undefined;
 };
 
 export type UnreadableDevice = BaseDevice & {
@@ -137,6 +140,7 @@ export type UnreadableDevice = BaseDevice & {
     unavailableCapabilities?: typeof undefined;
     availableTranslations?: typeof undefined;
     transportSessionOwner?: undefined;
+    transportDescriptorType: Descriptor['type'];
 };
 
 export type Device = KnownDevice | UnknownDevice | UnreadableDevice;

--- a/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
+++ b/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
@@ -20,6 +20,18 @@ jest.mock('cross-fetch', () => ({
     default: () => Promise.resolve({ ok: false }),
 }));
 
+// mock desktopApi
+jest.mock('@trezor/suite-desktop-api', () => ({
+    __esModule: true,
+    desktopApi: {
+        getBridgeStatus: () =>
+            Promise.resolve({ success: true, payload: { service: true, process: true } }),
+        getBridgeSettings: () => Promise.resolve({ success: true, payload: { enabled: true } }),
+        on: (_event: string, _cb: any) => {},
+        removeAllListeners: (_event: string) => {},
+    },
+}));
+
 // jest.mock('@firmware-components/ReconnectDevicePrompt', () => ({
 //     __esModule: true, // export as module
 //     default: ({ children }: any) => <div data-testid="box">{children}</div>,
@@ -215,7 +227,8 @@ describe('Preloader component', () => {
         const device: DeepPartial<AppState['device']> = {
             selectedDevice: {
                 type: 'unreadable',
-                error: 'LIBUSB_ERROR_ACCESS',
+                error: 'unable to open device',
+                transportDescriptorType: 0,
             },
         };
 
@@ -230,7 +243,7 @@ describe('Preloader component', () => {
         const { unmount } = renderWithProviders(store, <Index app={store.getState().router.app} />);
 
         expect(findByTestId('@connect-device-prompt')).not.toBeNull();
-        expect(findByTestId('@connect-device-prompt/unreadable-hid')).not.toBeNull();
+        expect(findByTestId('@connect-device-prompt/unreadable-unknown')).not.toBeNull();
 
         unmount();
     });

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceAcquire.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceAcquire.tsx
@@ -6,6 +6,7 @@ import { isDesktop } from '@trezor/env-utils';
 
 import { Translation, TroubleshootingTips } from 'src/components/suite';
 import { useDevice, useDispatch } from 'src/hooks/suite';
+import { TROUBLESHOOTING_TIP_RECONNECT } from 'src/components/suite/troubleshooting/tips';
 
 export const DeviceAcquire = () => {
     const { isLocked, device } = useDevice();
@@ -53,19 +54,7 @@ export const DeviceAcquire = () => {
                 />
             ),
         },
-        {
-            key: 'device-reconnect',
-            heading: <Translation id="TR_RECONNECT_YOUR_DEVICE" />,
-            description: (
-                <Translation
-                    id={
-                        isDesktop()
-                            ? 'TR_RECONNECT_DEVICE_DESCRIPTION_DESKTOP'
-                            : 'TR_RECONNECT_DEVICE_DESCRIPTION'
-                    }
-                />
-            ),
-        },
+        TROUBLESHOOTING_TIP_RECONNECT,
     ];
 
     return (

--- a/packages/suite/src/components/suite/PrerequisitesGuide/PrerequisitesGuide.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/PrerequisitesGuide.tsx
@@ -61,9 +61,7 @@ export const PrerequisitesGuide = ({ allowSwitchDevice }: PrerequisitesGuideProp
                 case 'device-unacquired':
                     return <DeviceAcquire />;
                 case 'device-unreadable':
-                    return (
-                        <DeviceUnreadable device={device} isWebUsbTransport={isWebUsbTransport} />
-                    );
+                    return <DeviceUnreadable device={device} />;
                 case 'device-unknown':
                     return <DeviceUnknown />;
                 case 'device-seedless':

--- a/packages/suite/src/components/suite/PrerequisitesGuide/Transport.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/Transport.tsx
@@ -1,23 +1,28 @@
 import { Translation, TroubleshootingTips } from 'src/components/suite';
+
 import {
     TROUBLESHOOTING_TIP_SUITE_DESKTOP,
     TROUBLESHOOTING_TIP_RESTART_COMPUTER,
     TROUBLESHOOTING_TIP_WEBUSB_ENVIRONMENT,
 } from 'src/components/suite/troubleshooting/tips';
 
-export const Transport = () => (
-    // No transport layer (bridge/webUSB) is available
-    // On web it makes sense to
-    // - offer downloading Trezor Suite desktop, or
-    // - use a browser that supports WebUSB
-    // Desktop app should have Bridge transport layer available as it is built-in, if it is not available we fucked up something.
-    <TroubleshootingTips
-        label={<Translation id="TR_TROUBLESHOOTING_DEVICE_NOT_DETECTED" />}
-        items={[
-            TROUBLESHOOTING_TIP_WEBUSB_ENVIRONMENT,
-            TROUBLESHOOTING_TIP_SUITE_DESKTOP,
-            TROUBLESHOOTING_TIP_RESTART_COMPUTER,
-        ]}
-        data-testid="@connect-device-prompt/bridge-not-running"
-    />
-);
+export const Transport = () => {
+    const items = [
+        TROUBLESHOOTING_TIP_WEBUSB_ENVIRONMENT,
+        TROUBLESHOOTING_TIP_SUITE_DESKTOP,
+        TROUBLESHOOTING_TIP_RESTART_COMPUTER,
+    ];
+
+    return (
+        // No transport layer (bridge/webUSB) is available
+        // On web it makes sense to
+        // - offer downloading Trezor Suite desktop, or
+        // - use a browser that supports WebUSB
+        // Desktop app should have Bridge transport layer available as it is built-in, if it is not available we fucked up something.
+        <TroubleshootingTips
+            label={<Translation id="TR_TROUBLESHOOTING_DEVICE_NOT_DETECTED" />}
+            items={items}
+            data-testid="@connect-device-prompt/bridge-not-running"
+        />
+    );
+};

--- a/packages/suite/src/components/suite/troubleshooting/tips/BridgeTip.tsx
+++ b/packages/suite/src/components/suite/troubleshooting/tips/BridgeTip.tsx
@@ -5,8 +5,10 @@ import { typography } from '@trezor/theme';
 import { TrezorLink } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
 import { useOpenSuiteDesktop } from 'src/hooks/suite/useOpenSuiteDesktop';
+import { useBridgeDesktopApi } from 'src/hooks/suite/useBridgeDesktopApi';
+import { useSelector } from 'src/hooks/suite';
 
-const Wrapper = styled.div`
+export const Wrapper = styled.div`
     a {
         ${typography.hint};
     }
@@ -45,3 +47,34 @@ export const BridgeStatus = () => (
         />
     </Wrapper>
 );
+
+export const BridgeToggle = () => {
+    const { changeBridgeSettings, bridgeSettings } = useBridgeDesktopApi();
+    const transport = useSelector(state => state.suite.transport);
+
+    if (!bridgeSettings) return null;
+
+    return (
+        <Wrapper>
+            <Translation
+                id="TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_BRIDGE_DESCRIPTION"
+                values={{
+                    currentVersion: transport?.version,
+                    a: chunks => (
+                        <TrezorLink
+                            variant="underline"
+                            onClick={() => {
+                                changeBridgeSettings({
+                                    ...bridgeSettings,
+                                    legacy: !bridgeSettings?.legacy,
+                                });
+                            }}
+                        >
+                            {chunks}
+                        </TrezorLink>
+                    ),
+                }}
+            />
+        </Wrapper>
+    );
+};

--- a/packages/suite/src/components/suite/troubleshooting/tips/index.tsx
+++ b/packages/suite/src/components/suite/troubleshooting/tips/index.tsx
@@ -1,4 +1,4 @@
-import { isWeb, isLinux, isAndroid } from '@trezor/env-utils';
+import { isWeb, isDesktop, isLinux, isAndroid } from '@trezor/env-utils';
 
 import { Translation } from 'src/components/suite/Translation';
 
@@ -56,4 +56,18 @@ export const TROUBLESHOOTING_TIP_UDEV = {
     heading: <Translation id="TR_UDEV_DOWNLOAD_TITLE" />,
     description: <UdevDescription />,
     hide: !isLinux(),
+};
+
+export const TROUBLESHOOTING_TIP_RECONNECT = {
+    key: 'device-reconnect',
+    heading: <Translation id="TR_RECONNECT_YOUR_DEVICE" />,
+    description: (
+        <Translation
+            id={
+                isDesktop()
+                    ? 'TR_RECONNECT_DEVICE_DESCRIPTION_DESKTOP'
+                    : 'TR_RECONNECT_DEVICE_DESCRIPTION'
+            }
+        />
+    ),
 };

--- a/packages/suite/src/components/suite/troubleshooting/tips/index.tsx
+++ b/packages/suite/src/components/suite/troubleshooting/tips/index.tsx
@@ -1,8 +1,10 @@
 import { isWeb, isDesktop, isLinux, isAndroid } from '@trezor/env-utils';
+import { TREZOR_SUPPORT_DEVICE_URL } from '@trezor/urls';
 
+import { TrezorLink } from 'src/components/suite';
 import { Translation } from 'src/components/suite/Translation';
 
-import { BridgeStatus, SuiteDesktopTip } from './BridgeTip';
+import { BridgeStatus, SuiteDesktopTip, BridgeToggle, Wrapper } from './BridgeTip';
 import { UdevDescription } from './UdevDescription';
 
 export const TROUBLESHOOTING_TIP_BRIDGE_STATUS = {
@@ -19,11 +21,37 @@ export const TROUBLESHOOTING_TIP_WEBUSB_ENVIRONMENT = {
     hide: !isWeb(),
 };
 
+export const TROUBLESHOOTING_TIP_UNREADABLE_HID = {
+    key: 'unreadable-hid',
+    heading: <Translation id="TR_TROUBLESHOOTING_TIP_UNREADABLE_HID_TITLE" />,
+    description: (
+        <Wrapper>
+            <Translation
+                id="TR_TROUBLESHOOTING_TIP_UNREADABLE_HID_DESCRIPTION"
+                values={{
+                    a: chunks => (
+                        <TrezorLink variant="underline" href={TREZOR_SUPPORT_DEVICE_URL}>
+                            {chunks}
+                        </TrezorLink>
+                    ),
+                }}
+            />
+        </Wrapper>
+    ),
+};
+
 export const TROUBLESHOOTING_TIP_SUITE_DESKTOP = {
     key: 'suite-desktop',
     heading: <Translation id="TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_TITLE" />,
     description: <SuiteDesktopTip />,
     hide: !isWeb(),
+};
+
+export const TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_BRIDGE = {
+    key: 'suite-desktop',
+    heading: <Translation id="TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_BRIDGE_TITLE" />,
+    description: <BridgeToggle />,
+    hide: isWeb() || isAndroid(),
 };
 
 export const TROUBLESHOOTING_TIP_CABLE = {

--- a/packages/suite/src/hooks/suite/useBridgeDesktopApi.ts
+++ b/packages/suite/src/hooks/suite/useBridgeDesktopApi.ts
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+
+import { desktopApi } from '@trezor/suite-desktop-api';
+import { BridgeSettings } from '@trezor/suite-desktop-api/src/messages';
+
+interface Process {
+    service: boolean;
+    process: boolean;
+}
+
+export const useBridgeDesktopApi = () => {
+    const [bridgeProcess, setBridgeProcess] = useState<Process>({ service: false, process: false });
+    const [bridgeSettings, setBridgeSettings] = useState<BridgeSettings | null>(null);
+    const [bridgeDesktopApiError, setBridgeDesktopApiError] = useState<string | null>(null);
+
+    useEffect(() => {
+        desktopApi.getBridgeStatus().then(result => {
+            if (result.success) {
+                setBridgeProcess(result.payload);
+            }
+        });
+
+        desktopApi.on('bridge/status', (status: Process) => {
+            setBridgeProcess(status);
+        });
+
+        desktopApi.getBridgeSettings().then(result => {
+            if (result.success) {
+                setBridgeSettings(result.payload);
+            } else {
+                setBridgeDesktopApiError(result.error);
+            }
+        });
+
+        desktopApi.on('bridge/settings', (settings: BridgeSettings) => {
+            setBridgeSettings(settings);
+        });
+
+        return () => {
+            desktopApi.removeAllListeners('bridge/status');
+            desktopApi.removeAllListeners('bridge/settings');
+        };
+    }, []);
+
+    const changeBridgeSettings = (settings: BridgeSettings) => {
+        desktopApi.changeBridgeSettings(settings);
+    };
+
+    return {
+        bridgeSettings,
+        bridgeProcess,
+        changeBridgeSettings,
+        bridgeDesktopApiError,
+    };
+};

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -100,12 +100,12 @@ export default defineMessages({
     },
     TR_RECONNECT_DEVICE_DESCRIPTION: {
         defaultMessage:
-            'If closing tabs and refreshing this page didn’t help, try reconnecting your Trezor.',
+            'If closing other apps that might be communicating with your Trezor and refreshing this page didn’t help, try reconnecting your Trezor.',
         id: 'TR_RECONNECT_DEVICE_DESCRIPTION',
     },
     TR_RECONNECT_DEVICE_DESCRIPTION_DESKTOP: {
         defaultMessage:
-            "If closing tabs and reopening Trezor Suite doesn't help, try reconnecting your Trezor.",
+            "If closing other apps that might be communicating with your Trezor and reopening Trezor Suite doesn't help, try reconnecting your Trezor.",
         id: 'TR_RECONNECT_DEVICE_DESCRIPTION_DESKTOP',
     },
     TR_ACQUIRE_DEVICE_TITLE: {

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7147,6 +7147,15 @@ export default defineMessages({
             'Only Chromium-based browsers currently allow direct communication with USB devices.',
         id: 'TR_TROUBLESHOOTING_TIP_BROWSER_WEBUSB_DESCRIPTION',
     },
+    TR_TROUBLESHOOTING_TIP_UNREADABLE_HID_TITLE: {
+        defaultMessage: 'You may be using a very old Trezor model',
+        id: 'TR_TROUBLESHOOTING_TIP_UNREADABLE_HID_TITLE',
+    },
+    TR_TROUBLESHOOTING_TIP_UNREADABLE_HID_DESCRIPTION: {
+        defaultMessage:
+            'If the last time you updated your device firmware was in 2019 and earlier please follow instructions in <a>the knowledge base</a>',
+        id: 'TR_TROUBLESHOOTING_TIP_UNREADABLE_HID_DESCRIPTION',
+    },
     TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_TITLE: {
         id: 'TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_TITLE',
         defaultMessage: 'Use the Trezor Suite desktop app',
@@ -7154,6 +7163,15 @@ export default defineMessages({
     TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_DESCRIPTION: {
         id: 'TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_DESCRIPTION',
         defaultMessage: 'Run the  <a>Trezor Suite</a> desktop app',
+    },
+    TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_BRIDGE_TITLE: {
+        id: 'TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_BRIDGE_TITLE',
+        defaultMessage: 'Use another version of Trezor Bridge',
+    },
+    TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_BRIDGE_DESCRIPTION: {
+        id: 'TR_TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_BRIDGE_DESCRIPTION',
+        defaultMessage:
+            '<a>Click to toggle</a> an alternative bridge implementation. Current version: ({currentVersion})',
     },
     TR_TROUBLESHOOTING_TIP_UDEV_INSTALL_DESCRIPTION: {
         id: 'TR_TROUBLESHOOTING_TIP_UDEV_INSTALL_DESCRIPTION',
@@ -7173,6 +7191,7 @@ export default defineMessages({
             'After closing other browser tabs and windows, try quitting and reopening Trezor Suite.',
         id: 'TR_TROUBLESHOOTING_CLOSE_TABS_DESCRIPTION_DESKTOP',
     },
+
     TR_TROUBLESHOOTING_TIP_CABLE_TITLE: {
         id: 'TR_TROUBLESHOOTING_TIP_CABLE_TITLE',
         defaultMessage: 'Try a different cable',
@@ -7207,11 +7226,6 @@ export default defineMessages({
         id: 'TR_TROUBLESHOOTING_TIP_RESTART_COMPUTER_DESCRIPTION',
         defaultMessage:
             'Restarting your computer may fix the communication issue between your browser and device.',
-    },
-    TR_TROUBLESHOOTING_UNREADABLE_WEBUSB: {
-        id: 'TR_TROUBLESHOOTING_UNREADABLE_WEBUSB',
-        defaultMessage:
-            "Your device is connected properly, but your browser can't communicate with it at the moment. You need to install Trezor Bridge.",
     },
     TR_TROUBLESHOOTING_UNREADABLE_UDEV: {
         id: 'TR_TROUBLESHOOTING_UNREADABLE_UDEV',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7196,7 +7196,8 @@ export default defineMessages({
     },
     TR_TROUBLESHOOTING_TIP_COMPUTER_DESCRIPTION: {
         id: 'TR_TROUBLESHOOTING_TIP_COMPUTER_DESCRIPTION',
-        defaultMessage: 'With Trezor Bridge installed.',
+        defaultMessage:
+            'There might be some unexpected issue preventing your computer from talking to your device.',
     },
     TR_TROUBLESHOOTING_TIP_RESTART_COMPUTER_TITLE: {
         id: 'TR_TROUBLESHOOTING_TIP_RESTART_COMPUTER_TITLE',

--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -154,6 +154,7 @@ const getConnectDevice = (dev?: Partial<StringPath<Device>>, feat?: Partial<Feat
             label: 'Unreadable device',
             name: 'name of unreadable device',
             error: 'unreadable device',
+            transportDescriptorType: 0,
         };
     }
 


### PR DESCRIPTION
addressing #14284

todos: 
- do we have a knowledge base article addressing old hid devices fw update issues?
- do we wan't to include button to switch to using old bridge (desktop only)

<img width="757" alt="image" src="https://github.com/user-attachments/assets/42ac8061-b3e1-4e78-be91-93b018179996">

cc @MiroslavProchazka 

resolve #14284