### PR TITLE
fix(suite): updating fiat rates

### DIFF
--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesSelectors.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesSelectors.ts
@@ -18,6 +18,7 @@ import {
     getFiatRateKey,
     getFiatRateKeyFromTicker,
     isNftTokenTransfer,
+    isTestnet,
     roundTimestampToNearestPastHour,
 } from '@suite-common/wallet-utils';
 import {
@@ -137,6 +138,7 @@ export const selectTickersToBeUpdated = (
         const fiatRateKey = getFiatRateKeyFromTicker(ticker, fiatCurrency);
 
         return (
+            !isTestnet(ticker.symbol) &&
             selectShouldUpdateFiatRate(state, currentTimestamp, fiatRateKey, rateType) &&
             !selectIsTickerLoading(state, ticker, fiatCurrency, rateType)
         );

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
@@ -142,7 +142,9 @@ export const updateFiatRatesThunk = createThunk(
             return rate;
         };
 
-        const rates = await Promise.allSettled(tickers.map(fetchRate));
+        const rates = await Promise.allSettled(
+            tickers.filter(({ symbol }) => !isTestnet(symbol)).map(fetchRate),
+        );
 
         return rates;
     },


### PR DESCRIPTION
## Description

Resolve a bug when discovering accounts on dashboard, the fiat rate would not load properly on some coins, 

## Screenshots:

:bug: 
![image](https://github.com/user-attachments/assets/ab2bbdbc-4578-4219-a743-df845d9ca5bf)
