### PR TITLE
fix(suite): fix lng property for zh.json

### DIFF
--- a/packages/suite/src/config/suite/languages.ts
+++ b/packages/suite/src/config/suite/languages.ts
@@ -32,7 +32,7 @@ const LANGUAGES = {
     tr: { name: 'Türkçe', en: 'Turkish', type: 'official' },
     uk: { name: 'Українська', en: 'Ukrainian', type: 'community' },
     vi: { name: 'Tiếng Việt', en: 'Vietnamese' },
-    'zh-CN': { name: '中文(简体)', en: 'Chinese Simplified', type: 'community' },
+    zh: { name: '中文(简体)', en: 'Chinese Simplified', type: 'community' },
     [TRANSLATION_PSEUDOLANGUAGE]: { name: 'TRANSLATION', en: 'TRANSLATION' },
 } as const;
 


### PR DESCRIPTION
Fixing property for Chinese simplified so Suite will display it correctly
<img width="1427" alt="image" src="https://github.com/user-attachments/assets/d5e32cab-f122-4c1b-8677-e659a9703990">
