### PR TITLE
Change the EVM legacy discovery error on old firmware

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -1728,6 +1728,11 @@ export default defineMessages({
         defaultMessage: 'Connection lost',
         id: 'TR_CONNECTION_LOST',
     },
+
+    TR_UPGRADE_FIRMWARE_TO_DISCOVER_ACCOUNT_ERROR: {
+        defaultMessage: 'Upgrade firmware to discover this account. (See the blue banner above.)',
+        id: 'TR_UPGRADE_FIRMWARE_TO_DISCOVER_ACCOUNT_ERROR',
+    },
     TR_DISCONNECT: {
         defaultMessage: 'Disconnect',
         id: 'TR_DISCONNECT',

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardException.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardException.tsx
@@ -7,7 +7,7 @@ import {
     authorizeDeviceThunk,
     restartDiscoveryThunk as restartDiscovery,
 } from '@suite-common/wallet-core';
-import { getNetwork } from '@suite-common/wallet-config';
+import { getNetwork, NetworkType } from '@suite-common/wallet-config';
 import { variables, Button, H3, Image, IconName } from '@trezor/components';
 import { Discovery } from '@suite-common/wallet-types';
 
@@ -102,9 +102,13 @@ const Container = ({ title, description, cta, dataTestBase }: ContainerProps) =>
     );
 };
 
-const getAccountError = (accountError: string) => {
+const getAccountError = (accountError: string, networkType: NetworkType) => {
     if (accountError === 'All backends are down') {
         return <Translation id="TR_CONNECTION_LOST" />;
+    }
+
+    if (networkType === 'ethereum' && accountError === 'Forbidden key path') {
+        return <Translation id="TR_UPGRADE_FIRMWARE_TO_DISCOVER_ACCOUNT_ERROR" />;
     }
 
     return accountError;
@@ -121,9 +125,13 @@ const discoveryFailedMessage = (discovery?: Discovery) => {
         if (networkError.includes(account.symbol)) return value;
         networkError.push(account.symbol);
 
+        const accountTypeDisplay =
+            account.accountType !== 'normal' ? ` ${account.accountType}` : '';
+
         return value.concat(
             <div key={account.symbol}>
-                {network.name}: {getAccountError(account.error)}
+                {network.name}
+                {accountTypeDisplay}: {getAccountError(account.error, network.networkType)}
             </div>,
         );
     }, [] as JSX.Element[]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changed the error message for non-normal EVM account types, when discovery error occurs. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/14638

## Screenshots:

<img width="1100" alt="image" src="https://github.com/user-attachments/assets/4aa904e4-2b4c-4f70-9ac9-1832acd11c42">

