### PR TITLE
Fix/device label selector

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceStatus.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceStatus.tsx
@@ -7,7 +7,7 @@ import { TrezorDevice } from 'src/types/suite';
 import { spacingsPx } from '@trezor/theme';
 import { RotateDeviceImage } from '@trezor/product-components';
 import { DeviceStatusText } from 'src/views/suite/SwitchDevice/DeviceItem/DeviceStatusText';
-import { selectDeviceLabelOrName } from '@suite-common/wallet-core';
+import { selectDeviceLabelOrNameById } from '@suite-common/wallet-core';
 import { useSelector } from 'src/hooks/suite';
 
 type DeviceStatusProps = {
@@ -45,7 +45,7 @@ export const DeviceStatus = ({
     handleRefreshClick,
     forceConnectionInfo = false,
 }: DeviceStatusProps) => {
-    const deviceLabel = useSelector(selectDeviceLabelOrName);
+    const deviceLabel = useSelector(state => selectDeviceLabelOrNameById(state, device?.id));
 
     return (
         <Container>

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -796,15 +796,6 @@ export const selectIsPortfolioTrackerDevice = (state: DeviceRootState) => {
     return device?.id === PORTFOLIO_TRACKER_DEVICE_ID;
 };
 
-export const selectDeviceNameById = (
-    state: DeviceRootState,
-    id: TrezorDevice['id'],
-): string | null => {
-    const device = selectDeviceById(state, id);
-
-    return device?.name ?? null;
-};
-
 export const selectDeviceLabel = (state: DeviceRootState) => {
     const device = selectDevice(state);
 
@@ -817,16 +808,19 @@ export const selectDeviceName = (state: DeviceRootState) => {
     return device?.name;
 };
 
+export const selectDeviceLabelOrNameById = (
+    state: DeviceRootState,
+    id: TrezorDevice['id'],
+): string => {
+    const device = selectDeviceById(state, id);
+
+    return device?.features?.label || device?.name || '';
+};
+
 export const selectDeviceLabelOrName = (state: DeviceRootState): string => {
-    const deviceLabel = selectDeviceLabel(state);
+    const selectedDevice = selectDevice(state);
 
-    if (deviceLabel) {
-        return deviceLabel;
-    }
-
-    const deviceName = selectDeviceName(state);
-
-    return deviceName ?? '';
+    return selectDeviceLabelOrNameById(state, selectedDevice?.id);
 };
 
 export const selectDeviceId = (state: DeviceRootState) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use correct selector in `DeviceStatus` so that a correct device label is shown when multiple devices are connected.

## Screenshots:
before:
![Screenshot 2024-10-01 at 12 03 35](https://github.com/user-attachments/assets/5594b415-b8bc-4de5-9d2a-612b482f1ad4)
after:
![Screenshot 2024-10-01 at 12 00 43](https://github.com/user-attachments/assets/890e93b7-769c-48fe-89a9-832b537641df)

