### PR TITLE
Lock utils improved

### DIFF
--- a/docker/docker-compose.connect-popup-ci.yml
+++ b/docker/docker-compose.connect-popup-ci.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env
+    image: ghcr.io/trezor/trezor-user-env:4ba1d062469911b9be78eff2c0503ac77b06f598
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.connect-popup-test.yml
+++ b/docker/docker-compose.connect-popup-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env
+    image: ghcr.io/trezor/trezor-user-env:4ba1d062469911b9be78eff2c0503ac77b06f598
     environment:
       - DISPLAY=$DISPLAY
       - QT_X11_NO_MITSHM=1

--- a/docker/docker-compose.connect-test.yml
+++ b/docker/docker-compose.connect-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env
+    image: ghcr.io/trezor/trezor-user-env:4ba1d062469911b9be78eff2c0503ac77b06f598
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.connect-webextension-test.yml
+++ b/docker/docker-compose.connect-webextension-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env
+    image: ghcr.io/trezor/trezor-user-env:4ba1d062469911b9be78eff2c0503ac77b06f598
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-ci.yml
+++ b/docker/docker-compose.suite-ci.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env
+    image: ghcr.io/trezor/trezor-user-env:4ba1d062469911b9be78eff2c0503ac77b06f598
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-desktop-ci.yml
+++ b/docker/docker-compose.suite-desktop-ci.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env
+    image: ghcr.io/trezor/trezor-user-env:4ba1d062469911b9be78eff2c0503ac77b06f598
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-dev.yml
+++ b/docker/docker-compose.suite-dev.yml
@@ -4,7 +4,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env
+    image: ghcr.io/trezor/trezor-user-env:4ba1d062469911b9be78eff2c0503ac77b06f598
     environment:
       - DISPLAY=$DISPLAY
       - QT_X11_NO_MITSHM=1

--- a/docker/docker-compose.suite-native-ci.yml
+++ b/docker/docker-compose.suite-native-ci.yml
@@ -3,7 +3,7 @@ services:
   trezor-user-env-unix:
     network_mode: "host"
     container_name: trezor-user-env.unix
-    image: ghcr.io/trezor/trezor-user-env
+    image: ghcr.io/trezor/trezor-user-env:4ba1d062469911b9be78eff2c0503ac77b06f598
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-test.yml
+++ b/docker/docker-compose.suite-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env
+    image: ghcr.io/trezor/trezor-user-env:4ba1d062469911b9be78eff2c0503ac77b06f598
     environment:
       - DISPLAY=$DISPLAY
       - QT_X11_NO_MITSHM=1

--- a/docker/docker-compose.transport-test-ci.yml
+++ b/docker/docker-compose.transport-test-ci.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env
+    image: ghcr.io/trezor/trezor-user-env:4ba1d062469911b9be78eff2c0503ac77b06f598
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/packages/utils/src/getMutex.ts
+++ b/packages/utils/src/getMutex.ts
@@ -1,0 +1,39 @@
+/**
+ * Ensures that since the awaited lock is obtained until unlock return from it
+ * is called, no other part of code can enter the same lock.
+ *
+ * Optionally, it also takes `lockId` param, in which case only actions with
+ * the same lock id are blocking each other.
+ *
+ * Example:
+ *
+ * ```
+ * const lock = getMutex();
+ *
+ * lock().then(unlock => writeToSocket('foo').finally(unlock));
+ * lock().then(unlock => writeToSocket('bar').finally(unlock));
+ * lock('differentLockId').then(unlock => writeToAnotherSocket('baz').finally(unlock));
+ *
+ * const unlock = await lock();
+ * await readFromSocket();
+ * unlock();
+ * ```
+ */
+export const getMutex = () => {
+    const DEFAULT_ID = Symbol();
+    const locks: Record<keyof any, Promise<void>> = {};
+
+    return async (lockId: keyof any = DEFAULT_ID) => {
+        while (locks[lockId]) {
+            await locks[lockId];
+        }
+        let resolve = () => {};
+        locks[lockId] = new Promise<void>(res => {
+            resolve = res;
+        }).finally(() => {
+            delete locks[lockId];
+        });
+
+        return resolve;
+    };
+};

--- a/packages/utils/src/getSynchronize.ts
+++ b/packages/utils/src/getSynchronize.ts
@@ -1,6 +1,8 @@
 /**
  * Ensures that all async actions passed to the returned function are called
  * immediately one after another, without interfering with each other.
+ * Optionally, it also takes `lockId` param, in which case only actions with
+ * the same lock id are blocking each other.
  *
  * Example:
  *
@@ -8,23 +10,28 @@
  * const synchronize = getSynchronize();
  * synchronize(() => asyncAction1());
  * synchronize(() => asyncAction2());
+ * synchronize(() => asyncAction3(), 'differentLockId');
  * ```
  */
 export const getSynchronize = () => {
-    let lock: Promise<unknown> | undefined;
+    const DEFAULT_ID = Symbol();
+    const locks: Record<keyof any, Promise<unknown>> = {};
 
-    return <T>(action: () => T): T extends Promise<unknown> ? T : Promise<T> => {
-        const newLock = (lock ?? Promise.resolve())
+    return <T>(
+        action: () => T,
+        lockId: keyof any = DEFAULT_ID,
+    ): T extends Promise<unknown> ? T : Promise<T> => {
+        const newLock = (locks[lockId] ?? Promise.resolve())
             .catch(() => {})
             .then(action)
             .finally(() => {
-                if (lock === newLock) {
-                    lock = undefined;
+                if (locks[lockId] === newLock) {
+                    delete locks[lockId];
                 }
             });
-        lock = newLock;
+        locks[lockId] = newLock;
 
-        return lock as any;
+        return newLock as any;
     };
 };
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -17,6 +17,7 @@ export * from './createDeferredManager';
 export * from './createLazy';
 export * from './createTimeoutPromise';
 export * from './getLocaleSeparators';
+export * from './getMutex';
 export * from './getNumberFromPixelString';
 export * from './getRandomNumberInRange';
 export * from './getSynchronize';

--- a/packages/utils/tests/createLazy.test.ts
+++ b/packages/utils/tests/createLazy.test.ts
@@ -6,8 +6,7 @@ const returnDelayed =
         new Promise(resolve => setTimeout(() => resolve(value), ms));
 
 describe('createLazy', () => {
-    // setImmediate hacks below works only with legacyFakeTimers
-    jest.useFakeTimers({ legacyFakeTimers: true });
+    jest.useFakeTimers();
 
     it('basic', async () => {
         const initFn = jest.fn(returnDelayed(500));
@@ -20,7 +19,7 @@ describe('createLazy', () => {
         expect(lazy.get()).toEqual(undefined);
         expect(lazy.getPending()).not.toEqual(undefined);
 
-        setImmediate(() => jest.advanceTimersToNextTimer());
+        jest.advanceTimersToNextTimerAsync();
         const res = await initPromise;
 
         expect(res).toEqual('taxation');
@@ -34,7 +33,7 @@ describe('createLazy', () => {
         const disposeFn = jest.fn();
         const lazy = createLazy(initFn, disposeFn);
 
-        setImmediate(() => jest.advanceTimersToNextTimer());
+        jest.advanceTimersToNextTimerAsync();
         await lazy.getOrInit([42]);
 
         expect(lazy.get()).toEqual([42]);

--- a/packages/utils/tests/getMutex.test.ts
+++ b/packages/utils/tests/getMutex.test.ts
@@ -1,0 +1,168 @@
+import { getMutex } from '../src/getMutex';
+import { mockTime, unmockTime } from './utils/mockTime';
+
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+const fail = (reason: string) => {
+    throw new Error(reason);
+};
+
+describe('getMutex', () => {
+    let state: any;
+    let lock: ReturnType<typeof getMutex>;
+
+    const sequence = async (...seq: [any, number][]) => {
+        for (const [str, ms] of seq) {
+            state = str;
+
+            await delay(ms);
+            expect(state).toBe(str);
+        }
+    };
+
+    const sync = (value: any) => (state = value);
+
+    beforeEach(() => {
+        state = 'init';
+        lock = getMutex();
+
+        mockTime();
+    });
+
+    afterEach(() => {
+        unmockTime();
+    });
+
+    it('basic', async () => {
+        await Promise.all([
+            lock().then(unlock => sequence(['init', 3], [42, 9], [null, 3]).finally(unlock)),
+            lock().then(unlock =>
+                sequence(['init', 5], ['boo', 3], [{ foo: 'bar' }, 6]).finally(unlock),
+            ),
+            lock().then(unlock =>
+                sequence([undefined, 8], [[1, 2, 3], 4], [NaN, 2]).finally(unlock),
+            ),
+        ]);
+    });
+
+    it('sync X async', async () => {
+        await Promise.all([
+            expect(
+                lock().then(unlock => {
+                    try {
+                        return sync('foo');
+                    } finally {
+                        unlock();
+                    }
+                }),
+            ).resolves.toBe('foo'),
+            lock().then(unlock => sequence([0, 3], ['a', 5]).finally(unlock)),
+            expect(
+                lock().then(unlock => {
+                    try {
+                        return sync([null, null]);
+                    } finally {
+                        unlock();
+                    }
+                }),
+            ).resolves.toStrictEqual([null, null]),
+        ]);
+    });
+
+    it('with errors', async () => {
+        await Promise.all([
+            lock().then(unlock => sequence(['a', 9]).finally(unlock)),
+            expect(
+                lock().then(unlock =>
+                    delay(5)
+                        .then(() => fail('err'))
+                        .finally(unlock),
+                ),
+            ).rejects.toThrow('err'),
+            lock().then(unlock => sequence(['b', 11]).finally(unlock)),
+            expect(
+                lock().then(unlock => {
+                    try {
+                        fail('err');
+                    } finally {
+                        unlock();
+                    }
+                }),
+            ).rejects.toThrow('err'),
+            lock().then(unlock => sequence(['c', 7]).finally(unlock)),
+        ]);
+    });
+
+    it('nested', done => {
+        lock().then(unlock =>
+            sequence(['a', 3])
+                .then(() => {
+                    // 'c' registers after 'a' ended and while 'b' is running
+                    delay(2).then(() =>
+                        lock()
+                            .then(unlock2 => sequence(['c', 3]).finally(unlock2))
+                            .then(done),
+                    );
+                })
+                .finally(unlock),
+        );
+        lock().then(unlock => sequence(['b', 8]).finally(unlock));
+    });
+
+    it('with keys', async () => {
+        let state1: any, state2: any;
+
+        await Promise.all([
+            lock('lock1').then(async unlock => {
+                state1 = 'a';
+                await delay(3);
+                expect(state1).toBe('a');
+
+                state1 = 'b';
+                await delay(9);
+                expect(state1).toBe('b');
+
+                state1 = 'c';
+                await delay(3);
+                expect(state1).toBe('c');
+
+                unlock();
+            }),
+            lock('lock2').then(async unlock => {
+                expect(state1).toBe('a');
+
+                state2 = 'g';
+                await delay(8);
+                expect(state2).toBe('g');
+                expect(state1).toBe('b');
+
+                state2 = 'h';
+                await delay(11);
+                expect(state2).toBe('h');
+                expect(state1).toBe('d');
+
+                state2 = 'i';
+                await delay(12);
+                expect(state2).toBe('i');
+                expect(state1).toBe('f');
+
+                unlock();
+            }),
+            lock('lock1').then(async unlock => {
+                state1 = 'd';
+                await delay(8);
+                expect(state1).toBe('d');
+
+                state1 = 'e';
+                await delay(4);
+                expect(state1).toBe('e');
+
+                state1 = 'f';
+                await delay(2);
+                expect(state1).toBe('f');
+
+                unlock();
+            }),
+        ]);
+    });
+});

--- a/packages/utils/tests/getSynchronize.test.ts
+++ b/packages/utils/tests/getSynchronize.test.ts
@@ -1,4 +1,5 @@
 import { getSynchronize } from '../src/getSynchronize';
+import { mockTime, unmockTime } from './utils/mockTime';
 
 const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
@@ -24,6 +25,12 @@ describe('getSynchronize', () => {
     beforeEach(() => {
         state = 'init';
         synchronize = getSynchronize();
+
+        mockTime();
+    });
+
+    afterEach(() => {
+        unmockTime();
     });
 
     it('basic', async () => {

--- a/packages/utils/tests/promiseAllSequence.test.ts
+++ b/packages/utils/tests/promiseAllSequence.test.ts
@@ -1,6 +1,15 @@
 import { promiseAllSequence } from '../src/promiseAllSequence';
+import { mockTime, unmockTime } from './utils/mockTime';
 
 describe('promiseAllSequence', () => {
+    beforeEach(() => {
+        mockTime();
+    });
+
+    afterEach(() => {
+        unmockTime();
+    });
+
     it('all passed', async () => {
         const actionInnerProcess = jest.fn();
 

--- a/packages/utils/tests/scheduleAction.test.ts
+++ b/packages/utils/tests/scheduleAction.test.ts
@@ -1,4 +1,5 @@
 import { scheduleAction } from '../src/scheduleAction';
+import { mockTime, unmockTime } from './utils/mockTime';
 
 const ERR_SIGNAL = 'Aborted by signal';
 const ERR_DEADLINE = 'Aborted by deadline';
@@ -26,7 +27,12 @@ describe('scheduleAction', () => {
             return `${addings.length - removals.length} listeners not cleaned`;
     };
 
+    beforeEach(() => {
+        mockTime();
+    });
+
     afterEach(() => {
+        unmockTime();
         jest.clearAllMocks();
     });
 
@@ -60,7 +66,6 @@ describe('scheduleAction', () => {
             throw new Error('Runtime error');
         });
 
-        // note: allow certain errors?
         await expect(() => scheduleAction(spy, { deadline: Date.now() + 1000 })).rejects.toThrow(
             ERR_DEADLINE,
         );
@@ -82,7 +87,6 @@ describe('scheduleAction', () => {
             throw new Error('Runtime error');
         });
 
-        // note: allow certain errors?
         await expect(() =>
             scheduleAction(spy, { deadline: Date.now() + 1000, signal: aborter.signal }),
         ).rejects.toThrow(ERR_SIGNAL);
@@ -102,7 +106,6 @@ describe('scheduleAction', () => {
             throw new Error('Runtime error');
         });
 
-        // note: allow certain errors?
         const result = await scheduleAction(spy, { deadline: Date.now() + 1000 });
 
         expect(result).toEqual('Foo');

--- a/packages/utils/tests/utils/mockTime.ts
+++ b/packages/utils/tests/utils/mockTime.ts
@@ -1,0 +1,16 @@
+let timeMocked = false;
+
+export const mockTime = async () => {
+    jest.useFakeTimers();
+    timeMocked = true;
+
+    await jest.advanceTimersToNextTimerAsync();
+    while (timeMocked && jest.getTimerCount()) {
+        await jest.advanceTimersToNextTimerAsync();
+    }
+};
+
+export const unmockTime = () => {
+    timeMocked = false;
+    jest.useRealTimers();
+};


### PR DESCRIPTION
## Description

- use mocked time in all relevant `@trezor/utils` unit tests, so they're faster and more reliable
- add lock ids to `getSynchronize` util so it's possible to lock async processes separately, based on some unique identifier
- implement `getMutex` util which does the same thing as `getSynchronize` but more raw (so it can be used in more flexible way), and directly use it in `getSynchronize` itself

## Related Issue

Prerequisite for #14442