### PR TITLE
test: deeplink connect native

### DIFF
--- a/packages/trezor-user-env-link/src/api.ts
+++ b/packages/trezor-user-env-link/src/api.ts
@@ -59,6 +59,7 @@ export const MNEMONICS = {
     mnemonic_12: 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle',
     mnemonic_abandon:
         'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+    mnemonic_immune: 'immune enlist rule measure fan swarm mandate track point menu security fan',
 };
 
 export const DEFAULT_BRIDGE_VERSION = '2.0.33';

--- a/suite-common/test-utils/src/conditionalDescribe.ts
+++ b/suite-common/test-utils/src/conditionalDescribe.ts
@@ -1,0 +1,11 @@
+export const conditionalDescribe = (
+    skipCondition: boolean,
+    title: string,
+    fn: jest.EmptyFunction,
+) => {
+    if (skipCondition) {
+        describe.skip(title, fn);
+    } else {
+        describe(title, fn);
+    }
+};

--- a/suite-common/test-utils/src/index.ts
+++ b/suite-common/test-utils/src/index.ts
@@ -1,3 +1,4 @@
 export * from './mocks';
 export * from './configureMockStore';
 export * from './extraDependenciesMock';
+export * from './conditionalDescribe';

--- a/suite-native/app/e2e/tests/deeplinkPopup.test.ts
+++ b/suite-native/app/e2e/tests/deeplinkPopup.test.ts
@@ -1,0 +1,142 @@
+import http from 'http';
+import { exec } from 'child_process';
+
+import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
+import TrezorConnect from '@trezor/connect-mobile';
+
+import {
+    appIsFullyLoaded,
+    disconnectTrezorUserEnv,
+    openApp,
+    prepareTrezorEmulator,
+    restartApp,
+} from '../utils';
+import { onOnboarding } from '../pageObjects/onboardingActions';
+import { onCoinEnablingInit } from '../pageObjects/coinEnablingActions';
+import { onHome } from '../pageObjects/homeActions';
+
+const SERVER_PORT = 8080;
+const SERVER_URL = `http://localhost:${SERVER_PORT}`;
+
+let server: http.Server | undefined;
+
+const openUriScheme = (url: string, platformToOpen: 'android') => {
+    const command = `npx uri-scheme open '${url.replace(/'/g, '')}' --${platformToOpen}`;
+
+    exec(command, (err, stdout, stderr) => {
+        if (err) {
+            console.error(err);
+
+            return;
+        }
+        // eslint-disable-next-line no-console
+        console.info(stdout);
+        console.error(stderr);
+    });
+};
+
+describe('Deeplink connect popup.', () => {
+    beforeAll(async () => {
+        await new Promise(resolve => {
+            server = http.createServer((req, res) => {
+                if (req.url) {
+                    const url = new URL(req.url, SERVER_URL);
+                    TrezorConnect.handleDeeplink(url.href);
+                    res.statusCode = 200;
+                    res.setHeader('Content-Type', 'text/plain');
+                    res.end('Callback URL received successfully!\n');
+                }
+            });
+
+            server.listen(SERVER_PORT, 'localhost', () => {
+                // eslint-disable-next-line no-console
+                console.info(`Server running at ${SERVER_URL}`);
+                resolve(null);
+            });
+        });
+
+        await prepareTrezorEmulator();
+        await openApp({ newInstance: true });
+        await onOnboarding.finishOnboarding();
+
+        await onCoinEnablingInit.waitForScreen();
+        await onCoinEnablingInit.enableNetwork('regtest');
+        await onCoinEnablingInit.clickOnConfirmButton();
+
+        await waitFor(element(by.id('skip-view-only-mode')))
+            .toBeVisible()
+            .withTimeout(10000); // communication between connected Trezor and app takes some time.
+
+        await element(by.id('skip-view-only-mode')).tap();
+
+        // This `TrezorConnect` instance here is pretending to be the integrator or @trezor/connect-mobile
+        await TrezorConnect.init({
+            manifest: {
+                email: 'developer@xyz.com',
+                appUrl: 'http://your.application.com',
+            },
+            deeplinkOpen: url => {
+                openUriScheme(url, 'android');
+            },
+            deeplinkCallbackUrl: `${SERVER_URL}/connect/`,
+            connectSrc: 'https://dev.suite.sldev.cz/connect/develop/',
+        });
+    });
+
+    beforeEach(async () => {
+        await restartApp();
+
+        await device.reverseTcpPort(SERVER_PORT);
+
+        await appIsFullyLoaded();
+
+        await waitFor(element(by.id('@screen/ConnectingDevice')))
+            .toBeVisible()
+            .withTimeout(10000);
+
+        await onHome.waitForScreen();
+    });
+
+    afterAll(async () => {
+        disconnectTrezorUserEnv();
+        await new Promise(resolve => {
+            if (server) {
+                server.close(() => {
+                    resolve(null);
+                });
+            }
+        });
+        await device.terminateApp();
+    });
+
+    it('Handle deeplink', async () => {
+        const promise = TrezorConnect.getAddress({
+            path: "m/49'/0'/0'/0/0",
+            coin: 'btc',
+        });
+
+        await element(by.id('@popup/deeplink-info'));
+
+        await waitFor(element(by.id('@popup/call-device')))
+            .toBeVisible()
+            .withTimeout(10 * 1000);
+        await element(by.id('@popup/call-device')).tap();
+
+        await TrezorUserEnvLink.pressYes();
+
+        const response = await promise;
+        const expectedResponse = {
+            id: 1,
+            payload: {
+                path: [49, 0, 0, 0, 0],
+                serializedPath: 'm/49/0/0/0/0',
+                address: '3J7UQSLAaFh1nkUomVdm8ArifPEvYfNr1o',
+            },
+            success: true,
+        };
+
+        if (JSON.stringify(response) !== JSON.stringify(expectedResponse)) {
+            throw new Error('Result does not match expected.');
+        }
+    });
+});

--- a/suite-native/app/e2e/tests/deeplinkPopup.test.ts
+++ b/suite-native/app/e2e/tests/deeplinkPopup.test.ts
@@ -3,6 +3,7 @@ import { exec } from 'child_process';
 
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 import TrezorConnect from '@trezor/connect-mobile';
+import { conditionalDescribe } from '@suite-common/test-utils';
 
 import {
     appIsFullyLoaded,
@@ -35,7 +36,7 @@ const openUriScheme = (url: string, platformToOpen: 'android') => {
     });
 };
 
-describe('Deeplink connect popup.', () => {
+conditionalDescribe(device.getPlatform() !== 'android', 'Deeplink connect popup.', () => {
     beforeAll(async () => {
         await new Promise(resolve => {
             server = http.createServer((req, res) => {

--- a/suite-native/app/e2e/utils.ts
+++ b/suite-native/app/e2e/utils.ts
@@ -1,7 +1,7 @@
 import { resolveConfig } from 'detox/internals';
 import { expect as detoxExpect } from 'detox';
 
-import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
+import { MNEMONICS, TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
 const APP_LAUNCH_ARGS = {
     // Do not synchronize communication with the trezor bridge and metro server running on localhost. Since the trezor
@@ -9,8 +9,6 @@ const APP_LAUNCH_ARGS = {
     detoxURLBlacklistRegex: '\\("^.*127.0.0.1.*",".*localhost.*","^*clients3\\.google\\.com*"\\)',
 };
 
-// Contains only one BTC account with a single transaction to make the discovery as fast as possible.
-const SIMPLE_SEED = 'immune enlist rule measure fan swarm mandate track point menu security fan';
 const TREZOR_DEVICE_LABEL = 'Trezor T - Tester';
 const platform = device.getPlatform();
 
@@ -94,7 +92,7 @@ export const appIsFullyLoaded = async () => {
         .withTimeout(35000);
 };
 
-export const prepareTrezorEmulator = async (seed: string = SIMPLE_SEED) => {
+export const prepareTrezorEmulator = async (seed: string = MNEMONICS.mnemonic_immune) => {
     if (platform === 'android') {
         // Prepare Trezor device for test scenario
         await TrezorUserEnvLink.disconnect();

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -123,6 +123,7 @@
         "@babel/plugin-transform-export-namespace-from": "^7.23.4",
         "@config-plugins/detox": "^8.0.0",
         "@react-native/babel-preset": "^0.75.2",
+        "@suite-common/test-utils": "workspace:^",
         "@trezor/connect-mobile": "workspace:^",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.11.24",

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -123,6 +123,7 @@
         "@babel/plugin-transform-export-namespace-from": "^7.23.4",
         "@config-plugins/detox": "^8.0.0",
         "@react-native/babel-preset": "^0.75.2",
+        "@trezor/connect-mobile": "workspace:^",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.11.24",
         "babel-plugin-transform-inline-environment-variables": "^0.4.4",

--- a/suite-native/app/tsconfig.json
+++ b/suite-native/app/tsconfig.json
@@ -79,6 +79,9 @@
             "path": "../../packages/trezor-user-env-link"
         },
         {
+            "path": "../../suite-common/test-utils"
+        },
+        {
             "path": "../../packages/connect-mobile"
         }
     ],

--- a/suite-native/app/tsconfig.json
+++ b/suite-native/app/tsconfig.json
@@ -77,6 +77,9 @@
         { "path": "../../packages/theme" },
         {
             "path": "../../packages/trezor-user-env-link"
+        },
+        {
+            "path": "../../packages/connect-mobile"
         }
     ],
     "include": [".", "**.json"]

--- a/suite-native/module-connect-popup/src/screens/ConnectPopupScreen.tsx
+++ b/suite-native/module-connect-popup/src/screens/ConnectPopupScreen.tsx
@@ -103,7 +103,7 @@ export const ConnectPopupScreen = ({
                 }
 
                 return (
-                    <VStack spacing="sp8" alignItems="center">
+                    <VStack testID="@popup/deeplink-info" spacing="sp8" alignItems="center">
                         <Text variant="titleSmall">
                             {method.confirmation?.label ?? method.info}
                         </Text>
@@ -122,7 +122,7 @@ export const ConnectPopupScreen = ({
                         >
                             <Translation id="moduleConnectPopup.areYouSureMessage" />
                         </Text>
-                        <Button onPress={callDevice}>
+                        <Button testID="@popup/call-device" onPress={callDevice}>
                             {method.confirmation?.customConfirmButton?.label ?? (
                                 <Translation id="moduleConnectPopup.confirm" />
                             )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9338,7 +9338,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@suite-common/test-utils@workspace:*, @suite-common/test-utils@workspace:suite-common/test-utils":
+"@suite-common/test-utils@workspace:*, @suite-common/test-utils@workspace:^, @suite-common/test-utils@workspace:suite-common/test-utils":
   version: 0.0.0-use.local
   resolution: "@suite-common/test-utils@workspace:suite-common/test-utils"
   dependencies:
@@ -9596,6 +9596,7 @@ __metadata:
     "@suite-common/message-system": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-constants": "workspace:*"
+    "@suite-common/test-utils": "workspace:^"
     "@suite-common/token-definitions": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9636,6 +9636,7 @@ __metadata:
     "@suite-native/toasts": "workspace:*"
     "@suite-native/transactions": "workspace:*"
     "@trezor/connect": "workspace:*"
+    "@trezor/connect-mobile": "workspace:^"
     "@trezor/react-native-usb": "workspace:*"
     "@trezor/styles": "workspace:*"
     "@trezor/theme": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add new native e2e android test `suite-native/app/e2e/tests/deeplinkPopup.test.ts` where we call a `@trezor/connect-mobile` and get response in callback of a test server to check that we are getting the right response.

## Related Issue
Related https://github.com/trezor/trezor-suite/issues/14744

