### PR TITLE
chore(address-validator) get rid of buffer deprecation warning

### DIFF
--- a/packages/address-validator/src/crypto/blake256.js
+++ b/packages/address-validator/src/crypto/blake256.js
@@ -27,7 +27,7 @@ Blake256.u256 = [
     0x452821e6, 0x38d01377, 0xbe5466cf, 0x34e90c6c, 0xc0ac29b7, 0xc97c50dd, 0x3f84d5b5, 0xb5470917,
 ];
 
-Blake256.padding = new Buffer([
+Blake256.padding = Buffer.from([
     0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -44,7 +44,7 @@ Blake256.prototype._length_carry = function (arr) {
 };
 
 Blake256.prototype.update = function (data, encoding) {
-    data = new Buffer(data, encoding);
+    data = Buffer.from(data, encoding);
     var block = this._block;
     var offset = 0;
 
@@ -62,8 +62,8 @@ Blake256.prototype.update = function (data, encoding) {
     return this;
 };
 
-var zo = new Buffer([0x01]);
-var oo = new Buffer([0x81]);
+var zo = Buffer.from([0x01]);
+var oo = Buffer.from([0x81]);
 
 function rot(x, n) {
     return ((x << (32 - n)) | (x >>> n)) >>> 0;
@@ -91,7 +91,7 @@ function Blake256() {
 
     this._s = [0, 0, 0, 0];
 
-    this._block = new Buffer(64);
+    this._block = Buffer.alloc(64);
     this._blockOffset = 0;
     this._length = [0, 0];
 
@@ -144,7 +144,7 @@ Blake256.prototype._padding = function () {
         hi += 1;
     }
 
-    var msglen = new Buffer(8);
+    var msglen = Buffer.alloc(8);
     msglen.writeUInt32BE(hi, 0);
     msglen.writeUInt32BE(lo, 4);
 
@@ -175,7 +175,7 @@ Blake256.prototype._padding = function () {
 Blake256.prototype.digest = function (encoding) {
     this._padding();
 
-    var buffer = new Buffer(32);
+    var buffer = Buffer.alloc(32);
     for (var i = 0; i < 8; ++i) buffer.writeUInt32BE(this._h[i], i * 4);
     return buffer.toString(encoding);
 };


### PR DESCRIPTION
get rid of deprecation warning in suite unit tests 

<img width="1290" alt="image" src="https://github.com/user-attachments/assets/76468b4a-bfa7-43a6-bf72-fae4bbaa6fa8">
