### PR TITLE
chore(suite): update security check URLs

### DIFF
--- a/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
@@ -1,14 +1,15 @@
 import { useEffect } from 'react';
 
+import { isDeviceAcquired } from '@suite-common/suite-utils';
+import { deviceActions } from '@suite-common/wallet-core';
 import { Card } from '@trezor/components';
 import { getFirmwareVersion } from '@trezor/device-utils';
-import { isDeviceAcquired } from '@suite-common/suite-utils';
+import { TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_URL } from '@trezor/urls';
 
 import { WelcomeLayout } from 'src/components/suite';
 import { useDevice, useDispatch } from 'src/hooks/suite';
 import { captureSentryMessage, withSentryScope } from 'src/utils/suite/sentry';
-import { SecurityCheckFail } from '../SecurityCheck/SecurityCheckFail';
-import { deviceActions } from '@suite-common/wallet-core';
+import { SecurityCheckFail } from 'src/components/suite/SecurityCheck/SecurityCheckFail';
 
 export const DeviceCompromised = () => {
     const dispatch = useDispatch();
@@ -45,7 +46,10 @@ export const DeviceCompromised = () => {
     return (
         <WelcomeLayout>
             <Card data-testid="@device-compromised">
-                <SecurityCheckFail goBack={goToSuite} />
+                <SecurityCheckFail
+                    goBack={goToSuite}
+                    supportUrl={TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_URL}
+                />
             </Card>
         </WelcomeLayout>
     );

--- a/packages/suite/src/components/suite/SecurityCheck/SecurityCheckFail.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/SecurityCheckFail.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { TranslationKey } from '@suite-common/intl-types';
 import { Button, Divider, H2, Row, Text } from '@trezor/components';
 import { spacings, spacingsPx } from '@trezor/theme';
-import { TREZOR_SUPPORT_FW_CHECK_FAILED, Url } from '@trezor/urls';
+import { Url } from '@trezor/urls';
 
 import { Translation } from 'src/components/suite';
 import { SecurityChecklist } from '../../../views/onboarding/steps/SecurityCheck/SecurityChecklist';
@@ -38,14 +38,14 @@ interface SecurityCheckFailProps {
     goBack?: () => void;
     heading?: TranslationKey;
     text?: TranslationKey;
-    supportUrl?: Url;
+    supportUrl: Url;
 }
 
 export const SecurityCheckFail = ({
     goBack,
     heading = 'TR_DEVICE_COMPROMISED_HEADING',
     text = 'TR_DEVICE_COMPROMISED_TEXT',
-    supportUrl = TREZOR_SUPPORT_FW_CHECK_FAILED,
+    supportUrl,
 }: SecurityCheckFailProps) => {
     const chatUrl = `${supportUrl}#open-chat`;
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AuthenticateDeviceFailModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AuthenticateDeviceFailModal.tsx
@@ -1,7 +1,8 @@
 import styled from 'styled-components';
 
 import { Modal } from 'src/components/suite';
-import { SecurityCheckFail } from '../../../SecurityCheck/SecurityCheckFail';
+import { SecurityCheckFail } from 'src/components/suite/SecurityCheck/SecurityCheckFail';
+import { TREZOR_SUPPORT_DEVICE_AUTHENTICATION_FAILED_URL } from '@trezor/urls';
 
 const StyledModal = styled(Modal)`
     text-align: left;
@@ -9,6 +10,6 @@ const StyledModal = styled(Modal)`
 
 export const AuthenticateDeviceFailModal = () => (
     <StyledModal>
-        <SecurityCheckFail />
+        <SecurityCheckFail supportUrl={TREZOR_SUPPORT_DEVICE_AUTHENTICATION_FAILED_URL} />
     </StyledModal>
 );

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/DeviceAuthenticity.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/DeviceAuthenticity.tsx
@@ -4,14 +4,15 @@ import styled from 'styled-components';
 import { checkDeviceAuthenticityThunk } from '@suite-common/device-authenticity';
 import { selectDevice, selectSelectedDeviceAuthenticity } from '@suite-common/wallet-core';
 import { variables } from '@trezor/components';
+import { spacingsPx } from '@trezor/theme';
+import { TREZOR_SUPPORT_DEVICE_AUTHENTICATION_FAILED_URL } from '@trezor/urls';
 
 import { OnboardingButtonCta, OnboardingStepBox } from 'src/components/onboarding';
 import { CollapsibleOnboardingCard } from 'src/components/onboarding/CollapsibleOnboardingCard';
 import { DeviceAuthenticationExplainer, Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
-import { SecurityCheckFail } from '../../../../components/suite/SecurityCheck/SecurityCheckFail';
-import { spacingsPx } from '@trezor/theme';
+import { SecurityCheckFail } from 'src/components/suite/SecurityCheck/SecurityCheckFail';
 
 const StyledCard = styled(CollapsibleOnboardingCard)`
     padding: ${spacingsPx.md};
@@ -109,7 +110,7 @@ export const DeviceAuthenticity = ({ goToNext }: DeviceAuthenticityProps) => {
     if (isCheckFailed) {
         return (
             <StyledCard>
-                <SecurityCheckFail />
+                <SecurityCheckFail supportUrl={TREZOR_SUPPORT_DEVICE_AUTHENTICATION_FAILED_URL} />
             </StyledCard>
         );
     }

--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -25,8 +25,10 @@ export const TREZOR_SUPPORT_DEVICE_URL: Url =
     'https://trezor.io/support/a/trezor-suite-doesn-t-see-my-device';
 export const TREZOR_SUPPORT_RECOVERY_ISSUES_URL: Url =
     'https://trezor.io/support/a/trezor-recovery-issues';
-export const TREZOR_SUPPORT_FW_CHECK_FAILED: Url =
-    'https://trezor.io/support/a/trezor-firmware-revision-check-failed';
+export const TREZOR_SUPPORT_DEVICE_AUTHENTICATION_FAILED_URL: Url =
+    'https://trezor.io/support/a/trezor-safe-device-authentication-check-failed';
+export const TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_URL: Url =
+    'https://trezor.io/support/a/trezor-fw-revision-check-failed';
 export const TREZOR_SUPPORT_FW_ALREADY_INSTALLED: Url =
     'https://trezor.io/support/a/firmware-is-already-installed';
 export const TREZOR_SUPPORT_IS_MY_DEVICE_SAFE: Url =


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Provide different URLs for failed revision/authenticity checks. There used to be one article, now there are two. Clicking "Contact Trezor Support" takes you to a corresponding page, depending on whether firmware revision or device authenticity check failed.
![Screenshot 2024-10-02 at 11 22 01](https://github.com/user-attachments/assets/d4221567-2864-4f94-be8c-1ef24060ca81)
