### PR TITLE
feat: NewModal can have color (to override the variant), also CSSColo…

### DIFF
--- a/packages/components/src/components/Badge/Badge.stories.tsx
+++ b/packages/components/src/components/Badge/Badge.stories.tsx
@@ -11,10 +11,24 @@ export default meta;
 export const Badge: StoryObj<BadgeProps> = {
     args: {
         children: 'Badge label',
+        isDisabled: false,
+        variant: 'primary',
         size: 'tiny',
         ...getFramePropsStory(allowedBadgeFrameProps).args,
     },
     argTypes: {
+        isDisabled: { control: 'boolean' },
+        variant: {
+            control: {
+                type: 'radio',
+            },
+            options: [
+                'primary',
+                'tertiary',
+                'destructive',
+                undefined,
+            ] satisfies BadgeProps['variant'][],
+        },
         size: {
             control: {
                 type: 'radio',

--- a/packages/components/src/components/Badge/Badge.tsx
+++ b/packages/components/src/components/Badge/Badge.tsx
@@ -18,7 +18,7 @@ export type BadgeSize = Extract<UISize, (typeof badgeSizes)[number]>;
 export const allowedBadgeFrameProps = ['margin'] as const satisfies FramePropsKeys[];
 type AllowedFrameProps = Pick<FrameProps, (typeof allowedBadgeFrameProps)[number]>;
 
-type BadgeVariant = Extract<UIVariant, 'primary' | 'tertiary' | 'destructive'>;
+export type BadgeVariant = Extract<UIVariant, 'primary' | 'tertiary' | 'destructive'>;
 
 export type BadgeProps = AllowedFrameProps & {
     size?: BadgeSize;
@@ -150,7 +150,7 @@ export const Badge = ({
                     name={icon}
                     color={
                         isDisabled
-                            ? 'iconDisabled'
+                            ? theme.iconDisabled
                             : mapVariantToIconColor({ $variant: variant, theme })
                     }
                 />

--- a/packages/components/src/components/Divider/Divider.stories.tsx
+++ b/packages/components/src/components/Divider/Divider.stories.tsx
@@ -35,7 +35,7 @@ export const Divider: StoryObj = {
             type: 'number',
         },
         color: {
-            type: 'string',
+            control: 'color',
         },
         ...getFramePropsStory(allowedDividerFrameProps).argTypes,
     },

--- a/packages/components/src/components/Icon/Icon.stories.tsx
+++ b/packages/components/src/components/Icon/Icon.stories.tsx
@@ -12,6 +12,7 @@ import {
     IconName as IconNameDeprecated,
 } from '@suite-common/icons-deprecated/src/webComponents';
 import { getFramePropsStory } from '../../utils/frameProps';
+
 const meta: Meta = {
     title: 'Icons',
     component: IconComponent,
@@ -54,6 +55,9 @@ export const Icon: StoryObj<IconProps> = {
             control: {
                 type: 'select',
             },
+        },
+        color: {
+            control: 'color',
         },
         size: {
             options: iconSizes,

--- a/packages/components/src/components/Icon/Icon.tsx
+++ b/packages/components/src/components/Icon/Icon.tsx
@@ -34,7 +34,7 @@ export type ExclusiveColorOrVariant =
     | {
           variant?: undefined;
           /** @deprecated Use only is case of absolute desperation. Prefer using `variant`. */
-          color?: string;
+          color?: CSSColor;
       };
 
 export const allowedIconFrameProps = [
@@ -70,10 +70,7 @@ export const getColorForIconVariant = ({
     variant,
     theme,
     color,
-}: Pick<IconProps, 'color' | 'variant'> & { theme: DefaultTheme }):
-    | CSSColor
-    | 'inherit'
-    | string => {
+}: Pick<IconProps, 'color' | 'variant'> & { theme: DefaultTheme }): CSSColor => {
     if (color !== undefined) {
         return color;
     }
@@ -92,7 +89,6 @@ const SvgWrapper = styled.div<SvgWrapperProps & TransientProps<AllowedFrameProps
         css`
             cursor: pointer;
         `}
-
     path {
         fill: ${({ $variant, $color, theme }) =>
             getColorForIconVariant({ variant: $variant, color: $color, theme })};

--- a/packages/components/src/components/Icon/icons.stories.tsx
+++ b/packages/components/src/components/Icon/icons.stories.tsx
@@ -152,6 +152,9 @@ export const AllIcons: StoryObj<IconProps> = {
                 type: 'select',
             },
         },
+        color: {
+            control: 'color',
+        },
         size: {
             options: iconSizes,
             control: {

--- a/packages/components/src/components/NewModal/NewModal.stories.tsx
+++ b/packages/components/src/components/NewModal/NewModal.stories.tsx
@@ -46,6 +46,8 @@ export default meta;
 export const NewModal: StoryObj<NewModalProps> = {
     args: {
         variant: 'primary',
+        iconName: undefined,
+        iconComponent: undefined,
         heading: 'Modal heading',
         description: 'Modal description',
         children:
@@ -62,13 +64,30 @@ export const NewModal: StoryObj<NewModalProps> = {
             control: {
                 type: 'radio',
             },
-            options: ['primary', 'warning', 'destructive'],
+            options: [
+                'primary',
+                'warning',
+                'destructive',
+                undefined,
+            ] satisfies NewModalProps['variant'][],
+        },
+        iconComponent: {
+            options: ['nothing', 'purple'],
+            mapping: {
+                nothing: undefined,
+                purple: (
+                    <ModalComponent.Icon
+                        iconName="eap"
+                        iconColor={{ foreground: '#550070', background: '#c458d9' }}
+                    />
+                ),
+            },
         },
         size: {
             control: {
                 type: 'radio',
             },
-            options: ['tiny', 'small', 'medium', 'large'],
+            options: ['tiny', 'small', 'medium', 'large'] satisfies NewModalProps['size'][],
         },
         heading: {
             control: 'text',
@@ -112,7 +131,7 @@ export const NewModal: StoryObj<NewModalProps> = {
                 },
             },
         },
-        icon: {
+        iconName: {
             options: ['none', ...variables.ICONS],
             mapping: {
                 ...variables.ICONS,

--- a/packages/components/src/components/NewModal/NewModalIcon.tsx
+++ b/packages/components/src/components/NewModal/NewModalIcon.tsx
@@ -1,0 +1,57 @@
+import styled from 'styled-components';
+
+import { ExclusiveColorOrVariant, Icon, IconName } from '../Icon/Icon';
+import { TransientProps } from '../../utils/transientProps';
+import { NewModalVariant } from './types';
+import { mapVariantToIconBackground, mapVariantToIconBorderColor } from './utils';
+import { borders, CSSColor, spacingsPx } from '@trezor/theme';
+
+const ICON_SIZE = 40;
+
+export type NewModalIconColors = { foreground: CSSColor; background: CSSColor };
+
+export type NewModalIconExclusiveColorOrVariant =
+    | { variant?: NewModalVariant; iconColor?: undefined }
+    | { variant?: undefined; iconColor?: NewModalIconColors };
+
+type IconWrapperProps = TransientProps<NewModalIconExclusiveColorOrVariant> & {
+    $size: number;
+    $isPushedTop: boolean;
+};
+
+const IconWrapper = styled.div<IconWrapperProps>`
+    width: ${({ $size }) => $size}px;
+    background: ${props => mapVariantToIconBackground(props)};
+    padding: ${spacingsPx.lg};
+    border-radius: ${borders.radii.full};
+    border: ${spacingsPx.sm} solid ${props => mapVariantToIconBorderColor(props)};
+    box-sizing: content-box;
+    margin-bottom: ${spacingsPx.md};
+    margin-top: ${({ $isPushedTop }) => ($isPushedTop ? `-${spacingsPx.md}` : 0)};
+`;
+
+type NewModalIconProps = {
+    isPushedTop?: boolean;
+    iconName: IconName;
+} & NewModalIconExclusiveColorOrVariant;
+
+export const NewModalIcon = ({
+    isPushedTop = false,
+    iconName,
+    iconColor,
+    variant,
+}: NewModalIconProps) => {
+    const wrapperColorOrVariant: TransientProps<NewModalIconExclusiveColorOrVariant> =
+        iconColor === undefined ? { $variant: variant ?? 'primary' } : { $iconColor: iconColor };
+
+    const iconColorOrVariant: ExclusiveColorOrVariant =
+        iconColor === undefined
+            ? { variant: variant ?? 'primary' }
+            : { color: iconColor.foreground };
+
+    return (
+        <IconWrapper $size={ICON_SIZE} $isPushedTop={isPushedTop} {...wrapperColorOrVariant}>
+            <Icon name={iconName} size={ICON_SIZE} {...iconColorOrVariant} />
+        </IconWrapper>
+    );
+};

--- a/packages/components/src/components/NewModal/utils.tsx
+++ b/packages/components/src/components/NewModal/utils.tsx
@@ -2,13 +2,18 @@ import { Color, CSSColor } from '@trezor/theme';
 import { NewModalVariant, NewModalSize, NewModalAlignment } from './types';
 import { DefaultTheme } from 'styled-components';
 import { UIVerticalAlignment, UIHorizontalAlignment } from '../../config/types';
+import { TransientProps } from '../../utils/transientProps';
+import { NewModalIconExclusiveColorOrVariant } from './NewModalIcon';
 
 type MapArgs = {
-    $variant: NewModalVariant;
     theme: DefaultTheme;
-};
+} & TransientProps<NewModalIconExclusiveColorOrVariant>;
 
-export const mapVariantToIconBackground = ({ $variant, theme }: MapArgs): CSSColor => {
+export const mapVariantToIconBackground = ({ $variant, theme, $iconColor }: MapArgs): CSSColor => {
+    if ($variant === undefined) {
+        return $iconColor?.background ?? 'transparent';
+    }
+
     const colorMap: Record<NewModalVariant, Color> = {
         primary: 'backgroundPrimarySubtleOnElevation2',
         warning: 'backgroundAlertYellowSubtleOnElevation2',
@@ -18,7 +23,11 @@ export const mapVariantToIconBackground = ({ $variant, theme }: MapArgs): CSSCol
     return theme[colorMap[$variant]];
 };
 
-export const mapVariantToIconBorderColor = ({ $variant, theme }: MapArgs): CSSColor => {
+export const mapVariantToIconBorderColor = ({ $variant, theme, $iconColor }: MapArgs): CSSColor => {
+    if ($variant === undefined) {
+        return $iconColor?.foreground ?? 'transparent';
+    }
+
     const colorMap: Record<NewModalVariant, Color> = {
         primary: 'backgroundPrimarySubtleOnElevation0',
         warning: 'backgroundAlertYellowSubtleOnElevation0',

--- a/packages/components/src/components/buttons/Button/Button.tsx
+++ b/packages/components/src/components/buttons/Button/Button.tsx
@@ -1,6 +1,6 @@
 import { ButtonHTMLAttributes } from 'react';
 import styled, { useTheme } from 'styled-components';
-import { borders, Elevation, spacingsPx, typography } from '@trezor/theme';
+import { borders, CSSColor, Elevation, spacingsPx, typography } from '@trezor/theme';
 import { Spinner } from '../../loaders/Spinner/Spinner';
 import {
     ButtonSize,
@@ -61,7 +61,6 @@ export const ButtonContainer = styled.button<ButtonContainerProps>`
 
     ${getFocusShadowStyle()}
     ${({ $variant, $isSubtle, $elevation }) => useVariantStyle($variant, $isSubtle, $elevation)}
-
     &:disabled {
         background: ${({ theme }) => theme.backgroundNeutralDisabled};
         color: ${({ theme }) => theme.textDisabled};
@@ -127,15 +126,13 @@ export type ButtonProps = SelectedHTMLButtonProps &
         textWrap?: boolean;
     };
 
-export const getIcon = ({
-    icon,
-    size,
-    color,
-}: {
+type GetIconProps = {
     icon?: IconName | React.ReactElement;
     size?: number;
-    color?: string;
-}) => {
+    color?: CSSColor;
+};
+
+export const getIcon = ({ icon, size, color }: GetIconProps) => {
     if (!icon) return null;
     if (typeof icon === 'string') {
         return <Icon name={icon as IconName} size={size} color={color} />;

--- a/packages/suite/src/components/suite/DeviceDisplay/DisplayPaginatedText.tsx
+++ b/packages/suite/src/components/suite/DeviceDisplay/DisplayPaginatedText.tsx
@@ -6,7 +6,7 @@ import { ResultRow, parseTextToPagesAndLines } from './parseTextToPagesAndLines'
 import { DeviceDisplayText } from './DeviceDisplayText';
 import { DisplayPageSeparator } from './DisplayPageSeparator';
 import { handleOnCopy } from 'src/utils/suite/deviceDisplay';
-import { Icon, IconName } from '@trezor/components';
+import { Icon, IconName, IconProps } from '@trezor/components';
 
 // eslint-disable-next-line local-rules/no-override-ds-component
 const StyledNextIcon = styled(Icon)<{ $isPixelType: boolean }>`
@@ -55,7 +55,7 @@ const Row = ({
     const iconNextName: IconName = isPixelType ? 'addressPixelNext' : 'addressNext';
     const iconContinuesName: IconName = isPixelType ? 'addressPixelContinues' : 'addressContinues';
 
-    const iconConfig = {
+    const iconConfig: Pick<IconProps, 'color' | 'size'> = {
         size: isPixelType ? 10 : 20,
         color: isPixelType ? '#ffffff' : '#959596',
     };

--- a/packages/suite/src/components/suite/QrCode.tsx
+++ b/packages/suite/src/components/suite/QrCode.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 
 import { Icon, Tooltip, variables, intermediaryTheme } from '@trezor/components';
 import { Translation } from './Translation';
+import { CSSColor } from '@trezor/theme/libDev/src';
 
 export const QRCODE_SIZE = 384;
 export const QRCODE_PADDING = 12;
@@ -49,8 +50,8 @@ interface QrCodeProps {
     value: string;
     className?: string;
     showMessage?: boolean;
-    bgColor?: string;
-    fgColor?: string;
+    bgColor?: CSSColor;
+    fgColor?: CSSColor;
 }
 
 export const QrCode = ({ value, className, bgColor, fgColor, showMessage }: QrCodeProps) => (

--- a/packages/suite/src/components/suite/TooltipSymbol.tsx
+++ b/packages/suite/src/components/suite/TooltipSymbol.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react';
 import styled from 'styled-components';
 import { Icon, IconName, Tooltip } from '@trezor/components';
+import { CSSColor } from '@trezor/theme';
 
 // eslint-disable-next-line local-rules/no-override-ds-component
 const InlineTooltip = styled(Tooltip)`
@@ -11,7 +12,7 @@ const InlineTooltip = styled(Tooltip)`
 type TooltipSymbolProps = {
     content: ReactNode;
     icon?: IconName;
-    iconColor?: string;
+    iconColor?: CSSColor;
     className?: string;
 };
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/CopyAddressModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/CopyAddressModal.tsx
@@ -46,7 +46,7 @@ export const CopyAddressModal = ({ address, onCancel, addressType }: CopyAddress
     return (
         <NewModal
             onCancel={onCancel}
-            icon="warning"
+            iconName="warning"
             variant="warning"
             bottomContent={
                 <>

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/NoBackupModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/NoBackupModal.tsx
@@ -19,7 +19,7 @@ export const NoBackupModal = () => {
     return (
         <NewModal
             onCancel={close}
-            icon="warning"
+            iconName="warning"
             variant="warning"
             size="small"
             bottomContent={

--- a/packages/suite/src/components/suite/modals/ReduxModal/UnhideTokenModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UnhideTokenModal.tsx
@@ -43,7 +43,7 @@ export const UnhideTokenModal = ({ address, onCancel }: UnhideTokenModalProps) =
     return (
         <NewModal
             onCancel={onCancel}
-            icon="warning"
+            iconName="warning"
             variant="warning"
             bottomContent={
                 <>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedModal.tsx
@@ -64,7 +64,7 @@ export const ConfirmUnverifiedModal = ({
         <NewModal
             variant="warning"
             size="small"
-            icon="shieldWarning"
+            iconName="shieldWarning"
             onCancel={handleClose}
             bottomContent={
                 <>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DeviceAuthenticityOptOutModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DeviceAuthenticityOptOutModal.tsx
@@ -22,7 +22,7 @@ export const DeviceAuthenticityOptOutModal = ({ onCancel }: DeviceAuthenticityOp
     return (
         <NewModal
             onCancel={onCancel}
-            icon="shieldWarning"
+            iconName="shieldWarning"
             size="small"
             bottomContent={
                 <>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/FirmwareRevisionOptOutModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/FirmwareRevisionOptOutModal.tsx
@@ -22,7 +22,7 @@ export const FirmwareRevisionOptOutModal = ({ onCancel }: DeviceAuthenticityOptO
     return (
         <NewModal
             onCancel={onCancel}
-            icon="shieldWarning"
+            iconName="shieldWarning"
             size="small"
             bottomContent={
                 <>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WipeDeviceModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WipeDeviceModal.tsx
@@ -23,7 +23,7 @@ export const WipeDeviceModal = ({ onCancel }: WipeDeviceModalProps) => {
         <NewModal
             onCancel={onCancel}
             variant="destructive"
-            icon="shieldWarning"
+            iconName="shieldWarning"
             size="small"
             bottomContent={
                 <>

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList.tsx
@@ -8,6 +8,7 @@ import { useSelector } from 'src/hooks/suite';
 import type { AccountUtxo } from '@trezor/connect';
 import { useSendFormContext } from 'src/hooks/wallet';
 import { UtxoSelection } from './UtxoSelection';
+import { CSSColor } from '@trezor/theme';
 
 const Wrapper = styled.section`
     border-bottom: 1px solid ${({ theme }) => theme.legacy.STROKE_GREY};
@@ -46,7 +47,7 @@ interface UtxoSelectionListProps {
     description: ReactNode;
     heading: ReactNode;
     icon: IconName;
-    iconColor?: string;
+    iconColor?: CSSColor;
     utxos: AccountUtxo[];
     withHeader: boolean;
 }

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoTag.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoTag.tsx
@@ -1,9 +1,10 @@
 import { ReactNode } from 'react';
 import { Icon, Tooltip, IconName } from '@trezor/components';
+import { CSSColor } from '@trezor/theme';
 
 interface UtxoTagProps {
     icon: IconName;
-    iconColor: string;
+    iconColor: CSSColor;
     tooltipMessage: ReactNode;
 }
 

--- a/packages/suite/src/views/wallet/send/Outputs/Address.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Address.tsx
@@ -306,7 +306,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
 
     const getBottomTextIconComponent = () => {
         if (hasAddressChecksummed) {
-            return <Icon name="check" size="medium" color="iconDisabled" />;
+            return <Icon name="check" size="medium" color={theme.iconDisabled} />;
         }
 
         if (isAddressWithLabel) {

--- a/packages/theme/src/types.ts
+++ b/packages/theme/src/types.ts
@@ -2,11 +2,5 @@ export type CSSColor =
     | `#${string}`
     | `rgb(${number}, ${number}, ${number})`
     | `rgba(${number}, ${number}, ${number}, ${number})`
-    | 'transparent';
-
-export const isCSSColor = (color: string): color is CSSColor => {
-    const cssColorRegex =
-        /^#([0-9a-fA-F]{3,8})$|^rgba?\((\d{1,3}),\s*(\d{1,3}),\s*(\d{1,3}),?\s*(\d{1,3})\)$/;
-
-    return cssColorRegex.test(color);
-};
+    | 'transparent'
+    | 'currentColor';

--- a/suite-common/icons-deprecated/src/components/Icon.tsx
+++ b/suite-common/icons-deprecated/src/components/Icon.tsx
@@ -26,7 +26,8 @@ function isCSSColor(value: any): value is CSSColor {
         (value.startsWith('#') ||
             value.startsWith('rgb(') ||
             value.startsWith('rgba(') ||
-            value === 'transparent')
+            value === 'transparent' ||
+            value === 'currentColor')
     );
 }
 


### PR DESCRIPTION
- Allows branding of the modal to custom color (while preserving the button variants)
- Fixes the string in IconColor and enforces stronly typed `CSSColor` everywhere

Partially related to https://github.com/trezor/trezor-suite/issues/13990

![image](https://github.com/user-attachments/assets/cfed03f4-0483-4bf7-809f-25463a38633a)


Example usage: 
![image](https://github.com/user-attachments/assets/fb374dd4-38ec-4d9b-8fa9-6035ad106e2c)
