### PR TITLE
fix(suite-native): align asset item values properly

### DIFF
--- a/suite-native/accounts/src/components/AccountsList/AccountsListItemBase.tsx
+++ b/suite-native/accounts/src/components/AccountsList/AccountsListItemBase.tsx
@@ -78,6 +78,7 @@ const valuesContainerStyle = prepareNativeStyle(utils => ({
     maxWidth: '40%',
     flexShrink: 0,
     alignItems: 'flex-end',
+    justifyContent: 'center',
     paddingLeft: utils.spacings.sp8,
 }));
 


### PR DESCRIPTION
Asset name and corresponding fiat amount are misaligned in the latest prod build, this PR fixes it.

## Screenshots:

Before:
![image](https://github.com/user-attachments/assets/44788815-e067-4033-86f3-7c6269bb1f7a)

After:
<img width="356" alt="image" src="https://github.com/user-attachments/assets/72fcbacf-10b2-4a48-860b-3536a9580151">
<img width="356" alt="image" src="https://github.com/user-attachments/assets/2103bf2e-dd2f-4324-82e9-d54fbc060c10">
