### PR TITLE
fix(blockchain-link): do not fetch solana token account signatures fo…

### DIFF
--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -153,14 +153,21 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
 
     const allAccounts = [payload.descriptor, ...tokenAccounts.value.map(a => a.pubkey.toString())];
 
-    const allTxIds = Array.from(
-        new Set(
-            (await Promise.all(allAccounts.map(account => getAllSignatures(api, account))))
-                .flat()
-                .sort((a, b) => b.slot - a.slot)
-                .map(it => it.signature),
-        ),
-    );
+    const allTxIds =
+        details === 'basic' || details === 'txs' || details === 'txids'
+            ? Array.from(
+                  new Set(
+                      (
+                          await Promise.all(
+                              allAccounts.map(account => getAllSignatures(api, account)),
+                          )
+                      )
+                          .flat()
+                          .sort((a, b) => b.slot - a.slot)
+                          .map(it => it.signature),
+                  ),
+              )
+            : [];
 
     const pageNumber = payload.page ? payload.page - 1 : 0;
     // for the first page of txs, payload.page is undefined, for the second page is 2


### PR DESCRIPTION
We use getAccountInfo call to get information about recipients token account. For this purpose we only need token accounts. Previously we were fetching also all signatures for every token account, which was not necessary and caused some transactions to fail, now we dont.


