### PR TITLE
connect - core in suite-desktop

### DIFF
--- a/packages/connect-explorer/src/components/Settings.tsx
+++ b/packages/connect-explorer/src/components/Settings.tsx
@@ -57,6 +57,7 @@ export const Settings = () => {
                 { value: 'iframe', label: 'Iframe' },
                 { value: 'popup', label: 'Popup' },
                 ...(isBetaOnly ? [{ value: 'deeplink', label: 'Deeplink (mobile)' }] : []),
+                ...(isBetaOnly ? [{ value: 'suite-desktop', label: 'Suite desktop' }] : []),
             ],
         },
         {

--- a/packages/connect-web/src/impl/core-in-suite-desktop.ts
+++ b/packages/connect-web/src/impl/core-in-suite-desktop.ts
@@ -23,8 +23,7 @@ import { createDeferred, createDeferredManager, DeferredManager } from '@trezor/
 import { parseConnectSettings } from '../connectSettings';
 
 /**
- * Base class for CoreInPopup methods for TrezorConnect factory.
- * This implementation is directly used here in connect-web, but it is also extended in connect-webextension.
+ * CoreInSuiteDesktop implementation for TrezorConnect factory.
  */
 export class CoreInSuiteDesktop implements ConnectFactoryDependencies<ConnectSettingsWeb> {
     public eventEmitter = new EventEmitter();

--- a/packages/connect-web/src/impl/core-in-suite-desktop.ts
+++ b/packages/connect-web/src/impl/core-in-suite-desktop.ts
@@ -1,0 +1,192 @@
+import EventEmitter from 'events';
+
+// NOTE: @trezor/connect part is intentionally not imported from the index so we do include the whole library.
+import {
+    IFRAME,
+    UiResponseEvent,
+    CallMethodPayload,
+    CallMethodAnyResponse,
+    POPUP,
+} from '@trezor/connect/src/events';
+import * as ERRORS from '@trezor/connect/src/constants/errors';
+import type {
+    ConnectSettings,
+    ConnectSettingsPublic,
+    ConnectSettingsWeb,
+    Manifest,
+    Response,
+} from '@trezor/connect/src/types';
+import { ConnectFactoryDependencies, factory } from '@trezor/connect/src/factory';
+import { Login } from '@trezor/connect/src/types/api/requestLogin';
+import { createDeferred, createDeferredManager, DeferredManager } from '@trezor/utils';
+
+import { parseConnectSettings } from '../connectSettings';
+
+/**
+ * Base class for CoreInPopup methods for TrezorConnect factory.
+ * This implementation is directly used here in connect-web, but it is also extended in connect-webextension.
+ */
+export class CoreInSuiteDesktop implements ConnectFactoryDependencies<ConnectSettingsWeb> {
+    public eventEmitter = new EventEmitter();
+    protected _settings: ConnectSettings;
+    private ws?: WebSocket;
+    private readonly messages: DeferredManager<CallMethodAnyResponse>;
+
+    public constructor() {
+        this._settings = parseConnectSettings();
+        this.messages = createDeferredManager();
+    }
+
+    public manifest(data: Manifest) {
+        this._settings = parseConnectSettings({
+            ...this._settings,
+            manifest: data,
+        });
+    }
+
+    public dispose() {
+        this.eventEmitter.removeAllListeners();
+        this._settings = parseConnectSettings();
+        this.ws?.close();
+
+        return Promise.resolve(undefined);
+    }
+
+    public cancel(_error?: string) {}
+
+    private async handshake() {
+        const { promise, promiseId } = this.messages.create(1000);
+        this.ws?.send(
+            JSON.stringify({
+                id: promiseId,
+                type: POPUP.HANDSHAKE,
+            }),
+        );
+        try {
+            await promise;
+        } catch (err) {
+            console.error(err);
+            throw new Error('Handshake timed out');
+        }
+    }
+
+    public async init(settings: Partial<ConnectSettingsPublic> = {}): Promise<void> {
+        const newSettings = parseConnectSettings({
+            ...this._settings,
+            ...settings,
+        });
+
+        // defaults
+        if (!newSettings.transports?.length) {
+            newSettings.transports = ['BridgeTransport', 'WebUsbTransport'];
+        }
+        this._settings = newSettings;
+
+        this.ws?.close();
+        const wsOpen = createDeferred(1000);
+        this.ws = new WebSocket('ws://localhost:21335/connect-ws');
+        this.ws.addEventListener('opened', () => {
+            wsOpen.resolve();
+        });
+        this.ws.addEventListener('error', () => {
+            wsOpen.reject(new Error('WebSocket error'));
+            this.messages.rejectAll(new Error('WebSocket error'));
+        });
+        this.ws.addEventListener('message', (event: WebSocketEventMap['message']) => {
+            try {
+                const data = JSON.parse(event.data);
+                this.messages.resolve(data.id, data);
+            } catch {
+                // Some undefined message format
+            }
+        });
+        this.ws.addEventListener('close', () => {
+            wsOpen.reject(new Error('WebSocket closed'));
+            this.messages.rejectAll(new Error('WebSocket closed'));
+        });
+
+        // Wait for the connection to be opened
+        if (this.ws.readyState !== WebSocket.OPEN) {
+            // There is some glitch that when reconnecting the open event doesn't fire
+            // So we do this as a workaround
+            setTimeout(() => {
+                if (this.ws?.readyState === WebSocket.OPEN) {
+                    wsOpen.resolve();
+                }
+            }, 500);
+            await wsOpen.promise;
+        }
+
+        return await this.handshake();
+    }
+
+    /**
+     * 1. opens popup
+     * 2. sends request to popup where the request is handled by core
+     * 3. returns response
+     */
+    public async call(params: CallMethodPayload): Promise<CallMethodAnyResponse> {
+        try {
+            if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+                await this.init();
+            }
+            await this.handshake();
+
+            const { promise, promiseId } = this.messages.create();
+
+            this.ws?.send(
+                JSON.stringify({
+                    id: promiseId,
+                    type: IFRAME.CALL,
+                    payload: params,
+                }),
+            );
+
+            return promise;
+        } catch (err) {
+            return {
+                success: false,
+                payload: {
+                    error: err.message,
+                },
+            };
+        }
+    }
+    // this shouldn't be needed, ui response should be handled in suite-desktop
+    uiResponse(_response: UiResponseEvent) {
+        throw ERRORS.TypedError('Method_InvalidPackage');
+    }
+
+    // todo: not supported yet
+    requestLogin(): Response<Login> {
+        throw ERRORS.TypedError('Method_InvalidPackage');
+    }
+
+    // todo: not needed, only because of types
+    disableWebUSB() {
+        throw ERRORS.TypedError('Method_InvalidPackage');
+    }
+
+    // todo: not needed, only because of types
+    requestWebUSBDevice() {
+        throw ERRORS.TypedError('Method_InvalidPackage');
+    }
+
+    // todo: not needed, only because of types
+    renderWebUSBButton() {}
+}
+
+const impl = new CoreInSuiteDesktop();
+
+// Exported to enable using directly
+export const TrezorConnect = factory({
+    // Bind all methods due to shadowing `this`
+    eventEmitter: impl.eventEmitter,
+    init: impl.init.bind(impl),
+    call: impl.call.bind(impl),
+    manifest: impl.manifest.bind(impl),
+    requestLogin: impl.requestLogin.bind(impl),
+    uiResponse: impl.uiResponse.bind(impl),
+    cancel: impl.cancel.bind(impl),
+    dispose: impl.dispose.bind(impl),
+});

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -4,6 +4,7 @@ import type { ConnectSettingsPublic, ConnectSettingsWeb } from '@trezor/connect'
 
 import { CoreInIframe } from './impl/core-in-iframe';
 import { CoreInPopup } from './impl/core-in-popup';
+import { CoreInSuiteDesktop } from './impl/core-in-suite-desktop';
 import { getEnv } from './connectSettings';
 
 const IFRAME_ERRORS = ['Init_IframeBlocked', 'Init_IframeTimeout', 'Transport_Missing'];
@@ -15,7 +16,7 @@ type ConnectWebExtraMethods = {
 };
 
 const impl = new TrezorConnectDynamic<
-    'iframe' | 'core-in-popup',
+    'iframe' | 'core-in-popup' | 'core-in-suite-desktop',
     ConnectSettingsWeb,
     ConnectFactoryDependencies<ConnectSettingsWeb> & ConnectWebExtraMethods
 >({
@@ -28,12 +29,18 @@ const impl = new TrezorConnectDynamic<
             type: 'core-in-popup',
             impl: new CoreInPopup(),
         },
+        {
+            type: 'core-in-suite-desktop',
+            impl: new CoreInSuiteDesktop(),
+        },
     ],
     getInitTarget: (settings: Partial<ConnectSettingsPublic & ConnectSettingsWeb>) => {
         if (settings.coreMode === 'iframe') {
             return 'iframe';
         } else if (settings.coreMode === 'popup') {
             return 'core-in-popup';
+        } else if (settings.coreMode === 'suite-desktop') {
+            return 'core-in-suite-desktop';
         } else {
             if (settings.coreMode && settings.coreMode !== 'auto') {
                 console.warn(`Invalid coreMode: ${settings.coreMode}`);

--- a/packages/connect/src/constants/errors.ts
+++ b/packages/connect/src/constants/errors.ts
@@ -78,6 +78,9 @@ export const serializeError = (payload: any) => {
     if (payload && payload.error instanceof Error) {
         return { error: payload.error.message, code: payload.error.code };
     }
+    if (payload instanceof TrezorError) {
+        return { error: payload.message, code: payload.code };
+    }
 
     return payload;
 };

--- a/packages/connect/src/types/settings.ts
+++ b/packages/connect/src/types/settings.ts
@@ -51,7 +51,7 @@ export interface ConnectSettingsInternal {
 export interface ConnectSettingsWeb {
     hostLabel?: string;
     hostIcon?: string;
-    coreMode?: 'auto' | 'popup' | 'iframe' | 'deeplink';
+    coreMode?: 'auto' | 'popup' | 'iframe' | 'deeplink' | 'suite-desktop';
 }
 export interface ConnectSettingsWebextension {
     /** _extendWebextensionLifetime features makes the service worker in @trezor/connect-webextension stay alive longer */

--- a/packages/suite-desktop-api/src/api.ts
+++ b/packages/suite-desktop-api/src/api.ts
@@ -104,6 +104,7 @@ export interface InvokeChannels {
     'app/auto-start/is-enabled': () => InvokeResult<boolean>;
     'tray/change-settings': (payload: TraySettings) => InvokeResult;
     'tray/get-settings': () => InvokeResult<TraySettings>;
+    'connect-popup/enabled': () => boolean;
     'connect-popup/ready': () => void;
     'connect-popup/response': (response: ConnectPopupResponse) => void;
 }
@@ -169,6 +170,7 @@ export interface DesktopApi {
     changeTraySettings: DesktopApiInvoke<'tray/change-settings'>;
     getTraySettings: DesktopApiInvoke<'tray/get-settings'>;
     // Connect popup
+    connectPopupEnabled: DesktopApiInvoke<'connect-popup/enabled'>;
     connectPopupReady: DesktopApiInvoke<'connect-popup/ready'>;
     connectPopupResponse: DesktopApiInvoke<'connect-popup/response'>;
 }

--- a/packages/suite-desktop-api/src/api.ts
+++ b/packages/suite-desktop-api/src/api.ts
@@ -16,6 +16,8 @@ import {
     BridgeSettings,
     TorSettings,
     TraySettings,
+    ConnectPopupResponse,
+    ConnectPopupCall,
 } from './messages';
 
 // Event messages from renderer to main process
@@ -72,6 +74,9 @@ export interface RendererChannels {
     'tray/settings': TraySettings;
 
     'handshake/event': HandshakeEvent;
+
+    // connect
+    'connect-popup/call': ConnectPopupCall;
 }
 
 // Invocation from renderer process
@@ -99,6 +104,8 @@ export interface InvokeChannels {
     'app/auto-start/is-enabled': () => InvokeResult<boolean>;
     'tray/change-settings': (payload: TraySettings) => InvokeResult;
     'tray/get-settings': () => InvokeResult<TraySettings>;
+    'connect-popup/ready': () => void;
+    'connect-popup/response': (response: ConnectPopupResponse) => void;
 }
 
 type DesktopApiListener = ListenerMethod<RendererChannels>;
@@ -161,4 +168,7 @@ export interface DesktopApi {
     // Tray
     changeTraySettings: DesktopApiInvoke<'tray/change-settings'>;
     getTraySettings: DesktopApiInvoke<'tray/get-settings'>;
+    // Connect popup
+    connectPopupReady: DesktopApiInvoke<'connect-popup/ready'>;
+    connectPopupResponse: DesktopApiInvoke<'connect-popup/response'>;
 }

--- a/packages/suite-desktop-api/src/factory.ts
+++ b/packages/suite-desktop-api/src/factory.ts
@@ -179,6 +179,7 @@ export const factory = <R extends StrictIpcRenderer<any, IpcRendererEvent>>(
         getTraySettings: () => ipcRenderer.invoke('tray/get-settings'),
 
         // Connect popup
+        connectPopupEnabled: () => ipcRenderer.invoke('connect-popup/enabled'),
         connectPopupReady: () => ipcRenderer.invoke('connect-popup/ready'),
         connectPopupResponse: response => ipcRenderer.invoke('connect-popup/response', response),
     };

--- a/packages/suite-desktop-api/src/factory.ts
+++ b/packages/suite-desktop-api/src/factory.ts
@@ -177,5 +177,9 @@ export const factory = <R extends StrictIpcRenderer<any, IpcRendererEvent>>(
             return Promise.resolve({ success: false, error: 'invalid params' });
         },
         getTraySettings: () => ipcRenderer.invoke('tray/get-settings'),
+
+        // Connect popup
+        connectPopupReady: () => ipcRenderer.invoke('connect-popup/ready'),
+        connectPopupResponse: response => ipcRenderer.invoke('connect-popup/response', response),
     };
 };

--- a/packages/suite-desktop-api/src/messages.ts
+++ b/packages/suite-desktop-api/src/messages.ts
@@ -131,6 +131,8 @@ export type ConnectPopupCall = {
     id: number;
     method: string;
     payload: any;
+    processName?: string;
+    origin?: string;
 };
 
 export type ConnectPopupResponse = {

--- a/packages/suite-desktop-api/src/messages.ts
+++ b/packages/suite-desktop-api/src/messages.ts
@@ -126,3 +126,15 @@ export type InvokeResult<Payload = undefined> =
     ExtractUndefined<Payload> extends undefined
         ? { success: true; payload?: Payload } | { success: false; error: string; code?: string }
         : { success: true; payload: Payload } | { success: false; error: string; code?: string };
+
+export type ConnectPopupCall = {
+    id: number;
+    method: string;
+    payload: any;
+};
+
+export type ConnectPopupResponse = {
+    id: number;
+    success: boolean;
+    payload: any;
+};

--- a/packages/suite-desktop-api/src/validation.ts
+++ b/packages/suite-desktop-api/src/validation.ts
@@ -44,5 +44,6 @@ const validChannels: Array<keyof RendererChannels> = [
     'bridge/status',
     'bridge/settings',
     'tray/settings',
+    'connect-popup/call',
 ];
 export const isValidChannel = (channel: any) => validChannels.includes(channel);

--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -37,7 +37,8 @@
         "electron-store": "8.2.0",
         "electron-updater": "6.3.9",
         "openpgp": "^5.11.2",
-        "systeminformation": "^5.23.5"
+        "systeminformation": "^5.23.5",
+        "ws": "^8.18.0"
     },
     "devDependencies": {
         "@currents/playwright": "^1.3.1",
@@ -50,6 +51,7 @@
         "@trezor/trezor-user-env-link": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@types/electron-localshortcut": "^3.1.3",
+        "@types/ws": "^8.5.12",
         "electron": "33.1.0",
         "fs-extra": "^11.2.0",
         "glob": "^10.3.10",

--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -268,7 +268,8 @@ const init = async () => {
         const mainWindow = mainWindowProxy.getInstance();
         const windowExists =
             mainWindow && !mainWindow.isDestroyed() && mainWindow.isClosable() && !app.isHidden();
-        const autoStartCurrentlyEnabled = isAutoStartEnabled();
+        const autoStartCurrentlyEnabled =
+            isAutoStartEnabled() || app.commandLine.hasSwitch('bridge-test');
         logger.info('main', `Before quit, window exists: ${windowExists}`);
         if (
             !stoppingDaemon &&

--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -208,8 +208,12 @@ const init = async () => {
 
         app.dock?.show();
         if (isMacOs()) app.show();
-        if (!mainWindow.isVisible()) mainWindow.show();
-        if (mainWindow.isMinimized()) mainWindow.restore();
+        //if (!mainWindow.isVisible())
+        mainWindow.show();
+        //if (mainWindow.isMinimized())
+        mainWindow.restore();
+        app.focus();
+        mainWindow.moveTop();
         mainWindow.focus();
     };
     app.on('second-instance', reactivateWindow);

--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -144,7 +144,7 @@ const init = async () => {
             interceptor,
             mainThreadEmitter,
         });
-    await loadBackgroundModules(undefined);
+    const backgroundModulesResponse = await loadBackgroundModules(undefined);
 
     // Daemon mode with no UI
     const { wasOpenedAtLogin } = app.getLoginItemSettings();
@@ -222,9 +222,9 @@ const init = async () => {
     // create handler for handshake/load-modules
     const loadModulesResponse = (clientData: HandshakeClient) =>
         loadModules(clientData)
-            .then(payload => ({
+            .then(modulesResponse => ({
                 success: true as const,
-                payload,
+                payload: { ...modulesResponse, ...backgroundModulesResponse },
             }))
             .catch(err => ({
                 success: false as const,

--- a/packages/suite-desktop-core/src/libs/connect-ws.ts
+++ b/packages/suite-desktop-core/src/libs/connect-ws.ts
@@ -1,0 +1,92 @@
+import { WebSocketServer } from 'ws';
+
+import TrezorConnect, { IFRAME, POPUP } from '@trezor/connect';
+
+import { createHttpReceiver } from './http-receiver';
+import { Dependencies } from '../modules';
+
+const LOG_PREFIX = 'connect-ws';
+
+export const exposeConnectWs = ({
+    mainThreadEmitter,
+    httpReceiver,
+}: {
+    mainThreadEmitter: Dependencies['mainThreadEmitter'];
+    httpReceiver: ReturnType<typeof createHttpReceiver>;
+}) => {
+    const { logger } = global;
+
+    const wss = new WebSocketServer({
+        noServer: true,
+    });
+
+    wss.on('listening', () => {
+        logger.info(LOG_PREFIX, 'Websocket server is listening');
+    });
+
+    wss.on('connection', ws => {
+        ws.on('error', err => {
+            logger.error(LOG_PREFIX, err.message);
+        });
+
+        ws.on('message', async data => {
+            logger.debug(LOG_PREFIX, data.toString());
+            let message;
+            try {
+                message = JSON.parse(data.toString());
+            } catch {
+                logger.error(LOG_PREFIX, 'message is not valid JSON');
+
+                return;
+            }
+
+            if (
+                typeof message !== 'object' ||
+                typeof message.id !== 'number' ||
+                typeof message.type !== 'string'
+            ) {
+                logger.error(LOG_PREFIX, 'message is missing required fields (id, type)');
+
+                return;
+            }
+
+            if (message.type === POPUP.HANDSHAKE) {
+                ws.send(JSON.stringify({ id: message.id, type: POPUP.HANDSHAKE, payload: 'ok' }));
+            } else if (message.type === IFRAME.CALL) {
+                if (!message.payload || !message.payload.method) {
+                    logger.error(LOG_PREFIX, 'invalid message payload');
+
+                    return;
+                }
+
+                const { method, ...rest } = message.payload;
+
+                try {
+                    // focus renderer window
+                    mainThreadEmitter.emit('app/show');
+                    // @ts-expect-error
+                    const response = await TrezorConnect[method](rest);
+                    ws.send(
+                        JSON.stringify({
+                            ...response,
+                            id: message.id,
+                        }),
+                    );
+                } finally {
+                    // blur renderer window
+                    // mainThreadEmitter.emit('');
+                }
+            }
+        });
+    });
+
+    httpReceiver.server.on('upgrade', (request, socket, head) => {
+        if (!request?.url) return;
+        const { pathname } = new URL(request.url, 'http://localhost');
+        if (pathname === '/connect-ws') {
+            wss.handleUpgrade(request, socket, head, ws => {
+                wss.emit('connection', ws, request);
+            });
+        }
+    });
+};

--- a/packages/suite-desktop-core/src/libs/find-process-from-port.ts
+++ b/packages/suite-desktop-core/src/libs/find-process-from-port.ts
@@ -1,0 +1,69 @@
+import { spawn } from 'child_process';
+
+export function spawnAndCollectStdout(command: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const child = spawn(command, { shell: true });
+        let stdout = '';
+        let stderr = '';
+        child.stdout.on('data', data => {
+            stdout += data.toString();
+        });
+        child.stderr.on('data', data => {
+            stderr += data.toString();
+        });
+        child.on('close', code => {
+            if (code !== 0) {
+                reject(new Error(`Command failed with code ${code}: ${stderr}`));
+            } else {
+                resolve(stdout);
+            }
+        });
+    });
+}
+
+export async function findProcessFromIncomingPort(port: number) {
+    switch (process.platform) {
+        case 'darwin':
+        case 'linux': {
+            const command = `lsof -iTCP:${port} -sTCP:ESTABLISHED -n -P +c0`;
+            const stdout = await spawnAndCollectStdout(command);
+            const lines = stdout.split('\n');
+            const process = lines.find(line => line.includes(`:${port}->`));
+            if (process) {
+                const name = process.split(/\s+/)[0].replace(/\\x\d{2}/g, ' ');
+                const pid = process.split(/\s+/)[1];
+                const user = process.split(/\s+/)[2];
+
+                return { name, pid, user };
+            }
+
+            return undefined;
+        }
+        case 'win32': {
+            const command = `netstat -ano | findstr :${port} | findstr ESTABLISHED`;
+            const stdout = await spawnAndCollectStdout(command);
+            const lines = stdout.split('\n');
+            const record = lines
+                .map(line => {
+                    const parts = line.split(/\s+/);
+                    const pid = parts[parts.length - 1];
+                    const local = parts[2];
+
+                    return { pid, local };
+                })
+                .find(({ local }) => local.endsWith(`:${port}`));
+            if (record) {
+                const processInfo = await spawnAndCollectStdout(
+                    `tasklist /FI "PID eq ${record.pid}" | findstr ${record.pid}`,
+                );
+                const parts = processInfo.split(/\s+/);
+                const name = parts[0];
+                const user = parts[2];
+
+                return { name, pid: record.pid, user };
+            }
+
+            return undefined;
+        }
+    }
+}

--- a/packages/suite-desktop-core/src/modules/http-receiver.ts
+++ b/packages/suite-desktop-core/src/modules/http-receiver.ts
@@ -65,9 +65,17 @@ export const initBackground: ModuleInitBackground = ({ mainWindowProxy, mainThre
         }
 
         logger.info(SERVICE_NAME, 'Starting server');
-        await receiver.start();
 
-        return receiver.getInfo();
+        try {
+            await receiver.start();
+
+            return receiver.getInfo();
+        } catch (error) {
+            // Don't fail hard if the server can't start
+            logger.error(SERVICE_NAME, 'Failed to start server: ' + error);
+
+            return { url: null };
+        }
     };
 
     const onQuit = async () => {

--- a/packages/suite-desktop-core/src/modules/http-receiver.ts
+++ b/packages/suite-desktop-core/src/modules/http-receiver.ts
@@ -55,7 +55,7 @@ export const initBackground: ModuleInitBackground = ({ mainWindowProxy, mainThre
         });
 
         if (app.commandLine.hasSwitch('expose-connect-ws') || isDevEnv) {
-            exposeConnectWs({ mainThreadEmitter, httpReceiver: receiver });
+            exposeConnectWs({ mainThreadEmitter, httpReceiver: receiver, mainWindowProxy });
         }
 
         logger.info(SERVICE_NAME, 'Starting server');

--- a/packages/suite-desktop-core/src/modules/http-receiver.ts
+++ b/packages/suite-desktop-core/src/modules/http-receiver.ts
@@ -54,7 +54,13 @@ export const initBackground: ModuleInitBackground = ({ mainWindowProxy, mainThre
             return receiver.getRouteAddress(pathname);
         });
 
-        if (app.commandLine.hasSwitch('expose-connect-ws') || isDevEnv) {
+        const connectPopupEnabled = app.commandLine.hasSwitch('expose-connect-ws') || isDevEnv;
+        ipcMain.handle('connect-popup/enabled', ipcEvent => {
+            validateIpcMessage(ipcEvent);
+
+            return connectPopupEnabled;
+        });
+        if (connectPopupEnabled) {
             exposeConnectWs({ mainThreadEmitter, httpReceiver: receiver, mainWindowProxy });
         }
 

--- a/packages/suite-desktop-core/src/modules/trezor-connect.ts
+++ b/packages/suite-desktop-core/src/modules/trezor-connect.ts
@@ -1,92 +1,11 @@
 import { ipcMain } from 'electron';
-import { WebSocketServer } from 'ws';
 
-import TrezorConnect, { DEVICE_EVENT, IFRAME, POPUP } from '@trezor/connect';
+import TrezorConnect, { DEVICE_EVENT } from '@trezor/connect';
 import { createIpcProxyHandler, IpcProxyHandlerOptions } from '@trezor/ipc-proxy';
-import { isDevEnv } from '@suite-common/suite-utils';
 
-import { app } from '../typed-electron';
-
-import { Dependencies, ModuleInit, ModuleInitBackground } from './index';
+import { ModuleInit, ModuleInitBackground } from './index';
 
 export const SERVICE_NAME = '@trezor/connect';
-
-const exposeConnectWs = ({
-    mainThreadEmitter,
-}: {
-    mainThreadEmitter: Dependencies['mainThreadEmitter'];
-}) => {
-    const { logger } = global;
-
-    const wss = new WebSocketServer({
-        port: 8090,
-    });
-
-    wss.on('listening', () => {
-        logger.info(`${SERVICE_NAME}-ws`, 'Listening on ws://localhost:8090');
-    });
-
-    wss.on('connection', ws => {
-        ws.on('error', err => {
-            logger.error(`${SERVICE_NAME}-ws`, err.message);
-        });
-
-        ws.on('message', async data => {
-            logger.debug(`${SERVICE_NAME}-ws`, data.toString());
-            let message;
-            try {
-                message = JSON.parse(data.toString());
-            } catch {
-                logger.error(`${SERVICE_NAME}-ws`, 'message is not valid JSON');
-
-                return;
-            }
-
-            if (
-                typeof message !== 'object' ||
-                typeof message.id !== 'number' ||
-                typeof message.type !== 'string'
-            ) {
-                logger.error(`${SERVICE_NAME}-ws`, 'message is missing required fields (id, type)');
-
-                return;
-            }
-
-            if (message.type === POPUP.HANDSHAKE) {
-                ws.send(JSON.stringify({ id: message.id, type: POPUP.HANDSHAKE, payload: 'ok' }));
-            } else if (message.type === IFRAME.CALL) {
-                if (!message.payload || !message.payload.method) {
-                    logger.error(`${SERVICE_NAME}-ws`, 'invalid message payload');
-
-                    return;
-                }
-
-                const { method, ...rest } = message.payload;
-
-                try {
-                    // focus renderer window
-                    mainThreadEmitter.emit('app/show');
-                    // @ts-expect-error
-                    const response = await TrezorConnect[method](rest);
-                    ws.send(
-                        JSON.stringify({
-                            ...response,
-                            id: message.id,
-                        }),
-                    );
-                } finally {
-                    // blur renderer window
-                    // mainThreadEmitter.emit('');
-                }
-            }
-        });
-    });
-
-    // todo: hmmm am I allowed to use app here directly?
-    app.on('before-quit', () => {
-        wss.close();
-    });
-};
 
 export const initBackground: ModuleInitBackground = ({ mainThreadEmitter, store }) => {
     const { logger } = global;
@@ -108,10 +27,6 @@ export const initBackground: ModuleInitBackground = ({ mainThreadEmitter, store 
                 if (method === 'init') {
                     const response = await TrezorConnect[method](...params);
                     await setProxy(true);
-
-                    if (app.commandLine.hasSwitch('expose-connect-ws') || isDevEnv) {
-                        exposeConnectWs({ mainThreadEmitter });
-                    }
 
                     return response;
                 }

--- a/packages/suite-desktop-core/src/modules/trezor-connect.ts
+++ b/packages/suite-desktop-core/src/modules/trezor-connect.ts
@@ -1,13 +1,94 @@
 import { ipcMain } from 'electron';
+import { WebSocketServer } from 'ws';
 
-import TrezorConnect, { DEVICE_EVENT } from '@trezor/connect';
+import TrezorConnect, { DEVICE_EVENT, IFRAME, POPUP } from '@trezor/connect';
 import { createIpcProxyHandler, IpcProxyHandlerOptions } from '@trezor/ipc-proxy';
+import { isDevEnv } from '@suite-common/suite-utils';
 
-import { Dependencies, mainThreadEmitter, ModuleInitBackground, ModuleInit } from './index';
+import { app } from '../typed-electron';
+
+import { Dependencies, ModuleInit, ModuleInitBackground } from './index';
 
 export const SERVICE_NAME = '@trezor/connect';
 
-export const initBackground: ModuleInitBackground = ({ store }: Pick<Dependencies, 'store'>) => {
+const exposeConnectWs = ({
+    mainThreadEmitter,
+}: {
+    mainThreadEmitter: Dependencies['mainThreadEmitter'];
+}) => {
+    const { logger } = global;
+
+    const wss = new WebSocketServer({
+        port: 8090,
+    });
+
+    wss.on('listening', () => {
+        logger.info(`${SERVICE_NAME}-ws`, 'Listening on ws://localhost:8090');
+    });
+
+    wss.on('connection', ws => {
+        ws.on('error', err => {
+            logger.error(`${SERVICE_NAME}-ws`, err.message);
+        });
+
+        ws.on('message', async data => {
+            logger.debug(`${SERVICE_NAME}-ws`, data.toString());
+            let message;
+            try {
+                message = JSON.parse(data.toString());
+            } catch {
+                logger.error(`${SERVICE_NAME}-ws`, 'message is not valid JSON');
+
+                return;
+            }
+
+            if (
+                typeof message !== 'object' ||
+                typeof message.id !== 'number' ||
+                typeof message.type !== 'string'
+            ) {
+                logger.error(`${SERVICE_NAME}-ws`, 'message is missing required fields (id, type)');
+
+                return;
+            }
+
+            if (message.type === POPUP.HANDSHAKE) {
+                ws.send(JSON.stringify({ id: message.id, type: POPUP.HANDSHAKE, payload: 'ok' }));
+            } else if (message.type === IFRAME.CALL) {
+                if (!message.payload || !message.payload.method) {
+                    logger.error(`${SERVICE_NAME}-ws`, 'invalid message payload');
+
+                    return;
+                }
+
+                const { method, ...rest } = message.payload;
+
+                try {
+                    // focus renderer window
+                    mainThreadEmitter.emit('app/show');
+                    // @ts-expect-error
+                    const response = await TrezorConnect[method](rest);
+                    ws.send(
+                        JSON.stringify({
+                            ...response,
+                            id: message.id,
+                        }),
+                    );
+                } finally {
+                    // blur renderer window
+                    // mainThreadEmitter.emit('');
+                }
+            }
+        });
+    });
+
+    // todo: hmmm am I allowed to use app here directly?
+    app.on('before-quit', () => {
+        wss.close();
+    });
+};
+
+export const initBackground: ModuleInitBackground = ({ mainThreadEmitter, store }) => {
     const { logger } = global;
     logger.info(SERVICE_NAME, `Starting service`);
 
@@ -27,6 +108,10 @@ export const initBackground: ModuleInitBackground = ({ store }: Pick<Dependencie
                 if (method === 'init') {
                     const response = await TrezorConnect[method](...params);
                     await setProxy(true);
+
+                    if (app.commandLine.hasSwitch('expose-connect-ws') || isDevEnv) {
+                        exposeConnectWs({ mainThreadEmitter });
+                    }
 
                     return response;
                 }

--- a/packages/suite/src/actions/suite/initAction.ts
+++ b/packages/suite/src/actions/suite/initAction.ts
@@ -113,6 +113,11 @@ export const init = () => async (dispatch: Dispatch, getState: GetState) => {
     // 13. start fetching staking data if needed, does need to be waited
     dispatch(periodicCheckStakeDataThunk());
 
-    // 14. backend connected, suite is ready to use
+    // 14. init connect popup handler
+    if (isDesktop()) {
+        dispatch(trezorConnectActions.connectPopupInitThunk());
+    }
+
+    // 15. backend connected, suite is ready to use
     dispatch(onSuiteReady());
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
@@ -1,5 +1,7 @@
 import { useCallback } from 'react';
 
+import { selectDevice } from '@suite-common/wallet-core';
+
 import { showAddress } from 'src/actions/wallet/receiveActions';
 import { Translation } from 'src/components/suite';
 import {
@@ -11,12 +13,15 @@ import { useCoinmarketInfo } from 'src/hooks/wallet/coinmarket/useCoinmarketInfo
 import { selectAccountIncludingChosenInCoinmarket } from 'src/reducers/wallet/selectedAccountReducer';
 import { cryptoIdToNetworkSymbol } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 
+import { ConfirmActionModal } from './DeviceContextModal/ConfirmActionModal';
+
 interface ConfirmAddressModalProps
     extends Pick<ConfirmValueModalProps, 'isConfirmed' | 'onCancel' | 'value'> {
     addressPath: string;
 }
 
 export const ConfirmAddressModal = ({ addressPath, value, ...props }: ConfirmAddressModalProps) => {
+    const device = useSelector(selectDevice);
     const account = useSelector(selectAccountIncludingChosenInCoinmarket);
     const { modalCryptoId } = useSelector(state => state.wallet.coinmarket);
     const displayMode = useDisplayMode({ type: 'address' });
@@ -27,7 +32,9 @@ export const ConfirmAddressModal = ({ addressPath, value, ...props }: ConfirmAdd
         [addressPath, value],
     );
 
-    if (!account) return null;
+    if (!device) return null;
+    // TODO: special case for Connect Popup
+    if (!account) return <ConfirmActionModal device={device} />;
 
     const getHeading = () => {
         if (modalCryptoId) {

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmXpubModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmXpubModal.tsx
@@ -1,3 +1,5 @@
+import { selectDevice } from '@suite-common/wallet-core';
+
 import { Translation } from 'src/components/suite';
 import { showXpub } from 'src/actions/wallet/publicKeyActions';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
@@ -6,14 +8,18 @@ import { useSelector } from 'src/hooks/suite';
 import { DisplayMode } from 'src/types/suite';
 
 import { ConfirmValueModal, ConfirmValueModalProps } from './ConfirmValueModal/ConfirmValueModal';
+import { ConfirmActionModal } from './DeviceContextModal/ConfirmActionModal';
 
 export const ConfirmXpubModal = (
     props: Pick<ConfirmValueModalProps, 'isConfirmed' | 'onCancel'>,
 ) => {
+    const device = useSelector(selectDevice);
     const account = useSelector(selectSelectedAccount);
     const { accountLabel } = useSelector(selectLabelingDataForSelectedAccount);
 
-    if (!account) return null;
+    if (!device) return null;
+    // TODO: special case for Connect Popup
+    if (!account) return <ConfirmActionModal device={device} />;
 
     const xpub =
         account.descriptorChecksum !== undefined

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
@@ -31,6 +31,7 @@ import { selectAccountIncludingChosenInCoinmarket } from 'src/reducers/wallet/se
 import { TransactionReviewSummary } from './TransactionReviewSummary';
 import { TransactionReviewOutputList } from './TransactionReviewOutputList/TransactionReviewOutputList';
 import { TransactionReviewEvmExplanation } from './TransactionReviewEvmExplanation';
+import { ConfirmActionModal } from '../DeviceContextModal/ConfirmActionModal';
 
 const StyledModal = styled(Modal)`
     ${Modal.Body} {
@@ -88,8 +89,10 @@ export const TransactionReviewModalContent = ({
         selectSendFormReviewButtonRequestsCount(state, account?.symbol, decreaseOutputId),
     );
 
-    if (!account || !device || !precomposedTx || !precomposedForm) {
-        return null;
+    if (!device) return null;
+    if (!account || !precomposedTx || !precomposedForm) {
+        // TODO: special case for Connect Popup
+        return <ConfirmActionModal device={device} />;
     }
 
     const network = networks[account.symbol];

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectPopupModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectPopupModal.tsx
@@ -1,0 +1,37 @@
+import { H2, Paragraph, NewModal } from '@trezor/components';
+import { spacings } from '@trezor/theme';
+
+import { Translation } from 'src/components/suite';
+
+interface ConnectPopupModalProps {
+    method: string;
+    onConfirm: () => void;
+    onCancel: () => void;
+}
+
+export const ConnectPopupModal = ({ method, onConfirm, onCancel }: ConnectPopupModalProps) => {
+    return (
+        <NewModal
+            onCancel={onCancel}
+            iconName="plugs"
+            variant="primary"
+            bottomContent={
+                <>
+                    <NewModal.Button variant="tertiary" onClick={onCancel}>
+                        <Translation id="TR_CANCEL" />
+                    </NewModal.Button>
+                    <NewModal.Button variant="primary" onClick={onConfirm}>
+                        <Translation id="TR_CONFIRM" />
+                    </NewModal.Button>
+                </>
+            }
+            heading={<Translation id="TR_TREZOR_CONNECT" />}
+        >
+            <H2>{method}</H2>
+            <Paragraph variant="tertiary" margin={{ top: spacings.xs }}>
+                A 3rd party application is trying to connect to your device. Do you want to allow
+                this action?
+            </Paragraph>
+        </NewModal>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectPopupModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectPopupModal.tsx
@@ -5,11 +5,19 @@ import { Translation } from 'src/components/suite';
 
 interface ConnectPopupModalProps {
     method: string;
+    processName?: string;
+    origin?: string;
     onConfirm: () => void;
     onCancel: () => void;
 }
 
-export const ConnectPopupModal = ({ method, onConfirm, onCancel }: ConnectPopupModalProps) => {
+export const ConnectPopupModal = ({
+    method,
+    processName,
+    origin,
+    onConfirm,
+    onCancel,
+}: ConnectPopupModalProps) => {
     return (
         <NewModal
             onCancel={onCancel}
@@ -28,6 +36,18 @@ export const ConnectPopupModal = ({ method, onConfirm, onCancel }: ConnectPopupM
             heading={<Translation id="TR_TREZOR_CONNECT" />}
         >
             <H2>{method}</H2>
+
+            {processName && (
+                <Paragraph margin={{ top: spacings.xs }}>
+                    Process: <strong>{processName}</strong>
+                </Paragraph>
+            )}
+            {origin && (
+                <Paragraph>
+                    Web Origin: <strong>{origin}</strong>
+                </Paragraph>
+            )}
+
             <Paragraph variant="tertiary" margin={{ top: spacings.xs }}>
                 A 3rd party application is trying to connect to your device. Do you want to allow
                 this action?

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
@@ -210,9 +210,11 @@ export const UserContextModal = ({
         case 'connect-popup':
             return (
                 <ConnectPopupModal
-                    onCancel={onCancel}
+                    onCancel={payload.onCancel}
                     onConfirm={payload.onConfirm}
                     method={payload.method}
+                    origin={payload.origin}
+                    processName={payload.processName}
                 />
             );
         default:

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
@@ -42,6 +42,7 @@ import {
     ConfirmUnverifiedAddressModal,
     ConfirmUnverifiedXpubModal,
     ConfirmUnverifiedProceedModal,
+    ConnectPopupModal,
 } from 'src/components/suite/modals';
 import type { AcquiredDevice } from 'src/types/suite';
 
@@ -206,6 +207,14 @@ export const UserContextModal = ({
             return <UnhideTokenModal onCancel={onCancel} address={payload.address} />;
         case 'passphrase-mismatch-warning':
             return <PassphraseMismatchModal onCancel={onCancel} />;
+        case 'connect-popup':
+            return (
+                <ConnectPopupModal
+                    onCancel={onCancel}
+                    onConfirm={payload.onConfirm}
+                    method={payload.method}
+                />
+            );
         default:
             return null;
     }

--- a/packages/suite/src/components/suite/modals/index.tsx
+++ b/packages/suite/src/components/suite/modals/index.tsx
@@ -48,3 +48,4 @@ export { ClaimModal } from './ReduxModal/UserContextModal/ClaimModal/ClaimModal'
 export { MultiShareBackupModal } from './ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupModal';
 export { CopyAddressModal } from './ReduxModal/CopyAddressModal';
 export { UnhideTokenModal } from './ReduxModal/UnhideTokenModal';
+export { ConnectPopupModal } from './ReduxModal/UserContextModal/ConnectPopupModal';

--- a/suite-common/connect-init/package.json
+++ b/suite-common/connect-init/package.json
@@ -19,6 +19,7 @@
         "@suite-common/wallet-core": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/env-utils": "workspace:^",
+        "@trezor/suite-desktop-api": "workspace:*",
         "@trezor/utils": "workspace:*"
     },
     "devDependencies": {

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -193,8 +193,6 @@ export const connectPopupCallThunk = createThunk(
 
             if (!device) {
                 console.error('Device not found');
-                // Need to select device first
-                dispatch(extra.thunks.openSwitchDeviceDialog());
 
                 // TODO: wait for device selection and continue
                 throw ERRORS.TypedError('Device_NotFound');

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -177,10 +177,14 @@ export const connectPopupCallThunk = createThunk(
             id,
             method,
             payload,
+            processName,
+            origin,
         }: {
             id: number;
             method: string;
             payload: any;
+            processName?: string;
+            origin?: string;
         },
         { dispatch, getState, extra },
     ) => {
@@ -210,8 +214,11 @@ export const connectPopupCallThunk = createThunk(
             dispatch(
                 extra.actions.openModal({
                     type: 'connect-popup',
+                    onCancel: () => confirmation.reject(ERRORS.TypedError('Method_Cancel')),
                     onConfirm: () => confirmation.resolve(),
                     method: methodInfo.payload.info,
+                    processName,
+                    origin,
                 }),
             );
             await confirmation.promise;

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -251,13 +251,12 @@ export const connectPopupCallThunk = createThunk(
 
 export const connectPopupInitThunk = createThunk(
     `${CONNECT_INIT_MODULE}/initPopupThunk`,
-    (_, { dispatch }) => {
-        if (!desktopApi.available) {
-            return;
+    async (_, { dispatch }) => {
+        if (desktopApi.available && (await desktopApi.connectPopupEnabled())) {
+            desktopApi.on('connect-popup/call', params => {
+                dispatch(connectPopupCallThunk(params));
+            });
+            desktopApi.connectPopupReady();
         }
-        desktopApi.on('connect-popup/call', params => {
-            dispatch(connectPopupCallThunk(params));
-        });
-        desktopApi.connectPopupReady();
     },
 );

--- a/suite-common/connect-init/tsconfig.json
+++ b/suite-common/connect-init/tsconfig.json
@@ -9,6 +9,9 @@
         { "path": "../wallet-core" },
         { "path": "../../packages/connect" },
         { "path": "../../packages/env-utils" },
+        {
+            "path": "../../packages/suite-desktop-api"
+        },
         { "path": "../../packages/utils" }
     ]
 }

--- a/suite-common/suite-types/src/modal.ts
+++ b/suite-common/suite-types/src/modal.ts
@@ -187,5 +187,8 @@ export type UserContextPayload =
     | {
           type: 'connect-popup';
           onConfirm: () => void;
+          onCancel: () => void;
           method: string;
+          processName?: string;
+          origin?: string;
       };

--- a/suite-common/suite-types/src/modal.ts
+++ b/suite-common/suite-types/src/modal.ts
@@ -183,4 +183,9 @@ export type UserContextPayload =
       }
     | {
           type: 'passphrase-mismatch-warning';
+      }
+    | {
+          type: 'connect-popup';
+          onConfirm: () => void;
+          method: string;
       };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8529,6 +8529,7 @@ __metadata:
     "@suite-common/wallet-core": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/env-utils": "workspace:^"
+    "@trezor/suite-desktop-api": "workspace:*"
     "@trezor/utils": "workspace:*"
     redux-mock-store: "npm:^1.5.4"
     redux-thunk: "npm:^2.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11451,6 +11451,7 @@ __metadata:
     "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@types/electron-localshortcut": "npm:^3.1.3"
+    "@types/ws": "npm:^8.5.12"
     chalk: "npm:^4.1.2"
     electron: "npm:33.1.0"
     electron-localshortcut: "npm:^3.2.1"
@@ -11462,6 +11463,7 @@ __metadata:
     systeminformation: "npm:^5.23.5"
     terser-webpack-plugin: "npm:^5.3.9"
     webpack: "npm:^5.96.1"
+    ws: "npm:^8.18.0"
     xvfb-maybe: "npm:^0.2.1"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
So far only some preliminary research and exploration of replacing connect-popup with suite-desktop. My general idea is to merge this feature behind debug. The motivation is that there are similar UX problems to be solved for both core-in-suite-native and core-in-suite-desktop so it makes sense to me to have some playground available for both.

suite-desktop:
- in dev or when `--expose-connect-ws` flag is on, suite-desktop opens websocket on 8090 and accepts connect calls here.
- the 1st commit has support for inter-module inducted window-focus and window-blur. it probably needs some more polishing.

connect-web:
- added new imp `core-in-suite-desktop`. what is a better name? `core-in-ws-server`?
- this impl should later be available also from base `connect` package. And also from `connect-webextension`. I need to discuss this with @karliatto 
-

<img width="1410" alt="image" src="https://github.com/user-attachments/assets/933b85dd-e939-4a41-bf6a-2b0d5d1f4512">
