### PR TITLE
chore(suite): remove synchronize of connect calls

### DIFF
--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -6,7 +6,6 @@ import TrezorConnect, {
     TRANSPORT_EVENT,
     UI_EVENT,
 } from '@trezor/connect';
-import { getSynchronize } from '@trezor/utils';
 import { deviceConnectThunks } from '@suite-common/wallet-core';
 import { resolveStaticPath } from '@suite-common/suite-utils';
 import { isNative } from '@trezor/env-utils';
@@ -59,8 +58,6 @@ export const connectInitThunk = createThunk(
             dispatch(action);
         });
 
-        const synchronize = getSynchronize();
-
         const wrappedMethods: Array<keyof typeof TrezorConnect> = [
             'applySettings',
             'authenticateDevice',
@@ -101,7 +98,7 @@ export const connectInitThunk = createThunk(
             if (!original) return;
             (TrezorConnect[key] as any) = async (params: any) => {
                 dispatch(lockDevice(true));
-                const result = await synchronize(() => original(params));
+                const result = await original(params);
                 dispatch(lockDevice(false));
 
                 return result;


### PR DESCRIPTION
This was a band-aid introduced in #9851 and I don't remember why anymore. 🤔 

And I am questioning whether it is still needed after all the changes and refactorings done on lower level in connect core, mainly by @marekrjpolak. Because if not, then we could get rid of all the connect methods wrapping here, see in #14690 where I am replacing the remaining functionality with a connected event (813585f1510f6db470f09ac022c5c16216fbd3ca)