### PR TITLE
feat(coinmarket): disable 'you buy' select in trezor btc only firmware

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -10,7 +10,6 @@ import { arrayPartition } from '@trezor/utils';
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 import { networks, Network, NetworkSymbol, NetworkAccount } from '@suite-common/wallet-config';
 import { CollapsibleBox, NewModal, Tooltip } from '@trezor/components';
-import { FirmwareType } from '@trezor/connect';
 import { spacings, spacingsPx } from '@trezor/theme';
 import { Translation, CoinList } from 'src/components/suite';
 import { Account } from 'src/types/wallet';
@@ -78,7 +77,7 @@ export const AddAccountModal = ({
     const preselectedNetwork = symbol && supportedNetworks.find(n => n.symbol === symbol);
     // or in case of only btc is enabled on bitcoin-only firmware
     const bitcoinOnlyDefaultNetworkSelection =
-        device.firmwareType === FirmwareType.BitcoinOnly &&
+        hasBitcoinOnlyFirmware(device) &&
         supportedMainnets.length === 1 &&
         allTestnetNetworksDisabled
             ? networks.btc

--- a/packages/suite/src/types/coinmarket/coinmarketForm.ts
+++ b/packages/suite/src/types/coinmarket/coinmarketForm.ts
@@ -305,6 +305,7 @@ export interface CoinmarketFormInputCryptoSelectProps<TFieldValues extends Field
     cryptoSelectName: FieldPath<TFieldValues>;
     supportedCryptoCurrencies: Set<CryptoId> | undefined;
     methods: UseFormReturn<TFieldValues>;
+    isDisabled?: boolean;
 }
 
 export interface CoinmarketFormInputFiatCryptoProps<TFieldValues extends FieldValues> {

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputCryptoSelect.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputCryptoSelect.tsx
@@ -37,6 +37,7 @@ export const CoinmarketFormInputCryptoSelect = <
     cryptoSelectName,
     supportedCryptoCurrencies,
     methods,
+    isDisabled,
 }: CoinmarketFormInputCryptoSelectProps<TFieldValues>) => {
     const context = useCoinmarketFormContext<CoinmarketTradeBuyExchangeType>();
     const { buildCryptoOptions, cryptoIdToPlatformName } = useCoinmarketInfo();
@@ -130,6 +131,7 @@ export const CoinmarketFormInputCryptoSelect = <
                         data-testid="@coinmarket/form/select-crypto"
                         isClearable={false}
                         isMenuOpen={false}
+                        isDisabled={isDisabled}
                     />
                 )}
             />

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInputs.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInputs.tsx
@@ -33,6 +33,7 @@ import { CoinmarketBalance } from 'src/views/wallet/coinmarket/common/Coinmarket
 import { TokenAddress } from '@suite-common/wallet-types';
 import { formatAmount } from '@suite-common/wallet-utils';
 import { getNetworkDecimals } from 'src/utils/wallet/coinmarket/coinmarketUtils';
+import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 
 const CoinmarketFeesWrapper = styled.div`
     margin-bottom: ${spacingsPx.md};
@@ -224,7 +225,7 @@ export const CoinmarketFormInputs = () => {
         );
     }
 
-    const { buyInfo } = context;
+    const { buyInfo, device } = context;
     const { currencySelect, cryptoSelect } = context.getValues();
     const supportedCryptoCurrencies = buyInfo?.supportedCryptoCurrencies;
 
@@ -236,6 +237,7 @@ export const CoinmarketFormInputs = () => {
                     cryptoSelectName={FORM_CRYPTO_CURRENCY_SELECT}
                     supportedCryptoCurrencies={supportedCryptoCurrencies}
                     methods={{ ...context }}
+                    isDisabled={hasBitcoinOnlyFirmware(device)}
                 />
             </CoinmarketFormInput>
             <CoinmarketFormInput>

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketLayoutNavigation.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketLayoutNavigation.tsx
@@ -1,11 +1,11 @@
 import styled, { css } from 'styled-components';
 import { useDevice, useSelector } from 'src/hooks/suite';
-import { FirmwareType } from '@trezor/connect';
 import { TranslationKey } from '@suite-common/intl-types';
 import { Route } from '@suite-common/suite-types';
 import { borders, spacingsPx, typography } from '@trezor/theme';
 import { NavigationItem } from '../../../../../components/suite/layouts/SuiteLayout/Sidebar/NavigationItem';
 import { variables, IconName } from '@trezor/components';
+import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 
 const List = styled.div`
     display: flex;
@@ -37,8 +37,6 @@ export const CoinmarketLayoutNavigation = () => {
 
     const { device } = useDevice();
 
-    const isBitcoinOnly = device?.firmwareType === FirmwareType.BitcoinOnly;
-
     const Item = ({
         route,
         title,
@@ -63,7 +61,7 @@ export const CoinmarketLayoutNavigation = () => {
             <Item route="wallet-coinmarket-buy" title="TR_NAV_BUY" icon="plus" />
             <Item route="wallet-coinmarket-sell" title="TR_NAV_SELL" icon="minus" />
 
-            {!isBitcoinOnly ? (
+            {!hasBitcoinOnlyFirmware(device) ? (
                 <Item
                     route="wallet-coinmarket-exchange"
                     title="TR_COINMARKET_SWAP"

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayoutNew/CoinmarketLayoutNavigation/CoinmarketLayoutNavigation.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayoutNew/CoinmarketLayoutNavigation/CoinmarketLayoutNavigation.tsx
@@ -1,12 +1,12 @@
 import styled from 'styled-components';
 import { useDevice, useSelector } from 'src/hooks/suite';
-import { FirmwareType } from '@trezor/connect';
 import CoinmarketLayoutNavigationItem from './CoinmarketLayoutNavigationItem';
 import { Divider } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 import regional from 'src/constants/wallet/coinmarket/regional';
 import { getIsTorEnabled } from 'src/utils/suite/tor';
 import { SelectedAccountLoaded } from '@suite-common/wallet-types';
+import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 
 const List = styled.div`
     display: flex;
@@ -24,7 +24,6 @@ interface CoinmarketLayoutNavigationProps {
 
 const CoinmarketLayoutNavigation = ({ selectedAccount }: CoinmarketLayoutNavigationProps) => {
     const { device } = useDevice();
-    const isBitcoinOnly = device?.firmwareType === FirmwareType.BitcoinOnly;
 
     const isBtcAccount = selectedAccount.account.symbol === 'btc';
     const torStatus = useSelector(state => state.suite.torStatus);
@@ -49,7 +48,7 @@ const CoinmarketLayoutNavigation = ({ selectedAccount }: CoinmarketLayoutNavigat
                 icon="minus"
             />
 
-            {!isBitcoinOnly ? (
+            {!hasBitcoinOnlyFirmware(device) ? (
                 <CoinmarketLayoutNavigationItem
                     route="wallet-coinmarket-exchange"
                     title="TR_COINMARKET_SWAP"

--- a/packages/suite/src/views/wallet/transactions/TradeBox/TradeBoxMenu.tsx
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/TradeBoxMenu.tsx
@@ -1,7 +1,7 @@
 import { Route } from '@suite-common/suite-types';
 import { Account } from '@suite-common/wallet-types';
 import { Button, variables } from '@trezor/components';
-import { FirmwareType } from '@trezor/connect';
+import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 import { EventType, analytics } from '@trezor/suite-analytics';
 import { spacingsPx } from '@trezor/theme';
 import { ReactNode } from 'react';
@@ -61,13 +61,7 @@ export const TradeBoxMenu = ({ account }: TradeBoxMenuProps) => {
     return (
         <Wrapper>
             {menuItems
-                .filter(
-                    item =>
-                        !(
-                            item.type === 'exchange' &&
-                            device?.firmwareType === FirmwareType.BitcoinOnly
-                        ),
-                )
+                .filter(item => !(item.type === 'exchange' && hasBitcoinOnlyFirmware(device)))
                 .map(item => (
                     <StyledButton
                         $isHideable={!!item.isHideable}


### PR DESCRIPTION
## Description 
- Bitcoin-only hardware is limited so that Swaps are not showing, we should also limit Buy to Bitcoin only.
- `You buy` dropdown should be displayed to indicate BTC, but disabled.
![image](https://github.com/user-attachments/assets/4169eb96-f776-4f33-a5c2-bdb13d062b9d)

## Related
Resolves https://github.com/trezor/trezor-suite/issues/14693
