### PR TITLE
fix(suite): HiddenPlaceholder onHover when not discreet mode

### DIFF
--- a/packages/components/src/components/Table/Table.stories.tsx
+++ b/packages/components/src/components/Table/Table.stories.tsx
@@ -37,8 +37,20 @@ export const Table: StoryObj = {
     ),
     args: {
         ...getFramePropsStory(allowedTableFrameProps).args,
+        colWidths: 'none',
     },
     argTypes: {
         ...getFramePropsStory(allowedTableFrameProps).argTypes,
+        colWidths: {
+            options: ['none', 'fixed'],
+            mapping: { none: undefined, fixed: ['150px', '400px'] },
+            control: {
+                type: 'select',
+                labels: {
+                    none: 'undefined',
+                    fixed: "fixed = ['150px', '400px']",
+                },
+            },
+        },
     },
 };

--- a/packages/components/src/components/Table/Table.tsx
+++ b/packages/components/src/components/Table/Table.tsx
@@ -43,7 +43,7 @@ export const Table = ({ children, margin, colWidths }: TableProps) => {
                     {colWidths && (
                         <colgroup>
                             {colWidths.map((width, index) => (
-                                <col key={index} style={{ width }} />
+                                <col key={index} style={{ minWidth: width, maxWidth: width }} />
                             ))}
                         </colgroup>
                     )}

--- a/packages/suite/src/components/suite/HiddenPlaceholder.tsx
+++ b/packages/suite/src/components/suite/HiddenPlaceholder.tsx
@@ -8,7 +8,6 @@ type WrapperProps = {
     $intensity: number;
     $discreetMode: boolean;
     $minWidth?: number;
-    $disableKeepingWidth?: boolean;
 };
 
 const Wrapper = styled.span<WrapperProps>`
@@ -26,9 +25,8 @@ const Wrapper = styled.span<WrapperProps>`
             }
         `}
 
-    ${({ $minWidth, $disableKeepingWidth }: WrapperProps) =>
+    ${({ $minWidth }: WrapperProps) =>
         !!$minWidth &&
-        !$disableKeepingWidth &&
         css`
             display: inline-block;
             min-width: ${$minWidth}px;
@@ -95,14 +93,15 @@ export const HiddenPlaceholder = ({
         setWrapperMinWidth(undefined);
     };
 
+    const shouldEnforceMinWidth = discreetMode && !disableKeepingWidth;
+
     return (
         <Wrapper
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}
             $discreetMode={discreetMode}
             $intensity={enforceIntensity !== undefined ? enforceIntensity : automaticIntensity}
-            $disableKeepingWidth={disableKeepingWidth}
-            $minWidth={wrapperMinWidth}
+            $minWidth={shouldEnforceMinWidth ? wrapperMinWidth : undefined}
             className={className}
             ref={ref}
             data-testid={dataTestId}


### PR DESCRIPTION
## Description

Fix oversight from #14528 
- when **not** in discreet mode, turn off the "keeping width behavior" altogether.
- refactor Table so that `colWidths` pro _enforces_ the width rather than just _preferring_ it

These two may seem unrelated, but are related to `TokensTable`