### PR TITLE
refactor(suite-native): use spacings constants for gap attributes

### DIFF
--- a/suite-native/device-manager/src/components/DeviceItem/DeviceItemContent.tsx
+++ b/suite-native/device-manager/src/components/DeviceItem/DeviceItemContent.tsx
@@ -38,12 +38,12 @@ const contentWrapperStyle = prepareNativeStyle<{ height: number }>((utils, { hei
     spacing: utils.spacings.sp16,
 }));
 
-const itemStyle = prepareNativeStyle<{ isCompact: boolean }>((_, { isCompact }) => ({
+const itemStyle = prepareNativeStyle<{ isCompact: boolean }>((utils, { isCompact }) => ({
     flexShrink: 1,
     extend: {
         condition: !isCompact,
         style: {
-            gap: 2,
+            gap: utils.spacings.sp2,
         },
     },
 }));

--- a/suite-native/device-manager/src/components/DeviceManagerContent.tsx
+++ b/suite-native/device-manager/src/components/DeviceManagerContent.tsx
@@ -26,8 +26,8 @@ import { useDeviceManager } from '../hooks/useDeviceManager';
 const CONTENT_MAX_HEIGHT = Dimensions.get('window').height * 0.8;
 const HEADER_HEIGHT = 86;
 
-const scrollViewStyle = prepareNativeStyle<{ maxHeight: number }>((_, { maxHeight }) => ({
-    gap: 12,
+const scrollViewStyle = prepareNativeStyle<{ maxHeight: number }>((utils, { maxHeight }) => ({
+    gap: utils.spacings.sp12,
     flexGrow: 0,
     maxHeight,
     borderBottomLeftRadius: MANAGER_MODAL_BOTTOM_RADIUS,

--- a/suite-native/device-manager/src/components/WalletItem.tsx
+++ b/suite-native/device-manager/src/components/WalletItem.tsx
@@ -23,7 +23,7 @@ const walletItemStyle = prepareNativeStyle<WalletItemStyleProps>(
         justifyContent: 'space-between',
         alignItems: 'center',
         height: 60,
-        gap: 12,
+        gap: utils.spacings.sp12,
         borderRadius: 12,
         borderColor: utils.colors.borderElevation1,
         flex: 1,

--- a/suite-native/module-add-accounts/src/screens/SelectAccountTypeScreen.tsx
+++ b/suite-native/module-add-accounts/src/screens/SelectAccountTypeScreen.tsx
@@ -79,7 +79,7 @@ const aboutStyle = prepareNativeStyle((utils, { bottomInset }: { bottomInset: nu
     paddingBottom: EXTRA_BOTTOM_PADDING + GRADIENT_HEIGHT + bottomInset,
     width: '100%',
     paddingHorizontal: utils.spacings.sp8,
-    gap: 12,
+    gap: utils.spacings.sp12,
 }));
 
 export const SelectAccountTypeScreen = ({

--- a/suite-native/module-authorize-device/src/screens/passphrase/PassphraseEmptyWalletScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/passphrase/PassphraseEmptyWalletScreen.tsx
@@ -24,7 +24,7 @@ import { QuestionMarks } from '../../assets/passphrase/QuestionMarks';
 const cardStyle = prepareNativeStyle(utils => ({
     borderColor: utils.colors.borderElevation0,
     borderWidth: utils.borders.widths.small,
-    gap: 12,
+    gap: utils.spacings.sp12,
 }));
 
 const cardContentStyle = prepareNativeStyle(() => ({

--- a/suite-native/module-settings/src/components/ViewOnly/DevicesManagement.tsx
+++ b/suite-native/module-settings/src/components/ViewOnly/DevicesManagement.tsx
@@ -18,7 +18,7 @@ const cardStyle = prepareNativeStyle(utils => ({
 const deviceStyle = prepareNativeStyle(utils => ({
     padding: utils.spacings.sp16,
     alignItems: 'center',
-    gap: 12,
+    gap: utils.spacings.sp12,
 }));
 
 export const DevicesManagement = ({ onPressAbout }: AboutProps) => {


### PR DESCRIPTION
One more place where literals were used.

## Related Issue

#11921
