### PR TITLE
fix(suite): tokens table columns

### DIFF
--- a/packages/components/src/components/Table/Table.stories.tsx
+++ b/packages/components/src/components/Table/Table.stories.tsx
@@ -42,13 +42,16 @@ export const Table: StoryObj = {
     argTypes: {
         ...getFramePropsStory(allowedTableFrameProps).argTypes,
         colWidths: {
-            options: ['none', 'fixed'],
-            mapping: { none: undefined, fixed: ['150px', '400px'] },
+            options: ['none', 'secondCol300px'],
+            mapping: {
+                none: undefined,
+                secondCol300px: [{}, { minWidth: '300px', maxWidth: '300px' }],
+            },
             control: {
                 type: 'select',
                 labels: {
                     none: 'undefined',
-                    fixed: "fixed = ['150px', '400px']",
+                    secondCol300px: 'second column 300px',
                 },
             },
         },

--- a/packages/components/src/components/Table/Table.tsx
+++ b/packages/components/src/components/Table/Table.tsx
@@ -29,7 +29,10 @@ const ScrollContainer = styled.div`
 
 export type TableProps = AllowedFrameProps & {
     children: ReactNode;
-    colWidths?: string[];
+    colWidths?: {
+        minWidth?: string;
+        maxWidth?: string;
+    }[];
 };
 
 export const Table = ({ children, margin, colWidths }: TableProps) => {
@@ -42,8 +45,8 @@ export const Table = ({ children, margin, colWidths }: TableProps) => {
                 <Container {...makePropsTransient({ margin })}>
                     {colWidths && (
                         <colgroup>
-                            {colWidths.map((width, index) => (
-                                <col key={index} style={{ minWidth: width, maxWidth: width }} />
+                            {colWidths.map((widths, index) => (
+                                <col key={index} style={widths} />
                             ))}
                         </colgroup>
                     )}

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx
@@ -94,10 +94,7 @@ export const MainBar = styled.div`
     flex: 1;
     flex-direction: column;
     align-items: center;
-
-    ${variables.SCREEN_QUERY.BELOW_LAPTOP} {
-        overflow-x: hidden;
-    }
+    overflow-x: hidden;
 `;
 
 interface SuiteLayoutProps {

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
@@ -179,7 +179,6 @@ export const TokenRow = ({
                         <FormattedCryptoAmount
                             value={token.balance}
                             symbol={formatTokenSymbol(token.symbol || '')}
-                            isBalance
                         />
                     </Text>
                 </Column>

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokensTable.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokensTable.tsx
@@ -42,10 +42,6 @@ export const TokensTable = ({
 }: TokensTableProps) => {
     const [isZeroBalanceOpen, setIsZeroBalanceOpen] = useState(false);
 
-    // first two columns have fixed width, the rest have variable width
-    // in case of 2nd column, it's due to HiddenPlaceholder - it changes content width when hovered
-    const colWidths = ['250px', '250px'];
-
     return (
         <Card paddingType="none" overflow="hidden">
             {tokensWithBalance.length === 0 && tokensWithoutBalance.length === 0 && searchQuery ? (
@@ -57,7 +53,13 @@ export const TokensTable = ({
                     <Translation id="TR_NO_SEARCH_RESULTS" />
                 </Paragraph>
             ) : (
-                <Table margin={{ top: spacings.xs, bottom: spacings.xs }} colWidths={colWidths}>
+                <Table
+                    margin={{ top: spacings.xs, bottom: spacings.xs }}
+                    colWidths={[
+                        { minWidth: '200px', maxWidth: '250px' },
+                        { minWidth: '140px', maxWidth: '250px' }, // due to HiddenPlaceholder - it changes content width when hovered
+                    ]}
+                >
                     <Table.Header>
                         <Table.Row>
                             <Table.Cell>


### PR DESCRIPTION
## Description

- fixes overflowing settings, cardano tx detail, tokens table - above 992px
- show whole balance of tokens
- make width of first two columns in tokens table variable

## Screenshots:
Before:
![Screenshot 2024-10-03 at 16 28 45](https://github.com/user-attachments/assets/4263fe93-b32c-484f-89e5-457303a8e0c0)
![Screenshot 2024-10-03 at 16 28 14](https://github.com/user-attachments/assets/9ce3f454-d4b3-43ef-8749-2c18acf95a35)
![Screenshot 2024-10-03 at 16 28 03](https://github.com/user-attachments/assets/4b4f1187-b78d-4483-9d12-44ecf6568e62)

Now:
![Screenshot 2024-10-03 at 16 24 44](https://github.com/user-attachments/assets/08bdb934-c824-4abb-b782-c128f0fb60a7)
![Screenshot 2024-10-03 at 16 25 54](https://github.com/user-attachments/assets/f0e550f7-eda6-4d17-b1cb-07033342fe85)
