### PR TITLE
Multitransport prerequisites

### DIFF
--- a/packages/connect-common/src/storage.ts
+++ b/packages/connect-common/src/storage.ts
@@ -17,7 +17,7 @@ export interface Permission {
  */
 export interface PreferredDevice {
     label?: string;
-    path: string;
+    path: string & { __type: 'DeviceUniquePath' };
     state?: string;
     internalState?: string;
     internalStateExpiration?: number;

--- a/packages/connect-popup/e2e/tests/popup-close.test.ts
+++ b/packages/connect-popup/e2e/tests/popup-close.test.ts
@@ -229,7 +229,7 @@ test('when user cancels permissions in popup it closes automatically', async ({
 
     await popup.waitForLoadState('load');
 
-    if (isCoreInPopup) {
+    if (isWebExtension || isCoreInPopup) {
         await popup.waitForSelector('.select-device-list button.list', { state: 'visible' });
         await popup.click('.select-device-list button.list');
     }

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -15,7 +15,7 @@ import {
 } from '../events';
 import { getHost } from '../utils/urlUtils';
 import type { Device } from '../device/Device';
-import type { FirmwareRange, DeviceState, StaticSessionId } from '../types';
+import type { FirmwareRange, DeviceState, StaticSessionId, DeviceUniquePath } from '../types';
 import { ERRORS } from '../constants';
 
 export type Payload<M> = Extract<CallMethodPayload, { method: M }> & { override?: boolean };
@@ -85,7 +85,7 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
     // @ts-expect-error: strictPropertyInitialization
     params: Params;
 
-    devicePath?: string;
+    devicePath?: DeviceUniquePath;
 
     deviceState?: DeviceState;
 
@@ -198,7 +198,7 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
 
     setDevice(device: Device) {
         this.device = device;
-        this.devicePath = device.getDevicePath();
+        this.devicePath = device.getUniquePath();
         // NOTE: every method should always send "device" parameter
         const originalFn = this.createUiPromise;
         this.createUiPromise = (t, d) => originalFn(t, d || device);

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -36,7 +36,12 @@ import { initLog, enableLog, setLogWriter, LogWriter } from '../utils/debug';
 import { dispose as disposeBackend } from '../backend/BlockchainLink';
 import { InteractionTimeout } from '../utils/interactionTimeout';
 import type { DeviceEvents, Device } from '../device/Device';
-import type { ConnectSettings, Device as DeviceTyped, StaticSessionId } from '../types';
+import type {
+    ConnectSettings,
+    Device as DeviceTyped,
+    DeviceUniquePath,
+    StaticSessionId,
+} from '../types';
 import { onCallFirmwareUpdate } from './onCallFirmwareUpdate';
 import { WebextensionStateStorage } from '../device/StateStorage';
 
@@ -65,7 +70,7 @@ const startInteractionTimeout = (context: CoreContext) =>
  * @returns {Promise<Device>}
  * @memberof Core
  */
-const initDevice = async (context: CoreContext, devicePath?: string) => {
+const initDevice = async (context: CoreContext, devicePath?: DeviceUniquePath) => {
     const { uiPromises, deviceList, sendCoreMessage } = context;
 
     assertDeviceListConnected(deviceList);

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -998,13 +998,7 @@ const initDeviceList = (context: CoreContext) => {
         sendCoreMessage(createDeviceMessage(DEVICE.DISCONNECT, device));
     });
 
-    deviceList.on(DEVICE.ACQUIRED, device => {
-        // TODO resolve ACQUIRED -> CHANGED transformation
-        sendCoreMessage(createDeviceMessage(DEVICE.CHANGED, device));
-    });
-
-    deviceList.on(DEVICE.RELEASED, device => {
-        // TODO resolve RELEASED > CHANGED transformation
+    deviceList.on(DEVICE.CHANGED, device => {
         sendCoreMessage(createDeviceMessage(DEVICE.CHANGED, device));
     });
 

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -993,7 +993,13 @@ const initDeviceList = (context: CoreContext) => {
         sendCoreMessage(createDeviceMessage(DEVICE.DISCONNECT, device));
     });
 
-    deviceList.on(DEVICE.CHANGED, device => {
+    deviceList.on(DEVICE.ACQUIRED, device => {
+        // TODO resolve ACQUIRED -> CHANGED transformation
+        sendCoreMessage(createDeviceMessage(DEVICE.CHANGED, device));
+    });
+
+    deviceList.on(DEVICE.RELEASED, device => {
+        // TODO resolve RELEASED > CHANGED transformation
         sendCoreMessage(createDeviceMessage(DEVICE.CHANGED, device));
     });
 

--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -91,8 +91,7 @@ const waitForReconnectedDevice = async (
 
         await createTimeoutPromise(2000);
         try {
-            const path = deviceList.getFirstDevicePath();
-            reconnectedDevice = deviceList.getDevice(path);
+            reconnectedDevice = deviceList.getOnlyDevice();
         } catch {}
         i++;
         log.debug('onCallFirmwareUpdate', 'waiting for device to reconnect', i);
@@ -306,7 +305,7 @@ export const onCallFirmwareUpdate = async ({
         throw ERRORS.TypedError('Runtime', 'device.firmwareRelease is not set');
     }
 
-    if (deviceList.allDevices().length > 1) {
+    if (deviceList.getDeviceCount() > 1) {
         throw ERRORS.TypedError(
             'Device_MultipleNotSupported',
             'Firmware update allowed with only 1 device connected',

--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -14,7 +14,7 @@ import {
     stripFwHeaders,
 } from '../api/firmware';
 import { getReleases } from '../data/firmwareInfo';
-import { CommonParams, IntermediaryVersion } from '../types';
+import { CommonParams, DeviceUniquePath, IntermediaryVersion } from '../types';
 import { FIRMWARE, PROTO, ERRORS } from '../constants';
 import type { Log } from '../utils/debug';
 import type { Device } from '../device/Device';
@@ -286,7 +286,7 @@ export type Params = {
 type Context = {
     deviceList: DeviceList;
     postMessage: PostMessage;
-    initDevice: (path?: string) => Promise<Device>;
+    initDevice: (path?: DeviceUniquePath) => Promise<Device>;
     log: Log;
     abortSignal: AbortSignal;
 };

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -37,6 +37,7 @@ import {
     StaticSessionId,
     FirmwareHashCheckResult,
     FirmwareHashCheckError,
+    DeviceUniquePath,
 } from '../types';
 import { models } from '../data/models';
 import { getLanguage } from '../data/getLanguage';
@@ -181,6 +182,8 @@ export class Device extends TypedEmitter<DeviceEvents> {
         firmwareHash: null,
     };
 
+    private readonly uniquePath;
+
     constructor(transport: Transport, descriptor: Descriptor) {
         super();
 
@@ -192,6 +195,9 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
         // this will be released after first run
         this.firstRunPromise = createDeferred();
+
+        const id = Math.floor(100 * (Date.now() + Math.random())).toString(36);
+        this.uniquePath = DeviceUniquePath(id);
     }
 
     static fromDescriptor(transport: Transport, originalDescriptor: Descriptor) {
@@ -929,8 +935,8 @@ export class Device extends TypedEmitter<DeviceEvents> {
         return this.firstRunPromise.promise;
     }
 
-    getDevicePath() {
-        return this.originalDescriptor.path;
+    getUniquePath() {
+        return this.uniquePath;
     }
 
     isT1() {
@@ -1001,12 +1007,9 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
     // simplified object to pass via postMessage
     toMessageObject(): DeviceTyped {
-        const { path } = this.originalDescriptor;
-        const { name } = this;
-        const base = {
-            path,
-            name,
-        };
+        const { name, uniquePath: path } = this;
+        const base = { path, name };
+
         if (this.unreadableError) {
             return {
                 ...base,

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -90,7 +90,6 @@ interface DeviceListEvents {
     [DEVICE.CONNECT]: DeviceTyped;
     [DEVICE.CONNECT_UNACQUIRED]: DeviceTyped;
     [DEVICE.DISCONNECT]: DeviceTyped;
-    [DEVICE.CHANGED]: DeviceTyped;
     [DEVICE.RELEASED]: DeviceTyped;
     [DEVICE.ACQUIRED]: DeviceTyped;
 }
@@ -270,9 +269,6 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
 
                 if (!device) break;
 
-                _log.debug('Event', DEVICE.CHANGED, device.toMessageObject());
-                this.emit(DEVICE.CHANGED, device.toMessageObject());
-
                 _log.debug('Event', DEVICE.ACQUIRED, device.toMessageObject());
                 this.emit(DEVICE.ACQUIRED, device.toMessageObject());
 
@@ -285,9 +281,6 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
                 if (methodStillRunning) {
                     device.keepTransportSession = false;
                 }
-
-                _log.debug('Event', DEVICE.CHANGED, device.toMessageObject());
-                this.emit(DEVICE.CHANGED, device.toMessageObject());
 
                 _log.debug('Event', DEVICE.RELEASED, device.toMessageObject());
                 this.emit(DEVICE.RELEASED, device.toMessageObject());

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -455,24 +455,20 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
         return Device.createUnacquired(transport, descriptor, unreadableError);
     }
 
-    getDevice(path: string) {
-        return this.devices[path];
+    getDeviceCount() {
+        return Object.keys(this.devices).length;
     }
 
-    getFirstDevicePath() {
-        return this.asArray()[0].path;
-    }
-
-    asArray(): DeviceTyped[] {
-        return this.allDevices().map(device => device.toMessageObject());
-    }
-
-    allDevices(): Device[] {
+    getAllDevices(): Device[] {
         return Object.keys(this.devices).map(key => this.devices[key]);
     }
 
-    length() {
-        return this.asArray().length;
+    getOnlyDevice(): Device | undefined {
+        return this.getDeviceCount() === 1 ? Object.values(this.devices)[0] : undefined;
+    }
+
+    getDeviceByPath(path: string): Device | undefined {
+        return this.devices[path];
     }
 
     transportType() {
@@ -495,7 +491,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
 
     async cleanup() {
         const { transport } = this;
-        const devices = this.allDevices();
+        const devices = this.getAllDevices();
 
         // @ts-expect-error will be fixed later
         this.transport = undefined;

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -262,7 +262,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
                 if (category.subtype === 'elsewhere') {
                     this.createDevicesQueue.remove(path);
                     if (device) {
-                        device.featuresNeedsReload = true;
+                        device.featuresNeedsReload();
                         device.interruptionFromOutside();
                     }
                 }
@@ -279,7 +279,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
 
                 const methodStillRunning = !device.commands?.isDisposed();
                 if (methodStillRunning) {
-                    device.keepTransportSession = false;
+                    device.releaseTransportSession();
                 }
 
                 _log.debug('Event', DEVICE.RELEASED, device.toMessageObject());

--- a/packages/connect/src/device/__tests__/DeviceList.test.ts
+++ b/packages/connect/src/device/__tests__/DeviceList.test.ts
@@ -21,13 +21,7 @@ const waitForNthEventOfType = (
     });
 };
 
-const DEVICE_CONNECTION_SEQUENCE = [
-    'device-changed',
-    'device-acquired',
-    'device-changed',
-    'device-released',
-    'device-connect',
-];
+const DEVICE_CONNECTION_SEQUENCE = ['device-acquired', 'device-released', 'device-connect'];
 
 describe('DeviceList', () => {
     beforeAll(async () => {
@@ -56,7 +50,6 @@ describe('DeviceList', () => {
             [
                 'transport-start',
                 'transport-error',
-                'device-changed',
                 'device-connect',
                 'device-connect_unacquired',
                 'device-acquired',
@@ -186,12 +179,7 @@ describe('DeviceList', () => {
         await list.pendingConnection();
 
         const events = eventsSpy.mock.calls.map(call => call[0]);
-        expect(events).toEqual([
-            'device-changed',
-            'device-acquired',
-            'device-connect_unacquired',
-            'transport-start',
-        ]);
+        expect(events).toEqual(['device-acquired', 'device-connect_unacquired', 'transport-start']);
     });
 
     it('.init() with pendingTransportEvent (multiple acquired devices)', async () => {
@@ -240,14 +228,11 @@ describe('DeviceList', () => {
         await transportFirstEvent;
         jest.useRealTimers();
 
-        expect(eventsSpy).toHaveBeenCalledTimes(8);
+        expect(eventsSpy).toHaveBeenCalledTimes(5);
         const events = eventsSpy.mock.calls.map(call => call[0]);
         expect(events).toEqual([
-            'device-changed',
             'device-acquired',
-            'device-changed',
             'device-acquired',
-            'device-changed',
             'device-released',
             'device-connect',
             'transport-start',

--- a/packages/connect/src/device/__tests__/DeviceList.test.ts
+++ b/packages/connect/src/device/__tests__/DeviceList.test.ts
@@ -193,7 +193,10 @@ describe('DeviceList', () => {
         list.init({ pendingTransportEvent: true });
         await list.pendingConnection();
 
-        const events = eventsSpy.mock.calls.map(([event, { path }]) => [event, path]);
+        const events = eventsSpy.mock.calls.map(([event, { path }]) => [
+            event,
+            (list.getDeviceByPath(path) as any)?.originalDescriptor.path,
+        ]);
 
         // note: acquire - release - connect should be ok.
         // acquire - deviceList._takeAndCreateDevice start (run -> rurInner -> getFeatures -> release) -> deviceList._takeAndCreateDevice end => emit DEVICE.CONNECT
@@ -280,7 +283,10 @@ describe('DeviceList', () => {
         // wait for all device-connect events
         await waitForNthEventOfType(list, 'device-connect', 3);
 
-        const events = eventsSpy.mock.calls.map(([event, { path }]) => [event, path]);
+        const events = eventsSpy.mock.calls.map(([event, { path }]) => [
+            event,
+            (list.getDeviceByPath(path) as any)?.originalDescriptor.path,
+        ]);
 
         expect(events).toEqual([
             ['transport-start', undefined],

--- a/packages/connect/src/device/prompts.ts
+++ b/packages/connect/src/device/prompts.ts
@@ -20,7 +20,9 @@ type DeviceEventCallback<K extends keyof DeviceEvents> = DeviceEvents[K] extends
     : never;
 
 export const cancelPrompt = (device: Device, expectResponse = true) => {
-    if (!device.transportSession) {
+    const session = device.getLocalSession();
+
+    if (!session) {
         // device disconnected or acquired by someone else
         return Promise.resolve({
             success: false,
@@ -29,7 +31,7 @@ export const cancelPrompt = (device: Device, expectResponse = true) => {
     }
 
     const cancelArgs = {
-        session: device.transportSession,
+        session,
         name: 'Cancel',
         data: {},
         protocol: device.protocol,

--- a/packages/connect/src/events/call.ts
+++ b/packages/connect/src/events/call.ts
@@ -80,7 +80,7 @@ export const createResponseMessage = (
     payload: success ? payload : serializeError(payload),
     device: device
         ? {
-              path: device?.getDevicePath(),
+              path: device?.getUniquePath(),
               state: device?.getState(),
               instance: device?.getInstance(),
           }

--- a/packages/connect/src/events/call.ts
+++ b/packages/connect/src/events/call.ts
@@ -80,9 +80,9 @@ export const createResponseMessage = (
     payload: success ? payload : serializeError(payload),
     device: device
         ? {
-              path: device?.originalDescriptor.path,
+              path: device?.getDevicePath(),
               state: device?.getState(),
-              instance: device?.instance,
+              instance: device?.getInstance(),
           }
         : undefined,
 });

--- a/packages/connect/src/events/device.ts
+++ b/packages/connect/src/events/device.ts
@@ -9,13 +9,6 @@ export const DEVICE = {
     CONNECT_UNACQUIRED: 'device-connect_unacquired',
     DISCONNECT: 'device-disconnect',
     CHANGED: 'device-changed',
-    ACQUIRE: 'device-acquire',
-    RELEASE: 'device-release',
-    ACQUIRED: 'device-acquired',
-    RELEASED: 'device-released',
-    USED_ELSEWHERE: 'device-used_elsewhere',
-
-    LOADING: 'device-loading',
 
     // trezor-link events in protobuf format
     BUTTON: 'button',

--- a/packages/connect/src/types/api/__tests__/binance.ts
+++ b/packages/connect/src/types/api/__tests__/binance.ts
@@ -1,4 +1,4 @@
-import { TrezorConnect } from '../../..';
+import { DeviceUniquePath, TrezorConnect } from '../../..';
 
 export const binanceGetAddress = async (api: TrezorConnect) => {
     // regular
@@ -29,7 +29,7 @@ export const binanceGetAddress = async (api: TrezorConnect) => {
     // with all possible params
     api.binanceGetAddress({
         device: {
-            path: '1',
+            path: DeviceUniquePath('1'),
             instance: 1,
             state: 'state@device-id:1',
         },

--- a/packages/connect/src/types/api/__tests__/bitcoin.ts
+++ b/packages/connect/src/types/api/__tests__/bitcoin.ts
@@ -1,4 +1,4 @@
-import { TrezorConnect } from '../../..';
+import { DeviceUniquePath, TrezorConnect } from '../../..';
 
 export const getAddress = async (api: TrezorConnect) => {
     // regular
@@ -29,7 +29,7 @@ export const getAddress = async (api: TrezorConnect) => {
     // with all possible params
     api.getAddress({
         device: {
-            path: '1',
+            path: DeviceUniquePath('1'),
             instance: 1,
             state: 'state@device-id:1',
         },

--- a/packages/connect/src/types/api/__tests__/cardano.ts
+++ b/packages/connect/src/types/api/__tests__/cardano.ts
@@ -1,4 +1,4 @@
-import { TrezorConnect, PROTO } from '../../..';
+import { TrezorConnect, PROTO, DeviceUniquePath } from '../../..';
 
 const {
     CardanoAddressType,
@@ -122,7 +122,7 @@ export const cardanoGetAddress = async (api: TrezorConnect) => {
     // with all possible params
     api.cardanoGetAddress({
         device: {
-            path: '1',
+            path: DeviceUniquePath('1'),
             instance: 1,
             state: 'state@device-id:1',
         },

--- a/packages/connect/src/types/api/__tests__/ethereum.ts
+++ b/packages/connect/src/types/api/__tests__/ethereum.ts
@@ -1,4 +1,4 @@
-import { TrezorConnect } from '../../..';
+import { DeviceUniquePath, TrezorConnect } from '../../..';
 
 export const ethereumGetAddress = async (api: TrezorConnect) => {
     // regular
@@ -30,7 +30,7 @@ export const ethereumGetAddress = async (api: TrezorConnect) => {
     // with all possible params
     api.ethereumGetAddress({
         device: {
-            path: '1',
+            path: DeviceUniquePath('1'),
             instance: 1,
             state: 'state@device-id:1',
         },

--- a/packages/connect/src/types/api/__tests__/nem.ts
+++ b/packages/connect/src/types/api/__tests__/nem.ts
@@ -1,4 +1,4 @@
-import { TrezorConnect, NEM } from '../../..';
+import { TrezorConnect, NEM, DeviceUniquePath } from '../../..';
 
 export const nemGetAddress = async (api: TrezorConnect) => {
     // regular
@@ -33,7 +33,7 @@ export const nemGetAddress = async (api: TrezorConnect) => {
     // with all possible params
     api.nemGetAddress({
         device: {
-            path: '1',
+            path: DeviceUniquePath('1'),
             instance: 1,
             state: 'state@device-id:1',
         },

--- a/packages/connect/src/types/api/__tests__/ripple.ts
+++ b/packages/connect/src/types/api/__tests__/ripple.ts
@@ -1,4 +1,4 @@
-import { TrezorConnect } from '../../..';
+import { DeviceUniquePath, TrezorConnect } from '../../..';
 
 export const rippleGetAddress = async (api: TrezorConnect) => {
     // regular
@@ -31,7 +31,7 @@ export const rippleGetAddress = async (api: TrezorConnect) => {
     // with all possible params
     api.rippleGetAddress({
         device: {
-            path: '1',
+            path: DeviceUniquePath('1'),
             instance: 1,
             state: 'state@device-id:1',
         },

--- a/packages/connect/src/types/api/__tests__/stellar.ts
+++ b/packages/connect/src/types/api/__tests__/stellar.ts
@@ -1,4 +1,4 @@
-import { TrezorConnect } from '../../..';
+import { DeviceUniquePath, TrezorConnect } from '../../..';
 
 export const stellarGetAddress = async (api: TrezorConnect) => {
     // regular
@@ -29,7 +29,7 @@ export const stellarGetAddress = async (api: TrezorConnect) => {
     // with all possible params
     api.stellarGetAddress({
         device: {
-            path: '1',
+            path: DeviceUniquePath('1'),
             instance: 1,
             state: 'state@device-id:1',
         },

--- a/packages/connect/src/types/api/__tests__/tezos.ts
+++ b/packages/connect/src/types/api/__tests__/tezos.ts
@@ -1,4 +1,4 @@
-import { TrezorConnect } from '../../..';
+import { DeviceUniquePath, TrezorConnect } from '../../..';
 
 export const tezosGetAddress = async (api: TrezorConnect) => {
     // regular
@@ -29,7 +29,7 @@ export const tezosGetAddress = async (api: TrezorConnect) => {
     // with all possible params
     api.tezosGetAddress({
         device: {
-            path: '1',
+            path: DeviceUniquePath('1'),
             instance: 1,
             state: 'state@device-id:1',
         },

--- a/packages/connect/src/types/device.ts
+++ b/packages/connect/src/types/device.ts
@@ -1,4 +1,3 @@
-import { Descriptor } from '@trezor/transport';
 import type { PROTO } from '../constants';
 import type { ReleaseInfo } from './firmware';
 
@@ -67,8 +66,11 @@ export type FirmwareHashCheckResult =
     | { success: true }
     | { success: false; error: FirmwareHashCheckError };
 
+export type DeviceUniquePath = string & { __type: 'DeviceUniquePath' };
+export const DeviceUniquePath = (id: string) => id as DeviceUniquePath;
+
 type BaseDevice = {
-    path: Descriptor['path'];
+    path: DeviceUniquePath;
     name: string;
 };
 

--- a/packages/connect/src/types/params.ts
+++ b/packages/connect/src/types/params.ts
@@ -1,11 +1,11 @@
 // API params
 
 import { Type, TSchema, Static } from '@trezor/schema-utils';
-import { DeviceState } from './device';
+import { DeviceState, DeviceUniquePath } from './device';
 import { ErrorCode } from '../constants/errors';
 
 export interface DeviceIdentity {
-    path?: string;
+    path?: DeviceUniquePath;
     state?: DeviceState;
     instance?: number;
 }

--- a/packages/connect/src/types/utils.ts
+++ b/packages/connect/src/types/utils.ts
@@ -18,3 +18,6 @@ export type MessageFactoryFn<Group, Event> = UnionToIntersection<
               ) => { event: Group; type: Event['type']; payload: undefined }
         : never
 >;
+
+export const typedObjectKeys = <T extends Record<any, any>>(obj: T): Array<keyof T> =>
+    Object.keys(obj) as Array<keyof T>;

--- a/packages/connect/src/utils/uiPromiseManager.ts
+++ b/packages/connect/src/utils/uiPromiseManager.ts
@@ -1,5 +1,6 @@
 import { DEVICE, UiPromise, AnyUiPromise, UiPromiseCreator, UiPromiseResponse } from '../events';
 import { createDeferred, arrayPartition } from '@trezor/utils';
+import { DeviceUniquePath } from '../types/device';
 
 export const createUiPromiseManager = (interactionTimeout: () => void) => {
     let _uiPromises: AnyUiPromise[] = [];
@@ -36,16 +37,16 @@ export const createUiPromiseManager = (interactionTimeout: () => void) => {
         _uiPromises = [];
     };
 
-    const disconnected = (devicePath: string) => {
+    const disconnected = (devicePath: DeviceUniquePath) => {
         const [toResolve, toKeep] = arrayPartition(
             _uiPromises,
             (p): p is UiPromise<typeof DEVICE.DISCONNECT> =>
-                p.device?.getDevicePath() === devicePath && p.id === DEVICE.DISCONNECT,
+                p.device?.getUniquePath() === devicePath && p.id === DEVICE.DISCONNECT,
         );
         toResolve.forEach(p => p.resolve({ type: DEVICE.DISCONNECT }));
         _uiPromises = toKeep;
 
-        return !!toResolve.length || toKeep.some(p => p.device?.getDevicePath() === devicePath);
+        return !!toResolve.length || toKeep.some(p => p.device?.getUniquePath() === devicePath);
     };
 
     const get = <T extends UiPromiseResponse['type']>(type: T) => {

--- a/packages/suite-web/e2e/tests/suite/unacquired-device.test.ts
+++ b/packages/suite-web/e2e/tests/suite/unacquired-device.test.ts
@@ -16,16 +16,16 @@ describe('unacquired device', () => {
         // simulate stolen session from another window. device receives indicative button
         cy.task('stealBridgeSession');
         cy.getTestElement('@menu/switch-device').click();
-        cy.getTestElement('@switch-device/1/solve-issue-button').click();
+        cy.getTestElement('@switch-device/solve-issue-button').click();
         cy.getTestElement('@deviceStatus-connected');
 
         // when user reloads app while device is acquired, suite will not try to acquire device so that it
         // does not interferes with somebody else's session
         cy.task('stealBridgeSession');
-        cy.getTestElement('@switch-device/1/solve-issue-button');
+        cy.getTestElement('@switch-device/solve-issue-button');
         cy.reload();
         cy.getTestElement('@menu/switch-device').click();
-        cy.getTestElement('@switch-device/1/solve-issue-button').click();
+        cy.getTestElement('@switch-device/solve-issue-button').click();
     });
 
     // todo:

--- a/packages/suite/src/views/password-manager/PasswordManager/PasswordEntry.tsx
+++ b/packages/suite/src/views/password-manager/PasswordManager/PasswordEntry.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import TrezorConnect from '@trezor/connect';
+import TrezorConnect, { DeviceUniquePath } from '@trezor/connect';
 import { Button } from '@trezor/components';
 
 import { spacingsPx } from '@trezor/theme';
@@ -34,7 +34,7 @@ const Row = styled.div`
 `;
 
 interface PasswordEntryProps extends PasswordEntryType {
-    devicePath: string;
+    devicePath: DeviceUniquePath;
     onEncrypted: (entry: PasswordEntryType) => void;
     formActive: number | null;
     setFormActive: (id: number | null) => void;

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceWarning.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceWarning.tsx
@@ -27,7 +27,7 @@ export const DeviceWarning = ({
                     button={{
                         children: <Translation id="TR_SOLVE_ISSUE" />,
                         onClick: onSolveIssueClick,
-                        'data-testid': `@switch-device/${device.path}/solve-issue-button`,
+                        'data-testid': `@switch-device/solve-issue-button`,
                         isDisabled: isLocked,
                     }}
                 >

--- a/packages/transport-test/e2e/bridge/bridge-listen.test.ts
+++ b/packages/transport-test/e2e/bridge/bridge-listen.test.ts
@@ -31,12 +31,10 @@ describe('bridge', () => {
         const brideSpy = jest.spyOn(bridge, 'emit');
         bridge.listen();
         await new Promise(resolve => setTimeout(resolve, 100));
-        expect(brideSpy).toHaveBeenCalledWith('transport-update', [
-            {
-                descriptor: { ...expectedDescriptor, session: null },
-                type: 'connected',
-            },
-        ]);
+        expect(brideSpy).toHaveBeenCalledWith('transport-update', {
+            descriptor: { ...expectedDescriptor, session: null },
+            type: 'connected',
+        });
         bridge.removeAllListeners('transport-update');
         jest.clearAllMocks();
     });

--- a/packages/transport-test/e2e/bridge/bridge-listen.test.ts
+++ b/packages/transport-test/e2e/bridge/bridge-listen.test.ts
@@ -31,11 +31,11 @@ describe('bridge', () => {
         const brideSpy = jest.spyOn(bridge, 'emit');
         bridge.listen();
         await new Promise(resolve => setTimeout(resolve, 100));
-        expect(brideSpy).toHaveBeenCalledWith('transport-update', {
-            descriptor: { ...expectedDescriptor, session: null },
-            type: 'connected',
+        expect(brideSpy).toHaveBeenCalledWith('transport-device_connected', {
+            ...expectedDescriptor,
+            session: null,
         });
-        bridge.removeAllListeners('transport-update');
+        bridge.removeAllListeners('transport-device_connected');
         jest.clearAllMocks();
     });
 });

--- a/packages/transport-test/e2e/bridge/multi-client.test.ts
+++ b/packages/transport-test/e2e/bridge/multi-client.test.ts
@@ -93,12 +93,16 @@ describe('bridge', () => {
             session: Session('1'),
         });
 
-        expect(bride1spy).toHaveBeenLastCalledWith('transport-update', [
-            { type: 'acquired', subtype: 'here', descriptor: expectedDescriptor1 },
-        ]);
-        expect(bride2spy).toHaveBeenLastCalledWith('transport-update', [
-            { type: 'acquired', subtype: 'elsewhere', descriptor: expectedDescriptor1 },
-        ]);
+        expect(bride1spy).toHaveBeenLastCalledWith('transport-update', {
+            type: 'acquired',
+            subtype: 'here',
+            descriptor: expectedDescriptor1,
+        });
+        expect(bride2spy).toHaveBeenLastCalledWith('transport-update', {
+            type: 'acquired',
+            subtype: 'elsewhere',
+            descriptor: expectedDescriptor1,
+        });
 
         expect(session1.success).toBe(true);
         if (!session1.success) {
@@ -114,13 +118,17 @@ describe('bridge', () => {
             session: null,
         });
 
-        expect(bride1spy).toHaveBeenLastCalledWith('transport-update', [
-            { type: 'released', subtype: 'here', descriptor: expectedDescriptor2 },
-        ]);
+        expect(bride1spy).toHaveBeenLastCalledWith('transport-update', {
+            type: 'released',
+            subtype: 'here',
+            descriptor: expectedDescriptor2,
+        });
 
-        expect(bride2spy).toHaveBeenLastCalledWith('transport-update', [
-            { type: 'released', subtype: 'elsewhere', descriptor: expectedDescriptor2 },
-        ]);
+        expect(bride2spy).toHaveBeenLastCalledWith('transport-update', {
+            type: 'released',
+            subtype: 'elsewhere',
+            descriptor: expectedDescriptor2,
+        });
 
         const session2 = await bridge2.acquire({
             input: { previous: null, path: descriptors[0].path },
@@ -159,13 +167,17 @@ describe('bridge', () => {
 
         await wait(); // wait for event to be propagated
 
-        expect(bride1spy).toHaveBeenLastCalledWith('transport-update', [
-            { type: 'acquired', subtype: 'elsewhere', descriptor: expectedDescriptor },
-        ]);
+        expect(bride1spy).toHaveBeenLastCalledWith('transport-update', {
+            type: 'acquired',
+            subtype: 'elsewhere',
+            descriptor: expectedDescriptor,
+        });
 
-        expect(bride2spy).toHaveBeenLastCalledWith('transport-update', [
-            { type: 'acquired', subtype: 'here', descriptor: expectedDescriptor },
-        ]);
+        expect(bride2spy).toHaveBeenLastCalledWith('transport-update', {
+            type: 'acquired',
+            subtype: 'here',
+            descriptor: expectedDescriptor,
+        });
     });
 
     // todo: udp not implemented correctly yet in new bridge

--- a/packages/transport/src/constants.ts
+++ b/packages/transport/src/constants.ts
@@ -26,9 +26,14 @@ export const TREZOR_USB_DESCRIPTORS = [
 export const ACTION_TIMEOUT = 10000;
 
 export const TRANSPORT = {
+    /* events */
     START: 'transport-start',
     ERROR: 'transport-error',
-    UPDATE: 'transport-update',
+    DEVICE_CONNECTED: 'transport-device_connected',
+    DEVICE_DISCONNECTED: 'transport-device_disconnected',
+    DEVICE_SESSION_CHANGED: 'transport-device_session_changed',
+    DEVICE_REQUEST_RELEASE: 'transport-device_request_release',
+    /* messages */
     DISABLE_WEBUSB: 'transport-disable_webusb',
     REQUEST_DEVICE: 'transport-request_device',
     GET_INFO: 'transport-get_info',

--- a/packages/transport/src/index.ts
+++ b/packages/transport/src/index.ts
@@ -14,7 +14,6 @@ protobuf.configure();
 export type { Descriptor, Session } from './types';
 export { TREZOR_USB_DESCRIPTORS, TRANSPORT } from './constants';
 
-export type { DeviceDescriptorDiff } from './transports/abstract';
 export { AbstractTransport as Transport, isTransportInstance } from './transports/abstract';
 export { AbstractApiTransport } from './transports/abstractApi';
 export { UsbApi } from './api/usb';

--- a/packages/transport/src/sessions/background-browser.ts
+++ b/packages/transport/src/sessions/background-browser.ts
@@ -43,7 +43,9 @@ export class BrowserSessionsBackground implements SessionsBackgroundInterface {
         });
     }
 
-    on(_event: 'descriptors', listener: (descriptors: Descriptor[]) => void): void {
+    on(event: 'descriptors', listener: (descriptors: Descriptor[]) => void): void;
+    on(event: 'releaseRequest', listener: (descriptor: Descriptor) => void): void;
+    on(event: 'descriptors' | 'releaseRequest', listener: (descriptors: any) => void): void {
         this.background.port.addEventListener(
             'message',
             (
@@ -55,7 +57,7 @@ export class BrowserSessionsBackground implements SessionsBackgroundInterface {
                 >,
             ) => {
                 if ('type' in e?.data) {
-                    if (e.data.type === 'descriptors') {
+                    if (e.data.type === event) {
                         listener(e.data.payload);
                     }
                 }

--- a/packages/transport/src/sessions/background-sharedworker.ts
+++ b/packages/transport/src/sessions/background-sharedworker.ts
@@ -20,6 +20,12 @@ background.on('descriptors', descriptors => {
     });
 });
 
+background.on('releaseRequest', descriptor => {
+    ports.forEach(p => {
+        p.postMessage({ type: 'releaseRequest', payload: descriptor });
+    });
+});
+
 self.onconnect = function (e) {
     const port = e.ports[0];
 

--- a/packages/transport/src/sessions/client.ts
+++ b/packages/transport/src/sessions/client.ts
@@ -19,6 +19,7 @@ import {
  */
 export class SessionsClient extends TypedEmitter<{
     descriptors: Descriptor[];
+    releaseRequest: Descriptor;
 }> {
     // used only for debugging - discriminating sessions clients in sessions background log
     private caller = getWeakRandomId(3);
@@ -30,6 +31,7 @@ export class SessionsClient extends TypedEmitter<{
         this.id = 0;
         this.background = background;
         background.on('descriptors', descriptors => this.emit('descriptors', descriptors));
+        background.on('releaseRequest', descriptor => this.emit('releaseRequest', descriptor));
     }
 
     public setBackground(background: SessionsBackgroundInterface) {
@@ -38,6 +40,7 @@ export class SessionsClient extends TypedEmitter<{
         this.id = 0;
         this.background = background;
         background.on('descriptors', descriptors => this.emit('descriptors', descriptors));
+        background.on('releaseRequest', descriptor => this.emit('releaseRequest', descriptor));
     }
 
     private request<M extends HandleMessageParams>(params: M) {

--- a/packages/transport/src/sessions/types.ts
+++ b/packages/transport/src/sessions/types.ts
@@ -27,7 +27,7 @@ export type EnumerateDoneResponse = BackgroundResponse<{
 export type AcquireIntentRequest = AcquireInput;
 
 export type AcquireIntentResponse = BackgroundResponseWithError<
-    { session: Session; path: PathInternal },
+    { session: Session; path: PathInternal; releaseRequest?: Descriptor },
     typeof ERRORS.SESSION_WRONG_PREVIOUS | typeof ERRORS.DESCRIPTOR_NOT_FOUND
 >;
 
@@ -113,6 +113,7 @@ export type HandleMessageResponse<P> = P extends { type: infer T }
 
 export interface SessionsBackgroundInterface {
     on(event: 'descriptors', listener: (descriptors: Descriptor[]) => void): void;
+    on(event: 'releaseRequest', listener: (descriptor: Descriptor) => void): void;
     handleMessage<M extends HandleMessageParams>(message: M): Promise<HandleMessageResponse<M>>;
     dispose(): void;
 }

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -37,15 +37,13 @@ export type ReleaseInput = {
     onClose?: boolean;
 };
 
-type DescriptorDiffItem = { descriptor: Descriptor } & (
+export type DeviceDescriptorDiff = { descriptor: Descriptor } & (
     | { type: 'connected' | 'disconnected' }
     | {
           type: 'acquired' | 'released';
           subtype: 'here' | 'elsewhere';
       }
 );
-
-export type DeviceDescriptorDiff = DescriptorDiffItem[];
 
 export interface AbstractTransportParams {
     messages?: Record<string, any>;
@@ -320,7 +318,7 @@ export abstract class AbstractTransport extends TransportEmitter {
         this.releasePromise = undefined;
     }
 
-    private getDiff(nextDescriptors: Descriptor[]): DeviceDescriptorDiff {
+    private getDiff(nextDescriptors: Descriptor[]): DeviceDescriptorDiff[] {
         const oldDescriptors = new Map(this.descriptors.map(d => [getKey(d), d]));
         const newDescriptors = new Map(nextDescriptors.map(d => [getKey(d), d]));
 
@@ -419,7 +417,9 @@ export abstract class AbstractTransport extends TransportEmitter {
             }
         });
 
-        this.emit(TRANSPORT.UPDATE, diff);
+        diff.forEach(diffItem => {
+            this.emit(TRANSPORT.UPDATE, diffItem);
+        });
     }
 
     /**

--- a/packages/transport/tests/abstractUsb.test.ts
+++ b/packages/transport/tests/abstractUsb.test.ts
@@ -117,13 +117,15 @@ describe('Usb', () => {
 
             transport.handleDescriptorsChange([{ path: PathPublic('1'), session: null, type: 1 }]);
 
-            expect(spy).toHaveBeenCalledWith([
-                { type: 'connected', descriptor: { path: '1', session: null, type: 1 } },
-            ]);
+            expect(spy).toHaveBeenCalledWith({
+                type: 'connected',
+                descriptor: { path: '1', session: null, type: 1 },
+            });
             transport.handleDescriptorsChange([]);
-            expect(spy).toHaveBeenCalledWith([
-                { type: 'disconnected', descriptor: { path: '1', session: null, type: 1 } },
-            ]);
+            expect(spy).toHaveBeenCalledWith({
+                type: 'disconnected',
+                descriptor: { path: '1', session: null, type: 1 },
+            });
         });
 
         it('enumerate', async () => {

--- a/packages/transport/tests/sessions.test.ts
+++ b/packages/transport/tests/sessions.test.ts
@@ -42,13 +42,6 @@ describe('sessions', () => {
             payload: {
                 session: '1',
                 path: 'abc', // <= pathInternal
-                descriptors: [
-                    {
-                        path: '1', // <= pathPublic
-                        session: '1',
-                        type: 1,
-                    },
-                ],
             },
         });
         const acquireDone = await client1.acquireDone({ path: PathPublic('1') });
@@ -67,7 +60,7 @@ describe('sessions', () => {
         });
     });
 
-    test('acquire', async () => {
+    test('acquire - acquire', async () => {
         expect.assertions(3);
 
         const client1 = new SessionsClient(background);
@@ -82,13 +75,8 @@ describe('sessions', () => {
         expect(acquire1).toMatchObject({
             success: true,
             payload: {
+                path: '1',
                 session: '1',
-                descriptors: [
-                    {
-                        path: '1',
-                        session: '1',
-                    },
-                ],
             },
         });
 
@@ -101,13 +89,12 @@ describe('sessions', () => {
         expect(acquire2).toMatchObject({
             success: true,
             payload: {
+                path: '1',
                 session: '2',
-                descriptors: [
-                    {
-                        path: '1',
-                        session: '2',
-                    },
-                ],
+                releaseRequest: {
+                    path: '1',
+                    session: '1',
+                },
             },
         });
 
@@ -140,12 +127,6 @@ describe('sessions', () => {
             success: true,
             payload: {
                 session: '1',
-                descriptors: [
-                    {
-                        path: '1',
-                        session: '1',
-                    },
-                ],
             },
         });
 

--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -7,6 +7,7 @@ import {
     Features,
     DeviceModelInternal,
     FirmwareType,
+    DeviceUniquePath,
 } from '@trezor/connect';
 import {
     TrezorDevice,
@@ -136,17 +137,17 @@ const getDeviceFeatures = (feat?: Partial<Features>): Features => ({
     ...feat,
 });
 
+type StringPath<T extends { path: DeviceUniquePath }> = Omit<T, 'path'> & { path: string };
+
 /**
  * simplified Device from '@trezor/connect'
  * @param {Partial<Device>} [dev]
  * @param {Partial<Features>} [feat]
  * @returns {Device}
  */
-const getConnectDevice = (
-    dev?: Partial<Omit<Device, 'path'> & { path: `${number}` }>,
-    feat?: Partial<Features>,
-): Device => {
-    const path = (dev && dev.path ? dev.path : '1') as `${number}` & { __type: 'PathPublic' };
+const getConnectDevice = (dev?: Partial<StringPath<Device>>, feat?: Partial<Features>): Device => {
+    const path = DeviceUniquePath(dev?.path ?? '1');
+
     if (dev && typeof dev.type === 'string' && dev.type === 'unreadable') {
         return {
             type: 'unreadable',
@@ -203,7 +204,7 @@ const getConnectDevice = (
  * @returns {TrezorDevice}
  */
 const getSuiteDevice = (
-    dev?: Partial<Omit<TrezorDevice, 'path'> & { path: `${number}` }>,
+    dev?: Partial<StringPath<TrezorDevice>>,
     feat?: Partial<Features>,
 ): TrezorDevice => {
     const device = getConnectDevice(dev, feat);


### PR DESCRIPTION
## Description

Refactoring (mostly) of abstract transport class (in `@trezor/transport`) and DeviceList (in `@trezor/connect`) so they're hopefully a bit more resilient and better prepared for multitransport support.

## Commits

- https://github.com/trezor/trezor-suite/pull/14726/commits/8d6270bc3fa2d766d1590317bc55cbf0ff49f15c - split `TRANSPORT.UPDATE` event per separate descriptors
- https://github.com/trezor/trezor-suite/pull/14726/commits/a78a9e3c20f7f9bfd2371fda46e3073c2f8edd14 - extract device creation locking into a separate util (but it will be removed later anyway)
- https://github.com/trezor/trezor-suite/pull/14726/commits/b705e9d2391adecf3b7be2b3a6f34a908d0b7920 - device-related methods on `DeviceList` improved so they better suit their real usage
- https://github.com/trezor/trezor-suite/pull/14726/commits/9f9ab9d4e24eac77a791fc485a92f34626bdcfce - stop using device changed event in favor of acquired/released events (will be changed later anyway)
- https://github.com/trezor/trezor-suite/pull/14726/commits/7e30624780251f366d480c46b446c771c1787fc1 - all the Device fields accessibility restricted as much as possible (potentially split into getter/setter), so it's easier to handle them
- https://github.com/trezor/trezor-suite/pull/14726/commits/7007e81aa4368a84fbcd1fcc3db4753897118b61 - **BIG ONE** - devices are now identified by randomly-generated unique ids (`DeviceUniquePath` branded type) instead of real transport paths, which will be necessary once there's a device accessible by multiple transports
- https://github.com/trezor/trezor-suite/pull/14726/commits/d5fee829c1585b603d8ba5ea4440389f4639986b - **BIGGEST ONE** - complete rework of device handling on transport/connect boundary
  - a bond between `acquire`/`release`/`listen` transport calls (e.g. postponing listen responses incoming during acquire after the acquire etc.) removed from abstract transport; it's handled in Connect's Device object instead where it's much easier to implement proper locks/promises
  - `Device` object is created in `DeviceList` as soon as first seen so it can be used for handling asynchronous cases without temporarily stored info (e.g. `creatingDevicesDescriptors`); that's why the constructor was simplified (there is only one variant now)
  - complex device-related logic (as the one above) moved into `Device` class where it belongs -> device lifecycle events emitted from there, acquiring, retrying to acquire and failing to acquire handled there, waiting for incoming descriptors while acquiring/releasing handled there...
  - added new `releaseRequest` event into sessions handling -> it was needed so the sessions are **not** changed during acquire intent while it's still possible to signal that some device should be released by others
  - `TRANSPORT.UPDATE` event divided even more into connected/disconnected/changed events
  - device creation locking extensively simplified so there's only one very simple `handshakeLock` now
- https://github.com/trezor/trezor-suite/pull/14726/commits/437f04a9e2d7cfe9b468c6beecf12f291ad902b0 - all the types of tests adjusted to the new changes

I apologize for not being able to make the commits clearer as I usually strive for, but the changes were too big and chaotic. Also, taxation is theft, which may seem unrelated, but it's pretty important anyway.

resolve #15062