### PR TITLE
fix(suite-desktop): app reset on mac

### DIFF
--- a/packages/suite-desktop-core/src/libs/app-utils.ts
+++ b/packages/suite-desktop-core/src/libs/app-utils.ts
@@ -14,7 +14,8 @@ export const restartApp = () => {
         options.args.unshift('--appimage-extract-and-run');
     }
 
-    app.removeAllListeners('before-quit');
+    // too: not sure why it was here
+    // app.removeAllListeners('before-quit');
     app.relaunch();
     app.quit();
 };


### PR DESCRIPTION
This appears to fix #14480  but I bet it also breaks something else. 

Maybe @martykan has a clue. Also if it only hinders autostart feature but fixes the aforementioned regression, it is probably still ok to merge it since the autostart feature is still kind of experimental and hidden in debug mode. 