### PR TITLE
chore(connect): rename 'getAssetByUrl' to a more apt fn name 'tryLoca…

### DIFF
--- a/packages/connect/src/utils/assetUtils.ts
+++ b/packages/connect/src/utils/assetUtils.ts
@@ -12,7 +12,7 @@ const firmwareAssets: Record<DeviceModelInternal, NodeRequire> = {
     [DeviceModelInternal.T3T1]: require('@trezor/connect-common/files/firmware/t3t1/releases.json'),
 };
 
-export const getAssetByUrl = (url: string) => {
+export const tryLocalAssetRequire = (url: string) => {
     const fileUrl = url.split('?')[0];
 
     switch (fileUrl) {

--- a/packages/connect/src/utils/assets.native.ts
+++ b/packages/connect/src/utils/assets.native.ts
@@ -1,3 +1,3 @@
-import { getAssetByUrl } from './assetUtils';
+import { tryLocalAssetRequire } from './assetUtils';
 
-export const httpRequest = (url: string, _type: string): any => getAssetByUrl(url);
+export const httpRequest = (url: string, _type: string): any => tryLocalAssetRequire(url);

--- a/packages/connect/src/utils/assets.ts
+++ b/packages/connect/src/utils/assets.ts
@@ -3,7 +3,7 @@
 import fetch from 'cross-fetch';
 import { promises as fs } from 'fs';
 import { httpRequest as browserHttpRequest } from './assets-browser';
-import { getAssetByUrl } from './assetUtils';
+import { tryLocalAssetRequire } from './assetUtils';
 
 if (global && typeof global.fetch !== 'function') {
     global.fetch = fetch;
@@ -36,7 +36,7 @@ export function httpRequest(
     options?: RequestInit,
     skipLocalForceDownload?: boolean,
 ) {
-    const asset = skipLocalForceDownload ? null : getAssetByUrl(url);
+    const asset = skipLocalForceDownload ? null : tryLocalAssetRequire(url);
 
     if (!asset) {
         return /^https?/.test(url) ? browserHttpRequest(url, type, options) : fs.readFile(url);


### PR DESCRIPTION
total nitpick. just renaming a method name I bumped into while browsing the codebase.