### PR TITLE
chore(ci): do not build node bridge in CI for labeled pull requests

### DIFF
--- a/.github/workflows/build-node-bridge.yml
+++ b/.github/workflows/build-node-bridge.yml
@@ -8,8 +8,6 @@ on:
   push:
     branches:
       - develop
-  pull_request:
-    types: [labeled]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
As described in https://github.com/trezor/trezor-suite/pull/14622#discussion_r1782714819, the `pull_request` section here does not make sense