### PR TITLE
fix(coinmarket): hide swap in BTC-only firmware

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActions.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActions.tsx
@@ -19,6 +19,7 @@ import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 import { goto } from 'src/actions/suite/routerActions';
 import { AppNavigationTooltip } from 'src/components/suite/AppNavigation/AppNavigationTooltip';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
+import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 
 const Container = styled.div`
     display: flex;
@@ -158,20 +159,22 @@ export const HeaderActions = () => {
                             <Translation id="TR_COINMARKET_BUY_AND_SELL" />
                         </ButtonComponent>
                     </ShowOnLargeDesktopWrapper>
-                    <ButtonComponent
-                        icon="arrowsLeftRight"
-                        onClick={() => {
-                            goToWithAnalytics('wallet-coinmarket-exchange', {
-                                preserveParams: true,
-                            });
-                        }}
-                        data-testid="@wallet/menu/wallet-coinmarket-exchange"
-                        variant="tertiary"
-                        size="small"
-                        isDisabled={isAccountLoading}
-                    >
-                        <Translation id="TR_COINMARKET_SWAP" />
-                    </ButtonComponent>
+                    {!hasBitcoinOnlyFirmware(device) && (
+                        <ButtonComponent
+                            icon="arrowsLeftRight"
+                            onClick={() => {
+                                goToWithAnalytics('wallet-coinmarket-exchange', {
+                                    preserveParams: true,
+                                });
+                            }}
+                            data-testid="@wallet/menu/wallet-coinmarket-exchange"
+                            variant="tertiary"
+                            size="small"
+                            isDisabled={isAccountLoading}
+                        >
+                            <Translation id="TR_COINMARKET_SWAP" />
+                        </ButtonComponent>
+                    )}
                 </AppNavigationTooltip>
             )}
 


### PR DESCRIPTION
## Info
Delete the _Swap_ button in the header for BTC-only firmware.

## Screenshot
### Before
![obrazek](https://github.com/user-attachments/assets/0be3474e-c1ff-4d96-a6bd-bb67646d9a5a)

### After 
![obrazek](https://github.com/user-attachments/assets/0d5b9fb1-b2c6-4ebd-a6ec-a10ca5ec3b29)

## Related
Resolve https://github.com/trezor/trezor-suite/issues/14746
