### PR TITLE
fix(coinmarket): minor fixes

### DIFF
--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketBuyForm.tsx
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketBuyForm.tsx
@@ -204,54 +204,51 @@ export const useCoinmarketBuyForm = ({
             const quoteRequest = getQuoteRequestData();
             const allQuotes = await getQuotesRequest(quoteRequest, offLoading);
 
-            if (Array.isArray(allQuotes)) {
-                if (allQuotes.length === 0) {
-                    timer.stop();
-
-                    return;
-                }
-
-                // processed quotes and without alternative quotes
-                const quotesDefault = filterQuotesAccordingTags<CoinmarketTradeBuyType>(
-                    addIdsToQuotes<CoinmarketTradeBuyType>(allQuotes, 'buy'),
-                );
-                // without errors
-                const quotesSuccess =
-                    coinmarketGetSuccessQuotes<CoinmarketTradeBuyType>(quotesDefault) ?? [];
-
-                const bestQuote = quotesSuccess?.[0];
-                const bestQuotePaymentMethod = bestQuote?.paymentMethod;
-                const bestQuotePaymentMethodName =
-                    bestQuote?.paymentMethodName ?? bestQuotePaymentMethod;
-                const paymentMethodSelected = values.paymentMethod?.value;
-                const paymentMethodsFromQuotes = getPaymentMethods(quotesSuccess);
-                const isSelectedPaymentMethodAvailable =
-                    paymentMethodsFromQuotes.find(item => item.value === paymentMethodSelected) !==
-                    undefined;
-                const limits = getAmountLimits(quoteRequest, quotesDefault); // from all quotes except alternative
-                if (limits && quoteRequest.wantCrypto) {
-                    limits.currency =
-                        cryptoIdToCoinSymbol(quoteRequest.receiveCurrency) ?? limits.currency;
-                }
-
-                setInnerQuotes(quotesSuccess);
-                dispatch(coinmarketBuyActions.saveQuotes(quotesSuccess));
-                dispatch(coinmarketBuyActions.saveQuoteRequest(quoteRequest));
-                dispatch(coinmarketInfoActions.savePaymentMethods(paymentMethodsFromQuotes));
-                setAmountLimits(limits);
-
-                if (!paymentMethodSelected || !isSelectedPaymentMethodAvailable) {
-                    setValue(FORM_PAYMENT_METHOD_SELECT, {
-                        value: bestQuotePaymentMethod ?? '',
-                        label: bestQuotePaymentMethodName ?? '',
-                    });
-                }
-
-                setIsSubmittingHelper(false);
-            } else {
+            if (!Array.isArray(allQuotes) || allQuotes.length === 0) {
+                timer.stop();
                 setInnerQuotes([]);
+                setIsSubmittingHelper(false);
+
+                return;
             }
 
+            // processed quotes and without alternative quotes
+            const quotesDefault = filterQuotesAccordingTags<CoinmarketTradeBuyType>(
+                addIdsToQuotes<CoinmarketTradeBuyType>(allQuotes, 'buy'),
+            );
+            // without errors
+            const quotesSuccess =
+                coinmarketGetSuccessQuotes<CoinmarketTradeBuyType>(quotesDefault) ?? [];
+
+            const bestQuote = quotesSuccess?.[0];
+            const bestQuotePaymentMethod = bestQuote?.paymentMethod;
+            const bestQuotePaymentMethodName =
+                bestQuote?.paymentMethodName ?? bestQuotePaymentMethod;
+            const paymentMethodSelected = values.paymentMethod?.value;
+            const paymentMethodsFromQuotes = getPaymentMethods(quotesSuccess);
+            const isSelectedPaymentMethodAvailable =
+                paymentMethodsFromQuotes.find(item => item.value === paymentMethodSelected) !==
+                undefined;
+            const limits = getAmountLimits(quoteRequest, quotesDefault); // from all quotes except alternative
+            if (limits && quoteRequest.wantCrypto) {
+                limits.currency =
+                    cryptoIdToCoinSymbol(quoteRequest.receiveCurrency) ?? limits.currency;
+            }
+
+            setInnerQuotes(quotesSuccess);
+            dispatch(coinmarketBuyActions.saveQuotes(quotesSuccess));
+            dispatch(coinmarketBuyActions.saveQuoteRequest(quoteRequest));
+            dispatch(coinmarketInfoActions.savePaymentMethods(paymentMethodsFromQuotes));
+            setAmountLimits(limits);
+
+            if (!paymentMethodSelected || !isSelectedPaymentMethodAvailable) {
+                setValue(FORM_PAYMENT_METHOD_SELECT, {
+                    value: bestQuotePaymentMethod ?? '',
+                    label: bestQuotePaymentMethodName ?? '',
+                });
+            }
+
+            setIsSubmittingHelper(false);
             timer.reset();
         },
         [

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeForm.ts
@@ -397,7 +397,11 @@ export const useCoinmarketExchangeForm = ({
         } else {
             // CONFIRMING, SUCCESS
             dispatch(
-                coinmarketExchangeActions.saveTrade(response, account, new Date().toISOString()),
+                coinmarketExchangeActions.saveTrade(
+                    response,
+                    selectedAccount.account,
+                    new Date().toISOString(),
+                ),
             );
             dispatch(coinmarketExchangeActions.saveTransactionId(response.orderId));
             ok = true;
@@ -437,7 +441,7 @@ export const useCoinmarketExchangeForm = ({
                     dispatch(
                         coinmarketExchangeActions.saveTrade(
                             quote,
-                            account,
+                            selectedAccount.account,
                             new Date().toISOString(),
                         ),
                     );
@@ -490,7 +494,7 @@ export const useCoinmarketExchangeForm = ({
                 dispatch(
                     coinmarketExchangeActions.saveTrade(
                         selectedQuote,
-                        account,
+                        selectedAccount.account,
                         new Date().toISOString(),
                     ),
                 );

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSellForm.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSellForm.ts
@@ -355,7 +355,7 @@ export const useCoinmarketSellForm = ({
                     dispatch(
                         coinmarketSellActions.saveTrade(
                             response.trade,
-                            account,
+                            selectedAccount.account,
                             new Date().toISOString(),
                         ),
                     );
@@ -499,15 +499,19 @@ export const useCoinmarketSellForm = ({
                 }
 
                 dispatch(
-                    coinmarketSellActions.saveTrade(response, account, new Date().toISOString()),
+                    coinmarketSellActions.saveTrade(
+                        response,
+                        selectedAccount.account,
+                        new Date().toISOString(),
+                    ),
                 );
                 dispatch(coinmarketSellActions.saveTransactionId(selectedQuote.orderId));
                 dispatch(
                     routerActions.goto('wallet-coinmarket-sell-detail', {
                         params: {
-                            symbol: account.symbol,
-                            accountIndex: account.index,
-                            accountType: account.accountType,
+                            symbol: selectedAccount.account.symbol,
+                            accountIndex: selectedAccount.account.index,
+                            accountType: selectedAccount.account.accountType,
                         },
                     }),
                 );

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -1166,6 +1166,10 @@ export default defineMessages({
         defaultMessage: 'Last transactions',
         id: 'TR_COINMARKET_LAST_TRANSACTIONS',
     },
+    TR_COINMARKET_TRANSACTION_COUNTER: {
+        defaultMessage: '{totalBuys} buys • {totalSells} sells • {totalSwaps} swaps',
+        id: 'TR_COINMARKET_TRANSACTION_COUNTER',
+    },
     TR_COINMARKET_PAYMENT_METHOD: {
         defaultMessage: 'Payment method',
         id: 'TR_COINMARKET_PAYMENT_METHOD',
@@ -1419,6 +1423,7 @@ export default defineMessages({
         defaultMessage: 'Swap',
         id: 'TR_COINMARKET_SWAP',
     },
+
     TR_ADDRESS_MODAL_CLIPBOARD: {
         defaultMessage: 'Copy address',
         id: 'TR_ADDRESS_MODAL_CLIPBOARD',
@@ -4439,18 +4444,6 @@ export default defineMessages({
         id: 'TR_BUY_RECEIVE_ADDRESS_QUESTION_TOOLTIP',
         defaultMessage:
             'This is the specific alphanumeric address that will receive your coins. Verify this address on your Trezor.',
-    },
-    TR_TRADE_BUYS: {
-        id: 'TR_TRADE_BUYS',
-        defaultMessage: 'buys',
-    },
-    TR_TRADE_SELLS: {
-        id: 'TR_TRADE_SELLS',
-        defaultMessage: 'sells',
-    },
-    TR_TRADE_EXCHANGES: {
-        id: 'TR_TRADE_EXCHANGES',
-        defaultMessage: 'exchanges',
     },
     TR_PAYMENT_METHOD_CREDITCARD: {
         id: 'TR_PAYMENT_METHOD_CREDITCARD',

--- a/packages/suite/src/views/wallet/coinmarket/buy/CoinmarketBuyOffers.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/CoinmarketBuyOffers.tsx
@@ -1,7 +1,6 @@
 import { useCoinmarketBuyForm } from 'src/hooks/wallet/coinmarket/form/useCoinmarketBuyForm';
 import { CoinmarketFormContext } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonForm';
 import { UseCoinmarketProps } from 'src/types/coinmarket/coinmarket';
-import { CoinmarketFooter } from 'src/views/wallet/coinmarket/common';
 import { CoinmarketContainer } from 'src/views/wallet/coinmarket/common/CoinmarketContainer';
 import { CoinmarketOffers } from 'src/views/wallet/coinmarket/common/CoinmarketOffers/CoinmarketOffers';
 
@@ -14,7 +13,6 @@ const CoinmarketBuyOffersComponent = ({ selectedAccount }: UseCoinmarketProps) =
     return (
         <CoinmarketFormContext.Provider value={coinmarketBuyFormContextValues}>
             <CoinmarketOffers />
-            <CoinmarketFooter />
         </CoinmarketFormContext.Provider>
     );
 };

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketContainer.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketContainer.tsx
@@ -5,6 +5,7 @@ import { PageHeader } from 'src/components/suite/layouts/SuiteLayout';
 import { WalletLayout } from 'src/components/wallet';
 import { useLayout, useSelector, useTranslation } from 'src/hooks/suite';
 import { UseCoinmarketProps } from 'src/types/coinmarket/coinmarket';
+import { CoinmarketFooter } from 'src/views/wallet/coinmarket/common/CoinmarketFooter/CoinmarketFooter';
 
 interface CoinmarketContainerProps {
     title?: Extract<
@@ -36,5 +37,10 @@ export const CoinmarketContainer = ({
         return <WalletLayout title="TR_NAV_TRADE" isSubpage account={selectedAccount} />;
     }
 
-    return <SectionComponent selectedAccount={selectedAccount} />;
+    return (
+        <>
+            <SectionComponent selectedAccount={selectedAccount} />
+            <CoinmarketFooter />
+        </>
+    );
 };

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketFooter/CoinmarketFooter.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketFooter/CoinmarketFooter.tsx
@@ -1,20 +1,20 @@
-import { variables, Icon, Link, Image } from '@trezor/components';
+import { variables, Icon, Link, Image, Row } from '@trezor/components';
 import { useState, useRef } from 'react';
 import styled, { css } from 'styled-components';
 import { useOnClickOutside } from '@trezor/react-utils';
 import { DATA_TOS_INVITY_URL, INVITY_URL } from '@trezor/urls';
 import { Translation } from 'src/components/suite';
-import { borders, spacingsPx, zIndices } from '@trezor/theme';
+import { borders, spacings, spacingsPx, zIndices } from '@trezor/theme';
 import { CoinmarketFooterLogoWrapper } from 'src/views/wallet/coinmarket';
 import { CoinmarketProvidedByInvity } from 'src/views/wallet/coinmarket/common/CoinmarketFooter/CoinmarketProvidedByInvity';
 
 const Wrapper = styled.div`
-    display: flex;
-    width: 100%;
-    align-items: center;
-    justify-content: center;
-    padding-top: 20px;
     margin-top: ${spacingsPx.xxxl};
+    padding: ${spacings.zero} ${spacingsPx.lg};
+`;
+
+const WrapperBorder = styled.div`
+    padding-top: ${spacingsPx.lg};
     border-top: 1px solid ${({ theme }) => theme.borderElevation1};
 `;
 
@@ -117,44 +117,48 @@ export const CoinmarketFooter = () => {
 
     return (
         <Wrapper>
-            <Left>
-                <CoinmarketProvidedByInvity />
-            </Left>
-            <Right>
-                {toggled && (
-                    <FooterBox ref={menuRef}>
-                        <Header>
-                            <BoxLeft>
-                                <CoinmarketFooterLogoWrapper>
-                                    <Link href={INVITY_URL} target="_blank">
-                                        <Image width={70} image="INVITY_LOGO" />
-                                    </Link>
-                                </CoinmarketFooterLogoWrapper>
-                            </BoxLeft>
-                            <BoxRight>
-                                <Link href={INVITY_URL}>invity.io</Link>
-                                <IconWrapper onClick={() => setToggled(false)}>
-                                    <Icon name="close" size={16} />
-                                </IconWrapper>
-                            </BoxRight>
-                        </Header>
-                        <FooterText>
-                            <Translation id="TR_BUY_FOOTER_TEXT_1" />
-                        </FooterText>
-                        <FooterText>
-                            <Translation id="TR_BUY_FOOTER_TEXT_2" />
-                        </FooterText>
-                    </FooterBox>
-                )}
+            <WrapperBorder>
+                <Row justifyContent="center">
+                    <Left>
+                        <CoinmarketProvidedByInvity />
+                    </Left>
+                    <Right>
+                        {toggled && (
+                            <FooterBox ref={menuRef}>
+                                <Header>
+                                    <BoxLeft>
+                                        <CoinmarketFooterLogoWrapper>
+                                            <Link href={INVITY_URL} target="_blank">
+                                                <Image width={70} image="INVITY_LOGO" />
+                                            </Link>
+                                        </CoinmarketFooterLogoWrapper>
+                                    </BoxLeft>
+                                    <BoxRight>
+                                        <Link href={INVITY_URL}>invity.io</Link>
+                                        <IconWrapper onClick={() => setToggled(false)}>
+                                            <Icon name="close" size={16} />
+                                        </IconWrapper>
+                                    </BoxRight>
+                                </Header>
+                                <FooterText>
+                                    <Translation id="TR_BUY_FOOTER_TEXT_1" />
+                                </FooterText>
+                                <FooterText>
+                                    <Translation id="TR_BUY_FOOTER_TEXT_2" />
+                                </FooterText>
+                            </FooterBox>
+                        )}
 
-                <StyledLink href={DATA_TOS_INVITY_URL} variant="nostyle">
-                    <Translation id="TR_TERMS_OF_USE_INVITY" />
-                </StyledLink>
-                <VerticalDivider />
-                <LearnMoreToggle ref={toggleRef} onClick={() => setToggled(true)}>
-                    <Translation id="TR_BUY_LEARN_MORE" />
-                </LearnMoreToggle>
-            </Right>
+                        <StyledLink href={DATA_TOS_INVITY_URL} variant="nostyle">
+                            <Translation id="TR_TERMS_OF_USE_INVITY" />
+                        </StyledLink>
+                        <VerticalDivider />
+                        <LearnMoreToggle ref={toggleRef} onClick={() => setToggled(true)}>
+                            <Translation id="TR_BUY_LEARN_MORE" />
+                        </LearnMoreToggle>
+                    </Right>
+                </Row>
+            </WrapperBorder>
         </Wrapper>
     );
 };

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketAccountTransactions/CoinmarketAccountTransactions.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketAccountTransactions/CoinmarketAccountTransactions.tsx
@@ -81,10 +81,14 @@ export const CoinmarketAccountTransactions = () => {
                         </H2>
                         <p>
                             <TransactionCount>
-                                {buyTransactions.length} <Translation id="TR_TRADE_BUYS" /> •{' '}
-                                {sellTransactions.length} <Translation id="TR_TRADE_SELLS" /> •{' '}
-                                {exchangeTransactions.length}{' '}
-                                <Translation id="TR_TRADE_EXCHANGES" />
+                                <Translation
+                                    id="TR_COINMARKET_TRANSACTION_COUNTER"
+                                    values={{
+                                        totalBuys: buyTransactions.length,
+                                        totalSells: sellTransactions.length,
+                                        totalSwaps: exchangeTransactions.length,
+                                    }}
+                                />
                             </TransactionCount>
                         </p>
                     </Header>

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketAccountTransactions/ExchangeTransaction.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketAccountTransactions/ExchangeTransaction.tsx
@@ -130,19 +130,24 @@ export const ExchangeTransaction = ({ trade, providers, account }: ExchangeTrans
         );
     };
 
+    if (!send || !receive) return null;
+
     return (
         <Wrapper>
             <Column>
                 <Row>
                     <Amount>
-                        <FormattedCryptoAmount value={sendStringAmount} symbol={send} />
+                        <FormattedCryptoAmount
+                            value={sendStringAmount}
+                            symbol={cryptoIdToCoinSymbol(send)}
+                        />
                     </Amount>
                     <Arrow>
                         <Icon color={theme.legacy.TYPE_LIGHT_GREY} size={13} name="caretRight" />
                     </Arrow>
                     <FormattedCryptoAmount
                         value={receiveStringAmount}
-                        symbol={cryptoIdToCoinSymbol(receive!)}
+                        symbol={cryptoIdToCoinSymbol(receive)}
                     />
                     {/* TODO FIX THIS LOGO */}
                     {/* <StyledCoinLogo size={13} symbol={symbol} /> */}

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketAccountTransactions/ExchangeTransaction.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketAccountTransactions/ExchangeTransaction.tsx
@@ -8,7 +8,7 @@ import { goto } from 'src/actions/suite/routerActions';
 import { saveTransactionId } from 'src/actions/wallet/coinmarketExchangeActions';
 import { Account } from 'src/types/wallet';
 import { Translation, FormattedDate, FormattedCryptoAmount } from 'src/components/suite';
-import { useDispatch } from 'src/hooks/suite';
+import { useDispatch, useTranslation } from 'src/hooks/suite';
 import { useCoinmarketWatchTrade } from 'src/hooks/wallet/coinmarket/useCoinmarketWatchTrade';
 import { useCoinmarketInfo } from 'src/hooks/wallet/coinmarket/useCoinmarketInfo';
 import { CoinmarketTransactionStatus } from 'src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketAccountTransactions/CoinmarketTransactionStatus';
@@ -109,6 +109,7 @@ interface ExchangeTransactionProps {
 
 export const ExchangeTransaction = ({ trade, providers, account }: ExchangeTransactionProps) => {
     const dispatch = useDispatch();
+    const { translationString } = useTranslation();
     const theme = useTheme();
     useCoinmarketWatchTrade({ account, trade });
     const { cryptoIdToCoinSymbol } = useCoinmarketInfo();
@@ -147,7 +148,8 @@ export const ExchangeTransaction = ({ trade, providers, account }: ExchangeTrans
                     {/* <StyledCoinLogo size={13} symbol={symbol} /> */}
                 </Row>
                 <SmallRowStatus>
-                    {trade.tradeType.toUpperCase()} • <FormattedDate value={date} date time /> •{' '}
+                    {translationString('TR_COINMARKET_SWAP').toUpperCase()} •{' '}
+                    <FormattedDate value={date} date time /> •{' '}
                     <StyledStatus trade={data} tradeType={trade.tradeType} />
                 </SmallRowStatus>
                 <SmallRow>

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketLayout.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketLayout.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 
 import { WalletLayout, WalletSubpageHeading } from 'src/components/wallet';
 import type { SelectedAccountLoaded } from '@suite-common/wallet-types';
-import { CoinmarketFooter } from 'src/views/wallet/coinmarket/common';
 import { spacingsPx } from '@trezor/theme';
 import { SCREEN_QUERY } from '@trezor/components/src/config/variables';
 import { CoinmarketLayoutNavigation } from 'src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketLayoutNavigation/CoinmarketLayoutNavigation';
@@ -31,7 +30,6 @@ export const CoinmarketLayout = ({ children, selectedAccount }: CoinmarketLayout
             <WalletSubpageHeading title="TR_NAV_TRADE" />
             <CoinmarketLayoutNavigation selectedAccount={selectedAccount} />
             <CoinmarketFormWrapper>{children}</CoinmarketFormWrapper>
-            <CoinmarketFooter />
         </CoinmarketWrapper>
     </WalletLayout>
 );

--- a/packages/suite/src/views/wallet/coinmarket/exchange/CoinmarketExchangeOffers.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/CoinmarketExchangeOffers.tsx
@@ -1,6 +1,5 @@
 import { UseCoinmarketProps } from 'src/types/coinmarket/coinmarket';
 import { CoinmarketOffers } from 'src/views/wallet/coinmarket/common/CoinmarketOffers/CoinmarketOffers';
-import { CoinmarketFooter } from 'src/views/wallet/coinmarket/common';
 import { useCoinmarketExchangeForm } from 'src/hooks/wallet/coinmarket/form/useCoinmarketExchangeForm';
 import { CoinmarketContainer } from 'src/views/wallet/coinmarket/common/CoinmarketContainer';
 import { CoinmarketFormContext } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonForm';
@@ -14,7 +13,6 @@ const CoinmarketExchangeOffersComponent = ({ selectedAccount }: UseCoinmarketPro
     return (
         <CoinmarketFormContext.Provider value={coinmarketExchangeContextValues}>
             <CoinmarketOffers />
-            <CoinmarketFooter />
         </CoinmarketFormContext.Provider>
     );
 };

--- a/packages/suite/src/views/wallet/coinmarket/sell/CoinmarketSellOffers.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/CoinmarketSellOffers.tsx
@@ -1,7 +1,6 @@
 import { UseCoinmarketProps } from 'src/types/coinmarket/coinmarket';
 import { CoinmarketFormContext } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonForm';
 import { useCoinmarketSellForm } from 'src/hooks/wallet/coinmarket/form/useCoinmarketSellForm';
-import { CoinmarketFooter } from 'src/views/wallet/coinmarket/common';
 import { CoinmarketOffers } from 'src/views/wallet/coinmarket/common/CoinmarketOffers/CoinmarketOffers';
 import { CoinmarketContainer } from 'src/views/wallet/coinmarket/common/CoinmarketContainer';
 
@@ -14,7 +13,6 @@ const CoinmarketSellOffersComponent = ({ selectedAccount }: UseCoinmarketProps) 
     return (
         <CoinmarketFormContext.Provider value={coinmarketSellFormContextValues}>
             <CoinmarketOffers />
-            <CoinmarketFooter />
         </CoinmarketFormContext.Provider>
     );
 };

--- a/packages/suite/src/views/wallet/coinmarket/transactions/CoinmarketTransactions.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/transactions/CoinmarketTransactions.tsx
@@ -1,20 +1,10 @@
-import { CoinmarketFooter } from 'src/views/wallet/coinmarket/common';
 import { CoinmarketAccountTransactions } from 'src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketAccountTransactions/CoinmarketAccountTransactions';
 import { CoinmarketContainer } from 'src/views/wallet/coinmarket/common/CoinmarketContainer';
-
-const CoinmarketTransactionsComponent = () => {
-    return (
-        <>
-            <CoinmarketAccountTransactions />
-            <CoinmarketFooter />
-        </>
-    );
-};
 
 export const CoinmarketTransactions = () => (
     <CoinmarketContainer
         title="TR_COINMARKET_LAST_TRANSACTIONS"
         backRoute="wallet-coinmarket-buy"
-        SectionComponent={CoinmarketTransactionsComponent}
+        SectionComponent={CoinmarketAccountTransactions}
     />
 );


### PR DESCRIPTION
## Description
- missing Invity Footer in confirm pages(1)
- in the Last transaction pages
  - replace `exchanges` → `swaps` (2)
  - send in swaps transactions using contract address instead of symbol (3)
- infinity loading when the response contains empty quotes (edge case - do not know how to replicate without localhost API)
- bad `watchTrade` account - change account to selectedAccount (some trades were saved in bad account) (4)

## Screenshots
**Missing footer (1)**
![obrazek](https://github.com/user-attachments/assets/d1141926-03e4-45db-8b9b-4151d8a7693f)
**Rename `exchanges` (2)** 
![obrazek](https://github.com/user-attachments/assets/8f26e342-c2af-43ff-b143-8b5ac1575634)
**Bad symbol (3)**
![obrazek](https://github.com/user-attachments/assets/5c319867-5589-4e9c-ae7d-1a19074408b3)

## Other
**Steps to reproduce (4)**
1. Select ETH account 
2. Go to Swap
3. Choose `From` SOL and `To` USDT
4. Make the trade
5. After transaction confirmation you will be on SOL account instead of ETH account

## Related 
Resolve https://github.com/trezor/trezor-suite/issues/14767
Will be rebased on develop branch after https://github.com/trezor/trezor-suite/pull/14758 will be merged