### PR TITLE
feat: implement sessionOwner - better 'used elsewhere' ux

### DIFF
--- a/packages/connect/setupJest.ts
+++ b/packages/connect/setupJest.ts
@@ -40,6 +40,7 @@ const createTransportApi = (override = {}) =>
 export const createTestTransport = (apiMethods = {}) =>
     new TestTransport({
         api: createTransportApi(apiMethods),
+        id: 'foo-bar-id',
     });
 
 export const getDeviceFeatures = (feat?: Partial<Features>): Features => ({

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -1206,7 +1206,7 @@ export class Core extends EventEmitter {
 
         try {
             await DataManager.load(settings);
-            const { debug, priority, _sessionsBackgroundUrl } = DataManager.getSettings();
+            const { debug, priority, _sessionsBackgroundUrl, manifest } = DataManager.getSettings();
             const messages = DataManager.getProtobufMessages();
 
             enableLog(debug);
@@ -1221,6 +1221,7 @@ export class Core extends EventEmitter {
                 messages,
                 priority,
                 _sessionsBackgroundUrl,
+                manifest,
             });
             initDeviceList(this.getCoreContext());
 

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -128,6 +128,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
     public readonly transport: Transport;
     public readonly protocol: TransportProtocol;
     private readonly transportPath;
+    private readonly transportSessionOwner;
     private session;
     private isLocalSession;
 
@@ -214,6 +215,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
         this.uniquePath = id;
         this.transport = transport;
         this.transportPath = descriptor.path;
+        this.transportSessionOwner = descriptor.sessionOwner;
 
         this.session = descriptor.session;
         this.isLocalSession = false;
@@ -1148,6 +1150,8 @@ export class Device extends TypedEmitter<DeviceEvents> {
                 ...base,
                 type: 'unacquired',
                 label: 'Unacquired device',
+                name: this.name,
+                transportSessionOwner: this.transportSessionOwner,
             };
         }
         const defaultLabel = 'My Trezor';

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -79,7 +79,10 @@ export const assertDeviceListConnected: (
     if (!deviceList.isConnected()) throw ERRORS.TypedError('Transport_Missing');
 };
 
-type ConstructorParams = Pick<ConnectSettings, 'priority' | 'debug' | '_sessionsBackgroundUrl'> & {
+type ConstructorParams = Pick<
+    ConnectSettings,
+    'priority' | 'debug' | '_sessionsBackgroundUrl' | 'manifest'
+> & {
     messages: Record<string, any>;
 };
 type InitParams = Pick<ConnectSettings, 'pendingTransportEvent' | 'transportReconnect'>;
@@ -111,7 +114,13 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
         return this.initPromise;
     }
 
-    constructor({ messages, priority, debug, _sessionsBackgroundUrl }: ConstructorParams) {
+    constructor({
+        messages,
+        priority,
+        debug,
+        _sessionsBackgroundUrl,
+        manifest,
+    }: ConstructorParams) {
         super();
 
         const transportLogger = initLog('@trezor/transport', debug);
@@ -122,6 +131,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
             messages,
             logger: transportLogger,
             sessionsBackgroundUrl: _sessionsBackgroundUrl,
+            id: manifest?.appUrl || 'unknown app',
         };
 
         this.transports = [

--- a/packages/connect/src/types/device.ts
+++ b/packages/connect/src/types/device.ts
@@ -96,6 +96,7 @@ export type KnownDevice = BaseDevice & {
         firmwareHash: FirmwareHashCheckResult | null;
         // Maybe add AuthenticityCheck result here?
     };
+    transportSessionOwner?: undefined;
 };
 
 export type UnknownDevice = BaseDevice & {
@@ -115,6 +116,7 @@ export type UnknownDevice = BaseDevice & {
     state?: typeof undefined;
     unavailableCapabilities?: typeof undefined;
     availableTranslations?: typeof undefined;
+    transportSessionOwner?: string;
 };
 
 export type UnreadableDevice = BaseDevice & {
@@ -134,6 +136,7 @@ export type UnreadableDevice = BaseDevice & {
     state?: typeof undefined;
     unavailableCapabilities?: typeof undefined;
     availableTranslations?: typeof undefined;
+    transportSessionOwner?: undefined;
 };
 
 export type Device = KnownDevice | UnknownDevice | UnreadableDevice;

--- a/packages/node-utils/src/tests/http.test.ts
+++ b/packages/node-utils/src/tests/http.test.ts
@@ -279,7 +279,7 @@ describe('HttpServer', () => {
         res = await post('foo-1/321', undefined); // body != array, fails in parseBodyJSON
         expect(res.status).toEqual(400);
         const { error } = await res.json();
-        expect(error).toMatch('Invalid json body:');
+        expect(error).toMatch('Invalid body');
 
         res = await post('foo-1/not-a-number', { foo: 'bar' });
         expect(res.status).toEqual(400);

--- a/packages/suite-web/e2e/cypress.config.ts
+++ b/packages/suite-web/e2e/cypress.config.ts
@@ -158,7 +158,7 @@ export default defineConfig({
                     return null;
                 },
                 stealBridgeSession: async () => {
-                    const bridge = new BridgeTransport({ messages });
+                    const bridge = new BridgeTransport({ messages, id: 'foo-bar' });
                     await bridge.init();
                     const enumerateRes = await bridge.enumerate();
                     if (!enumerateRes.success) return null;

--- a/packages/suite/src/components/suite/ConnectDevicePrompt.tsx
+++ b/packages/suite/src/components/suite/ConnectDevicePrompt.tsx
@@ -76,6 +76,8 @@ const getMessageId = ({
             return isDesktop() ? 'TR_NO_TRANSPORT_DESKTOP' : 'TR_NO_TRANSPORT';
         case 'device-bootloader':
             return 'TR_DEVICE_CONNECTED_BOOTLOADER';
+        case 'device-unacquired':
+            return 'TR_DEVICE_CONNECTED_UNACQUIRED';
         default: {
             if (connected) {
                 return !showWarning ? 'TR_DEVICE_CONNECTED' : 'TR_DEVICE_CONNECTED_WRONG_STATE';

--- a/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
+++ b/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
@@ -189,7 +189,10 @@ describe('Preloader component', () => {
 
     it('Unacquired device', () => {
         const device: DeepPartial<AppState['device']> = {
-            selectedDevice: { type: 'unacquired' },
+            selectedDevice: {
+                transportSessionOwner: 'foo',
+                type: 'unacquired',
+            },
         };
 
         const store = initStore(
@@ -210,7 +213,10 @@ describe('Preloader component', () => {
 
     it('Unreadable device: webusb HID', () => {
         const device: DeepPartial<AppState['device']> = {
-            selectedDevice: { type: 'unreadable', error: 'LIBUSB_ERROR_ACCESS' },
+            selectedDevice: {
+                type: 'unreadable',
+                error: 'LIBUSB_ERROR_ACCESS',
+            },
         };
 
         const store = initStore(
@@ -233,7 +239,10 @@ describe('Preloader component', () => {
         jest.spyOn(envUtils, 'isLinux').mockImplementation(() => true);
 
         const device: DeepPartial<AppState['device']> = {
-            selectedDevice: { type: 'unreadable', error: 'LIBUSB_ERROR_ACCESS' },
+            selectedDevice: {
+                type: 'unreadable',
+                error: 'LIBUSB_ERROR_ACCESS',
+            },
         };
 
         const store = initStore(
@@ -256,7 +265,10 @@ describe('Preloader component', () => {
         jest.spyOn(envUtils, 'isLinux').mockImplementation(() => false);
 
         const device: DeepPartial<AppState['device']> = {
-            selectedDevice: { type: 'unreadable', error: 'LIBUSB_ERROR_ACCESS' },
+            selectedDevice: {
+                type: 'unreadable',
+                error: 'LIBUSB_ERROR_ACCESS',
+            },
         };
 
         const store = initStore(
@@ -277,7 +289,10 @@ describe('Preloader component', () => {
 
     it('Unreadable device: unknown error', () => {
         const device: DeepPartial<AppState['device']> = {
-            selectedDevice: { type: 'unreadable', error: 'Unexpected error' },
+            selectedDevice: {
+                type: 'unreadable',
+                error: 'Unexpected error',
+            },
         };
 
         const store = initStore(
@@ -298,7 +313,10 @@ describe('Preloader component', () => {
 
     it('Unknown device (should never happen)', () => {
         const device: DeepPartial<AppState['device']> = {
-            selectedDevice: { features: undefined },
+            selectedDevice: {
+                transportSessionOwner: 'foo',
+                features: undefined,
+            },
         };
 
         const store = initStore(
@@ -319,7 +337,10 @@ describe('Preloader component', () => {
 
     it('Seedless device', () => {
         const device: DeepPartial<AppState['device']> = {
-            selectedDevice: { mode: 'seedless', features: {} },
+            selectedDevice: {
+                mode: 'seedless',
+                features: {},
+            },
         };
 
         const store = initStore(
@@ -365,7 +386,10 @@ describe('Preloader component', () => {
 
     it('Not initialized device', () => {
         const device: DeepPartial<AppState['device']> = {
-            selectedDevice: { mode: 'initialize', features: {} },
+            selectedDevice: {
+                mode: 'initialize',
+                features: {},
+            },
         };
 
         const store = initStore(
@@ -387,7 +411,10 @@ describe('Preloader component', () => {
 
     it('Bootloader device with installed firmware', () => {
         const device: DeepPartial<AppState['device']> = {
-            selectedDevice: { mode: 'bootloader', features: { firmware_present: true } },
+            selectedDevice: {
+                mode: 'bootloader',
+                features: { firmware_present: true },
+            },
         };
 
         const store = initStore(
@@ -409,7 +436,10 @@ describe('Preloader component', () => {
 
     it('Bootloader device without firmware', () => {
         const device: DeepPartial<AppState['device']> = {
-            selectedDevice: { mode: 'bootloader', features: { firmware_present: false } },
+            selectedDevice: {
+                mode: 'bootloader',
+                features: { firmware_present: false },
+            },
         };
 
         const store = initStore(
@@ -431,7 +461,10 @@ describe('Preloader component', () => {
 
     it('Required FW update device', () => {
         const device: DeepPartial<AppState['device']> = {
-            selectedDevice: { firmware: 'required', features: {} },
+            selectedDevice: {
+                firmware: 'required',
+                features: {},
+            },
         };
 
         const store = initStore(

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceAcquire.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceAcquire.tsx
@@ -8,7 +8,7 @@ import { Translation, TroubleshootingTips } from 'src/components/suite';
 import { useDevice, useDispatch } from 'src/hooks/suite';
 
 export const DeviceAcquire = () => {
-    const { isLocked } = useDevice();
+    const { isLocked, device } = useDevice();
     const dispatch = useDispatch();
 
     const isDeviceLocked = isLocked();
@@ -25,6 +25,21 @@ export const DeviceAcquire = () => {
     );
 
     const tips = [
+        {
+            key: 'device-used-elsewhere',
+            heading: <Translation id="TR_DEVICE_CONNECTED_UNACQUIRED" />,
+            description: device?.transportSessionOwner ? (
+                <Translation
+                    id="TR_DEVICE_CONNECTED_UNACQUIRED_DESCRIPTION"
+                    values={{
+                        transportSessionOwner: device.transportSessionOwner,
+                    }}
+                />
+            ) : (
+                // legacy bridge does not share transportSessionOwner information
+                <Translation id="TR_DEVICE_CONNECTED_UNACQUIRED_DESCRIPTION_UNKNOWN_APP" />
+            ),
+        },
         {
             key: 'device-acquire',
             heading: <Translation id="TR_TROUBLESHOOTING_CLOSE_TABS" />,

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -38,6 +38,7 @@ import {
 } from '@suite-common/token-definitions';
 import { selectSuiteSettings } from '../reducers/suite/suiteReducer';
 import { addWalletThunk, openSwitchDeviceDialog } from 'src/actions/wallet/addWalletThunk';
+import { isDesktop } from '@trezor/env-utils';
 
 const connectSrc = resolveStaticPath('connect/');
 // 'https://localhost:8088/';
@@ -50,7 +51,7 @@ const connectInitSettings = {
     popup: false,
     manifest: {
         email: 'info@trezor.io',
-        appUrl: '@trezor/suite',
+        appUrl: isDesktop() ? '@trezor/suite' : window.origin,
     },
     sharedLogger: false,
     enableFirmwareHashCheck: true,

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -6788,6 +6788,20 @@ export default defineMessages({
         id: 'TR_DEVICE_CONNECTED_BOOTLOADER_RECONNECT_IN_NORMAL_NO_TOUCH',
         defaultMessage: 'Reconnect the device without touching the screen.',
     },
+    TR_DEVICE_CONNECTED_UNACQUIRED: {
+        id: 'TR_DEVICE_CONNECTED_UNACQUIRED',
+        defaultMessage: 'Device used elsewhere',
+    },
+    TR_DEVICE_CONNECTED_UNACQUIRED_DESCRIPTION: {
+        id: 'TR_DEVICE_CONNECTED_UNACQUIRED_DESCRIPTION',
+        defaultMessage:
+            'App {transportSessionOwner} might be using the device right now. You may acquire the device for yourself.',
+    },
+    TR_DEVICE_CONNECTED_UNACQUIRED_DESCRIPTION_UNKNOWN_APP: {
+        id: 'TR_DEVICE_CONNECTED_UNACQUIRED_DESCRIPTION_UNKNOWN_APP',
+        defaultMessage:
+            'Another app might be using the device right now. You may acquire the device for yourself.',
+    },
     TR_WIPE_OR_UPDATE: {
         id: 'TR_WIPE_OR_UPDATE',
         defaultMessage: 'Reset device or update firmware',

--- a/packages/transport-bridge/src/core.ts
+++ b/packages/transport-bridge/src/core.ts
@@ -120,7 +120,7 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
         acquireInput: Omit<AcquireInput, 'previous'> & {
             previous: Session | 'null';
             signal: AbortSignal;
-        },
+        } & { sessionOwner: string },
     ) => {
         const acquireIntentResult = await sessionsClient.acquireIntent({
             path: acquireInput.path,
@@ -140,7 +140,10 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
         if (!openDeviceResult.success) {
             return openDeviceResult;
         }
-        await sessionsClient.acquireDone({ path: acquireInput.path });
+        await sessionsClient.acquireDone({
+            path: acquireInput.path,
+            sessionOwner: acquireInput.sessionOwner,
+        });
 
         return acquireIntentResult;
     };

--- a/packages/transport-bridge/src/http.ts
+++ b/packages/transport-bridge/src/http.ts
@@ -272,6 +272,7 @@ export class TrezordNode {
             ]);
 
             app.post('/acquire/:path/:previous', [
+                parseBodyJSON,
                 validateAcquireParams,
                 (req, res) => {
                     res.setHeader('Content-Type', 'text/plain');
@@ -280,6 +281,8 @@ export class TrezordNode {
                         .acquire({
                             path: req.params.path,
                             previous: req.params.previous,
+                            // @ts-expect-error
+                            sessionOwner: req?.body?.sessionOwner,
                             signal,
                         })
                         .then(result => {

--- a/packages/transport-bridge/src/ui/components/Device.tsx
+++ b/packages/transport-bridge/src/ui/components/Device.tsx
@@ -28,6 +28,9 @@ export const Device = ({ device }: DeviceProps) => {
             <div>model: {modelName}</div>
             <div>path: {device.path}</div>
             <div>session: {device.session ? device.session : 'none'}</div>
+            {device.session && (
+                <div>session owner: {device.sessionOwner ? device.sessionOwner : 'unknown'}</div>
+            )}
         </div>
     );
 };

--- a/packages/transport-test/e2e/bridge/bridge-complex-cases.test.ts
+++ b/packages/transport-test/e2e/bridge/bridge-complex-cases.test.ts
@@ -23,7 +23,7 @@ describe('restarting bridge', () => {
         await TrezorUserEnvLink.startEmu();
         await TrezorUserEnvLink.startBridge();
 
-        bridge = new BridgeTransport({ messages });
+        bridge = new BridgeTransport({ messages, id: '' });
         await bridge.init();
 
         const enumerateResult = await bridge.enumerate();
@@ -50,7 +50,7 @@ describe('restarting bridge', () => {
         await TrezorUserEnvLink.stopBridge();
         await TrezorUserEnvLink.startEmu();
         await TrezorUserEnvLink.startBridge();
-        bridge = new BridgeTransport({ messages });
+        bridge = new BridgeTransport({ messages, id: '' });
         await bridge.init();
 
         const enumerateResult = await bridge.enumerate();

--- a/packages/transport-test/e2e/bridge/bridge-listen.test.ts
+++ b/packages/transport-test/e2e/bridge/bridge-listen.test.ts
@@ -23,7 +23,7 @@ describe('bridge', () => {
     // special case of listen. for happy-path listen fixtures referer to multi-client.test.ts
     test('listen - bridge already has some descriptors, client subscribes with non-matching descriptors', async () => {
         await TrezorUserEnvLink.startBridge();
-        const bridge = new BridgeTransport({ messages });
+        const bridge = new BridgeTransport({ messages, id: '' });
         await bridge.init();
         const enumerateResult = await bridge.enumerate();
         assertSuccess(enumerateResult);

--- a/packages/transport-test/e2e/bridge/bridge.test.ts
+++ b/packages/transport-test/e2e/bridge/bridge.test.ts
@@ -18,7 +18,7 @@ describe('bridge', () => {
         await TrezorUserEnvLink.startEmu(emulatorStartOpts);
         await TrezorUserEnvLink.startBridge();
 
-        bridge = new BridgeTransport({ messages });
+        bridge = new BridgeTransport({ messages, id: '' });
         await bridge.init();
 
         const enumerateResult = await bridge.enumerate();

--- a/packages/transport/src/sessions/background.ts
+++ b/packages/transport/src/sessions/background.ts
@@ -215,6 +215,7 @@ export class SessionsBackground
             return this.error(ERRORS.DESCRIPTOR_NOT_FOUND);
         }
         this.descriptors[pathInternal].session = Session(`${this.lastSessionId}`);
+        this.descriptors[pathInternal].sessionOwner = payload.sessionOwner;
 
         return Promise.resolve(
             this.success({
@@ -238,6 +239,7 @@ export class SessionsBackground
 
     private releaseDone(payload: ReleaseDoneRequest) {
         this.descriptors[payload.path].session = null;
+        this.descriptors[payload.path].sessionOwner = undefined;
 
         this.clearLock();
 

--- a/packages/transport/src/sessions/types.ts
+++ b/packages/transport/src/sessions/types.ts
@@ -33,6 +33,7 @@ export type AcquireIntentResponse = BackgroundResponseWithError<
 
 export type AcquireDoneRequest = {
     path: PathPublic;
+    sessionOwner?: string;
 };
 
 export type AcquireDoneResponse = BackgroundResponseWithError<

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -35,6 +35,7 @@ export interface AbstractTransportParams {
     messages?: Record<string, any>;
     logger?: Logger;
     debugLink?: boolean;
+    id: string;
 }
 
 export const isTransportInstance = (transport?: AbstractTransport) => {
@@ -122,13 +123,19 @@ export abstract class AbstractTransport extends TransportEmitter {
      * and instance of logger from @trezor/connect/src/utils/debug could be passed to activate logs from transport
      */
     protected logger?: Logger;
+    /**
+     * identifier this transport
+     * todo: or app implementing this transport?
+     */
+    protected id: string;
 
-    constructor({ messages, logger }: AbstractTransportParams) {
+    constructor({ messages, logger, id }: AbstractTransportParams) {
         super();
         this.descriptors = [];
         this.messages = protobuf.Root.fromJSON(messages || {});
         this.abortController = new AbortController();
         this.logger = logger;
+        this.id = id;
     }
 
     /**

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -123,7 +123,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                     return openDeviceResult;
                 }
 
-                this.sessionsClient.acquireDone({ path });
+                this.sessionsClient.acquireDone({ path, sessionOwner: this.id });
 
                 return this.success(acquireIntentResponse.payload.session);
             },

--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -158,6 +158,9 @@ export class BridgeTransport extends AbstractTransport {
                 const response = await this.post('/acquire', {
                     params: `${input.path}/${input.previous ?? 'null'}`,
                     signal,
+                    body: {
+                        sessionOwner: this.id,
+                    },
                 });
 
                 return response;

--- a/packages/transport/src/types/index.ts
+++ b/packages/transport/src/types/index.ts
@@ -28,6 +28,8 @@ export type DescriptorApiLevel = {
 export type Descriptor = Omit<DescriptorApiLevel, 'path'> & {
     path: PathPublic;
     session: null | Session;
+    /** extension of 'session'. If session is defined then also sessionOwner must be defined. Describes which other application is using the session. */
+    sessionOwner?: string;
     /** only reported by old bridge */
     debugSession?: null | Session;
     /** only reported by old bridge */

--- a/packages/transport/src/utils/bridgeApiResult.ts
+++ b/packages/transport/src/utils/bridgeApiResult.ts
@@ -58,6 +58,7 @@ export function devices(res: UnknownPayload) {
             (o: any): Descriptor => ({
                 path: o.path,
                 session: o.session,
+                sessionOwner: o.sessionOwner,
                 product: o.product,
                 type: o.type,
                 vendor: o.vendor,

--- a/packages/transport/tests/abstractUsb.test.ts
+++ b/packages/transport/tests/abstractUsb.test.ts
@@ -56,6 +56,7 @@ const initTest = async () => {
     transport = new TestUsbTransport({
         api: testUsbApi,
         messages,
+        id: 'test',
     });
     const initResponse = await transport.init();
     expect(initResponse.success).toEqual(true);
@@ -88,6 +89,7 @@ describe('Usb', () => {
 
             const transport = new TestUsbTransport({
                 api: testUsbApi,
+                id: 'test',
             });
 
             await transport.init();

--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -147,7 +147,6 @@ type StringPath<T extends { path: DeviceUniquePath }> = Omit<T, 'path'> & { path
  */
 const getConnectDevice = (dev?: Partial<StringPath<Device>>, feat?: Partial<Features>): Device => {
     const path = DeviceUniquePath(dev?.path ?? '1');
-
     if (dev && typeof dev.type === 'string' && dev.type === 'unreadable') {
         return {
             type: 'unreadable',
@@ -164,6 +163,7 @@ const getConnectDevice = (dev?: Partial<StringPath<Device>>, feat?: Partial<Feat
             path,
             label: 'Unacquired device',
             name: 'name of unacquired device',
+            transportSessionOwner: 'another app name',
         };
     }
 


### PR DESCRIPTION
main changes:

- replace text "device detected in incorrect state" with "device used elsewhere". There is nothing wrong with the device. it is just used elsewhere.
- make information about what is elsewhere in the UI.

before:

![image](https://github.com/user-attachments/assets/be6d614f-04a1-4021-8812-d8d258d7b529)

afrer: 

![image](https://github.com/user-attachments/assets/136cff78-0a51-4d10-af2c-cc35e53b7f93)

![image](https://github.com/user-attachments/assets/53c1c3e2-337b-4fcf-b51f-476893d2e013)


related:
- #5543
- depend on #14776
- depends on #15080

