### PR TITLE
chore(suite): use receipt icon for gas

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
@@ -293,7 +293,7 @@ export const TransactionReviewSummary = ({
                 {!!tx.feeLimit && network.networkType !== 'solana' && (
                     <LeftDetailsRow>
                         <ReviewLeftDetailsLineLeft>
-                            <Icon size={12} color={theme.iconSubdued} name="gasPump" />
+                            <Icon size={12} color={theme.iconSubdued} name="receipt" />
                             <Translation id="TR_GAS_LIMIT" />
                         </ReviewLeftDetailsLineLeft>
 
@@ -304,7 +304,7 @@ export const TransactionReviewSummary = ({
                 )}
                 <LeftDetailsRow>
                     <ReviewLeftDetailsLineLeft>
-                        <Icon size={12} color={theme.iconSubdued} name="gasPump" />
+                        <Icon size={12} color={theme.iconSubdued} name="receipt" />
                         <Translation
                             id={feeLabelTranslationIdByNetworkTypeMap[network.networkType]}
                         />

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
@@ -267,7 +267,7 @@ export const BasicTxDetails = ({
                         <Title>
                             <Icon
                                 margin={{ right: spacings.xs }}
-                                name="gas"
+                                name="receipt"
                                 size={15}
                                 variant="tertiary"
                             />
@@ -290,7 +290,7 @@ export const BasicTxDetails = ({
                     <>
                         <Title>
                             <Icon
-                                name="gasPump"
+                                name="receipt"
                                 size={15}
                                 margin={{ right: spacings.xs }}
                                 variant="tertiary"
@@ -301,7 +301,7 @@ export const BasicTxDetails = ({
 
                         <Title>
                             <Icon
-                                name="gasPump"
+                                name="receipt"
                                 size={15}
                                 margin={{ right: spacings.xs }}
                                 variant="tertiary"
@@ -318,7 +318,7 @@ export const BasicTxDetails = ({
 
                         <Title>
                             <Icon
-                                name="gasPump"
+                                name="receipt"
                                 size={15}
                                 margin={{ right: spacings.xs }}
                                 variant="tertiary"


### PR DESCRIPTION
Replacing old and deprecated "gas" icon with a new one "receipt" that will be used for TXs for all networks (btc/eth like). 

<img width="773" alt="image" src="https://github.com/user-attachments/assets/2975c8d6-0f8b-46de-9410-03d839a9c72f">
<img width="763" alt="image" src="https://github.com/user-attachments/assets/d2f17fd9-e9a7-4cdf-8405-2e7923c69cd7">
