### PR TITLE
fix(suite-desktop-core): restart app when using autostart

### DIFF
--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -138,7 +138,8 @@ const init = async () => {
     // Daemon mode with no UI
     const { wasOpenedAtLogin } = app.getLoginItemSettings();
     const daemon = app.commandLine.hasSwitch('bridge-daemon') || wasOpenedAtLogin;
-    if (daemon) {
+    const daemonShowUI = app.commandLine.hasSwitch('bridge-daemon-show-ui'); // show UI immediately even in daemon mode
+    if (daemon && !daemonShowUI) {
         logger.info('main', 'App is hidden, starting bridge only');
         app.dock?.hide(); // hide dock icon on macOS
         const waitForFullStart = createDeferred<void>();


### PR DESCRIPTION
## Description

- Actually pass options to `app.relaunch()`, previously this code was there for Linux/Appimage handling, but was not used
- Add an arg `--bridge-daemon-show-ui` for daemon mode to show UI immediately with the process rather than after the user opens the app again. 
- Pass this arg to relaunch and quit the app properly when restarting in daemon mode

## Related Issue

Resolve #5055