### PR TITLE
Send coins - switch amount inputs when the inactive one is tapped

### DIFF
--- a/suite-native/module-send/src/components/AmountInputs.tsx
+++ b/suite-native/module-send/src/components/AmountInputs.tsx
@@ -118,6 +118,7 @@ export const AmountInputs = ({ index, accountKey }: AmountInputProps) => {
                     inputRef={cryptoRef}
                     isDisabled={!isCryptoSelected}
                     networkSymbol={networkSymbol}
+                    onPress={!isCryptoSelected ? handleSwitchInputs : undefined}
                     onFocus={handleInputFocus}
                 />
                 {isFiatDisplayed && (
@@ -130,6 +131,7 @@ export const AmountInputs = ({ index, accountKey }: AmountInputProps) => {
                             inputRef={fiatRef}
                             isDisabled={isCryptoSelected}
                             networkSymbol={networkSymbol}
+                            onPress={isCryptoSelected ? handleSwitchInputs : undefined}
                             onFocus={handleInputFocus}
                         />
                     </>

--- a/suite-native/module-send/src/components/CryptoAmountInput.tsx
+++ b/suite-native/module-send/src/components/CryptoAmountInput.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import { Pressable } from 'react-native';
 import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 
 import { Text, Input } from '@suite-native/atoms';
@@ -41,6 +42,7 @@ export const CryptoAmountInput = ({
     scaleValue,
     translateValue,
     networkSymbol,
+    onPress,
     onFocus,
     isDisabled = false,
 }: SendAmountInputProps) => {
@@ -83,24 +85,27 @@ export const CryptoAmountInput = ({
         <Animated.View
             style={[applyStyle(sendAmountInputWrapperStyle, { isDisabled }), cryptoAnimatedStyle]}
         >
-            <Input
-                ref={inputRef}
-                value={value}
-                placeholder="0"
-                keyboardType="numeric"
-                accessibilityLabel="amount to send input"
-                testID={cryptoFieldName}
-                editable={!isDisabled}
-                onChangeText={handleChangeValue}
-                onBlur={handleBlur}
-                onFocus={onFocus}
-                hasError={!isDisabled && hasError}
-                rightIcon={
-                    <SendAmountCurrencyLabelWrapper isDisabled={isDisabled}>
-                        {formatter.format(networkSymbol)}
-                    </SendAmountCurrencyLabelWrapper>
-                }
-            />
+            <Pressable onPress={onPress} /* onPress doesn't work on Android for disabled Input */>
+                <Input
+                    ref={inputRef}
+                    value={value}
+                    placeholder="0"
+                    keyboardType="numeric"
+                    accessibilityLabel="amount to send input"
+                    testID={cryptoFieldName}
+                    editable={!isDisabled}
+                    onChangeText={handleChangeValue}
+                    onBlur={handleBlur}
+                    onPress={onPress}
+                    onFocus={onFocus}
+                    hasError={!isDisabled && hasError}
+                    rightIcon={
+                        <SendAmountCurrencyLabelWrapper isDisabled={isDisabled}>
+                            {formatter.format(networkSymbol)}
+                        </SendAmountCurrencyLabelWrapper>
+                    }
+                />
+            </Pressable>
         </Animated.View>
     );
 };

--- a/suite-native/module-send/src/components/FiatAmountInput.tsx
+++ b/suite-native/module-send/src/components/FiatAmountInput.tsx
@@ -1,3 +1,4 @@
+import { Pressable } from 'react-native';
 import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
@@ -19,6 +20,7 @@ export const FiatAmountInput = ({
     translateValue,
     inputRef,
     networkSymbol,
+    onPress,
     onFocus,
     isDisabled = false,
 }: SendAmountInputProps) => {
@@ -61,24 +63,27 @@ export const FiatAmountInput = ({
         <Animated.View
             style={[applyStyle(sendAmountInputWrapperStyle, { isDisabled }), fiatAnimatedStyle]}
         >
-            <Input
-                ref={inputRef}
-                value={value}
-                placeholder="0"
-                keyboardType="numeric"
-                accessibilityLabel="amount to send input"
-                testID={fiatFieldName}
-                editable={!isDisabled}
-                onChangeText={handleChangeValue}
-                onBlur={onBlur}
-                onFocus={onFocus}
-                hasError={!isDisabled && hasError}
-                rightIcon={
-                    <SendAmountCurrencyLabelWrapper isDisabled={isDisabled}>
-                        {fiatCurrencyCode.toUpperCase()}
-                    </SendAmountCurrencyLabelWrapper>
-                }
-            />
+            <Pressable onPress={onPress} /* onPress doesn't work on Android for disabled Input */>
+                <Input
+                    ref={inputRef}
+                    value={value}
+                    placeholder="0"
+                    keyboardType="numeric"
+                    accessibilityLabel="amount to send input"
+                    testID={fiatFieldName}
+                    editable={!isDisabled}
+                    onChangeText={handleChangeValue}
+                    onBlur={onBlur}
+                    onPress={onPress}
+                    onFocus={onFocus}
+                    hasError={!isDisabled && hasError}
+                    rightIcon={
+                        <SendAmountCurrencyLabelWrapper isDisabled={isDisabled}>
+                            {fiatCurrencyCode.toUpperCase()}
+                        </SendAmountCurrencyLabelWrapper>
+                    }
+                />
+            </Pressable>
         </Animated.View>
     );
 };

--- a/suite-native/module-send/src/components/SwitchAmountsButton.tsx
+++ b/suite-native/module-send/src/components/SwitchAmountsButton.tsx
@@ -6,14 +6,11 @@ import { Box } from '@suite-native/atoms';
 
 type SwitchAmountsButtonProps = { onPress: () => void };
 
-const BUTTON_TOP_OFFSET = 40;
+const BUTTON_TOP_OFFSET = 42;
 const BUTTON_PADDING = 6;
 
 const buttonWrapperStyle = prepareNativeStyle(() => ({
-    position: 'absolute',
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: '100%',
+    alignSelf: 'center',
     top: BUTTON_TOP_OFFSET,
     zIndex: 3, // To stay above both of the absolute inputs.
 }));

--- a/suite-native/module-send/src/types.ts
+++ b/suite-native/module-send/src/types.ts
@@ -17,5 +17,6 @@ export type SendAmountInputProps = {
     scaleValue: SharedValue<number>;
     translateValue: SharedValue<number>;
     isDisabled?: boolean;
+    onPress?: TextInputProps['onPress'];
     onFocus?: TextInputProps['onFocus'];
 };


### PR DESCRIPTION
Using `onPress` on the `Input` component works fine on iOS but doesn't work on Android for non-editable inputs.
Wrapping the component into `Pressable` and removing ☝️ works on Android but not on iOS. 🤯

👉 I had to combine the two approaches. Please show me that I'm missing something.

## Screenshots:

https://github.com/user-attachments/assets/606b0c89-831d-4bb9-a896-4b8ba09b2306

