### PR TITLE
refactor(suite-native): unify fiat amount skeletons

### DIFF
--- a/suite-native/atoms/src/Skeleton/BoxSkeleton.tsx
+++ b/suite-native/atoms/src/Skeleton/BoxSkeleton.tsx
@@ -18,16 +18,17 @@ import {
 } from '@shopify/react-native-skia';
 
 import { useNativeStyles } from '@trezor/styles';
-import { Color, nativeBorders } from '@trezor/theme';
+import { Color, NativeRadius } from '@trezor/theme';
 
 import { ENDLESS_ANIMATION_VALUE } from '../constants';
 import { SurfaceElevation } from '../types';
+import { nativeRadiusToNumber } from '../utils';
 
 type BoxSkeletonProps = {
     height: number;
     width: number;
     elevation?: SurfaceElevation;
-    borderRadius?: number;
+    borderRadius?: NativeRadius | number;
 };
 
 const ANIMATION_DURATION = 1200;
@@ -49,7 +50,7 @@ export const BoxSkeleton = ({
     height,
     width,
     elevation = '1',
-    borderRadius = nativeBorders.radii.r8,
+    borderRadius = 'r8',
 }: BoxSkeletonProps) => {
     const {
         utils: { colors },
@@ -71,8 +72,9 @@ export const BoxSkeleton = ({
 
     const rct = useMemo(() => {
         const coreRect = rect(0, 0, width, height);
+        const radius = nativeRadiusToNumber(borderRadius);
 
-        return rrect(coreRect, borderRadius, borderRadius);
+        return rrect(coreRect, radius, radius);
     }, [width, height, borderRadius]);
 
     const gradientColors = useMemo(

--- a/suite-native/formatters/src/components/EmptyAmountSkeleton.tsx
+++ b/suite-native/formatters/src/components/EmptyAmountSkeleton.tsx
@@ -1,13 +1,17 @@
+import { Dimensions } from 'react-native';
+
 import { BoxSkeleton, HStack } from '@suite-native/atoms';
 
 import { EmptyAmountText } from './EmptyAmountText';
+
+const SKELETON_WIDTH = 0.2 * Dimensions.get('window').width;
 
 export const EmptyAmountSkeleton = () => {
     // Usage of EmptyAmountText ensures the correct line height.
     return (
         <HStack alignItems="center">
             <EmptyAmountText />
-            <BoxSkeleton width={48} height={20} />
+            <BoxSkeleton width={SKELETON_WIDTH} height={20} borderRadius="r4" />
         </HStack>
     );
 };


### PR DESCRIPTION
The size and shape of fiat amount skeletons used in `DiscoveryAssetsLoader` and `FiatAmountFormatter` was unified.

## Screenshots:

https://github.com/user-attachments/assets/90acc423-a7d2-4e3a-b854-e130e27f296b

