### PR TITLE
feat(mobile-connect-popup): handle all URLs, add feature flag for popup

### DIFF
--- a/suite-native/app/app.config.ts
+++ b/suite-native/app/app.config.ts
@@ -168,14 +168,20 @@ export default ({ config }: ConfigContext): ExpoConfig => {
                 monochromeImage: './assets/appIcon_android.png',
                 ...appIconAndroid,
             },
-            intentFilters:
-                buildType === 'production'
-                    ? []
-                    : [
-                          {
-                              action: 'VIEW',
-                              autoVerify: true,
-                              data: [
+            intentFilters: [
+                {
+                    action: 'VIEW',
+                    autoVerify: true,
+                    data:
+                        buildType === 'production'
+                            ? [
+                                  {
+                                      scheme: 'https',
+                                      host: 'connect.trezor.io',
+                                      pathPattern: '/9/deeplink/.*',
+                                  },
+                              ]
+                            : [
                                   {
                                       scheme: 'https',
                                       host: 'dev.suite.sldev.cz',
@@ -188,9 +194,9 @@ export default ({ config }: ConfigContext): ExpoConfig => {
                                       pathPattern: '/connect/.*/.*/deeplink/.*',
                                   },
                               ],
-                              category: ['BROWSABLE', 'DEFAULT'],
-                          },
-                      ],
+                    category: ['BROWSABLE', 'DEFAULT'],
+                },
+            ],
         },
         ios: {
             bundleIdentifier,
@@ -217,6 +223,10 @@ export default ({ config }: ConfigContext): ExpoConfig => {
                 },
                 UIRequiredDeviceCapabilities: ['armv7'],
             },
+            associatedDomains:
+                buildType === 'production'
+                    ? ['applinks:connect.trezor.io']
+                    : ['applinks:dev.suite.sldev.cz'],
         },
         plugins: getPlugins(),
         extra: {

--- a/suite-native/feature-flags/src/featureFlagsSlice.ts
+++ b/suite-native/feature-flags/src/featureFlagsSlice.ts
@@ -9,6 +9,7 @@ export const FeatureFlag = {
     IsRegtestEnabled: 'isRegtestEnabled',
     IsPolygonEnabled: 'IsPolygonEnabled',
     IsBscEnabled: 'IsBscEnabled',
+    IsConnectPopupEnabled: 'IsConnectPopupEnabled',
 } as const;
 export type FeatureFlag = (typeof FeatureFlag)[keyof typeof FeatureFlag];
 
@@ -24,6 +25,7 @@ export const featureFlagsInitialState: FeatureFlagsState = {
     [FeatureFlag.IsRegtestEnabled]: isDebugEnv() || isDetoxTestBuild(),
     [FeatureFlag.IsPolygonEnabled]: false,
     [FeatureFlag.IsBscEnabled]: false,
+    [FeatureFlag.IsConnectPopupEnabled]: isDevelopOrDebugEnv(),
 };
 
 export const featureFlagsPersistedKeys: Array<keyof FeatureFlagsState> = [
@@ -32,6 +34,7 @@ export const featureFlagsPersistedKeys: Array<keyof FeatureFlagsState> = [
     FeatureFlag.IsRegtestEnabled,
     FeatureFlag.IsPolygonEnabled,
     FeatureFlag.IsBscEnabled,
+    FeatureFlag.IsConnectPopupEnabled,
 ];
 
 export const featureFlagsSlice = createSlice({

--- a/suite-native/module-connect-popup/package.json
+++ b/suite-native/module-connect-popup/package.json
@@ -18,6 +18,7 @@
         "@suite-native/config": "workspace:*",
         "@suite-native/device": "workspace:*",
         "@suite-native/device-manager": "workspace:*",
+        "@suite-native/feature-flags": "workspace:^",
         "@suite-native/intl": "workspace:^",
         "@suite-native/navigation": "workspace:*",
         "@trezor/connect": "workspace:*",

--- a/suite-native/module-connect-popup/src/hooks/useConnectPopupNavigation.ts
+++ b/suite-native/module-connect-popup/src/hooks/useConnectPopupNavigation.ts
@@ -8,6 +8,7 @@ import {
     RootStackParamList,
     RootStackRoutes,
 } from '@suite-native/navigation';
+import { isDevelopOrDebugEnv } from '@suite-native/config';
 
 type NavigationProp = StackToStackCompositeNavigationProps<
     RootStackParamList,
@@ -15,7 +16,16 @@ type NavigationProp = StackToStackCompositeNavigationProps<
     RootStackParamList
 >;
 
-const isConnectPopupUrl = (url: string): boolean => url.startsWith('trezorsuitelite://');
+const isConnectPopupUrl = (url: string): boolean => {
+    if (isDevelopOrDebugEnv()) {
+        if (url.startsWith('trezorsuitelite://connect')) return true;
+        if (/^https:\/\/dev\.suite\.sldev\.cz\/connect\/(.*)\/deeplink(.*)$/g.test(url))
+            return true;
+    }
+    if (/^https:\/\/connect\.trezor\.io\/9\/deeplink(.*)$/g.test(url)) return true;
+
+    return false;
+};
 
 // TODO: will be necessary to handle if device is not connected/unlocked so we probably want to wait until user unlock device
 // we already have some modals like biometrics or coin enabled which are waiting for device to be connected

--- a/suite-native/module-connect-popup/src/hooks/useConnectPopupNavigation.ts
+++ b/suite-native/module-connect-popup/src/hooks/useConnectPopupNavigation.ts
@@ -9,6 +9,7 @@ import {
     RootStackRoutes,
 } from '@suite-native/navigation';
 import { isDevelopOrDebugEnv } from '@suite-native/config';
+import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
 
 type NavigationProp = StackToStackCompositeNavigationProps<
     RootStackParamList,
@@ -30,22 +31,23 @@ const isConnectPopupUrl = (url: string): boolean => {
 // TODO: will be necessary to handle if device is not connected/unlocked so we probably want to wait until user unlock device
 // we already have some modals like biometrics or coin enabled which are waiting for device to be connected
 export const useConnectPopupNavigation = () => {
+    const [featureFlagEnabled] = useFeatureFlag(FeatureFlag.IsConnectPopupEnabled);
     const navigation = useNavigation<NavigationProp>();
 
     const navigateToConnectPopup = useCallback(
         (url: string) => {
+            if (!featureFlagEnabled) return;
+            if (!isConnectPopupUrl(url)) return;
             const parsedUrl = Linking.parse(url);
             navigation.navigate(RootStackRoutes.ConnectPopup, { parsedUrl });
         },
-        [navigation],
+        [navigation, featureFlagEnabled],
     );
 
     useEffect(() => {
         const navigateToInitalUrl = async () => {
             const currentUrl = await Linking.getInitialURL();
-            if (currentUrl && isConnectPopupUrl(currentUrl)) {
-                // eslint-disable-next-line no-console
-                console.log('initial url', currentUrl);
+            if (currentUrl) {
                 navigateToConnectPopup(currentUrl);
             }
         };
@@ -56,8 +58,6 @@ export const useConnectPopupNavigation = () => {
         // there could be when you open same deep link for second time and in that case it will be ignored
         // this could be probably handed by Linking.addEventListener
         const subscription = Linking.addEventListener('url', event => {
-            // eslint-disable-next-line no-console
-            console.log('url event received', event.url);
             navigateToConnectPopup(event.url);
         });
 

--- a/suite-native/module-connect-popup/tsconfig.json
+++ b/suite-native/module-connect-popup/tsconfig.json
@@ -12,6 +12,7 @@
         { "path": "../config" },
         { "path": "../device" },
         { "path": "../device-manager" },
+        { "path": "../feature-flags" },
         { "path": "../intl" },
         { "path": "../navigation" },
         { "path": "../../packages/connect" },

--- a/suite-native/module-dev-utils/src/components/FeatureFlags.tsx
+++ b/suite-native/module-dev-utils/src/components/FeatureFlags.tsx
@@ -7,6 +7,7 @@ const featureFlagsTitleMap = {
     [FeatureFlagEnum.IsRegtestEnabled]: 'Regtest',
     [FeatureFlagEnum.IsPolygonEnabled]: 'Polygon',
     [FeatureFlagEnum.IsBscEnabled]: 'BNB Smart Chain',
+    [FeatureFlagEnum.IsConnectPopupEnabled]: 'Connect Popup',
 } as const satisfies Record<FeatureFlagEnum, string>;
 
 const FeatureFlag = ({ featureFlag }: { featureFlag: FeatureFlagEnum }) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9910,7 +9910,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@suite-native/feature-flags@workspace:*, @suite-native/feature-flags@workspace:suite-native/feature-flags":
+"@suite-native/feature-flags@workspace:*, @suite-native/feature-flags@workspace:^, @suite-native/feature-flags@workspace:suite-native/feature-flags":
   version: 0.0.0-use.local
   resolution: "@suite-native/feature-flags@workspace:suite-native/feature-flags"
   dependencies:
@@ -10216,6 +10216,7 @@ __metadata:
     "@suite-native/config": "workspace:*"
     "@suite-native/device": "workspace:*"
     "@suite-native/device-manager": "workspace:*"
+    "@suite-native/feature-flags": "workspace:^"
     "@suite-native/intl": "workspace:^"
     "@suite-native/navigation": "workspace:*"
     "@trezor/connect": "workspace:*"


### PR DESCRIPTION
## Description

Fix deeplink handling for develop and prod HTTPS URLs, eg.:

- https://connect.trezor.io/9/deeplink/
- https://dev.suite.sldev.cz/connect/develop/deeplink/

Note: Prod URL only opens on prod app, and vice versa for dev URL

Add a feature flag to enable/disable Connect Poup. By default it's enabled on dev builds.