### PR TITLE
fix(protobuf): repo path in build script

### DIFF
--- a/packages/protobuf/scripts/protobuf-build.sh
+++ b/packages/protobuf/scripts/protobuf-build.sh
@@ -11,7 +11,7 @@ get_abs_path() {
 SCRIPTS_PATH=$(get_abs_path "${BASH_SOURCE[0]}")
 
 REPO_BRANCH="main"
-REPO_PATH=$(get_abs_path "../../../trezor-firmware-probuf-update/.")
+REPO_PATH=$(get_abs_path "$SCRIPTS_PATH/../../../../.")/trezor-firmware-probuf-update
 
 if [[ $# -ne 0 && $# -ne 1 ]]
     then


### PR DESCRIPTION
## Description

There is an issue with running `protobuf-build.sh` in CI due to the REPO_PATH not being able set correctly if the directory does not exist yet. 

With this change the REPO_PATH will always be set to `trezor-firmware-probuf-update` within the parent directory which holds the trezor-suite repo. 

Before: https://github.com/trezor/trezor-suite/actions/runs/11265164884/job/31326531995

After: https://github.com/trezor/trezor-suite/actions/runs/11272831120/job/31348572302