### PR TITLE
chore(wallet-core): deduplicate code with getBinFilesBaseUrlThunk

### DIFF
--- a/packages/suite/src/reducers/desktop/index.ts
+++ b/packages/suite/src/reducers/desktop/index.ts
@@ -18,5 +18,3 @@ export const desktopReducer = (
             return state;
     }
 };
-
-export const selectDesktopBinDir = (state: DesktopState) => state?.paths?.binDir;

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -78,6 +78,7 @@ export const extraDependencies: ExtraDependencies = {
         selectLocalCurrency: (state: AppState) => state.wallet.settings.localCurrency,
         selectIsPendingTransportEvent,
         selectDebugSettings: (state: AppState) => state.suite.settings.debug,
+        // FW binaries on desktop are stored in "*/static/connect/data/firmware/*/*.bin" (see "connect-common" package)
         selectDesktopBinDir: (state: AppState) => state.desktop?.paths?.binDir,
         selectDevice: (state: AppState) => state.device.selectedDevice,
         selectLanguage: (state: AppState) => state.suite.settings.language,

--- a/suite-common/wallet-core/src/firmware/getBinFilesBaseUrlThunk.ts
+++ b/suite-common/wallet-core/src/firmware/getBinFilesBaseUrlThunk.ts
@@ -1,0 +1,15 @@
+import { isDesktop } from '@trezor/env-utils';
+import { resolveStaticPath } from '@suite-common/suite-utils';
+import { createThunk } from '@suite-common/redux-utils';
+import { FIRMWARE_MODULE_PREFIX } from './firmwareActions';
+
+/**
+ * Get URL for firmware binaries, which may be local (suite desktop) or remote (suite web)
+ */
+export const getBinFilesBaseUrlThunk = createThunk(
+    `${FIRMWARE_MODULE_PREFIX}/getBinFilesBaseUrlThunk`,
+    (_params, { getState, extra }) =>
+        isDesktop()
+            ? extra.selectors.selectDesktopBinDir(getState())
+            : resolveStaticPath('connect/data'),
+);


### PR DESCRIPTION
## Description

Create one thunk to get path to static bin files, currently you have to do two different approaches for desktop & web. 

## Screenshots

I console logged the `const binFilesBaseUrl` in `checkFirmwareHashThunk.ts ` and `firmwareThunks.ts`:
![Screenshot from 2024-10-10 14-54-58](https://github.com/user-attachments/assets/272ee3c0-c873-4cc4-b68b-34029b88ceaf)
![Screenshot from 2024-10-10 14-58-17](https://github.com/user-attachments/assets/3f544094-f35e-446f-955e-d779bfbdf564)


Firmware update still works:
![Screenshot from 2024-10-10 14-54-43](https://github.com/user-attachments/assets/f332b0ef-4c93-4749-9b64-9604fce1597c)
