### PR TITLE
chore(suite-native): send feature flag used for btc like coins

### DIFF
--- a/suite-native/feature-flags/src/featureFlagsSlice.ts
+++ b/suite-native/feature-flags/src/featureFlagsSlice.ts
@@ -5,7 +5,7 @@ import { isDebugEnv, isDetoxTestBuild, isDevelopOrDebugEnv } from '@suite-native
 
 export const FeatureFlag = {
     IsDeviceConnectEnabled: 'isDeviceConnectEnabled',
-    IsSendEnabled: 'isSendEnabled',
+    IsBitcoinLikeSendEnabled: 'isBitcoinLikeSendEnabled',
     IsRegtestEnabled: 'isRegtestEnabled',
     IsPolygonEnabled: 'IsPolygonEnabled',
     IsBscEnabled: 'IsBscEnabled',
@@ -20,7 +20,7 @@ export type FeatureFlagsRootState = {
 
 export const featureFlagsInitialState: FeatureFlagsState = {
     [FeatureFlag.IsDeviceConnectEnabled]: isAndroid() || isDebugEnv(),
-    [FeatureFlag.IsSendEnabled]: isAndroid() && isDevelopOrDebugEnv(),
+    [FeatureFlag.IsBitcoinLikeSendEnabled]: isAndroid() && isDevelopOrDebugEnv(),
     [FeatureFlag.IsRegtestEnabled]: isDebugEnv() || isDetoxTestBuild(),
     [FeatureFlag.IsPolygonEnabled]: false,
     [FeatureFlag.IsBscEnabled]: false,
@@ -28,7 +28,7 @@ export const featureFlagsInitialState: FeatureFlagsState = {
 
 export const featureFlagsPersistedKeys: Array<keyof FeatureFlagsState> = [
     FeatureFlag.IsDeviceConnectEnabled,
-    FeatureFlag.IsSendEnabled,
+    FeatureFlag.IsBitcoinLikeSendEnabled,
     FeatureFlag.IsRegtestEnabled,
     FeatureFlag.IsPolygonEnabled,
     FeatureFlag.IsBscEnabled,

--- a/suite-native/module-accounts-management/src/components/TransactionListHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/TransactionListHeader.tsx
@@ -20,14 +20,14 @@ import {
     TabToStackCompositeNavigationProp,
 } from '@suite-native/navigation';
 import { Translation } from '@suite-native/intl';
-import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import { FeatureFlag, FeatureFlagsRootState, useFeatureFlag } from '@suite-native/feature-flags';
 import { isCoinWithTokens } from '@suite-native/tokens';
 
 import { AccountDetailGraph } from './AccountDetailGraph';
 import { AccountDetailCryptoValue } from './AccountDetailCryptoValue';
 import { IncludeTokensToggle } from './IncludeTokensToggle';
 import { CoinPriceCard } from './CoinPriceCard';
+import { selectIsNetworkSendFlowEnabled } from '../selectors';
 
 type AccountDetailHeaderProps = {
     accountKey: AccountKey;
@@ -46,8 +46,6 @@ type AccountsNavigationProps = TabToStackCompositeNavigationProp<
     RootStackRoutes.ReceiveModal,
     RootStackParamList
 >;
-
-const SEND_NETWORK_WHITELIST: Readonly<NetworkSymbol[]> = ['btc', 'test', 'regtest'];
 
 const TransactionListHeaderContent = ({
     accountKey,
@@ -99,7 +97,7 @@ export const TransactionListHeader = memo(
         tokenContract,
     }: AccountDetailHeaderProps) => {
         const navigation = useNavigation<AccountsNavigationProps>();
-        const [isSendEnabled] = useFeatureFlag(FeatureFlag.IsSendEnabled);
+        const [isDeviceConnectEnabled] = useFeatureFlag(FeatureFlag.IsDeviceConnectEnabled);
 
         const account = useSelector((state: AccountsRootState) =>
             selectAccountByKey(state, accountKey),
@@ -109,6 +107,9 @@ export const TransactionListHeader = memo(
         );
         const isTestnetAccount = useSelector((state: AccountsRootState) =>
             selectIsTestnetAccount(state, accountKey),
+        );
+        const isNetworkSendFlowEnabled = useSelector((state: FeatureFlagsRootState) =>
+            selectIsNetworkSendFlowEnabled(state, account?.symbol),
         );
         const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
 
@@ -136,9 +137,7 @@ export const TransactionListHeader = memo(
         const isPriceCardDisplayed = !isTestnetAccount && !isTokenDetail;
 
         const isSendButtonDisplayed =
-            isSendEnabled &&
-            SEND_NETWORK_WHITELIST.includes(account.symbol) &&
-            !isPortfolioTrackerDevice;
+            isDeviceConnectEnabled && isNetworkSendFlowEnabled && !isPortfolioTrackerDevice;
 
         return (
             <Box marginBottom="sp8">

--- a/suite-native/module-accounts-management/src/selectors.ts
+++ b/suite-native/module-accounts-management/src/selectors.ts
@@ -1,0 +1,27 @@
+import { NetworkSymbol, getNetworkType } from '@suite-common/wallet-config';
+import {
+    FeatureFlagsRootState,
+    selectIsFeatureFlagEnabled,
+    FeatureFlag,
+} from '@suite-native/feature-flags';
+
+const SEND_COINS_WHITELIST: NetworkSymbol[] = ['btc', 'test', 'regtest'];
+
+export const selectIsNetworkSendFlowEnabled = (
+    state: FeatureFlagsRootState,
+    networkSymbol?: NetworkSymbol,
+) => {
+    if (!networkSymbol) return false;
+
+    if (SEND_COINS_WHITELIST.includes(networkSymbol)) return true;
+
+    const isBitcoinLikeSendEnabled = selectIsFeatureFlagEnabled(
+        state,
+        FeatureFlag.IsBitcoinLikeSendEnabled,
+    );
+
+    const networkType = getNetworkType(networkSymbol);
+    if (isBitcoinLikeSendEnabled && networkType === 'bitcoin') return true;
+
+    return false;
+};

--- a/suite-native/module-dev-utils/src/components/FeatureFlags.tsx
+++ b/suite-native/module-dev-utils/src/components/FeatureFlags.tsx
@@ -3,7 +3,7 @@ import { FeatureFlag as FeatureFlagEnum, useFeatureFlag } from '@suite-native/fe
 
 const featureFlagsTitleMap = {
     [FeatureFlagEnum.IsDeviceConnectEnabled]: 'Connect device',
-    [FeatureFlagEnum.IsSendEnabled]: 'Send',
+    [FeatureFlagEnum.IsBitcoinLikeSendEnabled]: 'Bitcoin-like coins send',
     [FeatureFlagEnum.IsRegtestEnabled]: 'Regtest',
     [FeatureFlagEnum.IsPolygonEnabled]: 'Polygon',
     [FeatureFlagEnum.IsBscEnabled]: 'BNB Smart Chain',


### PR DESCRIPTION

## Description
- BTC (+ TEST and REGTEST) send is available to all users of all builds
- Bitcoin based coins send can be enabled via feature flag
- send of other networks is still always disabled
## Related Issue

Resolve #14759 

## Screenshots:
https://github.com/user-attachments/assets/8f42161e-9386-4d06-8dcf-40cd73737184

