### PR TITLE
feat(suite-native): correct network name for tokens in account detail

### DIFF
--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -720,6 +720,10 @@ export const en = {
                 inputs: 'Inputs & Outputs',
             },
         },
+        tokens: {
+            toggleTokens: 'Include tokens',
+            title: 'Note, your {networkName} balance doesn’t include tokens.',
+        },
     },
     deviceManager: {
         deviceButtons: {

--- a/suite-native/module-accounts-management/src/components/IncludeTokensToggle.tsx
+++ b/suite-native/module-accounts-management/src/components/IncludeTokensToggle.tsx
@@ -1,31 +1,47 @@
 import Animated, { FadeIn } from 'react-native-reanimated';
 
 import { AlertBox, Box, Toggle, VStack } from '@suite-native/atoms';
+import { getNetwork, NetworkSymbol } from '@suite-common/wallet-config';
+import { Translation } from '@suite-native/intl';
 
 type IncludeTokensToggleProps = {
+    networkSymbol: NetworkSymbol;
     isToggled: boolean;
     onToggle: () => void;
 };
 
-export const IncludeTokensToggle = ({ isToggled, onToggle }: IncludeTokensToggleProps) => (
-    <VStack spacing="sp24" marginTop="sp8">
-        <Box marginHorizontal="sp24">
-            <Toggle
-                leftLabel="Ethereum"
-                rightLabel="Include tokens"
-                isToggled={isToggled}
-                onToggle={onToggle}
-            />
-        </Box>
-        {isToggled && (
-            <Animated.View entering={FadeIn}>
-                <Box marginHorizontal="sp8">
-                    <AlertBox
-                        variant="info"
-                        title="Note, your Ethereum balance doesn’t include tokens."
-                    />
-                </Box>
-            </Animated.View>
-        )}
-    </VStack>
-);
+export const IncludeTokensToggle = ({
+    networkSymbol,
+    isToggled,
+    onToggle,
+}: IncludeTokensToggleProps) => {
+    const networkName = getNetwork(networkSymbol).name;
+
+    return (
+        <VStack spacing="sp24" marginTop="sp8">
+            <Box marginHorizontal="sp24">
+                <Toggle
+                    leftLabel={networkName}
+                    rightLabel={<Translation id="transactions.tokens.toggleTokens" />}
+                    isToggled={isToggled}
+                    onToggle={onToggle}
+                />
+            </Box>
+            {isToggled && (
+                <Animated.View entering={FadeIn}>
+                    <Box marginHorizontal="sp8">
+                        <AlertBox
+                            variant="info"
+                            title={
+                                <Translation
+                                    id="transactions.tokens.title"
+                                    values={{ networkName }}
+                                />
+                            }
+                        />
+                    </Box>
+                </Animated.View>
+            )}
+        </VStack>
+    );
+};

--- a/suite-native/module-accounts-management/src/components/TransactionListHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/TransactionListHeader.tsx
@@ -102,6 +102,7 @@ export const TransactionListHeader = memo(
         const account = useSelector((state: AccountsRootState) =>
             selectAccountByKey(state, accountKey),
         );
+
         const accountHasTransactions = useSelector((state: AccountsRootState) =>
             selectHasAccountTransactions(state, accountKey),
         );
@@ -192,6 +193,7 @@ export const TransactionListHeader = memo(
 
                 {canHaveTokens && accountHasTransactions && (
                     <IncludeTokensToggle
+                        networkSymbol={account.symbol}
                         isToggled={areTokensIncluded}
                         onToggle={toggleIncludeTokenTransactions}
                     />


### PR DESCRIPTION
Reflect actual network while showing include token txns in account detail

## Related Issue

Resolve #14191

## Screenshots:
<img width=280 src="https://github.com/user-attachments/assets/dbf51d0a-673e-463e-90f1-e5b56fd12c0a" />
<img width=280 src="https://github.com/user-attachments/assets/77381a12-357e-47c8-93ab-d1c0385efa7a" />