### PR TITLE
fix(connect): make getBinaryOptional async

### DIFF
--- a/packages/connect/src/api/firmware/getBinary.ts
+++ b/packages/connect/src/api/firmware/getBinary.ts
@@ -14,9 +14,9 @@ export const getBinary = ({ baseUrl, btcOnly, release }: GetBinaryProps) => {
     return httpRequest(url, 'binary');
 };
 
-export const getBinaryOptional = (props: GetBinaryProps) => {
+export const getBinaryOptional = async (props: GetBinaryProps) => {
     try {
-        return getBinary(props);
+        return await getBinary(props);
     } catch (error) {
         return null;
     }


### PR DESCRIPTION
Bugfix after after PR #14766

`getBinaryOptional`, which has the sole purpose of handling error, did not handle anything because Promise creation doesn't throw :see_no_evil: 