### PR TITLE
feat(suite): hide fw hash check banner for old versions

### DIFF
--- a/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareRevisionCheckBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareRevisionCheckBanner.tsx
@@ -2,6 +2,7 @@ import { TranslationKey } from '@suite-common/intl-types';
 import { Banner } from '@trezor/components';
 import { FirmwareHashCheckError, FirmwareRevisionCheckError } from '@trezor/connect';
 import { HELP_CENTER_FIRMWARE_REVISION_CHECK } from '@trezor/urls';
+import { isArrayMember } from '@trezor/type-utils';
 
 import { Translation, TrezorLink } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
@@ -17,12 +18,17 @@ const revisionCheckMessages: Record<FirmwareRevisionCheckError, TranslationKey> 
     'firmware-version-unknown': 'TR_FIRMWARE_REVISION_CHECK_FAILED',
 };
 
+export const skippedHashCheckErrors = [
+    'check-skipped',
+    'check-unsupported',
+] satisfies FirmwareHashCheckError[];
+type SkippedHashCheckMessage = (typeof skippedHashCheckErrors)[number];
+
 const hashCheckMessages: Record<
-    Exclude<FirmwareHashCheckError, 'check-skipped'>,
+    Exclude<FirmwareHashCheckError, SkippedHashCheckMessage>,
     TranslationKey
 > = {
     'hash-mismatch': 'TR_DEVICE_FIRMWARE_HASH_CHECK_HASH_MISMATCH',
-    'check-unsupported': 'TR_DEVICE_FIRMWARE_HASH_CHECK_CHECK_UNSUPPORTED',
     'unknown-release': 'TR_DEVICE_FIRMWARE_HASH_CHECK_UNKNOWN_RELEASE',
     'other-error': 'TR_DEVICE_FIRMWARE_HASH_CHECK_OTHER_ERROR',
 };
@@ -34,7 +40,7 @@ const useAuthenticityCheckMessage = (): TranslationKey | null => {
     if (firmwareRevisionError) {
         return revisionCheckMessages[firmwareRevisionError];
     }
-    if (firmwareHashError && firmwareHashError !== 'check-skipped') {
+    if (firmwareHashError && !isArrayMember(firmwareHashError, skippedHashCheckErrors)) {
         return hashCheckMessages[firmwareHashError];
     }
 

--- a/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { selectBannerMessage } from '@suite-common/message-system';
 import { isDeviceAcquired } from '@suite-common/suite-utils';
 import { selectDevice } from '@suite-common/wallet-core';
+import { isArrayMember } from '@trezor/type-utils';
 import { isDesktop } from '@trezor/env-utils';
 import { spacingsPx } from '@trezor/theme';
 
@@ -23,7 +24,7 @@ import { FailedBackup } from './FailedBackupBanner';
 import { SafetyChecksBanner } from './SafetyChecksBanner';
 import { TranslationMode } from './TranslationModeBanner';
 import { FirmwareHashMismatch } from './FirmwareHashMismatchBanner';
-import { FirmwareRevisionCheckBanner } from './FirmwareRevisionCheckBanner';
+import { FirmwareRevisionCheckBanner, skippedHashCheckErrors } from './FirmwareRevisionCheckBanner';
 
 const Container = styled.div<{ $isVisible?: boolean }>`
     width: 100%;
@@ -71,7 +72,7 @@ export const SuiteBanners = () => {
     // the regular firmware hash check, and revision id check, either of them may fail
     else if (
         firmwareRevisionError ||
-        (firmwareHashError && firmwareHashError !== 'check-skipped')
+        (firmwareHashError && !isArrayMember(firmwareHashError, skippedHashCheckErrors))
     ) {
         banner = <FirmwareRevisionCheckBanner />;
         priority = 91;

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7025,11 +7025,6 @@ export default defineMessages({
         id: 'TR_DEVICE_FIRMWARE_HASH_CHECK_HASH_MISMATCH',
         defaultMessage: 'Firmware hash check failed. Your Trezor may be counterfeit.',
     },
-    TR_DEVICE_FIRMWARE_HASH_CHECK_CHECK_UNSUPPORTED: {
-        id: 'TR_DEVICE_FIRMWARE_HASH_CHECK_CHECK_UNSUPPORTED',
-        defaultMessage:
-            'New Trezor firmware is available! Update your device now to get latest security features.',
-    },
     TR_DEVICE_FIRMWARE_HASH_CHECK_UNKNOWN_RELEASE: {
         id: 'TR_DEVICE_FIRMWARE_HASH_CHECK_UNKNOWN_RELEASE',
         defaultMessage: 'Firmware unrecognized. Your Trezor may be counterfeit.',

--- a/packages/type-utils/src/utils.ts
+++ b/packages/type-utils/src/utils.ts
@@ -58,3 +58,17 @@ export type PartialRecord<K extends keyof any, T> = {
 
 // distributive conditional types to the rescue! This way we can infer union literal type from ReturnType but exclude undefined
 export type DefinedUnionMember<T> = T extends string ? T : never;
+
+/**
+ * Type-guard if a value is a subset of an array.
+ * Useful to narrow down a union type `value` to a subset of the union (typeof `arr`).
+ *
+ * Example:
+ * type Variant = 'a' | 'b' | 'c' | 'd';
+ * const skippedVariants = ['a', 'b'] satisfies Variant[];
+ * if(isArrayMember(variant, skippedVariants)) // variant is 'a' | 'b', else 'c' | 'd'
+ */
+export const isArrayMember = <Value extends string, Subset extends Value>(
+    value: Value,
+    arr: Subset[],
+): value is Subset => arr.some(v => v === value);


### PR DESCRIPTION
## Description

- Remove the SuiteBanner for FW hash case `check-unsupported` (old firmware)
- new TS util

## Related Issue

Followup to https://github.com/trezor/trezor-suite-private/issues/100

## Screenshots

if
![if](https://github.com/user-attachments/assets/c07b212c-11dc-4fb0-8eaf-9bacfbd0a542)

else
![else](https://github.com/user-attachments/assets/863f3d28-0763-4b01-9b3e-a131b705d78f)
