### PR TITLE
fix(wallet-utils): don't export from fixtures

### DIFF
--- a/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
@@ -1,4 +1,4 @@
-import { analyzeTransactionsFixtures as analyzeTransactions } from '@suite-common/wallet-utils';
+import { analyzeTransactions } from '@suite-common/wallet-utils/src/__fixtures__/transactionUtils';
 import { blockchainActions, transactionsActions, accountsActions } from '@suite-common/wallet-core';
 import { notificationsActions } from '@suite-common/toast-notifications';
 

--- a/packages/suite/src/storage/__tests__/storage.test.ts
+++ b/packages/suite/src/storage/__tests__/storage.test.ts
@@ -1,3 +1,5 @@
+import '@suite-common/test-utils/src/mocks';
+
 import { db } from '..';
 
 describe('storage', () => {

--- a/suite-common/wallet-utils/src/index.ts
+++ b/suite-common/wallet-utils/src/index.ts
@@ -20,5 +20,3 @@ export * from './stakingUtils';
 export * from './reviewTransactionUtils';
 export * from './filterReceiveAccounts';
 export * from './tokenUtils';
-
-export { analyzeTransactions as analyzeTransactionsFixtures } from './__fixtures__/transactionUtils';


### PR DESCRIPTION
## Description

Remove export from fixtures in `@suite-common/wallet-utils`. 
This leads to leaking mocks and test code into exported packages. 
In our case `fake-indexeddb` got into Connect Explorer.