### PR TITLE
Show confirmation pill for PIN input during FW update

### DIFF
--- a/packages/suite/src/components/firmware/CheckSeedStep.tsx
+++ b/packages/suite/src/components/firmware/CheckSeedStep.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { Button, Checkbox, variables } from '@trezor/components';
 import { spacingsPx } from '@trezor/theme';
 import { selectDeviceLabelOrName } from '@suite-common/wallet-core';
-import { useDevice, useDispatch, useFirmware, useSelector } from 'src/hooks/suite';
+import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 import { Translation } from 'src/components/suite';
 import { OnboardingStepBox } from 'src/components/onboarding';
 import { FirmwareButtonsRow } from './Buttons/FirmwareButtonsRow';
@@ -39,15 +39,15 @@ const StyledSwitchWarning = styled(FirmwareSwitchWarning)`
 `;
 
 type CheckSeedStepProps = {
+    deviceWillBeWiped: boolean;
     onClose?: () => void;
     onSuccess: () => void;
 };
 
-export const CheckSeedStep = ({ onClose, onSuccess }: CheckSeedStepProps) => {
+export const CheckSeedStep = ({ deviceWillBeWiped, onClose, onSuccess }: CheckSeedStepProps) => {
     const deviceLabel = useSelector(selectDeviceLabelOrName);
     const dispatch = useDispatch();
     const { device } = useDevice();
-    const { deviceWillBeWiped } = useFirmware();
     const [isChecked, setIsChecked] = useState(false);
 
     const handleCheckboxClick = () => setIsChecked(prev => !prev);

--- a/packages/suite/src/components/firmware/CheckSeedStep.tsx
+++ b/packages/suite/src/components/firmware/CheckSeedStep.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { Button, Checkbox, variables } from '@trezor/components';
 import { spacingsPx } from '@trezor/theme';
 import { selectDeviceLabelOrName } from '@suite-common/wallet-core';
-import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
+import { useDevice, useDispatch, useFirmware, useSelector } from 'src/hooks/suite';
 import { Translation } from 'src/components/suite';
 import { OnboardingStepBox } from 'src/components/onboarding';
 import { FirmwareButtonsRow } from './Buttons/FirmwareButtonsRow';
@@ -41,13 +41,13 @@ const StyledSwitchWarning = styled(FirmwareSwitchWarning)`
 type CheckSeedStepProps = {
     onClose?: () => void;
     onSuccess: () => void;
-    willBeWiped?: boolean;
 };
 
-export const CheckSeedStep = ({ onClose, onSuccess, willBeWiped }: CheckSeedStepProps) => {
+export const CheckSeedStep = ({ onClose, onSuccess }: CheckSeedStepProps) => {
     const deviceLabel = useSelector(selectDeviceLabelOrName);
     const dispatch = useDispatch();
     const { device } = useDevice();
+    const { deviceWillBeWiped } = useFirmware();
     const [isChecked, setIsChecked] = useState(false);
 
     const handleCheckboxClick = () => setIsChecked(prev => !prev);
@@ -60,7 +60,7 @@ export const CheckSeedStep = ({ onClose, onSuccess, willBeWiped }: CheckSeedStep
             <Translation id="TR_DEVICE_LABEL_IS_NOT_BACKED_UP" values={{ deviceLabel }} />
         );
 
-        if (willBeWiped) {
+        if (deviceWillBeWiped) {
             const goToDeviceSettingsAnchor = (anchor: SettingsAnchor) =>
                 dispatch(goto('settings-device', { anchor }));
             const goToCreateBackup = () =>
@@ -126,20 +126,22 @@ export const CheckSeedStep = ({ onClose, onSuccess, willBeWiped }: CheckSeedStep
             heading={heading}
             description={description}
             innerActions={
-                <FirmwareButtonsRow withCancelButton={willBeWiped} onClose={onClose}>
+                <FirmwareButtonsRow withCancelButton={deviceWillBeWiped} onClose={onClose}>
                     <Button
                         onClick={onSuccess}
                         data-testid="@firmware/confirm-seed-button"
                         isDisabled={!device?.connected || !isChecked}
                     >
-                        <Translation id={willBeWiped ? 'TR_WIPE_AND_REINSTALL' : 'TR_CONTINUE'} />
+                        <Translation
+                            id={deviceWillBeWiped ? 'TR_WIPE_AND_REINSTALL' : 'TR_CONTINUE'}
+                        />
                     </Button>
                 </FirmwareButtonsRow>
             }
             disableConfirmWrapper
             nested
         >
-            {willBeWiped && (
+            {deviceWillBeWiped && (
                 <StyledSwitchWarning>
                     <Translation id="TR_FIRMWARE_SWITCH_WARNING_3" />
                 </StyledSwitchWarning>

--- a/packages/suite/src/components/firmware/FirmwareInitial.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInitial.tsx
@@ -113,20 +113,19 @@ interface FirmwareInitialProps {
     // This component is shared between Onboarding flow and standalone fw update modal with few minor UI changes
     // If it is set to true, then you know it is being rendered in standalone fw update modal
     standaloneFwUpdate?: boolean;
-    shouldSwitchFirmwareType?: boolean;
     onClose?: () => void;
-    willBeWiped?: boolean;
 }
 
-export const FirmwareInitial = ({
-    standaloneFwUpdate = false,
-    shouldSwitchFirmwareType,
-    onClose,
-    willBeWiped,
-}: FirmwareInitialProps) => {
+export const FirmwareInitial = ({ standaloneFwUpdate = false, onClose }: FirmwareInitialProps) => {
     const [bitcoinOnlyOffer, setBitcoinOnlyOffer] = useState(false);
     const { device } = useDevice();
-    const { firmwareUpdate, getTargetFirmwareType, setStatus } = useFirmware();
+    const {
+        deviceWillBeWiped,
+        firmwareUpdate,
+        setStatus,
+        shouldSwitchFirmwareType,
+        targetFirmwareType,
+    } = useFirmware();
     const { goToNextStep, updateAnalytics } = useOnboarding();
     const devices = useSelector(selectDevices);
 
@@ -142,9 +141,7 @@ export const FirmwareInitial = ({
 
     let content;
 
-    const targetType = bitcoinOnlyOffer
-        ? FirmwareType.BitcoinOnly
-        : getTargetFirmwareType(!!shouldSwitchFirmwareType);
+    const targetType = bitcoinOnlyOffer ? FirmwareType.BitcoinOnly : targetFirmwareType;
     // Bitcoin-only firmware is only available on T2T1 from v2.0.8 - older devices must first upgrade to 2.1.1 which does not have a Bitcoin-only variant
     const isBitcoinOnlyAvailable = !!device.firmwareRelease?.release.url_bitcoinonly;
     const currentFwVersion = getFirmwareVersion(device);
@@ -301,7 +298,7 @@ export const FirmwareInitial = ({
             ),
             body: (
                 <>
-                    {willBeWiped && (
+                    {deviceWillBeWiped && (
                         <WarningListWrapper>
                             <Important>
                                 <Translation id="TR_IMPORTANT" />
@@ -324,14 +321,14 @@ export const FirmwareInitial = ({
                 </>
             ),
             innerActions: (
-                <FirmwareButtonsRow withCancelButton={willBeWiped} onClose={onClose}>
+                <FirmwareButtonsRow withCancelButton={deviceWillBeWiped} onClose={onClose}>
                     <FirmwareInstallButton
                         onClick={() =>
                             shouldCheckSeed ? setStatus('check-seed') : installFirmware(targetType)
                         }
                         multipleDevicesConnected={multipleDevicesConnected}
                     >
-                        <Translation id={willBeWiped ? 'TR_CONTINUE' : 'TR_INSTALL'} />
+                        <Translation id={deviceWillBeWiped ? 'TR_CONTINUE' : 'TR_INSTALL'} />
                     </FirmwareInstallButton>
                 </FirmwareButtonsRow>
             ),

--- a/packages/suite/src/components/firmware/FirmwareInitial.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInitial.tsx
@@ -110,22 +110,23 @@ const getNoFirmwareInstalledSubheading = (device: AcquiredDevice) => {
 };
 
 interface FirmwareInitialProps {
+    shouldSwitchFirmwareType?: boolean;
     // This component is shared between Onboarding flow and standalone fw update modal with few minor UI changes
     // If it is set to true, then you know it is being rendered in standalone fw update modal
     standaloneFwUpdate?: boolean;
     onClose?: () => void;
 }
 
-export const FirmwareInitial = ({ standaloneFwUpdate = false, onClose }: FirmwareInitialProps) => {
+export const FirmwareInitial = ({
+    shouldSwitchFirmwareType = false,
+    standaloneFwUpdate = false,
+    onClose,
+}: FirmwareInitialProps) => {
     const [bitcoinOnlyOffer, setBitcoinOnlyOffer] = useState(false);
     const { device } = useDevice();
-    const {
-        deviceWillBeWiped,
-        firmwareUpdate,
-        setStatus,
+    const { deviceWillBeWiped, firmwareUpdate, setStatus, targetFirmwareType } = useFirmware({
         shouldSwitchFirmwareType,
-        targetFirmwareType,
-    } = useFirmware();
+    });
     const { goToNextStep, updateAnalytics } = useOnboarding();
     const devices = useSelector(selectDevices);
 

--- a/packages/suite/src/components/suite/modals/ModalSwitcher/ForegroundAppModal.tsx
+++ b/packages/suite/src/components/suite/modals/ModalSwitcher/ForegroundAppModal.tsx
@@ -13,13 +13,10 @@ import { FunctionComponent } from 'react';
 import { MultiShareBackupModal } from '../ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupModal';
 import { BridgeRequested } from 'src/views/suite/bridge-requested';
 
-// would not work if defined directly in the switch
-const FirmwareType = () => <FirmwareUpdate shouldSwitchFirmwareType />;
-
 const getForegroundApp = (app: ForegroundAppRoute['app']) => {
     const map: Record<ForegroundAppRoute['app'], FunctionComponent<any>> = {
         firmware: FirmwareUpdate,
-        'firmware-type': FirmwareType,
+        'firmware-type': FirmwareUpdate,
         'firmware-custom': FirmwareCustom,
         version: Version,
         bridge: BridgeUnavailable,

--- a/packages/suite/src/components/suite/modals/ModalSwitcher/ForegroundAppModal.tsx
+++ b/packages/suite/src/components/suite/modals/ModalSwitcher/ForegroundAppModal.tsx
@@ -13,10 +13,13 @@ import { FunctionComponent } from 'react';
 import { MultiShareBackupModal } from '../ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupModal';
 import { BridgeRequested } from 'src/views/suite/bridge-requested';
 
+// would not work if defined directly in the switch
+const FirmwareType = () => <FirmwareUpdate shouldSwitchFirmwareType />;
+
 const getForegroundApp = (app: ForegroundAppRoute['app']) => {
     const map: Record<ForegroundAppRoute['app'], FunctionComponent<any>> = {
         firmware: FirmwareUpdate,
-        'firmware-type': FirmwareUpdate,
+        'firmware-type': FirmwareType,
         'firmware-custom': FirmwareCustom,
         version: Version,
         bridge: BridgeUnavailable,

--- a/packages/suite/src/hooks/suite/useFirmware.ts
+++ b/packages/suite/src/hooks/suite/useFirmware.ts
@@ -77,10 +77,10 @@ export const useFirmware = () => {
                 firmware.uiEvent.payload.code,
             )) ||
         // When a PIN-protected device reconnects to normal mode after installation, PIN is requested.
-        // There is a false positive in case such device is wiped (including PIN) during installation,
-        // but there is no straightforward way of detecting that. Some logic could be added to Connect, though.
+        // There is a false positive in case such device is wiped (including PIN) during custom installation.s
         (firmware.uiEvent?.type === UI.FIRMWARE_RECONNECT &&
-            originalDevice?.features?.pin_protection);
+            originalDevice?.features?.pin_protection &&
+            !deviceWillBeWiped);
 
     const showConfirmationPill =
         !showReconnectPrompt &&

--- a/packages/suite/src/hooks/suite/useFirmware.ts
+++ b/packages/suite/src/hooks/suite/useFirmware.ts
@@ -68,19 +68,23 @@ export const useFirmware = () => {
     const deviceWillBeWiped = willDeviceBeWiped();
 
     const confirmOnDevice =
-        // Show the confirmation pill at the start of installation using the "wait" or "manual" method,
-        // after ReconnectDevicePrompt is closed.
+        // Show the confirmation pill before starting the installation using the "wait" or "manual" method,
+        // after ReconnectDevicePrompt is closed and user selects the option to install firmware while in bootloader.
         // Also in case the device is PIN-locked at the start of the process.
         (firmware.uiEvent?.type === DEVICE.BUTTON &&
             firmware.uiEvent.payload.code !== undefined &&
             ['ButtonRequest_FirmwareUpdate', 'ButtonRequest_PinEntry'].includes(
                 firmware.uiEvent.payload.code,
             )) ||
-        // When a PIN-protected device reconnects to normal mode after installation, PIN is requested.
-        // There is a false positive in case such device is wiped (including PIN) during custom installation.s
+        // Show the confirmation pill right after ReconnectDevicePrompt is closed while using the "wait" or "manual" method,
+        // before user selects the option to install firmware while in bootloader
+        // When a PIN-protected device reconnects to normal mode after installation, PIN is requested and the pill is shown.
+        // There is a false positive in case such device is wiped (including PIN) during custom installation.
         (firmware.uiEvent?.type === UI.FIRMWARE_RECONNECT &&
-            originalDevice?.features?.pin_protection &&
-            !deviceWillBeWiped);
+            (firmware.uiEvent.payload.target === 'bootloader' ||
+                (firmware.uiEvent.payload.target === 'normal' &&
+                    originalDevice?.features?.pin_protection &&
+                    !deviceWillBeWiped)));
 
     const showConfirmationPill =
         !showReconnectPrompt &&

--- a/packages/suite/src/views/firmware/FirmwareModal.tsx
+++ b/packages/suite/src/views/firmware/FirmwareModal.tsx
@@ -41,18 +41,26 @@ type FirmwareModalProps = {
     heading: TranslationKey;
     install: () => void;
     isCustom?: boolean;
+    shouldSwitchFirmwareType?: boolean;
 };
 
-export const FirmwareModal = ({ children, heading, install, isCustom }: FirmwareModalProps) => {
+export const FirmwareModal = ({
+    children,
+    heading,
+    install,
+    isCustom,
+    shouldSwitchFirmwareType,
+}: FirmwareModalProps) => {
     const {
         resetReducer,
         status,
+        deviceWillBeWiped,
         error,
         firmwareHashInvalid,
         uiEvent,
         confirmOnDevice,
         showConfirmationPill,
-    } = useFirmware();
+    } = useFirmware({ shouldSwitchFirmwareType });
     const device = useSelector(selectDevice);
     const dispatch = useDispatch();
 
@@ -96,7 +104,13 @@ export const FirmwareModal = ({ children, heading, install, isCustom }: Firmware
             case 'initial':
                 return children;
             case 'check-seed':
-                return <CheckSeedStep onSuccess={install} onClose={onClose} />;
+                return (
+                    <CheckSeedStep
+                        deviceWillBeWiped={deviceWillBeWiped}
+                        onSuccess={install}
+                        onClose={onClose}
+                    />
+                );
             case 'started':
             case 'done':
                 return (

--- a/packages/suite/src/views/firmware/FirmwareModal.tsx
+++ b/packages/suite/src/views/firmware/FirmwareModal.tsx
@@ -38,19 +38,12 @@ const StyledModal = styled(Modal)`
 
 type FirmwareModalProps = {
     children: ReactElement;
-    deviceWillBeWiped?: boolean;
     heading: TranslationKey;
     install: () => void;
     isCustom?: boolean;
 };
 
-export const FirmwareModal = ({
-    children,
-    deviceWillBeWiped,
-    heading,
-    install,
-    isCustom,
-}: FirmwareModalProps) => {
+export const FirmwareModal = ({ children, heading, install, isCustom }: FirmwareModalProps) => {
     const {
         resetReducer,
         status,
@@ -103,13 +96,7 @@ export const FirmwareModal = ({
             case 'initial':
                 return children;
             case 'check-seed':
-                return (
-                    <CheckSeedStep
-                        onSuccess={install}
-                        onClose={onClose}
-                        willBeWiped={deviceWillBeWiped}
-                    />
-                );
+                return <CheckSeedStep onSuccess={install} onClose={onClose} />;
             case 'started':
             case 'done':
                 return (

--- a/packages/suite/src/views/firmware/FirmwareUpdate.tsx
+++ b/packages/suite/src/views/firmware/FirmwareUpdate.tsx
@@ -3,8 +3,12 @@ import { closeModalApp } from 'src/actions/suite/routerActions';
 import { useDispatch, useFirmware } from 'src/hooks/suite';
 import { FirmwareModal } from './FirmwareModal';
 
-export const FirmwareUpdate = () => {
-    const { firmwareUpdate, shouldSwitchFirmwareType, targetFirmwareType } = useFirmware();
+type FirmwareUpdateProps = {
+    shouldSwitchFirmwareType?: boolean;
+};
+
+export const FirmwareUpdate = ({ shouldSwitchFirmwareType }: FirmwareUpdateProps) => {
+    const { firmwareUpdate, targetFirmwareType } = useFirmware({ shouldSwitchFirmwareType });
     const dispatch = useDispatch();
 
     const close = () => dispatch(closeModalApp());
@@ -16,8 +20,16 @@ export const FirmwareUpdate = () => {
     const heading = shouldSwitchFirmwareType ? 'TR_SWITCH_FIRMWARE' : 'TR_INSTALL_FIRMWARE';
 
     return (
-        <FirmwareModal heading={heading} install={installTargetFirmware}>
-            <FirmwareInitial standaloneFwUpdate onClose={close} />
+        <FirmwareModal
+            shouldSwitchFirmwareType={shouldSwitchFirmwareType}
+            heading={heading}
+            install={installTargetFirmware}
+        >
+            <FirmwareInitial
+                shouldSwitchFirmwareType={shouldSwitchFirmwareType}
+                standaloneFwUpdate
+                onClose={close}
+            />
         </FirmwareModal>
     );
 };

--- a/packages/suite/src/views/firmware/FirmwareUpdate.tsx
+++ b/packages/suite/src/views/firmware/FirmwareUpdate.tsx
@@ -1,46 +1,23 @@
-import { DeviceModelInternal } from '@trezor/connect';
-
 import { FirmwareInitial } from 'src/components/firmware';
 import { closeModalApp } from 'src/actions/suite/routerActions';
-import { useDevice, useDispatch, useFirmware } from 'src/hooks/suite';
+import { useDispatch, useFirmware } from 'src/hooks/suite';
 import { FirmwareModal } from './FirmwareModal';
 
-type FirmwareUpdateProps = {
-    shouldSwitchFirmwareType?: boolean;
-};
-
-export const FirmwareUpdate = ({ shouldSwitchFirmwareType = false }: FirmwareUpdateProps) => {
-    const { device } = useDevice();
-    const { firmwareUpdate, getTargetFirmwareType } = useFirmware();
+export const FirmwareUpdate = () => {
+    const { firmwareUpdate, shouldSwitchFirmwareType, targetFirmwareType } = useFirmware();
     const dispatch = useDispatch();
-
-    const deviceModelInternal = device?.features?.internal_model;
-    // Device will be wiped because Universal and Bitcoin-only firmware have different vendor headers, except T1B1 and T2T1.
-    const deviceWillBeWiped =
-        shouldSwitchFirmwareType &&
-        deviceModelInternal &&
-        ![DeviceModelInternal.T1B1, DeviceModelInternal.T2T1].includes(deviceModelInternal);
 
     const close = () => dispatch(closeModalApp());
     const installTargetFirmware = () =>
         firmwareUpdate({
-            firmwareType: getTargetFirmwareType(!!shouldSwitchFirmwareType),
+            firmwareType: targetFirmwareType,
         });
 
     const heading = shouldSwitchFirmwareType ? 'TR_SWITCH_FIRMWARE' : 'TR_INSTALL_FIRMWARE';
 
     return (
-        <FirmwareModal
-            deviceWillBeWiped={deviceWillBeWiped}
-            heading={heading}
-            install={installTargetFirmware}
-        >
-            <FirmwareInitial
-                standaloneFwUpdate
-                shouldSwitchFirmwareType={shouldSwitchFirmwareType}
-                willBeWiped={deviceWillBeWiped}
-                onClose={close}
-            />
+        <FirmwareModal heading={heading} install={installTargetFirmware}>
+            <FirmwareInitial standaloneFwUpdate onClose={close} />
         </FirmwareModal>
     );
 };


### PR DESCRIPTION
When user is prompted to enter PIN during FW update, Suite did not direct them towards the device.

To test this, lock your Trezor by holding a button/screen and then start FW update. You will be prompted  to enter your PIN twice, Suite should tell you to "Confirm on Trezor" both times.

Video showing the bug:

https://github.com/user-attachments/assets/848ae136-5362-428b-97cb-eff7720b2f1d

#### Fixed:

Before installation, PIN entry on Trezor screen:
![Screenshot 2024-10-14 at 13 57 08](https://github.com/user-attachments/assets/98921cd4-d765-42d5-ad09-5c27c4f34a9a)

After installation, PIN entry on Trezor screen. The "Select Trezor" button does not do anything in this case, but there seems to be no way to differentiate this from another situation when the button is necessary :/ The button only appears on web.
![Screenshot 2024-10-14 at 13 59 21](https://github.com/user-attachments/assets/e825a8a8-0041-410e-a174-c2ed659c1b31)
