### PR TITLE
feat(mobile): migrate BottomSheetFlashList to new lib

### DIFF
--- a/scripts/list-outdated-dependencies/mobile-dependencies.txt
+++ b/scripts/list-outdated-dependencies/mobile-dependencies.txt
@@ -68,3 +68,4 @@ metro
 metro-react-native-babel-preset
 jest-expo
 intl-pluralrules
+@gorhom/bottom-sheet

--- a/suite-native/accounts/src/components/AccountSelectBottomSheet.tsx
+++ b/suite-native/accounts/src/components/AccountSelectBottomSheet.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 
 import { BottomSheetFlashList } from '@suite-native/atoms';
-import { ToastRenderer, useToast } from '@suite-native/toasts';
+import { useToast } from '@suite-native/toasts';
 import { Translation } from '@suite-native/intl';
 
 import { AccountSelectBottomSheetSection, OnSelectAccount } from '../types';
@@ -97,8 +97,7 @@ export const AccountSelectBottomSheet = React.memo(
                 data={data}
                 renderItem={renderItem}
                 estimatedItemSize={ESTIMATED_ITEM_SIZE}
-                estimatedListHeight={ESTIMATED_ITEM_SIZE * data.length}
-                ExtraProvider={ToastRenderer}
+                estimatedListHeight={ESTIMATED_ITEM_SIZE * data.length * 1.5}
             />
         );
     },

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -22,6 +22,7 @@
         "reverse-ports": "adb reverse tcp:8081 tcp:8081 && adb reverse tcp:21325 tcp:21325 && adb reverse tcp:19121 tcp:19121"
     },
     "dependencies": {
+        "@gorhom/bottom-sheet": "5.0.1",
         "@mobily/ts-belt": "^3.13.1",
         "@react-native-community/netinfo": "11.3.2",
         "@react-native/metro-config": "0.75.2",

--- a/suite-native/app/src/App.tsx
+++ b/suite-native/app/src/App.tsx
@@ -5,6 +5,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import * as SplashScreen from 'expo-splash-screen';
 import * as Sentry from '@sentry/react-native';
+import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 
 import { selectIsAppReady, selectIsConnectInitialized, StoreProvider } from '@suite-native/state';
 import { FormatterProvider } from '@suite-common/formatters';
@@ -65,7 +66,9 @@ const AppComponent = () => {
         <FormatterProvider config={formattersConfig}>
             <OfflineBanner />
             <MessageSystemBannerRenderer />
-            <RootStackNavigator />
+            <BottomSheetModalProvider>
+                <RootStackNavigator />
+            </BottomSheetModalProvider>
             <ModalsRenderer />
             {/* NOTE: Rendered as last item so that it covers the whole app screen */}
             <FeatureMessageScreen />

--- a/suite-native/atoms/package.json
+++ b/suite-native/atoms/package.json
@@ -11,6 +11,7 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
+        "@gorhom/bottom-sheet": "5.0.1",
         "@mobily/ts-belt": "^3.13.1",
         "@shopify/flash-list": "1.7.1",
         "@shopify/react-native-skia": "1.3.11",

--- a/suite-native/atoms/src/Sheet/BottomSheetFlashList.tsx
+++ b/suite-native/atoms/src/Sheet/BottomSheetFlashList.tsx
@@ -1,17 +1,15 @@
-import { useEffect, useRef, ReactNode } from 'react';
+import { ReactNode, useCallback, useEffect, useMemo, useRef } from 'react';
+import { Dimensions, StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import Animated from 'react-native-reanimated';
-import { PanGestureHandler } from 'react-native-gesture-handler';
-import { GestureResponderEvent, Pressable, Dimensions } from 'react-native';
 
-import { FlashList, FlashListProps } from '@shopify/flash-list';
+import {
+    BottomSheetBackdrop,
+    BottomSheetModal,
+    BottomSheetFlashList as FlashList,
+} from '@gorhom/bottom-sheet';
+import { FlashListProps } from '@shopify/flash-list';
 
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
-
-import { Box } from '../Box';
-import { BottomSheetContainer } from './BottomSheetContainer';
-import { useBottomSheetAnimation } from './useBottomSheetAnimation';
-import { BottomSheetHeader } from './BottomSheetHeader';
 
 export type BottomSheetFlashListProps<TItem> = {
     isVisible: boolean;
@@ -19,17 +17,16 @@ export type BottomSheetFlashListProps<TItem> = {
     onClose: (isVisible: boolean) => void;
     title?: ReactNode;
     subtitle?: ReactNode;
-    ExtraProvider?: React.ComponentType;
     estimatedListHeight?: number;
 } & FlashListProps<TItem>;
 
-const DEFAULT_INSET_BOTTOM = 50;
+const DEFAULT_INSET_BOTTOM = 25;
 
-const sheetWrapperStyle = prepareNativeStyle(utils => ({
+const bottomSheetStyle = prepareNativeStyle(utils => ({
     backgroundColor: utils.colors.backgroundSurfaceElevation0,
+
     borderTopLeftRadius: utils.borders.radii.r20,
     borderTopRightRadius: utils.borders.radii.r20,
-    maxHeight: '80%',
 }));
 
 const sheetContentContainerStyle = prepareNativeStyle<{
@@ -39,10 +36,13 @@ const sheetContentContainerStyle = prepareNativeStyle<{
     paddingHorizontal: utils.spacings.sp16,
 }));
 
-const sheetWithOverlayStyle = prepareNativeStyle(_ => ({
-    flex: 1,
-    justifyContent: 'flex-end',
+const handleStyle = prepareNativeStyle(utils => ({
+    backgroundColor: utils.colors.borderDashed,
 }));
+
+const WindowOverlay = ({ children }: { children: ReactNode }) => {
+    return <View style={StyleSheet.absoluteFill}>{children}</View>;
+};
 
 export const BottomSheetFlashList = <TItem,>({
     isVisible,
@@ -50,96 +50,69 @@ export const BottomSheetFlashList = <TItem,>({
     onClose,
     title,
     subtitle,
-    ExtraProvider,
     estimatedListHeight = 0,
     ...flashListProps
 }: BottomSheetFlashListProps<TItem>) => {
     const { applyStyle } = useNativeStyles();
     const insets = useSafeAreaInsets();
-    const {
-        animatedSheetWithOverlayStyle,
-        animatedSheetWrapperStyle,
-        closeSheetAnimated,
-        openSheetAnimated,
-        panGestureEvent,
-        scrollEvent,
-    } = useBottomSheetAnimation({
-        onClose,
-        isVisible,
-    });
-    const panGestureRef = useRef(null);
-    const scrollViewRef = useRef(null);
 
-    useEffect(() => {
-        if (isVisible) {
-            openSheetAnimated();
-        }
-    }, [isVisible, openSheetAnimated]);
+    const bottomSheetModalRef = useRef<BottomSheetModal>(null);
 
-    const handlePressOutside = (event: GestureResponderEvent) => {
-        if (event.target === event.currentTarget) closeSheetAnimated();
-    };
+    const handleClose = useCallback(() => {
+        bottomSheetModalRef.current?.dismiss();
+        onClose(false);
+    }, [onClose]);
 
     const insetBottom = Math.max(insets.bottom, DEFAULT_INSET_BOTTOM);
 
-    return (
-        <BottomSheetContainer
-            isVisible={isVisible}
-            onClose={closeSheetAnimated}
-            ExtraProvider={ExtraProvider}
-        >
-            <Animated.View
-                style={[animatedSheetWithOverlayStyle, applyStyle(sheetWithOverlayStyle)]}
-            >
-                <Pressable style={applyStyle(sheetWithOverlayStyle)} onPress={handlePressOutside}>
-                    <PanGestureHandler
-                        ref={panGestureRef}
-                        activeOffsetY={5}
-                        failOffsetY={-5}
-                        onGestureEvent={panGestureEvent}
-                    >
-                        <Animated.View
-                            style={[
-                                animatedSheetWrapperStyle,
-                                applyStyle(sheetWrapperStyle, {
-                                    insetBottom,
-                                }),
-                            ]}
-                        >
-                            <BottomSheetHeader
-                                title={title}
-                                subtitle={subtitle}
-                                isCloseDisplayed={isCloseDisplayed}
-                                onCloseSheet={closeSheetAnimated}
-                            />
+    const maxHeight = Dimensions.get('window').height * 0.9;
+    const minHeight = Math.max(Dimensions.get('window').height * 0.4, estimatedListHeight);
+    // minHeight can be higher than maxHeight because of estimatedListHeight, but it must be capped by maxHeight
+    const snapPoints = useMemo(() => [Math.min(minHeight, maxHeight)], [minHeight, maxHeight]);
 
-                            <Box
-                                style={{
-                                    // only estimated height is used, so we need to add some buffer to prevent unnecessary scrolling, when list is shorter than estimated
-                                    height: Math.max(
-                                        estimatedListHeight * 1.1,
-                                        // We use this because minHeight doesn't work with `height set
-                                        Dimensions.get('window').height * 0.35,
-                                    ),
-                                    maxHeight: '100%',
-                                }}
-                            >
-                                <FlashList
-                                    {...flashListProps}
-                                    overrideProps={{
-                                        simultaneousHandlers: panGestureRef,
-                                    }}
-                                    contentContainerStyle={applyStyle(sheetContentContainerStyle, {
-                                        insetBottom,
-                                    })}
-                                    ref={scrollViewRef}
-                                    onScroll={scrollEvent}
-                                />
-                            </Box>
-                        </Animated.View>
-                    </PanGestureHandler>
-                </Pressable>
-            </Animated.View>
-        </BottomSheetContainer>
+    const handleSheetChanges = useCallback(
+        (index: number) => {
+            if (index === -1) {
+                handleClose();
+            }
+        },
+        [handleClose],
+    );
+
+    useEffect(() => {
+        if (isVisible) {
+            bottomSheetModalRef.current?.present();
+        } else {
+            bottomSheetModalRef.current?.dismiss();
+        }
+    }, [isVisible]);
+
+    return (
+        <BottomSheetModal
+            ref={bottomSheetModalRef}
+            snapPoints={snapPoints}
+            maxDynamicContentSize={maxHeight}
+            enableDynamicSizing={false}
+            onChange={handleSheetChanges}
+            backdropComponent={props => (
+                <BottomSheetBackdrop
+                    {...props}
+                    onPress={handleClose}
+                    appearsOnIndex={0}
+                    disappearsOnIndex={-1}
+                />
+            )}
+            backgroundStyle={applyStyle(bottomSheetStyle)}
+            handleIndicatorStyle={applyStyle(handleStyle)}
+            // @ts-expect-error wrong type, doesn't expect children
+            containerComponent={WindowOverlay}
+        >
+            <FlashList
+                {...flashListProps}
+                contentContainerStyle={applyStyle(sheetContentContainerStyle, {
+                    insetBottom,
+                })}
+            />
+        </BottomSheetModal>
     );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4475,6 +4475,40 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@gorhom/bottom-sheet@npm:5.0.1":
+  version: 5.0.1
+  resolution: "@gorhom/bottom-sheet@npm:5.0.1"
+  dependencies:
+    "@gorhom/portal": "npm:1.0.14"
+    invariant: "npm:^2.2.4"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-native": "*"
+    react: "*"
+    react-native: "*"
+    react-native-gesture-handler: ">=2.16.1"
+    react-native-reanimated: ">=3.10.1"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-native":
+      optional: true
+  checksum: 10/61134493ac61f96a5bc7aae20f4a6465f19138d7d2d36129d2285022ee52fe02648d7706212b17d5e1c6acdf0d0a5ee0124884b44a34eb468406e89a86c6102c
+  languageName: node
+  linkType: hard
+
+"@gorhom/portal@npm:1.0.14":
+  version: 1.0.14
+  resolution: "@gorhom/portal@npm:1.0.14"
+  dependencies:
+    nanoid: "npm:^3.3.1"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10/e0fa06be88b850cccdc6a1417a86e5ac21d82e3bfd1cec7eb05eccf7f3b595babe305541f278fdcbde34f3a9db465097dca2c785445c28bafb83b744e235da0c
+  languageName: node
+  linkType: hard
+
 "@graphql-typed-document-node/core@npm:^3.1.0, @graphql-typed-document-node/core@npm:^3.1.1":
   version: 3.1.1
   resolution: "@graphql-typed-document-node/core@npm:3.1.1"
@@ -9542,6 +9576,7 @@ __metadata:
     "@babel/core": "npm:^7.20.0"
     "@babel/plugin-transform-export-namespace-from": "npm:^7.23.4"
     "@config-plugins/detox": "npm:^8.0.0"
+    "@gorhom/bottom-sheet": "npm:5.0.1"
     "@mobily/ts-belt": "npm:^3.13.1"
     "@react-native-community/netinfo": "npm:11.3.2"
     "@react-native/babel-preset": "npm:^0.75.2"
@@ -9684,6 +9719,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/atoms@workspace:suite-native/atoms"
   dependencies:
+    "@gorhom/bottom-sheet": "npm:5.0.1"
     "@mobily/ts-belt": "npm:^3.13.1"
     "@shopify/flash-list": "npm:1.7.1"
     "@shopify/react-native-skia": "npm:1.3.11"
@@ -32069,7 +32105,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.1.23, nanoid@npm:^3.1.3, nanoid@npm:^3.3.4, nanoid@npm:^3.3.6, nanoid@npm:^3.3.7":
+"nanoid@npm:^3.1.23, nanoid@npm:^3.1.3, nanoid@npm:^3.3.1, nanoid@npm:^3.3.4, nanoid@npm:^3.3.6, nanoid@npm:^3.3.7":
   version: 3.3.7
   resolution: "nanoid@npm:3.3.7"
   bin:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use external lib which provides much more "native" experience. In future we should migrate also normal BottomSheet, should be pretty easy.

It also solved bug on Android where scrolling down in BottomSheet closes BottomSheet.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

https://github.com/user-attachments/assets/e043a2f1-fa65-45cb-bbbb-c8f5ae245274

