### PR TITLE
feat(suite): add buy/sell and swap buttons to dashboard header

### DIFF
--- a/packages/suite-analytics/src/constants.ts
+++ b/packages/suite-analytics/src/constants.ts
@@ -17,6 +17,8 @@ export enum EventType {
 
     AppUriHandler = 'app/uri-handler',
 
+    DashboardActions = 'dashboard/actions',
+
     DeviceConnect = 'device-connect',
     DeviceDisconnect = 'device-disconnect',
     DeviceUpdateFirmware = 'device-update-firmware',

--- a/packages/suite-analytics/src/constants.ts
+++ b/packages/suite-analytics/src/constants.ts
@@ -17,8 +17,6 @@ export enum EventType {
 
     AppUriHandler = 'app/uri-handler',
 
-    DashboardActions = 'dashboard/actions',
-
     DeviceConnect = 'device-connect',
     DeviceDisconnect = 'device-disconnect',
     DeviceUpdateFirmware = 'device-update-firmware',
@@ -47,10 +45,11 @@ export enum EventType {
 
     CoinmarketConfirmTrade = 'trade/confirm-trade',
 
+    MenuGuide = 'menu/guide',
     MenuNotificationsToggle = 'menu/notifications/toggle',
     MenuToggleDiscreet = 'menu/toggle-discreet',
+    MenuActions = 'menu/actions',
 
-    MenuGuide = 'menu/guide',
     GuideHeaderNavigation = 'guide/header/navigation',
     GuideNodeNavigation = 'guide/node/navigation',
     GuideFeedbackNavigation = 'guide/feedback/navigation',

--- a/packages/suite-analytics/src/types/events.ts
+++ b/packages/suite-analytics/src/types/events.ts
@@ -53,6 +53,12 @@ export type SuiteAnalyticsEvent =
           };
       }
     | {
+          type: EventType.DashboardActions;
+          payload: {
+              type: string;
+          };
+      }
+    | {
           type: EventType.DeviceConnect;
           payload: {
               mode: 'normal' | 'bootloader' | 'initialize' | 'seedless';

--- a/packages/suite-analytics/src/types/events.ts
+++ b/packages/suite-analytics/src/types/events.ts
@@ -53,12 +53,6 @@ export type SuiteAnalyticsEvent =
           };
       }
     | {
-          type: EventType.DashboardActions;
-          payload: {
-              type: string;
-          };
-      }
-    | {
           type: EventType.DeviceConnect;
           payload: {
               mode: 'normal' | 'bootloader' | 'initialize' | 'seedless';
@@ -229,6 +223,12 @@ export type SuiteAnalyticsEvent =
       }
     | {
           type: EventType.MenuGuide;
+      }
+    | {
+          type: EventType.MenuActions;
+          payload: {
+              type: string;
+          };
       }
     | {
           type: EventType.GuideHeaderNavigation;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActionButton.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActionButton.tsx
@@ -1,0 +1,24 @@
+import { Button, ButtonProps, IconButton, IconButtonProps } from '@trezor/components';
+import { useSelector } from 'src/hooks/suite';
+
+export const HeaderActionButton = ({
+    icon,
+    onClick,
+    'data-testid': dataTestId,
+    variant,
+    size,
+    isDisabled,
+    children,
+}: Pick<ButtonProps, 'onClick' | 'data-testid' | 'variant' | 'size' | 'isDisabled' | 'children'> &
+    Pick<IconButtonProps, 'icon'>) => {
+    const layoutSize = useSelector(state => state.resize.size);
+
+    const isMobileLayout = layoutSize === 'TINY';
+    const commonProps = { icon, onClick, 'data-testid': dataTestId, variant, size, isDisabled };
+
+    return isMobileLayout ? (
+        <IconButton {...commonProps} />
+    ) : (
+        <Button {...commonProps}>{children}</Button>
+    );
+};

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActions.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActions.tsx
@@ -1,16 +1,6 @@
 import styled from 'styled-components';
 import { EventType, analytics } from '@trezor/suite-analytics';
-import {
-    Button,
-    ButtonGroup,
-    ButtonProps,
-    Dropdown,
-    DropdownMenuItemProps,
-    IconButton,
-    IconButtonProps,
-    IconName,
-    variables,
-} from '@trezor/components';
+import { ButtonGroup, Dropdown, DropdownMenuItemProps, IconName } from '@trezor/components';
 import { spacingsPx } from '@trezor/theme';
 import { hasNetworkFeatures } from '@suite-common/wallet-utils';
 import { WalletParams } from 'src/types/wallet';
@@ -19,19 +9,13 @@ import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 import { goto } from 'src/actions/suite/routerActions';
 import { AppNavigationTooltip } from 'src/components/suite/AppNavigation/AppNavigationTooltip';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
-import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
+import { TradeActions } from 'src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions';
+import { HeaderActionButton } from 'src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActionButton';
 
 const Container = styled.div`
     display: flex;
     align-items: center;
     gap: ${spacingsPx.xxs};
-`;
-
-// instant without computing the layout
-const ShowOnLargeDesktopWrapper = styled.div`
-    ${variables.SCREEN_QUERY.BELOW_DESKTOP} {
-        display: none;
-    }
 `;
 
 type ActionItem = {
@@ -41,28 +25,6 @@ type ActionItem = {
     title: JSX.Element;
     'data-testid'?: string;
     isHidden?: boolean;
-};
-
-const ButtonComponent = ({
-    icon,
-    onClick,
-    'data-testid': dataTestId,
-    variant,
-    size,
-    isDisabled,
-    children,
-}: Pick<ButtonProps, 'onClick' | 'data-testid' | 'variant' | 'size' | 'isDisabled' | 'children'> &
-    Pick<IconButtonProps, 'icon'>) => {
-    const layoutSize = useSelector(state => state.resize.size);
-
-    const isMobileLayout = layoutSize === 'TINY';
-    const commonProps = { icon, onClick, 'data-testid': dataTestId, variant, size, isDisabled };
-
-    return isMobileLayout ? (
-        <IconButton {...commonProps} />
-    ) : (
-        <Button {...commonProps}>{children}</Button>
-    );
 };
 
 export const HeaderActions = () => {
@@ -142,45 +104,15 @@ export const HeaderActions = () => {
             )}
 
             {isCoinmarketAvailable && (
-                <AppNavigationTooltip>
-                    <ShowOnLargeDesktopWrapper>
-                        <ButtonComponent
-                            icon="currencyCircleDollar"
-                            onClick={() => {
-                                goToWithAnalytics('wallet-coinmarket-buy', {
-                                    preserveParams: true,
-                                });
-                            }}
-                            data-testid="@wallet/menu/wallet-coinmarket-buy"
-                            variant="tertiary"
-                            size="small"
-                            isDisabled={isAccountLoading}
-                        >
-                            <Translation id="TR_COINMARKET_BUY_AND_SELL" />
-                        </ButtonComponent>
-                    </ShowOnLargeDesktopWrapper>
-                    {!hasBitcoinOnlyFirmware(device) && (
-                        <ButtonComponent
-                            icon="arrowsLeftRight"
-                            onClick={() => {
-                                goToWithAnalytics('wallet-coinmarket-exchange', {
-                                    preserveParams: true,
-                                });
-                            }}
-                            data-testid="@wallet/menu/wallet-coinmarket-exchange"
-                            variant="tertiary"
-                            size="small"
-                            isDisabled={isAccountLoading}
-                        >
-                            <Translation id="TR_COINMARKET_SWAP" />
-                        </ButtonComponent>
-                    )}
-                </AppNavigationTooltip>
+                <TradeActions
+                    analyticsEventType={EventType.AccountsActions}
+                    selectedAccount={selectedAccount}
+                />
             )}
 
             <AppNavigationTooltip>
                 <ButtonGroup size="small" isDisabled={isAccountLoading}>
-                    <ButtonComponent
+                    <HeaderActionButton
                         key="wallet-send"
                         icon="send"
                         onClick={() => {
@@ -190,9 +122,9 @@ export const HeaderActions = () => {
                         variant={isDeviceConnected ? 'primary' : 'tertiary'}
                     >
                         <Translation id="TR_NAV_SEND" />
-                    </ButtonComponent>
+                    </HeaderActionButton>
 
-                    <ButtonComponent
+                    <HeaderActionButton
                         key="wallet-receive"
                         icon="receive"
                         onClick={() => {
@@ -202,7 +134,7 @@ export const HeaderActions = () => {
                         variant={isDeviceConnected ? 'primary' : 'tertiary'}
                     >
                         <Translation id="TR_NAV_RECEIVE" />
-                    </ButtonComponent>
+                    </HeaderActionButton>
                 </ButtonGroup>
             </AppNavigationTooltip>
         </Container>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActions.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActions.tsx
@@ -107,6 +107,7 @@ export const HeaderActions = () => {
                 <TradeActions
                     analyticsEventType={EventType.AccountsActions}
                     selectedAccount={selectedAccount}
+                    hideBuyAndSellBelowDesktop
                 />
             )}
 

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageHeader.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageHeader.tsx
@@ -8,6 +8,8 @@ import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReduce
 import { selectIsAccountTabPage, selectRouteName } from 'src/reducers/suite/routerReducer';
 import { HeaderActions } from './HeaderActions';
 import { PageName } from './PageNames/PageName';
+import { TradeActions } from 'src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions';
+import { EventType } from '@trezor/suite-analytics';
 
 const HEADER_HEIGHT = 64;
 
@@ -41,6 +43,15 @@ export const PageHeader = ({ backRoute, children }: PageHeaderProps) => {
     // handle moment when children are not rendered yet in the Trade section
     if (routeName?.includes('wallet-coinmarket')) {
         return <Container>{children ?? null}</Container>;
+    }
+
+    if (routeName === 'suite-index') {
+        return (
+            <Container>
+                <PageName backRoute={backRoute} />
+                <TradeActions analyticsEventType={EventType.DashboardActions} />
+            </Container>
+        );
     }
 
     return children ? (

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageHeader.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageHeader.tsx
@@ -49,7 +49,7 @@ export const PageHeader = ({ backRoute, children }: PageHeaderProps) => {
         return (
             <Container>
                 <PageName backRoute={backRoute} />
-                <TradeActions analyticsEventType={EventType.DashboardActions} />
+                <TradeActions analyticsEventType={EventType.MenuActions} />
             </Container>
         );
     }

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageHeader.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageHeader.tsx
@@ -45,21 +45,14 @@ export const PageHeader = ({ backRoute, children }: PageHeaderProps) => {
         return <Container>{children ?? null}</Container>;
     }
 
-    if (routeName === 'suite-index') {
-        return (
-            <Container>
-                <PageName backRoute={backRoute} />
-                <TradeActions analyticsEventType={EventType.MenuActions} />
-            </Container>
-        );
-    }
-
     return children ? (
         <Container>{children}</Container>
     ) : (
         <Container>
             <PageName backRoute={backRoute} />
-
+            {routeName === 'suite-index' && (
+                <TradeActions analyticsEventType={EventType.MenuActions} />
+            )}
             {!!selectedAccount && isAccountTabPage && <HeaderActions />}
         </Container>
     );

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions.tsx
@@ -12,18 +12,27 @@ import { spacings } from '@trezor/theme';
 import { SelectedAccountStatus } from '@suite-common/wallet-types';
 
 // instant without computing the layout
-const ShowOnLargeDesktopWrapper = styled.div`
-    ${variables.SCREEN_QUERY.BELOW_DESKTOP} {
-        display: none;
-    }
+const ShowOnLargeDesktopWrapper = styled.div<{ $isActive?: boolean }>`
+    ${({ $isActive }) =>
+        $isActive
+            ? `
+        ${variables.SCREEN_QUERY.BELOW_DESKTOP} {
+            display: none;
+        }`
+            : ''}
 `;
 
 interface TradeActionsProps {
     analyticsEventType: EventType.AccountsActions | EventType.MenuActions;
     selectedAccount?: SelectedAccountStatus;
+    hideBuyAndSellBelowDesktop?: boolean;
 }
 
-export const TradeActions = ({ analyticsEventType, selectedAccount }: TradeActionsProps) => {
+export const TradeActions = ({
+    analyticsEventType,
+    selectedAccount,
+    hideBuyAndSellBelowDesktop,
+}: TradeActionsProps) => {
     const dispatch = useDispatch();
     const account = selectedAccount?.account;
     const device = useSelector(selectDevice);
@@ -51,7 +60,7 @@ export const TradeActions = ({ analyticsEventType, selectedAccount }: TradeActio
     return (
         <Row gap={spacings.xxs}>
             <AppNavigationTooltip>
-                <ShowOnLargeDesktopWrapper>
+                <ShowOnLargeDesktopWrapper $isActive={hideBuyAndSellBelowDesktop}>
                     <HeaderActionButton
                         icon="currencyCircleDollar"
                         onClick={() => {

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions.tsx
@@ -1,0 +1,89 @@
+import { Row, variables } from '@trezor/components';
+import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
+import { analytics, EventType } from '@trezor/suite-analytics';
+import { goto } from 'src/actions/suite/routerActions';
+import { AppNavigationTooltip } from 'src/components/suite/AppNavigation/AppNavigationTooltip';
+import { Translation } from 'src/components/suite/Translation';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import styled from 'styled-components';
+import { HeaderActionButton } from 'src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActionButton';
+import { selectDevice } from '@suite-common/wallet-core';
+import { spacings } from '@trezor/theme';
+import { SelectedAccountStatus } from '@suite-common/wallet-types';
+
+// instant without computing the layout
+const ShowOnLargeDesktopWrapper = styled.div`
+    ${variables.SCREEN_QUERY.BELOW_DESKTOP} {
+        display: none;
+    }
+`;
+
+interface TradeActionsProps {
+    analyticsEventType: EventType.AccountsActions | EventType.DashboardActions;
+    selectedAccount?: SelectedAccountStatus;
+}
+
+export const TradeActions = ({ analyticsEventType, selectedAccount }: TradeActionsProps) => {
+    const dispatch = useDispatch();
+    const account = selectedAccount?.account;
+    const device = useSelector(selectDevice);
+
+    const goToWithAnalytics = (...[routeName, options]: Parameters<typeof goto>) => {
+        if (analyticsEventType === EventType.DashboardActions) {
+            analytics.report({
+                type: analyticsEventType,
+                payload: { type: routeName },
+            });
+        }
+
+        if (analyticsEventType === EventType.AccountsActions && account?.symbol) {
+            analytics.report({
+                type: analyticsEventType,
+                payload: { symbol: account?.symbol, action: routeName },
+            });
+        }
+
+        dispatch(goto(routeName, options));
+    };
+
+    const isAccountLoading = selectedAccount ? selectedAccount.status === 'loading' : false;
+
+    return (
+        <Row gap={spacings.xxs}>
+            <AppNavigationTooltip>
+                <ShowOnLargeDesktopWrapper>
+                    <HeaderActionButton
+                        icon="currencyCircleDollar"
+                        onClick={() => {
+                            goToWithAnalytics('wallet-coinmarket-buy', {
+                                preserveParams: true,
+                            });
+                        }}
+                        data-testid="@wallet/menu/wallet-coinmarket-buy"
+                        variant="tertiary"
+                        size="small"
+                        isDisabled={isAccountLoading}
+                    >
+                        <Translation id="TR_COINMARKET_BUY_AND_SELL" />
+                    </HeaderActionButton>
+                </ShowOnLargeDesktopWrapper>
+                {!hasBitcoinOnlyFirmware(device) && (
+                    <HeaderActionButton
+                        icon="arrowsLeftRight"
+                        onClick={() => {
+                            goToWithAnalytics('wallet-coinmarket-exchange', {
+                                preserveParams: true,
+                            });
+                        }}
+                        data-testid="@wallet/menu/wallet-coinmarket-exchange"
+                        variant="tertiary"
+                        size="small"
+                        isDisabled={isAccountLoading}
+                    >
+                        <Translation id="TR_COINMARKET_SWAP" />
+                    </HeaderActionButton>
+                )}
+            </AppNavigationTooltip>
+        </Row>
+    );
+};

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions.tsx
@@ -19,7 +19,7 @@ const ShowOnLargeDesktopWrapper = styled.div`
 `;
 
 interface TradeActionsProps {
-    analyticsEventType: EventType.AccountsActions | EventType.DashboardActions;
+    analyticsEventType: EventType.AccountsActions | EventType.MenuActions;
     selectedAccount?: SelectedAccountStatus;
 }
 
@@ -29,7 +29,7 @@ export const TradeActions = ({ analyticsEventType, selectedAccount }: TradeActio
     const device = useSelector(selectDevice);
 
     const goToWithAnalytics = (...[routeName, options]: Parameters<typeof goto>) => {
-        if (analyticsEventType === EventType.DashboardActions) {
+        if (analyticsEventType === EventType.MenuActions) {
             analytics.report({
                 type: analyticsEventType,
                 payload: { type: routeName },

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions.tsx
@@ -5,7 +5,7 @@ import { goto } from 'src/actions/suite/routerActions';
 import { AppNavigationTooltip } from 'src/components/suite/AppNavigation/AppNavigationTooltip';
 import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { HeaderActionButton } from 'src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActionButton';
 import { selectDevice } from '@suite-common/wallet-core';
 import { spacings } from '@trezor/theme';
@@ -14,14 +14,13 @@ import { SelectedAccountStatus } from '@suite-common/wallet-types';
 // instant without computing the layout
 const ShowOnLargeDesktopWrapper = styled.div<{ $isActive?: boolean }>`
     ${({ $isActive }) =>
-        $isActive
-            ? `
-        ${variables.SCREEN_QUERY.BELOW_DESKTOP} {
-            display: none;
-        }`
-            : ''}
+        $isActive &&
+        css`
+            ${variables.SCREEN_QUERY.BELOW_DESKTOP} {
+                display: none;
+            }
+        `}
 `;
-
 interface TradeActionsProps {
     analyticsEventType: EventType.AccountsActions | EventType.MenuActions;
     selectedAccount?: SelectedAccountStatus;


### PR DESCRIPTION
## Description 
- Add **Buy&Sell** button and **Swap** button to Dashboard header + add click event.
  - Analytics event c_type=dashboard/actions after Buy&Sell or Swap button is clicked ([mandatory attributes doc](https://www.notion.so/satoshilabs/c63bdab01b704b099cab3bbb3227e1b1?v=406d107d6d584577a47d7580e8b2df89)).
  - Type attribute 
     - Buy&sell: `type=wallet-coinmarket-buy`
     - Swap: `type=wallet-coinmarket-exchange`
- Both sections will not require account context

## Screenshots
![image](https://github.com/user-attachments/assets/0aee7738-8d1c-49f4-b286-11126aceaadc)

## Related
Resolve https://github.com/trezor/trezor-suite/issues/14863