### PR TITLE
feat(suite-native): show correct network data for receive on POL and BNB

### DIFF
--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -359,12 +359,16 @@ export const en = {
         screenTitle: '{coinSymbol} Receive address',
         accountNotFound: 'Account {accountKey} not found.',
         deviceCancelError: 'Address confirmation canceled.',
+        tokens: {
+            runOn: 'Run on {accountLabel}',
+            errorMessage: 'Token not found.',
+        },
         receiveAddressCard: {
             alert: {
                 success: 'Receive address has been confirmed on your Trezor.',
                 longCardanoAddress:
                     'Cardano (ADA) address exceeds Trezor device’s screen. Scroll here and on the device to view it and confirm.',
-                ethereumToken: 'Your receive address is your Ethereum address',
+                token: 'Your receive address is your {networkName} address',
             },
             unverifiedWarning: {
                 portfolioTracker: {

--- a/suite-native/module-accounts-management/src/components/TokenAccountDetailScreenSubHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/TokenAccountDetailScreenSubHeader.tsx
@@ -9,7 +9,11 @@ import {
     ScreenSubHeader,
     GoBackIcon,
 } from '@suite-native/navigation';
-import { AccountsRootState, selectAccountLabel } from '@suite-common/wallet-core';
+import {
+    AccountsRootState,
+    selectAccountLabel,
+    selectAccountNetworkSymbol,
+} from '@suite-common/wallet-core';
 import { CryptoIcon } from '@suite-common/icons-deprecated';
 import { useTranslate } from '@suite-native/intl';
 
@@ -26,6 +30,9 @@ export const TokenAccountDetailScreenSubHeader = ({
     const accountLabel = useSelector((state: AccountsRootState) =>
         selectAccountLabel(state, accountKey),
     );
+    const networkSymbol = useSelector((state: AccountsRootState) =>
+        selectAccountNetworkSymbol(state, accountKey),
+    )!;
     const route = useRoute<RouteProp<RootStackParamList, RootStackRoutes.AccountDetail>>();
     const { closeActionType } = route.params;
 
@@ -37,7 +44,7 @@ export const TokenAccountDetailScreenSubHeader = ({
                         {tokenName}
                     </Text>
                     <HStack spacing="sp4" alignItems="center">
-                        <CryptoIcon symbol="eth" size="extraSmall" />
+                        <CryptoIcon symbol={networkSymbol} size="extraSmall" />
                         <Text
                             variant="label"
                             color="textSubdued"

--- a/suite-native/receive/src/components/ReceiveAccount.tsx
+++ b/suite-native/receive/src/components/ReceiveAccount.tsx
@@ -61,7 +61,7 @@ export const ReceiveAccount = ({ accountKey, tokenContract }: AccountReceiveProp
                 <ReceiveAddressCard
                     networkSymbol={account.symbol}
                     address={address}
-                    isEthereumTokenAddress={!!tokenContract}
+                    isTokenAddress={!!tokenContract}
                     isReceiveApproved={isReceiveApproved}
                     isUnverifiedAddressRevealed={isUnverifiedAddressRevealed}
                     onShowAddress={handleShowAddressAndRemoveButtonRequests}

--- a/suite-native/receive/src/components/ReceiveAddressCard.tsx
+++ b/suite-native/receive/src/components/ReceiveAddressCard.tsx
@@ -18,7 +18,7 @@ type ReceiveAddressCardProps = {
     isUnverifiedAddressRevealed: boolean;
     networkSymbol: NetworkSymbol;
     onShowAddress: () => void;
-    isEthereumTokenAddress?: boolean;
+    isTokenAddress?: boolean;
 };
 
 export const ReceiveAddressCard = ({
@@ -27,12 +27,12 @@ export const ReceiveAddressCard = ({
     isReceiveApproved,
     onShowAddress,
     networkSymbol,
-    isEthereumTokenAddress = false,
+    isTokenAddress = false,
 }: ReceiveAddressCardProps) => {
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const isDeviceInViewOnlyMode = useSelector(selectIsDeviceInViewOnlyMode);
 
-    const { networkType } = networks[networkSymbol];
+    const { networkType, name: networkName } = networks[networkSymbol];
 
     const getCardAlertProps = () => {
         if (isReceiveApproved && !isPortfolioTrackerDevice && !isDeviceInViewOnlyMode) {
@@ -49,10 +49,13 @@ export const ReceiveAddressCard = ({
                 alertVariant: 'info',
             } as const;
         }
-        if (isEthereumTokenAddress) {
+        if (isTokenAddress) {
             return {
                 alertTitle: (
-                    <Translation id="moduleReceive.receiveAddressCard.alert.ethereumToken" />
+                    <Translation
+                        id="moduleReceive.receiveAddressCard.alert.token"
+                        values={{ networkName }}
+                    />
                 ),
                 alertVariant: 'info',
             } as const;

--- a/suite-native/receive/src/components/TokenReceiveCard.tsx
+++ b/suite-native/receive/src/components/TokenReceiveCard.tsx
@@ -7,12 +7,17 @@ import {
 } from '@suite-native/formatters';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
-import { AccountsRootState, selectAccountLabel } from '@suite-common/wallet-core';
+import {
+    AccountsRootState,
+    selectAccountLabel,
+    selectAccountNetworkSymbol,
+} from '@suite-common/wallet-core';
 import {
     getTokenName,
     selectAccountTokenInfo,
     selectAccountTokenSymbol,
 } from '@suite-native/tokens';
+import { Translation } from '@suite-native/intl';
 
 type TokenReceiveCardProps = {
     accountKey: AccountKey;
@@ -36,7 +41,9 @@ export const TokenReceiveCard = ({ contract, accountKey }: TokenReceiveCardProps
     const accountLabel = useSelector((state: AccountsRootState) =>
         selectAccountLabel(state, accountKey),
     );
-
+    const accountNetworkSymbol = useSelector((state: AccountsRootState) =>
+        selectAccountNetworkSymbol(state, accountKey),
+    )!;
     const token = useSelector((state: AccountsRootState) =>
         selectAccountTokenInfo(state, accountKey, contract),
     );
@@ -45,7 +52,10 @@ export const TokenReceiveCard = ({ contract, accountKey }: TokenReceiveCardProps
         selectAccountTokenSymbol(state, accountKey, contract),
     );
 
-    if (!token) return <ErrorMessage errorMessage="Token not found." />;
+    if (!token)
+        return (
+            <ErrorMessage errorMessage={<Translation id="moduleReceive.tokens.errorMessage" />} />
+        );
 
     const tokenName = getTokenName(token.name);
 
@@ -59,8 +69,13 @@ export const TokenReceiveCard = ({ contract, accountKey }: TokenReceiveCardProps
                     <Box style={applyStyle(tokenDescriptionStyle)}>
                         <Text>{tokenName}</Text>
                         <Badge
-                            label={`Run on ${accountLabel}`}
-                            icon="eth"
+                            label={
+                                <Translation
+                                    id="moduleReceive.tokens.runOn"
+                                    values={{ accountLabel }}
+                                />
+                            }
+                            icon={accountNetworkSymbol}
                             size="small"
                             iconSize="extraSmall"
                         />


### PR DESCRIPTION
Correct network related icons and network names on receive

## Related Issue

Resolve #14631

## Screenshots:
<img width=300 src="https://github.com/user-attachments/assets/cd53ac46-abfa-4ff7-b63b-6bf558757299" />
<img width=300 src="https://github.com/user-attachments/assets/de0ca4e7-ea5f-4bd3-b17a-9c6bb96a66b9" />
