### PR TITLE
fix(suite-native): send amount inputs scrolling

### DIFF
--- a/suite-native/module-send/src/components/CryptoAmountInput.tsx
+++ b/suite-native/module-send/src/components/CryptoAmountInput.tsx
@@ -74,7 +74,10 @@ export const CryptoAmountInput = ({
         const transformedValue = cryptoAmountTransformer(newValue);
         onChange(transformedValue);
         setValue(fiatFieldName, converters?.convertCryptoToFiat?.(transformedValue));
-        debounce(() => trigger(cryptoFieldName));
+        debounce(() => {
+            trigger(cryptoFieldName);
+            onFocus?.();
+        });
     };
 
     const handleBlur = () => {

--- a/suite-native/module-send/src/components/FiatAmountInput.tsx
+++ b/suite-native/module-send/src/components/FiatAmountInput.tsx
@@ -57,6 +57,7 @@ export const FiatAmountInput = ({
         setValue(cryptoFieldName, converters?.convertFiatToCrypto?.(transformedValue), {
             shouldValidate: true,
         });
+        onFocus?.();
     };
 
     return (

--- a/suite-native/module-send/src/types.ts
+++ b/suite-native/module-send/src/types.ts
@@ -18,5 +18,5 @@ export type SendAmountInputProps = {
     translateValue: SharedValue<number>;
     isDisabled?: boolean;
     onPress?: TextInputProps['onPress'];
-    onFocus?: TextInputProps['onFocus'];
+    onFocus?: () => void;
 };


### PR DESCRIPTION
## Description
- Both amount inputs are scrolled to be visible on every focus or change so they always stay visible.

## Related Issue

Resolve #14871 

## Screenshots:

https://github.com/user-attachments/assets/b1953a5b-007b-41a3-94a7-531a1da955a1



