### PR TITLE
fix(suite-native): show correct device label for each device

### DIFF
--- a/suite-native/device-manager/src/components/DeviceItem/DeviceItemContent.tsx
+++ b/suite-native/device-manager/src/components/DeviceItem/DeviceItemContent.tsx
@@ -8,7 +8,7 @@ import {
     DeviceRootState,
     PORTFOLIO_TRACKER_DEVICE_ID,
     selectHasOnlyEmptyPortfolioTracker,
-    selectDeviceLabelOrName,
+    selectDeviceLabelOrNameById,
 } from '@suite-common/wallet-core';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { TypographyStyle } from '@trezor/theme';
@@ -67,7 +67,7 @@ export const DeviceItemContent = React.memo(
             return {
                 id: d.id,
                 name: d.name,
-                label: selectDeviceLabelOrName(state),
+                label: selectDeviceLabelOrNameById(state, d.id),
                 walletNumber: d.walletNumber,
                 useEmptyPassphrase: d.useEmptyPassphrase,
             };

--- a/suite-native/module-settings/src/components/ViewOnly/WalletRow.tsx
+++ b/suite-native/module-settings/src/components/ViewOnly/WalletRow.tsx
@@ -4,8 +4,9 @@ import { Button, HStack, Loader, Text } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
     ConnectDeviceSettings,
+    DeviceRootState,
     deviceActions,
-    selectDeviceLabelOrName,
+    selectDeviceLabelOrNameById,
     selectHasDeviceDiscovery,
 } from '@suite-common/wallet-core';
 import { analytics, EventType } from '@suite-native/analytics';
@@ -33,7 +34,9 @@ export const WalletRow = ({ device }: WalletRowProps) => {
     const { showToast } = useToast();
     const { applyStyle } = useNativeStyles();
     const hasDiscovery = useSelector(selectHasDeviceDiscovery);
-    const deviceLabel = useSelector(selectDeviceLabelOrName);
+    const deviceLabel = useSelector((state: DeviceRootState) =>
+        selectDeviceLabelOrNameById(state, device?.id),
+    );
 
     const walletNameLabel = device.useEmptyPassphrase ? (
         <Translation id="moduleSettings.viewOnly.wallet.standard" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

https://github.com/trezor/trezor-suite/pull/14483 broke device label in case of multiple devices. Device label of selected device was reused for all devices.

## Screenshots:

BEFORE:
<img width="350" alt="image" src="https://github.com/user-attachments/assets/01ac705f-f998-4fcc-b534-e462c74c0c7f">
<img width="350" alt="image" src="https://github.com/user-attachments/assets/184d71a9-10f5-47e1-8a90-acb677348463">

AFTER (fixed):
<img width="350" alt="image" src="https://github.com/user-attachments/assets/fab0471c-48f7-421b-8a9d-ea691bf548f9">

<img width="350" alt="image" src="https://github.com/user-attachments/assets/0005651a-1a87-4e35-99a9-42366f2aa31d">


