### PR TITLE
feat(suite-common): add pol and bnb to graph

### DIFF
--- a/packages/blockchain-link-types/src/common.ts
+++ b/packages/blockchain-link-types/src/common.ts
@@ -34,7 +34,7 @@ export interface ServerInfo {
     consensusBranchId?: number; // zcash current branch id
 }
 
-export type TokenStandard = 'ERC20' | 'ERC1155' | 'ERC721' | 'SPL';
+export type TokenStandard = 'ERC20' | 'ERC1155' | 'ERC721' | 'SPL' | 'BEP20';
 
 export type TransferType = 'sent' | 'recv' | 'self' | 'unknown';
 

--- a/suite-common/graph/src/balanceHistoryUtils.ts
+++ b/suite-common/graph/src/balanceHistoryUtils.ts
@@ -134,6 +134,7 @@ const getAccountHistoryMovementItemRipple = ({
     return { main: Array.from(summaryMap.values()).sort((a, b) => a.time - b.time), tokens: {} };
 };
 
+// this can be also used for networks of Ethereum type (like ETH, POL or BNB)
 export const getAccountHistoryMovementItemETH = ({
     transactions,
     from,
@@ -230,8 +231,10 @@ export const getAccountHistoryMovementItemETH = ({
         }
 
         tx.tokens.forEach(token => {
-            // skip empty amounts and non-ERC20 tokens
-            if (token.amount === '' || token.standard !== 'ERC20') return;
+            // skip empty amounts and non-ERC20 non-BEP20 tokens
+            // BEP20 is BNB Smart Chain (BSC) token standard
+            if (token.amount === '' || (token.standard !== 'ERC20' && token.standard !== 'BEP20'))
+                return;
 
             if (token.type === 'sent' || token.type === 'recv' || token.type === 'self') {
                 const tokenSummary: AccountHistoryMovementItem = {
@@ -320,6 +323,8 @@ export const getAccountHistoryMovementFromTransactions = ({
         case 'xrp':
             return getAccountHistoryMovementItemRipple({ transactions, from, to });
         case 'eth':
+        case 'pol':
+        case 'bnb':
             return getAccountHistoryMovementItemETH({ transactions, from, to });
         default:
             coin satisfies never;

--- a/suite-common/graph/src/constants.ts
+++ b/suite-common/graph/src/constants.ts
@@ -3,7 +3,12 @@ import { NetworkSymbol } from '@suite-common/wallet-config';
 // Going over 180 will broke graph in mobile app
 export const NUMBER_OF_POINTS = 40;
 
-export const LOCAL_BALANCE_HISTORY_COINS = ['eth', 'xrp'] satisfies Array<NetworkSymbol>;
+export const LOCAL_BALANCE_HISTORY_COINS = [
+    'eth',
+    'pol',
+    'bnb',
+    'xrp',
+] satisfies Array<NetworkSymbol>;
 export type LocalBalanceHistoryCoin = (typeof LOCAL_BALANCE_HISTORY_COINS)[number];
 
 export const isLocalBalanceHistoryCoin = (


### PR DESCRIPTION
POL and BNB networks should be counted in portfolio graph. 

- Adding `BEP20` as a contract type for BSC tokens
- fetching POL and BNB history movement events

## Related Issue

Resolve #14851

## Screenshots:
<img width=300 src="https://github.com/user-attachments/assets/4e532c69-02c1-41af-91cc-aef8d814f653" />
