### PR TITLE
feat(suite-native): allow enabled pol and bnb for portfolio tracker

### DIFF
--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -106,6 +106,10 @@ export const en = {
             },
             subtitle: "Here's what you have in your account.",
         },
+        coinList: {
+            mainnets: 'Select a coin to sync',
+            testnets: 'Testnet coins (have no value – for testing purposes only)',
+        },
         xpubScanScreen: {
             alert: {
                 address: {

--- a/suite-native/module-accounts-import/package.json
+++ b/suite-native/module-accounts-import/package.json
@@ -33,6 +33,7 @@
         "@suite-native/analytics": "workspace:*",
         "@suite-native/atoms": "workspace:*",
         "@suite-native/config": "workspace:*",
+        "@suite-native/discovery": "workspace:*",
         "@suite-native/feature-flags": "workspace:*",
         "@suite-native/formatters": "workspace:*",
         "@suite-native/forms": "workspace:*",

--- a/suite-native/module-accounts-import/src/components/AccountImportSummary.tsx
+++ b/suite-native/module-accounts-import/src/components/AccountImportSummary.tsx
@@ -8,13 +8,12 @@ import {
 } from '@suite-common/wallet-core';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { AccountInfo } from '@trezor/connect';
-import { portfolioTrackerSupportedNetworks } from '@suite-native/config';
 import { Translation } from '@suite-native/intl';
 import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
+import { selectPortfolioTrackerNetworkSymbols } from '@suite-native/discovery';
 
 import { AccountImportSummaryForm } from './AccountImportSummaryForm';
 import { AccountAlreadyImported } from './AccountAlreadyImported';
-
 type AccountImportDetailProps = {
     networkSymbol: NetworkSymbol;
     accountInfo: AccountInfo;
@@ -29,6 +28,7 @@ export const AccountImportSummary = ({ networkSymbol, accountInfo }: AccountImpo
             networkSymbol,
         ),
     );
+    const portfolioTrackerSupportedNetworks = useSelector(selectPortfolioTrackerNetworkSymbols);
 
     const isAccountImportSupported =
         portfolioTrackerSupportedNetworks.some(symbol => symbol === networkSymbol) ||

--- a/suite-native/module-accounts-import/src/components/SelectableNetworkList.tsx
+++ b/suite-native/module-accounts-import/src/components/SelectableNetworkList.tsx
@@ -1,8 +1,14 @@
+import { useSelector } from 'react-redux';
+import { ReactNode } from 'react';
+
 import { SelectableNetworkItem } from '@suite-native/accounts';
 import { HeaderedCard, VStack } from '@suite-native/atoms';
 import { NetworkSymbol } from '@suite-common/wallet-config';
-import { portfolioTrackerMainnets, portfolioTrackerTestnets } from '@suite-native/config';
-import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
+import {
+    selectPortfolioTrackerMainnetNetworkSymbols,
+    selectPortfolioTrackerTestnetNetworkSymbols,
+} from '@suite-native/discovery';
+import { Translation } from '@suite-native/intl';
 
 type SelectableAssetListProps = {
     onSelectItem: (networkSymbol: NetworkSymbol) => void;
@@ -13,42 +19,37 @@ const NetworkItemSection = ({
     networks,
     onSelectItem,
 }: {
-    title: string;
+    title: ReactNode;
     networks: NetworkSymbol[];
     onSelectItem: SelectableAssetListProps['onSelectItem'];
-}) => (
-    <HeaderedCard title={title}>
-        <VStack spacing="sp24">
-            {networks.map(symbol => (
-                <SelectableNetworkItem key={symbol} symbol={symbol} onPress={onSelectItem} />
-            ))}
-        </VStack>
-    </HeaderedCard>
-);
-
-const TestnetNetworkItemSection = ({ onSelectItem }: SelectableAssetListProps) => {
-    const [isRegtestEnabled] = useFeatureFlag(FeatureFlag.IsRegtestEnabled);
-    const regtestAdjustedTestnets = isRegtestEnabled
-        ? [...portfolioTrackerTestnets, 'regtest' as NetworkSymbol]
-        : portfolioTrackerTestnets;
-
+}) => {
     return (
-        <NetworkItemSection
-            title="Testnet coins (have no value – for testing purposes only)"
-            networks={regtestAdjustedTestnets}
-            onSelectItem={onSelectItem}
-        />
+        <HeaderedCard title={title}>
+            <VStack spacing="sp24">
+                {networks.map(symbol => (
+                    <SelectableNetworkItem key={symbol} symbol={symbol} onPress={onSelectItem} />
+                ))}
+            </VStack>
+        </HeaderedCard>
     );
 };
 
-export const SelectableNetworkList = ({ onSelectItem }: SelectableAssetListProps) => (
-    <VStack spacing="sp24">
-        <NetworkItemSection
-            title="Select a coin to sync"
-            networks={portfolioTrackerMainnets}
-            onSelectItem={onSelectItem}
-        />
+export const SelectableNetworkList = ({ onSelectItem }: SelectableAssetListProps) => {
+    const portfolioMainnets = useSelector(selectPortfolioTrackerMainnetNetworkSymbols);
+    const portfolioTestnets = useSelector(selectPortfolioTrackerTestnetNetworkSymbols);
 
-        <TestnetNetworkItemSection onSelectItem={onSelectItem} />
-    </VStack>
-);
+    return (
+        <VStack spacing="sp24">
+            <NetworkItemSection
+                title={<Translation id="moduleAccountImport.coinList.mainnets" />}
+                networks={portfolioMainnets}
+                onSelectItem={onSelectItem}
+            />
+            <NetworkItemSection
+                title={<Translation id="moduleAccountImport.coinList.testnets" />}
+                networks={portfolioTestnets}
+                onSelectItem={onSelectItem}
+            />
+        </VStack>
+    );
+};

--- a/suite-native/module-accounts-import/tsconfig.json
+++ b/suite-native/module-accounts-import/tsconfig.json
@@ -34,6 +34,7 @@
         { "path": "../analytics" },
         { "path": "../atoms" },
         { "path": "../config" },
+        { "path": "../discovery" },
         { "path": "../feature-flags" },
         { "path": "../formatters" },
         { "path": "../forms" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10128,6 +10128,7 @@ __metadata:
     "@suite-native/analytics": "workspace:*"
     "@suite-native/atoms": "workspace:*"
     "@suite-native/config": "workspace:*"
+    "@suite-native/discovery": "workspace:*"
     "@suite-native/feature-flags": "workspace:*"
     "@suite-native/formatters": "workspace:*"
     "@suite-native/forms": "workspace:*"


### PR DESCRIPTION
When POL and BNB are enabled, make them available for import in Portfolio Tracker

## Related Issue

Resolve #14826

## Screenshots:
<img width=300 src="https://github.com/user-attachments/assets/d6805213-3f72-4b5f-a909-2c77fb6a5a7d" />
