### PR TITLE
feat(trade): structure separation

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageHeader.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageHeader.tsx
@@ -39,8 +39,11 @@ export const PageHeader = ({ backRoute, children }: PageHeaderProps) => {
     const isAccountTabPage = useSelector(selectIsAccountTabPage);
     const routeName = useSelector(selectRouteName);
 
-    return children ? (
-        <Container>{children}</Container>
+    // handle moment when children are not rendered yet in the Trade section
+    const isTradeSection = routeName?.includes('wallet-coinmarket');
+
+    return isTradeSection || children ? (
+        <Container>{children ?? null}</Container>
     ) : (
         <Container>
             <PageName backRoute={backRoute} />

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -1428,7 +1428,7 @@ export default defineMessages({
         id: 'TR_COINMARKET_DCA_DOWNLOAD',
     },
     TR_COINMARKET_BUY_AND_SELL: {
-        defaultMessage: 'Buy & sell',
+        defaultMessage: 'Buy & Sell',
         id: 'TR_COINMARKET_BUY_AND_SELL',
     },
     TR_COINMARKET_SWAP: {

--- a/packages/suite/src/types/coinmarket/coinmarket.ts
+++ b/packages/suite/src/types/coinmarket/coinmarket.ts
@@ -31,7 +31,7 @@ import { Account, SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { AnyAction, Dispatch } from 'redux';
 import { State } from 'src/reducers/wallet/coinmarketReducer';
 import { AccountType } from '@suite-common/wallet-config';
-import { ExtendedMessageDescriptor, TrezorDevice } from 'src/types/suite';
+import { ExtendedMessageDescriptor, Route, TrezorDevice } from 'src/types/suite';
 import { Timer } from '@trezor/react-utils';
 import { AccountsState } from '@suite-common/wallet-core';
 import { TokenDefinitionsState } from '@suite-common/token-definitions';
@@ -276,4 +276,17 @@ export interface CoinmarketCryptoAmountProps {
     receiveAmount: string | number | undefined;
     receiveCurrency: CryptoId | undefined;
     className?: string;
+}
+
+export type CoinmarketContainerBackRouteType =
+    | Extract<Route['name'], `wallet-coinmarket-${string}`>
+    | 'wallet-index'
+    | 'suite-index';
+
+export interface CoinmarketContainerCommonProps {
+    title?: Extract<
+        ExtendedMessageDescriptor['id'],
+        'TR_COINMARKET_BUY_AND_SELL' | 'TR_COINMARKET_SWAP' | 'TR_COINMARKET_LAST_TRANSACTIONS'
+    >;
+    backRoute?: CoinmarketContainerBackRouteType;
 }

--- a/packages/suite/src/views/wallet/coinmarket/DCA/CoinmarketDCALanding.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/DCA/CoinmarketDCALanding.tsx
@@ -11,7 +11,6 @@ import {
     Row,
     Text,
 } from '@trezor/components';
-import { UseCoinmarketProps } from 'src/types/coinmarket/coinmarket';
 import styled from 'styled-components';
 import { borders, palette, spacings, spacingsPx } from '@trezor/theme';
 import { Translation, TrezorLink } from 'src/components/suite';
@@ -101,12 +100,12 @@ const FeatureItem = ({ icon, featureNumber }: FeatureItemProps) => (
     </Row>
 );
 
-const DCALanding = ({ selectedAccount }: UseCoinmarketProps) => {
+const DCALanding = () => {
     const currentTheme = useSelector(state => state.suite.settings.theme.variant);
     const isLightTheme = currentTheme !== 'dark';
 
     return (
-        <CoinmarketLayout selectedAccount={selectedAccount}>
+        <CoinmarketLayout>
             <Card paddingType="small">
                 <ColumnsWrapper>
                     <Column1>
@@ -157,5 +156,5 @@ const DCALanding = ({ selectedAccount }: UseCoinmarketProps) => {
 };
 
 export const CoinmarketDCALanding = () => (
-    <CoinmarketContainer title="TR_NAV_DCA" SectionComponent={DCALanding} />
+    <CoinmarketContainer title="TR_COINMARKET_BUY_AND_SELL" SectionComponent={DCALanding} />
 );

--- a/packages/suite/src/views/wallet/coinmarket/buy/CoinmarketBuyConfirm.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/CoinmarketBuyConfirm.tsx
@@ -19,7 +19,7 @@ const CoinmarketBuyConfirmComponent = ({ selectedAccount }: UseCoinmarketProps) 
 
 export const CoinmarketBuyConfirm = () => (
     <CoinmarketContainer
-        title="TR_NAV_BUY"
+        title="TR_COINMARKET_BUY_AND_SELL"
         backRoute="wallet-coinmarket-buy"
         SectionComponent={CoinmarketBuyConfirmComponent}
     />

--- a/packages/suite/src/views/wallet/coinmarket/buy/CoinmarketBuyDetail.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/CoinmarketBuyDetail.tsx
@@ -21,7 +21,7 @@ const CoinmarketBuyDetailComponent = ({ selectedAccount }: UseCoinmarketProps) =
 
 export const CoinmarketBuyDetail = () => (
     <CoinmarketContainer
-        title="TR_NAV_BUY"
+        title="TR_COINMARKET_BUY_AND_SELL"
         backRoute="wallet-coinmarket-transactions"
         SectionComponent={CoinmarketBuyDetailComponent}
     />

--- a/packages/suite/src/views/wallet/coinmarket/buy/CoinmarketBuyForm.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/CoinmarketBuyForm.tsx
@@ -9,7 +9,7 @@ const CoinmarketBuyComponent = ({ selectedAccount }: UseCoinmarketProps) => {
     const coinmarketBuyContextValues = useCoinmarketBuyForm({ selectedAccount });
 
     return (
-        <CoinmarketLayout selectedAccount={selectedAccount}>
+        <CoinmarketLayout>
             <CoinmarketFormContext.Provider value={coinmarketBuyContextValues}>
                 <CoinmarketFormLayout />
             </CoinmarketFormContext.Provider>
@@ -18,5 +18,8 @@ const CoinmarketBuyComponent = ({ selectedAccount }: UseCoinmarketProps) => {
 };
 
 export const CoinmarketBuyForm = () => (
-    <CoinmarketContainer title="TR_NAV_BUY" SectionComponent={CoinmarketBuyComponent} />
+    <CoinmarketContainer
+        title="TR_COINMARKET_BUY_AND_SELL"
+        SectionComponent={CoinmarketBuyComponent}
+    />
 );

--- a/packages/suite/src/views/wallet/coinmarket/buy/CoinmarketBuyOffers.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/CoinmarketBuyOffers.tsx
@@ -19,7 +19,7 @@ const CoinmarketBuyOffersComponent = ({ selectedAccount }: UseCoinmarketProps) =
 
 export const CoinmarketBuyOffers = () => (
     <CoinmarketContainer
-        title="TR_NAV_BUY"
+        title="TR_COINMARKET_BUY_AND_SELL"
         backRoute="wallet-coinmarket-buy"
         SectionComponent={CoinmarketBuyOffersComponent}
     />

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketContainer.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketContainer.tsx
@@ -1,24 +1,11 @@
-import { ExtendedMessageDescriptor } from '@suite-common/intl-types';
-import { Route } from '@suite-common/suite-types';
-import { ComponentType } from 'react';
-import { PageHeader } from 'src/components/suite/layouts/SuiteLayout';
-import { WalletLayout } from 'src/components/wallet';
-import { useLayout, useSelector, useTranslation } from 'src/hooks/suite';
-import { selectRouter } from 'src/reducers/suite/routerReducer';
-import { UseCoinmarketProps } from 'src/types/coinmarket/coinmarket';
+import { ElementType } from 'react';
+import { useSelector } from 'src/hooks/suite';
+import { CoinmarketContainerCommonProps } from 'src/types/coinmarket/coinmarket';
 import { CoinmarketFooter } from 'src/views/wallet/coinmarket/common/CoinmarketFooter/CoinmarketFooter';
+import { CoinmarketLayoutHeader } from 'src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketLayoutHeader';
 
-interface CoinmarketContainerProps {
-    title?: Extract<
-        ExtendedMessageDescriptor['id'],
-        | 'TR_NAV_BUY'
-        | 'TR_NAV_SELL'
-        | 'TR_NAV_DCA'
-        | 'TR_COINMARKET_SWAP'
-        | 'TR_COINMARKET_LAST_TRANSACTIONS'
-    >;
-    backRoute?: Extract<Route['name'], `wallet-coinmarket-${string}`>;
-    SectionComponent: ComponentType<UseCoinmarketProps>;
+export interface CoinmarketContainerProps extends CoinmarketContainerCommonProps {
+    SectionComponent: ElementType;
 }
 
 export const CoinmarketContainer = ({
@@ -26,37 +13,16 @@ export const CoinmarketContainer = ({
     title,
     SectionComponent,
 }: CoinmarketContainerProps) => {
-    const { translationString } = useTranslation();
-    const router = useSelector(selectRouter);
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
-    const suiteBackRouteName = useSelector(state => state.wallet.coinmarket.suiteBackRouteName);
-
-    const currentRouteName = router.route?.name;
-    const currentBackRouteName = router.settingsBackRoute.name;
-    const fallbackBackRoute =
-        currentRouteName &&
-        [
-            'wallet-coinmarket-buy',
-            'wallet-coinmarket-sell',
-            'wallet-coinmarket-exchange',
-            'wallet-coinmarket-dca',
-        ].includes(currentRouteName)
-            ? suiteBackRouteName
-            : currentBackRouteName;
-
-    const translatedTitle = translationString(title ?? 'TR_NAV_TRADE');
-    const pageTitle = `Trezor Suite | ${translatedTitle}`;
-
-    useLayout(pageTitle, () => <PageHeader backRoute={backRoute ?? fallbackBackRoute} />);
 
     if (selectedAccount.status !== 'loaded') {
-        return <WalletLayout title="TR_NAV_TRADE" isSubpage account={selectedAccount} />;
+        return <CoinmarketLayoutHeader title={title} backRoute={backRoute} />;
     }
 
     return (
-        <>
+        <CoinmarketLayoutHeader title={title} backRoute={backRoute}>
             <SectionComponent selectedAccount={selectedAccount} />
             <CoinmarketFooter />
-        </>
+        </CoinmarketLayoutHeader>
     );
 };

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketLayout.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketLayout.tsx
@@ -1,11 +1,11 @@
-import { ReactNode } from 'react';
+import { PropsWithChildren } from 'react';
 import styled from 'styled-components';
 
-import { WalletLayout, WalletSubpageHeading } from 'src/components/wallet';
-import type { SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { spacingsPx } from '@trezor/theme';
 import { SCREEN_QUERY } from '@trezor/components/src/config/variables';
 import { CoinmarketLayoutNavigation } from 'src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketLayoutNavigation/CoinmarketLayoutNavigation';
+import { useSelector } from 'src/hooks/suite';
+import { selectRouteName } from 'src/reducers/suite/routerReducer';
 
 const CoinmarketWrapper = styled.div`
     padding: 0 ${spacingsPx.lg};
@@ -19,17 +19,15 @@ const CoinmarketFormWrapper = styled.div`
     margin-top: ${spacingsPx.xl};
 `;
 
-interface CoinmarketLayoutProps {
-    children: ReactNode;
-    selectedAccount: SelectedAccountLoaded;
-}
+interface CoinmarketLayoutProps extends PropsWithChildren {}
 
-export const CoinmarketLayout = ({ children, selectedAccount }: CoinmarketLayoutProps) => (
-    <WalletLayout title="TR_NAV_TRADE" isSubpage account={selectedAccount}>
+export const CoinmarketLayout = ({ children }: CoinmarketLayoutProps) => {
+    const routeName = useSelector(selectRouteName);
+
+    return (
         <CoinmarketWrapper>
-            <WalletSubpageHeading title="TR_NAV_TRADE" />
-            <CoinmarketLayoutNavigation />
+            {!routeName?.includes(`wallet-coinmarket-exchange`) && <CoinmarketLayoutNavigation />}
             <CoinmarketFormWrapper>{children}</CoinmarketFormWrapper>
         </CoinmarketWrapper>
-    </WalletLayout>
-);
+    );
+};

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketLayoutHeader.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketLayoutHeader.tsx
@@ -1,0 +1,94 @@
+import { IconButton, Row } from '@trezor/components';
+import { spacings } from '@trezor/theme';
+import { PropsWithChildren, useCallback, useMemo } from 'react';
+import { goto } from 'src/actions/suite/routerActions';
+import { PageHeader } from 'src/components/suite/layouts/SuiteLayout';
+import { BasicName } from 'src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/BasicName';
+import { useDispatch, useLayout, useSelector, useTranslation } from 'src/hooks/suite';
+import { selectRouter } from 'src/reducers/suite/routerReducer';
+import type { CoinmarketContainerCommonProps } from 'src/types/coinmarket/coinmarket';
+import { CoinmarketLayoutNavigationItem } from 'src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketLayoutNavigation/CoinmarketLayoutNavigationItem';
+
+interface CoinmarketLayoutHeaderProps extends PropsWithChildren, CoinmarketContainerCommonProps {}
+
+export const CoinmarketLayoutHeader = ({
+    title,
+    backRoute,
+    children,
+}: CoinmarketLayoutHeaderProps) => {
+    const selectedAccount = useSelector(state => state.wallet.selectedAccount);
+    const router = useSelector(selectRouter);
+    const suiteBackRouteName = useSelector(state => state.wallet.coinmarket.suiteBackRouteName);
+
+    const currentRouteName = router.route?.name;
+    const currentBackRouteName = router.settingsBackRoute.name;
+    const fallbackBackRoute =
+        currentRouteName &&
+        [
+            'wallet-coinmarket-buy',
+            'wallet-coinmarket-sell',
+            'wallet-coinmarket-exchange',
+            'wallet-coinmarket-dca',
+        ].includes(currentRouteName)
+            ? suiteBackRouteName
+            : currentBackRouteName;
+
+    const { translationString } = useTranslation();
+    const dispatch = useDispatch();
+    const fallbackTitle = useMemo(() => title || 'TR_NAV_TRADE', [title]);
+    const transactionPageTitle = 'TR_COINMARKET_LAST_TRANSACTIONS';
+
+    const translatedTitle = translationString(fallbackTitle);
+    const pageTitle = `Trezor Suite | ${translatedTitle}`;
+    const newBackRoute = backRoute || fallbackBackRoute;
+
+    const handleBackClick = useCallback(() => {
+        if (selectedAccount.status === 'loaded') {
+            dispatch(
+                goto(newBackRoute, {
+                    params: {
+                        symbol: selectedAccount.account.symbol,
+                        accountIndex: selectedAccount.account.index,
+                        accountType: selectedAccount.account.accountType,
+                    },
+                }),
+            );
+
+            return;
+        }
+
+        dispatch(goto(newBackRoute));
+    }, [newBackRoute, selectedAccount, dispatch]);
+
+    const CoinmarketPageHeader = useCallback(
+        () => (
+            <PageHeader backRoute={newBackRoute}>
+                <Row width="100%" gap={spacings.md}>
+                    <IconButton
+                        icon="caretLeft"
+                        variant="tertiary"
+                        size="medium"
+                        onClick={handleBackClick}
+                        data-testid="@account-subpage/back"
+                    />
+                    <BasicName nameId={fallbackTitle} />
+                    {title !== transactionPageTitle && (
+                        <Row flex="auto" margin={{ left: 'auto' }}>
+                            <CoinmarketLayoutNavigationItem
+                                route="wallet-coinmarket-transactions"
+                                title={transactionPageTitle}
+                            />
+                        </Row>
+                    )}
+                </Row>
+            </PageHeader>
+        ),
+        [newBackRoute, fallbackTitle, title, handleBackClick],
+    );
+
+    useLayout(pageTitle, CoinmarketPageHeader);
+
+    if (!children) return null;
+
+    return children;
+};

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketLayoutNavigation/CoinmarketLayoutNavigation.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketLayoutNavigation/CoinmarketLayoutNavigation.tsx
@@ -1,61 +1,22 @@
-import styled from 'styled-components';
-import { useDevice } from 'src/hooks/suite';
-import { Divider } from '@trezor/components';
-import { spacings } from '@trezor/theme';
-import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
+import { Row } from '@trezor/components';
 import { CoinmarketLayoutNavigationItem } from 'src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketLayoutNavigation/CoinmarketLayoutNavigationItem';
 
-const List = styled.div`
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-`;
-
-const SeparatorWrapper = styled.div`
-    height: 42px;
-`;
-
-export const CoinmarketLayoutNavigation = () => {
-    const { device } = useDevice();
-
-    return (
-        <List>
-            <CoinmarketLayoutNavigationItem
-                route="wallet-coinmarket-buy"
-                title="TR_NAV_BUY"
-                icon="plus"
-            />
-            <CoinmarketLayoutNavigationItem
-                route="wallet-coinmarket-sell"
-                title="TR_NAV_SELL"
-                icon="minus"
-            />
-
-            {!hasBitcoinOnlyFirmware(device) ? (
-                <CoinmarketLayoutNavigationItem
-                    route="wallet-coinmarket-exchange"
-                    title="TR_COINMARKET_SWAP"
-                    icon="arrowsLeftRight"
-                />
-            ) : null}
-
-            <SeparatorWrapper>
-                <Divider
-                    orientation="vertical"
-                    strokeWidth={1}
-                    margin={{ left: spacings.sm, right: spacings.sm }}
-                />
-            </SeparatorWrapper>
-            <CoinmarketLayoutNavigationItem
-                route="wallet-coinmarket-dca"
-                title="TR_NAV_DCA"
-                icon="clock"
-            />
-
-            <CoinmarketLayoutNavigationItem
-                route="wallet-coinmarket-transactions"
-                title="TR_COINMARKET_LAST_TRANSACTIONS"
-            />
-        </List>
-    );
-};
+export const CoinmarketLayoutNavigation = () => (
+    <Row>
+        <CoinmarketLayoutNavigationItem
+            route="wallet-coinmarket-buy"
+            title="TR_NAV_BUY"
+            icon="plus"
+        />
+        <CoinmarketLayoutNavigationItem
+            route="wallet-coinmarket-sell"
+            title="TR_NAV_SELL"
+            icon="minus"
+        />
+        <CoinmarketLayoutNavigationItem
+            route="wallet-coinmarket-dca"
+            title="TR_NAV_DCA"
+            icon="clock"
+        />
+    </Row>
+);

--- a/packages/suite/src/views/wallet/coinmarket/exchange/CoinmarketExchangeForm.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/CoinmarketExchangeForm.tsx
@@ -9,7 +9,7 @@ const CoinmarketExchangeFormComponent = ({ selectedAccount }: UseCoinmarketProps
     const coinmarketExchangeContextValue = useCoinmarketExchangeForm({ selectedAccount });
 
     return (
-        <CoinmarketLayout selectedAccount={selectedAccount}>
+        <CoinmarketLayout>
             <CoinmarketFormContext.Provider value={coinmarketExchangeContextValue}>
                 <CoinmarketFormLayout />
             </CoinmarketFormContext.Provider>

--- a/packages/suite/src/views/wallet/coinmarket/sell/CoinmarketSellConfirm.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/CoinmarketSellConfirm.tsx
@@ -19,7 +19,7 @@ const CoinmarketSellConfirmComponent = ({ selectedAccount }: UseCoinmarketProps)
 
 export const CoinmarketSellConfirm = () => (
     <CoinmarketContainer
-        title="TR_NAV_SELL"
+        title="TR_COINMARKET_BUY_AND_SELL"
         backRoute="wallet-coinmarket-sell"
         SectionComponent={CoinmarketSellConfirmComponent}
     />

--- a/packages/suite/src/views/wallet/coinmarket/sell/CoinmarketSellDetail.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/CoinmarketSellDetail.tsx
@@ -21,7 +21,7 @@ const CoinmarketSellDetailComponent = ({ selectedAccount }: UseCoinmarketProps) 
 
 export const CoinmarketSellDetail = () => (
     <CoinmarketContainer
-        title="TR_NAV_SELL"
+        title="TR_COINMARKET_BUY_AND_SELL"
         backRoute="wallet-coinmarket-transactions"
         SectionComponent={CoinmarketSellDetailComponent}
     />

--- a/packages/suite/src/views/wallet/coinmarket/sell/CoinmarketSellForm.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/CoinmarketSellForm.tsx
@@ -9,7 +9,7 @@ const CoinmarketSellFormComponent = ({ selectedAccount }: UseCoinmarketProps) =>
     const coinmarketSellContextValues = useCoinmarketSellForm({ selectedAccount });
 
     return (
-        <CoinmarketLayout selectedAccount={selectedAccount}>
+        <CoinmarketLayout>
             <CoinmarketFormContext.Provider value={coinmarketSellContextValues}>
                 <CoinmarketFormLayout />
             </CoinmarketFormContext.Provider>
@@ -18,5 +18,8 @@ const CoinmarketSellFormComponent = ({ selectedAccount }: UseCoinmarketProps) =>
 };
 
 export const CoinmarketSellForm = () => (
-    <CoinmarketContainer title="TR_NAV_SELL" SectionComponent={CoinmarketSellFormComponent} />
+    <CoinmarketContainer
+        title="TR_COINMARKET_BUY_AND_SELL"
+        SectionComponent={CoinmarketSellFormComponent}
+    />
 );

--- a/packages/suite/src/views/wallet/coinmarket/sell/CoinmarketSellOffers.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/CoinmarketSellOffers.tsx
@@ -18,7 +18,7 @@ const CoinmarketSellOffersComponent = ({ selectedAccount }: UseCoinmarketProps) 
 };
 export const CoinmarketSellOffers = () => (
     <CoinmarketContainer
-        title="TR_NAV_SELL"
+        title="TR_COINMARKET_BUY_AND_SELL"
         backRoute="wallet-coinmarket-sell"
         SectionComponent={CoinmarketSellOffersComponent}
     />

--- a/packages/suite/src/views/wallet/coinmarket/transactions/CoinmarketTransactions.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/transactions/CoinmarketTransactions.tsx
@@ -1,10 +1,18 @@
 import { CoinmarketAccountTransactions } from 'src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketAccountTransactions/CoinmarketAccountTransactions';
 import { CoinmarketContainer } from 'src/views/wallet/coinmarket/common/CoinmarketContainer';
+import { useSelector } from 'src/hooks/suite';
+import { selectRouter } from 'src/reducers/suite/routerReducer';
+import { CoinmarketContainerBackRouteType } from 'src/types/coinmarket/coinmarket';
 
-export const CoinmarketTransactions = () => (
-    <CoinmarketContainer
-        title="TR_COINMARKET_LAST_TRANSACTIONS"
-        backRoute="wallet-coinmarket-buy"
-        SectionComponent={CoinmarketAccountTransactions}
-    />
-);
+export const CoinmarketTransactions = () => {
+    const router = useSelector(selectRouter);
+    const backRoute = router.settingsBackRoute.name as CoinmarketContainerBackRouteType;
+
+    return (
+        <CoinmarketContainer
+            title="TR_COINMARKET_LAST_TRANSACTIONS"
+            backRoute={backRoute}
+            SectionComponent={CoinmarketAccountTransactions}
+        />
+    );
+};


### PR DESCRIPTION
## Description
- Split Buy&Sell section and Swap section
- Header will not show account (instead there is a go back button)

## Screenshots
### Before
![image](https://github.com/user-attachments/assets/f408894a-fe29-45b6-84b3-3efe41d3cef9)
![image](https://github.com/user-attachments/assets/c45de900-40bf-4c67-a53f-7752cb324d11)

### After
![image](https://github.com/user-attachments/assets/bc7a6b20-3fe5-4120-80cf-d35d38f55d7e)
![image](https://github.com/user-attachments/assets/248ae3da-416a-4f6d-887a-03f612f84ee6)

## Related
Resolve https://github.com/trezor/trezor-suite/issues/14889
