### PR TITLE
feat(suite-native): debug prefilled send form address button

### DIFF
--- a/suite-native/accounts/src/selectors.ts
+++ b/suite-native/accounts/src/selectors.ts
@@ -143,3 +143,13 @@ export const selectAccountListSections = memoizeWithArgs(
     // Some reasonable number of accounts that could be in app
     { size: 40 },
 );
+
+export const selectFirstUnusedAccountAddress = (
+    state: NativeAccountsRootState,
+    accountKey: AccountKey,
+) => {
+    const account = selectAccountByKey(state, accountKey);
+    if (!account) return null;
+
+    return account.addresses?.unused[0]?.address ?? null;
+};

--- a/suite-native/module-send/package.json
+++ b/suite-native/module-send/package.json
@@ -28,6 +28,7 @@
         "@suite-native/alerts": "workspace:*",
         "@suite-native/analytics": "workspace:*",
         "@suite-native/atoms": "workspace:*",
+        "@suite-native/config": "workspace:*",
         "@suite-native/device": "workspace:*",
         "@suite-native/device-mutex": "workspace:*",
         "@suite-native/formatters": "workspace:*",

--- a/suite-native/module-send/src/components/AddressInput.tsx
+++ b/suite-native/module-send/src/components/AddressInput.tsx
@@ -2,13 +2,15 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 
 import { formInputsMaxLength } from '@suite-common/validators';
-import { VStack, Text } from '@suite-native/atoms';
+import { VStack, Text, HStack, Button } from '@suite-native/atoms';
 import { TextInputField, useFormContext } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
 import { analytics, EventType } from '@suite-native/analytics';
 import { isAddressValid } from '@suite-common/wallet-utils';
 import { AccountKey } from '@suite-common/wallet-types';
 import { AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
+import { NativeAccountsRootState, selectFirstUnusedAccountAddress } from '@suite-native/accounts';
+import { isDebugEnv } from '@suite-native/config';
 
 import { QrCodeBottomSheetIcon } from './QrCodeBottomSheetIcon';
 import { getOutputFieldName } from '../utils';
@@ -24,6 +26,9 @@ export const AddressInput = ({ index, accountKey }: AddressInputProps) => {
     const networkSymbol = useSelector((state: AccountsRootState) =>
         selectAccountNetworkSymbol(state, accountKey),
     );
+    const unusedAccountAddress = useSelector((state: NativeAccountsRootState) =>
+        selectFirstUnusedAccountAddress(state, accountKey),
+    );
 
     const handleScanAddressQRCode = (qrCodeData: string) => {
         setValue(addressFieldName, qrCodeData, { shouldValidate: true });
@@ -38,11 +43,23 @@ export const AddressInput = ({ index, accountKey }: AddressInputProps) => {
         }
     };
 
+    // Debug helper to fill opened account address.
+    const fillSelfAddress = () => {
+        setValue(addressFieldName, unusedAccountAddress, { shouldValidate: true });
+    };
+
     return (
         <VStack spacing="sp12">
-            <Text variant="hint">
-                <Translation id="moduleSend.outputs.recipients.addressLabel" />
-            </Text>
+            <HStack flex={1} justifyContent="space-between" alignItems="center">
+                <Text variant="hint">
+                    <Translation id="moduleSend.outputs.recipients.addressLabel" />
+                </Text>
+                {isDebugEnv() && (
+                    <Button size="small" colorScheme="tertiaryElevation0" onPress={fillSelfAddress}>
+                        self address
+                    </Button>
+                )}
+            </HStack>
             <TextInputField
                 multiline
                 name={addressFieldName}

--- a/suite-native/module-send/tsconfig.json
+++ b/suite-native/module-send/tsconfig.json
@@ -33,6 +33,7 @@
         { "path": "../alerts" },
         { "path": "../analytics" },
         { "path": "../atoms" },
+        { "path": "../config" },
         { "path": "../device" },
         { "path": "../device-mutex" },
         { "path": "../formatters" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10390,6 +10390,7 @@ __metadata:
     "@suite-native/alerts": "workspace:*"
     "@suite-native/analytics": "workspace:*"
     "@suite-native/atoms": "workspace:*"
+    "@suite-native/config": "workspace:*"
     "@suite-native/device": "workspace:*"
     "@suite-native/device-mutex": "workspace:*"
     "@suite-native/formatters": "workspace:*"


### PR DESCRIPTION

## Description
There is a button that automatically fills the address input with adress of currently opened account. Simillar to debug functionality in the account import form. The button is display only in `debug` builds.

## Screenshots:

https://github.com/user-attachments/assets/55ba4ac6-61ed-4fd7-bd9a-4392b1b0eb7d

