### PR TITLE
Types chores

### DIFF
--- a/packages/coinjoin/src/client/Status.ts
+++ b/packages/coinjoin/src/client/Status.ts
@@ -240,15 +240,15 @@ export class Status extends TypedEmitter<StatusEvents> {
                 identity: this.identities[0],
                 attempts: 3, // schedule 3 attempts on start
             },
-        ).then(patchResponse);
+        )
+            .then(patchResponse)
+            .catch(() => undefined);
 
-        return version
-            ? ({
-                  majorVersion: version.BackenMajordVersion,
-                  commitHash: version.CommitHash,
-                  legalDocumentsVersion: version.Ww2LegalDocumentsVersion,
-              } as CoinjoinClientVersion)
-            : undefined;
+        return {
+            majorVersion: version?.BackenMajordVersion ?? '0',
+            commitHash: version?.CommitHash ?? 'deadbeef',
+            legalDocumentsVersion: version?.Ww2LegalDocumentsVersion ?? '1.0',
+        } as CoinjoinClientVersion;
     }
 
     async start() {

--- a/packages/device-utils/src/bootloaderUtils.ts
+++ b/packages/device-utils/src/bootloaderUtils.ts
@@ -1,10 +1,10 @@
-import { Device } from '@trezor/connect';
-
 import { isDeviceInBootloaderMode } from './modeUtils';
+import { PartialDevice } from './types';
 
-export const getBootloaderHash = (device?: Device) => device?.features?.bootloader_hash || '';
+export const getBootloaderHash = (device?: PartialDevice) =>
+    device?.features?.bootloader_hash || '';
 
-export const getBootloaderVersion = (device?: Device) => {
+export const getBootloaderVersion = (device?: PartialDevice) => {
     if (!device?.features) {
         return '';
     }

--- a/packages/device-utils/src/firmwareUtils.ts
+++ b/packages/device-utils/src/firmwareUtils.ts
@@ -1,10 +1,11 @@
-import { FirmwareType, Device, VersionArray } from '@trezor/connect';
+import { FirmwareType, VersionArray } from '@trezor/connect';
 
 import { isDeviceInBootloaderMode } from './modeUtils';
+import { PartialDevice } from './types';
 
-export const getFirmwareRevision = (device?: Device) => device?.features?.revision || '';
+export const getFirmwareRevision = (device?: PartialDevice) => device?.features?.revision || '';
 
-export const getFirmwareVersionArray = (device?: Device): VersionArray | null => {
+export const getFirmwareVersionArray = (device?: PartialDevice): VersionArray | null => {
     if (!device?.features) {
         return null;
     }
@@ -19,7 +20,9 @@ export const getFirmwareVersionArray = (device?: Device): VersionArray | null =>
     return [features.major_version, features.minor_version, features.patch_version];
 };
 
-export const getFirmwareVersion = (device?: Device): '' | `${number}.${number}.${number}` => {
+export const getFirmwareVersion = (
+    device?: PartialDevice,
+): '' | `${number}.${number}.${number}` => {
     if (!device?.features) {
         return '';
     }
@@ -35,9 +38,9 @@ export const getFirmwareVersion = (device?: Device): '' | `${number}.${number}.$
 };
 
 // This can give a false negative in bootloader mode for T1B1 and T2T1.
-export const hasBitcoinOnlyFirmware = (device?: Device) =>
+export const hasBitcoinOnlyFirmware = (device?: PartialDevice) =>
     device?.firmwareType === FirmwareType.BitcoinOnly;
 
 // Bitcoin-only device with Universal firmware is treated as a regular device.
-export const isBitcoinOnlyDevice = (device?: Device) =>
+export const isBitcoinOnlyDevice = (device?: PartialDevice) =>
     !!device?.features?.unit_btconly && device?.firmwareType !== FirmwareType.Regular;

--- a/packages/device-utils/src/modeUtils.ts
+++ b/packages/device-utils/src/modeUtils.ts
@@ -1,8 +1,9 @@
-import { Device } from '@trezor/connect';
+import { PartialDevice } from './types';
 
-export const isDeviceInBootloaderMode = (device?: Device) => !!device?.features?.bootloader_mode;
+export const isDeviceInBootloaderMode = (device?: PartialDevice) =>
+    !!device?.features?.bootloader_mode;
 
-export const getDeviceMode = (device?: Device) => {
+export const getDeviceMode = (device?: PartialDevice) => {
     if (device?.features?.bootloader_mode) return 'bootloader';
     if (!device?.features?.initialized) return 'initialize';
     if (device?.features?.no_backup) return 'seedless';

--- a/packages/device-utils/src/types.ts
+++ b/packages/device-utils/src/types.ts
@@ -1,0 +1,6 @@
+import { Device } from '@trezor/connect';
+
+export type PartialDevice = {
+    features?: Device['features'];
+    firmwareType?: Device['firmwareType'];
+};

--- a/packages/suite/src/services/coinjoin/config.ts
+++ b/packages/suite/src/services/coinjoin/config.ts
@@ -21,7 +21,7 @@ export const COINJOIN_NETWORKS: PartialRecord<NetworkSymbol, ServerEnvironment> 
             network: 'btc',
             coordinatorName: 'CoinJoinCoordinatorIdentifier',
             coordinatorUrl: 'https://wasabiwallet.io/wabisabi/',
-            wabisabiBackendUrl: 'https://wasabiwallet.io/',
+            wabisabiBackendUrl: 'https://api.wasabiwallet.io/',
             blockbookUrls: [
                 'https://btc1.trezor.io',
                 'https://btc2.trezor.io',

--- a/packages/suite/src/views/wallet/transactions/CoinjoinSummary/BalancePrivacyBreakdown/BalancePrivacyBreakdown.tsx
+++ b/packages/suite/src/views/wallet/transactions/CoinjoinSummary/BalancePrivacyBreakdown/BalancePrivacyBreakdown.tsx
@@ -15,6 +15,7 @@ const BalanceContainer = styled.div`
     display: flex;
     flex-wrap: wrap;
     align-items: center;
+    align-self: normal;
     gap: 12px;
     padding: 0 10px;
 `;

--- a/packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinBalanceSection.tsx
+++ b/packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinBalanceSection.tsx
@@ -48,7 +48,7 @@ export const CoinjoinBalanceSection = ({ accountKey }: CoinjoinBalanceSectionPro
     return (
         <Container>
             <Card width="100%" height="100%">
-                <Column justifyContent="center">
+                <Column justifyContent="center" flex="1">
                     {errorMessageConfig ? (
                         <CoinjoinBalanceError {...errorMessageConfig} />
                     ) : (

--- a/suite-common/suite-utils/src/device.ts
+++ b/suite-common/suite-utils/src/device.ts
@@ -140,7 +140,7 @@ export const isSelectedDevice = (selected?: TrezorDevice | Device, device?: Trez
     return selected.id === device.id;
 };
 
-export const getFwUpdateVersion = (device: Device) =>
+export const getFwUpdateVersion = (device: TrezorDevice) =>
     device.firmwareRelease?.release?.version?.join('.') || null;
 
 export const getCoinUnavailabilityMessage = (reason: UnavailableCapability) => {


### PR DESCRIPTION
- f140fdda8174288d646dff5692dbea7e06df94f5 - only accept a subset of device properties in some utils. `Device` might be too strict. For example, suite saves Device into storage with path set to `''` (see #14776) which does not match device type but on the other hand we don't care about this fact in this util. 