### PR TITLE
fix(suite-desktop-core): restart app when using autostart on linux

### DIFF
--- a/packages/suite-desktop-core/src/modules/auto-updater.ts
+++ b/packages/suite-desktop-core/src/modules/auto-updater.ts
@@ -214,6 +214,12 @@ export const init: Module = ({ mainWindowProxy, store }) => {
         setImmediate(() => {
             // Removing listeners & closing window (https://github.com/electron-userland/electron-builder/issues/1604)
             app.removeAllListeners('window-all-closed');
+            if (process.platform === 'linux') {
+                // On Linux there were some issues with re-opening the app, due to a possible race condition where the old app was not fully closed yet.
+                // This resolves the issue by removing the handlers and closing the app immediately.
+                app.removeAllListeners('before-quit');
+                app.removeAllListeners('second-instance');
+            }
             mainWindowProxy.getInstance()?.removeAllListeners('close');
             mainWindowProxy.getInstance()?.close();
 


### PR DESCRIPTION
## Description

We see some issues with restarting after auto update on Ubuntu with Suite 24.9.2. 
The app will quit, but not re-open itself. 

One problem could be due to the `--no-sandbox` flag, however even after solving that it seems there is an issue. 

Based on a bug from Sentry (#14904), it could be that there is a race condition where the old app is not fully closed when the new instance is started. 
This means that the `second-instance` handler is triggered, which doesn't work since the app is already closing. 

This fix removes the `second-instance` and `before-quit` handlers (only on Linux), allowing the app to quit immediately. 