### PR TITLE
fix(suite): KB link to be next to configuration for Tor snowflake

### DIFF
--- a/packages/suite/src/constants/suite/experimental.ts
+++ b/packages/suite/src/constants/suite/experimental.ts
@@ -1,5 +1,5 @@
 import { TranslationKey } from '@suite-common/intl-types';
-import { EXPERIMENTAL_PASSWORD_MANAGER_KB_URL, TOR_SNOWFLAKE_KB_URL, Url } from '@trezor/urls';
+import { EXPERIMENTAL_PASSWORD_MANAGER_KB_URL, TOR_SNOWFLAKE_PROJECT_URL, Url } from '@trezor/urls';
 
 import { Dispatch } from '../../types/suite';
 
@@ -26,6 +26,6 @@ export const EXPERIMENTAL_FEATURES: Record<ExperimentalFeature, ExperimentalFeat
     'tor-snowflake': {
         title: 'TR_EXPERIMENTAL_TOR_SNOWFLAKE',
         description: 'TR_EXPERIMENTAL_TOR_SNOWFLAKE_DESCRIPTION',
-        knowledgeBaseUrl: TOR_SNOWFLAKE_KB_URL,
+        knowledgeBaseUrl: TOR_SNOWFLAKE_PROJECT_URL,
     },
 };

--- a/packages/suite/src/views/settings/SettingsGeneral/TorSnowflake.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/TorSnowflake.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { useSelector } from 'src/hooks/suite';
 import { selectTorState } from 'src/reducers/suite/suiteReducer';
 import { TorSettings } from '@trezor/suite-desktop-api/src/messages';
-import { TOR_SNOWFLAKE_PROJECT_URL } from '@trezor/urls';
+import { TOR_SNOWFLAKE_KB_URL } from '@trezor/urls';
 import { breakpointMediaQueries } from '@trezor/styles';
 import { desktopApi } from '@trezor/suite-desktop-api';
 import { Button, Input } from '@trezor/components';
@@ -96,7 +96,7 @@ export const TorSnowflake = () => {
             <TextColumn
                 title={<Translation id="TR_TOR_CONFIG_SNOWFLAKE_TITLE" />}
                 description={<Translation id="TR_TOR_CONFIG_SNOWFLAKE_DESCRIPTION" />}
-                buttonLink={TOR_SNOWFLAKE_PROJECT_URL}
+                buttonLink={TOR_SNOWFLAKE_KB_URL}
             />
             <ActionColumn>
                 <Container>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I realized the information about how to configure snowflake from Knowledge Base is better placed near the configuration, since it is there where the user is going to need it.. And the description of what is snowflake in the switch from experimental features.