### PR TITLE
fix(suite): clear snowflakeBinaryPath when disabling from external feat

### DIFF
--- a/packages/suite/src/constants/suite/experimental.ts
+++ b/packages/suite/src/constants/suite/experimental.ts
@@ -1,4 +1,6 @@
 import { TranslationKey } from '@suite-common/intl-types';
+import { desktopApi } from '@trezor/suite-desktop-api';
+
 import { EXPERIMENTAL_PASSWORD_MANAGER_KB_URL, TOR_SNOWFLAKE_PROJECT_URL, Url } from '@trezor/urls';
 
 import { Dispatch } from '../../types/suite';
@@ -27,5 +29,16 @@ export const EXPERIMENTAL_FEATURES: Record<ExperimentalFeature, ExperimentalFeat
         title: 'TR_EXPERIMENTAL_TOR_SNOWFLAKE',
         description: 'TR_EXPERIMENTAL_TOR_SNOWFLAKE_DESCRIPTION',
         knowledgeBaseUrl: TOR_SNOWFLAKE_PROJECT_URL,
+        onToggle: async ({ newValue }) => {
+            if (!newValue) {
+                const result = await desktopApi.getTorSettings();
+                if (result.success && result.payload.snowflakeBinaryPath !== '') {
+                    await desktopApi.changeTorSettings({
+                        ...result.payload,
+                        snowflakeBinaryPath: '',
+                    });
+                }
+            }
+        },
     },
 };

--- a/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
@@ -34,10 +34,10 @@ const FeatureLine = ({ feature, enabledFeatures }: FeatureLineProps) => {
     const descId = config.description;
     const url = config.knowledgeBaseUrl;
 
-    const onChangeFeature = () => {
+    const onChangeFeature = async () => {
         const newValue = !checked;
 
-        config?.onToggle?.({ dispatch, newValue });
+        await config?.onToggle?.({ dispatch, newValue });
 
         dispatch({
             type: SUITE.SET_EXPERIMENTAL_FEATURES,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Issue where `snowflakeBinaryPath` is not cleared if snowflake is disable from experimental features or if experimental features are switch off all at once. So even it was disable in this case it was trying to use it. As described in issue https://github.com/trezor/trezor-suite/issues/14731

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/14731


