### PR TITLE
fix(schema-utils): typebox typescript resolving issues

### DIFF
--- a/packages/schema-utils/src/index.ts
+++ b/packages/schema-utils/src/index.ts
@@ -121,4 +121,4 @@ export function AssertWeak<T extends TSchema>(
 
 export const Type = new CustomTypeBuilder();
 export { Optional, CloneType };
-export type { Static, TObject, TSchema };
+export type * from '@sinclair/typebox';

--- a/scripts/replace-imports.sh
+++ b/scripts/replace-imports.sh
@@ -24,14 +24,3 @@ if grep -Rl "$SEARCH_PATTERN" "$1"; then
 else
     echo "All occurrences of '@trezor/*/src' have been successfully replaced."
 fi
-
-# Patch for Typebox import issue, where TS uses an ESM import path, but our package is CommonJS
-# @sinclair/typebox/build/esm/index.mjs -> @sinclair/typebox
-
-REGEX="s/@sinclair\/typebox\/build\/esm\/index.mjs/@sinclair\/typebox/g"
-
-if [[ "$OS" == "Darwin" ]]; then
-    find "$1" -type f -exec sed -i '' -E "$REGEX" {} +
-else
-    find "$1" -type f -exec sed -i -E "$REGEX" {} +
-fi


### PR DESCRIPTION
## Description

I think this should finally be a good fix for the issues with Typebox and Typescript package resolution. 

What was happening is that `build:libs` would inline imports to types in `@sinclair/typebox` in definitions, even inside other packages than `@trezor/schema-utils`. 
This was a problem however, since the other packages don't have it as a dependency and Typescript gets confused about resolving it. 
This is why we had to add a condition to `replace-imports` for this.

By adding a re-export of all Typebox types to `@trezor/schema-utils`, the definitions will correctly refer to our package and TS resolutions should work smoothly.