### PR TITLE
feat(connect): try to reuse initialized session

### DIFF
--- a/packages/connect/e2e/tests/device/keepSession.test.ts
+++ b/packages/connect/e2e/tests/device/keepSession.test.ts
@@ -1,4 +1,4 @@
-import TrezorConnect from '../../../src';
+import TrezorConnect, { StaticSessionId } from '../../../src';
 
 import { getController, setup, conditionalTest, initTrezorConnect } from '../../common.setup';
 
@@ -9,6 +9,7 @@ describe('keepSession common param', () => {
         await TrezorConnect.dispose();
         await setup(controller, {
             mnemonic: 'mnemonic_all',
+            passphrase_protection: true,
         });
         await initTrezorConnect(controller);
     });
@@ -19,6 +20,10 @@ describe('keepSession common param', () => {
     });
 
     conditionalTest(['1', '<2.3.2'], 'keepSession with changing useCardanoDerivation', async () => {
+        TrezorConnect.on('ui-request_passphrase', () => {
+            TrezorConnect.uiResponse({ type: 'ui-receive_passphrase', payload: { value: 'a' } });
+        });
+
         const noDerivation = await TrezorConnect.getAccountDescriptor({
             coin: 'ada',
             path: "m/1852'/1815'/0'/0/0",
@@ -38,5 +43,35 @@ describe('keepSession common param', () => {
         });
         if (!enableDerivation.success) throw new Error(enableDerivation.payload.error);
         expect(enableDerivation.payload.descriptor).toBeDefined();
+
+        const { device } = enableDerivation;
+        if (!device || !device.state) throw new Error('Device not found');
+
+        // change device instance to simulate app reload
+        // passphrase request should not be called
+        TrezorConnect.removeAllListeners('ui-request_passphrase');
+        // modify instance in staticSessionId
+        const staticSessionId = device.state.staticSessionId?.replace(
+            ':0',
+            ':1',
+        ) as StaticSessionId;
+        const keepCardanoDerivation = await TrezorConnect.getAccountDescriptor({
+            coin: 'ada',
+            path: "m/1852'/1815'/0'/0/0",
+            device: {
+                // change instance to new but use already initialized state
+                instance: 1,
+                state: {
+                    ...device.state,
+                    staticSessionId,
+                },
+                path: device.path,
+            },
+            // useCardanoDerivation: true, // NOTE: not required, its in the state
+        });
+        if (!keepCardanoDerivation.success) throw new Error(keepCardanoDerivation.payload.error);
+        expect(keepCardanoDerivation.payload.descriptor).toEqual(
+            enableDerivation.payload.descriptor,
+        );
     });
 });

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -53,6 +53,30 @@ function validateStaticSessionId(input: unknown): StaticSessionId {
         'DeviceState: invalid staticSessionId: ' + input,
     );
 }
+// validate expected state from method parameter.
+// it could be undefined
+function validateDeviceState(input: unknown): DeviceState | undefined {
+    if (typeof input === 'string') {
+        return { staticSessionId: validateStaticSessionId(input) };
+    }
+    if (input && typeof input === 'object') {
+        const state: DeviceState = {};
+        if ('staticSessionId' in input) {
+            state.staticSessionId = validateStaticSessionId(input.staticSessionId);
+        }
+        if ('sessionId' in input && typeof input.sessionId === 'string') {
+            state.sessionId = input.sessionId;
+        }
+        if ('deriveCardano' in input && typeof input.deriveCardano === 'boolean') {
+            state.deriveCardano = input.deriveCardano;
+        }
+
+        return state;
+    }
+
+    return undefined;
+}
+
 export abstract class AbstractMethod<Name extends CallMethodPayload['method'], Params = undefined> {
     responseID: number;
 
@@ -131,20 +155,7 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
         this.payload = payload;
         this.responseID = message.id || 0;
         this.devicePath = payload.device?.path;
-
-        // expected state from method parameter.
-        // it could be undefined
-        this.deviceState =
-            // eslint-disable-next-line no-nested-ternary
-            typeof payload.device?.state === 'string'
-                ? { staticSessionId: validateStaticSessionId(payload.device.state) }
-                : payload.device?.state?.staticSessionId
-                  ? {
-                        staticSessionId: validateStaticSessionId(
-                            payload.device.state.staticSessionId,
-                        ),
-                    }
-                  : undefined;
+        this.deviceState = validateDeviceState(payload.device?.state);
         this.hasExpectedDeviceState = payload.device
             ? Object.prototype.hasOwnProperty.call(payload.device, 'state')
             : false;

--- a/packages/connect/src/types/device.ts
+++ b/packages/connect/src/types/device.ts
@@ -36,6 +36,7 @@ export type DeviceState = {
     sessionId?: string; // dynamic value: Features.session_id
     // ${first testnet address}@${device.features.device_id}:${device.instance}
     staticSessionId?: StaticSessionId;
+    deriveCardano?: boolean;
 };
 
 // NOTE: unavailableCapabilities is an object with information what is NOT supported by this device.

--- a/packages/connect/src/types/params.ts
+++ b/packages/connect/src/types/params.ts
@@ -6,12 +6,12 @@ import { ErrorCode } from '../constants/errors';
 
 export interface DeviceIdentity {
     path?: string;
-    state?: string | DeviceState;
+    state?: DeviceState;
     instance?: number;
 }
 
 export interface CommonParams {
-    device?: DeviceIdentity;
+    device?: DeviceIdentity & { state?: DeviceState | string }; // Note: state as string should be removed https://github.com/trezor/trezor-suite/issues/12710
     useEmptyPassphrase?: boolean;
     useEventListener?: boolean; // this param is set automatically in factory
     allowSeedlessDevice?: boolean;


### PR DESCRIPTION
## Description

`DeviceState` contains all the information to call `Initialize` message and potentially reuse already initialized session on the device.

This should fix the issue with app reload and entering the passphrase.

## Follow up
- i didnt change connect storage loadState() cc @mroz22 

## Related Issue

Related to [Epic connect 10 ](https://github.com/trezor/trezor-suite/issues/12710): Device.state as string > DeviceState
