### PR TITLE
feat(connect): uncouple enableFirmwareHashCheck setting from binFilesBaseUrl

### DIFF
--- a/packages/connect/src/data/connectSettings.ts
+++ b/packages/connect/src/data/connectSettings.ts
@@ -154,5 +154,9 @@ export const parseConnectSettings = (input: Partial<ConnectSettings> = {}) => {
         settings.binFilesBaseUrl = input.binFilesBaseUrl;
     }
 
+    if (typeof input.enableFirmwareHashCheck === 'boolean') {
+        settings.enableFirmwareHashCheck = Boolean(input.enableFirmwareHashCheck);
+    }
+
     return settings;
 };

--- a/packages/connect/src/types/settings.ts
+++ b/packages/connect/src/types/settings.ts
@@ -33,8 +33,10 @@ export interface ConnectSettingsPublic {
     _sessionsBackgroundUrl?: string;
     deeplinkOpen?: (url: string) => void;
     deeplinkCallbackUrl?: string;
-    // URL for binary files such as firmware, may be local or remote. If not provided, firmware hash check won't be done.
+    // URL for binary files such as firmware, may be local or remote
     binFilesBaseUrl?: string;
+    // enable firmware hash check automatically when device connects. Requires binFilesBaseUrl to be set.
+    enableFirmwareHashCheck?: boolean;
 }
 
 // internal part, not to be accepted from .init()

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -53,6 +53,7 @@ const connectInitSettings = {
         appUrl: '@trezor/suite',
     },
     sharedLogger: false,
+    enableFirmwareHashCheck: true,
 };
 
 export const extraDependencies: ExtraDependencies = {


### PR DESCRIPTION
## Description

Code cleanup after #14766. On second thoughts, I think it is quite obscure that supplying `binFilesBaseUrl` also incidentally turns on automatic firmware hash check, and explicitly supplying the flag is cleaner.