### PR TITLE
chore(connect): split types of different Connect implementations

### DIFF
--- a/packages/connect-explorer/src/actions/methodActions.ts
+++ b/packages/connect-explorer/src/actions/methodActions.ts
@@ -1,7 +1,7 @@
 import { TSchema } from '@sinclair/typebox';
 import JSON5 from 'json5';
 
-import TrezorConnect from '@trezor/connect-web';
+import TrezorConnect, { TrezorConnect as TrezorConnectType } from '@trezor/connect-web';
 import TrezorConnectMobile from '@trezor/connect-mobile';
 import { getDeepValue } from '@trezor/schema-utils/src/utils';
 
@@ -20,7 +20,7 @@ export const SET_METHOD_PROCESSING = 'method_set_processing';
 
 export type MethodAction =
     | { type: typeof SET_METHOD; methodConfig: any }
-    | { type: typeof SET_SCHEMA; method: keyof typeof TrezorConnect; schema: TSchema }
+    | { type: typeof SET_SCHEMA; method: keyof TrezorConnectType; schema: TSchema }
     | { type: typeof FIELD_CHANGE; field: Field<any>; value: any }
     | { type: typeof FIELD_DATA_CHANGE; field: Field<any>; data: any }
     | { type: typeof ADD_BATCH; field: Field<any>; item: any }

--- a/packages/connect-explorer/src/reducers/methodCommon.ts
+++ b/packages/connect-explorer/src/reducers/methodCommon.ts
@@ -1,11 +1,11 @@
-import TrezorConnect from '@trezor/connect-web';
+import type { TrezorConnect } from '@trezor/connect-web';
 import { TSchema } from '@trezor/schema-utils';
 import { setDeepValue } from '@trezor/schema-utils/src/utils';
 
 import { Field, FieldBasic, isFieldBasic } from '../types';
 
 export interface MethodState {
-    name?: keyof typeof TrezorConnect;
+    name?: keyof TrezorConnect;
     submitButton?: string;
     fields: Field<unknown>[];
     params: Record<string, unknown>;

--- a/packages/connect-explorer/src/reducers/methodInit.ts
+++ b/packages/connect-explorer/src/reducers/methodInit.ts
@@ -1,6 +1,6 @@
 import { TSchema, Kind, OptionalKind } from '@sinclair/typebox';
 
-import type TrezorConnect from '@trezor/connect-web';
+import type { TrezorConnect } from '@trezor/connect-web';
 
 import {
     MethodState,
@@ -165,7 +165,7 @@ export const getMethodState = (methodConfig?: Partial<MethodState>) => {
 };
 
 // Get method state from TypeBox schema
-export const getMethodStateFromSchema = (method: keyof typeof TrezorConnect, schema: TSchema) => {
+export const getMethodStateFromSchema = (method: keyof TrezorConnect, schema: TSchema) => {
     return {
         ...getMethodState({
             name: method,

--- a/packages/connect-iframe/src/connectSettings.ts
+++ b/packages/connect-iframe/src/connectSettings.ts
@@ -76,7 +76,6 @@ export const parseConnectSettings = (
     }
 
     if (disableWebUsb) {
-        settings.webusb = false;
         // allow all but WebUsbTransport
         settings.transports = settings.transports?.filter(
             transport => transport !== 'WebUsbTransport',

--- a/packages/connect-web/src/iframe/index.ts
+++ b/packages/connect-web/src/iframe/index.ts
@@ -85,9 +85,6 @@ export const init = async (settings: ConnectSettings) => {
     }
 
     instance.setAttribute('src', src);
-    if (settings.webusb) {
-        console.warn('webusb option is deprecated. use `transports: ["WebUsbTransport"] instead`');
-    }
     if (navigator.usb) {
         instance.setAttribute('allow', 'usb');
     }

--- a/packages/connect-web/src/impl/core-in-popup.ts
+++ b/packages/connect-web/src/impl/core-in-popup.ts
@@ -13,7 +13,7 @@ import {
 import * as ERRORS from '@trezor/connect/src/constants/errors';
 import type {
     ConnectSettings,
-    ConnectSettingsPublic,
+    ConnectSettingsWeb,
     Manifest,
     Response,
 } from '@trezor/connect/src/types';
@@ -24,12 +24,13 @@ import * as popup from '../popup';
 import { parseConnectSettings } from '../connectSettings';
 import { Login } from '@trezor/connect/src/types/api/requestLogin';
 import { createDeferred } from '@trezor/utils';
+import { InitFullSettings } from '@trezor/connect/src/types/api/init';
 
 /**
  * Base class for CoreInPopup methods for TrezorConnect factory.
  * This implementation is directly used here in connect-web, but it is also extended in connect-webextension.
  */
-export class CoreInPopup implements ConnectFactoryDependencies {
+export class CoreInPopup implements ConnectFactoryDependencies<ConnectSettingsWeb> {
     public eventEmitter = new EventEmitter();
     protected _settings: ConnectSettings;
 
@@ -81,7 +82,7 @@ export class CoreInPopup implements ConnectFactoryDependencies {
         }
     }
 
-    public init(settings: Partial<ConnectSettingsPublic> = {}): Promise<void> {
+    public init(settings: InitFullSettings<{}>): Promise<void> {
         const oldSettings = parseConnectSettings({
             ...this._settings,
         });
@@ -240,9 +241,6 @@ export const TrezorConnect = factory({
     manifest: impl.manifest.bind(impl),
     requestLogin: impl.requestLogin.bind(impl),
     uiResponse: impl.uiResponse.bind(impl),
-    renderWebUSBButton: impl.renderWebUSBButton.bind(impl),
-    disableWebUSB: impl.disableWebUSB.bind(impl),
-    requestWebUSBDevice: impl.requestWebUSBDevice.bind(impl),
     cancel: impl.cancel.bind(impl),
     dispose: impl.dispose.bind(impl),
 });

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -53,8 +53,7 @@ const impl = new TrezorConnectDynamic<
             // Check if WebUSB is available and enabled
             const webUsbUnavailableInBrowser = !(navigator as any)?.usb;
             const webUsbDisabledInSettings =
-                impl.lastSettings?.transports?.includes('WebUsbTransport') === false ||
-                impl.lastSettings?.webusb === false;
+                impl.lastSettings?.transports?.includes('WebUsbTransport') === false;
             if (
                 errorCode === 'Transport_Missing' &&
                 (webUsbUnavailableInBrowser || webUsbDisabledInSettings)

--- a/packages/connect-webextension/src/index.ts
+++ b/packages/connect-webextension/src/index.ts
@@ -3,13 +3,14 @@ import {
     POPUP,
     ConnectSettings,
     Manifest,
-    ConnectSettingsPublic,
+    ConnectSettingsWebextension,
 } from '@trezor/connect/src/exports';
 import { factory } from '@trezor/connect/src/factory';
 import { initLog } from '@trezor/connect/src/utils/debug';
 // Import as src not lib due to webpack issues with inlining content script later
 import { ServiceWorkerWindowChannel } from '@trezor/connect-web/src/channels/serviceworker-window';
 import { CoreInPopup } from '@trezor/connect-web/src/impl/core-in-popup';
+import { InitFullSettings } from '@trezor/connect/src/types/api/init';
 
 import { parseConnectSettings } from './connectSettings';
 
@@ -41,7 +42,7 @@ class CoreInPopupWebextension extends CoreInPopup {
         this.popupManagerLogger = initLog('@trezor/connect-webextension/popupManager');
     }
 
-    public init(settings: Partial<ConnectSettingsPublic> = {}): Promise<void> {
+    public init(settings: InitFullSettings<ConnectSettingsWebextension>): Promise<void> {
         if (settings._extendWebextensionLifetime) {
             extendLifetime();
         }
@@ -59,9 +60,6 @@ const TrezorConnect = factory({
     manifest: methods.manifest.bind(methods),
     requestLogin: methods.requestLogin.bind(methods),
     uiResponse: methods.uiResponse.bind(methods),
-    renderWebUSBButton: methods.renderWebUSBButton.bind(methods),
-    disableWebUSB: methods.disableWebUSB.bind(methods),
-    requestWebUSBDevice: methods.requestWebUSBDevice.bind(methods),
     cancel: methods.cancel.bind(methods),
     dispose: methods.dispose.bind(methods),
 });

--- a/packages/connect-webextension/src/proxy/index.ts
+++ b/packages/connect-webextension/src/proxy/index.ts
@@ -103,23 +103,8 @@ const uiResponse = () => {
     throw ERRORS.TypedError('Method_InvalidPackage');
 };
 
-const renderWebUSBButton = () => {
-    // Not needed here - webUSB pairing happens in popup.
-    throw ERRORS.TypedError('Method_InvalidPackage');
-};
-
 const requestLogin = () => {
     // Not needed here - Not used here.
-    throw ERRORS.TypedError('Method_InvalidPackage');
-};
-
-const disableWebUSB = () => {
-    // Not needed here - webUSB pairing happens in popup.
-    throw ERRORS.TypedError('Method_InvalidPackage');
-};
-
-const requestWebUSBDevice = () => {
-    // Not needed here - webUSB pairing happens in popup.
     throw ERRORS.TypedError('Method_InvalidPackage');
 };
 
@@ -130,9 +115,6 @@ const TrezorConnect = factory({
     call,
     requestLogin,
     uiResponse,
-    renderWebUSBButton,
-    disableWebUSB,
-    requestWebUSBDevice,
     cancel,
     dispose,
 });

--- a/packages/connect/src/constants/utxo.ts
+++ b/packages/connect/src/constants/utxo.ts
@@ -1,3 +1,3 @@
-import type { TransactionInputOutputSortingStrategy } from '@trezor/utxo-lib/libDev/src';
+import type { TransactionInputOutputSortingStrategy } from '@trezor/utxo-lib';
 
 export const DEFAULT_SORTING_STRATEGY: TransactionInputOutputSortingStrategy = 'bip69';

--- a/packages/connect/src/data/connectSettings.ts
+++ b/packages/connect/src/data/connectSettings.ts
@@ -90,11 +90,6 @@ export const parseConnectSettings = (input: Partial<ConnectSettings> = {}) => {
         settings.transportReconnect = input.transportReconnect;
     }
 
-    // deprecated, settings.transport should be used instead
-    if (typeof input.webusb === 'boolean') {
-        settings.webusb = input.webusb;
-    }
-
     if (Array.isArray(input.transports)) {
         settings.transports = input.transports;
     }

--- a/packages/connect/src/factory.ts
+++ b/packages/connect/src/factory.ts
@@ -2,270 +2,260 @@ import { UI } from './events';
 import type { EventEmitter } from 'events';
 import type { TrezorConnect } from './types';
 import type { CallMethod } from './events/call';
+import type { InitType } from './types/api/init';
 
-export interface ConnectFactoryDependencies {
+export interface ConnectFactoryDependencies<SettingsType extends Record<string, any>> {
+    init: InitType<SettingsType>;
     call: CallMethod;
     eventEmitter: EventEmitter;
     manifest: TrezorConnect['manifest'];
-    init: TrezorConnect['init'];
     requestLogin: TrezorConnect['requestLogin'];
     uiResponse: TrezorConnect['uiResponse'];
-    renderWebUSBButton: TrezorConnect['renderWebUSBButton'];
-    disableWebUSB: TrezorConnect['disableWebUSB'];
-    requestWebUSBDevice: TrezorConnect['requestWebUSBDevice'];
     cancel: TrezorConnect['cancel'];
     dispose: TrezorConnect['dispose'];
 }
 
-export const factory = ({
-    eventEmitter,
-    manifest,
-    init,
-    call,
-    requestLogin,
-    uiResponse,
-    renderWebUSBButton,
-    disableWebUSB,
-    requestWebUSBDevice,
-    cancel,
-    dispose,
-}: ConnectFactoryDependencies): TrezorConnect => {
-    const api: TrezorConnect = {
+export const factory = <
+    SettingsType extends Record<string, any>,
+    ExtraMethodsType extends Record<string, any>,
+>(
+    {
+        eventEmitter,
         manifest,
         init,
-        getSettings: () => call({ method: 'getSettings' }),
-
-        on: <T extends string, P extends (...args: any[]) => any>(type: T, fn: P) => {
-            eventEmitter.on(type, fn);
-        },
-
-        off: (type, fn) => {
-            eventEmitter.removeListener(type, fn);
-        },
-
-        removeAllListeners: type => {
-            if (typeof type === 'string') {
-                eventEmitter.removeAllListeners(type);
-            } else {
-                eventEmitter.removeAllListeners();
-            }
-        },
-
+        call,
+        requestLogin,
         uiResponse,
-
-        // methods
-
-        blockchainGetAccountBalanceHistory: params =>
-            call({ ...params, method: 'blockchainGetAccountBalanceHistory' }),
-
-        blockchainGetCurrentFiatRates: params =>
-            call({ ...params, method: 'blockchainGetCurrentFiatRates' }),
-
-        blockchainGetFiatRatesForTimestamps: params =>
-            call({ ...params, method: 'blockchainGetFiatRatesForTimestamps' }),
-
-        blockchainDisconnect: params => call({ ...params, method: 'blockchainDisconnect' }),
-
-        blockchainEstimateFee: params => call({ ...params, method: 'blockchainEstimateFee' }),
-
-        blockchainGetTransactions: params =>
-            call({ ...params, method: 'blockchainGetTransactions' }),
-
-        blockchainSetCustomBackend: params =>
-            call({ ...params, method: 'blockchainSetCustomBackend' }),
-
-        blockchainSubscribe: params => call({ ...params, method: 'blockchainSubscribe' }),
-
-        blockchainSubscribeFiatRates: params =>
-            call({ ...params, method: 'blockchainSubscribeFiatRates' }),
-
-        blockchainUnsubscribe: params => call({ ...params, method: 'blockchainUnsubscribe' }),
-
-        blockchainUnsubscribeFiatRates: params =>
-            call({ ...params, method: 'blockchainUnsubscribeFiatRates' }),
-
-        requestLogin: params => requestLogin(params),
-
-        cardanoGetAddress: params =>
-            call({
-                ...params,
-                method: 'cardanoGetAddress',
-                useEventListener: eventEmitter.listenerCount(UI.ADDRESS_VALIDATION) > 0,
-            }),
-
-        cardanoGetNativeScriptHash: params =>
-            call({ ...params, method: 'cardanoGetNativeScriptHash' }),
-
-        cardanoGetPublicKey: params => call({ ...params, method: 'cardanoGetPublicKey' }),
-
-        cardanoSignTransaction: params => call({ ...params, method: 'cardanoSignTransaction' }),
-
-        cardanoComposeTransaction: params =>
-            call({ ...params, method: 'cardanoComposeTransaction' }),
-
-        cipherKeyValue: params => call({ ...params, method: 'cipherKeyValue' }),
-
-        composeTransaction: params => call({ ...params, method: 'composeTransaction' }),
-
-        ethereumGetAddress: params =>
-            call({
-                ...params,
-                method: 'ethereumGetAddress',
-                useEventListener: eventEmitter.listenerCount(UI.ADDRESS_VALIDATION) > 0,
-            }),
-
-        ethereumGetPublicKey: params => call({ ...params, method: 'ethereumGetPublicKey' }),
-
-        ethereumSignMessage: params => call({ ...params, method: 'ethereumSignMessage' }),
-
-        ethereumSignTransaction: params => call({ ...params, method: 'ethereumSignTransaction' }),
-
-        // @ts-expect-error generic param
-        ethereumSignTypedData: params => call({ ...params, method: 'ethereumSignTypedData' }),
-
-        ethereumVerifyMessage: params => call({ ...params, method: 'ethereumVerifyMessage' }),
-
-        getAccountDescriptor: params => call({ ...params, method: 'getAccountDescriptor' }),
-
-        getAccountInfo: params => call({ ...params, method: 'getAccountInfo' }),
-
-        getAddress: params =>
-            call({
-                ...params,
-                method: 'getAddress',
-                useEventListener: eventEmitter.listenerCount(UI.ADDRESS_VALIDATION) > 0,
-            }),
-
-        getDeviceState: params => call({ ...params, method: 'getDeviceState' }),
-
-        getFeatures: params => call({ ...params, method: 'getFeatures' }),
-
-        getFirmwareHash: params => call({ ...params, method: 'getFirmwareHash' }),
-
-        getOwnershipId: params => call({ ...params, method: 'getOwnershipId' }),
-
-        getOwnershipProof: params => call({ ...params, method: 'getOwnershipProof' }),
-
-        getPublicKey: params => call({ ...params, method: 'getPublicKey' }),
-
-        nemGetAddress: params =>
-            call({
-                ...params,
-                method: 'nemGetAddress',
-                useEventListener: eventEmitter.listenerCount(UI.ADDRESS_VALIDATION) > 0,
-            }),
-
-        nemSignTransaction: params => call({ ...params, method: 'nemSignTransaction' }),
-
-        pushTransaction: params => call({ ...params, method: 'pushTransaction' }),
-
-        rippleGetAddress: params =>
-            call({
-                ...params,
-                method: 'rippleGetAddress',
-                useEventListener: eventEmitter.listenerCount(UI.ADDRESS_VALIDATION) > 0,
-            }),
-
-        rippleSignTransaction: params => call({ ...params, method: 'rippleSignTransaction' }),
-
-        signMessage: params => call({ ...params, method: 'signMessage' }),
-
-        signTransaction: params => call({ ...params, method: 'signTransaction' }),
-
-        solanaGetPublicKey: params => call({ ...params, method: 'solanaGetPublicKey' }),
-
-        solanaGetAddress: params => call({ ...params, method: 'solanaGetAddress' }),
-
-        solanaSignTransaction: params => call({ ...params, method: 'solanaSignTransaction' }),
-
-        stellarGetAddress: params =>
-            call({
-                ...params,
-                method: 'stellarGetAddress',
-                useEventListener: eventEmitter.listenerCount(UI.ADDRESS_VALIDATION) > 0,
-            }),
-
-        stellarSignTransaction: params => call({ ...params, method: 'stellarSignTransaction' }),
-
-        tezosGetAddress: params =>
-            call({
-                ...params,
-                method: 'tezosGetAddress',
-                useEventListener: eventEmitter.listenerCount(UI.ADDRESS_VALIDATION) > 0,
-            }),
-
-        tezosGetPublicKey: params => call({ ...params, method: 'tezosGetPublicKey' }),
-
-        tezosSignTransaction: params => call({ ...params, method: 'tezosSignTransaction' }),
-
-        unlockPath: params => call({ ...params, method: 'unlockPath' }),
-
-        eosGetPublicKey: params => call({ ...params, method: 'eosGetPublicKey' }),
-
-        eosSignTransaction: params => call({ ...params, method: 'eosSignTransaction' }),
-
-        binanceGetAddress: params =>
-            call({
-                ...params,
-                method: 'binanceGetAddress',
-                useEventListener: eventEmitter.listenerCount(UI.ADDRESS_VALIDATION) > 0,
-            }),
-
-        binanceGetPublicKey: params => call({ ...params, method: 'binanceGetPublicKey' }),
-
-        binanceSignTransaction: params => call({ ...params, method: 'binanceSignTransaction' }),
-
-        verifyMessage: params => call({ ...params, method: 'verifyMessage' }),
-
-        resetDevice: params => call({ ...params, method: 'resetDevice' }),
-
-        wipeDevice: params => call({ ...params, method: 'wipeDevice' }),
-
-        applyFlags: params => call({ ...params, method: 'applyFlags' }),
-
-        applySettings: params => call({ ...params, method: 'applySettings' }),
-
-        authenticateDevice: params => call({ ...params, method: 'authenticateDevice' }),
-
-        authorizeCoinjoin: params => call({ ...params, method: 'authorizeCoinjoin' }),
-
-        cancelCoinjoinAuthorization: params =>
-            call({ ...params, method: 'cancelCoinjoinAuthorization' }),
-
-        showDeviceTutorial: params => call({ ...params, method: 'showDeviceTutorial' }),
-
-        backupDevice: params => call({ ...params, method: 'backupDevice' }),
-
-        changeLanguage: params => call({ ...params, method: 'changeLanguage' }),
-
-        changePin: params => call({ ...params, method: 'changePin' }),
-
-        changeWipeCode: params => call({ ...params, method: 'changeWipeCode' }),
-
-        firmwareUpdate: params => call({ ...params, method: 'firmwareUpdate' }),
-
-        recoveryDevice: params => call({ ...params, method: 'recoveryDevice' }),
-
-        getCoinInfo: params => call({ ...params, method: 'getCoinInfo' }),
-
-        rebootToBootloader: params => call({ ...params, method: 'rebootToBootloader' }),
-
-        setBrightness: params => call({ ...params, method: 'setBrightness' }),
-
-        setBusy: params => call({ ...params, method: 'setBusy' }),
-
-        setProxy: params => call({ ...params, method: 'setProxy' }),
-
-        dispose,
-
         cancel,
+        dispose,
+    }: ConnectFactoryDependencies<SettingsType>,
+    extraMethods: ExtraMethodsType = {} as ExtraMethodsType,
+): Omit<TrezorConnect, 'init'> & { init: InitType<SettingsType> } & ExtraMethodsType => ({
+    manifest,
+    init,
 
-        renderWebUSBButton,
+    on: <T extends string, P extends (...args: any[]) => any>(type: T, fn: P) => {
+        eventEmitter.on(type, fn);
+    },
 
-        disableWebUSB,
+    off: (type, fn) => {
+        eventEmitter.removeListener(type, fn);
+    },
 
-        requestWebUSBDevice,
-    };
+    removeAllListeners: type => {
+        if (typeof type === 'string') {
+            eventEmitter.removeAllListeners(type);
+        } else {
+            eventEmitter.removeAllListeners();
+        }
+    },
 
-    return api;
-};
+    uiResponse,
+
+    // methods
+
+    blockchainGetAccountBalanceHistory: params =>
+        call({ ...params, method: 'blockchainGetAccountBalanceHistory' }),
+
+    blockchainGetCurrentFiatRates: params =>
+        call({ ...params, method: 'blockchainGetCurrentFiatRates' }),
+
+    blockchainGetFiatRatesForTimestamps: params =>
+        call({ ...params, method: 'blockchainGetFiatRatesForTimestamps' }),
+
+    blockchainDisconnect: params => call({ ...params, method: 'blockchainDisconnect' }),
+
+    blockchainEstimateFee: params => call({ ...params, method: 'blockchainEstimateFee' }),
+
+    blockchainGetTransactions: params => call({ ...params, method: 'blockchainGetTransactions' }),
+
+    blockchainSetCustomBackend: params => call({ ...params, method: 'blockchainSetCustomBackend' }),
+
+    blockchainSubscribe: params => call({ ...params, method: 'blockchainSubscribe' }),
+
+    blockchainSubscribeFiatRates: params =>
+        call({ ...params, method: 'blockchainSubscribeFiatRates' }),
+
+    blockchainUnsubscribe: params => call({ ...params, method: 'blockchainUnsubscribe' }),
+
+    blockchainUnsubscribeFiatRates: params =>
+        call({ ...params, method: 'blockchainUnsubscribeFiatRates' }),
+
+    requestLogin: params => requestLogin(params),
+
+    cardanoGetAddress: params =>
+        call({
+            ...params,
+            method: 'cardanoGetAddress',
+            useEventListener: eventEmitter.listenerCount(UI.ADDRESS_VALIDATION) > 0,
+        }),
+
+    cardanoGetNativeScriptHash: params => call({ ...params, method: 'cardanoGetNativeScriptHash' }),
+
+    cardanoGetPublicKey: params => call({ ...params, method: 'cardanoGetPublicKey' }),
+
+    cardanoSignTransaction: params => call({ ...params, method: 'cardanoSignTransaction' }),
+
+    cardanoComposeTransaction: params => call({ ...params, method: 'cardanoComposeTransaction' }),
+
+    cipherKeyValue: params => call({ ...params, method: 'cipherKeyValue' }),
+
+    composeTransaction: params => call({ ...params, method: 'composeTransaction' }),
+
+    ethereumGetAddress: params =>
+        call({
+            ...params,
+            method: 'ethereumGetAddress',
+            useEventListener: eventEmitter.listenerCount(UI.ADDRESS_VALIDATION) > 0,
+        }),
+
+    ethereumGetPublicKey: params => call({ ...params, method: 'ethereumGetPublicKey' }),
+
+    ethereumSignMessage: params => call({ ...params, method: 'ethereumSignMessage' }),
+
+    ethereumSignTransaction: params => call({ ...params, method: 'ethereumSignTransaction' }),
+
+    // @ts-expect-error generic param
+    ethereumSignTypedData: params => call({ ...params, method: 'ethereumSignTypedData' }),
+
+    ethereumVerifyMessage: params => call({ ...params, method: 'ethereumVerifyMessage' }),
+
+    getAccountDescriptor: params => call({ ...params, method: 'getAccountDescriptor' }),
+
+    getAccountInfo: params => call({ ...params, method: 'getAccountInfo' }),
+
+    getAddress: params =>
+        call({
+            ...params,
+            method: 'getAddress',
+            useEventListener: eventEmitter.listenerCount(UI.ADDRESS_VALIDATION) > 0,
+        }),
+
+    getDeviceState: params => call({ ...params, method: 'getDeviceState' }),
+
+    getFeatures: params => call({ ...params, method: 'getFeatures' }),
+
+    getFirmwareHash: params => call({ ...params, method: 'getFirmwareHash' }),
+
+    getOwnershipId: params => call({ ...params, method: 'getOwnershipId' }),
+
+    getOwnershipProof: params => call({ ...params, method: 'getOwnershipProof' }),
+
+    getPublicKey: params => call({ ...params, method: 'getPublicKey' }),
+
+    nemGetAddress: params =>
+        call({
+            ...params,
+            method: 'nemGetAddress',
+            useEventListener: eventEmitter.listenerCount(UI.ADDRESS_VALIDATION) > 0,
+        }),
+
+    nemSignTransaction: params => call({ ...params, method: 'nemSignTransaction' }),
+
+    pushTransaction: params => call({ ...params, method: 'pushTransaction' }),
+
+    rippleGetAddress: params =>
+        call({
+            ...params,
+            method: 'rippleGetAddress',
+            useEventListener: eventEmitter.listenerCount(UI.ADDRESS_VALIDATION) > 0,
+        }),
+
+    rippleSignTransaction: params => call({ ...params, method: 'rippleSignTransaction' }),
+
+    signMessage: params => call({ ...params, method: 'signMessage' }),
+
+    signTransaction: params => call({ ...params, method: 'signTransaction' }),
+
+    solanaGetPublicKey: params => call({ ...params, method: 'solanaGetPublicKey' }),
+
+    solanaGetAddress: params => call({ ...params, method: 'solanaGetAddress' }),
+
+    solanaSignTransaction: params => call({ ...params, method: 'solanaSignTransaction' }),
+
+    stellarGetAddress: params =>
+        call({
+            ...params,
+            method: 'stellarGetAddress',
+            useEventListener: eventEmitter.listenerCount(UI.ADDRESS_VALIDATION) > 0,
+        }),
+
+    stellarSignTransaction: params => call({ ...params, method: 'stellarSignTransaction' }),
+
+    tezosGetAddress: params =>
+        call({
+            ...params,
+            method: 'tezosGetAddress',
+            useEventListener: eventEmitter.listenerCount(UI.ADDRESS_VALIDATION) > 0,
+        }),
+
+    tezosGetPublicKey: params => call({ ...params, method: 'tezosGetPublicKey' }),
+
+    tezosSignTransaction: params => call({ ...params, method: 'tezosSignTransaction' }),
+
+    unlockPath: params => call({ ...params, method: 'unlockPath' }),
+
+    eosGetPublicKey: params => call({ ...params, method: 'eosGetPublicKey' }),
+
+    eosSignTransaction: params => call({ ...params, method: 'eosSignTransaction' }),
+
+    binanceGetAddress: params =>
+        call({
+            ...params,
+            method: 'binanceGetAddress',
+            useEventListener: eventEmitter.listenerCount(UI.ADDRESS_VALIDATION) > 0,
+        }),
+
+    binanceGetPublicKey: params => call({ ...params, method: 'binanceGetPublicKey' }),
+
+    binanceSignTransaction: params => call({ ...params, method: 'binanceSignTransaction' }),
+
+    verifyMessage: params => call({ ...params, method: 'verifyMessage' }),
+
+    resetDevice: params => call({ ...params, method: 'resetDevice' }),
+
+    wipeDevice: params => call({ ...params, method: 'wipeDevice' }),
+
+    applyFlags: params => call({ ...params, method: 'applyFlags' }),
+
+    applySettings: params => call({ ...params, method: 'applySettings' }),
+
+    getSettings: () => call({ method: 'getSettings' }),
+
+    authenticateDevice: params => call({ ...params, method: 'authenticateDevice' }),
+
+    authorizeCoinjoin: params => call({ ...params, method: 'authorizeCoinjoin' }),
+
+    cancelCoinjoinAuthorization: params =>
+        call({ ...params, method: 'cancelCoinjoinAuthorization' }),
+
+    showDeviceTutorial: params => call({ ...params, method: 'showDeviceTutorial' }),
+
+    backupDevice: params => call({ ...params, method: 'backupDevice' }),
+
+    changeLanguage: params => call({ ...params, method: 'changeLanguage' }),
+
+    changePin: params => call({ ...params, method: 'changePin' }),
+
+    changeWipeCode: params => call({ ...params, method: 'changeWipeCode' }),
+
+    firmwareUpdate: params => call({ ...params, method: 'firmwareUpdate' }),
+
+    recoveryDevice: params => call({ ...params, method: 'recoveryDevice' }),
+
+    getCoinInfo: params => call({ ...params, method: 'getCoinInfo' }),
+
+    rebootToBootloader: params => call({ ...params, method: 'rebootToBootloader' }),
+
+    setBrightness: params => call({ ...params, method: 'setBrightness' }),
+
+    setBusy: params => call({ ...params, method: 'setBusy' }),
+
+    setProxy: params => call({ ...params, method: 'setProxy' }),
+
+    dispose,
+
+    cancel,
+
+    ...extraMethods,
+});

--- a/packages/connect/src/index-browser.ts
+++ b/packages/connect/src/index-browser.ts
@@ -17,10 +17,7 @@ const TrezorConnect = factory({
     init: fallback,
     call: fallback,
     requestLogin: fallback,
-    requestWebUSBDevice: fallback,
     uiResponse: fallback,
-    renderWebUSBButton: fallback,
-    disableWebUSB: fallback,
     cancel: fallback,
     dispose: fallback,
 });

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -208,31 +208,19 @@ const cancel = (error?: string) => {
     });
 };
 
-const renderWebUSBButton = (_className?: string) => {
-    throw ERRORS.TypedError('Method_InvalidPackage');
-};
-
-const disableWebUSB = () => {
-    throw ERRORS.TypedError('Method_InvalidPackage');
-};
-
-const requestWebUSBDevice = () => {
-    throw ERRORS.TypedError('Method_InvalidPackage');
-};
-
-const TrezorConnect = factory({
-    eventEmitter,
-    manifest,
-    init,
-    call,
-    requestLogin,
-    uiResponse,
-    renderWebUSBButton,
-    disableWebUSB,
-    requestWebUSBDevice,
-    cancel,
-    dispose,
-});
+const TrezorConnect = factory(
+    {
+        eventEmitter,
+        manifest,
+        init,
+        call,
+        requestLogin,
+        uiResponse,
+        cancel,
+        dispose,
+    },
+    {},
+);
 
 export default TrezorConnect;
 export * from './exports';

--- a/packages/connect/src/types/api/__tests__/index.ts
+++ b/packages/connect/src/types/api/__tests__/index.ts
@@ -32,6 +32,4 @@ export const init = async (api: TrezorConnect) => {
     api.dispose();
     api.cancel();
     api.cancel('Interruption error');
-    api.renderWebUSBButton();
-    api.disableWebUSB();
 };

--- a/packages/connect/src/types/api/index.ts
+++ b/packages/connect/src/types/api/index.ts
@@ -29,7 +29,6 @@ import { changePin } from './changePin';
 import { changeWipeCode } from './changeWipeCode';
 import { cipherKeyValue } from './cipherKeyValue';
 import { composeTransaction } from './composeTransaction';
-import { disableWebUSB } from './disableWebUSB';
 import { dispose } from './dispose';
 import { eosGetPublicKey } from './eosGetPublicKey';
 import { eosSignTransaction } from './eosSignTransaction';
@@ -61,9 +60,7 @@ import { pushTransaction } from './pushTransaction';
 import { rebootToBootloader } from './rebootToBootloader';
 import { recoveryDevice } from './recoveryDevice';
 import { removeAllListeners } from './removeAllListeners';
-import { renderWebUSBButton } from './renderWebUSBButton';
 import { requestLogin } from './requestLogin';
-import { requestWebUSBDevice } from './requestWebUSBDevice';
 import { resetDevice } from './resetDevice';
 import { rippleGetAddress } from './rippleGetAddress';
 import { rippleSignTransaction } from './rippleSignTransaction';
@@ -184,12 +181,6 @@ export interface TrezorConnect {
     composeTransaction: typeof composeTransaction;
 
     // todo: link docs
-    disableWebUSB: typeof disableWebUSB;
-
-    // todo: link docs
-    requestWebUSBDevice: typeof requestWebUSBDevice;
-
-    // todo: link docs
     dispose: typeof dispose;
 
     // https://connect.trezor.io/9/methods/eos/eosGetPublicKey/
@@ -281,9 +272,6 @@ export interface TrezorConnect {
 
     // todo link docs
     removeAllListeners: typeof removeAllListeners;
-
-    // todo link docs
-    renderWebUSBButton: typeof renderWebUSBButton;
 
     // https://connect.trezor.io/9/methods/other/requestLogin/
     requestLogin: typeof requestLogin;

--- a/packages/connect/src/types/api/init.ts
+++ b/packages/connect/src/types/api/init.ts
@@ -5,6 +5,17 @@
 
 import type { ConnectSettingsPublic, Manifest } from '../settings';
 
-export declare function init(
-    settings: { manifest: Manifest } & Partial<ConnectSettingsPublic>,
+// explicitly don't overlap types
+export type InitFullSettings<ExtraSettingsType extends Record<string, any>> = {
+    manifest: Manifest;
+} & Partial<
+    Omit<ConnectSettingsPublic, 'manifest'> & Omit<ExtraSettingsType, keyof ConnectSettingsPublic>
+>;
+
+export type InitType<ExtraSettingsType extends Record<string, any>> = (
+    settings: InitFullSettings<ExtraSettingsType>,
+) => Promise<void>;
+
+export declare function init<ExtraSettingsType extends Record<string, any>>(
+    settings: InitFullSettings<ExtraSettingsType>,
 ): Promise<void>;

--- a/packages/connect/src/types/settings.ts
+++ b/packages/connect/src/types/settings.ts
@@ -15,8 +15,6 @@ export interface ConnectSettingsPublic {
     debug?: boolean;
     popup?: boolean;
     transportReconnect?: boolean;
-    /** @deprecated */
-    webusb?: boolean;
     transports?: (Transport['name'] | Transport | (new (...args: any[]) => Transport))[];
     pendingTransportEvent?: boolean;
     lazyLoad?: boolean;

--- a/packages/connect/src/types/settings.ts
+++ b/packages/connect/src/types/settings.ts
@@ -13,27 +13,20 @@ export interface ConnectSettingsPublic {
     manifest?: Manifest;
     connectSrc?: string;
     debug?: boolean;
-    hostLabel?: string;
-    hostIcon?: string;
     popup?: boolean;
     transportReconnect?: boolean;
-    webusb?: boolean; // deprecated
+    /** @deprecated */
+    webusb?: boolean;
     transports?: (Transport['name'] | Transport | (new (...args: any[]) => Transport))[];
     pendingTransportEvent?: boolean;
     lazyLoad?: boolean;
     interactionTimeout?: number;
     trustedHost: boolean;
-    coreMode?: 'auto' | 'popup' | 'iframe' | 'deeplink';
-    /* _extendWebextensionLifetime features makes the service worker in @trezor/connect-webextension stay alive longer */
-    _extendWebextensionLifetime?: boolean;
     /**
      * for internal use only!
      * in some exotic setups (suite-web where iframe is embedded locally), you might need to tell connect where it should search for sessions background shared-worker
      */
     _sessionsBackgroundUrl?: string;
-    // Options for Connect-mobile deep linking
-    deeplinkOpen?: (url: string) => void;
-    deeplinkCallbackUrl?: string;
     // URL for binary files such as firmware, may be local or remote
     binFilesBaseUrl?: string;
     // enable firmware hash check automatically when device connects. Requires binFilesBaseUrl to be set.
@@ -55,7 +48,25 @@ export interface ConnectSettingsInternal {
     proxy?: Proxy;
     sharedLogger?: boolean;
     useCoreInPopup?: boolean;
-    deeplinkUrl: string;
 }
 
-export type ConnectSettings = ConnectSettingsPublic & ConnectSettingsInternal;
+export interface ConnectSettingsWeb {
+    hostLabel?: string;
+    hostIcon?: string;
+    coreMode?: 'auto' | 'popup' | 'iframe' | 'deeplink';
+}
+export interface ConnectSettingsWebextension {
+    /** _extendWebextensionLifetime features makes the service worker in @trezor/connect-webextension stay alive longer */
+    _extendWebextensionLifetime?: boolean;
+}
+export interface ConnectSettingsMobile {
+    deeplinkUrl: string;
+    deeplinkOpen?: (url: string) => void;
+    deeplinkCallbackUrl?: string;
+}
+
+export type ConnectSettings = ConnectSettingsPublic &
+    ConnectSettingsInternal &
+    ConnectSettingsWeb &
+    ConnectSettingsWebextension &
+    ConnectSettingsMobile;

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -63,6 +63,7 @@
         "@trezor/coinjoin": "workspace:*",
         "@trezor/components": "workspace:*",
         "@trezor/connect": "workspace:*",
+        "@trezor/connect-web": "workspace:*",
         "@trezor/crypto-utils": "workspace:*",
         "@trezor/device-utils": "workspace:*",
         "@trezor/dom-utils": "workspace:*",

--- a/packages/suite/src/components/suite/QrCode.tsx
+++ b/packages/suite/src/components/suite/QrCode.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import { Icon, Tooltip, variables, intermediaryTheme } from '@trezor/components';
 import { Translation } from './Translation';
-import { CSSColor } from '@trezor/theme/libDev/src';
+import { CSSColor } from '@trezor/theme';
 
 export const QRCODE_SIZE = 384;
 export const QRCODE_PADDING = 12;

--- a/packages/suite/src/components/suite/WebUsbButton.tsx
+++ b/packages/suite/src/components/suite/WebUsbButton.tsx
@@ -1,4 +1,5 @@
 import TrezorConnect from '@trezor/connect';
+import type TrezorConnectWeb from '@trezor/connect-web';
 import { ButtonProps, Button, IconButton, Tooltip } from '@trezor/components';
 import { Translation, TranslationKey } from './Translation';
 
@@ -9,7 +10,7 @@ interface WebUsbButtonProps extends Omit<ButtonProps, 'children' | 'icon'> {
 
 const handleClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     e.stopPropagation();
-    TrezorConnect.requestWebUSBDevice();
+    (TrezorConnect as typeof TrezorConnectWeb).requestWebUSBDevice();
 };
 
 export const WebUsbButton = ({

--- a/packages/suite/src/components/suite/troubleshooting/TroubleshootingTips.tsx
+++ b/packages/suite/src/components/suite/troubleshooting/TroubleshootingTips.tsx
@@ -4,6 +4,7 @@ import { Translation, TrezorLink } from 'src/components/suite';
 import { variables, Button, CollapsibleBox, useElevation } from '@trezor/components';
 import { TREZOR_SUPPORT_DEVICE_URL } from '@trezor/urls';
 import TrezorConnect from '@trezor/connect';
+import type TrezorConnectWeb from '@trezor/connect-web';
 import { isAndroid } from '@trezor/env-utils';
 import { Elevation, mapElevationToBorder } from '@trezor/theme';
 
@@ -134,7 +135,7 @@ export const TroubleshootingTips = ({
                 <StyledButton
                     variant="tertiary"
                     data-testid="@onboarding/try-bridge-button"
-                    onClick={() => TrezorConnect.disableWebUSB()}
+                    onClick={() => (TrezorConnect as typeof TrezorConnectWeb).disableWebUSB()}
                 >
                     <Translation id="TR_DISABLE_WEBUSB_TRY_BRIDGE" />
                 </StyledButton>

--- a/packages/suite/src/hooks/suite/useOpenSuiteDesktop.ts
+++ b/packages/suite/src/hooks/suite/useOpenSuiteDesktop.ts
@@ -1,4 +1,5 @@
 import TrezorConnect from '@trezor/connect';
+import type TrezorConnectWeb from '@trezor/connect-web';
 import { useWindowFocus } from '@trezor/react-utils';
 import { SUITE_BRIDGE_DEEPLINK, SUITE_URL } from '@trezor/urls';
 import { isWebUsb } from 'src/utils/suite/transport';
@@ -9,7 +10,7 @@ export const useOpenSuiteDesktop = () => {
     const windowFocused = useWindowFocus();
     const handleOpenSuite = () => {
         if (isWebUsb(transport)) {
-            TrezorConnect.disableWebUSB();
+            (TrezorConnect as typeof TrezorConnectWeb).disableWebUSB();
         }
 
         location.href = SUITE_BRIDGE_DEEPLINK;

--- a/packages/suite/tsconfig.json
+++ b/packages/suite/tsconfig.json
@@ -91,6 +91,7 @@
         { "path": "../coinjoin" },
         { "path": "../components" },
         { "path": "../connect" },
+        { "path": "../connect-web" },
         { "path": "../crypto-utils" },
         { "path": "../device-utils" },
         { "path": "../dom-utils" },

--- a/suite-common/connect-init/src/cardanoConnectPatch.ts
+++ b/suite-common/connect-init/src/cardanoConnectPatch.ts
@@ -28,8 +28,6 @@ const blacklist: ConnectKey[] = [
     'getCoinInfo',
     'dispose',
     'cancel',
-    'renderWebUSBButton',
-    'disableWebUSB',
 ];
 
 export const cardanoConnectPatch = (getEnabledNetworks: () => string[]) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12153,6 +12153,7 @@ __metadata:
     "@trezor/coinjoin": "workspace:*"
     "@trezor/components": "workspace:*"
     "@trezor/connect": "workspace:*"
+    "@trezor/connect-web": "workspace:*"
     "@trezor/crypto-utils": "workspace:*"
     "@trezor/device-utils": "workspace:*"
     "@trezor/dom-utils": "workspace:*"


### PR DESCRIPTION
## Description

Previously, the settings and methods were the same for all Connect packages (eg. connect, connect-web, connect-webextension, connect-mobile).
This is not ideal, because some methods and settings are only available in some of them. 

The goal is to make it possible for each package to have it's own type - specifically for the settings and for additional methods besides the common ones. 