### PR TITLE
 feat(suite): add buy/sell and swap buttons to dashboard header

### DIFF
--- a/packages/suite-analytics/src/constants.ts
+++ b/packages/suite-analytics/src/constants.ts
@@ -45,10 +45,11 @@ export enum EventType {
 
     CoinmarketConfirmTrade = 'trade/confirm-trade',
 
+    MenuGuide = 'menu/guide',
     MenuNotificationsToggle = 'menu/notifications/toggle',
     MenuToggleDiscreet = 'menu/toggle-discreet',
+    MenuActions = 'menu/actions',
 
-    MenuGuide = 'menu/guide',
     GuideHeaderNavigation = 'guide/header/navigation',
     GuideNodeNavigation = 'guide/node/navigation',
     GuideFeedbackNavigation = 'guide/feedback/navigation',

--- a/packages/suite-analytics/src/types/events.ts
+++ b/packages/suite-analytics/src/types/events.ts
@@ -225,6 +225,12 @@ export type SuiteAnalyticsEvent =
           type: EventType.MenuGuide;
       }
     | {
+          type: EventType.MenuActions;
+          payload: {
+              type: string;
+          };
+      }
+    | {
           type: EventType.GuideHeaderNavigation;
           payload: {
               type: 'back' | 'close' | 'category';

--- a/packages/suite-web/e2e/tests/coinmarket/buy.test.ts
+++ b/packages/suite-web/e2e/tests/coinmarket/buy.test.ts
@@ -62,7 +62,6 @@ function setupAndAssertBuy(selectOffer: () => void) {
 
     // Goes back, then on the Last transactions page after verifies the transaction is listed
     cy.getTestElement('@account-subpage/back').click();
-    cy.getTestElement('@coinmarket/menu/wallet-coinmarket-transactions').click();
 
     // Verifies fiat amount
     cy.getTestElement('@coinmarket/transaction/fiat-amount')

--- a/packages/suite/src/actions/wallet/coinmarket/coinmarketCommonActions.ts
+++ b/packages/suite/src/actions/wallet/coinmarket/coinmarketCommonActions.ts
@@ -18,7 +18,10 @@ import { GetState, Dispatch } from 'src/types/suite';
 import * as modalActions from 'src/actions/suite/modalActions';
 import { getUnusedAddressFromAccount } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import { Account } from 'src/types/wallet';
-import { ComposedTransactionInfo } from 'src/reducers/wallet/coinmarketReducer';
+import {
+    CoinmarketSuiteBackRouteNameType,
+    ComposedTransactionInfo,
+} from 'src/reducers/wallet/coinmarketReducer';
 import { submitRequestForm as envSubmitRequestForm } from 'src/utils/suite/env';
 import * as formDraftActions from 'src/actions/wallet/formDraftActions';
 import { AddressDisplayOptions } from '@suite-common/wallet-types';
@@ -50,6 +53,10 @@ export type CoinmarketCommonAction =
     | {
           type: typeof COINMARKET_COMMON.SET_MODAL_ACCOUNT;
           modalAccount: Account | undefined;
+      }
+    | {
+          type: typeof COINMARKET_COMMON.SET_SUITE_BACK_ROUTE_NAME;
+          suiteBackRouteName: CoinmarketSuiteBackRouteNameType;
       };
 
 type FormState = {
@@ -67,6 +74,13 @@ export const setCoinmarketModalAccount = (
 ): CoinmarketCommonAction => ({
     type: COINMARKET_COMMON.SET_MODAL_ACCOUNT,
     modalAccount,
+});
+
+export const setSuiteBackRouteName = (
+    suiteBackRouteName: CoinmarketSuiteBackRouteNameType,
+): CoinmarketCommonAction => ({
+    type: COINMARKET_COMMON.SET_SUITE_BACK_ROUTE_NAME,
+    suiteBackRouteName,
 });
 
 export const verifyAddress =

--- a/packages/suite/src/actions/wallet/constants/coinmarketCommonConstants.ts
+++ b/packages/suite/src/actions/wallet/constants/coinmarketCommonConstants.ts
@@ -4,3 +4,4 @@ export const LOAD_DATA = '@coinmarket-common/load_data';
 export const SET_LOADING = '@coinmarket-common/set_loading';
 export const SET_MODAL_CRYPTO_CURRENCY = '@coinmarket-common/set_modal_crypto_currency';
 export const SET_MODAL_ACCOUNT = '@coinmarket-common/set_modal_account';
+export const SET_SUITE_BACK_ROUTE_NAME = '@coinmarket-common/set_suite_back_route_name';

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActionButton.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActionButton.tsx
@@ -1,0 +1,24 @@
+import { Button, ButtonProps, IconButton, IconButtonProps } from '@trezor/components';
+import { useSelector } from 'src/hooks/suite';
+
+export const HeaderActionButton = ({
+    icon,
+    onClick,
+    'data-testid': dataTestId,
+    variant,
+    size,
+    isDisabled,
+    children,
+}: Pick<ButtonProps, 'onClick' | 'data-testid' | 'variant' | 'size' | 'isDisabled' | 'children'> &
+    Pick<IconButtonProps, 'icon'>) => {
+    const layoutSize = useSelector(state => state.resize.size);
+
+    const isMobileLayout = layoutSize === 'TINY';
+    const commonProps = { icon, onClick, 'data-testid': dataTestId, variant, size, isDisabled };
+
+    return isMobileLayout ? (
+        <IconButton {...commonProps} />
+    ) : (
+        <Button {...commonProps}>{children}</Button>
+    );
+};

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActions.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActions.tsx
@@ -1,16 +1,6 @@
 import styled from 'styled-components';
 import { EventType, analytics } from '@trezor/suite-analytics';
-import {
-    Button,
-    ButtonGroup,
-    ButtonProps,
-    Dropdown,
-    DropdownMenuItemProps,
-    IconButton,
-    IconButtonProps,
-    IconName,
-    variables,
-} from '@trezor/components';
+import { ButtonGroup, Dropdown, DropdownMenuItemProps, IconName } from '@trezor/components';
 import { spacingsPx } from '@trezor/theme';
 import { hasNetworkFeatures } from '@suite-common/wallet-utils';
 import { WalletParams } from 'src/types/wallet';
@@ -19,19 +9,13 @@ import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 import { goto } from 'src/actions/suite/routerActions';
 import { AppNavigationTooltip } from 'src/components/suite/AppNavigation/AppNavigationTooltip';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
-import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
+import { TradeActions } from 'src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions';
+import { HeaderActionButton } from 'src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActionButton';
 
 const Container = styled.div`
     display: flex;
     align-items: center;
     gap: ${spacingsPx.xxs};
-`;
-
-// instant without computing the layout
-const ShowOnLargeDesktopWrapper = styled.div`
-    ${variables.SCREEN_QUERY.BELOW_DESKTOP} {
-        display: none;
-    }
 `;
 
 type ActionItem = {
@@ -41,28 +25,6 @@ type ActionItem = {
     title: JSX.Element;
     'data-testid'?: string;
     isHidden?: boolean;
-};
-
-const ButtonComponent = ({
-    icon,
-    onClick,
-    'data-testid': dataTestId,
-    variant,
-    size,
-    isDisabled,
-    children,
-}: Pick<ButtonProps, 'onClick' | 'data-testid' | 'variant' | 'size' | 'isDisabled' | 'children'> &
-    Pick<IconButtonProps, 'icon'>) => {
-    const layoutSize = useSelector(state => state.resize.size);
-
-    const isMobileLayout = layoutSize === 'TINY';
-    const commonProps = { icon, onClick, 'data-testid': dataTestId, variant, size, isDisabled };
-
-    return isMobileLayout ? (
-        <IconButton {...commonProps} />
-    ) : (
-        <Button {...commonProps}>{children}</Button>
-    );
 };
 
 export const HeaderActions = () => {
@@ -142,45 +104,12 @@ export const HeaderActions = () => {
             )}
 
             {isCoinmarketAvailable && (
-                <AppNavigationTooltip>
-                    <ShowOnLargeDesktopWrapper>
-                        <ButtonComponent
-                            icon="currencyCircleDollar"
-                            onClick={() => {
-                                goToWithAnalytics('wallet-coinmarket-buy', {
-                                    preserveParams: true,
-                                });
-                            }}
-                            data-testid="@wallet/menu/wallet-coinmarket-buy"
-                            variant="tertiary"
-                            size="small"
-                            isDisabled={isAccountLoading}
-                        >
-                            <Translation id="TR_COINMARKET_BUY_AND_SELL" />
-                        </ButtonComponent>
-                    </ShowOnLargeDesktopWrapper>
-                    {!hasBitcoinOnlyFirmware(device) && (
-                        <ButtonComponent
-                            icon="arrowsLeftRight"
-                            onClick={() => {
-                                goToWithAnalytics('wallet-coinmarket-exchange', {
-                                    preserveParams: true,
-                                });
-                            }}
-                            data-testid="@wallet/menu/wallet-coinmarket-exchange"
-                            variant="tertiary"
-                            size="small"
-                            isDisabled={isAccountLoading}
-                        >
-                            <Translation id="TR_COINMARKET_SWAP" />
-                        </ButtonComponent>
-                    )}
-                </AppNavigationTooltip>
+                <TradeActions selectedAccount={selectedAccount} hideBuyAndSellBelowDesktop />
             )}
 
             <AppNavigationTooltip>
                 <ButtonGroup size="small" isDisabled={isAccountLoading}>
-                    <ButtonComponent
+                    <HeaderActionButton
                         key="wallet-send"
                         icon="send"
                         onClick={() => {
@@ -190,9 +119,9 @@ export const HeaderActions = () => {
                         variant={isDeviceConnected ? 'primary' : 'tertiary'}
                     >
                         <Translation id="TR_NAV_SEND" />
-                    </ButtonComponent>
+                    </HeaderActionButton>
 
-                    <ButtonComponent
+                    <HeaderActionButton
                         key="wallet-receive"
                         icon="receive"
                         onClick={() => {
@@ -202,7 +131,7 @@ export const HeaderActions = () => {
                         variant={isDeviceConnected ? 'primary' : 'tertiary'}
                     >
                         <Translation id="TR_NAV_RECEIVE" />
-                    </ButtonComponent>
+                    </HeaderActionButton>
                 </ButtonGroup>
             </AppNavigationTooltip>
         </Container>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageHeader.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageHeader.tsx
@@ -5,9 +5,10 @@ import { Route } from '@suite-common/suite-types';
 import { spacingsPx, zIndices } from '@trezor/theme';
 import { useSelector } from 'src/hooks/suite';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
-import { selectIsAccountTabPage } from 'src/reducers/suite/routerReducer';
+import { selectIsAccountTabPage, selectRouteName } from 'src/reducers/suite/routerReducer';
 import { HeaderActions } from './HeaderActions';
 import { PageName } from './PageNames/PageName';
+import { TradeActions } from 'src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions';
 
 const HEADER_HEIGHT = 64;
 
@@ -36,13 +37,14 @@ export const PageHeader = ({ backRoute, children }: PageHeaderProps) => {
     const selectedAccount = useSelector(selectSelectedAccount);
     // TODO subpages + tabs could be in some router config? this approach feels a bit fragile
     const isAccountTabPage = useSelector(selectIsAccountTabPage);
+    const routeName = useSelector(selectRouteName);
 
     return children ? (
         <Container>{children}</Container>
     ) : (
         <Container>
             <PageName backRoute={backRoute} />
-
+            {routeName === 'suite-index' && <TradeActions />}
             {!!selectedAccount && isAccountTabPage && <HeaderActions />}
         </Container>
     );

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountDetails.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountDetails.tsx
@@ -15,6 +15,7 @@ import { useAccountLabel } from 'src/components/suite/AccountLabel';
 import { useSelector } from 'src/hooks/suite';
 import { selectLabelingDataForSelectedAccount } from 'src/reducers/suite/metadataReducer';
 import { CoinLogo } from '@trezor/product-components';
+import { isTestnet } from '@suite-common/wallet-utils';
 
 const rotateIn = keyframes`
     from {
@@ -141,10 +142,12 @@ export const AccountDetails = ({ selectedAccount, isBalanceShown }: AccountDetai
                             <FormattedCryptoAmount value={formattedBalance} symbol={symbol} />
                         </AmountUnitSwitchWrapper>
                     </CryptoBalance>
-                    <ForegroundWrapper>
-                        ≈&nbsp;
-                        <FiatValue amount={formattedBalance} symbol={symbol} />
-                    </ForegroundWrapper>
+                    {!isTestnet(symbol) && (
+                        <ForegroundWrapper>
+                            ≈&nbsp;
+                            <FiatValue amount={formattedBalance} symbol={symbol} />
+                        </ForegroundWrapper>
+                    )}
                 </AccountBalance>
             )}
         </DetailsContainer>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountDetails.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountDetails.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import styled, { keyframes } from 'styled-components';
 import { Account } from '@suite-common/wallet-types';
-import { spacingsPx } from '@trezor/theme';
+import { spacingsPx, zIndices } from '@trezor/theme';
 import { H2 } from '@trezor/components';
 import { typography } from '@trezor/theme';
 import {
@@ -74,6 +74,12 @@ const CryptoBalance = styled.div`
     gap: ${spacingsPx.xxs};
 `;
 
+// so that "to sats" button does not hide symbol and fiat
+const ForegroundWrapper = styled.div`
+    z-index: ${zIndices.base + 1};
+    display: flex;
+`;
+
 interface AccountDetailsProps {
     selectedAccount: Account;
     isBalanceShown: boolean;
@@ -128,14 +134,17 @@ export const AccountDetails = ({ selectedAccount, isBalanceShown }: AccountDetai
             {isBalanceShown && (
                 <AccountBalance>
                     <CryptoBalance>
-                        <CoinLogo size={16} symbol={symbol} />
+                        <ForegroundWrapper>
+                            <CoinLogo size={16} symbol={symbol} />
+                        </ForegroundWrapper>
                         <AmountUnitSwitchWrapper symbol={symbol}>
                             <FormattedCryptoAmount value={formattedBalance} symbol={symbol} />
                         </AmountUnitSwitchWrapper>
                     </CryptoBalance>
-                    <span>
-                        ≈ <FiatValue amount={formattedBalance} symbol={symbol} />
-                    </span>
+                    <ForegroundWrapper>
+                        ≈&nbsp;
+                        <FiatValue amount={formattedBalance} symbol={symbol} />
+                    </ForegroundWrapper>
                 </AccountBalance>
             )}
         </DetailsContainer>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions.tsx
@@ -1,0 +1,97 @@
+import { Row, variables } from '@trezor/components';
+import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
+import { analytics, EventType } from '@trezor/suite-analytics';
+import { goto } from 'src/actions/suite/routerActions';
+import { AppNavigationTooltip } from 'src/components/suite/AppNavigation/AppNavigationTooltip';
+import { Translation } from 'src/components/suite/Translation';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import styled, { css } from 'styled-components';
+import { HeaderActionButton } from 'src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActionButton';
+import { selectDevice } from '@suite-common/wallet-core';
+import { spacings } from '@trezor/theme';
+import { SelectedAccountStatus } from '@suite-common/wallet-types';
+import { selectIsAccountTabPage } from 'src/reducers/suite/routerReducer';
+
+// instant without computing the layout
+const ShowOnLargeDesktopWrapper = styled.div<{ $isActive?: boolean }>`
+    ${({ $isActive }) =>
+        $isActive &&
+        css`
+            ${variables.SCREEN_QUERY.BELOW_DESKTOP} {
+                display: none;
+            }
+        `}
+`;
+interface TradeActionsProps {
+    selectedAccount?: SelectedAccountStatus;
+    hideBuyAndSellBelowDesktop?: boolean;
+}
+
+export const TradeActions = ({
+    selectedAccount,
+    hideBuyAndSellBelowDesktop,
+}: TradeActionsProps) => {
+    const dispatch = useDispatch();
+    const account = selectedAccount?.account;
+    const device = useSelector(selectDevice);
+    const isAccountTabPage = useSelector(selectIsAccountTabPage);
+
+    const goToWithAnalytics = (...[routeName, options]: Parameters<typeof goto>) => {
+        if (routeName === 'suite-index') {
+            analytics.report({
+                type: EventType.MenuActions,
+                payload: { type: routeName },
+            });
+        }
+
+        if (isAccountTabPage && account?.symbol) {
+            analytics.report({
+                type: EventType.AccountsActions,
+                payload: { symbol: account?.symbol, action: routeName },
+            });
+        }
+
+        dispatch(goto(routeName, options));
+    };
+
+    const isAccountLoading = selectedAccount ? selectedAccount.status === 'loading' : false;
+
+    return (
+        <Row gap={spacings.xxs}>
+            <AppNavigationTooltip>
+                <ShowOnLargeDesktopWrapper $isActive={hideBuyAndSellBelowDesktop}>
+                    <HeaderActionButton
+                        icon="currencyCircleDollar"
+                        onClick={() => {
+                            goToWithAnalytics('wallet-coinmarket-buy', {
+                                preserveParams: true,
+                            });
+                        }}
+                        data-testid="@wallet/menu/wallet-coinmarket-buy"
+                        variant="tertiary"
+                        size="small"
+                        isDisabled={isAccountLoading}
+                    >
+                        <Translation id="TR_COINMARKET_BUY_AND_SELL" />
+                    </HeaderActionButton>
+                </ShowOnLargeDesktopWrapper>
+                {!hasBitcoinOnlyFirmware(device) && (
+                    <HeaderActionButton
+                        icon="arrowsLeftRight"
+                        onClick={() => {
+                            goToWithAnalytics('wallet-coinmarket-exchange', {
+                                preserveParams: true,
+                            });
+                        }}
+                        data-testid="@wallet/menu/wallet-coinmarket-exchange"
+                        variant="tertiary"
+                        size="small"
+                        isDisabled={isAccountLoading}
+                    >
+                        <Translation id="TR_COINMARKET_SWAP" />
+                    </HeaderActionButton>
+                )}
+            </AppNavigationTooltip>
+        </Row>
+    );
+};

--- a/packages/suite/src/middlewares/wallet/coinmarketMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/coinmarketMiddleware.ts
@@ -10,6 +10,7 @@ import * as coinmarketExchangeActions from 'src/actions/wallet/coinmarketExchang
 import * as coinmarketSellActions from 'src/actions/wallet/coinmarketSellActions';
 import { UI } from '@trezor/connect';
 import { ROUTER, MODAL } from 'src/actions/suite/constants';
+import { CoinmarketSuiteBackRouteNameType } from 'src/reducers/wallet/coinmarketReducer';
 
 export const coinmarketMiddleware =
     (api: MiddlewareAPI<Dispatch, AppState>) =>
@@ -121,6 +122,8 @@ export const coinmarketMiddleware =
         if (action.type === ROUTER.LOCATION_CHANGE) {
             const isSell = newState.router.route?.name === 'wallet-coinmarket-sell';
             const isExchange = newState.router.route?.name === 'wallet-coinmarket-exchange';
+            const currentBackRouteName = action.payload.settingsBackRoute?.name;
+            const { suiteBackRouteName } = newState.wallet.coinmarket;
 
             // clean coinmarketAccount in sell
             if (isSell && sellCoinmarketAccount) {
@@ -130,6 +133,18 @@ export const coinmarketMiddleware =
             // clean coinmarketAccount in exchange
             if (isExchange && exchangeCoinmarketAccount) {
                 api.dispatch(coinmarketExchangeActions.setCoinmarketExchangeAccount(undefined));
+            }
+
+            if (
+                currentBackRouteName &&
+                ['wallet-index', 'suite-index'].includes(currentBackRouteName) &&
+                suiteBackRouteName !== currentBackRouteName
+            ) {
+                api.dispatch(
+                    coinmarketCommonActions.setSuiteBackRouteName(
+                        currentBackRouteName as CoinmarketSuiteBackRouteNameType,
+                    ),
+                );
             }
         }
 

--- a/packages/suite/src/reducers/wallet/coinmarketReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinmarketReducer.ts
@@ -23,7 +23,7 @@ import {
     COINMARKET_INFO,
 } from 'src/actions/wallet/constants';
 import { STORAGE } from 'src/actions/suite/constants';
-import type { Action as SuiteAction } from 'src/types/suite';
+import type { Route, Action as SuiteAction } from 'src/types/suite';
 import type { SellInfo } from 'src/actions/wallet/coinmarketSellActions';
 import type { FeeLevel } from '@trezor/connect';
 import type { Trade } from 'src/types/wallet/coinmarketCommonTypes';
@@ -40,6 +40,11 @@ export interface ComposedTransactionInfo {
 export interface CoinmarketTradeCommonProps {
     transactionId?: string;
 }
+
+export type CoinmarketSuiteBackRouteNameType = Extract<
+    Route['name'],
+    'wallet-index' | 'suite-index'
+>;
 
 interface Info {
     platforms?: Platforms;
@@ -92,6 +97,7 @@ export interface State {
     modalAccount: Account | undefined;
     isLoading: boolean;
     lastLoadedTimestamp: number;
+    suiteBackRouteName: CoinmarketSuiteBackRouteNameType;
 }
 
 export const initialState: State = {
@@ -139,6 +145,7 @@ export const initialState: State = {
     modalAccount: undefined,
     modalCryptoId: undefined,
     lastLoadedTimestamp: 0,
+    suiteBackRouteName: 'wallet-index',
 };
 
 export const coinmarketReducer = (
@@ -254,6 +261,9 @@ export const coinmarketReducer = (
                 break;
             case COINMARKET_COMMON.SET_MODAL_CRYPTO_CURRENCY:
                 draft.modalCryptoId = action.modalCryptoId;
+                break;
+            case COINMARKET_COMMON.SET_SUITE_BACK_ROUTE_NAME:
+                draft.suiteBackRouteName = action.suiteBackRouteName;
                 break;
             // no default
         }

--- a/packages/suite/src/views/wallet/coinmarket/buy/CoinmarketBuyDetail.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/CoinmarketBuyDetail.tsx
@@ -22,7 +22,7 @@ const CoinmarketBuyDetailComponent = ({ selectedAccount }: UseCoinmarketProps) =
 export const CoinmarketBuyDetail = () => (
     <CoinmarketContainer
         title="TR_NAV_BUY"
-        backRoute="wallet-coinmarket-buy"
+        backRoute="wallet-coinmarket-transactions"
         SectionComponent={CoinmarketBuyDetailComponent}
     />
 );

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketContainer.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketContainer.tsx
@@ -4,6 +4,7 @@ import { ComponentType } from 'react';
 import { PageHeader } from 'src/components/suite/layouts/SuiteLayout';
 import { WalletLayout } from 'src/components/wallet';
 import { useLayout, useSelector, useTranslation } from 'src/hooks/suite';
+import { selectRouter } from 'src/reducers/suite/routerReducer';
 import { UseCoinmarketProps } from 'src/types/coinmarket/coinmarket';
 import { CoinmarketFooter } from 'src/views/wallet/coinmarket/common/CoinmarketFooter/CoinmarketFooter';
 
@@ -25,13 +26,28 @@ export const CoinmarketContainer = ({
     title,
     SectionComponent,
 }: CoinmarketContainerProps) => {
-    const selectedAccount = useSelector(state => state.wallet.selectedAccount);
     const { translationString } = useTranslation();
+    const router = useSelector(selectRouter);
+    const selectedAccount = useSelector(state => state.wallet.selectedAccount);
+    const suiteBackRouteName = useSelector(state => state.wallet.coinmarket.suiteBackRouteName);
+
+    const currentRouteName = router.route?.name;
+    const currentBackRouteName = router.settingsBackRoute.name;
+    const fallbackBackRoute =
+        currentRouteName &&
+        [
+            'wallet-coinmarket-buy',
+            'wallet-coinmarket-sell',
+            'wallet-coinmarket-exchange',
+            'wallet-coinmarket-dca',
+        ].includes(currentRouteName)
+            ? suiteBackRouteName
+            : currentBackRouteName;
 
     const translatedTitle = translationString(title ?? 'TR_NAV_TRADE');
     const pageTitle = `Trezor Suite | ${translatedTitle}`;
 
-    useLayout(pageTitle, () => <PageHeader backRoute={backRoute} />);
+    useLayout(pageTitle, () => <PageHeader backRoute={backRoute ?? fallbackBackRoute} />);
 
     if (selectedAccount.status !== 'loaded') {
         return <WalletLayout title="TR_NAV_TRADE" isSubpage account={selectedAccount} />;

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketLayout.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketLayout.tsx
@@ -28,7 +28,7 @@ export const CoinmarketLayout = ({ children, selectedAccount }: CoinmarketLayout
     <WalletLayout title="TR_NAV_TRADE" isSubpage account={selectedAccount}>
         <CoinmarketWrapper>
             <WalletSubpageHeading title="TR_NAV_TRADE" />
-            <CoinmarketLayoutNavigation selectedAccount={selectedAccount} />
+            <CoinmarketLayoutNavigation />
             <CoinmarketFormWrapper>{children}</CoinmarketFormWrapper>
         </CoinmarketWrapper>
     </WalletLayout>

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketLayoutNavigation/CoinmarketLayoutNavigation.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketLayoutNavigation/CoinmarketLayoutNavigation.tsx
@@ -1,10 +1,7 @@
 import styled from 'styled-components';
-import { useDevice, useSelector } from 'src/hooks/suite';
+import { useDevice } from 'src/hooks/suite';
 import { Divider } from '@trezor/components';
 import { spacings } from '@trezor/theme';
-import regional from 'src/constants/wallet/coinmarket/regional';
-import { getIsTorEnabled } from 'src/utils/suite/tor';
-import { SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 import { CoinmarketLayoutNavigationItem } from 'src/views/wallet/coinmarket/common/CoinmarketLayout/CoinmarketLayoutNavigation/CoinmarketLayoutNavigationItem';
 
@@ -18,24 +15,8 @@ const SeparatorWrapper = styled.div`
     height: 42px;
 `;
 
-interface CoinmarketLayoutNavigationProps {
-    selectedAccount: SelectedAccountLoaded;
-}
-
-export const CoinmarketLayoutNavigation = ({
-    selectedAccount,
-}: CoinmarketLayoutNavigationProps) => {
+export const CoinmarketLayoutNavigation = () => {
     const { device } = useDevice();
-
-    const isBtcAccount = selectedAccount.account.symbol === 'btc';
-    const torStatus = useSelector(state => state.suite.torStatus);
-    const isTorEnabled = getIsTorEnabled(torStatus);
-    const country = useSelector(
-        state =>
-            state.wallet.coinmarket.buy.buyInfo?.buyInfo?.country ??
-            state.wallet.coinmarket.sell.sellInfo?.sellList?.country,
-    );
-    const showDCA = Boolean(isBtcAccount && !isTorEnabled && country && regional.isInEEA(country));
 
     return (
         <List>
@@ -58,22 +39,18 @@ export const CoinmarketLayoutNavigation = ({
                 />
             ) : null}
 
-            {showDCA ? (
-                <>
-                    <SeparatorWrapper>
-                        <Divider
-                            orientation="vertical"
-                            strokeWidth={1}
-                            margin={{ left: spacings.sm, right: spacings.sm }}
-                        />
-                    </SeparatorWrapper>
-                    <CoinmarketLayoutNavigationItem
-                        route="wallet-coinmarket-dca"
-                        title="TR_NAV_DCA"
-                        icon="clock"
-                    />
-                </>
-            ) : null}
+            <SeparatorWrapper>
+                <Divider
+                    orientation="vertical"
+                    strokeWidth={1}
+                    margin={{ left: spacings.sm, right: spacings.sm }}
+                />
+            </SeparatorWrapper>
+            <CoinmarketLayoutNavigationItem
+                route="wallet-coinmarket-dca"
+                title="TR_NAV_DCA"
+                icon="clock"
+            />
 
             <CoinmarketLayoutNavigationItem
                 route="wallet-coinmarket-transactions"

--- a/packages/suite/src/views/wallet/coinmarket/exchange/CoinmarketExchangeDetail.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/CoinmarketExchangeDetail.tsx
@@ -22,7 +22,7 @@ const CoinmarketExchangeDetailComponent = ({ selectedAccount }: UseCoinmarketPro
 export const CoinmarketExchangeDetail = () => (
     <CoinmarketContainer
         title="TR_COINMARKET_SWAP"
-        backRoute="wallet-coinmarket-exchange"
+        backRoute="wallet-coinmarket-transactions"
         SectionComponent={CoinmarketExchangeDetailComponent}
     />
 );

--- a/packages/suite/src/views/wallet/coinmarket/sell/CoinmarketSellDetail.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/CoinmarketSellDetail.tsx
@@ -22,7 +22,7 @@ const CoinmarketSellDetailComponent = ({ selectedAccount }: UseCoinmarketProps) 
 export const CoinmarketSellDetail = () => (
     <CoinmarketContainer
         title="TR_NAV_SELL"
-        backRoute="wallet-coinmarket-sell"
+        backRoute="wallet-coinmarket-transactions"
         SectionComponent={CoinmarketSellDetailComponent}
     />
 );


### PR DESCRIPTION
## Description
- Always show the DCA tab in the Buy&Sell screen
- Add **Buy&Sell** button and **Swap** button to Dashboard header + add click event.
  - Analytics event c_type=dashboard/actions after Buy&Sell or Swap button is clicked ([mandatory attributes doc](https://www.notion.so/satoshilabs/c63bdab01b704b099cab3bbb3227e1b1?v=406d107d6d584577a47d7580e8b2df89)).
  - Type attribute 
     - Buy&sell: `type=wallet-coinmarket-buy`
     - Swap: `type=wallet-coinmarket-exchange`
- Both sections will not require account context

## Screenshots
![image](https://github.com/user-attachments/assets/0aee7738-8d1c-49f4-b286-11126aceaadc)

## Related
Resolve https://github.com/trezor/trezor-suite/issues/14863