### PR TITLE
iframeless suite - use connect core as a module in suite-web

### DIFF
--- a/.github/actions/release-connect/action.yml
+++ b/.github/actions/release-connect/action.yml
@@ -82,6 +82,7 @@ runs:
       shell: bash
       env:
         NODE_ENV: ${{ inputs.nodeEnv }}
+        ASSET_PREFIX: /${{ inputs.serverPath }}
       run: |
         yarn workspace @trezor/connect-popup build
 

--- a/.github/workflows/build-suite-web.yml
+++ b/.github/workflows/build-suite-web.yml
@@ -65,8 +65,6 @@ jobs:
         run: |
           yarn message-system-sign-config
           yarn workspace @trezor/suite-data build:lib
-          NODE_ENV=production yarn workspace @trezor/connect-iframe build:lib
-          yarn workspace @trezor/connect-web build
           yarn workspace @trezor/suite-web build
       # this step should upload build result to s3 bucket dev.suite.sldev.cz using awscli
       - name: Upload suite-web to dev.suite.sldev.cz

--- a/.github/workflows/test-suite-web-e2e.yml
+++ b/.github/workflows/test-suite-web-e2e.yml
@@ -76,8 +76,6 @@ jobs:
         run: |
           yarn message-system-sign-config
           yarn workspace @trezor/suite-data build:lib
-          NODE_ENV=production yarn workspace @trezor/connect-iframe build:lib
-          yarn workspace @trezor/connect-web build
           yarn workspace @trezor/suite-web build
       # this step should upload build result to s3 bucket dev.suite.sldev.cz using awscli
       - name: Upload suite-web to dev.suite.sldev.cz

--- a/packages/connect-iframe/package.json
+++ b/packages/connect-iframe/package.json
@@ -3,9 +3,10 @@
     "version": "9.0.0",
     "private": true,
     "scripts": {
-        "build:iframe": "TS_NODE_PROJECT=\"tsconfig.json\" yarn webpack --config ./webpack/prod.webpack.config.ts --stats-children",
+        "build:iframe": "TS_NODE_PROJECT=\"tsconfig.json\" yarn webpack --config ./webpack/iframe.webpack.config.ts --stats-children",
+        "build:sessions": "TS_NODE_PROJECT=\"tsconfig.json\" yarn webpack --config ./webpack/sessions.webpack.config.ts --stats-children",
         "build:core-module": "TS_NODE_PROJECT=\"tsconfig.json\" yarn webpack --config ./webpack/core.webpack.config.ts --stats-children",
-        "build": "yarn rimraf build && yarn build:iframe && yarn build:core-module",
+        "build": "yarn rimraf build && yarn build:iframe && yarn build:core-module && yarn build:sessions",
         "___NOTE__": "iframe build is one of the prerequisites of suite-web. build:lib script provides it together with other libraries",
         "build:lib": "yarn build",
         "type-check": "yarn g:tsc --build tsconfig.json",

--- a/packages/connect-iframe/webpack/base.webpack.config.ts
+++ b/packages/connect-iframe/webpack/base.webpack.config.ts
@@ -1,15 +1,20 @@
-import path from 'path';
 import { execSync } from 'child_process';
 import webpack from 'webpack';
 import CopyWebpackPlugin from 'copy-webpack-plugin';
 import TerserPlugin from 'terser-webpack-plugin';
 
 import { version } from '../package.json';
+import { getDistPathForProject } from './utils';
 
 const COMMON_DATA_SRC = '../../packages/connect-common/files';
 const MESSAGES_SRC = '../../packages/protobuf/messages.json';
 
-const DIST = path.resolve(__dirname, '../build');
+const project = process.env.PROJECT || 'iframe';
+
+if (project !== 'iframe' && project !== 'suite-web' && project !== 'popup') {
+    throw new Error(`Unsupported project: ${project}`);
+}
+const DIST = getDistPathForProject(project);
 
 // Because of Expo EAS, we need to use the commit hash from expo to avoid failing git command inside EAS
 // because we need to call `yarn build:libs during native build`

--- a/packages/connect-iframe/webpack/core.webpack.config.ts
+++ b/packages/connect-iframe/webpack/core.webpack.config.ts
@@ -3,8 +3,16 @@ import webpack from 'webpack';
 import merge from 'webpack-merge';
 
 import baseConfig from './base.webpack.config';
+import { getDistPathForProject } from './utils';
 
-const DIST = path.resolve(__dirname, '../build');
+const project = process.env.PROJECT || 'iframe';
+
+if (project !== 'iframe' && project !== 'suite-web' && project !== 'popup') {
+    throw new Error(`Unsupported project: ${project}`);
+}
+const DIST = getDistPathForProject(project);
+
+const CORE_PUBLIC_PATH = process.env.ASSET_PREFIX ? `${process.env.ASSET_PREFIX}/` : '/';
 
 export const config: webpack.Configuration = {
     target: 'web',
@@ -15,7 +23,7 @@ export const config: webpack.Configuration = {
     output: {
         filename: 'js/[name].js',
         path: DIST,
-        publicPath: './',
+        publicPath: CORE_PUBLIC_PATH,
         library: {
             type: 'module',
         },
@@ -23,7 +31,6 @@ export const config: webpack.Configuration = {
     experiments: {
         outputModule: true,
     },
-    // todo: nx implicit dependencies
 };
 
 export default merge([config, baseConfig]);

--- a/packages/connect-iframe/webpack/iframe.webpack.config.ts
+++ b/packages/connect-iframe/webpack/iframe.webpack.config.ts
@@ -6,17 +6,10 @@ import HtmlWebpackPlugin from 'html-webpack-plugin';
 import { config as baseConfig } from './base.webpack.config';
 
 const DIST = path.resolve(__dirname, '../build');
+
 const config: webpack.Configuration = {
-    // common instructions that are able to build correctly imports from @trezor/connect (reusing this in popup)
     entry: {
         iframe: path.resolve(__dirname, '../src/index.ts'),
-        ['sessions-background-sharedworker']: {
-            filename: 'workers/[name].js',
-            import: path.resolve(
-                __dirname,
-                '../../transport/src/sessions/background-sharedworker.ts',
-            ),
-        },
     },
     output: {
         filename: 'js/[name].[contenthash].js',

--- a/packages/connect-iframe/webpack/sessions.webpack.config.ts
+++ b/packages/connect-iframe/webpack/sessions.webpack.config.ts
@@ -1,0 +1,29 @@
+import path from 'path';
+import webpack from 'webpack';
+import merge from 'webpack-merge';
+
+import { config as baseConfig } from './base.webpack.config';
+
+const basePath = path.join(__dirname, '..');
+
+const DIST = path.join(basePath, 'build');
+
+const config: webpack.Configuration = {
+    // common instructions that are able to build correctly imports from @trezor/connect (reusing this in popup)
+    entry: {
+        ['sessions-background-sharedworker']: {
+            filename: 'workers/[name].js',
+            import: path.resolve(
+                __dirname,
+                '../../transport/src/sessions/background-sharedworker.ts',
+            ),
+        },
+    },
+    output: {
+        filename: 'js/[name].[contenthash].js',
+        path: DIST,
+        publicPath: './',
+    },
+};
+
+export default merge([config, baseConfig]);

--- a/packages/connect-iframe/webpack/utils.ts
+++ b/packages/connect-iframe/webpack/utils.ts
@@ -1,0 +1,17 @@
+import path from 'path';
+
+type Project = 'iframe' | 'popup' | 'suite-web';
+
+export const getDistPathForProject = (project: Project = 'iframe') => {
+    const basePath = path.join(__dirname, '..', '..');
+    switch (project) {
+        case 'iframe':
+            return path.join(basePath, 'connect-iframe', 'build');
+        case 'suite-web':
+            return path.join(basePath, 'suite-web', 'build');
+        case 'popup':
+            return path.join(basePath, 'connect-popup', 'build');
+        default:
+            throw new Error('Missing project.');
+    }
+};

--- a/packages/connect-popup/package.json
+++ b/packages/connect-popup/package.json
@@ -9,7 +9,8 @@
         "type-check": "yarn g:tsc --build",
         "dev": "yarn g:rimraf build && TS_NODE_PROJECT=\"tsconfig.json\" yarn webpack --config ./webpack/dev.webpack.config.ts",
         "build:popup": "TS_NODE_PROJECT=\"tsconfig.json\" yarn webpack --config ./webpack/prod.webpack.config.ts",
-        "build": "yarn g:rimraf build && yarn workspace @trezor/connect-popup build:popup",
+        "build": "yarn g:rimraf build && yarn core:popup && yarn workspace @trezor/connect-popup build:popup",
+        "core:popup": "PROJECT=\"popup\" yarn workspace @trezor/connect-iframe build:core-module",
         "test:e2e": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts",
         "test:unit": "yarn g:jest"
     },

--- a/packages/connect-popup/webpack/prod.webpack.config.ts
+++ b/packages/connect-popup/webpack/prod.webpack.config.ts
@@ -126,10 +126,6 @@ const config: webpack.Configuration = {
                     from: path.join(__dirname, '../../suite-data/files/images/png/trezor-*'),
                     to: `${DIST}/images/[name][ext]`,
                 },
-                {
-                    from: path.join(__dirname, '../../connect-iframe/build'),
-                    to: `${DIST}`,
-                },
             ],
         }),
     ],

--- a/packages/connect-web/src/module/index.ts
+++ b/packages/connect-web/src/module/index.ts
@@ -1,0 +1,61 @@
+import { factory } from '@trezor/connect/src/factory';
+import { config } from '@trezor/connect/src/data/config';
+import { TrezorConnectDynamic } from '@trezor/connect/src/impl/dynamic';
+import { CoreInModule } from '@trezor/connect/src/impl/core-in-module';
+import type { ConnectSettingsPublic } from '@trezor/connect/src/types';
+import type { ConnectFactoryDependencies } from '@trezor/connect/src/factory';
+import { CoreRequestMessage, ERRORS, TRANSPORT } from '@trezor/connect/src/exports';
+
+interface ConnectWebDynamicImplementation
+    extends ConnectFactoryDependencies<ConnectSettingsPublic> {
+    handleCoreMessage: (message: CoreRequestMessage) => void;
+}
+
+const impl = new TrezorConnectDynamic<
+    'core-in-module',
+    ConnectSettingsPublic,
+    ConnectWebDynamicImplementation
+>({
+    implementations: [
+        {
+            type: 'core-in-module',
+            impl: new CoreInModule(),
+        },
+    ],
+    getInitTarget: () => 'core-in-module',
+    handleErrorFallback: () => new Promise(resolve => resolve(false)),
+});
+
+const disableWebUSB = () => {
+    if (!impl.lastSettings) {
+        throw ERRORS.TypedError('Init_NotInitialized');
+    }
+
+    impl.getTarget().handleCoreMessage({ type: TRANSPORT.DISABLE_WEBUSB });
+};
+
+const requestWebUSBDevice = async () => {
+    await window.navigator.usb.requestDevice({ filters: config.webusb });
+
+    impl.getTarget().handleCoreMessage({ type: TRANSPORT.REQUEST_DEVICE });
+};
+
+const TrezorConnect = factory(
+    {
+        eventEmitter: impl.eventEmitter,
+        init: impl.init.bind(impl),
+        call: impl.call.bind(impl),
+        manifest: impl.manifest.bind(impl),
+        requestLogin: impl.requestLogin.bind(impl),
+        uiResponse: impl.uiResponse.bind(impl),
+        cancel: impl.cancel.bind(impl),
+        dispose: impl.dispose.bind(impl),
+    },
+    {
+        disableWebUSB: disableWebUSB.bind(impl),
+        requestWebUSBDevice: requestWebUSBDevice.bind(impl),
+    },
+);
+
+export default TrezorConnect;
+export * from '@trezor/connect/src/exports';

--- a/packages/connect-web/tsconfig.json
+++ b/packages/connect-web/tsconfig.json
@@ -15,7 +15,8 @@
     "include": [
         ".",
         "../connect-iframe/webpack/base.webpack.config.ts",
-        "../connect-iframe/webpack/prod.webpack.config.ts",
+        "../connect-iframe/webpack/iframe.webpack.config.ts",
+        "../connect-iframe/webpack/utils.ts",
         "../connect-iframe/package.json",
         "../connect-popup/webpack/prod.webpack.config.ts",
         "../connect-popup/package.json"

--- a/packages/connect-web/webpack/dev.webpack.config.ts
+++ b/packages/connect-web/webpack/dev.webpack.config.ts
@@ -6,7 +6,7 @@ import { WebpackPluginServe } from 'webpack-plugin-serve';
 // todo: https://github.com/trezor/trezor-suite/issues/5305
 import popup from '../../connect-popup/webpack/prod.webpack.config';
 // todo: https://github.com/trezor/trezor-suite/issues/5305
-import iframe from '../../connect-iframe/webpack/prod.webpack.config';
+import iframe from '../../connect-iframe/webpack/iframe.webpack.config';
 import prod from './prod.webpack.config';
 
 const dev = {

--- a/packages/connect/src/impl/core-in-module.ts
+++ b/packages/connect/src/impl/core-in-module.ts
@@ -1,6 +1,6 @@
 import EventEmitter from 'events';
 
-import { DeferredManager, createDeferredManager, cloneObject } from '@trezor/utils';
+import { DeferredManager, createDeferredManager, cloneObjectCyclic } from '@trezor/utils';
 
 import * as ERRORS from '../constants/errors';
 import {
@@ -207,7 +207,7 @@ export class CoreInModule implements ConnectFactoryDependencies<ConnectSettingsP
     public async call(params: CallMethodPayload) {
         try {
             const { promiseId, promise } = this._messagePromises.create();
-            const payload = cloneObject(params);
+            const payload = cloneObjectCyclic<any>(params);
             this.handleCoreMessage({
                 type: IFRAME.CALL,
                 id: promiseId,

--- a/packages/connect/src/impl/core-in-module.ts
+++ b/packages/connect/src/impl/core-in-module.ts
@@ -1,0 +1,286 @@
+import EventEmitter from 'events';
+
+import { DeferredManager, createDeferredManager, cloneObject } from '@trezor/utils';
+
+import * as ERRORS from '../constants/errors';
+import {
+    POPUP,
+    IFRAME,
+    UI,
+    UI_EVENT,
+    DEVICE_EVENT,
+    RESPONSE_EVENT,
+    TRANSPORT_EVENT,
+    BLOCKCHAIN_EVENT,
+    createErrorMessage,
+    UiResponseEvent,
+    CoreEventMessage,
+    CallMethodPayload,
+    CORE_EVENT,
+    CoreRequestMessage,
+} from '../events';
+import type { ConnectSettings, ConnectSettingsPublic, DeviceIdentity, Manifest } from '../types';
+import { ConnectFactoryDependencies, factory } from '../factory';
+import { Log, initLog } from '../utils/debug';
+import { parseConnectSettings } from '../data/connectSettings';
+
+export class CoreInModule implements ConnectFactoryDependencies<ConnectSettingsPublic> {
+    public eventEmitter = new EventEmitter();
+    public _settings: ConnectSettings;
+
+    private _coreManager?: any;
+    private _log: Log;
+    private _messagePromises: DeferredManager<{
+        id: number;
+        success: boolean;
+        payload: any;
+        device?: DeviceIdentity;
+    }>;
+
+    private readonly boundOnCoreEvent = this.onCoreEvent.bind(this);
+
+    public constructor() {
+        this._settings = parseConnectSettings();
+        this._log = initLog('@trezor/connect-web');
+        this._messagePromises = createDeferredManager({ initialId: 1 });
+    }
+
+    private async initCoreManager() {
+        const { connectSrc } = this._settings;
+        const { initCoreState, initTransport } = await import(
+            /* webpackIgnore: true */ `${connectSrc}js/core.js`
+        ).catch(_err => {
+            this._log.error('_err', _err);
+        });
+
+        if (!initCoreState) return;
+
+        if (initTransport) {
+            this._log.debug('initiating transport with settings: ', this._settings);
+            await initTransport(this._settings);
+        }
+
+        this._coreManager = initCoreState();
+
+        return this._coreManager;
+    }
+
+    public manifest(data: Manifest) {
+        this._settings = parseConnectSettings({
+            ...this._settings,
+            manifest: data,
+        });
+    }
+
+    public dispose() {
+        this.eventEmitter.removeAllListeners();
+        this._settings = parseConnectSettings();
+        if (this._coreManager) {
+            this._coreManager.dispose();
+        }
+
+        return Promise.resolve(undefined);
+    }
+
+    public cancel(error?: string) {
+        if (this._coreManager) {
+            const core = this._coreManager.get();
+            if (!core) {
+                throw ERRORS.TypedError('Runtime', 'postMessage: _core not found');
+            }
+
+            this.handleCoreMessage({
+                type: POPUP.CLOSED,
+                payload: error ? { error } : null,
+            });
+        }
+    }
+
+    // handle messages to core
+    public handleCoreMessage(message: CoreRequestMessage) {
+        const core = this._coreManager.get();
+        if (!core) {
+            throw ERRORS.TypedError('Runtime', 'postMessage: _core not found');
+        }
+        core.handleMessage(message);
+    }
+
+    // handle message received from Core
+    private onCoreEvent(message: CoreEventMessage) {
+        const { event, type, payload } = message;
+
+        if (type === UI.REQUEST_UI_WINDOW) {
+            this._coreManager.get()?.handleMessage({ type: POPUP.HANDSHAKE });
+
+            return;
+        }
+
+        if (type === POPUP.CANCEL_POPUP_REQUEST) return;
+
+        switch (event) {
+            case RESPONSE_EVENT: {
+                const { id = 0, success, device } = message;
+                const resolved = this._messagePromises.resolve(id, {
+                    id,
+                    success,
+                    payload,
+                    device,
+                });
+                if (!resolved) this._log.warn(`Unknown message id ${id}`);
+                break;
+            }
+            case DEVICE_EVENT:
+                // pass DEVICE event up to html
+                this.eventEmitter.emit(event, message);
+                this.eventEmitter.emit(type, payload); // DEVICE_EVENT also emit single events (connect/disconnect...)
+                break;
+
+            case TRANSPORT_EVENT:
+                this.eventEmitter.emit(event, message);
+                this.eventEmitter.emit(type, payload);
+                break;
+
+            case BLOCKCHAIN_EVENT:
+                this.eventEmitter.emit(event, message);
+                this.eventEmitter.emit(type, payload);
+                break;
+
+            case UI_EVENT:
+                // pass UI event up
+                this.eventEmitter.emit(event, message);
+                this.eventEmitter.emit(type, payload);
+                break;
+
+            default:
+                this._log.warn('Undefined message', event, message);
+        }
+    }
+
+    public async init(settings: Partial<ConnectSettings> = {}) {
+        if (this._coreManager && (this._coreManager.get() || this._coreManager.getPending())) {
+            throw ERRORS.TypedError('Init_AlreadyInitialized');
+        }
+
+        this._settings = parseConnectSettings({ ...this._settings, ...settings });
+
+        if (!this._settings.manifest) {
+            throw ERRORS.TypedError('Init_ManifestMissing');
+        }
+        this._settings.lazyLoad = true;
+
+        // defaults for connect-web
+        if (!this._settings.transports?.length) {
+            this._settings.transports = ['BridgeTransport', 'WebUsbTransport'];
+        }
+
+        if (!this._coreManager) {
+            this._coreManager = await this.initCoreManager();
+            await this._coreManager.getOrInit(this._settings, this.boundOnCoreEvent);
+        }
+
+        this._log.enabled = !!this._settings.debug;
+    }
+
+    private initSettings = (settings: Partial<ConnectSettings> = {}) => {
+        this._settings = parseConnectSettings({
+            ...this._settings,
+            ...settings,
+            popup: false,
+        });
+
+        if (!this._settings.manifest) {
+            throw ERRORS.TypedError('Init_ManifestMissing');
+        }
+
+        if (!this._settings.transports?.length) {
+            // default fallback for node
+            this._settings.transports = ['BridgeTransport'];
+        }
+    };
+
+    public initCore() {
+        this.initSettings({ lazyLoad: false });
+
+        return this._coreManager.getOrInit(this._settings, this.boundOnCoreEvent);
+    }
+
+    public async call(params: CallMethodPayload) {
+        try {
+            const { promiseId, promise } = this._messagePromises.create();
+            const payload = cloneObject(params);
+            this.handleCoreMessage({
+                type: IFRAME.CALL,
+                id: promiseId,
+                payload,
+            });
+            const response = await promise;
+
+            return response ?? createErrorMessage(ERRORS.TypedError('Method_NoResponse'));
+        } catch (error) {
+            this._log.error('call', error);
+
+            return createErrorMessage(error);
+        }
+    }
+
+    public uiResponse(response: UiResponseEvent) {
+        const core = this._coreManager.get();
+        if (!core) {
+            throw ERRORS.TypedError('Runtime', 'postMessage: _core not found');
+        }
+        this.handleCoreMessage(response);
+    }
+
+    public async requestLogin(params: any) {
+        if (typeof params.callback === 'function') {
+            const { callback } = params;
+            const core = this._coreManager.get();
+
+            // TODO: set message listener only if _core is loaded correctly
+            const loginChallengeListener = async (event: MessageEvent<CoreEventMessage>) => {
+                const { data } = event;
+                if (data && data.type === UI.LOGIN_CHALLENGE_REQUEST) {
+                    try {
+                        const payload = await callback();
+                        this.handleCoreMessage({
+                            type: UI.LOGIN_CHALLENGE_RESPONSE,
+                            payload,
+                        });
+                    } catch (error) {
+                        this.handleCoreMessage({
+                            type: UI.LOGIN_CHALLENGE_RESPONSE,
+                            payload: error.message,
+                        });
+                    }
+                }
+            };
+
+            core?.on(CORE_EVENT, loginChallengeListener);
+            const response = await this.call({
+                method: 'requestLogin',
+                ...params,
+                asyncChallenge: true,
+                callback: null,
+            });
+            core?.removeListener(CORE_EVENT, loginChallengeListener);
+
+            return response;
+        }
+
+        return this.call({ method: 'requestLogin', ...params });
+    }
+}
+
+const impl = new CoreInModule();
+
+// Exported to enable using directly
+export const TrezorConnect = factory({
+    eventEmitter: impl.eventEmitter,
+    manifest: impl.manifest.bind(impl),
+    init: impl.init.bind(impl),
+    call: impl.call.bind(impl),
+    requestLogin: impl.requestLogin.bind(impl),
+    uiResponse: impl.uiResponse.bind(impl),
+    cancel: impl.cancel.bind(impl),
+    dispose: impl.dispose.bind(impl),
+});

--- a/packages/connect/src/utils/assetUtils.ts
+++ b/packages/connect/src/utils/assetUtils.ts
@@ -5,7 +5,7 @@ import { DeviceModelInternal } from '../types';
 const isDeviceModel = (model: string): model is DeviceModelInternal =>
     isArrayMember(model, Object.values(DeviceModelInternal));
 
-const firmwareAssets: Record<DeviceModelInternal, NodeRequire> = {
+export const firmwareAssets: Record<DeviceModelInternal, NodeRequire> = {
     [DeviceModelInternal.T1B1]: require('@trezor/connect-common/files/firmware/t1b1/releases.json'),
     [DeviceModelInternal.T2T1]: require('@trezor/connect-common/files/firmware/t2t1/releases.json'),
     [DeviceModelInternal.T2B1]: require('@trezor/connect-common/files/firmware/t2b1/releases.json'),

--- a/packages/connect/src/utils/pathUtils.ts
+++ b/packages/connect/src/utils/pathUtils.ts
@@ -1,5 +1,5 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/utils/pathUtils.js
-
+// TODO: There might be other issues with side-effects https://github.com/trezor/trezor-suite/issues/15559
 import { PROTO, ERRORS } from '../constants';
 import type {
     CoinInfo,

--- a/packages/suite-build/configs/base.webpack.config.ts
+++ b/packages/suite-build/configs/base.webpack.config.ts
@@ -132,7 +132,7 @@ const config: webpack.Configuration = {
                     },
                 ],
             },
-            // Workers
+            // This worker loader is used for suite-desktop
             {
                 test: /\/workers\/[^/]+\/index\.ts$/,
                 use: [

--- a/packages/suite-build/configs/web.webpack.config.ts
+++ b/packages/suite-build/configs/web.webpack.config.ts
@@ -35,12 +35,6 @@ const config: webpack.Configuration = {
                         ),
                         to: path.join(baseDir, 'build', 'static', 'message-system'),
                     },
-                ])
-                .concat([
-                    {
-                        from: path.join(__dirname, '..', '..', 'connect-iframe', 'build'),
-                        to: path.join(baseDir, 'build', 'static', 'connect'),
-                    },
                 ]),
             options: {
                 concurrency: 100,
@@ -72,8 +66,11 @@ const config: webpack.Configuration = {
                     filename: path.join(baseDir, 'build', route.pattern, 'index.html'),
                 }),
         ),
-        // imports from @trezor/connect in @trezor/suite package need to be replaced by imports from @trezor/connect-web
-        new webpack.NormalModuleReplacementPlugin(/@trezor\/connect$/, '@trezor/connect-web'),
+        // imports from @trezor/connect in @trezor/suite package need to be replaced by imports from @trezor/connect-web/src/module
+        new webpack.NormalModuleReplacementPlugin(
+            /@trezor\/connect$/,
+            '@trezor/connect-web/src/module',
+        ),
         ...(!isDev ? [new CssMinimizerPlugin()] : []),
     ],
 };

--- a/packages/suite-build/package.json
+++ b/packages/suite-build/package.json
@@ -11,7 +11,8 @@
     "description": "trezor suite build",
     "scripts": {
         "base": "TS_NODE_PROJECT=\"tsconfig.json\" webpack --config ./webpack.config.ts",
-        "web": "PROJECT=web yarn run base",
+        "core:web": "PROJECT=\"suite-web\" yarn workspace @trezor/connect-iframe build:core-module",
+        "web": "yarn run core:web && PROJECT=web yarn run base",
         "dev:web": "yarn run web",
         "build:web": "NODE_ENV=production yarn run web",
         "desktop": "PROJECT=desktop yarn run base",

--- a/packages/suite-build/tsconfig.json
+++ b/packages/suite-build/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "./libDev" },
-    "include": ["."],
+    "include": [".", "**/*.json"],
     "references": [
         {
             "path": "../../suite-common/suite-config"

--- a/packages/suite-web/e2e/cypress.config.ts
+++ b/packages/suite-web/e2e/cypress.config.ts
@@ -69,7 +69,6 @@ export default defineConfig({
         video: true,
         trashAssetsBeforeRuns: false,
         chromeWebSecurity: false,
-        experimentalFetchPolyfill: true,
         experimentalRunAllSpecs: true,
         setupNodeEvents(on, config) {
             on('before:browser:launch', _browser => {

--- a/packages/suite-web/e2e/stubs/metadata.ts
+++ b/packages/suite-web/e2e/stubs/metadata.ts
@@ -17,7 +17,11 @@ export const rerouteMetadataToMockProvider = (
     try {
         url = new URL(uri);
     } catch {
-        // catching absolute next.js urls which throw in URL constructor
+        // When requests like `./data/firmware/t3w1/releases.json` from connect they need to be
+        // provided with baseUrl so cypress can figure out where it is going.
+        const baseUrl = window.location.origin;
+        uri = new URL(uri, baseUrl).href;
+
         return fetch(uri, options);
     }
 

--- a/packages/suite-web/e2e/tests/onboarding/firmware-update.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/firmware-update.test.ts
@@ -33,7 +33,7 @@ describe.skip('fw update from empty device bootloader 2.0.3 to firmware 2.5.1', 
         cy.task('startMockedBridge', har);
 
         // make sure that we always upgrade to version 2.5.1
-        cy.intercept('*', { pathname: '/static/connect/data/firmware/t2t1/releases.json' }, [
+        cy.intercept('*', { pathname: '/data/firmware/t2t1/releases.json' }, [
             {
                 required: false,
                 version: [2, 5, 1],
@@ -53,7 +53,7 @@ describe.skip('fw update from empty device bootloader 2.0.3 to firmware 2.5.1', 
         // make sure that 2.5.1 does not return 404
         cy.intercept(
             '*',
-            { pathname: '/static/connect/data/firmware/t2t1/trezor-t2t1-2.5.1.bin' },
+            { pathname: '/data/firmware/t2t1/trezor-t2t1-2.5.1.bin' },
             // seems like response does not matter. I thought there was firmware validation but it is probably
             // only in place for custom firmware?
             'foo-bar',

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -1,7 +1,6 @@
 import { saveAs } from 'file-saver';
 import { PayloadAction } from '@reduxjs/toolkit';
 
-import { resolveStaticPath } from '@suite-common/suite-utils';
 import { getAccountKey, buildHistoricRatesFromStorage } from '@suite-common/wallet-utils';
 import {
     DeviceRootState,
@@ -40,7 +39,7 @@ import { AppState, ButtonRequest, TrezorDevice } from '../types/suite';
 import { METADATA, STORAGE } from '../actions/suite/constants';
 import { selectSuiteSettings } from '../reducers/suite/suiteReducer';
 
-const connectSrc = resolveStaticPath('connect/');
+const connectSrc = '../';
 // 'https://localhost:8088/';
 // 'https://connect.corp.sldev.cz/develop/';
 

--- a/packages/utils/src/cloneObjectCyclic.ts
+++ b/packages/utils/src/cloneObjectCyclic.ts
@@ -1,0 +1,37 @@
+// Makes a deep copy of an object, handling cyclical references.
+export const cloneObjectCyclic = <T>(obj: T, seen = new WeakMap<object, any>()): T => {
+    if (obj === null || typeof obj !== 'object') {
+        return obj;
+    }
+
+    if (seen.has(obj)) {
+        return seen.get(obj);
+    }
+
+    if (obj instanceof ArrayBuffer) {
+        return obj.slice(0) as any;
+    }
+
+    if (ArrayBuffer.isView(obj)) {
+        const TypedArrayConstructor = obj.constructor as new (...args: any[]) => typeof obj;
+
+        return new TypedArrayConstructor(obj) as any;
+    }
+
+    const clone: any = Array.isArray(obj) ? [] : {};
+    seen.set(obj, clone);
+
+    for (const key in obj) {
+        if (Object.prototype.hasOwnProperty.call(obj, key)) {
+            const value = (obj as any)[key];
+
+            if (typeof value === 'function' || typeof value === 'symbol') {
+                continue;
+            }
+
+            (clone as any)[key] = cloneObjectCyclic(value, seen);
+        }
+    }
+
+    return clone;
+};

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -49,3 +49,4 @@ export * from './throttler';
 export * from './extractUrlsFromText';
 export * from './isFullPath';
 export * from './asciiUtils';
+export * from './cloneObjectCyclic';

--- a/packages/utils/tests/cloneObjectCyclic.test.ts
+++ b/packages/utils/tests/cloneObjectCyclic.test.ts
@@ -1,0 +1,71 @@
+import { cloneObjectCyclic } from '../src/cloneObjectCyclic';
+
+describe('cloneObjectCyclic', () => {
+    describe('deep cloning of objects', () => {
+        it('should clone a simple object', () => {
+            const original = { a: 1, b: 2 };
+            const cloned = cloneObjectCyclic(original);
+            expect(cloned).toEqual(original);
+            expect(cloned).not.toBe(original);
+        });
+
+        it('should clone an object with nested properties', () => {
+            const original = { a: { b: { c: 3 } } };
+            const cloned = cloneObjectCyclic(original);
+            expect(cloned).toEqual(original);
+            expect(cloned.a).not.toBe(original.a);
+        });
+
+        it('should handle cyclical references', () => {
+            const original = { a: 1 };
+            // @ts-expect-error"
+            original['cyclical'] = original;
+            const cloned = cloneObjectCyclic(original);
+            expect(cloned).toEqual(original);
+            // @ts-expect-error"
+            expect(cloned['cyclical']).toBe(cloned);
+        });
+
+        it('should clone arrays', () => {
+            const original = [1, 2, 3, { a: 4 }];
+            const cloned = cloneObjectCyclic(original);
+            expect(cloned).toEqual(original);
+            expect(cloned).not.toBe(original);
+            expect(cloned[3]).not.toBe(original[3]);
+        });
+
+        it('should handle arrays with cyclical references', () => {
+            const original = [1, 2, 3];
+            // @ts-expect-error"
+            original.push(original);
+            const cloned = cloneObjectCyclic(original);
+            expect(cloned).toEqual(original);
+            expect(cloned[3]).toBe(cloned);
+        });
+
+        it('should clone an object with functions and symbols', () => {
+            const original = {
+                a: 1,
+                b: () => {},
+                c: Symbol('symbol'),
+            };
+            const cloned = cloneObjectCyclic(original);
+            expect(cloned).toEqual({ a: 1 });
+            expect(cloned).not.toBe(original);
+        });
+
+        it('should clone an ArrayBuffer', () => {
+            const original = new ArrayBuffer(8);
+            const cloned = cloneObjectCyclic(original);
+            expect(cloned).not.toBe(original);
+            expect(cloned.byteLength).toBe(original.byteLength);
+        });
+
+        it('should clone typed arrays', () => {
+            const original = new Uint8Array([1, 2, 3]);
+            const cloned = cloneObjectCyclic(original);
+            expect(cloned).not.toBe(original);
+            expect(cloned).toEqual(original);
+        });
+    });
+});

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -9,7 +9,7 @@ import TrezorConnect, {
 } from '@trezor/connect';
 import { createDeferred, getSynchronize } from '@trezor/utils';
 import { deviceConnectThunks, selectDevice } from '@suite-common/wallet-core';
-import { resolveStaticPath } from '@suite-common/suite-utils';
+import { resolveConnectPath } from '@suite-common/suite-utils';
 import { isDesktop, isNative } from '@trezor/env-utils';
 import { desktopApi } from '@trezor/suite-desktop-api';
 import { serializeError } from '@trezor/connect/src/constants/errors';
@@ -147,7 +147,7 @@ export const connectInitThunk = createThunk(
         // and it would be impossible to test this thunk in isolation (many unit tests depend on it).
         const binFilesBaseUrl = isDesktop()
             ? extra.selectors.selectDesktopBinDir(getState())
-            : resolveStaticPath('connect/data');
+            : resolveConnectPath('data');
 
         try {
             await TrezorConnect.init({

--- a/suite-common/suite-utils/src/resolveStaticPath.ts
+++ b/suite-common/suite-utils/src/resolveStaticPath.ts
@@ -2,3 +2,8 @@ export const resolveStaticPath = (
     path: string,
     pathPrefix: string | undefined = process.env.ASSET_PREFIX,
 ) => `${pathPrefix || ''}/static/${path.replace(/^\/+/, '')}`;
+
+export const resolveConnectPath = (
+    path: string,
+    pathPrefix: string | undefined = process.env.ASSET_PREFIX,
+) => `${pathPrefix || ''}/${path.replace(/^\/+/, '')}`;

--- a/suite-common/wallet-core/src/firmware/getBinFilesBaseUrlThunk.ts
+++ b/suite-common/wallet-core/src/firmware/getBinFilesBaseUrlThunk.ts
@@ -1,5 +1,5 @@
 import { isDesktop } from '@trezor/env-utils';
-import { resolveStaticPath } from '@suite-common/suite-utils';
+import { resolveConnectPath } from '@suite-common/suite-utils';
 import { createThunk } from '@suite-common/redux-utils';
 
 import { FIRMWARE_MODULE_PREFIX } from './firmwareActions';
@@ -10,7 +10,5 @@ import { FIRMWARE_MODULE_PREFIX } from './firmwareActions';
 export const getBinFilesBaseUrlThunk = createThunk(
     `${FIRMWARE_MODULE_PREFIX}/getBinFilesBaseUrlThunk`,
     (_params, { getState, extra }) =>
-        isDesktop()
-            ? extra.selectors.selectDesktopBinDir(getState())
-            : resolveStaticPath('connect/data'),
+        isDesktop() ? extra.selectors.selectDesktopBinDir(getState()) : resolveConnectPath('data'),
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR makes changes in order to allow Trezor Suite to use connect as a module instead of using iframe.

* [feat(connect): core in module](https://github.com/trezor/trezor-suite/pull/14959/commits/76470c2db765556687941b05ffc8ea33ed4312a3) - new core-in-module implementation of Trezor Connect. - It required changes in DataManager so json files like `releases.json` are included in the conenct bundle instead of fetched. It makes the bundle a bit bigger but it requires less fetches.
* [feat(connect-iframe): build core in module for suite](https://github.com/trezor/trezor-suite/pull/14959/commits/f3053de37660b9701cd909f00c91127bb8ebbd68) - refactoring webpack in iframe so it allows to be used for iframe and core-in-module as well as core-in-popup. Eventually iframe could be ditched.
* [feat(connect-web): core in module for web](https://github.com/trezor/trezor-suite/pull/14959/commits/1678edfe47f35f438f2ba07053f5eb02eadc48f6) - implementation of core-in-module for connect-web - it uses `TrezorConnectDynamic`  and use the web code like WebUSB here so it in the environment where it is used.
* [feat(suite-common): integrate connect as module](https://github.com/trezor/trezor-suite/pull/14959/commits/8e638499a60935192a031c5dbb0243dd86cd2c99) - changes in suite-common so it fetches properly the new connect data using `resolveConnectPath`.
* [feat(suite-build): use core in module for suite](https://github.com/trezor/trezor-suite/pull/14959/commits/d14610c837fc5472b1ad7b591449ec9beddf0c11) - suite-builds now are able to build the whole connect. This could be a middle step to the final one where this webpack will build the whole connect instead of delegating it to the one in iframe.
* [feat(suite): update connectSrc in suite](https://github.com/trezor/trezor-suite/pull/14959/commits/3fa3ff612bfc6cc086b12badd716676539765bf9) - changing to new connect path in suite.
* [test(suite-web): update test for suite with core in module](https://github.com/trezor/trezor-suite/pull/14959/commits/d412eda4b7ea8f9f9ae4ab2d7efc1cfe36a70b90) - updating tests so they work with new core-in-module in suite.
* [chore(connect-popup): update core-module build process](https://github.com/trezor/trezor-suite/pull/14959/commits/a7c624cc7505d18fdf36c3e2be7d46c8d47350ce) - update popup to use core module from the new updated webpacks in iframe instead of copying.
* [ci(github): add asset path to popup build](https://github.com/trezor/trezor-suite/pull/14959/commits/bc817b9e4d25ac9de7e9925e128329ead4440320) - update release connect action to use the assets path.
* [ci(github): remove unnecessary build steps in suite-web](https://github.com/trezor/trezor-suite/pull/14959/commits/db158fe2db4fa15468de710cb71c3d14dc67c354)
* [feat(utils): cloneCyclicObject new util](https://github.com/trezor/trezor-suite/pull/14959/commits/0d31f2614e10864684993ee0445bb8123f15c3c7) - new utility that allows to clone object that contain cyclic objects inside


Now you should be able to run `yarn suite:dev` and have all the suite web built including the connect part.
