### PR TITLE
fix(protobuf): skip benchmark messages

### DIFF
--- a/packages/protobuf/scripts/protobuf-build.sh
+++ b/packages/protobuf/scripts/protobuf-build.sh
@@ -39,7 +39,7 @@ cd ..
 
 cd "$SCRIPTS_PATH"
 
-yarn tsx ./protobuf-definitions.ts "$REPO_PATH/common/protob" --skip=monero,webauthn,thp
+yarn tsx ./protobuf-definitions.ts "$REPO_PATH/common/protob" --skip=monero,webauthn,thp,benchmark
 yarn tsx ./protobuf-types.ts
 
 yarn workspace @trezor/protobuf g:prettier --write {messages.json,src/messages.ts} 


### PR DESCRIPTION
## Description

`messages-benchmark.proto` seems to be causing some issue in build and they probably shouldn't be included anyway, add them to the list of skipped defs.