### PR TITLE
fix(connect-popup): analytics for core in popup

### DIFF
--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -320,6 +320,22 @@ const handleMessageInCoreMode = (
                 info: method.info,
             });
             reactEventBus.dispatch({ type: 'state-update', payload: getState() });
+
+            const { settings } = getState();
+            const transport = core.getTransportInfo();
+            analytics.report({
+                type: EventType.AppReady,
+                payload: {
+                    version: settings?.version,
+                    origin: settings?.origin,
+                    referrerApp: settings?.manifest?.appUrl,
+                    referrerEmail: settings?.manifest?.email,
+                    method: method?.name,
+                    payload: method?.payload ? Object.keys(method.payload) : undefined,
+                    transportType: transport?.type,
+                    transportVersion: transport?.version,
+                },
+            });
         });
     }
 


### PR DESCRIPTION
## Description

Add AppReady event handling to core in popup flow.

## Related Issue

Resolve #14983