### PR TITLE
chore(suite-native): isArrayMember TS improvement

### DIFF
--- a/suite-native/discovery/src/discoveryThunks.ts
+++ b/suite-native/discovery/src/discoveryThunks.ts
@@ -37,6 +37,7 @@ import {
 import { DiscoveryStatus } from '@suite-common/wallet-constants';
 import { requestDeviceAccess } from '@suite-native/device-mutex';
 import { analytics, EventType } from '@suite-native/analytics';
+import { isArrayMember } from '@trezor/utils';
 
 import {
     selectDiscoveryInfo,
@@ -561,7 +562,8 @@ export const createDescriptorPreloadedDiscoveryThunk = createThunk(
                 ({ accountType }) =>
                     // Some cardano derivation may not be supported by the device. We need to exclude them from total count.
                     network.networkType !== 'cardano' ||
-                    (availableCardanoDerivations as string[]).includes(accountType),
+                    (availableCardanoDerivations !== undefined &&
+                        isArrayMember(accountType, availableCardanoDerivations)),
             );
 
             return count + availableAccountTypes.length;
@@ -664,7 +666,7 @@ export const startDescriptorPreloadedDiscoveryThunk = createThunk(
             network =>
                 network.networkType !== 'cardano' ||
                 normalizeNetworkAccounts(network).some(({ accountType }) =>
-                    (availableCardanoDerivations as string[]).includes(accountType),
+                    isArrayMember(accountType, availableCardanoDerivations),
                 ),
         );
 
@@ -689,7 +691,7 @@ export const startDescriptorPreloadedDiscoveryThunk = createThunk(
                 .filter(
                     ({ accountType }: NetworkAccount) =>
                         network.networkType !== 'cardano' ||
-                        (availableCardanoDerivations as string[]).includes(accountType),
+                        isArrayMember(accountType, availableCardanoDerivations),
                 )
                 .forEach(({ accountType }: NetworkAccount) => {
                     dispatch(discoverNetworkBatchThunk({ deviceState, network, accountType }));

--- a/suite-native/staking/package.json
+++ b/suite-native/staking/package.json
@@ -14,6 +14,7 @@
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
-        "@suite-common/wallet-utils": "workspace:*"
+        "@suite-common/wallet-utils": "workspace:*",
+        "@trezor/utils": "workspace:*"
     }
 }

--- a/suite-native/staking/src/utils.ts
+++ b/suite-native/staking/src/utils.ts
@@ -1,4 +1,5 @@
 import { NetworkSymbol } from '@suite-common/wallet-config';
+import { isArrayMember } from '@trezor/utils';
 
 const stakingCoins = ['eth', 'thol', 'tsep'] as const satisfies NetworkSymbol[];
 type NetworkSymbolWithStaking = (typeof stakingCoins)[number];
@@ -6,5 +7,5 @@ type NetworkSymbolWithStaking = (typeof stakingCoins)[number];
 export const doesCoinSupportStaking = (
     symbol: NetworkSymbol,
 ): symbol is NetworkSymbolWithStaking => {
-    return stakingCoins.includes(symbol as any);
+    return isArrayMember(symbol, stakingCoins);
 };

--- a/suite-native/staking/tsconfig.json
+++ b/suite-native/staking/tsconfig.json
@@ -13,6 +13,7 @@
         },
         {
             "path": "../../suite-common/wallet-utils"
-        }
+        },
+        { "path": "../../packages/utils" }
     ]
 }

--- a/suite-native/tokens/package.json
+++ b/suite-native/tokens/package.json
@@ -17,6 +17,7 @@
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
         "@trezor/blockchain-link": "workspace:*",
+        "@trezor/utils": "workspace:*",
         "proxy-memoize": "2.0.2",
         "react": "18.2.0"
     }

--- a/suite-native/tokens/src/utils.ts
+++ b/suite-native/tokens/src/utils.ts
@@ -1,6 +1,7 @@
 import { G, S } from '@mobily/ts-belt';
 
 import { NetworkSymbol } from '@suite-common/wallet-config';
+import { isArrayMember } from '@trezor/utils';
 
 export const getTokenName = (tokenName?: string) => {
     if (G.isNullable(tokenName) || S.isEmpty(tokenName)) return 'Unknown token';
@@ -11,7 +12,5 @@ export const getTokenName = (tokenName?: string) => {
 export const NETWORK_SYMBOLS_WITH_TOKENS = ['eth', 'pol', 'bnb'] satisfies Array<NetworkSymbol>;
 export type NetworkSymbolWithTokens = (typeof NETWORK_SYMBOLS_WITH_TOKENS)[number];
 
-export const isCoinWithTokens = (symbol: NetworkSymbol): symbol is NetworkSymbolWithTokens => {
-    // We typecast because TS does complain that other coins like btc are not included in NETWORKS_WITH_TOKENS which is whole point of this function to check it
-    return NETWORK_SYMBOLS_WITH_TOKENS.includes(symbol as NetworkSymbolWithTokens);
-};
+export const isCoinWithTokens = (symbol: NetworkSymbol): symbol is NetworkSymbolWithTokens =>
+    isArrayMember(symbol, NETWORK_SYMBOLS_WITH_TOKENS);

--- a/suite-native/tokens/tsconfig.json
+++ b/suite-native/tokens/tsconfig.json
@@ -16,6 +16,7 @@
         },
         {
             "path": "../../packages/blockchain-link"
-        }
+        },
+        { "path": "../../packages/utils" }
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10676,6 +10676,7 @@ __metadata:
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"
+    "@trezor/utils": "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -10791,6 +10792,7 @@ __metadata:
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@trezor/blockchain-link": "workspace:*"
+    "@trezor/utils": "workspace:*"
     proxy-memoize: "npm:2.0.2"
     react: "npm:18.2.0"
   languageName: unknown


### PR DESCRIPTION
## Description
A new typescript util [isArrayMember](https://github.com/trezor/trezor-suite/blob/e10d590dabb68d4654ef4b91b5bf39ea80e575cc/packages/type-utils/src/utils.ts#L62-L74) was added in #14830, and it solves [a common issue](https://github.com/trezor/trezor-suite/pull/15004#discussion_r1810377227) with `Array.includes`

:arrow_right: implement the util in `suite-native` to remove some `as` occurences (no change in behavior)