### PR TITLE
feat(suite): enable pin entry cancellation during fw update

### DIFF
--- a/packages/connect/src/device/DeviceCommands.ts
+++ b/packages/connect/src/device/DeviceCommands.ts
@@ -373,10 +373,10 @@ export class DeviceCommands {
     }
 
     async _commonCall(type: MessageKey, msg?: DefaultPayloadMessage['message']) {
-        const resp = await this.call(type, msg);
         if (this.disposed) {
             throw ERRORS.TypedError('Runtime', 'typedCall: DeviceCommands already disposed');
         }
+        const resp = await this.call(type, msg);
 
         return this._filterCommonTypes(resp);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Enable PIN entry cancellation in Suite during FW update.

To reproduce, lock your device by holding screen/button before starting the update flow.

Note that the PIN entry is cancellable only before the installation begins, not the second time PIN is requested after installation is completed. This is because the device is not acquired at that point, thus cannot be interacted with.

Resolves https://github.com/trezor/trezor-suite/pull/14833#issuecomment-2428686169

## Screenshots:
https://github.com/user-attachments/assets/4fb52538-f8df-4bd4-80ee-b7f90684c128

