### PR TITLE
fix(suite): tighten condition to set uiEvent for firmware update

### DIFF
--- a/suite-common/wallet-core/src/firmware/firmwareReducer.ts
+++ b/suite-common/wallet-core/src/firmware/firmwareReducer.ts
@@ -96,7 +96,10 @@ export const prepareFirmwareReducer = createReducerWithExtraDeps(initialState, (
                 action.type === UI.FIRMWARE_PROGRESS ||
                 action.type === DEVICE.BUTTON,
             (state, action) => {
-                state.uiEvent = action;
+                // DEVICE.BUTTON can be dispatched outside of the firmware update flow and that should not change the uiEvent,
+                // otherwise it could result in confirmation pill being displayed unintentionally.
+                if (!(action.type === DEVICE.BUTTON && state.status === 'initial'))
+                    state.uiEvent = action;
             },
         );
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

See the comment in code for explanation.

How to reproduce the bug:
1. Use TS5 with PIN.
2. Click _Change PIN_.
3. Cancel on device while entering PIN.
4. Open update modal - see unexpected confirmation pill on top.

## Screenshots:
Before:

https://github.com/user-attachments/assets/4caf9d38-297d-4396-8519-f3a1f167bd72

