### PR TITLE
fix(suite-native): prevent device actions cutoff by removing explicit height

### DIFF
--- a/suite-native/device-manager/src/components/DeviceAction.tsx
+++ b/suite-native/device-manager/src/components/DeviceAction.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 import { Pressable } from 'react-native';
 
-import { HStack, ACCESSIBILITY_FONTSIZE_MULTIPLIER } from '@suite-native/atoms';
+import { HStack } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 type DeviceActionProps = {
@@ -16,7 +16,6 @@ const contentStyle = prepareNativeStyle(utils => ({
     paddingHorizontal: utils.spacings.sp12,
     paddingVertical: utils.spacings.sp12,
     alignItems: 'center',
-    height: 44 * ACCESSIBILITY_FONTSIZE_MULTIPLIER,
     gap: utils.spacings.sp8,
     backgroundColor: utils.colors.backgroundSurfaceElevation1,
     borderWidth: utils.borders.widths.small,


### PR DESCRIPTION
## Description

This issue was not present in production; it was introduced in the development branch at https://github.com/trezor/trezor-suite/pull/14963. The issue was visible only with non-standard system font scaling.

With ACCESSIBILITY_FONTSIZE_MULTIPLIER == 1, everything worked fine, but with a lower value, the text was cut off.

The fixed height doesn't seems to be necessary. Tested with different font scales on both android and ios...

## Screenshots:

BEFORE:
<img width="371" alt="image" src="https://github.com/user-attachments/assets/e4fc3ed2-a903-4479-bf45-dd5e3bc241d3">



AFTER:
<img width="367" alt="image" src="https://github.com/user-attachments/assets/65fad01c-e7ea-4d62-ad43-d399d041557c">

