### PR TITLE
chore(suite-native): SENTRY_AUTH_TOKEN should be taken directly from env variables

### DIFF
--- a/suite-native/app/app.config.ts
+++ b/suite-native/app/app.config.ts
@@ -144,7 +144,6 @@ const getPlugins = (): ExpoPlugins => {
                       '@sentry/react-native/expo',
                       {
                           url: 'https://sentry.io/',
-                          authToken: process.env.SENTRY_AUTH_TOKEN,
                           project: 'suite-native',
                           organization: 'satoshilabs',
                       },


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Passing SENTRY_AUTH_TOKEN via authToken is not recommended and trigger errors like:
```
 Detected unsecure use of 'authToken' in Sentry plugin configuration. To avoid exposing the token use SENTRY_AUTH_TOKEN environment variable instead. https://docs.sentry.io/platforms/react-native/manual-setup/
 ```
 from expo doctor.
