### PR TITLE
feat(connect): expand FW hash check on all models

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -37,7 +37,6 @@ import {
     StaticSessionId,
     FirmwareHashCheckResult,
     FirmwareHashCheckError,
-    DeviceModelInternal,
 } from '../types';
 import { models } from '../data/models';
 import { getLanguage } from '../data/getLanguage';
@@ -617,10 +616,6 @@ export class Device extends TypedEmitter<DeviceEvents> {
         if (firmwareVersion === undefined || !this.features || this.features.bootloader_mode) {
             return null;
         }
-
-        // Initially rolled out only for Model One; in the future we may remove that condition and do it for all models
-        const isModelOne = this.features.internal_model === DeviceModelInternal.T1B1;
-        if (!isModelOne) return createFailResult('check-skipped');
 
         const checkSupported = this.atLeast(FIRMWARE.FW_HASH_SUPPORTED_VERSIONS);
         if (!checkSupported) return createFailResult('check-unsupported');


### PR DESCRIPTION
## Description

Followup to #14766 where FW hash check was implemented for T1B1.

Expand the FW hash check on all models.

## Related Issue

https://github.com/trezor/trezor-suite-private/issues/100