### PR TITLE
chore(connect): isArrayMember TS improvement

### DIFF
--- a/packages/connect/src/utils/assetUtils.ts
+++ b/packages/connect/src/utils/assetUtils.ts
@@ -1,8 +1,8 @@
+import { isArrayMember } from '@trezor/utils';
 import { DeviceModelInternal } from '../types';
 
-const isDeviceModel = (model: string): model is DeviceModelInternal => {
-    return Object.values(DeviceModelInternal).includes(model as DeviceModelInternal);
-};
+const isDeviceModel = (model: string): model is DeviceModelInternal =>
+    isArrayMember(model, Object.values(DeviceModelInternal));
 
 const firmwareAssets: Record<DeviceModelInternal, NodeRequire> = {
     [DeviceModelInternal.T1B1]: require('@trezor/connect-common/files/firmware/t1b1/releases.json'),

--- a/packages/connect/src/utils/deviceFeaturesUtils.ts
+++ b/packages/connect/src/utils/deviceFeaturesUtils.ts
@@ -1,4 +1,4 @@
-import { versionUtils } from '@trezor/utils';
+import { isArrayMember, versionUtils } from '@trezor/utils';
 import { PROTO } from '../constants';
 import { config } from '../data/config';
 import { Features, CoinInfo, UnavailableCapabilities, DeviceModelInternal } from '../types';
@@ -106,7 +106,7 @@ export const getUnavailableCapabilities = (features: Features, coins: CoinInfo[]
             return !capabilities.includes('Capability_Solana');
         }
 
-        return !capabilities.includes(`Capability_${info.name}` as PROTO.Capability);
+        return !isArrayMember(`Capability_${info.name}`, capabilities);
     });
 
     // add unavailable coins to list


### PR DESCRIPTION
## Description

In #15019, `isArrayMember` was created in `@trezor/utils`, and implemented in suite.

:arrow_right: Implement it in `connect` to remove some `as` occurences (no change in behavior)