### PR TITLE
fix(staking): zero amounts when bumping fee

### DIFF
--- a/packages/suite/src/actions/wallet/coinmarket/coinmarketCommonActions.ts
+++ b/packages/suite/src/actions/wallet/coinmarket/coinmarketCommonActions.ts
@@ -2,7 +2,7 @@ import { isDesktop } from '@trezor/env-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { PROTO } from '@trezor/connect';
 import {
-    amountToSatoshi,
+    amountToSmallestUnit,
     formatAmount,
     getAccountDecimals,
     hasNetworkFeatures,
@@ -204,7 +204,7 @@ export const convertDrafts = () => (dispatch: Dispatch, getState: GetState) => {
 
         if (draft) {
             const areSatsSelected = settings.bitcoinAmountUnit === PROTO.AmountUnit.SATOSHI;
-            const conversion = areSatsSelected ? amountToSatoshi : formatAmount;
+            const conversion = areSatsSelected ? amountToSmallestUnit : formatAmount;
             const decimals = getAccountDecimals(relatedAccount.symbol)!;
 
             if (draft.cryptoInput) {

--- a/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
+++ b/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
@@ -8,7 +8,7 @@ import { SignValue } from '@suite-common/suite-types';
 import {
     formatCoinBalance,
     localizeNumber,
-    networkAmountToSatoshi,
+    networkAmountToSmallestUnit,
 } from '@suite-common/wallet-utils';
 import { isSignValuePositive } from '@suite-common/formatters';
 import { selectLanguage } from 'src/reducers/suite/suiteReducer';
@@ -68,7 +68,10 @@ export const FormattedCryptoAmount = ({
 
     // convert to satoshis if needed
     if (isSatoshis) {
-        formattedValue = networkAmountToSatoshi(String(value), lowerCaseSymbol as NetworkSymbol);
+        formattedValue = networkAmountToSmallestUnit(
+            String(value),
+            lowerCaseSymbol as NetworkSymbol,
+        );
 
         formattedSymbol = isTestnet ? `sat ${symbol?.toUpperCase()}` : 'sat';
     }

--- a/packages/suite/src/components/suite/UnstakingTxAmount.tsx
+++ b/packages/suite/src/components/suite/UnstakingTxAmount.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import { isUnstakeTx } from '@suite-common/suite-utils';
+import { getUnstakeAmountByEthereumDataHex, isUnstakeTx } from '@suite-common/suite-utils';
 import { WalletAccountTransaction } from '@suite-common/wallet-types';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
-import { getUnstakingAmount } from 'src/utils/suite/stake';
 import { FormattedCryptoAmount } from './FormattedCryptoAmount';
 
 interface UnstakingTxAmountProps {
@@ -15,7 +14,7 @@ export const UnstakingTxAmount = ({ transaction }: UnstakingTxAmountProps) => {
 
     if (!isUnstakeTx(txSignature)) return null;
 
-    const amount = getUnstakingAmount(ethereumSpecific?.data);
+    const amount = getUnstakeAmountByEthereumDataHex(ethereumSpecific?.data);
 
     if (!amount) return null;
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
@@ -56,7 +56,8 @@ export type TransactionReviewOutputProps = {
 
 export const TransactionReviewOutput = forwardRef<HTMLDivElement, TransactionReviewOutputProps>(
     (props, ref) => {
-        const { type, state, label, value, symbol, token, account, ethereumStakeType } = props;
+        const { type, state, label, value, symbol, token, account, ethereumStakeType, isRbf } =
+            props;
         let outputLabel: ReactNode = label;
         const { networkType } = account;
         const { translationString } = useTranslation();
@@ -155,6 +156,11 @@ export const TransactionReviewOutput = forwardRef<HTMLDivElement, TransactionRev
             ];
         } else if (['data', 'address'].includes(type) && ethereumStakeType) {
             const displayModeStringsMap = getDisplayModeStringsMap();
+
+            // prevents double label when bumping stake type txs
+            if (type === 'address' && isRbf) {
+                return null;
+            }
 
             outputLines = [
                 {

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
@@ -171,12 +171,13 @@ export const TransactionReviewOutputElement = forwardRef<
         const network = account?.networkType;
         const cardanoFingerprint = getFingerprint(account?.tokens, token?.symbol);
         const isActive = state === 'active';
-        const hasMultipleLines = lines.length > 1;
+
+        const showMultiIndicator = lines.length > 1;
 
         return (
             <OutputWrapper ref={ref}>
-                <OutputLeft $isCentered={hasMultipleLines}>
-                    {hasMultipleLines ? (
+                <OutputLeft $isCentered={showMultiIndicator}>
+                    {showMultiIndicator ? (
                         <MultiIndicatorWrapper $linesCount={lines.length - 1}>
                             {indicator}
                         </MultiIndicatorWrapper>

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
@@ -6,7 +6,7 @@ import { FiatValue, FormattedCryptoAmount, Translation } from 'src/components/su
 import { Account } from 'src/types/wallet';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { TokenInfo } from '@trezor/connect';
-import { amountToSatoshi } from '@suite-common/wallet-utils';
+import { amountToSmallestUnit } from '@suite-common/wallet-utils';
 import { TransactionReviewStepIndicatorProps } from './TransactionReviewStepIndicator';
 import { zIndices } from '@trezor/theme';
 import { DeviceDisplay } from '../../../../DeviceDisplay/DeviceDisplay';
@@ -245,7 +245,7 @@ export const TransactionReviewOutputElement = forwardRef<
                                         <Translation id="TR_CARDANO_TREZOR_AMOUNT_HEADLINE" />
                                     </OutputHeadline>
                                     <OutputValue>
-                                        {amountToSatoshi(line.value, token.decimals)}
+                                        {amountToSmallestUnit(line.value, token.decimals)}
                                     </OutputValue>
                                 </CardanoTrezorAmountWrapper>
                             )}

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
@@ -234,6 +234,8 @@ export const TransactionReviewOutputList = ({
                                 outputs={outputs}
                                 buttonRequestsCount={buttonRequestsCount}
                                 precomposedTx={precomposedTx}
+                                ethereumStakeType={ethereumStakeType}
+                                isRbfAction={isRbfAction}
                             />
                         )}
                     </RightTopInner>

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
@@ -242,6 +242,8 @@ export const TransactionReviewSummary = ({
     const isFeeCustom = drafts[currentAccountKey]?.selectedFee === 'custom';
     const isComposedFeeRateDifferent = isFeeCustom && formFeeRate !== fee;
 
+    const isZeroAmount = amount === '0'; // bump claim tx and trade approve has 0 value
+
     return (
         <Wrapper>
             <SummaryHead>
@@ -254,13 +256,15 @@ export const TransactionReviewSummary = ({
 
                 <Headline>
                     <Translation id={actionText} />
-                    <HeadlineAmount>
-                        <FormattedCryptoAmount
-                            disableHiddenPlaceholder
-                            value={amount}
-                            symbol={tx.token?.symbol ?? symbol}
-                        />
-                    </HeadlineAmount>
+                    {!isZeroAmount && (
+                        <HeadlineAmount>
+                            <FormattedCryptoAmount
+                                disableHiddenPlaceholder
+                                value={amount}
+                                symbol={tx.token?.symbol ?? symbol}
+                            />
+                        </HeadlineAmount>
+                    )}
                 </Headline>
 
                 <AccountWrapper>

--- a/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketCurrencySwitcher.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketCurrencySwitcher.ts
@@ -1,6 +1,6 @@
 import { Network } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
-import { amountToSatoshi, formatAmount } from '@suite-common/wallet-utils';
+import { amountToSmallestUnit, formatAmount } from '@suite-common/wallet-utils';
 import { useDidUpdate } from '@trezor/react-utils';
 import { UseFormReturn, useWatch } from 'react-hook-form';
 import {
@@ -56,7 +56,7 @@ export const useCoinmarketCurrencySwitcher = <T extends CoinmarketAllFormProps>(
 
         if (!amountInCrypto) {
             const amount = shouldSendInSats
-                ? amountToSatoshi(quoteCryptoAmount ?? '', networkDecimals)
+                ? amountToSmallestUnit(quoteCryptoAmount ?? '', networkDecimals)
                 : quoteCryptoAmount;
 
             setValue(inputNames.cryptoInput, amount === '-1' ? '' : amount);
@@ -73,7 +73,7 @@ export const useCoinmarketCurrencySwitcher = <T extends CoinmarketAllFormProps>(
     };
 
     useDidUpdate(() => {
-        const conversion = shouldSendInSats ? amountToSatoshi : formatAmount;
+        const conversion = shouldSendInSats ? amountToSmallestUnit : formatAmount;
 
         if (!cryptoInputValue) {
             return;

--- a/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketFiatValues.tsx
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketFiatValues.tsx
@@ -1,7 +1,7 @@
 import { networks, NetworkSymbol } from '@suite-common/wallet-config';
 import { selectFiatRatesByFiatRateKey, updateFiatRatesThunk } from '@suite-common/wallet-core';
 import { FiatRatesResult, Rate, Timestamp, TokenAddress } from '@suite-common/wallet-types';
-import { amountToSatoshi, getFiatRateKey, toFiatCurrency } from '@suite-common/wallet-utils';
+import { amountToSmallestUnit, getFiatRateKey, toFiatCurrency } from '@suite-common/wallet-utils';
 import { CryptoId, FiatCurrencyCode } from 'invity-api';
 import { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -90,7 +90,7 @@ export const useCoinmarketFiatValues = ({
 
     const decimals = getNetworkDecimals(network?.decimals);
     const formattedBalance = shouldSendInSats
-        ? amountToSatoshi(accountBalance, decimals)
+        ? amountToSmallestUnit(accountBalance, decimals)
         : accountBalance;
     const fiatValue = toFiatCurrency(accountBalance, fiatRate?.rate, 2);
 

--- a/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketFormActions.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketFormActions.ts
@@ -1,7 +1,7 @@
 import { isChanged } from '@suite-common/suite-utils';
 import { selectAccounts, selectDevice } from '@suite-common/wallet-core';
 import {
-    amountToSatoshi,
+    amountToSmallestUnit,
     formatAmount,
     fromFiatCurrency,
     isEthereumAccountSymbol,
@@ -132,7 +132,7 @@ export const useCoinmarketFormActions = <T extends CoinmarketSellExchangeFormPro
 
             const formattedCryptoAmount =
                 cryptoAmount && shouldSendInSats
-                    ? amountToSatoshi(cryptoAmount, networkDecimals)
+                    ? amountToSmallestUnit(cryptoAmount, networkDecimals)
                     : cryptoAmount ?? '';
             setValue(FORM_OUTPUT_AMOUNT, formattedCryptoAmount, { shouldValidate: true });
         },
@@ -235,7 +235,7 @@ export const useCoinmarketFormActions = <T extends CoinmarketSellExchangeFormPro
                   .decimalPlaces(networkDecimals)
                   .toString();
         const cryptoInputValue = shouldSendInSats
-            ? amountToSatoshi(amount, networkDecimals)
+            ? amountToSmallestUnit(amount, networkDecimals)
             : amount;
         clearErrors([FORM_OUTPUT_FIAT, FORM_OUTPUT_AMOUNT]);
         setValue(FORM_OUTPUT_AMOUNT, cryptoInputValue, { shouldDirty: true });

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeForm.ts
@@ -7,7 +7,7 @@ import type {
     FiatCurrencyCode,
 } from 'invity-api';
 import useDebounce from 'react-use/lib/useDebounce';
-import { amountToSatoshi, formatAmount, toFiatCurrency } from '@suite-common/wallet-utils';
+import { amountToSmallestUnit, formatAmount, toFiatCurrency } from '@suite-common/wallet-utils';
 import { isChanged } from '@suite-common/suite-utils';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import invityAPI from 'src/services/suite/invityAPI';
@@ -484,7 +484,7 @@ export const useCoinmarketExchangeForm = ({
             selectedQuote.sendStringAmount
         ) {
             const sendStringAmount = shouldSendInSats
-                ? amountToSatoshi(selectedQuote.sendStringAmount, network.decimals)
+                ? amountToSmallestUnit(selectedQuote.sendStringAmount, network.decimals)
                 : selectedQuote.sendStringAmount;
             const result = await recomposeAndSign(
                 account,

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSellForm.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSellForm.ts
@@ -2,7 +2,7 @@ import { useCallback, useState, useEffect, useRef } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 import type { BankAccount, CryptoId, SellFiatTrade, SellFiatTradeQuoteRequest } from 'invity-api';
 import useDebounce from 'react-use/lib/useDebounce';
-import { amountToSatoshi, formatAmount } from '@suite-common/wallet-utils';
+import { amountToSmallestUnit, formatAmount } from '@suite-common/wallet-utils';
 import { isChanged } from '@suite-common/suite-utils';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import invityAPI from 'src/services/suite/invityAPI';
@@ -469,7 +469,7 @@ export const useCoinmarketSellForm = ({
             selectedQuote.cryptoStringAmount
         ) {
             const cryptoStringAmount = shouldSendInSats
-                ? amountToSatoshi(selectedQuote.cryptoStringAmount, network.decimals)
+                ? amountToSmallestUnit(selectedQuote.cryptoStringAmount, network.decimals)
                 : selectedQuote.cryptoStringAmount;
             const destinationPaymentExtraId =
                 selectedQuote.destinationPaymentExtraId || trade?.data?.destinationPaymentExtraId;

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -19,7 +19,7 @@ import { FormState } from '@suite-common/wallet-types';
 import {
     getFeeLevels,
     getDefaultValues,
-    amountToSatoshi,
+    amountToSmallestUnit,
     formatAmount,
 } from '@suite-common/wallet-utils';
 import { useSendFormOutputs } from './useSendFormOutputs';
@@ -290,7 +290,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
                 const protocolAmount = protocol.sendForm.amount.toString();
 
                 const formattedAmount = shouldSendInSats
-                    ? amountToSatoshi(protocolAmount, state.network.decimals)
+                    ? amountToSmallestUnit(protocolAmount, state.network.decimals)
                     : protocolAmount;
 
                 sendFormUtils.setAmount(outputIndex, formattedAmount);
@@ -356,7 +356,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
     useDidUpdate(() => {
         const { outputs } = getValues();
 
-        const conversionToUse = shouldSendInSats ? amountToSatoshi : formatAmount;
+        const conversionToUse = shouldSendInSats ? amountToSmallestUnit : formatAmount;
 
         outputs.forEach((output, index) => {
             if (!output.amount) {

--- a/packages/suite/src/hooks/wallet/useSendFormImport.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormImport.ts
@@ -6,7 +6,7 @@ import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 import { DEFAULT_PAYMENT } from '@suite-common/wallet-constants';
 import { FiatCurrencyCode, fiatCurrencies } from '@suite-common/suite-config';
 import {
-    amountToSatoshi,
+    amountToSmallestUnit,
     formatAmount,
     fromFiatCurrency,
     getFiatRateKey,
@@ -97,7 +97,7 @@ export const useSendFormImport = ({
                     const cryptoAmount = item.amount || '';
                     if (shouldSendInSats) {
                         // try to convert to satoshis
-                        output.amount = amountToSatoshi(cryptoAmount, network.decimals);
+                        output.amount = amountToSmallestUnit(cryptoAmount, network.decimals);
                     } else {
                         output.amount = cryptoAmount;
                     }
@@ -126,7 +126,7 @@ export const useSendFormImport = ({
                     const cryptoValue = fromFiatCurrency(output.fiat, network.decimals, itemRate);
                     const cryptoAmount =
                         cryptoValue && shouldSendInSats
-                            ? amountToSatoshi(cryptoValue, network.decimals)
+                            ? amountToSmallestUnit(cryptoValue, network.decimals)
                             : cryptoValue ?? '';
 
                     output.amount = cryptoAmount;

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -10,8 +10,8 @@ import type { OnUpgradeFunc } from '@trezor/suite-storage';
 import type { DBWalletAccountTransaction, SuiteDBSchema } from '../definitions';
 import {
     formatNetworkAmount,
-    networkAmountToSatoshi,
-    amountToSatoshi,
+    networkAmountToSmallestUnit,
+    amountToSmallestUnit,
 } from '@suite-common/wallet-utils';
 import { updateAll } from './utils';
 import { DeviceModelInternal, FirmwareType } from '@trezor/connect';
@@ -428,7 +428,8 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
             transaction,
             'txs',
             ({ order, tx: origTx }) => {
-                const unformat = (amount: string) => networkAmountToSatoshi(amount, origTx.symbol);
+                const unformat = (amount: string) =>
+                    networkAmountToSmallestUnit(amount, origTx.symbol);
                 const unformatIfDefined = (amount: string | undefined) =>
                     amount ? unformat(amount) : amount;
 
@@ -439,7 +440,7 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
                     totalSpent: unformat(origTx.totalSpent),
                     tokens: origTx.tokens.map(tok => ({
                         ...tok,
-                        amount: amountToSatoshi(tok.amount, tok.decimals),
+                        amount: amountToSmallestUnit(tok.amount, tok.decimals),
                     })),
                     targets: origTx.targets.map(target => ({
                         ...target,

--- a/packages/suite/src/utils/suite/__fixtures__/stake.ts
+++ b/packages/suite/src/utils/suite/__fixtures__/stake.ts
@@ -47,19 +47,6 @@ export const transformTxFixtures = [
     },
 ];
 
-export const getUnstakingAmountFixtures = [
-    {
-        description: 'should correctly extract and convert the unstaking amount from ethereum data',
-        ethereumData: '76ec871c0000000000000000000000000000000000000000000000000000000000000001', // without 0x
-        expectedAmountWei: '1', // 0.000000000000000001 eth
-    },
-    {
-        description: 'should correctly remove 0x prefix from ethereum data',
-        ethereumData: '0x76ec871c0000000000000000000000000000000000000000000000000000000000000001', // with 0x
-        expectedAmountWei: '1', // 0.000000000000000001 eth
-    },
-];
-
 export const stakeFixture = [
     {
         description: 'should stake 0.1 eth, expect correct transaction object with correct values',

--- a/packages/suite/src/utils/suite/__tests__/stake.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/stake.test.ts
@@ -23,11 +23,9 @@ import {
     getEthNetworkForWalletSdkFixture,
     getInstantStakeTypeFixture,
     getChangedInternalTxFixture,
-    getUnstakingAmountFixtures,
     simulateUnstakeFixture,
 } from '../__fixtures__/stake';
 import {
-    getUnstakingAmount,
     transformTx,
     stake,
     unstake,
@@ -61,15 +59,6 @@ describe('transformTx', () => {
             const result = transformTx(test.tx, test.gasPrice, test.nonce, test.chainId);
             expect(result).toEqual(test.result);
             expect(result).not.toHaveProperty('from');
-        });
-    });
-});
-
-describe('getUnstakingAmount', () => {
-    getUnstakingAmountFixtures.forEach(test => {
-        it(test.description, () => {
-            const result = getUnstakingAmount(test.ethereumData);
-            expect(result).toBe(test.expectedAmountWei);
         });
     });
 });

--- a/packages/suite/src/utils/suite/stake.ts
+++ b/packages/suite/src/utils/suite/stake.ts
@@ -7,7 +7,7 @@ import {
 import { DEFAULT_PAYMENT } from '@suite-common/wallet-constants';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { selectNetwork } from '@everstake/wallet-sdk/ethereum';
-import { fromWei, hexToNumberString, numberToHex, toWei } from 'web3-utils';
+import { fromWei, numberToHex, toWei } from 'web3-utils';
 import { getEthereumEstimateFeeParams, isPending, sanitizeHex } from '@suite-common/wallet-utils';
 import TrezorConnect, { EthereumTransaction, Success, InternalTransfer } from '@trezor/connect';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
@@ -561,16 +561,6 @@ export const getDaysToAddToPoolInitial = (validatorsQueue?: ValidatorsQueue) => 
     const daysToWait = secondsToDays(secondsToWait);
 
     return daysToWait <= 0 ? 1 : daysToWait;
-};
-
-export const getUnstakingAmount = (ethereumData: string | undefined): string | null => {
-    if (!ethereumData) return null;
-
-    // Check if the first two characters are '0x' and remove them if they are
-    const data = ethereumData.startsWith('0x') ? ethereumData.slice(2) : ethereumData;
-    const dataBuffer = Buffer.from(data, 'hex');
-
-    return hexToNumberString(`0x${dataBuffer.subarray(4, 36).toString('hex')}`);
 };
 
 export const getInstantStakeType = (

--- a/packages/suite/src/utils/suite/validation.ts
+++ b/packages/suite/src/utils/suite/validation.ts
@@ -7,7 +7,7 @@ import {
     formatNetworkAmount,
     isDecimalsValid,
     isInteger,
-    networkAmountToSatoshi,
+    networkAmountToSmallestUnit,
 } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { TranslationFunction } from 'src/hooks/suite/useTranslation';
@@ -59,7 +59,7 @@ export const validateLimits =
             let minCrypto = 0;
             if (amountLimits.minCrypto) {
                 minCrypto = areSatsUsed
-                    ? Number(networkAmountToSatoshi(amountLimits.minCrypto.toString(), symbol))
+                    ? Number(networkAmountToSmallestUnit(amountLimits.minCrypto.toString(), symbol))
                     : amountLimits.minCrypto;
             }
             if (amountLimits.minCrypto && Number(value) < minCrypto) {
@@ -74,7 +74,7 @@ export const validateLimits =
             let maxCrypto = 0;
             if (amountLimits.maxCrypto) {
                 maxCrypto = areSatsUsed
-                    ? Number(networkAmountToSatoshi(amountLimits.maxCrypto.toString(), symbol))
+                    ? Number(networkAmountToSmallestUnit(amountLimits.maxCrypto.toString(), symbol))
                     : amountLimits.maxCrypto;
             }
             if (amountLimits.maxCrypto && Number(value) > maxCrypto) {
@@ -106,7 +106,7 @@ export const validateLimitsBigNum =
             if (amountLimits.minCrypto) {
                 minCrypto = areSatsUsed
                     ? new BigNumber(
-                          networkAmountToSatoshi(amountLimits.minCrypto.toString(), symbol),
+                          networkAmountToSmallestUnit(amountLimits.minCrypto.toString(), symbol),
                       )
                     : new BigNumber(amountLimits.minCrypto);
             }
@@ -123,7 +123,7 @@ export const validateLimitsBigNum =
             if (amountLimits.maxCrypto) {
                 maxCrypto = areSatsUsed
                     ? new BigNumber(
-                          networkAmountToSatoshi(amountLimits.maxCrypto.toString(), symbol),
+                          networkAmountToSmallestUnit(amountLimits.maxCrypto.toString(), symbol),
                       )
                     : new BigNumber(amountLimits.maxCrypto);
             }

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketBalance.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketBalance.tsx
@@ -1,6 +1,6 @@
 import { networks, NetworkSymbol } from '@suite-common/wallet-config';
 import { TokenAddress } from '@suite-common/wallet-types';
-import { amountToSatoshi } from '@suite-common/wallet-utils';
+import { amountToSmallestUnit } from '@suite-common/wallet-utils';
 import { typography } from '@trezor/theme';
 import { FiatValue, HiddenPlaceholder, Translation } from 'src/components/suite';
 import { useFiatFromCryptoValue } from 'src/hooks/suite/useFiatFromCryptoValue';
@@ -39,7 +39,7 @@ export const CoinmarketBalance = ({
     const stringBalance = !isNaN(Number(balance)) ? balance : '0';
     const formattedBalance =
         stringBalance && shouldSendInSats
-            ? amountToSatoshi(stringBalance, networkDecimals)
+            ? amountToSmallestUnit(stringBalance, networkDecimals)
             : stringBalance;
 
     const { fiatAmount } = useFiatFromCryptoValue({

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputAccountOption.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputAccountOption.tsx
@@ -1,4 +1,4 @@
-import { amountToSatoshi } from '@suite-common/wallet-utils';
+import { amountToSmallestUnit } from '@suite-common/wallet-utils';
 import { useElevation } from '@trezor/components';
 import { HiddenPlaceholder } from 'src/components/suite';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
@@ -40,7 +40,7 @@ export const CoinmarketFormInputAccountOption = ({
 
     const balanceLabel = coinmarketGetAccountLabel(option.label, shouldSendInSats);
     const balance = shouldSendInSats
-        ? amountToSatoshi(option.balance, network.decimals)
+        ? amountToSmallestUnit(option.balance, network.decimals)
         : option.balance;
     const accountType = optionGroups.find(group =>
         group.options.find(

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/CoinControl.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/CoinControl.tsx
@@ -5,7 +5,7 @@ import { typography } from '@trezor/theme';
 import { COMPOSE_ERROR_TYPES } from '@suite-common/wallet-constants';
 import { fetchAllTransactionsForAccountThunk } from '@suite-common/wallet-core';
 import { getTxsPerPage } from '@suite-common/suite-utils';
-import { amountToSatoshi, formatNetworkAmount } from '@suite-common/wallet-utils';
+import { amountToSmallestUnit, formatNetworkAmount } from '@suite-common/wallet-utils';
 import { FormattedCryptoAmount, Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { Pagination } from 'src/components/wallet';
@@ -115,7 +115,7 @@ export const CoinControl = ({ close }: CoinControlProps) => {
     );
     const totalOutputsInSats = shouldSendInSats
         ? totalOutputs
-        : Number(amountToSatoshi(totalOutputs.toString(), network.decimals));
+        : Number(amountToSmallestUnit(totalOutputs.toString(), network.decimals));
     const missingToInput = totalOutputsInSats - totalInputs;
     const isMissingToAmount = missingToInput > 0; // relevant when the amount field is not validated, e.g. there is an error in the address
     const missingAmountTooBig = missingToInput > Number.MAX_SAFE_INTEGER;

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
@@ -10,7 +10,7 @@ import { formInputsMaxLength } from '@suite-common/validators';
 import { selectFiatRatesByFiatRateKey } from '@suite-common/wallet-core';
 import { Output, TokenAddress } from '@suite-common/wallet-types';
 import {
-    amountToSatoshi,
+    amountToSmallestUnit,
     formatNetworkAmount,
     hasNetworkFeatures,
     isLowAnonymityWarning,
@@ -199,7 +199,7 @@ export const Amount = ({ output, outputId }: AmountProps) => {
 
                 if (dust && amountBig.lt(dust)) {
                     if (shouldSendInSats) {
-                        dust = amountToSatoshi(dust, decimals);
+                        dust = amountToSmallestUnit(dust, decimals);
                     }
 
                     return translationString('AMOUNT_IS_BELOW_DUST', {

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/FiatInput.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/FiatInput.tsx
@@ -17,7 +17,7 @@ import {
     getInputState,
     findToken,
     isLowAnonymityWarning,
-    amountToSatoshi,
+    amountToSmallestUnit,
     formatAmount,
     buildCurrencyOptions,
     getFiatRateKey,
@@ -141,7 +141,7 @@ export const FiatInput = ({ output, outputId, labelHoverRight, labelRight }: Fia
             const amount = fiatRate?.rate ? fromFiatCurrency(value, decimals, fiatRate.rate) : null;
 
             const formattedAmount = shouldSendInSats
-                ? amountToSatoshi(amount || '0', decimals)
+                ? amountToSmallestUnit(amount || '0', decimals)
                 : amount;
 
             if (formattedAmount) {

--- a/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.ts
+++ b/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.ts
@@ -7,7 +7,7 @@ import {
     networks,
 } from '@suite-common/wallet-config';
 import {
-    amountToSatoshi,
+    amountToSmallestUnit,
     formatAmount,
     redactNumericalSubstring,
 } from '@suite-common/wallet-utils';
@@ -54,7 +54,7 @@ const convertToUnit = (
         : undefined;
 
     if (isBalance && areAmountUnitsSupported && bitcoinAmountUnit === PROTO.AmountUnit.SATOSHI) {
-        return amountToSatoshi(value, decimals);
+        return amountToSmallestUnit(value, decimals);
     }
 
     // if it's not balance and sats units are disabled, values other than balances are in sats so we need to convert it to BTC

--- a/suite-common/formatters/src/utils/convert.ts
+++ b/suite-common/formatters/src/utils/convert.ts
@@ -1,6 +1,6 @@
 import { networks, NetworkSymbol } from '@suite-common/wallet-config';
 import {
-    amountToSatoshi,
+    amountToSmallestUnit,
     formatNetworkAmount,
     fromFiatCurrency,
     toFiatCurrency,
@@ -46,5 +46,5 @@ export const convertFiatToCryptoAmount = ({
         return cryptoAmount;
     }
 
-    return amountToSatoshi(new BigNumber(cryptoAmount), decimals);
+    return amountToSmallestUnit(new BigNumber(cryptoAmount), decimals);
 };

--- a/suite-common/suite-utils/package.json
+++ b/suite-common/suite-utils/package.json
@@ -20,6 +20,7 @@
         "@suite-common/wallet-types": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/urls": "workspace:*",
-        "date-fns": "^2.30.0"
+        "date-fns": "^2.30.0",
+        "web3-utils": "^4.3.1"
     }
 }

--- a/suite-common/suite-utils/src/__fixtures__/stake.ts
+++ b/suite-common/suite-utils/src/__fixtures__/stake.ts
@@ -1,0 +1,22 @@
+export const getUnstakeAmountByEthereumDataHexFixtures = [
+    {
+        description: 'should correctly extract and convert the unstaking amount from ethereum data',
+        ethereumData: '76ec871c0000000000000000000000000000000000000000000000000000000000000001', // without 0x
+        expectedAmountWei: '1', // 0.000000000000000001 eth
+    },
+    {
+        description: 'should correctly remove 0x prefix from ethereum data',
+        ethereumData: '0x76ec871c0000000000000000000000000000000000000000000000000000000000000001', // with 0x
+        expectedAmountWei: '1', // 0.000000000000000001 eth
+    },
+    {
+        description: 'should return null when the transaction is not an unstake transaction',
+        ethereumData: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+        expectedAmountWei: null,
+    },
+    {
+        description: 'should return null for invalid or unsupported ethereum data',
+        ethereumData: '1234',
+        expectedAmountWei: null,
+    },
+];

--- a/suite-common/suite-utils/src/__tests__/stake.test.ts
+++ b/suite-common/suite-utils/src/__tests__/stake.test.ts
@@ -1,0 +1,11 @@
+import { getUnstakeAmountByEthereumDataHexFixtures } from '../__fixtures__/stake';
+import { getUnstakeAmountByEthereumDataHex } from '../stake';
+
+describe('getUnstakeAmountByEthereumDataHex', () => {
+    getUnstakeAmountByEthereumDataHexFixtures.forEach(f => {
+        it(f.description, () => {
+            const result = getUnstakeAmountByEthereumDataHex(f.ethereumData);
+            expect(result).toBe(f.expectedAmountWei);
+        });
+    });
+});

--- a/suite-common/suite-utils/src/stake.ts
+++ b/suite-common/suite-utils/src/stake.ts
@@ -1,3 +1,5 @@
+import { hexToNumberString } from 'web3-utils';
+
 import { StakeType } from '@suite-common/wallet-types';
 
 // Define signature constants
@@ -30,4 +32,18 @@ export const getTxStakeNameByDataHex = (dataHex: string | undefined): StakeType 
     const signature = getSignatureByEthereumDataHex(dataHex);
 
     return isStakeTypeTx(signature) ? signatureToStakeNameMap[signature] : null;
+};
+
+export const getUnstakeAmountByEthereumDataHex = (dataHex?: string) => {
+    if (!dataHex) return null;
+
+    // Check if the first two characters are '0x' and remove them if they are
+    const data = dataHex.startsWith('0x') ? dataHex.slice(2) : dataHex;
+
+    const signature = getSignatureByEthereumDataHex(data);
+    if (!isUnstakeTx(signature)) return null;
+
+    const dataBuffer = Buffer.from(data, 'hex');
+
+    return hexToNumberString(`0x${dataBuffer.subarray(4, 36).toString('hex')}`);
 };

--- a/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
@@ -24,7 +24,10 @@ import {
     AddressDisplayOptions,
 } from '@suite-common/wallet-types';
 import { getNetwork } from '@suite-common/wallet-config';
-import { getTxStakeNameByDataHex } from '@suite-common/suite-utils';
+import {
+    getTxStakeNameByDataHex,
+    getUnstakeAmountByEthereumDataHex,
+} from '@suite-common/suite-utils';
 
 import { selectTransactions } from '../transactions/transactionsReducer';
 import {
@@ -121,7 +124,15 @@ export const composeEthereumTransactionFeeLevelsThunk = createThunk<
     `${SEND_MODULE_PREFIX}/composeEthereumTransactionFeeLevelsThunk`,
     async ({ formState, composeContext }, { dispatch, rejectWithValue }) => {
         const { account, network, feeInfo } = composeContext;
-        const composedOutput = getExternalComposeOutput(formState, account, network);
+        const { ethereumDataHex } = formState;
+        const unstakeAmount = getUnstakeAmountByEthereumDataHex(ethereumDataHex);
+
+        const composedOutput = getExternalComposeOutput(
+            formState,
+            account,
+            network,
+            unstakeAmount || undefined,
+        );
 
         if (!composedOutput)
             return rejectWithValue({

--- a/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
@@ -10,7 +10,7 @@ import {
     getEthereumEstimateFeeParams,
     prepareEthereumTransaction,
     getExternalComposeOutput,
-    amountToSatoshi,
+    amountToSmallestUnit,
     formatAmount,
     isPending,
     getAccountIdentity,
@@ -50,7 +50,7 @@ const calculate = (
     let amount: string;
     let max: string | undefined;
     const availableTokenBalance = token
-        ? amountToSatoshi(token.balance!, token.decimals)
+        ? amountToSmallestUnit(token.balance!, token.decimals)
         : undefined;
     if (output.type === 'send-max' || output.type === 'send-max-noaddress') {
         max = availableTokenBalance || calculateMax(availableBalance, feeInSatoshi);
@@ -122,6 +122,7 @@ export const composeEthereumTransactionFeeLevelsThunk = createThunk<
     async ({ formState, composeContext }, { dispatch, rejectWithValue }) => {
         const { account, network, feeInfo } = composeContext;
         const composedOutput = getExternalComposeOutput(formState, account, network);
+
         if (!composedOutput)
             return rejectWithValue({
                 error: 'fee-levels-compose-failed',

--- a/suite-common/wallet-core/src/send/sendFormRippleThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormRippleThunks.ts
@@ -4,7 +4,7 @@ import {
     calculateTotal,
     calculateMax,
     getExternalComposeOutput,
-    networkAmountToSatoshi,
+    networkAmountToSmallestUnit,
     formatNetworkAmount,
 } from '@suite-common/wallet-utils';
 import { XRP_FLAG } from '@suite-common/wallet-constants';
@@ -213,7 +213,10 @@ export const signRippleSendFormTransactionThunk = createThunk<
 
         const payment: RipplePayment = {
             destination: formState.outputs[0].address,
-            amount: networkAmountToSatoshi(formState.outputs[0].amount, selectedAccount.symbol),
+            amount: networkAmountToSmallestUnit(
+                formState.outputs[0].amount,
+                selectedAccount.symbol,
+            ),
         };
 
         if (formState.rippleDestinationTag) {

--- a/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
@@ -10,7 +10,7 @@ import {
 } from '@suite-common/wallet-types';
 import { createThunk } from '@suite-common/redux-utils';
 import {
-    amountToSatoshi,
+    amountToSmallestUnit,
     calculateMax,
     calculateTotal,
     formatAmount,
@@ -45,7 +45,7 @@ const calculate = (
     let amount: string;
     let max: string | undefined;
     const availableTokenBalance = token
-        ? amountToSatoshi(token.balance!, token.decimals)
+        ? amountToSmallestUnit(token.balance!, token.decimals)
         : undefined;
     if (output.type === 'send-max' || output.type === 'send-max-noaddress') {
         max = availableTokenBalance || calculateMax(availableBalance, feeInLamports);

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -19,7 +19,7 @@ import { notificationsActions } from '@suite-common/toast-notifications';
 import { getNetwork, NetworkSymbol } from '@suite-common/wallet-config';
 import {
     hasNetworkFeatures,
-    amountToSatoshi,
+    amountToSmallestUnit,
     formatAmount,
     getAccountDecimals,
     getAreSatoshisUsed,
@@ -108,7 +108,7 @@ export const convertSendFormDraftsBtcAmountUnitsThunk = createThunk(
             const areSatsSupported = hasNetworkFeatures(relatedAccount, 'amount-unit');
 
             const amountFormatter =
-                areSatsAmountUnit && areSatsSupported ? amountToSatoshi : formatAmount;
+                areSatsAmountUnit && areSatsSupported ? amountToSmallestUnit : formatAmount;
 
             const updatedDraft = cloneObject(draft);
             const amountDecimals = getAccountDecimals(relatedAccount.symbol)!;

--- a/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
@@ -17,7 +17,7 @@ import {
     getNetworkAccountFeatures,
     hasNetworkFeatures,
     isTestnet,
-    networkAmountToSatoshi,
+    networkAmountToSmallestUnit,
     parseBIP44Path,
     sortByCoin,
     getUtxoOutpoint,
@@ -114,10 +114,10 @@ describe('account utils', () => {
     });
 
     it('format amount to satoshi', () => {
-        expect(networkAmountToSatoshi('0.00000001', 'btc')).toEqual('1');
-        expect(networkAmountToSatoshi('0.000001', 'xrp')).toEqual('1');
-        expect(networkAmountToSatoshi('0.000000000000000001', 'eth')).toEqual('1');
-        expect(networkAmountToSatoshi('aaa', 'eth')).toEqual('-1');
+        expect(networkAmountToSmallestUnit('0.00000001', 'btc')).toEqual('1');
+        expect(networkAmountToSmallestUnit('0.000001', 'xrp')).toEqual('1');
+        expect(networkAmountToSmallestUnit('0.000000000000000001', 'eth')).toEqual('1');
+        expect(networkAmountToSmallestUnit('aaa', 'eth')).toEqual('-1');
     });
 
     it('findAccountDevice', () => {

--- a/suite-common/wallet-utils/src/__tests__/sendFormUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/sendFormUtils.test.ts
@@ -330,6 +330,19 @@ describe('sendForm utils', () => {
             output: { type: 'payment-noaddress', amount: '1000000' },
             tokenInfo: undefined,
         });
+
+        expect(
+            getExternalComposeOutput(
+                { outputs: [{ ...OUTPUT, address: 'A', amount: '0', token: 'A' }] },
+                EthAccount,
+                EthNetwork,
+                '1', // already formatted
+            ),
+        ).toEqual({
+            decimals: 2,
+            output: { type: 'payment', address: 'A', amount: '1' },
+            tokenInfo: EthAccount.tokens![0],
+        });
     });
 
     it('calculateEthFee', () => {

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -362,7 +362,7 @@ export const formatAmount = (amount: BigNumberValue, decimals: number) => {
     }
 };
 
-export const amountToSatoshi = (amount: BigNumberValue, decimals: number) => {
+export const amountToSmallestUnit = (amount: BigNumberValue, decimals: number) => {
     try {
         const bAmount = new BigNumber(amount);
         if (bAmount.isNaN()) {
@@ -390,14 +390,14 @@ export const satoshiAmountToBtc = (amount: BigNumberValue) => {
     }
 };
 
-export const networkAmountToSatoshi = (amount: string | null, symbol: NetworkSymbol) => {
+export const networkAmountToSmallestUnit = (amount: string | null, symbol: NetworkSymbol) => {
     if (!amount) return '0';
 
     const decimals = getAccountDecimals(symbol);
 
     if (!decimals) return amount;
 
-    return amountToSatoshi(amount, decimals);
+    return amountToSmallestUnit(amount, decimals);
 };
 
 export const formatNetworkAmount = (

--- a/suite-common/wallet-utils/src/cardanoUtils.ts
+++ b/suite-common/wallet-utils/src/cardanoUtils.ts
@@ -11,10 +11,10 @@ import { CARDANO, CardanoCertificate, CardanoOutput, PROTO } from '@trezor/conne
 import { AccountType } from '@suite-common/wallet-config';
 
 import {
-    amountToSatoshi,
+    amountToSmallestUnit,
     formatAmount,
     formatNetworkAmount,
-    networkAmountToSatoshi,
+    networkAmountToSmallestUnit,
 } from './accountUtils';
 
 export const getDerivationType = (accountType: AccountType) => {
@@ -67,7 +67,7 @@ export const transformUserOutputs = (
     outputs.map((output, i) => {
         const setMax = i === maxOutputIndex;
         const amount =
-            output.amount === '' ? undefined : networkAmountToSatoshi(output.amount, symbol);
+            output.amount === '' ? undefined : networkAmountToSmallestUnit(output.amount, symbol);
         const tokenDecimals = accountTokens?.find(t => t.contract === output.token)?.decimals ?? 0;
 
         return {
@@ -78,7 +78,7 @@ export const transformUserOutputs = (
                       {
                           unit: output.token,
                           quantity: output.amount
-                              ? amountToSatoshi(output.amount, tokenDecimals)
+                              ? amountToSmallestUnit(output.amount, tokenDecimals)
                               : '0',
                       },
                   ]

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -327,6 +327,7 @@ export const getExternalComposeOutput = (
     values: Partial<FormState>,
     account: Account,
     network: Network,
+    formattedFallbackAmount?: string, // for cases when value is zero but amount is available in eth data
 ) => {
     if (!values || !Array.isArray(values.outputs) || !values.outputs[0]) return;
     const out = values.outputs[0];
@@ -356,7 +357,7 @@ export const getExternalComposeOutput = (
         output = {
             type: 'payment',
             address,
-            amount: amountInSatoshi,
+            amount: formattedFallbackAmount || formattedAmount,
         };
     } else {
         output = {

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -35,7 +35,7 @@ import type {
     SendFormDraftKey,
 } from '@suite-common/wallet-types';
 
-import { amountToSatoshi, getUtxoOutpoint, networkAmountToSatoshi } from './accountUtils';
+import { amountToSmallestUnit, getUtxoOutpoint, networkAmountToSmallestUnit } from './accountUtils';
 import { sanitizeHex } from './ethUtils';
 
 export const calculateTotal = (amount: string, fee: string): string => {
@@ -99,7 +99,7 @@ const getSerializedErc20Transfer = (token: TokenInfo, to: string, amount: string
     // 32 bytes address parameter, remove '0x' prefix
     const erc20recipient = padLeft(to, 64).substring(2);
     // convert amount to satoshi
-    const tokenAmount = amountToSatoshi(amount, token.decimals);
+    const tokenAmount = amountToSmallestUnit(amount, token.decimals);
     // 32 bytes amount paramter, remove '0x' prefix
     const erc20amount = padLeft(numberToHex(tokenAmount), 64).substring(2);
 
@@ -286,7 +286,7 @@ export const getBitcoinComposeOutputs = (
         } else if (output.amount) {
             const amount = isSatoshis
                 ? output.amount
-                : networkAmountToSatoshi(output.amount, symbol);
+                : networkAmountToSmallestUnit(output.amount, symbol);
 
             if (address) {
                 result.push({
@@ -338,7 +338,7 @@ export const getExternalComposeOutput = (
 
     const tokenInfo = findToken(account.tokens, token);
     const decimals = tokenInfo ? tokenInfo.decimals : network.decimals;
-    const amountInSatoshi = amountToSatoshi(amount, decimals);
+    const formattedAmount = amountToSmallestUnit(amount, decimals);
 
     let output: ExternalOutput;
     if (isMaxActive) {
@@ -361,7 +361,7 @@ export const getExternalComposeOutput = (
     } else {
         output = {
             type: 'payment-noaddress',
-            amount: amountInSatoshi,
+            amount: formattedAmount,
         };
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9118,6 +9118,7 @@ __metadata:
     "@trezor/connect": "workspace:*"
     "@trezor/urls": "workspace:*"
     date-fns: "npm:^2.30.0"
+    web3-utils: "npm:^4.3.1"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description
- no satoshi methods for non-bitcoin
- resolves zero amount issue when bumping fee during the unstake flow (proving amount)
- resolves zero amount issue when bumping fee during the claim flow (hiding amount)
- hide double label when bumping staking txs
- hide 0 amount in left panel in tx review modal. Applies for claim bump and approve token swap tx

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/13752
Resolve [#13397](https://github.com/trezor/trezor-suite/issues/13397)

## Screenshots:
![bump-fee-zero-amount](https://github.com/user-attachments/assets/d80ef709-5d5b-4e7d-8381-d5bca497b306)
<img width="788" alt="Screenshot 2024-11-03 at 16 07 12" src="https://github.com/user-attachments/assets/fcfc52a9-49dd-44f5-8ffa-5eb4a99f0f90">
<img width="765" alt="Screenshot 2024-11-03 at 16 06 06" src="https://github.com/user-attachments/assets/118b9416-6129-49c7-bebb-71f03d1f0520">
