### PR TITLE
feat(suite): expand FW hash check on all models (v2)

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -37,7 +37,6 @@ import {
     StaticSessionId,
     FirmwareHashCheckResult,
     FirmwareHashCheckError,
-    DeviceModelInternal,
 } from '../types';
 import { models } from '../data/models';
 import { getLanguage } from '../data/getLanguage';
@@ -617,10 +616,6 @@ export class Device extends TypedEmitter<DeviceEvents> {
         if (firmwareVersion === undefined || !this.features || this.features.bootloader_mode) {
             return null;
         }
-
-        // Initially rolled out only for Model One; in the future we may remove that condition and do it for all models
-        const isModelOne = this.features.internal_model === DeviceModelInternal.T1B1;
-        if (!isModelOne) return createFailResult('check-skipped');
 
         const checkSupported = this.atLeast(FIRMWARE.FW_HASH_SUPPORTED_VERSIONS);
         if (!checkSupported) return createFailResult('check-unsupported');

--- a/packages/suite-desktop-core/e2e/support/pageActions/dashboardActions.ts
+++ b/packages/suite-desktop-core/e2e/support/pageActions/dashboardActions.ts
@@ -5,8 +5,16 @@ import { NetworkSymbol } from '@suite-common/wallet-config';
 import { waitForDataTestSelector } from '../common';
 
 class DashboardActions {
+    optionallyDismissFwHashCheckError(window: Page) {
+        // dismiss the error modal only if it appears (handle it async in parallel, not necessary to block the rest of the flow)
+        window
+            .$('[data-testid="@device-compromised/back-button"]')
+            .then(dismissFwHashCheckButton => dismissFwHashCheckButton?.click());
+    }
+
     async passThroughInitialRun(window: Page) {
         await waitForDataTestSelector(window, '@welcome/title');
+        this.optionallyDismissFwHashCheckError(window);
         await window.getByTestId('@analytics/continue-button').click();
         await window.getByTestId('@onboarding/exit-app-button').click();
 

--- a/packages/suite-desktop-core/e2e/tests/general/eap-modal.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/general/eap-modal.test.ts
@@ -8,6 +8,7 @@ import {
 import { launchSuite } from '../../support/common';
 import { onTopBar } from '../../support/pageActions/topBarActions';
 import { onSettingsPage } from '../../support/pageActions/settingsActions';
+import { onDashboardPage } from '../../support/pageActions/dashboardActions';
 
 let electronApp: ElectronApplication;
 let window: Page;
@@ -32,6 +33,7 @@ testPlaywright.afterAll(() => {
 testPlaywright('Join early access button', async () => {
     const buttonText = 'Leave';
 
+    onDashboardPage.optionallyDismissFwHashCheckError(window);
     await onTopBar.openSettings(window);
     await onSettingsPage.goToDesiredSettingsPlace(window, 'general');
     await onSettingsPage.joinEarlyAccessProgram(window);

--- a/packages/suite-desktop-core/e2e/tests/general/suite-guide.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/general/suite-guide.test.ts
@@ -7,6 +7,7 @@ import {
 
 import { launchSuite } from '../../support/common';
 import { onSuiteGuidePage } from '../../support/pageActions/suiteGuideActions';
+import { onDashboardPage } from '../../support/pageActions/dashboardActions';
 
 let electronApp: ElectronApplication;
 let window: Page;
@@ -35,6 +36,7 @@ testPlaywright('Send a bug report', async () => {
         desiredLocation: 'Account',
         reportText: 'Henlo this is testy test writing hangry test user report',
     };
+    onDashboardPage.optionallyDismissFwHashCheckError(window);
 
     await onSuiteGuidePage.openSidePanel(window);
     await onSuiteGuidePage.openFeedback(window);

--- a/packages/suite-web/e2e/tests/analytics/events.test.ts
+++ b/packages/suite-web/e2e/tests/analytics/events.test.ts
@@ -20,6 +20,7 @@ describe('Analytics Events', () => {
 
     it('reports transport-type, suite-ready and device-connect/device-disconnect events when analytics is initialized and enabled', () => {
         cy.prefixedVisit('/');
+        cy.disableFirmwareHashCheck();
 
         // go to settings and enable analytics (makes analytics enabled and initialized)
         onNavBar.openSettings();
@@ -96,6 +97,10 @@ describe('Analytics Events', () => {
         cy.interceptDataTrezorIo(requests);
 
         cy.prefixedVisit('/', forceLightMode);
+        cy.disableFirmwareHashCheck();
+        // The next step is to press Settings Icon, and that can be done from DeviceCompromised modal as well as from a normal scren.
+        // But it can happen that Cypress tries to click it immediately, but fails, because the app is rerendering right now (modal is disappearing)
+        cy.wait(500);
 
         // change few settings to see if it is different from default values in suite-ready
         onNavBar.openSettings();

--- a/packages/suite-web/e2e/tests/analytics/toggle.test.ts
+++ b/packages/suite-web/e2e/tests/analytics/toggle.test.ts
@@ -18,13 +18,13 @@ describe('Analytics Toggle - Enablement and Disablement', () => {
         cy.viewport(1440, 2560).resetDb();
 
         requests = [];
-    });
-
-    it('should respect disabled analytics in onboarding with following enabling in settings', () => {
         cy.interceptDataTrezorIo(requests).as('data-fetch');
 
         cy.prefixedVisit('/');
+        cy.disableFirmwareHashCheck();
+    });
 
+    it('should respect disabled analytics in onboarding with following enabling in settings', () => {
         // pass through onboarding with disabled analytics
         cy.getTestElement('@analytics/toggle-switch').find('input').should('be.checked');
         cy.getTestElement('@analytics/toggle-switch').click({ force: true });
@@ -115,10 +115,6 @@ describe('Analytics Toggle - Enablement and Disablement', () => {
     });
 
     it('should respect enabled analytics in onboarding with following disabling in settings', () => {
-        cy.interceptDataTrezorIo(requests).as('data-fetch');
-
-        cy.prefixedVisit('/');
-
         // pass through onboarding with enabled analytics
         cy.getTestElement('@analytics/toggle-switch').find('input').should('be.checked');
         cy.getTestElement('@analytics/continue-button').click();

--- a/packages/suite-web/e2e/tests/metadata/account-metadata.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/account-metadata.test.ts
@@ -24,6 +24,7 @@ Hovering over fields that may be labeled shows "add label" button upon which is 
             },
         });
 
+        cy.disableFirmwareHashCheck();
         cy.getTestElement('@analytics/continue-button');
         cy.task('startBridge');
 

--- a/packages/suite-web/e2e/tests/metadata/interval-fetching.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/interval-fetching.test.ts
@@ -50,6 +50,7 @@ describe('Metadata - suite is watching cloud provider and syncs periodically', (
                     cy.stub(win, 'fetch').callsFake(rerouteMetadataToMockProvider);
                 },
             });
+            cy.disableFirmwareHashCheck();
             cy.tick(1000);
             cy.getTestElement('@analytics/continue-button', { timeout: 30_000 })
                 .click()

--- a/packages/suite-web/e2e/tests/onboarding/analytics-consent.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/analytics-consent.test.ts
@@ -19,6 +19,7 @@ describe('Onboarding - analytics consent', () => {
             needs_backup: false,
         });
         cy.prefixedVisit('/accounts');
+        cy.disableFirmwareHashCheck();
 
         acceptAnalyticsConsentOnInitializedDevice();
 

--- a/packages/suite-web/e2e/tests/settings/t2b1-device-settings.test.ts
+++ b/packages/suite-web/e2e/tests/settings/t2b1-device-settings.test.ts
@@ -43,6 +43,7 @@ describe('T2B1 - Device settings', () => {
 
         // pass through initial run and device auth check
         cy.prefixedVisit('/');
+        cy.disableFirmwareHashCheck();
         cy.getTestElement('@analytics/continue-button', { timeout: 40000 })
             .click()
             .getTestElement('@onboarding/exit-app-button')
@@ -99,6 +100,7 @@ describe('T2B1 - Device settings', () => {
 
         // pass through initial run and device auth check
         cy.prefixedVisit('/');
+        cy.disableFirmwareHashCheck();
         cy.getTestElement('@analytics/continue-button', { timeout: 40000 })
             .click()
             .getTestElement('@onboarding/exit-app-button')
@@ -125,6 +127,7 @@ describe('T2B1 - Device settings', () => {
 
         // pass through initial run and device auth check
         cy.prefixedVisit('/');
+        cy.disableFirmwareHashCheck();
         cy.getTestElement('@analytics/continue-button', { timeout: 40000 })
             .click()
             .getTestElement('@onboarding/exit-app-button')

--- a/packages/suite-web/e2e/tests/suite/guide.test.ts
+++ b/packages/suite-web/e2e/tests/suite/guide.test.ts
@@ -56,6 +56,7 @@ describe('Test Guide', () => {
 
     it('In onboarding with device', () => {
         cy.task('startEmu', { wipe: true });
+        cy.disableFirmwareHashCheck();
         cy.getTestElement('@analytics/continue-button').click();
         cy.getTestElement('@analytics/continue-button').click();
         cy.getTestElement('@guide/button-open').click();

--- a/packages/suite-web/e2e/tests/suite/initial-run.test.ts
+++ b/packages/suite-web/e2e/tests/suite/initial-run.test.ts
@@ -11,6 +11,7 @@ describe('Suite initial run', () => {
 
     it('Until user passed through initial run, it will be there after reload', () => {
         cy.prefixedVisit('/');
+        cy.disableFirmwareHashCheck();
         cy.getTestElement('@analytics/toggle-switch').should('be.visible');
         cy.safeReload();
         // analytics screen is there until user confirms his choice
@@ -23,6 +24,7 @@ describe('Suite initial run', () => {
 
     it('Once user passed trough, skips initial run and shows connect-device modal', () => {
         cy.prefixedVisit('/');
+        cy.disableFirmwareHashCheck();
         cy.getTestElement('@analytics/continue-button').click();
         cy.getTestElement('@onboarding/exit-app-button').click();
         cy.getTestElement('@onboarding/viewOnly/enable').click();

--- a/packages/suite/src/components/suite/SecurityCheck/SecurityCheckFail.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/SecurityCheckFail.tsx
@@ -63,7 +63,12 @@ export const SecurityCheckFail = ({
             <SecurityChecklist items={checklistItems} />
             <Row flexWrap="wrap" gap={spacings.xl} width="100%">
                 {goBack && (
-                    <Button variant="tertiary" onClick={goBack} size="large">
+                    <Button
+                        variant="tertiary"
+                        onClick={goBack}
+                        size="large"
+                        data-testid="@device-compromised/back-button"
+                    >
                         <Translation id="TR_BACK" />
                     </Button>
                 )}


### PR DESCRIPTION
Followup to #14766 where FW hash check was implemented for T1B1.

## Description

- a8ba1e8d50c58808fb002a38ccd93ba43a597ddf Reapply [#15018](https://github.com/trezor/trezor-suite/pull/15018): Expand the FW hash check on all models
- be5b44056c1a1f851830c0db9fcf4c72e78f4bff Fix Playwright tests
  - since playwright is concerned with desktop-specific app interface, and not so much the UI of react app itself, I think it is all right to take the easier path:
  - just dismiss the FW hash check modal via "Back" button
  - This will leave the error banner, but that doesn't interfere with scope of playwright tests
- 4182592e5203ea1066505a85d3e529d8fd8fdf69 Fix Cypress tests by using the already existing `cy.disableFirmwareHashCheck()`
  - most tests don't need it, as they use [passThroughInitialRun](https://github.com/trezor/trezor-suite/blob/77cd90627c60241c55fe16b42d46898dc37834de/packages/suite-web/e2e/support/utils/shortcuts.ts#L12-L13) that takes care of it
  - but some tests do not use passThroughInitialRun, since they do something customized instead
  - so it's a bit of boilerplate, but IMHO it's analogous to having to confirm analytics consent in all those tests :shrug: 
  - BTW unlike playwright, in Cypress there are some tests that would be broken by the warning banner, if the modal is just dismissed: such as testing for other SuiteBanners, or receiving addresses etc.

## Related Issue

resolves https://github.com/trezor/trezor-suite-private/issues/114