### PR TITLE
Fix/accounts tab search does not work correctly with special chars

### DIFF
--- a/packages/suite/src/components/suite/AccountLabel.tsx
+++ b/packages/suite/src/components/suite/AccountLabel.tsx
@@ -35,28 +35,14 @@ export const AccountLabel = ({
 }: AccountLabelProps) => {
     const { getDefaultAccountLabel } = useDefaultAccountLabel();
 
-    if (accountLabel) {
-        return (
-            <TruncateWithTooltip delayShow={TOOLTIP_DELAY_LONG}>
-                <Row gap={spacings.sm}>
-                    <TabularNums>{accountLabel}</TabularNums>
-                    {showAccountTypeBadge && (
-                        <AccountTypeBadge
-                            accountType={accountType}
-                            size={accountTypeBadgeSize}
-                            path={path}
-                            networkType={networkType}
-                        />
-                    )}
-                </Row>
-            </TruncateWithTooltip>
-        );
-    }
-
     return (
         <TruncateWithTooltip delayShow={TOOLTIP_DELAY_LONG}>
             <Row gap={spacings.sm}>
-                {getDefaultAccountLabel({ accountType, symbol, index })}
+                {accountLabel ? (
+                    <TabularNums>{accountLabel}</TabularNums>
+                ) : (
+                    getDefaultAccountLabel({ accountType, symbol, index })
+                )}
                 {showAccountTypeBadge && (
                     <AccountTypeBadge
                         accountType={accountType}

--- a/packages/suite/src/components/suite/AccountLabel.tsx
+++ b/packages/suite/src/components/suite/AccountLabel.tsx
@@ -1,12 +1,10 @@
 import styled from 'styled-components';
-import { getTitleForNetwork, getTitleForCoinjoinAccount } from '@suite-common/wallet-utils';
 import { BadgeSize, Row, TOOLTIP_DELAY_LONG, TruncateWithTooltip } from '@trezor/components';
-import { useCallback } from 'react';
-import { useTranslation } from '../../hooks/suite';
 import { spacings } from '@trezor/theme';
 import { AccountType, NetworkSymbol } from '@suite-common/wallet-config';
 import { AccountTypeBadge } from './AccountTypeBadge';
 import { Bip43Path, NetworkType } from '@suite-common/wallet-config';
+import { useDefaultAccountLabel } from 'src/hooks/suite';
 
 const TabularNums = styled.span`
     font-variant-numeric: tabular-nums;
@@ -14,7 +12,7 @@ const TabularNums = styled.span`
     overflow: hidden;
 `;
 
-export interface AccountLabelProps {
+interface AccountLabelProps {
     accountLabel?: string;
     accountType: AccountType;
     symbol: NetworkSymbol;
@@ -25,36 +23,6 @@ export interface AccountLabelProps {
     networkType?: NetworkType;
 }
 
-export const useAccountLabel = () => {
-    const { translationString } = useTranslation();
-
-    const defaultAccountLabelString = useCallback(
-        ({
-            accountType,
-            symbol,
-            index = 0,
-        }: {
-            accountType: AccountType;
-            symbol: NetworkSymbol;
-            index?: number;
-        }) => {
-            if (accountType === 'coinjoin') {
-                return translationString(getTitleForCoinjoinAccount(symbol));
-            }
-
-            return translationString('LABELING_ACCOUNT', {
-                networkName: translationString(getTitleForNetwork(symbol)), // Bitcoin, Ethereum, ...
-                index: index + 1, // This is the number which shows after hash, e.g. Ethereum #3
-            });
-        },
-        [translationString],
-    );
-
-    return {
-        defaultAccountLabelString,
-    };
-};
-
 export const AccountLabel = ({
     accountLabel,
     accountType = 'normal',
@@ -63,9 +31,9 @@ export const AccountLabel = ({
     showAccountTypeBadge,
     accountTypeBadgeSize = 'medium',
     symbol,
-    index = 0,
+    index,
 }: AccountLabelProps) => {
-    const { defaultAccountLabelString } = useAccountLabel();
+    const { getDefaultAccountLabel } = useDefaultAccountLabel();
 
     if (accountLabel) {
         return (
@@ -88,7 +56,7 @@ export const AccountLabel = ({
     return (
         <TruncateWithTooltip delayShow={TOOLTIP_DELAY_LONG}>
             <Row gap={spacings.sm}>
-                {defaultAccountLabelString({ accountType, symbol, index })}
+                {getDefaultAccountLabel({ accountType, symbol, index })}
                 {showAccountTypeBadge && (
                     <AccountTypeBadge
                         accountType={accountType}

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountDetails.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountDetails.tsx
@@ -11,8 +11,7 @@ import {
     FiatValue,
     AmountUnitSwitchWrapper,
 } from 'src/components/suite';
-import { useAccountLabel } from 'src/components/suite/AccountLabel';
-import { useSelector } from 'src/hooks/suite';
+import { useDefaultAccountLabel, useSelector } from 'src/hooks/suite';
 import { selectLabelingDataForSelectedAccount } from 'src/reducers/suite/metadataReducer';
 import { CoinLogo } from '@trezor/product-components';
 import { isTestnet } from '@suite-common/wallet-utils';
@@ -90,7 +89,7 @@ export const AccountDetails = ({ selectedAccount, isBalanceShown }: AccountDetai
     const [shouldAnimate, setShouldAnimate] = useState(false);
     const [hasMounted, setHasMounted] = useState(false);
     const selectedAccountLabels = useSelector(selectLabelingDataForSelectedAccount);
-    const { defaultAccountLabelString } = useAccountLabel();
+    const { getDefaultAccountLabel } = useDefaultAccountLabel();
     const { symbol, key, path, index, accountType, formattedBalance } = selectedAccount;
 
     useEffect(() => {
@@ -128,7 +127,7 @@ export const AccountDetails = ({ selectedAccount, isBalanceShown }: AccountDetai
                         defaultValue: path,
                         value: selectedAccountLabels.accountLabel,
                     }}
-                    defaultEditableValue={defaultAccountLabelString({ accountType, symbol, index })}
+                    defaultEditableValue={getDefaultAccountLabel({ accountType, symbol, index })}
                     updateFlag={isBalanceShown}
                 />
             </AccountHeading>

--- a/packages/suite/src/hooks/suite/index.ts
+++ b/packages/suite/src/hooks/suite/index.ts
@@ -22,6 +22,7 @@ export { useDispatch } from './useDispatch';
 export { usePasswords } from './usePasswords';
 export { useDebugLanguageShortcut } from './useDebugLanguageShortcut';
 export { useDisplayMode } from './useDisplayMode';
+export { useDefaultAccountLabel } from './useDefaultAccountLabel';
 
 // replaced in suite-native
 export { useLocales } from 'src/hooks/suite/useLocales';

--- a/packages/suite/src/hooks/suite/useDefaultAccountLabel.ts
+++ b/packages/suite/src/hooks/suite/useDefaultAccountLabel.ts
@@ -1,0 +1,34 @@
+import { getTitleForNetwork, getTitleForCoinjoinAccount } from '@suite-common/wallet-utils';
+import { useCallback } from 'react';
+import { useTranslation } from './useTranslation';
+import { AccountType, NetworkSymbol } from '@suite-common/wallet-config';
+
+export interface GetDefaultAccountLabelParams {
+    accountType: AccountType;
+    symbol: NetworkSymbol;
+    index?: number;
+}
+
+export const useDefaultAccountLabel = () => {
+    const { translationString } = useTranslation();
+
+    const getDefaultAccountLabel = useCallback(
+        ({ accountType, symbol, index = 0 }: GetDefaultAccountLabelParams): string => {
+            if (accountType === 'coinjoin') {
+                return translationString(getTitleForCoinjoinAccount(symbol));
+            }
+
+            const displayedAccountNumber = index + 1;
+
+            return translationString('LABELING_ACCOUNT', {
+                networkName: translationString(getTitleForNetwork(symbol)), // Bitcoin, Ethereum, ...
+                index: displayedAccountNumber,
+            });
+        },
+        [translationString],
+    );
+
+    return {
+        getDefaultAccountLabel,
+    };
+};

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSellFormDefaultValues.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSellFormDefaultValues.ts
@@ -16,9 +16,8 @@ import {
 import { CoinmarketSellFormDefaultValuesProps } from 'src/types/coinmarket/coinmarketForm';
 import { FormState, Output } from '@suite-common/wallet-types';
 import { selectAccountLabels } from 'src/reducers/suite/metadataReducer';
-import { useSelector } from 'src/hooks/suite';
+import { useSelector, useDefaultAccountLabel } from 'src/hooks/suite';
 import { selectAccounts, selectDevice } from '@suite-common/wallet-core';
-import { useAccountLabel } from 'src/components/suite/AccountLabel';
 import {
     FORM_DEFAULT_FIAT_CURRENCY,
     FORM_DEFAULT_PAYMENT_METHOD,
@@ -30,7 +29,7 @@ export const useCoinmarketBuildAccountGroups = (
     const accounts = useSelector(selectAccounts);
     const accountLabels = useSelector(selectAccountLabels);
     const device = useSelector(selectDevice);
-    const { defaultAccountLabelString } = useAccountLabel();
+    const { getDefaultAccountLabel } = useDefaultAccountLabel();
     const { tokenDefinitions } = useSelector(state => state);
     const supportedSymbols = useSelector(state =>
         type === 'sell'
@@ -46,7 +45,7 @@ export const useCoinmarketBuildAccountGroups = (
                 accountLabels,
                 tokenDefinitions,
                 supportedCryptoIds: supportedSymbols,
-                defaultAccountLabelString,
+                getDefaultAccountLabel,
             }),
         [
             accounts,
@@ -54,7 +53,7 @@ export const useCoinmarketBuildAccountGroups = (
             accountLabels,
             device,
             tokenDefinitions,
-            defaultAccountLabelString,
+            getDefaultAccountLabel,
         ],
     );
 

--- a/packages/suite/src/types/coinmarket/coinmarket.ts
+++ b/packages/suite/src/types/coinmarket/coinmarket.ts
@@ -41,6 +41,7 @@ import {
     SelectAssetOptionGroupProps,
     SelectAssetOptionProps,
 } from '@trezor/product-components/src/components/SelectAssetModal/SelectAssetModal';
+import { GetDefaultAccountLabelParams } from 'src/hooks/suite/useDefaultAccountLabel';
 
 export type UseCoinmarketProps = { selectedAccount: SelectedAccountLoaded };
 export type UseCoinmarketCommonProps = UseCoinmarketProps & {
@@ -189,15 +190,11 @@ export interface CoinmarketGetSortedAccountsProps {
 
 export interface CoinmarketBuildAccountOptionsProps extends CoinmarketGetSortedAccountsProps {
     accountLabels: Record<string, string | undefined>;
-    defaultAccountLabelString: ({
+    getDefaultAccountLabel: ({
         accountType,
         symbol,
         index,
-    }: {
-        accountType: Account['accountType'];
-        symbol: Account['symbol'];
-        index?: number;
-    }) => string;
+    }: GetDefaultAccountLabelParams) => string;
     supportedCryptoIds: Set<CryptoId> | undefined;
     tokenDefinitions: Partial<TokenDefinitionsState>;
 }

--- a/packages/suite/src/utils/wallet/coinmarket/__tests__/coinmarketUtils.test.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/__tests__/coinmarketUtils.test.ts
@@ -25,11 +25,11 @@ import * as BUY_FIXTURE from 'src/utils/wallet/coinmarket/__fixtures__/buyUtils'
 import * as SELL_FIXTURE from 'src/utils/wallet/coinmarket/__fixtures__/sellUtils';
 import * as EXCHANGE_FIXTURE from 'src/utils/wallet/coinmarket/__fixtures__/exchangeUtils';
 import { CryptoId } from 'invity-api';
-import { useAccountLabel } from 'src/components/suite/AccountLabel';
+import { useDefaultAccountLabel } from 'src/hooks/suite/useDefaultAccountLabel';
 
-jest.mock('src/components/suite/AccountLabel', () => ({
-    ...jest.requireActual('src/components/suite/AccountLabel'),
-    useAccountLabel: jest.fn(),
+jest.mock('src/hooks/suite/useDefaultAccountLabel', () => ({
+    ...jest.requireActual('src/hooks/suite/useDefaultAccountLabel'),
+    useDefaultAccountLabel: jest.fn(),
 }));
 
 describe('coinmarket utils', () => {
@@ -158,7 +158,7 @@ describe('coinmarket utils', () => {
 
     it('coinmarketBuildAccountOptions', () => {
         const label = 'mocked label';
-        const defaultAccountLabelString = (useAccountLabel as jest.Mock).mockImplementation(
+        const getDefaultAccountLabel = (useDefaultAccountLabel as jest.Mock).mockImplementation(
             () => label,
         );
 
@@ -166,7 +166,7 @@ describe('coinmarket utils', () => {
             accounts: FIXTURE_ACCOUNTS as Account[],
             deviceState: '1stTestnetAddress@device_id:0',
             accountLabels: {},
-            defaultAccountLabelString,
+            getDefaultAccountLabel,
             tokenDefinitions: { eth: { coin: coinDefinitions } },
             supportedCryptoIds: new Set([
                 'bitcoin',

--- a/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
@@ -310,7 +310,7 @@ export const coinmarketBuildAccountOptions = ({
     accountLabels,
     tokenDefinitions,
     supportedCryptoIds,
-    defaultAccountLabelString,
+    getDefaultAccountLabel,
 }: CoinmarketBuildAccountOptionsProps): CoinmarketAccountsOptionsGroupProps[] => {
     const accountsSorted = coinmarketGetSortedAccounts({
         accounts,
@@ -335,7 +335,7 @@ export const coinmarketBuildAccountOptions = ({
 
         const groupLabel =
             accountLabels[account.key] ??
-            defaultAccountLabelString({
+            getDefaultAccountLabel({
                 accountType,
                 symbol: accountSymbol,
                 index,

--- a/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
@@ -213,6 +213,7 @@ describe('account utils', () => {
                 'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
             ),
         ).toBe(true);
+        expect(accountSearchFn(btcAcc, '#1', undefined, 'Bitcoin #1')).toBe(true);
     });
 
     it('getNetworkAccountFeatures', () => {


### PR DESCRIPTION
Revive #14600 (closed because the contributor "mempoolboy" closed the github account) 

## Description

Unlabeled accounts are represented by default labels created as translation strings. As these are derived from account data based on user settings and require an intl provider, they are not saved in the store and therefore are not included in the search).

- a63b3a2bd423dec79ff12cf8e42791c907b76111 Include default labels in subject of account search
- 64689eec0174b2b1dae00cf3f40ca8142407f295 Refactor duplicated JSX
- 23bb4823b48db8843543edac51234d2a66e5dd2a Add a test case to cover new usage of `accountSearchFn`

## Related Issue

Resolve [#11383](https://github.com/trezor/trezor-suite/issues/11383)

## Screenshots:

<img width="275" alt="image" src="https://github.com/user-attachments/assets/0d6ccd90-1261-4407-bdd2-7c441c3b77b9">
<img width="275" alt="image" src="https://github.com/user-attachments/assets/f7ef08ec-8c6e-4596-b269-9b80a4aaf456">
<img width="275" alt="image" src="https://github.com/user-attachments/assets/95349d94-1601-4b35-b1c3-bf070a2d5f6a">
<img width="275" alt="image" src="https://github.com/user-attachments/assets/7c237af5-85e6-4abc-a948-af5488245568">

