### PR TITLE
test(suite-web): add comments to selected passphrase tests

### DIFF
--- a/packages/suite-web/e2e/tests/suite/passphrase-cardano.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase-cardano.test.ts
@@ -6,7 +6,10 @@ import { onNavBar } from '../../support/pageObjects/topBarObject';
 const correctPassphraseAddr =
     'addr1qx3ufjpwcx30ee73a7r29surauze6yt0jvr7c3rnahw0hnppg7qp5xvslcfucsqqayrtjhm4u66x';
 
-describe('Passphrase with cardano', () => {
+describe(`Passphrase with cardano
+     in order to use cardano a special argument must be provided to trezor-connect  calls (useCardanoDerivation true).
+     this is opt-in because cardano seed derivation takes more time than all other coins and we don't want to slow down non-cardano users
+    `, () => {
     beforeEach(() => {
         cy.task('startEmu', { wipe: true });
         cy.task('setupEmu', {

--- a/packages/suite-web/e2e/tests/suite/passphrase-input.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase-input.test.ts
@@ -15,7 +15,6 @@ describe('Passphrase', () => {
         cy.discoveryShouldFinish();
     });
 
-    // TODO: there is a problem with clearing our password input element -> cypress deletes only last char with {selectAll}{backspace} and totally ignores .clear() command
     it('just test passphrase input', () => {
         // enable passphrase on device
         cy.getTestElement('@suite/menu/settings').click();

--- a/packages/suite-web/e2e/tests/suite/passphrase.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase.test.ts
@@ -27,7 +27,15 @@ describe('Passphrase', () => {
         requests = [];
     });
 
-    it('add 1st hidden wallet (abc) -> fail to confirm passphrase -> try again from notification, succeed -> check 1st address -> switch to 2nd hidden wallet (def) -> check 1st address -> go back to 1st hidden wallet -> check confirm passphrase appears. ', () => {
+    it(`
+        - add 1st hidden wallet (abc) 
+        - fail to confirm passphrase
+        - try again from notification, succeed
+        - check 1st address 
+        - switch to 2nd hidden wallet (def) 
+        - check 1st address 
+        - go back to 1st hidden wallet 
+        - check confirm passphrase appears.`, () => {
         cy.log('passphrase abc for the first time');
         // add 1st hidden wallet
         cy.getTestElement('@menu/switch-device').click();


### PR DESCRIPTION
this is a negligible commit, it is just changing some test descriptions while I was doing something else and studying test coverage of that.
I am opening it because I would like to ignite discussion about best practices here as we discussed briefly with @HajekOndrej. 

Imho writing long test descriptions in the `describe` invocation isn't very helpful. It has the problem that it won't get updated automatically along with updates in test itself. I would rather like to see something like:

```
customTestClickCommand('here is my description', otherArgs);
customTestGetElementCommand('here is my description', otherArgs);

```

each custom command has a description that should describe what is user trying to do. It could also optionally capture a screenshot. With this data we should be able to generate some test overview that is always up to date and describes nicely what is the test trying to achieve.