### PR TITLE
improve connect test matrix

### DIFF
--- a/.github/workflows/template-connect-test-params.yml
+++ b/.github/workflows/template-connect-test-params.yml
@@ -2,14 +2,14 @@ name: "[Template] connect unit"
 on:
   workflow_call:
     inputs:
-      methods:
+      testPattern:
+        description: "Test pattern to use to match for test files (example: `init` or `methods`)"
+        type: "string"
+        required: true
+      includeFilter:
         description: "List of methods to include in tests (example: applySettings,applyFlags,getFeatures)"
         type: "string"
         required: false
-      testPattern:
-        description: "Test pattern to use (example: `init` or `methods`)"
-        type: "string"
-        required: true
       testsFirmware:
         description: "Firmware version for the tests (example: 2-latest, 2.2.0, 2-main)"
         type: "string"
@@ -19,16 +19,6 @@ on:
         description: "Firmware model for the tests (example: T3T1)"
         type: "string"
         required: false
-      nodeEnvironment:
-        description: "Should the test run on nodejs environment, it runs by default."
-        type: "boolean"
-        required: false
-        default: true
-      webEnvironment:
-        description: "Should the test run on web environment, it runs by default."
-        type: "boolean"
-        required: false
-        default: true
       testDescription:
         description: "A description to make test title more descriptive (example: T3T1-latest)"
         type: "string"
@@ -39,12 +29,25 @@ on:
         type: "boolean"
         required: false
         default: false
+      cache_tx:
+        description: "Cache transactions"
+        type: "string"
+        required: false
+        default: false
+      transport:
+        description: "Transport to use (example: bridge, node-bridge)"
+        type: "string"
+        required: false
+        default: "Bridge"
+      testEnv:
+        description: "Environment to test (example: node, web)"
+        type: "string"
+        required: true
 
 jobs:
-  node:
-    name: "node-${{ inputs.testDescription }}"
+  test:
+    name: "${{ inputs.testDescription }}"
     runs-on: ubuntu-latest
-    if: ${{ inputs.nodeEnvironment }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -54,54 +57,43 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: yarn
-      # todo: ideally do not install everything. possibly only devDependencies could be enough for testing (if there was not for building libs)?
-      - run: sed -i "/\"node\"/d" package.json
-      - run: yarn install
-      # nightly test - run without cached txs
-      - if: ${{ github.event_name == 'schedule' }}
-        run: echo "ADDITIONAL_ARGS=-c" >> "$GITHUB_ENV"
-      - if: ${{ inputs.testFirmwareModel }}
-        run: echo "ADDITIONAL_ARGS=$ADDITIONAL_ARGS -m ${{ inputs.testFirmwareModel }}" >> "$GITHUB_ENV"
-      - if: ${{ inputs.methods }}
-        run: echo "ADDITIONAL_ARGS=$ADDITIONAL_ARGS -i ${{ inputs.methods }}" >> "$GITHUB_ENV"
-      - if: ${{ inputs.testRandomizedOrder }}
-        run: echo "ADDITIONAL_ARGS=$ADDITIONAL_ARGS -r" >> "$GITHUB_ENV"
-      - run: './docker/docker-connect-test.sh node -p "${{ inputs.testPattern }}" -f "${{ inputs.testsFirmware }}" $ADDITIONAL_ARGS'
 
-  web:
-    name: "web-${{ inputs.testDescription }}"
-    runs-on: ubuntu-latest
-    if: ${{ inputs.webEnvironment }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: ".nvmrc"
-          cache: yarn
-      - run: |
+      - if: ${{ inputs.testEnv == 'web' }}
+        run: |
           echo -e "\nenableScripts: false" >> .yarnrc.yml
       # Install dependencies only for @trezor/connect package
-      - run: yarn workspaces focus @trezor/connect
-      - name: Retrieve build connect-web
+      - if: ${{ inputs.testEnv == 'web' }}
+        run: yarn workspaces focus @trezor/connect
+      - if: ${{ inputs.testEnv == 'web' }}
+        name: Retrieve build connect-web
         uses: actions/download-artifact@v4
         with:
           name: build-artifact-connect-web
           path: packages/connect-web/build
-      - name: Retrieve build connect-iframe
+      - if: ${{ inputs.testEnv == 'web' }}
+        name: Retrieve build connect-iframe
         uses: actions/download-artifact@v4
         with:
           name: build-artifact-connect-iframe
           path: packages/connect-iframe/build
-      - run: cd packages/connect-iframe && tree .
-      - name: "Echo download path"
+      - if: ${{ inputs.testEnv == 'web' }}
+        run: cd packages/connect-iframe && tree .
+      - if: ${{ inputs.testEnv == 'web' }}
+        name: "Echo download path"
         run: echo ${{steps.download.outputs.download-path}}
-      - if: ${{ github.event_name == 'schedule' }}
+
+      # todo: ideally do not install everything. possibly only devDependencies could be enough for testing (if there was not for building libs)?
+      - if: ${{ inputs.testEnv == 'node' }}
+        run: sed -i "/\"node\"/d" package.json
+      - if: ${{ inputs.testEnv == 'node' }}
+        run: yarn install
+
+      - if: ${{ inputs.cache_tx == 'true' }}
         run: echo "ADDITIONAL_ARGS=-c" >> "$GITHUB_ENV"
       - if: ${{ inputs.testFirmwareModel }}
         run: echo "ADDITIONAL_ARGS=$ADDITIONAL_ARGS -m ${{ inputs.testFirmwareModel }}" >> "$GITHUB_ENV"
-      - if: ${{ inputs.methods }}
-        run: echo "ADDITIONAL_ARGS=$ADDITIONAL_ARGS -i ${{ inputs.methods }}" >> "$GITHUB_ENV"
-      - run: './docker/docker-connect-test.sh web -p "${{ inputs.testPattern }}" -f "${{ inputs.testsFirmware }}" $ADDITIONAL_ARGS'
+      - if: ${{ inputs.includeFilter }}
+        run: echo "ADDITIONAL_ARGS=$ADDITIONAL_ARGS -i ${{ inputs.includeFilter }}" >> "$GITHUB_ENV"
+      - if: ${{ inputs.testRandomizedOrder }}
+        run: echo "ADDITIONAL_ARGS=$ADDITIONAL_ARGS -r" >> "$GITHUB_ENV"
+      - run: './docker/docker-connect-test.sh ${{ inputs.testEnv }} -p "${{ inputs.testPattern }}" -f "${{ inputs.testsFirmware }}" $ADDITIONAL_ARGS'

--- a/.github/workflows/test-connect.yml
+++ b/.github/workflows/test-connect.yml
@@ -77,91 +77,107 @@ jobs:
 
       - name: Set daily matrix
         id: set-matrix-daily
-        run: echo "dailyMatrix=$(node ./scripts/ci/connect-test-matrix-generator.js daily)" >> $GITHUB_OUTPUT
+        run: echo "dailyMatrix=$(node ./scripts/ci/connect-test-matrix-generator.js --model=T2T1 --firmware=2-latest --env=all --groups=api,api-flaky --cache_tx=true --transport=Bridge)" >> $GITHUB_OUTPUT
 
       - name: Set legacy devices matrix
         id: set-matrix-legacy-firmware
-        run: echo "legacyFirmwareMatrix=$(node ./scripts/ci/connect-test-matrix-generator.js legacyFirmware)" >> $GITHUB_OUTPUT
+        run: echo "legacyFirmwareMatrix=$(node ./scripts/ci/connect-test-matrix-generator.js --model=T2T1 --firmware=2.3.0 --env=all --groups=all --cache_tx=false --transport=Bridge)" >> $GITHUB_OUTPUT
 
       - name: Set canary devices matrix
         id: set-matrix-canary-firmware
-        run: echo "canaryFirmwareMatrix=$(node ./scripts/ci/connect-test-matrix-generator.js canaryFirmware)" >> $GITHUB_OUTPUT
+        run: echo "canaryFirmwareMatrix=$(node ./scripts/ci/connect-test-matrix-generator.js --model=T2T1 --firmware=2-main --env=all --groups=all --cache_tx=false --transport=Bridge)" >> $GITHUB_OUTPUT
 
       - name: Set other devices matrix
         id: set-matrix-other-devices
-        run: echo "otherDevicesMatrix=$(node ./scripts/ci/connect-test-matrix-generator.js otherDevices)" >> $GITHUB_OUTPUT
+        run: echo "otherDevicesMatrix=$(node ./scripts/ci/connect-test-matrix-generator.js --model=all --firmware=2-latest --env=node --groups=api --cache_tx=true --transport=Bridge)" >> $GITHUB_OUTPUT
 
-  connect-PR:
+  PR-check:
     needs: [build, set-matrix]
-    name: PR-${{ matrix.name }}
+    name: PR-check ${{ matrix.key }}
+    if: github.repository == 'trezor/trezor-suite'
     uses: ./.github/workflows/template-connect-test-params.yml
     with:
-      testPattern: ${{ matrix.pattern }}
-      methods: ${{ matrix.methods }}
+      testPattern: ${{ matrix.groups.pattern }}
+      includeFilter: ${{ matrix.groups.includeFilter }}
       testsFirmware: ${{ matrix.firmware }}
-      testDescription: ${{ matrix.name }}
+      testDescription: ${{ matrix.env }}-${{ matrix.groups.pattern }}-${{ matrix.groups.name }}
+      cache_tx: ${{ matrix.cache_tx }}
+      transport: ${{ matrix.transport }}
+      testEnv: ${{ matrix.env }}
+      testFirmwareModel: ${{ matrix.model }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.set-matrix.outputs.dailyMatrix) }}
 
-  connect-randomized-order:
+  randomized:
     needs: [build, set-matrix]
-    if: github.event_name == 'schedule' &&  github.repository == 'trezor/trezor-suite'
-    name: randomized-${{ matrix.name }}
+    name: randomized ${{ matrix.key }}
+    if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.repository == 'trezor/trezor-suite'
     uses: ./.github/workflows/template-connect-test-params.yml
     with:
-      testPattern: ${{ matrix.pattern }}
-      methods: ${{ matrix.methods }}
+      testPattern: ${{ matrix.groups.pattern }}
+      includeFilter: ${{ matrix.groups.includeFilter }}
       testsFirmware: ${{ matrix.firmware }}
-      testDescription: ${{ matrix.name }}-${{ matrix.firmware }}
+      testDescription: ${{ matrix.env }}-${{ matrix.groups.pattern }}-${{ matrix.groups.name }}
+      cache_tx: ${{ matrix.cache_tx }}
+      transport: ${{ matrix.transport }}
+      testEnv: ${{ matrix.env }}
+      testFirmwareModel: ${{ matrix.model }}
       testRandomizedOrder: true
-      webEnvironment: false
-      nodeEnvironment: true
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.set-matrix.outputs.dailyMatrix) }}
 
-  connect-legacy-firmware:
+  legacy-fw:
     needs: [build, set-matrix]
-    if: github.event_name == 'schedule' &&  github.repository == 'trezor/trezor-suite'
-    name: legacy-${{ matrix.name }}
+    name: legacy-fw ${{ matrix.key }}
+    if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.repository == 'trezor/trezor-suite'
     uses: ./.github/workflows/template-connect-test-params.yml
     with:
-      testPattern: ${{ matrix.pattern }}
-      methods: ${{ matrix.methods }}
+      testPattern: ${{ matrix.groups.pattern }}
+      includeFilter: ${{ matrix.groups.includeFilter }}
       testsFirmware: ${{ matrix.firmware }}
-      testDescription: ${{ matrix.name }}-${{ matrix.firmware }}
+      testDescription: ${{ matrix.groups.pattern }}-${{ matrix.groups.name }}-${{ matrix.env }}
+      cache_tx: ${{ matrix.cache_tx }}
+      transport: ${{ matrix.transport }}
+      testEnv: ${{ matrix.env }}
+      testFirmwareModel: ${{ matrix.model }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.set-matrix.outputs.legacyFirmwareMatrix) }}
 
-  connect-canary-firmware:
+  canary-fw:
     needs: [build, set-matrix]
-    if: github.event_name == 'schedule' &&  github.repository == 'trezor/trezor-suite'
-    name: canary-${{ matrix.name }}
+    name: canary-fw ${{ matrix.key }}
+    if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.repository == 'trezor/trezor-suite'
     uses: ./.github/workflows/template-connect-test-params.yml
     with:
-      testPattern: ${{ matrix.pattern }}
-      methods: ${{ matrix.methods }}
+      testPattern: ${{ matrix.groups.pattern }}
+      includeFilter: ${{ matrix.groups.includeFilter }}
       testsFirmware: ${{ matrix.firmware }}
-      testDescription: ${{ matrix.name }}-${{ matrix.firmware }}
+      testDescription: ${{ matrix.groups.pattern }}-${{ matrix.groups.name }}-${{ matrix.env }}
+      cache_tx: ${{ matrix.cache_tx }}
+      transport: ${{ matrix.transport }}
+      testEnv: ${{ matrix.env }}
+      testFirmwareModel: ${{ matrix.model }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.set-matrix.outputs.canaryFirmwareMatrix) }}
 
-  connect-other-devices:
+  all-models-api:
     needs: [build, set-matrix]
-    if: github.event_name == 'schedule' &&  github.repository == 'trezor/trezor-suite'
-    name: other-devices-${{ matrix.name }}-${{ matrix.model }}
+    name: all-models-api ${{ matrix.key }}
+    if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.repository == 'trezor/trezor-suite'
     uses: ./.github/workflows/template-connect-test-params.yml
     with:
-      testPattern: ${{ matrix.pattern }}
-      methods: ${{ matrix.methods }}
+      testPattern: ${{ matrix.groups.pattern }}
+      includeFilter: ${{ matrix.groups.includeFilter }}
       testsFirmware: ${{ matrix.firmware }}
+      testDescription: ${{ matrix.model }}
+      cache_tx: ${{ matrix.cache_tx }}
+      transport: ${{ matrix.transport }}
+      testEnv: ${{ matrix.env }}
       testFirmwareModel: ${{ matrix.model }}
-      nodeEnvironment: true
-      webEnvironment: false
-      testDescription: ${{ matrix.name }}-${{ matrix.firmware }}-${{ matrix.model }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.set-matrix.outputs.otherDevicesMatrix) }}

--- a/packages/connect/e2e/__fixtures__/cardanoGetAddress.ts
+++ b/packages/connect/e2e/__fixtures__/cardanoGetAddress.ts
@@ -3,6 +3,14 @@ import { MessagesSchema } from '@trezor/protobuf';
 
 const { CardanoAddressType } = MessagesSchema;
 
+const legacyResults = {
+    minConnectVersion: {
+        // older FW does support Cardano but Connect does not
+        rules: ['<2.4.3', '1'],
+        payload: false,
+    },
+};
+
 export default {
     method: 'cardanoGetAddress',
     setup: {
@@ -496,5 +504,5 @@ export default {
             },
             result: false,
         },
-    ],
+    ].map(test => ({ ...test, legacyResults: [legacyResults.minConnectVersion] })),
 };

--- a/packages/connect/e2e/__fixtures__/cardanoGetAddressDerivations.ts
+++ b/packages/connect/e2e/__fixtures__/cardanoGetAddressDerivations.ts
@@ -6,6 +6,14 @@ import { MessagesSchema } from '@trezor/protobuf';
 
 const { CardanoAddressType, CardanoDerivationType } = MessagesSchema;
 
+const legacyResults = {
+    minConnectVersion: {
+        // older FW does support Cardano but Connect does not
+        rules: ['<2.4.3', '1'],
+        payload: false,
+    },
+};
+
 export default {
     method: 'cardanoGetAddress',
     setup: {
@@ -28,5 +36,6 @@ export default {
         result: {
             address: result.expected_address,
         },
+        legacyResults: [legacyResults.minConnectVersion],
     })),
 };

--- a/packages/connect/e2e/__fixtures__/cardanoGetNativeScriptHash.ts
+++ b/packages/connect/e2e/__fixtures__/cardanoGetNativeScriptHash.ts
@@ -2,6 +2,14 @@ import { MessagesSchema } from '@trezor/protobuf';
 
 const { CardanoNativeScriptHashDisplayFormat, CardanoNativeScriptType } = MessagesSchema;
 
+const legacyResults = {
+    minConnectVersion: {
+        // older FW does support Cardano but Connect does not
+        rules: ['<2.4.3', '1'],
+        payload: false,
+    },
+};
+
 export default {
     method: 'cardanoGetNativeScriptHash',
     setup: {
@@ -306,5 +314,5 @@ export default {
                 scriptHash: '4a6b4288459bf34668c0b281f922691460caf0c7c09caee3a726c27a',
             },
         },
-    ],
+    ].map(test => ({ ...test, legacyResults: [legacyResults.minConnectVersion] })),
 };

--- a/packages/connect/e2e/__fixtures__/cardanoGetPublicKey.ts
+++ b/packages/connect/e2e/__fixtures__/cardanoGetPublicKey.ts
@@ -1,3 +1,11 @@
+const legacyResults = {
+    minConnectVersion: {
+        // older FW does support Cardano but Connect does not
+        rules: ['<2.4.3', '1'],
+        payload: false,
+    },
+};
+
 export default {
     method: 'cardanoGetPublicKey',
     setup: {
@@ -61,5 +69,5 @@ export default {
                     '5d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c1f123474e140a2c360b01f0fa66f2f22e2e965a5b07a80358cf75f77abbd66088',
             },
         },
-    ],
+    ].map(t => ({ ...t, legacyResults: [legacyResults.minConnectVersion] })),
 };

--- a/packages/connect/e2e/__fixtures__/cardanoSignTransaction.ts
+++ b/packages/connect/e2e/__fixtures__/cardanoSignTransaction.ts
@@ -438,7 +438,11 @@ const SCRIPT_DATA_HASH = 'd593fd793c377ac50a3169bb8378ffc257c944da31aa8f355dfa5a
 const TOTAL_COLLATERAL = '1000';
 
 const legacyResults = {
-    // FW <2.6.0 is not supported by Connect at all
+    minConnectVersion: {
+        // older FW does support Cardano but Connect does not
+        rules: ['<2.4.3', '1'],
+        payload: false,
+    },
     beforeConway: {
         // older FW doesn't support Conway certificates
         rules: ['<2.7.1', '1'],
@@ -2898,5 +2902,11 @@ export default {
                 auxiliaryDataSupplement: undefined,
             },
         },
-    ],
+    ].map(test => {
+        if (test.legacyResults) {
+            return test;
+        }
+
+        return { ...test, legacyResults: [legacyResults.minConnectVersion] };
+    }),
 };

--- a/scripts/ci/connect-test-matrix-generator.js
+++ b/scripts/ci/connect-test-matrix-generator.js
@@ -1,140 +1,227 @@
 const process = require('process');
 
+const DEBUG = false;
+
+const log = (...args) => {
+    if (DEBUG) {
+        return console.log(...args);
+    }
+};
+
 const groups = {
     api: {
         name: 'api',
         pattern:
-            'init authorizeCoinjoin cancelCoinjoinAuthorization passphrase unlockPath setBusy override checkFirmwareAuthenticity keepSession cancel.test info.test',
-        methods: '',
+            'init authorizeCoinjoin cancelCoinjoinAuthorization passphrase unlockPath setBusy checkFirmwareAuthenticity keepSession cancel.test info.test',
+        includeFilter: '',
+    },
+    // temporarily created group for flaky test - to spend less time on reruns and to make test result in CI more readable without investigating long logs
+    apiFlaky: {
+        name: 'api-flaky',
+        pattern: 'override',
     },
     management: {
         name: 'management',
         pattern: 'methods',
-        methods: 'applySettings,applyFlags,getFeatures,getFirmwareHash,changeLanguage,loadDevice',
+        includeFilter:
+            'applySettings,applyFlags,getFeatures,getFirmwareHash,changeLanguage,loadDevice',
     },
     btcSign: {
         name: 'btc-sign',
         pattern: 'methods',
-        methods: 'signTransaction',
+        includeFilter: 'signTransaction',
     },
     btcOthers: {
         name: 'btc-others',
         pattern: 'methods',
-        methods:
+        includeFilter:
             'getAccountInfo,getAccountDescriptor,getAddress,getPublicKey,signMessage,verifyMessage,composeTransaction,getOwnershipId,getOwnershipProof',
     },
     stellar: {
         name: 'stellar',
         pattern: 'methods',
-        methods: 'stellarGetAddress,stellarSignTransaction',
+        includeFilter: 'stellarGetAddress,stellarSignTransaction',
     },
     cardano: {
         name: 'cardano',
         pattern: 'methods',
-        methods:
+        includeFilter:
             'cardanoGetAddress,cardanoGetNativeScriptHash,cardanoGetPublicKey,cardanoSignTransaction',
     },
     eos: {
         name: 'eos',
         pattern: 'methods',
-        methods: 'eosGetPublicKey,eosSignTransaction',
+        includeFilter: 'eosGetPublicKey,eosSignTransaction',
     },
     ethereum: {
         name: 'ethereum',
         pattern: 'methods',
-        methods:
+        includeFilter:
             'ethereumGetAddress,ethereumGetPublicKey,ethereumSignMessage,ethereumSignTransaction,ethereumVerifyMessage,ethereumSignTypedData',
     },
     nem: {
         name: 'nem',
         pattern: 'methods',
-        methods: 'nemGetAddress,nemSignTransaction',
+        includeFilter: 'nemGetAddress,nemSignTransaction',
     },
     ripple: {
         name: 'ripple',
         pattern: 'methods',
-        methods: 'rippleGetAddress,rippleSignTransaction',
+        includeFilter: 'rippleGetAddress,rippleSignTransaction',
     },
     tezos: {
         name: 'tezos',
         pattern: 'methods',
-        methods: 'tezosGetAddress,tezosGetPublicKey,tezosSignTransaction',
+        includeFilter: 'tezosGetAddress,tezosGetPublicKey,tezosSignTransaction',
     },
     binance: {
         name: 'binance',
         pattern: 'methods',
-        methods: 'binanceGetAddress,binanceGetPublicKey,binanceSignTransaction',
+        includeFilter: 'binanceGetAddress,binanceGetPublicKey,binanceSignTransaction',
     },
 };
 
-const daily = {
-    firmwares: ['2-latest'],
-    tests: [...Object.values(groups)],
-};
+const firmwares1 = ['1.9.0', '1-latest', '1-main'];
+const firmwares2 = ['2.3.0', '2-latest', '2-main'];
 
-const legacyFirmware = {
-    firmwares: ['2.3.0'],
-    tests: daily.tests
-        // Cardano supports >=2.6.0
-        .filter(test => test.name !== 'cardano'),
-};
+const inputs = [
+    {
+        key: 'model',
+        value: ['T1B1', 'T2T1', 'T2B1', 'T3B1', 'T3T1'],
+    },
 
-const canaryFirmware = {
-    firmwares: ['2-main'],
-    tests: daily.tests,
-};
-
-const otherDevices = {
-    firmwares: ['2-latest'],
-    models: ['T2B1', 'T3T1'],
-    tests: [
-        ...Object.values(groups).filter(
-            // management, btc-others are specified below
-            // nem, eos are not supported anymore
-            g => ['management', 'btc-others', 'nem', 'eos'].includes(g.name) === false,
-        ),
-        {
-            ...groups.management,
-            methods: groups.management.methods
-                .split(',')
-                // getFeatures test is not abstract enough to serve all models
-                .filter(m => m !== 'getFeatures')
-                .join(','),
+    {
+        key: 'firmware',
+        value: ({ model }) => {
+            return model === 'T1B1' ? firmwares1 : firmwares2;
         },
-        {
-            ...groups.btcOthers,
-            methods: groups.btcOthers.methods
-                .split(',')
-                // getAddress (decred) does not work for model R
-                .filter(m => m !== 'getAddress')
-                .join(','),
-        },
-    ],
-};
+    },
+    {
+        key: 'transport',
+        value: ['Bridge', 'NodeBridge'],
+    },
+    {
+        key: 'groups',
+        value: Object.values(groups),
+    },
+    {
+        key: 'env',
+        value: ['node', 'web'],
+    },
+    {
+        key: 'cache_tx',
+        value: ['true', 'false'],
+    },
+    {
+        key: 'key',
+        value: [' '],
+    },
+];
 
-const prepareTest = ({ firmwares, tests, models }) => {
-    const withFirmwares = tests.flatMap(test => firmwares.map(firmware => ({ firmware, ...test })));
-
-    if (models && models.length > 0) {
-        return withFirmwares.flatMap(test => models.map(model => ({ model, ...test })));
-    } else {
-        return withFirmwares;
-    }
-};
-
-const testData = {
-    daily,
-    legacyFirmware,
-    canaryFirmware,
-    otherDevices,
-};
-
+// Get command-line arguments, excluding 'node' and the script name
 const args = process.argv.slice(2);
-const [tests] = args;
-const json = prepareTest(testData[tests]);
 
-process.stdout.write(
-    JSON.stringify({
-        include: json,
-    }),
-);
+// Initialize an object to store the parsed arguments
+const parsedArgs = {
+    key: ' ',
+};
+
+// Iterate over the arguments
+args.forEach(arg => {
+    // Split each argument by '=' to separate the key and value
+    const [key, value] = arg.split('=');
+
+    // Remove the leading '--' from the key
+    const argName = key.replace(/^--/, '');
+
+    // Check if the value contains commas to create an array
+    parsedArgs[argName] = value.includes(',') ? value.split(',') : value;
+});
+
+log('parsedArgs', parsedArgs);
+
+const validateArgs = () => {
+    const requiredArgs = ['model', 'firmware', 'env', 'groups', 'cache_tx', 'transport'];
+
+    requiredArgs.forEach(arg => {
+        if (!parsedArgs[arg]) {
+            throw new Error(`Missing required argument: ${arg}`);
+        }
+    });
+};
+
+validateArgs();
+
+log('validated args', parsedArgs);
+
+/**
+ a method that takes inputs and creates all combinations of results like this:
+ {model: T1B1, firmware: 1.9.0, transport: 'Bridge'... }
+ {model: T1B1, firmware: 1.9.0, transport: 'NodeBridge'... }
+ {model: T1B1, firmware: 1-latest, transport: 'Bridge'... }
+ {model: T1B1, firmware: 1-latest, transport: 'NodeBridge'... }
+ */
+const createCartesian = inputs => {
+    const keys = inputs.map(m => m.key);
+    const values = inputs.map(m => m.value);
+
+    const results = [];
+    const create = (index, current) => {
+        if (index === keys.length) {
+            results.push(current);
+            return;
+        }
+
+        const key = keys[index];
+        const value = typeof values[index] === 'function' ? values[index](current) : values[index];
+
+        for (let i = 0; i < value.length; i++) {
+            create(index + 1, {
+                ...current,
+                [key]: value[i],
+            });
+        }
+    };
+
+    create(0, {});
+    return results;
+};
+
+const cartesian = createCartesian(inputs);
+
+log('cartesian length', cartesian.length);
+
+/**
+ * filter cartesian by passed arguments
+ */
+const filterCartesianResultByArgs = () => {
+    const getValue = input => {
+        if (typeof input === 'object') {
+            return input.name;
+        }
+        return input;
+    };
+
+    return cartesian.filter(m => {
+        return Object.keys(m).every(key => {
+            const filterBy = parsedArgs[key];
+            if (filterBy === 'all') return true;
+            if (Array.isArray(filterBy)) {
+                return filterBy.includes(getValue(m[key]));
+            }
+            return getValue(m[key]) === filterBy;
+        });
+    });
+};
+
+const filtered = filterCartesianResultByArgs();
+
+log('filtered.length', filtered.length);
+
+if (!DEBUG) {
+    process.stdout.write(
+        JSON.stringify({
+            include: filtered,
+        }),
+    );
+}


### PR DESCRIPTION
-  update legacy results for cardano.
- `connect-test-matrix-generator.js` reworked now it:
  -   creates an array of all possible combinations of test modifiers (`'model', 'firmware', 'env', 'groups', 'cache_tx', 'transport'`). 
  -  accepts args in the format `--someStrArg=meow` or `--someArrOfStrArg=wuff,meow` and uses it to filter the array produced in the previous step. This way we only receive combinations we want to use to create the desired jobs matrix. 
  - special keyword `all` might be passed to allow all of the possibilities, for example: `--env=all` means the same as `--env=node,web`
  - some of  the inputs are not actively used yet. I created this mainly because of @szymonlesisz request to be able to extend test parametrization by specifying `transport`. this is now possible but the newly added param is not consumed anywhere yet.
- connect tests jobs slightly reorganized.
  - As we add more tests, we need to find a way to run them more efficiently and target them more precisely. So from now on in regular PRs, only the `api` section of connect is tested (so no `methods`). Methods (eth, nem, ada..) are the most time-consuming and at the same time, they don't break that often so they are now run only in nightly jobs. There will be a follow-up that will create new packages for all the shitcoin method families that will allow us to run them in regular PR pipelines again.
  - anyway, you can check yourself how the [full testing strategy including nightly looks like](https://github.com/trezor/trezor-suite/actions/runs/11549791189)

just a few screenshots to make the PR more visually appealing

<img width="280" alt="image" src="https://github.com/user-attachments/assets/010b8ab8-b6a9-4f32-afd7-b995393256ab">

<img width="380" alt="image" src="https://github.com/user-attachments/assets/e37c3d43-0712-438c-ac1f-5d1784c28c67">

what I don't understand is why github sometimes wraps two jobs under one dropdown and sometimes not, see this screenshot 
![image](https://github.com/user-attachments/assets/0d7c9cd7-1e09-4789-81aa-51ae4feec71a)

 
 