### PR TITLE
Chore: bip43Path template type

### DIFF
--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -3,7 +3,7 @@ import TrezorConnect from '@trezor/connect';
 import { promiseAllSequence } from '@trezor/utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { isDevEnv } from '@suite-common/suite-utils';
-import { NetworkAccount, Network, NetworkSymbol, Bip43Path } from '@suite-common/wallet-config';
+import { NetworkAccount, Network, NetworkSymbol } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
 import {
     accountsActions,
@@ -12,7 +12,11 @@ import {
     selectDevice,
     selectDevices,
 } from '@suite-common/wallet-core';
-import { getAccountTransactions, sortByBIP44AddressIndex } from '@suite-common/wallet-utils';
+import {
+    getAccountTransactions,
+    sortByBIP44AddressIndex,
+    substituteBip43Path,
+} from '@suite-common/wallet-utils';
 
 import { CoinjoinService, COORDINATOR_FEE_RATE_MULTIPLIER } from 'src/services/coinjoin';
 import { getAccountProgressHandle, getRegisterAccountParams } from 'src/utils/wallet/coinjoinUtils';
@@ -578,7 +582,7 @@ export const createCoinjoinAccount =
             return;
         }
 
-        const path = account.bip43Path.replace('i', '0') as Bip43Path;
+        const path = substituteBip43Path(account.bip43Path);
 
         // get coinjoin account xpub
         const publicKey = await TrezorConnect.getPublicKey({

--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -3,7 +3,7 @@ import TrezorConnect from '@trezor/connect';
 import { promiseAllSequence } from '@trezor/utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { isDevEnv } from '@suite-common/suite-utils';
-import { NetworkAccount, Network, NetworkSymbol } from '@suite-common/wallet-config';
+import { NetworkAccount, Network, NetworkSymbol, Bip43Path } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
 import {
     accountsActions,
@@ -578,7 +578,7 @@ export const createCoinjoinAccount =
             return;
         }
 
-        const path = account.bip43Path.replace('i', '0');
+        const path = account.bip43Path.replace('i', '0') as Bip43Path;
 
         // get coinjoin account xpub
         const publicKey = await TrezorConnect.getPublicKey({

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/definitions.ts
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/definitions.ts
@@ -1,13 +1,13 @@
 import { ReactNode } from 'react';
 import { DropdownMenuItemProps } from '@trezor/components';
 import { MetadataAddPayload } from 'src/types/suite/metadata';
-import { AccountType } from '@suite-common/wallet-config';
+import { AccountType, Bip43Path } from '@suite-common/wallet-config';
 import { NetworkType } from '@suite-common/wallet-config';
 
 export interface Props {
     accountType?: AccountType;
     networkType?: NetworkType;
-    path?: string;
+    path?: Bip43Path;
     defaultVisibleValue?: ReactNode;
     defaultEditableValue?: string;
     payload: MetadataAddPayload;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeDescription.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeDescription.tsx
@@ -1,5 +1,5 @@
 import { Paragraph } from '@trezor/components';
-import { Bip43Path } from '@suite-common/wallet-config';
+import { Bip43PathTemplate } from '@suite-common/wallet-config';
 import { Translation } from 'src/components/suite';
 import {
     getAccountTypeDesc,
@@ -15,7 +15,7 @@ import { spacings } from '@trezor/theme';
 import { Account } from '@suite-common/wallet-types';
 
 interface AccountTypeDescriptionProps {
-    bip43Path: Bip43Path;
+    bip43Path: Bip43PathTemplate;
     accountType?: AccountType;
     symbol?: Account['symbol'];
     networkType?: NetworkType;

--- a/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
@@ -13,7 +13,7 @@ import regional from 'src/constants/wallet/coinmarket/regional';
 import { ExtendedMessageDescriptor, TrezorDevice } from 'src/types/suite';
 import { BuyTrade, SellFiatTrade, CryptoId } from 'invity-api';
 import { DefinitionType, isTokenDefinitionKnown } from '@suite-common/token-definitions';
-import { getContractAddressForNetwork } from '@suite-common/wallet-utils';
+import { getContractAddressForNetwork, substituteBip43Path } from '@suite-common/wallet-utils';
 import {
     CoinmarketAccountOptionsGroupOptionProps,
     CoinmarketAccountsOptionsGroupProps,
@@ -160,7 +160,7 @@ export const getComposeAddressPlaceholder = async (
 
             if (device) {
                 // try to get the already discovered legacy account
-                const legacyPath = `${bip43Path.replace('i', '0')}`;
+                const legacyPath = substituteBip43Path(bip43Path);
                 const legacyAccount = accounts?.find(a => a.path === legacyPath);
                 if (legacyAccount?.addresses?.unused[0]) {
                     return legacyAccount?.addresses?.unused[0].address;
@@ -169,7 +169,7 @@ export const getComposeAddressPlaceholder = async (
                 const result = await TrezorConnect.getAddress({
                     device,
                     coin: account.symbol,
-                    path: `${bip43Path.replace('i', '0')}/0/0`,
+                    path: `${substituteBip43Path(bip43Path)}/0/0`,
                     useEmptyPassphrase: device.useEmptyPassphrase,
                     showOnTrezor: false,
                     chunkify,

--- a/suite-common/wallet-config/src/types.ts
+++ b/suite-common/wallet-config/src/types.ts
@@ -57,10 +57,14 @@ export type NetworkFeature =
     | 'nft-definitions';
 
 type Level = `/${number}'`;
-type LevelOrIndex = `/${number | 'i'}'`;
 type MaybeApostrophe = `'` | '';
+type MaybeLevel = `/${number}${MaybeApostrophe}` | '';
+type LevelOrIndex = `/${number | 'i'}'`;
 type MaybeLevelOrIndex = `/${number | 'i'}${MaybeApostrophe}` | '';
-export type Bip43Path = `m${Level}${Level}${LevelOrIndex}${MaybeLevelOrIndex}${MaybeLevelOrIndex}`;
+// template with i in place of account index, which shall be substituted with a number
+export type Bip43PathTemplate =
+    `m${Level}${Level}${LevelOrIndex}${MaybeLevelOrIndex}${MaybeLevelOrIndex}`;
+export type Bip43Path = `m${Level}${Level}${Level}${MaybeLevel}${MaybeLevel}`;
 
 export type Explorer = {
     tx: string;
@@ -73,7 +77,7 @@ export type Explorer = {
 
 type NetworkAccountWithSpecificKey<TKey extends AccountType> = {
     accountType: TKey;
-    bip43Path: Bip43Path;
+    bip43Path: Bip43PathTemplate;
     backendType?: BackendType;
     features?: NetworkFeature[];
     isDebugOnlyAccountType?: boolean;
@@ -91,7 +95,7 @@ type NetworkWithSpecificKey<TKey extends NetworkSymbol> = {
     symbol: TKey;
     name: string;
     networkType: NetworkType;
-    bip43Path: Bip43Path;
+    bip43Path: Bip43PathTemplate;
     decimals: number;
     testnet: boolean;
     explorer: Explorer;

--- a/suite-common/wallet-config/src/types.ts
+++ b/suite-common/wallet-config/src/types.ts
@@ -56,7 +56,11 @@ export type NetworkFeature =
     | 'coin-definitions'
     | 'nft-definitions';
 
-export type Bip43Path = string; // TODO define a more specific type
+type Level = `/${number}'`;
+type LevelOrIndex = `/${number | 'i'}'`;
+type MaybeApostrophe = `'` | '';
+type MaybeLevelOrIndex = `/${number | 'i'}${MaybeApostrophe}` | '';
+export type Bip43Path = `m${Level}${Level}${LevelOrIndex}${MaybeLevelOrIndex}${MaybeLevelOrIndex}`;
 
 export type Explorer = {
     tx: string;

--- a/suite-common/wallet-core/src/accounts/tests/accountsReducer.test.ts
+++ b/suite-common/wallet-core/src/accounts/tests/accountsReducer.test.ts
@@ -3,6 +3,7 @@ import { combineReducers } from '@reduxjs/toolkit';
 import { ExtraDependenciesPartial } from '@suite-common/redux-utils';
 import { configureMockStore, extraDependenciesMock } from '@suite-common/test-utils';
 import { Account } from '@suite-common/wallet-types';
+import { Bip43Path } from '@suite-common/wallet-config';
 
 import { accountsActions } from '../accountsActions';
 import { AccountsRootState, prepareAccountsReducer } from '../accountsReducer';
@@ -30,6 +31,8 @@ const getAccount = (a?: Partial<Account>) => ({
     ...a,
 });
 
+const testBip43Path: Bip43Path = "m/84'/0'/0'";
+
 describe('Account Reducer', () => {
     // accountActions.createAccount function is already tested by "discoveryActions"
     // it's pointless to write a complex tests for it
@@ -40,14 +43,14 @@ describe('Account Reducer', () => {
                 deviceState: '1stTestnetAddress@device_id:0',
                 discoveryItem: {
                     index: 0,
-                    path: "m/84'/0'/0'",
+                    path: testBip43Path,
                     accountType: 'normal',
                     networkType: 'bitcoin',
                     coin: 'btc',
                 },
                 accountInfo: {
                     descriptor: 'XPUB',
-                    path: "m/84'/0'/0'",
+                    path: testBip43Path,
                     empty: false,
                     balance: '0',
                     availableBalance: '0',
@@ -68,7 +71,13 @@ describe('Account Reducer', () => {
         const store = initStore({
             preloadedState: {
                 wallet: {
-                    accounts: [getAccount({ symbol: 'ltc', path: '1', visible: false }) as Account],
+                    accounts: [
+                        getAccount({
+                            symbol: 'ltc',
+                            path: testBip43Path,
+                            visible: false,
+                        }) as Account,
+                    ],
                 },
             },
         });
@@ -77,13 +86,13 @@ describe('Account Reducer', () => {
             accountsActions.changeAccountVisibility(
                 getAccount({
                     symbol: 'ltc',
-                    path: '1',
+                    path: testBip43Path,
                     visible: false,
                 }) as Account,
             ),
         );
         expect(store.getState().wallet.accounts[0]).toEqual(
-            getAccount({ symbol: 'ltc', path: '1', visible: true }),
+            getAccount({ symbol: 'ltc', path: testBip43Path, visible: true }),
         );
     });
 
@@ -94,7 +103,7 @@ describe('Account Reducer', () => {
             accountsActions.changeAccountVisibility(
                 getAccount({
                     symbol: 'ltc',
-                    path: '1',
+                    path: testBip43Path,
                     visible: false,
                 }) as Account,
             ),

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -7,6 +7,7 @@ import {
     tryGetAccountIdentity,
     getDerivationType,
     isTrezorConnectBackendType,
+    substituteBip43Path,
 } from '@suite-common/wallet-utils';
 import { Discovery, DiscoveryItem, PartialDiscovery } from '@suite-common/wallet-types';
 import { getTxsPerPage } from '@suite-common/suite-utils';
@@ -17,7 +18,6 @@ import {
     networksCollection,
     normalizeNetworkAccounts,
     NormalizedNetworkAccount,
-    Bip43Path,
 } from '@suite-common/wallet-config';
 import { getFirmwareVersion } from '@trezor/device-utils';
 import { versionUtils } from '@trezor/utils';
@@ -301,7 +301,7 @@ export const getBundleThunk = createThunk(
                 const pathIndex = (index + (isEvmLedgerDerivationPath ? 1 : 0)).toString();
 
                 bundle.push({
-                    path: bip43Path.replace('i', pathIndex) as Bip43Path,
+                    path: substituteBip43Path(bip43Path, pathIndex),
                     coin: networkSymbol,
                     identity: tryGetAccountIdentity({
                         networkType,

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -17,6 +17,7 @@ import {
     networksCollection,
     normalizeNetworkAccounts,
     NormalizedNetworkAccount,
+    Bip43Path,
 } from '@suite-common/wallet-config';
 import { getFirmwareVersion } from '@trezor/device-utils';
 import { versionUtils } from '@trezor/utils';
@@ -300,7 +301,7 @@ export const getBundleThunk = createThunk(
                 const pathIndex = (index + (isEvmLedgerDerivationPath ? 1 : 0)).toString();
 
                 bundle.push({
-                    path: bip43Path.replace('i', pathIndex),
+                    path: bip43Path.replace('i', pathIndex) as Bip43Path,
                     coin: networkSymbol,
                     identity: tryGetAccountIdentity({
                         networkType,

--- a/suite-common/wallet-types/src/account.ts
+++ b/suite-common/wallet-types/src/account.ts
@@ -1,4 +1,4 @@
-import { AccountType, BackendType, NetworkSymbol } from '@suite-common/wallet-config';
+import { AccountType, BackendType, Bip43Path, NetworkSymbol } from '@suite-common/wallet-config';
 import { AccountEntityKeys } from '@suite-common/metadata-types';
 import { AccountInfo, PROTO, StaticSessionId, TokenInfo } from '@trezor/connect';
 import {
@@ -83,7 +83,7 @@ export type Account = {
     deviceState: StaticSessionId;
     key: AccountKey;
     index: number;
-    path: string;
+    path: Bip43Path;
     unlockPath?: PROTO.UnlockPath; // parameter used to unlock SLIP-25/coinjoin keychain
     descriptor: string;
     descriptorChecksum?: string;

--- a/suite-common/wallet-types/src/discovery.ts
+++ b/suite-common/wallet-types/src/discovery.ts
@@ -1,6 +1,6 @@
 import { ObjectValues } from '@trezor/type-utils';
 import { DiscoveryStatus } from '@suite-common/wallet-constants';
-import { AccountType, NetworkSymbol } from '@suite-common/wallet-config';
+import { AccountType, Bip43Path, NetworkSymbol } from '@suite-common/wallet-config';
 import { Deferred } from '@trezor/utils';
 import { StaticSessionId } from '@trezor/connect';
 
@@ -35,7 +35,7 @@ export type PartialDiscovery = { deviceState: string } & Partial<Discovery>;
 
 export type DiscoveryItem = {
     // @trezor/connect
-    path: string;
+    path: Bip43Path;
     unlockPath?: Account['unlockPath'];
     coin: Account['symbol'];
     identity?: string;

--- a/suite-common/wallet-utils/src/__fixtures__/accountUtils.ts
+++ b/suite-common/wallet-utils/src/__fixtures__/accountUtils.ts
@@ -1,5 +1,5 @@
 import { testMocks } from '@suite-common/test-utils';
-import { Bip43Path } from '@suite-common/wallet-config';
+import { Bip43Path, Bip43PathTemplate } from '@suite-common/wallet-config';
 
 import { ACCOUNTS } from './accounts';
 
@@ -230,7 +230,7 @@ export const getBip43Type = [
 
 type SubstituteBip43PathFixture = {
     description: string;
-    pathTemplate: Bip43Path;
+    pathTemplate: Bip43PathTemplate;
     index?: number | string;
     result: Bip43Path;
 };

--- a/suite-common/wallet-utils/src/__fixtures__/accountUtils.ts
+++ b/suite-common/wallet-utils/src/__fixtures__/accountUtils.ts
@@ -1,4 +1,5 @@
 import { testMocks } from '@suite-common/test-utils';
+import { Bip43Path } from '@suite-common/wallet-config';
 
 import { ACCOUNTS } from './accounts';
 
@@ -224,6 +225,32 @@ export const getBip43Type = [
         description: 'invalid path type',
         path: undefined,
         result: 'unknown',
+    },
+];
+
+type SubstituteBip43PathFixture = {
+    description: string;
+    pathTemplate: Bip43Path;
+    index?: number | string;
+    result: Bip43Path;
+};
+export const substituteBip43Path: SubstituteBip43PathFixture[] = [
+    {
+        description: 'numerical index',
+        pathTemplate: "m/84'/0'/i'",
+        index: 7,
+        result: "m/84'/0'/7'",
+    },
+    {
+        description: 'stringified index',
+        pathTemplate: "m/44'/0'/i'/0",
+        index: '14',
+        result: "m/44'/0'/14'/0",
+    },
+    {
+        description: 'default index',
+        pathTemplate: "m/10025'/1'/i'/1'",
+        result: "m/10025'/1'/0'/1'",
     },
 ];
 

--- a/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
@@ -8,6 +8,7 @@ import {
     getAccountIdentifier,
     getAccountKey,
     getBip43Type,
+    substituteBip43Path,
     getFiatValue,
     getFirstFreshAddress,
     getTitleForNetwork,
@@ -84,6 +85,14 @@ describe('account utils', () => {
                 // @ts-expect-error intentional invalid params
                 const bip43 = getBip43Type(f.path);
                 expect(bip43).toBe(f.result);
+            });
+        });
+    });
+
+    describe(substituteBip43Path.name, () => {
+        fixtures.substituteBip43Path.forEach(f => {
+            it(f.description, () => {
+                expect(substituteBip43Path(f.pathTemplate, f.index)).toBe(f.result);
             });
         });
     });

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -17,6 +17,7 @@ import {
     networks,
     AccountType,
     Bip43Path,
+    Bip43PathTemplate,
     getNetwork,
 } from '@suite-common/wallet-config';
 import {
@@ -223,11 +224,13 @@ export const getBip43Type = (path: string) => {
     }
 };
 
-export const substituteBip43Path = (bip43Path: Bip43Path, accountIndex: string | number = '0') =>
-    bip43Path.replace('i', String(accountIndex)) as Bip43Path;
+export const substituteBip43Path = (
+    bip43PathTemplate: Bip43PathTemplate,
+    accountIndex: string | number = '0',
+) => bip43PathTemplate.replace('i', String(accountIndex)) as Bip43Path;
 
 type getAccountTypeNameProps = {
-    path?: Bip43Path;
+    path?: Bip43PathTemplate;
     networkType?: NetworkType;
     accountType?: AccountType;
 };
@@ -268,7 +271,7 @@ export const getAccountTypeName = ({ path, accountType, networkType }: getAccoun
     return 'TR_ACCOUNT_TYPE_BIP44_NAME';
 };
 
-export const getAccountTypeTech = (path: Bip43Path) => {
+export const getAccountTypeTech = (path: Bip43PathTemplate) => {
     const accountTypePrefix = getAccountTypePrefix(path);
     if (accountTypePrefix) return `${accountTypePrefix}_TECH` as const;
     const bip43 = getBip43Type(path);
@@ -282,7 +285,7 @@ export const getAccountTypeTech = (path: Bip43Path) => {
 };
 
 type getAccountTypeDescProps = {
-    path: Bip43Path;
+    path: Bip43PathTemplate;
     accountType?: AccountType;
     networkType?: NetworkType;
 };
@@ -565,7 +568,7 @@ export const enhanceAddresses = (
         case 'cardano': {
             const replaceAccountIndex = (address: AccountAddress) => ({
                 ...address,
-                path: substituteBip43Path(address.path as Bip43Path, accountIndex),
+                path: substituteBip43Path(address.path as Bip43PathTemplate, accountIndex),
             });
 
             return {
@@ -610,7 +613,7 @@ export const enhanceUtxo = (
 
     const enhancedUtxos = utxos.map(utxo => ({
         ...utxo,
-        path: substituteBip43Path(utxo.path as Bip43Path, accountIndex),
+        path: substituteBip43Path(utxo.path as Bip43PathTemplate, accountIndex),
     }));
 
     return enhancedUtxos;
@@ -846,7 +849,7 @@ export const getFailedAccounts = (discovery: Discovery): Account[] =>
             failed: true,
             deviceState: discovery.deviceState,
             index: f.index,
-            path: network.bip43Path, // placeholder - not relevant for failed, but required by TS to be an actual Bip43Path
+            path: substituteBip43Path(network.bip43Path), // placeholder - not relevant for failed, but required by TS to be an actual Bip43Path
             descriptor,
             key: descriptor,
             accountType: f.accountType,

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -840,12 +840,13 @@ export const getAccountSpecific = (accountInfo: Partial<AccountInfo>, networkTyp
 export const getFailedAccounts = (discovery: Discovery): Account[] =>
     discovery.failed.map(f => {
         const descriptor = `failed:${f.index}:${f.symbol}:${f.accountType}`;
+        const network = networks[f.symbol];
 
         return {
             failed: true,
             deviceState: discovery.deviceState,
             index: f.index,
-            path: descriptor,
+            path: network.bip43Path, // placeholder - not relevant for failed, but required by TS to be an actual Bip43Path
             descriptor,
             key: descriptor,
             accountType: f.accountType,
@@ -865,7 +866,7 @@ export const getFailedAccounts = (discovery: Discovery): Account[] =>
             metadata: {
                 key: descriptor,
             },
-            ...getAccountSpecific({}, networks[f.symbol].networkType),
+            ...getAccountSpecific({}, network.networkType),
         };
     });
 

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -223,6 +223,9 @@ export const getBip43Type = (path: string) => {
     }
 };
 
+export const substituteBip43Path = (bip43Path: Bip43Path, accountIndex: string | number = '0') =>
+    bip43Path.replace('i', String(accountIndex)) as Bip43Path;
+
 type getAccountTypeNameProps = {
     path?: Bip43Path;
     networkType?: NetworkType;
@@ -560,11 +563,9 @@ export const enhanceAddresses = (
 
     switch (networkType) {
         case 'cardano': {
-            const accountIndexStr = accountIndex.toString();
-
             const replaceAccountIndex = (address: AccountAddress) => ({
                 ...address,
-                path: address.path.replace('i', accountIndexStr),
+                path: substituteBip43Path(address.path as Bip43Path, accountIndex),
             });
 
             return {
@@ -607,10 +608,9 @@ export const enhanceUtxo = (
     if (!utxos) return undefined;
     if (networkType !== 'cardano') return utxos;
 
-    const accountIndexStr = accountIndex.toString();
     const enhancedUtxos = utxos.map(utxo => ({
         ...utxo,
-        path: utxo.path.replace('i', accountIndexStr),
+        path: substituteBip43Path(utxo.path as Bip43Path, accountIndex),
     }));
 
     return enhancedUtxos;

--- a/suite-native/discovery/src/discoveryThunks.ts
+++ b/suite-native/discovery/src/discoveryThunks.ts
@@ -33,6 +33,7 @@ import {
     getNetworkType,
     NetworkAccount,
     normalizeNetworkAccounts,
+    Bip43Path,
 } from '@suite-common/wallet-config';
 import { DiscoveryStatus } from '@suite-common/wallet-constants';
 import { requestDeviceAccess } from '@suite-native/device-mutex';
@@ -366,7 +367,7 @@ export const addAndDiscoverNetworkAccountThunk = createThunk<
             return rejectWithValue(discoveryErrors.accountLimitReached);
         }
 
-        const accountPath = network.bip43Path.replace('i', index.toString());
+        const accountPath = network.bip43Path.replace('i', index.toString()) as Bip43Path;
 
         // Take exclusive access to the device and hold it until fetching of the descriptors is done.
         const deviceAccessResponse = await requestDeviceAccess({
@@ -458,7 +459,8 @@ const discoverNetworkBatchThunk = createThunk(
             const index =
                 lastDiscoveredAccountIndex + batchIndex + (isEvmLedgerDerivationPath ? 1 : 0);
 
-            const accountPath = normalizedNetworkAccount.bip43Path.replace('i', index.toString());
+            const { bip43Path } = normalizedNetworkAccount;
+            const accountPath = bip43Path.replace('i', index.toString()) as Bip43Path;
 
             const isAccountAlreadyDiscovered = selectIsAccountAlreadyDiscovered(getState(), {
                 deviceState,

--- a/suite-native/discovery/src/discoveryThunks.ts
+++ b/suite-native/discovery/src/discoveryThunks.ts
@@ -24,7 +24,11 @@ import {
 import { selectIsAccountAlreadyDiscovered } from '@suite-native/accounts';
 import TrezorConnect, { StaticSessionId } from '@trezor/connect';
 import { Account, DiscoveryItem } from '@suite-common/wallet-types';
-import { getDerivationType, tryGetAccountIdentity } from '@suite-common/wallet-utils';
+import {
+    getDerivationType,
+    substituteBip43Path,
+    tryGetAccountIdentity,
+} from '@suite-common/wallet-utils';
 import {
     AccountType,
     Network,
@@ -33,7 +37,6 @@ import {
     getNetworkType,
     NetworkAccount,
     normalizeNetworkAccounts,
-    Bip43Path,
 } from '@suite-common/wallet-config';
 import { DiscoveryStatus } from '@suite-common/wallet-constants';
 import { requestDeviceAccess } from '@suite-native/device-mutex';
@@ -367,7 +370,7 @@ export const addAndDiscoverNetworkAccountThunk = createThunk<
             return rejectWithValue(discoveryErrors.accountLimitReached);
         }
 
-        const accountPath = network.bip43Path.replace('i', index.toString()) as Bip43Path;
+        const accountPath = substituteBip43Path(network.bip43Path, index);
 
         // Take exclusive access to the device and hold it until fetching of the descriptors is done.
         const deviceAccessResponse = await requestDeviceAccess({
@@ -460,7 +463,7 @@ const discoverNetworkBatchThunk = createThunk(
                 lastDiscoveredAccountIndex + batchIndex + (isEvmLedgerDerivationPath ? 1 : 0);
 
             const { bip43Path } = normalizedNetworkAccount;
-            const accountPath = bip43Path.replace('i', index.toString()) as Bip43Path;
+            const accountPath = substituteBip43Path(bip43Path, index);
 
             const isAccountAlreadyDiscovered = selectIsAccountAlreadyDiscovered(getState(), {
                 deviceState,

--- a/suite-native/module-accounts-import/src/accountsImportThunks.ts
+++ b/suite-native/module-accounts-import/src/accountsImportThunks.ts
@@ -6,7 +6,7 @@ import {
     updateFiatRatesThunk,
 } from '@suite-common/wallet-core';
 import TrezorConnect, { AccountInfo } from '@trezor/connect';
-import { networks, NetworkSymbol, AccountType } from '@suite-common/wallet-config';
+import { networks, NetworkSymbol, AccountType, Bip43Path } from '@suite-common/wallet-config';
 import { getXpubOrDescriptorInfo } from '@trezor/utxo-lib';
 import { getAccountIdentity, shouldUseIdentities } from '@suite-common/wallet-utils';
 import { Timestamp, TokenAddress } from '@suite-common/wallet-types';
@@ -59,7 +59,7 @@ export const importAccountThunk = createThunk(
                     deviceState,
                     discoveryItem: {
                         index: deviceNetworkAccounts.length, // indexed from 0
-                        path: accountInfo?.path ?? '',
+                        path: (accountInfo?.path ?? '') as Bip43Path,
                         accountType,
                         networkType: networks[coin].networkType,
                         coin,


### PR DESCRIPTION
## Description

- Define `Bip43Path` as a string template literal type rather than just `string`, to ensure that we don't accidentally produce a non-conforming path.
  - lot of TS errors had to be fixed, as we often had `string` directly, and _so far_ that was interchangeable with `Bip43Path`, but now it's not, it has to be used everywhere
  - but still there are interfaces with `connect` were the path is coming in as `string`
    - `suite-common` imports are not allowed in connect
    - :arrow_right: future TODO: move the path types to another package, for example `crypto-utils`..?  
- Create a helper `substituteBip43Path` to centralize substitution of index for `'i'` placeholder
  - it requires `as`, because `String.replace` returns `string` :disappointed: 
  - cover with unit test

## Related Issue

Part of #14445 
Resolves #16271