### PR TITLE
test(suite-web): remove temporary fixes for fw revision check

### DIFF
--- a/packages/suite-web/e2e/tests/onboarding/t1b1-recovery-advanced.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/t1b1-recovery-advanced.test.ts
@@ -9,8 +9,6 @@ describe('Onboarding - recover wallet T1B1', () => {
         cy.viewport(1440, 2560).resetDb();
         cy.prefixedVisit('/');
         cy.disableFirmwareHashCheck();
-        // TODO: Remove this compromised device workaround
-        cy.contains('Back').click();
     });
 
     it('Incomplete run of advanced recovery', () => {

--- a/packages/suite-web/e2e/tests/onboarding/t2t1-create-wallet.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/t2t1-create-wallet.test.ts
@@ -6,8 +6,6 @@ describe('Onboarding - create wallet', () => {
         cy.task('startBridge');
         cy.viewport(1920, 1080).resetDb();
         cy.prefixedVisit('/');
-
-        // TODO: add workaround that switches off the firmware revision check in settings/device
     });
 
     it('Success (Shamir backup)', () => {
@@ -16,8 +14,8 @@ describe('Onboarding - create wallet', () => {
         // in production, and we locally bumped emulator version, we would get into a screen saying "update your firmware" and the test would fail.
         cy.task('startEmu', { wipe: true, model: 'T2T1', version: '2-main' });
 
-        // TODO: compromised device workaround, refactor into more stable solution
-        cy.contains('Back').click();
+        // firmware revision check will fail with 2-main version, but we just need to get through onboarding, so it's fine to just dismiss it
+        cy.getTestElement('@device-compromised/back-button').click();
 
         cy.getTestElement('@analytics/continue-button').click();
         cy.getTestElement('@analytics/continue-button').click();

--- a/packages/suite-web/e2e/tests/settings/t1b1-device-settings.test.ts
+++ b/packages/suite-web/e2e/tests/settings/t1b1-device-settings.test.ts
@@ -14,8 +14,6 @@ describe('T1B1 - Device settings', () => {
         cy.task('startBridge');
         cy.viewport(1440, 2560).resetDb();
         cy.prefixedVisit('/');
-        // TODO: Remove this compromised device workaround
-        cy.contains('Back').click();
         cy.passThroughInitialRun();
     });
     afterEach(() => {

--- a/packages/suite-web/e2e/tests/settings/t2t1-device-settings.test.ts
+++ b/packages/suite-web/e2e/tests/settings/t2t1-device-settings.test.ts
@@ -82,13 +82,10 @@ describe('T2T1 - Device settings', () => {
     });
 
     it('able to change homescreen in firmware >= 2.5.4', () => {
-        cy.task('startEmu', { wipe: true, model: 'T2T1', version: '2-main' });
+        cy.task('startEmu', { wipe: true, model: 'T2T1', version: '2-latest' });
         cy.task('setupEmu');
 
         cy.prefixedVisit('/');
-
-        // TODO: compromised device workaround, refactor into more stable solution
-        cy.contains('Back').click();
 
         cy.passThroughInitialRun();
         onNavBar.openSettings();


### PR DESCRIPTION
## Description

Finish or remove temporary workarounds for FW _revision_ check in suite-web E2E tests (cypress)