### PR TITLE
refactor(suite-native): fresh address selector

### DIFF
--- a/suite-native/accounts/src/selectors.ts
+++ b/suite-native/accounts/src/selectors.ts
@@ -13,10 +13,17 @@ import {
     selectAccountByKey,
     selectAccounts,
     selectCurrentFiatRates,
+    selectIsAccountUtxoBased,
+    selectPendingAccountAddresses,
     selectVisibleDeviceAccounts,
+    TransactionsRootState,
 } from '@suite-common/wallet-core';
 import { AccountKey, TokenInfoBranded } from '@suite-common/wallet-types';
-import { getAccountFiatBalance, getAccountTotalStakingBalance } from '@suite-common/wallet-utils';
+import {
+    getAccountFiatBalance,
+    getAccountTotalStakingBalance,
+    getFirstFreshAddress,
+} from '@suite-common/wallet-utils';
 import { SettingsSliceRootState, selectFiatCurrencyCode } from '@suite-native/settings';
 import { isCoinWithTokens } from '@suite-native/tokens';
 
@@ -144,12 +151,17 @@ export const selectAccountListSections = memoizeWithArgs(
     { size: 40 },
 );
 
-export const selectFirstUnusedAccountAddress = (
-    state: NativeAccountsRootState,
+export const selectFreshAccountAddress = (
+    state: NativeAccountsRootState & TransactionsRootState,
     accountKey: AccountKey,
 ) => {
     const account = selectAccountByKey(state, accountKey);
+
     if (!account) return null;
 
-    return account.addresses?.unused[0]?.address ?? null;
+    const pendingAddresses = selectPendingAccountAddresses(state, accountKey);
+
+    const isAccountUtxoBased = selectIsAccountUtxoBased(state, accountKey);
+
+    return getFirstFreshAddress(account, [], pendingAddresses, isAccountUtxoBased);
 };

--- a/suite-native/module-send/src/components/AddressInput.tsx
+++ b/suite-native/module-send/src/components/AddressInput.tsx
@@ -8,8 +8,12 @@ import { Translation } from '@suite-native/intl';
 import { analytics, EventType } from '@suite-native/analytics';
 import { isAddressValid } from '@suite-common/wallet-utils';
 import { AccountKey } from '@suite-common/wallet-types';
-import { AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
-import { NativeAccountsRootState, selectFirstUnusedAccountAddress } from '@suite-native/accounts';
+import {
+    AccountsRootState,
+    selectAccountNetworkSymbol,
+    TransactionsRootState,
+} from '@suite-common/wallet-core';
+import { NativeAccountsRootState, selectFreshAccountAddress } from '@suite-native/accounts';
 import { isDebugEnv } from '@suite-native/config';
 
 import { QrCodeBottomSheetIcon } from './QrCodeBottomSheetIcon';
@@ -27,8 +31,9 @@ export const AddressInput = ({ index, accountKey }: AddressInputProps) => {
     const networkSymbol = useSelector((state: AccountsRootState) =>
         selectAccountNetworkSymbol(state, accountKey),
     );
-    const unusedAccountAddress = useSelector((state: NativeAccountsRootState) =>
-        selectFirstUnusedAccountAddress(state, accountKey),
+    const freshAccountAddress = useSelector(
+        (state: NativeAccountsRootState & TransactionsRootState) =>
+            selectFreshAccountAddress(state, accountKey),
     );
 
     const handleScanAddressQRCode = (qrCodeData: string) => {
@@ -46,8 +51,8 @@ export const AddressInput = ({ index, accountKey }: AddressInputProps) => {
 
     // Debug helper to fill opened account address.
     const fillSelfAddress = () => {
-        if (unusedAccountAddress)
-            setValue(addressFieldName, unusedAccountAddress, { shouldValidate: true });
+        if (freshAccountAddress)
+            setValue(addressFieldName, freshAccountAddress.address, { shouldValidate: true });
     };
 
     return (

--- a/suite-native/receive/package.json
+++ b/suite-native/receive/package.json
@@ -18,7 +18,6 @@
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
-        "@suite-common/wallet-utils": "workspace:*",
         "@suite-native/accounts": "workspace:*",
         "@suite-native/alerts": "workspace:*",
         "@suite-native/analytics": "workspace:*",

--- a/suite-native/receive/tsconfig.json
+++ b/suite-native/receive/tsconfig.json
@@ -11,9 +11,6 @@
         {
             "path": "../../suite-common/wallet-types"
         },
-        {
-            "path": "../../suite-common/wallet-utils"
-        },
         { "path": "../accounts" },
         { "path": "../alerts" },
         { "path": "../analytics" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10632,7 +10632,6 @@ __metadata:
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
-    "@suite-common/wallet-utils": "workspace:*"
     "@suite-native/accounts": "workspace:*"
     "@suite-native/alerts": "workspace:*"
     "@suite-native/analytics": "workspace:*"


### PR DESCRIPTION
## Description
- refactor of receive address selector
- send `self address` button works also for Ethereum based networks
