### PR TITLE
feat(suite): permit unrecognized FW with outdated suite

### DIFF
--- a/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareRevisionCheckBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareRevisionCheckBanner.tsx
@@ -9,6 +9,7 @@ import { useSelector } from 'src/hooks/suite';
 import {
     selectFirmwareHashCheckError,
     selectFirmwareRevisionCheckError,
+    selectIsUnrecognizedFirmwareWithOutdatedSuite,
 } from 'src/reducers/suite/suiteReducer';
 
 const revisionCheckMessages: Record<FirmwareRevisionCheckError, TranslationKey> = {
@@ -36,9 +37,15 @@ const hashCheckMessages: Record<
 const useAuthenticityCheckMessage = (): TranslationKey | null => {
     const firmwareRevisionError = useSelector(selectFirmwareRevisionCheckError);
     const firmwareHashError = useSelector(selectFirmwareHashCheckError);
+    const isUnrecognizedFwWithOutadedSuite = useSelector(
+        selectIsUnrecognizedFirmwareWithOutdatedSuite,
+    );
 
     if (firmwareRevisionError) {
         return revisionCheckMessages[firmwareRevisionError];
+    }
+    if (isUnrecognizedFwWithOutadedSuite) {
+        return 'TR_DEVICE_FIRMWARE_UNRECOGNIZED_OUTDATED_SUITE';
     }
     if (firmwareHashError && !isArrayMember(firmwareHashError, skippedHashCheckErrors)) {
         return hashCheckMessages[firmwareHashError];

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -1,11 +1,7 @@
 import produce from 'immer';
 
 import type { InvityServerEnvironment } from '@suite-common/invity';
-import {
-    Feature,
-    MessageSystemRootState,
-    selectIsFeatureDisabled,
-} from '@suite-common/message-system';
+import { Feature, selectIsFeatureDisabled } from '@suite-common/message-system';
 import { isDeviceAcquired } from '@suite-common/suite-utils';
 import { discoveryActions, DeviceRootState, selectDevice } from '@suite-common/wallet-core';
 import { versionUtils } from '@trezor/utils';
@@ -24,13 +20,14 @@ import { ensureLocale } from 'src/utils/suite/l10n';
 import type { Locale } from 'src/config/suite/languages';
 import { SUITE, STORAGE } from 'src/actions/suite/constants';
 import { ExperimentalFeature } from 'src/constants/suite/experimental';
-import { Action, Lock, TorBootstrap, TorStatus } from 'src/types/suite';
+import { Action, AppState, Lock, TorBootstrap, TorStatus } from 'src/types/suite';
 import { getExcludedPrerequisites, getPrerequisiteName } from 'src/utils/suite/prerequisites';
 import { RouterRootState, selectRouter } from './routerReducer';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { SuiteThemeVariant } from '@trezor/suite-desktop-api';
 import { AddressDisplayOptions, WalletType } from '@suite-common/wallet-types';
 import { SIDEBAR_WIDTH_NUMERIC } from 'src/constants/suite/layout';
+import { UpdateState } from './desktopUpdateReducer';
 
 export interface SuiteRootState {
     suite: SuiteState;
@@ -443,12 +440,10 @@ export const selectHasExperimentalFeature =
     (feature: ExperimentalFeature) => (state: SuiteRootState) =>
         state.suite.settings.experimental?.includes(feature) ?? false;
 
-type StateForFirmwareChecks = SuiteRootState & DeviceRootState & MessageSystemRootState;
-
 /**
  * Get firmware revision check error, or null if check was successful / skipped.
  */
-export const selectFirmwareRevisionCheckError = (state: StateForFirmwareChecks) => {
+export const selectFirmwareRevisionCheckError = (state: AppState) => {
     const device = selectDevice(state);
     if (!isDeviceAcquired(device) || !device.authenticityChecks) return null;
 
@@ -464,7 +459,7 @@ export const selectFirmwareRevisionCheckError = (state: StateForFirmwareChecks) 
  * Determine hard failure of firmware revision check - specific error types which are severe.
  * If Suite is offline and cannot perform check or there is some unexpected error, a banner is shown but device is accessible.
  */
-const selectIsFirmwareRevisionCheckEnabledAndFailed = (state: StateForFirmwareChecks): boolean => {
+const selectIsFirmwareRevisionCheckEnabledAndFailed = (state: AppState): boolean => {
     const error = selectFirmwareRevisionCheckError(state);
     const softErrors: FirmwareRevisionCheckError[] = [
         'cannot-perform-check-offline',
@@ -477,7 +472,7 @@ const selectIsFirmwareRevisionCheckEnabledAndFailed = (state: StateForFirmwareCh
 /**
  * Get firmware hash check error, or null if check was successful / skipped.
  */
-export const selectFirmwareHashCheckError = (state: StateForFirmwareChecks) => {
+export const selectFirmwareHashCheckError = (state: AppState) => {
     const device = selectDevice(state);
     if (!isDeviceAcquired(device) || !device.authenticityChecks) return null;
 
@@ -489,12 +484,23 @@ export const selectFirmwareHashCheckError = (state: StateForFirmwareChecks) => {
     return isCheckEnabled && checkResult?.success === false ? checkResult.error : null;
 };
 
+export const selectIsUnrecognizedFirmwareWithOutdatedSuite = (state: AppState): boolean => {
+    const device = selectDevice(state);
+    if (!isDeviceAcquired(device) || !device.authenticityChecks?.firmwareHash) return false;
+    const isUpdateAvailable = state.desktopUpdate.state === UpdateState.Available;
+    const checkResult = device.authenticityChecks.firmwareHash;
+
+    return !checkResult.success && checkResult.error === 'unknown-release' && isUpdateAvailable;
+};
+
 /**
  * Determine hard failure of firmware hash check - specific error types which are severe.
  * If check was skipped, don't consider it failed.
  * If check is unsupported by device, a banner is shown but device is accessible.
  */
-const selectIsFirmwareHashCheckEnabledAndFailed = (state: StateForFirmwareChecks): boolean => {
+const selectIsFirmwareHashCheckEnabledAndFailed = (state: AppState): boolean => {
+    if (selectIsUnrecognizedFirmwareWithOutdatedSuite(state)) return false; // treat this as a soft failure
+
     const error = selectFirmwareHashCheckError(state);
     const softErrors: FirmwareHashCheckError[] = ['check-skipped', 'check-unsupported'];
 
@@ -504,7 +510,7 @@ const selectIsFirmwareHashCheckEnabledAndFailed = (state: StateForFirmwareChecks
 /**
  * Determine hard failure of either of firmware authenticity checks to block access to device.
  */
-export const selectIsFirmwareAuthenticityCheckEnabledAndFailed = (state: StateForFirmwareChecks) =>
+export const selectIsFirmwareAuthenticityCheckEnabledAndFailed = (state: AppState) =>
     selectIsFirmwareRevisionCheckEnabledAndFailed(state) ||
     selectIsFirmwareHashCheckEnabledAndFailed(state);
 

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7047,6 +7047,11 @@ export default defineMessages({
         defaultMessage:
             "Firmware hash check couldn't be performed. Your Trezor may be counterfeit.",
     },
+    TR_DEVICE_FIRMWARE_UNRECOGNIZED_OUTDATED_SUITE: {
+        id: 'TR_DEVICE_FIRMWARE_UNRECOGNIZED_OUTDATED_SUITE',
+        defaultMessage:
+            'Firmware unrecognized. Please update your Trezor Suite to verify your Trezor.',
+    },
     TR_ONBOARDING_COINS_STEP: {
         id: 'TR_ONBOARDING_COINS_STEP',
         defaultMessage: 'Activate coins',


### PR DESCRIPTION
## Description

Currently, FW hash check will display ghost modal if FW version is not recognized locally.
But if Suite 24.12 offers newer firmware, user installs it and connects device to Suite 24.11, it would falsely flag the devices as non-existent version.

In that case, skip ghost modal, don't block receive addresses, but display urgent warning to update Suite.

:information_source: btw, FW _revision_ check tries to download `releases.json`, so it doesn't have the "uncertain state" unless offline. That could be done for hash check, but the hash check itself would still be skipped (binary not present). Urging people to update suite, because fw is too new, is better than urging them to update fw because too old, AFAIK?

## Related Issue

Resolve https://github.com/trezor/trezor-suite-private/issues/115

## Screenshots:

![new error banner](https://github.com/user-attachments/assets/aad195cf-ab6b-4782-afd6-b47095d0bf0a)

## QA instructions

This time, we do not need to verify that FW hash check works correctly for legit vs. fake devices. This is just _an exemption_ from FW hash check error, so it is sufficient to test with `trezor-user-env` (which simulates fake device).

There are 8 cases to verify:
- this branch vs. [testing branch](https://github.com/trezor/trezor-suite/tree/feat/hash-check-on-newer-fw-than-suite-TESTING) (it simulates outdated suite with available update)
- latest released version vs. unreleased version (for example T1B1 `1.12.1` vs. `1-main`)
- desktop vs. web

**Expected results**: all for both desktop & web, and starting with both fw checks **on**:
- latest released version, both branches:
Ghost modal & can't receive & banner "Firmware hash check failed. Your Trezor may be counterfeit."
- unreleased version, this branch:
Ghost modal & can't receive & banner "Firmware revision check failed. Your Trezor may be counterfeit."
  - Turn off fw **revision** check and reload:
  Ghost modal & can't receive & banner "Firmware unrecognized. Your Trezor may be counterfeit."
  - Turn fw revision check back on
- unreleased version, testing branch:
Ghost modal & can't receive & banner "Firmware revision check failed. Your Trezor may be counterfeit."
  - Turn off fw revision check and reload:
  **no** Ghost & **can** receive & banner "Firmware unrecognized. Please update your Trezor Suite to verify your Trezor."