### PR TITLE
feat(suite-native): other ethereum network account types have labels

### DIFF
--- a/suite-common/wallet-core/src/accounts/accountsConstants.ts
+++ b/suite-common/wallet-core/src/accounts/accountsConstants.ts
@@ -15,4 +15,8 @@ export const formattedAccountTypeMap: Partial<
         legacy: 'Legacy',
         ledger: 'Ledger',
     },
+    ethereum: {
+        legacy: 'Legacy',
+        ledger: 'Ledger',
+    },
 };


### PR DESCRIPTION
Add labels to other than normal ethereum accounts

## Related Issue

Resolve #14278


