### PR TITLE
ci(suite-native): enable to dispatch preview build by label 'build-mobile' on PR

### DIFF
--- a/.github/workflows/build-suite-native-preview.yml
+++ b/.github/workflows/build-suite-native-preview.yml
@@ -5,17 +5,19 @@ on:
     # push develop(default) branch is necessary for this action to update its fingerprint database
     branches: [develop]
   pull_request:
+    types: [opened, synchronize, labeled]
     paths:
       - "suite-native/**"
       - "packages/react-native-usb/**"
       - "packages/transport-native/**"
       - "yarn.lock"
-      # list of paths is not complete, but it's always possible to dispatch manually
+      # list of paths is not complete, but it's always possible to dispatch manually using 'build-mobile' label
   workflow_dispatch:
+    # manual dispatch will not add any comment to PR, use label 'build-mobile' if PR exists
 
 jobs:
   update:
-    if: github.repository == 'trezor/trezor-suite' || github.repository == 'trezor/trezor-suite-private'
+    if: ( github.event.action != 'labeled' || contains(github.event.pull_request.labels.*.name, 'build-mobile')) && (github.repository == 'trezor/trezor-suite' || github.repository == 'trezor/trezor-suite-private')
     name: EAS Update
     runs-on: ubuntu-latest
     concurrency: fingerprint-${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

We don't trigger preview build on every PR, but only those touching some paths to save some CI time and money. But we want an easy way to trigger that build manually.

Manual workflow dispatch lack the PR context so it doesn't add comments with links and QR.

