### PR TITLE
fix(connect-explorer): deeplink core mode from options

### DIFF
--- a/packages/connect-explorer/src/actions/trezorConnectActions.ts
+++ b/packages/connect-explorer/src/actions/trezorConnectActions.ts
@@ -162,7 +162,7 @@ export const init =
         };
 
         try {
-            if (coreMode === 'deeplink') {
+            if (connectOptions.coreMode === 'deeplink') {
                 await TrezorConnectMobile.init({
                     ...connectOptions,
                     deeplinkOpen(url) {


### PR DESCRIPTION
## Description

Tiny fix for an issue with selecting coreMode deeplink from the settings form in Connect Explorer