### PR TITLE
fix(blockchain-link): export socks-prosy-agent for browser

### DIFF
--- a/packages/blockchain-link/src/utils/socks-proxy-agent.ts
+++ b/packages/blockchain-link/src/utils/socks-proxy-agent.ts
@@ -1,6 +1,4 @@
 // socks-proxy-agent is not supported in browser
 // use fallback module. see package.json "browser" field
 
-const createSocksProxyAgent = (_opts: string) => ({});
-
-export default createSocksProxyAgent;
+export const SocksProxyAgent = (_opts: string) => ({});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`socks-proxy-agent` is not supported in browser, and the new version does not export it as a `default` so the util had to be updated for webpack not to complain.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/14997
