### PR TITLE
test(e2e): fix device compromised in database-migration test

### DIFF
--- a/packages/suite-web/e2e/tests/suite/database-migration.test.ts
+++ b/packages/suite-web/e2e/tests/suite/database-migration.test.ts
@@ -148,6 +148,7 @@ describe('Database migration', () => {
         cy.getTestElement('@modal/close-button').click().should('not.exist');
 
         cy.task('startEmu');
+        cy.disableFirmwareHashCheck(); // only applicable for the `to` version, not the older `from` version
         cy.getTestElement('@deviceStatus-connected').should('be.visible');
         cy.getTestElement('@account-subpage/back').last().click();
 


### PR DESCRIPTION
## Description

Fix a [cypress E2E failing](https://github.com/trezor/trezor-suite/actions/runs/11564761800/job/32205335224) because of Device Compromised modal.

This was omitted in #15031, because this test is in `@group_migrations`, and that is part of nightly tests, but not the PR tests :man_facepalming: 

:information_source: The test always visits `https://dev.suite.sldev.cz/suite-web` instead of local suite-web running in CI.
Even so, [I executed nightly tests from branch](https://github.com/trezor/trezor-suite/actions/runs/11574512686), which verifies this PR, because the change is only in _test_ code, and that is indeed sourced from this branch.  