### PR TITLE
chore(connect): move storage to `@trezor/connect`

### DIFF
--- a/packages/connect-common/README.md
+++ b/packages/connect-common/README.md
@@ -17,12 +17,6 @@ Binaries of the latest versions of firmware for each Trezor model are included i
 
 There is a `releases.json` file for each Trezor model which must be updated any time new binaries are added. This file provides data about all available firmware versions and it is used to display them in Suite and to make sure that the correct firmware is downloaded. Read more about `releases.json` and it's structure [here](../../docs/releases/adding-new-firmwares.md#firmware-releasesjson-files-structure)
 
-## src
-
-### Storage
-
-A utility to remember app permissions given by user.
-
 ## Publishing
 
 [Follow instructions](../../docs/releases/npm-packages.md) how to publish @trezor package to npm registry.

--- a/packages/connect-common/src/__tests__/systemInfo.test.ts
+++ b/packages/connect-common/src/__tests__/systemInfo.test.ts
@@ -1,0 +1,140 @@
+import {
+    getBrowserVersion,
+    getBrowserName,
+    getDeviceType,
+    getUserAgent,
+    getOsFamily,
+} from '@trezor/env-utils';
+
+import { getInstallerPackage, getSystemInfo } from '../systemInfo'; // replace with your actual file
+
+jest.mock('@trezor/env-utils', () => ({
+    getBrowserVersion: jest.fn(),
+    getBrowserName: jest.fn(),
+    getDeviceType: jest.fn(),
+    getUserAgent: jest.fn(),
+    getOsFamily: jest.fn(),
+}));
+
+describe('getInstallerPackage', () => {
+    it('should return mac for MacOS', () => {
+        (getOsFamily as jest.Mock).mockReturnValue('MacOS');
+        expect(getInstallerPackage()).toBe('mac');
+    });
+
+    it('should return win64 for Windows 64-bit', () => {
+        (getOsFamily as jest.Mock).mockReturnValue('Windows');
+        (getUserAgent as jest.Mock).mockReturnValue('Mozilla/5.0 (Windows NT 10.0; Win64; x64)');
+        expect(getInstallerPackage()).toBe('win64');
+    });
+
+    it('should return win32 for Windows 32-bit', () => {
+        (getOsFamily as jest.Mock).mockReturnValue('Windows');
+        (getUserAgent as jest.Mock).mockReturnValue('Mozilla/5.0 (Windows NT 10.0; Win32; x86)');
+        expect(getInstallerPackage()).toBe('win32');
+    });
+
+    it('should return rpm64 for Linux RPM 64-bit', () => {
+        (getOsFamily as jest.Mock).mockReturnValue('Linux');
+        (getUserAgent as jest.Mock).mockReturnValue('Mozilla/5.0 (X11; Fedora x86_64; Linux)');
+        expect(getInstallerPackage()).toBe('rpm64');
+    });
+
+    it('should return deb32 for Linux DEB 32-bit', () => {
+        (getOsFamily as jest.Mock).mockReturnValue('Linux');
+        (getUserAgent as jest.Mock).mockReturnValue('Mozilla/5.0 (X11; Linux i686)');
+        expect(getInstallerPackage()).toBe('deb32');
+    });
+
+    it('should return undefined for unsupported OS', () => {
+        (getOsFamily as jest.Mock).mockReturnValue('UnknownOS');
+        expect(getInstallerPackage()).toBeUndefined();
+    });
+});
+
+describe('getSystemInfo', () => {
+    const supportedBrowsers = {
+        chrome: { version: 90 },
+        firefox: { version: 85 },
+    };
+
+    it('should return supported browser info when browser is up-to-date', () => {
+        (getBrowserName as jest.Mock).mockReturnValue('chrome');
+        (getBrowserVersion as jest.Mock).mockReturnValue('90');
+        (getDeviceType as jest.Mock).mockReturnValue('desktop');
+        (getOsFamily as jest.Mock).mockReturnValue('Windows');
+
+        const result = getSystemInfo(supportedBrowsers);
+
+        expect(result).toEqual({
+            os: {
+                family: 'Windows',
+                mobile: false,
+            },
+            browser: {
+                supported: true,
+                outdated: false,
+            },
+        });
+    });
+
+    it('should return outdated browser info when browser version is older', () => {
+        (getBrowserName as jest.Mock).mockReturnValue('firefox');
+        (getBrowserVersion as jest.Mock).mockReturnValue('80');
+        (getDeviceType as jest.Mock).mockReturnValue('desktop');
+        (getOsFamily as jest.Mock).mockReturnValue('Linux');
+
+        const result = getSystemInfo(supportedBrowsers);
+
+        expect(result).toEqual({
+            os: {
+                family: 'Linux',
+                mobile: false,
+            },
+            browser: {
+                supported: false,
+                outdated: true,
+            },
+        });
+    });
+
+    it('should return unsupported for unknown browser', () => {
+        (getBrowserName as jest.Mock).mockReturnValue('unknown');
+        (getBrowserVersion as jest.Mock).mockReturnValue('1');
+        (getDeviceType as jest.Mock).mockReturnValue('desktop');
+        (getOsFamily as jest.Mock).mockReturnValue('MacOS');
+
+        const result = getSystemInfo(supportedBrowsers);
+
+        expect(result).toEqual({
+            os: {
+                family: 'MacOS',
+                mobile: false,
+            },
+            browser: {
+                supported: false,
+                outdated: false,
+            },
+        });
+    });
+
+    it('should return unsupported for iOS mobile device', () => {
+        (getBrowserName as jest.Mock).mockReturnValue('safari');
+        (getBrowserVersion as jest.Mock).mockReturnValue('14');
+        (getDeviceType as jest.Mock).mockReturnValue('mobile');
+        (getOsFamily as jest.Mock).mockReturnValue('MacOS');
+
+        const result = getSystemInfo(supportedBrowsers);
+
+        expect(result).toEqual({
+            os: {
+                family: 'MacOS',
+                mobile: true,
+            },
+            browser: {
+                supported: false,
+                outdated: false,
+            },
+        });
+    });
+});

--- a/packages/connect-common/src/index.ts
+++ b/packages/connect-common/src/index.ts
@@ -1,3 +1,2 @@
-export * from './storage';
 export * from './messageChannel/abstract';
 export * from './systemInfo';

--- a/packages/connect-iframe/src/index.ts
+++ b/packages/connect-iframe/src/index.ts
@@ -27,7 +27,8 @@ import { initLog, LogWriter } from '@trezor/connect/src/utils/debug';
 import { getOrigin } from '@trezor/connect/src/utils/urlUtils';
 import { suggestBridgeInstaller } from '@trezor/connect/src/data/transportInfo';
 import { suggestUdevInstaller } from '@trezor/connect/src/data/udevInfo';
-import { storage, getSystemInfo, getInstallerPackage } from '@trezor/connect-common';
+import { storage } from '@trezor/connect/src/storage';
+import { getSystemInfo, getInstallerPackage } from '@trezor/connect-common';
 import { parseConnectSettings, isOriginWhitelisted } from './connectSettings';
 import { analytics, EventType } from '@trezor/connect-analytics';
 // @ts-expect-error (typescript does not know this is worker constructor, this is done by webpack)

--- a/packages/connect-popup/src/view/browser.ts
+++ b/packages/connect-popup/src/view/browser.ts
@@ -1,7 +1,7 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/popup/view/browser.js
 
 import { SystemInfo } from '@trezor/connect';
-import { storage } from '@trezor/connect-common';
+import { storage } from '@trezor/connect/src/storage';
 import { container, showView } from './common';
 
 export const initBrowserView = (systemInfo: SystemInfo): Promise<boolean> => {

--- a/packages/connect-ui/package.json
+++ b/packages/connect-ui/package.json
@@ -16,7 +16,6 @@
         "@trezor/components": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/connect-analytics": "workspace:*",
-        "@trezor/connect-common": "workspace:*",
         "@trezor/dom-utils": "workspace:*",
         "@trezor/env-utils": "workspace:*",
         "@trezor/product-components": "workspace:*",

--- a/packages/connect-ui/src/components/BottomRightFloatingBar.tsx
+++ b/packages/connect-ui/src/components/BottomRightFloatingBar.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import styled from 'styled-components';
 
-import { storage } from '@trezor/connect-common';
+import { storage } from '@trezor/connect/src/storage';
 
 import { AnalyticsConsentWrapper } from './AnalyticsConsentWrapper';
 import { FloatingMenu } from './FloatingMenu';

--- a/packages/connect-ui/src/index.tsx
+++ b/packages/connect-ui/src/index.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useState, useMemo, ReactNode } from 'react';
 import styled from 'styled-components';
 
 import { UI, UI_REQUEST, POPUP, CoreRequestMessage } from '@trezor/connect';
-import { storage, OriginBoundState } from '@trezor/connect-common';
+import { storage, OriginBoundState } from '@trezor/connect/src/storage';
 
 // views
 import { Transport } from './views/Transport';

--- a/packages/connect-ui/src/types.ts
+++ b/packages/connect-ui/src/types.ts
@@ -1,6 +1,6 @@
 import { PopupHandshake, PopupMethodInfo, IFrameLoaded } from '@trezor/connect';
 import type { Core } from '@trezor/connect/src/core';
-import type { OriginBoundState } from '@trezor/connect-common';
+import type { OriginBoundState } from '@trezor/connect/src/storage';
 
 export type State = Partial<PopupHandshake['payload']> &
     Partial<PopupMethodInfo['payload']> &

--- a/packages/connect-ui/src/utils/analytics.ts
+++ b/packages/connect-ui/src/utils/analytics.ts
@@ -1,5 +1,5 @@
 import { analytics, EventType, getRandomId } from '@trezor/connect-analytics';
-import { storage } from '@trezor/connect-common';
+import { storage } from '@trezor/connect/src/storage';
 import {
     getBrowserName,
     getBrowserVersion,

--- a/packages/connect-ui/tsconfig.json
+++ b/packages/connect-ui/tsconfig.json
@@ -8,7 +8,6 @@
         { "path": "../components" },
         { "path": "../connect" },
         { "path": "../connect-analytics" },
-        { "path": "../connect-common" },
         { "path": "../dom-utils" },
         { "path": "../env-utils" },
         { "path": "../product-components" },

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -1,7 +1,7 @@
-import { storage } from '@trezor/connect-common';
 import { versionUtils } from '@trezor/utils';
 import { DataManager } from '../data/DataManager';
 import { NETWORK } from '../constants';
+import { storage } from '../storage';
 import {
     UI,
     DEVICE,

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -4,8 +4,8 @@ import EventEmitter from 'events';
 import { TRANSPORT, TRANSPORT_ERROR } from '@trezor/transport';
 import { createLazy, createDeferred, throwError } from '@trezor/utils';
 import { getSynchronize } from '@trezor/utils';
-import { storage } from '@trezor/connect-common';
 
+import { storage } from '../storage';
 import { DataManager } from '../data/DataManager';
 import { DeviceList, IDeviceList, assertDeviceListConnected } from '../device/DeviceList';
 import { enhanceMessageWithAnalytics } from '../data/analyticsInfo';

--- a/packages/connect/src/device/StateStorage.ts
+++ b/packages/connect/src/device/StateStorage.ts
@@ -1,6 +1,6 @@
 import { DeviceState } from '../types';
 import { Device } from './Device';
-import { storage } from '@trezor/connect-common';
+import { storage } from '../storage';
 
 export interface IStateStorage {
     saveState(device: Device, state: DeviceState): void;

--- a/packages/connect/src/storage/__tests__/storage.test.ts
+++ b/packages/connect/src/storage/__tests__/storage.test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { storage } from '..';
 
 const origin = 'foo.bar';

--- a/packages/connect/src/storage/index.ts
+++ b/packages/connect/src/storage/index.ts
@@ -1,6 +1,5 @@
-// https://github.com/trezor/connect/blob/develop/src/js/storage/index.js
-
 import { TypedEmitter } from '@trezor/utils';
+import type { StaticSessionId } from '../types';
 
 const storageVersion = 2;
 const storageName = `storage_v${storageVersion}`;
@@ -18,7 +17,7 @@ export interface Permission {
 export interface PreferredDevice {
     label?: string;
     path: string & { __type: 'DeviceUniquePath' };
-    state?: string;
+    state?: StaticSessionId;
     internalState?: string;
     internalStateExpiration?: number;
     instance?: number;
@@ -38,10 +37,6 @@ export interface GlobalState {
 export type Store = GlobalState & {
     origin: { [origin: string]: OriginBoundState };
 };
-
-// TODO: move storage somewhere else. Having it here brings couple of problems:
-// - We can not import types from connect (would cause cyclic dependency)
-// - it has here dependency on window object, not good
 
 const getEmptyState = (): Store => ({
     origin: {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -11563,7 +11563,6 @@ __metadata:
     "@trezor/components": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/connect-analytics": "workspace:*"
-    "@trezor/connect-common": "workspace:*"
     "@trezor/dom-utils": "workspace:*"
     "@trezor/env-utils": "workspace:*"
     "@trezor/product-components": "workspace:*"


### PR DESCRIPTION
## Description

Simply move Storage from `@trezor/connect-common` to `@trezor/connect`. 
This lets us type things properly and makes more sense for the future. 

I also added a benign test for systemInfo in `@trezor/connect-common`, so there are some tests in the package and Jest doesn't complain