### PR TITLE
fix(connect): device.unreadableError is always string

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -373,7 +373,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
                         // but it did not work out. this device is effectively unreadable and user should do something about it
                         error.code === 'Device_InitializeFailed'
                     ) {
-                        this.unreadableError = error;
+                        this.unreadableError = error?.message;
                         this.emitLifecycle(DEVICE.CONNECT_UNACQUIRED);
                     } else {
                         await createTimeoutPromise(501);


### PR DESCRIPTION
I am not sure when this broke (or has it been like this forever?)

![image](https://github.com/user-attachments/assets/d0de21fb-e2a8-4e99-87a8-a9764e358292)

![image](https://github.com/user-attachments/assets/04e8fcc0-2c5c-47cb-b76f-ad0775973834)

after this, unreadable error should be always string or undefined 

![image](https://github.com/user-attachments/assets/5649ba0e-0f6d-4486-b066-5a8c11e7724e)
