### PR TITLE
fix(suite): device state migration

### DIFF
--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -1107,11 +1107,16 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
     if (oldVersion < 48) {
         // Migrate device state to new object format
         await updateAll(transaction, 'devices', device => {
-            if (
-                typeof device.state === 'string' &&
-                typeof (device as any)?._state?.staticSessionId === 'string'
-            ) {
-                device.state = (device as any)._state;
+            if (typeof device.state === 'string') {
+                if (typeof (device as any)?._state?.staticSessionId === 'string') {
+                    // Has _state property, migrate to that
+                    device.state = (device as any)._state;
+                } else {
+                    // No _state property, create new object
+                    device.state = {
+                        staticSessionId: device.state,
+                    };
+                }
             }
 
             return device;


### PR DESCRIPTION
## Description

Fix an issue with DB migration for device state from old string to new object, where on older versions of suite there wouldn't be an `_state` property to use, so we will create a new object.

Broken test: https://github.com/trezor/trezor-suite/actions/runs/11584494152/job/32271569663
Green test: https://github.com/trezor/trezor-suite/actions/runs/11593246114/job/32277313136?pr=15116