### PR TITLE
feat(suite-native): send token drafts

### DIFF
--- a/packages/suite/src/actions/wallet/send/sendFormThunks.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormThunks.ts
@@ -16,7 +16,7 @@ import {
     selectSendFormDrafts,
     signTransactionThunk,
     sendFormActions,
-    selectSendFormDraftByAccountKey,
+    selectSendFormDraftByKey,
 } from '@suite-common/wallet-core';
 import { isCardanoTx, isRbfTransaction } from '@suite-common/wallet-utils';
 import { MetadataAddPayload } from '@suite-common/metadata-types';
@@ -140,7 +140,7 @@ const applySendFormMetadataLabelsThunk = createThunk(
 
         if (!metadata.enabled) return;
 
-        const formDraft = selectSendFormDraftByAccountKey(getState(), selectedAccount.key);
+        const formDraft = selectSendFormDraftByKey(getState(), selectedAccount.key);
 
         const outputsPermutation = isCardanoTx(selectedAccount, precomposedTransaction)
             ? precomposedTransaction?.outputs.map((_o, i) => i) // cardano preserves order of outputs

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
@@ -5,7 +5,7 @@ import { Deferred } from '@trezor/utils';
 import {
     DeviceRootState,
     selectDevice,
-    selectSendFormDraftByAccountKey,
+    selectSendFormDraftByKey,
     selectSendFormReviewButtonRequestsCount,
     selectStakePrecomposedForm,
     StakeState,
@@ -69,7 +69,7 @@ export const TransactionReviewModalContent = ({
     const precomposedForm = useSelector(state =>
         isStakeState(txInfoState)
             ? selectStakePrecomposedForm(state)
-            : selectSendFormDraftByAccountKey(state, account?.key),
+            : selectSendFormDraftByKey(state, account?.key),
     );
 
     const isRbfAction = precomposedTx !== undefined && isRbfTransaction(precomposedTx);

--- a/suite-common/wallet-core/src/send/sendFormActions.ts
+++ b/suite-common/wallet-core/src/send/sendFormActions.ts
@@ -4,6 +4,7 @@ import {
     FormState,
     AccountKey,
     GeneralPrecomposedTransactionFinal,
+    TokenAddress,
 } from '@suite-common/wallet-types';
 import { BlockbookTransaction } from '@trezor/blockchain-link-types';
 
@@ -12,7 +13,7 @@ import { SerializedTx } from './sendFormTypes';
 
 const storeDraft = createAction(
     `${SEND_MODULE_PREFIX}/store-draft`,
-    (payload: { accountKey: AccountKey; formState: FormState }) => ({
+    (payload: { accountKey: AccountKey; formState: FormState; tokenContract?: TokenAddress }) => ({
         payload,
     }),
 );

--- a/suite-common/wallet-types/src/index.ts
+++ b/suite-common/wallet-types/src/index.ts
@@ -10,3 +10,4 @@ export * from './selectedAccount';
 export * from './transaction';
 export * from './stake';
 export * from './stakeForm';
+export * from './send';

--- a/suite-common/wallet-types/src/send.ts
+++ b/suite-common/wallet-types/src/send.ts
@@ -1,0 +1,5 @@
+import { AccountKey, TokenAddress } from './account';
+
+export type SendFormDraftKey =
+    | AccountKey
+    | (`${AccountKey}-${TokenAddress}` & { __type: 'SendFormDraftKey' });

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -30,6 +30,9 @@ import type {
     CurrencyOption,
     ExcludedUtxos,
     GeneralPrecomposedTransactionFinal,
+    AccountKey,
+    TokenAddress,
+    SendFormDraftKey,
 } from '@suite-common/wallet-types';
 
 import { amountToSatoshi, getUtxoOutpoint, networkAmountToSatoshi } from './accountUtils';
@@ -459,6 +462,13 @@ export const getExcludedUtxos = ({
     });
 
     return excludedUtxos;
+};
+
+export const getSendFormDraftKey = (
+    accountKey: AccountKey,
+    tokenAddress?: TokenAddress,
+): SendFormDraftKey => {
+    return tokenAddress ? `${accountKey}-${tokenAddress}` : accountKey;
 };
 
 // SOL Specific

--- a/suite-native/module-send/src/components/AddressReviewStepList.tsx
+++ b/suite-native/module-send/src/components/AddressReviewStepList.tsx
@@ -73,7 +73,7 @@ export const AddressReviewStepList = () => {
 
     const isAddressConfirmed = useSelector(
         (state: AccountsRootState & DeviceRootState & SendRootState) =>
-            selectIsFirstTransactionAddressConfirmed(state, accountKey),
+            selectIsFirstTransactionAddressConfirmed(state, accountKey, tokenContract),
     );
 
     useEffect(() => {
@@ -104,6 +104,7 @@ export const AddressReviewStepList = () => {
             const response = await dispatch(
                 signTransactionThunk({
                     accountKey,
+                    tokenContract,
                     feeLevel: transaction,
                 }),
             );

--- a/suite-native/module-send/src/components/OutputsReviewFooter.tsx
+++ b/suite-native/module-send/src/components/OutputsReviewFooter.tsx
@@ -9,7 +9,7 @@ import { isFulfilled } from '@reduxjs/toolkit';
 import {
     AccountsRootState,
     selectAccountByKey,
-    selectSendFormDraftByAccountKey,
+    selectSendFormDraftByKey,
     SendRootState,
 } from '@suite-common/wallet-core';
 import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
@@ -82,7 +82,7 @@ export const OutputsReviewFooter = ({
     const isTransactionAlreadySigned = useSelector(selectIsTransactionAlreadySigned);
 
     const formValues = useSelector((state: SendRootState) =>
-        selectSendFormDraftByAccountKey(state, accountKey),
+        selectSendFormDraftByKey(state, accountKey, tokenContract),
     );
 
     {

--- a/suite-native/module-send/src/components/ReviewOutputItemList.tsx
+++ b/suite-native/module-send/src/components/ReviewOutputItemList.tsx
@@ -36,11 +36,11 @@ export const ReviewOutputItemList = ({ accountKey, tokenContract }: ReviewOutput
 
     const reviewOutputs = useSelector(
         (state: AccountsRootState & DeviceRootState & SendRootState) =>
-            selectTransactionReviewOutputs(state, accountKey),
+            selectTransactionReviewOutputs(state, accountKey, tokenContract),
     );
     const isTransactionAlreadySigned = useSelector(selectIsTransactionAlreadySigned);
     const activeStep = useSelector((state: AccountsRootState & DeviceRootState & SendRootState) =>
-        selectTransactionReviewActiveStepIndex(state, accountKey),
+        selectTransactionReviewActiveStepIndex(state, accountKey, tokenContract),
     );
 
     const [childHeights, setChildHeights] = useState<number[]>([]);

--- a/suite-native/module-send/src/components/ReviewOutputSummaryItem.tsx
+++ b/suite-native/module-send/src/components/ReviewOutputSummaryItem.tsx
@@ -72,7 +72,7 @@ export const ReviewOutputSummaryItem = ({
     const { translate } = useTranslate();
     const summaryOutput = useSelector(
         (state: AccountsRootState & DeviceRootState & SendRootState) =>
-            selectReviewSummaryOutput(state, accountKey),
+            selectReviewSummaryOutput(state, accountKey, tokenContract),
     );
 
     if (!summaryOutput) return null;

--- a/suite-native/module-send/src/screens/SendAddressReviewScreen.tsx
+++ b/suite-native/module-send/src/screens/SendAddressReviewScreen.tsx
@@ -28,12 +28,12 @@ export const SendAddressReviewScreen = ({
 
     const isAddressConfirmed = useSelector(
         (state: AccountsRootState & DeviceRootState & SendRootState) =>
-            selectIsFirstTransactionAddressConfirmed(state, accountKey),
+            selectIsFirstTransactionAddressConfirmed(state, accountKey, tokenContract),
     );
 
     const isReviewInProgress = useSelector(
         (state: AccountsRootState & DeviceRootState & SendRootState) =>
-            selectIsOutputsReviewInProgress(state, accountKey),
+            selectIsOutputsReviewInProgress(state, accountKey, tokenContract),
     );
 
     useEffect(() => {

--- a/suite-native/module-send/src/screens/SendOutputsScreen.tsx
+++ b/suite-native/module-send/src/screens/SendOutputsScreen.tsx
@@ -14,7 +14,7 @@ import {
     composeSendFormTransactionFeeLevelsThunk,
     selectAccountByKey,
     selectNetworkFeeInfo,
-    selectSendFormDraftByAccountKey,
+    selectSendFormDraftByKey,
     sendFormActions,
     updateFeeInfoThunk,
 } from '@suite-common/wallet-core';
@@ -91,7 +91,7 @@ export const SendOutputsScreen = ({
         selectNetworkFeeInfo(state, account?.symbol),
     );
     const sendFormDraft = useSelector((state: SendRootState) =>
-        selectSendFormDraftByAccountKey(state, accountKey),
+        selectSendFormDraftByKey(state, accountKey, tokenContract),
     );
 
     const network = account ? getNetwork(account.symbol) : null;
@@ -125,6 +125,7 @@ export const SendOutputsScreen = ({
         dispatch(
             sendFormActions.storeDraft({
                 accountKey,
+                tokenContract,
                 formState: constructFormDraft({ formValues: getValues(), tokenContract }),
             }),
         );
@@ -144,8 +145,6 @@ export const SendOutputsScreen = ({
     }, [getValues, accountKey, dispatch]);
 
     useEffect(() => {
-        // TODO: Store token draft to separate object so it do not override mainnet draft.
-        // https://github.com/trezor/trezor-suite/issues/15078
         const prefillValuesFromStoredDraft = async () => {
             if (sendFormDraft?.outputs) {
                 setValue('outputs', sendFormDraft.outputs);

--- a/suite-native/module-send/src/selectors.ts
+++ b/suite-native/module-send/src/selectors.ts
@@ -7,7 +7,7 @@ import {
     selectAccountByKey,
     selectDevice,
     selectSendPrecomposedTx,
-    selectSendFormDraftByAccountKey,
+    selectSendFormDraftByKey,
     selectSendFormReviewButtonRequestsCount,
     selectSendSerializedTx,
 } from '@suite-common/wallet-core';
@@ -17,15 +17,16 @@ import {
     getTransactionReviewOutputState,
     isRbfTransaction,
 } from '@suite-common/wallet-utils';
-import { ReviewOutputState } from '@suite-common/wallet-types';
+import { AccountKey, ReviewOutputState, TokenAddress } from '@suite-common/wallet-types';
 
 import { StatefulReviewOutput } from './types';
 
 export const selectTransactionReviewOutputs = (
     state: SendRootState & AccountsRootState & DeviceRootState,
-    accountKey: string,
+    accountKey: AccountKey,
+    tokenContract?: TokenAddress,
 ): StatefulReviewOutput[] | null => {
-    const precomposedForm = selectSendFormDraftByAccountKey(state, accountKey);
+    const precomposedForm = selectSendFormDraftByKey(state, accountKey, tokenContract);
     const precomposedTx = selectSendPrecomposedTx(state);
 
     const decreaseOutputId =
@@ -66,9 +67,10 @@ export const selectTransactionReviewOutputs = (
 
 export const selectIsOutputsReviewInProgress = (
     state: SendRootState & AccountsRootState & DeviceRootState,
-    accountKey: string,
+    accountKey: AccountKey,
+    tokenContract?: TokenAddress,
 ): boolean => {
-    const outputs = selectTransactionReviewOutputs(state, accountKey);
+    const outputs = selectTransactionReviewOutputs(state, accountKey, tokenContract);
 
     return G.isNotNullable(outputs) && A.isNotEmpty(outputs);
 };
@@ -76,8 +78,9 @@ export const selectIsOutputsReviewInProgress = (
 export const selectIsFirstTransactionAddressConfirmed = (
     state: SendRootState & AccountsRootState & DeviceRootState,
     accountKey: string,
+    tokenContract?: TokenAddress,
 ): boolean => {
-    const outputs = selectTransactionReviewOutputs(state, accountKey);
+    const outputs = selectTransactionReviewOutputs(state, accountKey, tokenContract);
 
     return outputs?.[0].state === 'success';
 };
@@ -90,7 +93,8 @@ export const selectIsTransactionAlreadySigned = (state: SendRootState) => {
 
 export const selectReviewSummaryOutputState = (
     state: SendRootState & AccountsRootState & DeviceRootState,
-    accountKey: string,
+    accountKey: AccountKey,
+    tokenContract?: TokenAddress,
 ): ReviewOutputState => {
     const isTransactionAlreadySigned = selectIsTransactionAlreadySigned(state);
 
@@ -98,7 +102,7 @@ export const selectReviewSummaryOutputState = (
         return 'success';
     }
 
-    const reviewOutputs = selectTransactionReviewOutputs(state, accountKey);
+    const reviewOutputs = selectTransactionReviewOutputs(state, accountKey, tokenContract);
 
     if (reviewOutputs && A.all(reviewOutputs, output => output.state === 'success')) {
         return 'active';
@@ -109,7 +113,8 @@ export const selectReviewSummaryOutputState = (
 
 export const selectReviewSummaryOutput = (
     state: AccountsRootState & DeviceRootState & SendRootState,
-    accountKey: string,
+    accountKey: AccountKey,
+    tokenContract?: TokenAddress,
 ) => {
     const precomposedTx = selectSendPrecomposedTx(state);
 
@@ -117,7 +122,7 @@ export const selectReviewSummaryOutput = (
 
     const { totalSpent, fee } = precomposedTx;
 
-    const outputState = selectReviewSummaryOutputState(state, accountKey);
+    const outputState = selectReviewSummaryOutputState(state, accountKey, tokenContract);
 
     return {
         state: outputState,
@@ -128,9 +133,10 @@ export const selectReviewSummaryOutput = (
 
 export const selectTransactionReviewActiveStepIndex = (
     state: AccountsRootState & DeviceRootState & SendRootState,
-    accountKey: string,
+    accountKey: AccountKey,
+    tokenContract?: TokenAddress,
 ) => {
-    const reviewOutputs = selectTransactionReviewOutputs(state, accountKey);
+    const reviewOutputs = selectTransactionReviewOutputs(state, accountKey, tokenContract);
 
     if (!reviewOutputs) return 0;
 


### PR DESCRIPTION
## Description
There is a send form draft stored for each of the account tokens so the mainnet and token accounts do not override each others draft.

## Related Issue

Resolve #15078 

## Screenshots:

https://github.com/user-attachments/assets/6dbcc93f-1fc5-4827-aea7-ce4977035d82

