### PR TITLE
feat(suite): ignore FW hash check unrecognized-version

### DIFF
--- a/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareRevisionCheckBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareRevisionCheckBanner.tsx
@@ -9,8 +9,8 @@ import { useSelector } from 'src/hooks/suite';
 import {
     selectFirmwareHashCheckError,
     selectFirmwareRevisionCheckError,
-    selectIsUnrecognizedFirmwareWithOutdatedSuite,
 } from 'src/reducers/suite/suiteReducer';
+import { skippedHashCheckErrors } from 'src/constants/suite/firmware';
 
 const revisionCheckMessages: Record<FirmwareRevisionCheckError, TranslationKey> = {
     'cannot-perform-check-offline': 'TR_DEVICE_FIRMWARE_REVISION_CHECK_UNABLE_TO_PERFORM',
@@ -19,10 +19,6 @@ const revisionCheckMessages: Record<FirmwareRevisionCheckError, TranslationKey> 
     'firmware-version-unknown': 'TR_FIRMWARE_REVISION_CHECK_FAILED',
 };
 
-export const skippedHashCheckErrors = [
-    'check-skipped',
-    'check-unsupported',
-] satisfies FirmwareHashCheckError[];
 type SkippedHashCheckMessage = (typeof skippedHashCheckErrors)[number];
 
 const hashCheckMessages: Record<
@@ -30,22 +26,15 @@ const hashCheckMessages: Record<
     TranslationKey
 > = {
     'hash-mismatch': 'TR_DEVICE_FIRMWARE_HASH_CHECK_HASH_MISMATCH',
-    'unknown-release': 'TR_DEVICE_FIRMWARE_HASH_CHECK_UNKNOWN_RELEASE',
     'other-error': 'TR_DEVICE_FIRMWARE_HASH_CHECK_OTHER_ERROR',
 };
 
 const useAuthenticityCheckMessage = (): TranslationKey | null => {
     const firmwareRevisionError = useSelector(selectFirmwareRevisionCheckError);
     const firmwareHashError = useSelector(selectFirmwareHashCheckError);
-    const isUnrecognizedFwWithOutadedSuite = useSelector(
-        selectIsUnrecognizedFirmwareWithOutdatedSuite,
-    );
 
     if (firmwareRevisionError) {
         return revisionCheckMessages[firmwareRevisionError];
-    }
-    if (isUnrecognizedFwWithOutadedSuite) {
-        return 'TR_DEVICE_FIRMWARE_UNRECOGNIZED_OUTDATED_SUITE';
     }
     if (firmwareHashError && !isArrayMember(firmwareHashError, skippedHashCheckErrors)) {
         return hashCheckMessages[firmwareHashError];

--- a/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
@@ -10,6 +10,7 @@ import { spacingsPx } from '@trezor/theme';
 import { isTranslationMode } from 'src/utils/suite/l10n';
 import { useSelector } from 'src/hooks/suite';
 import { MAX_CONTENT_WIDTH } from 'src/constants/suite/layout';
+import { skippedHashCheckErrors } from 'src/constants/suite/firmware';
 import {
     selectFirmwareHashCheckError,
     selectFirmwareRevisionCheckError,
@@ -22,7 +23,7 @@ import { FailedBackup } from './FailedBackupBanner';
 import { SafetyChecksBanner } from './SafetyChecksBanner';
 import { TranslationMode } from './TranslationModeBanner';
 import { FirmwareHashMismatch } from './FirmwareHashMismatchBanner';
-import { FirmwareRevisionCheckBanner, skippedHashCheckErrors } from './FirmwareRevisionCheckBanner';
+import { FirmwareRevisionCheckBanner } from './FirmwareRevisionCheckBanner';
 
 const Container = styled.div<{ $isVisible?: boolean }>`
     width: 100%;

--- a/packages/suite/src/constants/suite/firmware.ts
+++ b/packages/suite/src/constants/suite/firmware.ts
@@ -1,0 +1,13 @@
+import { FirmwareHashCheckError, FirmwareRevisionCheckError } from '@trezor/connect';
+
+export const skippedRevisionCheckErrors = [
+    'cannot-perform-check-offline',
+    'other-error',
+] satisfies FirmwareRevisionCheckError[];
+
+export const skippedHashCheckErrors = [
+    'check-skipped',
+    'check-unsupported',
+    // this could be serious, but it's also caught by revision check, which handles edge-cases better, so it's skipped here
+    'unknown-release',
+] satisfies FirmwareHashCheckError[];

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7061,11 +7061,6 @@ export default defineMessages({
         defaultMessage:
             "Firmware hash check couldn't be performed. Your Trezor may be counterfeit.",
     },
-    TR_DEVICE_FIRMWARE_UNRECOGNIZED_OUTDATED_SUITE: {
-        id: 'TR_DEVICE_FIRMWARE_UNRECOGNIZED_OUTDATED_SUITE',
-        defaultMessage:
-            'Firmware unrecognized. Please update your Trezor Suite to verify your Trezor.',
-    },
     TR_ONBOARDING_COINS_STEP: {
         id: 'TR_ONBOARDING_COINS_STEP',
         defaultMessage: 'Activate coins',


### PR DESCRIPTION
## Description

Currently, FW hash check [returns `'unknown-release'` error](https://github.com/trezor/trezor-suite/blob/aeab689d34d2d36b679d88fd4ca8dbe77b86be79/packages/connect/src/device/Device.ts#L787) if the FW version is not _locally_ known. A countefeit device might be like that, so this was considered a "hard failure".

:arrow_right: ignore this case in FW hash check, because FW revision check handles it more elegantly - it solves edge cases described [here](https://github.com/trezor/trezor-suite-private/issues/115) and [here](https://github.com/trezor/trezor-suite-private/issues/117)

## Related Issue

Part of [private#117](https://github.com/trezor/trezor-suite-private/issues/117)

Spoils PRs #15059, #15107

## QA instructions

- open suite, make sure in Settings > Device > Danger zone: that Firmware revision check is **on**
- use with trezor-user-env `2-main` or `1-main`
- you should get Ghost modal :ghost:  & banner
"Firmware revision check failed. Your Trezor may be counterfeit."
- in Settings > Debug > Device: turn **off** only Check firmware Revision, make sure Check firmware Hash is **on**,
- reload suite, should be clear :heavy_check_mark: 
- use with trezor-user-env latest official release for any device
- you should get Ghost modal :ghost:  & banner
"Firmware hash check failed. Your Trezor may be counterfeit."
- restart suite with any legit physical device with latest fw 
- make sure in Settings > Device > Danger zone: that Firmware revision check is **on**
- should be clear :heavy_check_mark: 