### PR TITLE
Session stealing fix

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -310,7 +310,6 @@ export class Device extends TypedEmitter<DeviceEvents> {
             .then(result => {
                 if (result.success) {
                     this.session = null;
-                    this.isLocalSession = false;
                 }
 
                 return result;
@@ -503,6 +502,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
         if (!this.isLocalSession) {
             return;
         }
+        this.isLocalSession = false;
         this._featuresNeedsReload = true;
 
         _log.debug('interruptionFromOutside');


### PR DESCRIPTION
## Description

Fixes bug when `usedElsewhere` did nothing if device wasn't currently occupied here, so it could e.g. be shown as `connected` in two separate tabs at once.