### PR TITLE
fix(suite): ethereum/cardano button request hack conflicted with labeling

### DIFF
--- a/packages/connect/src/api/firmware/uploadFirmware.ts
+++ b/packages/connect/src/api/firmware/uploadFirmware.ts
@@ -10,7 +10,10 @@ import type { TypedCall } from '../../device/DeviceCommands';
 const postConfirmationMessage = (device: Device) => {
     // only if firmware is already installed. fresh device does not require button confirmation
     if (device.features.firmware_present) {
-        device.emit(DEVICE.BUTTON, device, { code: 'ButtonRequest_FirmwareUpdate' });
+        device.emit(DEVICE.BUTTON, device, {
+            code: 'ButtonRequest_FirmwareUpdate',
+            method: 'FirmwareUpload',
+        });
     }
 };
 

--- a/packages/connect/src/api/wipeDevice.ts
+++ b/packages/connect/src/api/wipeDevice.ts
@@ -32,7 +32,10 @@ export default class WipeDevice extends AbstractMethod<'wipeDevice'> {
 
         if (this.device.isBootloader()) {
             // firmware doesn't send this button request in bootloader mode
-            this.device.emit(DEVICE.BUTTON, this.device, { code: 'ButtonRequest_WipeDevice' });
+            this.device.emit(DEVICE.BUTTON, this.device, {
+                code: 'ButtonRequest_WipeDevice',
+                method: 'WipeDevice',
+            });
         }
 
         const response = await cmd.typedCall('WipeDevice', 'Success');

--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -28,6 +28,7 @@ const registerEvents = (device: Device, postMessage: PostMessage) => {
             createDeviceMessage(DEVICE.BUTTON, {
                 code: request.code,
                 device: device.toMessageObject(),
+                method: 'FirmwareUpload',
             }),
         );
     });

--- a/packages/connect/src/device/DeviceCommands.ts
+++ b/packages/connect/src/device/DeviceCommands.ts
@@ -378,10 +378,13 @@ export class DeviceCommands {
             throw ERRORS.TypedError('Runtime', 'typedCall: DeviceCommands already disposed');
         }
 
-        return this._filterCommonTypes(resp);
+        return this._filterCommonTypes(type, resp);
     }
 
-    _filterCommonTypes(res: DefaultPayloadMessage): Promise<DefaultPayloadMessage> {
+    _filterCommonTypes(
+        reqType: MessageKey,
+        res: DefaultPayloadMessage,
+    ): Promise<DefaultPayloadMessage> {
         this.device.clearCancelableAction();
 
         if (res.type === 'Failure') {
@@ -419,7 +422,10 @@ export class DeviceCommands {
             if (res.message.code === 'ButtonRequest_PassphraseEntry') {
                 this.device.emit(DEVICE.PASSPHRASE_ON_DEVICE);
             } else {
-                this.device.emit(DEVICE.BUTTON, this.device, res.message);
+                this.device.emit(DEVICE.BUTTON, this.device, {
+                    ...res.message,
+                    method: reqType,
+                });
             }
 
             return this._commonCall('ButtonAck', {});

--- a/packages/connect/src/events/device.ts
+++ b/packages/connect/src/events/device.ts
@@ -20,6 +20,7 @@ export const DEVICE = {
 
 export interface DeviceButtonRequestPayload extends Omit<PROTO.ButtonRequest, 'code'> {
     code?: PROTO.ButtonRequest['code'] | 'ButtonRequest_FirmwareUpdate';
+    method: PROTO.MessageKey;
 }
 
 export interface DeviceButtonRequest {

--- a/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
@@ -40,13 +40,19 @@ const buttonRequest =
         // ugly hack to make Cardano review modal work
         // ugly hack to make Ethereum staking and bump fee review modal on specific devices work
         // root cause of this bug is wrong button request ButtonRequest_Other from CardanoSignTx - should be ButtonRequest_SignTx
-        if (action.type === UI.REQUEST_BUTTON && action.payload.code === 'ButtonRequest_Other') {
+        if (
+            action.type === UI.REQUEST_BUTTON &&
+            action.payload.code === 'ButtonRequest_Other' &&
+            // labeling can be done on these routes as well
+            action.payload.method !== 'CipherKeyValue'
+        ) {
             const {
                 wallet: {
                     selectedAccount: { account },
                 },
                 router: { route },
             } = api.getState();
+            // TODO: rewrite this condition to be based on payload.method
             if (
                 ['cardano', 'ethereum'].includes(account?.networkType || '') &&
                 ['wallet-send', 'wallet-staking', 'wallet-index'].includes(route?.name || '')


### PR DESCRIPTION
## Description

There is an ugly hack for button requests in Suite that rewrites `ButtonRequest_Other` to `ButtonRequest_SignTx` on Ethereum/Cardano account screens. 
This clashes with other calls to enable labeling, which may also happen on these screens. 

This PR modifies Connect, adding a `method` field to the button request payload, that identifies the message type to which this event is responding.

This field is then used in Suite to exclude labeling enabling (`CipherKeyValue` calls) from this hack.
 
It could also be used to remove the conditions for the hack that are based on the router to be entirely based on the method field, but I didn't want to change any  behavior unintentionally as part of this PR. 

## Related Issue

Resolve #15111