### PR TITLE
feat(tokens): Add relevant swap/buy/sell buttons to Tokens list

### DIFF
--- a/packages/components/src/components/Dropdown/Dropdown.tsx
+++ b/packages/components/src/components/Dropdown/Dropdown.tsx
@@ -12,9 +12,10 @@ import {
 } from 'react';
 import { createPortal } from 'react-dom';
 
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { useOnClickOutside } from '@trezor/react-utils';
+import { borders } from '@trezor/theme';
 
 import { Menu, MenuProps, DropdownMenuItemProps } from './Menu';
 import { Coords, getAdjustedCoords } from './getAdjustedCoords';
@@ -39,11 +40,12 @@ const Container = styled.div<{ $disabled?: boolean; $hasCustomChildren: boolean 
     ${getFocusShadowStyle()};
     cursor: ${({ $disabled }) => ($disabled ? 'default' : 'pointer')};
 
-    /**
-        This must be here to reduce clickable area to the "circle" of the (...) children.
-        However, if you use custom children its your own responsibility to handle it.
-    */
-    ${({ $hasCustomChildren }) => ($hasCustomChildren ? undefined : '50%;')}
+    ${({ $hasCustomChildren }) =>
+        $hasCustomChildren
+            ? undefined
+            : css`
+                  border-radius: ${borders.radii.full};
+              `}
 `;
 
 const getPlacementData = (

--- a/packages/suite/src/actions/wallet/coinmarket/coinmarketCommonActions.ts
+++ b/packages/suite/src/actions/wallet/coinmarket/coinmarketCommonActions.ts
@@ -56,6 +56,10 @@ export type CoinmarketCommonAction =
     | {
           type: typeof COINMARKET_COMMON.SET_COINMARKET_ACTIVE_SECTION;
           activeSection: CoinmarketTradeType;
+      }
+    | {
+          type: typeof COINMARKET_COMMON.SET_COINMARKET_FROM_PREFILLED_CRYPTO_ID;
+          prefilledFromCryptoId: CryptoId | undefined;
       };
 
 type FormState = {
@@ -224,3 +228,10 @@ export const convertDrafts = () => (dispatch: Dispatch, getState: GetState) => {
         }
     });
 };
+
+export const setCoinmarketPrefilledFromCryptoId = (
+    prefilledFromCryptoId: CryptoId | undefined,
+): CoinmarketCommonAction => ({
+    type: COINMARKET_COMMON.SET_COINMARKET_FROM_PREFILLED_CRYPTO_ID,
+    prefilledFromCryptoId,
+});

--- a/packages/suite/src/actions/wallet/constants/coinmarketCommonConstants.ts
+++ b/packages/suite/src/actions/wallet/constants/coinmarketCommonConstants.ts
@@ -5,3 +5,5 @@ export const SET_LOADING = '@coinmarket-common/set_loading';
 export const SET_MODAL_CRYPTO_CURRENCY = '@coinmarket-common/set_modal_crypto_currency';
 export const SET_MODAL_ACCOUNT = '@coinmarket-common/set_modal_account';
 export const SET_COINMARKET_ACTIVE_SECTION = '@coinmarket-common/set_coinmarket_active_section';
+export const SET_COINMARKET_FROM_PREFILLED_CRYPTO_ID =
+    '@coinmarket-common/set_coinmarket_from_prefilled_crypto_id';

--- a/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketBuildAccountGroups.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketBuildAccountGroups.ts
@@ -4,25 +4,22 @@ import { selectAccounts, selectDevice } from '@suite-common/wallet-core';
 
 import { useDefaultAccountLabel, useSelector } from 'src/hooks/suite';
 import { selectAccountLabels } from 'src/reducers/suite/metadataReducer';
+import { selectSupportedSymbols } from 'src/reducers/wallet/coinmarketReducer';
 import {
     CoinmarketAccountsOptionsGroupProps,
-    CoinmarketTradeSellExchangeType,
+    CoinmarketTradeType,
 } from 'src/types/coinmarket/coinmarket';
 import { coinmarketBuildAccountOptions } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 
 export const useCoinmarketBuildAccountGroups = (
-    type: CoinmarketTradeSellExchangeType,
+    type: CoinmarketTradeType,
 ): CoinmarketAccountsOptionsGroupProps[] => {
     const accounts = useSelector(selectAccounts);
     const accountLabels = useSelector(selectAccountLabels);
     const device = useSelector(selectDevice);
     const { getDefaultAccountLabel } = useDefaultAccountLabel();
     const { tokenDefinitions } = useSelector(state => state);
-    const supportedSymbols = useSelector(state =>
-        type === 'sell'
-            ? state.wallet.coinmarket.sell.sellInfo?.supportedCryptoCurrencies
-            : state.wallet.coinmarket.exchange.exchangeInfo?.sellSymbols,
-    );
+    const supportedSymbols = useSelector(selectSupportedSymbols(type));
 
     const groups = useMemo(
         () =>

--- a/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketFormActions.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketFormActions.ts
@@ -39,6 +39,7 @@ import {
 import {
     coinmarketGetSortedAccounts,
     cryptoIdToSymbol,
+    getAddressAndTokenFromAccountOptionsGroupProps,
     getCoinmarketNetworkDecimals,
 } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import { coinmarketGetExchangeReceiveCryptoId } from 'src/utils/wallet/coinmarket/exchangeUtils';
@@ -171,21 +172,12 @@ export const useCoinmarketFormActions = <T extends CoinmarketSellExchangeFormPro
 
         if (!account || isSameCryptoSelected) return;
 
-        setValue(FORM_OUTPUT_ADDRESS, '');
-        setValue(FORM_OUTPUT_AMOUNT, '');
-        setValue(FORM_CRYPTO_TOKEN, selected?.contractAddress ?? null);
-
-        if (account.networkType === 'ethereum') {
-            // set token address for ERC20 transaction to estimate the fees more precisely
-            setValue(FORM_OUTPUT_ADDRESS, selected?.contractAddress ?? '');
-        }
-        if (account.networkType === 'solana' && !selected?.contractAddress) {
-            setValue(FORM_OUTPUT_ADDRESS, selected?.descriptor ?? '');
-        }
-
+        const { address, token } = getAddressAndTokenFromAccountOptionsGroupProps(selected);
+        setValue(FORM_OUTPUT_ADDRESS, address);
+        setValue(FORM_CRYPTO_TOKEN, token);
         setValue(FORM_OUTPUT_MAX, undefined);
-        setValue(FORM_OUTPUT_AMOUNT, '');
         setValue(FORM_OUTPUT_FIAT, '');
+        setValue(FORM_OUTPUT_AMOUNT, '');
         setAmountLimits(undefined);
         setComposedLevels(undefined);
 

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketBuyFormDefaultValues.tsx
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketBuyFormDefaultValues.tsx
@@ -14,13 +14,17 @@ import {
     FORM_DEFAULT_PAYMENT_METHOD,
 } from 'src/constants/wallet/coinmarket/form';
 import { useCoinmarketInfo } from 'src/hooks/wallet/coinmarket/useCoinmarketInfo';
+import { useSelector } from 'src/hooks/suite';
 
 export const useCoinmarketBuyFormDefaultValues = (
     accountSymbol: Account['symbol'],
     buyInfo: BuyInfo | undefined,
 ): CoinmarketBuyFormDefaultValuesProps => {
     const { buildDefaultCryptoOption } = useCoinmarketInfo();
-    const cryptoId = networks[accountSymbol]?.coingeckoNativeId;
+    const prefilledFromCryptoId = useSelector(
+        state => state.wallet.coinmarket.prefilledFromCryptoId,
+    );
+    const cryptoId = prefilledFromCryptoId || networks[accountSymbol]?.coingeckoNativeId;
 
     const country = buyInfo?.buyInfo?.country;
     const defaultCountry = useMemo(() => getDefaultCountry(country), [country]);

--- a/packages/suite/src/middlewares/wallet/coinmarketMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/coinmarketMiddleware.ts
@@ -145,8 +145,20 @@ export const coinmarketMiddleware =
             }
 
             if (isExchange) {
-                console.log('coinmarketMiddleware ROUTER.LOCATION_CHANGE');
                 api.dispatch(coinmarketCommonActions.setActiveSection('exchange'));
+            }
+
+            const wasBuy = state.router.route?.name === 'wallet-coinmarket-buy';
+            const wasSell = state.router.route?.name === 'wallet-coinmarket-sell';
+            const isBuyToSell = wasBuy && isSell;
+            const isSellToBuy = wasSell && isBuy;
+
+            const cleanupPrefilledFromCryptoId =
+                !!newState.wallet.coinmarket.prefilledFromCryptoId &&
+                ((!isSell && !isExchange && !isBuy) || isBuyToSell || isSellToBuy);
+
+            if (cleanupPrefilledFromCryptoId) {
+                api.dispatch(coinmarketCommonActions.setCoinmarketPrefilledFromCryptoId(undefined));
             }
         }
 

--- a/packages/suite/src/reducers/wallet/coinmarketReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinmarketReducer.ts
@@ -25,7 +25,7 @@ import {
     COINMARKET_INFO,
 } from 'src/actions/wallet/constants';
 import { STORAGE } from 'src/actions/suite/constants';
-import type { Action as SuiteAction } from 'src/types/suite';
+import type { AppState, Action as SuiteAction } from 'src/types/suite';
 import type { SellInfo } from 'src/actions/wallet/coinmarketSellActions';
 import type { Trade } from 'src/types/wallet/coinmarketCommonTypes';
 import {
@@ -97,6 +97,7 @@ export interface State {
     isLoading: boolean;
     lastLoadedTimestamp: number;
     activeSection?: CoinmarketTradeType;
+    prefilledFromCryptoId: CryptoId | undefined;
 }
 
 export const initialState: State = {
@@ -145,6 +146,7 @@ export const initialState: State = {
     modalCryptoId: undefined,
     lastLoadedTimestamp: 0,
     activeSection: 'buy',
+    prefilledFromCryptoId: undefined,
 };
 
 export const coinmarketReducer = (
@@ -197,6 +199,9 @@ export const coinmarketReducer = (
                 break;
             case COINMARKET_BUY.DISPOSE:
                 draft.buy.addressVerified = undefined;
+                break;
+            case COINMARKET_COMMON.SET_COINMARKET_FROM_PREFILLED_CRYPTO_ID:
+                draft.prefilledFromCryptoId = action.prefilledFromCryptoId;
                 break;
             case COINMARKET_COMMON.SAVE_TRADE:
                 if (action.key) {
@@ -267,3 +272,17 @@ export const coinmarketReducer = (
             // no default
         }
     });
+
+export const selectSupportedSymbols =
+    (type: CoinmarketTradeType) =>
+    (state: AppState): Set<CryptoId> | undefined => {
+        const { coinmarket } = state.wallet;
+        switch (type) {
+            case 'buy':
+                return coinmarket.buy.buyInfo?.supportedCryptoCurrencies;
+            case 'exchange':
+                return coinmarket.exchange.exchangeInfo?.sellSymbols;
+            case 'sell':
+                return coinmarket.sell.sellInfo?.supportedCryptoCurrencies;
+        }
+    };

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -1419,6 +1419,10 @@ const messages = defineMessagesWithTypeCheck({
         defaultMessage: 'Swap',
         id: 'TR_COINMARKET_SWAP',
     },
+    TR_COINMARKET_SWAP_UNAVAILABLE: {
+        defaultMessage: 'Swap unavailable',
+        id: 'TR_COINMARKET_SWAP_UNAVAILABLE',
+    },
     TR_COINMARKET_TRANS_ID: {
         defaultMessage: 'Trans. ID:',
         id: 'TR_COINMARKET_TRANS_ID',

--- a/packages/suite/src/utils/wallet/coinmarket/__fixtures__/coinmarketUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/__fixtures__/coinmarketUtils.ts
@@ -1,5 +1,9 @@
+import { CryptoId } from 'invity-api';
+
 import { DefinitionType, TokenDefinitions } from '@suite-common/token-definitions';
 import { Account } from '@suite-common/wallet-types';
+
+import { CoinmarketAccountOptionsGroupOptionProps } from 'src/types/coinmarket/coinmarket';
 
 export const accountBtc = {
     index: 1,
@@ -186,5 +190,91 @@ export const FIXTURE_ACCOUNTS: Partial<Account>[] = [
         symbol: 'btc',
         visible: true,
         accountType: 'coinjoin',
+    },
+];
+
+const accountOptionPlaceholder = {
+    label: '',
+    cryptoName: '',
+    balance: '',
+    decimals: 0,
+    accountType: 'normal' as const,
+};
+
+export const FIXTURE_ACCOUNT_OPTIONS: Array<{
+    option: CoinmarketAccountOptionsGroupOptionProps | undefined;
+    result: { address: string; token: string | null };
+}> = [
+    {
+        option: {
+            ...accountOptionPlaceholder,
+            value: 'bitcoin' as CryptoId,
+            contractAddress: undefined,
+            descriptor: 'bbb',
+        },
+        result: {
+            address: '',
+            token: null,
+        },
+    },
+    {
+        option: {
+            ...accountOptionPlaceholder,
+            value: 'ethereum' as CryptoId,
+            contractAddress: undefined,
+            descriptor: 'eee',
+        },
+        result: {
+            address: '',
+            token: null,
+        },
+    },
+    {
+        option: {
+            ...accountOptionPlaceholder,
+            value: 'ethereum--0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9' as CryptoId,
+            contractAddress: '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9',
+            descriptor: 'aaa',
+        },
+        result: {
+            address: '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9',
+            token: '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9',
+        },
+    },
+    {
+        option: {
+            ...accountOptionPlaceholder,
+            value: 'solana' as CryptoId,
+            contractAddress: undefined,
+            descriptor: 'sss',
+        },
+        result: {
+            address: 'sss',
+            token: null,
+        },
+    },
+    {
+        option: {
+            ...accountOptionPlaceholder,
+            value: 'solana' as CryptoId,
+            contractAddress: '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9',
+            descriptor: 'ddd',
+        },
+        result: {
+            address: '',
+            token: '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9',
+        },
+    },
+    {
+        option: {
+            ...accountOptionPlaceholder,
+            value: 'cardano' as CryptoId,
+            contractAddress: undefined,
+            descriptor: 'ccc',
+        },
+        result: {
+            address: '',
+            token: null,
+        },
     },
 ];

--- a/packages/suite/src/utils/wallet/coinmarket/__tests__/coinmarketUtils.test.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/__tests__/coinmarketUtils.test.ts
@@ -16,9 +16,11 @@ import {
     coinmarketGetAmountLabels,
     coinmarketGetAccountLabel,
     testnetToProdCryptoId,
+    getAddressAndTokenFromAccountOptionsGroupProps,
 } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import {
     FIXTURE_ACCOUNTS,
+    FIXTURE_ACCOUNT_OPTIONS,
     accountBtc,
     accountEth,
     coinDefinitions,
@@ -322,5 +324,13 @@ describe('coinmarket utils', () => {
                 'ethereum--0x1234123412341234123412341234123412341236' as CryptoId,
             ),
         ).toEqual('ethereum--0x1234123412341234123412341234123412341236');
+    });
+
+    it('getAddressAndTokenFromAccountOptionsGroupProps - testing correct returning value fot setting FormState to send currency', () => {
+        FIXTURE_ACCOUNT_OPTIONS.forEach(item => {
+            expect(getAddressAndTokenFromAccountOptionsGroupProps(item.option)).toEqual(
+                item.result,
+            );
+        });
     });
 });

--- a/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
@@ -8,6 +8,7 @@ import {
     getNetworkByCoingeckoId,
     getNetworkByCoingeckoNativeId,
     getNetworkFeatures,
+    getNetworkType,
     networks,
 } from '@suite-common/wallet-config';
 import TrezorConnect from '@trezor/connect';
@@ -205,7 +206,6 @@ export const getComposeAddressPlaceholder = async (
             // return '37btjrVyb4KDXBNC4haBVPCrro8AQPHwvCMp3RFhhSVWwfFmZ6wwzSK6JK1hY6wHNmtrpTf1kdbva8TCneM2YsiXT7mrzT21EacHnPpz5YyUdj64na';
             return '';
         case 'solana':
-            return '';
         case 'ethereum':
         case 'ripple':
             return account.descriptor;
@@ -492,4 +492,34 @@ export const coinmarketGetSectionActionLabel = (
     if (type === 'sell') return 'TR_COINMARKET_SELL';
 
     return 'TR_COINMARKET_SWAP';
+};
+
+interface GetAddressAndTokenFromAccountOptionsGroupProps {
+    address: string;
+    token: string | null;
+}
+
+export const getAddressAndTokenFromAccountOptionsGroupProps = (
+    selected: CoinmarketAccountOptionsGroupOptionProps | undefined,
+): GetAddressAndTokenFromAccountOptionsGroupProps => {
+    if (!selected) {
+        return { address: '', token: null };
+    }
+
+    const networkSymbol = cryptoIdToSymbol(selected.value);
+    const networkType = networkSymbol ? getNetworkType(networkSymbol) : null;
+
+    // set token address for ERC20 transaction to estimate the fees more precisely
+    if (networkType === 'ethereum') {
+        return {
+            address: selected.contractAddress ?? '',
+            token: selected.contractAddress ?? null,
+        };
+    }
+
+    if (networkType === 'solana' && !selected.contractAddress) {
+        return { address: selected.descriptor, token: null };
+    }
+
+    return { address: '', token: selected.contractAddress ?? null };
 };

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokensTable.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokensTable.tsx
@@ -9,6 +9,7 @@ import { spacings } from '@trezor/theme';
 import { Icon, Table, Paragraph, Card, Row, Text } from '@trezor/components';
 
 import { Translation } from 'src/components/suite';
+import { useCoinmarketLoadData } from 'src/hooks/wallet/coinmarket/useCoinmarketLoadData';
 
 import { TokenRow } from './TokenRow';
 
@@ -43,6 +44,7 @@ export const TokensTable = ({
     isUnverifiedTable,
 }: TokensTableProps) => {
     const [isZeroBalanceOpen, setIsZeroBalanceOpen] = useState(false);
+    useCoinmarketLoadData();
 
     return (
         <Card paddingType="none" overflow="hidden">


### PR DESCRIPTION
### Tokens List

- add swap button (icon only), separate from send and receive 
<img width="34" alt="Screenshot 2024-10-22 at 15 27 17" src="https://github.com/user-attachments/assets/683d6907-44c1-4354-b58a-01161f93a997">


- add buy and sell button (icon+label) into the context menu before first item

- buttons will be showing only for the relevant assets - e.g. if a token can be swapped and not bought/sold, only swap is displayed

- trade form field "From" will be prefilled with the related crypto asset

## Before
<img width="1629" alt="Screenshot 2024-10-14 at 20 21 37 (1)" src="https://github.com/user-attachments/assets/88c39795-bd66-4f48-9bc3-0b38b9632d24">

## After
![image](https://github.com/user-attachments/assets/e63279ec-8e1e-432d-b2e4-89061bb0f6b9)


Resolves #15069