### PR TITLE
fix(suite): switch device shows on transport unavailable with view only

### DIFF
--- a/packages/suite/src/components/suite/ConnectDevicePrompt.tsx
+++ b/packages/suite/src/components/suite/ConnectDevicePrompt.tsx
@@ -2,7 +2,6 @@ import styled, { useTheme } from 'styled-components';
 
 import {
     variables,
-    Button,
     motionEasing,
     LottieAnimation,
     useElevation,
@@ -11,8 +10,7 @@ import {
 } from '@trezor/components';
 import { isDesktop } from '@trezor/env-utils';
 import { Translation } from 'src/components/suite';
-import { useDevice, useDispatch } from 'src/hooks/suite';
-import { goto } from 'src/actions/suite/routerActions';
+import { useDevice } from 'src/hooks/suite';
 import type { PrerequisiteType } from 'src/types/suite';
 import { motion } from 'framer-motion';
 import { Elevation, mapElevationToBackground, mapElevationToBorder } from '@trezor/theme';
@@ -28,7 +26,6 @@ const Wrapper = styled(motion.div)<{ $elevation: Elevation }>`
     border: 1px solid ${mapElevationToBorder};
     align-items: center;
     box-shadow: ${({ theme }) => theme.boxShadowElevated};
-    margin-bottom: 60px;
 `;
 
 const ImageWrapper = styled.div`
@@ -131,14 +128,8 @@ export const ConnectDevicePrompt = ({
     prerequisite,
     connected,
     showWarning,
-    allowSwitchDevice,
 }: ConnectDevicePromptProps) => {
-    const dispatch = useDispatch();
-
     const { elevation } = useElevation();
-
-    const handleSwitchDeviceClick = () =>
-        dispatch(goto('suite-switch-device', { params: { cancelable: true } }));
 
     return (
         <Wrapper
@@ -153,12 +144,6 @@ export const ConnectDevicePrompt = ({
 
                 <Text>
                     <Translation id={getMessageId({ connected, showWarning, prerequisite })} />
-
-                    {allowSwitchDevice && (
-                        <Button variant="tertiary" onClick={handleSwitchDeviceClick}>
-                            <Translation id="TR_SWITCH_DEVICE" />
-                        </Button>
-                    )}
                 </Text>
             </ElevationUp>
         </Wrapper>


### PR DESCRIPTION
## Description

The "Switch Device" button would be available on transport errors, because it would also count view only wallets. 

This PR fixes that by only counting connected wallets. 
It also moves the button below the box with the title due to overflowing. 

## Screenshots:
Before
<img width="544" alt="Screenshot 2024-10-31 at 11 33 09" src="https://github.com/user-attachments/assets/5ba249a5-3f12-4d82-b063-b53170df9540">
After
<img width="544" alt="Screenshot 2024-10-31 at 11 59 24" src="https://github.com/user-attachments/assets/8332458a-0163-4f2f-96c2-3e8c5d39b297">
