### PR TITLE
fix(suite-common): add check for bitcoin-only firmware type

### DIFF
--- a/packages/coinjoin/package.json
+++ b/packages/coinjoin/package.json
@@ -25,6 +25,7 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
+        "@suite-common/suite-constants": "workspace:*",
         "@trezor/blockchain-link": "workspace:*",
         "@trezor/blockchain-link-types": "workspace:*",
         "@trezor/blockchain-link-utils": "workspace:*",

--- a/packages/coinjoin/tests/tools/discovery.ts
+++ b/packages/coinjoin/tests/tools/discovery.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 /* eslint-disable @typescript-eslint/no-var-requires */
 
+import { BITCOIN_ONLY_NETWORKS } from '@suite-common/suite-constants';
 import { isArrayMember } from '@trezor/utils';
 
 import { CoinjoinBackend } from '../../src/backend/CoinjoinBackend';
@@ -8,7 +9,7 @@ import type { CoinjoinBackendSettings } from '../../src/types';
 
 const { getCoinjoinConfig } = require('../../../suite/src/services/coinjoin/config');
 
-const supportedNetworks = ['btc', 'test', 'regtest'] as const;
+const supportedNetworks = BITCOIN_ONLY_NETWORKS;
 type SupportedNetwork = (typeof supportedNetworks)[number];
 
 const isSupportedNetwork = (network: string): network is SupportedNetwork =>

--- a/packages/coinjoin/tsconfig.json
+++ b/packages/coinjoin/tsconfig.json
@@ -2,6 +2,9 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
+        {
+            "path": "../../suite-common/suite-constants"
+        },
         { "path": "../blockchain-link" },
         { "path": "../blockchain-link-types" },
         { "path": "../blockchain-link-utils" },

--- a/packages/suite/src/actions/wallet/__fixtures__/discoveryActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/discoveryActions.ts
@@ -60,6 +60,12 @@ export const fixtures = [
                     symbol: 'test',
                     accountType: 'legacy',
                 },
+                {
+                    error: 'Runtime discovery error',
+                    index: 3,
+                    symbol: 'regtest',
+                    accountType: 'legacy',
+                },
             ],
         },
     },

--- a/packages/suite/src/actions/wallet/__fixtures__/mockCoinjoinService.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/mockCoinjoinService.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 
 export const mockCoinjoinService = () => {
     const allowed = ['btc', 'test'];
@@ -65,7 +66,7 @@ export const mockCoinjoinService = () => {
         CoinjoinService: {
             getInstance: jest.fn((symbol: string) => clients[symbol]),
             getInstances: jest.fn(() => Object.values(clients)),
-            createInstance: jest.fn(({ network }: { network: string }) => {
+            createInstance: jest.fn(({ network }: { network: NetworkSymbol }) => {
                 if (!allowed.includes(network)) throw new Error('Client not supported');
                 if (clients[network]) return clients[network];
                 const instance = getMockedInstance(network);

--- a/packages/suite/src/actions/wallet/__tests__/discoveryActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/discoveryActions.test.ts
@@ -24,6 +24,7 @@ import walletSettingsReducer from 'src/reducers/wallet/settingsReducer';
 import { accountsReducer } from 'src/reducers/wallet';
 import * as walletSettingsActions from 'src/actions/settings/walletSettingsActions';
 import { extraDependencies } from 'src/support/extraDependencies';
+import { BITCOIN_ONLY_NETWORKS } from '@suite-common/suite-constants';
 
 import {
     paramsError,
@@ -182,7 +183,7 @@ export const getInitialState = (device = SUITE_DEVICE) => ({
         accounts: accountsReducer(undefined, { type: 'foo' } as any),
         settings: walletSettingsReducer(undefined, {
             type: walletSettingsActions.changeNetworks.type,
-            payload: ['btc', 'test'],
+            payload: BITCOIN_ONLY_NETWORKS,
         }),
     },
 });

--- a/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
@@ -9,6 +9,7 @@ import {
 import { Button, motionEasing, Tooltip } from '@trezor/components';
 import { DeviceModelInternal } from '@trezor/connect';
 import { Network } from '@suite-common/wallet-config';
+import { BITCOIN_ONLY_NETWORKS } from '@suite-common/suite-constants';
 
 import {
     DeviceBanner,
@@ -111,11 +112,11 @@ export const SettingsCoins = () => {
     const supportedTestnetNetworks = getNetworks(testnets);
 
     const bitcoinOnlyFirmware = hasBitcoinOnlyFirmware(device);
-    const bitcoinNetworks = ['btc', 'test', 'regtest'];
+    const bitcoinOnlyNetworks = BITCOIN_ONLY_NETWORKS;
 
     const onlyBitcoinNetworksEnabled =
         !!supportedEnabledNetworks.length &&
-        supportedEnabledNetworks.every(coin => bitcoinNetworks.includes(coin));
+        supportedEnabledNetworks.every(coin => bitcoinOnlyNetworks.includes(coin));
     const bitcoinOnlyDevice = isBitcoinOnlyDevice(device);
 
     const showDeviceBanner = device?.connected === false; // device is remembered and disconnected

--- a/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.ts
+++ b/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.ts
@@ -1,6 +1,11 @@
 import { A } from '@mobily/ts-belt';
 
-import { getNetworkOptional, isNetworkSymbol, NetworkSymbol } from '@suite-common/wallet-config';
+import {
+    getNetworkOptional,
+    isNetworkSymbol,
+    NetworkSymbol,
+    networks,
+} from '@suite-common/wallet-config';
 import {
     amountToSatoshi,
     formatAmount,
@@ -35,19 +40,18 @@ const truncateDecimals = (value: string, maxDecimals: number, isEllipsisAppended
     return value;
 };
 
-// We cannot use networks "A.includes(networks[symbol].features, 'amount-unit')" because this flag is on many coins like ETH.
-// These coins will looks very bad in app because for example ETH have 18 numbers... So we hardcode enabled coins here.
-const COINS_WITH_SATS = ['btc', 'test'] satisfies NetworkSymbol[];
-
 const convertToUnit = (
     value: string,
     isBalance: boolean,
     config: FormatterConfig,
-    symbol?: string,
+    symbol?: NetworkSymbol,
 ) => {
     const { bitcoinAmountUnit } = config;
     const decimals = getNetworkOptional(symbol)?.decimals ?? 0;
-    const areAmountUnitsSupported = A.includes(COINS_WITH_SATS, symbol);
+
+    const areAmountUnitsSupported = symbol
+        ? A.includes(networks[symbol]?.features, 'amount-unit')
+        : undefined;
 
     if (isBalance && areAmountUnitsSupported && bitcoinAmountUnit === PROTO.AmountUnit.SATOSHI) {
         return amountToSatoshi(value, decimals);

--- a/suite-common/suite-constants/src/bitcoinOnlyNetworks.ts
+++ b/suite-common/suite-constants/src/bitcoinOnlyNetworks.ts
@@ -1,0 +1,3 @@
+import { NetworkSymbol } from '@suite-common/wallet-config';
+
+export const BITCOIN_ONLY_NETWORKS = ['btc', 'test', 'regtest'] as NetworkSymbol[];

--- a/suite-common/suite-constants/src/index.ts
+++ b/suite-common/suite-constants/src/index.ts
@@ -3,3 +3,4 @@ export * from './units';
 export * from './protocol';
 export * from './desktopAppUpdateState';
 export * from './device';
+export * from './bitcoinOnlyNetworks';

--- a/suite-common/test-utils/package.json
+++ b/suite-common/test-utils/package.json
@@ -14,6 +14,7 @@
         "@mobily/ts-belt": "^3.13.1",
         "@reduxjs/toolkit": "1.9.5",
         "@suite-common/redux-utils": "workspace:*",
+        "@suite-common/suite-constants": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",

--- a/suite-common/test-utils/src/extraDependenciesMock.ts
+++ b/suite-common/test-utils/src/extraDependenciesMock.ts
@@ -1,5 +1,6 @@
 import { createAction } from '@reduxjs/toolkit';
 
+import { BITCOIN_ONLY_NETWORKS } from '@suite-common/suite-constants';
 import { createThunk, ExtraDependencies } from '@suite-common/redux-utils';
 import { PROTO } from '@trezor/connect';
 import { AddressDisplayOptions } from '@suite-common/wallet-types';
@@ -72,7 +73,7 @@ export const extraDependenciesMock: ExtraDependencies = {
         selectDevices: mockSelector('selectDevices', []),
         selectBitcoinAmountUnit: mockSelector('selectBitcoinAmountUnit', PROTO.AmountUnit.BITCOIN),
         selectAreSatsAmountUnit: mockSelector('selectAreSatsAmountUnit', false),
-        selectEnabledNetworks: mockSelector('selectEnabledNetworks', ['btc', 'test']),
+        selectEnabledNetworks: mockSelector('selectEnabledNetworks', BITCOIN_ONLY_NETWORKS),
         selectTokenDefinitionsEnabledNetworks: mockSelector(
             'selectTokenDefinitonsEnabledNetworks',
             ['eth'],

--- a/suite-common/test-utils/tsconfig.json
+++ b/suite-common/test-utils/tsconfig.json
@@ -3,6 +3,7 @@
     "compilerOptions": { "outDir": "libDev" },
     "references": [
         { "path": "../redux-utils" },
+        { "path": "../suite-constants" },
         { "path": "../suite-types" },
         { "path": "../wallet-config" },
         { "path": "../wallet-types" },

--- a/suite-native/module-accounts-management/package.json
+++ b/suite-native/module-accounts-management/package.json
@@ -17,6 +17,7 @@
         "@reduxjs/toolkit": "1.9.5",
         "@suite-common/fiat-services": "workspace:*",
         "@suite-common/graph": "workspace:*",
+        "@suite-common/suite-constants": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",

--- a/suite-native/module-accounts-management/src/selectors.ts
+++ b/suite-native/module-accounts-management/src/selectors.ts
@@ -1,11 +1,12 @@
 import { NetworkSymbol, getNetworkType } from '@suite-common/wallet-config';
+import { BITCOIN_ONLY_NETWORKS } from '@suite-common/suite-constants';
 import {
     FeatureFlagsRootState,
     selectIsFeatureFlagEnabled,
     FeatureFlag,
 } from '@suite-native/feature-flags';
 
-const SEND_COINS_WHITELIST: NetworkSymbol[] = ['btc', 'test', 'regtest'];
+const SEND_COINS_WHITELIST = BITCOIN_ONLY_NETWORKS;
 
 export const selectIsNetworkSendFlowEnabled = (
     state: FeatureFlagsRootState,

--- a/suite-native/module-accounts-management/tsconfig.json
+++ b/suite-native/module-accounts-management/tsconfig.json
@@ -7,6 +7,9 @@
         },
         { "path": "../../suite-common/graph" },
         {
+            "path": "../../suite-common/suite-constants"
+        },
+        {
             "path": "../../suite-common/wallet-config"
         },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9128,6 +9128,7 @@ __metadata:
     "@mobily/ts-belt": "npm:^3.13.1"
     "@reduxjs/toolkit": "npm:1.9.5"
     "@suite-common/redux-utils": "workspace:*"
+    "@suite-common/suite-constants": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
@@ -9961,6 +9962,7 @@ __metadata:
     "@reduxjs/toolkit": "npm:1.9.5"
     "@suite-common/fiat-services": "workspace:*"
     "@suite-common/graph": "workspace:*"
+    "@suite-common/suite-constants": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
@@ -11038,6 +11040,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/coinjoin@workspace:packages/coinjoin"
   dependencies:
+    "@suite-common/suite-constants": "workspace:*"
     "@trezor/blockchain-link": "workspace:*"
     "@trezor/blockchain-link-types": "workspace:*"
     "@trezor/blockchain-link-utils": "workspace:*"


### PR DESCRIPTION

## Description


Before, if the coin is not supported on this firmware version, it would be shown there with a CTA to update firmware, even if it was Bitcoin-only firmware. 

Added a check for non-bitcoin networks if the firmware is bitcoin only.


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/10612

## Screenshots:
![image](https://github.com/user-attachments/assets/6e898f02-bc3a-47a2-a89d-a4804badc194)
