### PR TITLE
feat(suite-desktop-core): handle closing based on current autostart preference

### DIFF
--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -23,6 +23,7 @@ import { createInterceptor } from './libs/request-interceptor';
 import { hangDetect } from './hang-detect';
 import { Logger } from './libs/logger';
 import { MainWindowProxy } from './libs/main-window-proxy';
+import { isAutoStartEnabled } from './modules/auto-start';
 
 // @ts-expect-error using internal electron API to set suite version in dev mode correctly
 if (isDevEnv) app.setVersion(process.env.VERSION);
@@ -165,16 +166,14 @@ const init = async () => {
         app.off('open-url', openURL);
     }
 
-    await initUi({ store, daemon, quitBridgeModule });
+    await initUi({ store, quitBridgeModule });
 };
 
 const initUi = async ({
     store,
-    daemon,
     quitBridgeModule,
 }: {
     store: Store;
-    daemon: boolean;
     quitBridgeModule: () => Promise<void>;
 }) => {
     const buildInfo = getBuildInfo();
@@ -267,9 +266,10 @@ const initUi = async ({
         const mainWindow = mainWindowProxy.getInstance();
         const windowExists =
             mainWindow && !mainWindow.isDestroyed() && mainWindow.isClosable() && !app.isHidden();
+        const autoStartCurrentlyEnabled = isAutoStartEnabled();
         logger.info('main', `Before quit, window exists: ${windowExists}`);
         if (
-            daemon &&
+            autoStartCurrentlyEnabled &&
             (!isMacOs() || windowExists) // On Mac the window closing and app quitting are different
         ) {
             // Prevent quitting app when in daemon mode, unless the UI is already closed

--- a/packages/suite-desktop-core/src/modules/auto-start.ts
+++ b/packages/suite-desktop-core/src/modules/auto-start.ts
@@ -37,7 +37,7 @@ StartupNotify=false
 Terminal=false
 `;
 
-const isAutoStartEnabled = () => {
+export const isAutoStartEnabled = () => {
     if (process.platform === 'linux') {
         return fs.existsSync(path.join(os.homedir(), LINUX_AUTOSTART_DIR, LINUX_AUTOSTART_FILE));
     } else {


### PR DESCRIPTION
## Description

This PR changes the behavior of closing the app to be based on the current setting autostart, not on how the app was started. 

Before if you newly enabled autostart and closed the window, it would not continue running in the background. 
The same thing vice versa, if you had autostart enabled and changed it to disabled, it would continue running. 

Now once you enable autostart, it will keep running in daemon mode.