### PR TITLE
chore: add 'import/no-duplicates' ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -98,6 +98,7 @@ module.exports = {
                 'newlines-between': 'always',
             },
         ],
+        'import/no-duplicates': 'error',
         'import/no-extraneous-dependencies': [
             'error',
             {

--- a/packages/blockchain-link/src/workers/baseWebsocket.ts
+++ b/packages/blockchain-link/src/workers/baseWebsocket.ts
@@ -1,7 +1,5 @@
 import WebSocket from 'ws';
-import { createDeferred } from '@trezor/utils';
-import { createDeferredManager } from '@trezor/utils';
-import { TypedEmitter } from '@trezor/utils';
+import { createDeferred, createDeferredManager, TypedEmitter } from '@trezor/utils';
 
 import { CustomError } from '@trezor/blockchain-link-types/src/constants/errors';
 

--- a/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
@@ -1,5 +1,10 @@
-import { scheduleAction, arrayShuffle, urlToOnion, getWeakRandomInt } from '@trezor/utils';
-import { TypedEmitter } from '@trezor/utils';
+import {
+    scheduleAction,
+    arrayShuffle,
+    urlToOnion,
+    getWeakRandomInt,
+    TypedEmitter,
+} from '@trezor/utils';
 import type { BlockbookAPI } from '@trezor/blockchain-link/src/workers/blockbook/websocket';
 
 import { RequestOptions, resetIdentityCircuit } from '../utils/http';

--- a/packages/coinjoin/src/client/CoinjoinRound.ts
+++ b/packages/coinjoin/src/client/CoinjoinRound.ts
@@ -1,5 +1,4 @@
-import { TypedEmitter } from '@trezor/utils';
-import { scheduleAction, arrayDistinct, arrayPartition } from '@trezor/utils';
+import { TypedEmitter, scheduleAction, arrayDistinct, arrayPartition } from '@trezor/utils';
 import { Network } from '@trezor/utxo-lib';
 
 import {

--- a/packages/components/src/components/NewModal/NewModal.stories.tsx
+++ b/packages/components/src/components/NewModal/NewModal.stories.tsx
@@ -5,10 +5,11 @@ import {
     NewModal as ModalComponent,
     NewModalProps,
     variables,
+    intermediaryTheme,
+    IconCircle,
 } from '../../index';
 import { newModalVariants, newModalSizes } from './types';
 import { ThemeProvider } from 'styled-components';
-import { intermediaryTheme, IconCircle } from '../../index';
 import { getFramePropsStory } from '../../utils/frameProps';
 
 const Buttons = () => (

--- a/packages/components/src/components/typography/utils.tsx
+++ b/packages/components/src/components/typography/utils.tsx
@@ -1,8 +1,7 @@
 import { typography, TypographyStyle, typographyStyles } from '@trezor/theme';
-import { TransientProps } from '../../utils/transientProps';
+import { TransientProps, makePropsTransient } from '../../utils/transientProps';
 import { UIHorizontalAlignment, uiHorizontalAlignments } from '../../config/types';
 import { css } from 'styled-components';
-import { makePropsTransient } from '../../utils/transientProps';
 
 export const textWraps = ['balance', 'break-word'];
 export type TextWrap = (typeof textWraps)[number];

--- a/packages/components/src/utils/useScrollShadow.tsx
+++ b/packages/components/src/utils/useScrollShadow.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
-import styled, { CSSObject } from 'styled-components';
+import styled, { CSSObject, DefaultTheme } from 'styled-components';
 import { useElevation } from '../components/ElevationContext/ElevationContext';
 import { Color, Elevation, mapElevationToBackground } from '@trezor/theme';
-import { DefaultTheme } from 'styled-components';
 import { UIHorizontalAlignment, UIVerticalAlignment } from '../config/types';
 
 type GradientDirection = Exclude<UIHorizontalAlignment | UIVerticalAlignment, 'center'>;

--- a/packages/connect-common/src/messageChannel/abstract.ts
+++ b/packages/connect-common/src/messageChannel/abstract.ts
@@ -3,9 +3,7 @@
  * this file is bundled into content script so be careful what you are importing not to bloat the bundle
  */
 
-import { Deferred, createDeferred } from '@trezor/utils';
-import { TypedEmitter } from '@trezor/utils';
-import { scheduleAction } from '@trezor/utils';
+import { Deferred, createDeferred, TypedEmitter, scheduleAction } from '@trezor/utils';
 
 // TODO: so logger should be probably moved to connect common, or this file should be moved to connect
 // import type { Log } from '@trezor/connect/src/utils/debug';

--- a/packages/connect-explorer/src/pages/_app.tsx
+++ b/packages/connect-explorer/src/pages/_app.tsx
@@ -1,10 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { Provider } from 'react-redux';
 
-import { ThemeProvider as NextThemeProvider } from 'next-themes';
+import { ThemeProvider as NextThemeProvider, useTheme } from 'next-themes';
 import { ThemeProvider } from 'styled-components';
 import type { AppProps } from 'next/app';
-import { useTheme } from 'next-themes';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 

--- a/packages/connect-mobile/src/index.ts
+++ b/packages/connect-mobile/src/index.ts
@@ -4,8 +4,12 @@ import * as ERRORS from '@trezor/connect/src/constants/errors';
 import { parseConnectSettings } from '@trezor/connect/src/data/connectSettings';
 import type { CallMethodPayload } from '@trezor/connect/src/events/call';
 import { ConnectFactoryDependencies, factory } from '@trezor/connect/src/factory';
-import type { ConnectSettingsMobile } from '@trezor/connect/src/types';
-import type { ConnectSettings, Manifest, Response } from '@trezor/connect/src/types';
+import type {
+    ConnectSettingsMobile,
+    ConnectSettings,
+    Manifest,
+    Response,
+} from '@trezor/connect/src/types';
 import { Login } from '@trezor/connect/src/types/api/requestLogin';
 import { Deferred, createDeferred } from '@trezor/utils';
 import { InitFullSettings } from '@trezor/connect/src/types/api/init';

--- a/packages/connect/src/api/ethereum/ethereumDefinitions.ts
+++ b/packages/connect/src/api/ethereum/ethereumDefinitions.ts
@@ -1,8 +1,7 @@
 import fetch from 'cross-fetch';
 
-import { MessagesSchema } from '@trezor/protobuf';
+import { MessagesSchema, parseConfigure, decode as decodeProtobuf } from '@trezor/protobuf';
 import { trzd } from '@trezor/protocol';
-import { parseConfigure, decode as decodeProtobuf } from '@trezor/protobuf';
 import { DataManager } from '../../data/DataManager';
 import { EthereumNetworkInfo } from '../../types';
 import { ethereumNetworkInfoBase } from '../../data/coinInfo';

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -1,7 +1,7 @@
 import { storage } from '@trezor/connect-common';
 import { versionUtils } from '@trezor/utils';
 import { DataManager } from '../data/DataManager';
-import { NETWORK } from '../constants';
+import { NETWORK, ERRORS } from '../constants';
 import {
     UI,
     DEVICE,
@@ -16,7 +16,6 @@ import {
 import { getHost } from '../utils/urlUtils';
 import type { Device } from '../device/Device';
 import type { FirmwareRange, DeviceState, StaticSessionId, DeviceUniquePath } from '../types';
-import { ERRORS } from '../constants';
 
 export type Payload<M> = Extract<CallMethodPayload, { method: M }> & { override?: boolean };
 export type MethodReturnType<M extends CallMethodPayload['method']> = CallMethodResponse<M>;

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -2,8 +2,7 @@
 import EventEmitter from 'events';
 
 import { TRANSPORT, TRANSPORT_ERROR } from '@trezor/transport';
-import { createLazy, createDeferred, throwError } from '@trezor/utils';
-import { getSynchronize } from '@trezor/utils';
+import { createLazy, createDeferred, throwError, getSynchronize } from '@trezor/utils';
 import { storage } from '@trezor/connect-common';
 
 import { DataManager } from '../data/DataManager';

--- a/packages/connect/src/types/api/composeTransaction.ts
+++ b/packages/connect/src/types/api/composeTransaction.ts
@@ -9,10 +9,10 @@ import type {
     ComposeResultError as ComposeResultErrorBase,
     ComposeResultFinal as ComposeResultFinalBase,
     ComposeResultNonFinal as ComposeResultNonFinalBase,
+    TransactionInputOutputSortingStrategy,
 } from '@trezor/utxo-lib';
 import type { PROTO } from '../../constants';
 import type { Params, Response } from '../params';
-import type { TransactionInputOutputSortingStrategy } from '@trezor/utxo-lib';
 
 // for convenience ComposeOutput `type: "payment"` field is not required by @trezor/connect api
 export type ComposeOutputPayment = Omit<Extract<ComposeOutputBase, { type: 'payment' }>, 'type'> & {

--- a/packages/node-utils/src/http.ts
+++ b/packages/node-utils/src/http.ts
@@ -3,8 +3,7 @@ import * as net from 'net';
 import * as url from 'url';
 
 import type { RequiredKey } from '@trezor/type-utils';
-import { Log, TypedEmitter } from '@trezor/utils';
-import { arrayPartition } from '@trezor/utils';
+import { Log, TypedEmitter, arrayPartition } from '@trezor/utils';
 
 import { getFreePort } from './getFreePort';
 

--- a/packages/product-components/src/components/ConfirmOnDevice/ConfirmOnDeviceContent.tsx
+++ b/packages/product-components/src/components/ConfirmOnDevice/ConfirmOnDeviceContent.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import styled, { css, useTheme } from 'styled-components';
-import { Icon } from '@trezor/components';
+import { Icon, useElevation } from '@trezor/components';
 import { DeviceModelInternal } from '@trezor/connect';
 import {
     Elevation,
@@ -9,7 +9,6 @@ import {
     spacingsPx,
     typography,
 } from '@trezor/theme';
-import { useElevation } from '@trezor/components';
 import { RotateDeviceImage } from '../RotateDeviceImage/RotateDeviceImage';
 
 const Column = styled.div`

--- a/packages/product-components/src/components/RotateDeviceImage/RotateDeviceImage.tsx
+++ b/packages/product-components/src/components/RotateDeviceImage/RotateDeviceImage.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { DeviceAnimation } from '@trezor/components';
+import { DeviceAnimation, Image } from '@trezor/components';
 import { DeviceModelInternal } from '@trezor/connect';
-import { Image } from '@trezor/components';
 import styled from 'styled-components';
 
 export type RotateDeviceImageProps = {

--- a/packages/product-components/src/components/TokenIconSet/TokenIconSet.tsx
+++ b/packages/product-components/src/components/TokenIconSet/TokenIconSet.tsx
@@ -1,6 +1,5 @@
 import { AssetLogo, useElevation } from '@trezor/components';
-import { getCoingeckoId } from '@suite-common/wallet-config';
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import { getCoingeckoId, NetworkSymbol } from '@suite-common/wallet-config';
 import { TokenInfo } from '@trezor/connect';
 import { getContractAddressForNetwork } from '@suite-common/wallet-utils';
 

--- a/packages/suite-desktop-core/src/modules/index.ts
+++ b/packages/suite-desktop-core/src/modules/index.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 
-import { isNotUndefined } from '@trezor/utils';
-import { TypedEmitter } from '@trezor/utils';
+import { isNotUndefined, TypedEmitter } from '@trezor/utils';
 import { InterceptedEvent } from '@trezor/request-manager';
 import { isDevEnv } from '@suite-common/suite-utils';
 import type { HandshakeClient, TorStatus } from '@trezor/suite-desktop-api';

--- a/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
@@ -10,6 +10,7 @@ import {
     transactionsActions,
     createDiscoveryThunk,
     deviceActions,
+    prepareSendFormReducer,
 } from '@suite-common/wallet-core';
 import * as discoveryActions from '@suite-common/wallet-core';
 import { getAccountTransactions, getAccountIdentifier } from '@suite-common/wallet-utils';
@@ -18,7 +19,6 @@ import * as walletSettingsActions from 'src/actions/settings/walletSettingsActio
 import { accountsReducer, fiatRatesReducer, transactionsReducer } from 'src/reducers/wallet';
 import walletSettingsReducer from 'src/reducers/wallet/settingsReducer';
 import suiteReducer from 'src/reducers/suite/suiteReducer';
-import { prepareSendFormReducer } from '@suite-common/wallet-core';
 import graphReducer from 'src/reducers/wallet/graphReducer';
 import storageMiddleware from 'src/middlewares/wallet/storageMiddleware';
 import { coinjoinReducer } from 'src/reducers/wallet/coinjoinReducer';

--- a/packages/suite/src/actions/wallet/__tests__/blockchainActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/blockchainActions.test.ts
@@ -10,11 +10,11 @@ import {
     preloadFeeInfoThunk,
     setCustomBackendThunk,
     updateFeeInfoThunk,
+    feesReducer,
 } from '@suite-common/wallet-core';
 
 import { configureStore, filterThunkActionTypes } from 'src/support/tests/configureStore';
 import { accountsReducer, transactionsReducer, blockchainReducer } from 'src/reducers/wallet';
-import { feesReducer } from '@suite-common/wallet-core';
 
 import * as fixtures from '../__fixtures__/blockchainActions';
 

--- a/packages/suite/src/actions/wallet/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinClientActions.ts
@@ -13,7 +13,7 @@ import { arrayDistinct, arrayToDictionary, promiseAllSequence } from '@trezor/ut
 import { getOsName } from '@trezor/env-utils';
 import { selectAccountByKey, selectDevices } from '@suite-common/wallet-core';
 import { getUtxoOutpoint } from '@suite-common/wallet-utils';
-import { Account } from '@suite-common/wallet-types';
+import { Account, AddressDisplayOptions } from '@suite-common/wallet-types';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { getDeviceInstances } from '@suite-common/suite-utils';
 
@@ -35,7 +35,6 @@ import {
 } from 'src/reducers/wallet/coinjoinReducer';
 
 import * as COINJOIN from './constants/coinjoinConstants';
-import { AddressDisplayOptions } from '@suite-common/wallet-types';
 
 import { selectAddressDisplayType } from 'src/reducers/suite/suiteReducer';
 import { Feature, selectIsFeatureDisabled } from '@suite-common/message-system';

--- a/packages/suite/src/actions/wallet/coinmarket/coinmarketCommonActions.ts
+++ b/packages/suite/src/actions/wallet/coinmarket/coinmarketCommonActions.ts
@@ -8,7 +8,7 @@ import {
     hasNetworkFeatures,
     parseFormDraftKey,
 } from '@suite-common/wallet-utils';
-import { Output } from '@suite-common/wallet-types/src';
+import { Output, AddressDisplayOptions } from '@suite-common/wallet-types/src';
 import {
     confirmAddressOnDeviceThunk,
     selectDevice,
@@ -24,7 +24,6 @@ import {
 } from 'src/reducers/wallet/coinmarketReducer';
 import { submitRequestForm as envSubmitRequestForm } from 'src/utils/suite/env';
 import * as formDraftActions from 'src/actions/wallet/formDraftActions';
-import { AddressDisplayOptions } from '@suite-common/wallet-types';
 import { selectAddressDisplayType } from 'src/reducers/suite/suiteReducer';
 import { CryptoId } from 'invity-api';
 import {

--- a/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
@@ -18,12 +18,12 @@ import {
     PrecomposedTransaction,
     PrecomposedTransactionFinal,
     ExternalOutput,
+    AddressDisplayOptions,
 } from '@suite-common/wallet-types';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectDevice, ComposeActionContext } from '@suite-common/wallet-core';
 
 import { Dispatch, GetState } from 'src/types/suite';
 import { selectAddressDisplayType } from 'src/reducers/suite/suiteReducer';
-import { AddressDisplayOptions } from '@suite-common/wallet-types';
 
 import {
     getStakeTxGasLimit,
@@ -37,7 +37,6 @@ import {
     MIN_ETH_FOR_WITHDRAWALS,
 } from 'src/constants/suite/ethStaking';
 import { NetworkSymbol } from '@suite-common/wallet-config';
-import { ComposeActionContext } from '@suite-common/wallet-core';
 
 const calculate = (
     availableBalance: string,

--- a/packages/suite/src/components/suite/AccountLabel.tsx
+++ b/packages/suite/src/components/suite/AccountLabel.tsx
@@ -1,9 +1,8 @@
 import styled from 'styled-components';
 import { BadgeSize, Row, TOOLTIP_DELAY_LONG, TruncateWithTooltip } from '@trezor/components';
 import { spacings } from '@trezor/theme';
-import { AccountType, NetworkSymbol } from '@suite-common/wallet-config';
+import { AccountType, NetworkSymbol, Bip43Path, NetworkType } from '@suite-common/wallet-config';
 import { AccountTypeBadge } from './AccountTypeBadge';
-import { Bip43Path, NetworkType } from '@suite-common/wallet-config';
 import { useDefaultAccountLabel } from 'src/hooks/suite';
 
 const TabularNums = styled.span`

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/definitions.ts
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/definitions.ts
@@ -1,8 +1,7 @@
 import { ReactNode } from 'react';
 import { DropdownMenuItemProps } from '@trezor/components';
 import { MetadataAddPayload } from 'src/types/suite/metadata';
-import { AccountType, Bip43Path } from '@suite-common/wallet-config';
-import { NetworkType } from '@suite-common/wallet-config';
+import { AccountType, Bip43Path, NetworkType } from '@suite-common/wallet-config';
 
 export interface Props {
     accountType?: AccountType;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountDetails.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountDetails.tsx
@@ -1,9 +1,8 @@
 import { useState, useEffect } from 'react';
 import styled, { keyframes } from 'styled-components';
 import { Account } from '@suite-common/wallet-types';
-import { spacingsPx, zIndices } from '@trezor/theme';
+import { spacingsPx, zIndices, typography } from '@trezor/theme';
 import { H2 } from '@trezor/components';
-import { typography } from '@trezor/theme';
 import {
     MetadataLabeling,
     AccountLabel,

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModal.tsx
@@ -1,10 +1,8 @@
 import { UserContextPayload } from '@suite-common/suite-types';
-import { selectStake } from '@suite-common/wallet-core';
+import { selectStake, cancelSignSendFormTransactionThunk } from '@suite-common/wallet-core';
 import { cancelSignTx as cancelSignStakingTx } from 'src/actions/wallet/stakeActions';
 import { TransactionReviewModalContent } from './TransactionReviewModalContent';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-
-import { cancelSignSendFormTransactionThunk } from '@suite-common/wallet-core';
 
 // This modal is opened either in Device (button request) or User (push tx) context
 // contexts are distinguished by `type` prop

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
@@ -9,10 +9,10 @@ import {
     selectSendFormReviewButtonRequestsCount,
     selectStakePrecomposedForm,
     StakeState,
+    SendState,
 } from '@suite-common/wallet-core';
 import { FormState, StakeFormState } from '@suite-common/wallet-types';
 import { constructTransactionReviewOutputs, isRbfTransaction } from '@suite-common/wallet-utils';
-import { SendState } from '@suite-common/wallet-core';
 import { useSelector } from 'src/hooks/suite';
 import { selectIsActionAbortable } from 'src/reducers/suite/suiteReducer';
 import { getTransactionReviewModalActionText } from 'src/utils/suite/transactionReview';

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
@@ -4,7 +4,7 @@ import { Translation } from 'src/components/suite';
 import { formatNetworkAmount, formatAmount, isTestnet } from '@suite-common/wallet-utils';
 import { BTC_LOCKTIME_VALUE } from '@suite-common/wallet-constants';
 import { NetworkSymbol } from '@suite-common/wallet-config';
-import { ReviewOutput } from '@suite-common/wallet-types';
+import { ReviewOutput, StakeType } from '@suite-common/wallet-types';
 import {
     TransactionReviewStepIndicator,
     TransactionReviewStepIndicatorProps,
@@ -14,7 +14,6 @@ import {
     OutputElementLine,
 } from './TransactionReviewOutputElement';
 import type { Account } from 'src/types/wallet';
-import { StakeType } from '@suite-common/wallet-types';
 import { useDisplayMode, useTranslation } from 'src/hooks/suite';
 import { TranslationKey } from '@suite-common/intl-types';
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
@@ -14,9 +14,8 @@ import type { Account } from 'src/types/wallet';
 import type { FormState, GeneralPrecomposedTransactionFinal } from '@suite-common/wallet-types';
 import { getTransactionReviewOutputState } from '@suite-common/wallet-utils';
 import { TransactionReviewTotalOutput } from './TransactionReviewTotalOutput';
-import { ReviewOutput } from '@suite-common/wallet-types';
+import { ReviewOutput, StakeFormState, StakeType } from '@suite-common/wallet-types';
 import { spacingsPx } from '@trezor/theme';
-import { StakeFormState, StakeType } from '@suite-common/wallet-types';
 
 const Content = styled.div`
     display: flex;

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
@@ -1,16 +1,18 @@
 import { forwardRef } from 'react';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
-import { formatAmount, formatNetworkAmount, isTestnet } from '@suite-common/wallet-utils';
-import { selectDevice } from '@suite-common/wallet-core';
-import { TrezorDevice } from 'src/types/suite';
-import { Translation } from 'src/components/suite/Translation';
-import { useSelector } from 'src/hooks/suite/useSelector';
 import {
+    formatAmount,
+    formatNetworkAmount,
+    isTestnet,
     getTransactionReviewOutputState,
     getIsUpdatedSendFlow,
     getIsUpdatedEthereumSendFlow,
 } from '@suite-common/wallet-utils';
+import { selectDevice } from '@suite-common/wallet-core';
+import { TrezorDevice } from 'src/types/suite';
+import { Translation } from 'src/components/suite/Translation';
+import { useSelector } from 'src/hooks/suite/useSelector';
 import { TransactionReviewStepIndicator } from './TransactionReviewStepIndicator';
 import {
     TransactionReviewOutputElement,

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
@@ -7,11 +7,10 @@ import { borders, spacingsPx, typography } from '@trezor/theme';
 import { TranslationKey } from '@suite-common/intl-types';
 import { Translation, FormattedCryptoAmount, AccountLabel } from 'src/components/suite';
 import { Account } from 'src/types/wallet';
-import { Network } from '@suite-common/wallet-config';
+import { Network, NetworkType } from '@suite-common/wallet-config';
 import { GeneralPrecomposedTransactionFinal, StakeType } from '@suite-common/wallet-types';
 import { useSelector } from 'src/hooks/suite/useSelector';
 import { selectLabelingDataForSelectedAccount } from 'src/reducers/suite/metadataReducer';
-import { NetworkType } from '@suite-common/wallet-config';
 import { CoinLogo } from '@trezor/product-components';
 
 const Wrapper = styled.div`

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeDescription.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeDescription.tsx
@@ -1,5 +1,5 @@
-import { Paragraph } from '@trezor/components';
-import { Bip43PathTemplate } from '@suite-common/wallet-config';
+import { Paragraph, Column } from '@trezor/components';
+import { Bip43PathTemplate, AccountType, NetworkType } from '@suite-common/wallet-config';
 import { Translation } from 'src/components/suite';
 import {
     getAccountTypeDesc,
@@ -7,10 +7,7 @@ import {
     getTitleForNetwork,
 } from '@suite-common/wallet-utils';
 import { LearnMoreButton } from 'src/components/suite/LearnMoreButton';
-import { AccountType } from '@suite-common/wallet-config';
-import { NetworkType } from '@suite-common/wallet-config';
 import { useTranslation } from 'src/hooks/suite';
-import { Column } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 import { Account } from '@suite-common/wallet-types';
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/instructionSteps.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/instructionSteps.tsx
@@ -1,7 +1,6 @@
-import { Row } from '@trezor/components';
+import { Row, Image, Text } from '@trezor/components';
 import styled from 'styled-components';
 
-import { Image, Text } from '@trezor/components';
 import { borders, spacings, spacingsPx } from '@trezor/theme';
 import { ESHOP_KEEP_METAL_SINGLE_SHARE_URL, HELP_CENTER_SEED_CARD_URL } from '@trezor/urls';
 

--- a/packages/suite/src/components/wallet/AccountExceptionLayout.tsx
+++ b/packages/suite/src/components/wallet/AccountExceptionLayout.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 import {
     H2,
     Button,
@@ -13,7 +13,6 @@ import {
     IconCircleVariant,
 } from '@trezor/components';
 import { spacings } from '@trezor/theme';
-import React from 'react';
 
 interface AccountExceptionLayoutProps {
     title: ReactNode;

--- a/packages/suite/src/components/wallet/Fees/CustomFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/CustomFee.tsx
@@ -9,12 +9,18 @@ import {
     UseFormReturn,
     UseFormSetValue,
 } from 'react-hook-form';
-import { Note, Banner, motionEasing, variables, Icon } from '@trezor/components';
+import {
+    Note,
+    Banner,
+    motionEasing,
+    variables,
+    Icon,
+    getInputStateTextColor,
+} from '@trezor/components';
 import { Translation } from 'src/components/suite';
 import { NumberInput } from 'src/components/suite/NumberInput';
 import { getInputState, getFeeUnits, isInteger } from '@suite-common/wallet-utils';
-import { FeeInfo } from '@suite-common/wallet-types';
-import { FormState } from '@suite-common/wallet-types';
+import { FeeInfo, FormState } from '@suite-common/wallet-types';
 import { NetworkType } from '@suite-common/wallet-config';
 import { useTranslation } from 'src/hooks/suite';
 import { InputError } from '../InputError';
@@ -24,7 +30,6 @@ import { BottomText } from '@trezor/components/src/components/form/BottomText';
 import { spacings, spacingsPx } from '@trezor/theme';
 import { HELP_CENTER_TRANSACTION_FEES_URL } from '@trezor/urls';
 import { LearnMoreButton } from 'src/components/suite/LearnMoreButton';
-import { getInputStateTextColor } from '@trezor/components';
 
 const Wrapper = styled.div`
     display: flex;

--- a/packages/suite/src/components/wallet/Fees/Fees.tsx
+++ b/packages/suite/src/components/wallet/Fees/Fees.tsx
@@ -9,18 +9,18 @@ import {
     UseFormSetValue,
 } from 'react-hook-form';
 import { Icon, Paragraph, SelectBar, Tooltip, motionEasing, variables } from '@trezor/components';
-import { FormState } from '@suite-common/wallet-types';
-import { spacingsPx, typography } from '@trezor/theme';
-import { FiatValue, FormattedCryptoAmount, Translation } from 'src/components/suite';
-import { formatNetworkAmount } from '@suite-common/wallet-utils';
-import { Account } from 'src/types/wallet';
-import { ExtendedMessageDescriptor } from 'src/types/suite';
 import {
+    FormState,
     FeeInfo,
     PrecomposedLevels,
     PrecomposedLevelsCardano,
     PrecomposedTransactionFinal,
 } from '@suite-common/wallet-types';
+import { spacingsPx, typography } from '@trezor/theme';
+import { FiatValue, FormattedCryptoAmount, Translation } from 'src/components/suite';
+import { formatNetworkAmount } from '@suite-common/wallet-utils';
+import { Account } from 'src/types/wallet';
+import { ExtendedMessageDescriptor } from 'src/types/suite';
 import { CustomFee } from './CustomFee';
 import { FeeDetails } from './FeeDetails';
 import { AnimatePresence, motion } from 'framer-motion';

--- a/packages/suite/src/components/wallet/FiatHeader.tsx
+++ b/packages/suite/src/components/wallet/FiatHeader.tsx
@@ -1,8 +1,7 @@
 import { useFormatters } from '@suite-common/formatters';
 import { typography } from '@trezor/theme';
 import { useShouldRedactNumbers } from '@suite-common/wallet-utils';
-import { HiddenPlaceholder } from 'src/components/suite';
-import { RedactNumericalValue } from 'src/components/suite';
+import { HiddenPlaceholder, RedactNumericalValue } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
 import { selectLanguage } from 'src/reducers/suite/suiteReducer';
 import { PropsWithChildren } from 'react';

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
@@ -2,7 +2,7 @@ import { memo, useMemo, useState } from 'react';
 import styled, { css } from 'styled-components';
 import { AnimatePresence } from 'framer-motion';
 import { selectIsPhishingTransaction } from '@suite-common/wallet-core';
-import { variables, Button, Card, Link } from '@trezor/components';
+import { variables, Button, Card, Link, Tooltip } from '@trezor/components';
 import { Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { openModal } from 'src/actions/suite/modalActions';
@@ -35,7 +35,6 @@ import { BlurWrapper } from './TransactionItemBlurWrapper';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 import { getInstantStakeType } from 'src/utils/suite/stake';
 import { isStakeTypeTx } from '@suite-common/suite-utils';
-import { Tooltip } from '@trezor/components';
 import { HELP_CENTER_REPLACE_BY_FEE } from '@trezor/urls';
 
 // eslint-disable-next-line local-rules/no-override-ds-component

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakeEthBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakeEthBanner.tsx
@@ -6,8 +6,10 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 import { setFlag } from 'src/actions/suite/suiteActions';
 import { selectSuiteFlags } from '../../../../reducers/suite/suiteReducer';
 import { Account } from '@suite-common/wallet-types';
-import { selectPoolStatsApyData } from '@suite-common/wallet-core';
-import { isSupportedEthStakingNetworkSymbol } from '@suite-common/wallet-core';
+import {
+    selectPoolStatsApyData,
+    isSupportedEthStakingNetworkSymbol,
+} from '@suite-common/wallet-core';
 import { MIN_ETH_AMOUNT_FOR_STAKING } from 'src/constants/suite/ethStaking';
 import { useTheme } from 'styled-components';
 

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
@@ -1,6 +1,11 @@
 import { sortByCoin, getFailedAccounts, accountSearchFn } from '@suite-common/wallet-utils';
 import { Account } from '@suite-common/wallet-types';
-import { useAccountSearch, useDiscovery, useSelector } from 'src/hooks/suite';
+import {
+    useAccountSearch,
+    useDiscovery,
+    useSelector,
+    useDefaultAccountLabel,
+} from 'src/hooks/suite';
 import { selectAccounts, selectDevice } from '@suite-common/wallet-core';
 import { selectAccountLabels } from 'src/reducers/suite/metadataReducer';
 import { Translation } from 'src/components/suite';
@@ -10,7 +15,6 @@ import { AccountsMenuNotice } from './AccountsMenuNotice';
 import { spacings } from '@trezor/theme';
 import { Column } from '@trezor/components';
 import { AccountSection } from './AcccountSection';
-import { useDefaultAccountLabel } from 'src/hooks/suite';
 
 interface AccountListProps {
     onItemClick?: () => void;

--- a/packages/suite/src/hooks/suite/useDisplayMode.ts
+++ b/packages/suite/src/hooks/suite/useDisplayMode.ts
@@ -1,10 +1,9 @@
 import { selectDeviceUnavailableCapabilities } from '@suite-common/wallet-core';
-import { AddressDisplayOptions } from '@suite-common/wallet-types';
+import { AddressDisplayOptions, StakeType, ReviewOutput } from '@suite-common/wallet-types';
 
 import { selectAddressDisplayType } from 'src/reducers/suite/suiteReducer';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 import { useSelector } from './useSelector';
-import { StakeType, ReviewOutput } from '@suite-common/wallet-types';
 import { DisplayMode } from 'src/types/suite';
 
 type UseDisplayModeProps = {

--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -2,12 +2,10 @@ import { combineReducers, createReducer } from '@reduxjs/toolkit';
 
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { DEFAULT_PAYMENT, DEFAULT_VALUES } from '@suite-common/wallet-constants';
-import { accountsActions } from '@suite-common/wallet-core';
+import { accountsActions, prepareSendFormReducer } from '@suite-common/wallet-core';
 import { PROTO } from '@trezor/connect';
 import { testMocks } from '@suite-common/test-utils';
 import { extraDependencies } from 'src/support/extraDependencies';
-
-import { prepareSendFormReducer } from '@suite-common/wallet-core';
 
 const sendFormReducer = prepareSendFormReducer(extraDependencies);
 

--- a/packages/suite/src/hooks/wallet/useRbfForm.ts
+++ b/packages/suite/src/hooks/wallet/useRbfForm.ts
@@ -10,8 +10,9 @@ import {
     Account,
     RbfTransactionParams,
     ChainedTransactions,
+    FormState,
+    FeeInfo,
 } from '@suite-common/wallet-types';
-import { FormState, FeeInfo } from '@suite-common/wallet-types';
 import { useFees } from './form/useFees';
 import { useCompose } from './form/useCompose';
 import { selectCurrentTargetAnonymity } from 'src/reducers/wallet/coinjoinReducer';

--- a/packages/suite/src/hooks/wallet/useSendFormFields.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormFields.ts
@@ -1,9 +1,8 @@
 import { useCallback } from 'react';
 import { FieldPath, UseFormReturn } from 'react-hook-form';
 import { formatNetworkAmount, getFiatRateKey, toFiatCurrency } from '@suite-common/wallet-utils';
-import { FormState, FormOptions, TokenAddress } from '@suite-common/wallet-types';
+import { FormState, FormOptions, TokenAddress, Rate } from '@suite-common/wallet-types';
 import { useBitcoinAmountUnit } from './useBitcoinAmountUnit';
-import { Rate } from '@suite-common/wallet-types';
 import { SendContextValues, UseSendFormState } from 'src/types/wallet/sendForm';
 import { FiatCurrencyCode } from '@suite-common/suite-config';
 import { selectCurrentFiatRates } from '@suite-common/wallet-core';

--- a/packages/suite/src/middlewares/wallet/__fixtures__/walletMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/__fixtures__/walletMiddleware.ts
@@ -1,11 +1,13 @@
 import { PROTO } from '@trezor/connect';
-import { Account } from '@suite-common/wallet-types';
-import { FormState as SendFormState, Output } from '@suite-common/wallet-types';
+import { Account, FormState as SendFormState, Output } from '@suite-common/wallet-types';
 import { WALLET_SETTINGS } from 'src/actions/settings/constants';
 import { RouterState } from 'src/reducers/suite/routerReducer';
 import { State as SelectedAccountState } from 'src/reducers/wallet/selectedAccountReducer';
-import { accountsActions, sendFormActions } from '@suite-common/wallet-core';
-import { convertSendFormDraftsBtcAmountUnitsThunk } from '@suite-common/wallet-core';
+import {
+    accountsActions,
+    sendFormActions,
+    convertSendFormDraftsBtcAmountUnitsThunk,
+} from '@suite-common/wallet-core';
 
 export const blockchainSubscription = [
     {

--- a/packages/suite/src/middlewares/wallet/__tests__/walletMiddleware.test.ts
+++ b/packages/suite/src/middlewares/wallet/__tests__/walletMiddleware.test.ts
@@ -1,5 +1,9 @@
 import { testMocks } from '@suite-common/test-utils';
-import { prepareBlockchainMiddleware } from '@suite-common/wallet-core';
+import {
+    prepareBlockchainMiddleware,
+    prepareSendFormReducer,
+    SendState,
+} from '@suite-common/wallet-core';
 
 import walletSettingsReducer from 'src/reducers/wallet/settingsReducer';
 import walletMiddleware from 'src/middlewares/wallet/walletMiddleware';
@@ -8,7 +12,6 @@ import { configureStore } from 'src/support/tests/configureStore';
 import selectedAccountReducer, {
     State as SelectedAccountState,
 } from 'src/reducers/wallet/selectedAccountReducer';
-import { prepareSendFormReducer, SendState } from '@suite-common/wallet-core';
 import formDraftReducer from 'src/reducers/wallet/formDraftReducer';
 import { RouterState } from 'src/reducers/suite/routerReducer';
 import { Action } from 'src/types/suite';

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -15,6 +15,7 @@ import {
     selectHistoricFiatRates,
     updateTxsFiatRatesThunk,
     selectDeviceByStaticSessionId,
+    sendFormActions,
 } from '@suite-common/wallet-core';
 import { isDeviceRemembered } from '@suite-common/suite-utils';
 import { messageSystemActions } from '@suite-common/message-system';
@@ -32,7 +33,6 @@ import * as metadataActions from 'src/actions/suite/metadataActions';
 import { serializeDiscovery } from 'src/utils/suite/storage';
 import type { AppState, Action as SuiteAction, Dispatch } from 'src/types/suite';
 import type { WalletAction } from 'src/types/wallet';
-import { sendFormActions } from '@suite-common/wallet-core';
 import { tokenDefinitionsActions } from '@suite-common/token-definitions/src/tokenDefinitionsActions';
 import { TokenManagementAction } from '@suite-common/token-definitions';
 

--- a/packages/suite/src/middlewares/wallet/walletMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/walletMiddleware.ts
@@ -10,14 +10,14 @@ import {
     unsubscribeBlockchainThunk,
     deviceActions,
     stakeActions,
+    sendFormActions,
+    convertSendFormDraftsBtcAmountUnitsThunk,
 } from '@suite-common/wallet-core';
 import { getTxsPerPage } from '@suite-common/suite-utils';
 
 import { ROUTER } from 'src/actions/suite/constants';
 import { WALLET_SETTINGS } from 'src/actions/settings/constants';
 import * as selectedAccountActions from 'src/actions/wallet/selectedAccountActions';
-import { sendFormActions } from '@suite-common/wallet-core';
-import { convertSendFormDraftsBtcAmountUnitsThunk } from '@suite-common/wallet-core';
 import * as receiveActions from 'src/actions/wallet/receiveActions';
 import * as cardanoStakingActions from 'src/actions/wallet/cardanoStakingActions';
 import * as coinmarketCommonActions from 'src/actions/wallet/coinmarket/coinmarketCommonActions';

--- a/packages/suite/src/reducers/wallet/__tests__/sendFormReducer.test.ts
+++ b/packages/suite/src/reducers/wallet/__tests__/sendFormReducer.test.ts
@@ -1,10 +1,13 @@
 import { STORAGE } from 'src/actions/suite/constants';
 import { Action } from 'src/types/suite';
-import { FormState, PrecomposedTransactionFinal } from '@suite-common/wallet-types';
-import { SerializedTx, accountsActions } from '@suite-common/wallet-core';
-import { prepareSendFormReducer, initialState, sendFormActions } from '@suite-common/wallet-core';
-
-import { Account } from '@suite-common/wallet-types';
+import { FormState, PrecomposedTransactionFinal, Account } from '@suite-common/wallet-types';
+import {
+    SerializedTx,
+    accountsActions,
+    prepareSendFormReducer,
+    initialState,
+    sendFormActions,
+} from '@suite-common/wallet-core';
 
 import { PreloadStoreAction } from 'src/support/suite/preloadStore';
 import { extraDependencies } from 'src/support/extraDependencies';

--- a/packages/suite/src/storage/definitions.ts
+++ b/packages/suite/src/storage/definitions.ts
@@ -2,7 +2,12 @@ import type { DBSchema } from 'idb';
 import { FieldValues } from 'react-hook-form';
 
 import type { SuiteState } from 'src/reducers/suite/suiteReducer';
-import type { FormState, RatesByTimestamps } from '@suite-common/wallet-types';
+import type {
+    FormState,
+    RatesByTimestamps,
+    BackendSettings,
+    WalletSettings,
+} from '@suite-common/wallet-types';
 import type { MetadataState } from 'src/types/suite/metadata';
 import type { Trade } from 'src/types/wallet/coinmarketCommonTypes';
 import type { MessageState } from '@suite-common/message-system';
@@ -10,7 +15,6 @@ import type { DeviceWithEmptyPath, MessageSystem } from '@suite-common/suite-typ
 import type { Account, Discovery, WalletAccountTransaction } from 'src/types/wallet';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import type { CoinjoinAccount, CoinjoinDebugSettings } from 'src/types/wallet/coinjoin';
-import type { BackendSettings, WalletSettings } from '@suite-common/wallet-types';
 import type { StorageUpdateMessage } from '@trezor/suite-storage';
 import { AnalyticsState } from '@suite-common/analytics';
 import { GraphData } from '../types/wallet/graph';

--- a/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
@@ -13,7 +13,11 @@ import regional from 'src/constants/wallet/coinmarket/regional';
 import { ExtendedMessageDescriptor, TrezorDevice } from 'src/types/suite';
 import { BuyTrade, SellFiatTrade, CryptoId } from 'invity-api';
 import { DefinitionType, isTokenDefinitionKnown } from '@suite-common/token-definitions';
-import { getContractAddressForNetwork, substituteBip43Path } from '@suite-common/wallet-utils';
+import {
+    getContractAddressForNetwork,
+    substituteBip43Path,
+    sortByCoin,
+} from '@suite-common/wallet-utils';
 import {
     CoinmarketAccountOptionsGroupOptionProps,
     CoinmarketAccountsOptionsGroupProps,
@@ -29,7 +33,6 @@ import {
 } from 'src/types/coinmarket/coinmarket';
 import { v4 as uuidv4 } from 'uuid';
 import { BigNumber } from '@trezor/utils';
-import { sortByCoin } from '@suite-common/wallet-utils';
 
 export const cryptoPlatformSeparator = '--';
 

--- a/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
+++ b/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
@@ -4,7 +4,7 @@ import { fromWei } from 'web3-utils';
 
 import { FiatCurrencyCode } from '@suite-common/suite-config';
 import { trezorLogo } from '@suite-common/suite-constants';
-import { TokenDefinitions } from '@suite-common/token-definitions';
+import { TokenDefinitions, getIsPhishingTransaction } from '@suite-common/token-definitions';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import {
     ExportFileType,
@@ -25,8 +25,6 @@ import {
     localizeNumber,
     roundTimestampToNearestPastHour,
 } from '@suite-common/wallet-utils';
-
-import { getIsPhishingTransaction } from '@suite-common/token-definitions';
 
 type AccountTransactionForExports = Omit<WalletAccountTransaction, 'targets'> & {
     targets: (TransactionTarget & { metadataLabel?: string })[];

--- a/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRow.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRow.tsx
@@ -1,7 +1,7 @@
 import { memo } from 'react';
 import { useTheme } from 'styled-components';
 import { Network } from '@suite-common/wallet-config';
-import { Icon, Table, Row, IconButton, Column } from '@trezor/components';
+import { Icon, Table, Row, IconButton, Column, Text } from '@trezor/components';
 import {
     AmountUnitSwitchWrapper,
     CoinBalance,
@@ -18,7 +18,6 @@ import { AssetFiatBalance } from '@suite-common/assets';
 import { AssetCoinLogo } from '../AssetCoinLogo';
 import { AssetCoinName } from '../AssetCoinName';
 import { CoinmarketBuyButton } from '../CoinmarketBuyButton';
-import { Text } from '@trezor/components';
 
 interface AssetTableProps {
     network: Network;

--- a/packages/suite/src/views/dashboard/PortfolioCard/EmptyWallet.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/EmptyWallet.tsx
@@ -4,10 +4,12 @@ import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
 import { useSelector, useDispatch } from 'src/hooks/suite';
-import { selectIsDeviceUsingPassphrase } from '@suite-common/wallet-core';
+import {
+    selectIsDeviceUsingPassphrase,
+    selectDeviceSupportedNetworks,
+} from '@suite-common/wallet-core';
 import { goto } from 'src/actions/suite/routerActions';
 import { useEnabledNetworks } from 'src/hooks/settings/useEnabledNetworks';
-import { selectDeviceSupportedNetworks } from '@suite-common/wallet-core';
 
 export const EmptyWallet = () => {
     const { enabledNetworks, mainnets } = useEnabledNetworks();

--- a/packages/suite/src/views/recovery/index.tsx
+++ b/packages/suite/src/views/recovery/index.tsx
@@ -80,7 +80,7 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
             device?.features?.capabilities?.includes('Capability_Shamir');
 
         switch (recovery.status) {
-            case 'initial':
+            case 'initial': {
                 const descriptionSuffix = isDeviceWithButtons(deviceModelInternal)
                     ? getNarrowedDeviceModelInternal(deviceModelInternal)
                     : 'TOUCHSCREEN';
@@ -143,6 +143,7 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
                         </Card>
                     </>
                 );
+            }
             case 'select-word-count':
                 return (
                     <>

--- a/packages/suite/src/views/settings/SettingsDebug/Backends.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/Backends.tsx
@@ -2,13 +2,12 @@ import styled from 'styled-components';
 
 import { typography } from '@trezor/theme';
 import { Button } from '@trezor/components';
-import { networks } from '@suite-common/wallet-config';
+import { networks, NetworkSymbol } from '@suite-common/wallet-config';
 import { ConnectionStatus } from '@suite-common/wallet-types';
 
 import { SectionItem, StatusLight, Translation } from 'src/components/suite';
 import { useEnabledNetworks } from 'src/hooks/settings/useEnabledNetworks';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { NetworkSymbol } from '@suite-common/wallet-config';
 import { selectNetworkBlockchainInfo } from '@suite-common/wallet-core';
 import { useBackendReconnection } from 'src/hooks/settings/backends';
 import { openModal } from 'src/actions/suite/modalActions';

--- a/packages/suite/src/views/settings/SettingsDevice/Brightness.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/Brightness.tsx
@@ -1,7 +1,12 @@
 import TrezorConnect from '@trezor/connect';
 import { analytics, EventType } from '@trezor/suite-analytics';
-import { SectionItem } from 'src/components/suite';
-import { ActionButton, ActionColumn, TextColumn, Translation } from 'src/components/suite';
+import {
+    SectionItem,
+    ActionButton,
+    ActionColumn,
+    TextColumn,
+    Translation,
+} from 'src/components/suite';
 import { useDevice } from '../../../hooks/suite';
 
 interface DeviceLabelProps {

--- a/packages/suite/src/views/settings/SettingsGeneral/TorSnowflake.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/TorSnowflake.tsx
@@ -1,6 +1,6 @@
 import { ChangeEventHandler, useEffect, useState } from 'react';
 import styled from 'styled-components';
-import { useSelector } from 'src/hooks/suite';
+import { useSelector, useTranslation } from 'src/hooks/suite';
 import { selectTorState } from 'src/reducers/suite/suiteReducer';
 import { TorSettings } from '@trezor/suite-desktop-api/src/messages';
 import { TOR_SNOWFLAKE_KB_URL } from '@trezor/urls';
@@ -11,7 +11,6 @@ import { isFullPath } from '@trezor/utils';
 import { spacingsPx } from '@trezor/theme';
 
 import { ActionColumn, SectionItem, TextColumn, Translation } from 'src/components/suite';
-import { useTranslation } from 'src/hooks/suite';
 
 const Container = styled.div`
     display: flex;

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx
@@ -2,13 +2,12 @@ import styled from 'styled-components';
 import { variables, Column } from '@trezor/components';
 import * as deviceUtils from '@suite-common/suite-utils';
 
-import { selectDevice, selectDeviceThunk } from '@suite-common/wallet-core';
+import { selectDevice, selectDeviceThunk, acquireDevice } from '@suite-common/wallet-core';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 import { WalletInstance } from './WalletInstance';
 import { AddWalletButton } from './AddWalletButton';
 
-import { acquireDevice } from '@suite-common/wallet-core';
 import type { TrezorDevice, AcquiredDevice, ForegroundAppProps } from 'src/types/suite';
 import { spacings } from '@trezor/theme';
 import { CardWithDevice } from '../CardWithDevice';

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormOffer.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormOffer.tsx
@@ -1,5 +1,5 @@
 import { Button, TextButton } from '@trezor/components';
-import { CryptoId } from 'invity-api';
+import { CryptoId, ExchangeTrade } from 'invity-api';
 import styled from 'styled-components';
 import { spacings, spacingsPx, typography } from '@trezor/theme';
 import { useCoinmarketFormContext } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonForm';
@@ -27,7 +27,6 @@ import {
     parseCryptoId,
 } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import { CoinmarketFormOfferFiatAmount } from 'src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormOfferFiatAmount';
-import { ExchangeTrade } from 'invity-api';
 import { CoinmarketTradeDetailType, CoinmarketTradeType } from 'src/types/coinmarket/coinmarket';
 import { CoinmarketFormContextValues } from 'src/types/coinmarket/coinmarketForm';
 import { FORM_EXCHANGE_DEX, FORM_EXCHANGE_TYPE } from 'src/constants/wallet/coinmarket/form';

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketOfferExchange/CoinmarketOfferExchangeSendSwap.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketOfferExchange/CoinmarketOfferExchangeSendSwap.tsx
@@ -10,6 +10,7 @@ import {
     SelectBar,
     Tooltip,
     variables,
+    getInputStateTextColor,
 } from '@trezor/components';
 import useDebounce from 'react-use/lib/useDebounce';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
@@ -19,7 +20,6 @@ import { TranslationKey } from '@suite-common/intl-types';
 import { spacings, spacingsPx } from '@trezor/theme';
 import { useCoinmarketFormContext } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonForm';
 import { CoinmarketTradeExchangeType } from 'src/types/coinmarket/coinmarket';
-import { getInputStateTextColor } from '@trezor/components';
 import { useCoinmarketInfo } from 'src/hooks/wallet/coinmarket/useCoinmarketInfo';
 
 const Wrapper = styled.div`

--- a/packages/suite/src/views/wallet/send/Outputs/Address.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Address.tsx
@@ -2,14 +2,22 @@ import { useCallback, useState } from 'react';
 import { checkAddressCheckSum, toChecksumAddress } from 'web3-utils';
 import styled, { useTheme } from 'styled-components';
 
-import { Input, Button, IconButton, getInputStateTextColor, Icon } from '@trezor/components';
+import {
+    Input,
+    Button,
+    IconButton,
+    getInputStateTextColor,
+    Icon,
+    Link,
+    Row,
+} from '@trezor/components';
 import { capitalizeFirstLetter } from '@trezor/utils';
 import * as URLS from '@trezor/urls';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { formInputsMaxLength } from '@suite-common/validators';
 import type { Output } from '@suite-common/wallet-types';
 import TrezorConnect from '@trezor/connect';
-import { useSelector } from 'src/hooks/suite';
+import { useSelector, useDevice, useDispatch, useTranslation } from 'src/hooks/suite';
 import {
     isAddressValid,
     isAddressDeprecated,
@@ -19,18 +27,15 @@ import {
 } from '@suite-common/wallet-utils';
 
 import { AddressLabeling, MetadataLabeling } from 'src/components/suite';
-import { Link } from '@trezor/components';
 import { Translation } from '../../../../components/suite/Translation';
 
 import { scanOrRequestSendFormThunk } from 'src/actions/wallet/send/sendFormThunks';
-import { useDevice, useDispatch, useTranslation } from 'src/hooks/suite';
 import { useSendFormContext } from 'src/hooks/wallet';
 import { getProtocolInfo } from 'src/utils/suite/protocol';
 import { getNetworkSymbolForProtocol } from '@suite-common/suite-utils';
 
 import { InputError } from 'src/components/wallet';
 import { InputErrorProps } from 'src/components/wallet/InputError';
-import { Row } from '@trezor/components';
 
 import { HELP_CENTER_EVM_ADDRESS_CHECKSUM } from '@trezor/urls';
 import { spacings } from '@trezor/theme';

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/FiatInput.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/FiatInput.tsx
@@ -1,5 +1,11 @@
 import { useCallback } from 'react';
-import { Timestamp, TokenAddress, FiatRatesResult } from '@suite-common/wallet-types';
+import {
+    Timestamp,
+    TokenAddress,
+    FiatRatesResult,
+    CurrencyOption,
+    Output,
+} from '@suite-common/wallet-types';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 import styled from 'styled-components';
 import { Controller } from 'react-hook-form';
@@ -16,7 +22,6 @@ import {
     buildCurrencyOptions,
     getFiatRateKey,
 } from '@suite-common/wallet-utils';
-import { CurrencyOption, Output } from '@suite-common/wallet-types';
 import { formInputsMaxLength } from '@suite-common/validators';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 import { NumberInput } from 'src/components/suite';

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/TokenSelect.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/TokenSelect.tsx
@@ -4,10 +4,9 @@ import { Select } from '@trezor/components';
 import styled from 'styled-components';
 import { useSendFormContext } from 'src/hooks/wallet';
 import { Account } from 'src/types/wallet';
-import { Output } from '@suite-common/wallet-types';
+import { Output, Timestamp, TokenAddress } from '@suite-common/wallet-types';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { updateFiatRatesThunk, selectCurrentFiatRates } from '@suite-common/wallet-core';
-import { Timestamp, TokenAddress } from '@suite-common/wallet-types';
 import { TooltipSymbol, Translation } from 'src/components/suite';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import {

--- a/packages/transport/src/sessions/background.ts
+++ b/packages/transport/src/sessions/background.ts
@@ -9,8 +9,7 @@
  * - we can say we trust the caller but not really thats why we implement auto-unlock
  */
 
-import { createDeferred, Deferred } from '@trezor/utils';
-import { TypedEmitter } from '@trezor/utils';
+import { createDeferred, Deferred, TypedEmitter } from '@trezor/utils';
 
 import type {
     EnumerateDoneRequest,

--- a/packages/transport/src/sessions/client.ts
+++ b/packages/transport/src/sessions/client.ts
@@ -1,5 +1,4 @@
-import { getWeakRandomId } from '@trezor/utils';
-import { TypedEmitter } from '@trezor/utils';
+import { getWeakRandomId, TypedEmitter } from '@trezor/utils';
 
 import { Descriptor } from '../types';
 import {

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -1,6 +1,5 @@
 import * as protobuf from 'protobufjs/light';
-import { scheduleAction, ScheduleActionParams, ScheduledAction } from '@trezor/utils';
-import { TypedEmitter } from '@trezor/utils';
+import { scheduleAction, ScheduleActionParams, ScheduledAction, TypedEmitter } from '@trezor/utils';
 import { PROTOCOL_MALFORMED, TransportProtocol } from '@trezor/protocol';
 import { MessageFromTrezor } from '@trezor/protobuf';
 

--- a/suite-common/token-definitions/src/tokenDefinitionsThunks.ts
+++ b/suite-common/token-definitions/src/tokenDefinitionsThunks.ts
@@ -1,10 +1,9 @@
 import { decode, verify } from 'jws';
 import { D, G } from '@mobily/ts-belt';
 
-import { getJWSPublicKey } from '@trezor/env-utils';
+import { getJWSPublicKey, isCodesignBuild } from '@trezor/env-utils';
 import { createThunk } from '@suite-common/redux-utils';
 import { NetworkSymbol, getCoingeckoId } from '@suite-common/wallet-config';
-import { isCodesignBuild } from '@trezor/env-utils';
 import { Timeout } from '@trezor/type-utils';
 
 import { selectNetworkTokenDefinitions } from './tokenDefinitionsSelectors';

--- a/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
@@ -21,8 +21,8 @@ import {
     PrecomposedLevels,
     PrecomposedTransaction,
     ExternalOutput,
+    AddressDisplayOptions,
 } from '@suite-common/wallet-types';
-import { AddressDisplayOptions } from '@suite-common/wallet-types';
 import { getNetwork } from '@suite-common/wallet-config';
 import { getTxStakeNameByDataHex } from '@suite-common/suite-utils';
 

--- a/suite-common/wallet-core/src/send/sendFormRippleThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormRippleThunks.ts
@@ -12,9 +12,9 @@ import {
     PrecomposedLevels,
     PrecomposedTransaction,
     ExternalOutput,
+    AddressDisplayOptions,
 } from '@suite-common/wallet-types';
 import { createThunk } from '@suite-common/redux-utils';
-import { AddressDisplayOptions } from '@suite-common/wallet-types';
 
 import {
     ComposeTransactionThunkArguments,

--- a/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
@@ -15,8 +15,6 @@ import {
     calculateTotal,
     formatAmount,
     getExternalComposeOutput,
-} from '@suite-common/wallet-utils';
-import {
     getPubKeyFromAddress,
     buildTransferTransaction,
     buildTokenTransferTransaction,

--- a/suite-common/wallet-core/src/send/sendFormTypes.ts
+++ b/suite-common/wallet-core/src/send/sendFormTypes.ts
@@ -6,10 +6,9 @@ import {
     ExcludedUtxos,
     FormState,
 } from '@suite-common/wallet-types';
-import { TokenInfo, Unsuccessful } from '@trezor/connect';
+import { TokenInfo, Unsuccessful, ERRORS as CONNECT_ERRORS } from '@trezor/connect';
 import { Network, NetworkSymbol } from '@suite-common/wallet-config';
 import { TrezorDevice } from '@suite-common/suite-types';
-import { ERRORS as CONNECT_ERRORS } from '@trezor/connect';
 
 export type SerializedTx = { tx: string; coin: NetworkSymbol };
 

--- a/suite-common/wallet-core/src/transactions/transactionsReducer.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsReducer.ts
@@ -8,11 +8,13 @@ import {
     isPending,
     getEverstakePool,
 } from '@suite-common/wallet-utils';
-import { getIsPhishingTransaction } from '@suite-common/token-definitions';
+import {
+    getIsPhishingTransaction,
+    TokenDefinitionsRootState,
+} from '@suite-common/token-definitions';
 import { isClaimTx, isStakeTx, isStakeTypeTx, isUnstakeTx } from '@suite-common/suite-utils';
 import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
 import { selectNetworkTokenDefinitions } from '@suite-common/token-definitions/src/tokenDefinitionsSelectors';
-import { TokenDefinitionsRootState } from '@suite-common/token-definitions';
 
 import { accountsActions } from '../accounts/accountsActions';
 import { transactionsActions } from './transactionsActions';

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.ts
@@ -8,8 +8,9 @@ import {
     FormState,
     GeneralPrecomposedTransactionFinal,
     ReviewOutputState,
+    StakeFormState,
+    ReviewOutput,
 } from '@suite-common/wallet-types';
-import { StakeFormState, ReviewOutput } from '@suite-common/wallet-types';
 import { TrezorDevice } from '@suite-common/suite-types';
 
 import { getShortFingerprint, isCardanoTx } from './cardanoUtils';

--- a/suite-native/atoms/src/Spinner/Spinner.tsx
+++ b/suite-native/atoms/src/Spinner/Spinner.tsx
@@ -1,6 +1,5 @@
 import { useRef, useState } from 'react';
 
-import Lottie from 'lottie-react-native';
 import LottieView from 'lottie-react-native';
 
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
@@ -49,7 +48,7 @@ export const Spinner = ({ loadingState, onComplete }: SpinnerProps) => {
     };
 
     return (
-        <Lottie
+        <LottieView
             autoPlay
             resizeMode="cover"
             loop={false}

--- a/suite-native/discovery/src/discoveryThunks.ts
+++ b/suite-native/discovery/src/discoveryThunks.ts
@@ -1,6 +1,6 @@
 import { A, G, pipe } from '@mobily/ts-belt';
 
-import { getWeakRandomId } from '@trezor/utils';
+import { getWeakRandomId, isArrayMember } from '@trezor/utils';
 import { createThunk } from '@suite-common/redux-utils';
 import {
     accountsActions,
@@ -41,7 +41,6 @@ import {
 import { DiscoveryStatus } from '@suite-common/wallet-constants';
 import { requestDeviceAccess } from '@suite-native/device-mutex';
 import { analytics, EventType } from '@suite-native/analytics';
-import { isArrayMember } from '@trezor/utils';
 
 import {
     selectDiscoveryInfo,

--- a/suite-native/icons/src/DeviceModelIcon.tsx
+++ b/suite-native/icons/src/DeviceModelIcon.tsx
@@ -1,7 +1,6 @@
 import { DeviceModelInternal } from '@trezor/connect';
 
-import { IconName, IconSize } from './Icon';
-import { Icon } from './Icon';
+import { IconName, IconSize, Icon } from './Icon';
 
 type DeviceModelIconProps = {
     deviceModel: DeviceModelInternal;

--- a/suite-native/module-authorize-device/src/useRedirectOnPassphraseCompletion.ts
+++ b/suite-native/module-authorize-device/src/useRedirectOnPassphraseCompletion.ts
@@ -9,8 +9,8 @@ import {
     selectHasAuthFailed,
     selectHasVerificationCancelledError,
     selectPassphraseError,
+    useAuthorizationGoBack,
 } from '@suite-native/device-authorization';
-import { useAuthorizationGoBack } from '@suite-native/device-authorization';
 import { EventType, analytics } from '@suite-native/analytics';
 
 export const useRedirectOnPassphraseCompletion = () => {

--- a/suite-native/module-send/src/components/CryptoAmountInput.tsx
+++ b/suite-native/module-send/src/components/CryptoAmountInput.tsx
@@ -4,8 +4,7 @@ import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
 import { Text, Input } from '@suite-native/atoms';
-import { useFormContext } from '@suite-native/forms';
-import { useField } from '@suite-native/forms';
+import { useFormContext, useField } from '@suite-native/forms';
 import { useCryptoFiatConverters } from '@suite-native/formatters';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { useFormatters } from '@suite-common/formatters';

--- a/suite-native/module-send/src/components/FiatAmountInput.tsx
+++ b/suite-native/module-send/src/components/FiatAmountInput.tsx
@@ -3,8 +3,7 @@ import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
 import { Input } from '@suite-native/atoms';
-import { useFormContext } from '@suite-native/forms';
-import { useField } from '@suite-native/forms';
+import { useFormContext, useField } from '@suite-native/forms';
 import { useCryptoFiatConverters } from '@suite-native/formatters';
 import { useNativeStyles } from '@trezor/styles';
 import { selectFiatCurrencyCode } from '@suite-native/settings';

--- a/suite-native/module-send/src/components/SignSuccessMessage.tsx
+++ b/suite-native/module-send/src/components/SignSuccessMessage.tsx
@@ -2,8 +2,7 @@ import { useSelector } from 'react-redux';
 import Animated, { SlideInDown } from 'react-native-reanimated';
 import { useEffect } from 'react';
 
-import { Text } from '@suite-native/atoms';
-import { VStack } from '@suite-native/atoms';
+import { Text, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { useScrollView } from '@suite-native/navigation';
 

--- a/suite-native/module-send/src/screens/SendAddressReviewScreen.tsx
+++ b/suite-native/module-send/src/screens/SendAddressReviewScreen.tsx
@@ -2,10 +2,9 @@ import { useSelector } from 'react-redux';
 import { useEffect } from 'react';
 
 import { SendStackParamList, SendStackRoutes, StackProps } from '@suite-native/navigation';
-import { Box, VStack } from '@suite-native/atoms';
+import { Box, VStack, Text } from '@suite-native/atoms';
 import { Translation, useTranslate } from '@suite-native/intl';
 import { AccountsRootState, DeviceRootState, SendRootState } from '@suite-common/wallet-core';
-import { Text } from '@suite-native/atoms';
 
 import {
     selectIsFirstTransactionAddressConfirmed,


### PR DESCRIPTION
This is a prep for https://github.com/trezor/trezor-suite/pull/15144

After the upgrade the `import/no-duplicates` is on by default & we probably wont this anyway.