### PR TITLE
fix(#14654): Fixing number formatting with whitespace input

### DIFF
--- a/packages/suite/src/components/suite/NumberInput.tsx
+++ b/packages/suite/src/components/suite/NumberInput.tsx
@@ -1,21 +1,21 @@
 import {
+    ClipboardEvent,
+    FormEvent,
+    KeyboardEvent,
     useCallback,
     useLayoutEffect,
     useRef,
     useState,
-    KeyboardEvent,
-    ClipboardEvent,
-    FormEvent,
 } from 'react';
 
-import { Control, FieldValues, useController, UseControllerProps } from 'react-hook-form';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
+import { Control, FieldValues, useController, UseControllerProps } from 'react-hook-form';
 
-import { Input, InputProps } from '@trezor/components';
 import { localizeNumber } from '@suite-common/wallet-utils';
+import { Input, InputProps } from '@trezor/components';
+import { getLocaleSeparators } from '@trezor/utils';
 import { Locale } from 'src/config/suite/languages';
 import { useSelector } from 'src/hooks/suite';
-import { getLocaleSeparators } from '@trezor/utils';
 import { selectLanguage } from 'src/reducers/suite/suiteReducer';
 
 const isValidDecimalString = (value: string) => /^([^.]*)\.[^.]+$/.test(value);
@@ -33,19 +33,20 @@ const cleanValueString = (value: string, locale: Locale) => {
 
     const { decimalSeparator, thousandsSeparator } = getLocaleSeparators(locale);
 
+    const trimmedValue = value.replace(/\s/g, '');
+
     // clean the entered number string if it's not convertible to Number or if it has a non-conventional format
     if (
-        !Number.isNaN(Number(value)) &&
+        !Number.isNaN(Number(trimmedValue)) &&
         thousandsSeparator !== '.' &&
-        !hasLeadingZeroes(value) &&
-        value.at(0) !== '.' &&
-        value.at(-1) !== '.'
+        !hasLeadingZeroes(trimmedValue) &&
+        trimmedValue.at(0) !== '.' &&
+        trimmedValue.at(-1) !== '.'
     ) {
-        return value;
+        return trimmedValue;
     }
 
-    let cleanedValue = value
-        .replace(/\s/g, '')
+    let cleanedValue = trimmedValue
         .replaceAll(thousandsSeparator, '')
         .replaceAll(decimalSeparator, '.');
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The issue stemmed from a condition mismatch due to whitespace. When the value contained whitespace, the cleanup function encountered an edge case that caused it to return the original, untrimmed value. The solution was to trim the whitespace before evaluating the condition, ensuring the function follows the correct branch going forward.

<!--- Describe your changes in detail -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/14654

## Loom:
Testing: copy and paste numbers with whitespace, inputting non-standard inputs. 
https://www.loom.com/share/a44a3c4e9ab448178ce8e4ffc8b5cc1e
