### PR TITLE
chore: add recommanded checks from eslint-plugin-jest

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
         'plugin:react/recommended',
         'plugin:import/typescript',
         'plugin:react-hooks/recommended',
+        'plugin:jest/recommended',
     ],
     settings: {
         react: {
@@ -303,6 +304,16 @@ module.exports = {
             'error',
             { packageName: '@trezor/product-components' },
         ],
+
+        // Jest plugin config
+        'jest/valid-title': 'off', // This rule does not use Typescript and produces false positives
+        'jest/no-disabled-tests': 'off', // we still have a lot of skipped tests (WIP)
+        'jest/no-conditional-expect': 'off', // Todo: we shall solve this, this is bad practice
+        'jest/expect-expect': 'off', // Todo: we have test with no assertions, this may be legit but it needs to be checked
+        'jest/no-standalone-expect': [
+            'error',
+            { additionalTestBlockFunctions: ['conditionalTest'] },
+        ],
     },
     overrides: [
         {
@@ -367,6 +378,18 @@ module.exports = {
                 'import/no-extraneous-dependencies': 'off',
                 'import/no-unresolved': 'off',
                 'import/no-default-export': 'off',
+            },
+        },
+        {
+            files: ['packages/suite-web/e2e/**/*'],
+            rules: {
+                'jest/valid-expect': 'off', // Cypress
+            },
+        },
+        {
+            files: ['packages/connect/e2e/**/*'],
+            rules: {
+                'jest/no-jasmine-globals': 'off', // Kamma tests
             },
         },
     ],

--- a/packages/blockchain-link/tests/integration/connection.test.ts
+++ b/packages/blockchain-link/tests/integration/connection.test.ts
@@ -131,17 +131,19 @@ backends.forEach((b, i) => {
         }, 10000);
 
         describe('Event listeners', () => {
-            it('Handle connect event', done => {
-                blockchain.on('connected', () => done());
-                blockchain.connect();
-            });
+            it('Handle connect event', () =>
+                new Promise<void>(done => {
+                    blockchain.on('connected', () => done());
+                    blockchain.connect();
+                }));
 
-            it('Handle disconnect event', done => {
-                blockchain.on('disconnected', () => done());
-                blockchain.connect().then(() => {
-                    blockchain.disconnect();
-                });
-            });
+            it('Handle disconnect event', () =>
+                new Promise<void>(done => {
+                    blockchain.on('disconnected', () => done());
+                    blockchain.connect().then(() => {
+                        blockchain.disconnect();
+                    });
+                }));
         });
     });
 });

--- a/packages/blockchain-link/tests/integration/solana.test.ts
+++ b/packages/blockchain-link/tests/integration/solana.test.ts
@@ -111,7 +111,7 @@ const fixtures = {
     ],
 };
 
-export const solanaApi = {
+const solanaApi = {
     getGenesisHash: () => '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d',
     getVersion: () => ({ 'feature-set': 1879391783, 'solana-core': '1.14.22' }),
     getParsedBlock: () => ({

--- a/packages/blockchain-link/tests/unit/connection.test.ts
+++ b/packages/blockchain-link/tests/unit/connection.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable jest/no-jasmine-globals */
 import { BackendWebsocketServerMock } from '@trezor/e2e-utils';
 import workers from './worker';
 import BlockchainLink from '../../src';
@@ -127,27 +128,29 @@ workers.forEach(instance => {
             expect(server.getFixtures()!.length).toEqual(2);
         });
 
-        it('Handle connect event', done => {
-            blockchain.on('connected', done);
-            blockchain.connect().then(result => {
-                expect(result).toEqual(true);
-            });
-        });
+        it('Handle connect event', () =>
+            new Promise<void>(done => {
+                blockchain.on('connected', done);
+                blockchain.connect().then(result => {
+                    expect(result).toEqual(true);
+                });
+            }));
 
-        it('Handle disconnect event', done => {
-            blockchain.on('disconnected', done);
-            blockchain.connect().then(() => {
-                // TODO: ripple-lib throws error when disconnect is called immediately
-                // investigate more, use setTimeout as a workaround
-                // Error [ERR_UNHANDLED_ERROR]: Unhandled error. (websocket)
-                // at Connection.RippleAPI.connection.on (../../node_modules/ripple-lib/src/api.ts:133:14)
-                if (instance.name === 'ripple') {
-                    setTimeout(() => blockchain.disconnect(), 100);
-                } else {
-                    blockchain.disconnect();
-                }
-            });
-        });
+        it('Handle disconnect event', () =>
+            new Promise<void>(done => {
+                blockchain.on('disconnected', done);
+                blockchain.connect().then(() => {
+                    // TODO: ripple-lib throws error when disconnect is called immediately
+                    // investigate more, use setTimeout as a workaround
+                    // Error [ERR_UNHANDLED_ERROR]: Unhandled error. (websocket)
+                    // at Connection.RippleAPI.connection.on (../../node_modules/ripple-lib/src/api.ts:133:14)
+                    if (instance.name === 'ripple') {
+                        setTimeout(() => blockchain.disconnect(), 100);
+                    } else {
+                        blockchain.disconnect();
+                    }
+                });
+            }));
 
         it('Connect (only one endpoint is valid)', async () => {
             // blockfrost has only one valid endpoint

--- a/packages/blockchain-link/tests/unit/workers.test.ts
+++ b/packages/blockchain-link/tests/unit/workers.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable jest/no-jasmine-globals */
 import TinyWorker from 'tiny-worker';
 import BlockchainLink from '../../src';
 

--- a/packages/coinjoin/tests/client/CoinjoinPrison.test.ts
+++ b/packages/coinjoin/tests/client/CoinjoinPrison.test.ts
@@ -1,24 +1,25 @@
 import { CoinjoinPrison } from '../../src/client/CoinjoinPrison';
 
 describe('CoinjoinPrison', () => {
-    it('release inmate when Round is no longer present in Status', done => {
-        const inmate = {
-            accountKey: 'account-A',
-            type: 'input',
-            sentenceStart: Date.now() - 10000,
-        } as const;
+    it('release inmate when Round is no longer present in Status', () =>
+        new Promise<void>(done => {
+            const inmate = {
+                accountKey: 'account-A',
+                type: 'input',
+                sentenceStart: Date.now() - 10000,
+            } as const;
 
-        const prison = new CoinjoinPrison([
-            { ...inmate, id: '00AA', roundId: '00', sentenceEnd: Date.now() + 10000 }, // will be released - round not present)
-            { ...inmate, id: '00AB', roundId: '00', sentenceEnd: Infinity }, // will NOT be released - sentence Infinity
-            { ...inmate, id: '01AA', roundId: '01', sentenceEnd: Date.now() + 10000 }, // wil NOT be released - round IS present
-            { ...inmate, id: '01AB', roundId: '01', sentenceEnd: Date.now() - 1 }, // will be released - sentence is lower
-        ]);
+            const prison = new CoinjoinPrison([
+                { ...inmate, id: '00AA', roundId: '00', sentenceEnd: Date.now() + 10000 }, // will be released - round not present)
+                { ...inmate, id: '00AB', roundId: '00', sentenceEnd: Infinity }, // will NOT be released - sentence Infinity
+                { ...inmate, id: '01AA', roundId: '01', sentenceEnd: Date.now() + 10000 }, // wil NOT be released - round IS present
+                { ...inmate, id: '01AB', roundId: '01', sentenceEnd: Date.now() - 1 }, // will be released - sentence is lower
+            ]);
 
-        prison.on('change', () => done()); // end test after change event
+            prison.on('change', () => done()); // end test after change event
 
-        prison.release(['01']); // only one round is present in Status
+            prison.release(['01']); // only one round is present in Status
 
-        expect(prison.inmates.map(({ id }) => id)).toEqual(['00AB', '01AA']);
-    });
+            expect(prison.inmates.map(({ id }) => id)).toEqual(['00AB', '01AA']);
+        }));
 });

--- a/packages/coinjoin/tests/client/CoinjoinRound.test.ts
+++ b/packages/coinjoin/tests/client/CoinjoinRound.test.ts
@@ -420,6 +420,7 @@ describe(`CoinjoinRound`, () => {
         round.on('changed', spyChanged);
 
         // process but not wait for the result
+        // eslint-disable-next-line jest/valid-expect-in-promise
         round.process([]).then(() => {
             expect(spyEnded).toHaveBeenCalledTimes(1);
             expect(spyChanged).toHaveBeenCalledTimes(1);

--- a/packages/coinjoin/tests/client/Status.test.ts
+++ b/packages/coinjoin/tests/client/Status.test.ts
@@ -208,25 +208,26 @@ describe('Status', () => {
         expect(identities.length).toEqual(1);
     });
 
-    it('Status start and immediate stop', done => {
-        status = new Status(server?.requestOptions);
-        const errorListener = jest.fn();
-        status.on('log', errorListener);
-        const updateListener = jest.fn();
-        status.on('update', updateListener);
-        const requestListener = jest.fn();
-        server?.addListener('test-handle-request', requestListener);
+    it('Status start and immediate stop', () =>
+        new Promise<void>(done => {
+            status = new Status(server?.requestOptions);
+            const errorListener = jest.fn();
+            status.on('log', errorListener);
+            const updateListener = jest.fn();
+            status.on('update', updateListener);
+            const requestListener = jest.fn();
+            server?.addListener('test-handle-request', requestListener);
 
-        // start but not await
-        status.start().then(() => {
-            expect(requestListener).toHaveBeenCalledTimes(0); // aborted, request not sent
-            expect(updateListener).toHaveBeenCalledTimes(0); // not emitted, listener removed by .stop()
-            expect(errorListener).toHaveBeenCalledTimes(0); // not emitted, listener removed by .stop()
-            done();
-        });
-        // immediate stop
-        status.stop();
-    });
+            // start but not await
+            status.start().then(() => {
+                expect(requestListener).toHaveBeenCalledTimes(0); // aborted, request not sent
+                expect(updateListener).toHaveBeenCalledTimes(0); // not emitted, listener removed by .stop()
+                expect(errorListener).toHaveBeenCalledTimes(0); // not emitted, listener removed by .stop()
+                done();
+            });
+            // immediate stop
+            status.stop();
+        }));
 
     it('Status start attempts, keep lifecycle regardless of failed requests', async () => {
         jest.spyOn(STATUS_TIMEOUT, 'registered', 'get').mockReturnValue(250 as any);

--- a/packages/coinjoin/tests/client/connectionConfirmation.test.ts
+++ b/packages/coinjoin/tests/client/connectionConfirmation.test.ts
@@ -196,38 +196,39 @@ describe('connectionConfirmation', () => {
             });
     });
 
-    it('connection-confirmation interval aborted, Alice unregistered', done => {
-        const alice = createInput('account-A', 'A1', {
-            registrationData: {
-                AliceId: '01A1-01a1',
-            },
-            realAmountCredentials: {},
-            realVsizeCredentials: {},
-        });
-
-        const interval = confirmationInterval(
-            createCoinjoinRound([alice], {
-                ...server?.requestOptions,
-                roundParameters: {
-                    ConnectionConfirmationTimeout: '0d 0h 0m 2s', // intervalDelay = 1 sec
+    it('connection-confirmation interval aborted, Alice unregistered', () =>
+        new Promise<void>(done => {
+            const alice = createInput('account-A', 'A1', {
+                registrationData: {
+                    AliceId: '01A1-01a1',
                 },
-                round: {
-                    phaseDeadline: Date.now() + 1000, // phase will end in less than intervalDelay
-                },
-            }),
-            alice,
-            server?.requestOptions,
-        );
+                realAmountCredentials: {},
+                realVsizeCredentials: {},
+            });
 
-        server?.addListener('test-request', ({ url, resolve }) => {
-            resolve();
-            if (url.includes('input-unregistration')) {
-                done();
-            }
-        });
+            const interval = confirmationInterval(
+                createCoinjoinRound([alice], {
+                    ...server?.requestOptions,
+                    roundParameters: {
+                        ConnectionConfirmationTimeout: '0d 0h 0m 2s', // intervalDelay = 1 sec
+                    },
+                    round: {
+                        phaseDeadline: Date.now() + 1000, // phase will end in less than intervalDelay
+                    },
+                }),
+                alice,
+                server?.requestOptions,
+            );
 
-        interval.abort();
-    });
+            server?.addListener('test-request', ({ url, resolve }) => {
+                resolve();
+                if (url.includes('input-unregistration')) {
+                    done();
+                }
+            });
+
+            interval.abort();
+        }));
 
     it('404 error in coordinator connection-confirmation', async () => {
         server?.addListener('test-request', ({ url, data, resolve, reject }) => {

--- a/packages/coinjoin/tests/client/coordinatorRequest.test.ts
+++ b/packages/coinjoin/tests/client/coordinatorRequest.test.ts
@@ -146,20 +146,21 @@ describe('http', () => {
         ).rejects.toThrow('Aborted by signal');
     });
 
-    it('successful', done => {
-        coordinatorRequest('input-registration', {}, { baseUrl }).then(resp => {
-            expect(resp).toMatchObject({ AliceId: expect.any(String) });
-        });
-        // without baseUrl
-        coordinatorRequest<any>(`status`, {}, { baseUrl }).then(resp => {
-            expect(resp.RoundStates.length).toEqual(1);
-        });
-        // without json response
-        coordinatorRequest('ready-to-sign', {}, { baseUrl }).then(resp => {
-            expect(resp).toEqual('');
-            done();
-        });
-    });
+    it('successful', () =>
+        new Promise<void>(done => {
+            coordinatorRequest('input-registration', {}, { baseUrl }).then(resp => {
+                expect(resp).toMatchObject({ AliceId: expect.any(String) });
+            });
+            // without baseUrl
+            coordinatorRequest<any>(`status`, {}, { baseUrl }).then(resp => {
+                expect(resp.RoundStates.length).toEqual(1);
+            });
+            // without json response
+            coordinatorRequest('ready-to-sign', {}, { baseUrl }).then(resp => {
+                expect(resp).toEqual('');
+                done();
+            });
+        }));
 
     it('with identity', async () => {
         const requestListener = jest.fn(req => {

--- a/packages/coinjoin/tests/client/inputRegistration.test.ts
+++ b/packages/coinjoin/tests/client/inputRegistration.test.ts
@@ -342,15 +342,16 @@ describe('inputRegistration', () => {
         expect(spy.mock.calls.length).toBeGreaterThan(0);
 
         // 2. wait for confirmation interval to resolve
-        Promise.all(response.inputs.map(input => input.getConfirmationInterval()?.promise)).then(
-            res => {
-                res.forEach(input => {
-                    expect(input?.getConfirmationInterval()).toBeUndefined();
-                });
-            },
+        const promises = Promise.all(
+            response.inputs.map(input => input.getConfirmationInterval()?.promise),
         );
 
         // 1. abort confirmation interval
         response.inputs.forEach(input => input.clearConfirmationInterval());
+
+        const res = await promises;
+        res.forEach(input => {
+            expect(input?.getConfirmationInterval()).toBeUndefined();
+        });
     });
 });

--- a/packages/connect/e2e/karma.setup.js
+++ b/packages/connect/e2e/karma.setup.js
@@ -50,6 +50,7 @@ jasmine.getEnv().beforeAll(() => {
                         return match;
                     }, {});
 
+                // eslint-disable-next-line jest/no-standalone-expect
                 expect(actual).toEqual(jasmine.objectContaining(nested(expected)));
 
                 return success;

--- a/packages/connect/src/api/bitcoin/__tests__/Fees.test.ts
+++ b/packages/connect/src/api/bitcoin/__tests__/Fees.test.ts
@@ -110,6 +110,7 @@ describe('api/bitcoin/Fees', () => {
 
     // const e2eNetworks = ['BTC', 'TEST', 'BCH', 'BTG', 'DASH', 'DGB', 'DOGE', 'LTC', 'NMC', 'VTC'];
     // e2eNetworks.forEach(network => {
+    // eslint-disable-next-line jest/no-commented-out-tests
     //     it.only(`${network} e2e smart FeeLevels`, async () => {
     //         const coinInfo = getBitcoinNetwork(network)!;
     //         if (!coinInfo) throw new Error('coinInfo is missing');

--- a/packages/connect/src/api/common/__tests__/paramsValidator.test.ts
+++ b/packages/connect/src/api/common/__tests__/paramsValidator.test.ts
@@ -23,24 +23,26 @@ describe('helpers/paramsValidator', () => {
             jest.clearAllMocks();
         });
         fixtures.getFirmwareRange.forEach(f => {
-            it(f.description, done => {
-                jest.resetModules();
+            it(f.description, () => {
+                return new Promise<void>(done => {
+                    jest.resetModules();
 
-                const mock = f.config;
-                jest.mock('../../../data/config', () => {
-                    const actualConfig = jest.requireActual('../../../data/config').config;
+                    const mock = f.config;
+                    jest.mock('../../../data/config', () => {
+                        const actualConfig = jest.requireActual('../../../data/config').config;
 
-                    return {
-                        __esModule: true,
-                        config: mock || actualConfig,
-                    };
-                });
+                        return {
+                            __esModule: true,
+                            config: mock || actualConfig,
+                        };
+                    });
 
-                import('../paramsValidator').then(({ getFirmwareRange }) => {
-                    // added new capability
-                    // @ts-expect-error
-                    expect(getFirmwareRange(...f.params)).toEqual(f.result);
-                    done();
+                    import('../paramsValidator').then(({ getFirmwareRange }) => {
+                        // added new capability
+                        // @ts-expect-error
+                        expect(getFirmwareRange(...f.params)).toEqual(f.result);
+                        done();
+                    });
                 });
             });
         });

--- a/packages/connect/src/api/ethereum/__tests__/ethereumSignTypedData.test.ts
+++ b/packages/connect/src/api/ethereum/__tests__/ethereumSignTypedData.test.ts
@@ -6,7 +6,7 @@ describe('helpers/ethereumSignTypeData', () => {
         fixtures.parseArrayType.forEach(f => {
             it(`${f.description} - ${f.input}`, () => {
                 if (f.error) {
-                    expect(() => parseArrayType(f.input)).toThrowError(...f.error);
+                    expect(() => parseArrayType(f.input)).toThrow(...f.error);
                 } else {
                     expect(parseArrayType(f.input)).toEqual(f.output);
                 }
@@ -19,7 +19,7 @@ describe('helpers/ethereumSignTypeData', () => {
             const { typeName, types } = f.input;
             it(`${f.description} - ${typeName}`, () => {
                 if (f.error) {
-                    expect(() => getFieldType(typeName, types as any)).toThrowError(...f.error);
+                    expect(() => getFieldType(typeName, types as any)).toThrow(...f.error);
                 } else {
                     expect(getFieldType(typeName, types as any)).toEqual(f.output);
                 }
@@ -32,7 +32,7 @@ describe('helpers/ethereumSignTypeData', () => {
             const { typeName, data } = f.input;
             it(`${f.description}`, () => {
                 if (f.error) {
-                    expect(() => encodeData(typeName, data)).toThrowError(...f.error);
+                    expect(() => encodeData(typeName, data)).toThrow(...f.error);
                 } else {
                     expect(encodeData(typeName, data)).toEqual(f.output);
                 }

--- a/packages/connect/src/api/firmware/__tests__/calculateFirmwareHash.test.ts
+++ b/packages/connect/src/api/firmware/__tests__/calculateFirmwareHash.test.ts
@@ -43,8 +43,6 @@ describe('firmware/calculateFirmwareHash', () => {
     });
 
     it('Firmware too big', () => {
-        expect(() => calculateFirmwareHash(2, Buffer.alloc(100000000))).toThrowError(
-            'Firmware too big',
-        );
+        expect(() => calculateFirmwareHash(2, Buffer.alloc(100000000))).toThrow('Firmware too big');
     });
 });

--- a/packages/connect/src/data/__tests__/DataManager.test.ts
+++ b/packages/connect/src/data/__tests__/DataManager.test.ts
@@ -32,6 +32,7 @@ describe('data/DataManager', () => {
         try {
             await DataManager.load(settings, false);
         } catch (err) {
+            // eslint-disable-next-line jest/no-standalone-expect
             expect(err).toBe(undefined);
         }
     });

--- a/packages/connect/src/utils/__tests__/accountUtils.test.ts
+++ b/packages/connect/src/utils/__tests__/accountUtils.test.ts
@@ -20,6 +20,5 @@ describe('utils/accountUtils', () => {
 
     // todo:
     describe.skip('getAccountAddressN', () => {});
-    describe.skip('getAccountLabel', () => {});
     describe.skip('getPublicKeyLabel', () => {});
 });

--- a/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
+++ b/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
@@ -223,53 +223,55 @@ describe('utils/deviceFeaturesUtils', () => {
             });
         });
 
-        it('T2T1 update-required', done => {
-            jest.resetModules();
+        it('T2T1 update-required', () =>
+            new Promise<void>(done => {
+                jest.resetModules();
 
-            jest.mock('../../data/config', () => ({
-                __esModule: true,
-                config: {
-                    supportedFirmware: [
-                        {
-                            min: { T1B1: '0', T2T1: '2.99.99' },
-                            capabilities: ['newCapabilityOrFeature'],
-                        },
-                    ],
-                },
+                jest.mock('../../data/config', () => ({
+                    __esModule: true,
+                    config: {
+                        supportedFirmware: [
+                            {
+                                min: { T1B1: '0', T2T1: '2.99.99' },
+                                capabilities: ['newCapabilityOrFeature'],
+                            },
+                        ],
+                    },
+                }));
+
+                import('../deviceFeaturesUtils').then(({ getUnavailableCapabilities }) => {
+                    // added new capability
+                    expect(getUnavailableCapabilities(featT2T1, coins)).toEqual({
+                        newCapabilityOrFeature: 'update-required',
+                    });
+                    done();
+                });
             }));
 
-            import('../deviceFeaturesUtils').then(({ getUnavailableCapabilities }) => {
-                // added new capability
-                expect(getUnavailableCapabilities(featT2T1, coins)).toEqual({
-                    newCapabilityOrFeature: 'update-required',
+        it('T2T1 no-support', () =>
+            new Promise<void>(done => {
+                jest.resetModules();
+
+                jest.mock('../../data/config', () => ({
+                    __esModule: true,
+                    config: {
+                        supportedFirmware: [
+                            {
+                                min: { T1B1: '0', T2T1: '0' },
+                                capabilities: ['newCapabilityOrFeature'],
+                            },
+                        ],
+                    },
+                }));
+
+                import('../deviceFeaturesUtils').then(({ getUnavailableCapabilities }) => {
+                    // added new capability
+                    expect(getUnavailableCapabilities(featT2T1, coins)).toEqual({
+                        newCapabilityOrFeature: 'no-support',
+                    });
+                    done();
                 });
-                done();
-            });
-        });
-
-        it('T2T1 no-support', done => {
-            jest.resetModules();
-
-            jest.mock('../../data/config', () => ({
-                __esModule: true,
-                config: {
-                    supportedFirmware: [
-                        {
-                            min: { T1B1: '0', T2T1: '0' },
-                            capabilities: ['newCapabilityOrFeature'],
-                        },
-                    ],
-                },
             }));
-
-            import('../deviceFeaturesUtils').then(({ getUnavailableCapabilities }) => {
-                // added new capability
-                expect(getUnavailableCapabilities(featT2T1, coins)).toEqual({
-                    newCapabilityOrFeature: 'no-support',
-                });
-                done();
-            });
-        });
 
         it('handles duplicated shortcuts correctly, ', () => {
             const customCoins = [

--- a/packages/node-utils/src/tests/http.test.ts
+++ b/packages/node-utils/src/tests/http.test.ts
@@ -26,14 +26,17 @@ describe('HttpServer', () => {
         });
     });
 
-    afterEach(done => {
-        server.stop().finally(() => {
-            done();
-        });
-    });
+    afterEach(
+        () =>
+            new Promise<void>(done => {
+                server.stop().finally(() => {
+                    done();
+                });
+            }),
+    );
 
     test('getServerAddress before server start', () => {
-        expect(() => server.getServerAddress()).toThrowError();
+        expect(() => server.getServerAddress()).toThrow();
     });
 
     test('getServerAddress after server start', async () => {

--- a/packages/protobuf/tests/encode-decode.test.ts
+++ b/packages/protobuf/tests/encode-decode.test.ts
@@ -541,6 +541,6 @@ describe('Real messages', () => {
         expect(() => {
             // @ts-expect-error
             encode(null, {});
-        }).toThrowError();
+        }).toThrow();
     });
 });

--- a/packages/suite-desktop-api/src/__tests__/api.test.ts
+++ b/packages/suite-desktop-api/src/__tests__/api.test.ts
@@ -11,21 +11,23 @@ describe('DesktopApi', () => {
     });
 
     describe('Events', () => {
-        it('DesktopApi.on omits event param', done => {
-            api.on('tor/status', state => {
-                expect(state).toBe(true);
-                done();
-            });
-            ipcRenderer.emit('tor/status', new Event('ipc'), true); // Event param should be omitted
-        });
+        it('DesktopApi.on omits event param', () =>
+            new Promise<void>(done => {
+                api.on('tor/status', state => {
+                    expect(state).toBe(true);
+                    done();
+                });
+                ipcRenderer.emit('tor/status', new Event('ipc'), true); // Event param should be omitted
+            }));
 
-        it('DesktopApi.once omits event param', done => {
-            api.once('tor/status', state => {
-                expect(state).toBe(true);
-                done();
-            });
-            ipcRenderer.emit('tor/status', new Event('ipc'), true); // Event param should be omitted
-        });
+        it('DesktopApi.once omits event param', () =>
+            new Promise<void>(done => {
+                api.once('tor/status', state => {
+                    expect(state).toBe(true);
+                    done();
+                });
+                ipcRenderer.emit('tor/status', new Event('ipc'), true); // Event param should be omitted
+            }));
 
         it('DesktopApi.removeAllListener', () => {
             const spy = jest.fn();

--- a/packages/suite-desktop-api/src/__tests__/renderer.test.ts
+++ b/packages/suite-desktop-api/src/__tests__/renderer.test.ts
@@ -3,7 +3,7 @@ import { factory } from '../factory';
 import { ipcRenderer } from './ipcRenderer';
 
 describe('Renderer', () => {
-    it('api is not defined', () => {
+    it('api is not defined', async () => {
         const spyError = jest.spyOn(console, 'error').mockImplementation();
         expect(desktopApi.available).toBe(false);
         desktopApi.on('protocol/open', () => {});
@@ -11,7 +11,7 @@ describe('Renderer', () => {
         desktopApi.removeAllListeners('protocol/open');
         desktopApi.clearStore();
         expect(spyError).toHaveBeenCalledTimes(4);
-        expect(desktopApi.metadataRead({ file: 'foo.txt' })).rejects.toThrow();
+        await expect(desktopApi.metadataRead({ file: 'foo.txt' })).rejects.toThrow();
     });
 
     it('api is defined', () => {

--- a/packages/suite-web/e2e/tests/analytics/events.test.ts
+++ b/packages/suite-web/e2e/tests/analytics/events.test.ts
@@ -228,5 +228,3 @@ describe('Analytics Events', () => {
         });
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/analytics/toggle.test.ts
+++ b/packages/suite-web/e2e/tests/analytics/toggle.test.ts
@@ -160,5 +160,3 @@ describe('Analytics Toggle - Enablement and Disablement', () => {
         });
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/backup/t2t1-fail.test.ts
+++ b/packages/suite-web/e2e/tests/backup/t2t1-fail.test.ts
@@ -52,5 +52,3 @@ describe('Backup fail', () => {
         });
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/backup/t2t1-misc.test.ts
+++ b/packages/suite-web/e2e/tests/backup/t2t1-misc.test.ts
@@ -68,5 +68,3 @@ describe('Backup misc', () => {
         cy.getTestElement('@backup/no-device');
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/backup/t2t1-success.test.ts
+++ b/packages/suite-web/e2e/tests/backup/t2t1-success.test.ts
@@ -64,5 +64,3 @@ describe('Backup success', () => {
         });
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/backup/t3t1-create-addtional-share.test.ts
+++ b/packages/suite-web/e2e/tests/backup/t3t1-create-addtional-share.test.ts
@@ -63,5 +63,3 @@ describe('Backup success', () => {
         onMultiShareBackupModal.finalizeMultiShareBackup();
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/browser/android.test.ts
+++ b/packages/suite-web/e2e/tests/browser/android.test.ts
@@ -30,5 +30,3 @@ describe('Android with non-chrome browser', () => {
         cy.getTestElement('@welcome/title');
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/browser/ios.test.ts
+++ b/packages/suite-web/e2e/tests/browser/ios.test.ts
@@ -21,5 +21,3 @@ describe('iPhone with chrome browser ', () => {
         cy.get('html').should('not.contain.text', 'Continue at my own risk');
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/browser/outdated-chrome.test.ts
+++ b/packages/suite-web/e2e/tests/browser/outdated-chrome.test.ts
@@ -32,5 +32,3 @@ describe('Windows 7 with outdated chrome ', () => {
         cy.getTestElement('@welcome/title');
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/browser/outdated-firefox.test.ts
+++ b/packages/suite-web/e2e/tests/browser/outdated-firefox.test.ts
@@ -32,5 +32,3 @@ describe('Ubuntu with outdated firefox ', () => {
         cy.getTestElement('@welcome/title');
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/browser/safari.test.ts
+++ b/packages/suite-web/e2e/tests/browser/safari.test.ts
@@ -31,5 +31,3 @@ describe('Safari on MacOS 14 ', () => {
         cy.getTestElement('@welcome/title');
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/coinmarket/buy.test.ts
+++ b/packages/suite-web/e2e/tests/coinmarket/buy.test.ts
@@ -196,5 +196,3 @@ describe('Coinmarket buy', () => {
         });
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/coinmarket/exchange.test.ts
+++ b/packages/suite-web/e2e/tests/coinmarket/exchange.test.ts
@@ -203,5 +203,3 @@ describe.skip('Coinmarket exchange', () => {
         cy.getTestElement('@coinmarket/exchange/payment/back-to-account').click();
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/dashboard/assets.test.ts
+++ b/packages/suite-web/e2e/tests/dashboard/assets.test.ts
@@ -75,5 +75,3 @@ describe.skip('Assets', () => {
         // });
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/dashboard/dashboard.test.ts
+++ b/packages/suite-web/e2e/tests/dashboard/dashboard.test.ts
@@ -39,5 +39,3 @@ describe('Dashboard', () => {
     // QA todo: test for graph
     // QA todo: dashboard appearance for seed with tx history vs seed without tx history
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/dashboard/discreet-mode.test.ts
+++ b/packages/suite-web/e2e/tests/dashboard/discreet-mode.test.ts
@@ -51,5 +51,3 @@ describe('Dashboard', () => {
         });
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/firmware/firmware.test.ts
+++ b/packages/suite-web/e2e/tests/firmware/firmware.test.ts
@@ -59,5 +59,3 @@ describe('Firmware', () => {
         // );
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/metadata/account-metadata.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/account-metadata.test.ts
@@ -122,5 +122,3 @@ Hovering over fields that may be labeled shows "add label" button upon which is 
         );
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/metadata/address-metadata.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/address-metadata.test.ts
@@ -40,5 +40,3 @@ describe('Metadata - address labeling', () => {
         cy.getTestElement('@metadata/input').type(' meoew meow{enter}');
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/metadata/dropbox-api-errors.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/dropbox-api-errors.test.ts
@@ -189,5 +189,3 @@ describe('Dropbox api errors', () => {
 
     // todo: add more possible errors
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/metadata/google-api-errors.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/google-api-errors.test.ts
@@ -67,5 +67,3 @@ describe('Google api errors', () => {
     // todo: add more possible errors
     // https://developers.google.com/drive/api/v3/handle-errors
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/metadata/interval-fetching.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/interval-fetching.test.ts
@@ -92,5 +92,3 @@ describe('Metadata - suite is watching cloud provider and syncs periodically', (
         });
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/metadata/metadata-lifecycle.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/metadata-lifecycle.test.ts
@@ -110,5 +110,3 @@ describe('Metadata - cancel metadata on device', () => {
         cy.task('pressNo');
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/metadata/output-labeling.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/output-labeling.test.ts
@@ -109,5 +109,3 @@ describe('Metadata - Output labeling', () => {
         });
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/metadata/remembered-device.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/remembered-device.test.ts
@@ -161,5 +161,3 @@ describe(
         });
     },
 );
-
-export {};

--- a/packages/suite-web/e2e/tests/metadata/switching-providers.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/switching-providers.test.ts
@@ -59,5 +59,3 @@ describe(`Metadata - switching between cloud providers`, () => {
         cy.getTestElement('@account-menu/btc/normal/0/label').should('contain', 'google label');
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/metadata/wallet-metadata.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/wallet-metadata.test.ts
@@ -151,5 +151,3 @@ describe('Metadata - wallet labeling', () => {
         });
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/onboarding/analytics-consent.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/analytics-consent.test.ts
@@ -29,5 +29,3 @@ describe('Onboarding - analytics consent', () => {
         cy.getTestElement('@wallet/menu/wallet-send');
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/onboarding/firmware-update.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/firmware-update.test.ts
@@ -100,5 +100,3 @@ describe.skip('fw update from empty device bootloader 2.0.3 to firmware 2.5.1', 
         }).click();
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts
@@ -69,5 +69,3 @@ describe('Onboarding - create wallet', () => {
         cy.getTestElement('@pin/input/1');
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/onboarding/t1b1/t1b1-recovery-advanced.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/t1b1/t1b1-recovery-advanced.test.ts
@@ -47,5 +47,3 @@ describe('Onboarding - recover wallet T1B1', () => {
         // todo: finish reading from device. needs support in trezor-user-env
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/onboarding/t1b1/t1b1-recovery-fail.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/t1b1/t1b1-recovery-fail.test.ts
@@ -47,5 +47,3 @@ describe('Onboarding - recover wallet T1B1', () => {
         });
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/onboarding/t1b1/t1b1-recovery-success.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/t1b1/t1b1-recovery-success.test.ts
@@ -78,5 +78,3 @@ describe('Onboarding - recover wallet T1B1', () => {
         });
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts
@@ -45,5 +45,3 @@ describe('Onboarding - create wallet', () => {
         cy.getTestElement('@onboarding/pin/continue-button');
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/onboarding/t2t1/t2t1-recovery-fail.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/t2t1/t2t1-recovery-fail.test.ts
@@ -54,5 +54,3 @@ describe('Onboarding - recover wallet T2T1', () => {
         });
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts
@@ -138,5 +138,3 @@ describe('Onboarding - T2T1 in recovery mode', () => {
         cy.getTestElement('@onboarding/skip-button').click();
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts
@@ -58,5 +58,3 @@ describe('Onboarding - recover wallet T2T1', () => {
         });
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/onboarding/transport.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/transport.test.ts
@@ -13,5 +13,3 @@ describe('Onboarding - transport webusb/bridge', () => {
         cy.getTestElement('@connect-device-prompt/no-device-detected').click();
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/recovery/t1b1-dry-run.test.ts
+++ b/packages/suite-web/e2e/tests/recovery/t1b1-dry-run.test.ts
@@ -24,5 +24,3 @@ describe.skip('Recovery - dry run', () => {
         // todo: elaborate more, seems like finally T1B1 tests are stable so it would make finally sense to finish this
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/recovery/t2t1-dry-run-persistence.test.ts
+++ b/packages/suite-web/e2e/tests/recovery/t2t1-dry-run-persistence.test.ts
@@ -61,5 +61,3 @@ describe('Recovery - dry run', () => {
         cy.getTestElement('@recovery/success-title');
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/settings/application-log.test.ts
+++ b/packages/suite-web/e2e/tests/settings/application-log.test.ts
@@ -30,5 +30,3 @@ describe('ApplicationLog', () => {
         // todo: check it really exports something;
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/settings/autodetect.test.ts
+++ b/packages/suite-web/e2e/tests/settings/autodetect.test.ts
@@ -32,5 +32,3 @@ describe('Language and theme detection', () => {
         cy.get('body').should('have.css', 'background-color', 'rgb(23, 23, 23)');
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/settings/coins.test.ts
+++ b/packages/suite-web/e2e/tests/settings/coins.test.ts
@@ -130,5 +130,3 @@ describe('Coin Settings', () => {
         });
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/settings/custom-firmware.test.ts
+++ b/packages/suite-web/e2e/tests/settings/custom-firmware.test.ts
@@ -62,5 +62,3 @@ describe('Install custom firmware', () => {
         cy.getTestElement('@firmware/reconnect-device').should('be.visible');
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/settings/general.test.ts
+++ b/packages/suite-web/e2e/tests/settings/general.test.ts
@@ -107,5 +107,3 @@ describe('General settings', () => {
         // cy.getTestElement('@onboarding/welcome', { timeout: 20000 }).should('be.visible');
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/settings/notification-toast.test.ts
+++ b/packages/suite-web/e2e/tests/settings/notification-toast.test.ts
@@ -41,5 +41,3 @@ describe('Check notification toast', () => {
         cy.getTestElement('@toast/settings-applied').should('be.visible');
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/settings/safety-checks.test.ts
+++ b/packages/suite-web/e2e/tests/settings/safety-checks.test.ts
@@ -74,5 +74,3 @@ describe('Safety Checks Settings', () => {
             });
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/settings/t1b1-device-settings.test.ts
+++ b/packages/suite-web/e2e/tests/settings/t1b1-device-settings.test.ts
@@ -93,5 +93,3 @@ describe('T1B1 - Device settings', () => {
     // TODO: keyboard handling
     // TODO: set auto-lock (needs pin)
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/settings/t2b1-device-settings.test.ts
+++ b/packages/suite-web/e2e/tests/settings/t2b1-device-settings.test.ts
@@ -148,5 +148,3 @@ describe('T2B1 - Device settings', () => {
         cy.task('pressYes');
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/settings/t2t1-device-settings.test.ts
+++ b/packages/suite-web/e2e/tests/settings/t2t1-device-settings.test.ts
@@ -136,5 +136,3 @@ describe('T2T1 - Device settings', () => {
     // TODO: upload custom image
     // TODO: set auto-lock (needs pin)
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/settings/without-device.test.ts
+++ b/packages/suite-web/e2e/tests/settings/without-device.test.ts
@@ -36,5 +36,3 @@ describe('Settings changes persist when device disconnected', () => {
         cy.location('pathname').should('match', /\/accounts\/send$/);
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/suite/bridge.test.ts
+++ b/packages/suite-web/e2e/tests/suite/bridge.test.ts
@@ -20,5 +20,3 @@ describe('Bridge page', () => {
         cy.getTestElement('@connect-device-prompt');
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/suite/bug-report-form.test.ts
+++ b/packages/suite-web/e2e/tests/suite/bug-report-form.test.ts
@@ -47,5 +47,3 @@ describe('Stories of bug report forms', () => {
         cy.getTestElement('@toast/user-feedback-send-success').should('be.visible');
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/suite/database-migration.test.ts
+++ b/packages/suite-web/e2e/tests/suite/database-migration.test.ts
@@ -164,5 +164,3 @@ describe('Database migration', () => {
         cy.get('body').should('have.css', 'background-color', 'rgb(23, 23, 23)');
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/suite/guide.test.ts
+++ b/packages/suite-web/e2e/tests/suite/guide.test.ts
@@ -68,5 +68,3 @@ describe('Test Guide', () => {
         });
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/suite/initial-run.test.ts
+++ b/packages/suite-web/e2e/tests/suite/initial-run.test.ts
@@ -36,5 +36,3 @@ describe('Suite initial run', () => {
         cy.getTestElement('@menu/switch-device').should('contain.text', 'Connected');
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/suite/passphrase-cancel.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase-cancel.test.ts
@@ -35,5 +35,3 @@ describe('Passphrase cancel', () => {
         });
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/suite/passphrase-cardano.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase-cardano.test.ts
@@ -92,5 +92,3 @@ describe('Passphrase with cardano', () => {
         cy.getTestElement('@toast/verify-address-error');
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/suite/passphrase-disabled.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase-disabled.test.ts
@@ -68,5 +68,3 @@ describe.skip('Suite switch wallet modal', () => {
         cy.getTestElement('@menu/switch-device').click();
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/suite/passphrase-duplicate.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase-duplicate.test.ts
@@ -43,5 +43,3 @@ describe('Passphrase', () => {
         // QA todo: continue to discovered wallet
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/suite/passphrase-input.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase-input.test.ts
@@ -76,5 +76,3 @@ describe('Passphrase', () => {
         // todo: select part of test + copy/paste
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/suite/passphrase-numbering.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase-numbering.test.ts
@@ -66,5 +66,3 @@ describe('Passphrase numbering', () => {
 
     // TODO: add coverage for different wallet names displaying in the device switcher component
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/suite/passphrase.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase.test.ts
@@ -165,5 +165,3 @@ describe('Passphrase', () => {
         cy.task('pressYes');
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/suite/safety-checks-warning.test.ts
+++ b/packages/suite-web/e2e/tests/suite/safety-checks-warning.test.ts
@@ -6,6 +6,7 @@ import { onNavBar } from '../../support/pageObjects/topBarObject';
 
 // TODO: enable this test once https://github.com/trezor/trezor-user-env/issues/54
 // is resolved
+// eslint-disable-next-line jest/no-commented-out-tests
 // describe('safety_checks Warning For PromptAlways', () => {
 //     beforeEach(() => {
 //         cy.task('startEmu', {  wipe: true });
@@ -17,6 +18,7 @@ import { onNavBar } from '../../support/pageObjects/topBarObject';
 //         // TODO: set safety_checks to `PromptAlways`
 //     });
 
+// eslint-disable-next-line jest/no-commented-out-tests
 //     it('Non-dismissible warning appears', () => {
 //         cy.getTestElement('@banner/safety-checks/button');
 //         cy.getTestElement('@banner/safety-checks/dismiss').should('not.exist');
@@ -102,5 +104,3 @@ describe('safety_checks Warning For PromptTemporarily', () => {
         cy.getTestElement('@banner/safety-checks/button');
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/suite/tooltip.test.ts
+++ b/packages/suite-web/e2e/tests/suite/tooltip.test.ts
@@ -24,7 +24,6 @@ describe.skip('Test tooltip links', () => {
     });
 });
 
-export {};
 // TODO: review this test if it's indeed obsolete
 describe.skip('Test tooltip conditional rendering', () => {
     beforeEach(() => {
@@ -60,5 +59,3 @@ describe.skip('Test tooltip conditional rendering', () => {
             .should('exist');
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/suite/unacquired-device.test.ts
+++ b/packages/suite-web/e2e/tests/suite/unacquired-device.test.ts
@@ -34,5 +34,3 @@ describe('unacquired device', () => {
     // - also firmware update, maybe standalone backup/recovery might have custom implementation  that might be worth revisiting
     // - device state is incorrect is wrong copy!!!
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/suite/version-page.test.ts
+++ b/packages/suite-web/e2e/tests/suite/version-page.test.ts
@@ -15,5 +15,3 @@ describe('There is a hidden route (not accessible in UI)', () => {
         cy.getTestElement('@modal/version').screenshot('version-modal');
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/wallet/add-account-types.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/add-account-types.test.ts
@@ -163,5 +163,3 @@ describe('Account types suite', () => {
         });
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/wallet/cardano.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/cardano.test.ts
@@ -75,5 +75,3 @@ describe('Cardano', () => {
         cy.getTestElement('@app').matchImageSnapshot('staking-not-enabled');
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/wallet/check-coins-xpub.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/check-coins-xpub.test.ts
@@ -54,5 +54,3 @@ describe('Check coins XPUB', () => {
         });
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/wallet/coin-balance.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/coin-balance.test.ts
@@ -45,5 +45,3 @@ describe('Dashboard with regtest', () => {
             });
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/wallet/custom-blockbook-discovery.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/custom-blockbook-discovery.test.ts
@@ -95,5 +95,3 @@ describe('Custom-blockbook-discovery', () => {
         cy.getTestElement('@dashboard/graph').should('exist');
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/wallet/discovery.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/discovery.test.ts
@@ -49,5 +49,3 @@ describe('Discovery', () => {
         });
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/wallet/export-transactions.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/export-transactions.test.ts
@@ -73,5 +73,3 @@ describe('Export transactions', () => {
         });
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/wallet/import-btc-csv.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/import-btc-csv.test.ts
@@ -75,5 +75,3 @@ describe('Import a BTC csv file', () => {
         });
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/wallet/look-up-an-account.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/look-up-an-account.test.ts
@@ -46,5 +46,3 @@ describe('Look up a BTC account', () => {
         cy.getTestElement('@account-menu/ltc/normal/0').should('not.exist');
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/wallet/overview-and-transactions.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/overview-and-transactions.test.ts
@@ -51,5 +51,3 @@ describe('Overview and transactions check', () => {
         onAccountsPage.accountsPaginationCheck();
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/wallet/pending-transactions.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/pending-transactions.test.ts
@@ -130,5 +130,3 @@ describe('Use regtest to test pending transactions', () => {
         });
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/wallet/send-form-doge.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/send-form-doge.test.ts
@@ -67,5 +67,3 @@ describe('Doge send form with mocked blockbook', () => {
         });
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/wallet/send-form-ltc.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/send-form-ltc.test.ts
@@ -66,5 +66,3 @@ describe('LTC send form with mocked blockbook', () => {
         );
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/wallet/send-form-regtest.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/send-form-regtest.test.ts
@@ -100,5 +100,3 @@ describe('Send form for bitcoin', () => {
         );
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/wallet/sign-and-verify-eth.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/sign-and-verify-eth.test.ts
@@ -83,5 +83,3 @@ describe('Sign and verify ETH', () => {
         cy.getTestElement('@toast/verify-message-success');
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/wallet/sign-and-verify.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/sign-and-verify.test.ts
@@ -75,5 +75,3 @@ describe('Sign and verify', () => {
         cy.getTestElement('@toast/verify-message-success');
     });
 });
-
-export {};

--- a/packages/suite-web/e2e/tests/wallet/staking.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/staking.test.ts
@@ -75,5 +75,3 @@ describe('ETH staking', () => {
         });
     });
 });
-
-export {};

--- a/packages/suite/src/actions/backup/__tests__/backupActions.test.ts
+++ b/packages/suite/src/actions/backup/__tests__/backupActions.test.ts
@@ -9,7 +9,7 @@ import { SUITE } from 'src/actions/suite/constants';
 import { BACKUP } from 'src/actions/backup/constants';
 import * as backupActions from 'src/actions/backup/backupActions';
 
-export const getInitialState = (override: any) => {
+const getInitialState = (override: any) => {
     const defaults = {
         suite: {
             locks: [3],

--- a/packages/suite/src/actions/firmware/__tests__/firmwareActions.test.ts
+++ b/packages/suite/src/actions/firmware/__tests__/firmwareActions.test.ts
@@ -20,7 +20,7 @@ interface InitialState {
 
 jest.doMock('@trezor/suite-analytics', () => testMocks.getAnalytics());
 
-export const getInitialState = (override?: InitialState): any => {
+const getInitialState = (override?: InitialState): any => {
     const suite = override ? override.suite : undefined;
     const device = override ? override.device : undefined;
 

--- a/packages/suite/src/actions/onboarding/__tests__/onboardingActions.test.ts
+++ b/packages/suite/src/actions/onboarding/__tests__/onboardingActions.test.ts
@@ -18,7 +18,7 @@ import { Action } from 'src/types/suite';
 //     suite?: SuiteState;
 // }
 
-export const getInitialState = (custom?: any) => {
+const getInitialState = (custom?: any) => {
     const suite = custom ? custom.suite : undefined;
     const onboarding = custom ? custom.onboarding : undefined;
 

--- a/packages/suite/src/actions/recovery/__tests__/recoveryActions.test.ts
+++ b/packages/suite/src/actions/recovery/__tests__/recoveryActions.test.ts
@@ -5,7 +5,7 @@ import recoveryReducer from 'src/reducers/recovery/recoveryReducer';
 import { Action } from 'src/types/suite';
 import * as recoveryActions from 'src/actions/recovery/recoveryActions';
 
-export const getInitialState = (custom?: any): any => ({
+const getInitialState = (custom?: any): any => ({
     suite: {
         flags: {},
         locks: [],

--- a/packages/suite/src/actions/settings/__tests__/deviceSettingsActions.test.ts
+++ b/packages/suite/src/actions/settings/__tests__/deviceSettingsActions.test.ts
@@ -16,7 +16,7 @@ jest.doMock('@trezor/suite-analytics', () => testMocks.getAnalytics());
 
 const DEVICE = getSuiteDevice({ path: '1', connected: true });
 
-export const getInitialState = (state: Partial<DeviceSettingsFixtureState> = {}) => ({
+const getInitialState = (state: Partial<DeviceSettingsFixtureState> = {}) => ({
     suite: {
         ...suiteReducer(undefined, { type: '@suite/init' }),
     },

--- a/packages/suite/src/actions/settings/__tests__/walletSettingsActions.test.ts
+++ b/packages/suite/src/actions/settings/__tests__/walletSettingsActions.test.ts
@@ -5,7 +5,7 @@ import settingsReducer from 'src/reducers/wallet/settingsReducer';
 import suiteReducer from 'src/reducers/suite/suiteReducer';
 import fixtures from '../__fixtures__/walletSettings';
 
-export const getInitialState = (settings?: any) => ({
+const getInitialState = (settings?: any) => ({
     suite: { ...suiteReducer(undefined, { type: 'foo' } as any) },
     wallet: {
         settings: {

--- a/packages/suite/src/actions/suite/__tests__/analyticsActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/analyticsActions.test.ts
@@ -12,7 +12,7 @@ type InitialState = {
     analytics: Partial<AnalyticsState>;
 };
 
-export const getInitialState = (state?: InitialState) => ({
+const getInitialState = (state?: InitialState) => ({
     analytics: {
         ...analyticsReducer(undefined, { type: 'foo' } as any),
         ...state?.analytics,

--- a/packages/suite/src/actions/suite/__tests__/metadataActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/metadataActions.test.ts
@@ -46,7 +46,7 @@ interface InitialState {
     suite: Partial<SuiteState>;
 }
 
-export const getInitialState = (state?: InitialState) => {
+const getInitialState = (state?: InitialState) => {
     const metadata = state ? state.metadata : undefined;
     const suite = state ? state.suite : {};
 

--- a/packages/suite/src/actions/suite/__tests__/protocolActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/protocolActions.test.ts
@@ -10,7 +10,7 @@ import * as protocolConstants from '../constants/protocolConstants';
 
 jest.doMock('@trezor/suite-analytics', () => testMocks.getAnalytics());
 
-export const getInitialState = (state?: ProtocolState) => ({
+const getInitialState = (state?: ProtocolState) => ({
     protocol: {
         ...protocolReducer(undefined, { type: 'foo' } as any),
         ...state,

--- a/packages/suite/src/actions/suite/__tests__/resizeActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/resizeActions.test.ts
@@ -3,7 +3,7 @@ import { configureStore } from 'src/support/tests/configureStore';
 import resizeReducer, { State as ResizeState } from 'src/reducers/suite/resizeReducer';
 import * as resizeActions from 'src/actions/suite/resizeActions';
 
-export const getInitialState = (state?: ResizeState) => ({
+const getInitialState = (state?: ResizeState) => ({
     resize: {
         ...resizeReducer(undefined, { type: 'foo' } as any),
         ...state,

--- a/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
@@ -108,7 +108,7 @@ type PartialState = Pick<AppState, 'suite' | 'device'> & {
     >;
 };
 
-export const getInitialState = (prevState?: Partial<PartialState>, action?: any) => ({
+const getInitialState = (prevState?: Partial<PartialState>, action?: any) => ({
     suite: suiteReducer(
         prevState ? prevState.suite : undefined,
         action || ({ type: 'foo' } as any),

--- a/packages/suite/src/actions/suite/__tests__/trezorConnectActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/trezorConnectActions.test.ts
@@ -12,7 +12,7 @@ const deviceReducer = prepareDeviceReducer(extraDependencies);
 
 type SuiteState = ReturnType<typeof suiteReducer>;
 type DevicesState = ReturnType<typeof deviceReducer>;
-export const getInitialState = (suite?: Partial<SuiteState>, device?: Partial<DevicesState>) => ({
+const getInitialState = (suite?: Partial<SuiteState>, device?: Partial<DevicesState>) => ({
     suite: {
         ...suiteReducer(undefined, { type: 'foo' } as any),
         ...suite,

--- a/packages/suite/src/actions/wallet/__tests__/blockchainActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/blockchainActions.test.ts
@@ -31,7 +31,7 @@ interface Args {
     transactions?: TransactionsState['transactions'];
 }
 
-export const getInitialState = (
+const getInitialState = (
     { accounts, transactions, blockchain, fees }: Args = {},
     action: any = { type: 'initial' },
 ) => ({

--- a/packages/suite/src/actions/wallet/__tests__/coinjoinClientActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/coinjoinClientActions.test.ts
@@ -234,6 +234,7 @@ describe('coinjoinClientActions', () => {
         spy.mockClear();
 
         // for coverage, init same instance multiple times without waiting
+        // eslint-disable-next-line jest/valid-expect-in-promise
         store.dispatch(initCoinjoinService('test')).then(cli3 => {
             expect(cli3?.client.settings.network).toEqual('test');
         });

--- a/packages/suite/src/actions/wallet/__tests__/coinmarketBuyActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/coinmarketBuyActions.test.ts
@@ -55,7 +55,7 @@ const setFetchMock = (mock: any) => {
 describe('Coinmarket Buy Actions', () => {
     invityAPI.createInvityAPIKey('mock');
 
-    it('load and saveBuyInfo', () => {
+    it('load and saveBuyInfo', async () => {
         const buyList = {
             country: 'CZ',
             suggestedFiatCurrency: 'CZK',
@@ -93,7 +93,7 @@ describe('Coinmarket Buy Actions', () => {
 
         const store = initStore(getInitialState());
 
-        coinmarketBuyActions.loadBuyInfo().then(buyInfo => {
+        await coinmarketBuyActions.loadBuyInfo().then(buyInfo => {
             store.dispatch(coinmarketBuyActions.saveBuyInfo(buyInfo));
             expect(store.getState().wallet.coinmarket.buy.buyInfo).toEqual({
                 buyInfo: {

--- a/packages/suite/src/actions/wallet/__tests__/coinmarketExchangeActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/coinmarketExchangeActions.test.ts
@@ -105,7 +105,7 @@ describe('Coinmarket Exchange Actions', () => {
 
         const store = initStore(getInitialState());
 
-        coinmarketExchangeActions.loadExchangeInfo().then(exchangeInfo => {
+        return coinmarketExchangeActions.loadExchangeInfo().then(exchangeInfo => {
             store.dispatch(coinmarketExchangeActions.saveExchangeInfo(exchangeInfo));
             expect(store.getState().wallet.coinmarket.exchange.exchangeInfo).toEqual({
                 exchangeList,

--- a/packages/suite/src/actions/wallet/__tests__/discoveryActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/discoveryActions.test.ts
@@ -172,7 +172,7 @@ const setTrezorConnectFixtures = (input?: FixtureInput) => {
 };
 
 const SUITE_DEVICE = getSuiteDevice({ state: '1stTestnetAddress@device_id:0', connected: true });
-export const getInitialState = (device = SUITE_DEVICE) => ({
+const getInitialState = (device = SUITE_DEVICE) => ({
     device: {
         devices: [device],
         selectedDevice: device,
@@ -437,25 +437,26 @@ describe('Discovery Actions', () => {
         expect(store.getState().wallet.discovery.length).toEqual(0);
     });
 
-    it('Start/stop', done => {
-        const f = new Promise<any>(resolve => {
-            setTimeout(() => resolve(paramsError('discovery_interrupted')), 100);
-        });
-        // set fixtures in @trezor/connect
-        setTrezorConnectFixtures(f);
-        const store = initStore();
-        store.dispatch(
-            createDiscoveryThunk({
-                deviceState: '1stTestnetAddress@device_id:0',
-                device: SUITE_DEVICE,
-            }),
-        );
-        store.dispatch(startDiscoveryThunk()).then(() => {
-            const action = filterThunkActionTypes(store.getActions()).pop();
-            done(expect(action?.type).toEqual(discoveryActions.stopDiscovery.type));
-        });
-        store.dispatch(stopDiscoveryThunk());
-    });
+    it('Start/stop', () =>
+        new Promise<void>(done => {
+            const f = new Promise<any>(resolve => {
+                setTimeout(() => resolve(paramsError('discovery_interrupted')), 100);
+            });
+            // set fixtures in @trezor/connect
+            setTrezorConnectFixtures(f);
+            const store = initStore();
+            store.dispatch(
+                createDiscoveryThunk({
+                    deviceState: '1stTestnetAddress@device_id:0',
+                    device: SUITE_DEVICE,
+                }),
+            );
+            store.dispatch(startDiscoveryThunk()).then(() => {
+                const action = filterThunkActionTypes(store.getActions()).pop();
+                done(expect(action?.type).toEqual(discoveryActions.stopDiscovery.type));
+            });
+            store.dispatch(stopDiscoveryThunk());
+        }));
 
     it('Stop discovery without device (discovery not exists)', async () => {
         const state = {

--- a/packages/suite/src/actions/wallet/__tests__/formDraftActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/formDraftActions.test.ts
@@ -3,7 +3,7 @@ import { configureStore } from 'src/support/tests/configureStore';
 import formDraftReducer, { FormDraftState } from 'src/reducers/wallet/formDraftReducer';
 import * as formDraftActions from '../formDraftActions';
 
-export const getInitialState = (state?: FormDraftState) => ({
+const getInitialState = (state?: FormDraftState) => ({
     wallet: {
         formDrafts: formDraftReducer(state, { type: 'foo' } as any),
     },

--- a/packages/suite/src/actions/wallet/__tests__/receiveActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/receiveActions.test.ts
@@ -86,7 +86,7 @@ interface InitialState {
     modal: ModalState;
 }
 
-export const getInitialState = (state: Partial<InitialState> | undefined) => ({
+const getInitialState = (state: Partial<InitialState> | undefined) => ({
     suite: {
         ...suiteReducer(undefined, { type: 'foo' } as any),
         ...state?.suite,

--- a/packages/suite/src/actions/wallet/__tests__/selectedAccountActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/selectedAccountActions.test.ts
@@ -5,7 +5,7 @@ import selectedAccountReducer from 'src/reducers/wallet/selectedAccountReducer';
 import { syncSelectedAccount } from '../selectedAccountActions';
 import fixtures from '../__fixtures__/selectedAccountActions';
 
-export const getInitialState = (_settings?: any) => ({
+const getInitialState = (_settings?: any) => ({
     wallet: {
         selectedAccount: {
             ...selectedAccountReducer(undefined, { type: 'foo' } as any),

--- a/packages/suite/src/actions/wallet/coinmarket/__tests__/coinmarketCommonActions.test.ts
+++ b/packages/suite/src/actions/wallet/coinmarket/__tests__/coinmarketCommonActions.test.ts
@@ -24,7 +24,7 @@ interface InitialState {
     };
 }
 
-export const getInitialState = (initial: InitialState) => ({
+const getInitialState = (initial: InitialState) => ({
     ...DEFAULT_STORE,
     ...initial,
     wallet: {

--- a/packages/suite/src/components/suite/DeviceDisplay/__tests__/DeviceDisplay.test.tsx
+++ b/packages/suite/src/components/suite/DeviceDisplay/__tests__/DeviceDisplay.test.tsx
@@ -8,9 +8,9 @@ import { DeviceModelInternal } from '@trezor/connect';
 import { DeepPartial } from '@trezor/type-utils';
 import suiteReducer from '../../../../reducers/suite/suiteReducer';
 
-export const deviceReducer = prepareDeviceReducer(extraDependencies);
+const deviceReducer = prepareDeviceReducer(extraDependencies);
 
-export type State = {
+type State = {
     device: DeepPartial<ReturnType<typeof deviceReducer>>;
     suite: DeepPartial<ReturnType<typeof suiteReducer>>;
 };

--- a/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
+++ b/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
@@ -52,7 +52,7 @@ jest.mock('@trezor/suite-desktop-api', () => ({
 //     default: () => ['ref', { height: 0 }],
 // }));
 
-export const getInitialState = ({ suite, router, device }: any = {}) => ({
+const getInitialState = ({ suite, router, device }: any = {}) => ({
     suite: {
         lifecycle: {
             status: 'ready',

--- a/packages/suite/src/hooks/suite/__tests__/useDiscovery.test.tsx
+++ b/packages/suite/src/hooks/suite/__tests__/useDiscovery.test.tsx
@@ -14,7 +14,7 @@ import { actions } from '../__fixtures__/useDiscovery';
 const discoveryReducer = prepareDiscoveryReducer(extraDependencies);
 const deviceReducer = prepareDeviceReducer(extraDependencies);
 
-export const getInitialState = (action: any = { type: 'initial' }) => ({
+const getInitialState = (action: any = { type: 'initial' }) => ({
     wallet: {
         discovery: discoveryReducer(undefined, action),
     },

--- a/packages/suite/src/middlewares/suite/__tests__/buttonRequestMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/buttonRequestMiddleware.test.ts
@@ -16,7 +16,7 @@ const { getSuiteDevice } = testMocks;
 
 const device = getSuiteDevice();
 
-export const getInitialState = () => ({
+const getInitialState = () => ({
     router: routerReducer(undefined, { type: 'foo' } as any),
     suite: {
         ...suiteReducer(undefined, { type: 'foo' } as any),

--- a/packages/suite/src/middlewares/suite/__tests__/messageSystemMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/messageSystemMiddleware.test.ts
@@ -20,7 +20,7 @@ type WalletsState = ReturnType<typeof WalletReducers>;
 type MessageSystemState = ReturnType<typeof messageSystemReducer>;
 type SuiteState = ReturnType<typeof suiteReducer>;
 
-export const getInitialState = (
+const getInitialState = (
     messageSystem?: Partial<MessageSystemState>,
     wallet?: Partial<WalletsState>,
     suite?: Partial<SuiteState>,

--- a/packages/suite/src/middlewares/suite/__tests__/protocolMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/protocolMiddleware.test.ts
@@ -14,7 +14,7 @@ const middlewares = [protocolMiddleware];
 type ProtocolState = ReturnType<typeof protocolReducer>;
 type NotificationsState = ReturnType<typeof notificationsReducer>;
 
-export const getInitialState = (
+const getInitialState = (
     notifications: Partial<NotificationsState>,
     protocol?: Partial<ProtocolState>,
 ) => ({

--- a/packages/suite/src/middlewares/wallet/__tests__/coinmarketMiddleware.test.ts
+++ b/packages/suite/src/middlewares/wallet/__tests__/coinmarketMiddleware.test.ts
@@ -22,7 +22,7 @@ invityAPI.getInfo = () =>
         platforms: {},
     });
 
-export const ACCOUNT = {
+const ACCOUNT = {
     descriptor: 'btc-descriptor',
 };
 
@@ -45,6 +45,7 @@ const COINMARKET_EXCHANGE_ROUTE = {
 type CoinmarketState = ReturnType<typeof coinmarketReducer>;
 type SelectedAccountState = ReturnType<typeof selectedAccountReducer>;
 type SuiteState = ReturnType<typeof suiteReducer>;
+
 interface Args {
     coinmarket?: CoinmarketState;
     selectedAccount?: SelectedAccountState;
@@ -53,7 +54,7 @@ interface Args {
     modal?: ModalState;
 }
 
-export const getInitialState = ({ coinmarket, selectedAccount }: Args = {}) => ({
+const getInitialState = ({ coinmarket, selectedAccount }: Args = {}) => ({
     wallet: {
         coinmarket:
             coinmarket ||

--- a/packages/suite/src/middlewares/wallet/__tests__/walletMiddleware.test.ts
+++ b/packages/suite/src/middlewares/wallet/__tests__/walletMiddleware.test.ts
@@ -27,6 +27,7 @@ const TrezorConnect = testMocks.getTrezorConnectMock();
 
 type AccountsState = ReturnType<typeof accountsReducer>;
 type SettingsState = ReturnType<typeof walletSettingsReducer>;
+
 interface Args {
     router?: Partial<RouterState>;
     accounts?: AccountsState;
@@ -35,13 +36,7 @@ interface Args {
     send?: Partial<SendState>;
 }
 
-export const getInitialState = ({
-    router,
-    accounts,
-    settings,
-    selectedAccount,
-    send,
-}: Args = {}) => ({
+const getInitialState = ({ router, accounts, settings, selectedAccount, send }: Args = {}) => ({
     router: {
         app: 'wallet',
         ...router,

--- a/packages/suite/src/reducers/wallet/__tests__/cardanoStakingReducer.test.ts
+++ b/packages/suite/src/reducers/wallet/__tests__/cardanoStakingReducer.test.ts
@@ -162,28 +162,6 @@ describe('cardanoStakingReducer reducer', () => {
         });
     });
 
-    it('CARDANO_STAKING.SET_FETCH_ERROR mainnet', () => {
-        expect(
-            reducer(undefined, {
-                type: CARDANO_STAKING.SET_FETCH_ERROR,
-                error: true,
-                network: 'mainnet',
-            } as any),
-        ).toEqual({
-            mainnet: {
-                trezorPools: undefined,
-                isFetchError: true,
-                isFetchLoading: false,
-            },
-            preview: {
-                trezorPools: undefined,
-                isFetchError: false,
-                isFetchLoading: false,
-            },
-            pendingTx: [],
-        });
-    });
-
     it('CARDANO_STAKING.SET_TREZOR_POOLS mainnet', () => {
         expect(
             reducer(undefined, {

--- a/packages/suite/src/utils/wallet/__tests__/coinjoinUtils.test.ts
+++ b/packages/suite/src/utils/wallet/__tests__/coinjoinUtils.test.ts
@@ -28,7 +28,7 @@ describe('getRoundPhaseFromSessionPhase', () => {
             const getSessionPhase = () => coinjoinUtils.getRoundPhaseFromSessionPhase(sessionPhase);
 
             if (result === 'error') {
-                expect(getSessionPhase).toThrowError();
+                expect(getSessionPhase).toThrow();
             } else {
                 expect(getSessionPhase()).toEqual(result);
             }
@@ -43,7 +43,7 @@ describe('getFirstSessionPhaseFromRoundPhase', () => {
                 coinjoinUtils.getFirstSessionPhaseFromRoundPhase(roundPhase);
 
             if (result === 'error') {
-                expect(getSessionPhase).toThrowError();
+                expect(getSessionPhase).toThrow();
             } else {
                 expect(getSessionPhase()).toEqual(result);
             }

--- a/packages/suite/src/utils/wallet/coinmarket/__tests__/coinmarketUtils.test.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/__tests__/coinmarketUtils.test.ts
@@ -289,7 +289,7 @@ describe('coinmarket utils', () => {
         });
     });
 
-    it('coinmarketBuildAccountOptions', () => {
+    it('coinmarketBuildAccountOptions: basic', () => {
         expect(coinmarketGetRoundedFiatAmount('0.23923')).toBe('0.24');
         expect(coinmarketGetRoundedFiatAmount('0.24423')).toBe('0.24');
         expect(coinmarketGetRoundedFiatAmount('0.2')).toBe('0.20');

--- a/packages/transport-test/e2e/bridge/bridge.test.ts
+++ b/packages/transport-test/e2e/bridge/bridge.test.ts
@@ -23,6 +23,7 @@ describe('bridge', () => {
 
         const enumerateResult = await bridge.enumerate();
         assertSuccess(enumerateResult);
+        // eslint-disable-next-line jest/no-standalone-expect
         expect(enumerateResult).toMatchObject({
             success: true,
             payload: [
@@ -35,6 +36,7 @@ describe('bridge', () => {
         });
 
         const { path } = enumerateResult.payload[0];
+        // eslint-disable-next-line jest/no-standalone-expect
         expect(path.length).toEqual(pathLength);
 
         descriptors = enumerateResult.payload;
@@ -43,6 +45,7 @@ describe('bridge', () => {
             input: { path: descriptors[0].path, previous: session },
         });
         assertSuccess(acquireResult);
+        // eslint-disable-next-line jest/no-standalone-expect
         expect(acquireResult).toEqual({
             success: true,
             payload: '1',

--- a/packages/transport-test/e2e/bridge/multi-client.test.ts
+++ b/packages/transport-test/e2e/bridge/multi-client.test.ts
@@ -209,7 +209,7 @@ describe('bridge', () => {
                 input: { previous: session1.payload, path },
             });
 
-            expect(receive1res).resolves.toMatchObject({
+            await expect(receive1res).resolves.toMatchObject({
                 success: false,
                 // todo: this error is expected, fix errors. also emu error is weird
                 error: errorCase1,

--- a/packages/transport/tests/abstractUsb.test.ts
+++ b/packages/transport/tests/abstractUsb.test.ts
@@ -349,7 +349,7 @@ describe('Usb', () => {
             });
             abort.abort();
 
-            expect(promise).resolves.toMatchObject({
+            await expect(promise).resolves.toMatchObject({
                 success: false,
                 error: 'Aborted by signal',
             });
@@ -361,7 +361,7 @@ describe('Usb', () => {
                 protocol: v1Protocol,
             });
             await promise2;
-            expect(promise2).resolves.toEqual({
+            await expect(promise2).resolves.toEqual({
                 success: true,
                 payload: {
                     type: 'Success',

--- a/packages/utils/tests/createLazy.test.ts
+++ b/packages/utils/tests/createLazy.test.ts
@@ -44,7 +44,7 @@ describe('createLazy', () => {
         expect(disposeFn).toHaveBeenCalledWith([42]);
     });
 
-    it('dispose during init', () => {
+    it('dispose during init', async () => {
         const initFn = jest.fn(returnDelayed(500));
         const lazy = createLazy(initFn);
 
@@ -62,8 +62,8 @@ describe('createLazy', () => {
 
         jest.advanceTimersByTime(400);
 
-        expect(initPromise).rejects.toThrow('Disposed during initialization');
         expect(lazy.getPending()).toEqual(undefined);
         expect(lazy.get()).toEqual(undefined);
+        await expect(initPromise).rejects.toThrow('Disposed during initialization');
     });
 });

--- a/packages/utils/tests/getMutex.test.ts
+++ b/packages/utils/tests/getMutex.test.ts
@@ -93,21 +93,22 @@ describe('getMutex', () => {
         ]);
     });
 
-    it('nested', done => {
-        lock().then(unlock =>
-            sequence(['a', 3])
-                .then(() => {
-                    // 'c' registers after 'a' ended and while 'b' is running
-                    delay(2).then(() =>
-                        lock()
-                            .then(unlock2 => sequence(['c', 3]).finally(unlock2))
-                            .then(done),
-                    );
-                })
-                .finally(unlock),
-        );
-        lock().then(unlock => sequence(['b', 8]).finally(unlock));
-    });
+    it('nested', () =>
+        new Promise<void>(done => {
+            lock().then(unlock =>
+                sequence(['a', 3])
+                    .then(() => {
+                        // 'c' registers after 'a' ended and while 'b' is running
+                        delay(2).then(() =>
+                            lock()
+                                .then(unlock2 => sequence(['c', 3]).finally(unlock2))
+                                .then(done),
+                        );
+                    })
+                    .finally(unlock),
+            );
+            lock().then(unlock => sequence(['b', 8]).finally(unlock));
+        }));
 
     it('with keys', async () => {
         let state1: any, state2: any;

--- a/packages/utils/tests/getRandomInt.test.ts
+++ b/packages/utils/tests/getRandomInt.test.ts
@@ -8,8 +8,8 @@ describe(getRandomInt.name, () => {
             'The value of "max" is out of range. It must be greater than the value of "min" (0). Received -1',
         );
 
-        expect(() => randomInt(0, -1)).toThrowError(EXPECTED_ERROR);
-        expect(() => getRandomInt(0, -1)).toThrowError(EXPECTED_ERROR);
+        expect(() => randomInt(0, -1)).toThrow(EXPECTED_ERROR);
+        expect(() => getRandomInt(0, -1)).toThrow(EXPECTED_ERROR);
     });
 
     it('raises error for range > 2^32', () => {
@@ -17,7 +17,7 @@ describe(getRandomInt.name, () => {
             'This function only provide 32 bits of entropy, therefore range cannot be more then 2^32.',
         );
 
-        expect(() => getRandomInt(0, Math.pow(2, 32) + 1)).toThrowError(EXPECTED_ERROR);
+        expect(() => getRandomInt(0, Math.pow(2, 32) + 1)).toThrow(EXPECTED_ERROR);
     });
 
     it('raises same error for unsafe integer', () => {
@@ -27,12 +27,8 @@ describe(getRandomInt.name, () => {
             'The "min" argument must be a safe integer. Received type number (9007199254740992)',
         );
 
-        expect(() => randomInt(UNSAFE_INTEGER, UNSAFE_INTEGER + 1)).toThrowError(
-            EXPECTED_ERROR_MIN,
-        );
-        expect(() => getRandomInt(UNSAFE_INTEGER, UNSAFE_INTEGER + 1)).toThrowError(
-            EXPECTED_ERROR_MIN,
-        );
+        expect(() => randomInt(UNSAFE_INTEGER, UNSAFE_INTEGER + 1)).toThrow(EXPECTED_ERROR_MIN);
+        expect(() => getRandomInt(UNSAFE_INTEGER, UNSAFE_INTEGER + 1)).toThrow(EXPECTED_ERROR_MIN);
 
         const EXPECTED_ERROR_MAX = new RangeError(
             'The "max" argument must be a safe integer. Received type number (9007199254740992)',
@@ -41,10 +37,10 @@ describe(getRandomInt.name, () => {
             'The "max" argument must be a safe integer. Received type number (-9007199254740992)',
         );
 
-        expect(() => randomInt(0, UNSAFE_INTEGER)).toThrowError(EXPECTED_ERROR_MAX);
-        expect(() => getRandomInt(0, UNSAFE_INTEGER)).toThrowError(EXPECTED_ERROR_MAX);
-        expect(() => randomInt(0, -UNSAFE_INTEGER)).toThrowError(EXPECTED_ERROR_MAX_NEGATIVE);
-        expect(() => getRandomInt(0, -UNSAFE_INTEGER)).toThrowError(EXPECTED_ERROR_MAX_NEGATIVE);
+        expect(() => randomInt(0, UNSAFE_INTEGER)).toThrow(EXPECTED_ERROR_MAX);
+        expect(() => getRandomInt(0, UNSAFE_INTEGER)).toThrow(EXPECTED_ERROR_MAX);
+        expect(() => randomInt(0, -UNSAFE_INTEGER)).toThrow(EXPECTED_ERROR_MAX_NEGATIVE);
+        expect(() => getRandomInt(0, -UNSAFE_INTEGER)).toThrow(EXPECTED_ERROR_MAX_NEGATIVE);
     });
 
     // This test takes 100+seconds to run. It is very needed for development and debugging,

--- a/packages/utils/tests/getSynchronize.test.ts
+++ b/packages/utils/tests/getSynchronize.test.ts
@@ -59,15 +59,16 @@ describe('getSynchronize', () => {
         ]);
     });
 
-    it('nested', done => {
-        synchronize(() =>
-            sequence(['a', 3]).then(() => {
-                // 'c' registers after 'a' ended and while 'b' is running
-                delay(2).then(() => synchronize(() => sequence(['c', 3])).then(done));
-            }),
-        );
-        synchronize(() => sequence(['b', 8]));
-    });
+    it('nested', () =>
+        new Promise<void>(done => {
+            synchronize(() =>
+                sequence(['a', 3]).then(() => {
+                    // 'c' registers after 'a' ended and while 'b' is running
+                    delay(2).then(() => synchronize(() => sequence(['c', 3])).then(done));
+                }),
+            );
+            synchronize(() => sequence(['b', 8]));
+        }));
 
     it('with keys', async () => {
         let state1: any, state2: any;

--- a/packages/utils/tests/getWeakRandomInt.test.ts
+++ b/packages/utils/tests/getWeakRandomInt.test.ts
@@ -6,12 +6,7 @@ describe(getWeakRandomInt.name, () => {
             'The value of "max" is out of range. It must be greater than the value of "min" (0). Received -1',
         );
 
-        expect(() => getWeakRandomInt(0, -1)).toThrowError(EXPECTED_ERROR);
-    });
-
-    it('returns same value when range is trivial', () => {
-        expect(getWeakRandomInt(0, 1)).toEqual(0);
-        expect(getWeakRandomInt(100, 101)).toEqual(100);
+        expect(() => getWeakRandomInt(0, -1)).toThrow(EXPECTED_ERROR);
     });
 
     it('returns same value when range is trivial', () => {

--- a/packages/utils/tests/mergeDeepObject.test.ts
+++ b/packages/utils/tests/mergeDeepObject.test.ts
@@ -162,7 +162,7 @@ describe('mergeDeepObject', () => {
         });
 
         it("can't mergeDeepObject arrays when provided directly as args", () => {
-            expect(() => mergeDeepObject([1], [2])).toThrowError(
+            expect(() => mergeDeepObject([1], [2])).toThrow(
                 new TypeError('Arguments provided to ts-deepmerge must be objects, not arrays.'),
             );
         });

--- a/packages/utils/tests/scheduleAction.test.ts
+++ b/packages/utils/tests/scheduleAction.test.ts
@@ -36,30 +36,32 @@ describe('scheduleAction', () => {
         jest.clearAllMocks();
     });
 
-    it('delay', done => {
-        const spy = jest.fn(() => Promise.resolve());
-        scheduleAction(spy, { delay: 1000 });
-        expect(spy).toHaveBeenCalledTimes(0);
-
-        setTimeout(() => {
-            expect(spy).toHaveBeenCalledTimes(1);
-            expect(checkListeners()).toBeUndefined();
-            done();
-        }, 1005);
-    });
-
-    it('delay aborted', done => {
-        const aborter = new AbortController();
-        const spy = jest.fn(() => Promise.resolve());
-        scheduleAction(spy, { delay: 1000, signal: aborter.signal }).catch(e => {
-            expect(e.message).toMatch(ERR_SIGNAL);
+    it('delay', () =>
+        new Promise<void>(done => {
+            const spy = jest.fn(() => Promise.resolve());
+            scheduleAction(spy, { delay: 1000 });
             expect(spy).toHaveBeenCalledTimes(0);
-            expect(checkListeners()).toBeUndefined();
-            done();
-        });
 
-        aborter.abort();
-    });
+            setTimeout(() => {
+                expect(spy).toHaveBeenCalledTimes(1);
+                expect(checkListeners()).toBeUndefined();
+                done();
+            }, 1005);
+        }));
+
+    it('delay aborted', () =>
+        new Promise<void>(done => {
+            const aborter = new AbortController();
+            const spy = jest.fn(() => Promise.resolve());
+            scheduleAction(spy, { delay: 1000, signal: aborter.signal }).catch(e => {
+                expect(e.message).toMatch(ERR_SIGNAL);
+                expect(spy).toHaveBeenCalledTimes(0);
+                expect(checkListeners()).toBeUndefined();
+                done();
+            });
+
+            aborter.abort();
+        }));
 
     it('deadline on always failing action', async () => {
         const spy = jest.fn(() => {

--- a/packages/utxo-lib/tests/address.test.ts
+++ b/packages/utxo-lib/tests/address.test.ts
@@ -22,7 +22,7 @@ describe('address', () => {
             it(`throws on ${f.exception}`, () => {
                 expect(() => {
                     baddress.fromBase58Check(f.address, getNetwork(f.network));
-                }).toThrowError(new RegExp(`${f.address} ${f.exception}`));
+                }).toThrow(new RegExp(`${f.address} ${f.exception}`));
             });
         });
     });
@@ -50,7 +50,7 @@ describe('address', () => {
             it(`decode fails for ${f.address}(${f.exception})`, () => {
                 expect(() => {
                     baddress.fromBech32(f.address);
-                }).toThrowError(new RegExp(f.exception));
+                }).toThrow(new RegExp(f.exception));
             });
         });
     });
@@ -69,7 +69,7 @@ describe('address', () => {
                 const script = bscript.fromASM(f.script);
                 expect(() => {
                     baddress.fromOutputScript(script);
-                }).toThrowError(new RegExp(f.exception));
+                }).toThrow(new RegExp(f.exception));
             });
         });
     });
@@ -86,6 +86,7 @@ describe('address', () => {
 
         // TODO: These fixtures (according to TypeScript) have none of the data used below
         // fixtures.invalid.bech32.forEach((f, i) => {
+        // eslint-disable-next-line jest/no-commented-out-tests
         //     it(`encode fails (${f.exception}`, () => {
         //         expect(() => {
         //             baddress.toBech32(Buffer.from(f.data, 'hex'), f.version, f.prefix);
@@ -111,7 +112,7 @@ describe('address', () => {
                 const network = typeof f.network === 'string' ? getNetwork(f.network) : f.network;
                 expect(() => {
                     baddress.toOutputScript(f.address, network);
-                }).toThrowError(new RegExp(`${f.address} ${f.exception}`));
+                }).toThrow(new RegExp(`${f.address} ${f.exception}`));
             });
         });
     });

--- a/packages/utxo-lib/tests/bip32.test.ts
+++ b/packages/utxo-lib/tests/bip32.test.ts
@@ -23,7 +23,7 @@ function verify(hd: BIP32.BIP32Interface, prv: boolean, f: Fixture, network: NET
     if (prv) expect(hd.toBase58()).toEqual(f.base58Priv);
     if (prv) expect(hd.privateKey?.toString('hex')).toEqual(f.privKey);
     if (prv) expect(hd.toWIF()).toEqual(f.wif);
-    if (!prv) expect(() => hd.toWIF()).toThrowError(/Missing private key/);
+    if (!prv) expect(() => hd.toWIF()).toThrow(/Missing private key/);
     if (!prv) expect(hd.privateKey).toEqual(undefined);
     expect(hd.neutered().toBase58()).toEqual(f.base58);
     expect(hd.isNeutered()).toEqual(!prv);
@@ -56,7 +56,7 @@ function verify(hd: BIP32.BIP32Interface, prv: boolean, f: Fixture, network: NET
 
         expect(() => {
             shd.derivePath('m/0');
-        }).toThrowError(/Expected master, got child/);
+        }).toThrow(/Expected master, got child/);
 
         verify(shd, prv, cf, network);
     });
@@ -104,7 +104,7 @@ describe('fromBase58 throws', () => {
         it(`throws ${f.exception}`, () => {
             expect(() => {
                 BIP32.fromBase58(f.string, getNetwork(f.network));
-            }).toThrowError(new RegExp(`${f.exception}`));
+            }).toThrow(new RegExp(`${f.exception}`));
         });
     });
 });
@@ -142,7 +142,7 @@ it('throws on Public -> public (hardened)', () => {
     const master = BIP32.fromBase58(f.base58);
     expect(() => {
         master.deriveHardened(c.m);
-    }).toThrowError(/Missing private key for hardened child key/);
+    }).toThrow(/Missing private key for hardened child key/);
 });
 
 it('throws on wrong types', () => {
@@ -152,19 +152,19 @@ it('throws on wrong types', () => {
     fixtures.invalid.derive.forEach(fx => {
         expect(() => {
             master.derive(fx as any);
-        }).toThrowError(/Expected UInt32/);
+        }).toThrow(/Expected UInt32/);
     });
 
     fixtures.invalid.deriveHardened.forEach(fx => {
         expect(() => {
             master.deriveHardened(fx as any);
-        }).toThrowError(/Expected UInt31/);
+        }).toThrow(/Expected UInt31/);
     });
 
     fixtures.invalid.derivePath.forEach(fx => {
         expect(() => {
             master.derivePath(fx as any);
-        }).toThrowError(/Expected BIP32Path, got/);
+        }).toThrow(/Expected BIP32Path, got/);
     });
 
     const ZERO = Buffer.alloc(32, 0);
@@ -172,13 +172,13 @@ it('throws on wrong types', () => {
 
     expect(() => {
         BIP32.fromPrivateKey(Buffer.alloc(2), ONES);
-    }).toThrowError(
+    }).toThrow(
         /Expected property "privateKey" of type Buffer\(Length: 32\), got Buffer\(Length: 2\)/,
     );
 
     expect(() => {
         BIP32.fromPrivateKey(ZERO, ONES);
-    }).toThrowError(/Private key not in range \[1, n\)/);
+    }).toThrow(/Private key not in range \[1, n\)/);
 });
 
 it('works when private key has leading zeros', () => {
@@ -201,7 +201,7 @@ it('fromSeed', () => {
     fixtures.invalid.fromSeed.forEach(f => {
         expect(() => {
             BIP32.fromSeed(Buffer.from(f.seed, 'hex'));
-        }).toThrowError(new RegExp(f.exception));
+        }).toThrow(new RegExp(f.exception));
     });
 });
 

--- a/packages/utxo-lib/tests/bufferutils.test.ts
+++ b/packages/utxo-lib/tests/bufferutils.test.ts
@@ -68,7 +68,7 @@ describe('bufferutils', () => {
 
                 expect(() => {
                     bufferutils.readUInt64LE(buffer, 0);
-                }).toThrowError(new RegExp(f.exception));
+                }).toThrow(new RegExp(f.exception));
             });
         });
     });
@@ -90,14 +90,16 @@ describe('bufferutils', () => {
 
                 expect(() => {
                     bufferutils.readVarInt(buffer, 0);
-                }).toThrowError(new RegExp(f.exception));
+                }).toThrow(new RegExp(f.exception));
             });
         });
     });
 
     // TODO: not-used
+    // eslint-disable-next-line jest/no-commented-out-tests
     // describe('varIntBuffer', () => {
     //     fixtures.valid.forEach(f => {
+    // eslint-disable-next-line jest/no-commented-out-tests
     //         it(`encodes ${f.dec} correctly`, () => {
     //             const buffer = bufferutils.varIntBuffer(f.dec);
 
@@ -145,7 +147,7 @@ describe('bufferutils', () => {
 
                 expect(() => {
                     bufferutils.writeUInt64LE(buffer, f.dec, 0);
-                }).toThrowError(new RegExp(f.exception));
+                }).toThrow(new RegExp(f.exception));
             });
         });
     });
@@ -166,7 +168,7 @@ describe('bufferutils', () => {
 
                 expect(() => {
                     bufferutils.writeVarInt(buffer, f.dec, 0);
-                }).toThrowError(new RegExp(f.exception));
+                }).toThrow(new RegExp(f.exception));
             });
         });
     });

--- a/packages/utxo-lib/tests/coinselect/coinselect.test.ts
+++ b/packages/utxo-lib/tests/coinselect/coinselect.test.ts
@@ -19,7 +19,7 @@ describe('coinselect errors', () => {
                     sendMaxOutputIndex: -1,
                     sortingStrategy: 'bip69',
                 }),
-            ).toThrowError(f.expected);
+            ).toThrow(f.expected);
         });
     });
 });

--- a/packages/utxo-lib/tests/script.test.ts
+++ b/packages/utxo-lib/tests/script.test.ts
@@ -12,12 +12,14 @@ describe('script', () => {
             // @ts-expect-error
             expect(bscript.isCanonicalPubKey(0)).toBe(false);
         });
+        // eslint-disable-next-line jest/no-commented-out-tests
         // it('rejects smaller than 33', () => {
         //     for (let i = 0; i < 33; i++) {
         //         expect(bscript.isCanonicalPubKey(Buffer.from('', i))).toBe(false);
         //     }
         // });
     });
+    // eslint-disable-next-line jest/no-commented-out-tests
     // describe.skip('isCanonicalSignature', () => {});
 
     describe('fromASM/toASM', () => {

--- a/packages/utxo-lib/tests/txweight.test.ts
+++ b/packages/utxo-lib/tests/txweight.test.ts
@@ -37,7 +37,9 @@ describe('TxWeightCalculator', () => {
         c.addOutputByKey('p2tr');
         expect(c.getTotal()).toEqual(4 * 94 + 68);
     });
+
     // multisig is not implemented
+    // eslint-disable-next-line jest/no-commented-out-tests
     // it('legacy multisig', () => {
     //     const c = new TxWeightCalculator();
     //     c.addInput({
@@ -51,6 +53,7 @@ describe('TxWeightCalculator', () => {
     //     expect(c.getTotal()).toEqual(4 * 341);
     // });
 
+    // eslint-disable-next-line jest/no-commented-out-tests
     // it('segwit multisig', () => {
     //     const c = new TxWeightCalculator();
     //     c.addInput({

--- a/suite-common/formatters/src/tests/makeFormatter.test.ts
+++ b/suite-common/formatters/src/tests/makeFormatter.test.ts
@@ -9,9 +9,5 @@ describe('makeFormatter', () => {
         it('handles trivial formatting', () => {
             expect(upperCaseFormatter.format('foo')).toBe('FOO');
         });
-
-        it('handles trivial formatting', () => {
-            expect(upperCaseFormatter.format('foo')).toBe('FOO');
-        });
     });
 });

--- a/suite-common/message-system/src/__tests__/messageSystemActions.test.ts
+++ b/suite-common/message-system/src/__tests__/messageSystemActions.test.ts
@@ -12,7 +12,7 @@ import * as fixtures from '../__fixtures__/messageSystemActions';
 
 const messageSystemReducer = prepareMessageSystemReducer(extraDependenciesMock);
 
-export const getInitialState = (state?: MessageSystemState) => ({
+const getInitialState = (state?: MessageSystemState) => ({
     messageSystem: {
         ...messageSystemReducer(undefined, { type: 'foo' } as any),
         ...state,

--- a/suite-common/suite-utils/src/__tests__/build.test.ts
+++ b/suite-common/suite-utils/src/__tests__/build.test.ts
@@ -11,7 +11,7 @@ describe('build', () => {
             process.env = { ...OLD_ENV };
         });
 
-        it.only('dev false when NODE_ENV is production', () => {
+        it('dev false when NODE_ENV is production', () => {
             process.env.NODE_ENV = 'production';
             const { isDevEnv } = require('../build');
 
@@ -40,5 +40,3 @@ describe('build', () => {
         });
     });
 });
-
-export {};

--- a/suite-common/test-utils/src/conditionalDescribe.ts
+++ b/suite-common/test-utils/src/conditionalDescribe.ts
@@ -4,8 +4,10 @@ export const conditionalDescribe = (
     fn: jest.EmptyFunction,
 ) => {
     if (skipCondition) {
+        // eslint-disable-next-line jest/valid-describe-callback
         describe.skip(title, fn);
     } else {
+        // eslint-disable-next-line jest/valid-describe-callback
         describe(title, fn);
     }
 };

--- a/suite-common/wallet-utils/src/__tests__/cardanoUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/cardanoUtils.test.ts
@@ -30,38 +30,40 @@ describe('cardano utils', () => {
         dateSpy.mockRestore();
     });
 
-    expect(getProtocolMagic('ada')).toEqual(CARDANO.PROTOCOL_MAGICS.mainnet);
-    expect(getProtocolMagic('tada')).toEqual(1097911063);
+    it('basic test', () => {
+        expect(getProtocolMagic('ada')).toEqual(CARDANO.PROTOCOL_MAGICS.mainnet);
+        expect(getProtocolMagic('tada')).toEqual(1097911063);
 
-    expect(getDerivationType('normal')).toEqual(1);
-    expect(getDerivationType('legacy')).toEqual(2);
-    expect(getDerivationType('ledger')).toEqual(0);
-    // TS does not allow this, but in runtime, the default case handles it
-    expect(getDerivationType(undefined as any)).toEqual(1);
+        expect(getDerivationType('normal')).toEqual(1);
+        expect(getDerivationType('legacy')).toEqual(2);
+        expect(getDerivationType('ledger')).toEqual(0);
+        // TS does not allow this, but in runtime, the default case handles it
+        expect(getDerivationType(undefined as any)).toEqual(1);
 
-    expect(getNetworkId('ada')).toEqual(CARDANO.NETWORK_IDS.mainnet);
-    expect(getNetworkId('tada')).toEqual(CARDANO.NETWORK_IDS.testnet);
+        expect(getNetworkId('ada')).toEqual(CARDANO.NETWORK_IDS.mainnet);
+        expect(getNetworkId('tada')).toEqual(CARDANO.NETWORK_IDS.testnet);
 
-    expect(getAddressType()).toEqual(PROTO.CardanoAddressType.BASE);
-    expect(getAddressType()).toEqual(PROTO.CardanoAddressType.BASE);
+        expect(getAddressType()).toEqual(PROTO.CardanoAddressType.BASE);
+        expect(getAddressType()).toEqual(PROTO.CardanoAddressType.BASE);
 
-    // @ts-expect-error
-    expect(getStakingPath({ index: 1, symbol: 'ada' })).toEqual(`m/1852'/1815'/1'/2/0`);
+        // @ts-expect-error
+        expect(getStakingPath({ index: 1, symbol: 'ada' })).toEqual(`m/1852'/1815'/1'/2/0`);
 
-    // @ts-expect-error
-    expect(getStakingPath({ index: 12, symbol: 'ada' })).toEqual(`m/1852'/1815'/12'/2/0`);
-    expect(getShortFingerprint('asset1dffrfk79uxwq2a8yaslcfedycgga55tuv5dezd')).toEqual(
-        'asset1dffr…55tuv5dezd',
-    );
+        // @ts-expect-error
+        expect(getStakingPath({ index: 12, symbol: 'ada' })).toEqual(`m/1852'/1815'/12'/2/0`);
+        expect(getShortFingerprint('asset1dffrfk79uxwq2a8yaslcfedycgga55tuv5dezd')).toEqual(
+            'asset1dffr…55tuv5dezd',
+        );
 
-    // @ts-expect-error params are partial
-    expect(isCardanoTx({ networkType: 'cardano' }, {})).toBe(true);
-    // @ts-expect-error params are partial
-    expect(isCardanoTx({ networkType: 'bitcoin' }, {})).toBe(false);
-    // @ts-expect-error params are partial
-    expect(isCardanoExternalOutput({ address: 'addr1' }, {})).toBe(true);
-    // @ts-expect-error params are partial
-    expect(isCardanoExternalOutput({ addressParameters: {} }, {})).toBe(false);
+        // @ts-expect-error params are partial
+        expect(isCardanoTx({ networkType: 'cardano' }, {})).toBe(true);
+        // @ts-expect-error params are partial
+        expect(isCardanoTx({ networkType: 'bitcoin' }, {})).toBe(false);
+        // @ts-expect-error params are partial
+        expect(isCardanoExternalOutput({ address: 'addr1' }, {})).toBe(true);
+        // @ts-expect-error params are partial
+        expect(isCardanoExternalOutput({ addressParameters: {} }, {})).toBe(false);
+    });
 
     fixtures.getChangeAddressParameters.forEach(f => {
         it(`getChangeAddressParameters: ${f.description}`, () => {

--- a/suite-common/wallet-utils/src/__tests__/localizeNumber.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/localizeNumber.test.ts
@@ -32,7 +32,7 @@ describe('localizeNumber', () => {
 
         expect(localizeNumber(123456789.111, 'en', 2, 2)).toStrictEqual('123,456,789.11');
 
-        expect(() => localizeNumber(123456789, 'en', 3, 2)).toThrowError();
+        expect(() => localizeNumber(123456789, 'en', 3, 2)).toThrow();
     });
 
     it('formats negative numbers', () => {

--- a/suite-native/accounts/src/tests/selectors.test.ts
+++ b/suite-native/accounts/src/tests/selectors.test.ts
@@ -32,13 +32,13 @@ describe('isFilterValueMatchingAccountLabelOrNetworkName', () => {
         expect(isFilterValueMatchingAccount(account, filterValue)).toBe(true);
     });
 
-    test('should return true if filter value matches the account type', () => {
+    test('should return true if filter value matches the account type: legacy', () => {
         const filterValue = 'legacy';
 
         expect(isFilterValueMatchingAccount(account, filterValue)).toBe(true);
     });
 
-    test('should return true if filter value matches the account type', () => {
+    test('should return true if filter value matches the account type: taproot', () => {
         const filterValue = 'taproot';
 
         expect(isFilterValueMatchingAccount(account, filterValue)).toBe(false);

--- a/suite-native/app/e2e/tests/send.test.ts
+++ b/suite-native/app/e2e/tests/send.test.ts
@@ -23,7 +23,7 @@ import {
     wait,
 } from '../utils';
 
-export const SEND_FORM_ERROR_MESSAGES = {
+const SEND_FORM_ERROR_MESSAGES = {
     invalidAddress: 'The address format is incorrect.',
     invalidDecimalValue: 'Invalid decimal value.',
     dustAmount: 'The value is lower than the dust limit.',


### PR DESCRIPTION
We are using `eslint-plugin-jest` but we are not using any of the rules from it. So I tried to add `plugin:jest/recommended` and this is the result. 

Mostly:
- do not export from test files
- use canonical `toThrow` instead of `toThrowError`
- safer usage of promises
- duplicates of the description text
- duplicate tests

There were some issues that I just silenced by `// eslint-disable` as they were in some complicated/old code. The rule is there for new tests and the old one, we can fix someday or never.

Namely it was:
- usage of Jasmine in Karma
- skipped and commented tests
- some `expects` out of the `it` scope
