### PR TITLE
fix(suite-native): update gorhom bottom sheet to get rid of warning

### DIFF
--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -22,7 +22,7 @@
         "reverse-ports": "adb reverse tcp:8081 tcp:8081 && adb reverse tcp:21325 tcp:21325 && adb reverse tcp:19121 tcp:19121"
     },
     "dependencies": {
-        "@gorhom/bottom-sheet": "5.0.1",
+        "@gorhom/bottom-sheet": "5.0.5",
         "@mobily/ts-belt": "^3.13.1",
         "@react-native-community/netinfo": "11.3.2",
         "@react-native/metro-config": "0.75.2",

--- a/suite-native/atoms/package.json
+++ b/suite-native/atoms/package.json
@@ -11,7 +11,7 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
-        "@gorhom/bottom-sheet": "5.0.1",
+        "@gorhom/bottom-sheet": "5.0.5",
         "@mobily/ts-belt": "^3.13.1",
         "@shopify/flash-list": "1.7.1",
         "@shopify/react-native-skia": "1.3.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4493,9 +4493,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gorhom/bottom-sheet@npm:5.0.1":
-  version: 5.0.1
-  resolution: "@gorhom/bottom-sheet@npm:5.0.1"
+"@gorhom/bottom-sheet@npm:5.0.5":
+  version: 5.0.5
+  resolution: "@gorhom/bottom-sheet@npm:5.0.5"
   dependencies:
     "@gorhom/portal": "npm:1.0.14"
     invariant: "npm:^2.2.4"
@@ -4511,7 +4511,7 @@ __metadata:
       optional: true
     "@types/react-native":
       optional: true
-  checksum: 10/61134493ac61f96a5bc7aae20f4a6465f19138d7d2d36129d2285022ee52fe02648d7706212b17d5e1c6acdf0d0a5ee0124884b44a34eb468406e89a86c6102c
+  checksum: 10/4c972e5c4459dce02858c4b5af691e412e8075e1cbfe049ae7d308746173ba27c3802d867eb54a94a804987d3d9e78f5886dc5a3f4163fb19ca2a91b4ad44864
   languageName: node
   linkType: hard
 
@@ -9596,7 +9596,7 @@ __metadata:
     "@babel/core": "npm:^7.20.0"
     "@babel/plugin-transform-export-namespace-from": "npm:^7.23.4"
     "@config-plugins/detox": "npm:^8.0.0"
-    "@gorhom/bottom-sheet": "npm:5.0.1"
+    "@gorhom/bottom-sheet": "npm:5.0.5"
     "@mobily/ts-belt": "npm:^3.13.1"
     "@react-native-community/netinfo": "npm:11.3.2"
     "@react-native/babel-preset": "npm:^0.75.2"
@@ -9744,7 +9744,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/atoms@workspace:suite-native/atoms"
   dependencies:
-    "@gorhom/bottom-sheet": "npm:5.0.1"
+    "@gorhom/bottom-sheet": "npm:5.0.5"
     "@mobily/ts-belt": "npm:^3.13.1"
     "@shopify/flash-list": "npm:1.7.1"
     "@shopify/react-native-skia": "npm:1.3.11"


### PR DESCRIPTION
By updating `@gorhom/bottom-sheet` we get rid of unwanted warning

So you should no longer see:
```
If you don't want to see this message, you can disable the `strict` mode. Refer to:
https://docs.swmansion.com/react-native-reanimated/docs/debugging/logger-configuration for more details.
 WARN  [Reanimated] Reading from `value` during component render. Please ensure that you do not access the `value` property or use `get` method of a shared value while React is rendering a component.
```