### PR TITLE
fix(suite-native): send minimal amount validation

### DIFF
--- a/suite-native/module-send/src/sendFormThunks.ts
+++ b/suite-native/module-send/src/sendFormThunks.ts
@@ -185,7 +185,7 @@ export const calculateFeeLevelsMaxAmountThunk = createThunk<
         if (isFulfilled(response)) {
             return pipe(
                 response.payload,
-                D.filter(x => x.type === 'final'),
+                D.filter(x => 'max' in x),
                 D.map(y => (y as GeneralPrecomposedTransactionFinal).max),
             ) as FeeLevelsMaxAmount;
         }


### PR DESCRIPTION
## Description

While fetching a minimal amount of each fee level, we were filtering out values of `type: 'non-final'` that are returned if the recipient address is still not known. For this reason, the validation did not work as expected in the form without the filled-in receive address.