### PR TITLE
fix(connect): loadDevice not-initialize method

### DIFF
--- a/packages/connect/src/api/loadDevice.ts
+++ b/packages/connect/src/api/loadDevice.ts
@@ -6,7 +6,7 @@ import { Assert } from '@trezor/schema-utils';
 
 export default class LoadDevice extends AbstractMethod<'loadDevice', PROTO.LoadDevice> {
     init() {
-        this.allowDeviceMode = [UI.SEEDLESS];
+        this.allowDeviceMode = [UI.INITIALIZE];
         this.useDeviceState = false;
         this.requiredPermissions = ['management'];
         this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Should fix breaking tests by previous changes in https://github.com/trezor/trezor-suite/pull/15154/files

Instead of checking for device is seedless it should check that device is not initialized.
