### PR TITLE
feature(#11410): Removing coin filter reset on wallet change

### DIFF
--- a/packages/suite/src/reducers/wallet/accountSearchReducer.ts
+++ b/packages/suite/src/reducers/wallet/accountSearchReducer.ts
@@ -1,9 +1,7 @@
 import produce from 'immer';
 
-import { deviceActions } from '@suite-common/wallet-core';
-
-import { ACCOUNT_SEARCH } from 'src/actions/wallet/constants';
 import * as walletSettingsActions from 'src/actions/settings/walletSettingsActions';
+import { ACCOUNT_SEARCH } from 'src/actions/wallet/constants';
 import { Action } from 'src/types/suite';
 import { Account as AccountType } from 'src/types/wallet';
 
@@ -28,8 +26,7 @@ const accountSearchReducer = (state: State = initialState, action: Action): Stat
                 break;
             // reset coin filter on:
             // 1) disabling/enabling coins
-            // 2) switching to another device/wallet
-            // * 3) adding a new account is handled directly in add account modal, reacting on ACCOUNT.CREATE would cause resetting during initial accounts discovery
+            // * 2) adding a new account is handled directly in add account modal, reacting on ACCOUNT.CREATE would cause resetting during initial accounts discovery
             case walletSettingsActions.changeNetworks.type: {
                 if (walletSettingsActions.changeNetworks.match(action)) {
                     draft.coinFilter = undefined;
@@ -37,10 +34,6 @@ const accountSearchReducer = (state: State = initialState, action: Action): Stat
                 }
                 break;
             }
-            case deviceActions.selectDevice.type:
-                draft.coinFilter = undefined;
-                draft.searchString = undefined;
-                break;
 
             // no default
         }

--- a/packages/suite/src/reducers/wallet/accountSearchReducer.ts
+++ b/packages/suite/src/reducers/wallet/accountSearchReducer.ts
@@ -1,5 +1,6 @@
 import produce from 'immer';
 
+import { deviceActions } from '@suite-common/wallet-core';
 import * as walletSettingsActions from 'src/actions/settings/walletSettingsActions';
 import { ACCOUNT_SEARCH } from 'src/actions/wallet/constants';
 import { Action } from 'src/types/suite';
@@ -34,6 +35,11 @@ const accountSearchReducer = (state: State = initialState, action: Action): Stat
                 }
                 break;
             }
+
+            // reset coin filter search
+            case deviceActions.selectDevice.type:
+                draft.searchString = undefined;
+                break;
 
             // no default
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The original code was set up to reset the coin filter whenever the wallet changed. The solution involved removing the reset lines within the Redux reducer for account search.

<!--- Describe your changes in detail -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/11410

## Loom:
https://www.loom.com/share/c847580f8e2a43ee84efeb832a4fc275
