### PR TITLE
fix(suite): different formatting for not that big numbers

### DIFF
--- a/packages/components/src/components/AssetLogo/AssetLogo.tsx
+++ b/packages/components/src/components/AssetLogo/AssetLogo.tsx
@@ -6,11 +6,12 @@ import {
 } from '../../utils/frameProps';
 import { useEffect, useState } from 'react';
 import styled from 'styled-components';
-import { borders } from '@trezor/theme';
+import { borders, Elevation, mapElevationToBackground, mapElevationToBorder } from '@trezor/theme';
 import { getAssetLogoUrl } from '@trezor/asset-utils';
 
 import { AssetInitials } from './AssetInitials';
 import { TransientProps } from '../../utils/transientProps';
+import { ElevationUp, useElevation } from '../ElevationContext/ElevationContext';
 
 export const allowedAssetLogoSizes = [20, 24];
 type AssetLogoSize = (typeof allowedAssetLogoSizes)[number];
@@ -36,14 +37,25 @@ const Container = styled.div<TransientProps<AllowedFrameProps> & { $size: number
     ${withFrameProps}
 `;
 
-const Logo = styled.img<{ $size: number; $isVisible: boolean }>(
-    ({ $size, $isVisible }) => `
-        width: ${$size}px;
-        height: ${$size}px;
-        border-radius: ${borders.radii.full};
-        visibility: ${$isVisible ? 'visible' : 'hidden'};
-    `,
-);
+const Logo = styled.img<{ $size: number; $isVisible: boolean; $elevation: Elevation }>`
+    width: ${({ $size }) => $size}px;
+    height: ${({ $size }) => $size}px;
+    border-radius: ${borders.radii.full};
+    visibility: ${({ $isVisible }) => ($isVisible ? 'visible' : 'hidden')};
+    box-shadow: inset 0 0 0 1px ${mapElevationToBorder};
+    background-color: ${mapElevationToBackground};
+`;
+
+interface LogoProps extends React.ImgHTMLAttributes<HTMLImageElement> {
+    $size: number;
+    $isVisible: boolean;
+}
+
+const ElevatedLogo = (props: LogoProps) => {
+    const { elevation } = useElevation();
+
+    return <Logo {...props} $elevation={elevation} />;
+};
 
 export const AssetLogo = ({
     size,
@@ -81,17 +93,19 @@ export const AssetLogo = ({
                 </AssetInitials>
             )}
             {!isPlaceholder && (
-                <Logo
-                    src={logoUrl}
-                    srcSet={`${logoUrl} 1x, ${logoUrl2x} 2x`}
-                    $size={size}
-                    onLoad={handleLoad}
-                    onError={handleError}
-                    $isVisible={!isLoading}
-                    data-testid={dataTest}
-                    alt={placeholder}
-                    loading="lazy"
-                />
+                <ElevationUp>
+                    <ElevatedLogo
+                        src={logoUrl}
+                        srcSet={`${logoUrl} 1x, ${logoUrl2x} 2x`}
+                        $size={size}
+                        onLoad={handleLoad}
+                        onError={handleError}
+                        $isVisible={!isLoading}
+                        data-testid={dataTest}
+                        alt={placeholder}
+                        loading="lazy"
+                    />
+                </ElevationUp>
             )}
         </Container>
     );

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokensTable.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokensTable.tsx
@@ -92,7 +92,7 @@ export const TokensTable = ({
                         {tokensWithoutBalance.length !== 0 && (
                             <>
                                 <Table.Row onClick={() => setIsZeroBalanceOpen(!isZeroBalanceOpen)}>
-                                    <Table.Cell colSpan={5}>
+                                    <Table.Cell colSpan={1}>
                                         <ZeroBalanceToggle>
                                             <Row gap={spacings.xs}>
                                                 <IconWrapper $isActive={isZeroBalanceOpen}>
@@ -108,6 +108,7 @@ export const TokensTable = ({
                                             </Row>
                                         </ZeroBalanceToggle>
                                     </Table.Cell>
+                                    <Table.Cell colSpan={hideRates ? 2 : 4} />
                                 </Table.Row>
                                 {tokensWithoutBalance.map(token => (
                                     <TokenRow

--- a/suite-common/formatters/src/formatters/prepareFiatAmountFormatter.ts
+++ b/suite-common/formatters/src/formatters/prepareFiatAmountFormatter.ts
@@ -20,7 +20,8 @@ const handleBigNumberFormatting = (
     const fiatValue = new BigNumber(value);
     const currencyForDisplay = currency ?? fiatCurrency;
 
-    if (fiatValue.gt(Number.MAX_SAFE_INTEGER)) {
+    if (fiatValue.gt(Number.MAX_VALUE)) {
+        // backup when number is too big, the formatting is different than should be for currencies
         return `${value} ${currencyForDisplay}`;
     }
 


### PR DESCRIPTION
## Description

- fix `usd` used instead of `$`
![Screenshot 2024-11-04 at 12 06 42](https://github.com/user-attachments/assets/5ed887f7-6fa8-423e-9f80-a34b978e8d28)
- fix token zero balange toggler moving
![Screenshot 2024-11-04 at 12 07 26](https://github.com/user-attachments/assets/985b8ab8-7b3c-4b98-868a-338941d15757)
- icon
![Screenshot 2024-11-04 at 10 55 12](https://github.com/user-attachments/assets/59cfa232-943e-4b04-95c7-095cf832e09e)

TODO in another PR
- missing symbol in tx when symbol for token is missing
- do not use fiat for tokens without decimals


## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
![Screenshot 2024-11-04 at 11 51 06](https://github.com/user-attachments/assets/757ba62f-294b-4356-8ff6-49e7ede0c264)
![Screenshot 2024-11-04 at 12 08 39](https://github.com/user-attachments/assets/5b5c5b25-ac09-47b4-abfe-e5bb627c16a9)
![Screenshot 2024-11-04 at 12 08 59](https://github.com/user-attachments/assets/c124952a-f3c7-4d38-b217-2fb9fc332880)

