### PR TITLE
feat(suite): autostart in bridge requested modal

### DIFF
--- a/packages/suite/src/actions/suite/protocolActions.ts
+++ b/packages/suite/src/actions/suite/protocolActions.ts
@@ -33,11 +33,7 @@ const saveCoinProtocol = (scheme: Protocol, address: string, amount?: number): P
 export const handleProtocolRequest = (uri: string) => (dispatch: Dispatch) => {
     const protocol = getProtocolInfo(uri);
 
-    if (protocol && 'error' in protocol) {
-        return;
-    }
-
-    if (protocol && getNetworkSymbolForProtocol(protocol.scheme)) {
+    if (protocol && !('error' in protocol) && getNetworkSymbolForProtocol(protocol.scheme)) {
         const { scheme, amount, address } = protocol as CoinProtocolInfo;
 
         dispatch(saveCoinProtocol(scheme, address, amount));

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -9232,6 +9232,11 @@ export default defineMessages({
         defaultMessage:
             "Are you sure? Your device can only be used by one app at a time. If you're currently using another app with your Trezor device, finish that session first.",
     },
+    TR_BRIDGE_TIP_AUTOSTART: {
+        id: 'TR_BRIDGE_TIP_AUTOSTART',
+        defaultMessage:
+            'Tip: You can enable the auto-start feature and have the Bridge always running in the background.',
+    },
     TR_BRIDGE_NEEDED_DESCRIPTION: {
         id: 'TR_BRIDGE_NEEDED_DESCRIPTION',
         defaultMessage:

--- a/packages/suite/src/views/suite/bridge-requested/index.tsx
+++ b/packages/suite/src/views/suite/bridge-requested/index.tsx
@@ -1,10 +1,14 @@
 import { useState } from 'react';
 import styled from 'styled-components';
 import { Translation, Modal, Metadata } from 'src/components/suite';
-import { Button, Image } from '@trezor/components';
+import { Button, Card, Image, Text } from '@trezor/components';
 import { goto } from 'src/actions/suite/routerActions';
-import { useDispatch, useLayout } from 'src/hooks/suite';
+import { useDispatch, useLayout, useSelector } from 'src/hooks/suite';
 import { desktopApi } from '@trezor/suite-desktop-api';
+import { AutoStart } from 'src/views/settings/SettingsDebug/AutoStart';
+import { isDesktop } from '@trezor/env-utils';
+import { spacings } from '@trezor/theme';
+import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
 
 const StyledModal = styled(Modal)`
     ${Modal.BottomBar} {
@@ -31,6 +35,7 @@ const StyledButton = styled(Button)`
  * This component renders only in desktop version
  */
 export const BridgeRequested = () => {
+    const isDebugModeActive = useSelector(selectIsDebugModeActive);
     const [confirmGoToWallet, setConfirmGoToWallet] = useState(false);
 
     const dispatch = useDispatch();
@@ -93,6 +98,21 @@ export const BridgeRequested = () => {
         >
             <Metadata title="Bridge | Trezor Suite" />
             <StyledImage image="CONNECT_DEVICE" width="360" />
+
+            {isDesktop() && isDebugModeActive && (
+                <>
+                    <Text
+                        typographyStyle="hint"
+                        variant="tertiary"
+                        margin={{ bottom: spacings.md }}
+                    >
+                        <Translation id="TR_BRIDGE_TIP_AUTOSTART" />
+                    </Text>
+                    <Card>
+                        <AutoStart />
+                    </Card>
+                </>
+            )}
         </StyledModal>
     );
 };


### PR DESCRIPTION
## Description

Add a CTA for the autostart setting into the bridge requested modal. 
Also fix an error in the bridge deeplink handling.

## Screenshots:
<img width="772" alt="Screenshot 2024-11-04 at 13 04 58" src="https://github.com/user-attachments/assets/00c7342b-40ac-4c3e-bfc3-1a57df711af8">
