### PR TITLE
fix(suite-native): revise navigation and spacing of the Sync my coins flow

### DIFF
--- a/suite-native/app/src/navigation/RootStackNavigator.tsx
+++ b/suite-native/app/src/navigation/RootStackNavigator.tsx
@@ -59,6 +59,7 @@ export const RootStackNavigator = () => {
             <RootStack.Screen
                 name={RootStackRoutes.AccountsImport}
                 component={AccountsImportStackNavigator}
+                options={{ animation: 'slide_from_bottom' }}
             />
             <RootStack.Screen
                 options={{ title: RootStackRoutes.AccountSettings }}
@@ -88,12 +89,11 @@ export const RootStackNavigator = () => {
                 name={RootStackRoutes.AddCoinAccountStack}
                 component={AddCoinAccountStackNavigator}
             />
-            <RootStack.Group screenOptions={{ animation: 'slide_from_bottom' }}>
-                <RootStack.Screen
-                    name={RootStackRoutes.CoinEnablingInit}
-                    component={CoinEnablingInitScreen}
-                />
-            </RootStack.Group>
+            <RootStack.Screen
+                name={RootStackRoutes.CoinEnablingInit}
+                component={CoinEnablingInitScreen}
+                options={{ animation: 'slide_from_bottom' }}
+            />
             <RootStack.Screen name={RootStackRoutes.ReceiveModal} component={ReceiveModalScreen} />
             <RootStack.Screen
                 name={RootStackRoutes.AuthorizeDeviceStack}
@@ -103,12 +103,11 @@ export const RootStackNavigator = () => {
                     animation: 'slide_from_bottom',
                 }}
             />
-            <RootStack.Group screenOptions={{ animation: 'slide_from_bottom' }}>
-                <RootStack.Screen
-                    name={RootStackRoutes.DeviceSettingsStack}
-                    component={DeviceSettingsStackNavigator}
-                />
-            </RootStack.Group>
+            <RootStack.Screen
+                name={RootStackRoutes.DeviceSettingsStack}
+                component={DeviceSettingsStackNavigator}
+                options={{ animation: 'slide_from_bottom' }}
+            />
             <RootStack.Screen name={RootStackRoutes.SendStack} component={SendStackNavigator} />
             <RootStack.Screen
                 name={RootStackRoutes.ConnectPopup}

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -109,10 +109,7 @@ export const en = {
             },
             subtitle: "Here's what you have in your account.",
             tokens: 'Tokens:',
-            button: {
-                importAnotherAsset: 'Import another asset',
-                continueToApp: 'Continue to app',
-            },
+            syncAnotherCoinButton: 'Sync another coin',
         },
         coinList: {
             mainnets: 'Select a coin to sync',

--- a/suite-native/module-accounts-import/src/components/AccountAlreadyImportedScreen.tsx
+++ b/suite-native/module-accounts-import/src/components/AccountAlreadyImportedScreen.tsx
@@ -7,11 +7,10 @@ import { Translation } from '@suite-native/intl';
 import {
     AccountsImportStackParamList,
     AccountsImportStackRoutes,
-    AppTabsRoutes,
-    HomeStackRoutes,
     RootStackParamList,
     RootStackRoutes,
     StackToTabCompositeProps,
+    useNavigateToInitialScreen,
 } from '@suite-native/navigation';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
@@ -36,20 +35,13 @@ type NavigationProp = StackToTabCompositeProps<
 export const AccountAlreadyImportedScreen = ({ account }: AccountAlreadyImportedScreenProps) => {
     const { applyStyle } = useNativeStyles();
     const navigation = useNavigation<NavigationProp>();
+    const navigateToInitialScreen = useNavigateToInitialScreen();
 
-    const handleImportAnotherAsset = () =>
+    const handleSyncAnotherAsset = () =>
         navigation.navigate(RootStackRoutes.AccountsImport, {
             screen: AccountsImportStackRoutes.XpubScan,
             params: {
                 networkSymbol: account.symbol,
-            },
-        });
-
-    const handleNavigateToDashboard = () =>
-        navigation.navigate(RootStackRoutes.AppTabs, {
-            screen: AppTabsRoutes.HomeStack,
-            params: {
-                screen: HomeStackRoutes.Home,
             },
         });
 
@@ -59,15 +51,15 @@ export const AccountAlreadyImportedScreen = ({ account }: AccountAlreadyImported
             subtitle={<Translation id="moduleAccountImport.summaryScreen.subtitle" />}
             footer={
                 <VStack spacing="sp16">
+                    <Button size="large" onPress={handleSyncAnotherAsset}>
+                        <Translation id="moduleAccountImport.summaryScreen.syncAnotherCoinButton" />
+                    </Button>
                     <Button
                         size="large"
                         colorScheme="tertiaryElevation0"
-                        onPress={handleImportAnotherAsset}
+                        onPress={navigateToInitialScreen}
                     >
-                        <Translation id="moduleAccountImport.summaryScreen.button.importAnotherAsset" />
-                    </Button>
-                    <Button size="large" onPress={handleNavigateToDashboard}>
-                        <Translation id="moduleAccountImport.summaryScreen.button.continueToApp" />
+                        <Translation id="generic.buttons.cancel" />
                     </Button>
                 </VStack>
             }

--- a/suite-native/module-accounts-import/src/components/AccountImportConfirmFormScreen.tsx
+++ b/suite-native/module-accounts-import/src/components/AccountImportConfirmFormScreen.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { CommonActions, useNavigation } from '@react-navigation/core';
+import { useNavigation } from '@react-navigation/core';
 import { FlashList } from '@shopify/flash-list';
 
 import { Translation } from '@suite-native/intl';
@@ -23,10 +23,9 @@ import { Form } from '@suite-native/forms';
 import {
     AccountsImportStackParamList,
     AccountsImportStackRoutes,
-    HomeStackRoutes,
     RootStackParamList,
-    RootStackRoutes,
     StackToStackCompositeNavigationProps,
+    useNavigateToInitialScreen,
 } from '@suite-native/navigation';
 import { AccountInfo, TokenInfo } from '@trezor/connect';
 
@@ -53,6 +52,7 @@ export const AccountImportConfirmFormScreen = ({
 }: AccountImportConfirmFormScreenProps) => {
     const dispatch = useDispatch();
     const navigation = useNavigation<NavigationProp>();
+    const navigateToInitialScreen = useNavigateToInitialScreen();
     const showImportError = useShowImportError(networkSymbol, navigation);
 
     const knownTokens = useSelector((state: TokenDefinitionsRootState) =>
@@ -92,19 +92,7 @@ export const AccountImportConfirmFormScreen = ({
                 },
             });
 
-            navigation.dispatch(
-                CommonActions.reset({
-                    index: 0,
-                    routes: [
-                        {
-                            name: RootStackRoutes.AppTabs,
-                            params: {
-                                screen: HomeStackRoutes.Home,
-                            },
-                        },
-                    ],
-                }),
-            );
+            navigateToInitialScreen();
         } catch {
             showImportError();
         }

--- a/suite-native/module-accounts-import/src/components/AccountImportOverview.tsx
+++ b/suite-native/module-accounts-import/src/components/AccountImportOverview.tsx
@@ -25,7 +25,6 @@ export const AccountImportOverview = ({ balance, networkSymbol }: AssetsOverview
         <AccountImportOverviewCard
             icon={<RoundedIcon networkSymbol={networkSymbol} iconSize="large" />}
             coinName={networks[networkSymbol].name}
-            symbol={networkSymbol}
             cryptoAmount={
                 <CryptoAmountFormatter
                     value={balance}

--- a/suite-native/module-accounts-import/src/components/AccountImportOverviewCard.tsx
+++ b/suite-native/module-accounts-import/src/components/AccountImportOverviewCard.tsx
@@ -1,17 +1,7 @@
 import { ReactNode } from 'react';
 
-import { useNavigation } from '@react-navigation/core';
-
-import { Box, Card, IconButton, Text } from '@suite-native/atoms';
+import { Box, Card, Text } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
-import {
-    AccountsImportStackParamList,
-    AccountsImportStackRoutes,
-    RootStackParamList,
-    RootStackRoutes,
-    StackToTabCompositeProps,
-} from '@suite-native/navigation';
-import { NetworkSymbol } from '@suite-common/wallet-config';
 
 const assetCardStyle = prepareNativeStyle(utils => ({
     padding: utils.spacings.sp24,
@@ -19,38 +9,20 @@ const assetCardStyle = prepareNativeStyle(utils => ({
     width: '100%',
 }));
 
-type NavigationProp = StackToTabCompositeProps<
-    AccountsImportStackParamList,
-    AccountsImportStackRoutes.AccountImportSummary,
-    RootStackParamList
->;
-
 type AccountImportOverviewCardProps = {
     children?: ReactNode;
     icon: ReactNode;
     cryptoAmount: ReactNode;
     coinName: string;
-    shouldDisplayDeleteIcon?: boolean;
-    symbol: NetworkSymbol;
 };
+
 export const AccountImportOverviewCard = ({
     children,
     icon,
     coinName,
-    symbol,
     cryptoAmount,
-    shouldDisplayDeleteIcon = true,
 }: AccountImportOverviewCardProps) => {
-    const navigation = useNavigation<NavigationProp>();
     const { applyStyle } = useNativeStyles();
-
-    const handleNavigateToQRScan = () =>
-        navigation.navigate(RootStackRoutes.AccountsImport, {
-            screen: AccountsImportStackRoutes.XpubScan,
-            params: {
-                networkSymbol: symbol,
-            },
-        });
 
     return (
         <Card style={applyStyle(assetCardStyle)}>
@@ -62,15 +34,6 @@ export const AccountImportOverviewCard = ({
                         {cryptoAmount}
                     </Box>
                 </Box>
-                {shouldDisplayDeleteIcon && (
-                    <IconButton
-                        data-testID="@account-import/coin-synced/delete-icon"
-                        iconName="trashSimple"
-                        colorScheme="tertiaryElevation1"
-                        onPress={handleNavigateToQRScan}
-                        size="medium"
-                    />
-                )}
             </Box>
             {children}
         </Card>

--- a/suite-native/module-accounts-import/src/components/AccountImportSubHeader.tsx
+++ b/suite-native/module-accounts-import/src/components/AccountImportSubHeader.tsx
@@ -1,61 +1,26 @@
-import { useSelector } from 'react-redux';
-
-import { useNavigation } from '@react-navigation/core';
-
-import { IconButton, Text, VStack } from '@suite-native/atoms';
+import { useTranslate } from '@suite-native/intl';
 import {
-    AccountsImportStackParamList,
-    AccountsImportStackRoutes,
-    AppTabsRoutes,
-    HomeStackRoutes,
-    RootStackParamList,
-    RootStackRoutes,
+    CloseActionType,
     ScreenSubHeader,
-    StackToTabCompositeProps,
+    useNavigateToInitialScreen,
 } from '@suite-native/navigation';
-import { Translation } from '@suite-native/intl';
-import { selectIsDeviceAccountless } from '@suite-common/wallet-core';
 
-type NavigationProp = StackToTabCompositeProps<
-    AccountsImportStackParamList,
-    AccountsImportStackRoutes.AccountImportSummary,
-    RootStackParamList
->;
+type AccountImportSubHeaderProps = {
+    closeActionType?: CloseActionType;
+};
 
-export const AccountImportSubHeader = () => {
-    const navigation = useNavigation<NavigationProp>();
-    const isDeviceAccountless = useSelector(selectIsDeviceAccountless);
-
-    const handleCloseOnboarding = () => {
-        navigation.navigate(RootStackRoutes.AppTabs, {
-            screen: AppTabsRoutes.HomeStack,
-            params: {
-                screen: HomeStackRoutes.Home,
-            },
-        });
-    };
+export const AccountImportSubHeader = ({
+    closeActionType = 'close',
+}: AccountImportSubHeaderProps) => {
+    const { translate } = useTranslate();
+    const navigateToInitialScreen = useNavigateToInitialScreen();
 
     return (
         <ScreenSubHeader
-            leftIcon={
-                !isDeviceAccountless ? (
-                    <IconButton
-                        iconName="x"
-                        colorScheme="tertiaryElevation0"
-                        onPress={handleCloseOnboarding}
-                        accessibilityRole="button"
-                        accessibilityLabel="close"
-                        size="medium"
-                    />
-                ) : null
-            }
-            content={
-                <VStack alignItems="center" spacing="sp8">
-                    <Text variant="titleSmall" adjustsFontSizeToFit numberOfLines={1}>
-                        <Translation id="moduleAccountImport.title" />
-                    </Text>
-                </VStack>
-            }
+            customHorizontalPadding="sp16"
+            closeActionType={closeActionType}
+            closeAction={closeActionType === 'close' ? navigateToInitialScreen : undefined}
+            content={translate('moduleAccountImport.title')}
         />
     );
 };

--- a/suite-native/module-accounts-import/src/components/TokenInfoCard.tsx
+++ b/suite-native/module-accounts-import/src/components/TokenInfoCard.tsx
@@ -37,8 +37,6 @@ export const TokenInfoCard = ({
     return (
         <AccountImportOverviewCard
             coinName={name}
-            symbol={networkSymbol}
-            shouldDisplayDeleteIcon={false}
             cryptoAmount={
                 <TokenAmountFormatter
                     value={balance}

--- a/suite-native/module-accounts-import/src/navigation/AccountsImportStackNavigator.tsx
+++ b/suite-native/module-accounts-import/src/navigation/AccountsImportStackNavigator.tsx
@@ -15,15 +15,15 @@ export const AccountsImportStack = createNativeStackNavigator<AccountsImportStac
 
 export const AccountsImportStackNavigator = () => (
     <AccountsImportStack.Navigator screenOptions={stackNavigationOptionsConfig}>
-        <AccountsImportStack.Group>
-            <AccountsImportStack.Screen
-                name={AccountsImportStackRoutes.SelectNetwork}
-                component={SelectNetworkScreen}
-            />
-            <AccountsImportStack.Screen
-                name={AccountsImportStackRoutes.XpubScan}
-                component={XpubScanScreen}
-            />
+        <AccountsImportStack.Screen
+            name={AccountsImportStackRoutes.SelectNetwork}
+            component={SelectNetworkScreen}
+        />
+        <AccountsImportStack.Screen
+            name={AccountsImportStackRoutes.XpubScan}
+            component={XpubScanScreen}
+        />
+        <AccountsImportStack.Group screenOptions={{ gestureEnabled: false }}>
             <AccountsImportStack.Screen
                 name={AccountsImportStackRoutes.AccountImportLoading}
                 component={AccountImportLoadingScreen}

--- a/suite-native/module-accounts-import/src/screens/AccountImportLoadingScreen.tsx
+++ b/suite-native/module-accounts-import/src/screens/AccountImportLoadingScreen.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import { BackHandler } from 'react-native';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { selectFiatCurrencyCode } from '@suite-native/settings';
@@ -69,6 +70,15 @@ export const AccountImportLoadingScreen = ({
         // eslint-disable-next-line react-hooks/exhaustive-deps
         [error, showImportError],
     );
+
+    useEffect(() => {
+        // prevent dismissing screen via HW
+        const subscription = BackHandler.addEventListener('hardwareBackPress', () => {
+            return true;
+        });
+
+        return () => subscription.remove();
+    }, []);
 
     useEffect(() => {
         fetchAccountInfo();

--- a/suite-native/module-accounts-import/src/screens/AccountImportSummaryScreen.tsx
+++ b/suite-native/module-accounts-import/src/screens/AccountImportSummaryScreen.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+import { BackHandler } from 'react-native';
 import { useSelector } from 'react-redux';
 
 import {
@@ -37,6 +39,15 @@ export const AccountImportSummaryScreen = ({
         ),
     );
     const portfolioTrackerSupportedNetworks = useSelector(selectPortfolioTrackerNetworkSymbols);
+
+    useEffect(() => {
+        // prevent dismissing screen via HW
+        const subscription = BackHandler.addEventListener('hardwareBackPress', () => {
+            return true;
+        });
+
+        return () => subscription.remove();
+    }, []);
 
     const isAccountImportSupported =
         portfolioTrackerSupportedNetworks.some(symbol => symbol === networkSymbol) ||

--- a/suite-native/module-accounts-import/src/screens/SelectNetworkScreen.tsx
+++ b/suite-native/module-accounts-import/src/screens/SelectNetworkScreen.tsx
@@ -19,7 +19,7 @@ export const SelectNetworkScreen = ({
     };
 
     return (
-        <Screen screenHeader={<AccountImportSubHeader />}>
+        <Screen screenHeader={<AccountImportSubHeader />} customHorizontalPadding="sp16">
             <SelectableNetworkList onSelectItem={handleSelectNetworkSymbol} />
         </Screen>
     );

--- a/suite-native/module-accounts-import/src/screens/XpubScanScreen.tsx
+++ b/suite-native/module-accounts-import/src/screens/XpubScanScreen.tsx
@@ -4,7 +4,7 @@ import Animated, { FadeIn } from 'react-native-reanimated';
 
 import { useFocusEffect } from '@react-navigation/native';
 
-import { Button, HeaderedCard, TextDivider, VStack } from '@suite-native/atoms';
+import { Button, Card, TextDivider, VStack } from '@suite-native/atoms';
 import { isDevelopOrDebugEnv } from '@suite-native/config';
 import { Form, TextInputField, useForm } from '@suite-native/forms';
 import {
@@ -164,7 +164,6 @@ export const XpubScanScreen = ({
     }, [handleXpubResult, route.params]);
 
     const handleOpenHint = () => setIsHintSheetVisible(true);
-    const handleGoBack = () => navigation.goBack();
 
     const handleToggleScanner = () => {
         setIsScannerVisible(prevState => !prevState);
@@ -177,19 +176,16 @@ export const XpubScanScreen = ({
 
     return (
         <Screen
-            screenHeader={<AccountImportSubHeader />}
+            screenHeader={<AccountImportSubHeader closeActionType="back" />}
             footer={<XpubHint networkType={networkType} handleOpen={handleOpenHint} />}
             extraKeyboardAvoidingViewHeight={EXTRA_KEYBOARD_AVOIDING_VIEW_HEIGHT}
+            customHorizontalPadding="sp16"
+            customVerticalPadding="sp16"
         >
-            <HeaderedCard
-                title="Coin to sync"
-                buttonTitle="Change"
-                buttonIcon="discover"
-                onButtonPress={handleGoBack}
-            >
+            <Card>
                 <SelectableNetworkItem symbol={networkSymbol} />
-            </HeaderedCard>
-            <VStack spacing="sp16" marginHorizontal="sp16">
+            </Card>
+            <VStack spacing="sp16">
                 <View style={applyStyle(cameraStyle)}>
                     <XpubImportSection
                         onRequestCamera={handleToggleScanner}

--- a/suite-native/module-home/src/screens/HomeScreen/HomeScreen.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/HomeScreen.tsx
@@ -41,7 +41,7 @@ export const HomeScreen = () => {
             customHorizontalPadding={0}
         >
             {isEmptyHomeRendererShown ? (
-                <Box marginHorizontal="sp8">
+                <Box marginHorizontal="sp16" marginBottom="sp8">
                     <EmptyHomeRenderer />
                 </Box>
             ) : (

--- a/suite-native/navigation/src/index.ts
+++ b/suite-native/navigation/src/index.ts
@@ -2,6 +2,7 @@ export * from './navigators';
 export * from './routes';
 export * from './types';
 export * from './config';
+export * from './useNavigateToInitialScreen';
 export * from './components/TabBar';
 export * from './components/Screen';
 export * from './components/ScreenHeader';

--- a/suite-native/navigation/src/useNavigateToInitialScreen.ts
+++ b/suite-native/navigation/src/useNavigateToInitialScreen.ts
@@ -1,0 +1,24 @@
+import { ParamListBase, useNavigation } from '@react-navigation/native';
+
+import { StackToTabCompositeProps } from './index';
+
+type NavigationProp = StackToTabCompositeProps<ParamListBase, string, ParamListBase>;
+
+export const useNavigateToInitialScreen = () => {
+    const navigation = useNavigation<NavigationProp>();
+
+    // Some flows use their own stack navigator and once they are finished, we want to return
+    // to the initial screen. This is achieved by navigating to the first screen of the current
+    // stack and then going back.
+    return () => {
+        // If there is more than 1 route, popToTop() will empty the stack. However, if there is
+        // only a single route (the current one), popToTop() will go to the previous stack instead.
+        // That's why we have to combine both popToTop() and goBack().
+        if (navigation.getState().routes.length > 1) {
+            navigation.popToTop();
+        }
+        if (navigation.canGoBack()) {
+            navigation.goBack();
+        }
+    };
+};


### PR DESCRIPTION
- Horizontal margin set to `16px` for relevant screens
- The font size of the  _Sync my coins_ title unified with the rest of the app
- Navigation is now the same for the 1st synced coin and any other
    - The _Sync my coins_ screen slides from bottom
    - Cross is shown for the first and the last screens of the flow
    - Going back from the summary screen forbidden
    - User returned to the original screen once the flow is finished
    - Removed change button on the xpub scan screen (same as going back)
    - Removed bin button on the summary screen
- _Sync another coin_ button is now the primary action

## Related Issue

Follow-up for #14065

## Screenshots:
![Simulator Screenshot - iPhone 16 Pro - 2024-11-04 at 13 21 00](https://github.com/user-attachments/assets/4f1a7fee-5369-4adf-b07b-c677ad162f1f)
![Simulator Screenshot - iPhone 16 Pro - 2024-11-04 at 13 21 04](https://github.com/user-attachments/assets/34c668ed-2687-4a7c-a339-bbc766dfb8e7)
![Simulator Screenshot - iPhone 16 Pro - 2024-11-04 at 13 21 09](https://github.com/user-attachments/assets/bcea249d-4044-4e72-8201-ae0ee28e4c3a)
![Simulator Screenshot - iPhone 16 Pro - 2024-11-04 at 13 21 20](https://github.com/user-attachments/assets/41ea365d-acef-45fd-a4cf-337f3cbba3bc)
![Simulator Screenshot - iPhone 16 Pro - 2024-11-04 at 13 21 34](https://github.com/user-attachments/assets/5aa78066-ee13-46b0-9d20-78e5496ce0e4)
