### PR TITLE
fix(coinmarket): Confirm on Trezor and Send button infinite loading while sell

### DIFF
--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSellForm.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSellForm.ts
@@ -375,6 +375,7 @@ export const useCoinmarketSellForm = ({
 
                 return undefined;
             }
+            setCallInProgress(false);
 
             return response.trade;
         }


### PR DESCRIPTION
**Describe the bug**
"Confirm on Trezor & Send" is disabled and in loading state while advancing through sell. The sell trade is in valid (non-blocked or non-loading) state.

**How to reproduce**
Steps to reproduce the behavior:

1. Go directly to https://suite.trezor.io/web/  in web browser (or desktop version)
2. Choose an account, e.g. Bitcoin account
3. Click on “Buy & Sell” button
4. Go to “Sell” section
5. Fill out amount to sell and click on “Compare all offers” button
6. Choose BTC Direct offerby clicking on “Select” button => click “I’m ready to sell”
7. Click on “Proceed” button => Infinite loading “Confirm on Trezor & Send” button appears

**Expected behavior**
The button has to be available when a user can continue with valid sell trade.

## Related Issue

Resolves #15190

**Screenshots**
## Current version
![image](https://github.com/user-attachments/assets/1d0a15ce-d2da-4c18-b17b-428bc910a975)


## Fixed version
![image](https://github.com/user-attachments/assets/5a6a835f-28c4-4cee-816a-f151dd4d85c3)