### PR TITLE
fix(suite): WelcomeLayout gap on top

### DIFF
--- a/packages/suite/src/components/suite/layouts/WelcomeLayout/WelcomeLayout.tsx
+++ b/packages/suite/src/components/suite/layouts/WelcomeLayout/WelcomeLayout.tsx
@@ -209,9 +209,11 @@ export const WelcomeLayout = ({ children }: WelcomeLayoutProps) => {
         <ElevationContext baseElevation={-1}>
             <TrafficLightOffset isVisible={Boolean(bannerMessage)}>
                 <Wrapper>
-                    <MessageContainer>
-                        {bannerMessage && <MessageSystemBanner message={bannerMessage} />}
-                    </MessageContainer>
+                    {bannerMessage && (
+                        <MessageContainer>
+                            <MessageSystemBanner message={bannerMessage} />
+                        </MessageContainer>
+                    )}
 
                     <Body data-testid="@welcome-layout/body">
                         <ElevationDown>


### PR DESCRIPTION
## Description

My personal pet peeve

There is a gap due to a wrapper for message system banner, even if there is no message.

## Screenshots:
Before
<img width="676" alt="Screenshot 2024-11-04 at 15 33 50" src="https://github.com/user-attachments/assets/c277194b-94ff-49d7-9212-702886d6597d">
After
<img width="676" alt="Screenshot 2024-11-04 at 15 34 06" src="https://github.com/user-attachments/assets/3a7c93a5-8c9b-4aaf-90ea-7fd256eabdce">
