### PR TITLE
Chore: bump mission deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
         "type-fest": "4.24.0",
         "bcrypto": "5.4.0",
         "react": "18.2.0",
-        "electron": "32.1.2",
+        "electron": "33.1.0",
         "@types/node": "20.12.7",
         "@types/react": "18.2.55",
         "bn.js": "5.2.1"

--- a/packages/auth-server/package.json
+++ b/packages/auth-server/package.json
@@ -15,7 +15,7 @@
     },
     "dependencies": {
         "cors": "^2.8.5",
-        "express": "^4.21.0"
+        "express": "^4.21.1"
     },
     "devDependencies": {
         "@types/cors": "^2.8.17"

--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -70,7 +70,7 @@
         "html-webpack-plugin": "^5.6.0",
         "tiny-worker": "^2.3.0",
         "tsx": "^4.16.3",
-        "webpack": "^5.94.0",
+        "webpack": "^5.96.1",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.0.4",
         "worker-loader": "^3.0.8"

--- a/packages/connect-examples/electron-main-process/package.json
+++ b/packages/connect-examples/electron-main-process/package.json
@@ -55,7 +55,7 @@
         "@trezor/connect": "workspace:*"
     },
     "devDependencies": {
-        "electron": "32.1.2",
+        "electron": "33.1.0",
         "electron-builder": "25.1.8"
     }
 }

--- a/packages/connect-examples/electron-main-process/package.json
+++ b/packages/connect-examples/electron-main-process/package.json
@@ -56,6 +56,6 @@
     },
     "devDependencies": {
         "electron": "32.1.2",
-        "electron-builder": "25.0.5"
+        "electron-builder": "25.1.8"
     }
 }

--- a/packages/connect-examples/electron-renderer-with-assets/package.json
+++ b/packages/connect-examples/electron-renderer-with-assets/package.json
@@ -60,7 +60,7 @@
         "babel-loader": "^9.1.3",
         "concurrently": "^8.2.2",
         "copy-webpack-plugin": "^12.0.2",
-        "electron": "32.1.2",
+        "electron": "33.1.0",
         "electron-builder": "25.1.8",
         "html-webpack-plugin": "^5.6.0",
         "terser-webpack-plugin": "^5.3.9",

--- a/packages/connect-examples/electron-renderer-with-assets/package.json
+++ b/packages/connect-examples/electron-renderer-with-assets/package.json
@@ -61,7 +61,7 @@
         "concurrently": "^8.2.2",
         "copy-webpack-plugin": "^12.0.2",
         "electron": "32.1.2",
-        "electron-builder": "25.0.5",
+        "electron-builder": "25.1.8",
         "html-webpack-plugin": "^5.6.0",
         "terser-webpack-plugin": "^5.3.9",
         "wait-on": "^7.0.1",

--- a/packages/connect-examples/electron-renderer-with-assets/package.json
+++ b/packages/connect-examples/electron-renderer-with-assets/package.json
@@ -65,7 +65,7 @@
         "html-webpack-plugin": "^5.6.0",
         "terser-webpack-plugin": "^5.3.9",
         "wait-on": "^7.0.1",
-        "webpack": "^5.94.0",
+        "webpack": "^5.96.1",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.0.4",
         "worker-loader": "^3.0.8"

--- a/packages/connect-examples/electron-renderer-with-popup/package.json
+++ b/packages/connect-examples/electron-renderer-with-popup/package.json
@@ -53,6 +53,6 @@
     },
     "devDependencies": {
         "electron": "32.1.2",
-        "electron-builder": "25.0.5"
+        "electron-builder": "25.1.8"
     }
 }

--- a/packages/connect-examples/electron-renderer-with-popup/package.json
+++ b/packages/connect-examples/electron-renderer-with-popup/package.json
@@ -52,7 +52,7 @@
         }
     },
     "devDependencies": {
-        "electron": "32.1.2",
+        "electron": "33.1.0",
         "electron-builder": "25.1.8"
     }
 }

--- a/packages/connect-examples/webextension-mv3-sw-ts/package.json
+++ b/packages/connect-examples/webextension-mv3-sw-ts/package.json
@@ -17,6 +17,6 @@
     "devDependencies": {
         "copy-webpack-plugin": "^12.0.2",
         "html-webpack-plugin": "^5.6.0",
-        "webpack": "^5.94.0"
+        "webpack": "^5.96.1"
     }
 }

--- a/packages/connect-explorer/package.json
+++ b/packages/connect-explorer/package.json
@@ -56,7 +56,7 @@
         "html-webpack-plugin": "^5.6.0",
         "rimraf": "^6.0.1",
         "tsx": "^4.16.3",
-        "webpack": "^5.94.0",
+        "webpack": "^5.96.1",
         "webpack-cli": "^5.1.4"
     }
 }

--- a/packages/connect-iframe/package.json
+++ b/packages/connect-iframe/package.json
@@ -26,7 +26,7 @@
         "html-webpack-plugin": "^5.6.0",
         "rimraf": "^6.0.1",
         "terser-webpack-plugin": "^5.3.9",
-        "webpack": "^5.94.0",
+        "webpack": "^5.96.1",
         "webpack-cli": "^5.1.4",
         "webpack-merge": "^6.0.1",
         "worker-loader": "^3.0.8"

--- a/packages/connect-popup/package.json
+++ b/packages/connect-popup/package.json
@@ -45,7 +45,7 @@
         "html-webpack-plugin": "^5.6.0",
         "rimraf": "^6.0.1",
         "terser-webpack-plugin": "^5.3.9",
-        "webpack": "^5.94.0",
+        "webpack": "^5.96.1",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.0.4",
         "webpack-merge": "^6.0.1",

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -61,7 +61,7 @@
         "selfsigned": "^2.4.1",
         "terser-webpack-plugin": "^5.3.9",
         "tsx": "^4.16.3",
-        "webpack": "^5.94.0",
+        "webpack": "^5.96.1",
         "webpack-cli": "^5.1.4",
         "webpack-merge": "^6.0.1",
         "webpack-plugin-serve": "^1.6.0",

--- a/packages/connect-webextension/package.json
+++ b/packages/connect-webextension/package.json
@@ -53,7 +53,7 @@
         "copy-webpack-plugin": "^12.0.2",
         "rimraf": "^6.0.1",
         "terser-webpack-plugin": "^5.3.9",
-        "webpack": "^5.94.0",
+        "webpack": "^5.96.1",
         "webpack-cli": "^5.1.4",
         "webpack-merge": "^6.0.1",
         "webpack-plugin-serve": "^1.6.0",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -103,7 +103,7 @@
         "node-libs-browser": "^2.2.1",
         "ts-node": "^10.9.1",
         "tsx": "^4.16.3",
-        "webpack": "^5.94.0",
+        "webpack": "^5.96.1",
         "ws": "^8.18.0"
     },
     "peerDependencies": {

--- a/packages/e2e-utils/package.json
+++ b/packages/e2e-utils/package.json
@@ -11,7 +11,7 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
-        "express": "^4.21.0",
+        "express": "^4.21.1",
         "uuid": "^10.0.0",
         "ws": "^8.18.0"
     },

--- a/packages/e2e-utils/package.json
+++ b/packages/e2e-utils/package.json
@@ -12,10 +12,7 @@
     },
     "dependencies": {
         "express": "^4.21.1",
-        "uuid": "^10.0.0",
+        "uuid": "^11.0.2",
         "ws": "^8.18.0"
-    },
-    "devDependencies": {
-        "@types/uuid": "^10.0.0"
     }
 }

--- a/packages/ipc-proxy/src/proxy-handler.ts
+++ b/packages/ipc-proxy/src/proxy-handler.ts
@@ -43,10 +43,11 @@ interface IpcMainHandlers<Api> {
     '/invoke': Parameters<ApiUnion<Api>>; // methodName, ...params
 }
 
+// Electron.IpcMainInvokeEvent narowed down only to properties we actually need
 export interface ElectronIpcMainInvokeEvent {
     senderFrame: {
         url: string;
-    };
+    } | null;
 }
 
 export interface ElectronIpcMainEvent {

--- a/packages/ipc-proxy/src/validateIpcMessage.ts
+++ b/packages/ipc-proxy/src/validateIpcMessage.ts
@@ -1,6 +1,5 @@
 import { ElectronIpcMainInvokeEvent } from './proxy-handler';
 
-// ipcEvent: Electron.IpcMainInvokeEvent
 export const validateIpcMessage = (ipcEvent: ElectronIpcMainInvokeEvent) => {
     if (ipcEvent?.senderFrame && 'url' in ipcEvent.senderFrame) {
         const parsedUrl = new URL(ipcEvent.senderFrame.url);

--- a/packages/suite-build/configs/desktop.webpack.config.ts
+++ b/packages/suite-build/configs/desktop.webpack.config.ts
@@ -17,7 +17,7 @@ const baseDirUI = getPathForProject('desktop-ui');
 const baseDir = getPathForProject('desktop');
 
 const config: webpack.Configuration = {
-    target: 'browserslist:Chrome >= 128', // Electron 32 is running on chromium 128
+    target: 'browserslist:Chrome >= 130', // Electron 33 is running on chromium 130
     entry: [path.join(baseDirUI, 'src', 'index.tsx')],
     output: {
         path: path.join(baseDir, 'build'),

--- a/packages/suite-build/package.json
+++ b/packages/suite-build/package.json
@@ -35,7 +35,7 @@
         "stream-browserify": "^3.0.0",
         "style-loader": "^3.3.4",
         "terser-webpack-plugin": "^5.3.9",
-        "webpack": "^5.94.0",
+        "webpack": "^5.96.1",
         "webpack-bundle-analyzer": "^4.10.1",
         "webpack-merge": "^6.0.1",
         "webpack-nano": "^1.1.1",

--- a/packages/suite-data/package.json
+++ b/packages/suite-data/package.json
@@ -40,7 +40,7 @@
         "simple-git": "^3.26.0",
         "style-loader": "^3.3.4",
         "tsx": "^4.16.3",
-        "webpack": "^5.94.0",
+        "webpack": "^5.96.1",
         "webpack-cli": "^5.1.4"
     },
     "nx": {

--- a/packages/suite-desktop-api/package.json
+++ b/packages/suite-desktop-api/package.json
@@ -19,6 +19,6 @@
         "type-check": "yarn g:tsc --build tsconfig.json"
     },
     "dependencies": {
-        "electron": "32.1.2"
+        "electron": "33.1.0"
     }
 }

--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -50,7 +50,7 @@
         "@trezor/trezor-user-env-link": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@types/electron-localshortcut": "^3.1.3",
-        "electron": "32.1.2",
+        "electron": "33.1.0",
         "fs-extra": "^11.2.0",
         "glob": "^10.3.10",
         "terser-webpack-plugin": "^5.3.9",

--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -54,7 +54,7 @@
         "fs-extra": "^11.2.0",
         "glob": "^10.3.10",
         "terser-webpack-plugin": "^5.3.9",
-        "webpack": "^5.94.0",
+        "webpack": "^5.96.1",
         "xvfb-maybe": "^0.2.1"
     }
 }

--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -36,7 +36,7 @@
         "electron-localshortcut": "^3.2.1",
         "electron-store": "8.2.0",
         "electron-updater": "6.3.9",
-        "openpgp": "^5.11.2",
+        "openpgp": "^6.0.0",
         "systeminformation": "^5.23.5"
     },
     "devDependencies": {

--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -35,7 +35,7 @@
         "chalk": "^4.1.2",
         "electron-localshortcut": "^3.2.1",
         "electron-store": "8.2.0",
-        "electron-updater": "6.3.4",
+        "electron-updater": "6.3.9",
         "openpgp": "^5.11.2",
         "systeminformation": "^5.23.5"
     },

--- a/packages/suite-desktop-core/src/libs/thread-proxy.ts
+++ b/packages/suite-desktop-core/src/libs/thread-proxy.ts
@@ -52,7 +52,7 @@ export class ThreadProxy<_Target extends object> {
         if (this.utility) throw new Error('Process already running');
         const utilityPath = path.join(THREADS_DIR_PATH, `${this.settings.name}.js`);
         const utility = utilityProcess.fork(utilityPath);
-        await new Promise((resolve, reject) => {
+        await new Promise<void>((resolve, reject) => {
             utility.once('spawn', resolve);
             utility.once('exit', reject);
         });

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -31,7 +31,7 @@
     },
     "devDependencies": {
         "@electron/notarize": "2.5.0",
-        "electron": "32.1.2",
+        "electron": "33.1.0",
         "electron-builder": "25.1.8",
         "glob": "^10.3.10"
     }

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -32,7 +32,7 @@
     "devDependencies": {
         "@electron/notarize": "2.5.0",
         "electron": "32.1.2",
-        "electron-builder": "25.0.5",
+        "electron-builder": "25.1.8",
         "glob": "^10.3.10"
     }
 }

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -26,7 +26,7 @@
         "blake-hash": "^2.0.0",
         "electron-localshortcut": "^3.2.1",
         "electron-store": "8.2.0",
-        "electron-updater": "6.3.4",
+        "electron-updater": "6.3.9",
         "usb": "^2.14.0"
     },
     "devDependencies": {

--- a/packages/suite-web/package.json
+++ b/packages/suite-web/package.json
@@ -52,7 +52,7 @@
         "stylelint": "^16.2.1",
         "stylelint-config-standard": "^36.0.0",
         "tsx": "^4.16.3",
-        "webpack": "^5.94.0",
+        "webpack": "^5.96.1",
         "ws": "^8.18.0",
         "yargs": "17.7.2"
     }

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -22,7 +22,7 @@
         "@everstake/wallet-sdk": "^0.3.66",
         "@floating-ui/react": "^0.26.9",
         "@formatjs/intl": "2.10.0",
-        "@hookform/resolvers": "3.9.0",
+        "@hookform/resolvers": "3.9.1",
         "@mobily/ts-belt": "^3.13.1",
         "@reduxjs/toolkit": "1.9.5",
         "@sentry/core": "^7.100.1",

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -98,7 +98,7 @@
         "react-dom": "18.2.0",
         "react-focus-lock": "^2.9.7",
         "react-helmet-async": "^2.0.4",
-        "react-hook-form": "^7.53.0",
+        "react-hook-form": "^7.53.1",
         "react-intl": "^6.6.8",
         "react-qr-reader": "^2.2.1",
         "react-redux": "8.0.7",

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -114,7 +114,7 @@
         "redux-thunk": "^2.4.2",
         "semver": "^7.6.3",
         "styled-components": "^6.1.8",
-        "uuid": "^10.0.0",
+        "uuid": "^11.0.2",
         "web3-utils": "^4.3.1",
         "zxcvbn": "^4.4.2"
     },
@@ -138,7 +138,6 @@
         "@types/redux-mock-store": "^1.0.6",
         "@types/semver": "^7.5.8",
         "@types/ua-parser-js": "^0.7.39",
-        "@types/uuid": "^10.0.0",
         "@types/zxcvbn": "^4.4.4",
         "jest-canvas-mock": "^2.5.2",
         "jest-watch-typeahead": "2.2.2",

--- a/packages/transport-bridge/package.json
+++ b/packages/transport-bridge/package.json
@@ -24,7 +24,7 @@
         "esbuild": "^0.23.1",
         "html-webpack-plugin": "^5.6.0",
         "pkg": "^5.8.1",
-        "webpack": "^5.94.0"
+        "webpack": "^5.96.1"
     },
     "dependencies": {
         "@trezor/components": "workspace:*",

--- a/scripts/list-outdated-dependencies/mission-dependencies.txt
+++ b/scripts/list-outdated-dependencies/mission-dependencies.txt
@@ -17,7 +17,6 @@ minimaldata
 n64
 @types/wif
 wif
-@types/uuid
 tiny-secp256k1
 uuid
 

--- a/suite-common/wallet-core/package.json
+++ b/suite-common/wallet-core/package.json
@@ -37,7 +37,7 @@
         "@trezor/utils": "workspace:*",
         "date-fns": "^2.30.0",
         "proxy-memoize": "2.0.2",
-        "react-hook-form": "^7.53.0",
+        "react-hook-form": "^7.53.1",
         "web3-utils": "^4.3.1"
     }
 }

--- a/suite-common/wallet-utils/package.json
+++ b/suite-common/wallet-utils/package.json
@@ -33,7 +33,7 @@
         "@trezor/utils": "workspace:*",
         "date-fns": "^2.30.0",
         "react": "18.2.0",
-        "react-hook-form": "^7.53.0",
+        "react-hook-form": "^7.53.1",
         "web3-utils": "^4.3.1"
     }
 }

--- a/suite-native/forms/package.json
+++ b/suite-native/forms/package.json
@@ -16,7 +16,7 @@
         "@suite-native/atoms": "workspace:*",
         "@suite-native/icons": "workspace:*",
         "react": "18.2.0",
-        "react-hook-form": "^7.53.0",
+        "react-hook-form": "^7.53.1",
         "react-native": "0.75.2",
         "yup": "^1.4.0"
     }

--- a/suite-native/forms/package.json
+++ b/suite-native/forms/package.json
@@ -11,7 +11,7 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
-        "@hookform/resolvers": "3.9.0",
+        "@hookform/resolvers": "3.9.1",
         "@mobily/ts-belt": "^3.13.1",
         "@suite-native/atoms": "workspace:*",
         "@suite-native/icons": "workspace:*",

--- a/suite-native/module-accounts-management/package.json
+++ b/suite-native/module-accounts-management/package.json
@@ -42,7 +42,7 @@
         "date-fns": "^2.30.0",
         "jotai": "1.9.1",
         "react": "18.2.0",
-        "react-hook-form": "^7.53.0",
+        "react-hook-form": "^7.53.1",
         "react-native": "0.75.2",
         "react-native-reanimated": "3.16.1",
         "react-redux": "8.0.7"

--- a/suite-native/module-send/package.json
+++ b/suite-native/module-send/package.json
@@ -50,7 +50,7 @@
         "expo-linear-gradient": "13.0.2",
         "jotai": "1.9.1",
         "react": "18.2.0",
-        "react-hook-form": "^7.53.0",
+        "react-hook-form": "^7.53.1",
         "react-native": "0.75.2",
         "react-native-reanimated": "3.16.1",
         "react-native-svg": "15.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4339,12 +4339,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hookform/resolvers@npm:3.9.0":
-  version: 3.9.0
-  resolution: "@hookform/resolvers@npm:3.9.0"
+"@hookform/resolvers@npm:3.9.1":
+  version: 3.9.1
+  resolution: "@hookform/resolvers@npm:3.9.1"
   peerDependencies:
     react-hook-form: ^7.0.0
-  checksum: 10/b878e92cebc703106a70987437ab4add0e71a327a0bb9864f82ab480b5d9a38b0d639f6154b138c3c4828af0db00c1b413279c102715146b19edc76b9786f1c3
+  checksum: 10/4e7a24f79ead48db5c869c17b5f47412a7d628939f743bdc1248ea3a291b1a9dd777cd02f84326e91d258283a6351566f13bca5cb30f996e5a9db7ee490b5cc5
   languageName: node
   linkType: hard
 
@@ -9772,7 +9772,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/forms@workspace:suite-native/forms"
   dependencies:
-    "@hookform/resolvers": "npm:3.9.0"
+    "@hookform/resolvers": "npm:3.9.1"
     "@mobily/ts-belt": "npm:^3.13.1"
     "@suite-native/atoms": "workspace:*"
     "@suite-native/icons": "workspace:*"
@@ -11902,7 +11902,7 @@ __metadata:
     "@floating-ui/react": "npm:^0.26.9"
     "@formatjs/cli": "npm:^6.2.7"
     "@formatjs/intl": "npm:2.10.0"
-    "@hookform/resolvers": "npm:3.9.0"
+    "@hookform/resolvers": "npm:3.9.1"
     "@mobily/ts-belt": "npm:^3.13.1"
     "@reduxjs/toolkit": "npm:1.9.5"
     "@sentry/core": "npm:^7.100.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11779,7 +11779,7 @@ __metadata:
     electron-updater: "npm:6.3.9"
     fs-extra: "npm:^11.2.0"
     glob: "npm:^10.3.10"
-    openpgp: "npm:^5.11.2"
+    openpgp: "npm:^6.0.0"
     systeminformation: "npm:^5.23.5"
     terser-webpack-plugin: "npm:^5.3.9"
     webpack: "npm:^5.96.1"
@@ -15164,7 +15164,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"asn1.js@npm:^5.0.0, asn1.js@npm:^5.2.0":
+"asn1.js@npm:^5.2.0":
   version: 5.4.1
   resolution: "asn1.js@npm:5.4.1"
   dependencies:
@@ -32768,12 +32768,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openpgp@npm:^5.11.2":
-  version: 5.11.2
-  resolution: "openpgp@npm:5.11.2"
-  dependencies:
-    asn1.js: "npm:^5.0.0"
-  checksum: 10/75052f8b89aa946d2b927f2a679d57671b2da5bf3dab1a223b9ba54305635ce37a86cb2ea274d0dcd830511e3fe1bae16d85259e907f56ec31219c4367c311a8
+"openpgp@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "openpgp@npm:6.0.0"
+  checksum: 10/ca634862edb04c3da0d4d25e0157015111f588fd5698f7dc9fc69a515455db52a798bda69de3f1eecfbb6a96a0f8f0d2fe2fde6d4a68736c95460d140d5c2c9c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2423,17 +2423,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@electron/notarize@npm:2.3.2":
-  version: 2.3.2
-  resolution: "@electron/notarize@npm:2.3.2"
-  dependencies:
-    debug: "npm:^4.1.1"
-    fs-extra: "npm:^9.0.1"
-    promise-retry: "npm:^2.0.1"
-  checksum: 10/c391c5b005496f3ad504fe323083d9ae1a14d4cbf7db03d7823b92dcad0815f9bd9d01732d9f748c933dae1b5d5ba98360df0ceedff4dd1814937376fc75be31
-  languageName: node
-  linkType: hard
-
 "@electron/notarize@npm:2.5.0":
   version: 2.5.0
   resolution: "@electron/notarize@npm:2.5.0"
@@ -2462,9 +2451,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@electron/rebuild@npm:3.6.0":
-  version: 3.6.0
-  resolution: "@electron/rebuild@npm:3.6.0"
+"@electron/rebuild@npm:3.6.1":
+  version: 3.6.1
+  resolution: "@electron/rebuild@npm:3.6.1"
   dependencies:
     "@malept/cross-spawn-promise": "npm:^2.0.0"
     chalk: "npm:^4.0.0"
@@ -2482,7 +2471,7 @@ __metadata:
     yargs: "npm:^17.0.1"
   bin:
     electron-rebuild: lib/cli.js
-  checksum: 10/bbc8f215059746874d194818785b47a96f3687539226c67074a4af5c4abd6e1e2339c5e91673d5b6312b98c37d056733af662bd68aba393a02e8b643035d08c7
+  checksum: 10/baedb09a8b109347fd1e7ee16559b4519ebc56a4ec624b3eec5215282a66def5fa4b96c19a26df0f53cd3ab60f077e88cd03429b46ddc63e70279f30c8e20c8a
   languageName: node
   linkType: hard
 
@@ -11837,7 +11826,7 @@ __metadata:
     "@electron/notarize": "npm:2.5.0"
     blake-hash: "npm:^2.0.0"
     electron: "npm:32.1.2"
-    electron-builder: "npm:25.0.5"
+    electron-builder: "npm:25.1.8"
     electron-localshortcut: "npm:^3.2.1"
     electron-store: "npm:8.2.0"
     electron-updater: "npm:6.3.4"
@@ -14828,50 +14817,53 @@ __metadata:
   languageName: node
   linkType: hard
 
-"app-builder-bin@npm:5.0.0-alpha.7":
-  version: 5.0.0-alpha.7
-  resolution: "app-builder-bin@npm:5.0.0-alpha.7"
-  checksum: 10/4338d9934b253c73d41a07f22f55e34f6e1e2550d6509c9813b54819c46755a501be1b5d6850b68918f717ec7d526494d896109f9b1de17100a4d36b4d518c73
+"app-builder-bin@npm:5.0.0-alpha.10":
+  version: 5.0.0-alpha.10
+  resolution: "app-builder-bin@npm:5.0.0-alpha.10"
+  checksum: 10/842dc0cade3f1dc2c3fc2809511a4ecb86146d17d22e35d97a493bf3c8bd131552e935abd8ed8df40f6f62d8b231b7b705c81df709becdd55dc28dc6f247af31
   languageName: node
   linkType: hard
 
-"app-builder-lib@npm:25.0.5":
-  version: 25.0.5
-  resolution: "app-builder-lib@npm:25.0.5"
+"app-builder-lib@npm:25.1.8":
+  version: 25.1.8
+  resolution: "app-builder-lib@npm:25.1.8"
   dependencies:
     "@develar/schema-utils": "npm:~2.6.5"
-    "@electron/notarize": "npm:2.3.2"
+    "@electron/notarize": "npm:2.5.0"
     "@electron/osx-sign": "npm:1.3.1"
-    "@electron/rebuild": "npm:3.6.0"
+    "@electron/rebuild": "npm:3.6.1"
     "@electron/universal": "npm:2.0.1"
     "@malept/flatpak-bundler": "npm:^0.4.0"
     "@types/fs-extra": "npm:9.0.13"
     async-exit-hook: "npm:^2.0.1"
     bluebird-lst: "npm:^1.0.9"
-    builder-util: "npm:25.0.3"
-    builder-util-runtime: "npm:9.2.5"
+    builder-util: "npm:25.1.7"
+    builder-util-runtime: "npm:9.2.10"
     chromium-pickle-js: "npm:^0.2.0"
+    config-file-ts: "npm:0.2.8-rc1"
     debug: "npm:^4.3.4"
+    dotenv: "npm:^16.4.5"
+    dotenv-expand: "npm:^11.0.6"
     ejs: "npm:^3.1.8"
-    electron-publish: "npm:25.0.3"
+    electron-publish: "npm:25.1.7"
     form-data: "npm:^4.0.0"
     fs-extra: "npm:^10.1.0"
     hosted-git-info: "npm:^4.1.0"
     is-ci: "npm:^3.0.0"
     isbinaryfile: "npm:^5.0.0"
     js-yaml: "npm:^4.1.0"
+    json5: "npm:^2.2.3"
     lazy-val: "npm:^1.0.5"
     minimatch: "npm:^10.0.0"
-    read-config-file: "npm:6.4.0"
     resedit: "npm:^1.7.0"
     sanitize-filename: "npm:^1.6.3"
     semver: "npm:^7.3.8"
     tar: "npm:^6.1.12"
     temp-file: "npm:^3.4.0"
   peerDependencies:
-    dmg-builder: 25.0.5
-    electron-builder-squirrel-windows: 25.0.5
-  checksum: 10/fa78e12fc5a56e4c536624585dcb8db26783f4c18517ff8be49259ea5e1dc39aab3cf612e577020ed3f52938505cfc297dd6a47439e8ff99dc1ca25d5620a88b
+    dmg-builder: 25.1.8
+    electron-builder-squirrel-windows: 25.1.8
+  checksum: 10/0af82ffd8389b6dbacffd0ee3191ed056b411f069c362e0f676bf00413d8cb14f0d6d9047e1ab388a578e7f41c8338daa489a259de1203d4b9fc465254dda685
   languageName: node
   linkType: hard
 
@@ -16552,6 +16544,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"builder-util-runtime@npm:9.2.10":
+  version: 9.2.10
+  resolution: "builder-util-runtime@npm:9.2.10"
+  dependencies:
+    debug: "npm:^4.3.4"
+    sax: "npm:^1.2.4"
+  checksum: 10/58b96675c174d1f495b4ffd5369fa496f4c33c9ea8150852191c45528bb47a2744142f2e9a449a077304a0f44ce0c35941ebb06b067ad39685c950c26d2137d2
+  languageName: node
+  linkType: hard
+
 "builder-util-runtime@npm:9.2.5":
   version: 9.2.5
   resolution: "builder-util-runtime@npm:9.2.5"
@@ -16562,27 +16564,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"builder-util@npm:25.0.3":
-  version: 25.0.3
-  resolution: "builder-util@npm:25.0.3"
+"builder-util@npm:25.1.7":
+  version: 25.1.7
+  resolution: "builder-util@npm:25.1.7"
   dependencies:
     7zip-bin: "npm:~5.2.0"
     "@types/debug": "npm:^4.1.6"
-    app-builder-bin: "npm:5.0.0-alpha.7"
+    app-builder-bin: "npm:5.0.0-alpha.10"
     bluebird-lst: "npm:^1.0.9"
-    builder-util-runtime: "npm:9.2.5"
+    builder-util-runtime: "npm:9.2.10"
     chalk: "npm:^4.1.2"
     cross-spawn: "npm:^7.0.3"
     debug: "npm:^4.3.4"
     fs-extra: "npm:^10.1.0"
-    http-proxy-agent: "npm:^5.0.0"
-    https-proxy-agent: "npm:^5.0.1"
+    http-proxy-agent: "npm:^7.0.0"
+    https-proxy-agent: "npm:^7.0.0"
     is-ci: "npm:^3.0.0"
     js-yaml: "npm:^4.1.0"
     source-map-support: "npm:^0.5.19"
     stat-mode: "npm:^1.0.0"
     temp-file: "npm:^3.4.0"
-  checksum: 10/0d2dea388b8e845479433c51b7fa2e27bc1560e5ea2bc434b62ba58b5bdd62154ee4631501ba6d12149519ecc2b2bc4605f9fc78b79a3d040b9a0505ddebd18a
+  checksum: 10/180817a9f5e24770050a2b23acb6b47e55156ee83c7296329ee538a1ec202cf21a626de9d731f4b674ab1d63bd995b152b02d8e8a4b3133a1964a586f0cc9037
   languageName: node
   linkType: hard
 
@@ -17906,7 +17908,7 @@ __metadata:
   dependencies:
     "@trezor/connect": "workspace:*"
     electron: "npm:32.1.2"
-    electron-builder: "npm:25.0.5"
+    electron-builder: "npm:25.1.8"
   languageName: unknown
   linkType: soft
 
@@ -17915,7 +17917,7 @@ __metadata:
   resolution: "connect-example-electron-renderer-popup@workspace:packages/connect-examples/electron-renderer-with-popup"
   dependencies:
     electron: "npm:32.1.2"
-    electron-builder: "npm:25.0.5"
+    electron-builder: "npm:25.1.8"
   languageName: unknown
   linkType: soft
 
@@ -17928,7 +17930,7 @@ __metadata:
     concurrently: "npm:^8.2.2"
     copy-webpack-plugin: "npm:^12.0.2"
     electron: "npm:32.1.2"
-    electron-builder: "npm:25.0.5"
+    electron-builder: "npm:25.1.8"
     html-webpack-plugin: "npm:^5.6.0"
     terser-webpack-plugin: "npm:^5.3.9"
     wait-on: "npm:^7.0.1"
@@ -20002,13 +20004,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dmg-builder@npm:25.0.5":
-  version: 25.0.5
-  resolution: "dmg-builder@npm:25.0.5"
+"dmg-builder@npm:25.1.8":
+  version: 25.1.8
+  resolution: "dmg-builder@npm:25.1.8"
   dependencies:
-    app-builder-lib: "npm:25.0.5"
-    builder-util: "npm:25.0.3"
-    builder-util-runtime: "npm:9.2.5"
+    app-builder-lib: "npm:25.1.8"
+    builder-util: "npm:25.1.7"
+    builder-util-runtime: "npm:9.2.10"
     dmg-license: "npm:^1.0.11"
     fs-extra: "npm:^10.1.0"
     iconv-lite: "npm:^0.6.2"
@@ -20016,7 +20018,7 @@ __metadata:
   dependenciesMeta:
     dmg-license:
       optional: true
-  checksum: 10/8d2f65a97d7669a8853d7620b28cd42c5b8cffd26c0e9bf9d0011e2a51088a623846b36d9e9a558ff61525b540bf0ca1a653f8ab1f8b3bf4a2f52ff66e4bdce8
+  checksum: 10/e776d27f1841a585db56e63b946b91aae89a1661ba5801b3adf0ff39996f7aad6090889eea6cc4db19c1664d86d9958ab0b3001bc2b69e97375e63ce3e5fe24e
   languageName: node
   linkType: hard
 
@@ -20369,25 +20371,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-builder@npm:25.0.5":
-  version: 25.0.5
-  resolution: "electron-builder@npm:25.0.5"
+"electron-builder@npm:25.1.8":
+  version: 25.1.8
+  resolution: "electron-builder@npm:25.1.8"
   dependencies:
-    app-builder-lib: "npm:25.0.5"
-    builder-util: "npm:25.0.3"
-    builder-util-runtime: "npm:9.2.5"
+    app-builder-lib: "npm:25.1.8"
+    builder-util: "npm:25.1.7"
+    builder-util-runtime: "npm:9.2.10"
     chalk: "npm:^4.1.2"
-    dmg-builder: "npm:25.0.5"
+    dmg-builder: "npm:25.1.8"
     fs-extra: "npm:^10.1.0"
     is-ci: "npm:^3.0.0"
     lazy-val: "npm:^1.0.5"
-    read-config-file: "npm:6.4.0"
     simple-update-notifier: "npm:2.0.0"
     yargs: "npm:^17.6.2"
   bin:
     electron-builder: cli.js
     install-app-deps: install-app-deps.js
-  checksum: 10/dcbcee76d0e405a2c062a46ede5144c38bdd9b9ce6d3fccf4b6c166f31485ba09fbceacae95a6e19fb2aa6ea5199186b81e6eddc525101bd33a1c892590b5b29
+  checksum: 10/d7eb5fd600f243a2824851eb6e4d2fa947bf17c3a78429f9dabc35f4bc32a5c5be90ed98b871475d56aaa2a490168a19d906a5aa5eb0d9744885f45412bef1b7
   languageName: node
   linkType: hard
 
@@ -20410,18 +20411,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-publish@npm:25.0.3":
-  version: 25.0.3
-  resolution: "electron-publish@npm:25.0.3"
+"electron-publish@npm:25.1.7":
+  version: 25.1.7
+  resolution: "electron-publish@npm:25.1.7"
   dependencies:
     "@types/fs-extra": "npm:^9.0.11"
-    builder-util: "npm:25.0.3"
-    builder-util-runtime: "npm:9.2.5"
+    builder-util: "npm:25.1.7"
+    builder-util-runtime: "npm:9.2.10"
     chalk: "npm:^4.1.2"
     fs-extra: "npm:^10.1.0"
     lazy-val: "npm:^1.0.5"
     mime: "npm:^2.5.2"
-  checksum: 10/ac0d4166c0c6eef9b78801b1e34157c2fae3b8a2e299ae21dc492f97caa27372ea224eb50b91d6403558068b45e8568afb79a4e98ae4872cc73e8edd4c3cf456
+  checksum: 10/75a3e6bcb796423456e01fb79d7c39257ae9a9ea9820ddbc64321ac888867da33198693af87366137d6c13b66a4273e89d15c268184bbddc24db6585d16067c1
   languageName: node
   linkType: hard
 
@@ -25327,6 +25328,16 @@ __metadata:
     agent-base: "npm:6"
     debug: "npm:4"
   checksum: 10/f0dce7bdcac5e8eaa0be3c7368bb8836ed010fb5b6349ffb412b172a203efe8f807d9a6681319105ea1b6901e1972c7b5ea899672a7b9aad58309f766dcbe0df
+  languageName: node
+  linkType: hard
+
+"https-proxy-agent@npm:^7.0.0":
+  version: 7.0.5
+  resolution: "https-proxy-agent@npm:7.0.5"
+  dependencies:
+    agent-base: "npm:^7.0.2"
+    debug: "npm:4"
+  checksum: 10/6679d46159ab3f9a5509ee80c3a3fc83fba3a920a5e18d32176c3327852c3c00ad640c0c4210a8fd70ea3c4a6d3a1b375bf01942516e7df80e2646bdc77658ab
   languageName: node
   linkType: hard
 
@@ -35858,20 +35869,6 @@ __metadata:
   dependencies:
     pify: "npm:^2.3.0"
   checksum: 10/83a39149d9dfa38f0c482ea0d77b34773c92fef07fe7599cdd914d255b14d0453e0229ef6379d8d27d6947f42d7581635296d0cfa7708f05a9bd8e789d398b31
-  languageName: node
-  linkType: hard
-
-"read-config-file@npm:6.4.0":
-  version: 6.4.0
-  resolution: "read-config-file@npm:6.4.0"
-  dependencies:
-    config-file-ts: "npm:0.2.8-rc1"
-    dotenv: "npm:^16.4.5"
-    dotenv-expand: "npm:^11.0.6"
-    js-yaml: "npm:^4.1.0"
-    json5: "npm:^2.2.3"
-    lazy-val: "npm:^1.0.5"
-  checksum: 10/b75325b7de94e8478badbb60daca1635ccde8cc8d7db3f494152602f21edc15b5da20baf2d52e6583e3f4fbd9e1eac433d73846d5db9d06c86905a74c0205a31
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9226,7 +9226,7 @@ __metadata:
     "@trezor/utils": "workspace:*"
     date-fns: "npm:^2.30.0"
     proxy-memoize: "npm:2.0.2"
-    react-hook-form: "npm:^7.53.0"
+    react-hook-form: "npm:^7.53.1"
     web3-utils: "npm:^4.3.1"
   languageName: unknown
   linkType: soft
@@ -9272,7 +9272,7 @@ __metadata:
     "@trezor/utils": "workspace:*"
     date-fns: "npm:^2.30.0"
     react: "npm:18.2.0"
-    react-hook-form: "npm:^7.53.0"
+    react-hook-form: "npm:^7.53.1"
     web3-utils: "npm:^4.3.1"
   languageName: unknown
   linkType: soft
@@ -9777,7 +9777,7 @@ __metadata:
     "@suite-native/atoms": "workspace:*"
     "@suite-native/icons": "workspace:*"
     react: "npm:18.2.0"
-    react-hook-form: "npm:^7.53.0"
+    react-hook-form: "npm:^7.53.1"
     react-native: "npm:0.75.2"
     yup: "npm:^1.4.0"
   languageName: unknown
@@ -9980,7 +9980,7 @@ __metadata:
     date-fns: "npm:^2.30.0"
     jotai: "npm:1.9.1"
     react: "npm:18.2.0"
-    react-hook-form: "npm:^7.53.0"
+    react-hook-form: "npm:^7.53.1"
     react-native: "npm:0.75.2"
     react-native-reanimated: "npm:3.16.1"
     react-redux: "npm:8.0.7"
@@ -10248,7 +10248,7 @@ __metadata:
     expo-linear-gradient: "npm:13.0.2"
     jotai: "npm:1.9.1"
     react: "npm:18.2.0"
-    react-hook-form: "npm:^7.53.0"
+    react-hook-form: "npm:^7.53.1"
     react-native: "npm:0.75.2"
     react-native-reanimated: "npm:3.16.1"
     react-native-svg: "npm:15.6.0"
@@ -11999,7 +11999,7 @@ __metadata:
     react-dom: "npm:18.2.0"
     react-focus-lock: "npm:^2.9.7"
     react-helmet-async: "npm:^2.0.4"
-    react-hook-form: "npm:^7.53.0"
+    react-hook-form: "npm:^7.53.1"
     react-intl: "npm:^6.6.8"
     react-qr-reader: "npm:^2.2.1"
     react-redux: "npm:8.0.7"
@@ -35223,12 +35223,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-hook-form@npm:^7.53.0":
-  version: 7.53.0
-  resolution: "react-hook-form@npm:7.53.0"
+"react-hook-form@npm:^7.53.1":
+  version: 7.53.1
+  resolution: "react-hook-form@npm:7.53.1"
   peerDependencies:
     react: ^16.8.0 || ^17 || ^18 || ^19
-  checksum: 10/b7d73696b7c10e042f6ea6fcec01f951091146bfbc89d1378327a970bcd724b968e93fae1657bddada75caf648cfaf8693c5ba03c25e96816b755079d29f65da
+  checksum: 10/41ac7140add546b90f75b0aef343b67b795d26a60da7bfeac1ded7716ec01234c6050f5c00a4487c28a73c24f9c9347cda741173a8083d7f4b02b588203e7544
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11737,7 +11737,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/suite-desktop-api@workspace:packages/suite-desktop-api"
   dependencies:
-    electron: "npm:32.1.2"
+    electron: "npm:33.1.0"
   languageName: unknown
   linkType: soft
 
@@ -11774,7 +11774,7 @@ __metadata:
     "@trezor/utils": "workspace:*"
     "@types/electron-localshortcut": "npm:^3.1.3"
     chalk: "npm:^4.1.2"
-    electron: "npm:32.1.2"
+    electron: "npm:33.1.0"
     electron-localshortcut: "npm:^3.2.1"
     electron-store: "npm:8.2.0"
     electron-updater: "npm:6.3.4"
@@ -11825,7 +11825,7 @@ __metadata:
   dependencies:
     "@electron/notarize": "npm:2.5.0"
     blake-hash: "npm:^2.0.0"
-    electron: "npm:32.1.2"
+    electron: "npm:33.1.0"
     electron-builder: "npm:25.1.8"
     electron-localshortcut: "npm:^3.2.1"
     electron-store: "npm:8.2.0"
@@ -17907,7 +17907,7 @@ __metadata:
   resolution: "connect-example-electron-main@workspace:packages/connect-examples/electron-main-process"
   dependencies:
     "@trezor/connect": "workspace:*"
-    electron: "npm:32.1.2"
+    electron: "npm:33.1.0"
     electron-builder: "npm:25.1.8"
   languageName: unknown
   linkType: soft
@@ -17916,7 +17916,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "connect-example-electron-renderer-popup@workspace:packages/connect-examples/electron-renderer-with-popup"
   dependencies:
-    electron: "npm:32.1.2"
+    electron: "npm:33.1.0"
     electron-builder: "npm:25.1.8"
   languageName: unknown
   linkType: soft
@@ -17929,7 +17929,7 @@ __metadata:
     babel-loader: "npm:^9.1.3"
     concurrently: "npm:^8.2.2"
     copy-webpack-plugin: "npm:^12.0.2"
-    electron: "npm:32.1.2"
+    electron: "npm:33.1.0"
     electron-builder: "npm:25.1.8"
     html-webpack-plugin: "npm:^5.6.0"
     terser-webpack-plugin: "npm:^5.3.9"
@@ -20459,16 +20459,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:32.1.2":
-  version: 32.1.2
-  resolution: "electron@npm:32.1.2"
+"electron@npm:33.1.0":
+  version: 33.1.0
+  resolution: "electron@npm:33.1.0"
   dependencies:
     "@electron/get": "npm:^2.0.0"
     "@types/node": "npm:^20.9.0"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10/a4793dd12b2d1dffff53420092ac7612eee41d193f07e847783136ee296b5380abb169eb1a4c1929b01a99b1d93bf53f071f2c5128e8241e70ec930d303fba51
+  checksum: 10/3347167d715e93a5ef8d9ca16981763b3c5b5e08be69226c5ec3bc7770160c7fffa8d063d7d92d0a76e5f6b8720a3b6e3e04bb1e1af81f89ebbc17dd7440a285
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11777,7 +11777,7 @@ __metadata:
     electron: "npm:33.1.0"
     electron-localshortcut: "npm:^3.2.1"
     electron-store: "npm:8.2.0"
-    electron-updater: "npm:6.3.4"
+    electron-updater: "npm:6.3.9"
     fs-extra: "npm:^11.2.0"
     glob: "npm:^10.3.10"
     openpgp: "npm:^5.11.2"
@@ -11829,7 +11829,7 @@ __metadata:
     electron-builder: "npm:25.1.8"
     electron-localshortcut: "npm:^3.2.1"
     electron-store: "npm:8.2.0"
-    electron-updater: "npm:6.3.4"
+    electron-updater: "npm:6.3.9"
     glob: "npm:^10.3.10"
     usb: "npm:^2.14.0"
   languageName: unknown
@@ -16554,16 +16554,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"builder-util-runtime@npm:9.2.5":
-  version: 9.2.5
-  resolution: "builder-util-runtime@npm:9.2.5"
-  dependencies:
-    debug: "npm:^4.3.4"
-    sax: "npm:^1.2.4"
-  checksum: 10/89c1e67c286ad5dd039abd56af91b3fa3d01eb62ce16c07e8d496a06eb0ed9ce015870d83dd919ffa387a32d47f9080923958672fc993154c8a184c6b1a78adc
-  languageName: node
-  linkType: hard
-
 "builder-util@npm:25.1.7":
   version: 25.1.7
   resolution: "builder-util@npm:25.1.7"
@@ -20443,11 +20433,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-updater@npm:6.3.4":
-  version: 6.3.4
-  resolution: "electron-updater@npm:6.3.4"
+"electron-updater@npm:6.3.9":
+  version: 6.3.9
+  resolution: "electron-updater@npm:6.3.9"
   dependencies:
-    builder-util-runtime: "npm:9.2.5"
+    builder-util-runtime: "npm:9.2.10"
     fs-extra: "npm:^10.1.0"
     js-yaml: "npm:^4.1.0"
     lazy-val: "npm:^1.0.5"
@@ -20455,7 +20445,7 @@ __metadata:
     lodash.isequal: "npm:^4.5.0"
     semver: "npm:^7.6.3"
     tiny-typed-emitter: "npm:^2.1.0"
-  checksum: 10/e31d827fc7f7372a5856e118e83e6e37ed22e5db26b8c2bc5ce7cebbd739bd9bacc1b6ed3fef21d69f2508a0266477ec6a0ec238a504b3ba108a3372f8c7b30b
+  checksum: 10/98a8a451fde48d6af71ef1e6c09df678feee59444ad296cb6276a01d8a2d0718b6233f884402ba61b736a8d7a16a5df7a86a8cf837ed686f9d3101ab4f34171f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11474,9 +11474,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/e2e-utils@workspace:packages/e2e-utils"
   dependencies:
-    "@types/uuid": "npm:^10.0.0"
     express: "npm:^4.21.1"
-    uuid: "npm:^10.0.0"
+    uuid: "npm:^11.0.2"
     ws: "npm:^8.18.0"
   languageName: unknown
   linkType: soft
@@ -11977,7 +11976,6 @@ __metadata:
     "@types/redux-mock-store": "npm:^1.0.6"
     "@types/semver": "npm:^7.5.8"
     "@types/ua-parser-js": "npm:^0.7.39"
-    "@types/uuid": "npm:^10.0.0"
     "@types/zxcvbn": "npm:^4.4.4"
     bs58check: "npm:^4.0.0"
     date-fns: "npm:^2.30.0"
@@ -12021,7 +12019,7 @@ __metadata:
     stylelint: "npm:^16.2.1"
     stylelint-config-standard: "npm:^36.0.0"
     typescript-styled-plugin: "npm:^0.18.3"
-    uuid: "npm:^10.0.0"
+    uuid: "npm:^11.0.2"
     web3-utils: "npm:^4.3.1"
     zxcvbn: "npm:^4.4.2"
   languageName: unknown
@@ -13635,13 +13633,6 @@ __metadata:
   version: 0.0.3
   resolution: "@types/use-sync-external-store@npm:0.0.3"
   checksum: 10/161ddb8eec5dbe7279ac971531217e9af6b99f7783213566d2b502e2e2378ea19cf5e5ea4595039d730aa79d3d35c6567d48599f69773a02ffcff1776ec2a44e
-  languageName: node
-  linkType: hard
-
-"@types/uuid@npm:^10.0.0":
-  version: 10.0.0
-  resolution: "@types/uuid@npm:10.0.0"
-  checksum: 10/e3958f8b0fe551c86c14431f5940c3470127293280830684154b91dc7eb3514aeb79fe3216968833cf79d4d1c67f580f054b5be2cd562bebf4f728913e73e944
   languageName: node
   linkType: hard
 
@@ -41280,12 +41271,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^10.0.0":
-  version: 10.0.0
-  resolution: "uuid@npm:10.0.0"
+"uuid@npm:^11.0.2":
+  version: 11.0.2
+  resolution: "uuid@npm:11.0.2"
   bin:
-    uuid: dist/bin/uuid
-  checksum: 10/35aa60614811a201ff90f8ca5e9ecb7076a75c3821e17f0f5ff72d44e36c2d35fcbc2ceee9c4ac7317f4cc41895da30e74f3885e30313bee48fda6338f250538
+    uuid: dist/esm/bin/uuid
+  checksum: 10/b98082f398fa2ece8cacc2264402f739256ca70def4bb82e3a14ec70777d189c01ce1054764c3b59b8fc098b62b135a15d1b24914712904c988822e2ac9b4f44
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10964,7 +10964,7 @@ __metadata:
   dependencies:
     "@types/cors": "npm:^2.8.17"
     cors: "npm:^2.8.5"
-    express: "npm:^4.21.0"
+    express: "npm:^4.21.1"
   peerDependencies:
     tslib: ^2.6.2
   languageName: unknown
@@ -11475,7 +11475,7 @@ __metadata:
   resolution: "@trezor/e2e-utils@workspace:packages/e2e-utils"
   dependencies:
     "@types/uuid": "npm:^10.0.0"
-    express: "npm:^4.21.0"
+    express: "npm:^4.21.1"
     uuid: "npm:^10.0.0"
     ws: "npm:^8.18.0"
   languageName: unknown
@@ -18046,7 +18046,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:0.6.0, cookie@npm:^0.6.0":
+"cookie@npm:0.7.1":
+  version: 0.7.1
+  resolution: "cookie@npm:0.7.1"
+  checksum: 10/aec6a6aa0781761bf55d60447d6be08861d381136a0fe94aa084fddd4f0300faa2b064df490c6798adfa1ebaef9e0af9b08a189c823e0811b8b313b3d9a03380
+  languageName: node
+  linkType: hard
+
+"cookie@npm:^0.6.0":
   version: 0.6.0
   resolution: "cookie@npm:0.6.0"
   checksum: 10/c1f8f2ea7d443b9331680598b0ae4e6af18a618c37606d1bbdc75bec8361cce09fe93e727059a673f2ba24467131a9fb5a4eec76bb1b149c1b3e1ccb268dc583
@@ -22571,16 +22578,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"express@npm:^4.17.3, express@npm:^4.18.2, express@npm:^4.21.0":
-  version: 4.21.0
-  resolution: "express@npm:4.21.0"
+"express@npm:^4.17.3, express@npm:^4.18.2, express@npm:^4.21.1":
+  version: 4.21.1
+  resolution: "express@npm:4.21.1"
   dependencies:
     accepts: "npm:~1.3.8"
     array-flatten: "npm:1.1.1"
     body-parser: "npm:1.20.3"
     content-disposition: "npm:0.5.4"
     content-type: "npm:~1.0.4"
-    cookie: "npm:0.6.0"
+    cookie: "npm:0.7.1"
     cookie-signature: "npm:1.0.6"
     debug: "npm:2.6.9"
     depd: "npm:2.0.0"
@@ -22606,7 +22613,7 @@ __metadata:
     type-is: "npm:~1.6.18"
     utils-merge: "npm:1.0.1"
     vary: "npm:~1.1.2"
-  checksum: 10/3b1ee5bc5b1bd996f688702519cebc9b63a24e506965f6e1773268238cfa2c24ffdb38cc3fcb4fde66f77de1c0bebd9ee058dad06bb9c6f084b525f3c09164d3
+  checksum: 10/5d4a36dd03c1d1cce93172e9b185b5cd13a978d29ee03adc51cd278be7b4a514ae2b63e2fdaec0c00fdc95c6cfb396d9dd1da147917ffd337d6cd0778e08c9bc
   languageName: node
   linkType: hard
 
@@ -25321,23 +25328,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"https-proxy-agent@npm:^7.0.0":
+"https-proxy-agent@npm:^7.0.0, https-proxy-agent@npm:^7.0.2":
   version: 7.0.5
   resolution: "https-proxy-agent@npm:7.0.5"
   dependencies:
     agent-base: "npm:^7.0.2"
     debug: "npm:4"
   checksum: 10/6679d46159ab3f9a5509ee80c3a3fc83fba3a920a5e18d32176c3327852c3c00ad640c0c4210a8fd70ea3c4a6d3a1b375bf01942516e7df80e2646bdc77658ab
-  languageName: node
-  linkType: hard
-
-"https-proxy-agent@npm:^7.0.2":
-  version: 7.0.4
-  resolution: "https-proxy-agent@npm:7.0.4"
-  dependencies:
-    agent-base: "npm:^7.0.2"
-    debug: "npm:4"
-  checksum: 10/405fe582bba461bfe5c7e2f8d752b384036854488b828ae6df6a587c654299cbb2c50df38c4b6ab303502c3c5e029a793fbaac965d1e86ee0be03faceb554d63
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11031,7 +11031,7 @@ __metadata:
     socks-proxy-agent: "npm:8.0.4"
     tiny-worker: "npm:^2.3.0"
     tsx: "npm:^4.16.3"
-    webpack: "npm:^5.94.0"
+    webpack: "npm:^5.96.1"
     webpack-cli: "npm:^5.1.4"
     webpack-dev-server: "npm:^5.0.4"
     worker-loader: "npm:^3.0.8"
@@ -11222,7 +11222,7 @@ __metadata:
     styled-components: "npm:^6.1.8"
     swr: "npm:^2.2.5"
     tsx: "npm:^4.16.3"
-    webpack: "npm:^5.94.0"
+    webpack: "npm:^5.96.1"
     webpack-cli: "npm:^5.1.4"
   languageName: unknown
   linkType: soft
@@ -11242,7 +11242,7 @@ __metadata:
     html-webpack-plugin: "npm:^5.6.0"
     rimraf: "npm:^6.0.1"
     terser-webpack-plugin: "npm:^5.3.9"
-    webpack: "npm:^5.94.0"
+    webpack: "npm:^5.96.1"
     webpack-cli: "npm:^5.1.4"
     webpack-merge: "npm:^6.0.1"
     worker-loader: "npm:^3.0.8"
@@ -11317,7 +11317,7 @@ __metadata:
     react-dom: "npm:18.2.0"
     rimraf: "npm:^6.0.1"
     terser-webpack-plugin: "npm:^5.3.9"
-    webpack: "npm:^5.94.0"
+    webpack: "npm:^5.96.1"
     webpack-cli: "npm:^5.1.4"
     webpack-dev-server: "npm:^5.0.4"
     webpack-merge: "npm:^6.0.1"
@@ -11379,7 +11379,7 @@ __metadata:
     selfsigned: "npm:^2.4.1"
     terser-webpack-plugin: "npm:^5.3.9"
     tsx: "npm:^4.16.3"
-    webpack: "npm:^5.94.0"
+    webpack: "npm:^5.96.1"
     webpack-cli: "npm:^5.1.4"
     webpack-merge: "npm:^6.0.1"
     webpack-plugin-serve: "npm:^1.6.0"
@@ -11407,7 +11407,7 @@ __metadata:
     events: "npm:^3.3.0"
     rimraf: "npm:^6.0.1"
     terser-webpack-plugin: "npm:^5.3.9"
-    webpack: "npm:^5.94.0"
+    webpack: "npm:^5.96.1"
     webpack-cli: "npm:^5.1.4"
     webpack-merge: "npm:^6.0.1"
     webpack-plugin-serve: "npm:^1.6.0"
@@ -11454,7 +11454,7 @@ __metadata:
     node-libs-browser: "npm:^2.2.1"
     ts-node: "npm:^10.9.1"
     tsx: "npm:^4.16.3"
-    webpack: "npm:^5.94.0"
+    webpack: "npm:^5.96.1"
     ws: "npm:^8.18.0"
   peerDependencies:
     tslib: ^2.6.2
@@ -11706,7 +11706,7 @@ __metadata:
     stream-browserify: "npm:^3.0.0"
     style-loader: "npm:^3.3.4"
     terser-webpack-plugin: "npm:^5.3.9"
-    webpack: "npm:^5.94.0"
+    webpack: "npm:^5.96.1"
     webpack-bundle-analyzer: "npm:^4.10.1"
     webpack-merge: "npm:^6.0.1"
     webpack-nano: "npm:^1.1.1"
@@ -11739,7 +11739,7 @@ __metadata:
     simple-git: "npm:^3.26.0"
     style-loader: "npm:^3.3.4"
     tsx: "npm:^4.16.3"
-    webpack: "npm:^5.94.0"
+    webpack: "npm:^5.96.1"
     webpack-cli: "npm:^5.1.4"
   languageName: unknown
   linkType: soft
@@ -11794,7 +11794,7 @@ __metadata:
     openpgp: "npm:^5.11.2"
     systeminformation: "npm:^5.23.5"
     terser-webpack-plugin: "npm:^5.3.9"
-    webpack: "npm:^5.94.0"
+    webpack: "npm:^5.96.1"
     xvfb-maybe: "npm:^0.2.1"
   languageName: unknown
   linkType: soft
@@ -11897,7 +11897,7 @@ __metadata:
     stylelint: "npm:^16.2.1"
     stylelint-config-standard: "npm:^36.0.0"
     tsx: "npm:^4.16.3"
-    webpack: "npm:^5.94.0"
+    webpack: "npm:^5.96.1"
     worker-loader: "npm:^3.0.8"
     ws: "npm:^8.18.0"
     yargs: "npm:17.7.2"
@@ -12067,7 +12067,7 @@ __metadata:
     react-intl: "npm:^6.6.8"
     styled-components: "npm:^6.1.8"
     usb: "npm:^2.14.0"
-    webpack: "npm:^5.94.0"
+    webpack: "npm:^5.96.1"
   languageName: unknown
   linkType: soft
 
@@ -12203,7 +12203,7 @@ __metadata:
     "@trezor/connect-webextension": "workspace:^"
     copy-webpack-plugin: "npm:^12.0.2"
     html-webpack-plugin: "npm:^5.6.0"
-    webpack: "npm:^5.94.0"
+    webpack: "npm:^5.96.1"
   languageName: unknown
   linkType: soft
 
@@ -12664,6 +12664,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/eslint-scope@npm:^3.7.7":
+  version: 3.7.7
+  resolution: "@types/eslint-scope@npm:3.7.7"
+  dependencies:
+    "@types/eslint": "npm:*"
+    "@types/estree": "npm:*"
+  checksum: 10/e2889a124aaab0b89af1bab5959847c5bec09809209255de0e63b9f54c629a94781daa04adb66bffcdd742f5e25a17614fb933965093c0eea64aacda4309380e
+  languageName: node
+  linkType: hard
+
+"@types/eslint@npm:*":
+  version: 9.6.1
+  resolution: "@types/eslint@npm:9.6.1"
+  dependencies:
+    "@types/estree": "npm:*"
+    "@types/json-schema": "npm:*"
+  checksum: 10/719fcd255760168a43d0e306ef87548e1e15bffe361d5f4022b0f266575637acc0ecb85604ac97879ee8ae83c6a6d0613b0ed31d0209ddf22a0fe6d608fc56fe
+  languageName: node
+  linkType: hard
+
 "@types/estree-jsx@npm:^1.0.0":
   version: 1.0.5
   resolution: "@types/estree-jsx@npm:1.0.5"
@@ -12673,7 +12693,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:*, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.5":
+"@types/estree@npm:*, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.6":
   version: 1.0.6
   resolution: "@types/estree@npm:1.0.6"
   checksum: 10/9d35d475095199c23e05b431bcdd1f6fec7380612aed068b14b2a08aa70494de8a9026765a5a91b1073f636fb0368f6d8973f518a31391d519e20c59388ed88d
@@ -12974,7 +12994,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:^7.0.11, @types/json-schema@npm:^7.0.12, @types/json-schema@npm:^7.0.6, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
+"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.11, @types/json-schema@npm:^7.0.12, @types/json-schema@npm:^7.0.6, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
   checksum: 10/1a3c3e06236e4c4aab89499c428d585527ce50c24fe8259e8b3926d3df4cfbbbcf306cfc73ddfb66cbafc973116efd15967020b0f738f63e09e64c7d260519e7
@@ -14478,15 +14498,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-import-attributes@npm:^1.9.5":
-  version: 1.9.5
-  resolution: "acorn-import-attributes@npm:1.9.5"
-  peerDependencies:
-    acorn: ^8
-  checksum: 10/8bfbfbb6e2467b9b47abb4d095df717ab64fce2525da65eabee073e85e7975fb3a176b6c8bba17c99a7d8ede283a10a590272304eb54a93c4aa1af9790d47a8b
-  languageName: node
-  linkType: hard
-
 "acorn-jsx@npm:^5.0.0, acorn-jsx@npm:^5.3.1, acorn-jsx@npm:^5.3.2":
   version: 5.3.2
   resolution: "acorn-jsx@npm:5.3.2"
@@ -14530,12 +14541,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.0.0, acorn@npm:^8.0.4, acorn@npm:^8.1.0, acorn@npm:^8.10.0, acorn@npm:^8.11.3, acorn@npm:^8.4.1, acorn@npm:^8.7.1, acorn@npm:^8.8.1, acorn@npm:^8.8.2, acorn@npm:^8.9.0":
-  version: 8.12.1
-  resolution: "acorn@npm:8.12.1"
+"acorn@npm:^8.0.0, acorn@npm:^8.0.4, acorn@npm:^8.1.0, acorn@npm:^8.10.0, acorn@npm:^8.11.3, acorn@npm:^8.14.0, acorn@npm:^8.4.1, acorn@npm:^8.8.1, acorn@npm:^8.8.2, acorn@npm:^8.9.0":
+  version: 8.14.0
+  resolution: "acorn@npm:8.14.0"
   bin:
     acorn: bin/acorn
-  checksum: 10/d08c2d122bba32d0861e0aa840b2ee25946c286d5dc5990abca991baf8cdbfbe199b05aacb221b979411a2fea36f83e26b5ac4f6b4e0ce49038c62316c1848f0
+  checksum: 10/6df29c35556782ca9e632db461a7f97947772c6c1d5438a81f0c873a3da3a792487e83e404d1c6c25f70513e91aa18745f6eafb1fcc3a43ecd1920b21dd173d2
   languageName: node
   linkType: hard
 
@@ -16321,17 +16332,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.0.0, browserslist@npm:^4.19.1, browserslist@npm:^4.21.10, browserslist@npm:^4.22.2, browserslist@npm:^4.23.1":
-  version: 4.23.3
-  resolution: "browserslist@npm:4.23.3"
+"browserslist@npm:^4.0.0, browserslist@npm:^4.19.1, browserslist@npm:^4.22.2, browserslist@npm:^4.23.1, browserslist@npm:^4.24.0":
+  version: 4.24.2
+  resolution: "browserslist@npm:4.24.2"
   dependencies:
-    caniuse-lite: "npm:^1.0.30001646"
-    electron-to-chromium: "npm:^1.5.4"
+    caniuse-lite: "npm:^1.0.30001669"
+    electron-to-chromium: "npm:^1.5.41"
     node-releases: "npm:^2.0.18"
-    update-browserslist-db: "npm:^1.1.0"
+    update-browserslist-db: "npm:^1.1.1"
   bin:
     browserslist: cli.js
-  checksum: 10/e266d18c6c6c5becf9a1a7aa264477677b9796387972e8fce34854bb33dc1666194dc28389780e5dc6566e68a95e87ece2ce222e1c4ca93c2b75b61dfebd5f1c
+  checksum: 10/f8a9d78bbabe466c57ffd5c50a9e5582a5df9aa68f43078ca62a9f6d0d6c70ba72eca72d0a574dbf177cf55cdca85a46f7eb474917a47ae5398c66f8b76f7d1c
   languageName: node
   linkType: hard
 
@@ -16907,10 +16918,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001578, caniuse-lite@npm:^1.0.30001579, caniuse-lite@npm:^1.0.30001646":
-  version: 1.0.30001657
-  resolution: "caniuse-lite@npm:1.0.30001657"
-  checksum: 10/5eb2f4e6dd114056d2c8563f70d9de9b0e7442622a2243ce902fbc00bce5b9951c8e8edd8bcb15a9d5dec1b849536d616f23611f18650e51d6c4912c09d3f179
+"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001578, caniuse-lite@npm:^1.0.30001579, caniuse-lite@npm:^1.0.30001669":
+  version: 1.0.30001677
+  resolution: "caniuse-lite@npm:1.0.30001677"
+  checksum: 10/e07439bdeade5ffdd974691f44f8549ae0730fcf510acaa32d0b657c10370cd5aad09eeca37248966205fb37fce5f464dbce73ce177b4a1fdc3a34adbcfd7192
   languageName: node
   linkType: hard
 
@@ -17921,7 +17932,7 @@ __metadata:
     html-webpack-plugin: "npm:^5.6.0"
     terser-webpack-plugin: "npm:^5.3.9"
     wait-on: "npm:^7.0.1"
-    webpack: "npm:^5.94.0"
+    webpack: "npm:^5.96.1"
     webpack-cli: "npm:^5.1.4"
     webpack-dev-server: "npm:^5.0.4"
     worker-loader: "npm:^3.0.8"
@@ -20424,10 +20435,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:^1.5.4":
-  version: 1.5.14
-  resolution: "electron-to-chromium@npm:1.5.14"
-  checksum: 10/eb5e0304ae952bf258caeb5eec77cbd8e493f54312c228f68cae1e4f11a8b26aaa8fb11222aa9bcbd701970c4c3634275c44b714eafdea144defee135cd7956b
+"electron-to-chromium@npm:^1.5.41":
+  version: 1.5.52
+  resolution: "electron-to-chromium@npm:1.5.52"
+  checksum: 10/464ea25529a901fcfcf69c5cf5d39d31607a4ea34d98012c18e22b32154280c90f830b8ac6acbad047b13f2966852ef7d5b78f49396548401757d9a9b025f028
   languageName: node
   linkType: hard
 
@@ -21297,7 +21308,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escalade@npm:^3.1.0, escalade@npm:^3.1.1, escalade@npm:^3.1.2":
+"escalade@npm:^3.1.0, escalade@npm:^3.1.1, escalade@npm:^3.2.0":
   version: 3.2.0
   resolution: "escalade@npm:3.2.0"
   checksum: 10/9d7169e3965b2f9ae46971afa392f6e5a25545ea30f2e2dd99c9b0a95a3f52b5653681a84f5b2911a413ddad2d7a93d3514165072f349b5ffc59c75a899970d6
@@ -33477,10 +33488,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picocolors@npm:^1.0.0, picocolors@npm:^1.0.1":
-  version: 1.1.0
-  resolution: "picocolors@npm:1.1.0"
-  checksum: 10/a2ad60d94d185c30f2a140b19c512547713fb89b920d32cc6cf658fa786d63a37ba7b8451872c3d9fc34883971fb6e5878e07a20b60506e0bb2554dce9169ccb
+"picocolors@npm:^1.0.0, picocolors@npm:^1.0.1, picocolors@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "picocolors@npm:1.1.1"
+  checksum: 10/e1cf46bf84886c79055fdfa9dcb3e4711ad259949e3565154b004b260cd356c5d54b31a1437ce9782624bf766272fe6b0154f5f0c744fb7af5d454d2b60db045
   languageName: node
   linkType: hard
 
@@ -41074,17 +41085,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"update-browserslist-db@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "update-browserslist-db@npm:1.1.0"
+"update-browserslist-db@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "update-browserslist-db@npm:1.1.1"
   dependencies:
-    escalade: "npm:^3.1.2"
-    picocolors: "npm:^1.0.1"
+    escalade: "npm:^3.2.0"
+    picocolors: "npm:^1.1.0"
   peerDependencies:
     browserslist: ">= 4.21.0"
   bin:
     update-browserslist-db: cli.js
-  checksum: 10/d70b9efeaf4601aadb1a4f6456a7a5d9118e0063d995866b8e0c5e0cf559482671dab6ce7b079f9536b06758a344fbd83f974b965211e1c6e8d1958540b0c24c
+  checksum: 10/7678dd8609750588d01aa7460e8eddf2ff9d16c2a52fb1811190e0d056390f1fdffd94db3cf8fb209cf634ab4fa9407886338711c71cc6ccade5eeb22b093734
   languageName: node
   linkType: hard
 
@@ -42497,17 +42508,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack@npm:5, webpack@npm:^5, webpack@npm:^5.94.0":
-  version: 5.94.0
-  resolution: "webpack@npm:5.94.0"
+"webpack@npm:5, webpack@npm:^5, webpack@npm:^5.96.1":
+  version: 5.96.1
+  resolution: "webpack@npm:5.96.1"
   dependencies:
-    "@types/estree": "npm:^1.0.5"
+    "@types/eslint-scope": "npm:^3.7.7"
+    "@types/estree": "npm:^1.0.6"
     "@webassemblyjs/ast": "npm:^1.12.1"
     "@webassemblyjs/wasm-edit": "npm:^1.12.1"
     "@webassemblyjs/wasm-parser": "npm:^1.12.1"
-    acorn: "npm:^8.7.1"
-    acorn-import-attributes: "npm:^1.9.5"
-    browserslist: "npm:^4.21.10"
+    acorn: "npm:^8.14.0"
+    browserslist: "npm:^4.24.0"
     chrome-trace-event: "npm:^1.0.2"
     enhanced-resolve: "npm:^5.17.1"
     es-module-lexer: "npm:^1.2.1"
@@ -42529,7 +42540,7 @@ __metadata:
       optional: true
   bin:
     webpack: bin/webpack.js
-  checksum: 10/648449c5fbbb0839814116e3b2b044ac6c75a7ba272435155ddeb1e64dfaa2f8079be3adfbb691f648b69900756ce0f6fb73beab0ced3cf5e0fd46868b4593a6
+  checksum: 10/d3419ffd198252e1d0301bd0c072cee93172f3e47937c745aa8202691d2f5d529d4ba4a1965d1450ad89a1bcd3c1f70ae09e57232b0d01dd38d69c1060e964d5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Update most Mission-related dependencies:
**major:**
- `electron`
  - updated webpack compilation target to [Chromium 130](https://www.electronjs.org/blog/electron-33-0#stack-changes) 
    - it wasn't supported by our browserlist, so I bumped `webpack` also 
- `uuid`
  - rewritten to TS, so we are dropping `@types/uuid`, see :information_source: note in [README](https://github.com/uuidjs/uuid?tab=readme-ov-file#uuid--)
- `openpgp`

**minor:**
- `electron-builder`
- `webpack`

**patch:**
- `electron-updater`
- `react-hook-form`
- `@hookform/resolvers`
- `express`

**not updated:**
-  `tiny-secp256k1` TODO in [#12261](https://github.com/trezor/trezor-suite/pull/12261) 
- `electron-store` requires refactoring our electron main process to ES = out of scope but planned

:information_source: For reference, last bump mission deps PR was #14684

## QA

:eye: Besides CI checks, I have tested locally:
- local suite web
- local suite desktop
  - tested Tor because `utilityProcess` was touched
  - superifical testing of google auth server: responds to GET `localhost:3005/status`
  - app update 
  - `react-hook-form` & `@hookform/resolvers` tested in `SignVerify` page 
- linux build