### PR TITLE
fix(connect): skip fw hash check when binary too tiny (DX)

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -773,8 +773,14 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
         const btcOnly = this.firmwareType === FirmwareType.BitcoinOnly;
         const binary = await getBinaryOptional({ baseUrl, btcOnly, release });
+        // release was found, but not its binary - happens on desktop, where only local files are searched
         if (binary === null) {
-            // release was found, but not its binary - happens on desktop, where only local files are searched
+            return createFailResult('check-unsupported');
+        }
+        // binary was found, but it's likely a git LFS pointer (can happen on dev) - see onCallFirmwareUpdate.ts
+        if (binary.byteLength < 200) {
+            _log.warn(`Firmware binary for hash check suspiciously small (< 200 b)`);
+
             return createFailResult('check-unsupported');
         }
 


### PR DESCRIPTION
## Description

When FW binary is only a git LFS pointer (which is the case on all web dev deployments), FW hash is mismatched so you get Ghost modal even with legit physical Trezor - [example](https://dev.suite.sldev.cz/suite-web/chore/bump-mission-deps/web/).

:arrow_right: ignore the FW hash check for too small binary files

:eyes: You can verify [on this dev deployment](https://dev.suite.sldev.cz/suite-web/fix/fw-hash-check-with-lfs-pointer/web/)

:information_source: This is DX only thing, won't happen in production