### PR TITLE
fix(trade): transaction fees

### DIFF
--- a/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketComposeTransaction.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketComposeTransaction.ts
@@ -122,10 +122,7 @@ export const useCoinmarketComposeTransaction = <T extends CoinmarketSellExchange
             });
         }
 
-        if (
-            composed.type === 'final' ||
-            (composed.type === 'nonfinal' && account.symbol === 'ada')
-        ) {
+        if (composed.type === 'final' || composed.type === 'nonfinal') {
             if (typeof setMaxOutputId === 'number' && composed.max) {
                 setValue(FORM_OUTPUT_AMOUNT, composed.max, {
                     shouldValidate: true,

--- a/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketCurrencySwitcher.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketCurrencySwitcher.ts
@@ -8,6 +8,7 @@ import {
     FORM_FIAT_INPUT,
     FORM_OUTPUT_AMOUNT,
     FORM_OUTPUT_FIAT,
+    FORM_SEND_CRYPTO_CURRENCY_SELECT,
 } from 'src/constants/wallet/coinmarket/form';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 import {
@@ -17,7 +18,7 @@ import {
 import { SendContextValues } from 'src/types/wallet/sendForm';
 import {
     coinmarketGetRoundedFiatAmount,
-    getNetworkDecimals,
+    getCoinmarketNetworkDecimals,
 } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 
 interface CoinmarketUseCurrencySwitcherProps<T extends CoinmarketAllFormProps> {
@@ -48,8 +49,12 @@ export const useCoinmarketCurrencySwitcher = <T extends CoinmarketAllFormProps>(
     const { setValue, getValues, control } =
         methods as unknown as UseFormReturn<CoinmarketAllFormProps>;
     const { shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
-    const networkDecimals = getNetworkDecimals(network?.decimals);
     const cryptoInputValue = useWatch({ control, name: inputNames.cryptoInput });
+    const sendCryptoSelect = getValues(FORM_SEND_CRYPTO_CURRENCY_SELECT);
+    const networkDecimals = getCoinmarketNetworkDecimals({
+        sendCryptoSelect,
+        network,
+    });
 
     const toggleAmountInCrypto = () => {
         const { amountInCrypto } = getValues();

--- a/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketFormActions.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketFormActions.ts
@@ -4,7 +4,6 @@ import {
     amountToSmallestUnit,
     formatAmount,
     fromFiatCurrency,
-    isEthereumAccountSymbol,
     isZero,
 } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
@@ -37,7 +36,7 @@ import {
 import {
     coinmarketGetSortedAccounts,
     cryptoIdToNetworkSymbol,
-    getNetworkDecimals,
+    getCoinmarketNetworkDecimals,
 } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import { coinmarketGetExchangeReceiveCryptoId } from 'src/utils/wallet/coinmarket/exchangeUtils';
 
@@ -82,12 +81,12 @@ export const useCoinmarketFormActions = <T extends CoinmarketSellExchangeFormPro
         ? isZero(tokenData.balance || '0')
         : isZero(account.formattedBalance);
     const coinmarketFiatValues = useCoinmarketFiatValues({
-        accountBalance: account.formattedBalance,
-        cryptoSymbol: sendCryptoSelect?.value,
-        tokenAddress,
+        sendCryptoSelect,
         fiatCurrency: getValues().outputs?.[0]?.currency?.value as FiatCurrencyCode,
     });
-    const networkDecimals = getNetworkDecimals(coinmarketFiatValues?.networkDecimals);
+    const networkDecimals = getCoinmarketNetworkDecimals({
+        sendCryptoSelect,
+    });
 
     // on manual change of crypto amount, set fiat amount
     const onFiatCurrencyChange = async (value: FiatCurrencyCode) => {
@@ -199,12 +198,11 @@ export const useCoinmarketFormActions = <T extends CoinmarketSellExchangeFormPro
         setValue(FORM_OUTPUT_AMOUNT, '');
         setValue(FORM_CRYPTO_TOKEN, selected?.contractAddress ?? null);
 
-        if (networkSymbol && isEthereumAccountSymbol(networkSymbol)) {
+        if (account.networkType === 'ethereum') {
             // set token address for ERC20 transaction to estimate the fees more precisely
             setValue(FORM_OUTPUT_ADDRESS, selected?.contractAddress ?? '');
         }
-
-        if (networkSymbol === 'sol') {
+        if (account.networkType === 'solana' && !selected?.contractAddress) {
             setValue(FORM_OUTPUT_ADDRESS, selected?.descriptor ?? '');
         }
 

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketBuyForm.tsx
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketBuyForm.tsx
@@ -19,6 +19,7 @@ import {
     coinmarketGetSuccessQuotes,
     cryptoIdToNetwork,
     filterQuotesAccordingTags,
+    getCoinmarketNetworkDecimals,
 } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import {
     CoinmarketBuyFormContextProps,
@@ -178,10 +179,9 @@ export const useCoinmarketBuyForm = ({
             countrySelect,
             amountInCrypto,
         } = methods.getValues();
+        const decimals = getCoinmarketNetworkDecimals({ network });
         const cryptoStringAmount =
-            cryptoInput && shouldSendInSats
-                ? formatAmount(cryptoInput, network.decimals)
-                : cryptoInput;
+            cryptoInput && shouldSendInSats ? formatAmount(cryptoInput, decimals) : cryptoInput;
 
         const request = {
             wantCrypto: amountInCrypto,
@@ -195,7 +195,7 @@ export const useCoinmarketBuyForm = ({
         };
 
         return request;
-    }, [methods, network.decimals, shouldSendInSats, quotesRequest]);
+    }, [methods, network, shouldSendInSats, quotesRequest]);
 
     const handleChange = useCallback(
         async (offLoading?: boolean) => {

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSellForm.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSellForm.ts
@@ -10,6 +10,7 @@ import {
     addIdsToQuotes,
     coinmarketGetSuccessQuotes,
     filterQuotesAccordingTags,
+    getCoinmarketNetworkDecimals,
     getUnusedAddressFromAccount,
 } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import { createQuoteLink, getAmountLimits } from 'src/utils/wallet/coinmarket/sellUtils';
@@ -18,7 +19,11 @@ import { useCoinmarketNavigation } from 'src/hooks/wallet/useCoinmarketNavigatio
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 import { AmountLimits, TradeSell } from 'src/types/wallet/coinmarketCommonTypes';
 import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
-import { CoinmarketTradeSellType, UseCoinmarketFormProps } from 'src/types/coinmarket/coinmarket';
+import {
+    CoinmarketAccountOptionsGroupOptionProps,
+    CoinmarketTradeSellType,
+    UseCoinmarketFormProps,
+} from 'src/types/coinmarket/coinmarket';
 import {
     CoinmarketSellFormContextProps,
     CoinmarketSellFormProps,
@@ -152,6 +157,12 @@ export const useCoinmarketSellForm = ({
         innerQuotes,
         values?.paymentMethod?.value ?? '',
     );
+    const decimals = getCoinmarketNetworkDecimals({
+        sendCryptoSelect: values.sendCryptoSelect as
+            | CoinmarketAccountOptionsGroupOptionProps
+            | undefined,
+        network,
+    });
 
     const {
         isComposing,
@@ -198,7 +209,7 @@ export const useCoinmarketSellForm = ({
         const unformattedOutputAmount = outputs[0].amount ?? '';
         const cryptoStringAmount =
             unformattedOutputAmount && shouldSendInSats
-                ? formatAmount(unformattedOutputAmount, network.decimals)
+                ? formatAmount(unformattedOutputAmount, decimals)
                 : unformattedOutputAmount;
         const currencySelect = outputs[0].currency ?? '';
         const request: SellFiatTradeQuoteRequest = {
@@ -219,7 +230,7 @@ export const useCoinmarketSellForm = ({
         }
 
         return request;
-    }, [methods, network.decimals, shouldSendInSats]);
+    }, [methods, decimals, shouldSendInSats]);
 
     const handleChange = useCallback(
         async (offLoading?: boolean) => {
@@ -470,7 +481,7 @@ export const useCoinmarketSellForm = ({
             selectedQuote.cryptoStringAmount
         ) {
             const cryptoStringAmount = shouldSendInSats
-                ? amountToSmallestUnit(selectedQuote.cryptoStringAmount, network.decimals)
+                ? amountToSmallestUnit(selectedQuote.cryptoStringAmount, decimals)
                 : selectedQuote.cryptoStringAmount;
             const destinationPaymentExtraId =
                 selectedQuote.destinationPaymentExtraId || trade?.data?.destinationPaymentExtraId;

--- a/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
@@ -202,9 +202,10 @@ export const getComposeAddressPlaceholder = async (
             // which need more fees than Shelley addresses used in the Suite, using dummy Byron address for the placeholder
             // return '37btjrVyb4KDXBNC4haBVPCrro8AQPHwvCMp3RFhhSVWwfFmZ6wwzSK6JK1hY6wHNmtrpTf1kdbva8TCneM2YsiXT7mrzT21EacHnPpz5YyUdj64na';
             return '';
+        case 'solana':
+            return '';
         case 'ethereum':
         case 'ripple':
-        case 'solana':
             return account.descriptor;
         // no default
     }

--- a/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
@@ -75,8 +75,20 @@ export const getNetworkName = (networkSymbol: NetworkSymbol) => {
     return networks[networkSymbol].name;
 };
 
-export const getNetworkDecimals = (networkDecimals: number | undefined) => {
-    return networkDecimals ?? 8;
+interface CoinmarketGetDecimalsProps {
+    sendCryptoSelect?: CoinmarketAccountOptionsGroupOptionProps;
+    network?: Network | null;
+}
+
+export const getCoinmarketNetworkDecimals = ({
+    sendCryptoSelect,
+    network,
+}: CoinmarketGetDecimalsProps) => {
+    if (sendCryptoSelect) {
+        return sendCryptoSelect.decimals;
+    }
+
+    return network?.decimals ?? 8;
 };
 
 /** @deprecated */

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketAddressOptions.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketAddressOptions.tsx
@@ -13,10 +13,13 @@ import { useSelector } from 'src/hooks/suite';
 import { CoinmarketBalance } from 'src/views/wallet/coinmarket/common/CoinmarketBalance';
 import { spacingsPx, typography } from '@trezor/theme';
 import { formatAmount } from '@suite-common/wallet-utils';
-import { getNetworkDecimals } from 'src/utils/wallet/coinmarket/coinmarketUtils';
+import { getCoinmarketNetworkDecimals } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import { networks } from '@suite-common/wallet-config';
 import { useCoinmarketInfo } from 'src/hooks/wallet/coinmarket/useCoinmarketInfo';
 import { CryptoId } from 'invity-api';
+import { isCoinmarketExchangeContext } from 'src/utils/wallet/coinmarket/coinmarketTypingUtils';
+import { useCoinmarketFormContext } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonForm';
+import { FORM_SEND_CRYPTO_CURRENCY_SELECT } from 'src/constants/wallet/coinmarket/form';
 
 const AddressWrapper = styled.div`
     display: flex;
@@ -84,6 +87,7 @@ export const CoinmarketAddressOptions = <TFieldValues extends CoinmarketBuyAddre
     // Type assertion allowing to make the component reusable, see https://stackoverflow.com/a/73624072.
     const { control, setValue } =
         props as unknown as UseFormReturn<CoinmarketBuyAddressOptionsType>;
+    const context = useCoinmarketFormContext();
 
     const addresses = account?.addresses;
     const addressDictionary = useAccountAddressDictionary(account);
@@ -114,9 +118,14 @@ export const CoinmarketAddressOptions = <TFieldValues extends CoinmarketBuyAddre
                     formatOptionLabel={(accountAddress: AccountAddress) => {
                         if (!accountAddress || !account || !receiveSymbol) return null;
 
-                        const networkDecimals = getNetworkDecimals(
-                            networks[account.symbol].decimals,
-                        );
+                        const sendCryptoSelect = isCoinmarketExchangeContext(context)
+                            ? context.getValues(FORM_SEND_CRYPTO_CURRENCY_SELECT)
+                            : undefined;
+
+                        const networkDecimals = getCoinmarketNetworkDecimals({
+                            sendCryptoSelect,
+                            network: networks[account.symbol],
+                        });
                         const balance = accountAddress.balance
                             ? formatAmount(accountAddress.balance, networkDecimals)
                             : accountAddress.balance;
@@ -133,6 +142,7 @@ export const CoinmarketAddressOptions = <TFieldValues extends CoinmarketBuyAddre
                                             balance={balance}
                                             cryptoSymbolLabel={cryptoIdToCoinSymbol(receiveSymbol)}
                                             networkSymbol={account.symbol}
+                                            sendCryptoSelect={sendCryptoSelect}
                                         />
                                         <span>•</span>
                                         <span>{accountAddress.path}</span>

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketBalance.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketBalance.tsx
@@ -5,9 +5,10 @@ import { typography } from '@trezor/theme';
 import { FiatValue, HiddenPlaceholder, Translation } from 'src/components/suite';
 import { useFiatFromCryptoValue } from 'src/hooks/suite/useFiatFromCryptoValue';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
+import { CoinmarketAccountOptionsGroupOptionProps } from 'src/types/coinmarket/coinmarket';
 import {
     coinmarketGetAccountLabel,
-    getNetworkDecimals,
+    getCoinmarketNetworkDecimals,
 } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import styled from 'styled-components';
 
@@ -23,6 +24,7 @@ interface CoinmarketBalanceProps {
     tokenAddress?: TokenAddress | undefined;
     showOnlyAmount?: boolean;
     amountInCrypto?: boolean;
+    sendCryptoSelect?: CoinmarketAccountOptionsGroupOptionProps;
 }
 
 export const CoinmarketBalance = ({
@@ -32,10 +34,14 @@ export const CoinmarketBalance = ({
     tokenAddress,
     showOnlyAmount,
     amountInCrypto,
+    sendCryptoSelect,
 }: CoinmarketBalanceProps) => {
     const { shouldSendInSats } = useBitcoinAmountUnit(networkSymbol);
     const balanceCurrency = coinmarketGetAccountLabel(cryptoSymbolLabel ?? '', shouldSendInSats);
-    const networkDecimals = getNetworkDecimals(networks[networkSymbol].decimals);
+    const networkDecimals = getCoinmarketNetworkDecimals({
+        sendCryptoSelect,
+        network: networks[networkSymbol],
+    });
     const stringBalance = !isNaN(Number(balance)) ? balance : '0';
     const formattedBalance =
         stringBalance && shouldSendInSats
@@ -48,7 +54,7 @@ export const CoinmarketBalance = ({
     });
 
     if (showOnlyAmount) {
-        if (!balance ?? isNaN(Number(balance))) return null;
+        if (typeof balance === 'undefined' || isNaN(Number(balance))) return null;
 
         return (
             <CoinmarketBalanceWrapper>

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputAccount.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputAccount.tsx
@@ -47,9 +47,7 @@ export const CoinmarketFormInputAccount = <
         | CoinmarketAccountOptionsGroupOptionProps
         | undefined;
     const fiatValues = useCoinmarketFiatValues({
-        accountBalance: selectedOption?.balance,
-        cryptoSymbol: selectedOption?.value,
-        tokenAddress: selectedOption?.contractAddress,
+        sendCryptoSelect: selectedOption,
         fiatCurrency: getValues().outputs?.[0]?.currency?.value as FiatCurrencyCode,
     });
 
@@ -89,6 +87,7 @@ export const CoinmarketFormInputAccount = <
                             <CoinmarketFormInputAccountOption
                                 option={option}
                                 optionGroups={optionGroups}
+                                decimals={option.decimals}
                                 isSelected={context === 'value'}
                             />
                         )}
@@ -105,6 +104,7 @@ export const CoinmarketFormInputAccount = <
                         networkSymbol={fiatValues.networkSymbol}
                         tokenAddress={fiatValues.tokenAddress}
                         cryptoSymbolLabel={selectedOption?.label}
+                        sendCryptoSelect={selectedOption}
                     />
                 </CoinmarketBalanceWrapper>
             )}

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputAccountOption.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputAccountOption.tsx
@@ -22,12 +22,14 @@ import {
 interface CoinmarketFormInputAccountOptionProps {
     option: CoinmarketAccountOptionsGroupOptionProps;
     optionGroups: CoinmarketAccountsOptionsGroupProps[];
+    decimals: number;
     isSelected: boolean;
 }
 
 export const CoinmarketFormInputAccountOption = ({
     option,
     optionGroups,
+    decimals,
     isSelected,
 }: CoinmarketFormInputAccountOptionProps) => {
     const { contractAddress } = parseCryptoId(option.value);
@@ -40,7 +42,7 @@ export const CoinmarketFormInputAccountOption = ({
 
     const balanceLabel = coinmarketGetAccountLabel(option.label, shouldSendInSats);
     const balance = shouldSendInSats
-        ? amountToSmallestUnit(option.balance, network.decimals)
+        ? amountToSmallestUnit(option.balance, decimals)
         : option.balance;
     const accountType = optionGroups.find(group =>
         group.options.find(

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputFiatCrypto/CoinmarketFormInputCryptoAmount.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputFiatCrypto/CoinmarketFormInputCryptoAmount.tsx
@@ -20,7 +20,10 @@ import {
 } from 'src/types/coinmarket/coinmarketForm';
 import { CoinmarketFormOptionLabel } from 'src/views/wallet/coinmarket';
 import { FieldErrors } from 'react-hook-form';
-import { coinmarketGetAccountLabel } from 'src/utils/wallet/coinmarket/coinmarketUtils';
+import {
+    coinmarketGetAccountLabel,
+    getCoinmarketNetworkDecimals,
+} from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import { useDidUpdate } from '@trezor/react-utils';
 import { FORM_OUTPUT_AMOUNT, FORM_OUTPUT_MAX } from 'src/constants/wallet/coinmarket/form';
 import {
@@ -63,12 +66,16 @@ export const CoinmarketFormInputCryptoAmount = <TFieldValues extends CoinmarketA
             ? (errors as FieldErrors<CoinmarketSellExchangeFormProps>)?.outputs?.[0]?.amount
             : (errors as FieldErrors<CoinmarketBuyFormProps>).cryptoInput;
     const networkSymbol = cryptoSelect?.value && cryptoIdToCoinSymbol(cryptoSelect?.value);
+    const decimals = getCoinmarketNetworkDecimals({
+        sendCryptoSelect: cryptoSelect as CoinmarketAccountOptionsGroupOptionProps | undefined,
+        network,
+    });
 
     const cryptoInputRules = {
         validate: {
             min: validateMin(translationString),
             integer: validateInteger(translationString, { except: !shouldSendInSats }),
-            decimals: validateDecimals(translationString, { decimals: network.decimals }),
+            decimals: validateDecimals(translationString, { decimals }),
             limits: validateLimits(translationString, {
                 amountLimits,
                 areSatsUsed: !!shouldSendInSats,

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInputs.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInputs.tsx
@@ -28,7 +28,7 @@ import { Row } from '@trezor/components';
 import { CoinmarketBalance } from 'src/views/wallet/coinmarket/common/CoinmarketBalance';
 import { TokenAddress } from '@suite-common/wallet-types';
 import { formatAmount } from '@suite-common/wallet-utils';
-import { getNetworkDecimals } from 'src/utils/wallet/coinmarket/coinmarketUtils';
+import { getCoinmarketNetworkDecimals } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 import {
     isCoinmarketExchangeContext,
@@ -62,7 +62,7 @@ export const CoinmarketFormInputs = () => {
         const tokenAddress = (output.token ?? undefined) as TokenAddress | undefined;
         const outputAmount =
             shouldSendInSats && output.amount
-                ? formatAmount(output.amount, getNetworkDecimals(sendCryptoSelect?.decimals))
+                ? formatAmount(output.amount, getCoinmarketNetworkDecimals({ sendCryptoSelect }))
                 : output.amount;
 
         return (
@@ -102,6 +102,7 @@ export const CoinmarketFormInputs = () => {
                             tokenAddress={tokenAddress as TokenAddress}
                             showOnlyAmount
                             amountInCrypto={amountInCrypto}
+                            sendCryptoSelect={sendCryptoSelect}
                         />
                     </Row>
                 )}
@@ -150,7 +151,7 @@ export const CoinmarketFormInputs = () => {
         const supportedCryptoCurrencies = exchangeInfo?.buySymbols;
         const outputAmount =
             shouldSendInSats && output.amount
-                ? formatAmount(output.amount, getNetworkDecimals(sendCryptoSelect?.decimals))
+                ? formatAmount(output.amount, getCoinmarketNetworkDecimals({ sendCryptoSelect }))
                 : output.amount;
 
         return (
@@ -190,6 +191,7 @@ export const CoinmarketFormInputs = () => {
                             tokenAddress={tokenAddress}
                             showOnlyAmount
                             amountInCrypto={amountInCrypto}
+                            sendCryptoSelect={sendCryptoSelect}
                         />
                     </Row>
                 )}

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketOfferExchange/CoinmarketOfferExchangeSendSwap.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketOfferExchange/CoinmarketOfferExchangeSendSwap.tsx
@@ -24,6 +24,8 @@ import { spacings } from '@trezor/theme';
 import { useCoinmarketFormContext } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonForm';
 import { CoinmarketTradeExchangeType } from 'src/types/coinmarket/coinmarket';
 import { useCoinmarketInfo } from 'src/hooks/wallet/coinmarket/useCoinmarketInfo';
+import { getCoinmarketNetworkDecimals } from 'src/utils/wallet/coinmarket/coinmarketUtils';
+import { FORM_SEND_CRYPTO_CURRENCY_SELECT } from 'src/constants/wallet/coinmarket/form';
 
 const BreakableValue = styled.span`
     word-break: break-all;
@@ -70,14 +72,25 @@ const formatCryptoAmountAsAmount = (amount: number, baseAmount: number, decimals
 
 export const CoinmarketOfferExchangeSendSwap = () => {
     const theme = useTheme();
-    const { account, callInProgress, selectedQuote, exchangeInfo, confirmTrade, sendTransaction } =
-        useCoinmarketFormContext<CoinmarketTradeExchangeType>();
+    const {
+        account,
+        callInProgress,
+        selectedQuote,
+        exchangeInfo,
+        confirmTrade,
+        sendTransaction,
+        getValues,
+    } = useCoinmarketFormContext<CoinmarketTradeExchangeType>();
     const { cryptoIdToCoinSymbol } = useCoinmarketInfo();
     const [slippage, setSlippage] = useState(selectedQuote?.swapSlippage ?? '1');
     const [customSlippage, setCustomSlippage] = useState(slippage);
     const [customSlippageError, setCustomSlippageError] = useState<
         (FieldError & { message: TranslationKey }) | undefined
     >();
+    const sendCryptoSelect = getValues(FORM_SEND_CRYPTO_CURRENCY_SELECT);
+    const decimals = getCoinmarketNetworkDecimals({
+        sendCryptoSelect,
+    });
 
     // only used for custom slippage
     useDebounce(
@@ -246,6 +259,7 @@ export const CoinmarketOfferExchangeSendSwap = () => {
                                 (Number(selectedQuote.swapSlippage) / 100) *
                                     Number(receiveStringAmount),
                                 Number(receiveStringAmount),
+                                decimals,
                             )} ${cryptoIdToCoinSymbol(receive)}`}
                         </InfoRow>
 
@@ -257,6 +271,7 @@ export const CoinmarketOfferExchangeSendSwap = () => {
                                 ((100 - Number(selectedQuote.swapSlippage)) / 100) *
                                     Number(receiveStringAmount),
                                 Number(receiveStringAmount),
+                                decimals,
                             )} ${cryptoIdToCoinSymbol(receive)}`}
                         </InfoRow>
                     </Column>

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketVerify/CoinmarketVerifyOptionsItem.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketVerify/CoinmarketVerifyOptionsItem.tsx
@@ -2,8 +2,11 @@ import { Column, Icon, Row, variables } from '@trezor/components';
 import { CoinLogo } from '@trezor/product-components';
 import { spacingsPx } from '@trezor/theme';
 import { AccountLabeling, Translation } from 'src/components/suite';
+import { FORM_SEND_CRYPTO_CURRENCY_SELECT } from 'src/constants/wallet/coinmarket/form';
+import { useCoinmarketFormContext } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonForm';
 import { useCoinmarketInfo } from 'src/hooks/wallet/coinmarket/useCoinmarketInfo';
 import { CoinmarketVerifyOptionsItemProps } from 'src/types/coinmarket/coinmarketVerify';
+import { isCoinmarketExchangeContext } from 'src/utils/wallet/coinmarket/coinmarketTypingUtils';
 import { parseCryptoId } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import { CoinmarketBalance } from 'src/views/wallet/coinmarket/common/CoinmarketBalance';
 import styled, { useTheme } from 'styled-components';
@@ -25,6 +28,7 @@ export const CoinmarketVerifyOptionsItem = ({
     option,
     receiveNetwork,
 }: CoinmarketVerifyOptionsItemProps) => {
+    const context = useCoinmarketFormContext();
     const { cryptoIdToPlatformName, cryptoIdToCoinName } = useCoinmarketInfo();
     const theme = useTheme();
     const iconSize = 24;
@@ -54,6 +58,11 @@ export const CoinmarketVerifyOptionsItem = ({
                             balance={formattedBalance}
                             cryptoSymbolLabel={symbol.toLocaleUpperCase()}
                             networkSymbol={symbol}
+                            sendCryptoSelect={
+                                isCoinmarketExchangeContext(context)
+                                    ? context.getValues(FORM_SEND_CRYPTO_CURRENCY_SELECT)
+                                    : undefined
+                            }
                         />
                     </Column>
                 </AccountWrapper>

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -45,8 +45,6 @@ import { getFiatRateKey } from './fiatRatesUtils';
 import { getAccountTotalStakingBalance } from './ethereumStakingUtils';
 import { isRbfTransaction } from './transactionUtils';
 
-export const isEthereumAccountSymbol = (symbol: NetworkSymbol) => symbol === 'eth';
-
 export const isUtxoBased = (account: Account) =>
     account.networkType === 'bitcoin' || account.networkType === 'cardano';
 


### PR DESCRIPTION
## Description
- Fixed decimals places - every selected account/token should support their decimals places (e.g. Solana supports max. 9 decimal places and USDT on Solana network should support max. 6)
- Fixed inappropriate recalculating of fees and all sent cryptocurrency
- Fixed All button always update input

## Related Issue
Resolve https://github.com/trezor/trezor-suite/issues/14823
Resolve https://github.com/trezor/trezor-suite/issues/14835