### PR TITLE
Bitcoin-only networks fixies

### DIFF
--- a/packages/suite/src/components/suite/CoinGroup/CoinGroup.tsx
+++ b/packages/suite/src/components/suite/CoinGroup/CoinGroup.tsx
@@ -2,30 +2,32 @@ import { useState } from 'react';
 import styled from 'styled-components';
 
 import { useDispatch } from 'src/hooks/suite';
+import { changeCoinVisibility } from 'src/actions/settings/walletSettingsActions';
 import { openModal } from 'src/actions/suite/modalActions';
 import { CoinList } from 'src/components/suite';
 import { Network, NetworkSymbol } from '@suite-common/wallet-config';
 
 import { CoinGroupHeader } from './CoinGroupHeader';
+import { CoinListProps } from '../CoinList/CoinList';
 
 const CoinGroupWrapper = styled.div`
     width: 100%;
 `;
 
-interface CoinGroupProps {
+type CoinGroupProps = {
     networks: Network[];
     enabledNetworks?: NetworkSymbol[];
-    className?: string;
-    onToggle: (symbol: NetworkSymbol, toggled: boolean) => void;
-}
+};
 
-export const CoinGroup = ({ onToggle, networks, enabledNetworks, className }: CoinGroupProps) => {
+export const CoinGroup = ({ networks, enabledNetworks }: CoinGroupProps) => {
     const [settingsMode, setSettingsMode] = useState(false);
 
     const dispatch = useDispatch();
 
     const isAtLeastOneActive = networks.some(({ symbol }) => enabledNetworks?.includes(symbol));
 
+    const onToggle: CoinListProps['onToggle'] = (symbol, shouldBeVisible) =>
+        dispatch(changeCoinVisibility(symbol, shouldBeVisible));
     const onSettings = (symbol: NetworkSymbol) => {
         setSettingsMode(false);
         dispatch(
@@ -38,7 +40,7 @@ export const CoinGroup = ({ onToggle, networks, enabledNetworks, className }: Co
     const toggleSettingsMode = () => setSettingsMode(value => !value);
 
     return (
-        <CoinGroupWrapper className={className}>
+        <CoinGroupWrapper>
             <CoinGroupHeader
                 isAtLeastOneActive={isAtLeastOneActive}
                 settingsMode={settingsMode}

--- a/packages/suite/src/components/suite/CoinList/CoinList.tsx
+++ b/packages/suite/src/components/suite/CoinList/CoinList.tsx
@@ -19,13 +19,13 @@ const Wrapper = styled.div`
     gap: 16px 12px;
 `;
 
-interface CoinListProps {
+export type CoinListProps = {
     networks: Network[];
     enabledNetworks?: NetworkSymbol[];
     settingsMode?: boolean;
     onSettings?: (symbol: NetworkSymbol) => void;
     onToggle: (symbol: NetworkSymbol, toggled: boolean) => void;
-}
+};
 
 export const CoinList = ({
     networks,

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/utils.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/utils.ts
@@ -1,8 +1,9 @@
 import { useCustomBackends } from 'src/hooks/settings/backends';
 import { useSelector } from 'src/hooks/suite';
+import { selectEnabledNetworks } from 'src/reducers/wallet/settingsReducer';
 
 export const useEnabledBackends = () => {
-    const enabledNetworks = useSelector(state => state.wallet.settings.enabledNetworks);
+    const enabledNetworks = useSelector(selectEnabledNetworks);
     const customBackends = useCustomBackends();
 
     return customBackends.filter(backend => enabledNetworks.includes(backend.coin));

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletConfirmationStep1.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletConfirmationStep1.tsx
@@ -7,10 +7,11 @@ import { CoinLogo } from '@trezor/product-components';
 import { Translation } from 'src/components/suite/Translation';
 import { TrezorLink } from 'src/components/suite/TrezorLink';
 import { ContentType } from './types';
-import { useDispatch } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { goto } from 'src/actions/suite/routerActions';
 import { onCancel as onCancelModal } from 'src/actions/suite/modalActions';
-import { useEnabledNetworks } from 'src/hooks/settings/useEnabledNetworks';
+import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
+import { selectEnabledNetworks } from 'src/reducers/wallet/settingsReducer';
 
 type PassphraseWalletConfirmationStep1Props = {
     setContentType: Dispatch<React.SetStateAction<ContentType>>;
@@ -25,7 +26,8 @@ export const PassphraseWalletConfirmationStep1 = ({
     onCancel,
     'data-testid': dataTest,
 }: PassphraseWalletConfirmationStep1Props) => {
-    const { enabledNetworks, supportedMainnets } = useEnabledNetworks();
+    const { supportedMainnets } = useNetworkSupport();
+    const enabledNetworks = useSelector(selectEnabledNetworks);
     const dispatch = useDispatch();
 
     const areAllNetworksEnabled = supportedMainnets.length === enabledNetworks.length;

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletConfirmationStep1.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletConfirmationStep1.tsx
@@ -30,7 +30,9 @@ export const PassphraseWalletConfirmationStep1 = ({
     const enabledNetworks = useSelector(selectEnabledNetworks);
     const dispatch = useDispatch();
 
-    const areAllNetworksEnabled = supportedMainnets.length === enabledNetworks.length;
+    const areAllNetworksEnabled = supportedMainnets.every(network =>
+        enabledNetworks.includes(network.symbol),
+    );
 
     return (
         <Column gap={spacings.sm} margin={{ top: spacings.xxs }} alignItems="stretch">

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletConfirmationStep1.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletConfirmationStep1.tsx
@@ -2,13 +2,12 @@ import { Dispatch } from 'react';
 import { spacings } from '@trezor/theme';
 import { Column, Card, Row, Button, H3, Paragraph } from '@trezor/components';
 import { HELP_CENTER_PASSPHRASE_URL } from '@trezor/urls';
-import { selectDeviceSupportedNetworks } from '@suite-common/wallet-core';
 import { CoinLogo } from '@trezor/product-components';
 
 import { Translation } from 'src/components/suite/Translation';
 import { TrezorLink } from 'src/components/suite/TrezorLink';
 import { ContentType } from './types';
-import { useSelector, useDispatch } from 'src/hooks/suite';
+import { useDispatch } from 'src/hooks/suite';
 import { goto } from 'src/actions/suite/routerActions';
 import { onCancel as onCancelModal } from 'src/actions/suite/modalActions';
 import { useEnabledNetworks } from 'src/hooks/settings/useEnabledNetworks';
@@ -26,15 +25,10 @@ export const PassphraseWalletConfirmationStep1 = ({
     onCancel,
     'data-testid': dataTest,
 }: PassphraseWalletConfirmationStep1Props) => {
-    const { enabledNetworks, mainnets } = useEnabledNetworks();
-    const deviceSupportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
+    const { enabledNetworks, supportedMainnets } = useEnabledNetworks();
     const dispatch = useDispatch();
 
-    const supportedNetworks = mainnets.filter(({ symbol }) =>
-        deviceSupportedNetworkSymbols.includes(symbol),
-    );
-
-    const areAllNetworksEnabled = supportedNetworks.length === enabledNetworks.length;
+    const areAllNetworksEnabled = supportedMainnets.length === enabledNetworks.length;
 
     return (
         <Column gap={spacings.sm} margin={{ top: spacings.xxs }} alignItems="stretch">

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -14,12 +14,13 @@ import { useSelector, useDispatch } from 'src/hooks/suite';
 import { changeCoinVisibility } from 'src/actions/settings/walletSettingsActions';
 import { goto } from 'src/actions/suite/routerActions';
 import { selectIsPublic } from 'src/reducers/wallet/coinjoinReducer';
-import { useEnabledNetworks } from 'src/hooks/settings/useEnabledNetworks';
+import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
 import { AccountTypeSelect } from './AccountTypeSelect/AccountTypeSelect';
 import { SelectNetwork } from './SelectNetwork';
 import { AddAccountButton } from './AddAccountButton/AddAccountButton';
 import { DeviceModelInternal } from '@trezor/connect';
 import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
+import { selectEnabledNetworks } from 'src/reducers/wallet/settingsReducer';
 
 const NetworksWrapper = styled.div`
     display: flex;
@@ -49,14 +50,10 @@ export const AddAccountModal = ({
     const isDebug = useSelector(selectIsDebugModeActive);
     const isCoinjoinPublic = useSelector(selectIsPublic);
     const deviceModel = useSelector(selectDeviceModel);
+    const enabledNetworkSymbols = useSelector(selectEnabledNetworks);
     const dispatch = useDispatch();
 
-    const {
-        supportedMainnets,
-        unsupportedMainnets,
-        supportedTestnets,
-        enabledNetworks: enabledNetworkSymbols,
-    } = useEnabledNetworks();
+    const { supportedMainnets, unsupportedMainnets, supportedTestnets } = useNetworkSupport();
 
     const supportedNetworks = [...supportedMainnets, ...supportedTestnets];
     const allTestnetNetworksDisabled = supportedTestnets.some(network =>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -56,7 +56,7 @@ export const AddAccountModal = ({
     const { supportedMainnets, unsupportedMainnets, supportedTestnets } = useNetworkSupport();
 
     const supportedNetworks = [...supportedMainnets, ...supportedTestnets];
-    const allTestnetNetworksDisabled = supportedTestnets.some(network =>
+    const allTestnetNetworksDisabled = !supportedTestnets.some(network =>
         enabledNetworkSymbols.includes(network.symbol),
     );
     const isBitcoinOnlyFirmware = hasBitcoinOnlyFirmware(device);
@@ -66,9 +66,7 @@ export const AddAccountModal = ({
     const preselectedNetwork = symbol && supportedNetworks.find(n => n.symbol === symbol);
     // or in case of only btc is enabled on bitcoin-only firmware
     const bitcoinOnlyDefaultNetworkSelection =
-        hasBitcoinOnlyFirmware(device) &&
-        supportedMainnets.length === 1 &&
-        allTestnetNetworksDisabled
+        isBitcoinOnlyFirmware && supportedMainnets.length === 1 && allTestnetNetworksDisabled
             ? networks.btc
             : undefined;
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -243,7 +243,7 @@ export const AddAccountModal = ({
                                   />
                               </CollapsibleBox>
                           )}
-                          {!!isBitcoinOnlyFirmware && deviceModel === DeviceModelInternal.T1B1 && (
+                          {!isBitcoinOnlyFirmware && deviceModel === DeviceModelInternal.T1B1 && (
                               <CollapsibleBox
                                   heading={
                                       <Tooltip

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -1,11 +1,7 @@
 import { useState } from 'react';
 import styled from 'styled-components';
 
-import {
-    accountsActions,
-    selectDeviceSupportedNetworks,
-    selectDeviceModel,
-} from '@suite-common/wallet-core';
+import { accountsActions, selectDeviceModel } from '@suite-common/wallet-core';
 import { arrayPartition } from '@trezor/utils';
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 import { networks, Network, NetworkSymbol, NetworkAccount } from '@suite-common/wallet-config';
@@ -49,23 +45,19 @@ export const AddAccountModal = ({
     isBackClickDisabled,
 }: AddAccountProps) => {
     const accounts = useSelector(state => state.wallet.accounts);
-    const supportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
     const app = useSelector(state => state.router.app);
     const isDebug = useSelector(selectIsDebugModeActive);
     const isCoinjoinPublic = useSelector(selectIsPublic);
     const deviceModel = useSelector(selectDeviceModel);
     const dispatch = useDispatch();
 
-    const { mainnets, testnets, enabledNetworks: enabledNetworkSymbols } = useEnabledNetworks();
+    const {
+        supportedMainnets,
+        unsupportedMainnets,
+        supportedTestnets,
+        enabledNetworks: enabledNetworkSymbols,
+    } = useEnabledNetworks();
 
-    const getNetworks = (networksToFilterFrom: Network[], getUnsupported = false) =>
-        networksToFilterFrom.filter(
-            ({ symbol }) => getUnsupported !== supportedNetworkSymbols.includes(symbol),
-        );
-
-    const supportedMainnets = getNetworks(mainnets);
-    const supportedTestnets = getNetworks(testnets);
-    const unsupportedNetworks = getNetworks(mainnets, true);
     const supportedNetworks = [...supportedMainnets, ...supportedTestnets];
     const allTestnetNetworksDisabled = supportedTestnets.some(network =>
         enabledNetworkSymbols.includes(network.symbol),
@@ -271,7 +263,7 @@ export const AddAccountModal = ({
                               >
                                   <CoinList
                                       onToggle={selectNetwork}
-                                      networks={unsupportedNetworks}
+                                      networks={unsupportedMainnets}
                                       enabledNetworks={selectedNetworks}
                                   />
                               </CollapsibleBox>

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSearchBox.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSearchBox.tsx
@@ -1,10 +1,11 @@
 import styled, { useTheme } from 'styled-components';
 
 import { Icon, Input } from '@trezor/components';
+import { borders } from '@trezor/theme';
 import { selectDevice } from '@suite-common/wallet-core';
 
 import { useSelector, useAccountSearch, useTranslation } from 'src/hooks/suite';
-import { borders } from '@trezor/theme';
+import { selectEnabledNetworks } from 'src/reducers/wallet/settingsReducer';
 
 const InputWrapper = styled.div<{ $showCoinFilter: boolean }>`
     flex: 1;
@@ -26,7 +27,7 @@ export const AccountSearchBox = () => {
     const theme = useTheme();
     const { translationString } = useTranslation();
     const { setCoinFilter, searchString, setSearchString } = useAccountSearch();
-    const enabledNetworks = useSelector(state => state.wallet.settings.enabledNetworks);
+    const enabledNetworks = useSelector(selectEnabledNetworks);
     const device = useSelector(selectDevice);
 
     const unavailableCapabilities = device?.unavailableCapabilities ?? {};

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/CoinsFilter.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/CoinsFilter.tsx
@@ -1,12 +1,13 @@
 import styled from 'styled-components';
-
-import { TOOLTIP_DELAY_NORMAL, Tooltip, motionEasing } from '@trezor/components';
 import { motion, AnimatePresence, MotionProps } from 'framer-motion';
-import { borders, spacingsPx } from '@trezor/theme';
+
 import { selectDevice } from '@suite-common/wallet-core';
+import { TOOLTIP_DELAY_NORMAL, Tooltip, motionEasing } from '@trezor/components';
+import { CoinLogo } from '@trezor/product-components';
+import { borders, spacingsPx } from '@trezor/theme';
 
 import { useSelector, useAccountSearch } from 'src/hooks/suite';
-import { CoinLogo } from '@trezor/product-components';
+import { selectEnabledNetworks } from 'src/reducers/wallet/settingsReducer';
 
 // eslint-disable-next-line local-rules/no-override-ds-component
 const StyledCoinLogo = styled(CoinLogo)<{ $isSelected?: boolean }>`
@@ -42,7 +43,7 @@ const Container = styled.div`
 
 export const CoinsFilter = () => {
     const { coinFilter, setCoinFilter } = useAccountSearch();
-    const enabledNetworks = useSelector(state => state.wallet.settings.enabledNetworks);
+    const enabledNetworks = useSelector(selectEnabledNetworks);
     const device = useSelector(selectDevice);
 
     const unavailableCapabilities = device?.unavailableCapabilities ?? {};

--- a/packages/suite/src/hooks/settings/useEnabledNetworks.ts
+++ b/packages/suite/src/hooks/settings/useEnabledNetworks.ts
@@ -1,6 +1,5 @@
 import { Network, NetworkSymbol, getMainnets, getTestnets } from '@suite-common/wallet-config';
-import { changeCoinVisibility } from 'src/actions/settings/walletSettingsActions';
-import { useActions, useSelector } from 'src/hooks/suite';
+import { useSelector } from 'src/hooks/suite';
 
 import {
     selectHasExperimentalFeature,
@@ -11,7 +10,6 @@ type EnabledNetworks = {
     mainnets: Network[];
     testnets: Network[];
     enabledNetworks: NetworkSymbol[];
-    setEnabled: (symbol: NetworkSymbol, enabled: boolean) => void;
 };
 
 export const useEnabledNetworks = (): EnabledNetworks => {
@@ -23,14 +21,9 @@ export const useEnabledNetworks = (): EnabledNetworks => {
 
     const testnets = getTestnets(isDebug);
 
-    const { setEnabled } = useActions({
-        setEnabled: changeCoinVisibility,
-    });
-
     return {
         mainnets,
         testnets,
         enabledNetworks,
-        setEnabled,
     };
 };

--- a/packages/suite/src/hooks/settings/useNetworkSupport.ts
+++ b/packages/suite/src/hooks/settings/useNetworkSupport.ts
@@ -8,8 +8,7 @@ import {
     selectIsDebugModeActive,
 } from 'src/reducers/suite/suiteReducer';
 
-export const useEnabledNetworks = () => {
-    const enabledNetworks = useSelector(state => state.wallet.settings.enabledNetworks);
+export const useNetworkSupport = () => {
     const isDebug = useSelector(selectIsDebugModeActive);
     const opExperimentalFeature = useSelector(selectHasExperimentalFeature('optimism'));
     const deviceSupportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
@@ -27,6 +26,5 @@ export const useEnabledNetworks = () => {
         supportedMainnets,
         unsupportedMainnets,
         supportedTestnets,
-        enabledNetworks,
     };
 };

--- a/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
@@ -11,13 +11,13 @@ import { useDiscovery, useDispatch, useLayoutSize, useSelector } from 'src/hooks
 import { useAccounts } from 'src/hooks/wallet';
 import { setFlag } from 'src/actions/suite/suiteActions';
 import { goto } from 'src/actions/suite/routerActions';
-import { useEnabledNetworks } from 'src/hooks/settings/useEnabledNetworks';
+import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
 
 import { AssetCard, AssetCardSkeleton } from './AssetCard/AssetCard';
 import { spacings, spacingsPx, typography } from '@trezor/theme';
 import { AssetFiatBalance } from '@suite-common/assets';
 import { getFiatRateKey, toFiatCurrency } from '@suite-common/wallet-utils';
-import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
+import { selectEnabledNetworks, selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
 import { AssetTable, AssetTableRowType } from './AssetTable/AssetTable';
 import { NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 
@@ -65,12 +65,13 @@ const useAssetsFiatBalances = (
 
 export const AssetsView = () => {
     const { dashboardAssetsGridMode } = useSelector(s => s.suite.flags);
+    const enabledNetworks = useSelector(selectEnabledNetworks);
 
     const theme = useTheme();
     const dispatch = useDispatch();
     const { discovery, getDiscoveryStatus, isDiscoveryRunning } = useDiscovery();
     const { accounts } = useAccounts(discovery);
-    const { supportedMainnets, enabledNetworks } = useEnabledNetworks();
+    const { supportedMainnets } = useNetworkSupport();
     const { isMobileLayout } = useLayoutSize();
 
     const hasMainnetNetworksToEnable = supportedMainnets.some(

--- a/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
@@ -2,7 +2,7 @@ import styled, { useTheme } from 'styled-components';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { Icon, Button, LoadingContent, Card } from '@trezor/components';
-import { selectCurrentFiatRates, selectDeviceSupportedNetworks } from '@suite-common/wallet-core';
+import { selectCurrentFiatRates } from '@suite-common/wallet-core';
 
 import { DashboardSection } from 'src/components/dashboard';
 import { Account } from 'src/types/wallet';
@@ -65,21 +65,16 @@ const useAssetsFiatBalances = (
 
 export const AssetsView = () => {
     const { dashboardAssetsGridMode } = useSelector(s => s.suite.flags);
-    const deviceSupportedNetworks = useSelector(selectDeviceSupportedNetworks);
 
     const theme = useTheme();
     const dispatch = useDispatch();
     const { discovery, getDiscoveryStatus, isDiscoveryRunning } = useDiscovery();
     const { accounts } = useAccounts(discovery);
-    const { mainnets, enabledNetworks } = useEnabledNetworks();
+    const { supportedMainnets, enabledNetworks } = useEnabledNetworks();
     const { isMobileLayout } = useLayoutSize();
 
-    const mainnetSymbols = mainnets.map(mainnet => mainnet.symbol);
-    const supportedMainnetNetworks = deviceSupportedNetworks.filter(network =>
-        mainnetSymbols.includes(network),
-    );
-    const hasMainnetNetworksToEnable = supportedMainnetNetworks.some(
-        network => !enabledNetworks.includes(network),
+    const hasMainnetNetworksToEnable = supportedMainnets.some(
+        network => !enabledNetworks.includes(network.symbol),
     );
 
     const assets: { [key: string]: Account[] } = {};

--- a/packages/suite/src/views/dashboard/PortfolioCard/EmptyWallet.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/EmptyWallet.tsx
@@ -15,7 +15,9 @@ export const EmptyWallet = () => {
     const enabledNetworks = useSelector(selectEnabledNetworks);
     const dispatch = useDispatch();
 
-    const areAllNetworksEnabled = supportedMainnets.length === enabledNetworks.length;
+    const areAllNetworksEnabled = supportedMainnets.every(network =>
+        enabledNetworks.includes(network.symbol),
+    );
 
     return (
         <Column gap={spacings.xxs} data-testid="@dashboard/wallet-ready">

--- a/packages/suite/src/views/dashboard/PortfolioCard/EmptyWallet.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/EmptyWallet.tsx
@@ -6,11 +6,13 @@ import { Translation } from 'src/components/suite';
 import { useSelector, useDispatch } from 'src/hooks/suite';
 import { selectIsDeviceUsingPassphrase } from '@suite-common/wallet-core';
 import { goto } from 'src/actions/suite/routerActions';
-import { useEnabledNetworks } from 'src/hooks/settings/useEnabledNetworks';
+import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
+import { selectEnabledNetworks } from 'src/reducers/wallet/settingsReducer';
 
 export const EmptyWallet = () => {
-    const { supportedMainnets, enabledNetworks } = useEnabledNetworks();
+    const { supportedMainnets } = useNetworkSupport();
     const isPassphraseType = useSelector(selectIsDeviceUsingPassphrase);
+    const enabledNetworks = useSelector(selectEnabledNetworks);
     const dispatch = useDispatch();
 
     const areAllNetworksEnabled = supportedMainnets.length === enabledNetworks.length;

--- a/packages/suite/src/views/dashboard/PortfolioCard/EmptyWallet.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/EmptyWallet.tsx
@@ -4,24 +4,16 @@ import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
 import { useSelector, useDispatch } from 'src/hooks/suite';
-import {
-    selectIsDeviceUsingPassphrase,
-    selectDeviceSupportedNetworks,
-} from '@suite-common/wallet-core';
+import { selectIsDeviceUsingPassphrase } from '@suite-common/wallet-core';
 import { goto } from 'src/actions/suite/routerActions';
 import { useEnabledNetworks } from 'src/hooks/settings/useEnabledNetworks';
 
 export const EmptyWallet = () => {
-    const { enabledNetworks, mainnets } = useEnabledNetworks();
+    const { supportedMainnets, enabledNetworks } = useEnabledNetworks();
     const isPassphraseType = useSelector(selectIsDeviceUsingPassphrase);
-    const deviceSupportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
     const dispatch = useDispatch();
 
-    const supportedNetworks = mainnets.filter(({ symbol }) =>
-        deviceSupportedNetworkSymbols.includes(symbol),
-    );
-
-    const areAllNetworksEnabled = supportedNetworks.length === enabledNetworks.length;
+    const areAllNetworksEnabled = supportedMainnets.length === enabledNetworks.length;
 
     return (
         <Column gap={spacings.xxs} data-testid="@dashboard/wallet-ready">

--- a/packages/suite/src/views/onboarding/steps/BasicSettings/BasicSettingsStepBox.tsx
+++ b/packages/suite/src/views/onboarding/steps/BasicSettings/BasicSettingsStepBox.tsx
@@ -5,10 +5,9 @@ import { CoinGroup, TooltipSymbol, Translation } from 'src/components/suite';
 import { useEnabledNetworks } from 'src/hooks/settings/useEnabledNetworks';
 import { CollapsibleBox } from '@trezor/components';
 import { spacings } from '@trezor/theme';
-import { selectDeviceSupportedNetworks, selectDeviceModel } from '@suite-common/wallet-core';
+import { selectDeviceModel } from '@suite-common/wallet-core';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { DeviceModelInternal } from '@trezor/connect';
-import { Network } from '@suite-common/wallet-config';
 import { changeCoinVisibility } from 'src/actions/settings/walletSettingsActions';
 
 const Separator = styled.hr`
@@ -21,19 +20,10 @@ const Separator = styled.hr`
 `;
 
 export const BasicSettingsStepBox = (props: OnboardingStepBoxProps) => {
-    const { mainnets, testnets, enabledNetworks } = useEnabledNetworks();
-    const deviceSupportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
+    const { supportedMainnets, unsupportedMainnets, supportedTestnets, enabledNetworks } =
+        useEnabledNetworks();
     const deviceModel = useSelector(selectDeviceModel);
     const dispatch = useDispatch();
-
-    const getNetworks = (networks: Network[], getUnsupported = false) =>
-        networks.filter(
-            ({ symbol }) => getUnsupported !== deviceSupportedNetworkSymbols.includes(symbol),
-        );
-
-    const supportedNetworks = getNetworks(mainnets);
-    const unsupportedNetworks = getNetworks(mainnets, true);
-    const supportedTestnetNetworks = getNetworks(testnets);
 
     // BTC should be enabled by default
     useEffect(() => {
@@ -43,7 +33,7 @@ export const BasicSettingsStepBox = (props: OnboardingStepBoxProps) => {
     return (
         <OnboardingStepBox image="COINS" {...props}>
             <Separator />
-            <CoinGroup networks={supportedNetworks} enabledNetworks={enabledNetworks} />
+            <CoinGroup networks={supportedMainnets} enabledNetworks={enabledNetworks} />
             <CollapsibleBox
                 margin={{ top: spacings.xl }}
                 heading={
@@ -56,7 +46,7 @@ export const BasicSettingsStepBox = (props: OnboardingStepBoxProps) => {
                 }
                 paddingType="large"
             >
-                <CoinGroup networks={supportedTestnetNetworks} enabledNetworks={enabledNetworks} />
+                <CoinGroup networks={supportedTestnets} enabledNetworks={enabledNetworks} />
             </CollapsibleBox>
             {deviceModel === DeviceModelInternal.T1B1 && (
                 <CollapsibleBox
@@ -71,7 +61,7 @@ export const BasicSettingsStepBox = (props: OnboardingStepBoxProps) => {
                     }
                     paddingType="large"
                 >
-                    <CoinGroup networks={unsupportedNetworks} enabledNetworks={enabledNetworks} />
+                    <CoinGroup networks={unsupportedMainnets} enabledNetworks={enabledNetworks} />
                 </CollapsibleBox>
             )}
         </OnboardingStepBox>

--- a/packages/suite/src/views/onboarding/steps/BasicSettings/BasicSettingsStepBox.tsx
+++ b/packages/suite/src/views/onboarding/steps/BasicSettings/BasicSettingsStepBox.tsx
@@ -6,9 +6,10 @@ import { useEnabledNetworks } from 'src/hooks/settings/useEnabledNetworks';
 import { CollapsibleBox } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 import { selectDeviceSupportedNetworks, selectDeviceModel } from '@suite-common/wallet-core';
-import { useSelector } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { DeviceModelInternal } from '@trezor/connect';
 import { Network } from '@suite-common/wallet-config';
+import { changeCoinVisibility } from 'src/actions/settings/walletSettingsActions';
 
 const Separator = styled.hr`
     height: 1px;
@@ -20,9 +21,10 @@ const Separator = styled.hr`
 `;
 
 export const BasicSettingsStepBox = (props: OnboardingStepBoxProps) => {
-    const { mainnets, testnets, enabledNetworks, setEnabled } = useEnabledNetworks();
+    const { mainnets, testnets, enabledNetworks } = useEnabledNetworks();
     const deviceSupportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
     const deviceModel = useSelector(selectDeviceModel);
+    const dispatch = useDispatch();
 
     const getNetworks = (networks: Network[], getUnsupported = false) =>
         networks.filter(
@@ -35,17 +37,13 @@ export const BasicSettingsStepBox = (props: OnboardingStepBoxProps) => {
 
     // BTC should be enabled by default
     useEffect(() => {
-        setEnabled('btc', true);
-    }, [setEnabled]);
+        dispatch(changeCoinVisibility('btc', true));
+    }, [dispatch]);
 
     return (
         <OnboardingStepBox image="COINS" {...props}>
             <Separator />
-            <CoinGroup
-                networks={supportedNetworks}
-                onToggle={setEnabled}
-                enabledNetworks={enabledNetworks}
-            />
+            <CoinGroup networks={supportedNetworks} enabledNetworks={enabledNetworks} />
             <CollapsibleBox
                 margin={{ top: spacings.xl }}
                 heading={
@@ -58,11 +56,7 @@ export const BasicSettingsStepBox = (props: OnboardingStepBoxProps) => {
                 }
                 paddingType="large"
             >
-                <CoinGroup
-                    networks={supportedTestnetNetworks}
-                    onToggle={setEnabled}
-                    enabledNetworks={enabledNetworks}
-                />
+                <CoinGroup networks={supportedTestnetNetworks} enabledNetworks={enabledNetworks} />
             </CollapsibleBox>
             {deviceModel === DeviceModelInternal.T1B1 && (
                 <CollapsibleBox
@@ -77,11 +71,7 @@ export const BasicSettingsStepBox = (props: OnboardingStepBoxProps) => {
                     }
                     paddingType="large"
                 >
-                    <CoinGroup
-                        networks={unsupportedNetworks}
-                        onToggle={setEnabled}
-                        enabledNetworks={enabledNetworks}
-                    />
+                    <CoinGroup networks={unsupportedNetworks} enabledNetworks={enabledNetworks} />
                 </CollapsibleBox>
             )}
         </OnboardingStepBox>

--- a/packages/suite/src/views/onboarding/steps/BasicSettings/BasicSettingsStepBox.tsx
+++ b/packages/suite/src/views/onboarding/steps/BasicSettings/BasicSettingsStepBox.tsx
@@ -2,13 +2,14 @@ import { useEffect } from 'react';
 import styled from 'styled-components';
 import { OnboardingStepBox, OnboardingStepBoxProps } from 'src/components/onboarding';
 import { CoinGroup, TooltipSymbol, Translation } from 'src/components/suite';
-import { useEnabledNetworks } from 'src/hooks/settings/useEnabledNetworks';
+import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
 import { CollapsibleBox } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 import { selectDeviceModel } from '@suite-common/wallet-core';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { DeviceModelInternal } from '@trezor/connect';
 import { changeCoinVisibility } from 'src/actions/settings/walletSettingsActions';
+import { selectEnabledNetworks } from 'src/reducers/wallet/settingsReducer';
 
 const Separator = styled.hr`
     height: 1px;
@@ -20,9 +21,9 @@ const Separator = styled.hr`
 `;
 
 export const BasicSettingsStepBox = (props: OnboardingStepBoxProps) => {
-    const { supportedMainnets, unsupportedMainnets, supportedTestnets, enabledNetworks } =
-        useEnabledNetworks();
+    const { supportedMainnets, unsupportedMainnets, supportedTestnets } = useNetworkSupport();
     const deviceModel = useSelector(selectDeviceModel);
+    const enabledNetworks = useSelector(selectEnabledNetworks);
     const dispatch = useDispatch();
 
     // BTC should be enabled by default

--- a/packages/suite/src/views/onboarding/steps/BasicSettings/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/BasicSettings/index.tsx
@@ -1,13 +1,16 @@
+import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
+
 import { Translation } from 'src/components/suite';
 import { OnboardingButtonCta } from 'src/components/onboarding';
 import { useDevice, useOnboarding, useSelector } from 'src/hooks/suite';
-import { BasicSettingsStepBox } from './BasicSettingsStepBox';
-import { AdvancedSetup } from './AdvancedSetup';
 import { getIsTorLoading } from 'src/utils/suite/tor';
-import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
+import { selectEnabledNetworks } from 'src/reducers/wallet/settingsReducer';
+
+import { AdvancedSetup } from './AdvancedSetup';
+import { BasicSettingsStepBox } from './BasicSettingsStepBox';
 
 const BasicSettings = () => {
-    const enabledNetworks = useSelector(state => state.wallet.settings.enabledNetworks);
+    const enabledNetworks = useSelector(selectEnabledNetworks);
     const torStatus = useSelector(state => state.suite.torStatus);
     const { device } = useDevice();
 

--- a/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
 import { AnimatePresence, MotionProps, motion } from 'framer-motion';
 
-import { hasBitcoinOnlyFirmware, isBitcoinOnlyDevice } from '@trezor/device-utils';
 import {
     startDiscoveryThunk,
     selectDeviceModel,
@@ -10,6 +9,8 @@ import {
 import { Button, motionEasing, Tooltip } from '@trezor/components';
 import { DeviceModelInternal } from '@trezor/connect';
 import { BITCOIN_ONLY_NETWORKS } from '@suite-common/suite-constants';
+import { hasBitcoinOnlyFirmware, isBitcoinOnlyDevice } from '@trezor/device-utils';
+import { spacingsPx } from '@trezor/theme';
 
 import {
     DeviceBanner,
@@ -18,7 +19,7 @@ import {
     SettingsSectionItem,
 } from 'src/components/settings';
 import { CoinGroup, TooltipSymbol, Translation } from 'src/components/suite';
-import { useEnabledNetworks } from 'src/hooks/settings/useEnabledNetworks';
+import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import {
     useDevice,
@@ -27,9 +28,9 @@ import {
     useSelector,
     useDiscovery,
 } from 'src/hooks/suite';
+import { selectEnabledNetworks } from 'src/reducers/wallet/settingsReducer';
 
 import { FirmwareTypeSuggestion } from './FirmwareTypeSuggestion';
-import { spacingsPx } from '@trezor/theme';
 import { selectSuiteFlags } from '../../../reducers/suite/suiteReducer';
 
 const DiscoveryButtonWrapper = styled.div`
@@ -89,9 +90,9 @@ const getDiscoveryButtonAnimationConfig = (isConfirmed: boolean): MotionProps =>
 
 export const SettingsCoins = () => {
     const { firmwareTypeBannerClosed } = useSelector(selectSuiteFlags);
+    const enabledNetworks = useSelector(selectEnabledNetworks);
     const isDiscoveryButtonVisible = useRediscoveryNeeded();
-    const { supportedMainnets, unsupportedMainnets, supportedTestnets, enabledNetworks } =
-        useEnabledNetworks();
+    const { supportedMainnets, unsupportedMainnets, supportedTestnets } = useNetworkSupport();
     const deviceSupportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
     const deviceModel = useSelector(selectDeviceModel);
     const { device, isLocked } = useDevice();

--- a/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
@@ -90,7 +90,7 @@ const getDiscoveryButtonAnimationConfig = (isConfirmed: boolean): MotionProps =>
 export const SettingsCoins = () => {
     const { firmwareTypeBannerClosed } = useSelector(selectSuiteFlags);
     const isDiscoveryButtonVisible = useRediscoveryNeeded();
-    const { mainnets, testnets, enabledNetworks, setEnabled } = useEnabledNetworks();
+    const { mainnets, testnets, enabledNetworks } = useEnabledNetworks();
     const deviceSupportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
     const deviceModel = useSelector(selectDeviceModel);
     const { device, isLocked } = useDevice();
@@ -147,11 +147,7 @@ export const SettingsCoins = () => {
 
             <StyledSettingsSection title={<Translation id="TR_COINS" />} icon="coin">
                 <StyledSectionItem anchorId={SettingsAnchor.Crypto}>
-                    <CoinGroup
-                        networks={supportedNetworks}
-                        onToggle={setEnabled}
-                        enabledNetworks={enabledNetworks}
-                    />
+                    <CoinGroup networks={supportedNetworks} enabledNetworks={enabledNetworks} />
                 </StyledSectionItem>
             </StyledSettingsSection>
 
@@ -169,7 +165,6 @@ export const SettingsCoins = () => {
                 <SettingsSectionItem anchorId={SettingsAnchor.TestnetCrypto}>
                     <CoinGroup
                         networks={supportedTestnetNetworks}
-                        onToggle={setEnabled}
                         enabledNetworks={enabledNetworks}
                     />
                 </SettingsSectionItem>
@@ -190,7 +185,6 @@ export const SettingsCoins = () => {
                     <SettingsSectionItem anchorId={SettingsAnchor.UnsupportedCrypto}>
                         <CoinGroup
                             networks={unsupportedNetworks}
-                            onToggle={setEnabled}
                             enabledNetworks={enabledNetworks}
                         />
                     </SettingsSectionItem>

--- a/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
@@ -1,14 +1,14 @@
 import styled from 'styled-components';
 import { AnimatePresence, MotionProps, motion } from 'framer-motion';
+
 import { hasBitcoinOnlyFirmware, isBitcoinOnlyDevice } from '@trezor/device-utils';
 import {
-    selectDeviceSupportedNetworks,
     startDiscoveryThunk,
     selectDeviceModel,
+    selectDeviceSupportedNetworks,
 } from '@suite-common/wallet-core';
 import { Button, motionEasing, Tooltip } from '@trezor/components';
 import { DeviceModelInternal } from '@trezor/connect';
-import { Network } from '@suite-common/wallet-config';
 import { BITCOIN_ONLY_NETWORKS } from '@suite-common/suite-constants';
 
 import {
@@ -90,7 +90,8 @@ const getDiscoveryButtonAnimationConfig = (isConfirmed: boolean): MotionProps =>
 export const SettingsCoins = () => {
     const { firmwareTypeBannerClosed } = useSelector(selectSuiteFlags);
     const isDiscoveryButtonVisible = useRediscoveryNeeded();
-    const { mainnets, testnets, enabledNetworks } = useEnabledNetworks();
+    const { supportedMainnets, unsupportedMainnets, supportedTestnets, enabledNetworks } =
+        useEnabledNetworks();
     const deviceSupportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
     const deviceModel = useSelector(selectDeviceModel);
     const { device, isLocked } = useDevice();
@@ -102,21 +103,12 @@ export const SettingsCoins = () => {
         deviceSupportedNetworkSymbols.includes(enabledNetwork),
     );
 
-    const getNetworks = (networks: Network[], getUnsupported = false) =>
-        networks.filter(
-            ({ symbol }) => getUnsupported !== deviceSupportedNetworkSymbols.includes(symbol),
-        );
-
-    const supportedNetworks = getNetworks(mainnets);
-    const unsupportedNetworks = getNetworks(mainnets, true);
-    const supportedTestnetNetworks = getNetworks(testnets);
-
     const bitcoinOnlyFirmware = hasBitcoinOnlyFirmware(device);
     const bitcoinOnlyNetworks = BITCOIN_ONLY_NETWORKS;
 
     const onlyBitcoinNetworksEnabled =
         !!supportedEnabledNetworks.length &&
-        supportedEnabledNetworks.every(coin => bitcoinOnlyNetworks.includes(coin));
+        supportedEnabledNetworks.every(network => bitcoinOnlyNetworks.includes(network));
     const bitcoinOnlyDevice = isBitcoinOnlyDevice(device);
 
     const showDeviceBanner = device?.connected === false; // device is remembered and disconnected
@@ -147,7 +139,7 @@ export const SettingsCoins = () => {
 
             <StyledSettingsSection title={<Translation id="TR_COINS" />} icon="coin">
                 <StyledSectionItem anchorId={SettingsAnchor.Crypto}>
-                    <CoinGroup networks={supportedNetworks} enabledNetworks={enabledNetworks} />
+                    <CoinGroup networks={supportedMainnets} enabledNetworks={enabledNetworks} />
                 </StyledSectionItem>
             </StyledSettingsSection>
 
@@ -163,10 +155,7 @@ export const SettingsCoins = () => {
                 icon="coin"
             >
                 <SettingsSectionItem anchorId={SettingsAnchor.TestnetCrypto}>
-                    <CoinGroup
-                        networks={supportedTestnetNetworks}
-                        enabledNetworks={enabledNetworks}
-                    />
+                    <CoinGroup networks={supportedTestnets} enabledNetworks={enabledNetworks} />
                 </SettingsSectionItem>
             </SettingsSection>
 
@@ -184,7 +173,7 @@ export const SettingsCoins = () => {
                 >
                     <SettingsSectionItem anchorId={SettingsAnchor.UnsupportedCrypto}>
                         <CoinGroup
-                            networks={unsupportedNetworks}
+                            networks={unsupportedMainnets}
                             enabledNetworks={enabledNetworks}
                         />
                     </SettingsSectionItem>

--- a/packages/suite/src/views/settings/SettingsDebug/Backends.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/Backends.tsx
@@ -1,17 +1,17 @@
 import styled from 'styled-components';
 
-import { typography } from '@trezor/theme';
-import { Button } from '@trezor/components';
 import { networks, NetworkSymbol } from '@suite-common/wallet-config';
+import { selectNetworkBlockchainInfo } from '@suite-common/wallet-core';
 import { ConnectionStatus } from '@suite-common/wallet-types';
+import { Button } from '@trezor/components';
+import { CoinLogo } from '@trezor/product-components';
+import { typography } from '@trezor/theme';
 
 import { SectionItem, StatusLight, Translation } from 'src/components/suite';
-import { useEnabledNetworks } from 'src/hooks/settings/useEnabledNetworks';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectNetworkBlockchainInfo } from '@suite-common/wallet-core';
 import { useBackendReconnection } from 'src/hooks/settings/backends';
 import { openModal } from 'src/actions/suite/modalActions';
-import { CoinLogo } from '@trezor/product-components';
+import { selectEnabledNetworks } from 'src/reducers/wallet/settingsReducer';
 
 const CoinSection = styled.div`
     display: flex;
@@ -161,7 +161,7 @@ const CoinItem = ({ symbol }: { symbol: NetworkSymbol }) => {
 };
 
 export const Backends = () => {
-    const { enabledNetworks } = useEnabledNetworks();
+    const enabledNetworks = useSelector(selectEnabledNetworks);
 
     return enabledNetworks.map(symbol => <CoinItem key={symbol} symbol={symbol} />);
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Found a bug, noticed a need for refactoring, found more bugs along the way.

#### 1. bug
Adding an account on a bitcoin-only T1, unsupported networks shouldn't be displayed:
![Screenshot 2024-11-04 at 20 02 23](https://github.com/user-attachments/assets/f228971d-8df5-4f45-a4df-cc31cca18f45)

#### 2. bug
Adding an account on a bitcoin-only firmware, network selection should only be skipped in case bitcoin is the only enabled network, not when a testnet is enabled. The condition was reversed.
![Screenshot 2024-11-04 at 20 19 58](https://github.com/user-attachments/assets/b5b1b6d7-6fa2-4442-91df-e0532e6dd237)

#### 3. bug
Upon entering an empty passphrase wallet, you should be prompted to enable more coins only in case not all networks are enabled. However, the condition was wrong and displayed the prompt when testnets were enabled together with all networks:
![Screenshot 2024-11-04 at 20 30 49](https://github.com/user-attachments/assets/da5d53f9-abce-4aee-bac6-0235a636f117)
