### PR TITLE
ci: enable workflow_dispatch for test-suite-web-e2e

### DIFF
--- a/.github/workflows/test-suite-web-e2e.yml
+++ b/.github/workflows/test-suite-web-e2e.yml
@@ -22,6 +22,7 @@ on:
       - ".github/workflows/release*"
       - ".github/workflows/template*"
       - ".github/actions/release*/**"
+  workflow_dispatch:
 
 env:
   DEV_SERVER_URL: "https://dev.suite.sldev.cz"


### PR DESCRIPTION
## Description

Enable manual dispatch for suite-web e2e.
We already have it for example on [desktop e2e](https://github.com/trezor/trezor-suite/blob/a85f6b6ce96920a8e4cb66ccffb36dba6e25a606/.github/workflows/test-suite-desktop-e2e.yml#L20).

Use case: you have PR that modifies only `connect`, but you know it will affect suite and need to test it