### PR TITLE
feat(suite): delete redundant buy button on the portfolio page

### DIFF
--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
@@ -92,7 +92,6 @@ export const PortfolioCard = memo(() => {
         );
 
     const goToReceive = () => dispatch(goto('wallet-receive'));
-    const goToBuy = () => dispatch(goto('wallet-coinmarket-buy'));
     const heading = <Translation id="TR_MY_PORTFOLIO" />;
 
     return (
@@ -154,7 +153,6 @@ export const PortfolioCard = memo(() => {
                         isWalletError={isWalletError}
                         isDiscoveryRunning={isDiscoveryRunning}
                         receiveClickHandler={goToReceive}
-                        buyClickHandler={goToBuy}
                     />
                 )}
 

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardHeader.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardHeader.tsx
@@ -55,7 +55,6 @@ export type PortfolioCardHeaderProps = {
     showGraphControls: boolean;
     hideBorder: boolean;
     receiveClickHandler: () => void;
-    buyClickHandler: () => void;
 };
 
 export const PortfolioCardHeader = ({
@@ -69,7 +68,6 @@ export const PortfolioCardHeader = ({
     showGraphControls,
     hideBorder,
     receiveClickHandler,
-    buyClickHandler,
 }: PortfolioCardHeaderProps) => {
     const accounts = useFastAccounts();
 
@@ -91,13 +89,6 @@ export const PortfolioCardHeader = ({
                             data-testid="@dashboard/receive-button"
                         >
                             <Translation id="TR_RECEIVE" />
-                        </WalletEmptyButton>
-                        <WalletEmptyButton
-                            onClick={buyClickHandler}
-                            data-testid="@dashboard/buy-button"
-                            variant="tertiary"
-                        >
-                            <Translation id="TR_BUY" />
                         </WalletEmptyButton>
                     </Buttons>
                 </>


### PR DESCRIPTION
## Description
Delete the buy button from a portfolio in case when wallet is empty.

## Related Issue
Resolve https://github.com/trezor/trezor-suite/issues/15218

## Screenshots
### Before

![image](https://github.com/user-attachments/assets/a76db244-e000-4d35-a248-a022a4287e28)

### After

![image](https://github.com/user-attachments/assets/4b945576-5a57-4425-888c-33e73f808ea6)
