### PR TITLE
fix: missing devDependency

### DIFF
--- a/packages/transport-test/package.json
+++ b/packages/transport-test/package.json
@@ -20,6 +20,7 @@
     },
     "devDependencies": {
         "@jest/types": "^29.6.3",
+        "@trezor/protobuf": "workspace:*",
         "@trezor/transport": "workspace:*",
         "@trezor/transport-bridge": "workspace:*",
         "@trezor/trezor-user-env-link": "workspace:^",

--- a/packages/transport-test/tsconfig.json
+++ b/packages/transport-test/tsconfig.json
@@ -2,6 +2,7 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
+        { "path": "../protobuf" },
         { "path": "../transport" },
         { "path": "../transport-bridge" },
         { "path": "../trezor-user-env-link" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12083,6 +12083,7 @@ __metadata:
   resolution: "@trezor/transport-test@workspace:packages/transport-test"
   dependencies:
     "@jest/types": "npm:^29.6.3"
+    "@trezor/protobuf": "workspace:*"
     "@trezor/transport": "workspace:*"
     "@trezor/transport-bridge": "workspace:*"
     "@trezor/trezor-user-env-link": "workspace:^"


### PR DESCRIPTION
`import * as messages from '@trezor/protobuf/messages.json';`

is used in that package

![image](https://github.com/user-attachments/assets/8033a3fc-76eb-44e8-a481-debdc6919116)
