### PR TITLE
fix(suite-native): revise and unify spacing of account-related screens

### DIFF
--- a/suite-native/accounts/src/components/SearchableAccountsListScreenHeader.tsx
+++ b/suite-native/accounts/src/components/SearchableAccountsListScreenHeader.tsx
@@ -78,6 +78,7 @@ export const SearchableAccountsListScreenHeader = ({
                     exiting={FadeOut.duration(HEADER_ANIMATION_DURATION)}
                 >
                     <ScreenSubHeader
+                        customHorizontalPadding="sp16"
                         content={title}
                         rightIcon={
                             <AddAccountButton

--- a/suite-native/module-accounts-import/src/components/AccountImportConfirmFormScreen.tsx
+++ b/suite-native/module-accounts-import/src/components/AccountImportConfirmFormScreen.tsx
@@ -100,7 +100,7 @@ export const AccountImportConfirmFormScreen = ({
 
     const renderItem = useCallback(
         ({ item }: { item: TokenInfo }) => (
-            <Box marginBottom="sp8">
+            <Box marginBottom="sp12">
                 <TokenInfoCard
                     networkSymbol={networkSymbol}
                     symbol={item.symbol as TokenSymbol}

--- a/suite-native/module-accounts-management/src/components/AccountDetailScreenHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountDetailScreenHeader.tsx
@@ -37,6 +37,7 @@ export const AccountDetailScreenHeader = ({
 
     return (
         <ScreenSubHeader
+            customHorizontalPadding="sp16"
             content={accountLabel}
             rightIcon={
                 <IconButton

--- a/suite-native/module-accounts-management/src/components/CoinPriceCard.tsx
+++ b/suite-native/module-accounts-management/src/components/CoinPriceCard.tsx
@@ -21,6 +21,7 @@ const cardStyle = prepareNativeStyle(utils => ({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItem: 'center',
+    marginHorizontal: utils.spacings.sp16,
     padding: utils.spacings.sp16,
     backgroundColor: utils.colors.backgroundSurfaceElevation1,
     borderRadius: utils.borders.radii.r16,

--- a/suite-native/module-accounts-management/src/components/IncludeTokensToggle.tsx
+++ b/suite-native/module-accounts-management/src/components/IncludeTokensToggle.tsx
@@ -19,7 +19,7 @@ export const IncludeTokensToggle = ({
 
     return (
         <VStack spacing="sp24" marginTop="sp8">
-            <Box marginHorizontal="sp24">
+            <Box marginHorizontal="sp16">
                 <Toggle
                     leftLabel={networkName}
                     rightLabel={<Translation id="transactions.tokens.toggleTokens" />}
@@ -29,7 +29,7 @@ export const IncludeTokensToggle = ({
             </Box>
             {isToggled && (
                 <Animated.View entering={FadeIn}>
-                    <Box marginHorizontal="sp8">
+                    <Box marginHorizontal="sp16">
                         <AlertBox
                             variant="info"
                             title={

--- a/suite-native/module-accounts-management/src/screens/AccountSettingsScreen.tsx
+++ b/suite-native/module-accounts-management/src/screens/AccountSettingsScreen.tsx
@@ -67,8 +67,10 @@ export const AccountSettingsScreen = ({
 
     return (
         <Screen
+            customHorizontalPadding="sp16"
             screenHeader={
                 <ScreenSubHeader
+                    customHorizontalPadding="sp16"
                     content={accountLabel}
                     rightIcon={<AccountRenameButton accountKey={accountKey} />}
                 />
@@ -87,7 +89,7 @@ export const AccountSettingsScreen = ({
                         )}
                     </VStack>
                 </Card>
-                <VStack marginHorizontal="sp16" spacing="sp16">
+                <VStack spacing="sp16">
                     <AccountSettingsShowXpubButton accountKey={account.key} />
                     {isPortfolioTrackerDevice && (
                         <AccountSettingsRemoveCoinButton accountKey={account.key} />

--- a/suite-native/module-accounts-management/src/screens/AccountsScreen/AccountsScreen.tsx
+++ b/suite-native/module-accounts-management/src/screens/AccountsScreen/AccountsScreen.tsx
@@ -42,6 +42,7 @@ export const AccountsScreen = () => {
 
     return (
         <Screen
+            customHorizontalPadding="sp16"
             screenHeader={<DeviceManagerScreenHeader />}
             subheader={
                 <SearchableAccountsListScreenHeader

--- a/suite-native/module-home/src/screens/HomeScreen/components/PortfolioContent.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/PortfolioContent.tsx
@@ -37,12 +37,12 @@ export const PortfolioContent = forwardRef<PortfolioGraphRef>((_props, ref) => {
     return (
         <VStack spacing="sp24" marginTop="sp8">
             <PortfolioGraph ref={ref} />
-            <VStack spacing="sp24" marginHorizontal="sp8">
+            <VStack spacing="sp24" marginHorizontal="sp16">
                 <Box>
                     <Assets />
                 </Box>
                 {isPortfolioTrackerDevice && (
-                    <Box>
+                    <Box marginBottom="sp8">
                         <Button
                             testID="@home/portfolio/sync-coins-button"
                             colorScheme="tertiaryElevation0"

--- a/suite-native/module-receive/src/screens/ReceiveAccountsScreen.tsx
+++ b/suite-native/module-receive/src/screens/ReceiveAccountsScreen.tsx
@@ -41,6 +41,7 @@ export const ReceiveAccountsScreen = () => {
 
     return (
         <Screen
+            customHorizontalPadding="sp16"
             screenHeader={<DeviceManagerScreenHeader />}
             subheader={
                 <SearchableAccountsListScreenHeader

--- a/suite-native/receive/src/components/ReceiveAccount.tsx
+++ b/suite-native/receive/src/components/ReceiveAccount.tsx
@@ -51,7 +51,7 @@ export const ReceiveAccount = ({ accountKey, tokenContract }: AccountReceiveProp
 
     return (
         <Box flex={1}>
-            <VStack spacing="sp12">
+            <VStack spacing="sp16">
                 {isAccountDetailVisible && (
                     <ReceiveAccountDetailsCard
                         accountKey={accountKey}

--- a/suite-native/receive/src/screens/ReceiveModalScreen.tsx
+++ b/suite-native/receive/src/screens/ReceiveModalScreen.tsx
@@ -85,6 +85,7 @@ const ReceiveModalScreenSubHeader = ({ accountKey, tokenContract }: ScreenSubHea
 
     return (
         <ScreenSubHeader
+            customHorizontalPadding="sp16"
             content={
                 <>
                     <Text variant="highlight">
@@ -152,6 +153,7 @@ export const ReceiveModalScreen = () => {
 
     return (
         <Screen
+            customHorizontalPadding="sp16"
             hasBottomInset={false}
             screenHeader={
                 <ReceiveModalScreenSubHeader

--- a/suite-native/transactions/src/components/TransactionsEmptyState.tsx
+++ b/suite-native/transactions/src/components/TransactionsEmptyState.tsx
@@ -16,7 +16,7 @@ const wrapperStyle = prepareNativeStyle(() => ({
 const cardStyle = prepareNativeStyle(utils => ({
     alignItems: 'center',
     flex: 1,
-    width: '100%',
+    marginHorizontal: utils.spacings.sp16,
     paddingHorizontal: utils.spacings.sp24,
     paddingVertical: utils.spacings.sp32,
     borderRadius: utils.borders.radii.r20,

--- a/suite-native/transactions/src/components/TransactionsList/TransactionList.tsx
+++ b/suite-native/transactions/src/components/TransactionsList/TransactionList.tsx
@@ -65,11 +65,6 @@ type TransactionListItem =
     | (TypedTokenTransferWithTx | MonthKey)
     | (WalletAccountTransaction | MonthKey);
 
-const sectionListStyle = prepareNativeStyle(utils => ({
-    paddingHorizontal: utils.spacings.sp8,
-    flex: 1,
-}));
-
 const sectionListContainerStyle = prepareNativeStyle(utils => ({
     paddingVertical: utils.spacings.sp8,
 }));
@@ -277,7 +272,7 @@ export const TransactionList = ({
     );
 
     return (
-        <Box style={applyStyle(sectionListStyle)}>
+        <Box flex={1}>
             <FlashList<TransactionListItem>
                 data={data}
                 renderItem={renderItem}

--- a/suite-native/transactions/src/components/TransactionsList/TransactionListItemContainer.tsx
+++ b/suite-native/transactions/src/components/TransactionsList/TransactionListItemContainer.tsx
@@ -60,7 +60,7 @@ export const transactionListItemContainerStyle = prepareNativeStyle<TransactionL
         alignItems: 'center',
         justifyContent: 'space-between',
         backgroundColor: utils.colors.backgroundSurfaceElevation1,
-        marginHorizontal: utils.spacings.sp8,
+        marginHorizontal: utils.spacings.sp16,
         paddingHorizontal: utils.spacings.sp16,
         paddingTop: utils.spacings.sp12,
         paddingBottom: utils.spacings.sp12,


### PR DESCRIPTION
- Horizontal screen padding unified to `16px` for relevant account screens
- Removed invalid margin around graph on the account detail screen

## Related Issue

Follow-up for #14065

## Screenshots:

![Simulator Screenshot - iPhone 16 Pro - 2024-11-05 at 14 56 06](https://github.com/user-attachments/assets/57273e69-159a-40a6-bac0-064ff24a17b9)
![Simulator Screenshot - iPhone 16 Pro - 2024-11-05 at 14 56 09](https://github.com/user-attachments/assets/385a69d6-e135-451d-9661-1c61c380c39f)
![Simulator Screenshot - iPhone 16 Pro - 2024-11-05 at 14 56 11](https://github.com/user-attachments/assets/829f2200-19ea-40ca-974e-5a4a32fc93ec)
![Simulator Screenshot - iPhone 16 Pro - 2024-11-05 at 14 57 25](https://github.com/user-attachments/assets/a2236bdc-715c-4d11-9179-7a4806d2b029)
![Simulator Screenshot - iPhone 16 Pro - 2024-11-05 at 14 57 31](https://github.com/user-attachments/assets/2f7fa9d9-e65c-42cc-82f8-ef14ec68f3d1)
![Simulator Screenshot - iPhone 16 Pro - 2024-11-05 at 15 00 39](https://github.com/user-attachments/assets/f4eac670-d7cc-42b4-a552-d280ea5d69be)
![Simulator Screenshot - iPhone 16 Pro - 2024-11-05 at 15 01 04](https://github.com/user-attachments/assets/96ad1731-1331-4a04-8005-8e373d41f230)
![Simulator Screenshot - iPhone 16 Pro - 2024-11-05 at 15 07 46](https://github.com/user-attachments/assets/7611c749-2150-4add-b6b0-062e50449d8c)
