### PR TITLE
fix(suite-desktop-core): tray update setting when window open, left click on windows

### DIFF
--- a/packages/suite-desktop-api/src/api.ts
+++ b/packages/suite-desktop-api/src/api.ts
@@ -69,6 +69,8 @@ export interface RendererChannels {
     'bridge/status': Status;
     'bridge/settings': BridgeSettings;
 
+    'tray/settings': TraySettings;
+
     'handshake/event': HandshakeEvent;
 }
 

--- a/packages/suite-desktop-api/src/validation.ts
+++ b/packages/suite-desktop-api/src/validation.ts
@@ -43,5 +43,6 @@ const validChannels: Array<keyof RendererChannels> = [
     'handshake/event',
     'bridge/status',
     'bridge/settings',
+    'tray/settings',
 ];
 export const isValidChannel = (channel: any) => validChannels.includes(channel);

--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -133,8 +133,10 @@ const init = async () => {
 
     // Load bridge module first, it is required in both UI and daemon mode
     const interceptor = createInterceptor();
+    const mainWindowProxy = new MainWindowProxy();
     const { loadModules: loadBackgroundModules, quitModules: quitBackgroundModules } =
         initBackgroundModules({
+            mainWindowProxy,
             store,
             interceptor,
             mainThreadEmitter,
@@ -173,18 +175,7 @@ const init = async () => {
         mainThreadEmitter.off('app/show', handleFullStart);
     }
 
-    await initUi({ store, interceptor, quitBackgroundModules });
-};
-
-const initUi = async ({
-    store,
-    interceptor,
-    quitBackgroundModules,
-}: {
-    store: Store;
-    interceptor: RequestInterceptor;
-    quitBackgroundModules: () => Promise<any>;
-}) => {
+    // UI is opening
     const buildInfo = getBuildInfo();
     logger.info('build', buildInfo);
 
@@ -193,8 +184,6 @@ const initUi = async ({
 
     const winBounds = store.getWinBounds();
     logger.debug('init', `Create Browser Window (${winBounds.width}x${winBounds.height})`);
-
-    const mainWindowProxy = new MainWindowProxy();
 
     // init modules
     const { loadModules, quitModules } = initModules({

--- a/packages/suite-desktop-core/src/modules/index.ts
+++ b/packages/suite-desktop-core/src/modules/index.ts
@@ -105,9 +105,7 @@ type ModuleInterface = {
 
 export type ModuleInit = (dependencies: Dependencies) => ModuleInterface;
 
-export type ModuleInitBackground = (
-    dependencies: Omit<Dependencies, 'mainWindowProxy'>,
-) => ModuleInterface;
+export type ModuleInitBackground = (dependencies: Dependencies) => ModuleInterface;
 
 export type Module = { SERVICE_NAME: string; init: ModuleInit };
 export type ModuleBackground = { SERVICE_NAME: string; initBackground: ModuleInitBackground };
@@ -219,5 +217,5 @@ export const initModules = (dependencies: Dependencies) => {
     return { loadModules, quitModules };
 };
 
-export const initBackgroundModules = (dependencies: Omit<Dependencies, 'mainWindowProxy'>) =>
+export const initBackgroundModules = (dependencies: Dependencies) =>
     initModulesInner(dependencies, true, MODULES_BACKGROUND);

--- a/packages/suite-desktop-core/src/modules/tray.ts
+++ b/packages/suite-desktop-core/src/modules/tray.ts
@@ -14,7 +14,7 @@ import { mainThreadEmitter, ModuleInitBackground } from './index';
 
 export const SERVICE_NAME = 'tray';
 
-export const initBackground: ModuleInitBackground = ({ store }) => {
+export const initBackground: ModuleInitBackground = ({ store, mainWindowProxy }) => {
     const { logger } = global;
     const initialSettings = store.getTraySettings();
 
@@ -82,6 +82,9 @@ export const initBackground: ModuleInitBackground = ({ store }) => {
                         ...store.getTraySettings(),
                         showOnTray: false,
                     });
+                    mainWindowProxy
+                        .getInstance()
+                        ?.webContents.send('tray/settings', store.getTraySettings());
                     state.visible = false;
                     renderTray();
                 },
@@ -95,6 +98,12 @@ export const initBackground: ModuleInitBackground = ({ store }) => {
             },
         ]);
         tray.setContextMenu(contextMenu);
+        // Windows left click to show context menu
+        if (process.platform === 'win32') {
+            tray.on('click', () => {
+                tray?.popUpContextMenu();
+            });
+        }
     };
 
     // Listeners for events that affect state

--- a/packages/suite/src/views/settings/SettingsGeneral/ShowOnTray.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/ShowOnTray.tsx
@@ -26,6 +26,14 @@ export const ShowOnTray = () => {
     // set initial state based on real electron settings
     useEffect(() => {
         updateStatus();
+
+        desktopApi.on('tray/settings', result => {
+            setShowOnTrayEnabled(result.showOnTray);
+        });
+
+        return () => {
+            desktopApi.removeAllListeners('tray/settings');
+        };
     }, []);
 
     const handleChange = (enabled: boolean) => {


### PR DESCRIPTION
## Description

Update toggle when clicking hide in tray when the settings screen is open.
Handle left-clicking on Windows.

## Related Issue

QA in PR #15224