### PR TITLE
fix(connect): emit changed event with state change in keepSession

### DIFF
--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -696,6 +696,15 @@ const onCallDevice = async (
         }
         // Work done
 
+        if (
+            method.keepSession &&
+            method.deviceState &&
+            method.deviceState.sessionId !== device.getState()?.sessionId
+        ) {
+            // if session was changed from the one that was sent, send a device changed event
+            sendCoreMessage(createDeviceMessage(DEVICE.CHANGED, device.toMessageObject()));
+        }
+
         // TODO: This requires a massive refactoring https://github.com/trezor/trezor-suite/issues/5323
         // @ts-expect-error TODO: messageResponse should be assigned from the response of "inner" function
         const response = messageResponse;

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -67,7 +67,7 @@ const mergeDeviceState = (
         // state was previously not defined, we can set it
         device.state === undefined ||
         // update sessionId for the same staticSessionId
-        (upcomingState?.sessionId &&
+        (upcomingState &&
             device.state?.staticSessionId === upcomingState.staticSessionId &&
             device.state?.sessionId !== upcomingState.sessionId)
     ) {

--- a/suite-native/discovery/src/discoveryThunks.ts
+++ b/suite-native/discovery/src/discoveryThunks.ts
@@ -209,7 +209,6 @@ const getCardanoSupportedAccountTypesThunk = createThunk(
                 dispatch(
                     getAvailableCardanoDerivationsThunk({
                         deviceState,
-                        device,
                     }),
                 ).unwrap(),
         });


### PR DESCRIPTION
## Description

We update `sessionId` in saved device state in Suite from receiving a `DEVICE.CHANGED` event.
However this event wasn't being sent for calls with `keepSession: true`, such as during account discovery, this meant that if the passphrase was entered during those calls, it wasn't saved.

## Related Issue

Resolve #15226