### PR TITLE
feat(suite-native): sort networks according to networksConfig

### DIFF
--- a/suite-native/accounts/src/utils.ts
+++ b/suite-native/accounts/src/utils.ts
@@ -3,7 +3,7 @@ import { A, D, G } from '@mobily/ts-belt';
 import { AccountType, getNetwork, networks } from '@suite-common/wallet-config';
 import { formattedAccountTypeMap } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
-import { discoverySupportedNetworks, orderedAccountTypes } from '@suite-native/config';
+import { orderedNetworkSymbols, orderedAccountTypes } from '@suite-native/config';
 
 const accountTypeToSectionHeader: Readonly<Partial<Record<AccountType, string>>> = {
     normal: 'default',
@@ -79,8 +79,8 @@ export const groupAccountsByNetworkAccountType = A.groupBy((account: Account) =>
 
 export const sortAccountsByNetworksAndAccountTypes = (accounts: readonly Account[]) => {
     return A.sort(accounts, (a, b) => {
-        const aOrder = discoverySupportedNetworks.indexOf(a.symbol) ?? Number.MAX_SAFE_INTEGER;
-        const bOrder = discoverySupportedNetworks.indexOf(b.symbol) ?? Number.MAX_SAFE_INTEGER;
+        const aOrder = orderedNetworkSymbols.indexOf(a.symbol) ?? Number.MAX_SAFE_INTEGER;
+        const bOrder = orderedNetworkSymbols.indexOf(b.symbol) ?? Number.MAX_SAFE_INTEGER;
 
         if (aOrder === bOrder) {
             const aAccountTypeOrder =

--- a/suite-native/assets/src/assetsSelectors.ts
+++ b/suite-native/assets/src/assetsSelectors.ts
@@ -16,7 +16,7 @@ import {
 import { getAccountFiatBalance } from '@suite-common/wallet-utils';
 import { selectAccountListSections } from '@suite-native/accounts';
 import { sortAccountsByNetworksAndAccountTypes } from '@suite-native/accounts/src/utils';
-import { discoverySupportedNetworks } from '@suite-native/config';
+import { orderedNetworkSymbols } from '@suite-native/config';
 import { selectFiatCurrencyCode, SettingsSliceRootState } from '@suite-native/settings';
 import {
     NativeStakingRootState,
@@ -60,8 +60,8 @@ export const selectDeviceNetworksWithAssets = (state: AssetsRootState) => {
         A.map(account => account.symbol),
         A.uniq,
         A.sort((a, b) => {
-            const aOrder = discoverySupportedNetworks.indexOf(a) ?? Number.MAX_SAFE_INTEGER;
-            const bOrder = discoverySupportedNetworks.indexOf(b) ?? Number.MAX_SAFE_INTEGER;
+            const aOrder = orderedNetworkSymbols.indexOf(a) ?? Number.MAX_SAFE_INTEGER;
+            const bOrder = orderedNetworkSymbols.indexOf(b) ?? Number.MAX_SAFE_INTEGER;
 
             return aOrder - bOrder;
         }),

--- a/suite-native/config/src/supportedNetworks.ts
+++ b/suite-native/config/src/supportedNetworks.ts
@@ -2,6 +2,7 @@ import { A } from '@mobily/ts-belt';
 
 import { isTestnet } from '@suite-common/wallet-utils';
 import {
+    networks,
     AccountType,
     Network,
     NetworkSymbol,
@@ -48,10 +49,12 @@ export const discoverySupportedNetworks = [
     ...networkSymbolsWhitelistMap.testnet,
 ];
 
-export const sortNetworks = (networks: Network[]) =>
-    A.sort(networks, (a, b) => {
-        const aOrder = discoverySupportedNetworks.indexOf(a.symbol) ?? Number.MAX_SAFE_INTEGER;
-        const bOrder = discoverySupportedNetworks.indexOf(b.symbol) ?? Number.MAX_SAFE_INTEGER;
+export const orderedNetworkSymbols = Object.keys(networks) as NetworkSymbol[];
+
+export const sortNetworks = (networksToSort: Network[]) =>
+    A.sort(networksToSort, (a, b) => {
+        const aOrder = orderedNetworkSymbols.indexOf(a.symbol);
+        const bOrder = orderedNetworkSymbols.indexOf(b.symbol);
 
         return aOrder - bOrder;
     });
@@ -65,8 +68,11 @@ export const filterTestnetNetworks = (
     return networkSymbols.filter(networkSymbol => !isTestnet(networkSymbol));
 };
 
-export const filterBlacklistedNetworks = (networks: Network[], allowList: NetworkSymbol[]) =>
-    networks.filter(
+export const filterBlacklistedNetworks = (
+    networksToFilter: Network[],
+    allowList: NetworkSymbol[],
+) =>
+    networksToFilter.filter(
         network =>
             !discoveryBlacklist.includes(network.symbol) || allowList.includes(network.symbol),
     );

--- a/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
+++ b/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
@@ -111,7 +111,7 @@ export const useAddCoinAccount = () => {
             availableTypes.set(symbol as NetworkSymbol, [
                 NORMAL_ACCOUNT_TYPE,
                 // For Cardano and EVMs allow only normal account type
-                ...(['ada', 'eth', 'pol', 'bnb', 'sol'].includes(symbol) ? [] : types),
+                ...(['ada', 'eth', 'pol', 'bnb', 'sol', 'op'].includes(symbol) ? [] : types),
             ]);
         });
 


### PR DESCRIPTION
Use networksConfig order of networks to sort networks in the app.

## Related Issue

Resolve #15222

## Screenshots:
<img width=280 src="https://github.com/user-attachments/assets/373c6865-a85a-4cc4-8a3f-cd4ddfa73fcd" />
<img width=280 src="https://github.com/user-attachments/assets/aad4fb3e-b7fa-4580-bd7e-df0e5fb49729" />
