### PR TITLE
feat(suite-native): whitelist pol and bnb and remove feature flags

### DIFF
--- a/suite-native/config/src/supportedNetworks.ts
+++ b/suite-native/config/src/supportedNetworks.ts
@@ -17,13 +17,15 @@ export const orderedAccountTypes: AccountType[] = [
     'ledger',
 ];
 
-const discoveryBlacklist: NetworkSymbol[] = ['sol', 'dsol', 'pol', 'bnb', 'op'];
+const discoveryBlacklist: NetworkSymbol[] = ['sol', 'dsol', 'op'];
 
 // All supported coins for device discovery
 export const networkSymbolsWhitelistMap = {
     mainnet: [
         'btc',
         'eth',
+        'pol',
+        'bnb',
         'ltc',
         'etc',
         'ada',

--- a/suite-native/discovery/src/discoveryConfigSlice.ts
+++ b/suite-native/discovery/src/discoveryConfigSlice.ts
@@ -94,19 +94,11 @@ export const selectDiscoveryInfo = (state: DiscoveryConfigSliceRootState) =>
 
 export const selectFeatureFlagEnabledNetworkSymbols = memoize(
     (state: FeatureFlagsRootState & DiscoveryConfigSliceRootState) => {
-        const isPolygonEnabled = selectIsFeatureFlagEnabled(state, FeatureFlag.IsPolygonEnabled);
-        const isBscEnabled = selectIsFeatureFlagEnabled(state, FeatureFlag.IsBscEnabled);
         const isSolanaEnabled = selectIsFeatureFlagEnabled(state, FeatureFlag.IsSolanaEnabled);
         const areTestnetsEnabled = selectAreTestnetsEnabled(state);
 
         const allowlist: NetworkSymbol[] = [];
 
-        if (isPolygonEnabled) {
-            allowlist.push('pol');
-        }
-        if (isBscEnabled) {
-            allowlist.push('bnb');
-        }
         if (isSolanaEnabled) {
             allowlist.push('sol');
             if (areTestnetsEnabled) {

--- a/suite-native/feature-flags/src/featureFlagsSlice.ts
+++ b/suite-native/feature-flags/src/featureFlagsSlice.ts
@@ -8,8 +8,6 @@ export const FeatureFlag = {
     IsBitcoinLikeSendEnabled: 'isBitcoinLikeSendEnabled',
     IsEthereumSendEnabled: 'isEthereumSendEnabled',
     IsRegtestEnabled: 'isRegtestEnabled',
-    IsPolygonEnabled: 'IsPolygonEnabled',
-    IsBscEnabled: 'IsBscEnabled',
     IsSolanaEnabled: 'IsSolanaEnabled',
     IsConnectPopupEnabled: 'IsConnectPopupEnabled',
 } as const;
@@ -26,8 +24,6 @@ export const featureFlagsInitialState: FeatureFlagsState = {
     [FeatureFlag.IsBitcoinLikeSendEnabled]: isAndroid() && isDevelopOrDebugEnv(),
     [FeatureFlag.IsEthereumSendEnabled]: isAndroid() && isDevelopOrDebugEnv(),
     [FeatureFlag.IsRegtestEnabled]: isDebugEnv() || isDetoxTestBuild(),
-    [FeatureFlag.IsPolygonEnabled]: false,
-    [FeatureFlag.IsBscEnabled]: false,
     [FeatureFlag.IsSolanaEnabled]: false,
     [FeatureFlag.IsConnectPopupEnabled]: isDevelopOrDebugEnv(),
 };
@@ -37,8 +33,6 @@ export const featureFlagsPersistedKeys: Array<keyof FeatureFlagsState> = [
     FeatureFlag.IsBitcoinLikeSendEnabled,
     FeatureFlag.IsEthereumSendEnabled,
     FeatureFlag.IsRegtestEnabled,
-    FeatureFlag.IsPolygonEnabled,
-    FeatureFlag.IsBscEnabled,
     FeatureFlag.IsSolanaEnabled,
     FeatureFlag.IsConnectPopupEnabled,
 ];

--- a/suite-native/module-dev-utils/src/components/FeatureFlags.tsx
+++ b/suite-native/module-dev-utils/src/components/FeatureFlags.tsx
@@ -6,8 +6,6 @@ const featureFlagsTitleMap = {
     [FeatureFlagEnum.IsBitcoinLikeSendEnabled]: 'Bitcoin-like coins send',
     [FeatureFlagEnum.IsEthereumSendEnabled]: 'Ethereum-like coins send',
     [FeatureFlagEnum.IsRegtestEnabled]: 'Regtest',
-    [FeatureFlagEnum.IsPolygonEnabled]: 'Polygon',
-    [FeatureFlagEnum.IsBscEnabled]: 'BNB Smart Chain',
     [FeatureFlagEnum.IsSolanaEnabled]: 'Solana',
     [FeatureFlagEnum.IsConnectPopupEnabled]: 'Connect Popup',
 } as const satisfies Record<FeatureFlagEnum, string>;


### PR DESCRIPTION
Enable Polygon and BNB Smart Chain by default and remove their feature flags for.

## Related Issue

Resolve #14887