### PR TITLE
fix(suite): order of network filter

### DIFF
--- a/packages/suite/src/actions/settings/__fixtures__/walletSettings.ts
+++ b/packages/suite/src/actions/settings/__fixtures__/walletSettings.ts
@@ -46,7 +46,7 @@ export default [
         initialState: { enabledNetworks: [] },
         action: () => walletSettingsActions.changeNetworks(['ltc', 'eth']),
         result: {
-            enabledNetworks: ['ltc', 'eth'],
+            enabledNetworks: ['eth', 'ltc'],
         },
     },
     {

--- a/packages/suite/src/reducers/wallet/settingsReducer.ts
+++ b/packages/suite/src/reducers/wallet/settingsReducer.ts
@@ -1,12 +1,14 @@
 import produce from 'immer';
 
-import { WalletSettings } from '@suite-common/wallet-types';
+import type { WalletSettings } from '@suite-common/wallet-types';
 import { PROTO } from '@trezor/connect';
 
-import { STORAGE } from 'src/actions/suite/constants';
+import { networkSymbolCollection } from '@suite-common/wallet-config';
+
 import { WALLET_SETTINGS } from 'src/actions/settings/constants';
 import * as walletSettingsActions from 'src/actions/settings/walletSettingsActions';
-import { Action, AppState } from 'src/types/suite';
+import { STORAGE } from 'src/actions/suite/constants';
+import type { Action, AppState } from 'src/types/suite';
 
 export type State = WalletSettings;
 
@@ -36,7 +38,10 @@ const settingsReducer = (state: State = initialState, action: Action): State =>
 
             case walletSettingsActions.changeNetworks.type: {
                 if (walletSettingsActions.changeNetworks.match(action)) {
-                    draft.enabledNetworks = action.payload;
+                    draft.enabledNetworks = [...action.payload].sort(
+                        (a, b) =>
+                            networkSymbolCollection.indexOf(a) - networkSymbolCollection.indexOf(b),
+                    );
                 }
                 break;
             }

--- a/suite-common/wallet-config/src/utils.ts
+++ b/suite-common/wallet-config/src/utils.ts
@@ -14,6 +14,11 @@ export const NORMAL_ACCOUNT_TYPE = 'normal' satisfies AccountType;
  */
 export const networksCollection: Network[] = Object.values(networks);
 
+/**
+ * array of network symbols
+ */
+export const networkSymbolCollection = networksCollection.map(n => n.symbol);
+
 export const getMainnets = (debug = false) =>
     networksCollection.filter(n => !n.testnet && (!n.isDebugOnlyNetwork || debug));
 


### PR DESCRIPTION
## Description

Fixed order of network filter. The order is now the same as the account order.

## Related Issue

Resolve #9165