### PR TITLE
[wip] chore(connect): move firmwareRange to AbstractMethod

### DIFF
--- a/packages/connect/src/api/authenticateDevice.ts
+++ b/packages/connect/src/api/authenticateDevice.ts
@@ -2,7 +2,6 @@ import { Assert } from '@trezor/schema-utils';
 
 import { AbstractMethod } from '../core/AbstractMethod';
 import { UI } from '../events';
-import { getFirmwareRange } from './common/paramsValidator';
 import { deviceAuthenticityConfig } from '../data/deviceAuthenticityConfig';
 import { AuthenticateDeviceParams } from '../types/api/authenticateDevice';
 import { getRandomChallenge, verifyAuthenticityProof } from './firmware/verifyAuthenticityProof';
@@ -16,7 +15,7 @@ export default class AuthenticateDevice extends AbstractMethod<
         this.allowDeviceMode = [UI.INITIALIZE, UI.SEEDLESS];
         this.requiredPermissions = ['management'];
         this.useDeviceState = false;
-        this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
+        this.setFirmwareRange(this.name, null);
 
         const { payload } = this;
 

--- a/packages/connect/src/api/authorizeCoinjoin.ts
+++ b/packages/connect/src/api/authorizeCoinjoin.ts
@@ -1,7 +1,6 @@
 import { Assert } from '@trezor/schema-utils';
 
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getFirmwareRange } from './common/paramsValidator';
 import { validatePath, getScriptType } from '../utils/pathUtils';
 import { getBitcoinNetwork } from '../data/coinInfo';
 import { PROTO } from '../constants';
@@ -18,7 +17,7 @@ export default class AuthorizeCoinjoin extends AbstractMethod<
         const address_n = validatePath(payload.path, 3);
         const script_type = payload.scriptType || getScriptType(address_n);
         const coinInfo = getBitcoinNetwork(payload.coin || address_n);
-        this.firmwareRange = getFirmwareRange(this.name, coinInfo, this.firmwareRange);
+        this.setFirmwareRange(this.name, coinInfo);
         this.preauthorized = payload.preauthorized;
 
         this.params = {

--- a/packages/connect/src/api/binance/api/binanceGetAddress.ts
+++ b/packages/connect/src/api/binance/api/binanceGetAddress.ts
@@ -3,7 +3,6 @@
 import { Assert } from '@trezor/schema-utils';
 
 import { AbstractMethod, MethodReturnType } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath, fromHardened, getSerializedPath } from '../../../utils/pathUtils';
 import { PROTO, ERRORS } from '../../../constants';
@@ -23,7 +22,7 @@ export default class BinanceGetAddress extends AbstractMethod<'binanceGetAddress
         this.noBackupConfirmationMode = 'always';
         this.requiredPermissions = ['read'];
         this.requiredDeviceCapabilities = ['Capability_Binance'];
-        this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('BNB'), this.firmwareRange);
+        this.setFirmwareRange(this.name, getMiscNetwork('BNB'));
 
         // create a bundle with only one batch if bundle doesn't exists
         this.hasBundle = !!this.payload.bundle;

--- a/packages/connect/src/api/binance/api/binanceGetPublicKey.ts
+++ b/packages/connect/src/api/binance/api/binanceGetPublicKey.ts
@@ -3,7 +3,6 @@
 import { Assert } from '@trezor/schema-utils';
 
 import { AbstractMethod, MethodReturnType } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath, fromHardened, getSerializedPath } from '../../../utils/pathUtils';
 import { UI, createUiMessage } from '../../../events';
@@ -19,7 +18,7 @@ export default class BinanceGetPublicKey extends AbstractMethod<
     init() {
         this.requiredPermissions = ['read'];
         this.requiredDeviceCapabilities = ['Capability_Binance'];
-        this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('BNB'), this.firmwareRange);
+        this.setFirmwareRange(this.name, getMiscNetwork('BNB'));
 
         // create a bundle with only one batch if bundle doesn't exists
         this.hasBundle = !!this.payload.bundle;

--- a/packages/connect/src/api/binance/api/binanceSignTransaction.ts
+++ b/packages/connect/src/api/binance/api/binanceSignTransaction.ts
@@ -3,7 +3,6 @@
 import { AssertWeak } from '@trezor/schema-utils';
 
 import { AbstractMethod } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath } from '../../../utils/pathUtils';
 import * as helper from '../binanceSignTx';
@@ -23,7 +22,7 @@ export default class BinanceSignTransaction extends AbstractMethod<
     init() {
         this.requiredPermissions = ['read', 'write'];
         this.requiredDeviceCapabilities = ['Capability_Binance'];
-        this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('BNB'), this.firmwareRange);
+        this.setFirmwareRange(this.name, getMiscNetwork('BNB'));
 
         const { payload } = this;
         // validate incoming parameters

--- a/packages/connect/src/api/cancelCoinjoinAuthorization.ts
+++ b/packages/connect/src/api/cancelCoinjoinAuthorization.ts
@@ -1,7 +1,6 @@
 import { Assert } from '@trezor/schema-utils';
 
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getFirmwareRange } from './common/paramsValidator';
 import { PROTO } from '../constants';
 import { CancelCoinjoinAuthorization as CancelCoinjoinAuthorizationSchema } from '../types/api/cancelCoinjoinAuthorization';
 
@@ -14,7 +13,7 @@ export default class CancelCoinjoinAuthorization extends AbstractMethod<
 
         Assert(CancelCoinjoinAuthorizationSchema, payload);
 
-        this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
+        this.setFirmwareRange(this.name, null);
         this.preauthorized =
             typeof payload.preauthorized === 'boolean' ? payload.preauthorized : true;
     }

--- a/packages/connect/src/api/cardano/api/cardanoGetAddress.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetAddress.ts
@@ -3,7 +3,6 @@
 import { Assert } from '@trezor/schema-utils';
 
 import { AbstractMethod, MethodReturnType } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { fromHardened, getSerializedPath } from '../../../utils/pathUtils';
 import {
@@ -29,11 +28,7 @@ export default class CardanoGetAddress extends AbstractMethod<'cardanoGetAddress
         this.noBackupConfirmationMode = 'always';
         this.requiredPermissions = ['read'];
         this.requiredDeviceCapabilities = ['Capability_Cardano'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Cardano'),
-            this.firmwareRange,
-        );
+        this.setFirmwareRange(this.name, getMiscNetwork('Cardano'));
 
         // create a bundle with only one batch if bundle doesn't exists
         this.hasBundle = !!this.payload.bundle;

--- a/packages/connect/src/api/cardano/api/cardanoGetNativeScriptHash.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetNativeScriptHash.ts
@@ -4,7 +4,6 @@ import { Assert } from '@trezor/schema-utils';
 
 import { PROTO } from '../../../constants';
 import { AbstractMethod } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath } from '../../../utils/pathUtils';
 import {
@@ -19,11 +18,7 @@ export default class CardanoGetNativeScriptHash extends AbstractMethod<
     init() {
         this.requiredPermissions = ['read'];
         this.requiredDeviceCapabilities = ['Capability_Cardano'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Cardano'),
-            this.firmwareRange,
-        );
+        this.setFirmwareRange(this.name, getMiscNetwork('Cardano'));
 
         const { payload } = this;
 

--- a/packages/connect/src/api/cardano/api/cardanoGetPublicKey.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetPublicKey.ts
@@ -4,7 +4,6 @@ import { Assert } from '@trezor/schema-utils';
 
 import { PROTO } from '../../../constants';
 import { AbstractMethod, MethodReturnType } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath, fromHardened, getSerializedPath } from '../../../utils/pathUtils';
 import { UI, createUiMessage } from '../../../events';
@@ -21,11 +20,7 @@ export default class CardanoGetPublicKey extends AbstractMethod<'cardanoGetPubli
     init() {
         this.requiredPermissions = ['read'];
         this.requiredDeviceCapabilities = ['Capability_Cardano'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Cardano'),
-            this.firmwareRange,
-        );
+        this.setFirmwareRange(this.name, getMiscNetwork('Cardano'));
 
         // create a bundle with only one batch if bundle doesn't exists
         this.hasBundle = !!this.payload.bundle;

--- a/packages/connect/src/api/cardano/api/cardanoSignTransaction.ts
+++ b/packages/connect/src/api/cardano/api/cardanoSignTransaction.ts
@@ -7,7 +7,6 @@ import { trezorUtils } from '@fivebinaries/coin-selection';
 import { AssertWeak, Type } from '@trezor/schema-utils';
 
 import { AbstractMethod } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath } from '../../../utils/pathUtils';
 import {
@@ -79,11 +78,7 @@ export default class CardanoSignTransaction extends AbstractMethod<
     init() {
         this.requiredPermissions = ['read', 'write'];
         this.requiredDeviceCapabilities = ['Capability_Cardano'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Cardano'),
-            this.firmwareRange,
-        );
+        this.setFirmwareRange(this.name, getMiscNetwork('Cardano'));
 
         const { payload } = this;
 

--- a/packages/connect/src/api/cipherKeyValue.ts
+++ b/packages/connect/src/api/cipherKeyValue.ts
@@ -4,7 +4,6 @@ import { Assert } from '@trezor/schema-utils';
 
 import { UI, createUiMessage } from '../events';
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getFirmwareRange } from './common/paramsValidator';
 import { validatePath } from '../utils/pathUtils';
 import type { PROTO } from '../constants';
 import { Bundle } from '../types/params';
@@ -18,7 +17,7 @@ export default class CipherKeyValue extends AbstractMethod<
 
     init() {
         this.requiredPermissions = ['read', 'write'];
-        this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
+        this.setFirmwareRange(this.name, null);
 
         // create a bundle with only one batch if bundle doesn't exists
         this.hasBundle = !!this.payload.bundle;

--- a/packages/connect/src/api/common/__tests__/paramsValidator.test.ts
+++ b/packages/connect/src/api/common/__tests__/paramsValidator.test.ts
@@ -17,34 +17,4 @@ describe('helpers/paramsValidator', () => {
             });
         });
     });
-
-    describe('getFirmwareRange', () => {
-        afterEach(() => {
-            jest.clearAllMocks();
-        });
-        fixtures.getFirmwareRange.forEach(f => {
-            it(f.description, () => {
-                return new Promise<void>(done => {
-                    jest.resetModules();
-
-                    const mock = f.config;
-                    jest.mock('../../../data/config', () => {
-                        const actualConfig = jest.requireActual('../../../data/config').config;
-
-                        return {
-                            __esModule: true,
-                            config: mock || actualConfig,
-                        };
-                    });
-
-                    import('../paramsValidator').then(({ getFirmwareRange }) => {
-                        // added new capability
-                        // @ts-expect-error
-                        expect(getFirmwareRange(...f.params)).toEqual(f.result);
-                        done();
-                    });
-                });
-            });
-        });
-    });
 });

--- a/packages/connect/src/api/common/paramsValidator.ts
+++ b/packages/connect/src/api/common/paramsValidator.ts
@@ -1,10 +1,8 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/helpers/paramsValidator.js
-import { versionUtils } from '@trezor/utils';
 
 import { ERRORS } from '../../constants';
 import { fromHardened } from '../../utils/pathUtils';
-import { config } from '../../data/config';
-import type { CoinInfo, FirmwareRange, DeviceModelInternal } from '../../types';
+import type { CoinInfo } from '../../types';
 
 type ParamType = 'string' | 'number' | 'array' | 'array-buffer' | 'boolean' | 'uint' | 'object';
 
@@ -98,104 +96,4 @@ export const validateCoinPath = (path: number[], coinInfo?: CoinInfo) => {
     if (coinInfo && coinInfo.slip44 !== fromHardened(path[1])) {
         throw invalidParameter('Parameters "path" and "coin" do not match.');
     }
-};
-
-export const getFirmwareRange = (
-    method: string,
-    coinInfo: CoinInfo | null | undefined,
-    currentRange: FirmwareRange,
-) => {
-    const range = JSON.parse(JSON.stringify(currentRange)) as FirmwareRange;
-    const models = Object.keys(range) as DeviceModelInternal[];
-    // set minimum required firmware from coins.json (coinInfo)
-    if (coinInfo) {
-        models.forEach(model => {
-            const supportVersion = coinInfo.support ? coinInfo.support[model] : false;
-            if (supportVersion === false) {
-                range[model].min = '0';
-            } else if (
-                range[model].min !== '0' &&
-                typeof supportVersion === 'string' &&
-                versionUtils.isNewer(supportVersion, range[model].min)
-            ) {
-                range[model].min = supportVersion;
-            }
-        });
-    }
-
-    const coinType = coinInfo?.type;
-    const shortcut = coinInfo?.shortcut.toLowerCase();
-    // find firmware range in config.json
-    const configRules = config.supportedFirmware
-        .filter(rule => {
-            // check if rule applies to requested method
-            if (rule.methods) {
-                return rule.methods.includes(method);
-            }
-            // check if rule applies to capability
-            if (rule.capabilities) {
-                return rule.capabilities.includes(method);
-            }
-
-            // rule doesn't have specified methods
-            // it may be a global rule for coin or coinType
-            return true;
-        })
-        .filter(rule => {
-            // REF_TODO: there is no coinType in config. possibly obsolete code?
-            // probably still useful, we just need to define type for config and not infer it.
-            // @ts-expect-error
-            if (rule.coinType) {
-                // rule for coin type
-                // @ts-expect-error
-                return rule.coinType === coinType;
-            }
-            if (rule.coin) {
-                // rule for coin shortcut
-                // @ts-expect-error
-                return (typeof rule.coin === 'string' ? [rule.coin] : rule.coin).includes(shortcut);
-            }
-
-            // rule for method
-            return rule.methods || rule.capabilities;
-        });
-
-    configRules.forEach(rule => {
-        // override defaults
-        // NOTE:
-        // 0 may be confusing. means: no-support for "min" and unlimited support for "max"
-        if (rule.min) {
-            models.forEach(model => {
-                const modelMin = (rule.min as Record<DeviceModelInternal, string | undefined>)[
-                    model
-                ];
-                if (modelMin) {
-                    if (
-                        modelMin === '0' ||
-                        range[model].min === '0' ||
-                        !versionUtils.isNewerOrEqual(range[model].min, modelMin)
-                    ) {
-                        range[model].min = modelMin;
-                    }
-                }
-            });
-        }
-        if (rule.max) {
-            models.forEach(model => {
-                // @ts-expect-error same issue as in coinType above, config needs to be typed not inferred.
-                const modelMax = rule.max[model];
-                if (modelMax) {
-                    if (
-                        modelMax === '0' ||
-                        range[model].max === '0' ||
-                        !versionUtils.isNewerOrEqual(range[model].max, modelMax)
-                    ) {
-                        range[model].max = modelMax;
-                    }
-                }
-            });
-        }
-    });
-
-    return range;
 };

--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -7,7 +7,7 @@ import { AbstractMethod } from '../core/AbstractMethod';
 import { ERRORS } from '../constants';
 import { UI, createUiMessage } from '../events';
 import { Discovery } from './common/Discovery';
-import { validateParams, getFirmwareRange } from './common/paramsValidator';
+import { validateParams } from './common/paramsValidator';
 import * as pathUtils from '../utils/pathUtils';
 import { resolveAfter } from '../utils/promiseUtils';
 import { formatAmount } from '../utils/formatUtils';
@@ -92,7 +92,7 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
         isBackendSupported(coinInfo);
 
         // set required firmware from coinInfo support
-        this.firmwareRange = getFirmwareRange(this.name, coinInfo, this.firmwareRange);
+        this.setFirmwareRange(this.name, coinInfo);
 
         // validate each output and transform into @trezor/utxo-lib/compose format
         const outputs: ComposeOutput[] = [];

--- a/packages/connect/src/api/eos/api/eosGetPublicKey.ts
+++ b/packages/connect/src/api/eos/api/eosGetPublicKey.ts
@@ -3,7 +3,6 @@
 import { Assert } from '@trezor/schema-utils';
 
 import { AbstractMethod, MethodReturnType } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath, fromHardened, getSerializedPath } from '../../../utils/pathUtils';
 import { UI, createUiMessage } from '../../../events';
@@ -19,7 +18,7 @@ export default class EosGetPublicKey extends AbstractMethod<
     init() {
         this.requiredPermissions = ['read'];
         this.requiredDeviceCapabilities = ['Capability_EOS'];
-        this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('EOS'), this.firmwareRange);
+        this.setFirmwareRange(this.name, getMiscNetwork('EOS'));
 
         // create a bundle with only one batch if bundle doesn't exists
         this.hasBundle = !!this.payload.bundle;

--- a/packages/connect/src/api/eos/api/eosSignTransaction.ts
+++ b/packages/connect/src/api/eos/api/eosSignTransaction.ts
@@ -3,7 +3,6 @@
 import { AssertWeak } from '@trezor/schema-utils';
 
 import { AbstractMethod } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath } from '../../../utils/pathUtils';
 import * as helper from '../eosSignTx';
@@ -22,7 +21,7 @@ export default class EosSignTransaction extends AbstractMethod<'eosSignTransacti
     init() {
         this.requiredPermissions = ['read', 'write'];
         this.requiredDeviceCapabilities = ['Capability_EOS'];
-        this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('EOS'), this.firmwareRange);
+        this.setFirmwareRange(this.name, getMiscNetwork('EOS'));
 
         const { payload } = this;
         // validate incoming parameters

--- a/packages/connect/src/api/ethereum/api/ethereumGetAddress.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumGetAddress.ts
@@ -3,7 +3,6 @@
 import { Assert } from '@trezor/schema-utils';
 
 import { AbstractMethod, MethodReturnType } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import { validatePath, getSerializedPath, getSlip44ByPath } from '../../../utils/pathUtils';
 import { getNetworkLabel } from '../../../utils/ethereumUtils';
 import { getEthereumNetwork, getUniqueNetworks } from '../../../data/coinInfo';
@@ -46,7 +45,7 @@ export default class EthereumGetAddress extends AbstractMethod<'ethereumGetAddre
         this.params = payload.bundle.map(batch => {
             const path = validatePath(batch.path, 3);
             const network = getEthereumNetwork(path);
-            this.firmwareRange = getFirmwareRange(this.name, network, this.firmwareRange);
+            this.setFirmwareRange(this.name, network);
 
             return {
                 address_n: path,

--- a/packages/connect/src/api/ethereum/api/ethereumGetPublicKey.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumGetPublicKey.ts
@@ -3,7 +3,6 @@
 import { Assert } from '@trezor/schema-utils';
 
 import { AbstractMethod, MethodReturnType } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import { validatePath } from '../../../utils/pathUtils';
 import { getNetworkLabel } from '../../../utils/ethereumUtils';
 import { getEthereumNetwork, getUniqueNetworks } from '../../../data/coinInfo';
@@ -35,7 +34,7 @@ export default class EthereumGetPublicKey extends AbstractMethod<'ethereumGetPub
         this.params = payload.bundle.map(batch => {
             const path = validatePath(batch.path, 3);
             const network = getEthereumNetwork(path);
-            this.firmwareRange = getFirmwareRange(this.name, network, this.firmwareRange);
+            this.setFirmwareRange(this.name, network);
 
             return {
                 address_n: path,

--- a/packages/connect/src/api/ethereum/api/ethereumSignMessage.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumSignMessage.ts
@@ -4,7 +4,6 @@ import { MessagesSchema } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
 import { AbstractMethod } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import { getSlip44ByPath, validatePath } from '../../../utils/pathUtils';
 import { getEthereumNetwork } from '../../../data/coinInfo';
 import { getNetworkLabel } from '../../../utils/ethereumUtils';
@@ -33,7 +32,7 @@ export default class EthereumSignMessage extends AbstractMethod<'ethereumSignMes
 
         const path = validatePath(payload.path, 3);
         const network = getEthereumNetwork(path);
-        this.firmwareRange = getFirmwareRange(this.name, network, this.firmwareRange);
+        this.setFirmwareRange(this.name, network);
 
         const messageHex = payload.hex
             ? messageToHex(payload.message)

--- a/packages/connect/src/api/ethereum/api/ethereumSignTransaction.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumSignTransaction.ts
@@ -6,7 +6,6 @@ import { MessagesSchema } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
 import { AbstractMethod } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import { getSlip44ByPath, validatePath } from '../../../utils/pathUtils';
 import { getEthereumNetwork } from '../../../data/coinInfo';
 import { getNetworkLabel } from '../../../utils/ethereumUtils';
@@ -73,11 +72,7 @@ export default class EthereumSignTransaction extends AbstractMethod<
 
         // get firmware range depending on used transaction type
         // eip1559 is possible since 2.4.2
-        this.firmwareRange = getFirmwareRange(
-            isEIP1559 ? 'eip1559' : this.name,
-            network,
-            this.firmwareRange,
-        );
+        this.setFirmwareRange(isEIP1559 ? 'eip1559' : this.name, network);
 
         if (isEIP1559) {
             this.params = { path, network, type: 'eip1559', tx: strip(tx), chunkify };

--- a/packages/connect/src/api/ethereum/api/ethereumSignTypedData.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumSignTypedData.ts
@@ -4,7 +4,6 @@ import { MessagesSchema } from '@trezor/protobuf';
 import { Assert, Type } from '@trezor/schema-utils';
 
 import { AbstractMethod } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import { getSlip44ByPath, validatePath } from '../../../utils/pathUtils';
 import { getEthereumNetwork } from '../../../data/coinInfo';
 import { getNetworkLabel } from '../../../utils/ethereumUtils';
@@ -52,7 +51,7 @@ export default class EthereumSignTypedData extends AbstractMethod<'ethereumSignT
 
         const path = validatePath(payload.path, 3);
         const network = getEthereumNetwork(path);
-        this.firmwareRange = getFirmwareRange(this.name, network, this.firmwareRange);
+        this.setFirmwareRange(this.name, network);
 
         this.params = {
             address_n: path,
@@ -85,11 +84,7 @@ export default class EthereumSignTypedData extends AbstractMethod<'ethereumSignT
         if (this.params.data.primaryType === 'EIP712Domain') {
             // Only newer firmwares support this feature
             // Older firmwares will give wrong results / throw errors
-            this.firmwareRange = getFirmwareRange(
-                'eip712-domain-only',
-                network,
-                this.firmwareRange,
-            );
+            this.setFirmwareRange('eip712-domain-only', network);
 
             if ('message_hash' in this.params) {
                 throw ERRORS.TypedError(

--- a/packages/connect/src/api/ethereum/api/ethereumVerifyMessage.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumVerifyMessage.ts
@@ -3,7 +3,6 @@
 import { Assert } from '@trezor/schema-utils';
 
 import { AbstractMethod } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import { stripHexPrefix, messageToHex } from '../../../utils/formatUtils';
 import type { PROTO } from '../../../constants';
 import { EthereumVerifyMessage as EthereumVerifyMessageSchema } from '../../../types';
@@ -14,7 +13,7 @@ export default class EthereumVerifyMessage extends AbstractMethod<
 > {
     init() {
         this.requiredPermissions = ['read', 'write'];
-        this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
+        this.setFirmwareRange(this.name, null);
         this.requiredDeviceCapabilities = ['Capability_Ethereum'];
 
         const { payload } = this;

--- a/packages/connect/src/api/getAccountDescriptor.ts
+++ b/packages/connect/src/api/getAccountDescriptor.ts
@@ -1,7 +1,6 @@
 import { Assert } from '@trezor/schema-utils';
 
-import { AbstractMethod, MethodReturnType, DEFAULT_FIRMWARE_RANGE } from '../core/AbstractMethod';
-import { getFirmwareRange } from './common/paramsValidator';
+import { AbstractMethod, MethodReturnType } from '../core/AbstractMethod';
 import { validatePath, getSerializedPath } from '../utils/pathUtils';
 import { getAccountLabel } from '../utils/accountUtils';
 import { getCoinInfo } from '../data/coinInfo';
@@ -46,7 +45,7 @@ export default class GetAccountDescriptor extends AbstractMethod<
             const address_n = validatePath(batch.path, 3);
 
             // set firmware range
-            this.firmwareRange = getFirmwareRange(this.name, coinInfo, this.firmwareRange);
+            this.setFirmwareRange(this.name, coinInfo);
 
             return {
                 ...batch,
@@ -110,11 +109,7 @@ export default class GetAccountDescriptor extends AbstractMethod<
         const invalid = [];
         for (let i = 0; i < this.params.length; i++) {
             // set FW range for current batch
-            this.firmwareRange = getFirmwareRange(
-                this.name,
-                this.params[i].coinInfo,
-                DEFAULT_FIRMWARE_RANGE,
-            );
+            this.setFirmwareRange(this.name, this.params[i].coinInfo);
             const exception = super.checkFirmwareRange();
             if (exception) {
                 invalid.push({

--- a/packages/connect/src/api/getAccountInfo.ts
+++ b/packages/connect/src/api/getAccountInfo.ts
@@ -1,8 +1,8 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/GetAccountInfo.js
 
-import { AbstractMethod, MethodReturnType, DEFAULT_FIRMWARE_RANGE } from '../core/AbstractMethod';
+import { AbstractMethod, MethodReturnType } from '../core/AbstractMethod';
 import { Discovery } from './common/Discovery';
-import { validateParams, getFirmwareRange } from './common/paramsValidator';
+import { validateParams } from './common/paramsValidator';
 import { validatePath, getSerializedPath } from '../utils/pathUtils';
 import { getAccountLabel, isUtxoBased } from '../utils/accountUtils';
 import { resolveAfter } from '../utils/promiseUtils';
@@ -82,7 +82,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
             }
 
             // set firmware range
-            this.firmwareRange = getFirmwareRange(this.name, coinInfo, this.firmwareRange);
+            this.setFirmwareRange(this.name, coinInfo);
 
             return {
                 ...batch,
@@ -165,11 +165,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
         const invalid = [];
         for (let i = 0; i < this.params.length; i++) {
             // set FW range for current batch
-            this.firmwareRange = getFirmwareRange(
-                this.name,
-                this.params[i].coinInfo,
-                DEFAULT_FIRMWARE_RANGE,
-            );
+            this.setFirmwareRange(this.name, this.params[i].coinInfo);
             const exception = super.checkFirmwareRange();
             if (exception) {
                 invalid.push({

--- a/packages/connect/src/api/getAddress.ts
+++ b/packages/connect/src/api/getAddress.ts
@@ -3,7 +3,7 @@
 import { Assert } from '@trezor/schema-utils';
 
 import { AbstractMethod, MethodReturnType } from '../core/AbstractMethod';
-import { validateCoinPath, getFirmwareRange } from './common/paramsValidator';
+import { validateCoinPath } from './common/paramsValidator';
 import { validatePath, getLabel, getSerializedPath } from '../utils/pathUtils';
 import { getBitcoinNetwork, fixCoinInfoNetwork, getUniqueNetworks } from '../data/coinInfo';
 import { PROTO, ERRORS } from '../constants';
@@ -59,7 +59,7 @@ export default class GetAddress extends AbstractMethod<'getAddress', Params[]> {
                 throw ERRORS.TypedError('Method_UnknownCoin');
             } else if (coinInfo) {
                 // set required firmware from coinInfo support
-                this.firmwareRange = getFirmwareRange(this.name, coinInfo, this.firmwareRange);
+                this.setFirmwareRange(this.name, coinInfo);
             }
 
             // fix coinInfo network values (segwit/legacy)

--- a/packages/connect/src/api/getFirmwareHash.ts
+++ b/packages/connect/src/api/getFirmwareHash.ts
@@ -3,7 +3,6 @@ import { Assert } from '@trezor/schema-utils';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { PROTO } from '../constants';
 import { UI } from '../events';
-import { getFirmwareRange } from './common/paramsValidator';
 
 export default class GetFirmwareHash extends AbstractMethod<
     'getFirmwareHash',
@@ -19,7 +18,7 @@ export default class GetFirmwareHash extends AbstractMethod<
 
         Assert(PROTO.GetFirmwareHash, payload);
 
-        this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
+        this.setFirmwareRange(this.name, null);
 
         this.params = {
             challenge: payload.challenge,

--- a/packages/connect/src/api/getOwnershipId.ts
+++ b/packages/connect/src/api/getOwnershipId.ts
@@ -1,7 +1,6 @@
 import { Assert } from '@trezor/schema-utils';
 
 import { AbstractMethod, MethodReturnType } from '../core/AbstractMethod';
-import { getFirmwareRange } from './common/paramsValidator';
 import { validatePath, getScriptType, getSerializedPath } from '../utils/pathUtils';
 import { getBitcoinNetwork } from '../data/coinInfo';
 import { PROTO } from '../constants';
@@ -31,7 +30,7 @@ export default class GetOwnershipId extends AbstractMethod<
             const address_n = validatePath(batch.path, 1);
             const coinInfo = getBitcoinNetwork(batch.coin || address_n);
             const script_type = batch.scriptType || getScriptType(address_n);
-            this.firmwareRange = getFirmwareRange(this.name, coinInfo, this.firmwareRange);
+            this.setFirmwareRange(this.name, coinInfo);
 
             return {
                 address_n,

--- a/packages/connect/src/api/getOwnershipProof.ts
+++ b/packages/connect/src/api/getOwnershipProof.ts
@@ -1,7 +1,6 @@
 import { Assert } from '@trezor/schema-utils';
 
 import { AbstractMethod, MethodReturnType } from '../core/AbstractMethod';
-import { getFirmwareRange } from './common/paramsValidator';
 import { validatePath, getScriptType, getSerializedPath } from '../utils/pathUtils';
 import { getBitcoinNetwork } from '../data/coinInfo';
 import { PROTO } from '../constants';
@@ -31,7 +30,7 @@ export default class GetOwnershipProof extends AbstractMethod<
             const address_n = validatePath(batch.path, 1);
             const coinInfo = getBitcoinNetwork(batch.coin || address_n);
             const script_type = batch.scriptType || getScriptType(address_n);
-            this.firmwareRange = getFirmwareRange(this.name, coinInfo, this.firmwareRange);
+            this.setFirmwareRange(this.name, coinInfo);
             if (batch.preauthorized) {
                 this.preauthorized = batch.preauthorized;
             }

--- a/packages/connect/src/api/getPublicKey.ts
+++ b/packages/connect/src/api/getPublicKey.ts
@@ -3,7 +3,7 @@
 import { Assert } from '@trezor/schema-utils';
 
 import { AbstractMethod, MethodReturnType } from '../core/AbstractMethod';
-import { validateCoinPath, getFirmwareRange } from './common/paramsValidator';
+import { validateCoinPath } from './common/paramsValidator';
 import { validatePath } from '../utils/pathUtils';
 import { UI, createUiMessage } from '../events';
 import { getBitcoinNetwork } from '../data/coinInfo';
@@ -52,7 +52,7 @@ export default class GetPublicKey extends AbstractMethod<'getPublicKey', Params[
             }
 
             // set required firmware from coinInfo support
-            this.firmwareRange = getFirmwareRange(this.name, coinInfo, this.firmwareRange);
+            this.setFirmwareRange(this.name, coinInfo);
 
             return {
                 address_n,

--- a/packages/connect/src/api/loadDevice.ts
+++ b/packages/connect/src/api/loadDevice.ts
@@ -2,7 +2,6 @@ import { Assert } from '@trezor/schema-utils';
 
 import { AbstractMethod } from '../core/AbstractMethod';
 import { UI } from '../events';
-import { getFirmwareRange } from './common/paramsValidator';
 import { PROTO } from '../constants';
 
 export default class LoadDevice extends AbstractMethod<'loadDevice', PROTO.LoadDevice> {
@@ -10,7 +9,7 @@ export default class LoadDevice extends AbstractMethod<'loadDevice', PROTO.LoadD
         this.allowDeviceMode = [UI.INITIALIZE];
         this.useDeviceState = false;
         this.requiredPermissions = ['management'];
-        this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
+        this.setFirmwareRange(this.name, null);
 
         const { payload } = this;
         // validate bundle type

--- a/packages/connect/src/api/nem/api/nemGetAddress.ts
+++ b/packages/connect/src/api/nem/api/nemGetAddress.ts
@@ -3,7 +3,6 @@
 import { Assert } from '@trezor/schema-utils';
 
 import { AbstractMethod, MethodReturnType } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath, fromHardened, getSerializedPath } from '../../../utils/pathUtils';
 import { PROTO, ERRORS } from '../../../constants';
@@ -27,7 +26,7 @@ export default class NEMGetAddress extends AbstractMethod<'nemGetAddress', Param
         this.noBackupConfirmationMode = 'always';
         this.requiredPermissions = ['read'];
         this.requiredDeviceCapabilities = ['Capability_NEM'];
-        this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('NEM'), this.firmwareRange);
+        this.setFirmwareRange(this.name, getMiscNetwork('NEM'));
 
         // create a bundle with only one batch if bundle doesn't exists
         this.hasBundle = !!this.payload.bundle;

--- a/packages/connect/src/api/nem/api/nemSignTransaction.ts
+++ b/packages/connect/src/api/nem/api/nemSignTransaction.ts
@@ -3,7 +3,6 @@
 import { AssertWeak } from '@trezor/schema-utils';
 
 import { AbstractMethod } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath } from '../../../utils/pathUtils';
 import * as helper from '../nemSignTx';
@@ -17,7 +16,7 @@ export default class NEMSignTransaction extends AbstractMethod<
     init() {
         this.requiredPermissions = ['read', 'write'];
         this.requiredDeviceCapabilities = ['Capability_NEM'];
-        this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('NEM'), this.firmwareRange);
+        this.setFirmwareRange(this.name, getMiscNetwork('NEM'));
 
         const { payload } = this;
         // validate incoming parameters

--- a/packages/connect/src/api/rebootToBootloader.ts
+++ b/packages/connect/src/api/rebootToBootloader.ts
@@ -3,7 +3,6 @@
 import { Assert } from '@trezor/schema-utils';
 
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getFirmwareRange } from './common/paramsValidator';
 import { UI } from '../events';
 import { PROTO } from '../constants';
 
@@ -17,7 +16,7 @@ export default class RebootToBootloader extends AbstractMethod<
         this.keepSession = false;
         this.requiredPermissions = ['management'];
         this.useDeviceState = false;
-        this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
+        this.setFirmwareRange(this.name, null);
 
         const { payload } = this;
         Assert(PROTO.RebootToBootloader, payload);

--- a/packages/connect/src/api/requestLogin.ts
+++ b/packages/connect/src/api/requestLogin.ts
@@ -3,7 +3,6 @@
 import { Assert, Type } from '@trezor/schema-utils';
 
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getFirmwareRange } from './common/paramsValidator';
 import { ERRORS } from '../constants';
 import { UI, createUiMessage } from '../events';
 import { DataManager } from '../data/DataManager';
@@ -16,7 +15,7 @@ export default class RequestLogin extends AbstractMethod<'requestLogin', PROTO.S
 
     init() {
         this.requiredPermissions = ['read', 'write'];
-        this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
+        this.setFirmwareRange(this.name, null);
         this.useEmptyPassphrase = true;
 
         const { payload } = this;

--- a/packages/connect/src/api/resetDevice.ts
+++ b/packages/connect/src/api/resetDevice.ts
@@ -4,7 +4,6 @@ import { Assert } from '@trezor/schema-utils';
 
 import { AbstractMethod } from '../core/AbstractMethod';
 import { UI } from '../events';
-import { getFirmwareRange } from './common/paramsValidator';
 import { PROTO } from '../constants';
 
 export default class ResetDevice extends AbstractMethod<'resetDevice', PROTO.ResetDevice> {
@@ -12,7 +11,7 @@ export default class ResetDevice extends AbstractMethod<'resetDevice', PROTO.Res
         this.allowDeviceMode = [UI.INITIALIZE, UI.SEEDLESS];
         this.useDeviceState = false;
         this.requiredPermissions = ['management'];
-        this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
+        this.setFirmwareRange(this.name, null);
 
         const { payload } = this;
         // validate bundle type

--- a/packages/connect/src/api/ripple/api/rippleGetAddress.ts
+++ b/packages/connect/src/api/ripple/api/rippleGetAddress.ts
@@ -3,7 +3,6 @@
 import { Assert } from '@trezor/schema-utils';
 
 import { AbstractMethod, MethodReturnType } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath, fromHardened, getSerializedPath } from '../../../utils/pathUtils';
 import { PROTO, ERRORS } from '../../../constants';
@@ -23,11 +22,7 @@ export default class RippleGetAddress extends AbstractMethod<'rippleGetAddress',
         this.noBackupConfirmationMode = 'always';
         this.requiredPermissions = ['read'];
         this.requiredDeviceCapabilities = ['Capability_Ripple'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Ripple'),
-            this.firmwareRange,
-        );
+        this.setFirmwareRange(this.name, getMiscNetwork('Ripple'));
 
         // create a bundle with only one batch if bundle doesn't exists
         this.hasBundle = !!this.payload.bundle;

--- a/packages/connect/src/api/ripple/api/rippleSignTransaction.ts
+++ b/packages/connect/src/api/ripple/api/rippleSignTransaction.ts
@@ -3,7 +3,6 @@
 import { AssertWeak } from '@trezor/schema-utils';
 
 import { AbstractMethod } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath } from '../../../utils/pathUtils';
 import type { PROTO } from '../../../constants';
@@ -16,11 +15,7 @@ export default class RippleSignTransaction extends AbstractMethod<
     init() {
         this.requiredPermissions = ['read', 'write'];
         this.requiredDeviceCapabilities = ['Capability_Ripple'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Ripple'),
-            this.firmwareRange,
-        );
+        this.setFirmwareRange(this.name, getMiscNetwork('Ripple'));
 
         const { payload } = this;
         // validate incoming parameters

--- a/packages/connect/src/api/setBusy.ts
+++ b/packages/connect/src/api/setBusy.ts
@@ -3,7 +3,6 @@ import { Assert } from '@trezor/schema-utils';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { DEVICE, createDeviceMessage } from '../events';
 import { PROTO } from '../constants';
-import { getFirmwareRange } from './common/paramsValidator';
 
 export default class SetBusy extends AbstractMethod<'setBusy', PROTO.SetBusy> {
     init() {
@@ -14,7 +13,7 @@ export default class SetBusy extends AbstractMethod<'setBusy', PROTO.SetBusy> {
 
         Assert(PROTO.SetBusy, payload);
 
-        this.firmwareRange = getFirmwareRange(this.name, undefined, this.firmwareRange);
+        this.setFirmwareRange(this.name, undefined);
 
         this.params = {
             expiry_ms: payload.expiry_ms,

--- a/packages/connect/src/api/showDeviceTutorial.ts
+++ b/packages/connect/src/api/showDeviceTutorial.ts
@@ -1,5 +1,4 @@
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getFirmwareRange } from './common/paramsValidator';
 import { PROTO } from '../constants';
 import { UI } from '../events';
 
@@ -8,7 +7,7 @@ export default class ShowDeviceTutorial extends AbstractMethod<
     PROTO.ShowDeviceTutorial
 > {
     init() {
-        this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
+        this.setFirmwareRange(this.name, null);
         this.useEmptyPassphrase = true;
         this.useDeviceState = false;
         this.allowDeviceMode = [UI.INITIALIZE];

--- a/packages/connect/src/api/signMessage.ts
+++ b/packages/connect/src/api/signMessage.ts
@@ -3,7 +3,7 @@
 import { Assert } from '@trezor/schema-utils';
 
 import { AbstractMethod } from '../core/AbstractMethod';
-import { validateCoinPath, getFirmwareRange } from './common/paramsValidator';
+import { validateCoinPath } from './common/paramsValidator';
 import { validatePath, getLabel, getScriptType } from '../utils/pathUtils';
 import { getBitcoinNetwork } from '../data/coinInfo';
 import { messageToHex } from '../utils/formatUtils';
@@ -31,10 +31,9 @@ export default class SignMessage extends AbstractMethod<'signMessage', PROTO.Sig
 
         // firmware range depends on used no_script_type parameter
         // no_script_type is possible since 1.10.4 / 2.4.3
-        this.firmwareRange = getFirmwareRange(
+        this.setFirmwareRange(
             payload.no_script_type ? 'signMessageNoScriptType' : this.name,
             coinInfo,
-            this.firmwareRange,
         );
 
         const messageHex = payload.hex

--- a/packages/connect/src/api/signTransaction.ts
+++ b/packages/connect/src/api/signTransaction.ts
@@ -3,7 +3,7 @@
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { AbstractMethod } from '../core/AbstractMethod';
-import { validateParams, getFirmwareRange } from './common/paramsValidator';
+import { validateParams } from './common/paramsValidator';
 import { getBitcoinNetwork } from '../data/coinInfo';
 import { getLabel } from '../utils/pathUtils';
 import { PROTO, ERRORS } from '../constants';
@@ -87,7 +87,7 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
             throw ERRORS.TypedError('Method_UnknownCoin');
         }
         // set required firmware from coinInfo support
-        this.firmwareRange = getFirmwareRange(this.name, coinInfo, this.firmwareRange);
+        this.setFirmwareRange(this.name, coinInfo);
         this.preauthorized = payload.preauthorized;
 
         const inputs = validateTrezorInputs(payload.inputs, coinInfo);

--- a/packages/connect/src/api/solana/api/solanaGetAddress.ts
+++ b/packages/connect/src/api/solana/api/solanaGetAddress.ts
@@ -2,7 +2,6 @@ import { Assert } from '@trezor/schema-utils';
 
 import { ERRORS, PROTO } from '../../../constants';
 import { AbstractMethod, MethodReturnType } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath, fromHardened, getSerializedPath } from '../../../utils/pathUtils';
 import { UI, createUiMessage } from '../../../events';
@@ -21,11 +20,7 @@ export default class SolanaGetAddress extends AbstractMethod<'solanaGetAddress',
         this.noBackupConfirmationMode = 'always';
         this.requiredPermissions = ['read'];
         this.requiredDeviceCapabilities = ['Capability_Solana'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Solana'),
-            this.firmwareRange,
-        );
+        this.setFirmwareRange(this.name, getMiscNetwork('Solana'));
 
         // create a bundle with only one batch if bundle doesn't exists
         this.hasBundle = !!this.payload.bundle;

--- a/packages/connect/src/api/solana/api/solanaGetPublicKey.ts
+++ b/packages/connect/src/api/solana/api/solanaGetPublicKey.ts
@@ -2,7 +2,6 @@ import { Assert } from '@trezor/schema-utils';
 
 import { PROTO } from '../../../constants';
 import { AbstractMethod, MethodReturnType } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath, fromHardened, getSerializedPath } from '../../../utils/pathUtils';
 import { UI, createUiMessage } from '../../../events';
@@ -18,11 +17,7 @@ export default class SolanaGetPublicKey extends AbstractMethod<
         this.noBackupConfirmationMode = 'always';
         this.requiredPermissions = ['read'];
         this.requiredDeviceCapabilities = ['Capability_Solana'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Solana'),
-            this.firmwareRange,
-        );
+        this.setFirmwareRange(this.name, getMiscNetwork('Solana'));
 
         // create a bundle with only one batch if bundle doesn't exists
         this.hasBundle = !!this.payload.bundle;

--- a/packages/connect/src/api/solana/api/solanaSignTransaction.ts
+++ b/packages/connect/src/api/solana/api/solanaSignTransaction.ts
@@ -2,7 +2,6 @@ import { AssertWeak } from '@trezor/schema-utils';
 
 import { PROTO } from '../../../constants';
 import { AbstractMethod } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath } from '../../../utils/pathUtils';
 import { transformAdditionalInfo } from '../additionalInfo';
@@ -15,11 +14,7 @@ export default class SolanaSignTransaction extends AbstractMethod<
     init() {
         this.requiredPermissions = ['read', 'write'];
         this.requiredDeviceCapabilities = ['Capability_Solana'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Solana'),
-            this.firmwareRange,
-        );
+        this.setFirmwareRange(this.name, getMiscNetwork('Solana'));
 
         const { payload } = this;
 

--- a/packages/connect/src/api/stellar/api/stellarGetAddress.ts
+++ b/packages/connect/src/api/stellar/api/stellarGetAddress.ts
@@ -3,7 +3,6 @@
 import { Assert } from '@trezor/schema-utils';
 
 import { AbstractMethod, MethodReturnType } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath, fromHardened, getSerializedPath } from '../../../utils/pathUtils';
 import { PROTO, ERRORS } from '../../../constants';
@@ -23,11 +22,7 @@ export default class StellarGetAddress extends AbstractMethod<'stellarGetAddress
         this.noBackupConfirmationMode = 'always';
         this.requiredPermissions = ['read'];
         this.requiredDeviceCapabilities = ['Capability_Stellar'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Stellar'),
-            this.firmwareRange,
-        );
+        this.setFirmwareRange(this.name, getMiscNetwork('Stellar'));
 
         // create a bundle with only one batch if bundle doesn't exists
         this.hasBundle = !!this.payload.bundle;

--- a/packages/connect/src/api/stellar/api/stellarSignTransaction.ts
+++ b/packages/connect/src/api/stellar/api/stellarSignTransaction.ts
@@ -3,7 +3,6 @@
 import { AssertWeak } from '@trezor/schema-utils';
 
 import { AbstractMethod } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath } from '../../../utils/pathUtils';
 import * as helper from '../stellarSignTx';
@@ -31,11 +30,7 @@ export default class StellarSignTransaction extends AbstractMethod<
     init() {
         this.requiredPermissions = ['read', 'write'];
         this.requiredDeviceCapabilities = ['Capability_Stellar'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Stellar'),
-            this.firmwareRange,
-        );
+        this.setFirmwareRange(this.name, getMiscNetwork('Stellar'));
 
         const { payload } = this;
         // validate incoming parameters

--- a/packages/connect/src/api/tezos/api/tezosGetAddress.ts
+++ b/packages/connect/src/api/tezos/api/tezosGetAddress.ts
@@ -3,7 +3,6 @@
 import { Assert } from '@trezor/schema-utils';
 
 import { AbstractMethod, MethodReturnType } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath, fromHardened, getSerializedPath } from '../../../utils/pathUtils';
 import { PROTO, ERRORS } from '../../../constants';
@@ -23,11 +22,7 @@ export default class TezosGetAddress extends AbstractMethod<'tezosGetAddress', P
         this.noBackupConfirmationMode = 'always';
         this.requiredPermissions = ['read'];
         this.requiredDeviceCapabilities = ['Capability_Tezos'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Tezos'),
-            this.firmwareRange,
-        );
+        this.setFirmwareRange(this.name, getMiscNetwork('Tezos'));
 
         // create a bundle with only one batch if bundle doesn't exists
         this.hasBundle = !!this.payload.bundle;

--- a/packages/connect/src/api/tezos/api/tezosGetPublicKey.ts
+++ b/packages/connect/src/api/tezos/api/tezosGetPublicKey.ts
@@ -3,7 +3,6 @@
 import { Assert } from '@trezor/schema-utils';
 
 import { AbstractMethod, MethodReturnType } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath, fromHardened, getSerializedPath } from '../../../utils/pathUtils';
 import { UI, createUiMessage } from '../../../events';
@@ -19,11 +18,7 @@ export default class TezosGetPublicKey extends AbstractMethod<
     init() {
         this.requiredPermissions = ['read'];
         this.requiredDeviceCapabilities = ['Capability_Tezos'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Tezos'),
-            this.firmwareRange,
-        );
+        this.setFirmwareRange(this.name, getMiscNetwork('Tezos'));
 
         // create a bundle with only one batch if bundle doesn't exists
         this.hasBundle = !!this.payload.bundle;

--- a/packages/connect/src/api/tezos/api/tezosSignTransaction.ts
+++ b/packages/connect/src/api/tezos/api/tezosSignTransaction.ts
@@ -3,7 +3,6 @@
 import { AssertWeak } from '@trezor/schema-utils';
 
 import { AbstractMethod } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath } from '../../../utils/pathUtils';
 import * as helper from '../tezosSignTx';
@@ -17,11 +16,7 @@ export default class TezosSignTransaction extends AbstractMethod<
     init() {
         this.requiredPermissions = ['read', 'write'];
         this.requiredDeviceCapabilities = ['Capability_Tezos'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Tezos'),
-            this.firmwareRange,
-        );
+        this.setFirmwareRange(this.name, getMiscNetwork('Tezos'));
 
         const { payload } = this;
 

--- a/packages/connect/src/api/unlockPath.ts
+++ b/packages/connect/src/api/unlockPath.ts
@@ -3,14 +3,13 @@ import { Assert } from '@trezor/schema-utils';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { PROTO } from '../constants';
 import { validatePath } from '../utils/pathUtils';
-import { getFirmwareRange } from './common/paramsValidator';
 import { UnlockPathParams } from '../types/api/unlockPath';
 
 export default class UnlockPath extends AbstractMethod<'unlockPath', PROTO.UnlockPath> {
     init() {
         this.requiredPermissions = ['read'];
         this.skipFinalReload = true;
-        this.firmwareRange = getFirmwareRange(this.name, undefined, this.firmwareRange);
+        this.setFirmwareRange(this.name, undefined);
 
         const { payload } = this;
 

--- a/packages/connect/src/api/verifyMessage.ts
+++ b/packages/connect/src/api/verifyMessage.ts
@@ -3,7 +3,6 @@
 import { Assert } from '@trezor/schema-utils';
 
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getFirmwareRange } from './common/paramsValidator';
 import { getBitcoinNetwork } from '../data/coinInfo';
 import { getLabel } from '../utils/pathUtils';
 import { messageToHex } from '../utils/formatUtils';
@@ -24,7 +23,7 @@ export default class VerifyMessage extends AbstractMethod<'verifyMessage', PROTO
             throw ERRORS.TypedError('Method_UnknownCoin');
         } else {
             // check required firmware with coinInfo support
-            this.firmwareRange = getFirmwareRange(this.name, coinInfo, this.firmwareRange);
+            this.setFirmwareRange(this.name, coinInfo);
         }
         const messageHex = payload.hex
             ? messageToHex(payload.message)

--- a/packages/connect/src/api/wipeDevice.ts
+++ b/packages/connect/src/api/wipeDevice.ts
@@ -2,14 +2,13 @@
 
 import { AbstractMethod } from '../core/AbstractMethod';
 import { UI, DEVICE } from '../events';
-import { getFirmwareRange } from './common/paramsValidator';
 
 export default class WipeDevice extends AbstractMethod<'wipeDevice'> {
     init() {
         this.allowDeviceMode = [UI.INITIALIZE, UI.SEEDLESS, UI.BOOTLOADER];
         this.useDeviceState = false;
         this.requiredPermissions = ['management'];
-        this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
+        this.setFirmwareRange(this.name, null);
     }
 
     get confirmation() {

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -22,6 +22,8 @@ import type {
     StaticSessionId,
     DeviceUniquePath,
     ConnectSettings,
+    CoinInfo,
+    DeviceModelInternal,
 } from '../types';
 import { config } from '../data/config';
 
@@ -361,4 +363,102 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
     abstract run(): Promise<MethodReturnType<Name>>;
 
     dispose() {}
+
+    setFirmwareRange(method: string, coinInfo: CoinInfo | null | undefined) {
+        const range = JSON.parse(JSON.stringify(this.firmwareRange)) as FirmwareRange;
+        const models = Object.keys(range) as DeviceModelInternal[];
+        // set minimum required firmware from coins.json (coinInfo)
+        if (coinInfo) {
+            models.forEach(model => {
+                const supportVersion = coinInfo.support ? coinInfo.support[model] : false;
+                if (supportVersion === false) {
+                    range[model].min = '0';
+                } else if (
+                    range[model].min !== '0' &&
+                    typeof supportVersion === 'string' &&
+                    versionUtils.isNewer(supportVersion, range[model].min)
+                ) {
+                    range[model].min = supportVersion;
+                }
+            });
+        }
+
+        const coinType = coinInfo?.type;
+        const shortcut = coinInfo?.shortcut.toLowerCase();
+        // find firmware range in config.json
+        const configRules = config.supportedFirmware
+            .filter(rule => {
+                // check if rule applies to requested method
+                if (rule.methods) {
+                    return rule.methods.includes(method);
+                }
+                // check if rule applies to capability
+                if (rule.capabilities) {
+                    return rule.capabilities.includes(method);
+                }
+
+                // rule doesn't have specified methods
+                // it may be a global rule for coin or coinType
+                return true;
+            })
+            .filter(rule => {
+                // REF_TODO: there is no coinType in config. possibly obsolete code?
+                // probably still useful, we just need to define type for config and not infer it.
+                // @ts-expect-error
+                if (rule.coinType) {
+                    // rule for coin type
+                    // @ts-expect-error
+                    return rule.coinType === coinType;
+                }
+                if (rule.coin) {
+                    // rule for coin shortcut
+                    // @ts-expect-error
+                    return (typeof rule.coin === 'string' ? [rule.coin] : rule.coin).includes(
+                        shortcut,
+                    );
+                }
+
+                // rule for method
+                return rule.methods || rule.capabilities;
+            });
+
+        configRules.forEach(rule => {
+            // override defaults
+            // NOTE:
+            // 0 may be confusing. means: no-support for "min" and unlimited support for "max"
+            if (rule.min) {
+                models.forEach(model => {
+                    const modelMin = (rule.min as Record<DeviceModelInternal, string | undefined>)[
+                        model
+                    ];
+                    if (modelMin) {
+                        if (
+                            modelMin === '0' ||
+                            range[model].min === '0' ||
+                            !versionUtils.isNewerOrEqual(range[model].min, modelMin)
+                        ) {
+                            range[model].min = modelMin;
+                        }
+                    }
+                });
+            }
+            if (rule.max) {
+                models.forEach(model => {
+                    // @ts-expect-error same issue as in coinType above, config needs to be typed not inferred.
+                    const modelMax = rule.max[model];
+                    if (modelMax) {
+                        if (
+                            modelMax === '0' ||
+                            range[model].max === '0' ||
+                            !versionUtils.isNewerOrEqual(range[model].max, modelMax)
+                        ) {
+                            range[model].max = modelMax;
+                        }
+                    }
+                });
+            }
+        });
+
+        this.firmwareRange = range;
+    }
 }

--- a/packages/connect/src/core/__tests__/AbstractMethod.test.ts
+++ b/packages/connect/src/core/__tests__/AbstractMethod.test.ts
@@ -1,0 +1,365 @@
+import { DeviceModelInternal, FirmwareRange, CoinInfo } from '../../exports';
+import { DEFAULT_FIRMWARE_RANGE as DEFAULT_RANGE } from '../AbstractMethod';
+
+const DEFAULT_COIN_INFO: CoinInfo = {
+    support: {
+        T1B1: '1.6.2',
+        T2T1: '2.1.0',
+        T2B1: '2.6.2',
+        T3B1: '2.8.2',
+        T3T1: '2.7.2',
+        T3W1: '2.7.2',
+    },
+    shortcut: 'btc',
+    type: 'bitcoin',
+} as CoinInfo;
+
+const EMPTY_CONFIG = {
+    supportedFirmware: [],
+};
+
+const rangeFromCoinInfo = (
+    Object.entries(DEFAULT_COIN_INFO.support) as [DeviceModelInternal, string][]
+).reduce((acc, [model]) => {
+    acc[model] = {
+        // @ts-expect-error
+        min: DEFAULT_COIN_INFO.support[model],
+        max: '0',
+    };
+
+    return acc;
+}, {} as FirmwareRange);
+
+type Fixture = {
+    description: string;
+    config?: any;
+    params: [string, Partial<CoinInfo> | null];
+    result: FirmwareRange;
+};
+
+const getFirmwareRange: Fixture[] = [
+    {
+        description: 'default range. coinInfo and config.ts data not found',
+        config: EMPTY_CONFIG,
+        params: ['signTransaction', null],
+        result: DEFAULT_RANGE,
+    },
+    {
+        description: 'range from coinInfo',
+        config: EMPTY_CONFIG,
+        params: ['signTransaction', DEFAULT_COIN_INFO],
+        result: rangeFromCoinInfo,
+    },
+    {
+        description: 'coinInfo without support',
+        config: EMPTY_CONFIG,
+        params: ['signTransaction', { shortcut: 'btc', type: 'bitcoin' }],
+        result: (Object.keys(DEFAULT_COIN_INFO.support) as DeviceModelInternal[]).reduce(
+            (acc, model) => {
+                acc[model] = { min: '0', max: '0' };
+
+                return acc;
+            },
+            {} as FirmwareRange,
+        ),
+    },
+    {
+        description: 'coinInfo without T1B1 support',
+        config: EMPTY_CONFIG,
+        params: [
+            'signTransaction',
+            {
+                support: {
+                    ...DEFAULT_COIN_INFO.support,
+                    T1B1: false,
+                },
+                shortcut: 'btc',
+                type: 'bitcoin',
+            },
+        ],
+        result: (
+            Object.entries(DEFAULT_COIN_INFO.support) as [DeviceModelInternal, string][]
+        ).reduce((acc, [model, min]) => {
+            acc[model] = { min: model === 'T1B1' ? '0' : min, max: '0' };
+
+            return acc;
+        }, {} as FirmwareRange),
+    },
+    {
+        description: 'coinInfo without T2 support',
+        config: EMPTY_CONFIG,
+        params: [
+            'signTransaction',
+            {
+                support: {
+                    ...DEFAULT_COIN_INFO.support,
+                    T2T1: false,
+                    T2B1: false,
+                    T3B1: false,
+                    T3T1: false,
+                    T3W1: false,
+                },
+                shortcut: 'btc',
+                type: 'bitcoin',
+            },
+        ],
+        result: (
+            Object.entries(DEFAULT_COIN_INFO.support) as [DeviceModelInternal, string][]
+        ).reduce((acc, [model, min]) => {
+            acc[model] = { min: model === 'T1B1' ? min : '0', max: '0' };
+
+            return acc;
+        }, {} as FirmwareRange),
+    },
+
+    {
+        description: 'range from config.ts (by coinType and coin as string)',
+        config: {
+            supportedFirmware: [
+                // this one is ignored, different excludedMethod
+                {
+                    coinType: 'bitcoin',
+                    methods: ['showAddress'],
+                    min: { T1B1: '1.12.0', T2T1: '2.6.0' },
+                },
+                // should merge both of these ranges together, since they both match
+                { coinType: 'bitcoin', min: { T1B1: '1.10.0', T2T1: '2.5.0' } },
+                { coin: 'btc', min: { T1B1: '1.11.0', T2T1: '2.4.0' } },
+            ],
+        },
+        params: ['signTransaction', DEFAULT_COIN_INFO],
+        result: {
+            ...rangeFromCoinInfo,
+            T1B1: { min: '1.11.0', max: '0' },
+            T2T1: { min: '2.5.0', max: '0' },
+        },
+    },
+
+    {
+        description: 'range from config.ts (by coin as string)',
+        config: {
+            supportedFirmware: [
+                // this one is ignored, different excludedMethod
+                { coin: 'btc', methods: ['showAddress'], min: { T1B1: '1.11.0', T2T1: '2.5.0' } },
+                { coin: 'btc', min: { T1B1: '1.10.0', T2T1: '2.4.0' } },
+            ],
+        },
+        params: ['signTransaction', DEFAULT_COIN_INFO],
+        result: {
+            ...rangeFromCoinInfo,
+            T1B1: { min: '1.10.0', max: '0' },
+            T2T1: { min: '2.4.0', max: '0' },
+        },
+    },
+    {
+        description: 'range from config.ts (by coin as array)',
+        config: {
+            supportedFirmware: [
+                // this one is ignored, different excludedMethod
+                { coin: ['btc'], methods: ['showAddress'], min: { T1B1: '1.11.0', T2T1: '2.5.0' } },
+                { coin: ['btc'], min: { T1B1: '1.10.0', T2T1: '2.4.0' } },
+            ],
+        },
+        params: ['signTransaction', DEFAULT_COIN_INFO],
+        result: {
+            ...rangeFromCoinInfo,
+            T1B1: { min: '1.10.0', max: '0' },
+            T2T1: { min: '2.4.0', max: '0' },
+        },
+    },
+    {
+        description: 'range from config.ts (by methods)',
+        config: {
+            supportedFirmware: [
+                // this one is ignored, no data
+                { min: { T1B1: '1.11.0', T2T1: '2.5.0' } },
+                // this one is ignored, different excludedMethod
+                { coin: ['btc'], methods: ['showAddress'], min: { T1B1: '1.11.0', T2T1: '2.5.0' } },
+                // this one is ignored because of coin (not btc)
+                {
+                    coin: ['ltc'],
+                    methods: ['signTransaction'],
+                    min: { T1B1: '1.11.0', T2T1: '2.5.0' },
+                },
+                // this one is ignored, different excludedMethod
+                {
+                    coinType: 'bitcoin',
+                    methods: ['showAddress'],
+                    min: { T1B1: '1.11.0', T2T1: '2.5.0' },
+                },
+                { methods: ['signTransaction'], min: { T1B1: '1.10.0', T2T1: '2.4.0' } },
+            ],
+        },
+        params: ['signTransaction', DEFAULT_COIN_INFO],
+        result: {
+            ...rangeFromCoinInfo,
+            T1B1: { min: '1.10.0', max: '0' },
+            T2T1: { min: '2.4.0', max: '0' },
+        },
+    },
+    {
+        description: 'range from config.ts (by capabilities)',
+        config: {
+            supportedFirmware: [
+                // this one is ignored, no data
+                { min: { T1B1: '1.11.0', T2T1: '2.5.0' } },
+                // this one is ignored, different excludedMethod
+                { coin: ['btc'], methods: ['showAddress'], min: { T1B1: '1.11.0', T2T1: '2.5.0' } },
+                // this one is ignored because of coin (not btc)
+                {
+                    coin: ['ltc'],
+                    methods: ['signTransaction'],
+                    min: { T1B1: '1.11.0', T2T1: '2.5.0' },
+                },
+                // this one is ignored, different excludedMethod
+                {
+                    coinType: 'bitcoin',
+                    methods: ['showAddress'],
+                    min: { T1B1: '1.11.0', T2T1: '2.5.0' },
+                },
+                { capabilities: ['decreaseOutput'], min: { T1B1: '1.10.0', T2T1: '2.4.0' } },
+            ],
+        },
+        params: ['decreaseOutput', DEFAULT_COIN_INFO],
+        result: {
+            ...rangeFromCoinInfo,
+            T1B1: { min: '1.10.0', max: '0' },
+            T2T1: { min: '2.4.0', max: '0' },
+        },
+    },
+    {
+        description: 'range from config.ts is lower than coinInfo',
+        config: {
+            supportedFirmware: [
+                { methods: ['signTransaction'], min: { T1B1: '1.6.2', T2T1: '2.1.0' } },
+            ],
+        },
+        params: [
+            'signTransaction',
+            {
+                // @ts-expect-error
+                support: { T1B1: '1.10.0', T2T1: '2.4.0' },
+                shortcut: 'btc',
+                type: 'bitcoin',
+            },
+            DEFAULT_RANGE,
+        ],
+        result: {
+            ...DEFAULT_RANGE,
+            T1B1: { min: '1.10.0', max: '0' },
+            T2T1: { min: '2.4.0', max: '0' },
+        },
+    },
+    {
+        description: 'range from config.ts using max',
+        config: {
+            supportedFirmware: [
+                { methods: ['signTransaction'], max: { T1B1: '1.10.0', T2T1: '2.4.0' } },
+            ],
+        },
+        params: ['signTransaction', DEFAULT_COIN_INFO],
+        result: {
+            ...rangeFromCoinInfo,
+            T1B1: { min: '1.6.2', max: '1.10.0' },
+            T2T1: { min: '2.1.0', max: '2.4.0' },
+        },
+    },
+
+    // real config.ts data
+    {
+        description: 'xrp + getAccountInfo: coinInfo range IS replaced by config.ts range',
+        params: [
+            'getAccountInfo',
+            {
+                // @ts-expect-error
+                support: { T1B1: '1.0.1', T2T1: '2.0.1' },
+                shortcut: 'xrp',
+                type: 'misc',
+            },
+            DEFAULT_RANGE,
+        ],
+        result: {
+            ...DEFAULT_RANGE,
+            T1B1: { min: '0', max: '0' },
+            T2T1: { min: '2.1.0', max: '0' },
+        },
+    },
+    {
+        description: 'btc + getAccountInfo: coinInfo range IS NOT replaced by config.ts range',
+        params: ['getAccountInfo', null],
+        result: DEFAULT_RANGE,
+    },
+    {
+        description: 'eip1559: coinInfo range is replaced by config.ts range',
+        params: [
+            'eip1559',
+            {
+                support: {
+                    ...DEFAULT_COIN_INFO.support,
+                    T1B1: '1.6.2',
+                    T2T1: '2.1.0',
+                },
+                shortcut: 'eth',
+                type: 'ethereum',
+            },
+        ],
+        result: {
+            ...rangeFromCoinInfo,
+            T1B1: { min: '1.10.4', max: '0' },
+            T2T1: { min: '2.4.2', max: '0' },
+        },
+    },
+    {
+        description: 'method not available for T1B1 and T2T1, defined by config',
+        params: ['authenticateDevice', null],
+        result: {
+            ...DEFAULT_RANGE,
+            T1B1: { min: '0', max: '0' },
+            T2T1: { min: '0', max: '0' },
+            T3T1: { min: '2.8.0', max: '0' },
+        },
+    },
+];
+
+describe('AbstractMethod.setFirmwareRange', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+    getFirmwareRange.forEach(f => {
+        it(f.description, () => {
+            return new Promise<void>(done => {
+                jest.resetModules();
+
+                const mock = f.config;
+                jest.mock('../../data/config', () => {
+                    const actualConfig = jest.requireActual('../../data/config').config;
+
+                    return {
+                        __esModule: true,
+                        config: mock || actualConfig,
+                    };
+                });
+
+                import('../AbstractMethod').then(({ AbstractMethod }) => {
+                    class TestMethod extends AbstractMethod<any, any> {
+                        init() {}
+                        run(): Promise<void> {
+                            return Promise.resolve();
+                        }
+                    }
+                    // @ts-expect-error
+                    const method = new TestMethod({ payload: { method: 'signTransaction' } });
+
+                    method.setFirmwareRange(
+                        f.params[0],
+                        // @ts-expect-error
+                        f.params[1],
+                    );
+
+                    expect(method.firmwareRange).toEqual(f.result);
+                    done();
+                });
+            });
+        });
+    });
+});

--- a/packages/suite/src/actions/suite/__tests__/initAction.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/initAction.test.ts
@@ -260,7 +260,7 @@ describe('Suite init action', () => {
             const store = initStore(getInitialState(options.initialRun));
 
             if (options?.initialPath) {
-                // eslint-disable-next-line @typescript-eslint/no-var-requires
+                 
                 require('src/support/history').default.location.pathname = options.initialPath;
             }
 

--- a/packages/suite/src/actions/suite/__tests__/routerActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/routerActions.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
+ 
 import { configureStore } from 'src/support/tests/configureStore';
 import suiteReducer from 'src/reducers/suite/suiteReducer';
 import routerReducer from 'src/reducers/suite/routerReducer';

--- a/packages/suite/src/actions/wallet/exportTransactionsActions.ts
+++ b/packages/suite/src/actions/wallet/exportTransactionsActions.ts
@@ -39,10 +39,10 @@ export const exportTransactionsThunk = createThunk(
         // TODO: this is not nice (copy-paste)
         // metadata reducer is still not part of trezor-common and I can not import it
         // here. so either followup, or maybe when I have a moment I'll refactor it  before merging this
-        // eslint-disable-next-line no-restricted-syntax
+         
         const provider = getState().metadata?.providers.find(
             // @ts-expect-error
-            // eslint-disable-next-line no-restricted-syntax
+             
             p => p.clientId === getState().metadata.selectedProvider.labels,
         );
         const metadataKeys = account?.metadata[1];

--- a/packages/suite/src/components/suite/FormFractionButtons.tsx
+++ b/packages/suite/src/components/suite/FormFractionButtons.tsx
@@ -12,7 +12,7 @@ const Flex = styled.div`
     gap: 4px;
 `;
 
-// eslint-disable-next-line local-rules/no-override-ds-component
+ 
 const TinyButton = styled(Button).attrs(props => ({
     ...props,
     variant: 'tertiary',

--- a/packages/suite/src/components/suite/labeling/MetadataLabeling/withEditable.tsx
+++ b/packages/suite/src/components/suite/labeling/MetadataLabeling/withEditable.tsx
@@ -29,7 +29,7 @@ const IconListWrapper = styled.div`
 
 // To inherit everything so the input looks like the text we want to edit
 // However, we need to reset some properties: for example margin and padding to not duplicate spacings
-// eslint-disable-next-line local-rules/no-override-ds-component
+ 
 const Editable = styled(AutoScalingInput)`
     all: inherit;
     margin: 0;

--- a/packages/suite/src/views/view-only/ViewOnlyPromoContent.tsx
+++ b/packages/suite/src/views/view-only/ViewOnlyPromoContent.tsx
@@ -58,12 +58,12 @@ const DeviceImage = styled(Image)`
     object-fit: contain;
 `;
 
-// eslint-disable-next-line local-rules/no-override-ds-component
+ 
 const SmallDeviceImage = styled(DeviceImage)`
     width: 18px;
 `;
 
-// eslint-disable-next-line local-rules/no-override-ds-component
+ 
 const LargeDeviceImage = styled(DeviceImage)`
     width: 93px;
 `;

--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/StakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/StakingCard.tsx
@@ -56,7 +56,7 @@ const ButtonsWrapper = styled.div`
     flex-wrap: wrap;
 `;
 
-// eslint-disable-next-line local-rules/no-override-ds-component
+ 
 const StyledButton = styled(Button).attrs(props => ({
     ...props,
     variant: 'tertiary',


### PR DESCRIPTION
I am trying to minimize config.ts file. Imho information about [the supported features ](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/data/config.ts#L109)(by firmware), don't need to be defined here. Wouldn't it be better to define them with respective methods => in a single place? 
