### PR TITLE
Connect Popup mobile issue

### DIFF
--- a/packages/connect-examples/mobile-expo/App.tsx
+++ b/packages/connect-examples/mobile-expo/App.tsx
@@ -22,6 +22,7 @@ const styles = StyleSheet.create({
 export const App = () => {
     const [errorData, setErrorData] = useState<any>(null);
     const [successData, setSuccessData] = useState<any>(null);
+    const isEmulator = true;
 
     const initialize = () => {
         TrezorConnect.init({
@@ -29,7 +30,8 @@ export const App = () => {
                 email: 'developer@xyz.com',
                 appUrl: 'http://your.application.com',
             },
-            connectSrc: 'https://dev.suite.sldev.cz/connect/develop/',
+            // for local development purposes. for production, leave it undefined to use the default value.
+            connectSrc: isEmulator ? 'trezorsuitelite://connect' : undefined,
             deeplinkOpen: url => {
                 // eslint-disable-next-line no-console
                 console.log('deeplinkOpen', url);

--- a/suite-native/app/src/navigation/RootStackNavigator.tsx
+++ b/suite-native/app/src/navigation/RootStackNavigator.tsx
@@ -109,13 +109,7 @@ export const RootStackNavigator = () => {
                 options={{ animation: 'slide_from_bottom' }}
             />
             <RootStack.Screen name={RootStackRoutes.SendStack} component={SendStackNavigator} />
-            <RootStack.Screen
-                name={RootStackRoutes.ConnectPopup}
-                component={ConnectPopupScreen}
-                options={{
-                    presentation: 'fullScreenModal',
-                }}
-            />
+            <RootStack.Screen name={RootStackRoutes.ConnectPopup} component={ConnectPopupScreen} />
         </RootStack.Navigator>
     );
 };


### PR DESCRIPTION
## Description

There was an issue with the passphrase screen not opening from Connect Popup.
The reason was that the Connect Popup screen had `presentation: 'fullScreenModal'` which was forcing it to always stay on top. 

I also changed `connectSrc` used in the mobile example to `trezorsuitelite://connect` instead of our dev env, so it works better with emulators.
