### PR TITLE
feat(connect): make transportReconnect implicitly true

### DIFF
--- a/packages/connect/e2e/common.setup.ts
+++ b/packages/connect/e2e/common.setup.ts
@@ -127,6 +127,7 @@ export const initTrezorConnect = async (
         debug: false,
         popup: false,
         pendingTransportEvent: true,
+        transportReconnect: false,
         connectSrc: process.env.TREZOR_CONNECT_SRC, // custom source for karma tests
         ...options,
     });

--- a/packages/connect/src/core/__tests__/Core.test.ts
+++ b/packages/connect/src/core/__tests__/Core.test.ts
@@ -7,7 +7,11 @@ import { initCoreState } from '../index';
 const { createTestTransport } = global.JestMocks;
 
 const getSettings = (partial: Partial<ConnectSettings> = {}) =>
-    parseConnectSettings({ transports: [createTestTransport()], ...partial });
+    parseConnectSettings({
+        transports: [createTestTransport()],
+        transportReconnect: false,
+        ...partial,
+    });
 
 describe('Core', () => {
     beforeAll(async () => {});

--- a/packages/connect/src/data/connectSettings.ts
+++ b/packages/connect/src/data/connectSettings.ts
@@ -29,6 +29,7 @@ const initialSettings: ConnectSettings = {
     interactionTimeout: 600, // 5 minutes
     sharedLogger: true,
     deeplinkUrl: `${DEFAULT_DOMAIN}deeplink/${DEEPLINK_VERSION}/`,
+    transportReconnect: true,
 };
 
 const parseManifest = (manifest?: Manifest) => {

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -263,7 +263,9 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
         const { promise, reject } = resolveAfter(1000, initParams);
         this.rejectPending = reject;
 
-        return promise.then(this.createInitPromise.bind(this));
+        return promise.then(this.createInitPromise.bind(this)).finally(() => {
+            this.rejectPending = undefined;
+        });
     }
 
     private async selectTransport([transport, ...rest]: Transport[]): Promise<Transport> {


### PR DESCRIPTION
## Description

Make transportReconnect implicitly true, so 3rd parties can reconnect when bridge was not running.

Existing tests affected by this are modified to use `transportReconnect: false`