### PR TITLE
fix(suite-desktop-core): is autostart enabled condition on windows

### DIFF
--- a/packages/suite-desktop-core/src/modules/auto-start.ts
+++ b/packages/suite-desktop-core/src/modules/auto-start.ts
@@ -40,6 +40,11 @@ Terminal=false
 export const isAutoStartEnabled = () => {
     if (process.platform === 'linux') {
         return fs.existsSync(path.join(os.homedir(), LINUX_AUTOSTART_DIR, LINUX_AUTOSTART_FILE));
+    } else if (process.platform === 'win32') {
+        return (
+            app.getLoginItemSettings().openAtLogin ||
+            app.getLoginItemSettings().executableWillLaunchAtLogin
+        );
     } else {
         return app.getLoginItemSettings().openAtLogin;
     }


### PR DESCRIPTION
## Description

Windows needs a special case for checking if autostart is enabled.

## Related Issue

Resolve #15272