### PR TITLE
fix(suite-native): send transaction detail redirect

### DIFF
--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -260,12 +260,12 @@ const synchronizeSentTransactionThunk = createThunk(
 
 export const pushSendFormTransactionThunk = createThunk<
     Success<{ txid: string }>,
-    { selectedAccount: Account },
+    { selectedAccount: Account; shouldDiscardTransaction?: boolean },
     { rejectValue: PushTransactionError }
 >(
     `${SEND_MODULE_PREFIX}/pushSendFormTransactionThunk`,
     async (
-        { selectedAccount },
+        { selectedAccount, shouldDiscardTransaction = true },
         { dispatch, getState, extra, rejectWithValue, fulfillWithValue },
     ) => {
         const {
@@ -338,7 +338,7 @@ export const pushSendFormTransactionThunk = createThunk<
         }
 
         // cleanup send form state and close review modal
-        dispatch(cancelSignSendFormTransactionThunk());
+        if (shouldDiscardTransaction) dispatch(cancelSignSendFormTransactionThunk());
 
         return pushTxResponse.success
             ? fulfillWithValue(pushTxResponse)


### PR DESCRIPTION
## Description
- The redirect from the send review to the transaction detail happens after the transaction is processed by a backend. This fix prevents navigation to the transaction details before getting the transaction metadata from the backend, which leads to a blank screen being rendered.

## Demo
https://github.com/user-attachments/assets/aff7cf4a-c1d1-48f4-a07d-378fab4edcf1

