### PR TITLE
[discuss] chore(connect): coinAbstractMethod

### DIFF
--- a/packages/connect/src/api/binance/api/binanceAbstractMethods.ts
+++ b/packages/connect/src/api/binance/api/binanceAbstractMethods.ts
@@ -1,0 +1,21 @@
+import { Capability } from '@trezor/protobuf/src/messages-schema';
+import { AbstractMethod, Payload } from '../../../core/AbstractMethod';
+import { CallMethodPayload } from '../../../events';
+import { getFirmwareRange } from '../../common/paramsValidator';
+import { getMiscNetwork } from '../../../data/coinInfo';
+
+export abstract class BinanceAbstractMethod<
+    Name extends CallMethodPayload['method'],
+    Params = undefined,
+> extends AbstractMethod<Name, Params> {
+    requiredDeviceCapabilities = [Capability.Binance];
+
+    constructor(message: { id?: number; payload: Payload<Name> }) {
+        super(message);
+        this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('BNB'), this.firmwareRange);
+    }
+
+    // firmwareRangeRequirements could be defined here instead of config.ts
+    // loading coin-specific protobuf could be done here
+    // anything else?
+}

--- a/packages/connect/src/api/binance/api/binanceGetAddress.ts
+++ b/packages/connect/src/api/binance/api/binanceGetAddress.ts
@@ -2,28 +2,28 @@
 
 import { Assert } from '@trezor/schema-utils';
 
-import { AbstractMethod, MethodReturnType } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
-import { getMiscNetwork } from '../../../data/coinInfo';
+import { MethodReturnType } from '../../../core/AbstractMethod';
 import { validatePath, fromHardened, getSerializedPath } from '../../../utils/pathUtils';
 import { PROTO, ERRORS } from '../../../constants';
 import { UI, createUiMessage } from '../../../events';
 import { Bundle } from '../../../types';
 import { GetAddress as GetAddressSchema } from '../../../types/api/getAddress';
+import { BinanceAbstractMethod } from './binanceAbstractMethods';
 
 type Params = PROTO.BinanceGetAddress & {
     address?: string;
 };
 
-export default class BinanceGetAddress extends AbstractMethod<'binanceGetAddress', Params[]> {
+export default class BinanceGetAddress extends BinanceAbstractMethod<
+    'binanceGetAddress',
+    Params[]
+> {
     hasBundle?: boolean;
     progress = 0;
 
     init() {
         this.noBackupConfirmationMode = 'always';
         this.requiredPermissions = ['read'];
-        this.requiredDeviceCapabilities = ['Capability_Binance'];
-        this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('BNB'), this.firmwareRange);
 
         // create a bundle with only one batch if bundle doesn't exists
         this.hasBundle = !!this.payload.bundle;

--- a/packages/connect/src/api/binance/api/binanceGetPublicKey.ts
+++ b/packages/connect/src/api/binance/api/binanceGetPublicKey.ts
@@ -2,15 +2,14 @@
 
 import { Assert } from '@trezor/schema-utils';
 
-import { AbstractMethod, MethodReturnType } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
-import { getMiscNetwork } from '../../../data/coinInfo';
+import { MethodReturnType } from '../../../core/AbstractMethod';
 import { validatePath, fromHardened, getSerializedPath } from '../../../utils/pathUtils';
 import { UI, createUiMessage } from '../../../events';
 import type { PROTO } from '../../../constants';
 import { Bundle, GetPublicKey as GetPublicKeySchema } from '../../../types';
+import { BinanceAbstractMethod } from './binanceAbstractMethods';
 
-export default class BinanceGetPublicKey extends AbstractMethod<
+export default class BinanceGetPublicKey extends BinanceAbstractMethod<
     'binanceGetPublicKey',
     PROTO.BinanceGetPublicKey[]
 > {
@@ -18,8 +17,6 @@ export default class BinanceGetPublicKey extends AbstractMethod<
 
     init() {
         this.requiredPermissions = ['read'];
-        this.requiredDeviceCapabilities = ['Capability_Binance'];
-        this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('BNB'), this.firmwareRange);
 
         // create a bundle with only one batch if bundle doesn't exists
         this.hasBundle = !!this.payload.bundle;

--- a/packages/connect/src/api/binance/api/binanceSignTransaction.ts
+++ b/packages/connect/src/api/binance/api/binanceSignTransaction.ts
@@ -2,13 +2,11 @@
 
 import { AssertWeak } from '@trezor/schema-utils';
 
-import { AbstractMethod } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
-import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath } from '../../../utils/pathUtils';
 import * as helper from '../binanceSignTx';
 import { BinanceSignTransaction as BinanceSignTransactionSchema } from '../../../types/api/binance';
 import type { BinancePreparedTransaction } from '../../../types/api/binance';
+import { BinanceAbstractMethod } from './binanceAbstractMethods';
 
 type Params = {
     path: number[];
@@ -16,14 +14,12 @@ type Params = {
     chunkify?: boolean;
 };
 
-export default class BinanceSignTransaction extends AbstractMethod<
+export default class BinanceSignTransaction extends BinanceAbstractMethod<
     'binanceSignTransaction',
     Params
 > {
     init() {
         this.requiredPermissions = ['read', 'write'];
-        this.requiredDeviceCapabilities = ['Capability_Binance'];
-        this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('BNB'), this.firmwareRange);
 
         const { payload } = this;
         // validate incoming parameters

--- a/packages/connect/src/api/cardano/api/cardanoAbstractMethods.ts
+++ b/packages/connect/src/api/cardano/api/cardanoAbstractMethods.ts
@@ -4,14 +4,18 @@ import { CallMethodPayload } from '../../../events';
 import { getFirmwareRange } from '../../common/paramsValidator';
 import { getMiscNetwork } from '../../../data/coinInfo';
 
-export abstract class BinanceAbstractMethod<
+export abstract class CardanoAbstractMethod<
     Name extends CallMethodPayload['method'],
     Params = undefined,
 > extends AbstractMethod<Name, Params> {
-    requiredDeviceCapabilities = [Capability.Binance];
+    requiredDeviceCapabilities = [Capability.Cardano];
 
     constructor(message: { id?: number; payload: Payload<Name> }) {
         super(message);
-        this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('BNB'), this.firmwareRange);
+        this.firmwareRange = getFirmwareRange(
+            this.name,
+            getMiscNetwork('Cardano'),
+            this.firmwareRange,
+        );
     }
 }

--- a/packages/connect/src/api/cardano/api/cardanoComposeTransaction.ts
+++ b/packages/connect/src/api/cardano/api/cardanoComposeTransaction.ts
@@ -1,14 +1,14 @@
 import { trezorUtils, CoinSelectionError } from '@fivebinaries/coin-selection';
 
-import { AbstractMethod } from '../../../core/AbstractMethod';
 import { validateParams } from '../../common/paramsValidator';
 import { composeTxPlan } from '../cardanoUtils';
 import type {
     CardanoComposeTransactionParams,
     PrecomposedTransactionCardano,
 } from '../../../types/api/cardanoComposeTransaction';
+import { CardanoAbstractMethod } from './cardanoAbstractMethods';
 
-export default class CardanoComposeTransaction extends AbstractMethod<
+export default class CardanoComposeTransaction extends CardanoAbstractMethod<
     'cardanoComposeTransaction',
     CardanoComposeTransactionParams
 > {

--- a/packages/connect/src/api/cardano/api/cardanoGetAddress.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetAddress.ts
@@ -2,9 +2,7 @@
 
 import { Assert } from '@trezor/schema-utils';
 
-import { AbstractMethod, MethodReturnType } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
-import { getMiscNetwork } from '../../../data/coinInfo';
+import { MethodReturnType } from '../../../core/AbstractMethod';
 import { fromHardened, getSerializedPath } from '../../../utils/pathUtils';
 import {
     addressParametersFromProto,
@@ -16,24 +14,22 @@ import { PROTO, ERRORS } from '../../../constants';
 import { UI, createUiMessage } from '../../../events';
 import { Bundle } from '../../../types';
 import { CardanoGetAddress as CardanoGetAddressSchema } from '../../../types/api/cardano';
+import { CardanoAbstractMethod } from './cardanoAbstractMethods';
 
 type Params = PROTO.CardanoGetAddress & {
     address?: string;
 };
 
-export default class CardanoGetAddress extends AbstractMethod<'cardanoGetAddress', Params[]> {
+export default class CardanoGetAddress extends CardanoAbstractMethod<
+    'cardanoGetAddress',
+    Params[]
+> {
     hasBundle?: boolean;
     progress = 0;
 
     init() {
         this.noBackupConfirmationMode = 'always';
         this.requiredPermissions = ['read'];
-        this.requiredDeviceCapabilities = ['Capability_Cardano'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Cardano'),
-            this.firmwareRange,
-        );
 
         // create a bundle with only one batch if bundle doesn't exists
         this.hasBundle = !!this.payload.bundle;

--- a/packages/connect/src/api/cardano/api/cardanoGetNativeScriptHash.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetNativeScriptHash.ts
@@ -3,27 +3,20 @@
 import { Assert } from '@trezor/schema-utils';
 
 import { PROTO } from '../../../constants';
-import { AbstractMethod } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath } from '../../../utils/pathUtils';
 import {
     CardanoGetNativeScriptHash as CardanoGetNativeScriptHashSchema,
     CardanoNativeScript,
 } from '../../../types/api/cardano';
+import { CardanoAbstractMethod } from './cardanoAbstractMethods';
 
-export default class CardanoGetNativeScriptHash extends AbstractMethod<
+export default class CardanoGetNativeScriptHash extends CardanoAbstractMethod<
     'cardanoGetNativeScriptHash',
     PROTO.CardanoGetNativeScriptHash
 > {
     init() {
         this.requiredPermissions = ['read'];
-        this.requiredDeviceCapabilities = ['Capability_Cardano'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Cardano'),
-            this.firmwareRange,
-        );
 
         const { payload } = this;
 

--- a/packages/connect/src/api/cardano/api/cardanoGetPublicKey.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetPublicKey.ts
@@ -3,29 +3,25 @@
 import { Assert } from '@trezor/schema-utils';
 
 import { PROTO } from '../../../constants';
-import { AbstractMethod, MethodReturnType } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
-import { getMiscNetwork } from '../../../data/coinInfo';
+import { MethodReturnType } from '../../../core/AbstractMethod';
 import { validatePath, fromHardened, getSerializedPath } from '../../../utils/pathUtils';
 import { UI, createUiMessage } from '../../../events';
 import { Bundle } from '../../../types';
 import { CardanoGetPublicKey as CardanoGetPublicKeySchema } from '../../../types/api/cardano';
+import { CardanoAbstractMethod } from './cardanoAbstractMethods';
 
 interface Params extends PROTO.CardanoGetPublicKey {
     suppressBackupWarning?: boolean;
 }
 
-export default class CardanoGetPublicKey extends AbstractMethod<'cardanoGetPublicKey', Params[]> {
+export default class CardanoGetPublicKey extends CardanoAbstractMethod<
+    'cardanoGetPublicKey',
+    Params[]
+> {
     hasBundle?: boolean;
 
     init() {
         this.requiredPermissions = ['read'];
-        this.requiredDeviceCapabilities = ['Capability_Cardano'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Cardano'),
-            this.firmwareRange,
-        );
 
         // create a bundle with only one batch if bundle doesn't exists
         this.hasBundle = !!this.payload.bundle;

--- a/packages/connect/src/api/cardano/api/cardanoSignTransaction.ts
+++ b/packages/connect/src/api/cardano/api/cardanoSignTransaction.ts
@@ -6,9 +6,6 @@ import { trezorUtils } from '@fivebinaries/coin-selection';
 
 import { AssertWeak, Type } from '@trezor/schema-utils';
 
-import { AbstractMethod } from '../../../core/AbstractMethod';
-import { getFirmwareRange } from '../../common/paramsValidator';
-import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath } from '../../../utils/pathUtils';
 import {
     modifyAuxiliaryDataForBackwardsCompatibility,
@@ -37,6 +34,7 @@ import {
 import { gatherWitnessPaths } from '../cardanoWitnesses';
 import type { AssetGroupWithTokens } from '../cardanoTokenBundle';
 import { tokenBundleToProto } from '../cardanoTokenBundle';
+import { CardanoAbstractMethod } from './cardanoAbstractMethods';
 
 const CardanoSignTransactionFeatures = Object.freeze({
     // FW <2.6.0 is not supported by Connect at all
@@ -72,18 +70,12 @@ export type CardanoSignTransactionParams = {
     chunkify?: boolean;
 };
 
-export default class CardanoSignTransaction extends AbstractMethod<
+export default class CardanoSignTransaction extends CardanoAbstractMethod<
     'cardanoSignTransaction',
     CardanoSignTransactionParams
 > {
     init() {
         this.requiredPermissions = ['read', 'write'];
-        this.requiredDeviceCapabilities = ['Capability_Cardano'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Cardano'),
-            this.firmwareRange,
-        );
 
         const { payload } = this;
 

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -341,6 +341,9 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
     }
 
     checkDeviceCapability() {
+        if (!this.useDevice) {
+            return true;
+        }
         const deviceHasAllRequiredCapabilities = (this.requiredDeviceCapabilities || []).every(
             capability => this.device.features.capabilities.includes(capability),
         );


### PR DESCRIPTION
I am exploring modularization possibilities. And it of course brings about many ideas for refactoring and improvements.
While thinking (#15291) about how to reduce the amount of data in config.ts - where specifically I don't like the information about [feature support](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/data/config.ts#L109) - IMHO it should be defined per coin-module. 

Would it make sense to define common stuff and stuff like this in a coin specific abstract method? cc @marekrjpolak @karliatto @martykan 