### PR TITLE
Revert "chore(suite-desktop-core): bump openpgp"

### DIFF
--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -36,7 +36,7 @@
         "electron-localshortcut": "^3.2.1",
         "electron-store": "8.2.0",
         "electron-updater": "6.3.9",
-        "openpgp": "^6.0.0",
+        "openpgp": "^5.11.2",
         "systeminformation": "^5.23.5"
     },
     "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11765,7 +11765,7 @@ __metadata:
     electron-updater: "npm:6.3.9"
     fs-extra: "npm:^11.2.0"
     glob: "npm:^10.3.10"
-    openpgp: "npm:^6.0.0"
+    openpgp: "npm:^5.11.2"
     systeminformation: "npm:^5.23.5"
     terser-webpack-plugin: "npm:^5.3.9"
     webpack: "npm:^5.96.1"
@@ -15126,7 +15126,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"asn1.js@npm:^5.2.0":
+"asn1.js@npm:^5.0.0, asn1.js@npm:^5.2.0":
   version: 5.4.1
   resolution: "asn1.js@npm:5.4.1"
   dependencies:
@@ -32601,10 +32601,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openpgp@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "openpgp@npm:6.0.0"
-  checksum: 10/ca634862edb04c3da0d4d25e0157015111f588fd5698f7dc9fc69a515455db52a798bda69de3f1eecfbb6a96a0f8f0d2fe2fde6d4a68736c95460d140d5c2c9c
+"openpgp@npm:^5.11.2":
+  version: 5.11.2
+  resolution: "openpgp@npm:5.11.2"
+  dependencies:
+    asn1.js: "npm:^5.0.0"
+  checksum: 10/75052f8b89aa946d2b927f2a679d57671b2da5bf3dab1a223b9ba54305635ce37a86cb2ea274d0dcd830511e3fe1bae16d85259e907f56ec31219c4367c311a8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This reverts commit a66ece5a64dd1fabe2918634c8e2f4956b7a1605 (downgrades OpenPGP back to 5.11.2)

[See slack convo](https://satoshilabs.slack.com/archives/G019WLX2P7B/p1730986359058219), it broke windows build :scream:
This fixes the windows build :heavy_check_mark: 

Reason not yet known, but I guess that when they rewritten the library to `mjs`, it's not exported as it should, or maybe has hacky code that hardcodes CWD at build time, IDK, I'll have to check.