### PR TITLE
chore: improve no-override-ds-component so it works better when ESLint is upgraded

### DIFF
--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -40,11 +40,11 @@ import {
     selectWeightedAnonymityByAccountKey,
 } from 'src/reducers/wallet/coinjoinReducer';
 import { openModal } from 'src/actions/suite/modalActions';
+import { selectIsDeviceLocked } from 'src/reducers/suite/suiteReducer';
 
 import * as coinjoinClientActions from './coinjoinClientActions';
 import { goto } from '../suite/routerActions';
 import * as COINJOIN from './constants/coinjoinConstants';
-import { selectIsDeviceLocked } from 'src/reducers/suite/suiteReducer';
 
 export const coinjoinAccountUpdateAnonymity = (accountKey: string, targetAnonymity: number) =>
     ({


### PR DESCRIPTION
With new ESLint the unused ignore is correctly flagged as unused. So it reveled it was not working for case like this:

![image](https://github.com/user-attachments/assets/410ff5d9-69ee-4e44-85bc-725506d693b2)

where `styled()` is not directly called as TaggedTemplate but chained and therefore checked as `ImportDeclaration`
