### PR TITLE
fix(suite): workers not loading in electron

### DIFF
--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -129,6 +129,10 @@ const init = async () => {
         restartApp();
     });
 
+    // Electron 32 has a bug with Worker due to Chromium changes
+    // https://github.com/electron/electron/issues/43556
+    app.commandLine.appendSwitch('disable-features', 'PlzDedicatedWorker');
+
     await app.whenReady();
 
     // Load bridge module first, it is required in both UI and daemon mode


### PR DESCRIPTION
## Description

Electron 32+ has a bug with loading Worker due to changes in recent Chromium versions.
It is not fixed yet: https://github.com/electron/electron/issues/43556

The suggested workaround is to disable the Chromium feature flag  `PlzDedicatedWorker`, which is what this PR does

## Related issues
Resolves #15292