### PR TITLE
feat(suite-native): bitcoin and ethereum send enabled

### DIFF
--- a/suite-native/feature-flags/src/featureFlagsSlice.ts
+++ b/suite-native/feature-flags/src/featureFlagsSlice.ts
@@ -5,8 +5,9 @@ import { isDebugEnv, isDetoxTestBuild, isDevelopOrDebugEnv } from '@suite-native
 
 export const FeatureFlag = {
     IsDeviceConnectEnabled: 'isDeviceConnectEnabled',
-    IsBitcoinLikeSendEnabled: 'isBitcoinLikeSendEnabled',
-    IsEthereumSendEnabled: 'isEthereumSendEnabled',
+    IsRippleSendEnabled: 'isRippleSendEnabled',
+    IsCardanoSendEnabled: 'isCardanoSendEnabled',
+    IsSolanaSendEnabled: 'isSolanaSendEnabled',
     IsRegtestEnabled: 'isRegtestEnabled',
     IsSolanaEnabled: 'IsSolanaEnabled',
     IsConnectPopupEnabled: 'IsConnectPopupEnabled',
@@ -21,8 +22,9 @@ export type FeatureFlagsRootState = {
 
 export const featureFlagsInitialState: FeatureFlagsState = {
     [FeatureFlag.IsDeviceConnectEnabled]: isAndroid() || isDebugEnv(),
-    [FeatureFlag.IsBitcoinLikeSendEnabled]: isAndroid() && isDevelopOrDebugEnv(),
-    [FeatureFlag.IsEthereumSendEnabled]: isAndroid() && isDevelopOrDebugEnv(),
+    [FeatureFlag.IsRippleSendEnabled]: isAndroid() && isDevelopOrDebugEnv(),
+    [FeatureFlag.IsCardanoSendEnabled]: isAndroid() && isDevelopOrDebugEnv(),
+    [FeatureFlag.IsSolanaSendEnabled]: isAndroid() && isDevelopOrDebugEnv(),
     [FeatureFlag.IsRegtestEnabled]: isDebugEnv() || isDetoxTestBuild(),
     [FeatureFlag.IsSolanaEnabled]: false,
     [FeatureFlag.IsConnectPopupEnabled]: isDevelopOrDebugEnv(),
@@ -30,8 +32,9 @@ export const featureFlagsInitialState: FeatureFlagsState = {
 
 export const featureFlagsPersistedKeys: Array<keyof FeatureFlagsState> = [
     FeatureFlag.IsDeviceConnectEnabled,
-    FeatureFlag.IsBitcoinLikeSendEnabled,
-    FeatureFlag.IsEthereumSendEnabled,
+    FeatureFlag.IsRippleSendEnabled,
+    FeatureFlag.IsCardanoSendEnabled,
+    FeatureFlag.IsSolanaSendEnabled,
     FeatureFlag.IsRegtestEnabled,
     FeatureFlag.IsSolanaEnabled,
     FeatureFlag.IsConnectPopupEnabled,

--- a/suite-native/module-accounts-management/package.json
+++ b/suite-native/module-accounts-management/package.json
@@ -17,7 +17,6 @@
         "@reduxjs/toolkit": "1.9.5",
         "@suite-common/fiat-services": "workspace:*",
         "@suite-common/graph": "workspace:*",
-        "@suite-common/suite-constants": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",

--- a/suite-native/module-accounts-management/src/selectors.ts
+++ b/suite-native/module-accounts-management/src/selectors.ts
@@ -1,35 +1,41 @@
-import { NetworkSymbol, getNetworkType } from '@suite-common/wallet-config';
-import { BITCOIN_ONLY_NETWORKS } from '@suite-common/suite-constants';
+import { D, pipe } from '@mobily/ts-belt';
+
+import { NetworkSymbol, getNetworkType, networks } from '@suite-common/wallet-config';
 import {
     FeatureFlagsRootState,
     selectIsFeatureFlagEnabled,
     FeatureFlag,
 } from '@suite-native/feature-flags';
 
-const SEND_COINS_WHITELIST = BITCOIN_ONLY_NETWORKS;
+const PRODUCTION_SEND_COINS_WHITELIST = pipe(
+    networks,
+    D.filter(network => network.networkType === 'bitcoin' || network.networkType === 'ethereum'),
+    D.keys,
+);
 
 export const selectIsNetworkSendFlowEnabled = (
     state: FeatureFlagsRootState,
     networkSymbol?: NetworkSymbol,
 ) => {
     if (!networkSymbol) return false;
-
-    if (SEND_COINS_WHITELIST.includes(networkSymbol)) return true;
-
-    const isBitcoinLikeSendEnabled = selectIsFeatureFlagEnabled(
-        state,
-        FeatureFlag.IsBitcoinLikeSendEnabled,
-    );
-
     const networkType = getNetworkType(networkSymbol);
-    if (isBitcoinLikeSendEnabled && networkType === 'bitcoin') return true;
 
-    const isEthereumSendEnabled = selectIsFeatureFlagEnabled(
+    if (PRODUCTION_SEND_COINS_WHITELIST.includes(networkSymbol)) return true;
+
+    const isRippleSendEnabled = selectIsFeatureFlagEnabled(state, FeatureFlag.IsRippleSendEnabled);
+
+    if (isRippleSendEnabled && networkType === 'ripple') return true;
+
+    const isCardanoSendEnabled = selectIsFeatureFlagEnabled(
         state,
-        FeatureFlag.IsEthereumSendEnabled,
+        FeatureFlag.IsCardanoSendEnabled,
     );
 
-    if (isEthereumSendEnabled && networkType === 'ethereum') return true;
+    if (isCardanoSendEnabled && networkType === 'cardano') return true;
+
+    const isSolanaSendEnabled = selectIsFeatureFlagEnabled(state, FeatureFlag.IsSolanaSendEnabled);
+
+    if (isSolanaSendEnabled && networkType === 'solana') return true;
 
     return false;
 };

--- a/suite-native/module-accounts-management/tsconfig.json
+++ b/suite-native/module-accounts-management/tsconfig.json
@@ -7,9 +7,6 @@
         },
         { "path": "../../suite-common/graph" },
         {
-            "path": "../../suite-common/suite-constants"
-        },
-        {
             "path": "../../suite-common/wallet-config"
         },
         {

--- a/suite-native/module-dev-utils/src/components/FeatureFlags.tsx
+++ b/suite-native/module-dev-utils/src/components/FeatureFlags.tsx
@@ -3,8 +3,9 @@ import { FeatureFlag as FeatureFlagEnum, useFeatureFlag } from '@suite-native/fe
 
 const featureFlagsTitleMap = {
     [FeatureFlagEnum.IsDeviceConnectEnabled]: 'Connect device',
-    [FeatureFlagEnum.IsBitcoinLikeSendEnabled]: 'Bitcoin-like coins send',
-    [FeatureFlagEnum.IsEthereumSendEnabled]: 'Ethereum-like coins send',
+    [FeatureFlagEnum.IsRippleSendEnabled]: 'Ripple send',
+    [FeatureFlagEnum.IsCardanoSendEnabled]: 'Cardano send',
+    [FeatureFlagEnum.IsSolanaSendEnabled]: 'Solana send',
     [FeatureFlagEnum.IsRegtestEnabled]: 'Regtest',
     [FeatureFlagEnum.IsSolanaEnabled]: 'Solana',
     [FeatureFlagEnum.IsConnectPopupEnabled]: 'Connect Popup',

--- a/yarn.lock
+++ b/yarn.lock
@@ -9941,7 +9941,6 @@ __metadata:
     "@reduxjs/toolkit": "npm:1.9.5"
     "@suite-common/fiat-services": "workspace:*"
     "@suite-common/graph": "workspace:*"
-    "@suite-common/suite-constants": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"


### PR DESCRIPTION
## Description
- send of Bitcoin and Ethereum based coins is enabled in production builds
- Ripple, Solana and Cardano send is hidden behind feature flag
