### PR TITLE
fix(suite-native): txn detail visual fixes

### DIFF
--- a/suite-native/transactions/src/components/TransactionDetail/TransactionDetailHeader.tsx
+++ b/suite-native/transactions/src/components/TransactionDetail/TransactionDetailHeader.tsx
@@ -55,13 +55,15 @@ export const TransactionDetailHeader = ({
     const isPendingTx = isPending(transaction);
     const isFailedTx = transaction.type === 'failed';
     const signValue = getTransactionValueSign(tokenTransfer?.type ?? transaction.type);
+    const isTokenOnlyTransaction = transaction.amount === '0' && transaction.tokens.length !== 0;
+    const txType = isTokenOnlyTransaction ? transaction.tokens[0].type : type;
 
     return (
         <DiscreetTextTrigger>
             <Box alignItems="center">
                 <VStack spacing="sp16" alignItems="center" justifyContent="center">
                     <TransactionIcon
-                        transactionType={type}
+                        transactionType={txType}
                         isAnimated={isPendingTx}
                         containerSize={ICON_SIZE}
                         iconSize="extraLarge"
@@ -86,7 +88,7 @@ export const TransactionDetailHeader = ({
                         )
                     )}
 
-                    <Box>
+                    <Box flexDirection="row">
                         {!isFailedTx && (
                             <SignValueFormatter
                                 color="textDefault"


### PR DESCRIPTION
1. some txns had wrong icon for token only txn detail
2. txn detail amount has wrong layout 

## Screenshots:
this txn:
<img width=280 src="https://github.com/user-attachments/assets/92c9160c-17d0-44a5-b15c-b528ac17ac4f" />

before:
<img width=280 src="https://github.com/user-attachments/assets/f4620cfc-454d-4237-8aaf-03a84f39cc7f" />

after:
<img width=280 src="https://github.com/user-attachments/assets/6851ea6b-60e7-4a2e-b5be-dd396a1cc807" />

