### PR TITLE
fix(connect): eip1559 set maxFeePerGas = maxPriorityFeePerGas

### DIFF
--- a/packages/connect/src/api/ethereum/api/ethereumSignTransaction.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumSignTransaction.ts
@@ -160,7 +160,7 @@ export default class EthereumSignTransaction extends AbstractMethod<
             ...signature,
             type: isLegacy ? 0 : 2, // 0 for legacy, 2 for EIP-1559
             gasPrice: isLegacy ? tx.gasPrice : null,
-            maxFeePerGas: isLegacy ? tx.maxFeePerGas : undefined,
+            maxFeePerGas: isLegacy ? tx.maxFeePerGas : tx.maxPriorityFeePerGas,
             maxPriorityFeePerGas: !isLegacy ? tx.maxPriorityFeePerGas : undefined,
         } as LegacyTxData | FeeMarketEIP1559TxData;
 


### PR DESCRIPTION
## Description

Seems like @ethereumjs handles `maxFeePerGas = undefined` as `maxFeePerGas = 0`, which doesn't work since `maxFeePerGas >= maxPriorityFeePerGas` must be true.

Therefore we set `maxFeePerGas = maxPriorityFeePerGas` to get the expected behavior


[canary-fw / methods-ethereum-node](https://github.com/trezor/trezor-suite/actions/runs/11741957405/job/32711763482)
[canary-fw / methods-ethereum-web](https://github.com/trezor/trezor-suite/actions/runs/11741957405/job/32711763069)