### PR TITLE
chore(suite-analytics): remove suite-analytics from common code

### DIFF
--- a/packages/suite/src/actions/firmware/__fixtures__/firmwareActions.ts
+++ b/packages/suite/src/actions/firmware/__fixtures__/firmwareActions.ts
@@ -187,6 +187,15 @@ export const actions = [
                 { type: firmwareActions.cacheDevice.type, payload: bootloaderDevice },
                 { type: firmwareActions.setStatus.type, payload: 'error' },
                 { type: firmwareActions.setFirmwareUpdateError.type, payload: 'foo' },
+                {
+                    type: firmwareUpdate.rejected.type,
+                    payload: {
+                        device: bootloaderDevice,
+                        error: 'foo',
+                        toBtcOnly: false,
+                        toFwVersion: '2.0.0',
+                    },
+                },
             ],
         },
     },
@@ -217,6 +226,15 @@ export const actions = [
                 {
                     type: firmwareActions.setFirmwareUpdateError.type,
                     payload: 'Firmware install failed',
+                },
+                {
+                    type: firmwareUpdate.rejected.type,
+                    payload: {
+                        device: bootloaderDevice,
+                        error: 'Firmware install failed',
+                        toBtcOnly: false,
+                        toFwVersion: '2.0.0',
+                    },
                 },
             ],
         },

--- a/suite-common/wallet-core/package.json
+++ b/suite-common/wallet-core/package.json
@@ -32,7 +32,6 @@
         "@trezor/connect": "workspace:*",
         "@trezor/device-utils": "workspace:*",
         "@trezor/env-utils": "workspace:*",
-        "@trezor/suite-analytics": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
         "date-fns": "^2.30.0",

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -11,7 +11,6 @@ import TrezorConnect, {
     DeviceState,
 } from '@trezor/connect';
 import { TrezorDevice } from '@suite-common/suite-types';
-import { analytics, EventType } from '@trezor/suite-analytics';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {
     sortByTimestamp,
@@ -87,20 +86,15 @@ export const selectDeviceThunk = createThunk<void, SelectDeviceThunkParams, void
  */
 export const toggleRememberDevice = createThunk(
     `${DEVICE_MODULE_PREFIX}/toggleRememberDevice`,
-    ({ device, forceRemember }: { device: TrezorDevice; forceRemember?: true }, { dispatch }) => {
-        analytics.report({
-            type: device.remember ? EventType.SwitchDeviceForget : EventType.SwitchDeviceRemember,
-        });
-
-        return dispatch(
+    ({ device, forceRemember }: { device: TrezorDevice; forceRemember?: true }, { dispatch }) =>
+        dispatch(
             deviceActions.rememberDevice({
                 device,
                 remember: !device.remember || !!forceRemember,
                 // if device is already remembered, do not force it, it would remove the remember on return to suite
                 forceRemember: device.remember ? undefined : forceRemember,
             }),
-        );
-    },
+        ),
 );
 
 export type CreateDeviceInstanceError = {

--- a/suite-common/wallet-core/tsconfig.json
+++ b/suite-common/wallet-core/tsconfig.json
@@ -24,9 +24,6 @@
         { "path": "../../packages/connect" },
         { "path": "../../packages/device-utils" },
         { "path": "../../packages/env-utils" },
-        {
-            "path": "../../packages/suite-analytics"
-        },
         { "path": "../../packages/type-utils" },
         { "path": "../../packages/utils" }
     ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -9207,7 +9207,6 @@ __metadata:
     "@trezor/connect": "workspace:*"
     "@trezor/device-utils": "workspace:*"
     "@trezor/env-utils": "workspace:*"
-    "@trezor/suite-analytics": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     date-fns: "npm:^2.30.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

During optimization of suite-native build, I found out that `@suite-common/wallet-core` depends on `@trezor/suite-analytics`, so mobile app also depends on web/desktop analytics package. This PR fixes that by reporting the same events from middleware in suite package.

Please test that it works the same as before 🙏 
