### PR TITLE
fix(components): ResizableBox fractional height

### DIFF
--- a/packages/components/src/components/ResizableBox/ResizableBox.tsx
+++ b/packages/components/src/components/ResizableBox/ResizableBox.tsx
@@ -5,6 +5,8 @@ import styled, { css } from 'styled-components';
 import { createCooldown } from '@trezor/utils';
 import { ZIndexValues, zIndices } from '@trezor/theme';
 
+import { getSafeWindowSize } from '../../utils/getSafeWindowSize';
+
 type Direction = 'top' | 'left' | 'right' | 'bottom';
 type Directions = Array<Direction>;
 
@@ -292,11 +294,12 @@ export const ResizableBox = ({
 
         window.onresize = () => {
             if (resizeCooldown() === true) {
+                const { windowHeight, windowWidth } = getSafeWindowSize();
                 if (updateHeightOnWindowResize) {
-                    setNewHeight(getMaxResult(maxHeight, window.innerHeight));
+                    setNewHeight(getMaxResult(maxHeight, windowHeight));
                 }
                 if (updateWidthOnWindowResize) {
-                    setNewWidth(getMaxResult(maxWidth, window.innerWidth));
+                    setNewWidth(getMaxResult(maxWidth, windowWidth));
                 }
             }
         };

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -85,6 +85,7 @@ export * from './constants/keyboardEvents';
 export * from './utils/useScrollShadow';
 export * from './utils/transientProps';
 export { useMediaQuery } from './utils/useMediaQuery';
+export { getSafeWindowSize } from './utils/getSafeWindowSize';
 
 export { intermediaryTheme } from './config/colors';
 export type { SuiteThemeColors } from './config/colors';

--- a/packages/components/src/utils/getSafeWindowSize.ts
+++ b/packages/components/src/utils/getSafeWindowSize.ts
@@ -1,0 +1,19 @@
+const roundDownFloatOrFallback = (value: string, fallback: number) => {
+    const parsed = Math.floor(parseFloat(value));
+
+    return Number.isNaN(parsed) ? fallback : parsed;
+};
+
+/**
+ * Get window size and try to round it down if it's a fractional number.
+ * Can happen at Windows with scaling enabled, see https://github.com/trezor/trezor-suite/issues/15195
+ */
+export const getSafeWindowSize = () => {
+    // window.innerWidth is always integer, but computedStyle bears the actual value if it's fractional
+    const computedStyle = window.getComputedStyle(document.body);
+    // but we have to convert from 'px' to number, so let's do it safely with fallback
+    const windowWidth = roundDownFloatOrFallback(computedStyle.width, window.innerWidth);
+    const windowHeight = roundDownFloatOrFallback(computedStyle.height, window.innerHeight);
+
+    return { windowWidth, windowHeight };
+};


### PR DESCRIPTION
## Description

- `ResizableBox` currently works with `window.innerHeight` (and `width` analogically).
- On Windows 10 with display scaling set to 125%, windows can have fractional height
  - :thought_balloon:  _discovered with 125%, but I assume it will do this with any value **not** multiple of 100%_
  - I don't know if there is any other case where window size can be fractional
- But `window.innerHeight` is always integer, rounded up
- This can cause `ResizableBox` to exceed window height by fraction of pixel, enough to create scrollbar :see_no_evil: 
- :arrow_right: use `window.getComputedStyle.height`, which provides the exact fractional value, and round it down

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/15195

## Screenshots:

See issue for screenshot of bug :bug: 
Cannot be reproduced on this branch :heavy_check_mark: 
(On Win 10, I tested both 24.11.1 RC (bug) and build from this branch (fixed))