### PR TITLE
revert adding standard wallet for only passphrase wallet remembered

### DIFF
--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -282,22 +282,6 @@ export const selectVisibleNonEmptyDeviceAccountsByNetworkSymbol = (
 export const selectNonEmptyDeviceAccounts = (state: AccountsRootState & DeviceRootState) =>
     selectDeviceAccounts(state).filter(account => !account.empty);
 
-export const selectDeviceHasAccountsByDeviceState = memoizeWithArgs(
-    (
-        state: AccountsRootState & DeviceRootState,
-        deviceState: StaticSessionId | DeviceState | undefined,
-    ) => {
-        if (!deviceState) {
-            return false;
-        }
-
-        return selectAccountsByDeviceState(state, deviceState).length > 0;
-    },
-    {
-        size: 10,
-    },
-);
-
 export const selectAccountsByNetworkAndDeviceState = memoizeWithArgs(
     (state: AccountsRootState, deviceState: StaticSessionId, networkSymbol: NetworkSymbol) => {
         const accounts = selectAccounts(state);

--- a/suite-native/device-manager/package.json
+++ b/suite-native/device-manager/package.json
@@ -25,7 +25,6 @@
         "@suite-native/intl": "workspace:*",
         "@suite-native/link": "workspace:*",
         "@suite-native/navigation": "workspace:*",
-        "@suite-native/settings": "workspace:*",
         "@trezor/styles": "workspace:*",
         "@trezor/theme": "workspace:*",
         "jotai": "1.9.1",

--- a/suite-native/device-manager/src/components/WalletItem.tsx
+++ b/suite-native/device-manager/src/components/WalletItem.tsx
@@ -6,17 +6,9 @@ import { Translation } from '@suite-native/intl';
 import { Icon } from '@suite-native/icons';
 import { TrezorDevice } from '@suite-common/suite-types';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
-import {
-    AccountsRootState,
-    DeviceRootState,
-    FiatRatesRootState,
-    selectDevice,
-    selectDeviceByState,
-    selectDeviceHasAccountsByDeviceState,
-} from '@suite-common/wallet-core';
+import { selectDevice, selectDeviceByState } from '@suite-common/wallet-core';
 import { FiatAmountFormatter } from '@suite-native/formatters';
 import { selectDeviceTotalFiatBalanceNative } from '@suite-native/device';
-import { SettingsSliceRootState } from '@suite-native/settings';
 
 type WalletItemProps = {
     deviceState: NonNullable<TrezorDevice['state']>;
@@ -61,14 +53,10 @@ const labelStyle = prepareNativeStyle(() => ({
 
 export const WalletItem = ({ deviceState, onPress, isSelectable = true }: WalletItemProps) => {
     const { applyStyle } = useNativeStyles();
-    const device = useSelector((state: DeviceRootState) => selectDeviceByState(state, deviceState));
-    const hasAccounts = useSelector((state: AccountsRootState & DeviceRootState) =>
-        selectDeviceHasAccountsByDeviceState(state, device?.state),
-    );
+    const device = useSelector((state: any) => selectDeviceByState(state, deviceState));
     const selectedDevice = useSelector(selectDevice);
-    const fiatBalance = useSelector(
-        (state: AccountsRootState & FiatRatesRootState & SettingsSliceRootState) =>
-            selectDeviceTotalFiatBalanceNative(state, deviceState.staticSessionId!),
+    const fiatBalance = useSelector((state: any) =>
+        selectDeviceTotalFiatBalanceNative(state, deviceState.staticSessionId!),
     );
 
     if (!device) {
@@ -105,13 +93,11 @@ export const WalletItem = ({ deviceState, onPress, isSelectable = true }: Wallet
                     </Text>
                 </HStack>
                 <HStack alignItems="center" spacing="sp12">
-                    {hasAccounts && (
-                        <FiatAmountFormatter
-                            value={String(fiatBalance)}
-                            variant="hint"
-                            color="textSubdued"
-                        />
-                    )}
+                    <FiatAmountFormatter
+                        value={String(fiatBalance)}
+                        variant="hint"
+                        color="textSubdued"
+                    />
                     {isSelectable && <Radio value="" onPress={onPress} isChecked={isSelected} />}
                 </HStack>
             </HStack>

--- a/suite-native/device-manager/tsconfig.json
+++ b/suite-native/device-manager/tsconfig.json
@@ -20,7 +20,6 @@
         { "path": "../intl" },
         { "path": "../link" },
         { "path": "../navigation" },
-        { "path": "../settings" },
         { "path": "../../packages/styles" },
         { "path": "../../packages/theme" }
     ]

--- a/suite-native/device/src/middlewares/deviceMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceMiddleware.ts
@@ -1,5 +1,4 @@
 import { AnyAction, isAnyOf } from '@reduxjs/toolkit';
-import { A } from '@mobily/ts-belt';
 
 import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
 import { DEVICE } from '@trezor/connect';
@@ -14,8 +13,6 @@ import {
     selectAccountsByDeviceState,
     createDeviceInstanceThunk,
     createImportedDeviceThunk,
-    selectDevice,
-    selectDeviceInstances,
 } from '@suite-common/wallet-core';
 import { FeatureFlag, selectIsFeatureFlagEnabled } from '@suite-native/feature-flags';
 import { clearAndUnlockDeviceAccessQueue } from '@suite-native/device-mutex';
@@ -41,7 +38,7 @@ const isActionDeviceRelated = (action: AnyAction): boolean => {
 };
 
 export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps(
-    async (action, { dispatch, next, getState }) => {
+    (action, { dispatch, next, getState }) => {
         if (action.type === DEVICE.DISCONNECT) {
             dispatch(forgetDisconnectedDevices(action.payload));
         }
@@ -78,26 +75,7 @@ export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps(
             case DEVICE.CONNECT:
             case DEVICE.CONNECT_UNACQUIRED:
                 if (isUsbDeviceConnectFeatureEnabled) {
-                    await dispatch(selectDeviceThunk(action.payload));
-
-                    const deviceInstances = selectDeviceInstances(getState());
-                    const selectedDevice = selectDevice(getState());
-
-                    // If there is selected device, but no useEmptyPassphrase device for connected trezor,
-                    // add normal wallet but keep the original one selected.
-                    // This happens after connecting device with only remembered passphrases wallet.
-                    if (
-                        selectedDevice &&
-                        A.isEmpty(deviceInstances.filter(d => d.useEmptyPassphrase))
-                    ) {
-                        await dispatch(
-                            createDeviceInstanceThunk({
-                                device: selectedDevice,
-                                useEmptyPassphrase: true,
-                            }),
-                        );
-                        dispatch(selectDeviceThunk({ device: selectedDevice }));
-                    }
+                    dispatch(selectDeviceThunk(action.payload));
                 }
                 break;
             case DEVICE.DISCONNECT:

--- a/yarn.lock
+++ b/yarn.lock
@@ -9636,7 +9636,6 @@ __metadata:
     "@suite-native/intl": "workspace:*"
     "@suite-native/link": "workspace:*"
     "@suite-native/navigation": "workspace:*"
-    "@suite-native/settings": "workspace:*"
     "@trezor/styles": "workspace:*"
     "@trezor/theme": "workspace:*"
     jotai: "npm:1.9.1"


### PR DESCRIPTION

This reverts commit 9e4882a35af4fe5acd765ea7e0026d7ed0e91aef.

This solution brought some problems with passphrase. The goal is to revert and add just fake standard wallet to device manager and add after user clicks it.



## Related Issue

Opens #12722 again


