### PR TITLE
Add fw 2.8.5

### DIFF
--- a/packages/connect-common/files/firmware/t2b1/releases.json
+++ b/packages/connect-common/files/firmware/t2b1/releases.json
@@ -5,7 +5,7 @@
         "min_firmware_version": [2, 6, 1],
         "min_bootloader_version": [2, 1, 1],
         "bootloader_version": [2, 1, 4],
-        "translations": ["cs-CZ", "de-DE", "es-ES", "fr-FR"],
+        "translations": ["cs-CZ", "de-DE", "es-ES", "fr-FR", "it-IT", "pt-BR", "tr-TR"],
         "url": "firmware/t2b1/trezor-t2b1-2.8.0.bin",
         "url_bitcoinonly": "firmware/t2b1/trezor-t2b1-2.8.0-bitcoinonly.bin",
         "fingerprint": "cf3ce230a69a681199f74cf6ac8c6c431f8fa7e0d0183437f93c5cc029fbd155",

--- a/packages/connect-common/files/firmware/t2t1/releases.json
+++ b/packages/connect-common/files/firmware/t2t1/releases.json
@@ -5,7 +5,7 @@
         "min_firmware_version": [2, 0, 8],
         "min_bootloader_version": [2, 0, 0],
         "bootloader_version": [2, 1, 6],
-        "translations": ["cs-CZ", "de-DE", "es-ES", "fr-FR"],
+        "translations": ["cs-CZ", "de-DE", "es-ES", "fr-FR", "it-IT", "pt-BR", "tr-TR"],
         "url": "firmware/t2t1/trezor-t2t1-2.8.1.bin",
         "url_bitcoinonly": "firmware/t2t1/trezor-t2t1-2.8.1-bitcoinonly.bin",
         "fingerprint": "d3af84a212d32785449ca6575e3cf2a641920b353a82dec9f059083ea5d4b149",

--- a/packages/connect-common/files/firmware/t3b1/releases.json
+++ b/packages/connect-common/files/firmware/t3b1/releases.json
@@ -5,7 +5,7 @@
         "min_firmware_version": [2, 8, 3],
         "min_bootloader_version": [2, 1, 8],
         "bootloader_version": [2, 1, 8],
-        "translations": ["cs-CZ", "de-DE", "es-ES", "fr-FR", "it-IT", "pt-BR"],
+        "translations": ["cs-CZ", "de-DE", "es-ES", "fr-FR", "it-IT", "pt-BR", "tr-TR"],
         "url": "firmware/t3b1/trezor-t3b1-2.8.3.bin",
         "url_bitcoinonly": "firmware/t3b1/trezor-t3b1-2.8.3-bitcoinonly.bin",
         "fingerprint": "b659bdc5ddce208d46ce649fc7a8995ae49541c7c41a88ddaac5dfc038ffb5de",

--- a/packages/connect-common/files/firmware/t3t1/releases.json
+++ b/packages/connect-common/files/firmware/t3t1/releases.json
@@ -1,6 +1,35 @@
 [
     {
         "required": false,
+        "version": [2, 8, 5],
+        "min_firmware_version": [2, 7, 2],
+        "min_bootloader_version": [2, 1, 6],
+        "bootloader_version": [2, 1, 9],
+        "translations": ["cs-CZ", "de-DE", "es-ES", "fr-FR", "it-IT", "pt-BR", "tr-TR"],
+        "url": "firmware/t3t1/trezor-t3t1-2.8.5.bin",
+        "url_bitcoinonly": "firmware/t3t1/trezor-t3t1-2.8.5-bitcoinonly.bin",
+        "fingerprint": "1b6ff3ae72aac4410782b89a67261b1db2f66b03e2fe3fe25f0508d223b4b668",
+        "fingerprint_bitcoinonly": "a2512b2e19a005c9ef92045c5adbd13b64597c7910752a5e68c57661da08b3c0",
+        "firmware_revision": "a61e783448043760a7c925e017bd08a4673a61c8",
+        "changelog": [
+            "- Simplified UI of Cardano flows initiated by Trezor Suite.",
+            "- New EVM call contract flow UI.",
+            "- Show account info in ETH send/stake flow.",
+            "- Fix ETH account number detection.",
+            "- Fix XPUB confirmed success screen title.",
+            "- Display menu items on two lines when one line is not enough.",
+            "- Fixed missing footer page hints in info about remaining shares in super-shamir recovery.",
+            "- Add instruction to Swipe up after changing brightness."
+        ],
+        "changelog_bitcoinonly": [
+            "- Fix XPUB confirmed success screen title.",
+            "- Display menu items on two lines when one line is not enough.",
+            "- Fixed missing footer page hints in info about remaining shares in super-shamir recovery.",
+            "- Add instruction to Swipe up after changing brightness."
+        ]
+    },
+    {
+        "required": false,
         "version": [2, 8, 3],
         "min_firmware_version": [2, 7, 2],
         "min_bootloader_version": [2, 1, 6],

--- a/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.3-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.3-bitcoinonly.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:49996a1a602f08809427cf3b959f3c70eeef1fcfd45f267bd6d058496a4cc37e
-size 1172992

--- a/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.3.bin
+++ b/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.3.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9f68696478e09d7bf8b8f5181413d8a5386b37571dc2f5ed8511a24f4c1d35b7
-size 1555456

--- a/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.5-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.5-bitcoinonly.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81129e39ea032e1476aef5bcf1ede317de425a919ef426bb4126a612e8984bdf
+size 1145856

--- a/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.5.bin
+++ b/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.5.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89c0541bccdf759e997257d9bac0ee71f79011a4cbf5fc42e907dd5872a47b76
+size 1528832


### PR DESCRIPTION
DO NOT MERGE

Add FW 2.8.5 for T3T1.

Something is broken though, firmware hash check gives RSOD as soon as Trezor is connected.