### PR TITLE
fix(suite): fix typo in settings for device homescreen

### DIFF
--- a/packages/suite/src/views/settings/SettingsDevice/Homescreen.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/Homescreen.tsx
@@ -145,7 +145,7 @@ export const Homescreen = ({ isDeviceLocked }: HomescreenProps) => {
                                 data-testid="@settings/device/homescreen-upload"
                                 key="@settings/device/homescreen-upload"
                             >
-                                <Translation id="TR_DEVICE_SETTINGS_HOMESCREEN_UPLOAD_IMAGE" />s
+                                <Translation id="TR_DEVICE_SETTINGS_HOMESCREEN_UPLOAD_IMAGE" />
                             </Button>
                             <Button
                                 onClick={openGallery}


### PR DESCRIPTION
Fixing small typo in in settings for device homescreen
Before
![image](https://github.com/user-attachments/assets/963f900f-74db-4881-bac2-5d2301d1e00a)
After
<img width="828" alt="image" src="https://github.com/user-attachments/assets/4c65204b-c6b2-4fb3-a5fc-818c117b2d7d">
