### PR TITLE
CLONE: fix(suite): order of network filter #15289

### DIFF
--- a/packages/suite/src/actions/settings/__fixtures__/walletSettings.ts
+++ b/packages/suite/src/actions/settings/__fixtures__/walletSettings.ts
@@ -46,7 +46,7 @@ export default [
         initialState: { enabledNetworks: [] },
         action: () => walletSettingsActions.changeNetworks(['ltc', 'eth']),
         result: {
-            enabledNetworks: ['ltc', 'eth'],
+            enabledNetworks: ['eth', 'ltc'],
         },
     },
     {

--- a/packages/suite/src/reducers/wallet/settingsReducer.ts
+++ b/packages/suite/src/reducers/wallet/settingsReducer.ts
@@ -1,12 +1,13 @@
 import produce from 'immer';
 
-import { WalletSettings } from '@suite-common/wallet-types';
+import type { WalletSettings } from '@suite-common/wallet-types';
 import { PROTO } from '@trezor/connect';
+import { networkSymbolCollection } from '@suite-common/wallet-config';
 
-import { STORAGE } from 'src/actions/suite/constants';
 import { WALLET_SETTINGS } from 'src/actions/settings/constants';
 import * as walletSettingsActions from 'src/actions/settings/walletSettingsActions';
-import { Action, AppState } from 'src/types/suite';
+import { STORAGE } from 'src/actions/suite/constants';
+import type { Action, AppState } from 'src/types/suite';
 
 export type State = WalletSettings;
 
@@ -36,7 +37,10 @@ const settingsReducer = (state: State = initialState, action: Action): State =>
 
             case walletSettingsActions.changeNetworks.type: {
                 if (walletSettingsActions.changeNetworks.match(action)) {
-                    draft.enabledNetworks = action.payload;
+                    draft.enabledNetworks = [...action.payload].sort(
+                        (a, b) =>
+                            networkSymbolCollection.indexOf(a) - networkSymbolCollection.indexOf(b),
+                    );
                 }
                 break;
             }

--- a/packages/suite/src/storage/CHANGELOG.md
+++ b/packages/suite/src/storage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Storage changelog
 
+## 49
+
+-   networks now have same order everywhere
+
 ## 48
 
 -   device state to new object format (`device._state` -> `device.state`)

--- a/packages/suite/src/storage/index.ts
+++ b/packages/suite/src/storage/index.ts
@@ -5,7 +5,7 @@ import { reloadApp } from 'src/utils/suite/reload';
 import { migrate } from './migrations';
 import type { SuiteDBSchema } from './definitions';
 
-const VERSION = 48; // don't forget to add migration and CHANGELOG when changing versions!
+const VERSION = 49; // don't forget to add migration and CHANGELOG when changing versions!
 
 /**
  *  If the object stores don't already exist then creates them.

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -2,7 +2,7 @@ import { toWei } from 'web3-utils';
 
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { isDesktop } from '@trezor/env-utils';
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import { NetworkSymbol, networkSymbolCollection } from '@suite-common/wallet-config';
 import type { BackendSettings } from '@suite-common/wallet-types';
 import type { OnUpgradeFunc } from '@trezor/suite-storage';
 import {
@@ -1123,6 +1123,16 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
             }
 
             return device;
+        });
+    }
+
+    if (oldVersion < 49) {
+        await updateAll(transaction, 'walletSettings', walletSettings => {
+            walletSettings.enabledNetworks.sort(
+                (a, b) => networkSymbolCollection.indexOf(a) - networkSymbolCollection.indexOf(b),
+            );
+
+            return walletSettings;
         });
     }
 };

--- a/suite-common/wallet-config/src/utils.ts
+++ b/suite-common/wallet-config/src/utils.ts
@@ -14,6 +14,11 @@ export const NORMAL_ACCOUNT_TYPE = 'normal' satisfies AccountType;
  */
 export const networksCollection: Network[] = Object.values(networks);
 
+/**
+ * array of network symbols
+ */
+export const networkSymbolCollection = networksCollection.map(n => n.symbol);
+
 export const getMainnets = (debug = false) =>
     networksCollection.filter(n => !n.testnet && (!n.isDebugOnlyNetwork || debug));
 


### PR DESCRIPTION
## Description

- clone of #15289 with added migration

Fixed order of network filter. The order is now the same as the account order.

## Related Issue

Resolve #9165