### PR TITLE
feat(suite-native): fetch token definitions while importing account

### DIFF
--- a/suite-native/module-accounts-import/src/accountsImportThunks.ts
+++ b/suite-native/module-accounts-import/src/accountsImportThunks.ts
@@ -12,8 +12,11 @@ import { getAccountIdentity, shouldUseIdentities } from '@suite-common/wallet-ut
 import { Timestamp, TokenAddress } from '@suite-common/wallet-types';
 import { FiatCurrencyCode } from '@suite-common/suite-config';
 import {
+    DefinitionType,
+    getTokenDefinitionThunk,
     periodicCheckTokenDefinitionsThunk,
     selectFilterKnownTokens,
+    selectNetworkTokenDefinitions,
 } from '@suite-common/token-definitions';
 
 import { paymentTypeToAccountType } from './constants';
@@ -116,6 +119,17 @@ export const getAccountInfoThunk = createThunk<
             ]);
 
             if (fetchedAccountInfo?.success) {
+                const tokenDefinitions = selectNetworkTokenDefinitions(getState(), networkSymbol);
+
+                // fetch token definitions for this network in case they are needed
+                if (!tokenDefinitions) {
+                    await dispatch(
+                        getTokenDefinitionThunk({
+                            networkSymbol,
+                            type: DefinitionType.COIN,
+                        }),
+                    );
+                }
                 // fetch fiat rates for all tokens of newly discovered account
                 // Even that there is check in updateFiatRatesThunk, it is better to do it here and do not dispatch thunk at all because it has some overhead and sometimes there could be lot of tokens
                 const knownTokens = selectFilterKnownTokens(


### PR DESCRIPTION
While fetching account data for imported account, fetch also token definitions for this network, if needed.

## Related Issue

Resolve #15332

## Screenshots:

https://github.com/user-attachments/assets/71759c78-e00f-4cdc-847b-608e02e5d84c



