### PR TITLE
fix(suite-native): checksum alert displayed for ethereum only

### DIFF
--- a/suite-native/module-send/src/components/AddressChecksumMessage.tsx
+++ b/suite-native/module-send/src/components/AddressChecksumMessage.tsx
@@ -1,3 +1,5 @@
+import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
+
 import { Link } from '@suite-native/link';
 import { HStack, Text } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
@@ -6,23 +8,25 @@ import { Translation } from '@suite-native/intl';
 const LINK_URL = 'https://trezor.io/learn/a/evm-address-checksum-in-trezor-suite';
 
 export const AddressChecksumMessage = () => (
-    <HStack>
-        <Icon name="info" size="medium" color="iconSubdued" />
-        <Text variant="label" color="textSubdued">
-            <Translation
-                id="moduleSend.outputs.recipients.checksum.label"
-                values={{
-                    link: linkChunk => (
-                        <Link
-                            href={LINK_URL}
-                            label={linkChunk}
-                            textVariant="label"
-                            isUnderlined
-                            textColor="textSubdued"
-                        />
-                    ),
-                }}
-            />
-        </Text>
-    </HStack>
+    <Animated.View entering={FadeIn} exiting={FadeOut}>
+        <HStack>
+            <Icon name="info" size="medium" color="iconSubdued" />
+            <Text variant="label" color="textSubdued">
+                <Translation
+                    id="moduleSend.outputs.recipients.checksum.label"
+                    values={{
+                        link: linkChunk => (
+                            <Link
+                                href={LINK_URL}
+                                label={linkChunk}
+                                textVariant="label"
+                                isUnderlined
+                                textColor="textSubdued"
+                            />
+                        ),
+                    }}
+                />
+            </Text>
+        </HStack>
+    </Animated.View>
 );

--- a/suite-native/module-send/src/hooks/useAddressValidationAlerts.tsx
+++ b/suite-native/module-send/src/hooks/useAddressValidationAlerts.tsx
@@ -14,6 +14,7 @@ import { isAddressValid } from '@suite-common/wallet-utils';
 import { AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
 import TrezorConnect from '@trezor/connect';
 import { Link } from '@suite-native/link';
+import { getNetworkType } from '@suite-common/wallet-config';
 
 import { getOutputFieldName } from '../utils';
 import { TokenOfNetworkAlertBody } from '../components/TokenOfNetworkAlertContent';
@@ -40,6 +41,7 @@ export const useAddressValidationAlerts = ({ inputIndex }: UseAddressValidationA
     const networkSymbol = useSelector((state: AccountsRootState) =>
         selectAccountNetworkSymbol(state, accountKey),
     );
+    const networkType = networkSymbol ? getNetworkType(networkSymbol) : null;
 
     const { watch, setValue } = useFormContext();
 
@@ -104,7 +106,10 @@ export const useAddressValidationAlerts = ({ inputIndex }: UseAddressValidationA
         const shouldShowTokenAlert =
             tokenContract && isFilledValidAddress && !wasTokenAlertDisplayed;
         const shouldChecksumAddress =
-            !wasAddressChecksummed && isFilledValidAddress && wasTokenAlertDisplayed;
+            networkType === 'ethereum' &&
+            !wasAddressChecksummed &&
+            isFilledValidAddress &&
+            wasTokenAlertDisplayed;
 
         if (shouldShowTokenAlert) {
             showAlert({
@@ -120,7 +125,7 @@ export const useAddressValidationAlerts = ({ inputIndex }: UseAddressValidationA
         } else if (shouldChecksumAddress) handleAddressChecksum();
         // TODO: add path for contract address alert: https://github.com/trezor/trezor-suite/issues/14936.
         else if (!isFilledValidAddress) {
-            setWasTokenAlertDisplayed(false);
+            if (tokenContract) setWasTokenAlertDisplayed(false);
             setWasAddressChecksummed(false);
         }
     }, [
@@ -129,6 +134,7 @@ export const useAddressValidationAlerts = ({ inputIndex }: UseAddressValidationA
         tokenContract,
         tokenSymbol,
         accountKey,
+        networkType,
         wasAddressChecksummed,
         handleAddressChecksum,
         wasTokenAlertDisplayed,


### PR DESCRIPTION
## Description
- Checksum alert is now displayed strictly for Ethereum-based networks only. The checksum message might have been displayed even for Bitcoin-based networks if the send form was entered with an already filled draft.
- Checksum message entering/exiting animation added (low-hanging fruit)


## Screenshots:
### BEFORE

https://github.com/user-attachments/assets/ab4b5804-6fee-489b-84fd-5ef3b6e1677a

### AFTER

https://github.com/user-attachments/assets/4822545a-c584-446e-8361-058be963a7eb


