### PR TITLE
fix(mobile): infite loading of fiat rates during discovery

### DIFF
--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesMiddleware.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesMiddleware.ts
@@ -108,21 +108,22 @@ export const prepareFiatRatesMiddleware = createMiddlewareWithExtraDeps(
         if (accountsActions.createIndexLabeledAccount.match(action)) {
             const localCurrency = selectLocalCurrency(getState());
 
-            const { tokens, symbol } = action.payload;
-            const tickers = tokens?.map(token => ({
+            const { tokens = [], symbol } = action.payload;
+            const tokenTickers = tokens.map(token => ({
                 symbol,
                 tokenAddress: token.contract as TokenAddress,
             }));
-            if (tickers) {
-                dispatch(
-                    updateFiatRatesThunk({
-                        tickers,
-                        rateType: 'current',
-                        localCurrency,
-                        fetchAttemptTimestamp: Date.now() as Timestamp,
-                    }),
-                );
-            }
+            // include main account fiat rate ticker
+            const tickers = [...tokenTickers, { symbol }];
+
+            dispatch(
+                updateFiatRatesThunk({
+                    tickers,
+                    rateType: 'current',
+                    localCurrency,
+                    fetchAttemptTimestamp: Date.now() as Timestamp,
+                }),
+            );
         }
 
         return next(action);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Main account was not included in fiat rates request but it worked because it was probably triggered by something else but randomly.

## Related Issue

Resolve #14785 

## Screenshots:
