### PR TITLE
chore: enable eslint recommendedTypeChecked

### DIFF
--- a/packages/eslint/src/typescriptConfig.mjs
+++ b/packages/eslint/src/typescriptConfig.mjs
@@ -2,6 +2,15 @@ import tseslint from 'typescript-eslint';
 
 export const typescriptConfig = [
     ...tseslint.configs.recommended,
+    ...tseslint.configs.recommendedTypeChecked,
+    {
+        languageOptions: {
+            parserOptions: {
+                projectService: true,
+                tsconfigRootDir: import.meta.dirname,
+            },
+        },
+    },
     {
         rules: {
             // Additional rules


### PR DESCRIPTION
Fails on `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory`

This will be probably very tricky to fix. Even 16GB of ram was not enough.