### PR TITLE
feat(suite-native): Send Custom Fee

### DIFF
--- a/packages/theme/src/spacings.ts
+++ b/packages/theme/src/spacings.ts
@@ -41,9 +41,10 @@ export const spacingsPx = (Object.keys(spacings) as Array<Spacing>).reduce((resu
     return result;
 }, {} as SpacingPx);
 
-type NativeSpacingValue = 2 | 4 | 8 | 12 | 16 | 20 | 24 | 32 | 40 | 52 | 64;
+type NativeSpacingValue = 1 | 2 | 4 | 8 | 12 | 16 | 20 | 24 | 32 | 40 | 52 | 64;
 
 export const nativeSpacings = {
+    sp1: 1,
     sp2: 2,
     sp4: 4,
     sp8: 8,

--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -368,6 +368,11 @@ export const selectAccountNetworkSymbol = createMemoizedSelector(
     account => account?.symbol ?? null,
 );
 
+export const selectAccountNetworkType = createMemoizedSelector(
+    [selectAccountByKey],
+    account => account?.networkType ?? null,
+);
+
 export const selectAccountAvailableBalance = createMemoizedSelector(
     [selectAccountByKey],
     account => account?.availableBalance ?? null,

--- a/suite-common/wallet-types/src/transaction.ts
+++ b/suite-common/wallet-types/src/transaction.ts
@@ -281,7 +281,7 @@ export type ExcludedUtxos = Record<string, 'low-anonymity' | 'dust' | undefined>
 export type FeeLevelLabel = FeeLevel['label'];
 
 export const isFinalPrecomposedTransaction = (
-    tx: GeneralPrecomposedTransaction,
+    tx?: GeneralPrecomposedTransaction,
 ): tx is PrecomposedTransactionFinal => {
-    return tx.type === 'final';
+    return !!tx && tx.type === 'final';
 };

--- a/suite-native/atoms/src/AlertBox.tsx
+++ b/suite-native/atoms/src/AlertBox.tsx
@@ -82,6 +82,7 @@ export type AlertBoxProps = {
     variant: AlertBoxVariant;
     title: ReactNode;
     borderRadius?: NativeRadius | number;
+    contentColor?: Color;
 };
 
 const AlertSpinner = ({ color }: { color: Color }) => {
@@ -92,9 +93,20 @@ const AlertSpinner = ({ color }: { color: Color }) => {
     return <ActivityIndicator size={16} color={colors[color]} />;
 };
 
-export const AlertBox = ({ title, variant = 'info', borderRadius = 'r16' }: AlertBoxProps) => {
+export const AlertBox = ({
+    title,
+    variant = 'info',
+    borderRadius = 'r16',
+    contentColor,
+}: AlertBoxProps) => {
     const { applyStyle } = useNativeStyles();
-    const { contentColor, backgroundColor, borderColor } = variantToColorMap[variant];
+    const {
+        contentColor: defaultContentColor,
+        backgroundColor,
+        borderColor,
+    } = variantToColorMap[variant];
+
+    const color = contentColor ?? defaultContentColor;
 
     return (
         <Box
@@ -105,11 +117,11 @@ export const AlertBox = ({ title, variant = 'info', borderRadius = 'r16' }: Aler
             })}
         >
             {variant === 'loading' ? (
-                <AlertSpinner color={contentColor} />
+                <AlertSpinner color={color} />
             ) : (
-                <Icon name={variantToIconName[variant]} color={contentColor} size="mediumLarge" />
+                <Icon name={variantToIconName[variant]} color={color} size="mediumLarge" />
             )}
-            <Text color={contentColor} variant="label" style={applyStyle(textStyle)}>
+            <Text color={color} variant="label" style={applyStyle(textStyle)}>
                 {title}
             </Text>
         </Box>

--- a/suite-native/atoms/src/Hint.tsx
+++ b/suite-native/atoms/src/Hint.tsx
@@ -7,7 +7,7 @@ import { Color } from '@trezor/theme';
 import { Text } from './Text';
 import { HStack } from './Stack';
 
-type HintVariant = 'hint' | 'error';
+type HintVariant = 'hint' | 'error' | 'info';
 
 type HintProps = {
     variant?: HintVariant;
@@ -37,6 +37,10 @@ const hintVariants: Record<HintVariant, { iconName: IconName; color: Color }> = 
     error: {
         color: 'textAlertRed',
         iconName: 'warningCircle',
+    },
+    info: {
+        color: 'textAlertBlue',
+        iconName: 'info',
     },
 };
 

--- a/suite-native/formatters/src/components/CryptoAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/CryptoAmountFormatter.tsx
@@ -10,6 +10,7 @@ import { FormatterProps } from '../types';
 import { EmptyAmountText } from './EmptyAmountText';
 import { AmountText } from './AmountText';
 import { formatNumberWithThousandCommas } from '../utils';
+import { EmptyAmountSkeleton } from './EmptyAmountSkeleton';
 
 type CryptoToFiatAmountFormatterProps = FormatterProps<string | null | number> &
     TextProps & {
@@ -18,6 +19,7 @@ type CryptoToFiatAmountFormatterProps = FormatterProps<string | null | number> &
         isDiscreetText?: boolean;
         decimals?: number;
         isForcedDiscreetMode?: boolean;
+        isLoading?: boolean;
     };
 
 export const CryptoAmountFormatter = React.memo(
@@ -28,10 +30,15 @@ export const CryptoAmountFormatter = React.memo(
         isDiscreetText = true,
         variant = 'hint',
         color = 'textSubdued',
+        isLoading = false,
         decimals,
         ...otherProps
     }: CryptoToFiatAmountFormatterProps) => {
         const { CryptoAmountFormatter: formatter } = useFormatters();
+
+        if (value === null || isLoading) {
+            return <EmptyAmountSkeleton />;
+        }
 
         if (G.isNullable(value)) return <EmptyAmountText />;
 

--- a/suite-native/formatters/src/components/CryptoToFiatAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/CryptoToFiatAmountFormatter.tsx
@@ -12,6 +12,7 @@ type CryptoToFiatAmountFormatterProps = FormatterProps<string | number | null> &
         useHistoricRate?: boolean;
         isBalance?: boolean;
         isForcedDiscreetMode?: boolean;
+        isLoading?: boolean;
     };
 
 export const CryptoToFiatAmountFormatter = ({
@@ -20,6 +21,7 @@ export const CryptoToFiatAmountFormatter = ({
     historicRate,
     useHistoricRate,
     isBalance = false,
+    isLoading = false,
     ...otherProps
 }: CryptoToFiatAmountFormatterProps) => {
     const fiatValue = useFiatFromCryptoValue({
@@ -30,5 +32,12 @@ export const CryptoToFiatAmountFormatter = ({
         cryptoValue: value ? value.toString() : null,
     });
 
-    return <FiatAmountFormatter network={network} value={fiatValue} {...otherProps} />;
+    return (
+        <FiatAmountFormatter
+            network={network}
+            value={fiatValue}
+            isLoading={isLoading}
+            {...otherProps}
+        />
+    );
 };

--- a/suite-native/formatters/src/components/FiatAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/FiatAmountFormatter.tsx
@@ -15,16 +15,23 @@ type FiatAmountFormatterProps = FormatterProps<string | null> &
         network?: NetworkSymbol;
         isDiscreetText?: boolean;
         isForcedDiscreetMode?: boolean;
+        isLoading?: boolean;
     };
 
 export const FiatAmountFormatter = React.memo(
-    ({ network, value, isDiscreetText = true, ...otherProps }: FiatAmountFormatterProps) => {
+    ({
+        network,
+        value,
+        isDiscreetText = true,
+        isLoading = false,
+        ...otherProps
+    }: FiatAmountFormatterProps) => {
         const { FiatAmountFormatter: formatter } = useFormatters();
 
         if (!!network && isTestnet(network)) {
             return <EmptyAmountText />;
         }
-        if (value === null) {
+        if (isLoading || value === null) {
             return <EmptyAmountSkeleton />;
         }
 

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -19,6 +19,7 @@ export const en = {
             gotIt: 'Got it',
             next: 'Next',
             tryAgain: 'Try again',
+            edit: 'Edit',
         },
         unknownError: 'Something went wrong',
         default: 'Default',
@@ -1015,9 +1016,28 @@ export const en = {
                 normal: 'Normal',
                 high: 'High',
             },
+            custom: {
+                addButton: 'Add custom fee',
+                bottomSheet: {
+                    title: 'Custom fee',
+                    minimumLabel: 'The minimum fee rate is {feePerUnit}',
+                    label: {
+                        feeRate: 'Fee rate',
+                        gasLimit: 'Gas limit',
+                        gasPrice: 'Gas price',
+                    },
+                    total: 'Total fee',
+                    confirmButton: 'Confirm custom fee',
+                },
+                card: {
+                    label: 'Custom',
+                    ethereumValues: 'Limit: {gasLimit} • Price: {gasPrice}',
+                },
+            },
             error: 'You don’t have enough balance to use this fee.',
             totalAmount: 'Total amount',
             submitButton: 'Review and sign',
+            total: 'Total fee',
         },
         review: {
             confirmOnDeviceMessage: 'Go to your Trezor and confirm the amounts & recipients.',

--- a/suite-native/module-send/src/components/CustomFee.tsx
+++ b/suite-native/module-send/src/components/CustomFee.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import Animated, { FadeInLeft, FadeOutLeft } from 'react-native-reanimated';
+
+import { Box, Button } from '@suite-native/atoms';
+import { Icon } from '@suite-native/icons';
+import { Translation } from '@suite-native/intl';
+import { useFormContext } from '@suite-native/forms';
+
+import { CustomFeeBottomSheet } from './CustomFeeBottomSheet';
+import { SendFeesFormValues } from '../sendFeesFormSchema';
+import { CustomFeeCard } from './CustomFeeCard';
+import { NativeSupportedFeeLevel } from '../types';
+
+export const CustomFee = () => {
+    const [isBottomSheetVisible, setIsBottomSheetVisible] = useState(false);
+    const [previousSelectedFeeLevelLabel, setPreviousSelectedFeeLevelLabel] =
+        useState<NativeSupportedFeeLevel>('normal');
+    const { watch, setValue, getValues } = useFormContext<SendFeesFormValues>();
+
+    const isCustomFeeSelected = watch('feeLevel') === 'custom';
+
+    const openCustomFeeBottomSheet = () => {
+        setIsBottomSheetVisible(true);
+
+        const currentSelectedFeeLevelLabel = getValues('feeLevel');
+        if (currentSelectedFeeLevelLabel !== 'custom')
+            setPreviousSelectedFeeLevelLabel(currentSelectedFeeLevelLabel);
+    };
+
+    const closeCustomFeeBottomSheet = () => {
+        setIsBottomSheetVisible(false);
+    };
+
+    const cancelCustomFee = () => {
+        setValue('feeLevel', previousSelectedFeeLevelLabel);
+        setIsBottomSheetVisible(false);
+    };
+
+    return (
+        <Box flex={1}>
+            {isCustomFeeSelected ? (
+                <CustomFeeCard onEdit={openCustomFeeBottomSheet} onCancel={cancelCustomFee} />
+            ) : (
+                <Animated.View entering={FadeInLeft.delay(300)} exiting={FadeOutLeft}>
+                    <Box alignSelf="center">
+                        <Button
+                            colorScheme="tertiaryElevation0"
+                            size="small"
+                            viewLeft={<Icon name="plus" size="mediumLarge" />}
+                            onPress={openCustomFeeBottomSheet}
+                        >
+                            <Translation id="moduleSend.fees.custom.addButton" />
+                        </Button>
+                    </Box>
+                </Animated.View>
+            )}
+
+            <CustomFeeBottomSheet
+                isVisible={isBottomSheetVisible}
+                onClose={closeCustomFeeBottomSheet}
+            />
+        </Box>
+    );
+};

--- a/suite-native/module-send/src/components/CustomFeeBottomSheet.tsx
+++ b/suite-native/module-send/src/components/CustomFeeBottomSheet.tsx
@@ -1,0 +1,114 @@
+import { useSelector } from 'react-redux';
+import Animated, {
+    FadeInDown,
+    FadeOutDown,
+    SlideInDown,
+    SlideOutDown,
+    useAnimatedStyle,
+    withTiming,
+} from 'react-native-reanimated';
+
+import { useRoute } from '@react-navigation/native';
+
+import { AlertBox, BottomSheet, Button, HStack, Text, VStack } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+import { useFormContext } from '@suite-native/forms';
+import { CryptoAmountFormatter, CryptoToFiatAmountFormatter } from '@suite-native/formatters';
+import { AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
+import { SendStackParamList, SendStackRoutes, StackProps } from '@suite-native/navigation';
+
+import { SendFeesFormValues } from '../sendFeesFormSchema';
+import { CustomFeeInputs } from './CustomFeeInputs';
+import { useCustomFee } from '../hooks/useCustomFee';
+
+type CustomFeeBottomSheetProps = {
+    isVisible: boolean;
+    onClose: () => void;
+};
+
+type RouteProps = StackProps<SendStackParamList, SendStackRoutes.SendAddressReview>['route'];
+
+export const CustomFeeBottomSheet = ({ isVisible, onClose }: CustomFeeBottomSheetProps) => {
+    const route = useRoute<RouteProps>();
+    const { accountKey, tokenContract } = route.params;
+
+    const { feeValue, isFeeLoading, isSubmittable, isErrorBoxVisible } = useCustomFee({
+        accountKey,
+        tokenContract,
+    });
+
+    const networkSymbol = useSelector((state: AccountsRootState) =>
+        selectAccountNetworkSymbol(state, accountKey),
+    );
+
+    const { setValue, handleSubmit } = useFormContext<SendFeesFormValues>();
+
+    const handleSetCustomFee = handleSubmit(() => {
+        setValue('feeLevel', 'custom');
+        onClose();
+    });
+
+    const animatedButtonContainerStyle = useAnimatedStyle(
+        () => ({
+            height: withTiming(isSubmittable && isVisible ? 50 : 0),
+        }),
+        [isSubmittable, isVisible],
+    );
+
+    if (!networkSymbol) return null;
+
+    return (
+        <BottomSheet
+            isVisible={isVisible}
+            onClose={onClose}
+            title={<Translation id="moduleSend.fees.custom.bottomSheet.title" />}
+        >
+            <VStack spacing="sp24" justifyContent="space-between" flex={1}>
+                <CustomFeeInputs networkSymbol={networkSymbol} />
+                <HStack
+                    flex={1}
+                    justifyContent="space-between"
+                    alignItems="center"
+                    paddingHorizontal="sp1"
+                >
+                    <Text variant="highlight">
+                        <Translation id="moduleSend.fees.custom.bottomSheet.total" />
+                    </Text>
+                    <VStack alignItems="flex-end">
+                        <CryptoToFiatAmountFormatter
+                            value={feeValue}
+                            isLoading={isFeeLoading}
+                            network={networkSymbol}
+                        />
+                        <CryptoAmountFormatter
+                            value={feeValue}
+                            network={networkSymbol}
+                            variant="body"
+                            isLoading={isFeeLoading}
+                            isBalance={false}
+                        />
+                    </VStack>
+                </HStack>
+                {isErrorBoxVisible && (
+                    <Animated.View entering={FadeInDown} exiting={FadeOutDown}>
+                        <AlertBox
+                            variant="error"
+                            title={<Translation id="moduleSend.fees.error" />}
+                            contentColor="textDefault"
+                        />
+                    </Animated.View>
+                )}
+
+                <Animated.View style={animatedButtonContainerStyle}>
+                    {isSubmittable && (
+                        <Animated.View entering={SlideInDown} exiting={SlideOutDown}>
+                            <Button onPress={handleSetCustomFee}>
+                                <Translation id="moduleSend.fees.custom.bottomSheet.confirmButton" />
+                            </Button>
+                        </Animated.View>
+                    )}
+                </Animated.View>
+            </VStack>
+        </BottomSheet>
+    );
+};

--- a/suite-native/module-send/src/components/CustomFeeCard.tsx
+++ b/suite-native/module-send/src/components/CustomFeeCard.tsx
@@ -1,0 +1,123 @@
+import { useSelector } from 'react-redux';
+import Animated, { FadeInLeft, FadeOutLeft } from 'react-native-reanimated';
+
+import { useRoute } from '@react-navigation/native';
+
+import { Card, HStack, VStack, Text, Box, Button } from '@suite-native/atoms';
+import { useFormContext } from '@suite-native/forms';
+import { Translation } from '@suite-native/intl';
+import { CryptoAmountFormatter, CryptoToFiatAmountFormatter } from '@suite-native/formatters';
+import { AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
+import { getFeeUnits } from '@suite-common/wallet-utils';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+import { SendStackParamList, SendStackRoutes, StackProps } from '@suite-native/navigation';
+import { networks, NetworkType } from '@suite-common/wallet-config';
+import { isFinalPrecomposedTransaction } from '@suite-common/wallet-types';
+
+import { SendFeesFormValues } from '../sendFeesFormSchema';
+import { selectFeeLevels } from '../sendFormSlice';
+
+type CustomFeeCardProps = {
+    onEdit: () => void;
+    onCancel: () => void;
+};
+
+const cardStyle = prepareNativeStyle(utils => ({
+    ...utils.boxShadows.none,
+}));
+
+type RouteProps = StackProps<SendStackParamList, SendStackRoutes.SendAddressReview>['route'];
+
+const CustomFeeLabel = ({ networkType }: { networkType: NetworkType }) => {
+    const feeUnits = getFeeUnits(networkType);
+
+    const { watch } = useFormContext<SendFeesFormValues>();
+    const { customFeeLimit, customFeePerUnit } = watch();
+
+    const formattedFeePerUnit = `${customFeePerUnit} ${feeUnits}`;
+
+    if (networkType === 'ethereum') {
+        return (
+            <VStack spacing="sp2" flex={1}>
+                <Text variant="highlight">
+                    <Translation id="moduleSend.fees.custom.card.label" />
+                </Text>
+                <Text variant="hint" color="textSubdued" numberOfLines={1} adjustsFontSizeToFit>
+                    <Translation
+                        id="moduleSend.fees.custom.card.ethereumValues"
+                        values={{ gasPrice: formattedFeePerUnit, gasLimit: customFeeLimit }}
+                    />
+                </Text>
+            </VStack>
+        );
+    }
+
+    return (
+        <Text variant="highlight">
+            <Translation id="moduleSend.fees.custom.card.label" />
+            {' • '}
+            <Text color="textSubdued">{formattedFeePerUnit}</Text>
+        </Text>
+    );
+};
+
+export const CustomFeeCard = ({ onEdit, onCancel }: CustomFeeCardProps) => {
+    const { applyStyle } = useNativeStyles();
+    const route = useRoute<RouteProps>();
+    const { accountKey } = route.params;
+
+    const feeLevels = useSelector(selectFeeLevels);
+
+    const customFeeTransaction = feeLevels.custom;
+
+    const networkSymbol = useSelector((state: AccountsRootState) =>
+        selectAccountNetworkSymbol(state, accountKey),
+    );
+
+    if (!isFinalPrecomposedTransaction(customFeeTransaction) || !networkSymbol) {
+        return null;
+    }
+
+    const { networkType } = networks[networkSymbol];
+
+    return (
+        <Animated.View entering={FadeInLeft.delay(300)} exiting={FadeOutLeft}>
+            <Card style={applyStyle(cardStyle)}>
+                <VStack spacing="sp16">
+                    <VStack>
+                        <HStack flex={1} justifyContent="space-between" alignItems="center">
+                            <CustomFeeLabel networkType={networkType} />
+                            <VStack alignItems="flex-end" spacing={0}>
+                                <CryptoToFiatAmountFormatter
+                                    value={customFeeTransaction.fee}
+                                    network={networkSymbol}
+                                    variant="body"
+                                />
+                                <CryptoAmountFormatter
+                                    value={customFeeTransaction?.fee}
+                                    network={networkSymbol}
+                                    isBalance={false}
+                                    variant="hint"
+                                    numberOfLines={1}
+                                    adjustsFontSizeToFit
+                                />
+                            </VStack>
+                        </HStack>
+                    </VStack>
+                    <HStack flex={1} justifyContent="space-between">
+                        <Box flex={1}>
+                            <Button onPress={onCancel} colorScheme="redElevation1">
+                                <Translation id="generic.buttons.cancel" />
+                            </Button>
+                        </Box>
+                        <Box flex={2}>
+                            <Button onPress={onEdit} colorScheme="tertiaryElevation1">
+                                <Translation id="generic.buttons.edit" />
+                            </Button>
+                        </Box>
+                    </HStack>
+                </VStack>
+            </Card>
+        </Animated.View>
+    );
+};

--- a/suite-native/module-send/src/components/CustomFeeInputs.tsx
+++ b/suite-native/module-send/src/components/CustomFeeInputs.tsx
@@ -1,0 +1,69 @@
+import { useSelector } from 'react-redux';
+
+import { G } from '@mobily/ts-belt';
+
+import { NetworkSymbol, getNetworkType } from '@suite-common/wallet-config';
+import { FeesRootState, selectNetworkFeeInfo } from '@suite-common/wallet-core';
+import { getFeeUnits } from '@suite-common/wallet-utils';
+import { VStack, Hint, Text } from '@suite-native/atoms';
+import { TextInputField, useFormContext } from '@suite-native/forms';
+import { useTranslate, Translation } from '@suite-native/intl';
+
+import { useSendAmountTransformers, integerTransformer } from '../hooks/useSendAmountTransformers';
+import { SendFeesFormValues } from '../sendFeesFormSchema';
+
+type CustomFeeInputsProps = {
+    networkSymbol: NetworkSymbol;
+};
+
+export const CustomFeeInputs = ({ networkSymbol }: CustomFeeInputsProps) => {
+    const { translate } = useTranslate();
+    const feeInfo = useSelector((state: FeesRootState) => selectNetworkFeeInfo(state, 'btc'));
+    const { cryptoAmountTransformer } = useSendAmountTransformers(networkSymbol!);
+
+    const {
+        formState: { errors },
+    } = useFormContext<SendFeesFormValues>();
+    const feePerUnitFieldName = 'customFeePerUnit';
+    const hasFeePerByteError = G.isNotNullable(errors[feePerUnitFieldName]);
+
+    const networkType = getNetworkType(networkSymbol);
+    const feeUnits = getFeeUnits(networkType);
+    const formattedFeePerUnit = `${feeInfo?.minFee} ${feeUnits}`;
+
+    return (
+        <VStack spacing="sp8">
+            {networkType === 'ethereum' && (
+                <TextInputField
+                    label={translate('moduleSend.fees.custom.bottomSheet.label.gasLimit')}
+                    name="customFeeLimit"
+                    testID="customFeeLimit"
+                    accessibilityLabel="address input"
+                    keyboardType="number-pad"
+                    valueTransformer={integerTransformer}
+                />
+            )}
+            <TextInputField
+                label={
+                    networkType === 'ethereum'
+                        ? translate('moduleSend.fees.custom.bottomSheet.label.gasPrice')
+                        : translate('moduleSend.fees.custom.bottomSheet.label.feeRate')
+                }
+                name={feePerUnitFieldName}
+                testID={feePerUnitFieldName}
+                accessibilityLabel="address input"
+                keyboardType="number-pad"
+                rightIcon={<Text color="textSubdued">{feeUnits}</Text>}
+                valueTransformer={cryptoAmountTransformer}
+            />
+            {networkType !== 'ethereum' && !hasFeePerByteError && (
+                <Hint variant="info">
+                    <Translation
+                        id="moduleSend.fees.custom.bottomSheet.minimumLabel"
+                        values={{ feePerUnit: formattedFeePerUnit }}
+                    />
+                </Hint>
+            )}
+        </VStack>
+    );
+};

--- a/suite-native/module-send/src/components/FeeOptionsList.tsx
+++ b/suite-native/module-send/src/components/FeeOptionsList.tsx
@@ -1,7 +1,9 @@
+import Animated, { FadeInLeft, FadeOutLeft } from 'react-native-reanimated';
+
 import { D, pipe } from '@mobily/ts-belt';
 
 import { NetworkSymbol } from '@suite-common/wallet-config';
-import { AccountKey, GeneralPrecomposedLevels } from '@suite-common/wallet-types';
+import { AccountKey, GeneralPrecomposedLevels, TokenAddress } from '@suite-common/wallet-types';
 import { VStack } from '@suite-native/atoms';
 
 import { FeeOption } from './FeeOption';
@@ -11,6 +13,7 @@ type FeeOptionsListProps = {
     feeLevels: GeneralPrecomposedLevels;
     networkSymbol: NetworkSymbol;
     accountKey: AccountKey;
+    tokenContract?: TokenAddress;
 };
 
 // User is not able to enter the fees screen if there is not normal fee or at least the economy fee (in final state) present.
@@ -26,8 +29,12 @@ const getTransactionBytes = (feeLevels: Partial<GeneralPrecomposedLevels>) => {
     return 0;
 };
 
-export const FeeOptionsList = ({ feeLevels, networkSymbol, accountKey }: FeeOptionsListProps) => {
-    // Remove custom fee level from the list. It is not supported in the first version of the send flow.
+export const FeeOptionsList = ({
+    feeLevels,
+    networkSymbol,
+    accountKey,
+    tokenContract,
+}: FeeOptionsListProps) => {
     const predefinedFeeLevels = pipe(
         feeLevels,
         D.filterWithKey(key => key !== 'custom'),
@@ -38,18 +45,21 @@ export const FeeOptionsList = ({ feeLevels, networkSymbol, accountKey }: FeeOpti
     const isMultipleOptionsDisplayed = Object.keys(predefinedFeeLevels).length > 1;
 
     return (
-        <VStack spacing="sp12">
-            {Object.entries(predefinedFeeLevels).map(([feeKey, feeLevel]) => (
-                <FeeOption
-                    key={feeKey}
-                    feeKey={feeKey as NativeSupportedFeeLevel}
-                    feeLevel={feeLevel}
-                    accountKey={accountKey}
-                    networkSymbol={networkSymbol}
-                    transactionBytes={transactionBytes}
-                    isInteractive={isMultipleOptionsDisplayed}
-                />
-            ))}
-        </VStack>
+        <Animated.View entering={FadeInLeft.delay(300)} exiting={FadeOutLeft}>
+            <VStack spacing="sp12">
+                {Object.entries(predefinedFeeLevels).map(([feeKey, feeLevel]) => (
+                    <FeeOption
+                        key={feeKey}
+                        feeKey={feeKey as Exclude<NativeSupportedFeeLevel, 'custom'>}
+                        feeLevel={feeLevel}
+                        accountKey={accountKey}
+                        tokenContract={tokenContract}
+                        networkSymbol={networkSymbol}
+                        transactionBytes={transactionBytes}
+                        isInteractive={isMultipleOptionsDisplayed}
+                    />
+                ))}
+            </VStack>
+        </Animated.View>
     );
 };

--- a/suite-native/module-send/src/components/FeesFooter.tsx
+++ b/suite-native/module-send/src/components/FeesFooter.tsx
@@ -8,7 +8,7 @@ import Animated, {
 import { useSelector } from 'react-redux';
 
 import { NetworkSymbol } from '@suite-common/wallet-config';
-import { Text, Button, Box, Card, HStack, VStack } from '@suite-native/atoms';
+import { Text, Button, Card, HStack, VStack } from '@suite-native/atoms';
 import {
     CryptoToFiatAmountFormatter,
     CryptoAmountFormatter,
@@ -35,17 +35,10 @@ type FeesFooterProps = {
 };
 
 const CARD_BOTTOM_PADDING = 40;
-const BUTTON_ENTERING_DELAY = 45;
-
-const footerWrapperStyle = prepareNativeStyle(utils => ({
-    marginBottom: utils.spacings.sp16,
-}));
 
 const cardStyle = prepareNativeStyle(utils => ({
-    position: 'absolute',
-    bottom: 0,
     width: '100%',
-    paddingTop: utils.spacings.sp8,
+    paddingHorizontal: utils.spacings.sp8,
     backgroundColor: utils.colors.backgroundSurfaceElevationNegative,
     borderColor: utils.colors.borderElevation0,
     borderWidth: utils.borders.widths.small,
@@ -164,7 +157,7 @@ export const FeesFooter = ({
     );
 
     return (
-        <Box style={applyStyle(footerWrapperStyle)}>
+        <>
             <Card style={applyStyle(cardStyle)}>
                 <Animated.View style={animatedFooterStyle}>
                     {tokenContract ? (
@@ -183,7 +176,7 @@ export const FeesFooter = ({
             {isSubmittable && (
                 <Animated.View
                     style={applyStyle(buttonWrapperStyle)}
-                    entering={FadeInDown.delay(BUTTON_ENTERING_DELAY)}
+                    entering={FadeInDown}
                     exiting={FadeOutDown}
                 >
                     <Button
@@ -197,6 +190,6 @@ export const FeesFooter = ({
                     </Button>
                 </Animated.View>
             )}
-        </Box>
+        </>
     );
 };

--- a/suite-native/module-send/src/hooks/useCustomFee.tsx
+++ b/suite-native/module-send/src/hooks/useCustomFee.tsx
@@ -1,0 +1,121 @@
+import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { isRejected } from '@reduxjs/toolkit';
+import { G } from '@mobily/ts-belt';
+
+import { AccountsRootState, selectAccountNetworkType } from '@suite-common/wallet-core';
+import {
+    AccountKey,
+    isFinalPrecomposedTransaction,
+    TokenAddress,
+} from '@suite-common/wallet-types';
+import { useTranslate } from '@suite-native/intl';
+import { useDebounce } from '@trezor/react-utils';
+import { BigNumber } from '@trezor/utils';
+import { useFormContext } from '@suite-native/forms';
+
+import { SendFeesFormValues } from '../sendFeesFormSchema';
+import {
+    selectCustomFeeLevel,
+    NativeSendRootState,
+    selectFeeLevelTransactionBytes,
+} from '../sendFormSlice';
+import { calculateCustomFeeLevelThunk } from '../sendFormThunks';
+
+type UseCustomFeeProps = {
+    accountKey: AccountKey;
+    tokenContract?: TokenAddress;
+};
+
+export const useCustomFee = ({ accountKey, tokenContract }: UseCustomFeeProps) => {
+    const dispatch = useDispatch();
+    const debounce = useDebounce();
+    const { translate } = useTranslate();
+
+    const [isErrorBoxVisible, setIsErrorBoxVisible] = useState(false);
+    const [isFeeLoading, setIsFeeLoading] = useState(false);
+
+    const customFeeLevel = useSelector(selectCustomFeeLevel);
+    const networkType = useSelector((state: AccountsRootState) =>
+        selectAccountNetworkType(state, accountKey),
+    );
+
+    const {
+        formState: { errors },
+        setError,
+        trigger,
+        getValues,
+        watch,
+    } = useFormContext<SendFeesFormValues>();
+
+    const feePerUnitFieldName = 'customFeePerUnit';
+    const feeLimitFieldName = 'customFeeLimit';
+
+    const watchedFeePerUnit = watch(feePerUnitFieldName, '0');
+    const watchedFeeLimit = watch(feeLimitFieldName, '1') as string;
+
+    const normalLevelTransactionBytes = useSelector((state: NativeSendRootState) =>
+        selectFeeLevelTransactionBytes(state, 'normal'),
+    );
+
+    const handleValuesChange = useCallback(async () => {
+        const { customFeePerUnit, customFeeLimit } = getValues();
+
+        trigger();
+        if (!customFeePerUnit) {
+            setIsFeeLoading(false);
+
+            return;
+        }
+
+        setIsFeeLoading(true);
+        setIsErrorBoxVisible(false);
+        const response = await dispatch(
+            calculateCustomFeeLevelThunk({
+                accountKey,
+                tokenContract,
+                feePerUnit: customFeePerUnit,
+                feeLimit: customFeeLimit,
+            }),
+        );
+
+        if (isRejected(response)) {
+            if (networkType === 'ethereum') {
+                setIsErrorBoxVisible(true);
+            } else {
+                setError(feePerUnitFieldName, {
+                    message: translate('moduleSend.fees.error'),
+                });
+            }
+        }
+
+        setIsFeeLoading(false);
+    }, [accountKey, dispatch, networkType, setError, tokenContract, translate, trigger, getValues]);
+
+    useEffect(() => {
+        setIsFeeLoading(true);
+        debounce(handleValuesChange);
+    }, [watchedFeePerUnit, watchedFeeLimit, handleValuesChange, debounce]);
+
+    // If the trezor-connect is unable to compose the transaction, we display rough estimate of the fee instead.
+    const feeEstimate = useMemo(
+        () =>
+            watchedFeePerUnit
+                ? BigNumber(watchedFeePerUnit)
+                      .times(watchedFeeLimit)
+                      .times(normalLevelTransactionBytes)
+                      .toString()
+                : '0',
+        [watchedFeePerUnit, watchedFeeLimit, normalLevelTransactionBytes],
+    );
+    const feeValue = isFinalPrecomposedTransaction(customFeeLevel)
+        ? customFeeLevel.fee
+        : feeEstimate;
+
+    const hasFeePerByteError = G.isNotNullable(errors[feePerUnitFieldName]);
+    const isSubmittable =
+        G.isNotNullable(customFeeLevel) && !hasFeePerByteError && !isErrorBoxVisible;
+
+    return { feeValue, isFeeLoading, isErrorBoxVisible, isSubmittable };
+};

--- a/suite-native/module-send/src/hooks/useSendAmountTransformers.ts
+++ b/suite-native/module-send/src/hooks/useSendAmountTransformers.ts
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { selectIsAmountInSats, SettingsSliceRootState } from '@suite-native/settings';
 
-const decimalTransformer = (value: string) =>
+export const decimalTransformer = (value: string) =>
     value
         .replace(/,/g, '.') // remove all non-numeric characters
         .replace(/[^\d.]/g, '') // remove all non-numeric characters
@@ -11,7 +11,7 @@ const decimalTransformer = (value: string) =>
         .replace(/(?<=\..*)\./g, '') // keep only first appearance of the '.' symbol
         .replace(/^0+(?=\d)/g, ''); // remove all leading zeros except the first one
 
-const integerTransformer = (value: string) =>
+export const integerTransformer = (value: string) =>
     value
         .replace(/\D/g, '') // remove all non-digit characters
         .replace(/^0+/g, ''); // remove all leading zeros

--- a/suite-native/module-send/src/screens/SendFeesScreen.tsx
+++ b/suite-native/module-send/src/screens/SendFeesScreen.tsx
@@ -1,7 +1,6 @@
 import { useSelector } from 'react-redux';
 
 import { SendStackParamList, SendStackRoutes, StackProps } from '@suite-native/navigation';
-import { VStack } from '@suite-native/atoms';
 import { AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 
 import { SendFeesForm } from '../components/SendFeesForm';
@@ -11,7 +10,7 @@ import { AccountBalanceScreenHeader } from '../components/SendScreenSubHeader';
 export const SendFeesScreen = ({
     route: { params },
 }: StackProps<SendStackParamList, SendStackRoutes.SendFees>) => {
-    const { accountKey, tokenContract, feeLevels } = params;
+    const { accountKey, tokenContract } = params;
 
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
@@ -25,13 +24,7 @@ export const SendFeesScreen = ({
                 <AccountBalanceScreenHeader accountKey={accountKey} tokenContract={tokenContract} />
             }
         >
-            <VStack spacing="sp32" flex={1}>
-                <SendFeesForm
-                    accountKey={accountKey}
-                    tokenContract={tokenContract}
-                    feeLevels={feeLevels}
-                />
-            </VStack>
+            <SendFeesForm accountKey={accountKey} tokenContract={tokenContract} />
         </SendScreen>
     );
 };

--- a/suite-native/module-send/src/screens/SendOutputsScreen.tsx
+++ b/suite-native/module-send/src/screens/SendOutputsScreen.tsx
@@ -41,6 +41,7 @@ import { AccountBalanceScreenHeader } from '../components/SendScreenSubHeader';
 import { calculateFeeLevelsMaxAmountThunk } from '../sendFormThunks';
 import { constructFormDraft } from '../utils';
 import { FeeLevelsMaxAmount } from '../types';
+import { storeFeeLevels } from '../sendFormSlice';
 
 const buttonWrapperStyle = prepareNativeStyle(utils => ({
     width: '100%',
@@ -193,10 +194,10 @@ export const SendOutputsScreen = ({
         );
 
         if (isFulfilled(response)) {
+            dispatch(storeFeeLevels({ feeLevels: response.payload }));
             navigation.navigate(SendStackRoutes.SendFees, {
                 accountKey,
                 tokenContract,
-                feeLevels: response.payload,
             });
 
             return;

--- a/suite-native/module-send/src/sendFeesFormSchema.ts
+++ b/suite-native/module-send/src/sendFeesFormSchema.ts
@@ -1,11 +1,97 @@
 import { yup } from '@suite-common/validators';
+import { isDecimalsValid } from '@suite-common/wallet-utils';
+import { FeeInfo } from '@suite-common/wallet-types';
+import { NetworkType } from '@suite-common/wallet-config';
+import { BigNumber } from '@trezor/utils';
 
 import { NativeSupportedFeeLevel } from './types';
 
-const nativeSupportedFeeLevels: Array<NativeSupportedFeeLevel> = ['economy', 'normal', 'high'];
+type SendFeesFormContext = {
+    networkType?: NetworkType;
+    networkFeeInfo?: FeeInfo;
+    minimalFeeLimit?: string;
+};
+
+const nativeSupportedFeeLevels: Array<NativeSupportedFeeLevel> = [
+    'economy',
+    'normal',
+    'high',
+    'custom',
+];
 
 export const sendFeesFormValidationSchema = yup.object({
     feeLevel: yup.string().oneOf(nativeSupportedFeeLevels).required('Fee level is required'),
+    customFeePerUnit: yup
+        .string()
+        .required()
+        .test(
+            'too-many-decimals',
+            'Too many decimals.',
+            (value, { options: { context } }: yup.TestContext<SendFeesFormContext>) => {
+                if (!value) return true;
+
+                const { networkFeeInfo, networkType } = context!;
+                if (!networkFeeInfo || !networkType) return false;
+
+                if (networkType !== 'bitcoin' && networkType !== 'ethereum') return true;
+
+                let maxDecimals = 0;
+                if (networkType === 'bitcoin') {
+                    maxDecimals = 2;
+                } else if (networkType === 'ethereum') {
+                    maxDecimals = 9;
+                }
+
+                return isDecimalsValid(value, maxDecimals);
+            },
+        )
+        .test(
+            'fee-too-low',
+            'Fee is too low.',
+            (value, { options: { context } }: yup.TestContext<SendFeesFormContext>) => {
+                if (!value) return true;
+                const { networkFeeInfo } = context!;
+
+                if (!networkFeeInfo) return false;
+                const { minFee } = networkFeeInfo;
+
+                return Number(value) >= minFee;
+            },
+        )
+        .test(
+            'fee-too-high',
+            'Fee is too high.',
+            (value, { options: { context } }: yup.TestContext<SendFeesFormContext>) => {
+                if (!value) return true;
+
+                const { networkFeeInfo } = context!;
+
+                if (!value || !networkFeeInfo) return false;
+
+                const feeBig = new BigNumber(value);
+                const { maxFee } = networkFeeInfo;
+
+                return feeBig.lte(maxFee);
+            },
+        ),
+    customFeeLimit: yup
+        .string()
+        .test(
+            'fee-limit-too-low',
+            'Value is too low.',
+            (value, { options: { context } }: yup.TestContext<SendFeesFormContext>) => {
+                const { networkType, minimalFeeLimit } = context!;
+
+                // Fee limit is used only for Ethereum, pass this validation for other networks.
+                if (networkType !== 'ethereum') return true;
+
+                if (!value || !minimalFeeLimit) return false;
+
+                const feeBig = new BigNumber(value);
+
+                return feeBig.gte(minimalFeeLimit);
+            },
+        ),
 });
 
 export type SendFeesFormValues = yup.InferType<typeof sendFeesFormValidationSchema>;

--- a/suite-native/module-send/src/types.ts
+++ b/suite-native/module-send/src/types.ts
@@ -13,8 +13,7 @@ import { NetworkSymbol } from '@suite-common/wallet-config';
 
 export type StatefulReviewOutput = ReviewOutput & { state: ReviewOutputState };
 
-// TODO: add 'custom' in next send flow iteration
-export type NativeSupportedFeeLevel = Exclude<FeeLevelLabel, 'custom' | 'low'>;
+export type NativeSupportedFeeLevel = Exclude<FeeLevelLabel, 'low'>;
 
 export type SendAmountInputProps = {
     recipientIndex: number;

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -4,7 +4,6 @@ import { ParsedURL } from 'expo-linking';
 
 import {
     AccountKey,
-    GeneralPrecomposedLevels,
     GeneralPrecomposedTransactionFinal,
     TokenAddress,
     XpubAddress,
@@ -79,7 +78,6 @@ export type SendStackParamList = {
         tokenContract?: TokenAddress;
     };
     [SendStackRoutes.SendFees]: {
-        feeLevels: GeneralPrecomposedLevels;
         accountKey: AccountKey;
         tokenContract?: TokenAddress;
     };


### PR DESCRIPTION
## Description
- custom fee implemented for all the enabled network (both Bitcoin-like and Ethereum-like + tokens)
- working with a send max enabled as well (the total amount is always adjusted so all the balance is send from the account)
## Related Issue

Resolve  #15180

## Screenshots:
### BTC 

https://github.com/user-attachments/assets/0738cc27-cbcd-4698-8765-bd81366346f2

### BTC - Send Max

https://github.com/user-attachments/assets/efde781e-dce4-43ac-bf08-44ff4e464961

### ETH 


https://github.com/user-attachments/assets/60ba68da-c4be-4bf2-8e92-f7ab96ac4e01


