### PR TITLE
fix(suite): backup check always resulting in error

### DIFF
--- a/packages/suite/src/actions/recovery/recoveryActions.ts
+++ b/packages/suite/src/actions/recovery/recoveryActions.ts
@@ -22,7 +22,7 @@ export type SeedInputStatus =
 export type RecoveryAction =
     | { type: typeof RECOVERY.SET_WORDS_COUNT; payload: WordCount }
     | { type: typeof RECOVERY.SET_ADVANCED_RECOVERY; payload: boolean }
-    | { type: typeof RECOVERY.SET_ERROR; payload: string }
+    | { type: typeof RECOVERY.SET_ERROR; payload: string | undefined }
     | { type: typeof RECOVERY.SET_STATUS; payload: SeedInputStatus }
     | { type: typeof RECOVERY.RESET_REDUCER };
 
@@ -36,7 +36,7 @@ const setAdvancedRecovery = (value: boolean): RecoveryAction => ({
     payload: value,
 });
 
-const setError = (payload: string): RecoveryAction => ({
+const setError = (payload: string | undefined): RecoveryAction => ({
     type: RECOVERY.SET_ERROR,
     payload,
 });
@@ -60,7 +60,7 @@ const checkSeed = () => async (dispatch: Dispatch, getState: GetState) => {
 
     if (!device?.features) return;
 
-    dispatch(setError(''));
+    dispatch(setError(undefined));
 
     if (device.features.internal_model === DeviceModelInternal.T1B1) {
         dispatch(setStatus('waiting-for-confirmation'));
@@ -101,7 +101,7 @@ const recoverDevice = () => async (dispatch: Dispatch, getState: GetState) => {
     if (!device?.features) {
         return;
     }
-    dispatch(setError(''));
+    dispatch(setError(undefined));
 
     if (device.features.internal_model === DeviceModelInternal.T1B1) {
         dispatch(setStatus('waiting-for-confirmation'));

--- a/packages/suite/src/reducers/recovery/recoveryReducer.ts
+++ b/packages/suite/src/reducers/recovery/recoveryReducer.ts
@@ -15,7 +15,7 @@ export interface RecoveryState {
 const initialState: RecoveryState = {
     advancedRecovery: false,
     wordsCount: 12,
-    error: '',
+    error: undefined,
     status: 'initial',
 };
 


### PR DESCRIPTION
## Description

Fix backup check, which currently always ends up in error.

Caused by #14643 where `!!recovery.error` was changed to `recovery.error !== undefined`.
That's a good pattern generally, but unfortunately the `recovery.error` was messy,
and it couldn't decide between `''` and `undefined`, so `''` was misreported as an error.

:arrow_right: use only `undefined` for `recovery.error`

## Related Issue

Resolve #15365

## Screenshots:

After completing the seed check with physical T2T1:
![image](https://github.com/user-attachments/assets/9d378b1a-4ffb-4530-8de5-0a8262ddf56b)

