### PR TITLE
fix(suite): backup check for T1B1

### DIFF
--- a/packages/suite/src/views/recovery/index.tsx
+++ b/packages/suite/src/views/recovery/index.tsx
@@ -7,14 +7,13 @@ import {
     isDeviceAcquired,
     isDeviceWithButtons,
 } from '@suite-common/suite-utils';
-import { H2, H3, Paragraph, Image, NewModal, Card, List } from '@trezor/components';
+import { Card, H2, H3, Image, List, NewModal, Paragraph } from '@trezor/components';
 import { pickByDeviceModel } from '@trezor/device-utils';
 import TrezorConnect, { DeviceModelInternal } from '@trezor/connect';
 import { spacings } from '@trezor/theme';
 
-import { SelectWordCount, SelectRecoveryType } from 'src/components/recovery';
-import { Loading, Translation, CheckItem } from 'src/components/suite';
-import { ReduxModal } from 'src/components/suite/modals/ReduxModal/ReduxModal';
+import { SelectRecoveryType, SelectWordCount } from 'src/components/recovery';
+import { CheckItem, Loading, Translation } from 'src/components/suite';
 import {
     checkSeed,
     setAdvancedRecovery,
@@ -26,6 +25,10 @@ import type { ForegroundAppProps } from 'src/types/suite';
 import type { WordCount } from 'src/types/recovery';
 import messages from 'src/support/messages';
 import { LearnMoreButton } from 'src/components/suite/LearnMoreButton';
+import { MODAL } from 'src/actions/suite/constants';
+
+import { T1B1InputStep } from './steps/T1B1InputStep';
+import { EnterOnDeviceStep } from './steps/EnterOnDeviceStep';
 
 export const Recovery = ({ onCancel }: ForegroundAppProps) => {
     const recovery = useSelector(state => state.recovery);
@@ -164,18 +167,16 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
                 );
             case 'in-progress':
             case 'waiting-for-confirmation':
-                return modal.context !== '@modal/context-none' ? (
-                    <>
-                        {device.features.capabilities.includes('Capability_PassphraseEntry') && (
-                            <Paragraph>
-                                <Translation id="TR_ENTER_SEED_WORDS_ON_DEVICE" />
-                            </Paragraph>
-                        )}
-                        <ReduxModal {...modal} />
-                    </>
+                if (modal.context !== MODAL.CONTEXT_DEVICE) {
+                    return <Loading />;
+                }
+
+                return device.features.capabilities.includes('Capability_PassphraseEntry') ? (
+                    <EnterOnDeviceStep />
                 ) : (
-                    <Loading />
+                    <T1B1InputStep />
                 );
+
             case 'finished':
                 return !hasError ? (
                     <>

--- a/packages/suite/src/views/recovery/steps/EnterOnDeviceStep.tsx
+++ b/packages/suite/src/views/recovery/steps/EnterOnDeviceStep.tsx
@@ -1,0 +1,9 @@
+import { Paragraph } from '@trezor/components';
+
+import { Translation } from 'src/components/suite';
+
+export const EnterOnDeviceStep = () => (
+    <Paragraph>
+        <Translation id="TR_ENTER_SEED_WORDS_ON_DEVICE" />
+    </Paragraph>
+);

--- a/packages/suite/src/views/recovery/steps/T1B1InputStep.tsx
+++ b/packages/suite/src/views/recovery/steps/T1B1InputStep.tsx
@@ -1,0 +1,54 @@
+import { Paragraph } from '@trezor/components';
+import { HELP_CENTER_ADVANCED_RECOVERY_URL } from '@trezor/urls';
+
+import { Translation, TrezorLink, WordInput, WordInputAdvanced } from 'src/components/suite';
+import { useSelector } from 'src/hooks/suite';
+import { MODAL } from 'src/actions/suite/constants';
+
+const RequestConfirmationStep = () => (
+    <Paragraph>
+        <Translation id="TR_CONFIRM_ACTION_ON_YOUR" />
+    </Paragraph>
+);
+
+type WordAdvancedStepProps = { count: 6 | 9 };
+
+const WordAdvancedStep = ({ count }: WordAdvancedStepProps) => (
+    <>
+        <WordInputAdvanced count={count} />
+        <Paragraph typographyStyle="label">
+            <Translation id="TR_ADVANCED_RECOVERY_NOT_SURE" />{' '}
+            <TrezorLink type="label" href={HELP_CENTER_ADVANCED_RECOVERY_URL}>
+                <Translation id="TR_LEARN_MORE" />
+            </TrezorLink>
+        </Paragraph>
+    </>
+);
+
+const WordStep = () => (
+    <>
+        <Translation id="TR_ENTER_SEED_WORDS_INSTRUCTION" />{' '}
+        <Translation id="TR_RANDOM_SEED_WORDS_DISCLAIMER" />
+        <WordInput />
+    </>
+);
+
+export const T1B1InputStep = () => {
+    const modal = useSelector(state => state.modal);
+
+    if (modal.context !== MODAL.CONTEXT_DEVICE) return null;
+
+    switch (modal.windowType) {
+        case 'ButtonRequest_Other':
+            return <RequestConfirmationStep />;
+        case 'WordRequestType_Plain':
+            return <WordStep />;
+        case 'WordRequestType_Matrix6':
+            return <WordAdvancedStep count={6} />;
+        case 'WordRequestType_Matrix9':
+            return <WordAdvancedStep count={9} />;
+        // to satisfy TS, should not happen
+        default:
+            return null;
+    }
+};


### PR DESCRIPTION
## Description

Fix backup check for T1B1, which gets stuck because two modals are overlayed.

- This required quite some refactoring, because the UI for T1B1 was currently only in ReduxModal > [DeviceContextModal](https://github.com/trezor/trezor-suite/blob/7c2e781e309ef45df1b6606af8a73a78cd680894/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/DeviceContextModal.tsx#L50-L55).
- So I had to recreate the UI in the `Recovery` modal
- I at least separeted the JSX for individual steps and their variants to new components
  - this could be done for the whole `Recovery` component 

## Related Issue

Resolve #15378

## Screenshots:

**Last working version 24.10.1:** (screenshots for comparison of UI)
- [T1B1 standard](https://github.com/user-attachments/assets/5ef58a12-3c6d-4466-a9db-1a7b7e74fc60)
- [T1B1 advanced](https://github.com/user-attachments/assets/a934a20f-9829-4678-98ba-bb5cb736c5d5)

**Before 24.11.1:** [video of bug](https://github.com/user-attachments/assets/dcfb451a-f844-4edc-958b-c1d4b5a367dc) from issue

**After** (feel free to skip through the video)
- [T1B1 standard](https://github.com/user-attachments/assets/0f29d486-7c86-4921-b9d5-73d75bc18505) :heavy_check_mark:
- [T1B1 advanced](https://github.com/user-attachments/assets/a19d8ffd-8706-4bfa-b274-348ed99e8e1a) :heavy_check_mark:
- [T2T1](https://github.com/user-attachments/assets/fcb0d00d-8cb8-4a73-ac44-b4df0b82a291) :heavy_check_mark:
  - I also tested T2B1 physical, and it works just as well (need physical, can't press both buttons on tenv :see_no_evil: ) 

**BTW** [I discovered another bug in 24.10.1](https://github.com/user-attachments/assets/8ffe7f97-a3d6-4252-8209-a2bf51a0a96e) :hear_no_evil:  :grimacing:  I did not bother creating an issue, because this PR also fixes it.
After entering all the words, there is one step where I just have to confirm on device, but the modal was empty, with only Close button. That's super confusing, might lead users to Close the process before it's finished because they are not aware they have to confirm on device, which means they don't get to the result and their time is wasted :confused:  
