### PR TITLE
fix(e2e): Switched firmware to 2-latest in onboarding tests

### DIFF
--- a/packages/suite-web/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts
@@ -1,23 +1,19 @@
 // @group_device-management
 // @retry=2
 
-import { onDeviceCompromisedModal } from '../../../support/pageObjects/deviceCompromisedObject';
-
 describe('Onboarding - create wallet', () => {
     beforeEach(() => {
         cy.task('startBridge');
         cy.viewport('macbook-13').resetDb();
         cy.prefixedVisit('/');
+        cy.disableFirmwareHashCheck();
     });
 
     it('Success (Shamir backup)', () => {
         // note: this is an example of test that can not be parametrized to be both integration (isolated) test and e2e test.
         // the problem is that it always needs to run the newest possible emulator. If this was pinned to use emulator which is currently
         // in production, and we locally bumped emulator version, we would get into a screen saying "update your firmware" and the test would fail.
-        cy.task('startEmu', { wipe: true, model: 'T2T1', version: '2-main' });
-
-        // firmware revision check will fail with 2-main version, but we just need to get through onboarding, so it's fine to just dismiss it
-        onDeviceCompromisedModal.ignoreDeviceCompromisedWarning();
+        cy.task('startEmu', { wipe: true, model: 'T2T1', version: '2-latest' });
 
         cy.getTestElement('@analytics/continue-button').click();
         cy.getTestElement('@analytics/continue-button').click();

--- a/packages/suite-web/e2e/tests/onboarding/t2t1/t2t1-recovery-fail.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/t2t1/t2t1-recovery-fail.test.ts
@@ -4,26 +4,17 @@
 import { onAnalyticsPage } from '../../../support/pageObjects/analyticsObject';
 import { onConnectDevicePrompt } from '../../../support/pageObjects/connectDeviceObject';
 import { onOnboardingPage } from '../../../support/pageObjects/onboardingObject';
-import { onNavBar } from '../../../support/pageObjects/topBarObject';
 
 describe('Onboarding - recover wallet T2T1', () => {
     beforeEach(() => {
         cy.task('startBridge');
         cy.viewport('macbook-13').resetDb();
         cy.prefixedVisit('/');
+        cy.disableFirmwareHashCheck();
         // note: this is an example of test that can not be parametrized to be both integration (isolated) test and e2e test.
         // the problem is that it always needs to run the newest possible emulator. If this was pinned to use emulator which is currently
         // in production, and we locally bumped emulator version, we would get into a screen saying "update your firmware" and the test would fail.
-        cy.task('startEmu', { wipe: true, model: 'T2T1', version: '2-main' });
-
-        // Disable revision check. On emulator '2-main' it wont pass as it is unreleased version
-        cy.getTestElement('@device-compromised').should('be.visible');
-        onNavBar.openSettings();
-        cy.getTestElement('@settings/menu/device').click();
-        cy.getTestElement('@settings/device/open-firmware-revision-check-modal-button').click();
-        cy.getTestElement('@device-firmware-revision/checkbox').click();
-        cy.getTestElement('@device-firmware-revision/opt-out-button').click();
-        cy.getTestElement('@settings/menu/close').click();
+        cy.task('startEmu', { wipe: true, model: 'T2T1', version: '2-latest' });
 
         cy.step('Go through analytics', () => {
             onAnalyticsPage.continue();
@@ -45,7 +36,7 @@ describe('Onboarding - recover wallet T2T1', () => {
             cy.task('stopEmu');
             cy.wait(500);
             onConnectDevicePrompt.waitForConnectDevicePrompt();
-            cy.task('startEmu', { model: 'T2T1', version: '2-main', wipe: false });
+            cy.task('startEmu', { model: 'T2T1', version: '2-latest', wipe: false });
         });
 
         cy.step('Check that you can retry', () => {

--- a/packages/suite-web/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts
@@ -3,7 +3,6 @@
 
 import { SeedType } from '../../../support/enums/seedType';
 import { onAnalyticsPage } from '../../../support/pageObjects/analyticsObject';
-import { onDeviceCompromisedModal } from '../../../support/pageObjects/deviceCompromisedObject';
 import { onOnboardingPage } from '../../../support/pageObjects/onboardingObject';
 import { getConfirmActionOnDeviceModal } from '../../../support/utils/selectors';
 
@@ -23,8 +22,7 @@ describe('Onboarding - create wallet', () => {
         cy.viewport('macbook-13').resetDb();
         cy.prefixedVisit('/');
         cy.disableFirmwareHashCheck();
-        cy.task('startEmu', { wipe: true, model: 'T3T1', version: '2-main' });
-        onDeviceCompromisedModal.ignoreDeviceCompromisedWarning();
+        cy.task('startEmu', { wipe: true, model: 'T3T1', version: '2-latest' });
 
         cy.step('Go through analytics', () => {
             onAnalyticsPage.continue();
@@ -34,7 +32,7 @@ describe('Onboarding - create wallet', () => {
 
     it('Success (Shamir backup)', () => {
         cy.step('Go through Device onboarding step', () => {
-            onOnboardingPage.continueFirmware();
+            onOnboardingPage.skipFirmware();
             cy.passThroughAuthenticityCheck();
 
             cy.wait(500);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Hotfix for failing tests. With 2-main firmware the tenv gets stuck.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
