### PR TITLE
Skip storing draft in RBF form, reintroduce precomposedForm

### DIFF
--- a/packages/suite/src/actions/wallet/send/sendFormThunks.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormThunks.ts
@@ -16,7 +16,7 @@ import {
     selectSendFormDrafts,
     signTransactionThunk,
     sendFormActions,
-    selectSendFormDraftByKey,
+    selectPrecomposedSendForm,
 } from '@suite-common/wallet-core';
 import { isCardanoTx, isRbfTransaction } from '@suite-common/wallet-utils';
 import { MetadataAddPayload } from '@suite-common/metadata-types';
@@ -141,15 +141,14 @@ const applySendFormMetadataLabelsThunk = createThunk(
 
         if (!metadata.enabled) return;
 
-        const formDraft = selectSendFormDraftByKey(getState(), selectedAccount.key);
-
+        const precomposedForm = selectPrecomposedSendForm(getState());
         const outputsPermutation = isCardanoTx(selectedAccount, precomposedTransaction)
             ? precomposedTransaction?.outputs.map((_o, i) => i) // cardano preserves order of outputs
             : precomposedTransaction?.outputsPermutation;
 
         const synchronize = getSynchronize();
 
-        formDraft?.outputs
+        precomposedForm?.outputs
             // create array of metadata objects
             .map((formOutput, index) => {
                 const { label } = formOutput;

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
@@ -7,7 +7,7 @@ import { Deferred } from '@trezor/utils';
 import {
     DeviceRootState,
     selectDevice,
-    selectSendFormDraftByKey,
+    selectPrecomposedSendForm,
     selectSendFormReviewButtonRequestsCount,
     selectStakePrecomposedForm,
     StakeState,
@@ -76,7 +76,7 @@ export const TransactionReviewModalContent = ({
     const precomposedForm = useSelector(state =>
         isStakeState(txInfoState)
             ? selectStakePrecomposedForm(state)
-            : selectSendFormDraftByKey(state, account?.key),
+            : selectPrecomposedSendForm(state),
     );
 
     const isRbfAction = precomposedTx !== undefined && isRbfTransaction(precomposedTx);

--- a/packages/suite/src/reducers/wallet/__tests__/sendFormReducer.test.ts
+++ b/packages/suite/src/reducers/wallet/__tests__/sendFormReducer.test.ts
@@ -68,6 +68,7 @@ describe('sendFormReducer', () => {
 
     it('SEND.REQUEST_SIGN_TRANSACTION - save', () => {
         const action: Action = sendFormActions.storePrecomposedTransaction({
+            formState: formStateMock,
             precomposedTransaction: precomposedTxMock,
         });
 
@@ -94,12 +95,14 @@ describe('sendFormReducer', () => {
             {
                 ...initialState,
                 serializedTx: formSignedTxMock,
+                precomposedForm: formStateMock,
                 precomposedTx: precomposedTxMock,
             },
             action,
         );
         expect(state.serializedTx).toBeUndefined();
         expect(state.precomposedTx).toBeUndefined();
+        expect(state.precomposedForm).toBeUndefined();
     });
 
     it('SEND.SEND_RAW', () => {
@@ -120,12 +123,14 @@ describe('sendFormReducer', () => {
                 ...initialState,
                 sendRaw: true,
                 precomposedTx: precomposedTxMock,
+                precomposedForm: formStateMock,
                 serializedTx: formSignedTxMock,
             },
             action,
         );
         expect(state.sendRaw).toBeUndefined();
         expect(state.precomposedTx).toBeUndefined();
+        expect(state.precomposedForm).toBeUndefined();
         expect(state.serializedTx).toBeUndefined();
     });
 });

--- a/suite-common/wallet-core/src/send/sendFormActions.ts
+++ b/suite-common/wallet-core/src/send/sendFormActions.ts
@@ -27,7 +27,10 @@ const removeDraft = createAction(
 
 const storePrecomposedTransaction = createAction(
     `${SEND_MODULE_PREFIX}/store-precomposed-transaction`,
-    (payload: { precomposedTransaction: GeneralPrecomposedTransactionFinal }) => ({
+    (payload: {
+        formState: FormState;
+        precomposedTransaction: GeneralPrecomposedTransactionFinal;
+    }) => ({
         payload,
     }),
 );

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -572,11 +572,9 @@ export const enhancePrecomposedTransactionThunk = createThunk<
         // store formValues and transactionInfo in send reducer to be used by TransactionReviewModal
         dispatch(
             sendFormActions.storePrecomposedTransaction({
+                formState: formValues,
                 precomposedTransaction: enhancedPrecomposedTransaction,
             }),
-        );
-        dispatch(
-            sendFormActions.storeDraft({ accountKey: selectedAccount.key, formState: formValues }),
         );
 
         return enhancedPrecomposedTransaction;


### PR DESCRIPTION
RBF form should not store transaction drafts. It creates confusion when send form is opened with unexpected pre-filled data and also causes errors when a transaction is created in thusly affected send form.

This PR reintroduces `precomposedForm` which holds similar data as drafts, but is used by both send form and RBF form synchronize data between the form and the review modal.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/13325
Resolve https://github.com/trezor/trezor-suite/issues/14753 (create a transaction, open RBF form, **replace the transaction**, go to send form, try to send)
Resolve https://github.com/trezor/trezor-suite/issues/15114 (create a transaction, open RBF form, **close it without replacing the transaction**, go to send form, try to send)