### PR TITLE
chore(suite-native, e2e): fix debug E2E tests by patching expo-updates

### DIFF
--- a/patches/README.md
+++ b/patches/README.md
@@ -3,3 +3,8 @@
 ## ripple-lib
 
 allow passing custom agent to websocket constructor
+
+## expo-updates
+
+fix e2e tests in debug mode
+upstream PR https://github.com/expo/expo/pull/32951

--- a/patches/expo-updates+0.26.6.patch
+++ b/patches/expo-updates+0.26.6.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt b/node_modules/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
+index 6385d40..1f03038 100644
+--- a/node_modules/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
++++ b/node_modules/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
+@@ -97,7 +97,7 @@ class UpdatesPackage : Package {
+     val handler = object : ApplicationLifecycleListener {
+       override fun onCreate(application: Application) {
+         super.onCreate(application)
+-        if (isRunningAndroidTest()) {
++        if (!BuildConfig.USE_DEV_CLIENT && isRunningAndroidTest()) {
+           // Preload updates to prevent Detox ANR
+           UpdatesController.initialize(context)
+           UpdatesController.instance.launchAssetFile


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

This will fix running local E2E tests in debug build using `yarn test:e2e android.emu.debug` 

- Use patch untill https://github.com/expo/expo/pull/32951 is merged and released.
