### PR TITLE
fix(connect): postMessage instance not propagated correctly

### DIFF
--- a/packages/connect/src/api/blockchainEvmRpcCall.ts
+++ b/packages/connect/src/api/blockchainEvmRpcCall.ts
@@ -53,7 +53,7 @@ export default class BlockchainEvmRpcCall extends AbstractMethod<'blockchainEvmR
     async run() {
         const backend = await initBlockchain(
             this.params.coinInfo,
-            postMessage,
+            this.postMessage,
             this.params.identity,
         );
         const response = await backend.rpcCall(this.params.request);

--- a/packages/suite/src/hooks/wallet/useUnstakeEthForm.ts
+++ b/packages/suite/src/hooks/wallet/useUnstakeEthForm.ts
@@ -38,6 +38,7 @@ import {
 import { useStakeCompose } from './form/useStakeCompose';
 import { useFormDraft } from './useFormDraft';
 import { useFees } from './form/useFees';
+import { BigNumber } from '@trezor/utils';
 
 type UnstakeOptions = 'all' | 'rewards' | 'other';
 
@@ -118,7 +119,11 @@ export const useUnstakeEthForm = ({
     useEffect(() => {
         const { cryptoInput } = values;
 
-        if (!cryptoInput || Object.keys(formState.errors).length) {
+        if (
+            !cryptoInput ||
+            new BigNumber(cryptoInput).lte(0) ||
+            Object.keys(formState.errors).length
+        ) {
             setApproximatedInstantEthAmount(null);
 
             return;


### PR DESCRIPTION
## Description

- fix not working rpc calls in desktop app
- fix simulation for invalid amount (there are no form errors yet, we handle it wrong I would say, but let's leave that for later)

## Related Issue

Resolve #15343

## Screenshots:
