### PR TITLE
Radical Solana refresh optimizations

### DIFF
--- a/packages/blockchain-link-types/src/params.ts
+++ b/packages/blockchain-link-types/src/params.ts
@@ -56,4 +56,5 @@ export interface AccountInfoParams {
         ledger: number;
         seq: number;
     };
+    tokenAccountsPubKeys?: string[]; // solana only, token accounts to fetch txids for
 }

--- a/packages/blockchain-link-utils/src/solana.ts
+++ b/packages/blockchain-link-utils/src/solana.ts
@@ -393,7 +393,7 @@ export const getDetails = (
 
     const getVin = ({ address, amount }: { address: string; amount?: BigNumber }, i: number) => ({
         txid: transaction.transaction.signatures[0].toString(),
-        version: transaction.version,
+        version: transaction.version?.toString(),
         isAddress: true,
         isAccountOwned: address === accountAddress,
         n: i,

--- a/packages/blockchain-link/src/workers/solana/fee.ts
+++ b/packages/blockchain-link/src/workers/solana/fee.ts
@@ -1,15 +1,19 @@
 import {
     Address,
+    Base64EncodedWireTransaction,
     CompiledTransactionMessage,
     decompileTransactionMessage,
     getBase64Decoder,
     getCompiledTransactionMessageEncoder,
     GetFeeForMessageApi,
     GetRecentPrioritizationFeesApi,
+    getTransactionEncoder,
     isWritableRole,
-    MicroLamports,
     pipe,
     Rpc,
+    SignaturesMap,
+    SimulateTransactionApi,
+    TransactionMessageBytes,
     TransactionMessageBytesBase64,
 } from '@solana/web3.js';
 
@@ -17,28 +21,25 @@ import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 const COMPUTE_BUDGET_PROGRAM_ID =
     'ComputeBudget111111111111111111111111111111' as Address<'ComputeBudget111111111111111111111111111111'>;
-const DEFAULT_COMPUTE_UNIT_PRICE_MICROLAMPORTS = BigInt(100_000); // micro-lamports, value taken from other wallets
-// sending tokens with token account creation requires ~28K units. However we over-reserve for now
-// since otherwise the transactions don't seem to go through otherwise. This can perhaps be changed
-// if e.g. https://github.com/anza-xyz/agave/pull/187 is merged.
-const DEFAULT_COMPUTE_UNIT_LIMIT = BigInt(200_000);
+const DEFAULT_COMPUTE_UNIT_PRICE_MICROLAMPORTS = BigInt(300_000); // micro-lamports, value taken from other wallets
+
+const stripComputeBudgetInstructions = (message: CompiledTransactionMessage) => ({
+    ...message,
+    // Remove ComputeBudget instructions from the message when estimating the base fee
+    // since the exact priority fees are computed separately and getFeeForMessage also
+    // considers priority fees.
+    instructions: message.instructions.filter(
+        instruction =>
+            message.staticAccounts[instruction.programAddressIndex] !== COMPUTE_BUDGET_PROGRAM_ID,
+    ),
+});
 
 export const getBaseFee = async (
     api: Rpc<GetFeeForMessageApi>,
     message: CompiledTransactionMessage,
 ) => {
     const messageWithoutComputeBudget = pipe(
-        {
-            ...message,
-            // Remove ComputeBudget instructions from the message when estimating the base fee
-            // since the exact priority fees are computed separately and getFeeForMessage also
-            // considers priority fees.
-            instructions: message.instructions.filter(
-                instruction =>
-                    message.staticAccounts[instruction.programAddressIndex] !==
-                    COMPUTE_BUDGET_PROGRAM_ID,
-            ),
-        },
+        stripComputeBudgetInstructions(message),
         getCompiledTransactionMessageEncoder().encode,
         getBase64Decoder().decode,
     ) as TransactionMessageBytesBase64;
@@ -55,8 +56,9 @@ export const getBaseFee = async (
 // More about Solana priority fees here:
 // https://solana.com/developers/guides/advanced/how-to-use-priority-fees#how-do-i-estimate-priority-fees
 export const getPriorityFee = async (
-    api: Rpc<GetRecentPrioritizationFeesApi>,
+    api: Rpc<GetRecentPrioritizationFeesApi & SimulateTransactionApi>,
     compiledMessage: CompiledTransactionMessage,
+    signatures: SignaturesMap,
 ) => {
     const message = decompileTransactionMessage(compiledMessage);
     const affectedAccounts = new Set<Address>(
@@ -66,9 +68,34 @@ export const getPriorityFee = async (
             .map(({ address }) => address),
     );
 
-    const recentFees = await api.getRecentPrioritizationFees(Array.from(affectedAccounts)).send();
+    // Reconstruct TX for simulation
+    const messageBytes = pipe(
+        compiledMessage,
+        getCompiledTransactionMessageEncoder().encode,
+    ) as TransactionMessageBytes;
+    const rawTx = pipe(
+        {
+            messageBytes,
+            signatures,
+        },
+        getTransactionEncoder().encode,
+        getBase64Decoder().decode,
+    ) as Base64EncodedWireTransaction;
 
-    const computeUnitLimit = DEFAULT_COMPUTE_UNIT_LIMIT;
+    const simulated = await api
+        .simulateTransaction(rawTx, { commitment: 'confirmed', encoding: 'base64' })
+        .send();
+    if (simulated.value.err != null || !simulated.value.unitsConsumed) {
+        console.error('Could not simulate transaction:', simulated.value.err);
+        throw new Error(`Could not simulate transaction: ${simulated.value.err}`);
+    }
+    // Add 20% margin to the computed limit
+    const computeUnitLimit = new BigNumber(simulated.value.unitsConsumed.toString())
+        .times(1.2)
+        .decimalPlaces(0, BigNumber.ROUND_UP);
+
+    // Local fees from API
+    const recentFees = await api.getRecentPrioritizationFees(Array.from(affectedAccounts)).send();
 
     const networkPriorityFee = recentFees
         .map(a => a.prioritizationFee)
@@ -81,13 +108,13 @@ export const getPriorityFee = async (
 
     const fee = new BigNumber(computeUnitPrice.toString())
         .times(10 ** -6) // microLamports -> Lamports
-        .times(computeUnitLimit.toString())
+        .times(computeUnitLimit)
         .decimalPlaces(0, BigNumber.ROUND_UP)
         .toString(10);
 
     return {
-        computeUnitPrice,
-        computeUnitLimit,
-        fee: BigInt(fee) as MicroLamports,
+        computeUnitPrice: computeUnitPrice.toString(10),
+        computeUnitLimit: computeUnitLimit.toString(10),
+        fee,
     };
 };

--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -171,8 +171,7 @@ const pushTransaction = async (request: Request<MessageTypes.PushTransaction>) =
         const sendAndConfirmTransaction = sendAndConfirmTransactionFactory(api);
         await sendAndConfirmTransaction(transactionWithBlockhashLifetime, {
             commitment: 'confirmed',
-            maxRetries: BigInt(0),
-            skipPreflight: true,
+            skipPreflight: false,
         });
 
         return {

--- a/packages/connect/src/api/blockchainUnsubscribe.ts
+++ b/packages/connect/src/api/blockchainUnsubscribe.ts
@@ -11,6 +11,7 @@ type Params = {
     accounts: Payload<'blockchainUnsubscribe'>['accounts'];
     coinInfo: CoinInfo;
     identity?: string;
+    blocks: boolean;
 };
 
 export default class BlockchainUnsubscribe extends AbstractMethod<'blockchainUnsubscribe', Params> {
@@ -23,6 +24,7 @@ export default class BlockchainUnsubscribe extends AbstractMethod<'blockchainUns
         // validate incoming parameters
         validateParams(payload, [
             { name: 'accounts', type: 'array', allowEmpty: true },
+            { name: 'blocks', type: 'boolean' },
             { name: 'coin', type: 'string', required: true },
             { name: 'identity', type: 'string' },
         ]);
@@ -44,6 +46,7 @@ export default class BlockchainUnsubscribe extends AbstractMethod<'blockchainUns
             accounts: payload.accounts,
             coinInfo,
             identity: payload.identity,
+            blocks: payload.blocks ?? false,
         };
     }
 
@@ -56,6 +59,13 @@ export default class BlockchainUnsubscribe extends AbstractMethod<'blockchainUns
 
         const { accounts } = this.params;
 
-        return accounts ? backend.unsubscribeAccounts(accounts) : backend.unsubscribeAll();
+        if (this.params.blocks) {
+            return backend.unsubscribeBlocks();
+        }
+        if (accounts) {
+            return backend.unsubscribeAccounts(accounts);
+        }
+
+        return backend.unsubscribeAll();
     }
 }

--- a/packages/connect/src/api/getAccountInfo.ts
+++ b/packages/connect/src/api/getAccountInfo.ts
@@ -273,6 +273,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
                     contractFilter: request.contractFilter,
                     gap: request.gap,
                     marker: request.marker,
+                    tokenAccountsPubKeys: request.tokenAccountsPubKeys,
                 });
 
                 if (this.disposed) break;

--- a/packages/suite/src/hooks/wallet/useSendFormCompose.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormCompose.ts
@@ -15,7 +15,7 @@ import {
 import { useDebounce } from '@trezor/react-utils';
 import { isChanged } from '@suite-common/suite-utils';
 import { findComposeErrors } from '@suite-common/wallet-utils';
-import { FeeLevel } from '@trezor/connect';
+import TrezorConnect, { FeeLevel } from '@trezor/connect';
 import { COMPOSE_ERROR_TYPES } from '@suite-common/wallet-constants';
 import { composeSendFormTransactionFeeLevelsThunk } from '@suite-common/wallet-core';
 
@@ -343,6 +343,23 @@ export const useSendFormCompose = ({
         updateContext,
         setLoading,
     ]);
+
+    useEffect(() => {
+        // Subscribe to blocks for Solana, since they are not fetched globally
+        if (state.account.networkType === 'solana') {
+            TrezorConnect.blockchainSubscribe({
+                coin: state.account.symbol,
+                blocks: true,
+            });
+
+            return () => {
+                TrezorConnect.blockchainUnsubscribe({
+                    coin: state.account.symbol,
+                    blocks: true,
+                });
+            };
+        }
+    }, [state.account]);
 
     return {
         composeDraft,

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -89,12 +89,18 @@ export const fetchAndUpdateAccountThunk = createThunk(
         if (!isTrezorConnectBackendType(account.backendType)) return; // skip unsupported backend type
         // first basic check, traffic optimization
         // basic check returns only small amount of data without full transaction history
+        const tokenAccountsPubKeys =
+            account.networkType === 'solana'
+                ? account.tokens?.flatMap(t => t.accounts ?? []).map(a => a.publicKey)
+                : undefined;
+
         const basic = await TrezorConnect.getAccountInfo({
             coin: account.symbol,
             identity: tryGetAccountIdentity(account),
             descriptor: account.descriptor,
-            details: 'basic',
+            details: 'txids',
             suppressBackupWarning: true,
+            tokenAccountsPubKeys,
         });
         if (!basic.success) return;
 

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -17,6 +17,7 @@ import {
     isTrezorConnectBackendType,
     shouldUseIdentities,
     getAccountIdentity,
+    shouldSubscribeBlocks,
 } from '@suite-common/wallet-utils';
 import TrezorConnect, {
     BlockchainBlock,
@@ -244,9 +245,11 @@ export const subscribeBlockchainThunk = createThunk(
         { getState },
     ) => {
         const useIdentities = shouldUseIdentities(symbol);
+        // Don't subscribe to blocks for Solana, this is too intensive
+        const blocks = shouldSubscribeBlocks(symbol);
 
         if (onConnect && useIdentities) {
-            await TrezorConnect.blockchainSubscribe({ coin: symbol, blocks: true });
+            await TrezorConnect.blockchainSubscribe({ coin: symbol, blocks });
         }
 
         // do NOT subscribe if there are no accounts
@@ -266,7 +269,7 @@ export const subscribeBlockchainThunk = createThunk(
                       blocks: false,
                   }),
               )
-            : [{ accounts: accountsToSubscribe, coin: symbol, blocks: true }];
+            : [{ accounts: accountsToSubscribe, coin: symbol, blocks }];
 
         return Promise.all(paramsArray.map(params => TrezorConnect.blockchainSubscribe(params)));
     },

--- a/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
@@ -181,6 +181,15 @@ export const composeSolanaTransactionFeeLevelsThunk = createThunk<
                 message: 'Token accounts not found.',
             });
 
+        if (formState.setMaxOutputId !== undefined && !formState.outputs[0].amount) {
+            if (tokenInfo?.balance) {
+                formState.outputs[0].amount = tokenInfo.balance;
+            } else {
+                // small amount for purpose of fee estimation
+                formState.outputs[0].amount = '0.000000001';
+            }
+        }
+
         const tokenTransferTxAndDestinationAddress =
             tokenInfo && tokenInfo.accounts
                 ? await buildTokenTransferTransaction(

--- a/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
@@ -241,6 +241,7 @@ export const composeSolanaTransactionFeeLevelsThunk = createThunk<
             fetchedFeeLimit = feeLevel.feeLimit;
         } else {
             // Error fetching fee, fall back on default values defined in `/packages/connect/src/data/defaultFeeLevels.ts`
+            console.warn('Error fetching fee, using default values.', estimatedFee.payload.error);
         }
 
         // FeeLevels are read-only, so we create a copy if need be

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -634,11 +634,13 @@ export const enhanceHistory = ({
     unconfirmed,
     tokens,
     addrTxCount,
+    txids,
 }: AccountInfo['history']): Account['history'] => ({
     total,
     unconfirmed,
     tokens,
     addrTxCount,
+    txids,
 });
 
 export const getAccountTokensFiatBalance = (
@@ -810,6 +812,9 @@ export const isAccountOutdated = (account: Account, freshInfo: AccountInfo) => {
                 // changed stake pool
                 freshInfo.misc!.staking?.poolId !== account.misc.staking.poolId
             );
+        case 'solana':
+            // compare last transaction signature since the total number of txs may not be fetched fully
+            return freshInfo.history.txids?.[0] !== account.history.txids?.[0];
         default:
             return false;
     }

--- a/suite-common/wallet-utils/src/backendUtils.ts
+++ b/suite-common/wallet-utils/src/backendUtils.ts
@@ -61,6 +61,8 @@ export const isTrezorConnectBackendType = (type?: BackendType) => {
 
 export const shouldUseIdentities = (symbol: NetworkSymbol) => getNetworkType(symbol) === 'ethereum';
 
+export const shouldSubscribeBlocks = (symbol: NetworkSymbol) => getNetworkType(symbol) !== 'solana';
+
 export const getAccountIdentity = (account: Pick<Account, 'deviceState'>) => account.deviceState;
 
 export const tryGetAccountIdentity = (account: Pick<Account, 'networkType' | 'deviceState'>) =>


### PR DESCRIPTION
## Description

Reduce the amount of periodic calls for Solana

1. Check if the account was updated only based on txids. This means that it uses only 1 request per account + 1 per token. Previously this was more than 5 requests per account + 1 per token. 
2. Remove Solana block subscription from Suite's side and move it to send form only, at a reduced interval of 50 seconds.
3. Fixed baseFee calculation, increase priority fee unit price x3, added simulations for precise calculation of compute limit, resulting in overall lower fees but higher priority. 
4. Fixed Solana account subscriptions. Added solution to reconnect Solana backend when subscription goes down.
5. Changed configuration for sending TX to run the preflight check and allow retries
6. Fixed "send max" in send form

## Benchmark

Count of all Solana requests when opening a wallet with 4 accounts and several tokens and waiting for 5 min (including discovery)

- Before: 449 (121 discovery + 82 per minute)
- After: 200 (72 discovery + 32 per minute)