### PR TITLE
fix(suite): change p to span to make DOM nesting valid

### DIFF
--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardException.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardException.tsx
@@ -6,7 +6,7 @@ import {
     restartDiscoveryThunk as restartDiscovery,
 } from '@suite-common/wallet-core';
 import { getNetwork, NetworkType } from '@suite-common/wallet-config';
-import { Button, H3, IconName, Column, Row, Paragraph, IconCircle } from '@trezor/components';
+import { Button, H3, IconName, Column, Row, IconCircle, Text } from '@trezor/components';
 import { Discovery } from '@suite-common/wallet-types';
 import { spacings } from '@trezor/theme';
 
@@ -43,13 +43,13 @@ const Container = ({ title, description, cta, dataTestBase }: ContainerProps) =>
                 <Translation id={title} />
             </H3>
             {description && (
-                <Paragraph variant="tertiary" typographyStyle="hint">
+                <Text variant="tertiary" typographyStyle="hint">
                     {typeof description === 'string' ? (
                         <Translation id={description} />
                     ) : (
                         description
                     )}
-                </Paragraph>
+                </Text>
             )}
             <Row gap={spacings.sm} margin={{ top: spacings.md }}>
                 {actions.map(a => (


### PR DESCRIPTION
Fixing console error, no user-facing change.

![Screenshot 2024-11-19 at 13 08 15](https://github.com/user-attachments/assets/16f33149-0c08-4651-b459-cf8dd650dd24)
![Screenshot 2024-11-19 at 13 08 21](https://github.com/user-attachments/assets/74c3a4ce-9603-496c-9331-853bf3f839d8)
