### PR TITLE
Update electron-updater to 6.5.0 + fix: progress bar for update on linux

### DIFF
--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -40,7 +40,7 @@
         "chalk": "^4.1.2",
         "electron-localshortcut": "^3.2.1",
         "electron-store": "8.2.0",
-        "electron-updater": "6.3.9",
+        "electron-updater": "6.5.0",
         "openpgp": "^6.1.0",
         "systeminformation": "^5.25.11",
         "ws": "^8.18.0"

--- a/packages/suite-desktop-core/src/modules/auto-updater.ts
+++ b/packages/suite-desktop-core/src/modules/auto-updater.ts
@@ -65,6 +65,10 @@ export const init: ModuleInit = ({ mainWindowProxy, store }) => {
 
     autoUpdater.logger = null;
 
+    if (process.platform === 'linux') {
+        autoUpdater.disableDifferentialDownload = true;
+    }
+
     autoUpdater.setFeedURL(feedURL);
     logger.warn(SERVICE_NAME, [`Feed url: ${feedURL}`]);
 

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -25,7 +25,7 @@
         "blake-hash": "^2.0.0",
         "electron-localshortcut": "^3.2.1",
         "electron-store": "8.2.0",
-        "electron-updater": "6.3.9",
+        "electron-updater": "6.5.0",
         "openpgp": "^6.1.0",
         "usb": "^2.14.0"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13027,7 +13027,7 @@ __metadata:
     electron: "npm:34.1.0"
     electron-localshortcut: "npm:^3.2.1"
     electron-store: "npm:8.2.0"
-    electron-updater: "npm:6.3.9"
+    electron-updater: "npm:6.5.0"
     fs-extra: "npm:^11.2.0"
     glob: "npm:^10.3.10"
     jest-diff: "npm:^29.7.0"
@@ -13082,7 +13082,7 @@ __metadata:
     electron-builder: "npm:26.0.3"
     electron-localshortcut: "npm:^3.2.1"
     electron-store: "npm:8.2.0"
-    electron-updater: "npm:6.3.9"
+    electron-updater: "npm:6.5.0"
     glob: "npm:^10.3.10"
     openpgp: "npm:^6.1.0"
     usb: "npm:^2.14.0"
@@ -17877,16 +17877,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"builder-util-runtime@npm:9.2.10":
-  version: 9.2.10
-  resolution: "builder-util-runtime@npm:9.2.10"
-  dependencies:
-    debug: "npm:^4.3.4"
-    sax: "npm:^1.2.4"
-  checksum: 10/58b96675c174d1f495b4ffd5369fa496f4c33c9ea8150852191c45528bb47a2744142f2e9a449a077304a0f44ce0c35941ebb06b067ad39685c950c26d2137d2
-  languageName: node
-  linkType: hard
-
 "builder-util-runtime@npm:9.3.1":
   version: 9.3.1
   resolution: "builder-util-runtime@npm:9.3.1"
@@ -21783,11 +21773,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-updater@npm:6.3.9":
-  version: 6.3.9
-  resolution: "electron-updater@npm:6.3.9"
+"electron-updater@npm:6.5.0":
+  version: 6.5.0
+  resolution: "electron-updater@npm:6.5.0"
   dependencies:
-    builder-util-runtime: "npm:9.2.10"
+    builder-util-runtime: "npm:9.3.1"
     fs-extra: "npm:^10.1.0"
     js-yaml: "npm:^4.1.0"
     lazy-val: "npm:^1.0.5"
@@ -21795,7 +21785,7 @@ __metadata:
     lodash.isequal: "npm:^4.5.0"
     semver: "npm:^7.6.3"
     tiny-typed-emitter: "npm:^2.1.0"
-  checksum: 10/98a8a451fde48d6af71ef1e6c09df678feee59444ad296cb6276a01d8a2d0718b6233f884402ba61b736a8d7a16a5df7a86a8cf837ed686f9d3101ab4f34171f
+  checksum: 10/161137dac327049650b58dbd996b9a8b4f25cd858ac17cce0374613976a0fac1778011cb1a8bb663bf52f826ab95d330746255bbebb8431bbc86a6d5fae0f8d0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Problem is, that for differential downloads, the progress bar is not working correctly (seems to not be implemented for multi-range downloads at all).

Solution is therefore to fallback to direct full download. However, the switch for this is simply not working for AppImage so we have to fix it in Electron Builder first.

Resolves: https://github.com/trezor/trezor-suite/issues/14416

- This PR is related to this in Electron Repo: https://github.com/electron-userland/electron-builder/issues/8659
- :exclamation: This https://github.com/electron-userland/electron-builder/pull/8695 needs to be finished, merged and released first in the electron builder repo first.

