### PR TITLE
fix(suite): count total txs amount on solana

### DIFF
--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -173,7 +173,11 @@ export const sumTransactions = (transactions: WalletAccountTransaction[]) => {
 
         // count in only if Inputs/Outputs includes my account (EVM does not need to)
         if (tx.type === 'sent') {
-            totalAmount = totalAmount.minus(amount);
+            if (tx.symbol === 'sol') {
+                totalAmount = totalAmount.plus(amount);
+            } else {
+                totalAmount = totalAmount.minus(amount);
+            }
         }
 
         if (tx.type === 'recv' || tx.type === 'joint') {
@@ -188,7 +192,11 @@ export const sumTransactions = (transactions: WalletAccountTransaction[]) => {
             const amountInternal = formatNetworkAmount(internalTx.amount, tx.symbol);
 
             if (internalTx.type === 'sent') {
-                totalAmount = totalAmount.minus(amountInternal);
+                if (tx.symbol === 'sol') {
+                    totalAmount = totalAmount.plus(amountInternal);
+                } else {
+                    totalAmount = totalAmount.minus(amountInternal);
+                }
             }
             if (internalTx.type === 'recv') {
                 totalAmount = totalAmount.plus(amountInternal);
@@ -242,9 +250,15 @@ export const sumTransactionsFiat = (
                 const tokenAmount = formatAmount(token.amount, token.decimals);
 
                 if (transferType === 'sent') {
-                    totalAmount = totalAmount.minus(
-                        toFiatCurrency(tokenAmount, historicTokenRate, -1) ?? 0,
-                    );
+                    if (tx.symbol === 'sol') {
+                        totalAmount = totalAmount.plus(
+                            toFiatCurrency(tokenAmount, historicTokenRate, -1) ?? 0,
+                        );
+                    } else {
+                        totalAmount = totalAmount.minus(
+                            toFiatCurrency(tokenAmount, historicTokenRate, -1) ?? 0,
+                        );
+                    }
                 }
 
                 if (transferType === 'recv') {
@@ -256,7 +270,11 @@ export const sumTransactionsFiat = (
         } else {
             // count in only if Inputs/Outputs includes my account (EVM does not need to)
             if (tx.type === 'sent') {
-                totalAmount = totalAmount.minus(toFiatCurrency(amount, historicRate, -1) ?? 0);
+                if (tx.symbol === 'sol') {
+                    totalAmount = totalAmount.plus(toFiatCurrency(amount, historicRate, -1) ?? 0);
+                } else {
+                    totalAmount = totalAmount.minus(toFiatCurrency(amount, historicRate, -1) ?? 0);
+                }
             }
 
             if (tx.type === 'recv' || tx.type === 'joint') {
@@ -273,7 +291,11 @@ export const sumTransactionsFiat = (
             const amountInternalFiat = toFiatCurrency(amountInternal, historicRate, -1) ?? 0;
 
             if (internalTx.type === 'sent') {
-                totalAmount = totalAmount.minus(amountInternalFiat);
+                if (tx.symbol === 'sol') {
+                    totalAmount = totalAmount.plus(amountInternalFiat);
+                } else {
+                    totalAmount = totalAmount.minus(amountInternalFiat);
+                }
             }
             if (internalTx.type === 'recv') {
                 totalAmount = totalAmount.plus(amountInternalFiat);


### PR DESCRIPTION
## Description

While on other chains tx amout is sign agnostic, on solana the outgoing transactions have a sign of negativity. So they should be handled with addition instead of subtraction, that changes the sign to plus. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/12992

## Screenshots:

### Before: 

<img width="913" alt="image" src="https://github.com/user-attachments/assets/d465e070-db4c-42d0-a5fb-8ddbba2da936">


### After:

<img width="913" alt="image" src="https://github.com/user-attachments/assets/f268b9c6-883e-40c3-92c3-4fe975e22f31">
 