### PR TITLE
fix(suite): CoinJoin status double scrollbar

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/CoinjoinBars/CoinjoinStatusBar.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/CoinjoinBars/CoinjoinStatusBar.tsx
@@ -31,6 +31,7 @@ const ViewText = styled.div`
 
 const Container = styled.div<{ $isClickable: boolean }>`
     display: flex;
+    align-self: stretch;
     align-items: center;
     height: 28px;
     padding: 0 ${SPACING}px;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx
@@ -129,7 +129,7 @@ export const SuiteLayout = ({ children }: SuiteLayoutProps) => {
 
                             <ModalSwitcher />
 
-                            <CoinjoinBars />
+                            {isMobileLayout && <CoinjoinBars />}
 
                             {isMobileLayout && <MobileMenu />}
 
@@ -144,6 +144,7 @@ export const SuiteLayout = ({ children }: SuiteLayoutProps) => {
                                             </ElevationDown>
                                         )}
                                         <MainBar>
+                                            {!isMobileLayout && <CoinjoinBars />}
                                             <SuiteBanners />
                                             <AppWrapper
                                                 data-testid="@app"


### PR DESCRIPTION
## Description

- When CJ status bar is displayed, double scrollbar is visible.
- This is because of the way how `Sidebar` works - it takes up 100vh, so it overflows. It doesn't really support being displayed  with any bar above it, and would be a lot of work to refactor it.
- Since CJ is a _deprecated_ feature and no new rounds can be initiated, I don't think we need to be true to the original design (it's all "hidden" UI)
- :arrow_right: move the status bar inside `AppBar`
  - don't do that for mobile screen, because there is no sidebar, so let's keep it on top

## Screenshots:
**Before:**
![be4](https://github.com/user-attachments/assets/820642cf-7d5d-4436-891a-10e5dea1528a)

**After:**
![after](https://github.com/user-attachments/assets/73aef586-4f30-460c-94b7-771021414eb5)

**Mobile (unchanged):**
![mobile](https://github.com/user-attachments/assets/9d3685ed-3b91-4071-9c8c-9f2c19d03ff3)
