### PR TITLE
fix(blockchain-link-utils): solana with negative tx amount

### DIFF
--- a/packages/blockchain-link-utils/src/solana.ts
+++ b/packages/blockchain-link-utils/src/solana.ts
@@ -415,7 +415,7 @@ export const getAmount = (
         return '0';
     }
 
-    return accountEffect.amount.toString();
+    return accountEffect.amount.abs().toString();
 };
 
 type TokenTransferInstruction = {

--- a/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
+++ b/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
@@ -636,6 +636,14 @@ export const fixtures = {
             expectedOutput: '0',
         },
         {
+            description: 'should return positive amount even though effect is negative',
+            input: {
+                accountEffect: effects.negative,
+                txType: 'sent',
+            },
+            expectedOutput: '20',
+        },
+        {
             description: 'should return the amount as a string for other transaction types',
             input: {
                 accountEffect: effects.positive,
@@ -874,7 +882,7 @@ export const fixtures = {
                 type: 'sent',
                 txid: 'txid1',
                 blockTime: 1631753600,
-                amount: '-20',
+                amount: '20',
                 fee: '10',
                 solanaSpecific: {
                     status: 'confirmed',

--- a/packages/suite/src/storage/CHANGELOG.md
+++ b/packages/suite/src/storage/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 49
 
 -   networks now have same order everywhere
+-   solana tx amount is always positive
 
 ## 48
 

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -1134,5 +1134,13 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
 
             return walletSettings;
         });
+
+        await updateAll(transaction, 'txs', tx => {
+            if (['sol', 'dsol'].includes(tx.tx.symbol)) {
+                tx.tx.amount = new BigNumber(tx.tx.amount).abs().toString();
+            }
+
+            return tx;
+        });
     }
 };


### PR DESCRIPTION
## Description

- @vytick pointed out that for some reason solana txs have negative amounts, this PR should fix it
- the problem is better to handle in blockchain link and not in Suite as here #15450

## Related Issue

Resolve #12992 
Resolve #15424

## Screenshots:

<img width="1238" alt="Screenshot 2024-11-19 at 18 28 00" src="https://github.com/user-attachments/assets/75e4fc26-81d0-4ad1-b8a6-a6ca36ec375c">
