### PR TITLE
feat(suite-common): fetch stake data based on device account symbols

### DIFF
--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -1,5 +1,5 @@
 import { isAnyOf } from '@reduxjs/toolkit';
-import { A, G, pipe } from '@mobily/ts-belt';
+import { A, F, G, pipe } from '@mobily/ts-belt';
 
 import {
     createReducerWithExtraDeps,
@@ -322,6 +322,18 @@ export const selectVisibleNonEmptyDeviceAccountsByNetworkSymbol = createMemoized
             accounts,
             A.filter(account => !account.empty || account.visible),
             returnStableArrayIfEmpty,
+        ),
+);
+
+export const selectAllNetworkSymbolsOfVisibleAccounts = createMemoizedSelector(
+    [selectAccounts],
+    accounts =>
+        pipe(
+            accounts,
+            A.filter(account => account.visible),
+            A.map(account => account.symbol),
+            A.uniq,
+            F.toMutable,
         ),
 );
 


### PR DESCRIPTION
On mobile, using enabled networks might not work for imported accounts (portfolio tracker), because `ETH` might not be amongst enabled networks. On iOS, enabled networks are always empty array. This caused imported accounts with eth staking to show there `BACKUP_ETH_APY` instead of fetching actual apy. 

This is now resolved by fetching apy based on network symbols of actual device accounts.

## Related Issue

Resolve #15362 for portfolio tracker

<img width=300 src="https://github.com/user-attachments/assets/ea6d3ed6-43a7-4d8f-908b-693f93f1450e" />

