### PR TITLE
feat(suite-native): selected fee remembered

### DIFF
--- a/suite-native/module-send/src/components/CustomFeeBottomSheet.tsx
+++ b/suite-native/module-send/src/components/CustomFeeBottomSheet.tsx
@@ -1,4 +1,4 @@
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import Animated, {
     FadeInDown,
     FadeOutDown,
@@ -20,6 +20,7 @@ import { SendStackParamList, SendStackRoutes, StackProps } from '@suite-native/n
 import { SendFeesFormValues } from '../sendFeesFormSchema';
 import { CustomFeeInputs } from './CustomFeeInputs';
 import { useCustomFee } from '../hooks/useCustomFee';
+import { updateSelectedFeeLevelThunk } from '../sendFormThunks';
 
 type CustomFeeBottomSheetProps = {
     isVisible: boolean;
@@ -30,6 +31,7 @@ type RouteProps = StackProps<SendStackParamList, SendStackRoutes.SendAddressRevi
 
 export const CustomFeeBottomSheet = ({ isVisible, onClose }: CustomFeeBottomSheetProps) => {
     const route = useRoute<RouteProps>();
+    const dispatch = useDispatch();
     const { accountKey, tokenContract } = route.params;
 
     const { feeValue, isFeeLoading, isSubmittable, isErrorBoxVisible } = useCustomFee({
@@ -41,10 +43,18 @@ export const CustomFeeBottomSheet = ({ isVisible, onClose }: CustomFeeBottomShee
         selectAccountNetworkSymbol(state, accountKey),
     );
 
-    const { setValue, handleSubmit } = useFormContext<SendFeesFormValues>();
+    const { setValue, handleSubmit, getValues } = useFormContext<SendFeesFormValues>();
 
     const handleSetCustomFee = handleSubmit(() => {
         setValue('feeLevel', 'custom');
+        dispatch(
+            updateSelectedFeeLevelThunk({
+                accountKey,
+                feeLevelLabel: 'custom',
+                feePerUnit: getValues('customFeePerUnit'),
+                feeLimit: getValues('customFeeLimit'),
+            }),
+        );
         onClose();
     });
 

--- a/suite-native/module-send/src/components/SendFeesForm.tsx
+++ b/suite-native/module-send/src/components/SendFeesForm.tsx
@@ -18,6 +18,8 @@ import {
     selectAccountByKey,
     selectNetworkFeeInfo,
     selectNetworkFeeLevelFeePerUnit,
+    selectSendFormDraftByKey,
+    SendRootState,
 } from '@suite-common/wallet-core';
 import {
     AuthorizeDeviceStackRoutes,
@@ -37,6 +39,7 @@ import { FeeOptionsList } from './FeeOptionsList';
 import { RecipientsSummary } from './RecipientsSummary';
 import { CustomFee } from './CustomFee';
 import { selectFeeLevels } from '../sendFormSlice';
+import { NativeSupportedFeeLevel } from '../types';
 
 type SendFormProps = {
     accountKey: AccountKey;
@@ -48,8 +51,6 @@ type SendFeesNavigationProps = StackToStackCompositeNavigationProps<
     SendStackRoutes.SendFees,
     RootStackParamList
 >;
-
-const DEFAULT_FEE = 'normal';
 
 export const SendFeesForm = ({ accountKey, tokenContract }: SendFormProps) => {
     const navigation = useNavigation<SendFeesNavigationProps>();
@@ -63,7 +64,10 @@ export const SendFeesForm = ({ accountKey, tokenContract }: SendFormProps) => {
         selectNetworkFeeInfo(state, account?.symbol),
     );
 
-    const normalFeeLevelInfo = networkFeeInfo?.levels.find(l => l.label === 'normal');
+    const formDraft = useSelector((state: SendRootState) =>
+        selectSendFormDraftByKey(state, accountKey, tokenContract),
+    );
+
     const networkType = account?.symbol ? getNetworkType(account.symbol) : undefined;
 
     const minimalFeeLimit =
@@ -72,9 +76,9 @@ export const SendFeesForm = ({ accountKey, tokenContract }: SendFormProps) => {
     const form = useForm<SendFeesFormValues>({
         validation: sendFeesFormValidationSchema,
         defaultValues: {
-            feeLevel: DEFAULT_FEE,
-            customFeePerUnit: normalFeeLevelInfo?.feePerUnit,
-            customFeeLimit: normalFeeLevelInfo?.feeLimit,
+            feeLevel: formDraft?.selectedFee as NativeSupportedFeeLevel,
+            customFeePerUnit: formDraft?.feePerUnit,
+            customFeeLimit: formDraft?.feeLimit,
         },
         context: {
             networkFeeInfo,

--- a/suite-native/module-send/src/screens/SendOutputsScreen.tsx
+++ b/suite-native/module-send/src/screens/SendOutputsScreen.tsx
@@ -123,14 +123,20 @@ export const SendOutputsScreen = ({
     const watchedAddress = useWatch({ name: 'outputs.0.address', control });
 
     const storeFormDraftIfValid = useCallback(() => {
+        const normalFeeLevel = networkFeeInfo?.levels.find(level => level.label === 'normal');
+
         dispatch(
             sendFormActions.storeDraft({
                 accountKey,
                 tokenContract,
-                formState: constructFormDraft({ formValues: getValues(), tokenContract }),
+                formState: constructFormDraft({
+                    formValues: getValues(),
+                    tokenContract,
+                    feeLevel: normalFeeLevel,
+                }),
             }),
         );
-    }, [accountKey, dispatch, getValues, tokenContract]);
+    }, [accountKey, dispatch, getValues, tokenContract, networkFeeInfo]);
 
     const calculateNormalFeeMaxAmount = useCallback(async () => {
         const response = await dispatch(

--- a/suite-native/module-send/src/utils.ts
+++ b/suite-native/module-send/src/utils.ts
@@ -1,4 +1,5 @@
 import { FormState, TokenAddress } from '@suite-common/wallet-types';
+import { FeeLevel } from '@trezor/connect';
 
 import { SendOutputFieldName, SendOutputsFormValues } from './sendOutputsFormSchema';
 
@@ -10,9 +11,11 @@ export const getOutputFieldName = <TField extends SendOutputFieldName>(
 export const constructFormDraft = ({
     formValues: { outputs, setMaxOutputId },
     tokenContract,
+    feeLevel = { label: 'normal', feePerUnit: '' },
 }: {
     formValues: SendOutputsFormValues;
     tokenContract?: TokenAddress;
+    feeLevel?: Pick<FeeLevel, 'label' | 'feePerUnit' | 'feeLimit'>;
 }): FormState => ({
     outputs: outputs.map(({ address, amount, fiat = '' }) => ({
         address,
@@ -26,8 +29,8 @@ export const constructFormDraft = ({
     isCoinControlEnabled: false,
     hasCoinControlBeenOpened: false,
     selectedUtxos: [],
-    feeLimit: '',
-    feePerUnit: '',
     options: [],
-    selectedFee: 'normal',
+    selectedFee: feeLevel.label,
+    feePerUnit: feeLevel.feePerUnit,
+    feeLimit: feeLevel.feeLimit ?? '',
 });


### PR DESCRIPTION
## Description
- on every change of the selected fee level, it is saved to the send form draft right away
- if the user modify send outputs (adrress, crypto value, etc.) the selection is returned to the default `normal` level

## Related Issue

Resolve #15046 

## Screenshots:

https://github.com/user-attachments/assets/7747f4a3-5a5d-4cf5-956a-49b1c388f914

