### PR TITLE
feat(suite): display modals in WelcomeLayout

### DIFF
--- a/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
@@ -5,7 +5,7 @@ import { Card } from '@trezor/components';
 import { getFirmwareVersion } from '@trezor/device-utils';
 import { TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_URL } from '@trezor/urls';
 
-import { WelcomeLayout } from 'src/components/suite';
+import { WelcomeLayout } from 'src/components/suite/layouts/WelcomeLayout/WelcomeLayout';
 import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 import { captureSentryMessage, withSentryScope } from 'src/utils/suite/sentry';
 import {

--- a/packages/suite/src/components/suite/index.tsx
+++ b/packages/suite/src/components/suite/index.tsx
@@ -2,7 +2,6 @@ import { AccountLabel } from './AccountLabel';
 import { DeviceConfirmImage } from './DeviceConfirmImage';
 import { CheckItem } from './CheckItem';
 import { PrerequisitesGuide } from './PrerequisitesGuide/PrerequisitesGuide';
-import { WelcomeLayout } from './layouts/WelcomeLayout/WelcomeLayout';
 import { NotificationCard } from './NotificationCard';
 import { WordInput } from './WordInput';
 import { WordInputAdvanced } from './WordInputAdvanced';
@@ -60,7 +59,6 @@ export {
     DeviceConfirmImage,
     CheckItem,
     PrerequisitesGuide,
-    WelcomeLayout,
     NotificationCard,
     FiatValue,
     Translation,

--- a/packages/suite/src/components/suite/layouts/WelcomeLayout/WelcomeLayout.tsx
+++ b/packages/suite/src/components/suite/layouts/WelcomeLayout/WelcomeLayout.tsx
@@ -32,6 +32,8 @@ import { MAX_ONBOARDING_WIDTH } from 'src/constants/suite/layout';
 
 import { NavSettings } from './NavSettings';
 import { TrafficLightOffset } from '../../TrafficLightOffset';
+import { ModalContextProvider } from 'src/support/suite/ModalContext';
+import { ModalSwitcher } from 'src/components/suite/modals/ModalSwitcher/ModalSwitcher';
 
 const MessageContainer = styled.div`
     margin: ${spacingsPx.xxs} ${spacingsPx.xs} ${spacingsPx.xs};
@@ -132,57 +134,64 @@ const Left = () => {
 
     return (
         <WelcomeWrapper $elevation={elevation}>
-            <AnimatePresence>
-                {(!isGuideOpen || isGuideOnTop) && (
-                    <MotionWelcome
-                        initial={{
-                            width: isFirstRender ? '40vw' : 0,
-                            minWidth: isFirstRender ? '380px' : 0,
-                        }}
-                        animate={{
-                            width: '40vw',
-                            minWidth: '380px',
-                            transition: { duration: 0.3, bounce: 0 },
-                        }}
-                        exit={{
-                            width: 0,
-                            minWidth: 0,
-                            transition: { duration: 0.3, bounce: 0 },
-                        }}
-                    >
-                        <TrafficLightOffset>
-                            <Column justifyContent="center" alignItems="center" height="100%">
-                                <Expander data-testid="@welcome/title">
-                                    <TrezorLogo type="symbol" width="57px" />
-                                </Expander>
+            <ModalContextProvider>
+                <ModalSwitcher />
+                <AnimatePresence>
+                    {(!isGuideOpen || isGuideOnTop) && (
+                        <MotionWelcome
+                            initial={{
+                                width: isFirstRender ? '40vw' : 0,
+                                minWidth: isFirstRender ? '380px' : 0,
+                            }}
+                            animate={{
+                                width: '40vw',
+                                minWidth: '380px',
+                                transition: { duration: 0.3, bounce: 0 },
+                            }}
+                            exit={{
+                                width: 0,
+                                minWidth: 0,
+                                transition: { duration: 0.3, bounce: 0 },
+                            }}
+                        >
+                            <TrafficLightOffset>
+                                <Column justifyContent="center" alignItems="center" height="100%">
+                                    <Expander data-testid="@welcome/title">
+                                        <TrezorLogo type="symbol" width="57px" />
+                                    </Expander>
 
-                                <LinksContainer>
-                                    {isWeb() && (
-                                        <TrezorLink type="hint" variant="nostyle" href={SUITE_URL}>
+                                    <LinksContainer>
+                                        {isWeb() && (
+                                            <TrezorLink
+                                                type="hint"
+                                                variant="nostyle"
+                                                href={SUITE_URL}
+                                            >
+                                                <Button
+                                                    variant="tertiary"
+                                                    icon="arrowUpRight"
+                                                    iconAlignment="right"
+                                                >
+                                                    <Translation id="TR_ONBOARDING_DOWNLOAD_DESKTOP_APP" />
+                                                </Button>
+                                            </TrezorLink>
+                                        )}
+                                        <TrezorLink type="hint" variant="nostyle" href={TREZOR_URL}>
                                             <Button
                                                 variant="tertiary"
                                                 icon="arrowUpRight"
                                                 iconAlignment="right"
                                             >
-                                                <Translation id="TR_ONBOARDING_DOWNLOAD_DESKTOP_APP" />
+                                                trezor.io
                                             </Button>
                                         </TrezorLink>
-                                    )}
-                                    <TrezorLink type="hint" variant="nostyle" href={TREZOR_URL}>
-                                        <Button
-                                            variant="tertiary"
-                                            icon="arrowUpRight"
-                                            iconAlignment="right"
-                                        >
-                                            trezor.io
-                                        </Button>
-                                    </TrezorLink>
-                                </LinksContainer>
-                            </Column>
-                        </TrafficLightOffset>
-                    </MotionWelcome>
-                )}
-            </AnimatePresence>
+                                    </LinksContainer>
+                                </Column>
+                            </TrafficLightOffset>
+                        </MotionWelcome>
+                    )}
+                </AnimatePresence>
+            </ModalContextProvider>
         </WelcomeWrapper>
     );
 };

--- a/packages/suite/src/views/start/SuiteStart.tsx
+++ b/packages/suite/src/views/start/SuiteStart.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { WelcomeLayout } from 'src/components/suite';
+import { WelcomeLayout } from 'src/components/suite/layouts/WelcomeLayout/WelcomeLayout';
 
 import { StartContent } from './StartContent';
 

--- a/packages/suite/src/views/view-only/ViewOnlyPromo.tsx
+++ b/packages/suite/src/views/view-only/ViewOnlyPromo.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { WelcomeLayout } from 'src/components/suite';
+import { WelcomeLayout } from 'src/components/suite/layouts/WelcomeLayout/WelcomeLayout';
 
 import { ViewOnlyPromoContent } from './ViewOnlyPromoContent';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Prerequisite for bluetooth and thp.

we need to open modals in WelcomeLayout (scan result, pairing process etc)

`WelcomeLayout` component is removed from `scr/components/suite/index` as it causes some circular dependency errors