### PR TITLE
fix(connect): preferred device handling based on state

### DIFF
--- a/packages/connect-common/src/storage.ts
+++ b/packages/connect-common/src/storage.ts
@@ -18,7 +18,7 @@ export interface Permission {
 export interface PreferredDevice {
     label?: string;
     path: string & { __type: 'DeviceUniquePath' };
-    state?: string;
+    state?: `${string}@${string}:${number}`;
     internalState?: string;
     internalStateExpiration?: number;
     instance?: number;

--- a/packages/connect-popup/e2e/tests/popup-close.test.ts
+++ b/packages/connect-popup/e2e/tests/popup-close.test.ts
@@ -231,7 +231,8 @@ test('when user cancels permissions in popup it closes automatically', async ({
 
     await popup.waitForLoadState('load');
 
-    if (isWebExtension || isCoreInPopup) {
+    // Device is implicitly remembered in webextension, but not in core-in-popup
+    if (isCoreInPopup) {
         await popup.waitForSelector('.select-device-list button.list', { state: 'visible' });
         await popup.click('.select-device-list button.list');
     }

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -16,13 +16,7 @@ import {
 } from '../events';
 import { getHost } from '../utils/urlUtils';
 import type { Device } from '../device/Device';
-import type {
-    FirmwareRange,
-    DeviceState,
-    StaticSessionId,
-    DeviceUniquePath,
-    ConnectSettings,
-} from '../types';
+import type { FirmwareRange, DeviceState, StaticSessionId, ConnectSettings } from '../types';
 import { config } from '../data/config';
 
 export type Payload<M> = Extract<CallMethodPayload, { method: M }> & { override?: boolean };
@@ -93,8 +87,6 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
     // @ts-expect-error: strictPropertyInitialization
     params: Params;
 
-    devicePath?: DeviceUniquePath;
-
     deviceState?: DeviceState;
 
     hasExpectedDeviceState: boolean;
@@ -164,7 +156,6 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
         this.name = payload.method;
         this.payload = payload;
         this.responseID = message.id || 0;
-        this.devicePath = payload.device?.path;
         this.deviceState = validateDeviceState(payload.device?.state);
         this.hasExpectedDeviceState = payload.device
             ? Object.prototype.hasOwnProperty.call(payload.device, 'state')
@@ -208,7 +199,6 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
 
     setDevice(device: Device) {
         this.device = device;
-        this.devicePath = device.getUniquePath();
         // NOTE: every method should always send "device" parameter
         const originalFn = this.createUiPromise;
         this.createUiPromise = (t, d) => originalFn(t, d || device);

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -15,7 +15,12 @@ import { Descriptor, PathPublic } from '@trezor/transport/src/types';
 import { ERRORS } from '../constants';
 import { DEVICE, TransportInfo } from '../events';
 import { Device } from './Device';
-import { ConnectSettings, DeviceUniquePath, Device as DeviceTyped } from '../types';
+import {
+    ConnectSettings,
+    DeviceUniquePath,
+    Device as DeviceTyped,
+    StaticSessionId,
+} from '../types';
 import { getBridgeInfo } from '../data/transportInfo';
 import { initLog } from '../utils/debug';
 import { resolveAfter } from '../utils/promiseUtils';
@@ -368,6 +373,12 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
 
     getDeviceByPath(path: DeviceUniquePath): Device | undefined {
         return this.getAllDevices().find(d => d.getUniquePath() === path);
+    }
+
+    getDeviceByStaticState(state: StaticSessionId): Device | undefined {
+        const deviceId = state.split('@')[1].split(':')[0];
+
+        return this.getAllDevices().find(d => d.features?.device_id === deviceId);
     }
 
     transportType() {


### PR DESCRIPTION
## Description

- Find device by ID from state
- Move all`preferredDevice` related logic to initDevice
- Remove `devicePath` from AbstractMethod

## Related Issue

Resolve #15452