### PR TITLE
Solana and analyze tx improvements

### DIFF
--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -220,11 +220,14 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
     // https://solana.stackexchange.com/a/13102
     const rent = await api.getMinimumBalanceForRentExemption(accountInfo?.data.byteLength || 0);
 
+    // allTxIds can be empty for non-archive rpc nodes
+    const isAccountEmpty = !(allTxIds.length || balance || tokens.length);
+
     const account: AccountInfo = {
         descriptor: payload.descriptor,
         balance: balance.toString(),
         availableBalance: balance.toString(),
-        empty: !allTxIds.length,
+        empty: isAccountEmpty,
         history: {
             total: allTxIds.length,
             unconfirmed: 0,

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AdvancedTxDetails/IODetails/AnalyzeInExplorerBanner.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AdvancedTxDetails/IODetails/AnalyzeInExplorerBanner.tsx
@@ -39,8 +39,8 @@ export const AnalyzeInExplorerBanner = ({ txid, symbol }: AnalyzeInExplorerBanne
             variant="info"
             icon="cube"
             button={{
-                href: `${explorer?.tx}${txid}`,
-                children: <Translation id="TR_ANALYZE_IN_BLOCKBOOK_OPEN" />,
+                href: `${explorer?.tx}${txid}${explorer.queryString ?? ''}`,
+                children: <Translation id="TR_ANALYZE_IN_EXPLORER_OPEN" />,
                 icon: 'arrowUpRight',
                 iconAlignment: 'right',
                 size: 'small',
@@ -48,10 +48,10 @@ export const AnalyzeInExplorerBanner = ({ txid, symbol }: AnalyzeInExplorerBanne
         >
             <TextWrapper>
                 <Heading>
-                    <Translation id="TR_ANALYZE_IN_BLOCKBOOK" />
+                    <Translation id="TR_ANALYZE_IN_EXPLORER" />
                 </Heading>
                 <Description>
-                    <Translation id="TR_ANALYZE_IN_BLOCKBOOK_DESC" />
+                    <Translation id="TR_ANALYZE_IN_EXPLORER_DESC" />
                 </Description>
             </TextWrapper>
         </NotificationCard>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AdvancedTxDetails/IODetails/IODetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AdvancedTxDetails/IODetails/IODetails.tsx
@@ -201,7 +201,6 @@ const GridRowGroupComponent = ({
                     explorerUrlQueryString={network?.explorer.queryString}
                     shouldAllowCopy={!isPhishingTransaction}
                 />
-                <br />
                 {typeof amount === 'string' ? (
                     <StyledFormattedCryptoAmount value={amount} symbol={symbol} />
                 ) : (

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3161,7 +3161,7 @@ const messages = defineMessagesWithTypeCheck({
         id: 'TR_SHOW_DETAILS',
     },
     TR_SHOW_DETAILS_IN_BLOCK_EXPLORER: {
-        defaultMessage: 'Show details in Block Explorer',
+        defaultMessage: 'Show details in blockchain explorer',
         id: 'TR_SHOW_DETAILS_IN_BLOCK_EXPLORER',
     },
     TR_SHOW_UNVERIFIED_ADDRESS: {
@@ -6518,17 +6518,17 @@ const messages = defineMessagesWithTypeCheck({
         id: 'TR_FINGERPRINT_ADDRESS',
         defaultMessage: 'Fingerprint:',
     },
-    TR_ANALYZE_IN_BLOCKBOOK: {
-        id: 'TR_ANALYZE_IN_BLOCKBOOK',
-        defaultMessage: 'Analyze in Trezor Blockbook',
+    TR_ANALYZE_IN_EXPLORER: {
+        id: 'TR_ANALYZE_IN_EXPLORER',
+        defaultMessage: 'Analyze in blockchain explorer',
     },
-    TR_ANALYZE_IN_BLOCKBOOK_DESC: {
-        id: 'TR_ANALYZE_IN_BLOCKBOOK_DESC',
+    TR_ANALYZE_IN_EXPLORER_DESC: {
+        id: 'TR_ANALYZE_IN_EXPLORER_DESC',
         defaultMessage:
-            'See inputs and outputs in Trezor Blockbook as it might be easier to analyze there.',
+            'See inputs and outputs in blockchain explorer as it might be easier to analyze there.',
     },
-    TR_ANALYZE_IN_BLOCKBOOK_OPEN: {
-        id: 'TR_ANALYZE_IN_BLOCKBOOK_OPEN',
+    TR_ANALYZE_IN_EXPLORER_OPEN: {
+        id: 'TR_ANALYZE_IN_EXPLORER_OPEN',
         defaultMessage: 'Open',
     },
     TR_PAGINATION_NEWER: {

--- a/packages/suite/src/views/wallet/transactions/Transactions.tsx
+++ b/packages/suite/src/views/wallet/transactions/Transactions.tsx
@@ -116,6 +116,7 @@ export const Transactions = () => {
     return (
         <Layout selectedAccount={selectedAccount} showEmptyHeaderPlaceholder>
             <NoTransactions account={account} />
+            <TradeBox account={account} />
         </Layout>
     );
 };

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -173,9 +173,9 @@ export const networks = {
         testnet: false,
         features: ['tokens', 'coin-definitions' /*, 'staking' */],
         explorer: {
-            tx: 'https://explorer.solana.com/tx/',
-            account: 'https://explorer.solana.com/address/',
-            address: 'https://explorer.solana.com/address/',
+            tx: 'https://solscan.io/tx/',
+            account: 'https://solscan.io/account/',
+            address: 'https://solscan.io/account/',
         },
         support: {
             [DeviceModelInternal.T2T1]: '2.6.4',
@@ -591,9 +591,9 @@ export const networks = {
         testnet: true,
         features: ['tokens' /* , 'staking' */],
         explorer: {
-            tx: 'https://explorer.solana.com/tx/',
-            account: 'https://explorer.solana.com/address/',
-            address: 'https://explorer.solana.com/address/',
+            tx: 'https://solscan.io/tx/',
+            account: 'https://solscan.io/account/',
+            address: 'https://solscan.io/account/',
             queryString: '?cluster=devnet',
         },
         support: {


### PR DESCRIPTION
## Description

- finish discovery even on non-archive solana rpc node (tx history is not available) **RELEASE 24.11.3**
- show tradebox when no tx history is available **RELEASE 24.11.3**
- solscan is more user friendly than solana explorer
- analyze in blockchain explorer so that it is generic for all coins


- @trezor/qa  change backend to `solana5.trezor.io` to test it (check current production so that you see difference)

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

![Screenshot 2024-11-20 at 13 16 57](https://github.com/user-attachments/assets/07147441-0d07-4566-9449-7f4d21cc217b)

![Screenshot 2024-11-20 at 13 10 14](https://github.com/user-attachments/assets/f4424453-6a19-4762-b1d4-71fe508f5773)
