### PR TITLE
feat(message-system): warn users about t1b1 fw update

### DIFF
--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,7 +1,7 @@
 {
     "version": 1,
-    "timestamp": "2024-11-14T00:00:00+00:00",
-    "sequence": 64,
+    "timestamp": "2024-11-20T00:00:00+00:00",
+    "sequence": 65,
     "actions": [
         {
             "conditions": [
@@ -1113,6 +1113,76 @@
                         "tr": "Daha Fazla Bilgi",
                         "pt": "Saiba Mais",
                         "uk": "Дізнатись більше"
+                    }
+                }
+            }
+        },
+        {
+            "conditions": [
+                {
+                    "environment": {
+                        "desktop": "*",
+                        "mobile": "!",
+                        "web": "*"
+                    },
+                    "devices": [
+                        {
+                            "model": "1",
+                            "firmware": "<1.7.0",
+                            "bootloader": "*",
+                            "variant": "*",
+                            "firmwareRevision": "*",
+                            "vendor": "*"
+                        },
+                        {
+                            "model": "T1B1",
+                            "firmware": "<1.7.0",
+                            "bootloader": "*",
+                            "variant": "*",
+                            "firmwareRevision": "*",
+                            "vendor": "*"
+                        }
+                    ]
+                }
+            ],
+            "message": {
+                "id": "6b16072f-0a7e-42b7-a56e-eb3cceb9115b",
+                "priority": 96,
+                "dismissible": true,
+                "variant": "critical",
+                "category": "banner",
+                "content": {
+                    "en-GB": "Updating firmware will delete your wallet backup. Verify your backup now to ensure you can recover your assets.",
+                    "en": "Updating firmware will delete your wallet backup. Verify your backup now to ensure you can recover your assets.",
+                    "es": "La actualización del firmware eliminará tu copia de seguridad de la cartera. Verifica tu copia de seguridad ahora para asegurarte de que puedes recuperar tus activos.",
+                    "cs": "Aktualizace firmware smaže zálohu vaší peněženky. Ověřte svou zálohu nyní, abyste zajistili, že můžete obnovit svá aktiva.",
+                    "ru": "Обновление прошивки удалит резервную копию вашего кошелька. Проверьте свою резервную копию сейчас, чтобы убедиться, что вы сможете восстановить свои активы.",
+                    "ja": "ファームウェアの更新により、ウォレットのバックアップが削除されます。資産を回復できることを確認するために、今すぐバックアップを確認してください。",
+                    "hu": "A firmware frissítése törölni fogja a pénztárcád biztonsági mentését. Ellenőrizze most a biztonsági mentését, hogy biztosítsa, hogy vissza tudja állítani az eszközeit.",
+                    "it": "L'aggiornamento del firmware cancellerà il backup del tuo portafoglio. Verifica subito il tuo backup per assicurarti di poter recuperare i tuoi asset.",
+                    "fr": "La mise à jour du micrologiciel supprimera votre sauvegarde de portefeuille. Vérifiez votre sauvegarde dès maintenant pour vous assurer de pouvoir récupérer vos actifs.",
+                    "de": "Das Aktualisieren der Firmware löscht Ihr Wallet-Backup. Überprüfen Sie jetzt Ihr Backup, um sicherzustellen, dass Sie Ihre Assets wiederherstellen können.",
+                    "tr": "Firmware güncellemesi cüzdan yedeğinizi silecektir. Varlıklarınızı kurtarabileceğinizden emin olmak için yedeğinizi şimdi doğrulayın.",
+                    "pt": "A atualização do firmware apagará o backup da sua carteira. Verifique o seu backup agora para garantir que pode recuperar os seus ativos.",
+                    "uk": "Оновлення прошивки видалить резервну копію вашого гаманця. Перевірте свою резервну копію зараз, щоб переконатися, що зможете відновити свої активи."
+                },
+                "cta": {
+                    "action": "internal-link",
+                    "link": "recovery-index",
+                    "label": {
+                        "en-GB": "Check wallet backup",
+                        "en": "Check wallet backup",
+                        "es": "Verificar copia de seguridad de la cartera",
+                        "cs": "Zkontrolovat zálohu peněženky",
+                        "ru": "Проверить резервную копию кошелька",
+                        "ja": "ウォレットのバックアップを確認",
+                        "hu": "Ellenőrizze a pénztárca biztonsági mentését",
+                        "it": "Verifica il backup del portafoglio",
+                        "fr": "Vérifier la sauvegarde du portefeuille",
+                        "de": "Überprüfen Sie das Wallet-Backup",
+                        "tr": "Cüzdan yedeğini kontrol et",
+                        "pt": "Verificar backup da carteira",
+                        "uk": "Перевірити резервну копію гаманця"
                     }
                 }
             }


### PR DESCRIPTION
Adding a new secure message sequence to warn users on old t1b1 fw versions to check their wallet backup before proceeding with update. 

Tracked in notion [here](https://www.notion.so/satoshilabs/Warn-users-about-risks-of-updating-of-old-FWs-on-T1B1-144dc526060680798410c77adca85bd0?pvs=4)

Tested in [here](https://satoshilabs.slack.com/archives/CKYFBT2C9/p1732004776051999)
