### PR TITLE
fix: propagate onClick to the tooltip row

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/Update/UpdateStatusActionBarIcon.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/Update/UpdateStatusActionBarIcon.tsx
@@ -166,14 +166,17 @@ export const UpdateStatusActionBarIcon = ({
         return null;
     }
 
-    const suiteOnClick = () => mapSuiteUpdateToClick[updateStatusSuite]?.({ dispatch });
-    const deviceOnClick = () => mapDeviceUpdateToClick[updateStatusDevice]?.({ dispatch });
+    const suiteOnClick = mapSuiteUpdateToClick[updateStatusSuite];
+    const deviceOnClick = mapDeviceUpdateToClick[updateStatusDevice];
+
+    const suiteOnClickHandler = suiteOnClick ? () => suiteOnClick({ dispatch }) : undefined;
+    const deviceOnClickHandler = deviceOnClick ? () => deviceOnClick({ dispatch }) : undefined;
 
     const handleClick = () => {
         if (updateStatusSuite !== 'up-to-date') {
-            suiteOnClick();
+            suiteOnClickHandler?.();
         } else if (updateStatusDevice !== 'up-to-date') {
-            deviceOnClick();
+            deviceOnClickHandler?.();
         }
     };
 
@@ -184,7 +187,9 @@ export const UpdateStatusActionBarIcon = ({
                     !showUpdateBannerNotification && (
                         <UpdateTooltip
                             updateStatusDevice={updateStatusDevice}
+                            onClickSuite={suiteOnClickHandler}
                             updateStatusSuite={updateStatusSuite}
+                            onClickDevice={deviceOnClickHandler}
                         />
                     )
                 }

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/Update/UpdateTooltip.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/Update/UpdateTooltip.tsx
@@ -12,8 +12,8 @@ import {
     mapUpdateStatusToIcon,
     mapUpdateStatusToVariant,
     UpdateStatus,
-    UpdateStatusSuite,
     UpdateStatusDevice,
+    UpdateStatusSuite,
 } from './updateQuickActionTypes';
 import { useDevice, useSelector } from '../../../../../../../hooks/suite';
 import { TooltipRow } from '../TooltipRow';
@@ -113,16 +113,23 @@ const SuiteRow = ({ updateStatus, onClick }: SuiteRowProps) => {
 
 type UpdateTooltipProps = {
     updateStatusDevice: UpdateStatusDevice;
+    onClickDevice?: () => void;
     updateStatusSuite: UpdateStatusSuite;
+    onClickSuite?: () => void;
 };
 
-export const UpdateTooltip = ({ updateStatusDevice, updateStatusSuite }: UpdateTooltipProps) => {
+export const UpdateTooltip = ({
+    updateStatusDevice,
+    onClickDevice,
+    updateStatusSuite,
+    onClickSuite,
+}: UpdateTooltipProps) => {
     const isDesktopSuite = isDesktop();
 
     return (
         <Column gap={spacings.md} alignItems="start">
-            <DeviceRow updateStatus={updateStatusDevice} />
-            {isDesktopSuite && <SuiteRow updateStatus={updateStatusSuite} />}
+            <DeviceRow updateStatus={updateStatusDevice} onClick={onClickDevice} />
+            {isDesktopSuite && <SuiteRow updateStatus={updateStatusSuite} onClick={onClickSuite} />}
         </Column>
     );
 };


### PR DESCRIPTION
This fixes the missing `onClick` on the tooltips row for updates.

![image](https://github.com/user-attachments/assets/924878b2-b849-4773-877b-57443d541a42)


Row that shows available Suite Update is clickable and triggers the update flow same way as clicking on the icon in the bar.
