### PR TITLE
fix(connect): workaround for staging deployment url

### DIFF
--- a/packages/connect-explorer/next.config.mjs
+++ b/packages/connect-explorer/next.config.mjs
@@ -43,7 +43,10 @@ export default withNextra({
                 'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
                 'process.env.BUILD_TARGET': JSON.stringify(process.env.BUILD_TARGET),
                 'process.env.CONNECT_EXPLORER_FULL_URL': JSON.stringify(
-                    process.env.CONNECT_EXPLORER_FULL_URL,
+                    process.env.CONNECT_EXPLORER_FULL_URL?.replace(
+                        'staging-connect.trezor.io',
+                        'connect.trezor.io',
+                    ),
                 ),
             }),
         );


### PR DESCRIPTION
## Description

We use an env variable `CONNECT_EXPLORER_FULL_URL`, however due to the way we copy from staging to production, it's always set to `staging-connect.trezor.io`

This PR replaces it to always be set to production instead of staging