### PR TITLE
fix(connect): install test types node

### DIFF
--- a/packages/connect/e2e/test-yarn-install.sh
+++ b/packages/connect/e2e/test-yarn-install.sh
@@ -22,4 +22,4 @@ echo import TrezorConnect from \"@trezor/connect\" >index.ts
 
 # compile with typescript
 yarn add typescript@5.5.4
-yarn tsc ./index.ts --types node --types w3c-web-usb --esModuleInterop
+yarn tsc ./index.ts --types node,w3c-web-usb --esModuleInterop


### PR DESCRIPTION
## Description

Fix types parameter passed to `tsc` in our Yarn install test.
Not sure why the behavior changed now