### PR TITLE
Deal with missing device on method

### DIFF
--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -592,7 +592,7 @@ const onCallDevice = async (
         call =>
             call &&
             call !== method &&
-            call.device.getUniquePath() === method.device.getUniquePath(),
+            call.device?.getUniquePath() === method.device.getUniquePath(),
     );
     if (previousCall.length > 0 && method.overridePreviousCall) {
         // set flag for each pending method


### PR DESCRIPTION
## Description

Fixes bug from #15473 which causes (at least) Suite discovery to fail when there's some previous method call without device set.