### PR TITLE
ci(github): add test-connect-mist to release branch

### DIFF
--- a/.github/workflows/test-connect-misc.yml
+++ b/.github/workflows/test-connect-misc.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     # Runs at midnight UTC every day at 01:00 AM CET
     - cron: "0 0 * * *"
+  push:
+    branches: [release/connect/**]
   pull_request:
     paths:
       - ".github/workflows/test-connect-misc.yml"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding test-connect-misc so it is run also on release branch. So we make sure when we release connect that all connect related tests are :green_circle: 