### PR TITLE
feat(suite-web): use data.trezor.io for FW hash check

### DIFF
--- a/packages/connect/src/api/firmware/getBinary.ts
+++ b/packages/connect/src/api/firmware/getBinary.ts
@@ -1,6 +1,8 @@
 import { httpRequest } from '../../utils/assets';
 import { FirmwareRelease } from '../../types';
 
+const ALL_SLASHES_AT_THE_END_REGEX = /\/+$/;
+
 interface GetBinaryProps {
     baseUrl: string;
     btcOnly?: boolean;
@@ -9,7 +11,8 @@ interface GetBinaryProps {
 
 export const getBinary = ({ baseUrl, btcOnly, release }: GetBinaryProps) => {
     const fwUrl = release[btcOnly ? 'url_bitcoinonly' : 'url'];
-    const url = `${baseUrl}/${fwUrl}`;
+    const sanitizedBaseUrl = baseUrl.replace(ALL_SLASHES_AT_THE_END_REGEX, '');
+    const url = `${sanitizedBaseUrl}/${fwUrl}`;
 
     return httpRequest(url, 'binary');
 };

--- a/packages/suite-web/e2e/tests/backup/t3t1-create-addtional-share.test.ts
+++ b/packages/suite-web/e2e/tests/backup/t3t1-create-addtional-share.test.ts
@@ -19,6 +19,7 @@ describe('Backup success', () => {
 
         cy.viewport('macbook-15').resetDb();
         cy.prefixedVisit('/');
+        cy.disableFirmwareHashCheck();
     });
 
     it('Successful backup happy path', () => {

--- a/packages/suite-web/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts
@@ -53,6 +53,7 @@ describe('Onboarding - T2T1 in recovery mode', () => {
         cy.resetDb();
         cy.viewport('macbook-13');
         cy.prefixedVisit('/');
+        cy.disableFirmwareHashCheck();
         cy.getTestElement('@analytics/continue-button').click();
         cy.getTestElement('@analytics/continue-button').click();
 
@@ -83,6 +84,7 @@ describe('Onboarding - T2T1 in recovery mode', () => {
 
         // now suite has reloaded. database is wiped.
         cy.task('startEmu', { wipe: false, model: 'T2T1', version: '2.5.3' });
+        cy.disableFirmwareHashCheck(); // need to disable again after reset
         // analytics opt-out again
         cy.getTestElement('@analytics/continue-button').click();
         cy.getTestElement('@analytics/continue-button').click();

--- a/packages/suite-web/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts
@@ -10,6 +10,7 @@ describe('Onboarding - recover wallet T2T1', () => {
         cy.task('startEmu', { wipe: true, model: 'T2T1', version: '2.5.3' });
         cy.viewport('macbook-13').resetDb();
         cy.prefixedVisit('/');
+        cy.disableFirmwareHashCheck();
 
         cy.step('Go through analytics', () => {
             onAnalyticsPage.continue();

--- a/suite-common/connect-init/package.json
+++ b/suite-common/connect-init/package.json
@@ -14,12 +14,12 @@
         "@reduxjs/toolkit": "1.9.5",
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
-        "@suite-common/suite-utils": "workspace:^",
         "@suite-common/test-utils": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/env-utils": "workspace:^",
         "@trezor/suite-desktop-api": "workspace:*",
+        "@trezor/urls": "workspace:*",
         "@trezor/utils": "workspace:*"
     },
     "devDependencies": {

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -7,9 +7,9 @@ import TrezorConnect, {
     TRANSPORT_EVENT,
     UI_EVENT,
 } from '@trezor/connect';
+import { DATA_URL } from '@trezor/urls';
 import { createDeferred, getSynchronize } from '@trezor/utils';
 import { deviceConnectThunks, selectDevice } from '@suite-common/wallet-core';
-import { resolveConnectPath } from '@suite-common/suite-utils';
 import { isDesktop, isNative } from '@trezor/env-utils';
 import { desktopApi } from '@trezor/suite-desktop-api';
 import { serializeError } from '@trezor/connect/src/constants/errors';
@@ -143,11 +143,9 @@ export const connectInitThunk = createThunk(
             }
         }
 
-        // Duplicates `getBinFilesBaseUrlThunk`, because calling any other thunk would change store.getActions() history,
-        // and it would be impossible to test this thunk in isolation (many unit tests depend on it).
         const binFilesBaseUrl = isDesktop()
             ? extra.selectors.selectDesktopBinDir(getState())
-            : resolveConnectPath('data');
+            : DATA_URL;
 
         try {
             await TrezorConnect.init({

--- a/suite-common/connect-init/tsconfig.json
+++ b/suite-common/connect-init/tsconfig.json
@@ -4,7 +4,6 @@
     "references": [
         { "path": "../redux-utils" },
         { "path": "../suite-types" },
-        { "path": "../suite-utils" },
         { "path": "../test-utils" },
         { "path": "../wallet-core" },
         { "path": "../../packages/connect" },
@@ -12,6 +11,7 @@
         {
             "path": "../../packages/suite-desktop-api"
         },
+        { "path": "../../packages/urls" },
         { "path": "../../packages/utils" }
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9153,12 +9153,12 @@ __metadata:
     "@reduxjs/toolkit": "npm:1.9.5"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
-    "@suite-common/suite-utils": "workspace:^"
     "@suite-common/test-utils": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/env-utils": "workspace:^"
     "@trezor/suite-desktop-api": "workspace:*"
+    "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"
     redux-mock-store: "npm:^1.5.4"
     redux-thunk: "npm:^2.4.2"
@@ -9385,7 +9385,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@suite-common/suite-utils@workspace:*, @suite-common/suite-utils@workspace:^, @suite-common/suite-utils@workspace:suite-common/suite-utils":
+"@suite-common/suite-utils@workspace:*, @suite-common/suite-utils@workspace:suite-common/suite-utils":
   version: 0.0.0-use.local
   resolution: "@suite-common/suite-utils@workspace:suite-common/suite-utils"
   dependencies:


### PR DESCRIPTION
## Description

Currently suite-web downloads FW binary for FW hash check from suite.trezor.io, where only some binaries are available, and it cannot be relied upon.

:arrow_right:  switch to data.trezor.io where all binaries are available so all [supported versions](https://github.com/trezor/trezor-suite/blob/0fd023dbe89e77037f7ab75118ee10d83047449b/packages/connect/src/constants/firmware.ts) can be checked

## Related Issue

Resolve https://github.com/trezor/trezor-suite-private/issues/122

## QA instructions

<!--
- if this PR has already been merged, visit https://dev.suite.sldev.cz/suite-web/develop/web/settings/debug
-->
- visit https://dev.suite.sldev.cz/suite-web/feat/fw-hash-check-from-data-on-web/web/settings/debug
- Turn **OFF revision** check
- Turn **ON hash** check
- Open `trezor-user-env`, try with following devices. The expected results are that it should either pass :heavy_check_mark: , or get ghost modal :ghost: with "Firmware hash check failed. Your Trezor might be counterfeit." banner after clicking Back
  - T1B1
    - 1.10.5 :heavy_check_mark: 
    - 1.11.1 :ghost: 
    - 1.12.1 :ghost: 
  - T2T1
    - 2.3.0 :heavy_check_mark: 
    - 2.5.1 :ghost: 
    - 2.5.2 :ghost: 
    - 2.8.1 :ghost: 
  - T2B1 
    - 2.8.0 :ghost: 
  - T3T1 
    - 2.8.1 :ghost: 