### PR TITLE
chore(suite-native): use method info instead of core api in connect popup

### DIFF
--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -25,6 +25,15 @@ export type MethodReturnType<M extends CallMethodPayload['method']> = CallMethod
 export type MethodPermission = 'read' | 'write' | 'management' | 'push_tx';
 export type DeviceMode = typeof UI.SEEDLESS | typeof UI.BOOTLOADER | typeof UI.INITIALIZE;
 
+export interface MethodInfo {
+    useDevice: boolean;
+    useDeviceState: boolean;
+    name: string;
+    requiredPermissions: MethodPermission[];
+    info: string;
+    confirmation?: UiRequestConfirmation['payload'];
+}
+
 export const DEFAULT_FIRMWARE_RANGE: FirmwareRange = {
     T1B1: { min: '1.0.0', max: '0' },
     T2T1: { min: '2.0.0', max: '0' },
@@ -326,6 +335,9 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
             useDevice: this.useDevice,
             useDeviceState: this.useDeviceState,
             name: this.name,
+            requiredPermissions: this.requiredPermissions,
+            info: this.info,
+            confirmation: this.confirmation,
             // this could be used for more. it could tell clients what are min firmware versions (firmwareRange) and much more
         };
     }

--- a/suite-native/module-connect-popup/src/hooks/useConnectMethod.ts
+++ b/suite-native/module-connect-popup/src/hooks/useConnectMethod.ts
@@ -1,12 +1,11 @@
 import { useEffect, useState } from 'react';
 
-import { getMethod } from '@trezor/connect/src/core/method';
-import { AbstractMethod } from '@trezor/connect/src/core/AbstractMethod';
-import { isDevelopOrDebugEnv } from '@suite-native/config';
+import TrezorConnect from '@trezor/connect';
+import type { MethodInfo } from '@trezor/connect/src/core/AbstractMethod';
 
 // Load AbstractMethod from @trezor/connect based on the URL parameters
 export const useConnectMethod = (popupOptions?: { method: string; params: any }) => {
-    const [method, setMethod] = useState<AbstractMethod<any> | undefined>();
+    const [method, setMethod] = useState<MethodInfo | undefined>();
     const [methodError, setMethodError] = useState<string | undefined>();
 
     useEffect(() => {
@@ -20,35 +19,30 @@ export const useConnectMethod = (popupOptions?: { method: string; params: any })
 
         setMethod(undefined);
         setMethodError(undefined);
-        getMethod({
-            id: 0,
-            type: 'iframe-call',
-            payload: {
-                method: popupOptions?.method,
-                ...popupOptions?.params,
-            },
-        })
-            .then(async _method => {
-                _method.init();
-                await _method.initAsync?.();
 
+        const run = async () => {
+            try {
+                // @ts-expect-error method is dynamic
+                const methodInfo = await TrezorConnect[popupOptions.method]({
+                    ...popupOptions.params,
+                    __info: true,
+                });
                 if (
-                    _method.requiredPermissions.includes('management') ||
-                    _method.requiredPermissions.includes('push_tx') ||
-                    (!isDevelopOrDebugEnv() && _method.requiredPermissions.includes('write'))
+                    methodInfo.payload.requiredPermissions.includes('management') ||
+                    methodInfo.payload.requiredPermissions.includes('push_tx')
                 ) {
                     setMethodError('Method requires unsafe permissions');
 
                     return;
                 }
-
-                setMethod(_method);
-            })
-            .catch(e => {
-                console.error('Error while getting method', e);
+                setMethod(methodInfo.payload);
+            } catch (error) {
+                console.error('Error while getting method', error);
                 setMethod(undefined);
-                setMethodError(e.message);
-            });
+                setMethodError(error.message);
+            }
+        };
+        run();
     }, [popupOptions?.method, popupOptions?.params]);
 
     return { method, methodError };


### PR DESCRIPTION
## Description

Add requiredPermissions and other interesting things to method info returned with the `__info` parameter.
This is used in Connect Popup in mobile instead of the previous solution of getting it from core. 
And it will be useful for Connect Popup in Suite desktop.