### PR TITLE
feat(suite): ignore FW hash check other-error

### DIFF
--- a/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareRevisionCheckBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareRevisionCheckBanner.tsx
@@ -26,7 +26,6 @@ const hashCheckMessages: Record<
     TranslationKey
 > = {
     'hash-mismatch': 'TR_DEVICE_FIRMWARE_HASH_CHECK_HASH_MISMATCH',
-    'other-error': 'TR_DEVICE_FIRMWARE_HASH_CHECK_OTHER_ERROR',
 };
 
 const useAuthenticityCheckMessage = (): TranslationKey | null => {

--- a/packages/suite/src/constants/suite/firmware.ts
+++ b/packages/suite/src/constants/suite/firmware.ts
@@ -8,6 +8,8 @@ export const skippedRevisionCheckErrors = [
 export const skippedHashCheckErrors = [
     'check-skipped',
     'check-unsupported',
+    // TODO this shouldn't be ignored -> investigate false positives
+    'other-error',
     // this could be serious, but it's also caught by revision check, which handles edge-cases better, so it's skipped here
     'unknown-release',
 ] satisfies FirmwareHashCheckError[];


### PR DESCRIPTION
## Description

Ignore FW hash check result when it returns `other-error`