### PR TITLE
fix(suite): fix wrapping on tor button

### DIFF
--- a/packages/suite/src/components/suite/TorLoader/TorProgressBar.tsx
+++ b/packages/suite/src/components/suite/TorLoader/TorProgressBar.tsx
@@ -138,6 +138,7 @@ export const TorProgressBar = ({
                     <DisableButton
                         data-testid="@tor-loading-screen/disable-button"
                         variant="tertiary"
+                        textWrap={false}
                         onClick={disableTor}
                     >
                         <Translation id="TR_TOR_DISABLE" />


### PR DESCRIPTION
Fixing wrapping of Tor button during Suite startup. 

Before
![image](https://github.com/user-attachments/assets/94a065ab-81f2-495b-aeb0-75e18d9902eb)



After
![image](https://github.com/user-attachments/assets/055d6146-a6e6-47ab-8eb0-ef7926f783ad)
