### PR TITLE
fix(suite): check seed backup on T1B1 with seed

### DIFF
--- a/packages/suite/src/views/recovery/steps/T1B1InputStep.tsx
+++ b/packages/suite/src/views/recovery/steps/T1B1InputStep.tsx
@@ -1,8 +1,15 @@
 import { Paragraph } from '@trezor/components';
 import { HELP_CENTER_ADVANCED_RECOVERY_URL } from '@trezor/urls';
+import { UI } from '@trezor/connect';
 
-import { Translation, TrezorLink, WordInput, WordInputAdvanced } from 'src/components/suite';
-import { useSelector } from 'src/hooks/suite';
+import {
+    PinMatrix,
+    Translation,
+    TrezorLink,
+    WordInput,
+    WordInputAdvanced,
+} from 'src/components/suite';
+import { useDevice, useSelector } from 'src/hooks/suite';
 import { MODAL } from 'src/actions/suite/constants';
 
 const RequestConfirmationStep = () => (
@@ -33,12 +40,31 @@ const WordStep = () => (
     </>
 );
 
+const EnterPinStep = () => {
+    const { device } = useDevice();
+    if (!device) return null;
+
+    return (
+        <>
+            <Translation id="TR_ENTER_PIN" />
+            <PinMatrix
+                device={device}
+                hideExplanation
+                // not relevant to entering pin, only for setting/changing pin
+                invalid={false}
+            />
+        </>
+    );
+};
+
 export const T1B1InputStep = () => {
     const modal = useSelector(state => state.modal);
 
     if (modal.context !== MODAL.CONTEXT_DEVICE) return null;
 
     switch (modal.windowType) {
+        case UI.REQUEST_PIN:
+            return <EnterPinStep />;
         case 'ButtonRequest_Other':
             return <RequestConfirmationStep />;
         case 'WordRequestType_Plain':


### PR DESCRIPTION
## Description

Followup to #15380, where seed backup check was fixed for T1B1, but it was still broken for devices **with** PIN. 
:arrow_right: provide UI for entering PIN.

:point_right: it must be discussed further with engagement team, why was the dialog moved out of `ReduxModal`. Because now we have to explicitly handle a lot of states that were handled implicitly by `ReduxModal`. 

## Related Issue

Resolve #15547

## Screenshots:

PIN matrix displayed for both standard & advanced recovery:

![happy](https://github.com/user-attachments/assets/3586be84-ee66-4555-810a-a122f3dd59c9)

Wrong PIN entered:

![invalid](https://github.com/user-attachments/assets/5a3edb2a-d868-4296-bb05-f46d60ac62f7)

## QA instructions

- it is enough to test on suite-web
- go through check seed modal for:
  - T1B1 without PIN & standard recovery
  - T1B1 without PIN & advanced recovery
  - T1B1 with PIN & standard recovery
    - try also entering wrong PIN
  - T1B1 with PIN & advanced recovery
  - any other device