### PR TITLE
feat(suite): enhance FW checks reporting

### DIFF
--- a/packages/connect/src/types/device.ts
+++ b/packages/connect/src/types/device.ts
@@ -66,7 +66,7 @@ export type FirmwareHashCheckError =
     | 'other-error';
 export type FirmwareHashCheckResult =
     | { success: true }
-    | { success: false; error: FirmwareHashCheckError };
+    | { success: false; error: FirmwareHashCheckError; errorPayload?: unknown };
 
 export type DeviceUniquePath = string & { __type: 'DeviceUniquePath' };
 export const DeviceUniquePath = (id: string) => id as DeviceUniquePath;

--- a/packages/suite/src/components/suite/Preloader/Preloader.tsx
+++ b/packages/suite/src/components/suite/Preloader/Preloader.tsx
@@ -28,6 +28,7 @@ import { LoggedOutLayout } from '../layouts/LoggedOutLayout';
 import { WelcomeLayout } from '../layouts/WelcomeLayout/WelcomeLayout';
 import { DeviceCompromised } from '../SecurityCheck/DeviceCompromised';
 import { RouterAppWithParams } from '../../../constants/suite/routes';
+import { useReportDeviceCompromised } from '../SecurityCheck/useReportDeviceCompromised';
 
 const ROUTES_TO_SKIP_FIRMWARE_CHECK: RouterAppWithParams['app'][] = [
     'settings',
@@ -61,6 +62,8 @@ export const Preloader = ({ children }: PropsWithChildren) => {
     const isFirmwareAuthenticityCheckDismissed = useSelector(
         selectIsFirmwareAuthenticityCheckDismissed,
     );
+    // report firmware authenticity failures even when the UI is disabled
+    useReportDeviceCompromised();
 
     const dispatch = useDispatch();
 

--- a/packages/suite/src/components/suite/SecurityCheck/useReportDeviceCompromised.ts
+++ b/packages/suite/src/components/suite/SecurityCheck/useReportDeviceCompromised.ts
@@ -1,0 +1,62 @@
+import { useEffect, useMemo } from 'react';
+
+import { getFirmwareVersion } from '@trezor/device-utils';
+import { isDeviceAcquired } from '@suite-common/suite-utils';
+
+import { useDevice } from 'src/hooks/suite';
+import { captureSentryMessage, withSentryScope } from 'src/utils/suite/sentry';
+
+const reportCheckFail = (checkType: 'revision' | 'hash', contextData: any) =>
+    withSentryScope(scope => {
+        scope.setLevel('error');
+        scope.setTag('deviceAuthenticityError', `firmware ${checkType} check failed`);
+        captureSentryMessage(
+            `Firmware ${checkType} check failed! ${JSON.stringify(contextData)}`,
+            scope,
+        );
+    });
+
+const useCommonData = () => {
+    const { device } = useDevice();
+    const revision = device?.features?.revision;
+    const version = getFirmwareVersion(device);
+    const vendor = device?.features?.fw_vendor;
+
+    return useMemo(() => ({ revision, version, vendor }), [revision, version, vendor]);
+};
+
+const useReportRevisionCheck = () => {
+    const { device } = useDevice();
+    const commonData = useCommonData();
+
+    const revisionCheck = isDeviceAcquired(device)
+        ? device.authenticityChecks?.firmwareRevision
+        : null;
+    const isRevisionCheckError = revisionCheck && !revisionCheck.success;
+    const revisionCheckError = isRevisionCheckError ? revisionCheck.error : null;
+
+    useEffect(() => {
+        if (!isRevisionCheckError) return;
+        reportCheckFail('revision', { ...commonData, revisionCheckError });
+    }, [commonData, isRevisionCheckError, revisionCheckError]);
+};
+
+const useReportHashCheck = () => {
+    const { device } = useDevice();
+    const commonData = useCommonData();
+
+    const hashCheck = isDeviceAcquired(device) ? device.authenticityChecks?.firmwareHash : null;
+    const isHashCheckError = hashCheck && !hashCheck.success;
+    const hashCheckError = isHashCheckError ? hashCheck.error : null;
+    const hashCheckErrorPayload = isHashCheckError ? hashCheck.errorPayload : null;
+
+    useEffect(() => {
+        if (!isHashCheckError) return;
+        reportCheckFail('hash', { ...commonData, hashCheckError, hashCheckErrorPayload });
+    }, [commonData, hashCheckError, isHashCheckError, hashCheckErrorPayload]);
+};
+
+export const useReportDeviceCompromised = () => {
+    useReportRevisionCheck();
+    useReportHashCheck();
+};


### PR DESCRIPTION
## Description

- connect: add `errorPayload` for detailed debugging of FW hash check `other-error`
- extract sentry reporting from `DeviceCompromised`, and fire it always when there is error
  - currently the sentry report only fires when error & the check is enabled
- split `useEffect` for revision check & hash check
  - solves potential problem with duplicate sentry events
    - unknown if this is a problem, it probably gets deduplicated via the anonymous user ID