### PR TITLE
Prevent text wrapping in NotificationCard's Button

### DIFF
--- a/packages/suite/src/components/suite/NotificationCard.tsx
+++ b/packages/suite/src/components/suite/NotificationCard.tsx
@@ -122,12 +122,12 @@ const CardButton = ({ href, ...props }: ButtonType) => {
     if (href) {
         return (
             <TrezorLink variant="nostyle" href={href}>
-                <Button {...props} />
+                <Button textWrap={false} {...props} />
             </TrezorLink>
         );
     }
 
-    return <Button {...props} />;
+    return <Button textWrap={false} {...props} />;
 };
 
 export const NotificationCard = ({


### PR DESCRIPTION
## Screenshots:
before:
![Screenshot 2024-11-25 at 16 02 18](https://github.com/user-attachments/assets/5238a448-65cd-4c4f-b5bc-e8b82ffceaec)
after:
![Screenshot 2024-11-25 at 16 00 54](https://github.com/user-attachments/assets/2a58b1a0-0ba8-4429-b579-32865bddacdb)

**QA:** Hopefully this doesn't break layout of other banners.

