### PR TITLE
fix(e2e): Resolve local fails of core tests

### DIFF
--- a/docs/tests/e2e-suite-desktop.md
+++ b/docs/tests/e2e-suite-desktop.md
@@ -18,6 +18,10 @@
 
     To run the `trezor-user-env` that Playwright tests needs.
 
+4. `cd path/to/trezor-suite-desktop && bash docker/docker-regtest-electrum.sh`
+
+    To run the Regtest server that few Playwright tests need.
+
 ### Running tests locally
 
 `yarn workspace @trezor/suite-desktop-core test:e2e`

--- a/packages/suite-desktop-core/e2e/support/fixtures.ts
+++ b/packages/suite-desktop-core/e2e/support/fixtures.ts
@@ -9,7 +9,7 @@ import { SuiteGuide } from './pageActions/suiteGuideActions';
 import { TopBarActions } from './pageActions/topBarActions';
 import { WalletActions } from './pageActions/walletActions';
 
-const test = base.extend<{
+type Fixtures = {
     electronApp: ElectronApplication;
     window: Page;
     dashboardPage: DashboardActions;
@@ -17,16 +17,21 @@ const test = base.extend<{
     suiteGuidePage: SuiteGuide;
     topBar: TopBarActions;
     walletPage: WalletActions;
-}>({
+};
+
+const test = base.extend<Fixtures>({
     /* eslint-disable no-empty-pattern */
     electronApp: async ({}, use) => {
         const suite = await launchSuite();
         await use(suite.electronApp);
         await suite.electronApp.close(); // Ensure cleanup after tests
     },
-    window: async ({ electronApp }, use) => {
+    window: async ({ electronApp }, use, testInfo) => {
         const window = await electronApp.firstWindow();
+        await window.context().tracing.start({ screenshots: true, snapshots: true });
         await use(window);
+        const tracePath = `${testInfo.outputDir}/trace.electron.zip`;
+        await window.context().tracing.stop({ path: tracePath });
     },
     dashboardPage: async ({ window }, use) => {
         const dashboardPage = new DashboardActions(window);

--- a/packages/suite-desktop-core/e2e/support/pageActions/settingsActions.ts
+++ b/packages/suite-desktop-core/e2e/support/pageActions/settingsActions.ts
@@ -4,6 +4,14 @@ import { BackendType, NetworkSymbol } from '@suite-common/wallet-config';
 
 import { waitForDataTestSelector } from '../common';
 
+const settingSectionsLocators = {
+    debug: '@settings/debug/github',
+    general: '@general-settings/language',
+    device: '@settings/device/backup-recovery-seed',
+    wallet: '@settings/wallet/network/btc',
+} as const;
+type Section = keyof typeof settingSectionsLocators;
+
 export class SettingsActions {
     private readonly window: Page;
     constructor(window: Page) {
@@ -20,33 +28,11 @@ export class SettingsActions {
         await this.window.getByTestId('@settings/menu/debug').waitFor({ state: 'visible' });
     }
 
-    async goToDesiredSettingsPlace(desiredLocation: 'debug' | 'general' | 'device' | 'wallet') {
-        //TODO: Investigate if this is neccessary. Ideally there should be simple test for navigation
-        //and all other test does not need to verify the navigation, they will check elements on that page instead.
-        // and there should never happen default case as typescript should allow only those 4 values in union.
-        let desiredLocationTestid: string;
-        switch (desiredLocation) {
-            case 'debug':
-                desiredLocationTestid = '@settings/debug/github';
-                break;
-            case 'general':
-                desiredLocationTestid = '@general-settings/language';
-                break;
-            case 'device':
-                desiredLocationTestid = '@settings/device/backup-recovery-seed';
-                break;
-            // TODO: later add coverage for edge cases. Test now assumes active btc network
-            case 'wallet':
-                desiredLocationTestid = '@settings/wallet/network/btc';
-                break;
-            default:
-                throw new Error('Unknown location, check your selector.');
-        }
-        await this.window.getByTestId(`@settings/menu/${desiredLocation}`).click();
+    async goToSettingSection(section: Section) {
+        await this.window.getByTestId(`@settings/menu/${section}`).click();
+        //TODO: #15552 Refactor navigation verification to specific tests and remove this method completely
         await this.window
-            .locator(`[data-testid="${desiredLocationTestid}"]`)
-            // TODO: fix data-testid selectors in the app
-            // .getByTestId(desiredLocationTestid)
+            .getByTestId(settingSectionsLocators[section])
             .waitFor({ state: 'visible', timeout: 10_000 });
     }
 

--- a/packages/suite-desktop-core/e2e/tests/general/cardano-discovery.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/general/cardano-discovery.test.ts
@@ -32,7 +32,7 @@ test.skip('Discover all Cardano account types', async ({
     await dashboardPage.discoveryShouldFinish();
 
     await topBar.openSettings();
-    await settingsPage.goToDesiredSettingsPlace('wallet');
+    await settingsPage.goToSettingSection('wallet');
     await settingsPage.enableCoin('ada');
     await settingsPage.enableCoin('btc');
 

--- a/packages/suite-desktop-core/e2e/tests/general/eap-modal.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/general/eap-modal.test.ts
@@ -8,13 +8,15 @@ import { test, expect } from '../../support/fixtures';
  * 4. Confrim the EAP modal
  * 5. Check if there is a button with `Leave` on it
  */
-// TODO: FIX settings cleanup:  eap setting is remembered even after cache cleanup at the beginning of the test. This shouldn't affect gha run but breaks the local one.
+// TODO: #15561 FIX settings cleanup:  eap setting is remembered even after cache cleanup at the beginning of the test. This shouldn't affect gha run but breaks the local one.
+test.skip(!process.env.GITHUB_ACTION, 'Test is working only in CI. Skipping local run.');
+
 test('Join early access button', async ({ dashboardPage, topBar, settingsPage }) => {
     const buttonText = 'Leave';
 
     dashboardPage.optionallyDismissFwHashCheckError();
     await topBar.openSettings();
-    await settingsPage.goToDesiredSettingsPlace('general');
+    await settingsPage.goToSettingSection('general');
     await settingsPage.joinEarlyAccessProgram();
 
     expect(await settingsPage.getEarlyAccessButtonText()).toContain(buttonText);

--- a/packages/suite-desktop-core/e2e/tests/settings/electrum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/electrum.test.ts
@@ -18,6 +18,11 @@ test.describe.serial('Suite works with Electrum server', () => {
         topBar,
         settingsPage,
     }) => {
+        test.info().annotations.push({
+            type: 'dependency',
+            description:
+                'This test needs running RegTest docker. Read how to run this dependency in docs/tests/regtest.md',
+        });
         const electrumUrl = '127.0.0.1:50001:t';
 
         await dashboardPage.passThroughInitialRun();
@@ -25,7 +30,7 @@ test.describe.serial('Suite works with Electrum server', () => {
 
         await topBar.openSettings();
         await settingsPage.toggleDebugModeInSettings();
-        await settingsPage.goToDesiredSettingsPlace('wallet');
+        await settingsPage.goToSettingSection('wallet');
         await settingsPage.openNetworkSettings('regtest');
         await settingsPage.changeNetworkBackend('electrum', electrumUrl);
 


### PR DESCRIPTION
Few tests are passing without an issue on CLI but failing in local runs.

I have added a conditionaly skipping local runs of 'EAP test'. Adding issue to backlog 
I have added annotation of dependency to  'Electrum completes discovery successfully' test. I have found out you need RegTest running locally. I have mentioned this also in docs
Minor refactoring
Added tracing for electron window. I would like to discuss that.


