### PR TITLE
feat(connect): add blockchainGetInfo method, use it to fetch latest Solana block hash when sending

### DIFF
--- a/packages/connect/src/api/blockchainGetInfo.ts
+++ b/packages/connect/src/api/blockchainGetInfo.ts
@@ -1,0 +1,48 @@
+import { AbstractMethod } from '../core/AbstractMethod';
+import { validateParams } from './common/paramsValidator';
+import { ERRORS } from '../constants';
+import { isBackendSupported, initBlockchain } from '../backend/BlockchainLink';
+import { getCoinInfo } from '../data/coinInfo';
+import type { CoinInfo } from '../types';
+
+type Params = {
+    coinInfo: CoinInfo;
+    identity?: string;
+};
+
+export default class BlockchainGetInfo extends AbstractMethod<'blockchainGetInfo', Params> {
+    init() {
+        this.useDevice = false;
+        this.useUi = false;
+
+        const { payload } = this;
+
+        // validate incoming parameters
+        validateParams(payload, [
+            { name: 'coin', type: 'string', required: true },
+            { name: 'identity', type: 'string' },
+        ]);
+
+        const coinInfo = getCoinInfo(payload.coin);
+        if (!coinInfo) {
+            throw ERRORS.TypedError('Method_UnknownCoin');
+        }
+        // validate backend
+        isBackendSupported(coinInfo);
+
+        this.params = {
+            coinInfo,
+            identity: payload.identity,
+        };
+    }
+
+    async run() {
+        const backend = await initBlockchain(
+            this.params.coinInfo,
+            this.postMessage,
+            this.params.identity,
+        );
+
+        return backend.getNetworkInfo();
+    }
+}

--- a/packages/connect/src/api/index.ts
+++ b/packages/connect/src/api/index.ts
@@ -9,6 +9,7 @@ export { default as blockchainDisconnect } from './blockchainDisconnect';
 export { default as blockchainEstimateFee } from './blockchainEstimateFee';
 export { default as blockchainGetAccountBalanceHistory } from './blockchainGetAccountBalanceHistory';
 export { default as blockchainGetCurrentFiatRates } from './blockchainGetCurrentFiatRates';
+export { default as blockchainGetInfo } from './blockchainGetInfo';
 export { default as blockchainEvmRpcCall } from './blockchainEvmRpcCall';
 export { default as blockchainGetFiatRatesForTimestamps } from './blockchainGetFiatRatesForTimestamps';
 export { default as blockchainGetTransactions } from './blockchainGetTransactions';

--- a/packages/connect/src/factory.ts
+++ b/packages/connect/src/factory.ts
@@ -64,6 +64,8 @@ export const factory = <
     blockchainGetFiatRatesForTimestamps: params =>
         call({ ...params, method: 'blockchainGetFiatRatesForTimestamps' }),
 
+    blockchainGetInfo: params => call({ ...params, method: 'blockchainGetInfo' }),
+
     blockchainEvmRpcCall: params => call({ ...params, method: 'blockchainEvmRpcCall' }),
 
     blockchainDisconnect: params => call({ ...params, method: 'blockchainDisconnect' }),

--- a/packages/connect/src/types/api/blockchainGetInfo.ts
+++ b/packages/connect/src/types/api/blockchainGetInfo.ts
@@ -1,0 +1,7 @@
+import type { BlockchainLinkResponse } from '@trezor/blockchain-link';
+
+import type { CommonParamsWithCoin, Response } from '../params';
+
+export declare function blockchainGetInfo(
+    params: CommonParamsWithCoin,
+): Response<BlockchainLinkResponse<'getInfo'>>;

--- a/packages/connect/src/types/api/index.ts
+++ b/packages/connect/src/types/api/index.ts
@@ -10,6 +10,7 @@ import { blockchainDisconnect } from './blockchainDisconnect';
 import { blockchainEstimateFee } from './blockchainEstimateFee';
 import { blockchainGetAccountBalanceHistory } from './blockchainGetAccountBalanceHistory';
 import { blockchainGetCurrentFiatRates } from './blockchainGetCurrentFiatRates';
+import { blockchainGetInfo } from './blockchainGetInfo';
 import { blockchainEvmRpcCall } from './blockchainEvmRpcCall';
 import { blockchainGetFiatRatesForTimestamps } from './blockchainGetFiatRatesForTimestamps';
 import { blockchainGetTransactions } from './blockchainGetTransactions';
@@ -127,6 +128,10 @@ export interface TrezorConnect {
     // todo: link docs
     blockchainGetCurrentFiatRates: typeof blockchainGetCurrentFiatRates;
 
+    // todo: link docs
+    blockchainGetInfo: typeof blockchainGetInfo;
+
+    // todo: link docs
     blockchainEvmRpcCall: typeof blockchainEvmRpcCall;
 
     // todo: link docs

--- a/suite-common/connect-init/src/cardanoConnectPatch.ts
+++ b/suite-common/connect-init/src/cardanoConnectPatch.ts
@@ -14,6 +14,7 @@ const blacklist: ConnectKey[] = [
     'removeAllListeners',
     'uiResponse',
     'blockchainGetAccountBalanceHistory',
+    'blockchainGetInfo',
     'blockchainGetCurrentFiatRates',
     'blockchainGetFiatRatesForTimestamps',
     'blockchainDisconnect',


### PR DESCRIPTION
## Description

1. Added `TrezorConnect.blockchainGetInfo()`, which exposes `blockchain.getNetworkInfo()`
2. Used it to fetch latest Solana blockhash/blockheight when signing in send form, instead of the one in the account which may be delayed
3. Fetch isTestnet only once in Solana and pass it, to avoid subsequent unnecessary `getGenesisHash` calls