### PR TITLE
fix(e2e): Prevent element detached from DOM error while opening settings

### DIFF
--- a/packages/suite-web/e2e/support/pageObjects/topBarObject.ts
+++ b/packages/suite-web/e2e/support/pageObjects/topBarObject.ts
@@ -8,7 +8,10 @@ class NavBar {
     }
 
     openSettings() {
-        cy.getTestElement('@suite/menu/settings', { timeout: 30000 }).should('be.visible').click();
+        cy.getTestElement('@suite/menu/settings', { timeout: 30000 })
+            .as('settingsButton')
+            .should('be.visible');
+        cy.get('@settingsButton').click();
         cy.getTestElement('@settings/menu/general').should('be.visible');
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Experimental attempt to fix flakiness in opening settings.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
