### PR TITLE
refactor(e2e): Refactors locators and methods of Page Objects

### DIFF
--- a/packages/suite-desktop-core/e2e/support/fixtures.ts
+++ b/packages/suite-desktop-core/e2e/support/fixtures.ts
@@ -8,6 +8,7 @@ import { SettingsActions } from './pageActions/settingsActions';
 import { SuiteGuide } from './pageActions/suiteGuideActions';
 import { TopBarActions } from './pageActions/topBarActions';
 import { WalletActions } from './pageActions/walletActions';
+import { OnboardingActions } from './pageActions/onboardingActions';
 
 type Fixtures = {
     electronApp: ElectronApplication;
@@ -17,6 +18,7 @@ type Fixtures = {
     suiteGuidePage: SuiteGuide;
     topBar: TopBarActions;
     walletPage: WalletActions;
+    onboardingPage: OnboardingActions;
 };
 
 const test = base.extend<Fixtures>({
@@ -52,6 +54,10 @@ const test = base.extend<Fixtures>({
     walletPage: async ({ window }, use) => {
         const walletPage = new WalletActions(window);
         await use(walletPage);
+    },
+    onboardingPage: async ({ window }, use) => {
+        const onboardingPage = new OnboardingActions(window);
+        await use(onboardingPage);
     },
 });
 

--- a/packages/suite-desktop-core/e2e/support/pageActions/dashboardActions.ts
+++ b/packages/suite-desktop-core/e2e/support/pageActions/dashboardActions.ts
@@ -1,72 +1,52 @@
-import { Page, expect } from '@playwright/test';
+import { Locator, Page, expect } from '@playwright/test';
 
 import { NetworkSymbol } from '@suite-common/wallet-config';
 
-import { waitForDataTestSelector } from '../common';
-
 export class DashboardActions {
     private readonly window: Page;
+    readonly discoveryBar: Locator;
+    readonly dashboardGraph: Locator;
+    readonly deviceSwitchingOpenButton: Locator;
+    readonly modal: Locator;
+    readonly walletAtIndex = (index: number) =>
+        this.window.getByTestId(`@switch-device/wallet-on-index/${index}`);
+    readonly walletAtIndexEjectButton = (index: number) =>
+        this.window.getByTestId(`@switch-device/wallet-on-index/${index}/eject-button`);
+    readonly confirmDeviceEjectButton: Locator;
+    readonly addStandardWalletButton: Locator;
+    readonly balanceOfNetwork = (network: NetworkSymbol) =>
+        this.window.getByTestId(`@wallet/coin-balance/value-${network}`);
+
     constructor(window: Page) {
         this.window = window;
-    }
-    optionallyDismissFwHashCheckError() {
-        // dismiss the error modal only if it appears (handle it async in parallel, not necessary to block the rest of the flow)
-        this.window
-            .$('[data-testid="@device-compromised/back-button"]')
-            .then(dismissFwHashCheckButton => dismissFwHashCheckButton?.click());
-    }
-
-    async passThroughInitialRun() {
-        await waitForDataTestSelector(this.window, '@welcome/title');
-        this.optionallyDismissFwHashCheckError();
-        await this.window.getByTestId('@analytics/continue-button').click();
-        await this.window.getByTestId('@onboarding/exit-app-button').click();
-
-        await this.window.getByTestId('@onboarding/viewOnly/skip').click();
-        await this.window.getByTestId('@viewOnlyTooltip/gotIt').click();
+        this.discoveryBar = this.window.getByTestId('@wallet/discovery-progress-bar');
+        this.dashboardGraph = this.window.getByTestId('@dashboard/graph');
+        this.deviceSwitchingOpenButton = this.window.getByTestId('@menu/switch-device');
+        this.modal = this.window.getByTestId('@modal');
+        this.confirmDeviceEjectButton = this.window.getByTestId('@switch-device/eject');
+        this.addStandardWalletButton = this.window.getByTestId('@switch-device/add-wallet-button');
     }
 
     async discoveryShouldFinish() {
-        const discoveryBarSelector = '@wallet/discovery-progress-bar';
-        await waitForDataTestSelector(this.window, discoveryBarSelector, {
-            state: 'attached',
-            timeout: 10_000,
-        });
-        await waitForDataTestSelector(this.window, discoveryBarSelector, {
-            state: 'detached',
-            timeout: 120_000,
-        });
-        await waitForDataTestSelector(this.window, '@dashboard/graph', { timeout: 30000 });
+        await this.discoveryBar.waitFor({ state: 'attached', timeout: 10_000 });
+        await this.discoveryBar.waitFor({ state: 'detached', timeout: 120_000 });
+        await expect(this.dashboardGraph).toBeVisible();
     }
 
     async openDeviceSwitcher() {
-        await this.window.getByTestId('@menu/switch-device').click();
-        const deviceSwitcherModal = this.window.getByTestId('@modal');
-        await deviceSwitcherModal.waitFor({ state: 'visible' });
+        await this.deviceSwitchingOpenButton.click();
+        await expect(this.modal).toBeVisible();
     }
 
     async ejectWallet(walletIndex: number = 0) {
-        const wallet = this.window.locator(
-            `[data-testid="@switch-device/wallet-on-index/${walletIndex}"]`,
-        );
-        await this.window
-            .locator('[data-testid="@switch-device/wallet-on-index/0/eject-button"]')
-            .click();
-        await this.window.locator('[data-testid="@switch-device/eject"]').click();
-        await wallet.waitFor({ state: 'detached' });
+        await this.walletAtIndexEjectButton(walletIndex).click();
+        await this.confirmDeviceEjectButton.click();
+        await this.walletAtIndex(walletIndex).waitFor({ state: 'detached' });
     }
 
     async addStandardWallet() {
-        const addStandardWallet = this.window.getByTestId('@switch-device/add-wallet-button');
-        await addStandardWallet.click();
-        await this.window.getByTestId('@modal').waitFor({ state: 'detached' });
+        await this.addStandardWalletButton.click();
+        await this.modal.waitFor({ state: 'detached' });
         await this.discoveryShouldFinish();
-    }
-
-    // asserts
-    async assertHasVisibleBalanceOnFirstAccount(network: NetworkSymbol) {
-        const locator = this.window.getByTestId(`@wallet/coin-balance/value-${network}`).first();
-
-        await expect(locator).toBeVisible();
     }
 }

--- a/packages/suite-desktop-core/e2e/support/pageActions/onboardingActions.ts
+++ b/packages/suite-desktop-core/e2e/support/pageActions/onboardingActions.ts
@@ -1,0 +1,35 @@
+import { Locator, Page, expect } from '@playwright/test';
+
+export class OnboardingActions {
+    private readonly window: Page;
+    readonly welcomeTitle: Locator;
+    readonly analyticsContinueButton: Locator;
+    readonly onboardingContinueButton: Locator;
+    readonly onboardingViewOnlySkipButton: Locator;
+    readonly viewOnlyTooltipGotItButton: Locator;
+
+    constructor(window: Page) {
+        this.window = window;
+        this.welcomeTitle = this.window.getByTestId('@welcome/title');
+        this.analyticsContinueButton = this.window.getByTestId('@analytics/continue-button');
+        this.onboardingContinueButton = this.window.getByTestId('@onboarding/exit-app-button');
+        this.onboardingViewOnlySkipButton = this.window.getByTestId('@onboarding/viewOnly/skip');
+        this.viewOnlyTooltipGotItButton = this.window.getByTestId('@viewOnlyTooltip/gotIt');
+    }
+
+    optionallyDismissFwHashCheckError() {
+        // dismisses the error modal only if it appears (handle it async in parallel, not necessary to block the rest of the flow)
+        this.window
+            .$('[data-testid="@device-compromised/back-button"]')
+            .then(dismissFwHashCheckButton => dismissFwHashCheckButton?.click());
+    }
+
+    async completeOnboarding() {
+        await expect(this.welcomeTitle).toBeVisible();
+        this.optionallyDismissFwHashCheckError();
+        await this.analyticsContinueButton.click();
+        await this.onboardingContinueButton.click();
+        await this.onboardingViewOnlySkipButton.click();
+        await this.viewOnlyTooltipGotItButton.click();
+    }
+}

--- a/packages/suite-desktop-core/e2e/support/pageActions/suiteGuideActions.ts
+++ b/packages/suite-desktop-core/e2e/support/pageActions/suiteGuideActions.ts
@@ -51,7 +51,7 @@ export class SuiteGuide {
         await submitButton.click();
     }
 
-    async sendBugreport({
+    async sendBugReport({
         reportText,
         desiredLocation,
     }: {

--- a/packages/suite-desktop-core/e2e/tests/general/cardano-discovery.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/general/cardano-discovery.test.ts
@@ -23,16 +23,16 @@ test.afterAll(() => {
  * 3. Check that Staking section is available
  */
 test.skip('Discover all Cardano account types', async ({
+    onboardingPage,
     dashboardPage,
     topBar,
     settingsPage,
     walletPage,
 }) => {
-    await dashboardPage.passThroughInitialRun();
+    await onboardingPage.completeOnboarding();
     await dashboardPage.discoveryShouldFinish();
-
     await topBar.openSettings();
-    await settingsPage.goToSettingSection('wallet');
+    await settingsPage.coinsTabButton.click();
     await settingsPage.enableCoin('ada');
     await settingsPage.enableCoin('btc');
 

--- a/packages/suite-desktop-core/e2e/tests/general/eap-modal.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/general/eap-modal.test.ts
@@ -11,13 +11,14 @@ import { test, expect } from '../../support/fixtures';
 // TODO: #15561 FIX settings cleanup:  eap setting is remembered even after cache cleanup at the beginning of the test. This shouldn't affect gha run but breaks the local one.
 test.skip(!process.env.GITHUB_ACTION, 'Test is working only in CI. Skipping local run.');
 
-test('Join early access button', async ({ dashboardPage, topBar, settingsPage }) => {
+test.beforeAll(async ({ onboardingPage }) => {
+    await onboardingPage.completeOnboarding();
+});
+
+test('Join early access button', async ({ topBar, settingsPage }) => {
     const buttonText = 'Leave';
-
-    dashboardPage.optionallyDismissFwHashCheckError();
     await topBar.openSettings();
-    await settingsPage.goToSettingSection('general');
+    await settingsPage.applicationTabButton.click();
     await settingsPage.joinEarlyAccessProgram();
-
-    expect(await settingsPage.getEarlyAccessButtonText()).toContain(buttonText);
+    expect(await settingsPage.earlyAccessJoinButton.textContent()).toContain(buttonText);
 });

--- a/packages/suite-desktop-core/e2e/tests/general/suite-guide.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/general/suite-guide.test.ts
@@ -7,17 +7,17 @@ import { test, expect } from '../../support/fixtures';
  * 3. Write into feedback field
  * 4. Submit bug report (reporttext)
  */
-test('Send a bug report', async ({ dashboardPage, suiteGuidePage }) => {
+test('Send a bug report', async ({ onboardingPage, suiteGuidePage }) => {
     const testData = {
         desiredLocation: 'Account',
         reportText: 'Henlo this is testy test writing hangry test user report',
     };
 
-    dashboardPage.optionallyDismissFwHashCheckError();
+    onboardingPage.optionallyDismissFwHashCheckError();
 
     await suiteGuidePage.openSidePanel();
     await suiteGuidePage.openFeedback();
-    await suiteGuidePage.sendBugreport(testData);
+    await suiteGuidePage.sendBugReport(testData);
 
     expect(await suiteGuidePage.getSuccessToast()).toBeTruthy();
     await suiteGuidePage.closeGuide();

--- a/packages/suite-desktop-core/e2e/tests/general/wallet-discovery.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/general/wallet-discovery.test.ts
@@ -1,6 +1,6 @@
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
-import { test } from '../../support/fixtures';
+import { test, expect } from '../../support/fixtures';
 
 test.beforeAll(async () => {
     await TrezorUserEnvLink.connect();
@@ -16,13 +16,11 @@ test.beforeAll(async () => {
  * 1. Discover a standard wallet
  * 2. Verify discovery by checking a the first btc value under the graph
  */
-test('Discover a standard wallet', async ({ dashboardPage }) => {
-    await dashboardPage.passThroughInitialRun();
+test('Discover a standard wallet', async ({ onboardingPage, dashboardPage }) => {
+    await onboardingPage.completeOnboarding();
     await dashboardPage.discoveryShouldFinish();
-
     await dashboardPage.openDeviceSwitcher();
     await dashboardPage.ejectWallet();
     await dashboardPage.addStandardWallet();
-
-    await dashboardPage.assertHasVisibleBalanceOnFirstAccount('btc');
+    await expect(dashboardPage.balanceOfNetwork('btc').first()).toBeVisible();
 });

--- a/packages/suite-desktop-core/e2e/tests/settings/electrum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/electrum.test.ts
@@ -1,6 +1,6 @@
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
-import { test } from '../../support/fixtures';
+import { test, expect } from '../../support/fixtures';
 
 test.describe.serial('Suite works with Electrum server', () => {
     test.beforeAll(async () => {
@@ -14,6 +14,7 @@ test.describe.serial('Suite works with Electrum server', () => {
     });
 
     test('Electrum completes discovery successfully', async ({
+        onboardingPage,
         dashboardPage,
         topBar,
         settingsPage,
@@ -24,19 +25,18 @@ test.describe.serial('Suite works with Electrum server', () => {
                 'This test needs running RegTest docker. Read how to run this dependency in docs/tests/regtest.md',
         });
         const electrumUrl = '127.0.0.1:50001:t';
-
-        await dashboardPage.passThroughInitialRun();
+        await onboardingPage.completeOnboarding();
         await dashboardPage.discoveryShouldFinish();
 
         await topBar.openSettings();
         await settingsPage.toggleDebugModeInSettings();
-        await settingsPage.goToSettingSection('wallet');
-        await settingsPage.openNetworkSettings('regtest');
-        await settingsPage.changeNetworkBackend('electrum', electrumUrl);
+        await settingsPage.coinsTabButton.click();
+        await settingsPage.openCoinAdvanceSettings('regtest');
+        await settingsPage.changeCoinBackend('electrum', electrumUrl);
 
         await topBar.openDashboard();
         await dashboardPage.discoveryShouldFinish();
 
-        await dashboardPage.assertHasVisibleBalanceOnFirstAccount('regtest');
+        await expect(dashboardPage.balanceOfNetwork('regtest').first()).toBeVisible();
     });
 });

--- a/packages/suite-desktop-core/e2e/tests/spawn-bridge.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/spawn-bridge.test.ts
@@ -2,7 +2,7 @@ import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
 import { test, expect } from '../support/fixtures';
 import { launchSuite, LEGACY_BRIDGE_VERSION, waitForDataTestSelector } from '../support/common';
-import { DashboardActions } from '../support/pageActions/dashboardActions';
+import { OnboardingActions } from '../support/pageActions/onboardingActions';
 
 test.describe.serial('Bridge', () => {
     test.beforeEach(async () => {
@@ -66,8 +66,8 @@ test.describe.serial('Bridge', () => {
         const suite = await launchSuite();
         await suite.window.title();
         await waitForDataTestSelector(suite.window, '@welcome/title');
-        const onDashboardPage = new DashboardActions(suite.window);
-        await onDashboardPage.passThroughInitialRun();
+        const onboardingPage = new OnboardingActions(suite.window);
+        await onboardingPage.completeOnboarding();
 
         await TrezorUserEnvLink.stopBridge();
 


### PR DESCRIPTION
this first commit deals with dashboard and settings page object, rest will come in following commit but this one is already way too big (sorry)

- refactors locators, they are now defined as page object class properties -> better readability of methods, easier maintanance
- splits onboarding page object from dashboard one
- simplifies majority of methods, removes plenty of redundant one
- bunch of renaming to improve readbillity 

I have tried to move `completeOnboarding` step from tests to beforeAll but that cause electron app initialization before emulator is ready and device is not detected. Postponing that to a separate PR