### PR TITLE
fix: NewModal shall have also 'info' variant (blue)

### DIFF
--- a/packages/components/src/components/NewModal/types.tsx
+++ b/packages/components/src/components/NewModal/types.tsx
@@ -1,6 +1,6 @@
 import { UIVariant, UISize, UIHorizontalAlignment, UIVerticalAlignment } from '../../config/types';
 
-export const newModalVariants = ['primary', 'warning', 'destructive'] as const;
+export const newModalVariants = ['primary', 'warning', 'destructive', 'info'] as const;
 export type NewModalVariant = Extract<UIVariant, (typeof newModalVariants)[number]>;
 
 export const newModalSizes = ['huge', 'large', 'medium', 'small', 'tiny'] as const;


### PR DESCRIPTION
We need this in Bluetooth UI