### PR TITLE
feat(coinmarket): kyc swap flow

### DIFF
--- a/packages/suite-desktop-core/src/libs/http-receiver.ts
+++ b/packages/suite-desktop-core/src/libs/http-receiver.ts
@@ -18,6 +18,7 @@ interface Events {
     'oauth/error': (message: string) => void;
     'buy/redirect': (url: string) => void;
     'sell/redirect': (url: string) => void;
+    'exchange/redirect': (url: string) => void;
 }
 
 const applyTemplate = (content = 'You may now close this window.', options?: TemplateOptions) => {
@@ -149,6 +150,19 @@ export const createHttpReceiver = () => {
             const { query } = url.parse(request.url, true);
             if (query && query.p) {
                 httpReceiver.emit('sell/redirect', query.p.toString());
+            }
+
+            const template = applyTemplate();
+            response.end(template);
+        },
+    ]);
+
+    httpReceiver.get('/exchange-redirect', [
+        allowReferers(['']), // No referer
+        (request, response) => {
+            const { query } = url.parse(request.url, true);
+            if (query && query.p) {
+                httpReceiver.emit('exchange/redirect', query.p.toString());
             }
 
             const template = applyTemplate();

--- a/packages/suite-desktop-core/src/modules/http-receiver.ts
+++ b/packages/suite-desktop-core/src/modules/http-receiver.ts
@@ -45,6 +45,13 @@ export const initBackground: ModuleInitBackground = ({ mainWindowProxy, mainThre
                 // as the user was redirected from the Suite to the partner's site and is now coming back.
                 app.focus({ steal: true });
             });
+
+            receiver.on('exchange/redirect', () => {
+                // It is enough to set focus to the Suite, the Suite should be on a page with info about the trade status,
+                // if the user has not moved somewhere else in the Suite. This is a reasonable assumption
+                // as the user was redirected from the Suite to the partner's site and is now coming back.
+                app.focus({ steal: true });
+            });
         });
 
         // when httpReceiver was asked to provide current address for given pathname

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -123,7 +123,7 @@
         "@testing-library/user-event": "14.5.2",
         "@trezor/eslint": "workspace:*",
         "@types/file-saver": "^2.0.6",
-        "@types/invity-api": "^1.1.1",
+        "@types/invity-api": "^1.1.2",
         "@types/jws": "^3.2.10",
         "@types/pako": "^2.0.3",
         "@types/pdfmake": "^0.2.9",

--- a/packages/suite/src/actions/wallet/coinmarketExchangeActions.ts
+++ b/packages/suite/src/actions/wallet/coinmarketExchangeActions.ts
@@ -27,7 +27,8 @@ export type CoinmarketExchangeAction =
           type: typeof COINMARKET_EXCHANGE.SAVE_QUOTE_REQUEST;
           request: ExchangeTradeQuoteRequest;
       }
-    | { type: typeof COINMARKET_EXCHANGE.SAVE_TRANSACTION_ID; transactionId: string }
+    | { type: typeof COINMARKET_EXCHANGE.SAVE_TRANSACTION_ID; transactionId: string | undefined }
+    | { type: typeof COINMARKET_EXCHANGE.SET_IS_FROM_REDIRECT; isFromRedirect: boolean }
     | { type: typeof COINMARKET_EXCHANGE.VERIFY_ADDRESS; addressVerified: string }
     | {
           type: typeof COINMARKET_EXCHANGE.SAVE_QUOTES;
@@ -127,7 +128,7 @@ export const saveQuoteRequest = (request: ExchangeTradeQuoteRequest): Coinmarket
     request,
 });
 
-export const saveTransactionId = (transactionId: string): CoinmarketExchangeAction => ({
+export const saveTransactionId = (transactionId: string | undefined): CoinmarketExchangeAction => ({
     type: COINMARKET_EXCHANGE.SAVE_TRANSACTION_ID,
     transactionId,
 });
@@ -140,6 +141,11 @@ export const saveQuotes = (quotes: ExchangeTrade[]): CoinmarketExchangeAction =>
 export const saveSelectedQuote = (quote: ExchangeTrade | undefined): CoinmarketExchangeAction => ({
     type: COINMARKET_EXCHANGE.SAVE_QUOTE,
     quote,
+});
+
+export const setIsFromRedirect = (isFromRedirect: boolean): CoinmarketExchangeAction => ({
+    type: COINMARKET_EXCHANGE.SET_IS_FROM_REDIRECT,
+    isFromRedirect,
 });
 
 export const verifyAddress = (account: Account, address?: string, path?: string) =>

--- a/packages/suite/src/actions/wallet/constants/coinmarketExchangeConstants.ts
+++ b/packages/suite/src/actions/wallet/constants/coinmarketExchangeConstants.ts
@@ -5,4 +5,5 @@ export const SAVE_QUOTE = '@coinmarket-exchange/save_exchange_quote';
 export const CLEAR_QUOTES = '@coinmarket-exchange/clear_exchange_quotes';
 export const VERIFY_ADDRESS = '@coinmarket-exchange/verify_address';
 export const SAVE_TRANSACTION_ID = '@coinmarket-exchange/save_transaction_id';
+export const SET_IS_FROM_REDIRECT = '@coinmarket-exchange/set_is_from_redirect';
 export const SET_COINMARKET_ACCOUNT = '@coinmarket-exchange/set_coinmarket_account';

--- a/packages/suite/src/constants/wallet/coinmarket/kyc.ts
+++ b/packages/suite/src/constants/wallet/coinmarket/kyc.ts
@@ -1,3 +1,4 @@
+export const KYC_REQUIRED = 'KYC-required';
 export const KYC_NO_REFUND = 'KYC-norefund';
 export const KYC_YES_REFUND = 'KYC-yesrefund';
 export const KYC_NO_KYC = 'noKYC';

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeForm.ts
@@ -530,20 +530,25 @@ export const useCoinmarketExchangeForm = ({
 
             return;
         }
+
+        // sendAddress may be set by useCoinmarketWatchTrade hook to the trade object
+        const sendAddress = selectedQuote?.sendAddress || trade?.data?.sendAddress;
         if (
             selectedQuote &&
             selectedQuote.orderId &&
-            selectedQuote.sendAddress &&
+            sendAddress &&
             selectedQuote.sendStringAmount
         ) {
             const sendStringAmount = shouldSendInSats
                 ? amountToSmallestUnit(selectedQuote.sendStringAmount, decimals)
                 : selectedQuote.sendStringAmount;
+            const sendPaymentExtraId =
+                selectedQuote.partnerPaymentExtraId || trade?.data?.partnerPaymentExtraId;
             const result = await recomposeAndSign({
                 account,
-                address: selectedQuote.sendAddress,
+                address: sendAddress,
                 amount: sendStringAmount,
-                destinationTag: selectedQuote.partnerPaymentExtraId,
+                destinationTag: sendPaymentExtraId,
                 setMaxOutputId: values.setMaxOutputId,
             });
             // in case of not success, recomposeAndSign shows notification

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeForm.ts
@@ -368,10 +368,14 @@ export const useCoinmarketExchangeForm = ({
             if (!trade) {
                 trade = selectedQuote;
             }
-            if (!quotesRequest || !trade || !refundAddress || !trade.quoteId) return false;
+            if (!quotesRequest || !trade || !refundAddress) return false;
 
             if (trade.isDex && !trade.fromAddress) {
                 trade = { ...trade, fromAddress: refundAddress };
+            }
+
+            if (!trade.quoteId) {
+                return false;
             }
 
             setCallInProgress(true);
@@ -381,7 +385,7 @@ export const useCoinmarketExchangeForm = ({
                 quotesRequest,
                 account,
                 { selectedFee: selectedFeeRecomposedAndSigned, composed },
-                trade.quoteId!,
+                trade.quoteId,
             );
 
             const response = await invityAPI.doExchangeTrade({

--- a/packages/suite/src/hooks/wallet/coinmarket/useCoinmarketWatchTrade.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/useCoinmarketWatchTrade.ts
@@ -80,6 +80,11 @@ const coinmarketWatchTrade = async <T extends CoinmarketTradeType>({
                 error: exchangeResponse.error,
             };
 
+            if (exchangeResponse.sendAddress) {
+                tradeData.sendAddress = exchangeResponse.sendAddress;
+                tradeData.partnerPaymentExtraId = exchangeResponse.partnerPaymentExtraId;
+            }
+
             dispatch(saveExchangeTrade(tradeData, account, newDate));
         }
     }

--- a/packages/suite/src/middlewares/wallet/coinmarketMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/coinmarketMiddleware.ts
@@ -142,28 +142,41 @@ export const coinmarketMiddleware =
         const exchangeCoinmarketAccount = newState.wallet.coinmarket.exchange.coinmarketAccount;
 
         if (action.type === ROUTER.LOCATION_CHANGE) {
-            const wasTradeType = getTradeTypeByRoute(state.router.route);
-            const isTradeType = getTradeTypeByRoute(newState.router.route);
-            if (isTradeType) {
-                api.dispatch(coinmarketCommonActions.setActiveSection(isTradeType));
-            }
+            const routeName = newState.router.route?.name;
+            const isBuy = routeName === 'wallet-coinmarket-buy';
+            const isSell = routeName === 'wallet-coinmarket-sell';
+            const isExchange = routeName === 'wallet-coinmarket-exchange';
 
             // clean coinmarketAccount in sell
-            if (isTradeType === 'sell' && sellCoinmarketAccount) {
+            if (isSell && sellCoinmarketAccount) {
                 api.dispatch(coinmarketSellActions.setCoinmarketSellAccount(undefined));
             }
 
             // clean coinmarketAccount in exchange
-            if (isTradeType === 'exchange' && exchangeCoinmarketAccount) {
+            if (isExchange && exchangeCoinmarketAccount) {
                 api.dispatch(coinmarketExchangeActions.setCoinmarketExchangeAccount(undefined));
             }
 
-            const isBuyToSell = wasTradeType === 'buy' && isTradeType === 'sell';
-            const isSellToBuy = wasTradeType === 'sell' && isTradeType === 'buy';
+            if (isBuy) {
+                api.dispatch(coinmarketCommonActions.setActiveSection('buy'));
+            }
+
+            if (isSell) {
+                api.dispatch(coinmarketCommonActions.setActiveSection('sell'));
+            }
+
+            if (isExchange) {
+                api.dispatch(coinmarketCommonActions.setActiveSection('exchange'));
+            }
+
+            const wasBuy = state.router.route?.name === 'wallet-coinmarket-buy';
+            const wasSell = state.router.route?.name === 'wallet-coinmarket-sell';
+            const isBuyToSell = wasBuy && isSell;
+            const isSellToBuy = wasSell && isBuy;
 
             const cleanupPrefilledFromCryptoId =
                 !!newState.wallet.coinmarket.prefilledFromCryptoId &&
-                (!isTradeType || isBuyToSell || isSellToBuy);
+                ((!isSell && !isExchange && !isBuy) || isBuyToSell || isSellToBuy);
 
             if (cleanupPrefilledFromCryptoId) {
                 api.dispatch(coinmarketCommonActions.setCoinmarketPrefilledFromCryptoId(undefined));

--- a/packages/suite/src/reducers/wallet/coinmarketReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinmarketReducer.ts
@@ -73,6 +73,7 @@ interface Exchange extends CoinmarketTradeCommonProps {
     addressVerified: string | undefined;
     coinmarketAccount?: Account;
     selectedQuote: ExchangeTrade | undefined;
+    isFromRedirect: boolean;
 }
 
 interface Sell extends CoinmarketTradeCommonProps {
@@ -129,6 +130,7 @@ export const initialState: State = {
         addressVerified: undefined,
         coinmarketAccount: undefined,
         selectedQuote: undefined,
+        isFromRedirect: false,
     },
     sell: {
         sellInfo: undefined,
@@ -222,6 +224,9 @@ export const coinmarketReducer = (
                 break;
             case COINMARKET_EXCHANGE.SAVE_QUOTE:
                 draft.exchange.selectedQuote = action.quote;
+                break;
+            case COINMARKET_EXCHANGE.SET_IS_FROM_REDIRECT:
+                draft.exchange.isFromRedirect = action.isFromRedirect;
                 break;
             case COINMARKET_EXCHANGE.VERIFY_ADDRESS:
                 draft.exchange.addressVerified = action.addressVerified;

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -1346,6 +1346,10 @@ const messages = defineMessagesWithTypeCheck({
         defaultMessage: 'KYC never required',
         id: 'TR_COINMARKET_KYC_POLICY_NEVER_REQUIRED',
     },
+    TR_COINMARKET_KYC_REQUIRED: {
+        defaultMessage: 'KYC required.',
+        id: 'TR_COINMARKET_KYC_REQUIRED',
+    },
     TR_COINMARKET_KYC_NO_REFUND: {
         defaultMessage: 'KYC requested in exceptional cases. KYC required for refunds. 👈',
         id: 'TR_COINMARKET_KYC_NO_REFUND',

--- a/packages/suite/src/types/coinmarket/coinmarketForm.ts
+++ b/packages/suite/src/types/coinmarket/coinmarketForm.ts
@@ -46,6 +46,7 @@ import {
     AmountLimits,
     CryptoAmountLimits,
     Option,
+    TradeExchange,
     TradeSell,
 } from 'src/types/wallet/coinmarketCommonTypes';
 import { SendContextValues } from 'src/types/wallet/sendForm';
@@ -241,7 +242,7 @@ export interface CoinmarketExchangeFormContextProps
     };
 
     selectedQuote?: ExchangeTrade;
-    trade?: TradeSell;
+    trade?: TradeExchange;
     suiteReceiveAccounts?: AccountsState;
     exchangeStep: CoinmarketExchangeStepType;
     feeInfo: FeeInfo;

--- a/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
@@ -1,4 +1,4 @@
-import { BuyTrade, SellFiatTrade, CryptoId } from 'invity-api';
+import { BuyTrade, SellFiatTrade, CryptoId, ExchangeTrade } from 'invity-api';
 import { v4 as uuidv4 } from 'uuid';
 
 import {
@@ -268,7 +268,7 @@ export const filterQuotesAccordingTags = <T extends CoinmarketTradeBuySellType>(
     return allQuotes.filter(q => !q.tags || !q.tags.includes('alternativeCurrency'));
 };
 
-// fill orderId for all and paymentId for sell and buy
+// fill orderId for all, paymentId for sell and buy, quoteId for exchange
 export const addIdsToQuotes = <T extends CoinmarketTradeType>(
     allQuotes: CoinmarketTradeDetailMapProps[T][] | undefined,
     type: CoinmarketTradeType,
@@ -282,6 +282,10 @@ export const addIdsToQuotes = <T extends CoinmarketTradeType>(
 
         if (sellBuyQuote && !sellBuyQuote.paymentId) {
             sellBuyQuote.paymentId = uuidv4();
+        }
+
+        if (type === 'exchange' && !q.quoteId) {
+            (q as ExchangeTrade).quoteId = uuidv4();
         }
 
         q.orderId = uuidv4();

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketOfferExchange/CoinmarketOfferExchangeSend.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketOfferExchange/CoinmarketOfferExchangeSend.tsx
@@ -1,37 +1,82 @@
-import { Button, Column, Divider, InfoItem } from '@trezor/components';
+import { useEffect } from 'react';
+
+import { Button, Column, Divider, InfoItem, Spinner, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { useCoinmarketFormContext } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonForm';
+import { useCoinmarketWatchTrade } from 'src/hooks/wallet/coinmarket/useCoinmarketWatchTrade';
 import { CoinmarketTradeExchangeType } from 'src/types/coinmarket/coinmarket';
 import { AccountLabeling, Translation } from 'src/components/suite';
+import { useCoinmarketNavigation } from 'src/hooks/wallet/useCoinmarketNavigation';
 
 export const CoinmarketOfferExchangeSend = () => {
-    const { account, callInProgress, selectedQuote, exchangeInfo, sendTransaction } =
+    const { account, callInProgress, selectedQuote, exchangeInfo, sendTransaction, trade } =
         useCoinmarketFormContext<CoinmarketTradeExchangeType>();
-    if (!selectedQuote) return null;
-    const { exchange, sendAddress } = selectedQuote;
+    useCoinmarketWatchTrade({
+        account,
+        trade,
+    });
+    const { navigateToExchangeDetail } = useCoinmarketNavigation(account);
+
+    const exchangeTrade = trade?.data || selectedQuote;
+
+    useEffect(() => {
+        if (exchangeTrade?.status === 'ERROR') {
+            navigateToExchangeDetail();
+        }
+    }, [exchangeTrade, navigateToExchangeDetail]);
+
+    if (!exchangeTrade || !exchangeTrade.exchange) return null;
+
+    const { exchange, sendAddress, status } = exchangeTrade;
     if (!exchange) return null;
     const providerName =
-        exchangeInfo?.providerInfos[exchange]?.companyName || selectedQuote.exchange;
+        exchangeInfo?.providerInfos[exchange]?.companyName || exchangeTrade.exchange;
 
     return (
-        <Column gap={spacings.lg} flex="1">
-            <InfoItem label={<Translation id="TR_EXCHANGE_SEND_FROM" />}>
-                <AccountLabeling account={account} />
-            </InfoItem>
-            <InfoItem label={<Translation id="TR_EXCHANGE_SEND_TO" values={{ providerName }} />}>
-                {sendAddress}
-            </InfoItem>
-            <Column margin={{ top: 'auto' }}>
-                <Divider margin={{ top: spacings.xs, bottom: spacings.lg }} />
-                <Button
-                    data-testid="@coinmarket/offer/exchange/confirm-on-trezor-and-send"
-                    isLoading={callInProgress}
-                    onClick={sendTransaction}
+        <>
+            {(status === 'CONFIRM' || status === 'SENDING') && sendAddress ? (
+                <Column gap={spacings.lg} flex="1">
+                    <InfoItem label={<Translation id="TR_EXCHANGE_SEND_FROM" />}>
+                        <AccountLabeling account={account} />
+                    </InfoItem>
+                    <InfoItem
+                        label={<Translation id="TR_EXCHANGE_SEND_TO" values={{ providerName }} />}
+                    >
+                        {sendAddress}
+                    </InfoItem>
+                    <Column margin={{ top: 'auto' }}>
+                        <Divider margin={{ top: spacings.xs, bottom: spacings.lg }} />
+                        <Button
+                            data-testid="@coinmarket/offer/exchange/confirm-on-trezor-and-send"
+                            isLoading={callInProgress}
+                            onClick={sendTransaction}
+                        >
+                            <Translation id="TR_EXCHANGE_CONFIRM_ON_TREZOR_SEND" />
+                        </Button>
+                    </Column>
+                </Column>
+            ) : (
+                <Column
+                    alignItems="center"
+                    justifyContent="center"
+                    margin={{ horizontal: spacings.lg, vertical: spacings.xxxxl }}
                 >
-                    <Translation id="TR_EXCHANGE_CONFIRM_ON_TREZOR_SEND" />
-                </Button>
-            </Column>
-        </Column>
+                    <Spinner margin={{ bottom: spacings.xl }} />
+                    <Text>
+                        <Translation
+                            id="TR_SELL_DETAIL_WAITING_FOR_SEND_CRYPTO"
+                            values={{ providerName }}
+                        />
+                    </Text>
+                    <Text variant="tertiary">
+                        <Translation
+                            id="TR_SELL_DETAIL_WAITING_FOR_SEND_CRYPTO_INFO"
+                            values={{ providerName }}
+                        />
+                    </Text>
+                </Column>
+            )}
+        </>
     );
 };

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketOfferSell/CoinmarketOfferSellTransaction.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketOfferSell/CoinmarketOfferSellTransaction.tsx
@@ -59,9 +59,9 @@ export const CoinmarketSelectedOfferSellTransaction = () => {
         account,
         trade,
     });
-    const t = trade?.data || selectedQuote;
+    const sellTrade = trade?.data || selectedQuote;
 
-    if (!t || !t.exchange) return null;
+    if (!sellTrade || !sellTrade.exchange) return null;
 
     const {
         exchange,
@@ -69,7 +69,7 @@ export const CoinmarketSelectedOfferSellTransaction = () => {
         destinationPaymentExtraId,
         destinationPaymentExtraIdDescription,
         status,
-    } = t;
+    } = sellTrade;
     const providerName = sellInfo?.providerInfos[exchange]?.companyName || exchange;
 
     return (

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketOfferSell/CoinmarketOfferSellTransaction.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketOfferSell/CoinmarketOfferSellTransaction.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
-import { Button, Spinner } from '@trezor/components';
-import { fontWeights, spacingsPx, typography } from '@trezor/theme';
+import { Button, Column, Spinner, Text } from '@trezor/components';
+import { spacings, spacingsPx, typography } from '@trezor/theme';
 
 import { Translation, AccountLabeling } from 'src/components/suite';
 import { useCoinmarketWatchTrade } from 'src/hooks/wallet/coinmarket/useCoinmarketWatchTrade';
@@ -12,14 +12,6 @@ const Wrapper = styled.div`
     display: flex;
     flex-direction: column;
     margin-top: ${spacingsPx.sm};
-`;
-
-const WaitingWrapper = styled.div`
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 60px ${spacingsPx.lg};
-    flex-direction: column;
 `;
 
 const LabelText = styled.div`
@@ -46,11 +38,6 @@ const Row = styled.div`
 `;
 
 const Address = styled.div``;
-
-const Title = styled.div`
-    margin-top: ${spacingsPx.xl};
-    font-weight: ${fontWeights.semiBold};
-`;
 
 export const CoinmarketSelectedOfferSellTransaction = () => {
     const { account, callInProgress, selectedQuote, sellInfo, sendTransaction, trade } =
@@ -120,21 +107,25 @@ export const CoinmarketSelectedOfferSellTransaction = () => {
                     </ButtonWrapper>
                 </>
             ) : (
-                <WaitingWrapper>
-                    <Spinner />
-                    <Title>
+                <Column
+                    alignItems="center"
+                    justifyContent="center"
+                    margin={{ horizontal: spacings.lg, vertical: spacings.xxxxl }}
+                >
+                    <Spinner margin={{ bottom: spacings.xl }} />
+                    <Text>
                         <Translation
                             id="TR_SELL_DETAIL_WAITING_FOR_SEND_CRYPTO"
                             values={{ providerName }}
                         />
-                    </Title>
-                    <Value>
+                    </Text>
+                    <Text variant="tertiary">
                         <Translation
                             id="TR_SELL_DETAIL_WAITING_FOR_SEND_CRYPTO_INFO"
                             values={{ providerName }}
                         />
-                    </Value>
-                </WaitingWrapper>
+                    </Text>
+                </Column>
             )}
         </Wrapper>
     );

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketUtils/CoinmarketUtilsKyc.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketUtils/CoinmarketUtilsKyc.tsx
@@ -10,6 +10,7 @@ import {
     KYC_DEX,
     KYC_NO_KYC,
     KYC_NO_REFUND,
+    KYC_REQUIRED,
     KYC_YES_REFUND,
 } from 'src/constants/wallet/coinmarket/kyc';
 
@@ -19,6 +20,10 @@ interface CoinmarketUtilsProviderProps {
     isForComparator?: boolean;
 }
 const getKycPolicy = (kycPolicyType: ExchangeKYCType | undefined) => {
+    if (kycPolicyType === KYC_REQUIRED) {
+        return <Translation id="TR_COINMARKET_KYC_REQUIRED" />;
+    }
+
     if (kycPolicyType === KYC_NO_REFUND) {
         return <Translation id="TR_COINMARKET_KYC_NO_REFUND" />;
     }

--- a/packages/suite/src/views/wallet/coinmarket/redirect/CoinmarketRedirect.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/redirect/CoinmarketRedirect.tsx
@@ -22,7 +22,8 @@ const Wrapper = styled.div`
 `;
 
 export const CoinmarketRedirect = () => {
-    const { redirectToOffers, redirectToDetail, redirectToSellOffers } = useCoinmarketRedirect();
+    const { redirectToOffers, redirectToDetail, redirectToSellOffers, redirectToExchangeOffers } =
+        useCoinmarketRedirect();
     const router = useSelector(state => state.router);
 
     useEffect(() => {
@@ -31,7 +32,7 @@ export const CoinmarketRedirect = () => {
         if (!params) return;
 
         const redirectCommonParams = {
-            routeType: params[0] as 'detail' | 'offers' | 'sell-offers',
+            routeType: params[0] as 'detail' | 'offers' | 'sell-offers' | 'exchange-offers',
             symbol: params[1] as Account['symbol'],
             accountType: params[2] as Account['accountType'],
             index: parseInt(params[3], 10),
@@ -71,10 +72,30 @@ export const CoinmarketRedirect = () => {
             });
         }
 
+        if (redirectCommonParams.routeType === 'exchange-offers') {
+            const feeIndex = 8;
+            redirectToExchangeOffers({
+                ...redirectCommonParams,
+                send: params[4] as CryptoId,
+                receive: params[5] as CryptoId,
+                amount: params[6],
+                orderId: params[7],
+                selectedFee: params[feeIndex] as FeeLevel['label'],
+                feePerByte: params[feeIndex + 1],
+                feeLimit: params[feeIndex + 2],
+            });
+        }
+
         if (redirectCommonParams.routeType === 'detail') {
             redirectToDetail({ ...redirectCommonParams, transactionId: params[4] });
         }
-    }, [redirectToOffers, redirectToDetail, redirectToSellOffers, router]);
+    }, [
+        redirectToOffers,
+        redirectToDetail,
+        redirectToSellOffers,
+        redirectToExchangeOffers,
+        router,
+    ]);
 
     return (
         <Wrapper>

--- a/yarn.lock
+++ b/yarn.lock
@@ -12185,7 +12185,7 @@ __metadata:
     "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@types/file-saver": "npm:^2.0.6"
-    "@types/invity-api": "npm:^1.1.1"
+    "@types/invity-api": "npm:^1.1.2"
     "@types/jws": "npm:^3.2.10"
     "@types/pako": "npm:^2.0.3"
     "@types/pdfmake": "npm:^0.2.9"
@@ -13135,10 +13135,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/invity-api@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "@types/invity-api@npm:1.1.1"
-  checksum: 10/8f6a5ee51ed774aab1b0ddd1b79431ee6a92d4818e164418af8885aea27b4df64b572e57f2e91c8f7f93f3c71bbfd1e339e66025a3f48474cafba72248ea7f1d
+"@types/invity-api@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@types/invity-api@npm:1.1.2"
+  checksum: 10/4c3f638c9f6fd674a9bb9360c06dcf5a7d6c1b9750b05b3d70da83277a8145effed660b50c294833c0aef3a22a0511d8459e69ce3cf8d6e618743be2cd2fc1fb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

KYC flow for swap:
1. Swap section; BTC to ETH; click `Compare all offers`
2. Select Moonpay offer; confirm receive address; click `Finish transaction`
3. You are redirected to invity.io page with Moonpay widget where you need complete KYC registration
4. After KYC registration is done, you are redirected back to suite with selected offer in pending state (waiting for address)
5. After a while, you get the provider's address; confirm on address and send the transaction; trade done after a while

## Related Issue

Resolve #15556

## Screenshots:
