### PR TITLE
Transport device disconnected

### DIFF
--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -714,8 +714,13 @@ const onCallDevice = async (
         const response = messageResponse;
 
         if (response) {
-            await device.cleanup();
+            const shouldReleaseSession =
+                response.success ||
+                (!response.success &&
+                    // @ts-expect-error
+                    response?.payload?.error !== 'device disconnected during action');
 
+            await device.cleanup(shouldReleaseSession);
             if (useCoreInPopup) {
                 // We need to send response before closing popup
                 sendCoreMessage(response);

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -753,7 +753,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
         this._updateFeatures(message);
     }
 
-    async checkFirmwareHash(): Promise<FirmwareHashCheckResult | null> {
+    private async checkFirmwareHash(): Promise<FirmwareHashCheckResult | null> {
         const createFailResult = (error: FirmwareHashCheckError, errorPayload?: unknown) => ({
             success: false,
             error,
@@ -821,7 +821,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
         }
     }
 
-    async checkFirmwareRevision() {
+    private async checkFirmwareRevision() {
         const firmwareVersion = this.getVersion();
 
         if (!firmwareVersion || !this.features) {

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -327,13 +327,15 @@ export class Device extends TypedEmitter<DeviceEvents> {
         this.keepTransportSession = false;
     }
 
-    async cleanup() {
+    async cleanup(release = true) {
         // remove all listeners
         this.eventNames().forEach(e => this.removeAllListeners(e as keyof DeviceEvents));
 
         // make sure that Device_CallInProgress will not be thrown
         delete this.runPromise;
-        await this.release();
+        if (release) {
+            await this.release();
+        }
     }
 
     // call only once, right after device creation

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -556,6 +556,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
                     ]);
                 }
             } catch (error) {
+                _log.warn('Device._runInner error: ', error.message);
                 if (
                     !this.inconsistent &&
                     (error.message === 'GetFeatures timeout' || error.message === 'Unknown message')

--- a/packages/suite/src/components/suite/ConnectDevicePrompt.tsx
+++ b/packages/suite/src/components/suite/ConnectDevicePrompt.tsx
@@ -74,8 +74,10 @@ const getMessageId = ({
             return isDesktop() ? 'TR_NO_TRANSPORT_DESKTOP' : 'TR_NO_TRANSPORT';
         case 'device-bootloader':
             return 'TR_DEVICE_CONNECTED_BOOTLOADER';
-        case 'device-unacquired':
+        case 'device-used-elsewhere':
             return 'TR_DEVICE_CONNECTED_UNACQUIRED';
+        case 'device-unacquired':
+            return 'TR_NEEDS_ATTENTION_UNABLE_TO_CONNECT';
         default: {
             if (connected) {
                 return !showWarning ? 'TR_DEVICE_CONNECTED' : 'TR_DEVICE_CONNECTED_WRONG_STATE';

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceAcquire.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceAcquire.tsx
@@ -2,14 +2,16 @@ import { MouseEventHandler } from 'react';
 
 import { acquireDevice } from '@suite-common/wallet-core';
 import { Button } from '@trezor/components';
-import { isDesktop } from '@trezor/env-utils';
 
 import { Translation, TroubleshootingTips } from 'src/components/suite';
 import { useDevice, useDispatch } from 'src/hooks/suite';
-import { TROUBLESHOOTING_TIP_RECONNECT } from 'src/components/suite/troubleshooting/tips';
+import {
+    TROUBLESHOOTING_TIP_RECONNECT,
+    TROUBLESHOOTING_TIP_CLOSE_ALL_TABS,
+} from 'src/components/suite/troubleshooting/tips';
 
 export const DeviceAcquire = () => {
-    const { isLocked, device } = useDevice();
+    const { isLocked } = useDevice();
     const dispatch = useDispatch();
 
     const isDeviceLocked = isLocked();
@@ -21,45 +23,15 @@ export const DeviceAcquire = () => {
 
     const ctaButton = (
         <Button data-testid="@device-acquire" isLoading={isDeviceLocked} onClick={handleClick}>
-            <Translation id="TR_ACQUIRE_DEVICE" />
+            <Translation id="TR_TRY_AGAIN" />
         </Button>
     );
 
-    const tips = [
-        {
-            key: 'device-used-elsewhere',
-            heading: <Translation id="TR_DEVICE_CONNECTED_UNACQUIRED" />,
-            description: device?.transportSessionOwner ? (
-                <Translation
-                    id="TR_DEVICE_CONNECTED_UNACQUIRED_DESCRIPTION"
-                    values={{
-                        transportSessionOwner: device.transportSessionOwner,
-                    }}
-                />
-            ) : (
-                // legacy bridge does not share transportSessionOwner information
-                <Translation id="TR_DEVICE_CONNECTED_UNACQUIRED_DESCRIPTION_UNKNOWN_APP" />
-            ),
-        },
-        {
-            key: 'device-acquire',
-            heading: <Translation id="TR_TROUBLESHOOTING_CLOSE_TABS" />,
-            description: (
-                <Translation
-                    id={
-                        isDesktop()
-                            ? 'TR_TROUBLESHOOTING_CLOSE_TABS_DESCRIPTION_DESKTOP'
-                            : 'TR_TROUBLESHOOTING_CLOSE_TABS_DESCRIPTION'
-                    }
-                />
-            ),
-        },
-        TROUBLESHOOTING_TIP_RECONNECT,
-    ];
+    const tips = [TROUBLESHOOTING_TIP_CLOSE_ALL_TABS, TROUBLESHOOTING_TIP_RECONNECT];
 
     return (
         <TroubleshootingTips
-            label={<Translation id="TR_ACQUIRE_DEVICE_TITLE" />}
+            label={<Translation id="TR_NEEDS_ATTENTION_UNABLE_TO_CONNECT" />}
             cta={ctaButton}
             items={tips}
         />

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUnreadable.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUnreadable.tsx
@@ -13,6 +13,7 @@ import {
     TROUBLESHOOTING_TIP_UNREADABLE_HID,
     TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_BRIDGE,
     TROUBLESHOOTING_TIP_RECONNECT,
+    TROUBLESHOOTING_TIP_CLOSE_ALL_TABS,
 } from 'src/components/suite/troubleshooting/tips';
 import { useSelector, useDispatch } from 'src/hooks/suite';
 import type { TrezorDevice } from 'src/types/suite';
@@ -143,6 +144,11 @@ export const DeviceUnreadable = ({ device }: DeviceUnreadableProps) => {
         // you might have a very old device which is no longer supported current bridge
         // if on desktop - try toggling between the 2 bridges we have available
         items.push(TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_BRIDGE);
+    } else {
+        // it might also be unreadable because device was acquired on transport layer by another app and never released.
+        // this should be rather exceptional case that happens only when sessions synchronization is broken or other app
+        // is not cooperating with us
+        items.push(TROUBLESHOOTING_TIP_CLOSE_ALL_TABS);
     }
 
     return (

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUnreadable.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUnreadable.tsx
@@ -120,16 +120,7 @@ export const DeviceUnreadable = ({ device }: DeviceUnreadableProps) => {
     }
 
     // generic troubleshooting tips
-    const items = [
-        // closing other apps and reloading should be the first step. Either we might have made a bug and let two apps to talk
-        // to device at the same time or there might be another application in the wild not really playing according to our rules
-        TROUBLESHOOTING_TIP_RECONNECT,
-        // if on web - try installing desktop. this takes you to using bridge which should be more powerful than WebUSB
-        TROUBLESHOOTING_TIP_SUITE_DESKTOP,
-        // unfortunately we have seen reports that even old bridge might not be enough for some Windows users. So the only chance
-        // is using another computer, or maybe it would be better to say another OS
-        TROUBLESHOOTING_TIP_DIFFERENT_COMPUTER,
-    ];
+    const items = [];
 
     // only for unreadable HID devices
     if (
@@ -141,6 +132,10 @@ export const DeviceUnreadable = ({ device }: DeviceUnreadableProps) => {
         // If even this did not work, go to support or knowledge base
         // 'If the last time you updated your device firmware was in 2019 and earlier please follow instructions in <a>the knowledge base</a>',
         items.push(TROUBLESHOOTING_TIP_UNREADABLE_HID);
+        // if on web - try installing desktop. this takes you to using bridge which should be more powerful than WebUSB.
+        // at the time of writing this, there is still an option to opt-in for legacy bridge in suite-desktop which can
+        // communicate with this device. see the next troubleshooting point
+        items.push(TROUBLESHOOTING_TIP_SUITE_DESKTOP);
         // you might have a very old device which is no longer supported current bridge
         // if on desktop - try toggling between the 2 bridges we have available
         items.push(TROUBLESHOOTING_TIP_SUITE_DESKTOP_TOGGLE_BRIDGE);
@@ -149,6 +144,14 @@ export const DeviceUnreadable = ({ device }: DeviceUnreadableProps) => {
         // this should be rather exceptional case that happens only when sessions synchronization is broken or other app
         // is not cooperating with us
         items.push(TROUBLESHOOTING_TIP_CLOSE_ALL_TABS);
+        // closing other apps and reloading should be the first step. Either we might have made a bug and let two apps to talk
+        // to device at the same time or there might be another application in the wild not really playing according to our rules
+        items.push(TROUBLESHOOTING_TIP_RECONNECT);
+        // if on web - try installing desktop. this takes you to using bridge which should be more powerful than WebUSB
+        items.push(TROUBLESHOOTING_TIP_SUITE_DESKTOP);
+        // unfortunately we have seen reports that even old bridge might not be enough for some Windows users. So the only chance
+        // is using another computer, or maybe it would be better to say another OS
+        items.push(TROUBLESHOOTING_TIP_DIFFERENT_COMPUTER);
     }
 
     return (

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUsedElsewhere.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUsedElsewhere.tsx
@@ -1,0 +1,58 @@
+import { MouseEventHandler } from 'react';
+
+import { acquireDevice } from '@suite-common/wallet-core';
+import { Button } from '@trezor/components';
+
+import { Translation, TroubleshootingTips } from 'src/components/suite';
+import { useDevice, useDispatch } from 'src/hooks/suite';
+import {
+    TROUBLESHOOTING_TIP_RECONNECT,
+    TROUBLESHOOTING_TIP_CLOSE_ALL_TABS,
+} from 'src/components/suite/troubleshooting/tips';
+
+export const DeviceUsedElsewhere = () => {
+    const { isLocked, device } = useDevice();
+    const dispatch = useDispatch();
+
+    const isDeviceLocked = isLocked();
+
+    const handleClick: MouseEventHandler = e => {
+        e.stopPropagation();
+        dispatch(acquireDevice());
+    };
+
+    const ctaButton = (
+        <Button
+            data-testid="@device-used-elsewhere"
+            isLoading={isDeviceLocked}
+            onClick={handleClick}
+        >
+            <Translation id="TR_ACQUIRE_DEVICE" />
+        </Button>
+    );
+
+    const tips = [
+        {
+            key: 'device-used-elsewhere',
+            heading: <Translation id="TR_DEVICE_CONNECTED_UNACQUIRED" />,
+            description: (
+                <Translation
+                    id="TR_DEVICE_CONNECTED_UNACQUIRED_DESCRIPTION"
+                    values={{
+                        transportSessionOwner: device?.transportSessionOwner || 'unknown',
+                    }}
+                />
+            ),
+        },
+        TROUBLESHOOTING_TIP_CLOSE_ALL_TABS,
+        TROUBLESHOOTING_TIP_RECONNECT,
+    ];
+
+    return (
+        <TroubleshootingTips
+            label={<Translation id="TR_ACQUIRE_DEVICE_TITLE" />}
+            cta={ctaButton}
+            items={tips}
+        />
+    );
+};

--- a/packages/suite/src/components/suite/PrerequisitesGuide/PrerequisitesGuide.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/PrerequisitesGuide.tsx
@@ -26,6 +26,7 @@ import { DeviceNoFirmware } from './DeviceNoFirmware';
 import { DeviceUpdateRequired } from './DeviceUpdateRequired';
 import { DeviceDisconnectRequired } from './DeviceDisconnectRequired';
 import { MultiShareBackupInProgress } from './MultiShareBackupInProgress';
+import { DeviceUsedElsewhere } from './DeviceUsedElsewhere';
 
 const Wrapper = styled.div`
     display: flex;
@@ -68,6 +69,8 @@ export const PrerequisitesGuide = ({ allowSwitchDevice }: PrerequisitesGuideProp
                     return <DeviceConnect isWebUsbTransport={isWebUsbTransport} />;
                 case 'device-unacquired':
                     return <DeviceAcquire />;
+                case 'device-used-elsewhere':
+                    return <DeviceUsedElsewhere />;
                 case 'device-unreadable':
                     return <DeviceUnreadable device={device} />;
                 case 'device-unknown':

--- a/packages/suite/src/components/suite/troubleshooting/tips/index.tsx
+++ b/packages/suite/src/components/suite/troubleshooting/tips/index.tsx
@@ -99,3 +99,17 @@ export const TROUBLESHOOTING_TIP_RECONNECT = {
         />
     ),
 };
+
+export const TROUBLESHOOTING_TIP_CLOSE_ALL_TABS = {
+    key: 'device-acquire',
+    heading: <Translation id="TR_TROUBLESHOOTING_CLOSE_TABS" />,
+    description: (
+        <Translation
+            id={
+                isDesktop()
+                    ? 'TR_TROUBLESHOOTING_CLOSE_TABS_DESCRIPTION_DESKTOP'
+                    : 'TR_TROUBLESHOOTING_CLOSE_TABS_DESCRIPTION'
+            }
+        />
+    ),
+};

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2087,6 +2087,10 @@ const messages = defineMessagesWithTypeCheck({
         defaultMessage: 'Trezor is not readable.',
         id: 'TR_NEEDS_ATTENTION_UNREADABLE',
     },
+    TR_NEEDS_ATTENTION_UNABLE_TO_CONNECT: {
+        defaultMessage: 'Failed to communicate with Trezor',
+        id: 'TR_NEEDS_ATTENTION_UNABLE_TO_CONNECT',
+    },
     TR_UDEV_DOWNLOAD_TITLE: {
         defaultMessage: 'Download udev rules',
         id: 'TR_UDEV_DOWNLOAD_TITLE',
@@ -6789,11 +6793,6 @@ const messages = defineMessagesWithTypeCheck({
         id: 'TR_DEVICE_CONNECTED_UNACQUIRED_DESCRIPTION',
         defaultMessage:
             'The app {transportSessionOwner} may currently be using this device. You can take control of the device if needed.',
-    },
-    TR_DEVICE_CONNECTED_UNACQUIRED_DESCRIPTION_UNKNOWN_APP: {
-        id: 'TR_DEVICE_CONNECTED_UNACQUIRED_DESCRIPTION_UNKNOWN_APP',
-        defaultMessage:
-            'Another app may currently be using this device. You can take control of the device if needed.',
     },
     TR_WIPE_OR_UPDATE: {
         id: 'TR_WIPE_OR_UPDATE',

--- a/packages/suite/src/utils/suite/prerequisites.ts
+++ b/packages/suite/src/utils/suite/prerequisites.ts
@@ -28,6 +28,9 @@ export const getPrerequisiteName = ({ router, device, transport }: GetPrerequisi
         return 'device-disconnect-required';
     }
 
+    if (device.type === 'unacquired' && device?.transportSessionOwner)
+        return 'device-used-elsewhere';
+
     // device features cannot be read, device is probably used in another window
     if (device.type === 'unacquired') return 'device-unacquired';
 

--- a/packages/transport/src/api/abstract.ts
+++ b/packages/transport/src/api/abstract.ts
@@ -113,6 +113,7 @@ export abstract class AbstractApi extends TypedEmitter<{
         | typeof ERRORS.UNEXPECTED_ERROR
         | typeof ERRORS.ABORTED_BY_TIMEOUT
         | typeof ERRORS.ABORTED_BY_SIGNAL
+        | typeof ERRORS.LIBUSB_ERROR_ACCESS
     >;
 
     /**

--- a/packages/transport/src/api/usb.ts
+++ b/packages/transport/src/api/usb.ts
@@ -203,7 +203,7 @@ export class UsbApi extends AbstractApi {
                 { signal, onAbort: () => device?.reset() },
             );
             this.logger?.debug(
-                `usb: device.transferIn done. status: ${res.status}, byteLength: ${res.data?.byteLength}. device: ${this.formatDeviceForLog(device)}`,
+                `usb: device.transferIn done. status: ${res.status}, byteLength: ${res.data?.byteLength}.`,
             );
 
             if (!res.data?.byteLength) {
@@ -237,9 +237,7 @@ export class UsbApi extends AbstractApi {
                     ),
                 { signal, onAbort: () => device?.reset() },
             );
-            this.logger?.debug(
-                `usb: device.transferOut done. device: ${this.formatDeviceForLog(device)}`,
-            );
+            this.logger?.debug(`usb: device.transferOut done.`);
             if (result.status !== 'ok') {
                 this.logger?.error(`usb: device.transferOut status not ok: ${result.status}`);
                 throw new Error('transfer out status not ok');
@@ -299,9 +297,7 @@ export class UsbApi extends AbstractApi {
                 await this.abortableMethod(() => device.selectConfiguration(CONFIGURATION_ID), {
                     signal,
                 });
-                this.logger?.debug(
-                    `usb: device.selectConfiguration done: ${CONFIGURATION_ID}. device: ${this.formatDeviceForLog(device)}`,
-                );
+                this.logger?.debug(`usb: device.selectConfiguration done: ${CONFIGURATION_ID}.`);
             } catch (err) {
                 this.logger?.error(
                     `usb: device.selectConfiguration error ${err}. device: ${this.formatDeviceForLog(device)}`,
@@ -311,9 +307,7 @@ export class UsbApi extends AbstractApi {
                 // reset fails on ChromeOS and windows
                 this.logger?.debug('usb: device.reset');
                 await this.abortableMethod(() => device?.reset(), { signal });
-                this.logger?.debug(
-                    `usb: device.reset done. device: ${this.formatDeviceForLog(device)}`,
-                );
+                this.logger?.debug(`usb: device.reset done.`);
             } catch (err) {
                 this.logger?.error(
                     `usb: device.reset error ${err}. device: ${this.formatDeviceForLog(device)}`,
@@ -326,13 +320,9 @@ export class UsbApi extends AbstractApi {
             this.logger?.debug(`usb: device.claimInterface: ${interfaceId}`);
             // claim device for exclusive access by this app
             await this.abortableMethod(() => device.claimInterface(interfaceId), { signal });
-            this.logger?.debug(
-                `usb: device.claimInterface done: ${interfaceId}. device: ${this.formatDeviceForLog(device)}`,
-            );
+            this.logger?.debug(`usb: device.claimInterface done: ${interfaceId}.`);
         } catch (err) {
-            this.logger?.error(
-                `usb: device.claimInterface error ${err}. device: ${this.formatDeviceForLog(device)}`,
-            );
+            this.logger?.error(`usb: device.claimInterface error ${err}.`);
 
             return this.error({
                 error: ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE,
@@ -371,13 +361,9 @@ export class UsbApi extends AbstractApi {
                 this.logger?.debug(`usb: device.releaseInterface: ${interfaceId}`);
 
                 await device.releaseInterface(interfaceId);
-                this.logger?.debug(
-                    `usb: device.releaseInterface done: ${interfaceId}. device: ${this.formatDeviceForLog(device)}`,
-                );
+                this.logger?.debug(`usb: device.releaseInterface done: ${interfaceId}.`);
             } catch (err) {
-                this.logger?.error(
-                    `usb: releaseInterface error ${err}. device: ${this.formatDeviceForLog(device)}`,
-                );
+                this.logger?.error(`usb: releaseInterface error ${err}.`);
                 // ignore
             }
         }
@@ -386,13 +372,9 @@ export class UsbApi extends AbstractApi {
             try {
                 this.logger?.debug(`usb: device.close`);
                 await device.close();
-                this.logger?.debug(
-                    `usb: device.close done. device: ${this.formatDeviceForLog(device)}`,
-                );
+                this.logger?.debug(`usb: device.close done.`);
             } catch (err) {
-                this.logger?.debug(
-                    `usb: device.close error ${err}. device: ${this.formatDeviceForLog(device)}`,
-                );
+                this.logger?.debug(`usb: device.close error ${err}.`);
 
                 return this.error({
                     error: ERRORS.INTERFACE_UNABLE_TO_CLOSE_DEVICE,

--- a/packages/transport/src/api/usb.ts
+++ b/packages/transport/src/api/usb.ts
@@ -283,6 +283,9 @@ export class UsbApi extends AbstractApi {
             this.logger?.debug(`usb: device.open done. device: ${this.formatDeviceForLog(device)}`);
         } catch (err) {
             this.logger?.error(`usb: device.open error ${err}`);
+            if (err.message.includes('LIBUSB_ERROR_ACCESS')) {
+                return this.error({ error: ERRORS.LIBUSB_ERROR_ACCESS });
+            }
 
             return this.error({
                 error: ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE,

--- a/packages/transport/src/errors.ts
+++ b/packages/transport/src/errors.ts
@@ -92,3 +92,7 @@ export const ABORTED_BY_SIGNAL = 'Aborted by signal' as const;
  * see scheduleAction
  */
 export const ABORTED_BY_TIMEOUT = 'Aborted by timeout' as const;
+/**
+ * missing udev rules on linux
+ */
+export const LIBUSB_ERROR_ACCESS = 'LIBUSB_ERROR_ACCESS' as const;

--- a/packages/transport/src/sessions/background.ts
+++ b/packages/transport/src/sessions/background.ts
@@ -118,11 +118,11 @@ export class SessionsBackground
             if (result && result.success && result.payload) {
                 if ('descriptors' in result.payload) {
                     const { descriptors } = result.payload;
-                    setTimeout(() => this.emit('descriptors', Object.values(descriptors)), 0);
+                    this.emit('descriptors', Object.values(descriptors));
                 }
                 if ('releaseRequest' in result.payload && result.payload.releaseRequest) {
                     const { releaseRequest } = result.payload;
-                    setTimeout(() => this.emit('releaseRequest', releaseRequest));
+                    this.emit('releaseRequest', releaseRequest);
                 }
             }
         }

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -205,6 +205,7 @@ export abstract class AbstractTransport extends TransportEmitter {
         | typeof ERRORS.ABORTED_BY_TIMEOUT
         | typeof ERRORS.ABORTED_BY_SIGNAL
         | typeof ERRORS.WRONG_ENVIRONMENT
+        | typeof ERRORS.LIBUSB_ERROR_ACCESS
     >;
 
     /**

--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -380,6 +380,7 @@ export class BridgeTransport extends AbstractTransport {
                         ERRORS.DEVICE_NOT_FOUND,
                         ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE,
                         ERRORS.DEVICE_DISCONNECTED_DURING_ACTION,
+                        ERRORS.LIBUSB_ERROR_ACCESS,
                     ]);
                 case '/call':
                 case '/read':

--- a/packages/transport/tests/apiUsb.test.ts
+++ b/packages/transport/tests/apiUsb.test.ts
@@ -58,7 +58,7 @@ describe('api/usb', () => {
 
         const result = await promise;
         if (result.success) throw new Error('Unexpected success');
-        expect(result.error).toContain('A transfer error has occurred.');
+        expect(result.error).toContain('unexpected error');
         expect(reset).toHaveBeenCalledTimes(1);
     });
 


### PR DESCRIPTION

- 1st commit - narrow error cases from all node-usb and web-usb and convert them to "device disconnected during action" in the same way legacy bridge does. This helps with proper error handling on the trezor-connect layer. 
- 2nd commit - do not release disconnected devices.
     - Trying to do this causes #15336 on my machine (mac-arm). I am unaware of anyone else who could reproduce it locally.
     - The legacy bridge is okay with it, and I haven't found out yet what the key difference is. But anyway, it doesn't feel right to me to release devices that are no longer present. The only possible problem this may cause could be when we false positively handle an error as a disconnected device and omit proper clean up. 
     - Here is a little table where I tested the scenario explained in #15336 and it worked for me locally.

 | fixes #15336  	|   legacy bridge	| node bridge  	| webusb  	|
  |---	|---	|---	|---	|
  | enable labelling - button request - disconnect    	|   	|   	|   	|  
  | get address - button request disconnect  	|   	|   	|   	|  
-  3rd commit - split the 'unacquired screen' into two 1] unacquired 2] device-used-elsewhere 
    - now there is a common "unacquired" screen. Unacquired here means that features of the device are not known because some bug happened. There is a "Try again" button. <img width="500" alt="image" src="https://github.com/user-attachments/assets/6a3fbcac-e1dd-41cd-8377-c555f712b131">
    - then there is a special case of "used-elsewhere" screen that appears if we know `device.transportSessionOwner`. <img width="500" alt="image" src="https://github.com/user-attachments/assets/394e258e-472f-45c4-a8c2-c22ae638bc12">
    - todo: maybe it could be shown also when `device.used = true`? This way this screen never renders for the legacy bridge since it never returns `transportSessionOwner`.
- 4th commit - rework device.run error handling
    - in general, there are the following categories of errors: 
        - recoverable -> show try again button
        -  non-recoverable -> don't show button. only maybe reloading or reconnect could help
        - device disconnected -> do nothing. `todo: maybe we should enumerate in this case to be sure that it really disconnected`?
- 5th commit - thanks to previous changes, unreadable device state is now better targeted and we don't need to show that many troubleshooting tips anymore.  
    - unreadable non-hid device. this is not recoverable. This is typically the case of missing synchronization between apps for whatever reason.
    - <img width="500" alt="image" src="https://github.com/user-attachments/assets/fa8d9cad-7ffc-4ec7-a866-71cabc118fb9">
    - webusb + unreadable hid device 
    - <img width="500" alt="image" src="https://github.com/user-attachments/assets/e6ea7084-66a4-4f82-9799-364a99433580">
    - unreadable hid device + suite desktop - allows to toggle legacy bridge 
    - <img width="500" alt="image" src="https://github.com/user-attachments/assets/06112edb-1f72-4641-942c-11c80e4f45e9">

related issues:
- #15336 
- #15676
- #15480