### PR TITLE
Chore(suite): refactor FW check selectors

### DIFF
--- a/packages/suite/src/components/suite/Preloader/Preloader.tsx
+++ b/packages/suite/src/components/suite/Preloader/Preloader.tsx
@@ -15,7 +15,7 @@ import {
     selectPrerequisite,
     selectIsLoggedOut,
     selectSuiteFlags,
-    selectIsFirmwareAuthenticityCheckEnabledAndFailed,
+    selectIsFirmwareAuthenticityCheckEnabledAndHardFailed,
 } from 'src/reducers/suite/suiteReducer';
 import { SuiteStart } from 'src/views/start/SuiteStart';
 import { ViewOnlyPromo } from 'src/views/view-only/ViewOnlyPromo';
@@ -58,7 +58,9 @@ export const Preloader = ({ children }: PropsWithChildren) => {
     const isLoggedOut = useSelector(selectIsLoggedOut);
     const selectedDevice = useSelector(selectDevice);
     const { initialRun, viewOnlyPromoClosed } = useSelector(selectSuiteFlags);
-    const isFirmwareCheckFailed = useSelector(selectIsFirmwareAuthenticityCheckEnabledAndFailed);
+    const isFirmwareCheckFailed = useSelector(
+        selectIsFirmwareAuthenticityCheckEnabledAndHardFailed,
+    );
     const isFirmwareAuthenticityCheckDismissed = useSelector(
         selectIsFirmwareAuthenticityCheckDismissed,
     );

--- a/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
@@ -3,21 +3,13 @@ import { Card } from '@trezor/components';
 import { TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_URL } from '@trezor/urls';
 
 import { WelcomeLayout } from 'src/components/suite';
-import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
-import {
-    selectFirmwareHashCheckErrorIfEnabled,
-    selectFirmwareRevisionCheckErrorIfEnabled,
-} from 'src/reducers/suite/suiteReducer';
+import { useDevice, useDispatch } from 'src/hooks/suite';
 
-import { SecurityCheckFail, SecurityCheckFailProps } from './SecurityCheckFail';
-import { softFailureChecklistItems } from './checklistItems';
+import { SecurityCheckFail } from './SecurityCheckFail';
 
 export const DeviceCompromised = () => {
     const dispatch = useDispatch();
     const { device } = useDevice();
-
-    const revisionCheckError = useSelector(selectFirmwareRevisionCheckErrorIfEnabled);
-    const hashCheckError = useSelector(selectFirmwareHashCheckErrorIfEnabled);
 
     const goToSuite = () => {
         // Condition to satisfy TypeScript, device.id is always defined at this point.
@@ -26,22 +18,12 @@ export const DeviceCompromised = () => {
         }
     };
 
-    const isSoftFailure = revisionCheckError === null && hashCheckError === 'other-error';
-    const softFailureSecurityCheckFailProps: Partial<SecurityCheckFailProps> = isSoftFailure
-        ? {
-              heading: 'TR_DEVICE_MAYBE_COMPROMISED_HEADING',
-              text: 'TR_DEVICE_MAYBE_COMPROMISED_TEXT',
-              checklistItems: softFailureChecklistItems,
-          }
-        : {};
-
     return (
         <WelcomeLayout>
             <Card data-testid="@device-compromised">
                 <SecurityCheckFail
                     goBack={goToSuite}
                     supportUrl={TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_URL}
-                    {...softFailureSecurityCheckFailProps}
                 />
             </Card>
         </WelcomeLayout>

--- a/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
@@ -5,8 +5,8 @@ import { TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_URL } from '@trezor/urls';
 import { WelcomeLayout } from 'src/components/suite';
 import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 import {
-    selectFirmwareHashCheckError,
-    selectFirmwareRevisionCheckError,
+    selectFirmwareHashCheckErrorIfEnabled,
+    selectFirmwareRevisionCheckErrorIfEnabled,
 } from 'src/reducers/suite/suiteReducer';
 
 import { SecurityCheckFail, SecurityCheckFailProps } from './SecurityCheckFail';
@@ -16,8 +16,8 @@ export const DeviceCompromised = () => {
     const dispatch = useDispatch();
     const { device } = useDevice();
 
-    const revisionCheckError = useSelector(selectFirmwareRevisionCheckError);
-    const hashCheckError = useSelector(selectFirmwareHashCheckError);
+    const revisionCheckError = useSelector(selectFirmwareRevisionCheckErrorIfEnabled);
+    const hashCheckError = useSelector(selectFirmwareHashCheckErrorIfEnabled);
 
     const goToSuite = () => {
         // Condition to satisfy TypeScript, device.id is always defined at this point.

--- a/packages/suite/src/components/suite/SecurityCheck/checklistItems.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/checklistItems.tsx
@@ -16,18 +16,3 @@ export const hardFailureChecklistItems: SecurityChecklistItem[] = [
         content: <Translation id="TR_USE_CHAT" values={{ b: chunks => <b>{chunks}</b> }} />,
     },
 ];
-
-export const softFailureChecklistItems: SecurityChecklistItem[] = [
-    {
-        icon: 'plugs',
-        content: <Translation id="TR_RECONNECT_YOUR_DEVICE" />,
-    },
-    {
-        icon: 'eye',
-        content: <Translation id="TR_SEE_IF_ISSUE_PERSISTS" />,
-    },
-    {
-        icon: 'chat',
-        content: <Translation id="TR_USE_CHAT" values={{ b: chunks => <b>{chunks}</b> }} />,
-    },
-];

--- a/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareRevisionCheckBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareRevisionCheckBanner.tsx
@@ -5,11 +5,11 @@ import { HELP_CENTER_FIRMWARE_REVISION_CHECK } from '@trezor/urls';
 
 import { Translation, TrezorLink } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
+import { SkippedHashCheckError } from 'src/constants/suite/firmware';
 import {
     selectFirmwareHashCheckErrorIfEnabled,
     selectFirmwareRevisionCheckErrorIfEnabled,
 } from 'src/reducers/suite/suiteReducer';
-import { skippedHashCheckErrors } from 'src/constants/suite/firmware';
 
 const revisionCheckMessages: Record<FirmwareRevisionCheckError, TranslationKey> = {
     'cannot-perform-check-offline': 'TR_DEVICE_FIRMWARE_REVISION_CHECK_UNABLE_TO_PERFORM',
@@ -18,10 +18,8 @@ const revisionCheckMessages: Record<FirmwareRevisionCheckError, TranslationKey> 
     'firmware-version-unknown': 'TR_FIRMWARE_REVISION_CHECK_FAILED',
 };
 
-type SkippedHashCheckMessage = (typeof skippedHashCheckErrors)[number];
-
 const hashCheckMessages: Record<
-    Exclude<FirmwareHashCheckError, SkippedHashCheckMessage>,
+    Exclude<FirmwareHashCheckError, SkippedHashCheckError>,
     TranslationKey
 > = {
     'hash-mismatch': 'TR_DEVICE_FIRMWARE_HASH_CHECK_HASH_MISMATCH',

--- a/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareRevisionCheckBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareRevisionCheckBanner.tsx
@@ -2,7 +2,6 @@ import { TranslationKey } from '@suite-common/intl-types';
 import { Banner } from '@trezor/components';
 import { FirmwareHashCheckError, FirmwareRevisionCheckError } from '@trezor/connect';
 import { HELP_CENTER_FIRMWARE_REVISION_CHECK } from '@trezor/urls';
-import { isArrayMember } from '@trezor/utils';
 
 import { Translation, TrezorLink } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
@@ -36,7 +35,7 @@ const useAuthenticityCheckMessage = (): TranslationKey | null => {
     if (firmwareRevisionError) {
         return revisionCheckMessages[firmwareRevisionError];
     }
-    if (firmwareHashError && !isArrayMember(firmwareHashError, skippedHashCheckErrors)) {
+    if (firmwareHashError) {
         return hashCheckMessages[firmwareHashError];
     }
 

--- a/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareRevisionCheckBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareRevisionCheckBanner.tsx
@@ -6,8 +6,8 @@ import { HELP_CENTER_FIRMWARE_REVISION_CHECK } from '@trezor/urls';
 import { Translation, TrezorLink } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
 import {
-    selectFirmwareHashCheckError,
-    selectFirmwareRevisionCheckError,
+    selectFirmwareHashCheckErrorIfEnabled,
+    selectFirmwareRevisionCheckErrorIfEnabled,
 } from 'src/reducers/suite/suiteReducer';
 import { skippedHashCheckErrors } from 'src/constants/suite/firmware';
 
@@ -29,8 +29,8 @@ const hashCheckMessages: Record<
 };
 
 const useAuthenticityCheckMessage = (): TranslationKey | null => {
-    const firmwareRevisionError = useSelector(selectFirmwareRevisionCheckError);
-    const firmwareHashError = useSelector(selectFirmwareHashCheckError);
+    const firmwareRevisionError = useSelector(selectFirmwareRevisionCheckErrorIfEnabled);
+    const firmwareHashError = useSelector(selectFirmwareHashCheckErrorIfEnabled);
 
     if (firmwareRevisionError) {
         return revisionCheckMessages[firmwareRevisionError];
@@ -43,7 +43,7 @@ const useAuthenticityCheckMessage = (): TranslationKey | null => {
 };
 
 export const FirmwareRevisionCheckBanner = () => {
-    const firmwareRevisionError = useSelector(selectFirmwareRevisionCheckError);
+    const firmwareRevisionError = useSelector(selectFirmwareRevisionCheckErrorIfEnabled);
     const wasOffline = firmwareRevisionError === 'cannot-perform-check-offline';
 
     const message = useAuthenticityCheckMessage();

--- a/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareRevisionCheckBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareRevisionCheckBanner.tsx
@@ -25,7 +25,6 @@ const hashCheckMessages: Record<
     TranslationKey
 > = {
     'hash-mismatch': 'TR_DEVICE_FIRMWARE_HASH_CHECK_HASH_MISMATCH',
-    'other-error': 'TR_DEVICE_FIRMWARE_HASH_CHECK_OTHER_ERROR',
 };
 
 const useAuthenticityCheckMessage = (): TranslationKey | null => {

--- a/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
@@ -11,8 +11,8 @@ import { isTranslationMode } from 'src/utils/suite/l10n';
 import { useSelector } from 'src/hooks/suite';
 import { MAX_CONTENT_WIDTH } from 'src/constants/suite/layout';
 import {
-    selectFirmwareHashCheckError,
-    selectFirmwareRevisionCheckError,
+    selectFirmwareHashCheckErrorIfEnabled,
+    selectFirmwareRevisionCheckErrorIfEnabled,
 } from 'src/reducers/suite/suiteReducer';
 
 import { MessageSystemBanner } from '../MessageSystemBanner';
@@ -41,8 +41,8 @@ export const SuiteBanners = () => {
     const isOnline = useSelector(state => state.suite.online);
     const firmwareHashInvalid = useSelector(state => state.firmware.firmwareHashInvalid);
     const bannerMessage = useSelector(selectBannerMessage);
-    const firmwareRevisionError = useSelector(selectFirmwareRevisionCheckError);
-    const firmwareHashError = useSelector(selectFirmwareHashCheckError);
+    const firmwareRevisionError = useSelector(selectFirmwareRevisionCheckErrorIfEnabled);
+    const firmwareHashError = useSelector(selectFirmwareHashCheckErrorIfEnabled);
 
     // The dismissal doesn't need to outlive the session. Use local state.
     const [safetyChecksDismissed, setSafetyChecksDismissed] = useState(false);

--- a/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
@@ -4,14 +4,12 @@ import styled from 'styled-components';
 
 import { selectBannerMessage } from '@suite-common/message-system';
 import { selectDevice } from '@suite-common/wallet-core';
-import { isArrayMember } from '@trezor/utils';
 import { isDesktop } from '@trezor/env-utils';
 import { spacingsPx } from '@trezor/theme';
 
 import { isTranslationMode } from 'src/utils/suite/l10n';
 import { useSelector } from 'src/hooks/suite';
 import { MAX_CONTENT_WIDTH } from 'src/constants/suite/layout';
-import { skippedHashCheckErrors } from 'src/constants/suite/firmware';
 import {
     selectFirmwareHashCheckError,
     selectFirmwareRevisionCheckError,
@@ -72,10 +70,7 @@ export const SuiteBanners = () => {
         priority = 92;
     }
     // the regular firmware hash check, and revision id check, either of them may fail
-    else if (
-        firmwareRevisionError ||
-        (firmwareHashError && !isArrayMember(firmwareHashError, skippedHashCheckErrors))
-    ) {
+    else if (firmwareRevisionError || firmwareHashError) {
         banner = <FirmwareRevisionCheckBanner />;
         priority = 91;
     } else if (device?.features?.unfinished_backup) {

--- a/packages/suite/src/constants/suite/firmware.ts
+++ b/packages/suite/src/constants/suite/firmware.ts
@@ -14,8 +14,10 @@ export const skippedHashCheckErrors = [
     'check-unsupported',
     // this could be serious, but it's also caught by revision check, which handles edge-cases better, so it's skipped here
     'unknown-release',
+    // TODO fix unreliability & reenable
+    'other-error',
 ] satisfies FirmwareHashCheckError[];
 
 // Of those skipped errors, these ones should nevertheless be reported to Sentry
 type SkippedHashCheckErrors = typeof skippedHashCheckErrors;
-export const skippedButReportedHashCheckErrors = [] satisfies SkippedHashCheckErrors;
+export const skippedButReportedHashCheckErrors = ['other-error'] satisfies SkippedHashCheckErrors;

--- a/packages/suite/src/constants/suite/firmware.ts
+++ b/packages/suite/src/constants/suite/firmware.ts
@@ -16,5 +16,6 @@ export const skippedHashCheckErrors = [
     'unknown-release',
 ] satisfies FirmwareHashCheckError[];
 
-// These errors will be treated softly, with only a warning displayed instead of modal
-export const softHashCheckErrors = [...skippedHashCheckErrors];
+// Of those skipped errors, these ones should nevertheless be reported to Sentry
+type SkippedHashCheckErrors = typeof skippedHashCheckErrors;
+export const skippedButReportedHashCheckErrors = [] satisfies SkippedHashCheckErrors;

--- a/packages/suite/src/constants/suite/firmware.ts
+++ b/packages/suite/src/constants/suite/firmware.ts
@@ -1,13 +1,20 @@
 import { FirmwareHashCheckError, FirmwareRevisionCheckError } from '@trezor/connect';
 
-export const skippedRevisionCheckErrors = [
+// These errors will be treated softly, with only a warning displayed instead of modal
+// note: there are no skipped revision check errors
+export const softRevisionCheckErrors = [
     'cannot-perform-check-offline',
     'other-error',
 ] satisfies FirmwareRevisionCheckError[];
 
+// These errors are omitted entirely
+// note: there are no soft hash check errors
 export const skippedHashCheckErrors = [
     'check-skipped',
     'check-unsupported',
     // this could be serious, but it's also caught by revision check, which handles edge-cases better, so it's skipped here
     'unknown-release',
 ] satisfies FirmwareHashCheckError[];
+
+// These errors will be treated softly, with only a warning displayed instead of modal
+export const softHashCheckErrors = [...skippedHashCheckErrors];

--- a/packages/suite/src/constants/suite/firmware.ts
+++ b/packages/suite/src/constants/suite/firmware.ts
@@ -1,23 +1,45 @@
 import { FirmwareHashCheckError, FirmwareRevisionCheckError } from '@trezor/connect';
+import { FilterPropertiesByType } from '@trezor/type-utils';
 
-// These errors will be treated softly, with only a warning displayed instead of modal
-// note: there are no skipped revision check errors
-export const softRevisionCheckErrors = [
-    'cannot-perform-check-offline',
-    'other-error',
-] satisfies FirmwareRevisionCheckError[];
+/*
+ * Various scenarios how firmware authenticity check errors are handled
+ */
 
-// These errors are omitted entirely
-// note: there are no soft hash check errors
-export const skippedHashCheckErrors = [
-    'check-skipped',
-    'check-unsupported',
-    // this could be serious, but it's also caught by revision check, which handles edge-cases better, so it's skipped here
-    'unknown-release',
-    // TODO fix unreliability & reenable
-    'other-error',
-] satisfies FirmwareHashCheckError[];
+// will be ignored completely
+type SkippedBehavior = { type: 'skipped'; shouldReport: boolean };
+// display `SuiteBanners` warning
+type SoftWarningBehavior = { type: 'softWarning'; shouldReport: true };
+// display `SuiteBanners`, show `DeviceCompromised` modal, block receiving address
+type HardModalBehavior = { type: 'hardModal'; shouldReport: true };
 
-// Of those skipped errors, these ones should nevertheless be reported to Sentry
-type SkippedHashCheckErrors = typeof skippedHashCheckErrors;
-export const skippedButReportedHashCheckErrors = ['other-error'] satisfies SkippedHashCheckErrors;
+type RevisionErrorBehavior = SoftWarningBehavior | HardModalBehavior;
+type RevisionCheckErrorScenarios = Record<FirmwareRevisionCheckError, RevisionErrorBehavior>;
+
+type HashErrorBehavior = SkippedBehavior | HardModalBehavior;
+type HashCheckErrorScenarios = Record<FirmwareHashCheckError, HashErrorBehavior>;
+
+export const revisionCheckErrorScenarios = {
+    'revision-mismatch': { type: 'hardModal', shouldReport: true },
+    'firmware-version-unknown': { type: 'hardModal', shouldReport: true },
+    'cannot-perform-check-offline': { type: 'softWarning', shouldReport: true },
+    'other-error': { type: 'softWarning', shouldReport: true },
+} satisfies RevisionCheckErrorScenarios;
+
+export const hashCheckErrorScenarios = {
+    'hash-mismatch': { type: 'hardModal', shouldReport: true },
+    'check-skipped': { type: 'skipped', shouldReport: false },
+    'check-unsupported': { type: 'skipped', shouldReport: false },
+    // could mean counterfeit firmware, but it's also caught by revision check, which handles edge-cases better
+    'unknown-release': { type: 'skipped', shouldReport: false },
+    // TODO fix FW hash check unreliability & reenable
+    'other-error': { type: 'skipped', shouldReport: true },
+} satisfies HashCheckErrorScenarios;
+
+export type SkippedHashCheckError = keyof FilterPropertiesByType<
+    typeof hashCheckErrorScenarios,
+    { type: 'skipped' }
+>;
+
+export const isSkippedHashCheckError = (
+    error: FirmwareHashCheckError,
+): error is SkippedHashCheckError => hashCheckErrorScenarios[error].type === 'skipped';

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -468,16 +468,6 @@ export const selectFirmwareRevisionCheckErrorIfEnabled = (state: AppState) => {
 };
 
 /**
- * Determine hard failure of firmware revision check - specific error types which are severe.
- * If Suite is offline and cannot perform check or there is some unexpected error, a banner is shown but device is accessible.
- */
-const selectIsFirmwareRevisionCheckEnabledAndHardFailed = (state: AppState): boolean => {
-    const error = selectFirmwareRevisionCheckErrorIfEnabled(state);
-
-    return error !== null ? !isArrayMember(error, softRevisionCheckErrors) : false;
-};
-
-/**
  * Get firmware hash check error, or null if check was successful / skipped.
  */
 export const selectFirmwareHashCheckError = (state: AppState) => {
@@ -501,24 +491,21 @@ export const selectFirmwareHashCheckErrorIfEnabled = (state: AppState) => {
 };
 
 /**
- * Determine hard failure of firmware hash check - specific error types which are severe.
- * If check was skipped, don't consider it failed.
- * If check is unsupported by device, a banner is shown but device is accessible.
- */
-const selectIsFirmwareHashCheckEnabledAndHardFailed = (state: AppState): boolean => {
-    const error = selectFirmwareHashCheckErrorIfEnabled(state);
-
-    return error !== null
-        ? // broaden the error type, so that `softHashCheckErrors` is assignable as a subset of `error`
-          !isArrayMember(error as FirmwareHashCheckError, softHashCheckErrors)
-        : false;
-};
-
-/**
  * Determine hard failure of either of firmware authenticity checks to block access to device.
  */
-export const selectIsFirmwareAuthenticityCheckEnabledAndHardFailed = (state: AppState) =>
-    selectIsFirmwareRevisionCheckEnabledAndHardFailed(state) ||
-    selectIsFirmwareHashCheckEnabledAndHardFailed(state);
+export const selectIsFirmwareAuthenticityCheckEnabledAndHardFailed = (state: AppState) => {
+    const revisionError = selectFirmwareRevisionCheckErrorIfEnabled(state);
+    const isRevisionHardError =
+        revisionError !== null ? !isArrayMember(revisionError, softRevisionCheckErrors) : false;
+
+    const hashError = selectFirmwareHashCheckErrorIfEnabled(state);
+    const isHashHardError =
+        hashError !== null
+            ? // broaden the hashError type, so that `softHashCheckErrors` is assignable as a subset of `hashError`
+              !isArrayMember(hashError as FirmwareHashCheckError, softHashCheckErrors)
+            : false;
+
+    return isRevisionHardError || isHashHardError;
+};
 
 export default suiteReducer;

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -6,7 +6,7 @@ import { isDeviceAcquired } from '@suite-common/suite-utils';
 import { discoveryActions, DeviceRootState, selectDevice } from '@suite-common/wallet-core';
 import { isArrayMember, versionUtils } from '@trezor/utils';
 import { isWeb } from '@trezor/env-utils';
-import { TRANSPORT, TransportInfo, ConnectSettings, FirmwareHashCheckError } from '@trezor/connect';
+import { TRANSPORT, TransportInfo, ConnectSettings } from '@trezor/connect';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { SuiteThemeVariant } from '@trezor/suite-desktop-api';
 import { AddressDisplayOptions, WalletType } from '@suite-common/wallet-types';
@@ -20,11 +20,7 @@ import { ExperimentalFeature } from 'src/constants/suite/experimental';
 import { Action, AppState, TorBootstrap, TorStatus } from 'src/types/suite';
 import { getExcludedPrerequisites, getPrerequisiteName } from 'src/utils/suite/prerequisites';
 import { SIDEBAR_WIDTH_NUMERIC } from 'src/constants/suite/layout';
-import {
-    skippedHashCheckErrors,
-    softHashCheckErrors,
-    softRevisionCheckErrors,
-} from 'src/constants/suite/firmware';
+import { skippedHashCheckErrors, softRevisionCheckErrors } from 'src/constants/suite/firmware';
 
 import { RouterRootState, selectRouter } from './routerReducer';
 
@@ -499,11 +495,7 @@ export const selectIsFirmwareAuthenticityCheckEnabledAndHardFailed = (state: App
         revisionError !== null ? !isArrayMember(revisionError, softRevisionCheckErrors) : false;
 
     const hashError = selectFirmwareHashCheckErrorIfEnabled(state);
-    const isHashHardError =
-        hashError !== null
-            ? // broaden the hashError type, so that `softHashCheckErrors` is assignable as a subset of `hashError`
-              !isArrayMember(hashError as FirmwareHashCheckError, softHashCheckErrors)
-            : false;
+    const isHashHardError = hashError !== null;
 
     return isRevisionHardError || isHashHardError;
 };

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -20,7 +20,7 @@ import { ExperimentalFeature } from 'src/constants/suite/experimental';
 import { Action, AppState, TorBootstrap, TorStatus } from 'src/types/suite';
 import { getExcludedPrerequisites, getPrerequisiteName } from 'src/utils/suite/prerequisites';
 import { SIDEBAR_WIDTH_NUMERIC } from 'src/constants/suite/layout';
-import { skippedHashCheckErrors, skippedRevisionCheckErrors } from 'src/constants/suite/firmware';
+import { softHashCheckErrors, softRevisionCheckErrors } from 'src/constants/suite/firmware';
 
 import { RouterRootState, selectRouter } from './routerReducer';
 
@@ -459,10 +459,10 @@ export const selectFirmwareRevisionCheckError = (state: AppState) => {
  * Determine hard failure of firmware revision check - specific error types which are severe.
  * If Suite is offline and cannot perform check or there is some unexpected error, a banner is shown but device is accessible.
  */
-const selectIsFirmwareRevisionCheckEnabledAndFailed = (state: AppState): boolean => {
+const selectIsFirmwareRevisionCheckEnabledAndHardFailed = (state: AppState): boolean => {
     const error = selectFirmwareRevisionCheckError(state);
 
-    return error !== null ? !isArrayMember(error, skippedRevisionCheckErrors) : false;
+    return error !== null ? !isArrayMember(error, softRevisionCheckErrors) : false;
 };
 
 /**
@@ -485,17 +485,17 @@ export const selectFirmwareHashCheckError = (state: AppState) => {
  * If check was skipped, don't consider it failed.
  * If check is unsupported by device, a banner is shown but device is accessible.
  */
-const selectIsFirmwareHashCheckEnabledAndFailed = (state: AppState): boolean => {
+const selectIsFirmwareHashCheckEnabledAndHardFailed = (state: AppState): boolean => {
     const error = selectFirmwareHashCheckError(state);
 
-    return error !== null ? !isArrayMember(error, skippedHashCheckErrors) : false;
+    return error !== null ? !isArrayMember(error, softHashCheckErrors) : false;
 };
 
 /**
  * Determine hard failure of either of firmware authenticity checks to block access to device.
  */
-export const selectIsFirmwareAuthenticityCheckEnabledAndFailed = (state: AppState) =>
-    selectIsFirmwareRevisionCheckEnabledAndFailed(state) ||
-    selectIsFirmwareHashCheckEnabledAndFailed(state);
+export const selectIsFirmwareAuthenticityCheckEnabledAndHardFailed = (state: AppState) =>
+    selectIsFirmwareRevisionCheckEnabledAndHardFailed(state) ||
+    selectIsFirmwareHashCheckEnabledAndHardFailed(state);
 
 export default suiteReducer;

--- a/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
+++ b/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
@@ -23,7 +23,7 @@ import { Translation, ReadMoreLink } from 'src/components/suite';
 import { AppState } from 'src/types/suite';
 import { showAddress } from 'src/actions/wallet/receiveActions';
 import { useDispatch, useSelector } from 'src/hooks/suite/';
-import { selectIsFirmwareAuthenticityCheckEnabledAndFailed } from 'src/reducers/suite/suiteReducer';
+import { selectIsFirmwareAuthenticityCheckEnabledAndHardFailed } from 'src/reducers/suite/suiteReducer';
 
 const FreshAddressWrapper = styled.div`
     position: relative;
@@ -93,7 +93,7 @@ export const FreshAddress = ({
         selectIsAccountUtxoBased(state, account?.key ?? ''),
     );
     const isAuthenticityCheckFailed = useSelector(
-        selectIsFirmwareAuthenticityCheckEnabledAndFailed,
+        selectIsFirmwareAuthenticityCheckEnabledAndHardFailed,
     );
     const dispatch = useDispatch();
 

--- a/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
+++ b/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
@@ -23,7 +23,7 @@ import { MetadataAddPayload } from 'src/types/suite/metadata';
 import { showAddress } from 'src/actions/wallet/receiveActions';
 import { useDispatch, useSelector } from 'src/hooks/suite/';
 import { selectLabelingDataForSelectedAccount } from 'src/reducers/suite/metadataReducer';
-import { selectIsFirmwareAuthenticityCheckEnabledAndFailed } from 'src/reducers/suite/suiteReducer';
+import { selectIsFirmwareAuthenticityCheckEnabledAndHardFailed } from 'src/reducers/suite/suiteReducer';
 
 const AddressActions = styled.div<{ $isVisible?: boolean }>`
     opacity: ${({ $isVisible }) => ($isVisible ? '1' : '0')};
@@ -49,7 +49,7 @@ type ItemProps = {
 
 const Item = ({ addr, locked, symbol, onClick, metadataPayload, index }: ItemProps) => {
     const isAuthenticityCheckFailed = useSelector(
-        selectIsFirmwareAuthenticityCheckEnabledAndFailed,
+        selectIsFirmwareAuthenticityCheckEnabledAndHardFailed,
     );
     const [isHovered, setIsHovered] = useState(false);
 

--- a/packages/type-utils/src/utils.ts
+++ b/packages/type-utils/src/utils.ts
@@ -72,6 +72,11 @@ export type GetObjectWithoutKey<U, K extends PropertyKey> = U extends object
 
 export type ObjectsOnly<T> = T extends Record<string, unknown> ? T : never;
 
+// map object `T` to a narrowed type with only those entries that match given `ValueFilter` type
+export type FilterPropertiesByType<T, ValueFilter> = {
+    [Key in keyof T as T[Key] extends ValueFilter ? Key : never]: T[Key];
+};
+
 export type OverloadImplementations<T, U extends keyof T> = Overloads<T[U]>;
 export type Overloads<T> = Overloads24<T>;
 type Overloads24<T> = T extends {


### PR DESCRIPTION
## Description

Refactor selectors for FW authenticity checks, as they became complex, duplicated and with misleading names.
Most notably, soft errors were called skipped errors, even though they display banner, so they're not rly skipped :see_no_evil:

Incidentally, fix small issue from #15555 where [sentry](https://satoshilabs.sentry.io/issues/6016986779/?project=5193825) reports even skipped errors like `check-unsupported`. The main purpose of 15555 was to report it even when turned off in settings. But thinking about it again, IMO we should report soft reivision check errors too (also didn't before 15555), but exclude the skipped hash check errors.

- bac01207bc rename skippedErrors to softErrors, because they were used as such, and decouple skippedErrors
- bbab835b98 actually use skipped hash check errors in selector to centralize it
- b9357d7002 rename `error` selectors to `errorIfEnabled`, and split `error` from them so they can be used for Sentry
- 4394bf52d2 on the other hand, squash selectors used only locally, IMO they don't add much clarity
- b429b12d2d introduce another category - errors skipped but still reported to Sentry :see_no_evil: 
- 266e7f5b62 add `other-error` to that category
- 2eea204b0a574a22346c7bafedcfa70f8c3e4c3d cleanup: reorganize scenarios for each errors

You can test other-error by checking out [testing branch](https://github.com/trezor/trezor-suite/tree/chore/refactor-fw-hash-check-selectors-TESTING)

## Notes

I attempted to standardize variable names as follows:
- we start with the basic definition of any error ([of those types](https://github.com/trezor/trezor-suite/blob/6744666b9a2c7e20cfb71bd4f9de59d6c7d37f36/packages/connect/src/types/device.ts#L48-L66)). Some of those are:
- **skipped error**: is not handled at all
  - no modal, not blocking recieve addr, no banner, no sentry
- **skipped but reported error**:
- **soft error**: is handled in a non-blocking way
  - no modal, not blocking recieve addr, **but will do** banner, sentry
- **hard error**: fully handled, gets the full treatment
  - modal, blocking receive addr, banner, sentry
  - equals "not soft error"

Still, it's not consistent between revision & hash check because they got different requirements:
- revision check only has soft and hard, but no skipped
- hash check has skipped, skipped+reported and hard, but no soft