### PR TITLE
fix(protobuf): ApplySettings.display_rotation allow both enum keys and values

### DIFF
--- a/packages/protobuf/scripts/protobuf-patches/index.ts
+++ b/packages/protobuf/scripts/protobuf-patches/index.ts
@@ -158,6 +158,7 @@ export const TYPE_PATCH = {
     'Features.display_rotation': 'DisplayRotation | null',
     'Features.experimental_features': 'boolean | null',
     'Features.internal_model': DeviceModelInternal,
+    'ApplySettings.display_rotation': 'DisplayRotation | Enum_DisplayRotation',
     'HDNodePathType.node': 'HDNodeType | string',
     'FirmwareUpload.payload': 'Buffer | ArrayBuffer',
     'EthereumGetAddress.encoded_network': 'ArrayBuffer',

--- a/packages/protobuf/src/messages-schema.ts
+++ b/packages/protobuf/src/messages-schema.ts
@@ -2402,7 +2402,7 @@ export const ApplySettings = Type.Object(
         homescreen: Type.Optional(Type.String()),
         _passphrase_source: Type.Optional(Type.Number()),
         auto_lock_delay_ms: Type.Optional(Type.Number()),
-        display_rotation: Type.Optional(DisplayRotation),
+        display_rotation: Type.Optional(Type.Union([DisplayRotation, EnumEnum_DisplayRotation])),
         passphrase_always_on_device: Type.Optional(Type.Boolean()),
         safety_checks: Type.Optional(SafetyCheckLevel),
         experimental_features: Type.Optional(Type.Boolean()),

--- a/packages/protobuf/src/messages.ts
+++ b/packages/protobuf/src/messages.ts
@@ -1586,7 +1586,7 @@ export type ApplySettings = {
     homescreen?: string;
     _passphrase_source?: number;
     auto_lock_delay_ms?: number;
-    display_rotation?: DisplayRotation;
+    display_rotation?: DisplayRotation | Enum_DisplayRotation;
     passphrase_always_on_device?: boolean;
     safety_checks?: SafetyCheckLevel;
     experimental_features?: boolean;


### PR DESCRIPTION
## Description

Change `ApplySettings.display_rotation` to allow both enum keys and values - eg. both 'North' and 0

Previously it was numerical, but with #15588 it was changed to enum keys and broke [this test](https://github.com/trezor/trezor-suite/actions/runs/12060236594/job/33647934485).