### PR TITLE
Refactor e2e emulator use to fixture

### DIFF
--- a/packages/suite-desktop-core/e2e/support/fixtures.ts
+++ b/packages/suite-desktop-core/e2e/support/fixtures.ts
@@ -12,11 +12,12 @@ import { WalletActions } from './pageActions/walletActions';
 import { OnboardingActions } from './pageActions/onboardingActions';
 
 type Fixtures = {
+    startEmulator: boolean;
     emulatorConf: {
         needs_backup: boolean;
         mnemonic: string;
     };
-    TrezorUserEnvLink: TrezorUserEnvLinkClass;
+    trezorUserEnvLink: TrezorUserEnvLinkClass;
     electronApp: ElectronApplication;
     window: Page;
     dashboardPage: DashboardActions;
@@ -27,20 +28,22 @@ type Fixtures = {
 };
 
 const test = base.extend<Fixtures>({
+    startEmulator: true,
     emulatorConf: {
         needs_backup: true,
         mnemonic: 'mnemonic_all',
     },
-     
-    TrezorUserEnvLink: async ({ emulatorConf }, use) => {
-        await TrezorUserEnvLink.stopBridge();
-        await TrezorUserEnvLink.connect();
-        await TrezorUserEnvLink.startEmu({ wipe: true });
-        await TrezorUserEnvLink.setupEmu(emulatorConf);
+    trezorUserEnvLink: async (_, use) => {
         await use(TrezorUserEnvLink);
     },
-    // eslint-disable-next-line no-empty-pattern
-    electronApp: async ({}, use) => {
+    electronApp: async ({ trezorUserEnvLink, startEmulator, emulatorConf }, use) => {
+        // We need to ensure emulator is running before launching the suite
+        if (startEmulator) {
+            await trezorUserEnvLink.stopBridge();
+            await trezorUserEnvLink.connect();
+            await trezorUserEnvLink.startEmu({ wipe: true });
+            await trezorUserEnvLink.setupEmu(emulatorConf);
+        }
         const suite = await launchSuite();
         await use(suite.electronApp);
         await suite.electronApp.close(); // Ensure cleanup after tests

--- a/packages/suite-desktop-core/e2e/support/fixtures.ts
+++ b/packages/suite-desktop-core/e2e/support/fixtures.ts
@@ -2,6 +2,8 @@
 
 import { test as base, ElectronApplication, Page } from '@playwright/test';
 
+import { TrezorUserEnvLink, TrezorUserEnvLinkClass } from '@trezor/trezor-user-env-link';
+
 import { DashboardActions } from './pageActions/dashboardActions';
 import { launchSuite } from './common';
 import { SettingsActions } from './pageActions/settingsActions';
@@ -10,6 +12,7 @@ import { WalletActions } from './pageActions/walletActions';
 import { OnboardingActions } from './pageActions/onboardingActions';
 
 type Fixtures = {
+    TrezorUserEnvLink: TrezorUserEnvLinkClass;
     electronApp: ElectronApplication;
     window: Page;
     dashboardPage: DashboardActions;
@@ -20,7 +23,14 @@ type Fixtures = {
 };
 
 const test = base.extend<Fixtures>({
-    /* eslint-disable no-empty-pattern */
+    // eslint-disable-next-line no-empty-pattern
+    TrezorUserEnvLink: async ({}, use) => {
+        await TrezorUserEnvLink.stopBridge();
+        await TrezorUserEnvLink.connect();
+        await TrezorUserEnvLink.startEmu({ wipe: true });
+        await use(TrezorUserEnvLink);
+    },
+    // eslint-disable-next-line no-empty-pattern
     electronApp: async ({}, use) => {
         const suite = await launchSuite();
         await use(suite.electronApp);

--- a/packages/suite-desktop-core/e2e/support/fixtures.ts
+++ b/packages/suite-desktop-core/e2e/support/fixtures.ts
@@ -33,7 +33,8 @@ const test = base.extend<Fixtures>({
         needs_backup: true,
         mnemonic: 'mnemonic_all',
     },
-    trezorUserEnvLink: async (_, use) => {
+    /* eslint-disable-next-line no-empty-pattern */
+    trezorUserEnvLink: async ({}, use) => {
         await use(TrezorUserEnvLink);
     },
     electronApp: async ({ trezorUserEnvLink, startEmulator, emulatorConf }, use) => {

--- a/packages/suite-desktop-core/e2e/support/fixtures.ts
+++ b/packages/suite-desktop-core/e2e/support/fixtures.ts
@@ -12,6 +12,10 @@ import { WalletActions } from './pageActions/walletActions';
 import { OnboardingActions } from './pageActions/onboardingActions';
 
 type Fixtures = {
+    emulatorConf: {
+        needs_backup: boolean;
+        mnemonic: string;
+    };
     TrezorUserEnvLink: TrezorUserEnvLinkClass;
     electronApp: ElectronApplication;
     window: Page;
@@ -23,11 +27,16 @@ type Fixtures = {
 };
 
 const test = base.extend<Fixtures>({
-    // eslint-disable-next-line no-empty-pattern
-    TrezorUserEnvLink: async ({}, use) => {
+    emulatorConf: {
+        needs_backup: true,
+        mnemonic: 'mnemonic_all',
+    },
+     
+    TrezorUserEnvLink: async ({ emulatorConf }, use) => {
         await TrezorUserEnvLink.stopBridge();
         await TrezorUserEnvLink.connect();
         await TrezorUserEnvLink.startEmu({ wipe: true });
+        await TrezorUserEnvLink.setupEmu(emulatorConf);
         await use(TrezorUserEnvLink);
     },
     // eslint-disable-next-line no-empty-pattern

--- a/packages/suite-desktop-core/e2e/tests/general/cardano-discovery.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/general/cardano-discovery.test.ts
@@ -1,11 +1,16 @@
 import { test, expect } from '../../support/fixtures';
 
-test.beforeAll(async ({ TrezorUserEnvLink }) => {
-    await TrezorUserEnvLink.setupEmu({
+test.use({
+    emulatorConf: {
         needs_backup: true,
         mnemonic:
             'cloth trim improve bag pigeon party wave mechanic beyond clean cake maze protect left assist carry guitar bridge nest faith critic excuse tooth dutch',
-    });
+    },
+});
+
+test.beforeEach(async ({ TrezorUserEnvLink, onboardingPage, dashboardPage }) => {
+    await onboardingPage.completeOnboarding();
+    await dashboardPage.discoveryShouldFinish();
 });
 
 /**
@@ -14,14 +19,7 @@ test.beforeAll(async ({ TrezorUserEnvLink }) => {
  * 2. Check that all types of Cardano accounts are discovered
  * 3. Check that Staking section is available
  */
-test('Discover all Cardano account types', async ({
-    onboardingPage,
-    dashboardPage,
-    settingsPage,
-    walletPage,
-}) => {
-    await onboardingPage.completeOnboarding();
-    await dashboardPage.discoveryShouldFinish();
+test('Discover all Cardano account types', async ({ dashboardPage, settingsPage, walletPage }) => {
     await settingsPage.navigateTo();
     await settingsPage.coinsTabButton.click();
     await settingsPage.enableCoin('ada');

--- a/packages/suite-desktop-core/e2e/tests/general/cardano-discovery.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/general/cardano-discovery.test.ts
@@ -1,19 +1,11 @@
-import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link/src';
-
 import { test, expect } from '../../support/fixtures';
 
-test.beforeAll(async () => {
-    await TrezorUserEnvLink.connect();
-    await TrezorUserEnvLink.startEmu({ wipe: true });
+test.beforeAll(async ({ TrezorUserEnvLink }) => {
     await TrezorUserEnvLink.setupEmu({
         needs_backup: true,
         mnemonic:
             'cloth trim improve bag pigeon party wave mechanic beyond clean cake maze protect left assist carry guitar bridge nest faith critic excuse tooth dutch',
     });
-});
-
-test.afterAll(() => {
-    TrezorUserEnvLink.stopEmu();
 });
 
 /**

--- a/packages/suite-desktop-core/e2e/tests/general/cardano-discovery.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/general/cardano-discovery.test.ts
@@ -8,7 +8,7 @@ test.use({
     },
 });
 
-test.beforeEach(async ({ TrezorUserEnvLink, onboardingPage, dashboardPage }) => {
+test.beforeEach(async ({ onboardingPage, dashboardPage }) => {
     await onboardingPage.completeOnboarding();
     await dashboardPage.discoveryShouldFinish();
 });

--- a/packages/suite-desktop-core/e2e/tests/general/eap-modal.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/general/eap-modal.test.ts
@@ -10,7 +10,7 @@ import { test, expect } from '../../support/fixtures';
  */
 // TODO: #15561 FIX settings cleanup: eap setting is remembered even after cache cleanup at the beginning of the test. This shouldn't affect gha run but breaks the local one.
 test.skip(!process.env.GITHUB_ACTION, 'Test is working only in CI. Skipping local run.');
-
+test.use({ startEmulator: false });
 test.beforeAll(async ({ onboardingPage }) => {
     await onboardingPage.completeOnboarding();
 });

--- a/packages/suite-desktop-core/e2e/tests/general/eap-modal.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/general/eap-modal.test.ts
@@ -8,7 +8,7 @@ import { test, expect } from '../../support/fixtures';
  * 4. Confrim the EAP modal
  * 5. Check if there is a button with `Leave` on it
  */
-// TODO: #15561 FIX settings cleanup:  eap setting is remembered even after cache cleanup at the beginning of the test. This shouldn't affect gha run but breaks the local one.
+// TODO: #15561 FIX settings cleanup: eap setting is remembered even after cache cleanup at the beginning of the test. This shouldn't affect gha run but breaks the local one.
 test.skip(!process.env.GITHUB_ACTION, 'Test is working only in CI. Skipping local run.');
 
 test.beforeAll(async ({ onboardingPage }) => {

--- a/packages/suite-desktop-core/e2e/tests/general/suite-guide.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/general/suite-guide.test.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '../../support/fixtures';
 
+test.use({ startEmulator: false });
 /**
  * Test case:
  * 1. Go to Bug section in Suite Guide

--- a/packages/suite-desktop-core/e2e/tests/general/wallet-discovery.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/general/wallet-discovery.test.ts
@@ -1,17 +1,15 @@
 import { test, expect } from '../../support/fixtures';
 
-test.beforeAll(async ({ TrezorUserEnvLink }) => {
-    await TrezorUserEnvLink.setupEmu({ needs_backup: true, mnemonic: 'mnemonic_all' });
+test.beforeEach(async ({ TrezorUserEnvLink, onboardingPage, dashboardPage }) => {
+    await onboardingPage.completeOnboarding();
+    await dashboardPage.discoveryShouldFinish();
 });
-
 /**
  * Test case:
  * 1. Discover a standard wallet
  * 2. Verify discovery by checking a the first btc value under the graph
  */
-test('Discover a standard wallet', async ({ onboardingPage, dashboardPage }) => {
-    await onboardingPage.completeOnboarding();
-    await dashboardPage.discoveryShouldFinish();
+test('Discover a standard wallet', async ({ dashboardPage }) => {
     await dashboardPage.openDeviceSwitcher();
     await dashboardPage.ejectWallet();
     await dashboardPage.addStandardWallet();

--- a/packages/suite-desktop-core/e2e/tests/general/wallet-discovery.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/general/wallet-discovery.test.ts
@@ -1,14 +1,7 @@
-import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
-
 import { test, expect } from '../../support/fixtures';
 
-test.beforeAll(async () => {
-    await TrezorUserEnvLink.connect();
-    await TrezorUserEnvLink.startEmu({ wipe: true });
-    await TrezorUserEnvLink.setupEmu({
-        needs_backup: true,
-        mnemonic: 'mnemonic_all',
-    });
+test.beforeAll(async ({ TrezorUserEnvLink }) => {
+    await TrezorUserEnvLink.setupEmu({ needs_backup: true, mnemonic: 'mnemonic_all' });
 });
 
 /**

--- a/packages/suite-desktop-core/e2e/tests/general/wallet-discovery.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/general/wallet-discovery.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '../../support/fixtures';
 
-test.beforeEach(async ({ TrezorUserEnvLink, onboardingPage, dashboardPage }) => {
+test.beforeEach(async ({ onboardingPage, dashboardPage }) => {
     await onboardingPage.completeOnboarding();
     await dashboardPage.discoveryShouldFinish();
 });

--- a/packages/suite-desktop-core/e2e/tests/settings/electrum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/electrum.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '../../support/fixtures';
 
 test.describe.serial('Suite works with Electrum server', () => {
-    test.beforeEach(async ({ TrezorUserEnvLink, onboardingPage, dashboardPage }) => {
+    test.beforeEach(async ({ onboardingPage, dashboardPage }) => {
         await onboardingPage.completeOnboarding();
         await dashboardPage.discoveryShouldFinish();
     });

--- a/packages/suite-desktop-core/e2e/tests/settings/electrum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/electrum.test.ts
@@ -1,23 +1,18 @@
 import { test, expect } from '../../support/fixtures';
 
 test.describe.serial('Suite works with Electrum server', () => {
-    test.beforeAll(async ({ TrezorUserEnvLink }) => {
-        await TrezorUserEnvLink.setupEmu({ needs_backup: true, mnemonic: 'mnemonic_all' });
+    test.beforeEach(async ({ TrezorUserEnvLink, onboardingPage, dashboardPage }) => {
+        await onboardingPage.completeOnboarding();
+        await dashboardPage.discoveryShouldFinish();
     });
 
-    test('Electrum completes discovery successfully', async ({
-        onboardingPage,
-        dashboardPage,
-        settingsPage,
-    }) => {
+    test('Electrum completes discovery successfully', async ({ dashboardPage, settingsPage }) => {
         test.info().annotations.push({
             type: 'dependency',
             description:
                 'This test needs running RegTest docker. Read how to run this dependency in docs/tests/regtest.md',
         });
         const electrumUrl = '127.0.0.1:50001:t';
-        await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
 
         await settingsPage.navigateTo();
         await settingsPage.toggleDebugModeInSettings();

--- a/packages/suite-desktop-core/e2e/tests/settings/electrum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/settings/electrum.test.ts
@@ -1,16 +1,8 @@
-import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
-
 import { test, expect } from '../../support/fixtures';
 
 test.describe.serial('Suite works with Electrum server', () => {
-    test.beforeAll(async () => {
-        await TrezorUserEnvLink.stopBridge();
-        await TrezorUserEnvLink.connect();
-        await TrezorUserEnvLink.startEmu({ wipe: true });
-        await TrezorUserEnvLink.setupEmu({
-            needs_backup: true,
-            mnemonic: 'mnemonic_all',
-        });
+    test.beforeAll(async ({ TrezorUserEnvLink }) => {
+        await TrezorUserEnvLink.setupEmu({ needs_backup: true, mnemonic: 'mnemonic_all' });
     });
 
     test('Electrum completes discovery successfully', async ({


### PR DESCRIPTION
Two commits each having different approach. I favor the second.

First commit: [refactor(e2e): Cleanup test setups](https://github.com/trezor/trezor-suite/pull/15636/commits/a7f9331af5e2f5a66143c4f1efb3f533b6c1a2d2)
Emulator setup is done only when imported to test file
but the catch is we need to complete the emulator setup before we initlize electron window. So the order of import of TrezorUserLinkEnv and Dashboard fixtures must be in this order or the thing breaks.
Also, the whole emulator setup must be in fixture so that left us with importing TrezorUserLinkEnv fixture to beforeEach but then we have nothing usefull to do with the object since all setup is already done. So we have unsused import which might be super confusing. It is a MECH solution and fragile

Second commit: [refactor(e2e): Improve readability and robustness of emulator setup](https://github.com/trezor/trezor-suite/pull/15636/commits/c6d62135f02328fc9a77986f1476207e654df162)
Keeps the TrezorUserLinkEnv fixture so we can easily use the api in future tests, but the setup of emulator is done in electron fixture. Intuitively, it makes sence to have the emulator setup in TrezorUserLinkEnv fixture but we really need to ensure the order of setuping first emulator and then creating electron window. Ergo, having emulator setup in Electron fixture is the best solution that will not need all the participants to remember some obscure information on how to correctly import things.
Also the emulator setup is conditioned and default is true. So in worse case scenario if you forgot to disable the emulator start for test that dont need it ... then you can add some seconds of test run.