### PR TITLE
feat(wallet-core): update non-blockbook accounts only if visible in UI

### DIFF
--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -1,6 +1,7 @@
 import { createThunk } from '@suite-common/redux-utils';
 import {
     getNetworkOptional,
+    isBlockbookBasedNetwork,
     isNetworkSymbol,
     networksCollection,
     NetworkSymbol,
@@ -335,9 +336,14 @@ export const syncAccountsWithBlockchainThunk = createThunk(
         // First clear, to cancel last planned sync
         tryClearTimeout(blockchain[symbol].syncTimeout);
 
+        // non-blockbook networks will not update periodically if not visible in UI (sidebar)
+        const visibleAccounts = findAccountsByNetwork(symbol, accounts).filter(
+            account => isBlockbookBasedNetwork(symbol) || account.visible,
+        );
+
         await Promise.all(
-            findAccountsByNetwork(symbol, accounts).map(a =>
-                dispatch(fetchAndUpdateAccountThunk({ accountKey: a.key })),
+            visibleAccounts.map(account =>
+                dispatch(fetchAndUpdateAccountThunk({ accountKey: account.key })),
             ),
         );
 


### PR DESCRIPTION
## Description

- do not update empty accounts which are not visible in UI

- this should save at least 2 requests for solana every minute (after merge of https://github.com/trezor/trezor-suite/pull/15445), now it is 12 requests (1 ledger account, 1 default account)

- will also save 1 to 3 requests per minute for cardano (depends on type of seed)

## Related Issue


## Screenshots:
