### PR TITLE
Feat/transport adjustments

### DIFF
--- a/packages/connect/setupJest.ts
+++ b/packages/connect/setupJest.ts
@@ -6,6 +6,7 @@ import { DeviceModelInternal, type Features, type FirmwareRelease } from './src/
 
 class TestTransport extends AbstractApiTransport {
     name = 'TestTransport' as any;
+    apiType = 'usb' as const;
 }
 
 // mock of navigator.usb

--- a/packages/connect/src/types/api/__tests__/index.ts
+++ b/packages/connect/src/types/api/__tests__/index.ts
@@ -19,6 +19,18 @@ export const init = async (api: TrezorConnect) => {
     // @ts-expect-error
     api.manifest({ email: 1 });
 
+    api.init({
+        manifest,
+        // @ts-expect-error
+        transports: ['BluetoothTransport'],
+    });
+
+    api.init({
+        manifest,
+        // @ts-expect-error
+        transports: ['NativeUsbTransport'],
+    });
+
     const settings = await api.getSettings();
     if (settings.success) {
         const { payload } = settings;

--- a/packages/connect/src/types/settings.ts
+++ b/packages/connect/src/types/settings.ts
@@ -9,13 +9,16 @@ export interface Manifest {
 
 export type Proxy = BlockchainSettings['proxy'];
 
+// omit transports which are not implemented in @trezor/connect
+type KnownTransport = Exclude<Transport['name'], 'NativeUsbTransport' | 'BluetoothTransport'>;
+
 export interface ConnectSettingsPublic {
     manifest?: Manifest;
     connectSrc?: string;
     debug?: boolean;
     popup?: boolean;
     transportReconnect?: boolean;
-    transports?: (Transport['name'] | Transport | (new (...args: any[]) => Transport))[];
+    transports?: (KnownTransport | Transport | (new (...args: any[]) => Transport))[];
     pendingTransportEvent?: boolean;
     lazyLoad?: boolean;
     interactionTimeout?: number;

--- a/packages/transport-native/src/nativeUsb.ts
+++ b/packages/transport-native/src/nativeUsb.ts
@@ -4,6 +4,7 @@ import { Transport as AbstractTransport, AbstractApiTransport, UsbApi } from '@t
 export class NativeUsbTransport extends AbstractApiTransport {
     // TODO: Not sure how to solve this type correctly.
     public name = 'NativeUsbTransport' as any;
+    public apiType = 'usb' as const;
 
     constructor(params: ConstructorParameters<typeof AbstractTransport>[0]) {
         const { logger, ...rest } = params;

--- a/packages/transport-native/src/nativeUsb.ts
+++ b/packages/transport-native/src/nativeUsb.ts
@@ -16,10 +16,4 @@ export class NativeUsbTransport extends AbstractApiTransport {
             ...rest,
         });
     }
-
-    public listen() {
-        this.api.listen();
-
-        return super.listen();
-    }
 }

--- a/packages/transport-native/src/nativeUsb.ts
+++ b/packages/transport-native/src/nativeUsb.ts
@@ -2,8 +2,7 @@ import { WebUSB } from '@trezor/react-native-usb';
 import { Transport as AbstractTransport, AbstractApiTransport, UsbApi } from '@trezor/transport';
 
 export class NativeUsbTransport extends AbstractApiTransport {
-    // TODO: Not sure how to solve this type correctly.
-    public name = 'NativeUsbTransport' as any;
+    public name = 'NativeUsbTransport' as const;
     public apiType = 'usb' as const;
 
     constructor(params: ConstructorParameters<typeof AbstractTransport>[0]) {

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -92,7 +92,9 @@ export abstract class AbstractTransport extends TransportEmitter {
         | 'BridgeTransport'
         | 'NodeUsbTransport'
         | 'WebUsbTransport'
-        | 'UdpTransport';
+        | 'UdpTransport'
+        | 'NativeUsbTransport' // implementation in @trezor/transport-native
+        | 'BluetoothTransport'; // implementation in @trezor/transport-bluetooth
 
     public abstract readonly apiType: TransportApiType;
     /**

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -85,12 +85,16 @@ class TransportEmitter extends TypedEmitter<{
         | typeof ERRORS.UNEXPECTED_ERROR;
 }> {}
 
+export type TransportApiType = 'usb' | 'udp' | 'bluetooth';
+
 export abstract class AbstractTransport extends TransportEmitter {
-    public abstract name:
+    public abstract readonly name:
         | 'BridgeTransport'
         | 'NodeUsbTransport'
         | 'WebUsbTransport'
         | 'UdpTransport';
+
+    public abstract readonly apiType: TransportApiType;
     /**
      * transports with "external element" such as bridge can be outdated.
      */

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -54,6 +54,8 @@ export abstract class AbstractApiTransport extends AbstractTransport {
             return this.error({ error: ERRORS.ALREADY_LISTENING });
         }
 
+        this.api.listen();
+
         this.listening = true;
 
         // 1. transport api reports descriptors change

--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -78,6 +78,7 @@ export class BridgeTransport extends AbstractTransport {
     private url: string;
 
     public name = 'BridgeTransport' as const;
+    public apiType = 'usb' as const;
 
     constructor(params: BridgeConstructorParameters) {
         const { url = DEFAULT_URL, latestVersion, ...rest } = params || {};

--- a/packages/transport/src/transports/nodeusb.browser.ts
+++ b/packages/transport/src/transports/nodeusb.browser.ts
@@ -6,6 +6,7 @@ import { empty, emptySync } from '../utils/resultEmpty';
 
 export class NodeUsbTransport extends AbstractTransport {
     public name = 'NodeUsbTransport' as const;
+    public apiType = 'usb' as const;
 
     constructor(params: AbstractTransportParams) {
         super(params);

--- a/packages/transport/src/transports/nodeusb.ts
+++ b/packages/transport/src/transports/nodeusb.ts
@@ -26,10 +26,4 @@ export class NodeUsbTransport extends AbstractApiTransport {
             ...rest,
         });
     }
-
-    public listen() {
-        this.api.listen();
-
-        return super.listen();
-    }
 }

--- a/packages/transport/src/transports/nodeusb.ts
+++ b/packages/transport/src/transports/nodeusb.ts
@@ -10,6 +10,7 @@ import { UsbApi } from '../api/usb';
 
 export class NodeUsbTransport extends AbstractApiTransport {
     public name = 'NodeUsbTransport' as const;
+    public apiType = 'usb' as const;
 
     constructor(params: AbstractTransportParams) {
         const { logger, debugLink, ...rest } = params;

--- a/packages/transport/src/transports/udp.browser.ts
+++ b/packages/transport/src/transports/udp.browser.ts
@@ -8,6 +8,7 @@ const emptySync = () => error({ error: WRONG_ENVIRONMENT });
 
 export class UdpTransport extends AbstractTransport {
     public name = 'UdpTransport' as const;
+    public apiType = 'udp' as const;
 
     init = empty;
     acquire = empty;

--- a/packages/transport/src/transports/udp.ts
+++ b/packages/transport/src/transports/udp.ts
@@ -17,12 +17,6 @@ export class UdpTransport extends AbstractApiTransport {
         });
     }
 
-    public listen() {
-        this.api.listen();
-
-        return super.listen();
-    }
-
     public stop() {
         if (this.enumerateTimeout) {
             clearTimeout(this.enumerateTimeout);

--- a/packages/transport/src/transports/udp.ts
+++ b/packages/transport/src/transports/udp.ts
@@ -4,6 +4,7 @@ import { AbstractApiTransport } from './abstractApi';
 
 export class UdpTransport extends AbstractApiTransport {
     public name = 'UdpTransport' as const;
+    public apiType = 'udp' as const;
     private enumerateTimeout: ReturnType<typeof setTimeout> | undefined;
 
     constructor(params: AbstractTransportParams) {

--- a/packages/transport/src/transports/webusb.browser.ts
+++ b/packages/transport/src/transports/webusb.browser.ts
@@ -15,6 +15,7 @@ type WebUsbTransportParams = AbstractTransportParams & { sessionsBackgroundUrl?:
  */
 export class WebUsbTransport extends AbstractApiTransport {
     public name = 'WebUsbTransport' as const;
+    public apiType = 'usb' as const;
 
     private readonly sessionsBackgroundUrl: string | null = defaultSessionsBackgroundUrl;
 

--- a/packages/transport/src/transports/webusb.browser.ts
+++ b/packages/transport/src/transports/webusb.browser.ts
@@ -62,10 +62,4 @@ export class WebUsbTransport extends AbstractApiTransport {
 
         return super.init({ signal });
     }
-
-    public listen() {
-        this.api.listen();
-
-        return super.listen();
-    }
 }

--- a/packages/transport/src/transports/webusb.ts
+++ b/packages/transport/src/transports/webusb.ts
@@ -5,6 +5,7 @@ import { empty, emptySync } from '../utils/resultEmpty';
 // this class loads in node environment only in case of accidental use of WebusbTransport
 export class WebUsbTransport extends AbstractTransport {
     public name = 'WebUsbTransport' as const;
+    public apiType = 'usb' as const;
 
     constructor(params: AbstractTransportParams) {
         super(params);

--- a/packages/transport/tests/abstractUsb.test.ts
+++ b/packages/transport/tests/abstractUsb.test.ts
@@ -41,6 +41,7 @@ const createUsbMock = (optional = {}) =>
 
 class TestUsbTransport extends AbstractApiTransport {
     public name = 'WebUsbTransport' as const;
+    public apiType = 'usb' as const;
 }
 
 // we cant directly use abstract class (UsbTransport)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Prerequisites for [multitransport](https://github.com/trezor/trezor-suite/pull/15324) and [bluetooth](https://github.com/trezor/trezor-suite/tree/feat/rust-bluetooth) branches.

1. add `apiType` to each transport
2. add missing (NativeUsbTransport) and new (BluetoothTransport) names to `Transport.name` type.
    both external names are excluded from the connect settings and cannot be used in `init` function, both needs to be provided as class
3.  remove `listen` duplicates from `AbstractApiTransport` implementations


To discuss **naming**.

`BluetoothTransport` seems to be too common, there will be `NativeBluetoothTransport` (?) or even `WebBluetoothTransport`.

maybe it should be called `RustBluetoothTransport`?
or maybe all three cases should be called  `BluetoothTransport` and `getVersion` would return the implementation/technology detail?
