### PR TITLE
fix(suite-native): navigate back to device settings if DAC is cancelled

### DIFF
--- a/suite-native/module-device-settings/src/components/DeviceAuthenticityCard.tsx
+++ b/suite-native/module-device-settings/src/components/DeviceAuthenticityCard.tsx
@@ -51,7 +51,7 @@ export const DeviceAuthenticityCard = () => {
             navigation.navigate(DeviceAuthenticityStackRoutes.AuthenticitySummary, {
                 checkResult: payload.valid ? 'successful' : 'compromised',
             });
-        } else {
+        } else if (payload.code === 'Failure_ActionCancelled') {
             navigation.goBack();
         }
     }, [navigation, device]);

--- a/suite-native/navigation/src/components/GoBackIcon.tsx
+++ b/suite-native/navigation/src/components/GoBackIcon.tsx
@@ -16,9 +16,7 @@ export const GoBackIcon = ({ closeActionType = 'back', closeAction }: GoBackIcon
         if (navigation.canGoBack()) {
             navigation.goBack();
         }
-        if (closeAction) {
-            closeAction();
-        }
+        closeAction?.();
     };
 
     return (


### PR DESCRIPTION
Tapping on the "X" close button in the app leads to calling `navigation.goBack()` (in `GoBackIcon`) and `TrezorConnect.cancel()` (in `DeviceInteractionScreenWrapper`) which aborts the `TrezorConnect.authenticateDevice()` call and `navigation.goBack()` is called **incorrectly** once more.

## Related Issue

#14617