### PR TITLE
fix(connect): FW revision check offline handling

### DIFF
--- a/packages/connect/src/device/checkFirmwareRevision.ts
+++ b/packages/connect/src/device/checkFirmwareRevision.ts
@@ -11,13 +11,21 @@ type GetOnlineReleaseMetadataParams = {
     internalModel: string;
 };
 
+const OFFLINE_ERROR = 'OFFLINE_ERROR';
+
 const getOnlineReleaseMetadata = async ({
     firmwareVersion,
     internalModel,
 }: GetOnlineReleaseMetadataParams): Promise<FirmwareRelease | undefined> => {
-    const onlineReleases = await downloadReleasesMetadata({ internal_model: internalModel });
+    try {
+        const onlineReleases = await downloadReleasesMetadata({ internal_model: internalModel });
 
-    return onlineReleases.find(onlineRelease => isEqual(onlineRelease.version, firmwareVersion));
+        return onlineReleases.find(onlineRelease =>
+            isEqual(onlineRelease.version, firmwareVersion),
+        );
+    } catch {
+        throw OFFLINE_ERROR;
+    }
 };
 
 const failFirmwareRevisionCheck = (
@@ -87,7 +95,7 @@ export const checkFirmwareRevision = async ({
 
             return { success: true };
         } catch (e) {
-            if (e.name === 'FetchError' && e.code === 'ENOTFOUND') {
+            if (e === OFFLINE_ERROR) {
                 return failFirmwareRevisionCheck('cannot-perform-check-offline');
             }
 


### PR DESCRIPTION
## Description

Fix handling of fetch errors when FW revision check encounters version not known locally.

You can test locally with user env `1-main | 2-main` and turning off Wi-Fi.
Or you can start a released emulator and delete the corresponding entry from `releases.json`, and try it with Wi-Fi on/off.

## Screenshots:

**Before:**
![other error](https://github.com/user-attachments/assets/8e3ec38c-6e79-43fa-8373-0c473a9bd445)

**After:**
![offline error](https://github.com/user-attachments/assets/ec134a28-a282-4057-9a88-dda218bb8881)