### PR TITLE
fix(tokens): Get correct contract address for token list context menu items

### DIFF
--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
@@ -132,7 +132,8 @@ export const TokenRow = ({
 
     const isReceiveButtonDisabled = isDeviceLocked || !!device.authConfirm;
 
-    const tokenCryptoId = toTokenCryptoId(account.symbol, token.contract.toLowerCase());
+    const contractAddress = getContractAddressForNetwork(account.symbol, token.contract);
+    const tokenCryptoId = toTokenCryptoId(account.symbol, contractAddress);
     const tokenTradingOptions = coins?.[tokenCryptoId]?.services;
 
     const canBuyToken = !!tokenTradingOptions && tokenTradingOptions.buy;


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Added call `getContractAddressForNetwork`. It was missing in the https://github.com/trezor/trezor-suite/pull/15128

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/15069
