### PR TITLE
feat(connect): retry FW hash check

### DIFF
--- a/packages/connect/src/constants/firmware.ts
+++ b/packages/connect/src/constants/firmware.ts
@@ -1,3 +1,13 @@
+import { FirmwareHashCheckError, FirmwareRevisionCheckError } from '../types';
+
 // given that firmware hash is a security feature, we prefer to hardcode the version rather than to query the device capabilities
 // (a counterfeit device could simply declare it's incapable of hash check)
 export const FW_HASH_SUPPORTED_VERSIONS = ['1.11.1', '2.5.1'];
+
+export const HASH_CHECK_MAX_ATTEMPTS = 3;
+
+export const HASH_CHECK_RETRIABLE_ERRORS = ['other-error'] satisfies FirmwareHashCheckError[];
+export const REVISION_CHECK_RETRIABLE_ERRORS = [
+    'cannot-perform-check-offline',
+    'other-error',
+] satisfies FirmwareRevisionCheckError[];

--- a/packages/connect/src/types/device.ts
+++ b/packages/connect/src/types/device.ts
@@ -65,8 +65,13 @@ export type FirmwareHashCheckError =
     | 'unknown-release'
     | 'other-error';
 export type FirmwareHashCheckResult =
-    | { success: true }
-    | { success: false; error: FirmwareHashCheckError; errorPayload?: unknown };
+    | { success: true; attemptCount?: number; warningPayload?: unknown }
+    | {
+          success: false;
+          error: FirmwareHashCheckError;
+          attemptCount?: number;
+          errorPayload?: unknown;
+      };
 
 export type DeviceUniquePath = string & { __type: 'DeviceUniquePath' };
 export const DeviceUniquePath = (id: string) => id as DeviceUniquePath;


### PR DESCRIPTION
## Description

- retry FW hash check if it ended up in `other-error`
  - max 3 attempts
  - if it succeeds within 3 attempts, suite sends warning to Sentry with `lastErrorPayload` and `attempts` count (no. of successful attempt)
- cleanup the connect getFeatures code a little bit (consistent boilerplate with revision check)

[See testing branch](https://github.com/trezor/trezor-suite/tree/feat/fw-hash-check-retry-TESTING) to play around with simulated retried check :wink: 

### Notes :thought_balloon: 

This implementation is kinda hacky - it relies on the fact that Suite does call `Device.run()` multiple times for whatever reasons. I put no mechanism in place to ensure that FW hash check is repeated after an `other-error`; repeating it is only a side effect _when_ Suite calls `Device.run()`. If Suite wouldn't call again, hash check wouldn't be retried.

I think that's ok at the moment - we're just collecting diagnostics for `other-error`, and no UI is bound to it. We might find out that the retries are no longer necessary and abandon them. But if we do need them, we'd need to either:
1) ensure Suite calls `Device.run()` until (success || max retries), or
2) recursively call `_runInner` in from `_runInner` until (success || max retries)
_(but then we'd need some timeout maybe? To ensure the calls are not spammed right after each other - that'd be really futile if device is busy)._

## Related Issue

Resolve https://github.com/trezor/trezor-suite-private/issues/120

## Screenshots:

suite log from testing branch
[debug branch suite.txt](https://github.com/user-attachments/files/17979107/debug.branch.suite.txt)

connect log from testing branch
[debug branch connect.txt](https://github.com/user-attachments/files/17979109/debug.branch.connect.txt)
