### PR TITLE
fix(suite-native): improve DAC error handling and report check result

### DIFF
--- a/suite-native/analytics/src/constants.ts
+++ b/suite-native/analytics/src/constants.ts
@@ -49,4 +49,5 @@ export enum EventType {
     SendTransactionDispatched = 'send/transaction_dispatched',
     SendFlowExited = 'send/flow_exited',
     DeviceSettingsPinProtectionChange = 'device_settings/pin_protection_change',
+    DeviceSettingsAuthenticityCheck = 'device_settings/authenticity_check',
 }

--- a/suite-native/analytics/src/events.ts
+++ b/suite-native/analytics/src/events.ts
@@ -5,7 +5,7 @@ import { FeeLevelLabel, TokenAddress, TokenSymbol } from '@suite-common/wallet-t
 import { DeviceModelInternal, VersionArray } from '@trezor/connect';
 
 import { EventType } from './constants';
-import { AnalyticsSendFlowStep } from './types';
+import { AnalyticsSendFlowStep, DeviceAuthenticityCheckResult } from './types';
 
 export type SuiteNativeAnalyticsEvent =
     | {
@@ -309,5 +309,11 @@ export type SuiteNativeAnalyticsEvent =
           type: EventType.DeviceSettingsPinProtectionChange;
           payload: {
               action: 'enable' | 'change' | 'disable';
+          };
+      }
+    | {
+          type: EventType.DeviceSettingsAuthenticityCheck;
+          payload: {
+              result: DeviceAuthenticityCheckResult;
           };
       };

--- a/suite-native/analytics/src/types.ts
+++ b/suite-native/analytics/src/types.ts
@@ -4,3 +4,5 @@ export type AnalyticsSendFlowStep =
     | 'address_review'
     | 'outputs_review'
     | 'destination_tag_review';
+
+export type DeviceAuthenticityCheckResult = 'successful' | 'compromised' | 'cancelled' | 'failed';


### PR DESCRIPTION
Any unexpected error results fall back to the compromised summary screen while check result is reported for all outcomes.

## Related Issue

#14617