### PR TITLE
fix(suite): Show full device section when sidebar is collapsed

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceStatus.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceStatus.tsx
@@ -13,14 +13,13 @@ import { TrezorDevice } from 'src/types/suite';
 import { DeviceDetail } from 'src/views/suite/SwitchDevice/DeviceItem/DeviceDetail';
 import { useSelector } from 'src/hooks/suite';
 
-import { ExpandedSidebarOnly } from '../Sidebar/ExpandedSidebarOnly';
-
 type DeviceStatusProps = {
     deviceModel: DeviceModelInternal;
     deviceNeedsRefresh?: boolean;
     device?: TrezorDevice;
     handleRefreshClick?: MouseEventHandler;
     forceConnectionInfo?: boolean;
+    isDeviceDetailVisible?: boolean;
 };
 
 const DeviceWrapper = styled.div<{ $isLowerOpacity: boolean }>`
@@ -35,6 +34,7 @@ export const DeviceStatus = ({
     device,
     handleRefreshClick,
     forceConnectionInfo = false,
+    isDeviceDetailVisible = true,
 }: DeviceStatusProps) => {
     const deviceLabel = useSelector(state => selectDeviceLabelOrNameById(state, device?.id));
 
@@ -49,17 +49,15 @@ export const DeviceStatus = ({
                 />
             </DeviceWrapper>
 
-            <ExpandedSidebarOnly>
-                {device && (
-                    <DeviceDetail label={deviceLabel}>
-                        <DeviceStatusText
-                            onRefreshClick={handleRefreshClick}
-                            device={device}
-                            forceConnectionInfo={forceConnectionInfo}
-                        />
-                    </DeviceDetail>
-                )}
-            </ExpandedSidebarOnly>
+            {isDeviceDetailVisible && device && (
+                <DeviceDetail label={deviceLabel}>
+                    <DeviceStatusText
+                        onRefreshClick={handleRefreshClick}
+                        device={device}
+                        forceConnectionInfo={forceConnectionInfo}
+                    />
+                </DeviceDetail>
+            )}
         </Row>
     );
 };

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/SidebarDeviceStatus.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/SidebarDeviceStatus.tsx
@@ -7,6 +7,7 @@ import { TrezorDevice } from 'src/types/suite';
 
 import { useDispatch, useSelector } from '../../../../../hooks/suite';
 import { DeviceStatus } from './DeviceStatus';
+import { useIsSidebarCollapsed } from '../Sidebar/utils';
 
 const needsRefresh = (device?: TrezorDevice) => {
     if (!device) return false;
@@ -24,6 +25,7 @@ export const SidebarDeviceStatus = () => {
     const selectedDevice = useSelector(selectDevice);
     const devices = useSelector(selectDevices);
     const dispatch = useDispatch();
+    const isSidebarCollapsed = useIsSidebarCollapsed();
 
     const deviceNeedsRefresh = needsRefresh(selectedDevice);
 
@@ -52,6 +54,7 @@ export const SidebarDeviceStatus = () => {
             device={selectedDevice}
             handleRefreshClick={handleRefreshClick}
             forceConnectionInfo={isConnectionShown}
+            isDeviceDetailVisible={!isSidebarCollapsed}
         />
     );
 };

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/CollapsedSidebarOnly.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/CollapsedSidebarOnly.tsx
@@ -1,16 +1,14 @@
 import React from 'react';
 
-import { SIDEBAR_COLLAPSED_WIDTH } from './consts';
-import { useResponsiveContext } from '../../../../../support/suite/ResponsiveContext';
+import { useIsSidebarCollapsed } from './utils';
 
 type Props = {
     children: React.ReactNode;
 };
 
 export const CollapsedSidebarOnly = ({ children }: Props) => {
-    const { sidebarWidth } = useResponsiveContext();
-
-    if (sidebarWidth && sidebarWidth >= SIDEBAR_COLLAPSED_WIDTH) return null;
+    const isSidebarCollapsed = useIsSidebarCollapsed();
+    if (!isSidebarCollapsed) return null;
 
     return children;
 };

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/ExpandedSidebarOnly.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/ExpandedSidebarOnly.tsx
@@ -1,16 +1,14 @@
 import React from 'react';
 
-import { SIDEBAR_COLLAPSED_WIDTH } from './consts';
-import { useResponsiveContext } from '../../../../../support/suite/ResponsiveContext';
+import { useIsSidebarCollapsed } from './utils';
 
 type Props = {
     children: React.ReactNode;
 };
 
 export const ExpandedSidebarOnly = ({ children }: Props) => {
-    const { sidebarWidth } = useResponsiveContext();
-
-    if (sidebarWidth && sidebarWidth < SIDEBAR_COLLAPSED_WIDTH) return null;
+    const isSidebarCollapsed = useIsSidebarCollapsed();
+    if (isSidebarCollapsed) return null;
 
     return children;
 };

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/utils.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/utils.ts
@@ -1,0 +1,9 @@
+import { SIDEBAR_COLLAPSED_WIDTH } from './consts';
+import { useResponsiveContext } from '../../../../../support/suite/ResponsiveContext';
+
+export const useIsSidebarCollapsed = () => {
+    const { sidebarWidth } = useResponsiveContext();
+    if (!sidebarWidth) return undefined;
+
+    return sidebarWidth < SIDEBAR_COLLAPSED_WIDTH;
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/15682

## Screenshots:

before
<img width="577" alt="Screenshot 2024-12-02 at 15 03 44" src="https://github.com/user-attachments/assets/7dc7bde7-6034-4a92-9584-ba0974a9df7d">

after
<img width="453" alt="image" src="https://github.com/user-attachments/assets/5070bc7d-b0a0-4d4a-9ac6-9c1e53dea5d3">

