### PR TITLE
Run e2e tests against emulator from URL or firmware branch

### DIFF
--- a/docker/docker-compose.connect-popup-ci.yml
+++ b/docker/docker-compose.connect-popup-ci.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:c637c2f58e799284f6019481fa0de30457bd6b60
+    image: ghcr.io/trezor/trezor-user-env:36dfd1174f56dde0b0b85b3acd927bfda4a63043
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.connect-popup-test.yml
+++ b/docker/docker-compose.connect-popup-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:c637c2f58e799284f6019481fa0de30457bd6b60
+    image: ghcr.io/trezor/trezor-user-env:36dfd1174f56dde0b0b85b3acd927bfda4a63043
     environment:
       - DISPLAY=$DISPLAY
       - QT_X11_NO_MITSHM=1

--- a/docker/docker-compose.connect-test.yml
+++ b/docker/docker-compose.connect-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:c637c2f58e799284f6019481fa0de30457bd6b60
+    image: ghcr.io/trezor/trezor-user-env:36dfd1174f56dde0b0b85b3acd927bfda4a63043
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.connect-webextension-test.yml
+++ b/docker/docker-compose.connect-webextension-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:c637c2f58e799284f6019481fa0de30457bd6b60
+    image: ghcr.io/trezor/trezor-user-env:36dfd1174f56dde0b0b85b3acd927bfda4a63043
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-ci.yml
+++ b/docker/docker-compose.suite-ci.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:c637c2f58e799284f6019481fa0de30457bd6b60
+    image: ghcr.io/trezor/trezor-user-env:36dfd1174f56dde0b0b85b3acd927bfda4a63043
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-desktop-ci.yml
+++ b/docker/docker-compose.suite-desktop-ci.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:c637c2f58e799284f6019481fa0de30457bd6b60
+    image: ghcr.io/trezor/trezor-user-env:36dfd1174f56dde0b0b85b3acd927bfda4a63043
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-dev.yml
+++ b/docker/docker-compose.suite-dev.yml
@@ -4,7 +4,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:c637c2f58e799284f6019481fa0de30457bd6b60
+    image: ghcr.io/trezor/trezor-user-env:36dfd1174f56dde0b0b85b3acd927bfda4a63043
     environment:
       - DISPLAY=$DISPLAY
       - QT_X11_NO_MITSHM=1

--- a/docker/docker-compose.suite-native-ci.yml
+++ b/docker/docker-compose.suite-native-ci.yml
@@ -3,7 +3,7 @@ services:
   trezor-user-env-unix:
     network_mode: "host"
     container_name: trezor-user-env.unix
-    image: ghcr.io/trezor/trezor-user-env:c637c2f58e799284f6019481fa0de30457bd6b60
+    image: ghcr.io/trezor/trezor-user-env:36dfd1174f56dde0b0b85b3acd927bfda4a63043
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-test.yml
+++ b/docker/docker-compose.suite-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:c637c2f58e799284f6019481fa0de30457bd6b60
+    image: ghcr.io/trezor/trezor-user-env:36dfd1174f56dde0b0b85b3acd927bfda4a63043
     environment:
       - DISPLAY=$DISPLAY
       - QT_X11_NO_MITSHM=1

--- a/docker/docker-compose.transport-test-ci.yml
+++ b/docker/docker-compose.transport-test-ci.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:c637c2f58e799284f6019481fa0de30457bd6b60
+    image: ghcr.io/trezor/trezor-user-env:36dfd1174f56dde0b0b85b3acd927bfda4a63043
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-connect-test.sh
+++ b/docker/docker-connect-test.sh
@@ -35,6 +35,8 @@ show_usage() {
   echo "  -e       All methods except excluded, example: applySettings,signTransaction"
   echo "  -p       Test pattern"
   echo "  -f       Use specific firmware version, example: 2.1.4, 1.8.0 default: -main"
+  echo "  -b       Use specific firmware branch"
+  echo "  -o       Use BTC-only firmware of the specified branch"
   echo "  -i       Included methods only, example: applySettings,signTransaction"
   echo "  -s       actual test script. default: 'yarn test:integration'"
   echo "  -u       Firmware url"
@@ -46,6 +48,8 @@ show_usage() {
 # default options
 FIRMWARE=""
 FIRMWARE_URL=""
+FIRMWARE_BRANCH=""
+FIRMWARE_BTC_ONLY=false
 INCLUDED_METHODS=""
 EXCLUDED_METHODS=""
 DOCKER=true
@@ -59,7 +63,7 @@ TRANSPORT="2.0.33"
 # echo $OPTARG
 # user options
 OPTIND=2
-while getopts ":p:i:e:f:u:m:t:hdcr" opt; do
+while getopts ":p:i:e:f:b:u:m:t:hdcro" opt; do
   case $opt in
   d)
     DOCKER=false
@@ -70,6 +74,9 @@ while getopts ":p:i:e:f:u:m:t:hdcr" opt; do
     ;;
   f)
     FIRMWARE=$OPTARG
+    ;;
+  b)
+    FIRMWARE_BRANCH=$OPTARG
     ;;
   u)
     FIRMWARE_URL=$OPTARG
@@ -82,6 +89,9 @@ while getopts ":p:i:e:f:u:m:t:hdcr" opt; do
     ;;
   p)
     PATTERN=$OPTARG
+    ;;
+  o)
+    FIRMWARE_BTC_ONLY=true
     ;;
   m)
     FIRMWARE_MODEL=$OPTARG
@@ -110,6 +120,11 @@ else
   SCRIPT="yarn workspace @trezor/connect test:e2e:web"
 fi
 
+if [[ $FIRMWARE_BTC_ONLY == true && -z $FIRMWARE_BRANCH ]]; then
+  echo "BTC-only firmware requires a branch to be specified"
+  exit 1
+fi
+
 # export essential process.env variables
 export TESTS_FIRMWARE=$FIRMWARE
 export TESTS_INCLUDED_METHODS=$INCLUDED_METHODS
@@ -119,6 +134,8 @@ export TESTS_USE_WS_CACHE=$USE_WS_CACHE
 export TESTS_PATTERN=$PATTERN
 export TESTS_SCRIPT=$SCRIPT
 export TESTS_FIRMWARE_URL=$FIRMWARE_URL
+export TESTS_FIRMWARE_BRANCH=$FIRMWARE_BRANCH
+export TESTS_FIRMWARE_BTC_ONLY=$FIRMWARE_BTC_ONLY
 export TESTS_FIRMWARE_MODEL=$FIRMWARE_MODEL
 export TESTS_RANDOM=$RANDOMIZE
 export TESTS_TRANSPORT=$TRANSPORT
@@ -133,6 +150,8 @@ run() {
   echo "  Firmware: ${TESTS_FIRMWARE}"
   echo "  Firmware model: ${TESTS_FIRMWARE_MODEL}"
   echo "  Firmware from url: ${FIRMWARE_URL}"
+  echo "  Firmware from branch: ${FIRMWARE_BRANCH}"
+  echo "  Firmware BTC-only: ${FIRMWARE_BTC_ONLY}"
   echo "  Test pattern: $PATTERN"
   echo "  Included methods: ${INCLUDED_METHODS}"
   echo "  Excluded methods: ${EXCLUDED_METHODS}"

--- a/packages/connect/e2e/common.setup.ts
+++ b/packages/connect/e2e/common.setup.ts
@@ -2,7 +2,7 @@ import { versionUtils } from '@trezor/utils';
 import {
     TrezorUserEnvLink,
     type TrezorUserEnvLinkClass,
-    StartEmu,
+    EmuStartOptsType,
     MNEMONICS,
 } from '@trezor/trezor-user-env-link';
 import { ApplySettings } from '@trezor/protobuf/src/messages-schema';
@@ -10,14 +10,37 @@ import { ApplySettings } from '@trezor/protobuf/src/messages-schema';
 import { UI } from '../src/events';
 import TrezorConnect from '../src';
 
-const emulatorStartOpts =
-    (process.env.emulatorStartOpts as StartEmu) || global.emulatorStartOpts || {};
+const emulatorStartOpts: EmuStartOptsType =
+    (process.env.emulatorStartOpts as any) || global.emulatorStartOpts || {};
 
-const firmware = emulatorStartOpts.version;
+const emuStartType = emulatorStartOpts.type;
+const firmware: string | null =
+    'version' in emulatorStartOpts ? emulatorStartOpts.version || null : null;
 const deviceModel = emulatorStartOpts.model;
 
-if (!firmware || !deviceModel) {
-    throw new Error('Firmware and device model must be provided');
+if (!deviceModel) {
+    throw new Error('Device model must be provided');
+}
+
+switch (emuStartType) {
+    case 'emulator-start':
+    case undefined:
+        if (!firmware) {
+            throw new Error('Firmware version must be provided');
+        }
+        break;
+    case 'emulator-start-from-url':
+        if (!emulatorStartOpts.url) {
+            throw new Error('URL must be provided');
+        }
+        break;
+    case 'emulator-start-from-branch':
+        if (!emulatorStartOpts.branch) {
+            throw new Error('Branch must be provided');
+        }
+        break;
+    default:
+        throw new Error('Unknown emulator start type');
 }
 
 export const getController = () => {
@@ -55,7 +78,20 @@ export const setup = async (
 
     if (!options?.mnemonic && !options.wiped) return true; // skip setup if test is not using the device (composeTransaction)
 
-    await TrezorUserEnvLink.startEmu(emulatorStartOpts);
+    switch (emuStartType) {
+        case 'emulator-start':
+        case undefined:
+            await TrezorUserEnvLink.startEmu(emulatorStartOpts);
+            break;
+        case 'emulator-start-from-url':
+            await TrezorUserEnvLink.startEmuFromUrl(emulatorStartOpts);
+            break;
+        case 'emulator-start-from-branch':
+            await TrezorUserEnvLink.startEmuFromBranch(emulatorStartOpts);
+            break;
+        default:
+            throw new Error('Unknown emulator start type');
+    }
 
     if (!options.wiped) {
         const mnemonic = options.mnemonic || MNEMONICS.mnemonic_all;
@@ -152,6 +188,7 @@ export const initTrezorConnect = async (
 // "!T3T1" - skip for specific device model
 export const skipTest = (rules: string[]) => {
     if (!rules || !Array.isArray(rules)) return;
+    if (!firmware) return;
     const fwModel = firmware.substring(0, 1);
     const fwMaster = firmware.includes('-main');
     const deviceRule = rules.find(skip => skip === '!' + deviceModel);

--- a/packages/connect/e2e/run.ts
+++ b/packages/connect/e2e/run.ts
@@ -3,13 +3,20 @@ import { runCLI, getVersion as getJestVersion } from 'jest';
 import webpack from 'webpack';
 import karma from 'karma';
 
-import { TrezorUserEnvLink, Firmwares, Model } from '@trezor/trezor-user-env-link';
+import {
+    TrezorUserEnvLink,
+    Firmwares,
+    Model,
+    EmuStartOptsType,
+} from '@trezor/trezor-user-env-link';
 
 import argv from './jest.config';
 
 const firmwareArg = process.env.TESTS_FIRMWARE;
 const firmwareUrl = process.env.TESTS_FIRMWARE_URL;
 const firmwareModel = process.env.TESTS_FIRMWARE_MODEL;
+const firmwareBranch = process.env.TESTS_FIRMWARE_BRANCH;
+const firmwareBtcOnly = process.env.TESTS_FIRMWARE_BTC_ONLY === 'true';
 
 /**
  * Translate test command arguments into trezor-user-env options.
@@ -30,25 +37,36 @@ const getEmulatorOptions = (availableFirmwares: Firmwares) => {
         throw new Error('could not translate n-latest into specific firmware version');
     }
 
-    const emulatorStartOpts = {
-        type: 'emulator-start',
-        wipe: true,
-        version: firmwareArg,
-        model,
-    };
+    let emulatorStartOpts: EmuStartOptsType;
 
-    if (firmwareArg?.endsWith('-latest')) {
-        Object.assign(emulatorStartOpts, { version: latest });
-    }
-    // no firmwareArg and not loading from url at the same time - provide fallback
-    if (!firmwareArg && !firmwareUrl) {
-        Object.assign(emulatorStartOpts, { version: latest });
-    }
     if (firmwareUrl) {
-        Object.assign(emulatorStartOpts, {
+        emulatorStartOpts = {
             type: 'emulator-start-from-url',
             url: firmwareUrl,
-        });
+            wipe: true,
+            model,
+        };
+    } else if (firmwareBranch) {
+        emulatorStartOpts = {
+            type: 'emulator-start-from-branch',
+            branch: firmwareBranch,
+            btcOnly: firmwareBtcOnly,
+            wipe: true,
+            model,
+        };
+    } else {
+        let version;
+        if (firmwareArg) {
+            version = firmwareArg.endsWith('-latest') ? latest : firmwareArg;
+        } else {
+            version = latest;
+        }
+        emulatorStartOpts = {
+            type: 'emulator-start',
+            wipe: true,
+            version,
+            model,
+        };
     }
 
     return emulatorStartOpts;
@@ -67,7 +85,6 @@ const getEmulatorOptions = (availableFirmwares: Firmwares) => {
 
     argv.globals = {
         emulatorStartOpts,
-        firmware: emulatorStartOpts.version,
     };
 
     // @ts-expect-error there is some mismatch between jest implementation and definitely typed package.
@@ -109,8 +126,6 @@ const getEmulatorOptions = (availableFirmwares: Firmwares) => {
                 // @ts-expect-error
                 karmaConfig.webpack.plugins.push(
                     new webpack.DefinePlugin({
-                        // @ts-expect-error
-                        'process.env.firmware': JSON.stringify(argv.globals.firmware),
                         'process.env.emulatorStartOpts': JSON.stringify(
                             // @ts-expect-error
                             argv.globals.emulatorStartOpts,

--- a/packages/trezor-user-env-link/src/api.ts
+++ b/packages/trezor-user-env-link/src/api.ts
@@ -22,9 +22,35 @@ export interface StartEmu {
     model?: Model;
 }
 
-interface StartEmuFromUrl extends Omit<StartEmu, 'version'> {
-    url: string;
+interface StartEmuType {
+    type: 'emulator-start';
+    version?: string;
+    wipe: boolean;
+    model: Model;
 }
+
+interface StartEmuFromUrl {
+    url: string;
+    model: Model;
+    wipe: boolean;
+}
+
+interface StartEmuFromUrlType extends StartEmuFromUrl {
+    type: 'emulator-start-from-url';
+}
+
+interface StartEmuFromBranch {
+    branch: string;
+    btcOnly: boolean;
+    model: Model;
+    wipe: boolean;
+}
+
+interface StartEmuFromBranchType extends StartEmuFromBranch {
+    type: 'emulator-start-from-branch';
+}
+
+export type EmuStartOptsType = StartEmuType | StartEmuFromUrlType | StartEmuFromBranchType;
 
 interface ClickEmu {
     x: number;
@@ -189,13 +215,26 @@ export class TrezorUserEnvLinkClass extends TypedEmitter<WebsocketClientEvents> 
 
         return null;
     }
-    startEmuFromUrl({ url, model, wipe }: StartEmuFromUrl) {
-        return this.client.send({
+    async startEmuFromUrl({ url, model, wipe }: StartEmuFromUrl) {
+        await this.client.send({
             type: 'emulator-start-from-url',
             url,
             model,
             wipe,
         });
+
+        return null;
+    }
+    async startEmuFromBranch({ branch, btcOnly = false, model, wipe }: StartEmuFromBranch) {
+        await this.client.send({
+            type: 'emulator-start-from-branch',
+            branch,
+            btc_only: btcOnly,
+            model,
+            wipe,
+        });
+
+        return null;
     }
 
     async stopEmu() {

--- a/packages/trezor-user-env-link/src/websocket-client.ts
+++ b/packages/trezor-user-env-link/src/websocket-client.ts
@@ -35,6 +35,14 @@ export type WebsocketClientEvents = {
     disconnected: () => void;
 };
 
+interface WebsocketRequest {
+    type: string;
+}
+
+interface WebsocketResponse {
+    response: any;
+}
+
 export class WebsocketClient extends TypedEmitter<WebsocketClientEvents> {
     private messageID: number;
     private options: Options;
@@ -111,8 +119,7 @@ export class WebsocketClient extends TypedEmitter<WebsocketClientEvents> {
         this.dispose();
     }
 
-    // todo: typesafe interface
-    async send(params: any) {
+    async send<T extends WebsocketRequest>(params: T): Promise<WebsocketResponse> {
         // probably after update to node 18 it started to disconnect after certain
         // period of inactivity.
         await this.connect();
@@ -134,7 +141,6 @@ export class WebsocketClient extends TypedEmitter<WebsocketClientEvents> {
 
         ws.send(JSON.stringify(req));
 
-        // todo: proper return type
         return dfd.promise;
     }
 


### PR DESCRIPTION
Allow for running `e2e` tests not only with emulators hardcoded in `tenv`, but also from:
- specified URL
- firmware branch

The way of running these is either:
- hardcoding these in `packages/connect/e2e/run.ts`: 
```ts
const firmwareArg = process.env.TESTS_FIRMWARE;
const firmwareUrl = process.env.TESTS_FIRMWARE_URL;
const firmwareModel = process.env.TESTS_FIRMWARE_MODEL;
const firmwareBranch = process.env.TESTS_FIRMWARE_BRANCH;
const firmwareBtcOnly = process.env.TESTS_FIRMWARE_BTC_ONLY === 'true';
```
- setting ENV variable when spawning the tests:
```sh
TESTS_FIRMWARE_MODEL="T3T1" TESTS_FIRMWARE_URL="https://data.trezor.io/dev/firmware/emu-branches/grdddj/emulator_upload_all_branches/trezor-emu-core-T3T1-universal" yarn workspace @trezor/connect-web test:e2e:node
TESTS_FIRMWARE_MODEL="T3T1" TESTS_FIRMWARE_BRANCH="obrusvit/refactor-confirm-summary" TESTS_FIRMWARE_BTC_ONLY="true" yarn workspace @trezor/connect-web test:e2e:node

```

NOTE: for local development, emulators from branches do not support `ARM`, so it will work for you only in CI