### PR TITLE
Warn about device going to be wiped when updating from 1.6.1

### DIFF
--- a/packages/device-utils/src/firmwareUtils.ts
+++ b/packages/device-utils/src/firmwareUtils.ts
@@ -1,7 +1,7 @@
 import { FirmwareType, VersionArray } from '@trezor/connect';
 
 import { isDeviceInBootloaderMode } from './modeUtils';
-import { PartialDevice } from './types';
+import { FirmwareVersionString, PartialDevice } from './types';
 
 export const getFirmwareRevision = (device?: PartialDevice) => device?.features?.revision || '';
 
@@ -20,9 +20,7 @@ export const getFirmwareVersionArray = (device?: PartialDevice): VersionArray | 
     return [features.major_version, features.minor_version, features.patch_version];
 };
 
-export const getFirmwareVersion = (
-    device?: PartialDevice,
-): '' | `${number}.${number}.${number}` => {
+export const getFirmwareVersion = (device?: PartialDevice): '' | FirmwareVersionString => {
     if (!device?.features) {
         return '';
     }

--- a/packages/device-utils/src/types.ts
+++ b/packages/device-utils/src/types.ts
@@ -4,3 +4,5 @@ export type PartialDevice = {
     features?: Device['features'];
     firmwareType?: Device['firmwareType'];
 };
+
+export type FirmwareVersionString = `${number}.${number}.${number}`;

--- a/packages/suite-data/files/translations/en.json
+++ b/packages/suite-data/files/translations/en.json
@@ -1044,7 +1044,7 @@
   "TR_FIRMWARE_SUBHEADING_NONE_BITCOIN_ONLY_DEVICE": "Your device is ready for the latest firmware in order to be used safely. For Bitcoin enthusiasts, a Bitcoin-only firmware is available.",
   "TR_FIRMWARE_SUBHEADING_UNKNOWN": "Your Trezor is shipped without firmware. Install the latest firmware in order to use your device safely. For Bitcoin-only users, we recommend installing <button>{bitcoinOnly} firmware</button>.",
   "TR_FIRMWARE_SUBHEADING_UNKNOWN_BITCOIN_ONLY_DEVICE": "A lightweight firmware supporting Bitcoin-only operations.",
-  "TR_FIRMWARE_SWITCH_WARNING_1": "Switching firmware <b>wipes all your device data</b>, including wallets, keys, and accounts.",
+  "TR_FIRMWARE_SWITCH_WARNING_1": "This action will <b>wipe all your device data</b>, including wallets, keys, and accounts.",
   "TR_FIRMWARE_SWITCH_WARNING_2": "To regain access to your coins, you must <b>recover your wallet using your wallet backup</b>. Ensure your wallet backup is accessible and legible.",
   "TR_FIRMWARE_SWITCH_WARNING_3": "If you don't have your wallet backup, there's no way to recover your coins!",
   "TR_FIRMWARE_TYPE": "Type",

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -4645,7 +4645,7 @@ export default defineMessagesWithTypeCheck({
     TR_FIRMWARE_SWITCH_WARNING_1: {
         id: 'TR_FIRMWARE_SWITCH_WARNING_1',
         defaultMessage:
-            'Switching firmware <b>wipes all your device data</b>, including wallets, keys, and accounts.',
+            'This action will <b>wipe all your device data</b>, including wallets, keys, and accounts.',
     },
     TR_FIRMWARE_SWITCH_WARNING_2: {
         id: 'TR_FIRMWARE_SWITCH_WARNING_2',

--- a/packages/suite/src/types/onboarding/index.ts
+++ b/packages/suite/src/types/onboarding/index.ts
@@ -1,11 +1,12 @@
 import { DeviceModelInternal } from '@trezor/connect';
+import { FirmwareVersionString } from '@trezor/device-utils/src/types';
 
 import * as STEP from 'src/constants/onboarding/steps';
 import { PrerequisiteType } from 'src/utils/suite/prerequisites';
 
 type ModelWithFirmwareVersion = {
     model: DeviceModelInternal;
-    minFwVersion: `${number}.${number}.${number}`;
+    minFwVersion: FirmwareVersionString;
 };
 
 export type Step = {


### PR DESCRIPTION
## Description

I deviated from the specification a bit, I found making the copy more general is more straightforward. [Crowdin](https://crowdin.com/editor/trezor-suite/103/en-en?view=comfortable&filter=basic&value=0#q=TR_FIRMWARE_SWITCH_WARNING_1) updated.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/15630

## Screenshots:
