### PR TITLE
Enable Solana on mobile via message system feature

### DIFF
--- a/suite-common/message-system/src/messageSystemSelectors.ts
+++ b/suite-common/message-system/src/messageSystemSelectors.ts
@@ -4,7 +4,7 @@ import { Message, Category } from '@suite-common/suite-types';
 import { ContextDomain, FeatureDomain, MessageSystemRootState } from './messageSystemTypes';
 
 // Create app-specific selectors with correct types
-const createMemoizedSelector = createWeakMapSelector.withTypes<MessageSystemRootState>();
+export const createMemoizedSelector = createWeakMapSelector.withTypes<MessageSystemRootState>();
 
 // Basic selectors don't need memoization
 export const selectMessageSystemConfig = (state: MessageSystemRootState) =>

--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -24,6 +24,7 @@ export const Feature = {
     ethClaim: 'eth.staking.claim',
     firmwareRevisionCheck: 'security.firmware.check',
     firmwareHashCheck: 'security.firmware.hashCheck',
+    solanaMobile: 'mobile.solana',
 } as const;
 
 export type FeatureDomain = (typeof Feature)[keyof typeof Feature];

--- a/suite-native/app/src/App.tsx
+++ b/suite-native/app/src/App.tsx
@@ -10,7 +10,7 @@ import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 import { selectIsAppReady, selectIsConnectInitialized, StoreProvider } from '@suite-native/state';
 import { FormatterProvider } from '@suite-common/formatters';
 import { NavigationContainerWithAnalytics } from '@suite-native/navigation';
-import { FeatureMessageScreen, MessageSystemBannerRenderer } from '@suite-native/message-system';
+import { KillswitchMessageScreen, MessageSystemBannerRenderer } from '@suite-native/message-system';
 import { configureNetInfo, OfflineBanner } from '@suite-native/connection-status';
 import { IntlProvider } from '@suite-native/intl';
 import { isDebugEnv } from '@suite-native/config';
@@ -71,7 +71,7 @@ const AppComponent = () => {
             </BottomSheetModalProvider>
             <ModalsRenderer />
             {/* NOTE: Rendered as last item so that it covers the whole app screen */}
-            <FeatureMessageScreen />
+            <KillswitchMessageScreen />
         </FormatterProvider>
     );
 };

--- a/suite-native/discovery/src/discoverySelectors.ts
+++ b/suite-native/discovery/src/discoverySelectors.ts
@@ -27,6 +27,7 @@ import { TokenAddress, TokenSymbol } from '@suite-common/wallet-types';
 import { isFirmwareVersionSupported } from '@suite-native/device';
 import { FeatureFlagsRootState } from '@suite-native/feature-flags';
 import { StaticSessionId } from '@trezor/connect';
+import { MessageSystemRootState } from '@suite-common/message-system';
 
 import {
     DiscoveryConfigSliceRootState,
@@ -106,7 +107,8 @@ export const selectNetworksWithUnfinishedDiscovery = (
     state: DeviceRootState &
         AccountsRootState &
         FeatureFlagsRootState &
-        DiscoveryConfigSliceRootState,
+        DiscoveryConfigSliceRootState &
+        MessageSystemRootState,
     forcedAreTestnetsEnabled?: boolean,
     availableCardanoDerivations?: AccountType[],
 ) => {
@@ -132,7 +134,8 @@ export const selectShouldRunDiscoveryForDevice = (
     state: DeviceRootState &
         AccountsRootState &
         FeatureFlagsRootState &
-        DiscoveryConfigSliceRootState,
+        DiscoveryConfigSliceRootState &
+        MessageSystemRootState,
 ) => {
     // no discovery for PortfolioTracker ever
     const isPortfolioTrackerDevice = selectIsPortfolioTrackerDevice(state);

--- a/suite-native/feature-flags/src/featureFlagsSlice.ts
+++ b/suite-native/feature-flags/src/featureFlagsSlice.ts
@@ -6,7 +6,6 @@ import { isDebugEnv, isDetoxTestBuild, isDevelopOrDebugEnv } from '@suite-native
 export const FeatureFlag = {
     IsDeviceConnectEnabled: 'isDeviceConnectEnabled',
     IsCardanoSendEnabled: 'isCardanoSendEnabled',
-    IsSolanaSendEnabled: 'isSolanaSendEnabled',
     IsRegtestEnabled: 'isRegtestEnabled',
     IsSolanaEnabled: 'IsSolanaEnabled',
     IsConnectPopupEnabled: 'IsConnectPopupEnabled',
@@ -22,7 +21,6 @@ export type FeatureFlagsRootState = {
 export const featureFlagsInitialState: FeatureFlagsState = {
     [FeatureFlag.IsDeviceConnectEnabled]: isAndroid() || isDebugEnv(),
     [FeatureFlag.IsCardanoSendEnabled]: isAndroid() && isDevelopOrDebugEnv(),
-    [FeatureFlag.IsSolanaSendEnabled]: isAndroid() && isDevelopOrDebugEnv(),
     [FeatureFlag.IsRegtestEnabled]: isDebugEnv() || isDetoxTestBuild(),
     [FeatureFlag.IsSolanaEnabled]: false,
     [FeatureFlag.IsConnectPopupEnabled]: isDevelopOrDebugEnv(),
@@ -31,7 +29,6 @@ export const featureFlagsInitialState: FeatureFlagsState = {
 export const featureFlagsPersistedKeys: Array<keyof FeatureFlagsState> = [
     FeatureFlag.IsDeviceConnectEnabled,
     FeatureFlag.IsCardanoSendEnabled,
-    FeatureFlag.IsSolanaSendEnabled,
     FeatureFlag.IsRegtestEnabled,
     FeatureFlag.IsSolanaEnabled,
     FeatureFlag.IsConnectPopupEnabled,

--- a/suite-native/message-system/src/components/KillswitchMessageScreen.tsx
+++ b/suite-native/message-system/src/components/KillswitchMessageScreen.tsx
@@ -5,8 +5,11 @@ import { A, G } from '@mobily/ts-belt';
 import { Box, Button, PictogramTitleHeader, VStack } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { messageSystemActions, selectActiveFeatureMessages } from '@suite-common/message-system';
+import { Variant } from '@suite-common/suite-types';
 import { Translation } from '@suite-native/intl';
 import { useOpenLink } from '@suite-native/link';
+
+import { selectActiveKillswitchMessages } from '../selectors';
 
 const screenStyle = prepareNativeStyle(utils => ({
     flexGrow: 1,
@@ -36,12 +39,11 @@ export const FeatureMessageScreen = () => {
     const dispatch = useDispatch();
     const openLink = useOpenLink();
 
-    const activeFeatureMessages = useSelector(selectActiveFeatureMessages);
-    const firstFeatureMessage = A.head(activeFeatureMessages);
+    const killswitch = A.head(useSelector(selectActiveKillswitchMessages));
 
     const { applyStyle } = useNativeStyles();
 
-    if (!firstFeatureMessage) return null;
+    if (!killswitch) return null;
 
     const {
         id: messageId,
@@ -49,14 +51,9 @@ export const FeatureMessageScreen = () => {
         headline,
         content,
         cta,
-        dismissible: isDismissable,
+        dismissible: isDismissible,
         category,
-        feature,
-    } = firstFeatureMessage;
-
-    const isKillswitch = A.isNotEmpty(
-        feature?.filter(item => item.domain === 'killswitch' && item.flag) ?? [],
-    );
+    } = killswitch;
 
     // TODO: We use only English locale in suite-native so far. When the localization to other
     // languages is implemented, the language selection logic has to be added here.
@@ -77,7 +74,7 @@ export const FeatureMessageScreen = () => {
     const isCtaVisible = ctaLabel && ctaLink;
 
     const handleDismiss = () => {
-        if (!isDismissable) return;
+        if (!isDismissible) return;
 
         const categories = G.isArray(category) ? category : [category];
         categories.forEach(item => {
@@ -90,20 +87,15 @@ export const FeatureMessageScreen = () => {
         });
     };
 
-    const defaultTitle = isKillswitch ? (
-        <Translation id="messageSystem.killswitch.title" />
-    ) : undefined;
-    const defaultContent = isKillswitch ? (
-        <Translation id="messageSystem.killswitch.content" />
-    ) : undefined;
-
     return (
         <Box style={applyStyle(screenStyle)}>
             <Box style={applyStyle(contentStyle)}>
                 <PictogramTitleHeader
                     variant={variant}
-                    title={messageTitle ?? defaultTitle}
-                    subtitle={messageContent ?? defaultContent}
+                    title={messageTitle ?? <Translation id="messageSystem.killswitch.title" />}
+                    subtitle={
+                        messageContent ?? <Translation id="messageSystem.killswitch.content" />
+                    }
                     titleVariant="titleMedium"
                 />
             </Box>
@@ -113,7 +105,7 @@ export const FeatureMessageScreen = () => {
                         {ctaLabel}
                     </Button>
                 )}
-                {isDismissable && (
+                {isDismissible && (
                     <Button size="large" colorScheme="tertiaryElevation0" onPress={handleDismiss}>
                         <Translation id="generic.buttons.dismiss" />
                     </Button>

--- a/suite-native/message-system/src/components/KillswitchMessageScreen.tsx
+++ b/suite-native/message-system/src/components/KillswitchMessageScreen.tsx
@@ -1,15 +1,14 @@
 import { useDispatch, useSelector } from 'react-redux';
 
-import { A, G } from '@mobily/ts-belt';
+import { G } from '@mobily/ts-belt';
 
 import { Box, Button, PictogramTitleHeader, VStack } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
-import { messageSystemActions, selectActiveFeatureMessages } from '@suite-common/message-system';
-import { Variant } from '@suite-common/suite-types';
+import { messageSystemActions } from '@suite-common/message-system';
 import { Translation } from '@suite-native/intl';
 import { useOpenLink } from '@suite-native/link';
 
-import { selectActiveKillswitchMessages } from '../selectors';
+import { selectActiveKillswitchMessage } from '../messageSystemSelectors';
 
 const screenStyle = prepareNativeStyle(utils => ({
     flexGrow: 1,
@@ -35,13 +34,12 @@ const buttonsWrapperStyle = prepareNativeStyle(_ => ({
     width: '100%',
 }));
 
-export const FeatureMessageScreen = () => {
+export const KillswitchMessageScreen = () => {
     const dispatch = useDispatch();
     const openLink = useOpenLink();
-
-    const killswitch = A.head(useSelector(selectActiveKillswitchMessages));
-
     const { applyStyle } = useNativeStyles();
+
+    const killswitch = useSelector(selectActiveKillswitchMessage);
 
     if (!killswitch) return null;
 

--- a/suite-native/message-system/src/index.ts
+++ b/suite-native/message-system/src/index.ts
@@ -1,3 +1,3 @@
 export * from './messageSystemMiddleware';
 export * from './components/MessageSystemBannerRenderer';
-export * from './components/FeatureMessageScreen';
+export * from './components/KillswitchMessageScreen';

--- a/suite-native/message-system/src/index.ts
+++ b/suite-native/message-system/src/index.ts
@@ -1,3 +1,4 @@
 export * from './messageSystemMiddleware';
 export * from './components/MessageSystemBannerRenderer';
 export * from './components/KillswitchMessageScreen';
+export * from './messageSystemSelectors';

--- a/suite-native/message-system/src/messageSystemSelectors.ts
+++ b/suite-native/message-system/src/messageSystemSelectors.ts
@@ -1,0 +1,17 @@
+import { A } from '@mobily/ts-belt';
+
+import { createMemoizedSelector, selectActiveFeatureMessages } from '@suite-common/message-system';
+
+export const selectActiveKillswitchMessage = createMemoizedSelector(
+    [selectActiveFeatureMessages],
+    messages =>
+        A.head(
+            messages.filter(m => {
+                const killswitchFeatures = m.feature?.filter(
+                    item => item.domain === 'killswitch' && item?.flag,
+                );
+
+                return A.isNotEmpty(killswitchFeatures ?? []);
+            }),
+        ),
+);

--- a/suite-native/message-system/src/selectors.ts
+++ b/suite-native/message-system/src/selectors.ts
@@ -1,0 +1,9 @@
+import { createMemoizedSelector, selectActiveFeatureMessages } from '@suite-common/message-system';
+
+export const selectActiveKillswitchMessages = createMemoizedSelector(
+    [selectActiveFeatureMessages],
+    messages =>
+        messages.filter(
+            m => m.feature?.filter(item => item.domain === 'killswitch' && item.flag) ?? false,
+        ),
+);

--- a/suite-native/message-system/src/selectors.ts
+++ b/suite-native/message-system/src/selectors.ts
@@ -1,9 +1,0 @@
-import { createMemoizedSelector, selectActiveFeatureMessages } from '@suite-common/message-system';
-
-export const selectActiveKillswitchMessages = createMemoizedSelector(
-    [selectActiveFeatureMessages],
-    messages =>
-        messages.filter(
-            m => m.feature?.filter(item => item.domain === 'killswitch' && item.flag) ?? false,
-        ),
-);

--- a/suite-native/module-accounts-management/src/selectors.ts
+++ b/suite-native/module-accounts-management/src/selectors.ts
@@ -1,22 +1,9 @@
-import { D, pipe } from '@mobily/ts-belt';
-
-import { type NetworkSymbol, getNetworkType, networks } from '@suite-common/wallet-config';
+import { type NetworkSymbol, getNetworkType } from '@suite-common/wallet-config';
 import {
     FeatureFlagsRootState,
     selectIsFeatureFlagEnabled,
     FeatureFlag,
 } from '@suite-native/feature-flags';
-
-const PRODUCTION_SEND_COINS_WHITELIST = pipe(
-    networks,
-    D.filter(
-        network =>
-            network.networkType === 'bitcoin' ||
-            network.networkType === 'ethereum' ||
-            network.networkType === 'ripple',
-    ),
-    D.keys,
-);
 
 export const selectIsNetworkSendFlowEnabled = (
     state: FeatureFlagsRootState,
@@ -25,18 +12,12 @@ export const selectIsNetworkSendFlowEnabled = (
     if (!symbol) return false;
     const networkType = getNetworkType(symbol);
 
-    if (PRODUCTION_SEND_COINS_WHITELIST.includes(symbol)) return true;
-
     const isCardanoSendEnabled = selectIsFeatureFlagEnabled(
         state,
         FeatureFlag.IsCardanoSendEnabled,
     );
 
-    if (isCardanoSendEnabled && networkType === 'cardano') return true;
-
-    const isSolanaSendEnabled = selectIsFeatureFlagEnabled(state, FeatureFlag.IsSolanaSendEnabled);
-
-    if (isSolanaSendEnabled && networkType === 'solana') return true;
+    if (networkType !== 'cardano' || isCardanoSendEnabled) return true;
 
     return false;
 };

--- a/suite-native/module-dev-utils/src/components/FeatureFlags.tsx
+++ b/suite-native/module-dev-utils/src/components/FeatureFlags.tsx
@@ -4,7 +4,6 @@ import { FeatureFlag as FeatureFlagEnum, useFeatureFlag } from '@suite-native/fe
 const featureFlagsTitleMap = {
     [FeatureFlagEnum.IsDeviceConnectEnabled]: 'Connect device',
     [FeatureFlagEnum.IsCardanoSendEnabled]: 'Cardano send',
-    [FeatureFlagEnum.IsSolanaSendEnabled]: 'Solana send',
     [FeatureFlagEnum.IsRegtestEnabled]: 'Regtest',
     [FeatureFlagEnum.IsSolanaEnabled]: 'Solana',
     [FeatureFlagEnum.IsConnectPopupEnabled]: 'Connect Popup',


### PR DESCRIPTION
- feature messages are not blocking entire app anymore apart of killswitch
- Solana can be enabled/disabled in mobile via message system
- Disabling message to be deployed via #15701

Resolve #15613


