### PR TITLE
fix(connect): FW revision check offline handling v2

### DIFF
--- a/packages/connect/src/device/checkFirmwareRevision.ts
+++ b/packages/connect/src/device/checkFirmwareRevision.ts
@@ -6,6 +6,14 @@ import { FirmwareRelease, VersionArray } from '../types';
 import { FirmwareRevisionCheckError, FirmwareRevisionCheckResult } from '../types/device';
 import { calculateRevisionForDevice } from './calculateRevisionForDevice';
 
+/*
+ * error names that signify unavailable internet connection, see https://github.com/node-fetch/node-fetch/blob/main/docs/ERROR-HANDLING.md
+ * Only works in Suite Desktop, where `cross-fetch` uses `node-fetch` (nodeJS environment)
+ * In Suite Web, the errors are unfortunately indistinguishable from other errors, because they are all lumped as CORS errors
+ * (even a request that had no response is CORS error, since a non-existent response does not have CORS headers)
+ */
+const NODE_FETCH_OFFLINE_ERROR_NAMES = ['FetchError', 'AbortError'] as const;
+
 type GetOnlineReleaseMetadataParams = {
     firmwareVersion: VersionArray;
     internalModel: string;
@@ -87,7 +95,7 @@ export const checkFirmwareRevision = async ({
 
             return { success: true };
         } catch (e) {
-            if (e.name === 'FetchError' && e.code === 'ENOTFOUND') {
+            if (NODE_FETCH_OFFLINE_ERROR_NAMES.includes(e.name)) {
                 return failFirmwareRevisionCheck('cannot-perform-check-offline');
             }
 


### PR DESCRIPTION
## Description

Fix handling of fetch errors when FW revision check encounters version not known locally: display "go online" banner instead of generic error banner.

Works only for Suite Desktop, see comment. On web, there is no change; offline will still be `'other-error'`

Replacement of closed #15664, [see comment](https://github.com/trezor/trezor-suite/pull/15664#pullrequestreview-2472508890)

### Testing

- You can test locally with user env `1-main | 2-main` and turning off Wi-Fi :arrow_right: go online banner
- Or go to [downloadReleasesMetadata.ts](https://github.com/trezor/trezor-suite/blob/905e656a24907aa91ae3bfdfe68388778a05d979/packages/connect/src/data/downloadReleasesMetadata.ts#L12) and switch the URL for:
  - URL where host cannot be resolved e.g. `'https://asdf.trezor.io'` :arrow_right: go online banner
  - URL returning invalid JSON e.g. `'https://trezor.io'` :arrow_right: generic error banner
    - user is online, but there was error thrown _somewhere_ during processing the http response
  - URL returning http error code e.g. `'https://data.trezor.io/whatever.json'` :arrow_right: generic error banner
    - if our servers return 404 it's our problem, definitely shouldn't prompt users to "go online"

## Screenshots:

**Before:**
![other error](https://github.com/user-attachments/assets/8e3ec38c-6e79-43fa-8373-0c473a9bd445)

**After:**
![offline error](https://github.com/user-attachments/assets/ec134a28-a282-4057-9a88-dda218bb8881)