### PR TITLE
fix(suite): transaction pagination

### DIFF
--- a/packages/suite/src/views/wallet/transactions/Transactions.tsx
+++ b/packages/suite/src/views/wallet/transactions/Transactions.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from 'react';
 import styled from 'styled-components';
 
 import {
-    selectAccountTransactions,
+    selectAccountTransactionsWithNulls,
     selectIsLoadingAccountTransactions,
 } from '@suite-common/wallet-core';
 import { spacingsPx } from '@trezor/theme';
@@ -48,7 +48,7 @@ export const Transactions = () => {
         selectIsLoadingAccountTransactions(state, selectedAccount.account?.key || null),
     );
     const accountTransactions = useSelector(state =>
-        selectAccountTransactions(state, selectedAccount.account?.key || ''),
+        selectAccountTransactionsWithNulls(state, selectedAccount.account?.key || ''),
     );
 
     if (selectedAccount.status !== 'loaded') {


### PR DESCRIPTION
## Description

Previously, if you had an account with multiple pages of transactions and would jump to a page which has preceding unloaded pages, you would see an empty page.

The paginiation in TransactionList works by slicing the array by the indexes of the items on the page. 

This means that every item must be at the expected index determined by its page and if some pages are not loaded yet, those indexes must be null. 

Therefore `selectAccountTransactionsWithNulls` must be used instead of `selectAccountTransactions` for pagination to work. 

## Related Issue

Resolve #15420