### PR TITLE
fix(suite-desktop): adjust release notes for 24.12

### DIFF
--- a/packages/suite-desktop/releaseNotes/release-notes.md
+++ b/packages/suite-desktop/releaseNotes/release-notes.md
@@ -3,7 +3,6 @@
 -   Transactions now use nVersion=2, reducing fingerprinting for enhanced privacy.
 -   Improved token selection for more control when sending.
 -   Optimized main menu resizing for seamless navigation across all screen sizes.
--   Manual UTXO sorting added to Coin Control, offering improved flexibility.
 
 ### 🔧 Bug fixes
 


### PR DESCRIPTION
As we were not able to finish UTXO sorting in Coin control until Freeze, I need to adjust release notes as well.