### PR TITLE
fix: incorrect import of the code from 'libDev' triggers eslint error

### DIFF
--- a/packages/eslint/src/typescriptConfig.mjs
+++ b/packages/eslint/src/typescriptConfig.mjs
@@ -17,7 +17,12 @@ export const typescriptConfig = [
                 'error',
                 {
                     paths: [{ name: '.' }, { name: '..' }, { name: '../..' }],
-                    patterns: ['@trezor/*/lib', '@trezor/*/lib/**'],
+                    patterns: [
+                        '@trezor/*/lib',
+                        '@trezor/*/lib/**',
+                        '@trezor/*/libDev',
+                        '@trezor/*/libDev/**',
+                    ],
                 },
             ],
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1ae3eef5-95e0-4296-8310-17c1819c1d6f)

![image](https://github.com/user-attachments/assets/a2e9fb59-077e-4dfe-b934-0c1bc01825dd)
