### PR TITLE
chore(suite): move autostart under experimental

### DIFF
--- a/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
@@ -57,6 +57,7 @@ export const SettingsGeneral = () => {
 
     const isMetadataEnabled = metadata.enabled && !metadata.initiating;
     const isProviderConnected = useSelector(selectSelectedProviderForLabels);
+    const isExperimentalEnabled = useSelector(state => state.suite.settings.experimental);
 
     return (
         <SettingsLayout data-testid="@settings/index">
@@ -102,13 +103,6 @@ export const SettingsGeneral = () => {
                 <EnableViewOnly />
             </SettingsSection>
 
-            {isDesktop() && (
-                <SettingsSection title={<Translation id="TR_TREZOR_CONNECT" />} icon="plugs">
-                    <AutoStart />
-                    <ShowOnTray />
-                </SettingsSection>
-            )}
-
             <SettingsSection
                 title={<Translation id="TR_EXPERIMENTAL_FEATURES" />}
                 icon="experimental"
@@ -116,6 +110,13 @@ export const SettingsGeneral = () => {
                 {desktopUpdate.enabled && <EarlyAccess />}
                 <Experimental />
             </SettingsSection>
+
+            {isDesktop() && isExperimentalEnabled !== undefined && (
+                <SettingsSection title={<Translation id="TR_TREZOR_CONNECT" />} icon="plugs">
+                    <AutoStart />
+                    <ShowOnTray />
+                </SettingsSection>
+            )}
         </SettingsLayout>
     );
 };


### PR DESCRIPTION
## Description

Product needs more time to polish it, so we're moving autostart & tray settings under experimental features.

## Screenshots:
<img width="1243" alt="Screenshot 2024-12-04 at 09 01 05" src="https://github.com/user-attachments/assets/1bc0db28-7c28-496a-b8e9-b0f758323ffd">


