### PR TITLE
chore(suite-desktop): downgrade electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
         "type-fest": "4.24.0",
         "bcrypto": "5.4.0",
         "react": "18.2.0",
-        "electron": "33.1.0",
+        "electron": "32.2.6",
         "@types/node": "22.10.1",
         "@types/react": "18.2.55",
         "bn.js": "5.2.1",

--- a/packages/connect-examples/electron-main-process/package.json
+++ b/packages/connect-examples/electron-main-process/package.json
@@ -56,7 +56,7 @@
     },
     "devDependencies": {
         "@trezor/eslint": "workspace:*",
-        "electron": "33.1.0",
+        "electron": "32.2.6",
         "electron-builder": "25.1.8"
     }
 }

--- a/packages/connect-examples/electron-renderer-with-assets/package.json
+++ b/packages/connect-examples/electron-renderer-with-assets/package.json
@@ -62,7 +62,7 @@
         "babel-loader": "^9.1.3",
         "concurrently": "^8.2.2",
         "copy-webpack-plugin": "^12.0.2",
-        "electron": "33.1.0",
+        "electron": "32.2.6",
         "electron-builder": "25.1.8",
         "html-webpack-plugin": "^5.6.0",
         "terser-webpack-plugin": "^5.3.9",

--- a/packages/connect-examples/electron-renderer-with-popup/package.json
+++ b/packages/connect-examples/electron-renderer-with-popup/package.json
@@ -53,7 +53,7 @@
     },
     "devDependencies": {
         "@trezor/eslint": "workspace:*",
-        "electron": "33.1.0",
+        "electron": "32.2.6",
         "electron-builder": "25.1.8"
     }
 }

--- a/packages/suite-build/configs/desktop.webpack.config.ts
+++ b/packages/suite-build/configs/desktop.webpack.config.ts
@@ -17,7 +17,7 @@ const baseDirUI = getPathForProject('desktop-ui');
 const baseDir = getPathForProject('desktop');
 
 const config: webpack.Configuration = {
-    target: 'browserslist:Chrome >= 130', // Electron 33 is running on chromium 130
+    target: 'browserslist:Chrome >= 128', // Electron 32 is running on chromium 128
     entry: [path.join(baseDirUI, 'src', 'index.tsx')],
     output: {
         path: path.join(baseDir, 'build'),

--- a/packages/suite-desktop-api/package.json
+++ b/packages/suite-desktop-api/package.json
@@ -18,6 +18,6 @@
         "type-check": "yarn g:tsc --build tsconfig.json"
     },
     "dependencies": {
-        "electron": "33.1.0"
+        "electron": "32.2.6"
     }
 }

--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -54,7 +54,7 @@
         "@trezor/type-utils": "workspace:*",
         "@types/electron-localshortcut": "^3.1.3",
         "@types/ws": "^8.5.12",
-        "electron": "33.1.0",
+        "electron": "32.2.6",
         "fs-extra": "^11.2.0",
         "glob": "^10.3.10",
         "terser-webpack-plugin": "^5.3.9",

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -30,7 +30,7 @@
     },
     "devDependencies": {
         "@electron/notarize": "2.5.0",
-        "electron": "33.1.0",
+        "electron": "32.2.6",
         "electron-builder": "25.1.8",
         "glob": "^10.3.10"
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12293,7 +12293,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/suite-desktop-api@workspace:packages/suite-desktop-api"
   dependencies:
-    electron: "npm:33.1.0"
+    electron: "npm:32.2.6"
   languageName: unknown
   linkType: soft
 
@@ -12332,7 +12332,7 @@ __metadata:
     "@types/electron-localshortcut": "npm:^3.1.3"
     "@types/ws": "npm:^8.5.12"
     chalk: "npm:^4.1.2"
-    electron: "npm:33.1.0"
+    electron: "npm:32.2.6"
     electron-localshortcut: "npm:^3.2.1"
     electron-store: "npm:8.2.0"
     electron-updater: "npm:6.3.9"
@@ -12384,7 +12384,7 @@ __metadata:
   dependencies:
     "@electron/notarize": "npm:2.5.0"
     blake-hash: "npm:^2.0.0"
-    electron: "npm:33.1.0"
+    electron: "npm:32.2.6"
     electron-builder: "npm:25.1.8"
     electron-localshortcut: "npm:^3.2.1"
     electron-store: "npm:8.2.0"
@@ -18432,7 +18432,7 @@ __metadata:
   dependencies:
     "@trezor/connect": "workspace:*"
     "@trezor/eslint": "workspace:*"
-    electron: "npm:33.1.0"
+    electron: "npm:32.2.6"
     electron-builder: "npm:25.1.8"
   languageName: unknown
   linkType: soft
@@ -18442,7 +18442,7 @@ __metadata:
   resolution: "connect-example-electron-renderer-popup@workspace:packages/connect-examples/electron-renderer-with-popup"
   dependencies:
     "@trezor/eslint": "workspace:*"
-    electron: "npm:33.1.0"
+    electron: "npm:32.2.6"
     electron-builder: "npm:25.1.8"
   languageName: unknown
   linkType: soft
@@ -18457,7 +18457,7 @@ __metadata:
     babel-loader: "npm:^9.1.3"
     concurrently: "npm:^8.2.2"
     copy-webpack-plugin: "npm:^12.0.2"
-    electron: "npm:33.1.0"
+    electron: "npm:32.2.6"
     electron-builder: "npm:25.1.8"
     html-webpack-plugin: "npm:^5.6.0"
     terser-webpack-plugin: "npm:^5.3.9"
@@ -20949,16 +20949,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:33.1.0":
-  version: 33.1.0
-  resolution: "electron@npm:33.1.0"
+"electron@npm:32.2.6":
+  version: 32.2.6
+  resolution: "electron@npm:32.2.6"
   dependencies:
     "@electron/get": "npm:^2.0.0"
     "@types/node": "npm:^20.9.0"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10/3347167d715e93a5ef8d9ca16981763b3c5b5e08be69226c5ec3bc7770160c7fffa8d063d7d92d0a76e5f6b8720a3b6e3e04bb1e1af81f89ebbc17dd7440a285
+  checksum: 10/3f5c396266a8612002d36286e78eee4cc69718d8f9440087239a221357f2e203b4ec50656687833c0f3e9dbec34bf8083b7daa2f20dd0ae00cbbd593a1ab5055
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Downgrade electron from 33 to 32.

It shall be kept at 32 until we are ready to cut off macOS Catalina.

:information_source: [electron 32 support](https://github.com/electron/electron/tree/v32.2.8?tab=readme-ov-file#platform-support)
:information_source: [current electron support](https://github.com/electron/electron/blob/main/README.md#platform-support)
:information_source: [systems supported by Suite](https://trezor.io/learn/a/os-requirements-for-trezor)
