### PR TITLE
feat(solana): add support for Token-2022 tokens

### DIFF
--- a/packages/blockchain-link-types/src/common.ts
+++ b/packages/blockchain-link-types/src/common.ts
@@ -53,7 +53,7 @@ export interface ServerInfo {
     consensusBranchId?: number; // zcash current branch id
 }
 
-export type TokenStandard = 'ERC20' | 'ERC1155' | 'ERC721' | 'SPL' | 'BEP20';
+export type TokenStandard = 'ERC20' | 'ERC1155' | 'ERC721' | 'SPL' | 'SPL-2022' | 'BEP20';
 
 export type TransferType = 'sent' | 'recv' | 'self' | 'unknown';
 

--- a/packages/blockchain-link-types/src/params.ts
+++ b/packages/blockchain-link-types/src/params.ts
@@ -32,6 +32,7 @@ export interface EstimateFeeParams {
         data?: string; // eth tx data, sol tx message
         value?: string; // eth tx amount
         isCreatingAccount?: boolean; // sol account creation
+        newTokenAccountProgramName?: 'spl-token' | 'spl-token-2022'; // program name of the Solana Token account that is being created, ignored if isCreatingAccount is false, default: 'spl-token'
     };
 }
 

--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -77,6 +77,7 @@
     },
     "dependencies": {
         "@solana-program/token": "^0.4.1",
+        "@solana-program/token-2022": "^0.3.1",
         "@solana/web3.js": "^2.0.0",
         "@trezor/blockchain-link-types": "workspace:*",
         "@trezor/blockchain-link-utils": "workspace:*",

--- a/packages/connect/src/api/blockchainEstimateFee.ts
+++ b/packages/connect/src/api/blockchainEstimateFee.ts
@@ -44,6 +44,7 @@ export default class BlockchainEstimateFee extends AbstractMethod<'blockchainEst
                     { name: 'to', type: 'string' },
                     { name: 'txsize', type: 'number' },
                     { name: 'isCreatingAccount', type: 'boolean' },
+                    { name: 'newTokenAccountProgramName', type: 'string' },
                 ]);
             }
         }

--- a/suite-common/wallet-utils/package.json
+++ b/suite-common/wallet-utils/package.json
@@ -16,6 +16,7 @@
         "@solana-program/compute-budget": "^0.6.1",
         "@solana-program/system": "^0.6.2",
         "@solana-program/token": "^0.4.1",
+        "@solana-program/token-2022": "^0.3.1",
         "@solana/web3.js": "^2.0.0",
         "@suite-common/fiat-services": "workspace:*",
         "@suite-common/metadata-types": "workspace:*",

--- a/suite-common/wallet-utils/src/__fixtures__/solanaUtils.ts
+++ b/suite-common/wallet-utils/src/__fixtures__/solanaUtils.ts
@@ -4,6 +4,7 @@ import { BigNumber } from '@trezor/utils/src/bigNumber';
 import {
     TOKEN_PROGRAM_PUBLIC_KEY,
     SYSTEM_PROGRAM_PUBLIC_KEY,
+    TOKEN_2022_PROGRAM_PUBLIC_KEY,
 } from '@trezor/blockchain-link-utils/src/solana';
 
 export const fixtures = {
@@ -93,7 +94,7 @@ export const fixtures = {
     ],
     buildTokenTransferInstruction: [
         {
-            description: 'builds token transfer instruction',
+            description: 'builds token transfer instruction for the SPL Token program',
             input: {
                 from: 'CR6QfobBidQTSYdR6jihKTfMnHkRUtw8cLDCxENDVYmd',
                 to: 'GrwHUG2U6Nmr2CHjQ2kesKzbjMwvCNytcMAbhQxq1Jyd',
@@ -101,6 +102,7 @@ export const fixtures = {
                 amount: new BigNumber('1'),
                 mint: '6YuhWADZyAAxAaVKPm1G5N51RvDBXsnWo4SfsJ47wSoK',
                 decimals: 9,
+                tokenProgramName: 'spl-token' as const,
             },
             expectedOutput: {
                 accounts: [
@@ -127,14 +129,52 @@ export const fixtures = {
                 data: new Uint8Array([12, 1, 0, 0, 0, 0, 0, 0, 0, 9]),
             },
         },
+        {
+            description: 'builds token transfer instruction for the Token 2022 program',
+            input: {
+                from: 'EdThAwDjfEj9joy2U7WvSsMwsHn5Wkby8R4j74qYJujz',
+                to: '4Qon5ZG7yYRkheuUwdqwN9nGRgu7oYn9tAp5tkhE77Mi',
+                owner: '6y2EP2MtSCuNE41h3gG9Fs7ZU2n24gcYiGqDpEYjDbRn',
+                amount: new BigNumber('1'),
+                mint: '8JH5uP374VW4YmVzE7LCRK9CbyRe1uXb85jK72RQzvWU',
+                decimals: 9,
+                tokenProgramName: 'spl-token-2022' as const,
+            },
+            expectedOutput: {
+                accounts: [
+                    {
+                        address: 'EdThAwDjfEj9joy2U7WvSsMwsHn5Wkby8R4j74qYJujz',
+                        role: AccountRole.WRITABLE,
+                    },
+                    {
+                        address: '8JH5uP374VW4YmVzE7LCRK9CbyRe1uXb85jK72RQzvWU',
+                        role: AccountRole.READONLY,
+                    },
+                    {
+                        address: '4Qon5ZG7yYRkheuUwdqwN9nGRgu7oYn9tAp5tkhE77Mi',
+                        role: AccountRole.WRITABLE,
+                    },
+                    expect.objectContaining({
+                        address: '6y2EP2MtSCuNE41h3gG9Fs7ZU2n24gcYiGqDpEYjDbRn',
+                        role: AccountRole.READONLY_SIGNER,
+                        signer: expect.objectContaining({
+                            address: '6y2EP2MtSCuNE41h3gG9Fs7ZU2n24gcYiGqDpEYjDbRn',
+                        }),
+                    }),
+                ],
+                data: new Uint8Array([12, 1, 0, 0, 0, 0, 0, 0, 0, 9]),
+            },
+        },
     ],
     buildCreateAssociatedTokenAccountInstruction: [
         {
-            description: 'builds create associated token account instruction',
+            description:
+                'builds create associated token account instruction for the SPL Token program',
             input: {
                 funderAddress: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF',
                 tokenMintAddress: '6YuhWADZyAAxAaVKPm1G5N51RvDBXsnWo4SfsJ47wSoK',
                 newOwnerAddress: 'FAeNERRWGL8xtnwtM5dWBUs9Z1y5fenSJcawu55NQSWk',
+                tokenProgramName: 'spl-token' as const,
             },
             expectedOutput: {
                 pubkey: 'GrwHUG2U6Nmr2CHjQ2kesKzbjMwvCNytcMAbhQxq1Jyd',
@@ -170,10 +210,54 @@ export const fixtures = {
                 data: new Uint8Array([]),
             },
         },
+        {
+            description:
+                'builds create associated token account instruction for the Token 2022 program',
+            input: {
+                funderAddress: '8CxSyuSwEjUXU2ABWU2pFmvxwZR5aMmSxFQ4mAS7Kg4p',
+                tokenMintAddress: '8JH5uP374VW4YmVzE7LCRK9CbyRe1uXb85jK72RQzvWU',
+                newOwnerAddress: '6y2EP2MtSCuNE41h3gG9Fs7ZU2n24gcYiGqDpEYjDbRn',
+                tokenProgramName: 'spl-token-2022' as const,
+            },
+            expectedOutput: {
+                pubkey: 'EdThAwDjfEj9joy2U7WvSsMwsHn5Wkby8R4j74qYJujz',
+                accounts: [
+                    expect.objectContaining({
+                        address: '8CxSyuSwEjUXU2ABWU2pFmvxwZR5aMmSxFQ4mAS7Kg4p',
+                        role: AccountRole.WRITABLE_SIGNER,
+                        signer: expect.objectContaining({
+                            address: '8CxSyuSwEjUXU2ABWU2pFmvxwZR5aMmSxFQ4mAS7Kg4p',
+                        }),
+                    }),
+                    {
+                        address: 'EdThAwDjfEj9joy2U7WvSsMwsHn5Wkby8R4j74qYJujz',
+                        role: AccountRole.WRITABLE,
+                    },
+                    {
+                        address: '6y2EP2MtSCuNE41h3gG9Fs7ZU2n24gcYiGqDpEYjDbRn',
+                        role: AccountRole.READONLY,
+                    },
+                    {
+                        address: '8JH5uP374VW4YmVzE7LCRK9CbyRe1uXb85jK72RQzvWU',
+                        role: AccountRole.READONLY,
+                    },
+                    {
+                        address: SYSTEM_PROGRAM_PUBLIC_KEY,
+                        role: AccountRole.READONLY,
+                    },
+                    {
+                        address: TOKEN_2022_PROGRAM_PUBLIC_KEY,
+                        role: AccountRole.READONLY,
+                    },
+                ],
+                data: new Uint8Array([]),
+            },
+        },
     ],
     buildTokenTransferTransaction: [
         {
-            description: 'builds token transfer transaction in most common case',
+            description:
+                'builds token transfer (SPL Token program) transaction in most common case',
             input: {
                 fromAddress: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF',
                 toAddress: 'FAeNERRWGL8xtnwtM5dWBUs9Z1y5fenSJcawu55NQSWk',
@@ -194,13 +278,14 @@ export const fixtures = {
                     computeUnitPrice: '100000',
                     computeUnitLimit: '50000',
                 },
+                tokenProgramName: 'spl-token' as const,
             },
             expectedOutput:
                 '01000609c80f8b50107e9f3e3c16a661b8c806df454a6deb293d5e8730a9d28f2f4998c6a99c9c4d0c7def9dd60a3a40dc5266faf41996310aa62ad6cbd9b64e1e2cca78ebaa24826cef9644c1ecf0dfcf955775b8438528e97820efc2b20ed46be1dc580000000000000000000000000000000000000000000000000000000000000000527706a12f3f7c3c852582f0f79b515c03c6ffbe6e3100044ba7c982eb5cf9f28c97258f4e2489f1bb3d1029148e0d830b5a1399daff1084048e7bd8dbe9f8590306466fe5211732ffecadba72c39be7bc8ce5bbc5f7126b2c439b3a40000000d27c181cb023db6239e22e49e4b67f7dd9ed13f3d7ed319f9e91b3bc64cec0a906ddf6e1d765a193d9cbe146ceeb79ac1cb485ed5f5b37913a8cf5857eff00a96772b7d36a2e66e52c817f385d7e94d3d4b6d47d7171c9f2dd86c6f1be1a93eb040600050250c3000006000903a0860100000000000506000207040308000804010402000a0c00e1f5050000000009',
         },
         {
             description:
-                'builds token transfer transaction in the case an account already exists (simplest case, second most common)',
+                'builds token transfer transaction (SPL Token program) in the case an account already exists (simplest case, second most common)',
             input: {
                 fromAddress: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF',
                 toAddress: 'FAeNERRWGL8xtnwtM5dWBUs9Z1y5fenSJcawu55NQSWk',
@@ -224,13 +309,14 @@ export const fixtures = {
                     computeUnitPrice: '100000',
                     computeUnitLimit: '50000',
                 },
+                tokenProgramName: 'spl-token' as const,
             },
             expectedOutput:
                 '01000306c80f8b50107e9f3e3c16a661b8c806df454a6deb293d5e8730a9d28f2f4998c6a99c9c4d0c7def9dd60a3a40dc5266faf41996310aa62ad6cbd9b64e1e2cca78ebaa24826cef9644c1ecf0dfcf955775b8438528e97820efc2b20ed46be1dc58527706a12f3f7c3c852582f0f79b515c03c6ffbe6e3100044ba7c982eb5cf9f20306466fe5211732ffecadba72c39be7bc8ce5bbc5f7126b2c439b3a4000000006ddf6e1d765a193d9cbe146ceeb79ac1cb485ed5f5b37913a8cf5857eff00a96772b7d36a2e66e52c817f385d7e94d3d4b6d47d7171c9f2dd86c6f1be1a93eb030400050250c3000004000903a0860100000000000504010302000a0c00e1f5050000000009',
         },
         {
             description:
-                'builds token transfer transaction in the case the destination is a token account (rare case, power user case)',
+                'builds token transfer transaction (SPL Token program) in the case the destination is a token account (rare case, power user case)',
             input: {
                 fromAddress: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF',
                 toAddress: 'GrwHUG2U6Nmr2CHjQ2kesKzbjMwvCNytcMAbhQxq1Jyd',
@@ -251,9 +337,97 @@ export const fixtures = {
                     computeUnitPrice: '100000',
                     computeUnitLimit: '50000',
                 },
+                tokenProgramName: 'spl-token' as const,
             },
             expectedOutput:
                 '01000306c80f8b50107e9f3e3c16a661b8c806df454a6deb293d5e8730a9d28f2f4998c6a99c9c4d0c7def9dd60a3a40dc5266faf41996310aa62ad6cbd9b64e1e2cca78ebaa24826cef9644c1ecf0dfcf955775b8438528e97820efc2b20ed46be1dc58527706a12f3f7c3c852582f0f79b515c03c6ffbe6e3100044ba7c982eb5cf9f20306466fe5211732ffecadba72c39be7bc8ce5bbc5f7126b2c439b3a4000000006ddf6e1d765a193d9cbe146ceeb79ac1cb485ed5f5b37913a8cf5857eff00a96772b7d36a2e66e52c817f385d7e94d3d4b6d47d7171c9f2dd86c6f1be1a93eb030400050250c3000004000903a0860100000000000504010302000a0c00e1f5050000000009',
+        },
+        {
+            description:
+                'builds token transfer (Token 2022 program) transaction in most common case',
+            input: {
+                fromAddress: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF',
+                toAddress: 'FAeNERRWGL8xtnwtM5dWBUs9Z1y5fenSJcawu55NQSWk',
+                toAddressOwner: SYSTEM_PROGRAM_PUBLIC_KEY,
+                tokenMint: '8JH5uP374VW4YmVzE7LCRK9CbyRe1uXb85jK72RQzvWU',
+                tokenUiAmount: '0.1',
+                tokenDecimals: 9,
+                fromTokenAccounts: [
+                    {
+                        publicKey: 'EdThAwDjfEj9joy2U7WvSsMwsHn5Wkby8R4j74qYJujz',
+                        balance: '12200000000',
+                    },
+                ],
+                toTokenAccount: undefined,
+                blockhash: '7xpT7BDE7q1ZWhe6Pg8PHRYbqgDwNK3L2v97rEfsjMkn',
+                lastValidBlockHeight: 50,
+                priorityFees: {
+                    computeUnitPrice: '100000',
+                    computeUnitLimit: '50000',
+                },
+                tokenProgramName: 'spl-token-2022' as const,
+            },
+            expectedOutput:
+                '01000609c80f8b50107e9f3e3c16a661b8c806df454a6deb293d5e8730a9d28f2f4998c6ca7f0545e6ff0eb69540020573c128136015f2a26163f90081ea42fb43be1665f18003838ed2728bc8bc4083dee3b9255492d2e65cf670bc2fdd51d1c32c499100000000000000000000000000000000000000000000000000000000000000006c6ede7c260ca13beca7a3017513ac103b5dad8335213f57d38b78967c6608b98c97258f4e2489f1bb3d1029148e0d830b5a1399daff1084048e7bd8dbe9f8590306466fe5211732ffecadba72c39be7bc8ce5bbc5f7126b2c439b3a40000000d27c181cb023db6239e22e49e4b67f7dd9ed13f3d7ed319f9e91b3bc64cec0a906ddf6e1ee758fde18425dbce46ccddab61afc4d83b90d27febdf928d8a18bfc6772b7d36a2e66e52c817f385d7e94d3d4b6d47d7171c9f2dd86c6f1be1a93eb040600050250c3000006000903a0860100000000000506000207040308000804010402000a0c00e1f5050000000009',
+        },
+        {
+            description:
+                'builds token transfer transaction (Token 2022 program) in the case an account already exists (simplest case, second most common)',
+            input: {
+                fromAddress: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF',
+                toAddress: 'FAeNERRWGL8xtnwtM5dWBUs9Z1y5fenSJcawu55NQSWk',
+                toAddressOwner: SYSTEM_PROGRAM_PUBLIC_KEY,
+                tokenMint: '8JH5uP374VW4YmVzE7LCRK9CbyRe1uXb85jK72RQzvWU',
+                tokenUiAmount: '0.1',
+                tokenDecimals: 9,
+                fromTokenAccounts: [
+                    {
+                        publicKey: 'EdThAwDjfEj9joy2U7WvSsMwsHn5Wkby8R4j74qYJujz',
+                        balance: '12200000000',
+                    },
+                ],
+                toTokenAccount: {
+                    publicKey: '4Qon5ZG7yYRkheuUwdqwN9nGRgu7oYn9tAp5tkhE77Mi',
+                    balance: '600000000',
+                },
+                blockhash: '7xpT7BDE7q1ZWhe6Pg8PHRYbqgDwNK3L2v97rEfsjMkn',
+                lastValidBlockHeight: 50,
+                priorityFees: {
+                    computeUnitPrice: '100000',
+                    computeUnitLimit: '50000',
+                },
+                tokenProgramName: 'spl-token-2022' as const,
+            },
+            expectedOutput:
+                '01000306c80f8b50107e9f3e3c16a661b8c806df454a6deb293d5e8730a9d28f2f4998c632ac4f80897dd3abcbea173b042cdc1b710fab8b71bbe29ebc3328c1bc44c589ca7f0545e6ff0eb69540020573c128136015f2a26163f90081ea42fb43be16656c6ede7c260ca13beca7a3017513ac103b5dad8335213f57d38b78967c6608b90306466fe5211732ffecadba72c39be7bc8ce5bbc5f7126b2c439b3a4000000006ddf6e1ee758fde18425dbce46ccddab61afc4d83b90d27febdf928d8a18bfc6772b7d36a2e66e52c817f385d7e94d3d4b6d47d7171c9f2dd86c6f1be1a93eb030400050250c3000004000903a0860100000000000504020301000a0c00e1f5050000000009',
+        },
+        {
+            description:
+                'builds token transfer transaction (Token 2022 program) in the case the destination is a token account (rare case, power user case)',
+            input: {
+                fromAddress: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF',
+                toAddress: 'GrwHUG2U6Nmr2CHjQ2kesKzbjMwvCNytcMAbhQxq1Jyd',
+                toAddressOwner: TOKEN_2022_PROGRAM_PUBLIC_KEY,
+                tokenMint: '8JH5uP374VW4YmVzE7LCRK9CbyRe1uXb85jK72RQzvWU',
+                tokenUiAmount: '0.1',
+                tokenDecimals: 9,
+                fromTokenAccounts: [
+                    {
+                        publicKey: 'EdThAwDjfEj9joy2U7WvSsMwsHn5Wkby8R4j74qYJujz',
+                        balance: '12200000000',
+                    },
+                ],
+                toTokenAccount: undefined,
+                blockhash: '7xpT7BDE7q1ZWhe6Pg8PHRYbqgDwNK3L2v97rEfsjMkn',
+                lastValidBlockHeight: 50,
+                priorityFees: {
+                    computeUnitPrice: '100000',
+                    computeUnitLimit: '50000',
+                },
+                tokenProgramName: 'spl-token-2022' as const,
+            },
+            expectedOutput:
+                '01000306c80f8b50107e9f3e3c16a661b8c806df454a6deb293d5e8730a9d28f2f4998c6ca7f0545e6ff0eb69540020573c128136015f2a26163f90081ea42fb43be1665ebaa24826cef9644c1ecf0dfcf955775b8438528e97820efc2b20ed46be1dc586c6ede7c260ca13beca7a3017513ac103b5dad8335213f57d38b78967c6608b90306466fe5211732ffecadba72c39be7bc8ce5bbc5f7126b2c439b3a4000000006ddf6e1ee758fde18425dbce46ccddab61afc4d83b90d27febdf928d8a18bfc6772b7d36a2e66e52c817f385d7e94d3d4b6d47d7171c9f2dd86c6f1be1a93eb030400050250c3000004000903a0860100000000000504010302000a0c00e1f5050000000009',
         },
     ],
 };

--- a/suite-common/wallet-utils/src/__tests__/solanaUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/solanaUtils.test.ts
@@ -32,6 +32,7 @@ describe('solana utils', () => {
                     input.amount,
                     input.mint,
                     input.decimals,
+                    input.tokenProgramName,
                 );
 
                 expect(txix.accounts).toEqual(expectedOutput.accounts);
@@ -48,6 +49,7 @@ describe('solana utils', () => {
                         input.funderAddress,
                         input.newOwnerAddress,
                         input.tokenMintAddress,
+                        input.tokenProgramName,
                     );
 
                     expect(pubkey).toEqual(expectedOutput.pubkey);
@@ -73,6 +75,7 @@ describe('solana utils', () => {
                     input.blockhash,
                     input.lastValidBlockHeight,
                     input.priorityFees,
+                    input.tokenProgramName,
                 );
                 const message = tx.transaction.serializeMessage();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7809,6 +7809,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@solana-program/token-2022@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "@solana-program/token-2022@npm:0.3.1"
+  peerDependencies:
+    "@solana/web3.js": ^2.0.0
+  checksum: 10/1d18bb7d5f160134a08b59aa651de102f0c11798b1a7c99af89928b27a00cb4021afc98cfb27dc666d3a384d7f180160d0e428e9d7cede5f959bf7e651c13707
+  languageName: node
+  linkType: hard
+
 "@solana-program/token@npm:^0.4.1":
   version: 0.4.1
   resolution: "@solana-program/token@npm:0.4.1"
@@ -9542,6 +9551,7 @@ __metadata:
     "@solana-program/compute-budget": "npm:^0.6.1"
     "@solana-program/system": "npm:^0.6.2"
     "@solana-program/token": "npm:^0.4.1"
+    "@solana-program/token-2022": "npm:^0.3.1"
     "@solana/web3.js": "npm:^2.0.0"
     "@suite-common/fiat-services": "workspace:*"
     "@suite-common/metadata-types": "workspace:*"
@@ -11321,6 +11331,7 @@ __metadata:
   resolution: "@trezor/blockchain-link@workspace:packages/blockchain-link"
   dependencies:
     "@solana-program/token": "npm:^0.4.1"
+    "@solana-program/token-2022": "npm:^0.3.1"
     "@solana/web3.js": "npm:^2.0.0"
     "@trezor/blockchain-link-types": "workspace:*"
     "@trezor/blockchain-link-utils": "workspace:*"


### PR DESCRIPTION
This PR adds support for Solana Token-2022 tokens. This means:
- Users can view Token-2022 tokens in the tokens list
- Users can send Token-2022 tokens
- Suite correctly parses _sent_ and _received_ transactions for Token-2022 tokens and displays them in the tx history

## Screenshots:
### Tokens list
<img width="1170" alt="tokens-list" src="https://github.com/user-attachments/assets/ac67a3cd-be81-4db0-ba72-625dd0cd9442">

### Send token
<img width="738" alt="send" src="https://github.com/user-attachments/assets/6c16fdf3-9115-4ac6-a028-89d4fca2c882">

### Transaction history
<img width="1180" alt="tx-history-received" src="https://github.com/user-attachments/assets/de8ac40f-3554-4ddf-ab45-1f5223dbcc15">
<img width="1184" alt="tx-history-sent" src="https://github.com/user-attachments/assets/ec6212f0-355d-4d33-a503-c22e8069e2f1">
