### PR TITLE
Readd udev/bridge installation info to transport events

### DIFF
--- a/packages/connect-iframe/src/index.ts
+++ b/packages/connect-iframe/src/index.ts
@@ -25,9 +25,7 @@ import { DataManager } from '@trezor/connect/src/data/DataManager';
 import { config } from '@trezor/connect/src/data/config';
 import { initLog, LogWriter } from '@trezor/connect/src/utils/debug';
 import { getOrigin } from '@trezor/connect/src/utils/urlUtils';
-import { suggestBridgeInstaller } from '@trezor/connect/src/data/transportInfo';
-import { suggestUdevInstaller } from '@trezor/connect/src/data/udevInfo';
-import { storage, getSystemInfo, getInstallerPackage } from '@trezor/connect-common';
+import { storage, getSystemInfo } from '@trezor/connect-common';
 import { analytics, EventType } from '@trezor/connect-analytics';
 
 import { parseConnectSettings, isOriginWhitelisted } from './connectSettings';
@@ -231,13 +229,6 @@ const postMessage = (message: CoreEventMessage) => {
     // check if permissions to read from device is granted
     if (!trustedHost && message.event === DEVICE_EVENT && !filterDeviceEvent(message)) {
         return;
-    }
-
-    if (message.event === TRANSPORT_EVENT) {
-        // add preferred bridge installer
-        const platform = getInstallerPackage();
-        message.payload.bridge = suggestBridgeInstaller(platform);
-        message.payload.udev = suggestUdevInstaller(platform);
     }
 
     if (usingPopup && _popupMessagePort) {

--- a/packages/connect-web/src/module/index.ts
+++ b/packages/connect-web/src/module/index.ts
@@ -19,7 +19,15 @@ const impl = new TrezorConnectDynamic<
     implementations: [
         {
             type: 'core-in-module',
-            impl: new CoreInModule(),
+            impl: new CoreInModule((message: CoreEventMessage) => {
+                if (message.event === TRANSPORT_EVENT) {
+                    const platform = getInstallerPackage();
+                    message.payload.bridge = suggestBridgeInstaller(platform);
+                    message.payload.udev = suggestUdevInstaller(platform);
+                }
+
+                return message;
+            }),
         },
     ],
     getInitTarget: () => 'core-in-module',

--- a/packages/connect-web/src/module/index.ts
+++ b/packages/connect-web/src/module/index.ts
@@ -4,7 +4,16 @@ import { TrezorConnectDynamic } from '@trezor/connect/src/impl/dynamic';
 import { CoreInModule } from '@trezor/connect/src/impl/core-in-module';
 import type { ConnectSettingsPublic } from '@trezor/connect/src/types';
 import type { ConnectFactoryDependencies } from '@trezor/connect/src/factory';
-import { CoreRequestMessage, ERRORS, TRANSPORT } from '@trezor/connect/src/exports';
+import {
+    CoreEventMessage,
+    CoreRequestMessage,
+    ERRORS,
+    TRANSPORT,
+    TRANSPORT_EVENT,
+} from '@trezor/connect/src/exports';
+import { getInstallerPackage } from '@trezor/connect-common';
+import { suggestBridgeInstaller } from '@trezor/connect/src/data/transportInfo';
+import { suggestUdevInstaller } from '@trezor/connect/src/data/udevInfo';
 
 interface ConnectWebDynamicImplementation
     extends ConnectFactoryDependencies<ConnectSettingsPublic> {


### PR DESCRIPTION
## Description

Since #14959 Connect is integrated in Suite without iframe. Because of that, udev & bridge installation info [is not injected into transport events](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-iframe/src/index.ts#L236-L241), which causes some issues in web Suite (compare production udev modal to develop one):
![image](https://github.com/user-attachments/assets/ab725628-ca6a-4856-91e9-06765842a817)
![image](https://github.com/user-attachments/assets/4dedbb34-1369-4473-92c9-9b00b3806f15)

As a quick fix I started to enhance the events on Connect core level (including ugly window check) with which I'm not happy at all, and I'm not well oriented in all the new Connect entry points, so if you guys (@martykan @karliatto) have any idea where to put this to be applicable only in web environment, share it with me pls.

Until that, I'll try to come up with a better way of propagating this info into Suite than to extend all the transport events.
