### PR TITLE
Feat: solve hash check on install false positives

### DIFF
--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -311,6 +311,8 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 case FORM_DRAFT.REMOVE_DRAFT:
                     storageActions.removeFormDraft(action.key);
                     break;
+
+                case deviceActions.connectDevice.type: // so that firmwareReducer.addCase for the same action is persisted
                 case firmwareActions.clearInvalidHash.type:
                 case firmwareActions.setHashInvalid.type:
                     api.dispatch(storageActions.saveFirmware());

--- a/suite-common/firmware/src/firmwareReducer.ts
+++ b/suite-common/firmware/src/firmwareReducer.ts
@@ -9,6 +9,7 @@ import {
 } from '@trezor/connect';
 import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
 import { deviceActions } from '@suite-common/wallet-core';
+import { isDeviceKnown } from '@suite-common/suite-utils';
 
 import { firmwareActions } from './firmwareActions';
 
@@ -86,6 +87,18 @@ export const prepareFirmwareReducer = createReducerWithExtraDeps(initialState, (
             state.cachedDevice = payload;
         })
         .addCase(deviceActions.addButtonRequest, extra.reducers.addButtonRequestFirmware)
+        .addCase(deviceActions.connectDevice, (state, { payload: { device } }) => {
+            if (!isDeviceKnown(device)) return;
+
+            // use the automatic hash check to clear device if it hasn't passed hash check done after firmware update
+            // otherwise it'd be stuck in "error" state until next firmware update
+            // in `storageMiddleware` this is persisted into storage (on the same action type)
+            if (device.authenticityChecks?.firmwareHash?.success) {
+                state.firmwareHashInvalid = state.firmwareHashInvalid.filter(
+                    deviceId => deviceId !== device.id,
+                );
+            }
+        })
         .addMatcher(
             action => action.type === extra.actionTypes.storageLoad,
             extra.reducers.storageLoadFirmware,

--- a/suite-common/firmware/src/firmwareThunks.ts
+++ b/suite-common/firmware/src/firmwareThunks.ts
@@ -158,7 +158,7 @@ export const firmwareUpdate = createThunk<
                 // hash check was performed, and it does not match, so consider firmware counterfeit
                 dispatch(handleFwHashMismatch(device));
             } else if (check === 'other-error') {
-                // device failed to respond to the hash check, consider the firmware counterfeit
+                // device failed to respond, so display a warning in the modal
                 dispatch(
                     handleFwHashError({
                         errorMessage: firmwareUpdateResponse.payload.checkError,

--- a/suite-common/firmware/src/firmwareThunks.ts
+++ b/suite-common/firmware/src/firmwareThunks.ts
@@ -9,11 +9,8 @@ import { getBinFilesBaseUrlThunk } from './getBinFilesBaseUrlThunk';
 
 export const handleFwHashError = createThunk(
     `${FIRMWARE_MODULE_PREFIX}/handleFwHashError`,
-    ({ device, errorMessage }: { device: TrezorDevice; errorMessage: string }, { dispatch }) => {
-        // device.id should always be present here (device is initialized and in normal mode) during successful TrezorConnect.getFirmwareHash call
-        if (device.id) {
-            dispatch(firmwareActions.setHashInvalid(device.id));
-        }
+    ({ errorMessage }: { errorMessage: string }, { dispatch }) => {
+        // TODO dispatch `setHashInvalid` once again when we are sure it works correctly.
         dispatch(
             firmwareActions.setFirmwareUpdateError(
                 `${errorMessage}. Unable to validate firmware hash. If you want to check authenticity of newly installed firmware please proceed to device settings and reinstall firmware.`,
@@ -27,7 +24,7 @@ export const INVALID_HASH_ERROR = 'Invalid hash';
 const handleFwHashMismatch = createThunk(
     `${FIRMWARE_MODULE_PREFIX}/handleFwHashMismatch`,
     (device: TrezorDevice, { dispatch }) => {
-        // see `handleFwHashError`
+        // device.id should always be present here (device is initialized and in normal mode) during successful TrezorConnect.getFirmwareHash call
         if (device.id) {
             dispatch(firmwareActions.setHashInvalid(device.id));
         }
@@ -38,7 +35,7 @@ const handleFwHashMismatch = createThunk(
 const handleFwHashValid = createThunk(
     `${FIRMWARE_MODULE_PREFIX}/handleFwHashValid`,
     (device: TrezorDevice, { dispatch }) => {
-        // see `handleFwHashError`
+        // device.id should always be present here (device is initialized and in normal mode) during successful TrezorConnect.getFirmwareHash call
         if (device.id) {
             dispatch(firmwareActions.clearInvalidHash(device.id));
         }
@@ -164,7 +161,6 @@ export const firmwareUpdate = createThunk<
                 // device failed to respond to the hash check, consider the firmware counterfeit
                 dispatch(
                     handleFwHashError({
-                        device,
                         errorMessage: firmwareUpdateResponse.payload.checkError,
                     }),
                 );

--- a/suite-common/suite-utils/src/device.ts
+++ b/suite-common/suite-utils/src/device.ts
@@ -1,4 +1,4 @@
-import { Device, UnavailableCapability, DeviceModelInternal } from '@trezor/connect';
+import { Device, UnavailableCapability, DeviceModelInternal, KnownDevice } from '@trezor/connect';
 import { TrezorDevice, AcquiredDevice } from '@suite-common/suite-types';
 import * as URLS from '@trezor/urls';
 
@@ -118,6 +118,10 @@ export const isDeviceAccessible = (device?: TrezorDevice) => {
 
     return device.mode === 'normal' && device.firmware !== 'required';
 };
+
+// useful for working with `Device` type straight from connect, which is missing `ExtendedDevice` properties (required on `TrezorDevice`)
+export const isDeviceKnown = (device?: Device): device is KnownDevice =>
+    device?.type === 'acquired';
 
 export const isDeviceAcquired = (device?: TrezorDevice): device is AcquiredDevice =>
     !!device?.features;


### PR DESCRIPTION
## Description

1. after FW update, if hash check threw an error, don't persist the device as hard failure FW
2. when device connects and succeeds automatic FW hash check _(even when turned off)_, exonerate it from having failed FW hash check after update
3. persist that in storage

Checkout [testing branch](https://github.com/trezor/trezor-suite/tree/feat/hash-check-on-install-false-positives-TESTING) to simulate hash mismatch, or other error _(separate commits for each)_

## Related issue

:disappointed:  Reopens https://github.com/trezor/trezor-suite/issues/5868

## Screenshots

1. **simulated other error:** only modal is displayed, but banner is not shown [other error is now soft.webm](https://github.com/user-attachments/assets/9a28e9a3-6cb9-4836-88e9-28b8c18aeddf)
2. **simulated hash mismatch:** banner is displayed at first, but reloading the suite clears it 
[hash mismatch is exonerated.webm](https://github.com/user-attachments/assets/b13de38d-ecd3-4d3f-832b-fba350702100)
