### PR TITLE
fix(suite): make sure getEthNetworkForWalletSdk never returns undefined

### DIFF
--- a/packages/suite/src/utils/suite/stake.ts
+++ b/packages/suite/src/utils/suite/stake.ts
@@ -44,9 +44,9 @@ export const getEthNetworkForWalletSdk = (
         thol: 'holesky',
         eth: 'mainnet',
     };
-    const network = symbol && symbol !== 'unknown' ? ethNetworks[symbol] : ethNetworks.eth;
+    const network = symbol && symbol !== 'unknown' ? ethNetworks[symbol] : null;
 
-    return network!;
+    return network ?? 'mainnet';
 };
 
 export const getAdjustedGasLimitConsumption = (estimatedFee: Success<BlockchainEstimatedFee>) =>


### PR DESCRIPTION
## Description
Suite is crashing on develop on OP and BNB, this should fix this issue. 

## Screenshots:
![image](https://github.com/user-attachments/assets/bcd0e95b-e9c6-47ed-aa5d-1749b18a4afd)

