### PR TITLE
fix(suite-native): send transaction error handling

### DIFF
--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -1144,6 +1144,19 @@ export const en = {
                 },
                 successMessage: 'Everything is ready, you can send the transaction now.',
                 submitButton: 'Send transaction',
+                errorAlert: {
+                    secondaryButtonTitle: 'I’ll do it later',
+                    generic: {
+                        title: 'Transaction failed',
+                        description:
+                            'There has been an unexpected error, please try sending your transaction again.',
+                    },
+                    solana: {
+                        title: 'Transaction failed due to timeout',
+                        description:
+                            'Make sure you send the transaction within 1 minute from signing.',
+                    },
+                },
             },
         },
     },


### PR DESCRIPTION
## Description
In case that transaction dispatch fails, the error is informed about it.

## Related Issue

Resolve #15464 

## Screenshots:

### Generic error
![Snímek obrazovky 2024-12-05 v 10 46 32](https://github.com/user-attachments/assets/12fb7670-26dc-4ff0-a4c4-95fd56b282b0)

# Solana timeout error
![Snímek obrazovky 2024-12-05 v 11 03 57](https://github.com/user-attachments/assets/1a110653-9c4a-4d81-b50f-1fa5880e22d0)



