### PR TITLE
refactor(suite-native): use semantic naming for pictogram variants

### DIFF
--- a/suite-native/accounts/src/components/AccountsList/AccountsListEmptyPlaceholder.tsx
+++ b/suite-native/accounts/src/components/AccountsList/AccountsListEmptyPlaceholder.tsx
@@ -55,7 +55,7 @@ export const AccountsListEmptyPlaceholder = ({
     return (
         <Box style={applyStyle(titleVariant)}>
             <PictogramTitleHeader
-                variant="yellow"
+                variant="info"
                 icon={getIcon()}
                 title={<Translation id="moduleAccounts.emptyState.title" />}
                 subtitle={<Translation id={getSubtitle()} />}

--- a/suite-native/alerts/src/components/AlertSheet.tsx
+++ b/suite-native/alerts/src/components/AlertSheet.tsx
@@ -100,7 +100,7 @@ export const AlertSheet = ({ alert }: AlertSheetProps) => {
                     >
                         <Card style={applyStyle(alertSheetContainerStyle)}>
                             <VStack style={applyStyle(alertSheetContentStyle)}>
-                                {icon && pictogramVariant && (
+                                {pictogramVariant && (
                                     <Box alignItems="center">
                                         <Pictogram variant={pictogramVariant} icon={icon} />
                                     </Box>

--- a/suite-native/atoms/src/Pictogram.tsx
+++ b/suite-native/atoms/src/Pictogram.tsx
@@ -1,58 +1,51 @@
-import { IconName, Icon } from '@suite-native/icons';
-import { Color } from '@trezor/theme';
+import { Icon, IconName } from '@suite-native/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+import { Color } from '@trezor/theme';
 
 import { Box } from './Box';
 
-export type PictogramVariant = 'green' | 'red' | 'yellow';
-export type PictogramSize = 'small' | 'large';
-
-const ICON_SIZE = 40;
+export type PictogramVariant = 'success' | 'info' | 'warning' | 'critical';
 
 type PictogramProps = {
     variant: PictogramVariant;
-    icon: IconName;
-    size?: PictogramSize;
+    icon?: IconName;
 };
 
 type PictogramStyle = {
     outerBackgroundColor: Color;
     innerBackgroundColor: Color;
+    iconName: IconName;
     iconColor: Color;
 };
+
 const pictogramVariantsMap = {
-    green: {
+    success: {
         outerBackgroundColor: 'backgroundPrimarySubtleOnElevation0',
         innerBackgroundColor: 'backgroundPrimarySubtleOnElevation1',
+        iconName: 'checkCircle',
         iconColor: 'iconPrimaryDefault',
     },
-    red: {
-        outerBackgroundColor: 'backgroundAlertRedSubtleOnElevation0',
-        innerBackgroundColor: 'backgroundAlertRedSubtleOnElevation1',
-        iconColor: 'iconAlertRed',
+    info: {
+        outerBackgroundColor: 'backgroundAlertBlueSubtleOnElevation0',
+        innerBackgroundColor: 'backgroundAlertBlueSubtleOnElevation1',
+        iconName: 'info',
+        iconColor: 'iconAlertBlue',
     },
-    yellow: {
+    warning: {
         outerBackgroundColor: 'backgroundAlertYellowSubtleOnElevation0',
         innerBackgroundColor: 'backgroundAlertYellowSubtleOnElevation1',
+        iconName: 'warning',
         iconColor: 'iconAlertYellow',
+    },
+    critical: {
+        outerBackgroundColor: 'backgroundAlertRedSubtleOnElevation0',
+        innerBackgroundColor: 'backgroundAlertRedSubtleOnElevation1',
+        iconName: 'warning',
+        iconColor: 'iconAlertRed',
     },
 } as const satisfies Record<PictogramVariant, PictogramStyle>;
 
-type PictogramSizeProps = { outerRingSize: number; innerRingSize: number };
-const sizeToDimensionsMap = {
-    small: {
-        outerRingSize: 88,
-        innerRingSize: 64,
-    },
-    large: {
-        outerRingSize: 104,
-        innerRingSize: 80,
-    },
-} as const satisfies Record<PictogramSize, PictogramSizeProps>;
-
-type CircleStyleProps = { backgroundColorName: Color; size: number };
-
-const circleContainerStyle = prepareNativeStyle<CircleStyleProps>(
+const circleContainerStyle = prepareNativeStyle<{ backgroundColorName: Color; size: number }>(
     (utils, { backgroundColorName, size }) => ({
         alignItems: 'center',
         justifyContent: 'center',
@@ -63,25 +56,25 @@ const circleContainerStyle = prepareNativeStyle<CircleStyleProps>(
     }),
 );
 
-export const Pictogram = ({ variant, icon, size = 'large' }: PictogramProps) => {
+export const Pictogram = ({ variant, icon }: PictogramProps) => {
     const { applyStyle } = useNativeStyles();
-    const { outerBackgroundColor, innerBackgroundColor, iconColor } = pictogramVariantsMap[variant];
-    const { outerRingSize, innerRingSize } = sizeToDimensionsMap[size];
+    const { outerBackgroundColor, innerBackgroundColor, iconName, iconColor } =
+        pictogramVariantsMap[variant];
 
     return (
         <Box
             style={applyStyle(circleContainerStyle, {
                 backgroundColorName: outerBackgroundColor,
-                size: outerRingSize,
+                size: 104,
             })}
         >
             <Box
                 style={applyStyle(circleContainerStyle, {
                     backgroundColorName: innerBackgroundColor,
-                    size: innerRingSize,
+                    size: 80,
                 })}
             >
-                <Icon name={icon} color={iconColor} size={ICON_SIZE} />
+                <Icon name={icon ?? iconName} color={iconColor} size={40} />
             </Box>
         </Box>
     );

--- a/suite-native/atoms/src/TitleHeader/PictogramTitleHeader.tsx
+++ b/suite-native/atoms/src/TitleHeader/PictogramTitleHeader.tsx
@@ -4,13 +4,12 @@ import { IconName } from '@suite-native/icons';
 import { TypographyStyle } from '@trezor/theme';
 
 import { VStack } from '../Stack';
-import { PictogramVariant, PictogramSize, Pictogram } from '../Pictogram';
+import { PictogramVariant, Pictogram } from '../Pictogram';
 import { CenteredTitleHeader } from './CenteredTitleHeader';
 
 type PictogramTitleHeaderProps = {
     variant: PictogramVariant;
-    icon: IconName;
-    size?: PictogramSize;
+    icon?: IconName;
     title?: ReactNode;
     titleVariant?: TypographyStyle;
     subtitle?: ReactNode;
@@ -22,11 +21,10 @@ export const PictogramTitleHeader = ({
     title,
     subtitle,
     titleVariant = 'titleSmall',
-    size = 'large',
 }: PictogramTitleHeaderProps) => {
     return (
         <VStack alignItems="center" spacing="sp24">
-            <Pictogram variant={variant} icon={icon} size={size} />
+            <Pictogram variant={variant} icon={icon} />
             <CenteredTitleHeader title={title} subtitle={subtitle} titleVariant={titleVariant} />
         </VStack>
     );

--- a/suite-native/biometrics/src/useBiometricsSettings.ts
+++ b/suite-native/biometrics/src/useBiometricsSettings.ts
@@ -29,8 +29,7 @@ export const useBiometricsSettings = () => {
                     'No security features on your device. Make sure you have biometrics setup on your phone and try again.',
                 primaryButtonTitle: 'Cancel',
                 onPressPrimaryButton: () => null,
-                icon: 'warningCircle',
-                pictogramVariant: 'yellow',
+                pictogramVariant: 'warning',
             });
 
             return 'notAvailable';

--- a/suite-native/device-authorization/src/hooks/useHandlePassphraseMismatch.tsx
+++ b/suite-native/device-authorization/src/hooks/useHandlePassphraseMismatch.tsx
@@ -64,8 +64,7 @@ export const useHandlePassphraseMismatch = () => {
                     });
                 },
                 secondaryButtonVariant: 'redElevation0',
-                icon: 'warning',
-                pictogramVariant: 'red',
+                pictogramVariant: 'critical',
             });
         }
     }, [dispatch, hasPassphraseMismatchError, navigation, showAlert]);

--- a/suite-native/device/src/hooks/useDetectDeviceError.tsx
+++ b/suite-native/device/src/hooks/useDetectDeviceError.tsx
@@ -83,8 +83,7 @@ export const useDetectDeviceError = () => {
             showAlert({
                 title: <Translation id="moduleDevice.unacquiredDeviceModal.title" />,
                 description: <Translation id="moduleDevice.unacquiredDeviceModal.description" />,
-                icon: 'warningCircle',
-                pictogramVariant: 'red',
+                pictogramVariant: 'critical',
                 primaryButtonTitle: <Translation id="moduleDevice.unacquiredDeviceModal.button" />,
                 appendix: <UnacquiredDeviceModalAppendix />,
                 onPressPrimaryButton: () => dispatch(acquireDevice()),
@@ -100,8 +99,7 @@ export const useDetectDeviceError = () => {
             showAlert({
                 title: <Translation id="moduleDevice.unsupportedFirmwareModal.title" />,
                 description: <Translation id="moduleDevice.unsupportedFirmwareModal.description" />,
-                icon: 'warningCircle',
-                pictogramVariant: 'red',
+                pictogramVariant: 'critical',
                 primaryButtonTitle: <Translation id="generic.buttons.eject" />,
                 primaryButtonVariant: 'tertiaryElevation1',
                 appendix: <IncompatibleFirmwareModalAppendix />,
@@ -134,8 +132,7 @@ export const useDetectDeviceError = () => {
             if (hasDeviceFirmwareInstalled) {
                 showAlert({
                     title: <Translation id="moduleDevice.noSeedWithFWModal.title" />,
-                    icon: 'checkCircle',
-                    pictogramVariant: 'green',
+                    pictogramVariant: 'success',
                     description: <Translation id="moduleDevice.noSeedWithFWModal.description" />,
                     primaryButtonTitle: (
                         <Translation id="moduleDevice.noSeedWithFWModal.primaryButton" />
@@ -189,8 +186,7 @@ export const useDetectDeviceError = () => {
             showAlert({
                 title: <Translation id="moduleDevice.bootloaderModal.title" />,
                 description: <Translation id="moduleDevice.bootloaderModal.description" />,
-                icon: 'warningCircle',
-                pictogramVariant: 'red',
+                pictogramVariant: 'critical',
                 primaryButtonVariant: 'tertiaryElevation1',
                 primaryButtonTitle: <Translation id="generic.buttons.eject" />,
                 appendix: <BootloaderModalAppendix />,
@@ -219,8 +215,7 @@ export const useDetectDeviceError = () => {
             showAlert({
                 title: <Translation id="moduleDevice.genericErrorModal.title" />,
                 description: <Translation id="moduleDevice.genericErrorModal.description" />,
-                icon: 'warningCircle',
-                pictogramVariant: 'red',
+                pictogramVariant: 'critical',
                 primaryButtonVariant: 'redBold',
                 primaryButtonTitle: (
                     <Translation id="moduleDevice.genericErrorModal.buttons.reconnect" />

--- a/suite-native/message-system/src/components/FeatureMessageScreen.tsx
+++ b/suite-native/message-system/src/components/FeatureMessageScreen.tsx
@@ -2,10 +2,8 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { A, G } from '@mobily/ts-belt';
 
-import { IconName } from '@suite-native/icons';
-import { Box, Button, PictogramTitleHeader, PictogramVariant, VStack } from '@suite-native/atoms';
+import { Box, Button, PictogramTitleHeader, VStack } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
-import { Variant } from '@suite-common/suite-types';
 import { messageSystemActions, selectActiveFeatureMessages } from '@suite-common/message-system';
 import { Translation } from '@suite-native/intl';
 import { useOpenLink } from '@suite-native/link';
@@ -33,18 +31,6 @@ const contentStyle = prepareNativeStyle(_ => ({
 const buttonsWrapperStyle = prepareNativeStyle(_ => ({
     width: '100%',
 }));
-
-const variantMap = {
-    info: 'green',
-    warning: 'yellow',
-    critical: 'red',
-} as const satisfies Record<Variant, PictogramVariant>;
-
-const iconVariantMap = {
-    info: 'info',
-    warning: 'warning',
-    critical: 'warning',
-} as const satisfies Record<Variant, IconName>;
 
 export const FeatureMessageScreen = () => {
     const dispatch = useDispatch();
@@ -115,14 +101,12 @@ export const FeatureMessageScreen = () => {
         <Box style={applyStyle(screenStyle)}>
             <Box style={applyStyle(contentStyle)}>
                 <PictogramTitleHeader
+                    variant={variant}
                     title={messageTitle ?? defaultTitle}
-                    variant={variantMap[variant]}
                     subtitle={messageContent ?? defaultContent}
-                    icon={iconVariantMap[variant]}
                     titleVariant="titleMedium"
                 />
             </Box>
-
             <VStack spacing="sp16" style={applyStyle(buttonsWrapperStyle)}>
                 {isCtaVisible && (
                     <Button size="large" colorScheme="primary" onPress={handleCtaPress}>

--- a/suite-native/module-accounts-import/src/components/AccountImportSummaryScreen.tsx
+++ b/suite-native/module-accounts-import/src/components/AccountImportSummaryScreen.tsx
@@ -33,12 +33,7 @@ export const AccountImportSummaryScreen = ({
         >
             <VStack spacing="sp32" flex={1}>
                 <Box flex={1} alignItems="center" justifyContent="center">
-                    <PictogramTitleHeader
-                        title={title}
-                        subtitle={subtitle}
-                        variant="green"
-                        icon="coinVerticalCheck"
-                    />
+                    <PictogramTitleHeader variant="success" title={title} subtitle={subtitle} />
                 </Box>
                 <Box flex={1} justifyContent="flex-end" testID={testID}>
                     {children}

--- a/suite-native/module-accounts-import/src/screens/XpubScanScreen.tsx
+++ b/suite-native/module-accounts-import/src/screens/XpubScanScreen.tsx
@@ -103,8 +103,7 @@ export const XpubScanScreen = ({
                 description: (
                     <Translation id="moduleAccountImport.xpubScanScreen.alert.xpub.description" />
                 ),
-                icon: 'warningCircle',
-                pictogramVariant: 'red',
+                pictogramVariant: 'critical',
                 primaryButtonTitle: <Translation id="generic.buttons.gotIt" />,
                 onPressPrimaryButton: () => null,
             });
@@ -123,8 +122,7 @@ export const XpubScanScreen = ({
                 description: (
                     <Translation id="moduleAccountImport.xpubScanScreen.alert.address.description" />
                 ),
-                icon: 'warningCircle',
-                pictogramVariant: 'red',
+                pictogramVariant: 'critical',
                 primaryButtonTitle: <Translation id="generic.buttons.gotIt" />,
                 onPressPrimaryButton: () => null,
                 secondaryButtonTitle: (

--- a/suite-native/module-accounts-import/src/useShowImportError.ts
+++ b/suite-native/module-accounts-import/src/useShowImportError.ts
@@ -10,40 +10,34 @@ import {
     StackToStackCompositeNavigationProps,
 } from '@suite-native/navigation';
 import { IconName } from '@suite-native/icons';
-import { PictogramVariant } from '@suite-native/atoms';
 
 type AlertError = 'invalidXpub' | 'invalidReceiveAddress' | 'networkError' | 'unknownError';
 type AlertErrorOptions = {
     title: string;
     description: string;
-    icon: IconName;
+    icon?: IconName;
 };
 
 const alertErrorMap: Record<AlertError, AlertErrorOptions> = {
     invalidXpub: {
         title: 'Invalid Public address (XPUB)',
         description: 'Check and correct the public address (XPUB).',
-        icon: 'warning',
     },
     invalidReceiveAddress: {
         title: 'Receive address invalid',
         description: 'Check and correct the receive address.',
-        icon: 'warning',
     },
     networkError: {
         title: 'Network error',
-        icon: 'wifiX',
         description:
             'We were unable to retrieve the data from the blockchain due to a network error.',
+        icon: 'wifiX',
     },
     unknownError: {
         title: 'Something went wrong',
-        icon: 'warning',
         description: 'We are unable to gather the data right now. Please try again.',
     },
 };
-
-const pictogramVariant: PictogramVariant = 'red';
 
 type NavigationProp = StackToStackCompositeNavigationProps<
     AccountsImportStackParamList,
@@ -88,7 +82,7 @@ export const useShowImportError = (networkSymbol: NetworkSymbol, navigation: Nav
                     title,
                     description,
                     icon,
-                    pictogramVariant,
+                    pictogramVariant: 'critical',
                     primaryButtonTitle: 'Try Again',
                     onPressPrimaryButton: onRetry,
                     secondaryButtonTitle: 'Go back',
@@ -99,7 +93,7 @@ export const useShowImportError = (networkSymbol: NetworkSymbol, navigation: Nav
                     title,
                     description,
                     icon,
-                    pictogramVariant,
+                    pictogramVariant: 'critical',
                     primaryButtonTitle: 'Go back',
                     onPressPrimaryButton: handleGoBack,
                     testID: `@alert-sheet/error/${alertError}`,

--- a/suite-native/module-accounts-management/src/components/AccountSettingsRemoveCoinButton.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountSettingsRemoveCoinButton.tsx
@@ -45,8 +45,7 @@ export const AccountSettingsRemoveCoinButton = ({
 
     const handleShowAlert = () => {
         showAlert({
-            icon: 'shieldWarning',
-            pictogramVariant: 'red',
+            pictogramVariant: 'critical',
             title: (
                 <>
                     Do you really want to remove this coin from <TrezorSuiteLiteHeader />?
@@ -55,9 +54,10 @@ export const AccountSettingsRemoveCoinButton = ({
             description:
                 'Your coins remain intact and safe. Import this coin again using your public key (XPUB) or receive address at any time.',
             primaryButtonTitle: 'Remove coin',
-            primaryButtonVariant: 'redElevation0',
+            primaryButtonVariant: 'redBold',
             onPressPrimaryButton: handleRemoveAccount,
             secondaryButtonTitle: 'Cancel',
+            secondaryButtonVariant: 'redElevation0',
             onPressSecondaryButton: () => hideAlert(),
         });
     };

--- a/suite-native/module-add-accounts/src/hooks/useAddCoinAccountAlerts.ts
+++ b/suite-native/module-add-accounts/src/hooks/useAddCoinAccountAlerts.ts
@@ -11,8 +11,7 @@ export const useAddCoinAccountAlerts = () => {
         showAlert({
             title: translate('moduleAddAccounts.alerts.tooManyAccounts.title'),
             description: translate('moduleAddAccounts.alerts.tooManyAccounts.description'),
-            icon: 'warning',
-            pictogramVariant: 'red',
+            pictogramVariant: 'critical',
             primaryButtonTitle: translate('moduleAddAccounts.alerts.tooManyAccounts.actionPrimary'),
             onPressPrimaryButton: hideAlert,
         });
@@ -21,8 +20,7 @@ export const useAddCoinAccountAlerts = () => {
         showAlert({
             title: translate('moduleAddAccounts.alerts.anotherEmptyAccount.title'),
             description: translate('moduleAddAccounts.alerts.anotherEmptyAccount.description'),
-            icon: 'warning',
-            pictogramVariant: 'red',
+            pictogramVariant: 'critical',
             primaryButtonTitle: translate(
                 'moduleAddAccounts.alerts.anotherEmptyAccount.actionPrimary',
             ),
@@ -42,15 +40,14 @@ export const useAddCoinAccountAlerts = () => {
         showAlert({
             title: translate('moduleAddAccounts.alerts.generalError.title'),
             description: translate('moduleAddAccounts.alerts.generalError.description'),
-            icon: 'warning',
-            pictogramVariant: 'red',
+            pictogramVariant: 'critical',
             primaryButtonTitle: translate('moduleAddAccounts.alerts.generalError.actionPrimary'),
             onPressPrimaryButton: hideAlert,
         });
     const showPassphraseAuthAlert = () =>
         showAlert({
             title: translate('modulePassphrase.featureAuthorizationError'),
-            pictogramVariant: 'red',
+            pictogramVariant: 'critical',
             primaryButtonTitle: translate('generic.buttons.close'),
             primaryButtonVariant: 'redBold',
         });

--- a/suite-native/module-authorize-device/src/components/connect/ConnectDeviceScreenHeader.tsx
+++ b/suite-native/module-authorize-device/src/components/connect/ConnectDeviceScreenHeader.tsx
@@ -55,8 +55,7 @@ export const ConnectDeviceScreenHeader = ({
                 description: (
                     <Translation id="moduleConnectDevice.pinCanceledDuringDiscovery.subtitle" />
                 ),
-                icon: 'warningCircle',
-                pictogramVariant: 'red',
+                pictogramVariant: 'critical',
                 primaryButtonTitle: (
                     <Translation id="moduleConnectDevice.pinCanceledDuringDiscovery.button" />
                 ),

--- a/suite-native/module-authorize-device/src/components/connect/PinFormControlButtons.tsx
+++ b/suite-native/module-authorize-device/src/components/connect/PinFormControlButtons.tsx
@@ -71,8 +71,7 @@ export const PinFormControlButtons = ({ onSuccess }: PinFormControlButtonsProps)
             description: (
                 <Translation id="moduleConnectDevice.pinScreen.wrongPinAlert.description" />
             ),
-            icon: 'warningCircle',
-            pictogramVariant: 'red',
+            pictogramVariant: 'critical',
             primaryButtonTitle: (
                 <Translation id="moduleConnectDevice.pinScreen.wrongPinAlert.button.tryAgain" />
             ),

--- a/suite-native/module-device-settings/src/screens/DeviceAuthenticitySummaryScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/DeviceAuthenticitySummaryScreen.tsx
@@ -7,7 +7,6 @@ import {
     PictogramVariant,
     VStack,
 } from '@suite-native/atoms';
-import { IconName } from '@suite-native/icons';
 import { Translation, TxKeyPath } from '@suite-native/intl';
 import {
     DeviceAuthenticityStackParamList,
@@ -22,7 +21,6 @@ import {
 type CheckResult = 'successful' | 'compromised';
 type SummaryConfig = {
     pictogramVariant: PictogramVariant;
-    pictogramIcon: IconName;
     title: TxKeyPath;
     subtitle: TxKeyPath;
     closeColorScheme: ButtonColorScheme;
@@ -30,15 +28,13 @@ type SummaryConfig = {
 
 const summaryConfigMap = {
     successful: {
-        pictogramVariant: 'green',
-        pictogramIcon: 'check',
+        pictogramVariant: 'success',
         title: 'moduleDeviceSettings.authenticity.summary.successful.title',
         subtitle: 'moduleDeviceSettings.authenticity.summary.successful.subtitle',
         closeColorScheme: 'primary',
     },
     compromised: {
-        pictogramVariant: 'red',
-        pictogramIcon: 'warningCircle',
+        pictogramVariant: 'critical',
         title: 'moduleDeviceSettings.authenticity.summary.compromised.title',
         subtitle: 'moduleDeviceSettings.authenticity.summary.compromised.subtitle',
         closeColorScheme: 'redElevation0',
@@ -57,8 +53,7 @@ export const DeviceAuthenticitySummaryScreen = ({
     const navigateToInitialScreen = useNavigateToInitialScreen();
     const openLink = useOpenLink();
 
-    const { pictogramVariant, pictogramIcon, title, subtitle, closeColorScheme } =
-        summaryConfigMap[checkResult];
+    const { pictogramVariant, title, subtitle, closeColorScheme } = summaryConfigMap[checkResult];
 
     return (
         <Screen
@@ -74,7 +69,6 @@ export const DeviceAuthenticitySummaryScreen = ({
             <VStack flex={1} spacing="sp40" justifyContent="center">
                 <PictogramTitleHeader
                     variant={pictogramVariant}
-                    icon={pictogramIcon}
                     title={<Translation id={title} />}
                     titleVariant="titleMedium"
                     subtitle={<Translation id={subtitle} />}

--- a/suite-native/module-home/src/screens/HomeScreen/components/EmptyConnectedDeviceState.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/EmptyConnectedDeviceState.tsx
@@ -40,9 +40,7 @@ export const EmptyConnectedDeviceState = () => {
         <Card style={applyStyle(cardStyle)}>
             <VStack spacing="sp24" style={applyStyle(contentStyle)}>
                 <PictogramTitleHeader
-                    variant="green"
-                    size="large"
-                    icon="info"
+                    variant="info"
                     title={<Translation id="moduleHome.emptyState.device.title" />}
                     subtitle={<Translation id="moduleHome.emptyState.device.subtitle" />}
                 />

--- a/suite-native/module-send/src/components/AddressReviewHelpSheet.tsx
+++ b/suite-native/module-send/src/components/AddressReviewHelpSheet.tsx
@@ -20,7 +20,7 @@ export const AddressReviewHelpSheet = ({ body, title, subtitle }: AddressReviewH
             description: subtitle,
             appendix: body,
             textAlign: 'left',
-            pictogramVariant: 'red',
+            pictogramVariant: 'critical',
             primaryButtonTitle: <Translation id="generic.buttons.gotIt" />,
             titleSpacing: 'sp4',
         });

--- a/suite-native/module-send/src/hooks/useHandleOnDeviceTransactionReview.tsx
+++ b/suite-native/module-send/src/hooks/useHandleOnDeviceTransactionReview.tsx
@@ -101,7 +101,7 @@ export const useHandleOnDeviceTransactionReview = () => {
             ) {
                 showAlert({
                     title: <Translation id="modulePassphrase.featureAuthorizationError" />,
-                    pictogramVariant: 'red',
+                    pictogramVariant: 'critical',
                     primaryButtonTitle: <Translation id="generic.buttons.close" />,
                     primaryButtonVariant: 'redBold',
                 });

--- a/suite-native/module-settings/src/components/SupportCard.tsx
+++ b/suite-native/module-settings/src/components/SupportCard.tsx
@@ -24,7 +24,7 @@ export const SupportCard = () => {
                         <Translation id="moduleSettings.faq.supportCard.contact" />
                     </Button>
                 </VStack>
-                <PictogramTitleHeader variant="green" size="small" icon="lifebuoy" />
+                <PictogramTitleHeader variant="success" icon="lifebuoy" />
             </HStack>
         </Card>
     );

--- a/suite-native/qr-code/src/components/XpubQRCodeWarningOverlay.tsx
+++ b/suite-native/qr-code/src/components/XpubQRCodeWarningOverlay.tsx
@@ -13,8 +13,7 @@ export const XpubOverlayWarning = () => {
     return (
         <Box style={applyStyle(overlayStyle)}>
             <PictogramTitleHeader
-                variant="yellow"
-                icon="warningCircle"
+                variant="warning"
                 title="Handle your public key (XPUB) with caution"
                 subtitle="Sharing your public key (XPUB) with a third party gives them the ability to
                         view your transaction history."

--- a/suite-native/receive/src/components/UnverifiedAddressWarning.tsx
+++ b/suite-native/receive/src/components/UnverifiedAddressWarning.tsx
@@ -39,8 +39,7 @@ export const UnverifiedAddressWarning = () => {
     return (
         <Box marginVertical="sp16" paddingHorizontal="sp16" paddingVertical="sp32">
             <PictogramTitleHeader
-                variant="yellow"
-                icon="warning"
+                variant="warning"
                 title={pictogramContent[pictogramContentKey].title}
                 subtitle={pictogramContent[pictogramContentKey].subtitle}
             />

--- a/suite-native/receive/src/hooks/useAccountReceiveAddress.tsx
+++ b/suite-native/receive/src/hooks/useAccountReceiveAddress.tsx
@@ -86,7 +86,7 @@ export const useAccountReceiveAddress = (accountKey: AccountKey) => {
             ) {
                 showAlert({
                     title: <Translation id="modulePassphrase.featureAuthorizationError" />,
-                    pictogramVariant: 'red',
+                    pictogramVariant: 'critical',
                     primaryButtonTitle: <Translation id="generic.buttons.close" />,
                     onPressPrimaryButton: handleCancel,
                     primaryButtonVariant: 'redBold',
@@ -108,8 +108,7 @@ export const useAccountReceiveAddress = (accountKey: AccountKey) => {
                 showAlert({
                     title: response.payload.payload.code,
                     description: response.payload.payload.error,
-                    icon: 'warningCircle',
-                    pictogramVariant: 'red',
+                    pictogramVariant: 'critical',
                     primaryButtonTitle: <Translation id="generic.buttons.cancel" />,
                     onPressPrimaryButton: () => {
                         handleCancel();


### PR DESCRIPTION
- Semantic names `success`, `info`, `warning` and `critical` used instead of colours
- Small size pictograms removed as required by @shenkys
- Added default icon for each pictogram variant
- Revised and updated pictogram usages

## Related Issue

#15487
