### PR TITLE
Feat(suite): analytics OS versions

### DIFF
--- a/packages/suite-desktop-api/src/__tests__/api.test.ts
+++ b/packages/suite-desktop-api/src/__tests__/api.test.ts
@@ -304,5 +304,13 @@ describe('DesktopApi', () => {
             // @ts-expect-error param expected
             api.loadModules();
         });
+
+        it('DesktopApi.getSystemInformation', async () => {
+            const spy = jest
+                .spyOn(ipcRenderer, 'invoke')
+                .mockImplementation(() => Promise.resolve());
+            await api.getSystemInformation();
+            expect(spy).toHaveBeenCalledWith('system/get-system-information');
+        });
     });
 });

--- a/packages/suite-desktop-api/src/api.ts
+++ b/packages/suite-desktop-api/src/api.ts
@@ -18,6 +18,7 @@ import {
     TraySettings,
     ConnectPopupResponse,
     ConnectPopupCall,
+    GetSystemInformationResponse,
 } from './messages';
 
 // Event messages from renderer to main process
@@ -107,6 +108,7 @@ export interface InvokeChannels {
     'connect-popup/enabled': () => boolean;
     'connect-popup/ready': () => void;
     'connect-popup/response': (response: ConnectPopupResponse) => void;
+    'system/get-system-information': () => InvokeResult<GetSystemInformationResponse>;
 }
 
 type DesktopApiListener = ListenerMethod<RendererChannels>;
@@ -173,4 +175,6 @@ export interface DesktopApi {
     connectPopupEnabled: DesktopApiInvoke<'connect-popup/enabled'>;
     connectPopupReady: DesktopApiInvoke<'connect-popup/ready'>;
     connectPopupResponse: DesktopApiInvoke<'connect-popup/response'>;
+    //system
+    getSystemInformation: DesktopApiInvoke<'system/get-system-information'>;
 }

--- a/packages/suite-desktop-api/src/factory.ts
+++ b/packages/suite-desktop-api/src/factory.ts
@@ -182,5 +182,7 @@ export const factory = <R extends StrictIpcRenderer<any, IpcRendererEvent>>(
         connectPopupEnabled: () => ipcRenderer.invoke('connect-popup/enabled'),
         connectPopupReady: () => ipcRenderer.invoke('connect-popup/ready'),
         connectPopupResponse: response => ipcRenderer.invoke('connect-popup/response', response),
+
+        getSystemInformation: () => ipcRenderer.invoke('system/get-system-information'),
     };
 };

--- a/packages/suite-desktop-api/src/messages.ts
+++ b/packages/suite-desktop-api/src/messages.ts
@@ -140,3 +140,9 @@ export type ConnectPopupResponse = {
     success: boolean;
     payload: any;
 };
+
+export type GetSystemInformationResponse = {
+    osVersion: string;
+    osName: string;
+    osArchitecture: string;
+};

--- a/packages/suite-desktop-core/src/modules/index.ts
+++ b/packages/suite-desktop-core/src/modules/index.ts
@@ -34,6 +34,7 @@ import * as fileProtocol from './file-protocol';
 import * as autoStart from './auto-start';
 import * as tray from './tray';
 import * as bridge from './bridge';
+import * as systemInformation from './system-information';
 import { MainWindowProxy } from '../libs/main-window-proxy';
 
 // General modules (both dev & prod)
@@ -63,6 +64,7 @@ const MODULES: Module[] = [
     coinjoin,
     autoStart,
     bridge,
+    systemInformation,
     // Modules used only in dev/prod mode
     ...(isDevEnv ? [] : [csp, fileProtocol]),
 ];

--- a/packages/suite-desktop-core/src/modules/system-information.ts
+++ b/packages/suite-desktop-core/src/modules/system-information.ts
@@ -1,0 +1,25 @@
+import os from 'os';
+
+import { validateIpcMessage } from '@trezor/ipc-proxy';
+
+import { ipcMain } from '../typed-electron';
+
+import type { ModuleInit } from './index';
+
+export const SERVICE_NAME = 'system-information';
+
+export const init: ModuleInit = () => {
+    ipcMain.handle('system/get-system-information', ipcEvent => {
+        validateIpcMessage(ipcEvent);
+
+        try {
+            const osVersion = os.platform();
+            const osName = os.release();
+            const osArchitecture = os.arch();
+
+            return { success: true, payload: { osVersion, osName, osArchitecture } };
+        } catch (error) {
+            return { success: false, error };
+        }
+    });
+};

--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -95,9 +95,12 @@ const analyticsMiddleware =
         switch (action.type) {
             case SUITE.READY:
                 // reporting can start when analytics is properly initialized and enabled
-                analytics.report({
-                    type: EventType.SuiteReady,
-                    payload: getSuiteReadyPayload(state),
+                // it is done async because ipcMain is queried for system info, if available
+                getSuiteReadyPayload(state).then(payload => {
+                    analytics.report({
+                        type: EventType.SuiteReady,
+                        payload,
+                    });
                 });
                 break;
             case TRANSPORT.START:

--- a/packages/suite/src/middlewares/suite/sentryMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/sentryMiddleware.ts
@@ -97,7 +97,10 @@ const sentryMiddleware =
 
         switch (action.type) {
             case SUITE.READY:
-                setSentryContext('suite-ready', getSuiteReadyPayload(state));
+                // done async because ipcMain is queried for system info, if available
+                getSuiteReadyPayload(state).then(payload =>
+                    setSentryContext('suite-ready', payload),
+                );
                 break;
             case DEVICE.CONNECT: {
                 const { features, mode } = action.payload.device;

--- a/packages/suite/src/utils/suite/analytics.ts
+++ b/packages/suite/src/utils/suite/analytics.ts
@@ -9,10 +9,12 @@ import {
     getWindowWidth,
     getWindowHeight,
     getPlatformLanguages,
+    isDesktop,
 } from '@trezor/env-utils';
 import { getCustomBackends } from '@suite-common/wallet-utils';
 import { UNIT_ABBREVIATIONS } from '@suite-common/suite-constants';
-import type { UpdateInfo } from '@trezor/suite-desktop-api';
+import { desktopApi, UpdateInfo } from '@trezor/suite-desktop-api';
+import { GetSystemInformationResponse } from '@trezor/suite-desktop-api/src/messages';
 import {
     selectRememberedStandardWalletsCount,
     selectRememberedHiddenWalletsCount,
@@ -22,6 +24,17 @@ import { AccountTransactionBaseAnchor } from 'src/constants/suite/anchors';
 import { AppState } from 'src/types/suite';
 
 import { getIsTorEnabled } from './tor';
+
+const getOptionalSystemInformation = async (): Promise<GetSystemInformationResponse | null> => {
+    if (!isDesktop()) return null;
+    try {
+        const response = await desktopApi.getSystemInformation();
+
+        return response.success ? response.payload : null;
+    } catch {
+        return null;
+    }
+};
 
 // redact transaction id from account transaction anchor
 export const redactTransactionIdFromAnchor = (anchor?: string) => {
@@ -35,39 +48,50 @@ export const redactTransactionIdFromAnchor = (anchor?: string) => {
 // 1. replace coinjoin by taproot
 export const redactRouterUrl = (url: string) => url.replace(/coinjoin/g, 'taproot');
 
-export const getSuiteReadyPayload = (state: AppState) => ({
-    language: state.suite.settings.language,
-    enabledNetworks: state.wallet.settings.enabledNetworks,
-    customBackends: getCustomBackends(state.wallet.blockchain)
-        .map(({ coin }) => coin)
-        .filter(coin => state.wallet.settings.enabledNetworks.includes(coin)),
-    localCurrency: state.wallet.settings.localCurrency,
-    bitcoinUnit: UNIT_ABBREVIATIONS[state.wallet.settings.bitcoinAmountUnit],
-    discreetMode: state.wallet.settings.discreetMode,
-    screenWidth: getScreenWidth(),
-    screenHeight: getScreenHeight(),
-    platformLanguages: getPlatformLanguages().join(','),
-    tor: getIsTorEnabled(state.suite.torStatus),
-    // todo: duplicated with suite/src/utils/suite/logUtils
-    labeling: state.metadata.enabled
-        ? state.metadata.providers.find(p => p.clientId === state.metadata.selectedProvider.labels)
-              ?.type || 'missing-provider'
-        : '',
-    rememberedStandardWallets: selectRememberedStandardWalletsCount(state),
-    rememberedHiddenWallets: selectRememberedHiddenWalletsCount(state),
-    theme: state.suite.settings.theme.variant,
-    suiteVersion: process.env.VERSION || '',
-    earlyAccessProgram: state.desktopUpdate.allowPrerelease,
-    experimentalFeatures: state.suite.settings.experimental,
-    browserName: getBrowserName(),
-    browserVersion: getBrowserVersion(),
-    osName: getOsName(),
-    osVersion: getOsVersion(),
-    windowWidth: getWindowWidth(),
-    windowHeight: getWindowHeight(),
-    autodetectLanguage: state.suite.settings.autodetect.language,
-    autodetectTheme: state.suite.settings.autodetect.theme,
-});
+export const getSuiteReadyPayload = async (state: AppState) => {
+    const systemInformation = await getOptionalSystemInformation();
+
+    return {
+        language: state.suite.settings.language,
+        enabledNetworks: state.wallet.settings.enabledNetworks,
+        customBackends: getCustomBackends(state.wallet.blockchain)
+            .map(({ coin }) => coin)
+            .filter(coin => state.wallet.settings.enabledNetworks.includes(coin)),
+        localCurrency: state.wallet.settings.localCurrency,
+        bitcoinUnit: UNIT_ABBREVIATIONS[state.wallet.settings.bitcoinAmountUnit],
+        discreetMode: state.wallet.settings.discreetMode,
+        screenWidth: getScreenWidth(),
+        screenHeight: getScreenHeight(),
+        platformLanguages: getPlatformLanguages().join(','),
+        tor: getIsTorEnabled(state.suite.torStatus),
+        // todo: duplicated with suite/src/utils/suite/logUtils
+        labeling: state.metadata.enabled
+            ? state.metadata.providers.find(
+                  p => p.clientId === state.metadata.selectedProvider.labels,
+              )?.type || 'missing-provider'
+            : '',
+        rememberedStandardWallets: selectRememberedStandardWalletsCount(state),
+        rememberedHiddenWallets: selectRememberedHiddenWalletsCount(state),
+        theme: state.suite.settings.theme.variant,
+        suiteVersion: process.env.VERSION || '',
+        earlyAccessProgram: state.desktopUpdate.allowPrerelease,
+        experimentalFeatures: state.suite.settings.experimental,
+        browserName: getBrowserName(),
+        browserVersion: getBrowserVersion(),
+        osName: getOsName(),
+        // version from UA parser, which includes only the most basic info as it runs in renderer process
+        osVersion: getOsVersion(),
+        // detailed info obtained in main process, if available
+        desktopOsVersion: systemInformation?.osVersion,
+        desktopOsName: systemInformation?.osName,
+        desktopOsArchitecture: systemInformation?.osArchitecture,
+
+        windowWidth: getWindowWidth(),
+        windowHeight: getWindowHeight(),
+        autodetectLanguage: state.suite.settings.autodetect.language,
+        autodetectTheme: state.suite.settings.autodetect.theme,
+    };
+};
 
 export const getAppUpdatePayload = (
     status: AppUpdateEvent['status'],


### PR DESCRIPTION
## Description

1. add a new `ipcMain` api `getSystemInformation`
2. optionally use it to enrich context for Analytics `'suite-ready'` event (desktop only)

## Related Issue

Resolve #15770
