### PR TITLE
[wip] fix(connect): fix device getting into hanged state after app reload

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -537,6 +537,8 @@ export class Device extends TypedEmitter<DeviceEvents> {
                 if (fn) {
                     await this.initialize(!!options.useCardanoDerivation);
                 } else {
+                    await this.commands?.typedCall('Cancel', 'Success').catch(() => {});
+
                     const getFeaturesTimeout =
                         DataManager.getSettings('env') === 'react-native'
                             ? GET_FEATURES_TIMEOUT_REACT_NATIVE


### PR DESCRIPTION
Before: 
1. go to suite (webusb)
2. get address
3. reload
4. observe that the device is stuck

After:
- sending cancel seems to be the universal remedy, that flushes all the communication and forces the device to cooperate again after exiting the initial communication ungracefully.


this appears to be fixing a couple of issues, for example: 
- #4385 