### PR TITLE
chore(suite): rename some suite banners

### DIFF
--- a/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareAuthenticityCheckBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareAuthenticityCheckBanner.tsx
@@ -39,7 +39,7 @@ const useAuthenticityCheckMessage = (): TranslationKey | null => {
     return null;
 };
 
-export const FirmwareRevisionCheckBanner = () => {
+export const FirmwareAuthenticityCheckBanner = () => {
     const firmwareRevisionError = useSelector(selectFirmwareRevisionCheckErrorIfEnabled);
     const wasOffline = firmwareRevisionError === 'cannot-perform-check-offline';
 

--- a/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareHashMismatchOnLastUpdateBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/FirmwareHashMismatchOnLastUpdateBanner.tsx
@@ -2,7 +2,7 @@ import { Banner } from '@trezor/components';
 
 import { Translation } from 'src/components/suite';
 
-export const FirmwareHashMismatch = () => (
+export const FirmwareHashMismatchOnLastUpdateBanner = () => (
     <Banner icon variant="destructive">
         <Translation id="TR_FIRMWARE_HASH_MISMATCH" />
     </Banner>

--- a/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
@@ -23,8 +23,8 @@ import { NoBackup } from './NoBackupBanner';
 import { FailedBackup } from './FailedBackupBanner';
 import { SafetyChecksBanner } from './SafetyChecksBanner';
 import { TranslationMode } from './TranslationModeBanner';
-import { FirmwareHashMismatch } from './FirmwareHashMismatchBanner';
-import { FirmwareRevisionCheckBanner } from './FirmwareRevisionCheckBanner';
+import { FirmwareHashMismatchOnLastUpdateBanner } from './FirmwareHashMismatchOnLastUpdateBanner';
+import { FirmwareAuthenticityCheckBanner } from './FirmwareAuthenticityCheckBanner';
 
 const Container = styled.div<{ $isVisible?: boolean }>`
     width: 100%;
@@ -67,12 +67,12 @@ export const SuiteBanners = () => {
     let priority = 0;
     // this handles firmware hash being invalid after a firmware update, not the regular firmware hash check
     if (device?.id && firmwareHashInvalid.includes(device.id)) {
-        banner = <FirmwareHashMismatch />;
+        banner = <FirmwareHashMismatchOnLastUpdateBanner />;
         priority = 92;
     }
     // the regular firmware hash check, and revision id check, either of them may fail
     else if (firmwareRevisionError || firmwareHashError) {
-        banner = <FirmwareRevisionCheckBanner />;
+        banner = <FirmwareAuthenticityCheckBanner />;
         priority = 91;
     } else if (device?.features?.unfinished_backup) {
         banner = <FailedBackup />;


### PR DESCRIPTION
## Description

- rename `FirmwareRevisionCheckBanner` :arrow_right: `FirmwareAuthenticityCheckBanner`
  - because it does both
- rename `FirmwareHashMismatch` :arrow_right: `FirmwareHashMismatchOnLastUpdateBanner`
  - to make it clear it's not the regularly performed hash check