### PR TITLE
fix(suite-desktop): swapped fields in desktop analytics

### DIFF
--- a/packages/suite-desktop-core/src/modules/system-information.ts
+++ b/packages/suite-desktop-core/src/modules/system-information.ts
@@ -13,8 +13,8 @@ export const init: ModuleInit = () => {
         validateIpcMessage(ipcEvent);
 
         try {
-            const osVersion = os.platform();
-            const osName = os.release();
+            const osVersion = os.release();
+            const osName = os.platform();
             const osArchitecture = os.arch();
 
             return { success: true, payload: { osVersion, osName, osArchitecture } };


### PR DESCRIPTION
## Description

In #15789, the OS version analytics for suite desktop were implemented, but the fields were swapped in the issue description (fixed now).
I have confirmed with Data team that `desktopOsName` and `desktopOsVersion` should be swapped

## Related Issue

Followup to https://github.com/trezor/trezor-suite/issues/15770
