### PR TITLE
fix(connect-explorer): bundle adding problem

### DIFF
--- a/packages/connect-explorer/src/components/fields/ArrayWrapper.tsx
+++ b/packages/connect-explorer/src/components/fields/ArrayWrapper.tsx
@@ -17,6 +17,7 @@ const AddBatchButton = styled.div`
     flex-direction: row;
     align-items: center;
     gap: 8px;
+    align-self: flex-start;
 `;
 
 const AddButton = ({ field, onAdd, label }: AddButtonProps) => {
@@ -26,7 +27,7 @@ const AddButton = ({ field, onAdd, label }: AddButtonProps) => {
 
     return (
         <AddBatchButton title="Add batch" onClick={onAdd}>
-            <Icon name="plus" onClick={() => {}} /> {label}
+            <Icon name="plus" onClick={onAdd} /> {label}
         </AddBatchButton>
     );
 };


### PR DESCRIPTION
## Description

Fixes an issue with arrays - when editing the params in manual mode it wouldn't add/remove items, it would only modify the existing items in the schema.  

Also includes a fix for clicking the plus icon for bundle.

## Related Issue

Resolves #15793