### PR TITLE
fix(coinmarket): fix disabled buttons with connected device

### DIFF
--- a/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketInitializer.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketInitializer.ts
@@ -11,15 +11,12 @@ import {
 } from 'src/types/coinmarket/coinmarket';
 
 export const useCoinmarketInitializer = ({
-    type,
     selectedAccount,
 }: UseCoinmarketCommonProps): UseCoinmarketCommonReturnProps => {
     const timer = useTimer();
     const { account } = selectedAccount;
-    const { isLocked, device } = useDevice();
-    const [callInProgress, setCallInProgress] = useState<boolean>(
-        type !== 'buy' ? isLocked() : false,
-    );
+    const { device } = useDevice();
+    const [callInProgress, setCallInProgress] = useState<boolean>(false);
 
     const checkQuotesTimer = (callback: () => Promise<void>) => {
         if (!timer.isLoading && !timer.isStopped) {

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeForm.ts
@@ -128,7 +128,7 @@ export const useCoinmarketExchangeForm = ({
     const trades = useSelector(state => state.wallet.coinmarket.trades);
     const trade = trades.find(
         trade =>
-            trade.tradeType === 'exchange' && transactionId && trade.data.quoteId === transactionId,
+            trade.tradeType === 'exchange' && transactionId && trade.data.orderId === transactionId,
     ) as TradeExchange | undefined;
 
     const { defaultCurrency, defaultValues } = useCoinmarketExchangeFormDefaultValues(account);

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketOffers/CoinmarketOffersItem.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketOffers/CoinmarketOffersItem.tsx
@@ -95,7 +95,7 @@ export interface CoinmarketOffersItemProps {
 export const CoinmarketOffersItem = ({ quote }: CoinmarketOffersItemProps) => {
     const theme = useTheme();
     const context = useCoinmarketFormContext();
-    const { callInProgress } = context;
+    const { device, callInProgress } = context;
     const providers = getProvidersInfoProps(context);
     const cryptoAmountProps = getCryptoQuoteAmountProps(quote, context);
     const { exchange } = quote;
@@ -149,7 +149,7 @@ export const CoinmarketOffersItem = ({ quote }: CoinmarketOffersItemProps) => {
                                 <Button
                                     isFullWidth
                                     isLoading={callInProgress}
-                                    isDisabled={!!quote.error || callInProgress}
+                                    isDisabled={!!quote.error || !device?.connected}
                                     onClick={() => selectQuote(quote)}
                                     data-testid="@coinmarket/offers/get-this-deal-button"
                                 >

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketOfferExchange/CoinmarketOfferExchangeSend.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketOfferExchange/CoinmarketOfferExchangeSend.tsx
@@ -10,7 +10,7 @@ import { AccountLabeling, Translation } from 'src/components/suite';
 import { useCoinmarketNavigation } from 'src/hooks/wallet/useCoinmarketNavigation';
 
 export const CoinmarketOfferExchangeSend = () => {
-    const { account, callInProgress, selectedQuote, exchangeInfo, sendTransaction, trade } =
+    const { device, account, callInProgress, selectedQuote, exchangeInfo, sendTransaction, trade } =
         useCoinmarketFormContext<CoinmarketTradeExchangeType>();
     useCoinmarketWatchTrade({
         account,
@@ -50,6 +50,7 @@ export const CoinmarketOfferExchangeSend = () => {
                         <Button
                             data-testid="@coinmarket/offer/exchange/confirm-on-trezor-and-send"
                             isLoading={callInProgress}
+                            isDisabled={!device?.connected}
                             onClick={sendTransaction}
                         >
                             <Translation id="TR_EXCHANGE_CONFIRM_ON_TREZOR_SEND" />

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketOfferExchange/CoinmarketOfferExchangeSendApproval.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketOfferExchange/CoinmarketOfferExchangeSendApproval.tsx
@@ -37,6 +37,7 @@ const BreakableValue = styled.span`
 export const CoinmarketOfferExchangeSendApproval = () => {
     const dispatch = useDispatch();
     const {
+        device,
         account,
         callInProgress,
         selectedQuote,
@@ -280,7 +281,7 @@ export const CoinmarketOfferExchangeSendApproval = () => {
                     (selectedQuote.status === 'CONFIRM' && approvalType === 'ZERO')) && (
                     <Button
                         isLoading={callInProgress}
-                        isDisabled={callInProgress}
+                        isDisabled={!device?.connected}
                         onClick={sendTransaction}
                     >
                         <Translation id="TR_EXCHANGE_CONFIRM_ON_TREZOR_SEND" />

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketOfferExchange/CoinmarketOfferExchangeSendSwap.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketOfferExchange/CoinmarketOfferExchangeSendSwap.tsx
@@ -73,6 +73,7 @@ const formatCryptoAmountAsAmount = (amount: number, baseAmount: number, decimals
 
 export const CoinmarketOfferExchangeSendSwap = () => {
     const {
+        device,
         account,
         callInProgress,
         selectedQuote,
@@ -270,7 +271,7 @@ export const CoinmarketOfferExchangeSendSwap = () => {
                 <Divider margin={{ top: spacings.xs, bottom: spacings.lg }} />
                 <Button
                     isLoading={callInProgress}
-                    isDisabled={callInProgress}
+                    isDisabled={!device?.connected}
                     onClick={sendTransaction}
                 >
                     <Translation id="TR_EXCHANGE_CONFIRM_ON_TREZOR_SEND" />

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketOfferSell/CoinmarketOfferSellTransaction.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketOfferSell/CoinmarketOfferSellTransaction.tsx
@@ -40,7 +40,7 @@ const Row = styled.div`
 const Address = styled.div``;
 
 export const CoinmarketSelectedOfferSellTransaction = () => {
-    const { account, callInProgress, selectedQuote, sellInfo, sendTransaction, trade } =
+    const { device, account, callInProgress, selectedQuote, sellInfo, sendTransaction, trade } =
         useCoinmarketFormContext<CoinmarketTradeSellType>();
     useCoinmarketWatchTrade({
         account,
@@ -101,7 +101,12 @@ export const CoinmarketSelectedOfferSellTransaction = () => {
                     )}
 
                     <ButtonWrapper>
-                        <Button minWidth={200} isLoading={callInProgress} onClick={sendTransaction}>
+                        <Button
+                            minWidth={200}
+                            isLoading={callInProgress}
+                            isDisabled={!device?.connected}
+                            onClick={sendTransaction}
+                        >
                             <Translation id="TR_SELL_CONFIRM_ON_TREZOR_SEND" />
                         </Button>
                     </ButtonWrapper>

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketVerify/CoinmarketVerify.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketVerify/CoinmarketVerify.tsx
@@ -19,7 +19,10 @@ import { useCoinmarketInfo } from 'src/hooks/wallet/coinmarket/useCoinmarketInfo
 import { useDispatch } from 'src/hooks/suite';
 import { COINMARKET_BUY } from 'src/actions/wallet/constants';
 import * as modalActions from 'src/actions/suite/modalActions';
-import { isCoinmarketExchangeContext } from 'src/utils/wallet/coinmarket/coinmarketTypingUtils';
+import {
+    isCoinmarketBuyContext,
+    isCoinmarketExchangeContext,
+} from 'src/utils/wallet/coinmarket/coinmarketTypingUtils';
 
 interface CoinmarketVerifyProps {
     coinmarketVerifyAccount: CoinmarketVerifyAccountReturnProps;
@@ -183,7 +186,10 @@ export const CoinmarketVerify = ({ coinmarketVerifyAccount, currency }: Coinmark
                             <Button
                                 data-testid="@coinmarket/offer/confirm-on-trezor-button"
                                 isLoading={callInProgress}
-                                isDisabled={callInProgress}
+                                isDisabled={
+                                    callInProgress ||
+                                    (!device?.connected && !isCoinmarketBuyContext(context))
+                                }
                                 onClick={() => {
                                     if (selectedAccountOption.account && accountAddress) {
                                         dispatch(
@@ -198,7 +204,7 @@ export const CoinmarketVerify = ({ coinmarketVerifyAccount, currency }: Coinmark
                             >
                                 <Translation
                                     id={
-                                        device?.connected
+                                        device?.connected || !isCoinmarketBuyContext(context)
                                             ? 'TR_CONFIRM_ON_TREZOR'
                                             : 'TR_CONFIRM_ADDRESS'
                                     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Even with connected device, sometimes (due to race condition) the confirm button in sell and exchange sections got stucked in loading/disabled state.

## Screenshots:
### Before
![image](https://github.com/user-attachments/assets/230033bb-6cb9-439f-bf01-ea0c4c26e8bc)


### After
![image](https://github.com/user-attachments/assets/336c7ec6-b035-421d-b1d5-46a0d5728341)


