### PR TITLE
fix(mobile): fiat rates infinite loading fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,9 @@
         "@types/react": "18.2.55",
         "bn.js": "5.2.1",
         "node-gyp": "10.2.0",
-        "reselect": "5.1.1"
+        "reselect": "5.1.1",
+        "### We need promise to be same version in mobile unless it produces undefined behavior, check PR #15815": "1.0.0",
+        "promise": "8.3.0"
     },
     "devDependencies": {
         "@babel/cli": "^7.23.9",

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesReducer.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesReducer.ts
@@ -96,6 +96,19 @@ export const prepareFiatRatesReducer = createReducerWithExtraDeps(
                     };
                 }
             })
+            .addCase(updateFiatRatesThunk.rejected, (state, action) => {
+                // This case should ideally never happen, but in case something will seriously go wrong
+                // we want to have some error message in the state.
+                const { tickers, localCurrency, rateType } = action.meta.arg;
+
+                const errorMessage = `${action.error?.message}\n${action.error?.stack}`;
+
+                tickers.forEach(ticker => {
+                    const fiatRateKey = getFiatRateKeyFromTicker(ticker, localCurrency);
+                    state[rateType][fiatRateKey].error = errorMessage;
+                    state[rateType][fiatRateKey].isLoading = false;
+                });
+            })
             .addCase(updateTxsFiatRatesThunk.fulfilled, (state, action) => {
                 if (!action.payload) return;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -15707,7 +15707,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"asap@npm:~2.0.3, asap@npm:~2.0.6":
+"asap@npm:~2.0.6":
   version: 2.0.6
   resolution: "asap@npm:2.0.6"
   checksum: 10/b244c0458c571945e4b3be0b14eb001bea5596f9868cc50cc711dc03d58a7e953517d3f0dad81ccde3ff37d1f074701fa76a6f07d41aaa992d7204a37b915dda
@@ -34784,16 +34784,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"promise@npm:^7.1.1":
-  version: 7.3.1
-  resolution: "promise@npm:7.3.1"
-  dependencies:
-    asap: "npm:~2.0.3"
-  checksum: 10/37dbe58ca7b0716cc881f0618128f1fd6ff9c46cdc529a269fd70004e567126a449a94e9428e2d19b53d06182d11b45d0c399828f103e06b2bb87643319bd2e7
-  languageName: node
-  linkType: hard
-
-"promise@npm:^8.3.0":
+"promise@npm:8.3.0":
   version: 8.3.0
   resolution: "promise@npm:8.3.0"
   dependencies:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Having multiple version of `promise` package, can cause random undefined behaviour like `Promise.allSettled` or `Promise.any` to be undefined. So we need to enforce same version everywhere. More details here: https://github.com/expo/expo/issues/26949

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
