### PR TITLE
chore(suite-desktop): bump openpgp

### DIFF
--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -38,7 +38,7 @@
         "electron-localshortcut": "^3.2.1",
         "electron-store": "8.2.0",
         "electron-updater": "6.3.9",
-        "openpgp": "^5.11.2",
+        "openpgp": "^6.0.1",
         "systeminformation": "^5.23.5",
         "ws": "^8.18.0"
     },

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -26,6 +26,7 @@
         "electron-localshortcut": "^3.2.1",
         "electron-store": "8.2.0",
         "electron-updater": "6.3.9",
+        "openpgp": "^6.0.1",
         "usb": "^2.14.0"
     },
     "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12337,7 +12337,7 @@ __metadata:
     electron-updater: "npm:6.3.9"
     fs-extra: "npm:^11.2.0"
     glob: "npm:^10.3.10"
-    openpgp: "npm:^5.11.2"
+    openpgp: "npm:^6.0.1"
     systeminformation: "npm:^5.23.5"
     terser-webpack-plugin: "npm:^5.3.9"
     webpack: "npm:^5.96.1"
@@ -12389,6 +12389,7 @@ __metadata:
     electron-store: "npm:8.2.0"
     electron-updater: "npm:6.3.9"
     glob: "npm:^10.3.10"
+    openpgp: "npm:^6.0.1"
     usb: "npm:^2.14.0"
   languageName: unknown
   linkType: soft
@@ -15714,7 +15715,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"asn1.js@npm:^5.0.0, asn1.js@npm:^5.2.0":
+"asn1.js@npm:^5.2.0":
   version: 5.4.1
   resolution: "asn1.js@npm:5.4.1"
   dependencies:
@@ -33047,12 +33048,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openpgp@npm:^5.11.2":
-  version: 5.11.2
-  resolution: "openpgp@npm:5.11.2"
-  dependencies:
-    asn1.js: "npm:^5.0.0"
-  checksum: 10/75052f8b89aa946d2b927f2a679d57671b2da5bf3dab1a223b9ba54305635ce37a86cb2ea274d0dcd830511e3fe1bae16d85259e907f56ec31219c4367c311a8
+"openpgp@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "openpgp@npm:6.0.1"
+  checksum: 10/29b4dca5027925573b7bbcc38d07e27ebec6fbb9c1d96398784129d2bb70176c4e80ca70e0584c1b183c52a437d090181ca408e3617ffa2d9bebeedfcee34161
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Bump `openpgp` to latest.

Not done in #15752 because it broke windows build due to Webpack misconfiguration. Turns out, it was easily fixable by explicitly adding the dependency as [external](https://github.com/trezor/trezor-suite/blob/e0fa409fe0d1949af12c21a1b1f29029dea93ce5/packages/suite-desktop-core/webpack/core.webpack.config.ts#L82) by adding it to `suite-desktop/package.json`

## QA

:eye: Besides CI checks, I have tested locally:
- local suite desktop
- linux build incl. update
- windows build incl. update
