### PR TITLE
feat(mobile): add usb priority mode for FW update

### DIFF
--- a/packages/react-native-usb/src/ReactNativeUsbModule.ts
+++ b/packages/react-native-usb/src/ReactNativeUsbModule.ts
@@ -16,6 +16,7 @@ declare class ReactNativeUsbModuleDeclaration extends NativeModule<DeviceEvents>
     selectConfiguration: (deviceName: string, configurationValue: number) => Promise<void>;
     transferIn: (deviceName: string, endpointNumber: number, length: number) => Promise<number[]>;
     transferOut: (deviceName: string, endpointNumber: number, data: string) => Promise<void>;
+    setPriorityMode: (isInPriorityMode: boolean) => void;
 }
 
 // It loads the native module object from the JSI or falls back to

--- a/packages/react-native-usb/src/index.ts
+++ b/packages/react-native-usb/src/index.ts
@@ -10,6 +10,9 @@ const debugLog = (...args: any[]) => {
     }
 };
 
+export const setPriorityMode = (isInPriorityMode: boolean) =>
+    ReactNativeUsbModule.setPriorityMode(isInPriorityMode);
+
 const open = (deviceName: string) => ReactNativeUsbModule.open(deviceName);
 
 const close = (deviceName: string) => ReactNativeUsbModule.close(deviceName);

--- a/suite-native/app/app.config.ts
+++ b/suite-native/app/app.config.ts
@@ -169,7 +169,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
         slug: appSlugs[buildType],
         owner: appOwners[buildType],
         version: suiteNativeVersion,
-        runtimeVersion: '17',
+        runtimeVersion: '18',
         ...(buildType === 'production'
             ? {}
             : {

--- a/suite-native/firmware/package.json
+++ b/suite-native/firmware/package.json
@@ -18,6 +18,7 @@
         "@suite-common/icons": "workspace:*",
         "@suite-native/link": "workspace:*",
         "@trezor/connect": "workspace:*",
+        "@trezor/react-native-usb": "workspace:*",
         "@trezor/styles": "workspace:*",
         "react": "18.2.0",
         "react-native": "0.76.1",

--- a/suite-native/firmware/src/hooks/useFirmware.tsx
+++ b/suite-native/firmware/src/hooks/useFirmware.tsx
@@ -7,6 +7,7 @@ import {
     UseFirmwareInstallationParams,
 } from '@suite-common/firmware';
 import { TxKeyPath, useTranslate } from '@suite-native/intl';
+import { setPriorityMode } from '@trezor/react-native-usb';
 
 import { nativeFirmwareActions } from '../nativeFirmwareSlice';
 
@@ -60,6 +61,7 @@ export const useFirmware = (params: UseFirmwareInstallationParams) => {
     }, [progress, status, setMayBeStuckedTimeout, resetMayBeStuckedTimeout]);
 
     const firmwareUpdate = useCallback(async () => {
+        setPriorityMode(true);
         const result = await firmwareUpdateCommon({ ignoreBaseUrl: true })
             .unwrap()
             .catch(error => {
@@ -73,6 +75,7 @@ export const useFirmware = (params: UseFirmwareInstallationParams) => {
                 return connectResponse;
             })
             .finally(() => {
+                setPriorityMode(false);
                 resetMayBeStuckedTimeout();
             });
 

--- a/suite-native/firmware/src/screens/FirmwareUpdateInProgressScreen.tsx
+++ b/suite-native/firmware/src/screens/FirmwareUpdateInProgressScreen.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Animated, {
+    FadeIn,
     FadeInDown,
     FadeInUp,
     FadeOutDown,
@@ -11,7 +12,7 @@ import { useDispatch } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 
 import { authorizeDeviceThunk } from '@suite-common/wallet-core';
-import { Box, Button, Text, VStack } from '@suite-native/atoms';
+import { Box, Button, Text, VStack, IconButton } from '@suite-native/atoms';
 import { ConfirmOnTrezorImage, setDeviceForceRememberedThunk } from '@suite-native/device';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import { Translation } from '@suite-native/intl';
@@ -42,6 +43,12 @@ const bottomButtonsContainerStyle = prepareNativeStyle<{ bottom: number }>((util
     left: utils.spacings.sp16,
     right: utils.spacings.sp16,
     bottom,
+}));
+
+const cancelButtonStyle = prepareNativeStyle(utils => ({
+    position: 'absolute',
+    left: utils.spacings.sp8,
+    top: utils.spacings.sp8,
 }));
 
 export const FirmwareUpdateInProgressScreen = () => {
@@ -80,6 +87,10 @@ export const FirmwareUpdateInProgressScreen = () => {
         });
         navigation.goBack();
     }, [dispatch, navigation]);
+
+    const handleCancel = useCallback(() => {
+        navigation.goBack();
+    }, [navigation]);
 
     const startFirmwareUpdate = useCallback(async () => {
         setIsFirmwareInstallationRunning(true);
@@ -161,6 +172,18 @@ export const FirmwareUpdateInProgressScreen = () => {
 
     return (
         <Screen>
+            {isError && (
+                <Animated.View entering={FadeIn} style={applyStyle(cancelButtonStyle)}>
+                    <IconButton
+                        iconName="x"
+                        size="medium"
+                        colorScheme="tertiaryElevation0"
+                        accessibilityRole="button"
+                        accessibilityLabel="close"
+                        onPress={handleCancel}
+                    />
+                </Animated.View>
+            )}
             <VStack justifyContent="center" alignItems="center" flex={1}>
                 <UpdateProgressIndicator progress={progress} status={indicatorStatus} />
                 <Animated.View entering={FadeInUp} exiting={FadeOutDown} key={translatedText.title}>

--- a/suite-native/firmware/tsconfig.json
+++ b/suite-native/firmware/tsconfig.json
@@ -6,6 +6,9 @@
         { "path": "../../suite-common/icons" },
         { "path": "../link" },
         { "path": "../../packages/connect" },
+        {
+            "path": "../../packages/react-native-usb"
+        },
         { "path": "../../packages/styles" }
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10245,6 +10245,7 @@ __metadata:
     "@suite-common/icons": "workspace:*"
     "@suite-native/link": "workspace:*"
     "@trezor/connect": "workspace:*"
+    "@trezor/react-native-usb": "workspace:*"
     "@trezor/styles": "workspace:*"
     react: "npm:18.2.0"
     react-native: "npm:0.76.1"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This should make FW update more resilient, for example when device is locked or user leaves to another app it should keep connection opened.

## Related Issue

Resolve 
## Screenshots:
