### PR TITLE
fix(suite-native): bottomsheet container has fixed size

### DIFF
--- a/suite-native/atoms/src/Sheet/BottomSheetContainer.tsx
+++ b/suite-native/atoms/src/Sheet/BottomSheetContainer.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react';
 import { KeyboardAvoidingView, Modal as RNModal, Platform } from 'react-native';
 import { gestureHandlerRootHOC } from 'react-native-gesture-handler';
 
+import { getWindowWidth, getWindowHeight } from '@trezor/env-utils';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 type SheetProps = {
@@ -11,7 +12,11 @@ type SheetProps = {
     ExtraProvider?: React.ComponentType;
 };
 
-const ContentWrapperStyle = prepareNativeStyle(_ => ({ flex: 1 }));
+const ContentWrapperStyle = prepareNativeStyle(_ => ({
+    flex: 1,
+    width: getWindowWidth(),
+    height: getWindowHeight(),
+}));
 
 /**
  * On Android RNGH does not work by default because modals are not located under React Native Root view in native hierarchy.


### PR DESCRIPTION
make fixed size container for bottomsheet not to jump


## Related Issue

Resolve #15852

## Screenshots:

https://github.com/user-attachments/assets/7aae62fa-d0b9-4952-b6c5-5460942746c1

