### PR TITLE
fix(suite): update features when backup fails

### DIFF
--- a/packages/suite/src/actions/backup/__tests__/backupActions.test.ts
+++ b/packages/suite/src/actions/backup/__tests__/backupActions.test.ts
@@ -113,6 +113,8 @@ describe('Backup Actions', () => {
         });
         expect(store.getActions().shift()).toEqual({ type: SUITE.LOCK_DEVICE, payload: true });
         expect(store.getActions().shift()).toEqual({ type: SUITE.LOCK_DEVICE, payload: false });
+        expect(store.getActions().shift()).toEqual({ type: SUITE.LOCK_DEVICE, payload: true });
+        expect(store.getActions().shift()).toEqual({ type: SUITE.LOCK_DEVICE, payload: false });
         expect(store.getActions().shift()).toMatchObject({
             type: notificationsActions.addToast.type,
             payload: { type: 'backup-failed' },

--- a/packages/suite/src/actions/backup/backupActions.ts
+++ b/packages/suite/src/actions/backup/backupActions.ts
@@ -65,6 +65,14 @@ export const backupDevice =
             },
         });
         if (!result.success) {
+            // When backupDevice fails (e.g. user cancels it) features are not updated in connect so we need to update at suite level
+            // in order for suite to know it, and do not allow user to recovery again and fail.
+            await TrezorConnect.getFeatures({
+                device: {
+                    path: device.path,
+                },
+            });
+
             dispatch(notificationsActions.addToast({ type: 'backup-failed' }));
             dispatch({
                 type: BACKUP.SET_ERROR,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The issue is that Connect does not update features automatically when a method fails, and it would require some deeper changes in connect to do that. So after considering it with @mroz22 solving this at Suite level was the best.

I have located the change in `packages/suite/src/actions/backup/backupActions.ts` since I for my understanding is the best place for it, but there might be a better way to do it, if so, I welcome suggestions. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/15549
## Screenshots:

![image](https://github.com/user-attachments/assets/7379c54c-6df0-40a7-9a38-7e3eb427d4e5)

