### PR TITLE
fix(suite-desktop): changelog url for new version

### DIFF
--- a/packages/suite/src/views/settings/SettingsGeneral/VersionWithUpdate.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/VersionWithUpdate.tsx
@@ -61,7 +61,10 @@ const Description = ({ desktopUpdateState }: { desktopUpdateState: DesktopUpdate
                             id={getUpdateStateMessage(desktopUpdateState.state)}
                             values={{
                                 version: (
-                                    <TrezorLink href={getReleaseUrl(appVersion)} variant="nostyle">
+                                    <TrezorLink
+                                        href={getReleaseUrl(desktopUpdateState.latest.version)}
+                                        variant="nostyle"
+                                    >
                                         <Button
                                             variant="destructive"
                                             size="tiny"


### PR DESCRIPTION
## Description

Display proper changelog link for the new available version in Settings Application (instead of displaying url for the _current_ version)

## Screenshots:

![Screenshot from 2024-12-10 09-34-04](https://github.com/user-attachments/assets/d49e42d6-ad18-4a79-afc4-945f29a7719f)
