### PR TITLE
Fix(suite): discreet mode placeholder cutout

### DIFF
--- a/packages/suite/src/components/suite/FiatValue.tsx
+++ b/packages/suite/src/components/suite/FiatValue.tsx
@@ -15,12 +15,6 @@ import { HiddenPlaceholder } from 'src/components/suite';
 
 import { HiddenPlaceholderProps } from './HiddenPlaceholder';
 
-const StyledHiddenPlaceholder = styled((props: HiddenPlaceholderProps) => (
-    <HiddenPlaceholder {...props} />
-))`
-    font-variant-numeric: tabular-nums;
-`;
-
 // Do NOT use any prop from <HiddenPlaceholderProps>, its here just to fix types
 const SameWidthNums = styled.span<HiddenPlaceholderProps>`
     font-variant-numeric: tabular-nums;
@@ -86,7 +80,7 @@ export const FiatValue = ({
     const { FiatAmountFormatter } = useFormatters();
     const value = shouldConvert ? fiatAmount : amount;
 
-    const WrapperComponent = disableHiddenPlaceholder ? SameWidthNums : StyledHiddenPlaceholder;
+    const WrapperComponent = disableHiddenPlaceholder ? SameWidthNums : HiddenPlaceholder;
 
     const isTokenKnown = useSelector(state =>
         selectIsSpecificCoinDefinitionKnown(state, symbol, tokenAddress || ('' as TokenAddress)),

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/SubpageNavigation.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/SubpageNavigation.tsx
@@ -15,7 +15,7 @@ const Container = styled.div`
     top: ${HEADER_HEIGHT};
     background: ${({ theme }) => theme.backgroundSurfaceElevation0};
     border-bottom: 1px solid ${({ theme }) => theme.borderElevation1};
-    z-index: ${zIndices.pageHeader};
+    z-index: ${zIndices.stickyBar};
     width: 100%;
     padding: ${spacingsPx.md} ${spacingsPx.md} 0;
 `;

--- a/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountTopPanel.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountTopPanel.tsx
@@ -2,7 +2,7 @@ import { forwardRef } from 'react';
 
 import styled from 'styled-components';
 
-import { spacingsPx } from '@trezor/theme';
+import { spacingsPx, zIndices } from '@trezor/theme';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { SkeletonCircle, SkeletonRectangle } from '@trezor/components';
 import { CoinLogo } from '@trezor/product-components';
@@ -23,6 +23,7 @@ const Container = styled.div`
     padding-left: ${spacingsPx.md};
     padding-right: ${spacingsPx.md};
     margin-top: ${spacingsPx.lg};
+    z-index: ${zIndices.pageSubHeader};
 `;
 
 const AccountCryptoBalance = styled.div`

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
@@ -11,12 +11,7 @@ import { Card, Icon, Tooltip, Row, Column, Text, Divider } from '@trezor/compone
 import { getAllAccounts, getTotalFiatBalance } from '@suite-common/wallet-utils';
 import { spacings, negativeSpacings } from '@trezor/theme';
 
-import {
-    WalletLabeling,
-    Translation,
-    MetadataLabeling,
-    HiddenPlaceholder,
-} from 'src/components/suite';
+import { WalletLabeling, Translation, MetadataLabeling } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { AcquiredDevice, ForegroundAppProps } from 'src/types/suite';
 import { selectLabelingDataForWallet } from 'src/reducers/suite/metadataReducer';
@@ -163,13 +158,11 @@ export const WalletInstance = ({
                     </Row>
                 </Text>
 
-                <HiddenPlaceholder>
-                    <FiatHeader
-                        amount={instanceBalance.toString()}
-                        size="medium"
-                        localCurrency={localCurrency}
-                    />
-                </HiddenPlaceholder>
+                <FiatHeader
+                    amount={instanceBalance.toString()}
+                    size="medium"
+                    localCurrency={localCurrency}
+                />
             </Column>
 
             {(isViewOnlyRendered ||

--- a/packages/theme/src/zIndices.ts
+++ b/packages/theme/src/zIndices.ts
@@ -17,7 +17,8 @@ export const zIndices = {
     navigationBar: 30,
     expandableNavigationHeader: 21, // above EXPANDABLE_NAVIGATION to cover its box-shadow
     expandableNavigation: 20, // above PAGE_HEADER to spread over it
-    pageHeader: 11, // above STICKY_BAR to hide it when the page is on top
+    pageHeader: 12, // above STICKY_BAR to hide it when the page is on top
+    pageSubHeader: 11, // below PAGE_HEADER to be hidden beneath it, but above STICKY_BAR
     stickyBar: 10, // above page content to scroll over it
     secondaryStickyBar: 9, // below STICKY_BAR so that it can hide beneath it when no longer needed
     selectMenu: 3,


### PR DESCRIPTION
## Description

Fix three instances of `HiddenPlaceholder` CSS blur being cut off for various reasons.

:information_source: this problem will likely pop up again in future, because as you can see, the blur can be clipped even from an element quite far in DOM. It's just not easily controllable - unless we would add paddings to HiddenPlaceholder just so that the blur can render into them :disappointed: 

## Related Issue

Resolve #14736

## Screenshots:

**Before:** see issue

**Sidebar after:**
![image](https://github.com/user-attachments/assets/ab83047a-edf8-4970-983d-1fafa2e6596a)

**Fiat header after:**
[video incl. scrolling behavior](https://github.com/user-attachments/assets/01cafb29-6458-4792-ab2e-a71c4aece7ea)

**Only FYI** the `TruncateWithTooltip` isn't working, this is on develop, the value is mocked to be long:
![Truncate not working](https://github.com/user-attachments/assets/57907530-8ec6-4755-aad3-5fcdce8444b2)

