### PR TITLE
fix(suite-native): xrp unspendable reserve

### DIFF
--- a/suite-native/module-send/src/screens/SendOutputsScreen.tsx
+++ b/suite-native/module-send/src/screens/SendOutputsScreen.tsx
@@ -109,7 +109,7 @@ export const SendOutputsScreen = ({
             networkFeeInfo,
             accountDescriptor: account?.descriptor,
             symbol: account?.symbol,
-            availableBalance: tokenInfo?.balance ?? account?.formattedBalance,
+            availableBalance: tokenInfo?.balance ?? account?.availableBalance,
             isTokenFlow: !!tokenContract,
             isValueInSats: isAmountInSats,
             feeLevelsMaxAmount,
@@ -157,8 +157,7 @@ export const SendOutputsScreen = ({
 
                 if (isReserveError) {
                     setError('outputs.0.amount', {
-                        message:
-                            'Recipient account requires minimum reserve of 10 XRP to activate.',
+                        message: 'Recipient account requires minimum reserve of 1 XRP to activate.',
                     });
                 }
 

--- a/suite-native/module-send/src/sendOutputsFormSchema.ts
+++ b/suite-native/module-send/src/sendOutputsFormSchema.ts
@@ -139,7 +139,7 @@ export const sendOutputsFormValidationSchema = yup.object({
                     )
                     .test(
                         'ripple-higher-than-reserve',
-                        'Amount is above the required unspendable reserve (10 XRP)',
+                        'Amount is above the required unspendable reserve (1 XRP)',
                         function (
                             value,
                             { options: { context } }: yup.TestContext<SendFormFormContext>,


### PR DESCRIPTION
## Description

- resolves the unspedable reserve bug in the send form
- ufortunately the error messages need to have the reserve value hard coded in the string because there is no easy way to inject variable values from context to the `yup` validation error messages. This will need to be revisited later because of internalialization of the messages. So please let's not take care of this now since it would require a way bigger refactor

## Screenshots:


https://github.com/user-attachments/assets/817c36ad-28dc-4a2a-8f1b-2076713a7013

![Snímek obrazovky 2024-12-11 v 9 51 54](https://github.com/user-attachments/assets/045e9153-08d4-46ab-8a06-ef5b343d5af1)

