### PR TITLE
fix(suite): transaction labels blurred during editing

### DIFF
--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
@@ -23,6 +23,7 @@ import { WalletAccountTransaction } from 'src/types/wallet';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { AccountLabels } from 'src/types/suite/metadata';
 import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
+import { selectLabelingValueBeingEdited } from 'src/reducers/suite/metadataReducer';
 
 import { TokenTransferAddressLabel } from './TokenTransferAddressLabel';
 import { TargetAddressLabel } from './TargetAddressLabel';
@@ -167,6 +168,10 @@ export const TransactionTarget = ({
     const operation = getTxOperation(transaction.type);
     const targetMetadata = accountMetadata?.outputLabels?.[transaction.txid]?.[target.n];
 
+    const defaultMetadataValue = `${transaction.txid}-${target.n}`;
+    const labelingValueBeingEdited = useSelector(selectLabelingValueBeingEdited);
+    const isBeingEdited = defaultMetadataValue === labelingValueBeingEdited;
+
     const copyAddress = () => {
         let payload: ToastPayload = { type: 'copy-to-clipboard' };
         if (!target?.addresses) {
@@ -190,6 +195,7 @@ export const TransactionTarget = ({
     return (
         <TransactionTargetLayout
             {...baseLayoutProps}
+            useHiddenPlaceholder={!isBeingEdited}
             addressLabel={
                 <MetadataLabeling
                     isDisabled={isActionDisabled}
@@ -213,7 +219,7 @@ export const TransactionTarget = ({
                         entityKey: accountKey,
                         txid: transaction.txid,
                         outputIndex: target.n,
-                        defaultValue: `${transaction.txid}-${target.n}`,
+                        defaultValue: defaultMetadataValue,
                         value: targetMetadata,
                     }}
                 />

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTargetLayout.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTargetLayout.tsx
@@ -101,6 +101,7 @@ interface TransactionTargetLayoutProps {
     amount?: ReactNode;
     fiatAmount?: ReactNode;
     useAnimation?: boolean;
+    useHiddenPlaceholder?: boolean;
     singleRowLayout?: boolean;
     isFirst?: boolean;
     isLast?: boolean;
@@ -115,6 +116,7 @@ export const TransactionTargetLayout = ({
     singleRowLayout,
     isFirst,
     isLast,
+    useHiddenPlaceholder,
     ...rest
 }: TransactionTargetLayoutProps) => {
     const animation = useAnimation ? motionAnimation.expand : {};
@@ -128,7 +130,11 @@ export const TransactionTargetLayout = ({
             </TimelineDotWrapper>
 
             <TargetAddress>
-                <StyledHiddenPlaceholder>{addressLabel}</StyledHiddenPlaceholder>
+                {useHiddenPlaceholder === false ? (
+                    addressLabel
+                ) : (
+                    <StyledHiddenPlaceholder>{addressLabel}</StyledHiddenPlaceholder>
+                )}
             </TargetAddress>
 
             <TargetAmountsWrapper $paddingBottom={!isLast}>

--- a/packages/suite/src/reducers/suite/metadataReducer.ts
+++ b/packages/suite/src/reducers/suite/metadataReducer.ts
@@ -280,7 +280,7 @@ export const selectIsLabelingAvailable = (state: MetadataRootState) => {
 };
 
 /**
- it is possible to initiate metadata 
+ it is possible to initiate metadata
  */
 export const selectIsLabelingInitPossible = (state: MetadataRootState) => {
     const device = selectDevice(state);
@@ -327,5 +327,7 @@ export const selectPasswordManagerState = (
     return (provider.data[fileName] ||
         METADATA_PASSWORDS.DEFAULT_PASSWORD_MANAGER_STATE) as PasswordManagerState;
 };
+
+export const selectLabelingValueBeingEdited = ({ metadata }: MetadataRootState) => metadata.editing;
 
 export default metadataReducer;


### PR DESCRIPTION
## Description

Do not wrap transaction address in HiddenPlaceholder when it's label is being edited.
The reason is, that the editing textfield is persistent until you confirm or cancel it, but blurred unless you also hover on it the whole time.

## Related Issue

Resolve #14737

## Screenshots:

[before](https://github.com/user-attachments/assets/9cafbc74-a382-4f3c-8afe-fffa64872d23)
[after](https://github.com/user-attachments/assets/89bf54c3-055c-4f4b-bcb1-7e907e4b8e33)
