### PR TITLE
fix(nix): pin yarn nodejs version to build input

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -28,7 +28,9 @@ in
       docker         # for e2e tests running on localhost
       docker-compose # for e2e tests running on localhost
       nodejs
-      yarn
+      (yarn.override {
+        nodejs = null; # use input nodejs
+      })
       jre
       p7zip
       electron


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
yarn should use build-in nodejs

before:
```
[nix-shell:~/suite]$ node --version
v22.8.0
[nix-shell:~/suite]$ yarn node --version
v20.17.0
[nix-shell:~/suite]$ yarn -v
4.5.3
```

after:

```
[nix-shell:~/suite]$ node --version
v22.8.0
[nix-shell:~/suite]$ yarn node --version
v22.8.0
```