### PR TITLE
fix(suite-native): if txn list has no txn for token in the month, dont show month name

### DIFF
--- a/suite-native/transactions/src/components/TransactionsList/TransactionList.tsx
+++ b/suite-native/transactions/src/components/TransactionsList/TransactionList.tsx
@@ -239,8 +239,14 @@ export const TransactionList = ({
     const renderItem = useCallback(
         ({ item, index }: { item: TransactionListItem; index: number }) => {
             if (typeof item === 'string') {
-                return renderSectionHeader({ section: { monthKey: item as MonthKey } });
+                // month with only month name and without token txn
+                const isEmptyMonth = typeof data.at(index + 1) === 'string' || !data.at(index + 1);
+
+                return isEmptyMonth
+                    ? null
+                    : renderSectionHeader({ section: { monthKey: item as MonthKey } });
             }
+
             const isFirstInSection = typeof data.at(index - 1) === 'string';
             const isLastInSection =
                 typeof data.at(index + 1) === 'string' || index === data.length - 1;


### PR DESCRIPTION
Dont show month name when there is no txn when filtered by token


## Screenshots:
before:
<img width=300 src="https://github.com/user-attachments/assets/a8692e84-8349-4b9a-a2a3-75428dd2fe3e" />


after:
<img width=300 src="https://github.com/user-attachments/assets/7e1ffaef-d658-4d4f-ace0-1d7ff776975e" />
