### PR TITLE
npm-prerelease: @trezor/connect 9.4.7-beta.1

### DIFF
--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/connect-web",
-    "version": "9.4.6",
+    "version": "9.4.7-beta.1",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect-web",
     "description": "High-level javascript interface for Trezor hardware wallet in web environment.",

--- a/packages/connect-web/src/webextension/trezor-usb-permissions.js
+++ b/packages/connect-web/src/webextension/trezor-usb-permissions.js
@@ -1,4 +1,4 @@
-const VERSION = '9.4.6';
+const VERSION = '9.4.7-beta.1';
 const versionN = VERSION.split('.').map(s => parseInt(s, 10));
 
 const isBeta = VERSION.includes('beta');

--- a/packages/connect-webextension/package.json
+++ b/packages/connect-webextension/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/connect-webextension",
-    "version": "9.4.6",
+    "version": "9.4.7-beta.1",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect-webextension",
     "description": "High-level javascript interface for Trezor hardware wallet in webextension serviceworker environment.",

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -1,6 +1,6 @@
 # @trezor/connect
 
-API version 9.4.6
+API version 9.4.7-beta.1
 
 [![Build Status](https://github.com/trezor/trezor-suite/actions/workflows/test-connect.yml/badge.svg)](https://github.com/trezor/trezor-suite/actions/workflows/test-connect.yml)
 [![NPM](https://img.shields.io/npm/v/@trezor/connect.svg)](https://www.npmjs.org/package/@trezor/connect)

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/connect",
-    "version": "9.4.6",
+    "version": "9.4.7-beta.1",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect",
     "description": "High-level javascript interface for Trezor hardware wallet.",

--- a/packages/connect/src/data/version.ts
+++ b/packages/connect/src/data/version.ts
@@ -1,4 +1,4 @@
-export const VERSION = '9.4.6';
+export const VERSION = '9.4.7-beta.1';
 
 const versionN = VERSION.split('.').map(s => parseInt(s, 10));
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Manually fixing connect versions due to previous job triggered as prerelase instead of prepatch. https://github.com/trezor/trezor-suite/pull/15918

As per Connect Release Guide documentation in notion and comment in related script https://github.com/trezor/trezor-suite/blob/develop/scripts/ci/connect-bump-versions.ts#L20

```
- minor: Increase minor version (if version 9.5.0-beta.3 --> 9.5.0)
- patch: Increase patch version (if version 9.4.2-beta.3 --> 9.4.2)
- preminor: Increase preminor version, pre-release (if version 9.4.1 --> 9.5.0-beta.1)
- prepatch: Increase prepatch version, pre-release (if version 9.4.1 --> 9.4.2-beta.1)
- prerelease: Increase prerelease version (if version 9.4.1-beta.1 --> 9.4.1-beta.2)
```

## Related Issue

Related https://github.com/trezor/trezor-suite/pull/15918 
