### PR TITLE
fix(coinmarket): fix kyc swap pending state

### DIFF
--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeForm.ts
@@ -535,19 +535,20 @@ export const useCoinmarketExchangeForm = ({
             return;
         }
 
+        const selectedTrade = trade?.data || selectedQuote;
         // sendAddress may be set by useCoinmarketWatchTrade hook to the trade object
-        const sendAddress = selectedQuote?.sendAddress || trade?.data?.sendAddress;
+        const sendAddress = selectedTrade?.sendAddress;
         if (
-            selectedQuote &&
-            selectedQuote.orderId &&
+            selectedTrade &&
+            selectedTrade.orderId &&
             sendAddress &&
-            selectedQuote.sendStringAmount
+            selectedTrade.sendStringAmount
         ) {
             const sendStringAmount = shouldSendInSats
-                ? amountToSmallestUnit(selectedQuote.sendStringAmount, decimals)
-                : selectedQuote.sendStringAmount;
+                ? amountToSmallestUnit(selectedTrade.sendStringAmount, decimals)
+                : selectedTrade.sendStringAmount;
             const sendPaymentExtraId =
-                selectedQuote.partnerPaymentExtraId || trade?.data?.partnerPaymentExtraId;
+                selectedTrade.partnerPaymentExtraId || trade?.data?.partnerPaymentExtraId;
             const result = await recomposeAndSign({
                 account,
                 address: sendAddress,
@@ -559,12 +560,12 @@ export const useCoinmarketExchangeForm = ({
             if (result?.success) {
                 dispatch(
                     coinmarketExchangeActions.saveTrade(
-                        selectedQuote,
+                        selectedTrade,
                         selectedAccount.account,
                         new Date().toISOString(),
                     ),
                 );
-                dispatch(coinmarketExchangeActions.saveTransactionId(selectedQuote.orderId));
+                dispatch(coinmarketExchangeActions.saveTransactionId(selectedTrade.orderId));
                 navigateToExchangeDetail();
             }
         } else {

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -633,7 +633,7 @@ export const networks = {
         customBackends: ['solana'],
         accountTypes: {},
         coingeckoId: undefined,
-        coingeckoNativeId: 'test-ripple', // fake, coingecko does not have testnets
+        coingeckoNativeId: undefined,
     },
     tada: {
         // icarus derivation


### PR DESCRIPTION
- fix endless pending state of trade; wrong object was used for this specific swap flow
- fix bad coingeckoNativeId for solana devnet which caused we couldn't trade XRP testnet in trade section

## Related Issue

Resolve #15941

