### PR TITLE
chore(ci): retrieve APK url in github workflow

### DIFF
--- a/.github/workflows/release-suite-native-production.yml
+++ b/.github/workflows/release-suite-native-production.yml
@@ -95,9 +95,9 @@ jobs:
       - name: Install libs
         run: yarn workspaces focus @suite-native/app
       - name: Build on EAS Android
-        run: eas build
-          --platform android
-          --profile productionAPK
-          --non-interactive
-          --message ${{ github.sha }}
+        run: |
+          BUILD_ID=$(eas build --platform android --profile productionAPK --non-interactive --message ${{ github.sha }} --wait --json | jq -r '.[0].id')
+          echo "BUILD_ID: $BUILD_ID"
+          BUILD_URL=$(eas build:view "$BUILD_ID" --json | jq -r '.artifacts.buildUrl')
+          echo "BUILD_URL: $BUILD_URL"
         working-directory: suite-native/app

--- a/suite-native/app/eas-post-success.sh
+++ b/suite-native/app/eas-post-success.sh
@@ -16,60 +16,8 @@ distribute_develop_apk() {
         --release-notes "$release_notes"
 }
 
-create_release_draft() {
-    suite_native_version=$(grep -E '^\s*"suiteNativeVersion":' package.json | awk -F ': ' '{print $2}' | tr -d ',"')
-
-    # Create a GitHub release draft
-    curl -L \
-        -X POST \
-        -H "Accept: application/vnd.github+json" \
-        -H "Authorization: Bearer $GITHUB_TREZOR_SUITE_TOKEN" \
-        -H "X-GitHub-Api-Version: 2022-11-28" \
-        -d '{
-            "tag_name": "v'"$suite_native_version"'@mobile",
-            "name": "Suite Mobile v'"$suite_native_version"'",
-            "body": "'"$EAS_BUILD_GIT_COMMIT_HASH"'",
-            "draft": true,
-            "prerelease": false,
-            "generate_release_notes": false,
-            "make_latest": "false"
-        }' \
-        https://api.github.com/repos/trezor/trezor-suite/releases > /tmp/release_response.json
-}
-
-upload_production_apk() {
-    # Extract upload URL from the GitHub release draft response
-    upload_url=$(grep -o '"upload_url": *"[^"]*"' /tmp/release_response.json | grep -o '"[^"]*"$' | tr -d '"')
-    upload_url="${upload_url%\{*}"  # Remove the curly braces and everything after them
-    upload_url="${upload_url}?name=Trezor-Suite-Lite-${suite_native_version}.apk"
-
-    # Upload production APK to newly created GitHub release
-    curl -L \
-        -X POST \
-        -H "Accept: application/vnd.github+json" \
-        -H "Authorization: Bearer $GITHUB_TREZOR_SUITE_TOKEN" \
-        -H "X-GitHub-Api-Version: 2022-11-28" \
-        -H "Content-Type: application/octet-stream" \
-        "${upload_url}" \
-        --data-binary "@$EAS_BUILD_WORKINGDIR/suite-native/app/android/app/build/outputs/apk/release/app-release.apk" > /tmp/asset_response.json
-
-    # Wait until the response file is created and contains data
-    until [ -s /tmp/asset_response.json ]; do
-        sleep 1
-    done
-
-    cat /tmp/asset_response.json
-
-    echo "APK uploaded"
-}
-
-if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then
-    if [[ "$EAS_BUILD_PROFILE" == "develop" ]]; then
-        distribute_develop_apk
-    elif [[ "$EAS_BUILD_PROFILE" == "productionAPK" ]]; then
-        create_release_draft
-        upload_production_apk
-    fi
+if [[ "$EAS_BUILD_PLATFORM" == "android" && "$EAS_BUILD_PROFILE" == "develop" ]]; then
+    distribute_develop_apk
 elif [[ "$EAS_BUILD_PLATFORM" == "ios" ]]; then
     exit 0
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Get APK url in github workflow so it can be uploaded anywhere
- Delete hook to upload APK on github

Example run: https://github.com/trezor/trezor-suite/actions/runs/12312464741/job/34364557163#step:6:38 (with preview build because of permissions)

## Related Issue

Related [#5728](https://github.com/trezor/trezor-suite/issues/5728)