### PR TITLE
chore(suite-native): add easignore to  reduce archive size and upload time

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -1,3 +1,21 @@
+.github
+docker
+docs
+
+packages/ipc-proxy/
+packages/suite/
+packages/suite-analytics/
+packages/suite-build/
+packages/suite-data/
+packages/suite-desktop/
+packages/suite-desktop-api/
+packages/suite-desktop-core/
+packages/suite-desktop-ui/
+packages/suite-storage/
+packages/suite-web/
+
+### content of all .gitignore files is not applied if .easignore is present
+
 build
 build-electron
 build-renderer
@@ -100,8 +118,9 @@ _.hprof
 
 !**/suite-native/app/.env.debug
 !**/suite-native/app/.env.develop
+!**/suite-native/app/.env.preview
 !**/suite-native/app/.env.production
-!**/suite-native/app/.env.staging
+!\*\*/suite-native/app/.env.staging
 
 # ios
 
@@ -148,14 +167,54 @@ packages/suite-data/files/translations/master.json
 
 # @trezor/connect-explorer
 
-packages/connect-explorer/build-webextension
-
-# @trezor/connect-explorer-theme
-
-packages/connect-explorer-theme/style.css
+**/build-webextension/**
 
 # cypress download folder
 
 packages/suite-web/e2e/downloads
 
-.github
+### suite-native/app/.gitignore
+
+# Expo
+
+.expo/
+web-build/
+
+# Native
+
+suite-native/app/**/_.orig._
+suite-native/app/**/_.jks
+suite-native/app/\*\*/_.p8
+suite-native/app/**/\*.p12
+suite-native/app/**/_.key
+suite-native/app/\*\*/_.mobileprovision
+
+# These are generated when running `expo prebuild`
+
+suite-native/app/ios
+suite-native/app/android
+
+# Metro
+
+.metro-health-check\*
+
+# debug
+
+npm-debug._
+yarn-debug._
+yarn-error.\*
+
+# macOS
+
+.DS_Store
+\*.pem
+
+# local env files
+
+.env
+!suite-native/app/.env._
+.env._.local
+
+# typescript
+
+\*.tsbuildinfo

--- a/.gitignore
+++ b/.gitignore
@@ -87,31 +87,6 @@ local.properties
 *.keystore
 !debug.keystore
 
-# fastlane
-#
-# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
-# screenshots whenever they are needed.
-# For more information about the recommended setup visit:
-# https://docs.fastlane.tools/best-practices/source-control/
-
-**/android/fastlane/report.xml
-**/android/fastlane/Preview.html
-**/android/fastlane/screenshots
-**/android/fastlane/test_output
-**/ios/fastlane/report.xml
-**/ios/fastlane/Preview.html
-**/ios/fastlane/screenshots
-**/ios/fastlane/test_output
-**/fastlane/report.xml
-**/fastlane/Preview.html
-**/fastlane/screenshots
-**/fastlane/test_output
-
-*.cer
-*.certSigningRequest
-*.p12
-*.mobileprovision
-
 # scan temporary files
 **/android/fastlane/test_output
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -94,33 +94,7 @@ buck-out/
 *.keystore
 !debug.keystore
 
-# fastlane
-#
-# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
-# screenshots whenever they are needed.
-# For more information about the recommended setup visit:
-# https://docs.fastlane.tools/best-practices/source-control/
-
-**/android/fastlane/report.xml
-**/android/fastlane/Preview.html
-**/android/fastlane/screenshots
-**/android/fastlane/test_output
-**/ios/fastlane/report.xml
-**/ios/fastlane/Preview.html
-**/ios/fastlane/screenshots
-**/ios/fastlane/test_output
-**/fastlane/report.xml
-**/fastlane/Preview.html
-**/fastlane/screenshots
-**/fastlane/test_output
-
-*.cer
-*.certSigningRequest
-*.p12
-*.mobileprovision
-
 # scan temporary files
-**/android/fastlane/test_output
 
 !**/suite-native/app/.env.debug
 !**/suite-native/app/.env.develop


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Reduce archive size and upload time.


https://docs.expo.dev/build-reference/easignore/

It can be verified locally what files are included using command like this:
` EXPO_PUBLIC_ENVIRONMENT=preview eas build:inspect --platform android --stage archive --output ~/Downloads/suite-lite-inspect-easignore --profile production`
