### PR TITLE
Fix and remaname of weird selectors

### DIFF
--- a/packages/suite/src/actions/backup/backupActions.ts
+++ b/packages/suite/src/actions/backup/backupActions.ts
@@ -1,7 +1,7 @@
 import TrezorConnect from '@trezor/connect';
 import { analytics, EventType } from '@trezor/suite-analytics';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 
 import { BACKUP } from 'src/actions/backup/constants';
 import type { Dispatch, GetState } from 'src/types/suite';
@@ -43,7 +43,7 @@ export const resetReducer = (): BackupAction => ({
 export const backupDevice =
     (params: Parameters<typeof TrezorConnect.backupDevice>[0] = {}, skipSuccessToast?: boolean) =>
     async (dispatch: Dispatch, getState: GetState) => {
-        const device = selectDevice(getState());
+        const device = selectSelectedDevice(getState());
         if (!device) {
             return dispatch(
                 notificationsActions.addToast({

--- a/packages/suite/src/actions/onboarding/onboardingActions.ts
+++ b/packages/suite/src/actions/onboarding/onboardingActions.ts
@@ -1,6 +1,6 @@
 import { OnboardingAnalytics } from '@trezor/suite-analytics';
 import TrezorConnect from '@trezor/connect';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 
 import { ONBOARDING } from 'src/actions/onboarding/constants';
 import * as STEP from 'src/constants/onboarding/steps';
@@ -123,7 +123,7 @@ const updateBackupType = (payload: BackupType): OnboardingAction => ({
 });
 
 const beginOnboardingTutorial = () => async (dispatch: Dispatch, getState: GetState) => {
-    const device = selectDevice(getState());
+    const device = selectSelectedDevice(getState());
     if (!device) return;
 
     dispatch(setDeviceTutorialStatus('active'));

--- a/packages/suite/src/actions/recovery/recoveryActions.ts
+++ b/packages/suite/src/actions/recovery/recoveryActions.ts
@@ -1,4 +1,4 @@
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import TrezorConnect, { UI, RecoveryDevice, DeviceModelInternal, PROTO } from '@trezor/connect';
 import { analytics, EventType } from '@trezor/suite-analytics';
 
@@ -56,7 +56,7 @@ const submit = (word: string) => () => {
 
 const checkSeed = () => async (dispatch: Dispatch, getState: GetState) => {
     const { advancedRecovery, wordsCount } = getState().recovery;
-    const device = selectDevice(getState());
+    const device = selectSelectedDevice(getState());
 
     if (!device?.features) return;
 
@@ -96,7 +96,7 @@ const checkSeed = () => async (dispatch: Dispatch, getState: GetState) => {
 
 const recoverDevice = () => async (dispatch: Dispatch, getState: GetState) => {
     const { advancedRecovery, wordsCount } = getState().recovery;
-    const device = selectDevice(getState());
+    const device = selectSelectedDevice(getState());
 
     if (!device?.features) {
         return;
@@ -142,7 +142,7 @@ const recoverDevice = () => async (dispatch: Dispatch, getState: GetState) => {
 // or seed check). This way, communication is renewed and host starts receiving messages from device again.
 const rerun = () => async (dispatch: Dispatch, getState: GetState) => {
     const { router } = getState();
-    const device = selectDevice(getState());
+    const device = selectSelectedDevice(getState());
     if (!device?.features) {
         return;
     }

--- a/packages/suite/src/actions/settings/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/deviceSettingsActions.ts
@@ -1,4 +1,4 @@
-import { selectDevices, selectDevice, deviceActions } from '@suite-common/wallet-core';
+import { selectDevices, selectSelectedDevice, deviceActions } from '@suite-common/wallet-core';
 import { FIRMWARE_MODULE_PREFIX } from '@suite-common/firmware';
 import * as deviceUtils from '@suite-common/suite-utils';
 import TrezorConnect, { ERRORS } from '@trezor/connect';
@@ -16,7 +16,7 @@ import { selectSuiteSettings } from '../../reducers/suite/suiteReducer';
 export const applySettings =
     (params: Parameters<typeof TrezorConnect.applySettings>[0]) =>
     async (dispatch: Dispatch, getState: GetState) => {
-        const device = selectDevice(getState());
+        const device = selectSelectedDevice(getState());
         if (!device) return;
         const result = await TrezorConnect.applySettings({
             device: {
@@ -36,7 +36,7 @@ export const applySettings =
 export const changePin =
     (params: Parameters<typeof TrezorConnect.changePin>[0] = {}, skipSuccessToast?: boolean) =>
     async (dispatch: Dispatch, getState: GetState) => {
-        const device = selectDevice(getState());
+        const device = selectSelectedDevice(getState());
 
         if (!device) return;
 
@@ -69,7 +69,7 @@ export const changePin =
 export const changeWipeCode =
     ({ remove }: Parameters<typeof TrezorConnect.changeWipeCode>[0] = {}) =>
     async (dispatch: Dispatch, getState: GetState) => {
-        const device = selectDevice(getState());
+        const device = selectSelectedDevice(getState());
 
         if (!device) return;
 
@@ -93,7 +93,7 @@ export const changeWipeCode =
     };
 
 export const wipeDevice = () => async (dispatch: Dispatch, getState: GetState) => {
-    const device = selectDevice(getState());
+    const device = selectSelectedDevice(getState());
     if (!device) return;
     const bootloaderMode = device.mode === 'bootloader';
     const devices = selectDevices(getState());
@@ -114,7 +114,7 @@ export const wipeDevice = () => async (dispatch: Dispatch, getState: GetState) =
         // we need to retrieve device objects BEFORE and AFTER the wipe process.
         // and call SUITE.FORGET_DEVICE on ALL devices (with old and new device.id)
         const state = getState();
-        const newDevice = selectDevice(getState());
+        const newDevice = selectSelectedDevice(getState());
         const newDevices = selectDevices(getState());
         const settings = selectSuiteSettings(getState());
 
@@ -147,7 +147,7 @@ export const wipeDevice = () => async (dispatch: Dispatch, getState: GetState) =
 export const resetDevice =
     (params: Parameters<typeof TrezorConnect.resetDevice>[0] = {}) =>
     async (dispatch: Dispatch, getState: GetState) => {
-        const device = selectDevice(getState());
+        const device = selectSelectedDevice(getState());
 
         if (!device || !device.features) return;
 
@@ -175,7 +175,7 @@ export const resetDevice =
 export const changeLanguage = createThunk(
     `${FIRMWARE_MODULE_PREFIX}/update-firmware-language`,
     async (params: Parameters<typeof TrezorConnect.changeLanguage>[0], { dispatch, getState }) => {
-        const device = selectDevice(getState());
+        const device = selectSelectedDevice(getState());
 
         if (!device) return;
 

--- a/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
@@ -3,7 +3,7 @@
 import { testMocks } from '@suite-common/test-utils';
 import {
     prepareDeviceReducer,
-    selectDevice,
+    selectSelectedDevice,
     selectDevices,
     selectDevicesCount,
     deviceActions,
@@ -307,7 +307,7 @@ describe('Suite Actions', () => {
             await store.dispatch(
                 switchDuplicatedDevice({ device: f.device, duplicate: f.duplicate }),
             );
-            const device = selectDevice(store.getState());
+            const device = selectSelectedDevice(store.getState());
             const devicesCount = selectDevicesCount(store.getState());
             expect(device).toEqual(f.result.selected);
             expect(devicesCount).toEqual(f.result.devices.length);

--- a/packages/suite/src/actions/suite/metadataLabelingActions.ts
+++ b/packages/suite/src/actions/suite/metadataLabelingActions.ts
@@ -2,7 +2,7 @@ import TrezorConnect, { StaticSessionId } from '@trezor/connect';
 import { cloneObject } from '@trezor/utils';
 import {
     selectDevices,
-    selectDevice,
+    selectSelectedDevice,
     selectDeviceByStaticSessionId,
 } from '@suite-common/wallet-core';
 
@@ -165,7 +165,7 @@ export const fetchAndSaveMetadata =
 
         let device = deviceStateArg
             ? selectDeviceByStaticSessionId(getState(), deviceStateArg)
-            : selectDevice(getState());
+            : selectSelectedDevice(getState());
 
         if (
             !device?.state?.staticSessionId ||
@@ -196,7 +196,7 @@ export const fetchAndSaveMetadata =
 
             device = deviceStateArg
                 ? selectDeviceByStaticSessionId(getState(), deviceStateArg)
-                : selectDevice(getState());
+                : selectSelectedDevice(getState());
             if (
                 !device?.state?.staticSessionId ||
                 !device?.metadata?.[METADATA_LABELING.ENCRYPTION_VERSION]
@@ -560,7 +560,7 @@ export const init =
     async (dispatch: Dispatch, getState: GetState) => {
         let device = deviceStateArg
             ? selectDeviceByStaticSessionId(getState(), deviceStateArg)
-            : selectDevice(getState());
+            : selectSelectedDevice(getState());
 
         if (!device?.state?.staticSessionId) {
             return false;
@@ -611,7 +611,7 @@ export const init =
 
         device = deviceStateArg
             ? selectDeviceByStaticSessionId(getState(), deviceStateArg)
-            : selectDevice(getState());
+            : selectSelectedDevice(getState());
 
         if (!device) return false;
 
@@ -639,7 +639,7 @@ export const init =
         const selectedProvider = selectSelectedProviderForLabels(getState());
         device = deviceStateArg
             ? selectDeviceByStaticSessionId(getState(), deviceStateArg)
-            : selectDevice(getState());
+            : selectSelectedDevice(getState());
 
         if (!device?.state?.staticSessionId || !selectedProvider) {
             return true;
@@ -656,7 +656,7 @@ export const init =
             // todo: possible race condition that has been around since always
             // user is editing label and at that very moment update arrives. updates to specific entities should be probably discarded in such case?
             metadataProviderActions.fetchIntervals[fetchIntervalTrackingId] = setInterval(() => {
-                const device = selectDevice(getState());
+                const device = selectSelectedDevice(getState());
                 if (!getState().suite.online || !device?.state?.staticSessionId) {
                     return;
                 }

--- a/packages/suite/src/actions/suite/metadataPasswordsActions.ts
+++ b/packages/suite/src/actions/suite/metadataPasswordsActions.ts
@@ -2,7 +2,7 @@ import crypto from 'crypto';
 
 import TrezorConnect from '@trezor/connect';
 import { cloneObject } from '@trezor/utils';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 
 import { METADATA, METADATA_PROVIDER, METADATA_PASSWORDS } from 'src/actions/suite/constants';
 import { Dispatch, GetState } from 'src/types/suite';
@@ -74,7 +74,7 @@ export const fetchPasswords =
     };
 
 export const init = () => async (dispatch: Dispatch, getState: GetState) => {
-    let device = selectDevice(getState());
+    let device = selectSelectedDevice(getState());
 
     if (!device?.state) {
         console.error('no device state!');
@@ -160,7 +160,7 @@ export const init = () => async (dispatch: Dispatch, getState: GetState) => {
         console.error('cipherKeyValue error', err);
     }
 
-    device = selectDevice(getState());
+    device = selectSelectedDevice(getState());
     const selectedProvider = selectSelectedProviderForPasswords(getState());
     if (!selectedProvider || !device?.state?.staticSessionId) {
         // ts, should not happen
@@ -174,7 +174,7 @@ export const init = () => async (dispatch: Dispatch, getState: GetState) => {
 
     if (device?.state && !metadataProviderActions.fetchIntervals[fetchIntervalTrackingId]) {
         metadataProviderActions.fetchIntervals[fetchIntervalTrackingId] = setInterval(() => {
-            device = selectDevice(getState());
+            device = selectSelectedDevice(getState());
             const { fileName, aesKey } = device?.passwords?.[1] || {};
 
             if (!getState().suite.online || !device?.state || !fileName || !aesKey) {

--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -9,7 +9,7 @@ import {
     accountsActions,
     selectAccountByKey,
     transactionsActions,
-    selectDevice,
+    selectSelectedDevice,
     selectDevices,
 } from '@suite-common/wallet-core';
 import {
@@ -578,7 +578,7 @@ export const createCoinjoinAccount =
 
         dispatch(coinjoinAccountPreloading(true));
 
-        const device = selectDevice(getState());
+        const device = selectSelectedDevice(getState());
         const unlockPath = await TrezorConnect.unlockPath({
             path: "m/10025'",
             device,
@@ -697,7 +697,7 @@ export const rescanCoinjoinAccount =
 const authorizeCoinjoin =
     (account: Account, coordinator: string, params: CoinjoinSessionParameters) =>
     async (dispatch: Dispatch, getState: GetState) => {
-        const device = selectDevice(getState());
+        const device = selectSelectedDevice(getState());
 
         // authorize coinjoin session on Trezor
         dispatch(coinjoinAccountAuthorize(account.key));
@@ -775,7 +775,7 @@ export const restoreCoinjoinSession =
     (accountKey: string) => async (dispatch: Dispatch, getState: GetState) => {
         // TODO: check if device is connected, passphrase is authorized...
         const isDeviceLocked = selectIsDeviceLocked(getState());
-        const device = selectDevice(getState());
+        const device = selectSelectedDevice(getState());
         const account = selectAccountByKey(getState(), accountKey);
 
         if (!account || !isCoinjoinSupportedSymbol(account.symbol)) {

--- a/packages/suite/src/actions/wallet/coinmarket/coinmarketCommonActions.ts
+++ b/packages/suite/src/actions/wallet/coinmarket/coinmarketCommonActions.ts
@@ -13,7 +13,7 @@ import {
 import { Output, AddressDisplayOptions } from '@suite-common/wallet-types/src';
 import {
     confirmAddressOnDeviceThunk,
-    selectDevice,
+    selectSelectedDevice,
     toggleRememberDevice,
 } from '@suite-common/wallet-core';
 
@@ -94,7 +94,7 @@ export const verifyAddress =
             | typeof COINMARKET_BUY.VERIFY_ADDRESS,
     ) =>
     async (dispatch: Dispatch, getState: GetState) => {
-        const device = selectDevice(getState());
+        const device = selectSelectedDevice(getState());
         if (!device || !account) return;
         const accountAddress = getUnusedAddressFromAccount(account);
         address = address ?? accountAddress.address;
@@ -165,7 +165,7 @@ export const submitRequestForm =
         };
     }) =>
     (dispatch: Dispatch, getState: GetState) => {
-        const device = selectDevice(getState());
+        const device = selectSelectedDevice(getState());
         if (device && !device.remember && !isDesktop()) {
             dispatch(toggleRememberDevice({ device, forceRemember: true }));
         }

--- a/packages/suite/src/actions/wallet/publicKeyActions.ts
+++ b/packages/suite/src/actions/wallet/publicKeyActions.ts
@@ -1,7 +1,7 @@
 import { UserContextPayload } from '@suite-common/suite-types';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import TrezorConnect, { Success, Unsuccessful } from '@trezor/connect';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { getDerivationType } from '@suite-common/wallet-utils';
 
 import { onCancel, openModal, preserve } from 'src/actions/suite/modalActions';
@@ -14,7 +14,7 @@ export const openXpubModal =
     };
 
 export const showXpub = () => async (dispatch: Dispatch, getState: GetState) => {
-    const device = selectDevice(getState());
+    const device = selectSelectedDevice(getState());
     const { account } = getState().wallet.selectedAccount;
 
     if (!device || !account) return;

--- a/packages/suite/src/actions/wallet/receiveActions.ts
+++ b/packages/suite/src/actions/wallet/receiveActions.ts
@@ -1,6 +1,6 @@
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { UserContextPayload } from '@suite-common/suite-types';
-import { confirmAddressOnDeviceThunk, selectDevice } from '@suite-common/wallet-core';
+import { confirmAddressOnDeviceThunk, selectSelectedDevice } from '@suite-common/wallet-core';
 import { AddressDisplayOptions } from '@suite-common/wallet-types';
 
 import { RECEIVE } from 'src/actions/wallet/constants';
@@ -40,7 +40,7 @@ export const openAddressModal =
 
 export const showAddress =
     (path: string, address: string) => async (dispatch: Dispatch, getState: GetState) => {
-        const device = selectDevice(getState());
+        const device = selectSelectedDevice(getState());
         const { account } = getState().wallet.selectedAccount;
 
         if (!device || !account) return;

--- a/packages/suite/src/actions/wallet/selectedAccountActions.ts
+++ b/packages/suite/src/actions/wallet/selectedAccountActions.ts
@@ -1,6 +1,6 @@
 import {
     selectDeviceDiscovery,
-    selectDevice,
+    selectSelectedDevice,
     accountsActions,
     blockchainActions,
     discoveryActions,
@@ -17,7 +17,7 @@ import { getSelectedAccount } from 'src/utils/wallet/accountUtils';
 import { Action, Dispatch, GetState, AppState } from 'src/types/suite';
 
 const getAccountState = (state: AppState): SelectedAccountStatus => {
-    const device = selectDevice(state);
+    const device = selectSelectedDevice(state);
 
     // waiting for device
     if (!device) {

--- a/packages/suite/src/actions/wallet/send/sendFormThunks.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormThunks.ts
@@ -12,7 +12,7 @@ import {
     enhancePrecomposedTransactionThunk,
     pushSendFormTransactionThunk,
     replaceTransactionThunk,
-    selectDevice,
+    selectSelectedDevice,
     selectSendFormDrafts,
     signTransactionThunk,
     sendFormActions,
@@ -199,7 +199,7 @@ export const signAndPushSendFormTransactionThunk = createThunk(
         },
         { dispatch, getState },
     ) => {
-        const device = selectDevice(getState());
+        const device = selectSelectedDevice(getState());
         if (!device || !selectedAccount) return;
 
         const enhancedPrecomposedTransaction = await dispatch(

--- a/packages/suite/src/actions/wallet/signVerifyActions.ts
+++ b/packages/suite/src/actions/wallet/signVerifyActions.ts
@@ -1,6 +1,6 @@
 import TrezorConnect, { Unsuccessful, Success } from '@trezor/connect';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { AddressDisplayOptions } from '@suite-common/wallet-types';
 
 import type { Dispatch, GetState, TrezorDevice } from 'src/types/suite';
@@ -27,7 +27,7 @@ const getStateParams = (getState: GetState): Promise<StateParams> => {
             selectedAccount: { account },
         },
     } = getState();
-    const device = selectDevice(getState());
+    const device = selectSelectedDevice(getState());
     const addressDisplayType = selectAddressDisplayType(getState());
 
     return !device || !device.connected || !device.available || !account

--- a/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
@@ -26,7 +26,7 @@ import {
     MIN_ETH_FOR_WITHDRAWALS,
     UNSTAKE_INTERCHANGES,
 } from '@suite-common/wallet-constants';
-import { selectDevice, ComposeActionContext } from '@suite-common/wallet-core';
+import { selectSelectedDevice, ComposeActionContext } from '@suite-common/wallet-core';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
 
 import { Dispatch, GetState } from 'src/types/suite';
@@ -190,7 +190,7 @@ export const signTransaction =
     (formValues: StakeFormState, transactionInfo: PrecomposedTransactionFinal) =>
     async (dispatch: Dispatch, getState: GetState) => {
         const { selectedAccount, transactions } = getState().wallet;
-        const device = selectDevice(getState());
+        const device = selectSelectedDevice(getState());
         if (
             selectedAccount.status !== 'loaded' ||
             !device ||

--- a/packages/suite/src/actions/wallet/stakeActions.ts
+++ b/packages/suite/src/actions/wallet/stakeActions.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 import TrezorConnect from '@trezor/connect';
 import {
-    selectDevice,
+    selectSelectedDevice,
     replaceTransactionThunk,
     syncAccountsWithBlockchainThunk,
     stakeActions,
@@ -56,7 +56,7 @@ const pushTransaction =
     (stakeType: StakeType) => async (dispatch: Dispatch, getState: GetState) => {
         const { serializedTx, precomposedTx } = getState().wallet.stake;
         const { account } = getState().wallet.selectedAccount;
-        const device = selectDevice(getState());
+        const device = selectSelectedDevice(getState());
         if (!serializedTx || !precomposedTx || !account) return;
 
         const sentTx = await TrezorConnect.pushTransaction({
@@ -147,7 +147,7 @@ const pushTransaction =
 export const signTransaction =
     (formValues: StakeFormState, transactionInfo: PrecomposedTransactionFinal) =>
     async (dispatch: Dispatch, getState: GetState) => {
-        const device = selectDevice(getState());
+        const device = selectSelectedDevice(getState());
         const { account } = getState().wallet.selectedAccount;
 
         if (!device || !account) return;

--- a/packages/suite/src/components/firmware/CheckSeedStep.tsx
+++ b/packages/suite/src/components/firmware/CheckSeedStep.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import { Button, Checkbox, variables } from '@trezor/components';
 import { spacingsPx } from '@trezor/theme';
-import { selectDeviceLabelOrName } from '@suite-common/wallet-core';
+import { selectSelectedDeviceLabelOrName } from '@suite-common/wallet-core';
 
 import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 import { Translation } from 'src/components/suite';
@@ -48,7 +48,7 @@ type CheckSeedStepProps = {
 };
 
 export const CheckSeedStep = ({ deviceWillBeWiped, onClose, onSuccess }: CheckSeedStepProps) => {
-    const deviceLabel = useSelector(selectDeviceLabelOrName);
+    const deviceLabel = useSelector(selectSelectedDeviceLabelOrName);
     const dispatch = useDispatch();
     const { device } = useDevice();
     const [isChecked, setIsChecked] = useState(false);

--- a/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
+++ b/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
@@ -6,7 +6,7 @@ import { DEVICE, Device, DeviceModelInternal, UI } from '@trezor/connect';
 import { ConfirmOnDevice } from '@trezor/product-components';
 import { TranslationKey } from '@suite-common/intl-types';
 import { spacings } from '@trezor/theme';
-import { selectDeviceLabelOrName } from '@suite-common/wallet-core';
+import { selectSelectedDeviceLabelOrName } from '@suite-common/wallet-core';
 import { useFirmwareInstallation } from '@suite-common/firmware';
 
 import { useDevice, useSelector } from 'src/hooks/suite';
@@ -63,7 +63,7 @@ interface ReconnectDevicePromptProps {
 }
 
 export const ReconnectDevicePrompt = ({ onClose, onSuccess }: ReconnectDevicePromptProps) => {
-    const deviceLabel = useSelector(selectDeviceLabelOrName);
+    const deviceLabel = useSelector(selectSelectedDeviceLabelOrName);
     const isWebUsbTransport = useSelector(selectIsWebUsb);
     const { showManualReconnectPrompt, status, uiEvent } = useFirmwareInstallation();
     const { device } = useDevice();

--- a/packages/suite/src/components/guide/SupportFeedbackSelection.tsx
+++ b/packages/suite/src/components/guide/SupportFeedbackSelection.tsx
@@ -6,7 +6,7 @@ import { resolveStaticPath, isDevEnv } from '@suite-common/suite-utils';
 import { Icon, Link, variables } from '@trezor/components';
 import { isDesktop } from '@trezor/env-utils';
 import { getFirmwareVersion } from '@trezor/device-utils';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { borders } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
@@ -105,7 +105,7 @@ const LabelSubheadline = styled.div`
 
 export const SupportFeedbackSelection = () => {
     const desktopUpdate = useSelector(state => state.desktopUpdate);
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const dispatch = useDispatch();
 
     const appUpToDate =

--- a/packages/suite/src/components/onboarding/Hologram.tsx
+++ b/packages/suite/src/components/onboarding/Hologram.tsx
@@ -2,7 +2,7 @@ import { useRef } from 'react';
 
 import styled from 'styled-components';
 
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { getPackagingUrl } from '@suite-common/suite-utils';
 import { DeviceAnimation, Banner, variables } from '@trezor/components';
 import { TREZOR_RESELLERS_URL, TREZOR_SUPPORT_URL } from '@trezor/urls';
@@ -33,7 +33,7 @@ const StyledWarning = styled(Banner)`
 `;
 
 export const Hologram = () => {
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const hologramRef = useRef<HTMLVideoElement>(null);
 
     const packagingUrl = getPackagingUrl(device);

--- a/packages/suite/src/components/suite/Preloader/Preloader.tsx
+++ b/packages/suite/src/components/suite/Preloader/Preloader.tsx
@@ -1,7 +1,7 @@
 import { FC, useEffect, PropsWithChildren } from 'react';
 
 import {
-    selectDevice,
+    selectSelectedDevice,
     selectIsFirmwareAuthenticityCheckDismissed,
 } from '@suite-common/wallet-core';
 
@@ -58,7 +58,7 @@ export const Preloader = ({ children }: PropsWithChildren) => {
     const router = useSelector(state => state.router);
     const prerequisite = useSelector(selectPrerequisite);
     const isLoggedOut = useSelector(selectIsLoggedOut);
-    const selectedDevice = useSelector(selectDevice);
+    const selectedDevice = useSelector(selectSelectedDevice);
     const { initialRun, viewOnlyPromoClosed } = useSelector(selectSuiteFlags);
     const isFirmwareCheckFailed = useSelector(
         selectIsFirmwareAuthenticityCheckEnabledAndHardFailed,

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUnreadable.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUnreadable.tsx
@@ -4,7 +4,7 @@ import { Button } from '@trezor/components';
 import { desktopApi } from '@trezor/suite-desktop-api';
 import { isDesktop, isLinux } from '@trezor/env-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 
 import { Translation, TroubleshootingTips, UdevDownload } from 'src/components/suite';
 import {
@@ -112,7 +112,7 @@ interface DeviceUnreadableProps {
  * - missing udev rule on linux
  */
 export const DeviceUnreadable = ({ device }: DeviceUnreadableProps) => {
-    const selectedDevice = useSelector(selectDevice);
+    const selectedDevice = useSelector(selectSelectedDevice);
 
     // this error is dispatched by trezord when udev rules are missing
     if (isLinux() && device?.error === 'LIBUSB_ERROR_ACCESS') {

--- a/packages/suite/src/components/suite/PrerequisitesGuide/PrerequisitesGuide.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/PrerequisitesGuide.tsx
@@ -5,7 +5,7 @@ import { motion } from 'framer-motion';
 
 import { getStatus, deviceNeedsAttention } from '@suite-common/suite-utils';
 import { Button, motionEasing } from '@trezor/components';
-import { selectDevices, selectDevice } from '@suite-common/wallet-core';
+import { selectDevices, selectSelectedDevice } from '@suite-common/wallet-core';
 
 import { ConnectDevicePrompt, Translation } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -49,7 +49,7 @@ interface PrerequisitesGuideProps {
 
 export const PrerequisitesGuide = ({ allowSwitchDevice }: PrerequisitesGuideProps) => {
     const dispatch = useDispatch();
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const devices = useSelector(selectDevices);
     const connectedDevicesCount = devices.filter(d => d.connected === true).length;
     const isWebUsbTransport = useSelector(selectIsWebUsb);

--- a/packages/suite/src/components/suite/SecurityCheck/SecurityCheckLayout.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/SecurityCheckLayout.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 import { Image, variables } from '@trezor/components';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 
 import { useSelector } from 'src/hooks/suite';
 
@@ -48,7 +48,7 @@ interface SecurityCheckLayoutProps {
 }
 
 export const SecurityCheckLayout = ({ isFailed, children }: SecurityCheckLayoutProps) => {
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
 
     const deviceModelInternal = device?.features?.internal_model;
     const imageVariant = isFailed ? 'GHOST' : 'LARGE';

--- a/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react';
 import styled from 'styled-components';
 
 import { selectBannerMessage } from '@suite-common/message-system';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { isDesktop } from '@trezor/env-utils';
 import { spacingsPx } from '@trezor/theme';
 
@@ -38,7 +38,7 @@ const Container = styled.div<{ $isVisible?: boolean }>`
 
 export const SuiteBanners = () => {
     const transport = useSelector(selectTransport);
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const isOnline = useSelector(state => state.suite.online);
     const firmwareHashInvalid = useSelector(state => state.firmware.firmwareHashInvalid);
     const bannerMessage = useSelector(selectBannerMessage);

--- a/packages/suite/src/components/suite/labeling/AccountLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/AccountLabeling.tsx
@@ -1,6 +1,6 @@
 import { findAccountDevice } from '@suite-common/wallet-utils';
 import { isSelectedDevice } from '@suite-common/suite-utils';
-import { selectDevices, selectDevice } from '@suite-common/wallet-core';
+import { selectDevices, selectSelectedDevice } from '@suite-common/wallet-core';
 import { BadgeProps } from '@trezor/components';
 
 import { AccountLabel } from 'src/components/suite';
@@ -21,7 +21,7 @@ export const AccountLabeling = ({
     accountTypeBadgeSize,
     showAccountTypeBadge,
 }: AccountProps) => {
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const devices = useSelector(selectDevices);
 
     const accounts = !Array.isArray(account) ? [account] : account;

--- a/packages/suite/src/components/suite/labeling/WalletLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/WalletLabeling.tsx
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 
 import styled from 'styled-components';
 
-import { selectDeviceLabelOrName } from '@suite-common/wallet-core';
+import { selectSelectedDeviceLabelOrName } from '@suite-common/wallet-core';
 
 import { TrezorDevice } from 'src/types/suite';
 import { useTranslation } from 'src/hooks/suite/useTranslation';
@@ -38,7 +38,7 @@ export const useWalletLabeling = () => {
 
 export const useGetWalletLabel = ({ device, shouldUseDeviceLabel }: WalletLabellingProps) => {
     const { defaultAccountLabelString } = useWalletLabeling();
-    const deviceLabel = useSelector(selectDeviceLabelOrName);
+    const deviceLabel = useSelector(selectSelectedDeviceLabelOrName);
     const { walletLabel } = useSelector(state => selectLabelingDataForWallet(state, device.state));
 
     let label: string | undefined;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/CoinjoinBars/CoinjoinStatusBar.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/CoinjoinBars/CoinjoinStatusBar.tsx
@@ -1,7 +1,7 @@
 import styled, { css } from 'styled-components';
 
 import {
-    selectDevice,
+    selectSelectedDevice,
     selectDevices,
     selectAccountByKey,
     selectDeviceThunk,
@@ -81,7 +81,7 @@ interface CoinjoinStatusBarProps {
 export const CoinjoinStatusBar = ({ accountKey, session, isSingle }: CoinjoinStatusBarProps) => {
     const devices = useSelector(selectDevices);
     const relatedAccount = useSelector(state => selectAccountByKey(state, accountKey));
-    const selectedDevice = useSelector(selectDevice);
+    const selectedDevice = useSelector(selectSelectedDevice);
     const routerParams = useSelector(selectRouterParams);
     const sessionProgress = useSelector(state =>
         selectSessionProgressByAccountKey(state, accountKey),

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 
 import styled, { css } from 'styled-components';
 
-import { selectDevicesCount, selectDevice } from '@suite-common/wallet-core';
+import { selectDevicesCount, selectSelectedDevice } from '@suite-common/wallet-core';
 import type { TimerId } from '@trezor/type-utils';
 import { borders, spacingsPx } from '@trezor/theme';
 import { focusStyleTransition, getFocusShadowStyle } from '@trezor/components/src/utils/utils';
@@ -69,7 +69,7 @@ const InnerContainer = styled.div`
 `;
 
 export const DeviceSelector = () => {
-    const selectedDevice = useSelector(selectDevice);
+    const selectedDevice = useSelector(selectSelectedDevice);
 
     const deviceCount = useSelector(selectDevicesCount);
     const dispatch = useDispatch();

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/SidebarDeviceStatus.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/SidebarDeviceStatus.tsx
@@ -1,6 +1,6 @@
 import { MouseEventHandler } from 'react';
 
-import { acquireDevice, selectDevice, selectDevices } from '@suite-common/wallet-core';
+import { acquireDevice, selectSelectedDevice, selectDevices } from '@suite-common/wallet-core';
 import * as deviceUtils from '@suite-common/suite-utils';
 
 import { TrezorDevice } from 'src/types/suite';
@@ -22,7 +22,7 @@ const needsRefresh = (device?: TrezorDevice) => {
 };
 
 export const SidebarDeviceStatus = () => {
-    const selectedDevice = useSelector(selectDevice);
+    const selectedDevice = useSelector(selectSelectedDevice);
     const devices = useSelector(selectDevices);
     const dispatch = useDispatch();
     const isSidebarCollapsed = useIsSidebarCollapsed();

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions.tsx
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components';
 import { Row, variables } from '@trezor/components';
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 import { analytics, EventType } from '@trezor/suite-analytics';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { spacings } from '@trezor/theme';
 import { SelectedAccountStatus } from '@suite-common/wallet-types';
 
@@ -35,7 +35,7 @@ export const TradeActions = ({
 }: TradeActionsProps) => {
     const dispatch = useDispatch();
     const account = selectedAccount?.account;
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const isAccountTabPage = useSelector(selectIsAccountTabPage);
     const currentRouteName = useSelector(selectRouteName);
 

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/useAppShortcuts.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/useAppShortcuts.tsx
@@ -1,6 +1,6 @@
 import { useEvent } from 'react-use';
 
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { KEYBOARD_CODE } from '@trezor/components';
 
 import { closeModalApp, goto } from 'src/actions/suite/routerActions';
@@ -8,7 +8,7 @@ import { addWalletThunk } from 'src/actions/wallet/addWalletThunk';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 export const useAppShortcuts = () => {
-    const selectedDevice = useSelector(selectDevice);
+    const selectedDevice = useSelector(selectSelectedDevice);
     const dispatch = useDispatch();
 
     useEvent('keydown', e => {

--- a/packages/suite/src/components/suite/modals/ModalSwitcher/DiscoveryLoader.tsx
+++ b/packages/suite/src/components/suite/modals/ModalSwitcher/DiscoveryLoader.tsx
@@ -1,5 +1,5 @@
 import { H3, Spinner, Column } from '@trezor/components';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
@@ -8,7 +8,7 @@ import { SwitchDeviceModal } from 'src/views/suite/SwitchDevice/SwitchDeviceModa
 import { useSelector } from 'src/hooks/suite';
 
 export const DiscoveryLoader = () => {
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     if (!device) return null;
 
     return (

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 
 import { showAddress } from 'src/actions/wallet/receiveActions';
 import { Translation } from 'src/components/suite';
@@ -21,7 +21,7 @@ interface ConfirmAddressModalProps
 }
 
 export const ConfirmAddressModal = ({ addressPath, value, ...props }: ConfirmAddressModalProps) => {
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const account = useSelector(selectAccountIncludingChosenInCoinmarket);
     const { modalCryptoId } = useSelector(state => state.wallet.coinmarket);
     const displayMode = useDisplayMode({ type: 'address' });

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
@@ -12,7 +12,7 @@ import {
     Card,
 } from '@trezor/components';
 import { copyToClipboard } from '@trezor/dom-utils';
-import { selectDevice, selectDeviceLabelOrName } from '@suite-common/wallet-core';
+import { selectSelectedDevice, selectSelectedDeviceLabelOrName } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 import { palette, spacings } from '@trezor/theme';
 import { getNetworkFeatures } from '@suite-common/wallet-config';
@@ -53,10 +53,10 @@ export const ConfirmValueModal = ({
     value,
     displayMode,
 }: ConfirmValueModalProps) => {
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const modalContext = useSelector(state => state.modal.context);
     const isActionAbortable = useSelector(selectIsActionAbortable);
-    const deviceLabel = useSelector(selectDeviceLabelOrName);
+    const deviceLabel = useSelector(selectSelectedDeviceLabelOrName);
     const dispatch = useDispatch();
 
     const canConfirmOnDevice = !!(device?.connected && device?.available);

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmXpubModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmXpubModal.tsx
@@ -1,4 +1,4 @@
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 
 import { Translation } from 'src/components/suite';
 import { showXpub } from 'src/actions/wallet/publicKeyActions';
@@ -13,7 +13,7 @@ import { ConfirmActionModal } from './DeviceContextModal/ConfirmActionModal';
 export const ConfirmXpubModal = (
     props: Pick<ConfirmValueModalProps, 'isConfirmed' | 'onCancel'>,
 ) => {
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const account = useSelector(selectSelectedAccount);
     const { accountLabel } = useSelector(selectLabelingDataForSelectedAccount);
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/DeviceContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/DeviceContextModal.tsx
@@ -1,7 +1,7 @@
 import { useIntl } from 'react-intl';
 
 import TrezorConnect, { UI } from '@trezor/connect';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 
 import messages from 'src/support/messages';
 import { MODAL } from 'src/actions/suite/constants';
@@ -28,7 +28,7 @@ export const DeviceContextModal = ({
     renderer,
     data,
 }: ReduxModalProps<typeof MODAL.CONTEXT_DEVICE>) => {
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const intl = useIntl();
 
     if (!device) return null;

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseOnDeviceModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseOnDeviceModal.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { H2, NewModal, Paragraph } from '@trezor/components';
 import { ConfirmOnDevice } from '@trezor/product-components';
 import {
-    selectDeviceLabelOrName,
+    selectSelectedDeviceLabelOrName,
     selectIsDiscoveryAuthConfirmationRequired,
 } from '@suite-common/wallet-core';
 import TrezorConnect from '@trezor/connect';
@@ -34,7 +34,7 @@ export const PassphraseOnDeviceModal = ({ device }: PassphraseOnDeviceModalProps
     const intl = useIntl();
     const authConfirmation =
         useSelector(selectIsDiscoveryAuthConfirmationRequired) || device.authConfirm;
-    const deviceLabel = useSelector(selectDeviceLabelOrName);
+    const deviceLabel = useSelector(selectSelectedDeviceLabelOrName);
 
     const onCancel = () => TrezorConnect.cancel(intl.formatMessage(messages.TR_CANCELLED));
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PinInvalidModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PinInvalidModal.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { selectDeviceLabelOrName } from '@suite-common/wallet-core';
+import { selectSelectedDeviceLabelOrName } from '@suite-common/wallet-core';
 import { Paragraph } from '@trezor/components';
 
 import { Translation } from 'src/components/suite/Translation';
@@ -21,7 +21,7 @@ interface PinInvalidModalProps extends ModalProps {
 }
 
 export const PinInvalidModal = ({ device, ...rest }: PinInvalidModalProps) => {
-    const deviceLabel = useSelector(selectDeviceLabelOrName);
+    const deviceLabel = useSelector(selectSelectedDeviceLabelOrName);
 
     return (
         <StyledModal

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PinModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PinModal.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 import TrezorConnect from '@trezor/connect';
-import { selectDeviceLabelOrName } from '@suite-common/wallet-core';
+import { selectSelectedDeviceLabelOrName } from '@suite-common/wallet-core';
 
 import { Modal, ModalProps, PinMatrix, Translation } from 'src/components/suite';
 import { PIN_MATRIX_MAX_WIDTH } from 'src/components/suite/PinMatrix/PinMatrix';
@@ -25,7 +25,7 @@ interface PinModalProps extends ModalProps {
 }
 
 export const PinModal = ({ device, ...rest }: PinModalProps) => {
-    const deviceLabel = useSelector(selectDeviceLabelOrName);
+    const deviceLabel = useSelector(selectSelectedDeviceLabelOrName);
     const { isRequestingNewPinCode, isWipeCode, isPinInvalid, isModalExtended } = usePin();
 
     if (!device.features) return null;

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
@@ -6,7 +6,7 @@ import { variables } from '@trezor/components';
 import { Deferred } from '@trezor/utils';
 import {
     DeviceRootState,
-    selectDevice,
+    selectSelectedDevice,
     selectPrecomposedSendForm,
     selectSendFormReviewButtonRequestsCount,
     selectStakePrecomposedForm,
@@ -66,7 +66,7 @@ export const TransactionReviewModalContent = ({
 }: TransactionReviewModalContentProps) => {
     const account = useSelector(selectAccountIncludingChosenInCoinmarket);
     const fees = useSelector(state => state.wallet.fees);
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const isActionAbortable = useSelector(selectIsActionAbortable);
     const [detailsOpen, setDetailsOpen] = useState(false);
     const [isSending, setIsSending] = useState(false);

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
@@ -9,7 +9,7 @@ import {
     getIsUpdatedSendFlow,
     getIsUpdatedEthereumSendFlow,
 } from '@suite-common/wallet-utils';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { StakeType } from '@suite-common/wallet-types';
 
 import { TrezorDevice } from 'src/types/suite';
@@ -131,7 +131,7 @@ export const TransactionReviewTotalOutput = forwardRef<
         },
         ref,
     ) => {
-        const device = useSelector(selectDevice);
+        const device = useSelector(selectSelectedDevice);
 
         if (!device) {
             return null;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddAccountButton.tsx
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 
 import { analytics, EventType } from '@trezor/suite-analytics';
 import { UnavailableCapability } from '@trezor/connect';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { Network, NetworkAccount } from '@suite-common/wallet-config';
 
 import { Account } from 'src/types/wallet';
@@ -67,7 +67,7 @@ const AddDefaultAccountButton = ({
     selectedAccount,
 }: AddAccountButtonProps) => {
     const defaultAccount = emptyAccounts[emptyAccounts.length - 1];
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
 
     const { setCoinFilter, setSearchString, coinFilter } = useAccountSearch();
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddCoinjoinAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddCoinjoinAccountButton.tsx
@@ -5,7 +5,7 @@ import { UnavailableCapabilities } from '@trezor/connect';
 import { isDesktop } from '@trezor/env-utils';
 import { isDevEnv } from '@suite-common/suite-utils';
 import { RequestEnableTorResponse } from '@suite-common/suite-config';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { Network, NetworkAccount, NetworkSymbol } from '@suite-common/wallet-config';
 
 import { Translation } from 'src/components/suite';
@@ -54,7 +54,7 @@ export const AddCoinjoinAccountButton = ({ network, selectedAccount }: AddCoinjo
     const [isLoading, setIsLoading] = useState(false);
 
     const { isTorEnabled } = useSelector(selectTorState);
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const accounts = useSelector(state => state.wallet.accounts);
     const dispatch = useDispatch();
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedModal.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
 import { Button, H3, NewModal, Paragraph } from '@trezor/components';
-import { selectDeviceLabelOrName } from '@suite-common/wallet-core';
+import { selectSelectedDeviceLabelOrName } from '@suite-common/wallet-core';
 
 import { Translation } from 'src/components/suite';
 import { TranslationKey } from 'src/components/suite/Translation';
@@ -25,7 +25,7 @@ export const ConfirmUnverifiedModal = ({
     warningText,
     verifyProcess,
 }: ConfirmUnverifiedModalProps) => {
-    const deviceLabel = useSelector(selectDeviceLabelOrName);
+    const deviceLabel = useSelector(selectSelectedDeviceLabelOrName);
     const { device } = useDevice();
     const dispatch = useDispatch();
     const { isLocked } = useDevice();

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupModal.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { NewModal, NewModalProps } from '@trezor/components';
 import {
     HELP_CENTER_KEEPING_SEED_SAFE_URL,
@@ -30,7 +30,7 @@ type MultiShareBackupModalProps = {
 type StepConfig = Partial<NewModalProps>;
 
 export const MultiShareBackupModal = ({ onCancel }: MultiShareBackupModalProps) => {
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
 
     const isInBackupMode =
         device?.features !== undefined && isAdditionalShamirBackupInProgress(device.features);

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
@@ -2,7 +2,7 @@ import type { ComponentType } from 'react';
 import { useSelector } from 'react-redux';
 
 import { AUTH_DEVICE, type NotificationEntry } from '@suite-common/toast-notifications';
-import { selectDeviceLabelOrName } from '@suite-common/wallet-core';
+import { selectSelectedDeviceLabelOrName } from '@suite-common/wallet-core';
 import { DEVICE } from '@trezor/connect';
 
 import { NotificationViewProps } from 'src/components/suite';
@@ -65,7 +65,7 @@ export const NotificationRenderer = ({
     notification,
     render,
 }: NotificationRendererProps): JSX.Element => {
-    const deviceLabel = useSelector(selectDeviceLabelOrName);
+    const deviceLabel = useSelector(selectSelectedDeviceLabelOrName);
 
     switch (notification.type) {
         case 'acquire-error':

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx
@@ -1,5 +1,5 @@
 import {
-    selectDevice as selectDeviceSelector,
+    selectSelectedDevice as selectDeviceSelector,
     selectDevices,
     selectAccounts,
     selectBlockchainState,

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSearchBox.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSearchBox.tsx
@@ -2,7 +2,7 @@ import styled, { useTheme } from 'styled-components';
 
 import { Icon, Input } from '@trezor/components';
 import { borders } from '@trezor/theme';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 
 import { useSelector, useAccountSearch, useTranslation } from 'src/hooks/suite';
 import { selectEnabledNetworks } from 'src/reducers/wallet/settingsReducer';
@@ -28,7 +28,7 @@ export const AccountSearchBox = () => {
     const { translationString } = useTranslation();
     const { setCoinFilter, searchString, setSearchString } = useAccountSearch();
     const enabledNetworks = useSelector(selectEnabledNetworks);
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
 
     const unavailableCapabilities = device?.unavailableCapabilities ?? {};
     const supportedNetworks = enabledNetworks.filter(symbol => !unavailableCapabilities[symbol]);

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
@@ -1,6 +1,6 @@
 import { sortByCoin, getFailedAccounts, accountSearchFn } from '@suite-common/wallet-utils';
 import { Account } from '@suite-common/wallet-types';
-import { selectAccounts, selectDevice } from '@suite-common/wallet-core';
+import { selectAccounts, selectSelectedDevice } from '@suite-common/wallet-core';
 import { spacings } from '@trezor/theme';
 import { Column } from '@trezor/components';
 import { AccountType } from '@suite-common/wallet-config';
@@ -72,7 +72,7 @@ const Accounts = ({
 };
 
 export const AccountsList = ({ onItemClick }: AccountListProps) => {
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const accounts = useSelector(selectAccounts);
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
     const coinjoinIsPreloading = useSelector(state => state.wallet.coinjoin.isPreloading);

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenu.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenu.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { spacings, spacingsPx, zIndices } from '@trezor/theme';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { getFailedAccounts, sortByCoin } from '@suite-common/wallet-utils';
 import { useScrollShadow, Row, Column } from '@trezor/components';
 
@@ -41,7 +41,7 @@ const ScrollContainer = styled.div`
 `;
 
 export const AccountsMenu = () => {
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const accounts = useSelector(state => state.wallet.accounts);
     const { discovery } = useDiscovery();
     const { scrollElementRef, onScroll, ShadowTop, ShadowBottom, ShadowContainer } =

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/CoinsFilter.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/CoinsFilter.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { motion, AnimatePresence, MotionProps } from 'framer-motion';
 
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { TOOLTIP_DELAY_NORMAL, Tooltip, motionEasing } from '@trezor/components';
 import { CoinLogo } from '@trezor/product-components';
 import { borders, spacingsPx } from '@trezor/theme';
@@ -44,7 +44,7 @@ const Container = styled.div`
 export const CoinsFilter = () => {
     const { coinFilter, setCoinFilter } = useAccountSearch();
     const enabledNetworks = useSelector(selectEnabledNetworks);
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
 
     const unavailableCapabilities = device?.unavailableCapabilities ?? {};
     const supportedNetworks = enabledNetworks.filter(symbol => !unavailableCapabilities[symbol]);

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/MobileAccountsMenu.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/MobileAccountsMenu.tsx
@@ -4,7 +4,7 @@ import styled, { css, useTheme } from 'styled-components';
 
 import { H2, variables, Icon } from '@trezor/components';
 import { zIndices, spacingsPx } from '@trezor/theme';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 
 import { Translation } from 'src/components/suite';
 import { useDiscovery, useSelector } from 'src/hooks/suite';
@@ -95,7 +95,7 @@ const StyledIcon = styled(Icon)<{ $isActive: boolean }>`
 `;
 
 export const MobileAccountsMenu = () => {
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const [isExpanded, setIsExpanded] = useState(false);
 
     const theme = useTheme();

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/RefreshAfterDiscoveryNeeded.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/RefreshAfterDiscoveryNeeded.tsx
@@ -5,7 +5,7 @@ import { AnimatePresence, MotionProps, motion } from 'framer-motion';
 
 import { Button, IconButton, motionEasing, Row, Tooltip } from '@trezor/components';
 import { spacings, spacingsPx, typography } from '@trezor/theme';
-import { selectDevice, startDiscoveryThunk } from '@suite-common/wallet-core';
+import { selectSelectedDevice, startDiscoveryThunk } from '@suite-common/wallet-core';
 
 import { useRediscoveryNeeded, useDispatch, useSelector } from 'src/hooks/suite';
 import { Translation } from 'src/components/suite';
@@ -42,7 +42,7 @@ const animationConfig: MotionProps = {
 export const RefreshAfterDiscoveryNeeded = () => {
     const dispatch = useDispatch();
     const isDiscoveryButtonVisible = useRediscoveryNeeded();
-    const selectedDevice = useSelector(selectDevice);
+    const selectedDevice = useSelector(selectSelectedDevice);
     const isSidebarCollapsed = useIsSidebarCollapsed();
     if (!selectedDevice?.connected) {
         return null;

--- a/packages/suite/src/hooks/settings/useNetworkSupport.ts
+++ b/packages/suite/src/hooks/settings/useNetworkSupport.ts
@@ -1,5 +1,5 @@
 import { Network, getMainnets, getTestnets } from '@suite-common/wallet-config';
-import { selectDevice, selectDeviceSupportedNetworks } from '@suite-common/wallet-core';
+import { selectSelectedDevice, selectDeviceSupportedNetworks } from '@suite-common/wallet-core';
 import { DeviceModelInternal } from '@trezor/connect';
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 import { arrayPartition } from '@trezor/utils';
@@ -8,7 +8,7 @@ import { useSelector } from 'src/hooks/suite';
 import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
 
 export const useNetworkSupport = () => {
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const isDebug = useSelector(selectIsDebugModeActive);
     const deviceSupportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
 

--- a/packages/suite/src/hooks/suite/useDevice.ts
+++ b/packages/suite/src/hooks/suite/useDevice.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { TrezorDevice } from '@suite-common/suite-types';
 
 import { selectIsDeviceOrUiLocked } from 'src/reducers/suite/suiteReducer';
@@ -13,7 +13,7 @@ type Result = {
 };
 
 export const useDevice = (): Result => {
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const isDeviceOrUiLocked = useSelector(selectIsDeviceOrUiLocked);
 
     const isLocked = useCallback(

--- a/packages/suite/src/hooks/suite/useDiscovery.ts
+++ b/packages/suite/src/hooks/suite/useDiscovery.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 
-import { selectDiscoveryByDeviceState, selectDevice } from '@suite-common/wallet-core';
+import { selectDiscoveryByDeviceState, selectSelectedDevice } from '@suite-common/wallet-core';
 import { DiscoveryStatus } from '@suite-common/wallet-constants';
 
 import { DiscoveryStatusType } from 'src/types/wallet';
@@ -8,7 +8,7 @@ import { DiscoveryStatusType } from 'src/types/wallet';
 import { useSelector } from './useSelector';
 
 export const useDiscovery = () => {
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const discovery = useSelector(state => selectDiscoveryByDeviceState(state, device?.state));
 
     const calculateProgress = useCallback(() => {

--- a/packages/suite/src/hooks/suite/useLoadingSkeleton.ts
+++ b/packages/suite/src/hooks/suite/useLoadingSkeleton.ts
@@ -1,9 +1,9 @@
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 
 import { useSelector } from 'src/hooks/suite';
 
 export const useLoadingSkeleton = () => {
-    const waitingForDevice = !useSelector(selectDevice)?.state;
+    const waitingForDevice = !useSelector(selectSelectedDevice)?.state;
     const modalActive = useSelector(state => state.modal.context) !== '@modal/context-none';
 
     return {

--- a/packages/suite/src/hooks/suite/usePasswords.ts
+++ b/packages/suite/src/hooks/suite/usePasswords.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 
 import { useSelector, useDispatch } from 'src/hooks/suite';
 import * as metadataProviderActions from 'src/actions/suite/metadataProviderActions';
@@ -18,7 +18,7 @@ export const usePasswords = () => {
 
     const [selectedTags, setSelectedTags] = useState<Record<string, boolean>>({});
 
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const selectedProvider = useSelector(selectSelectedProviderForPasswords);
 
     const { fileName, aesKey } = device?.passwords?.[1] || {};

--- a/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketAccount.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketAccount.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { selectAccounts, selectDevice } from '@suite-common/wallet-core';
+import { selectAccounts, selectSelectedDevice } from '@suite-common/wallet-core';
 import { Account, SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { isTestnet } from '@suite-common/wallet-utils';
 
@@ -22,7 +22,7 @@ export const useCoinmarketAccount = ({
     isNotFormPage,
 }: CoinmarketUseAccountProps): [Account, (state: Account) => void] => {
     const accounts = useSelector(selectAccounts);
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
 
     // coinmarketAccount is used on offers page
     // if is testnet, use

--- a/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketBuildAccountGroups.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketBuildAccountGroups.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { selectAccounts, selectDevice } from '@suite-common/wallet-core';
+import { selectAccounts, selectSelectedDevice } from '@suite-common/wallet-core';
 
 import { useDefaultAccountLabel, useSelector } from 'src/hooks/suite';
 import { selectAccountLabels } from 'src/reducers/suite/metadataReducer';
@@ -16,7 +16,7 @@ export const useCoinmarketBuildAccountGroups = (
 ): CoinmarketAccountsOptionsGroupProps[] => {
     const accounts = useSelector(selectAccounts);
     const accountLabels = useSelector(selectAccountLabels);
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const { getDefaultAccountLabel } = useDefaultAccountLabel();
     const { tokenDefinitions } = useSelector(state => state);
     const supportedSymbols = useSelector(selectSupportedSymbols(type));

--- a/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketComposeTransaction.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketComposeTransaction.ts
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { UseFormReturn } from 'react-hook-form';
 
 import { COMPOSE_ERROR_TYPES } from '@suite-common/wallet-constants';
-import { selectAccounts, selectDevice } from '@suite-common/wallet-core';
+import { selectAccounts, selectSelectedDevice } from '@suite-common/wallet-core';
 import { AddressDisplayOptions } from '@suite-common/wallet-types';
 import { getFeeLevels } from '@suite-common/wallet-utils';
 
@@ -31,7 +31,7 @@ export const useCoinmarketComposeTransaction = <T extends CoinmarketSellExchange
 }: CoinmarketUseComposeTransactionProps<T>): CoinmarketUseComposeTransactionReturnProps => {
     const dispatch = useDispatch();
     const accounts = useSelector(selectAccounts);
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const addressDisplayType = useSelector(selectAddressDisplayType);
     const fees = useSelector(state => state.wallet.fees);
     const { translationString } = useTranslation();

--- a/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketFormActions.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketFormActions.ts
@@ -5,7 +5,7 @@ import { useDebounce } from 'react-use';
 import { FiatCurrencyCode } from 'invity-api';
 
 import { isChanged } from '@suite-common/suite-utils';
-import { selectAccounts, selectDevice } from '@suite-common/wallet-core';
+import { selectAccounts, selectSelectedDevice } from '@suite-common/wallet-core';
 import {
     amountToSmallestUnit,
     formatAmount,
@@ -65,7 +65,7 @@ export const useCoinmarketFormActions = <T extends CoinmarketSellExchangeFormPro
     const { symbol } = account;
     const { shouldSendInSats } = useBitcoinAmountUnit(symbol);
     const accounts = useSelector(selectAccounts);
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const accountsSorted = coinmarketGetSortedAccounts({
         accounts,
         deviceState: device?.state?.staticSessionId,

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketVerifyAccount.tsx
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketVerifyAccount.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { Network, networksCollection } from '@suite-common/wallet-config';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 import { TrezorDevice } from '@suite-common/suite-types';
 import { filterReceiveAccounts } from '@suite-common/wallet-utils';
@@ -100,7 +100,7 @@ const useCoinmarketVerifyAccount = ({
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
     const accounts = useSelector(state => state.wallet.accounts);
     const isDebug = useSelector(selectIsDebugModeActive);
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const dispatch = useDispatch();
     const [isMenuOpen, setIsMenuOpen] = useState<boolean | undefined>(undefined);
 

--- a/packages/suite/src/hooks/wallet/useAccounts.ts
+++ b/packages/suite/src/hooks/wallet/useAccounts.ts
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo } from 'react';
 
 import type { AccountAddress } from '@trezor/connect';
 import * as accountUtils from '@suite-common/wallet-utils';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 
 import { useSelector } from 'src/hooks/suite';
 import type { Account, Discovery } from 'src/types/wallet';
@@ -10,7 +10,7 @@ import type { Account, Discovery } from 'src/types/wallet';
 export const useAccounts = (discovery?: Discovery) => {
     const [accounts, setAccounts] = useState<Account[]>([]);
 
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const accountsState = useSelector(state => state.wallet.accounts);
 
     useEffect(() => {
@@ -28,7 +28,7 @@ export const useAccounts = (discovery?: Discovery) => {
 };
 
 export const useFastAccounts = () => {
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const accounts = useSelector(state => state.wallet.accounts);
 
     const deviceAccounts = useMemo(

--- a/packages/suite/src/hooks/wallet/useCardanoStaking.ts
+++ b/packages/suite/src/hooks/wallet/useCardanoStaking.ts
@@ -14,7 +14,7 @@ import {
 } from '@suite-common/wallet-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import trezorConnect, { PROTO } from '@trezor/connect';
-import { addFakePendingCardanoTxThunk, selectDevice } from '@suite-common/wallet-core';
+import { addFakePendingCardanoTxThunk, selectSelectedDevice } from '@suite-common/wallet-core';
 
 import { ActionAvailability, CardanoStaking } from 'src/types/wallet/cardanoStaking';
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -62,7 +62,7 @@ export const useCardanoStaking = (): CardanoStaking => {
         throw Error('useCardanoStaking used for other network');
     }
 
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const isDeviceLocked = useSelector(selectIsDeviceLocked);
     const cardanoStaking = useSelector(state => state.wallet.cardanoStaking);
     const dispatch = useDispatch();

--- a/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
@@ -1,6 +1,6 @@
 import { MiddlewareAPI } from 'redux';
 
-import { selectDevice, deviceActions } from '@suite-common/wallet-core';
+import { selectSelectedDevice, deviceActions } from '@suite-common/wallet-core';
 import TrezorConnect, { UI } from '@trezor/connect';
 import { checkDeviceAuthenticityThunk } from '@suite-common/device-authenticity';
 
@@ -16,7 +16,7 @@ const buttonRequest =
         // in case when "passphrase on device" was chosen in <PassphraseModal /> do not display this modal ever again.
         // catch passphrase request and respond immediately with `passphraseOnDevice: true` without action propagation
         if (action.type === UI.REQUEST_PASSPHRASE) {
-            const device = selectDevice(api.getState());
+            const device = selectSelectedDevice(api.getState());
             if (
                 device &&
                 device.features &&
@@ -70,7 +70,7 @@ const buttonRequest =
             case UI.INVALID_PIN:
                 api.dispatch(
                     deviceActions.addButtonRequest({
-                        device: selectDevice(api.getState()),
+                        device: selectSelectedDevice(api.getState()),
                         buttonRequest: {
                             code: action.payload.type ? action.payload.type : action.type,
                         },
@@ -81,7 +81,7 @@ const buttonRequest =
                 const { device: _, ...request } = action.payload;
                 api.dispatch(
                     deviceActions.addButtonRequest({
-                        device: selectDevice(api.getState()),
+                        device: selectSelectedDevice(api.getState()),
                         buttonRequest: request,
                     }),
                 );
@@ -91,7 +91,7 @@ const buttonRequest =
                 if (!action.payload) {
                     api.dispatch(
                         deviceActions.removeButtonRequests({
-                            device: selectDevice(api.getState()),
+                            device: selectSelectedDevice(api.getState()),
                         }),
                     );
                 }
@@ -101,7 +101,7 @@ const buttonRequest =
                 // clear all device's button requests in each step of the onboarding and after device authenticity check
                 api.dispatch(
                     deviceActions.removeButtonRequests({
-                        device: selectDevice(api.getState()),
+                        device: selectSelectedDevice(api.getState()),
                     }),
                 );
                 break;

--- a/packages/suite/src/middlewares/suite/eventsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/eventsMiddleware.ts
@@ -2,7 +2,7 @@ import { MiddlewareAPI } from 'redux';
 
 import {
     selectDevices,
-    selectDevice,
+    selectSelectedDevice,
     accountsActions,
     deviceActions,
     authorizeDeviceThunk,
@@ -43,7 +43,7 @@ const eventsMiddleware =
             if (!device) return action; // this shouldn't happen
             const seen = deviceUtils.isSelectedDevice(
                 action.payload.device,
-                selectDevice(api.getState()),
+                selectSelectedDevice(api.getState()),
             );
 
             const toRemove = api

--- a/packages/suite/src/middlewares/suite/messageSystemMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/messageSystemMiddleware.ts
@@ -1,6 +1,6 @@
 import { MiddlewareAPI } from 'redux';
 
-import { deviceActions, selectDevice } from '@suite-common/wallet-core';
+import { deviceActions, selectSelectedDevice } from '@suite-common/wallet-core';
 import { TRANSPORT, DEVICE } from '@trezor/connect';
 import {
     messageSystemActions,
@@ -32,7 +32,7 @@ const messageSystemMiddleware =
         if (actions.includes(action.type)) {
             const { config } = api.getState().messageSystem;
             const { transport, torStatus } = api.getState().suite;
-            const device = selectDevice(api.getState());
+            const device = selectSelectedDevice(api.getState());
             const { enabledNetworks } = api.getState().wallet.settings;
 
             const validMessages = getValidMessages(config, {

--- a/packages/suite/src/middlewares/suite/redirectMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/redirectMiddleware.ts
@@ -1,6 +1,6 @@
 import { MiddlewareAPI } from 'redux';
 
-import { selectDevice, selectDevices, deviceActions } from '@suite-common/wallet-core';
+import { selectSelectedDevice, selectDevices, deviceActions } from '@suite-common/wallet-core';
 
 import * as routerActions from 'src/actions/suite/routerActions';
 import { AppState, Action, Dispatch, TrezorDevice } from 'src/types/suite';
@@ -38,7 +38,7 @@ const handleDeviceRedirect = (dispatch: Dispatch, state: AppState, device?: Trez
     }
 
     // reset wallet params if switching from one device to another
-    if (selectDevice(state) && state.router.app === 'wallet' && state.router.params) {
+    if (selectSelectedDevice(state) && state.router.app === 'wallet' && state.router.params) {
         dispatch(routerActions.goto(state.router.route.name));
     }
 };

--- a/packages/suite/src/middlewares/suite/sentryMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/sentryMiddleware.ts
@@ -4,7 +4,7 @@ import {
     discoveryActions,
     accountsActions,
     blockchainActions,
-    selectDevice,
+    selectSelectedDevice,
     deviceActions,
     authorizeDeviceThunk,
 } from '@suite-common/wallet-core';
@@ -112,7 +112,7 @@ const sentryMiddleware =
                     firmware: getFirmwareVersion(action.payload.device),
                     isBitcoinOnly: hasBitcoinOnlyFirmware(action.payload.device),
                     bootloader: getBootloaderVersion(action.payload.device),
-                    model: selectDevice(state)?.features?.internal_model,
+                    model: selectSelectedDevice(state)?.features?.internal_model,
                 });
                 break;
             }

--- a/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
@@ -1,7 +1,7 @@
 import {
     authorizeDeviceThunk,
     deviceActions,
-    selectDevice,
+    selectSelectedDevice,
     selectDeviceDiscovery,
     accountsActions,
     disableAccountsThunk,
@@ -84,7 +84,7 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
             return action;
 
         let authorizationIntent = false;
-        const device = selectDevice(nextState);
+        const device = selectSelectedDevice(nextState);
         const isDeviceLocked = selectIsDeviceLocked(nextState);
         // 1. selected device is acquired but doesn't have a state
         if (

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -3,7 +3,7 @@ import { isAnyOf } from '@reduxjs/toolkit';
 
 import {
     selectDevices,
-    selectDevice,
+    selectSelectedDevice,
     selectDiscoveryByDeviceState,
     discoveryActions,
     accountsActions,
@@ -204,7 +204,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
             }
 
             if (sendFormActions.storeDraft.match(action)) {
-                const device = selectDevice(api.getState());
+                const device = selectSelectedDevice(api.getState());
                 const { formState, accountKey } = action.payload;
                 // save drafts for remembered device
                 if (isDeviceRemembered(device)) {
@@ -242,7 +242,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                     api.dispatch(storageActions.saveSuiteSettings());
                     break;
                 case SUITE.COINJOIN_RECEIVE_WARNING: {
-                    const device = selectDevice(api.getState());
+                    const device = selectSelectedDevice(api.getState());
                     const isWalletRemembered = device?.remember;
 
                     if (!isWalletRemembered) {
@@ -301,7 +301,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                     break;
                 }
                 case FORM_DRAFT.STORE_DRAFT: {
-                    const device = selectDevice(api.getState());
+                    const device = selectSelectedDevice(api.getState());
                     // save drafts for remembered device
                     if (isDeviceRemembered(device)) {
                         storageActions.saveFormDraft(action.key, action.formDraft);

--- a/packages/suite/src/reducers/suite/metadataReducer.ts
+++ b/packages/suite/src/reducers/suite/metadataReducer.ts
@@ -4,7 +4,7 @@ import {
     AccountsRootState,
     selectAccountByKey,
     DeviceRootState,
-    selectDevice,
+    selectSelectedDevice,
     State,
     selectDeviceByState,
     deviceActions,
@@ -268,7 +268,7 @@ const selectLabelableEntityByKey = (
 export const selectIsLabelingAvailable = (state: MetadataRootState) => {
     const { enabled, error } = selectMetadata(state);
     const provider = selectSelectedProviderForLabels(state);
-    const device = selectDevice(state);
+    const device = selectSelectedDevice(state);
 
     return (
         enabled &&
@@ -283,7 +283,7 @@ export const selectIsLabelingAvailable = (state: MetadataRootState) => {
  it is possible to initiate metadata
  */
 export const selectIsLabelingInitPossible = (state: MetadataRootState) => {
-    const device = selectDevice(state);
+    const device = selectSelectedDevice(state);
 
     return (
         // device already has keys or it is at least connected and authorized
@@ -301,7 +301,7 @@ export const selectIsLabelingAvailableForEntity = (
 ) => {
     const device = deviceState
         ? selectDeviceByStaticSessionId(state, deviceState)
-        : selectDevice(state);
+        : selectSelectedDevice(state);
     if (!device?.state?.staticSessionId) return false;
     const entity = selectLabelableEntityByKey(state, device.state.staticSessionId, entityKey);
 

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -3,7 +3,7 @@ import produce from 'immer';
 import type { InvityServerEnvironment } from '@suite-common/invity';
 import { Feature, selectIsFeatureDisabled } from '@suite-common/message-system';
 import { isDeviceAcquired } from '@suite-common/suite-utils';
-import { discoveryActions, DeviceRootState, selectDevice } from '@suite-common/wallet-core';
+import { discoveryActions, DeviceRootState, selectSelectedDevice } from '@suite-common/wallet-core';
 import { versionUtils } from '@trezor/utils';
 import { isWeb } from '@trezor/env-utils';
 import { TRANSPORT, TransportInfo, ConnectSettings } from '@trezor/connect';
@@ -416,7 +416,7 @@ export const selectIsActionAbortable = (state: SuiteRootState) => {
 
 export const selectPrerequisite = (state: SuiteRootState & RouterRootState & DeviceRootState) => {
     const { transport } = state.suite;
-    const device = selectDevice(state);
+    const device = selectSelectedDevice(state);
     const router = selectRouter(state);
 
     const excluded = getExcludedPrerequisites(router);
@@ -460,7 +460,7 @@ export const selectHasExperimentalFeature =
  * Get firmware revision check error, or null if check was successful / skipped.
  */
 export const selectFirmwareRevisionCheckError = (state: AppState) => {
-    const device = selectDevice(state);
+    const device = selectSelectedDevice(state);
     if (!isDeviceAcquired(device) || !device.authenticityChecks) return null;
     const checkResult = device.authenticityChecks.firmwareRevision;
 
@@ -483,7 +483,7 @@ export const selectFirmwareRevisionCheckErrorIfEnabled = (state: AppState) => {
  * Get firmware hash check error, or null if check was successful / skipped.
  */
 export const selectFirmwareHashCheckError = (state: AppState) => {
-    const device = selectDevice(state);
+    const device = selectSelectedDevice(state);
     if (!isDeviceAcquired(device) || !device.authenticityChecks) return null;
     const checkResult = device.authenticityChecks.firmwareHash;
 

--- a/packages/suite/src/utils/onboarding/steps.ts
+++ b/packages/suite/src/utils/onboarding/steps.ts
@@ -1,4 +1,4 @@
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { getFirmwareVersion } from '@trezor/device-utils';
 import { versionUtils } from '@trezor/utils';
 
@@ -8,7 +8,7 @@ import { ID_AUTHENTICATE_DEVICE_STEP } from 'src/constants/onboarding/steps';
 
 export const isStepUsed = (step: Step, getState: GetState): boolean => {
     const state = getState();
-    const device = selectDevice(state);
+    const device = selectSelectedDevice(state);
 
     const { path } = state.onboarding;
     const deviceModelInternal = device?.features?.internal_model;

--- a/packages/suite/src/utils/suite/sentry.ts
+++ b/packages/suite/src/utils/suite/sentry.ts
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/core';
 
 import { allowReportTag } from '@suite-common/sentry';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 
 import { Dispatch, GetState } from 'src/types/suite';
 import { redactDevice, redactDiscovery, getApplicationLog } from 'src/utils/suite/logsUtils';
@@ -30,7 +30,7 @@ export const unsetSentryUser = () => {
 
 export const reportToSentry = (error: any) => (_: Dispatch, getState: GetState) => {
     const { analytics, wallet, logs } = getState();
-    const device = selectDevice(getState());
+    const device = selectSelectedDevice(getState());
 
     Sentry.withScope(scope => {
         scope.setUser({ id: analytics.instanceId });

--- a/packages/suite/src/views/backup/index.tsx
+++ b/packages/suite/src/views/backup/index.tsx
@@ -2,7 +2,7 @@ import { Paragraph, Image, Column, NewModal } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 import { HELP_CENTER_RECOVERY_ISSUES_URL } from '@trezor/urls';
 import { isDeviceAcquired } from '@suite-common/suite-utils';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { backupDevice } from 'src/actions/backup/backupActions';
@@ -78,7 +78,7 @@ const getModalContent = (backupStatus: BackupStatus, error?: string) => {
 };
 
 export const Backup = ({ onCancel }: ForegroundAppProps) => {
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const backup = useSelector(selectBackup);
     const isDeviceLocked = useSelector(selectIsDeviceLocked);
 

--- a/packages/suite/src/views/dashboard/DashboardPassphraseBanner.tsx
+++ b/packages/suite/src/views/dashboard/DashboardPassphraseBanner.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import styled from 'styled-components';
 
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { Banner, Text, Button, IconButton, Row, Column } from '@trezor/components';
 import { WalletType } from '@suite-common/wallet-types';
 
@@ -25,7 +25,7 @@ export const DashboardPassphraseBanner = () => {
     const dispatch = useDispatch();
     const { isDashboardPassphraseBannerVisible } = useSelector(selectSuiteFlags);
     const selectedAddressDisplay = useSelector(state => state.suite.settings.defaultWalletLoading);
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const { isDiscoveryRunning } = useDiscovery();
 
     if (

--- a/packages/suite/src/views/dashboard/PortfolioCard/DashboardGraph.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/DashboardGraph.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 
 import { variables, Button } from '@trezor/components';
 import { calcTicks, calcTicksFromData } from '@suite-common/suite-utils';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 
 import GraphWorker from 'src/support/workers/graph';
 import { getGraphDataForInterval, updateGraphData } from 'src/actions/wallet/graphActions';
@@ -47,7 +47,7 @@ type DashboardGraphProps = {
 
 export const DashboardGraph = memo(({ accounts }: DashboardGraphProps) => {
     const { error, isLoading, selectedRange } = useSelector(state => state.wallet.graph);
-    const selectedDevice = useSelector(selectDevice);
+    const selectedDevice = useSelector(selectSelectedDevice);
     const localCurrency = useSelector(selectLocalCurrency);
     const dispatch = useDispatch();
 

--- a/packages/suite/src/views/firmware/FirmwareModal.tsx
+++ b/packages/suite/src/views/firmware/FirmwareModal.tsx
@@ -4,7 +4,7 @@ import { useIntl } from 'react-intl';
 import styled from 'styled-components';
 
 import { TranslationKey } from '@suite-common/intl-types';
-import { acquireDevice, selectDevice } from '@suite-common/wallet-core';
+import { acquireDevice, selectSelectedDevice } from '@suite-common/wallet-core';
 import { variables } from '@trezor/components';
 import TrezorConnect from '@trezor/connect';
 import { ConfirmOnDevice } from '@trezor/product-components';
@@ -66,7 +66,7 @@ export const FirmwareModal = ({
         confirmOnDevice,
         showConfirmationPill,
     } = useFirmwareInstallation({ shouldSwitchFirmwareType });
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const dispatch = useDispatch();
     const intl = useIntl();
 

--- a/packages/suite/src/views/onboarding/UnexpectedState/index.tsx
+++ b/packages/suite/src/views/onboarding/UnexpectedState/index.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 import styled from 'styled-components';
 
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 
 import { PinMatrix, PrerequisitesGuide, Translation } from 'src/components/suite';
 import { useOnboarding, useSelector } from 'src/hooks/suite';
@@ -24,7 +24,7 @@ interface UnexpectedStateProps {
  * This component handles unexpected device states across various steps in the onboarding.
  */
 const UnexpectedState = ({ children }: UnexpectedStateProps) => {
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const prerequisite = useSelector(selectPrerequisite);
 
     const { prevDevice, activeStepId, showPinMatrix } = useOnboarding();

--- a/packages/suite/src/views/onboarding/steps/Backup.tsx
+++ b/packages/suite/src/views/onboarding/steps/Backup.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import styled from 'styled-components';
 
 import { Image } from '@trezor/components';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 
 import {
     OnboardingButtonCta,
@@ -31,7 +31,7 @@ const StyledImage = styled(Image)`
 export const BackupStep = () => {
     const [showSkipConfirmation, setShowSkipConfirmation] = useState(false);
     const backup = useSelector(state => state.backup);
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const isDeviceLocked = useSelector(selectIsDeviceLocked);
     const isActionAbortable = useSelector(selectIsActionAbortable);
     const dispatch = useDispatch();

--- a/packages/suite/src/views/onboarding/steps/DeviceTutorial.tsx
+++ b/packages/suite/src/views/onboarding/steps/DeviceTutorial.tsx
@@ -3,7 +3,7 @@ import { useIntl } from 'react-intl';
 
 import styled from 'styled-components';
 
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import TrezorConnect from '@trezor/connect';
 import { Button } from '@trezor/components';
 import { spacingsPx } from '@trezor/theme';
@@ -33,7 +33,7 @@ const ButtonContainer = styled.div`
 export const DeviceTutorial = () => {
     const isActionAbortable = useSelector(selectIsActionAbortable);
     const status = useSelector(selectOnboardingTutorialStatus);
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const dispatch = useDispatch();
     const intl = useIntl();
 

--- a/packages/suite/src/views/onboarding/steps/FirmwareStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/FirmwareStep.tsx
@@ -1,5 +1,5 @@
 import { getFirmwareVersion } from '@trezor/device-utils';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { useFirmwareInstallation } from '@suite-common/firmware';
 
 import { MODAL } from 'src/actions/suite/constants';
@@ -17,7 +17,7 @@ import { useSelector, useOnboarding } from 'src/hooks/suite';
 import { getSuiteFirmwareTypeString } from 'src/utils/firmware';
 
 export const FirmwareStep = () => {
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const modal = useSelector(state => state.modal);
     const { goToNextStep, updateAnalytics } = useOnboarding();
     const { status, error, resetReducer, firmwareUpdate, firmwareHashInvalid, targetType } =

--- a/packages/suite/src/views/onboarding/steps/Pin.tsx
+++ b/packages/suite/src/views/onboarding/steps/Pin.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 
 import { PinMatrix, Translation } from 'src/components/suite';
 import {
@@ -18,7 +18,7 @@ const SetPinStep = () => {
     const [status, setStatus] = useState<'initial' | 'enter-pin' | 'repeat-pin' | 'success'>(
         'initial',
     );
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const modal = useSelector(state => state.modal);
     const isActionAbortable = useSelector(selectIsActionAbortable);
     const dispatch = useDispatch();

--- a/packages/suite/src/views/onboarding/steps/Recovery/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Recovery/index.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { pickByDeviceModel } from '@trezor/device-utils';
 import { DeviceModelInternal } from '@trezor/connect';
 import { isDeviceWithButtons } from '@suite-common/suite-utils';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 
 import { OnboardingButtonCta } from 'src/components/onboarding';
 import { SelectWordCount, SelectRecoveryType, SelectRecoveryWord } from 'src/components/recovery';
@@ -23,7 +23,7 @@ const InProgressRecoveryStepBox = styled(RecoveryStepBox)<{
 
 export const RecoveryStep = () => {
     const isActionAbortable = useSelector(selectIsActionAbortable);
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const dispatch = useDispatch();
 
     const {

--- a/packages/suite/src/views/onboarding/steps/ResetDevice.tsx
+++ b/packages/suite/src/views/onboarding/steps/ResetDevice.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 
 import styled from 'styled-components';
 
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { Button, Divider, Text } from '@trezor/components';
 import { DeviceModelInternal } from '@trezor/connect';
 
@@ -36,7 +36,7 @@ const canChooseBackupType = (device: DeviceModelInternal) => device !== DeviceMo
 
 export const ResetDeviceStep = () => {
     const { isLocked } = useDevice();
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const isActionAbortable = useSelector(selectIsActionAbortable);
 
     const deviceModel = device?.features?.internal_model;

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/DeviceAuthenticity.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/DeviceAuthenticity.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import styled from 'styled-components';
 
 import { checkDeviceAuthenticityThunk } from '@suite-common/device-authenticity';
-import { selectDevice, selectSelectedDeviceAuthenticity } from '@suite-common/wallet-core';
+import { selectSelectedDevice, selectSelectedDeviceAuthenticity } from '@suite-common/wallet-core';
 import { variables } from '@trezor/components';
 import { spacingsPx } from '@trezor/theme';
 import { TREZOR_SUPPORT_DEVICE_AUTHENTICATION_FAILED_URL } from '@trezor/urls';
@@ -30,7 +30,7 @@ type DeviceAuthenticityProps = {
 };
 
 export const DeviceAuthenticity = ({ goToNext }: DeviceAuthenticityProps) => {
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const selectedDeviceAuthenticity = useSelector(selectSelectedDeviceAuthenticity);
     const isDebugModeActive = useSelector(selectIsDebugModeActive);
     const dispatch = useDispatch();

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheck.tsx
@@ -4,7 +4,7 @@ import styled, { useTheme } from 'styled-components';
 
 import { getConnectedDeviceStatus } from '@suite-common/suite-utils';
 import { AcquiredDevice } from '@suite-common/suite-types';
-import { deviceActions, selectDevice, selectDevices } from '@suite-common/wallet-core';
+import { deviceActions, selectSelectedDevice, selectDevices } from '@suite-common/wallet-core';
 import { Button, Column, Icon, H2, Text, Tooltip, Divider } from '@trezor/components';
 import { spacings, spacingsPx, typography } from '@trezor/theme';
 import {
@@ -157,7 +157,7 @@ const SecurityCheckContent = ({
 }: SecurityCheckContentProps) => {
     const { isMobileLayout } = useLayoutSize();
     const recovery = useSelector(state => state.recovery);
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const isOnboardingActive = useSelector(selectIsOnboardingActive);
 
     const [isFailed, setIsFailed] = useState(false);
@@ -270,7 +270,7 @@ const SecurityCheckContent = ({
 };
 
 export const SecurityCheck = () => {
-    const selectedDevice = useSelector(selectDevice);
+    const selectedDevice = useSelector(selectSelectedDevice);
     const devices = useSelector(selectDevices);
     const { initialRun } = useSelector(selectSuiteFlags);
     const {

--- a/packages/suite/src/views/onboarding/steps/SelectBackupType/SelectBackupType.tsx
+++ b/packages/suite/src/views/onboarding/steps/SelectBackupType/SelectBackupType.tsx
@@ -22,7 +22,7 @@ import {
     mapElevationToBorder,
     spacingsPx,
 } from '@trezor/theme';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { TranslationKey } from '@suite-common/intl-types';
 import { DeviceModelInternal } from '@trezor/connect';
 
@@ -102,7 +102,7 @@ export const SelectBackupType = ({
 }: SelectBackupTypeProps) => {
     const { elevation } = useElevation();
     const [isOpen, setIsOpen] = useState(false);
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const { isMobileLayout } = useLayoutSize();
 
     const defaultBackupType: BackupType = device?.features?.internal_model

--- a/packages/suite/src/views/onboarding/steps/SelectBackupType/ShamirOptions.tsx
+++ b/packages/suite/src/views/onboarding/steps/SelectBackupType/ShamirOptions.tsx
@@ -2,7 +2,7 @@ import { satisfies } from 'semver';
 
 import { Badge, Tooltip } from '@trezor/components';
 import { spacings } from '@trezor/theme';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { getFirmwareVersion } from '@trezor/device-utils';
 
 import { Translation } from '../../../../components/suite';
@@ -48,7 +48,7 @@ type ShamirOptionsProps = {
 };
 
 export const ShamirOptions = ({ defaultType, onSelect, selected }: ShamirOptionsProps) => {
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const firmwareVersion = getFirmwareVersion(device);
 
     const is1of1shamirSupportedByFirmware = satisfies(firmwareVersion, '>=2.7.1');

--- a/packages/suite/src/views/password-manager/PasswordManager/EntryForm.tsx
+++ b/packages/suite/src/views/password-manager/PasswordManager/EntryForm.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 import TrezorConnect from '@trezor/connect';
 import { Button, Checkbox, Input } from '@trezor/components';
 import type { PasswordEntry, PasswordEntryDecoded } from '@suite-common/metadata-types';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { isUrl } from '@trezor/utils';
 import { spacingsPx } from '@trezor/theme';
 
@@ -46,7 +46,7 @@ export const EntryForm = ({ onEncrypted, entry, cancel }: Props) => {
     const [inProgress, setInProgress] = useState(false);
 
     const { tags } = usePasswords();
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
 
     const encrypt = () => {
         if (inProgress || !device) return;

--- a/packages/suite/src/views/password-manager/PasswordManager/PasswordsList.tsx
+++ b/packages/suite/src/views/password-manager/PasswordManager/PasswordsList.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 
 import type { PasswordEntry as PasswordEntryType } from 'src/types/suite/metadata';
 import { useSelector } from 'src/hooks/suite';
@@ -47,7 +47,7 @@ export const PasswordsList = ({
     fileName,
     nextId,
 }: PasswordsListProps) => {
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
 
     return (
         <Wrapper>

--- a/packages/suite/src/views/settings/SettingsDevice/DefaultWalletLoading.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/DefaultWalletLoading.tsx
@@ -1,7 +1,7 @@
 import { WalletType as DefaultWalletLoadingOptions } from '@suite-common/wallet-types';
 import { SelectBar } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
-import { deviceActions, selectDevice } from '@suite-common/wallet-core';
+import { deviceActions, selectSelectedDevice } from '@suite-common/wallet-core';
 
 import { Translation } from 'src/components/suite/Translation';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
@@ -22,7 +22,7 @@ const options = [
 ];
 
 export const DefaultWalletLoading = () => {
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const selectedAddressDisplay = useSelector(state => state.suite.settings.defaultWalletLoading);
     const dispatch = useDispatch();
 

--- a/packages/suite/src/views/settings/SettingsDevice/MultiShareBackup.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/MultiShareBackup.tsx
@@ -1,5 +1,5 @@
 import { HELP_CENTER_MULTI_SHARE_BACKUP_URL } from '@trezor/urls';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { TrezorDevice } from '@suite-common/suite-types';
 import { EventType, analytics } from '@trezor/suite-analytics';
 
@@ -34,7 +34,7 @@ const doesSupportMultiShare = (device: TrezorDevice | undefined): boolean => {
 };
 
 export const MultiShareBackup = ({ isDeviceLocked }: { isDeviceLocked: boolean }) => {
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const dispatch = useDispatch();
 
     // "NotAvailable" means, that backup has been already done and thus is not available.

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceHeader.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceHeader.tsx
@@ -3,7 +3,7 @@ import { motion } from 'framer-motion';
 
 import { IconButton, IconName, Row, TOOLTIP_DELAY_LONG, Tooltip } from '@trezor/components';
 import { spacings, spacingsPx } from '@trezor/theme';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 
 import { DeviceStatus } from 'src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceStatus';
 import { Translation, WebUsbButton } from 'src/components/suite';
@@ -45,7 +45,7 @@ export const DeviceHeader = ({
     forceConnectionInfo,
     icon = 'caretCircleDown',
 }: DeviceHeaderProps) => {
-    const selectedDevice = useSelector(selectDevice);
+    const selectedDevice = useSelector(selectSelectedDevice);
     const isWebUsbTransport = useSelector(selectIsWebUsb);
     const isDeviceConnected = selectedDevice?.connected === true;
     const deviceModelInternal = device.features?.internal_model;

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 import { variables, Column } from '@trezor/components';
 import * as deviceUtils from '@suite-common/suite-utils';
-import { selectDevice, selectDeviceThunk, acquireDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice, selectDeviceThunk, acquireDevice } from '@suite-common/wallet-core';
 import { spacings } from '@trezor/theme';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -37,7 +37,7 @@ export const DeviceItem = ({
     onCancel,
     isFullHeaderVisible,
 }: DeviceItemProps) => {
-    const selectedDevice = useSelector(selectDevice);
+    const selectedDevice = useSelector(selectSelectedDevice);
     const dispatch = useDispatch();
     const deviceStatus = deviceUtils.getStatus(device);
     const needsAttention = deviceUtils.deviceNeedsAttention(deviceStatus);

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
@@ -4,7 +4,7 @@ import {
     selectDiscoveryByDeviceState,
     selectCurrentFiatRates,
     selectDeviceThunk,
-    selectDevice,
+    selectSelectedDevice,
     createDiscoveryThunk,
 } from '@suite-common/wallet-core';
 import { Card, Icon, Tooltip, Row, Column, Text, Divider } from '@trezor/components';
@@ -51,7 +51,7 @@ export const WalletInstance = ({
     const discoveryProcess = useSelector(state =>
         selectDiscoveryByDeviceState(state, instance.state),
     );
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const { defaultAccountLabelString } = useWalletLabeling();
 
     const deviceAccounts = getAllAccounts(instance.state, accounts);

--- a/packages/suite/src/views/suite/SwitchDevice/SwitchDevice.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/SwitchDevice.tsx
@@ -1,5 +1,5 @@
 import * as deviceUtils from '@suite-common/suite-utils';
-import { selectDevice, selectDevices } from '@suite-common/wallet-core';
+import { selectSelectedDevice, selectDevices } from '@suite-common/wallet-core';
 import { Column } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
@@ -10,7 +10,7 @@ import { DeviceItem } from './DeviceItem/DeviceItem';
 import { SwitchDeviceModal } from './SwitchDeviceModal';
 
 export const SwitchDevice = ({ onCancel }: ForegroundAppProps) => {
-    const selectedDevice = useSelector(selectDevice);
+    const selectedDevice = useSelector(selectSelectedDevice);
     const devices = useSelector(selectDevices);
 
     // exclude selectedDevice from list, because other devices could have a higher priority

--- a/packages/suite/src/views/view-only/ViewOnlyPromoContent.tsx
+++ b/packages/suite/src/views/view-only/ViewOnlyPromoContent.tsx
@@ -14,7 +14,7 @@ import {
     variables,
 } from '@trezor/components';
 import { Elevation, borders, mapElevationToBackground, spacings, spacingsPx } from '@trezor/theme';
-import { selectDevice, toggleRememberDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice, toggleRememberDevice } from '@suite-common/wallet-core';
 import { DEFAULT_FLAGSHIP_MODEL } from '@suite-common/suite-constants';
 import { analytics, EventType } from '@trezor/suite-analytics';
 
@@ -153,7 +153,7 @@ const ButtonsContainer = styled.div`
 
 const Top = () => {
     const { elevation } = useElevation();
-    const selectedDevice = useSelector(selectDevice);
+    const selectedDevice = useSelector(selectSelectedDevice);
     const selectedDeviceModelInternal =
         selectedDevice?.features?.internal_model || DEFAULT_FLAGSHIP_MODEL;
 
@@ -204,7 +204,7 @@ const Top = () => {
 
 const Buttons = () => {
     const dispatch = useDispatch();
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
 
     const onYes = () => {
         if (device !== undefined) {

--- a/packages/suite/src/views/wallet/receive/Receive.tsx
+++ b/packages/suite/src/views/wallet/receive/Receive.tsx
@@ -1,4 +1,4 @@
-import { selectDevice, selectPendingAccountAddresses } from '@suite-common/wallet-core';
+import { selectSelectedDevice, selectPendingAccountAddresses } from '@suite-common/wallet-core';
 import { Column } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
@@ -17,7 +17,7 @@ export const Receive = () => {
     );
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
     const receive = useSelector(state => state.wallet.receive);
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
 
     const { account } = selectedAccount;
 

--- a/packages/suite/src/views/wallet/receive/components/ConnectDevicePromo.tsx
+++ b/packages/suite/src/views/wallet/receive/components/ConnectDevicePromo.tsx
@@ -1,5 +1,5 @@
 import { H4, Paragraph, Banner } from '@trezor/components';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { DEFAULT_FLAGSHIP_MODEL } from '@suite-common/suite-constants';
 
 import { Translation } from 'src/components/suite';
@@ -12,7 +12,7 @@ type ConnectDevicePromoProps = {
 };
 
 const ConnectDevicePromo = ({ title, description }: ConnectDevicePromoProps) => {
-    const selectedDevice = useSelector(selectDevice);
+    const selectedDevice = useSelector(selectSelectedDevice);
     const selectedDeviceModelInternal =
         selectedDevice?.features?.internal_model || DEFAULT_FLAGSHIP_MODEL;
 

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { Account, TokenAddress } from '@suite-common/wallet-types';
 import { Network, getCoingeckoId } from '@suite-common/wallet-config';
 import {
@@ -99,7 +99,7 @@ export const TokenRow = ({
     const { isMobileLayout } = useLayoutSize();
     const { translationString } = useTranslation();
     const { address: unusedAddress, path } = getUnusedAddressFromAccount(account);
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const { isLocked } = useDevice();
     const shouldShowCopyAddressModal = useSelector(selectIsCopyAddressModalShown);
     const shouldShowUnhideTokenModal = useSelector(selectIsUnhideTokenModalShown);

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -9,7 +9,7 @@ import TrezorConnect, {
 } from '@trezor/connect';
 import { DATA_URL } from '@trezor/urls';
 import { createDeferred, getSynchronize } from '@trezor/utils';
-import { deviceConnectThunks, selectDevice } from '@suite-common/wallet-core';
+import { deviceConnectThunks, selectSelectedDevice } from '@suite-common/wallet-core';
 import { isDesktop, isNative } from '@trezor/env-utils';
 import { desktopApi } from '@trezor/suite-desktop-api';
 import { serializeError } from '@trezor/connect/src/constants/errors';
@@ -187,7 +187,7 @@ export const connectPopupCallThunk = createThunk(
         { dispatch, getState, extra },
     ) => {
         try {
-            const device = selectDevice(getState());
+            const device = selectSelectedDevice(getState());
 
             if (!device) {
                 console.error('Device not found');

--- a/suite-common/firmware/src/firmwareThunks.ts
+++ b/suite-common/firmware/src/firmwareThunks.ts
@@ -2,7 +2,7 @@ import { hasBitcoinOnlyFirmware, isBitcoinOnlyDevice } from '@trezor/device-util
 import TrezorConnect, { FirmwareType } from '@trezor/connect';
 import { createThunk } from '@suite-common/redux-utils';
 import { TrezorDevice } from '@suite-common/suite-types';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 
 import { selectFirmware } from './firmwareReducer';
 import { FIRMWARE_MODULE_PREFIX, firmwareActions } from './firmwareActions';
@@ -81,7 +81,7 @@ export const firmwareUpdate = createThunk<
             selectors: { selectLanguage },
         } = extra;
 
-        const device = selectDevice(getState());
+        const device = selectSelectedDevice(getState());
         const binFilesBaseUrl = await dispatch(getBinFilesBaseUrlThunk()).unwrap();
         const suiteLanguage = selectLanguage(getState());
         const { useDevkit, cachedDevice, error } = selectFirmware(getState());

--- a/suite-common/firmware/src/hooks/useFirmwareInstallation.ts
+++ b/suite-common/firmware/src/hooks/useFirmwareInstallation.ts
@@ -13,7 +13,7 @@ import {
     hasBitcoinOnlyFirmware,
     isBitcoinOnlyDevice,
 } from '@trezor/device-utils';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 
 /*
 There are three firmware update flows, depending on current firmware version:
@@ -44,7 +44,7 @@ export const useFirmwareInstallation = (
 ) => {
     const dispatch = useDispatch();
     const firmware = useSelector(selectFirmware);
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
 
     // Device in its state before installation is cached when installation begins.
     // Until then, access device as normal.

--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -15,7 +15,7 @@ import { accountsActions } from './accountsActions';
 import { formattedAccountTypeMap } from './accountsConstants';
 import {
     DeviceRootState,
-    selectDevice,
+    selectSelectedDevice,
     selectDeviceState,
     selectHasOnlyPortfolioDevice,
 } from '../device/deviceReducer';
@@ -195,7 +195,7 @@ export const selectAccountsByDeviceStateAndNetworkSymbol = createMemoizedSelecto
 );
 
 export const selectDeviceAccounts = createMemoizedSelector(
-    [selectAccounts, selectDevice],
+    [selectAccounts, selectSelectedDevice],
     (accounts, device) => {
         if (!device?.state?.staticSessionId) return EMPTY_STABLE_ACCOUNTS_ARRAY;
 

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -655,7 +655,7 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(initialState, (bu
 // Basic state selectors (no need to wrap in createMemoizedSelector)
 export const selectDevices = (state: DeviceRootState) => state.device?.devices;
 export const selectDevicesCount = (state: DeviceRootState) => state.device?.devices?.length;
-export const selectDevice = (state: DeviceRootState) => state.device.selectedDevice;
+export const selectSelectedDevice = (state: DeviceRootState) => state.device.selectedDevice;
 
 // Derived selectors
 export const selectIsPendingTransportEvent = createMemoizedSelector(
@@ -664,19 +664,22 @@ export const selectIsPendingTransportEvent = createMemoizedSelector(
 );
 
 export const selectIsDeviceUnlocked = createMemoizedSelector(
-    [selectDevice],
+    [selectSelectedDevice],
     device => !!device?.features?.unlocked,
 );
 
 export const selectDeviceAuthFailed = createMemoizedSelector(
-    [selectDevice],
+    [selectSelectedDevice],
     device => !!device?.authFailed,
 );
 
-export const selectDeviceType = createMemoizedSelector([selectDevice], device => device?.type);
+export const selectDeviceType = createMemoizedSelector(
+    [selectSelectedDevice],
+    device => device?.type,
+);
 
 export const selectDeviceFeatures = createMemoizedSelector(
-    [selectDevice],
+    [selectSelectedDevice],
     device => device?.features,
 );
 
@@ -696,7 +699,7 @@ export const selectIsDeviceProtectedByWipeCode = createMemoizedSelector(
 );
 
 export const selectDeviceButtonRequests = createMemoizedSelector(
-    [selectDevice],
+    [selectSelectedDevice],
     device => device?.buttonRequests ?? [],
 );
 
@@ -709,7 +712,10 @@ export const selectDeviceButtonRequestsCodes = createMemoizedSelector(
         ),
 );
 
-export const selectDeviceMode = createMemoizedSelector([selectDevice], device => device?.mode);
+export const selectDeviceMode = createMemoizedSelector(
+    [selectSelectedDevice],
+    device => device?.mode,
+);
 
 export const selectIsUnacquiredDevice = createMemoizedSelector(
     [selectDeviceType],
@@ -731,17 +737,17 @@ export const selectIsDeviceInitialized = createMemoizedSelector(
 );
 
 export const selectIsConnectedDeviceUninitialized = createMemoizedSelector(
-    [selectDevice, selectIsDeviceInitialized],
+    [selectSelectedDevice, selectIsDeviceInitialized],
     (device, isDeviceInitialized) => device && !isDeviceInitialized,
 );
 
 export const selectIsDeviceAuthorized = createMemoizedSelector(
-    [selectDevice],
+    [selectSelectedDevice],
     device => !!device?.state,
 );
 
 export const selectHasDeviceAuthConfirm = createMemoizedSelector(
-    [selectDevice],
+    [selectSelectedDevice],
     device => !!device?.authConfirm,
 );
 
@@ -751,7 +757,7 @@ export const selectIsDeviceConnectedAndAuthorized = createMemoizedSelector(
 );
 
 export const selectDeviceInternalModel = createMemoizedSelector(
-    [selectDevice],
+    [selectSelectedDevice],
     device => device?.features?.internal_model,
 );
 
@@ -770,7 +776,7 @@ export const selectDeviceByStaticSessionId = createMemoizedSelector(
 );
 
 export const selectDeviceUnavailableCapabilities = createMemoizedSelector(
-    [selectDevice],
+    [selectSelectedDevice],
     device => device?.unavailableCapabilities,
 );
 
@@ -785,31 +791,34 @@ export const selectHasDevicePassphraseEntryCapability = createMemoizedSelector(
 );
 
 export const selectDeviceStatus = createMemoizedSelector(
-    [selectDevice],
+    [selectSelectedDevice],
     device => device && getStatus(device),
 );
 
-export const selectDeviceSupportedNetworks = createMemoizedSelector([selectDevice], device => {
-    const firmwareVersion = getFirmwareVersion(device);
-    const result = networkSymbolCollection.filter(symbol => {
-        const unavailableCapability = device?.unavailableCapabilities?.[symbol];
-        // if device does not have fw, do not show coins which are not supported by device in any case
-        if (!firmwareVersion && unavailableCapability === 'no-support') {
-            return false;
-        }
-        // if device has fw, do not show coins which are not supported by current fw
-        if (
-            firmwareVersion &&
-            ['no-support', 'no-capability'].includes(unavailableCapability || '')
-        ) {
-            return false;
-        }
+export const selectDeviceSupportedNetworks = createMemoizedSelector(
+    [selectSelectedDevice],
+    device => {
+        const firmwareVersion = getFirmwareVersion(device);
+        const result = networkSymbolCollection.filter(symbol => {
+            const unavailableCapability = device?.unavailableCapabilities?.[symbol];
+            // if device does not have fw, do not show coins which are not supported by device in any case
+            if (!firmwareVersion && unavailableCapability === 'no-support') {
+                return false;
+            }
+            // if device has fw, do not show coins which are not supported by current fw
+            if (
+                firmwareVersion &&
+                ['no-support', 'no-capability'].includes(unavailableCapability || '')
+            ) {
+                return false;
+            }
 
-        return true;
-    });
+            return true;
+        });
 
-    return returnStableArrayIfEmpty(result);
-});
+        return returnStableArrayIfEmpty(result);
+    },
+);
 
 export const selectDeviceById = createMemoizedSelector(
     [state => state.device.devices, (_state, deviceId: TrezorDevice['id']) => deviceId],
@@ -822,26 +831,29 @@ export const selectDeviceAuthenticity = createMemoizedSelector(
 );
 
 export const selectSelectedDeviceAuthenticity = createMemoizedSelector(
-    [selectDevice, selectDeviceAuthenticity],
+    [selectSelectedDevice, selectDeviceAuthenticity],
     (device, deviceAuthenticity) => (device?.id ? deviceAuthenticity?.[device.id] : undefined),
 );
 
 export const selectIsFirmwareAuthenticityCheckDismissed = createMemoizedSelector(
-    [selectDevice, state => state.device.dismissedSecurityChecks?.firmwareAuthenticity],
+    [selectSelectedDevice, state => state.device.dismissedSecurityChecks?.firmwareAuthenticity],
     (device, dismissedChecks) => !!(device?.id && dismissedChecks?.includes(device.id)),
 );
 
 export const selectIsPortfolioTrackerDevice = createMemoizedSelector(
-    [selectDevice],
+    [selectSelectedDevice],
     device => device?.id === PORTFOLIO_TRACKER_DEVICE_ID,
 );
 
 export const selectDeviceLabel = createMemoizedSelector(
-    [selectDevice],
+    [selectSelectedDevice],
     device => device?.features?.label,
 );
 
-export const selectDeviceName = createMemoizedSelector([selectDevice], device => device?.name);
+export const selectDeviceName = createMemoizedSelector(
+    [selectSelectedDevice],
+    device => device?.name,
+);
 
 export const selectDeviceLabelOrNameById = createMemoizedSelector(
     [state => state.device.devices, (_state, id: TrezorDevice['id']) => id],
@@ -852,13 +864,13 @@ export const selectDeviceLabelOrNameById = createMemoizedSelector(
     },
 );
 
-export const selectDeviceLabelOrName = createMemoizedSelector(
-    [selectDevice],
+export const selectSelectedDeviceLabelOrName = createMemoizedSelector(
+    [selectSelectedDevice],
     selectedDevice => selectedDevice?.features?.label || selectedDevice?.name || '',
 );
 
 export const selectDeviceId = createMemoizedSelector(
-    [selectDevice],
+    [selectSelectedDevice],
     selectedDevice => selectedDevice?.id ?? null,
 );
 
@@ -872,16 +884,16 @@ export const selectDeviceModelById = createMemoizedSelector(
 );
 
 export const selectDeviceModel = createMemoizedSelector(
-    [selectDevice],
+    [selectSelectedDevice],
     selectedDevice => selectedDevice?.features?.internal_model ?? null,
 );
 
 export const selectDeviceReleaseInfo = createMemoizedSelector(
-    [selectDevice],
+    [selectSelectedDevice],
     device => device?.firmwareRelease ?? null,
 );
 
-export const selectDeviceFirmwareVersion = createMemoizedSelector([selectDevice], device =>
+export const selectDeviceFirmwareVersion = createMemoizedSelector([selectSelectedDevice], device =>
     getFirmwareVersionArray(device),
 );
 
@@ -914,17 +926,17 @@ export const selectDeviceLanguage = createMemoizedSelector(
 );
 
 export const selectHasDeviceFirmwareInstalled = createMemoizedSelector(
-    [selectDevice],
+    [selectSelectedDevice],
     device => !!device && device.firmware !== 'none',
 );
 
 export const selectIsDeviceRemembered = createMemoizedSelector(
-    [selectDevice],
+    [selectSelectedDevice],
     device => !!device?.remember,
 );
 
 export const selectIsDeviceForceRemembered = createMemoizedSelector(
-    [selectDevice],
+    [selectSelectedDevice],
     device => !!device?.forceRemember,
 );
 
@@ -945,7 +957,7 @@ export const selectRememberedHiddenWalletsCount = createMemoizedSelector(
 );
 
 export const selectIsDeviceConnected = createMemoizedSelector(
-    [selectDevice],
+    [selectSelectedDevice],
     device => !!device?.connected,
 );
 
@@ -955,7 +967,7 @@ export const selectIsDeviceInViewOnlyMode = createMemoizedSelector(
 );
 
 export const selectIsDeviceUsingPassphrase = createMemoizedSelector(
-    [selectIsDeviceProtectedByPassphrase, selectDevice],
+    [selectIsDeviceProtectedByPassphrase, selectSelectedDevice],
     (isDeviceProtectedByPassphrase, device) => {
         const shouldTreatAsPassphraseProtected = (device?.instance ?? 1) > 1;
 
@@ -972,17 +984,17 @@ export const selectPhysicalDevicesGrouppedById = createMemoizedSelector(
 );
 
 export const selectDeviceState = createMemoizedSelector(
-    [selectDevice],
+    [selectSelectedDevice],
     device => device?.state ?? null,
 );
 
 export const selectDeviceStaticSessionId = createMemoizedSelector(
-    [selectDevice],
+    [selectSelectedDevice],
     device => device?.state?.staticSessionId ?? null,
 );
 
 export const selectDeviceInstances = createMemoizedSelector(
-    [selectDevice, selectDevices],
+    [selectSelectedDevice, selectDevices],
     (device, allDevices) => {
         if (!device) {
             return [];
@@ -998,7 +1010,7 @@ export const selectNumberOfDeviceInstances = createMemoizedSelector(
 );
 
 export const selectInstacelessUnselectedDevices = createMemoizedSelector(
-    [selectDevice, selectDevices],
+    [selectSelectedDevice, selectDevices],
     (device, allDevices) =>
         pipe(
             deviceUtils.getSortedDevicesWithoutInstances(allDevices, device?.id),
@@ -1006,16 +1018,16 @@ export const selectInstacelessUnselectedDevices = createMemoizedSelector(
         ),
 );
 
-export const selectIsBitcoinOnlyDevice = createMemoizedSelector([selectDevice], device =>
+export const selectIsBitcoinOnlyDevice = createMemoizedSelector([selectSelectedDevice], device =>
     isBitcoinOnlyDevice(device),
 );
 
-export const selectHasBitcoinOnlyFirmware = createMemoizedSelector([selectDevice], device =>
+export const selectHasBitcoinOnlyFirmware = createMemoizedSelector([selectSelectedDevice], device =>
     hasBitcoinOnlyFirmware(device),
 );
 
 export const selectDeviceUpdateFirmwareVersion = (state: DeviceRootState) => {
-    const device = selectDevice(state);
+    const device = selectSelectedDevice(state);
 
     return device ? getFwUpdateVersion(device) : null;
 };

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -853,12 +853,8 @@ export const selectDeviceLabelOrNameById = createMemoizedSelector(
 );
 
 export const selectDeviceLabelOrName = createMemoizedSelector(
-    [selectDevice, selectDevices],
-    (selectedDevice, devices) => {
-        const device = devices.find(d => d.id === selectedDevice?.id);
-
-        return device?.features?.label || device?.name || '';
-    },
+    [selectDevice],
+    selectedDevice => selectedDevice?.features?.label || selectedDevice?.name || '',
 );
 
 export const selectDeviceId = createMemoizedSelector(

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -32,8 +32,8 @@ import {
 import { getEnvironment } from '@trezor/env-utils';
 
 import {
-    selectDevice,
-    selectDevice as selectDeviceSelector,
+    selectSelectedDevice,
+    selectSelectedDevice as selectDeviceSelector,
     selectDeviceById,
     selectDevices,
 } from './deviceReducer';
@@ -552,7 +552,7 @@ export const confirmAddressOnDeviceThunk = createThunk(
         }: { accountKey: AccountKey; addressPath: string; chunkify: boolean },
         { getState },
     ): Promise<ConnectResponse<Address | CardanoAddress>> => {
-        const device = selectDevice(getState());
+        const device = selectSelectedDevice(getState());
         const account = selectAccountByKey(getState(), accountKey);
 
         if (!device || !account)
@@ -619,7 +619,7 @@ export const onPassphraseSubmit = createThunk(
         { value, passphraseOnDevice }: { value: string; passphraseOnDevice: boolean },
         { dispatch, getState },
     ) => {
-        const device = selectDevice(getState());
+        const device = selectSelectedDevice(getState());
         if (!device) return;
 
         if (!device.state) {

--- a/suite-common/wallet-core/src/discovery/discoveryReducer.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryReducer.ts
@@ -5,7 +5,7 @@ import { DiscoveryStatus } from '@suite-common/wallet-constants';
 import { DeviceState, StaticSessionId } from '@trezor/connect';
 
 import { discoveryActions } from './discoveryActions';
-import { DeviceRootState, selectDevice } from '../device/deviceReducer';
+import { DeviceRootState, selectSelectedDevice } from '../device/deviceReducer';
 
 export type DiscoveryState = Discovery[];
 
@@ -94,7 +94,7 @@ export const selectDiscoveryByDeviceState = (
         : undefined;
 
 export const selectDeviceDiscovery = (state: DiscoveryRootState & DeviceRootState) => {
-    const selectedDevice = selectDevice(state);
+    const selectedDevice = selectSelectedDevice(state);
 
     return selectDiscoveryByDeviceState(state, selectedDevice?.state?.staticSessionId);
 };

--- a/suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts
@@ -27,7 +27,7 @@ import {
 import { createThunk } from '@suite-common/redux-utils';
 
 import { selectTransactions } from '../transactions/transactionsReducer';
-import { selectDevice } from '../device/deviceReducer';
+import { selectSelectedDevice } from '../device/deviceReducer';
 import {
     ComposeTransactionThunkArguments,
     ComposeFeeLevelsError,
@@ -64,7 +64,7 @@ export const composeBitcoinTransactionFeeLevelsThunk = createThunk<
         const { account, excludedUtxos, feeInfo, prison } = composeContext;
 
         const areSatsAmountUnit = selectAreSatsAmountUnit(getState());
-        const device = selectDevice(getState());
+        const device = selectSelectedDevice(getState());
 
         const isSatoshis =
             areSatsAmountUnit &&

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -38,7 +38,7 @@ import {
 } from '../transactions/transactionsThunks';
 import { accountsActions } from '../accounts/accountsActions';
 import { selectAccountByKey } from '../accounts/accountsReducer';
-import { selectDevice } from '../device/deviceReducer';
+import { selectSelectedDevice } from '../device/deviceReducer';
 import { syncAccountsWithBlockchainThunk } from '../blockchain/blockchainThunks';
 import {
     selectSendFormDrafts,
@@ -274,7 +274,7 @@ export const pushSendFormTransactionThunk = createThunk<
         } = extra;
         const precomposedTransaction = selectSendPrecomposedTx(getState());
         const serializedTx = selectSendSerializedTx(getState());
-        const device = selectDevice(getState());
+        const device = selectSelectedDevice(getState());
         const bitcoinAmountUnit = selectBitcoinAmountUnit(getState());
 
         if (!serializedTx || !precomposedTransaction)
@@ -413,7 +413,7 @@ export const signTransactionThunk = createThunk<
             selectors: { selectSelectedAccountStatus },
         } = extra;
         const accountStatus = selectSelectedAccountStatus(getState());
-        const device = selectDevice(getState());
+        const device = selectSelectedDevice(getState());
 
         if (
             G.isNullable(selectedAccount) ||
@@ -512,7 +512,7 @@ export const enhancePrecomposedTransactionThunk = createThunk<
         { transactionFormValues: formValues, precomposedTransaction, selectedAccount },
         { getState, dispatch, rejectWithValue },
     ) => {
-        const device = selectDevice(getState());
+        const device = selectSelectedDevice(getState());
         const selectedAccountNetwork = getNetwork(selectedAccount.symbol);
         if (!device) return rejectWithValue('Device not found');
 

--- a/suite-native/coin-enabling/src/coinEnablingSelectors.ts
+++ b/suite-native/coin-enabling/src/coinEnablingSelectors.ts
@@ -1,6 +1,6 @@
 import {
     DeviceRootState,
-    selectDevice,
+    selectSelectedDevice,
     selectIsDeviceConnectedAndAuthorized,
     selectIsDeviceUnlocked,
     selectIsPortfolioTrackerDevice,
@@ -15,7 +15,7 @@ import { FeatureFlagsRootState } from '@suite-native/feature-flags';
 export const selectShouldShowCoinEnablingInitFlow = (
     state: DeviceRootState & DiscoveryConfigSliceRootState & FeatureFlagsRootState,
 ) => {
-    const device = selectDevice(state);
+    const device = selectSelectedDevice(state);
     const isDeviceUnlocked = selectIsDeviceUnlocked(state);
     const isPortfolioTrackerDevice = selectIsPortfolioTrackerDevice(state);
     const isCoinEnablingInitFinished = selectIsCoinEnablingInitFinished(state);

--- a/suite-native/device-authorization/src/passphraseThunks.ts
+++ b/suite-native/device-authorization/src/passphraseThunks.ts
@@ -1,7 +1,7 @@
 import { createThunk } from '@suite-common/redux-utils';
 import {
     deviceActions,
-    selectDevice,
+    selectSelectedDevice,
     selectDeviceThunk,
     selectDevices,
     createDeviceInstanceThunk,
@@ -16,7 +16,7 @@ export const cancelPassphraseAndSelectStandardDeviceThunk = createThunk(
     `${PASSPHRASE_MODULE_PREFIX}/cancelPassphraseFlow`,
     (_, { getState, dispatch, extra }) => {
         const devices = selectDevices(getState());
-        const device = selectDevice(getState());
+        const device = selectSelectedDevice(getState());
 
         if (!device) return;
 
@@ -50,7 +50,7 @@ export const verifyPassphraseOnEmptyWalletThunk = createThunk<
 >(
     `${PASSPHRASE_MODULE_PREFIX}/verifyPassphraseOnEmptyWallet`,
     async (_, { getState, rejectWithValue, fulfillWithValue, dispatch }) => {
-        const device = selectDevice(getState());
+        const device = selectSelectedDevice(getState());
 
         if (!device) return rejectWithValue({ error: 'no-device' });
 
@@ -86,7 +86,7 @@ export const verifyPassphraseOnEmptyWalletThunk = createThunk<
 export const retryPassphraseAuthenticationThunk = createThunk(
     `${PASSPHRASE_MODULE_PREFIX}/retryPassphraseAuthentication`,
     (_, { dispatch, getState, extra }) => {
-        const device = selectDevice(getState());
+        const device = selectSelectedDevice(getState());
 
         if (!device) return;
 
@@ -95,7 +95,7 @@ export const retryPassphraseAuthenticationThunk = createThunk(
         // Remove device on which the passphrase flow was restarted
         dispatch(deviceActions.forgetDevice({ device, settings }));
 
-        const newDevice = selectDevice(getState());
+        const newDevice = selectSelectedDevice(getState());
 
         if (!newDevice) return;
 

--- a/suite-native/device-manager/src/components/AddHiddenWalletButton.tsx
+++ b/suite-native/device-manager/src/components/AddHiddenWalletButton.tsx
@@ -6,7 +6,7 @@ import { Translation } from '@suite-native/intl';
 import { HStack, Text } from '@suite-native/atoms';
 import {
     createDeviceInstanceThunk,
-    selectDevice,
+    selectSelectedDevice,
     selectIsDeviceProtectedByPassphrase,
 } from '@suite-common/wallet-core';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
@@ -40,7 +40,7 @@ export const AddHiddenWalletButton = () => {
 
     const { applyStyle } = useNativeStyles();
 
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const isPassphraseEnabledOnDevice = useSelector(selectIsDeviceProtectedByPassphrase);
 
     const { setIsDeviceManagerVisible } = useDeviceManager();

--- a/suite-native/device-manager/src/components/DeviceList.tsx
+++ b/suite-native/device-manager/src/components/DeviceList.tsx
@@ -12,7 +12,7 @@ import {
 } from '@suite-native/navigation';
 import { analytics, EventType } from '@suite-native/analytics';
 import {
-    selectDevice,
+    selectSelectedDevice,
     selectIsDeviceConnected,
     selectInstacelessUnselectedDevices,
     selectHasDeviceDiscovery,
@@ -129,7 +129,7 @@ export const DeviceList = ({ isVisible, onSelectDevice }: DeviceListProps) => {
     const { applyStyle } = useNativeStyles();
     const navigation = useNavigation<NavigationProp>();
     const { setIsDeviceManagerVisible } = useDeviceManager();
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const notSelectedInstancelessDevices = useSelector(selectInstacelessUnselectedDevices);
     const hasDiscovery = useSelector(selectHasDeviceDiscovery);
     const isDeviceConnected = useSelector(selectIsDeviceConnected);

--- a/suite-native/device-manager/src/components/DeviceManagerContent.tsx
+++ b/suite-native/device-manager/src/components/DeviceManagerContent.tsx
@@ -6,7 +6,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { VStack, Stack, ACCESSIBILITY_FONTSIZE_MULTIPLIER } from '@suite-native/atoms';
 import {
     PORTFOLIO_TRACKER_DEVICE_ID,
-    selectDevice,
+    selectSelectedDevice,
     selectDeviceThunk,
     selectHasDeviceDiscovery,
     selectIsPortfolioTrackerDevice,
@@ -47,7 +47,7 @@ export const DeviceManagerContent = () => {
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
 
     const hasDiscovery = useSelector(selectHasDeviceDiscovery);
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const { setIsDeviceManagerVisible } = useDeviceManager();
 
     const toggleIsChangeDeviceRequested = () =>

--- a/suite-native/device-manager/src/components/DeviceSettingsButton.tsx
+++ b/suite-native/device-manager/src/components/DeviceSettingsButton.tsx
@@ -4,7 +4,7 @@ import { useNavigation } from '@react-navigation/native';
 
 import { analytics, EventType } from '@suite-native/analytics';
 import { HStack, Text } from '@suite-native/atoms';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { Translation } from '@suite-native/intl';
 import {
     DeviceStackRoutes,
@@ -45,7 +45,7 @@ export const DeviceSettingsButton = ({ showAsFullWidth }: DeviceInfoButtonProps)
     const { applyStyle } = useNativeStyles();
     const navigation = useNavigation<NavigationProp>();
     const { setIsDeviceManagerVisible } = useDeviceManager();
-    const selectedDevice = useSelector(selectDevice);
+    const selectedDevice = useSelector(selectSelectedDevice);
 
     const handleDeviceRedirect = () => {
         setIsDeviceManagerVisible(false);

--- a/suite-native/device-manager/src/components/WalletItem.tsx
+++ b/suite-native/device-manager/src/components/WalletItem.tsx
@@ -1,7 +1,7 @@
 import { useSelector } from 'react-redux';
 
 import { TrezorDevice } from '@suite-common/suite-types';
-import { selectDevice, selectDeviceByState } from '@suite-common/wallet-core';
+import { selectSelectedDevice, selectDeviceByState } from '@suite-common/wallet-core';
 import { selectDeviceTotalFiatBalanceNative } from '@suite-native/device';
 
 import { WalletItemBase } from './WalletItemBase';
@@ -14,7 +14,7 @@ type WalletItemProps = {
 
 export const WalletItem = ({ onPress, deviceState, isSelectable = true }: WalletItemProps) => {
     const device = useSelector((state: any) => selectDeviceByState(state, deviceState));
-    const selectedDevice = useSelector(selectDevice);
+    const selectedDevice = useSelector(selectSelectedDevice);
     const fiatBalance = useSelector((state: any) =>
         device?.state?.staticSessionId
             ? String(selectDeviceTotalFiatBalanceNative(state, device?.state?.staticSessionId))

--- a/suite-native/device-manager/src/components/WalletList.tsx
+++ b/suite-native/device-manager/src/components/WalletList.tsx
@@ -5,7 +5,7 @@ import { A } from '@mobily/ts-belt';
 import { TrezorDevice } from '@suite-common/suite-types';
 import {
     createDeviceInstanceThunk,
-    selectDevice,
+    selectSelectedDevice,
     selectDeviceInstances,
     selectIsPortfolioTrackerDevice,
 } from '@suite-common/wallet-core';
@@ -22,7 +22,7 @@ type WalletListProps = {
 export const WalletList = ({ onSelectDevice }: WalletListProps) => {
     const dispatch = useDispatch();
     const devices = useSelector(selectDeviceInstances);
-    const selectedDevice = useSelector(selectDevice);
+    const selectedDevice = useSelector(selectSelectedDevice);
     const hasNoDeviceWithEmptyPassphrase = useSelector(selectHasNoDeviceWithEmptyPassphrase);
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const isSelectable = devices.length > 1 || hasNoDeviceWithEmptyPassphrase;

--- a/suite-native/device/src/deviceThunks.ts
+++ b/suite-native/device/src/deviceThunks.ts
@@ -1,4 +1,4 @@
-import { deviceActions, selectDevice } from '@suite-common/wallet-core';
+import { deviceActions, selectSelectedDevice } from '@suite-common/wallet-core';
 import { createThunk } from '@suite-common/redux-utils';
 
 const NATIVE_DEVICE_MODULE_PREFIX = 'nativeDevice';
@@ -6,7 +6,7 @@ const NATIVE_DEVICE_MODULE_PREFIX = 'nativeDevice';
 export const setDeviceForceRememberedThunk = createThunk(
     `${NATIVE_DEVICE_MODULE_PREFIX}/setDeviceForceRemembered`,
     ({ forceRemember }: { forceRemember: boolean }, { getState, rejectWithValue, dispatch }) => {
-        const device = selectDevice(getState());
+        const device = selectSelectedDevice(getState());
         if (!device) {
             return rejectWithValue('Device not found');
         }

--- a/suite-native/device/src/hooks/useDetectDeviceError.tsx
+++ b/suite-native/device/src/hooks/useDetectDeviceError.tsx
@@ -8,7 +8,7 @@ import { analytics, EventType } from '@suite-native/analytics';
 import {
     acquireDevice,
     deviceActions,
-    selectDevice,
+    selectSelectedDevice,
     selectIsConnectedDeviceUninitialized,
     selectIsNoPhysicalDeviceConnected,
     selectIsDeviceInBootloader,
@@ -50,7 +50,7 @@ export const useDetectDeviceError = () => {
     const openLink = useOpenLink();
     const navigation = useNavigation<NavigationProps>();
 
-    const selectedDevice = useSelector(selectDevice);
+    const selectedDevice = useSelector(selectSelectedDevice);
     const isUnacquiredDevice = useSelector(selectIsUnacquiredDevice);
     const isConnectedDeviceUninitialized = useSelector(selectIsConnectedDeviceUninitialized);
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);

--- a/suite-native/device/src/middlewares/buttonRequestMiddleware.ts
+++ b/suite-native/device/src/middlewares/buttonRequestMiddleware.ts
@@ -1,6 +1,6 @@
 import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
 import { UI } from '@trezor/connect';
-import { deviceActions, selectDevice } from '@suite-common/wallet-core';
+import { deviceActions, selectSelectedDevice } from '@suite-common/wallet-core';
 
 export const prepareButtonRequestMiddleware = createMiddlewareWithExtraDeps(
     (action, { dispatch, getState, next }) => {
@@ -9,7 +9,7 @@ export const prepareButtonRequestMiddleware = createMiddlewareWithExtraDeps(
         if (action.type === UI.REQUEST_PIN) {
             dispatch(
                 deviceActions.addButtonRequest({
-                    device: selectDevice(getState()),
+                    device: selectSelectedDevice(getState()),
                     buttonRequest: {
                         code: action.payload.type,
                     },
@@ -22,7 +22,7 @@ export const prepareButtonRequestMiddleware = createMiddlewareWithExtraDeps(
 
             dispatch(
                 deviceActions.addButtonRequest({
-                    device: selectDevice(getState()),
+                    device: selectSelectedDevice(getState()),
                     buttonRequest: request,
                 }),
             );

--- a/suite-native/device/src/selectors.ts
+++ b/suite-native/device/src/selectors.ts
@@ -11,7 +11,7 @@ import {
     selectAccounts,
     selectAccountsByDeviceState,
     selectCurrentFiatRates,
-    selectDevice,
+    selectSelectedDevice,
     selectDeviceFirmwareVersion,
     selectDeviceInstances,
     selectDeviceModel,
@@ -64,7 +64,7 @@ export const selectIsDeviceReadyToUseAndAuthorized = (
 export const selectDeviceError = (
     state: DeviceRootState & AccountsRootState & DiscoveryRootState,
 ) => {
-    const device = selectDevice(state);
+    const device = selectSelectedDevice(state);
 
     return device?.error;
 };

--- a/suite-native/discovery/src/discoveryThunks.ts
+++ b/suite-native/discovery/src/discoveryThunks.ts
@@ -11,7 +11,7 @@ import {
     removeDiscovery,
     getAvailableCardanoDerivationsThunk,
     selectDeviceAccountByDescriptorAndNetworkSymbol,
-    selectDevice,
+    selectSelectedDevice,
     LIMIT,
     selectDeviceAccountsForNetworkSymbolAndAccountType,
     disableAccountsThunk,
@@ -90,7 +90,7 @@ const fetchBundleDescriptorsThunk = createThunk<
 >(
     `${DISCOVERY_MODULE_PREFIX}/fetchBundleDescriptorsThunk`,
     async (bundle, { getState, rejectWithValue, fulfillWithValue }) => {
-        const device = selectDevice(getState());
+        const device = selectSelectedDevice(getState());
 
         const result = await TrezorConnect.getAccountDescriptor({
             bundle,
@@ -235,7 +235,7 @@ export const addAccountByDescriptorThunk = createThunk(
         },
         { dispatch, getState },
     ) => {
-        const device = selectDevice(getState());
+        const device = selectSelectedDevice(getState());
         const { success, payload: accountInfo } = await TrezorConnect.getAccountInfo({
             coin: bundleItem.coin,
             identity,
@@ -300,7 +300,7 @@ const discoverAccountsByDescriptorThunk = createThunk(
             isFinalRound = true;
         }
 
-        const device = selectDevice(getState());
+        const device = selectSelectedDevice(getState());
         for (const bundleItem of descriptorsBundle) {
             const { success, payload: accountInfo } = await TrezorConnect.getAccountInfo({
                 coin: bundleItem.coin,

--- a/suite-native/message-system/src/messageSystemMiddleware.ts
+++ b/suite-native/message-system/src/messageSystemMiddleware.ts
@@ -7,7 +7,7 @@ import {
     getValidMessages,
     selectMessageSystemConfig,
 } from '@suite-common/message-system';
-import { deviceActions, selectDevice } from '@suite-common/wallet-core';
+import { deviceActions, selectSelectedDevice } from '@suite-common/wallet-core';
 import {
     selectDeviceEnabledDiscoveryNetworkSymbols,
     toggleEnabledDiscoveryNetworkSymbol,
@@ -27,7 +27,7 @@ export const messageSystemMiddleware = createMiddleware((action, { next, dispatc
 
     if (isAnyOfMessageSystemAffectingActions(action)) {
         const config = selectMessageSystemConfig(getState());
-        const device = selectDevice(getState());
+        const device = selectSelectedDevice(getState());
         const enabledNetworks = selectDeviceEnabledDiscoveryNetworkSymbols(getState());
 
         const validMessages = getValidMessages(config, {

--- a/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
+++ b/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
@@ -18,7 +18,7 @@ import {
     AccountsRootState,
     DeviceRootState,
     LIMIT,
-    selectDevice,
+    selectSelectedDevice,
     selectDeviceAccounts,
     selectIsDeviceInViewOnlyMode,
     accountsActions,
@@ -82,7 +82,7 @@ export const useAddCoinAccount = () => {
     const deviceAccounts = useSelector((state: AccountsRootState & DeviceRootState) =>
         selectDeviceAccounts(state),
     );
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const isDeviceInViewOnlyMode = useSelector(selectIsDeviceInViewOnlyMode);
     const enabledDiscoveryNetworkSymbols = useSelector(selectDeviceEnabledDiscoveryNetworkSymbols);
 

--- a/suite-native/module-authorize-device/src/screens/passphrase/PassphraseConfirmOnTrezorScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/passphrase/PassphraseConfirmOnTrezorScreen.tsx
@@ -13,7 +13,7 @@ import { CenteredTitleHeader, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
     deviceActions,
-    selectDevice,
+    selectSelectedDevice,
     selectIsDeviceConnectedAndAuthorized,
     selectHasDeviceDiscovery,
 } from '@suite-common/wallet-core';
@@ -36,7 +36,7 @@ export const PassphraseConfirmOnTrezorScreen = () => {
 
     const isDeviceConnectedAndAuthorized = useSelector(selectIsDeviceConnectedAndAuthorized);
     const hasDiscovery = useSelector(selectHasDeviceDiscovery);
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
 
     // If this screen was present during authorizing device with passphrase for some feature,
     // on success, this hook will close the stack and go back

--- a/suite-native/module-authorize-device/src/screens/passphrase/PassphraseEmptyWalletScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/passphrase/PassphraseEmptyWalletScreen.tsx
@@ -12,7 +12,7 @@ import {
 import { VStack, Card, Text, Button, Box, TextDivider } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { Translation } from '@suite-native/intl';
-import { deviceActions, selectDevice } from '@suite-common/wallet-core';
+import { deviceActions, selectSelectedDevice } from '@suite-common/wallet-core';
 import { retryPassphraseAuthenticationThunk } from '@suite-native/device-authorization';
 import { EventType, analytics } from '@suite-native/analytics';
 
@@ -37,7 +37,7 @@ export const PassphraseEmptyWalletScreen = () => {
 
     const dispatch = useDispatch();
 
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
 
     const navigation = useNavigation<NavigationProp>();
 

--- a/suite-native/module-connect-popup/src/components/ButtonRequestsOverlay.tsx
+++ b/suite-native/module-connect-popup/src/components/ButtonRequestsOverlay.tsx
@@ -1,13 +1,13 @@
 import { useSelector } from 'react-redux';
 
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { Box, Text, VStack } from '@suite-native/atoms';
 import { ConfirmOnTrezorImage } from '@suite-native/device';
 import { ButtonRequest } from '@suite-common/suite-types';
 import { Translation } from '@suite-native/intl';
 
 export const ButtonRequestsOverlay = () => {
-    const selectedDevice = useSelector(selectDevice);
+    const selectedDevice = useSelector(selectSelectedDevice);
 
     if (!selectedDevice?.buttonRequests || selectedDevice.buttonRequests.length === 0) {
         return null;

--- a/suite-native/module-connect-popup/src/screens/ConnectPopupScreen.tsx
+++ b/suite-native/module-connect-popup/src/screens/ConnectPopupScreen.tsx
@@ -15,7 +15,7 @@ import {
 import { DeviceManager } from '@suite-native/device-manager';
 import {
     deviceActions,
-    selectDevice,
+    selectSelectedDevice,
     selectIsDeviceConnectedAndAuthorized,
     selectIsDeviceDiscoveryActive,
     selectIsPortfolioTrackerDevice,
@@ -36,7 +36,7 @@ export const ConnectPopupScreen = ({
     const navigation = useNavigation();
 
     const dispatch = useDispatch();
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const deviceConnectedAndAuthorized = useSelector(selectIsDeviceConnectedAndAuthorized);
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const validDevice = deviceConnectedAndAuthorized && !isPortfolioTrackerDevice;

--- a/suite-native/module-dev-utils/src/components/DevicePassphraseSwitch.tsx
+++ b/suite-native/module-dev-utils/src/components/DevicePassphraseSwitch.tsx
@@ -4,7 +4,7 @@ import TrezorConnect from '@trezor/connect';
 import { Box, HStack, Switch, Text } from '@suite-native/atoms';
 import {
     removeButtonRequests,
-    selectDevice,
+    selectSelectedDevice,
     selectDeviceButtonRequestsCodes,
     selectIsDeviceProtectedByPassphrase,
     selectIsPortfolioTrackerDevice,
@@ -13,7 +13,7 @@ import { useToast } from '@suite-native/toasts';
 
 export const DevicePassphraseSwitch = () => {
     const dispatch = useDispatch();
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const isPassphraseEnabled = useSelector(selectIsDeviceProtectedByPassphrase);
     const { showToast } = useToast();

--- a/suite-native/module-device-settings/src/components/DeviceAuthenticityCard.tsx
+++ b/suite-native/module-device-settings/src/components/DeviceAuthenticityCard.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 
 import { analytics, DeviceAuthenticityCheckResult, EventType } from '@suite-native/analytics';
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import { useAlert } from '@suite-native/alerts';
 import { Button, IconListItem, Text, VStack } from '@suite-native/atoms';
@@ -30,7 +30,7 @@ export const DeviceAuthenticityCard = () => {
     const navigation = useNavigation<NavigationProp>();
     const { showAlert } = useAlert();
 
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
 
     const reportCheckResult = useCallback(
         (result: DeviceAuthenticityCheckResult) =>

--- a/suite-native/module-device-settings/src/components/DeviceFirmwareCard.tsx
+++ b/suite-native/module-device-settings/src/components/DeviceFirmwareCard.tsx
@@ -9,7 +9,7 @@ import { deviceModelToIconName } from '@suite-native/icons';
 import {
     DeviceRootState,
     DiscoveryRootState,
-    selectDevice,
+    selectSelectedDevice,
     selectDeviceModel,
     selectDeviceReleaseInfo,
     selectIsDiscoveryActiveByDeviceState,
@@ -59,7 +59,7 @@ type NavigationProp = StackNavigationProps<
 const allowReinstall = isDevelopOrDebugEnv();
 
 export const DeviceFirmwareCard = () => {
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const deviceModel = useSelector(selectDeviceModel);
     const deviceReleaseInfo = useSelector(selectDeviceReleaseInfo);
     const isDiscoveryRunning = useSelector((state: DiscoveryRootState & DeviceRootState) =>

--- a/suite-native/module-device-settings/src/components/DeviceInteractionScreenWrapper.tsx
+++ b/suite-native/module-device-settings/src/components/DeviceInteractionScreenWrapper.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
-import { selectDevice } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { Screen, ScreenSubHeader } from '@suite-native/navigation';
 import TrezorConnect from '@trezor/connect';
 
@@ -12,7 +12,7 @@ type DeviceInteractionScreenWrapperProps = {
 export const DeviceInteractionScreenWrapper = ({
     children,
 }: DeviceInteractionScreenWrapperProps) => {
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
 
     const closeAction = useCallback(() => {
         TrezorConnect.cancel();

--- a/suite-native/module-device-settings/src/components/DevicePinActionButton.tsx
+++ b/suite-native/module-device-settings/src/components/DevicePinActionButton.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
-import { removeButtonRequests, selectDevice } from '@suite-common/wallet-core';
+import { removeButtonRequests, selectSelectedDevice } from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
 import { analytics, EventType } from '@suite-native/analytics';
 import { Button, ButtonColorScheme } from '@suite-native/atoms';
@@ -64,7 +64,7 @@ export const DevicePinActionButton = ({
     const { showToast } = useToast();
     const { showAlert, hideAlert } = useAlert();
 
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
 
     const showSuccess = useCallback(
         (messageKey: TxKeyPath) => {

--- a/suite-native/module-device-settings/src/components/DevicePinProtectionCard.tsx
+++ b/suite-native/module-device-settings/src/components/DevicePinProtectionCard.tsx
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux';
 
-import { selectDevice, selectIsDeviceProtectedByPin } from '@suite-common/wallet-core';
+import { selectSelectedDevice, selectIsDeviceProtectedByPin } from '@suite-common/wallet-core';
 import { Box, HStack, Text, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 
@@ -8,7 +8,7 @@ import { DevicePinActionButton } from './DevicePinActionButton';
 import { DeviceSettingsCardLayout } from './DeviceSettingsCardLayout';
 
 export const DevicePinProtectionCard = () => {
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const isDeviceProtectedByPin = useSelector(selectIsDeviceProtectedByPin);
 
     if (!device) {

--- a/suite-native/module-device-settings/src/screens/DeviceSettingsModalScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/DeviceSettingsModalScreen.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { SUPPORTS_DEVICE_AUTHENTICITY_CHECK } from '@suite-common/suite-constants';
 import {
-    selectDevice,
+    selectSelectedDevice,
     selectDeviceModel,
     selectDeviceReleaseInfo,
 } from '@suite-common/wallet-core';
@@ -20,7 +20,7 @@ import { HowToUpdateBottomSheet } from '../components/HowToUpdateBottomSheet';
 export const DeviceSettingsModalScreen = () => {
     const { translate } = useTranslate();
 
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const deviceModel = useSelector(selectDeviceModel);
     const deviceReleaseInfo = useSelector(selectDeviceReleaseInfo);
 

--- a/suite-native/module-home/src/screens/HomeScreen/useShowViewOnlyAlert.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/useShowViewOnlyAlert.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import {
     deviceActions,
-    selectDevice,
+    selectSelectedDevice,
     selectHasDeviceDiscovery,
     selectIsDeviceRemembered,
     selectIsPortfolioTrackerDevice,
@@ -34,7 +34,7 @@ export const useShowViewOnlyAlert = () => {
     const { showToast } = useToast();
 
     const { isBiometricsInitialSetupFinished } = useIsBiometricsInitialSetupFinished();
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const isDeviceReadyToUseAndAuthorized = useSelector(selectIsDeviceReadyToUseAndAuthorized);
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const viewOnlyCancelationTimestamp = useSelector(selectViewOnlyCancelationTimestamp);

--- a/suite-native/module-send/src/selectors.ts
+++ b/suite-native/module-send/src/selectors.ts
@@ -5,7 +5,7 @@ import {
     AccountsRootState,
     DeviceRootState,
     selectAccountByKey,
-    selectDevice,
+    selectSelectedDevice,
     selectSendPrecomposedTx,
     selectSendFormDraftByKey,
     selectSendFormReviewButtonRequestsCount,
@@ -35,7 +35,7 @@ export const selectTransactionReviewOutputs = (
             : undefined;
 
     const account = selectAccountByKey(state, accountKey);
-    const device = selectDevice(state);
+    const device = selectSelectedDevice(state);
 
     const sendReviewButtonRequests = selectSendFormReviewButtonRequestsCount(
         state,

--- a/suite-native/module-send/src/sendFormThunks.ts
+++ b/suite-native/module-send/src/sendFormThunks.ts
@@ -9,7 +9,7 @@ import {
     enhancePrecomposedTransactionThunk,
     pushSendFormTransactionThunk,
     selectAccountByKey,
-    selectDevice,
+    selectSelectedDevice,
     selectSendFormDraftByKey,
     sendFormActions,
     signTransactionThunk,
@@ -51,7 +51,7 @@ export const signTransactionNativeThunk = createThunk<
     ) => {
         const account = selectAccountByKey(getState(), accountKey);
         const formState = selectSendFormDraftByKey(getState(), accountKey, tokenContract);
-        const device = selectDevice(getState());
+        const device = selectSelectedDevice(getState());
 
         if (!account || !formState)
             return rejectWithValue({
@@ -112,7 +112,7 @@ export const cleanupSendFormThunk = createThunk(
         }: { accountKey: AccountKey; shouldDeleteDraft?: boolean },
         { dispatch, getState },
     ) => {
-        const device = selectDevice(getState());
+        const device = selectSelectedDevice(getState());
 
         dispatch(sendFormActions.dispose());
 

--- a/suite-native/receive/src/components/ReceiveAccount.tsx
+++ b/suite-native/receive/src/components/ReceiveAccount.tsx
@@ -7,7 +7,7 @@ import {
     AccountsRootState,
     removeButtonRequests,
     selectAccountByKey,
-    selectDevice,
+    selectSelectedDevice,
 } from '@suite-common/wallet-core';
 import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
 import { Translation } from '@suite-native/intl';
@@ -29,7 +29,7 @@ export const ReceiveAccount = ({ accountKey, tokenContract }: AccountReceiveProp
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
-    const device = useSelector(selectDevice);
+    const device = useSelector(selectSelectedDevice);
     const hasReceiveButtonRequest = useSelector(hasReceiveAddressButtonRequest);
 
     const { address, isReceiveApproved, isUnverifiedAddressRevealed, handleShowAddress } =


### PR DESCRIPTION
In this PR I want to demonstrate an naming issue and weird logic to handle selected device. Maybe I am not getting something, but this makes much more sense to me.

1. commit: to get label/name of selected device, we don't need to iterate over all devices
2. commit: naming the selectors that selects the selected device properly. I know the `selectSelectedDevice` is a bit weird, but IMO much more clear what it actually does.