### PR TITLE
fix(suite): Disable labelling button when trezor disconnected

### DIFF
--- a/packages/suite/src/views/settings/SettingsGeneral/ConnectLabelingProvider.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/ConnectLabelingProvider.tsx
@@ -1,12 +1,15 @@
+import { Tooltip } from '@trezor/components';
+
 import { SettingsSectionItem } from 'src/components/settings';
 import { ActionButton, ActionColumn, TextColumn, Translation } from 'src/components/suite';
-import { useDispatch } from 'src/hooks/suite';
+import { useDevice, useDispatch } from 'src/hooks/suite';
 import * as metadataLabelingActions from 'src/actions/suite/metadataLabelingActions';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 
 export const ConnectLabelingProvider = () => {
     const dispatch = useDispatch();
-
+    const { device } = useDevice();
+    const isDeviceConnected = device?.connected && device?.available;
     const handleClick = () => dispatch(metadataLabelingActions.init(true));
 
     return (
@@ -16,13 +19,20 @@ export const ConnectLabelingProvider = () => {
                 description={<Translation id="TR_TO_MAKE_YOUR_LABELS_PERSISTENT" />}
             />
             <ActionColumn>
-                <ActionButton
-                    variant="primary"
-                    onClick={handleClick}
-                    data-testid="@settings/metadata/connect-provider-button"
+                <Tooltip
+                    content={
+                        isDeviceConnected ? undefined : <Translation id="TR_DEVICE_NOT_CONNECTED" />
+                    }
                 >
-                    <Translation id="TR_CONNECT" />
-                </ActionButton>
+                    <ActionButton
+                        variant="primary"
+                        onClick={handleClick}
+                        isDisabled={!isDeviceConnected}
+                        data-testid="@settings/metadata/connect-provider-button"
+                    >
+                        <Translation id="TR_CONNECT" />
+                    </ActionButton>
+                </Tooltip>
             </ActionColumn>
         </SettingsSectionItem>
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
<img width="1259" alt="image" src="https://github.com/user-attachments/assets/f35d4d16-5986-4753-9908-9d7c721eda8b" />
