### PR TITLE
chore(suite): do not spam console with updateAccountRefreshTimestamp

### DIFF
--- a/packages/suite/src/reducers/store.ts
+++ b/packages/suite/src/reducers/store.ts
@@ -9,6 +9,7 @@ import { isCodesignBuild } from '@trezor/env-utils';
 import { mergeDeepObject } from '@trezor/utils';
 import { prepareTokenDefinitionsReducer } from '@suite-common/token-definitions';
 import { prepareFirmwareReducer } from '@suite-common/firmware';
+import { accountsActions } from '@suite-common/wallet-core';
 
 import suiteMiddlewares from 'src/middlewares/suite';
 import walletMiddlewares from 'src/middlewares/wallet';
@@ -54,7 +55,7 @@ const middleware = [
     ...recoveryMiddlewares,
 ];
 
-const excludedActions = [addLog.type];
+const excludedActions = [addLog.type, accountsActions.updateAccountRefreshTimestamp.type];
 
 if (!isCodesignBuild()) {
     const excludeLogger = (_getState: any, action: any): boolean =>


### PR DESCRIPTION
## Description
- no more spam of `updateAccountRefreshTimestamp` which is fired when it is checked if account needs update
<img width="376" alt="Screenshot 2024-12-14 at 11 09 21" src="https://github.com/user-attachments/assets/c6e2721c-6c2f-458b-ac3a-75476b688aac" />
