### PR TITLE
chore: refactoring of the TxDetailModal to split the BumpFee (rbf) flow

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ChangeFee.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ChangeFee.tsx
@@ -7,7 +7,7 @@ import { spacings } from '@trezor/theme';
 
 import { Translation, FiatValue, FormattedCryptoAmount } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
-import { useRbf, RbfContext, UseRbfProps } from 'src/hooks/wallet/useRbfForm';
+import { useRbfContext, UseRbfProps } from 'src/hooks/wallet/useRbfForm';
 
 import { RbfFees } from './RbfFees';
 import { AffectedTransactions } from './AffectedTransactions';
@@ -21,53 +21,53 @@ interface ChangeFeeProps extends UseRbfProps {
 }
 
 const ChangeFeeLoaded = (props: ChangeFeeProps) => {
-    const contextValues = useRbf(props);
     const { tx, showChained, children } = props;
-    const { networkType } = contextValues.account;
+    const {
+        account: { networkType },
+    } = useRbfContext();
+
     const feeRate =
         networkType === 'bitcoin' ? `${tx.rbfParams?.feeRate} ${getFeeUnits(networkType)}` : null;
     const fee = formatNetworkAmount(tx.fee, tx.symbol);
 
     return (
-        <RbfContext.Provider value={contextValues}>
-            <Card fillType="none">
-                <InfoItem
-                    direction="row"
-                    label={
-                        <>
-                            <Translation id="TR_CURRENT_FEE" />
-                            &nbsp;({feeRate})
-                        </>
-                    }
-                    typographyStyle="body"
-                >
-                    <Row gap={spacings.md} alignItems="baseline">
-                        <FormattedCryptoAmount
+        <Card fillType="none">
+            <InfoItem
+                direction="row"
+                label={
+                    <>
+                        <Translation id="TR_CURRENT_FEE" />
+                        &nbsp;({feeRate})
+                    </>
+                }
+                typographyStyle="body"
+            >
+                <Row gap={spacings.md} alignItems="baseline">
+                    <FormattedCryptoAmount
+                        disableHiddenPlaceholder
+                        value={fee}
+                        symbol={tx.symbol}
+                    />
+                    <Text variant="tertiary" typographyStyle="label">
+                        <FiatValue
                             disableHiddenPlaceholder
-                            value={fee}
+                            amount={fee}
                             symbol={tx.symbol}
+                            showApproximationIndicator
                         />
-                        <Text variant="tertiary" typographyStyle="label">
-                            <FiatValue
-                                disableHiddenPlaceholder
-                                amount={fee}
-                                symbol={tx.symbol}
-                                showApproximationIndicator
-                            />
-                        </Text>
-                    </Row>
-                </InfoItem>
+                    </Text>
+                </Row>
+            </InfoItem>
 
-                <Divider />
+            <Divider />
 
-                <RbfFees />
+            <RbfFees />
 
-                <DecreasedOutputs />
-                <AffectedTransactions showChained={showChained} />
+            <DecreasedOutputs />
+            <AffectedTransactions showChained={showChained} />
 
-                {children}
-            </Card>
-        </RbfContext.Provider>
+            {children}
+        </Card>
     );
 };
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ReplaceTxButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ReplaceTxButton.tsx
@@ -1,21 +1,14 @@
 import { NewModal } from '@trezor/components';
-import { SelectedAccountLoaded, RbfTransactionParams } from '@suite-common/wallet-types';
 
 import { Translation } from 'src/components/suite';
 import { useDevice } from 'src/hooks/suite';
-import { useRbf } from 'src/hooks/wallet/useRbfForm';
 
-type ReplaceTxButtonProps = {
-    rbfParams: RbfTransactionParams;
-    selectedAccount: SelectedAccountLoaded;
-};
+import { useRbfContext } from '../../../../../../../hooks/wallet/useRbfForm';
 
-export const ReplaceTxButton = ({ rbfParams, selectedAccount }: ReplaceTxButtonProps) => {
+export const ReplaceTxButton = () => {
     const { device, isLocked } = useDevice();
-    const { isLoading, signTransaction, getValues, composedLevels } = useRbf({
-        selectedAccount,
-        rbfParams,
-    });
+
+    const { isLoading, signTransaction, getValues, composedLevels } = useRbfContext();
 
     const values = getValues();
     const composedTx = composedLevels ? composedLevels[values.selectedFee || 'normal'] : undefined;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ReplaceTxButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ReplaceTxButton.tsx
@@ -2,8 +2,7 @@ import { NewModal } from '@trezor/components';
 
 import { Translation } from 'src/components/suite';
 import { useDevice } from 'src/hooks/suite';
-
-import { useRbfContext } from '../../../../../../../hooks/wallet/useRbfForm';
+import { useRbfContext } from 'src/hooks/wallet/useRbfForm';
 
 export const ReplaceTxButton = () => {
     const { device, isLocked } = useDevice();

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModalBase.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModalBase.tsx
@@ -1,0 +1,90 @@
+import { ReactNode } from 'react';
+
+import { NewModal, Column, Banner } from '@trezor/components';
+import { HELP_CENTER_ZERO_VALUE_ATTACKS } from '@trezor/urls';
+import { getAccountKey } from '@suite-common/wallet-utils';
+import { getNetwork } from '@suite-common/wallet-config';
+import {
+    selectAccountByKey,
+    selectTransactionConfirmations,
+    selectIsPhishingTransaction,
+} from '@suite-common/wallet-core';
+import { spacings } from '@trezor/theme';
+
+import { useSelector } from 'src/hooks/suite';
+import { Translation, TrezorLink } from 'src/components/suite';
+import { Account, WalletAccountTransaction } from 'src/types/wallet';
+
+import { BasicTxDetails } from './BasicTxDetails';
+
+type TxDetailModalProps = {
+    tx: WalletAccountTransaction;
+    onCancel: () => void;
+    onBackClick: (() => void) | undefined;
+    heading: ReactNode;
+    bottomContent: ReactNode | undefined;
+    children: ReactNode;
+};
+
+export const TxDetailModalBase = ({
+    tx,
+    onCancel,
+    onBackClick,
+    heading,
+    bottomContent,
+    children,
+}: TxDetailModalProps) => {
+    const blockchain = useSelector(state => state.wallet.blockchain[tx.symbol]);
+
+    const accountKey = getAccountKey(tx.descriptor, tx.symbol, tx.deviceState);
+    const confirmations = useSelector(state =>
+        selectTransactionConfirmations(state, tx.txid, accountKey),
+    );
+    const account = useSelector(state => selectAccountByKey(state, accountKey)) as Account;
+    const network = getNetwork(account.symbol);
+
+    const isPhishingTransaction = useSelector(state =>
+        selectIsPhishingTransaction(state, tx.txid, accountKey),
+    );
+
+    return (
+        <NewModal
+            onCancel={onCancel}
+            heading={heading}
+            size="large"
+            bottomContent={bottomContent}
+            onBackClick={onBackClick}
+        >
+            <Column gap={spacings.lg}>
+                <BasicTxDetails
+                    explorerUrl={blockchain.explorer.tx}
+                    explorerUrlQueryString={blockchain.explorer.queryString}
+                    tx={tx}
+                    network={network}
+                    confirmations={confirmations}
+                />
+
+                {isPhishingTransaction && (
+                    <Banner icon>
+                        <Translation
+                            id="TR_ZERO_PHISHING_BANNER"
+                            values={{
+                                a: chunks => (
+                                    <TrezorLink
+                                        typographyStyle="hint"
+                                        href={HELP_CENTER_ZERO_VALUE_ATTACKS}
+                                        variant="underline"
+                                    >
+                                        {chunks}
+                                    </TrezorLink>
+                                ),
+                            }}
+                        />
+                    </Banner>
+                )}
+
+                {children}
+            </Column>
+        </NewModal>
+    );
+};

--- a/suite-common/wallet-types/src/transaction.ts
+++ b/suite-common/wallet-types/src/transaction.ts
@@ -15,6 +15,7 @@ import {
 } from '@trezor/connect';
 import { Network, NetworkSymbol } from '@suite-common/wallet-config';
 import { TranslationKey } from '@suite-common/intl-types';
+import { RequiredKey } from '@trezor/type-utils';
 
 import { Account } from './account';
 
@@ -184,6 +185,11 @@ export interface WalletAccountTransaction extends AccountTransaction {
      */
     deadline?: number;
 }
+
+export type WalletAccountTransactionWithRequiredRbfParams = RequiredKey<
+    WalletAccountTransaction,
+    'rbfParams'
+>;
 
 export interface ChainedTransactions {
     own: WalletAccountTransaction[];


### PR DESCRIPTION
In this PR I am separating the code for `TxDetailModal` and `TxDetailModal` with bump-fee (RBF) form in it. The issue here is, that `useRbf` is used twice, so the internal form state is initialized twice. User changes fee in one, but when they submit it, the different state is used (with just default values). This result in the bug, there the custom fee is not used when set.


:point_right: For code-review, it will be best go commit by commit. 

Resolves: https://github.com/trezor/trezor-suite/issues/15598