### PR TITLE
fix(suite): unsubscribe disabled coins

### DIFF
--- a/packages/suite/src/middlewares/wallet/__fixtures__/walletMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/__fixtures__/walletMiddleware.ts
@@ -44,7 +44,7 @@ export const blockchainSubscription = [
                 coin: 'eth',
             },
             disconnect: {
-                called: 0,
+                called: 1,
             },
         },
     },
@@ -62,7 +62,7 @@ export const blockchainSubscription = [
                 called: 0,
             },
             disconnect: {
-                called: 1,
+                called: 2,
                 coin: 'eth',
             },
         },

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -305,7 +305,7 @@ export const unsubscribeBlockchainThunk = createThunk(
                     true,
                 );
 
-                return removedAccounts
+                const transformedRemovedAccounts = removedAccounts
                     .filter(acc => acc.symbol === symbol)
                     .map(getAccountIdentity)
                     .filter(arrayDistinct)
@@ -315,6 +315,8 @@ export const unsubscribeBlockchainThunk = createThunk(
                         blocks: false,
                         accounts: accountIdentities[identity] ?? [],
                     }));
+
+                return [...transformedRemovedAccounts, { symbol, blocks: true, accounts: [] }];
             } else {
                 return [{ symbol, accounts: accountsToSubscribe, blocks: true }];
             }


### PR DESCRIPTION
## Description

When a coin is disabled, it should be unsubscribed from blockchain backend.

## Related Issue

Resolve #12904 

## Screenshots:

Polygon is selected and is subscribed to blockchain backend.
<img width="1512" alt="subscribed" src="https://github.com/user-attachments/assets/9e46355e-f4df-413f-9613-1dd497403e7d" />

Polygon is deselected and is no longer subscribed to blockchain backend.
<img width="1512" alt="unsubscribed" src="https://github.com/user-attachments/assets/e186bf9c-26ea-499c-8696-8d16be0eaedc" />

