### PR TITLE
feat(suite): added token search

### DIFF
--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -955,6 +955,13 @@ export const accountSearchFn = (
     const metadataMatch = !!metadataAccountLabel?.toLowerCase().includes(searchString);
     const accountLabelMatch = !!account.accountLabel?.toLowerCase().includes(searchString);
 
+    const filterTokens = (token: TokenInfo) =>
+        token.name?.toLowerCase().includes(searchString) ||
+        token.symbol?.toLowerCase().includes(searchString) ||
+        token.contract.toLowerCase().includes(searchString);
+
+    const tokenMatch = !!account.tokens && !!account.tokens.filter(filterTokens).length;
+
     return (
         symbolMatch ||
         networkNameMatch ||
@@ -963,7 +970,8 @@ export const accountSearchFn = (
         addressMatch ||
         matchXRPAlternativeName ||
         metadataMatch ||
-        accountLabelMatch
+        accountLabelMatch ||
+        tokenMatch
     );
 };
 


### PR DESCRIPTION
## Description

Accounts are now filtered also based on token name, token symbol or token contract address for any token associated with the account.

## Related Issue

Resolve #15585 

## Screenshots:
Entered search query "frax ether", ETH account no. 1 with Staked Frax Ether token is filtered.

<img width="1512" alt="eth-1-frax-ether" src="https://github.com/user-attachments/assets/f5d8fd65-0db5-49ea-99f1-78083971e048" />

Entered search query "pax dollar", ETH account no. 1 with Pax Dollar token is filtered.

<img width="1512" alt="eth-1-pax-dollar" src="https://github.com/user-attachments/assets/14416fe4-d50c-408a-b10f-402006999e1e" />

Entered search query "uniswap", ETH account no. 2 with Uniswap token is filtered.

<img width="1512" alt="eth-2-uniswap" src="https://github.com/user-attachments/assets/cfe85686-7b5b-4dba-9dd9-ade8b54978f0" />

