### PR TITLE
Fix send form output labelling

### DIFF
--- a/packages/suite/src/actions/wallet/send/sendFormThunks.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormThunks.ts
@@ -17,6 +17,7 @@ import {
     signTransactionThunk,
     sendFormActions,
     selectPrecomposedSendForm,
+    cancelSignSendFormTransactionThunk,
 } from '@suite-common/wallet-core';
 import { isCardanoTx, isRbfTransaction } from '@suite-common/wallet-utils';
 import { MetadataAddPayload } from '@suite-common/metadata-types';
@@ -270,6 +271,7 @@ export const signAndPushSendFormTransactionThunk = createThunk(
             );
         }
 
+        // This thunk uses precomposedForm so it must be called before cleanup.
         dispatch(
             applySendFormMetadataLabelsThunk({
                 selectedAccount,
@@ -277,6 +279,9 @@ export const signAndPushSendFormTransactionThunk = createThunk(
                 txid,
             }),
         );
+
+        // Clean send form state and close review modal.
+        dispatch(cancelSignSendFormTransactionThunk());
 
         return result;
     },

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -260,12 +260,12 @@ const synchronizeSentTransactionThunk = createThunk(
 
 export const pushSendFormTransactionThunk = createThunk<
     Success<{ txid: string }>,
-    { selectedAccount: Account; shouldDiscardTransaction?: boolean },
+    { selectedAccount: Account },
     { rejectValue: PushTransactionError }
 >(
     `${SEND_MODULE_PREFIX}/pushSendFormTransactionThunk`,
     async (
-        { selectedAccount, shouldDiscardTransaction = true },
+        { selectedAccount },
         { dispatch, getState, extra, rejectWithValue, fulfillWithValue },
     ) => {
         const {
@@ -337,9 +337,6 @@ export const pushSendFormTransactionThunk = createThunk<
                 }),
             );
         }
-
-        // cleanup send form state and close review modal
-        if (shouldDiscardTransaction) dispatch(cancelSignSendFormTransactionThunk());
 
         return pushTxResponse.success
             ? fulfillWithValue(pushTxResponse)

--- a/suite-native/module-send/src/components/OutputsReviewFooter.tsx
+++ b/suite-native/module-send/src/components/OutputsReviewFooter.tsx
@@ -145,7 +145,6 @@ export const OutputsReviewFooter = ({
         const sendResponse = await dispatch(
             pushSendFormTransactionThunk({
                 selectedAccount: account,
-                shouldDiscardTransaction: false,
             }),
         );
         if (isFulfilled(sendResponse)) {


### PR DESCRIPTION
## Description

Cause: Dispatching `addAccountMetadata` after  `discardTransaction`. At that point, `precomposedForm` was `undefined` so there is no metadata to be saved.

Origin: The order was changed in c4e2fc549aef94d71c45d9b2627685fcd9c6391e, but it didn't break the feature because `precomposedForm` was replaced with persistent `draft` in the same PR. I did not notice this when going back from `draft` to `precomposedForm` in 8e681ea01f68c39e01ed9fe6e6f4d403e766e945.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/15953
Resolve https://github.com/trezor/trezor-suite/issues/13862 (This is weird though, the bug was introduced in 24.11, but the issue is older.)
