### PR TITLE
test(connect): disable flaky authorizeCoinjoin and override test

### DIFF
--- a/packages/connect/e2e/tests/device/authorizeCoinjoin.test.ts
+++ b/packages/connect/e2e/tests/device/authorizeCoinjoin.test.ts
@@ -182,7 +182,9 @@ describe('TrezorConnect.authorizeCoinjoin', () => {
         expect(round3.payload).toMatchObject({ error: 'No preauthorized operation' });
     });
 
-    conditionalTest(['1', '<2.5.4'], 'Authorize and re-authorize', async () => {
+    // TODO: currently skipped due to flaky behavior
+    // Original condition: ['1', '<2.5.4']
+    conditionalTest(['1', '2'], 'Authorize and re-authorize', async () => {        
         const confirmationScreensCount = 1;
         // setup two wallets, 1 with and 1 without passphrase
         await TrezorConnect.applySettings({ use_passphrase: true });

--- a/packages/connect/e2e/tests/device/override.test.ts
+++ b/packages/connect/e2e/tests/device/override.test.ts
@@ -17,7 +17,7 @@ describe('TrezorConnect override param', () => {
     });
 
     [1, 10, 100, 300, 500, 1000, 1500].forEach(delay => {
-        it(`override previous call after ${delay}ms`, async () => {
+        it.skip(`override previous call after ${delay}ms`, async () => {
             TrezorConnect.removeAllListeners();
 
             const overriden = TrezorConnect.getAddress({


### PR DESCRIPTION
## Description

Skipped 2 problematic tests in Connect that are not working long term: 
1. authorizeCoinjoin: Authorize and re-authorize
2. override: override previous call after ... ms

## Related Issue

Resolves #15995
Followup TODO