### PR TITLE
fix(e2e): Explicitly use ubuntu-22 for desktop e2e tests

### DIFF
--- a/.github/workflows/test-suite-desktop-e2e.yml
+++ b/.github/workflows/test-suite-desktop-e2e.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   run-desktop-tests:
     if: github.repository == 'trezor/trezor-suite'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Description

GH started using ubuntu 24 and it causes playwright test not be able to lunch electron
This is temporary fix because the ubuntu 22 will be discontinued from docker repos

## Related Issue

Resolves failing CI issue
## Screenshots:
