### PR TITLE
Recompose tx when opening send form from token row

### DIFF
--- a/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
@@ -123,7 +123,6 @@ export const TokenSelect = ({ outputId }: TokenSelectProps) => {
         composeTransaction,
         watch,
         setValue,
-        setDraftSaveRequest,
     } = useSendFormContext();
 
     const dispatch = useDispatch();
@@ -172,13 +171,13 @@ export const TokenSelect = ({ outputId }: TokenSelectProps) => {
     useEffect(() => {
         if (sendFormPrefill) {
             setValue(tokenInputName, sendFormPrefill, { shouldValidate: true, shouldDirty: true });
-            setDraftSaveRequest(true);
+            composeTransaction(tokenInputName);
             dispatch({
                 type: SUITE.SET_SEND_FORM_PREFILL,
                 payload: '',
             });
         }
-    }, [sendFormPrefill, setValue, tokenInputName, setDraftSaveRequest, dispatch]);
+    }, [sendFormPrefill, setValue, tokenInputName, composeTransaction, dispatch]);
 
     const tokensWithRates = enhanceTokensWithRates(
         account.tokens,

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { selectSelectedDevice, sendFormActions } from '@suite-common/wallet-core';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { Account, TokenAddress } from '@suite-common/wallet-types';
 import { Network, getCoingeckoId } from '@suite-common/wallet-config';
 import {
@@ -494,11 +494,6 @@ export const TokenRow = ({
                                             type: SUITE.SET_SEND_FORM_PREFILL,
                                             payload: token.contract,
                                         });
-                                        dispatch(
-                                            sendFormActions.removeDraft({
-                                                accountKey: account.key,
-                                            }),
-                                        );
                                         goToWithAnalytics('wallet-send', {
                                             params: {
                                                 symbol: account.symbol,


### PR DESCRIPTION
## Description

Alternative approach for resolving #16012. Instead of clearing draft before opening send form, existing precomposed transaction is recomposed with a new token.