### PR TITLE
feat(suite): show just receiving network in add account

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -82,7 +82,7 @@ export const AddAccountModal = ({
     const [enabledNetworks, disabledNetworks] = arrayPartition(supportedNetworks, network =>
         enabledNetworkSymbols.includes(network.symbol),
     );
-    const [disabledMainnetNetworks, disabledTestnetNetworks] = arrayPartition(
+    const [, disabledTestnetNetworks] = arrayPartition(
         disabledNetworks,
         network => !network?.testnet,
     );
@@ -98,6 +98,15 @@ export const AddAccountModal = ({
                   a.empty,
           )
         : [];
+
+    const filterNetworksBySymbol = (networks: Network[], symbol?: NetworkSymbol) =>
+        symbol ? networks.filter(network => network.symbol === symbol) : networks;
+
+    const filteredDisabledNetworks = filterNetworksBySymbol(disabledNetworks, symbol);
+    const filteredEnabledNetworks = filterNetworksBySymbol(enabledNetworks, symbol);
+
+    const visibleNetworks =
+        emptyAccounts.length > 0 ? filteredEnabledNetworks : filteredDisabledNetworks;
 
     const isCoinjoinVisible = (isCoinjoinPublic || isDebug) && !isCoinjoinDisabled;
 
@@ -208,20 +217,22 @@ export const AddAccountModal = ({
                   children: (
                       <>
                           <NetworksWrapper>
-                              <SelectNetwork
-                                  heading={<Translation id="TR_ACTIVATED_COINS" />}
-                                  networks={enabledNetworks}
-                                  selectedNetworks={selectedNetworks}
-                                  handleNetworkSelection={selectNetwork}
-                              />
+                              {!symbol && (
+                                  <SelectNetwork
+                                      heading={<Translation id="TR_ACTIVATED_COINS" />}
+                                      networks={enabledNetworks}
+                                      selectedNetworks={selectedNetworks}
+                                      handleNetworkSelection={selectNetwork}
+                                  />
+                              )}
                               <SelectNetwork
                                   heading={<Translation id="TR_INACTIVE_COINS" />}
-                                  networks={disabledMainnetNetworks}
+                                  networks={visibleNetworks}
                                   selectedNetworks={selectedNetworks}
                                   handleNetworkSelection={selectNetwork}
                               />
                           </NetworksWrapper>
-                          {!!disabledTestnetNetworks.length && (
+                          {!symbol && !!disabledTestnetNetworks.length && (
                               <CollapsibleBox
                                   heading={
                                       <Tooltip
@@ -243,7 +254,7 @@ export const AddAccountModal = ({
                                   />
                               </CollapsibleBox>
                           )}
-                          {showUnsupportedCoins && (
+                          {!symbol && showUnsupportedCoins && (
                               <CollapsibleBox
                                   heading={
                                       <Tooltip

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketVerifyAccount.tsx
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketVerifyAccount.tsx
@@ -63,7 +63,7 @@ const getTranslationIds = (
 };
 
 const useCoinmarketVerifyAccount = ({
-    currency,
+    cryptoId,
 }: CoinmarketVerifyAccountProps): CoinmarketVerifyAccountReturnProps => {
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
     const accounts = useSelector(state => state.wallet.accounts);
@@ -82,15 +82,15 @@ const useCoinmarketVerifyAccount = ({
         CoinmarketVerifyFormAccountOptionProps | undefined
     >();
 
-    const networkId = currency && parseCryptoId(currency).networkId;
-    const symbol = currency && cryptoIdToSymbol(currency);
+    const networkId = cryptoId && parseCryptoId(cryptoId).networkId;
+    const symbol = cryptoId && cryptoIdToSymbol(cryptoId);
 
     const isSupportedNetwork = [...supportedMainnets, ...supportedTestnets].some(
         network => network.symbol === symbol,
     );
 
     const suiteReceiveAccounts = useMemo(() => {
-        if (currency) {
+        if (cryptoId) {
             return filterReceiveAccounts({
                 accounts,
                 deviceState: device?.state?.staticSessionId,
@@ -100,7 +100,7 @@ const useCoinmarketVerifyAccount = ({
         }
 
         return undefined;
-    }, [accounts, currency, device, isDebug, symbol]);
+    }, [accounts, cryptoId, device, isDebug, symbol]);
 
     const selectAccountOptions = useMemo(
         () => getSelectAccountOptions(suiteReceiveAccounts, device, isSupportedNetwork),

--- a/packages/suite/src/types/coinmarket/coinmarketVerify.ts
+++ b/packages/suite/src/types/coinmarket/coinmarketVerify.ts
@@ -20,7 +20,7 @@ export interface CoinmarketVerifyFormAccountOptionProps {
 }
 
 export interface CoinmarketVerifyAccountProps {
-    currency: CryptoId | undefined;
+    cryptoId: CryptoId | undefined;
 }
 
 export interface CoinmarketGetTranslationIdsProps {

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketOfferBuy/CoinmarketOfferBuy.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketOfferBuy/CoinmarketOfferBuy.tsx
@@ -14,16 +14,16 @@ export const CoinmarketOfferBuy = ({
     paymentMethod,
     paymentMethodName,
 }: CoinmarketOfferBuyProps) => {
-    const currency = selectedQuote?.receiveCurrency;
-    const coinmarketVerifyAccount = useCoinmarketVerifyAccount({ currency });
+    const cryptoId = selectedQuote?.receiveCurrency;
+    const coinmarketVerifyAccount = useCoinmarketVerifyAccount({ cryptoId });
 
     return (
         <>
             <Card>
-                {currency && (
+                {cryptoId && (
                     <CoinmarketVerify
                         coinmarketVerifyAccount={coinmarketVerifyAccount}
-                        currency={currency}
+                        cryptoId={cryptoId}
                     />
                 )}
             </Card>

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketOfferExchange/CoinmarketOfferExchange.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketOfferExchange/CoinmarketOfferExchange.tsx
@@ -25,18 +25,18 @@ export const CoinmarketOfferExchange = ({
     quoteAmounts,
 }: CoinmarketOfferExchangeProps) => {
     const { exchangeStep } = useCoinmarketFormContext<CoinmarketTradeExchangeType>();
-    const currency = selectedQuote?.receive;
-    const coinmarketVerifyAccount = useCoinmarketVerifyAccount({ currency });
+    const cryptoId = selectedQuote?.receive;
+    const coinmarketVerifyAccount = useCoinmarketVerifyAccount({ cryptoId });
 
     const steps: CoinmarketSelectedOfferStepperItemProps[] = [
         {
             step: 'RECEIVING_ADDRESS',
             translationId: 'TR_EXCHANGE_VERIFY_ADDRESS_STEP',
             isActive: exchangeStep === 'RECEIVING_ADDRESS',
-            component: currency ? (
+            component: cryptoId ? (
                 <CoinmarketVerify
                     coinmarketVerifyAccount={coinmarketVerifyAccount}
-                    currency={currency}
+                    cryptoId={cryptoId}
                 />
             ) : null,
         },

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketVerify/CoinmarketVerify.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketVerify/CoinmarketVerify.tsx
@@ -27,10 +27,10 @@ import { getCoinmarketNetworkDisplaySymbol } from 'src/utils/wallet/coinmarket/c
 
 interface CoinmarketVerifyProps {
     coinmarketVerifyAccount: CoinmarketVerifyAccountReturnProps;
-    currency: CryptoId;
+    cryptoId: CryptoId;
 }
 
-export const CoinmarketVerify = ({ coinmarketVerifyAccount, currency }: CoinmarketVerifyProps) => {
+export const CoinmarketVerify = ({ coinmarketVerifyAccount, cryptoId }: CoinmarketVerifyProps) => {
     const dispatch = useDispatch();
     const { translationString } = useTranslation();
     const { cryptoIdToCoinSymbol, cryptoIdToNativeCoinSymbol } = useCoinmarketInfo();
@@ -60,13 +60,13 @@ export const CoinmarketVerify = ({ coinmarketVerifyAccount, currency }: Coinmark
     const { accountTooltipTranslationId, addressTooltipTranslationId } = getTranslationIds(
         selectedAccountOption?.type,
     );
-    const coinSymbol = getCoinmarketNetworkDisplaySymbol(cryptoIdToCoinSymbol(currency) ?? '');
+    const coinSymbol = getCoinmarketNetworkDisplaySymbol(cryptoIdToCoinSymbol(cryptoId) ?? '');
 
     const { ref: networkRef, ...networkField } = form.register('address', {
         required: translationString('TR_EXCHANGE_RECEIVING_ADDRESS_REQUIRED'),
         validate: value => {
-            if (selectedAccountOption?.type === 'NON_SUITE' && currency) {
-                const symbol = cryptoIdToNativeCoinSymbol(currency);
+            if (selectedAccountOption?.type === 'NON_SUITE' && cryptoId) {
+                const symbol = cryptoIdToNativeCoinSymbol(cryptoId);
                 if (value && !addressValidator.validate(value, symbol)) {
                     return translationString('TR_EXCHANGE_RECEIVING_ADDRESS_INVALID');
                 }
@@ -111,7 +111,7 @@ export const CoinmarketVerify = ({ coinmarketVerifyAccount, currency }: Coinmark
                 />
             </Paragraph>
             <CoinmarketVerifyOptions
-                receiveNetwork={currency}
+                receiveNetwork={cryptoId}
                 selectedAccountOption={selectedAccountOption}
                 selectAccountOptions={selectAccountOptions}
                 isMenuOpen={isMenuOpen}
@@ -129,7 +129,7 @@ export const CoinmarketVerify = ({ coinmarketVerifyAccount, currency }: Coinmark
                             account={selectedAccountOption?.account}
                             address={address}
                             control={form.control}
-                            receiveSymbol={currency}
+                            receiveSymbol={cryptoId}
                             setValue={form.setValue}
                             label={
                                 <Tooltip


### PR DESCRIPTION
## Description

When buying a coin and creating a new account for that coin, the coin select modal should show only the coin we want to buy and hide all other irrelevant coins.

Moreover, when buying a coin that is not supported by Suite, disable creating a new account for that coin.

## Related Issue

Resolve #14847 

## Screenshots:

We are buying Cardano and creating a new account for Cardano, therefore the modal only shows Cardano.

<img width="772" alt="add-account-modal" src="https://github.com/user-attachments/assets/d2887a75-f128-498d-a3a8-5a04fee069f8" />

We are buying Arbitrum, which is not supported in Suite, therefore there is only the option to use an account that is not in Suite.

<img width="876" alt="disabled-new-account" src="https://github.com/user-attachments/assets/32f1d911-c1ef-4bf5-b863-bf82e3b3e6d7" />

