### PR TITLE
chore(connect-commmon): decrease min bootloader version for 2.8.3

### DIFF
--- a/packages/connect-common/files/firmware/t3b1/releases.json
+++ b/packages/connect-common/files/firmware/t3b1/releases.json
@@ -3,7 +3,7 @@
         "required": false,
         "version": [2, 8, 3],
         "min_firmware_version": [2, 8, 3],
-        "min_bootloader_version": [2, 1, 8],
+        "min_bootloader_version": [2, 1, 7],
         "bootloader_version": [2, 1, 8],
         "translations": ["cs-CZ", "de-DE", "es-ES", "fr-FR", "it-IT", "pt-BR"],
         "url": "firmware/t3b1/trezor-t3b1-2.8.3.bin",


### PR DESCRIPTION
Decreasing the requirement for 2.8.3 t3b1 FW so even devices with 2.1.7 BL can proceed in onboarding.

Suite data PR [here](https://github.com/trezor/data/pull/119)
