### PR TITLE
Fix bridge installation info (again)

### DIFF
--- a/packages/connect-web/src/module/index.ts
+++ b/packages/connect-web/src/module/index.ts
@@ -1,3 +1,4 @@
+import { cloneObject } from '@trezor/utils';
 import { factory } from '@trezor/connect/src/factory';
 import { config } from '@trezor/connect/src/data/config';
 import { TrezorConnectDynamic } from '@trezor/connect/src/impl/dynamic';
@@ -31,8 +32,8 @@ const impl = new TrezorConnectDynamic<
             impl: new CoreInModule((message: CoreEventMessage) => {
                 if (message.event === TRANSPORT_EVENT) {
                     const platform = getInstallerPackage();
-                    message.payload.bridge = suggestBridgeInstaller(platform);
-                    message.payload.udev = suggestUdevInstaller(platform);
+                    message.payload.bridge = cloneObject(suggestBridgeInstaller(platform));
+                    message.payload.udev = cloneObject(suggestUdevInstaller(platform));
                 }
 
                 return message;


### PR DESCRIPTION
## Description

In #15771 we introduced two bugs:
- both udev and bridge installer data added into transport events are not cloned, therefore there's the bug when they're already wrapped in redux but edited from Connect: `(Uncaught (in promise) TypeError: Cannot assign to read only property 'packages' of object '#<Object>' )`
- the bridge installer data is parsed by `parseBridgeJSON` in one bundle but extracted by `suggestBridgeInstaller` in another bundle (= not a singleton as expected), so only the default dummy data is always passed to Suite
  - udev data are ok as they're hardcoded instead of parsed from json

The first one should be already fixed in this PR, but we have to handle the second one yet.