### PR TITLE
Fix/coin control layout

### DIFF
--- a/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
+++ b/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
@@ -95,7 +95,7 @@ export const FormattedCryptoAmount = ({
     }
 
     const content = (
-        <Row width="100%" gap={spacings.xxs} className={className}>
+        <Row width="100%" gap={spacings.xxs}>
             <Row data-testid={dataTest}>
                 {!!signValue && <Sign value={signValue} />}
                 <Value>
@@ -115,5 +115,5 @@ export const FormattedCryptoAmount = ({
         return content;
     }
 
-    return <HiddenPlaceholder>{content}</HiddenPlaceholder>;
+    return <HiddenPlaceholder className={className}>{content}</HiddenPlaceholder>;
 };

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx
@@ -6,6 +6,7 @@ import { formatNetworkAmount, isSameUtxo } from '@suite-common/wallet-utils';
 import { Checkbox, Spinner, TextButton, Tooltip } from '@trezor/components';
 import type { AccountUtxo } from '@trezor/connect';
 import { borders, spacingsPx, typography } from '@trezor/theme';
+import { CheckContainer } from '@trezor/components/src/components/form/Checkbox/Checkbox';
 
 import { openModal } from 'src/actions/suite/modalActions';
 import {
@@ -56,7 +57,7 @@ const StyledCheckbox = styled(Checkbox)`
     margin-right: ${spacingsPx.xs};
 `;
 
-const Wrapper = styled.div<{ $isDisabled: boolean }>`
+const Wrapper = styled.div<{ $isChecked: boolean; $isDisabled: boolean }>`
     align-items: flex-start;
     border-radius: ${borders.radii.xs};
     display: flex;
@@ -74,19 +75,18 @@ const Wrapper = styled.div<{ $isDisabled: boolean }>`
 
     &:hover,
     &:focus-within {
-        ${({ $isDisabled }) =>
+        background: ${({ $isDisabled, theme }) =>
+            !$isDisabled && theme.backgroundSurfaceElevation2};
+
+        ${({ $isChecked, $isDisabled }) =>
+            !$isChecked &&
             !$isDisabled &&
             css`
-                background: ${({ theme }) => theme.backgroundSurfaceElevation2};
-
-                ${StyledCheckbox} > :first-child {
+                ${CheckContainer} {
+                    background: ${({ theme }) => theme.backgroundSurfaceElevation0};
                     border-color: ${({ theme }) => theme.borderFocus};
                 }
             `};
-
-        ${DetailPartVisibleOnHover} {
-            opacity: 1;
-        }
     }
 `;
 
@@ -191,7 +191,11 @@ export const UtxoSelection = ({ transaction, utxo }: UtxoSelectionProps) => {
     };
 
     return (
-        <Wrapper $isDisabled={isDisabled} onClick={isDisabled ? undefined : handleCheckbox}>
+        <Wrapper
+            $isChecked={isChecked}
+            $isDisabled={isDisabled}
+            onClick={isDisabled ? undefined : handleCheckbox}
+        >
             <Tooltip content={isDisabled && <Translation id="TR_UTXO_REGISTERED_IN_COINJOIN" />}>
                 <StyledCheckbox
                     isChecked={isChecked}

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx
@@ -3,9 +3,9 @@ import { MouseEventHandler } from 'react';
 import styled, { css, useTheme } from 'styled-components';
 
 import { formatNetworkAmount, isSameUtxo } from '@suite-common/wallet-utils';
-import { Checkbox, Spinner, TextButton, Tooltip } from '@trezor/components';
+import { Checkbox, Row, Spinner, TextButton, Tooltip } from '@trezor/components';
 import type { AccountUtxo } from '@trezor/connect';
-import { borders, spacingsPx, typography } from '@trezor/theme';
+import { borders, spacings, spacingsPx, typography } from '@trezor/theme';
 import { CheckContainer } from '@trezor/components/src/components/form/Checkbox/Checkbox';
 
 import { openModal } from 'src/actions/suite/modalActions';
@@ -51,12 +51,6 @@ const DetailPartVisibleOnHover = styled.div<{ $alwaysVisible?: boolean }>`
         `};
 `;
 
-// eslint-disable-next-line local-rules/no-override-ds-component
-const StyledCheckbox = styled(Checkbox)`
-    margin-top: ${spacingsPx.xxxs};
-    margin-right: ${spacingsPx.xs};
-`;
-
 const Wrapper = styled.div<{ $isChecked: boolean; $isDisabled: boolean }>`
     align-items: flex-start;
     border-radius: ${borders.radii.xs};
@@ -97,17 +91,6 @@ const Body = styled.div`
     min-width: 0;
 `;
 
-const Row = styled.div`
-    align-items: center;
-    display: flex;
-    gap: ${spacingsPx.xs};
-`;
-
-const BottomRow = styled(Row)`
-    margin-top: 6px;
-    min-height: 24px;
-`;
-
 const Address = styled.div`
     overflow: hidden;
     font-variant-numeric: tabular-nums slashed-zero;
@@ -130,22 +113,17 @@ const TransactionDetailButton = styled(TextButton)`
     }
 `;
 
-// eslint-disable-next-line local-rules/no-override-ds-component
-const StyledFluidSpinner = styled(Spinner)`
-    margin-right: ${spacingsPx.xs};
-`;
-
 const StyledFiatValue = styled(FiatValue)`
     margin-left: auto;
-    padding-left: 4px;
+    padding-left: ${spacingsPx.xxs};
     color: ${({ theme }) => theme.textSubdued};
     ${typography.hint}
 `;
 
-interface UtxoSelectionProps {
+type UtxoSelectionProps = {
     transaction?: WalletAccountTransaction;
     utxo: AccountUtxo;
-}
+};
 
 export const UtxoSelection = ({ transaction, utxo }: UtxoSelectionProps) => {
     const {
@@ -197,15 +175,16 @@ export const UtxoSelection = ({ transaction, utxo }: UtxoSelectionProps) => {
             onClick={isDisabled ? undefined : handleCheckbox}
         >
             <Tooltip content={isDisabled && <Translation id="TR_UTXO_REGISTERED_IN_COINJOIN" />}>
-                <StyledCheckbox
+                <Checkbox
                     isChecked={isChecked}
                     isDisabled={isDisabled}
                     onClick={handleCheckbox}
+                    margin={{ top: spacings.xxxs, right: spacings.xs }}
                 />
             </Tooltip>
 
             <Body>
-                <Row>
+                <Row gap={spacings.xs}>
                     {isPendingTransaction && (
                         <UtxoTag
                             tooltipMessage={<Translation id="TR_IN_PENDING_TRANSACTION" />}
@@ -238,7 +217,7 @@ export const UtxoSelection = ({ transaction, utxo }: UtxoSelectionProps) => {
                     />
                 </Row>
 
-                <BottomRow>
+                <Row margin={{ top: spacings.xxs }} minHeight={spacings.xl}>
                     {transaction ? (
                         <TransactionTimestamp showDate transaction={transaction} />
                     ) : (
@@ -246,7 +225,7 @@ export const UtxoSelection = ({ transaction, utxo }: UtxoSelectionProps) => {
                             cursor="pointer"
                             content={<Translation id="TR_LOADING_TRANSACTION_DETAILS" />}
                         >
-                            <StyledFluidSpinner size={14} />
+                            <Spinner size={14} margin={{ right: spacings.xs }} />
                         </Tooltip>
                     )}
 
@@ -287,7 +266,7 @@ export const UtxoSelection = ({ transaction, utxo }: UtxoSelectionProps) => {
                         amount={formatNetworkAmount(utxo.amount, account.symbol, false)}
                         symbol={network.symbol}
                     />
-                </BottomRow>
+                </Row>
             </Body>
         </Wrapper>
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- Fixes broken selector (checkbox should be in hovered state when the section is hovered)
- Fixes horizontal alignment

A `className` prop should always be attached to the topmost element, otherwise layout-related styles are ignored. This bug originates from https://github.com/trezor/trezor-suite/pull/15457/commits/c27f9895fefcb137228d70476441d1099ab18aec. Discussion [here](https://satoshilabs.slack.com/archives/C07NNMUBJFN/p1734519767134879).

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/16026

## Screenshots:
before:

https://github.com/user-attachments/assets/541609fd-21e3-4cf2-a2d7-763bc1e1b745

after:

https://github.com/user-attachments/assets/0d7b18be-9c68-4238-b0b3-93c48cccf9e6




