### PR TITLE
fix(suite-native): fw update feature flag fix

### DIFF
--- a/suite-native/module-device-settings/src/components/DeviceFirmwareCard.tsx
+++ b/suite-native/module-device-settings/src/components/DeviceFirmwareCard.tsx
@@ -66,9 +66,9 @@ export const DeviceFirmwareCard = () => {
         selectIsDiscoveryActiveByDeviceState(state, device?.state),
     );
     const navigation = useNavigation<NavigationProp>();
-    const isFirmwareUpdateEnabled = useFeatureFlag(FeatureFlag.IsFirmwareUpdateEnabled);
+    const [isFirmwareUpdateEnabled] = useFeatureFlag(FeatureFlag.IsFirmwareUpdateEnabled);
 
-    if (!device || !deviceModel || !isFirmwareUpdateEnabled) {
+    if (!device || !deviceModel) {
         return null;
     }
 
@@ -78,6 +78,10 @@ export const DeviceFirmwareCard = () => {
         : 'moduleDeviceSettings.firmware.typeUniversal';
 
     const firmwareUpdateProps = (() => {
+        if (!isFirmwareUpdateEnabled) {
+            return undefined;
+        }
+
         if (G.isNotNullable(deviceReleaseInfo)) {
             const isUpgradable = deviceReleaseInfo.isNewer ?? false;
 


### PR DESCRIPTION
Fixes FW update UI so it reflects the `Firmware update` feature flag value.

## Screenshots:

###BEFORE:
![Snímek obrazovky 2024-12-19 v 9 17 59](https://github.com/user-attachments/assets/4989c6d1-25cb-4b6f-8c88-fe781ee1626a)


### AFTER:
![Snímek obrazovky 2024-12-19 v 9 18 06](https://github.com/user-attachments/assets/8020b49f-8354-4203-a12b-4f25074a77bc)

