### PR TITLE
fix(suite): don't show hidden token balance in portfolio balance

### DIFF
--- a/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketBuildAccountGroups.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketBuildAccountGroups.ts
@@ -18,7 +18,7 @@ export const useCoinmarketBuildAccountGroups = (
     const accountLabels = useSelector(selectAccountLabels);
     const device = useSelector(selectSelectedDevice);
     const { getDefaultAccountLabel } = useDefaultAccountLabel();
-    const { tokenDefinitions } = useSelector(state => state);
+    const tokenDefinitions = useSelector(state => state.tokenDefinitions);
     const supportedSymbols = useSelector(selectSupportedSymbols(type));
 
     const groups = useMemo(

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
@@ -15,6 +15,8 @@ import { useFastAccounts } from 'src/hooks/wallet';
 import { goto } from 'src/actions/suite/routerActions';
 import { setFlag } from 'src/actions/suite/suiteActions';
 import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
+import { getTokens } from 'src/utils/wallet/tokenUtils';
+import { Account } from 'src/types/wallet';
 
 import { PortfolioCardHeader } from './PortfolioCardHeader';
 import { PortfolioCardException } from './PortfolioCardException';
@@ -47,9 +49,17 @@ export const PortfolioCard = memo(() => {
     const dispatch = useDispatch();
     const { device } = useDevice();
 
+    const tokenDefinitions = useSelector(state => state.tokenDefinitions);
+    const deviceAccounts: Account[] = accounts.map(account => {
+        const coinDefinitions = tokenDefinitions?.[account.symbol]?.coin;
+        const tokens = getTokens(account.tokens ?? [], account.symbol, coinDefinitions);
+
+        return { ...account, tokens: tokens.shownWithBalance };
+    });
+
     const isDeviceEmpty = useMemo(() => accounts.every(a => a.empty), [accounts]);
     const fiatAmount = getTotalFiatBalance({
-        deviceAccounts: accounts,
+        deviceAccounts,
         localCurrency,
         rates: currentFiatRates,
     }).toString();


### PR DESCRIPTION
## Description

When a token is hidden, don't show its balance in the total portfolio balance in the dashboard.

## Related Issue

Resolve #15199 

## Screenshots:

Initial portfolio balance.

<img width="807" alt="Screenshot 2024-12-19 at 11 42 37" src="https://github.com/user-attachments/assets/f66046d6-07ce-47a6-a14b-48e919e4521e" />

I hid this token with large balance.

<img width="977" alt="Screenshot 2024-12-19 at 11 42 55" src="https://github.com/user-attachments/assets/998c31b6-e953-40e8-9ee5-2cb4d3f0bc4a" />

I go back to the dashboard and the token's balance is no longer a part of the total portfolio balance.

<img width="577" alt="Screenshot 2024-12-19 at 11 43 17" src="https://github.com/user-attachments/assets/1968ecb8-24a4-4940-bce3-69afbe0d31fc" />


