### PR TITLE
Display gas price for token transaction when not enough Eth balance 

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5426,6 +5426,11 @@ export default defineMessages({
         defaultMessage: 'Not enough {symbol} to cover transaction fee',
         id: 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE',
     },
+
+    AMOUNT_NOT_ENOUGH_CURRENCY_FEE_WITH_ETH_AMOUNT: {
+        defaultMessage: 'Not enough {symbol} to cover transaction fee {feeAmount}',
+        id: 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE_WITH_ETH_AMOUNT',
+    },
     REMAINING_BALANCE_LESS_THAN_RENT: {
         defaultMessage:
             'After sending this amount, your account will have {remainingSolBalance} SOL remaining. A non-empty account must maintain a balance of more than {rent} SOL.',

--- a/suite-common/wallet-types/src/transaction.ts
+++ b/suite-common/wallet-types/src/transaction.ts
@@ -32,7 +32,8 @@ type PrecomposedTransactionErrorExtended =
               | 'AMOUNT_IS_TOO_LOW'
               | 'AMOUNT_IS_LESS_THAN_RESERVE'
               | 'TR_STAKE_NOT_ENOUGH_FUNDS'
-              | 'REMAINING_BALANCE_LESS_THAN_RENT';
+              | 'REMAINING_BALANCE_LESS_THAN_RENT'
+              | 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE_WITH_ETH_AMOUNT';
       };
 
 export type PrecomposedTransactionCardanoNonFinal =

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -75,21 +75,31 @@ export const calculateMax = (availableBalance: string, fee: string): string => {
 
 // ETH SPECIFIC
 
-/*
-    Calculate fee from gas price and gas limit
+/**
+ * Calculate the Ethereum fee from gas price and gas limit.
+ * @param {string} [gasPrice] - The gas price in wei.
+ * @param {string} [gasLimit] - The gas limit.
+ * @returns {string} The calculated fee in wei, or '0' if inputs are invalid.
  */
 export const calculateEthFee = (gasPrice?: string, gasLimit?: string): string => {
     if (!gasPrice || !gasLimit) {
         return '0';
     }
-    try {
-        const result = new BigNumber(gasPrice).times(gasLimit);
-        if (result.isNaN()) throw new Error('NaN');
 
-        return result.toFixed();
-    } catch {
+    const gasPriceBN = new BigNumber(gasPrice);
+    const gasLimitBN = new BigNumber(gasLimit);
+
+    if (gasPriceBN.isNaN() || gasLimitBN.isNaN()) {
         return '0';
     }
+
+    const fee = gasPriceBN.times(gasLimitBN);
+
+    if (fee.isNaN()) {
+        return '0';
+    }
+
+    return fee.toFixed();
 };
 
 const getSerializedAmount = (amount?: string) =>


### PR DESCRIPTION
## Description

Now users can see ow much Eth they need for a token transaction, when they don't have enough 

## Related Issue 

Resolve https://github.com/trezor/trezor-suite/issues/15219

## Screenshots:
Before:
<img width="613" alt="Screenshot 2024-12-19 at 15 30 52" src="https://github.com/user-attachments/assets/0198bae6-bfbe-4c73-9939-b6146e0b933a" />

After:
<img width="648" alt="Screenshot 2024-12-19 at 15 26 04" src="https://github.com/user-attachments/assets/d68c70d3-ac02-4a5f-ae9f-1acbef5cd7ed" />
<img width="613" alt="Screenshot 2024-12-19 at 15 29 30" src="https://github.com/user-attachments/assets/51aa52a8-e8d9-4859-bab2-e3b492356540" />
