### PR TITLE
fix(suite-native): remove android foreground permissions

### DIFF
--- a/suite-native/app/app.config.ts
+++ b/suite-native/app/app.config.ts
@@ -222,6 +222,8 @@ export default ({ config }: ConfigContext): ExpoConfig => {
                     category: ['BROWSABLE', 'DEFAULT'],
                 },
             ],
+            // These permission are included by expo-video, but we don't need them. The video is always played when is the app open and user is on the specific screen.
+            blockedPermissions: ['FOREGROUND_SERVICE', 'FOREGROUND_SERVICE_MEDIA_PLAYBACK'],
         },
         ios: {
             bundleIdentifier,


### PR DESCRIPTION
Fixes the Android Google Play Foreground service permissions declaration issue:
![Snímek obrazovky 2024-12-19 v 12 59 11](https://github.com/user-attachments/assets/3621afe6-3363-4bd8-a54c-eb573f86e19d)

Builded production app does not contain the problematic permission in the AndroidManifest.xml file anymore.

Inspired by https://github.com/expo/expo/issues/26846