### PR TITLE
Remove useless scrollbar from sidebar

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Sidebar.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Sidebar.tsx
@@ -18,6 +18,7 @@ import { setSidebarWidth as setSidebarWidthInRedux } from '../../../../../action
 import { useResponsiveContext } from '../../../../../support/suite/ResponsiveContext';
 
 const Container = styled.nav<{ $elevation: Elevation }>`
+    overflow-x: hidden;
     display: flex;
     container-type: inline-size;
     flex-direction: column;


### PR DESCRIPTION
## Description

When device selector animation was playing (e.g. when adding new passphrase wallet), ugly scrollbar was briefly displayed at the bottom of sidebar. This should fix it.
