### PR TITLE
fix: show h instead of apostrophe in taproot xpub to be consistent with firmware

### DIFF
--- a/packages/connect/src/device/__tests__/resolveDescriptorForTaproot.test.ts
+++ b/packages/connect/src/device/__tests__/resolveDescriptorForTaproot.test.ts
@@ -85,7 +85,7 @@ describe(resolveDescriptorForTaproot.name, () => {
         });
 
         expect(response).toEqual({
-            checksum: undefined, // code is defensive, it will work but it wont provide checksum
+            checksum: undefined, // code is defensive, it will work but it won't provide checksum
             xpub: "tr([71d98c03/86'/0'/0']xpub6CXYpDGLuWpjqFXRTbo8LMYVsiiRjwWiDY7iwDkq1mk4GDYE7TWmSBCnNmbcVYQK4T56RZRRwhCAG7ucTBHAG2rhWHpXdMQtkZVDeVuv33p/<0;1>/*)",
         });
     });

--- a/packages/connect/src/exports.ts
+++ b/packages/connect/src/exports.ts
@@ -3,3 +3,6 @@ export * from './events';
 export * from './types';
 
 export { parseConnectSettings } from './data/connectSettings';
+
+// Do NOT add any code exports here. Only TrezorConnect and types shall be exported from
+// `@trezor/connect` package.

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmXpubModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmXpubModal.tsx
@@ -1,4 +1,5 @@
 import { selectSelectedDevice } from '@suite-common/wallet-core';
+import { convertTaprootXpub } from '@trezor/utils';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 
 import { Translation } from 'src/components/suite';
@@ -27,6 +28,13 @@ export const ConfirmXpubModal = (
             ? `${account.descriptor}#${account.descriptorChecksum}`
             : account.descriptor;
 
+    // Suite internally uses apostrophe, but FW uses 'h' for taproot descriptors,
+    // and we want to show it correctly to the user
+    const xpubWithReplacedApostropheWithH = convertTaprootXpub({
+        xpub,
+        direction: 'apostrophe-to-h',
+    });
+
     return (
         <ConfirmValueModal
             account={account}
@@ -47,7 +55,7 @@ export const ConfirmXpubModal = (
             confirmStepLabel={<Translation id="TR_XPUB_MATCH" />}
             validateOnDevice={showXpub}
             copyButtonText={<Translation id="TR_XPUB_MODAL_CLIPBOARD" />}
-            value={xpub}
+            value={xpubWithReplacedApostropheWithH ?? xpub}
             displayMode={DisplayMode.PAGINATED_TEXT}
             {...props}
         />

--- a/packages/utils/src/convertTaprootXpub.ts
+++ b/packages/utils/src/convertTaprootXpub.ts
@@ -1,0 +1,27 @@
+// Todo: one day, we shall purify the @trezor/utils and remove domain-specific stuff from it
+
+export type ConvertTaprootXpubParams = {
+    xpub: string;
+    direction: 'h-to-apostrophe' | 'apostrophe-to-h';
+};
+
+export const convertTaprootXpub = ({ xpub, direction }: ConvertTaprootXpubParams) => {
+    const find = direction === 'h-to-apostrophe' ? 'h' : "'";
+    const replace = direction === 'h-to-apostrophe' ? "'" : 'h';
+
+    const openingSquareBracketSplit = xpub.split('[');
+    if (openingSquareBracketSplit.length === 2) {
+        const [beforeOpeningBracket, afterOpeningBracket] = openingSquareBracketSplit;
+
+        const closingSquareBracketSplit = afterOpeningBracket.split(']');
+        if (closingSquareBracketSplit.length === 2) {
+            const [path, afterClosingBracket] = closingSquareBracketSplit;
+
+            const correctedPath = path.replace(new RegExp(find, 'g'), replace); // .replaceAll()
+
+            return `${beforeOpeningBracket}[${correctedPath}]${afterClosingBracket}`;
+        }
+    }
+
+    return null;
+};

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -51,3 +51,4 @@ export * from './isFullPath';
 export * from './asciiUtils';
 export * from './resolveAfter';
 export * from './zip';
+export * from './convertTaprootXpub';

--- a/packages/utils/src/parseElectrumUrl.ts
+++ b/packages/utils/src/parseElectrumUrl.ts
@@ -1,3 +1,5 @@
+// Todo: one day, we shall purify the @trezor/utils and remove domain-specific stuff from it
+
 // URL is in format host:port:[t|s] (t for tcp, s for ssl)
 const ELECTRUM_URL_REGEX = /^(?:([a-zA-Z0-9.-]+)|\[([a-f0-9:]+)\]):([0-9]{1,5}):([ts])$/;
 


### PR DESCRIPTION
Resolves: https://github.com/trezor/trezor-suite/issues/15277

![image](https://github.com/user-attachments/assets/0e6a5ad3-be69-4288-8e5a-8f3032914ee5)
