### PR TITLE
feat(suite): added reusable hook for total portfolio balance

### DIFF
--- a/packages/suite/src/hooks/wallet/useTotalFiatBalance.ts
+++ b/packages/suite/src/hooks/wallet/useTotalFiatBalance.ts
@@ -13,7 +13,11 @@ export const useTotalFiatBalance = (
     const tokenDefinitions = useSelector(state => state.tokenDefinitions);
     const deviceAccounts: Account[] = accounts.map(account => {
         const coinDefinitions = tokenDefinitions?.[account.symbol]?.coin;
-        const tokens = getTokens(account.tokens ?? [], account.symbol, coinDefinitions);
+        const tokens = getTokens({
+            tokens: account.tokens ?? [],
+            symbol: account.symbol,
+            tokenDefinitions: coinDefinitions,
+        });
 
         return { ...account, tokens: tokens.shownWithBalance };
     });

--- a/packages/suite/src/hooks/wallet/useTotalFiatBalance.ts
+++ b/packages/suite/src/hooks/wallet/useTotalFiatBalance.ts
@@ -1,0 +1,28 @@
+import { FiatCurrencyCode } from '@suite-common/suite-config/src/fiat';
+import { Account, RatesByKey } from '@suite-common/wallet-types';
+import { getTotalFiatBalance } from '@suite-common/wallet-utils/src/accountUtils';
+
+import { useSelector } from 'src/hooks/suite';
+import { getTokens } from 'src/utils/wallet/tokenUtils';
+
+export const useTotalFiatBalance = (
+    accounts: Account[],
+    localCurrency: FiatCurrencyCode,
+    rates?: RatesByKey,
+) => {
+    const tokenDefinitions = useSelector(state => state.tokenDefinitions);
+    const deviceAccounts: Account[] = accounts.map(account => {
+        const coinDefinitions = tokenDefinitions?.[account.symbol]?.coin;
+        const tokens = getTokens(account.tokens ?? [], account.symbol, coinDefinitions);
+
+        return { ...account, tokens: tokens.shownWithBalance };
+    });
+
+    const totalFiatBalance = getTotalFiatBalance({
+        deviceAccounts,
+        localCurrency,
+        rates,
+    }).toString();
+
+    return totalFiatBalance;
+};

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
@@ -8,7 +8,7 @@ import {
     createDiscoveryThunk,
 } from '@suite-common/wallet-core';
 import { Card, Icon, Tooltip, Row, Column, Text, Divider, Box } from '@trezor/components';
-import { getAllAccounts, getTotalFiatBalance } from '@suite-common/wallet-utils';
+import { getAllAccounts } from '@suite-common/wallet-utils';
 import { spacings, negativeSpacings } from '@trezor/theme';
 
 import { WalletLabeling, Translation, MetadataLabeling } from 'src/components/suite';
@@ -19,6 +19,7 @@ import { METADATA_LABELING } from 'src/actions/suite/constants';
 import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
 import { FiatHeader } from 'src/components/wallet/FiatHeader';
 import { redirectAfterWalletSelectedThunk } from 'src/actions/wallet/addWalletThunk';
+import { useTotalFiatBalance } from 'src/hooks/wallet/useTotalFiatBalance';
 
 import { useWalletLabeling } from '../../../../components/suite/labeling/WalletLabeling';
 import { EjectConfirmation, EjectConfirmationDisableViewOnly } from './EjectConfirmation';
@@ -55,11 +56,9 @@ export const WalletInstance = ({
     const { defaultAccountLabelString } = useWalletLabeling();
 
     const deviceAccounts = getAllAccounts(instance.state, accounts);
-    const instanceBalance = getTotalFiatBalance({
-        deviceAccounts,
-        localCurrency,
-        rates: currentFiatRates,
-    });
+
+    const walletBalance = useTotalFiatBalance(deviceAccounts, localCurrency, currentFiatRates);
+
     const isSelected = enabled && selected && !!discoveryProcess;
     const { walletLabel } = useSelector(state =>
         selectLabelingDataForWallet(state, instance.state),
@@ -174,7 +173,7 @@ export const WalletInstance = ({
                     </Text>
 
                     <FiatHeader
-                        amount={instanceBalance.toString()}
+                        amount={walletBalance}
                         size="medium"
                         localCurrency={localCurrency}
                     />


### PR DESCRIPTION
## Description

Created a reusable hook for retrieving total portfolio fiat balance, which is reused in several places.

## Related Issue

Resolve #16075 

## Screenshots:
<img width="490" alt="Screenshot 2024-12-20 at 11 44 03" src="https://github.com/user-attachments/assets/3f260cdc-b7b5-439c-bd80-f50400366c9a" />

<img width="467" alt="Screenshot 2024-12-20 at 11 44 09" src="https://github.com/user-attachments/assets/6799f584-18cc-46e8-ad39-52a9deeade07" />
