### PR TITLE
fix: show proper info for unspendable coinbase transactions

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5805,6 +5805,11 @@ export default defineMessages({
         defaultMessage: 'Rejected by coordinator',
         description: 'Tooltip over an icon in Coin control section',
     },
+    TR_UTXO_NOT_MATURED_COINBASE: {
+        id: 'TR_UTXO_NOT_MATURED_COINBASE',
+        defaultMessage:
+            'Coinbase transaction has to have at least {confirmations} confirmations to be spendable',
+    },
     TR_CHANGE_ADDRESS_TOOLTIP: {
         id: 'TR_CHANGE_ADDRESS_TOOLTIP',
         defaultMessage: 'This is a change address created from a previous send.',

--- a/packages/utxo-lib/src/coinselect/coinselectUtils.ts
+++ b/packages/utxo-lib/src/coinselect/coinselectUtils.ts
@@ -39,6 +39,9 @@ const INPUT_SIZE = 160; // 4 * (32 + 4 + 4)
 
 const DUST_RELAY_FEE_RATE = 3; // 3000 sat/kB https://github.com/bitcoin/bitcoin/blob/be443328037162f265cc85d05b1a7665b5f104d2/src/policy/policy.h#L55
 
+/** Coinbase transaction must have at least 100 confirmations to be spendable.*/
+export const MINIMAL_COINBASE_CONFIRMATIONS = 100;
+
 type Vin = { type: CoinSelectInput['type']; script: { length: number }; weight?: number };
 type VinVout = { script: { length: number }; weight?: number };
 

--- a/packages/utxo-lib/src/coinselect/outputs/split.ts
+++ b/packages/utxo-lib/src/coinselect/outputs/split.ts
@@ -8,6 +8,7 @@ import {
     getFee,
     finalize,
     ZERO,
+    MINIMAL_COINBASE_CONFIRMATIONS,
 } from '../coinselectUtils';
 import {
     CoinSelectInput,
@@ -23,7 +24,7 @@ export function split(
     feeRate: number,
     options: CoinSelectOptions,
 ): CoinSelectResult {
-    const coinbase = options.coinbase || 100;
+    const coinbase = options.coinbase || MINIMAL_COINBASE_CONFIRMATIONS;
     const utxos = filterCoinbase(utxosOrig, coinbase);
 
     const fee = getFee(utxos, outputs, feeRate, options);

--- a/packages/utxo-lib/src/coinselect/tryconfirmed.ts
+++ b/packages/utxo-lib/src/coinselect/tryconfirmed.ts
@@ -1,4 +1,4 @@
-import { filterCoinbase } from './coinselectUtils';
+import { filterCoinbase, MINIMAL_COINBASE_CONFIRMATIONS } from './coinselectUtils';
 import { CoinSelectAlgorithm, CoinSelectOptions, CoinSelectInput } from '../types';
 
 function filterUtxos(utxos: CoinSelectInput[], minConfOwn: number, minConfOther: number) {
@@ -31,7 +31,7 @@ export function tryConfirmed(
 ): CoinSelectAlgorithm {
     const own = options.own || 1;
     const other = options.other || 6;
-    const coinbase = options.coinbase || 100;
+    const coinbase = options.coinbase || MINIMAL_COINBASE_CONFIRMATIONS;
 
     return (utxosO, outputs, feeRate, optionsIn) => {
         const utxos = filterCoinbase(utxosO, coinbase);


### PR DESCRIPTION
Resolve: https://github.com/trezor/trezor-suite/issues/14270

![image](https://github.com/user-attachments/assets/dc23f2bd-fb9e-4330-824d-f2eda464f65e)