### PR TITLE
fix(suite): fixed receive account select cannot be closed

### DIFF
--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketVerifyAccount.tsx
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketVerifyAccount.tsx
@@ -156,7 +156,6 @@ const useCoinmarketVerifyAccount = ({
 
     const onChangeAccount = (account: CoinmarketVerifyFormAccountOptionProps) => {
         if (account.type === 'ADD_SUITE' && device) {
-            setIsMenuOpen(true);
             dispatch(
                 openModal({
                     type: 'add-account',
@@ -181,7 +180,7 @@ const useCoinmarketVerifyAccount = ({
             selectAccountOption(preselectedAccount);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+    }, [accounts]);
 
     useEffect(() => {
         methods.trigger();


### PR DESCRIPTION
## Description

When selecting "Create new account" in receive account select and then closing the modal (without selecting any account), the select cannot be closed and overlaps the receive address input. This PR fixes this issue.

## Related Issue

Resolve #14845 

## Screenshots:

https://github.com/user-attachments/assets/fbe496c1-6637-42f9-9b9f-de9e9baffc8b


