### PR TITLE
Use Tor daemon from Tor browser experimental

### DIFF
--- a/packages/request-manager/src/controllerExternal.ts
+++ b/packages/request-manager/src/controllerExternal.ts
@@ -40,6 +40,10 @@ export class TorControllerExternal extends EventEmitter {
         this.status = TOR_CONTROLLER_STATUS.ExternalTorRunning;
     }
 
+    public updatePort(port: number) {
+        this.options.port = port;
+    }
+
     public getTorConfiguration() {
         return '';
     }

--- a/packages/suite-desktop-api/src/factory.ts
+++ b/packages/suite-desktop-api/src/factory.ts
@@ -125,7 +125,9 @@ export const factory = <R extends StrictIpcRenderer<any, IpcRendererEvent>>(
         getTorSettings: () => ipcRenderer.invoke('tor/get-settings'),
 
         changeTorSettings: payload => {
-            if (validation.isObject({ useExternalTor: 'boolean' }, payload)) {
+            if (
+                validation.isObject({ useExternalTor: 'boolean', externalPort: 'number' }, payload)
+            ) {
                 return ipcRenderer.invoke('tor/change-settings', payload);
             }
 

--- a/packages/suite-desktop-api/src/messages.ts
+++ b/packages/suite-desktop-api/src/messages.ts
@@ -55,6 +55,7 @@ export type HandshakeTorModule = {
 
 export type TorSettings = {
     useExternalTor: boolean;
+    externalPort: number;
 };
 
 export type TraySettings = {

--- a/packages/suite-desktop-core/src/index.d.ts
+++ b/packages/suite-desktop-core/src/index.d.ts
@@ -113,6 +113,7 @@ declare type TorSettings = {
     controlPort: number; // Port of the Tor Control Port
     torDataDir: string; // Path of tor data directory
     useExternalTor: boolean; // Tor should use external daemon instead of the one built-in suite.
+    externalPort: number; // Tor external port.
 };
 
 declare type BridgeSettings = {

--- a/packages/suite-desktop-core/src/libs/processes/TorExternalProcess.ts
+++ b/packages/suite-desktop-core/src/libs/processes/TorExternalProcess.ts
@@ -4,16 +4,20 @@ import { Status } from './BaseProcess';
 
 export type TorProcessStatus = Status & { isBootstrapping?: boolean };
 
-const DEFAULT_TOR_EXTERNAL_HOST = '127.0.0.1';
-const DEFAULT_TOR_EXTERNAL_PORT = 9050;
-
 export class TorExternalProcess {
     isStopped = true;
     torController: TorControllerExternal;
-    port = DEFAULT_TOR_EXTERNAL_PORT;
-    host = DEFAULT_TOR_EXTERNAL_HOST;
-    constructor() {
+    port: number;
+    host: string;
+    constructor({ port, host }: { port: number; host: string }) {
+        this.port = port;
+        this.host = host;
         this.torController = new TorControllerExternal({ host: this.host, port: this.port });
+    }
+
+    public updatePort(port: number) {
+        this.port = port;
+        this.torController.updatePort(port);
     }
 
     public getPort() {

--- a/packages/suite-desktop-core/src/libs/processes/TorProcess.ts
+++ b/packages/suite-desktop-core/src/libs/processes/TorProcess.ts
@@ -28,6 +28,10 @@ export class TorProcess extends BaseProcess {
         });
     }
 
+    public updatePort(port: number) {
+        this.port = port;
+    }
+
     public getPort() {
         return this.port;
     }

--- a/packages/suite-desktop-core/src/libs/store.ts
+++ b/packages/suite-desktop-core/src/libs/store.ts
@@ -66,6 +66,7 @@ export class Store {
             controlPort: 9051,
             host: '127.0.0.1',
             useExternalTor: false,
+            externalPort: 9050,
             torDataDir: '',
         });
     }

--- a/packages/suite-desktop-core/src/modules/trezor-connect.ts
+++ b/packages/suite-desktop-core/src/modules/trezor-connect.ts
@@ -12,8 +12,10 @@ export const initBackground: ModuleInitBackground = ({ mainThreadEmitter, store 
     logger.info(SERVICE_NAME, `Starting service`);
 
     const setProxy = () => {
-        const { running, host, port } = store.getTorSettings();
-        const payload = running ? { proxy: `socks://${host}:${port}` } : { proxy: '' };
+        const { running, host, port, externalPort, useExternalTor } = store.getTorSettings();
+        const payload = running
+            ? { proxy: `socks://${host}:${useExternalTor ? externalPort : port}` }
+            : { proxy: '' };
         logger.info(SERVICE_NAME, `${running ? 'Enable' : 'Disable'} proxy ${payload.proxy}`);
 
         return TrezorConnect.setProxy(payload);

--- a/packages/suite/src/constants/suite/anchors.ts
+++ b/packages/suite/src/constants/suite/anchors.ts
@@ -6,6 +6,7 @@ export const enum SettingsAnchor {
     LabelingDisconnect = '@general-settings/labeling-disconnect',
     LabelingConnect = '@general-settings/labeling-connect',
     Tor = '@general-settings/tor',
+    TorExternal = '@general-settings/tor-external',
     TorOnionLinks = '@general-settings/tor-onion-links',
     Theme = '@general-settings/theme',
     AddressDisplay = '@general-settings/address-display',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5040,6 +5040,15 @@ export default defineMessages({
         defaultMessage:
             'Allows you to use Tor daemon running in a external process on port 9050 instead of the one bundled with Trezor Suite.',
     },
+    TR_EXPERIMENTAL_TOR_EXTERNAL_PORT: {
+        id: 'TR_EXPERIMENTAL_TOR_EXTERNAL_PORT',
+        defaultMessage: 'Tor external port',
+    },
+    TR_EXPERIMENTAL_TOR_EXTERNAL_PORT_DESCRIPTION: {
+        id: 'TR_EXPERIMENTAL_TOR_EXTERNAL_PORT_DESCRIPTION',
+        defaultMessage:
+            'Allows you to use Tor daemon running in a external process instead of the one bundled with Trezor Suite.',
+    },
     TR_EARLY_ACCESS: {
         id: 'TR_EARLY_ACCESS',
         defaultMessage: 'Early Access Program',

--- a/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
@@ -7,6 +7,7 @@ import { useLayoutSize, useSelector } from 'src/hooks/suite';
 import {
     selectIsSettingsDesktopAppPromoBannerShown,
     selectTorState,
+    selectHasExperimentalFeature,
 } from 'src/reducers/suite/suiteReducer';
 import { selectEnabledNetworks } from 'src/reducers/wallet/settingsReducer';
 import { selectSelectedProviderForLabels } from 'src/reducers/suite/metadataReducer';
@@ -32,6 +33,7 @@ import { Experimental } from './Experimental';
 import { AutomaticUpdate } from './AutomaticUpdate';
 import { AutoStart } from './AutoStart';
 import { ShowOnTray } from './ShowOnTray';
+import { TorExternal } from './TorExternal';
 
 export const SettingsGeneral = () => {
     const shouldShowSettingsDesktopAppPromoBanner = useSelector(
@@ -49,6 +51,10 @@ export const SettingsGeneral = () => {
 
         return networkFeatures.includes('amount-unit');
     });
+
+    const torExternalExperimentalFeature = useSelector(
+        selectHasExperimentalFeature('tor-external'),
+    );
 
     const isMetadataEnabled = metadata.enabled && !metadata.initiating;
     const isProviderConnected = useSelector(selectSelectedProviderForLabels);
@@ -80,6 +86,7 @@ export const SettingsGeneral = () => {
                 <SettingsSection title={<Translation id="TR_TOR" />} icon="torBrowser">
                     {isDesktop() && <Tor />}
                     {isTorEnabled && <TorOnionLinks />}
+                    {torExternalExperimentalFeature && <TorExternal />}
                 </SettingsSection>
             )}
 

--- a/packages/suite/src/views/settings/SettingsGeneral/TorExternal.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/TorExternal.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useState } from 'react';
+
+import { TorSettings } from '@trezor/suite-desktop-api/src/messages';
+import { desktopApi } from '@trezor/suite-desktop-api';
+
+import { ActionColumn, ActionSelect, TextColumn, Translation } from 'src/components/suite';
+import { selectTorState } from 'src/reducers/suite/suiteReducer';
+import { useSelector } from 'src/hooks/suite';
+import { SettingsSectionItem } from 'src/components/settings';
+import { SettingsAnchor } from 'src/constants/suite/anchors';
+
+const options = [
+    {
+        value: 9050,
+        label: 'Tor external (9050)',
+    },
+    {
+        value: 9150,
+        label: 'Tor browser (9150)',
+    },
+];
+
+export const TorExternal = () => {
+    const { isTorEnabled } = useSelector(selectTorState);
+
+    const [torSettings, setTorSettings] = useState<TorSettings | null>(null);
+
+    const [selectedOption, setSelectedOption] = useState<{ value: number; label: string }>(
+        options[0],
+    );
+
+    useEffect(() => {
+        const fetchTorSettings = async () => {
+            const result = await desktopApi.getTorSettings();
+            if (result.success) {
+                setTorSettings(result.payload);
+            }
+        };
+
+        fetchTorSettings();
+
+        const handleTorSettingsChange = (settings: TorSettings) => setTorSettings(settings);
+        desktopApi.on('tor/settings', handleTorSettingsChange);
+
+        return () => {
+            desktopApi.removeAllListeners('tor/settings');
+        };
+    }, []);
+
+    useEffect(() => {
+        if (!torSettings) return;
+        const { externalPort } = torSettings;
+        const selectedOption = options.find(o => o.value === externalPort);
+        setSelectedOption(selectedOption!);
+    }, [torSettings]);
+
+    const onChange = async ({ value }: { value: number }) => {
+        if (!torSettings) return;
+        await desktopApi.changeTorSettings({
+            ...torSettings,
+            externalPort: value,
+        });
+    };
+
+    if (!torSettings) return null;
+
+    return (
+        <SettingsSectionItem anchorId={SettingsAnchor.TorExternal}>
+            <TextColumn
+                title={<Translation id="TR_EXPERIMENTAL_TOR_EXTERNAL_PORT" />}
+                description={<Translation id="TR_EXPERIMENTAL_TOR_EXTERNAL_PORT_DESCRIPTION" />}
+            />
+            <ActionColumn>
+                <ActionSelect
+                    useKeyPressScroll
+                    value={selectedOption}
+                    options={options}
+                    onChange={onChange}
+                    isDisabled={isTorEnabled}
+                />
+            </ActionColumn>
+        </SettingsSectionItem>
+    );
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Allow user to configure Tor External Port to use "Custom Tor (9050)" or "Tor Browser (9150)
The main idea of this is to make the usage of external Tor daemon easier. In case use wants to use Tor daemon from Tor Browser with some Tor bridge they can. So they do not have do it themselves and they can for example configure snowflake in Tor Browser and use it in Trezor Suite.

We can change the UI how it is presented to the user. And we need to update documentation, but this makes it all quite easier for user.

:thinking: 
I am thinking if adding new option to the select (Tor bundled) will make it better, like:

* Tor bundled
* Tor external custom (9050)
* Tor from Tor browser (9150)

I haven't done it like that since Tor Bundled is used when Tor external is disabled.

## Screenshots:

![image](https://github.com/user-attachments/assets/81732f1e-16b2-4692-9825-e2cae3eb7d83)

