### PR TITLE
feat(suite): show gas price before staking amount is provided

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ClaimModal/ClaimModal.tsx
@@ -123,7 +123,6 @@ export const ClaimModal = ({ onCancel }: ClaimModalModalProps) => {
                             composedLevels={composedLevels}
                             changeFeeLevel={changeFeeLevel}
                             helperText={<Translation id="TR_STAKE_PAID_FROM_BALANCE" />}
-                            showFeeWhilePending={true}
                         />
                     </Card>
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/StakeEthForm.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/StakeEthForm.tsx
@@ -55,7 +55,6 @@ export const StakeEthForm = () => {
                         composedLevels={composedLevels}
                         changeFeeLevel={changeFeeLevel}
                         helperText={<Translation id="TR_STAKE_PAID_FROM_BALANCE" />}
-                        showFeeWhilePending={false}
                     />
                 </Card>
             </Column>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/Fees.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/Fees.tsx
@@ -37,7 +37,6 @@ const UnstakeFees = () => {
                 composedLevels={composedLevels}
                 changeFeeLevel={changeFeeLevel}
                 helperText={<Translation id="TR_STAKE_PAID_FROM_BALANCE" />}
-                showFeeWhilePending={false}
             />
         </StyledCard>
     );

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/UnstakeEthForm.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/UnstakeEthForm.tsx
@@ -80,7 +80,6 @@ export const UnstakeEthForm = () => {
                         composedLevels={composedLevels}
                         changeFeeLevel={changeFeeLevel}
                         helperText={<Translation id="TR_STAKE_PAID_FROM_BALANCE" />}
-                        showFeeWhilePending={false}
                     />
                 </Card>
 

--- a/packages/suite/src/components/wallet/Fees/Fees.tsx
+++ b/packages/suite/src/components/wallet/Fees/Fees.tsx
@@ -66,7 +66,6 @@ export interface FeesProps<TFieldValues extends FormState> {
     label?: TranslationKey;
     rbfForm?: boolean;
     helperText?: React.ReactNode;
-    showFeeWhilePending?: boolean;
 }
 
 export const Fees = <TFieldValues extends FormState>({
@@ -79,7 +78,6 @@ export const Fees = <TFieldValues extends FormState>({
     label,
     rbfForm,
     helperText,
-    showFeeWhilePending = true,
     ...props
 }: FeesProps<TFieldValues>) => {
     // Type assertion allowing to make the component reusable, see https://stackoverflow.com/a/73624072.
@@ -95,8 +93,7 @@ export const Fees = <TFieldValues extends FormState>({
     // Solana has only `normal` fee level, so we do not display any feeOptions since there is nothing to choose from
     const feeOptions = networkType === 'solana' ? [] : buildFeeOptions(feeInfo.levels);
 
-    const showNormalFee = showFeeWhilePending || transactionInfo?.type === 'final';
-    const shouldAnimateNormalFee = showNormalFee && !isCustomLevel;
+    const shouldAnimateNormalFee = !isCustomLevel;
 
     return (
         <Column gap={spacings.xs}>
@@ -164,7 +161,7 @@ export const Fees = <TFieldValues extends FormState>({
                                     feeInfo={feeInfo}
                                     selectedLevel={selectedLevel}
                                     transactionInfo={transactionInfo}
-                                    showFee={showNormalFee}
+                                    showFee={true}
                                 />
                             </motion.div>
                         )}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Show gas price in each form with fees (send, sell, stake, unstake).

## Screenshots:

![image](https://github.com/user-attachments/assets/1e8460e7-535d-437f-8d88-c4edaf2e9929)

![image](https://github.com/user-attachments/assets/2f842e34-9f81-44cd-8a08-d16f07042c60)

![image](https://github.com/user-attachments/assets/0c1ff4fa-50a9-4162-93a4-63e9096d0996)

![image](https://github.com/user-attachments/assets/4b096bbf-eaf4-47f5-a25b-32fd6500b5d1)

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/13756
