### PR TITLE
feat(suite): add message system debug info

### DIFF
--- a/packages/suite/src/views/settings/SettingsDebug/MessageSystemDebugInfo.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/MessageSystemDebugInfo.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+
+import { Box, Button, ButtonGroup, Column, NewModal, Paragraph, Row } from '@trezor/components';
+import { selectAllValidMessages, selectMessageSystemConfig } from '@suite-common/message-system';
+import { copyToClipboard } from '@trezor/dom-utils';
+import { Message } from '@suite-common/suite-types';
+import { spacings } from '@trezor/theme';
+
+import { useSelector } from 'src/hooks/suite';
+
+const serializeCategory = (category: Message['category']): string =>
+    typeof category === 'string' ? category : category.join(', ');
+
+export const MessageSystemDebugInfo = () => {
+    const config = useSelector(selectMessageSystemConfig);
+    const allValidMessages = useSelector(selectAllValidMessages);
+
+    const [isModalOpen, setIsModalOpen] = useState(false);
+
+    const handleCopyConfig = () => {
+        if (config === null) return;
+        copyToClipboard(JSON.stringify(config));
+    };
+    const handleOpenValidMessages = () => setIsModalOpen(true);
+    const handleCloseValidMessages = () => setIsModalOpen(false);
+
+    return (
+        <>
+            <Row justifyContent="space-between">
+                <Box>
+                    <Paragraph>Sequence: {config?.sequence}</Paragraph>
+                    <Paragraph>Timestamp: {config?.timestamp}</Paragraph>
+                </Box>
+                <ButtonGroup size="small">
+                    <Button onClick={handleCopyConfig}>Copy full config</Button>
+                    <Button
+                        onClick={handleOpenValidMessages}
+                        isDisabled={allValidMessages.length === 0}
+                    >
+                        See active messages
+                    </Button>
+                </ButtonGroup>
+            </Row>
+            {isModalOpen && (
+                <NewModal onCancel={handleCloseValidMessages}>
+                    <Column gap={spacings.sm}>
+                        {allValidMessages.map(m => (
+                            <div key={m.id}>
+                                <Paragraph typographyStyle="highlight">
+                                    {m.id} ({serializeCategory(m.category)})
+                                </Paragraph>
+                                <Paragraph>{m.content.en}</Paragraph>
+                            </div>
+                        ))}
+                    </Column>
+                </NewModal>
+            )}
+        </>
+    );
+};

--- a/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
@@ -22,6 +22,7 @@ import { Backends } from './Backends';
 import { PreField } from './PreField';
 import { Tor } from './Tor';
 import { Metadata } from './Metadata';
+import { MessageSystemDebugInfo } from './MessageSystemDebugInfo';
 
 export const SettingsDebug = () => {
     const flags = useSelector(selectSuiteFlags);
@@ -79,6 +80,9 @@ export const SettingsDebug = () => {
             </SettingsSection>
             <SettingsSection title="Metadata">
                 <Metadata />
+            </SettingsSection>
+            <SettingsSection title="Message system info">
+                <MessageSystemDebugInfo />
             </SettingsSection>
         </SettingsLayout>
     );


### PR DESCRIPTION
## Description

Add a very brief message system debug info to Suite Debug settings.
Shamelessly stolen from [mobile](https://github.com/trezor/trezor-suite/blob/d800b0ef197783aefc9727dbc3b968cb6d0c4745/suite-native/module-dev-utils/src/components/MessageSystemInfo.tsx) :smiley: 
Because this is just a section of the Debug settings page, and not a standalone page, the list of active messages is in a modal, so as not to bloat it.

## Screenshots:

Debug settings after:
![Screenshot from 2024-12-20 19-11-38](https://github.com/user-attachments/assets/0e8df888-690c-4c39-9cd7-b125d4057625)

See active messages modal:
![Screenshot from 2024-12-20 19-11-45](https://github.com/user-attachments/assets/53d895ad-3d88-4a57-a046-2ab95ea0e59a)
