### PR TITLE
feat(suite): added banner to trading indicating disconnected device

### DIFF
--- a/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketDeviceDisconnected.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketDeviceDisconnected.ts
@@ -1,0 +1,18 @@
+import {
+    isCoinmarketExchangeContext,
+    isCoinmarketSellContext,
+} from 'src/utils/wallet/coinmarket/coinmarketTypingUtils';
+import { useCoinmarketFormContext } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonForm';
+
+export const useCoinmarketDeviceDisconnected = () => {
+    const context = useCoinmarketFormContext();
+    const { device } = context;
+
+    const isSellOrExchangeContext =
+        isCoinmarketSellContext(context) || isCoinmarketExchangeContext(context);
+    const isDeviceDisconnected = !device?.connected;
+
+    const coinmarketDeviceDisconnected = isSellOrExchangeContext && isDeviceDisconnected;
+
+    return { coinmarketDeviceDisconnected };
+};

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -9275,6 +9275,14 @@ export default defineMessages({
         id: 'TR_UNRECOGNIZED',
         defaultMessage: 'Unrecognized',
     },
+    TR_CONNECT_DEVICE_GENERIC_PROMO_TITLE: {
+        id: 'TR_CONNECT_DEVICE_GENERIC_PROMO_TITLE',
+        defaultMessage: 'Trezor disconnected',
+    },
+    TR_CONNECT_DEVICE_GENERIC_PROMO_DESCRIPTION: {
+        id: 'TR_CONNECT_DEVICE_GENERIC_PROMO_DESCRIPTION',
+        defaultMessage: 'To perform trade, connect your Trezor.',
+    },
     TR_CONNECT_DEVICE_SEND_PROMO_TITLE: {
         id: 'TR_CONNECT_DEVICE_SEND_PROMO_TITLE',
         defaultMessage: "Your Trezor isn't connected",

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormLayout.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormLayout.tsx
@@ -7,23 +7,31 @@ import { CoinmarketFormInputs } from 'src/views/wallet/coinmarket/common/Coinmar
 import { CoinmarketFormOffer } from 'src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormOffer';
 import { CoinmarketFeaturedOffers } from 'src/views/wallet/coinmarket/common/CoinmarketFeaturedOffers/CoinmarketFeaturedOffers';
 import { CoinmarketWrapper } from 'src/views/wallet/coinmarket/common/CoinmarketWrapper';
+import { ConnectDeviceGenericPromo } from 'src/views/wallet/receive/components/ConnectDevicePromo';
+import { useCoinmarketDeviceDisconnected } from 'src/hooks/wallet/coinmarket/form/common/useCoinmarketDeviceDisconnected';
 
 const CoinmarketFormLayoutWrapper = styled.form`
     ${CoinmarketWrapper}
 `;
 
-export const CoinmarketFormLayout = () => (
-    <Column gap={spacings.xxxxl} data-testid="@coinmarket/form">
-        <CoinmarketFormLayoutWrapper>
-            <Card>
-                <Column gap={spacings.lg}>
-                    <CoinmarketFormInputs />
-                </Column>
-            </Card>
-            <Card>
-                <CoinmarketFormOffer />
-            </Card>
-        </CoinmarketFormLayoutWrapper>
-        <CoinmarketFeaturedOffers />
-    </Column>
-);
+export const CoinmarketFormLayout = () => {
+    const { coinmarketDeviceDisconnected } = useCoinmarketDeviceDisconnected();
+
+    return (
+        <Column gap={spacings.md} data-testid="@coinmarket/form">
+            {coinmarketDeviceDisconnected && <ConnectDeviceGenericPromo />}
+
+            <CoinmarketFormLayoutWrapper>
+                <Card>
+                    <Column gap={spacings.lg}>
+                        <CoinmarketFormInputs />
+                    </Column>
+                </Card>
+                <Card>
+                    <CoinmarketFormOffer />
+                </Card>
+            </CoinmarketFormLayoutWrapper>
+            <CoinmarketFeaturedOffers />
+        </Column>
+    );
+};

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormOffer.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormOffer.tsx
@@ -29,6 +29,7 @@ import { CoinmarketFormContextValues } from 'src/types/coinmarket/coinmarketForm
 import { FORM_EXCHANGE_DEX, FORM_EXCHANGE_TYPE } from 'src/constants/wallet/coinmarket/form';
 import { useCoinmarketInfo } from 'src/hooks/wallet/coinmarket/useCoinmarketInfo';
 import { CoinmarketFormOffersSwitcher } from 'src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormOffersSwitcher';
+import { useCoinmarketDeviceDisconnected } from 'src/hooks/wallet/coinmarket/form/common/useCoinmarketDeviceDisconnected';
 
 const getSelectedQuote = (
     context: CoinmarketFormContextValues<CoinmarketTradeType>,
@@ -73,6 +74,8 @@ export const CoinmarketFormOffer = () => {
     const shouldDisplayFiatAmount = isCoinmarketExchangeContext(context) ? false : amountInCrypto;
     const { networkId, contractAddress } = parseCryptoId(selectedCrypto?.value ?? ('' as CryptoId));
     const network = selectedCrypto?.value ? cryptoIdToPlatformName(networkId) : undefined;
+
+    const { coinmarketDeviceDisconnected } = useCoinmarketDeviceDisconnected();
 
     return (
         <Column gap={spacings.lg}>
@@ -154,7 +157,7 @@ export const CoinmarketFormOffer = () => {
                     top: spacings.md,
                 }}
                 isFullWidth
-                isDisabled={state.isLoadingOrInvalid || !quote}
+                isDisabled={coinmarketDeviceDisconnected || state.isLoadingOrInvalid || !quote}
                 data-testid={`@coinmarket/form/${type}-button`}
             >
                 <Translation id={coinmarketGetSectionActionLabel(type)} />

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketOffers/CoinmarketOffers.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketOffers/CoinmarketOffers.tsx
@@ -1,3 +1,4 @@
+import { useCoinmarketDeviceDisconnected } from 'src/hooks/wallet/coinmarket/form/common/useCoinmarketDeviceDisconnected';
 import { useCoinmarketFormContext } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonForm';
 import { isCoinmarketExchangeContext } from 'src/utils/wallet/coinmarket/coinmarketTypingUtils';
 import { getBestRatedQuote } from 'src/utils/wallet/coinmarket/coinmarketUtils';
@@ -5,6 +6,7 @@ import { CoinmarketHeader } from 'src/views/wallet/coinmarket/common/CoinmarketH
 import { CoinmarketOffersEmpty } from 'src/views/wallet/coinmarket/common/CoinmarketOffers/CoinmarketOffersEmpty';
 import { CoinmarketOffersExchange } from 'src/views/wallet/coinmarket/common/CoinmarketOffers/CoinmarketOffersExchange';
 import { CoinmarketOffersItem } from 'src/views/wallet/coinmarket/common/CoinmarketOffers/CoinmarketOffersItem';
+import { ConnectDeviceGenericPromo } from 'src/views/wallet/receive/components/ConnectDevicePromo';
 
 export const CoinmarketOffers = () => {
     const context = useCoinmarketFormContext();
@@ -12,6 +14,8 @@ export const CoinmarketOffers = () => {
     const hasLoadingFailed = !quotes;
     const noOffers = hasLoadingFailed || quotes.length === 0;
     const bestRatedQuote = getBestRatedQuote(quotes, type);
+
+    const { coinmarketDeviceDisconnected } = useCoinmarketDeviceDisconnected();
 
     const offers = isCoinmarketExchangeContext(context) ? (
         <CoinmarketOffersExchange />
@@ -27,10 +31,13 @@ export const CoinmarketOffers = () => {
 
     return (
         <>
+            {coinmarketDeviceDisconnected && <ConnectDeviceGenericPromo />}
+
             <CoinmarketHeader
                 title="TR_COINMARKET_SHOW_OFFERS"
                 titleTimer="TR_COINMARKET_OFFERS_REFRESH"
             />
+
             {noOffers ? <CoinmarketOffersEmpty /> : offers}
         </>
     );

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketOffers/CoinmarketOffersItem.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketOffers/CoinmarketOffersItem.tsx
@@ -20,6 +20,7 @@ import { CoinmarketTestWrapper } from 'src/views/wallet/coinmarket';
 import { CoinmarketUtilsPrice } from 'src/views/wallet/coinmarket/common/CoinmarketUtils/CoinmarketUtilsPrice';
 import { CoinmarketUtilsProvider } from 'src/views/wallet/coinmarket/common/CoinmarketUtils/CoinmarketUtilsProvider';
 import { useCoinmarketFormContext } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonForm';
+import { useCoinmarketDeviceDisconnected } from 'src/hooks/wallet/coinmarket/form/common/useCoinmarketDeviceDisconnected';
 
 const Offer = styled.div`
     display: flex;
@@ -95,7 +96,7 @@ export interface CoinmarketOffersItemProps {
 export const CoinmarketOffersItem = ({ quote }: CoinmarketOffersItemProps) => {
     const theme = useTheme();
     const context = useCoinmarketFormContext();
-    const { device, callInProgress } = context;
+    const { callInProgress } = context;
     const providers = getProvidersInfoProps(context);
     const cryptoAmountProps = getCryptoQuoteAmountProps(quote, context);
     const { exchange } = quote;
@@ -103,6 +104,8 @@ export const CoinmarketOffersItem = ({ quote }: CoinmarketOffersItemProps) => {
     const tagsExist = tag !== '';
 
     const selectQuote = getSelectQuoteTyped(context);
+
+    const { coinmarketDeviceDisconnected } = useCoinmarketDeviceDisconnected();
 
     if (!cryptoAmountProps) return null;
 
@@ -152,7 +155,7 @@ export const CoinmarketOffersItem = ({ quote }: CoinmarketOffersItemProps) => {
                                 <Button
                                     isFullWidth
                                     isLoading={callInProgress}
-                                    isDisabled={!!quote.error || !device?.connected}
+                                    isDisabled={!!quote.error || coinmarketDeviceDisconnected}
                                     onClick={() => selectQuote(quote)}
                                     data-testid="@coinmarket/offers/get-this-deal-button"
                                 >

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOffer.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketSelectedOffer.tsx
@@ -1,5 +1,8 @@
 import styled from 'styled-components';
 
+import { Column } from '@trezor/components';
+import { spacings } from '@trezor/theme';
+
 import { useCoinmarketFormContext } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonForm';
 import {
     getCryptoQuoteAmountProps,
@@ -13,6 +16,8 @@ import { CoinmarketOfferSell } from 'src/views/wallet/coinmarket/common/Coinmark
 import { CoinmarketOfferBuy } from 'src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketOfferBuy/CoinmarketOfferBuy';
 import { CoinmarketOfferExchange } from 'src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketOfferExchange/CoinmarketOfferExchange';
 import { CoinmarketWrapper } from 'src/views/wallet/coinmarket/common/CoinmarketWrapper';
+import { useCoinmarketDeviceDisconnected } from 'src/hooks/wallet/coinmarket/form/common/useCoinmarketDeviceDisconnected';
+import { ConnectDeviceGenericPromo } from 'src/views/wallet/receive/components/ConnectDevicePromo';
 
 const Wrapper = styled.div`
     ${CoinmarketWrapper}
@@ -23,42 +28,48 @@ export const CoinmarketSelectedOffer = () => {
     const { account } = context;
     const providers = getProvidersInfoProps(context);
 
+    const { coinmarketDeviceDisconnected } = useCoinmarketDeviceDisconnected();
+
     if (!context.selectedQuote) return null;
 
     const quoteAmounts = getCryptoQuoteAmountProps(context.selectedQuote, context);
     const paymentMethod = getPaymentMethod(context.selectedQuote, context);
 
     return (
-        <Wrapper data-testid="@coinmarket/selected-offer">
-            {isCoinmarketBuyContext(context) && (
-                <CoinmarketOfferBuy
-                    account={account}
-                    selectedQuote={context.selectedQuote}
-                    providers={providers}
-                    type={context.type}
-                    quoteAmounts={quoteAmounts}
-                    {...paymentMethod}
-                />
-            )}
-            {isCoinmarketSellContext(context) && (
-                <CoinmarketOfferSell
-                    account={account}
-                    selectedQuote={context.selectedQuote}
-                    providers={providers}
-                    type={context.type}
-                    quoteAmounts={quoteAmounts}
-                    {...paymentMethod}
-                />
-            )}
-            {isCoinmarketExchangeContext(context) && (
-                <CoinmarketOfferExchange
-                    account={account}
-                    selectedQuote={context.selectedQuote}
-                    providers={providers}
-                    type={context.type}
-                    quoteAmounts={quoteAmounts}
-                />
-            )}
-        </Wrapper>
+        <Column gap={spacings.md}>
+            {coinmarketDeviceDisconnected && <ConnectDeviceGenericPromo />}
+
+            <Wrapper data-testid="@coinmarket/selected-offer">
+                {isCoinmarketBuyContext(context) && (
+                    <CoinmarketOfferBuy
+                        account={account}
+                        selectedQuote={context.selectedQuote}
+                        providers={providers}
+                        type={context.type}
+                        quoteAmounts={quoteAmounts}
+                        {...paymentMethod}
+                    />
+                )}
+                {isCoinmarketSellContext(context) && (
+                    <CoinmarketOfferSell
+                        account={account}
+                        selectedQuote={context.selectedQuote}
+                        providers={providers}
+                        type={context.type}
+                        quoteAmounts={quoteAmounts}
+                        {...paymentMethod}
+                    />
+                )}
+                {isCoinmarketExchangeContext(context) && (
+                    <CoinmarketOfferExchange
+                        account={account}
+                        selectedQuote={context.selectedQuote}
+                        providers={providers}
+                        type={context.type}
+                        quoteAmounts={quoteAmounts}
+                    />
+                )}
+            </Wrapper>
+        </Column>
     );
 };

--- a/packages/suite/src/views/wallet/receive/components/ConnectDevicePromo.tsx
+++ b/packages/suite/src/views/wallet/receive/components/ConnectDevicePromo.tsx
@@ -33,6 +33,13 @@ const ConnectDevicePromo = ({ title, description }: ConnectDevicePromoProps) => 
     );
 };
 
+export const ConnectDeviceGenericPromo = () => (
+    <ConnectDevicePromo
+        title={<Translation id="TR_CONNECT_DEVICE_GENERIC_PROMO_TITLE" />}
+        description={<Translation id="TR_CONNECT_DEVICE_GENERIC_PROMO_DESCRIPTION" />}
+    />
+);
+
 export const ConnectDeviceReceivePromo = () => (
     <ConnectDevicePromo
         title={<Translation id="TR_CONNECT_DEVICE_RECEIVE_PROMO_TITLE" />}


### PR DESCRIPTION
## Description

When device is disconnected but remembered, show a banner that suggests reconnecting the device.

## Related Issue

Resolve #14848 

## Screenshots:

<img width="1270" alt="Screenshot 2024-12-23 at 15 03 46" src="https://github.com/user-attachments/assets/e960318e-00aa-4261-98a2-052243a9fe06" />

<img width="1269" alt="Screenshot 2024-12-23 at 15 04 24" src="https://github.com/user-attachments/assets/8beed448-e9ae-41a6-ab3c-4315696a6d7c" />
