### PR TITLE
fix(suite-native): tweak coin enabling gradients

### DIFF
--- a/suite-native/coin-enabling/src/components/DiscoveryCoinsFilter.tsx
+++ b/suite-native/coin-enabling/src/components/DiscoveryCoinsFilter.tsx
@@ -47,7 +47,7 @@ export const DiscoveryCoinsFilter = ({
                     allowChangeAnalytics={allowChangeAnalytics}
                 />
             ))}
-            <VStack paddingTop="sp8" paddingBottom="sp16" alignItems="center">
+            <VStack paddingVertical="sp8" alignItems="center">
                 <Icon name="question" color="textSubdued" size="large" />
                 <Text color="textSubdued" textAlign="center">
                     <Translation id="moduleSettings.coinEnabling.bottomNote" />

--- a/suite-native/coin-enabling/src/screens/CoinEnablingInitScreen.tsx
+++ b/suite-native/coin-enabling/src/screens/CoinEnablingInitScreen.tsx
@@ -42,9 +42,9 @@ const contentStyle = prepareNativeStyle(_ => ({
 }));
 
 const gradientBackgroundBottomStyle = prepareNativeStyle<{ showButton: boolean }>(
-    (_, { showButton }) => ({
+    (utils, { showButton }) => ({
         width: '100%',
-        height: 40,
+        height: utils.spacings.sp16,
         position: 'absolute',
         bottom: -BOTTOM_OFFSET,
         pointerEvents: 'none',

--- a/suite-native/module-settings/src/screens/SettingsCoinEnablingScreen.tsx
+++ b/suite-native/module-settings/src/screens/SettingsCoinEnablingScreen.tsx
@@ -20,13 +20,11 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { hexToRgba } from '@suite-common/suite-utils';
 import { selectViewOnlyDevicesAccountsNetworkSymbols } from '@suite-native/device';
 
-const GRADIENT_HEIGHT = 40;
-
-const gradientBaseStyleParams = prepareNativeStyle<{ bottom: number }>((_, { bottom }) => ({
+const gradientBaseStyleParams = prepareNativeStyle(utils => ({
     width: '100%',
-    height: GRADIENT_HEIGHT,
+    height: utils.spacings.sp16,
     position: 'absolute',
-    bottom,
+    bottom: -utils.spacings.sp16,
     pointerEvents: 'none',
 }));
 
@@ -80,26 +78,15 @@ export const SettingsCoinEnablingScreen = () => {
                         <LinearGradient
                             dither={false}
                             colors={[utils.colors.backgroundSurfaceElevation0, transparentColor]}
-                            style={applyStyle(gradientBaseStyleParams, {
-                                bottom: -GRADIENT_HEIGHT,
-                            })}
+                            style={applyStyle(gradientBaseStyleParams)}
                         />
                     )}
                 </View>
             }
-            footer={
-                showNetworks && (
-                    <LinearGradient
-                        dither={false}
-                        colors={[transparentColor, utils.colors.backgroundSurfaceElevation0]}
-                        style={applyStyle(gradientBaseStyleParams, { bottom: 0 })}
-                    />
-                )
-            }
             noTopPadding
         >
             {showNetworks ? (
-                <Box paddingTop="sp24" paddingBottom="sp16">
+                <Box paddingTop="sp16">
                     <DiscoveryCoinsFilter />
                 </Box>
             ) : (


### PR DESCRIPTION
Gradients tweaked based on [Coin enabling gradient in onboarding](https://www.figma.com/design/xSWRW8Csq7zYJ3TiqwoIxB/Small-Things-%5BMOB%5D?node-id=1910-60753&t=gkG3WqZteEHuKlHt-4) and [Settings tabbar & coin enabling in settings](https://www.figma.com/design/xSWRW8Csq7zYJ3TiqwoIxB/Small-Things-%5BMOB%5D?node-id=1909-60437&t=03RMTjusxkOfLKLs-4) in Figma.

A follow-up PR to be created for the tab bar / navigation changes.

## Screenshots:
![Simulator Screenshot - iPhone 16 Pro - 2024-12-24 at 10 54 29](https://github.com/user-attachments/assets/2a9bdc5d-4daf-49d2-9782-22656f85a1c7)
![Simulator Screenshot - iPhone 16 Pro - 2024-12-24 at 10 54 47](https://github.com/user-attachments/assets/1d6febc5-b060-4a83-9e37-599d35987c92)
![Simulator Screenshot - iPhone 16 Pro - 2024-12-24 at 10 55 03](https://github.com/user-attachments/assets/45461bac-33b0-4773-94e4-81e705d6b58a)
![Simulator Screenshot - iPhone 16 Pro - 2024-12-24 at 10 55 53](https://github.com/user-attachments/assets/076ec303-0179-4d41-8fe7-2ea022525827)
![Simulator Screenshot - iPhone 16 Pro - 2024-12-24 at 10 55 59](https://github.com/user-attachments/assets/74f7b769-fac4-47e0-b621-76fb4b145db1)
