### PR TITLE
fix(suite-native): remove tab bar from settings subscreens

### DIFF
--- a/suite-native/app/src/navigation/AppTabNavigator.tsx
+++ b/suite-native/app/src/navigation/AppTabNavigator.tsx
@@ -3,7 +3,7 @@ import { BottomTabBarProps, createBottomTabNavigator } from '@react-navigation/b
 import { ReceiveStackNavigator } from '@suite-native/module-receive';
 import { HomeStackNavigator } from '@suite-native/module-home';
 import { AccountsStackNavigator } from '@suite-native/module-accounts-management';
-import { SettingsStackNavigator } from '@suite-native/module-settings';
+import { SettingsScreen } from '@suite-native/module-settings';
 import { AppTabsParamList, AppTabsRoutes, TabBar } from '@suite-native/navigation';
 import { useHandleDeviceRequestsPassphrase } from '@suite-native/device-authorization';
 
@@ -28,7 +28,7 @@ export const AppTabNavigator = () => {
             <Tab.Screen name={AppTabsRoutes.HomeStack} component={HomeStackNavigator} />
             <Tab.Screen name={AppTabsRoutes.AccountsStack} component={AccountsStackNavigator} />
             <Tab.Screen name={AppTabsRoutes.ReceiveStack} component={ReceiveStackNavigator} />
-            <Tab.Screen name={AppTabsRoutes.SettingsStack} component={SettingsStackNavigator} />
+            <Tab.Screen name={AppTabsRoutes.Settings} component={SettingsScreen} />
         </Tab.Navigator>
     );
 };

--- a/suite-native/app/src/navigation/RootStackNavigator.tsx
+++ b/suite-native/app/src/navigation/RootStackNavigator.tsx
@@ -25,6 +25,7 @@ import { SendStackNavigator } from '@suite-native/module-send';
 import { CoinEnablingInitScreen } from '@suite-native/coin-enabling';
 import { ConnectPopupScreen, useConnectPopupNavigation } from '@suite-native/module-connect-popup';
 import { StakingDetailScreen } from '@suite-native/module-staking-management';
+import { SettingsStackNavigator } from '@suite-native/module-settings';
 
 import { AppTabNavigator } from './AppTabNavigator';
 import { useCoinEnablingInitialCheck } from '../hooks/useCoinEnablingInitialCheck';
@@ -110,6 +111,10 @@ export const RootStackNavigator = () => {
             />
             <RootStack.Screen name={RootStackRoutes.SendStack} component={SendStackNavigator} />
             <RootStack.Screen name={RootStackRoutes.ConnectPopup} component={ConnectPopupScreen} />
+            <RootStack.Screen
+                name={RootStackRoutes.SettingsScreenStack}
+                component={SettingsStackNavigator}
+            />
         </RootStack.Navigator>
     );
 };

--- a/suite-native/app/src/navigation/routes.ts
+++ b/suite-native/app/src/navigation/routes.ts
@@ -26,8 +26,8 @@ const receiveStack = enhanceTabOption({
     focusedIconName: 'arrowLineDown',
 });
 
-const settingsStack = enhanceTabOption({
-    routeName: AppTabsRoutes.SettingsStack,
+const settings = enhanceTabOption({
+    routeName: AppTabsRoutes.Settings,
     iconName: 'gear',
     focusedIconName: 'gearFilled',
     label: 'Settings',
@@ -37,5 +37,5 @@ export const rootTabsOptions = {
     ...homeStack,
     ...accountsStack,
     ...receiveStack,
-    ...settingsStack,
+    ...settings,
 };

--- a/suite-native/module-settings/src/components/FeaturesSettings.tsx
+++ b/suite-native/module-settings/src/components/FeaturesSettings.tsx
@@ -5,36 +5,26 @@ import { useAtomValue } from 'jotai';
 
 import {
     SettingsStackRoutes,
-    SettingsStackParamList,
-    StackToStackCompositeNavigationProps,
-    RootStackParamList,
     RootStackRoutes,
+    StackNavigationProps,
+    RootStackParamList,
 } from '@suite-native/navigation';
 import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
 import { Translation } from '@suite-native/intl';
 import { selectHasDeviceDiscovery } from '@suite-common/wallet-core';
 
+import { useSettingsNavigateTo } from '../navigation/useSettingsNavigateTo';
 import { SettingsSection } from './SettingsSection';
 import { SettingsSectionItem } from './SettingsSectionItem';
 import { isDevButtonVisibleAtom } from './ProductionDebug';
 
-type NavigationProp = StackToStackCompositeNavigationProps<
-    SettingsStackParamList,
-    SettingsStackRoutes.Settings,
-    RootStackParamList
->;
-
 export const FeaturesSettings = () => {
     const isDevButtonVisible = useAtomValue(isDevButtonVisibleAtom);
     const [isUsbDeviceConnectFeatureEnabled] = useFeatureFlag(FeatureFlag.IsDeviceConnectEnabled);
+    const navigation = useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes>>();
+    const navigateTo = useSettingsNavigateTo();
 
     const hasDiscovery = useSelector(selectHasDeviceDiscovery);
-
-    const navigation = useNavigation<NavigationProp>();
-
-    const handleNavigation = (routeName: SettingsStackRoutes): void => {
-        navigation.navigate(routeName);
-    };
 
     return (
         <SettingsSection title={<Translation id="moduleSettings.items.features.title" />}>
@@ -53,7 +43,7 @@ export const FeaturesSettings = () => {
                 subtitle={
                     <Translation id="moduleSettings.items.features.privacyAndSecurity.subtitle" />
                 }
-                onPress={() => handleNavigation(SettingsStackRoutes.SettingsPrivacyAndSecurity)}
+                onPress={() => navigateTo(SettingsStackRoutes.SettingsPrivacyAndSecurity)}
                 testID="@settings/privacy-and-security"
             />
             {isUsbDeviceConnectFeatureEnabled && (
@@ -64,7 +54,7 @@ export const FeaturesSettings = () => {
                         subtitle={
                             <Translation id="moduleSettings.items.features.viewOnly.subtitle" />
                         }
-                        onPress={() => handleNavigation(SettingsStackRoutes.SettingsViewOnly)}
+                        onPress={() => navigateTo(SettingsStackRoutes.SettingsViewOnly)}
                         testID="@settings/view-only"
                     />
                     <SettingsSectionItem
@@ -75,7 +65,7 @@ export const FeaturesSettings = () => {
                         subtitle={
                             <Translation id="moduleSettings.items.features.coinEnabling.subtitle" />
                         }
-                        onPress={() => handleNavigation(SettingsStackRoutes.SettingsCoinEnabling)}
+                        onPress={() => navigateTo(SettingsStackRoutes.SettingsCoinEnabling)}
                         isLoading={hasDiscovery}
                         testID="@settings/coin-enabling"
                     />

--- a/suite-native/module-settings/src/components/PreferencesSettings.tsx
+++ b/suite-native/module-settings/src/components/PreferencesSettings.tsx
@@ -1,29 +1,12 @@
-import { useNavigation } from '@react-navigation/core';
-
-import {
-    SettingsStackRoutes,
-    SettingsStackParamList,
-    StackToStackCompositeNavigationProps,
-    RootStackParamList,
-} from '@suite-native/navigation';
 import { Translation } from '@suite-native/intl';
+import { SettingsStackRoutes } from '@suite-native/navigation';
 
+import { useSettingsNavigateTo } from '../navigation/useSettingsNavigateTo';
 import { SettingsSection } from './SettingsSection';
 import { SettingsSectionItem } from './SettingsSectionItem';
 
 export const PreferencesSettings = () => {
-    const navigation =
-        useNavigation<
-            StackToStackCompositeNavigationProps<
-                SettingsStackParamList,
-                SettingsStackRoutes.Settings,
-                RootStackParamList
-            >
-        >();
-
-    const handleNavigation = (routeName: SettingsStackRoutes): void => {
-        navigation.navigate(routeName);
-    };
+    const navigateTo = useSettingsNavigateTo();
 
     return (
         <SettingsSection title={<Translation id="moduleSettings.items.preferences.title" />}>
@@ -33,7 +16,7 @@ export const PreferencesSettings = () => {
                 subtitle={
                     <Translation id="moduleSettings.items.preferences.localization.subtitle" />
                 }
-                onPress={() => handleNavigation(SettingsStackRoutes.SettingsLocalization)}
+                onPress={() => navigateTo(SettingsStackRoutes.SettingsLocalization)}
                 testID="@settings/localization"
             />
             <SettingsSectionItem
@@ -42,7 +25,7 @@ export const PreferencesSettings = () => {
                 subtitle={
                     <Translation id="moduleSettings.items.preferences.customization.subtitle" />
                 }
-                onPress={() => handleNavigation(SettingsStackRoutes.SettingsCustomization)}
+                onPress={() => navigateTo(SettingsStackRoutes.SettingsCustomization)}
                 testID="@settings/customization"
             />
         </SettingsSection>

--- a/suite-native/module-settings/src/components/SupportSettings.tsx
+++ b/suite-native/module-settings/src/components/SupportSettings.tsx
@@ -1,26 +1,13 @@
-import { useNavigation } from '@react-navigation/core';
-
-import {
-    RootStackParamList,
-    SettingsStackParamList,
-    SettingsStackRoutes,
-    StackToStackCompositeNavigationProps,
-} from '@suite-native/navigation';
+import { SettingsStackRoutes } from '@suite-native/navigation';
 import { TrezorSuiteLiteHeader } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 
+import { useSettingsNavigateTo } from '../navigation/useSettingsNavigateTo';
 import { SettingsSection } from './SettingsSection';
 import { SettingsSectionItem } from './SettingsSectionItem';
 
 export const SupportSettings = () => {
-    const navigation =
-        useNavigation<
-            StackToStackCompositeNavigationProps<
-                SettingsStackParamList,
-                SettingsStackRoutes,
-                RootStackParamList
-            >
-        >();
+    const navigateTo = useSettingsNavigateTo();
 
     return (
         <SettingsSection title="Support">
@@ -28,7 +15,7 @@ export const SupportSettings = () => {
                 iconName="question"
                 title={<Translation id="moduleSettings.items.support.help.title" />}
                 subtitle={<Translation id="moduleSettings.items.support.help.subtitle" />}
-                onPress={() => navigation.navigate(SettingsStackRoutes.SettingsFAQ)}
+                onPress={() => navigateTo(SettingsStackRoutes.SettingsFAQ)}
                 testID="@settings/help"
             />
             <SettingsSectionItem
@@ -39,7 +26,7 @@ export const SupportSettings = () => {
                     </>
                 }
                 iconName="trezorSafe5"
-                onPress={() => navigation.navigate(SettingsStackRoutes.SettingsAbout)}
+                onPress={() => navigateTo(SettingsStackRoutes.SettingsAbout)}
                 testID="@settings/about"
             />
         </SettingsSection>

--- a/suite-native/module-settings/src/index.ts
+++ b/suite-native/module-settings/src/index.ts
@@ -1,2 +1,3 @@
 export * from './navigation/SettingsStackNavigator';
 export * from './components/ColorSchemePicker';
+export * from './screens/SettingsScreen';

--- a/suite-native/module-settings/src/navigation/SettingsStackNavigator.tsx
+++ b/suite-native/module-settings/src/navigation/SettingsStackNavigator.tsx
@@ -6,7 +6,6 @@ import {
     stackNavigationOptionsConfig,
 } from '@suite-native/navigation';
 
-import { SettingsScreen } from '../screens/SettingsScreen';
 import { SettingsLocalizationScreen } from '../screens/SettingsLocalizationScreen';
 import { SettingsCustomizationScreen } from '../screens/SettingsCustomizationScreen';
 import { SettingsPrivacyAndSecurity } from '../screens/SettingsPrivacyAndSecurity';
@@ -15,18 +14,10 @@ import { SettingsAboutUsScreen } from '../screens/SettingsAboutUsScreen';
 import { SettingsFAQScreen } from '../screens/SettingsFAQScreen';
 import { SettingsCoinEnablingScreen } from '../screens/SettingsCoinEnablingScreen';
 
-export const SettingsStack = createNativeStackNavigator<SettingsStackParamList>();
+const SettingsStack = createNativeStackNavigator<SettingsStackParamList>();
 
 export const SettingsStackNavigator = () => (
-    <SettingsStack.Navigator
-        initialRouteName={SettingsStackRoutes.Settings}
-        screenOptions={stackNavigationOptionsConfig}
-    >
-        <SettingsStack.Screen
-            options={{ title: SettingsStackRoutes.Settings }}
-            name={SettingsStackRoutes.Settings}
-            component={SettingsScreen}
-        />
+    <SettingsStack.Navigator screenOptions={stackNavigationOptionsConfig}>
         <SettingsStack.Screen
             options={{ title: SettingsStackRoutes.SettingsLocalization }}
             name={SettingsStackRoutes.SettingsLocalization}

--- a/suite-native/module-settings/src/navigation/useSettingsNavigateTo.ts
+++ b/suite-native/module-settings/src/navigation/useSettingsNavigateTo.ts
@@ -1,0 +1,21 @@
+import { useCallback } from 'react';
+
+import { useNavigation } from '@react-navigation/core';
+
+import {
+    RootStackParamList,
+    RootStackRoutes,
+    SettingsStackRoutes,
+    StackNavigationProps,
+} from '@suite-native/navigation';
+
+export const useSettingsNavigateTo = () => {
+    const navigation = useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes>>();
+
+    return useCallback(
+        (routeName: SettingsStackRoutes): void => {
+            navigation.navigate(RootStackRoutes.SettingsScreenStack, { screen: routeName });
+        },
+        [navigation],
+    );
+};

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -57,7 +57,6 @@ export type DevUtilsStackParamList = {
 };
 
 export type SettingsStackParamList = {
-    [SettingsStackRoutes.Settings]: undefined;
     [SettingsStackRoutes.SettingsLocalization]: undefined;
     [SettingsStackRoutes.SettingsCustomization]: undefined;
     [SettingsStackRoutes.SettingsPrivacyAndSecurity]: undefined;
@@ -102,7 +101,7 @@ export type AppTabsParamList = {
     [AppTabsRoutes.HomeStack]: NavigatorScreenParams<HomeStackParamList>;
     [AppTabsRoutes.AccountsStack]: NavigatorScreenParams<AccountsStackParamList>;
     [AppTabsRoutes.ReceiveStack]: NavigatorScreenParams<ReceiveStackParamList>;
-    [AppTabsRoutes.SettingsStack]: NavigatorScreenParams<SettingsStackParamList>;
+    [AppTabsRoutes.Settings]: undefined;
 };
 
 export type OnboardingStackParamList = {
@@ -213,4 +212,5 @@ export type RootStackParamList = {
     [RootStackRoutes.ConnectPopup]: {
         parsedUrl: ParsedURL;
     };
+    [RootStackRoutes.SettingsScreenStack]: NavigatorScreenParams<SettingsStackParamList>;
 };

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -14,13 +14,14 @@ export enum RootStackRoutes {
     AddCoinAccountStack = 'AddCoinAccountStack',
     CoinEnablingInit = 'CoinEnablingInit',
     ConnectPopup = 'ConnectPopup',
+    SettingsScreenStack = 'SettingsScreenStack',
 }
 
 export enum AppTabsRoutes {
     HomeStack = 'HomeStack',
     AccountsStack = 'AccountsStack',
     ReceiveStack = 'ReceiveStack',
-    SettingsStack = 'SettingsStack',
+    Settings = 'Settings',
 }
 
 export enum OnboardingStackRoutes {
@@ -108,7 +109,6 @@ export enum AddCoinAccountStackRoutes {
 }
 
 export enum SettingsStackRoutes {
-    Settings = 'Settings',
     SettingsLocalization = 'SettingsLocalization',
     SettingsCustomization = 'SettingsCustomization',
     SettingsPrivacyAndSecurity = 'SettingsPrivacyAndSecurity',


### PR DESCRIPTION
Tab bar is not shown on settings subscreens. Based on [Settings tabbar & coin enabling in settings](https://www.figma.com/design/xSWRW8Csq7zYJ3TiqwoIxB/Small-Things-%5BMOB%5D?node-id=1909-60437&t=03RMTjusxkOfLKLs-4) in Figma.

## Screenshots:
![Simulator Screenshot - iPhone 16 Pro - 2024-12-24 at 11 13 04](https://github.com/user-attachments/assets/79b446c0-2934-462e-a004-4437150f225b)
![Simulator Screenshot - iPhone 16 Pro - 2024-12-24 at 11 13 10](https://github.com/user-attachments/assets/9901853c-3013-41ae-8069-022a74893df1)
