### PR TITLE
Put Optimism, Base and Arbitrum one into one experimental feature

### DIFF
--- a/packages/suite/src/actions/suite/constants/suiteConstants.ts
+++ b/packages/suite/src/actions/suite/constants/suiteConstants.ts
@@ -1,3 +1,5 @@
+import type { NetworkSymbol } from '@suite-common/wallet-config';
+
 export const INIT = '@suite/init';
 export const READY = '@suite/ready';
 export const ERROR = '@suite/error';
@@ -35,3 +37,4 @@ export const LOCK_TYPE = {
 export const REQUEST_DEVICE_RECONNECT = '@suite/request-device-reconnect';
 export const SET_EXPERIMENTAL_FEATURES = '@suite/set-experimental-features';
 export const SET_SIDEBAR_WIDTH = '@suite/set-sidebar-width';
+export const EXPERIMENTAL_L2_NETWORKS: readonly NetworkSymbol[] = ['op', 'arb', 'base'];

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSearchBox.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSearchBox.tsx
@@ -2,14 +2,8 @@ import styled, { useTheme } from 'styled-components';
 
 import { Icon, Input } from '@trezor/components';
 import { borders } from '@trezor/theme';
-import { selectSelectedDevice } from '@suite-common/wallet-core';
 
-import { useSelector, useAccountSearch, useTranslation } from 'src/hooks/suite';
-import { selectEnabledNetworks } from 'src/reducers/wallet/settingsReducer';
-
-const InputWrapper = styled.div<{ $showCoinFilter: boolean }>`
-    flex: 1;
-`;
+import { useAccountSearch, useTranslation } from 'src/hooks/suite';
 
 // eslint-disable-next-line local-rules/no-override-ds-component
 const StyledInput = styled(Input)`
@@ -27,13 +21,6 @@ export const AccountSearchBox = () => {
     const theme = useTheme();
     const { translationString } = useTranslation();
     const { setCoinFilter, searchString, setSearchString } = useAccountSearch();
-    const enabledNetworks = useSelector(selectEnabledNetworks);
-    const device = useSelector(selectSelectedDevice);
-
-    const unavailableCapabilities = device?.unavailableCapabilities ?? {};
-    const supportedNetworks = enabledNetworks.filter(symbol => !unavailableCapabilities[symbol]);
-
-    const showCoinFilter = supportedNetworks.length > 1;
 
     const onClear = () => {
         setSearchString(undefined);
@@ -41,20 +28,18 @@ export const AccountSearchBox = () => {
     };
 
     return (
-        <InputWrapper $showCoinFilter={showCoinFilter}>
-            <StyledInput
-                value={searchString ?? ''}
-                onChange={e => {
-                    setSearchString(e.target.value);
-                }}
-                innerAddon={<Icon name="search" size={16} color={theme.iconDefault} />}
-                innerAddonAlign="left"
-                size="small"
-                placeholder={translationString('TR_SEARCH')}
-                showClearButton="always"
-                onClear={onClear}
-                data-testid="@account-menu/search-input"
-            />
-        </InputWrapper>
+        <StyledInput
+            value={searchString ?? ''}
+            onChange={e => {
+                setSearchString(e.target.value);
+            }}
+            innerAddon={<Icon name="search" size={16} color={theme.iconDefault} />}
+            innerAddonAlign="left"
+            size="small"
+            placeholder={translationString('TR_SEARCH')}
+            showClearButton="always"
+            onClear={onClear}
+            data-testid="@account-menu/search-input"
+        />
     );
 };

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/CoinsFilter.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/CoinsFilter.tsx
@@ -1,13 +1,13 @@
 import styled from 'styled-components';
 import { motion, AnimatePresence, MotionProps } from 'framer-motion';
 
-import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { TOOLTIP_DELAY_NORMAL, Tooltip, motionEasing } from '@trezor/components';
 import { CoinLogo } from '@trezor/product-components';
 import { borders, spacingsPx } from '@trezor/theme';
 
 import { useSelector, useAccountSearch } from 'src/hooks/suite';
 import { selectEnabledNetworks } from 'src/reducers/wallet/settingsReducer';
+import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
 
 // eslint-disable-next-line local-rules/no-override-ds-component
 const StyledCoinLogo = styled(CoinLogo)<{ $isSelected?: boolean }>`
@@ -44,12 +44,15 @@ const Container = styled.div`
 export const CoinsFilter = () => {
     const { coinFilter, setCoinFilter } = useAccountSearch();
     const enabledNetworks = useSelector(selectEnabledNetworks);
-    const device = useSelector(selectSelectedDevice);
+    const { supportedMainnets, supportedTestnets } = useNetworkSupport();
 
-    const unavailableCapabilities = device?.unavailableCapabilities ?? {};
-    const supportedNetworks = enabledNetworks.filter(symbol => !unavailableCapabilities[symbol]);
+    const supportedNetworks = [...supportedMainnets, ...supportedTestnets].map(
+        network => network.symbol,
+    );
 
-    const showCoinFilter = supportedNetworks.length > 1;
+    const availableNetworks = enabledNetworks.filter(symbol => supportedNetworks.includes(symbol));
+
+    const showCoinFilter = availableNetworks.length > 1;
 
     const coinAnimcationConfig: MotionProps = {
         initial: {
@@ -80,7 +83,7 @@ export const CoinsFilter = () => {
             }}
         >
             <AnimatePresence initial={false}>
-                {supportedNetworks.map(network => {
+                {availableNetworks.map(network => {
                     const isSelected = coinFilter === network;
 
                     return (

--- a/packages/suite/src/constants/suite/experimental.ts
+++ b/packages/suite/src/constants/suite/experimental.ts
@@ -6,7 +6,11 @@ import { isDesktop } from '@trezor/env-utils';
 
 import { Dispatch } from '../../types/suite';
 
-export type ExperimentalFeature = 'password-manager' | 'tor-external' | 'nft-section';
+export type ExperimentalFeature =
+    | 'password-manager'
+    | 'tor-external'
+    | 'nft-section'
+    | 'ethereum-l2-support';
 
 export type ExperimentalFeatureConfig = {
     title: TranslationKey;
@@ -39,6 +43,10 @@ export const EXPERIMENTAL_FEATURES: Record<ExperimentalFeature, ExperimentalFeat
                 });
             }
         },
+    },
+    'ethereum-l2-support': {
+        title: 'TR_EXPERIMENTAL_ETHEREUM_L2_SUPPORT',
+        description: 'TR_EXPERIMENTAL_ETHEREUM_L2_SUPPORT_DESCRIPTION',
     },
     'nft-section': {
         title: 'TR_EXPERIMENTAL_NFT_SECTION',

--- a/packages/suite/src/hooks/settings/useNetworkSupport.ts
+++ b/packages/suite/src/hooks/settings/useNetworkSupport.ts
@@ -5,14 +5,35 @@ import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 import { arrayPartition } from '@trezor/utils';
 
 import { useSelector } from 'src/hooks/suite';
-import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
+import {
+    selectIsDebugModeActive,
+    selectHasExperimentalFeature,
+} from 'src/reducers/suite/suiteReducer';
+import { EXPERIMENTAL_L2_NETWORKS } from 'src/actions/suite/constants/suiteConstants';
+import { selectEnabledNetworks } from 'src/reducers/wallet/settingsReducer';
 
 export const useNetworkSupport = () => {
     const device = useSelector(selectSelectedDevice);
     const isDebug = useSelector(selectIsDebugModeActive);
     const deviceSupportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
+    const isEthereumL2SupportEnabled = useSelector(
+        selectHasExperimentalFeature('ethereum-l2-support'),
+    );
+    const enabledNetworks = useSelector(selectEnabledNetworks);
 
-    const mainnets = getMainnets(isDebug);
+    const mainnets = getMainnets(isDebug).filter(network => {
+        if (isEthereumL2SupportEnabled) {
+            return true; // no filtering needed if L2 support is enabled
+        }
+
+        // if L2 support is not enabled
+        const isExperimentalL2 = EXPERIMENTAL_L2_NETWORKS.includes(network.symbol);
+        const isEnabled = enabledNetworks.includes(network.symbol);
+
+        // filter out experimental L2 networks unless they are in the enabled networks
+        return !(isExperimentalL2 && !isEnabled);
+    });
+
     const testnets = getTestnets(isDebug);
 
     const isNetworkSupported = (network: Network) =>

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -4998,7 +4998,16 @@ export default defineMessages({
     TR_EXPERIMENTAL_NFT_SECTION_DESCRIPTION: {
         id: 'TR_EXPERIMENTAL_NFT_SECTION_DESCRIPTION',
         defaultMessage:
-            'Access the NFTs stored in your wallet. Currently available for EVM-based chains only.',
+            'Adds an NFT section to EVM-based chain accounts. Currently, viewing is supported, but sending is not available.',
+    },
+    TR_EXPERIMENTAL_ETHEREUM_L2_SUPPORT: {
+        id: 'TR_EXPERIMENTAL_ETHEREUM_L2_SUPPORT',
+        defaultMessage: 'Support for Ethereum L2 networks (Arbitrum One, Base, Optimism)',
+    },
+    TR_EXPERIMENTAL_ETHEREUM_L2_SUPPORT_DESCRIPTION: {
+        id: 'TR_EXPERIMENTAL_ETHEREUM_L2_SUPPORT_DESCRIPTION',
+        defaultMessage:
+            'Allows to enable Arbitrum One, Base, and Optimism networks in the coin settings.',
     },
     TR_EXPERIMENTAL_FEATURES_ALLOW: {
         id: 'TR_EXPERIMENTAL_FEATURES_ALLOW',

--- a/packages/suite/src/types/coinmarket/coinmarketVerify.ts
+++ b/packages/suite/src/types/coinmarket/coinmarketVerify.ts
@@ -3,11 +3,10 @@ import { UseFormReturn } from 'react-hook-form';
 
 import { CryptoId } from 'invity-api';
 
-import { NetworkSymbol } from '@suite-common/wallet-config';
 import { AccountAddress } from '@trezor/connect';
 
 import type { Account } from 'src/types/wallet';
-import { ExtendedMessageDescriptor, TrezorDevice } from 'src/types/suite';
+import { ExtendedMessageDescriptor } from 'src/types/suite';
 
 export interface CoinmarketVerifyFormProps {
     address?: string;
@@ -50,12 +49,4 @@ export type CoinmarketVerifyOptionsProps = { receiveNetwork: CryptoId; label: Re
 export interface CoinmarketVerifyOptionsItemProps {
     option: CoinmarketVerifyFormAccountOptionProps;
     receiveNetwork: CryptoId;
-}
-
-export interface CoinmarketGetSuiteReceiveAccountsProps {
-    currency: CryptoId | undefined;
-    device: TrezorDevice | undefined;
-    symbol: NetworkSymbol | undefined;
-    isDebug: boolean;
-    accounts: Account[];
 }

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -186,7 +186,6 @@ export const networks = {
         },
         coingeckoId: 'arbitrum-one',
         coingeckoNativeId: 'ethereum',
-        isDebugOnlyNetwork: true,
     },
     base: {
         symbol: 'base',
@@ -210,7 +209,6 @@ export const networks = {
         },
         coingeckoId: 'base',
         coingeckoNativeId: 'ethereum',
-        isDebugOnlyNetwork: true,
     },
     op: {
         symbol: 'op',
@@ -234,7 +232,6 @@ export const networks = {
         },
         coingeckoId: 'optimistic-ethereum',
         coingeckoNativeId: 'ethereum',
-        isDebugOnlyNetwork: true,
     },
     sol: {
         symbol: 'sol',

--- a/suite-common/wallet-utils/src/__tests__/filterReceiveAccounts.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/filterReceiveAccounts.test.ts
@@ -1,5 +1,5 @@
 import { testMocks } from '@suite-common/test-utils';
-import { Network, networksCollection, NetworkSymbol } from '@suite-common/wallet-config';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
 
 import { isDebugOnlyAccountType, filterReceiveAccounts } from '../filterReceiveAccounts';
@@ -47,21 +47,12 @@ const runFilterReceiveAccouns = ({
         },
         state: deviceState,
     });
-    const unavailableCapabilities = device?.unavailableCapabilities ?? {};
-
-    const receiveNetworks = networksCollection.filter(
-        (n: Network) =>
-            n.symbol === symbol &&
-            !unavailableCapabilities[n.symbol] &&
-            ((n.isDebugOnlyNetwork && isDebug) || !n.isDebugOnlyNetwork),
-    );
 
     return filterReceiveAccounts({
         accounts,
         deviceState: device.state?.staticSessionId,
         symbol,
         isDebug,
-        receiveNetworks,
     });
 };
 

--- a/suite-common/wallet-utils/src/filterReceiveAccounts.ts
+++ b/suite-common/wallet-utils/src/filterReceiveAccounts.ts
@@ -1,4 +1,4 @@
-import { AccountType, getNetwork, Network, NetworkSymbol } from '@suite-common/wallet-config';
+import { AccountType, getNetwork, NetworkSymbol } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
 import { StaticSessionId } from '@trezor/connect';
 
@@ -20,7 +20,6 @@ type FilterReceiveAccountsProps = {
     deviceState?: StaticSessionId;
     symbol?: NetworkSymbol;
     isDebug: boolean;
-    receiveNetworks: Network[];
 };
 
 export const filterReceiveAccounts = ({


### PR DESCRIPTION
## Description

- Optimism, Base and Arbitrum are moved into an experimental feature
- fix coinmarket allow to add non-existing account
- use shared logic for sidebar networks filter

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/16084
Resolve #16115

## Screenshots:

![Screenshot 2024-12-29 at 12 37 01](https://github.com/user-attachments/assets/cbb5de4f-6215-4dbb-8712-3ed856a9b42d)
![Screenshot 2024-12-29 at 12 36 56](https://github.com/user-attachments/assets/e8e9fdce-8ca7-49cb-bd19-3bdab15180f5)


Experimental not enabled
![Screenshot 2024-12-29 at 12 32 23](https://github.com/user-attachments/assets/ba501b1a-1c15-4987-8d4e-d39c0f805660)

Experimental enabled 
![Screenshot 2024-12-29 at 12 35 03](https://github.com/user-attachments/assets/17673e05-5da6-4b3b-8228-fbc5869abf48)

XLM
![Screenshot 2024-12-29 at 12 35 49](https://github.com/user-attachments/assets/d157b119-612f-4978-9194-3e34746f441d)

