### PR TITLE
fix(e2e): Enable forgotten group of tests and fix tag of guide tests

### DIFF
--- a/.github/workflows/test-suite-desktop-e2e.yml
+++ b/.github/workflows/test-suite-desktop-e2e.yml
@@ -27,8 +27,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # - TEST_GROUP: "@group=suite"
-          #   CONTAINERS: "trezor-user-env-unix"
+          - TEST_GROUP: "@group=suite"
+            CONTAINERS: "trezor-user-env-unix"
           - TEST_GROUP: "@group=device-management"
             CONTAINERS: "trezor-user-env-unix"
           - TEST_GROUP: "@group=settings"

--- a/.github/workflows/test-suite-web-e2e-pw.yml
+++ b/.github/workflows/test-suite-web-e2e-pw.yml
@@ -95,8 +95,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # - TEST_GROUP: "@group=suite"
-          #   CONTAINERS: "trezor-user-env-unix"
+          - TEST_GROUP: "@group=suite"
+            CONTAINERS: "trezor-user-env-unix"
           - TEST_GROUP: "@group=device-management"
             CONTAINERS: "trezor-user-env-unix"
           - TEST_GROUP: "@group=settings"

--- a/packages/suite-desktop-core/e2e/support/bridge.ts
+++ b/packages/suite-desktop-core/e2e/support/bridge.ts
@@ -20,6 +20,6 @@ export const expectBridgeToBeStopped = async (request: APIRequestContext) => {
 // Bridge should be ready to check `/status` endpoint.
 export const waitForAppToBeInitialized = async (suite: any) =>
     await Promise.race([
-        expect(suite.page.getByTestId('@welcome/title')).toBeVisible(),
-        expect(suite.page.getByTestId('@dashboard/graph')).toBeVisible(),
+        expect(suite.window.getByTestId('@welcome/title')).toBeVisible(),
+        expect(suite.window.getByTestId('@dashboard/graph')).toBeVisible(),
     ]);

--- a/packages/suite-desktop-core/e2e/tests/bridge-thor/spawn-bridge-daemon.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/bridge-thor/spawn-bridge-daemon.test.ts
@@ -1,10 +1,10 @@
-import { test, expect } from '../support/fixtures';
-import { launchSuite, launchSuiteElectronApp } from '../support/common';
+import { test, expect } from '../../support/fixtures';
+import { launchSuite, launchSuiteElectronApp } from '../../support/common';
 import {
     expectBridgeToBeRunning,
     expectBridgeToBeStopped,
     waitForAppToBeInitialized,
-} from '../support/bridge';
+} from '../../support/bridge';
 
 test.describe.serial('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => {
     test.beforeAll(async ({ trezorUserEnvLink }) => {

--- a/packages/suite-desktop-core/e2e/tests/bridge-thor/spawn-bridge.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/bridge-thor/spawn-bridge.test.ts
@@ -1,13 +1,13 @@
-import { test, expect } from '../support/fixtures';
-import { launchSuite, LEGACY_BRIDGE_VERSION } from '../support/common';
-import { OnboardingActions } from '../support/pageActions/onboardingActions';
+import { test, expect } from '../../support/fixtures';
+import { launchSuite, LEGACY_BRIDGE_VERSION } from '../../support/common';
+import { OnboardingActions } from '../../support/pageActions/onboardingActions';
 import {
     BRIDGE_URL,
     expectBridgeToBeRunning,
     expectBridgeToBeStopped,
     waitForAppToBeInitialized,
-} from '../support/bridge';
-import { AnalyticsActions } from '../support/pageActions/analyticsActions';
+} from '../../support/bridge';
+import { AnalyticsActions } from '../../support/pageActions/analyticsActions';
 
 test.describe.serial('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => {
     test.beforeEach(async ({ trezorUserEnvLink }) => {

--- a/packages/suite-desktop-core/e2e/tests/bridge-thor/spawn-tor.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/bridge-thor/spawn-tor.test.ts
@@ -1,8 +1,8 @@
 import { Page } from '@playwright/test';
 
-import { test, expect } from '../support/fixtures';
-import { launchSuite } from '../support/common';
-import { NetworkAnalyzer } from '../support/networkAnalyzer';
+import { test, expect } from '../../support/fixtures';
+import { launchSuite } from '../../support/common';
+import { NetworkAnalyzer } from '../../support/networkAnalyzer';
 
 const timeout = 1000 * 60 * 5; // 5 minutes because it takes a while to start tor.
 

--- a/packages/suite-desktop-core/e2e/tests/general/suite-guide.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/general/suite-guide.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '../../support/fixtures';
 
-test.describe('Suite Guide', { tag: '@suite' }, () => {
+test.describe('Suite Guide', { tag: '@group=suite' }, () => {
     test.use({ startEmulator: false });
     /**
      * Test case:


### PR DESCRIPTION
## Description

Enable forgotten group of tests and fix tag of guide tests
@group=suite

## Related Issue
Resolves 15606

## Screenshots:
