### PR TITLE
chore(nix): add git to nix-shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -21,6 +21,7 @@ in
     name = "trezor-suite-dev";
     buildInputs = [
       bash
+      git
       git-lfs
       gnupg
       mdbook


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We have 'git' in nix-shell but it is missing 'git', if you use it in a fresh OS (as it happened to me right now) it does not work.
