### PR TITLE
feat(suite): enable contract address warning for sepolia and holesky

### DIFF
--- a/packages/suite/src/views/wallet/send/Outputs/Address.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Address.tsx
@@ -96,6 +96,8 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
     const broadcastEnabled = options.includes('broadcast');
     const isOnline = useSelector(state => state.suite.online);
 
+    const isContractAddressWarningEnabled = ['eth', 'tsep', 'thol'].includes(symbol);
+
     useEffect(() => {
         contractAddressWarningDismissed.current = false;
     }, [address]);
@@ -291,8 +293,11 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                         }
                     }
 
-                    //2. Check if address is a contract address
-                    if (!contractAddressWarningDismissed.current && symbol === 'eth') {
+                    // 2. Check if address is a contract address (right now only for Eth, Holesky and Sepolia)
+                    if (
+                        !contractAddressWarningDismissed.current &&
+                        isContractAddressWarningEnabled
+                    ) {
                         const isContract = payload.misc?.contractInfo;
                         if (isContract) {
                             return translationString('TR_EVM_ADDRESS_IS_CONTRACT');


### PR DESCRIPTION
## Description

Enable contract address warning for sepolia and holesky

## Screenshots:
<img width="883" alt="Screenshot 2025-01-02 at 09 08 20" src="https://github.com/user-attachments/assets/6efafd1f-6f9d-4123-a14b-89102df58283" />
<img width="883" alt="Screenshot 2025-01-02 at 09 11 16" src="https://github.com/user-attachments/assets/5965ffce-0d32-43a5-b3a1-0b55e0548c4c" />
