### PR TITLE
Fix same labels for all evm accounts

### DIFF
--- a/packages/suite/src/storage/CHANGELOG.md
+++ b/packages/suite/src/storage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Storage changelog
 
+## 51
+
+-   Changed `metadata.key` on non-eth EVM networks accounts to be `descriptor-chainId`
+
 ## 49
 
 -   networks now have same order everywhere

--- a/packages/suite/src/storage/index.ts
+++ b/packages/suite/src/storage/index.ts
@@ -5,7 +5,7 @@ import { reloadApp } from 'src/utils/suite/reload';
 import { migrate } from './migrations';
 import type { SuiteDBSchema } from './definitions';
 
-const VERSION = 50; // don't forget to add migration and CHANGELOG when changing versions!
+const VERSION = 51; // don't forget to add migration and CHANGELOG when changing versions!
 
 /**
  *  If the object stores don't already exist then creates them.


### PR DESCRIPTION
## Description
Now the keys generated for non-mainnet evm accounts will be different than the ones generated for miannnet, so the files on the storage will be different and labels will not duplicate for each network.

Ethereum mainnet labels should stay the same and the others networks will be replaced by the new files.

To rewrite metadata keys it's needed to rediscover accounts 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/15546

## Screenshots:

<img width="276" alt="Screenshot 2025-01-02 at 13 27 53" src="https://github.com/user-attachments/assets/42da4607-001e-49f9-86dc-5ea72f16aa24" />
<img width="276" alt="Screenshot 2025-01-02 at 13 28 17" src="https://github.com/user-attachments/assets/046317ec-290f-4a22-bbbb-d0f3104357e0" />
