### PR TITLE
fix: eslint pre-commit hook now supports partially staged files

### DIFF
--- a/.husky/eslint.sh
+++ b/.husky/eslint.sh
@@ -3,6 +3,7 @@
 GREEN='\033[0;32m'
 NC='\033[0m' # No Color
 
+
 if [ "$TREZOR_PRE_COMMIT_ESLINT_SKIP" == "true" ]; then
   echo "Skipping eslint pre-commit hook, do: 'export TREZOR_PRE_COMMIT_ESLINT_SKIP=false' to re-enable it."
   exit 0
@@ -24,14 +25,49 @@ else
   echo "$STAGED_FILES"
   echo ""
 
+  # This will stashed all changes that are not added (the red files), but keeps added (the green files)
+#  echo -e "Stashing the ${GREEN}staged${NC} files."
+  git stash push --staged -q   # Stash staged changes (green files)
+#  git status
+
+  UNSTAGED_FILES=$(git diff --name-only)
+
+  if [ -z "$UNSTAGED_FILES" ]; then
+#    echo -e "There are no ${RED}unstaged${NC} files to stash."
+    git stash pop -q # In case no unstaged files are present, we can pop the stash
+    git add . # And we need to stage them as well (from stash pop they became unstaged)
+#    git status
+
+  else
+#    echo -e "Stashing the ${RED}unstaged${NC} files."
+    git stash -q # If there are some unstaged (red) files, we need to stash them into second stash
+#    git status
+
+#    echo -e "Restoring the ${GREEN}staged${NC} files."
+    git stash pop stash@\{1\} -q   # And then restore the first stash with the staged (green), files
+    git add . # And we need to stage them as well (from stash pop they became unstaged)
+#    git status
+  fi
+
+  echo -e "Running lint..."
+
   # No quotes to pass as separate arguments (files)
   # shellcheck disable=SC2086
   if ! yarn lint:js:fix-files $STAGED_FILES; then
     echo "Eslint failed! Please fix the errors and try again. You can also use --no-verify to skip pre-commit checks."
+
+    if [ -n "$UNSTAGED_FILES" ]; then
+#      echo -e "Restoring the ${RED}unstaged${NC} files."
+      git stash pop -q # Restore the stash of the unstaged files if there were any
+    fi
     exit 1
   fi
 
-  git update-index --again
-fi
+  git update-index --again # Stage all changes (made by ESlint)
 
+  if [ -n "$UNSTAGED_FILES" ]; then
+#    echo -e "Restoring the ${RED}unstaged${NC} files."
+    git stash pop -q # Restore the stash of the unstaged files if there were any
+  fi
+fi
 

--- a/scripts/shellcheck.sh
+++ b/scripts/shellcheck.sh
@@ -7,4 +7,11 @@ set -o pipefail
 
 shellcheck --version
 # lint all *.sh files
-find . -type f -name '*.sh' ! -path './node_modules/*' ! -path './yarn/*' ! -path './suite-native/app/ios/*' ! -path './submodules/*' -print0 | xargs -0 shellcheck
+find . -type f -name '*.sh' \
+  ! -path './node_modules/*' \
+  ! -path './node_modules/*' \
+  ! -path './yarn/*' \
+  ! -path './suite-native/app/ios/*' \
+  ! -path './submodules/*' \
+  ! -path './.husky/_/*' \
+  -print0 | xargs -0 shellcheck


### PR DESCRIPTION
This PR tweaks the pre-commit hook to enable working with both staged and unstaged files. 

In case you have staged changes on the file that you want to commit and then some other unstaged changes on the very same file, this fix will preserve the unstaged changes without committing them.


:exclamation: :point_right: The Git version at least `2.35` is required for this to work. For older Ubuntu the git can be updated from this repository: https://launchpad.net/%7Egit-core/+archive/ubuntu/ppa



-------

The unsolved issue is, that if you have staged and unstaged changes next to each other, it will produce conflict 

Staged:
![image](https://github.com/user-attachments/assets/dbcc395a-591c-4e9b-8a88-6b2b59f0d8db)

Unstaged:

![image](https://github.com/user-attachments/assets/858935bc-e888-40fe-832c-125fcade7c38)

Conflict:

![image](https://github.com/user-attachments/assets/cdfe5235-d3a9-4059-8c06-70f559f26fe8)
