### PR TITLE
blockchain-link: update networks to use trezor.io proxy servers

### DIFF
--- a/packages/blockchain-link/src/ui/config.ts
+++ b/packages/blockchain-link/src/ui/config.ts
@@ -4,10 +4,10 @@ export default [
             name: 'Ripple',
             worker: 'js/ripple-worker.js',
             server: [
-                'wss://xrplcluster.com',
-                'wss://xrpl.ws',
-                'wss://s1.ripple.com',
-                'wss://s2.ripple.com',
+                'wss://xrp1.trezor.io',
+                'wss://xrp2.trezor.io',
+                'wss://xrp3.trezor.io',
+                'wss://xrp4.trezor.io',
             ],
             debug: true,
         },
@@ -38,8 +38,7 @@ export default [
         blockchain: {
             name: 'Ripple Testnet',
             worker: 'js/ripple-worker.js',
-            server: ['wss://s.altnet.rippletest.net'],
-            // server: ['wss://s.devnet.rippletest.net'],
+            server: ['wss://txrp1.trezor.io'],
             debug: true,
         },
         data: {
@@ -499,8 +498,7 @@ export default [
         blockchain: {
             name: 'Cardano Mainnet',
             worker: 'js/blockfrost-worker.js',
-            server: ['wss://trezor-cardano-mainnet.blockfrost.io'],
-            // server: ['ws://localhost:3005'],
+            server: ['wss://ada1.trezor.io', 'wss://ada2.trezor.io'],
             debug: true,
         },
         data: {
@@ -523,7 +521,7 @@ export default [
         blockchain: {
             name: 'Cardano Preview Testnet',
             worker: 'js/blockfrost-worker.js',
-            server: ['wss://trezor-cardano-preview.blockfrost.io'],
+            server: ['wss://tada1.trezor.io'],
             debug: true,
         },
         data: {
@@ -579,7 +577,7 @@ export default [
             name: 'Solana Devnet',
             // we do not use path to worker build here because its not used, we use it just to match this config to actual implementation of the worker
             worker: 'solana',
-            server: ['https://solana-dev.trezor.io'],
+            server: ['https://dsol1.trezor.io'],
             debug: true,
         },
         data: {

--- a/packages/connect-common/files/coins.json
+++ b/packages/connect-common/files/coins.json
@@ -2582,7 +2582,7 @@
         {
             "blockchain_link": {
                 "type": "blockfrost",
-                "url": ["wss://trezor-cardano-mainnet.blockfrost.io"]
+                "url": ["wss://ada1.trezor.io", "wss://ada2.trezor.io"]
             },
             "curve": "ed25519",
             "decimals": 6,
@@ -2615,7 +2615,7 @@
             }
         },
         {
-            "blockchain_link": { "type": "solana", "url": ["https://solana-dev.trezor.io"] },
+            "blockchain_link": { "type": "solana", "url": ["https://dsol1.trezor.io"] },
             "curve": "ed25519",
             "decimals": 9,
             "is_testnet": false,
@@ -2705,7 +2705,7 @@
         {
             "blockchain_link": {
                 "type": "blockfrost",
-                "url": ["wss://trezor-cardano-preview.blockfrost.io"]
+                "url": ["wss://tada1.trezor.io"]
             },
             "curve": "ed25519",
             "decimals": 6,
@@ -2722,7 +2722,7 @@
             }
         },
         {
-            "blockchain_link": { "type": "ripple", "url": ["wss://s.altnet.rippletest.net"] },
+            "blockchain_link": { "type": "ripple", "url": ["wss://txrp1.trezor.io"] },
             "curve": "secp256k1",
             "decimals": 6,
             "is_testnet": false,
@@ -2789,10 +2789,10 @@
             "blockchain_link": {
                 "type": "ripple",
                 "url": [
-                    "wss://xrplcluster.com",
-                    "wss://xrpl.ws",
-                    "wss://s1.ripple.com",
-                    "wss://s2.ripple.com"
+                    "wss://xrp1.trezor.io",
+                    "wss://xrp2.trezor.io",
+                    "wss://xrp3.trezor.io",
+                    "wss://xrp4.trezor.io"
                 ]
             },
             "curve": "secp256k1",

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -524,7 +524,7 @@ export const networks = {
     },
     tsep: {
         symbol: 'tsep',
-        displaySymbol: 'tSEP',
+        displaySymbol: 'tETH',
         name: 'Ethereum Sepolia',
         networkType: 'ethereum',
         bip43Path: "m/44'/1'/0'/0/i",
@@ -540,7 +540,7 @@ export const networks = {
     },
     thol: {
         symbol: 'thol',
-        displaySymbol: 'tHOL',
+        displaySymbol: 'tETH',
         name: 'Ethereum Holesky',
         networkType: 'ethereum',
         bip43Path: "m/44'/1'/0'/0/i",
@@ -556,7 +556,7 @@ export const networks = {
     },
     dsol: {
         symbol: 'dsol',
-        displaySymbol: 'DSOL',
+        displaySymbol: 'dSOL',
         name: 'Solana Devnet',
         networkType: 'solana',
         bip43Path: "m/44'/501'/i'/0'",


### PR DESCRIPTION
## Description

- match display symbol of ethereum, cardano testnets with device 
- use trezor proxy servers for Cardano and Ripple and it's testnets so that we can react when something is not working

@trezor/qa please test that all xrp, ada, tada, txrp backends are working

## Screenshots:
![Screenshot 2025-01-02 at 13 41 56](https://github.com/user-attachments/assets/226e890c-751c-4053-a901-30f3e96a40da)

