### PR TITLE
feat(suite): do not show empty accounts in sell section

### DIFF
--- a/packages/suite/src/utils/wallet/coinmarket/__tests__/coinmarketUtils.test.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/__tests__/coinmarketUtils.test.ts
@@ -187,20 +187,6 @@ describe('coinmarket utils', () => {
                     {
                         accountType: 'normal',
                         balance: '0',
-                        cryptoName: 'Bitcoin',
-                        descriptor: 'descriptor1',
-                        label: 'BTC',
-                        value: 'bitcoin',
-                        decimals: 8,
-                    },
-                ],
-            },
-            {
-                label,
-                options: [
-                    {
-                        accountType: 'normal',
-                        balance: '0',
                         cryptoName: 'Ethereum',
                         descriptor: 'descriptor3',
                         label: 'ETH',

--- a/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
@@ -396,6 +396,8 @@ export const coinmarketBuildAccountOptions = ({
         const options: CoinmarketAccountOptionsGroupOptionProps[] =
             !skipNotNativeNetworkSymbols.includes(network.symbol) ? [option] : [];
 
+        const hasNativeToken = options.length > 0;
+
         // add crypto tokens to options
         if (tokens && tokens.length > 0) {
             const hasCoinDefinitions = getNetworkFeatures(account.symbol).includes(
@@ -436,6 +438,13 @@ export const coinmarketBuildAccountOptions = ({
                     decimals: token.decimals,
                 });
             });
+        }
+
+        const hasTokens = hasNativeToken && options.length > 1;
+
+        // exclude account if the native token has 0 balance and has no other tokens
+        if (!hasTokens && hasNativeToken && options[0].balance === '0') {
+            return;
         }
 
         groups.push({


### PR DESCRIPTION
## Description

In sell sections, empty accounts are hidden and therefore cannot be selected, specifically:
- if balance is 0 and there are no tokens, the account is hidden
- if balance is 0 and there are tokens, the account is shown

## Related Issue

Resolve #15036 

## Screenshots:
ETH has 0 balance but there are tokens with non-zero balance.

<img width="717" alt="Screenshot 2025-01-02 at 15 48 16" src="https://github.com/user-attachments/assets/ed95140c-3a88-4f5e-bfc7-e8e51a0b39eb" />

Other accounts with 0 balance and no tokens are hidden.