### PR TITLE
fix(suite): display symbols

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 
 import { selectSelectedDevice } from '@suite-common/wallet-core';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol, isNetworkSymbol } from '@suite-common/wallet-config';
 
 import { showAddress } from 'src/actions/wallet/receiveActions';
 import { Translation } from 'src/components/suite';
@@ -39,16 +39,16 @@ export const ConfirmAddressModal = ({ addressPath, value, ...props }: ConfirmAdd
 
     const getHeading = () => {
         if (modalCryptoId) {
-            const coinSymbol = cryptoIdToCoinSymbol(modalCryptoId)?.toUpperCase();
-            const symbol = cryptoIdToSymbol(modalCryptoId)?.toUpperCase();
+            const coinSymbol = cryptoIdToCoinSymbol(modalCryptoId)?.toLowerCase();
+            const symbol = cryptoIdToSymbol(modalCryptoId);
 
             if (symbol && coinSymbol !== symbol) {
                 return (
                     <Translation
                         id="TR_ADDRESS_MODAL_TITLE_EXCHANGE"
                         values={{
-                            networkSymbol: symbol,
-                            networkCurrencyName: coinSymbol,
+                            networkSymbol: getNetworkDisplaySymbol(symbol),
+                            networkCurrencyName: coinSymbol?.toUpperCase(),
                         }}
                     />
                 );
@@ -58,7 +58,10 @@ export const ConfirmAddressModal = ({ addressPath, value, ...props }: ConfirmAdd
                 <Translation
                     id="TR_ADDRESS_MODAL_TITLE"
                     values={{
-                        networkSymbol: coinSymbol,
+                        networkSymbol:
+                            coinSymbol && isNetworkSymbol(coinSymbol)
+                                ? getNetworkDisplaySymbol(coinSymbol)
+                                : coinSymbol?.toUpperCase(),
                     }}
                 />
             );

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ImportTransactionModal/ImportTransactionModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ImportTransactionModal/ImportTransactionModal.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import { UserContextPayload } from '@suite-common/suite-types';
 import { parseCSV } from '@suite-common/wallet-utils';
+import { networksCollection } from '@suite-common/wallet-config';
 
 import { Translation, Modal } from 'src/components/suite';
 import type { ExtendedMessageDescriptor } from 'src/types/suite';
@@ -29,6 +30,17 @@ export const ImportTransactionModal = ({ onCancel, decision }: ImportTransaction
 
     const onCsvResult = (result: string) => {
         const parsed = parseCSV(result, ['address', 'amount', 'currency', 'label'], delimiter);
+
+        parsed.forEach(item => {
+            const network = networksCollection.find(
+                network => network.displaySymbol === item.currency,
+            );
+
+            if (network) {
+                item.currency = network.symbol;
+            }
+        });
+
         decision.resolve(parsed);
         onCancel();
     };

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
@@ -2,6 +2,7 @@ import { getTxHeaderSymbol, isSupportedEthStakingNetworkSymbol } from '@suite-co
 import { AccountTransaction } from '@trezor/connect';
 import { Row } from '@trezor/components';
 import { spacings } from '@trezor/theme';
+import { getNetworkDisplaySymbol, isNetworkSymbol } from '@suite-common/wallet-config';
 
 import { useTranslation } from 'src/hooks/suite';
 import { WalletAccountTransaction } from 'src/types/wallet';
@@ -79,7 +80,11 @@ export const TransactionHeader = ({ transaction, isPending }: TransactionHeaderP
     }
 
     const isMultiTokenTransaction = transaction.tokens.length > 1;
-    const symbol = getTxHeaderSymbol(transaction)?.toUpperCase();
+    const transactionSymbol = getTxHeaderSymbol(transaction);
+    const symbol =
+        transactionSymbol && isNetworkSymbol(transactionSymbol)
+            ? getNetworkDisplaySymbol(transactionSymbol)
+            : transactionSymbol?.toUpperCase();
 
     return (
         <BlurUrls

--- a/packages/suite/src/hooks/wallet/coinmarket/useCoinmarketInfo.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/useCoinmarketInfo.ts
@@ -2,7 +2,11 @@ import { useCallback } from 'react';
 
 import { CoinInfo, CryptoId } from 'invity-api';
 
-import { getNetwork, getNetworkByCoingeckoNativeId } from '@suite-common/wallet-config';
+import {
+    getNetwork,
+    getNetworkByCoingeckoNativeId,
+    isNetworkSymbol,
+} from '@suite-common/wallet-config';
 import addressValidator from '@trezor/address-validator';
 
 import { useSelector } from 'src/hooks/suite/useSelector';
@@ -17,19 +21,26 @@ const supportedAddressValidatorSymbols = new Set(
     addressValidator.getCurrencies().map(c => c.symbol),
 );
 
-function toCryptoOption(cryptoId: CryptoId, coinInfo: CoinInfo): CoinmarketCryptoSelectItemProps {
+const toCryptoOption = (
+    cryptoId: CryptoId,
+    coinInfo: CoinInfo,
+): CoinmarketCryptoSelectItemProps => {
     const { networkId, contractAddress } = parseCryptoId(cryptoId);
+    const coinInfoSymbol = coinInfo.symbol.toLowerCase();
+    const displaySymbol = isNetworkSymbol(coinInfoSymbol)
+        ? getNetwork(coinInfoSymbol)?.displaySymbol
+        : coinInfoSymbol.toUpperCase();
 
     return {
         type: 'currency',
         value: cryptoId,
-        label: coinInfo.symbol.toUpperCase(),
+        label: displaySymbol,
         cryptoName: coinInfo.name,
         coingeckoId: networkId,
         contractAddress: contractAddress || null,
         symbol: coinInfo.symbol,
     };
-}
+};
 
 const sortPopularCurrencies = (
     a: CoinmarketCryptoSelectItemProps,

--- a/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
@@ -8,8 +8,10 @@ import {
     getNetwork,
     getNetworkByCoingeckoId,
     getNetworkByCoingeckoNativeId,
+    getNetworkDisplaySymbol,
     getNetworkFeatures,
     getNetworkType,
+    isNetworkSymbol,
 } from '@suite-common/wallet-config';
 import TrezorConnect from '@trezor/connect';
 import { DefinitionType, isTokenDefinitionKnown } from '@suite-common/token-definitions';
@@ -76,6 +78,14 @@ export function testnetToProdCryptoId(cryptoId: CryptoId): CryptoId {
 
 export const getNetworkName = (symbol: NetworkSymbol) => {
     return getNetwork(symbol).name;
+};
+
+export const getCoinmarketNetworkDisplaySymbol = (symbol: string) => {
+    const symbolLowered = symbol.toLowerCase();
+
+    return isNetworkSymbol(symbolLowered)
+        ? getNetworkDisplaySymbol(symbolLowered)
+        : symbol.toUpperCase();
 };
 
 interface CoinmarketGetDecimalsProps {
@@ -376,7 +386,7 @@ export const coinmarketBuildAccountOptions = ({
         const accountDecimals = network.decimals;
         const option: CoinmarketAccountOptionsGroupOptionProps = {
             value: network.coingeckoNativeId as CryptoId,
-            label: accountSymbol.toUpperCase(),
+            label: getNetworkDisplaySymbol(accountSymbol),
             cryptoName: network.name,
             descriptor,
             balance: formattedBalance ?? '',

--- a/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
+++ b/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
@@ -5,7 +5,7 @@ import { fromWei } from 'web3-utils';
 import { FiatCurrencyCode } from '@suite-common/suite-config';
 import { trezorLogo } from '@suite-common/suite-constants';
 import { TokenDefinitions, getIsPhishingTransaction } from '@suite-common/token-definitions';
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol, NetworkSymbol } from '@suite-common/wallet-config';
 import {
     ExportFileType,
     RatesByTimestamps,
@@ -186,11 +186,13 @@ const prepareContent = (
                     const targetData = {
                         ...sharedData,
                         fee: !hasFeeBeenAlreadyUsed ? t.fee : '', // fee only once per tx
-                        feeSymbol: !hasFeeBeenAlreadyUsed ? symbol.toUpperCase() : '',
+                        feeSymbol: !hasFeeBeenAlreadyUsed
+                            ? getNetworkDisplaySymbol(data.symbol)
+                            : '',
                         address: target.isAddress ? target.addresses[0] : '', // SENT - it is destination address, RECV - it is MY address
                         label: target.isAddress && target.metadataLabel ? target.metadataLabel : '',
                         amount: target.isAddress ? target.amount : '',
-                        symbol: target.isAddress ? symbol.toUpperCase() : '',
+                        symbol: target.isAddress ? getNetworkDisplaySymbol(data.symbol) : '',
                         fiat:
                             target.isAddress && target.amount && historicRate
                                 ? localizeNumber(
@@ -227,7 +229,9 @@ const prepareContent = (
                     const tokenData = {
                         ...sharedData,
                         fee: !hasFeeBeenAlreadyUsed ? t.fee : '', // fee only once per tx
-                        feeSymbol: !hasFeeBeenAlreadyUsed ? symbol.toUpperCase() : '',
+                        feeSymbol: !hasFeeBeenAlreadyUsed
+                            ? getNetworkDisplaySymbol(data.symbol)
+                            : '',
                         address: token.to || '', // SENT - it is destination address, RECV - it is MY address
                         label: '', // token transactions do not have labels
                         amount: token.amount, // TODO: what to show if token.decimals missing so amount is not formatted correctly?
@@ -256,11 +260,13 @@ const prepareContent = (
                     const internalTransferData = {
                         ...sharedData,
                         fee: !hasFeeBeenAlreadyUsed ? t.fee : '', // fee only once per tx
-                        feeSymbol: !hasFeeBeenAlreadyUsed ? symbol.toUpperCase() : '',
+                        feeSymbol: !hasFeeBeenAlreadyUsed
+                            ? getNetworkDisplaySymbol(data.symbol)
+                            : '',
                         address: internal.to || '', // SENT - it is destination address, RECV - it is MY address
                         label: '', // internal transactions do not have labels
                         amount: internal.amount,
-                        symbol: symbol.toUpperCase(), // if symbol not available, use contract address
+                        symbol: getNetworkDisplaySymbol(data.symbol), // if symbol not available, use contract address
                         fiat:
                             internal.amount && historicRate
                                 ? localizeNumber(

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketAddressOptions.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketAddressOptions.tsx
@@ -15,7 +15,10 @@ import { useAccountAddressDictionary } from 'src/hooks/wallet/useAccounts';
 import { selectLabelingDataForAccount } from 'src/reducers/suite/metadataReducer';
 import { useSelector } from 'src/hooks/suite';
 import { CoinmarketBalance } from 'src/views/wallet/coinmarket/common/CoinmarketBalance';
-import { getCoinmarketNetworkDecimals } from 'src/utils/wallet/coinmarket/coinmarketUtils';
+import {
+    getCoinmarketNetworkDecimals,
+    getCoinmarketNetworkDisplaySymbol,
+} from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import { useCoinmarketInfo } from 'src/hooks/wallet/coinmarket/useCoinmarketInfo';
 import { isCoinmarketExchangeContext } from 'src/utils/wallet/coinmarket/coinmarketTypingUtils';
 import { useCoinmarketFormContext } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonForm';
@@ -111,6 +114,10 @@ export const CoinmarketAddressOptions = <TFieldValues extends CoinmarketBuyAddre
                             ? formatAmount(accountAddress.balance, networkDecimals)
                             : accountAddress.balance;
 
+                        const coinSymbol = cryptoIdToCoinSymbol(receiveSymbol);
+                        const displaySymbol =
+                            coinSymbol && getCoinmarketNetworkDisplaySymbol(coinSymbol);
+
                         return (
                             <Column>
                                 <div data-testid="@coinmarket/form/verify/address">
@@ -120,7 +127,7 @@ export const CoinmarketAddressOptions = <TFieldValues extends CoinmarketBuyAddre
                                 <InfoSegments typographyStyle="label" variant="tertiary">
                                     <CoinmarketBalance
                                         balance={balance}
-                                        cryptoSymbolLabel={cryptoIdToCoinSymbol(receiveSymbol)}
+                                        displaySymbol={displaySymbol}
                                         symbol={account.symbol}
                                         sendCryptoSelect={sendCryptoSelect}
                                     />

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketBalance.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketBalance.tsx
@@ -14,8 +14,8 @@ import {
 
 interface CoinmarketBalanceProps {
     balance: string | undefined;
-    cryptoSymbolLabel: string | undefined;
     symbol: NetworkSymbol;
+    displaySymbol: string | undefined;
     tokenAddress?: TokenAddress | undefined;
     showOnlyAmount?: boolean;
     amountInCrypto?: boolean;
@@ -24,15 +24,15 @@ interface CoinmarketBalanceProps {
 
 export const CoinmarketBalance = ({
     balance, // expects a value in full units (BTC not sats)
-    cryptoSymbolLabel,
     symbol,
+    displaySymbol,
     tokenAddress,
     showOnlyAmount,
     amountInCrypto,
     sendCryptoSelect,
 }: CoinmarketBalanceProps) => {
     const { shouldSendInSats } = useBitcoinAmountUnit(symbol);
-    const balanceCurrency = coinmarketGetAccountLabel(cryptoSymbolLabel ?? '', shouldSendInSats);
+    const balanceCurrency = coinmarketGetAccountLabel(displaySymbol ?? '', shouldSendInSats);
     const networkDecimals = getCoinmarketNetworkDecimals({
         sendCryptoSelect,
         network: getNetwork(symbol),
@@ -56,7 +56,7 @@ export const CoinmarketBalance = ({
                 &asymp;{' '}
                 {!amountInCrypto ? (
                     <HiddenPlaceholder>
-                        {formattedBalance} {cryptoSymbolLabel}
+                        {formattedBalance} {balanceCurrency}
                     </HiddenPlaceholder>
                 ) : (
                     stringBalance &&

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketCryptoAmount.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketCryptoAmount.tsx
@@ -8,6 +8,7 @@ import { FormattedCryptoAmount } from 'src/components/suite';
 import { CoinmarketCoinLogo } from 'src/views/wallet/coinmarket/common/CoinmarketCoinLogo';
 import { useCoinmarketInfo } from 'src/hooks/wallet/coinmarket/useCoinmarketInfo';
 import { CoinmarketTestWrapper } from 'src/views/wallet/coinmarket';
+import { getCoinmarketNetworkDisplaySymbol } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 
 const LogoWrapper = styled.div`
     line-height: 0;
@@ -25,7 +26,7 @@ export const CoinmarketCryptoAmount = ({
     displayLogo,
 }: CoinmarketCryptoAmountProps) => {
     const { cryptoIdToCoinSymbol } = useCoinmarketInfo();
-    const symbol = cryptoIdToCoinSymbol(cryptoId);
+    const symbol = cryptoIdToCoinSymbol(cryptoId)?.toLowerCase();
 
     if (!amount || amount === '') {
         return (
@@ -35,7 +36,7 @@ export const CoinmarketCryptoAmount = ({
                         <CoinmarketCoinLogo cryptoId={cryptoId} margin={{ right: spacings.xs }} />
                     </LogoWrapper>
                 )}
-                {symbol}
+                {symbol ? getCoinmarketNetworkDisplaySymbol(symbol) : ''}
             </Row>
         );
     }

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputAccount.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputAccount.tsx
@@ -96,7 +96,7 @@ export const CoinmarketFormInputAccount = <
                                 balance={fiatValues.accountBalance}
                                 symbol={fiatValues.symbol}
                                 tokenAddress={fiatValues.tokenAddress}
-                                cryptoSymbolLabel={selectedOption?.label}
+                                displaySymbol={selectedOption?.label}
                                 sendCryptoSelect={selectedOption}
                             />
                         )

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputFiatCrypto/CoinmarketFormInputCryptoAmount.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputFiatCrypto/CoinmarketFormInputCryptoAmount.tsx
@@ -26,6 +26,7 @@ import {
 import {
     coinmarketGetAccountLabel,
     getCoinmarketNetworkDecimals,
+    getCoinmarketNetworkDisplaySymbol,
 } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import {
     FORM_OUTPUT_AMOUNT,
@@ -73,6 +74,10 @@ export const CoinmarketFormInputCryptoAmount = <TFieldValues extends CoinmarketA
             ? (errors as FieldErrors<CoinmarketSellExchangeFormProps>)?.outputs?.[0]?.amount
             : (errors as FieldErrors<CoinmarketBuyFormProps>).cryptoInput;
     const symbol = cryptoSelect?.value && cryptoIdToCoinSymbol(cryptoSelect?.value);
+    const displaySymbol = coinmarketGetAccountLabel(
+        getCoinmarketNetworkDisplaySymbol(symbol ?? ''),
+        shouldSendInSats,
+    );
     const decimals = getCoinmarketNetworkDecimals({
         sendCryptoSelect: !isCoinmarketBuyContext(context)
             ? context.getValues()[FORM_SEND_CRYPTO_CURRENCY_SELECT]
@@ -129,14 +134,7 @@ export const CoinmarketFormInputCryptoAmount = <TFieldValues extends CoinmarketA
             rules={cryptoInputRules}
             maxLength={formInputsMaxLength.amount}
             bottomText={cryptoInputError?.message || null}
-            innerAddon={
-                <>
-                    {coinmarketGetAccountLabel(
-                        cryptoSelect?.value && symbol ? symbol : '',
-                        shouldSendInSats,
-                    )}
-                </>
-            }
+            innerAddon={<>{displaySymbol}</>}
             data-testid="@coinmarket/form/crypto-input"
         />
     );

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputFiatCrypto/CoinmarketFormInputFiatCrypto.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputFiatCrypto/CoinmarketFormInputFiatCrypto.tsx
@@ -6,7 +6,10 @@ import {
     CoinmarketSellFormProps,
 } from 'src/types/coinmarket/coinmarketForm';
 import { CoinmarketFormSwitcherCryptoFiat } from 'src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormSwitcherCryptoFiat';
-import { coinmarketGetAmountLabels } from 'src/utils/wallet/coinmarket/coinmarketUtils';
+import {
+    coinmarketGetAmountLabels,
+    getCoinmarketNetworkDisplaySymbol,
+} from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import { CoinmarketFormInputCryptoAmount } from 'src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputFiatCrypto/CoinmarketFormInputCryptoAmount';
 import { useCoinmarketInfo } from 'src/hooks/wallet/coinmarket/useCoinmarketInfo';
 import { CoinmarketFormInputFiat } from 'src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputFiatCrypto/CoinmarketFormInputFiat';
@@ -38,6 +41,11 @@ export const CoinmarketFormInputFiatCrypto = <
     } = formProps;
     const { amountInCrypto } = methods.getValues();
     const amountLabels = coinmarketGetAmountLabels({ type, amountInCrypto });
+    const coinSymbol =
+        !amountInCrypto && cryptoCurrencyLabel
+            ? cryptoIdToCoinSymbol(cryptoCurrencyLabel)
+            : currencySelectLabel ?? '';
+    const displaySymbol = coinSymbol && getCoinmarketNetworkDisplaySymbol(coinSymbol);
 
     const inputProps = {
         cryptoInputName,
@@ -47,11 +55,7 @@ export const CoinmarketFormInputFiatCrypto = <
         labelLeft: showLabel ? <Translation id={amountLabels.inputLabel} /> : undefined,
         labelRight: showLabel ? (
             <CoinmarketFormSwitcherCryptoFiat
-                symbol={
-                    !amountInCrypto && cryptoCurrencyLabel
-                        ? cryptoIdToCoinSymbol(cryptoCurrencyLabel)
-                        : currencySelectLabel ?? ''
-                }
+                currency={displaySymbol}
                 isDisabled={isFormLoading}
                 toggleAmountInCrypto={toggleAmountInCrypto}
             />

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormSwitcherCryptoFiat.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormSwitcherCryptoFiat.tsx
@@ -3,13 +3,14 @@ import { TextButton } from '@trezor/components';
 import { Translation } from 'src/components/suite';
 
 interface CoinmarketFormSwitcherCryptoFiatProps {
-    symbol?: string;
+    // displaySymbol or fiat currency
+    currency?: string;
     isDisabled: boolean;
     toggleAmountInCrypto: () => void;
 }
 
 export const CoinmarketFormSwitcherCryptoFiat = ({
-    symbol,
+    currency,
     isDisabled,
     toggleAmountInCrypto,
 }: CoinmarketFormSwitcherCryptoFiatProps) => (
@@ -24,7 +25,7 @@ export const CoinmarketFormSwitcherCryptoFiat = ({
         <Translation
             id="TR_COINMARKET_ENTER_AMOUNT_IN"
             values={{
-                currency: symbol,
+                currency,
             }}
         />
     </TextButton>

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInputs.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInputs.tsx
@@ -85,7 +85,7 @@ export const CoinmarketFormInputs = () => {
                             />
                             <CoinmarketBalance
                                 balance={outputAmount}
-                                cryptoSymbolLabel={sendCryptoSelect?.value}
+                                displaySymbol={sendCryptoSelect?.value}
                                 symbol={account.symbol}
                                 tokenAddress={tokenAddress as TokenAddress}
                                 showOnlyAmount
@@ -166,7 +166,7 @@ export const CoinmarketFormInputs = () => {
                             />
                             <CoinmarketBalance
                                 balance={outputAmount}
-                                cryptoSymbolLabel={sendCryptoSelect?.value}
+                                displaySymbol={sendCryptoSelect?.value}
                                 symbol={account.symbol}
                                 tokenAddress={tokenAddress}
                                 showOnlyAmount

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormOfferCryptoAmount.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormOfferCryptoAmount.tsx
@@ -17,9 +17,9 @@ export const CoinmarketFormOfferCryptoAmount = ({
     cryptoId,
 }: CoinmarketCryptoAmountProps) => {
     const { cryptoIdToCoinSymbol } = useCoinmarketInfo();
-    const symbol = cryptoIdToCoinSymbol(cryptoId);
+    const coinSymbol = cryptoIdToCoinSymbol(cryptoId)?.toLowerCase(); // lowercase - possible can be a NetworkSymbol
 
-    if (!symbol) {
+    if (!coinSymbol) {
         return;
     }
 
@@ -33,7 +33,7 @@ export const CoinmarketFormOfferCryptoAmount = ({
             >
                 <FormattedCryptoAmount
                     value={amount}
-                    symbol={symbol}
+                    symbol={coinSymbol}
                     isRawString
                     isBalance={false}
                 />

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketInfo/CoinmarketInfoHeader.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketInfo/CoinmarketInfoHeader.tsx
@@ -5,7 +5,10 @@ import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
 import { useCoinmarketInfo } from 'src/hooks/wallet/coinmarket/useCoinmarketInfo';
-import { parseCryptoId } from 'src/utils/wallet/coinmarket/coinmarketUtils';
+import {
+    getCoinmarketNetworkDisplaySymbol,
+    parseCryptoId,
+} from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import { CoinmarketCoinLogo } from 'src/views/wallet/coinmarket/common/CoinmarketCoinLogo';
 
 interface CoinmarketInfoHeaderProps {
@@ -16,22 +19,25 @@ export const CoinmarketInfoHeader = ({ receiveCurrency }: CoinmarketInfoHeaderPr
     const { cryptoIdToCoinSymbol, cryptoIdToPlatformName } = useCoinmarketInfo();
 
     const { networkId, contractAddress } = parseCryptoId(receiveCurrency!);
-    const network = cryptoIdToPlatformName(networkId);
+    const platform = cryptoIdToPlatformName(networkId);
+    const displaySymbol = platform ? getCoinmarketNetworkDisplaySymbol(platform) : platform;
+    const tokenNameHelper = receiveCurrency && cryptoIdToCoinSymbol(receiveCurrency);
+    const tokenName = tokenNameHelper ? getCoinmarketNetworkDisplaySymbol(tokenNameHelper) : '';
 
     return (
         <Row gap={spacings.xs}>
             {receiveCurrency && <CoinmarketCoinLogo cryptoId={receiveCurrency} size={24} />}
             <Text typographyStyle="titleSmall">
-                {contractAddress && network ? (
+                {contractAddress && displaySymbol ? (
                     <Translation
                         id="TR_COINMARKET_TOKEN_NETWORK"
                         values={{
-                            tokenName: cryptoIdToCoinSymbol(receiveCurrency!),
-                            networkName: network,
+                            tokenName,
+                            networkName: displaySymbol,
                         }}
                     />
                 ) : (
-                    cryptoIdToCoinSymbol(receiveCurrency!)
+                    tokenName
                 )}
             </Text>
         </Row>

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketVerify/CoinmarketVerify.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketVerify/CoinmarketVerify.tsx
@@ -23,6 +23,7 @@ import {
     isCoinmarketBuyContext,
     isCoinmarketExchangeContext,
 } from 'src/utils/wallet/coinmarket/coinmarketTypingUtils';
+import { getCoinmarketNetworkDisplaySymbol } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 
 interface CoinmarketVerifyProps {
     coinmarketVerifyAccount: CoinmarketVerifyAccountReturnProps;
@@ -59,6 +60,7 @@ export const CoinmarketVerify = ({ coinmarketVerifyAccount, currency }: Coinmark
     const { accountTooltipTranslationId, addressTooltipTranslationId } = getTranslationIds(
         selectedAccountOption?.type,
     );
+    const coinSymbol = getCoinmarketNetworkDisplaySymbol(cryptoIdToCoinSymbol(currency) ?? '');
 
     const { ref: networkRef, ...networkField } = form.register('address', {
         required: translationString('TR_EXCHANGE_RECEIVING_ADDRESS_REQUIRED'),
@@ -105,7 +107,7 @@ export const CoinmarketVerify = ({ coinmarketVerifyAccount, currency }: Coinmark
             <Paragraph typographyStyle="hint" variant="tertiary">
                 <Translation
                     id="TR_EXCHANGE_RECEIVING_ADDRESS_INFO"
-                    values={{ symbol: cryptoIdToCoinSymbol(currency) }}
+                    values={{ symbol: coinSymbol }}
                 />
             </Paragraph>
             <CoinmarketVerifyOptions

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketVerify/CoinmarketVerifyOptions.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketVerify/CoinmarketVerifyOptions.tsx
@@ -6,7 +6,10 @@ import {
     CoinmarketVerifyOptionsProps,
     CoinmarketVerifyFormAccountOptionProps,
 } from 'src/types/coinmarket/coinmarketVerify';
-import { parseCryptoId } from 'src/utils/wallet/coinmarket/coinmarketUtils';
+import {
+    getCoinmarketNetworkDisplaySymbol,
+    parseCryptoId,
+} from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import { CoinmarketVerifyOptionsItem } from 'src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketVerify/CoinmarketVerifyOptionsItem';
 
 export const CoinmarketVerifyOptions = ({
@@ -20,9 +23,10 @@ export const CoinmarketVerifyOptions = ({
     const { cryptoIdToPlatformName, cryptoIdToCoinName } = useCoinmarketInfo();
 
     const { networkId, contractAddress } = parseCryptoId(receiveNetwork);
-    const networkName = contractAddress
+    const coinName = contractAddress
         ? cryptoIdToPlatformName(networkId)
         : cryptoIdToCoinName(networkId);
+    const displaySymbol = coinName && getCoinmarketNetworkDisplaySymbol(coinName);
 
     return (
         <Select
@@ -43,7 +47,7 @@ export const CoinmarketVerifyOptions = ({
                 <Translation
                     id="TR_EXCHANGE_SELECT_RECEIVE_ACCOUNT"
                     values={{
-                        symbol: networkName,
+                        symbol: displaySymbol,
                     }}
                 />
             }

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketVerify/CoinmarketVerifyOptionsItem.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketVerify/CoinmarketVerifyOptionsItem.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { Column, Icon, Row, variables } from '@trezor/components';
 import { CoinLogo } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
+import { getNetwork } from '@suite-common/wallet-config';
 
 import { AccountLabeling, Translation } from 'src/components/suite';
 import { FORM_SEND_CRYPTO_CURRENCY_SELECT } from 'src/constants/wallet/coinmarket/form';
@@ -44,7 +45,7 @@ export const CoinmarketVerifyOptionsItem = ({
                     </AccountName>
                     <CoinmarketBalance
                         balance={formattedBalance}
-                        cryptoSymbolLabel={symbol.toLocaleUpperCase()}
+                        displaySymbol={getNetwork(symbol).displaySymbol}
                         symbol={symbol}
                         sendCryptoSelect={
                             isCoinmarketExchangeContext(context)

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -418,12 +418,11 @@ export const formatNetworkAmount = (
     let formattedAmount = formatAmount(amount, decimals);
 
     if (withSymbol) {
-        let formattedSymbol = getNetworkDisplaySymbol(symbol).toUpperCase();
+        let formattedSymbol = getNetworkDisplaySymbol(symbol);
 
         if (isSatoshis) {
             formattedAmount = amount;
-            formattedSymbol =
-                symbol === 'btc' ? 'sat' : `sat ${getNetworkDisplaySymbol(symbol).toUpperCase()}`;
+            formattedSymbol = symbol === 'btc' ? 'sat' : `sat ${getNetworkDisplaySymbol(symbol)}`;
         }
 
         return `${formattedAmount} ${formattedSymbol}`;


### PR DESCRIPTION
## Description
Fix display symbols. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/16121

## Screenshots:

### Before
![Screenshot 2024-12-29 at 17 11 50](https://github.com/user-attachments/assets/ca2fbd96-c6e5-4cfb-8156-db741b47b139)
![Screenshot 2024-12-29 at 17 14 00](https://github.com/user-attachments/assets/48ace66b-0d6f-4c2c-b1ca-764422e0620a)
![Screenshot 2024-12-29 at 17 14 17](https://github.com/user-attachments/assets/6eb087a9-e994-4e67-a9ad-6dc7a6329dc5)
![Screenshot 2024-12-29 at 17 17 10](https://github.com/user-attachments/assets/3c33f4ae-6a8f-4089-b61d-cd64c6f00768)
![Screenshot 2024-12-29 at 17 17 25](https://github.com/user-attachments/assets/1e546298-8fe0-43dc-8296-518ad5ce7382)
![Screenshot 2024-12-29 at 17 21 09](https://github.com/user-attachments/assets/3631dbb3-9eaf-40ab-a1ee-ed0336d21c17)
![Screenshot 2024-12-29 at 17 30 51 (2)](https://github.com/user-attachments/assets/ff201b5f-2088-4f6f-bb14-1870b011bc07)

### After
![image](https://github.com/user-attachments/assets/d9ef8be8-0b0e-4a1b-b50e-d84a289f7791)

![image](https://github.com/user-attachments/assets/fceb1593-8f5b-411f-8504-d18fcd24d4c8) (this is only testing case, `TEST` symbol is correct)

![image](https://github.com/user-attachments/assets/9310be8d-77f2-4798-9df5-df52950d3638)
(this is only testing case, `TEST` symbol is correct)

<img width="1351" alt="image" src="https://github.com/user-attachments/assets/b614cf33-0f72-4bed-bd9d-b34904626d40" />

![image](https://github.com/user-attachments/assets/13787f18-b2a8-4af6-b578-7d92ada87896)
(this is only testing case, `TEST` symbol is correct)


