### PR TITLE
fix(components): reenable closing modals with ESC

### DIFF
--- a/packages/components/src/components/NewModal/NewModal.tsx
+++ b/packages/components/src/components/NewModal/NewModal.tsx
@@ -228,7 +228,7 @@ const NewModal = ({ isBackdropCancelable = true, ...rest }: NewModalProps) => {
             onClick={isBackdropCancelable ? onCancel : undefined}
             alignment={alignment}
         >
-            <NewModalBase {...rest} />
+            <NewModalBase isBackdropCancelable={isBackdropCancelable} {...rest} />
         </NewModalBackdrop>
     );
 };


### PR DESCRIPTION
Make modals cancellable by ESC again.

How to reproduce:
- Open a modal (e.g. Show application log).
- Press ESC.
- Modal should close.
