### PR TITLE
fix(e2e): Fix dry backup run test

### DIFF
--- a/packages/suite-desktop-core/e2e/support/pageActions/devicePromptActions.ts
+++ b/packages/suite-desktop-core/e2e/support/pageActions/devicePromptActions.ts
@@ -3,10 +3,12 @@ import { Locator, Page, expect } from '@playwright/test';
 export class DevicePromptActions {
     private readonly confirmOnDevicePrompt: Locator;
     private readonly connectDevicePrompt: Locator;
+    readonly modal: Locator;
 
     constructor(page: Page) {
         this.confirmOnDevicePrompt = page.getByTestId('@onboarding/confirm-on-device');
         this.connectDevicePrompt = page.getByTestId('@connect-device-prompt');
+        this.modal = page.getByTestId('@modal');
     }
 
     async confirmOnDevicePromptIsShown() {

--- a/packages/suite-desktop-core/e2e/tests/recovery/t1b1-dry-run.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/recovery/t1b1-dry-run.test.ts
@@ -1,13 +1,13 @@
+import { MNEMONICS } from '@trezor/trezor-user-env-link';
+
 import { test, expect } from '../../support/fixtures';
 
-const mnemonic =
-    'nasty answer gentle inform unaware abandon regret supreme dragon gravity behind lava dose pilot garden into dynamic outer hard speed luxury run truly armed';
 const pin = '1';
 
 test.describe('Recovery T1B1 - dry run', { tag: ['@group=device-management'] }, () => {
     test.use({
         emulatorStartConf: { model: 'T1B1', version: '1-latest', wipe: true },
-        emulatorSetupConf: { mnemonic, pin },
+        emulatorSetupConf: { mnemonic: MNEMONICS.mnemonic_all, pin },
     });
 
     test.beforeEach(async ({ onboardingPage, settingsPage }) => {
@@ -23,9 +23,9 @@ test.describe('Recovery T1B1 - dry run', { tag: ['@group=device-management'] }, 
         trezorUserEnvLink,
     }) => {
         await settingsPage.checkSeedButton.click();
-        await recoveryPage.initDryCheck('basic', 24);
+        await recoveryPage.initDryCheck('basic', 12);
         await trezorInput.enterPinOnBlindMatrix(pin);
-        await trezorInput.inputMnemonicT1B1(mnemonic);
+        await trezorInput.inputMnemonicT1B1(MNEMONICS.mnemonic_all);
         await trezorUserEnvLink.pressYes();
         await expect(recoveryPage.successTitle).toHaveText('Wallet backup checked successfully');
     });

--- a/packages/suite-desktop-core/e2e/tests/recovery/t1b1-dry-run.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/recovery/t1b1-dry-run.test.ts
@@ -1,13 +1,13 @@
-import { MNEMONICS } from '@trezor/trezor-user-env-link';
-
 import { test, expect } from '../../support/fixtures';
 
+const mnemonic =
+    'nasty answer gentle inform unaware abandon regret supreme dragon gravity behind lava dose pilot garden into dynamic outer hard speed luxury run truly armed';
 const pin = '1';
 
 test.describe('Recovery T1B1 - dry run', { tag: ['@group=device-management'] }, () => {
     test.use({
         emulatorStartConf: { model: 'T1B1', version: '1-latest', wipe: true },
-        emulatorSetupConf: { mnemonic: MNEMONICS.mnemonic_all, pin },
+        emulatorSetupConf: { mnemonic, pin },
     });
 
     test.beforeEach(async ({ onboardingPage, settingsPage }) => {
@@ -21,11 +21,15 @@ test.describe('Recovery T1B1 - dry run', { tag: ['@group=device-management'] }, 
         recoveryPage,
         trezorInput,
         trezorUserEnvLink,
+        devicePrompt,
     }) => {
         await settingsPage.checkSeedButton.click();
-        await recoveryPage.initDryCheck('basic', 12);
+        await recoveryPage.initDryCheck('basic', 24);
         await trezorInput.enterPinOnBlindMatrix(pin);
-        await trezorInput.inputMnemonicT1B1(MNEMONICS.mnemonic_all);
+        await trezorInput.inputMnemonicT1B1(mnemonic);
+        await expect(devicePrompt.modal).toContainText(
+            "Follow the instructions on your Trezor's screen",
+        );
         await trezorUserEnvLink.pressYes();
         await expect(recoveryPage.successTitle).toHaveText('Wallet backup checked successfully');
     });


### PR DESCRIPTION
## Description

Attemp to fix broekn test Recovery T2T1 - dry run 

the logic for inputing words now takes into account fakeWords
I will rerun the test group 5 times to verify stability of the fix

## Related Issue 

Resolves issue reported by dev team

## Screenshots:
