### PR TITLE
Fix flaky connect tests

### DIFF
--- a/packages/blockchain-link/src/workers/blockfrost/index.ts
+++ b/packages/blockchain-link/src/workers/blockfrost/index.ts
@@ -91,7 +91,8 @@ const pushTransaction = async (request: Request<MessageTypes.PushTransaction>) =
 
 const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => {
     const api = await request.connect();
-    const info = await api.getAccountInfo(request.payload);
+    const { details = 'basic', ...rest } = request.payload;
+    const info = await api.getAccountInfo({ details, ...rest });
 
     return {
         type: RESPONSES.GET_ACCOUNT_INFO,

--- a/packages/connect/e2e/common.setup.ts
+++ b/packages/connect/e2e/common.setup.ts
@@ -246,3 +246,11 @@ export const conditionalTest = (rules: string[], ...args: any) => {
     // @ts-expect-error
     return testMethod(...args);
 };
+
+export const conditionalDescribe = (rules: string[], ...args: any) => {
+    const skipMethod = typeof jest !== 'undefined' ? describe.skip : xdescribe;
+    const testMethod = skipTest(rules) ? skipMethod : describe;
+
+    // @ts-expect-error
+    return testMethod(...args);
+};

--- a/packages/connect/e2e/common.setup.ts
+++ b/packages/connect/e2e/common.setup.ts
@@ -165,7 +165,8 @@ export const initTrezorConnect = async (
     });
 
     if (autoConfirm) {
-        TrezorConnect.on(UI.REQUEST_BUTTON, () => {
+        TrezorConnect.on(UI.REQUEST_BUTTON, e => {
+            if (e.code === 'ButtonRequest_PinEntry') return;
             setTimeout(() => TrezorUserEnvLink.send({ type: 'emulator-press-yes' }), 1);
         });
     }

--- a/packages/connect/e2e/common.setup.ts
+++ b/packages/connect/e2e/common.setup.ts
@@ -127,10 +127,12 @@ export const setup = async (
     );
 };
 
+type InitParams = Partial<Parameters<typeof TrezorConnect.init>[0]> & { autoConfirm?: boolean };
+
 export const initTrezorConnect = async (
     // eslint-disable-next-line @typescript-eslint/no-shadow
     TrezorUserEnvLink: TrezorUserEnvLinkClass,
-    options?: Partial<Parameters<typeof TrezorConnect.init>[0]>,
+    { autoConfirm = true, ...options }: InitParams = {},
 ) => {
     TrezorConnect.removeAllListeners();
 
@@ -162,9 +164,11 @@ export const initTrezorConnect = async (
         });
     });
 
-    TrezorConnect.on(UI.REQUEST_BUTTON, () => {
-        setTimeout(() => TrezorUserEnvLink.send({ type: 'emulator-press-yes' }), 1);
-    });
+    if (autoConfirm) {
+        TrezorConnect.on(UI.REQUEST_BUTTON, () => {
+            setTimeout(() => TrezorUserEnvLink.send({ type: 'emulator-press-yes' }), 1);
+        });
+    }
 
     await TrezorConnect.init({
         manifest: {

--- a/packages/connect/e2e/tests/device/authorizeCoinjoin.test.ts
+++ b/packages/connect/e2e/tests/device/authorizeCoinjoin.test.ts
@@ -1,9 +1,17 @@
 import TrezorConnect from '../../../src';
-import { getController, setup, conditionalTest, initTrezorConnect } from '../../common.setup';
+import {
+    getController,
+    setup,
+    conditionalTest,
+    conditionalDescribe,
+    initTrezorConnect,
+} from '../../common.setup';
 
 const controller = getController();
 
-describe('TrezorConnect.authorizeCoinjoin', () => {
+// skip T3T1 until `emulator-apply-settings` with `auto_lock_delay_ms` is fixed on emu
+// https://github.com/trezor/trezor-user-env/issues/280
+conditionalDescribe(['!T3T1'], 'TrezorConnect.authorizeCoinjoin', () => {
     beforeAll(async () => {
         await setup(controller, {
             mnemonic: 'mnemonic_all',

--- a/packages/connect/e2e/tests/device/cancel.test.ts
+++ b/packages/connect/e2e/tests/device/cancel.test.ts
@@ -1,6 +1,6 @@
 import { StartEmu, SetupEmu } from '@trezor/trezor-user-env-link';
 
-import { getController, initTrezorConnect } from '../../common.setup';
+import { conditionalTest, getController, initTrezorConnect } from '../../common.setup';
 import TrezorConnect from '../../../src';
 
 const getAddress = (showOnTrezor: boolean, coin: string = 'regtest') => {
@@ -159,8 +159,7 @@ describe('TrezorConnect.cancel', () => {
         await assertGetAddressWorks();
     });
 
-    // todo: this should be conditionalTest(['2'])
-    it('Pin request - Cancel', async () => {
+    conditionalTest(['2'], 'Pin request - Cancel', async () => {
         await setupTest({
             setupParams: {
                 version: '1-latest',
@@ -190,8 +189,7 @@ describe('TrezorConnect.cancel', () => {
         expect(feat.payload).toMatchObject({ initialized: true });
     });
 
-    // todo: this should be conditionalTest(['2'])
-    it('Word request - Cancel', async () => {
+    conditionalTest(['2'], 'Word request - Cancel', async () => {
         await controller.startEmu({ version: '1-latest', model: 'T1B1', wipe: true });
         await controller.startBridge(
             // @ts-expect-error

--- a/packages/connect/e2e/tests/device/override.test.ts
+++ b/packages/connect/e2e/tests/device/override.test.ts
@@ -8,7 +8,7 @@ describe('TrezorConnect override param', () => {
         await setup(controller, {
             mnemonic: 'mnemonic_all',
         });
-        await initTrezorConnect(controller);
+        await initTrezorConnect(controller, { autoConfirm: false });
     });
 
     afterAll(() => {

--- a/packages/connect/e2e/tests/device/setBusy.test.ts
+++ b/packages/connect/e2e/tests/device/setBusy.test.ts
@@ -1,9 +1,17 @@
 import TrezorConnect from '../../../src';
-import { getController, setup, conditionalTest, initTrezorConnect } from '../../common.setup';
+import {
+    getController,
+    setup,
+    conditionalTest,
+    initTrezorConnect,
+    conditionalDescribe,
+} from '../../common.setup';
 
 const controller = getController();
 
-describe('TrezorConnect.setBusy', () => {
+// skip T3T1 until `emulator-apply-settings` with `auto_lock_delay_ms` is fixed on emu
+// https://github.com/trezor/trezor-user-env/issues/280
+conditionalDescribe(['!T3T1'], 'TrezorConnect.setBusy', () => {
     beforeAll(async () => {
         await setup(controller, {
             mnemonic: 'mnemonic_all',


### PR DESCRIPTION
## Description

Fix recurring failures in Connect E2E tests:

https://github.com/trezor/trezor-suite/pull/16149/commits/02d15d62dba180aa75bbb8dd4ed7b3179c334bee - Allow to turn off automatic `emulator-press-yes` on every button request, and immediately use it in override test so it works as expected (we don't want to confirm shown address because we try to override the call).
https://github.com/trezor/trezor-suite/pull/16149/commits/5a68f5c661bd880f75f5ea303f521c358ae0a21e - Disable automatic `emulator-press-yes` specifically for `ButtonRequest_PinEntry` as it's not needed (`emulator-input` is enough) and it was causing issues on 2-main (some DebugLink changes).
https://github.com/trezor/trezor-suite/pull/16149/commits/95cd713ee2fd16c3f246417bf1a07929576fa9be - `details` field is now required on Blockfrost API (https://github.com/blockfrost/blockfrost-websocket-link/commit/ff1a03a47ee8ef8904e7b7d6b517526265d24266) so we're defaulting to `basic`.
https://github.com/trezor/trezor-suite/pull/16149/commits/6cde9ec5cf368b9131cf633d4572dadebbb4779c - some `cancel` tests are now conditional for T1 (as intended)
https://github.com/trezor/trezor-suite/pull/16149/commits/d4df770257d77d43d6576720a193a7ce327c4e12 - Tests requiring setting `auto_lock_delay_ms` are now skipped for T3T1 until https://github.com/trezor/trezor-user-env/issues/280 is fixed

