### PR TITLE
fix(coinmarket): fix address validator check

### DIFF
--- a/packages/suite/src/hooks/wallet/coinmarket/useCoinmarketInfo.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/useCoinmarketInfo.ts
@@ -15,7 +15,11 @@ import {
     CoinmarketCryptoSelectOptionProps,
     CoinmarketInfoProps,
 } from 'src/types/coinmarket/coinmarket';
-import { parseCryptoId, testnetToProdCryptoId } from 'src/utils/wallet/coinmarket/coinmarketUtils';
+import {
+    cryptoIdToNetwork,
+    parseCryptoId,
+    testnetToProdCryptoId,
+} from 'src/utils/wallet/coinmarket/coinmarketUtils';
 
 const supportedAddressValidatorSymbols = new Set(
     addressValidator.getCurrencies().map(c => c.symbol),
@@ -103,9 +107,9 @@ export const useCoinmarketInfo = (): CoinmarketInfoProps => {
                     return;
                 }
 
-                const nativeCoinSymbol = cryptoIdToNativeCoinSymbol(
-                    testnetToProdCryptoId(cryptoId),
-                );
+                const nativeCoinSymbol =
+                    cryptoIdToNetwork(testnetToProdCryptoId(cryptoId))?.symbol ??
+                    cryptoIdToNativeCoinSymbol(testnetToProdCryptoId(cryptoId));
                 if (!nativeCoinSymbol || !supportedAddressValidatorSymbols.has(nativeCoinSymbol)) {
                     return;
                 }

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketVerify/CoinmarketVerify.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketVerify/CoinmarketVerify.tsx
@@ -23,7 +23,10 @@ import {
     isCoinmarketBuyContext,
     isCoinmarketExchangeContext,
 } from 'src/utils/wallet/coinmarket/coinmarketTypingUtils';
-import { getCoinmarketNetworkDisplaySymbol } from 'src/utils/wallet/coinmarket/coinmarketUtils';
+import {
+    cryptoIdToNetwork,
+    getCoinmarketNetworkDisplaySymbol,
+} from 'src/utils/wallet/coinmarket/coinmarketUtils';
 
 interface CoinmarketVerifyProps {
     coinmarketVerifyAccount: CoinmarketVerifyAccountReturnProps;
@@ -66,7 +69,8 @@ export const CoinmarketVerify = ({ coinmarketVerifyAccount, cryptoId }: Coinmark
         required: translationString('TR_EXCHANGE_RECEIVING_ADDRESS_REQUIRED'),
         validate: value => {
             if (selectedAccountOption?.type === 'NON_SUITE' && cryptoId) {
-                const symbol = cryptoIdToNativeCoinSymbol(cryptoId);
+                const symbol =
+                    cryptoIdToNetwork(cryptoId)?.symbol ?? cryptoIdToNativeCoinSymbol(cryptoId);
                 if (value && !addressValidator.validate(value, symbol)) {
                     return translationString('TR_EXCHANGE_RECEIVING_ADDRESS_INVALID');
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Better check for address validator of cryptoId.
(BNB Smart Chain symbol changed from bnb to bsc, so we can't search for it only by native coin symbol - bnb)

## Related Issue

Resolve #16159

## Screenshots:
### Before
![image](https://github.com/user-attachments/assets/fa91f66c-a633-4315-ba59-0adfdd481369)

### After
![image](https://github.com/user-attachments/assets/2f25a8f1-6ec4-49cd-a613-7d00c0da9197)
