### PR TITLE
fix(suite): empty account translation string symbol

### DIFF
--- a/packages/suite/src/views/wallet/transactions/components/AccountEmpty.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/AccountEmpty.tsx
@@ -55,7 +55,7 @@ export const AccountEmpty = ({ account }: AccountEmptyProps) => {
                     children: (
                         <Translation
                             id="TR_RECEIVE_NETWORK"
-                            values={{ displayNetworkSymbol: displaySymbol }}
+                            values={{ networkDisplaySymbol: displaySymbol }}
                         />
                     ),
                 },
@@ -66,7 +66,7 @@ export const AccountEmpty = ({ account }: AccountEmptyProps) => {
                     children: (
                         <Translation
                             id="TR_BUY_NETWORK"
-                            values={{ displayNetworkSymbol: displaySymbol }}
+                            values={{ networkDisplaySymbol: displaySymbol }}
                         />
                     ),
                 },


### PR DESCRIPTION

![Screenshot 2025-01-06 at 13 11 58](https://github.com/user-attachments/assets/61f7ad02-d347-4c74-8225-cdfe2e7c7d9f)
