### PR TITLE
fix(suite): add missing NewModal.Provider to LoggedOutLayout

### DIFF
--- a/packages/suite/src/components/suite/layouts/LoggedOutLayout.tsx
+++ b/packages/suite/src/components/suite/layouts/LoggedOutLayout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useRef, useState } from 'react';
 
-import { ElevationContext, ElevationUp } from '@trezor/components';
+import { ElevationContext, ElevationUp, NewModal } from '@trezor/components';
 
 import { LayoutContext, LayoutContextPayload } from 'src/support/suite/LayoutContext';
 import { ModalContextProvider } from 'src/support/suite/ModalContext';
@@ -39,29 +39,31 @@ export const LoggedOutLayout = ({ children }: LoggedOutLayout) => {
             <TrafficLightOffset>
                 <Wrapper ref={wrapperRef} data-testid="@logged-out-layout">
                     <PageWrapper>
-                        <ModalContextProvider>
-                            <Metadata title={title} />
-                            <ModalSwitcher />
+                        <NewModal.Provider>
+                            <ModalContextProvider>
+                                <Metadata title={title} />
+                                <ModalSwitcher />
 
-                            <LayoutContext.Provider value={setLayoutPayload}>
-                                <Body data-testid="@suite-layout/body">
-                                    <Columns>
-                                        <AppWrapper
-                                            data-testid="@app"
-                                            ref={scrollRef}
-                                            id="layout-scroll"
-                                        >
-                                            {layoutHeader}
-                                            <ElevationUp>
-                                                <ContentWrapper>{children}</ContentWrapper>
-                                            </ElevationUp>
-                                        </AppWrapper>
-                                    </Columns>
-                                </Body>
-                            </LayoutContext.Provider>
+                                <LayoutContext.Provider value={setLayoutPayload}>
+                                    <Body data-testid="@suite-layout/body">
+                                        <Columns>
+                                            <AppWrapper
+                                                data-testid="@app"
+                                                ref={scrollRef}
+                                                id="layout-scroll"
+                                            >
+                                                {layoutHeader}
+                                                <ElevationUp>
+                                                    <ContentWrapper>{children}</ContentWrapper>
+                                                </ElevationUp>
+                                            </AppWrapper>
+                                        </Columns>
+                                    </Body>
+                                </LayoutContext.Provider>
 
-                            {!isMobileLayout && <GuideButton />}
-                        </ModalContextProvider>
+                                {!isMobileLayout && <GuideButton />}
+                            </ModalContextProvider>
+                        </NewModal.Provider>
                     </PageWrapper>
                     <GuideRouter />
                 </Wrapper>


### PR DESCRIPTION
## Description

Add missing `NewModal.Provider` to `LoggedOutLayout`, which caused all NewModal to fail to render when a device is not connected.
Discovered in #16093

## Screenshots:

Before, on #16093 when device is not connected
![image](https://github.com/user-attachments/assets/4db3da51-44ec-41c6-922b-3326bcfec874)

After, on #16093 when device is not connected
![image](https://github.com/user-attachments/assets/9d92595f-85ee-448c-a129-8354d9bbd2e6)

