### PR TITLE
Display network name instead of symbol on tooltip

### DIFF
--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/CoinsFilter.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/CoinsFilter.tsx
@@ -4,6 +4,7 @@ import { motion, AnimatePresence, MotionProps } from 'framer-motion';
 import { TOOLTIP_DELAY_NORMAL, Tooltip, motionEasing } from '@trezor/components';
 import { CoinLogo } from '@trezor/product-components';
 import { borders, spacingsPx } from '@trezor/theme';
+import { getNetwork } from '@suite-common/wallet-config';
 
 import { useSelector, useAccountSearch } from 'src/hooks/suite';
 import { selectEnabledNetworks } from 'src/reducers/wallet/settingsReducer';
@@ -46,13 +47,15 @@ export const CoinsFilter = () => {
     const enabledNetworks = useSelector(selectEnabledNetworks);
     const { supportedMainnets, supportedTestnets } = useNetworkSupport();
 
-    const supportedNetworks = [...supportedMainnets, ...supportedTestnets].map(
+    const supportedNetworkSymbols = [...supportedMainnets, ...supportedTestnets].map(
         network => network.symbol,
     );
 
-    const availableNetworks = enabledNetworks.filter(symbol => supportedNetworks.includes(symbol));
+    const availableNetworksSymbols = enabledNetworks.filter(networkSymbol =>
+        supportedNetworkSymbols.includes(networkSymbol),
+    );
 
-    const showCoinFilter = availableNetworks.length > 1;
+    const showCoinFilter = availableNetworksSymbols.length > 1;
 
     const coinAnimcationConfig: MotionProps = {
         initial: {
@@ -83,27 +86,31 @@ export const CoinsFilter = () => {
             }}
         >
             <AnimatePresence initial={false}>
-                {availableNetworks.map(network => {
-                    const isSelected = coinFilter === network;
+                {availableNetworksSymbols.map(networkSymbol => {
+                    const isSelected = coinFilter === networkSymbol;
 
                     return (
                         <Tooltip
-                            key={network}
-                            content={network.toUpperCase()}
+                            key={networkSymbol}
+                            content={getNetwork(networkSymbol).name}
                             cursor="pointer"
                             delayShow={TOOLTIP_DELAY_NORMAL}
                         >
-                            <motion.div key={network} {...coinAnimcationConfig} layout>
+                            <motion.div key={networkSymbol} {...coinAnimcationConfig} layout>
                                 <StyledCoinLogo
-                                    data-testid={`@account-menu/filter/${network}`}
-                                    symbol={network}
+                                    data-testid={`@account-menu/filter/${networkSymbol}`}
+                                    symbol={networkSymbol}
                                     size={16}
-                                    data-test-activated={coinFilter === network}
+                                    data-test-activated={coinFilter === networkSymbol}
                                     $isSelected={isSelected}
                                     onClick={e => {
                                         e.stopPropagation();
                                         // select the coin or deactivate if it's already selected
-                                        setCoinFilter(coinFilter === network ? undefined : network);
+                                        setCoinFilter(
+                                            coinFilter === networkSymbol
+                                                ? undefined
+                                                : networkSymbol,
+                                        );
                                     }}
                                 />
                             </motion.div>


### PR DESCRIPTION
## Description

Refactor variables names for more precise naming and display network name instead of symbol

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/16166

## Screenshots:
<img width="278" alt="Screenshot 2025-01-06 at 14 37 21" src="https://github.com/user-attachments/assets/51b580ef-4298-4530-8b99-a500def035b0" />
<img width="278" alt="Screenshot 2025-01-06 at 14 37 48" src="https://github.com/user-attachments/assets/48a4421d-db12-4c97-9045-9a83d9fee2c6" />
<img width="278" alt="Screenshot 2025-01-06 at 14 38 14" src="https://github.com/user-attachments/assets/081e2cd8-f337-4a0f-a14a-e74da121f5b5" />
