### PR TITLE
fix(suite): scroll page header on mobile

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageHeader.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageHeader.tsx
@@ -25,7 +25,7 @@ const Container = styled.div`
     padding: ${spacingsPx.xs} ${spacingsPx.md};
     background: ${({ theme }) => theme.backgroundSurfaceElevation0};
     border-bottom: 1px solid ${({ theme }) => theme.borderElevation1};
-    overflow: hidden;
+    overflow: auto hidden;
     z-index: ${zIndices.pageHeader};
 `;
 


### PR DESCRIPTION
## Description

Make page header scrollable for access on mobile

## Screenshots:

https://github.com/user-attachments/assets/748e1312-1636-4b94-81cc-d91237f49741

