### PR TITLE
fix(suite): L2 non native token names

### DIFF
--- a/packages/product-components/src/components/SelectAssetModal/AssetItem.tsx
+++ b/packages/product-components/src/components/SelectAssetModal/AssetItem.tsx
@@ -44,9 +44,10 @@ export const AssetItem = ({
 }: AssetItemProps) => {
     const getCoinLogo = () =>
         isCoinSymbol(symbol) ? <CoinLogo size={24} symbol={symbol} /> : null;
-    const displaySymbol = isNetworkSymbol(ticker)
-        ? getNetworkDisplaySymbol(ticker)
-        : ticker.toUpperCase();
+    const displaySymbol =
+        isNetworkSymbol(ticker) && !contractAddress
+            ? getNetworkDisplaySymbol(ticker)
+            : ticker.toUpperCase();
 
     return (
         <ClickableContainer

--- a/packages/suite/src/hooks/wallet/coinmarket/useCoinmarketInfo.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/useCoinmarketInfo.ts
@@ -31,9 +31,10 @@ const toCryptoOption = (
 ): CoinmarketCryptoSelectItemProps => {
     const { networkId, contractAddress } = parseCryptoId(cryptoId);
     const coinInfoSymbol = coinInfo.symbol.toLowerCase();
-    const displaySymbol = isNetworkSymbol(coinInfoSymbol)
-        ? getNetwork(coinInfoSymbol)?.displaySymbol
-        : coinInfoSymbol.toUpperCase();
+    const displaySymbol =
+        isNetworkSymbol(coinInfoSymbol) && !contractAddress
+            ? getNetwork(coinInfoSymbol)?.displaySymbol
+            : coinInfoSymbol.toUpperCase();
 
     return {
         type: 'currency',


### PR DESCRIPTION
## Description
Fix incorrect symbols of Optimism, Base and Arbitrum tokens

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/16162

## Screenshots
### Before 
![image](https://github.com/user-attachments/assets/cd6cf566-0271-43bc-a85e-4e290dbf8ddb)
### After 
![image](https://github.com/user-attachments/assets/0069cc96-8ab9-4ec9-a3ef-d333d284bec9)

