### PR TITLE
fix(suite): removed disabled testnet coins from disabled mainnet coins section

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -82,7 +82,7 @@ export const AddAccountModal = ({
     const [enabledNetworks, disabledNetworks] = arrayPartition(supportedNetworks, network =>
         enabledNetworkSymbols.includes(network.symbol),
     );
-    const [, disabledTestnetNetworks] = arrayPartition(
+    const [disabledMainnetNetworks, disabledTestnetNetworks] = arrayPartition(
         disabledNetworks,
         network => !network?.testnet,
     );
@@ -102,7 +102,10 @@ export const AddAccountModal = ({
     const filterNetworksBySymbol = (networks: Network[], symbol?: NetworkSymbol) =>
         symbol ? networks.filter(network => network.symbol === symbol) : networks;
 
-    const filteredDisabledNetworks = filterNetworksBySymbol(disabledNetworks, symbol);
+    const filteredDisabledNetworks = filterNetworksBySymbol(
+        symbol ? disabledNetworks : disabledMainnetNetworks,
+        symbol,
+    );
     const filteredEnabledNetworks = filterNetworksBySymbol(enabledNetworks, symbol);
 
     const visibleNetworks =


### PR DESCRIPTION
## Description

Removed duplicate testnet coins from mainnet coins section in add account modal.

## Related Issue

Resolve #16216 

## Screenshots:

When adding a new account, mainnet and testnet coins are in separate sections.

<img width="692" alt="Screenshot 2025-01-07 at 11 03 34" src="https://github.com/user-attachments/assets/8ad5ff78-6c70-416b-92e3-f260840d75f8" />

When buying a disabled mainnet coin, show just the disabled mainnet coin.

<img width="730" alt="Screenshot 2025-01-07 at 11 03 51" src="https://github.com/user-attachments/assets/c322a2b4-1c13-4485-8854-0c50a59cced1" />

When buying a disabled testnet coin, show just the disabled testnet coin.

<img width="741" alt="Screenshot 2025-01-07 at 11 04 03" src="https://github.com/user-attachments/assets/596d2a90-d6f1-47e3-a5e7-f1bce41afaf6" />

