### PR TITLE
fix: show 'Check on device' prompt when device is locked and is requesting PIN during auth-check in onboarding

### DIFF
--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/DeviceAuthenticity.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/DeviceAuthenticity.tsx
@@ -40,7 +40,9 @@ export const DeviceAuthenticity = ({ goToNext }: DeviceAuthenticityProps) => {
     if (!device) return null;
 
     const isWaitingForConfirmation = device.buttonRequests.some(
-        request => request.code === 'ButtonRequest_Other',
+        request =>
+            request.code === 'ButtonRequest_Other' || // Device Authenticity prompt
+            request.code === 'ButtonRequest_PinEntry', // Device can be locked, and we can get Pin Request first
     );
     const isCheckFailed = isSubmitted && selectedDeviceAuthenticity?.valid === false;
     const isCheckSuccessful = isSubmitted && selectedDeviceAuthenticity?.valid;


### PR DESCRIPTION
Resolves: https://github.com/trezor/trezor-suite/issues/15061

When device gets locked (timeout or manual) just before user confirms security check in on-boarding, the device asks for PIN first. => Suite was not showing "check your device" prompt.

![image](https://github.com/user-attachments/assets/c5b78c0e-00fe-48c8-90af-d9bc042617eb)
