### PR TITLE
fix(suite): remove translatable network title

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeDescription.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeDescription.tsx
@@ -1,16 +1,16 @@
 import { Paragraph, Column } from '@trezor/components';
-import { Bip43PathTemplate, AccountType, NetworkType } from '@suite-common/wallet-config';
 import {
-    getAccountTypeDesc,
-    getAccountTypeUrl,
-    getTitleForNetwork,
-} from '@suite-common/wallet-utils';
+    Bip43PathTemplate,
+    AccountType,
+    NetworkType,
+    getNetwork,
+} from '@suite-common/wallet-config';
+import { getAccountTypeDesc, getAccountTypeUrl } from '@suite-common/wallet-utils';
 import { spacings } from '@trezor/theme';
 import { Account } from '@suite-common/wallet-types';
 
 import { Translation } from 'src/components/suite';
 import { LearnMoreButton } from 'src/components/suite/LearnMoreButton';
-import { useTranslation } from 'src/hooks/suite';
 
 interface AccountTypeDescriptionProps {
     bip43Path: Bip43PathTemplate;
@@ -25,16 +25,13 @@ export const AccountTypeDescription = ({
     symbol,
     networkType,
 }: AccountTypeDescriptionProps) => {
-    const { translationString } = useTranslation();
     const accountTypeUrl = getAccountTypeUrl(bip43Path);
     const accountTypeDescId = getAccountTypeDesc({ path: bip43Path, accountType, networkType });
 
     const renderAccountTypeDesc = () => {
         if (symbol && accountType === 'normal' && networkType === 'ethereum') {
-            const value = getTitleForNetwork(symbol);
-
             return (
-                <Translation id={accountTypeDescId} values={{ value: translationString(value) }} />
+                <Translation id={accountTypeDescId} values={{ value: getNetwork(symbol).name }} />
             );
         }
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DisableTorModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DisableTorModal.tsx
@@ -3,10 +3,9 @@ import { useState } from 'react';
 import styled from 'styled-components';
 
 import { Button, H3, Paragraph, variables } from '@trezor/components';
-import { getTitleForNetwork } from '@suite-common/wallet-utils';
 import { UserContextPayload } from '@suite-common/suite-types';
 import { blockchainActions } from '@suite-common/wallet-core';
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { getNetwork, type NetworkSymbol } from '@suite-common/wallet-config';
 import { CoinLogo } from '@trezor/product-components';
 
 import { Modal, Translation } from 'src/components/suite';
@@ -61,9 +60,7 @@ const BackendRow = ({ symbol, urls, onSettings }: BackendRowProps) => (
     <BackendRowWrapper>
         <CoinLogo symbol={symbol} />
         <CoinDescription>
-            <CoinTitle>
-                <Translation id={getTitleForNetwork(symbol)} />
-            </CoinTitle>
+            <CoinTitle>{getNetwork(symbol).name}</CoinTitle>
             <CoinUrls>{urls.join(', ')}</CoinUrls>
         </CoinDescription>
         <Button variant="tertiary" onClick={onSettings} icon="settings">

--- a/packages/suite/src/hooks/suite/useDefaultAccountLabel.ts
+++ b/packages/suite/src/hooks/suite/useDefaultAccountLabel.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 
-import { getTitleForNetwork, getTitleForCoinjoinAccount } from '@suite-common/wallet-utils';
-import { AccountType, NetworkSymbol } from '@suite-common/wallet-config';
+import { getTitleForCoinjoinAccount } from '@suite-common/wallet-utils';
+import { AccountType, getNetwork, NetworkSymbol } from '@suite-common/wallet-config';
 
 import { useTranslation } from './useTranslation';
 
@@ -23,7 +23,7 @@ export const useDefaultAccountLabel = () => {
             const displayedAccountNumber = index + 1;
 
             return translationString('LABELING_ACCOUNT', {
-                networkName: translationString(getTitleForNetwork(symbol)), // Bitcoin, Ethereum, ...
+                networkName: getNetwork(symbol).name,
                 index: displayedAccountNumber,
             });
         },

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2742,46 +2742,6 @@ export default defineMessages({
         description: 'Title of the coinjoin setup page.',
         id: 'TR_NAV_ANONYMIZE',
     },
-    TR_NETWORK_BITCOIN: {
-        defaultMessage: 'Bitcoin',
-        id: 'TR_NETWORK_BITCOIN',
-    },
-    TR_NETWORK_BITCOIN_CASH: {
-        defaultMessage: 'Bitcoin Cash',
-        id: 'TR_NETWORK_BITCOIN_CASH',
-    },
-    TR_NETWORK_BITCOIN_GOLD: {
-        defaultMessage: 'Bitcoin Gold',
-        id: 'TR_NETWORK_BITCOIN_GOLD',
-    },
-    TR_NETWORK_BITCOIN_TESTNET: {
-        defaultMessage: 'Bitcoin Testnet',
-        id: 'TR_NETWORK_BITCOIN_TESTNET',
-    },
-    TR_NETWORK_BITCOIN_REGTEST: {
-        defaultMessage: 'Bitcoin Regtest',
-        id: 'TR_NETWORK_BITCOIN_REGTEST',
-    },
-    TR_NETWORK_CARDANO: {
-        defaultMessage: 'Cardano',
-        id: 'TR_NETWORK_CARDANO',
-    },
-    TR_NETWORK_DASH: {
-        defaultMessage: 'Dash',
-        id: 'TR_NETWORK_DASH',
-    },
-    TR_NETWORK_DIGIBYTE: {
-        defaultMessage: 'DigiByte',
-        id: 'TR_NETWORK_DIGIBYTE',
-    },
-    TR_NETWORK_DOGECOIN: {
-        defaultMessage: 'Dogecoin',
-        id: 'TR_NETWORK_DOGECOIN',
-    },
-    TR_NETWORK_ETHEREUM: {
-        defaultMessage: 'Ethereum',
-        id: 'TR_NETWORK_ETHEREUM',
-    },
     TR_INCLUDING_TOKENS: {
         defaultMessage: 'Including tokens',
         id: 'TR_INCLUDING_TOKENS',
@@ -2789,78 +2749,6 @@ export default defineMessages({
     TR_INCLUDING_TOKENS_AND_STAKING: {
         defaultMessage: 'Incl. tokens & staking',
         id: 'TR_INCLUDING_TOKENS_AND_STAKING',
-    },
-    TR_NETWORK_ETHEREUM_CLASSIC: {
-        defaultMessage: 'Ethereum Classic',
-        id: 'TR_NETWORK_ETHEREUM_CLASSIC',
-    },
-    TR_NETWORK_ETHEREUM_SEPOLIA: {
-        defaultMessage: 'Ethereum Sepolia',
-        id: 'TR_NETWORK_ETHEREUM_SEPOLIA',
-    },
-    TR_NETWORK_ETHEREUM_HOLESKY: {
-        defaultMessage: 'Ethereum Holesky',
-        id: 'TR_NETWORK_ETHEREUM_HOLESKY',
-    },
-    TR_NETWORK_BNB: {
-        defaultMessage: 'BNB Smart Chain',
-        id: 'TR_NETWORK_BNB',
-    },
-    TR_NETWORK_ARBITRUM_ONE: {
-        defaultMessage: 'Arbitrum One',
-        id: 'TR_NETWORK_ARBITRUM_ONE',
-    },
-    TR_NETWORK_BASE: {
-        defaultMessage: 'Base',
-        id: 'TR_NETWORK_BASE',
-    },
-    TR_NETWORK_OP: {
-        defaultMessage: 'Optimism',
-        id: 'TR_NETWORK_OP',
-    },
-    TR_NETWORK_LITECOIN: {
-        defaultMessage: 'Litecoin',
-        id: 'TR_NETWORK_LITECOIN',
-    },
-    TR_NETWORK_NAMECOIN: {
-        defaultMessage: 'Namecoin',
-        id: 'TR_NETWORK_NAMECOIN',
-    },
-    TR_NETWORK_NEM: {
-        defaultMessage: 'NEM',
-        id: 'TR_NETWORK_NEM',
-    },
-    TR_NETWORK_POLYGON: {
-        defaultMessage: 'Polygon PoS',
-        id: 'TR_NETWORK_POLYGON',
-    },
-    TR_NETWORK_STELLAR: {
-        defaultMessage: 'Stellar',
-        id: 'TR_NETWORK_STELLAR',
-    },
-    TR_NETWORK_TEZOS: {
-        defaultMessage: 'Tezos',
-        id: 'TR_NETWORK_TEZOS',
-    },
-    TR_NETWORK_UNKNOWN: {
-        defaultMessage: 'unknown',
-        id: 'TR_NETWORK_UNKNOWN',
-    },
-    TR_NETWORK_VERTCOIN: {
-        defaultMessage: 'Vertcoin',
-        id: 'TR_NETWORK_VERTCOIN',
-    },
-    TR_NETWORK_XRP: {
-        defaultMessage: 'XRP',
-        id: 'TR_NETWORK_XRP',
-    },
-    TR_NETWORK_XRP_TESTNET: {
-        defaultMessage: 'XRP Testnet',
-        id: 'TR_NETWORK_XRP_TESTNET',
-    },
-    TR_NETWORK_ZCASH: {
-        defaultMessage: 'Zcash',
-        id: 'TR_NETWORK_ZCASH',
     },
     TR_NETWORK_COINJOIN_BITCOIN: {
         defaultMessage: 'Coinjoin',
@@ -2873,14 +2761,6 @@ export default defineMessages({
     TR_NETWORK_COINJOIN_BITCOIN_REGTEST: {
         defaultMessage: 'Coinjoin Regtest',
         id: 'TR_NETWORK_COINJOIN_BITCOIN_REGTEST',
-    },
-    TR_NETWORK_SOLANA_MAINNET: {
-        defaultMessage: 'Solana',
-        id: 'TR_NETWORK_SOLANA_MAINNET',
-    },
-    TR_NETWORK_SOLANA_DEVNET: {
-        defaultMessage: 'Solana Devnet',
-        id: 'TR_NETWORK_SOLANA_DEVNET',
     },
     TR_SOLANA_DEVNET_SHORTCUT_WARNING: {
         defaultMessage:

--- a/packages/suite/src/utils/wallet/coinmarket/__tests__/coinmarketUtils.test.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/__tests__/coinmarketUtils.test.ts
@@ -211,7 +211,7 @@ describe('coinmarket utils', () => {
                     {
                         accountType: 'normal',
                         balance: '250',
-                        cryptoName: 'Polygon PoS',
+                        cryptoName: 'Polygon',
                         descriptor: 'descriptor6',
                         label: 'POL',
                         value: 'polygon-ecosystem-token',

--- a/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
@@ -9,6 +9,7 @@ import {
     getNetworkByCoingeckoId,
     getNetworkByCoingeckoNativeId,
     getNetworkDisplaySymbol,
+    getNetworkDisplaySymbolName,
     getNetworkFeatures,
     getNetworkType,
     isNetworkSymbol,
@@ -75,10 +76,6 @@ export function testnetToProdCryptoId(cryptoId: CryptoId): CryptoId {
     return ((networkId.split('test-')?.[1] ?? networkId) +
         (contractAddress ? `${cryptoPlatformSeparator}${contractAddress}` : '')) as CryptoId;
 }
-
-export const getNetworkName = (symbol: NetworkSymbol) => {
-    return getNetwork(symbol).name;
-};
 
 export const getCoinmarketNetworkDisplaySymbol = (symbol: string) => {
     const symbolLowered = symbol.toLowerCase();
@@ -387,7 +384,7 @@ export const coinmarketBuildAccountOptions = ({
         const option: CoinmarketAccountOptionsGroupOptionProps = {
             value: network.coingeckoNativeId as CryptoId,
             label: getNetworkDisplaySymbol(accountSymbol),
-            cryptoName: network.name,
+            cryptoName: getNetworkDisplaySymbolName(accountSymbol),
             descriptor,
             balance: formattedBalance ?? '',
             accountType: account.accountType,

--- a/packages/suite/src/views/dashboard/StakeEthCard/StakeEthCardFooter/StakeEthCardFooter.tsx
+++ b/packages/suite/src/views/dashboard/StakeEthCard/StakeEthCardFooter/StakeEthCardFooter.tsx
@@ -1,5 +1,6 @@
 import { Button, Paragraph, Row } from '@trezor/components';
 import { spacings } from '@trezor/theme';
+import { getNetwork } from '@suite-common/wallet-config';
 
 import { Translation } from 'src/components/suite';
 import { useAccountSearch, useDispatch } from 'src/hooks/suite';
@@ -36,7 +37,7 @@ export const StakeEthCardFooter = ({ accountIndex = 0, hideSection }: StakeEthCa
                 <Paragraph variant="tertiary" typographyStyle="label">
                     <Translation id="TR_AVAILABLE_NOW_FOR" />
                 </Paragraph>
-                <NetworkBadge symbol="eth" name={<Translation id="TR_NETWORK_ETHEREUM" />} />
+                <NetworkBadge symbol="eth" name={getNetwork('eth').name} />
             </div>
 
             <Row gap={spacings.xs}>

--- a/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
@@ -27,7 +27,12 @@ import {
     selectIsSpecificCoinDefinitionKnown,
     TokenDefinitions,
 } from '@suite-common/token-definitions';
-import { getCoingeckoId, getNetwork, type NetworkSymbol } from '@suite-common/wallet-config';
+import {
+    getCoingeckoId,
+    getNetwork,
+    getNetworkDisplaySymbolName,
+    type NetworkSymbol,
+} from '@suite-common/wallet-config';
 import { FiatCurrencyCode } from '@suite-common/suite-config';
 import { TokenInfo } from '@trezor/blockchain-link-types';
 
@@ -78,7 +83,7 @@ const buildTokenOptions = (
         result.push({
             ticker: symbol,
             symbol,
-            cryptoName: getNetwork(symbol).name,
+            cryptoName: getNetworkDisplaySymbolName(symbol),
             badge: undefined,
             contractAddress: null,
             height: ITEM_HEIGHT,
@@ -331,7 +336,8 @@ export const TokenSelect = ({ outputId }: TokenSelectProps) => {
                         <Column alignItems="flex-start">
                             <Row justifyContent="flex-start">
                                 <Text variant="default" typographyStyle="body">
-                                    {selectedToken?.name || getNetwork(account.symbol).name}
+                                    {selectedToken?.name ||
+                                        getNetworkDisplaySymbolName(account.symbol)}
                                 </Text>
                             </Row>
                             <Row>

--- a/packages/suite/src/views/wallet/transactions/TradeBox/TradeBox.tsx
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/TradeBox.tsx
@@ -9,9 +9,12 @@ import {
     Button,
     useMediaQuery,
 } from '@trezor/components';
-import { getTitleForNetwork } from '@suite-common/wallet-utils';
 import { CoinLogo } from '@trezor/product-components';
-import { getNetwork, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import {
+    getNetwork,
+    getNetworkDisplaySymbol,
+    getNetworkDisplaySymbolName,
+} from '@suite-common/wallet-config';
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 import { EventType, analytics } from '@trezor/suite-analytics';
 
@@ -77,7 +80,7 @@ export const TradeBox = ({ account }: TradeBoxProps) => {
                         <Row gap={spacings.sm}>
                             <CoinLogo size={24} symbol={account.symbol} />
                             <InfoItem
-                                label={<Translation id={getTitleForNetwork(account.symbol)} />}
+                                label={getNetworkDisplaySymbolName(account.symbol)}
                                 typographyStyle="highlight"
                                 variant="default"
                                 gap={0}

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/ExportAction.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/ExportAction.tsx
@@ -5,8 +5,9 @@ import { analytics, EventType } from '@trezor/suite-analytics';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { fetchAllTransactionsForAccountThunk } from '@suite-common/wallet-core';
 import { ExportFileType } from '@suite-common/wallet-types';
-import { getTitleForNetwork, getTitleForCoinjoinAccount } from '@suite-common/wallet-utils';
+import { getTitleForCoinjoinAccount } from '@suite-common/wallet-utils';
 import { AccountLabels } from '@suite-common/metadata-types';
+import { getNetwork } from '@suite-common/wallet-config';
 
 import { Translation } from 'src/components/suite';
 import { useDispatch } from 'src/hooks/suite';
@@ -33,7 +34,7 @@ export const ExportAction = ({ account, searchQuery, accountMetadata }: ExportAc
         }
 
         return translationString('LABELING_ACCOUNT', {
-            networkName: translationString(getTitleForNetwork(account.symbol)),
+            networkName: getNetwork(account.symbol).name,
             index: account.index + 1,
         });
     }, [account, translationString]);

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -79,6 +79,7 @@ export const networks = {
     pol: {
         symbol: 'pol',
         displaySymbol: 'POL',
+        displaySymbolName: 'Polygon',
         name: 'Polygon PoS',
         networkType: 'ethereum',
         chainId: 137,
@@ -102,6 +103,7 @@ export const networks = {
     bsc: {
         symbol: 'bsc',
         displaySymbol: 'BNB',
+        displaySymbolName: 'BNB',
         name: 'BNB Smart Chain',
         networkType: 'ethereum',
         chainId: 56,
@@ -125,6 +127,7 @@ export const networks = {
     arb: {
         symbol: 'arb',
         displaySymbol: 'ETH',
+        displaySymbolName: 'Ethereum',
         name: 'Arbitrum One',
         networkType: 'ethereum',
         chainId: 42161,
@@ -148,6 +151,7 @@ export const networks = {
     base: {
         symbol: 'base',
         displaySymbol: 'ETH',
+        displaySymbolName: 'Ethereum',
         name: 'Base',
         networkType: 'ethereum',
         chainId: 8453,
@@ -171,6 +175,7 @@ export const networks = {
     op: {
         symbol: 'op',
         displaySymbol: 'ETH',
+        displaySymbolName: 'Ethereum',
         name: 'Optimism',
         networkType: 'ethereum',
         chainId: 10,

--- a/suite-common/wallet-config/src/types.ts
+++ b/suite-common/wallet-config/src/types.ts
@@ -102,6 +102,7 @@ export type NetworkDeviceSupport = Partial<Record<DeviceModelInternal, string>>;
 type NetworkWithSpecificKey<TKey extends NetworkSymbol> = {
     symbol: TKey;
     displaySymbol: string;
+    displaySymbolName?: string;
     name: string;
     networkType: NetworkType;
     bip43Path: Bip43PathTemplate;

--- a/suite-common/wallet-config/src/utils.ts
+++ b/suite-common/wallet-config/src/utils.ts
@@ -89,3 +89,9 @@ export const getNetworkByCoingeckoNativeId = (coingeckoId: string) =>
     networksCollection.find(n => n.coingeckoNativeId === coingeckoId);
 
 export const getNetworkDisplaySymbol = (symbol: NetworkSymbol) => getNetwork(symbol).displaySymbol;
+
+export const getNetworkDisplaySymbolName = (symbol: NetworkSymbol) => {
+    const network = getNetwork(symbol);
+
+    return network.displaySymbolName || network.name;
+};

--- a/suite-common/wallet-utils/src/__fixtures__/accountUtils.ts
+++ b/suite-common/wallet-utils/src/__fixtures__/accountUtils.ts
@@ -49,49 +49,14 @@ export const getDiscoveryProcess = [
     },
 ];
 
-export const accountTitleFixture: Array<{
-    symbol: NetworkSymbolExtended;
-    title: TranslationKey;
-}> = [
-    { symbol: 'btc', title: 'TR_NETWORK_BITCOIN' },
-    { symbol: 'test', title: 'TR_NETWORK_BITCOIN_TESTNET' },
-    { symbol: 'bch', title: 'TR_NETWORK_BITCOIN_CASH' },
-    { symbol: 'btg', title: 'TR_NETWORK_BITCOIN_GOLD' },
-    { symbol: 'dash', title: 'TR_NETWORK_DASH' },
-    { symbol: 'xrp', title: 'TR_NETWORK_XRP' },
-    { symbol: 'txrp', title: 'TR_NETWORK_XRP_TESTNET' },
-    { symbol: 'tsep', title: 'TR_NETWORK_ETHEREUM_SEPOLIA' },
-    { symbol: 'thol', title: 'TR_NETWORK_ETHEREUM_HOLESKY' },
-    { symbol: 'dgb', title: 'TR_NETWORK_DIGIBYTE' },
-    { symbol: 'doge', title: 'TR_NETWORK_DOGECOIN' },
-    { symbol: 'ltc', title: 'TR_NETWORK_LITECOIN' },
-    { symbol: 'nmc', title: 'TR_NETWORK_NAMECOIN' },
-    { symbol: 'vtc', title: 'TR_NETWORK_VERTCOIN' },
-    { symbol: 'zec', title: 'TR_NETWORK_ZCASH' },
-    { symbol: 'eth', title: 'TR_NETWORK_ETHEREUM' },
-    { symbol: 'bsc', title: 'TR_NETWORK_BNB' },
-    { symbol: 'arb', title: 'TR_NETWORK_ARBITRUM_ONE' },
-    { symbol: 'base', title: 'TR_NETWORK_BASE' },
-    { symbol: 'op', title: 'TR_NETWORK_OP' },
-    { symbol: 'etc', title: 'TR_NETWORK_ETHEREUM_CLASSIC' },
-    { symbol: 'xem', title: 'TR_NETWORK_NEM' },
-    { symbol: 'xlm', title: 'TR_NETWORK_STELLAR' },
-    { symbol: 'ada', title: 'TR_NETWORK_CARDANO' },
-    { symbol: 'xtz', title: 'TR_NETWORK_TEZOS' },
-    { symbol: 'aaaaaa', title: 'TR_NETWORK_UNKNOWN' },
-    { symbol: 'bbb', title: 'TR_NETWORK_UNKNOWN' },
-    { symbol: 'c', title: 'TR_NETWORK_UNKNOWN' },
-];
-
 export const accountTitleCoinjoinFixture: Array<{
     symbol: NetworkSymbolExtended;
     title: TranslationKey;
 }> = [
     { symbol: 'btc', title: 'TR_NETWORK_COINJOIN_BITCOIN' },
+    { symbol: 'eth', title: 'TR_NETWORK_COINJOIN_BITCOIN' },
     { symbol: 'test', title: 'TR_NETWORK_COINJOIN_BITCOIN_TESTNET' },
     { symbol: 'regtest', title: 'TR_NETWORK_COINJOIN_BITCOIN_REGTEST' },
-    { symbol: 'btg', title: 'TR_NETWORK_UNKNOWN' },
-    { symbol: 'aaaaaa', title: 'TR_NETWORK_UNKNOWN' },
 ];
 
 export const parseBIP44Path = [

--- a/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
@@ -11,7 +11,6 @@ import {
     substituteBip43Path,
     getFiatValue,
     getFirstFreshAddress,
-    getTitleForNetwork,
     getTitleForCoinjoinAccount,
     getUtxoFromSignedTransaction,
     getNetworkAccountFeatures,
@@ -60,14 +59,6 @@ describe('account utils', () => {
     fixtures.sortByCoin.forEach(f => {
         it('accountUtils.sortByCoin', () => {
             expect(sortByCoin(f.accounts as Account[])).toEqual(f.result);
-        });
-    });
-
-    describe('get title for network', () => {
-        fixtures.accountTitleFixture.forEach(fixture => {
-            it(fixture.symbol, () => {
-                expect(getTitleForNetwork(fixture.symbol)).toBe(fixture.title);
-            });
         });
     });
 

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -119,81 +119,13 @@ export const getFiatValue = (amount: string, rate: string, fixedTo = 2) => {
 
 export const getTitleForCoinjoinAccount = (symbol: NetworkSymbolExtended) => {
     switch (symbol) {
-        case 'btc':
-            return 'TR_NETWORK_COINJOIN_BITCOIN';
         case 'test':
             return 'TR_NETWORK_COINJOIN_BITCOIN_TESTNET';
         case 'regtest':
             return 'TR_NETWORK_COINJOIN_BITCOIN_REGTEST';
-        default:
-            return 'TR_NETWORK_UNKNOWN';
-    }
-};
-
-export const getTitleForNetwork = (symbol: NetworkSymbolExtended) => {
-    switch (symbol) {
         case 'btc':
-            return 'TR_NETWORK_BITCOIN';
-        case 'test':
-            return 'TR_NETWORK_BITCOIN_TESTNET';
-        case 'regtest':
-            return 'TR_NETWORK_BITCOIN_REGTEST';
-        case 'bch':
-            return 'TR_NETWORK_BITCOIN_CASH';
-        case 'btg':
-            return 'TR_NETWORK_BITCOIN_GOLD';
-        case 'dash':
-            return 'TR_NETWORK_DASH';
-        case 'dgb':
-            return 'TR_NETWORK_DIGIBYTE';
-        case 'doge':
-            return 'TR_NETWORK_DOGECOIN';
-        case 'ltc':
-            return 'TR_NETWORK_LITECOIN';
-        case 'nmc':
-            return 'TR_NETWORK_NAMECOIN';
-        case 'vtc':
-            return 'TR_NETWORK_VERTCOIN';
-        case 'zec':
-            return 'TR_NETWORK_ZCASH';
-        case 'eth':
-            return 'TR_NETWORK_ETHEREUM';
-        case 'bsc':
-            return 'TR_NETWORK_BNB';
-        case 'arb':
-            return 'TR_NETWORK_ARBITRUM_ONE';
-        case 'base':
-            return 'TR_NETWORK_BASE';
-        case 'op':
-            return 'TR_NETWORK_OP';
-        case 'tsep':
-            return 'TR_NETWORK_ETHEREUM_SEPOLIA';
-        case 'thol':
-            return 'TR_NETWORK_ETHEREUM_HOLESKY';
-        case 'etc':
-            return 'TR_NETWORK_ETHEREUM_CLASSIC';
-        case 'xem':
-            return 'TR_NETWORK_NEM';
-        case 'xlm':
-            return 'TR_NETWORK_STELLAR';
-        case 'ada':
-            return 'TR_NETWORK_CARDANO';
-        case 'xtz':
-            return 'TR_NETWORK_TEZOS';
-        case 'xrp':
-            return 'TR_NETWORK_XRP';
-        case 'txrp':
-            return 'TR_NETWORK_XRP_TESTNET';
-        case 'tada':
-            return 'TR_NETWORK_CARDANO_TESTNET';
-        case 'sol':
-            return 'TR_NETWORK_SOLANA_MAINNET';
-        case 'dsol':
-            return 'TR_NETWORK_SOLANA_DEVNET';
-        case 'pol':
-            return 'TR_NETWORK_POLYGON';
         default:
-            return 'TR_NETWORK_UNKNOWN';
+            return 'TR_NETWORK_COINJOIN_BITCOIN';
     }
 };
 


### PR DESCRIPTION
## Description

- in some places we used "translatable" network name and in some not. So I removed it completely
- introduced `displaySymbolName`

## Related Issue

Resolve [#16193](https://github.com/trezor/trezor-suite/issues/16193)

## Screenshots:


![Screenshot 2025-01-07 at 11 44 54](https://github.com/user-attachments/assets/df716f64-3b37-49fe-aab6-0b6a13d7f351)
![Screenshot 2025-01-07 at 11 44 22](https://github.com/user-attachments/assets/8080da14-1dd0-4a8c-ad0c-e1876a032b6a)
![Screenshot 2025-01-07 at 11 44 19](https://github.com/user-attachments/assets/caa2a746-0a2f-41a0-b929-4d14c19f91e2)
