### PR TITLE
Fix: change tor urls to use Trezor Knowlded base article

### DIFF
--- a/packages/suite/src/constants/suite/experimental.ts
+++ b/packages/suite/src/constants/suite/experimental.ts
@@ -1,6 +1,6 @@
 import { TranslationKey } from '@suite-common/intl-types';
 import { desktopApi } from '@trezor/suite-desktop-api';
-import { EXPERIMENTAL_PASSWORD_MANAGER_KB_URL, Url } from '@trezor/urls';
+import { EXPERIMENTAL_PASSWORD_MANAGER_KB_URL, HELP_CENTER_TOR_URL, Url } from '@trezor/urls';
 import { Route } from '@suite-common/suite-types';
 import { isDesktop } from '@trezor/env-utils';
 
@@ -31,8 +31,7 @@ export const EXPERIMENTAL_FEATURES: Record<ExperimentalFeature, ExperimentalFeat
     'tor-external': {
         title: 'TR_EXPERIMENTAL_TOR_EXTERNAL',
         description: 'TR_EXPERIMENTAL_TOR_EXTERNAL_DESCRIPTION',
-        // TODO: create knowledge base page for this!
-        // knowledgeBaseUrl: TOR_EXTERNAL_KNOWLEDGE_BASE,
+        knowledgeBaseUrl: HELP_CENTER_TOR_URL,
         isDisabled: () => !isDesktop(),
         onToggle: async ({ newValue }) => {
             const result = await desktopApi.getTorSettings();

--- a/packages/suite/src/views/settings/SettingsGeneral/Tor.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Tor.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { LoadingContent, Switch } from '@trezor/components';
-import { TOR_PROJECT_URL } from '@trezor/urls';
+import { HELP_CENTER_TOR_URL } from '@trezor/urls';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { toggleTor } from 'src/actions/suite/suiteActions';
@@ -68,7 +68,7 @@ export const Tor = () => {
                         }}
                     />
                 }
-                buttonLink={TOR_PROJECT_URL}
+                buttonLink={HELP_CENTER_TOR_URL}
             />
             <ActionColumn>
                 <Switch

--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -68,7 +68,7 @@ export const HELP_CENTER_ADDRESSES_URL: Url =
 export const HELP_CENTER_COINJOIN_URL: Url = 'https://trezor.io/learn/a/what-is-coinjoin';
 export const HELP_CENTER_TAPROOT_URL: Url = 'https://trezor.io/learn/a/what-is-taproot';
 export const HELP_CENTER_UDEV_URL: Url = 'https://trezor.io/learn/a/udev-rules';
-export const HELP_CENTER_TOR_URL: Url = 'https://trezor.io/learn/a/tor-in-trezor-suite-app';
+export const HELP_CENTER_TOR_URL: Url = 'https://trezor.io/learn/a/tor-in-trezor-suite';
 export const HELP_CENTER_FW_DOWNGRADE_T1B1_URL: Url =
     'https://trezor.io/learn/a/downgrade-firmware-trezor-model-one';
 export const HELP_CENTER_FW_DOWNGRADE_T2T1_URL: Url =
@@ -129,7 +129,6 @@ export const CHROME_URL: Url = 'https://www.google.com/chrome/';
 export const CHROME_UPDATE_URL: Url = 'https://support.google.com/chrome/answer/95414';
 export const CHROME_ANDROID_URL: Url =
     'https://play.google.com/store/apps/details?id=com.android.chrome';
-export const TOR_PROJECT_URL: Url = 'https://www.torproject.org/';
 export const EXPERIMENTAL_FEATURES_KB_URL: Url =
     'https://trezor.io/learn/a/experimental-features-in-trezor-suite';
 export const EXPERIMENTAL_PASSWORD_MANAGER_KB_URL: Url =


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The URL https://trezor.io/learn/a/tor-in-trezor-suite will be the source of information for Tor normal usage and experimental features explanation. 

The article is still to be updated this week but the changes should be included in this release.