### PR TITLE
Fix 1 min timeout for fetching new token info 

### DIFF
--- a/packages/suite/src/actions/wallet/tokenActions.ts
+++ b/packages/suite/src/actions/wallet/tokenActions.ts
@@ -1,41 +1,22 @@
 import { TokenInfo } from '@trezor/connect';
 import * as accountUtils from '@suite-common/wallet-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { accountsActions, updateFiatRatesThunk } from '@suite-common/wallet-core';
-import { Timestamp, TokenAddress } from '@suite-common/wallet-types';
-import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { accountsActions } from '@suite-common/wallet-core';
 
 import { Dispatch } from 'src/types/suite';
 import { Account } from 'src/types/wallet';
 
-export const addToken =
-    (account: Account, tokenInfo: TokenInfo[], localCurrency: FiatCurrencyCode) =>
-    (dispatch: Dispatch) => {
-        dispatch(
-            accountsActions.updateAccount({
-                ...account,
-                tokens: (account.tokens || []).concat(accountUtils.enhanceTokens(tokenInfo)),
-            }),
-        );
+export const addToken = (account: Account, tokenInfo: TokenInfo[]) => (dispatch: Dispatch) => {
+    dispatch(
+        accountsActions.updateAccount({
+            ...account,
+            tokens: (account.tokens || []).concat(accountUtils.enhanceTokens(tokenInfo)),
+        }),
+    );
 
-        dispatch(
-            updateFiatRatesThunk({
-                tickers: [
-                    {
-                        symbol: account.symbol,
-                        tokenAddress: tokenInfo[0].contract as TokenAddress,
-                    },
-                ],
-                localCurrency,
-                rateType: 'current',
-                fetchAttemptTimestamp: Date.now() as Timestamp,
-                forceFetchToken: true,
-            }),
-        );
-
-        dispatch(
-            notificationsActions.addToast({
-                type: 'add-token-success',
-            }),
-        );
-    };
+    dispatch(
+        notificationsActions.addToast({
+            type: 'add-token-success',
+        }),
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddTokenModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddTokenModal.tsx
@@ -11,7 +11,6 @@ import { Translation } from 'src/components/suite/Translation';
 import { useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
 import { Account } from 'src/types/wallet';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
-import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
 
 interface AddTokenModalProps {
     onCancel: () => void;
@@ -23,7 +22,6 @@ export const AddTokenModal = ({ onCancel }: AddTokenModalProps) => {
     const [isFetching, setIsFetching] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const account = useSelector(selectSelectedAccount);
-    const localCurrency = useSelector(selectLocalCurrency);
     const dispatch = useDispatch();
     const { translationString } = useTranslation();
 
@@ -99,7 +97,7 @@ export const AddTokenModal = ({ onCancel }: AddTokenModalProps) => {
 
     const handleAddTokenButtonClick = () => {
         if (tokenInfo) {
-            dispatch(addToken(account, tokenInfo, localCurrency));
+            dispatch(addToken(account, tokenInfo));
             onCancel();
 
             analytics.report({

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesMiddleware.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesMiddleware.ts
@@ -17,6 +17,7 @@ import { fetchAllTransactionsForAccountThunk } from '../transactions/transaction
 
 export const prepareFiatRatesMiddleware = createMiddlewareWithExtraDeps(
     (action, { dispatch, extra, next, getState }) => {
+        next(action); //next must be at the beginning, othervise tickers are not going to be updated and fiat rates wont fetch (the user will have to wait for 1m timeout)
         const {
             actions: { setWalletSettingsLocalCurrency },
             selectors: { selectLocalCurrency },
@@ -126,6 +127,6 @@ export const prepareFiatRatesMiddleware = createMiddlewareWithExtraDeps(
             );
         }
 
-        return next(action);
+        return action;
     },
 );


### PR DESCRIPTION
## Description

- Now the newly received token data is being fetched instantly, instead of waiting for the 1 min 
timeout

- Token added through "Add token" also fetches last week rates to display the change 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/15493

## Screenshots:
Receive new token Before:


https://github.com/user-attachments/assets/46455a99-ef29-43aa-a6b3-139c9d1eca4c



Receive new token After:

https://github.com/user-attachments/assets/49b8d9cd-6ff5-47d3-83a4-4563de40bfaf



Add token Before:

https://github.com/user-attachments/assets/e793194b-9177-4862-82ee-1c6bd6b582d8



Add token After:

https://github.com/user-attachments/assets/58857c4e-5c8e-45be-a8cc-22c293431f10

