### PR TITLE
Receive address modal

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
@@ -1,7 +1,12 @@
 import { useCallback } from 'react';
 
 import { selectSelectedDevice } from '@suite-common/wallet-core';
-import { getNetworkDisplaySymbol, isNetworkSymbol } from '@suite-common/wallet-config';
+import {
+    getNetwork,
+    getNetworkDisplaySymbol,
+    getNetworkFeatures,
+    isNetworkSymbol,
+} from '@suite-common/wallet-config';
 
 import { showAddress } from 'src/actions/wallet/receiveActions';
 import { Translation } from 'src/components/suite';
@@ -37,6 +42,8 @@ export const ConfirmAddressModal = ({ addressPath, value, ...props }: ConfirmAdd
     // TODO: special case for Connect Popup
     if (!account) return <ConfirmActionModal device={device} />;
 
+    const isTokensNetwork = getNetworkFeatures(account.symbol).includes('tokens');
+
     const getHeading = () => {
         if (modalCryptoId) {
             const coinSymbol = cryptoIdToCoinSymbol(modalCryptoId)?.toLowerCase();
@@ -47,7 +54,7 @@ export const ConfirmAddressModal = ({ addressPath, value, ...props }: ConfirmAdd
                     <Translation
                         id="TR_ADDRESS_MODAL_TITLE_EXCHANGE"
                         values={{
-                            networkName: getNetworkDisplaySymbol(symbol),
+                            networkName: getNetwork(symbol).name,
                             networkCurrencyName: coinSymbol?.toUpperCase(),
                         }}
                     />
@@ -60,7 +67,7 @@ export const ConfirmAddressModal = ({ addressPath, value, ...props }: ConfirmAdd
                     values={{
                         networkName:
                             coinSymbol && isNetworkSymbol(coinSymbol)
-                                ? getNetworkDisplaySymbol(coinSymbol)
+                                ? getNetwork(coinSymbol).name
                                 : coinSymbol?.toUpperCase(),
                     }}
                 />
@@ -71,7 +78,7 @@ export const ConfirmAddressModal = ({ addressPath, value, ...props }: ConfirmAdd
             <Translation
                 id="TR_ADDRESS_MODAL_TITLE"
                 values={{
-                    networkName: getNetworkDisplaySymbol(account.symbol),
+                    networkName: getNetwork(account.symbol).name,
                 }}
             />
         );
@@ -81,6 +88,20 @@ export const ConfirmAddressModal = ({ addressPath, value, ...props }: ConfirmAdd
         <ConfirmValueModal
             account={account}
             heading={getHeading()}
+            description={
+                modalCryptoId ? null : (
+                    <Translation
+                        id={
+                            isTokensNetwork
+                                ? 'TR_ADDRESS_MODAL_DESCRIPTION_TOKENS'
+                                : 'TR_ADDRESS_MODAL_DESCRIPTION'
+                        }
+                        values={{
+                            displaySymbol: getNetworkDisplaySymbol(account.symbol),
+                        }}
+                    />
+                )
+            }
             stepLabel={<Translation id="TR_RECEIVE_ADDRESS" />}
             confirmStepLabel={<Translation id="TR_RECEIVE_ADDRESS_MATCH" />}
             copyButtonText={<Translation id="TR_ADDRESS_MODAL_CLIPBOARD" />}

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmAddressModal.tsx
@@ -104,7 +104,13 @@ export const ConfirmAddressModal = ({ addressPath, value, ...props }: ConfirmAdd
             }
             stepLabel={<Translation id="TR_RECEIVE_ADDRESS" />}
             confirmStepLabel={<Translation id="TR_RECEIVE_ADDRESS_MATCH" />}
-            copyButtonText={<Translation id="TR_ADDRESS_MODAL_CLIPBOARD" />}
+            copyButtonText={
+                modalCryptoId ? (
+                    <Translation id="TR_CONFIRM" />
+                ) : (
+                    <Translation id="TR_ADDRESS_MODAL_CLIPBOARD" />
+                )
+            }
             validateOnDevice={validateAddress}
             value={value}
             data-testid="@metadata/copy-address-button"

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
@@ -15,7 +15,6 @@ import { copyToClipboard } from '@trezor/dom-utils';
 import { selectSelectedDevice, selectSelectedDeviceLabelOrName } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 import { palette, spacings } from '@trezor/theme';
-import { getNetworkFeatures } from '@suite-common/wallet-config';
 import { ConfirmOnDevice } from '@trezor/product-components';
 
 import { selectIsActionAbortable } from 'src/reducers/suite/suiteReducer';
@@ -28,7 +27,8 @@ import { DisplayMode, ThunkAction } from 'src/types/suite';
 import { TransactionReviewStepIndicator } from '../TransactionReviewModal/TransactionReviewOutputList/TransactionReviewStepIndicator';
 import { TransactionReviewOutputElement } from '../TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement';
 
-export interface ConfirmValueModalProps extends Pick<NewModalProps, 'onCancel' | 'heading'> {
+export interface ConfirmValueModalProps
+    extends Pick<NewModalProps, 'onCancel' | 'heading' | 'description'> {
     account: Account;
     copyButtonText: ReactNode;
     stepLabel: ReactNode;
@@ -47,6 +47,7 @@ export const ConfirmValueModal = ({
     stepLabel,
     confirmStepLabel,
     heading,
+    description,
     isConfirmed,
     onCancel,
     validateOnDevice,
@@ -72,7 +73,6 @@ export const ConfirmValueModal = ({
             confirmLabel: confirmStepLabel,
         },
     ];
-    const showTokensSubheading = getNetworkFeatures(account.symbol).includes('tokens');
 
     const copy = () => {
         const result = copyToClipboard(value);
@@ -111,7 +111,7 @@ export const ConfirmValueModal = ({
             )}
             <NewModal.ModalBase
                 heading={heading}
-                description={showTokensSubheading && <Translation id="TR_INCLUDING_TOKENS" />}
+                description={description}
                 onCancel={isCancelable ? onCancel : undefined}
             >
                 <Column gap={spacings.xl}>

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmXpubModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmXpubModal.tsx
@@ -1,6 +1,6 @@
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { convertTaprootXpub } from '@trezor/utils';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getNetwork } from '@suite-common/wallet-config';
 
 import { Translation } from 'src/components/suite';
 import { showXpub } from 'src/actions/wallet/publicKeyActions';
@@ -45,7 +45,7 @@ export const ConfirmXpubModal = (
                     <Translation
                         id="TR_XPUB_MODAL_TITLE"
                         values={{
-                            networkName: getNetworkDisplaySymbol(account.symbol),
+                            networkName: getNetwork(account.symbol).name,
                             accountIndex: `#${account.index + 1}`,
                         }}
                     />

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -1437,7 +1437,7 @@ export default defineMessages({
         id: 'TR_XPUB_MODAL_CLIPBOARD',
     },
     TR_XPUB_MODAL_TITLE: {
-        defaultMessage: '{networkName} Account {accountIndex} public key (XPUB)',
+        defaultMessage: '{networkName} {accountIndex} public key (XPUB)',
         id: 'TR_XPUB_MODAL_TITLE',
     },
     TR_XPUB_MODAL_TITLE_METADATA: {

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -1425,12 +1425,20 @@ export default defineMessages({
         id: 'TR_COPY_TO_CLIPBOARD',
     },
     TR_ADDRESS_MODAL_TITLE: {
-        defaultMessage: '{networkName} receive address',
+        defaultMessage: '{networkName} network receive address',
         id: 'TR_ADDRESS_MODAL_TITLE',
     },
     TR_ADDRESS_MODAL_TITLE_EXCHANGE: {
         defaultMessage: '{networkCurrencyName} receive address on {networkName} network',
         id: 'TR_ADDRESS_MODAL_TITLE_EXCHANGE',
+    },
+    TR_ADDRESS_MODAL_DESCRIPTION: {
+        defaultMessage: 'Receive {displaySymbol}',
+        id: 'TR_ADDRESS_MODAL_DESCRIPTION',
+    },
+    TR_ADDRESS_MODAL_DESCRIPTION_TOKENS: {
+        defaultMessage: 'Receive {displaySymbol} and tokens',
+        id: 'TR_ADDRESS_MODAL_DESCRIPTION_TOKENS',
     },
     TR_XPUB_MODAL_CLIPBOARD: {
         defaultMessage: 'Copy public key',


### PR DESCRIPTION
## Description

- fixed name of account in xpub modal (fixed also in crowdin)
- replace `Copy address` by `Confirm` in trade receive address confirm modal
- improve heading and subheading of receive modal in receive section
  - as a followup I will try to improve it also for trade section, I will think about some unification

## Related Issue

Resolve #14929 (partially, but let's close it, i will cover it in followup issue)
resolve #16200
Resolve #16167
Resolve #14857

## Screenshots:
trade
<img width="794" alt="Screenshot 2025-01-07 at 13 30 41" src="https://github.com/user-attachments/assets/6903afe6-7f52-4608-a66c-a3f048cdb319" />

custom backend
![Screenshot 2025-01-07 at 13 02 15](https://github.com/user-attachments/assets/b1962143-e950-41be-b463-205081445693)

token network receive
![Screenshot 2025-01-07 at 13 01 59](https://github.com/user-attachments/assets/afec85aa-2eae-45ec-a253-009342c985de)

no token network receive
![Screenshot 2025-01-07 at 13 01 47](https://github.com/user-attachments/assets/18eb6a3f-c1ef-4bc2-9fb0-290e2a39217d)

