### PR TITLE
chore(suite-desktop): add release notes for 25.1 release

### DIFF
--- a/packages/suite-desktop/releaseNotes/release-notes.md
+++ b/packages/suite-desktop/releaseNotes/release-notes.md
@@ -1,9 +1,16 @@
+### 🚀 New features
+
+-   Solana Token-2022 now supported.
+-   Added support for Base, Optimism, and Arbitrum One networks, which can be accessed via Experimental features.
+-   Introduced an NFT section for EVM-based chains, which can be enabled via Experimental features.
+-   Enabled delegation of voting rights when staking Cardano.
+
 ### 🎨 Improvements
 
--   Transactions now use nVersion=2, reducing fingerprinting for enhanced privacy.
--   Improved token selection for more control when sending.
--   Optimized main menu resizing for seamless navigation across all screen sizes.
+-   Added the option to check or create a wallet backup during firmware updates.
+-   Introduced a warning when sending funds to a contract address on the Ethereum network.
 
 ### 🔧 Bug fixes
 
+-   Fixed labeling for Polygon and BNB Smart Chain networks.
 -   Resolved minor bugs, enhanced usability, and optimized performance.


### PR DESCRIPTION
Adding release notes for upcoming Suite 25.1 release 

<img width="894" alt="image" src="https://github.com/user-attachments/assets/ceec30f0-f2c6-426a-8e1d-12750190ec3e" />

