### PR TITLE
fix(e2e): Increase timeout of expectVisible in browser tests

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/browser/firefox.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/browser/firefox.test.ts
@@ -2,8 +2,8 @@ import { test, expect } from '../../support/fixtures';
 
 test.use({ startEmulator: false, browserName: 'firefox' });
 test.describe('Firefox', { tag: ['@group=other', '@webOnly'] }, () => {
-    test('Suite does support Firefox', async ({ page }) => {
-        await expect(page.getByTestId('@welcome/title')).toBeVisible();
+    test('Suite does support Firefox', async ({ page, onboardingPage }) => {
+        await expect(onboardingPage.welcomeTitle).toBeVisible({ timeout: 10_000 });
         await expect(page.getByText('Continue at my own risk')).not.toBeVisible();
     });
 });

--- a/packages/suite-desktop-core/e2e/tests/browser/safari.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/browser/safari.test.ts
@@ -15,10 +15,10 @@ const safariAria = `
 
 test.use({ startEmulator: false, browserName: 'webkit' });
 test.describe('Safari', { tag: ['@group=other', '@webOnly'] }, () => {
-    test('Suite does not support Safari', async ({ page }) => {
+    test('Suite does not support Safari', async ({ page, onboardingPage }) => {
         await expect(page.locator('body')).toMatchAriaSnapshot(safariAria);
         await expect(page.getByTestId('@continue-to-suite')).toHaveText('Continue at my own risk');
         await page.getByTestId('@continue-to-suite').click();
-        await expect(page.getByTestId('@welcome/title')).toBeVisible();
+        await expect(onboardingPage.welcomeTitle).toBeVisible({ timeout: 10_000 });
     });
 });


### PR DESCRIPTION
## Description

Fixes test instability cause by not sufficient timeout on first check when suite loads. Default is 5s but the average load time is around 6s. So sometimes it passed, sometimes it failed.
