### PR TITLE
fix: filter all requests not just xhr, all requests are potentially harmfull (can spy on the user via header, etc...)

### DIFF
--- a/packages/suite-desktop-core/src/libs/request-interceptor.ts
+++ b/packages/suite-desktop-core/src/libs/request-interceptor.ts
@@ -1,8 +1,10 @@
 import { session } from 'electron';
 
-// Should be used for all webRequest.on* events as there can be only
-// one listener for each of them, but sometimes we need to bind more
-// of them
+/**
+ * Should be used for all webRequest.on* events as there can be only
+ * one listener for each of them, but sometimes we need to bind more
+ * of them.
+ */
 export const createInterceptor = (): RequestInterceptor => {
     let beforeRequestListeners: BeforeRequestListener[] = [];
     const filter = { urls: ['*://*/*'] };

--- a/packages/suite-desktop-core/src/modules/request-filter.ts
+++ b/packages/suite-desktop-core/src/modules/request-filter.ts
@@ -12,17 +12,7 @@ export const SERVICE_NAME = 'request-filter';
 export const init: ModuleInit = ({ interceptor }) => {
     const { logger } = global;
 
-    const resourceTypeFilter = ['xhr']; // What resource types we want to filter
     interceptor.onBeforeRequest(details => {
-        if (!resourceTypeFilter.includes(details.resourceType)) {
-            logger.debug(
-                SERVICE_NAME,
-                `${details.url} was allowed because its resource type (${details.resourceType}) is not filtered`,
-            );
-
-            return;
-        }
-
         const { hostname } = new URL(details.url);
 
         if (allowedDomains.find(d => hostname.endsWith(d)) !== undefined) {


### PR DESCRIPTION
If we got somehow code injection like this, it will get through as the `request-filter.ts` only check for `xhr` requests.

![image](https://github.com/user-attachments/assets/c668f7c5-703c-414f-b819-3b11f08a6b80)

Asset loading can be potentially harmful as well. It can be utilized for 

1. Spying on the user with headers 
2. Showing scams and phishing 
3. ... and probably more

ALL requests suite does shall be subject to the whitelisting to reduce the attack vector.

![image](https://github.com/user-attachments/assets/ab47ae9c-6e59-4131-a20c-5a80603d74b8)


## For QA

- this may break some asset loading we have in case we are not whitelisting it
- I assume that something like fiat-rates, coin logos, etc... may be affected by this


Related to: https://github.com/trezor/trezor-suite/issues/7171

