### PR TITLE
Fix `resetDevice` emulator tests

### DIFF
--- a/docker/docker-compose.connect-popup-ci.yml
+++ b/docker/docker-compose.connect-popup-ci.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:36dfd1174f56dde0b0b85b3acd927bfda4a63043
+    image: ghcr.io/trezor/trezor-user-env:bc4d202ed4be726145d61a6afad1c5754b3726d7
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.connect-popup-test.yml
+++ b/docker/docker-compose.connect-popup-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:36dfd1174f56dde0b0b85b3acd927bfda4a63043
+    image: ghcr.io/trezor/trezor-user-env:bc4d202ed4be726145d61a6afad1c5754b3726d7
     environment:
       - DISPLAY=$DISPLAY
       - QT_X11_NO_MITSHM=1

--- a/docker/docker-compose.connect-test.yml
+++ b/docker/docker-compose.connect-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:36dfd1174f56dde0b0b85b3acd927bfda4a63043
+    image: ghcr.io/trezor/trezor-user-env:bc4d202ed4be726145d61a6afad1c5754b3726d7
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.connect-webextension-test.yml
+++ b/docker/docker-compose.connect-webextension-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:36dfd1174f56dde0b0b85b3acd927bfda4a63043
+    image: ghcr.io/trezor/trezor-user-env:bc4d202ed4be726145d61a6afad1c5754b3726d7
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-ci-pw.yml
+++ b/docker/docker-compose.suite-ci-pw.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:c637c2f58e799284f6019481fa0de30457bd6b60
+    image: ghcr.io/trezor/trezor-user-env:bc4d202ed4be726145d61a6afad1c5754b3726d7
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-ci.yml
+++ b/docker/docker-compose.suite-ci.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:36dfd1174f56dde0b0b85b3acd927bfda4a63043
+    image: ghcr.io/trezor/trezor-user-env:bc4d202ed4be726145d61a6afad1c5754b3726d7
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-desktop-ci.yml
+++ b/docker/docker-compose.suite-desktop-ci.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:36dfd1174f56dde0b0b85b3acd927bfda4a63043
+    image: ghcr.io/trezor/trezor-user-env:bc4d202ed4be726145d61a6afad1c5754b3726d7
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-dev.yml
+++ b/docker/docker-compose.suite-dev.yml
@@ -4,7 +4,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:36dfd1174f56dde0b0b85b3acd927bfda4a63043
+    image: ghcr.io/trezor/trezor-user-env:bc4d202ed4be726145d61a6afad1c5754b3726d7
     environment:
       - DISPLAY=$DISPLAY
       - QT_X11_NO_MITSHM=1

--- a/docker/docker-compose.suite-native-ci.yml
+++ b/docker/docker-compose.suite-native-ci.yml
@@ -3,7 +3,7 @@ services:
   trezor-user-env-unix:
     network_mode: "host"
     container_name: trezor-user-env.unix
-    image: ghcr.io/trezor/trezor-user-env:36dfd1174f56dde0b0b85b3acd927bfda4a63043
+    image: ghcr.io/trezor/trezor-user-env:bc4d202ed4be726145d61a6afad1c5754b3726d7
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-test.yml
+++ b/docker/docker-compose.suite-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:36dfd1174f56dde0b0b85b3acd927bfda4a63043
+    image: ghcr.io/trezor/trezor-user-env:bc4d202ed4be726145d61a6afad1c5754b3726d7
     environment:
       - DISPLAY=$DISPLAY
       - QT_X11_NO_MITSHM=1

--- a/docker/docker-compose.transport-test-ci.yml
+++ b/docker/docker-compose.transport-test-ci.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:36dfd1174f56dde0b0b85b3acd927bfda4a63043
+    image: ghcr.io/trezor/trezor-user-env:bc4d202ed4be726145d61a6afad1c5754b3726d7
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/packages/connect/e2e/tests/device/resetDevice.test.ts
+++ b/packages/connect/e2e/tests/device/resetDevice.test.ts
@@ -1,5 +1,5 @@
 import TrezorConnect from '../../../src';
-import { getController, setup, initTrezorConnect } from '../../common.setup';
+import { getController, setup, initTrezorConnect, conditionalTest } from '../../common.setup';
 
 const controller = getController();
 
@@ -35,7 +35,7 @@ describe('TrezorConnect.resetDevice', () => {
         expect(response.success).toEqual(true);
     });
 
-    it('resetDevice Slip39_Basic_Extendable', async () => {
+    conditionalTest(['<2.7.2'], 'resetDevice Slip39_Basic_Extendable', async () => {
         const response = await TrezorConnect.resetDevice({
             skip_backup: true,
             backup_type: 4,
@@ -51,7 +51,7 @@ describe('TrezorConnect.resetDevice', () => {
         expect(response.success).toEqual(true);
     });
 
-    it('resetDevice Slip39_Advanced_Extendable', async () => {
+    conditionalTest(['<2.7.2'], 'resetDevice Slip39_Advanced_Extendable', async () => {
         const response = await TrezorConnect.resetDevice({
             skip_backup: true,
             backup_type: 5,
@@ -59,7 +59,7 @@ describe('TrezorConnect.resetDevice', () => {
         expect(response.success).toEqual(true);
     });
 
-    it('resetDevice Slip39_Single_Extendable', async () => {
+    conditionalTest(['<2.7.2'], 'resetDevice Slip39_Single_Extendable', async () => {
         const response = await TrezorConnect.resetDevice({
             skip_backup: true,
             backup_type: 3,


### PR DESCRIPTION
## Description

- [x] SLIP-39 Extendable is supported from 2.7.2, so its tests must be conditional.
- [x] Emulators for 2-main in trezor-user-env are probably outdated. -> **Newer trezor-user-env pinned**