### PR TITLE
fix(product-components): automatic focus in search input

### DIFF
--- a/packages/product-components/src/components/SelectAssetModal/SearchAsset.tsx
+++ b/packages/product-components/src/components/SelectAssetModal/SearchAsset.tsx
@@ -22,5 +22,7 @@ export const SearchAsset = ({
         showClearButton="always"
         innerAddon={<Icon name="search" variant="tertiary" size="medium" />}
         innerAddonAlign="left"
+        // eslint-disable-next-line jsx-a11y/no-autofocus
+        autoFocus
     />
 );


### PR DESCRIPTION
Related: [Trezor suite - automatic focus in search input #16270](https://github.com/trezor/trezor-suite/issues/16270)

## Description
There is a bug (or possible improvement) in Trezor suite (v24.12.3). When selecting coins to buy or swap, there is a “Select a token” modal window with search input. It would be better to add an auto focus to this input when the user opens this modal window, so he can start typing without any additional click.


## Screenshots:
![image-20250108-130106](https://github.com/user-attachments/assets/3dc72abf-76b8-4e39-9610-a30b0470c9e5)
