### PR TITLE
fix(suite): render supported coins only once in add account modal

### DIFF
--- a/packages/suite-desktop-core/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts
@@ -1,3 +1,4 @@
+import { isWebProject } from '../../../support/common';
 import { SeedType } from '../../../support/enums/seedType';
 import { test, expect } from '../../../support/fixtures';
 
@@ -19,9 +20,13 @@ test.describe('Onboarding - create wallet', { tag: ['@group=device-management'] 
         onboardingPage,
         devicePrompt,
         trezorUserEnvLink,
-    }) => {
+    }, testInfo) => {
         await analyticsPage.passThroughAnalytics();
-        await onboardingPage.firmware.continueButton.click();
+        if (isWebProject(testInfo)) {
+            await onboardingPage.firmware.skip();
+        } else {
+            await onboardingPage.firmware.continueButton.click();
+        }
 
         // Will be clicking on Shamir backup button
         await onboardingPage.createWalletButton.click();

--- a/packages/suite-desktop-core/e2e/tests/onboarding/t2t1/t2t1-recovery-fail.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/onboarding/t2t1/t2t1-recovery-fail.test.ts
@@ -1,3 +1,4 @@
+import { isWebProject } from '../../../support/common';
 import { test } from '../../../support/fixtures';
 
 test.describe('Onboarding - recover wallet T2T1', { tag: ['@group=device-management'] }, () => {
@@ -18,11 +19,15 @@ test.describe('Onboarding - recover wallet T2T1', { tag: ['@group=device-managem
         analyticsPage,
         devicePrompt,
         trezorUserEnvLink,
-    }) => {
+    }, testInfo) => {
         await analyticsPage.passThroughAnalytics();
+        if (isWebProject(testInfo)) {
+            await onboardingPage.firmware.skip();
+        } else {
+            await onboardingPage.firmware.continueButton.click();
+        }
 
         // Start wallet recovery process and confirm on device
-        await onboardingPage.firmware.continueButton.click();
         await onboardingPage.recoverWalletButton.click();
         await onboardingPage.startRecoveryButton.click();
         await devicePrompt.confirmOnDevicePromptIsShown();

--- a/packages/suite-web/e2e/tests/wallet/add-account-types.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/add-account-types.test.ts
@@ -134,7 +134,7 @@ describe('Account types suite', () => {
             onAccountsPage.applyCoinFilter(symbol);
             // get the element containing all accounts
             cy.get(
-                `[data-testid="@account-menu/normal"] > [data-testid*="@account-menu/${symbol}/normal"]`,
+                `[data-testid="@account-menu/normal/group"] > [data-testid*="@account-menu/${symbol}/normal"]`,
             ).then(currentAccounts => {
                 const numberOfAccounts1 = currentAccounts.length;
 
@@ -147,7 +147,7 @@ describe('Account types suite', () => {
                 cy.discoveryShouldFinish();
 
                 cy.get(
-                    `[data-testid="@account-menu/normal"] > [data-testid*="@account-menu/${symbol}/normal"]`,
+                    `[data-testid="@account-menu/normal/group"] > [data-testid*="@account-menu/${symbol}/normal"]`,
                 ).then(newAccounts => {
                     const numberOfAccounts2 = newAccounts.length;
                     expect(numberOfAccounts2).to.be.equal(numberOfAccounts1 + 1);

--- a/packages/suite-web/e2e/tests/wallet/add-account-types.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/add-account-types.test.ts
@@ -75,6 +75,7 @@ describe('Account types suite', () => {
                 // Test execution
                 //
                 onAccountsPage.clickAllAccountArrows();
+                cy.getTestElement(`@account-menu/normal`).click();
 
                 // for a specific type of BTC acc, get the current number of accounts
                 cy.getTestElement(`@account-menu/${type}/group`)
@@ -133,7 +134,7 @@ describe('Account types suite', () => {
             onAccountsPage.applyCoinFilter(symbol);
             // get the element containing all accounts
             cy.get(
-                `[data-testid="@account-menu/normal/group"] > [data-testid*="@account-menu/${symbol}/normal"]`,
+                `[data-testid="@account-menu/normal"] > [data-testid*="@account-menu/${symbol}/normal"]`,
             ).then(currentAccounts => {
                 const numberOfAccounts1 = currentAccounts.length;
 
@@ -146,7 +147,7 @@ describe('Account types suite', () => {
                 cy.discoveryShouldFinish();
 
                 cy.get(
-                    `[data-testid="@account-menu/normal/group"] > [data-testid*="@account-menu/${symbol}/normal"]`,
+                    `[data-testid="@account-menu/normal"] > [data-testid*="@account-menu/${symbol}/normal"]`,
                 ).then(newAccounts => {
                     const numberOfAccounts2 = newAccounts.length;
                     expect(numberOfAccounts2).to.be.equal(numberOfAccounts1 + 1);

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -230,7 +230,7 @@ export const AddAccountModal = ({
                               )}
                               <SelectNetwork
                                   heading={<Translation id="TR_INACTIVE_COINS" />}
-                                  networks={visibleNetworks}
+                                  networks={symbol ? visibleNetworks : disabledMainnetNetworks}
                                   selectedNetworks={selectedNetworks}
                                   handleNetworkSelection={selectNetwork}
                               />


### PR DESCRIPTION
## Description

In add account modal, on creating a new account for an already activated coin, render it only once in the "Activated coins" section.

## Related Issue

Resolve #16266 

## Screenshots:

Go to settings -> activate Cardano -> open add account modal and select Cardano -> Cardano shows only once in the "Activated coins" section

https://github.com/user-attachments/assets/825aaa53-6bf8-4033-92db-59a22565f5a3

Buying a non-activated coin works as before.

https://github.com/user-attachments/assets/1005679d-39c1-4288-90bb-f94acf179aa5


