### PR TITLE
chore(connect-common): add fw binaries for 2.8.7

### DIFF
--- a/packages/connect-common/files/firmware/t2b1/releases.json
+++ b/packages/connect-common/files/firmware/t2b1/releases.json
@@ -1,6 +1,21 @@
 [
     {
         "required": false,
+        "version": [2, 8, 7],
+        "min_firmware_version": [2, 6, 1],
+        "min_bootloader_version": [2, 1, 1],
+        "bootloader_version": [2, 1, 8],
+        "translations": ["cs-CZ", "de-DE", "es-ES", "fr-FR", "it-IT", "pt-BR"],
+        "url": "firmware/t2b1/trezor-t2b1-2.8.7.bin",
+        "url_bitcoinonly": "firmware/t2b1/trezor-t2b1-2.8.7-bitcoinonly.bin",
+        "fingerprint": "554c6586df79e1281dd377bfb99d7b2594dbac66d749837c6a78b9c5e0751098",
+        "fingerprint_bitcoinonly": "6381f8a373f9f91a3cf4000a762b8dbf553d11a4a6d433c8863b2fa9eecfd9f1",
+        "firmware_revision": "8a254aa8eae82f99630df63f40e4d290066a3efc",
+        "changelog": "* Show last typed PIN number for short period of time.\n* Multisig-related changes.\n* Simplify UI of Cardano transactions initiated by Trezor Suite.\n* Included new version of bootloader (2.1.8).\n* Fix ETH account number detection.\n* New EVM call contract flow UI.\n* Fix translation of the 'Enable labeling' screen.",
+        "changelog_bitcoinonly": "* Show last typed PIN number for short period of time.\n* Multisig-related changes.\n* Included new version of bootloader (2.1.8).\n* Fix translation of the 'Enable labeling' screen."
+    },
+    {
+        "required": false,
         "version": [2, 8, 0],
         "min_firmware_version": [2, 6, 1],
         "min_bootloader_version": [2, 1, 1],

--- a/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.8.0-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.8.0-bitcoinonly.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7dfc875f9208524d00bcb8e56ef05e92f60e1a4bc94872dcabe01609a8177b35
-size 1241088

--- a/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.8.0.bin
+++ b/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.8.0.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bd29cf141327fd0a0e04fff9213eeacb9adc273586dd8992ecb3b09d05320666
-size 1540096

--- a/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.8.7-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.8.7-bitcoinonly.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:93e617a5a15448dbdc28b57ae68f4a175e673072e93067bec9e63dc6b69a483c
+size 1200128

--- a/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.8.7.bin
+++ b/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.8.7.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0511851ddb71dac16a12934b74835a57e499b81aa322772ff208cb2add2bc1fa
+size 1501184

--- a/packages/connect-common/files/firmware/t2t1/releases.json
+++ b/packages/connect-common/files/firmware/t2t1/releases.json
@@ -1,6 +1,21 @@
 [
     {
         "required": false,
+        "version": [2, 8, 7],
+        "min_firmware_version": [2, 0, 8],
+        "min_bootloader_version": [2, 0, 0],
+        "bootloader_version": [2, 1, 8],
+        "translations": ["cs-CZ", "de-DE", "es-ES", "fr-FR", "it-IT", "pt-BR"],
+        "url": "firmware/t2t1/trezor-t2t1-2.8.7.bin",
+        "url_bitcoinonly": "firmware/t2t1/trezor-t2t1-2.8.7-bitcoinonly.bin",
+        "fingerprint": "7f7bae53913c3a339f22adddb16db70b11bcf908af1c7a5986bae09af9d4ab62",
+        "fingerprint_bitcoinonly": "7bdf5de0c00c5d15c06d526a5b0d22cfd8343eb3e7aa01ee3c4ed60dd063bbf1",
+        "firmware_revision": "8a254aa8eae82f99630df63f40e4d290066a3efc",
+        "changelog": "* Show last typed PIN number for short period of time.\n* Multisig-related changes.\n* Simplify UI of Cardano transactions initiated by Trezor Suite.\n* Included new version of bootloader (2.1.8).\n* Fix ETH account number detection.\n* New EVM call contract flow UI.\n* Fix translation of the 'Enable labeling' screen.",
+        "changelog_bitcoinonly": "* Show last typed PIN number for short period of time.\n* Multisig-related changes.\n* Included new version of bootloader (2.1.8).\n* Fix translation of the 'Enable labeling' screen."
+    },
+    {
+        "required": false,
         "version": [2, 8, 1],
         "min_firmware_version": [2, 0, 8],
         "min_bootloader_version": [2, 0, 0],

--- a/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.8.1-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.8.1-bitcoinonly.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:95d4e96c77525998e4d0c9a234e2c808e275ef26505e45cbe503465e69c606c4
-size 1292800

--- a/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.8.1.bin
+++ b/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.8.1.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5289e1d5476c5097918c1d145d5a2e0a708da11d4cae13771012b8f792941b46
-size 1623552

--- a/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.8.7-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.8.7-bitcoinonly.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d887ce2f9a92c9605ff78fe7440d7b92b51d4989a291b00f3f5c4ca40ca1ceda
+size 1268736

--- a/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.8.7.bin
+++ b/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.8.7.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29b0cb1877188e0875b8bcf8f36818b63cd7c590c56b140daddb4134e2a82242
+size 1602560

--- a/packages/connect-common/files/firmware/t3b1/releases.json
+++ b/packages/connect-common/files/firmware/t3b1/releases.json
@@ -1,6 +1,21 @@
 [
     {
         "required": false,
+        "version": [2, 8, 7],
+        "min_firmware_version": [2, 8, 3],
+        "min_bootloader_version": [2, 1, 7],
+        "bootloader_version": [2, 1, 8],
+        "translations": ["cs-CZ", "de-DE", "es-ES", "fr-FR", "it-IT", "pt-BR"],
+        "url": "firmware/t3b1/trezor-t3b1-2.8.7.bin",
+        "url_bitcoinonly": "firmware/t3b1/trezor-t3b1-2.8.7-bitcoinonly.bin",
+        "fingerprint": "1dd5ec22c2609beb6d17a97bf9b4f42a18af1c12db2446d29a945f4ece8727f6",
+        "fingerprint_bitcoinonly": "4737a6e12d0ebff19fec3aceb212adff57bbcea7a44f8208caf91cc656382d94",
+        "firmware_revision": "8a254aa8eae82f99630df63f40e4d290066a3efc",
+        "changelog": "* Show last typed PIN number for short period of time.\n* Multisig-related changes.\n* Simplify UI of Cardano transactions initiated by Trezor Suite.\n* Included new version of bootloader (2.1.8).\n* Fix ETH account number detection.\n* New EVM call contract flow UI.\n* Fix translation of the 'Enable labeling' screen.",
+        "changelog_bitcoinonly": "* Show last typed PIN number for short period of time.\n* Multisig-related changes.\n* Included new version of bootloader (2.1.8).\n* Fix translation of the 'Enable labeling' screen."
+    },
+    {
+        "required": false,
         "version": [2, 8, 3],
         "min_firmware_version": [2, 8, 3],
         "min_bootloader_version": [2, 1, 7],

--- a/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.8.3-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.8.3-bitcoinonly.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8e392c9ad81d42b7966b2aff247fe91da5b742bf146c60381dbc5e47efe4dde2
-size 998912

--- a/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.8.3.bin
+++ b/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.8.3.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e751d8b712f0f30e0fc0bad285d609c196cbd4fb1cbcd281aa08ed871d3d0e28
-size 1357824

--- a/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.8.7-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.8.7-bitcoinonly.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33c769d054f758179f26a3c2be7bce902c35d19e4c49a7b561d2f78ca9f2b156
+size 992256

--- a/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.8.7.bin
+++ b/packages/connect-common/files/firmware/t3b1/trezor-t3b1-2.8.7.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f89fa5f507c2c4bbff109a62d1daa8bc114ca1c7dc617e980b4ac8c062fa4fb
+size 1352192

--- a/packages/connect-common/files/firmware/t3t1/releases.json
+++ b/packages/connect-common/files/firmware/t3t1/releases.json
@@ -1,6 +1,21 @@
 [
     {
         "required": false,
+        "version": [2, 8, 7],
+        "min_firmware_version": [2, 7, 2],
+        "min_bootloader_version": [2, 1, 6],
+        "bootloader_version": [2, 1, 9],
+        "translations": ["cs-CZ", "de-DE", "es-ES", "fr-FR", "it-IT", "pt-BR"],
+        "url": "firmware/t3t1/trezor-t3t1-2.8.7.bin",
+        "url_bitcoinonly": "firmware/t3t1/trezor-t3t1-2.8.7-bitcoinonly.bin",
+        "fingerprint": "be15ee1f4b7891dc965512455f8d17067ff54a7047e28ed06cec8d56529ab2ef",
+        "fingerprint_bitcoinonly": "2f58de2b7c2c29b6a2f14909ad0941e4aa9dd6d3e1416ab66c512a743b5385a9",
+        "firmware_revision": "8a254aa8eae82f99630df63f40e4d290066a3efc",
+        "changelog": "* Show last typed PIN number for short period of time.\n* Multisig-related changes.\n* Simplify UI of Cardano transactions initiated by Trezor Suite.\n* Included new version of bootloader (2.1.9).\n* Fix ETH account number detection.\n* Show account info in ETH send/stake flow.\n* Fix XPUB confirmed success screen title.\n* New EVM call contract flow UI.\n* Fix incorrect navigation in handy menu while signing BTC message.\n* Fix translation of the 'Enable labeling' screen.",
+        "changelog_bitcoinonly": "* Show last typed PIN number for short period of time.\n* Multisig-related changes.\n* Included new version of bootloader (2.1.9).\n* Fix XPUB confirmed success screen title.\n* Fix incorrect navigation in handy menu while signing BTC message.\n* Fix translation of the 'Enable labeling' screen."
+    },
+    {
+        "required": false,
         "version": [2, 8, 3],
         "min_firmware_version": [2, 7, 2],
         "min_bootloader_version": [2, 1, 6],

--- a/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.3-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.3-bitcoinonly.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:49996a1a602f08809427cf3b959f3c70eeef1fcfd45f267bd6d058496a4cc37e
-size 1172992

--- a/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.3.bin
+++ b/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.3.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9f68696478e09d7bf8b8f5181413d8a5386b37571dc2f5ed8511a24f4c1d35b7
-size 1555456

--- a/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.7-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.7-bitcoinonly.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8c6b6c2187c88d32805b77da4661c65298a30a5f350f1086f888f0854c1f9ec
+size 1159680

--- a/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.7.bin
+++ b/packages/connect-common/files/firmware/t3t1/trezor-t3t1-2.8.7.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88eccdabe9085ba49eb60bd72f99d466b0209b4288d9a5963e8c351406b42773
+size 1542656


### PR DESCRIPTION
Based on https://github.com/trezor/data/pull/121, adding binaries for FW 2.8.7