### PR TITLE
chore(suite-native): set L2 EVMs disabled on first run

### DIFF
--- a/suite-native/feature-flags/src/featureFlagsSlice.ts
+++ b/suite-native/feature-flags/src/featureFlagsSlice.ts
@@ -27,7 +27,7 @@ export const featureFlagsInitialState: FeatureFlagsState = {
     [FeatureFlag.IsSolanaEnabled]: false,
     [FeatureFlag.IsConnectPopupEnabled]: isDevelopOrDebugEnv(),
     [FeatureFlag.IsFirmwareUpdateEnabled]: isDevelopOrDebugEnv(),
-    [FeatureFlag.AreEthL2sEnabled]: isDevelopOrDebugEnv(),
+    [FeatureFlag.AreEthL2sEnabled]: isDebugEnv(),
 };
 
 export const featureFlagsPersistedKeys: Array<keyof FeatureFlagsState> = [


### PR DESCRIPTION


## Related Issue

Resolve #16185 

## Screenshots:
