### PR TITLE
feat(suite-native): slightly better contrast for default switch background

### DIFF
--- a/suite-native/atoms/src/Switch.tsx
+++ b/suite-native/atoms/src/Switch.tsx
@@ -79,10 +79,7 @@ const useAnimationStyles = ({ isChecked }: Pick<SwitchProps, 'isChecked'>) => {
         backgroundColor: interpolateColor(
             translateX.value,
             [0, SWITCH_CIRCLE_TRACK_WIDTH],
-            [
-                utils.colors.backgroundNeutralSubtleOnElevationNegative,
-                utils.colors.backgroundPrimaryDefault,
-            ],
+            [utils.colors.backgroundNeutralSubdued, utils.colors.backgroundPrimaryDefault],
         ),
     }));
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Hotfix solution before new palette is implemented.

## Screenshots:

BEFORE (current state):
<img width="374" alt="image" src="https://github.com/user-attachments/assets/de866c10-467d-4cec-8f3a-7be85ed12fcd" />
<img width="375" alt="image" src="https://github.com/user-attachments/assets/cd3fe168-f8d7-4a56-9607-85550a95f29c" />
<img width="374" alt="image" src="https://github.com/user-attachments/assets/baa2abcd-1472-4ec3-a09d-5ea784d5a16c" />
<img width="373" alt="image" src="https://github.com/user-attachments/assets/adb73e3a-846a-435d-a80a-aae18293690c" />



___ 

AFTER (proposed state)
<img width="375" alt="image" src="https://github.com/user-attachments/assets/315f9694-1c96-4dce-96b2-8e297074c93c" />
<img width="374" alt="image" src="https://github.com/user-attachments/assets/c63dc67f-6abe-4860-8bb7-bbb960235694" />
<img width="371" alt="image" src="https://github.com/user-attachments/assets/a064df2a-58db-4860-ad6c-2e6a1141150b" />
<img width="372" alt="image" src="https://github.com/user-attachments/assets/53f5c243-5750-4f6e-8e97-3d4c54231678" />



