### PR TITLE
Remove NFT section from Ethereum Classic

### DIFF
--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -271,7 +271,7 @@ export const networks = {
         decimals: 18,
         testnet: false,
         explorer: getExplorerUrls('https://etc1.trezor.io', 'ethereum'),
-        features: ['sign-verify', 'tokens', 'coin-definitions', 'nfts', 'nft-definitions'],
+        features: ['sign-verify', 'tokens', 'coin-definitions'],
         backendTypes: ['blockbook'],
         accountTypes: {},
         coingeckoId: 'ethereum-classic',


### PR DESCRIPTION
## Description

Ethereum Classic NFTs are not supported by Coingecko, so we exclude it from Suite 

