### PR TITLE
fix(e2e): Uses correct regtest docker for our dekstop e2e tests

### DIFF
--- a/.github/workflows/test-suite-desktop-e2e.yml
+++ b/.github/workflows/test-suite-desktop-e2e.yml
@@ -36,7 +36,7 @@ jobs:
           - TEST_GROUP: "@group=device-management"
             CONTAINERS: "trezor-user-env-unix"
           - TEST_GROUP: "@group=settings"
-            CONTAINERS: "trezor-user-env-unix electrum-regtest"
+            CONTAINERS: "trezor-user-env-unix bitcoin-regtest"
           # - TEST_GROUP: "@group=metadata"
           #   CONTAINERS: "trezor-user-env-unix"
           # - TEST_GROUP: "@group=passphrase"
@@ -44,7 +44,7 @@ jobs:
           - TEST_GROUP: "@group=other"
             CONTAINERS: "trezor-user-env-unix"
           - TEST_GROUP: "@group=wallet"
-            CONTAINERS: "trezor-user-env-unix electrum-regtest"
+            CONTAINERS: "trezor-user-env-unix bitcoin-regtest"
 
     steps:
       - name: Checkout

--- a/docker/docker-compose.suite-desktop-ci.yml
+++ b/docker/docker-compose.suite-desktop-ci.yml
@@ -6,9 +6,8 @@ services:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp
     network_mode: host
-
-  electrum-regtest:
-    image: ghcr.io/trezor/electrs:latest
-    volumes:
-      - ../:/trezor-suite
+  bitcoin-regtest:
+    image: ghcr.io/trezor/trezor-user-env-regtest # this is a special image that runs regtest and blockbook
+    depends_on:
+      - trezor-user-env-unix
     network_mode: service:trezor-user-env-unix

--- a/packages/suite-desktop-core/e2e/tests/wallet/coin-balance.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/coin-balance.test.ts
@@ -1,7 +1,6 @@
 import { test, expect } from '../../support/fixtures';
 
-//TODO: We have a failing Desktop version on websocket parsing JSON response
-test.describe('Coin balance', { tag: ['@group=wallet', '@webOnly'] }, () => {
+test.describe('Coin balance', { tag: ['@group=wallet'] }, () => {
     const address = 'bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v';
 
     test.use({

--- a/packages/suite-desktop-core/eslint.config.mjs
+++ b/packages/suite-desktop-core/eslint.config.mjs
@@ -18,6 +18,6 @@ export default [
         },
     },
     {
-        ignores: ['**/playwright-report/'],
+        ignores: ['**/playwright-report/', '**/test-results/'],
     },
 ];


### PR DESCRIPTION
## Description

Replaces incorrect regtest docker with correct one for desktop e2e test ci
Also enables one dekstop test that was failing for unknown reason - probably due to the wrong docker being used.