### PR TITLE
fix(mobile): downgrade reanimated to fix crash

### DIFF
--- a/suite-native/accounts/package.json
+++ b/suite-native/accounts/package.json
@@ -40,7 +40,7 @@
         "react": "18.2.0",
         "react-hook-form": "^7.54.2",
         "react-native": "0.76.1",
-        "react-native-reanimated": "3.16.1",
+        "react-native-reanimated": "3.15.5",
         "react-redux": "8.0.7"
     }
 }

--- a/suite-native/alerts/package.json
+++ b/suite-native/alerts/package.json
@@ -17,6 +17,6 @@
         "jotai": "1.9.1",
         "react": "18.2.0",
         "react-native": "0.76.1",
-        "react-native-reanimated": "3.16.1"
+        "react-native-reanimated": "3.15.5"
     }
 }

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -113,7 +113,7 @@
         "react-native-keyboard-aware-scroll-view": "0.9.5",
         "react-native-mmkv": "2.12.2",
         "react-native-quick-crypto": "^0.7.6",
-        "react-native-reanimated": "3.16.1",
+        "react-native-reanimated": "3.15.5",
         "react-native-restart": "0.0.27",
         "react-native-safe-area-context": "^4.14.0",
         "react-native-screens": "^4.0.0",

--- a/suite-native/assets/package.json
+++ b/suite-native/assets/package.json
@@ -30,7 +30,7 @@
         "@suite-native/tokens": "workspace:*",
         "react": "^18.2.0",
         "react-native": "0.76.1",
-        "react-native-reanimated": "3.16.1",
+        "react-native-reanimated": "3.15.5",
         "react-redux": "8.0.7"
     }
 }

--- a/suite-native/atoms/package.json
+++ b/suite-native/atoms/package.json
@@ -29,7 +29,7 @@
         "react": "18.2.0",
         "react-native": "0.76.1",
         "react-native-gesture-handler": "^2.21.0",
-        "react-native-reanimated": "3.16.1",
+        "react-native-reanimated": "3.15.5",
         "react-native-safe-area-context": "^4.14.0",
         "react-native-svg": "15.9.0"
     }

--- a/suite-native/coin-enabling/package.json
+++ b/suite-native/coin-enabling/package.json
@@ -30,7 +30,7 @@
         "expo-linear-gradient": "^14.0.1",
         "react": "18.2.0",
         "react-native": "0.76.1",
-        "react-native-reanimated": "3.16.1",
+        "react-native-reanimated": "3.15.5",
         "react-native-svg": "^15.9.0",
         "react-redux": "8.0.7"
     }

--- a/suite-native/device-manager/package.json
+++ b/suite-native/device-manager/package.json
@@ -30,7 +30,7 @@
         "jotai": "1.9.1",
         "react": "^18.2.0",
         "react-native": "0.76.1",
-        "react-native-reanimated": "3.16.1",
+        "react-native-reanimated": "3.15.5",
         "react-native-safe-area-context": "^4.14.0",
         "react-redux": "8.0.7"
     }

--- a/suite-native/device/package.json
+++ b/suite-native/device/package.json
@@ -33,7 +33,7 @@
         "lottie-react-native": "^7.1.0",
         "react": "18.2.0",
         "react-native": "0.76.1",
-        "react-native-reanimated": "3.16.1",
+        "react-native-reanimated": "3.15.5",
         "react-redux": "8.0.7",
         "semver": "^7.6.3"
     }

--- a/suite-native/firmware/package.json
+++ b/suite-native/firmware/package.json
@@ -22,7 +22,7 @@
         "@trezor/styles": "workspace:*",
         "react": "18.2.0",
         "react-native": "0.76.1",
-        "react-native-reanimated": "3.16.1",
+        "react-native-reanimated": "3.15.5",
         "react-native-safe-area-context": "4.14.0",
         "react-redux": "8.0.7"
     }

--- a/suite-native/graph/package.json
+++ b/suite-native/graph/package.json
@@ -40,7 +40,7 @@
         "jotai": "1.9.1",
         "react": "18.2.0",
         "react-native": "0.76.1",
-        "react-native-reanimated": "3.16.1",
+        "react-native-reanimated": "3.15.5",
         "react-redux": "8.0.7",
         "redux-persist": "6.0.0"
     }

--- a/suite-native/icons/package.json
+++ b/suite-native/icons/package.json
@@ -22,6 +22,6 @@
         "expo-image": "^2.0.0",
         "react": "18.2.0",
         "react-native": "0.76.1",
-        "react-native-reanimated": "3.16.1"
+        "react-native-reanimated": "3.15.5"
     }
 }

--- a/suite-native/message-system/package.json
+++ b/suite-native/message-system/package.json
@@ -26,7 +26,7 @@
         "@trezor/theme": "workspace:*",
         "react": "18.2.0",
         "react-native": "0.76.1",
-        "react-native-reanimated": "3.16.1",
+        "react-native-reanimated": "3.15.5",
         "react-redux": "8.0.7"
     }
 }

--- a/suite-native/module-accounts-import/package.json
+++ b/suite-native/module-accounts-import/package.json
@@ -47,7 +47,7 @@
         "react": "18.2.0",
         "react-hook-form": "^7.54.2",
         "react-native": "0.76.1",
-        "react-native-reanimated": "3.16.1",
+        "react-native-reanimated": "3.15.5",
         "react-redux": "8.0.7"
     }
 }

--- a/suite-native/module-authorize-device/package.json
+++ b/suite-native/module-authorize-device/package.json
@@ -34,7 +34,7 @@
         "@trezor/styles": "workspace:*",
         "react": "18.2.0",
         "react-native": "0.76.1",
-        "react-native-reanimated": "3.16.1",
+        "react-native-reanimated": "3.15.5",
         "react-native-svg": "^15.9.0",
         "react-redux": "8.0.7"
     }

--- a/suite-native/module-send/package.json
+++ b/suite-native/module-send/package.json
@@ -51,7 +51,7 @@
         "react": "18.2.0",
         "react-hook-form": "^7.54.2",
         "react-native": "0.76.1",
-        "react-native-reanimated": "3.16.1",
+        "react-native-reanimated": "3.15.5",
         "react-native-svg": "^15.9.0",
         "react-redux": "8.0.7",
         "web3-utils": "^4.3.1"

--- a/suite-native/navigation/package.json
+++ b/suite-native/navigation/package.json
@@ -32,7 +32,7 @@
         "react": "18.2.0",
         "react-native": "0.76.1",
         "react-native-keyboard-aware-scroll-view": "0.9.5",
-        "react-native-reanimated": "3.16.1",
+        "react-native-reanimated": "3.15.5",
         "react-native-safe-area-context": "^4.14.0",
         "react-redux": "8.0.7"
     }

--- a/suite-native/notifications/package.json
+++ b/suite-native/notifications/package.json
@@ -26,7 +26,7 @@
         "react": "18.2.0",
         "react-native": "0.76.1",
         "react-native-gesture-handler": "^2.21.0",
-        "react-native-reanimated": "3.16.1",
+        "react-native-reanimated": "3.15.5",
         "react-redux": "8.0.7"
     }
 }

--- a/suite-native/react-native-graph/package.json
+++ b/suite-native/react-native-graph/package.json
@@ -17,7 +17,7 @@
         "react": "18.2.0",
         "react-native": "0.76.1",
         "react-native-gesture-handler": "^2.21.0",
-        "react-native-reanimated": "3.16.1"
+        "react-native-reanimated": "3.15.5"
     },
     "devDependencies": {
         "@trezor/eslint": "workspace:*"

--- a/suite-native/receive/package.json
+++ b/suite-native/receive/package.json
@@ -38,7 +38,7 @@
         "react": "18.2.0",
         "react-native": "0.76.1",
         "react-native-gesture-handler": "^2.21.0",
-        "react-native-reanimated": "3.16.1",
+        "react-native-reanimated": "3.15.5",
         "react-redux": "8.0.7"
     }
 }

--- a/suite-native/toasts/package.json
+++ b/suite-native/toasts/package.json
@@ -18,6 +18,6 @@
         "@trezor/theme": "workspace:*",
         "jotai": "1.9.1",
         "react": "18.2.0",
-        "react-native-reanimated": "3.16.1"
+        "react-native-reanimated": "3.15.5"
     }
 }

--- a/suite-native/transactions/package.json
+++ b/suite-native/transactions/package.json
@@ -41,7 +41,7 @@
         "react": "18.2.0",
         "react-native": "0.76.1",
         "react-native-gesture-handler": "^2.21.0",
-        "react-native-reanimated": "3.16.1",
+        "react-native-reanimated": "3.15.5",
         "react-native-svg": "15.9.0",
         "react-redux": "8.0.7"
     }

--- a/suite-native/video-assets/package.json
+++ b/suite-native/video-assets/package.json
@@ -18,6 +18,6 @@
         "prettier": "^3.3.2",
         "react": "18.2.0",
         "react-native": "0.76.1",
-        "react-native-reanimated": "3.16.1"
+        "react-native-reanimated": "3.15.5"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9895,7 +9895,7 @@ __metadata:
     react: "npm:18.2.0"
     react-hook-form: "npm:^7.54.2"
     react-native: "npm:0.76.1"
-    react-native-reanimated: "npm:3.16.1"
+    react-native-reanimated: "npm:3.15.5"
     react-redux: "npm:8.0.7"
   languageName: unknown
   linkType: soft
@@ -9911,7 +9911,7 @@ __metadata:
     jotai: "npm:1.9.1"
     react: "npm:18.2.0"
     react-native: "npm:0.76.1"
-    react-native-reanimated: "npm:3.16.1"
+    react-native-reanimated: "npm:3.15.5"
   languageName: unknown
   linkType: soft
 
@@ -10045,7 +10045,7 @@ __metadata:
     react-native-keyboard-aware-scroll-view: "npm:0.9.5"
     react-native-mmkv: "npm:2.12.2"
     react-native-quick-crypto: "npm:^0.7.6"
-    react-native-reanimated: "npm:3.16.1"
+    react-native-reanimated: "npm:3.15.5"
     react-native-restart: "npm:0.0.27"
     react-native-safe-area-context: "npm:^4.14.0"
     react-native-screens: "npm:^4.0.0"
@@ -10081,7 +10081,7 @@ __metadata:
     "@suite-native/tokens": "workspace:*"
     react: "npm:^18.2.0"
     react-native: "npm:0.76.1"
-    react-native-reanimated: "npm:3.16.1"
+    react-native-reanimated: "npm:3.15.5"
     react-redux: "npm:8.0.7"
   languageName: unknown
   linkType: soft
@@ -10109,7 +10109,7 @@ __metadata:
     react: "npm:18.2.0"
     react-native: "npm:0.76.1"
     react-native-gesture-handler: "npm:^2.21.0"
-    react-native-reanimated: "npm:3.16.1"
+    react-native-reanimated: "npm:3.15.5"
     react-native-safe-area-context: "npm:^4.14.0"
     react-native-svg: "npm:15.9.0"
   languageName: unknown
@@ -10170,7 +10170,7 @@ __metadata:
     expo-linear-gradient: "npm:^14.0.1"
     react: "npm:18.2.0"
     react-native: "npm:0.76.1"
-    react-native-reanimated: "npm:3.16.1"
+    react-native-reanimated: "npm:3.15.5"
     react-native-svg: "npm:^15.9.0"
     react-redux: "npm:8.0.7"
   languageName: unknown
@@ -10246,7 +10246,7 @@ __metadata:
     jotai: "npm:1.9.1"
     react: "npm:^18.2.0"
     react-native: "npm:0.76.1"
-    react-native-reanimated: "npm:3.16.1"
+    react-native-reanimated: "npm:3.15.5"
     react-native-safe-area-context: "npm:^4.14.0"
     react-redux: "npm:8.0.7"
   languageName: unknown
@@ -10287,7 +10287,7 @@ __metadata:
     lottie-react-native: "npm:^7.1.0"
     react: "npm:18.2.0"
     react-native: "npm:0.76.1"
-    react-native-reanimated: "npm:3.16.1"
+    react-native-reanimated: "npm:3.15.5"
     react-redux: "npm:8.0.7"
     semver: "npm:^7.6.3"
   languageName: unknown
@@ -10347,7 +10347,7 @@ __metadata:
     "@trezor/styles": "workspace:*"
     react: "npm:18.2.0"
     react-native: "npm:0.76.1"
-    react-native-reanimated: "npm:3.16.1"
+    react-native-reanimated: "npm:3.15.5"
     react-native-safe-area-context: "npm:4.14.0"
     react-redux: "npm:8.0.7"
   languageName: unknown
@@ -10425,7 +10425,7 @@ __metadata:
     jotai: "npm:1.9.1"
     react: "npm:18.2.0"
     react-native: "npm:0.76.1"
-    react-native-reanimated: "npm:3.16.1"
+    react-native-reanimated: "npm:3.15.5"
     react-redux: "npm:8.0.7"
     redux-persist: "npm:6.0.0"
   languageName: unknown
@@ -10457,7 +10457,7 @@ __metadata:
     expo-image: "npm:^2.0.0"
     react: "npm:18.2.0"
     react-native: "npm:0.76.1"
-    react-native-reanimated: "npm:3.16.1"
+    react-native-reanimated: "npm:3.15.5"
   languageName: unknown
   linkType: soft
 
@@ -10505,7 +10505,7 @@ __metadata:
     "@trezor/theme": "workspace:*"
     react: "npm:18.2.0"
     react-native: "npm:0.76.1"
-    react-native-reanimated: "npm:3.16.1"
+    react-native-reanimated: "npm:3.15.5"
     react-redux: "npm:8.0.7"
   languageName: unknown
   linkType: soft
@@ -10550,7 +10550,7 @@ __metadata:
     react: "npm:18.2.0"
     react-hook-form: "npm:^7.54.2"
     react-native: "npm:0.76.1"
-    react-native-reanimated: "npm:3.16.1"
+    react-native-reanimated: "npm:3.15.5"
     react-redux: "npm:8.0.7"
   languageName: unknown
   linkType: soft
@@ -10650,7 +10650,7 @@ __metadata:
     "@trezor/styles": "workspace:*"
     react: "npm:18.2.0"
     react-native: "npm:0.76.1"
-    react-native-reanimated: "npm:3.16.1"
+    react-native-reanimated: "npm:3.15.5"
     react-native-svg: "npm:^15.9.0"
     react-redux: "npm:8.0.7"
   languageName: unknown
@@ -10845,7 +10845,7 @@ __metadata:
     react: "npm:18.2.0"
     react-hook-form: "npm:^7.54.2"
     react-native: "npm:0.76.1"
-    react-native-reanimated: "npm:3.16.1"
+    react-native-reanimated: "npm:3.15.5"
     react-native-svg: "npm:^15.9.0"
     react-redux: "npm:8.0.7"
     web3-utils: "npm:^4.3.1"
@@ -10941,7 +10941,7 @@ __metadata:
     react: "npm:18.2.0"
     react-native: "npm:0.76.1"
     react-native-keyboard-aware-scroll-view: "npm:0.9.5"
-    react-native-reanimated: "npm:3.16.1"
+    react-native-reanimated: "npm:3.15.5"
     react-native-safe-area-context: "npm:^4.14.0"
     react-redux: "npm:8.0.7"
   languageName: unknown
@@ -10967,7 +10967,7 @@ __metadata:
     react: "npm:18.2.0"
     react-native: "npm:0.76.1"
     react-native-gesture-handler: "npm:^2.21.0"
-    react-native-reanimated: "npm:3.16.1"
+    react-native-reanimated: "npm:3.15.5"
     react-redux: "npm:8.0.7"
   languageName: unknown
   linkType: soft
@@ -11004,7 +11004,7 @@ __metadata:
     react: "npm:18.2.0"
     react-native: "npm:0.76.1"
     react-native-gesture-handler: "npm:^2.21.0"
-    react-native-reanimated: "npm:3.16.1"
+    react-native-reanimated: "npm:3.15.5"
   languageName: unknown
   linkType: soft
 
@@ -11040,7 +11040,7 @@ __metadata:
     react: "npm:18.2.0"
     react-native: "npm:0.76.1"
     react-native-gesture-handler: "npm:^2.21.0"
-    react-native-reanimated: "npm:3.16.1"
+    react-native-reanimated: "npm:3.15.5"
     react-redux: "npm:8.0.7"
   languageName: unknown
   linkType: soft
@@ -11167,7 +11167,7 @@ __metadata:
     "@trezor/theme": "workspace:*"
     jotai: "npm:1.9.1"
     react: "npm:18.2.0"
-    react-native-reanimated: "npm:3.16.1"
+    react-native-reanimated: "npm:3.15.5"
   languageName: unknown
   linkType: soft
 
@@ -11221,7 +11221,7 @@ __metadata:
     react: "npm:18.2.0"
     react-native: "npm:0.76.1"
     react-native-gesture-handler: "npm:^2.21.0"
-    react-native-reanimated: "npm:3.16.1"
+    react-native-reanimated: "npm:3.15.5"
     react-native-svg: "npm:15.9.0"
     react-redux: "npm:8.0.7"
   languageName: unknown
@@ -11237,7 +11237,7 @@ __metadata:
     prettier: "npm:^3.3.2"
     react: "npm:18.2.0"
     react-native: "npm:0.76.1"
-    react-native-reanimated: "npm:3.16.1"
+    react-native-reanimated: "npm:3.15.5"
   languageName: unknown
   linkType: soft
 
@@ -36073,9 +36073,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-reanimated@npm:3.16.1":
-  version: 3.16.1
-  resolution: "react-native-reanimated@npm:3.16.1"
+"react-native-reanimated@npm:3.15.5":
+  version: 3.15.5
+  resolution: "react-native-reanimated@npm:3.15.5"
   dependencies:
     "@babel/plugin-transform-arrow-functions": "npm:^7.0.0-0"
     "@babel/plugin-transform-class-properties": "npm:^7.0.0-0"
@@ -36092,7 +36092,7 @@ __metadata:
     "@babel/core": ^7.0.0-0
     react: "*"
     react-native: "*"
-  checksum: 10/3e46c32655a5e3d89dd79606179ebd6da96cedf31f15c64a32d4cea2c35ec5724411099aeaa59e5f8220c93fc268ee1b391b3210e7e87e43544e279edd2a2ccc
+  checksum: 10/e516405ed52f1d4f844680e3c403bb3e57447be18df0e684d775eb25baa4563678f88fab32553f1c0242e3bbbe0a5566750a60241ac609634b2ab5489b401284
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
After some investigation of #16168 I might have clue what's going on. There is bug (race condition probably or some GC magic) in Reanimated code that was caused by one of these PRs https://github.com/software-mansion/react-native-reanimated/pull/6789 or https://github.com/software-mansion/react-native-reanimated/pull/6530

They just moved some files around but I think it could caused race condition manifest or it caused to run GC in slightly different time that before which resulted in random crashed we experience. I am already working on fix, this is temp solution to move to version that doesn't include any of these changes.

## Related Issue

Resolve #16168 

## Screenshots:
