### PR TITLE
feat(suite-native): Improve colors in account label hint

### DIFF
--- a/suite-native/accounts/src/components/AccountLabelFieldHint.tsx
+++ b/suite-native/accounts/src/components/AccountLabelFieldHint.tsx
@@ -3,11 +3,27 @@ import { Control, useWatch } from 'react-hook-form';
 import { Box, Text } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 
-import { AccountFormValues, MAX_ACCOUNT_LABEL_LENGTH } from '../hooks/useAccountLabelForm';
+import {
+    AccountFormValues,
+    ALMOST_MAX_ACCOUNT_LABEL_LENGTH,
+    MAX_ACCOUNT_LABEL_LENGTH,
+} from '../hooks/useAccountLabelForm';
 
 type AccountLabelFieldHintProps = {
     formControl: Control<AccountFormValues>;
 };
+
+function getTextColor(accountLabelLength: number) {
+    if (accountLabelLength > MAX_ACCOUNT_LABEL_LENGTH) {
+        return 'textAlertRed';
+    }
+
+    if (accountLabelLength > ALMOST_MAX_ACCOUNT_LABEL_LENGTH) {
+        return 'textAlertYellow';
+    }
+
+    return 'textSubdued';
+}
 
 export const AccountLabelFieldHint = ({ formControl }: AccountLabelFieldHintProps) => {
     const { accountLabel } = useWatch({ control: formControl });
@@ -16,7 +32,7 @@ export const AccountLabelFieldHint = ({ formControl }: AccountLabelFieldHintProp
 
     return (
         <Box paddingLeft="sp8">
-            <Text variant="label" color="textSubdued">
+            <Text variant="label" color={getTextColor(accountLabelLength)}>
                 <Translation
                     id="accounts.accountLabelFieldHint.letterCount"
                     values={{

--- a/suite-native/accounts/src/hooks/useAccountLabelForm.ts
+++ b/suite-native/accounts/src/hooks/useAccountLabelForm.ts
@@ -2,6 +2,7 @@ import { yup } from '@suite-common/validators';
 import { useForm } from '@suite-native/forms';
 
 export const MAX_ACCOUNT_LABEL_LENGTH = 30;
+export const ALMOST_MAX_ACCOUNT_LABEL_LENGTH = MAX_ACCOUNT_LABEL_LENGTH - 5;
 
 export type AccountFormValues = yup.InferType<typeof accountFormValidationSchema>;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Improves colors in hint based on available characters.

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

https://github.com/user-attachments/assets/bcd1a21c-5c24-4ac5-80f4-f826cb016016

