### PR TITLE
feat(suite): Add parameters for window size (electron) from terminal

### DIFF
--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -186,7 +186,12 @@ const init = async () => {
     const computerInfo = await getComputerInfo();
     logger.debug('computer', computerInfo);
 
-    const winBounds = store.getWinBounds();
+    const widthArg = parseInt(app.commandLine.getSwitchValue('width'), 10);
+    const heightArg = parseInt(app.commandLine.getSwitchValue('height'), 10);
+    const winBounds = {
+        width: !isNaN(widthArg) ? Math.max(widthArg, MIN_WIDTH) : store.getWinBounds().width,
+        height: !isNaN(heightArg) ? Math.max(heightArg, MIN_HEIGHT) : store.getWinBounds().height,
+    };
     logger.debug('init', `Create Browser Window (${winBounds.width}x${winBounds.height})`);
 
     // init modules


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

How to use it:

in `@trezor/suite-desktop`: run:

```
yarn electron . --width=1200 --height=100
```


<img width="953" alt="image" src="https://github.com/user-attachments/assets/aa49d348-819a-4ede-9413-9b8e015590f8" />



**Warning**: there are limits for window sizes in `packages/suite-desktop-core/src/libs/screen.ts`

<img width="746" alt="image" src="https://github.com/user-attachments/assets/96fa5256-b664-4a51-a9d6-15986ee90fa5" />




