### PR TITLE
16190 we show network symbol in place of display symbol

### DIFF
--- a/suite-common/formatters/src/formatters/prepareNetworkSymbolFormatter.ts
+++ b/suite-common/formatters/src/formatters/prepareNetworkSymbolFormatter.ts
@@ -1,5 +1,5 @@
 import { UNIT_ABBREVIATIONS } from '@suite-common/suite-constants';
-import { getNetwork, NetworkSymbol } from '@suite-common/wallet-config';
+import { getNetwork, getNetworkDisplaySymbol, NetworkSymbol } from '@suite-common/wallet-config';
 
 import { FormatterConfig } from '../types';
 import { makeFormatter } from '../makeFormatter';
@@ -14,13 +14,13 @@ export const prepareNetworkSymbolFormatter = (config: FormatterConfig) =>
 
             const { features: networkFeatures, testnet: isTestnet } = getNetwork(symbol);
             const areAmountUnitsSupported = !!networkFeatures?.includes('amount-unit');
-            let formattedSymbol = symbol.toUpperCase();
+            let formattedSymbol = getNetworkDisplaySymbol(symbol);
 
             // convert to different units if needed
             if (areAmountUnitsEnabled && areAmountUnitsSupported) {
                 const unitAbbreviation = UNIT_ABBREVIATIONS[bitcoinAmountUnit];
                 formattedSymbol = isTestnet
-                    ? `${unitAbbreviation} ${symbol.toUpperCase()}`
+                    ? `${unitAbbreviation} ${formattedSymbol}`
                     : unitAbbreviation;
             }
 

--- a/suite-common/formatters/src/formatters/tests/prepareNetworkSymbolFormatter.test.ts
+++ b/suite-common/formatters/src/formatters/tests/prepareNetworkSymbolFormatter.test.ts
@@ -1,0 +1,30 @@
+import { PROTO } from '@trezor/connect';
+import { NetworkSymbol } from '@suite-common/wallet-config';
+
+import { prepareNetworkSymbolFormatter } from '../prepareNetworkSymbolFormatter';
+
+describe('prepareNetworkSymbolFormatter', () => {
+    let networkSymbolFormatter: ReturnType<typeof prepareNetworkSymbolFormatter>;
+
+    beforeEach(() => {
+        networkSymbolFormatter = prepareNetworkSymbolFormatter({
+            coins: [],
+            locale: 'en',
+            bitcoinAmountUnit: PROTO.AmountUnit.BITCOIN,
+            // @ts-expect-error - no need to test it with Intl for now
+            intl: {},
+        });
+    });
+
+    it.each([
+        ['bsc', 'BNB'],
+        ['arb', 'ETH'],
+        ['base', 'ETH'],
+        ['btc', 'BTC'],
+    ] as [NetworkSymbol, string][])(
+        'should display symbolName (#16190) case %#',
+        (symbol: NetworkSymbol, expectedValue: string) => {
+            expect(networkSymbolFormatter.format(symbol, {})).toBe(expectedValue);
+        },
+    );
+});

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -835,6 +835,12 @@ export const en = {
                 coinLabel: 'Coin label',
             },
         },
+        accountDetailContentScreen: {
+            coinPriceCard: {
+                changeIn24h: '24h change',
+                coinPrice: '{coinName} price',
+            },
+        },
     },
     moduleAccounts: {
         accountDetail: {

--- a/suite-native/module-accounts-management/src/components/CoinPriceCard.tsx
+++ b/suite-native/module-accounts-management/src/components/CoinPriceCard.tsx
@@ -6,6 +6,7 @@ import { getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
 import { FiatAmountFormatter } from '@suite-native/formatters';
 import { AccountKey } from '@suite-common/wallet-types';
 import { AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
+import { Translation } from '@suite-native/intl';
 
 import { useDayCoinPriceChange } from '../hooks/useDayCoinPriceChange';
 
@@ -53,7 +54,7 @@ const PriceChangeIndicator = ({ valuePercentageChange }: PriceChangeIndicatorPro
     return (
         <Box style={applyStyle(indicatorContainer)}>
             <Text variant="label" color="textSubdued">
-                24h change
+                <Translation id="moduleAccountManagement.accountDetailContentScreen.coinPriceCard.changeIn24h" />
             </Text>
             <Box justifyContent="center" alignItems="center" flexDirection="row">
                 {valuePercentageChange ? (
@@ -92,7 +93,10 @@ export const CoinPriceCard = ({ accountKey }: CoinPriceCardProps) => {
                 </Box>
                 <Box style={applyStyle(cardContentStyle)}>
                     <Text variant="label" color="textSubdued">
-                        {coinName} price
+                        <Translation
+                            id="moduleAccountManagement.accountDetailContentScreen.coinPriceCard.coinPrice"
+                            values={{ coinName }}
+                        />
                     </Text>
                     {currentValue && (
                         <FiatAmountFormatter


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Uses `displaySymbol` instead of `symbol` in `prepareNetworkSymbolFormatter`.
- Bonus: Fixed translations in `CoinPriceCard`.

## Related Issue

Resolves #16190
![Screenshot 2025-01-13 at 13 10 28](https://github.com/user-attachments/assets/be0fdfe8-e700-4088-9233-847f11e7c2e2)
![Screenshot 2025-01-13 at 13 11 49](https://github.com/user-attachments/assets/934b4022-1788-4939-97a8-2a19d0260e12)


## Screenshots:
