### PR TITLE
fix(suite-desktop-core): app isHidden check is mac only

### DIFF
--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -268,9 +268,11 @@ const init = async () => {
 
         const mainWindow = mainWindowProxy.getInstance();
         const windowExists =
-            mainWindow && !mainWindow.isDestroyed() && mainWindow.isClosable() && !app.isHidden();
-        const autoStartCurrentlyEnabled =
-            isAutoStartEnabled() || app.commandLine.hasSwitch('bridge-test');
+            mainWindow &&
+            !mainWindow.isDestroyed() &&
+            mainWindow.isClosable() &&
+            (!isMacOs() || !app.isHidden());
+        const autoStartCurrentlyEnabled = isAutoStartEnabled();
         logger.info('main', `Before quit, window exists: ${windowExists}`);
         if (
             !stoppingDaemon &&


### PR DESCRIPTION
## Description

I noticed this error message in Electron logs in CI tests. We were checking `app.isHidden` on window close, this function only works on Mac and it would only be used in logic for Mac, however it was called on all platforms.

I believe this wasn't causing other issues besides the error message itself. 

![Screenshot 2025-01-13 at 13 39 16](https://github.com/user-attachments/assets/53d1c2d4-f425-4d3a-8213-c4964f3c47d2)

Also removes a check for `bridge-test` flag which changes the behavior of autostart, this is not relevant anymore and messes with tests.