### PR TITLE
fix(suite-native): align toasts vertically with the close icon

### DIFF
--- a/suite-native/toasts/package.json
+++ b/suite-native/toasts/package.json
@@ -12,12 +12,12 @@
     "dependencies": {
         "@mobily/ts-belt": "^3.13.1",
         "@suite-native/atoms": "workspace:*",
-        "@suite-native/connection-status": "workspace:*",
         "@suite-native/icons": "workspace:*",
         "@trezor/styles": "workspace:*",
         "@trezor/theme": "workspace:*",
         "jotai": "1.9.1",
         "react": "18.2.0",
-        "react-native-reanimated": "3.16.1"
+        "react-native-reanimated": "3.16.1",
+        "react-native-safe-area-context": "4.14.0"
     }
 }

--- a/suite-native/toasts/src/components/ToastRenderer.tsx
+++ b/suite-native/toasts/src/components/ToastRenderer.tsx
@@ -1,6 +1,7 @@
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
 import { useAtomValue } from 'jotai';
 
-import { useOfflineBannerAwareSafeAreaInsets } from '@suite-native/connection-status';
 import { Box, VStack } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
@@ -8,18 +9,19 @@ import { toastsAtom } from '../toastsAtoms';
 import { Toast } from './Toast';
 
 const toastsContainerStyle = prepareNativeStyle<{ topSafeAreaInset: number }>(
-    (utils, { topSafeAreaInset }) => ({
+    ({ spacings }, { topSafeAreaInset }) => ({
         width: '100%',
         position: 'absolute',
         justifyContent: 'center',
-        marginTop: topSafeAreaInset,
-        paddingHorizontal: utils.spacings.sp16,
+        // top margin = screen top padding + screen header top padding
+        marginTop: Math.max(topSafeAreaInset, spacings.sp8) + spacings.sp8,
+        paddingHorizontal: spacings.sp16,
     }),
 );
 
 export const ToastRenderer = () => {
     const { applyStyle } = useNativeStyles();
-    const { top: topSafeAreaInset } = useOfflineBannerAwareSafeAreaInsets();
+    const { top: topSafeAreaInset } = useSafeAreaInsets();
     const toasts = useAtomValue(toastsAtom);
 
     return (

--- a/suite-native/toasts/tsconfig.json
+++ b/suite-native/toasts/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": { "outDir": "libDev" },
     "references": [
         { "path": "../atoms" },
-        { "path": "../connection-status" },
         { "path": "../icons" },
         { "path": "../../packages/styles" },
         { "path": "../../packages/theme" }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11161,13 +11161,13 @@ __metadata:
   dependencies:
     "@mobily/ts-belt": "npm:^3.13.1"
     "@suite-native/atoms": "workspace:*"
-    "@suite-native/connection-status": "workspace:*"
     "@suite-native/icons": "workspace:*"
     "@trezor/styles": "workspace:*"
     "@trezor/theme": "workspace:*"
     jotai: "npm:1.9.1"
     react: "npm:18.2.0"
     react-native-reanimated: "npm:3.16.1"
+    react-native-safe-area-context: "npm:4.14.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Screenshots:
<img width="360" alt="image" src="https://github.com/user-attachments/assets/73a9b73d-8880-460e-a746-60badd857fd0" />
<img width="360" alt="image" src="https://github.com/user-attachments/assets/1e77cc24-e3d8-440c-93fe-eb0fa7fe33c6" />

