### PR TITLE
feat(mobile): nicer animation for discovery loader

### DIFF
--- a/suite-native/assets/src/components/Assets.tsx
+++ b/suite-native/assets/src/components/Assets.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import Animated, { FadeInDown } from 'react-native-reanimated';
+import Animated, { FadeInDown, LinearTransition } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
@@ -8,7 +8,7 @@ import { useSelectorDeepComparison } from '@suite-common/redux-utils';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { selectIsDeviceAuthorized, selectHasDeviceDiscovery } from '@suite-common/wallet-core';
 import { OnSelectAccount } from '@suite-native/accounts';
-import { Card } from '@suite-native/atoms';
+import { AnimatedCard } from '@suite-native/atoms';
 import {
     AppTabsParamList,
     AppTabsRoutes,
@@ -63,14 +63,18 @@ export const Assets = () => {
 
     return (
         <>
-            <Card noPadding>
+            <AnimatedCard noPadding layout={LinearTransition}>
                 {deviceNetworks.map(symbol => (
-                    <Animated.View entering={isLoading ? FadeInDown : undefined} key={symbol}>
+                    <Animated.View
+                        entering={isLoading ? FadeInDown : undefined}
+                        layout={LinearTransition}
+                        key={symbol}
+                    >
                         <AssetItem cryptoCurrencySymbol={symbol} onPress={setSelectedAssetSymbol} />
                     </Animated.View>
                 ))}
                 {isLoading && <DiscoveryAssetsLoader isListEmpty={deviceNetworks.length < 1} />}
-            </Card>
+            </AnimatedCard>
             {selectedAssetSymbol && (
                 <NetworkAssetsBottomSheet
                     symbol={selectedAssetSymbol}

--- a/suite-native/assets/src/components/DiscoveryAssetsLoader.tsx
+++ b/suite-native/assets/src/components/DiscoveryAssetsLoader.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Animated, { FadeInDown, LinearTransition } from 'react-native-reanimated';
 
 import { ListItemSkeleton, HStack, Text } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
@@ -16,12 +17,12 @@ export const DiscoveryAssetsLoader = ({ isListEmpty }: { isListEmpty: boolean })
     );
 
     return (
-        <>
+        <Animated.View entering={FadeInDown} layout={LinearTransition}>
             <ListItemSkeleton />
             <HStack justifyContent="center" marginBottom="sp16">
                 <Icon size="mediumLarge" name="trezorLogo" />
                 <Text variant="callout">{discoveryProgressText}</Text>
             </HStack>
-        </>
+        </Animated.View>
     );
 };

--- a/suite-native/atoms/src/Card/Card.tsx
+++ b/suite-native/atoms/src/Card/Card.tsx
@@ -1,5 +1,6 @@
-import { ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 import { View } from 'react-native';
+import Animated from 'react-native-reanimated';
 
 import { RequireAllOrNone } from 'type-fest';
 import { G } from '@mobily/ts-belt';
@@ -55,34 +56,42 @@ const alertBoxWrapperStyle = prepareNativeStyle(utils => ({
     paddingTop: utils.spacings.sp4,
 }));
 
-export const Card = ({
-    children,
-    style,
-    alertVariant,
-    alertTitle,
-    borderColor,
-    noPadding = false,
-}: CardProps) => {
-    const { applyStyle } = useNativeStyles();
+export const Card = React.forwardRef<View, CardProps>(
+    (
+        { children, style, alertVariant, alertTitle, borderColor, noPadding = false }: CardProps,
+        ref,
+    ) => {
+        const { applyStyle } = useNativeStyles();
 
-    const isAlertDisplayed = !!alertVariant;
+        const isAlertDisplayed = !!alertVariant;
 
-    return (
-        <View>
-            {isAlertDisplayed && (
-                <View style={applyStyle(alertBoxWrapperStyle)}>
-                    <AlertBox variant={alertVariant} title={alertTitle} borderRadius={12} />
+        return (
+            <View>
+                {isAlertDisplayed && (
+                    <View style={applyStyle(alertBoxWrapperStyle)}>
+                        <AlertBox variant={alertVariant} title={alertTitle} borderRadius={12} />
+                    </View>
+                )}
+                {/* CAUTION: in case that alert is displayed, it is not possible to change styles of the top borders by the `style` prop. */}
+                <View
+                    style={[
+                        applyStyle(cardContainerStyle, {
+                            isAlertDisplayed,
+                            noPadding,
+                            borderColor,
+                        }),
+                        style,
+                    ]}
+                    // Ref must be here otherwise the animation will not work
+                    ref={ref}
+                >
+                    {children}
                 </View>
-            )}
-            {/* CAUTION: in case that alert is displayed, it is not possible to change styles of the top borders by the `style` prop. */}
-            <View
-                style={[
-                    applyStyle(cardContainerStyle, { isAlertDisplayed, noPadding, borderColor }),
-                    style,
-                ]}
-            >
-                {children}
             </View>
-        </View>
-    );
-};
+        );
+    },
+);
+
+Card.displayName = 'Card';
+export const AnimatedCard = Animated.createAnimatedComponent(Card);
+AnimatedCard.displayName = 'AnimatedCard';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Little bit smoother animation for discovery asset loader. Check video for more details (graph is hidden in video on purpose so it's better noticeable)

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

**Prev:**
https://github.com/user-attachments/assets/d16a49a8-2471-4e44-b0f7-308f1e71dea2

**After:**
https://github.com/user-attachments/assets/644fc5c3-0bd2-4d77-9061-33b5ea55190b

