### PR TITLE
feat(connect-explorer): document cardanoComposeTransaction

### DIFF
--- a/packages/connect-explorer/src/pages/methods/cardano/cardanoComposeTransaction.mdx
+++ b/packages/connect-explorer/src/pages/methods/cardano/cardanoComposeTransaction.mdx
@@ -1,0 +1,125 @@
+import { CardanoComposeTransactionParamsSchema } from '@trezor/connect/src/types/api/cardanoComposeTransaction';
+
+import { ParamsTable } from '../../../components/ParamsTable';
+import { CommonParamsLink } from '../../../components/CommonParamsLink';
+import { ApiPlayground } from '../../../components/ApiPlayground';
+
+<ApiPlayground
+    options={[
+        {
+            title: 'Advanced schema',
+            method: 'cardanoComposeTransaction',
+            schema: CardanoComposeTransactionParamsSchema,
+        },
+    ]}
+/>
+
+export const paramDescriptions = {};
+
+## Cardano: Compose transaction
+
+Composes a transaction from the given account information and outputs.
+
+```javascript
+const result = await TrezorConnect.cardanoComposeTransaction(params);
+```
+
+### Params
+
+<CommonParamsLink />
+
+<ParamsTable schema={CardanoComposeTransactionParamsSchema} descriptions={paramDescriptions} />
+
+### Examples
+
+```javascript
+// Get account info
+const accountInfo = await TrezorConnect.getAccountInfo({
+    path: "m/1852'/1815'/0'/0/0",
+    coin: 'cardano',
+    details: 'txs',
+});
+const account = accountInfo.payload;
+
+// Find an unused change address
+const changeAddress = account.addresses.change.find(a => a.transfers === 0);
+
+TrezorConnect.cardanoComposeTransaction({
+    account: {
+        descriptor: account.descriptor,
+        addresses: account.addresses,
+        utxo: account.utxo,
+    },
+    changeAddress,
+    addressParameters: {
+        addressType: CardanoAddressType.BASE,
+        path: changeAddress.path,
+    },
+    outputs: [
+        {
+            format: CardanoTxOutputSerializationFormat.ARRAY_LEGACY,
+            address:
+                'addr1q84sh2j72ux0l03fxndjnhctdg7hcppsaejafsa84vh7lwgmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hlsd5tq5r',
+            amount: '1',
+        },
+    ],
+    feeLevels: [{ feePerUnit: '1' }, { feePerUnit: '5' }, { feePerUnit: '30' }],
+    testnet: false,
+});
+```
+
+### Result
+
+[PrecomposedTransactionCardano[] type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/cardanoComposeTransaction.ts#L41)
+
+PrecomposedTransactionFinalCardano
+
+```javascript
+{
+    success: true,
+    payload: {
+        type: 'final';
+        max?: string;
+        totalSpent: string; // all the outputs, no fee, no change
+        fee: string;
+        feePerByte: string;
+        bytes: number;
+        deposit?: string;
+        ttl?: number;
+        inputs: CardanoInput[];
+        outputs: CardanoOutput[];
+        unsignedTx: {
+            body: string;
+            hash: string;
+        };
+    }
+}
+```
+
+PrecomposedTransactionNonFinalCardano
+
+```javascript
+{
+    success: true,
+    payload: {
+        type: 'nonfinal';
+        max?: string;
+        totalSpent: string; // all the outputs, no fee, no change
+        fee: string;
+        feePerByte: string;
+        bytes: number;
+        deposit?: string;
+    }
+}
+```
+
+Error
+
+```javascript
+{
+    success: false,
+    payload: {
+        error: string // error message
+    }
+}
+```

--- a/packages/connect/src/api/cardano/api/cardanoComposeTransaction.ts
+++ b/packages/connect/src/api/cardano/api/cardanoComposeTransaction.ts
@@ -1,11 +1,13 @@
 import { trezorUtils, CoinSelectionError } from '@fivebinaries/coin-selection';
 
+import { AssertWeak } from '@trezor/schema-utils';
+
 import { AbstractMethod } from '../../../core/AbstractMethod';
-import { validateParams } from '../../common/paramsValidator';
 import { composeTxPlan } from '../cardanoUtils';
-import type {
-    CardanoComposeTransactionParams,
-    PrecomposedTransactionCardano,
+import {
+    CardanoComposeTransactionParamsSchema,
+    type CardanoComposeTransactionParams,
+    type PrecomposedTransactionCardano,
 } from '../../../types/api/cardanoComposeTransaction';
 
 export default class CardanoComposeTransaction extends AbstractMethod<
@@ -16,16 +18,8 @@ export default class CardanoComposeTransaction extends AbstractMethod<
         const { payload } = this;
 
         // validate incoming parameters
-        validateParams(payload, [
-            { name: 'account', type: 'object', required: true },
-            { name: 'feeLevels', type: 'array' },
-            { name: 'outputs', type: 'array' },
-            { name: 'certificates', type: 'array', allowEmpty: true },
-            { name: 'withdrawals', type: 'array', allowEmpty: true },
-            { name: 'changeAddress', type: 'object', required: true },
-            { name: 'addressParameters', type: 'object', required: true },
-            { name: 'testnet', type: 'boolean' },
-        ]);
+        // TODO: weak assert for compatibility purposes (issue #10841)
+        AssertWeak(CardanoComposeTransactionParamsSchema, payload);
 
         this.useDevice = false;
         this.useDeviceState = false;

--- a/packages/connect/src/types/api/index.ts
+++ b/packages/connect/src/types/api/index.ts
@@ -171,7 +171,7 @@ export interface TrezorConnect {
     // https://connect.trezor.io/9/methods/cardano/cardanoSignTransaction/
     cardanoSignTransaction: typeof cardanoSignTransaction;
 
-    // todo: link docs
+    // https://connect.trezor.io/9/methods/cardano/cardanoComposeTransaction/
     cardanoComposeTransaction: typeof cardanoComposeTransaction;
 
     // https://connect.trezor.io/9/methods/device/changeLanguage/


### PR DESCRIPTION
## Description

Added Typebox validation schema for `cardanoComposeTransaction`, use only weak assert for compatibility purposes. 
Added Connect Explorer documentation page for `cardanoComposeTransaction`.

## Related Issue

Part of #14718