### PR TITLE
Fix/connect entropy check error code

### DIFF
--- a/packages/connect/src/api/resetDevice.ts
+++ b/packages/connect/src/api/resetDevice.ts
@@ -89,7 +89,7 @@ export default class ResetDevice extends AbstractMethod<'resetDevice', PROTO.Res
         });
         if (res.error) {
             await cancelPrompt(this.device);
-            throw ERRORS.TypedError('Failure_EntropyCheck', res.error);
+            throw new Error(res.error);
         }
 
         return currentData;
@@ -113,7 +113,11 @@ export default class ResetDevice extends AbstractMethod<'resetDevice', PROTO.Res
             for (let i = 0; i < tries; i++) {
                 // steps: 5 - 6
                 // GetPublicKey > ResetDeviceContinue > EntropyRequest > EntropyAck > EntropyCheckReady
-                entropyData = await this.entropyCheck(entropyData);
+                try {
+                    entropyData = await this.entropyCheck(entropyData);
+                } catch (error) {
+                    throw ERRORS.TypedError('Failure_EntropyCheck', error.message);
+                }
             }
             // step 7 EntropyCheckContinue > Success
             await cmd.typedCall('EntropyCheckContinue', 'Success', { finish: true });

--- a/packages/suite/src/actions/settings/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/deviceSettingsActions.ts
@@ -168,13 +168,13 @@ export const resetDevice =
         });
 
         if (!result.success) {
-            dispatch(
-                notificationsActions.addToast({
-                    type: 'error',
-                    error: 'Something went wrong, try again.',
-                }),
-            );
             if (result.payload.code === 'Failure_EntropyCheck') {
+                dispatch(
+                    notificationsActions.addToast({
+                        type: 'error',
+                        error: 'Something went wrong, try again.',
+                    }),
+                );
                 const model = device?.features?.internal_model;
                 const revision = device?.features?.revision;
                 const version = getFirmwareVersion(device);


### PR DESCRIPTION
- Return `Failure_EntropyCheck` instead of `Failure_InvalidSession` on devices not supporting entropy check.
- Display error toast only on `Failure_EntropyCheck` error.
