### PR TITLE
feat(suite): add subtle variant to rewards button

### DIFF
--- a/packages/components/src/components/buttons/buttonStyleUtils.ts
+++ b/packages/components/src/components/buttons/buttonStyleUtils.ts
@@ -48,7 +48,7 @@ export const getIconColor = ({
 
     switch (variant) {
         case 'primary':
-            return theme.iconOnPrimary;
+            return isSubtle ? theme.iconPrimaryDefault : theme.iconOnPrimary;
         case 'tertiary':
             return theme.iconOnTertiary;
         case 'info':
@@ -117,8 +117,11 @@ export const useVariantStyle = (
     const variantsColors: Record<ButtonVariant, Record<string, string | Colors>> = {
         primary: {
             background: theme.backgroundPrimaryDefault,
+            backgroundSubtle: hexToRgba(theme.backgroundPrimaryDefault, SUBTLE_ALPHA),
             backgroundHover: theme.backgroundPrimaryPressed,
+            backgroundSubtleHover: hexToRgba(theme.backgroundPrimaryDefault, SUBTLE_ALPHA_HOVER),
             text: theme.textOnPrimary,
+            textSubtle: theme.textPrimaryDefault,
         },
         tertiary: {
             background: mapElevationToButtonBackground({

--- a/packages/components/src/components/form/FractionButton/FractionButton.tsx
+++ b/packages/components/src/components/form/FractionButton/FractionButton.tsx
@@ -9,6 +9,7 @@ export type FractionButtonProps = {
     children: React.ReactNode;
     tooltip?: React.ReactNode;
     isDisabled?: boolean;
+    isSubtle?: boolean;
     variant?: ButtonVariant;
     onClick: () => void;
 };
@@ -18,6 +19,7 @@ export const FractionButton = ({
     children,
     tooltip,
     isDisabled,
+    isSubtle,
     variant,
     onClick,
 }: FractionButtonProps) => (
@@ -27,6 +29,7 @@ export const FractionButton = ({
             type="button"
             size="tiny"
             isDisabled={isDisabled}
+            isSubtle={isSubtle}
             onClick={onClick}
         >
             {children}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/Inputs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/Inputs.tsx
@@ -44,6 +44,8 @@ export const Inputs = () => {
         restakedReward = '0',
     } = getStakingDataForNetwork(account) ?? {};
 
+    const isRewardsDisabled = restakedReward === '0';
+
     const { symbol } = account;
     const networkDisplaySymbol = getNetworkDisplaySymbol(symbol);
 
@@ -172,7 +174,9 @@ export const Inputs = () => {
                     {
                         id: 'TR_FRACTION_BUTTONS_REWARDS',
                         children: <Translation id="TR_FRACTION_BUTTONS_REWARDS" />,
-                        tooltip: (
+                        tooltip: isRewardsDisabled ? (
+                            <Translation id="TR_STAKE_NO_REWARDS" />
+                        ) : (
                             <Column alignItems="flex-end">
                                 <FormattedCryptoAmount value={restakedReward} symbol={symbol} />
                                 <Text variant="primary">
@@ -180,7 +184,9 @@ export const Inputs = () => {
                                 </Text>
                             </Column>
                         ),
+                        isSubtle: true,
                         variant: 'primary',
+                        isDisabled: isRewardsDisabled,
                         onClick: () => onCryptoAmountChange(restakedReward),
                     },
                 ]}

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -8891,6 +8891,10 @@ export default defineMessages({
         id: 'TR_STAKE_ONLY_REWARDS',
         defaultMessage: 'Only rewards',
     },
+    TR_STAKE_NO_REWARDS: {
+        id: 'TR_STAKE_NO_REWARDS',
+        defaultMessage: 'No rewards available',
+    },
     TR_STAKE_UNSTAKED_AND_READY_TO_CLAIM: {
         id: 'TR_STAKE_UNSTAKED_AND_READY_TO_CLAIM',
         defaultMessage: 'Unstaked and ready to claim',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

It adds a subtle variant to the rewards button in the unstaking form and a tooltip in case no rewards are available.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/3b50743d-3f03-4cf5-868b-5ea3d8a54dbb" />

<img width="494" alt="image" src="https://github.com/user-attachments/assets/9c878aa5-99d0-440b-898a-5c3c4e80cdc9" />

<img width="478" alt="image" src="https://github.com/user-attachments/assets/63ee96c4-1465-4b6d-bcc2-3fdfbdfd8a82" />

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/15920

## Screenshots:
