### PR TITLE
feat(trade): allow trading of L2 native tokens

### DIFF
--- a/packages/product-components/src/components/SelectAssetModal/AssetItem.tsx
+++ b/packages/product-components/src/components/SelectAssetModal/AssetItem.tsx
@@ -47,6 +47,7 @@ export const AssetItem = ({
     const getCoinLogo = () =>
         isCoinSymbol(symbol) ? <CoinLogo size={24} symbol={symbol} /> : null;
     const displaySymbol = getDisplaySymbol(ticker, contractAddress);
+    const nativeContractAddress = '0x0000000000000000000000000000000000000000';
 
     return (
         <ClickableContainer
@@ -61,7 +62,7 @@ export const AssetItem = ({
             }
         >
             <Row data-testid={dataTestId} gap={spacings.sm}>
-                {coingeckoId ? (
+                {coingeckoId && !coingeckoId.includes(nativeContractAddress) ? (
                     <AssetLogo
                         size={24}
                         coingeckoId={coingeckoId}

--- a/packages/product-components/src/components/SelectAssetModal/NetworkTabs.tsx
+++ b/packages/product-components/src/components/SelectAssetModal/NetworkTabs.tsx
@@ -82,7 +82,7 @@ export const NetworkTabs = ({
                         onClick={() => {
                             if (
                                 activeTab?.coingeckoId === network.coingeckoId &&
-                                activeTab?.coingeckoNativeId === network.coingeckoNativeId
+                                activeTab?.tradeCryptoId === network.tradeCryptoId
                             ) {
                                 setActiveTab(null);
 
@@ -96,7 +96,7 @@ export const NetworkTabs = ({
                         key={network.coingeckoId}
                     >
                         <Row gap={spacings.xxs}>
-                            {network.coingeckoNativeId && (
+                            {network.tradeCryptoId && (
                                 <CoinLogo size={20} symbol={network.symbol} />
                             )}
                             {network.name}

--- a/packages/product-components/src/components/SelectAssetModal/NetworkTabs.tsx
+++ b/packages/product-components/src/components/SelectAssetModal/NetworkTabs.tsx
@@ -4,7 +4,12 @@ import styled from 'styled-components';
 
 import { Row, Tooltip, useElevation } from '@trezor/components';
 import { Elevation, mapElevationToBorder, spacings, spacingsPx } from '@trezor/theme';
-import { type NetworkSymbol, type Network } from '@suite-common/wallet-config';
+import {
+    getNetwork,
+    NetworkSymbol,
+    networkSymbolCollection,
+    type Network,
+} from '@suite-common/wallet-config';
 
 import { CheckableTag } from './CheckableTag';
 import { CoinLogo } from '../CoinLogo/CoinLogo';
@@ -17,17 +22,10 @@ const NetworkTabsWrapper = styled.div<{ $elevation: Elevation }>`
         ${({ theme, $elevation }) => mapElevationToBorder({ $elevation, theme })};
 `;
 
-export type NetworkFilterCategory = {
-    name: Network['name'];
-    symbol: NetworkSymbol;
-    coingeckoId: Network['coingeckoId'];
-    coingeckoNativeId?: Network['coingeckoNativeId'];
-};
-
-export type SelectAssetSearchCategory = NetworkFilterCategory | null;
+export type SelectAssetSearchCategory = Network | null;
 
 interface NetworkTabsProps {
-    tabs: NetworkFilterCategory[];
+    tabs: NetworkSymbol[];
     activeTab: SelectAssetSearchCategory;
     setActiveTab: (value: SelectAssetSearchCategory) => void;
     networkCount: number;
@@ -42,6 +40,9 @@ export const NetworkTabs = ({
     'data-testid': dataTestId,
 }: NetworkTabsProps) => {
     const { elevation } = useElevation();
+    // sort according to networks
+    const networkKeys = networkSymbolCollection.filter(item => tabs.includes(item));
+    const networkTabs = networkKeys.map(key => getNetwork(key));
 
     // TODO: FormattedMessage - resolve messages sharing https://github.com/trezor/trezor-suite/issues/5325}
     return (
@@ -71,7 +72,7 @@ export const NetworkTabs = ({
                         />
                     </Tooltip>
                 </CheckableTag>
-                {tabs.map(network => (
+                {networkTabs.map(network => (
                     <CheckableTag
                         data-testid={`${dataTestId}/${network.symbol}`}
                         $elevation={elevation}

--- a/packages/product-components/src/components/SelectAssetModal/SelectAssetModal.storiesData.ts
+++ b/packages/product-components/src/components/SelectAssetModal/SelectAssetModal.storiesData.ts
@@ -1,4 +1,3 @@
-import { NetworkFilterCategory } from './NetworkTabs';
 import { AssetOptionBaseProps } from './SelectAssetModal';
 
 interface SelectAssetOptionCurrencyProps extends AssetOptionBaseProps {
@@ -450,38 +449,5 @@ export const selectAssetModalOptions: (
         networkName: 'Base',
         ticker: 'BRETT',
         symbol: 'base',
-    },
-];
-
-export const selectAssetModalNetworks: NetworkFilterCategory[] = [
-    {
-        name: 'Ethereum',
-        symbol: 'eth',
-        coingeckoId: 'ethereum',
-        coingeckoNativeId: 'ethereum',
-    },
-    {
-        name: 'Polygon PoS',
-        symbol: 'pol',
-        coingeckoId: 'polygon-pos',
-        coingeckoNativeId: 'polygon-ecosystem-token',
-    },
-    {
-        name: 'Solana',
-        symbol: 'sol',
-        coingeckoId: 'solana',
-        coingeckoNativeId: 'solana',
-    },
-    {
-        name: 'BNB Smart Chain',
-        symbol: 'bsc',
-        coingeckoId: 'binance-smart-chain',
-        coingeckoNativeId: 'binancecoin',
-    },
-    {
-        name: 'Base',
-        symbol: 'base',
-        coingeckoId: 'base',
-        coingeckoNativeId: 'ethereum',
     },
 ];

--- a/packages/product-components/src/index.ts
+++ b/packages/product-components/src/index.ts
@@ -17,7 +17,6 @@ export * from './components/TokenIconSet/TokenIconSet';
 export { TokenTabs, type TokenTab } from './components/SelectAssetModal/TokenTabs';
 export {
     NetworkTabs,
-    type NetworkFilterCategory,
     type SelectAssetSearchCategory,
 } from './components/SelectAssetModal/NetworkTabs';
 export { NumberInput } from './components/NumberInput/NumberInput';

--- a/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketAccount.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketAccount.ts
@@ -32,10 +32,7 @@ export const useCoinmarketAccount = ({
             return coinmarketAccount;
         }
 
-        if (
-            isTestnet(selectedAccount.account.symbol) &&
-            !selectedAccount.network.coingeckoNativeId
-        ) {
+        if (isTestnet(selectedAccount.account.symbol) && !selectedAccount.network.tradeCryptoId) {
             const defaultSymbol = mapTestnetSymbol(selectedAccount.account.symbol);
             const accountsSorted = coinmarketGetSortedAccounts({
                 accounts,

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketBuyFormDefaultValues.tsx
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketBuyFormDefaultValues.tsx
@@ -24,7 +24,7 @@ export const useCoinmarketBuyFormDefaultValues = (
     const prefilledFromCryptoId = useSelector(
         state => state.wallet.coinmarket.prefilledFromCryptoId,
     );
-    const cryptoId = prefilledFromCryptoId || networks[accountSymbol]?.coingeckoNativeId;
+    const cryptoId = prefilledFromCryptoId || networks[accountSymbol]?.tradeCryptoId;
 
     const country = buyInfo?.buyInfo?.country;
     const defaultCountry = useMemo(() => getDefaultCountry(country), [country]);

--- a/packages/suite/src/hooks/wallet/coinmarket/useCoinmarketInfo.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/useCoinmarketInfo.ts
@@ -5,7 +5,7 @@ import { CoinInfo, CryptoId } from 'invity-api';
 import {
     getDisplaySymbol,
     getNetwork,
-    getNetworkByCoingeckoNativeId,
+    getNetworkByTradeCryptoId,
     NetworkSymbolExtended,
 } from '@suite-common/wallet-config';
 import addressValidator from '@trezor/address-validator';
@@ -131,7 +131,7 @@ export const useCoinmarketInfo = (): CoinmarketInfoProps => {
                 const networkName = cryptoIdToPlatformName(networkId) ?? networkId;
                 const option = toCryptoOption(cryptoId, coinInfo);
 
-                if (getNetworkByCoingeckoNativeId(cryptoId)) {
+                if (getNetworkByTradeCryptoId(cryptoId)) {
                     const isNativeToken = isCryptoIdForNativeToken(cryptoId);
                     const optionWithNetworkName = isNativeToken
                         ? { ...option, networkName }

--- a/packages/suite/src/hooks/wallet/coinmarket/useCoinmarketInfo.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/useCoinmarketInfo.ts
@@ -18,6 +18,7 @@ import {
 } from 'src/types/coinmarket/coinmarket';
 import {
     cryptoIdToNetwork,
+    isCryptoIdForNativeToken,
     parseCryptoId,
     testnetToProdCryptoId,
 } from 'src/utils/wallet/coinmarket/coinmarketUtils';
@@ -31,7 +32,11 @@ const toCryptoOption = (
     coinInfo: CoinInfo,
 ): CoinmarketCryptoSelectItemProps => {
     const { networkId, contractAddress } = parseCryptoId(cryptoId);
+    const isNativeToken = isCryptoIdForNativeToken(cryptoId);
     const coinInfoSymbol = coinInfo.symbol.toLowerCase();
+    const symbol = isNativeToken
+        ? cryptoIdToNetwork(cryptoId)?.symbol ?? coinInfoSymbol
+        : coinInfoSymbol;
     const displaySymbol = getDisplaySymbol(coinInfoSymbol, contractAddress);
 
     return {
@@ -41,7 +46,7 @@ const toCryptoOption = (
         cryptoName: coinInfo.name,
         coingeckoId: networkId,
         contractAddress: contractAddress || null,
-        symbol: coinInfo.symbol,
+        symbol,
     };
 };
 
@@ -106,6 +111,7 @@ export const useCoinmarketInfo = (): CoinmarketInfoProps => {
 
             cryptoIds.forEach(cryptoId => {
                 const coinInfo = coins[cryptoId];
+
                 if (!coinInfo) {
                     return;
                 }
@@ -122,14 +128,19 @@ export const useCoinmarketInfo = (): CoinmarketInfoProps => {
                 }
 
                 const { networkId, contractAddress } = parseCryptoId(cryptoId);
+                const networkName = cryptoIdToPlatformName(networkId) ?? networkId;
                 const option = toCryptoOption(cryptoId, coinInfo);
 
                 if (getNetworkByCoingeckoNativeId(cryptoId)) {
-                    popularCurrencies.push(option);
+                    const isNativeToken = isCryptoIdForNativeToken(cryptoId);
+                    const optionWithNetworkName = isNativeToken
+                        ? { ...option, networkName }
+                        : option;
+
+                    popularCurrencies.push(optionWithNetworkName);
                 } else if (!contractAddress) {
                     otherCurrencies.push(option);
                 } else {
-                    const networkName = cryptoIdToPlatformName(networkId) || networkId;
                     const tokenGroup = tokenGroups.find(group =>
                         group.find(item => item.networkName === networkName),
                     );

--- a/packages/suite/src/utils/wallet/coinmarket/__tests__/coinmarketUtils.test.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/__tests__/coinmarketUtils.test.ts
@@ -17,6 +17,7 @@ import {
     coinmarketGetAccountLabel,
     testnetToProdCryptoId,
     getAddressAndTokenFromAccountOptionsGroupProps,
+    isCryptoIdForNativeToken,
 } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import {
     FIXTURE_ACCOUNTS,
@@ -318,5 +319,24 @@ describe('coinmarket utils', () => {
                 item.result,
             );
         });
+    });
+
+    it('isCryptoIdForNativeToken - test if token is L2 native token', () => {
+        expect(isCryptoIdForNativeToken('ethereum' as CryptoId)).toEqual(false);
+        expect(
+            isCryptoIdForNativeToken(
+                'ethereum--0x1234123412341234123412341234123412341236' as CryptoId,
+            ),
+        ).toEqual(false);
+        expect(
+            isCryptoIdForNativeToken(
+                'ethereum--0x0000000000000000000000000000000000000000' as CryptoId,
+            ),
+        ).toEqual(true);
+        expect(
+            isCryptoIdForNativeToken(
+                'base--0x0000000000000000000000000000000000000000' as CryptoId,
+            ),
+        ).toEqual(true);
     });
 });

--- a/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
@@ -40,43 +40,51 @@ import {
 } from 'src/types/coinmarket/coinmarket';
 
 export const cryptoPlatformSeparator = '--';
+/**
+ * Used for for L2 networks (e.g. base, op)
+ */
+export const contractAddressForNativeToken = '0x0000000000000000000000000000000000000000';
 
 interface ParsedCryptoId {
     networkId: CryptoId;
     contractAddress: string | undefined;
 }
 
-export function parseCryptoId(cryptoId: CryptoId): ParsedCryptoId {
+export const parseCryptoId = (cryptoId: CryptoId): ParsedCryptoId => {
     const parts = cryptoId.split(cryptoPlatformSeparator);
 
     return { networkId: parts[0] as CryptoId, contractAddress: parts[1] };
-}
+};
 
-export function cryptoIdToNetwork(cryptoId: CryptoId): Network | undefined {
+export const cryptoIdToNetwork = (cryptoId: CryptoId): Network | undefined => {
     const { networkId, contractAddress } = parseCryptoId(cryptoId);
 
     return contractAddress
         ? getNetworkByCoingeckoId(networkId)
         : getNetworkByCoingeckoNativeId(networkId);
-}
+};
 
-export function cryptoIdToSymbol(cryptoId: CryptoId): NetworkSymbol | undefined {
-    return cryptoIdToNetwork(cryptoId)?.symbol;
-}
+export const cryptoIdToSymbol = (cryptoId: CryptoId): NetworkSymbol | undefined =>
+    cryptoIdToNetwork(cryptoId)?.symbol;
 
-export function toTokenCryptoId(symbol: NetworkSymbol, contractAddress: string): CryptoId {
-    return `${getCoingeckoId(symbol)}${cryptoPlatformSeparator}${contractAddress}` as CryptoId;
-}
+export const toTokenCryptoId = (symbol: NetworkSymbol, contractAddress: string): CryptoId =>
+    `${getCoingeckoId(symbol)}${cryptoPlatformSeparator}${contractAddress}` as CryptoId;
 
 /** Convert testnet cryptoId to prod cryptoId (test-bitcoin -> bitcoin) */
-export function testnetToProdCryptoId(cryptoId: CryptoId): CryptoId {
+export const testnetToProdCryptoId = (cryptoId: CryptoId): CryptoId => {
     const { networkId, contractAddress } = parseCryptoId(cryptoId);
 
     return ((networkId.split('test-')?.[1] ?? networkId) +
         (contractAddress ? `${cryptoPlatformSeparator}${contractAddress}` : '')) as CryptoId;
-}
+};
 
-interface CoinmarketGetDecimalsProps {
+export const isCryptoIdForNativeToken = (cryptoId: CryptoId) => {
+    const { contractAddress } = parseCryptoId(cryptoId);
+
+    return contractAddress === contractAddressForNativeToken;
+};
+
+export interface CoinmarketGetDecimalsProps {
     sendCryptoSelect?: CoinmarketAccountOptionsGroupOptionProps;
     network?: Network | null;
 }
@@ -337,12 +345,6 @@ export const coinmarketBuildAccountOptions = ({
         deviceState,
     });
 
-    /**
-     * TODO: allow second layer ETH coins to trade, now it is not working -> skip them
-     * Temporary solution to skip not native network symbols
-     */
-    const skipNotNativeNetworkSymbols: readonly NetworkSymbol[] = ['op', 'base', 'arb'];
-
     const groups: CoinmarketAccountsOptionsGroupProps[] = [];
 
     accountsSorted.forEach(account => {
@@ -379,8 +381,7 @@ export const coinmarketBuildAccountOptions = ({
             accountType: account.accountType,
             decimals: accountDecimals,
         };
-        const options: CoinmarketAccountOptionsGroupOptionProps[] =
-            !skipNotNativeNetworkSymbols.includes(network.symbol) ? [option] : [];
+        const options: CoinmarketAccountOptionsGroupOptionProps[] = [option];
 
         const hasNativeToken = options.length > 0;
 

--- a/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
@@ -7,7 +7,7 @@ import {
     getCoingeckoId,
     getNetwork,
     getNetworkByCoingeckoId,
-    getNetworkByCoingeckoNativeId,
+    getNetworkByTradeCryptoId,
     getNetworkDisplaySymbol,
     getNetworkDisplaySymbolName,
     getNetworkFeatures,
@@ -61,7 +61,7 @@ export const cryptoIdToNetwork = (cryptoId: CryptoId): Network | undefined => {
 
     return contractAddress
         ? getNetworkByCoingeckoId(networkId)
-        : getNetworkByCoingeckoNativeId(networkId);
+        : getNetworkByTradeCryptoId(networkId);
 };
 
 export const cryptoIdToSymbol = (cryptoId: CryptoId): NetworkSymbol | undefined =>
@@ -359,7 +359,7 @@ export const coinmarketBuildAccountOptions = ({
 
         const network = getNetwork(accountSymbol);
 
-        if (!network.coingeckoNativeId) {
+        if (!network.tradeCryptoId) {
             return;
         }
 
@@ -373,7 +373,7 @@ export const coinmarketBuildAccountOptions = ({
 
         const accountDecimals = network.decimals;
         const option: CoinmarketAccountOptionsGroupOptionProps = {
-            value: network.coingeckoNativeId as CryptoId,
+            value: network.tradeCryptoId as CryptoId,
             label: getNetworkDisplaySymbol(accountSymbol),
             cryptoName: getNetworkDisplaySymbolName(accountSymbol),
             descriptor,

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketCoinLogo.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketCoinLogo.tsx
@@ -1,9 +1,14 @@
 import styled from 'styled-components';
 
 import { AssetLogo } from '@trezor/components';
+import { CoinLogo } from '@trezor/product-components';
 
 import { CoinmarketCoinLogoProps } from 'src/types/coinmarket/coinmarket';
-import { parseCryptoId } from 'src/utils/wallet/coinmarket/coinmarketUtils';
+import {
+    cryptoIdToNetwork,
+    isCryptoIdForNativeToken,
+    parseCryptoId,
+} from 'src/utils/wallet/coinmarket/coinmarketUtils';
 
 const Wrapper = styled.div``;
 
@@ -14,6 +19,11 @@ export const CoinmarketCoinLogo = ({
     className,
 }: CoinmarketCoinLogoProps) => {
     const { networkId, contractAddress } = parseCryptoId(cryptoId);
+    const network = cryptoIdToNetwork(cryptoId);
+
+    if (isCryptoIdForNativeToken(cryptoId) && network) {
+        return <CoinLogo size={size} symbol={network.symbol} />;
+    }
 
     return (
         <Wrapper className={className}>

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputCryptoSelect.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputCryptoSelect.tsx
@@ -49,8 +49,8 @@ const getNetworkCount = (options: SelectAssetOptionProps[]) => {
         .filter(item => item.type === 'group' && item.networkName)
         .map(networkGroup => ({
             ...networkGroup,
-            coingeckoNativeId: networkGroup.coingeckoId
-                ? getNetworkByCoingeckoId(networkGroup.coingeckoId)?.coingeckoNativeId
+            tradeCryptoId: networkGroup.coingeckoId
+                ? getNetworkByCoingeckoId(networkGroup.coingeckoId)?.tradeCryptoId
                 : undefined,
         }));
 
@@ -61,7 +61,7 @@ const getNetworkCount = (options: SelectAssetOptionProps[]) => {
             !networkNetworkGroups.find(
                 group =>
                     group.coingeckoId === item.coingeckoId ||
-                    group.coingeckoNativeId === item.coingeckoId,
+                    group.tradeCryptoId === item.coingeckoId,
             ),
     );
 
@@ -123,10 +123,8 @@ export const CoinmarketFormInputCryptoSelect = <
 
                     const { symbol } = network;
                     const isNativeToken = isCryptoIdForNativeToken(option.value);
-                    // for native tokens (eg. base) to use coingeckoNativeId
-                    const coingeckoId = isNativeToken
-                        ? network.coingeckoNativeId
-                        : option.coingeckoId;
+                    // for native tokens (eg. base) to use tradeCryptoId
+                    const coingeckoId = isNativeToken ? network.tradeCryptoId : option.coingeckoId;
 
                     return {
                         ...option,

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputCryptoSelect.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputCryptoSelect.tsx
@@ -7,19 +7,12 @@ import { Badge, Row, Select, Text } from '@trezor/components';
 import {
     SearchAsset,
     SelectAssetModal,
-    NetworkFilterCategory,
     NetworkTabs,
-    SelectAssetSearchCategory,
     AssetProps,
     ITEM_HEIGHT,
     AssetOptionBaseProps,
 } from '@trezor/product-components';
-import {
-    type NetworkSymbol,
-    getNetworkByCoingeckoId,
-    getNetwork,
-    networkSymbolCollection,
-} from '@suite-common/wallet-config';
+import { getNetworkByCoingeckoId, Network, NetworkSymbol } from '@suite-common/wallet-config';
 import { spacings } from '@trezor/theme';
 
 import {
@@ -101,7 +94,7 @@ export const CoinmarketFormInputCryptoSelect = <
     const { buildCryptoOptions, cryptoIdToPlatformName } = useCoinmarketInfo();
     const { control } = methods;
     const [isModalActive, setIsModalActive] = useState(false);
-    const [activeTab, setActiveTab] = useState<SelectAssetSearchCategory>(null); // coingeckoNativeId as fallback for ex. polygon
+    const [activeTab, setActiveTab] = useState<Network | null>(null);
     const [search, setSearch] = useState('');
     const { translationString } = useTranslation();
 
@@ -172,23 +165,6 @@ export const CoinmarketFormInputCryptoSelect = <
         setIsModalActive(false);
     };
 
-    const getNetworks = () => {
-        const networksToSelect: NetworkSymbol[] = ['eth', 'sol', 'pol', 'bsc', 'base', 'op', 'arb'];
-        const networkKeys = networkSymbolCollection.filter(item => networksToSelect.includes(item));
-        const networksSelected: NetworkFilterCategory[] = networkKeys.map(networkKey => {
-            const network = getNetwork(networkKey);
-
-            return {
-                name: network.name,
-                symbol: network.symbol,
-                coingeckoId: network.coingeckoId,
-                coingeckoNativeId: network.coingeckoNativeId,
-            };
-        });
-
-        return networksSelected;
-    };
-
     const data = useMemo(() => getData(modalOptions), [modalOptions]);
 
     const filteredData = data.filter(item => {
@@ -213,7 +189,7 @@ export const CoinmarketFormInputCryptoSelect = <
         );
     });
 
-    const tabs = getNetworks();
+    const quickTabs: NetworkSymbol[] = ['eth', 'sol', 'pol', 'bsc', 'base', 'op', 'arb'];
 
     return (
         <>
@@ -236,10 +212,7 @@ export const CoinmarketFormInputCryptoSelect = <
                             <Translation
                                 id="TR_TOKEN_NOT_FOUND_ON_NETWORK"
                                 values={{
-                                    networkName: tabs.find(
-                                        (category: NetworkFilterCategory) =>
-                                            category.coingeckoId === activeTab?.coingeckoId,
-                                    )?.name,
+                                    networkName: activeTab?.name ?? '',
                                 }}
                             />
                         ),
@@ -248,7 +221,7 @@ export const CoinmarketFormInputCryptoSelect = <
                     filterTabs={
                         <NetworkTabs
                             data-testid="@coinmarket/form/select-crypto/network-tab"
-                            tabs={tabs}
+                            tabs={quickTabs}
                             networkCount={getNetworkCount(modalOptions)}
                             activeTab={activeTab}
                             setActiveTab={setActiveTab}

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputCryptoSelect.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputCryptoSelect.tsx
@@ -1,6 +1,8 @@
 import { Controller } from 'react-hook-form';
 import { useMemo, useState } from 'react';
 
+import { CryptoId } from 'invity-api';
+
 import { Badge, Row, Select, Text } from '@trezor/components';
 import {
     SearchAsset,
@@ -14,7 +16,6 @@ import {
 } from '@trezor/product-components';
 import {
     type NetworkSymbol,
-    getNetworkByCoingeckoNativeId,
     getNetworkByCoingeckoId,
     getNetwork,
     networkSymbolCollection,
@@ -35,7 +36,9 @@ import {
 } from 'src/types/coinmarket/coinmarketForm';
 import { useCoinmarketInfo } from 'src/hooks/wallet/coinmarket/useCoinmarketInfo';
 import {
+    cryptoIdToNetwork,
     cryptoPlatformSeparator,
+    isCryptoIdForNativeToken,
     parseCryptoId,
 } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import { useCoinmarketFormContext } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonForm';
@@ -117,28 +120,42 @@ export const CoinmarketFormInputCryptoSelect = <
 
     const modalOptions: SelectAssetOptionProps[] = useMemo(
         () =>
-            formOptions.map(
-                (option): SelectAssetOptionProps =>
-                    option.type === 'currency'
-                        ? {
-                              ...option,
-                              ticker: option.ticker || option.label,
-                              symbol:
-                                  getNetworkByCoingeckoNativeId(
-                                      parseCryptoId(option.value).networkId,
-                                  )?.symbol || parseCryptoId(option.value).networkId,
-                              contractAddress: option.contractAddress ?? null,
-                          }
-                        : option,
-            ),
+            formOptions
+                .map(option => {
+                    if (option.type !== 'currency') return option; // label
+
+                    const network = cryptoIdToNetwork(option.value);
+
+                    if (!network) return null;
+
+                    const { symbol } = network;
+                    const isNativeToken = isCryptoIdForNativeToken(option.value);
+                    // for native tokens (eg. base) to use coingeckoNativeId
+                    const coingeckoId = isNativeToken
+                        ? network.coingeckoNativeId
+                        : option.coingeckoId;
+
+                    return {
+                        ...option,
+                        ticker: option.ticker || option.label,
+                        symbol,
+                        contractAddress: option.contractAddress ?? null,
+                        coingeckoId,
+                    };
+                })
+                .filter(option => option !== null),
         [formOptions],
     );
 
     const handleSelectChange = (selectedAsset: AssetOptionBaseProps) => {
         const findOption = formOptions.find(option => {
-            const cryptoId = selectedAsset.contractAddress
-                ? `${selectedAsset.coingeckoId}${cryptoPlatformSeparator}${selectedAsset.contractAddress}`
-                : selectedAsset.coingeckoId;
+            const { coingeckoId, contractAddress } = selectedAsset;
+            const isNativeTokenSymbol = isCryptoIdForNativeToken(coingeckoId as CryptoId);
+            const tokenCryptoId = isNativeTokenSymbol
+                ? coingeckoId
+                : `${coingeckoId}${cryptoPlatformSeparator}${contractAddress}`;
+
+            const cryptoId = contractAddress ? tokenCryptoId : coingeckoId;
 
             return option.type === 'currency' && option.value === cryptoId;
         }) as CoinmarketCryptoSelectItemProps | undefined;

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketOfferExchange/CoinmarketOfferExchangeSendSwap.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketOfferExchange/CoinmarketOfferExchangeSendSwap.tsx
@@ -248,7 +248,7 @@ export const CoinmarketOfferExchangeSendSwap = () => {
                         <InfoItem label={<Translation id="TR_EXCHANGE_SWAP_SLIPPAGE_OFFERED" />}>
                             <FormattedCryptoAmount
                                 value={receiveStringAmount}
-                                symbol={receive}
+                                symbol={receiveCoinSymbol}
                                 contractAddress={receiveContractAddress}
                             />
                         </InfoItem>

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -37,7 +37,7 @@ export const networks = {
             },
         },
         coingeckoId: 'bitcoin',
-        coingeckoNativeId: 'bitcoin',
+        tradeCryptoId: 'bitcoin',
     },
     eth: {
         symbol: 'eth',
@@ -74,7 +74,7 @@ export const networks = {
             },
         },
         coingeckoId: 'ethereum',
-        coingeckoNativeId: 'ethereum',
+        tradeCryptoId: 'ethereum',
     },
     pol: {
         symbol: 'pol',
@@ -98,7 +98,7 @@ export const networks = {
             },
         },
         coingeckoId: 'polygon-pos',
-        coingeckoNativeId: 'polygon-ecosystem-token',
+        tradeCryptoId: 'polygon-ecosystem-token',
     },
     bsc: {
         symbol: 'bsc',
@@ -122,7 +122,7 @@ export const networks = {
             },
         },
         coingeckoId: 'binance-smart-chain',
-        coingeckoNativeId: 'binancecoin',
+        tradeCryptoId: 'binancecoin',
     },
     arb: {
         symbol: 'arb',
@@ -146,7 +146,7 @@ export const networks = {
             },
         },
         coingeckoId: 'arbitrum-one',
-        coingeckoNativeId: 'arbitrum-one--0x0000000000000000000000000000000000000000',
+        tradeCryptoId: 'arbitrum-one--0x0000000000000000000000000000000000000000',
     },
     base: {
         symbol: 'base',
@@ -170,7 +170,7 @@ export const networks = {
             },
         },
         coingeckoId: 'base',
-        coingeckoNativeId: 'base--0x0000000000000000000000000000000000000000',
+        tradeCryptoId: 'base--0x0000000000000000000000000000000000000000',
     },
     op: {
         symbol: 'op',
@@ -194,7 +194,7 @@ export const networks = {
             },
         },
         coingeckoId: 'optimistic-ethereum',
-        coingeckoNativeId: 'optimistic-ethereum--0x0000000000000000000000000000000000000000',
+        tradeCryptoId: 'optimistic-ethereum--0x0000000000000000000000000000000000000000',
     },
     sol: {
         symbol: 'sol',
@@ -223,7 +223,7 @@ export const networks = {
             },
         },
         coingeckoId: 'solana',
-        coingeckoNativeId: 'solana',
+        tradeCryptoId: 'solana',
     },
     ada: {
         // icarus derivation
@@ -259,7 +259,7 @@ export const networks = {
             },
         },
         coingeckoId: 'cardano',
-        coingeckoNativeId: 'cardano',
+        tradeCryptoId: 'cardano',
     },
     etc: {
         symbol: 'etc',
@@ -275,7 +275,7 @@ export const networks = {
         backendTypes: ['blockbook'],
         accountTypes: {},
         coingeckoId: 'ethereum-classic',
-        coingeckoNativeId: 'ethereum-classic',
+        tradeCryptoId: 'ethereum-classic',
     },
     xrp: {
         symbol: 'xrp',
@@ -290,7 +290,7 @@ export const networks = {
         backendTypes: ['ripple'],
         accountTypes: {},
         coingeckoId: 'ripple',
-        coingeckoNativeId: 'ripple',
+        tradeCryptoId: 'ripple',
     },
     ltc: {
         symbol: 'ltc',
@@ -314,7 +314,7 @@ export const networks = {
             },
         },
         coingeckoId: 'litecoin',
-        coingeckoNativeId: 'litecoin',
+        tradeCryptoId: 'litecoin',
     },
     bch: {
         symbol: 'bch',
@@ -329,7 +329,7 @@ export const networks = {
         backendTypes: ['blockbook'],
         accountTypes: {},
         coingeckoId: 'bitcoin-cash',
-        coingeckoNativeId: 'bitcoin-cash',
+        tradeCryptoId: 'bitcoin-cash',
     },
     doge: {
         symbol: 'doge',
@@ -344,7 +344,7 @@ export const networks = {
         backendTypes: ['blockbook'],
         accountTypes: {},
         coingeckoId: 'dogecoin',
-        coingeckoNativeId: 'dogecoin',
+        tradeCryptoId: 'dogecoin',
     },
     zec: {
         symbol: 'zec',
@@ -359,7 +359,7 @@ export const networks = {
         backendTypes: ['blockbook'],
         accountTypes: {},
         coingeckoId: 'zcash',
-        coingeckoNativeId: 'zcash',
+        tradeCryptoId: 'zcash',
     },
     dash: {
         symbol: 'dash',
@@ -374,7 +374,7 @@ export const networks = {
         backendTypes: ['blockbook'],
         accountTypes: {},
         coingeckoId: 'dash',
-        coingeckoNativeId: 'dash',
+        tradeCryptoId: 'dash',
     },
     btg: {
         symbol: 'btg',
@@ -394,7 +394,7 @@ export const networks = {
             },
         },
         coingeckoId: 'bitcoin-gold',
-        coingeckoNativeId: 'bitcoin-gold',
+        tradeCryptoId: 'bitcoin-gold',
     },
     dgb: {
         symbol: 'dgb',
@@ -414,7 +414,7 @@ export const networks = {
             },
         },
         coingeckoId: 'digibyte',
-        coingeckoNativeId: 'digibyte',
+        tradeCryptoId: 'digibyte',
     },
     nmc: {
         symbol: 'nmc',
@@ -429,7 +429,7 @@ export const networks = {
         backendTypes: ['blockbook'],
         accountTypes: {},
         coingeckoId: 'namecoin',
-        coingeckoNativeId: 'namecoin',
+        tradeCryptoId: 'namecoin',
     },
     vtc: {
         symbol: 'vtc',
@@ -453,7 +453,7 @@ export const networks = {
             },
         },
         coingeckoId: 'vertcoin',
-        coingeckoNativeId: 'vertcoin',
+        tradeCryptoId: 'vertcoin',
     },
     // testnets
     test: {
@@ -489,7 +489,7 @@ export const networks = {
             },
         },
         coingeckoId: undefined,
-        coingeckoNativeId: 'test-bitcoin', // fake, coingecko does not have testnets
+        tradeCryptoId: 'test-bitcoin', // fake, coingecko does not have testnets
     },
     regtest: {
         symbol: 'regtest',
@@ -525,7 +525,7 @@ export const networks = {
         },
         isDebugOnlyNetwork: true,
         coingeckoId: undefined,
-        coingeckoNativeId: undefined,
+        tradeCryptoId: undefined,
     },
     tsep: {
         symbol: 'tsep',
@@ -541,7 +541,7 @@ export const networks = {
         backendTypes: ['blockbook'],
         accountTypes: {},
         coingeckoId: undefined,
-        coingeckoNativeId: undefined,
+        tradeCryptoId: undefined,
     },
     thol: {
         symbol: 'thol',
@@ -557,7 +557,7 @@ export const networks = {
         backendTypes: ['blockbook'],
         accountTypes: {},
         coingeckoId: undefined,
-        coingeckoNativeId: undefined,
+        tradeCryptoId: undefined,
     },
     dsol: {
         symbol: 'dsol',
@@ -579,7 +579,7 @@ export const networks = {
         backendTypes: ['solana'],
         accountTypes: {},
         coingeckoId: undefined,
-        coingeckoNativeId: undefined,
+        tradeCryptoId: undefined,
     },
     tada: {
         // icarus derivation
@@ -613,7 +613,7 @@ export const networks = {
             },
         },
         coingeckoId: undefined,
-        coingeckoNativeId: undefined,
+        tradeCryptoId: undefined,
     },
     txrp: {
         symbol: 'txrp',
@@ -628,6 +628,6 @@ export const networks = {
         backendTypes: [],
         accountTypes: {},
         coingeckoId: undefined,
-        coingeckoNativeId: 'test-ripple', // fake, coingecko does not have testnets
+        tradeCryptoId: 'test-ripple', // fake, coingecko does not have testnets
     },
 } as const satisfies Networks;

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -146,7 +146,7 @@ export const networks = {
             },
         },
         coingeckoId: 'arbitrum-one',
-        coingeckoNativeId: 'ethereum',
+        coingeckoNativeId: 'arbitrum-one--0x0000000000000000000000000000000000000000',
     },
     base: {
         symbol: 'base',
@@ -170,7 +170,7 @@ export const networks = {
             },
         },
         coingeckoId: 'base',
-        coingeckoNativeId: 'ethereum',
+        coingeckoNativeId: 'base--0x0000000000000000000000000000000000000000',
     },
     op: {
         symbol: 'op',
@@ -194,7 +194,7 @@ export const networks = {
             },
         },
         coingeckoId: 'optimistic-ethereum',
-        coingeckoNativeId: 'ethereum',
+        coingeckoNativeId: 'optimistic-ethereum--0x0000000000000000000000000000000000000000',
     },
     sol: {
         symbol: 'sol',

--- a/suite-common/wallet-config/src/types.ts
+++ b/suite-common/wallet-config/src/types.ts
@@ -117,7 +117,7 @@ type NetworkWithSpecificKey<TKey extends NetworkSymbol> = {
     support?: NetworkDeviceSupport;
     isDebugOnlyNetwork?: boolean;
     coingeckoId?: string;
-    coingeckoNativeId?: string;
+    tradeCryptoId?: string;
 };
 export type Network = NetworkWithSpecificKey<NetworkSymbol>;
 

--- a/suite-common/wallet-config/src/utils.ts
+++ b/suite-common/wallet-config/src/utils.ts
@@ -56,7 +56,7 @@ export const getNetworkFeatures = (symbol: NetworkSymbol): NetworkFeature[] =>
 
 export const getCoingeckoId = (symbol: NetworkSymbol) => networks[symbol].coingeckoId;
 
-export const getCoingeckoNativeId = (symbol: NetworkSymbol) => networks[symbol].coingeckoNativeId;
+export const getTradeCryptoId = (symbol: NetworkSymbol) => networks[symbol].tradeCryptoId;
 
 export const isNetworkSymbol = (symbol: NetworkSymbolExtended): symbol is NetworkSymbol =>
     Object.prototype.hasOwnProperty.call(networks, symbol);
@@ -85,8 +85,8 @@ export const isAccountOfNetwork = (
 export const getNetworkByCoingeckoId = (coingeckoId: string) =>
     networksCollection.find(n => n.coingeckoId === coingeckoId);
 
-export const getNetworkByCoingeckoNativeId = (coingeckoId: string) =>
-    networksCollection.find(n => n.coingeckoNativeId === coingeckoId);
+export const getNetworkByTradeCryptoId = (coingeckoId: string) =>
+    networksCollection.find(n => n.tradeCryptoId === coingeckoId);
 
 export const getNetworkDisplaySymbol = (symbol: NetworkSymbol) => getNetwork(symbol).displaySymbol;
 


### PR DESCRIPTION
## Description
Allowance of trading L2 native tokens (ETH) for Arbitrum one, Base, and Optimism.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/16164

## Screenshots
![obrazek](https://github.com/user-attachments/assets/508edd4d-2f86-4489-817c-2b0816a22a04)
