### PR TITLE
fix(connect): remove account.addresses from cardanoComposeTransaction

### DIFF
--- a/packages/connect-explorer/src/pages/methods/cardano/cardanoComposeTransaction.mdx
+++ b/packages/connect-explorer/src/pages/methods/cardano/cardanoComposeTransaction.mdx
@@ -47,7 +47,6 @@ const changeAddress = account.addresses.change.find(a => a.transfers === 0);
 TrezorConnect.cardanoComposeTransaction({
     account: {
         descriptor: account.descriptor,
-        addresses: account.addresses,
         utxo: account.utxo,
     },
     changeAddress,

--- a/packages/connect/src/types/api/cardanoComposeTransaction.ts
+++ b/packages/connect/src/types/api/cardanoComposeTransaction.ts
@@ -3,7 +3,7 @@ import type { types, trezorUtils } from '@fivebinaries/coin-selection';
 import { Static, Type } from '@trezor/schema-utils';
 
 import { PROTO } from '../../exports';
-import type { AccountAddresses, AccountUtxo } from '../../exports';
+import type { AccountUtxo } from '../../exports';
 import { DerivationPath, type Params, type Response } from '../params';
 import { CardanoCertificatePointer, CardanoCertificate } from './cardano';
 import type { CardanoInput, CardanoOutput } from './cardano';
@@ -60,7 +60,6 @@ export const AccountAddress = Type.Object(
 export type CardanoComposeTransactionParams = {
     account: {
         descriptor: string;
-        addresses: AccountAddresses;
         utxo: AccountUtxo[];
     };
     feeLevels?: { feePerUnit?: string }[];
@@ -79,11 +78,6 @@ export type CardanoComposeTransactionParamsSchema = Static<
 export const CardanoComposeTransactionParamsSchema = Type.Object({
     account: Type.Object({
         descriptor: Type.String(),
-        addresses: Type.Object({
-            change: Type.Array(AccountAddress),
-            used: Type.Array(AccountAddress),
-            unused: Type.Array(AccountAddress),
-        }),
         utxo: Type.Array(
             Type.Object(
                 {

--- a/packages/suite/src/hooks/wallet/useCardanoStaking.ts
+++ b/packages/suite/src/hooks/wallet/useCardanoStaking.ts
@@ -151,7 +151,6 @@ export const useCardanoStaking = (): CardanoStaking => {
 
             const response = await trezorConnect.cardanoComposeTransaction({
                 account: {
-                    addresses: account.addresses,
                     descriptor: account.descriptor,
                     utxo: account.utxo,
                 },

--- a/suite-common/wallet-core/src/send/sendFormCardanoThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormCardanoThunks.ts
@@ -62,7 +62,6 @@ export const composeCardanoTransactionFeeLevelsThunk = createThunk<
             outputs,
             account: {
                 descriptor: account.descriptor,
-                addresses: account.addresses,
                 utxo: account.utxo,
             },
             changeAddress,


### PR DESCRIPTION
## Description

Removed the `account.addresses` parameter from `cardanoComposeTransaction`. It was not actually used anywhere and was causing issues with types.