### PR TITLE
feat(suite): hide rewards button for unknown data

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/Inputs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/Inputs.tsx
@@ -1,4 +1,4 @@
-import { Text, Column } from '@trezor/components';
+import { Text, Column, FractionButtonProps } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 import { formInputsMaxLength } from '@suite-common/validators';
 import { useFormatters } from '@suite-common/formatters';
@@ -44,6 +44,7 @@ export const Inputs = () => {
         restakedReward = '0',
     } = getStakingDataForNetwork(account) ?? {};
 
+    const isRewardsVisible = restakedReward != '';
     const isRewardsDisabled = restakedReward === '0';
 
     const { symbol } = account;
@@ -171,24 +172,31 @@ export const Inputs = () => {
                         ),
                         onClick: () => onCryptoAmountChange(autocompoundBalance),
                     },
-                    {
-                        id: 'TR_FRACTION_BUTTONS_REWARDS',
-                        children: <Translation id="TR_FRACTION_BUTTONS_REWARDS" />,
-                        tooltip: isRewardsDisabled ? (
-                            <Translation id="TR_STAKE_NO_REWARDS" />
-                        ) : (
-                            <Column alignItems="flex-end">
-                                <FormattedCryptoAmount value={restakedReward} symbol={symbol} />
-                                <Text variant="primary">
-                                    <FiatValue amount={restakedReward} symbol={symbol} />
-                                </Text>
-                            </Column>
-                        ),
-                        isSubtle: true,
-                        variant: 'primary',
-                        isDisabled: isRewardsDisabled,
-                        onClick: () => onCryptoAmountChange(restakedReward),
-                    },
+                    ...(isRewardsVisible
+                        ? [
+                              {
+                                  id: 'TR_FRACTION_BUTTONS_REWARDS',
+                                  children: <Translation id="TR_FRACTION_BUTTONS_REWARDS" />,
+                                  tooltip: isRewardsDisabled ? (
+                                      <Translation id="TR_STAKE_NO_REWARDS" />
+                                  ) : (
+                                      <Column alignItems="flex-end">
+                                          <FormattedCryptoAmount
+                                              value={restakedReward}
+                                              symbol={symbol}
+                                          />
+                                          <Text variant="primary">
+                                              <FiatValue amount={restakedReward} symbol={symbol} />
+                                          </Text>
+                                      </Column>
+                                  ),
+                                  isSubtle: true,
+                                  variant: 'primary',
+                                  isDisabled: isRewardsDisabled,
+                                  onClick: () => onCryptoAmountChange(restakedReward),
+                              } as FractionButtonProps,
+                          ]
+                        : []),
                 ]}
             />
         </Column>


### PR DESCRIPTION
## Description

The rewards on Solana are unknown, so I removed the rewards button where there is unknown or missing data.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/16378

## Screenshots:

![image](https://github.com/user-attachments/assets/360c15a1-5acd-4607-91f5-793e39934702)

![image](https://github.com/user-attachments/assets/9a004a16-1360-4ce1-ab1e-99eef5e72b9e)
