### PR TITLE
Log firmware revision check to Sentry on mobile

### DIFF
--- a/suite-native/app/src/hooks/useGlobalHooks.tsx
+++ b/suite-native/app/src/hooks/useGlobalHooks.tsx
@@ -1,4 +1,8 @@
-import { useDetectDeviceError, useHandleDeviceConnection } from '@suite-native/device';
+import {
+    useDetectDeviceError,
+    useHandleDeviceConnection,
+    useReportDeviceCompromised,
+} from '@suite-native/device';
 import { useConnectPopupNavigation } from '@suite-native/module-connect-popup';
 
 import { useCoinEnablingInitialCheck } from './useCoinEnablingInitialCheck';
@@ -14,4 +18,5 @@ export const useGlobalHooks = () => {
 
     useHandleDeviceConnection();
     useDetectDeviceError();
+    useReportDeviceCompromised();
 };

--- a/suite-native/device/package.json
+++ b/suite-native/device/package.json
@@ -15,6 +15,7 @@
         "@reduxjs/toolkit": "1.9.5",
         "@sentry/react-native": "6.5.0",
         "@suite-common/redux-utils": "workspace:*",
+        "@suite-common/suite-utils": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-utils": "workspace:*",
         "@suite-native/alerts": "workspace:*",

--- a/suite-native/device/package.json
+++ b/suite-native/device/package.json
@@ -30,6 +30,7 @@
         "@suite-native/navigation": "workspace:*",
         "@suite-native/settings": "workspace:*",
         "@trezor/connect": "workspace:*",
+        "@trezor/device-utils": "workspace:*",
         "@trezor/styles": "workspace:*",
         "lottie-react-native": "^7.1.0",
         "react": "18.2.0",

--- a/suite-native/device/src/hooks/useReportDeviceCompromised.ts
+++ b/suite-native/device/src/hooks/useReportDeviceCompromised.ts
@@ -1,0 +1,38 @@
+import { useSelector } from 'react-redux';
+import { useEffect, useMemo } from 'react';
+
+import * as Sentry from '@sentry/react-native';
+
+import { getFirmwareVersion } from '@trezor/device-utils';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
+
+import { selectFirmwareRevisionCheckError } from '../selectors';
+
+const reportCheckFail = (checkType: 'Firmware revision', contextData: any) => {
+    Sentry.captureException(`${checkType} check failed! ${JSON.stringify(contextData)}`);
+};
+
+const useCommonData = () => {
+    const device = useSelector(selectSelectedDevice);
+    const model = device?.features?.internal_model;
+    const revision = device?.features?.revision;
+    const version = getFirmwareVersion(device);
+    const vendor = device?.features?.fw_vendor;
+
+    return useMemo(
+        () => ({ model, revision, version, vendor }),
+        [model, revision, version, vendor],
+    );
+};
+
+export const useReportDeviceCompromised = () => {
+    const commonData = useCommonData();
+
+    const revisionCheckError = useSelector(selectFirmwareRevisionCheckError);
+
+    useEffect(() => {
+        if (revisionCheckError !== null) {
+            reportCheckFail('Firmware revision', { ...commonData, revisionCheckError });
+        }
+    }, [commonData, revisionCheckError]);
+};

--- a/suite-native/device/src/index.ts
+++ b/suite-native/device/src/index.ts
@@ -3,6 +3,7 @@ export * from './middlewares/buttonRequestMiddleware';
 export * from './hooks/useHandleDeviceConnection';
 export * from './hooks/useDetectDeviceError';
 export * from './hooks/useReportDeviceConnectToAnalytics';
+export * from './hooks/useReportDeviceCompromised';
 export * from './components/ConnectDeviceAnimation';
 export * from './components/ConfirmOnTrezorImage';
 export * from './components/ConnectorImage';

--- a/suite-native/device/src/selectors.ts
+++ b/suite-native/device/src/selectors.ts
@@ -21,6 +21,7 @@ import {
     selectIsDiscoveredDeviceAccountless,
     selectIsUnacquiredDevice,
 } from '@suite-common/wallet-core';
+import { isDeviceAcquired } from '@suite-common/suite-utils';
 import { getTotalFiatBalance } from '@suite-common/wallet-utils';
 import { selectFiatCurrencyCode, SettingsSliceRootState } from '@suite-native/settings';
 
@@ -106,3 +107,17 @@ export const selectHasNoDeviceWithEmptyPassphrase = createMemoizedSelector(
     [selectDeviceInstances],
     deviceInstances => A.isEmpty(deviceInstances.filter(d => d.useEmptyPassphrase)),
 );
+
+/**
+ * Get firmware revision check error, or null if check was successful / skipped.
+ */
+export const selectFirmwareRevisionCheckError = (state: DeviceRootState) => {
+    const device = selectSelectedDevice(state);
+    if (!isDeviceAcquired(device) || !device.authenticityChecks) return null;
+    const checkResult = device.authenticityChecks.firmwareRevision;
+
+    // null means not performed, then don't consider it failed
+    if (!checkResult || checkResult.success) return null;
+
+    return checkResult.error;
+};

--- a/suite-native/device/tsconfig.json
+++ b/suite-native/device/tsconfig.json
@@ -6,6 +6,9 @@
             "path": "../../suite-common/redux-utils"
         },
         {
+            "path": "../../suite-common/suite-utils"
+        },
+        {
             "path": "../../suite-common/wallet-core"
         },
         {

--- a/suite-native/device/tsconfig.json
+++ b/suite-native/device/tsconfig.json
@@ -26,6 +26,7 @@
         { "path": "../navigation" },
         { "path": "../settings" },
         { "path": "../../packages/connect" },
+        { "path": "../../packages/device-utils" },
         { "path": "../../packages/styles" }
     ],
     "include": [".", "**/*.json"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -10274,6 +10274,7 @@ __metadata:
     "@reduxjs/toolkit": "npm:1.9.5"
     "@sentry/react-native": "npm:6.5.0"
     "@suite-common/redux-utils": "workspace:*"
+    "@suite-common/suite-utils": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"
     "@suite-native/alerts": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10289,6 +10289,7 @@ __metadata:
     "@suite-native/navigation": "workspace:*"
     "@suite-native/settings": "workspace:*"
     "@trezor/connect": "workspace:*"
+    "@trezor/device-utils": "workspace:*"
     "@trezor/styles": "workspace:*"
     lottie-react-native: "npm:^7.1.0"
     react: "npm:18.2.0"


### PR DESCRIPTION
## Description

First step to implement FW revision check in Mobile - just log the result to Sentry in background, no UI.
:information_source:  FYI the check has been done silently for months in suite native, because Connect does it automatically. 

- prepare redux state and selectors
  - may seem superfluous now, but I'll build on it in [#16273](https://github.com/trezor/trezor-suite/issues/16273)
- add `useDeviceCompromised` hook that sends Sentry exception if the check failed
  - similar to [the desktop implementation](https://github.com/trezor/trezor-suite/blob/4d870e4e19d82588f193de10ee5dd7bca5caed36/packages/suite/src/components/suite/SecurityCheck/useReportDeviceCompromised.ts) but still simpler, because we didn't get to FW hash check yet

## Testing
- you may merge [#16356](https://github.com/trezor/trezor-suite/pull/16356) locally into this branch to easily turn on Sentry for testing
- start emulator with `1-main` or `2-main` _(those versions always fail the check)_
- you should see a new sentry issue [such as this one](https://satoshilabs.sentry.io/issues/6221440781/?project=4504214699245568)

## Related Issue

Resolve #16379