### PR TITLE
fix(suite): send form fiat token decimals

### DIFF
--- a/packages/suite/src/views/wallet/send/Outputs/Amount/FiatInput.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/FiatInput.tsx
@@ -69,9 +69,10 @@ export const FiatInput = ({
     const outputError = errors.outputs ? errors.outputs[outputId] : undefined;
     const error = outputError ? outputError.fiat : undefined;
     const fiatValue = getDefaultValue(fiatInputName, output.fiat || '');
-    const tokenValue = getDefaultValue(tokenInputName, output.token);
+    const tokenContractAddress = getDefaultValue(tokenInputName, output.token);
+
     const amountValue = getDefaultValue(amountInputName, '');
-    const token = findToken(account.tokens, tokenValue);
+    const token = findToken(account.tokens, tokenContractAddress);
 
     const currencyValue = watch(currencyInputName);
 
@@ -107,7 +108,7 @@ export const FiatInput = ({
     const inputState = isLowAnonymity ? 'warning' : getInputState(errorToDisplay);
     const bottomText = isLowAnonymity ? null : errorToDisplay?.message;
 
-    const handleChange = (value: string) => handleFiatChange({ outputId, value });
+    const handleChange = (value: string) => handleFiatChange({ outputId, token, value });
 
     const rules = {
         required: translationString('AMOUNT_IS_NOT_SET'),


### PR DESCRIPTION

## Description

- @komret broke send form fiat input for tokens 88caa6580ac67f7919d5278c4fabefaff94f8a81
- this pr is fixing it

## Related Issue

Resolve #16306


## Screenshots:
![Screenshot 2025-01-15 at 17 18 45](https://github.com/user-attachments/assets/8124c1f3-c9bc-4ed5-9a53-5ed6a07f2bac)
