### PR TITLE
fix(suite-native): ios e2e test build in ci

### DIFF
--- a/.github/workflows/test-suite-native-e2e-ios.yml
+++ b/.github/workflows/test-suite-native-e2e-ios.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Use latest stable Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          xcode-version: 16.1.0
 
       - name: Build a Detox test app
         working-directory: ./suite-native/app


### PR DESCRIPTION
This update fixes iOS weekly E2E tests by changing the Xcode version from the latest to static `16.1.0`. The [last week run](https://github.com/trezor/trezor-suite/actions/runs/12738435850) failed because the new Xcode version was being released.
