### PR TITLE
Feat/connect fw update version check

### DIFF
--- a/packages/connect/setupJest.ts
+++ b/packages/connect/setupJest.ts
@@ -90,7 +90,6 @@ const getRelease = (model: 1 | 2): FirmwareRelease => ({
 
 const getReleaseT1 = (release: any): FirmwareRelease => ({
     ...getRelease(1),
-    bootloader_version: [1, 0, 0],
     ...release,
 });
 

--- a/packages/connect/src/api/firmware/parseFirmwareHeaders.ts
+++ b/packages/connect/src/api/firmware/parseFirmwareHeaders.ts
@@ -1,3 +1,4 @@
+import type { VersionArray } from '../../types/firmware';
 /**
  * parse firmware headers
  * based on
@@ -42,7 +43,7 @@ export const parseFirmwareHeaders = (buff: Buffer) => {
 
     const version_patch = restbuff.readInt8(14);
 
-    const version: [number, number, number] = [version_major, version_minor, version_patch];
+    const version: VersionArray = [version_major, version_minor, version_patch];
 
     return {
         version,

--- a/packages/connect/src/core/__tests__/onCallFirmwareUpdate.test.ts
+++ b/packages/connect/src/core/__tests__/onCallFirmwareUpdate.test.ts
@@ -1,0 +1,557 @@
+import { Log } from '@trezor/utils';
+import { v1 as protocolV1 } from '@trezor/protocol';
+import { parseConfigure } from '@trezor/protobuf';
+import { buildMessage } from '@trezor/transport/src/utils/send';
+import releasesT2T1 from '@trezor/connect-common/files/firmware/t2t1/releases.json';
+import releasesT1B1 from '@trezor/connect-common/files/firmware/t1b1/releases.json';
+
+import { onCallFirmwareUpdate } from '../onCallFirmwareUpdate';
+import { parseConnectSettings } from '../../data/connectSettings';
+import { DataManager } from '../../data/DataManager';
+import { DeviceList } from '../../device/DeviceList';
+// mocks
+import * as mockFwHash from '../../api/firmware/calculateFirmwareHash';
+import * as mockAssets from '../../utils/assets';
+
+// NOTE:
+// to disable asset mock and work with the real binaries (tests takes longer):
+// - comment one of ASSETS_BASE_URL's (local or online file)
+// - comment jest.setTimeout(30000);
+const ASSETS_BASE_URL = '';
+// const ASSETS_BASE_URL = require('path').resolve(__dirname, '../../../../', 'connect-common/files');
+// const ASSETS_BASE_URL = 'https://suite.trezor.io/web/static/connect/data';
+// jest.setTimeout(30000);
+
+const { createTestTransport } = global.JestMocks;
+const LATEST_RELEASE = releasesT2T1[0];
+
+type ResponseFixture = {
+    id: string; // messageType from .write
+    data: string; // protobuf response from .read
+};
+
+const transportApiMock = (fixtures: ResponseFixture[]) => {
+    let request = '';
+    let eventChangeListener: (...args: any[]) => void;
+
+    const response = (data: string) =>
+        Promise.resolve({
+            success: true,
+            payload: Buffer.from(data, 'hex'),
+        });
+
+    const success = '3f23230002000000060a046d656f77';
+
+    return {
+        on: (evt: string, listener: any) => {
+            if (evt === 'transport-interface-change') {
+                eventChangeListener = (...args: any[]) => {
+                    setTimeout(() => listener(...args), 1);
+                };
+            }
+        },
+        emitInterfaceChange: (...args: any[]) => {
+            eventChangeListener(...args);
+        },
+        enumerate: () => Promise.resolve({ success: true, payload: [{ path: '1' }] }),
+        write: (_: string, data: Buffer) => {
+            request = data.subarray(3, 5).toString('hex');
+
+            return Promise.resolve({ success: true });
+        },
+        read: () => {
+            const index = fixtures.findIndex(f => f.id === request);
+            if (index >= 0) {
+                const { data } = fixtures[index];
+                fixtures.splice(index, 1);
+
+                return response(data);
+            }
+
+            if (request === '0057' || request === '0006') {
+                // RebootToBootloader (57) > Success
+                // FirmwareErase (06) > Success
+                eventChangeListener([]); // dispatch disconnected device event
+
+                return response(success);
+            } else if (request === '0058') {
+                // GetFirmwareHash > FirmwareHash
+                return response('3f23230059000000160a14' + LATEST_RELEASE.firmware_revision);
+            }
+
+            // Success
+            return response(success);
+        },
+    };
+};
+
+// build protobuf message.
+// default: recent release Features
+const buildProtobufMessage = (messages: any, override: any = {}) => {
+    const major_version = override.data?.major_version || 2;
+    const model = major_version === 1 ? 1 : 2;
+    const internal_model = major_version === 1 ? 'T1B1' : 'T2T1';
+    const latest = major_version === 1 ? releasesT1B1[0] : LATEST_RELEASE;
+    const [fw_major, fw_minor, fw_patch] = latest.version;
+    const version = {
+        major_version: fw_major,
+        minor_version: fw_minor,
+        patch_version: fw_patch,
+    };
+    if (override.data?.bootloader_mode) {
+        const [bl_major, bl_minor, bl_patch] = latest.bootloader_version || [major_version, 0, 0];
+        version.major_version = bl_major;
+        version.minor_version = bl_minor;
+        version.patch_version = bl_patch;
+    }
+
+    return buildMessage({
+        messages,
+        name: override.name || 'Features',
+        data: override.name
+            ? override.data
+            : {
+                  ...version,
+                  fw_major,
+                  fw_minor,
+                  fw_patch,
+                  firmware_present: override.data?.bootloader_mode ? false : true,
+                  model,
+                  internal_model,
+                  revision: LATEST_RELEASE.firmware_revision, // used in calculateFirmwareHashMock
+                  ...override.data,
+              },
+        encode: protocolV1.encode,
+    }).toString('hex');
+};
+
+const httpRequestMock = (version?: number[]) => {
+    const binary = Buffer.concat([
+        Buffer.from('TRZV', 'utf-8'),
+        Buffer.from([200]),
+        Buffer.alloc(200 - 5),
+        Buffer.from('TRZF', 'utf-8'),
+        Buffer.alloc(12),
+        Buffer.from(version || LATEST_RELEASE.version),
+    ]);
+
+    // as ArrayBuffer:
+    // binary.buffer.slice(binary.byteOffset, binary.byteOffset + binary.byteLength)
+    return Promise.resolve(binary);
+};
+
+const calculateFirmwareHashMock = (hash?: string) => ({
+    hash: hash || LATEST_RELEASE.firmware_revision,
+    challenge: '',
+});
+
+// common setup for all tests
+const setupTest = () => {
+    const messages = parseConfigure(DataManager.getProtobufMessages());
+    const deviceList = new DeviceList({
+        ...DataManager.getSettings(),
+        messages,
+        // debug: true,
+    });
+
+    const fixtures: ResponseFixture[] = [];
+    const api = transportApiMock(fixtures);
+    const transport = createTestTransport(api);
+
+    const waitForDeviceList = async (f: ResponseFixture[]) => {
+        fixtures.push(...f);
+        await deviceList.init({ transports: [transport], pendingTransportEvent: true });
+        await deviceList.pendingConnection();
+    };
+
+    const postMessage = ({ type, payload }: any) => {
+        if (type === 'ui-firmware-progress') {
+            // T1B1, without automatic reboot to bootloader
+            if (payload.operation === 'downloading' && payload.progress === 100) {
+                api.emitInterfaceChange([]);
+            }
+            if (payload.operation === 'flashing' && payload.progress === 100) {
+                api.emitInterfaceChange([]);
+            }
+        }
+        if (type === 'ui-firmware_reconnect') {
+            if (payload.target === 'bootloader') {
+                api.emitInterfaceChange([{ path: '1' }]);
+            }
+            if (payload.target === 'normal') {
+                api.emitInterfaceChange([{ path: '1' }]);
+            }
+        }
+    };
+
+    const buildFixture = (id: string, data: any = {}, name?: string) => ({
+        id,
+        data: buildProtobufMessage(messages, { data, name }),
+    });
+
+    const context = {
+        deviceList,
+        postMessage,
+        initDevice: () => Promise.resolve(deviceList.getAllDevices()[0]),
+        log: new Log('Test', false),
+        abortSignal: new AbortController().signal,
+    };
+
+    return {
+        context,
+        deviceList,
+        waitForDeviceList,
+        buildFixture,
+    };
+};
+
+describe('onCallFirmwareUpdate', () => {
+    beforeAll(() => {
+        DataManager.load(parseConnectSettings({}));
+    });
+    beforeEach(() => {
+        if (!ASSETS_BASE_URL) {
+            jest.spyOn(mockAssets, 'httpRequest').mockImplementation((url, type) => {
+                if (type === 'json') {
+                    return Promise.reject(new Error('Offline'));
+                }
+
+                const intermediary = /.*inter-v(.*)?.bin$/.exec(url);
+                if (intermediary) {
+                    return httpRequestMock([1, 8, 1]);
+                    // switch (intermediary[1]) {
+                    //     case '1':
+                    //         return httpRequestMock([1, 8, 1]);
+                    //     case '2':
+                    //         return httpRequestMock([1, 6, 7]);
+                    //     case '3':
+                    //         return httpRequestMock([1, 6, 7]);
+                    //     default:
+                    //         throw new Error(`Unknown intermediary version ${url}`);
+                    // }
+                }
+
+                const version = /.*-(.*)?.bin$/
+                    .exec(url)?.[1]
+                    .split('.')
+                    .map(i => Number(i));
+
+                return httpRequestMock(version);
+            });
+        }
+
+        jest.spyOn(mockFwHash, 'calculateFirmwareHash').mockImplementation((..._args) =>
+            calculateFirmwareHashMock(),
+        );
+    });
+    afterEach(() => {
+        jest.clearAllMocks();
+        jest.useRealTimers();
+    });
+
+    const runFirmwareUpdate = async ({
+        params,
+        context,
+    }: Parameters<typeof onCallFirmwareUpdate>[0]) => {
+        // onCallFirmwareUpdate is using timeouts while waiting for disconnection
+        jest.useFakeTimers();
+        const resultPromise = onCallFirmwareUpdate({
+            params: { baseUrl: ASSETS_BASE_URL, ...params },
+            context,
+        });
+        await jest.advanceTimersByTimeAsync(10 * 1000);
+        jest.useRealTimers();
+
+        return resultPromise;
+    };
+
+    it('T2T1: updated to latest release', async () => {
+        const { context, deviceList, waitForDeviceList, buildFixture } = setupTest();
+
+        await waitForDeviceList([
+            // GetFeatures before reboot
+            buildFixture('0037', {
+                major_version: 2,
+                minor_version: 8,
+                patch_version: 3,
+            }),
+            // GetFeatures in bootloader mode
+            buildFixture('0037', {
+                bootloader_mode: true,
+            }),
+            // Initialize in bootloader mode
+            buildFixture('0000', {}),
+            // GetFeatures after reboot
+            buildFixture('0037', {}),
+        ]);
+
+        const result = await runFirmwareUpdate({
+            params: {},
+            context,
+        });
+
+        expect(result.check).toEqual('valid');
+        expect(result.versionCheck).toEqual(true);
+
+        await deviceList.dispose();
+    });
+
+    it('T2T1: started in bootloader_mode', async () => {
+        const { context, deviceList, waitForDeviceList, buildFixture } = setupTest();
+
+        await waitForDeviceList([
+            // GetFeatures in bootloader mode
+            buildFixture('0037', {
+                bootloader_mode: true,
+            }),
+            // Initialize in bootloader mode
+            buildFixture('0000', {}),
+            // GetFeatures after reboot
+            buildFixture('0037', {}),
+        ]);
+
+        const result = await runFirmwareUpdate({
+            params: {},
+            context,
+        });
+
+        expect(result.check).toEqual('valid');
+        expect(result.versionCheck).toEqual(true);
+
+        await deviceList.dispose();
+    });
+
+    it('T2T1: hash mismatch', async () => {
+        const { context, deviceList, waitForDeviceList, buildFixture } = setupTest();
+
+        jest.spyOn(mockFwHash, 'calculateFirmwareHash').mockImplementation((..._args) =>
+            calculateFirmwareHashMock('aa00'),
+        );
+
+        await waitForDeviceList([
+            // GetFeatures before reboot
+            buildFixture('0037', {
+                major_version: 2,
+                minor_version: 8,
+                patch_version: 3,
+            }),
+            // GetFeatures in bootloader mode
+            buildFixture('0037', {
+                bootloader_mode: true,
+            }),
+            // Initialize in bootloader mode
+            buildFixture('0000', {}),
+            // GetFeatures after reboot
+            buildFixture('0037', {}),
+        ]);
+
+        const result = await runFirmwareUpdate({
+            params: {},
+            context,
+        });
+
+        expect(result.check).toEqual('mismatch');
+        expect(result.versionCheck).toEqual(true);
+
+        await deviceList.dispose();
+    });
+
+    it('T2T1: installed version mismatch', async () => {
+        const { context, deviceList, waitForDeviceList, buildFixture } = setupTest();
+
+        await waitForDeviceList([
+            // GetFeatures before reboot
+            buildFixture('0037', {
+                major_version: 2,
+                minor_version: 8,
+                patch_version: 3,
+            }),
+            // GetFeatures in bootloader mode
+            buildFixture('0037', {
+                bootloader_mode: true,
+            }),
+            // Initialize in bootloader mode
+            buildFixture('0000', {}),
+            // GetFeatures after reboot
+            buildFixture('0037', {
+                major_version: 2,
+                minor_version: 8,
+                patch_version: 2,
+            }),
+        ]);
+
+        const result = await runFirmwareUpdate({
+            params: {},
+            context,
+        });
+
+        expect(result.check).toEqual('valid');
+        expect(result.versionCheck).toEqual(false);
+        expect(result.releaseVersion).toEqual(result.binaryVersion);
+        expect(result.releaseVersion).not.toEqual(result.installedVersion);
+
+        await deviceList.dispose();
+    });
+
+    it('T2T1: updated from binary', async () => {
+        const { context, deviceList, waitForDeviceList, buildFixture } = setupTest();
+
+        await waitForDeviceList([
+            // GetFeatures before reboot
+            buildFixture('0037', {
+                major_version: 2,
+                minor_version: 8,
+                patch_version: 3,
+            }),
+            // GetFeatures in bootloader mode
+            buildFixture('0037', {
+                bootloader_mode: true,
+            }),
+            // Initialize in bootloader mode
+            buildFixture('0000', {}),
+            // GetFeatures after reboot
+            buildFixture('0037', {}),
+        ]);
+
+        const binary = await httpRequestMock();
+        const result = await runFirmwareUpdate({
+            params: { binary },
+            context,
+        });
+
+        expect(result.check).toEqual('omitted');
+        expect(result.versionCheck).toEqual(true);
+
+        await deviceList.dispose();
+    });
+
+    it('T2T1: from binary, started in bootloader_mode', async () => {
+        const { context, deviceList, waitForDeviceList, buildFixture } = setupTest();
+
+        await waitForDeviceList([
+            // GetFeatures in bootloader mode
+            buildFixture('0037', {
+                bootloader_mode: true,
+            }),
+            // Initialize in bootloader mode
+            buildFixture('0000', {}),
+            // GetFeatures after reboot
+            buildFixture('0037', {}),
+        ]);
+
+        const binary = await httpRequestMock();
+        const result = await runFirmwareUpdate({
+            params: { binary },
+            context,
+        });
+
+        expect(result.check).toEqual('omitted');
+        expect(result.versionCheck).toEqual(true);
+
+        await deviceList.dispose();
+    });
+
+    it('T2T1: from binary, binary version mismatch', async () => {
+        const { context, deviceList, waitForDeviceList, buildFixture } = setupTest();
+
+        await waitForDeviceList([
+            // GetFeatures in bootloader mode
+            buildFixture('0037', {
+                bootloader_mode: true,
+            }),
+            // Initialize in bootloader mode
+            buildFixture('0000', {}),
+            // GetFeatures after reboot
+            buildFixture('0037', {}),
+        ]);
+
+        const binary = await httpRequestMock([2, 8, 3]);
+        const result = await runFirmwareUpdate({
+            params: { binary },
+            context,
+        });
+
+        expect(result.check).toEqual('omitted');
+        expect(result.versionCheck).toEqual(false);
+        expect(result.binaryVersion).not.toEqual(result.installedVersion);
+
+        await deviceList.dispose();
+    });
+
+    it('T1B1: updated to latest release', async () => {
+        const { context, deviceList, waitForDeviceList, buildFixture } = setupTest();
+
+        // NOTE: to avoid intermediary always update from latest to latest
+        const t1 = {
+            major_version: 1,
+        };
+
+        // NOTE: 1.11.1 is using intermediary v2
+        await waitForDeviceList([
+            // GetFeatures before reboot
+            buildFixture('0037', { ...t1 }),
+            // GetFeatures in bootloader mode
+            buildFixture('0037', { ...t1, bootloader_mode: true }),
+            // Initialize in bootloader mode
+            buildFixture('0000', { ...t1, bootloader_mode: true }),
+            // GetFeatures after reboot
+            buildFixture('0037', { ...t1 }),
+        ]);
+
+        const result = await runFirmwareUpdate({
+            params: {},
+            context,
+        });
+
+        expect(result.check).toEqual('valid');
+        expect(result.versionCheck).toEqual(true);
+
+        await deviceList.dispose();
+    });
+
+    it('T1B1: intermediary v1', async () => {
+        const { context, deviceList, waitForDeviceList, buildFixture } = setupTest();
+
+        const t1 = {
+            major_version: 1,
+        };
+
+        await waitForDeviceList([
+            // GetFeatures before reboot
+            buildFixture('0037', { ...t1, minor_version: 0, patch_version: 0 }),
+            // GetFeatures in bootloader mode
+            buildFixture('0037', {
+                ...t1,
+                bootloader_mode: true,
+                minor_version: 0,
+                patch_version: 0,
+            }),
+            // Initialize in bootloader mode
+            buildFixture('0000', {
+                ...t1,
+                bootloader_mode: true,
+                minor_version: 0,
+                patch_version: 0,
+            }),
+            // GetFeatures in bootloader mode after intermediary installation
+            buildFixture('0037', {
+                ...t1,
+                bootloader_mode: true,
+            }),
+            // Initialize in bootloader mode
+            buildFixture('0000', { ...t1, bootloader_mode: true }),
+            // GetFeatures after reboot
+            buildFixture('0037', { ...t1 }),
+        ]);
+
+        const result = await runFirmwareUpdate({
+            params: {},
+            context,
+        });
+
+        expect(result.check).toEqual('valid');
+        expect(result.versionCheck).toEqual(true);
+
+        await deviceList.dispose();
+    });
+});

--- a/packages/connect/src/core/__tests__/onCallFirmwareUpdate.test.ts
+++ b/packages/connect/src/core/__tests__/onCallFirmwareUpdate.test.ts
@@ -554,4 +554,53 @@ describe('onCallFirmwareUpdate', () => {
 
         await deviceList.dispose();
     });
+
+    it('T3W1: from binary', async () => {
+        const { context, deviceList, waitForDeviceList, buildFixture } = setupTest();
+        const t3 = {
+            internal_model: 'T3W1',
+        };
+
+        await waitForDeviceList([
+            // GetFeatures before reboot
+            buildFixture('0037', { ...t3 }),
+            // GetFeatures in bootloader mode
+            buildFixture('0037', { ...t3, bootloader_mode: true }),
+            // Initialize in bootloader mode
+            buildFixture('0000', { ...t3 }),
+            // GetFeatures after reboot
+            buildFixture('0037', { ...t3 }),
+        ]);
+
+        const binary = await httpRequestMock();
+        const result = await runFirmwareUpdate({
+            params: { binary },
+            context,
+        });
+
+        expect(result.check).toEqual('omitted');
+        expect(result.versionCheck).toEqual(true);
+
+        await deviceList.dispose();
+    });
+
+    // NOTE: this test fails because there are no official releases for T3W1, should be removed after release
+    it('T3W1: failed from config', async () => {
+        const { context, deviceList, waitForDeviceList, buildFixture } = setupTest();
+        const t3 = { internal_model: 'T3W1' };
+
+        await waitForDeviceList([
+            // GetFeatures before reboot
+            buildFixture('0037', { ...t3 }),
+        ]);
+
+        await expect(() =>
+            onCallFirmwareUpdate({
+                params: {},
+                context,
+            }),
+        ).rejects.toThrow('firmwareRelease is not set');
+
+        await deviceList.dispose();
+    });
 });

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -651,6 +651,9 @@ const onCallDevice = async (
             createUiMessage(UI.REQUEST_PASSPHRASE_ON_DEVICE, { device: device.toMessageObject() }),
         );
     });
+    device.on(DEVICE.FIRMWARE_VERSION_CHANGED, payload => {
+        sendCoreMessage(createDeviceMessage(DEVICE.FIRMWARE_VERSION_CHANGED, payload));
+    });
     if (useCoreInPopup && env === 'webextension' && origin) {
         device.initStorage(new WebextensionStateStorage(origin));
     }

--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -185,15 +185,16 @@ const getBinaryHelper = (
     postMessage: PostMessage,
     btcOnly: boolean,
 ) => {
-    if (!device.firmwareRelease) {
-        throw ERRORS.TypedError('Runtime', 'device.firmwareRelease is not set');
-    }
     if (params.binary) {
         return {
             binary: params.binary,
             binaryVersion: parseFirmwareHeaders(Buffer.from(params.binary)).version,
             releaseVersion: undefined,
         };
+    }
+
+    if (!device.firmwareRelease) {
+        throw ERRORS.TypedError('Runtime', 'device.firmwareRelease is not set');
     }
 
     const {
@@ -318,10 +319,6 @@ export const onCallFirmwareUpdate = async ({
     log.debug('onCallFirmwareUpdate with params: ', params);
 
     const device = await initDevice(params?.device?.path);
-    if (!device.firmwareRelease) {
-        throw ERRORS.TypedError('Runtime', 'device.firmwareRelease is not set');
-    }
-
     if (deviceList.getDeviceCount() > 1) {
         throw ERRORS.TypedError(
             'Device_MultipleNotSupported',
@@ -378,7 +375,7 @@ export const onCallFirmwareUpdate = async ({
 
         const targetLanguage = params.language || device.features.language || 'en-US';
         const languageBlob =
-            language && targetLanguage !== 'en-US'
+            device.firmwareRelease && language && targetLanguage !== 'en-US'
                 ? await getLanguage({
                       language: targetLanguage,
                       version: device.firmwareRelease.release.version,
@@ -438,7 +435,7 @@ export const onCallFirmwareUpdate = async ({
         );
     }
 
-    const intermediary = !params.binary && device.firmwareRelease.intermediaryVersion;
+    const intermediary = !params.binary && device.firmwareRelease?.intermediaryVersion;
     const bootloaderVersion = reconnectedDevice.getVersion();
 
     // note: fw major_version 1 requires calling initialize before calling FirmwareErase. Without it device would not respond

--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from 'crypto';
 
 import { createTimeoutPromise } from '@trezor/utils';
-import { isNewer } from '@trezor/utils/src/versionUtils';
+import { isNewer, isEqual } from '@trezor/utils/src/versionUtils';
 
 import { DeviceList } from '../device/DeviceList';
 import { UI, DEVICE, createUiMessage, createDeviceMessage, CoreEventMessage } from '../events';
@@ -15,7 +15,8 @@ import {
     stripFwHeaders,
 } from '../api/firmware';
 import { getReleases } from '../data/firmwareInfo';
-import { CommonParams, DeviceUniquePath, IntermediaryVersion } from '../types';
+import { CommonParams, DeviceUniquePath } from '../types';
+import { FirmwareUpdateResponse } from '../types/api/firmwareUpdate';
 import { FIRMWARE, PROTO, ERRORS } from '../constants';
 import type { Log } from '../utils/debug';
 import type { Device } from '../device/Device';
@@ -183,18 +184,28 @@ const getBinaryHelper = (
     log: Log,
     postMessage: PostMessage,
     btcOnly: boolean,
-    intermediaryVersion?: IntermediaryVersion,
 ) => {
     if (!device.firmwareRelease) {
         throw ERRORS.TypedError('Runtime', 'device.firmwareRelease is not set');
     }
+    if (params.binary) {
+        return {
+            binary: params.binary,
+            binaryVersion: parseFirmwareHeaders(Buffer.from(params.binary)).version,
+            releaseVersion: undefined,
+        };
+    }
 
+    const {
+        intermediaryVersion,
+        release: { version },
+    } = device.firmwareRelease;
     log.debug(
         'onCallFirmwareUpdate loading binary',
         'intermediaryVersion',
         intermediaryVersion,
         'version',
-        device.firmwareRelease.release.version,
+        version,
         'btcOnly',
         btcOnly,
     );
@@ -212,7 +223,7 @@ const getBinaryHelper = (
         features: device.features,
         releases: getReleases(device.features?.internal_model),
         baseUrl: params.baseUrl || 'https://data.trezor.io',
-        version: device.firmwareRelease.release.version,
+        version,
         btcOnly,
         intermediaryVersion,
     })
@@ -234,7 +245,11 @@ const getBinaryHelper = (
                 }),
             );
 
-            return res;
+            return {
+                binary: res,
+                binaryVersion: parseFirmwareHeaders(Buffer.from(res)).version,
+                releaseVersion: version,
+            };
         });
 };
 
@@ -299,7 +314,7 @@ export const onCallFirmwareUpdate = async ({
 }: {
     params: Params;
     context: Context;
-}) => {
+}): Promise<FirmwareUpdateResponse> => {
     log.debug('onCallFirmwareUpdate with params: ', params);
 
     const device = await initDevice(params?.device?.path);
@@ -326,16 +341,8 @@ export const onCallFirmwareUpdate = async ({
         btcOnly,
     });
 
-    const binary =
-        params.binary ||
-        (await getBinaryHelper(
-            device,
-            params,
-            log,
-            postMessage,
-            btcOnly,
-            device.firmwareRelease.intermediaryVersion,
-        ));
+    let binaryInfo = await getBinaryHelper(device, params, log, postMessage, btcOnly);
+    const { binary } = binaryInfo;
 
     const deviceInitiallyConnectedInBootloader = device.features.bootloader_mode;
     const deviceInitiallyConnectedWithoutFirmware = device.features.firmware_present === false;
@@ -432,6 +439,7 @@ export const onCallFirmwareUpdate = async ({
     }
 
     const intermediary = !params.binary && device.firmwareRelease.intermediaryVersion;
+    const bootloaderVersion = reconnectedDevice.getVersion();
 
     // note: fw major_version 1 requires calling initialize before calling FirmwareErase. Without it device would not respond
     await reconnectedDevice.initialize(false);
@@ -454,9 +462,8 @@ export const onCallFirmwareUpdate = async ({
             { deviceList, device: reconnectedDevice, log, postMessage, abortSignal },
         );
 
-        stripped = stripFwHeaders(
-            await getBinaryHelper(reconnectedDevice, params, log, postMessage, btcOnly),
-        );
+        binaryInfo = await getBinaryHelper(reconnectedDevice, params, log, postMessage, btcOnly);
+        stripped = stripFwHeaders(binaryInfo.binary);
         // note: fw major_version 1 requires calling initialize before calling FirmwareErase. Without it device would not respond
         await reconnectedDevice.initialize(false);
 
@@ -497,6 +504,26 @@ export const onCallFirmwareUpdate = async ({
     const checkSupported =
         reconnectedDevice.atLeast(FIRMWARE.FW_HASH_SUPPORTED_VERSIONS) && !params.binary;
 
+    let check: FirmwareUpdateResponse['check'];
+    const installedVersion = reconnectedDevice.getVersion();
+    if (!bootloaderVersion || !installedVersion) {
+        throw ERRORS.TypedError('Runtime', 'reconnectedDevice.installedVersion is not set');
+    }
+
+    const { binaryVersion, releaseVersion } = binaryInfo;
+    // check if installed version matches binary version
+    const assertBinaryVersion = isEqual(installedVersion, binaryVersion);
+    // check if installed version matches requested release version
+    const assertReleaseVersion = releaseVersion ? isEqual(installedVersion, releaseVersion) : true; // binary
+
+    const versionDetails = {
+        versionCheck: assertBinaryVersion && assertReleaseVersion,
+        bootloaderVersion,
+        installedVersion,
+        binaryVersion,
+        releaseVersion,
+    };
+
     if (checkSupported) {
         try {
             log.debug(
@@ -509,18 +536,19 @@ export const onCallFirmwareUpdate = async ({
             await reconnectedDevice.release();
             if (isValid) {
                 log.debug('onCallFirmwareUpdate', 'installed fw hash and calculated hash match');
-
-                return { check: 'valid' as const };
+                check = 'valid';
             } else {
-                return { check: 'mismatch' as const };
+                check = 'mismatch';
             }
         } catch (err) {
             // device failed to respond to the hash check, consider the firmware counterfeit
-            return { check: 'other-error' as const, checkError: err.message };
+            return { check: 'other-error', checkError: err.message, ...versionDetails };
         }
     } else {
         await reconnectedDevice.release();
 
-        return { check: 'omitted' };
+        check = 'omitted';
     }
+
+    return { check, ...versionDetails };
 };

--- a/packages/connect/src/data/__tests__/getInfo.bootloader.test.ts
+++ b/packages/connect/src/data/__tests__/getInfo.bootloader.test.ts
@@ -139,7 +139,7 @@ const fixtures = [
         },
     },
     {
-        desc: 'test bootloader lower version',
+        desc: 'T1 test bootloader lower version',
         features: getDeviceFeatures({
             bootloader_mode: true,
             major_version: 1,
@@ -155,12 +155,34 @@ const fixtures = [
             {
                 version: [1, 1, 0],
                 min_bootloader_version: [1, 0, 0],
-                bootloader_version: [1, 0, 0],
+                bootloader_version: undefined,
+            },
+        ]),
+        result: null,
+    },
+    {
+        desc: 'T2 test bootloader lower version',
+        features: getDeviceFeatures({
+            bootloader_mode: true,
+            major_version: 2,
+            minor_version: 5,
+            patch_version: 0,
+        }),
+        releases: getReleasesT2([
+            {
+                version: [2, 2, 0],
+                min_bootloader_version: [2, 0, 0],
+                bootloader_version: undefined,
             },
             {
-                version: [1, 0, 0],
-                min_bootloader_version: [1, 0, 0],
-                bootloader_version: [1, 0, 0],
+                version: [2, 2, 0],
+                min_bootloader_version: [2, 0, 0],
+                bootloader_version: [2, 1, 0],
+            },
+            {
+                version: [2, 1, 0],
+                min_bootloader_version: [2, 0, 0],
+                bootloader_version: undefined,
             },
         ]),
         result: null,

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -22,6 +22,7 @@ import {
     UiResponsePin,
     UiResponsePassphrase,
     UiResponseWord,
+    DeviceVersionChanged,
 } from '../events';
 import { getAllNetworks } from '../data/coinInfo';
 import { DataManager } from '../data/DataManager';
@@ -106,6 +107,7 @@ export interface DeviceEvents {
     ) => void;
     [DEVICE.PASSPHRASE_ON_DEVICE]: () => void;
     [DEVICE.BUTTON]: (device: Device, payload: DeviceButtonRequestPayload) => void;
+    [DEVICE.FIRMWARE_VERSION_CHANGED]: (payload: DeviceVersionChanged['payload']) => void;
 }
 
 type DeviceLifecycle =
@@ -983,6 +985,13 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
         // check if FW version or capabilities did change
         if (!version || !versionUtils.isEqual(version, newVersion)) {
+            if (version) {
+                this.emit(DEVICE.FIRMWARE_VERSION_CHANGED, {
+                    oldVersion: version,
+                    newVersion,
+                    device: this.toMessageObject(),
+                });
+            }
             this._unavailableCapabilities = getUnavailableCapabilities(feat, getAllNetworks());
             this._firmwareStatus = getFirmwareStatus(feat);
             this._firmwareRelease = getRelease(feat);

--- a/packages/connect/src/device/__tests__/DeviceList.test.ts
+++ b/packages/connect/src/device/__tests__/DeviceList.test.ts
@@ -275,4 +275,41 @@ describe('DeviceList', () => {
             ...DEVICE_CONNECTION_SEQUENCE.map(e => [e, events[8][1]]), // path 4
         ]);
     });
+
+    it('FIRMWARE_VERSION_CHANGED event', async () => {
+        let readCount = 0;
+        const transport = createTestTransport({
+            read: () => {
+                let features = '3f232300110000000c1002180020006000aa010154'; // 2.0.0
+                if (readCount > 0) {
+                    features = `3f232300110000000c10021800200${1}6000aa010154`; // 2.0.1
+                }
+                readCount++;
+
+                return Promise.resolve({
+                    success: true,
+                    payload: Buffer.from(features, 'hex'),
+                });
+            },
+        });
+
+        list.init({ transports: [transport], pendingTransportEvent: true });
+        await list.pendingConnection();
+
+        const device = list.getOnlyDevice();
+        if (!device) throw new Error('Device is missing');
+
+        const spyEvent = jest.fn();
+        device.on('device-firmware_version_changed', spyEvent);
+
+        // Initialize > GetFeatures
+        await device.acquire();
+        await device.initialize(false);
+        await device.release();
+
+        expect(spyEvent.mock.calls[0][0]).toMatchObject({
+            oldVersion: [2, 0, 0],
+            newVersion: [2, 0, 1],
+        });
+    });
 });

--- a/packages/connect/src/events/device.ts
+++ b/packages/connect/src/events/device.ts
@@ -1,5 +1,6 @@
 import type { PROTO } from '../constants';
 import type { Device } from '../types/device';
+import type { VersionArray } from '../types/firmware';
 import type { MessageFactoryFn } from '../types/utils';
 
 export const DEVICE_EVENT = 'DEVICE_EVENT';
@@ -9,6 +10,7 @@ export const DEVICE = {
     CONNECT_UNACQUIRED: 'device-connect_unacquired',
     DISCONNECT: 'device-disconnect',
     CHANGED: 'device-changed',
+    FIRMWARE_VERSION_CHANGED: 'device-firmware_version_changed',
 
     // trezor-link events in protobuf format
     BUTTON: 'button',
@@ -27,6 +29,15 @@ export interface DeviceButtonRequest {
     payload: DeviceButtonRequestPayload & { device: Device };
 }
 
+export interface DeviceVersionChanged {
+    type: typeof DEVICE.FIRMWARE_VERSION_CHANGED;
+    payload: {
+        device: Device;
+        oldVersion: VersionArray;
+        newVersion: VersionArray;
+    };
+}
+
 export type DeviceEvent =
     | {
           type:
@@ -36,7 +47,8 @@ export type DeviceEvent =
               | typeof DEVICE.DISCONNECT;
           payload: Device;
       }
-    | DeviceButtonRequest;
+    | DeviceButtonRequest
+    | DeviceVersionChanged;
 
 export type DeviceEventMessage = DeviceEvent & { event: typeof DEVICE_EVENT };
 

--- a/packages/connect/src/types/api/__tests__/events.ts
+++ b/packages/connect/src/types/api/__tests__/events.ts
@@ -22,6 +22,13 @@ export const events = (api: TrezorConnect) => {
 
             return;
         }
+        if (event.type === 'device-firmware_version_changed') {
+            const { payload } = event;
+            payload.oldVersion.join('.');
+            payload.newVersion.join('.');
+
+            return;
+        }
         const { payload } = event;
         payload.path.toLowerCase();
         if (payload.type === 'acquired') {

--- a/packages/connect/src/types/api/firmwareUpdate.ts
+++ b/packages/connect/src/types/api/firmwareUpdate.ts
@@ -1,6 +1,7 @@
 import { Static, Type } from '@trezor/schema-utils';
 
 import type { Params, Response } from '../params';
+import type { VersionArray } from '../firmware';
 
 export type FirmwareUpdate = Static<typeof FirmwareUpdate>;
 export const FirmwareUpdate = Type.Union([
@@ -15,17 +16,27 @@ export const FirmwareUpdate = Type.Union([
     }),
 ]);
 
-export type FirmwareUpdateResponse =
-    | {
-          check:
-              | 'mismatch' //  firmware is not legitimate
-              | 'valid' // ok
-              | 'omitted'; // custom fw binary, or maybe older fw
-      }
-    | {
-          check: 'other-error';
-          checkError: string; // unable to carry out the check due to a non-related error such as disconnected device
-      };
+type FirmwareUpdateDetails = {
+    versionCheck: boolean; // installedVersion == binaryVersion == releaseVersion
+    bootloaderVersion: VersionArray; // bootloader version
+    installedVersion: VersionArray; // version installed by this process
+    binaryVersion: VersionArray; // version read from the binary
+    releaseVersion?: VersionArray; // version offered automatically by config. undefined if params.binary is used
+};
+
+export type FirmwareUpdateResponse = FirmwareUpdateDetails &
+    (
+        | {
+              check:
+                  | 'mismatch' //  firmware is not legitimate
+                  | 'valid' // ok
+                  | 'omitted'; // custom fw binary, or maybe older fw
+          }
+        | {
+              check: 'other-error';
+              checkError: string; // unable to carry out the check due to a non-related error such as disconnected device
+          }
+    );
 
 export declare function firmwareUpdate(
     params: Params<FirmwareUpdate>,

--- a/packages/connect/src/utils/firmwareUtils.ts
+++ b/packages/connect/src/utils/firmwareUtils.ts
@@ -25,14 +25,29 @@ export const isValidReleases = (extReleases: any): extReleases is FirmwareReleas
 export const filterSafeListByBootloader = (
     releasesList: FirmwareRelease[],
     bootloaderVersion: VersionArray,
-) =>
-    releasesList.filter(
+) => {
+    // bootloader_version indicates that there could be more than one version
+    const bootloaderVersions = releasesList.flatMap(item =>
+        item.bootloader_version ? [item.bootloader_version] : [],
+    );
+    // find at least one compatible release by bootloader_version
+    const compatibleRelease = bootloaderVersions.find(item =>
+        versionUtils.isNewerOrEqual(item, bootloaderVersion),
+    );
+
+    if (bootloaderVersions.length > 0 && !compatibleRelease) {
+        // no compatible releases, bootloaderVersion is greater than any known
+        return [];
+    }
+
+    return releasesList.filter(
         item =>
             (!item.min_bootloader_version ||
                 versionUtils.isNewerOrEqual(bootloaderVersion, item.min_bootloader_version)) &&
             (!item.bootloader_version ||
                 versionUtils.isNewerOrEqual(item.bootloader_version, bootloaderVersion)),
     );
+};
 
 export const filterSafeListByFirmware = (
     releasesList: FirmwareRelease[],

--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -96,47 +96,57 @@ const getFirmwareRelease = (): NonNullable<Device['firmwareRelease']> => ({
  * @param {Partial<Features>} [feat]
  * @returns {Features}
  */
-const getDeviceFeatures = (feat?: Partial<Features>): Features => ({
-    vendor: 'trezor.io',
-    major_version: 2,
-    minor_version: 1,
-    patch_version: 1,
-    bootloader_mode: null,
-    device_id: 'device-id',
-    pin_protection: false,
-    passphrase_protection: false,
-    language: 'en-US',
-    label: 'My Trezor',
-    initialized: true,
-    revision: 'df0963ec',
-    bootloader_hash: '7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c',
-    imported: null,
-    unlocked: true,
-    firmware_present: null,
-    backup_availability: 'NotAvailable',
-    flags: 0,
-    model: 'T',
-    internal_model: DeviceModelInternal.T2T1,
-    fw_major: null,
-    fw_minor: null,
-    fw_patch: null,
-    fw_vendor: null,
-    unfinished_backup: false,
-    no_backup: false,
-    recovery_status: 'Nothing',
-    capabilities: [],
-    backup_type: 'Bip39',
-    sd_card_present: false,
-    sd_protection: false,
-    wipe_code_protection: false,
-    session_id: 'session-id',
-    passphrase_always_on_device: false,
-    safety_checks: 'Strict',
-    auto_lock_delay_ms: 60000,
-    display_rotation: 'North',
-    experimental_features: false,
-    ...feat,
-});
+const getDeviceFeatures = (feat?: Partial<Features>): Features => {
+    const isBootloader = feat?.bootloader_mode;
+    const major_version = feat?.major_version || 2;
+    const [_, minor_version, patch_version] = isBootloader ? [2, 0, 0] : [2, 1, 1];
+    const [fw_major, fw_minor, fw_patch] = isBootloader
+        ? [major_version, 1, 1]
+        : [null, null, null];
+    const firmware_present = isBootloader ? false : null;
+
+    return {
+        vendor: 'trezor.io',
+        major_version,
+        minor_version,
+        patch_version,
+        bootloader_mode: null,
+        device_id: 'device-id',
+        pin_protection: false,
+        passphrase_protection: false,
+        language: 'en-US',
+        label: 'My Trezor',
+        initialized: true,
+        revision: 'df0963ec',
+        bootloader_hash: '7447a41717022e3eb32011b00b2a68ebb9c7f603cdc730e7307850a3f4d62a5c',
+        imported: null,
+        unlocked: true,
+        firmware_present,
+        backup_availability: 'NotAvailable',
+        flags: 0,
+        model: 'T',
+        internal_model: DeviceModelInternal.T2T1,
+        fw_major,
+        fw_minor,
+        fw_patch,
+        fw_vendor: null,
+        unfinished_backup: false,
+        no_backup: false,
+        recovery_status: 'Nothing',
+        capabilities: [],
+        backup_type: 'Bip39',
+        sd_card_present: false,
+        sd_protection: false,
+        wipe_code_protection: false,
+        session_id: 'session-id',
+        passphrase_always_on_device: false,
+        safety_checks: 'Strict',
+        auto_lock_delay_ms: 60000,
+        display_rotation: 'North',
+        experimental_features: false,
+        ...feat,
+    };
+};
 
 type StringPath<T extends { path: DeviceUniquePath }> = Omit<T, 'path'> & { path: string };
 
@@ -213,7 +223,8 @@ const getSuiteDevice = (
     >,
     feat?: Partial<Features>,
 ): TrezorDevice => {
-    const device = getConnectDevice(dev, feat);
+    const bootloader_mode = dev?.mode === 'bootloader';
+    const device = getConnectDevice(dev, { bootloader_mode, ...feat });
     if (device.type === 'acquired') {
         return {
             useEmptyPassphrase: true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. added `TrezorConnect.updateFirmware` with fw version check and enhanced response
   returns
   ```
   check: FirmwareUpdateResponse['check']; // firmwareCheck result
   versionCheck: boolean; // version check assert:  installedVersion == binaryVersion == releaseVersion
   bootloaderVersion: VersionArray;
   installedVersion: VersionArray;
   binaryVersion: VersionArray;
   releaseVersion?: VersionArray;
   ```
   
1. added unit tests for `onCallFirmwareUpdate` module.
   Setup could be used to test with real FW binaries (tests are slower), could be used in some nightly workflow?

1. added `TrezorConnect.on(UI.FIRMWARE_VERSION_CHANGED, { device, oldVersion, newVersion });`
  emitted when previous Features !== current  Features
  
1. fixed `filterSafeListByBootloader` util
   if bootloader was higher than any known version it was oferring first release without `bootloader_version` field (some prehistoric)
   
   since `filterSafeListByBootloader` starts working properly i needed to adjust few mocks and prefill expected bootloader specific fields. suite tests were failing because of unsupported bootloader
   
1. fixed `firmwareUpdate` for models without `firmwareRelease`
 