### PR TITLE
Chore/mix of cherrypicks

### DIFF
--- a/packages/blockchain-link-types/src/constants/errors.ts
+++ b/packages/blockchain-link-types/src/constants/errors.ts
@@ -1,6 +1,7 @@
 const PREFIX = 'blockchain_link/';
 
 const ERROR: { [key: string]: string | undefined } = {
+    connect: undefined,
     worker_not_found: 'Worker not found',
     worker_invalid: 'Invalid worker object',
     worker_timeout: 'Worker timeout',
@@ -19,23 +20,28 @@ export class CustomError extends Error {
 
     message = '';
 
-    constructor(code: string, message = '') {
+    constructor(codeOrMessage: string, message = '') {
         // test reports that super is not covered, TODO: investigate more
         super(message);
 
         this.message = message;
 
-        if (typeof code === 'string') {
-            const c =
-                code.indexOf(PREFIX) === 0 ? code.substring(PREFIX.length, code.length) : code;
-            this.code = `${PREFIX}${c}`;
-            const msg = ERROR[c];
-            if (typeof msg === 'string') {
-                if (this.message === '') {
-                    this.message = msg;
-                } else if (message.indexOf('+') === 0) {
-                    this.message = `${msg} ${message.substring(1)}`;
+        if (typeof codeOrMessage === 'string') {
+            const isPrefixed = codeOrMessage.indexOf(PREFIX) === 0;
+            const code = isPrefixed ? codeOrMessage.substring(PREFIX.length) : codeOrMessage;
+            const knownCode = Object.keys(ERROR).includes(code);
+            if (isPrefixed || knownCode) {
+                this.code = `${PREFIX}${code}`;
+                const codeMessage = ERROR[code];
+                if (codeMessage) {
+                    if (this.message === '') {
+                        this.message = codeMessage;
+                    } else if (message.indexOf('+') === 0) {
+                        this.message = `${codeMessage} ${message.substring(1)}`;
+                    }
                 }
+            } else if (this.message === '') {
+                this.message = code;
             }
         }
 

--- a/packages/blockchain-link/tests/unit/errors.test.ts
+++ b/packages/blockchain-link/tests/unit/errors.test.ts
@@ -19,16 +19,16 @@ describe('Custom errors', () => {
         expect(error.message).toBe('Worker not found');
     });
 
-    it('Error with custom code and custom message', () => {
+    it('Error with custom prefixed code and custom message', () => {
         const error = new CustomError('blockchain_link/custom', 'Custom message');
         expect(error.code).toBe('blockchain_link/custom');
         expect(error.message).toBe('Custom message');
     });
 
-    it('Error with custom code and without message', () => {
+    it('Error with custom code as message', () => {
         const error = new CustomError('custom');
-        expect(error.code).toBe('blockchain_link/custom');
-        expect(error.message).toBe('Message not set');
+        expect(error.code).toBe(undefined);
+        expect(error.message).toBe('custom');
     });
 
     it('Error without code and with custom message', () => {

--- a/packages/eslint/src/index.mjs
+++ b/packages/eslint/src/index.mjs
@@ -27,6 +27,7 @@ export const eslint = [
             '**/ci/',
             '**/.expo/*',
             'eslint-local-rules/*',
+            '**/.cache/*',
         ],
     },
     { files: ['**/*.{js,mjs,cjs,ts,jsx,tsx}'] },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Some cherry picks

- ignore eslinting .cache directory (if you run playwright locally there are some .js builds in there)
- fix CustomError in blockchain-link, there are few places where the error message is passed as code param like:
```
if (!hex) throw new CustomError(`Missing hex of ${request.payload}`);

// -> the result before the fix: Error({ code: 'blockchain_link/', message: '' })
// -> after the fix: Error({ code: undefined, message: 'Missing hex...' })
```
