### PR TITLE
feat(suite): added blockbook link to approval tx

### DIFF
--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketOfferExchange/CoinmarketOfferExchangeSendApproval.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketSelectedOffer/CoinmarketOfferExchange/CoinmarketOfferExchangeSendApproval.tsx
@@ -23,9 +23,10 @@ import { CoinmarketTradeExchangeType } from 'src/types/coinmarket/coinmarket';
 import { useCoinmarketFormContext } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonForm';
 import { useCoinmarketInfo } from 'src/hooks/wallet/coinmarket/useCoinmarketInfo';
 import { useCoinmarketExchangeWatchSendApproval } from 'src/hooks/wallet/coinmarket/form/useCoinmarketExchangeWatchSendApproval';
-import { useDispatch } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { saveSelectedQuote } from 'src/actions/wallet/coinmarketExchangeActions';
-import { parseCryptoId } from 'src/utils/wallet/coinmarket/coinmarketUtils';
+import { cryptoIdToSymbol, parseCryptoId } from 'src/utils/wallet/coinmarket/coinmarketUtils';
+import { IOAddress } from 'src/components/suite/copy/IOAddress';
 
 // add APPROVED means no approval request is necessary
 type ExtendedDexApprovalType = DexApprovalType | 'APPROVED';
@@ -51,6 +52,8 @@ export const CoinmarketOfferExchangeSendApproval = () => {
         selectedQuote?.status === 'CONFIRM' ? 'APPROVED' : 'MINIMAL',
     );
 
+    const blockchain = useSelector(state => state.wallet.blockchain);
+
     const { navigateToExchangeForm } = useCoinmarketNavigation(account);
 
     useCoinmarketExchangeWatchSendApproval({
@@ -69,6 +72,9 @@ export const CoinmarketOfferExchangeSendApproval = () => {
     const isFullApproval = !(Number(selectedQuote.preapprovedStringAmount) > 0);
 
     if (!selectedQuote.send) return null;
+
+    const symbol = cryptoIdToSymbol(selectedQuote.send);
+    const blockchainNetwork = symbol && blockchain[symbol];
 
     const isToken = parseCryptoId(selectedQuote.send)?.contractAddress !== undefined;
 
@@ -141,7 +147,11 @@ export const CoinmarketOfferExchangeSendApproval = () => {
             </InfoItem>
             {selectedQuote.approvalSendTxHash && (
                 <InfoItem label={<Translation id="TR_EXCHANGE_APPROVAL_TXID" />}>
-                    {selectedQuote.approvalSendTxHash}
+                    <IOAddress
+                        txAddress={selectedQuote.approvalSendTxHash}
+                        explorerUrl={blockchainNetwork?.explorer.tx}
+                        explorerUrlQueryString={blockchainNetwork?.explorer.queryString}
+                    />
                 </InfoItem>
             )}
             {selectedQuote.status === 'APPROVAL_PENDING' && (


### PR DESCRIPTION
## Description

After approving a token to swap, while the blockchain is confirming the approval transaction, allow the user to copy the approval transaction ID as well as redirect to blockbook transaction detail page.

## Related Issue

Resolve #14840 

## Screenshots:

On moving the mouse over the transaction ID, options to copy the transaction ID or go to the blockbook transaction detail page are displayed.

<img width="774" alt="Screenshot 2025-01-17 at 10 48 17" src="https://github.com/user-attachments/assets/a1b79c27-a5f4-4a8d-9f37-5beecce83b8a" />

Upon clicking the redirect button, the user is redirected to the blockbook transaction detail page.

<img width="912" alt="Screenshot 2025-01-17 at 10 48 23" src="https://github.com/user-attachments/assets/f3eb976c-5d22-4a35-b34c-53294d5bc20b" />
