### PR TITLE
chore(suite-native): prepare one place for all global hooks

### DIFF
--- a/suite-native/app/src/hooks/useGlobalHooks.tsx
+++ b/suite-native/app/src/hooks/useGlobalHooks.tsx
@@ -1,0 +1,14 @@
+import { useHandleDeviceConnection } from '@suite-native/device';
+import { useConnectPopupNavigation } from '@suite-native/module-connect-popup';
+
+import { useCoinEnablingInitialCheck } from './useCoinEnablingInitialCheck';
+
+/**
+ * @description This hook is used to initialize all the hooks,
+ * that are supposed to be active globally once the app is ready.
+ */
+export const useGlobalHooks = () => {
+    useHandleDeviceConnection();
+    useCoinEnablingInitialCheck();
+    useConnectPopupNavigation();
+};

--- a/suite-native/app/src/hooks/useGlobalHooks.tsx
+++ b/suite-native/app/src/hooks/useGlobalHooks.tsx
@@ -1,4 +1,4 @@
-import { useHandleDeviceConnection } from '@suite-native/device';
+import { useDetectDeviceError, useHandleDeviceConnection } from '@suite-native/device';
 import { useConnectPopupNavigation } from '@suite-native/module-connect-popup';
 
 import { useCoinEnablingInitialCheck } from './useCoinEnablingInitialCheck';
@@ -8,7 +8,10 @@ import { useCoinEnablingInitialCheck } from './useCoinEnablingInitialCheck';
  * that are supposed to be active globally once the app is ready.
  */
 export const useGlobalHooks = () => {
-    useHandleDeviceConnection();
-    useCoinEnablingInitialCheck();
     useConnectPopupNavigation();
+
+    useCoinEnablingInitialCheck();
+
+    useHandleDeviceConnection();
+    useDetectDeviceError();
 };

--- a/suite-native/app/src/navigation/RootStackNavigator.tsx
+++ b/suite-native/app/src/navigation/RootStackNavigator.tsx
@@ -2,7 +2,6 @@ import { useSelector } from 'react-redux';
 
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
-import { useHandleDeviceConnection } from '@suite-native/device';
 import {
     AccountDetailScreen,
     AccountSettingsScreen,
@@ -24,19 +23,17 @@ import { AddCoinAccountStackNavigator } from '@suite-native/module-add-accounts'
 import { DeviceSettingsStackNavigator } from '@suite-native/module-device-settings';
 import { SendStackNavigator } from '@suite-native/module-send';
 import { CoinEnablingInitScreen } from '@suite-native/coin-enabling';
-import { ConnectPopupScreen, useConnectPopupNavigation } from '@suite-native/module-connect-popup';
+import { ConnectPopupScreen } from '@suite-native/module-connect-popup';
 import { StakingDetailScreen } from '@suite-native/module-staking-management';
 import { SettingsStackNavigator } from '@suite-native/module-settings';
 
 import { AppTabNavigator } from './AppTabNavigator';
-import { useCoinEnablingInitialCheck } from '../hooks/useCoinEnablingInitialCheck';
+import { useGlobalHooks } from '../hooks/useGlobalHooks';
 
 const RootStack = createNativeStackNavigator<RootStackParamList>();
 
 export const RootStackNavigator = () => {
-    useHandleDeviceConnection();
-    useCoinEnablingInitialCheck();
-    useConnectPopupNavigation();
+    useGlobalHooks();
 
     const isOnboardingFinished = useSelector(selectIsOnboardingFinished);
 

--- a/suite-native/module-authorize-device/src/navigation/AuthorizeDeviceStackNavigator.tsx
+++ b/suite-native/module-authorize-device/src/navigation/AuthorizeDeviceStackNavigator.tsx
@@ -11,7 +11,7 @@ import {
     selectDeviceRequestedPin,
     useHandleDuplicatePassphrase,
 } from '@suite-native/device-authorization';
-import { useDetectDeviceError, useReportDeviceConnectToAnalytics } from '@suite-native/device';
+import { useReportDeviceConnectToAnalytics } from '@suite-native/device';
 
 import { ConnectAndUnlockDeviceScreen } from '../screens/connect/ConnectAndUnlockDeviceScreen';
 import { PinScreen } from '../screens/connect/PinScreen';
@@ -30,7 +30,8 @@ export const AuthorizeDeviceStack = createNativeStackNavigator<AuthorizeDeviceSt
 export const AuthorizeDeviceStackNavigator = () => {
     const hasDeviceRequestedPin = useSelector(selectDeviceRequestedPin);
 
-    useDetectDeviceError();
+    // TODO: This should be in global hook to be reported if view-only enabled device is connected.
+    // But we should prevent the re-reporting of an already connected device when the state changes.
     useReportDeviceConnectToAnalytics();
     useHandleDuplicatePassphrase();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We have multiple hooks that is supposed to be global and available everywhere, this is defining one place for those hooks.

We apparently have incorrectly placed hooks in the `AuthorizeDeviceStackNavigator`, namely `useReportDeviceConnectToAnalytics `and `useDetectDeviceError`. The `AuthorizeDeviceStackNavigator` only mounts when connecting a Trezor that hasn't been remembered (view-only on). If the Trezor with view-only enabled was connected, it did not mount, and those hooks remained inactive.

Notes for @trezor/qa 
The only change that this PR is supposed to cause is that if you connect Trezor, that has view-only already enabled and have some error, it should show the alert. Previously it was ignored. So it can theoretically cause more Unacquired errors.

It makes sense to test connecting Trezor to the app in different scenarios (view-only enabled/disabled, welcome flow finished/fresh app, open app by connecting the Trezor...)


Followup to move and fix reporting of device connected to analytics https://github.com/trezor/trezor-suite/issues/16446

## Screenshots

Trezor connected at the first screen of Welcome flow, warning visible only after Welcome flow:
https://github.com/user-attachments/assets/f3a2f7f4-1494-484b-b44c-ed5f597f30c0



