### PR TITLE
fix(trade): unnecessary requesting in buy/sell/swap

### DIFF
--- a/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketInitializer.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/common/useCoinmarketInitializer.ts
@@ -12,6 +12,7 @@ import {
 
 export const useCoinmarketInitializer = ({
     selectedAccount,
+    pageType,
 }: UseCoinmarketCommonProps): UseCoinmarketCommonReturnProps => {
     const timer = useTimer();
     const { account } = selectedAccount;
@@ -22,6 +23,12 @@ export const useCoinmarketInitializer = ({
         if (!timer.isLoading && !timer.isStopped) {
             if (timer.resetCount >= 40) {
                 timer.stop();
+            }
+
+            if (pageType === 'confirm') {
+                timer.stop();
+
+                return;
             }
 
             if (timer.timeSpend.seconds === INVITY_API_RELOAD_QUOTES_AFTER_SECONDS) {

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketBuyForm.tsx
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketBuyForm.tsx
@@ -64,7 +64,7 @@ export const useCoinmarketBuyForm = ({
         useSelector(state => state.wallet.coinmarket.buy);
     const { cryptoIdToCoinSymbol } = useCoinmarketInfo();
     const { callInProgress, account, timer, device, setCallInProgress, checkQuotesTimer } =
-        useCoinmarketInitializer({ selectedAccount, type });
+        useCoinmarketInitializer({ selectedAccount, pageType });
     const { paymentMethods, getPaymentMethods, getQuotesByPaymentMethod } =
         useCoinmarketPaymentMethod<CoinmarketTradeBuyType>();
     const { navigateToBuyForm, navigateToBuyOffers, navigateToBuyConfirm } =
@@ -386,6 +386,10 @@ export const useCoinmarketBuyForm = ({
     // call change handler on every change of text inputs with debounce
     useDebounce(
         () => {
+            if (pageType === 'confirm') {
+                return;
+            }
+
             if (
                 isChanged(previousValues.current?.fiatInput, values.fiatInput) ||
                 isChanged(previousValues.current?.cryptoInput, values.cryptoInput)
@@ -398,11 +402,22 @@ export const useCoinmarketBuyForm = ({
             }
         },
         500,
-        [previousValues, values.fiatInput, values.cryptoInput, handleChange, handleSubmit],
+        [
+            previousValues,
+            values.fiatInput,
+            values.cryptoInput,
+            pageType,
+            handleChange,
+            handleSubmit,
+        ],
     );
 
     // call change handler on every change of select inputs
     useEffect(() => {
+        if (pageType === 'confirm') {
+            return;
+        }
+
         if (
             isChanged(previousValues.current?.countrySelect, values.countrySelect) ||
             isChanged(previousValues.current?.currencySelect, values.currencySelect) ||
@@ -414,7 +429,7 @@ export const useCoinmarketBuyForm = ({
 
             previousValues.current = values;
         }
-    }, [previousValues, values, handleChange, handleSubmit, isNotFormPage]);
+    }, [previousValues, values, isNotFormPage, pageType, handleChange, handleSubmit]);
 
     useEffect(() => {
         // when draft doesn't exist, we need to bind actual default values - that happens when we've got buyInfo from Invity API server

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeForm.ts
@@ -93,7 +93,7 @@ export const useCoinmarketExchangeForm = ({
         isNotFormPage,
     });
     const { callInProgress, timer, device, setCallInProgress, checkQuotesTimer } =
-        useCoinmarketInitializer({ selectedAccount, type });
+        useCoinmarketInitializer({ selectedAccount, pageType });
     const { buildDefaultCryptoOption } = useCoinmarketInfo();
 
     const dispatch = useDispatch();

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSellForm.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSellForm.ts
@@ -82,7 +82,7 @@ export const useCoinmarketSellForm = ({
         isNotFormPage,
     });
     const { callInProgress, timer, device, setCallInProgress, checkQuotesTimer } =
-        useCoinmarketInitializer({ selectedAccount, type });
+        useCoinmarketInitializer({ selectedAccount, pageType });
     const { paymentMethods, getPaymentMethods, getQuotesByPaymentMethod } =
         useCoinmarketPaymentMethod<CoinmarketTradeSellType>();
     const {

--- a/packages/suite/src/types/coinmarket/coinmarket.ts
+++ b/packages/suite/src/types/coinmarket/coinmarket.ts
@@ -42,9 +42,11 @@ import type { SellInfo } from 'src/actions/wallet/coinmarketSellActions';
 import type { ExchangeInfo } from 'src/actions/wallet/coinmarketExchangeActions';
 import type { BuyInfo } from 'src/actions/wallet/coinmarketBuyActions';
 
+type CoinmarketPageType = 'form' | 'offers' | 'confirm';
+
 export type UseCoinmarketProps = { selectedAccount: SelectedAccountLoaded };
 export type UseCoinmarketCommonProps = UseCoinmarketProps & {
-    type: CoinmarketTradeType;
+    pageType: CoinmarketPageType;
 };
 export interface UseCoinmarketCommonReturnProps {
     callInProgress: boolean;
@@ -54,7 +56,6 @@ export interface UseCoinmarketCommonReturnProps {
     setCallInProgress: (state: boolean) => void;
     checkQuotesTimer: (callback: () => Promise<void>) => void;
 }
-type CoinmarketPageType = 'form' | 'offers' | 'confirm';
 export type UseCoinmarketFormProps = UseCoinmarketProps & {
     /**
      * Difference between form and offers is that on the offers page are used all data filled in the form


### PR DESCRIPTION
## Description
- fixed periodically (30s) requested `/api/v3/[buy/sell/exchange]/quotes` on the `/confirm` page (unnecessary)
- fixed unnecessary requesting `/api/v3/buy/quotes` after redirecting to `buy/confirm` page

## Related Issue

Resolved https://github.com/trezor/trezor-suite/issues/16374
