### PR TITLE
feat(suite-native): add more params to IconListItem for reusability

### DIFF
--- a/suite-native/atoms/src/IconListItem.tsx
+++ b/suite-native/atoms/src/IconListItem.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react';
+import { FlexAlignType } from 'react-native';
 
-import { IconName } from '@suite-native/icons';
+import { IconName, IconSize } from '@suite-native/icons';
 import { Color } from '@trezor/theme';
 
 import { Box } from './Box';
@@ -8,7 +9,7 @@ import { OrderedListIcon } from './OrderedListIcon';
 import { HStack } from './Stack';
 import { Text } from './Text';
 
-type Variant = 'default' | 'red';
+type Variant = 'default' | 'red' | 'yellow';
 type IconColors = {
     iconColor: Color;
     iconBorderColor: Color;
@@ -26,23 +27,40 @@ const iconColorsMap = {
         iconBorderColor: 'backgroundAlertRedSubtleOnElevation0',
         iconBackgroundColor: 'backgroundAlertRedSubtleOnElevation1',
     },
+    yellow: {
+        iconColor: 'iconAlertYellow',
+        iconBorderColor: 'backgroundAlertYellowSubtleOnElevation0',
+        iconBackgroundColor: 'backgroundAlertYellowSubtleOnElevation1',
+    },
 } as const satisfies Record<Variant, IconColors>;
 
 type IconListItemProps = {
     children: ReactNode;
     icon: IconName;
+    iconSize?: IconSize;
     variant?: Variant;
+    verticalAlign?: FlexAlignType;
 };
 
-export const IconListItem = ({ icon, children, variant = 'default' }: IconListItemProps) => {
+export const IconListItem = ({
+    icon,
+    children,
+    iconSize = 'medium',
+    variant = 'default',
+    verticalAlign = 'center',
+}: IconListItemProps) => {
     const iconColors = iconColorsMap[variant];
 
     return (
-        <HStack spacing="sp12" alignItems="center">
-            <OrderedListIcon iconName={icon} iconSize="medium" {...iconColors} />
-            <Box flexShrink={1}>
-                <Text variant="hint">{children}</Text>
-            </Box>
+        <HStack spacing="sp12" alignItems={verticalAlign}>
+            <OrderedListIcon iconName={icon} iconSize={iconSize} {...iconColors} />
+            <Box flexShrink={1}>{children}</Box>
         </HStack>
     );
 };
+
+export const IconListTextItem = ({ children, ...rest }: IconListItemProps) => (
+    <IconListItem {...rest}>
+        <Text variant="hint">{children}</Text>
+    </IconListItem>
+);

--- a/suite-native/atoms/src/OrderedListIcon.tsx
+++ b/suite-native/atoms/src/OrderedListIcon.tsx
@@ -12,8 +12,7 @@ const iconBackgroundStyle = prepareNativeStyle<{ color: Color; borderColor: Colo
     (utils, { color, borderColor }) => ({
         alignItems: 'center',
         justifyContent: 'center',
-        width: utils.spacings.sp32,
-        height: utils.spacings.sp32,
+        padding: utils.spacings.sp8,
         borderRadius: utils.borders.radii.r12,
         extend: [
             {

--- a/suite-native/module-device-settings/src/components/DeviceAuthenticityCard.tsx
+++ b/suite-native/module-device-settings/src/components/DeviceAuthenticityCard.tsx
@@ -7,7 +7,7 @@ import { analytics, DeviceAuthenticityCheckResult, EventType } from '@suite-nati
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import { useAlert } from '@suite-native/alerts';
-import { Button, IconListItem, Text, VStack } from '@suite-native/atoms';
+import { Button, IconListTextItem, Text, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
     DeviceAuthenticityStackParamList,
@@ -84,15 +84,15 @@ export const DeviceAuthenticityCard = () => {
             textAlign: 'left',
             appendix: (
                 <VStack spacing="sp24">
-                    <IconListItem icon="shieldCheck">
+                    <IconListTextItem icon="shieldCheck">
                         <Translation id="moduleDeviceSettings.authenticity.info.item1" />
-                    </IconListItem>
-                    <IconListItem icon="cpu">
+                    </IconListTextItem>
+                    <IconListTextItem icon="cpu">
                         <Translation id="moduleDeviceSettings.authenticity.info.item2" />
-                    </IconListItem>
-                    <IconListItem icon="check">
+                    </IconListTextItem>
+                    <IconListTextItem icon="check">
                         <Translation id="moduleDeviceSettings.authenticity.info.item3" />
-                    </IconListItem>
+                    </IconListTextItem>
                 </VStack>
             ),
             primaryButtonTitle: (

--- a/suite-native/module-device-settings/src/screens/DeviceAuthenticitySummaryScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/DeviceAuthenticitySummaryScreen.tsx
@@ -2,7 +2,7 @@ import { SUITE_LITE_SUPPORT_URL, useOpenLink } from '@suite-native/link';
 import {
     Button,
     ButtonColorScheme,
-    IconListItem,
+    IconListTextItem,
     PictogramTitleHeader,
     PictogramVariant,
     VStack,
@@ -68,15 +68,15 @@ export const DeviceAuthenticitySummaryScreen = ({
                 />
                 {checkResult === 'compromised' && (
                     <VStack spacing="sp24" justifyContent="center">
-                        <IconListItem icon="plugs" variant="red">
+                        <IconListTextItem icon="plugs" variant="red">
                             <Translation id="moduleDeviceSettings.authenticity.summary.compromised.item1" />
-                        </IconListItem>
-                        <IconListItem icon="handPalm" variant="red">
+                        </IconListTextItem>
+                        <IconListTextItem icon="handPalm" variant="red">
                             <Translation id="moduleDeviceSettings.authenticity.summary.compromised.item2" />
-                        </IconListItem>
-                        <IconListItem icon="chatCircle" variant="red">
+                        </IconListTextItem>
+                        <IconListTextItem icon="chatCircle" variant="red">
                             <Translation id="moduleDeviceSettings.authenticity.summary.compromised.item3" />
-                        </IconListItem>
+                        </IconListTextItem>
                     </VStack>
                 )}
             </VStack>


### PR DESCRIPTION
## Description

Refactor `IconListItem` to make its usage more flexible
- allow different size of icons
- allow multiline content
- allow different flex align (useful for multiline content)

:information_source: Required for [this figma frame](https://www.figma.com/design/eKie94qfryjTHEnR8jfmgk/Security-checks?node-id=4116-2445&t=fv9Xv7X06uaZhw6Q-4)

## Related Issue

Related to #16447

## Screenshots:

Current usage of `IconListItem` is **unchanged**:
![image](https://github.com/user-attachments/assets/a8af053d-f579-4962-898a-38b3f1869b5d)
![image](https://github.com/user-attachments/assets/98ded618-999a-4f96-9b1a-77ac0e5f911b)
