### PR TITLE
fix(mobile): balance mismatch

### DIFF
--- a/suite-common/graph/src/types.ts
+++ b/suite-common/graph/src/types.ts
@@ -5,6 +5,9 @@ import { BigNumber } from '@trezor/utils';
 export type FiatGraphPoint = {
     date: Date;
     value: number;
+    // Because graph latest point doesn't include staking, some tokens etc. we display this value when user is not touching the graph
+    // But we can't override value of the "real" latest point, because we calculate percentage change based on it
+    valueLatestTotal?: string;
 };
 
 export type FiatGraphPointWithCryptoBalance = {

--- a/suite-native/accounts/src/selectors.ts
+++ b/suite-native/accounts/src/selectors.ts
@@ -24,10 +24,12 @@ import { Account, AccountKey, TokenInfoBranded } from '@suite-common/wallet-type
 import {
     getAccountFiatBalance,
     getAccountTotalStakingBalance,
+    getFiatRateKey,
     getFirstFreshAddress,
+    toFiatCurrency,
 } from '@suite-common/wallet-utils';
 import { SettingsSliceRootState, selectFiatCurrencyCode } from '@suite-native/settings';
-import { isCoinWithTokens } from '@suite-native/tokens';
+import { isCoinWithTokens, selectAccountTokenInfo } from '@suite-native/tokens';
 import type { StaticSessionId } from '@trezor/connect';
 import { createWeakMapSelector } from '@suite-common/redux-utils';
 import { doesCoinSupportStaking } from '@suite-native/staking';
@@ -43,7 +45,8 @@ export type NativeAccountsRootState = AccountsRootState &
     FiatRatesRootState &
     SettingsSliceRootState &
     DeviceRootState &
-    TokenDefinitionsRootState;
+    TokenDefinitionsRootState &
+    TransactionsRootState;
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<NativeAccountsRootState>();
 
@@ -82,25 +85,54 @@ export const selectIsAccountAlreadyDiscovered = (
         ),
     );
 
-export const selectAccountFiatBalance = (state: NativeAccountsRootState, accountKey: string) => {
-    const fiatRates = selectCurrentFiatRates(state);
-    const account = selectAccountByKey(state, accountKey);
-    const localCurrency = selectFiatCurrencyCode(state);
-    const shouldIncludeStaking = !!account && doesCoinSupportStaking(account.symbol);
+export const selectAccountFiatBalance = createMemoizedSelector(
+    [
+        selectCurrentFiatRates,
+        selectAccountByKey,
+        selectFiatCurrencyCode,
+        (_, _accountKey: AccountKey, shouldIncludeStaking?: boolean) =>
+            shouldIncludeStaking ?? true,
+        (
+            _,
+            _accountKey: AccountKey,
+            _shouldIncludeStaking?: boolean,
+            shouldIncludeTokens?: boolean,
+        ) => shouldIncludeTokens ?? true,
+    ],
+    (fiatRates, account, localCurrency, shouldIncludeStaking, shouldIncludeTokens) => {
+        if (!account) {
+            return '0';
+        }
 
-    if (!account) {
-        return '0';
-    }
+        const totalBalance = getAccountFiatBalance({
+            account,
+            rates: fiatRates,
+            localCurrency,
+            shouldIncludeStaking,
+            shouldIncludeTokens,
+        });
 
-    const totalBalance = getAccountFiatBalance({
-        account,
-        rates: fiatRates,
-        localCurrency,
-        shouldIncludeStaking,
-    });
+        if (!totalBalance) {
+            return '0';
+        }
 
-    return totalBalance;
-};
+        return totalBalance;
+    },
+);
+
+export const selectAccountTokenFiatBalance = createMemoizedSelector(
+    [selectCurrentFiatRates, selectFiatCurrencyCode, selectAccountByKey, selectAccountTokenInfo],
+    (fiatRates, localCurrency, account, tokenInfo) => {
+        if (!account || !fiatRates || !tokenInfo) return '0';
+        const { contract, balance } = tokenInfo;
+        const fiatRateKey = getFiatRateKey(account.symbol, localCurrency, contract);
+        const rate = fiatRates[fiatRateKey]?.rate;
+
+        if (!rate || !balance) return '0';
+
+        return toFiatCurrency(balance, rate) ?? '0';
+    },
+);
 
 export const getAccountListSections = (
     account: Account,

--- a/suite-native/device/src/selectors.ts
+++ b/suite-native/device/src/selectors.ts
@@ -9,7 +9,6 @@ import {
     getAccountsByDeviceState,
     PORTFOLIO_TRACKER_DEVICE_ID,
     selectAccounts,
-    selectAccountsByDeviceState,
     selectCurrentFiatRates,
     selectSelectedDevice,
     selectDeviceFirmwareVersion,
@@ -20,6 +19,8 @@ import {
     selectIsDeviceConnectedAndAuthorized,
     selectIsDiscoveredDeviceAccountless,
     selectIsUnacquiredDevice,
+    selectDeviceAccounts,
+    selectAccountsByDeviceState,
 } from '@suite-common/wallet-core';
 import { isDeviceAcquired } from '@suite-common/suite-utils';
 import { getTotalFiatBalance } from '@suite-common/wallet-utils';
@@ -70,17 +71,29 @@ export const selectDeviceError = (
     return device?.error;
 };
 
-export const selectDeviceTotalFiatBalanceNative = createMemoizedSelector(
-    [selectAccountsByDeviceState, selectCurrentFiatRates, selectFiatCurrencyCode],
+export const selectSelectedDeviceTotalFiatBalance = createMemoizedSelector(
+    [selectDeviceAccounts, selectCurrentFiatRates, selectFiatCurrencyCode],
     (deviceAccounts, rates, localCurrency) => {
         const fiatBalance = getTotalFiatBalance({
             deviceAccounts,
             localCurrency,
             rates,
-            shouldIncludeStaking: false,
         });
 
-        return fiatBalance;
+        return fiatBalance.toFixed(2);
+    },
+);
+
+export const selectDeviceTotalFiatBalanceNative = createMemoizedSelector(
+    [selectAccountsByDeviceState, selectCurrentFiatRates, selectFiatCurrencyCode],
+    (accounts, rates, localCurrency) => {
+        const fiatBalance = getTotalFiatBalance({
+            deviceAccounts: accounts,
+            localCurrency,
+            rates,
+        });
+
+        return fiatBalance.toFixed(2);
     },
 );
 

--- a/suite-native/graph/src/components/Graph.tsx
+++ b/suite-native/graph/src/components/Graph.tsx
@@ -26,6 +26,7 @@ type GraphProps<TGraphPoint extends GraphPoint> = {
     loading?: boolean;
     onPointSelected?: (point: TGraphPoint) => void;
     onGestureEnd?: () => void;
+    onGestureStart?: () => void;
     animated?: boolean;
     error?: string | null;
     onTryAgain: () => void;
@@ -70,6 +71,7 @@ const getAccessibilityLineThickness = () => {
 export const Graph = <TGraphPoint extends FiatGraphPoint>({
     onPointSelected,
     onGestureEnd,
+    onGestureStart,
     onTryAgain,
     error,
     events,
@@ -144,6 +146,7 @@ export const Graph = <TGraphPoint extends FiatGraphPoint>({
                 BottomAxisLabel={axisLabels?.BottomAxisLabel}
                 onPointSelected={onPointSelected as any /* because of ExtendedGraphPoint */}
                 onGestureEnd={onGestureEnd}
+                onGestureStart={onGestureStart}
                 panGestureDelay={panGestureDelay}
                 events={events}
                 EventComponent={TransactionEvent}

--- a/suite-native/graph/src/components/GraphDateFormatter.tsx
+++ b/suite-native/graph/src/components/GraphDateFormatter.tsx
@@ -4,26 +4,31 @@ import { useFormatters } from '@suite-common/formatters';
 import { FiatGraphPoint } from '@suite-common/graph';
 import { Text } from '@suite-native/atoms';
 
-type SelectedPointAtom = Atom<FiatGraphPoint>;
+type SelectedPointAtom = Atom<FiatGraphPoint | null>;
 
 type GraphDateFormatterProps = {
     firstPointDate: Date;
-    selectedPointAtom: Atom<FiatGraphPoint>;
+    selectedPointAtom: SelectedPointAtom;
 };
 
 const WeekFormatter = ({ selectedPointAtom }: { selectedPointAtom: SelectedPointAtom }) => {
     const { DateTimeFormatter } = useFormatters();
-    const { date: value } = useAtomValue(selectedPointAtom);
+    const selectedPoint = useAtomValue(selectedPointAtom);
 
-    return <DateTimeFormatter value={value} />;
+    // Empty space to prevent layout shift
+    if (!selectedPoint) return <Text> </Text>;
+
+    return <DateTimeFormatter value={selectedPoint.date} />;
 };
 
 const OtherDateFormatter = ({ selectedPointAtom }: { selectedPointAtom: SelectedPointAtom }) => {
     const { DateFormatter } = useFormatters();
 
-    const { date: value } = useAtomValue(selectedPointAtom);
+    const selectedPoint = useAtomValue(selectedPointAtom);
 
-    return <DateFormatter value={value} />;
+    if (!selectedPoint) return null;
+
+    return <DateFormatter value={selectedPoint.date} />;
 };
 
 const millisecondsPerTwoWeek = 1209600000;
@@ -36,13 +41,11 @@ export const GraphDateFormatter = ({
     // this check is significantly faster than using date-fns/differenceInWeeks(days)
     const isWeekFormatted = millisecondElapsedFromFistPoint < millisecondsPerTwoWeek;
 
+    const Formatter = isWeekFormatted ? WeekFormatter : OtherDateFormatter;
+
     return (
         <Text variant="hint" color="textSubdued">
-            {isWeekFormatted ? (
-                <WeekFormatter selectedPointAtom={selectedPointAtom} />
-            ) : (
-                <OtherDateFormatter selectedPointAtom={selectedPointAtom} />
-            )}
+            <Formatter selectedPointAtom={selectedPointAtom} />
         </Text>
     );
 };

--- a/suite-native/graph/src/components/GraphFiatBalance.tsx
+++ b/suite-native/graph/src/components/GraphFiatBalance.tsx
@@ -1,15 +1,17 @@
 import { Atom, useAtomValue } from 'jotai';
 
 import { FiatGraphPoint } from '@suite-common/graph';
-import { Box, BoxSkeleton, DiscreetTextTrigger, HStack, VStack } from '@suite-native/atoms';
+import { Box, BoxSkeleton, DiscreetTextTrigger, HStack, VStack, Text } from '@suite-native/atoms';
 import { FiatBalanceFormatter } from '@suite-native/formatters';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+import { useFormatters } from '@suite-common/formatters';
 
 import { GraphDateFormatter } from './GraphDateFormatter';
 import { PriceChangeIndicator } from './PriceChangeIndicator';
 
 type BalanceProps = {
-    selectedPointAtom: Atom<FiatGraphPoint>;
+    selectedPointAtom: Atom<FiatGraphPoint | null>;
+    latestValue?: string;
 };
 
 type GraphFiatBalanceProps = BalanceProps & {
@@ -18,6 +20,8 @@ type GraphFiatBalanceProps = BalanceProps & {
     hasPriceIncreasedAtom: Atom<boolean>;
     showChange?: boolean;
     isLoading?: boolean;
+    totalFiatBalance: string;
+    isHistoryEnabledAccount?: boolean;
 };
 
 const wrapperStyle = prepareNativeStyle(_ => ({
@@ -32,9 +36,10 @@ const Skeleton = () => (
     </VStack>
 );
 
-const Balance = ({ selectedPointAtom }: BalanceProps) => {
+const Balance = ({ selectedPointAtom, latestValue }: BalanceProps) => {
     const point = useAtomValue(selectedPointAtom);
-    const fiatValue = String(point.value);
+    const fiatValue =
+        latestValue || point?.valueLatestTotal || (point?.value ? String(point.value) : '0');
 
     return (
         <DiscreetTextTrigger>
@@ -50,11 +55,36 @@ export const GraphFiatBalance = ({
     hasPriceIncreasedAtom,
     showChange = true,
     isLoading = false,
+    totalFiatBalance,
+    isHistoryEnabledAccount = true,
 }: GraphFiatBalanceProps) => {
     const { applyStyle } = useNativeStyles();
     const firstGraphPoint = useAtomValue(referencePointAtom);
+    const { DateTimeFormatter } = useFormatters();
 
-    if (isLoading || !firstGraphPoint) {
+    const showLoading = isLoading || !firstGraphPoint;
+
+    // During loading or error we just show latest total balance
+    if (
+        (Number(totalFiatBalance) !== 0 && (isLoading || !firstGraphPoint)) ||
+        !isHistoryEnabledAccount
+    ) {
+        return (
+            <Box style={applyStyle(wrapperStyle)}>
+                <Balance selectedPointAtom={selectedPointAtom} latestValue={totalFiatBalance} />
+                {showChange && (
+                    <HStack alignItems="center">
+                        {/*  Empty space to prevent layout shift */}
+                        <Text variant="hint" color="textSubdued">
+                            <DateTimeFormatter value={new Date()} />
+                        </Text>
+                    </HStack>
+                )}
+            </Box>
+        );
+    }
+
+    if (showLoading) {
         return <Skeleton />;
     }
 

--- a/suite-native/graph/src/hooks.ts
+++ b/suite-native/graph/src/hooks.ts
@@ -1,12 +1,14 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { captureException } from '@sentry/react-native';
 import { A } from '@mobily/ts-belt';
+import { useSetAtom, WritableAtom } from 'jotai';
 
 import {
     AccountItem,
     CommonUseGraphParams,
+    FiatGraphPoint,
     useGetTimeFrameForHistoryHours,
     useGraphForAccounts,
 } from '@suite-common/graph';
@@ -218,5 +220,70 @@ export const useGraphForAllDeviceAccounts = ({ fiatCurrency }: CommonUseGraphPar
         isAnyMainnetAccountPresent: A.isNotEmpty(accountItems),
         timeframe: portfolioGraphTimeframe,
         onSelectTimeFrame: handleSelectPortfolioTimeframe,
+    };
+};
+
+export const useGraphAtoms = <TGraphPoint extends FiatGraphPoint>({
+    referencePointAtom,
+    selectedPointAtom,
+    graphPoints,
+    totalFiatBalance,
+}: {
+    referencePointAtom: WritableAtom<TGraphPoint | null, TGraphPoint | null>;
+    selectedPointAtom: WritableAtom<TGraphPoint | null, TGraphPoint | null>;
+    graphPoints: TGraphPoint[];
+    totalFiatBalance: string;
+}): {
+    handleGestureStart: () => void;
+    setInitialSelectedPoints: () => void;
+    setSelectedPoint: (point: TGraphPoint) => void;
+} => {
+    const [isGestureActive, setIsGestureActive] = useState(false);
+    const setSelectedPoint = useSetAtom(selectedPointAtom);
+    const setReferencePoint = useSetAtom(referencePointAtom);
+
+    const lastPoint: TGraphPoint | undefined = graphPoints[graphPoints.length - 1];
+    const referencePoint: TGraphPoint | undefined = useMemo(
+        () => graphPoints.find(point => point.value > 0) ?? graphPoints[0],
+        [graphPoints],
+    );
+
+    useEffect(
+        () => () => {
+            // we should reset everything to default on unmount otherwise it will broke loading state when navigating to same or another account
+            setSelectedPoint(null);
+            setReferencePoint(null);
+        },
+        [setSelectedPoint, setReferencePoint],
+    );
+
+    const setInitialSelectedPoints = useCallback(() => {
+        setIsGestureActive(false);
+        if (lastPoint && referencePoint) {
+            setSelectedPoint({
+                ...lastPoint,
+                valueLatestTotal: totalFiatBalance,
+            });
+            setReferencePoint(referencePoint);
+        }
+    }, [lastPoint, referencePoint, setSelectedPoint, setReferencePoint, totalFiatBalance]);
+
+    const handleGestureStart = useCallback(() => {
+        setIsGestureActive(true);
+    }, [setIsGestureActive]);
+
+    useEffect(() => {
+        if (!isGestureActive && lastPoint) {
+            setSelectedPoint({
+                ...lastPoint,
+                valueLatestTotal: totalFiatBalance,
+            });
+        }
+    }, [isGestureActive, setInitialSelectedPoints, totalFiatBalance, lastPoint, setSelectedPoint]);
+
+    return {
+        handleGestureStart,
+        setInitialSelectedPoints,
+        setSelectedPoint,
     };
 };

--- a/suite-native/module-accounts-management/src/accountDetailGraphAtoms.ts
+++ b/suite-native/module-accounts-management/src/accountDetailGraphAtoms.ts
@@ -3,13 +3,7 @@ import { atom } from 'jotai';
 import { FiatGraphPointWithCryptoBalance } from '@suite-common/graph';
 import { percentageDiff } from '@suite-native/graph';
 
-export const emptyGraphPoint: FiatGraphPointWithCryptoBalance = {
-    value: 0,
-    date: new Date(0),
-    cryptoBalance: '0',
-};
-
-export const selectedPointAtom = atom<FiatGraphPointWithCryptoBalance>(emptyGraphPoint);
+export const selectedPointAtom = atom<FiatGraphPointWithCryptoBalance | null>(null);
 
 // reference is usually first point, same as Revolut does in their app
 export const referencePointAtom = atom<FiatGraphPointWithCryptoBalance | null>(null);
@@ -17,7 +11,7 @@ export const referencePointAtom = atom<FiatGraphPointWithCryptoBalance | null>(n
 export const percentageChangeAtom = atom(get => {
     const selectedPoint = get(selectedPointAtom);
     const referencePoint = get(referencePointAtom);
-    if (!referencePoint) return 0;
+    if (!referencePoint || !selectedPoint) return 0;
 
     return percentageDiff(referencePoint.value, selectedPoint.value);
 });

--- a/suite-native/module-accounts-management/src/components/AccountDetailGraph.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountDetailGraph.tsx
@@ -1,22 +1,24 @@
-import { useCallback, useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
-import { A } from '@mobily/ts-belt';
-import { useSetAtom } from 'jotai';
-
-import { useGraphForSingleAccount, Graph, TimeSwitch } from '@suite-native/graph';
+import { useGraphForSingleAccount, Graph, TimeSwitch, useGraphAtoms } from '@suite-native/graph';
 import { VStack } from '@suite-native/atoms';
 import { selectFiatCurrencyCode } from '@suite-native/settings';
 import { FiatGraphPointWithCryptoBalance } from '@suite-common/graph';
-import { TokenAddress } from '@suite-common/wallet-types';
+import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
 import { selectIsHistoryEnabledAccountByAccountKey } from '@suite-native/graph/src/selectors';
 import { AccountsRootState } from '@suite-common/wallet-core';
+import {
+    NativeAccountsRootState,
+    selectAccountFiatBalance,
+    selectAccountTokenFiatBalance,
+} from '@suite-native/accounts';
 
 import { AccountDetailHeader } from './AccountDetailHeader';
 import { referencePointAtom, selectedPointAtom } from '../accountDetailGraphAtoms';
 
 type AccountDetailGraphProps = {
-    accountKey: string;
+    accountKey: AccountKey;
     tokenContract?: TokenAddress;
 };
 
@@ -33,30 +35,34 @@ export const AccountDetailGraph = ({ accountKey, tokenContract }: AccountDetailG
             tokensFilter,
             hideMainAccount: !!tokenContract,
         });
+    const totalFiatBalance = useSelector((state: NativeAccountsRootState) =>
+        tokenContract
+            ? selectAccountTokenFiatBalance(state, accountKey, tokenContract)
+            : selectAccountFiatBalance(state, accountKey, false, false),
+    );
 
-    const setSelectedPoint = useSetAtom(selectedPointAtom);
-    const setReferencePoint = useSetAtom(referencePointAtom);
-    const lastPoint = A.last(graphPoints);
-    const firstPoint = A.head(graphPoints);
-
-    const setInitialSelectedPoints = useCallback(() => {
-        if (lastPoint && firstPoint) {
-            setSelectedPoint(lastPoint);
-            setReferencePoint(firstPoint);
-        }
-    }, [lastPoint, firstPoint, setSelectedPoint, setReferencePoint]);
-
-    useEffect(setInitialSelectedPoints, [setInitialSelectedPoints]);
+    const { handleGestureStart, setInitialSelectedPoints, setSelectedPoint } =
+        useGraphAtoms<FiatGraphPointWithCryptoBalance>({
+            referencePointAtom,
+            selectedPointAtom,
+            graphPoints,
+            totalFiatBalance,
+        });
 
     return (
         <VStack spacing="sp24">
-            <AccountDetailHeader accountKey={accountKey} tokenAddress={tokenContract} />
+            <AccountDetailHeader
+                accountKey={accountKey}
+                tokenAddress={tokenContract}
+                totalFiatBalance={totalFiatBalance}
+            />
 
             {isHistoryEnabledAccount && (
                 <>
                     <Graph<FiatGraphPointWithCryptoBalance>
                         onPointSelected={setSelectedPoint}
                         onGestureEnd={setInitialSelectedPoints}
+                        onGestureStart={handleGestureStart}
                         points={graphPoints}
                         loading={isLoading}
                         error={error}

--- a/suite-native/module-accounts-management/src/components/AccountDetailHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountDetailHeader.tsx
@@ -1,19 +1,28 @@
-import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 
-import { useAtomValue, useSetAtom } from 'jotai';
+import { useAtomValue } from 'jotai';
 
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
+import {
+    AccountsRootState,
+    DeviceRootState,
+    selectAccountByKey,
+    selectAccountFormattedBalance,
+    TransactionsRootState,
+} from '@suite-common/wallet-core';
 import { AccountKey, TokenAddress, TokenSymbol } from '@suite-common/wallet-types';
 import { DiscreetTextTrigger, VStack } from '@suite-native/atoms';
-import { selectAccountTokenSymbol, TokensRootState } from '@suite-native/tokens';
+import {
+    selectAccountTokenBalance,
+    selectAccountTokenSymbol,
+    TokensRootState,
+} from '@suite-native/tokens';
 import { GraphFiatBalance } from '@suite-native/graph';
 import { selectIsHistoryEnabledAccountByAccountKey } from '@suite-native/graph/src/selectors';
+import { TokenDefinitionsRootState } from '@suite-common/token-definitions';
 
 import { AccountDetailCryptoValue } from './AccountDetailCryptoValue';
 import {
-    emptyGraphPoint,
     hasPriceIncreasedAtom,
     percentageChangeAtom,
     referencePointAtom,
@@ -23,18 +32,22 @@ import {
 type AccountBalanceProps = {
     accountKey: AccountKey;
     tokenAddress?: TokenAddress;
+    totalFiatBalance: string;
 };
 
 const CryptoBalance = ({
     symbol,
     tokenSymbol,
     tokenAddress,
+    totalCryptoBalance,
 }: {
     symbol: NetworkSymbol;
     tokenSymbol?: TokenSymbol | null;
     tokenAddress?: TokenAddress;
+    totalCryptoBalance: string | null;
 }) => {
     const selectedPoint = useAtomValue(selectedPointAtom);
+    const value = selectedPoint?.cryptoBalance || totalCryptoBalance || '0';
 
     return (
         <DiscreetTextTrigger>
@@ -42,13 +55,17 @@ const CryptoBalance = ({
                 symbol={symbol}
                 tokenSymbol={tokenSymbol}
                 tokenAddress={tokenAddress}
-                value={selectedPoint.cryptoBalance}
+                value={value}
             />
         </DiscreetTextTrigger>
     );
 };
 
-export const AccountDetailHeader = ({ accountKey, tokenAddress }: AccountBalanceProps) => {
+export const AccountDetailHeader = ({
+    accountKey,
+    tokenAddress,
+    totalFiatBalance,
+}: AccountBalanceProps) => {
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
@@ -58,10 +75,20 @@ export const AccountDetailHeader = ({ accountKey, tokenAddress }: AccountBalance
     const isHistoryEnabledAccount = useSelector((state: AccountsRootState) =>
         selectIsHistoryEnabledAccountByAccountKey(state, accountKey),
     );
-    const setPoint = useSetAtom(selectedPointAtom);
+    const totalCryptoBalance = useSelector(
+        (
+            state: AccountsRootState &
+                DeviceRootState &
+                TokenDefinitionsRootState &
+                TransactionsRootState,
+        ) => {
+            if (tokenSymbol) {
+                return selectAccountTokenBalance(state, accountKey, tokenAddress);
+            }
 
-    // Reset selected point on unmount so that it doesn't display on device change
-    useEffect(() => () => setPoint(emptyGraphPoint), [setPoint]);
+            return selectAccountFormattedBalance(state, accountKey);
+        },
+    );
 
     if (!account) return null;
 
@@ -71,6 +98,7 @@ export const AccountDetailHeader = ({ accountKey, tokenAddress }: AccountBalance
                 symbol={account.symbol}
                 tokenSymbol={tokenSymbol}
                 tokenAddress={tokenAddress}
+                totalCryptoBalance={totalCryptoBalance}
             />
             <GraphFiatBalance
                 selectedPointAtom={selectedPointAtom}
@@ -78,6 +106,8 @@ export const AccountDetailHeader = ({ accountKey, tokenAddress }: AccountBalance
                 percentageChangeAtom={percentageChangeAtom}
                 hasPriceIncreasedAtom={hasPriceIncreasedAtom}
                 showChange={isHistoryEnabledAccount}
+                totalFiatBalance={totalFiatBalance}
+                isHistoryEnabledAccount={isHistoryEnabledAccount}
             />
         </VStack>
     );

--- a/suite-native/module-home/src/screens/HomeScreen/components/PortfolioGraph.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/PortfolioGraph.tsx
@@ -1,25 +1,25 @@
-import { forwardRef, useCallback, useEffect, useImperativeHandle } from 'react';
+import { forwardRef, useImperativeHandle } from 'react';
 import { useSelector } from 'react-redux';
 
-import { useSetAtom } from 'jotai';
-
+import { selectHasDeviceDiscovery } from '@suite-common/wallet-core';
+import { Box, Text, VStack } from '@suite-native/atoms';
+import { selectSelectedDeviceTotalFiatBalance } from '@suite-native/device';
+import { useIsDiscoveryDurationTooLong } from '@suite-native/discovery';
 import {
-    useGraphForAllDeviceAccounts,
     Graph,
-    TimeSwitch,
     selectHasDeviceHistoryEnabledAccounts,
     selectHasDeviceHistoryIgnoredAccounts,
+    TimeSwitch,
+    useGraphAtoms,
+    useGraphForAllDeviceAccounts,
 } from '@suite-native/graph';
-import { selectFiatCurrencyCode } from '@suite-native/settings';
-import { Box, VStack, Text } from '@suite-native/atoms';
-import { useIsDiscoveryDurationTooLong } from '@suite-native/discovery';
 import { CryptoIcon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
+import { selectFiatCurrencyCode } from '@suite-native/settings';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
-import { selectHasDeviceDiscovery } from '@suite-common/wallet-core';
 
-import { PortfolioHeader } from './PortfolioHeader';
 import { referencePointAtom, selectedPointAtom } from '../portfolioGraphAtoms';
+import { PortfolioHeader } from './PortfolioHeader';
 
 export type PortfolioGraphRef = {
     refetchGraph: () => Promise<void>;
@@ -61,6 +61,7 @@ export const PortfolioGraph = forwardRef<PortfolioGraphRef>((_props, ref) => {
     const hasDeviceHistoryEnabledAccounts = useSelector(selectHasDeviceHistoryEnabledAccounts);
     const hasDeviceDiscovery = useSelector(selectHasDeviceDiscovery);
     const loadingTakesLongerThanExpected = useIsDiscoveryDurationTooLong();
+    const totalFiatBalance = useSelector(selectSelectedDeviceTotalFiatBalance);
 
     const {
         graphPoints,
@@ -74,20 +75,12 @@ export const PortfolioGraph = forwardRef<PortfolioGraphRef>((_props, ref) => {
         fiatCurrency: fiatCurrencyCode,
     });
 
-    const setSelectedPoint = useSetAtom(selectedPointAtom);
-    const setReferencePoint = useSetAtom(referencePointAtom);
-
-    const lastPoint = graphPoints[graphPoints.length - 1];
-    const firstPoint = graphPoints[0];
-
-    const setInitialSelectedPoints = useCallback(() => {
-        if (lastPoint && firstPoint) {
-            setSelectedPoint(lastPoint);
-            setReferencePoint(firstPoint);
-        }
-    }, [lastPoint, firstPoint, setSelectedPoint, setReferencePoint]);
-
-    useEffect(setInitialSelectedPoints, [setInitialSelectedPoints]);
+    const { handleGestureStart, setInitialSelectedPoints, setSelectedPoint } = useGraphAtoms({
+        referencePointAtom,
+        selectedPointAtom,
+        graphPoints,
+        totalFiatBalance,
+    });
 
     useImperativeHandle(
         ref,
@@ -102,7 +95,9 @@ export const PortfolioGraph = forwardRef<PortfolioGraphRef>((_props, ref) => {
 
     return (
         <VStack spacing="sp24" testID="@home/portfolio/graph">
-            {showHeader && <PortfolioHeader isLoading={isLoading} />}
+            {showHeader && (
+                <PortfolioHeader isLoading={isLoading} totalFiatBalance={totalFiatBalance} />
+            )}
             {showGraph && (
                 <Graph
                     points={graphPoints}
@@ -110,6 +105,7 @@ export const PortfolioGraph = forwardRef<PortfolioGraphRef>((_props, ref) => {
                     loadingTakesLongerThanExpected={loadingTakesLongerThanExpected}
                     onPointSelected={setSelectedPoint}
                     onGestureEnd={setInitialSelectedPoints}
+                    onGestureStart={handleGestureStart}
                     onTryAgain={refetch}
                     error={error}
                 />

--- a/suite-native/module-home/src/screens/HomeScreen/components/PortfolioHeader.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/PortfolioHeader.tsx
@@ -12,9 +12,10 @@ import {
 
 type PortfolioHeaderProps = {
     isLoading: boolean;
+    totalFiatBalance: string;
 };
 
-export const PortfolioHeader = ({ isLoading }: PortfolioHeaderProps) => {
+export const PortfolioHeader = ({ isLoading, totalFiatBalance }: PortfolioHeaderProps) => {
     const hasDeviceHistoryEnabledAccounts = useSelector(selectHasDeviceHistoryEnabledAccounts);
 
     return (
@@ -27,6 +28,7 @@ export const PortfolioHeader = ({ isLoading }: PortfolioHeaderProps) => {
                     hasPriceIncreasedAtom={hasPriceIncreasedAtom}
                     showChange={hasDeviceHistoryEnabledAccounts}
                     isLoading={isLoading}
+                    totalFiatBalance={totalFiatBalance}
                 />
             </VStack>
         </Box>

--- a/suite-native/module-home/src/screens/HomeScreen/portfolioGraphAtoms.ts
+++ b/suite-native/module-home/src/screens/HomeScreen/portfolioGraphAtoms.ts
@@ -1,17 +1,11 @@
 import { atom } from 'jotai';
 
-import { FiatGraphPoint, FiatGraphPointWithCryptoBalance } from '@suite-common/graph';
+import { FiatGraphPoint } from '@suite-common/graph';
 import { percentageDiff } from '@suite-native/graph';
-
-const emptyGraphPoint: FiatGraphPointWithCryptoBalance = {
-    value: 0,
-    date: new Date(0),
-    cryptoBalance: '0',
-};
 
 // use atomic jotai structure for absolute minimum re-renders and maximum performance
 // otherwise graph will be freezing on slower device while point swipe gesture
-export const selectedPointAtom = atom<FiatGraphPoint>(emptyGraphPoint);
+export const selectedPointAtom = atom<FiatGraphPoint | null>(null);
 
 // reference is usually first point, same as Revolut does in their app
 export const referencePointAtom = atom<FiatGraphPoint | null>(null);
@@ -20,7 +14,7 @@ export const percentageChangeAtom = atom(get => {
     const selectedPoint = get(selectedPointAtom);
     const referencePoint = get(referencePointAtom);
 
-    if (!referencePoint) return 0;
+    if (!referencePoint || !selectedPoint) return 0;
 
     return percentageDiff(referencePoint.value, selectedPoint.value);
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. When user is not touching graph show same value as everywhere else
2. Reflect staking in device switcher

I was not able to hide percentages for when there is zero because there is lot of valid cases when there could be zero, so I decided to change it little bit so now it will not calculate agains first point of graph but agains first non-zero point of graph so now percentages kind of make sense even for "all" timeframe etc.

## Related Issue

Resolve #12352 

## Screenshots:

![Simulator Screenshot - iPhone 16 Pro - 2025-01-17 at 19 15 59](https://github.com/user-attachments/assets/753df313-f5e3-4188-aefd-969ea762be49)
![Simulator Screenshot - iPhone 16 Pro - 2025-01-17 at 19 15 23](https://github.com/user-attachments/assets/3bbc7c5e-8fdb-4b26-8b45-cdbea566bfb3)

