### PR TITLE
fix(mobile): fw update redirect to home and temp remember device

### DIFF
--- a/suite-native/device/src/deviceThunks.ts
+++ b/suite-native/device/src/deviceThunks.ts
@@ -5,7 +5,7 @@ const NATIVE_DEVICE_MODULE_PREFIX = 'nativeDevice';
 
 export const setDeviceForceRememberedThunk = createThunk(
     `${NATIVE_DEVICE_MODULE_PREFIX}/setDeviceForceRemembered`,
-    ({ forceRemember }: { forceRemember: boolean }, { getState, rejectWithValue, dispatch }) => {
+    ({ remember }: { remember: boolean }, { getState, rejectWithValue, dispatch }) => {
         const device = selectSelectedDevice(getState());
         if (!device) {
             return rejectWithValue('Device not found');
@@ -17,8 +17,8 @@ export const setDeviceForceRememberedThunk = createThunk(
         dispatch(
             deviceActions.rememberDevice({
                 device,
-                remember: false,
-                forceRemember: forceRemember ? true : undefined,
+                remember,
+                forceRemember: remember ? true : undefined,
             }),
         );
 

--- a/suite-native/firmware/src/screens/FirmwareUpdateInProgressScreen.tsx
+++ b/suite-native/firmware/src/screens/FirmwareUpdateInProgressScreen.tsx
@@ -19,6 +19,8 @@ import { Translation } from '@suite-native/intl';
 import {
     DeviceSettingsStackParamList,
     DeviceStackRoutes,
+    HomeStackParamList,
+    HomeStackRoutes,
     Screen,
     StackNavigationProps,
 } from '@suite-native/navigation';
@@ -35,7 +37,7 @@ import { MayBeStuckedBottomSheet } from '../components/MayBeStuckedBottomSheet';
 import { useFirmwareAnalytics } from '../hooks/useFirmwareAnalytics';
 
 type NavigationProp = StackNavigationProps<
-    DeviceSettingsStackParamList,
+    DeviceSettingsStackParamList & HomeStackParamList,
     DeviceStackRoutes.FirmwareUpdateInProgress
 >;
 
@@ -59,6 +61,7 @@ export const FirmwareUpdateInProgressScreen = () => {
     const [isMayBeStuckedBottomSheetOpened, setIsMayBeStuckedBottomSheetOpened] =
         useState<boolean>(false);
     const { bottom: bottomSafeAreaInset } = useSafeAreaInsets();
+
     const {
         operation,
         setIsFirmwareInstallationRunning,
@@ -85,10 +88,10 @@ export const FirmwareUpdateInProgressScreen = () => {
 
     useEffect(() => {
         // This will prevent device from being forgotten after firmware update, so discovery will not run again
-        dispatch(setDeviceForceRememberedThunk({ forceRemember: true }));
+        dispatch(setDeviceForceRememberedThunk({ remember: true }));
 
         return () => {
-            dispatch(setDeviceForceRememberedThunk({ forceRemember: false }));
+            dispatch(setDeviceForceRememberedThunk({ remember: false }));
             resetReducer();
         };
     }, [dispatch, resetReducer]);
@@ -97,7 +100,7 @@ export const FirmwareUpdateInProgressScreen = () => {
         requestPrioritizedDeviceAccess({
             deviceCallback: () => dispatch(authorizeDeviceThunk()),
         });
-        navigation.goBack();
+        navigation.navigate(HomeStackRoutes.Home);
     }, [dispatch, navigation]);
 
     const handleCancel = useCallback(() => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This may help with redirect after FW upgrade is done, it should also fix temporary remember device during FW update.

## Related Issue

Resolve #16460 

## Screenshots:
