### PR TITLE
fix(suite-desktop-core): connect popup process detection on windows

### DIFF
--- a/packages/suite-desktop-core/src/libs/find-process-from-port.ts
+++ b/packages/suite-desktop-core/src/libs/find-process-from-port.ts
@@ -45,9 +45,9 @@ export async function findProcessFromIncomingPort(port: number) {
             const lines = stdout.split('\n');
             const record = lines
                 .map(line => {
-                    const parts = line.split(/\s+/);
+                    const parts = line.trim().split(/\s+/);
                     const pid = parts[parts.length - 1];
-                    const local = parts[2];
+                    const local = parts[1];
 
                     return { pid, local };
                 })


### PR DESCRIPTION
## Description

Fixed an issue with parsing the process information on Windows for the new popup in desktop mode.

## Screenshots:

![Capture](https://github.com/user-attachments/assets/ff916152-f9d5-4dc0-8f7c-845ee963a957)
