### PR TITLE
fix(suite-native): hide fw update for not backed up devices

### DIFF
--- a/packages/suite/src/components/firmware/CheckSeedStep/CheckSeedStep.tsx
+++ b/packages/suite/src/components/firmware/CheckSeedStep/CheckSeedStep.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import { Button, Checkbox, Column, variables } from '@trezor/components';
 import { spacings, spacingsPx } from '@trezor/theme';
-import { selectSelectedDeviceLabelOrName } from '@suite-common/wallet-core';
+import { selectIsDeviceBackedUp, selectSelectedDeviceLabelOrName } from '@suite-common/wallet-core';
 
 import { useDevice, useSelector } from 'src/hooks/suite';
 import { Translation } from 'src/components/suite';
@@ -32,12 +32,9 @@ type CheckSeedStepProps = {
 
 export const CheckSeedStep = ({ deviceWillBeWiped, onClose, onSuccess }: CheckSeedStepProps) => {
     const deviceLabel = useSelector(selectSelectedDeviceLabelOrName);
+    const isDeviceBackedUp = useSelector(selectIsDeviceBackedUp);
     const { device } = useDevice();
     const [isChecked, setIsChecked] = useState(false);
-
-    const isBackedUp =
-        device?.features?.backup_availability !== 'Required' &&
-        !device?.features?.unfinished_backup;
 
     const handleCheckboxClick = () => setIsChecked(prev => !prev);
     const getContent = () => {
@@ -47,7 +44,7 @@ export const CheckSeedStep = ({ deviceWillBeWiped, onClose, onSuccess }: CheckSe
 
         if (deviceWillBeWiped) {
             return {
-                heading: isBackedUp ? (
+                heading: isDeviceBackedUp ? (
                     <Translation id="TR_CONTINUE_ONLY_WITH_SEED" />
                 ) : (
                     noBackupHeading
@@ -56,14 +53,14 @@ export const CheckSeedStep = ({ deviceWillBeWiped, onClose, onSuccess }: CheckSe
                     <Column gap={spacings.md}>
                         <Translation
                             id={
-                                isBackedUp
+                                isDeviceBackedUp
                                     ? 'TR_CONTINUE_ONLY_WITH_SEED_DESCRIPTION'
                                     : 'TR_SWITCH_FIRMWARE_NO_BACKUP'
                             }
                         />
                         <Translation
                             id={
-                                isBackedUp
+                                isDeviceBackedUp
                                     ? 'TR_CONTINUE_ONLY_WITH_SEED_DESCRIPTION_2'
                                     : 'TR_SWITCH_FIRMWARE_NO_BACKUP_2'
                             }
@@ -74,7 +71,7 @@ export const CheckSeedStep = ({ deviceWillBeWiped, onClose, onSuccess }: CheckSe
             };
         }
 
-        return isBackedUp
+        return isDeviceBackedUp
             ? {
                   heading: <Translation id="TR_SECURITY_CHECKPOINT_GOT_SEED" />,
                   description: <Translation id="TR_BEFORE_ANY_FURTHER_ACTIONS" />,
@@ -105,7 +102,7 @@ export const CheckSeedStep = ({ deviceWillBeWiped, onClose, onSuccess }: CheckSe
                             id={deviceWillBeWiped ? 'TR_WIPE_AND_REINSTALL' : 'TR_CONTINUE'}
                         />
                     </Button>
-                    <FirmwareInstallationBackupButton isBackedUp={isBackedUp} />
+                    <FirmwareInstallationBackupButton isBackedUp={isDeviceBackedUp} />
                 </FirmwareButtonsRow>
             }
             disableConfirmWrapper

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -698,6 +698,11 @@ export const selectIsDeviceProtectedByWipeCode = createMemoizedSelector(
     features => !!features?.wipe_code_protection,
 );
 
+export const selectIsDeviceBackedUp = createMemoizedSelector(
+    [selectDeviceFeatures],
+    features => features?.backup_availability !== 'Required' && !features?.unfinished_backup,
+);
+
 export const selectDeviceButtonRequests = createMemoizedSelector(
     [selectSelectedDevice],
     device => device?.buttonRequests ?? [],

--- a/suite-native/module-device-settings/src/components/DeviceFirmwareCard.tsx
+++ b/suite-native/module-device-settings/src/components/DeviceFirmwareCard.tsx
@@ -13,6 +13,7 @@ import {
     selectDeviceModel,
     selectDeviceReleaseInfo,
     selectIsDiscoveryActiveByDeviceState,
+    selectIsDeviceBackedUp,
 } from '@suite-common/wallet-core';
 import { Button, HStack, Text, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
@@ -62,6 +63,7 @@ export const DeviceFirmwareCard = () => {
     const device = useSelector(selectSelectedDevice);
     const deviceModel = useSelector(selectDeviceModel);
     const deviceReleaseInfo = useSelector(selectDeviceReleaseInfo);
+    const isDeviceBackedUp = useSelector(selectIsDeviceBackedUp);
     const isDiscoveryRunning = useSelector((state: DiscoveryRootState & DeviceRootState) =>
         selectIsDiscoveryActiveByDeviceState(state, device?.state),
     );
@@ -78,7 +80,7 @@ export const DeviceFirmwareCard = () => {
         : 'moduleDeviceSettings.firmware.typeUniversal';
 
     const firmwareUpdateProps = (() => {
-        if (!isFirmwareUpdateEnabled) {
+        if (!isFirmwareUpdateEnabled || !isDeviceBackedUp) {
             return undefined;
         }
 


### PR DESCRIPTION
## Description
- hides FW update option for devices without seed backup

## Related Issue

Resolve #16395 

## Screenshots:

### BACKED UP DEVICE 
![IMG_5674](https://github.com/user-attachments/assets/62bd10e5-ba9e-4572-824c-490e09a6e292)

### DEVICE WITHOUT BACKUP
![IMG_5670](https://github.com/user-attachments/assets/b51aed12-270a-47c8-a486-a86c3a077497)

