### PR TITLE
fix(suite-native): do not warn about bootloader and uninitialized device while FW update is running

### DIFF
--- a/suite-native/device/src/hooks/useDetectDeviceError.tsx
+++ b/suite-native/device/src/hooks/useDetectDeviceError.tsx
@@ -28,6 +28,7 @@ import {
     AuthorizeDeviceStackRoutes,
 } from '@suite-native/navigation';
 import { selectIsOnboardingFinished } from '@suite-native/settings';
+import { selectIsFirmwareInstallationRunning } from '@suite-native/firmware';
 
 import { selectDeviceError, selectIsDeviceFirmwareSupported } from '../selectors';
 import { IncompatibleFirmwareModalAppendix } from '../components/IncompatibleFirmwareModalAppendix';
@@ -57,6 +58,7 @@ export const useDetectDeviceError = () => {
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const isNoPhysicalDeviceConnected = useSelector(selectIsNoPhysicalDeviceConnected);
     const isDeviceInBootloader = useSelector(selectIsDeviceInBootloader);
+    const isFirmwareInstallationRunning = useSelector(selectIsFirmwareInstallationRunning);
     const hasDeviceFirmwareInstalled = useSelector(selectHasDeviceFirmwareInstalled);
     const isOnboardingFinished = useSelector(selectIsOnboardingFinished);
 
@@ -135,6 +137,7 @@ export const useDetectDeviceError = () => {
 
         if (
             isConnectedDeviceUninitialized &&
+            !isFirmwareInstallationRunning &&
             !wasDeviceEjectedByUser &&
             !isUnacquiredDevice &&
             !deviceError
@@ -183,6 +186,7 @@ export const useDetectDeviceError = () => {
     }, [
         hasDeviceFirmwareInstalled,
         isConnectedDeviceUninitialized,
+        isFirmwareInstallationRunning,
         isOnboardingFinished,
         isUnacquiredDevice,
         wasDeviceEjectedByUser,
@@ -196,6 +200,7 @@ export const useDetectDeviceError = () => {
         if (
             isDeviceInBootloader &&
             hasDeviceFirmwareInstalled &&
+            !isFirmwareInstallationRunning &&
             !wasDeviceEjectedByUser &&
             isOnboardingFinished
         ) {
@@ -218,6 +223,7 @@ export const useDetectDeviceError = () => {
         }
     }, [
         isDeviceInBootloader,
+        isFirmwareInstallationRunning,
         isOnboardingFinished,
         hasDeviceFirmwareInstalled,
         wasDeviceEjectedByUser,


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Handling of device errors remains global, but disabled if FW update is running.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/16494

## Screenshots:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/2d4d0804-97b2-460e-9b9f-ffb25d01aaa3" />

https://github.com/user-attachments/assets/e0e6bf8f-ec20-4989-bbf4-b3d9ae56f200


