### PR TITLE
fix(suite): remove plus sign (+) from unstake tooltip

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/Inputs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnstakeModal/UnstakeEthForm/Inputs.tsx
@@ -162,11 +162,19 @@ export const Inputs = () => {
                                 />
                                 <Text typographyStyle="hint">
                                     <FiatValue amount={depositedBalance} symbol={symbol}>
-                                        {({ value }) => value && <span>{value} + </span>}
+                                        {({ value }) => value && <span>{value}</span>}
                                     </FiatValue>
-                                    <Text variant="primary">
-                                        <FiatValue amount={restakedReward} symbol={symbol} />
-                                    </Text>
+                                    {isRewardsVisible && (
+                                        <>
+                                            {' + '}
+                                            <Text variant="primary">
+                                                <FiatValue
+                                                    amount={restakedReward}
+                                                    symbol={symbol}
+                                                />
+                                            </Text>
+                                        </>
+                                    )}
                                 </Text>
                             </Column>
                         ),


### PR DESCRIPTION
## Description

The tooltip for Solana unstaking showed an unnecessary + when a reward was missing.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/16468

## Screenshots:

![image](https://github.com/user-attachments/assets/7c54b217-c6ee-483e-9b47-d09f4705d614)

![image](https://github.com/user-attachments/assets/4628fee9-0832-493e-b660-10e9e20b4f80)
