### PR TITLE
fix(suite-native): navigate to receive address screen after account is added

### DIFF
--- a/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
+++ b/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
@@ -148,6 +148,17 @@ export const useAddCoinAccount = () => {
         accountIndex: number;
     }) => {
         switch (flowType) {
+            case 'home':
+                navigation.replace(RootStackRoutes.ReceiveStack, {
+                    screen: ReceiveStackRoutes.ReceiveAccount,
+                    params: {
+                        networkSymbol: symbol,
+                        accountType,
+                        accountIndex,
+                        closeActionType: 'close',
+                    },
+                });
+                break;
             case 'accounts':
                 navigation.replace(RootStackRoutes.AccountDetail, {
                     networkSymbol: symbol,


### PR DESCRIPTION
Steps to reproduce in previous app versions:

1. Enable just _Vertcoin_ in _Enabled coins_ in _Settings_.
2. Connect a device and wait for the empty _Home_ screen.
3. Tap the _Receive assets_ button on the empty _Home_ screen.
4. Choose _Bitcoin_ and wait for discovery to finish.
5. You cannot continue in the flow, just cancel it.