### PR TITLE
feat(suite): add support for Solana staking rewards

### DIFF
--- a/packages/suite-desktop-core/src/config.ts
+++ b/packages/suite-desktop-core/src/config.ts
@@ -28,6 +28,7 @@ export const allowedDomains = [
     'eth-api-b2c-stage.everstake.one', // staking endpoint for Holesky testnet, works only with VPN
     'eth-api-b2c.everstake.one', // staking endpoint for Ethereum mainnet
     'dashboard-api.everstake.one', // staking enpoint for Solana
+    'stake-sync-api.everstake.one', // staking rewards enpoint for Solana
 ];
 
 export const cspRules = [

--- a/packages/suite/src/hooks/wallet/useSolanaRewards.ts
+++ b/packages/suite/src/hooks/wallet/useSolanaRewards.ts
@@ -82,6 +82,5 @@ export const useSolanaRewards = (account: Account) => {
         itemsPerPage,
         showPagination,
         isLastPage,
-        fetchRewards,
     };
 };

--- a/packages/suite/src/hooks/wallet/useSolanaRewards.ts
+++ b/packages/suite/src/hooks/wallet/useSolanaRewards.ts
@@ -1,0 +1,87 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import {
+    EverstakeRewardsEndpointType,
+    StakeAccountRewards,
+    StakeRootState,
+    fetchEverstakeRewards,
+    selectStakingRewards,
+} from '@suite-common/wallet-core';
+import { useDebounce } from '@trezor/react-utils';
+
+import { Account } from 'src/types/wallet';
+
+const PAGE_SIZE_DEFAULT = 10;
+
+export const useSolanaRewards = (account: Account) => {
+    const { data, isLoading } =
+        useSelector((state: StakeRootState) => selectStakingRewards(state, account.symbol)) || {};
+
+    const { rewards } = data ?? {};
+    const selectedAccountRewards = rewards?.[account.descriptor];
+
+    const dispatch = useDispatch();
+    const debounce = useDebounce();
+
+    const itemsPerPage = PAGE_SIZE_DEFAULT;
+    const startPage = 1;
+
+    const [currentPage, setSelectedPage] = useState(startPage);
+    const [slicedRewards, setSlicedRewards] = useState<StakeAccountRewards[]>([]);
+
+    const startIndex = (currentPage - 1) * itemsPerPage;
+    const stopIndex = startIndex + itemsPerPage;
+
+    const fetchRewards = useCallback(
+        async ({ symbol, descriptor }: Account) => {
+            const controller = new AbortController();
+            await debounce(() => {
+                if (symbol !== 'sol') return;
+                dispatch(
+                    fetchEverstakeRewards({
+                        symbol,
+                        endpointType: EverstakeRewardsEndpointType.GetRewards,
+                        address: descriptor,
+                        signal: controller.signal,
+                    }),
+                );
+            });
+
+            return () => controller.abort();
+        },
+        [dispatch, debounce],
+    );
+
+    useEffect(() => {
+        fetchRewards(account);
+    }, [account, fetchRewards]);
+
+    useEffect(() => {
+        if (selectedAccountRewards) {
+            const slicedRewards = selectedAccountRewards?.slice(startIndex, stopIndex);
+            setSlicedRewards(slicedRewards);
+        }
+    }, [currentPage, selectedAccountRewards, startIndex, stopIndex]);
+
+    useEffect(() => {
+        // reset page on account change
+        setSelectedPage(startPage);
+    }, [account.descriptor, account.symbol, startPage]);
+
+    const totalItems = selectedAccountRewards?.length ?? 0;
+    const showPagination = totalItems > itemsPerPage;
+    const isLastPage = stopIndex >= totalItems;
+
+    return {
+        slicedRewards,
+        isLoading,
+        currentPage,
+        setSelectedPage,
+        totalItems,
+        itemsPerPage,
+        showPagination,
+        isLastPage,
+        fetchRewards,
+    };
+};

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -8705,14 +8705,27 @@ export default defineMessages({
         id: 'TR_STAKE_RESTAKED_BADGE',
         defaultMessage: 'Restaked',
     },
-    TR_STAKE_REWARDS_BAGE: {
-        id: 'TR_STAKE_REWARDS_BAGE',
+    TR_STAKE_REWARDS_BADGE: {
+        id: 'TR_STAKE_REWARDS_BADGE',
         defaultMessage: 'Epoch number {count}',
     },
     TR_STAKE_REWARDS_TOOLTIP: {
         id: 'TR_STAKE_REWARDS_TOOLTIP',
         defaultMessage:
             'An epoch in Solana is approximately {count, plural, one {# day} other {# days}} long.',
+    },
+    TR_STAKE_REFRESH_REWARDS_TOOLTIP: {
+        id: 'TR_STAKE_REFRESH_REWARDS_TOOLTIP',
+        defaultMessage: 'Refresh your rewards for this account.',
+    },
+    TR_STAKE_REWARDS_ARE_EMPTY: {
+        id: 'TR_STAKE_REWARDS_ARE_EMPTY',
+        defaultMessage: 'No Rewards',
+    },
+    TR_STAKE_WAIT_TO_CHECK_REWARDS: {
+        id: 'TR_STAKE_WAIT_TO_CHECK_REWARDS',
+        defaultMessage:
+            'Wait up to {count, plural, one {# day} other {# days}} to check your rewards',
     },
     TR_STAKE_ETH_CARD_TITLE: {
         id: 'TR_STAKE_ETH_CARD_TITLE',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5214,6 +5214,14 @@ export default defineMessages({
         id: 'TR_MY_PORTFOLIO',
         defaultMessage: 'Portfolio',
     },
+    TR_REWARD: {
+        id: 'TR_REWARD',
+        defaultMessage: 'Reward',
+    },
+    TR_REWARDS: {
+        id: 'TR_REWARDS',
+        defaultMessage: 'Rewards',
+    },
     TR_ALL_TRANSACTIONS: {
         id: 'TR_ALL_TRANSACTIONS',
         defaultMessage: 'Transactions',
@@ -8696,6 +8704,15 @@ export default defineMessages({
     TR_STAKE_RESTAKED_BADGE: {
         id: 'TR_STAKE_RESTAKED_BADGE',
         defaultMessage: 'Restaked',
+    },
+    TR_STAKE_REWARDS_BAGE: {
+        id: 'TR_STAKE_REWARDS_BAGE',
+        defaultMessage: 'Epoch number {count}',
+    },
+    TR_STAKE_REWARDS_TOOLTIP: {
+        id: 'TR_STAKE_REWARDS_TOOLTIP',
+        defaultMessage:
+            'An epoch in Solana is approximately {count, plural, one {# day} other {# days}} long.',
     },
     TR_STAKE_ETH_CARD_TITLE: {
         id: 'TR_STAKE_ETH_CARD_TITLE',

--- a/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/SolStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/SolStakingDashboard.tsx
@@ -12,6 +12,7 @@ import { DashboardSection } from 'src/components/dashboard';
 import { Translation } from 'src/components/suite';
 
 import { StakingDashboard } from '../StakingDashboard/StakingDashboard';
+import { RewardsList } from './components/RewardsList';
 import { ApyCard } from '../StakingDashboard/components/ApyCard';
 import { ClaimCard } from '../StakingDashboard/components/ClaimCard';
 import { PayoutCard } from '../StakingDashboard/components/PayoutCard';
@@ -65,6 +66,7 @@ export const SolStakingDashboard = ({ selectedAccount }: SolStakingDashboardProp
                             />
                         </Column>
                     </DashboardSection>
+                    <RewardsList account={account} />
                 </Column>
             }
         />

--- a/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/SolStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/SolStakingDashboard.tsx
@@ -12,11 +12,11 @@ import { DashboardSection } from 'src/components/dashboard';
 import { Translation } from 'src/components/suite';
 
 import { StakingDashboard } from '../StakingDashboard/StakingDashboard';
-import { RewardsList } from './components/RewardsList';
 import { ApyCard } from '../StakingDashboard/components/ApyCard';
 import { ClaimCard } from '../StakingDashboard/components/ClaimCard';
 import { PayoutCard } from '../StakingDashboard/components/PayoutCard';
 import { StakingCard } from '../StakingDashboard/components/StakingCard';
+import { RewardsList } from './components/Rewards/RewardsList';
 
 interface SolStakingDashboardProps {
     selectedAccount: SelectedAccountLoaded;

--- a/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/components/Rewards/RewardsEmpty.tsx
+++ b/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/components/Rewards/RewardsEmpty.tsx
@@ -1,0 +1,18 @@
+import { SOLANA_EPOCH_DAYS } from '@suite-common/wallet-constants';
+
+import { Translation } from 'src/components/suite';
+import { AccountExceptionLayout } from 'src/components/wallet';
+
+export const RewardsEmpty = () => (
+    <AccountExceptionLayout
+        title={<Translation id="TR_STAKE_REWARDS_ARE_EMPTY" />}
+        description={
+            <Translation
+                id="TR_STAKE_WAIT_TO_CHECK_REWARDS"
+                values={{ count: SOLANA_EPOCH_DAYS }}
+            />
+        }
+        iconName="arrowLineDown"
+        iconVariant="tertiary"
+    />
+);

--- a/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/components/Rewards/RewardsList.tsx
+++ b/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/components/Rewards/RewardsList.tsx
@@ -2,23 +2,13 @@ import React, { useRef } from 'react';
 
 import { SOLANA_EPOCH_DAYS } from '@suite-common/wallet-constants';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
-import {
-    Badge,
-    Card,
-    Column,
-    Icon,
-    IconButton,
-    Row,
-    SkeletonStack,
-    Text,
-    Tooltip,
-} from '@trezor/components';
+import { Badge, Card, Column, Icon, Row, SkeletonStack, Text, Tooltip } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { DashboardSection } from 'src/components/dashboard';
 import {
-    CoinBalance,
     FiatValue,
+    FormattedCryptoAmount,
     FormattedDate,
     HiddenPlaceholder,
     Translation,
@@ -47,7 +37,6 @@ export const RewardsList = ({ account }: RewardsListProps) => {
         itemsPerPage,
         showPagination,
         isLastPage,
-        fetchRewards,
     } = useSolanaRewards(account);
 
     const isSolanaMainnet = account.symbol === 'sol';
@@ -58,6 +47,10 @@ export const RewardsList = ({ account }: RewardsListProps) => {
             sectionRef.current.scrollIntoView();
         }
     };
+
+    if (!isSolanaMainnet || !totalItems) {
+        return <RewardsEmpty />;
+    }
 
     return (
         <DashboardSection
@@ -108,7 +101,7 @@ export const RewardsList = ({ account }: RewardsListProps) => {
                                                 <Badge size="small">
                                                     <Row gap={spacings.xxs} alignItems="center">
                                                         <Translation
-                                                            id="TR_STAKE_REWARDS_BAGE"
+                                                            id="TR_STAKE_REWARDS_BADGE"
                                                             values={{ count: reward.epoch }}
                                                         />
                                                         <Icon name="info" size="small" />
@@ -120,7 +113,7 @@ export const RewardsList = ({ account }: RewardsListProps) => {
                                     {reward?.amount && (
                                         <Column alignItems="end">
                                             <HiddenPlaceholder>
-                                                <CoinBalance
+                                                <FormattedCryptoAmount
                                                     value={formatNetworkAmount(
                                                         reward?.amount,
                                                         account.symbol,
@@ -148,7 +141,7 @@ export const RewardsList = ({ account }: RewardsListProps) => {
                 </>
             )}
 
-            {showPagination && (
+            {showPagination && !isLoading && slicedRewards?.length && (
                 <Pagination
                     hasPages={true}
                     currentPage={currentPage}

--- a/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/components/RewardsList.tsx
+++ b/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/components/RewardsList.tsx
@@ -1,0 +1,163 @@
+import React, { useRef } from 'react';
+
+import { SOLANA_EPOCH_DAYS } from '@suite-common/wallet-constants';
+import { formatNetworkAmount } from '@suite-common/wallet-utils';
+import {
+    Badge,
+    Card,
+    Column,
+    Icon,
+    IconButton,
+    Row,
+    SkeletonStack,
+    Text,
+    Tooltip,
+} from '@trezor/components';
+import { spacings } from '@trezor/theme';
+
+import { DashboardSection } from 'src/components/dashboard';
+import {
+    CoinBalance,
+    FiatValue,
+    FormattedDate,
+    HiddenPlaceholder,
+    Translation,
+} from 'src/components/suite';
+import { Pagination } from 'src/components/wallet';
+import { useSolanaRewards } from 'src/hooks/wallet/useSolanaRewards';
+import { Account } from 'src/types/wallet';
+import SkeletonTransactionItem from 'src/views/wallet/transactions/TransactionList/SkeletonTransactionItem';
+import { ColDate } from 'src/views/wallet/transactions/TransactionList/TransactionsGroup/CommonComponents';
+
+import { RewardsEmpty } from './RewardsEmpty';
+
+interface RewardsListProps {
+    account: Account;
+}
+
+export const RewardsList = ({ account }: RewardsListProps) => {
+    const sectionRef = useRef<HTMLDivElement>(null);
+
+    const {
+        slicedRewards,
+        isLoading,
+        currentPage,
+        setSelectedPage,
+        totalItems,
+        itemsPerPage,
+        showPagination,
+        isLastPage,
+        fetchRewards,
+    } = useSolanaRewards(account);
+
+    const isSolanaMainnet = account.symbol === 'sol';
+
+    const onPageSelected = (page: number) => {
+        setSelectedPage(page);
+        if (sectionRef.current) {
+            sectionRef.current.scrollIntoView();
+        }
+    };
+
+    return (
+        <DashboardSection
+            ref={sectionRef}
+            heading={<Translation id="TR_REWARDS" />}
+            data-testid="@wallet/accounts/rewards-list"
+        >
+            {isLoading ? (
+                <SkeletonStack $col $childMargin="0px 0px 16px 0px">
+                    <SkeletonTransactionItem />
+                    <SkeletonTransactionItem />
+                    <SkeletonTransactionItem />
+                </SkeletonStack>
+            ) : (
+                <>
+                    {slicedRewards?.map(reward => (
+                        <React.Fragment key={reward.epoch}>
+                            <Row>
+                                <ColDate>
+                                    <FormattedDate
+                                        value={reward?.time ?? undefined}
+                                        day="numeric"
+                                        month="long"
+                                        year="numeric"
+                                    />
+                                </ColDate>
+                            </Row>
+                            <Card>
+                                <Row
+                                    justifyContent="space-between"
+                                    margin={{ horizontal: spacings.xs, bottom: spacings.xs }}
+                                >
+                                    <Row gap={spacings.xs}>
+                                        <Icon name="arrowLineDown" variant="tertiary" />
+                                        <Column>
+                                            <Text typographyStyle="body" variant="tertiary">
+                                                <Translation id="TR_REWARD" />
+                                            </Text>
+                                            <Tooltip
+                                                maxWidth={250}
+                                                content={
+                                                    <Translation
+                                                        id="TR_STAKE_REWARDS_TOOLTIP"
+                                                        values={{ count: SOLANA_EPOCH_DAYS }}
+                                                    />
+                                                }
+                                            >
+                                                <Badge size="small">
+                                                    <Row gap={spacings.xxs} alignItems="center">
+                                                        <Translation
+                                                            id="TR_STAKE_REWARDS_BAGE"
+                                                            values={{ count: reward.epoch }}
+                                                        />
+                                                        <Icon name="info" size="small" />
+                                                    </Row>
+                                                </Badge>
+                                            </Tooltip>
+                                        </Column>
+                                    </Row>
+                                    {reward?.amount && (
+                                        <Column alignItems="end">
+                                            <HiddenPlaceholder>
+                                                <CoinBalance
+                                                    value={formatNetworkAmount(
+                                                        reward?.amount,
+                                                        account.symbol,
+                                                    )}
+                                                    symbol={account.symbol}
+                                                />
+                                            </HiddenPlaceholder>
+                                            <HiddenPlaceholder>
+                                                <Text typographyStyle="hint" variant="tertiary">
+                                                    <FiatValue
+                                                        amount={formatNetworkAmount(
+                                                            reward?.amount,
+                                                            account.symbol,
+                                                        )}
+                                                        symbol={account.symbol}
+                                                    />
+                                                </Text>
+                                            </HiddenPlaceholder>
+                                        </Column>
+                                    )}
+                                </Row>
+                            </Card>
+                        </React.Fragment>
+                    ))}
+                </>
+            )}
+
+            {showPagination && (
+                <Pagination
+                    hasPages={true}
+                    currentPage={currentPage}
+                    isLastPage={isLastPage}
+                    perPage={itemsPerPage}
+                    totalItems={totalItems}
+                    onPageSelected={onPageSelected}
+                />
+            )}
+        </DashboardSection>
+    );
+};

--- a/suite-common/wallet-core/src/stake/stakeConstants.ts
+++ b/suite-common/wallet-core/src/stake/stakeConstants.ts
@@ -12,3 +12,6 @@ export const EVERSTAKE_ENDPOINT_PREFIX: Record<
     sol: 'https://dashboard-api.everstake.one',
     dsol: 'https://dashboard-api.everstake.one',
 };
+
+export const EVERSTAKE_REWARDS_SOLANA_ENPOINT =
+    'https://stake-sync-api.everstake.one/solana/rewards';

--- a/suite-common/wallet-core/src/stake/stakeReducer.ts
+++ b/suite-common/wallet-core/src/stake/stakeReducer.ts
@@ -5,7 +5,7 @@ import { cloneObject } from '@trezor/utils';
 
 import { stakeActions } from './stakeActions';
 import { fetchEverstakeAssetData, fetchEverstakeData, fetchEverstakeRewards } from './stakeThunks';
-import { StakeAccountRewards, ValidatorsQueue } from './stakeTypes';
+import { StakeRewardsByAccount, ValidatorsQueue } from './stakeTypes';
 import { SerializedTx } from '../send/sendFormTypes';
 
 export interface StakeState {
@@ -40,7 +40,7 @@ export interface StakeState {
                 error: boolean | string;
                 isLoading: boolean;
                 lastSuccessfulFetchTimestamp: Timestamp;
-                data: { rewards?: StakeAccountRewards[] };
+                data: { rewards?: StakeRewardsByAccount };
             };
         };
     };

--- a/suite-common/wallet-core/src/stake/stakeReducer.ts
+++ b/suite-common/wallet-core/src/stake/stakeReducer.ts
@@ -4,8 +4,8 @@ import { PrecomposedTransactionFinal, StakeFormState, Timestamp } from '@suite-c
 import { cloneObject } from '@trezor/utils';
 
 import { stakeActions } from './stakeActions';
-import { fetchEverstakeAssetData, fetchEverstakeData } from './stakeThunks';
-import { ValidatorsQueue } from './stakeTypes';
+import { fetchEverstakeAssetData, fetchEverstakeData, fetchEverstakeRewards } from './stakeThunks';
+import { StakeAccountRewards, ValidatorsQueue } from './stakeTypes';
 import { SerializedTx } from '../send/sendFormTypes';
 
 export interface StakeState {
@@ -35,6 +35,12 @@ export interface StakeState {
                 isLoading: boolean;
                 lastSuccessfulFetchTimestamp: Timestamp;
                 data: { apy?: number };
+            };
+            stakingRewards?: {
+                error: boolean | string;
+                isLoading: boolean;
+                lastSuccessfulFetchTimestamp: Timestamp;
+                data: { rewards?: StakeAccountRewards[] };
             };
         };
     };
@@ -124,10 +130,11 @@ export const prepareStakeReducer = createReducerWithExtraDeps(stakeInitialState,
             }
         })
         .addCase(fetchEverstakeAssetData.pending, (state, action) => {
-            const { symbol } = action.meta.arg;
+            const { symbol, endpointType } = action.meta.arg;
 
-            if (!state.data[symbol]) {
+            if (!state.data[symbol]?.[endpointType]) {
                 state.data[symbol] = {
+                    ...state.data[symbol],
                     getAssets: {
                         error: false,
                         isLoading: true,
@@ -152,6 +159,50 @@ export const prepareStakeReducer = createReducerWithExtraDeps(stakeInitialState,
             }
         })
         .addCase(fetchEverstakeAssetData.rejected, (state, action) => {
+            const { symbol, endpointType } = action.meta.arg;
+
+            const data = state.data[symbol];
+
+            if (data?.[endpointType]) {
+                data[endpointType] = {
+                    error: true,
+                    isLoading: false,
+                    lastSuccessfulFetchTimestamp: 0 as Timestamp,
+                    data: {},
+                };
+            }
+        })
+        .addCase(fetchEverstakeRewards.pending, (state, action) => {
+            const { symbol, endpointType } = action.meta.arg;
+
+            if (!state.data[symbol]?.[endpointType]) {
+                state.data[symbol] = {
+                    ...state.data[symbol],
+                    stakingRewards: {
+                        error: false,
+                        isLoading: true,
+                        lastSuccessfulFetchTimestamp: 0 as Timestamp,
+                        data: {},
+                    },
+                };
+            }
+        })
+        .addCase(fetchEverstakeRewards.fulfilled, (state, action) => {
+            const { symbol, endpointType } = action.meta.arg;
+
+            const data = state.data[symbol];
+
+            if (data?.[endpointType]) {
+                data[endpointType] = {
+                    error: false,
+                    isLoading: false,
+                    lastSuccessfulFetchTimestamp: Date.now() as Timestamp,
+                    data: action.payload,
+                };
+            }
+        })
+
+        .addCase(fetchEverstakeRewards.rejected, (state, action) => {
             const { symbol, endpointType } = action.meta.arg;
 
             const data = state.data[symbol];

--- a/suite-common/wallet-core/src/stake/stakeSelectors.ts
+++ b/suite-common/wallet-core/src/stake/stakeSelectors.ts
@@ -47,3 +47,11 @@ export const selectValidatorsQueue = (state: StakeRootState, symbol?: NetworkSym
 
     return state.wallet.stake?.data?.[symbol]?.validatorsQueue;
 };
+
+export const selectStakingRewards = (state: StakeRootState, symbol?: NetworkSymbol) => {
+    if (!symbol) {
+        return undefined;
+    }
+
+    return state.wallet.stake?.data?.[symbol]?.stakingRewards;
+};

--- a/suite-common/wallet-core/src/stake/stakeThunks.ts
+++ b/suite-common/wallet-core/src/stake/stakeThunks.ts
@@ -11,13 +11,15 @@ import {
 import { TimerId } from '@trezor/type-utils';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
-import { EVERSTAKE_ENDPOINT_PREFIX } from './stakeConstants';
+import { EVERSTAKE_ENDPOINT_PREFIX, EVERSTAKE_REWARDS_SOLANA_ENPOINT } from './stakeConstants';
 import { selectEverstakeData } from './stakeSelectors';
 import {
     EVERSTAKE_ASSET_ENDPOINT_TYPES,
     EVERSTAKE_ENDPOINT_TYPES,
     EverstakeAssetEndpointType,
     EverstakeEndpointType,
+    EverstakeRewardsEndpointType,
+    StakeAccountRewards,
     ValidatorsQueue,
 } from './stakeTypes';
 import { selectAllNetworkSymbolsOfVisibleAccounts } from '../accounts/accountsReducer';
@@ -98,6 +100,41 @@ export const fetchEverstakeAssetData = createThunk<
 
             return fulfillWithValue({
                 apy: data.blockchain.apr,
+            });
+        } catch (error) {
+            return rejectWithValue(error.toString());
+        }
+    },
+);
+
+export const fetchEverstakeRewards = createThunk<
+    { rewards: StakeAccountRewards[] },
+    {
+        symbol: SupportedSolanaNetworkSymbols;
+        endpointType: EverstakeRewardsEndpointType;
+        address: string;
+        signal?: AbortSignal;
+    },
+    { rejectValue: string }
+>(
+    `${STAKE_MODULE}/fetchEverstakeRewardsData`,
+    async (params, { fulfillWithValue, rejectWithValue }) => {
+        const { address, signal } = params;
+
+        try {
+            const response = await fetch(`${EVERSTAKE_REWARDS_SOLANA_ENPOINT}/${address}`, {
+                method: 'POST',
+                signal,
+            });
+
+            if (!response.ok) {
+                throw Error(response.statusText);
+            }
+
+            const data = await response.json();
+
+            return fulfillWithValue({
+                rewards: data,
             });
         } catch (error) {
             return rejectWithValue(error.toString());

--- a/suite-common/wallet-core/src/stake/stakeThunks.ts
+++ b/suite-common/wallet-core/src/stake/stakeThunks.ts
@@ -19,7 +19,7 @@ import {
     EverstakeAssetEndpointType,
     EverstakeEndpointType,
     EverstakeRewardsEndpointType,
-    StakeAccountRewards,
+    StakeRewardsByAccount,
     ValidatorsQueue,
 } from './stakeTypes';
 import { selectAllNetworkSymbolsOfVisibleAccounts } from '../accounts/accountsReducer';
@@ -108,7 +108,7 @@ export const fetchEverstakeAssetData = createThunk<
 );
 
 export const fetchEverstakeRewards = createThunk<
-    { rewards: StakeAccountRewards[] },
+    { rewards: StakeRewardsByAccount },
     {
         symbol: SupportedSolanaNetworkSymbols;
         endpointType: EverstakeRewardsEndpointType;
@@ -134,7 +134,9 @@ export const fetchEverstakeRewards = createThunk<
             const data = await response.json();
 
             return fulfillWithValue({
-                rewards: data,
+                rewards: {
+                    [address]: data,
+                },
             });
         } catch (error) {
             return rejectWithValue(error.toString());

--- a/suite-common/wallet-core/src/stake/stakeTypes.ts
+++ b/suite-common/wallet-core/src/stake/stakeTypes.ts
@@ -25,6 +25,10 @@ export enum EverstakeAssetEndpointType {
     GetAssets = 'getAssets',
 }
 
+export enum EverstakeRewardsEndpointType {
+    GetRewards = 'stakingRewards',
+}
+
 export const EVERSTAKE_ASSET_ENDPOINT_TYPES = {
     [EverstakeAssetEndpointType.GetAssets]: 'chain',
 };
@@ -89,3 +93,14 @@ export type UnstakeContextValues = UseFormReturn<UnstakeFormState> &
         onFiatAmountChange: (amount: string) => void;
         currentRate: Rate | undefined;
     };
+
+export type StakeAccountRewards = {
+    height: number;
+    epoch: number;
+    validator: string;
+    authority: string;
+    stake_account: string;
+    amount: string;
+    currency: string;
+    time: string;
+};

--- a/suite-common/wallet-core/src/stake/stakeTypes.ts
+++ b/suite-common/wallet-core/src/stake/stakeTypes.ts
@@ -104,3 +104,7 @@ export type StakeAccountRewards = {
     currency: string;
     time: string;
 };
+
+export type StakeRewardsByAccount = {
+    [address: string]: StakeAccountRewards[];
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds rewards to the Solana staking dashboard. Key changes:

- Fetching and displaying Solana staking rewards.
- UI components to show detailed reward information.
- Pagination support for navigating through rewards.
- Added empty state and the refetch logic for the rewards list

## Related Issue

Resolve [#16597](https://github.com/trezor/trezor-suite/issues/16597)

## Screenshots:

![image](https://github.com/user-attachments/assets/5553f0e3-ef56-4227-a62e-607090dc827b)
![image](https://github.com/user-attachments/assets/f90f8aeb-b3f5-45fc-b2ee-8b16c21199f5)
![image](https://github.com/user-attachments/assets/84d88be9-0157-42bd-9c4b-441b84a131ee)



