### PR TITLE
connect device communication fixes

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -56,7 +56,7 @@ import { checkFirmwareRevision } from './checkFirmwareRevision';
 import { IStateStorage } from './StateStorage';
 import type { PromptCallback } from './prompts';
 import { calculateFirmwareHash, getBinaryOptional, stripFwHeaders } from '../api/firmware';
-
+import { cancelPrompt } from './prompts';
 // custom log
 const _log = initLog('Device');
 
@@ -555,10 +555,11 @@ export class Device extends TypedEmitter<DeviceEvents> {
                         // set the timeout for this call so whenever it happens "unacquired device" will be created instead
                         // next time device should be called together with "Initialize" (calling "acquireDevice" from the UI)
                         new Promise((_resolve, reject) => {
-                            getFeaturesTimeoutId = setTimeout(
-                                () => reject(new Error('GetFeatures timeout')),
-                                getFeaturesTimeout,
-                            );
+                            getFeaturesTimeoutId = setTimeout(() => {
+                                cancelPrompt(this, false).finally(() => {
+                                    reject(new Error('GetFeatures timeout'));
+                                });
+                            }, getFeaturesTimeout);
                         }),
                     ]);
                 }

--- a/packages/connect/src/device/DeviceCommands.ts
+++ b/packages/connect/src/device/DeviceCommands.ts
@@ -354,10 +354,20 @@ export class DeviceCommands {
         } catch (error) {
             // handle possible race condition
             // Bridge may have some unread message in buffer, read it
-            await this.transport.receive({
-                session: this.transportSession,
-                protocol: this.device.protocol,
-            });
+            const abortController = new AbortController();
+            const timeout = setTimeout(() => {
+                abortController.abort();
+            }, 500);
+
+            await this.transport
+                .receive({
+                    session: this.transportSession,
+                    protocol: this.device.protocol,
+                    signal: abortController.signal,
+                })
+                .finally(() => {
+                    clearTimeout(timeout);
+                });
             // throw error anyway, next call should be resolved properly
             throw error;
         }


### PR DESCRIPTION
Before:
- go to suite (webusb)
- get address
- reload
- observe that the device is stuck

After:
- sending cancel seems to be the universal remedy, that flushes all the communication and forces the device to cooperate again after exiting the initial communication ungracefully.

Another possible scenario
- trezorctl get-address --show-display --coin Bitcoin -n "44'/0'/0'/0/0"
- kill terminal window without approving on device 
- go to suite 

possibly related issues:
maybe resolve #4385 (at least the point where app doesn't load after reload)
