### PR TITLE
fix(suite-native): empty homescreen paddings

### DIFF
--- a/suite-native/module-home/src/screens/HomeScreen/HomeScreen.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/HomeScreen.tsx
@@ -7,7 +7,6 @@ import {
     selectIsDeviceUnlocked,
     selectIsDiscoveredDeviceAccountless,
 } from '@suite-common/wallet-core';
-import { Box } from '@suite-native/atoms';
 import { DeviceManagerScreenHeader } from '@suite-native/device-manager';
 import { Screen } from '@suite-native/navigation';
 
@@ -44,9 +43,7 @@ export const HomeScreen = () => {
             noHorizontalPadding
         >
             {isEmptyHomeRendererShown ? (
-                <Box marginHorizontal="sp16">
-                    <EmptyHomeRenderer />
-                </Box>
+                <EmptyHomeRenderer />
             ) : (
                 <PortfolioContent ref={portfolioContentRef} />
             )}

--- a/suite-native/module-home/src/screens/HomeScreen/components/EmptyConnectedDeviceState.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/EmptyConnectedDeviceState.tsx
@@ -14,8 +14,9 @@ const cardStyle = prepareNativeStyle(utils => ({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    paddingVertical: utils.spacings.sp32,
-    paddingHorizontal: utils.spacings.sp24,
+    paddingTop: utils.spacings.sp32,
+    paddingBottom: utils.spacings.sp16,
+    paddingHorizontal: utils.spacings.sp16,
 }));
 
 const contentStyle = prepareNativeStyle(_ => ({

--- a/suite-native/module-home/src/screens/HomeScreen/components/EmptyHomeRenderer.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/EmptyHomeRenderer.tsx
@@ -7,6 +7,7 @@ import {
     selectIsPortfolioTrackerDevice,
 } from '@suite-common/wallet-core';
 import { selectIsDeviceReadyToUse } from '@suite-native/device';
+import { Box } from '@suite-native/atoms';
 
 import { EmptyPortfolioTrackerState } from './EmptyPortfolioTrackerState';
 import { EmptyConnectedDeviceState } from './EmptyConnectedDeviceState';
@@ -26,17 +27,21 @@ export const EmptyHomeRenderer = () => {
         return null;
     }
 
+    let ScreenContent = EmptyPortfolioTrackerState;
+
     if (isUsbDeviceConnectFeatureEnabled) {
         // Crossroads should be displayed if there is no real device connected and portfolio tracker has no accounts
         // or if there is device connected, but not authorized (PIN enter cancelled).
         if (hasOnlyEmptyPortfolioTracker || !isDeviceAuthorized) {
-            return <EmptyPortfolioCrossroads />;
-        }
-
-        if (!isPortfolioTrackerDevice && isDeviceAuthorized) {
-            return <EmptyConnectedDeviceState />;
+            ScreenContent = EmptyPortfolioCrossroads;
+        } else if (!isPortfolioTrackerDevice && isDeviceAuthorized) {
+            ScreenContent = EmptyConnectedDeviceState;
         }
     }
 
-    return <EmptyPortfolioTrackerState />;
+    return (
+        <Box marginHorizontal="sp16">
+            <ScreenContent />
+        </Box>
+    );
 };

--- a/suite-native/module-home/src/screens/HomeScreen/components/EmptyPortfolioCrossroads.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/EmptyPortfolioCrossroads.tsx
@@ -22,8 +22,8 @@ const cardStyle = prepareNativeStyle<{ flex: 1 | 2 }>((utils, { flex }) => ({
     flex,
     justifyContent: 'center',
     paddingTop: utils.spacings.sp40,
-    paddingBottom: utils.spacings.sp32,
-    paddingHorizontal: utils.spacings.sp24,
+    paddingBottom: utils.spacings.sp16,
+    paddingHorizontal: utils.spacings.sp16,
 }));
 
 const buttonWrapperStyle = prepareNativeStyle(() => ({

--- a/suite-native/module-home/src/screens/HomeScreen/components/EmptyPortfolioTrackerState.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/EmptyPortfolioTrackerState.tsx
@@ -18,8 +18,8 @@ const SCREEN_HEIGHT = Dimensions.get('screen').height;
 
 const cardStyle = prepareNativeStyle(utils => ({
     paddingTop: utils.spacings.sp32,
-    paddingBottom: utils.spacings.sp24,
-    paddingVertical: utils.spacings.sp24,
+    paddingBottom: utils.spacings.sp16,
+    paddingVertical: utils.spacings.sp16,
 }));
 const imageStyle = prepareNativeStyle(_ => ({
     maxHeight: SCREEN_HEIGHT * 0.25,
@@ -55,12 +55,7 @@ export const EmptyPortfolioTrackerState = () => {
                 alertTitle={<Translation id="moduleHome.emptyState.portfolioTracker.alert" />}
                 style={applyStyle(cardStyle)}
             >
-                <VStack
-                    spacing="sp32"
-                    alignItems="center"
-                    justifyContent="center"
-                    paddingHorizontal="sp4"
-                >
+                <VStack spacing="sp32" alignItems="center" justifyContent="center">
                     <VStack
                         spacing="sp16"
                         paddingTop="sp8"


### PR DESCRIPTION
Fixes empty dashboard paddings according to [this design](https://www.figma.com/design/UdQpTfz2RhsoZzqLp9L8fU/Onboarding?node-id=1149-29977&t=LB0LjhWbllCBa4EJ-4).
