### PR TITLE
chore(trade): move API to the suite-common

### DIFF
--- a/packages/suite-desktop-core/e2e/support/pageActions/marketActions.ts
+++ b/packages/suite-desktop-core/e2e/support/pageActions/marketActions.ts
@@ -2,8 +2,8 @@ import { Locator, Page } from '@playwright/test';
 
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 import { FiatCurrencyCode } from '@suite-common/suite-config';
-import regional from '@trezor/suite/src/constants/wallet/coinmarket/regional';
 import { NetworkSymbol } from '@suite-common/wallet-config';
+import { regional } from '@suite-common/invity';
 
 import { expect } from '../customMatchers';
 import { step } from '../common';

--- a/packages/suite/src/actions/wallet/__tests__/coinmarketBuyActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/coinmarketBuyActions.test.ts
@@ -1,8 +1,9 @@
 import { BuyTrade, BuyTradeQuoteRequest, CryptoId } from 'invity-api';
 
+import { invityAPI } from '@suite-common/invity';
+
 import { configureStore } from 'src/support/tests/configureStore';
 import { coinmarketReducer } from 'src/reducers/wallet/coinmarketReducer';
-import invityAPI from 'src/services/suite/invityAPI';
 
 import * as coinmarketBuyActions from '../coinmarketBuyActions';
 

--- a/packages/suite/src/actions/wallet/__tests__/coinmarketExchangeActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/coinmarketExchangeActions.test.ts
@@ -1,8 +1,9 @@
 import { CryptoId, ExchangeTrade, ExchangeTradeQuoteRequest } from 'invity-api';
 
+import { invityAPI } from '@suite-common/invity';
+
 import { configureStore } from 'src/support/tests/configureStore';
 import { coinmarketReducer } from 'src/reducers/wallet/coinmarketReducer';
-import invityAPI from 'src/services/suite/invityAPI';
 
 import * as coinmarketExchangeActions from '../coinmarketExchangeActions';
 

--- a/packages/suite/src/actions/wallet/coinmarketBuyActions.ts
+++ b/packages/suite/src/actions/wallet/coinmarketBuyActions.ts
@@ -7,8 +7,9 @@ import {
     FiatCurrencyCode,
 } from 'invity-api';
 
+import { invityAPI } from '@suite-common/invity';
+
 import { Account } from 'src/types/wallet';
-import invityAPI from 'src/services/suite/invityAPI';
 import { Dispatch } from 'src/types/suite';
 import regional from 'src/constants/wallet/coinmarket/regional';
 import * as modalActions from 'src/actions/suite/modalActions';

--- a/packages/suite/src/actions/wallet/coinmarketBuyActions.ts
+++ b/packages/suite/src/actions/wallet/coinmarketBuyActions.ts
@@ -7,11 +7,10 @@ import {
     FiatCurrencyCode,
 } from 'invity-api';
 
-import { invityAPI } from '@suite-common/invity';
+import { invityAPI, regional } from '@suite-common/invity';
 
 import { Account } from 'src/types/wallet';
 import { Dispatch } from 'src/types/suite';
-import regional from 'src/constants/wallet/coinmarket/regional';
 import * as modalActions from 'src/actions/suite/modalActions';
 import { verifyAddress as verifyBuyAddress } from 'src/actions/wallet/coinmarket/coinmarketCommonActions';
 import { CoinmarketFiatCurrenciesProps } from 'src/types/coinmarket/coinmarket';
@@ -68,7 +67,7 @@ export const loadBuyInfo = async (): Promise<BuyInfo> => {
     if (!buyInfo || !buyInfo.providers) {
         return {
             buyInfo: {
-                country: regional.unknownCountry,
+                country: regional.UNKNOWN_COUNTRY,
                 providers: [],
                 defaultAmountsOfFiatCurrencies,
             },

--- a/packages/suite/src/actions/wallet/coinmarketExchangeActions.ts
+++ b/packages/suite/src/actions/wallet/coinmarketExchangeActions.ts
@@ -6,9 +6,10 @@ import {
     CryptoId,
 } from 'invity-api';
 
+import { invityAPI } from '@suite-common/invity';
+
 import { Account } from 'src/types/wallet';
 import { Dispatch } from 'src/types/suite';
-import invityAPI from 'src/services/suite/invityAPI';
 import * as modalActions from 'src/actions/suite/modalActions';
 import { verifyAddress as verifyExchangeAddress } from 'src/actions/wallet/coinmarket/coinmarketCommonActions';
 

--- a/packages/suite/src/actions/wallet/coinmarketSellActions.ts
+++ b/packages/suite/src/actions/wallet/coinmarketSellActions.ts
@@ -6,10 +6,11 @@ import {
     SellProviderInfo,
 } from 'invity-api';
 
+import { invityAPI } from '@suite-common/invity';
+
 import { Account } from 'src/types/wallet';
 import { Dispatch } from 'src/types/suite';
 import * as modalActions from 'src/actions/suite/modalActions';
-import invityAPI from 'src/services/suite/invityAPI';
 
 import { COINMARKET_COMMON, COINMARKET_SELL } from './constants';
 

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketBuyForm.tsx
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketBuyForm.tsx
@@ -10,9 +10,9 @@ import { notificationsActions } from '@suite-common/toast-notifications';
 import { isDesktop } from '@trezor/env-utils';
 import { networks } from '@suite-common/wallet-config';
 import { analytics, EventType } from '@trezor/suite-analytics';
+import { invityAPI } from '@suite-common/invity';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import invityAPI from 'src/services/suite/invityAPI';
 import {
     createQuoteLink,
     createTxLink,

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeForm.ts
@@ -15,9 +15,9 @@ import { Account } from '@suite-common/wallet-types';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { networks } from '@suite-common/wallet-config';
 import { analytics, EventType } from '@trezor/suite-analytics';
+import { invityAPI } from '@suite-common/invity';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import invityAPI from 'src/services/suite/invityAPI';
 import { saveQuoteRequest, saveQuotes } from 'src/actions/wallet/coinmarketExchangeActions';
 import {
     addIdsToQuotes,

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeWatchSendApproval.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeWatchSendApproval.ts
@@ -3,7 +3,8 @@ import { useTimeoutFn, useUnmount } from 'react-use';
 
 import { ExchangeTrade } from 'invity-api';
 
-import invityAPI from 'src/services/suite/invityAPI';
+import { invityAPI } from '@suite-common/invity';
+
 import { CoinmarketTradeExchangeType } from 'src/types/coinmarket/coinmarket';
 import { useDispatch } from 'src/hooks/suite';
 import { saveSelectedQuote } from 'src/actions/wallet/coinmarketExchangeActions';

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSellForm.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSellForm.ts
@@ -9,9 +9,9 @@ import { isChanged } from '@suite-common/suite-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { networks } from '@suite-common/wallet-config';
 import { analytics, EventType } from '@trezor/suite-analytics';
+import { invityAPI } from '@suite-common/invity';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import invityAPI from 'src/services/suite/invityAPI';
 import {
     addIdsToQuotes,
     coinmarketGetSuccessQuotes,

--- a/packages/suite/src/hooks/wallet/coinmarket/useCoinmarketWatchTrade.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/useCoinmarketWatchTrade.ts
@@ -11,8 +11,9 @@ import {
     WatchSellTradeResponse,
 } from 'invity-api';
 
+import { invityAPI } from '@suite-common/invity';
+
 import { Trade, TradeType } from 'src/types/wallet/coinmarketCommonTypes';
-import invityAPI from 'src/services/suite/invityAPI';
 import { saveTrade as saveBuyTrade } from 'src/actions/wallet/coinmarketBuyActions';
 import { saveTrade as saveExchangeTrade } from 'src/actions/wallet/coinmarketExchangeActions';
 import { saveTrade as saveSellTrade } from 'src/actions/wallet/coinmarketSellActions';

--- a/packages/suite/src/hooks/wallet/coinmarket/useServerEnviroment.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/useServerEnviroment.ts
@@ -1,5 +1,6 @@
+import { invityAPI } from '@suite-common/invity';
+
 import { useSelector } from 'src/hooks/suite';
-import invityAPI from 'src/services/suite/invityAPI';
 
 export const useServerEnvironment = () => {
     const invityServerEnvironment = useSelector(

--- a/packages/suite/src/middlewares/wallet/__tests__/coinmarketMiddleware.test.ts
+++ b/packages/suite/src/middlewares/wallet/__tests__/coinmarketMiddleware.test.ts
@@ -1,4 +1,5 @@
 import { UI } from '@trezor/connect';
+import { invityAPI } from '@suite-common/invity';
 
 import { configureStore } from 'src/support/tests/configureStore';
 import { coinmarketReducer, initialState } from 'src/reducers/wallet/coinmarketReducer';
@@ -6,14 +7,13 @@ import selectedAccountReducer from 'src/reducers/wallet/selectedAccountReducer';
 import { coinmarketMiddleware } from 'src/middlewares/wallet/coinmarketMiddleware';
 import { Action } from 'src/types/suite';
 import { COINMARKET_COMMON } from 'src/actions/wallet/constants';
-import invityAPI from 'src/services/suite/invityAPI';
 import suiteReducer from 'src/reducers/suite/suiteReducer';
 import { accounts } from 'src/reducers/wallet/__fixtures__/transactionConstants';
 import routerReducer, { RouterState } from 'src/reducers/suite/routerReducer';
 import modalReducer, { State as ModalState } from 'src/reducers/suite/modalReducer';
 import { MODAL, ROUTER } from 'src/actions/suite/constants';
 
-jest.mock('src/services/suite/invityAPI');
+jest.mock('@suite-common/invity');
 invityAPI.setInvityServersEnvironment = () => {};
 invityAPI.createInvityAPIKey = () => {};
 invityAPI.getInfo = () =>

--- a/packages/suite/src/middlewares/wallet/coinmarketMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/coinmarketMiddleware.ts
@@ -2,6 +2,7 @@ import { MiddlewareAPI } from 'redux';
 
 import { UI } from '@trezor/connect';
 import { accountsActions } from '@suite-common/wallet-core';
+import { invityAPI } from '@suite-common/invity';
 
 import { AppState, Action, Dispatch } from 'src/types/suite';
 import {
@@ -10,7 +11,6 @@ import {
     COINMARKET_SELL,
 } from 'src/actions/wallet/constants';
 import { INVITY_API_RELOAD_DATA_AFTER_MS } from 'src/constants/wallet/coinmarket/metadata';
-import invityAPI from 'src/services/suite/invityAPI';
 import * as coinmarketCommonActions from 'src/actions/wallet/coinmarket/coinmarketCommonActions';
 import * as coinmarketInfoAction from 'src/actions/wallet/coinmarketInfoActions';
 import * as coinmarketBuyActions from 'src/actions/wallet/coinmarketBuyActions';

--- a/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
@@ -21,9 +21,9 @@ import {
     sortByCoin,
 } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
+import { regional } from '@suite-common/invity';
 
 import { Account } from 'src/types/wallet';
-import regional from 'src/constants/wallet/coinmarket/regional';
 import { ExtendedMessageDescriptor, Route, TrezorDevice } from 'src/types/suite';
 import {
     CoinmarketAccountOptionsGroupOptionProps,
@@ -253,13 +253,13 @@ export const coinmarketGetSuccessQuotes = <T extends CoinmarketTradeType>(
     quotes: CoinmarketTradeDetailMapProps[T][] | undefined,
 ) => (quotes ? quotes.filter(quote => quote.error === undefined) : undefined);
 
-export const getDefaultCountry = (country: string = regional.unknownCountry) => {
+export const getDefaultCountry = (country: string = regional.UNKNOWN_COUNTRY) => {
     const label = regional.countriesMap.get(country);
 
     if (!label)
         return {
-            label: regional.countriesMap.get(regional.unknownCountry)!,
-            value: regional.unknownCountry,
+            label: regional.countriesMap.get(regional.UNKNOWN_COUNTRY)!,
+            value: regional.UNKNOWN_COUNTRY,
         };
 
     return {

--- a/packages/suite/src/views/settings/SettingsDebug/InvityApi.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/InvityApi.tsx
@@ -1,12 +1,12 @@
 import styled from 'styled-components';
 
 import type { InvityServerEnvironment } from '@suite-common/invity';
+import { invityAPI } from '@suite-common/invity';
 
 import { SettingsSectionItem } from 'src/components/settings';
 import { ActionColumn, ActionSelect, TextColumn } from 'src/components/suite';
 import { setDebugMode } from 'src/actions/suite/suiteActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import invityAPI from 'src/services/suite/invityAPI';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { reloadApp } from 'src/utils/suite/reload';
 
@@ -18,7 +18,7 @@ export const InvityApi = () => {
     const debug = useSelector(state => state.suite.settings.debug);
     const dispatch = useDispatch();
 
-    const invityApiServerOptions = Object.entries(invityAPI.servers).map(
+    const invityApiServerOptions = Object.entries(invityAPI.SERVERS).map(
         ([environment, server]) => ({
             label: server,
             value: environment as InvityServerEnvironment,

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketDetail/CoinmarketDetailBuy/CoinmarketDetailBuyPaymentWaitingForUser.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketDetail/CoinmarketDetailBuy/CoinmarketDetailBuyPaymentWaitingForUser.tsx
@@ -5,10 +5,10 @@ import { BuyTrade, BuyTradeStatus } from 'invity-api';
 
 import { Button, variables, Image } from '@trezor/components';
 import { spacings } from '@trezor/theme';
+import { invityAPI } from '@suite-common/invity';
 
 import { Translation } from 'src/components/suite/Translation';
 import { Account } from 'src/types/wallet';
-import invityAPI from 'src/services/suite/invityAPI';
 import { createTxLink } from 'src/utils/wallet/coinmarket/buyUtils';
 import { submitRequestForm } from 'src/actions/wallet/coinmarket/coinmarketCommonActions';
 import { useDispatch } from 'src/hooks/suite';

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputCountry.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputCountry.tsx
@@ -2,8 +2,8 @@ import { Control, Controller } from 'react-hook-form';
 
 import { Flag, Select, Row } from '@trezor/components';
 import { spacings } from '@trezor/theme';
+import { regional } from '@suite-common/invity';
 
-import regional from 'src/constants/wallet/coinmarket/regional';
 import { CountryOption } from 'src/types/wallet/coinmarketCommonTypes';
 import { getCountryLabelParts } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import { useCoinmarketFormContext } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonForm';

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketPaymentType.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketPaymentType.tsx
@@ -1,7 +1,7 @@
 import { Row } from '@trezor/components';
 import { spacings } from '@trezor/theme';
+import { invityAPI } from '@suite-common/invity';
 
-import invityAPI from 'src/services/suite/invityAPI';
 import { CoinmarketPaymentPlainType } from 'src/views/wallet/coinmarket/common/CoinmarketPaymentPlainType';
 import { CoinmarketPaymentMethodType } from 'src/types/coinmarket/coinmarket';
 import { CoinmarketIcon } from 'src/views/wallet/coinmarket/common/CoinmarketIcon';

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketProviderInfo.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketProviderInfo.tsx
@@ -1,8 +1,8 @@
 import { Row, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
+import { invityAPI } from '@suite-common/invity';
 
 import { Translation } from 'src/components/suite';
-import invityAPI from 'src/services/suite/invityAPI';
 import { CoinmarketIcon } from 'src/views/wallet/coinmarket/common/CoinmarketIcon';
 
 export interface CoinmarketProviderInfoProps {

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketUtils/CoinmarketUtilsProvider.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketUtils/CoinmarketUtilsProvider.tsx
@@ -2,9 +2,9 @@ import styled from 'styled-components';
 
 import { spacings } from '@trezor/theme';
 import { Row } from '@trezor/components';
+import { invityAPI } from '@suite-common/invity';
 
 import { Translation } from 'src/components/suite';
-import invityAPI from 'src/services/suite/invityAPI';
 import { CoinmarketUtilsProvidersProps } from 'src/types/coinmarket/coinmarket';
 
 const Icon = styled.img`

--- a/suite-common/invity/package.json
+++ b/suite-common/invity/package.json
@@ -10,7 +10,8 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
-        "@trezor/env-utils": "workspace:*"
+        "@trezor/env-utils": "workspace:*",
+        "@trezor/utils": "workspace:*"
     },
     "devDependencies": {
         "@types/invity-api": "^1.1.2"

--- a/suite-common/invity/package.json
+++ b/suite-common/invity/package.json
@@ -8,5 +8,11 @@
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build"
+    },
+    "dependencies": {
+        "@trezor/env-utils": "workspace:*"
+    },
+    "devDependencies": {
+        "@types/invity-api": "^1.1.2"
     }
 }

--- a/suite-common/invity/src/index.ts
+++ b/suite-common/invity/src/index.ts
@@ -1,2 +1,3 @@
 export * from './types';
 export * from './invityAPI';
+export * from './regional';

--- a/suite-common/invity/src/index.ts
+++ b/suite-common/invity/src/index.ts
@@ -1,1 +1,2 @@
 export * from './types';
+export * from './invityAPI';

--- a/suite-common/invity/src/invityAPI.ts
+++ b/suite-common/invity/src/invityAPI.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto';
-import {
+import type {
     ExchangeListResponse,
     ExchangeTradeQuoteResponse,
     ExchangeTradeQuoteRequest,
@@ -24,15 +24,15 @@ import {
     InfoResponse,
 } from 'invity-api';
 
+import type {
+    InvityServerEnvironment,
+    InvityServers,
+    TradingTradeType,
+    TradingPaymentMethodType,
+    TradingType,
+    TradingWatchTradeResponsePropsMap,
+} from '@suite-common/invity';
 import { getSuiteVersion, isDesktop } from '@trezor/env-utils';
-import type { InvityServerEnvironment, InvityServers } from '@suite-common/invity';
-
-import {
-    CoinmarketPaymentMethodType,
-    CoinmarketTradeDetailType,
-    CoinmarketTradeType,
-    CoinmarketWatchTradeResponseMapProps,
-} from 'src/types/coinmarket/coinmarket';
 
 type BodyType =
     | BuyTrade
@@ -48,41 +48,41 @@ type BodyType =
 type SignalType = AbortSignal | null | undefined;
 
 class InvityAPI {
-    unknownCountry = 'unknown';
+    private readonly UNKNOWN_COUNTRY = 'unknown';
 
-    servers = {
+    readonly SERVERS: InvityServers = {
         production: 'https://exchange.trezor.io',
         staging: 'https://staging-exchange.invity.io',
         dev: 'https://dev-exchange.invity.io',
         localhost: 'http://localhost:3330',
-    } as InvityServers;
+    };
 
-    private serverEnvironment = 'production' as InvityServerEnvironment;
+    private serverEnvironment: InvityServerEnvironment = 'production';
 
     // info service
-    private INFO = '/api/info';
-    private DETECT_COUNTRY_INFO = '/api/info/country';
-    private GET_COUNTRY_INFO = '/api/info/country/{{country}}';
+    private readonly INFO = '/api/info';
+    private readonly DETECT_COUNTRY_INFO = '/api/info/country';
+    private readonly GET_COUNTRY_INFO = '/api/info/country/{{country}}';
 
     // exchange service
-    private EXCHANGE_LIST = '/api/v3/exchange/list';
-    private EXCHANGE_QUOTES = '/api/v3/exchange/quotes';
-    private EXCHANGE_DO_TRADE = '/api/v3/exchange/trade';
-    private EXCHANGE_WATCH_TRADE = '/api/v3/exchange/watch/{{counter}}';
+    private readonly EXCHANGE_LIST = '/api/v3/exchange/list';
+    private readonly EXCHANGE_QUOTES = '/api/v3/exchange/quotes';
+    private readonly EXCHANGE_DO_TRADE = '/api/v3/exchange/trade';
+    private readonly EXCHANGE_WATCH_TRADE = '/api/v3/exchange/watch/{{counter}}';
 
     // buy service
-    private BUY_LIST = '/api/v3/buy/list';
-    private BUY_QUOTES = '/api/v3/buy/quotes';
-    private BUY_DO_TRADE = '/api/v3/buy/trade';
-    private BUY_GET_TRADE_FORM = '/api/v3/buy/tradeform';
-    private BUY_WATCH_TRADE = '/api/v3/buy/watch/{{counter}}';
+    private readonly BUY_LIST = '/api/v3/buy/list';
+    private readonly BUY_QUOTES = '/api/v3/buy/quotes';
+    private readonly BUY_DO_TRADE = '/api/v3/buy/trade';
+    private readonly BUY_GET_TRADE_FORM = '/api/v3/buy/tradeform';
+    private readonly BUY_WATCH_TRADE = '/api/v3/buy/watch/{{counter}}';
 
     // sell service
-    private SELL_LIST = '/api/v3/sell/list';
-    private SELL_FIAT_QUOTES = '/api/v3/sell/fiat/quotes';
-    private SELL_FIAT_DO_TRADE = '/api/v3/sell/fiat/trade';
-    private SELL_FIAT_CONFIRM = '/api/v3/sell/fiat/confirm';
-    private SELL_FIAT_WATCH_TRADE = '/api/v3/sell/fiat/watch/{{counter}}';
+    private readonly SELL_LIST = '/api/v3/sell/list';
+    private readonly SELL_FIAT_QUOTES = '/api/v3/sell/fiat/quotes';
+    private readonly SELL_FIAT_DO_TRADE = '/api/v3/sell/fiat/trade';
+    private readonly SELL_FIAT_CONFIRM = '/api/v3/sell/fiat/confirm';
+    private readonly SELL_FIAT_WATCH_TRADE = '/api/v3/sell/fiat/watch/{{counter}}';
 
     private static accountDescriptor: string;
     private static apiKey: string;
@@ -96,7 +96,7 @@ class InvityAPI {
     }
 
     getApiServerUrl() {
-        return this.servers[this.serverEnvironment];
+        return this.SERVERS[this.serverEnvironment];
     }
 
     getCurrentAccountDescriptor() {
@@ -175,17 +175,17 @@ class InvityAPI {
     fetchCountryInfo = async (country: string): Promise<CountryInfo> => {
         try {
             const url =
-                country && country !== this.unknownCountry
+                country && country !== this.UNKNOWN_COUNTRY
                     ? this.GET_COUNTRY_INFO.replace('{{country}}', country)
                     : this.DETECT_COUNTRY_INFO;
             const response: CountryInfo = await this.request(url, {}, 'GET');
 
             return response;
         } catch (error) {
-            console.log('[fetchCountryInfo]', error);
+            console.error('[fetchCountryInfo]', error);
         }
 
-        return { country: this.unknownCountry };
+        return { country: this.UNKNOWN_COUNTRY };
     };
 
     getInfo = async (): Promise<InfoResponse> => {
@@ -195,7 +195,7 @@ class InvityAPI {
                 return response;
             }
         } catch (error) {
-            console.log('[getInfo]', error);
+            console.error('[getInfo]', error);
         }
 
         return { platforms: {}, coins: {} };
@@ -210,7 +210,7 @@ class InvityAPI {
 
             return response;
         } catch (error) {
-            console.log('[getExchangeList]', error);
+            console.error('[getExchangeList]', error);
         }
 
         return [];
@@ -231,7 +231,7 @@ class InvityAPI {
 
             return response;
         } catch (error) {
-            console.log('[getExchangeQuotes]', error);
+            console.error('[getExchangeQuotes]', error);
         }
     };
 
@@ -245,7 +245,7 @@ class InvityAPI {
 
             return response;
         } catch (error) {
-            console.log('[doExchangeTrade]', error);
+            console.error('[doExchangeTrade]', error);
 
             return { error: error.toString(), exchange: tradeRequest.trade.exchange };
         }
@@ -257,7 +257,7 @@ class InvityAPI {
 
             return response;
         } catch (error) {
-            console.log('[getBuyList]', error);
+            console.error('[getBuyList]', error);
         }
     };
 
@@ -276,7 +276,7 @@ class InvityAPI {
 
             return response;
         } catch (error) {
-            console.log('[getBuyQuotes]', error);
+            console.error('[getBuyQuotes]', error);
         }
     };
 
@@ -290,7 +290,7 @@ class InvityAPI {
 
             return response;
         } catch (error) {
-            console.log('[doBuyTrade]', error);
+            console.error('[doBuyTrade]', error);
 
             return { trade: { error: error.toString(), exchange: tradeRequest.trade.exchange } };
         }
@@ -306,7 +306,7 @@ class InvityAPI {
 
             return response;
         } catch (error) {
-            console.log('[getBuyTradeForm]', error);
+            console.error('[getBuyTradeForm]', error);
 
             return { error: error.toString() };
         }
@@ -318,7 +318,7 @@ class InvityAPI {
 
             return response;
         } catch (error) {
-            console.log('[getSellList]', error);
+            console.error('[getSellList]', error);
         }
     };
 
@@ -337,7 +337,7 @@ class InvityAPI {
 
             return response;
         } catch (error) {
-            console.log('[getSellQuotes]', error);
+            console.error('[getSellQuotes]', error);
         }
     };
 
@@ -351,7 +351,7 @@ class InvityAPI {
 
             return response;
         } catch (error) {
-            console.log('[doSellTrade]', error);
+            console.error('[doSellTrade]', error);
 
             return { trade: { error: error.toString(), exchange: tradeRequest.trade.exchange } };
         }
@@ -367,7 +367,7 @@ class InvityAPI {
 
             return response;
         } catch (error) {
-            console.log('[doSellConfirm]', error);
+            console.error('[doSellConfirm]', error);
 
             return { error: error.toString(), exchange: trade.exchange };
         }
@@ -381,11 +381,11 @@ class InvityAPI {
         return `${this.getApiServerUrl()}/images/exchange/${logo}`;
     }
 
-    getPaymentMethodUrl(paymentMethod: CoinmarketPaymentMethodType): string {
+    getPaymentMethodUrl(paymentMethod: TradingPaymentMethodType): string {
         return `${this.getApiServerUrl()}/images/paymentMethods/suite/${paymentMethod}.svg`;
     }
 
-    private getWatchTradeData = (tradeType: CoinmarketTradeType) => {
+    private getWatchTradeData = (tradeType: TradingType) => {
         const tradesData = {
             exchange: {
                 url: this.EXCHANGE_WATCH_TRADE,
@@ -405,15 +405,15 @@ class InvityAPI {
         return tradesData[tradeType];
     };
 
-    watchTrade = async <T extends CoinmarketTradeType>(
-        tradeData: CoinmarketTradeDetailType,
-        tradeType: CoinmarketTradeType,
+    watchTrade = async <T extends TradingType>(
+        tradeData: TradingTradeType,
+        tradeType: TradingType,
         counter: number,
-    ): Promise<CoinmarketWatchTradeResponseMapProps[T]> => {
+    ): Promise<TradingWatchTradeResponsePropsMap[T]> => {
         const tradesData = this.getWatchTradeData(tradeType);
 
         try {
-            const response: CoinmarketWatchTradeResponseMapProps[T] = await this.request(
+            const response: TradingWatchTradeResponsePropsMap[T] = await this.request(
                 tradesData.url.replace('{{counter}}', counter.toString()),
                 tradeData,
                 'POST',
@@ -421,13 +421,11 @@ class InvityAPI {
 
             return response;
         } catch (error) {
-            console.log(tradesData.logPrefix, error);
+            console.error(tradesData.logPrefix, error);
 
             return { error: error.toString() };
         }
     };
 }
 
-const invityAPI = new InvityAPI();
-
-export default invityAPI;
+export const invityAPI = new InvityAPI();

--- a/suite-common/invity/src/invityAPI.ts
+++ b/suite-common/invity/src/invityAPI.ts
@@ -32,7 +32,7 @@ import type {
     TradingType,
     TradingWatchTradeResponsePropsMap,
 } from '@suite-common/invity';
-import { getSuiteVersion, isDesktop } from '@trezor/env-utils';
+import { getSuiteVersion, isDesktop, isNative } from '@trezor/env-utils';
 
 type BodyType =
     | BuyTrade
@@ -122,13 +122,20 @@ class InvityAPI {
         }
     }
 
+    private getOptionAPIHeader() {
+        if (isNative()) return 'X-SuiteN-Api';
+        if (isDesktop()) return 'X-SuiteA-Api';
+
+        return 'X-SuiteW-Api';
+    }
+
     private options(
         body: BodyType = {},
         method = 'POST',
         apiHeaderValue?: string,
         signal?: SignalType,
     ): any {
-        const apiHeader = isDesktop() ? 'X-SuiteA-Api' : 'X-SuiteW-Api';
+        const apiHeader = this.getOptionAPIHeader();
 
         return {
             method,

--- a/suite-common/invity/src/regional.ts
+++ b/suite-common/invity/src/regional.ts
@@ -1,10 +1,10 @@
 import { isArrayMember } from '@trezor/utils';
 
 class Regional {
-    unknownCountry = 'unknown';
+    readonly UNKNOWN_COUNTRY = 'unknown';
 
     countries: [string, string][] = [
-        [this.unknownCountry, `🌍 Worldwide`],
+        [this.UNKNOWN_COUNTRY, `🌍 Worldwide`],
         ['AD', '🇦🇩 Andorra'],
         ['AE', '🇦🇪 United Arab Emirates'],
         ['AF', '🇦🇫 Afghanistan'],
@@ -311,6 +311,4 @@ class Regional {
 
 type EEACountryCodes = (typeof regional.EEACountryCodes)[number];
 
-const regional = new Regional();
-
-export default regional;
+export const regional = new Regional();

--- a/suite-common/invity/src/types.ts
+++ b/suite-common/invity/src/types.ts
@@ -1,4 +1,29 @@
+import type {
+    BuyCryptoPaymentMethod,
+    BuyTrade,
+    ExchangeTrade,
+    SellCryptoPaymentMethod,
+    SellFiatTrade,
+    WatchBuyTradeResponse,
+    WatchExchangeTradeResponse,
+    WatchSellTradeResponse,
+} from 'invity-api';
+
 export type InvityServerEnvironment = 'production' | 'staging' | 'dev' | 'localhost';
-export type InvityServers = {
-    [key in InvityServerEnvironment]: string;
+export type InvityServers = Record<InvityServerEnvironment, string>;
+
+export type TradingBuyType = 'buy';
+export type TradingSellType = 'sell';
+export type TradingExchangeType = 'exchange';
+export type TradingType = TradingBuyType | TradingSellType | TradingExchangeType;
+
+// information about created trade
+export type TradingTradeType = BuyTrade | SellFiatTrade | ExchangeTrade;
+
+export type TradingWatchTradeResponsePropsMap = {
+    buy: WatchBuyTradeResponse;
+    sell: WatchSellTradeResponse;
+    exchange: WatchExchangeTradeResponse;
 };
+
+export type TradingPaymentMethodType = BuyCryptoPaymentMethod | SellCryptoPaymentMethod;

--- a/suite-common/invity/tsconfig.json
+++ b/suite-common/invity/tsconfig.json
@@ -1,5 +1,7 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
-    "references": []
+    "references": [
+        { "path": "../../packages/env-utils" }
+    ]
 }

--- a/suite-common/invity/tsconfig.json
+++ b/suite-common/invity/tsconfig.json
@@ -2,6 +2,7 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
-        { "path": "../../packages/env-utils" }
+        { "path": "../../packages/env-utils" },
+        { "path": "../../packages/utils" }
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9587,6 +9587,7 @@ __metadata:
   resolution: "@suite-common/invity@workspace:suite-common/invity"
   dependencies:
     "@trezor/env-utils": "workspace:*"
+    "@trezor/utils": "workspace:*"
     "@types/invity-api": "npm:^1.1.2"
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -9585,6 +9585,9 @@ __metadata:
 "@suite-common/invity@workspace:*, @suite-common/invity@workspace:suite-common/invity":
   version: 0.0.0-use.local
   resolution: "@suite-common/invity@workspace:suite-common/invity"
+  dependencies:
+    "@trezor/env-utils": "workspace:*"
+    "@types/invity-api": "npm:^1.1.2"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description
- Moving trading API to the `suite-common` package
- Creating some necessary types for API
- Prepare headers for mobile

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/16517
Resolve https://github.com/trezor/trezor-suite/issues/16546