### PR TITLE
Minor Solana fixes from Sentry

### DIFF
--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -615,12 +615,13 @@ const handleAccountNotification = async (
             });
         }
     } catch (error) {
-        console.error('Solana subscription error:', error);
         if (isSolanaError(error, SOLANA_ERROR__RPC_SUBSCRIPTIONS__CHANNEL_CONNECTION_CLOSED)) {
             // The WS was closed, we should unsubscribe
             if (account.subscriptionId) abortSubscription(account.subscriptionId);
             state.removeAccounts([account]);
             context.onNetworkDisconnect();
+        } else {
+            console.error('Solana subscription error:', error);
         }
     }
 };

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketExchangeForm.ts
@@ -60,6 +60,7 @@ import { useCoinmarketFiatValues } from 'src/hooks/wallet/coinmarket/form/common
 import type { CryptoAmountLimitProps } from 'src/utils/suite/validation';
 import { useCoinmarketExchangeQuotesFilter } from 'src/hooks/wallet/coinmarket/form/common/useCoinmarketExchangeQuotesFilter';
 import { useCoinmarketPreviousRoute } from 'src/hooks/wallet/coinmarket/form/common/useCoinmarketPreviousRoute';
+import { useSolanaSubscribeBlocks } from 'src/hooks/wallet/form/useSolanaSubscribeBlocks';
 
 import { useCoinmarketInitializer } from './common/useCoinmarketInitializer';
 
@@ -680,6 +681,9 @@ export const useCoinmarketExchangeForm = ({
             }
         };
     }, []);
+
+    // Subscribe to blocks for Solana, since they are not fetched globally
+    useSolanaSubscribeBlocks(account);
 
     return {
         type,

--- a/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSellForm.ts
+++ b/packages/suite/src/hooks/wallet/coinmarket/form/useCoinmarketSellForm.ts
@@ -56,6 +56,7 @@ import { useCoinmarketAccount } from 'src/hooks/wallet/coinmarket/form/common/us
 import { useCoinmarketInfo } from 'src/hooks/wallet/coinmarket/useCoinmarketInfo';
 import type { AmountLimitProps } from 'src/utils/suite/validation';
 import { useCoinmarketPreviousRoute } from 'src/hooks/wallet/coinmarket/form/common/useCoinmarketPreviousRoute';
+import { useSolanaSubscribeBlocks } from 'src/hooks/wallet/form/useSolanaSubscribeBlocks';
 
 import { useCoinmarketInitializer } from './common/useCoinmarketInitializer';
 
@@ -656,6 +657,9 @@ export const useCoinmarketSellForm = ({
             }
         };
     }, []);
+
+    // Subscribe to blocks for Solana, since they are not fetched globally
+    useSolanaSubscribeBlocks(account);
 
     return {
         type,

--- a/packages/suite/src/hooks/wallet/form/useSolanaSubscribeBlocks.ts
+++ b/packages/suite/src/hooks/wallet/form/useSolanaSubscribeBlocks.ts
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+
+import TrezorConnect from '@trezor/connect';
+import { Account } from '@suite-common/wallet-types';
+
+export const useSolanaSubscribeBlocks = (account: Account) => {
+    useEffect(() => {
+        if (account.networkType === 'solana') {
+            TrezorConnect.blockchainSubscribe({
+                coin: account.symbol,
+                blocks: true,
+            });
+
+            return () => {
+                TrezorConnect.blockchainUnsubscribe({
+                    coin: account.symbol,
+                    blocks: true,
+                });
+            };
+        }
+    }, [account]);
+};

--- a/packages/suite/src/hooks/wallet/useSendFormCompose.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormCompose.ts
@@ -15,7 +15,7 @@ import {
 import { useDebounce } from '@trezor/react-utils';
 import { isChanged } from '@suite-common/suite-utils';
 import { findComposeErrors } from '@suite-common/wallet-utils';
-import TrezorConnect, { FeeLevel } from '@trezor/connect';
+import { FeeLevel } from '@trezor/connect';
 import { COMPOSE_ERROR_TYPES } from '@suite-common/wallet-constants';
 import { composeSendFormTransactionFeeLevelsThunk } from '@suite-common/wallet-core';
 
@@ -23,6 +23,7 @@ import { TranslationKey } from 'src/components/suite/Translation';
 import { SendContextValues, UseSendFormState } from 'src/types/wallet/sendForm';
 
 import { useTranslation } from '../suite';
+import { useSolanaSubscribeBlocks } from './form/useSolanaSubscribeBlocks';
 
 type Props = UseFormReturn<FormState> & {
     state: UseSendFormState;
@@ -344,22 +345,8 @@ export const useSendFormCompose = ({
         setLoading,
     ]);
 
-    useEffect(() => {
-        // Subscribe to blocks for Solana, since they are not fetched globally
-        if (state.account.networkType === 'solana') {
-            TrezorConnect.blockchainSubscribe({
-                coin: state.account.symbol,
-                blocks: true,
-            });
-
-            return () => {
-                TrezorConnect.blockchainUnsubscribe({
-                    coin: state.account.symbol,
-                    blocks: true,
-                });
-            };
-        }
-    }, [state.account]);
+    // Subscribe to blocks for Solana, since they are not fetched globally
+    useSolanaSubscribeBlocks(state.account);
 
     return {
         composeDraft,

--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -474,13 +474,13 @@ export const selectIsDeviceNotEmpty = createMemoizedSelector(
 );
 
 export const selectSolStakingAccounts = createMemoizedSelector([selectAccountByKey], account => {
-    if (!account || account.networkType !== 'solana') return null;
+    if (!account?.misc || account.networkType !== 'solana') return null;
 
     return account.misc.solStakingAccounts ?? [];
 });
 
 export const selectSolAccountHasStaked = createMemoizedSelector([selectAccountByKey], account => {
-    if (!account || account.networkType !== 'solana') return false;
+    if (!account?.misc || account.networkType !== 'solana') return false;
 
     return !!account.misc.solStakingAccounts?.length;
 });

--- a/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
@@ -226,7 +226,7 @@ export const composeSolanaTransactionFeeLevelsThunk = createThunk<
                 output,
                 level,
                 decimals,
-                account.misc.rent ?? 0,
+                account.misc?.rent ?? 0,
                 tokenInfo,
             ),
         );

--- a/suite-common/wallet-types/src/account.ts
+++ b/suite-common/wallet-types/src/account.ts
@@ -68,7 +68,7 @@ type AccountNetworkSpecific =
       }
     | {
           networkType: 'solana';
-          misc: {
+          misc?: {
               rent?: number;
               solStakingAccounts?: SolanaStakingAccount[];
               solEpoch?: number;

--- a/suite-common/wallet-utils/src/solanaStakingUtils.ts
+++ b/suite-common/wallet-utils/src/solanaStakingUtils.ts
@@ -71,7 +71,7 @@ export const calculateTotalSolStakingBalance = (stakingAccounts: SolanaStakingAc
 };
 
 export const getSolAccountTotalStakingBalance = (account: Account) => {
-    if (!account || account.networkType !== 'solana') {
+    if (!account?.misc || account.networkType !== 'solana') {
         return null;
     }
 
@@ -112,7 +112,7 @@ interface StakingAccountWithStatus extends SolDelegation {
 export const getSolanaStakingAccountsWithStatus = (
     account: Account,
 ): StakingAccountWithStatus[] | null => {
-    if (account.networkType !== 'solana') return null;
+    if (!account.misc || account.networkType !== 'solana') return null;
 
     const { solStakingAccounts, solEpoch } = account.misc;
     if (!solStakingAccounts?.length || !solEpoch) return null;


### PR DESCRIPTION
## Description

Multiple fixes for Solana issues from Sentry.

1. Subscribe to Solana blocks in coinmarket form (resolves #16534)

2. Solana account.misc may be undefined - when still loading or on backend issues (resolves #16538, resolves #16537)

3. Don't log error when solana RPC channel closed (resolves #16539)