### PR TITLE
fix(suite): eth failed tx heading

### DIFF
--- a/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
@@ -84,7 +84,7 @@ const getSolTransactionStakeTypeName = (stakeType: StakeType) => {
 export const TransactionHeader = ({ transaction, isPending }: TransactionHeaderProps) => {
     const { translationString } = useTranslation();
 
-    if (transaction?.ethereumSpecific?.parsedData?.name) {
+    if (transaction?.ethereumSpecific?.parsedData?.name && transaction.type !== 'failed') {
         return (
             <Row gap={spacings.xxs} overflow="hidden">
                 <span>{transaction.ethereumSpecific.parsedData.name}</span>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- do not use ETH tx name when tx fails 

## Screenshots:
Before
![Screenshot 2025-01-23 at 14 01 59](https://github.com/user-attachments/assets/a232a24d-a8c2-4a1f-a10d-0ca5f69c7c07)

Now
![Screenshot 2025-01-23 at 14 00 41](https://github.com/user-attachments/assets/925f7c3b-98a6-4c97-b601-54326a377d59)
