### PR TITLE
chore(trading): move regional to suite-common

### DIFF
--- a/packages/suite-desktop-core/e2e/support/pageActions/marketActions.ts
+++ b/packages/suite-desktop-core/e2e/support/pageActions/marketActions.ts
@@ -2,8 +2,8 @@ import { Locator, Page, expect } from '@playwright/test';
 
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 import { FiatCurrencyCode } from '@suite-common/suite-config';
-import regional from '@trezor/suite/src/constants/wallet/coinmarket/regional';
 import { NetworkSymbol } from '@suite-common/wallet-config';
+import { regional } from '@suite-common/invity';
 
 import { step } from '../common';
 import { invityResponses } from '../../fixtures/invity/index';

--- a/packages/suite/src/actions/wallet/coinmarketBuyActions.ts
+++ b/packages/suite/src/actions/wallet/coinmarketBuyActions.ts
@@ -7,11 +7,10 @@ import {
     FiatCurrencyCode,
 } from 'invity-api';
 
-import { invityAPI } from '@suite-common/invity';
+import { invityAPI, regional } from '@suite-common/invity';
 
 import { Account } from 'src/types/wallet';
 import { Dispatch } from 'src/types/suite';
-import regional from 'src/constants/wallet/coinmarket/regional';
 import * as modalActions from 'src/actions/suite/modalActions';
 import { verifyAddress as verifyBuyAddress } from 'src/actions/wallet/coinmarket/coinmarketCommonActions';
 import { CoinmarketFiatCurrenciesProps } from 'src/types/coinmarket/coinmarket';
@@ -68,7 +67,7 @@ export const loadBuyInfo = async (): Promise<BuyInfo> => {
     if (!buyInfo || !buyInfo.providers) {
         return {
             buyInfo: {
-                country: regional.unknownCountry,
+                country: regional.UNKNOWN_COUNTRY,
                 providers: [],
                 defaultAmountsOfFiatCurrencies,
             },

--- a/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
@@ -21,9 +21,9 @@ import {
     sortByCoin,
 } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
+import { regional } from '@suite-common/invity';
 
 import { Account } from 'src/types/wallet';
-import regional from 'src/constants/wallet/coinmarket/regional';
 import { ExtendedMessageDescriptor, TrezorDevice } from 'src/types/suite';
 import {
     CoinmarketAccountOptionsGroupOptionProps,
@@ -253,13 +253,13 @@ export const coinmarketGetSuccessQuotes = <T extends CoinmarketTradeType>(
     quotes: CoinmarketTradeDetailMapProps[T][] | undefined,
 ) => (quotes ? quotes.filter(quote => quote.error === undefined) : undefined);
 
-export const getDefaultCountry = (country: string = regional.unknownCountry) => {
+export const getDefaultCountry = (country: string = regional.UNKNOWN_COUNTRY) => {
     const label = regional.countriesMap.get(country);
 
     if (!label)
         return {
-            label: regional.countriesMap.get(regional.unknownCountry)!,
-            value: regional.unknownCountry,
+            label: regional.countriesMap.get(regional.UNKNOWN_COUNTRY)!,
+            value: regional.UNKNOWN_COUNTRY,
         };
 
     return {

--- a/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputCountry.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/CoinmarketForm/CoinmarketFormInput/CoinmarketFormInputCountry.tsx
@@ -2,8 +2,8 @@ import { Control, Controller } from 'react-hook-form';
 
 import { Flag, Select, Row } from '@trezor/components';
 import { spacings } from '@trezor/theme';
+import { regional } from '@suite-common/invity';
 
-import regional from 'src/constants/wallet/coinmarket/regional';
 import { CountryOption } from 'src/types/wallet/coinmarketCommonTypes';
 import { getCountryLabelParts } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import { useCoinmarketFormContext } from 'src/hooks/wallet/coinmarket/form/useCoinmarketCommonForm';

--- a/suite-common/invity/package.json
+++ b/suite-common/invity/package.json
@@ -10,7 +10,8 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
-        "@trezor/env-utils": "workspace:*"
+        "@trezor/env-utils": "workspace:*",
+        "@trezor/utils": "workspace:*"
     },
     "devDependencies": {
         "@types/invity-api": "^1.1.2"

--- a/suite-common/invity/src/index.ts
+++ b/suite-common/invity/src/index.ts
@@ -1,2 +1,3 @@
 export * from './types';
 export * from './invityAPI';
+export * from './regional';

--- a/suite-common/invity/src/regional.ts
+++ b/suite-common/invity/src/regional.ts
@@ -1,10 +1,10 @@
 import { isArrayMember } from '@trezor/utils';
 
 class Regional {
-    unknownCountry = 'unknown';
+    readonly UNKNOWN_COUNTRY = 'unknown';
 
     countries: [string, string][] = [
-        [this.unknownCountry, `🌍 Worldwide`],
+        [this.UNKNOWN_COUNTRY, `🌍 Worldwide`],
         ['AD', '🇦🇩 Andorra'],
         ['AE', '🇦🇪 United Arab Emirates'],
         ['AF', '🇦🇫 Afghanistan'],
@@ -311,6 +311,4 @@ class Regional {
 
 type EEACountryCodes = (typeof regional.EEACountryCodes)[number];
 
-const regional = new Regional();
-
-export default regional;
+export const regional = new Regional();

--- a/suite-common/invity/tsconfig.json
+++ b/suite-common/invity/tsconfig.json
@@ -2,6 +2,7 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
-        { "path": "../../packages/env-utils" }
+        { "path": "../../packages/env-utils" },
+        { "path": "../../packages/utils" }
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9587,6 +9587,7 @@ __metadata:
   resolution: "@suite-common/invity@workspace:suite-common/invity"
   dependencies:
     "@trezor/env-utils": "workspace:*"
+    "@trezor/utils": "workspace:*"
     "@types/invity-api": "npm:^1.1.2"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION

## Description

Moved the `Regional` class used for a list of countries to `suite-common`

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/16546
Based on https://github.com/trezor/trezor-suite/pull/16545 (in progress)
