### PR TITLE
chore(monorepo): update deps responsibilities

### DIFF
--- a/scripts/list-outdated-dependencies/connect-dependencies.txt
+++ b/scripts/list-outdated-dependencies/connect-dependencies.txt
@@ -8,12 +8,6 @@ postcss
 postcss-cli
 postcss-import
 postcss-lightningcss
-postcss-loader
-postcss-modules-extract-imports
-postcss-modules-local-by-default
-postcss-modules-scope
-postcss-modules-values
-postcss-styled-syntax
 @tailwindcss/nesting
 @codemirror/state
 @sentry/browser

--- a/scripts/list-outdated-dependencies/usability-dependencies.txt
+++ b/scripts/list-outdated-dependencies/usability-dependencies.txt
@@ -15,6 +15,12 @@
 @types/react-qr-reader
 @types/ua-parser-js
 autoprefixer
+postcss-loader
+postcss-modules-extract-imports
+postcss-modules-local-by-default
+postcss-modules-scope
+postcss-modules-values
+postcss-styled-syntax
 babel-plugin-styled-components
 css-in-js-utils
 css-loader


### PR DESCRIPTION
I tried to remove these but it turned out that they are somehow used, see #16548
These libs don't have anything in common with connect team so I suggest shifting them to another team. 