### PR TITLE
Fix(suite): FW hash check Sentry reporting

### DIFF
--- a/packages/suite/src/components/suite/SecurityCheck/useReportDeviceCompromised.ts
+++ b/packages/suite/src/components/suite/SecurityCheck/useReportDeviceCompromised.ts
@@ -10,20 +10,35 @@ import { hashCheckErrorScenarios } from 'src/constants/suite/firmware';
 
 export const reportCheckFail = (
     checkType: 'Firmware revision' | 'Firmware hash' | 'Entropy',
-    contextData: any,
-) =>
+    contextData: Record<string, any>,
+    errorPayload?: unknown,
+) => {
+    const payloadLabel = `${checkType} check failed!`;
+    console.warn(payloadLabel, contextData, errorPayload);
+
     withSentryScope(scope => {
         scope.setLevel('error');
         scope.setTag('deviceAuthenticityError', `firmware ${checkType} check failed`);
-        captureSentryMessage(`${checkType} check failed! ${JSON.stringify(contextData)}`, scope);
+        scope.setExtra('errorPayload', errorPayload);
+        captureSentryMessage(`${payloadLabel} ${JSON.stringify(contextData)}`, scope);
     });
+};
 
-const reportCheckWarning = (checkType: 'Firmware revision' | 'Firmware hash', contextData: any) =>
+const reportCheckWarning = (
+    checkType: 'Firmware revision' | 'Firmware hash',
+    contextData: Record<string, any>,
+    warningPayload?: unknown,
+) => {
+    const payloadLabel = `${checkType} check warning!`;
+    console.warn(payloadLabel, contextData, warningPayload);
+
     withSentryScope(scope => {
         scope.setLevel('warning');
         scope.setTag('deviceAuthenticityError', `firmware ${checkType} check warning`);
-        captureSentryMessage(`${checkType} check warning! ${JSON.stringify(contextData)}`, scope);
+        scope.setExtra('warningPayload', warningPayload);
+        captureSentryMessage(`${payloadLabel} ${JSON.stringify(contextData)}`, scope);
     });
+};
 
 const useCommonData = () => {
     const { device } = useDevice();
@@ -40,13 +55,13 @@ const useCommonData = () => {
 
 const useReportRevisionCheck = () => {
     const commonData = useCommonData();
-    const revisionCheckError = useSelector(selectFirmwareRevisionCheckError);
+    const errorType = useSelector(selectFirmwareRevisionCheckError);
 
     useEffect(() => {
-        if (revisionCheckError !== null) {
-            reportCheckFail('Firmware revision', { ...commonData, revisionCheckError });
+        if (errorType !== null) {
+            reportCheckFail('Firmware revision', { ...commonData, errorType });
         }
-    }, [commonData, revisionCheckError]);
+    }, [commonData, errorType]);
 };
 
 const useReportHashCheck = () => {
@@ -55,28 +70,29 @@ const useReportHashCheck = () => {
 
     // `errorPayload` must also be extracted, which is why `selectFirmwareHashCheckError` would be impractical
     const hashCheck = isDeviceAcquired(device) ? device.authenticityChecks?.firmwareHash : null;
-    const isHashCheckError = hashCheck && !hashCheck.success;
-    const hashCheckError = isHashCheckError ? hashCheck.error : null;
-    const hashCheckErrorPayload = isHashCheckError ? hashCheck.errorPayload : null;
+    const isError = hashCheck && !hashCheck.success;
+    const errorType = isError ? hashCheck.error : null;
+    const errorPayload = isError ? hashCheck.errorPayload : null;
+    const attemptCount = isError ? hashCheck.attemptCount : null;
 
     useEffect(() => {
-        if (hashCheckError && hashCheckErrorScenarios[hashCheckError].shouldReport) {
-            reportCheckFail('Firmware hash', {
-                ...commonData,
-                hashCheckError,
-                hashCheckErrorPayload,
-            });
+        if (errorType && hashCheckErrorScenarios[errorType].shouldReport) {
+            reportCheckFail(
+                'Firmware hash',
+                { ...commonData, errorType, attemptCount },
+                errorPayload,
+            );
         }
-    }, [commonData, hashCheckError, hashCheckErrorPayload]);
+    }, [commonData, errorType, errorPayload, attemptCount]);
 
     // success bears warning if it needed retries, so we report the previous error payload, see Device.ts in connect
     const isHashCheckSuccess = hashCheck && hashCheck.success;
-    const hashCheckWarning = isHashCheckSuccess ? hashCheck.warningPayload : null;
+    const warningPayload = isHashCheckSuccess ? hashCheck.warningPayload : null;
     useEffect(() => {
-        if (hashCheckWarning) {
-            reportCheckWarning('Firmware hash', { ...commonData, hashCheckWarning });
+        if (warningPayload) {
+            reportCheckWarning('Firmware hash', commonData, warningPayload);
         }
-    }, [commonData, hashCheckWarning]);
+    }, [commonData, warningPayload]);
 };
 
 export const useReportDeviceCompromised = () => {

--- a/packages/suite/src/components/suite/SecurityCheck/useReportDeviceCompromised.ts
+++ b/packages/suite/src/components/suite/SecurityCheck/useReportDeviceCompromised.ts
@@ -1,7 +1,9 @@
 import { useEffect, useMemo } from 'react';
 
+import { FIRMWARE } from '@trezor/connect';
 import { getFirmwareVersion } from '@trezor/device-utils';
 import { isDeviceAcquired } from '@suite-common/suite-utils';
+import { isArrayMember } from '@trezor/utils';
 
 import { useDevice, useSelector } from 'src/hooks/suite';
 import { captureSentryMessage, withSentryScope } from 'src/utils/suite/sentry';
@@ -76,13 +78,14 @@ const useReportHashCheck = () => {
     const attemptCount = isError ? hashCheck.attemptCount : null;
 
     useEffect(() => {
-        if (errorType && hashCheckErrorScenarios[errorType].shouldReport) {
-            reportCheckFail(
-                'Firmware hash',
-                { ...commonData, errorType, attemptCount },
-                errorPayload,
-            );
-        }
+        if (!errorType) return;
+        if (!hashCheckErrorScenarios[errorType].shouldReport) return;
+        const willBeRetried =
+            isArrayMember(errorType, FIRMWARE.HASH_CHECK_RETRIABLE_ERRORS) &&
+            (attemptCount ?? 0) < FIRMWARE.HASH_CHECK_MAX_ATTEMPTS;
+        if (willBeRetried) return;
+
+        reportCheckFail('Firmware hash', { ...commonData, errorType, attemptCount }, errorPayload);
     }, [commonData, errorType, errorPayload, attemptCount]);
 
     // success bears warning if it needed retries, so we report the previous error payload, see Device.ts in connect


### PR DESCRIPTION
## Description

- solve broken errorPayloads due to bad serialization
- only report `other-error` on attempt 3 (meaning retries maxed), not errors received in meantime
- log FW revision|hash check errors|warnings to console
  - :warning: must use `console.warn`, not `.error`, as Sentry'd pick it up and send a duplicate event :see_no_evil:  
- cleanup in variable names, I'm also intentionally changing the `contextData` object that is sent in event message, see [comment](https://github.com/trezor/trezor-suite/pull/16585#discussion_r1928558299)

## Related Issue

Resolve #16584

## Screenshots:

N/A, but see illustrative Sentry events from localhost.
Sent from testing branch https://github.com/trezor/trezor-suite/commit/e0668b8a810c99bb67697850660eeb6db50b5ef5 . You can try for yourself - comment/uncomment to pick from the 3 scenarios.

For all cases see trace: that there is only FW revision failure alongside, but no other FW hash check events

- [1st other-error, then success](https://satoshilabs.sentry.io/issues/6241035716/events/318b41816fd240dbba84042e7158d32c/?project=5193825), see warningPayload at the bottom
- [other-error maxed out](https://satoshilabs.sentry.io/issues/6240996662/events/f486f6aaf78d40549d331486f93b28da/), see errorPayload at the bottom
- [1st other-error, then hash-mismatch](https://satoshilabs.sentry.io/issues/6240996891/events/cdf804c96769496681aaad3bce6233ac/?project=5193825). Only theoretical concern: it means a counterfeit device that is flaky