### PR TITLE
test: make request manager tests retry

### DIFF
--- a/.github/workflows/test-request-manager.yml
+++ b/.github/workflows/test-request-manager.yml
@@ -31,4 +31,4 @@ jobs:
           node-version-file: ".nvmrc"
 
       - run: yarn install --immutable
-      - run: yarn workspace @trezor/request-manager test:e2e
+      - run: yarn workspace @trezor/request-manager test:all

--- a/packages/request-manager/jest.config.js
+++ b/packages/request-manager/jest.config.js
@@ -1,0 +1,6 @@
+const baseConfig = require('../../jest.config.base.js');
+
+module.exports = {
+    ...baseConfig,
+    testRetryTimes: 3,
+};

--- a/packages/request-manager/package.json
+++ b/packages/request-manager/package.json
@@ -6,8 +6,9 @@
     "sideEffects": false,
     "main": "src/index.ts",
     "scripts": {
-        "test:unit": "yarn g:jest  --testPathIgnorePatterns e2e -c ../../jest.config.base.js",
-        "test:e2e": "yarn g:jest --runInBand -c ../../jest.config.base.js",
+        "test:all": "yarn g:jest --runInBand -c jest.config.js",
+        "test:unit": "yarn g:jest  --testPathIgnorePatterns e2e -c jest.config.js",
+        "test:e2e": "yarn g:jest --runInBand --testPathIgnorePatterns tests -c jest.config..js",
         "type-check": "yarn g:tsc --build tsconfig.json",
         "test:stress": "ts-node  -O '{\"module\": \"commonjs\"}' ./e2e/identities-stress.ts"
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Make request manager tests retry when they fail since it is expected sometimes to fail due to network or the service we use to get the IPs to make sure the Tor identities are different.

I also separated into 'test:e2e', 'test:unit' and 'test:all'.

Closes https://github.com/trezor/trezor-suite/issues/16581