### PR TITLE
Fix `RangeError: Maximum call stack size exceeded`

### DIFF
--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -620,8 +620,6 @@ const handleAccountNotification = async (
             if (account.subscriptionId) abortSubscription(account.subscriptionId);
             state.removeAccounts([account]);
             context.onNetworkDisconnect();
-        } else {
-            console.error('Solana subscription error:', error);
         }
     }
 };


### PR DESCRIPTION
## Description

When Solana websocket disconnects, the thrown `SolanaError` has cyclic dependency in `cause` field, which caused an error when sending to Sentry (it's specific to `@sentry/electron` package and its dependency `deepmerge`):

```
...
  extra: { arguments: [ 'Solana subscription error:', [SolanaError] ] },
...
```
Dunno why Sentry serialization can't handle this e.g. by `normalizeDepth` setting, it may be a bug on their side, but the simplest solution is to remove one residual `console.error`.

## Related Issue

Resolve #16530
