### PR TITLE
fix(suite): update handling of ethereum unstaking period

### DIFF
--- a/packages/suite/src/components/suite/StakingProcess/UnstakingInfo.tsx
+++ b/packages/suite/src/components/suite/StakingProcess/UnstakingInfo.tsx
@@ -3,18 +3,12 @@ import { useSelector } from 'react-redux';
 
 import { BulletList } from '@trezor/components';
 import { spacings } from '@trezor/theme';
-import {
-    selectAccountUnstakeTransactions,
-    selectValidatorsQueue,
-    TransactionsRootState,
-    StakeRootState,
-    AccountsRootState,
-} from '@suite-common/wallet-core';
+import { selectValidatorsQueue, StakeRootState } from '@suite-common/wallet-core';
 import { getNetworkDisplaySymbol, NetworkSymbol, NetworkType } from '@suite-common/wallet-config';
 import { SOLANA_EPOCH_DAYS } from '@suite-common/wallet-constants';
 
 import { Translation } from 'src/components/suite';
-import { getDaysToUnstake } from 'src/utils/suite/ethereumStaking';
+import { getUnstakingPeriodInDays } from 'src/utils/suite/ethereumStaking';
 import { CoinjoinRootState } from 'src/reducers/wallet/coinjoinReducer';
 
 import { InfoRow } from './InfoRow';
@@ -67,13 +61,13 @@ export const UnstakingInfo = ({ isExpanded }: UnstakingInfoProps) => {
     const { data } =
         useSelector((state: StakeRootState) => selectValidatorsQueue(state, account?.symbol)) || {};
 
-    const unstakeTxs = useSelector((state: TransactionsRootState & AccountsRootState) =>
-        selectAccountUnstakeTransactions(state, account?.key ?? ''),
-    );
-
     if (!account) return null;
 
-    const daysToUnstake = getDaysToUnstake(unstakeTxs, data);
+    const daysToUnstake = getUnstakingPeriodInDays(
+        data?.validatorWithdrawTime,
+        data?.validatorExitTime,
+    );
+
     const displaySymbol = getNetworkDisplaySymbol(account.symbol);
     const infoRowsData = getInfoRowsData(account.networkType, account.symbol, daysToUnstake);
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeInANutshellModal/StakeInANutshellModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeInANutshellModal/StakeInANutshellModal.tsx
@@ -57,11 +57,11 @@ interface StakeInANutshellModalProps {
 export const StakeInANutshellModal = ({ onCancel }: StakeInANutshellModalProps) => {
     const account = useSelector(selectSelectedAccount);
     const dispatch = useDispatch();
-    const { validatorWithdrawTime } = useSelector(state =>
+    const { validatorWithdrawTime, validatorExitTime } = useSelector(state =>
         selectValidatorsQueueData(state, account?.symbol),
     );
 
-    const unstakingPeriod = getUnstakingPeriodInDays(validatorWithdrawTime);
+    const unstakingPeriod = getUnstakingPeriodInDays(validatorWithdrawTime, validatorExitTime);
 
     const proceedToEverstakeModal = () => {
         onCancel();

--- a/packages/suite/src/utils/suite/__fixtures__/ethereumStaking.ts
+++ b/packages/suite/src/utils/suite/__fixtures__/ethereumStaking.ts
@@ -529,8 +529,9 @@ export const getUnstakingPeriodInDaysFixture = [
         description: 'should return correct unstaking period in days',
         args: {
             validatorWithdrawTimeInSeconds: 604800, // 7 days
+            validatorExitTimeInSeconds: 259200, // 3 days
         },
-        result: 7,
+        result: 10, // 7 + 3
     },
     {
         description:

--- a/packages/suite/src/utils/suite/__tests__/ethereumStaking.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/ethereumStaking.test.ts
@@ -166,7 +166,10 @@ describe('getStakeTxGasLimit', () => {
 describe('getUnstakingPeriodInDays', () => {
     getUnstakingPeriodInDaysFixture.forEach(test => {
         it(test.description, async () => {
-            const result = await getUnstakingPeriodInDays(test.args.validatorWithdrawTimeInSeconds);
+            const result = await getUnstakingPeriodInDays(
+                test.args.validatorWithdrawTimeInSeconds,
+                test.args.validatorExitTimeInSeconds,
+            );
             expect(result).toEqual(test.result);
         });
     });

--- a/packages/suite/src/utils/suite/ethereumStaking.ts
+++ b/packages/suite/src/utils/suite/ethereumStaking.ts
@@ -512,12 +512,19 @@ export const getStakeTxGasLimit = async ({
     }
 };
 
-export const getUnstakingPeriodInDays = (validatorWithdrawTimeInSeconds?: number) => {
-    if (validatorWithdrawTimeInSeconds === undefined) {
+export const getUnstakingPeriodInDays = (
+    validatorWithdrawTimeInSeconds?: number,
+    validatorExitTime?: number,
+) => {
+    if (validatorWithdrawTimeInSeconds === undefined || validatorExitTime === undefined) {
         return UNSTAKING_ETH_PERIOD;
     }
 
-    return secondsToDays(validatorWithdrawTimeInSeconds);
+    const unstakingPeriodInSeconds = new BigNumber(validatorWithdrawTimeInSeconds)
+        .plus(validatorExitTime)
+        .toNumber();
+
+    return secondsToDays(unstakingPeriodInSeconds);
 };
 
 export const getDaysToAddToPool = (


### PR DESCRIPTION
## Description

Fixed an issue where the unstaking period was being calculated incorrectly.
- https://www.validatorqueue.com/

## Screenshots:
Before:
![Screenshot 2025-01-24 at 17 41 07](https://github.com/user-attachments/assets/571c4e48-3841-486a-bd42-7dff1c6fb931)

Now:
![image](https://github.com/user-attachments/assets/a04722c6-9de4-4de7-9be8-79b4ab3f491a)

