### PR TITLE
refactor(suite-native): icon list item used in analytics screen

### DIFF
--- a/suite-native/module-onboarding/src/components/AnalyticsInfoRow.tsx
+++ b/suite-native/module-onboarding/src/components/AnalyticsInfoRow.tsx
@@ -1,8 +1,7 @@
 import { ReactNode } from 'react';
 
-import { Box, HStack, Text, VStack } from '@suite-native/atoms';
-import { Icon, IconName } from '@suite-native/icons';
-import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+import { IconListItem, Text, VStack } from '@suite-native/atoms';
+import { IconName } from '@suite-native/icons';
 
 type AnalyticsInfoRowProps = {
     iconName: IconName;
@@ -10,33 +9,13 @@ type AnalyticsInfoRowProps = {
     description: ReactNode;
 };
 
-const WRAPPER_SIZE = 36;
-
-const iconWrapper = prepareNativeStyle(utils => ({
-    justifyContent: 'center',
-    alignItems: 'center',
-    width: WRAPPER_SIZE,
-    height: WRAPPER_SIZE,
-    backgroundColor: utils.colors.backgroundSurfaceElevation2,
-    borderRadius: utils.borders.radii.r12,
-    borderWidth: 1,
-    borderColor: utils.colors.backgroundTertiaryDefaultOnElevation0,
-}));
-
-export const AnalyticsInfoRow = ({ iconName, title, description }: AnalyticsInfoRowProps) => {
-    const { applyStyle } = useNativeStyles();
-
-    return (
-        <HStack spacing="sp12" flexDirection="row" alignItems="center">
-            <Box style={applyStyle(iconWrapper)}>
-                <Icon name={iconName} size="mediumLarge" />
-            </Box>
-            <VStack spacing="sp4" flex={1}>
-                <Text variant="highlight">{title}</Text>
-                <Text variant="hint" color="textSubdued">
-                    {description}
-                </Text>
-            </VStack>
-        </HStack>
-    );
-};
+export const AnalyticsInfoRow = ({ iconName, title, description }: AnalyticsInfoRowProps) => (
+    <IconListItem icon={iconName} iconSize="mediumLarge">
+        <VStack spacing="sp4" flex={1}>
+            <Text variant="highlight">{title}</Text>
+            <Text variant="hint" color="textSubdued">
+                {description}
+            </Text>
+        </VStack>
+    </IconListItem>
+);


### PR DESCRIPTION
## Description
- IconListItem generic component reused in AnalyticsConsentScreen to simplify the UI code
- the screen looks the same as before

## Screenshots:
![Screenshot 2025-01-27 at 6 51 28 AM](https://github.com/user-attachments/assets/95e0d6eb-4784-4e4b-ab39-c27b0c741cd5)
