### PR TITLE
Add SafeAreaProvider to BasicProvider for component tests

### DIFF
--- a/suite-native/test-utils/package.json
+++ b/suite-native/test-utils/package.json
@@ -16,6 +16,7 @@
         "@trezor/styles": "workspace:*",
         "@trezor/theme": "workspace:*",
         "react": "18.2.0",
+        "react-native-safe-area-context": "^4.14.0",
         "react-redux": "8.0.7"
     }
 }

--- a/suite-native/test-utils/src/BasicProvider.tsx
+++ b/suite-native/test-utils/src/BasicProvider.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import { NavigationContainer } from '@react-navigation/native';
 
@@ -14,9 +15,11 @@ const renderer = createRenderer();
 const theme = prepareNativeTheme({ colorVariant: 'standard' });
 
 export const BasicProvider = ({ children }: ProviderProps) => (
-    <IntlProvider>
-        <StylesProvider theme={theme} renderer={renderer}>
-            <NavigationContainer>{children}</NavigationContainer>
-        </StylesProvider>
-    </IntlProvider>
+    <SafeAreaProvider>
+        <IntlProvider>
+            <StylesProvider theme={theme} renderer={renderer}>
+                <NavigationContainer>{children}</NavigationContainer>
+            </StylesProvider>
+        </IntlProvider>
+    </SafeAreaProvider>
 );

--- a/suite-native/test-utils/src/expoMock.js
+++ b/suite-native/test-utils/src/expoMock.js
@@ -1,3 +1,5 @@
+import mockSafeAreaContext from 'react-native-safe-area-context/jest/mock';
+
 jest.mock('expo-localization', () => {
     const Localization = {
         getLocales: () => [
@@ -403,3 +405,5 @@ jest.mock('expo-constants', () => {
 });
 
 jest.mock('redux-devtools-expo-dev-plugin', () => () => next => next);
+
+jest.mock('react-native-safe-area-context', () => mockSafeAreaContext);

--- a/yarn.lock
+++ b/yarn.lock
@@ -11168,6 +11168,7 @@ __metadata:
     "@trezor/styles": "workspace:*"
     "@trezor/theme": "workspace:*"
     react: "npm:18.2.0"
+    react-native-safe-area-context: "npm:^4.14.0"
     react-redux: "npm:8.0.7"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Added `SafeAreaProvider` to `BasicProvider` and mocked it in tests to simplify testing of some of our components (e.g. `BottomSheet`).

See `react-native-safe-area-context` [testing docs](https://github.com/AppAndFlow/react-native-safe-area-context?tab=readme-ov-file#testing) for more info.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
