### PR TITLE
fix: Wait for token definitions in import

### DIFF
--- a/suite-native/module-accounts-import/src/accountsImportThunks.ts
+++ b/suite-native/module-accounts-import/src/accountsImportThunks.ts
@@ -124,7 +124,7 @@ export const getAccountInfoThunk = createThunk<
                 if (!tokenDefinitions && isCoinWithTokens(symbol)) {
                     const definitionTypes = getSupportedDefinitionTypes(symbol);
 
-                    definitionTypes.forEach(async type => {
+                    const promises = definitionTypes.map(async type => {
                         await dispatch(
                             getTokenDefinitionThunk({
                                 symbol,
@@ -132,6 +132,7 @@ export const getAccountInfoThunk = createThunk<
                             }),
                         );
                     });
+                    await Promise.all(promises);
                 }
                 // fetch fiat rates for all tokens of newly discovered account
                 // Even that there is check in updateFiatRatesThunk, it is better to do it here and do not dispatch thunk at all because it has some overhead and sometimes there could be lot of tokens


### PR DESCRIPTION
When importing account there was no await for token definitions which could cause fiat values not being shown in case fetch took too long.

This awaits token definitions to be downloaded and triggers fiat rates update to be fetched. So the fiat rates should load gradually once the import confirmation is shown.