### PR TITLE
chore(transport): make messages param required in abstract constructor

### DIFF
--- a/packages/connect/setupJest.ts
+++ b/packages/connect/setupJest.ts
@@ -34,6 +34,7 @@ export const createTestTransport = (apiMethods = {}) =>
     new TestTransport({
         api: createTransportApi(apiMethods),
         id: 'foo-bar-id',
+        messages: {},
     });
 
 export const getDeviceFeatures = (feat?: Partial<Features>): Features => ({

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -31,7 +31,7 @@ export type ReleaseInput = {
 };
 
 export interface AbstractTransportParams {
-    messages?: Record<string, any>;
+    messages: Record<string, any>;
     logger?: Logger;
     debugLink?: boolean;
     id: string;
@@ -137,7 +137,7 @@ export abstract class AbstractTransport extends TransportEmitter {
     constructor({ messages, logger, id }: AbstractTransportParams) {
         super();
         this.descriptors = [];
-        this.messages = protobuf.Root.fromJSON(messages || {});
+        this.messages = protobuf.Root.fromJSON(messages);
         this.abortController = new AbortController();
         this.logger = logger;
         this.id = id;

--- a/packages/transport/tests/abstractUsb.test.ts
+++ b/packages/transport/tests/abstractUsb.test.ts
@@ -88,6 +88,7 @@ describe('Usb', () => {
             const transport = new TestUsbTransport({
                 api: testUsbApi,
                 id: 'test',
+                messages: {},
             });
 
             await transport.init();


### PR DESCRIPTION
transport can't really work without messages loaded so it probably makes sense to require at least some messages at the time the constructor is called?

( 🦵 🔫 @Nodonisko )