### PR TITLE
fix(suite): use TrezorLink in IOAddress to handle tor properly

### DIFF
--- a/packages/suite/src/components/suite/copy/IOAddress.tsx
+++ b/packages/suite/src/components/suite/copy/IOAddress.tsx
@@ -2,10 +2,11 @@ import { useState } from 'react';
 
 import styled, { css, useTheme } from 'styled-components';
 
-import { Icon, Link, Text } from '@trezor/components';
+import { Icon, Text } from '@trezor/components';
 import { copyToClipboard } from '@trezor/dom-utils';
 
 import { HiddenPlaceholder } from 'src/components/suite/HiddenPlaceholder';
+import { TrezorLink } from 'src/components/suite/TrezorLink';
 
 const IconWrapper = styled.div`
     display: none;
@@ -124,13 +125,13 @@ export const IOAddress = ({
                     ) : null}
                     {explorerUrl ? (
                         <IconWrapper>
-                            <Link
+                            <TrezorLink
                                 typographyStyle="label"
                                 variant="nostyle"
                                 href={`${explorerUrl}${txAddress}${explorerUrlQueryString}`}
                             >
                                 <Icon name="arrowUpRight" size={12} color={theme.iconOnPrimary} />
-                            </Link>
+                            </TrezorLink>
                         </IconWrapper>
                     ) : null}
                 </TextOverflowContainer>


### PR DESCRIPTION
## Description

Updated `IOAddress` to use `TrezorLink` instead of just `Link` when linking to explorer, so now the address is correctly converted to `.onion` when using Tor.