### PR TITLE
feat(connect-popup): enable taproot discovery

### DIFF
--- a/packages/connect/src/api/common/Discovery.ts
+++ b/packages/connect/src/api/common/Discovery.ts
@@ -70,13 +70,13 @@ export class Discovery extends EventEmitter {
                     getPath: getDescriptor.bind(this, 84),
                 });
             }
-            // if (coinInfo.taproot) {
-            // TODO: enable taproot/p2tr discovery type in popup
-            // this.types.push({
-            //     type: 'p2tr',
-            //     getPath: getDescriptor.bind(this, 86),
-            // });
-            // }
+            if (coinInfo.taproot) {
+                // TODO: enable taproot/p2tr discovery type in popup
+                this.types.push({
+                    type: 'p2tr',
+                    getPath: getDescriptor.bind(this, 86),
+                });
+            }
             // add segwit/p2sh discovery type (normal if bech32 is not supported)
             if (coinInfo.xPubMagicSegwit) {
                 this.types.push({


### PR DESCRIPTION
why haven't we enabled the taproot for popup discovery?  cc @Hannsek 

![image](https://github.com/user-attachments/assets/e7303591-b181-4231-9241-91abd0c663e5)

this would resolve #16624