### PR TITLE
Fix/fw hash check error payload serialization

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -8,6 +8,7 @@ import {
     TypedEmitter,
     createTimeoutPromise,
     isArrayMember,
+    serializeError,
 } from '@trezor/utils';
 import { Session } from '@trezor/transport';
 import { TransportProtocol, v1 as v1Protocol } from '@trezor/protocol';
@@ -831,7 +832,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
             return { success: true };
         } catch (errorPayload) {
-            return createFailResult('other-error', errorPayload);
+            return createFailResult('other-error', serializeError(errorPayload));
         }
     }
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -46,6 +46,7 @@ export * from './promiseAllSequence';
 export * from './redactUserPath';
 export * from './resolveAfter';
 export * from './scheduleAction';
+export * from './serializeError';
 export * from './splitStringEveryNCharacters';
 export * from './throttler';
 export * from './throwError';

--- a/packages/utils/src/serializeError.ts
+++ b/packages/utils/src/serializeError.ts
@@ -1,0 +1,15 @@
+/**
+ * Serialize an error of unknown type to a string.
+ */
+export const serializeError = (error: unknown): string => {
+    // Error instances are objects, but have no JSON printable properties
+    if (error instanceof Error) {
+        return error.toString();
+    }
+    if (typeof error === 'object') {
+        return JSON.stringify(error);
+    }
+
+    // assumed to be a primitive type; exotic types such as function will also be simply stringified
+    return `${error}`;
+};

--- a/packages/utils/tests/serializeError.test.ts
+++ b/packages/utils/tests/serializeError.test.ts
@@ -1,0 +1,30 @@
+import { serializeError } from '../src/serializeError';
+
+class CustomError extends Error {
+    somethingExtra = 'extra stuff';
+
+    toString() {
+        return `${super.toString()} + ${this.somethingExtra} `;
+    }
+}
+
+describe(serializeError.name, () => {
+    it('serializes an Error instance', () => {
+        const error = new Error('example message');
+        expect(serializeError(error)).toBe('Error: example message');
+
+        const customError = new CustomError('example message');
+        expect(serializeError(customError)).toBe('Error: example message + extra stuff ');
+    });
+
+    it('serializes a plain object', () => {
+        const error = { message: 'test' };
+        expect(serializeError(error)).toBe(JSON.stringify(error));
+    });
+
+    it('serializes a primitive', () => {
+        expect(serializeError('test')).toBe('test');
+        expect(serializeError(123)).toBe('123');
+        expect(serializeError(false)).toBe('false');
+    });
+});


### PR DESCRIPTION
## Description

Followup to #16585 to reliably log FW hash check errors to Sentry

- create `serializeError` helper which correctly detects how the caught error should be serialized
- use it on FW hash check error payload in connect

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/16584

## Logs:

I placed `throw ERRORS.TypedError('Runtime', 'Mock Error Description')` [at this line](https://github.com/trezor/trezor-suite/blob/108fb3198435c60e1f6993e651e04b63eeb858cd/packages/connect/src/device/Device.ts#L828).
Console logging `errorPayload.toString()` in the `catch (errorPayload)` block returns:
```
Runtime Mock Error Description
```
Which means that `TypedError` responds to `.toString()` as it would be expected from an `Error` inheritor :heavy_check_mark: :ok_hand: 

But before this change, an `Error` instance gets mangled somewhere between Connect and Suite Redux.
Looking into redux `state.device.selectedDevice.authenticityChecks.firmwareHash.errorPayload` :confused: 
```
{ "code": "Runtime" }
```
After this change it is :slightly_smiling_face: 
```
"Error: Mock Error Description"
```