### PR TITLE
chore(message-system): refresh uuids for deprecate coins warning

### DIFF
--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,7 +1,7 @@
 {
     "version": 1,
-    "timestamp": "2024-01-03T00:00:00+00:00",
-    "sequence": 74,
+    "timestamp": "2025-01-28T00:00:00+00:00",
+    "sequence": 75,
     "actions": [
         {
             "conditions": [
@@ -1105,7 +1105,7 @@
                 }
             ],
             "message": {
-                "id": "036c0094-49f0-4033-a23c-b9150890a285",
+                "id": "717447c0-543f-4451-97fa-7700045842b3",
                 "priority": 93,
                 "dismissible": true,
                 "variant": "warning",


### PR DESCRIPTION
Refreshing the UUID for the Coins deprecation message so that users who have already dismissed it will see it again.