### PR TITLE
fix(suite): env utils mock in Preloader unit test

### DIFF
--- a/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
+++ b/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
@@ -32,6 +32,11 @@ jest.mock('@trezor/suite-desktop-api', () => ({
     },
 }));
 
+jest.mock('@trezor/env-utils', () => ({
+    ...jest.requireActual('@trezor/env-utils'),
+    isLinux: () => true,
+}));
+
 // jest.mock('@firmware-components/ReconnectDevicePrompt', () => ({
 //     __esModule: true, // export as module
 //     default: ({ children }: any) => <div data-testid="box">{children}</div>,


### PR DESCRIPTION
## Description

There was an issue with mocking `envUtils.isLinux` which was causing the  "Unreadable device: missing udev on Linux" test to fail on other platforms. 
This was not apparent in CI since it's already Linux. 

This PR adds a more reliable mock.