### PR TITLE
ci: add workflow_dispatch for build-suite-web

### DIFF
--- a/.github/workflows/build-suite-web.yml
+++ b/.github/workflows/build-suite-web.yml
@@ -20,6 +20,7 @@ on:
       - ".github/workflows/build-desktop*"
       - ".github/workflows/release*"
       - ".github/workflows/template*"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
## Description

Add `workflow_dispatch` for `build-suite-web`.
Useful when oyu just want to test sldev web build, without opening PR (and running any other CI) :slightly_smiling_face: 

This is currently the only "build" workflow that doesn't have it..