### PR TITLE
feat(suite): simplify DeviceCompromised checklist

### DIFF
--- a/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
@@ -16,7 +16,7 @@ const useSecurityCheckFailProps = (): Partial<SecurityCheckFailProps> => {
     const revisionCheckError = useSelector(selectFirmwareRevisionCheckErrorIfEnabled);
     const hashCheckError = useSelector(selectFirmwareHashCheckErrorIfEnabled);
 
-    // revision check has precedence over hash check, because it is unimpeachable
+    // revision check has precedence over hash check, because it does not have the ambiguous other-error state
     if (revisionCheckError !== null) {
         return {
             heading: 'TR_DEVICE_COMPROMISED_HEADING',

--- a/packages/suite/src/components/suite/SecurityCheck/checklistItems.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/checklistItems.tsx
@@ -15,10 +15,6 @@ const IconBackground = styled.div`
 
 export const hardFailureChecklistItems: SecurityChecklistItem[] = [
     {
-        icon: <Icon size={24} variant="default" name="plugs" />,
-        content: <Translation id="TR_DISCONNECT_DEVICE" />,
-    },
-    {
         icon: <Icon size={24} variant="default" name="hand" />,
         content: <Translation id="TR_AVOID_USING_DEVICE" />,
     },

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -6864,10 +6864,6 @@ export default defineMessages({
         defaultMessage:
             'We want to be sure that your device is in tip-top shape before you start using it. Reach out to Trezor Support to find out what to do next.',
     },
-    TR_DISCONNECT_DEVICE: {
-        id: 'TR_DISCONNECT_DEVICE',
-        defaultMessage: 'Disconnect your device from your laptop or computer.',
-    },
     TR_AVOID_USING_DEVICE: {
         id: 'TR_AVOID_USING_DEVICE',
         defaultMessage: 'Avoid using this device or sending any funds to it.',


### PR DESCRIPTION
## Description

Remove misleading first point from `DeviceCompromised` modal

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/16407 (ad-hoc followup)

## Screenshots:

FW hash check, security check, authenticity check:
![image](https://github.com/user-attachments/assets/d83e0c35-84b0-40bb-a0e8-e939be25170c)
![image](https://github.com/user-attachments/assets/37bc1b20-4145-4eac-b110-f80f345321e4)
![image](https://github.com/user-attachments/assets/3bf64982-5ef0-4c0c-8e92-9b84c208f372)

