### PR TITLE
fix(suite): Known tokens named as URLs are not blurred

### DIFF
--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
@@ -156,7 +156,7 @@ export const TokenRow = ({
                         size={24}
                         shouldTryToFetch={isTokenKnown}
                     />
-                    <BlurUrls text={token.name} />
+                    {isTokenKnown ? token.name : <BlurUrls text={token.name} />}
                 </Row>
             </Table.Cell>
             <Table.Cell>


### PR DESCRIPTION
## Description

Some tokens are named like URLs (e.g. **OCADA.AI**). If they are known, there is no need to blur them.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/15939

## Screenshots:

![image](https://github.com/user-attachments/assets/b6a05b2b-9249-4334-b32b-ded542c751db)
