### PR TITLE
fix(blockchain-link): stop ripple ping timeout if api disconnected

### DIFF
--- a/packages/blockchain-link/src/workers/baseWorker.ts
+++ b/packages/blockchain-link/src/workers/baseWorker.ts
@@ -163,7 +163,7 @@ export abstract class BaseWorker<API> {
             return true;
         }
         if (data.type === MESSAGES.DISCONNECT) {
-            this.disconnect();
+            await this.disconnect();
             this.post({ id, type: RESPONSES.DISCONNECTED, payload: true });
 
             return true;

--- a/packages/blockchain-link/src/workers/ripple/index.ts
+++ b/packages/blockchain-link/src/workers/ripple/index.ts
@@ -475,9 +475,7 @@ class RippleWorker extends BaseWorker<RippleAPI> {
     }
 
     disconnect() {
-        if (this.api) {
-            this.api.disconnect();
-        }
+        return this.api?.disconnect();
     }
 
     async messageHandler(event: { data: MessageTypes.Message }) {
@@ -508,10 +506,9 @@ class RippleWorker extends BaseWorker<RippleAPI> {
         if (this.pingTimeout) {
             clearTimeout(this.pingTimeout);
         }
-        this.pingTimeout = setTimeout(
-            () => this.onPing(),
-            this.settings.pingTimeout || DEFAULT_PING_TIMEOUT,
-        );
+        this.pingTimeout = this.api?.isConnected()
+            ? setTimeout(() => this.onPing(), this.settings.pingTimeout || DEFAULT_PING_TIMEOUT)
+            : undefined;
     }
 
     async onPing() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`yarn workspace @trezor/blockchain-link test:unit --coverage=false`

ends with:
```
A worker process has failed to exit gracefully and has been force exited.
This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks.
Active timers can also cause this, ensure that .unref() was called on them.
```

there were 2 reasons:
1. setPingTimeout is calling itself recursively. now it should stop if api is disconnected
2.  worker.dispose() is async (at least in ripple worker) and it is awaited in tests teardown, but it was never awaited in baseWorker while processing the request
