### PR TITLE
Feat: add more information to serializeError

### DIFF
--- a/packages/connect/src/constants/errors.ts
+++ b/packages/connect/src/constants/errors.ts
@@ -69,6 +69,11 @@ export class TrezorError extends Error {
         this.code = code;
         this.message = message;
     }
+
+    // Error.prototype.toString() does not include custom property `code`
+    toString() {
+        return `${this.name} (code: ${this.code}): ${this.message}`;
+    }
 }
 
 export const TypedError = (id: ErrorCode, message?: string) =>

--- a/packages/utils/src/serializeError.ts
+++ b/packages/utils/src/serializeError.ts
@@ -2,10 +2,14 @@
  * Serialize an error of unknown type to a string.
  */
 export const serializeError = (error: unknown): string => {
-    // Error instances are objects, but have no JSON printable properties
+    // Error instances are objects, but have no JSON printable properties.
+    // Instead, .toString() is their standard string representation. Though stack trace must be included separately
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/toString
     if (error instanceof Error) {
-        return error.toString();
+        return JSON.stringify({ message: error.toString(), stackTrace: error.stack });
     }
+
+    // plain javascript object is not a conventional error type, but we have to count with it
     if (typeof error === 'object') {
         return JSON.stringify(error);
     }

--- a/packages/utils/tests/serializeError.test.ts
+++ b/packages/utils/tests/serializeError.test.ts
@@ -4,17 +4,32 @@ class CustomError extends Error {
     somethingExtra = 'extra stuff';
 
     toString() {
-        return `${super.toString()} + ${this.somethingExtra} `;
+        return `${super.toString()} + ${this.somethingExtra}`;
     }
 }
 
 describe(serializeError.name, () => {
     it('serializes an Error instance', () => {
         const error = new Error('example message');
-        expect(serializeError(error)).toBe('Error: example message');
+        /*
+        A very crude way to mock the stack trace.. But although we can generally mock anything in Jest,
+        (in this case that would be Error.prototype.captureStackTrace that sets the Error.stack property)
+        specifically errors are not mockable, as Jest relies on them internally and it bugs out Jest.
+        But couldn't we then do it at least for CustomError? No, because for Error instances,
+        JavaScript bypasses the prototype chain and calls Error.prototype.captureStackTrace directly.
+        */
+        error.stack = 'Mock Stack Trace';
+        expect(JSON.parse(serializeError(error))).toMatchObject({
+            message: 'Error: example message',
+            stackTrace: 'Mock Stack Trace',
+        });
 
         const customError = new CustomError('example message');
-        expect(serializeError(customError)).toBe('Error: example message + extra stuff ');
+        customError.stack = 'Mock Stack Trace';
+        expect(JSON.parse(serializeError(customError))).toMatchObject({
+            message: 'Error: example message + extra stuff',
+            stackTrace: 'Mock Stack Trace',
+        });
     });
 
     it('serializes a plain object', () => {


### PR DESCRIPTION
## Description

Followup to #16652

- add `stackTrace` to the new util `serializeError`
- redefine `.toString()` on `TrezorError` (a.k.a. `TypedError`)
  - currently it uses `Error.prototype.toString()` which omits the very important `code` property

:information_source: when sending the error to sentry, [it might get clipped](https://forum.sentry.io/t/how-to-disable-data-clipping-in-the-additional-data-block/694/3). Different sources say different max size so idk, but it's typically the beginning of stack trace that's most pertinent.  

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/16584 (followup) 

## Logs:

This can be tested with the FW hash check.
I placed `throw ERRORS.TypedError('Runtime', 'Mock Error Description')` [at this line](https://github.com/trezor/trezor-suite/blob/108fb3198435c60e1f6993e651e04b63eeb858cd/packages/connect/src/device/Device.ts#L828).

Looking into redux `state.device.selectedDevice.authenticityChecks.firmwareHash.errorPayload`:
**Desktop:**
```
{"message":"Error (code: Runtime): Mock Error Description","stackTrace":"Error: Mock Error Description
    at Module.TypedError (/trezor-suite/packages/suite-desktop/dist/app.js:64291:37)
    at Device.checkFirmwareHash (/trezor-suite/packages/suite-desktop/dist/app.js:68745:63)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Device.checkFirmwareHashWithRetries (/trezor-suite/packages/suite-desktop/dist/app.js:68682:22)
    at async Device._runInner (/trezor-suite/packages/suite-desktop/dist/app.js:68533:5)"}
```

**Web:**
```
{"message":"Error (code: Runtime): Mock Error Description","stackTrace":"TrezorError@webpack://@trezor/connect-iframe/../connect/src/constants/errors.ts?:103:5
TypedError@webpack://@trezor/connect-iframe/../connect/src/constants/errors.ts?:113:37
checkFirmwareHash@webpack://@trezor/connect-iframe/../connect/src/device/Device.ts?:640:63
async*checkFirmwareHashWithRetries@webpack://@trezor/connect-iframe/../connect/src/device/Device.ts?:577:33
_runInner@webpack://@trezor/connect-iframe/../connect/src/device/Device.ts?:428:16
async*run@webpack://@trezor/connect-iframe/../connect/src/device/Device.ts?:306:10
handshake@webpack://@trezor/connect-iframe/../connect/src/device/Device.ts?:239:22
async*onDeviceConnected/<@webpack://@trezor/connect-iframe/../connect/src/device/DeviceList.ts?:216:22
invokeCallback@webpack://@trezor/connect-iframe/../../node_modules/es6-promise/dist/es6-promise.js?:408:15
then/<@webpack://@trezor/connect-iframe/../../node_modules/es6-promise/dist/es6-promise.js?:176:14
flush@webpack://@trezor/connect-iframe/../../node_modules/es6-promise/dist/es6-promise.js?:128:13
MutationCallback*useMutationObserver@webpack://@trezor/connect-iframe/../../node_modules/es6-promise/dist/es6-promise.js?:95:18
@webpack://@trezor/connect-iframe/../../node_modules/es6-promise/dist/es6-promise.js?:152:19
@webpack://@trezor/connect-iframe/../../node_modules/es6-promise/dist/es6-promise.js?:11:27
@webpack://@trezor/connect-iframe/../../node_modules/es6-promise/dist/es6-promise.js?:13:2
../../node_modules/es6-promise/dist/es6-promise.js@http://localhost:8000/js/core.js:4277:1
__webpack_require__@http://localhost:8000/js/core.js:7231:41
@webpack://@trezor/connect-iframe/../../node_modules/events/events.js?:1:60
../../node_modules/events/events.js@http://localhost:8000/js/core.js:4287:1
__webpack_require__@http://localhost:8000/js/core.js:7231:41
@webpack://@trezor/connect-iframe/../connect/src/core/index.ts?:5:83
../connect/src/core/index.ts@http://localhost:8000/js/core.js:1137:1
__webpack_require__@http://localhost:8000/js/core.js:7231:41
@http://localhost:8000/js/core.js:7546:55
"}
```