### PR TITLE
fix(suite): Missing external link hooks for explorer

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/AnalyzeInExplorerBanner.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/AnalyzeInExplorerBanner.tsx
@@ -2,7 +2,7 @@ import { Banner, Paragraph, H4, Column } from '@trezor/components';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { selectBlockchainExplorerBySymbol } from '@suite-common/wallet-core';
 
-import { useSelector } from 'src/hooks/suite';
+import { useExternalLink, useSelector } from 'src/hooks/suite';
 import { Translation } from 'src/components/suite';
 
 type AnalyzeInExplorerBannerProps = {
@@ -12,18 +12,14 @@ type AnalyzeInExplorerBannerProps = {
 
 export const AnalyzeInExplorerBanner = ({ txid, symbol }: AnalyzeInExplorerBannerProps) => {
     const explorer = useSelector(state => selectBlockchainExplorerBySymbol(state, symbol));
+    const href = useExternalLink(`${explorer?.tx}${txid}${explorer.queryString ?? ''}`);
 
     return (
         <Banner
             variant="info"
             icon="cube"
             rightContent={
-                <Banner.Button
-                    icon="arrowUpRight"
-                    iconAlignment="right"
-                    size="small"
-                    href={`${explorer?.tx}${txid}${explorer.queryString ?? ''}`}
-                >
+                <Banner.Button icon="arrowUpRight" iconAlignment="right" size="small" href={href}>
                     <Translation id="TR_ANALYZE_IN_EXPLORER_OPEN" />
                 </Banner.Button>
             }

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
@@ -40,6 +40,7 @@ import {
 import {
     useDevice,
     useDispatch,
+    useExternalLink,
     useLayoutSize,
     useSelector,
     useTranslation,
@@ -111,6 +112,7 @@ export const TokenRow = ({
         token.contract,
     );
     const coingeckoId = getCoingeckoId(account.symbol);
+    const explorerUrl = useExternalLink(getTokenExplorerUrl(network, token));
 
     if (!unusedAddress || !device) return null;
 
@@ -337,10 +339,7 @@ export const TokenRow = ({
                                             label: <Translation id="TR_VIEW_IN_EXPLORER" />,
                                             icon: 'arrowUpRight',
                                             onClick: () => {
-                                                window.open(
-                                                    getTokenExplorerUrl(network, token),
-                                                    '_blank',
-                                                );
+                                                window.open(explorerUrl, '_blank');
                                             },
                                         },
                                     ],


### PR DESCRIPTION
## Description

Use external link hook in "Analyze in blockchain explorer" banner and token row.
This correctly converts the link .onion when tor is in use.