### PR TITLE
fix(e2e): Disables snapshot verification for web tests

### DIFF
--- a/packages/suite-desktop-core/e2e/playwright.config.ts
+++ b/packages/suite-desktop-core/e2e/playwright.config.ts
@@ -19,6 +19,8 @@ const config: PlaywrightTestConfig = {
                 baseURL: process.env.BASE_URL || 'http://localhost:8000/',
             },
             grepInvert: /@desktopOnly/,
+            //TODO: #16073 We are still encountering instabilities, snapshots resolution differs, tolerance does not help
+            ignoreSnapshots: true,
         },
         {
             name: PlaywrightProjects.Desktop,


### PR DESCRIPTION
Due to continuing instabilities we will disable these checks and revisit it later
