### PR TITLE
chore(suite-desktop): enable trezor-connect logger when debug mode is…

### DIFF
--- a/packages/suite-desktop-core/src/modules/trezor-connect.ts
+++ b/packages/suite-desktop-core/src/modules/trezor-connect.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from 'electron';
+import { app, ipcMain } from 'electron';
 
 import TrezorConnect, { DEVICE_EVENT } from '@trezor/connect';
 import { IpcProxyHandlerOptions, createIpcProxyHandler } from '@trezor/ipc-proxy';
@@ -56,7 +56,12 @@ export const initBackground: ModuleInitBackground = ({ mainThreadEmitter, store 
             onRequest: async (method, params) => {
                 logger.debug(SERVICE_NAME, `call ${method}`);
                 if (method === 'init') {
-                    const response = await TrezorConnect[method](...params);
+                    const response = await TrezorConnect.init({
+                        ...params[0],
+                        // poor mans solution to enable debug logs in trezor-connect.
+                        // todo: ideally connect should accept logger as a param
+                        debug: app?.commandLine.getSwitchValue('log-connect') === 'true',
+                    });
                     await setProxy();
 
                     return response;


### PR DESCRIPTION
sometimes it might be useful to see logs from a production build running, mainly in case when we can reproduce an issue on a specific computer. We opened this topic together with @MiroslavProchazka while we were debugging some firmware update issues.

This PR brings a very naive way to achieve this - when debug mode is active during the startup of the suite-desktop app you get connect logs printed to stdout. 


