### PR TITLE
test(blockchain-link): use JestCustomEnv.js to detect exceeding liste…

### DIFF
--- a/packages/blockchain-link/jest.config.unit.js
+++ b/packages/blockchain-link/jest.config.unit.js
@@ -18,4 +18,5 @@ module.exports = {
         'unit/worker/index.ts',
     ],
     setupFiles: ['./tests/setup.js'],
+    testEnvironment: '../../JestCustomEnv.js',
 };


### PR DESCRIPTION
after this change, you can run 

```
yarn workspace @trezor/blockchain-link test:unit --detectOpenHandles
```
and detect where specifically the following warning

```
(node:33533) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 warning listeners added to [process]. MaxListeners is 10. Use emitter.setMaxListeners() to increase limit
```
is produced.

I think it is a good practice in general to tighten unit test setup this way. Also note that this leak seems to be fixed by #16680