### PR TITLE
Fees redesign

### DIFF
--- a/packages/components/src/components/InfoItem/InfoItem.tsx
+++ b/packages/components/src/components/InfoItem/InfoItem.tsx
@@ -86,6 +86,7 @@ export const InfoItem = ({
                     gap={mapTypographyStyleToIconGap(typographyStyle)}
                     width={labelWidth}
                     flex={labelWidth ? '0 0 auto' : '1 0 auto'}
+                    height={24}
                 >
                     {iconName && (
                         <Icon

--- a/packages/components/src/components/RadioCard/RadioCard.tsx
+++ b/packages/components/src/components/RadioCard/RadioCard.tsx
@@ -2,7 +2,14 @@ import { ReactNode } from 'react';
 
 import styled, { css } from 'styled-components';
 
-import { borders, palette, spacingsPx } from '@trezor/theme';
+import {
+    Elevation,
+    borders,
+    mapElevationToBackground,
+    mapElevationToBorder,
+    palette,
+    spacingsPx,
+} from '@trezor/theme';
 
 import {
     FrameProps,
@@ -12,6 +19,7 @@ import {
 } from '../../utils/frameProps';
 import { TransientProps } from '../../utils/transientProps';
 import { Box } from '../Box/Box';
+import { useElevation } from '../ElevationContext/ElevationContext';
 import { Icon } from '../Icon/Icon';
 
 export const allowedRadioCardFrameProps = [
@@ -27,14 +35,17 @@ export type RadioCardProps = {
     onClick?: () => void;
 } & AllowedFrameProps;
 
-const Wrapper = styled.div<{ $isActive: boolean } & TransientProps<AllowedFrameProps>>`
+const Wrapper = styled.div<
+    { $isActive: boolean; $elevation: Elevation } & TransientProps<AllowedFrameProps>
+>`
     position: relative;
     width: 100%;
     border-radius: ${borders.radii.md};
     box-shadow: ${({ theme }) => theme.boxShadowBase};
     padding: ${spacingsPx.md};
-    outline: ${borders.widths.small} solid ${({ theme }) => theme.borderFocus};
+    outline: ${borders.widths.small} solid ${mapElevationToBorder};
     outline-offset: -${borders.widths.small};
+    background-color: ${mapElevationToBackground};
 
     ${({ onClick }) => onClick && 'cursor: pointer;'}
 
@@ -61,10 +72,11 @@ const IconWrapper = styled.div`
 `;
 
 export const RadioCard = ({ isActive, onClick, children, ...rest }: RadioCardProps) => {
+    const { elevation } = useElevation();
     const frameProps = pickAndPrepareFrameProps(rest, allowedRadioCardFrameProps);
 
     return (
-        <Wrapper $isActive={isActive} onClick={onClick} {...frameProps}>
+        <Wrapper $isActive={isActive} onClick={onClick} $elevation={elevation} {...frameProps}>
             {isActive && (
                 <Box position={{ type: 'absolute', top: '-3px', right: '-3px' }}>
                     <IconWrapper>

--- a/packages/product-components/src/components/CoinLogo/CoinLogo.tsx
+++ b/packages/product-components/src/components/CoinLogo/CoinLogo.tsx
@@ -3,7 +3,7 @@ import { ReactSVG } from 'react-svg';
 
 import styled from 'styled-components';
 
-import { NetworkSymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { NetworkSymbol, getNetworkOptional } from '@suite-common/wallet-config';
 import { borders } from '@trezor/theme';
 
 import { COINS, LegacyNetworkSymbol } from './coins';
@@ -81,15 +81,8 @@ export const CoinLogo = ({
     } else if (type === 'network') {
         symbolSrc = NETWORK_ICONS[symbol as NetworkSymbol];
     } else {
-        // TODO: should be changed, this is hacky way
-        let networkSymbol;
-        try {
-            networkSymbol = getNetworkDisplaySymbol(
-                symbol as NetworkSymbol,
-            ).toLowerCase() as NetworkSymbol;
-        } catch {
-            networkSymbol = symbol as NetworkSymbol;
-        }
+        const network = getNetworkOptional(symbol);
+        const networkSymbol = network?.settlementLayer ?? symbol;
 
         badge = networkSymbol !== symbol ? NETWORK_ICONS[symbol as NetworkSymbol] : null;
         symbolSrc = COINS[networkSymbol !== symbol ? networkSymbol : symbol];

--- a/packages/product-components/src/components/FeeRate/FeeRate.tsx
+++ b/packages/product-components/src/components/FeeRate/FeeRate.tsx
@@ -3,16 +3,19 @@ import { getFeeUnits } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
 type FeeRateProps = {
-    feeRate: string | BigNumber;
+    feeRate?: string | BigNumber;
     networkType: NetworkType;
 };
 
 export const FeeRate = ({ feeRate, networkType }: FeeRateProps) => {
+    if (!feeRate) return null;
+
     const fee = typeof feeRate === 'string' ? new BigNumber(feeRate) : feeRate;
 
     return (
         <span>
-            {fee.toFixed(2)}&nbsp;{getFeeUnits(networkType)}
+            {networkType === 'bitcoin' ? fee.toFixed(2) : fee.toString()}&nbsp;
+            {getFeeUnits(networkType)}
         </span>
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
@@ -1,4 +1,4 @@
-import { formatDuration } from '@suite-common/suite-utils';
+import { formatDurationStrict } from '@suite-common/suite-utils';
 import { NetworkType, networks } from '@suite-common/wallet-config';
 import { FeeInfo, GeneralPrecomposedTransactionFinal, StakeType } from '@suite-common/wallet-types';
 import { getFee } from '@suite-common/wallet-utils';
@@ -7,6 +7,7 @@ import { CoinLogo, FeeRate } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
 import { AccountLabel, Translation } from 'src/components/suite';
+import { useLocales } from 'src/hooks/suite';
 import { useSelector } from 'src/hooks/suite/useSelector';
 import { selectLabelingDataForSelectedAccount } from 'src/reducers/suite/metadataReducer';
 import { Account } from 'src/types/wallet';
@@ -44,6 +45,7 @@ export const TransactionReviewSummary = ({
         state => state.wallet.selectedAccount.account?.key,
     ) as string;
     const fees = useSelector(state => state.wallet.fees);
+    const locale = useLocales();
 
     const network = networks[account.symbol];
     const { symbol, accountType, index, networkType } = account;
@@ -69,7 +71,7 @@ export const TransactionReviewSummary = ({
             {estimateTime !== undefined && (
                 <Note iconName="clock">
                     {'≈ '}
-                    {formatDuration(estimateTime)}
+                    {formatDurationStrict(estimateTime, locale)}
                 </Note>
             )}
 

--- a/packages/suite/src/components/wallet/Fees/CustomFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/CustomFee.tsx
@@ -11,7 +11,18 @@ import {
 import { NetworkType } from '@suite-common/wallet-config';
 import { FeeInfo, FormState } from '@suite-common/wallet-types';
 import { getFeeUnits, getInputState, isInteger } from '@suite-common/wallet-utils';
-import { Banner, Column, Grid, Note, Text, useMediaQuery, variables } from '@trezor/components';
+import {
+    Banner,
+    Column,
+    Grid,
+    Icon,
+    Note,
+    Row,
+    Text,
+    useMediaQuery,
+    variables,
+} from '@trezor/components';
+import { FeeLevel } from '@trezor/connect';
 import { NumberInput } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 import { HELP_CENTER_TRANSACTION_FEES_URL } from '@trezor/urls';
@@ -36,16 +47,21 @@ interface CustomFeeProps<TFieldValues extends FormState> {
     control: Control;
     setValue: UseFormSetValue<TFieldValues>;
     getValues: UseFormGetValues<TFieldValues>;
-    changeFeeLimit?: (value: string) => void;
     composedFeePerByte: string;
 }
+
+// TODO: revisit with priority fees
+const getCurrentFee = (levels: FeeLevel[]) => {
+    const middleIndex = Math.floor((levels.length - 1) / 2);
+
+    return levels[middleIndex].feePerUnit;
+};
 
 export const CustomFee = <TFieldValues extends FormState>({
     networkType,
     feeInfo,
     register,
     control,
-    changeFeeLimit,
     composedFeePerByte,
     ...props
 }: CustomFeeProps<TFieldValues>) => {
@@ -146,7 +162,7 @@ export const CustomFee = <TFieldValues extends FormState>({
         feeLimitError?.type === 'feeLimit' ? feeLimitValidationProps : undefined;
 
     return (
-        <Column gap={spacings.xs}>
+        <Column gap={spacings.md} margin={{ bottom: spacings.md }}>
             <Banner
                 icon
                 variant="warning"
@@ -160,6 +176,22 @@ export const CustomFee = <TFieldValues extends FormState>({
             >
                 <Translation id="TR_CUSTOM_FEE_WARNING" />
             </Banner>
+            <Row justifyContent="space-between">
+                <Text variant="tertiary" typographyStyle="hint">
+                    <Translation id="TR_CURRENT_FEE_CUSTOM_FEES" />
+                </Text>
+                <Text variant="default" typographyStyle="hint">
+                    <Row alignItems="center" gap={spacings.xxs}>
+                        <Text>
+                            {getCurrentFee(feeInfo.levels)} {getFeeUnits(networkType)}
+                        </Text>
+                        <Icon
+                            name={networkType === 'ethereum' ? 'gasPump' : 'receipt'}
+                            size="mediumLarge"
+                        />
+                    </Row>
+                </Text>
+            </Row>
             <Grid gap={spacings.xs} columns={useFeeLimit && !isBelowLaptop ? 2 : 1}>
                 {useFeeLimit ? (
                     <NumberInput
@@ -169,7 +201,6 @@ export const CustomFee = <TFieldValues extends FormState>({
                         inputState={getInputState(feeLimitError)}
                         name={FEE_LIMIT}
                         data-testid={FEE_LIMIT}
-                        onChange={changeFeeLimit}
                         bottomText={
                             feeLimitError?.message ? (
                                 <InputError

--- a/packages/suite/src/components/wallet/Fees/FeeDetails.tsx
+++ b/packages/suite/src/components/wallet/Fees/FeeDetails.tsx
@@ -1,123 +1,285 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
+
+import styled from 'styled-components';
 
 import { formatDuration } from '@suite-common/suite-utils';
-import { NetworkType } from '@suite-common/wallet-config';
+import { NetworkSymbol, NetworkType, getNetwork } from '@suite-common/wallet-config';
 import {
     FeeInfo,
     PrecomposedTransaction,
     PrecomposedTransactionCardano,
 } from '@suite-common/wallet-types';
 import { getFeeUnits } from '@suite-common/wallet-utils';
-import { Row, Text } from '@trezor/components';
+import { Box, Column, ElevationUp, RadioCard, Row, Text } from '@trezor/components';
 import { FeeLevel } from '@trezor/connect';
 import { FeeRate } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
-import { Translation } from 'src/components/suite/Translation';
+import { FiatValue } from 'src/components/suite/FiatValue';
+
+import { FeeOption } from './Fees';
 
 type DetailsProps = {
     networkType: NetworkType;
+    symbol: NetworkSymbol;
     selectedLevel: FeeLevel;
     // fields below are validated as false-positives, eslint claims that they are not used...
-
+    feeOptions: FeeOption[];
     feeInfo: FeeInfo;
-
+    changeFeeLevel: (level: FeeLevel['label']) => void;
     transactionInfo?: PrecomposedTransaction | PrecomposedTransactionCardano;
 
     showFee: boolean;
 };
 
-type ItemProps = {
-    label: React.ReactNode;
-    children: React.ReactNode;
+export const FeeCardsWrapper = styled.div<{ $columns: number }>`
+    width: 100%;
+    display: grid;
+    grid-template-columns: repeat(${({ $columns }) => $columns}, 1fr);
+    gap: ${spacings.xs};
+    align-items: stretch;
+`;
+
+type FeeCardProps = {
+    value: FeeLevel['label'];
+    isSelected: boolean;
+    changeFeeLevel: (level: FeeLevel['label']) => void;
+    topLeftChild: React.ReactNode;
+    topRightChild: React.ReactNode;
+    bottomLeftChild: React.ReactNode;
+    bottomRightChild: React.ReactNode;
 };
 
-const Item = ({ label, children }: ItemProps) => (
-    <Row gap={spacings.xxs}>
-        <Text variant="tertiary">{label}:</Text>
-        {children}
-    </Row>
+const FEE_CARD_MIN_WIDTH = 180;
+
+type ResizeObserverType = (
+    feeOptions: FeeOption[],
+    setColumns: (columns: number) => void,
+) => ResizeObserver;
+
+const resizeObserver: ResizeObserverType = (feeOptions, setColumns) =>
+    new ResizeObserver(entries => {
+        const borderBoxSize = entries[0].borderBoxSize?.[0];
+        if (!borderBoxSize) {
+            return;
+        }
+
+        const { inlineSize: elementWidth } = borderBoxSize;
+
+        const minWidth = (FEE_CARD_MIN_WIDTH + spacings.xs) * feeOptions.length;
+
+        const columns = elementWidth > minWidth ? feeOptions.length : 1;
+
+        setColumns(columns);
+    });
+
+const FeeCard = ({
+    value,
+    isSelected,
+    changeFeeLevel,
+    topLeftChild,
+    topRightChild,
+    bottomLeftChild,
+    bottomRightChild,
+}: FeeCardProps) => (
+    <Box minWidth={FEE_CARD_MIN_WIDTH} margin={spacings.xxs}>
+        <ElevationUp>
+            <RadioCard onClick={() => changeFeeLevel(value)} isActive={isSelected}>
+                <Column>
+                    <Row justifyContent="space-between">
+                        <Text typographyStyle="highlight">{topLeftChild}</Text>
+                        <Text variant="tertiary" typographyStyle="hint">
+                            {topRightChild}
+                        </Text>
+                    </Row>
+                    <Row justifyContent="space-between" height={24}>
+                        <Text>{bottomLeftChild}</Text>
+                        <Text variant="tertiary" typographyStyle="hint">
+                            {bottomRightChild}
+                        </Text>
+                    </Row>
+                </Column>
+            </RadioCard>
+        </ElevationUp>
+    </Box>
 );
 
 const BitcoinDetails = ({
     networkType,
     feeInfo,
-    selectedLevel,
     transactionInfo,
+    feeOptions,
     showFee,
+    selectedLevel,
+    changeFeeLevel,
+    symbol,
 }: DetailsProps) => {
+    const [columns, setColumns] = React.useState(1);
+
     const hasInfo = transactionInfo && transactionInfo.type !== 'error';
+    const ref = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        if (!ref.current) return;
+
+        resizeObserver(feeOptions, setColumns).observe(ref.current);
+
+        return () => resizeObserver(feeOptions, setColumns).disconnect();
+    }, [feeOptions, setColumns]);
 
     return (
         showFee && (
-            <>
-                <Item label={<Translation id="ESTIMATED_TIME" />}>
-                    {formatDuration(feeInfo.blockTime * selectedLevel.blocks * 60)}
-                </Item>
-
-                <Item label={<Translation id="TR_FEE_RATE" />}>
-                    <FeeRate
-                        feeRate={hasInfo ? transactionInfo.feePerByte : selectedLevel.feePerUnit}
-                        networkType={networkType}
+            <FeeCardsWrapper ref={ref} $columns={columns}>
+                {feeOptions?.map((fee, index) => (
+                    <FeeCard
+                        key={index}
+                        value={fee.value}
+                        isSelected={selectedLevel.label === fee.value}
+                        changeFeeLevel={changeFeeLevel}
+                        topLeftChild={
+                            <span data-testid={`@fee-card/${fee.value}`}>{fee.label}</span>
+                        }
+                        topRightChild={
+                            <>~{formatDuration(feeInfo.blockTime * (fee?.blocks ?? 0) * 60)}</>
+                        }
+                        bottomLeftChild={
+                            <FiatValue
+                                disableHiddenPlaceholder
+                                amount={fee?.networkAmount ?? ''}
+                                symbol={symbol}
+                                showApproximationIndicator
+                            />
+                        }
+                        bottomRightChild={
+                            <>
+                                <FeeRate
+                                    feeRate={
+                                        hasInfo
+                                            ? transactionInfo.feePerByte
+                                            : selectedLevel.feePerUnit
+                                    }
+                                    networkType={networkType}
+                                />
+                                {hasInfo ? ` (${transactionInfo.bytes} B)` : ''}
+                            </>
+                        }
                     />
-                    {hasInfo ? ` (${transactionInfo.bytes} B)` : ''}
-                </Item>
-            </>
+                ))}
+            </FeeCardsWrapper>
         )
     );
 };
 
 const EthereumDetails = ({
-    networkType,
-    selectedLevel,
-    transactionInfo,
     showFee,
+    feeOptions,
+    selectedLevel,
+    changeFeeLevel,
+    symbol,
+    networkType,
 }: DetailsProps) => {
-    // States to remember the last known values of feeLimit and feePerByte when isComposedTx was true.
-    const [lastKnownFeeLimit, setLastKnownFeeLimit] = useState('');
-    const [lastKnownFeePerByte, setLastKnownFeePerByte] = useState('');
+    const isMainnet = !getNetwork(symbol).settlementLayer;
 
-    const isComposedTx = transactionInfo && transactionInfo.type !== 'error';
+    // TODO: this can be probably moved to FeeRate component
+    const formatFeePerUnit = (feePerUnit?: string) => {
+        const num = Number(feePerUnit) || 0;
 
-    useEffect(() => {
-        if (isComposedTx && transactionInfo.feeLimit) {
-            setLastKnownFeeLimit(transactionInfo.feeLimit);
-            setLastKnownFeePerByte(transactionInfo.feePerByte);
-        }
-    }, [isComposedTx, transactionInfo]);
-
-    const gasLimit = isComposedTx
-        ? transactionInfo.feeLimit
-        : lastKnownFeeLimit || selectedLevel.feeLimit;
-    const gasPrice = isComposedTx
-        ? transactionInfo.feePerByte
-        : lastKnownFeePerByte || selectedLevel.feePerUnit;
+        return (Math.ceil(num * 100) / 100).toFixed(isMainnet ? 2 : 4);
+    };
 
     return (
         showFee && (
-            <>
-                <Item label={<Translation id="TR_GAS_LIMIT" />}>{gasLimit}</Item>
-
-                <Item label={<Translation id="TR_GAS_PRICE" />}>
-                    <FeeRate feeRate={gasPrice} networkType={networkType} />
-                </Item>
-            </>
+            <Column width="100%">
+                <FeeCardsWrapper $columns={1}>
+                    {feeOptions?.map((fee, index) => (
+                        <FeeCard
+                            key={index}
+                            value={fee.value}
+                            isSelected={selectedLevel.label === fee.value}
+                            changeFeeLevel={changeFeeLevel}
+                            topLeftChild={
+                                <span data-testid={`@fee-card/${fee.value}`}>{fee.label}</span>
+                            }
+                            topRightChild=""
+                            bottomLeftChild={
+                                <FiatValue
+                                    disableHiddenPlaceholder
+                                    amount={fee.networkAmount || ''}
+                                    symbol={symbol}
+                                    showApproximationIndicator
+                                />
+                            }
+                            bottomRightChild={
+                                <FeeRate
+                                    feeRate={formatFeePerUnit(fee?.feePerUnit)}
+                                    networkType={networkType}
+                                />
+                            }
+                        />
+                    ))}
+                </FeeCardsWrapper>
+            </Column>
         )
     );
 };
 
-const RippleDetails = ({ networkType, selectedLevel, showFee }: DetailsProps) =>
-    showFee && <Item label={getFeeUnits(networkType)}>{selectedLevel.feePerUnit}</Item>;
+// Solana, Ripple, Cardano and other networks with only one option
+const MiscDetails = ({
+    networkType,
+    showFee,
+    feeOptions,
+    symbol,
+    changeFeeLevel,
+}: DetailsProps) => {
+    if (!feeOptions?.length) return null;
+
+    const feeOption = feeOptions[0]; // in the future Solana should have it's own Details component
+    const feeAmount = networkType === 'solana' ? feeOption.feePerTx : feeOption.feePerUnit;
+
+    return (
+        showFee && (
+            <Column padding={spacings.xxxs} width="100%">
+                <FeeCard
+                    value={feeOption.value}
+                    isSelected={true}
+                    changeFeeLevel={changeFeeLevel}
+                    topLeftChild={
+                        <span data-testid={`@fee-card/${feeOption.value}`}>{feeOption.label}</span>
+                    }
+                    topRightChild=""
+                    bottomLeftChild={
+                        <FiatValue
+                            disableHiddenPlaceholder
+                            amount={feeOption.networkAmount || ''}
+                            symbol={symbol}
+                            showApproximationIndicator
+                        />
+                    }
+                    bottomRightChild={
+                        <Text variant="tertiary">
+                            {feeAmount} {getFeeUnits(networkType)}
+                        </Text>
+                    }
+                />
+            </Column>
+        )
+    );
+};
 
 export const FeeDetails = (props: DetailsProps) => {
     const { networkType } = props;
 
+    const detailsComponentMap: Partial<Record<NetworkType, React.FC<DetailsProps>>> = {
+        bitcoin: BitcoinDetails,
+        ethereum: EthereumDetails,
+    };
+
+    const DetailsComponent = detailsComponentMap[networkType] ?? MiscDetails;
+
     return (
-        <Text data-testid="@wallet/fee-details" as="div" typographyStyle="hint">
-            <Row gap={spacings.md}>
-                {networkType === 'bitcoin' && <BitcoinDetails {...props} />}
-                {networkType === 'ethereum' && <EthereumDetails {...props} />}
-                {networkType === 'ripple' && <RippleDetails {...props} />}
+        <Text data-testid="@wallet/fee-details" as="div">
+            <Row gap={spacings.md} justifyContent="space-evenly">
+                <DetailsComponent {...props} />
             </Row>
         </Text>
     );

--- a/packages/suite/src/components/wallet/Fees/FeeDetails.tsx
+++ b/packages/suite/src/components/wallet/Fees/FeeDetails.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react';
 
 import styled from 'styled-components';
 
-import { formatDuration } from '@suite-common/suite-utils';
+import { formatDurationStrict } from '@suite-common/suite-utils';
 import { NetworkSymbol, NetworkType, getNetwork } from '@suite-common/wallet-config';
 import {
     FeeInfo,
@@ -16,6 +16,7 @@ import { FeeRate } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
 import { FiatValue } from 'src/components/suite/FiatValue';
+import { useLocales } from 'src/hooks/suite';
 
 import { FeeOption } from './Fees';
 
@@ -115,6 +116,7 @@ const BitcoinDetails = ({
     symbol,
 }: DetailsProps) => {
     const [columns, setColumns] = React.useState(1);
+    const locale = useLocales();
 
     const hasInfo = transactionInfo && transactionInfo.type !== 'error';
     const ref = useRef<HTMLDivElement>(null);
@@ -140,7 +142,13 @@ const BitcoinDetails = ({
                             <span data-testid={`@fee-card/${fee.value}`}>{fee.label}</span>
                         }
                         topRightChild={
-                            <>~{formatDuration(feeInfo.blockTime * (fee?.blocks ?? 0) * 60)}</>
+                            <>
+                                ~
+                                {formatDurationStrict(
+                                    feeInfo.blockTime * (fee?.blocks ?? 0) * 60,
+                                    locale,
+                                )}
+                            </>
                         }
                         bottomLeftChild={
                             <FiatValue

--- a/packages/suite/src/components/wallet/Fees/FeeDetails.tsx
+++ b/packages/suite/src/components/wallet/Fees/FeeDetails.tsx
@@ -178,13 +178,17 @@ const EthereumDetails = ({
     symbol,
     networkType,
 }: DetailsProps) => {
-    const isMainnet = !getNetwork(symbol).settlementLayer;
+    const hasSettlementLayer = !!getNetwork(symbol).settlementLayer;
 
     // TODO: this can be probably moved to FeeRate component
     const formatFeePerUnit = (feePerUnit?: string) => {
         const num = Number(feePerUnit) || 0;
 
-        return (Math.ceil(num * 100) / 100).toFixed(isMainnet ? 2 : 4);
+        const numOfDecimalPlaces = hasSettlementLayer ? 4 : 2;
+
+        const multiplier = Math.pow(10, numOfDecimalPlaces);
+
+        return (Math.ceil(num * multiplier) / multiplier).toFixed(numOfDecimalPlaces);
     };
 
     return (

--- a/packages/suite/src/components/wallet/Fees/Fees.tsx
+++ b/packages/suite/src/components/wallet/Fees/Fees.tsx
@@ -7,9 +7,10 @@ import {
     UseFormSetValue,
 } from 'react-hook-form';
 
-import { AnimatePresence, motion } from 'framer-motion';
+import styled from 'styled-components';
 
 import { TranslationKey } from '@suite-common/intl-types';
+import { NetworkSymbol, NetworkType } from '@suite-common/wallet-config';
 import {
     FeeInfo,
     FormState,
@@ -18,19 +19,9 @@ import {
     PrecomposedTransactionFinal,
 } from '@suite-common/wallet-types';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
-import {
-    Banner,
-    Column,
-    InfoItem,
-    Note,
-    Row,
-    SelectBar,
-    Text,
-    Tooltip,
-    motionEasing,
-} from '@trezor/components';
+import { Banner, Column, InfoItem, Note, Row, SelectBar, Text, Tooltip } from '@trezor/components';
 import { FeeLevel } from '@trezor/connect';
-import { spacings } from '@trezor/theme';
+import { spacings, spacingsPx } from '@trezor/theme';
 
 import { FiatValue, FormattedCryptoAmount, Translation } from 'src/components/suite';
 import { Account } from 'src/types/wallet';
@@ -39,18 +30,26 @@ import { CustomFee } from './CustomFee';
 import { FeeDetails } from './FeeDetails';
 
 const FEE_LEVELS_TRANSLATIONS: Record<FeeLevel['label'], TranslationKey> = {
-    custom: 'FEE_LEVEL_CUSTOM',
+    custom: 'FEE_LEVEL_ADVANCED',
     high: 'FEE_LEVEL_HIGH',
     normal: 'FEE_LEVEL_NORMAL',
     economy: 'FEE_LEVEL_LOW',
     low: 'FEE_LEVEL_LOW',
 } as const;
 
-const buildFeeOptions = (levels: FeeLevel[]) =>
-    levels.map(({ label }) => ({
-        label: <Translation id={FEE_LEVELS_TRANSLATIONS[label]} />,
-        value: label,
-    }));
+export type FeeOption = {
+    label: React.ReactNode;
+    value: FeeLevel['label'];
+    blocks?: number;
+    feePerUnit?: string;
+    networkAmount?: string | null;
+    feePerTx?: string;
+};
+
+const SelectBarWrapper = styled.div`
+    justify-self: end;
+    margin-top: ${spacingsPx.xs};
+`;
 
 export interface FeesProps<TFieldValues extends FormState> {
     account: Account;
@@ -61,19 +60,77 @@ export interface FeesProps<TFieldValues extends FormState> {
     getValues: UseFormGetValues<TFieldValues>;
     errors: FieldErrors<TFieldValues>;
     changeFeeLevel: (level: FeeLevel['label']) => void;
-    changeFeeLimit?: (value: string) => void;
     composedLevels?: PrecomposedLevels | PrecomposedLevelsCardano;
     label?: TranslationKey;
     rbfForm?: boolean;
     helperText?: React.ReactNode;
 }
 
+const buildFeeOptions = (
+    levels: FeeLevel[],
+    networkType: NetworkType,
+    symbol: NetworkSymbol,
+    composedLevels?: PrecomposedLevels | PrecomposedLevelsCardano,
+) => {
+    const filteredLevels = levels.filter(level => level.label !== 'custom');
+
+    const getNetworkAmount = (level: FeeLevel) => {
+        const transactionInfo = composedLevels?.[level.label];
+        const hasTransactionInfo =
+            transactionInfo !== undefined && transactionInfo.type !== 'error';
+        const networkAmount = hasTransactionInfo
+            ? formatNetworkAmount(transactionInfo.fee, symbol)
+            : null;
+        // Needed only for Solana because of fee estimation on compose Tx
+        const fee = hasTransactionInfo ? transactionInfo.fee : level.feePerTx;
+
+        return { networkAmount, fee };
+    };
+
+    const buildBasicFeeOptions = (level: FeeLevel) => {
+        const { networkAmount } = getNetworkAmount(level);
+
+        return {
+            label: <Translation id={FEE_LEVELS_TRANSLATIONS[level.label]} />,
+            value: level.label,
+            feePerUnit: level.feePerUnit,
+            networkAmount,
+        };
+    };
+
+    switch (networkType) {
+        case 'solana':
+            return filteredLevels.map(level => {
+                const { fee } = getNetworkAmount(level);
+                const basicFeeOption = buildBasicFeeOptions(level);
+
+                return {
+                    ...basicFeeOption,
+                    feePerTx: fee,
+                };
+            });
+        case 'ethereum':
+            // legacy fee format
+            return filteredLevels.map(level => buildBasicFeeOptions(level));
+        case 'bitcoin':
+            return filteredLevels.map(level => {
+                const basicFeeOption = buildBasicFeeOptions(level);
+
+                return {
+                    ...basicFeeOption,
+                    blocks: level.blocks,
+                };
+            });
+        default:
+            return filteredLevels.map(level => buildBasicFeeOptions(level));
+    }
+};
+
 export const Fees = <TFieldValues extends FormState>({
     account: { symbol, networkType },
     feeInfo,
     control,
     changeFeeLevel,
-    changeFeeLimit,
     composedLevels,
     label,
     rbfForm,
@@ -82,134 +139,136 @@ export const Fees = <TFieldValues extends FormState>({
 }: FeesProps<TFieldValues>) => {
     // Type assertion allowing to make the component reusable, see https://stackoverflow.com/a/73624072.
     const { getValues, register, setValue } = props as unknown as UseFormReturn<FormState>;
-    const errors = props.errors as unknown as FieldErrors<FormState>;
 
     const selectedOption = getValues('selectedFee') || 'normal';
-    const isCustomLevel = selectedOption === 'custom';
+    const isCustomFee = selectedOption === 'custom';
+    const errors = props.errors as unknown as FieldErrors<FormState>;
 
     const error = errors.selectedFee;
     const selectedLevel = feeInfo.levels.find(level => level.label === selectedOption)!;
     const transactionInfo = composedLevels?.[selectedOption];
+
+    const feeOptions = buildFeeOptions(feeInfo.levels, networkType, symbol, composedLevels);
+
     const hasTransactionInfo = transactionInfo !== undefined && transactionInfo.type !== 'error';
-    // Solana has only `normal` fee level, so we do not display any feeOptions since there is nothing to choose from
-    const feeOptions = networkType === 'solana' ? [] : buildFeeOptions(feeInfo.levels);
-
-    const shouldAnimateNormalFee = !isCustomLevel;
-
     const networkAmount = hasTransactionInfo
         ? formatNetworkAmount(transactionInfo.fee, symbol)
         : null;
 
+    const supportsCustomFee = networkType !== 'solana';
+
     return (
-        <Column gap={spacings.xs}>
-            <InfoItem
-                direction="row"
-                typographyStyle="body"
-                label={
-                    networkType === 'ethereum' ? (
-                        <Tooltip
-                            maxWidth={328}
-                            hasIcon
-                            content={<Translation id="TR_STAKE_MAX_FEE_DESC" />}
-                        >
-                            <Translation id={label ?? 'MAX_FEE'} />
-                        </Tooltip>
-                    ) : (
-                        <Translation id={label ?? 'FEE'} />
-                    )
-                }
-            >
-                {networkAmount && (
-                    <Row gap={spacings.md} alignItems="baseline">
-                        <FormattedCryptoAmount
-                            disableHiddenPlaceholder
-                            value={networkAmount}
-                            symbol={symbol}
-                        />
-                        <Text variant="tertiary" typographyStyle="label">
-                            <FiatValue
-                                disableHiddenPlaceholder
-                                amount={networkAmount}
-                                symbol={symbol}
-                                showApproximationIndicator
-                            />
-                        </Text>
-                    </Row>
-                )}
-            </InfoItem>
-
-            {feeOptions.length > 0 && (
-                <>
-                    <SelectBar
-                        selectedOption={selectedOption}
-                        options={feeOptions}
-                        onChange={changeFeeLevel}
-                        isFullWidth
-                        margin={{ top: spacings.sm }}
-                    />
-                    <AnimatePresence>
-                        {shouldAnimateNormalFee && (
-                            <motion.div
-                                animate={shouldAnimateNormalFee ? 'open' : 'closed'}
-                                variants={{
-                                    open: { opacity: 1, height: 'auto', marginTop: 0 },
-                                    closed: { opacity: 0, height: 0, marginTop: 0 },
-                                }}
-                                transition={{
-                                    opacity: { duration: 0.15, ease: motionEasing.transition },
-                                    height: { duration: 0.2, ease: motionEasing.transition },
-                                    marginTop: { duration: 0.25, ease: motionEasing.transition },
-                                }}
-                            >
-                                <FeeDetails
-                                    networkType={networkType}
-                                    feeInfo={feeInfo}
-                                    selectedLevel={selectedLevel}
-                                    transactionInfo={transactionInfo}
-                                    showFee={true}
-                                />
-                            </motion.div>
-                        )}
-                    </AnimatePresence>
-
-                    <AnimatePresence>
-                        {isCustomLevel && (
-                            <motion.div
-                                initial={{ opacity: 0, height: 0, marginTop: 0 }}
-                                animate={{ opacity: 1, height: 'auto', marginTop: 0 }}
-                                exit={{ opacity: 0, height: 0, marginTop: 0 }}
-                                transition={{
-                                    opacity: { duration: 0.15, ease: motionEasing.transition },
-                                    height: { duration: 0.2, ease: motionEasing.transition },
-                                    marginTop: { duration: 0.25, ease: motionEasing.transition },
-                                }}
-                            >
-                                <CustomFee
-                                    control={control}
-                                    networkType={networkType}
-                                    feeInfo={feeInfo}
-                                    errors={errors}
-                                    register={register}
-                                    getValues={getValues}
-                                    setValue={setValue}
-                                    changeFeeLimit={changeFeeLimit}
-                                    composedFeePerByte={
-                                        (transactionInfo as PrecomposedTransactionFinal)?.feePerByte
+        <Column gap={spacings.md}>
+            <Row flexWrap="wrap">
+                <Row flex="1">
+                    <InfoItem
+                        direction="row"
+                        typographyStyle="body"
+                        verticalAlignment="bottom"
+                        label={
+                            <Row gap={spacings.xs}>
+                                <Tooltip
+                                    dashed
+                                    maxWidth={328}
+                                    content={
+                                        networkType === 'ethereum' ? (
+                                            <Translation id="TR_EVM_MAX_FEE_DESC" />
+                                        ) : (
+                                            <Translation id="TR_TRANSACTION_FEE_DESC" />
+                                        )
                                     }
-                                />
-                            </motion.div>
-                        )}
-                    </AnimatePresence>
+                                >
+                                    <Text variant="default">
+                                        <Translation
+                                            id={
+                                                label ??
+                                                (networkType === 'ethereum' ? 'MAX_FEE' : 'FEE')
+                                            }
+                                        />
+                                    </Text>
+                                </Tooltip>
+                            </Row>
+                        }
+                    />
+                </Row>
+                {supportsCustomFee && (
+                    <SelectBarWrapper>
+                        <SelectBar
+                            orientation="horizontal"
+                            selectedOption={isCustomFee ? 'custom' : 'normal'}
+                            options={[
+                                { label: <Translation id="FEE_LEVEL_STANDARD" />, value: 'normal' },
+                                { label: <Translation id="FEE_LEVEL_ADVANCED" />, value: 'custom' },
+                            ]}
+                            onChange={() => changeFeeLevel(isCustomFee ? 'normal' : 'custom')}
+                            isFullWidth
+                        />
+                    </SelectBarWrapper>
+                )}
+            </Row>
 
-                    {error && (
-                        <Banner icon margin={{ top: spacings.sm }} variant="destructive">
-                            {error.message}
-                        </Banner>
-                    )}
+            {!isCustomFee && (
+                <FeeDetails
+                    networkType={networkType}
+                    feeInfo={feeInfo}
+                    selectedLevel={selectedLevel}
+                    transactionInfo={transactionInfo}
+                    showFee={true}
+                    feeOptions={feeOptions}
+                    symbol={symbol}
+                    changeFeeLevel={changeFeeLevel}
+                />
+            )}
 
-                    {helperText && <Note margin={{ top: spacings.md }}>{helperText}</Note>}
+            {isCustomFee && (
+                <>
+                    <CustomFee
+                        control={control}
+                        networkType={networkType}
+                        feeInfo={feeInfo}
+                        errors={errors}
+                        register={register}
+                        getValues={getValues}
+                        setValue={setValue}
+                        composedFeePerByte={
+                            (transactionInfo as PrecomposedTransactionFinal)?.feePerByte
+                        }
+                    />
+                    <Column>
+                        <Row gap={spacings.sm} alignItems="baseline" justifyContent="space-between">
+                            <Text variant="tertiary" typographyStyle="hint">
+                                <Translation id="FEE" />:
+                            </Text>
+                            {networkAmount && (
+                                <Row gap={spacings.xxs}>
+                                    <Text variant="default" typographyStyle="hint">
+                                        <FormattedCryptoAmount
+                                            disableHiddenPlaceholder
+                                            value={networkAmount}
+                                            symbol={symbol}
+                                        />
+                                    </Text>
+                                    <Text variant="tertiary" typographyStyle="hint">
+                                        <FiatValue
+                                            disableHiddenPlaceholder
+                                            amount={networkAmount}
+                                            symbol={symbol}
+                                            showApproximationIndicator
+                                        />
+                                    </Text>
+                                </Row>
+                            )}
+                        </Row>
+                    </Column>
                 </>
             )}
+            {error && (
+                <Banner icon variant="destructive">
+                    {error.message}
+                </Banner>
+            )}
+
+            {helperText && <Note>{helperText}</Note>}
         </Column>
     );
 };

--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -1724,7 +1724,7 @@ export const feeChange = [
         actionSequence: [
             {
                 type: 'click',
-                element: 'select-bar/high',
+                element: '@fee-card/high',
                 result: {
                     composeTransactionCalls: 1,
                     formValues: {
@@ -1757,7 +1757,19 @@ export const feeChange = [
             },
             {
                 type: 'click',
-                element: 'select-bar/economy',
+                element: 'select-bar/normal',
+                result: {
+                    composeTransactionCalls: 1,
+                    formValues: {
+                        selectedFee: 'normal' as const,
+                        feePerUnit: '40',
+                    },
+                },
+            },
+
+            {
+                type: 'click',
+                element: '@fee-card/economy',
                 result: {
                     composeTransactionCalls: 1,
                     formValues: {

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3437,6 +3437,10 @@ export default defineMessages({
         id: 'TR_GAS_PRICE',
         defaultMessage: 'Gas price',
     },
+    TR_CURRENT_FEE_CUSTOM_FEES: {
+        id: 'TR_CURRENT_FEE_CUSTOM_FEES',
+        defaultMessage: 'Current network fee:',
+    },
     TR_GAS_LIMIT: {
         id: 'TR_GAS_LIMIT',
         defaultMessage: 'Gas limit',
@@ -5606,9 +5610,13 @@ export default defineMessages({
         description: 'Label in Send form for Solana network type',
         id: 'EXPECTED_FEE',
     },
-    FEE_LEVEL_CUSTOM: {
-        defaultMessage: 'Custom',
-        id: 'FEE_LEVEL_CUSTOM',
+    FEE_LEVEL_STANDARD: {
+        defaultMessage: 'Standard',
+        id: 'FEE_LEVEL_STANDARD',
+    },
+    FEE_LEVEL_ADVANCED: {
+        defaultMessage: 'Advanced',
+        id: 'FEE_LEVEL_ADVANCED',
     },
     FEE_LEVEL_HIGH: {
         defaultMessage: 'High',
@@ -8893,6 +8901,14 @@ export default defineMessages({
         id: 'TR_STAKE_MAX_FEE_DESC',
         defaultMessage:
             'Maximum fee is the network transaction fee that you’re willing to pay on the network to ensure your transaction gets processed.',
+    },
+    TR_EVM_MAX_FEE_DESC: {
+        id: 'TR_EVM_MAX_FEE_DESC',
+        defaultMessage: `The maximum fee you're willing to pay to network validators to get your transaction processed. A higher fee can speed up confirmation, though you'll only pay what's needed if the actual fee is lower.`,
+    },
+    TR_TRANSACTION_FEE_DESC: {
+        id: 'TR_TRANSACTION_FEE_DESC',
+        defaultMessage: `The transaction fee you're willing to pay to network miners to ensure your transaction gets processed. A higher fee can speed up confirmation times.`,
     },
     TR_STAKE_MAX: {
         id: 'TR_STAKE_MAX',

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormSwitcherExchangeRates.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormSwitcherExchangeRates.tsx
@@ -1,6 +1,6 @@
 import { UseFormSetValue } from 'react-hook-form';
 
-import { Column, Grid, Paragraph, RadioCard } from '@trezor/components';
+import { Column, ElevationUp, Grid, Paragraph, RadioCard } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { Translation } from 'src/components/suite';
@@ -20,16 +20,18 @@ type ItemProps = {
 };
 
 const Item = ({ isSelected, onClick, title, label }: ItemProps) => (
-    <RadioCard isActive={isSelected} onClick={onClick}>
-        <Column alignItems="flex-start" gap={spacings.xxxs}>
-            <Paragraph typographyStyle="highlight">
-                <Translation id={title} />
-            </Paragraph>
-            <Paragraph typographyStyle="hint">
-                <Translation id={label} />
-            </Paragraph>
-        </Column>
-    </RadioCard>
+    <ElevationUp>
+        <RadioCard isActive={isSelected} onClick={onClick}>
+            <Column alignItems="flex-start" gap={spacings.xxxs}>
+                <Paragraph typographyStyle="highlight">
+                    <Translation id={title} />
+                </Paragraph>
+                <Paragraph typographyStyle="hint">
+                    <Translation id={label} />
+                </Paragraph>
+            </Column>
+        </RadioCard>
+    </ElevationUp>
 );
 
 type TradingFormSwitcherExchangeRatesProps = {

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInputs.tsx
@@ -1,13 +1,6 @@
 import { TokenAddress } from '@suite-common/wallet-types';
 import { formatAmount } from '@suite-common/wallet-utils';
-import {
-    Card,
-    Column,
-    ElevationContext,
-    FractionButton,
-    FractionButtonProps,
-    Row,
-} from '@trezor/components';
+import { Column, FractionButton, FractionButtonProps, Row } from '@trezor/components';
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils/src/firmwareUtils';
 import { spacings } from '@trezor/theme';
 
@@ -131,21 +124,17 @@ export const TradingFormInputs = () => {
                         </Row>
                     )}
                 </Column>
-                <Card margin={{ vertical: spacings.sm }}>
-                    <ElevationContext baseElevation={0}>
-                        <Fees
-                            control={control}
-                            feeInfo={feeInfo}
-                            account={account}
-                            composedLevels={composedLevels}
-                            errors={errors}
-                            register={register}
-                            setValue={setValue}
-                            getValues={getValues}
-                            changeFeeLevel={changeFeeLevel}
-                        />
-                    </ElevationContext>
-                </Card>
+                <Fees
+                    control={control}
+                    feeInfo={feeInfo}
+                    account={account}
+                    composedLevels={composedLevels}
+                    errors={errors}
+                    register={register}
+                    setValue={setValue}
+                    getValues={getValues}
+                    changeFeeLevel={changeFeeLevel}
+                />
                 <TradingFormInputPaymentMethod label="TR_TRADING_RECEIVE_METHOD" />
                 <TradingFormInputCountry label="TR_TRADING_COUNTRY" />
             </>
@@ -218,21 +207,17 @@ export const TradingFormInputs = () => {
                     supportedCryptoCurrencies={supportedCryptoCurrencies}
                     methods={{ ...context }}
                 />
-                <Card margin={{ vertical: spacings.sm }}>
-                    <ElevationContext baseElevation={0}>
-                        <Fees
-                            control={control}
-                            feeInfo={feeInfo}
-                            account={account}
-                            composedLevels={composedLevels}
-                            errors={errors}
-                            register={register}
-                            setValue={setValue}
-                            getValues={getValues}
-                            changeFeeLevel={changeFeeLevel}
-                        />
-                    </ElevationContext>
-                </Card>
+                <Fees
+                    control={control}
+                    feeInfo={feeInfo}
+                    account={account}
+                    composedLevels={composedLevels}
+                    errors={errors}
+                    register={register}
+                    setValue={setValue}
+                    getValues={getValues}
+                    changeFeeLevel={changeFeeLevel}
+                />
                 <TradingFormSwitcherExchangeRates rateType={rateType} setValue={setValue} />
             </>
         );

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -126,6 +126,7 @@ export const networks = {
     },
     arb: {
         symbol: 'arb',
+        settlementLayer: 'eth',
         displaySymbol: 'ETH',
         displaySymbolName: 'Arbitrum One Ethereum',
         name: 'Arbitrum One',
@@ -150,6 +151,7 @@ export const networks = {
     },
     base: {
         symbol: 'base',
+        settlementLayer: 'eth',
         displaySymbol: 'ETH',
         displaySymbolName: 'Base Ethereum',
         name: 'Base',
@@ -174,6 +176,7 @@ export const networks = {
     },
     op: {
         symbol: 'op',
+        settlementLayer: 'eth',
         displaySymbol: 'ETH',
         displaySymbolName: 'Optimism Ethereum',
         name: 'Optimism',

--- a/suite-common/wallet-config/src/types.ts
+++ b/suite-common/wallet-config/src/types.ts
@@ -96,6 +96,7 @@ export type NetworkDeviceSupport = Partial<Record<DeviceModelInternal, string>>;
 
 type NetworkWithSpecificKey<TKey extends NetworkSymbol> = {
     symbol: TKey;
+    settlementLayer?: NetworkSymbol;
     displaySymbol: string;
     displaySymbolName?: string;
     name: string;

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -221,7 +221,7 @@ export const isLowAnonymityWarning = (error?: Merge<FieldError, FieldErrorsImpl<
 const mapNetworkTypeToFeeUnits: Record<NetworkType, string> = {
     bitcoin: 'sat/vB',
     cardano: 'Lovelaces/B',
-    ethereum: 'GWEI',
+    ethereum: 'Gwei',
     ripple: 'Drops',
     solana: 'Lamports',
 };


### PR DESCRIPTION
## Description
Implement new design to fees

! The wrong colors of Badge on different elevations is a known issue and @trezor/suite-engagement  is working on it 

[Design](https://www.figma.com/design/6ePOAsBHwKArEQ2DuYLqRl/Priority-fees?node-id=27-15615&t=T0BMtUteQfL476Zo-0)

Resolves [#16439](https://github.com/trezor/trezor-suite/issues/16439)
Resolve  #16832

## Screenshots:

#### Bitcoin:

![Screenshot 2025-02-17 at 13 10 55](https://github.com/user-attachments/assets/888ec065-8748-4c37-9ba6-56b0d141d919)

#### Bump fee: 

![Screenshot 2025-02-17 at 13 12 10](https://github.com/user-attachments/assets/0e81e94a-646f-4d81-b46b-8b8b57f2e2ec)
![Screenshot 2025-02-17 at 13 12 36](https://github.com/user-attachments/assets/7467a8a7-09ca-4ea7-b210-994dcb15134b)

#### Stake/unstake:
![Screenshot 2025-02-17 at 13 12 55](https://github.com/user-attachments/assets/f99a2ce4-f4fc-4e00-92ef-f13a637abd91)


#### Swap:
![Screenshot 2025-02-17 at 13 13 14](https://github.com/user-attachments/assets/5bced0ee-9e7e-4067-96f3-54e1295131fb)


#### Buy and sell:
![Screenshot 2025-02-17 at 13 13 35](https://github.com/user-attachments/assets/83d3b053-53c0-41d2-95bb-240a7d86fee0)



