### PR TITLE
fix(e2e): test 'compared offers' waits for quotes response before pro…

### DIFF
--- a/packages/suite-desktop-core/e2e/support/pageActions/marketActions.ts
+++ b/packages/suite-desktop-core/e2e/support/pageActions/marketActions.ts
@@ -225,7 +225,9 @@ export class MarketActions {
         await expect(this.youPayFiatInput).not.toHaveValue('');
         await this.selectCountryOfResidence(country);
         await this.selectFiatCurrency(currency);
+        const quotesPromise = this.page.waitForResponse(invityEndpoint.buyQuotes);
         await this.youPayFiatInput.fill(amount);
+        await quotesPromise;
         // Warning: Bug #16054, as a workaround we wait for offer sync after setting the amount
         await this.waitForOffersSyncToFinish();
     }


### PR DESCRIPTION
There was instability when test went to compared offers before the new quotes response arrived and as result the compared prices didn't have the correct input value
