### PR TITLE
fix(suite): enforce that the Security Check List icon is NOT just a s…

### DIFF
--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheck.tsx
@@ -27,6 +27,7 @@ import { selectSuiteFlags } from 'src/reducers/suite/suiteReducer';
 
 import { DeviceAuthenticity } from './DeviceAuthenticity';
 import { SecurityChecklist } from './SecurityChecklist';
+import { SecurityChecklistItem } from './types';
 
 const StyledCard = styled(CollapsibleOnboardingCard)`
     max-width: 840px;
@@ -90,15 +91,15 @@ const TooltipWrapper = styled.span`
 
 const firmwareInstalledChecklist = [
     {
-        icon: 'info',
+        icon: <Icon size={24} name="info" />,
         content: <Translation id="TR_ONBOARDING_DEVICE_CHECK_4" />,
     },
-] as const;
+] as const satisfies SecurityChecklistItem[];
 
 const getNoFirmwareChecklist = (isMobileLayout: boolean) =>
     [
         {
-            icon: 'verified',
+            icon: <Icon size={24} name="verified" />,
             content: (
                 <Translation
                     id="TR_ONBOARDING_DEVICE_CHECK_2"
@@ -118,7 +119,7 @@ const getNoFirmwareChecklist = (isMobileLayout: boolean) =>
             ),
         },
         {
-            icon: 'hologram',
+            icon: <Icon size={24} name="hologram" />,
             content: (
                 <Translation
                     id="TR_ONBOARDING_DEVICE_CHECK_1"
@@ -139,10 +140,10 @@ const getNoFirmwareChecklist = (isMobileLayout: boolean) =>
             ),
         },
         {
-            icon: 'package',
+            icon: <Icon size={24} name="package" />,
             content: <Translation id="TR_ONBOARDING_DEVICE_CHECK_3" />,
         },
-    ] as const;
+    ] as const satisfies SecurityChecklistItem[];
 
 type SecurityCheckContentProps = {
     goToDeviceAuthentication: () => void;

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/__tests__/types.test.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/__tests__/types.test.tsx
@@ -1,0 +1,26 @@
+import { Icon } from '@trezor/components';
+
+import { SecurityChecklistItem } from '../types';
+
+describe('SecurityChecklistItem', () => {
+    describe('type tests', () => {
+        it("should not accept icon: 'string' as an icon prop", () => {
+            const x: SecurityChecklistItem = {
+                // @ts-expect-error: this should correctly throw a TS error - it cannot be a string
+                icon: 'string',
+                content: <div />,
+            };
+
+            expect(x).toBeTruthy();
+        });
+
+        it('should accept icon: ReactElement<<Icon />> as an icon prop', () => {
+            const x: SecurityChecklistItem = {
+                icon: <Icon name="hologram" />,
+                content: <div />,
+            };
+
+            expect(x).toBeTruthy();
+        });
+    });
+});

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/types.ts
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/types.ts
@@ -1,7 +1,9 @@
-import { ReactNode } from 'react';
+import { ReactElement, ReactNode } from 'react';
+
+import { Icon, IconProps } from '@trezor/components';
 
 export type SecurityChecklistItem = {
-    icon: ReactNode;
+    icon: ReactElement<IconProps, typeof Icon>;
     content: ReactNode;
     subtitle?: ReactNode;
 };


### PR DESCRIPTION
…tring

<!--- Provide a general summary of your changes in the Title above -->

## Description

- an imperfect react type caused that needed updates were overlooked
- we improved the typing and fixed the cases so that it shouldn't happen again (altough, `<div />` still passes)

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/16692
## Screenshots:
Before
![Screenshot 2025-01-29 at 10 34 38 AM](https://github.com/user-attachments/assets/2e0e70b5-64f2-4e9d-a618-a52c1d5c8d7f)
After
<img width="866" alt="Screenshot 2025-01-29 at 10 34 42 AM" src="https://github.com/user-attachments/assets/cc625398-5abc-4203-8985-8a0bea09a8b1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced type safety for security checklist items
	- Improved icon rendering in security checklists

- **Tests**
	- Added type validation tests for security checklist items

- **Refactor**
	- Updated icon type definitions to be more specific
	- Replaced string-based icon references with React component icons

<!-- end of auto-generated comment: release notes by coderabbit.ai -->