### PR TITLE
Chore: desktop FW revision check code cleanup

### DIFF
--- a/packages/suite/src/constants/suite/firmware.ts
+++ b/packages/suite/src/constants/suite/firmware.ts
@@ -3,14 +3,15 @@ import { FilterPropertiesByType } from '@trezor/type-utils';
 import { isDevEnv } from '@suite-common/suite-utils';
 
 /*
- * Various scenarios how firmware authenticity check errors are handled
+ * Various scenarios how firmware authenticity check errors are handled in Suite
+ * see suite-native/device/src/config/firmware.ts for Suite Lite
  */
 
 // will be ignored completely
 type SkippedBehavior = { type: 'skipped'; shouldReport: boolean };
-// display `SuiteBanners` warning
+// display a warning banner
 type SoftWarningBehavior = { type: 'softWarning'; shouldReport: true };
-// display `SuiteBanners`, show `DeviceCompromised` modal, block receiving address
+// display "Device Compromised" modal, after closing it display a warning banner, block receiving address
 type HardModalBehavior = { type: 'hardModal'; shouldReport: true };
 
 type RevisionErrorBehavior = SoftWarningBehavior | HardModalBehavior;

--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -112,7 +112,7 @@ export const HELP_CENTER_EVM_ADDRESS_CHECKSUM: Url =
 export const HELP_CENTER_EVM_SEND_TO_CONTRACT_URL =
     'https://trezor.io/support/a/where-is-my-ethereum';
 export const HELP_CENTER_FIRMWARE_REVISION_CHECK: Url =
-    'https://trezor.io/learn/a/trezor-firmware-revision-check';
+    'https://trezor.io/learn/a/trezor-firmware-authenticity-check';
 export const HELP_CENTER_REPLACE_BY_FEE: Url =
     'https://trezor.io/learn/a/replace-by-fee-rbf-ethereum';
 


### PR DESCRIPTION
## Description

Having implemented FW revision check in mobile in #16435, I noticed two tiny things to enhance in Desktop:

- update an outdated link to trezor.io
- update code comments to link with [similar section in mobile](https://github.com/trezor/trezor-suite/blob/a80b4248560a451241ccf8e7d28360b89c259ee9/suite-native/device/src/config/firmware.ts)