### PR TITLE
feat(connect): trust localhost subdomains

### DIFF
--- a/packages/connect/src/utils/__tests__/urlUtils.test.ts
+++ b/packages/connect/src/utils/__tests__/urlUtils.test.ts
@@ -16,6 +16,7 @@ describe('utils/urlUtils', () => {
 
     it('getHost', () => {
         expect(getHost('http://localhost:8088/')).toEqual('localhost');
+        expect(getHost('http://subdomain.localhost:8088/')).toEqual('localhost');
         expect(getHost('file://index.html')).toEqual(undefined);
         expect(getHost('https://trezor.io')).toEqual('trezor.io');
         expect(getHost('https://connect.trezor.io')).toEqual('trezor.io');

--- a/packages/connect/src/utils/urlUtils.ts
+++ b/packages/connect/src/utils/urlUtils.ts
@@ -16,6 +16,9 @@ export const getHost = (url: unknown) => {
     if (uri) {
         const parts = uri.split('.');
 
+        // allow localhost subdomains
+        if (parts[parts.length - 1] === 'localhost') return 'localhost';
+
         return parts.length > 2
             ? // slice subdomain
               parts.slice(parts.length - 2, parts.length).join('.')


### PR DESCRIPTION
## Description

Treat subdomains of localhost (eg. https://subdomain.localhost/) the same way we treat localhost itself.

## Related Issue

Resolve #16671
