### PR TITLE
chore(suite-native): Unify PriceChangeIndicator

### DIFF
--- a/suite-native/atoms/jest.config.js
+++ b/suite-native/atoms/jest.config.js
@@ -1,0 +1,11 @@
+/**
+ * Jest configuration for native packages.
+ * Keeping this file next to the package.json file instead of providing configuration
+ * with `-c ../../jest.config.native` option in package.json scripts
+ * allows us to run jest tests directly from IDEs.
+ */
+const { ...baseConfig } = require('../../jest.config.native');
+
+module.exports = {
+    ...baseConfig,
+};

--- a/suite-native/atoms/package.json
+++ b/suite-native/atoms/package.json
@@ -8,7 +8,7 @@
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build",
-        "test:unit": "yarn g:jest -c ../../jest.config.native.js"
+        "test:unit": "yarn g:jest"
     },
     "dependencies": {
         "@gorhom/bottom-sheet": "5.0.5",

--- a/suite-native/atoms/src/PriceChangeBadge.tsx
+++ b/suite-native/atoms/src/PriceChangeBadge.tsx
@@ -1,0 +1,37 @@
+import { IconName } from '@suite-native/icons';
+
+import { Badge, BadgeVariant } from './Badge';
+import { BoxSkeleton } from './Skeleton/BoxSkeleton';
+
+export type PriceChangeBadgeProps = {
+    valuePercentageChange: number | null;
+};
+
+const percentFormatter = new Intl.NumberFormat('en-US', {
+    style: 'percent',
+    maximumSignificantDigits: 3,
+    minimumSignificantDigits: 3,
+});
+
+export const PriceChangeBadge = ({ valuePercentageChange }: PriceChangeBadgeProps) => {
+    const percentageChange = valuePercentageChange ?? 0;
+    const priceHasIncreased = percentageChange >= 0;
+
+    const icon: IconName = priceHasIncreased ? 'caretUpFilled' : 'caretDownFilled';
+    const badgeVariant: BadgeVariant = priceHasIncreased ? 'greenSubtle' : 'red';
+    const formattedPercentage = percentFormatter.format(percentageChange);
+
+    if (valuePercentageChange == null) {
+        return <BoxSkeleton width={70} height={24} borderRadius={12} />;
+    }
+
+    return (
+        <Badge
+            icon={icon}
+            iconSize="medium"
+            size="medium"
+            variant={badgeVariant}
+            label={formattedPercentage}
+        />
+    );
+};

--- a/suite-native/atoms/src/__tests__/PriceChangeBadge.comp.test.tsx
+++ b/suite-native/atoms/src/__tests__/PriceChangeBadge.comp.test.tsx
@@ -1,0 +1,48 @@
+import { BasicProvider, render, renderHook } from '@suite-native/test-utils';
+import { NativeStyleUtils, useNativeStyles } from '@trezor/styles';
+
+import { Box as MockBox } from '../Box';
+import { PriceChangeBadge } from '../PriceChangeBadge';
+
+jest.mock('../Skeleton/BoxSkeleton', () => ({
+    BoxSkeleton: () => <MockBox testID="skeleton-box" />,
+}));
+
+describe('PriceChangeBadge', () => {
+    let colors: NativeStyleUtils['colors'];
+
+    beforeAll(() => {
+        const { result } = renderHook(() => useNativeStyles(), { wrapper: BasicProvider });
+        ({ colors } = result.current.utils);
+    });
+
+    it('should render green badge for change > 0', () => {
+        const { getByText } = render(<PriceChangeBadge valuePercentageChange={0.01} />);
+
+        expect(getByText('1.00%')).toHaveStyle({ color: colors.textPrimaryDefault });
+    });
+
+    it('should render green badge for change = 0', () => {
+        const { getByText } = render(<PriceChangeBadge valuePercentageChange={0} />);
+
+        expect(getByText('0.00%')).toHaveStyle({ color: colors.textPrimaryDefault });
+    });
+
+    it('should render red badge for change < 0', () => {
+        const { getByText } = render(<PriceChangeBadge valuePercentageChange={-0.01} />);
+
+        expect(getByText('-1.00%')).toHaveStyle({ color: colors.textAlertRed });
+    });
+
+    it('should render skeleton when value is null', () => {
+        const { getByTestId } = render(<PriceChangeBadge valuePercentageChange={null} />);
+
+        expect(getByTestId('skeleton-box')).toBeDefined();
+    });
+
+    it('should render 3 significant digits', () => {
+        const { getByText } = render(<PriceChangeBadge valuePercentageChange={0.1234} />);
+
+        expect(getByText('12.3%')).toBeDefined();
+    });
+});

--- a/suite-native/atoms/src/index.ts
+++ b/suite-native/atoms/src/index.ts
@@ -56,5 +56,6 @@ export * from './SelectableItem';
 export * from './constants';
 export * from './useIllustrationColors';
 export * from './utils';
+export * from './PriceChangeBadge';
 
 export { useDebugView } from './DebugView';

--- a/suite-native/graph/src/components/GraphFiatBalance.tsx
+++ b/suite-native/graph/src/components/GraphFiatBalance.tsx
@@ -20,7 +20,6 @@ type BalanceProps = {
 type GraphFiatBalanceProps = BalanceProps & {
     referencePointAtom: Atom<FiatGraphPoint | null>;
     percentageChangeAtom: Atom<number>;
-    hasPriceIncreasedAtom: Atom<boolean>;
     showChange?: boolean;
     isLoading?: boolean;
     totalFiatBalance: string;
@@ -55,7 +54,6 @@ export const GraphFiatBalance = ({
     selectedPointAtom,
     referencePointAtom,
     percentageChangeAtom,
-    hasPriceIncreasedAtom,
     showChange = true,
     isLoading = false,
     totalFiatBalance,
@@ -101,10 +99,7 @@ export const GraphFiatBalance = ({
                         firstPointDate={firstGraphPoint.date}
                         selectedPointAtom={selectedPointAtom}
                     />
-                    <PriceChangeIndicator
-                        hasPriceIncreasedAtom={hasPriceIncreasedAtom}
-                        percentageChangeAtom={percentageChangeAtom}
-                    />
+                    <PriceChangeIndicator percentageChangeAtom={percentageChangeAtom} />
                 </HStack>
             )}
         </Box>

--- a/suite-native/graph/src/components/PriceChangeIndicator.tsx
+++ b/suite-native/graph/src/components/PriceChangeIndicator.tsx
@@ -1,86 +1,15 @@
 import { Atom, useAtom } from 'jotai';
 
-import { HStack, Text } from '@suite-native/atoms';
-import { Icon, IconName } from '@suite-native/icons';
-import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+import { PriceChangeBadge } from '@suite-native/atoms';
+
+type PercentageChangeAtom = Atom<number>;
 
 type PriceChangeIndicatorProps = {
     percentageChangeAtom: PercentageChangeAtom;
-    hasPriceIncreasedAtom: HasPriceIncreasedAtom;
 };
 
-const getColorForPercentageChange = (hasIncreased: boolean) =>
-    hasIncreased ? 'textPrimaryDefault' : 'textAlertRed';
-
-type PercentageChangeAtom = Atom<number>;
-type HasPriceIncreasedAtom = Atom<boolean>;
-
-type PercentageChangeProps = {
-    percentageChangeAtom: PercentageChangeAtom;
-    hasPriceIncreasedAtom: HasPriceIncreasedAtom;
-};
-
-const PRICE_CHANGE_ICON_SIZE = 12;
-
-const PercentageChange = ({
-    percentageChangeAtom,
-    hasPriceIncreasedAtom,
-}: PercentageChangeProps) => {
+export const PriceChangeIndicator = ({ percentageChangeAtom }: PriceChangeIndicatorProps) => {
     const [percentageChange] = useAtom(percentageChangeAtom);
-    const [hasPriceIncreased] = useAtom(hasPriceIncreasedAtom);
 
-    return (
-        <Text color={getColorForPercentageChange(hasPriceIncreased)} variant="label">
-            {percentageChange.toFixed(2)}%
-        </Text>
-    );
-};
-
-const PercentageChangeArrow = ({
-    hasPriceIncreasedAtom,
-}: {
-    hasPriceIncreasedAtom: HasPriceIncreasedAtom;
-}) => {
-    const [hasPriceIncreased] = useAtom(hasPriceIncreasedAtom);
-
-    const iconName: IconName = hasPriceIncreased ? 'caretUpFilled' : 'caretDownFilled';
-
-    return (
-        <Icon
-            name={iconName}
-            color={getColorForPercentageChange(hasPriceIncreased)}
-            size={PRICE_CHANGE_ICON_SIZE}
-        />
-    );
-};
-
-const priceIncreaseWrapperStyle = prepareNativeStyle<{ hasPriceIncreased: boolean }>(
-    (utils, { hasPriceIncreased }) => ({
-        backgroundColor: hasPriceIncreased
-            ? utils.colors.backgroundPrimarySubtleOnElevation0
-            : utils.colors.backgroundAlertRedSubtleOnElevation0,
-        flexDirection: 'row',
-        alignItems: 'center',
-        paddingHorizontal: utils.spacings.sp8,
-        paddingVertical: utils.spacings.sp2,
-        borderRadius: utils.borders.radii.round,
-    }),
-);
-
-export const PriceChangeIndicator = ({
-    hasPriceIncreasedAtom,
-    percentageChangeAtom,
-}: PriceChangeIndicatorProps) => {
-    const { applyStyle } = useNativeStyles();
-    const [hasPriceIncreased] = useAtom(hasPriceIncreasedAtom);
-
-    return (
-        <HStack spacing="sp4" style={applyStyle(priceIncreaseWrapperStyle, { hasPriceIncreased })}>
-            <PercentageChangeArrow hasPriceIncreasedAtom={hasPriceIncreasedAtom} />
-            <PercentageChange
-                hasPriceIncreasedAtom={hasPriceIncreasedAtom}
-                percentageChangeAtom={percentageChangeAtom}
-            />
-        </HStack>
-    );
+    return <PriceChangeBadge valuePercentageChange={percentageChange} />;
 };

--- a/suite-native/graph/src/utils.ts
+++ b/suite-native/graph/src/utils.ts
@@ -56,5 +56,5 @@ export const getExtremaFromGraphPoints = (points: FiatGraphPoint[]) => {
 export const percentageDiff = (a: number, b: number) => {
     if (a === 0 || b === 0) return 0;
 
-    return 100 * ((b - a) / ((b + a) / 2));
+    return (b - a) / ((b + a) / 2);
 };

--- a/suite-native/module-accounts-management/src/accountDetailGraphAtoms.ts
+++ b/suite-native/module-accounts-management/src/accountDetailGraphAtoms.ts
@@ -15,9 +15,3 @@ export const percentageChangeAtom = atom(get => {
 
     return percentageDiff(referencePoint.value, selectedPoint.value);
 });
-
-export const hasPriceIncreasedAtom = atom(get => {
-    const percentageChange = get(percentageChangeAtom);
-
-    return percentageChange >= 0;
-});

--- a/suite-native/module-accounts-management/src/components/AccountDetailHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountDetailHeader.tsx
@@ -23,7 +23,6 @@ import {
 
 import { AccountDetailCryptoValue } from './AccountDetailCryptoValue';
 import {
-    hasPriceIncreasedAtom,
     percentageChangeAtom,
     referencePointAtom,
     selectedPointAtom,
@@ -104,7 +103,6 @@ export const AccountDetailHeader = ({
                 selectedPointAtom={selectedPointAtom}
                 referencePointAtom={referencePointAtom}
                 percentageChangeAtom={percentageChangeAtom}
-                hasPriceIncreasedAtom={hasPriceIncreasedAtom}
                 showChange={isHistoryEnabledAccount}
                 totalFiatBalance={totalFiatBalance}
                 isHistoryEnabledAccount={isHistoryEnabledAccount}

--- a/suite-native/module-accounts-management/src/components/CoinPriceCard.tsx
+++ b/suite-native/module-accounts-management/src/components/CoinPriceCard.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import { getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
 import { AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
 import { AccountKey } from '@suite-common/wallet-types';
-import { Badge, Box, BoxSkeleton, Card, RoundedIcon, Text } from '@suite-native/atoms';
+import { Box, Card, PriceChangeBadge, RoundedIcon, Text } from '@suite-native/atoms';
 import { FiatAmountFormatter } from '@suite-native/formatters';
 import { Translation } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
@@ -44,31 +44,12 @@ const indicatorContainer = prepareNativeStyle(utils => ({
 const PriceChangeIndicator = ({ valuePercentageChange }: PriceChangeIndicatorProps) => {
     const { applyStyle } = useNativeStyles();
 
-    const percentageChange = valuePercentageChange ?? 0;
-    const priceHasIncreased = percentageChange >= 0;
-
-    const icon = priceHasIncreased ? 'arrowUp' : 'arrowDown';
-    const badgeVariant = priceHasIncreased ? 'greenSubtle' : 'red';
-    const formattedPercentage = `${percentageChange.toPrecision(3)} %`;
-
     return (
         <Box style={applyStyle(indicatorContainer)}>
             <Text variant="label" color="textSubdued">
                 <Translation id="moduleAccountManagement.accountDetailContentScreen.coinPriceCard.changeIn24h" />
             </Text>
-            <Box justifyContent="center" alignItems="center" flexDirection="row">
-                {valuePercentageChange ? (
-                    <Badge
-                        icon={icon}
-                        iconSize="extraSmall"
-                        size="medium"
-                        variant={badgeVariant}
-                        label={formattedPercentage}
-                    />
-                ) : (
-                    <BoxSkeleton width={70} height={24} borderRadius={12} />
-                )}
-            </Box>
+            <PriceChangeBadge valuePercentageChange={valuePercentageChange} />
         </Box>
     );
 };

--- a/suite-native/module-dev-utils/src/screens/DemoScreen.tsx
+++ b/suite-native/module-dev-utils/src/screens/DemoScreen.tsx
@@ -17,6 +17,7 @@ import {
     Input,
     InputWrapper,
     NumPadButton,
+    PriceChangeBadge,
     Radio,
     SearchInput,
     Switch,
@@ -112,6 +113,15 @@ export const DemoScreen = () => {
                             />
                         ))}
                         <Badge key="disabled" label="disabled" icon="question" isDisabled />
+                    </HStack>
+                </VStack>
+                <VStack>
+                    <Text variant="titleSmall">PriceChangeBadge:</Text>
+                    <HStack justifyContent="center" style={applyStyle(flexWrapStyle)}>
+                        <PriceChangeBadge valuePercentageChange={0.123} />
+                        <PriceChangeBadge valuePercentageChange={-1.23} />
+                        <PriceChangeBadge valuePercentageChange={0} />
+                        <PriceChangeBadge valuePercentageChange={null} />
                     </HStack>
                 </VStack>
                 <Divider />

--- a/suite-native/module-home/src/screens/HomeScreen/components/PortfolioHeader.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/PortfolioHeader.tsx
@@ -4,7 +4,6 @@ import { Box, VStack } from '@suite-native/atoms';
 import { GraphFiatBalance, selectHasDeviceHistoryEnabledAccounts } from '@suite-native/graph';
 
 import {
-    hasPriceIncreasedAtom,
     percentageChangeAtom,
     referencePointAtom,
     selectedPointAtom,
@@ -25,7 +24,6 @@ export const PortfolioHeader = ({ isLoading, totalFiatBalance }: PortfolioHeader
                     selectedPointAtom={selectedPointAtom}
                     referencePointAtom={referencePointAtom}
                     percentageChangeAtom={percentageChangeAtom}
-                    hasPriceIncreasedAtom={hasPriceIncreasedAtom}
                     showChange={hasDeviceHistoryEnabledAccounts}
                     isLoading={isLoading}
                     totalFiatBalance={totalFiatBalance}

--- a/suite-native/module-home/src/screens/HomeScreen/portfolioGraphAtoms.ts
+++ b/suite-native/module-home/src/screens/HomeScreen/portfolioGraphAtoms.ts
@@ -18,9 +18,3 @@ export const percentageChangeAtom = atom(get => {
 
     return percentageDiff(referencePoint.value, selectedPoint.value);
 });
-
-export const hasPriceIncreasedAtom = atom(get => {
-    const percentageChange = get(percentageChangeAtom);
-
-    return percentageChange >= 0;
-});

--- a/suite-native/test-utils/src/index.tsx
+++ b/suite-native/test-utils/src/index.tsx
@@ -17,3 +17,5 @@ export {
 export const render = createRender(BasicProvider);
 
 export const renderWithStore = createRender(StoreProviderForTests);
+
+export { BasicProvider, StoreProviderForTests };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- Refactored "Price change badges" to single component which is used from "everywhere".
- Unified look. (size, colors, carets)

## Questions
- When change is exactly 0%. Badge is green. Is this intended or do we want to introduce grey state?
- Previously when change was exactly 0%, skeleton element was displayed instead. I expect this was a bug. (Now covered by test.)
- Do we want to add `PriceChangeIndicator` to Component demo screen?

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
![Screenshot 2025-01-30 at 13 42 34](https://github.com/user-attachments/assets/57a90bd2-6c4f-482f-adc3-065807945a74)


