### PR TITLE
Build: connect plugins support esm

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -72,6 +72,7 @@ test-results
 
 lib
 libDev
+libESM
 dist
 public
 coverage

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ playwright-report
 # build outputs
 lib
 libDev
+libESM
 dist
 public
 coverage

--- a/.nxignore
+++ b/.nxignore
@@ -55,6 +55,7 @@ test-results
 
 lib
 libDev
+libESM
 dist
 public
 coverage

--- a/.prettierignore
+++ b/.prettierignore
@@ -52,6 +52,7 @@ __pycache__/
 # build outputs
 lib
 libDev
+libESM
 dist
 public
 coverage

--- a/packages/connect-plugin-ethereum/package.json
+++ b/packages/connect-plugin-ethereum/package.json
@@ -23,8 +23,14 @@
     },
     "main": "src/index.ts",
     "files": [
-        "lib/"
+        "lib/",
+        "libESM",
+        "!**/*.map"
     ],
+    "exports": {
+        "node": "./lib/index.js",
+        "default": "./libESM/index.js"
+    },
     "peerDependencies": {
         "@metamask/eth-sig-util": "^8.0.0",
         "tslib": "^2.6.2"
@@ -35,6 +41,8 @@
     "scripts": {
         "test:unit": "yarn g:jest -c ../../jest.config.base.js",
         "type-check": "yarn g:tsc --build tsconfig.json",
-        "build:lib": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/replace-imports.sh ./lib"
+        "build:lib": "yarn build:lib:cjs && yarn build:lib:esm",
+        "build:lib:cjs": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/replace-imports.sh ./lib",
+        "build:lib:esm": "yarn g:rimraf ./libESM && yarn g:tsc --build tsconfig.libESM.json && ../../scripts/replace-imports.sh ./libESM libESM"
     }
 }

--- a/packages/connect-plugin-ethereum/tsconfig.libESM.json
+++ b/packages/connect-plugin-ethereum/tsconfig.libESM.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig.lib.json",
+    "compilerOptions": {
+        "outDir": "libESM",
+        "module": "ESNext",
+        "target": "esnext"
+    }
+}

--- a/packages/connect-plugin-stellar/package.json
+++ b/packages/connect-plugin-stellar/package.json
@@ -22,8 +22,14 @@
     "publishConfig": {
         "main": "lib/index.js"
     },
+    "exports": {
+        "node": "./lib/index.js",
+        "default": "./libESM/index.js"
+    },
     "files": [
-        "lib/"
+        "lib/",
+        "libESM",
+        "!**/*.map"
     ],
     "peerDependencies": {
         "@stellar/stellar-sdk": "^12.1.3",
@@ -40,6 +46,8 @@
     "scripts": {
         "test:unit": "jest -c ../../jest.config.base.js",
         "type-check": "yarn g:tsc --build tsconfig.json",
-        "build:lib": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/replace-imports.sh ./lib"
+        "build:lib": "yarn build:lib:cjs && yarn build:lib:esm",
+        "build:lib:cjs": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/replace-imports.sh ./lib",
+        "build:lib:esm": "yarn g:rimraf ./libESM && yarn g:tsc --build tsconfig.libESM.json && ../../scripts/replace-imports.sh ./libESM libESM"
     }
 }

--- a/packages/connect-plugin-stellar/tsconfig.libESM.json
+++ b/packages/connect-plugin-stellar/tsconfig.libESM.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig.lib.json",
+    "compilerOptions": {
+        "outDir": "libESM",
+        "module": "ESNext",
+        "target": "esnext"
+    }
+}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -20,12 +20,15 @@
     "main": "src/index.ts",
     "files": [
         "lib/",
+        "libESM",
         "!**/*.map"
     ],
     "scripts": {
         "test:unit": "yarn g:jest --verbose -c ./jest.config.js",
         "type-check": "yarn g:tsc --build tsconfig.json",
-        "build:lib": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/replace-imports.sh ./lib",
+        "build:lib": "yarn build:lib:cjs && yarn build:lib:esm",
+        "build:lib:cjs": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/replace-imports.sh ./lib",
+        "build:lib:esm": "yarn g:rimraf ./libESM && yarn g:tsc --build tsconfig.libESM.json && ../../scripts/replace-imports.sh ./libESM libESM",
         "prepublishOnly": "yarn tsx ../../scripts/prepublishNPM.js",
         "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },

--- a/packages/utils/tsconfig.libESM.json
+++ b/packages/utils/tsconfig.libESM.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig.lib.json",
+    "compilerOptions": {
+        "outDir": "libESM",
+        "module": "ESNext",
+        "target": "esnext"
+    }
+}

--- a/scripts/replace-imports.sh
+++ b/scripts/replace-imports.sh
@@ -2,7 +2,34 @@
 
 set -euxo pipefail
 
-REGEX="s/@trezor\/([^/]+)\/src/@trezor\/\1\/lib/g"
+# Usage: 
+#   bash replace-imports.sh <directory> [lib-type]
+#
+# Arguments:
+#   <directory>   The path to the directory containing files to modify.
+#   [lib-type]    (Optional) The type of library to use. Defaults to "lib" if not provided.
+#                 Use "libESM" for ESM libraries.
+#
+# Example:
+#   To replace imports in the ./lib directory using the default library type:
+#     bash replace-imports.sh ./lib
+#
+#   To replace imports in the ./libESM directory using the "libESM" library type:
+#     bash replace-imports.sh ./libESM libESM
+
+# By default set to "lib" but when providing second argument it uses it.
+if [ $# -ge 2 ]; then
+    LIB_TYPE="$2"
+else
+    LIB_TYPE="lib"
+fi
+
+# Set the regex based on the LIB_TYPE argument
+if [[ "$LIB_TYPE" == "libESM" ]]; then
+    REGEX="s/@trezor\/([^/]+)\/src/@trezor\/\1\/libESM/g"
+else
+    REGEX="s/@trezor\/([^/]+)\/src/@trezor\/\1\/lib/g"
+fi
 
 # Determine the operating system
 OS="$(uname)"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -32,6 +32,7 @@
     "exclude": [
         "**/node_modules",
         "**/lib",
+        "**/libESM",
         "**/libDev",
         "**/build",
         "**/build-electron",

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -15,6 +15,7 @@
     "exclude": [
         "**/node_modules",
         "**/lib",
+        "**/libESM",
         "**/libDev",
         "**/build",
         "**/build-electron",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add esm support to connect plugins.
* Using the field `"exports"` in package.json to define the entry points of the libraries. While keeping the previous `publishConfig` for bundlers that do not support `exports`. Using `exports` give us control over the entry points that are accessible they the developers using this packages, making it more clear in the future if we change somehting in source we can be safe since they only will use whatever entrypoints we define there. 
* The packages are including a new `libESM` that will be publish to NPM.
 
## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/16245



