### PR TITLE
feat(suite): show FW hash check other-error when debug settings

### DIFF
--- a/packages/suite/src/constants/suite/firmware.ts
+++ b/packages/suite/src/constants/suite/firmware.ts
@@ -1,18 +1,19 @@
 import { FirmwareHashCheckError, FirmwareRevisionCheckError } from '@trezor/connect';
 import { FilterPropertiesByType } from '@trezor/type-utils';
-import { isDevEnv } from '@suite-common/suite-utils';
 
 /*
  * Various scenarios how firmware authenticity check errors are handled in Suite
  * see suite-native/device/src/config/firmware.ts for Suite Lite
  */
 
+type BehaviorBaseType = { shouldReport: boolean; debugOnly?: boolean };
+
 // will be ignored completely
-type SkippedBehavior = { type: 'skipped'; shouldReport: boolean };
+type SkippedBehavior = BehaviorBaseType & { type: 'skipped' };
 // display a warning banner
-type SoftWarningBehavior = { type: 'softWarning'; shouldReport: true };
+type SoftWarningBehavior = BehaviorBaseType & { type: 'softWarning'; shouldReport: true };
 // display "Device Compromised" modal, after closing it display a warning banner, block receiving address
-type HardModalBehavior = { type: 'hardModal'; shouldReport: true };
+type HardModalBehavior = BehaviorBaseType & { type: 'hardModal'; shouldReport: true };
 
 type RevisionErrorBehavior = SoftWarningBehavior | HardModalBehavior;
 type RevisionCheckErrorScenarios = Record<FirmwareRevisionCheckError, RevisionErrorBehavior>;
@@ -33,8 +34,8 @@ export const hashCheckErrorScenarios = {
     'check-unsupported': { type: 'skipped', shouldReport: false },
     // could mean counterfeit firmware, but it's also caught by revision check, which handles edge-cases better
     'unknown-release': { type: 'skipped', shouldReport: false },
-    // TODO fix FW hash check unreliability & reenable on production
-    'other-error': { type: isDevEnv ? 'hardModal' : 'skipped', shouldReport: true },
+    // TODO fix FW hash check unreliability & reenable on production (outside of debug mode)
+    'other-error': { type: 'hardModal', shouldReport: true, debugOnly: true },
 } satisfies HashCheckErrorScenarios;
 
 export type SkippedHashCheckError = keyof FilterPropertiesByType<
@@ -45,3 +46,9 @@ export type SkippedHashCheckError = keyof FilterPropertiesByType<
 export const isSkippedHashCheckError = (
     error: FirmwareHashCheckError,
 ): error is SkippedHashCheckError => hashCheckErrorScenarios[error].type === 'skipped';
+
+export const isDebugOnlyRevisionCheckError = (error: FirmwareRevisionCheckError): boolean =>
+    (revisionCheckErrorScenarios[error] as RevisionErrorBehavior).debugOnly ?? false;
+
+export const isDebugOnlyHashCheckError = (error: FirmwareHashCheckError): boolean =>
+    (hashCheckErrorScenarios[error] as HashErrorBehavior).debugOnly ?? false;

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -22,6 +22,8 @@ import { getExcludedPrerequisites, getPrerequisiteName } from 'src/utils/suite/p
 import { SIDEBAR_WIDTH_NUMERIC } from 'src/constants/suite/layout';
 import {
     hashCheckErrorScenarios,
+    isDebugOnlyHashCheckError,
+    isDebugOnlyRevisionCheckError,
     isSkippedHashCheckError,
     revisionCheckErrorScenarios,
 } from 'src/constants/suite/firmware';
@@ -493,11 +495,19 @@ export const selectFirmwareRevisionCheckError = (state: AppState) => {
 
 export const selectFirmwareRevisionCheckErrorIfEnabled = (state: AppState) => {
     const revisionCheckError = selectFirmwareRevisionCheckError(state);
-    const { isFirmwareRevisionCheckDisabled } = state.suite.settings;
-    const isDisabledByMessage = selectIsFeatureDisabled(state, Feature.firmwareRevisionCheck);
-    const isCheckEnabled = !isFirmwareRevisionCheckDisabled && !isDisabledByMessage;
+    if (revisionCheckError === null) return null;
 
-    return isCheckEnabled ? revisionCheckError : null;
+    const { isFirmwareRevisionCheckDisabled } = state.suite.settings;
+    if (isFirmwareRevisionCheckDisabled) return null;
+
+    const isDisabledByMessageSystem = selectIsFeatureDisabled(state, Feature.firmwareRevisionCheck);
+    if (isDisabledByMessageSystem) return null;
+
+    const isHiddenBehindDebug =
+        isDebugOnlyRevisionCheckError(revisionCheckError) && !selectIsDebugModeActive(state);
+    if (isHiddenBehindDebug) return null;
+
+    return revisionCheckError;
 };
 
 /**
@@ -518,11 +528,19 @@ export const selectFirmwareHashCheckError = (state: AppState) => {
 
 export const selectFirmwareHashCheckErrorIfEnabled = (state: AppState) => {
     const hashCheckError = selectFirmwareHashCheckError(state);
-    const { isFirmwareHashCheckDisabled } = state.suite.settings;
-    const isDisabledByMessage = selectIsFeatureDisabled(state, Feature.firmwareHashCheck);
-    const isCheckEnabled = !isFirmwareHashCheckDisabled && !isDisabledByMessage;
+    if (hashCheckError === null) return null;
 
-    return isCheckEnabled ? hashCheckError : null;
+    const { isFirmwareHashCheckDisabled } = state.suite.settings;
+    if (isFirmwareHashCheckDisabled) return null;
+
+    const isDisabledByMessageSystem = selectIsFeatureDisabled(state, Feature.firmwareHashCheck);
+    if (isDisabledByMessageSystem) return null;
+
+    const isHiddenBehindDebug =
+        isDebugOnlyHashCheckError(hashCheckError) && !selectIsDebugModeActive(state);
+    if (isHiddenBehindDebug) return null;
+
+    return hashCheckError;
 };
 
 /**


### PR DESCRIPTION
## Description

Currently, FW hash check `other-error` is enabled only on dev env. That means it cannot be tested on sldev or develop desktop builds.
So instead, it will be displayed only when Debug settings are on, regardless of env. 

## Related Issue

Resolve #16732

## QA

Make sure that Settings > Device > Danger area > Firmware Authenticity is **on** (i.e. both revision & hash check) 

3 parameters to test:
- [develop](https://dev.suite.sldev.cz/suite-web/develop/web/) | [testing branch](https://dev.suite.sldev.cz/suite-web/TEST-OTHER-ERROR/web/) (hash check always throws an `other-error`)
  - this has been merged, that's why develop. But you can test [this branch](https://dev.suite.sldev.cz/suite-web/FW-hash-check-other-error-when-debug/web/) as well
- debug settings on | off
- any physical device with legit latest FW | user env T1B1 1.12.1
  - gotta use T1B1 only; unfortunately user-env is outdated, and 2.8.7 is completely missing. 2-main used to be 2.8.7, but now it's 2.8.8. [I made issue there](https://github.com/trezor/trezor-user-env/issues/287) 

Which makes test matrix with 8 cases:
- this branch
  - debug on
    - physical: :heavy_check_mark:
    - emulator: :ghost: [mismatch](https://github.com/user-attachments/assets/1961ddcb-1319-49fe-8b22-2bb6da16020f)
  - debug off
    - physical: :heavy_check_mark:
    - emulator: :ghost: [mismatch](https://github.com/user-attachments/assets/1961ddcb-1319-49fe-8b22-2bb6da16020f)
- testing branch
  - debug on
    - physical & emulator: :ghost: [other-error](https://github.com/user-attachments/assets/e95ff109-cde6-4285-b04f-5e9e283d714d) **(the new behavior)**
  - debug off
    - physical & emulator: :heavy_check_mark: but console :warning: about failed hash check, containing `MOCK OTHER ERROR` 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for firmware checks with debug-mode specific error scenarios.
	- Added ability to conditionally display firmware-related errors based on debug state.

- **Refactor**
	- Improved type definitions for error behavior types.
	- Introduced a base type for error behaviors with an optional debug-only flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->