### PR TITLE
feat(suite): change copy for Device authentication ghost modal

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AuthenticateDeviceFailModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AuthenticateDeviceFailModal.tsx
@@ -11,6 +11,9 @@ const StyledModal = styled(Modal)`
 
 export const AuthenticateDeviceFailModal = () => (
     <StyledModal>
-        <SecurityCheckFail supportUrl={TREZOR_SUPPORT_DEVICE_AUTHENTICATION_FAILED_URL} />
+        <SecurityCheckFail
+            supportUrl={TREZOR_SUPPORT_DEVICE_AUTHENTICATION_FAILED_URL}
+            text="TR_DEVICE_COMPROMISED_DEVICE_AUTHENTICITY_TEXT"
+        />
     </StyledModal>
 );

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -6878,6 +6878,10 @@ export default defineMessages({
         id: 'TR_DEVICE_COMPROMISED_FW_REVISION_CHECK_TEXT',
         defaultMessage: 'Your device firmware revision check failed.',
     },
+    TR_DEVICE_COMPROMISED_DEVICE_AUTHENTICITY_TEXT: {
+        id: 'TR_DEVICE_COMPROMISED_DEVICE_AUTHENTICITY_TEXT',
+        defaultMessage: 'Your device authentication check failed.',
+    },
     TR_PLAY_IT_SAFE: {
         id: 'TR_PLAY_IT_SAFE',
         defaultMessage: "Let's play it safe",

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/DeviceAuthenticity.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/DeviceAuthenticity.tsx
@@ -113,7 +113,10 @@ export const DeviceAuthenticity = ({ goToNext }: DeviceAuthenticityProps) => {
     if (isCheckFailed) {
         return (
             <StyledCard>
-                <SecurityCheckFail supportUrl={TREZOR_SUPPORT_DEVICE_AUTHENTICATION_FAILED_URL} />
+                <SecurityCheckFail
+                    supportUrl={TREZOR_SUPPORT_DEVICE_AUTHENTICATION_FAILED_URL}
+                    text="TR_DEVICE_COMPROMISED_DEVICE_AUTHENTICITY_TEXT"
+                />
             </StyledCard>
         );
     }


### PR DESCRIPTION
## Description

Followup to #16599 - make subtitle copies consistent for FW revcheck, FW hashcheck-mismatch, and now also device authenticity. Or "authentication", as I just learned is [the official term](https://trezor.io/learn/a/trezor-safe-device-authentication-check) :monocle_face: 

## Screenshots:

Device authentication failure during onboarding
![image](https://github.com/user-attachments/assets/4c62ef3a-3219-4818-9a71-33afbbd5a430)

Device authentication failure prompted by button in Settings > Device 
![image](https://github.com/user-attachments/assets/c2bbe192-755b-490a-9638-d28a0a1d6693)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new error message for device authentication failure.
	- Enhanced security check failure modal with additional context about device authentication issues.

- **Documentation**
	- Added localized message for device authentication failure scenario.

The changes improve user awareness and provide clearer information when a device authentication check fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->