### PR TITLE
chore(eslint): ignore all libESM dirs

### DIFF
--- a/packages/eslint/src/index.mjs
+++ b/packages/eslint/src/index.mjs
@@ -18,6 +18,7 @@ export const eslint = [
             '**/.nx/*',
             '**/lib/*',
             '**/libDev/*',
+            '**/libESM/*',
             '**/dist/*',
             '**/coverage/*',
             '**/build/*',


### PR DESCRIPTION
## Description

Ignore `libESM` directories from eslint.

Reason: after #16729, `yarn build:libs` creates `libESM` builds, but running lint throws hundreds of errors on them. This does not happen in CI, as the runner for eslint does not build libs, but on local dev env.
 

@coderabbitai ignore