### PR TITLE
ci(script): fix connect test generator

### DIFF
--- a/scripts/ci/connect-test-matrix-generator.js
+++ b/scripts/ci/connect-test-matrix-generator.js
@@ -115,7 +115,7 @@ const inputs = [
         value: ['node', 'web'],
     },
     {
-        key: 'cache_tx',
+        key: 'disable_cache_tx',
         value: ['true', 'false'],
     },
     {
@@ -147,7 +147,7 @@ args.forEach(arg => {
 log('parsedArgs', parsedArgs);
 
 const validateArgs = () => {
-    const requiredArgs = ['model', 'firmware', 'env', 'groups', 'cache_tx', 'transport'];
+    const requiredArgs = ['model', 'firmware', 'env', 'groups', 'disable_cache_tx', 'transport'];
 
     requiredArgs.forEach(arg => {
         if (!parsedArgs[arg]) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixing variable name `disable_cache_tx` that was not totally replace for the script to generate the tests matrix.
