### PR TITLE
Feat infinite scroll transactions

### DIFF
--- a/packages/components/src/components/Dropdown/Dropdown.tsx
+++ b/packages/components/src/components/Dropdown/Dropdown.tsx
@@ -17,12 +17,13 @@ import { FrameProps, FramePropsKeys } from '../../utils/frameProps';
 import { DropdownMenuItemProps, Menu, MenuProps } from '../Menu/Menu';
 import { Popover, PopoverRef } from '../Popover/Popover';
 import { PopoverPlacement } from '../Popover/utils';
+import { type IconOrComponent } from '../buttons/Button/Button';
 import { IconButton } from '../buttons/IconButton/IconButton';
 
 export const allowedDropdownFrameProps = ['width'] as const satisfies FramePropsKeys[];
 type AllowedFrameProps = Pick<FrameProps, (typeof allowedDropdownFrameProps)[number]>;
 
-const MoreIcon = styled(IconButton)<{ $isToggled: boolean }>`
+const DropdownTriggerStyledIcon = styled(IconButton)<{ $isToggled: boolean }>`
     background: ${({ isDisabled, $isToggled, theme }) =>
         !isDisabled && $isToggled && theme.backgroundNeutralSubdued};
 
@@ -35,6 +36,7 @@ export type DropdownProps = Omit<MenuProps, 'setToggled'> &
     AllowedFrameProps & {
         placement?: PopoverPlacement;
         isDisabled?: boolean;
+        icon?: IconOrComponent;
         renderOnClickPosition?: boolean;
         onToggle?: (isToggled: boolean) => void;
         className?: string;
@@ -59,6 +61,7 @@ export const Dropdown = forwardRef(
             placement,
             onToggle,
             children,
+            icon = 'dotsThree',
             'data-testid': dataTest,
         }: DropdownProps,
         ref,
@@ -110,10 +113,10 @@ export const Dropdown = forwardRef(
                 })}
             </div>
         ) : (
-            <MoreIcon
+            <DropdownTriggerStyledIcon
                 size="small"
                 variant="tertiary"
-                icon="dotsThree"
+                icon={icon}
                 tabIndex={-1}
                 $isToggled={isToggled}
                 isDisabled={isDisabled}

--- a/packages/components/src/components/Flex/Flex.tsx
+++ b/packages/components/src/components/Flex/Flex.tsx
@@ -21,6 +21,7 @@ export const allowedFlexFrameProps = [
     'minHeight',
     'maxWidth',
     'overflow',
+    'cursor',
 ] as const satisfies FramePropsKeys[];
 type AllowedFrameProps = Pick<FrameProps, (typeof allowedFlexFrameProps)[number]>;
 

--- a/packages/components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.tsx
@@ -71,6 +71,7 @@ type TooltipUiProps = {
     appendTo?: HTMLElement | null | MutableRefObject<HTMLElement | null>;
     zIndex?: ZIndexValues;
     isInline?: boolean;
+    disableFlip?: boolean;
 } & AllowedFrameProps;
 
 export type ManagedTooltipProps = ManagedModeProps & TooltipUiProps & TooltipBoxProps;
@@ -101,6 +102,7 @@ export const Tooltip = ({
     appendTo,
     shift,
     zIndex = zIndices.tooltip,
+    disableFlip = false,
     ...rest
 }: TooltipProps) => {
     const frameProps = pickAndPrepareFrameProps(rest, allowedTooltipFrameProps);
@@ -121,6 +123,7 @@ export const Tooltip = ({
                 offset={offset}
                 shift={shift}
                 delay={delayConfiguration}
+                disableFlip={disableFlip}
             >
                 <TooltipTrigger>
                     <Content

--- a/packages/components/src/components/Tooltip/TooltipFloatingUi.tsx
+++ b/packages/components/src/components/Tooltip/TooltipFloatingUi.tsx
@@ -54,6 +54,7 @@ interface TooltipOptions {
     offset: number;
     shift?: ShiftOptions;
     delay: Delay;
+    disableFlip?: boolean;
 }
 
 type UseTooltipReturn = ReturnType<typeof useInteractions> & {
@@ -71,6 +72,7 @@ export const useTooltip = ({
     offset: offsetValue,
     delay,
     shift,
+    disableFlip = false,
 }: TooltipOptions): UseTooltipReturn => {
     const arrowRef = useRef<SVGSVGElement>(null);
     const [isUncontrolledTooltipOpen, setIsUncontrolledTooltipOpen] = useState(isInitiallyOpen);
@@ -79,17 +81,23 @@ export const useTooltip = ({
     const open = isActive === false ? false : isControlledOpen ?? isUncontrolledTooltipOpen;
     const setOpen = setControlledOpen ?? setIsUncontrolledTooltipOpen;
 
+    const middleware = useMemo(() => {
+        const middlewareArray = [
+            offset(offsetValue),
+            ...(!disableFlip ? [flip()] : []),
+            shiftFloatingUI(shift),
+            arrow({ element: arrowRef }),
+        ];
+
+        return middlewareArray;
+    }, [offsetValue, shift, disableFlip, arrowRef]);
+
     const data = useFloating({
         placement,
         open,
         onOpenChange: setOpen,
         whileElementsMounted: autoUpdate,
-        middleware: [
-            offset(offsetValue),
-            flip(),
-            shiftFloatingUI(shift),
-            arrow({ element: arrowRef }),
-        ],
+        middleware,
     });
 
     const { context } = data;

--- a/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/onboardingPage.ts
+++ b/packages/suite-desktop-core/e2e/support/pageObjects/onboarding/onboardingPage.ts
@@ -115,6 +115,27 @@ export class OnboardingPage {
     }
 
     @step()
+    async completeTransactionOnboarding() {
+        // NOTE: this tooltip may cover the underlying UI so it is not clickable
+        const hideScamTransactionsTooltipGotItButton = await this.page.getByTestId(
+            '@hideScamTransactionsTooltip/gotIt',
+        );
+        const scamTransactionsDropdown = await this.page.getByTestId(
+            '@wallet/accounts/hide-scam-transactions/dropdown',
+        );
+
+        // NOTE: when this is not in the view, it is simply not visible, the test should fail if it should be visible
+        if (!(await scamTransactionsDropdown.isVisible())) {
+            return;
+        }
+
+        await scamTransactionsDropdown.scrollIntoViewIfNeeded();
+        if (await hideScamTransactionsTooltipGotItButton.isVisible()) {
+            await hideScamTransactionsTooltipGotItButton.click();
+        }
+    }
+
+    @step()
     async disableFirmwareHashCheck(options?: { skipSuiteLoadedCheck?: boolean }) {
         // Desktop starts with already disabled firmware hash check. Web needs to disable it.
         if (!isWebProject(this.testInfo)) {

--- a/packages/suite-desktop-core/e2e/tests/metadata/output-labeling.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/metadata/output-labeling.test.ts
@@ -79,6 +79,7 @@ test.describe('Metadata - Output labeling', { tag: ['@group=metadata1', '@webOnl
             metadataPage.output.outputLabel(OutputLabelId.BitcoinLegacy10, 0),
         ).toContainText('submitted by button');
 
+        await onboardingPage.completeTransactionOnboarding();
         await walletPage.exportTransactions('csv');
 
         const download = await page.waitForEvent('download');

--- a/packages/suite-desktop-core/e2e/tests/wallet/export-transactions.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/wallet/export-transactions.test.ts
@@ -31,6 +31,7 @@ test.describe('Export transactions', { tag: ['@group=wallet', '@webOnly'] }, () 
         dashboardPage,
         settingsPage,
         walletPage,
+        onboardingPage,
     }) => {
         const symbols: NetworkSymbol[] = ['btc', 'ltc', 'eth', 'ada'];
         await settingsPage.navigateTo('coins');
@@ -45,6 +46,7 @@ test.describe('Export transactions', { tag: ['@group=wallet', '@webOnly'] }, () 
             await walletPage.accountButton({ symbol }).click();
 
             const typesOfExport: ExportType[] = ['pdf', 'csv', 'json'];
+            await onboardingPage.completeTransactionOnboarding();
             for (const type of typesOfExport) {
                 await walletPage.exportTransactions(type);
                 const download = await page.waitForEvent('download');

--- a/packages/suite/src/actions/settings/constants/walletSettings.ts
+++ b/packages/suite/src/actions/settings/constants/walletSettings.ts
@@ -4,3 +4,5 @@ export const CHANGE_NETWORKS = '@wallet-settings/change-networks';
 export const SET_LAST_USED_FEE_LEVEL = '@wallet-settings/set-last-used-fee-level';
 export const FROM_STORAGE = '@wallet-settings/from-storage';
 export const SET_BITCOIN_AMOUNT_UNITS = '@suite/set-bitcoin-amount-units';
+export const TOGGLE_HIDE_SUSPICIOUS_TRANSACTIONS =
+    '@wallet-settings/toggle-hide-suspicious-transactions';

--- a/packages/suite/src/actions/settings/walletSettingsActions.ts
+++ b/packages/suite/src/actions/settings/walletSettingsActions.ts
@@ -30,6 +30,7 @@ export const changeNetworks = createAction(
 export type WalletSettingsAction =
     | ReturnType<typeof changeNetworks>
     | ReturnType<typeof setLocalCurrency>
+    | { type: typeof WALLET_SETTINGS.TOGGLE_HIDE_SUSPICIOUS_TRANSACTIONS }
     | { type: typeof WALLET_SETTINGS.SET_HIDE_BALANCE; toggled: boolean }
     | {
           type: typeof WALLET_SETTINGS.SET_LAST_USED_FEE_LEVEL;
@@ -110,6 +111,10 @@ export const setBitcoinAmountUnits = (units: PROTO.AmountUnit): WalletSettingsAc
         payload: units,
     };
 };
+
+export const toggleHideSuspiciousTransactions = (): WalletSettingsAction => ({
+    type: WALLET_SETTINGS.TOGGLE_HIDE_SUSPICIOUS_TRANSACTIONS,
+});
 
 export const toggleBitcoinAmountUnits = () => (dispatch: Dispatch, getState: GetState) => {
     const currentUnits = getState().wallet.settings.bitcoinAmountUnit;

--- a/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
@@ -207,6 +207,7 @@ const initialRun = [
                 showSettingsDesktopAppPromoBanner: true,
                 stakeEthBannerClosed: false,
                 stakeSolBannerClosed: false,
+                suspiciousTransactionsTooltipClosed: false,
                 showDashboardStakingPromoBanner: true,
                 viewOnlyPromoClosed: true,
                 viewOnlyTooltipClosed: true,

--- a/packages/suite/src/components/wallet/Pagination.tsx
+++ b/packages/suite/src/components/wallet/Pagination.tsx
@@ -48,12 +48,15 @@ const Actions = styled.div<{ $isActive: boolean }>`
     ${typography.callout};
 `;
 
+const LIMITED_NUMBER_OF_NEXT_VISIBLE_PAGES = 2;
+
 interface PaginationProps {
     currentPage: number;
     isLastPage?: boolean;
     hasPages?: boolean;
     perPage: number;
     totalItems: number;
+    isPageListLimited?: boolean;
     onPageSelected: (page: number) => void;
 }
 
@@ -64,6 +67,7 @@ export const Pagination = ({
     isLastPage,
     perPage,
     totalItems,
+    isPageListLimited,
     ...rest
 }: PaginationProps) => {
     const totalPages = Math.ceil(totalItems / perPage);
@@ -109,17 +113,24 @@ export const Pagination = ({
             </Actions>
 
             {totalPages ? (
-                calculatedPages.map(i => (
-                    <PageItem
-                        key={i}
-                        data-testid={`@wallet/accounts/pagination/${i}`}
-                        data-test-activated={i === currentPage}
-                        onClick={() => onPageSelected(i)}
-                        $isActive={i === currentPage}
-                    >
-                        {i}
-                    </PageItem>
-                ))
+                calculatedPages
+                    .slice(
+                        0,
+                        isPageListLimited
+                            ? currentPage + LIMITED_NUMBER_OF_NEXT_VISIBLE_PAGES
+                            : calculatedPages.length,
+                    )
+                    .map(i => (
+                        <PageItem
+                            key={i}
+                            data-testid={`@wallet/accounts/pagination/${i}`}
+                            data-test-activated={i === currentPage}
+                            onClick={() => onPageSelected(i)}
+                            $isActive={i === currentPage}
+                        >
+                            {i}
+                        </PageItem>
+                    ))
             ) : (
                 <>
                     {[...Array(currentPage - 1)].map((_p, i) => (
@@ -142,7 +153,7 @@ export const Pagination = ({
 
             <Actions $isActive={currentPage < (totalPages || 1)}>
                 <PageItem onClick={() => onPageSelected(currentPage + 1)}>›</PageItem>
-                {totalPages && totalPages > 2 && (
+                {totalPages && totalPages > 2 && !isPageListLimited && (
                     <PageItem onClick={() => onPageSelected(totalPages)}>»</PageItem>
                 )}
             </Actions>

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -80,6 +80,7 @@ export interface Flags {
     isDashboardPassphraseBannerVisible: boolean;
     viewOnlyPromoClosed: boolean;
     viewOnlyTooltipClosed: boolean;
+    suspiciousTransactionsTooltipClosed: boolean;
     showUnhideTokenModal: boolean;
     showCopyAddressModal: boolean;
     enableAutoupdateOnNextRun: boolean;
@@ -159,6 +160,7 @@ const initialState: SuiteState = {
         showDashboardStakingPromoBanner: true,
         viewOnlyPromoClosed: false,
         viewOnlyTooltipClosed: false,
+        suspiciousTransactionsTooltipClosed: false,
         isDashboardPassphraseBannerVisible: true,
         showCopyAddressModal: true,
         showUnhideTokenModal: true,

--- a/packages/suite/src/reducers/wallet/settingsReducer.ts
+++ b/packages/suite/src/reducers/wallet/settingsReducer.ts
@@ -15,6 +15,7 @@ export const initialState: State = {
     localCurrency: 'usd',
     discreetMode: false,
     enabledNetworks: ['btc'],
+    hideSuspiciousTransactions: false,
     bitcoinAmountUnit: PROTO.AmountUnit.BITCOIN,
     lastUsedFeeLevel: {},
 };
@@ -56,6 +57,10 @@ const settingsReducer = (state: State = initialState, action: Action): State =>
                 draft.bitcoinAmountUnit = action.payload;
                 break;
 
+            case WALLET_SETTINGS.TOGGLE_HIDE_SUSPICIOUS_TRANSACTIONS:
+                draft.hideSuspiciousTransactions = !draft.hideSuspiciousTransactions;
+                break;
+
             // no default
         }
     });
@@ -63,6 +68,8 @@ const settingsReducer = (state: State = initialState, action: Action): State =>
 export const selectEnabledNetworks = (state: AppState) => state.wallet.settings.enabledNetworks;
 export const selectLocalCurrency = (state: AppState) => state.wallet.settings.localCurrency;
 export const selectIsDiscreteModeActive = (state: AppState) => state.wallet.settings.discreetMode;
+export const selectIsHideSuspiciousTransactions = (state: AppState) =>
+    state.wallet.settings.hideSuspiciousTransactions;
 export const selectBitcoinAmountUnit = (state: AppState) => state.wallet.settings.bitcoinAmountUnit;
 
 export const selectAreSatsAmountUnit = (state: AppState) => {

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -88,6 +88,11 @@ export default defineMessages({
         defaultMessage: 'No transactions',
         id: 'TR_ACCOUNT_IS_EMPTY_TITLE',
     },
+    TR_NO_VISIBLE_TRANSACTIONS: {
+        defaultMessage:
+            'No visible transactions. Looking for something? Try showing suspicious transactions—use the filter menu above on the right. Stay cautious, some may be risky.',
+        id: 'TR_NO_VISIBLE_TRANSACTIONS',
+    },
     TR_ACCOUNT_PASSPHRASE_DISABLED: {
         defaultMessage: 'Change passphrase settings to use this device',
         id: 'TR_ACCOUNT_PASSPHRASE_DISABLED',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -84,6 +84,22 @@ export default defineMessages({
             'A watch-only account is a public address you’ve imported into your wallet, allowing the wallet to watch for outputs but not spend them.',
         id: 'TR_ACCOUNT_IMPORTED_ANNOUNCEMENT',
     },
+    TR_HIDE_SCAM_TRANSACTIONS_TOOLTIP: {
+        defaultMessage: 'Want a cleaner view? Try hiding suspicious transactions.',
+        id: 'TR_HIDE_SCAM_TRANSACTIONS_TOOLTIP',
+    },
+    TR_SHOW_SUSPICIOUS_TRANSACTIONS: {
+        defaultMessage: 'Show suspicious transactions',
+        id: 'TR_SHOW_SUSPICIOUS_TRANSACTIONS',
+    },
+    TR_HIDE_SUSPICIOUS_TRANSACTIONS: {
+        defaultMessage: 'Hide suspicious transactions',
+        id: 'TR_HIDE_SUSPICIOUS_TRANSACTIONS',
+    },
+    TR_HIDE_SUSPICIOUS_TRANSACTIONS_DESCRIPTION: {
+        defaultMessage: 'Crypto moves fast. Our filters might not be always perfect.',
+        id: 'TR_HIDE_SUSPICIOUS_TRANSACTIONS_DESCRIPTION',
+    },
     TR_ACCOUNT_IS_EMPTY_TITLE: {
         defaultMessage: 'No transactions',
         id: 'TR_ACCOUNT_IS_EMPTY_TITLE',

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/Transactions.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/Transactions.tsx
@@ -1,5 +1,6 @@
 import {
     selectAccountStakeTypeTransactions,
+    selectAccountTransactionsWithNulls,
     selectAreAllTransactionsLoaded,
     selectIsLoadingAccountTransactions,
 } from '@suite-common/wallet-core';
@@ -17,7 +18,9 @@ export const Transactions = () => {
     const areAllTransactionsLoaded = useSelector(state =>
         selectAreAllTransactionsLoaded(state, accountKey),
     );
-
+    const allTransactions = useSelector(state =>
+        selectAccountTransactionsWithNulls(state, accountKey),
+    );
     const stakeTxs = useSelector(state => selectAccountStakeTypeTransactions(state, accountKey));
 
     if (selectedAccount.status !== 'loaded' || stakeTxs.length < 1) {
@@ -28,6 +31,7 @@ export const Transactions = () => {
 
     return (
         <TransactionList
+            allTransactions={allTransactions}
             account={account}
             transactions={stakeTxs}
             symbol={account.symbol}

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
@@ -4,10 +4,6 @@ import useDebounce from 'react-use/lib/useDebounce';
 
 import { getTxsPerPage } from '@suite-common/suite-utils';
 import {
-    fetchAllTransactionsForAccountThunk,
-    fetchTransactionsPageThunk,
-} from '@suite-common/wallet-core';
-import {
     advancedSearchTransactions,
     groupTransactionsByDate,
     isPending,
@@ -29,32 +25,40 @@ import { TransactionCandidates } from './TransactionCandidates';
 import { TransactionGroupedList } from './TransactionGroupedList';
 import { TransactionListActions } from './TransactionListActions/TransactionListActions';
 import { PendingGroupHeader } from './TransactionsGroup/PendingGroupHeader';
+import { useFetchTransactions } from './useFetchTransactions';
 
 interface TransactionListProps {
+    allTransactions: WalletAccountTransaction[];
     transactions: WalletAccountTransaction[];
     symbol: WalletAccountTransaction['symbol'];
     isLoading?: boolean;
     account: Account;
     customTotalItems?: number;
     isExportable?: boolean;
+    customPageFetching?: boolean;
+    onPageRequested?: (page: number) => void;
 }
 
 export const TransactionList = ({
+    allTransactions,
     transactions,
     isLoading,
     account,
     symbol,
     customTotalItems,
+    onPageRequested,
     isExportable = true,
+    customPageFetching,
 }: TransactionListProps) => {
     const anchor = useSelector(state => state.router.anchor);
     const dispatch = useDispatch();
     const accountMetadata = useSelector(state => selectLabelingDataForAccount(state, account.key));
 
+    const { fetchPage, fetchedAll, fetchAll } = useFetchTransactions(account, allTransactions);
+
     // Search
     const [searchQuery, setSearchQuery] = useState('');
     const [searchedTransactions, setSearchedTransactions] = useState(transactions);
-    const [hasFetchedAll, setHasFetchedAll] = useState(false);
 
     const sectionRef = useRef<HTMLDivElement>(null);
 
@@ -68,26 +72,26 @@ export const TransactionList = ({
     );
 
     useEffect(() => {
-        if (anchor && !hasFetchedAll) {
-            dispatch(
-                fetchAllTransactionsForAccountThunk({
-                    accountKey: account.key,
-                    noLoading: true,
-                }),
-            );
-            setHasFetchedAll(true);
+        if (anchor && !fetchedAll) {
+            fetchAll();
         }
-    }, [anchor, account, dispatch, hasFetchedAll]);
+    }, [anchor, account, dispatch, fetchedAll, fetchAll]);
 
     // Pagination
     const perPage = getTxsPerPage(account.networkType);
-    const startPage = findAnchorTransactionPage(transactions, perPage, anchor);
-    const [currentPage, setSelectedPage] = useState(startPage);
+    // NOTE: if there is no anchor, we can keep the page 1
+    const startPage = useMemo(
+        () => (anchor ? findAnchorTransactionPage(transactions, perPage, anchor) : null),
+        [anchor, perPage, transactions],
+    );
+    const [currentPage, setSelectedPage] = useState(startPage ?? 1);
 
     useEffect(() => {
         // reset page on account change
+        if (startPage === null) return;
         setSelectedPage(startPage);
-    }, [account.descriptor, account.symbol, startPage]);
+        onPageRequested?.(startPage);
+    }, [account.descriptor, account.symbol, onPageRequested, startPage]);
 
     const isSearching = searchQuery.trim() !== '';
     const defaultTotalItems = customTotalItems ?? account.history.total;
@@ -95,9 +99,10 @@ export const TransactionList = ({
 
     const onPageSelected = (page: number) => {
         setSelectedPage(page);
+        onPageRequested?.(page);
 
-        if (!isSearching) {
-            dispatch(fetchTransactionsPageThunk({ accountKey: account.key, page, perPage }));
+        if (!isSearching && !customPageFetching) {
+            fetchPage(page);
         }
 
         if (sectionRef.current) {

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
@@ -33,6 +33,7 @@ interface TransactionListProps {
     symbol: WalletAccountTransaction['symbol'];
     isLoading?: boolean;
     account: Account;
+    isPagingLimited?: boolean;
     customTotalItems?: number;
     isExportable?: boolean;
     customPageFetching?: boolean;
@@ -45,6 +46,7 @@ export const TransactionList = ({
     isLoading,
     account,
     symbol,
+    isPagingLimited,
     customTotalItems,
     onPageRequested,
     isExportable = true,
@@ -195,6 +197,7 @@ export const TransactionList = ({
 
             {showPagination && (
                 <Pagination
+                    isPageListLimited={Boolean(isPagingLimited)}
                     hasPages={!isRipple}
                     currentPage={currentPage}
                     isLastPage={isLastRipplePage}

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 
 import useDebounce from 'react-use/lib/useDebounce';
 
@@ -35,6 +35,7 @@ interface TransactionListProps {
     account: Account;
     isPagingLimited?: boolean;
     customTotalItems?: number;
+    customNoTransactions?: ReactNode;
     isExportable?: boolean;
     customPageFetching?: boolean;
     onPageRequested?: (page: number) => void;
@@ -47,6 +48,7 @@ export const TransactionList = ({
     account,
     symbol,
     isPagingLimited,
+    customNoTransactions,
     customTotalItems,
     onPageRequested,
     isExportable = true,
@@ -171,27 +173,31 @@ export const TransactionList = ({
                 </SkeletonStack>
             ) : (
                 <>
-                    {areTransactionsAvailable ? (
-                        <NoSearchResults />
-                    ) : (
-                        <>
-                            {pendingTxs.length > 0 && (
-                                <PendingGroupHeader txsCount={pendingTxs.length} />
-                            )}
-                            <TransactionGroupedList
-                                transactionGroups={pendingTxsByDate}
-                                symbol={symbol}
-                                account={account}
-                                isPending={true}
-                            />
-                            <TransactionGroupedList
-                                transactionGroups={confirmedTxsByDate}
-                                symbol={symbol}
-                                account={account}
-                                isPending={false}
-                            />
-                        </>
-                    )}
+                    {areTransactionsAvailable && <NoSearchResults />}
+                    {!areTransactionsAvailable &&
+                        (customNoTransactions &&
+                        confirmedTxs.length === 0 &&
+                        pendingTxs.length === 0 ? (
+                            customNoTransactions
+                        ) : (
+                            <>
+                                {pendingTxs.length > 0 && (
+                                    <PendingGroupHeader txsCount={pendingTxs.length} />
+                                )}
+                                <TransactionGroupedList
+                                    transactionGroups={pendingTxsByDate}
+                                    symbol={symbol}
+                                    account={account}
+                                    isPending={true}
+                                />
+                                <TransactionGroupedList
+                                    transactionGroups={confirmedTxsByDate}
+                                    symbol={symbol}
+                                    account={account}
+                                    isPending={false}
+                                />
+                            </>
+                        ))}
                 </>
             )}
 

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx
@@ -1,0 +1,149 @@
+import { useRef } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import {
+    Box,
+    Button,
+    Column,
+    Dropdown,
+    DropdownRef,
+    Paragraph,
+    Radio,
+    Row,
+    Text,
+    Tooltip,
+} from '@trezor/components';
+import { spacings } from '@trezor/theme';
+
+import { toggleHideSuspiciousTransactions } from 'src/actions/settings/walletSettingsActions';
+import { setFlag } from 'src/actions/suite/suiteActions';
+import { Translation } from 'src/components/suite';
+import { selectSuiteFlags } from 'src/reducers/suite/suiteReducer';
+import { selectIsHideSuspiciousTransactions } from 'src/reducers/wallet/settingsReducer';
+
+const options = [
+    {
+        id: 0,
+        label: <Translation id="TR_SHOW_SUSPICIOUS_TRANSACTIONS" />,
+    },
+    {
+        id: 1,
+        label: <Translation id="TR_HIDE_SUSPICIOUS_TRANSACTIONS" />,
+        description: <Translation id="TR_HIDE_SUSPICIOUS_TRANSACTIONS_DESCRIPTION" />,
+    },
+] as const;
+
+export const FilterAction = () => {
+    const { suspiciousTransactionsTooltipClosed } = useSelector(selectSuiteFlags);
+    const suspiciousTransactionsHidden = useSelector(selectIsHideSuspiciousTransactions);
+    const dispatch = useDispatch();
+
+    const isOpen = !suspiciousTransactionsTooltipClosed;
+
+    const handleClose = () => {
+        dispatch(setFlag('suspiciousTransactionsTooltipClosed', true));
+    };
+    const dataTest = '@wallet/accounts/hide-scam-transactions';
+
+    const dropdownRef = useRef<DropdownRef>();
+
+    const handleToggleSuspiciousTransactionsRequest = (requestedHidden: boolean) => {
+        if (requestedHidden === suspiciousTransactionsHidden) return;
+        dropdownRef.current?.close();
+        dispatch(toggleHideSuspiciousTransactions());
+    };
+
+    return (
+        <Tooltip
+            disableFlip
+            hasArrow
+            isOpen={isOpen}
+            placement="bottom-end"
+            content={
+                <Row gap={spacings.sm} margin={{ horizontal: spacings.xs, vertical: spacings.sm }}>
+                    <Box maxWidth={290}>
+                        <Text>
+                            <Translation id="TR_HIDE_SCAM_TRANSACTIONS_TOOLTIP" />
+                        </Text>
+                    </Box>
+                    <Box>
+                        <Button
+                            minWidth={70}
+                            variant="tertiary"
+                            size="small"
+                            onClick={handleClose}
+                            data-testid="@hideScamTransactionsTooltip/gotIt"
+                        >
+                            <Translation id="TR_GOT_IT_BUTTON" />
+                        </Button>
+                    </Box>
+                </Row>
+            }
+        >
+            <Dropdown
+                icon="funnelSimple"
+                ref={dropdownRef}
+                placement={{ position: 'bottom', alignment: 'end' }}
+                isDisabled={false}
+                content={
+                    <Column
+                        maxWidth={272}
+                        margin={{ horizontal: spacings.xxs, vertical: spacings.xxs }}
+                        gap={spacings.md}
+                    >
+                        {options.map(option => (
+                            <Row
+                                key={option.id}
+                                cursor="pointer"
+                                justifyContent="space-between"
+                                gap={spacings.md}
+                                onClick={() => {
+                                    handleToggleSuspiciousTransactionsRequest(Boolean(option.id));
+                                }}
+                            >
+                                <Box>
+                                    <Text
+                                        typographyStyle="callout"
+                                        variant={
+                                            Boolean(suspiciousTransactionsHidden) ===
+                                            Boolean(option.id)
+                                                ? 'primary'
+                                                : undefined
+                                        }
+                                    >
+                                        {option.label}
+                                    </Text>
+                                    {'description' in option && option.description && (
+                                        <Paragraph
+                                            typographyStyle="hint"
+                                            variant="tertiary"
+                                            textWrap="balance"
+                                        >
+                                            {option.description}
+                                        </Paragraph>
+                                    )}
+                                </Box>
+                                <Box>
+                                    <Radio
+                                        isChecked={
+                                            Boolean(suspiciousTransactionsHidden) ===
+                                            Boolean(option.id)
+                                        }
+                                        data-testid={dataTest}
+                                        onClick={event => {
+                                            event.stopPropagation();
+                                            handleToggleSuspiciousTransactionsRequest(
+                                                Boolean(option.id),
+                                            );
+                                        }}
+                                    />
+                                </Box>
+                            </Row>
+                        ))}
+                    </Column>
+                }
+                data-testid={`${dataTest}/dropdown`}
+            />
+        </Tooltip>
+    );
+};

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/TransactionListActions.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/TransactionListActions.tsx
@@ -1,22 +1,19 @@
 import { Dispatch, SetStateAction, useCallback, useEffect, useState } from 'react';
 
-import styled from 'styled-components';
-
 import { AccountLabels } from '@suite-common/metadata-types';
 import { notificationsActions } from '@suite-common/toast-notifications';
+import { hasNetworkPotentialFraudTransactions } from '@suite-common/token-definitions';
 import { fetchAllTransactionsForAccountThunk } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
+import { Row } from '@trezor/components/src/components/Flex/Flex';
+import { spacings } from '@trezor/theme';
 
 import { SUITE } from 'src/actions/suite/constants';
 import { SearchAction } from 'src/components/wallet/SearchAction';
 import { useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
 
 import { ExportAction } from './ExportAction';
-
-const Wrapper = styled.div`
-    display: flex;
-    align-items: center;
-`;
+import { FilterAction } from './FilterAction';
 
 interface TransactionListActionsProps {
     account: Account;
@@ -91,7 +88,7 @@ export const TransactionListActions = ({
     }, [transactionHistoryPrefill, setSearch, onSearch, account, dispatch]);
 
     return (
-        <Wrapper>
+        <Row gap={spacings.xxs}>
             <SearchAction
                 tooltipText="TR_TRANSACTIONS_SEARCH_TOOLTIP"
                 placeholder="TR_SEARCH_TRANSACTIONS"
@@ -102,6 +99,7 @@ export const TransactionListActions = ({
                 onSearch={onSearch}
                 data-testid="@wallet/accounts/search-icon"
             />
+            {hasNetworkPotentialFraudTransactions(account.symbol) && <FilterAction />}
             {isExportable && (
                 <ExportAction
                     account={account}
@@ -109,6 +107,6 @@ export const TransactionListActions = ({
                     accountMetadata={accountMetadata}
                 />
             )}
-        </Wrapper>
+        </Row>
     );
 };

--- a/packages/suite/src/views/wallet/transactions/TransactionList/WalletTransactionList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/WalletTransactionList.tsx
@@ -49,6 +49,7 @@ export const WalletTransactionList = ({
         <TransactionList
             key={account.key} // NOTE: ensure that transaction list is unmounted when account key changes
             customPageFetching={fraudTransactionPossible}
+            customNoTransactions={<NoVisibleTransactions />}
             isPagingLimited={fraudTransactionPossible}
             allTransactions={result.allTransactions}
             transactions={result.visibleTransactions}

--- a/packages/suite/src/views/wallet/transactions/TransactionList/WalletTransactionList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/WalletTransactionList.tsx
@@ -1,9 +1,22 @@
 import { useState } from 'react';
 
+import { Card, Column, Text } from '@trezor/components';
+
+import { Translation } from 'src/components/suite';
 import { Account, WalletAccountTransaction } from 'src/types/wallet';
 
 import { TransactionList } from './TransactionList';
 import { useVisibleTransactions } from './useFetchTransactions';
+
+export const NoVisibleTransactions = () => (
+    <Card>
+        <Column alignItems="center">
+            <Text typographyStyle="hint" variant="tertiary">
+                <Translation id="TR_NO_VISIBLE_TRANSACTIONS" />
+            </Text>
+        </Column>
+    </Card>
+);
 
 interface TransactionListProps {
     symbol: WalletAccountTransaction['symbol'];
@@ -24,6 +37,10 @@ export const WalletTransactionList = ({
         account,
         numberOfPagesRequested: visiblePages,
     });
+
+    if (!result.isLoading && result.visibleTransactions.length === 0) {
+        return <NoVisibleTransactions />;
+    }
 
     return (
         <TransactionList

--- a/packages/suite/src/views/wallet/transactions/TransactionList/WalletTransactionList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/WalletTransactionList.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
+import { useSelector } from 'react-redux';
 
 import { hasNetworkPotentialFraudTransactions } from '@suite-common/token-definitions';
 import { Card, Column, Text } from '@trezor/components';
 
 import { Translation } from 'src/components/suite';
+import { selectIsHideSuspiciousTransactions } from 'src/reducers/wallet/settingsReducer';
 import { Account, WalletAccountTransaction } from 'src/types/wallet';
 
 import { TransactionList } from './TransactionList';
@@ -33,17 +35,15 @@ export const WalletTransactionList = ({
     isExportable = true,
 }: TransactionListProps) => {
     // NOTE: The number of the displayed pages may be different from the number of the pages for all transactions
+    const suspiciousTransactionsHidden = useSelector(selectIsHideSuspiciousTransactions);
+    const fraudTransactionPossible =
+        suspiciousTransactionsHidden && hasNetworkPotentialFraudTransactions(symbol);
     const [visiblePages, setVisiblePages] = useState(1);
     const result = useVisibleTransactions({
         account,
         numberOfPagesRequested: visiblePages,
+        enableFiltering: fraudTransactionPossible,
     });
-
-    if (!result.isLoading && result.visibleTransactions.length === 0) {
-        return <NoVisibleTransactions />;
-    }
-
-    const fraudTransactionPossible = hasNetworkPotentialFraudTransactions(symbol);
 
     return (
         <TransactionList

--- a/packages/suite/src/views/wallet/transactions/TransactionList/WalletTransactionList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/WalletTransactionList.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+
+import { Account, WalletAccountTransaction } from 'src/types/wallet';
+
+import { TransactionList } from './TransactionList';
+import { useVisibleTransactions } from './useFetchTransactions';
+
+interface TransactionListProps {
+    symbol: WalletAccountTransaction['symbol'];
+    account: Account;
+    customTotalItems?: number;
+    isExportable?: boolean;
+}
+
+export const WalletTransactionList = ({
+    account,
+    symbol,
+    customTotalItems,
+    isExportable = true,
+}: TransactionListProps) => {
+    // NOTE: The number of the displayed pages may be different from the number of the pages for all transactions
+    const [visiblePages, setVisiblePages] = useState(1);
+    const result = useVisibleTransactions({
+        account,
+        numberOfPagesRequested: visiblePages,
+    });
+
+    return (
+        <TransactionList
+            key={account.key} // NOTE: ensure that transaction list is unmounted when account key changes
+            allTransactions={result.allTransactions}
+            transactions={result.visibleTransactions}
+            symbol={symbol}
+            account={account}
+            isLoading={result.isFetching}
+            customTotalItems={customTotalItems ?? result.visibleTotal}
+            isExportable={isExportable}
+            onPageRequested={setVisiblePages}
+        />
+    );
+};

--- a/packages/suite/src/views/wallet/transactions/TransactionList/WalletTransactionList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/WalletTransactionList.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { hasNetworkPotentialFraudTransactions } from '@suite-common/token-definitions';
 import { Card, Column, Text } from '@trezor/components';
 
 import { Translation } from 'src/components/suite';
@@ -42,9 +43,13 @@ export const WalletTransactionList = ({
         return <NoVisibleTransactions />;
     }
 
+    const fraudTransactionPossible = hasNetworkPotentialFraudTransactions(symbol);
+
     return (
         <TransactionList
             key={account.key} // NOTE: ensure that transaction list is unmounted when account key changes
+            customPageFetching={fraudTransactionPossible}
+            isPagingLimited={fraudTransactionPossible}
             allTransactions={result.allTransactions}
             transactions={result.visibleTransactions}
             symbol={symbol}

--- a/packages/suite/src/views/wallet/transactions/TransactionList/__tests__/transaction-fetch-utils.test.ts
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/__tests__/transaction-fetch-utils.test.ts
@@ -1,0 +1,132 @@
+import { shouldAttemptToLoadNextPageForVisibleTransactions } from '../transaction-fetch-utils';
+
+describe('TransactionFetchUtils', () => {
+    it('should request fetching because the current number of visible transaction is 0 and there are still available', () => {
+        const result = shouldAttemptToLoadNextPageForVisibleTransactions({
+            totalNumberOfTransactions: 100,
+            currentNumberOfTransactions: 0,
+            currentNumberOfVisibleTransactions: 0,
+            perPage: 25,
+            numberOfPagesRequested: 0,
+        });
+
+        expect(result).toBe(true);
+    });
+
+    it('should request fetching because there are still pages a available even though many transactions were filtered', () => {
+        const result = shouldAttemptToLoadNextPageForVisibleTransactions({
+            totalNumberOfTransactions: 100,
+            currentNumberOfTransactions: 25,
+            currentNumberOfVisibleTransactions: 0,
+            perPage: 25,
+            numberOfPagesRequested: 1,
+        });
+
+        expect(result).toBe(true);
+    });
+
+    it("should request fetching because the number of visible pages won't fit even one page", () => {
+        const result = shouldAttemptToLoadNextPageForVisibleTransactions({
+            totalNumberOfTransactions: 100,
+            currentNumberOfTransactions: 25,
+            currentNumberOfVisibleTransactions: 10,
+            perPage: 25,
+            numberOfPagesRequested: 1,
+        });
+
+        expect(result).toBe(true);
+    });
+
+    it('should NOT request fetching because the number of visible pages will fit even one page', () => {
+        const result = shouldAttemptToLoadNextPageForVisibleTransactions({
+            totalNumberOfTransactions: 100,
+            currentNumberOfTransactions: 25,
+            currentNumberOfVisibleTransactions: 25,
+            perPage: 25,
+            numberOfPagesRequested: 1,
+        });
+
+        expect(result).toBe(false);
+    });
+
+    it('should request fetching because there is too little number of page for 2 pages', () => {
+        const result = shouldAttemptToLoadNextPageForVisibleTransactions({
+            totalNumberOfTransactions: 100,
+            currentNumberOfTransactions: 50,
+            currentNumberOfVisibleTransactions: 40,
+            perPage: 25,
+            numberOfPagesRequested: 2,
+        });
+
+        expect(result).toBe(true);
+    });
+
+    it('should request fetching because there is too little number of page for 3 pages', () => {
+        const result = shouldAttemptToLoadNextPageForVisibleTransactions({
+            totalNumberOfTransactions: 100,
+            currentNumberOfTransactions: 75,
+            currentNumberOfVisibleTransactions: 50,
+            perPage: 25,
+            numberOfPagesRequested: 3,
+        });
+
+        expect(result).toBe(true);
+    });
+
+    it('should NOT request fetching any more pages because there are not any left', () => {
+        const result = shouldAttemptToLoadNextPageForVisibleTransactions({
+            totalNumberOfTransactions: 100,
+            currentNumberOfTransactions: 100,
+            currentNumberOfVisibleTransactions: 2,
+            perPage: 25,
+            numberOfPagesRequested: 1,
+        });
+
+        expect(result).toBe(false);
+    });
+
+    it('should NOT request fetching any more pages since there is enough of visible transactions already', () => {
+        const result = shouldAttemptToLoadNextPageForVisibleTransactions({
+            totalNumberOfTransactions: 130,
+            currentNumberOfTransactions: 75,
+            currentNumberOfVisibleTransactions: 58,
+            perPage: 25,
+            numberOfPagesRequested: 2,
+        });
+
+        expect(result).toBe(false);
+    });
+
+    it('should NOT request fetching any more pages since there are no transactions', () => {
+        const result = shouldAttemptToLoadNextPageForVisibleTransactions({
+            totalNumberOfTransactions: 0,
+            currentNumberOfTransactions: 0,
+            currentNumberOfVisibleTransactions: 0,
+            perPage: 25,
+            numberOfPagesRequested: 1,
+        });
+        expect(result).toBe(false);
+    });
+
+    it('should request fetching when there is more more data to be loaded', () => {
+        const result = shouldAttemptToLoadNextPageForVisibleTransactions({
+            totalNumberOfTransactions: 22,
+            currentNumberOfTransactions: 20,
+            currentNumberOfVisibleTransactions: 20,
+            perPage: 5,
+            numberOfPagesRequested: 5,
+        });
+        expect(result).toBe(true);
+    });
+
+    it('should NOT request fetching when there is no more data to be loaded', () => {
+        const result = shouldAttemptToLoadNextPageForVisibleTransactions({
+            totalNumberOfTransactions: 22,
+            currentNumberOfTransactions: 20,
+            currentNumberOfVisibleTransactions: 20,
+            perPage: 5,
+            numberOfPagesRequested: 6,
+        });
+        expect(result).toBe(false);
+    });
+});

--- a/packages/suite/src/views/wallet/transactions/TransactionList/transaction-fetch-utils.ts
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/transaction-fetch-utils.ts
@@ -1,0 +1,30 @@
+export function shouldAttemptToLoadNextPageForVisibleTransactions({
+    totalNumberOfTransactions,
+    currentNumberOfTransactions,
+    currentNumberOfVisibleTransactions,
+    perPage,
+    numberOfPagesRequested,
+}: {
+    totalNumberOfTransactions: number;
+    perPage: number;
+    currentNumberOfTransactions: number;
+    currentNumberOfVisibleTransactions: number;
+    numberOfPagesRequested: number;
+}): boolean {
+    if (totalNumberOfTransactions === 0) return false;
+    if (currentNumberOfTransactions === totalNumberOfTransactions) return false;
+
+    const requestedNumberOfVisibleItems = numberOfPagesRequested * perPage;
+    if (requestedNumberOfVisibleItems > Math.ceil(totalNumberOfTransactions / perPage) * perPage)
+        return false;
+
+    if (currentNumberOfTransactions === 0 && totalNumberOfTransactions > 0) return true;
+
+    if (requestedNumberOfVisibleItems > currentNumberOfVisibleTransactions) return true;
+
+    const pagesByVisibleTransactions = Math.ceil(currentNumberOfVisibleTransactions / perPage);
+
+    if (pagesByVisibleTransactions === 0 && totalNumberOfTransactions > 0) return true;
+
+    return false;
+}

--- a/packages/suite/src/views/wallet/transactions/TransactionList/useFetchTransactions.ts
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/useFetchTransactions.ts
@@ -1,0 +1,214 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { getTxsPerPage } from '@suite-common/suite-utils';
+import {
+    getIsPhishingTransaction,
+    selectNetworkTokenDefinitions,
+} from '@suite-common/token-definitions';
+import {
+    fetchAllTransactionsForAccountThunk,
+    fetchTransactionsPageThunk,
+    selectAccountTotalTransactions,
+    selectAccountTransactionsWithNulls,
+    selectIsLoadingAccountTransactions,
+} from '@suite-common/wallet-core';
+import { getSynchronize } from '@trezor/utils';
+
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { Account, WalletAccountTransaction } from 'src/types/wallet';
+
+import { shouldAttemptToLoadNextPageForVisibleTransactions } from './transaction-fetch-utils';
+
+const getPaging = (network: Account['networkType'], txFetched: number, txTotal: number) => {
+    const perPage = getTxsPerPage(network);
+    // There is no total in XRP, so always presume there could be one more tx and calculate page count accordingly
+    const totalItems = network === 'ripple' ? txFetched + 1 : txTotal;
+    const pagesTotal = Math.ceil(totalItems / perPage);
+    // Consider incomplete pages unfetched unless fetched tx count equals total
+    const page = txFetched === totalItems ? pagesTotal : Math.floor(txFetched / perPage);
+
+    return { page, pagesTotal, perPage };
+};
+
+export const useFetchTransactions = (
+    account: Account,
+    transactions: WalletAccountTransaction[],
+) => {
+    const accountKey = account.key;
+    const { page, pagesTotal, perPage } = getPaging(
+        account.networkType,
+        transactions.length,
+        account.history.total,
+    );
+
+    const [pagesFetched, setPagesFetched] = useState(page);
+    const [isFetching, setFetching] = useState(false);
+    const [fetchedAll, setFetchedAll] = useState(false);
+
+    useEffect(() => {
+        setPagesFetched(1);
+        setFetching(false);
+        setFetchedAll(false);
+    }, [accountKey]);
+
+    useEffect(() => {
+        if (page > pagesFetched) {
+            setPagesFetched(page);
+        }
+    }, [pagesFetched, page]);
+
+    const isLastPage = pagesFetched >= pagesTotal;
+
+    useEffect(() => {
+        if (!fetchedAll && isLastPage) {
+            setFetchedAll(true);
+        }
+    }, [fetchedAll, isLastPage]);
+
+    const synchronize = useMemo(getSynchronize, [accountKey]);
+    const dispatch = useDispatch();
+
+    const fetchCommon = useCallback(
+        (
+            page: number,
+            options: {
+                recursive?: boolean;
+            } = {},
+        ) => {
+            if (options.recursive) {
+                // NOTE: when recursion is requested, load all the transactions along but don't wait for it
+                dispatch(fetchAllTransactionsForAccountThunk({ accountKey }));
+            }
+
+            return dispatch(
+                fetchTransactionsPageThunk({
+                    accountKey: account.key,
+                    page,
+                    perPage,
+                }),
+            );
+        },
+        [dispatch, account.key, perPage, accountKey],
+    );
+
+    const fetchPage = useCallback(
+        (
+            page: number,
+            options: {
+                recursive?: boolean;
+                noLoading?: boolean;
+            } = {},
+        ) => {
+            synchronize(async () => {
+                setFetching(true);
+                await dispatch(
+                    fetchTransactionsPageThunk({
+                        accountKey: account.key,
+                        page,
+                        perPage,
+                        noLoading: Boolean(options.noLoading),
+                    }),
+                );
+                setFetching(false);
+            });
+        },
+        [account.key, dispatch, perPage, synchronize],
+    );
+
+    const fetchNext = useCallback(
+        () =>
+            synchronize(async () => {
+                if (fetchedAll) return;
+                setFetching(true);
+                await fetchCommon(pagesFetched + 1);
+                setFetching(false);
+                setPagesFetched(pagesFetched + 1);
+            }),
+        [synchronize, fetchCommon, pagesFetched, fetchedAll],
+    );
+
+    const fetchAll = useCallback(
+        () =>
+            synchronize(async () => {
+                if (fetchedAll) return;
+                setFetching(true);
+                await fetchCommon(pagesFetched + 1, {
+                    recursive: true,
+                });
+                setFetching(false);
+                setFetchedAll(true);
+            }),
+        [synchronize, fetchCommon, pagesFetched, fetchedAll],
+    );
+
+    return { fetchNext, pagesFetched, fetchPage, fetchAll, isFetching, fetchedAll };
+};
+
+export const useVisibleTransactionsRetriever = ({ account }: { account: Account }) => {
+    const allTransactions = useSelector(state =>
+        selectAccountTransactionsWithNulls(state, account.key),
+    );
+
+    const { fetchedAll, isFetching, pagesFetched, fetchPage } = useFetchTransactions(
+        account,
+        allTransactions,
+    );
+    const allAccountTransactions = useSelector(state =>
+        selectAccountTotalTransactions(state, account.key),
+    );
+    const transactionsIsLoading = useSelector(state =>
+        selectIsLoadingAccountTransactions(state, account.key),
+    );
+    const tokenDefinitions = useSelector(state =>
+        selectNetworkTokenDefinitions(state, account.symbol),
+    );
+
+    const visibleTransactions = useMemo(
+        () =>
+            tokenDefinitions
+                ? allTransactions.filter(
+                      transaction =>
+                          // NOTE: due to some weirdness, the transaction here can be `undefined`!
+                          transaction
+                              ? !getIsPhishingTransaction(transaction, tokenDefinitions)
+                              : false, // NOTE: when transaction is falsy, hide it
+                  )
+                : allTransactions,
+        [allTransactions, tokenDefinitions],
+    );
+
+    const perPage = getTxsPerPage(account.networkType);
+    const numberOfHidden = allTransactions.length - visibleTransactions.length;
+    const totalPossiblyVisible = allAccountTransactions - numberOfHidden;
+
+    useEffect(() => {
+        if (
+            shouldAttemptToLoadNextPageForVisibleTransactions({
+                totalNumberOfTransactions: allAccountTransactions,
+                currentNumberOfVisibleTransactions: visibleTransactions.length,
+                currentNumberOfTransactions: allTransactions.length,
+                perPage,
+                pagesFetched,
+            })
+        ) {
+            fetchPage(pagesFetched + 1);
+        }
+    }, [
+        account.networkType,
+        allAccountTransactions,
+        allTransactions.length,
+        fetchPage,
+        fetchedAll,
+        pagesFetched,
+        perPage,
+        totalPossiblyVisible,
+        visibleTransactions.length,
+    ]);
+
+    return {
+        allTransactions,
+        visibleTransactions,
+        visibleTotal: totalPossiblyVisible,
+        isFetching: isFetching || transactionsIsLoading,
+    };
+};

--- a/packages/suite/src/views/wallet/transactions/TransactionList/useFetchTransactions.ts
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/useFetchTransactions.ts
@@ -5,6 +5,7 @@ import {
     getIsPhishingTransaction,
     selectNetworkTokenDefinitions,
 } from '@suite-common/token-definitions';
+import { DiscoveryStatus } from '@suite-common/wallet-constants';
 import {
     fetchAllTransactionsForAccountThunk,
     fetchTransactionsPageThunk,
@@ -14,7 +15,7 @@ import {
 } from '@suite-common/wallet-core';
 import { getSynchronize } from '@trezor/utils';
 
-import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
 import { Account, WalletAccountTransaction } from 'src/types/wallet';
 
 import { shouldAttemptToLoadNextPageForVisibleTransactions } from './transaction-fetch-utils';
@@ -144,15 +145,24 @@ export const useFetchTransactions = (
     return { fetchNext, pagesFetched, fetchPage, fetchAll, isFetching, fetchedAll };
 };
 
-export const useVisibleTransactionsRetriever = ({ account }: { account: Account }) => {
+export const useVisibleTransactions = ({
+    account,
+    numberOfPagesRequested,
+}: {
+    account: Account;
+    numberOfPagesRequested: number;
+}) => {
     const allTransactions = useSelector(state =>
         selectAccountTransactionsWithNulls(state, account.key),
     );
+    const { discovery } = useDiscovery();
 
-    const { fetchedAll, isFetching, pagesFetched, fetchPage } = useFetchTransactions(
-        account,
-        allTransactions,
-    );
+    const {
+        fetchedAll,
+        isFetching,
+        pagesFetched: allTransactionsPagesFetched,
+        fetchPage,
+    } = useFetchTransactions(account, allTransactions);
     const allAccountTransactions = useSelector(state =>
         selectAccountTotalTransactions(state, account.key),
     );
@@ -178,8 +188,10 @@ export const useVisibleTransactionsRetriever = ({ account }: { account: Account 
     );
 
     const perPage = getTxsPerPage(account.networkType);
-    const numberOfHidden = allTransactions.length - visibleTransactions.length;
-    const totalPossiblyVisible = allAccountTransactions - numberOfHidden;
+    // NOTE: as the paging increases / all is fetched, the number of the "all transactions" increases as the visible transactions decrease
+    // that's how the estimate of the "totalPossiblyVisible" gets more an more accurate
+    const numberOfHiddenInTheBatch = allTransactions.length - visibleTransactions.length;
+    const totalPossiblyVisible = allAccountTransactions - numberOfHiddenInTheBatch;
 
     useEffect(() => {
         if (
@@ -188,27 +200,31 @@ export const useVisibleTransactionsRetriever = ({ account }: { account: Account 
                 currentNumberOfVisibleTransactions: visibleTransactions.length,
                 currentNumberOfTransactions: allTransactions.length,
                 perPage,
-                pagesFetched,
+                numberOfPagesRequested,
             })
         ) {
-            fetchPage(pagesFetched + 1);
+            fetchPage(allTransactionsPagesFetched + 1);
         }
     }, [
         account.networkType,
         allAccountTransactions,
         allTransactions.length,
+        allTransactionsPagesFetched,
         fetchPage,
         fetchedAll,
-        pagesFetched,
+        numberOfPagesRequested,
         perPage,
         totalPossiblyVisible,
         visibleTransactions.length,
     ]);
 
+    const isLoading = discovery && discovery?.status !== DiscoveryStatus.COMPLETED; // NOTE: loading indicates that the state of the data is unknown and we are "loading for the first time"
+
     return {
         allTransactions,
         visibleTransactions,
         visibleTotal: totalPossiblyVisible,
-        isFetching: isFetching || transactionsIsLoading,
+        isFetching: isLoading || isFetching || transactionsIsLoading,
+        isLoading,
     };
 };

--- a/packages/suite/src/views/wallet/transactions/TransactionList/useFetchTransactions.ts
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/useFetchTransactions.ts
@@ -110,6 +110,7 @@ export const useFetchTransactions = (
                         noLoading: Boolean(options.noLoading),
                     }),
                 );
+            }).finally(() => {
                 setFetching(false);
             });
         },
@@ -122,8 +123,9 @@ export const useFetchTransactions = (
                 if (fetchedAll) return;
                 setFetching(true);
                 await fetchCommon(pagesFetched + 1);
-                setFetching(false);
                 setPagesFetched(pagesFetched + 1);
+            }).finally(() => {
+                setFetching(false);
             }),
         [synchronize, fetchCommon, pagesFetched, fetchedAll],
     );
@@ -136,8 +138,9 @@ export const useFetchTransactions = (
                 await fetchCommon(pagesFetched + 1, {
                     recursive: true,
                 });
-                setFetching(false);
                 setFetchedAll(true);
+            }).finally(() => {
+                setFetching(false);
             }),
         [synchronize, fetchCommon, pagesFetched, fetchedAll],
     );
@@ -148,9 +151,11 @@ export const useFetchTransactions = (
 export const useVisibleTransactions = ({
     account,
     numberOfPagesRequested,
+    enableFiltering = false,
 }: {
     account: Account;
     numberOfPagesRequested: number;
+    enableFiltering?: boolean;
 }) => {
     const allTransactions = useSelector(state =>
         selectAccountTransactionsWithNulls(state, account.key),
@@ -175,7 +180,7 @@ export const useVisibleTransactions = ({
 
     const visibleTransactions = useMemo(
         () =>
-            tokenDefinitions
+            tokenDefinitions && enableFiltering
                 ? allTransactions.filter(
                       transaction =>
                           // NOTE: due to some weirdness, the transaction here can be `undefined`!
@@ -184,7 +189,7 @@ export const useVisibleTransactions = ({
                               : false, // NOTE: when transaction is falsy, hide it
                   )
                 : allTransactions,
-        [allTransactions, tokenDefinitions],
+        [allTransactions, tokenDefinitions, enableFiltering],
     );
 
     const perPage = getTxsPerPage(account.networkType);
@@ -195,6 +200,7 @@ export const useVisibleTransactions = ({
 
     useEffect(() => {
         if (
+            enableFiltering &&
             shouldAttemptToLoadNextPageForVisibleTransactions({
                 totalNumberOfTransactions: allAccountTransactions,
                 currentNumberOfVisibleTransactions: visibleTransactions.length,
@@ -210,6 +216,7 @@ export const useVisibleTransactions = ({
         allAccountTransactions,
         allTransactions.length,
         allTransactionsPagesFetched,
+        enableFiltering,
         fetchPage,
         fetchedAll,
         numberOfPagesRequested,

--- a/packages/suite/src/views/wallet/transactions/Transactions.tsx
+++ b/packages/suite/src/views/wallet/transactions/Transactions.tsx
@@ -12,7 +12,7 @@ import { AppState } from 'src/types/suite';
 import { CoinjoinExplanation } from './CoinjoinExplanation/CoinjoinExplanation';
 import { CoinjoinSummary } from './CoinjoinSummary/CoinjoinSummary';
 import { TradeBox } from './TradeBox/TradeBox';
-import { TransactionList } from './TransactionList/TransactionList';
+import { WalletTransactionList } from './TransactionList/WalletTransactionList';
 import { AccountEmpty } from './components/AccountEmpty';
 import { NoTransactions } from './components/NoTransactions';
 import { TransactionSummary } from './components/TransactionSummary';
@@ -58,12 +58,7 @@ export const Transactions = () => {
                         {isEmpty ? (
                             <CoinjoinExplanation />
                         ) : (
-                            <TransactionList
-                                account={account}
-                                transactions={accountTransactions}
-                                symbol={account.symbol}
-                                isLoading={transactionsIsLoading}
-                            />
+                            <WalletTransactionList account={account} symbol={account.symbol} />
                         )}
                     </>
                 )}
@@ -76,12 +71,7 @@ export const Transactions = () => {
             <Layout selectedAccount={selectedAccount}>
                 <TransactionSummary account={account} />
                 <TradeBox account={account} />
-                <TransactionList
-                    account={account}
-                    transactions={accountTransactions}
-                    symbol={account.symbol}
-                    isLoading={transactionsIsLoading}
-                />
+                <WalletTransactionList account={account} symbol={account.symbol} />
             </Layout>
         );
     }

--- a/packages/suite/src/views/wallet/transactions/components/TransactionSummary.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionSummary.tsx
@@ -2,6 +2,7 @@ import { getUnixTime } from 'date-fns';
 import styled from 'styled-components';
 
 import { calcTicks, calcTicksFromData } from '@suite-common/suite-utils';
+import { hasNetworkPotentialFraudTransactions } from '@suite-common/token-definitions';
 import { Button, Card, Column, Row, variables } from '@trezor/components';
 
 import { getGraphDataForInterval, updateGraphData } from 'src/actions/wallet/graphActions';
@@ -137,14 +138,16 @@ export const TransactionSummary = ({ account }: TransactionSummaryProps) => {
                     </Column>
                 </>
             )}
-            <SummaryCards
-                selectedRange={selectedRange}
-                dataInterval={dataInterval}
-                data={data}
-                localCurrency={localCurrency}
-                account={account}
-                isLoading={isLoading}
-            />
+            {!hasNetworkPotentialFraudTransactions(account.symbol) && (
+                <SummaryCards
+                    selectedRange={selectedRange}
+                    dataInterval={dataInterval}
+                    data={data}
+                    localCurrency={localCurrency}
+                    account={account}
+                    isLoading={isLoading}
+                />
+            )}
         </Column>
     );
 };

--- a/suite-common/token-definitions/src/antiFraud.ts
+++ b/suite-common/token-definitions/src/antiFraud.ts
@@ -1,6 +1,6 @@
 import { D } from '@mobily/ts-belt';
 
-import { getNetworkType } from '@suite-common/wallet-config';
+import { NetworkSymbol, getNetworkType } from '@suite-common/wallet-config';
 import type { WalletAccountTransaction } from '@suite-common/wallet-types';
 import { isNftTokenTransfer } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
@@ -39,11 +39,16 @@ export const getIsFakeTokenPhishing = (
         );
     }); // there is hidden or unknown token in tx
 
+// NOTE: This function determins, for which symbols there are filters in the UI to hide / display spam transactions
+// when handling fraud for other symbols, make sure this function is updated!
+export const hasNetworkPotentialFraudTransactions = (symbol: NetworkSymbol) =>
+    getNetworkType(symbol) === 'ethereum';
+
 export const getIsPhishingTransaction = (
     transaction: WalletAccountTransaction,
     tokenDefinitions: TokenDefinitions,
 ) =>
-    getNetworkType(transaction.symbol) === 'ethereum' &&
+    hasNetworkPotentialFraudTransactions(transaction.symbol) &&
     (getIsZeroValuePhishing(transaction) ||
         (D.isNotEmpty(tokenDefinitions) && // at least one token definition is available
             getIsFakeTokenPhishing(transaction, tokenDefinitions)));

--- a/suite-common/wallet-config/src/types.ts
+++ b/suite-common/wallet-config/src/types.ts
@@ -43,6 +43,7 @@ export const TREZOR_CONNECT_BACKENDS = [
     'blockfrost',
     'solana',
 ] as const;
+
 export const NON_STANDARD_BACKENDS = ['coinjoin'] as const;
 
 type TrezorConnectBackendType = (typeof TREZOR_CONNECT_BACKENDS)[number];

--- a/suite-common/wallet-config/src/utils.ts
+++ b/suite-common/wallet-config/src/utils.ts
@@ -1,11 +1,11 @@
 import { networks } from './networksConfig';
-import type {
-    AccountType,
-    Network,
-    NetworkFeature,
-    NetworkSymbol,
-    NetworkSymbolExtended,
-    NormalizedNetworkAccount,
+import {
+    type AccountType,
+    type Network,
+    type NetworkFeature,
+    type NetworkSymbol,
+    type NetworkSymbolExtended,
+    type NormalizedNetworkAccount,
 } from './types';
 
 export const NORMAL_ACCOUNT_TYPE = 'normal' satisfies AccountType;

--- a/suite-common/wallet-types/src/settings.ts
+++ b/suite-common/wallet-types/src/settings.ts
@@ -21,6 +21,7 @@ export interface WalletSettings {
     localCurrency: FiatCurrencyCode;
     discreetMode: boolean;
     enabledNetworks: NetworkSymbol[];
+    hideSuspiciousTransactions: boolean;
     bitcoinAmountUnit: PROTO.AmountUnit;
     lastUsedFeeLevel: {
         [key: string]: Omit<FeeLevel, 'blocks'>; // Key: Network['symbol']


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## What to always check
- [ ] If the anchor scrolling works
- [ ] if search works
- [ ] if solana pagination works
- [ ] if not all transactions are loaded when second page is accessed
- [ ] bitcoin pagination should not be changed

## Description

5.2.2025 from call todo:
-✅ wait for Jakub to provide the list of "unrealible coins" added https://github.com/trezor/trezor-suite/pull/16760#issuecomment-2639864036
- ✅ based on that, we will limit the pagination so that there are 2 pages around the current one, so that it won't be possible to "click directly to the last
- ✅ there will still be a button to "got to last page" but the functionality has to be changed - to ensure that it goes to "proper" page
- ✅ the "transaction stats" under the graph should be hidden for "unrealiable" coins as well

## updated assignmed 1/2 Feb 2025
- add "switch" for displaying / hidding spam transaction above transaction list
- display it only for eth network coins
- add tooltip that explains the functionallity of the new filter


<!--- Describe your changes in detail -->

## Related Issue

Resolve [<!--- link the issue here -->](https://github.com/trezor/trezor-suite/issues/11306)

Test url: https://dev.suite.sldev.cz/suite-web/feat-infinite-scroll-transactions/web/

## Screenshots:

### UX stuff
The current state: coz there is an unknown number of "hidden" transactions, the total number of pages is unreliable. Here is, how it works with Polygon. It is far worse for Solana though, coz for Solana, we only load 4 transactions per page.


https://github.com/user-attachments/assets/eee31b04-ee8e-4dbb-9ba3-6107f655523a

### Provisional empty state - when there are no visible transactions to be displayed
![Screenshot 2025-02-04 at 1 18 58 PM](https://github.com/user-attachments/assets/64aa2b7e-bffc-4e77-8e64-dac971e4b920)


