### PR TITLE
Fix/use exports with import and require

### DIFF
--- a/packages/connect-plugin-ethereum/package.json
+++ b/packages/connect-plugin-ethereum/package.json
@@ -28,8 +28,10 @@
         "!**/*.map"
     ],
     "exports": {
-        "node": "./lib/index.js",
-        "default": "./libESM/index.js"
+        ".": {
+            "import": "./libESM/index.js",
+            "require": "./lib/index.js"
+        }
     },
     "peerDependencies": {
         "@metamask/eth-sig-util": "^8.0.0",

--- a/packages/connect-plugin-stellar/package.json
+++ b/packages/connect-plugin-stellar/package.json
@@ -23,8 +23,10 @@
         "main": "lib/index.js"
     },
     "exports": {
-        "node": "./lib/index.js",
-        "default": "./libESM/index.js"
+        ".": {
+            "import": "./libESM/index.js",
+            "require": "./lib/index.js"
+        }
     },
     "files": [
         "lib/",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changing the `exports` field to be more descriptive about what entrypoint is defined.
Also I like more the syntax using require and import instead of node and default  that I introduced last week.
From:
```
    "exports": {
        "node": "./lib/index.js",
        "default": "./libESM/index.js"
    },
```
To:
```
    "exports": {
        ".": {
            "import": "./libESM/index.js",
            "require": "./lib/index.js"
        }
    },
```