### PR TITLE
chore(connect): re-enable logs redacting; redact also features

### DIFF
--- a/packages/connect/src/device/DeviceCommands.ts
+++ b/packages/connect/src/device/DeviceCommands.ts
@@ -42,27 +42,32 @@ const assertType = (res: DefaultPayloadMessage, resType: MessageKey | MessageKey
 };
 
 const filterForLog = (type: string, msg: any) => {
-    const blacklist: { [key: string]: Record<string, string> } = {
-        // PassphraseAck: {
-        //     passphrase: '(redacted...)',
-        // },
-        // CipheredKeyValue: {
-        //     value: '(redacted...)',
-        // },
-        // GetPublicKey: {
-        //     address_n: '(redacted...)',
-        // },
-        // PublicKey: {
-        //     node: '(redacted...)',
-        //     xpub: '(redacted...)',
-        // },
-        // DecryptedMessage: {
-        //     message: '(redacted...)',
-        //     address: '(redacted...)',
-        // },
+    const blacklist: { [key: string]: Record<string, string> | string } = {
+        PassphraseAck: {
+            passphrase: '(redacted...)',
+        },
+        CipheredKeyValue: {
+            value: '(redacted...)',
+        },
+        GetPublicKey: {
+            address_n: '(redacted...)',
+        },
+        PublicKey: {
+            node: '(redacted...)',
+            xpub: '(redacted...)',
+        },
+        DecryptedMessage: {
+            message: '(redacted...)',
+            address: '(redacted...)',
+        },
+        Features: '(redacted...)',
     };
 
     if (type in blacklist) {
+        if (typeof blacklist[type] === 'string') {
+            return blacklist[type];
+        }
+
         return { ...msg, ...blacklist[type] };
     }
 


### PR DESCRIPTION
just a tiny followup after https://github.com/trezor/trezor-suite/pull/16699

in terminal, all the log output is serialized and since we print Features quite often it tends to get really hard to read. I found some commented out code, uncomented it and extended a bit to redact not only properties but also full objects. 

![image](https://github.com/user-attachments/assets/79b3b716-de44-4226-9f65-6ec6511397f7)

