### PR TITLE
feat(suite): remove experimental feature - ethereum-l2-support

### DIFF
--- a/packages/suite-data/files/translations/en.json
+++ b/packages/suite-data/files/translations/en.json
@@ -913,8 +913,6 @@
   "TR_EXCHANGE_SWAP_SLIPPAGE_TOLERANCE": "Slippage tolerance",
   "TR_EXCHANGE_USE_NON_SUITE_ACCOUNT": "Use an account ({symbol}) that isn't in Suite",
   "TR_EXCHANGE_VERIFY_ADDRESS_STEP": "Receive address",
-  "TR_EXPERIMENTAL_ETHEREUM_L2_SUPPORT": "Support Ethereum L2 networks",
-  "TR_EXPERIMENTAL_ETHEREUM_L2_SUPPORT_DESCRIPTION": "Enable support for Arbitrum One, Base, and Optimism networks in coin settings.",
   "TR_EXPERIMENTAL_FEATURES": "Experimental",
   "TR_EXPERIMENTAL_FEATURES_ALLOW": "Experimental features",
   "TR_EXPERIMENTAL_FEATURES_WARNING": "For experienced users only. Use at your own risk. These features are in testing, may be unstable, and might not have long-term support.",

--- a/packages/suite/src/actions/suite/constants/suiteConstants.ts
+++ b/packages/suite/src/actions/suite/constants/suiteConstants.ts
@@ -1,5 +1,3 @@
-import type { NetworkSymbol } from '@suite-common/wallet-config';
-
 export const INIT = '@suite/init';
 export const READY = '@suite/ready';
 export const ERROR = '@suite/error';
@@ -37,4 +35,3 @@ export const LOCK_TYPE = {
 export const REQUEST_DEVICE_RECONNECT = '@suite/request-device-reconnect';
 export const SET_EXPERIMENTAL_FEATURES = '@suite/set-experimental-features';
 export const SET_SIDEBAR_WIDTH = '@suite/set-sidebar-width';
-export const EXPERIMENTAL_L2_NETWORKS: readonly NetworkSymbol[] = ['op', 'arb', 'base'];

--- a/packages/suite/src/constants/suite/experimental.ts
+++ b/packages/suite/src/constants/suite/experimental.ts
@@ -6,11 +6,7 @@ import { EXPERIMENTAL_PASSWORD_MANAGER_KB_URL, HELP_CENTER_TOR_URL, Url } from '
 
 import { Dispatch } from '../../types/suite';
 
-export type ExperimentalFeature =
-    | 'password-manager'
-    | 'tor-external'
-    | 'nft-section'
-    | 'ethereum-l2-support';
+export type ExperimentalFeature = 'password-manager' | 'tor-external' | 'nft-section';
 
 export type ExperimentalFeatureConfig = {
     title: TranslationKey;
@@ -42,10 +38,6 @@ export const EXPERIMENTAL_FEATURES: Record<ExperimentalFeature, ExperimentalFeat
                 });
             }
         },
-    },
-    'ethereum-l2-support': {
-        title: 'TR_EXPERIMENTAL_ETHEREUM_L2_SUPPORT',
-        description: 'TR_EXPERIMENTAL_ETHEREUM_L2_SUPPORT_DESCRIPTION',
     },
     'nft-section': {
         title: 'TR_EXPERIMENTAL_NFT_SECTION',

--- a/packages/suite/src/hooks/settings/useNetworkSupport.ts
+++ b/packages/suite/src/hooks/settings/useNetworkSupport.ts
@@ -4,35 +4,15 @@ import { DeviceModelInternal } from '@trezor/connect';
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 import { arrayPartition } from '@trezor/utils';
 
-import { EXPERIMENTAL_L2_NETWORKS } from 'src/actions/suite/constants/suiteConstants';
 import { useSelector } from 'src/hooks/suite';
-import {
-    selectHasExperimentalFeature,
-    selectIsDebugModeActive,
-} from 'src/reducers/suite/suiteReducer';
-import { selectEnabledNetworks } from 'src/reducers/wallet/settingsReducer';
+import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
 
 export const useNetworkSupport = () => {
     const device = useSelector(selectSelectedDevice);
     const isDebug = useSelector(selectIsDebugModeActive);
     const deviceSupportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
-    const isEthereumL2SupportEnabled = useSelector(
-        selectHasExperimentalFeature('ethereum-l2-support'),
-    );
-    const enabledNetworks = useSelector(selectEnabledNetworks);
 
-    const mainnets = getMainnets(isDebug).filter(network => {
-        if (isEthereumL2SupportEnabled) {
-            return true; // no filtering needed if L2 support is enabled
-        }
-
-        // if L2 support is not enabled
-        const isExperimentalL2 = EXPERIMENTAL_L2_NETWORKS.includes(network.symbol);
-        const isEnabled = enabledNetworks.includes(network.symbol);
-
-        // filter out experimental L2 networks unless they are in the enabled networks
-        return !(isExperimentalL2 && !isEnabled);
-    });
+    const mainnets = getMainnets(isDebug);
 
     const testnets = getTestnets(isDebug);
 

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -4899,15 +4899,6 @@ export default defineMessages({
         defaultMessage:
             "Adds an NFT section to EVM-based chain accounts, allowing you to view NFTs. Note: Sending NFTs isn't currently supported.",
     },
-    TR_EXPERIMENTAL_ETHEREUM_L2_SUPPORT: {
-        id: 'TR_EXPERIMENTAL_ETHEREUM_L2_SUPPORT',
-        defaultMessage: 'Support Ethereum L2 networks',
-    },
-    TR_EXPERIMENTAL_ETHEREUM_L2_SUPPORT_DESCRIPTION: {
-        id: 'TR_EXPERIMENTAL_ETHEREUM_L2_SUPPORT_DESCRIPTION',
-        defaultMessage:
-            'Enable support for Arbitrum One, Base, and Optimism networks in coin settings.',
-    },
     TR_EXPERIMENTAL_FEATURES_ALLOW: {
         id: 'TR_EXPERIMENTAL_FEATURES_ALLOW',
         defaultMessage: 'Experimental features',


### PR DESCRIPTION
## Description

Removed Arbitrum, Optimism and Base from experimental features and add them to Suite by default.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/16773

## Screenshots:

<img width="1217" alt="image" src="https://github.com/user-attachments/assets/6cc69fe5-ce41-41d1-9444-73167909a0cf" />

<img width="1213" alt="image" src="https://github.com/user-attachments/assets/d73d8b90-d5f7-47e9-87ba-b8b1fb30838b" />