### PR TITLE
feat(e2e): Introduce JS exception catcher to whole test suite

### DIFF
--- a/packages/suite-desktop-core/e2e/support/common.ts
+++ b/packages/suite-desktop-core/e2e/support/common.ts
@@ -171,3 +171,10 @@ export const isEqualWithOmit = (param: { object1: any; object2: any; mask: strin
     isEqual(omit(param.object1, param.mask), omit(param.object2, param.mask));
 
 export const formatAddress = (address: string) => splitStringEveryNCharacters(address, 4).join(' ');
+
+// This function is used to override automatic fixtures that we want to skip in specific tests.
+/* eslint-disable no-empty-pattern, react-hooks/rules-of-hooks */
+export async function skipFixture({}, use: (r: void) => Promise<void>) {
+    await use();
+}
+/* eslint-enable no-empty-pattern, react-hooks/rules-of-hooks */

--- a/packages/suite-desktop-core/e2e/support/fixtures.ts
+++ b/packages/suite-desktop-core/e2e/support/fixtures.ts
@@ -60,6 +60,7 @@ type Fixtures = {
     indexedDb: IndexedDbFixture;
     metadataProviderMock: MetadataProviderMock;
     blockbookMock: BlockbookMock;
+    exceptionLogger: void;
 };
 
 const test = base.extend<Fixtures>({
@@ -217,6 +218,24 @@ const test = base.extend<Fixtures>({
         const blockbookMock = new BlockbookMock();
         await use(blockbookMock);
     },
+    exceptionLogger: [
+        async ({ page }, use) => {
+            const errors: Error[] = [];
+            page.on('pageerror', error => {
+                errors.push(error);
+            });
+
+            await use();
+
+            if (errors.length > 0) {
+                throw new Error(
+                    `There was a JS exception during test run.
+                    \n${errors.map(error => `${error.message}\n${error.stack}`).join('\n-----\n')}`,
+                );
+            }
+        },
+        { auto: true },
+    ],
 });
 
 export { test };

--- a/packages/suite-desktop-core/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts
@@ -3,9 +3,10 @@ import {
     expectBridgeToBeStopped,
     waitForAppToBeInitialized,
 } from '../../support/bridge';
-import { launchSuite, launchSuiteElectronApp } from '../../support/common';
+import { launchSuite, launchSuiteElectronApp, skipFixture } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
 
+test.use({ exceptionLogger: skipFixture });
 test.describe.serial('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => {
     test.beforeAll(async ({ trezorUserEnvLink }) => {
         // Ensure bridge is stopped so we properly test the electron app starting node-bridge module.

--- a/packages/suite-desktop-core/e2e/tests/bridge-tor/spawn-bridge.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/bridge-tor/spawn-bridge.test.ts
@@ -4,12 +4,13 @@ import {
     expectBridgeToBeStopped,
     waitForAppToBeInitialized,
 } from '../../support/bridge';
-import { LEGACY_BRIDGE_VERSION, launchSuite } from '../../support/common';
+import { LEGACY_BRIDGE_VERSION, launchSuite, skipFixture } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
 import { AnalyticsActions } from '../../support/pageActions/analyticsActions';
 import { DevicePromptActions } from '../../support/pageActions/devicePromptActions';
 import { OnboardingActions } from '../../support/pageActions/onboarding/onboardingActions';
 
+test.use({ exceptionLogger: skipFixture });
 test.describe.serial('Bridge', { tag: ['@group=suite', '@desktopOnly'] }, () => {
     test.beforeEach(async ({ trezorUserEnvLink }) => {
         //Ensure bridge is stopped so we properly test the electron app starting node-bridge module.

--- a/packages/suite-desktop-core/e2e/tests/bridge-tor/spawn-tor.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/bridge-tor/spawn-tor.test.ts
@@ -1,8 +1,10 @@
 import { Page } from '@playwright/test';
 
-import { launchSuite } from '../../support/common';
+import { launchSuite, skipFixture } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
 import { NetworkAnalyzer } from '../../support/networkAnalyzer';
+
+test.use({ exceptionLogger: skipFixture });
 
 const timeout = 1000 * 60 * 5; // 5 minutes because it takes a while to start tor.
 

--- a/packages/suite-desktop-core/e2e/tests/browser/safari.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/browser/safari.test.ts
@@ -1,5 +1,6 @@
 import { devices } from '@playwright/test';
 
+import { skipFixture } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
 
 const safariAria = `
@@ -15,7 +16,12 @@ const safariAria = `
     - paragraph: Continue at my own risk
 `;
 
-test.use({ startEmulator: false, ...devices['Desktop Safari'], channel: 'webkit' });
+test.use({
+    startEmulator: false,
+    ...devices['Desktop Safari'],
+    channel: 'webkit',
+    exceptionLogger: skipFixture,
+});
 test.describe('Safari', { tag: ['@group=other', '@webOnly', '@snapshot'] }, () => {
     test('Suite does not support Safari', async ({ page, onboardingPage }) => {
         await expect(page.locator('body')).toMatchAriaSnapshot(safariAria);


### PR DESCRIPTION
## Description

Introduces a JS exception catcher that fails the test in a teardown if there was any JS exception in the page during test run.

## Screenshots:
Here you can see a at the top a failed test because of the JS catcher detect a JS exception during test run (I have sabotaged it). Then I commented out the JS catcher and run the tests again. You can see the test passed even tho there were JS exception thrown in the page.
![Screenshot from 2025-02-03 21-39-52](https://github.com/user-attachments/assets/c95ebd08-1c4a-49b8-bf6b-b188d27af1a7)
