### PR TITLE
fix(transport): usb - write timeout

### DIFF
--- a/packages/transport/src/api/usb.ts
+++ b/packages/transport/src/api/usb.ts
@@ -230,9 +230,15 @@ export class UsbApi extends AbstractApi {
         const newArray = new Uint8Array(this.chunkSize);
         newArray.set(new Uint8Array(buffer));
 
+        const timeout = setTimeout(() => {
+            this.logger?.debug('usb: device.transfer out take suspiciously long. timing out.');
+            device?.reset();
+        }, 1000);
+
         try {
             // https://wicg.github.io/webusb/#ref-for-dom-usbdevice-transferout
             this.logger?.debug('usb: device.transferOut');
+
             const result = await this.abortableMethod(
                 () =>
                     device.transferOut(
@@ -250,6 +256,8 @@ export class UsbApi extends AbstractApi {
             return this.success(undefined);
         } catch (err) {
             return this.handleReadWriteError(err);
+        } finally {
+            clearTimeout(timeout);
         }
     }
 


### PR DESCRIPTION
another interesting issue I found while testing #16783 

unfortunately, even with cancel in place, I was able to get into a weird state where after window reload I got "malformed protocol error". This happens when transport tries to interpret data from usb as the first chunk of message but it wasn't the first chunk but maybe the second one or third one.. 

Note that I was using webusb. 

Steps roughly as follows:
1. reload app during some operation. you need to be lucky
2. get 'malformed error'. From this moment on, device is in some weird stuck state and nothing but reconnecting it helps to re-establish communication
3. observe that tha last usb operation was "transferOut"
4. now timer in DeviceList times out and emits transport.start, loader in suite disappears but we can't see any connected device

![image](https://github.com/user-attachments/assets/efa0b962-7547-4b7a-bacf-f8b97636c3da)

If we let transfer.out to timeout, it would look like this. 

![image](https://github.com/user-attachments/assets/15491373-9361-48ff-8a3a-01586597cf52)

At least there are troubleshooting tips and also user sess that we do detect that his device is connected. The try again button does not help however. 

![image](https://github.com/user-attachments/assets/4fbe8da4-9310-4f8e-a720-f3df9e706ce9)

In my opinion this is still little better UX. 


Also @marekrjpolak maybe transport-start should react also to unacquired devices? in this scenario suite only receives device-changed event. device-connect is never emitted 

![image](https://github.com/user-attachments/assets/cfb6be37-bdb6-4648-9d15-61288962cfec)

