### PR TITLE
fix(suite): set destination tag as enabled by default

### DIFF
--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -432,7 +432,7 @@ export const restoreOrigOutputsOrder = (
 
 export const getDefaultValues = (currency: Output['currency']): FormState => ({
     ...DEFAULT_VALUES,
-    options: ['broadcast'],
+    options: ['broadcast', 'rippleDestinationTag'],
     outputs: [{ ...DEFAULT_PAYMENT, currency }],
     selectedUtxos: [],
 });


### PR DESCRIPTION
## Description

The Destination tag in the send form is now enabled by default.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/pull/16621

## Screenshots:

<img width="783" alt="Screenshot 2025-02-04 at 12 26 04" src="https://github.com/user-attachments/assets/33330c8c-aef0-4192-8b30-a8d1764db376" />
