### PR TITLE
fix DeviceBanner layout

### DIFF
--- a/packages/suite/src/components/settings/DeviceBanner.tsx
+++ b/packages/suite/src/components/settings/DeviceBanner.tsx
@@ -2,7 +2,8 @@ import { ReactNode } from 'react';
 
 import styled from 'styled-components';
 
-import { Card, Column, LottieAnimation, Paragraph, Row, Text, variables } from '@trezor/components';
+import { isDeviceAcquired } from '@suite-common/suite-utils';
+import { Card, Column, LottieAnimation, Paragraph, Row, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { WebUsbButton } from 'src/components/suite/WebUsbButton';
@@ -22,21 +23,6 @@ const StyledLottieAnimation = styled(LottieAnimation)`
     background: ${({ theme }) => theme.legacy.BG_GREY};
 `;
 
-// eslint-disable-next-line local-rules/no-override-ds-component
-const Title = styled(Paragraph)`
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-
-    @media (max-width: ${variables.SCREEN_SIZE.SM}) {
-        display: flex;
-        flex-direction: column;
-        align-items: start;
-        gap: 0.4rem;
-    }
-`;
-
 type DeviceBannerProps = {
     title: ReactNode;
     description?: ReactNode;
@@ -45,6 +31,7 @@ type DeviceBannerProps = {
 export const DeviceBanner = ({ title, description }: DeviceBannerProps) => {
     const { device } = useDevice();
     const isWebUsbTransport = useSelector(selectHasTransportOfType('WebUsbTransport'));
+    const deviceConnectedButNotAcquired = device && !isDeviceAcquired(device);
 
     return (
         <Card
@@ -60,16 +47,15 @@ export const DeviceBanner = ({ title, description }: DeviceBannerProps) => {
                     loop
                 />
                 <Column>
-                    <Row justifyContent="space-between">
-                        <Title typographyStyle="highlight">{title}</Title>
+                    <Row gap={spacings.sm} flexWrap="wrap">
+                        <Paragraph typographyStyle="highlight">{title}</Paragraph>
                         {!description && isWebUsbTransport && !device?.connected && (
                             <WebUsbButton />
                         )}
                     </Row>
                     {description && <Text color="textSubdued">{description}</Text>}
                 </Column>
-
-                {!device?.features && <StyledAcquireDeviceButton />}
+                {deviceConnectedButNotAcquired && <StyledAcquireDeviceButton />}{' '}
             </Row>
         </Card>
     );


### PR DESCRIPTION
Fix `DeviceBanner` in various cases.

Related to https://github.com/trezor/trezor-suite/pull/16696

## Screenshots:
#### Before
"Find Trezor" button missing gap, "Use Trezor here" present despite no device is connected.
![Screenshot 2025-02-04 at 14 51 44](https://github.com/user-attachments/assets/1f083980-587e-431d-956c-0a8306a96d55)
#### After
Suite open in browser while Trezor is used by desktop app (receive address displayed):
![Screenshot 2025-02-04 at 14 57 27](https://github.com/user-attachments/assets/c255a3f4-d1fb-494c-9ccd-5f08bc4a60d1)
No device connected, bridge running:
![Screenshot 2025-02-04 at 14 57 43](https://github.com/user-attachments/assets/edb44982-16a4-43d2-9772-900735219dfa)
No device connected, WebUSB used:
![Screenshot 2025-02-04 at 14 57 57](https://github.com/user-attachments/assets/e7f5c729-5979-47a8-9873-02bbbfae0112)
As above, small screen:
![Screenshot 2025-02-04 at 15 13 50](https://github.com/user-attachments/assets/7931df9d-749c-446f-86ce-3b6229b0e6f2)

