### PR TITLE
fix(connect): allow to: null in ethereumSignTransaction for contract deployment

### DIFF
--- a/packages/connect-explorer/src/components/ParamsTable.tsx
+++ b/packages/connect-explorer/src/components/ParamsTable.tsx
@@ -93,7 +93,11 @@ const SingleParam = ({
             {hasDescendants && (
                 <div style={{ marginLeft: 30 }}>
                     {/* eslint-disable-next-line @typescript-eslint/no-use-before-define */}
-                    <ParamsTable schema={value} topLevelSchema={topLevelSchema} />
+                    <ParamsTable
+                        schema={value}
+                        topLevelSchema={topLevelSchema}
+                        descriptions={descriptions}
+                    />
                 </div>
             )}
         </>

--- a/packages/connect-explorer/src/pages/methods/ethereum/ethereumSignTransaction.mdx
+++ b/packages/connect-explorer/src/pages/methods/ethereum/ethereumSignTransaction.mdx
@@ -28,6 +28,7 @@ export const paramDescriptions = {
         'type of [`EthereumTransactionEIP1559`](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/ethereum/index.ts)`|`[`EthereumSignTransaction`](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/ethereum/index.ts) "0x" prefix for each field is optional',
     chunkify:
         'determines if recipient address will be displayed in chunks of 4 characters. Default is set to `false`',
+    to: "recipient's address, contract address or `null` in case of contract creation",
 };
 
 ## Ethereum: Sign transaction

--- a/packages/connect/src/api/ethereum/api/ethereumSignTransaction.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumSignTransaction.ts
@@ -103,7 +103,8 @@ export default class EthereumSignTransaction extends AbstractMethod<
         const definitions = await getEthereumDefinitions({
             chainId: this.params.tx.chainId,
             slip44,
-            contractAddress: this.params.tx.data ? this.params.tx.to : undefined,
+            contractAddress:
+                this.params.tx.data && this.params.tx.to != null ? this.params.tx.to : undefined,
         });
         this.params.definitions = definitions;
 

--- a/packages/connect/src/api/ethereum/ethereumSignTx.ts
+++ b/packages/connect/src/api/ethereum/ethereumSignTx.ts
@@ -88,6 +88,7 @@ export const serializeEthereumTx = (
     const txData = deepHexPrefix({
         ...tx,
         ...signature,
+        to: tx.to || undefined,
         type: isLegacy ? 0 : 2, // 0 for legacy, 2 for EIP-1559
         ...(isLegacy
             ? {
@@ -123,7 +124,7 @@ export const ethereumSignTx = async (
     // todo: don't we change parameters here to object?
     typedCall: TypedCall,
     address_n: number[],
-    to: string,
+    to: string | null,
     value: string,
     gas_limit: string,
     gas_price: string,
@@ -144,7 +145,7 @@ export const ethereumSignTx = async (
         nonce: stripLeadingZeroes(nonce),
         gas_price: stripLeadingZeroes(gas_price),
         gas_limit: stripLeadingZeroes(gas_limit),
-        to,
+        to: to || undefined,
         value: stripLeadingZeroes(value),
         definitions,
         chunkify,
@@ -174,7 +175,7 @@ export const ethereumSignTxEIP1559 = async (
     // todo: don't we change parameters here to object?
     typedCall: TypedCall,
     address_n: number[],
-    to: string,
+    to: string | null,
     value: string,
     gas_limit: string,
     max_gas_fee: string,
@@ -196,7 +197,7 @@ export const ethereumSignTxEIP1559 = async (
         max_gas_fee: stripLeadingZeroes(max_gas_fee),
         max_priority_fee: stripLeadingZeroes(max_priority_fee),
         gas_limit: stripLeadingZeroes(gas_limit),
-        to,
+        to: to || undefined,
         value: stripLeadingZeroes(value),
         data_length: length,
         data_initial_chunk: first,

--- a/packages/connect/src/types/api/ethereum/index.ts
+++ b/packages/connect/src/types/api/ethereum/index.ts
@@ -15,7 +15,7 @@ export const EthereumSignMessage = Type.Object({
 
 export type EthereumTransaction = Static<typeof EthereumTransaction>;
 export const EthereumTransaction = Type.Object({
-    to: Type.String(),
+    to: Type.Union([Type.String(), Type.Null()]),
     value: Type.String(),
     gasPrice: Type.String(),
     gasLimit: Type.String(),
@@ -35,7 +35,7 @@ export const EthereumAccessList = Type.Object({
 
 export type EthereumTransactionEIP1559 = Static<typeof EthereumTransactionEIP1559>;
 export const EthereumTransactionEIP1559 = Type.Object({
-    to: Type.String(),
+    to: Type.Union([Type.String(), Type.Null()]),
     value: Type.String(),
     gasLimit: Type.String(),
     gasPrice: Type.Optional(Type.Undefined()),


### PR DESCRIPTION
## Description

`to: null` is used in Ethereum transactions that are deploying a new contract. 
Previously we only accepted empty strings, which is not ideal. 