### PR TITLE
fix(product-components): CoinLogo for unsupported networks

### DIFF
--- a/packages/product-components/src/components/CoinLogo/CoinLogo.tsx
+++ b/packages/product-components/src/components/CoinLogo/CoinLogo.tsx
@@ -61,7 +61,7 @@ export const CoinLogo = ({
 }: CoinLogoProps) => {
     const networkSymbol = getNetworkDisplaySymbol(
         symbol as NetworkSymbol,
-    ).toLowerCase() as NetworkSymbol;
+    )?.toLowerCase() as NetworkSymbol;
 
     const symbolSrc =
         // eslint-disable-next-line no-nested-ternary

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingVerify/TradingVerifyOptionsItem.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingVerify/TradingVerifyOptionsItem.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 import { parseCryptoId } from '@suite-common/trading';
-import { getNetwork } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { Column, Icon, Row, variables } from '@trezor/components';
 import { CoinLogo } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
@@ -45,7 +45,7 @@ export const TradingVerifyOptionsItem = ({
                     </AccountName>
                     <TradingBalance
                         balance={formattedBalance}
-                        displaySymbol={getNetwork(symbol).displaySymbol}
+                        displaySymbol={getNetworkDisplaySymbol(symbol)}
                         symbol={symbol}
                         sendCryptoSelect={
                             isTradingExchangeContext(context)

--- a/suite-common/wallet-config/src/utils.ts
+++ b/suite-common/wallet-config/src/utils.ts
@@ -96,7 +96,7 @@ export const getNetworkByCoingeckoId = (coingeckoId: string) =>
 export const getNetworkByTradeCryptoId = (coingeckoId: string) =>
     networksCollection.find(n => n.tradeCryptoId === coingeckoId);
 
-export const getNetworkDisplaySymbol = (symbol: NetworkSymbol) => getNetwork(symbol).displaySymbol;
+export const getNetworkDisplaySymbol = (symbol: NetworkSymbol) => getNetwork(symbol)?.displaySymbol;
 
 export const getDisplaySymbol = (coinSymbol: string, contractAddress?: string | null) => {
     const symbol = coinSymbol.toLowerCase();


### PR DESCRIPTION
## Description

We use CoinLogo in Connect Explorer for some networks which are not actually supported in Suite. 

With the changes in #16784 this broke, 
since `getNetworkDisplaySymbol` failed to find the network