### PR TITLE
fix(transport): transferOut timeout must be inside try block

### DIFF
--- a/packages/transport/src/api/usb.ts
+++ b/packages/transport/src/api/usb.ts
@@ -234,7 +234,7 @@ export class UsbApi extends AbstractApi {
 
         const timeout = setTimeout(() => {
             this.logger?.debug('usb: device.transfer out take suspiciously long. timing out.');
-            device?.reset();
+            device?.reset().catch(() => {});
         }, 1000);
 
         try {


### PR DESCRIPTION
argh face-palm me 🤕 🌴. 
<img width="860" alt="image" src="https://github.com/user-attachments/assets/b79da230-7c46-448a-a93b-2419ce2574ad" />

in #16793 I made some last time changes - moving the timeout outside of try block so that I can clear it in finally easily which resulted in the error from device.reset not being catched