### PR TITLE
fix(connect): ts config in installing connect test

### DIFF
--- a/packages/connect/e2e/test-yarn-install.sh
+++ b/packages/connect/e2e/test-yarn-install.sh
@@ -22,4 +22,5 @@ echo import TrezorConnect from \"@trezor/connect\" >index.ts
 
 # compile with typescript
 yarn add typescript@5.5.4
-yarn tsc ./index.ts --types node,w3c-web-usb --esModuleInterop
+yarn tsc ./index.ts --types node,w3c-web-usb --esModuleInterop --target ES2022 --module commonjs 
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

After adding `@solana-program/...` dependencies the test for installing connect and compile it with TS was failing, this configuration fixes it and makes it clear it requries target `ES2022` and module `commonjs`.
