### PR TITLE
ci(github): disabling unchained tests for now

### DIFF
--- a/.github/workflows/test-connect-popup.yml
+++ b/.github/workflows/test-connect-popup.yml
@@ -123,13 +123,15 @@ jobs:
       testName: transport.test
       serverHostname: dev.suite.sldev.cz
 
-  unchained:
-    needs: [build-deploy]
-    uses: ./.github/workflows/template-connect-popup-test-params.yml
-    with:
-      testName: unchained.test
-      serverHostname: dev.suite.sldev.cz
-      runWeb: ${{ github.event_name == 'schedule' }}
+  # Disabling it for now since after adding testnet 4 as default it is failing and 
+  # it runs not in our code so we cannot update it.
+  # unchained:
+  #   needs: [build-deploy]
+  #   uses: ./.github/workflows/template-connect-popup-test-params.yml
+  #   with:
+  #     testName: unchained.test
+  #     serverHostname: dev.suite.sldev.cz
+  #     runWeb: ${{ github.event_name == 'schedule' }}
 
   webextension-examples:
     needs: [build-deploy]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Since we added Testnet 4  https://github.com/trezor/trezor-suite/pull/16426 the default testnet in suite and TrezorConnect the unchained tests that relay on them were failing. We cannot fix them since it is not our code, but we have notified them about it. 
I would leave the tests for the time been if they get updated then we can re-run them 
