### PR TITLE
FIX: flicking device status

### DIFF
--- a/packages/components/__mocks__/fileMock.js
+++ b/packages/components/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';

--- a/packages/components/jest.config.js
+++ b/packages/components/jest.config.js
@@ -4,4 +4,8 @@ module.exports = {
     ...baseConfig,
     setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
     testEnvironment: 'jsdom',
+    moduleNameMapper: {
+        ...baseConfig.moduleNameMapper,
+        '\\.svg$': '<rootDir>/__mocks__/fileMock.js',
+    },
 };

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -59,6 +59,7 @@
         "@storybook/react-webpack5": "^7.6.13",
         "@storybook/theming": "^7.6.13",
         "@testing-library/react": "14.2.1",
+        "@testing-library/user-event": "^14.6.1",
         "@trezor/eslint": "workspace:*",
         "@types/react": "18.2.79",
         "@types/react-date-range": "^1.4.9",

--- a/packages/components/src/components/Icon/Icon.tsx
+++ b/packages/components/src/components/Icon/Icon.tsx
@@ -185,8 +185,8 @@ export const Icon = forwardRef(
                 onClick={onClick ? handleClick : undefined}
                 className={className}
                 ref={ref}
-                $cursor={cursor ?? (onClick ? 'pointer' : undefined)}
                 {...frameProps}
+                $cursor={cursor ?? (onClick ? 'pointer' : undefined)}
             >
                 <SVG
                     tabIndex={onClick ? 0 : undefined}

--- a/packages/components/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.stories.tsx
@@ -6,13 +6,14 @@ import styled from 'styled-components';
 
 import { Elevation, mapElevationToBackground, spacingsPx, zIndices } from '@trezor/theme';
 
-import { Tooltip as TooltipComponent, TooltipProps } from './Tooltip';
+import { Tooltip as TooltipComponent, TooltipProps, allowedTooltipFrameProps } from './Tooltip';
 import {
     TOOLTIP_DELAY_LONG,
     TOOLTIP_DELAY_NONE,
     TOOLTIP_DELAY_NORMAL,
     TOOLTIP_DELAY_SHORT,
 } from './TooltipDelay';
+import { getFramePropsStory } from '../../utils/frameProps';
 import { ElevationContext, useElevation } from '../ElevationContext/ElevationContext';
 import { Button } from '../buttons/Button/Button';
 
@@ -107,6 +108,7 @@ export const Tooltip: StoryObj<TooltipProps> = {
         offset: 10,
         delayHide: TOOLTIP_DELAY_SHORT,
         delayShow: TOOLTIP_DELAY_SHORT,
+        ...getFramePropsStory(allowedTooltipFrameProps).args,
     },
     argTypes: {
         hasArrow: {
@@ -176,5 +178,6 @@ export const Tooltip: StoryObj<TooltipProps> = {
             control: 'select',
             options: DELAYS,
         },
+        ...getFramePropsStory(allowedTooltipFrameProps).argTypes,
     },
 };

--- a/packages/components/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.test.tsx
@@ -1,0 +1,77 @@
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { Tooltip } from './Tooltip';
+
+describe('Tooltip', () => {
+    it('should show tooltip on hover when isActive is true', async () => {
+        const tooltipContent = 'Tooltip Content';
+        render(
+            <Tooltip delayShow={0} content={tooltipContent} isActive={true}>
+                <button>Hover me</button>
+            </Tooltip>,
+        );
+
+        const trigger = screen.getByText('Hover me');
+        await userEvent.hover(trigger);
+
+        const tooltip = screen.getByText(tooltipContent);
+        expect(tooltip).toBeInTheDocument();
+    });
+
+    it('should show tooltip on hover when isActive is not defined (default behavior)', async () => {
+        const tooltipContent = 'Tooltip Content';
+        render(
+            <Tooltip delayShow={0} content={tooltipContent}>
+                <button id="hover-me">Hover me</button>
+            </Tooltip>,
+        );
+        await act(() => {});
+
+        const trigger = screen.getByText('Hover me');
+
+        await userEvent.hover(trigger);
+
+        const tooltip = screen.getByText(tooltipContent);
+        expect(tooltip).toBeInTheDocument();
+    });
+
+    it('should not show tooltip on hover when isActive is false', async () => {
+        const tooltipContent = 'Tooltip Content';
+        render(
+            <Tooltip delayShow={0} content={tooltipContent} isActive={false}>
+                <button>Hover me</button>
+            </Tooltip>,
+        );
+
+        const trigger = screen.getByText('Hover me');
+        await userEvent.hover(trigger);
+
+        const tooltip = screen.queryByText(tooltipContent);
+        expect(tooltip).not.toBeInTheDocument();
+    });
+
+    it('should hide tooltip when mouse leaves trigger element', async () => {
+        const tooltipContent = 'Tooltip Content';
+        render(
+            <Tooltip isActive delayShow={0} delayHide={0} content={tooltipContent}>
+                <button>Hover me</button>
+            </Tooltip>,
+        );
+
+        const trigger = screen.getByText('Hover me');
+
+        await userEvent.hover(trigger);
+
+        const currentTrigger = screen.getByText('Hover me');
+        expect(currentTrigger.parentElement).toHaveAttribute('data-state', 'open');
+
+        await userEvent.unhover(trigger);
+
+        const triggerBefore = screen.getByText('Hover me');
+
+        // NOTE: for some reason, the content is still in the DOM but the state is definitely closed
+        const parent = triggerBefore.parentElement;
+        expect(parent).toHaveAttribute('data-state', 'closed');
+    });
+});

--- a/packages/components/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.test.tsx
@@ -74,4 +74,26 @@ describe('Tooltip', () => {
         const parent = triggerBefore.parentElement;
         expect(parent).toHaveAttribute('data-state', 'closed');
     });
+
+    it('should apply the cursor prop to the content wrapper', () => {
+        const tooltipContent = 'Tooltip Content';
+        render(
+            <Tooltip content={tooltipContent} cursor="pointer">
+                <button>Hover me</button>
+            </Tooltip>,
+        );
+
+        expect(screen.getByText('Hover me').parentElement).toHaveStyle({ cursor: 'pointer' });
+    });
+
+    it('should should apply the default=help cursor when the passed cursor is undefined', () => {
+        const tooltipContent = 'Tooltip Content';
+        render(
+            <Tooltip content={tooltipContent} cursor={undefined}>
+                <button>Hover me</button>
+            </Tooltip>,
+        );
+
+        expect(screen.getByText('Hover me').parentElement).toHaveStyle({ cursor: 'help' });
+    });
 });

--- a/packages/components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.tsx
@@ -11,15 +11,27 @@ import { TooltipBox, TooltipBoxProps } from './TooltipBox';
 import { TOOLTIP_DELAY_SHORT, TooltipDelay } from './TooltipDelay';
 import { TooltipContent, TooltipFloatingUi, TooltipTrigger } from './TooltipFloatingUi';
 import { intermediaryTheme } from '../../config/colors';
+import {
+    FrameProps,
+    FramePropsKeys,
+    pickAndPrepareFrameProps,
+    withFrameProps,
+} from '../../utils/frameProps';
+import { TransientProps } from '../../utils/transientProps';
 import { Icon } from '../Icon/Icon';
 
-export type Cursor = 'inherit' | 'pointer' | 'help' | 'default' | 'not-allowed';
+export type TooltipInteraction = 'none' | 'hover';
+
+export const allowedTooltipFrameProps = ['cursor'] as const satisfies FramePropsKeys[];
+export type AllowedFrameProps = Pick<FrameProps, (typeof allowedTooltipFrameProps)[number]>;
 
 const Wrapper = styled.div<{ $isFullWidth: boolean }>`
     width: ${({ $isFullWidth }) => ($isFullWidth ? '100%' : 'auto')};
 `;
 
-const Content = styled.div<{ $dashed: boolean; $isInline: boolean; $cursor: Cursor }>`
+const Content = styled.div<
+    { $dashed: boolean; $isInline: boolean } & TransientProps<AllowedFrameProps>
+>`
     display: ${({ $isInline }) => ($isInline ? 'inline-flex' : 'flex')};
     align-items: center;
     justify-content: flex-start;
@@ -27,9 +39,9 @@ const Content = styled.div<{ $dashed: boolean; $isInline: boolean; $cursor: Curs
     cursor: ${({ $cursor }) => $cursor};
     border-bottom: ${({ $dashed, theme }) =>
         $dashed && `1.5px dotted ${transparentize(0.66, theme.textSubdued)}`};
-`;
 
-export type TooltipInteraction = 'none' | 'hover';
+    ${withFrameProps}
+`;
 
 type ManagedModeProps = {
     isOpen?: boolean;
@@ -46,14 +58,12 @@ type UnmanagedModeProps = {
 };
 
 type TooltipUiProps = {
-    isActive?: boolean; // Determines if the tooltip is activated - if it listens and reacts to the interaction
+    isActive?: boolean;
     children: ReactNode;
     className?: string;
     dashed?: boolean;
-    disabled?: boolean;
     offset?: number;
     shift?: ShiftOptions;
-    cursor?: Cursor;
     isFullWidth?: boolean;
     placement?: Placement;
     hasArrow?: boolean;
@@ -61,16 +71,15 @@ type TooltipUiProps = {
     appendTo?: HTMLElement | null | MutableRefObject<HTMLElement | null>;
     zIndex?: ZIndexValues;
     isInline?: boolean;
-};
+} & AllowedFrameProps;
 
 export type TooltipProps = (ManagedModeProps | UnmanagedModeProps) &
     TooltipUiProps &
     TooltipBoxProps;
 
 export const Tooltip = ({
-    isActive = true, // NOTE: determines, if the tooltip is actually working - is displayed, reacts to the events
+    isActive = true,
     placement = 'top',
-    disabled = false, // NOTE: determines the appearance of the cursor over the tooltip trigger
     children,
     isLarge = false,
     dashed = false,
@@ -78,7 +87,6 @@ export const Tooltip = ({
     delayHide = TOOLTIP_DELAY_SHORT,
     maxWidth = 400,
     offset = spacings.sm,
-    cursor = 'help',
     content,
     addon,
     title,
@@ -92,7 +100,10 @@ export const Tooltip = ({
     appendTo,
     shift,
     zIndex = zIndices.tooltip,
+    ...rest
 }: TooltipProps) => {
+    const frameProps = pickAndPrepareFrameProps(rest, allowedTooltipFrameProps);
+
     if (!content || !children) {
         return <>{children}</>;
     }
@@ -114,8 +125,9 @@ export const Tooltip = ({
                     <Content
                         $dashed={dashed}
                         $isInline={isInline}
-                        $cursor={disabled ? 'not-allowed' : cursor}
                         as={elType}
+                        {...frameProps}
+                        $cursor={frameProps.$cursor ?? 'help'}
                     >
                         {children}
                         {hasIcon && <Icon name="question" size="medium" />}

--- a/packages/components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.tsx
@@ -46,10 +46,11 @@ type UnmanagedModeProps = {
 };
 
 type TooltipUiProps = {
+    isActive?: boolean; // Determines if the tooltip is activated - if it listens and reacts to the interaction
     children: ReactNode;
     className?: string;
-    disabled?: boolean;
     dashed?: boolean;
+    disabled?: boolean;
     offset?: number;
     shift?: ShiftOptions;
     cursor?: Cursor;
@@ -67,7 +68,9 @@ export type TooltipProps = (ManagedModeProps | UnmanagedModeProps) &
     TooltipBoxProps;
 
 export const Tooltip = ({
+    isActive = true, // NOTE: determines, if the tooltip is actually working - is displayed, reacts to the events
     placement = 'top',
+    disabled = false, // NOTE: determines the appearance of the cursor over the tooltip trigger
     children,
     isLarge = false,
     dashed = false,
@@ -80,7 +83,6 @@ export const Tooltip = ({
     addon,
     title,
     headerIcon,
-    disabled,
     className,
     isFullWidth = false,
     isInline = false,
@@ -101,6 +103,7 @@ export const Tooltip = ({
     return (
         <Wrapper $isFullWidth={isFullWidth} className={className} as={elType}>
             <TooltipFloatingUi
+                isActive={isActive}
                 placement={placement}
                 isOpen={isOpen}
                 offset={offset}
@@ -111,7 +114,7 @@ export const Tooltip = ({
                     <Content
                         $dashed={dashed}
                         $isInline={isInline}
-                        $cursor={disabled ? 'default' : cursor}
+                        $cursor={disabled ? 'not-allowed' : cursor}
                         as={elType}
                     >
                         {children}

--- a/packages/components/src/components/Tooltip/TooltipFloatingUi.tsx
+++ b/packages/components/src/components/Tooltip/TooltipFloatingUi.tsx
@@ -46,6 +46,7 @@ type Delay = {
 };
 
 interface TooltipOptions {
+    isActive?: boolean; // Determines if the tooltip is active - reacts to the hovering
     isInitiallyOpen?: boolean;
     placement?: Placement;
     isOpen?: boolean;
@@ -62,6 +63,7 @@ type UseTooltipReturn = ReturnType<typeof useInteractions> & {
 } & UseFloatingReturn;
 
 export const useTooltip = ({
+    isActive = true,
     isInitiallyOpen = false,
     placement = 'top',
     isOpen: isControlledOpen,
@@ -73,7 +75,8 @@ export const useTooltip = ({
     const arrowRef = useRef<SVGSVGElement>(null);
     const [isUncontrolledTooltipOpen, setIsUncontrolledTooltipOpen] = useState(isInitiallyOpen);
 
-    const open = isControlledOpen ?? isUncontrolledTooltipOpen;
+    // NOTE: if the tooltip is overall inactive (isActive === false), always hide it / never display it
+    const open = isActive === false ? false : isControlledOpen ?? isUncontrolledTooltipOpen;
     const setOpen = setControlledOpen ?? setIsUncontrolledTooltipOpen;
 
     const data = useFloating({

--- a/packages/components/src/components/typography/TruncateWithTooltip/TruncateWithTooltip.stories.tsx
+++ b/packages/components/src/components/typography/TruncateWithTooltip/TruncateWithTooltip.stories.tsx
@@ -9,6 +9,7 @@ import {
 const Container = styled.div`
     overflow: hidden;
     white-space: nowrap;
+    max-width: 200px;
 `;
 
 const meta: Meta = {

--- a/packages/components/src/components/typography/TruncateWithTooltip/TruncateWithTooltip.tsx
+++ b/packages/components/src/components/typography/TruncateWithTooltip/TruncateWithTooltip.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 
 import styled from 'styled-components';
 
-import { Cursor, Tooltip } from '../../Tooltip/Tooltip';
+import { Tooltip, type AllowedFrameProps as TooltipAllowedFrameProps } from '../../Tooltip/Tooltip';
 import { TooltipDelay } from '../../Tooltip/TooltipDelay';
 
 const EllipsisContainer = styled.div`
@@ -10,52 +10,49 @@ const EllipsisContainer = styled.div`
     overflow: hidden;
 `;
 
-export interface TruncateWithTooltipProps {
+export interface TruncateWithTooltipProps extends TooltipAllowedFrameProps {
     children: React.ReactNode;
     delayShow?: TooltipDelay;
-    cursor?: Cursor;
 }
 
-export const TruncateWithTooltip = ({
-    children,
-    delayShow,
-    cursor = 'inherit',
-}: TruncateWithTooltipProps) => {
-    const [isTooltipVisible, setIsTooltipVisible] = useState(false);
+export const TruncateWithTooltip = ({ children, delayShow, ...rest }: TruncateWithTooltipProps) => {
+    const [isEllipsisActive, setEllipsisActive] = useState(false);
 
     const containerRef = useRef<HTMLDivElement | null>(null);
 
-    const scrollWidth = containerRef.current?.scrollWidth ?? null;
-    const scrollHeight = containerRef.current?.scrollHeight ?? null;
-
     useEffect(() => {
-        if (!containerRef.current || !scrollWidth || !scrollHeight) return;
+        if (!containerRef.current) return;
+
         const resizeObserver = new ResizeObserver(entries => {
+            const scrollWidth = containerRef.current?.scrollWidth ?? null;
+            const scrollHeight = containerRef.current?.scrollHeight ?? null;
             const borderBoxSize = entries[0].borderBoxSize?.[0];
-            if (!borderBoxSize) {
+            if (!borderBoxSize || !scrollWidth || !scrollHeight) {
                 return;
             }
 
             const { inlineSize: elementWidth, blockSize: elementHeight } = borderBoxSize;
 
-            setIsTooltipVisible(
-                scrollWidth > Math.ceil(elementWidth) || scrollHeight > Math.ceil(elementHeight),
-            );
+            const nextEllipsisActive =
+                scrollWidth > Math.ceil(elementWidth) || scrollHeight > Math.ceil(elementHeight);
+
+            setEllipsisActive(nextEllipsisActive);
         });
         resizeObserver.observe(containerRef.current);
 
         return () => resizeObserver.disconnect();
-    }, [children, scrollWidth, scrollHeight]);
+    }, [children]);
 
     return (
         <EllipsisContainer ref={containerRef}>
-            {isTooltipVisible ? (
-                <Tooltip delayShow={delayShow} content={children} cursor={cursor}>
-                    <EllipsisContainer>{children}</EllipsisContainer>
-                </Tooltip>
-            ) : (
-                children
-            )}
+            <Tooltip
+                isActive={Boolean(children) && isEllipsisActive}
+                delayShow={delayShow}
+                content={children ?? null}
+                {...rest}
+            >
+                {isEllipsisActive ? <EllipsisContainer>{children}</EllipsisContainer> : children}
+            </Tooltip>
         </EllipsisContainer>
     );
 };

--- a/packages/components/src/utils/frameProps.test.ts
+++ b/packages/components/src/utils/frameProps.test.ts
@@ -1,0 +1,59 @@
+import { makePropsTransient } from './transientProps';
+
+describe('frameprops', () => {
+    describe('type tests', () => {
+        it('should return the same keys just with the $ prefix as type', () => {
+            const result: {
+                $a: 1;
+                $b: 2;
+            } = makePropsTransient({ a: 1, b: 2 } as const);
+            expect(result).toEqual({
+                $a: 1,
+                $b: 2,
+            });
+        });
+
+        it('should correctly be able to pick individual key', () => {
+            const result: {
+                $a: 1;
+                $b: 2;
+            } = makePropsTransient({ a: 1, b: 2 } as const);
+
+            const a = result.$a;
+            expect(a).toEqual(1);
+        });
+
+        it('should throw a type error when the resulting object is not assigned to a variable with a $ prefix', () => {
+            // @ts-expect-error: here should be $ prefix for the key
+            const result: {
+                a: 1;
+                $b: 2;
+            } = makePropsTransient({ a: 1, b: 2 } as const);
+            expect(result).toEqual({
+                $a: 1,
+                $b: 2,
+            });
+        });
+        it('should throw a type error when trying to get the key that is not specified in the argument object', () => {
+            // @ts-expect-error: c is not a key of the object
+            const result: {
+                $c: 1;
+            } = makePropsTransient({ a: 1, b: 2 } as const);
+            expect(result).toEqual({
+                $a: 1,
+                $b: 2,
+            });
+        });
+
+        it('should throw a type error when trying to access a key without a $ prefix', () => {
+            const result: {
+                $a: 1;
+                $b: 2;
+            } = makePropsTransient({ a: 1, b: 2 } as const);
+
+            // @ts-expect-error: here should be $ prefix for the key
+            const { a } = result;
+            expect(a).toEqual(undefined);
+        });
+    });
+});

--- a/packages/components/src/utils/frameProps.tsx
+++ b/packages/components/src/utils/frameProps.tsx
@@ -56,7 +56,7 @@ type Position = {
     left?: string | number;
 };
 
-const cursors = ['pointer', 'help', 'default', 'not-allowed'] as const;
+const cursors = ['pointer', 'help', 'default', 'not-allowed', 'inherit'] as const;
 type Cursor = (typeof cursors)[number];
 
 export type FrameProps = {
@@ -83,21 +83,21 @@ type TransientFrameProps = TransientProps<FrameProps>;
 const getValueWithUnit = (value: string | number) =>
     typeof value === 'number' ? `${value}px` : value;
 
-export const pickAndPrepareFrameProps = (
-    props: Record<string, any>,
-    allowedFrameProps: Array<FramePropsKeys>,
-    convertToTransient = true,
+export const pickAndPrepareFrameProps = <
+    TProps extends { [K in FramePropsKeys]?: FrameProps[K] },
+    KFP extends FramePropsKeys[],
+>(
+    props: TProps,
+    allowedFrameProps: KFP,
 ) => {
-    const selectedProps = allowedFrameProps.reduce(
+    const selectedProps = allowedFrameProps.reduce<{
+        [value in KFP[number]]: TProps[value];
+    }>(
         (acc, item) => ({ ...acc, [item]: props[item] }),
-        {},
+        {} as { [value in KFP[number]]: TProps[value] },
     );
 
-    if (convertToTransient) {
-        return makePropsTransient(selectedProps);
-    }
-
-    return selectedProps;
+    return makePropsTransient(selectedProps);
 };
 
 export const withFrameProps = ({

--- a/packages/components/src/utils/transientProps.test.ts
+++ b/packages/components/src/utils/transientProps.test.ts
@@ -1,0 +1,28 @@
+import { makePropsTransient } from './transientProps';
+
+describe('transientProps', () => {
+    describe('type tests', () => {
+        it('should return the same keys just with the $ prefix as type', () => {
+            const result: {
+                $a: 1;
+                $b: 2;
+            } = makePropsTransient({ a: 1, b: 2 } as const);
+            expect(result).toEqual({
+                $a: 1,
+                $b: 2,
+            });
+        });
+
+        it("should should throw an a type error when there isn't a property with a $ prefix", () => {
+            // @ts-expect-error: here should be $ prefixes for the keys
+            const result: {
+                a: 1;
+                b: 2;
+            } = makePropsTransient({ a: 1, b: 2 } as const);
+            expect(result).toEqual({
+                $a: 1,
+                $b: 2,
+            });
+        });
+    });
+});

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
@@ -137,6 +137,7 @@ export const DeviceSelector = () => {
                     isActive={discoveryInProgress}
                     isFullWidth
                     placement="bottom"
+                    cursor={discoveryInProgress ? 'not-allowed' : undefined}
                     content={<Translation id="TR_UNAVAILABLE_WHILE_LOADING" />}
                 >
                     <InnerContainer

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
@@ -77,7 +77,7 @@ export const DeviceSelector = () => {
     const dispatch = useDispatch();
     const { getDiscoveryStatus } = useDiscovery();
     const discoveryStatus = getDiscoveryStatus();
-    const discoveryInProgress = discoveryStatus && discoveryStatus.status === 'loading';
+    const discoveryInProgress = Boolean(discoveryStatus && discoveryStatus.status === 'loading');
 
     const [localCount, setLocalCount] = useState<number | null>(null);
     const [isAnimationTriggered, setIsAnimationTriggered] = useState(false);
@@ -134,13 +134,10 @@ export const DeviceSelector = () => {
         >
             <ViewOnlyTooltip>
                 <Tooltip
+                    isActive={discoveryInProgress}
                     isFullWidth
                     placement="bottom"
-                    content={
-                        discoveryInProgress ? (
-                            <Translation id="TR_UNAVAILABLE_WHILE_LOADING" />
-                        ) : undefined
-                    }
+                    content={<Translation id="TR_UNAVAILABLE_WHILE_LOADING" />}
                 >
                     <InnerContainer
                         onClick={handleSwitchDeviceClick}

--- a/packages/suite/src/views/dashboard/PromoBanner.tsx
+++ b/packages/suite/src/views/dashboard/PromoBanner.tsx
@@ -136,7 +136,7 @@ const StoreBadge = ({
     return (
         <Tooltip
             isOpen={isTooltipOpen}
-            disabled={isMobileLayout}
+            cursor={isMobileLayout ? 'not-allowed' : undefined}
             content={
                 <Column alignItems="center">
                     <StoreTitle

--- a/packages/suite/src/views/settings/SettingsDevice/FirmwareVersion.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/FirmwareVersion.tsx
@@ -100,7 +100,10 @@ export const FirmwareVersion = ({ isDeviceLocked }: FirmwareVersionProps) => {
                                 id="TR_YOUR_FIRMWARE_VERSION"
                                 values={{
                                     version: (
-                                        <VersionTooltip content={revision} disabled={!revision}>
+                                        <VersionTooltip
+                                            content={revision}
+                                            cursor={!revision ? 'not-allowed' : undefined}
+                                        >
                                             {revision ? (
                                                 <TrezorLink href={changelogUrl} variant="nostyle">
                                                     <GithubButton />

--- a/yarn.lock
+++ b/yarn.lock
@@ -11580,6 +11580,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/user-event@npm:^14.6.1":
+  version: 14.6.1
+  resolution: "@testing-library/user-event@npm:14.6.1"
+  peerDependencies:
+    "@testing-library/dom": ">=7.21.4"
+  checksum: 10/34b74fff56a0447731a94b40d4cf246deb8dbc1c1e3aec93acd1c3377a760bb062e979f1572bb34ec164ad28ee2a391744b42d0d6d6cc16c4ce527e5e09610e1
+  languageName: node
+  linkType: hard
+
 "@theguild/remark-mermaid@npm:^0.0.5":
   version: 0.0.5
   resolution: "@theguild/remark-mermaid@npm:0.0.5"
@@ -11758,6 +11767,7 @@ __metadata:
     "@suite-common/validators": "workspace:*"
     "@testing-library/jest-dom": "npm:^6.6.3"
     "@testing-library/react": "npm:14.2.1"
+    "@testing-library/user-event": "npm:^14.6.1"
     "@trezor/asset-utils": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/dom-utils": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- there was flicking of the device status rotating image due to weird config of the tooltip
- fixed is based on adding a special prop to the tooltip that indicates, if the tooltip should be actually operating

Resolve[ <!--- link the issue here -->](https://github.com/trezor/trezor-suite/issues/16178)

## Screenshots:
before:
https://github.com/user-attachments/assets/38f9a581-f260-4e5a-97d4-777b057f5d4b

Now: 

https://github.com/user-attachments/assets/6633084b-861f-4893-adbd-6875c5013510

