### PR TITLE
Fix modal shadow not updating on content load

### DIFF
--- a/packages/components/src/utils/useScrollShadow.tsx
+++ b/packages/components/src/utils/useScrollShadow.tsx
@@ -88,18 +88,24 @@ export const useScrollShadow = () => {
 
     useEffect(() => {
         setShadows();
-        window.addEventListener('resize', () => setShadows());
-        window.addEventListener('orientationchange', () => setShadows());
+
+        const observer = new ResizeObserver(() => {
+            setShadows();
+        });
+
+        if (scrollElementRef?.current) {
+            observer.observe(scrollElementRef.current);
+        }
 
         return () => {
-            window.removeEventListener('resize', () => setShadows());
-            window.removeEventListener('orientationchange', () => setShadows());
+            observer.disconnect();
         };
     }, []);
 
     const onScroll = () => {
         setShadows();
     };
+
     type ShadowProps = { backgroundColor?: Color; style?: CSSObject };
 
     const ShadowTop = ({ backgroundColor, style }: ShadowProps) => (

--- a/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
@@ -17,6 +17,12 @@ import { ReplaceTxButton } from 'src/components/suite/modals/ReduxModal/UserCont
 import * as fixtures from '../__fixtures__/useRbfForm';
 import { RbfContext, useRbf, useRbfContext } from '../useRbfForm';
 
+global.ResizeObserver = class MockedResizeObserver {
+    observe = jest.fn();
+    unobserve = jest.fn();
+    disconnect = jest.fn();
+};
+
 // do not mock
 jest.unmock('@trezor/connect');
 


### PR DESCRIPTION
## Description

Fixed the problem with shadows in the modal not updating correctly when the content dynamically changed size. Previously, shadows were only set on mount and on window resize, but changes within the modal (e.g., image loading) were not triggering updates.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/15215

## Screenshots:

### After

<img width="665" alt="image" src="https://github.com/user-attachments/assets/32d2e807-2555-45d5-b5f1-f9c8446878c3" />

### Before

<img width="660" alt="image" src="https://github.com/user-attachments/assets/173eab7e-442a-4b82-9596-7a02a6480ee8" />