### PR TITLE
Fix EAS builds by downgrading eas-cli to 14.7 fixed version

### DIFF
--- a/.github/workflows/build-suite-native-preview.yml
+++ b/.github/workflows/build-suite-native-preview.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup EAS
         uses: expo/expo-github-action@v8
         with:
-          eas-version: latest
+          eas-version: 14.7.1
           token: ${{ secrets.EXPO_TOKEN_DEVELOP }}
       - name: Install libs
         run: yarn workspaces focus @suite-native/app

--- a/.github/workflows/release-suite-native-production.yml
+++ b/.github/workflows/release-suite-native-production.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup EAS
         uses: expo/expo-github-action@v8
         with:
-          eas-version: latest
+          eas-version: 14.7.1
           token: ${{ secrets.EXPO_TOKEN }}
       - name: Install libs
         run: yarn workspaces focus @suite-native/app
@@ -62,7 +62,7 @@ jobs:
       - name: Setup EAS
         uses: expo/expo-github-action@v8
         with:
-          eas-version: latest
+          eas-version: 14.7.1
           token: ${{ secrets.EXPO_TOKEN }}
       - name: Install libs
         run: yarn workspaces focus @suite-native/app
@@ -90,7 +90,7 @@ jobs:
       - name: Setup EAS
         uses: expo/expo-github-action@v8
         with:
-          eas-version: latest
+          eas-version: 14.7.1
           token: ${{ secrets.EXPO_TOKEN }}
       - name: Configure aws credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

Since eas-cli@15 has been published, all of our eas builds on CI have been failing with 
`git clone --no-hardlinks --depth 1 file:///home/runner/work/trezor-suite/trezor-suite /tmp/runner/eas-cli-nodejs/6792bb74-cf45-45d6-928a-56bc57a7fbb7-shallow-clone exited with non-zero code: 128` 
error.

I believe the error means that there are files too deep in the folder structure because node_modules are included even if they should not be. 

It's probably this issue https://github.com/expo/eas-cli/issues/2882

Let's downgrade to unblock our builds and try to resolve the issue so we can update the expo-cli again.
