### PR TITLE
feat(suite-native): disable FW rev check by message system

### DIFF
--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -24,6 +24,7 @@ export const Feature = {
     ethUnstake: 'eth.staking.unstake',
     ethClaim: 'eth.staking.claim',
     firmwareRevisionCheck: 'security.firmware.revisionCheck',
+    firmwareRevisionCheckMobile: 'security.firmware.revisionCheck.mobile',
     firmwareHashCheck: 'security.firmware.hashCheck',
     entropyCheck: 'security.entropyCheck',
     // FW update feature flag implemented only for mobile app

--- a/suite-native/device/package.json
+++ b/suite-native/device/package.json
@@ -14,6 +14,7 @@
         "@react-navigation/native": "6.1.18",
         "@reduxjs/toolkit": "1.9.5",
         "@sentry/react-native": "6.5.0",
+        "@suite-common/message-system": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-utils": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",

--- a/suite-native/device/src/selectors.ts
+++ b/suite-native/device/src/selectors.ts
@@ -1,5 +1,10 @@
 import { A, pipe } from '@mobily/ts-belt';
 
+import {
+    Feature,
+    MessageSystemRootState,
+    selectIsFeatureEnabled,
+} from '@suite-common/message-system';
 import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import { FiatCurrencyCode } from '@suite-common/suite-config';
 import { isDeviceAcquired } from '@suite-common/suite-utils';
@@ -156,7 +161,9 @@ export const selectFirmwareRevisionCheckError = (state: DeviceRootState) => {
     return checkResult.error;
 };
 
-type FwAuthenticityCheckState = NativeDeviceRootState & FeatureFlagsRootState;
+type FwAuthenticityCheckState = NativeDeviceRootState &
+    FeatureFlagsRootState &
+    MessageSystemRootState;
 /**
  * Get firmware revision check error, or null if check was successful / skipped, if the check is enabled in settings and through message system.
  */
@@ -167,8 +174,13 @@ export const selectFirmwareRevisionCheckErrorIfEnabled = (state: FwAuthenticityC
         state,
         FeatureFlag.IsFwRevisionCheckEnabled,
     );
-    const isCheckEnabled = isFirmwareRevisionCheckEnabled && isFeatureFlagEnabled;
-    // TODO #16456 disable also by message-system feature flag
+    const isMessageSystemFeatureEnabled = selectIsFeatureEnabled(
+        state,
+        Feature.firmwareRevisionCheckMobile,
+        true,
+    );
+    const isCheckEnabled =
+        isFirmwareRevisionCheckEnabled && isFeatureFlagEnabled && isMessageSystemFeatureEnabled;
 
     return isCheckEnabled ? revisionCheckError : null;
 };

--- a/suite-native/device/tsconfig.json
+++ b/suite-native/device/tsconfig.json
@@ -3,6 +3,9 @@
     "compilerOptions": { "outDir": "libDev" },
     "references": [
         {
+            "path": "../../suite-common/message-system"
+        },
+        {
             "path": "../../suite-common/redux-utils"
         },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10757,6 +10757,7 @@ __metadata:
     "@react-navigation/native": "npm:6.1.18"
     "@reduxjs/toolkit": "npm:1.9.5"
     "@sentry/react-native": "npm:6.5.0"
+    "@suite-common/message-system": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-utils": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"


### PR DESCRIPTION
## Description

Create a message system feature flag that disables the FW revision check **on mobile only**.

## Related Issue

Resolve #16456

## QA instructions:

Possible locally in dev build by adding the following to `config.v1.json`, signing and [forcing local JWS to true](https://github.com/trezor/trezor-suite/blob/16447f48d913aa733ae6b19d0bf34d160194a62b/suite-common/message-system/src/messageSystemThunks.ts#L27)

```
{
    "conditions": [
        {
            "environment": {
                "desktop": "!",
                "mobile": "*",
                "web": "!"
            }
        }
    ],
    "message": {
        "id": "a0563f6e-aad9-4e62-bb18-72cda92ac4a8",
        "priority": 1,
        "dismissible": false,
        "variant": "info",
        "category": "feature",
        "content": {"en-GB": "Placeholder", "en": "Placeholder", "es": "Placeholder", "cs": "Placeholder", "de": "Placeholder", "fr": "Placeholder", "it": "Placeholder", "pt": "Placeholder", "tr": "Placeholder", "ru": "Placeholder", "ja": "Placeholder", "uk": "Placeholder", "hu": "Placeholder" },
        "feature": [
            {
                "domain": "security.firmware.revisionCheck.mobile",
                "flag": false
            }
        ]
    }
}
```
