### PR TITLE
fix(suite-native): navigation animation tweaks

### DIFF
--- a/suite-native/app/src/navigation/RootStackNavigator.tsx
+++ b/suite-native/app/src/navigation/RootStackNavigator.tsx
@@ -50,6 +50,10 @@ export const RootStackNavigator = () => {
             initialRouteName={getInitialRouteName()}
             screenOptions={stackNavigationOptionsConfig}
         >
+            <RootStack.Screen
+                name={RootStackRoutes.OnboardingStack}
+                component={OnboardingStackNavigator}
+            />
             <RootStack.Screen name={RootStackRoutes.AppTabs} component={AppTabNavigator} />
             <RootStack.Screen
                 options={{ title: RootStackRoutes.AccountSettings }}
@@ -88,10 +92,6 @@ export const RootStackNavigator = () => {
             {/* Navigation flows that start by push from bottom animation on the first screen of its stack. */}
             <RootStack.Group screenOptions={{ animation: 'slide_from_bottom' }}>
                 <RootStack.Screen
-                    name={RootStackRoutes.OnboardingStack}
-                    component={OnboardingStackNavigator}
-                />
-                <RootStack.Screen
                     name={RootStackRoutes.AccountsImport}
                     component={AccountsImportStackNavigator}
                 />
@@ -108,16 +108,15 @@ export const RootStackNavigator = () => {
                     component={ReceiveStackNavigator}
                 />
                 <RootStack.Screen
+                    name={RootStackRoutes.DeviceSettingsStack}
+                    component={DeviceSettingsStackNavigator}
+                />
+                <RootStack.Screen
                     name={RootStackRoutes.AuthorizeDeviceStack}
                     component={AuthorizeDeviceStackNavigator}
                     options={{
-                        ...stackNavigationOptionsConfig,
                         gestureEnabled: false,
                     }}
-                />
-                <RootStack.Screen
-                    name={RootStackRoutes.DeviceSettingsStack}
-                    component={DeviceSettingsStackNavigator}
                 />
             </RootStack.Group>
         </RootStack.Navigator>


### PR DESCRIPTION
## Description
- `AuthorizeDeviceStack` do not reuse `stackNavigationOptionsConfig` since it is redundant and already applied in the parent. This makes the animation of this stack work as expected `slide_from_bottom`)
- OnboardingStack does not stard with `slide_from_bottom` animation. That screen is preceeded with Connect & Unlock Screen, so there should not be a second from bottom animation.

