### PR TITLE
fix: disable keybinds or wallet switcher during discovery

### DIFF
--- a/packages/suite/src/actions/wallet/addWalletThunk.ts
+++ b/packages/suite/src/actions/wallet/addWalletThunk.ts
@@ -7,11 +7,13 @@ import {
     deviceActions,
     selectDeviceThunk,
     selectDevices,
+    selectDiscoveryByDeviceState,
 } from '@suite-common/wallet-core';
 import { WalletType } from '@suite-common/wallet-types';
 
 import { getBackgroundRoute } from 'src/utils/suite/router';
 
+import { getDiscoveryStatus } from '../../utils/wallet/getDiscoveryStatus';
 import { goto } from '../suite/routerActions';
 
 export const redirectAfterWalletSelectedThunk = createThunk<void, void, void>(
@@ -39,6 +41,13 @@ export const addWalletThunk = createThunk<
     { walletType: WalletType; device: TrezorDevice },
     void
 >(`${DEVICE_MODULE_PREFIX}/addWalletThunk`, ({ walletType, device }, { dispatch, getState }) => {
+    const discovery = selectDiscoveryByDeviceState(getState(), device?.state);
+    const discoveryStatus = getDiscoveryStatus({ device, discovery });
+
+    if (discoveryStatus !== undefined && discoveryStatus.status === 'loading') {
+        return;
+    }
+
     const addDeviceInstance = async () => {
         await dispatch(
             createDeviceInstanceThunk({

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/useAppShortcuts.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/useAppShortcuts.tsx
@@ -5,11 +5,16 @@ import { KEYBOARD_CODE } from '@trezor/components';
 
 import { closeModalApp, goto } from 'src/actions/suite/routerActions';
 import { addWalletThunk } from 'src/actions/wallet/addWalletThunk';
-import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
 
 export const useAppShortcuts = () => {
     const selectedDevice = useSelector(selectSelectedDevice);
     const dispatch = useDispatch();
+
+    const { getDiscoveryStatus } = useDiscovery();
+    const discoveryStatus = getDiscoveryStatus();
+    const discoveryInProgress =
+        discoveryStatus !== undefined && discoveryStatus.status === 'loading';
 
     useEvent('keydown', e => {
         const { altKey, metaKey } = e;
@@ -29,13 +34,12 @@ export const useAppShortcuts = () => {
 
         // press ALT + D to show SwitchDevice
         if (altKey && e.code === KEYBOARD_CODE.KEY_D && isDeviceSelected) {
-            dispatch(
-                goto('suite-switch-device', {
-                    params: {
-                        cancelable: true,
-                    },
-                }),
-            );
+            if (!discoveryInProgress) {
+                dispatch(goto('suite-switch-device', { params: { cancelable: true } }));
+            }
+
+            // Firefox has default ALT+D shortcut to open address bar so we want to prevent that
+            // anyway (even when we are doing nothing due to running discovery) to avoid inconsistent behavior
             e.preventDefault();
         }
 

--- a/packages/suite/src/hooks/suite/useDiscovery.ts
+++ b/packages/suite/src/hooks/suite/useDiscovery.ts
@@ -3,9 +3,8 @@ import { useCallback } from 'react';
 import { DiscoveryStatus } from '@suite-common/wallet-constants';
 import { selectDiscoveryByDeviceState, selectSelectedDevice } from '@suite-common/wallet-core';
 
-import { DiscoveryStatusType } from 'src/types/wallet';
-
 import { useSelector } from './useSelector';
+import { getDiscoveryStatus } from '../../utils/wallet/getDiscoveryStatus';
 
 export const useDiscovery = () => {
     const device = useSelector(selectSelectedDevice);
@@ -19,62 +18,10 @@ export const useDiscovery = () => {
         return 0;
     }, [discovery]);
 
-    const getStatus = useCallback((): DiscoveryStatusType | undefined => {
-        if (!device)
-            return {
-                status: 'loading',
-                type: 'waiting-for-device',
-            };
-        if (device.authFailed)
-            return {
-                status: 'exception',
-                type: 'auth-failed',
-            };
-        if (device.authConfirm)
-            return {
-                status: 'exception',
-                type: 'auth-confirm-failed',
-            };
-        if (!device.state)
-            return {
-                status: 'loading',
-                type: 'auth',
-            };
-
-        if (discovery) {
-            if (discovery.status < DiscoveryStatus.STOPPING)
-                return {
-                    status: 'loading',
-                    type: discovery.authConfirm ? 'auth-confirm' : 'discovery',
-                };
-
-            if (discovery.status === DiscoveryStatus.COMPLETED && discovery.authConfirm)
-                return {
-                    status: 'loading',
-                    type: 'auth-confirm',
-                };
-
-            if (discovery.networks.length === 0)
-                return {
-                    status: 'exception',
-                    type: 'discovery-empty',
-                };
-
-            if (discovery.errorCode === 'Device_InvalidState' && !device.available)
-                return {
-                    status: 'exception',
-                    type: 'device-unavailable',
-                };
-
-            if (discovery.error || discovery.failed.length > 0)
-                return {
-                    status: 'exception',
-                    type: 'discovery-failed',
-                };
-        }
-
-        return undefined;
-    }, [device, discovery]);
+    const getStatus = useCallback(
+        () => getDiscoveryStatus({ device, discovery }),
+        [device, discovery],
+    );
 
     return {
         device,

--- a/packages/suite/src/utils/wallet/getDiscoveryStatus.ts
+++ b/packages/suite/src/utils/wallet/getDiscoveryStatus.ts
@@ -1,0 +1,69 @@
+import { TrezorDevice } from '@suite-common/suite-types';
+import { DiscoveryStatus } from '@suite-common/wallet-constants';
+
+import { Discovery, DiscoveryStatusType } from '../../types/wallet';
+
+type GetDiscoveryStatusParams = {
+    device: TrezorDevice | undefined;
+    discovery: Discovery | undefined;
+};
+
+export const getDiscoveryStatus = ({
+    device,
+    discovery,
+}: GetDiscoveryStatusParams): DiscoveryStatusType | undefined => {
+    if (!device)
+        return {
+            status: 'loading',
+            type: 'waiting-for-device',
+        };
+    if (device.authFailed)
+        return {
+            status: 'exception',
+            type: 'auth-failed',
+        };
+    if (device.authConfirm)
+        return {
+            status: 'exception',
+            type: 'auth-confirm-failed',
+        };
+    if (!device.state)
+        return {
+            status: 'loading',
+            type: 'auth',
+        };
+
+    if (discovery) {
+        if (discovery.status < DiscoveryStatus.STOPPING)
+            return {
+                status: 'loading',
+                type: discovery.authConfirm ? 'auth-confirm' : 'discovery',
+            };
+
+        if (discovery.status === DiscoveryStatus.COMPLETED && discovery.authConfirm)
+            return {
+                status: 'loading',
+                type: 'auth-confirm',
+            };
+
+        if (discovery.networks.length === 0)
+            return {
+                status: 'exception',
+                type: 'discovery-empty',
+            };
+
+        if (discovery.errorCode === 'Device_InvalidState' && !device.available)
+            return {
+                status: 'exception',
+                type: 'device-unavailable',
+            };
+
+        if (discovery.error || discovery.failed.length > 0)
+            return {
+                status: 'exception',
+                type: 'discovery-failed',
+            };
+    }
+
+    return undefined;
+};


### PR DESCRIPTION
This is probably not a proper fix. But our wallet-switcher & discovery are not a best friends. 

=> until discovery is not finished, we shall not allow wallet switcher stuff (it is [already disabled in the UI](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx#L145) so I assume we shall disable keybinds as well

Resolves: https://github.com/trezor/trezor-suite/issues/15579