### PR TITLE
chore(connect-common): add fw binaries for 2.8.8 and 1.13.0

### DIFF
--- a/packages/connect-common/files/firmware/t1b1/releases.json
+++ b/packages/connect-common/files/firmware/t1b1/releases.json
@@ -1,6 +1,19 @@
 [
     {
         "required": false,
+        "version": [1, 13, 0],
+        "bootloader_version": [1, 12, 1],
+        "min_firmware_version": [1, 12, 0],
+        "min_bootloader_version": [1, 12, 0],
+        "url": "firmware/t1b1/trezor-t1b1-1.13.0.bin",
+        "url_bitcoinonly": "firmware/t1b1/trezor-t1b1-1.13.0-bitcoinonly.bin",
+        "fingerprint": "356433bd9de6cb564bf7778fc5de73c56197459523358f267e9235af9e1ce46d",
+        "fingerprint_bitcoinonly": "253042fb209c78e02482c645b16cc9894c19124e9c9c0c1051b3c68b6e7c700b",
+        "firmware_revision": "592590cf66a9b62dfeee7e4d2afb6e01005e5b2c",
+        "changelog": "* Multisig-related changes.\n* Reworked PIN processing.\n* Fixed the ability to display the XPUB using a QR code."
+    },
+    {
+        "required": false,
         "version": [1, 12, 1],
         "bootloader_version": [1, 12, 1],
         "min_firmware_version": [1, 12, 0],

--- a/packages/connect-common/files/firmware/t1b1/trezor-t1b1-1.12.1-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t1b1/trezor-t1b1-1.12.1-bitcoinonly.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ce576268ce81d4fa7aa6a80d1c8ee01c49fdab4efaf9e0c703d899a24e168eb4
-size 569868

--- a/packages/connect-common/files/firmware/t1b1/trezor-t1b1-1.12.1.bin
+++ b/packages/connect-common/files/firmware/t1b1/trezor-t1b1-1.12.1.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eab18bf870d6096a2dee477a2f032dc3084a1864b6767a8f2f313a12dff2d180
-size 763676

--- a/packages/connect-common/files/firmware/t1b1/trezor-t1b1-1.13.0-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t1b1/trezor-t1b1-1.13.0-bitcoinonly.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:370122a4ecc2d7a900585944b2c1ecf216dd39367e49ffc09f0debc228e0ec69
+size 404204

--- a/packages/connect-common/files/firmware/t1b1/trezor-t1b1-1.13.0.bin
+++ b/packages/connect-common/files/firmware/t1b1/trezor-t1b1-1.13.0.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5f51f64c0ad8dac888ed5a1c5e6b64271b382b6ed73cfe6a569cfb874cd4545
+size 504172

--- a/packages/connect-common/files/firmware/t2t1/releases.json
+++ b/packages/connect-common/files/firmware/t2t1/releases.json
@@ -1,6 +1,21 @@
 [
     {
         "required": false,
+        "version": [2, 8, 8],
+        "min_firmware_version": [2, 0, 8],
+        "min_bootloader_version": [2, 0, 0],
+        "bootloader_version": [2, 1, 8],
+        "firmware_revision": "592590cf66a9b62dfeee7e4d2afb6e01005e5b2c",
+        "translations": ["cs-CZ", "de-DE", "es-ES", "fr-FR", "it-IT", "pt-BR"],
+        "url": "firmware/t2t1/trezor-t2t1-2.8.8.bin",
+        "fingerprint": "f4888bed3e75205464910f3956d1f3ad19bb73e093b31c9141a66226a7081990",
+        "changelog": "* Fix \"PIN attempts exceeded\" screen\n* Fixed a bug resulting in restarting the recovery flow when inputting 33-word mnemonic",
+        "url_bitcoinonly": "firmware/t2t1/trezor-t2t1-2.8.8-bitcoinonly.bin",
+        "fingerprint_bitcoinonly": "81928bbb5bc855f46a2ccb210173f9676b69d153a513bfa0101abfc063f7aef5",
+        "changelog_bitcoinonly": "* Fix \"PIN attempts exceeded\" screen\n* Fixed a bug resulting in restarting the recovery flow when inputting 33-word mnemonic"
+    },
+    {
+        "required": false,
         "version": [2, 8, 7],
         "min_firmware_version": [2, 0, 8],
         "min_bootloader_version": [2, 0, 0],

--- a/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.8.7-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.8.7-bitcoinonly.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d887ce2f9a92c9605ff78fe7440d7b92b51d4989a291b00f3f5c4ca40ca1ceda
-size 1268736

--- a/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.8.7.bin
+++ b/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.8.7.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:29b0cb1877188e0875b8bcf8f36818b63cd7c590c56b140daddb4134e2a82242
-size 1602560

--- a/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.8.8-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.8.8-bitcoinonly.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dbd9fc206f6467012008f7e0c9749e975b4e26fdae9cc3a7fa5f926feeb12357
+size 1267712

--- a/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.8.8.bin
+++ b/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.8.8.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24f68c9351b0d71b8480de413e1e130fef965e115e7dedf71259b131dc49a2a3
+size 1595392


### PR DESCRIPTION
Following up on https://github.com/trezor/data/pull/125, adding FW binaries for 2.8.8 and 1.13.0