### PR TITLE
fix(suite-native): has account transactions selector

### DIFF
--- a/packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinBalanceSection.tsx
+++ b/packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinBalanceSection.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 import styled, { useTheme } from 'styled-components';
 
-import { selectHasAccountTransactions } from '@suite-common/wallet-core';
+import { selectHasBitcoinAccountTransactions } from '@suite-common/wallet-core';
 import { Card, Column } from '@trezor/components';
 
 import { useSelector } from 'src/hooks/suite';
@@ -27,7 +27,9 @@ interface CoinjoinBalanceSectionProps {
 
 export const CoinjoinBalanceSection = ({ accountKey }: CoinjoinBalanceSectionProps) => {
     const hasAnonymitySetError = useSelector(selectHasAnonymitySetError);
-    const hasTransactions = useSelector(state => selectHasAccountTransactions(state, accountKey));
+    const hasTransactions = useSelector(state =>
+        selectHasBitcoinAccountTransactions(state, accountKey),
+    );
 
     const theme = useTheme();
 

--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -280,7 +280,10 @@ export const selectAccountByKey = createMemoizedSelector(
     },
 );
 
-export const selectHasAccountTransactions = createMemoizedSelector(
+// CAUTION!: This selector does not work for XRP accounts! It should be used only for Bitcoin-like accounts.
+// Ripple backend does not provide the total transaction count info.
+// The property`account.history.total` is always equal to -1 for XRP accounts.
+export const selectHasBitcoinAccountTransactions = createMemoizedSelector(
     [selectAccountByKey],
     account => !!account?.history.total,
 );

--- a/suite-native/module-accounts-management/src/components/TransactionListHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/TransactionListHeader.tsx
@@ -5,8 +5,8 @@ import { useNavigation } from '@react-navigation/native';
 
 import {
     AccountsRootState,
+    TransactionsRootState,
     selectAccountByKey,
-    selectHasAccountTransactions,
     selectIsPortfolioTrackerDevice,
     selectIsTestnetAccount,
 } from '@suite-common/wallet-core';
@@ -22,6 +22,7 @@ import {
     SendStackRoutes,
     StackNavigationProps,
 } from '@suite-native/navigation';
+import { TokensRootState, selectHasAccountAnyTransactions } from '@suite-native/tokens';
 
 import { AccountDetailCryptoValue } from './AccountDetailCryptoValue';
 import { AccountDetailGraph } from './AccountDetailGraph';
@@ -47,8 +48,8 @@ const TransactionListHeaderContent = ({
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
-    const accountHasTransactions = useSelector((state: AccountsRootState) =>
-        selectHasAccountTransactions(state, accountKey),
+    const hasAccountTransactions = useSelector((state: TransactionsRootState & TokensRootState) =>
+        selectHasAccountAnyTransactions(state, accountKey),
     );
     const isTestnetAccount = useSelector((state: AccountsRootState) =>
         selectIsTestnetAccount(state, accountKey),
@@ -60,7 +61,7 @@ const TransactionListHeaderContent = ({
 
     // Graph is temporarily hidden also for ERC20 tokens.
     // Will be solved in issue: https://github.com/trezor/trezor-suite/issues/7839
-    const isGraphDisplayed = accountHasTransactions && !isTestnetAccount && !isTokenAccount;
+    const isGraphDisplayed = hasAccountTransactions && !isTestnetAccount && !isTokenAccount;
 
     if (isGraphDisplayed) {
         return <AccountDetailGraph accountKey={accountKey} />;
@@ -87,8 +88,9 @@ export const TransactionListHeader = memo(
             selectAccountByKey(state, accountKey),
         );
 
-        const accountHasTransactions = useSelector((state: AccountsRootState) =>
-            selectHasAccountTransactions(state, accountKey),
+        const hasAccountTransactions = useSelector(
+            (state: TransactionsRootState & TokensRootState) =>
+                selectHasAccountAnyTransactions(state, accountKey),
         );
         const isTestnetAccount = useSelector((state: AccountsRootState) =>
             selectIsTestnetAccount(state, accountKey),
@@ -138,7 +140,7 @@ export const TransactionListHeader = memo(
                         accountKey={accountKey}
                         tokenContract={tokenContract}
                     />
-                    {accountHasTransactions && (
+                    {hasAccountTransactions && (
                         <HStack paddingTop="sp8" paddingHorizontal="sp16" flex={1} spacing="sp12">
                             {isReceiveButtonDisplayed && (
                                 <Box flex={1}>
@@ -166,7 +168,7 @@ export const TransactionListHeader = memo(
                     )}
                     {isPriceCardDisplayed && <CoinPriceCard accountKey={accountKey} />}
                 </VStack>
-                {accountHasTransactions && (
+                {hasAccountTransactions && (
                     <Box marginTop="sp52" marginHorizontal="sp32">
                         <Text variant="titleSmall">
                             <Translation id="transactions.title" />

--- a/suite-native/tokens/src/tokensSelectors.ts
+++ b/suite-native/tokens/src/tokensSelectors.ts
@@ -163,6 +163,11 @@ export const selectAccountTransactionsWithTokenTransfers = createMemoizedSelecto
         ) as WalletAccountTransaction[],
 );
 
+export const selectHasAccountAnyTransactions = createMemoizedSelector(
+    [selectAccountTransactionsWithTokenTransfers],
+    (transactions): boolean => transactions.length > 0,
+);
+
 export const selectAccountsKnownTokens = createMemoizedSelector(
     [selectAccountByKey, selectTokenDefinitions],
     (account, tokenDefinitions): TokenInfoBranded[] => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- suite-common`selectHasAccountTransactions` was used but it does not work for XRP accounts because the Ripple backend does not provide total transactions count info
![Screenshot 2025-02-11 at 9 46 42 AM](https://github.com/user-attachments/assets/432e2a2f-0bea-4777-94a3-bc9f0f56f9ca)
  - this selector was renamed to make this backend discrepancy clear 
  - new correct selector was created specifically for suite-native


## Related Issue

Resolve #16814 

## Screenshots:


https://github.com/user-attachments/assets/ce40449d-a8e2-4da1-b2db-90ae8be34037


