### PR TITLE
fix(suite-native): develop build pipeline fix

### DIFF
--- a/.github/workflows/release-suite-native-develop.yml
+++ b/.github/workflows/release-suite-native-develop.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup EAS
         uses: expo/expo-github-action@v8
         with:
-          eas-version: latest
+          eas-version: 14.7.1
           token: ${{ secrets.EXPO_TOKEN }}
       - name: Install libs
         run: yarn workspaces focus @suite-native/app


### PR DESCRIPTION
- Apply the same eas version to develop builds as this PR did to other tracks: https://github.com/trezor/trezor-suite/pull/16887
