### PR TITLE
fix(suite-native): add missing footer bottom margin on coin enabling init screen

### DIFF
--- a/suite-native/coin-enabling/src/screens/CoinEnablingInitScreen.tsx
+++ b/suite-native/coin-enabling/src/screens/CoinEnablingInitScreen.tsx
@@ -58,7 +58,7 @@ export const CoinEnablingInitScreen = () => {
                 canBeSaved && (
                     <Animated.View entering={SlideInDown} exiting={SlideOutDown}>
                         <ScreenFooterGradient />
-                        <Box marginHorizontal="sp16">
+                        <Box marginHorizontal="sp16" marginBottom="sp16">
                             <Button onPress={handleSave} testID="@coin-enabling/button-save">
                                 <Translation id="moduleSettings.coinEnabling.initialSetup.button" />
                             </Button>


### PR DESCRIPTION
Before:
<img width="353" alt="Screenshot 2025-02-11 at 12 16 07" src="https://github.com/user-attachments/assets/063fa42c-1dc4-4440-8bd7-3f647b490cf4" />

After:
<img width="353" alt="Screenshot 2025-02-11 at 12 16 24" src="https://github.com/user-attachments/assets/09eafc90-b95d-458c-af3e-1f325d16a5f7" />
