### PR TITLE
fix(suite): add missing accounts to the trading buy, sell and exchange box

### DIFF
--- a/packages/suite/src/actions/wallet/tradingSellActions.ts
+++ b/packages/suite/src/actions/wallet/tradingSellActions.ts
@@ -56,6 +56,7 @@ export type TradingSellAction =
               accountIndex: Account['index'];
               accountType: Account['accountType'];
           };
+          sendAccountKey: AccountKey | undefined;
       };
 
 export const loadSellInfo = async (): Promise<SellInfo> => {
@@ -94,6 +95,7 @@ export const saveTrade = (
     exchangeTrade: SellFiatTrade,
     account: Account,
     date: string,
+    sendAccountKey: AccountKey | undefined,
 ): TradingSellAction => ({
     type: TRADING_COMMON.SAVE_TRADE,
     tradeType: 'sell',
@@ -106,6 +108,7 @@ export const saveTrade = (
         accountType: account.accountType,
         accountIndex: account.index,
     },
+    sendAccountKey,
 });
 
 export const saveQuoteRequest = (request: SellFiatTradeQuoteRequest): TradingSellAction => ({

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -396,6 +396,7 @@ export const useTradingSellForm = ({
                             response.trade,
                             selectedAccount.account,
                             new Date().toISOString(),
+                            tradingAccountKey,
                         ),
                     );
                     dispatch(tradingSellActions.saveTransactionId(response.trade.orderId));
@@ -634,6 +635,7 @@ export const useTradingSellForm = ({
                 response,
                 selectedAccount.account,
                 new Date().toISOString(),
+                tradingAccountKey,
             ),
         );
         dispatch(tradingSellActions.saveTransactionId(selectedTrade.orderId));

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingVerifyAccount.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingVerifyAccount.tsx
@@ -6,6 +6,7 @@ import {
     cryptoIdToSymbol,
     getUnusedAddressFromAccount,
     parseCryptoId,
+    tradingExchangeActions,
 } from '@suite-common/trading';
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
@@ -129,7 +130,8 @@ const useTradingVerifyAccount = ({
 
     const selectAccountOption = (option: TradingVerifyFormAccountOptionProps) => {
         setSelectedAccountOption(option);
-        // setReceiveAccount(option.account);
+        dispatch(tradingExchangeActions.setReceiveAccountKey(option.account?.key));
+
         if (option.account) {
             const { address } = getUnusedAddressFromAccount(option.account);
             methods.setValue('address', address, { shouldValidate: true });

--- a/packages/suite/src/hooks/wallet/trading/useTradingWatchTrade.ts
+++ b/packages/suite/src/hooks/wallet/trading/useTradingWatchTrade.ts
@@ -63,7 +63,7 @@ const tradingWatchTrade = async <T extends TradingType>({
                 tradeData.cryptoStringAmount = sellResponse.cryptoStringAmount;
             }
 
-            dispatch(saveSellTrade(tradeData, account, newDate));
+            dispatch(saveSellTrade(tradeData, account, newDate, trade.sendAccountKey));
         }
     }
 

--- a/packages/suite/src/reducers/wallet/__tests__/tradingReducer.test.ts
+++ b/packages/suite/src/reducers/wallet/__tests__/tradingReducer.test.ts
@@ -147,6 +147,7 @@ describe('settings reducer', () => {
                 accountIndex: 0,
                 accountType: 'normal',
             },
+            sendAccountKey: 'xxx',
         };
 
         const updatedTradeSell = {

--- a/packages/suite/src/storage/CHANGELOG.md
+++ b/packages/suite/src/storage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Storage changelog
 
+## 55
+
+-   change `tradingTrades` - add `sendAccountKey` and `receiveAccountKey` to each exchange trade
+
 ## 54
 
 -   create `connect` object for Connect Popup related data

--- a/packages/suite/src/storage/CHANGELOG.md
+++ b/packages/suite/src/storage/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 55
 
--   change `tradingTrades` - add `sendAccountKey` and `receiveAccountKey` to each exchange trade
+-   change `tradingTrades` - add `sendAccountKey` and `receiveAccountKey` to each buy, sell, and exchange trade
 
 ## 54
 

--- a/packages/suite/src/storage/index.ts
+++ b/packages/suite/src/storage/index.ts
@@ -5,7 +5,7 @@ import { reloadApp } from 'src/utils/suite/reload';
 import type { SuiteDBSchema } from './definitions';
 import { migrate } from './migrations';
 
-const VERSION = 54; // don't forget to add migration and CHANGELOG when changing versions!
+const VERSION = 55; // don't forget to add migration and CHANGELOG when changing versions!
 
 /**
  *  If the object stores don't already exist then creates them.

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -1,19 +1,15 @@
-import { CryptoId } from 'invity-api';
 import { toWei } from 'web3-utils';
 
-import { cryptoIdToNetwork, toTokenCryptoId } from '@suite-common/trading';
 import {
     type NetworkSymbol,
     getNetwork,
     isNetworkSymbol,
     networkSymbolCollection,
 } from '@suite-common/wallet-config';
-import type { Account, BackendSettings } from '@suite-common/wallet-types';
+import type { BackendSettings } from '@suite-common/wallet-types';
 import {
     amountToSmallestUnit,
-    findAccountsByAddress,
     formatNetworkAmount,
-    getContractAddressForNetworkSymbol,
     networkAmountToSmallestUnit,
 } from '@suite-common/wallet-utils';
 import { parseAsset } from '@trezor/blockchain-link-utils/src/blockfrost';
@@ -31,6 +27,7 @@ import type { BlockbookUrl, CustomBackend } from 'src/types/wallet/backend';
 
 import { updateAll } from './utils';
 import type { DBWalletAccountTransaction, SuiteDBSchema } from '../definitions';
+import { migrateToV55 } from './versions/migrateToV55';
 
 type WalletWithBackends = {
     backends?: PartialRecord<NetworkSymbol, Omit<CustomBackend, 'coin'>>;
@@ -1282,60 +1279,6 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
     }
 
     if (oldVersion < 55) {
-        const findAccountForTrade = (
-            accounts: Account[],
-            address: string | undefined,
-            cryptoId: CryptoId | undefined,
-        ): Account | undefined => {
-            if (!address || !cryptoId) {
-                return undefined;
-            }
-
-            const network = cryptoIdToNetwork(cryptoId);
-            if (!network) {
-                return undefined;
-            }
-
-            const account = findAccountsByAddress(network.symbol, address, accounts).at(0);
-
-            if (account) {
-                return account;
-            }
-
-            return accounts.find(account => {
-                const cryptoIds = [
-                    ...(account.tokens?.flatMap(token =>
-                        toTokenCryptoId(
-                            account.symbol,
-                            getContractAddressForNetworkSymbol(account.symbol, token.contract),
-                        ),
-                    ) ?? []),
-                    getNetwork(account.symbol).tradeCryptoId,
-                ].filter(Boolean) as CryptoId[];
-
-                return account.descriptor === address && cryptoIds.includes(cryptoId);
-            });
-        };
-
-        const accountsStoreOld = transaction.objectStore('accounts');
-        const accounts = await accountsStoreOld.getAll();
-
-        await updateAll(transaction, 'tradingTrades', trade => {
-            if (trade.tradeType === 'exchange') {
-                trade.sendAccountKey = findAccountForTrade(
-                    accounts,
-                    trade.account.descriptor,
-                    trade.data.send,
-                )?.key;
-
-                trade.receiveAccountKey = findAccountForTrade(
-                    accounts,
-                    trade.data.receiveAddress,
-                    trade.data.receive,
-                )?.key;
-
-                return trade;
-            }
-        });
+        await migrateToV55(db, oldVersion, newVersion, transaction);
     }
 };

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -1,15 +1,19 @@
+import { CryptoId } from 'invity-api';
 import { toWei } from 'web3-utils';
 
+import { cryptoIdToNetwork, toTokenCryptoId } from '@suite-common/trading';
 import {
     type NetworkSymbol,
     getNetwork,
     isNetworkSymbol,
     networkSymbolCollection,
 } from '@suite-common/wallet-config';
-import type { BackendSettings } from '@suite-common/wallet-types';
+import type { Account, BackendSettings } from '@suite-common/wallet-types';
 import {
     amountToSmallestUnit,
+    findAccountsByAddress,
     formatNetworkAmount,
+    getContractAddressForNetworkSymbol,
     networkAmountToSmallestUnit,
 } from '@suite-common/wallet-utils';
 import { parseAsset } from '@trezor/blockchain-link-utils/src/blockfrost';
@@ -1275,5 +1279,63 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
 
     if (oldVersion < 54) {
         db.createObjectStore('connect');
+    }
+
+    if (oldVersion < 55) {
+        const findAccountForTrade = (
+            accounts: Account[],
+            address: string | undefined,
+            cryptoId: CryptoId | undefined,
+        ): Account | undefined => {
+            if (!address || !cryptoId) {
+                return undefined;
+            }
+
+            const network = cryptoIdToNetwork(cryptoId);
+            if (!network) {
+                return undefined;
+            }
+
+            const account = findAccountsByAddress(network.symbol, address, accounts).at(0);
+
+            if (account) {
+                return account;
+            }
+
+            return accounts.find(account => {
+                const cryptoIds = [
+                    ...(account.tokens?.flatMap(token =>
+                        toTokenCryptoId(
+                            account.symbol,
+                            getContractAddressForNetworkSymbol(account.symbol, token.contract),
+                        ),
+                    ) ?? []),
+                    getNetwork(account.symbol).tradeCryptoId,
+                ].filter(Boolean) as CryptoId[];
+
+                return account.descriptor === address && cryptoIds.includes(cryptoId);
+            });
+        };
+
+        const accountsStoreOld = transaction.objectStore('accounts');
+        const accounts = await accountsStoreOld.getAll();
+
+        await updateAll(transaction, 'tradingTrades', trade => {
+            if (trade.tradeType === 'exchange') {
+                trade.sendAccountKey = findAccountForTrade(
+                    accounts,
+                    trade.account.descriptor,
+                    trade.data.send,
+                )?.key;
+
+                trade.receiveAccountKey = findAccountForTrade(
+                    accounts,
+                    trade.data.receiveAddress,
+                    trade.data.receive,
+                )?.key;
+
+                return trade;
+            }
+        });
     }
 };

--- a/packages/suite/src/storage/migrations/versions/migrateToV55.ts
+++ b/packages/suite/src/storage/migrations/versions/migrateToV55.ts
@@ -1,0 +1,103 @@
+import { CryptoId } from 'invity-api';
+
+import { cryptoIdToNetwork, toTokenCryptoId } from '@suite-common/trading';
+import { getNetwork } from '@suite-common/wallet-config';
+import type { Account } from '@suite-common/wallet-types';
+import {
+    findAccountsByAddress,
+    getContractAddressForNetworkSymbol,
+} from '@suite-common/wallet-utils';
+import { OnUpgradeFunc } from '@trezor/suite-storage';
+
+import { SuiteDBSchema } from 'src/storage/definitions';
+
+import { updateAll } from '../utils';
+
+const findAccountForTrade = (
+    accounts: Account[],
+    address: string | undefined,
+    cryptoId: CryptoId | undefined,
+): Account | undefined => {
+    if (!address || !cryptoId) {
+        return undefined;
+    }
+
+    const network = cryptoIdToNetwork(cryptoId);
+    if (!network) {
+        return undefined;
+    }
+
+    const account = findAccountsByAddress(network.symbol, address, accounts).at(0);
+
+    if (account) {
+        return account;
+    }
+
+    return accounts.find(account => {
+        const cryptoIds = [
+            ...(account.tokens?.flatMap(token =>
+                toTokenCryptoId(
+                    account.symbol,
+                    getContractAddressForNetworkSymbol(account.symbol, token.contract),
+                ),
+            ) ?? []),
+            getNetwork(account.symbol).tradeCryptoId,
+        ].filter(Boolean) as CryptoId[];
+
+        return account.descriptor === address && cryptoIds.includes(cryptoId);
+    });
+};
+
+export const migrateToV55: OnUpgradeFunc<SuiteDBSchema> = async (
+    _db,
+    _oldVersion,
+    _newVersion,
+    transaction,
+) => {
+    const accountsStoreOld = transaction.objectStore('accounts');
+    const accounts = await accountsStoreOld.getAll();
+
+    await updateAll(transaction, 'tradingTrades', trade => {
+        if (trade.tradeType === 'buy' && trade.receiveAccountKey === undefined) {
+            trade.receiveAccountKey = findAccountForTrade(
+                accounts,
+                trade.data.receiveAddress,
+                trade.data.receiveCurrency,
+            )?.key;
+
+            return trade;
+        }
+
+        if (trade.tradeType === 'sell' && trade.sendAccountKey === undefined) {
+            trade.sendAccountKey = findAccountForTrade(
+                accounts,
+                // account may be incorrect because it may not be current, but the default
+                trade.account.descriptor,
+                trade.data.cryptoCurrency,
+            )?.key;
+
+            return trade;
+        }
+
+        if (trade.tradeType === 'exchange') {
+            if (trade.sendAccountKey === undefined) {
+                trade.sendAccountKey = findAccountForTrade(
+                    accounts,
+                    // account may be incorrect because it may not be current, but the default
+                    trade.account.descriptor,
+                    trade.data.send,
+                )?.key;
+            }
+
+            if (trade.receiveAccountKey === undefined) {
+                trade.receiveAccountKey = findAccountForTrade(
+                    accounts,
+                    trade.data.receiveAddress,
+                    trade.data.receive,
+                )?.key;
+            }
+
+            return trade;
+        }
+    });
+};

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailBuy/TradingDetailBuy.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailBuy/TradingDetailBuy.tsx
@@ -5,11 +5,12 @@ import { BuyTradeStatus } from 'invity-api';
 import styled from 'styled-components';
 
 import type { TradingBuyType } from '@suite-common/trading';
+import { selectAccounts } from '@suite-common/wallet-core';
 import { Card } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
 
 import { goto } from 'src/actions/suite/routerActions';
-import { useDispatch } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useTradingDetailContext } from 'src/hooks/wallet/trading/useTradingDetail';
 import { TradingGetCryptoQuoteAmountProps } from 'src/types/trading/trading';
 import { TradingDetailBuyPaymentFailed } from 'src/views/wallet/trading/common/TradingDetail/TradingDetailBuy/TradingDetailBuyPaymentFailed';
@@ -41,6 +42,7 @@ const getTradeStatusStep = (tradeStatus?: BuyTradeStatus) => {
 };
 
 export const TradingDetailBuy = () => {
+    const accounts = useSelector(selectAccounts);
     const { trade, info, account } = useTradingDetailContext<TradingBuyType>();
     const dispatch = useDispatch();
 
@@ -61,6 +63,8 @@ export const TradingDetailBuy = () => {
         receiveAmount: trade?.data?.receiveStringAmount ?? '',
         receiveCurrency: trade?.data?.receiveCurrency,
     };
+
+    const receiveAccount = accounts.find(account => account.key === trade?.receiveAccountKey);
 
     useEffect(() => {
         // if tradeStatus hasn't changed, don't send the analytics event
@@ -115,6 +119,7 @@ export const TradingDetailBuy = () => {
             <Card>
                 <TradingSelectedOfferInfo
                     account={account}
+                    selectedAccount={receiveAccount}
                     selectedQuote={trade.data}
                     transactionId={trade.key}
                     providers={info?.providerInfos}

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
@@ -5,13 +5,14 @@ import { ExchangeTradeStatus } from 'invity-api';
 import styled from 'styled-components';
 
 import { type TradingExchangeType, cryptoIdToNetwork } from '@suite-common/trading';
+import { selectAccounts } from '@suite-common/wallet-core';
 import { Card, InfoItem } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
 
 import { goto } from 'src/actions/suite/routerActions';
 import { Translation } from 'src/components/suite';
 import { IOAddress } from 'src/components/suite/copy/IOAddress';
-import { useDispatch } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useTradingDetailContext } from 'src/hooks/wallet/trading/useTradingDetail';
 import { tradeFinalStatuses } from 'src/hooks/wallet/trading/useTradingWatchTrade';
 import { TradingGetCryptoQuoteAmountProps } from 'src/types/trading/trading';
@@ -48,6 +49,7 @@ const getTradeStatusStep = (tradeStatus: ExchangeTradeStatus) => {
 };
 
 export const TradingDetailExchange = () => {
+    const accounts = useSelector(selectAccounts);
     const { account, trade, info } = useTradingDetailContext<TradingExchangeType>();
     const dispatch = useDispatch();
 
@@ -103,6 +105,9 @@ export const TradingDetailExchange = () => {
     const { receiveTxHash, send } = trade.data;
     const network = send && cryptoIdToNetwork(send);
 
+    const sendAccount = accounts.find(account => account.key === trade.sendAccountKey);
+    const receiveAccount = accounts.find(account => account.key === trade.receiveAccountKey);
+
     return (
         <Wrapper>
             <Card>
@@ -142,6 +147,8 @@ export const TradingDetailExchange = () => {
             </Card>
             <Card>
                 <TradingSelectedOfferInfo
+                    account={sendAccount}
+                    selectedAccount={receiveAccount}
                     selectedQuote={trade.data}
                     transactionId={trade.key}
                     providers={info?.providerInfos}

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSell.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSell.tsx
@@ -5,11 +5,12 @@ import { SellTradeStatus } from 'invity-api';
 import styled from 'styled-components';
 
 import type { TradingSellType } from '@suite-common/trading';
+import { selectAccounts } from '@suite-common/wallet-core';
 import { Card } from '@trezor/components';
 import { EventType, analytics } from '@trezor/suite-analytics';
 
 import { goto } from 'src/actions/suite/routerActions';
-import { useDispatch } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useTradingDetailContext } from 'src/hooks/wallet/trading/useTradingDetail';
 import { tradeFinalStatuses } from 'src/hooks/wallet/trading/useTradingWatchTrade';
 import { TradingGetCryptoQuoteAmountProps } from 'src/types/trading/trading';
@@ -36,6 +37,7 @@ const getTradeStatusStep = (tradeStatus: SellTradeStatus) => {
 };
 
 export const TradingDetailSell = () => {
+    const accounts = useSelector(selectAccounts);
     const { account, trade, info } = useTradingDetailContext<TradingSellType>();
     const dispatch = useDispatch();
 
@@ -56,6 +58,8 @@ export const TradingDetailSell = () => {
         receiveAmount: trade?.data?.cryptoStringAmount ?? '',
         receiveCurrency: trade?.data?.cryptoCurrency,
     };
+
+    const sendAccount = accounts.find(account => account.key === trade?.sendAccountKey);
 
     useEffect(() => {
         // if tradeStatus hasn't changed, don't send the analytics event
@@ -109,6 +113,7 @@ export const TradingDetailSell = () => {
             <Card>
                 <TradingSelectedOfferInfo
                     account={account}
+                    selectedAccount={sendAccount}
                     providers={info?.providerInfos}
                     selectedQuote={trade.data}
                     transactionId={trade.key}

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferSell/TradingOfferSell.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferSell/TradingOfferSell.tsx
@@ -1,9 +1,11 @@
 import { Fragment } from 'react';
 
 import type { TradingSellType } from '@suite-common/trading';
+import { selectAccounts } from '@suite-common/wallet-core';
 import { Card, Divider } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
+import { useSelector } from 'src/hooks/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { TradingOfferSellProps } from 'src/types/trading/tradingForm';
 import { TradingOfferSellBankAccount } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferSell/TradingOfferSellBankAccount';
@@ -15,7 +17,10 @@ import {
 } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferStepper';
 
 export const TradingOfferSell = (props: TradingOfferSellProps) => {
-    const { sellStep } = useTradingFormContext<TradingSellType>();
+    const accounts = useSelector(selectAccounts);
+    const { sellStep, trade } = useTradingFormContext<TradingSellType>();
+
+    const sendAccount = accounts.find(account => account.key === trade?.sendAccountKey);
 
     const steps: (TradingSelectedOfferStepperItemProps & {
         component: JSX.Element | null;
@@ -44,7 +49,7 @@ export const TradingOfferSell = (props: TradingOfferSellProps) => {
                 ))}
             </Card>
             <Card>
-                <TradingSelectedOfferInfo {...props} />
+                <TradingSelectedOfferInfo {...props} selectedAccount={sendAccount} />
             </Card>
         </>
     );

--- a/suite-common/trading/src/reducers/__fixtures__/tradingReducer.ts
+++ b/suite-common/trading/src/reducers/__fixtures__/tradingReducer.ts
@@ -35,6 +35,7 @@ const tradeBuy: TradingTransactionBuy = {
         accountIndex: 0,
         accountType: 'normal',
     },
+    receiveAccountKey: 'yyy',
 };
 
 const tradeExchange: TradingTransactionExchange = {
@@ -56,6 +57,8 @@ const tradeExchange: TradingTransactionExchange = {
         accountIndex: 0,
         accountType: 'normal',
     },
+    sendAccountKey: 'xxx',
+    receiveAccountKey: 'yyy',
 };
 
 const symbolsInfo: InfoResponse = {

--- a/suite-common/trading/src/reducers/exchangeReducer.ts
+++ b/suite-common/trading/src/reducers/exchangeReducer.ts
@@ -24,6 +24,7 @@ export type TradingExchangeState = {
     addressVerified: string | undefined;
     // internal selected account key in trading section
     tradingAccountKey?: AccountKey;
+    receiveAccountKey?: AccountKey;
     selectedQuote: ExchangeTrade | undefined;
     isFromRedirect: boolean;
     isLoading: boolean;
@@ -40,6 +41,7 @@ export const exchangeInitialState: TradingExchangeState = {
     quotes: [],
     addressVerified: undefined,
     tradingAccountKey: undefined,
+    receiveAccountKey: undefined,
     selectedQuote: undefined,
     isFromRedirect: false,
     isLoading: false,
@@ -74,6 +76,9 @@ const tradingExchangeSlice = createSlice({
         },
         setTradingAccountKey(state, action: PayloadAction<AccountKey | undefined>) {
             state.tradingAccountKey = action.payload;
+        },
+        setReceiveAccountKey(state, action: PayloadAction<AccountKey | undefined>) {
+            state.receiveAccountKey = action.payload;
         },
         saveSelectedQuote(state, action: PayloadAction<ExchangeTrade | undefined>) {
             state.selectedQuote = action.payload;

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -340,3 +340,9 @@ export const selectValidTradingBuyQuotes = createMemoizedSelector(
         return quotes.filter(item => item.rate && item.rate !== 0);
     },
 );
+
+export const selectTradingExchangeAccountKey = (state: TradingRootState) =>
+    state.wallet.tradingNew.exchange.tradingAccountKey;
+
+export const selectTradingExchangeReceiveAccountKey = (state: TradingRootState) =>
+    state.wallet.tradingNew.exchange.receiveAccountKey;

--- a/suite-common/trading/src/thunks/buy/confirmTradeThunk.ts
+++ b/suite-common/trading/src/thunks/buy/confirmTradeThunk.ts
@@ -8,7 +8,10 @@ import { TRADING_BUY_THUNK_PREFIX } from '../../constants';
 import { invityAPI } from '../../invityAPI';
 import { tradingBuyActions } from '../../reducers/buyReducer';
 import { tradingActions } from '../../reducers/tradingReducer';
-import { selectTradingBuySelectedQuote } from '../../selectors/tradingSelectors';
+import {
+    selectTradingBuySelectedQuote,
+    selectTradingExchangeReceiveAccountKey,
+} from '../../selectors/tradingSelectors';
 
 export type ConfirmTradeThunkProps = {
     returnUrl: string;
@@ -32,6 +35,7 @@ export const confirmTradeThunk = createThunk(
         { dispatch, getState },
     ) => {
         const selectedQuote = selectTradingBuySelectedQuote(getState());
+        const receiveAccountKey = selectTradingExchangeReceiveAccountKey(getState());
 
         if (!selectedQuote) return;
 
@@ -76,6 +80,7 @@ export const confirmTradeThunk = createThunk(
                         accountIndex: account.index,
                     },
                     data: response.trade,
+                    receiveAccountKey,
                 }),
             );
 

--- a/suite-common/trading/src/thunks/common/watchTradeThunk.ts
+++ b/suite-common/trading/src/thunks/common/watchTradeThunk.ts
@@ -106,6 +106,8 @@ export const watchTradeThunk = createThunk(
                         key: data.tradeData.orderId,
                         account: accountData,
                         data: data.tradeData,
+                        sendAccountKey: trade.sendAccountKey,
+                        receiveAccountKey: trade.receiveAccountKey,
                     }),
                 );
 

--- a/suite-common/trading/src/thunks/common/watchTradeThunk.ts
+++ b/suite-common/trading/src/thunks/common/watchTradeThunk.ts
@@ -78,6 +78,7 @@ export const watchTradeThunk = createThunk(
                         key: data.tradeData.paymentId,
                         account: accountData,
                         data: data.tradeData,
+                        receiveAccountKey: trade.receiveAccountKey,
                     }),
                 );
 

--- a/suite-common/trading/src/thunks/exchange/confirmTradeThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/confirmTradeThunk.ts
@@ -9,8 +9,10 @@ import { invityAPI } from '../../invityAPI';
 import { tradingExchangeActions } from '../../reducers/exchangeReducer';
 import { tradingActions } from '../../reducers/tradingReducer';
 import {
+    selectTradingExchangeAccountKey,
     selectTradingExchangeFormStep,
     selectTradingExchangeQuotesRequest,
+    selectTradingExchangeReceiveAccountKey,
     selectTradingExchangeSelectedQuote,
 } from '../../selectors/tradingSelectors';
 import { getUnusedAddressFromAccount } from '../../utils';
@@ -46,6 +48,8 @@ export const confirmTradeThunk = createThunk(
 
         const selectedQuote = selectTradingExchangeSelectedQuote(getState());
         const quotesRequest = selectTradingExchangeQuotesRequest(getState());
+        const sendAccountKey = selectTradingExchangeAccountKey(getState());
+        const receiveAccountKey = selectTradingExchangeReceiveAccountKey(getState());
         const formStep = selectTradingExchangeFormStep(getState());
         const { address: refundAddress } = getUnusedAddressFromAccount(account);
 
@@ -152,6 +156,8 @@ export const confirmTradeThunk = createThunk(
                     accountIndex: account.index,
                 },
                 data: response,
+                sendAccountKey,
+                receiveAccountKey,
             }),
         );
         dispatch(tradingExchangeActions.saveTransactionId(response.orderId));

--- a/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
@@ -6,7 +6,11 @@ import { Account } from '@suite-common/wallet-types';
 import { exchangeThunks, tradingThunks } from '../';
 import { TRADING_EXCHANGE_THUNK_PREFIX } from '../../constants';
 import { tradingActions } from '../../reducers/tradingReducer';
-import { selectTradingExchangeSelectedQuote } from '../../selectors/tradingSelectors';
+import {
+    selectTradingExchangeAccountKey,
+    selectTradingExchangeReceiveAccountKey,
+    selectTradingExchangeSelectedQuote,
+} from '../../selectors/tradingSelectors';
 import { TradingSendRejectedProps } from '../../types';
 import { RecomposeAndSignTxThunkProps } from '../common/recomposeAndSignTxThunk';
 
@@ -42,6 +46,8 @@ export const sendDexTransactionThunk = createThunk<
         { dispatch, getState, rejectWithValue },
     ) => {
         const selectedQuote = selectTradingExchangeSelectedQuote(getState());
+        const sendAccountKey = selectTradingExchangeAccountKey(getState());
+        const receiveAccountKey = selectTradingExchangeReceiveAccountKey(getState());
 
         if (
             !selectedQuote ||
@@ -104,6 +110,8 @@ export const sendDexTransactionThunk = createThunk<
                         accountIndex: account.index,
                     },
                     data: trade,
+                    sendAccountKey,
+                    receiveAccountKey,
                 }),
             );
         } else {

--- a/suite-common/trading/src/thunks/exchange/sendTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/sendTransactionThunk.ts
@@ -8,7 +8,11 @@ import { SendDexTransactionThunkProps } from './sendDexTransactionThunk';
 import { TRADING_EXCHANGE_THUNK_PREFIX } from '../../constants';
 import { tradingExchangeActions } from '../../reducers/exchangeReducer';
 import { tradingActions } from '../../reducers/tradingReducer';
-import { selectTradingExchangeSelectedQuote } from '../../selectors/tradingSelectors';
+import {
+    selectTradingExchangeAccountKey,
+    selectTradingExchangeReceiveAccountKey,
+    selectTradingExchangeSelectedQuote,
+} from '../../selectors/tradingSelectors';
 import { TradingSendRejectedProps } from '../../types';
 
 export type SendTransactionThunkProps = {
@@ -41,6 +45,8 @@ export const sendTransactionThunk = createThunk<
         { dispatch, getState, rejectWithValue },
     ) => {
         const selectedQuote = selectTradingExchangeSelectedQuote(getState());
+        const sendAccountKey = selectTradingExchangeAccountKey(getState());
+        const receiveAccountKey = selectTradingExchangeReceiveAccountKey(getState());
         const selectedTrade = trade ?? selectedQuote;
         // sendAddress may be set by useTradingWatchTrade hook to the trade object
         const sendAddress = selectedTrade?.sendAddress;
@@ -117,6 +123,8 @@ export const sendTransactionThunk = createThunk<
                     accountIndex: account.index,
                 },
                 data: selectedTrade,
+                sendAccountKey,
+                receiveAccountKey,
             }),
         );
         dispatch(tradingExchangeActions.saveTransactionId(selectedTrade.orderId));

--- a/suite-common/trading/src/thunks/exchange/signDataAndConfirmThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/signDataAndConfirmThunk.ts
@@ -10,7 +10,11 @@ import TrezorConnect, {
 import { exchangeThunks } from '../';
 import { TRADING_EXCHANGE_THUNK_PREFIX } from '../../constants';
 import { tradingActions } from '../../reducers/tradingReducer';
-import { selectTradingExchangeSelectedQuote } from '../../selectors/tradingSelectors';
+import {
+    selectTradingExchangeAccountKey,
+    selectTradingExchangeReceiveAccountKey,
+    selectTradingExchangeSelectedQuote,
+} from '../../selectors/tradingSelectors';
 
 export type SignDataAndConfirmThunkProps = {
     account: Account;
@@ -36,6 +40,8 @@ export const signDataAndConfirmThunk = createThunk(
         { dispatch, getState },
     ) => {
         const selectedQuote = selectTradingExchangeSelectedQuote(getState());
+        const sendAccountKey = selectTradingExchangeAccountKey(getState());
+        const receiveAccountKey = selectTradingExchangeReceiveAccountKey(getState());
 
         if (!selectedQuote?.signData) {
             dispatch(
@@ -106,6 +112,8 @@ export const signDataAndConfirmThunk = createThunk(
                     accountIndex: account.index,
                 },
                 data: trade,
+                sendAccountKey,
+                receiveAccountKey,
             }),
         );
 

--- a/suite-common/trading/src/types.ts
+++ b/suite-common/trading/src/types.ts
@@ -88,16 +88,21 @@ type TradingCommonTransaction = {
         accountIndex: Account['index'];
     };
 };
-export type TradingTransactionBuy = TradingCommonTransaction & { tradeType: 'buy'; data: BuyTrade };
+export type TradingTransactionBuy = TradingCommonTransaction & {
+    tradeType: 'buy';
+    data: BuyTrade;
+    receiveAccountKey: Account['key'] | undefined;
+};
 export type TradingTransactionSell = TradingCommonTransaction & {
     tradeType: 'sell';
     data: SellFiatTrade;
+    sendAccountKey: Account['key'] | undefined;
 };
 export type TradingTransactionExchange = TradingCommonTransaction & {
     tradeType: 'exchange';
     data: ExchangeTrade;
-    sendAccountKey?: Account['key'];
     receiveAccountKey?: Account['key'];
+    sendAccountKey: Account['key'] | undefined;
 };
 export type TradingTransaction =
     | TradingTransactionBuy

--- a/suite-common/trading/src/types.ts
+++ b/suite-common/trading/src/types.ts
@@ -96,6 +96,8 @@ export type TradingTransactionSell = TradingCommonTransaction & {
 export type TradingTransactionExchange = TradingCommonTransaction & {
     tradeType: 'exchange';
     data: ExchangeTrade;
+    sendAccountKey?: Account['key'];
+    receiveAccountKey?: Account['key'];
 };
 export type TradingTransaction =
     | TradingTransactionBuy


### PR DESCRIPTION
## Description

Adds missing account information to the trading box for buy, sell, and exchange flows.

**UI update:**
Display sendAccount and receiveAccount in the transaction detail for:

- **Buy** - shows `receiveAccount`
- **Sell** - shows `sendAccount`
- **Exchange** - shows both `sendAccount` and `receiveAccount`

**Migration:**
Updates existing transactions in IndexedDB to include:

- `sendAccount` for **sell** and **exchange**
- `receiveAccount` for **buy** and **exchange**

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/15900

## Screenshots:

<img width="1104" alt="image" src="https://github.com/user-attachments/assets/34a08be0-cc0d-40eb-b4d8-c44f2d15ed18" />



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-exchange-missing-accounts&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-exchange-missing-accounts&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/trading-exchange-missing-accounts&lookback=7)