### PR TITLE
Experiment - mock debounce in send form unit test

### DIFF
--- a/packages/suite/src/hooks/wallet/__tests__/useSendForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useSendForm.test.tsx
@@ -361,6 +361,19 @@ describe('useSendForm hook', () => {
             `changeFee: ${f.description}`,
             async () => {
                 testMocks.setTrezorConnectFixtures(f.connect);
+
+                jest.mock('@trezor/react-utils', () => {
+                    const originalModule = jest.requireActual('@trezor/react-utils');
+
+                    return {
+                        ...originalModule,
+                        __esModule: true,
+                        useDebounce: () => async (fn: any) => {
+                            await fn();
+                        },
+                    };
+                });
+
                 const store = initStore(f.store);
                 const callback: TestCallback = {};
                 const { unmount } = renderWithProviders(


### PR DESCRIPTION
This PR is attempting to address a failing unit test related to ETH fee estimation in the send form. There is some nondeterministic behavior - sometimes the test makes 3 calls instead of 2.

<img width="1025" alt="Screenshot 2025-02-17 at 08 59 49" src="https://github.com/user-attachments/assets/9e18921c-0c15-412c-b0b9-74812703fef9" />

My hypothesis is that this is caused by timing related factors, so I’m trying to mock the debounce function to eliminate waiting time to get a more consistent test outcome.