### PR TITLE
chore: specify correct tab width for *.json

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,3 +20,7 @@ trim_trailing_whitespace = unset
 # Use indentation of 2 spaces for all yaml files.
 [*.{yaml,yml}]
 indent_size = 2
+
+# Use indentation of 4 spaces for all json files.
+[*.json]
+indent_size = 4


### PR DESCRIPTION
## Description

Correctly specify tab width = 4 for json files in `.editorconfig`, since some editors may use 2 as default.
This isn't relevant for source files (js, ts, tsx), because prettier config takes precedence.