### PR TITLE
fix(connect): test install to use target ES2019

### DIFF
--- a/packages/connect/e2e/test-yarn-install.sh
+++ b/packages/connect/e2e/test-yarn-install.sh
@@ -22,5 +22,5 @@ echo import TrezorConnect from \"@trezor/connect\" >index.ts
 
 # compile with typescript
 yarn add typescript@5.5.4
-yarn tsc ./index.ts --types node,w3c-web-usb --esModuleInterop --target ES2022 --module commonjs 
+yarn tsc ./index.ts --types node,w3c-web-usb --esModuleInterop --lib ES2022,DOM --target ES2019 --module commonjs 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
It looks like target `ES2022` was not required, having `ES2019` with `DOM,ES2022.error` lib was enough to satisfy typescript.
