### PR TITLE
fix(connect): releasing device on browser reload using sendBeacon api

### DIFF
--- a/packages/connect-web/src/module/index.ts
+++ b/packages/connect-web/src/module/index.ts
@@ -79,3 +79,7 @@ const TrezorConnect = factory(
 
 export default TrezorConnect;
 export * from '@trezor/connect/src/exports';
+
+window.addEventListener('beforeunload', () => {
+    impl.dispose();
+});

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -550,6 +550,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
                     // note 3: in 99% of cases we send this message unnecessarily. as @Szymon pointed out, it might be better to catch this call and repeat it.
                     // note 4: this case can happen also in the 'if' branch. 1] reload app, 2], browser doesn't fire release in time, 3] you get unacquired device, 4] you click
                     //         the 'use device here' button and here you go. Yet I didn't want to burden every TrezorConnect method call with this but we may reconsider this.
+                    // note 5: ad note 4. it is not so problematic anymore since cleanup on dispose has been improved in https://github.com/trezor/trezor-suite/pull/16930
                     if (['v1', 'bridge'].includes(this.protocol.name)) {
                         _log.debug(
                             'sending a preventive cancel on the first encounter with the device',
@@ -1170,21 +1171,14 @@ export class Device extends TypedEmitter<DeviceEvents> {
         return null;
     }
 
-    async dispose() {
+    dispose() {
         this.removeAllListeners();
         if (this.session && this.lastAcquiredHere) {
-            try {
-                await this.cancelableAction?.();
-                await this.commands?.cancel();
-
-                return this.transport.release({
-                    session: this.session,
-                    path: this.transportPath,
-                    onClose: true,
-                });
-            } catch {
-                // empty
-            }
+            return this.transport.release({
+                session: this.session,
+                path: this.transportPath,
+                onClose: true,
+            });
         }
     }
 

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -582,7 +582,6 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
                 await device.dispose();
             }),
         );
-
         // now we can be relatively sure that release calls have been dispatched
         // and we can safely kill all async subscriptions in transport layer
         transport?.stop();

--- a/packages/suite-web/e2e/tests/wallet/discovery.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/discovery.test.ts
@@ -1,6 +1,8 @@
 // @group_wallet
 // @retry=2
 
+import { getRandomInt } from '@trezor/utils';
+
 import { onNavBar } from '../../support/pageObjects/topBarObject';
 
 // discovery should end within this time frame
@@ -29,6 +31,18 @@ describe('Discovery', () => {
         cy.log('all available networks should return something from discovery');
 
         cy.getTestElement('@dashboard/loading', { timeout: 1000 * 10 });
+
+        // wait randomly between 1000 and 4000 ms
+        cy.wait(getRandomInt(1, 40) * 100);
+        // trigger reload to simulate interruption. we want to make sure that communication with the device does not
+        // end up in some de-synced state. if this test becomes flaky, this reload might be the reason.
+        cy.reload();
+
+        // device appears as connected
+        cy.getTestElement('@deviceStatus-connected');
+        // dashboard is still loading, discovery starts, no error appears
+        cy.getTestElement('@dashboard/loading');
+
         cy.getTestElement('@dashboard/loading', { timeout: DISCOVERY_LIMIT }).should('not.exist');
         ['btc', ...coinsToActivate].forEach(symbol => {
             cy.getTestElement(`@wallet/coin-balance/value-${symbol}`);

--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -184,6 +184,12 @@ export class BridgeTransport extends AbstractTransport {
         onClose,
         signal,
     }: AbstractTransportMethodParams<'release'>) {
+        if (onClose && typeof navigator !== 'undefined' && 'sendBeacon' in navigator) {
+            navigator.sendBeacon(`${this.url}/release/${session}?beacon=1`);
+
+            return Promise.resolve(this.success(null));
+        }
+
         return this.scheduleAction(
             async signal => {
                 const releasePromise = this.post('/release', {


### PR DESCRIPTION
still wip... ignore 

fig 1: firing release request. query string parameter has only informative purpose 

<img width="714" alt="image" src="https://github.com/user-attachments/assets/b42c7fc5-c498-4a03-b1f7-79c1fcea4600" />
