### PR TITLE
fix(suite): Fix non-ascii banner in passphrase wallet

### DIFF
--- a/packages/product-components/src/components/PassphraseTypeCard/NonAsciiBanner.tsx
+++ b/packages/product-components/src/components/PassphraseTypeCard/NonAsciiBanner.tsx
@@ -25,7 +25,9 @@ const SpecialCharsWrapper = styled.div`
 
 const SpecialChars = styled.div`
     padding: 0 ${spacingsPx.xxs};
-    box-shadow: inset 0 0 0 2px #f2f2f2;
+    box-shadow: inset 0 0 0 1px ${({ theme }) => theme.borderElevation0};
+    border-radius: ${borders.radii.xs} ${borders.radii.xs} 0 0;
+    padding-bottom: ${spacingsPx.xxxs};
     font-family: RobotoMono, 'PixelOperatorMono8', monospace;
     font-weight: 400;
     letter-spacing: 0.1em;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

dark mode problem only

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

before

<img width="415" alt="Screenshot 2025-02-11 at 14 40 56" src="https://github.com/user-attachments/assets/f05d8717-b467-4082-902e-6e7145389a0d" />


after

<img width="406" alt="Screenshot 2025-02-11 at 14 48 08" src="https://github.com/user-attachments/assets/437d1ae2-42af-424d-87f0-06c2b2050e42" />
