### PR TITLE
chore(suite-native): move tokenDefinitionsMiddleware to desktop packages

### DIFF
--- a/packages/suite/src/middlewares/wallet/index.ts
+++ b/packages/suite/src/middlewares/wallet/index.ts
@@ -5,7 +5,6 @@ import {
     prepareFiatRatesMiddleware,
     prepareStakeMiddleware,
 } from '@suite-common/wallet-core';
-import { prepareTokenDefinitionsMiddleware } from '@suite-common/token-definitions';
 
 import { extraDependencies } from 'src/support/extraDependencies';
 
@@ -16,6 +15,7 @@ import graphMiddleware from './graphMiddleware';
 import { tradingMiddleware } from './tradingMiddleware';
 import { coinjoinMiddleware } from './coinjoinMiddleware';
 import { replaceByFeeErrorMiddleware } from './replaceByFeeErrorMiddleware';
+import { prepareTokenDefinitionsMiddleware } from './tokenDefinitionsMiddleware';
 
 export default [
     prepareBlockchainMiddleware(extraDependencies),

--- a/packages/suite/src/middlewares/wallet/tokenDefinitionsMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/tokenDefinitionsMiddleware.ts
@@ -1,9 +1,9 @@
 import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 
-import { selectNetworkTokenDefinitions } from './tokenDefinitionsSelectors';
-import { getTokenDefinitionThunk } from './tokenDefinitionsThunks';
-import { getSupportedDefinitionTypes } from './tokenDefinitionsUtils';
+import { selectNetworkTokenDefinitions } from '../../../../../suite-common/token-definitions/src/tokenDefinitionsSelectors';
+import { getTokenDefinitionThunk } from '../../../../../suite-common/token-definitions/src/tokenDefinitionsThunks';
+import { getSupportedDefinitionTypes } from '../../../../../suite-common/token-definitions/src/tokenDefinitionsUtils';
 
 const CHANGE_NETWORKS = '@wallet-settings/change-networks'; // from walletSettings.ts
 

--- a/suite-common/token-definitions/src/index.ts
+++ b/suite-common/token-definitions/src/index.ts
@@ -3,7 +3,6 @@ export * from './tokenDefinitionsConstants';
 export * from './tokenDefinitionsSelectors';
 export * from './tokenDefinitionsReducer';
 export * from './tokenDefinitionsThunks';
-export * from './tokenDefinitionsMiddleware';
 export * from './tokenDefinitionsTypes';
 export * from './tokenDefinitionsUtils';
 export * from './antiFraud';


### PR DESCRIPTION
## Description

Moving `tokenDefinitionsMiddleware` from suite-common to suite.

## Related Issue

Trying to resolve issue #11454.

## Screenshots:
