### PR TITLE
fix(suite-native): fix device onboarding feature flag evaluation

### DIFF
--- a/suite-native/device/src/hooks/useHandleDeviceConnection.ts
+++ b/suite-native/device/src/hooks/useHandleDeviceConnection.ts
@@ -128,13 +128,13 @@ export const useHandleDeviceConnection = () => {
         if (isFirmwareInstallationRunning || isSuspiciousDeviceScreenFocused(navigation)) return;
 
         if (
-            isDeviceInitialized &&
             isDeviceConnected &&
             isOnboardingFinished &&
             !isPortfolioTrackerDevice &&
             !isDeviceConnectedAndAuthorized &&
             !isBiometricsOverlayVisible &&
-            !shouldNavigateToDeviceCompromisedModal
+            !shouldNavigateToDeviceCompromisedModal &&
+            !isDeviceSetupSupported
         ) {
             requestPrioritizedDeviceAccess({
                 deviceCallback: () => dispatch(authorizeDeviceThunk()),
@@ -165,6 +165,7 @@ export const useHandleDeviceConnection = () => {
         isFirmwareInstallationRunning,
         isDeviceInitialized,
         shouldNavigateToDeviceCompromisedModal,
+        isDeviceSetupSupported,
     ]);
 
     // In case that the physical device is disconnected, redirect to the home screen and

--- a/suite-native/device/src/selectors.ts
+++ b/suite-native/device/src/selectors.ts
@@ -1,4 +1,4 @@
-import { A, pipe } from '@mobily/ts-belt';
+import { A, G, pipe } from '@mobily/ts-belt';
 
 import {
     Feature,
@@ -47,7 +47,8 @@ type NativeDeviceRootState = DeviceRootState &
     AccountsRootState &
     DiscoveryRootState &
     SettingsSliceRootState &
-    FiatRatesRootState;
+    FiatRatesRootState &
+    FeatureFlagsRootState;
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<NativeDeviceRootState>();
 
@@ -199,6 +200,13 @@ export const selectHasFirmwareAuthenticityCheckHardFailed = (state: FwAuthentici
 };
 
 export const selectIsDeviceSetupSupported = createMemoizedSelector(
-    [selectDeviceModel],
-    model => !!model && isDeviceSetupSupported(model),
+    [
+        selectDeviceModel,
+        (state: NativeDeviceRootState) =>
+            selectIsFeatureFlagEnabled(state, FeatureFlag.IsDeviceOnboardingEnabled),
+    ],
+    (model, isDeviceOnboardingFeatureFlagEnabled) =>
+        isDeviceOnboardingFeatureFlagEnabled &&
+        G.isNotNullable(model) &&
+        isDeviceSetupSupported(model),
 );


### PR DESCRIPTION
## Description
- fixes usage of `IsDeviceOnboardingEnabled` so the device onboarding flow is hidden for the production builds

