### PR TITLE
fix(suite-native): suspicious device back button removed

### DIFF
--- a/suite-native/module-onboarding/src/screens/SuspiciousDeviceScreen.tsx
+++ b/suite-native/module-onboarding/src/screens/SuspiciousDeviceScreen.tsx
@@ -103,23 +103,13 @@ export const SuspiciousDeviceScreen = ({
                         </IconListTextItem>
                     </VStack>
                 </VStack>
-                <VStack spacing="sp12">
-                    <Button
-                        testID="@onboarding/SuspiciousDeviceScreen/contactSupportBtn"
-                        colorScheme="yellowBold"
-                        onPress={handleContactSupportButtonPress}
-                    >
-                        <Translation id="moduleOnboarding.suspiciousDeviceScreen.contactSupportButton" />
-                    </Button>
-
-                    <Button
-                        colorScheme="yellowElevation0"
-                        onPress={handleBackButtonPress}
-                        testID="@onboarding/SuspiciousDeviceScreen/backBtn"
-                    >
-                        <Translation id="generic.buttons.back" />
-                    </Button>
-                </VStack>
+                <Button
+                    testID="@onboarding/SuspiciousDeviceScreen/contactSupportBtn"
+                    colorScheme="yellowBold"
+                    onPress={handleContactSupportButtonPress}
+                >
+                    <Translation id="moduleOnboarding.suspiciousDeviceScreen.contactSupportButton" />
+                </Button>
             </VStack>
         </Screen>
     );


### PR DESCRIPTION
## Description
- back button removed form SuspiciousDeviceScreen [as requested here](https://www.figma.com/design/UdQpTfz2RhsoZzqLp9L8fU?node-id=1246-33191#1127497831)

## Related Issue
#16279 

## Screenshots:
![Screenshot 2025-02-12 at 7 40 53 AM](https://github.com/user-attachments/assets/fb785eea-f119-47a6-8adf-2edc79d6b617)
