### PR TITLE
fix(suite-native): apply blur correctly after Skia update

### DIFF
--- a/suite-native/atoms/src/DiscreetText/DiscreetCanvas.tsx
+++ b/suite-native/atoms/src/DiscreetText/DiscreetCanvas.tsx
@@ -37,8 +37,9 @@ export const DiscreetCanvas = ({ width, height, fontSize, text, color }: Discree
 
     return (
         <Canvas style={applyStyle(discreetCanvasStyle, { height, width })}>
-            <SkiaText y={fontSize} text={text} font={font} color={colors[color]} />
-            <Blur blur={blurValue} mode="decal" />
+            <SkiaText y={fontSize} text={text} font={font} color={colors[color]}>
+                <Blur blur={blurValue} mode="decal" />
+            </SkiaText>
         </Canvas>
     );
 };


### PR DESCRIPTION
The way blur is applied has been changed, see https://shopify.github.io/react-native-skia/docs/image-filters/blur/.

Resolves #16947