### PR TITLE
feat(suite-desktop): turn on ASAR integrity check

### DIFF
--- a/packages/suite-desktop/electron-builder-config.js
+++ b/packages/suite-desktop/electron-builder-config.js
@@ -162,5 +162,10 @@ module.exports = {
         category: 'Utility',
         target: ['AppImage'],
     },
+    electronFuses: {
+        // the fuse may be enabled for all build targets, but as of Jan 2025, it actually affects only macOS & Windows
+        enableEmbeddedAsarIntegrityValidation: true,
+        onlyLoadAppFromAsar: true,
+    },
     afterSign: '../suite-desktop-core/scripts/notarize.ts',
 };


### PR DESCRIPTION
## Description

Turn on ASAR integrity check on Windows & macOS.

:information_source:  Duplicate of [private PR](https://github.com/trezor/trezor-suite-private/pull/118).
See the private PR for extended description.

## Related Issue

See the private PR