### PR TITLE
fix(suite-native): add missing footer margin to account import summary screen

### DIFF
--- a/suite-native/module-accounts-import/src/components/AccountImportSummaryScreen.tsx
+++ b/suite-native/module-accounts-import/src/components/AccountImportSummaryScreen.tsx
@@ -26,7 +26,9 @@ export const AccountImportSummaryScreen = ({
         footer={
             <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
                 <ScreenFooterGradient />
-                <Box marginHorizontal="sp16">{footer}</Box>
+                <Box marginHorizontal="sp16" marginBottom="sp16">
+                    {footer}
+                </Box>
             </KeyboardAvoidingView>
         }
     >


### PR DESCRIPTION
Before:
<img width="353" alt="image" src="https://github.com/user-attachments/assets/1718688b-987a-4393-8e2d-2178b9be0f0c" />

After:
<img width="353" alt="image" src="https://github.com/user-attachments/assets/7a7139ed-7189-4b80-9953-63e0c62e6976" />
