### PR TITLE
fix(suite): restructure SettingsSection to properly display explanato…

### DIFF
--- a/packages/components/src/components/InfoItem/InfoItem.tsx
+++ b/packages/components/src/components/InfoItem/InfoItem.tsx
@@ -23,7 +23,10 @@ import { Icon, IconName } from '../Icon/Icon';
 import { Text } from '../typography/Text/Text';
 import { TextProps, TextPropsKeys } from '../typography/utils';
 
-export const allowedInfoItemTextProps = ['typographyStyle'] as const satisfies TextPropsKeys[];
+export const allowedInfoItemTextProps = [
+    'typographyStyle',
+    'ellipsisLineCount',
+] as const satisfies TextPropsKeys[];
 type AllowedTextProps = Pick<TextProps, (typeof allowedInfoItemTextProps)[number]>;
 
 export const allowedInfoItemFrameProps = [
@@ -56,6 +59,7 @@ export type InfoItemProps = AllowedFrameProps &
     };
 
 export const InfoItem = ({
+    ellipsisLineCount,
     children,
     label,
     direction = 'column',
@@ -94,7 +98,7 @@ export const InfoItem = ({
                         variant={variant}
                         typographyStyle={typographyStyle}
                         as="div"
-                        ellipsisLineCount={1}
+                        ellipsisLineCount={ellipsisLineCount ?? 1}
                     >
                         {label}
                     </Text>

--- a/packages/suite/src/components/settings/SettingsSection.tsx
+++ b/packages/suite/src/components/settings/SettingsSection.tsx
@@ -1,6 +1,16 @@
 import React, { ReactNode } from 'react';
 
-import { Card, Column, IconName, InfoItem, useMediaQuery, variables } from '@trezor/components';
+import {
+    Box,
+    Card,
+    Column,
+    Icon,
+    IconName,
+    InfoItem,
+    Tooltip,
+    useMediaQuery,
+    variables,
+} from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 type SettingsSectionProps = {
@@ -8,17 +18,37 @@ type SettingsSectionProps = {
     icon?: IconName;
     className?: string;
     children?: ReactNode;
+    tooltipText?: ReactNode;
 };
 
-export const SettingsSection = ({ title, icon, children }: SettingsSectionProps) => {
+export const SettingsSection = ({ title, icon, children, tooltipText }: SettingsSectionProps) => {
     const isBelowLaptop = useMediaQuery(`(max-width: ${variables.SCREEN_SIZE.LG})`);
 
     return (
         <InfoItem
+            ellipsisLineCount={0}
             direction={isBelowLaptop ? 'column' : 'row'}
             labelWidth={250}
             iconName={icon}
-            label={title}
+            label={
+                <>
+                    {title}
+                    {tooltipText && (
+                        <Box
+                            as="span"
+                            position={{
+                                type: 'relative',
+                                top: 2,
+                                left: 5,
+                            }}
+                        >
+                            <Tooltip isInline content={tooltipText}>
+                                <Icon name="question" size="medium" />
+                            </Tooltip>
+                        </Box>
+                    )}
+                </>
+            }
             variant="default"
             typographyStyle="titleSmall"
             verticalAlignment="top"

--- a/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
@@ -128,11 +128,8 @@ export const SettingsCoins = () => {
             </SettingsSection>
 
             <SettingsSection
-                title={
-                    <Tooltip content={<Translation id="TR_TESTNET_COINS_DESCRIPTION" />} hasIcon>
-                        <Translation id="TR_TESTNET_COINS" />
-                    </Tooltip>
-                }
+                tooltipText={<Translation id="TR_TESTNET_COINS_DESCRIPTION" />}
+                title={<Translation id="TR_TESTNET_COINS" />}
                 icon="coin"
             >
                 <SettingsSectionItem anchorId={SettingsAnchor.TestnetCrypto}>
@@ -142,14 +139,8 @@ export const SettingsCoins = () => {
 
             {showUnsupportedCoins && (
                 <SettingsSection
-                    title={
-                        <Tooltip
-                            content={<Translation id="TR_UNSUPPORTED_COINS_DESCRIPTION" />}
-                            hasIcon
-                        >
-                            <Translation id="TR_UNSUPPORTED_COINS" />
-                        </Tooltip>
-                    }
+                    tooltipText={<Translation id="TR_UNSUPPORTED_COINS_DESCRIPTION" />}
+                    title={<Translation id="TR_UNSUPPORTED_COINS" />}
                     icon="coin"
                 >
                     <SettingsSectionItem anchorId={SettingsAnchor.UnsupportedCrypto}>


### PR DESCRIPTION
…ry tooltips
TODO:
- [x] Level the tooltip icon with the rest of the text
- [x] test out properly that nothing else in the settings is broken SettingsSection is used just in settings
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve  https://github.com/trezor/trezor-suite/issues/16610

## Screenshots:

BRF
<img width="594" alt="406865411-609c1028-bc8c-4121-935b-e3dc6b5b4603" src="https://github.com/user-attachments/assets/659d2d1c-0aa5-4d5c-a344-482995aa2601" />


AFTR
![Screenshot 2025-02-12 at 2 22 28 PM](https://github.com/user-attachments/assets/3ffc7e09-0a64-47d9-bb93-8c98d8a2a984)
