### PR TITLE
feat(suite-native): show banner for DeviceCompromised

### DIFF
--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -28,7 +28,9 @@ export const TREZOR_SUPPORT_RECOVERY_ISSUES_URL: Url =
 export const TREZOR_SUPPORT_DEVICE_AUTHENTICATION_FAILED_URL: Url =
     'https://trezor.io/support/a/trezor-safe-device-authentication-check-failed';
 export const TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_URL: Url =
-    'https://trezor.io/support/a/trezor-fw-revision-check-failed';
+    'https://trezor.io/support/a/trezor-fw-authenticity-check-failed';
+export const TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_MOBILE_URL: Url =
+    'https://trezor.io/support/a/trezor-fw-authenticity-check-failed-mobile';
 export const TREZOR_SUPPORT_FW_ALREADY_INSTALLED: Url =
     'https://trezor.io/support/a/firmware-is-already-installed';
 export const TREZOR_SUPPORT_IS_MY_DEVICE_SAFE: Url =
@@ -115,6 +117,9 @@ export const HELP_CENTER_EVM_SEND_TO_CONTRACT_URL =
     'https://trezor.io/support/a/where-is-my-ethereum';
 export const HELP_CENTER_FIRMWARE_REVISION_CHECK: Url =
     'https://trezor.io/learn/a/trezor-firmware-authenticity-check';
+export const HELP_CENTER_FIRMWARE_REVISION_CHECK_MOBILE: Url =
+    'https://trezor.io/learn/a/trezor-firmware-authenticity-check-mobile';
+
 export const HELP_CENTER_REPLACE_BY_FEE_ETHEREUM: Url =
     'https://trezor.io/learn/a/replace-by-fee-rbf-ethereum';
 export const HELP_CENTER_REPLACE_BY_FEE_BITCOIN =

--- a/suite-native/app/src/App.tsx
+++ b/suite-native/app/src/App.tsx
@@ -11,6 +11,7 @@ import { FormatterProvider } from '@suite-common/formatters';
 import { OfflineBanner, configureNetInfo } from '@suite-native/connection-status';
 import { IntlProvider } from '@suite-native/intl';
 import { KillswitchMessageScreen, MessageSystemBannerRenderer } from '@suite-native/message-system';
+import { DeviceCompromisedBanner } from '@suite-native/module-authenticity-checks';
 import { NavigationContainerWithAnalytics } from '@suite-native/navigation';
 import { StoreProvider, selectIsAppReady, selectIsConnectInitialized } from '@suite-native/state';
 
@@ -64,6 +65,7 @@ const AppComponent = () => {
     return (
         <FormatterProvider config={formattersConfig}>
             <OfflineBanner />
+            <DeviceCompromisedBanner />
             <MessageSystemBannerRenderer />
             <BottomSheetModalProvider>
                 <RootStackNavigator />

--- a/suite-native/app/src/hooks/useGlobalHooks.tsx
+++ b/suite-native/app/src/hooks/useGlobalHooks.tsx
@@ -3,6 +3,7 @@ import {
     useHandleDeviceConnection,
     useReportDeviceCompromised,
 } from '@suite-native/device';
+import { useRenderDeviceCompromisedBanner } from '@suite-native/module-authenticity-checks';
 import { useConnectPopupNavigation } from '@suite-native/module-connect-popup';
 
 import { useCoinEnablingInitialCheck } from './useCoinEnablingInitialCheck';
@@ -19,4 +20,5 @@ export const useGlobalHooks = () => {
     useHandleDeviceConnection();
     useDetectDeviceError();
     useReportDeviceCompromised();
+    useRenderDeviceCompromisedBanner();
 };

--- a/suite-native/connection-status/src/OfflineBanner.tsx
+++ b/suite-native/connection-status/src/OfflineBanner.tsx
@@ -37,7 +37,7 @@ export const OfflineBanner = () => {
             <HStack style={applyStyle(contentStyle, { topSafeAreaInset })}>
                 <Icon name="wifiSlash" size="mediumLarge" />
                 <Text>
-                    <Translation id="generic.offline" />
+                    <Translation id="generic.banners.offline.title" />
                 </Text>
             </HStack>
         </View>

--- a/suite-native/device/src/config/firmware.ts
+++ b/suite-native/device/src/config/firmware.ts
@@ -5,17 +5,20 @@ import { FirmwareRevisionCheckError } from '@trezor/connect';
  * see packages/suite/src/constants/suite/firmware.ts for Suite
  */
 
+// will be ignored completely
+type SkippedBehavior = { type: 'skipped'; shouldReport: boolean };
 // display a warning banner
 type SoftWarningBehavior = { type: 'softWarning'; shouldReport: boolean };
 // display "Device Compromised" modal, after closing it dispaly a warning banner, block receiving address
 type HardModalBehavior = { type: 'hardModal'; shouldReport: true };
 
-type RevisionErrorBehavior = SoftWarningBehavior | HardModalBehavior;
+type RevisionErrorBehavior = SkippedBehavior | SoftWarningBehavior | HardModalBehavior;
 type RevisionCheckErrorScenarios = Record<FirmwareRevisionCheckError, RevisionErrorBehavior>;
 
 export const revisionCheckErrorScenarios = {
     'revision-mismatch': { type: 'hardModal', shouldReport: true },
     'firmware-version-unknown': { type: 'hardModal', shouldReport: true },
-    'cannot-perform-check-offline': { type: 'softWarning', shouldReport: false },
+    // offline state has its own special handling, see useIsOfflineBannerVisible
+    'cannot-perform-check-offline': { type: 'skipped', shouldReport: false },
     'other-error': { type: 'softWarning', shouldReport: true },
 } satisfies RevisionCheckErrorScenarios;

--- a/suite-native/intl/src/en.ts
+++ b/suite-native/intl/src/en.ts
@@ -27,7 +27,17 @@ export const en = {
         unknownError: 'Something went wrong',
         default: 'Default',
         orSeparator: 'OR',
-        offline: "You're offline.",
+        banners: {
+            offline: {
+                title: "You're offline.",
+            },
+            deviceCompromised: {
+                title: 'Unofficial firmware detected',
+                subtitle:
+                    'Your Trezor may be counterfeit. To ensure your safety, receiving funds has been disabled. Contact Trezor Support immediately.',
+                contactSupportButton: 'Contact Trezor Support',
+            },
+        },
         tokens: '+ Tokens',
     },
     icons: {

--- a/suite-native/module-authenticity-checks/package.json
+++ b/suite-native/module-authenticity-checks/package.json
@@ -17,6 +17,7 @@
         "@suite-native/intl": "workspace:*",
         "@suite-native/link": "workspace:*",
         "@suite-native/navigation": "workspace:*",
+        "@trezor/urls": "workspace:*",
         "react-redux": "8.0.7"
     }
 }

--- a/suite-native/module-authenticity-checks/package.json
+++ b/suite-native/module-authenticity-checks/package.json
@@ -14,10 +14,17 @@
         "@react-navigation/native": "6.1.18",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-native/atoms": "workspace:*",
+        "@suite-native/connection-status": "workspace:*",
+        "@suite-native/device": "workspace:*",
+        "@suite-native/icons": "workspace:*",
         "@suite-native/intl": "workspace:*",
         "@suite-native/link": "workspace:*",
         "@suite-native/navigation": "workspace:*",
+        "@trezor/styles": "workspace:*",
         "@trezor/urls": "workspace:*",
+        "jotai": "1.9.1",
+        "react": "18.2.0",
+        "react-native": "0.76.1",
         "react-redux": "8.0.7"
     }
 }

--- a/suite-native/module-authenticity-checks/src/DeviceCompromisedBannerAtoms.ts
+++ b/suite-native/module-authenticity-checks/src/DeviceCompromisedBannerAtoms.ts
@@ -1,0 +1,11 @@
+import { atom } from 'jotai';
+
+/**
+ * Represents the display variants for the DeviceCompromisedBanner.
+ * - 'none': Banner is hidden
+ * - 'brief': Shows banner with only title
+ * - 'extended': Shows banner with title, subtitle and CTA
+ */
+type DeviceCompromisedBannerVariant = 'none' | 'brief' | 'extended';
+
+export const deviceCompromisedBannerAtom = atom<DeviceCompromisedBannerVariant>('none');

--- a/suite-native/module-authenticity-checks/src/components/DeviceCompromisedBanner.tsx
+++ b/suite-native/module-authenticity-checks/src/components/DeviceCompromisedBanner.tsx
@@ -1,0 +1,66 @@
+import { View } from 'react-native';
+
+import { useAtomValue } from 'jotai';
+
+import { Button, HStack, Text, VStack } from '@suite-native/atoms';
+import { useOfflineBannerAwareSafeAreaInsets } from '@suite-native/connection-status';
+import { Icon } from '@suite-native/icons';
+import { Translation } from '@suite-native/intl';
+import { useOpenLink } from '@suite-native/link';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+import { TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_MOBILE_URL } from '@trezor/urls';
+
+import { deviceCompromisedBannerAtom } from '../DeviceCompromisedBannerAtoms';
+
+const containerStyle = prepareNativeStyle(utils => ({
+    backgroundColor: utils.colors.backgroundAlertRedSubtleOnElevation0,
+}));
+
+const contentStyle = prepareNativeStyle<{ topSafeAreaInset: number }>(
+    (utils, { topSafeAreaInset }) => ({
+        marginTop: topSafeAreaInset,
+        paddingTop: utils.spacings.sp8,
+        paddingBottom: utils.spacings.sp16,
+        paddingHorizontal: utils.spacings.sp24,
+        alignItems: 'center',
+    }),
+);
+
+const ExtendedBannerContent = () => {
+    const openLink = useOpenLink();
+    const handleContactSupportClick = () =>
+        openLink(TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_MOBILE_URL);
+
+    return (
+        <VStack spacing="sp16">
+            <Text textAlign="center">
+                <Translation id="generic.banners.deviceCompromised.subtitle" />
+            </Text>
+            <Button colorScheme="redBold" onPress={handleContactSupportClick}>
+                <Translation id="generic.banners.deviceCompromised.contactSupportButton" />
+            </Button>
+        </VStack>
+    );
+};
+
+export const DeviceCompromisedBanner = () => {
+    const bannerVariant = useAtomValue(deviceCompromisedBannerAtom);
+    const { applyStyle } = useNativeStyles();
+    const { top: topSafeAreaInset } = useOfflineBannerAwareSafeAreaInsets();
+
+    if (bannerVariant === 'none') return null;
+
+    return (
+        <View style={applyStyle(containerStyle)}>
+            <VStack spacing="sp2" style={applyStyle(contentStyle, { topSafeAreaInset })}>
+                <HStack alignItems="center">
+                    <Icon name="warningCircle" size="mediumLarge" />
+                    <Text variant="highlight">
+                        <Translation id="generic.banners.deviceCompromised.title" />
+                    </Text>
+                </HStack>
+                {bannerVariant === 'extended' && <ExtendedBannerContent />}
+            </VStack>
+        </View>
+    );
+};

--- a/suite-native/module-authenticity-checks/src/index.ts
+++ b/suite-native/module-authenticity-checks/src/index.ts
@@ -1,1 +1,3 @@
+export * from './useRenderDeviceCompromisedBanner';
+export * from './components/DeviceCompromisedBanner';
 export * from './screens/DeviceCompromisedModalScreen';

--- a/suite-native/module-authenticity-checks/src/screens/DeviceCompromisedModalScreen.tsx
+++ b/suite-native/module-authenticity-checks/src/screens/DeviceCompromisedModalScreen.tsx
@@ -15,11 +15,9 @@ import {
     ScreenHeader,
     StackToStackCompositeNavigationProps,
 } from '@suite-native/navigation';
+import { TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_MOBILE_URL } from '@trezor/urls';
 
-// TODO this page is for desktop; await creation of new page tailored to the suite-native UX
-const TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_URL =
-    'https://trezor.io/support/a/trezor-fw-revision-check-failed';
-const chatUrl = `${TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_URL}#open-chat`;
+const chatUrl = `${TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_MOBILE_URL}#open-chat`;
 
 const InformativeList = () => (
     <VStack spacing="sp24">

--- a/suite-native/module-authenticity-checks/src/useRenderDeviceCompromisedBanner.ts
+++ b/suite-native/module-authenticity-checks/src/useRenderDeviceCompromisedBanner.ts
@@ -1,0 +1,42 @@
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+
+import { useSetAtom } from 'jotai';
+
+import {
+    revisionCheckErrorScenarios,
+    selectFirmwareRevisionCheckErrorIfEnabled,
+} from '@suite-native/device';
+import {
+    AppTabsRoutes,
+    HomeStackRoutes,
+    RootStackRoutes,
+    useNavigationRouteMatch,
+} from '@suite-native/navigation';
+
+import { deviceCompromisedBannerAtom } from './DeviceCompromisedBannerAtoms';
+
+export const useRenderDeviceCompromisedBanner = () => {
+    const isRouteExcluded = useNavigationRouteMatch(RootStackRoutes.DeviceCompromisedModalScreen);
+    // need to match both; see note in hook definition
+    const isExtendedBanner = useNavigationRouteMatch([
+        AppTabsRoutes.HomeStack,
+        HomeStackRoutes.Home,
+    ]);
+
+    const revisionCheckError = useSelector(selectFirmwareRevisionCheckErrorIfEnabled);
+
+    const setBannerVariant = useSetAtom(deviceCompromisedBannerAtom);
+
+    useEffect(() => {
+        if (
+            isRouteExcluded ||
+            revisionCheckError === null ||
+            revisionCheckErrorScenarios[revisionCheckError].type === 'skipped'
+        ) {
+            return setBannerVariant('none');
+        }
+
+        setBannerVariant(isExtendedBanner ? 'extended' : 'brief');
+    }, [isRouteExcluded, isExtendedBanner, revisionCheckError, setBannerVariant]);
+};

--- a/suite-native/module-authenticity-checks/tsconfig.json
+++ b/suite-native/module-authenticity-checks/tsconfig.json
@@ -6,9 +6,13 @@
             "path": "../../suite-common/wallet-core"
         },
         { "path": "../atoms" },
+        { "path": "../connection-status" },
+        { "path": "../device" },
+        { "path": "../icons" },
         { "path": "../intl" },
         { "path": "../link" },
         { "path": "../navigation" },
+        { "path": "../../packages/styles" },
         { "path": "../../packages/urls" }
     ]
 }

--- a/suite-native/module-authenticity-checks/tsconfig.json
+++ b/suite-native/module-authenticity-checks/tsconfig.json
@@ -8,6 +8,7 @@
         { "path": "../atoms" },
         { "path": "../intl" },
         { "path": "../link" },
-        { "path": "../navigation" }
+        { "path": "../navigation" },
+        { "path": "../../packages/urls" }
     ]
 }

--- a/suite-native/module-settings/package.json
+++ b/suite-native/module-settings/package.json
@@ -43,6 +43,7 @@
         "@trezor/env-utils": "workspace:*",
         "@trezor/styles": "workspace:*",
         "@trezor/theme": "workspace:*",
+        "@trezor/urls": "workspace:*",
         "jotai": "1.9.1",
         "react": "18.2.0",
         "react-native": "0.76.1",

--- a/suite-native/module-settings/src/components/TurnOffFirmwareAuthenticityCheckCard.tsx
+++ b/suite-native/module-settings/src/components/TurnOffFirmwareAuthenticityCheckCard.tsx
@@ -11,19 +11,16 @@ import {
 } from '@suite-native/settings';
 import { useToast } from '@suite-native/toasts';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+import { HELP_CENTER_FIRMWARE_REVISION_CHECK_MOBILE } from '@trezor/urls';
 
 import { useSettingsNavigateTo } from '../navigation/useSettingsNavigateTo';
-
-// TODO this page is for desktop; await creation of new page tailored to the suite-native UX
-const HELP_CENTER_FIRMWARE_REVISION_CHECK =
-    'https://trezor.io/learn/a/trezor-firmware-authenticity-check';
 
 const fullWidthButtonStyle = prepareNativeStyle(() => ({ flex: 1 }));
 
 const LearnMoreButton = () => {
     const { applyStyle } = useNativeStyles();
     const openLink = useOpenLink();
-    const handleButtonPress = () => openLink(HELP_CENTER_FIRMWARE_REVISION_CHECK);
+    const handleButtonPress = () => openLink(HELP_CENTER_FIRMWARE_REVISION_CHECK_MOBILE);
 
     return (
         <Button

--- a/suite-native/module-settings/tsconfig.json
+++ b/suite-native/module-settings/tsconfig.json
@@ -38,7 +38,8 @@
         { "path": "../../packages/connect" },
         { "path": "../../packages/env-utils" },
         { "path": "../../packages/styles" },
-        { "path": "../../packages/theme" }
+        { "path": "../../packages/theme" },
+        { "path": "../../packages/urls" }
     ],
     "include": [".", "**/*.json"]
 }

--- a/suite-native/navigation/src/hooks/useNavigationRoute.ts
+++ b/suite-native/navigation/src/hooks/useNavigationRoute.ts
@@ -1,0 +1,41 @@
+import { useNavigationState } from '@react-navigation/native';
+import type { NavigationState } from '@react-navigation/routers';
+
+/**
+ * Recursively get the most specific active route name from the hierarchy of navigation states.
+ */
+export const getActiveRouteName = (state: NavigationState): string | undefined => {
+    if (!state || !state.routes || state.index == null) return undefined;
+
+    const route = state.routes[state.index];
+
+    if (route.state) return getActiveRouteName(route.state as NavigationState);
+
+    return route.name;
+};
+
+/**
+ * Get the most specific active route name from the hierarchy of navigation states.
+ *
+ * The value should be same as from useRoute hook provided by lib, but that hook can only be used in
+ * components downstream of the stack navigators! In components above the navigators, use this hook.
+ */
+export const useNavigationRoute = () => useNavigationState(state => getActiveRouteName(state));
+
+/**
+ * Determine if the most specific active route name matches the query.
+ *
+ * WARNING: if you need to match a route that is default in its stack, e.g. HomeStack.Home inside HomeStack,
+ * you'll need to query both [AppTabs.HomeStack, HomeStack.Home], because if a link in our app leads
+ * only to HomeStack, the navigation state will also end with HomeStack, and not show HomeStack.Home.
+ *
+ * @param routesToBeMatched Route name or array of route names to be matched
+ */
+export const useNavigationRouteMatch = (routesToBeMatched: string | string[]): boolean => {
+    const activeRouteName = useNavigationRoute();
+    if (!activeRouteName) return false;
+
+    return typeof routesToBeMatched === 'string'
+        ? routesToBeMatched === activeRouteName
+        : routesToBeMatched.includes(activeRouteName);
+};

--- a/suite-native/navigation/src/index.ts
+++ b/suite-native/navigation/src/index.ts
@@ -5,6 +5,7 @@ export * from './config';
 export * from './useHandleHardwareBackNavigation';
 export * from './useNavigateToInitialScreen';
 export * from './useScrollDivider';
+export * from './hooks/useNavigationRoute';
 export * from './components/TabBar';
 export * from './components/Screen';
 export * from './components/ScreenHeader';

--- a/yarn.lock
+++ b/yarn.lock
@@ -11485,6 +11485,7 @@ __metadata:
     "@suite-native/intl": "workspace:*"
     "@suite-native/link": "workspace:*"
     "@suite-native/navigation": "workspace:*"
+    "@trezor/urls": "workspace:*"
     react-redux: "npm:8.0.7"
   languageName: unknown
   linkType: soft
@@ -11755,6 +11756,7 @@ __metadata:
     "@trezor/env-utils": "workspace:*"
     "@trezor/styles": "workspace:*"
     "@trezor/theme": "workspace:*"
+    "@trezor/urls": "workspace:*"
     jotai: "npm:1.9.1"
     react: "npm:18.2.0"
     react-native: "npm:0.76.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11482,10 +11482,17 @@ __metadata:
     "@react-navigation/native": "npm:6.1.18"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-native/atoms": "workspace:*"
+    "@suite-native/connection-status": "workspace:*"
+    "@suite-native/device": "workspace:*"
+    "@suite-native/icons": "workspace:*"
     "@suite-native/intl": "workspace:*"
     "@suite-native/link": "workspace:*"
     "@suite-native/navigation": "workspace:*"
+    "@trezor/styles": "workspace:*"
     "@trezor/urls": "workspace:*"
+    jotai: "npm:1.9.1"
+    react: "npm:18.2.0"
+    react-native: "npm:0.76.1"
     react-redux: "npm:8.0.7"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Description

- update support/learn more links to placeholder URLs, where new articles will be created
- add helpers useNavigationRoute, useNavigationRouteMatch
- create DeviceCompromisedBanner
  - is rendered according to a jotai atom value, similarly to `Alert` and `Banner` but simpler 
  - show the brief banner on most pages, show extended banner at Home, and hide it on the DeviceCompromisedModal

## Related Issue

Part of #16452 (except the offline banner)

## Screenshots:

Video of the whole flow, to show that the detection of route is reliable:
[Screencast from 2025-02-12 13-55-34.webm](https://github.com/user-attachments/assets/3a2272f9-639a-4d15-87d8-2fa6611eff5e)


Together with OfflineBanner
![Screenshot from 2025-02-14 09-28-04](https://github.com/user-attachments/assets/46b78944-6fd6-4bb1-a755-14a432479ca3)
