### PR TITLE
fix(suite-native): handle device authenticity check for expired configs

### DIFF
--- a/suite-native/analytics/src/types.ts
+++ b/suite-native/analytics/src/types.ts
@@ -7,7 +7,12 @@ export type AnalyticsSendFlowStep =
     | 'outputs_review'
     | 'destination_tag_review';
 
-export type DeviceAuthenticityCheckResult = 'successful' | 'compromised' | 'cancelled' | 'failed';
+export type DeviceAuthenticityCheckResult =
+    | 'successful'
+    | 'compromised'
+    | 'configExpired'
+    | 'cancelled'
+    | 'failed';
 
 export type FirmwareUpdatePayload = {
     model: DeviceModelInternal;

--- a/suite-native/module-device-settings/src/components/DeviceAuthenticityCard.tsx
+++ b/suite-native/module-device-settings/src/components/DeviceAuthenticityCard.tsx
@@ -58,8 +58,11 @@ export const DeviceAuthenticityCard = () => {
         const { success, payload } = result.payload;
         if (success) {
             const checkResult = payload.valid ? 'successful' : 'compromised';
-            navigation.navigate(DeviceAuthenticityStackRoutes.AuthenticitySummary, { checkResult });
-            reportCheckResult(checkResult);
+            const configExpired = payload.error === 'CA_PUBKEY_NOT_FOUND' && payload.configExpired;
+            navigation.navigate(DeviceAuthenticityStackRoutes.AuthenticitySummary, {
+                checkResult: configExpired ? 'successful' : checkResult,
+            });
+            reportCheckResult(configExpired ? 'configExpired' : checkResult);
         } else {
             const errorCode = payload.code;
             if (errorCode === 'Failure_ActionCancelled' || errorCode === 'Failure_PinCancelled') {


### PR DESCRIPTION
Do not show devices as compromised if the app has expired DAC config.