### PR TITLE
fix(suite-native): return to Onboarding from DeviceCompromisedModal

### DIFF
--- a/suite-native/module-authenticity-checks/src/screens/DeviceCompromisedModalScreen.tsx
+++ b/suite-native/module-authenticity-checks/src/screens/DeviceCompromisedModalScreen.tsx
@@ -58,10 +58,17 @@ export const DeviceCompromisedModalScreen = () => {
     // After dismissCheck, an effect could fire in useHandleDeviceConnection to navigate away, but it's not guaranteed!
     // To be sure we don't lock user on on this screen, we navigate home.
     const handleClose = () => {
-        navigation.navigate(RootStackRoutes.AppTabs, {
-            screen: AppTabsRoutes.HomeStack,
-            params: { screen: HomeStackRoutes.Home },
-        });
+        // the modal is most likely entered from OnboardingStack, ConnectingDevice or Home, so let's send user back
+        if (navigation.canGoBack()) {
+            navigation.goBack();
+        }
+        // Home screen set only as fallback if can't go back
+        else {
+            navigation.navigate(RootStackRoutes.AppTabs, {
+                screen: AppTabsRoutes.HomeStack,
+                params: { screen: HomeStackRoutes.Home },
+            });
+        }
         dismissCheck();
     };
 


### PR DESCRIPTION
## Description

When closing `DeviceCompromisedModalScreen`, first let's try to navigate _back_, and only use the Home route as fallback.

There are three cases depending _from where_ you enter the modal (
Actually, the FW revision check is done async by Connect (sometimes it may await http fetch), so basically the modal can be entered from _anywhere_. But it seems to me there are three typical cases from where you enter the modal:
- `HomeStack.Home`: behaves the same
- `AuthorizeDeviceStackRoutes.ConnectingDevice`: that worked, but with a glitch, because it'd first send you Home, but `useHandleDeviceConnection` would immediately redirect to ConnectingDevice, with disruptive animations. Now goes straight to ConnectingDevice (smoother)
- `OnboardingStack` that was broken :x: if modal was entered from onboarding, onboarding was effectively aborted (couldn't reenter it from Home), but now you are sent back to continue onboarding :heavy_check_mark:  

## Related Issue

Part of  https://github.com/trezor/trezor-suite/issues/16448

## Screenshots

wipe app to reproduce:
[Screencast from 2025-02-12 18-29-35.webm](https://github.com/user-attachments/assets/10058e7e-58fa-428c-9a9e-3f9dd33cff85)
