### PR TITLE
Tenv link default model

### DIFF
--- a/docker/docker-compose.connect-popup-ci.yml
+++ b/docker/docker-compose.connect-popup-ci.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:6339d48f1df4f007fe5caee659e4bca3997d480a
+    image: ghcr.io/trezor/trezor-user-env:0eff3cb37dc607dc83ce4802d1c39727ec298993
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.connect-popup-ci.yml
+++ b/docker/docker-compose.connect-popup-ci.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:b23cde1860e03c8bdaebbbc8fcbcd2cc9d6375d3
+    image: ghcr.io/trezor/trezor-user-env:6339d48f1df4f007fe5caee659e4bca3997d480a
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.connect-popup-ci.yml
+++ b/docker/docker-compose.connect-popup-ci.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:0eff3cb37dc607dc83ce4802d1c39727ec298993
+    image: ghcr.io/trezor/trezor-user-env:c23309d96f013376a54bf442fe710e80341e6ff3
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.connect-popup-test.yml
+++ b/docker/docker-compose.connect-popup-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:b23cde1860e03c8bdaebbbc8fcbcd2cc9d6375d3
+    image: ghcr.io/trezor/trezor-user-env:6339d48f1df4f007fe5caee659e4bca3997d480a
     environment:
       - DISPLAY=$DISPLAY
       - QT_X11_NO_MITSHM=1

--- a/docker/docker-compose.connect-popup-test.yml
+++ b/docker/docker-compose.connect-popup-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:6339d48f1df4f007fe5caee659e4bca3997d480a
+    image: ghcr.io/trezor/trezor-user-env:0eff3cb37dc607dc83ce4802d1c39727ec298993
     environment:
       - DISPLAY=$DISPLAY
       - QT_X11_NO_MITSHM=1

--- a/docker/docker-compose.connect-popup-test.yml
+++ b/docker/docker-compose.connect-popup-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:0eff3cb37dc607dc83ce4802d1c39727ec298993
+    image: ghcr.io/trezor/trezor-user-env:c23309d96f013376a54bf442fe710e80341e6ff3
     environment:
       - DISPLAY=$DISPLAY
       - QT_X11_NO_MITSHM=1

--- a/docker/docker-compose.connect-test.yml
+++ b/docker/docker-compose.connect-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:6339d48f1df4f007fe5caee659e4bca3997d480a
+    image: ghcr.io/trezor/trezor-user-env:0eff3cb37dc607dc83ce4802d1c39727ec298993
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.connect-test.yml
+++ b/docker/docker-compose.connect-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:b23cde1860e03c8bdaebbbc8fcbcd2cc9d6375d3
+    image: ghcr.io/trezor/trezor-user-env:6339d48f1df4f007fe5caee659e4bca3997d480a
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.connect-test.yml
+++ b/docker/docker-compose.connect-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:0eff3cb37dc607dc83ce4802d1c39727ec298993
+    image: ghcr.io/trezor/trezor-user-env:c23309d96f013376a54bf442fe710e80341e6ff3
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.connect-webextension-test.yml
+++ b/docker/docker-compose.connect-webextension-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:6339d48f1df4f007fe5caee659e4bca3997d480a
+    image: ghcr.io/trezor/trezor-user-env:0eff3cb37dc607dc83ce4802d1c39727ec298993
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.connect-webextension-test.yml
+++ b/docker/docker-compose.connect-webextension-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:b23cde1860e03c8bdaebbbc8fcbcd2cc9d6375d3
+    image: ghcr.io/trezor/trezor-user-env:6339d48f1df4f007fe5caee659e4bca3997d480a
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.connect-webextension-test.yml
+++ b/docker/docker-compose.connect-webextension-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:0eff3cb37dc607dc83ce4802d1c39727ec298993
+    image: ghcr.io/trezor/trezor-user-env:c23309d96f013376a54bf442fe710e80341e6ff3
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-ci-pw.yml
+++ b/docker/docker-compose.suite-ci-pw.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:6339d48f1df4f007fe5caee659e4bca3997d480a
+    image: ghcr.io/trezor/trezor-user-env:0eff3cb37dc607dc83ce4802d1c39727ec298993
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-ci-pw.yml
+++ b/docker/docker-compose.suite-ci-pw.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:b23cde1860e03c8bdaebbbc8fcbcd2cc9d6375d3
+    image: ghcr.io/trezor/trezor-user-env:6339d48f1df4f007fe5caee659e4bca3997d480a
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-ci-pw.yml
+++ b/docker/docker-compose.suite-ci-pw.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:0eff3cb37dc607dc83ce4802d1c39727ec298993
+    image: ghcr.io/trezor/trezor-user-env:c23309d96f013376a54bf442fe710e80341e6ff3
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-ci.yml
+++ b/docker/docker-compose.suite-ci.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:6339d48f1df4f007fe5caee659e4bca3997d480a
+    image: ghcr.io/trezor/trezor-user-env:0eff3cb37dc607dc83ce4802d1c39727ec298993
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-ci.yml
+++ b/docker/docker-compose.suite-ci.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:b23cde1860e03c8bdaebbbc8fcbcd2cc9d6375d3
+    image: ghcr.io/trezor/trezor-user-env:6339d48f1df4f007fe5caee659e4bca3997d480a
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-ci.yml
+++ b/docker/docker-compose.suite-ci.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:0eff3cb37dc607dc83ce4802d1c39727ec298993
+    image: ghcr.io/trezor/trezor-user-env:c23309d96f013376a54bf442fe710e80341e6ff3
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-desktop-ci.yml
+++ b/docker/docker-compose.suite-desktop-ci.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:6339d48f1df4f007fe5caee659e4bca3997d480a
+    image: ghcr.io/trezor/trezor-user-env:0eff3cb37dc607dc83ce4802d1c39727ec298993
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-desktop-ci.yml
+++ b/docker/docker-compose.suite-desktop-ci.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:b23cde1860e03c8bdaebbbc8fcbcd2cc9d6375d3
+    image: ghcr.io/trezor/trezor-user-env:6339d48f1df4f007fe5caee659e4bca3997d480a
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-desktop-ci.yml
+++ b/docker/docker-compose.suite-desktop-ci.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:0eff3cb37dc607dc83ce4802d1c39727ec298993
+    image: ghcr.io/trezor/trezor-user-env:c23309d96f013376a54bf442fe710e80341e6ff3
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-dev.yml
+++ b/docker/docker-compose.suite-dev.yml
@@ -4,7 +4,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:b23cde1860e03c8bdaebbbc8fcbcd2cc9d6375d3
+    image: ghcr.io/trezor/trezor-user-env:6339d48f1df4f007fe5caee659e4bca3997d480a
     environment:
       - DISPLAY=$DISPLAY
       - QT_X11_NO_MITSHM=1

--- a/docker/docker-compose.suite-dev.yml
+++ b/docker/docker-compose.suite-dev.yml
@@ -4,7 +4,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:0eff3cb37dc607dc83ce4802d1c39727ec298993
+    image: ghcr.io/trezor/trezor-user-env:c23309d96f013376a54bf442fe710e80341e6ff3
     environment:
       - DISPLAY=$DISPLAY
       - QT_X11_NO_MITSHM=1

--- a/docker/docker-compose.suite-dev.yml
+++ b/docker/docker-compose.suite-dev.yml
@@ -4,7 +4,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:6339d48f1df4f007fe5caee659e4bca3997d480a
+    image: ghcr.io/trezor/trezor-user-env:0eff3cb37dc607dc83ce4802d1c39727ec298993
     environment:
       - DISPLAY=$DISPLAY
       - QT_X11_NO_MITSHM=1

--- a/docker/docker-compose.suite-native-ci.yml
+++ b/docker/docker-compose.suite-native-ci.yml
@@ -3,7 +3,7 @@ services:
   trezor-user-env-unix:
     network_mode: "host"
     container_name: trezor-user-env.unix
-    image: ghcr.io/trezor/trezor-user-env:0eff3cb37dc607dc83ce4802d1c39727ec298993
+    image: ghcr.io/trezor/trezor-user-env:c23309d96f013376a54bf442fe710e80341e6ff3
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-native-ci.yml
+++ b/docker/docker-compose.suite-native-ci.yml
@@ -3,7 +3,7 @@ services:
   trezor-user-env-unix:
     network_mode: "host"
     container_name: trezor-user-env.unix
-    image: ghcr.io/trezor/trezor-user-env:b23cde1860e03c8bdaebbbc8fcbcd2cc9d6375d3
+    image: ghcr.io/trezor/trezor-user-env:6339d48f1df4f007fe5caee659e4bca3997d480a
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-native-ci.yml
+++ b/docker/docker-compose.suite-native-ci.yml
@@ -3,7 +3,7 @@ services:
   trezor-user-env-unix:
     network_mode: "host"
     container_name: trezor-user-env.unix
-    image: ghcr.io/trezor/trezor-user-env:6339d48f1df4f007fe5caee659e4bca3997d480a
+    image: ghcr.io/trezor/trezor-user-env:0eff3cb37dc607dc83ce4802d1c39727ec298993
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-test.yml
+++ b/docker/docker-compose.suite-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:b23cde1860e03c8bdaebbbc8fcbcd2cc9d6375d3
+    image: ghcr.io/trezor/trezor-user-env:6339d48f1df4f007fe5caee659e4bca3997d480a
     environment:
       - DISPLAY=$DISPLAY
       - QT_X11_NO_MITSHM=1

--- a/docker/docker-compose.suite-test.yml
+++ b/docker/docker-compose.suite-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:6339d48f1df4f007fe5caee659e4bca3997d480a
+    image: ghcr.io/trezor/trezor-user-env:0eff3cb37dc607dc83ce4802d1c39727ec298993
     environment:
       - DISPLAY=$DISPLAY
       - QT_X11_NO_MITSHM=1

--- a/docker/docker-compose.suite-test.yml
+++ b/docker/docker-compose.suite-test.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:0eff3cb37dc607dc83ce4802d1c39727ec298993
+    image: ghcr.io/trezor/trezor-user-env:c23309d96f013376a54bf442fe710e80341e6ff3
     environment:
       - DISPLAY=$DISPLAY
       - QT_X11_NO_MITSHM=1

--- a/docker/docker-compose.transport-test-ci.yml
+++ b/docker/docker-compose.transport-test-ci.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:6339d48f1df4f007fe5caee659e4bca3997d480a
+    image: ghcr.io/trezor/trezor-user-env:0eff3cb37dc607dc83ce4802d1c39727ec298993
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.transport-test-ci.yml
+++ b/docker/docker-compose.transport-test-ci.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:b23cde1860e03c8bdaebbbc8fcbcd2cc9d6375d3
+    image: ghcr.io/trezor/trezor-user-env:6339d48f1df4f007fe5caee659e4bca3997d480a
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.transport-test-ci.yml
+++ b/docker/docker-compose.transport-test-ci.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:0eff3cb37dc607dc83ce4802d1c39727ec298993
+    image: ghcr.io/trezor/trezor-user-env:c23309d96f013376a54bf442fe710e80341e6ff3
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/packages/suite-desktop-core/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '../../../support/fixtures';
 
-test.describe.skip('Onboarding - create wallet', { tag: ['@group=device-management'] }, () => {
+test.describe('Onboarding - create wallet', { tag: ['@group=device-management'] }, () => {
     test.use({
         emulatorStartConf: { model: 'T1B1', version: '1-latest', wipe: true },
         setupEmulator: false,

--- a/packages/suite-desktop-core/e2e/tests/onboarding/t1b1/t1b1-recovery-advanced.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/onboarding/t1b1/t1b1-recovery-advanced.test.ts
@@ -1,63 +1,59 @@
 import { expect, test } from '../../../support/fixtures';
 
-test.describe.skip(
-    'Onboarding - recover wallet T1B1',
-    { tag: ['@group=device-management'] },
-    () => {
-        test.use({
-            emulatorStartConf: { model: 'T1B1', version: '1-latest', wipe: true },
-            setupEmulator: false,
-        });
+test.describe('Onboarding - recover wallet T1B1', { tag: ['@group=device-management'] }, () => {
+    test.use({
+        emulatorStartConf: { model: 'T1B1', version: '1-latest', wipe: true },
+        setupEmulator: false,
+    });
 
-        test.beforeEach(async ({ onboardingPage }) => {
-            await onboardingPage.disableFirmwareHashCheck();
-        });
+    test.beforeEach(async ({ onboardingPage }) => {
+        await onboardingPage.disableFirmwareHashCheck();
+    });
 
-        test('Incomplete run of advanced recovery', async ({
-            onboardingPage,
-            analyticsPage,
-            devicePrompt,
-            recoveryPage,
-            page,
-            trezorUserEnvLink,
-        }) => {
-            // Navigate through onboarding steps
-            await analyticsPage.passThroughAnalytics();
-            await onboardingPage.firmware.continueButton.click();
-            await onboardingPage.recoverWalletButton.click();
+    test('Incomplete run of advanced recovery', async ({
+        onboardingPage,
+        analyticsPage,
+        devicePrompt,
+        recoveryPage,
+        page,
+        trezorUserEnvLink,
+    }) => {
+        // Navigate through onboarding steps
+        await analyticsPage.passThroughAnalytics();
+        await onboardingPage.firmware.continueButton.click();
+        await onboardingPage.recoverWalletButton.click();
 
-            // Select advanced recovery
-            await recoveryPage.selectWordCount(24);
-            await page.getByTestId('@recover/select-type/advanced').click();
-            await devicePrompt.confirmOnDevicePromptIsShown();
-            await trezorUserEnvLink.pressYes();
+        // Select advanced recovery
+        await recoveryPage.selectWordCount(24);
+        await page.getByTestId('@recover/select-type/advanced').click();
+        await devicePrompt.confirmOnDevicePromptIsShown();
+        await trezorUserEnvLink.pressYes();
 
-            // Simulate user input
-            for (let i = 0; i <= 4; i++) {
-                await page.getByTestId('@recovery/word-input-advanced/1').click({ force: true });
-            }
+        // Simulate user input
+        for (let i = 0; i <= 4; i++) {
+            await page.getByTestId('@recovery/word-input-advanced/1').click({ force: true });
+        }
 
-            // Simulate device disconnection due to lack of cancel button
-            await page.waitForTimeout(501);
-            await trezorUserEnvLink.stopEmu();
-            await devicePrompt.confirmOnDevicePromptIsShown();
+        // Simulate device disconnection due to lack of cancel button
+        await page.waitForTimeout(501);
+        await trezorUserEnvLink.stopEmu();
+        await devicePrompt.confirmOnDevicePromptIsShown();
 
-            // Restart emulator
-            await trezorUserEnvLink.startEmu({ model: 'T1B1', version: '1-latest' });
+        // Restart emulator
+        await trezorUserEnvLink.startEmu({ model: 'T1B1', version: '1-latest' });
 
-            // Retry recovery with basic type
-            await onboardingPage.retryRecoveryButton.click();
-            await recoveryPage.selectWordCount(12);
-            await page.getByTestId('@recover/select-type/basic').click();
+        // Retry recovery with basic type
+        await onboardingPage.retryRecoveryButton.click();
+        await recoveryPage.selectWordCount(12);
+        await page.getByTestId('@recover/select-type/basic').click();
 
-            // Confirm on device
-            await devicePrompt.confirmOnDevicePromptIsShown();
-            await trezorUserEnvLink.pressYes();
+        // Confirm on device
+        await devicePrompt.confirmOnDevicePromptIsShown();
+        await trezorUserEnvLink.pressYes();
 
-            // Ensure input field for basic recovery is visible
-            await expect(page.getByTestId('@word-input-select/input')).toBeVisible();
+        // Ensure input field for basic recovery is visible
+        await expect(page.getByTestId('@word-input-select/input')).toBeVisible();
 
-            // Note: Completion of reading device data requires support in trezor-user-env
-        });
-    },
-);
+        // Note: Completion of reading device data requires support in trezor-user-env
+    });
+});

--- a/packages/suite-desktop-core/e2e/tests/onboarding/t1b1/t1b1-recovery-fail.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/onboarding/t1b1/t1b1-recovery-fail.test.ts
@@ -1,45 +1,41 @@
 import { test } from '../../../support/fixtures';
 
-test.describe.skip(
-    'Onboarding - recover wallet T1B1',
-    { tag: ['@group=device-management'] },
-    () => {
-        test.use({
-            emulatorStartConf: { model: 'T1B1', version: '1-latest', wipe: true },
-            setupEmulator: false,
-        });
+test.describe('Onboarding - recover wallet T1B1', { tag: ['@group=device-management'] }, () => {
+    test.use({
+        emulatorStartConf: { model: 'T1B1', version: '1-latest', wipe: true },
+        setupEmulator: false,
+    });
 
-        test.beforeEach(async ({ onboardingPage }) => {
-            await onboardingPage.disableFirmwareHashCheck();
-        });
+    test.beforeEach(async ({ onboardingPage }) => {
+        await onboardingPage.disableFirmwareHashCheck();
+    });
 
-        test('Device disconnected during recovery offers retry', async ({
-            onboardingPage,
-            analyticsPage,
-            recoveryPage,
-            devicePrompt,
-            trezorUserEnvLink,
-        }) => {
-            await analyticsPage.passThroughAnalytics();
+    test('Device disconnected during recovery offers retry', async ({
+        onboardingPage,
+        analyticsPage,
+        recoveryPage,
+        devicePrompt,
+        trezorUserEnvLink,
+    }) => {
+        await analyticsPage.passThroughAnalytics();
 
-            // Start wallet recovery process
-            await onboardingPage.firmware.continueButton.click();
-            await onboardingPage.recoverWalletButton.click();
-            await recoveryPage.selectWordCount(24);
-            await recoveryPage.selectBasicRecoveryButton.click();
-            await devicePrompt.confirmOnDevicePromptIsShown();
-            await trezorUserEnvLink.pressYes();
+        // Start wallet recovery process
+        await onboardingPage.firmware.continueButton.click();
+        await onboardingPage.recoverWalletButton.click();
+        await recoveryPage.selectWordCount(24);
+        await recoveryPage.selectBasicRecoveryButton.click();
+        await devicePrompt.confirmOnDevicePromptIsShown();
+        await trezorUserEnvLink.pressYes();
 
-            // Disconnect the device
-            await trezorUserEnvLink.stopEmu();
-            await devicePrompt.connectDevicePromptIsShown();
-            await trezorUserEnvLink.startEmu({ model: 'T1B1', version: '1-latest', wipe: false });
+        // Disconnect the device
+        await trezorUserEnvLink.stopEmu();
+        await devicePrompt.connectDevicePromptIsShown();
+        await trezorUserEnvLink.startEmu({ model: 'T1B1', version: '1-latest', wipe: false });
 
-            // Retry recovery process
-            await onboardingPage.retryRecoveryButton.click();
-            await recoveryPage.selectWordCount(24);
-            await recoveryPage.selectBasicRecoveryButton.click();
-            await devicePrompt.confirmOnDevicePromptIsShown();
-        });
-    },
-);
+        // Retry recovery process
+        await onboardingPage.retryRecoveryButton.click();
+        await recoveryPage.selectWordCount(24);
+        await recoveryPage.selectBasicRecoveryButton.click();
+        await devicePrompt.confirmOnDevicePromptIsShown();
+    });
+});

--- a/packages/suite-desktop-core/e2e/tests/onboarding/t1b1/t1b1-recovery-success.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/onboarding/t1b1/t1b1-recovery-success.test.ts
@@ -3,48 +3,44 @@ import { expect, test } from '../../../support/fixtures';
 const mnemonic =
     'nasty answer gentle inform unaware abandon regret supreme dragon gravity behind lava dose pilot garden into dynamic outer hard speed luxury run truly armed';
 
-test.describe.skip(
-    'Onboarding - recover wallet T1B1',
-    { tag: ['@group=device-management'] },
-    () => {
-        test.use({
-            emulatorStartConf: { model: 'T1B1', version: '1-latest', wipe: true },
-            setupEmulator: false,
-        });
+test.describe('Onboarding - recover wallet T1B1', { tag: ['@group=device-management'] }, () => {
+    test.use({
+        emulatorStartConf: { model: 'T1B1', version: '1-latest', wipe: true },
+        setupEmulator: false,
+    });
 
-        test.beforeEach(async ({ onboardingPage }) => {
-            await onboardingPage.disableFirmwareHashCheck();
-        });
+    test.beforeEach(async ({ onboardingPage }) => {
+        await onboardingPage.disableFirmwareHashCheck();
+    });
 
-        test('Successfully recovers wallet from mnemonic', async ({
-            page,
-            onboardingPage,
-            analyticsPage,
-            devicePrompt,
-            recoveryPage,
-            trezorInput,
-            trezorUserEnvLink,
-        }) => {
-            await analyticsPage.passThroughAnalytics();
+    test('Successfully recovers wallet from mnemonic', async ({
+        page,
+        onboardingPage,
+        analyticsPage,
+        devicePrompt,
+        recoveryPage,
+        trezorInput,
+        trezorUserEnvLink,
+    }) => {
+        await analyticsPage.passThroughAnalytics();
 
-            // Start wallet recovery process
-            await onboardingPage.firmware.continueButton.click();
-            await onboardingPage.recoverWalletButton.click();
-            await recoveryPage.selectWordCount(24);
-            await recoveryPage.selectBasicRecoveryButton.click();
-            await devicePrompt.confirmOnDevicePromptIsShown();
-            await page.waitForTimeout(1000);
-            await trezorUserEnvLink.pressYes();
+        // Start wallet recovery process
+        await onboardingPage.firmware.continueButton.click();
+        await onboardingPage.recoverWalletButton.click();
+        await recoveryPage.selectWordCount(24);
+        await recoveryPage.selectBasicRecoveryButton.click();
+        await devicePrompt.confirmOnDevicePromptIsShown();
+        await page.waitForTimeout(1000);
+        await trezorUserEnvLink.pressYes();
 
-            // Input mnemonic
-            await trezorInput.inputMnemonicT1B1(mnemonic);
+        // Input mnemonic
+        await trezorInput.inputMnemonicT1B1(mnemonic);
 
-            // Finalize recovery, skip pin, and verify success
-            await onboardingPage.continueRecoveryButton.click();
-            await onboardingPage.pin.skip();
-            await onboardingPage.continueCoinsButton.click();
-            await expect(onboardingPage.finalTitle).toBeVisible();
-            await expect(onboardingPage.finalTitle).toContainText('Setup complete!');
-        });
-    },
-);
+        // Finalize recovery, skip pin, and verify success
+        await onboardingPage.continueRecoveryButton.click();
+        await onboardingPage.pin.skip();
+        await onboardingPage.continueCoinsButton.click();
+        await expect(onboardingPage.finalTitle).toBeVisible();
+        await expect(onboardingPage.finalTitle).toContainText('Setup complete!');
+    });
+});

--- a/packages/suite-desktop-core/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts
@@ -21,7 +21,7 @@ test.describe('Onboarding - create wallet', { tag: ['@group=device-management'] 
         trezorUserEnvLink,
     }) => {
         await analyticsPage.passThroughAnalytics();
-        await onboardingPage.firmware.skip();
+        await onboardingPage.firmware.continueButton.click();
 
         // Will be clicking on Shamir backup button
         await onboardingPage.createWalletButton.click();

--- a/packages/suite-desktop-core/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts
@@ -1,7 +1,8 @@
 import { SeedType } from '../../../support/enums/seedType';
 import { expect, test } from '../../../support/fixtures';
 
-test.describe('Onboarding - create wallet', { tag: ['@group=device-management'] }, () => {
+// TODO: unskip after https://github.com/trezor/trezor-suite/issues/17148 is resolved
+test.describe.skip('Onboarding - create wallet', { tag: ['@group=device-management'] }, () => {
     // This test always needs to run the newest possible emulator version
     // Emulator setup: wipe: true, model: T2T1, version: 2-latest
     test.use({

--- a/packages/suite-desktop-core/e2e/tests/onboarding/t2t1/t2t1-recovery-fail.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/onboarding/t2t1/t2t1-recovery-fail.test.ts
@@ -20,7 +20,8 @@ test.describe('Onboarding - recover wallet T2T1', { tag: ['@group=device-managem
         trezorUserEnvLink,
     }) => {
         await analyticsPage.passThroughAnalytics();
-        await onboardingPage.firmware.skip();
+        await onboardingPage.firmware.continueButton.click();
+
         // Start wallet recovery process and confirm on device
         await onboardingPage.recoverWalletButton.click();
         await onboardingPage.startRecoveryButton.click();

--- a/packages/suite-desktop-core/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts
@@ -21,7 +21,7 @@ test.describe('Onboarding - create wallet', { tag: ['@group=device-management'] 
         await analyticsPage.passThroughAnalytics();
 
         // Device onboarding steps
-        await onboardingPage.firmware.skip();
+        await onboardingPage.firmware.continueButton.click();
         await onboardingPage.passThroughAuthenticityCheck();
         await page.waitForTimeout(500);
         await onboardingPage.tutorial.skip();


### PR DESCRIPTION
based on #16969

till now, all models had the same firmware version which is not true anymore since this change https://github.com/trezor/trezor-user-env/commit/6339d48f1df4f007fe5caee659e4bca3997d480a#diff-4e726d3141a1307472f5c4ee56a6adde4dbd0664257e4898847074c18faa25dfR60. which results into 
```
websocket_error_message: RuntimeError - Unknown firmware T3T1 2.8.8-arm
```
so we need to extend our client-side logic that selects a proper default. It would feel better to do this server side - could trezor-user-env start emulator command always pick as default the highest available version which is not main version? cc @grdddj 