### PR TITLE
Revert "feat(suite-desktop): turn on ASAR integrity check"

### DIFF
--- a/packages/suite-desktop/electron-builder-config.js
+++ b/packages/suite-desktop/electron-builder-config.js
@@ -162,10 +162,5 @@ module.exports = {
         category: 'Utility',
         target: ['AppImage'],
     },
-    electronFuses: {
-        // the fuse may be enabled for all build targets, but as of Jan 2025, it actually affects only macOS & Windows
-        enableEmbeddedAsarIntegrityValidation: true,
-        onlyLoadAppFromAsar: true,
-    },
     afterSign: '../suite-desktop-core/scripts/notarize.ts',
 };


### PR DESCRIPTION
Reverts trezor/trezor-suite#16951

It crashes MacOS build, after this revert it works again; need to investigate further :disappointed: 


@coderabbitai ignore