### PR TITLE
Feat/bluetooth-transport package part 1

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -66,6 +66,8 @@
 
 /packages/transport @mroz22 @szymonlesisz
 
+/packages/transport-bluetooth @szymonlesisz
+
 /packages/transport-bridge @mroz22 @szymonlesisz
 
 /packages/transport-test @mroz22

--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -35,6 +35,7 @@
         "@trezor/suite": "workspace:*",
         "@trezor/suite-desktop-api": "workspace:*",
         "@trezor/transport": "workspace:*",
+        "@trezor/transport-bluetooth": "workspace:*",
         "@trezor/transport-bridge": "workspace:*",
         "@trezor/urls": "workspace:*",
         "@trezor/utils": "workspace:*",

--- a/packages/suite-desktop-core/src/modules/bluetooth.ts
+++ b/packages/suite-desktop-core/src/modules/bluetooth.ts
@@ -1,0 +1,48 @@
+import { ipcMain } from 'electron';
+
+import { IpcProxyHandlerOptions, createIpcProxyHandler } from '@trezor/ipc-proxy';
+import { BluetoothIpc, BluetoothIpcApi } from '@trezor/transport-bluetooth';
+
+import type { ModuleInit } from './index';
+
+export const SERVICE_NAME = '@trezor/transport-bluetooth';
+
+export const init: ModuleInit = () => {
+    const { logger } = global;
+
+    const proxyOptions: IpcProxyHandlerOptions<BluetoothIpcApi> = {
+        onCreateInstance() {
+            const api = new BluetoothIpc();
+
+            return {
+                onRequest: (method, params) => {
+                    logger.debug(SERVICE_NAME, `call ${method}`);
+
+                    return (api[method] as any)(...params);
+                },
+                onAddListener: (eventName, listener) => {
+                    logger.debug(SERVICE_NAME, `add listener ${eventName}`);
+
+                    return api.on(eventName, listener);
+                },
+                onRemoveListener: (eventName: any) => {
+                    logger.debug(SERVICE_NAME, `remove listener ${eventName}`);
+
+                    return api.removeAllListeners(eventName);
+                },
+            };
+        },
+    };
+
+    const unregisterProxy = createIpcProxyHandler(ipcMain, 'Bluetooth', proxyOptions);
+    const onLoad = () => {
+        // TODO: start binary
+    };
+
+    const onQuit = () => {
+        logger.info(SERVICE_NAME, 'Stopping (app quit)');
+        unregisterProxy();
+    };
+
+    return { onLoad, onQuit };
+};

--- a/packages/suite-desktop-core/src/modules/index.ts
+++ b/packages/suite-desktop-core/src/modules/index.ts
@@ -8,6 +8,7 @@ import { TypedEmitter, isNotUndefined } from '@trezor/utils';
 
 import * as autoStart from './auto-start';
 import * as autoUpdater from './auto-updater';
+import * as bluetooth from './bluetooth';
 import * as bridge from './bridge';
 import * as coinjoin from './coinjoin';
 import * as crashRecover from './crash-recover';
@@ -65,6 +66,7 @@ const MODULES: Module[] = [
     bridge,
     systemInformation,
     systemSettings,
+    bluetooth,
     // Modules used only in dev/prod mode
     ...(isDevEnv ? [] : [csp, fileProtocol]),
 ];

--- a/packages/suite-desktop-core/src/preload.ts
+++ b/packages/suite-desktop-core/src/preload.ts
@@ -6,7 +6,12 @@ import { getDesktopApi } from '@trezor/suite-desktop-api';
 import '@sentry/electron/preload'; // With this only IPCMode.Classic is ever taken into account
 
 contextBridge.exposeInMainWorld(
-    ...exposeIpcProxy(ipcRenderer, ['TrezorConnect', 'CoinjoinBackend', 'CoinjoinClient']),
+    ...exposeIpcProxy(ipcRenderer, [
+        'Bluetooth',
+        'CoinjoinBackend',
+        'CoinjoinClient',
+        'TrezorConnect',
+    ]),
 );
 
 const desktopApi = getDesktopApi(ipcRenderer);

--- a/packages/suite-desktop-core/tsconfig.json
+++ b/packages/suite-desktop-core/tsconfig.json
@@ -39,6 +39,7 @@
         { "path": "../suite" },
         { "path": "../suite-desktop-api" },
         { "path": "../transport" },
+        { "path": "../transport-bluetooth" },
         { "path": "../transport-bridge" },
         { "path": "../urls" },
         { "path": "../utils" },

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -80,6 +80,7 @@
         "@trezor/suite-desktop-connect-popup": "workspace:*",
         "@trezor/suite-storage": "workspace:*",
         "@trezor/theme": "workspace:*",
+        "@trezor/transport-bluetooth": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/urls": "workspace:*",
         "@trezor/utils": "workspace:*",

--- a/packages/suite/tsconfig.json
+++ b/packages/suite/tsconfig.json
@@ -113,6 +113,7 @@
         },
         { "path": "../suite-storage" },
         { "path": "../theme" },
+        { "path": "../transport-bluetooth" },
         { "path": "../type-utils" },
         { "path": "../urls" },
         { "path": "../utils" },

--- a/packages/transport-bluetooth/README.md
+++ b/packages/transport-bluetooth/README.md
@@ -1,0 +1,39 @@
+# @trezor/transport-bluetooth
+
+### `BluetoothIpc` and `bluetoothIpc` proxy
+
+`@trezor/suite` renderer context
+
+use `bluetoothIpc` proxy
+
+```
+import { bluetoothIpc } from '@trezor/transport-bluetooth';
+
+await bluetoothIpc.init();
+```
+
+`@trezor/suite-desktop-core` main context module
+
+implement proxy handler and `BluetoothIpc`
+
+```
+import { BluetoothIpc } from '@trezor/transport-bluetooth';
+
+createIpcProxyHandler(ipcMain, 'Bluetooth', {
+    onCreateInstance: () => {
+        const api = new BluetoothIpc();
+
+        return {
+            onRequest: (method, params) => {
+                api[method](...params);
+            },
+            onAddListener: (eventName, listener) => {
+                api.on(eventName, listener);
+            },
+            onRemoveListener: (eventName) => {
+                api.removeAllListeners(eventName)
+            },
+        };
+    },
+});
+```

--- a/packages/transport-bluetooth/package.json
+++ b/packages/transport-bluetooth/package.json
@@ -1,0 +1,27 @@
+{
+    "name": "@trezor/transport-bluetooth",
+    "version": "1.0.0",
+    "private": true,
+    "license": "See LICENSE.md in repo root",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/trezor/trezor-suite.git"
+    },
+    "bugs": {
+        "url": "https://github.com/trezor/trezor-suite/issues"
+    },
+    "keywords": [
+        "Trezor",
+        "transport"
+    ],
+    "main": "./src/index.ts",
+    "browser": "./src/browser.ts",
+    "scripts": {
+        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "type-check": "yarn g:tsc --build"
+    },
+    "dependencies": {
+        "@trezor/ipc-proxy": "workspace:*",
+        "@trezor/utils": "workspace:*"
+    }
+}

--- a/packages/transport-bluetooth/src/browser.ts
+++ b/packages/transport-bluetooth/src/browser.ts
@@ -1,0 +1,29 @@
+import { createIpcProxy } from '@trezor/ipc-proxy';
+
+import { bluetoothIpc } from './client/bluetooth-ipc-renderer';
+import { BluetoothIpcApi } from './client/types';
+
+/*
+ * index in browser context (electron renderer)
+ */
+const proxyState = () => {
+    let proxyPromise: Promise<BluetoothIpcApi> | undefined;
+
+    return () => {
+        if (proxyPromise) return proxyPromise;
+
+        proxyPromise = createIpcProxy<BluetoothIpcApi>('Bluetooth');
+
+        return proxyPromise;
+    };
+};
+
+// create ipcProxy and wrap each bluetoothIpc method
+const getProxy = proxyState();
+(Object.keys(bluetoothIpc) as (keyof BluetoothIpcApi)[]).forEach(key => {
+    (bluetoothIpc[key] as unknown) = (...args: any[]) =>
+        getProxy().then(p => (p[key] as any)(...args));
+});
+
+// export modified bluetoothIpc
+export { bluetoothIpc };

--- a/packages/transport-bluetooth/src/client/bluetooth-ipc-main.ts
+++ b/packages/transport-bluetooth/src/client/bluetooth-ipc-main.ts
@@ -1,0 +1,40 @@
+import { TypedEmitter } from '@trezor/utils';
+
+import type { BluetoothIpcApi, BluetoothIpcEvents, BluetoothIpcState } from './types';
+
+const noop = (..._args: any[]) =>
+    Promise.resolve({ success: false, error: 'BluetoothIpc.NOOP' } as const);
+
+/*
+ * used in @trezor/suite-desktop-core nodejs (main) context
+ * unavailable in browser (renderer) context
+ */
+export class BluetoothIpc extends TypedEmitter<BluetoothIpcEvents> implements BluetoothIpcApi {
+    init(state?: BluetoothIpcState) {
+        return Promise.resolve({ success: true, payload: state } as const);
+    }
+
+    dispose() {
+        return noop();
+    }
+
+    startScan() {
+        return noop();
+    }
+
+    stopScan() {
+        return noop();
+    }
+
+    connectDevice(id: string) {
+        return noop(id);
+    }
+
+    disconnectDevice(id: string) {
+        return noop(id);
+    }
+
+    forgetDevice(id: string) {
+        return noop(id);
+    }
+}

--- a/packages/transport-bluetooth/src/client/bluetooth-ipc-renderer.ts
+++ b/packages/transport-bluetooth/src/client/bluetooth-ipc-renderer.ts
@@ -1,0 +1,22 @@
+import type { BluetoothIpcApi } from './types';
+
+const noop = () => {
+    throw new Error('bluetoothIpc.NOOP');
+};
+
+/*
+ * wrap bluetoothIpc with ipcProxy in ./src/browser.ts
+ * throws NOOP in nodejs (main) context
+ */
+export const bluetoothIpc: BluetoothIpcApi = {
+    init: noop,
+    dispose: noop,
+    startScan: noop,
+    stopScan: noop,
+    connectDevice: noop,
+    disconnectDevice: noop,
+    forgetDevice: noop,
+    on: noop,
+    off: noop,
+    removeAllListeners: noop,
+};

--- a/packages/transport-bluetooth/src/client/types.ts
+++ b/packages/transport-bluetooth/src/client/types.ts
@@ -1,0 +1,58 @@
+import type { TypedEmitter } from '@trezor/utils';
+
+export interface BluetoothDevice {
+    id: string;
+    name: string;
+    macAddress: string; // changes after pairing (linux), unknown on macos
+    data: number[]; // advertisement data bytes
+    connected: boolean;
+    connectionStatus: DeviceConnectionStatus;
+    lastUpdatedTimestamp: number; // last known activity from the device (discovery, advertisements)
+    paired?: boolean; // known (linux, windows), unknown (macos)
+    rssi?: number; // signal strength
+}
+
+// IpcApi related types
+export type DeviceConnectionStatus =
+    | { type: 'disconnected' }
+    | { type: 'pairing'; pin?: string }
+    | { type: 'paired' }
+    | { type: 'connecting' }
+    | { type: 'connected' }
+    | {
+          type: 'pairing-error'; // This device cannot be paired ever again (new macAddress, new device)
+          error: string;
+      }
+    | {
+          type: 'connection-error'; // Out-of-range, offline, in the faraday cage, ...
+          error: string;
+      };
+
+type Success<P> = P extends unknown ? { success: true } : { success: true; payload: P };
+type Failure = { success: false; error: string };
+type IpcResponse<P = unknown> = Success<P> | Failure;
+
+export interface BluetoothIpcEvents {
+    'adapter-event': boolean;
+    'device-list-update': BluetoothDevice[];
+    'device-update': BluetoothDevice;
+}
+
+type TypedManagerEvents = TypedEmitter<BluetoothIpcEvents>;
+
+export interface BluetoothIpcState {
+    knownDevices: BluetoothDevice[];
+}
+
+export interface BluetoothIpcApi {
+    init(state?: BluetoothIpcState): Promise<IpcResponse>;
+    dispose(): Promise<IpcResponse>;
+    startScan(): Promise<IpcResponse>;
+    stopScan(): Promise<IpcResponse>;
+    connectDevice(id: string): Promise<IpcResponse>;
+    disconnectDevice(id: string): Promise<IpcResponse>;
+    forgetDevice(id: string): Promise<IpcResponse>;
+    on: TypedManagerEvents['on'];
+    off: TypedManagerEvents['off'];
+    removeAllListeners: TypedManagerEvents['removeAllListeners'];
+}

--- a/packages/transport-bluetooth/src/index.ts
+++ b/packages/transport-bluetooth/src/index.ts
@@ -1,0 +1,3 @@
+export { BluetoothIpc } from './client/bluetooth-ipc-main';
+export { bluetoothIpc } from './client/bluetooth-ipc-renderer';
+export * from './client/types';

--- a/packages/transport-bluetooth/tsconfig.json
+++ b/packages/transport-bluetooth/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "outDir": "./libDev",
+        "types": ["jest", "node"]
+    },
+    "references": [
+        { "path": "../ipc-proxy" },
+        { "path": "../utils" }
+    ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12459,6 +12459,7 @@ __metadata:
     "@trezor/suite": "workspace:*"
     "@trezor/suite-desktop-api": "workspace:*"
     "@trezor/transport": "workspace:*"
+    "@trezor/transport-bluetooth": "workspace:*"
     "@trezor/transport-bridge": "workspace:*"
     "@trezor/trezor-user-env-link": "workspace:*"
     "@trezor/type-utils": "workspace:*"
@@ -12665,6 +12666,7 @@ __metadata:
     "@trezor/suite-desktop-connect-popup": "workspace:*"
     "@trezor/suite-storage": "workspace:*"
     "@trezor/theme": "workspace:*"
+    "@trezor/transport-bluetooth": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"
@@ -12740,7 +12742,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/transport-bluetooth@workspace:packages/transport-bluetooth":
+"@trezor/transport-bluetooth@workspace:*, @trezor/transport-bluetooth@workspace:packages/transport-bluetooth":
   version: 0.0.0-use.local
   resolution: "@trezor/transport-bluetooth@workspace:packages/transport-bluetooth"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -12740,6 +12740,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@trezor/transport-bluetooth@workspace:packages/transport-bluetooth":
+  version: 0.0.0-use.local
+  resolution: "@trezor/transport-bluetooth@workspace:packages/transport-bluetooth"
+  dependencies:
+    "@trezor/ipc-proxy": "workspace:*"
+    "@trezor/utils": "workspace:*"
+  languageName: unknown
+  linkType: soft
+
 "@trezor/transport-bridge@workspace:*, @trezor/transport-bridge@workspace:packages/transport-bridge":
   version: 0.0.0-use.local
   resolution: "@trezor/transport-bridge@workspace:packages/transport-bridge"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

cherry picking from the [bluetooth](https://github.com/trezor/trezor-suite/commits/feat/rust-bluetooth/) branch

this is not exactly transport yet, but it is important part for the whole puzzle.
`ipcProxy` between main and renderer contexts in suite-desktop.
This part is responsible **only** for the bluetooth scanning/connection management, think of if as the custom UI for webusb native window.

Implementation is similar to `TrezorConnect` or `Coinjoin` ipc proxies with a small difference in "renderer proxy mapping". This time it is done in `transport-bluetooth` browser.ts (the package index for browser context) unlike mentioned which is done directly in suite (Main.tsx)
i have my doubts if this new approach is better but at least its done in one place
 
following `BluetoothIpc` implementation will use the real transports

Temporary usage in `@trezor/suite`:

```
import { bluetoothIpc } from '@trezor/transport-bluetooth';

await bluetoothIpc.init(); // returns success: true
await bluetoothIpc.startScan(); // and any other returns success: false + error
```
