### PR TITLE
Dep cleanup (move babel ts to dev deps, move from deprecated ripple-lib to xrpl)

### DIFF
--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -84,8 +84,8 @@
         "@trezor/websocket-client": "workspace:*",
         "@types/web": "^0.0.197",
         "events": "^3.3.0",
-        "ripple-lib": "^1.10.1",
-        "socks-proxy-agent": "8.0.4"
+        "socks-proxy-agent": "8.0.4",
+        "xrpl": "^4.2.0"
     },
     "peerDependencies": {
         "tslib": "^2.6.2"

--- a/packages/blockchain-link/src/workers/ripple/index.ts
+++ b/packages/blockchain-link/src/workers/ripple/index.ts
@@ -1,5 +1,4 @@
-import { APIOptions, RippleAPI } from 'ripple-lib';
-import { RippleError } from 'ripple-lib/dist/npm/common/errors';
+import { Client, ClientOptions, RippledError, xrpToDrops } from 'xrpl';
 
 import type { AccountInfo, Response, SubscriptionAccountInfo } from '@trezor/blockchain-link-types';
 import { MESSAGES, RESPONSES } from '@trezor/blockchain-link-types/src/constants';
@@ -11,7 +10,7 @@ import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { BaseWorker, CONTEXT, ContextType } from '../baseWorker';
 
-type Context = ContextType<RippleAPI>;
+type Context = ContextType<Client>;
 type Request<T> = T & Context;
 
 const DEFAULT_TIMEOUT = 20 * 1000;
@@ -22,11 +21,11 @@ const RESERVE = {
 };
 
 const transformError = (error: any) => {
-    if (error instanceof RippleError) {
+    if (error instanceof RippledError) {
         const code =
             error.name === 'TimeoutError' ? 'websocket_timeout' : 'websocket_error_message';
         if (error.data) {
-            return new CustomError(code, `${error.name} ${error.data.error_message}`);
+            return new CustomError(code, `${error.name} ${(error.data as any).error_message}`);
         }
 
         return new CustomError(code, error.toString());
@@ -37,11 +36,13 @@ const transformError = (error: any) => {
 
 const getInfo = async (request: Request<MessageTypes.GetInfo>) => {
     const api = await request.connect();
-    const info = await api.getServerInfo();
+    const info = await api.request({ command: 'server_info' });
 
     // store current ledger values
-    RESERVE.BASE = api.xrpToDrops(info.validatedLedger.reserveBaseXRP);
-    RESERVE.OWNER = api.xrpToDrops(info.validatedLedger.reserveIncrementXRP);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
+    RESERVE.BASE = xrpToDrops(info.result.info.validated_ledger?.reserve_base_xrp!);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
+    RESERVE.OWNER = xrpToDrops(info.result.info.validated_ledger?.reserve_inc_xrp!);
 
     return {
         type: RESPONSES.GET_INFO,
@@ -54,17 +55,18 @@ const getInfo = async (request: Request<MessageTypes.GetInfo>) => {
 
 // Custom request
 // Ripple js api doesn't support "ledger_index": "current", which will fetch data from mempool
-const getMempoolAccountInfo = async (api: RippleAPI, account: string) => {
-    const info = await api.request('account_info', {
+const getMempoolAccountInfo = async (api: Client, account: string) => {
+    const info = await api.request({
+        command: 'account_info',
         account,
         ledger_index: 'current',
         queue: true,
     });
 
     return {
-        xrpBalance: info.account_data.Balance,
-        sequence: info.account_data.Sequence,
-        txs: info.queue_data ? info.queue_data.txn_count : 0,
+        xrpBalance: info.result.account_data.Balance,
+        sequence: info.result.account_data.Sequence,
+        txs: info.result.queue_data ? info.result.queue_data.txn_count : 0,
     };
 };
 
@@ -105,25 +107,28 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
 
     try {
         const api = await request.connect();
-        const info = await api.getAccountInfo(payload.descriptor);
+        const info = await api.request({
+            command: 'account_info',
+            account: payload.descriptor,
+        });
         const ownersReserve =
-            info.ownerCount > 0
-                ? new BigNumber(info.ownerCount).times(RESERVE.OWNER).toString()
+            info.result.account_data.OwnerCount > 0
+                ? new BigNumber(info.result.account_data.OwnerCount).times(RESERVE.OWNER).toString()
                 : '0';
 
         const reserve = new BigNumber(RESERVE.BASE).plus(ownersReserve).toString();
         const misc = {
-            sequence: info.sequence,
+            sequence: info.result.account_data.Sequence,
             reserve,
         };
         account.misc = misc;
-        account.balance = api.xrpToDrops(info.xrpBalance);
+        account.balance = xrpToDrops(info.result.account_data.Balance);
         account.availableBalance = new BigNumber(account.balance).minus(reserve).toString();
         account.empty = false;
     } catch (error) {
         // empty account throws error "actNotFound"
         // catch it and respond with empty account
-        if (error instanceof RippleError && error.data && error.data.error === 'actNotFound') {
+        if (error instanceof RippledError && error.data && error.data.error === 'actNotFound') {
             return {
                 type: RESPONSES.GET_ACCOUNT_INFO,
                 payload: account,
@@ -164,7 +169,10 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
     };
 
     const api = await request.connect();
-    const transactionsData: RawTxData = await api.request('account_tx', requestOptions);
+    const transactionsData: RawTxData = await api.request({
+        command: 'account_tx',
+        ...requestOptions
+    });
     account.history.transactions = transactionsData.transactions.map(raw =>
         utils.transformTransaction(raw.tx, raw.meta, payload.descriptor),
     );
@@ -180,7 +188,7 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
 
 const getTransaction = async ({ connect, payload }: Request<MessageTypes.GetTransaction>) => {
     const api = await connect();
-    const rawTx = await api.request('tx', { transaction: payload, binary: false });
+    const rawTx = await api.request({ command:'tx',transaction: payload, binary: false });
     const tx = utils.transformTransaction(rawTx, null);
 
     return {
@@ -194,23 +202,23 @@ const pushTransaction = async ({ connect, payload }: Request<MessageTypes.PushTr
     // tx_blob hex must be in upper case
     const info = await api.submit(payload.toUpperCase());
 
-    if (info.resultCode === 'tesSUCCESS') {
+    if (info.result.engine_result === 'tesSUCCESS') {
         return {
             type: RESPONSES.PUSH_TRANSACTION,
             // payload: info.resultMessage,
-            // @ts-expect-error this param is not typed in RippleApi
+            // @ts-expect-error this param is not typed in Client
             payload: info.tx_json.hash,
         } as const;
     }
-    throw new Error(info.resultMessage);
+    throw new Error(info.result.engine_result_message);
 };
 
 const estimateFee = async (request: Request<MessageTypes.EstimateFee>) => {
     const api = await request.connect();
-    const fee = await api.getFee();
+    const fee = await api.request({ command: 'fee' });
     // TODO: sometimes rippled returns very high values in "server_info.load_factor" and calculated fee jumps from basic 12 drops to 6000+ drops for a moment
     // investigate more...
-    let drops = api.xrpToDrops(fee);
+    let drops = fee.result.drops.base_fee
     if (new BigNumber(drops).gt('2000')) {
         drops = '12';
     }
@@ -278,7 +286,8 @@ const subscribeAccounts = async (ctx: Context, accounts: SubscriptionAccountInfo
             api.connection.on('transaction', ev => onTransaction(ctx, ev));
             state.addSubscription('notification');
         }
-        await api.request('subscribe', {
+        await api.request({
+            command: 'subscribe',
             accounts_proposed: uniqueAddresses,
         });
     }
@@ -305,7 +314,7 @@ const subscribeAddresses = async (ctx: Context, addresses: string[]) => {
             // accounts_proposed: mempool ? uniqueAddresses : [],
         };
 
-        await api.request('subscribe', request);
+        await api.request({ command: 'subscribe', ...request });
     }
 
     return { subscribed: state.getAddresses().length > 0 };
@@ -314,7 +323,7 @@ const subscribeAddresses = async (ctx: Context, addresses: string[]) => {
 const subscribeBlock = async (ctx: Context) => {
     if (!ctx.state.getSubscription('ledger')) {
         const api = await ctx.connect();
-        api.on('ledger', ev => onNewBlock(ctx, ev));
+        api.on('ledgerClosed', ev => onNewBlock(ctx, ev));
         ctx.state.addSubscription('ledger');
     }
 
@@ -348,12 +357,14 @@ const unsubscribeAddresses = async ({ state, connect }: Context, addresses?: str
         const all = state.getAddresses();
         state.removeAccounts(state.getAccounts());
         state.removeAddresses(all);
-        await api.request('unsubscribe', {
+        await api.request({
+            command: 'unsubscribe',
             accounts_proposed: all,
         });
     } else {
         state.removeAddresses(addresses);
-        await api.request('unsubscribe', {
+        await api.request({
+            command: 'unsubscribe',
             accounts_proposed: addresses,
         });
     }
@@ -378,7 +389,7 @@ const unsubscribeAccounts = async (ctx: Context, accounts?: SubscriptionAccountI
 const unsubscribeBlock = async ({ state, connect }: Context) => {
     if (!state.getSubscription('ledger')) return;
     const api = await connect();
-    api.removeAllListeners('ledger');
+    api.removeAllListeners('ledgerClosed');
     state.removeSubscription('ledger');
 };
 
@@ -420,7 +431,7 @@ const onRequest = (request: Request<MessageTypes.Message>) => {
     }
 };
 
-class RippleWorker extends BaseWorker<RippleAPI> {
+class RippleWorker extends BaseWorker<Client> {
     pingTimeout?: TimerId;
 
     cleanup() {
@@ -433,35 +444,34 @@ class RippleWorker extends BaseWorker<RippleAPI> {
         super.cleanup();
     }
 
-    protected isConnected(api: RippleAPI | undefined): api is RippleAPI {
+    protected isConnected(api: Client | undefined): api is Client {
         return api?.isConnected() ?? false;
     }
 
-    async tryConnect(url: string): Promise<RippleAPI> {
-        const options: APIOptions = {
-            server: url,
+    async tryConnect(url: string): Promise<Client> {
+        const options: ClientOptions = {
             timeout: this.settings.timeout || DEFAULT_TIMEOUT, // timeout is used for request and heartbeat (ping), see node_modules/ripple-lib/dist/npm/common/connection.js
             connectionTimeout: this.settings.timeout || DEFAULT_TIMEOUT, // connectionTimeout is used only for connection
         };
         // proxy agent is available only in suite because of the patch.
         // it will fail in standalone trezor-connect implementation where this patch is not present.
         // TODO: https://github.com/trezor/trezor-suite/issues/4942
-        if (RippleAPI._ALLOW_AGENT) {
+        if (Client._ALLOW_AGENT) {
             options.agent = this.proxyAgent;
         }
-        const api = new RippleAPI(options);
+        const api = new Client(url, options);
         // disable websocket auto reconnecting
-        // workaround for RippleApi which doesn't have possibility to disable reconnection
+        // workaround for Client which doesn't have possibility to disable reconnection
         // issue: https://github.com/ripple/ripple-lib/issues/1068
         // override Api (connection) private methods and return never ending promises to prevent this behavior
         api.connection.reconnect = () => new Promise(() => {});
         await api.connect();
 
         // Ripple api does set ledger listener automatically
-        api.on('ledger', ledger => {
+        api.on('ledgerClosed', ledger => {
             // store current ledger values
-            RESERVE.BASE = api.xrpToDrops(ledger.reserveBaseXRP);
-            RESERVE.OWNER = api.xrpToDrops(ledger.reserveIncrementXRP);
+            RESERVE.BASE = xrpToDrops(ledger.reserve_base);
+            RESERVE.OWNER = xrpToDrops(ledger.reserve_inc);
         });
 
         api.on('disconnected', () => {

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -68,7 +68,6 @@
         "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "dependencies": {
-        "@babel/preset-typescript": "^7.24.7",
         "@ethereumjs/common": "^4.4.0",
         "@ethereumjs/tx": "^5.4.0",
         "@fivebinaries/coin-selection": "3.0.0",
@@ -98,6 +97,7 @@
         "cross-fetch": "^4.0.0"
     },
     "devDependencies": {
+        "@babel/preset-typescript": "^7.24.7",
         "@trezor/eslint": "workspace:*",
         "@trezor/trezor-user-env-link": "workspace:*",
         "@types/karma": "^6.3.9",

--- a/packages/connect/src/api/ethereum/ethereumDefinitions.ts
+++ b/packages/connect/src/api/ethereum/ethereumDefinitions.ts
@@ -1,5 +1,3 @@
-import fetch from 'cross-fetch';
-
 import { MessagesSchema, decode as decodeProtobuf, parseConfigure } from '@trezor/protobuf';
 import { trzd } from '@trezor/protocol';
 import { Assert, Static, Type } from '@trezor/schema-utils';

--- a/packages/connect/src/utils/assets-browser.ts
+++ b/packages/connect/src/utils/assets-browser.ts
@@ -1,5 +1,3 @@
-import fetch from 'cross-fetch';
-
 import { HttpRequestOptions, HttpRequestReturnType, HttpRequestType } from './assetsTypes';
 
 export const httpRequest = async <T extends HttpRequestType>(

--- a/packages/trezor-user-env-link/package.json
+++ b/packages/trezor-user-env-link/package.json
@@ -11,7 +11,6 @@
     "dependencies": {
         "@trezor/utils": "workspace:*",
         "@trezor/websocket-client": "workspace:*",
-        "cross-fetch": "^4.0.0",
         "semver": "^7.6.3"
     },
     "devDependencies": {

--- a/packages/trezor-user-env-link/src/websocket-client.ts
+++ b/packages/trezor-user-env-link/src/websocket-client.ts
@@ -1,7 +1,5 @@
 /* eslint-disable no-console */
 
-import fetch from 'cross-fetch';
-
 import {
     WebsocketClient as WebsocketClientBase,
     WebsocketResponse as WebsocketResponseData,

--- a/yarn.lock
+++ b/yarn.lock
@@ -13742,7 +13742,6 @@ __metadata:
     "@trezor/utils": "workspace:*"
     "@trezor/websocket-client": "workspace:*"
     "@types/semver": "npm:^7.5.8"
-    cross-fetch: "npm:^4.0.0"
     semver: "npm:^7.6.3"
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -5312,10 +5312,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@noble/curves@npm:^1.0.0, @noble/curves@npm:~1.8.1":
+  version: 1.8.1
+  resolution: "@noble/curves@npm:1.8.1"
+  dependencies:
+    "@noble/hashes": "npm:1.7.1"
+  checksum: 10/e861db372cc0734b02a4c61c0f5a6688d4a7555edca3d8a9e7c846c9aa103ca52d3c3818e8bc333a1a95b5be7f370ff344668d5d759471b11c2d14c7f24b3984
+  languageName: node
+  linkType: hard
+
 "@noble/hashes@npm:1.4.0, @noble/hashes@npm:~1.4.0":
   version: 1.4.0
   resolution: "@noble/hashes@npm:1.4.0"
   checksum: 10/e156e65794c473794c52fa9d06baf1eb20903d0d96719530f523cc4450f6c721a957c544796e6efd0197b2296e7cd70efeb312f861465e17940a3e3c7e0febc6
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:1.7.1, @noble/hashes@npm:^1.0.0, @noble/hashes@npm:~1.7.1":
+  version: 1.7.1
+  resolution: "@noble/hashes@npm:1.7.1"
+  checksum: 10/ca3120da0c3e7881d6a481e9667465cc9ebbee1329124fb0de442e56d63fef9870f8cc96f264ebdb18096e0e36cebc0e6e979a872d545deb0a6fed9353f17e05
   languageName: node
   linkType: hard
 
@@ -8211,6 +8227,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@scure/base@npm:~1.2.2, @scure/base@npm:~1.2.4":
+  version: 1.2.4
+  resolution: "@scure/base@npm:1.2.4"
+  checksum: 10/4b61679209af40143b49ce7b7570e1d9157c19df311ea6f57cd212d764b0b82222dbe3707334f08bec181caf1f047aca31aa91193c678d6548312cb3f9c82ab1
+  languageName: node
+  linkType: hard
+
 "@scure/bip32@npm:1.4.0":
   version: 1.4.0
   resolution: "@scure/bip32@npm:1.4.0"
@@ -8222,6 +8245,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@scure/bip32@npm:^1.3.1":
+  version: 1.6.2
+  resolution: "@scure/bip32@npm:1.6.2"
+  dependencies:
+    "@noble/curves": "npm:~1.8.1"
+    "@noble/hashes": "npm:~1.7.1"
+    "@scure/base": "npm:~1.2.2"
+  checksum: 10/474ee315a8631aa1a7d378b0521b4494e09a231519ec53d879088cb88c8ff644a89b27a02a8bf0b5a9b1c4c0417acc70636ccdb121b800c34594ae53c723f8d7
+  languageName: node
+  linkType: hard
+
 "@scure/bip39@npm:1.3.0":
   version: 1.3.0
   resolution: "@scure/bip39@npm:1.3.0"
@@ -8229,6 +8263,16 @@ __metadata:
     "@noble/hashes": "npm:~1.4.0"
     "@scure/base": "npm:~1.1.6"
   checksum: 10/7d71fd58153de22fe8cd65b525f6958a80487bc9d0fbc32c71c328aeafe41fa259f989d2f1e0fa4fdfeaf83b8fcf9310d52ed9862987e46c2f2bfb9dd8cf9fc1
+  languageName: node
+  linkType: hard
+
+"@scure/bip39@npm:^1.2.1":
+  version: 1.5.4
+  resolution: "@scure/bip39@npm:1.5.4"
+  dependencies:
+    "@noble/hashes": "npm:~1.7.1"
+    "@scure/base": "npm:~1.2.4"
+  checksum: 10/9f08b433511d7637bc48c51aa411457d5f33da5a85bd03370bf394822b0ea8c007ceb17247a3790c28237303d8fc20c4e7725765940cd47e1365a88319ad0d5c
   languageName: node
   linkType: hard
 
@@ -12546,7 +12590,6 @@ __metadata:
     events: "npm:^3.3.0"
     fs-extra: "npm:^11.2.0"
     html-webpack-plugin: "npm:^5.6.0"
-    ripple-lib: "npm:^1.10.1"
     socks-proxy-agent: "npm:8.0.4"
     tiny-worker: "npm:^2.3.0"
     tsx: "npm:^4.16.3"
@@ -12554,6 +12597,7 @@ __metadata:
     webpack-cli: "npm:^5.1.4"
     webpack-dev-server: "npm:^5.0.4"
     worker-loader: "npm:^3.0.8"
+    xrpl: "npm:^4.2.0"
   peerDependencies:
     tslib: ^2.6.2
   languageName: unknown
@@ -14768,7 +14812,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/lodash@npm:^4, @types/lodash@npm:^4.14.136, @types/lodash@npm:^4.14.167, @types/lodash@npm:^4.17.7":
+"@types/lodash@npm:^4, @types/lodash@npm:^4.14.167, @types/lodash@npm:^4.17.7":
   version: 4.17.15
   resolution: "@types/lodash@npm:4.17.15"
   checksum: 10/27b348b5971b9c670215331b52448a13d7d65bf1fbd320a7049c9c153c1186ff5d116ba75f05f07d32d7ece8a992b26a30c7bdc9be22a3d1e4e3e6068aa04603
@@ -15403,7 +15447,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/ws@npm:^7.2.0, @types/ws@npm:^7.4.4":
+"@types/ws@npm:^7.4.4":
   version: 7.4.7
   resolution: "@types/ws@npm:7.4.7"
   dependencies:
@@ -16309,6 +16353,27 @@ __metadata:
   version: 1.9.5
   resolution: "@xobotyi/scrollbar-width@npm:1.9.5"
   checksum: 10/026ccd174ec3ce032f42794c7e2ee9dab3cfee4f8f9d6ce4f2b4a2fe50cbf8be7406583fb2e203707c699690c5d40a13ee1611f1f67f6ceb01ac2a543acadc30
+  languageName: node
+  linkType: hard
+
+"@xrplf/isomorphic@npm:^1.0.0, @xrplf/isomorphic@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@xrplf/isomorphic@npm:1.0.1"
+  dependencies:
+    "@noble/hashes": "npm:^1.0.0"
+    eventemitter3: "npm:5.0.1"
+    ws: "npm:^8.13.0"
+  checksum: 10/2d24f0631528be2611c2d41beb97e2f89623d2613e14292e306d96fb6c7f0e044a33f1d93a5e609cdde9f49ea5debd2ca855ddb387ae8aba1aa21358f10df941
+  languageName: node
+  linkType: hard
+
+"@xrplf/secret-numbers@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@xrplf/secret-numbers@npm:1.0.0"
+  dependencies:
+    "@xrplf/isomorphic": "npm:^1.0.0"
+    ripple-keypairs: "npm:^2.0.0"
+  checksum: 10/f9e584fdc73a605b2aba4a6b86f3a090c0df1a26e48817b7fa256d64211950d084b6f4419e89bef036e9eaedf85fd5fa98089e888b14e4232fe51ab9491742e0
   languageName: node
   linkType: hard
 
@@ -17773,7 +17838,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base-x@npm:3.0.9, base-x@npm:^3.0.2, base-x@npm:^3.0.6":
+"base-x@npm:^3.0.2, base-x@npm:^3.0.6":
   version: 3.0.9
   resolution: "base-x@npm:3.0.9"
   dependencies:
@@ -17918,7 +17983,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"big-integer@npm:1.6.x, big-integer@npm:^1.6.44, big-integer@npm:^1.6.48":
+"big-integer@npm:1.6.x, big-integer@npm:^1.6.44":
   version: 1.6.51
   resolution: "big-integer@npm:1.6.51"
   checksum: 10/c7a12640901906d6f6b6bdb42a4eaba9578397b6d9a0dd090cf001ec813ff2bfcd441e364068ea0416db6175d2615f8ed19cff7d1a795115bf7c92d44993f991
@@ -18189,7 +18254,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brorand@npm:^1.0.1, brorand@npm:^1.0.5, brorand@npm:^1.1.0":
+"brorand@npm:^1.0.1, brorand@npm:^1.1.0":
   version: 1.1.0
   resolution: "brorand@npm:1.1.0"
   checksum: 10/8a05c9f3c4b46572dec6ef71012b1946db6cae8c7bb60ccd4b7dd5a84655db49fe043ecc6272e7ef1f69dc53d6730b9e2a3a03a8310509a3d797a618cbee52be
@@ -18476,16 +18541,6 @@ __metadata:
   version: 1.0.3
   resolution: "buffer-xor@npm:1.0.3"
   checksum: 10/4a63d48b5117c7eda896d81cd3582d9707329b07c97a14b0ece2edc6e64220ea7ea17c94b295e8c2cb7b9f8291e2b079f9096be8ac14be238420a43e06ec66e2
-  languageName: node
-  linkType: hard
-
-"buffer@npm:5.6.0":
-  version: 5.6.0
-  resolution: "buffer@npm:5.6.0"
-  dependencies:
-    base64-js: "npm:^1.0.2"
-    ieee754: "npm:^1.1.4"
-  checksum: 10/7874745b06533184c467d79e6cd35df1a528a4d587eb65cc8f0359200ff16837a3047bab88084c9eb01628665f554f99381682d90d4b6aa3fe5b1c16effa61ad
   languageName: node
   linkType: hard
 
@@ -21449,7 +21504,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"decimal.js@npm:^10.2.0, decimal.js@npm:^10.4.2, decimal.js@npm:^10.4.3":
+"decimal.js@npm:^10.4.2, decimal.js@npm:^10.4.3":
   version: 10.4.3
   resolution: "decimal.js@npm:10.4.3"
   checksum: 10/de663a7bc4d368e3877db95fcd5c87b965569b58d16cdc4258c063d231ca7118748738df17cd638f7e9dd0be8e34cec08d7234b20f1f2a756a52fc5a38b188d0
@@ -24040,17 +24095,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eventemitter3@npm:5.0.1, eventemitter3@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "eventemitter3@npm:5.0.1"
+  checksum: 10/ac6423ec31124629c84c7077eed1e6987f6d66c31cf43c6fcbf6c87791d56317ce808d9ead483652436df171b526fc7220eccdc9f3225df334e81582c3cf7dd5
+  languageName: node
+  linkType: hard
+
 "eventemitter3@npm:^4.0.0, eventemitter3@npm:^4.0.1, eventemitter3@npm:^4.0.4":
   version: 4.0.7
   resolution: "eventemitter3@npm:4.0.7"
   checksum: 10/8030029382404942c01d0037079f1b1bc8fed524b5849c237b80549b01e2fc49709e1d0c557fa65ca4498fc9e24cff1475ef7b855121fcc15f9d61f93e282346
-  languageName: node
-  linkType: hard
-
-"eventemitter3@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "eventemitter3@npm:5.0.1"
-  checksum: 10/ac6423ec31124629c84c7077eed1e6987f6d66c31cf43c6fcbf6c87791d56317ce808d9ead483652436df171b526fc7220eccdc9f3225df334e81582c3cf7dd5
   languageName: node
   linkType: hard
 
@@ -30196,13 +30251,6 @@ __metadata:
   version: 1.3.1
   resolution: "jsonparse@npm:1.3.1"
   checksum: 10/24531e956f0f19d79e22c157cebd81b37af3486ae22f9bc1028f8c2a4d1b70df48b168ff86f8568d9c2248182de9b6da9f50f685d5e4b9d1d2d339d2a29d15bc
-  languageName: node
-  linkType: hard
-
-"jsonschema@npm:1.2.2":
-  version: 1.2.2
-  resolution: "jsonschema@npm:1.2.2"
-  checksum: 10/aa778e23f1ff879345dabee968c2d7b36d39fe60bb0aa0d251e60d18aed7038499fb203be6c06f4185b0a301b5b187295a46a0a139f19be17b50b6c04b48193d
   languageName: node
   linkType: hard
 
@@ -39471,69 +39519,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ripple-address-codec@npm:^4.1.1, ripple-address-codec@npm:^4.2.4":
-  version: 4.2.4
-  resolution: "ripple-address-codec@npm:4.2.4"
+"ripple-address-codec@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "ripple-address-codec@npm:5.0.0"
   dependencies:
-    base-x: "npm:3.0.9"
-    create-hash: "npm:^1.1.2"
-  checksum: 10/bb04e94ad8194629fa20d4b319229d5158eba3173ef5d912d3099cfd65582db2a37e589d84440a4a083cfb3b256173471d358515c4463085b12c9f8e2368a452
+    "@scure/base": "npm:^1.1.3"
+    "@xrplf/isomorphic": "npm:^1.0.0"
+  checksum: 10/e8e274c7181789cfbd4659cfaa2e65ac7615ebdb49a72515b957e4dbadba1b9398aa7635834f45e729a820af20dfa77569ac033e66aff2763f02a4db7943a60e
   languageName: node
   linkType: hard
 
-"ripple-binary-codec@npm:^1.1.3":
-  version: 1.4.2
-  resolution: "ripple-binary-codec@npm:1.4.2"
+"ripple-binary-codec@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "ripple-binary-codec@npm:2.3.0"
   dependencies:
-    assert: "npm:^2.0.0"
-    big-integer: "npm:^1.6.48"
-    buffer: "npm:5.6.0"
-    create-hash: "npm:^1.2.0"
-    decimal.js: "npm:^10.2.0"
-    ripple-address-codec: "npm:^4.2.4"
-  checksum: 10/72d19962725bdd63398fb474a571827c848e589cf9267c34bc51908b358cc8d32bede047ad0a58e30446c95bb6b00ac810fb63e4a555e313330d7d00761be3b3
-  languageName: node
-  linkType: hard
-
-"ripple-keypairs@npm:^1.0.3":
-  version: 1.1.4
-  resolution: "ripple-keypairs@npm:1.1.4"
-  dependencies:
-    bn.js: "npm:^5.1.1"
-    brorand: "npm:^1.0.5"
-    elliptic: "npm:^6.5.4"
-    hash.js: "npm:^1.0.3"
-    ripple-address-codec: "npm:^4.2.4"
-  checksum: 10/2cca6ed94e779551745a3c747f3d695c8339aa79ae8d8122cf1b656be55b5bdd429511293e187adce118431851937a03120860fb1f81c023ced34bcd4904afc1
-  languageName: node
-  linkType: hard
-
-"ripple-lib-transactionparser@npm:0.8.2":
-  version: 0.8.2
-  resolution: "ripple-lib-transactionparser@npm:0.8.2"
-  dependencies:
+    "@xrplf/isomorphic": "npm:^1.0.1"
     bignumber.js: "npm:^9.0.0"
-    lodash: "npm:^4.17.15"
-  checksum: 10/4b0084d97ac820589fc0ec7b8cfe00d757dc0fb8394dec0dbaf5b8a5e014e169d4b9be3926f41504eb30419f74d47c8beb2b64c74538f667eaa32dd1c91f20b1
+    ripple-address-codec: "npm:^5.0.0"
+  checksum: 10/e93878f2269f388b9551b5e37c5f317afb597ab640d3bb091054c7bcd19a29c4b4407aeccf2e5d8de5653b4140472e05c5edecb22ebf5f377c2c462b00b472a8
   languageName: node
   linkType: hard
 
-"ripple-lib@npm:^1.10.1":
-  version: 1.10.1
-  resolution: "ripple-lib@npm:1.10.1"
+"ripple-keypairs@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "ripple-keypairs@npm:2.0.0"
   dependencies:
-    "@types/lodash": "npm:^4.14.136"
-    "@types/ws": "npm:^7.2.0"
-    bignumber.js: "npm:^9.0.0"
-    https-proxy-agent: "npm:^5.0.0"
-    jsonschema: "npm:1.2.2"
-    lodash: "npm:^4.17.4"
-    ripple-address-codec: "npm:^4.1.1"
-    ripple-binary-codec: "npm:^1.1.3"
-    ripple-keypairs: "npm:^1.0.3"
-    ripple-lib-transactionparser: "npm:0.8.2"
-    ws: "npm:^7.2.0"
-  checksum: 10/e77ebca3eda5c508d8f404b6ede60f5c9ac4bc23dab1d002b494f51af92c8b4cec3069eab11c0cacb1e06563f7bb0865e6b69060642711a291c04c313cae5a10
+    "@noble/curves": "npm:^1.0.0"
+    "@xrplf/isomorphic": "npm:^1.0.0"
+    ripple-address-codec: "npm:^5.0.0"
+  checksum: 10/401ade8b179b8693f9689457346a5f0b5b7d789bb88613f27917c2a1ef907edc23bb1902ba5e8158dcd303e462f160e39897047fb778227af2dc6fab8897f503
   languageName: node
   linkType: hard
 
@@ -45700,7 +45714,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^7, ws@npm:^7.0.0, ws@npm:^7.2.0, ws@npm:^7.3.1, ws@npm:^7.5.1, ws@npm:^7.5.10, ws@npm:^7.5.3":
+"ws@npm:^7, ws@npm:^7.0.0, ws@npm:^7.3.1, ws@npm:^7.5.1, ws@npm:^7.5.10, ws@npm:^7.5.3":
   version: 7.5.10
   resolution: "ws@npm:7.5.10"
   peerDependencies:
@@ -45715,7 +45729,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.11.0, ws@npm:^8.12.1, ws@npm:^8.16.0, ws@npm:^8.17.1, ws@npm:^8.18.0, ws@npm:^8.2.3, ws@npm:^8.5.0":
+"ws@npm:^8.11.0, ws@npm:^8.12.1, ws@npm:^8.13.0, ws@npm:^8.16.0, ws@npm:^8.17.1, ws@npm:^8.18.0, ws@npm:^8.2.3, ws@npm:^8.5.0":
   version: 8.18.0
   resolution: "ws@npm:8.18.0"
   peerDependencies:
@@ -45837,6 +45851,23 @@ __metadata:
   dependencies:
     sax: "npm:^1.2.4"
   checksum: 10/1e984154ce6b821f8bccf53d8fa1a2855ab203478325251fd2886461226361a085e56a6a5dbad12aa7c4fb27c229fd3b37b2790a6b0e701c088d45b9a5f366e4
+  languageName: node
+  linkType: hard
+
+"xrpl@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "xrpl@npm:4.2.0"
+  dependencies:
+    "@scure/bip32": "npm:^1.3.1"
+    "@scure/bip39": "npm:^1.2.1"
+    "@xrplf/isomorphic": "npm:^1.0.1"
+    "@xrplf/secret-numbers": "npm:^1.0.0"
+    bignumber.js: "npm:^9.0.0"
+    eventemitter3: "npm:^5.0.1"
+    ripple-address-codec: "npm:^5.0.0"
+    ripple-binary-codec: "npm:^2.3.0"
+    ripple-keypairs: "npm:^2.0.0"
+  checksum: 10/40ed2a681500b076cd6b9b1222e18a3b27a8581c5546a0ecc6fbfa66427b4a704eaf7f846d2ddd3bdcd551aa44c07fa842ae933b72bacc6e1945da94f770514c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Moves `"@babel/preset-typescript` to dev dependencies (it's not imported in src anywhere)
* Removes usage of `node-fetch` where it is not needed. Fetch API is supported everywhere, incl. Node.js, React Native and all Serverless and the polyfill is no longer needed, unless proxies or custom agents are used.
* Rewrites `blockchain-link` from a deprecated ripple-lib to xrpl, drops 63 dependencies

## Related Issue

## Screenshots:
