### PR TITLE
chore(message-system): add warning about discovery issues on polygon

### DIFF
--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,6 +1,6 @@
 {
     "version": 1,
-    "timestamp": "2025-02-03T00:00:00+00:00",
+    "timestamp": "2025-02-14T00:00:00+00:00",
     "sequence": 79,
     "actions": [
         {
@@ -180,13 +180,16 @@
                 {
                     "settings": [
                         {
+                            "pol": true
+                        },
+                        {
                             "matic": true
                         }
                     ],
                     "environment": {
-                        "desktop": "<=24.9.2",
+                        "desktop": "<=25.1.2",
                         "mobile": "!",
-                        "web": "*"
+                        "web": "!"
                     }
                 }
             ],
@@ -197,38 +200,38 @@
                 "variant": "info",
                 "category": ["banner"],
                 "content": {
-                    "en-GB": "If you encounter any issues syncing your Polygon PoS balance, please update your Trezor Suite to the latest version.",
-                    "en": "If you encounter any issues syncing your Polygon PoS balance, please update your Trezor Suite to the latest version.",
-                    "es": "Si encuentras algún problema al sincronizar tu saldo de Polygon PoS, por favor actualiza tu Trezor Suite a la última versión.",
-                    "cs": "Pokud narazíte na problémy se synchronizací vašeho zůstatku Polygon PoS, aktualizujte svůj Trezor Suite na nejnovější verzi.",
-                    "ru": "Если у вас возникли проблемы с синхронизацией баланса Polygon PoS, обновите Trezor Suite до последней версии.",
-                    "ja": "Polygon PoSの残高の同期に問題がある場合は、Trezor Suiteを最新バージョンに更新してください。",
-                    "hu": "Ha bármilyen problémába ütközik a Polygon PoS egyenlegének szinkronizálásakor, frissítse a Trezor Suite alkalmazást a legújabb verzióra.",
-                    "it": "Se riscontri problemi di sincronizzazione del saldo Polygon PoS, aggiorna la tua Trezor Suite all'ultima versione.",
-                    "fr": "Si vous rencontrez des problèmes de synchronisation de votre solde Polygon PoS, veuillez mettre à jour votre Trezor Suite vers la dernière version.",
-                    "de": "Wenn Sie Probleme beim Synchronisieren Ihres Polygon PoS-Guthabens haben, aktualisieren Sie Ihre Trezor Suite auf die neueste Version.",
-                    "tr": "Polygon PoS bakiyenizi senkronize etme konusunda herhangi bir sorunla karşılaşırsanız, Trezor Suite'inizi en son sürüme güncelleyin.",
-                    "pt": "Se encontrar problemas ao sincronizar o saldo do seu Polygon PoS, atualize o seu Trezor Suite para a versão mais recente.",
-                    "uk": "Якщо у вас виникли проблеми з синхронізацією балансу Polygon PoS, оновіть ваш Trezor Suite до останньої версії."
+                    "en-GB": "If you encounter any issues syncing your Polygon PoS balance, please join our Early Access program, where the issue has been fixed.",
+                    "en": "If you encounter any issues syncing your Polygon PoS balance, please join our Early Access program, where the issue has been fixed.",
+                    "es": "Si encuentras algún problema al sincronizar tu saldo de Polygon PoS, por favor únete a nuestro programa de Acceso Anticipado, donde se ha solucionado el problema.",
+                    "cs": "Pokud narazíte na jakékoliv problémy se synchronizací vašeho zůstatku Polygon PoS, připojte se prosím k našemu programu Early Access, kde byl problém vyřešen.",
+                    "ru": "Если у вас возникнут проблемы с синхронизацией баланса Polygon PoS, пожалуйста, присоединяйтесь к нашей программе раннего доступа, где проблема уже решена.",
+                    "ja": "Polygon PoS の残高同期に問題が発生した場合は、問題が解決されたEarly Accessプログラムにご参加ください。",
+                    "hu": "Ha problémákat tapasztalsz a Polygon PoS egyenleged szinkronizálásában, kérlek, csatlakozz az Early Access programunkhoz, ahol a hiba már megoldásra került.",
+                    "it": "Se riscontri problemi nella sincronizzazione del saldo Polygon PoS, unisciti al nostro programma Early Access, dove il problema è stato risolto.",
+                    "fr": "Si vous rencontrez des problèmes lors de la synchronisation de votre solde Polygon PoS, veuillez rejoindre notre programme Early Access, où le problème a été résolu.",
+                    "de": "Wenn Sie Probleme bei der Synchronisierung Ihres Polygon PoS-Guthabens haben, treten Sie bitte unserem Early Access-Programm bei, in dem das Problem behoben wurde.",
+                    "tr": "Polygon PoS bakiyenizi senkronize ederken herhangi bir sorunla karşılaşırsanız, lütfen sorunun çözüldüğü Early Access programımıza katılın.",
+                    "pt": "Se você encontrar algum problema ao sincronizar seu saldo Polygon PoS, por favor, participe do nosso programa Early Access, onde o problema foi corrigido.",
+                    "uk": "Якщо у вас виникнуть проблеми із синхронізацією балансу Polygon PoS, будь ласка, приєднуйтесь до нашої програми раннього доступу, де проблема вже вирішена."
                 },
                 "cta": {
                     "action": "internal-link",
                     "link": "settings-index",
-                    "anchor": "@general-settings/version-with-update",
+                    "anchor": "@general-settings/early-access",
                     "label": {
-                        "en-GB": "Update Suite",
-                        "en": "Update Suite",
-                        "es": "Actualizar Suite",
-                        "cs": "Aktualizovat Suite",
-                        "ru": "Обновить Suite",
-                        "ja": "Suiteのアップデート",
-                        "hu": "Frissítés Suite",
-                        "it": "Aggiorna Suite",
-                        "fr": "Mettre à jour Suite",
-                        "de": "Suite aktualisieren",
-                        "tr": "Suite'i Güncelle",
-                        "pt": "Atualizar Suite",
-                        "uk": "Оновити Suite"
+                        "en-GB": "Join Early Access",
+                        "en": "Join Early Access",
+                        "es": "Únete al Acceso Anticipado",
+                        "cs": "Připojit se k Early Access",
+                        "ru": "Присоединиться к раннему доступу",
+                        "ja": "Early Accessに参加",
+                        "hu": "Csatlakozás az Early Access programhoz",
+                        "it": "Unisciti all'Early Access",
+                        "fr": "Rejoindre l'accès anticipé",
+                        "de": "Early Access beitreten",
+                        "tr": "Erken Erişime Katıl",
+                        "pt": "Participar do Acesso Antecipado",
+                        "uk": "Приєднатися до раннього доступу"
                     }
                 }
             }


### PR DESCRIPTION
Adding message system banner with warning about discovery issues on polygon, prompting users to join EAP

Tracked in Notion [here](https://www.notion.so/satoshilabs/Polygon-discovery-issues-warning-19adc5260606805d8d90dfe1540ae6cf?pvs=4)
Deployed to develop via [this](https://github.com/trezor/trezor-suite/actions/runs/13327947237)

![image](https://github.com/user-attachments/assets/7e32b2a3-9d3b-49f9-a80e-e93537d21524)
