### PR TITLE
feat(trading): trading sign message flow

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -126,7 +126,7 @@
         "@testing-library/user-event": "14.5.2",
         "@trezor/eslint": "workspace:*",
         "@types/file-saver": "^2.0.6",
-        "@types/invity-api": "^1.1.3",
+        "@types/invity-api": "^1.1.5",
         "@types/jws": "^3.2.10",
         "@types/pako": "^2.0.3",
         "@types/pdfmake": "^0.2.9",

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -23,6 +23,10 @@ import { networks } from '@suite-common/wallet-config';
 import { selectAccountByKey } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 import { amountToSmallestUnit, formatAmount, toFiatCurrency } from '@suite-common/wallet-utils';
+import TrezorConnect, {
+    EthereumSignTypedDataMessage,
+    EthereumSignTypedDataTypes,
+} from '@trezor/connect';
 import { EventType, analytics } from '@trezor/suite-analytics';
 
 import * as tradingCommonActions from 'src/actions/wallet/trading/tradingCommonActions';
@@ -422,6 +426,10 @@ export const useTradingExchangeForm = ({
                 dispatch(tradingExchangeActions.saveSelectedQuote(response));
                 setExchangeStep('SEND_APPROVAL_TRANSACTION');
                 ok = true;
+            } else if (response.status === 'SIGN_DATA') {
+                dispatch(tradingExchangeActions.saveSelectedQuote(response));
+                setExchangeStep('SIGN_DATA');
+                ok = true;
             } else if (response.status === 'CONFIRM') {
                 dispatch(tradingExchangeActions.saveSelectedQuote(response));
                 if (response.isDex) {
@@ -510,11 +518,11 @@ export const useTradingExchangeForm = ({
                             new Date().toISOString(),
                         ),
                     );
-                    confirmTrade(quote.receiveAddress || '', undefined, quote);
+                    await confirmTrade(quote.receiveAddress || '', undefined, quote);
                 } else {
                     quote.approvalSendTxHash = txid;
                     quote.status = 'APPROVAL_PENDING';
-                    confirmTrade(quote.receiveAddress || '', undefined, quote);
+                    await confirmTrade(quote.receiveAddress || '', undefined, quote);
                 }
             }
         } else {
@@ -531,7 +539,7 @@ export const useTradingExchangeForm = ({
         dispatch(tradingCommonActions.setTradingModalAccountKey(account.key));
 
         if (selectedQuote?.isDex) {
-            sendDexTransaction();
+            await sendDexTransaction();
 
             return;
         }
@@ -576,6 +584,76 @@ export const useTradingExchangeForm = ({
                 }),
             );
         }
+    };
+
+    const signDataAndConfirm = async () => {
+        if (!selectedQuote?.signData) {
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'error',
+                    error: 'Cannot sign, missing data',
+                }),
+            );
+
+            return;
+        }
+
+        dispatch(tradingCommonActions.setTradingModalAccountKey(account.key));
+
+        let signature;
+        if (
+            account.networkType === 'ethereum' &&
+            selectedQuote.signData.type === 'eip712-typed-data'
+        ) {
+            const typedData = selectedQuote?.signData
+                .data as EthereumSignTypedDataMessage<EthereumSignTypedDataTypes>;
+
+            const result = await TrezorConnect.ethereumSignTypedData({
+                device,
+                path: account.path,
+                metamask_v4_compat: false,
+                data: typedData,
+            });
+
+            if (!result.success) {
+                dispatch(
+                    notificationsActions.addToast({
+                        type: 'sign-message-error',
+                        error: result.payload.error,
+                    }),
+                );
+
+                return;
+            }
+
+            signature = result.payload.signature;
+        } else {
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'error',
+                    error: 'Cannot sign data, unsupported network',
+                }),
+            );
+
+            return;
+        }
+
+        const trade = { ...selectedQuote };
+        trade.signature = signature;
+        trade.status = 'SIGN_DATA';
+
+        if (!trade.receiveAddress) {
+            return;
+        }
+
+        dispatch(
+            tradingExchangeActions.saveTrade(
+                trade,
+                selectedAccount.account,
+                new Date().toISOString(),
+            ),
+        );
+        await confirmTrade(trade.receiveAddress, undefined, trade);
     };
 
     const goToOffers = async () => {
@@ -726,6 +804,7 @@ export const useTradingExchangeForm = ({
         goToOffers,
         setExchangeStep,
         sendTransaction,
+        signDataAndConfirm,
         verifyAddress: tradingExchangeActions.verifyAddress,
         selectQuote,
         confirmTrade,

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -718,6 +718,22 @@ export default defineMessages({
         defaultMessage: 'DEX',
         id: 'TR_TRADING_EXCHANGE_COMPARATOR_FILTER_RATE_DEX',
     },
+    TR_TRADING_EXCHANGE_SIGN_BANNER_TITLE: {
+        defaultMessage: 'You’re swapping with {provider}',
+        id: 'TR_TRADING_EXCHANGE_SIGN_BANNER_TITLE',
+    },
+    TR_TRADING_EXCHANGE_SIGN_BANNER_POINT_1: {
+        defaultMessage: 'Simply sign the order — no need to send transactions manually',
+        id: 'TR_TRADING_EXCHANGE_SIGN_BANNER_POINT_1',
+    },
+    TR_TRADING_EXCHANGE_SIGN_BANNER_POINT_2: {
+        defaultMessage: 'No gas fees — the smart contract handles everything for you',
+        id: 'TR_TRADING_EXCHANGE_SIGN_BANNER_POINT_2',
+    },
+    TR_TRADING_EXCHANGE_SIGN_BANNER_POINT_3: {
+        defaultMessage: 'Your swap might be partially filled based on market conditions',
+        id: 'TR_TRADING_EXCHANGE_SIGN_BANNER_POINT_3',
+    },
     TR_SELL_STATUS_ERROR: {
         defaultMessage: 'Rejected',
         id: 'TR_SELL_STATUS_ERROR',

--- a/packages/suite/src/types/trading/tradingForm.ts
+++ b/packages/suite/src/types/trading/tradingForm.ts
@@ -140,7 +140,8 @@ export type TradingSellStepType = 'BANK_ACCOUNT' | 'SEND_TRANSACTION';
 export type TradingExchangeStepType =
     | 'RECEIVING_ADDRESS'
     | 'SEND_TRANSACTION'
-    | 'SEND_APPROVAL_TRANSACTION';
+    | 'SEND_APPROVAL_TRANSACTION'
+    | 'SIGN_DATA';
 
 interface TradingFormStateProps {
     isFormLoading: boolean;
@@ -267,7 +268,8 @@ export interface TradingExchangeFormContextProps
 
     setExchangeStep: (step: TradingExchangeStepType) => void;
     confirmTrade: (address: string, extraField?: string, trade?: ExchangeTrade) => Promise<boolean>;
-    sendTransaction: () => void;
+    sendTransaction: () => Promise<void>;
+    signDataAndConfirm: () => Promise<void>;
     selectQuote: (quote: ExchangeTrade) => void;
     verifyAddress: TradingVerifyAccountProps;
 }

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx
@@ -10,6 +10,7 @@ import { TradingOfferExchangeProps } from 'src/types/trading/tradingForm';
 import { TradingOfferExchangeSend } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSend';
 import { TradingOfferExchangeSendApproval } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSendApproval';
 import { TradingOfferExchangeSendSwap } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSendSwap';
+import { TradingOfferExchangeSignData } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSignData';
 import { TradingSelectedOfferInfo } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferInfo';
 import {
     TradingSelectedOfferStepper,
@@ -53,11 +54,17 @@ export const TradingOfferExchange = ({
         {
             step: 'SEND_TRANSACTION',
             translationId: 'TR_EXCHANGE_CONFIRM_SEND_STEP',
-            isActive: exchangeStep === 'SEND_TRANSACTION',
+            isActive: exchangeStep === 'SEND_TRANSACTION' || exchangeStep === 'SIGN_DATA',
             component: !selectedQuote.isDex ? (
                 <TradingOfferExchangeSend />
             ) : (
-                <TradingOfferExchangeSendSwap />
+                <>
+                    {exchangeStep === 'SIGN_DATA' ? (
+                        <TradingOfferExchangeSignData />
+                    ) : (
+                        <TradingOfferExchangeSendSwap />
+                    )}
+                </>
             ),
         },
     ];

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSendApproval.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSendApproval.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { DexApprovalType } from 'invity-api';
+import { DexApprovalType, ExchangeTrade } from 'invity-api';
 import styled from 'styled-components';
 
 import { type TradingExchangeType, cryptoIdToSymbol, parseCryptoId } from '@suite-common/trading';
@@ -44,7 +44,6 @@ export const TradingOfferExchangeSendApproval = () => {
         exchangeInfo,
         confirmTrade,
         sendTransaction,
-        setExchangeStep,
     } = useTradingFormContext<TradingExchangeType>();
     const { cryptoIdToCoinSymbol } = useTradingInfo();
     const [approvalType, setApprovalType] = useState<ExtendedDexApprovalType>(
@@ -110,30 +109,16 @@ export const TradingOfferExchangeSendApproval = () => {
             return;
         }
 
+        const updatedSelectedQuote: ExchangeTrade = {
+            ...selectedQuote,
+        };
+
         if (selectedQuote.approvalType) {
-            const updatedSelectedQuote = {
-                ...selectedQuote,
-                approvalType: undefined,
-            };
-            dispatch(
-                saveSelectedQuote({
-                    ...selectedQuote,
-                    approvalType: undefined,
-                }),
-            );
-
-            const confirmedTrade = await confirmTrade(
-                selectedQuote.receiveAddress,
-                undefined,
-                updatedSelectedQuote,
-            );
-
-            if (!confirmedTrade) {
-                return;
-            }
+            updatedSelectedQuote.approvalType = undefined;
+            dispatch(saveSelectedQuote(updatedSelectedQuote));
         }
 
-        setExchangeStep('SEND_TRANSACTION');
+        await confirmTrade(selectedQuote.receiveAddress, undefined, updatedSelectedQuote);
     };
 
     return (

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSignData.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSignData.tsx
@@ -1,0 +1,107 @@
+import styled from 'styled-components';
+
+import type { TradingExchangeType } from '@suite-common/trading';
+import { Button, Card, CollapsibleBox, Column, Divider, InfoItem, Text } from '@trezor/components';
+import { EthereumSignTypedDataMessage, EthereumSignTypedDataTypes } from '@trezor/connect';
+import { spacings } from '@trezor/theme';
+
+import { AccountLabeling, Address, Translation } from 'src/components/suite';
+import { BannerPoints } from 'src/components/wallet/WalletLayout/AccountBanners/BannerPoints';
+import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
+
+const Pre = styled.pre`
+    text-align: left;
+    word-break: break-all;
+    white-space: pre-wrap;
+`;
+
+export const TradingOfferExchangeSignData = () => {
+    const { device, account, callInProgress, selectedQuote, exchangeInfo, signDataAndConfirm } =
+        useTradingFormContext<TradingExchangeType>();
+
+    if (!selectedQuote) return null;
+
+    const { exchange, dexTx, receive, send, signData } = selectedQuote;
+    if (!exchange || !dexTx || !receive || !send || !signData) return null;
+
+    const providerName =
+        exchangeInfo?.providerInfos[exchange]?.companyName || selectedQuote.exchange;
+
+    const typedData = signData.data as EthereumSignTypedDataMessage<EthereumSignTypedDataTypes>;
+
+    return (
+        <Column gap={spacings.lg} flex="1">
+            <InfoItem label={<Translation id="TR_EXCHANGE_SEND_FROM" />}>
+                <AccountLabeling account={account} />
+            </InfoItem>
+            <InfoItem
+                label={
+                    <Translation
+                        id="TR_EXCHANGE_SWAP_SEND_TO"
+                        values={{ provider: providerName }}
+                    />
+                }
+            >
+                <Address value={dexTx.to} />
+            </InfoItem>
+            <Card>
+                <Text typographyStyle="highlight" as="div" margin={{ bottom: spacings.xs }}>
+                    <Translation
+                        id="TR_TRADING_EXCHANGE_SIGN_BANNER_TITLE"
+                        values={{ provider: providerName }}
+                    />
+                </Text>
+                <BannerPoints
+                    points={[
+                        <Translation
+                            id="TR_TRADING_EXCHANGE_SIGN_BANNER_POINT_1"
+                            key="TR_TRADING_EXCHANGE_SIGN_BANNER_POINT_1"
+                        />,
+                        <Translation
+                            id="TR_TRADING_EXCHANGE_SIGN_BANNER_POINT_2"
+                            key="TR_TRADING_EXCHANGE_SIGN_BANNER_POINT_2"
+                        />,
+                        <Translation
+                            id="TR_TRADING_EXCHANGE_SIGN_BANNER_POINT_3"
+                            key="TR_TRADING_EXCHANGE_SIGN_BANNER_POINT_3"
+                        />,
+                    ]}
+                />
+            </Card>
+            <CollapsibleBox heading="Typed data to sign">
+                <InfoItem label="Domain">
+                    <Card paddingType="small">
+                        <Column gap={spacings.xs}>
+                            {Object.entries(typedData.domain).map(([key, value]) => (
+                                <InfoItem key={key} label={key} gap={spacings.zero}>
+                                    <Pre>{value.toString()}</Pre>
+                                </InfoItem>
+                            ))}
+                        </Column>
+                    </Card>
+                </InfoItem>
+                <InfoItem label={typedData.primaryType}>
+                    <Card paddingType="small">
+                        <Column gap={spacings.xs}>
+                            {Object.entries(typedData.message).map(([key, value]) => (
+                                <InfoItem key={key} label={key} gap={spacings.zero}>
+                                    <Pre>{value.toString()}</Pre>
+                                </InfoItem>
+                            ))}
+                        </Column>
+                    </Card>
+                </InfoItem>
+            </CollapsibleBox>
+            <Column>
+                <Divider margin={{ top: spacings.xs, bottom: spacings.lg }} />
+                <Button
+                    isLoading={callInProgress}
+                    isDisabled={!device?.connected}
+                    onClick={signDataAndConfirm}
+                >
+                    <Translation id="TR_EXCHANGE_CONFIRM_ON_TREZOR_SEND" />
+                </Button>
+            </Column>
+        </Column>
+    );
+};

--- a/suite-common/trading/package.json
+++ b/suite-common/trading/package.json
@@ -23,6 +23,6 @@
     },
     "devDependencies": {
         "@suite-common/test-utils": "workspace:*",
-        "@types/invity-api": "^1.1.3"
+        "@types/invity-api": "^1.1.5"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9692,7 +9692,7 @@ __metadata:
     "@trezor/connect": "workspace:*"
     "@trezor/env-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.3"
+    "@types/invity-api": "npm:^1.1.5"
     uuid: "npm:^11.0.5"
   languageName: unknown
   linkType: soft
@@ -12625,7 +12625,7 @@ __metadata:
     "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@types/file-saver": "npm:^2.0.6"
-    "@types/invity-api": "npm:^1.1.3"
+    "@types/invity-api": "npm:^1.1.5"
     "@types/jws": "npm:^3.2.10"
     "@types/pako": "npm:^2.0.3"
     "@types/pdfmake": "npm:^0.2.9"
@@ -13528,10 +13528,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/invity-api@npm:^1.1.3":
-  version: 1.1.4
-  resolution: "@types/invity-api@npm:1.1.4"
-  checksum: 10/6a17f3d84274c86eb31950cb525b3a0a5bf87a7539e8ac35a011f15d354fd1c0cd7dee88bd3d475d5b973829d71817de2b019bedddd03224be85e51dabac830b
+"@types/invity-api@npm:^1.1.5":
+  version: 1.1.5
+  resolution: "@types/invity-api@npm:1.1.5"
+  checksum: 10/104a0e0ea4082ab5b7f45b6f36bce39551f9dc0fc5f4786d411bb2ef6bf08294b33e079299cfc0c0b0ad5c91eee6c4ffe371033c0c645c73351d6f6ab171c0fe
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

For 1inch fusion/fusion+, user doesn't send a swap tx, only the signature of typed data (permit) is passed to the partner via API.
New sign flow is invoked by SIGN_DATA trade status.

## Related Issue

Resolve #17118

## Screenshots:
![image](https://github.com/user-attachments/assets/88a6fb2a-51fc-4693-b264-39eff0856d65)
![image](https://github.com/user-attachments/assets/aa5d63c3-3ffb-483b-a381-6b9bf6e11d37)
