### PR TITLE
Log stack trace for warnings

### DIFF
--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -24,6 +24,8 @@ import { isAutoStartEnabled } from './modules/auto-start';
 import { init as initTorModule } from './modules/tor';
 import { ipcMain } from './typed-electron';
 
+process.traceProcessWarnings = true;
+
 // @ts-expect-error using internal electron API to set suite version in dev mode correctly
 if (isDevEnv) app.setVersion(process.env.VERSION);
 


### PR DESCRIPTION
## Description

Use electron's `traceProcessWarnings` to print stack traces together with node warnings, which could help a bit with identifying memory leaks, e.g. [MaxListenersExceededWarning](https://satoshilabs.sentry.io/issues/6299321428/events/acc835cb10924eca894728cf703849d0).

This is just a proposal, take it or leave it. Cc: @MiroslavProchazka 
