### PR TITLE
Repo: move connect lib to es2022

### DIFF
--- a/packages/connect-plugin-ethereum/tsconfig.lib.json
+++ b/packages/connect-plugin-ethereum/tsconfig.lib.json
@@ -1,8 +1,7 @@
 {
     "extends": "../../tsconfig.lib.json",
     "compilerOptions": {
-        "outDir": "lib",
-        "lib": ["ES2019"]
+        "outDir": "lib"
     },
     "include": ["./src"],
     "references": []

--- a/packages/connect-web/tsconfig.lib.json
+++ b/packages/connect-web/tsconfig.lib.json
@@ -2,7 +2,6 @@
     "extends": "../../tsconfig.lib.json",
     "compilerOptions": {
         "outDir": "lib",
-        "target": "es2017",
         "types": ["chrome", "w3c-web-usb"]
     },
     "include": ["./src"],

--- a/packages/connect-webextension/tsconfig.lib.json
+++ b/packages/connect-webextension/tsconfig.lib.json
@@ -2,7 +2,6 @@
     "extends": "../../tsconfig.lib.json",
     "compilerOptions": {
         "outDir": "lib",
-        "target": "es2017",
         "types": ["chrome", "w3c-web-usb"]
     },
     "include": ["./src"],

--- a/packages/connect/tsconfig.lib.json
+++ b/packages/connect/tsconfig.lib.json
@@ -2,8 +2,7 @@
     "extends": "../../tsconfig.lib.json",
     "compilerOptions": {
         "outDir": "lib",
-        "target": "es2019",
-        "lib": ["es2019", "webworker"]
+        "lib": ["webworker"]
     },
     "include": ["./src"],
     "references": [

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -3,7 +3,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "moduleResolution": "node",
-        "target": "es6",
+        "target": "ES2022",
         "importHelpers": true,
 
         "composite": false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changing base `tsconfig.lib.json` to target ES2022. Since in connect we have added a new library that is only transpiled to ES2022 using some features that are only ES2022 therefore making connect also ES2022.
