### PR TITLE
feat(suite-desktop): open system settings using desktopApi

### DIFF
--- a/packages/suite-desktop-api/src/api.ts
+++ b/packages/suite-desktop-api/src/api.ts
@@ -109,6 +109,7 @@ export interface InvokeChannels {
     'connect-popup/ready': () => void;
     'connect-popup/response': (response: ConnectPopupResponse) => void;
     'system/get-system-information': () => InvokeResult<GetSystemInformationResponse>;
+    'system/open-settings': (settings: 'bluetooth') => InvokeResult;
 }
 
 type DesktopApiListener = ListenerMethod<RendererChannels>;
@@ -175,4 +176,5 @@ export interface DesktopApi {
     connectPopupResponse: DesktopApiInvoke<'connect-popup/response'>;
     //system
     getSystemInformation: DesktopApiInvoke<'system/get-system-information'>;
+    openSystemSettings: DesktopApiInvoke<'system/open-settings'>;
 }

--- a/packages/suite-desktop-api/src/factory.ts
+++ b/packages/suite-desktop-api/src/factory.ts
@@ -183,5 +183,6 @@ export const factory = <R extends StrictIpcRenderer<any, IpcRendererEvent>>(
         connectPopupResponse: response => ipcRenderer.invoke('connect-popup/response', response),
 
         getSystemInformation: () => ipcRenderer.invoke('system/get-system-information'),
+        openSystemSettings: settings => ipcRenderer.invoke('system/open-settings', settings),
     };
 };

--- a/packages/suite-desktop-core/src/modules/index.ts
+++ b/packages/suite-desktop-core/src/modules/index.ts
@@ -30,6 +30,7 @@ import * as requestInterceptor from './request-interceptor';
 import * as shortcuts from './shortcuts';
 import * as store from './store';
 import * as systemInformation from './system-information';
+import * as systemSettings from './system-settings';
 import * as theme from './theme';
 import * as tray from './tray';
 import * as trezorConnect from './trezor-connect';
@@ -63,6 +64,7 @@ const MODULES: Module[] = [
     autoStart,
     bridge,
     systemInformation,
+    systemSettings,
     // Modules used only in dev/prod mode
     ...(isDevEnv ? [] : [csp, fileProtocol]),
 ];

--- a/packages/suite-desktop-core/src/modules/system-settings.ts
+++ b/packages/suite-desktop-core/src/modules/system-settings.ts
@@ -1,0 +1,56 @@
+import { exec } from 'child_process';
+
+import { isLinux, isMacOs, isWindows } from '@trezor/env-utils';
+import { InvokeResult } from '@trezor/suite-desktop-api';
+
+import { ipcMain } from '../typed-electron';
+
+import type { ModuleInit } from './index';
+
+export const SERVICE_NAME = 'system-settings';
+
+const openSettings = (cmd: string, env?: Record<string, string>) =>
+    new Promise<InvokeResult>(resolve => {
+        exec(cmd, { env: { ...process.env, ...env } }, error => {
+            if (error) {
+                resolve({ success: false, error: error.toString() });
+            } else {
+                resolve({ success: true });
+            }
+        });
+    });
+
+const openBluetoothSettings = () => {
+    if (isLinux()) {
+        // https://github.com/electron/electron/blob/ab2a4fd836d539194bc5cde5f0d665eddeb6a134/docs/api/environment-variables.md?plain=1#L190
+        // Electron modifies the value of XDG_CURRENT_DESKTOP
+        const xdg = process.env.ORIGINAL_XDG_CURRENT_DESKTOP || process.env.XDG_CURRENT_DESKTOP;
+        if (xdg?.includes('GNOME')) {
+            return openSettings('gnome-control-center bluetooth', {
+                XDG_CURRENT_DESKTOP: xdg,
+            });
+        } else if (xdg?.includes('KDE')) {
+            return openSettings('systemsettings5', {
+                XDG_CURRENT_DESKTOP: xdg,
+            });
+        }
+    }
+    if (isMacOs()) {
+        return openSettings('open "x-apple.systempreferences:com.apple.Bluetooth"');
+    }
+    if (isWindows()) {
+        return openSettings('start ms-settings:bluetooth');
+    }
+
+    return { success: false, error: 'Unsupported os' };
+};
+
+export const init: ModuleInit = () => {
+    ipcMain.handle('system/open-settings', (_, settings) => {
+        if (settings === 'bluetooth') {
+            return openBluetoothSettings();
+        }
+
+        return { success: false, error: `Unknown settings: ${settings}` };
+    });
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Another cherry pick from the `bluetooth` branch.
Open system settings using desktopApi.

Originally i did it only for the bluetooth module but then i realized it could be also used to open other settings, like for example camera settings if it was once declined (useful especially on macos) 

tested on linux ubuntu gnome, debian gnome, macos and windows, i didnt tried KDE or any other

