### PR TITLE
Refactor e2e trading tests

### DIFF
--- a/packages/suite-desktop-core/e2e/fixtures/invity/index.ts
+++ b/packages/suite-desktop-core/e2e/fixtures/invity/index.ts
@@ -55,7 +55,7 @@ export const invityRequest = {
     sellWatchPayload,
 };
 
-export const invityResponses = {
+export const invityGeneralResponses = {
     [invityEndpoint.exchangeCoins]: exchangeCoins,
     [invityEndpoint.exchangeList]: exchangeList,
     [invityEndpoint.exchangeQuotes]: exchangeQuotes,

--- a/packages/suite-desktop-core/e2e/fixtures/invity/index.ts
+++ b/packages/suite-desktop-core/e2e/fixtures/invity/index.ts
@@ -1,5 +1,3 @@
-import { cloneDeep } from 'lodash';
-
 import buyList from './buy/list.json';
 import buyQuotesBTC from './buy/quotes-bitcoin.json';
 import buyQuotesEthereum from './buy/quotes-ethereum.json';
@@ -21,16 +19,12 @@ import sellList from './sell/list.json';
 import sellQuotesBTC from './sell/quotes-bitcoin.json';
 import sellQuotesEthereumToken from './sell/quotes-ethereum-token.json';
 import sellQuotesSolana from './sell/quotes-solana.json';
-import sellQuotesPayload from './sell/requests/quotes-request.json';
 import sellTradePayload from './sell/requests/trade-request.json';
 import sellWatchPayload from './sell/requests/watch-request.json';
 import sellTradeBTC from './sell/trade-bitcoin.json';
 import sellTradeEthereumToken from './sell/trade-ethereum-token.json';
 import sellTradeSolana from './sell/trade-solana.json';
 import sellWatch from './sell/watch.json';
-//Payloads
-//Types
-import { SellTradeResponse, TradeResponse } from './types';
 
 const invityUrl = 'https://exchange.trezor.io';
 
@@ -55,7 +49,6 @@ export const invityRequest = {
     buyTradeBTCPayload,
     buyTradeSolanaPayload,
     buyWatchPayload,
-    sellQuotesPayload,
     sellTradePayload,
     sellWatchPayload,
 };
@@ -71,23 +64,6 @@ export const invityResponses = {
     [invityEndpoint.buyWatch]: buyWatch,
     [invityEndpoint.sellList]: sellList,
     [invityEndpoint.sellWatch]: sellWatch,
-};
-
-// This modification allows us to skip the provider's part of the flow and continue further.
-export const createRedirectedTradeResponse = (
-    tradeResponse: TradeResponse | SellTradeResponse,
-    tradeRequest: any,
-) => {
-    const modifiedResponse = cloneDeep(tradeResponse);
-    modifiedResponse.trade.partnerData = tradeRequest.returnUrl;
-    modifiedResponse.tradeForm.form.formAction = tradeRequest.returnUrl;
-    modifiedResponse.trade.paymentId = tradeRequest.trade.paymentId;
-    modifiedResponse.trade.orderId = tradeRequest.trade.orderId;
-    if ('refundAddress' in modifiedResponse.trade && tradeRequest.refundAddress) {
-        modifiedResponse.trade.refundAddress = tradeRequest.refundAddress;
-    }
-
-    return modifiedResponse;
 };
 
 export const getCompanyNameFromList = (name: string, type: 'buyList' | 'sellList') => {

--- a/packages/suite-desktop-core/e2e/fixtures/invity/index.ts
+++ b/packages/suite-desktop-core/e2e/fixtures/invity/index.ts
@@ -24,7 +24,9 @@ import sellWatchPayload from './sell/requests/watch-request.json';
 import sellTradeBTC from './sell/trade-bitcoin.json';
 import sellTradeEthereumToken from './sell/trade-ethereum-token.json';
 import sellTradeSolana from './sell/trade-solana.json';
-import sellWatch from './sell/watch.json';
+import sellWatchBTC from './sell/watch-bitcoin.json';
+import sellWatchEthereum from './sell/watch-ethereum.json';
+import sellWatchSolana from './sell/watch-solana.json';
 
 const invityUrl = 'https://exchange.trezor.io';
 
@@ -63,7 +65,6 @@ export const invityResponses = {
     [invityEndpoint.buyList]: buyList,
     [invityEndpoint.buyWatch]: buyWatch,
     [invityEndpoint.sellList]: sellList,
-    [invityEndpoint.sellWatch]: sellWatch,
 };
 
 export const getCompanyNameFromList = (name: string, type: 'buyList' | 'sellList') => {
@@ -101,5 +102,7 @@ export {
     sellTradeBTC,
     sellTradeEthereumToken,
     sellTradeSolana,
-    sellWatch,
+    sellWatchBTC,
+    sellWatchEthereum,
+    sellWatchSolana,
 };

--- a/packages/suite-desktop-core/e2e/fixtures/invity/sell/requests/quotes-request.json
+++ b/packages/suite-desktop-core/e2e/fixtures/invity/sell/requests/quotes-request.json
@@ -1,9 +1,0 @@
-{
-    "amountInCrypto": true,
-    "cryptoCurrency": "bitcoin",
-    "fiatCurrency": "EUR",
-    "country": "CZ",
-    "cryptoStringAmount": "0.00065",
-    "fiatStringAmount": "",
-    "flows": ["BANK_ACCOUNT", "PAYMENT_GATE"]
-}

--- a/packages/suite-desktop-core/e2e/fixtures/invity/sell/watch-bitcoin.json
+++ b/packages/suite-desktop-core/e2e/fixtures/invity/sell/watch-bitcoin.json
@@ -1,0 +1,5 @@
+{
+    "status": "SEND_CRYPTO",
+    "destinationAddress": "bc1qftjj5a3s8emtxhexlgpne5d7zp26qsjfxhhgfu",
+    "destinationPaymentExtraId": "6d666a5f-b99c-4482-b8bc-2df04fc11b7b"
+}

--- a/packages/suite-desktop-core/e2e/fixtures/invity/sell/watch-ethereum.json
+++ b/packages/suite-desktop-core/e2e/fixtures/invity/sell/watch-ethereum.json
@@ -1,5 +1,5 @@
 {
     "status": "SEND_CRYPTO",
-    "destinationAddress": "bc1q3tzqaakjpjdljaudkhusr95s23fl48wh4xdmvy",
+    "destinationAddress": "0xF93b32f856d44B7E4AcFa209862f43b8f49bAb67",
     "destinationPaymentExtraId": "6d666a5f-b99c-4482-b8bc-2df04fc11b7b"
 }

--- a/packages/suite-desktop-core/e2e/fixtures/invity/sell/watch-solana.json
+++ b/packages/suite-desktop-core/e2e/fixtures/invity/sell/watch-solana.json
@@ -1,0 +1,5 @@
+{
+    "status": "SEND_CRYPTO",
+    "destinationAddress": "ENk2eeP4umP6cjAGRsVG4NEVKEVQmRn6JEpN8hubv2Hf",
+    "destinationPaymentExtraId": "6d666a5f-b99c-4482-b8bc-2df04fc11b7b"
+}

--- a/packages/suite-desktop-core/e2e/support/fixtures.ts
+++ b/packages/suite-desktop-core/e2e/support/fixtures.ts
@@ -14,6 +14,7 @@ import {
 import { IndexedDbFixture } from './indexedDb';
 import { BlockbookMock } from './mocks/blockBookMock';
 import { MetadataProviderMock } from './mocks/metadataProviderMock';
+import { TradingMock } from './mocks/tradingMock';
 import { AnalyticsActions } from './pageActions/analyticsActions';
 import { AssetsActions } from './pageActions/assetsActions';
 import { DashboardActions } from './pageActions/dashboardActions';
@@ -54,6 +55,7 @@ type Fixtures = {
     indexedDb: IndexedDbFixture;
     metadataProviderMock: MetadataProviderMock;
     blockbookMock: BlockbookMock;
+    tradingMock: TradingMock;
     exceptionLogger: void;
 };
 
@@ -211,6 +213,10 @@ const test = base.extend<Fixtures>({
     blockbookMock: async ({}, use) => {
         const blockbookMock = new BlockbookMock();
         await use(blockbookMock);
+    },
+    tradingMock: async ({ page }, use) => {
+        const tradingMock = new TradingMock(page);
+        await use(tradingMock);
     },
     exceptionLogger: [
         async ({ page }, use) => {

--- a/packages/suite-desktop-core/e2e/support/mocks/tradingMock.ts
+++ b/packages/suite-desktop-core/e2e/support/mocks/tradingMock.ts
@@ -1,0 +1,99 @@
+import { Page } from '@playwright/test';
+import { cloneDeep } from 'lodash';
+
+import { invityEndpoint, invityResponses } from '../../fixtures/invity';
+import { SellTradeResponse, TradeResponse } from '../../fixtures/invity/types';
+import {
+    getSignatureStatusesResponse,
+    sendTransactionResponse,
+} from '../../fixtures/solana-responses';
+import { step } from '../common';
+
+export class TradingMock {
+    constructor(private page: Page) {
+        this.validatePassphraseEnv();
+    }
+
+    @step()
+    async routeInvityGeneralEndpoints() {
+        for (const [url, response] of Object.entries(invityResponses)) {
+            await this.page.route(url, async route => {
+                await route.fulfill({ json: response });
+            });
+        }
+    }
+
+    // We bypass the provider part of the flow by having a modified redirect in trade response.
+    // This redirect is provided by Invity and normaly leads to provider's page.
+    // But our mocked response redirects us to transaction detail where our flow continues.
+    @step()
+    async routeTrade(endpointUrl: string, tradeResponse: TradeResponse | SellTradeResponse) {
+        await this.routeInvityGeneralEndpoints();
+        await this.page.route(endpointUrl, async (route, request) => {
+            const redirectedTradeResponse = this.createRedirectedTradeResponse(
+                tradeResponse,
+                request.postDataJSON(),
+            );
+            await route.fulfill({ json: redirectedTradeResponse });
+        });
+    }
+
+    @step()
+    async routeSolanaSendRequests() {
+        const solUrlPattern = /^https:\/\/sol\d+\.trezor\.io\//;
+        await this.page.route(solUrlPattern, (route, request) => {
+            const method = request.method();
+            const postData = request.postData();
+
+            if (method === 'POST' && postData) {
+                const postDataJson = JSON.parse(postData);
+
+                //IMPORTANT: Mocking this request prevents from actually sending crypto
+                if (postDataJson.method === 'sendTransaction') {
+                    route.fulfill({ json: sendTransactionResponse(postDataJson.id) });
+
+                    return;
+                }
+
+                if (postDataJson.method === 'getSignatureStatuses') {
+                    route.fulfill({ json: getSignatureStatusesResponse(postDataJson.id) });
+
+                    return;
+                }
+            }
+            route.continue();
+        });
+    }
+
+    @step()
+    async changeBuyWatchResponseTo(status: 'SUBMITTED' | 'SUCCESS') {
+        await this.page.route(invityEndpoint.buyWatch, async route => {
+            await route.fulfill({ json: { status } });
+        });
+    }
+
+    // This modification allows us to skip the provider's part of the flow and continue further.
+    createRedirectedTradeResponse = (
+        tradeResponse: TradeResponse | SellTradeResponse,
+        tradeRequest: any,
+    ) => {
+        const modifiedResponse = cloneDeep(tradeResponse);
+        modifiedResponse.trade.partnerData = tradeRequest.returnUrl;
+        modifiedResponse.tradeForm.form.formAction = tradeRequest.returnUrl;
+        modifiedResponse.trade.paymentId = tradeRequest.trade.paymentId;
+        modifiedResponse.trade.orderId = tradeRequest.trade.orderId;
+        if ('refundAddress' in modifiedResponse.trade && tradeRequest.refundAddress) {
+            modifiedResponse.trade.refundAddress = tradeRequest.refundAddress;
+        }
+
+        return modifiedResponse;
+    };
+
+    validatePassphraseEnv = () => {
+        if (!process.env.PASSPHRASE) {
+            throw new Error(
+                'PASSPHRASE not provided in env variables. Check docs/tests/e2e-playwright-suite.md.',
+            );
+        }
+    };
+}

--- a/packages/suite-desktop-core/e2e/support/mocks/tradingMock.ts
+++ b/packages/suite-desktop-core/e2e/support/mocks/tradingMock.ts
@@ -1,7 +1,7 @@
 import { Page } from '@playwright/test';
 import { cloneDeep } from 'lodash';
 
-import { invityEndpoint, invityResponses } from '../../fixtures/invity';
+import { invityEndpoint, invityGeneralResponses } from '../../fixtures/invity';
 import { SellTradeResponse, TradeResponse } from '../../fixtures/invity/types';
 import {
     getSignatureStatusesResponse,
@@ -14,9 +14,10 @@ export class TradingMock {
         this.validatePassphraseEnv();
     }
 
+    // Common responses for all trading tests.
     @step()
     async routeInvityGeneralEndpoints() {
-        for (const [url, response] of Object.entries(invityResponses)) {
+        for (const [url, response] of Object.entries(invityGeneralResponses)) {
             await this.page.route(url, async route => {
                 await route.fulfill({ json: response });
             });
@@ -38,6 +39,9 @@ export class TradingMock {
         });
     }
 
+    // Solana sell flow uses Solana provider to send transactions.
+    // We mock these requests to prevent sending real transactions.
+    // Thanks to that we are able to test the whole sell flow without sending real crypto.
     @step()
     async routeSolanaSendRequests() {
         const solUrlPattern = /^https:\/\/sol\d+\.trezor\.io\//;
@@ -73,6 +77,7 @@ export class TradingMock {
     }
 
     // This modification allows us to skip the provider's part of the flow and continue further.
+    // Partner's URL is replaced with Suite's URL redirect. And we also set correct Ids
     createRedirectedTradeResponse = (
         tradeResponse: TradeResponse | SellTradeResponse,
         tradeRequest: any,

--- a/packages/suite-desktop-core/e2e/support/mocks/tradingMock.ts
+++ b/packages/suite-desktop-core/e2e/support/mocks/tradingMock.ts
@@ -25,7 +25,7 @@ export class TradingMock {
 
     // We bypass the provider part of the flow by having a modified redirect in trade response.
     // This redirect is provided by Invity and normaly leads to provider's page.
-    // But our mocked response redirects us to transaction detail where our flow continues.
+    // But our mocked response redirects us to back to Suite where our flow continues.
     @step()
     async routeTrade(endpointUrl: string, tradeResponse: TradeResponse | SellTradeResponse) {
         await this.routeInvityGeneralEndpoints();

--- a/packages/suite-desktop-core/e2e/support/pageActions/marketActions.ts
+++ b/packages/suite-desktop-core/e2e/support/pageActions/marketActions.ts
@@ -4,16 +4,10 @@ import { FiatCurrencyCode } from '@suite-common/suite-config';
 import { regional } from '@suite-common/trading';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 
-import {
-    buyQuotesBTC,
-    createRedirectedTradeResponse,
-    invityEndpoint,
-    invityResponses,
-} from '../../fixtures/invity';
+import { buyQuotesBTC, invityEndpoint } from '../../fixtures/invity';
 import { TrezorUserEnvLinkProxy, step } from '../common';
 import { expect } from '../customMatchers';
 import { DevicePromptActions } from './devicePromptActions';
-import { SellTradeResponse, TradeResponse } from '../../fixtures/invity/types';
 
 const quoteProviderLocator = '@trading/offers/quote/provider';
 const quoteAmountLocator = '@trading/offers/quote/crypto-amount';
@@ -238,7 +232,7 @@ export class MarketActions {
     }
 
     @step()
-    async setYouPayAmount(
+    async setYouBuyAmount(
         amount: string,
         cryptoCurrency: string = 'bitcoin',
         wantCrypto: boolean = false,
@@ -265,6 +259,28 @@ export class MarketActions {
     }
 
     @step()
+    async setYouSellAmount(
+        amount: string,
+        cryptoCurrency: string = 'bitcoin',
+        fiatCurrencyCode: FiatCurrencyCode = 'eur',
+        country: string = 'CZ',
+    ) {
+        await this.selectCountryOfResidence(country);
+        const quoteRequestPromise = this.page.waitForRequest(invityEndpoint.sellQuotes);
+        await this.youPayCryptoInput.fill(amount);
+        await expect(quoteRequestPromise).toHavePayload({
+            amountInCrypto: true,
+            cryptoCurrency,
+            fiatCurrency: fiatCurrencyCode.toUpperCase(),
+            country,
+            cryptoStringAmount: amount,
+            fiatStringAmount: '',
+            flows: ['BANK_ACCOUNT', 'PAYMENT_GATE'],
+        });
+        await this.waitForSellOffersSync();
+    }
+
+    @step()
     async confirmTrade(addressToCheck?: string) {
         await expect(this.modal).toBeVisible();
         await this.buyTermsConfirmButton.click();
@@ -277,34 +293,17 @@ export class MarketActions {
         await this.devicePrompt.confirmOnDevicePromptIsHidden();
     }
 
-    // We bypass the provider part of the flow by having a modified redirect in trade response.
-    // This redirect is provided by Invity and normaly leads to provider's page.
-    // But our mocked response redirects us to transaction detail where our flow continues.
     @step()
-    async mockInvityTrade(tradeResponse: TradeResponse | SellTradeResponse, endpointUrl: string) {
-        await this.page.route(endpointUrl, async (route, request) => {
-            const redirectedTradeResponse = createRedirectedTradeResponse(
-                tradeResponse,
-                request.postDataJSON(),
-            );
-            await route.fulfill({ json: redirectedTradeResponse });
-        });
-    }
-
-    @step()
-    async mockInvity() {
-        for (const [url, response] of Object.entries(invityResponses)) {
-            await this.page.route(url, async route => {
-                await route.fulfill({ json: response });
-            });
-        }
-    }
-
-    @step()
-    async changeBuyWatchResponseTo(status: 'SUBMITTED' | 'SUCCESS') {
-        await this.page.route(invityEndpoint.buyWatch, async route => {
-            await route.fulfill({ json: { status } });
-        });
+    async initiateSendConfirmation() {
+        await this.confirmTradeButton.click();
+        await expect(this.devicePrompt.sellButton).toBeDisabled();
+        await this.devicePrompt.confirmOnDevicePromptIsShown();
+        await TrezorUserEnvLinkProxy.pressYes();
+        await this.devicePrompt.confirmOnDevicePromptIsShown();
+        await TrezorUserEnvLinkProxy.pressYes();
+        // Note: We intentionally skip clicking the sell button in tests to prevent actual cryptocurrency transactions.
+        // In a real scenario, the user would complete the transaction by clicking this button.
+        await expect(this.devicePrompt.sellButton).toBeEnabled();
     }
 
     @step()
@@ -332,5 +331,11 @@ export class MarketActions {
             expect.soft(provider?.toLowerCase()).toBe(expectedQuotes[index].exchange);
             expect.soft(amount).toBe(expectedQuotes[index].receiveStringAmount);
         }
+    }
+
+    @step()
+    async waitForRedirectCompletion() {
+        await expect(this.page.getByText('Buy & sell')).not.toBeVisible();
+        await expect(this.page.getByText('Buy & sell')).toBeVisible({ timeout: 15000 });
     }
 }

--- a/packages/suite-desktop-core/e2e/support/pageActions/marketActions.ts
+++ b/packages/suite-desktop-core/e2e/support/pageActions/marketActions.ts
@@ -90,6 +90,7 @@ export class MarketActions {
     readonly confirmationProvider: Locator;
     readonly confirmationAddress: Locator;
     readonly confirmationPaymentMethod: Locator;
+    readonly confirmationPaymentId: Locator;
     readonly confirmTradeButton: Locator;
     // Exchange
     readonly exchangeFeeDetails: Locator;
@@ -108,6 +109,7 @@ export class MarketActions {
     readonly watchPeriod = '00:30';
     // Sell
     readonly formSellButton: Locator;
+    readonly detailSellStatus: Locator;
 
     constructor(private page: Page) {
         this.devicePrompt = new DevicePromptActions(page);
@@ -162,6 +164,7 @@ export class MarketActions {
         this.confirmationProvider = this.page.getByTestId('@trading/form/info/provider');
         this.confirmationAddress = this.page.getByTestId('@trading/form/verify/address');
         this.confirmationPaymentMethod = this.page.getByTestId('@trading/form/info/payment-method');
+        this.confirmationPaymentId = this.page.getByTestId('@trading/form/verify/extra-id');
         this.confirmTradeButton = this.page.getByTestId(
             '@trading/offer/continue-transaction-button',
         );
@@ -178,6 +181,7 @@ export class MarketActions {
         this.proceedToPayButton = this.page.getByRole('button', { name: 'Proceed to pay' });
         this.transactionDetail = this.page.getByTestId('@trading/transaction/detail');
         this.formSellButton = this.page.getByTestId('@trading/form/sell-button');
+        this.detailSellStatus = this.page.getByTestId('@trading/detail-sell/status');
     }
 
     @step()

--- a/packages/suite-desktop-core/e2e/support/pageActions/walletActions.ts
+++ b/packages/suite-desktop-core/e2e/support/pageActions/walletActions.ts
@@ -118,14 +118,14 @@ export class WalletActions {
     @step()
     async openTrading(params: WalletParams = {}) {
         await this.accountButton(params).click();
-        //TODO: #16073 We cannot set resolution for Electron. on CI button is hidden under dropdown due to a breakpoint
-        const isBuyButtonHidden = !(await this.tradingBuyButton.isVisible());
-        if (isBuyButtonHidden) {
-            await this.walletExtraDropDown.click();
-            await this.tradingDropdownBuyButton.click();
-        } else {
-            await this.tradingBuyButton.click();
-        }
+        await this.tradingBuyButton.click();
+    }
+
+    @step()
+    async openSellTradingOfToken(symbol: NetworkSymbol, tokenName: string) {
+        await this.accountButton({ symbol, tokens: true }).click();
+        await this.page.getByRole('row', { name: tokenName }).getByRole('button').first().click();
+        await this.page.getByTestId('@trading/tokens/sell-button').click();
     }
 
     @step()

--- a/packages/suite-desktop-core/e2e/tests/trading/buy-bitcoin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/buy-bitcoin.test.ts
@@ -16,12 +16,11 @@ const formattedFiatAmount = `CZK ${localizeNumber(fiatAmount, 'en', 2)}`;
 const { receiveAddress, paymentMethodName } = buyTradeBTC.trade;
 
 test.describe('Trading - Buy BTC', { tag: ['@group=other', '@webOnly'] }, () => {
-    test.beforeEach(async ({ page, marketPage, onboardingPage, dashboardPage, walletPage }) => {
-        await marketPage.mockInvity();
-        await marketPage.mockInvityTrade(buyTradeBTC, invityEndpoint.buyTrade);
+    test.beforeEach(async ({ page, tradingMock, onboardingPage, dashboardPage, walletPage }) => {
         await page.route(invityEndpoint.buyQuotes, async route => {
             await route.fulfill({ json: buyQuotesBTC });
         });
+        await tradingMock.routeTrade(invityEndpoint.buyTrade, buyTradeBTC);
         await onboardingPage.completeOnboarding();
         await dashboardPage.discoveryShouldFinish();
         await walletPage.openTrading();
@@ -29,7 +28,7 @@ test.describe('Trading - Buy BTC', { tag: ['@group=other', '@webOnly'] }, () => 
 
     test('Buy Bitcoin from compared offer', async ({ marketPage }) => {
         await test.step('Fill input amount and opens offer comparison', async () => {
-            await marketPage.setYouPayAmount(fiatAmount);
+            await marketPage.setYouBuyAmount(fiatAmount);
             await expect(marketPage.bestOfferAmount).toHaveText(bestBuyCryptoAmount);
             await expect(marketPage.quoteProvider).toHaveText(bestBuyProvider);
             await marketPage.compareButton.click();
@@ -54,9 +53,9 @@ test.describe('Trading - Buy BTC', { tag: ['@group=other', '@webOnly'] }, () => 
         });
     });
 
-    test('Buy Bitcoin from best offer', async ({ page, marketPage }) => {
+    test('Buy Bitcoin from best offer', async ({ page, marketPage, tradingMock }) => {
         await test.step('Request a trade', async () => {
-            await marketPage.setYouPayAmount(fiatAmount);
+            await marketPage.setYouBuyAmount(fiatAmount);
             await marketPage.buyBestOfferButton.click();
             await marketPage.confirmTrade();
         });
@@ -64,7 +63,7 @@ test.describe('Trading - Buy BTC', { tag: ['@group=other', '@webOnly'] }, () => 
         await page.clock.install();
 
         await test.step('Confirm the trade and get redirected to transaction detail', async () => {
-            await marketPage.changeBuyWatchResponseTo('SUBMITTED');
+            await tradingMock.changeBuyWatchResponseTo('SUBMITTED');
             const tradeRequestPromise = page.waitForRequest(invityEndpoint.buyTrade);
             const watchRequestPromise = page.waitForRequest(invityEndpoint.buyWatch);
             await marketPage.confirmTradeButton.click();
@@ -81,7 +80,7 @@ test.describe('Trading - Buy BTC', { tag: ['@group=other', '@webOnly'] }, () => 
         });
 
         await test.step('Wait 30s for watch refresh and change of status to Approved', async () => {
-            await marketPage.changeBuyWatchResponseTo('SUCCESS');
+            await tradingMock.changeBuyWatchResponseTo('SUCCESS');
             await page.clock.fastForward(marketPage.watchPeriod);
             await expect(marketPage.transactionDetailStatus).toHaveText('Approved');
             await expect(marketPage.confirmationFiatAmount).toHaveText(formattedFiatAmount);

--- a/packages/suite-desktop-core/e2e/tests/trading/buy-bitcoin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/buy-bitcoin.test.ts
@@ -79,7 +79,7 @@ test.describe('Trading - Buy BTC', { tag: ['@group=other', '@webOnly'] }, () => 
             await expect(marketPage.proceedToPayButton).toBeVisible();
         });
 
-        await test.step('Wait 30s for watch refresh and change of status to Approved', async () => {
+        await test.step('Wait 30s for watch refresh and status change to Approved', async () => {
             await tradingMock.changeBuyWatchResponseTo('SUCCESS');
             await page.clock.fastForward(marketPage.watchPeriod);
             await expect(marketPage.transactionDetailStatus).toHaveText('Approved');

--- a/packages/suite-desktop-core/e2e/tests/trading/buy-ethereum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/buy-ethereum.test.ts
@@ -13,12 +13,11 @@ const formattedFiatAmount = `CZK ${localizeNumber(fiatAmount, 'en', 2)}`;
 const { receiveAddress, paymentMethodName } = buyTradeEthereum.trade;
 
 test.describe('Trading - Buy Ethereum', { tag: ['@group=other', '@webOnly'] }, () => {
-    test.beforeEach(async ({ page, marketPage, onboardingPage, dashboardPage }) => {
-        await marketPage.mockInvity();
-        await marketPage.mockInvityTrade(buyTradeEthereum, invityEndpoint.buyTrade);
+    test.beforeEach(async ({ page, tradingMock, onboardingPage, dashboardPage }) => {
         await page.route(invityEndpoint.buyQuotes, async route => {
             await route.fulfill({ json: buyQuotesEthereum });
         });
+        await tradingMock.routeTrade(invityEndpoint.buyTrade, buyTradeEthereum);
         await onboardingPage.completeOnboarding();
         await dashboardPage.discoveryShouldFinish();
     });
@@ -35,7 +34,7 @@ test.describe('Trading - Buy Ethereum', { tag: ['@group=other', '@webOnly'] }, (
         await test.step('Request to buy Ethereum', async () => {
             await walletPage.tradingBuyButton.click();
             await marketPage.selectAccount('Ethereum', 'eth');
-            await marketPage.setYouPayAmount(fiatAmount, 'ethereum');
+            await marketPage.setYouBuyAmount(fiatAmount, 'ethereum');
             await expect(marketPage.bestOfferAmount).toHaveText(formattedCryptoAmount);
             await expect(marketPage.quoteProvider).toHaveText(provider);
             await marketPage.buyBestOfferButton.click();
@@ -80,10 +79,10 @@ test.describe('Trading - Buy Ethereum', { tag: ['@group=other', '@webOnly'] }, (
             //     await marketPage.confirmTradeButton.click();
             // });
 
+            // await marketPage.waitForRedirectCompletion();
+
             // await test.step('Verify transaction detail', async () => {
-            //     await expect(marketPage.transactionDetailStatus).toHaveText('Approved', {
-            //         timeout: 15_000,
-            //     });
+            //     await expect(marketPage.transactionDetailStatus).toHaveText('Approved');
             //     await expect(marketPage.confirmationFiatAmount).toHaveText(formattedFiatAmount);
             //     await expect(marketPage.confirmationCryptoAmount).toHaveText(formattedCryptoAmount);
             //     await expect(marketPage.confirmationProvider).toHaveText(provider);

--- a/packages/suite-desktop-core/e2e/tests/trading/buy-solana-token.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/buy-solana-token.test.ts
@@ -19,30 +19,26 @@ const formattedFiatAmount = `CZK ${fiatAmount}`;
 const { receiveAddress, paymentMethodName } = buyTradeSolanaToken.trade;
 
 test.describe('Trading - Buy Solana', { tag: ['@group=other', '@webOnly'] }, () => {
-    test.beforeEach(async ({ page, tradingMock, onboardingPage, dashboardPage }) => {
-        await page.route(invityEndpoint.buyQuotes, async route => {
-            await route.fulfill({ json: buyQuotesSolanaToken });
-        });
-        await tradingMock.routeTrade(invityEndpoint.buyTrade, buyTradeSolanaToken);
-        await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
-    });
-
-    test('Buy Solana Jupiter token - amount specified in crypto', async ({
-        page,
-        settingsPage,
-        dashboardPage,
-        walletPage,
-        marketPage,
-    }) => {
-        await test.step('Enable Solana and open its trading', async () => {
-            await settingsPage.navigateTo('coins');
-            await settingsPage.coins.enableNetwork('sol');
-            await dashboardPage.navigateTo();
+    test.beforeEach(
+        async ({ page, tradingMock, onboardingPage, settingsPage, walletPage, dashboardPage }) => {
+            await page.route(invityEndpoint.buyQuotes, async route => {
+                await route.fulfill({ json: buyQuotesSolanaToken });
+            });
+            await tradingMock.routeTrade(invityEndpoint.buyTrade, buyTradeSolanaToken);
+            await onboardingPage.completeOnboarding();
             await dashboardPage.discoveryShouldFinish();
-            await walletPage.openTrading({ symbol: 'sol' });
-        });
 
+            await test.step('Enable Solana and open its trading', async () => {
+                await settingsPage.navigateTo('coins');
+                await settingsPage.coins.enableNetwork('sol');
+                await dashboardPage.navigateTo();
+                await dashboardPage.discoveryShouldFinish();
+                await walletPage.openTrading({ symbol: 'sol' });
+            });
+        },
+    );
+
+    test('Buy Solana Jupiter token - amount specified in crypto', async ({ page, marketPage }) => {
         await test.step('Request a specific crypto amount of Jupiter token to buy', async () => {
             await marketPage.selectAccount('Jupiter', 'sol');
             await marketPage.waitForBuyOffersSync();

--- a/packages/suite-desktop-core/e2e/tests/trading/buy-solana-token.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/buy-solana-token.test.ts
@@ -19,12 +19,11 @@ const formattedFiatAmount = `CZK ${fiatAmount}`;
 const { receiveAddress, paymentMethodName } = buyTradeSolanaToken.trade;
 
 test.describe('Trading - Buy Solana', { tag: ['@group=other', '@webOnly'] }, () => {
-    test.beforeEach(async ({ page, marketPage, onboardingPage, dashboardPage }) => {
-        await marketPage.mockInvity();
-        await marketPage.mockInvityTrade(buyTradeSolanaToken, invityEndpoint.buyTrade);
+    test.beforeEach(async ({ page, tradingMock, onboardingPage, dashboardPage }) => {
         await page.route(invityEndpoint.buyQuotes, async route => {
             await route.fulfill({ json: buyQuotesSolanaToken });
         });
+        await tradingMock.routeTrade(invityEndpoint.buyTrade, buyTradeSolanaToken);
         await onboardingPage.completeOnboarding();
         await dashboardPage.discoveryShouldFinish();
     });
@@ -49,7 +48,7 @@ test.describe('Trading - Buy Solana', { tag: ['@group=other', '@webOnly'] }, () 
             await marketPage.waitForBuyOffersSync();
             await marketPage.youPayFiatCryptoSwitchButton.click();
             const isCryptoInput = true;
-            await marketPage.setYouPayAmount(
+            await marketPage.setYouBuyAmount(
                 cryptoAmount,
                 'solana--JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN',
                 isCryptoInput,
@@ -75,10 +74,10 @@ test.describe('Trading - Buy Solana', { tag: ['@group=other', '@webOnly'] }, () 
             });
         });
 
+        await marketPage.waitForRedirectCompletion();
+
         await test.step('Verify transaction detail', async () => {
-            await expect(marketPage.transactionDetailStatus).toHaveText('Approved', {
-                timeout: 15_000,
-            });
+            await expect(marketPage.transactionDetailStatus).toHaveText('Approved');
             await expect(marketPage.confirmationFiatAmount).toHaveText(formattedFiatAmount);
             await expect(marketPage.confirmationCryptoAmount).toHaveText(formattedCryptoAmount);
             await expect(marketPage.confirmationProvider).toHaveText(provider);

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-bitcoin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-bitcoin.test.ts
@@ -1,4 +1,3 @@
-import { MNEMONICS } from '@trezor/trezor-user-env-link';
 import { capitalizeFirstLetter } from '@trezor/utils';
 
 import {
@@ -23,7 +22,7 @@ const { paymentMethodName } = sellTradeBTC.trade;
 
 test.describe('Trading - Sell BTC', { tag: ['@group=other', '@webOnly'] }, () => {
     test.use({
-        emulatorSetupConf: { mnemonic: MNEMONICS.mnemonic_academic, passphrase_protection: true },
+        emulatorSetupConf: { mnemonic: 'mnemonic_academic', passphrase_protection: true },
     });
     test.beforeEach(
         async ({ page, marketPage, tradingMock, onboardingPage, dashboardPage, walletPage }) => {

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-bitcoin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-bitcoin.test.ts
@@ -1,3 +1,4 @@
+import { MNEMONICS } from '@trezor/trezor-user-env-link';
 import { capitalizeFirstLetter } from '@trezor/utils';
 
 import {
@@ -9,9 +10,6 @@ import {
     sellWatch,
 } from '../../fixtures/invity';
 import { expect, test } from '../../support/fixtures';
-
-const mnemonic =
-    'academic again academic academic academic academic academic academic academic academic academic academic academic academic academic academic academic pecan provide remember';
 
 // Expected values based on our mocked responses
 const fiatAmount = sellQuotesBTC[0].fiatStringAmount;
@@ -25,39 +23,26 @@ const { paymentMethodName } = sellTradeBTC.trade;
 
 test.describe('Trading - Sell BTC', { tag: ['@group=other', '@webOnly'] }, () => {
     test.use({
-        emulatorSetupConf: { mnemonic, passphrase_protection: true },
+        emulatorSetupConf: { mnemonic: MNEMONICS.mnemonic_academic, passphrase_protection: true },
     });
-    test.beforeEach(async ({ page, marketPage, onboardingPage, dashboardPage, walletPage }) => {
-        if (!process.env.PASSPHRASE) {
-            throw new Error(
-                'PASSPHRASE not provided in env variables. Check docs/tests/e2e-playwright-suite.md.',
-            );
-        }
-        await marketPage.mockInvity();
-        await marketPage.mockInvityTrade(sellTradeBTC, invityEndpoint.sellTrade);
-        await page.route(invityEndpoint.sellQuotes, async route => {
-            await route.fulfill({ json: sellQuotesBTC });
-        });
-        await onboardingPage.completeOnboarding();
-        await dashboardPage.discoveryShouldFinish();
-        await dashboardPage.deviceSwitchingOpenButton.click();
-        await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
-        await walletPage.openTrading();
-        await marketPage.sellTabButton.click();
-    });
+    test.beforeEach(
+        async ({ page, marketPage, tradingMock, onboardingPage, dashboardPage, walletPage }) => {
+            await page.route(invityEndpoint.sellQuotes, async route => {
+                await route.fulfill({ json: sellQuotesBTC });
+            });
+            await tradingMock.routeTrade(invityEndpoint.sellTrade, sellTradeBTC);
+            await onboardingPage.completeOnboarding();
+            await dashboardPage.discoveryShouldFinish();
+            await dashboardPage.deviceSwitchingOpenButton.click();
+            await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
+            await walletPage.openTrading();
+            await marketPage.sellTabButton.click();
+        },
+    );
 
-    test('Sell Bitcoin for best offer', async ({
-        page,
-        marketPage,
-        devicePrompt,
-        trezorUserEnvLink,
-    }) => {
+    test('Sell Bitcoin for best offer', async ({ page, marketPage, devicePrompt }) => {
         await test.step('Fill in a sell request', async () => {
-            await marketPage.selectCountryOfResidence('CZ');
-            const quoteRequestPromise = page.waitForRequest(invityEndpoint.sellQuotes);
-            await marketPage.youPayCryptoInput.fill(cryptoAmount);
-            await expect(quoteRequestPromise).toHavePayload(invityRequest.sellQuotesPayload);
-            await marketPage.waitForSellOffersSync();
+            await marketPage.setYouSellAmount(cryptoAmount);
             await expect(marketPage.bestOfferAmount).toHaveText(fiatAmount);
             await expect(marketPage.quoteProvider).toHaveText(capitalizeFirstLetter(provider));
         });
@@ -70,10 +55,8 @@ test.describe('Trading - Sell BTC', { tag: ['@group=other', '@webOnly'] }, () =>
                 omit: ['returnUrl', 'trade.orderId', 'trade.paymentId', 'trade.refundAddress'],
             });
         });
-        await test.step('Wait for the redirection to complete', async () => {
-            await expect(page.getByText('Buy & sell')).not.toBeVisible();
-            await expect(page.getByText('Buy & sell')).toBeVisible({ timeout: 15_000 });
-        });
+
+        await marketPage.waitForRedirectCompletion();
 
         await test.step('Verify all confirmation values', async () => {
             await expect(marketPage.confirmationFiatAmount).toHaveText(formattedFiatAmount);
@@ -88,16 +71,10 @@ test.describe('Trading - Sell BTC', { tag: ['@group=other', '@webOnly'] }, () =>
         });
 
         await test.step('Initiate send', async () => {
-            await marketPage.confirmTradeButton.click();
-            await expect(devicePrompt.sellButton).toBeDisabled();
-            await devicePrompt.confirmOnDevicePromptIsShown();
-            await trezorUserEnvLink.pressYes();
+            await marketPage.initiateSendConfirmation();
             await expect(devicePrompt.cryptoAmountOf('amount')).toHaveText(formattedCryptoAmount);
-            await devicePrompt.confirmOnDevicePromptIsShown();
-            await trezorUserEnvLink.pressYes();
-            // Note: We intentionally skip clicking the sell button in tests to prevent actual cryptocurrency transactions.
-            // In a real scenario, the user would complete the transaction by clicking this button.
-            await expect(devicePrompt.sellButton).toBeEnabled();
         });
+
+        // Rest of the flow is not implemented as we don't know how to mock the send request and actually not send the crypto
     });
 });

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-bitcoin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-bitcoin.test.ts
@@ -7,7 +7,7 @@ import {
     invityRequest,
     sellQuotesBTC,
     sellTradeBTC,
-    sellWatch,
+    sellWatchBTC,
 } from '../../fixtures/invity';
 import { expect, test } from '../../support/fixtures';
 
@@ -15,8 +15,8 @@ import { expect, test } from '../../support/fixtures';
 const fiatAmount = sellQuotesBTC[0].fiatStringAmount;
 const cryptoAmount = sellQuotesBTC[0].cryptoStringAmount;
 const provider = getCompanyNameFromList(sellQuotesBTC[0].exchange, 'sellList');
-const providerAddress = sellWatch.destinationAddress;
-const providerPaymentId = sellWatch.destinationPaymentExtraId;
+const providerAddress = sellWatchBTC.destinationAddress;
+const providerPaymentId = sellWatchBTC.destinationPaymentExtraId;
 const formattedCryptoAmount = `${cryptoAmount} BTC`;
 const formattedFiatAmount = `€${fiatAmount}`;
 const { paymentMethodName } = sellTradeBTC.trade;
@@ -27,10 +27,15 @@ test.describe('Trading - Sell BTC', { tag: ['@group=other', '@webOnly'] }, () =>
     });
     test.beforeEach(
         async ({ page, marketPage, tradingMock, onboardingPage, dashboardPage, walletPage }) => {
-            await page.route(invityEndpoint.sellQuotes, async route => {
-                await route.fulfill({ json: sellQuotesBTC });
+            await test.step('Mocking responses', async () => {
+                await page.route(invityEndpoint.sellQuotes, async route => {
+                    await route.fulfill({ json: sellQuotesBTC });
+                });
+                await tradingMock.routeTrade(invityEndpoint.sellTrade, sellTradeBTC);
+                await page.route(invityEndpoint.sellWatch, async route => {
+                    await route.fulfill({ json: sellWatchBTC });
+                });
             });
-            await tradingMock.routeTrade(invityEndpoint.sellTrade, sellTradeBTC);
             await onboardingPage.completeOnboarding();
             await dashboardPage.discoveryShouldFinish();
             await dashboardPage.deviceSwitchingOpenButton.click();
@@ -65,9 +70,7 @@ test.describe('Trading - Sell BTC', { tag: ['@group=other', '@webOnly'] }, () =>
             await expect(marketPage.confirmationPaymentMethod).toHaveText(paymentMethodName);
             await expect(marketPage.confirmationAddress).toHaveText(providerAddress);
             await expect(marketPage.confirmationAccount).toHaveText('Bitcoin #1');
-            await expect(page.getByTestId('@trading/form/verify/extra-id')).toHaveText(
-                providerPaymentId,
-            );
+            await expect(marketPage.confirmationPaymentId).toHaveText(providerPaymentId);
         });
 
         await test.step('Initiate send', async () => {

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum-token.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum-token.test.ts
@@ -1,4 +1,3 @@
-import { MNEMONICS } from '@trezor/trezor-user-env-link';
 import { capitalizeFirstLetter } from '@trezor/utils';
 
 import {
@@ -22,7 +21,7 @@ const provider = getCompanyNameFromList(sellQuotesEthereumToken[0].exchange, 'se
 
 test.describe('Trading - Sell Ethereum', { tag: ['@group=other', '@webOnly'] }, () => {
     test.use({
-        emulatorSetupConf: { mnemonic: MNEMONICS.mnemonic_academic, passphrase_protection: true },
+        emulatorSetupConf: { mnemonic: 'mnemonic_academic', passphrase_protection: true },
     });
     test.beforeEach(
         async ({ page, tradingMock, onboardingPage, dashboardPage, settingsPage, walletPage }) => {

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum-token.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum-token.test.ts
@@ -1,3 +1,4 @@
+import { MNEMONICS } from '@trezor/trezor-user-env-link';
 import { capitalizeFirstLetter } from '@trezor/utils';
 
 import {
@@ -8,52 +9,42 @@ import {
 } from '../../fixtures/invity';
 import { expect, test } from '../../support/fixtures';
 
-const mnemonic =
-    'academic again academic academic academic academic academic academic academic academic academic academic academic academic academic academic academic pecan provide remember';
-
 // Expected values based on our mocked responses
 const fiatAmount = sellQuotesEthereumToken[0].fiatStringAmount;
 const cryptoAmount = sellQuotesEthereumToken[0].cryptoStringAmount;
 const provider = getCompanyNameFromList(sellQuotesEthereumToken[0].exchange, 'sellList');
 // const providerAddress = sellWatch.destinationAddress;
 // const providerPaymentId = sellWatch.destinationPaymentExtraId;
-// const formattedCryptoAmount = `${cryptoAmount} BTC`;
+// const formattedCryptoAmount = `${cryptoAmount} ETH`;
 // const formattedFiatAmount = `€${fiatAmount}`;
-// const { paymentMethodName } = sellTradeBTC.trade;
+// const { paymentMethodName } = sellTradeEthereum.trade;
 
 test.describe('Trading - Sell Ethereum', { tag: ['@group=other', '@webOnly'] }, () => {
     test.use({
-        emulatorSetupConf: { mnemonic, passphrase_protection: true },
+        emulatorSetupConf: { mnemonic: MNEMONICS.mnemonic_academic, passphrase_protection: true },
     });
     test.beforeEach(
-        async ({ page, marketPage, onboardingPage, dashboardPage, settingsPage, walletPage }) => {
-            if (!process.env.PASSPHRASE) {
-                throw new Error(
-                    'PASSPHRASE not provided in env variables. Check docs/tests/e2e-playwright-suite.md.',
-                );
-            }
-            await marketPage.mockInvity();
-            await marketPage.mockInvityTrade(sellTradeEthereumToken, invityEndpoint.sellTrade);
+        async ({ page, tradingMock, onboardingPage, dashboardPage, settingsPage, walletPage }) => {
             await page.route(invityEndpoint.sellQuotes, async route => {
                 await route.fulfill({ json: sellQuotesEthereumToken });
             });
+            await tradingMock.routeTrade(invityEndpoint.sellTrade, sellTradeEthereumToken);
             await onboardingPage.completeOnboarding();
             await dashboardPage.discoveryShouldFinish();
             await settingsPage.navigateTo('coins');
             await settingsPage.coins.enableNetwork('eth');
             await dashboardPage.deviceSwitchingOpenButton.click();
             await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
-            await walletPage.accountButton({ symbol: 'eth', tokens: true }).click();
-            await page.getByRole('row', { name: 'USD Coin' }).getByRole('button').first().click();
-            await page.getByTestId('@trading/tokens/sell-button').click();
+            await walletPage.openSellTradingOfToken('eth', 'USD Coin');
         },
     );
 
     test('Sell Ethereum', async ({ marketPage }) => {
         await test.step('Fill in a sell request', async () => {
-            await marketPage.selectCountryOfResidence('CZ');
-            await marketPage.youPayCryptoInput.fill(cryptoAmount);
-            await marketPage.waitForSellOffersSync();
+            await marketPage.setYouSellAmount(
+                cryptoAmount,
+                'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            );
             await expect(marketPage.bestOfferAmount).toHaveText(fiatAmount);
             await expect(marketPage.quoteProvider).toHaveText(capitalizeFirstLetter(provider));
         });
@@ -64,10 +55,7 @@ test.describe('Trading - Sell Ethereum', { tag: ['@group=other', '@webOnly'] }, 
         });
 
         // TODO: Fix the redirection. I need to troubleshoot this with the team.
-        // await test.step('Wait for the redirection to complete', async () => {
-        //     await expect(page.getByText('Buy & sell')).not.toBeVisible();
-        //     await expect(page.getByText('Buy & sell')).toBeVisible({ timeout: 15_000 });
-        // });
+        // await marketPage.waitForRedirectCompletion();
 
         // await test.step('Verify all confirmation values', async () => {
         //     await expect(marketPage.confirmationFiatAmount).toHaveText(formattedFiatAmount);
@@ -82,16 +70,10 @@ test.describe('Trading - Sell Ethereum', { tag: ['@group=other', '@webOnly'] }, 
         // });
 
         // await test.step('Initiate send', async () => {
-        //     await marketPage.confirmTradeButton.click();
-        //     await expect(devicePrompt.sellButton).toBeDisabled();
-        //     await devicePrompt.confirmOnDevicePromptIsShown();
-        //     await trezorUserEnvLink.pressYes();
+        //     await marketPage.confirmSend();
         //     await expect(devicePrompt.cryptoAmountOf('amount')).toHaveText(formattedCryptoAmount);
-        //     await devicePrompt.confirmOnDevicePromptIsShown();
-        //     await trezorUserEnvLink.pressYes();
-        //     // Note: We intentionally skip clicking the sell button in tests to prevent actual cryptocurrency transactions.
-        //     // In a real scenario, the user would complete the transaction by clicking this button.
-        //     await expect(devicePrompt.sellButton).toBeEnabled();
         // });
+
+        // Rest of the flow is not implemented as we don't know how to mock the send request and actually not send the crypto
     });
 });

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum-token.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-ethereum-token.test.ts
@@ -6,6 +6,7 @@ import {
     invityEndpoint,
     sellQuotesEthereumToken,
     sellTradeEthereumToken,
+    sellWatchEthereum,
 } from '../../fixtures/invity';
 import { expect, test } from '../../support/fixtures';
 
@@ -13,8 +14,8 @@ import { expect, test } from '../../support/fixtures';
 const fiatAmount = sellQuotesEthereumToken[0].fiatStringAmount;
 const cryptoAmount = sellQuotesEthereumToken[0].cryptoStringAmount;
 const provider = getCompanyNameFromList(sellQuotesEthereumToken[0].exchange, 'sellList');
-// const providerAddress = sellWatch.destinationAddress;
-// const providerPaymentId = sellWatch.destinationPaymentExtraId;
+// const providerAddress = sellWatchEthereum.destinationAddress;
+// const providerPaymentId = sellWatchEthereum.destinationPaymentExtraId;
 // const formattedCryptoAmount = `${cryptoAmount} ETH`;
 // const formattedFiatAmount = `€${fiatAmount}`;
 // const { paymentMethodName } = sellTradeEthereum.trade;
@@ -25,17 +26,25 @@ test.describe('Trading - Sell Ethereum', { tag: ['@group=other', '@webOnly'] }, 
     });
     test.beforeEach(
         async ({ page, tradingMock, onboardingPage, dashboardPage, settingsPage, walletPage }) => {
-            await page.route(invityEndpoint.sellQuotes, async route => {
-                await route.fulfill({ json: sellQuotesEthereumToken });
+            await test.step('Mocking responses', async () => {
+                await page.route(invityEndpoint.sellQuotes, async route => {
+                    await route.fulfill({ json: sellQuotesEthereumToken });
+                });
+                await tradingMock.routeTrade(invityEndpoint.sellTrade, sellTradeEthereumToken);
+                await page.route(invityEndpoint.sellWatch, async route => {
+                    await route.fulfill({ json: sellWatchEthereum });
+                });
             });
-            await tradingMock.routeTrade(invityEndpoint.sellTrade, sellTradeEthereumToken);
             await onboardingPage.completeOnboarding();
             await dashboardPage.discoveryShouldFinish();
-            await settingsPage.navigateTo('coins');
-            await settingsPage.coins.enableNetwork('eth');
-            await dashboardPage.deviceSwitchingOpenButton.click();
-            await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
-            await walletPage.openSellTradingOfToken('eth', 'USD Coin');
+
+            await test.step('Enable Ethereum and open its token sell trading', async () => {
+                await settingsPage.navigateTo('coins');
+                await settingsPage.coins.enableNetwork('eth');
+                await dashboardPage.deviceSwitchingOpenButton.click();
+                await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
+                await walletPage.openSellTradingOfToken('eth', 'USD Coin');
+            });
         },
     );
 
@@ -64,9 +73,7 @@ test.describe('Trading - Sell Ethereum', { tag: ['@group=other', '@webOnly'] }, 
         //     await expect(marketPage.confirmationPaymentMethod).toHaveText(paymentMethodName);
         //     await expect(marketPage.confirmationAddress).toHaveText(providerAddress);
         //     await expect(marketPage.confirmationAccount).toHaveText('Bitcoin #1');
-        //     await expect(page.getByTestId('@trading/form/verify/extra-id')).toHaveText(
-        //         providerPaymentId,
-        //     );
+        //     await expect(marketPage.confirmationPaymentId).toHaveText(providerPaymentId);
         // });
 
         // await test.step('Initiate send', async () => {

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-solana.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-solana.test.ts
@@ -97,7 +97,6 @@ test.describe('Trading - Sell Solana', { tag: ['@group=other', '@webOnly'] }, ()
         await test.step('Send crypto to provider', async () => {
             await page.clock.install();
             await devicePrompt.sellButton.click();
-            await expect(devicePrompt.sellButton).toHaveText('Confirming transaction');
             await expect(marketPage.detailSellStatus).toHaveText('Trade in progress...');
             await expect(
                 page.getByRole('link', { name: "Open partner's support site" }),

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-solana.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-solana.test.ts
@@ -1,6 +1,5 @@
-import { Request, Route } from '@playwright/test';
-
 import { localizeNumber } from '@suite-common/wallet-utils';
+import { MNEMONICS } from '@trezor/trezor-user-env-link';
 import { capitalizeFirstLetter } from '@trezor/utils';
 
 import {
@@ -9,14 +8,7 @@ import {
     sellQuotesSolana,
     sellTradeSolana,
 } from '../../fixtures/invity';
-import {
-    getSignatureStatusesResponse,
-    sendTransactionResponse,
-} from '../../fixtures/solana-responses';
 import { expect, test } from '../../support/fixtures';
-
-const mnemonic =
-    'academic again academic academic academic academic academic academic academic academic academic academic academic academic academic academic academic pecan provide remember';
 
 // Expected values based on our mocked responses
 const fiatAmount = localizeNumber(sellQuotesSolana[0].fiatStringAmount, 'en', 2, 2);
@@ -31,44 +23,27 @@ const formattedFiatAmount = `€${fiatAmount}`;
 const { paymentMethodName } = sellTradeSolana.trade;
 const toastText = `${formattedCryptoAmount} sent from Solana #1`;
 
-function mockSolanaSendRequests(route: Route, request: Request) {
-    const method = request.method();
-    const postData = request.postData();
-
-    if (method === 'POST' && postData) {
-        const postDataJson = JSON.parse(postData);
-
-        //IMPORTANT: Mocking this request prevents from actually sending crypto
-        if (postDataJson.method === 'sendTransaction') {
-            route.fulfill({ json: sendTransactionResponse(postDataJson.id) });
-
-            return;
-        }
-
-        if (postDataJson.method === 'getSignatureStatuses') {
-            route.fulfill({ json: getSignatureStatusesResponse(postDataJson.id) });
-
-            return;
-        }
-    }
-}
-
 test.describe('Trading - Sell Solana', { tag: ['@group=other', '@webOnly'] }, () => {
     test.use({
-        emulatorSetupConf: { mnemonic, passphrase_protection: true },
+        emulatorSetupConf: { mnemonic: MNEMONICS.mnemonic_academic, passphrase_protection: true },
     });
     test.beforeEach(
-        async ({ page, marketPage, onboardingPage, dashboardPage, settingsPage, walletPage }) => {
-            if (!process.env.PASSPHRASE) {
-                throw new Error(
-                    'PASSPHRASE not provided in env variables. Check docs/tests/e2e-playwright-suite.md.',
-                );
-            }
-            await marketPage.mockInvity();
-            await marketPage.mockInvityTrade(sellTradeSolana, invityEndpoint.sellTrade);
+        async ({
+            page,
+            marketPage,
+            tradingMock,
+            onboardingPage,
+            dashboardPage,
+            settingsPage,
+            walletPage,
+        }) => {
             await page.route(invityEndpoint.sellQuotes, async route => {
                 await route.fulfill({ json: sellQuotesSolana });
             });
+            await tradingMock.routeTrade(invityEndpoint.sellTrade, sellTradeSolana);
+            //IMPORTANT: Mocking this request prevents from actually sending crypto
+            await tradingMock.routeSolanaSendRequests();
+            //TODO: Rework watch routing for sell tests. Eveyrone should point to QA passphrase wallet.
             await page.route(invityEndpoint.sellWatch, async route => {
                 await route.fulfill({
                     json: {
@@ -89,11 +64,9 @@ test.describe('Trading - Sell Solana', { tag: ['@group=other', '@webOnly'] }, ()
         },
     );
 
-    test('Sell Solana', async ({ page, marketPage, devicePrompt, trezorUserEnvLink }) => {
+    test('Sell Solana', async ({ page, marketPage, devicePrompt }) => {
         await test.step('Fill in a sell request', async () => {
-            await marketPage.selectCountryOfResidence('CZ');
-            await marketPage.youPayCryptoInput.fill(cryptoAmount);
-            await marketPage.waitForSellOffersSync();
+            await marketPage.setYouSellAmount(cryptoAmount, 'solana');
             await expect(marketPage.bestOfferAmount).toHaveText(fiatAmount);
             await expect(marketPage.quoteProvider).toHaveText(capitalizeFirstLetter(provider));
         });
@@ -102,10 +75,8 @@ test.describe('Trading - Sell Solana', { tag: ['@group=other', '@webOnly'] }, ()
             await marketPage.formSellButton.click();
             await marketPage.sellTermsConfirmButton.click();
         });
-        await test.step('Wait for the redirection to complete', async () => {
-            await expect(page.getByText('Buy & sell')).not.toBeVisible();
-            await expect(page.getByText('Buy & sell')).toBeVisible({ timeout: 15_000 });
-        });
+
+        await marketPage.waitForRedirectCompletion();
 
         await test.step('Verify all confirmation values', async () => {
             await expect(marketPage.confirmationFiatAmount).toHaveText(formattedFiatAmount);
@@ -120,20 +91,12 @@ test.describe('Trading - Sell Solana', { tag: ['@group=other', '@webOnly'] }, ()
         });
 
         await test.step('Initiate send', async () => {
-            await marketPage.confirmTradeButton.click();
-            await expect(devicePrompt.sellButton).toBeDisabled();
-            await devicePrompt.confirmOnDevicePromptIsShown();
-            await trezorUserEnvLink.pressYes();
+            await marketPage.initiateSendConfirmation();
             await expect(devicePrompt.cryptoAmountOf('total')).toHaveText(formattedCryptoAmount);
-            await devicePrompt.confirmOnDevicePromptIsShown();
-            await trezorUserEnvLink.pressYes();
-            await expect(devicePrompt.sellButton).toBeEnabled();
         });
 
+        // Thanks to our mocked responses, the crypto is actually not send.
         await test.step('Send crypto to provider', async () => {
-            const solUrlPattern = /^https:\/\/sol\d+\.trezor\.io\//;
-            //IMPORTANT: Mocking this request prevents from actually sending crypto
-            await page.route(solUrlPattern, mockSolanaSendRequests);
             await page.clock.install();
             await devicePrompt.sellButton.click();
             await expect(devicePrompt.sellButton).toHaveText('Confirming transaction');

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-solana.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-solana.test.ts
@@ -7,6 +7,7 @@ import {
     invityEndpoint,
     sellQuotesSolana,
     sellTradeSolana,
+    sellWatchSolana,
 } from '../../fixtures/invity';
 import { expect, test } from '../../support/fixtures';
 
@@ -14,10 +15,11 @@ import { expect, test } from '../../support/fixtures';
 const fiatAmount = localizeNumber(sellQuotesSolana[0].fiatStringAmount, 'en', 2, 2);
 const cryptoAmount = sellQuotesSolana[0].cryptoStringAmount;
 const provider = getCompanyNameFromList(sellQuotesSolana[0].exchange, 'sellList');
-// This address belongs to QA passphrase wallet. So if me make mistake in updating the test case,
-// and actually send crypto. It will be sent to this address and we will not lose it.
-const providerAddress = '6YaYu1rHw95rtyrADg1pgrKuDPB3fte8GdRAcAUyx3zK';
-const providerPaymentId = '6d666a5f-b99c-4482-b8bc-2df04fc11b7b';
+// This address belongs to second account in this wallet.
+// So if me make mistake in updating the test case, and actually send crypto.
+// It will be sent to this address and we will not lose it.
+const providerAddress = sellWatchSolana.destinationAddress;
+const providerPaymentId = sellWatchSolana.destinationPaymentExtraId;
 const formattedCryptoAmount = `${cryptoAmount} SOL`;
 const formattedFiatAmount = `€${fiatAmount}`;
 const { paymentMethodName } = sellTradeSolana.trade;
@@ -37,30 +39,28 @@ test.describe('Trading - Sell Solana', { tag: ['@group=other', '@webOnly'] }, ()
             settingsPage,
             walletPage,
         }) => {
-            await page.route(invityEndpoint.sellQuotes, async route => {
-                await route.fulfill({ json: sellQuotesSolana });
-            });
-            await tradingMock.routeTrade(invityEndpoint.sellTrade, sellTradeSolana);
-            //IMPORTANT: Mocking this request prevents from actually sending crypto
-            await tradingMock.routeSolanaSendRequests();
-            //TODO: Rework watch routing for sell tests. Eveyrone should point to QA passphrase wallet.
-            await page.route(invityEndpoint.sellWatch, async route => {
-                await route.fulfill({
-                    json: {
-                        status: 'SEND_CRYPTO',
-                        destinationAddress: providerAddress,
-                        destinationPaymentExtraId: providerPaymentId,
-                    },
+            await test.step('Mocking responses', async () => {
+                await page.route(invityEndpoint.sellQuotes, async route => {
+                    await route.fulfill({ json: sellQuotesSolana });
+                });
+                await tradingMock.routeTrade(invityEndpoint.sellTrade, sellTradeSolana);
+                //IMPORTANT: Mocking this request prevents from actually sending crypto
+                await tradingMock.routeSolanaSendRequests();
+                await page.route(invityEndpoint.sellWatch, async route => {
+                    await route.fulfill({ json: sellWatchSolana });
                 });
             });
             await onboardingPage.completeOnboarding();
             await dashboardPage.discoveryShouldFinish();
-            await settingsPage.navigateTo('coins');
-            await settingsPage.coins.enableNetwork('sol');
-            await dashboardPage.deviceSwitchingOpenButton.click();
-            await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
-            await walletPage.openTrading({ symbol: 'sol' });
-            await marketPage.sellTabButton.click();
+
+            await test.step('Enable Solana and open its sell trading', async () => {
+                await settingsPage.navigateTo('coins');
+                await settingsPage.coins.enableNetwork('sol');
+                await dashboardPage.deviceSwitchingOpenButton.click();
+                await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
+                await walletPage.openTrading({ symbol: 'sol' });
+                await marketPage.sellTabButton.click();
+            });
         },
     );
 
@@ -85,9 +85,7 @@ test.describe('Trading - Sell Solana', { tag: ['@group=other', '@webOnly'] }, ()
             await expect(marketPage.confirmationPaymentMethod).toHaveText(paymentMethodName);
             await expect(marketPage.confirmationAddress).toHaveText(providerAddress);
             await expect(marketPage.confirmationAccount).toHaveText('Solana #1');
-            await expect(page.getByTestId('@trading/form/verify/extra-id')).toHaveText(
-                providerPaymentId,
-            );
+            await expect(marketPage.confirmationPaymentId).toHaveText(providerPaymentId);
         });
 
         await test.step('Initiate send', async () => {
@@ -100,23 +98,19 @@ test.describe('Trading - Sell Solana', { tag: ['@group=other', '@webOnly'] }, ()
             await page.clock.install();
             await devicePrompt.sellButton.click();
             await expect(devicePrompt.sellButton).toHaveText('Confirming transaction');
-            await expect(page.getByTestId('@trading/detail-sell/pending')).toHaveText(
-                'Trade in progress...',
-            );
+            await expect(marketPage.detailSellStatus).toHaveText('Trade in progress...');
             await expect(
                 page.getByRole('link', { name: "Open partner's support site" }),
             ).toBeVisible();
             await expect(page.getByTestId('@toast/tx-sent')).toContainText(toastText);
         });
 
-        await test.step('Wait 30s for watch refresh and change of status to Success', async () => {
+        await test.step('Wait 30s for watch refresh and status change to Success', async () => {
             await page.route(invityEndpoint.sellWatch, async route => {
                 await route.fulfill({ json: { status: 'SUCCESS' } });
             });
             await page.clock.fastForward(marketPage.watchPeriod);
-            await expect(page.getByTestId('@trading/detail-sell/success-title')).toHaveText(
-                'Trade success',
-            );
+            await expect(marketPage.detailSellStatus).toHaveText('Trade success');
         });
     });
 });

--- a/packages/suite-desktop-core/e2e/tests/trading/sell-solana.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/trading/sell-solana.test.ts
@@ -1,5 +1,4 @@
 import { localizeNumber } from '@suite-common/wallet-utils';
-import { MNEMONICS } from '@trezor/trezor-user-env-link';
 import { capitalizeFirstLetter } from '@trezor/utils';
 
 import {
@@ -27,7 +26,7 @@ const toastText = `${formattedCryptoAmount} sent from Solana #1`;
 
 test.describe('Trading - Sell Solana', { tag: ['@group=other', '@webOnly'] }, () => {
     test.use({
-        emulatorSetupConf: { mnemonic: MNEMONICS.mnemonic_academic, passphrase_protection: true },
+        emulatorSetupConf: { mnemonic: 'mnemonic_academic', passphrase_protection: true },
     });
     test.beforeEach(
         async ({

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSellPaymentFailed.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSellPaymentFailed.tsx
@@ -55,7 +55,7 @@ export const TradingDetailSellPaymentFailed = ({
     return (
         <Wrapper>
             <Image image="UNI_ERROR" />
-            <H4 margin={{ top: spacings.xl }}>
+            <H4 data-testid="@trading/detail-sell/status" margin={{ top: spacings.xl }}>
                 <Translation id="TR_SELL_DETAIL_ERROR_TITLE" />
             </H4>
             <Description>

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSellPaymentPending.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSellPaymentPending.tsx
@@ -20,7 +20,7 @@ interface PaymentConvertingProps {
 export const TradingDetailSellPaymentPending = ({ supportUrl }: PaymentConvertingProps) => (
     <Wrapper>
         <Spinner />
-        <H4 data-testid="@trading/detail-sell/pending" margin={{ top: spacings.xl }}>
+        <H4 data-testid="@trading/detail-sell/status" margin={{ top: spacings.xl }}>
             <Translation id="TR_SELL_DETAIL_PENDING_TITLE" />
         </H4>
         {supportUrl && (

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSellPaymentSuccessful.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSellPaymentSuccessful.tsx
@@ -68,7 +68,7 @@ export const TradingDetailSellPaymentSuccessful = ({ account }: PaymentSuccessfu
     return (
         <Wrapper>
             <Image image="TRADING_SUCCESS" />
-            <Title data-testid="@trading/detail-sell/success-title">
+            <Title data-testid="@trading/detail-sell/status">
                 <Translation id="TR_SELL_DETAIL_SUCCESS_TITLE" />
             </Title>
             <Description>

--- a/packages/trezor-user-env-link/src/api.ts
+++ b/packages/trezor-user-env-link/src/api.ts
@@ -88,6 +88,8 @@ export const MNEMONICS = {
     mnemonic_abandon:
         'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
     mnemonic_immune: 'immune enlist rule measure fan swarm mandate track point menu security fan',
+    mnemonic_academic:
+        'academic again academic academic academic academic academic academic academic academic academic academic academic academic academic academic academic pecan provide remember',
 };
 
 export const DEFAULT_BRIDGE_VERSION = '2.0.33';


### PR DESCRIPTION
## Description

Refactors our trading tests
- mocking moved to its own fixture
- sell test are using addresses of secondary of the same wallet. So we cannot lose the crypto by accident when a faulty change would send the crypto
- DRY up some common steps
- clean up setups

## Related Issue

Resolve 16579

## Screenshots:
