### PR TITLE
chore(ci): don't trigger web/desktop CI for yarn.lock

### DIFF
--- a/.github/workflows/build-desktop-apps.yml
+++ b/.github/workflows/build-desktop-apps.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
     paths-ignore:
+      - "yarn.lock"
       - "suite-native/**"
       - "docs/**"
       - "docker/**"

--- a/.github/workflows/build-suite-web.yml
+++ b/.github/workflows/build-suite-web.yml
@@ -11,6 +11,7 @@ on:
     branches:
       - develop
     paths-ignore:
+      - "yarn.lock"
       - "suite-native/**"
       - "packages/connect*/**"
       - "packages/react-native-usb/**"

--- a/.github/workflows/test-suite-desktop-e2e.yml
+++ b/.github/workflows/test-suite-desktop-e2e.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - develop
     paths-ignore:
+      - "yarn.lock"
       - "suite-native/**"
       - "packages/connect*/**"
       - "packages/react-native-usb/**"
@@ -50,7 +51,7 @@ jobs:
             CONTAINERS: "trezor-user-env-unix bitcoin-regtest"
 
     steps:
-        # Electron requires unprivileged user namespaces to function properly. 
+        # Electron requires unprivileged user namespaces to function properly.
         # Disabling this security rule allows Electron to create sandboxed processes
         # without requiring elevated privileges, which is essential for running the application.
         # This is workaround until electron builder solves this issue in future release.

--- a/.github/workflows/test-suite-web-e2e-pw.yml
+++ b/.github/workflows/test-suite-web-e2e-pw.yml
@@ -11,6 +11,7 @@ on:
     branches:
       - develop
     paths-ignore:
+      - "yarn.lock"
       - "suite-native/**"
       - "packages/connect*/**"
       # - "packages/suite-desktop*/**"

--- a/.github/workflows/test-suite-web-e2e.yml
+++ b/.github/workflows/test-suite-web-e2e.yml
@@ -11,6 +11,7 @@ on:
     branches:
       - develop
     paths-ignore:
+      - "yarn.lock"
       - "suite-native/**"
       - "packages/connect*/**"
       - "packages/suite-desktop*/**"


### PR DESCRIPTION
## Description

Exclude `yarn.lock` from triggering Suite Web/Desktop CI changes.

Yarn.lock can change if the following change:
1. repo root package.json :arrow_right: run tests :heavy_check_mark: 
2. a `@trezor` / `@suite-common` workspace package.json :arrow_right: run tests :heavy_check_mark: 
3. a `@suite-native` workspace package.json :arrow_right: don't run those tests :x:

Seems to me that it is useless to watch for `yarn.lock` changes, because in case of 1. or 2., the changes in the respective `package.json` are enough to trigger CI.
Meanwhile, due to the structure of `suite-native` (app split into many workspaces) there are very frequent changes that only add an internal workspace to another, which updates `yarn.lock`, and wastes CI time by running the entire battery of tests.

:thought_balloon: then again, [connect tests](https://github.com/trezor/trezor-suite/blob/5cfa592a8833d8472b8fffc1ec45dbcf14a0316a/.github/workflows/test-connect.yml#L24) **explicitely** watch `yarn.lock`. Idk why not `package.json` instead, so maybe I'm missing something? :thinking: 